### PR TITLE
chore: remove extension-migrated deps from root deno.json

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -294,7 +294,8 @@
     "veryfront/chat/message-prep": "./src/chat/message-prep.ts",
     "veryfront/chat/final-step-fallback": "./src/chat/final-step-fallback.ts",
     "veryfront/chat/provider-errors": "./src/chat/provider-errors.ts",
-    "bash-tool": "npm:bash-tool@1.3.16"
+    "bash-tool": "npm:bash-tool@1.3.16",
+    "just-bash": "npm:just-bash@2.14.5"
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/deno.json
+++ b/deno.json
@@ -284,12 +284,8 @@
     "@opentelemetry/sdk-node": "npm:@opentelemetry/sdk-node@0.217.0",
     "@opentelemetry/sdk-trace-base": "npm:@opentelemetry/sdk-trace-base@2.7.1",
     "@mdx-js/mdx": "npm:@mdx-js/mdx@3.1.1",
-    "@babel/parser": "npm:@babel/parser@7.29.2",
     "gray-matter": "npm:gray-matter@4.0.3",
     "zod": "npm:zod@4.3.6",
-    "mdast": "npm:@types/mdast@4.0.3",
-    "hast": "npm:@types/hast@3.0.3",
-    "unist": "npm:@types/unist@3.0.2",
     "unified": "npm:unified@11.0.5",
     "class-variance-authority": "npm:class-variance-authority@0.7.1",
     "tailwind-merge": "npm:tailwind-merge@3.5.0",
@@ -298,8 +294,7 @@
     "veryfront/chat/message-prep": "./src/chat/message-prep.ts",
     "veryfront/chat/final-step-fallback": "./src/chat/final-step-fallback.ts",
     "veryfront/chat/provider-errors": "./src/chat/provider-errors.ts",
-    "bash-tool": "npm:bash-tool@1.3.16",
-    "just-bash": "npm:just-bash@2.14.5"
+    "bash-tool": "npm:bash-tool@1.3.16"
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/scripts/lint/find-duplicate-functions.ts
+++ b/scripts/lint/find-duplicate-functions.ts
@@ -14,7 +14,7 @@
  *   deno task dupes -- --json
  */
 
-import { parse } from "@babel/parser";
+import { parse } from "npm:@babel/parser@7.29.2";
 import { walk } from "jsr:@std/fs/walk";
 import { parseArgs } from "jsr:@std/cli/parse-args";
 import { relative, resolve } from "jsr:@std/path";

--- a/scripts/lint/style-conventions/ast.ts
+++ b/scripts/lint/style-conventions/ast.ts
@@ -1,4 +1,4 @@
-import { parse, type ParserPlugin } from "@babel/parser";
+import { parse, type ParserPlugin } from "npm:@babel/parser@7.29.2";
 import { BASE_TS_PLUGINS } from "./config.ts";
 import type { AstNodeLike } from "./types.ts";
 

--- a/scripts/lint/style-conventions/config.ts
+++ b/scripts/lint/style-conventions/config.ts
@@ -1,4 +1,4 @@
-import type { ParserPlugin } from "@babel/parser";
+import type { ParserPlugin } from "npm:@babel/parser@7.29.2";
 import type { RuleId } from "./types.ts";
 
 export interface IdentifierCasingReplacement {


### PR DESCRIPTION
## Summary
- Remove `@babel/parser`, `mdast`, `hast`, `unist` from root `deno.json` imports — these are no longer used in `src/` or `cli/` and now live exclusively in their respective extensions (`ext-parser-babel`, `ext-transform-mdx`)

## Test plan
- [x] Pre-push hook ran full test suite (1836 passed, 0 failed)
- [x] Verified zero imports of removed packages in `src/` and `cli/` via grep