### PR TITLE
ci: trigger sync-docs on guide and integration changes

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -8,6 +8,9 @@ on:
       - "src/**/types.ts"
       - "scripts/docs/**"
       - "deno.json"
+      - "docs/guides/**"
+      - "docs/reference/**"
+      - "docs/integrations.md"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Add \`docs/guides/**\`, \`docs/reference/**\`, and \`docs/integrations.md\` to the \`paths:\` filter in \`.github/workflows/sync-docs.yml\`.
- Without this, hand-edited guides under \`docs/guides/\` did not dispatch the \`docs-update\` event, so veryfront-docs never picked them up automatically.

## Test plan
- [ ] Merge, then push a small edit to a file under \`docs/guides/\` and confirm the \`Sync Docs\` workflow runs and dispatches \`docs-update\` to veryfront-docs.