### PR TITLE
security: require explicit opt-in for Node.js sandbox (SEC-008)

### DIFF
--- a/src/security/sandbox/deno-sandbox.test.ts
+++ b/src/security/sandbox/deno-sandbox.test.ts
@@ -2,7 +2,11 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { isDeno } from "#veryfront/platform/compat/runtime.ts";
-import { runInWorker } from "./deno-sandbox.ts";
+import {
+  isNodeSandboxAllowedUnsafe,
+  NODE_SANDBOX_ALLOW_UNSAFE_ENV,
+  runInWorker,
+} from "./deno-sandbox.ts";
 import { MAX_SANDBOX_CODE_SIZE } from "./constants.ts";
 
 // Input validation tests work in all runtimes (no Worker needed)
@@ -42,6 +46,40 @@ describe("deno-sandbox input validation", () => {
       Error,
       "maximum size",
     );
+  });
+});
+
+// SEC-008: Node.js Workers do not support permission isolation. The opt-in
+// decision helper must be strict — only the literal "1" enables unsafe mode.
+// Unit-testing the pure helper means coverage works under any runtime.
+describe("deno-sandbox Node opt-in guard (SEC-008)", () => {
+  it("exposes the documented env var name", () => {
+    assertEquals(NODE_SANDBOX_ALLOW_UNSAFE_ENV, "VERYFRONT_NODE_SANDBOX_ALLOW_UNSAFE");
+  });
+
+  it("blocks when env var is undefined", () => {
+    assertEquals(isNodeSandboxAllowedUnsafe(undefined), false);
+  });
+
+  it("blocks when env var is empty", () => {
+    assertEquals(isNodeSandboxAllowedUnsafe(""), false);
+  });
+
+  it("blocks when env var is '0'", () => {
+    assertEquals(isNodeSandboxAllowedUnsafe("0"), false);
+  });
+
+  it("blocks when env var is loose truthy (rejects 'true', 'yes', etc.)", () => {
+    assertEquals(isNodeSandboxAllowedUnsafe("true"), false);
+    assertEquals(isNodeSandboxAllowedUnsafe("TRUE"), false);
+    assertEquals(isNodeSandboxAllowedUnsafe("yes"), false);
+    assertEquals(isNodeSandboxAllowedUnsafe("on"), false);
+    assertEquals(isNodeSandboxAllowedUnsafe("1 "), false);
+    assertEquals(isNodeSandboxAllowedUnsafe(" 1"), false);
+  });
+
+  it("allows execution only on the literal string '1'", () => {
+    assertEquals(isNodeSandboxAllowedUnsafe("1"), true);
   });
 });
 

--- a/src/security/sandbox/deno-sandbox.ts
+++ b/src/security/sandbox/deno-sandbox.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_SANDBOX_TIMEOUT_MS, MAX_SANDBOX_CODE_SIZE } from "./constants.ts";
 import { isCompiledBinary, serverLogger } from "#veryfront/utils";
 import { isDeno, isNode } from "#veryfront/platform/compat/runtime.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process/env.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { INVALID_ARGUMENT, NOT_SUPPORTED, TIMEOUT_ERROR, UNKNOWN_ERROR } from "#veryfront/errors";
 
@@ -19,6 +20,53 @@ type ExtendedWorkerOptions = WorkerOptions & {
   };
 };
 
+/**
+ * Operator opt-in env var that allows {@link runInWorker} to execute on Node.js
+ * despite the lack of permission isolation. Read via {@link getHostEnv} so that
+ * a per-request project env overlay cannot enable unsafe execution from inside
+ * a tenant context.
+ *
+ * @internal Exported for testing.
+ */
+export const NODE_SANDBOX_ALLOW_UNSAFE_ENV = "VERYFRONT_NODE_SANDBOX_ALLOW_UNSAFE";
+
+/**
+ * Pure decision helper for the Node.js sandbox guard. Given the raw env-var
+ * value, decide whether to block execution on Node.
+ *
+ * Returns `true` only when the value is the literal string `"1"`. Any other
+ * value (including `"true"`, `"yes"`, whitespace, or empty string) keeps the
+ * guard active. Strict equality is intentional for a security opt-in.
+ *
+ * @internal Exported for testing only.
+ */
+export function isNodeSandboxAllowedUnsafe(envValue: string | undefined): boolean {
+  return envValue === "1";
+}
+
+/**
+ * Run untrusted JavaScript in an isolated Worker.
+ *
+ * ## Isolation model
+ *
+ * - **Deno (recommended):** the worker is spawned with `permissions: "none"`,
+ *   denying filesystem, network, env, and subprocess access. This is the
+ *   primary safe execution path.
+ * - **Node.js:** Node Workers do not support permission isolation. They
+ *   inherit full access to the filesystem, network, env vars, and built-in
+ *   modules. Only memory limits can be enforced. Because of this, the Node
+ *   path is **disabled by default** and throws {@link NOT_SUPPORTED}.
+ *   Operators who deliberately trust their input may set the env var
+ *   `VERYFRONT_NODE_SANDBOX_ALLOW_UNSAFE=1` to bypass the guard.
+ * - **Bun and other runtimes:** Bun Workers have the same lack of permission
+ *   isolation as Node. This guard does not currently cover Bun; treat Bun as
+ *   "no sandbox" for untrusted code until explicit support is added.
+ *
+ * Callers SHOULD NOT pass untrusted code to this function on Node.js unless
+ * they have audited every caller and operator and accept the risk.
+ *
+ * @throws NOT_SUPPORTED — on Node.js without the explicit opt-in env var.
+ */
 export function runInWorker<T = unknown>(code: string, options: SandboxOptions = {}): Promise<T> {
   if (typeof code !== "string") {
     return Promise.reject(INVALID_ARGUMENT.create({ message: "Sandbox code must be a string" }));
@@ -30,6 +78,18 @@ export function runInWorker<T = unknown>(code: string, options: SandboxOptions =
   if (codeByteLength > MAX_SANDBOX_CODE_SIZE) {
     return Promise.reject(INVALID_ARGUMENT.create({
       message: `Sandbox code exceeds maximum size (${MAX_SANDBOX_CODE_SIZE} bytes)`,
+    }));
+  }
+
+  // SEC-008: Node Workers have no permission isolation. Refuse execution
+  // unless the operator has explicitly opted in via host env var. Use
+  // getHostEnv so a tenant project env overlay cannot enable this.
+  if (isNode && !isNodeSandboxAllowedUnsafe(getHostEnv(NODE_SANDBOX_ALLOW_UNSAFE_ENV))) {
+    return Promise.reject(NOT_SUPPORTED.create({
+      detail: "Sandbox execution is not safely supported on Node.js. The current " +
+        "implementation provides only memory limits, not permission isolation. " +
+        "Set VERYFRONT_NODE_SANDBOX_ALLOW_UNSAFE=1 to enable execution at your " +
+        "own risk, or run under Deno for full isolation.",
     }));
   }
 


### PR DESCRIPTION
## Summary
- runInWorker() on Node previously ran code with no permission restrictions (full FS/network/env access).
- Now throws NOT_SUPPORTED unless VERYFRONT_NODE_SANDBOX_ALLOW_UNSAFE=1 is set.
- Deno path unchanged (still uses permissions: "none").

## Why this matters
SEC-008 in the security audit (Medium severity). The previous behavior was sandbox-escape-by-default for any deployment that ran on Node and accepted untrusted code.

## Migration impact
Operators running on Node who deliberately trust their input must opt in via env var. Deno deployments are unaffected.

## Test plan
- [x] Node path throws NOT_SUPPORTED by default
- [x] Opt-in env var bypasses the guard
- [x] Deno path remains unchanged