### PR TITLE
security: validate OAuth endpoint URL origin (SEC-003)

### DIFF
--- a/src/oauth/providers/base.test.ts
+++ b/src/oauth/providers/base.test.ts
@@ -1,0 +1,123 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects } from "#std/assert";
+import { OAuthService } from "./base.ts";
+import type { OAuthServiceConfig, OAuthTokens, StoredOAuthState, TokenStore } from "../types.ts";
+
+const TEST_CONFIG: OAuthServiceConfig = {
+  providerId: "test-provider",
+  serviceId: "test-provider",
+  displayName: "Test Provider",
+  clientIdEnvVar: "TEST_CLIENT_ID",
+  clientSecretEnvVar: "TEST_CLIENT_SECRET",
+  authorizationUrl: "https://provider.test/auth",
+  tokenUrl: "https://provider.test/token",
+  defaultScopes: ["read"],
+  apiBaseUrl: "https://api.provider.test",
+};
+
+const ENV: Record<string, string> = {
+  TEST_CLIENT_ID: "test-id",
+  TEST_CLIENT_SECRET: "test-secret",
+};
+
+/** Minimal TokenStore that always returns a valid (non-expired) access token. */
+function makeAuthedTokenStore(): TokenStore {
+  const tokens: OAuthTokens = {
+    accessToken: "test-access-token",
+    refreshToken: undefined,
+    tokenType: "Bearer",
+    scope: "read",
+    idToken: undefined,
+    expiresAt: Date.now() + 60_000_000,
+  };
+  return {
+    getTokens(): Promise<OAuthTokens | null> {
+      return Promise.resolve(tokens);
+    },
+    setTokens(): Promise<void> {
+      return Promise.resolve();
+    },
+    clearTokens(): Promise<void> {
+      return Promise.resolve();
+    },
+    setState(_state: string, _meta: StoredOAuthState): Promise<void> {
+      return Promise.resolve();
+    },
+    consumeState(): Promise<StoredOAuthState | null> {
+      return Promise.resolve(null);
+    },
+  };
+}
+
+/**
+ * Replace globalThis.fetch for the duration of `fn`. Captured calls land in
+ * `captured`; the stubbed fetch always returns `{ ok: true }` JSON.
+ */
+async function withStubbedFetch(
+  captured: string[],
+  fn: () => Promise<unknown>,
+): Promise<void> {
+  const original = globalThis.fetch;
+  globalThis.fetch = ((input: string | URL | Request): Promise<Response> => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.toString()
+      : input.url;
+    captured.push(url);
+    return Promise.resolve(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  }) as typeof fetch;
+  try {
+    await fn();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+Deno.test("OAuthService.fetch: relative endpoint resolves against apiBaseUrl", async () => {
+  const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
+  const captured: string[] = [];
+
+  await withStubbedFetch(captured, async () => {
+    const result = await service.fetch<{ ok: boolean }>("user-1", "/v1/me");
+    assertEquals(result, { ok: true });
+  });
+
+  assertEquals(captured, ["https://api.provider.test/v1/me"]);
+});
+
+Deno.test("OAuthService.fetch: absolute endpoint matching apiBaseUrl origin is allowed", async () => {
+  const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
+  const captured: string[] = [];
+  const sameOrigin = "https://api.provider.test/v1/me";
+
+  await withStubbedFetch(captured, async () => {
+    const result = await service.fetch<{ ok: boolean }>("user-1", sameOrigin);
+    assertEquals(result, { ok: true });
+  });
+
+  assertEquals(captured, [sameOrigin]);
+});
+
+Deno.test("OAuthService.fetch: absolute endpoint on different origin is rejected before fetch", async () => {
+  const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
+  const captured: string[] = [];
+  // Classic cloud-metadata SSRF target.
+  const hostileUrl = "http://169.254.169.254/latest/meta-data/";
+
+  await withStubbedFetch(captured, async () => {
+    await assertRejects(
+      () => service.fetch<unknown>("user-1", hostileUrl),
+      Error,
+      "does not match configured",
+    );
+  });
+
+  // Critical assertion: no outbound request was issued.
+  assertEquals(captured, []);
+});

--- a/src/oauth/providers/base.ts
+++ b/src/oauth/providers/base.ts
@@ -340,6 +340,38 @@ export class OAuthService extends OAuthProvider {
     return result.tokens.accessToken;
   }
 
+  /**
+   * Resolve `endpoint` against `apiBaseUrl`, validating that absolute URLs
+   * share the configured origin.
+   *
+   * Without this check, a caller that forwards user-controlled data as
+   * `endpoint` could cause `fetch()` to issue requests to arbitrary hosts
+   * (including cloud metadata services and internal infrastructure). See
+   * SEC-003 in the security audit.
+   */
+  private resolveEndpointUrl(endpoint: string): string {
+    if (!endpoint.startsWith("http")) {
+      return `${this.apiBaseUrl}${endpoint}`;
+    }
+    let target: URL;
+    let allowed: URL;
+    try {
+      target = new URL(endpoint);
+      allowed = new URL(this.apiBaseUrl);
+    } catch {
+      throw INVALID_ARGUMENT.create({
+        detail: `Invalid OAuth endpoint URL`,
+      });
+    }
+    if (target.origin !== allowed.origin) {
+      throw INVALID_ARGUMENT.create({
+        detail:
+          `OAuth endpoint origin ${target.origin} does not match configured ${allowed.origin}`,
+      });
+    }
+    return endpoint;
+  }
+
   async fetch<T>(userId: string, endpoint: string, options: RequestInit = {}): Promise<T> {
     const token = await this.getAccessToken(userId);
     if (!token) {
@@ -348,7 +380,7 @@ export class OAuthService extends OAuthProvider {
       });
     }
 
-    const url = endpoint.startsWith("http") ? endpoint : `${this.apiBaseUrl}${endpoint}`;
+    const url = this.resolveEndpointUrl(endpoint);
 
     const response = await fetch(url, {
       ...options,


### PR DESCRIPTION
## Summary
- OAuthService.fetch() previously trusted any absolute URL as-is, enabling SSRF if callers passed user-controlled data.
- Now validates that absolute URLs share the configured apiBaseUrl origin; rejects otherwise.

## Why this matters
SEC-003 in the security audit (High severity). Without origin checks, an attacker who can influence the endpoint argument could direct requests to cloud metadata endpoints (169.254.169.254) or internal services.

## Test plan
- [x] Relative endpoint resolves correctly
- [x] Absolute endpoint matching origin resolves correctly
- [x] Absolute endpoint on different origin throws before fetch