### PR TITLE
Default agent services to the single discovered agent

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Install Chromium
         run: |
           for attempt in 1 2 3; do
-            deno run -A npm:playwright install --with-deps chromium && exit 0
+            timeout 300s deno run -A npm:playwright install --with-deps chromium && exit 0
             status=$?
 
             if [ "$attempt" -eq 3 ]; then
@@ -134,7 +134,7 @@ jobs:
       - name: Install Chromium
         run: |
           for attempt in 1 2 3; do
-            deno run -A npm:playwright install --with-deps chromium && exit 0
+            timeout 300s deno run -A npm:playwright install --with-deps chromium && exit 0
             status=$?
 
             if [ "$attempt" -eq 3 ]; then

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.511",
+  "version": "0.1.512",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -188,8 +188,6 @@ import { startAgentService } from "veryfront/agent";
 
 await startAgentService({
   serviceName: "support-agent",
-  agentId: "support",
-  entrypointUrl: import.meta.url,
 });
 ```
 
@@ -202,11 +200,13 @@ Veryfront projects: `agents/`, `tools/`, `skills/`, `resources/`, `prompts/`,
 them in `veryfront.config.ts` under `ai.<primitive>.discovery.paths` instead of
 adding service-specific discovery configuration.
 
-The `agentId` option selects the default agent for direct `/api/runs` requests.
+When exactly one code or markdown agent is discovered, it becomes the default
+automatically. The optional `agentId` setting selects the default agent for
+direct `/api/runs` requests when a service exposes more than one agent.
 Control-plane runtime invocations can target any discovered code or markdown
-agent by setting `run.agentId` in the `/api/control-plane/agents/stream`
-payload. This lets one deployed service expose multiple project agents while
-keeping direct chat integrations on a predictable default.
+agent by setting `run.agentId` in the `/api/runs` payload. This lets one
+deployed service expose multiple project agents while keeping direct chat
+integrations on a predictable default.
 
 ## Agent configuration
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -277,7 +277,6 @@ import { startAgentService, veryfrontMcpServer } from "veryfront/agent";
 
 await startAgentService({
   serviceName: "support-agent",
-  agentId: "support",
   mcpServers: [veryfrontMcpServer()],
 });
 ```
@@ -285,6 +284,9 @@ await startAgentService({
 By default, discovery is rooted at the process cwd. Pass `baseDir` only when the
 service may start from another working directory. `entrypointUrl` is a
 convenience fallback for deriving `baseDir` from an entry module URL.
+If the service discovers exactly one code or markdown agent, that agent becomes
+the default automatically. Set `agentId` when the service exposes multiple
+agents or when direct `/api/runs` requests should use a specific default.
 
 Remote MCP servers are configured as an explicit list. Use normal MCP server
 configs for third-party servers, and use `veryfrontMcpServer()` helpers for
@@ -294,7 +296,6 @@ trusted Studio-capable clients:
 ```ts
 await startAgentService({
   serviceName: "support-agent",
-  agentId: "support",
   mcpServers: [
     veryfrontMcpServer(),
     veryfrontMcpServer("studio"),
@@ -325,11 +326,11 @@ available from discovery; set `agentSource: "markdown"` to force markdown
 definitions. Use `veryfront.config.ts` `ai.<primitive>.discovery.paths` for
 non-standard project paths.
 
-The `agentId` option selects the default agent for direct `/api/runs` requests.
+The optional `agentId` option selects the default agent for direct `/api/runs` requests.
 Control-plane runtime invocations can target any discovered code or markdown
-agent by setting `run.agentId` in the `/api/control-plane/agents/stream`
-payload. This lets one deployed service expose multiple project agents while
-keeping direct chat integrations on a predictable default.
+agent by setting `run.agentId` in the `/api/runs` payload. This lets one
+deployed service expose multiple project agents while keeping direct chat
+integrations on a predictable default.
 
 For a conversations/control-plane host composition that combines
 `runHostedLifecycle()` with the public durable-run helpers, see

--- a/src/agent/runtime-agent-definition-files.ts
+++ b/src/agent/runtime-agent-definition-files.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { basename, resolve } from "node:path";
 import { z } from "zod";
 import {
@@ -17,6 +17,14 @@ export const resolveRuntimeAgentDefinitionsDirInputSchema = z.object({
 
 export type ResolveRuntimeAgentDefinitionsDirInput = z.infer<
   typeof resolveRuntimeAgentDefinitionsDirInputSchema
+>;
+
+export const listRuntimeAgentMarkdownDefinitionIdsInputSchema = z.object({
+  baseDir: z.string().min(1),
+});
+
+export type ListRuntimeAgentMarkdownDefinitionIdsInput = z.infer<
+  typeof listRuntimeAgentMarkdownDefinitionIdsInputSchema
 >;
 
 export const loadRuntimeAgentMarkdownDefinitionFromFileInputSchema = z.object({
@@ -40,25 +48,60 @@ function hasRuntimeAgentDefinitionFile(path: string, fileName: string): boolean 
   return existsSync(resolve(path, fileName));
 }
 
+function getRuntimeAgentDefinitionsDirCandidates(baseDir: string): string[] {
+  const firstCandidate = resolve(baseDir, "agents");
+  const sourceLayoutCandidate = resolve(baseDir, "../agents");
+  const candidates = [
+    firstCandidate,
+    sourceLayoutCandidate,
+    resolve(baseDir, "../../agents"),
+    resolve(baseDir, "../../../agents"),
+  ];
+
+  return [...new Set(candidates)];
+}
+
 export function resolveRuntimeAgentDefinitionsDir(
   input: ResolveRuntimeAgentDefinitionsDirInput,
 ): string {
   const parsedInput = resolveRuntimeAgentDefinitionsDirInputSchema.parse(input);
   const fileName = getRuntimeAgentDefinitionFileName(parsedInput);
-  const firstCandidate = resolve(parsedInput.baseDir, "agents");
+  const candidates = getRuntimeAgentDefinitionsDirCandidates(parsedInput.baseDir);
   const sourceLayoutCandidate = resolve(parsedInput.baseDir, "../agents");
-  const candidates = [
-    firstCandidate,
-    sourceLayoutCandidate,
-    resolve(parsedInput.baseDir, "../../agents"),
-    resolve(parsedInput.baseDir, "../../../agents"),
-  ];
   const fallbackCandidate = basename(parsedInput.baseDir) === "src"
     ? sourceLayoutCandidate
-    : firstCandidate;
+    : resolve(parsedInput.baseDir, "agents");
 
   return candidates.find((candidate) => hasRuntimeAgentDefinitionFile(candidate, fileName)) ??
     fallbackCandidate;
+}
+
+export function listRuntimeAgentMarkdownDefinitionIds(
+  input: ListRuntimeAgentMarkdownDefinitionIdsInput,
+): string[] {
+  const parsedInput = listRuntimeAgentMarkdownDefinitionIdsInputSchema.parse(input);
+  const ids = new Set<string>();
+
+  for (const dir of getRuntimeAgentDefinitionsDirCandidates(parsedInput.baseDir)) {
+    if (!existsSync(dir)) {
+      continue;
+    }
+
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isFile()) {
+        continue;
+      }
+
+      const parseResult = runtimeAgentDefinitionFileNameSchema.safeParse(entry.name);
+      if (!parseResult.success) {
+        continue;
+      }
+
+      ids.add(parseResult.data.slice(0, -".md".length));
+    }
+  }
+
+  return [...ids].sort((left, right) => left.localeCompare(right));
 }
 
 export function resolveRuntimeAgentMarkdownDefinitionFilePath(

--- a/src/agent/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/veryfront-cloud-agent-service.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { CreateSandboxBashTool } from "#veryfront/sandbox";
@@ -22,11 +22,11 @@ async function withTempDir(fn: (dir: string) => Promise<void> | void): Promise<v
   }
 }
 
-function writeMarkdownAgentDefinition(rootDir: string): void {
+function writeMarkdownAgentDefinition(rootDir: string, id = "veryfront"): void {
   const agentsDir = resolve(rootDir, "agents");
   Deno.mkdirSync(agentsDir, { recursive: true });
   Deno.writeTextFileSync(
-    resolve(agentsDir, "veryfront.md"),
+    resolve(agentsDir, `${id}.md`),
     `---
 name: Veryfront
 model: openai/gpt-5.4
@@ -115,6 +115,49 @@ Deno.test("createNodeVeryfrontCloudAgentServiceRuntime loads the markdown agent 
     const liveness = await bundle.runtime.request("http://localhost/liveness");
     assertEquals(liveness.status, 200);
     assertEquals(await liveness.text(), "OK");
+  });
+});
+
+Deno.test("createNodeVeryfrontCloudAgentServiceRuntime defaults to the single markdown agent", async () => {
+  await withTempDir(async (rootDir) => {
+    writeMarkdownAgentDefinition(rootDir, "support");
+
+    const bundle = await createNodeVeryfrontCloudAgentServiceRuntime({
+      serviceName: "single-markdown-agent-test",
+      entrypointUrl: pathToFileURL(resolve(rootDir, "main.ts")),
+      env: {
+        NODE_ENV: "test",
+        VERYFRONT_API_URL: "https://api.example.com",
+        PORT: "3146",
+        ALLOWED_ORIGINS: "https://studio.example.com",
+      },
+    });
+
+    assertEquals(bundle.runtime.contract.defaultAgentId, "support");
+    assertEquals(getRuntimeAgent(bundle, "support").config.model, "openai/gpt-5.4");
+  });
+});
+
+Deno.test("createNodeVeryfrontCloudAgentServiceRuntime requires agentId for multiple markdown agents", async () => {
+  await withTempDir(async (rootDir) => {
+    writeMarkdownAgentDefinition(rootDir, "support");
+    writeMarkdownAgentDefinition(rootDir, "writer");
+
+    await assertRejects(
+      () =>
+        createNodeVeryfrontCloudAgentServiceRuntime({
+          serviceName: "multi-markdown-agent-test",
+          entrypointUrl: pathToFileURL(resolve(rootDir, "main.ts")),
+          env: {
+            NODE_ENV: "test",
+            VERYFRONT_API_URL: "https://api.example.com",
+            PORT: "3147",
+            ALLOWED_ORIGINS: "https://studio.example.com",
+          },
+        }),
+      Error,
+      "agentId is required",
+    );
   });
 });
 
@@ -209,6 +252,36 @@ Deno.test({
       assertEquals(bundle.runtime.contract.defaultAgentId, "support");
       assertEquals(getRuntimeAgent(bundle, "support").config.system, "Help users from code.");
       assertEquals(toolRegistry.has("echo"), true);
+    });
+  },
+});
+
+Deno.test({
+  name: "createNodeVeryfrontCloudAgentServiceRuntime defaults to the single code agent",
+  // Code primitive discovery invokes the esbuild-backed transpiler, which starts
+  // an esbuild child process. This matches the sanitizer policy in
+  // src/discovery/transpiler.test.ts.
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withTempDir(async (rootDir) => {
+      writeCodeAgentDefinition(rootDir);
+
+      const bundle = await createNodeVeryfrontCloudAgentServiceRuntime({
+        serviceName: "single-code-agent-test",
+        agentSource: "code",
+        entrypointUrl: pathToFileURL(resolve(rootDir, "src", "main.ts")),
+        createBashTool,
+        env: {
+          NODE_ENV: "test",
+          VERYFRONT_API_URL: "https://api.example.com",
+          PORT: "3148",
+          ALLOWED_ORIGINS: "https://studio.example.com",
+        },
+      });
+
+      assertEquals(bundle.runtime.contract.defaultAgentId, "support");
+      assertEquals(getRuntimeAgent(bundle, "support").config.system, "Help users from code.");
     });
   },
 });

--- a/src/agent/veryfront-cloud-agent-service.ts
+++ b/src/agent/veryfront-cloud-agent-service.ts
@@ -39,7 +39,10 @@ import {
 } from "./agent-service-bootstrap.ts";
 import { loadAgentServiceEnvFiles } from "./agent-service-env-files.ts";
 import { createHostedFormInputTool } from "./hosted-form-input-tool.ts";
-import { createHostedAgentProjectSteering } from "./hosted-agent-project-steering.ts";
+import {
+  createHostedAgentProjectSteering,
+  type HostedAgentProjectSteering,
+} from "./hosted-agent-project-steering.ts";
 import { type HostedChatRuntimeCreationResult } from "./hosted-chat-runtime-contract.ts";
 import type { HostedConversationRootRunContext } from "./conversation-root-run-lifecycle.ts";
 import { type AgentRuntimeMessage } from "./agent-runtime-message-adapter.ts";
@@ -64,10 +67,7 @@ import type { AgentServiceMcpServerConfig } from "./agent-service-mcp-server-con
 import type { RuntimeLoadSkillToolContext } from "./runtime-load-skill-tool.ts";
 import type { RuntimeProjectSteeringLookup } from "./runtime-project-skill-catalog.ts";
 import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
-import {
-  loadRuntimeAgentMarkdownDefinitionFromFile,
-  resolveRuntimeAgentDefinitionsDir,
-} from "./runtime-agent-definition-files.ts";
+import { listRuntimeAgentMarkdownDefinitionIds } from "./runtime-agent-definition-files.ts";
 import type { RuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
 import {
   buildVeryfrontCloudRuntimeInstructions,
@@ -131,7 +131,11 @@ type AgentServicePathOption = string | URL;
 
 export type NodeVeryfrontCloudAgentServiceOptions = {
   serviceName: string;
-  agentId: string;
+  /**
+   * Default agent served by requests that do not provide an agent id. When
+   * omitted, the service selects the only discovered code or markdown agent.
+   */
+  agentId?: string;
   /**
    * Project/discovery root. Defaults to the process cwd when neither baseDir
    * nor an entrypoint URL is provided.
@@ -309,13 +313,6 @@ function createNodeVeryfrontCloudAgentServiceContext(
   ): TResult | Promise<TResult> {
     return infrastructure.tracer.trace(operationName, operation);
   }
-  const projectSteering = createHostedAgentProjectSteering({
-    baseDir: resolveBaseDir(options),
-    agentId: options.agentId,
-    getApiUrl: () => infrastructure.getConfig().VERYFRONT_API_URL,
-    logger: infrastructure.logger,
-    trace,
-  });
 
   return {
     options,
@@ -323,7 +320,8 @@ function createNodeVeryfrontCloudAgentServiceContext(
     projectDir: resolveProjectDir(options),
     infrastructure,
     trace,
-    projectSteering,
+    defaultAgentId: null as string | null,
+    projectSteeringByAgentId: new Map<string, HostedAgentProjectSteering>(),
     tracker: createDetachedRunTracker<AgUiResumeValue>(),
     discoveryResult: null as DiscoveryResult | null,
     agentConfig: null as RuntimeAgentMarkdownDefinition | null,
@@ -350,27 +348,16 @@ async function createRuntimeAgentDefinitionFromCodeAgent(
 
 function getMarkdownAgentConfig(
   context: NodeVeryfrontCloudAgentServiceContext,
+  agentId: string,
 ): RuntimeAgentMarkdownDefinition {
-  return context.projectSteering.getAgentConfig();
+  return getProjectSteering(context, agentId).getAgentConfig();
 }
 
 function loadMarkdownAgentConfig(
   context: NodeVeryfrontCloudAgentServiceContext,
   agentId: string,
 ): RuntimeAgentMarkdownDefinition {
-  if (agentId === context.options.agentId) {
-    return getMarkdownAgentConfig(context);
-  }
-
-  const agentsDir = resolveRuntimeAgentDefinitionsDir({
-    baseDir: resolveBaseDir(context.options),
-    id: agentId,
-  });
-
-  return loadRuntimeAgentMarkdownDefinitionFromFile({
-    agentsDir,
-    id: agentId,
-  });
+  return getMarkdownAgentConfig(context, agentId);
 }
 
 async function resolveAgentConfig(
@@ -426,11 +413,102 @@ async function discoverProjectPrimitives(
   context.discoveryResult = await discoverAll(discoveryOptions);
 }
 
+function getDiscoveredCodeAgentIds(context: NodeVeryfrontCloudAgentServiceContext): string[] {
+  return [...(context.discoveryResult?.agents.keys() ?? [])].sort((left, right) =>
+    left.localeCompare(right)
+  );
+}
+
+function getDiscoveredMarkdownAgentIds(context: NodeVeryfrontCloudAgentServiceContext): string[] {
+  return listRuntimeAgentMarkdownDefinitionIds({
+    baseDir: resolveBaseDir(context.options),
+  });
+}
+
+function describeAgentIdCandidates(input: {
+  codeAgentIds: string[];
+  markdownAgentIds: string[];
+}): string {
+  const ids = [...new Set([...input.codeAgentIds, ...input.markdownAgentIds])]
+    .sort((left, right) => left.localeCompare(right));
+
+  return ids.length > 0 ? ids.join(", ") : "none";
+}
+
+function resolveSingleAgentId(input: {
+  codeAgentIds: string[];
+  markdownAgentIds: string[];
+  source: NodeVeryfrontCloudAgentServiceAgentSource;
+}): string | null {
+  if (input.source === "code") {
+    return input.codeAgentIds.length === 1 ? input.codeAgentIds[0] ?? null : null;
+  }
+
+  if (input.source === "markdown") {
+    return input.markdownAgentIds.length === 1 ? input.markdownAgentIds[0] ?? null : null;
+  }
+
+  const candidateIds = [...new Set([...input.codeAgentIds, ...input.markdownAgentIds])];
+  return candidateIds.length === 1 ? candidateIds[0] ?? null : null;
+}
+
+function resolveDefaultAgentId(context: NodeVeryfrontCloudAgentServiceContext): string {
+  if (context.options.agentId) {
+    return context.options.agentId;
+  }
+
+  const source = context.options.agentSource ?? "auto";
+  const codeAgentIds = getDiscoveredCodeAgentIds(context);
+  const markdownAgentIds = getDiscoveredMarkdownAgentIds(context);
+  const agentId = resolveSingleAgentId({ codeAgentIds, markdownAgentIds, source });
+
+  if (agentId) {
+    return agentId;
+  }
+
+  throw new Error(
+    [
+      "agentId is required when agent discovery does not resolve to exactly one agent.",
+      `Discovered agents: ${describeAgentIdCandidates({ codeAgentIds, markdownAgentIds })}.`,
+    ].join(" "),
+  );
+}
+
 async function initializeNodeVeryfrontCloudAgentServiceContext(
   context: NodeVeryfrontCloudAgentServiceContext,
 ): Promise<void> {
   await discoverProjectPrimitives(context);
-  context.agentConfig = await resolveAgentConfig(context, context.options.agentId);
+  context.defaultAgentId = resolveDefaultAgentId(context);
+  context.agentConfig = await resolveAgentConfig(context, context.defaultAgentId);
+}
+
+function getDefaultAgentId(context: NodeVeryfrontCloudAgentServiceContext): string {
+  if (!context.defaultAgentId) {
+    throw new Error("Agent service context has not been initialized.");
+  }
+
+  return context.defaultAgentId;
+}
+
+function getProjectSteering(
+  context: NodeVeryfrontCloudAgentServiceContext,
+  agentId: string = getDefaultAgentId(context),
+): HostedAgentProjectSteering {
+  const cachedProjectSteering = context.projectSteeringByAgentId.get(agentId);
+  if (cachedProjectSteering) {
+    return cachedProjectSteering;
+  }
+
+  const projectSteering = createHostedAgentProjectSteering({
+    baseDir: resolveBaseDir(context.options),
+    agentId,
+    getApiUrl: () => context.infrastructure.getConfig().VERYFRONT_API_URL,
+    logger: context.infrastructure.logger,
+    trace: context.trace,
+  });
+
+  context.projectSteeringByAgentId.set(agentId, projectSteering);
+  return projectSteering;
 }
 
 function getDiscoveredHostTools(): HostToolSet {
@@ -444,7 +522,7 @@ function getProjectInstructions(
   lookup: RuntimeProjectSteeringLookup,
 ): Promise<string> {
   return context.trace("chat.getProjectInstructions", async () => {
-    return await context.projectSteering.getProjectInstructions(lookup);
+    return await getProjectSteering(context).getProjectInstructions(lookup);
   });
 }
 
@@ -453,7 +531,7 @@ function getSkillsConfig(
   lookup: RuntimeProjectSteeringLookup,
 ): Promise<RuntimeSkillDefinition[]> {
   return context.trace("chat.getSkillsConfig", async () => {
-    return await context.projectSteering.getSkillsConfig(lookup);
+    return await getProjectSteering(context).getSkillsConfig(lookup);
   });
 }
 
@@ -461,14 +539,14 @@ function createLoadSkillTool(
   context: NodeVeryfrontCloudAgentServiceContext,
   toolContext: RuntimeLoadSkillToolContext,
 ) {
-  return context.projectSteering.createLoadSkillTool(toolContext);
+  return getProjectSteering(context).createLoadSkillTool(toolContext);
 }
 
 async function refreshProjectSkillIds(
   context: NodeVeryfrontCloudAgentServiceContext,
   skillContext: HostedProjectSkillIdsContext,
 ): Promise<void> {
-  await context.projectSteering.refreshProjectSkillIds(skillContext);
+  await getProjectSteering(context).refreshProjectSkillIds(skillContext);
 }
 
 function setFilteredTraceAttributes(
@@ -682,7 +760,7 @@ async function prepareChatExecution(
 
   setPrepareChatExecutionStartAttributes(context, { projectId, userId });
 
-  const agentConfig = await resolveAgentConfig(context, req.agentId ?? context.options.agentId);
+  const agentConfig = await resolveAgentConfig(context, req.agentId ?? getDefaultAgentId(context));
   const {
     effectiveMessages,
     rootRunContext,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.511";
+export const VERSION = "0.1.512";


### PR DESCRIPTION
## Summary
- make the default agent id optional for agent services when discovery resolves exactly one code or markdown agent
- add markdown definition id discovery for convention-based agent services
- document the smaller convention-first entrypoint shape and update run endpoint references
- bound Playwright Chromium install retries so browser setup cannot hang CI indefinitely
- bump framework version to 0.1.512 for CI/CD release

## Verification
- deno test -A src/agent/veryfront-cloud-agent-service.test.ts src/agent/hosted-agent-project-steering.test.ts
- deno task verify:quick
- deno task build:npm
- pre-push checks: fmt, lint, typecheck, unit tests (1841 passed, 0 failed)
- GitHub CI: format, lint, typecheck, unit, integration, rsc browser e2e, binary e2e, CodeQL, dependency audit all green
