### PR TITLE
Unify agent service MCP server normalization

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.510",
+  "version": "0.1.511",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/agent-service-mcp-server-config.test.ts
+++ b/src/agent/agent-service-mcp-server-config.test.ts
@@ -1,0 +1,108 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import {
+  createAgentServiceRemoteMcpConfig,
+  defaultAgentServiceMcpServers,
+} from "./agent-service-mcp-server-config.ts";
+
+Deno.test("defaultAgentServiceMcpServers enables the Veryfront API MCP server", () => {
+  assertEquals(defaultAgentServiceMcpServers(), [{ kind: "veryfront-api" }]);
+});
+
+Deno.test("createAgentServiceRemoteMcpConfig builds Veryfront API MCP config", () => {
+  assertEquals(
+    createAgentServiceRemoteMcpConfig({
+      server: { kind: "veryfront-api" },
+      authToken: "token-1",
+      apiMcpUrl: "https://api.example/mcp",
+    }),
+    {
+      id: "veryfront-mcp",
+      endpoint: "https://api.example/mcp",
+      headers: {
+        Authorization: "Bearer token-1",
+      },
+    },
+  );
+
+  assertEquals(
+    createAgentServiceRemoteMcpConfig({
+      server: { kind: "veryfront-api", id: "veryfront-child" },
+      authToken: "token-1",
+      apiMcpUrl: "https://api.example/mcp",
+      defaultSourceId: "veryfront-mcp-fork",
+    })?.id,
+    "veryfront-child",
+  );
+});
+
+Deno.test("createAgentServiceRemoteMcpConfig builds generic MCP config without dropping options", () => {
+  const customFetch = () => Promise.resolve(new Response("{}"));
+  const headers = { Authorization: "Bearer external-token" };
+  assertEquals(
+    createAgentServiceRemoteMcpConfig({
+      server: {
+        id: "linear",
+        endpoint: "https://linear.example/mcp",
+        headers,
+        fetch: customFetch,
+        listMethod: "tools/list",
+        callMethod: "tools/call",
+      },
+      authToken: "token-1",
+      apiMcpUrl: "https://api.example/mcp",
+    }),
+    {
+      id: "linear",
+      endpoint: "https://linear.example/mcp",
+      headers,
+      fetch: customFetch,
+      listMethod: "tools/list",
+      callMethod: "tools/call",
+    },
+  );
+});
+
+Deno.test("createAgentServiceRemoteMcpConfig gates Studio MCP by client profile", async () => {
+  const blockedConfig = createAgentServiceRemoteMcpConfig({
+    server: { kind: "veryfront-studio" },
+    authToken: "token-1",
+    apiMcpUrl: "https://api.example/mcp",
+    studioMcpUrl: "https://studio.example/mcp",
+    clientProfile: {
+      id: "veryfront-cli",
+      type: "cli",
+      trusted: true,
+      capabilities: [],
+    },
+    getProjectId: () => "project-1",
+  });
+  assertEquals(blockedConfig, null);
+
+  let projectId = "project-1";
+  const allowedConfig = createAgentServiceRemoteMcpConfig({
+    server: { kind: "veryfront-studio" },
+    authToken: "token-1",
+    apiMcpUrl: "https://api.example/mcp",
+    studioMcpUrl: "https://studio.example/mcp",
+    clientProfile: {
+      id: "veryfront-studio",
+      type: "web",
+      trusted: true,
+      capabilities: ["ui_panels"],
+    },
+    conversationId: "conversation-1",
+    getProjectId: () => projectId,
+  });
+
+  assertEquals(allowedConfig?.id, "studio-mcp");
+  assertEquals(allowedConfig?.endpoint, "https://studio.example/mcp");
+  projectId = "project-2";
+  const headers = typeof allowedConfig?.headers === "function"
+    ? await allowedConfig.headers()
+    : allowedConfig?.headers;
+  assertEquals(headers, {
+    Authorization: "Bearer token-1",
+    "x-conversation-id": "conversation-1",
+    "x-project-id": "project-2",
+  });
+});

--- a/src/agent/agent-service-mcp-server-config.ts
+++ b/src/agent/agent-service-mcp-server-config.ts
@@ -1,0 +1,112 @@
+import type { RemoteMCPToolSourceConfig } from "#veryfront/tool";
+import { buildStudioMcpHeaders } from "./live-studio-mcp-tools.ts";
+import { clientAllowsStudioMcp, type RuntimeClientProfile } from "./runtime-client-profile.ts";
+
+export type AgentServiceVeryfrontApiMcpServerConfig = {
+  kind: "veryfront-api";
+  id?: string;
+};
+
+export type AgentServiceVeryfrontStudioMcpServerConfig = {
+  kind: "veryfront-studio";
+  id?: string;
+};
+
+export type AgentServiceGenericMcpServerConfig = {
+  kind?: "generic";
+  id?: string;
+  endpoint: RemoteMCPToolSourceConfig["endpoint"];
+  headers?: RemoteMCPToolSourceConfig["headers"];
+  fetch?: RemoteMCPToolSourceConfig["fetch"];
+  listMethod?: RemoteMCPToolSourceConfig["listMethod"];
+  callMethod?: RemoteMCPToolSourceConfig["callMethod"];
+};
+
+export type AgentServiceMcpServerConfig =
+  | AgentServiceVeryfrontApiMcpServerConfig
+  | AgentServiceVeryfrontStudioMcpServerConfig
+  | AgentServiceGenericMcpServerConfig;
+
+export type CreateAgentServiceRemoteMcpConfigInput = {
+  server: AgentServiceMcpServerConfig;
+  authToken: string;
+  apiMcpUrl: string;
+  studioMcpUrl?: string | null;
+  clientProfile?: RuntimeClientProfile | null;
+  getProjectId?: () => string | null | undefined;
+  conversationId?: string;
+  defaultSourceId?: string;
+};
+
+export function defaultAgentServiceMcpServers(): AgentServiceMcpServerConfig[] {
+  return [{ kind: "veryfront-api" }];
+}
+
+function createGenericRemoteMcpConfig(
+  server: AgentServiceGenericMcpServerConfig,
+): RemoteMCPToolSourceConfig {
+  const config: RemoteMCPToolSourceConfig = {
+    endpoint: server.endpoint,
+  };
+
+  if (server.id !== undefined) config.id = server.id;
+  if (server.headers !== undefined) config.headers = server.headers;
+  if (server.fetch !== undefined) config.fetch = server.fetch;
+  if (server.listMethod !== undefined) config.listMethod = server.listMethod;
+  if (server.callMethod !== undefined) config.callMethod = server.callMethod;
+
+  return config;
+}
+
+function createVeryfrontApiRemoteMcpConfig(
+  input: Pick<
+    CreateAgentServiceRemoteMcpConfigInput,
+    "apiMcpUrl" | "authToken" | "defaultSourceId"
+  >,
+  server: AgentServiceVeryfrontApiMcpServerConfig,
+): RemoteMCPToolSourceConfig {
+  return {
+    id: server.id ?? input.defaultSourceId ?? "veryfront-mcp",
+    endpoint: input.apiMcpUrl,
+    headers: {
+      Authorization: `Bearer ${input.authToken}`,
+    },
+  };
+}
+
+function createVeryfrontStudioRemoteMcpConfig(
+  input: Pick<
+    CreateAgentServiceRemoteMcpConfigInput,
+    "authToken" | "clientProfile" | "conversationId" | "getProjectId" | "studioMcpUrl"
+  >,
+  server: AgentServiceVeryfrontStudioMcpServerConfig,
+): RemoteMCPToolSourceConfig | null {
+  if (!input.studioMcpUrl || !clientAllowsStudioMcp(input.clientProfile)) {
+    return null;
+  }
+
+  return {
+    id: server.id ?? "studio-mcp",
+    endpoint: input.studioMcpUrl,
+    headers: () =>
+      buildStudioMcpHeaders(
+        input.authToken,
+        input.getProjectId?.() ?? null,
+        input.conversationId,
+      ),
+  };
+}
+
+export function createAgentServiceRemoteMcpConfig(
+  input: CreateAgentServiceRemoteMcpConfigInput,
+): RemoteMCPToolSourceConfig | null {
+  if (input.server.kind === "veryfront-api") {
+    return createVeryfrontApiRemoteMcpConfig(input, input.server);
+  }
+
+  if (input.server.kind === "veryfront-studio") {
+    return createVeryfrontStudioRemoteMcpConfig(input, input.server);
+  }
+
+  return createGenericRemoteMcpConfig(input.server);
+}

--- a/src/agent/default-hosted-chat-runtime.ts
+++ b/src/agent/default-hosted-chat-runtime.ts
@@ -29,7 +29,7 @@ import {
   prepareHostedChatRuntimeToolAssembly,
   type PrepareHostedChatRuntimeToolAssemblyInput,
 } from "./hosted-chat-runtime-tool-assembly.ts";
-import type { HostedProjectMcpServerConfig } from "./hosted-project-remote-tool-source.ts";
+import type { AgentServiceMcpServerConfig } from "./agent-service-mcp-server-config.ts";
 import {
   createHostedRuntimeStateResolver,
   type HostedRuntimeStateResolverContext,
@@ -45,7 +45,7 @@ export type DefaultHostedChatRuntimeConfig = {
   apiUrl: string;
   apiMcpUrl: string;
   studioMcpUrl?: string | null;
-  mcpServers?: readonly HostedProjectMcpServerConfig[];
+  mcpServers?: readonly AgentServiceMcpServerConfig[];
 };
 
 export type DefaultHostedChatRuntimeLogger = {

--- a/src/agent/default-hosted-invoke-agent-tool.ts
+++ b/src/agent/default-hosted-invoke-agent-tool.ts
@@ -28,7 +28,7 @@ import { startHostedChildForkRuntimeWithHostTools } from "./hosted-child-fork-ru
 import {
   prepareDefaultHostedChildForkSandboxToolSources,
 } from "./hosted-child-fork-tool-sources.ts";
-import type { HostedProjectMcpServerConfig } from "./hosted-project-remote-tool-source.ts";
+import type { AgentServiceMcpServerConfig } from "./agent-service-mcp-server-config.ts";
 import { executeHostedChildForkToolInput } from "./hosted-child-fork-execution-runner.ts";
 import { createHostedChildInvokeTool } from "./hosted-child-invoke-tool.ts";
 import {
@@ -79,7 +79,7 @@ export type DefaultHostedInvokeAgentConfig = {
   apiUrl: string;
   apiMcpUrl: string;
   studioMcpUrl?: string | null;
-  mcpServers?: readonly HostedProjectMcpServerConfig[];
+  mcpServers?: readonly AgentServiceMcpServerConfig[];
   enableDurableInvokeAgent?: boolean;
 };
 

--- a/src/agent/hosted-chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted-chat-runtime-tool-assembly.ts
@@ -17,9 +17,9 @@ import {
   fetchLatestConversationUserText,
   updateDefaultResearchArtifacts,
 } from "./default-research-artifact-support.ts";
+import { type AgentServiceMcpServerConfig } from "./agent-service-mcp-server-config.ts";
 import {
   createHostedProjectRemoteToolSources,
-  type HostedProjectMcpServerConfig,
   type HostedProjectRemoteToolSourceMutationHandler,
   type HostedProjectRemoteToolSourcePrepareToolInput,
   type HostedProjectRemoteToolSourceProjectSwitchHandler,
@@ -59,7 +59,7 @@ export type PrepareHostedChatRuntimeToolAssemblyInput<
   apiUrl: string;
   apiMcpUrl: string;
   studioMcpUrl?: string | null;
-  mcpServers?: readonly HostedProjectMcpServerConfig[];
+  mcpServers?: readonly AgentServiceMcpServerConfig[];
   conversationId?: string;
   allowedToolNames?: HostedChatRuntimeAllowedToolNames;
   projectScopedRemoteToolOptions?: ProjectScopedRemoteToolOptions;

--- a/src/agent/hosted-child-fork-tool-sources.ts
+++ b/src/agent/hosted-child-fork-tool-sources.ts
@@ -6,6 +6,11 @@ import {
   type RemoteToolSource,
 } from "#veryfront/tool";
 import {
+  type AgentServiceMcpServerConfig,
+  createAgentServiceRemoteMcpConfig,
+  defaultAgentServiceMcpServers,
+} from "./agent-service-mcp-server-config.ts";
+import {
   type AgentServiceSandboxToolsOptions,
   type AgentServiceSandboxToolsResult,
   createAgentServiceSandboxTools,
@@ -14,11 +19,6 @@ import {
   createLiveStudioMcpTools,
   type LiveStudioMcpToolsOptions,
 } from "./live-studio-mcp-tools.ts";
-import type { HostedProjectMcpServerConfig } from "./hosted-project-remote-tool-source.ts";
-import {
-  createHostedProjectGenericRemoteMcpConfig,
-  createHostedProjectVeryfrontApiRemoteMcpConfig,
-} from "./hosted-project-remote-tool-source.ts";
 import type { RuntimeClientProfile } from "./runtime-client-profile.ts";
 import {
   type HostedChildProjectSwitchHandler,
@@ -36,7 +36,7 @@ export type HostedChildForkToolSourcesLogger = {
 export type PrepareDefaultHostedChildForkToolSourcesInput = {
   authToken: string;
   apiMcpUrl: string;
-  mcpServers?: readonly HostedProjectMcpServerConfig[];
+  mcpServers?: readonly AgentServiceMcpServerConfig[];
   getProjectId: () => string | null | undefined;
   studioMcpUrl?: string | null;
   clientProfile?: RuntimeClientProfile | null;
@@ -75,10 +75,6 @@ export type PrepareDefaultHostedChildForkSandboxToolSourcesInput =
     ) => Promise<AgentServiceSandboxToolsResult>;
   };
 
-function defaultChildForkMcpServers(): HostedProjectMcpServerConfig[] {
-  return [{ kind: "veryfront-api" }];
-}
-
 export async function prepareDefaultHostedChildForkToolSources(
   input: PrepareDefaultHostedChildForkToolSourcesInput,
 ): Promise<DefaultHostedChildForkToolSourcesResult> {
@@ -93,7 +89,7 @@ export async function prepareDefaultHostedChildForkToolSources(
     createToolsFromRemoteDefinitions;
 
   try {
-    const mcpServers = input.mcpServers ?? defaultChildForkMcpServers();
+    const mcpServers = input.mcpServers ?? defaultAgentServiceMcpServers();
     for (const server of mcpServers) {
       if (server.kind === "veryfront-studio") {
         const studioTools = await createLiveStudioTools({
@@ -114,13 +110,15 @@ export async function prepareDefaultHostedChildForkToolSources(
         continue;
       }
 
-      const remoteConfig = server.kind === "veryfront-api"
-        ? createHostedProjectVeryfrontApiRemoteMcpConfig({
-          authToken: input.authToken,
-          apiMcpUrl: input.apiMcpUrl,
-          defaultSourceId: "veryfront-mcp-fork",
-        }, server)
-        : createHostedProjectGenericRemoteMcpConfig(server);
+      const remoteConfig = createAgentServiceRemoteMcpConfig({
+        server,
+        authToken: input.authToken,
+        apiMcpUrl: input.apiMcpUrl,
+        defaultSourceId: "veryfront-mcp-fork",
+      });
+      if (!remoteConfig) {
+        continue;
+      }
       const remoteSource = createRemoteToolSource(remoteConfig);
       const definitions = await remoteSource.listTools();
       remoteMcpTools = {

--- a/src/agent/hosted-project-remote-tool-source.ts
+++ b/src/agent/hosted-project-remote-tool-source.ts
@@ -8,9 +8,13 @@ import {
   type RemoteToolSource,
   type ToolExecutionContext,
 } from "#veryfront/tool";
+import {
+  type AgentServiceMcpServerConfig,
+  createAgentServiceRemoteMcpConfig,
+  defaultAgentServiceMcpServers,
+} from "./agent-service-mcp-server-config.ts";
 import { toChildRunToolInputRecord } from "./child-run-execution-support.ts";
-import { buildStudioMcpHeaders } from "./live-studio-mcp-tools.ts";
-import { clientAllowsStudioMcp, type RuntimeClientProfile } from "./runtime-client-profile.ts";
+import type { RuntimeClientProfile } from "./runtime-client-profile.ts";
 import { getConfirmedProjectContextSwitchId } from "./project-context.ts";
 import {
   getProjectSteeringMutation,
@@ -26,31 +30,6 @@ export type HostedProjectRemoteToolSourceMutationHandler = (
 export type HostedProjectRemoteToolSourceProjectSwitchHandler = (
   projectId: string,
 ) => Promise<void> | void;
-
-export type HostedProjectVeryfrontApiMcpServerConfig = {
-  kind: "veryfront-api";
-  id?: string;
-};
-
-export type HostedProjectVeryfrontStudioMcpServerConfig = {
-  kind: "veryfront-studio";
-  id?: string;
-};
-
-export type HostedProjectGenericMcpServerConfig = {
-  kind?: "generic";
-  id?: string;
-  endpoint: RemoteMCPToolSourceConfig["endpoint"];
-  headers?: RemoteMCPToolSourceConfig["headers"];
-  fetch?: RemoteMCPToolSourceConfig["fetch"];
-  listMethod?: RemoteMCPToolSourceConfig["listMethod"];
-  callMethod?: RemoteMCPToolSourceConfig["callMethod"];
-};
-
-export type HostedProjectMcpServerConfig =
-  | HostedProjectVeryfrontApiMcpServerConfig
-  | HostedProjectVeryfrontStudioMcpServerConfig
-  | HostedProjectGenericMcpServerConfig;
 
 export type HostedProjectRemoteToolSourcePrepareToolInput = (input: {
   toolName: string;
@@ -213,86 +192,13 @@ export type CreateHostedProjectRemoteToolSourcesInput =
     authToken: string;
     apiMcpUrl: string;
     studioMcpUrl?: string | null;
-    mcpServers?: readonly HostedProjectMcpServerConfig[];
+    mcpServers?: readonly AgentServiceMcpServerConfig[];
     clientProfile?: RuntimeClientProfile | null;
     getProjectId: () => string | null | undefined;
     conversationId?: string;
     createRemoteToolSource?: (config: RemoteMCPToolSourceConfig) => RemoteToolSource;
     onStudioProjectSwitch?: HostedProjectRemoteToolSourceProjectSwitchHandler;
   };
-
-function defaultHostedProjectMcpServers(): HostedProjectMcpServerConfig[] {
-  return [{ kind: "veryfront-api" }];
-}
-
-export function createHostedProjectGenericRemoteMcpConfig(
-  server: HostedProjectGenericMcpServerConfig,
-): RemoteMCPToolSourceConfig {
-  const config: RemoteMCPToolSourceConfig = {
-    endpoint: server.endpoint,
-  };
-
-  if (server.id !== undefined) config.id = server.id;
-  if (server.headers !== undefined) config.headers = server.headers;
-  if (server.fetch !== undefined) config.fetch = server.fetch;
-  if (server.listMethod !== undefined) config.listMethod = server.listMethod;
-  if (server.callMethod !== undefined) config.callMethod = server.callMethod;
-
-  return config;
-}
-
-export function createHostedProjectVeryfrontApiRemoteMcpConfig(
-  input: Pick<CreateHostedProjectRemoteToolSourcesInput, "apiMcpUrl" | "authToken"> & {
-    defaultSourceId?: string;
-  },
-  server: HostedProjectVeryfrontApiMcpServerConfig,
-): RemoteMCPToolSourceConfig {
-  return {
-    id: server.id ?? input.defaultSourceId ?? "veryfront-mcp",
-    endpoint: input.apiMcpUrl,
-    headers: {
-      Authorization: `Bearer ${input.authToken}`,
-    },
-  };
-}
-
-function createVeryfrontStudioRemoteMcpConfig(
-  input: Pick<
-    CreateHostedProjectRemoteToolSourcesInput,
-    "authToken" | "clientProfile" | "conversationId" | "getProjectId" | "studioMcpUrl"
-  >,
-  server: HostedProjectVeryfrontStudioMcpServerConfig,
-): RemoteMCPToolSourceConfig | null {
-  if (!input.studioMcpUrl || !clientAllowsStudioMcp(input.clientProfile)) {
-    return null;
-  }
-
-  return {
-    id: server.id ?? "studio-mcp",
-    endpoint: input.studioMcpUrl,
-    headers: () =>
-      buildStudioMcpHeaders(
-        input.authToken,
-        input.getProjectId() ?? null,
-        input.conversationId,
-      ),
-  };
-}
-
-function createRemoteMcpConfig(
-  input: CreateHostedProjectRemoteToolSourcesInput,
-  server: HostedProjectMcpServerConfig,
-): RemoteMCPToolSourceConfig | null {
-  if (server.kind === "veryfront-api") {
-    return createHostedProjectVeryfrontApiRemoteMcpConfig(input, server);
-  }
-
-  if (server.kind === "veryfront-studio") {
-    return createVeryfrontStudioRemoteMcpConfig(input, server);
-  }
-
-  return createHostedProjectGenericRemoteMcpConfig(server);
-}
 
 function createHostedProjectRemoteToolSourceFromConfig(
   input: CreateHostedProjectRemoteToolSourcesInput,
@@ -327,10 +233,18 @@ export function createHostedProjectRemoteToolSources(
 ): RemoteToolSource[] {
   const createRemoteToolSource = input.createRemoteToolSource ?? createRemoteMCPToolSource;
   const sources: RemoteToolSource[] = [];
-  const mcpServers = input.mcpServers ?? defaultHostedProjectMcpServers();
+  const mcpServers = input.mcpServers ?? defaultAgentServiceMcpServers();
 
   for (const server of mcpServers) {
-    const remoteConfig = createRemoteMcpConfig(input, server);
+    const remoteConfig = createAgentServiceRemoteMcpConfig({
+      server,
+      authToken: input.authToken,
+      apiMcpUrl: input.apiMcpUrl,
+      studioMcpUrl: input.studioMcpUrl,
+      clientProfile: input.clientProfile,
+      getProjectId: input.getProjectId,
+      conversationId: input.conversationId,
+    });
     if (!remoteConfig) {
       continue;
     }

--- a/src/agent/veryfront-cloud-agent-service.ts
+++ b/src/agent/veryfront-cloud-agent-service.ts
@@ -60,7 +60,7 @@ import {
   fetchDefaultHostedProjectSteering,
 } from "./default-hosted-project-steering-refresh.ts";
 import { type HostedProjectSkillIdsContext } from "./hosted-project-steering-adapter.ts";
-import type { HostedProjectMcpServerConfig } from "./hosted-project-remote-tool-source.ts";
+import type { AgentServiceMcpServerConfig } from "./agent-service-mcp-server-config.ts";
 import type { RuntimeLoadSkillToolContext } from "./runtime-load-skill-tool.ts";
 import type { RuntimeProjectSteeringLookup } from "./runtime-project-skill-catalog.ts";
 import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
@@ -115,11 +115,11 @@ export type NodeVeryfrontCloudAgentServiceAgentSource = "auto" | "code" | "markd
 
 export type VeryfrontMcpServerKind = "api" | "studio";
 
-export type NodeVeryfrontCloudAgentServiceMcpServer = HostedProjectMcpServerConfig;
+export type NodeVeryfrontCloudAgentServiceMcpServer = AgentServiceMcpServerConfig;
 
 export function veryfrontMcpServer(
   kind: VeryfrontMcpServerKind = "api",
-): HostedProjectMcpServerConfig {
+): AgentServiceMcpServerConfig {
   if (kind === "studio") {
     return { kind: "veryfront-studio" };
   }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.510";
+export const VERSION = "0.1.511";


### PR DESCRIPTION
## Summary
- centralize agent service MCP server config normalization in one framework helper
- reuse the helper for root runtime tool sources and child fork tool sources
- bump framework package version to 0.1.511

## Verification
- deno test --no-check --allow-all src/agent/agent-service-mcp-server-config.test.ts src/agent/hosted-project-remote-tool-source.test.ts src/agent/hosted-child-fork-tool-sources.test.ts src/agent/hosted-chat-runtime-tool-assembly.test.ts src/agent/default-hosted-chat-runtime.test.ts src/agent/default-hosted-invoke-agent-tool.test.ts src/agent/veryfront-cloud-agent-service.test.ts
- deno task typecheck
- deno task verify:quick
- deno task build:npm
- pre-push full unit checks: 1838 passed, 0 failed