### PR TITLE
docs: move extensions table from root README to extensions/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Purpose-built for TypeScript and React, Veryfront gives you everything you need 
 
 - [**Workflows**](https://veryfront.com/docs/code/guides/workflows) — Orchestrate multi-step AI pipelines with branching, parallelism, human-in-the-loop approval gates, and durable crash recovery via Redis checkpoints.
 
-- **Skills** — Project-level agent capabilities defined as `SKILL.md` files following the agentskills.io specification. Skills provide prompt augmentation, tool allowlists, and script execution.
+- [**Skills**](https://veryfront.com/docs/code/guides/skills) — Project-level agent capabilities defined as `SKILL.md` files following the agentskills.io specification. Skills provide prompt augmentation, tool allowlists, and script execution.
 
 - [**Jobs & Cron Jobs**](https://veryfront.com/docs/code/guides/jobs) — Run durable project-scoped background work now or on a schedule through the Veryfront platform.
 
-- **Tasks** — File-based background task definitions discovered automatically and executable via the jobs system.
+- [**Tasks**](https://veryfront.com/docs/code/guides/tasks) — File-based background task definitions discovered automatically and executable via the jobs system.
 
 - [**Multi-Agent**](https://veryfront.com/docs/code/guides/multi-agent) — Compose agents that delegate to each other as tools for complex, coordinated tasks. AG-UI control-plane for hosted agent orchestration.
 
@@ -38,24 +38,7 @@ Purpose-built for TypeScript and React, Veryfront gives you everything you need 
 
 - [**Data Fetching & API Routes**](https://veryfront.com/docs/code/guides/data-fetching) — Server-side data loading, API route handlers, and [middleware](https://veryfront.com/docs/code/guides/middleware) with built-in [OAuth](https://veryfront.com/docs/code/guides/oauth) support.
 
-## Extensions
-
-Veryfront uses an extension system to keep the core lightweight while enabling powerful capabilities through first-party packages:
-
-| Extension                                                                        | Contract             | Description                                        |
-| -------------------------------------------------------------------------------- | -------------------- | -------------------------------------------------- |
-| [`@veryfront/ext-llm-anthropic`](./extensions/ext-llm-anthropic)                 | LLMProvider          | Anthropic Claude models (chat, streaming)          |
-| [`@veryfront/ext-llm-google`](./extensions/ext-llm-google)                       | LLMProvider          | Google Gemini models (chat, embeddings)            |
-| [`@veryfront/ext-llm-openai`](./extensions/ext-llm-openai)                       | LLMProvider          | OpenAI models (chat, embeddings, Responses API)    |
-| [`@veryfront/ext-auth-jwt`](./extensions/ext-auth-jwt)                           | AuthProvider         | JWT sign/verify (HS256) and remote JWKS validation |
-| [`@veryfront/ext-bundler-esbuild`](./extensions/ext-bundler-esbuild)             | Bundler, ModuleLexer | ESM bundling and module analysis                   |
-| [`@veryfront/ext-cache-redis`](./extensions/ext-cache-redis)                     | TokenCacheStore      | Redis-backed token persistence                     |
-| [`@veryfront/ext-css-tailwind`](./extensions/ext-css-tailwind)                   | CSSProcessor         | Tailwind CSS v4 compilation with dynamic plugins   |
-| [`@veryfront/ext-node-compatibility`](./extensions/ext-node-compatibility)       | NodeCompat           | SQLite persistence and document text extraction    |
-| [`@veryfront/ext-parser-babel`](./extensions/ext-parser-babel)                   | CodeParser           | Babel AST parsing, traversal, and generation       |
-| [`@veryfront/ext-tracing-opentelemetry`](./extensions/ext-tracing-opentelemetry) | TracingExporter      | OpenTelemetry trace export via OTLP                |
-| [`@veryfront/ext-transform-mdx`](./extensions/ext-transform-mdx)                 | ContentTransformer   | MDX and Markdown compilation with remark/rehype    |
-| [`@veryfront/ext-zod`](./extensions/ext-zod)                                     | SchemaValidator      | Schema-first runtime validation backed by Zod      |
+- [**Extensions**](./docs/guides/extensions.md) — Contract-based plugin system with 12 first-party packages for LLM providers, bundling, CSS, tracing, caching, and more.
 
 ## Get Started
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -34,12 +34,14 @@ Learn Veryfront Code from the ground up: pages, routing, AI agents, and deployme
 | [Chat UI](./chat-ui.md)                                 | Pre-built chat components and React hooks for chat interfaces.                      |
 | [Workflows](./workflows.md)                             | DAG-based multi-step workflows with branching and parallelism.                      |
 | [Multi-Agent](./multi-agent.md)                         | Agent composition, delegation, and agent-as-tool patterns.                          |
+| [Skills](./skills.md)                                   | Project-level agent capabilities as SKILL.md files with tool restrictions.          |
 
 ## Infrastructure
 
 | Guide                              | Description                                                                                       |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------- |
 | [Jobs & Cron Jobs](./jobs.md)      | Create one-off jobs, schedule cron jobs, inspect events, and work with batch summaries.           |
+| [Tasks](./tasks.md)                | Define background task functions that run locally or as cloud jobs.                               |
 | [Providers](./providers.md)        | Unified model interface for local, Veryfront Cloud, and direct provider runtimes.                 |
 | [Middleware](./middleware.md)      | CORS, rate limiting, logging, and custom middleware pipelines.                                    |
 | [OAuth](./oauth.md)                | OAuth 2.0 helpers with a built-in provider catalog.                                               |

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -1,0 +1,122 @@
+---
+title: "Skills"
+description: "Define project-level agent capabilities as SKILL.md files with prompt augmentation, tool restrictions, and script execution."
+order: 11
+---
+
+# Skills
+
+Skills are project-level agent capabilities defined as `SKILL.md` files following the [agentskills.io](https://agentskills.io) specification. They give agents structured instructions, restrict which tools are available, and provide reference files and executable scripts.
+
+## Quick start
+
+Create a skill directory with a `SKILL.md` file:
+
+```
+skills/
+  code-review/
+    SKILL.md
+    references/
+      style-guide.md
+    scripts/
+      lint.sh
+```
+
+The `SKILL.md` file uses YAML frontmatter for metadata and Markdown for instructions:
+
+```markdown
+---
+name: code-review
+description: Review code changes for style, correctness, and security issues.
+allowed_tools: load-skill load-skill-reference execute-skill-script
+---
+
+# Code Review
+
+Review the submitted code changes following the project style guide.
+
+1. Load the style guide from `references/style-guide.md`
+2. Check for common issues
+3. Run the linter via `scripts/lint.sh`
+4. Provide feedback with specific line references
+```
+
+## Skill structure
+
+Each skill lives in its own directory under `skills/`:
+
+```
+skills/<skill-id>/
+├── SKILL.md              # Required: frontmatter + instructions
+├── references/           # Optional: reference files the agent can read
+│   └── *.md
+├── scripts/              # Optional: executable scripts
+│   └── *.sh
+└── assets/               # Optional: static assets
+    └── *
+```
+
+## Frontmatter fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Skill identifier (lowercase alphanumeric + hyphens, 1-64 chars) |
+| `description` | Yes | Human-readable description (max 1024 chars) |
+| `allowed_tools` | No | Space-delimited tool IDs or prefix patterns (e.g. `api:*`) the agent may use |
+| `license` | No | SPDX license identifier |
+| `compatibility` | No | Compatibility constraints |
+| `metadata` | No | Arbitrary key-value pairs |
+
+## Discovery
+
+Skills are discovered automatically from the `skills/` directory at server startup and on HMR file changes. No registration is needed.
+
+```
+skills/
+  code-review/SKILL.md     → skill ID: "code-review"
+  data-analysis/SKILL.md   → skill ID: "data-analysis"
+```
+
+## Agent tools
+
+When skills are available, agents get three built-in tools:
+
+| Tool | Description |
+|------|-------------|
+| `load-skill` | Load a skill's full instructions by ID |
+| `load-skill-reference` | Read a reference file from a skill |
+| `execute-skill-script` | Execute a script from a skill (5-minute timeout) |
+
+## Tool restrictions
+
+The `allowed_tools` field restricts which tools an agent can use while a skill is active. Use exact IDs or prefix wildcards:
+
+```yaml
+# Exact tool IDs
+allowed_tools: load-skill load-skill-reference execute-skill-script
+
+# Prefix wildcards
+allowed_tools: api:* database:read
+
+# No restriction (agent can use all tools)
+# omit the field entirely
+```
+
+## CLI commands
+
+```bash
+# Create a new skill
+veryfront skills create my-skill
+
+# Validate a skill
+veryfront skills validate skills/my-skill
+```
+
+## Next
+
+- [Agents](./agents.md) — agents use skills for structured instructions
+- [Tools](./tools.md) — define custom tools that skills can reference
+
+## Related
+
+- [agentskills.io specification](https://agentskills.io)

--- a/docs/guides/tasks.md
+++ b/docs/guides/tasks.md
@@ -1,0 +1,128 @@
+---
+title: "Tasks"
+description: "Define background task functions that can run locally or as cloud jobs."
+order: 15.6
+---
+
+# Tasks
+
+Tasks are user-defined functions in `tasks/` that can run locally via `veryfront task <name>` or in the cloud as Jobs and Cron Jobs.
+
+## Quick start
+
+Create a task file:
+
+```ts
+// tasks/sync-data.ts
+export default {
+  name: "Sync external data",
+  description: "Pull latest records from the external API",
+  schedulable: true,
+
+  async run(ctx) {
+    const response = await fetch("https://api.example.com/records");
+    const data = await response.json();
+    return { synced: data.length };
+  },
+};
+```
+
+Run it locally:
+
+```bash
+veryfront task sync-data
+```
+
+## Task definition
+
+A task file exports a `TaskDefinition` object as its default export:
+
+```ts
+interface TaskDefinition {
+  name?: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  schedulable?: boolean;
+  run: (ctx: TaskContext) => Promise<unknown> | unknown;
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | No | Human-readable name |
+| `description` | No | What the task does |
+| `inputSchema` | No | JSON-schema-like input contract for APIs and UIs |
+| `outputSchema` | No | JSON-schema-like output contract |
+| `schedulable` | No | Whether it can be used as a cron job target |
+| `run` | Yes | The function to execute |
+
+## Task context
+
+The `run` function receives a `TaskContext`:
+
+```ts
+interface TaskContext {
+  env: Record<string, string>;
+  config: Record<string, unknown>;
+  projectId?: string;
+}
+```
+
+- **`env`** — filtered environment variables (use `envAllowlist` to restrict)
+- **`config`** — job configuration (passed when run as a cloud job)
+- **`projectId`** — project identifier (available in cloud context)
+
+## Discovery
+
+Tasks are discovered automatically from the `tasks/` directory:
+
+```
+tasks/
+  sync-data.ts           → task ID: "sync-data"
+  reports/weekly.ts      → task ID: "reports-weekly"
+```
+
+File extensions `.ts`, `.tsx`, `.js`, `.jsx` are supported. Test files and `node_modules` are ignored.
+
+## Running tasks
+
+### CLI
+
+```bash
+# Run a task by ID
+veryfront task sync-data
+
+# List discovered tasks
+veryfront task --list
+```
+
+### As a cloud job
+
+Tasks with `schedulable: true` can be targeted by Jobs and Cron Jobs:
+
+```ts
+import { VeryfrontJobsClient } from "veryfront/jobs";
+
+const jobs = new VeryfrontJobsClient({
+  authToken: process.env.VERYFRONT_API_TOKEN,
+  projectReference: "my-project",
+});
+
+await jobs.create({
+  name: "Daily sync",
+  target: "task:sync-data",
+  config: { batchSize: 100 },
+});
+```
+
+See [Jobs & Cron Jobs](./jobs.md) for scheduling and event monitoring.
+
+## Next
+
+- [Jobs & Cron Jobs](./jobs.md) — schedule tasks as cloud jobs
+- [Agents](./agents.md) — agents can invoke tasks as tools
+
+## Related
+
+- [Jobs & Cron Jobs](./jobs.md) — the jobs system that executes scheduled tasks


### PR DESCRIPTION
## Summary

- Remove the duplicate extensions table from the root `README.md`
- Replace it with a one-liner link to `extensions/README.md` in the feature list

The full catalog (grouped by category, with contracts and built-in/optional markings) already lives in `extensions/README.md` from #1620.

## Test plan

- [x] Pre-push checks pass (format, lint, typecheck, unit tests)