### PR TITLE
feat: add agent service control-plane registration

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.512",
+  "version": "0.1.513",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -191,6 +191,21 @@ await startAgentService({
 });
 ```
 
+To let the Veryfront control plane discover this separately deployed push
+runtime, set the control-plane connection environment variables. The default
+registration mode is `auto`: registration runs only when a token and public
+service URL are present.
+
+```bash
+VERYFRONT_API_URL=https://api.example.com
+VERYFRONT_API_TOKEN=<TOKEN>
+VERYFRONT_PROJECT_ID=<PROJECT_ID>
+VERYFRONT_AGENT_SERVICE_URL=https://agent.example.com
+```
+
+Use `VERYFRONT_AGENT_SERVICE_REGISTRATION=enabled` when startup must fail if the
+service cannot register. Use `disabled` to opt out.
+
 Use the lower-level helpers when a service needs custom tools, a custom
 server adapter, or a different control-plane integration.
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -28,9 +28,9 @@ export default defineConfig({
 
 ```ts
 defineConfig({
-  projectSlug: "my-app",         // Project identifier
-  title: "My App",               // Default page title
-  description: "A great app",    // Default meta description
+  projectSlug: "my-app", // Project identifier
+  title: "My App", // Default page title
+  description: "A great app", // Default meta description
 });
 ```
 
@@ -41,8 +41,8 @@ Override the default directory conventions:
 ```ts
 defineConfig({
   directories: {
-    app: "src/app",              // Override page/route directory
-    pages: "src/pages",          // Override pages-router directory
+    app: "src/app", // Override page/route directory
+    pages: "src/pages", // Override pages-router directory
     components: ["src/components"],
     ai: "src/ai",
   },
@@ -53,7 +53,7 @@ defineConfig({
 
 ```ts
 defineConfig({
-  router: "app",    // "app" (default) | "pages"
+  router: "app", // "app" (default) | "pages"
 });
 ```
 
@@ -62,8 +62,8 @@ defineConfig({
 ```ts
 defineConfig({
   build: {
-    outDir: "dist",              // Output directory
-    trailingSlash: false,        // Add trailing slashes to URLs
+    outDir: "dist", // Output directory
+    trailingSlash: false, // Add trailing slashes to URLs
   },
 });
 ```
@@ -72,7 +72,7 @@ defineConfig({
 
 ```ts
 defineConfig({
-  layout: "components/layout.tsx",  // Custom layout path
+  layout: "components/layout.tsx", // Custom layout path
   // layout: false,                 // Disable layout
 });
 ```
@@ -81,7 +81,7 @@ defineConfig({
 
 ```ts
 defineConfig({
-  app: "components/app.tsx",    // Custom app wrapper
+  app: "components/app.tsx", // Custom app wrapper
   // app: false,                // Disable app wrapper
 });
 ```
@@ -91,7 +91,7 @@ defineConfig({
 ```ts
 defineConfig({
   react: {
-    version: "19.1.1",           // Override detected React version
+    version: "19.1.1", // Override detected React version
   },
 });
 ```
@@ -101,8 +101,8 @@ defineConfig({
 ```ts
 defineConfig({
   experimental: {
-    rsc: true,                   // React Server Components
-    precompileMDX: true,         // Pre-compile MDX at build time
+    rsc: true, // React Server Components
+    precompileMDX: true, // Pre-compile MDX at build time
   },
 });
 ```
@@ -157,6 +157,7 @@ defineConfig({
 ```
 
 Notes:
+
 - `paths` are relative to your project root.
 - Defaults are `tools`, `agents`, `skills`, `prompts`, `resources`, `workflows`, and `tasks`.
 - Set `enabled: false` to disable discovery for that primitive.
@@ -188,56 +189,62 @@ Set environment variables in `.env` files or your deployment platform:
 
 ### Veryfront Cloud bootstrap
 
-| Variable | Description |
-|----------|-------------|
-| `VERYFRONT_API_TOKEN` | Veryfront API token for cloud/bootstrap-aware features |
-| `VERYFRONT_PROJECT_SLUG` | Project slug used by Veryfront Cloud-aware features |
-| `VERYFRONT_API_URL` | Override the hosted API URL for self-hosted API deployments |
-| `VERYFRONT_API_BASE_URL` | Override the REST API base URL directly |
-| `VERYFRONT_DEFAULT_MODEL` | Override the default Veryfront Cloud model |
-| `VERYFRONT_DEFAULT_EMBEDDING_MODEL` | Override the default Veryfront Cloud embedding model |
-| `VERYFRONT_RAG_BACKEND` | Override the default RAG backend selection |
+| Variable                                        | Description                                                                                                                              |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `VERYFRONT_API_TOKEN`                           | Veryfront API token for cloud/bootstrap-aware features and agent service registration                                                    |
+| `VERYFRONT_PROJECT_ID`                          | Project id used for project-scoped agent service registration                                                                            |
+| `VERYFRONT_PROJECT_SLUG`                        | Project slug used by Veryfront Cloud-aware features                                                                                      |
+| `VERYFRONT_API_URL`                             | Override the hosted API URL for self-hosted API deployments                                                                              |
+| `VERYFRONT_AGENT_SERVICE_URL`                   | Public URL for a separately deployed agent service that should register with the control plane                                           |
+| `VERYFRONT_AGENT_SERVICE_KEY`                   | Optional stable key for this agent service instance. Defaults to a deterministic key derived from service name, agent id, scope, and URL |
+| `VERYFRONT_AGENT_SERVICE_REGISTRATION`          | Agent service registration mode: `auto`, `enabled`, or `disabled`. Defaults to `auto`                                                    |
+| `VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS` | Push runtime heartbeat interval in milliseconds. Defaults to `30000`                                                                     |
+| `VERYFRONT_AGENT_SERVICE_REGION`                | Optional region metadata for the registered agent service                                                                                |
+| `VERYFRONT_API_BASE_URL`                        | Override the REST API base URL directly                                                                                                  |
+| `VERYFRONT_DEFAULT_MODEL`                       | Override the default Veryfront Cloud model                                                                                               |
+| `VERYFRONT_DEFAULT_EMBEDDING_MODEL`             | Override the default Veryfront Cloud embedding model                                                                                     |
+| `VERYFRONT_RAG_BACKEND`                         | Override the default RAG backend selection                                                                                               |
 
 ### Provider API keys
 
-| Variable | Description |
-|----------|-------------|
-| `OPENAI_API_KEY` | OpenAI API key |
-| `OPENAI_BASE_URL` | Custom OpenAI-compatible endpoint |
-| `ANTHROPIC_API_KEY` | Anthropic API key |
-| `ANTHROPIC_BASE_URL` | Custom Anthropic-compatible endpoint |
-| `GOOGLE_API_KEY` | Google AI API key |
+| Variable                       | Description                          |
+| ------------------------------ | ------------------------------------ |
+| `OPENAI_API_KEY`               | OpenAI API key                       |
+| `OPENAI_BASE_URL`              | Custom OpenAI-compatible endpoint    |
+| `ANTHROPIC_API_KEY`            | Anthropic API key                    |
+| `ANTHROPIC_BASE_URL`           | Custom Anthropic-compatible endpoint |
+| `GOOGLE_API_KEY`               | Google AI API key                    |
 | `GOOGLE_GENERATIVE_AI_API_KEY` | Alternate Google AI API key env name |
 
 ### Local AI
 
-| Variable | Description |
-|----------|-------------|
+| Variable                     | Description                                                                                                                                 |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `VERYFRONT_DISABLE_LOCAL_AI` | Set to `1` to disable server-side local model fallback (browser fallback may still run unless `browserFallback: false` is set in `useChat`) |
 
 ### Framework
 
-| Variable | Description |
-|----------|-------------|
-| `PORT` | Server port (default: 3000) |
-| `NODE_ENV` | `development`, `production`, or `test` |
-| `REDIS_URL` | Redis connection URL |
-| `REQUEST_TIMEOUT_MS` | Incoming HTTP request timeout |
-| `VF_HTTP_FETCH_TIMEOUT` | Outgoing fetch timeout |
-| `SSR_MAX_CONCURRENT_TRANSFORMS` | Concurrency limit for SSR transforms |
-| `VERYFRONT_EXPERIMENTAL_RSC` | Force-enable RSC experimental mode |
+| Variable                        | Description                            |
+| ------------------------------- | -------------------------------------- |
+| `PORT`                          | Server port (default: 3000)            |
+| `NODE_ENV`                      | `development`, `production`, or `test` |
+| `REDIS_URL`                     | Redis connection URL                   |
+| `REQUEST_TIMEOUT_MS`            | Incoming HTTP request timeout          |
+| `VF_HTTP_FETCH_TIMEOUT`         | Outgoing fetch timeout                 |
+| `SSR_MAX_CONCURRENT_TRANSFORMS` | Concurrency limit for SSR transforms   |
+| `VERYFRONT_EXPERIMENTAL_RSC`    | Force-enable RSC experimental mode     |
 
 ### Observability
 
-| Variable | Description |
-|----------|-------------|
-| `VERYFRONT_OTEL` | Enable Veryfront tracing and metrics defaults |
-| `OTEL_TRACES_ENABLED` | Enable OpenTelemetry tracing explicitly |
-| `OTEL_METRICS_ENABLED` | Enable OpenTelemetry metrics explicitly |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | Shared OTLP collector endpoint |
-| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Trace-specific OTLP endpoint |
-| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Metrics-specific OTLP endpoint |
-| `OTEL_SERVICE_NAME` | Service name for traces |
+| Variable                              | Description                                   |
+| ------------------------------------- | --------------------------------------------- |
+| `VERYFRONT_OTEL`                      | Enable Veryfront tracing and metrics defaults |
+| `OTEL_TRACES_ENABLED`                 | Enable OpenTelemetry tracing explicitly       |
+| `OTEL_METRICS_ENABLED`                | Enable OpenTelemetry metrics explicitly       |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`         | Shared OTLP collector endpoint                |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  | Trace-specific OTLP endpoint                  |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Metrics-specific OTLP endpoint                |
+| `OTEL_SERVICE_NAME`                   | Service name for traces                       |
 
 For runtime-specific env behavior, `veryfront/config` and the cloud bootstrap helpers resolve these values per request where needed. Prefer environment variables for secrets and deployment-specific values, and keep `veryfront.config.ts` for stable project structure and feature defaults.
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -23,6 +23,7 @@ import {
   AgUiResumeSignalSchema,
   AgUiRuntimeRequestSchema,
   buildAgUiBrowserFinalizeResponse,
+  createAgentServiceRegistrationLifecycle,
   createAgentServiceRuntime,
   createAgUiBrowserEncoderState,
   createAgUiCancelHandler,
@@ -56,6 +57,7 @@ import {
   parseRuntimeAgentRunInvocation,
   parseRuntimeAgentRunInvocationOrError,
   registerAgent,
+  resolveAgentServiceRegistrationInput,
   runHostedChildLifecycle,
   runHostedLifecycle,
   RunResumeSessionManager,
@@ -313,6 +315,22 @@ await startAgentService({
 If `mcpServers` is omitted, the Veryfront Cloud preset includes
 `veryfrontMcpServer()` by default. Pass `mcpServers: []` to run without remote
 MCP tools.
+
+Control-plane registration is convention-first and explicit through environment
+variables. In `auto` mode, `startAgentService()` registers the service only when
+`VERYFRONT_API_TOKEN` and `VERYFRONT_AGENT_SERVICE_URL` are present. Set
+`VERYFRONT_PROJECT_ID` to register a project-scoped runtime service, or omit it
+for a global runtime service. Set `VERYFRONT_AGENT_SERVICE_REGISTRATION=enabled`
+to require registration during startup, or `disabled` to opt out. The registered
+push service heartbeats until the service shuts down.
+
+```bash
+VERYFRONT_API_URL=https://api.example.com
+VERYFRONT_API_TOKEN=<TOKEN>
+VERYFRONT_PROJECT_ID=<PROJECT_ID>
+VERYFRONT_AGENT_SERVICE_URL=https://agent.example.com
+VERYFRONT_AGENT_SERVICE_REGISTRATION=auto
+```
 
 `createNodeVeryfrontCloudAgentServiceRuntime()` returns the same runtime bundle
 without starting a server, which is useful for tests and custom host shells.
@@ -888,17 +906,32 @@ process entrypoint.
 
 Run the default cross-runtime bootstrap for a Veryfront Cloud agent service. The
 helper loads `.env` files, initializes OpenTelemetry where supported, registers
-trace-context logging, starts the service server, and handles startup failures
-through the provided process target.
+trace-context logging, optionally registers and heartbeats the push runtime
+service with the control plane, starts the service server, and handles startup
+failures through the provided process target.
 
 ### `parseAgentServiceConfig(env)`
 
 Parse the default agent service environment contract. The helper
-validates API URL, node environment, port, durable feature flags, OAuth public
-key, Studio MCP URL, allowed origins, and OpenTelemetry endpoint flags, and it
+validates API URL, token and project registration settings, public agent
+service URL, node environment, port, durable feature flags, OAuth public key,
+Studio MCP URL, allowed origins, and OpenTelemetry endpoint flags, and it
 derives the Veryfront API MCP URL from `VERYFRONT_API_URL`.
 
 `parseHostedAgentServiceConfig()` remains available as a compatibility alias.
+
+### `resolveAgentServiceRegistrationInput(options)`
+
+Resolve the control-plane push runtime registration payload from parsed agent
+service config. The helper returns `null` in `auto` mode unless both
+`VERYFRONT_API_TOKEN` and `VERYFRONT_AGENT_SERVICE_URL` are available. In
+`enabled` mode, missing required settings fail startup.
+
+### `createAgentServiceRegistrationLifecycle(options)`
+
+Register a push runtime service with `/agent-runtimes/push-services` and keep it
+healthy by posting heartbeats to the returned service id. The lifecycle exposes
+`stop()` so service hosts can clear heartbeat timers during graceful shutdown.
 
 ### `loadAgentServiceEnvFiles(options)`
 
@@ -1123,6 +1156,7 @@ Clear all stored messages from memory.
 | `createAgUiRunErrorEvent`                                             | Create a `RunError` AG-UI SSE event                                      |
 | `createAgUiSseErrorResponse`                                          | Create an AG-UI SSE error `Response`                                     |
 | `createAgUiResumeHandler`                                             | Create a POST handler for hosted AG-UI run resume values                 |
+| `createAgentServiceRegistrationLifecycle`                             | Register and heartbeat a push runtime service with the control plane     |
 | `createAgentServiceRuntime`                                           | Create an agent service runtime with default service routes              |
 | `createAgentServiceRouteSet`                                          | Create default agent-service route handlers                              |
 | `createDefaultAgentServiceProjectSteeringRefresh`                     | Create the default agent-service project steering refresh callback       |
@@ -1142,6 +1176,7 @@ Clear all stored messages from memory.
 | `parseAgentServiceChatRequestFromRequest`                             | Parse the agent-service chat request body and auth context               |
 | `loadRuntimeAgentMarkdownDefinitionFromFile`                          | Load and parse a markdown agent definition from an agents directory      |
 | `parseAgentServiceConfig`                                             | Parse default agent service environment config                           |
+| `resolveAgentServiceRegistrationInput`                                | Resolve push runtime registration input from service config              |
 | `resolveNodeAgentServiceTelemetryConfig`                              | Resolve Node service OpenTelemetry config from environment               |
 | `prepareVeryfrontCloudAgentServiceChatExecution`                      | Prepare agent-service chat execution with Veryfront Cloud defaults       |
 | `normalizeAgUiRuntimeMessages`                                        | Normalize runtime AG-UI messages into package `Message[]`                |

--- a/src/agent/agent-service-config.test.ts
+++ b/src/agent/agent-service-config.test.ts
@@ -26,6 +26,13 @@ describe("agent/agent-service-config", () => {
     assertEquals(config.PORT, 3001);
     assertEquals(config.ALLOWED_ORIGINS, ["http://localhost:3000", "http://veryfront.me:3000"]);
     assertEquals(config.OTEL_ENABLED, false);
+    assertEquals(config.VERYFRONT_API_TOKEN, undefined);
+    assertEquals(config.VERYFRONT_PROJECT_ID, undefined);
+    assertEquals(config.VERYFRONT_AGENT_SERVICE_URL, undefined);
+    assertEquals(config.VERYFRONT_AGENT_SERVICE_KEY, undefined);
+    assertEquals(config.VERYFRONT_AGENT_SERVICE_REGISTRATION, "auto");
+    assertEquals(config.VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS, 30000);
+    assertEquals(config.VERYFRONT_AGENT_SERVICE_REGION, undefined);
     assertEquals(config.VERYFRONT_ENABLE_DURABLE_INVOKE_AGENT, false);
     assertEquals(config.VERYFRONT_ENABLE_DURABLE_TASK, false);
   });
@@ -42,6 +49,13 @@ describe("agent/agent-service-config", () => {
       ALLOWED_ORIGINS: "https://a.example.com, https://b.example.com",
       OTEL_ENABLED: "true",
       OTEL_EXPORTER_OTLP_ENDPOINT: "https://otel.example.com",
+      VERYFRONT_API_TOKEN: "token-1",
+      VERYFRONT_PROJECT_ID: "11111111-1111-4111-a111-111111111111",
+      VERYFRONT_AGENT_SERVICE_URL: "https://agent.example.com",
+      VERYFRONT_AGENT_SERVICE_KEY: "agent-service-key",
+      VERYFRONT_AGENT_SERVICE_REGISTRATION: "enabled",
+      VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS: "45000",
+      VERYFRONT_AGENT_SERVICE_REGION: "iad",
     });
 
     assertEquals(config.VERYFRONT_API_URL, "https://api.example.com");
@@ -55,6 +69,13 @@ describe("agent/agent-service-config", () => {
     assertEquals(config.ALLOWED_ORIGINS, ["https://a.example.com", "https://b.example.com"]);
     assertEquals(config.OTEL_ENABLED, true);
     assertEquals(config.OTEL_EXPORTER_OTLP_ENDPOINT, "https://otel.example.com");
+    assertEquals(config.VERYFRONT_API_TOKEN, "token-1");
+    assertEquals(config.VERYFRONT_PROJECT_ID, "11111111-1111-4111-a111-111111111111");
+    assertEquals(config.VERYFRONT_AGENT_SERVICE_URL, "https://agent.example.com");
+    assertEquals(config.VERYFRONT_AGENT_SERVICE_KEY, "agent-service-key");
+    assertEquals(config.VERYFRONT_AGENT_SERVICE_REGISTRATION, "enabled");
+    assertEquals(config.VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS, 45000);
+    assertEquals(config.VERYFRONT_AGENT_SERVICE_REGION, "iad");
   });
 
   it("rejects invalid API URLs", () => {

--- a/src/agent/agent-service-config.ts
+++ b/src/agent/agent-service-config.ts
@@ -10,8 +10,24 @@ function splitAllowedOrigins(value: string): string[] {
 
 const booleanFlagSchema = z.string().default("false").transform(parseBooleanFlag);
 
+const agentServiceRegistrationModeInputSchema = z
+  .enum(["auto", "enabled", "disabled", "true", "false"])
+  .default("auto")
+  .transform((value) => {
+    if (value === "true") return "enabled";
+    if (value === "false") return "disabled";
+    return value;
+  });
+
 export const agentServiceConfigSchema = z.object({
   VERYFRONT_API_URL: z.string().url().default("https://api.veryfront.com"),
+  VERYFRONT_API_TOKEN: z.string().min(1).optional(),
+  VERYFRONT_PROJECT_ID: z.string().min(1).optional(),
+  VERYFRONT_AGENT_SERVICE_URL: z.string().url().optional(),
+  VERYFRONT_AGENT_SERVICE_KEY: z.string().min(1).max(128).optional(),
+  VERYFRONT_AGENT_SERVICE_REGISTRATION: agentServiceRegistrationModeInputSchema,
+  VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS: z.coerce.number().positive().default(30_000),
+  VERYFRONT_AGENT_SERVICE_REGION: z.string().min(1).max(128).optional(),
   NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
   PORT: z.coerce.number().default(3001),
   OAUTH_PUBLIC_KEY: z.string().optional(),
@@ -24,6 +40,13 @@ export const agentServiceConfigSchema = z.object({
 }).transform((env) => ({
   VERYFRONT_API_URL: env.VERYFRONT_API_URL,
   VERYFRONT_MCP_URL: `${env.VERYFRONT_API_URL}/mcp`,
+  VERYFRONT_API_TOKEN: env.VERYFRONT_API_TOKEN,
+  VERYFRONT_PROJECT_ID: env.VERYFRONT_PROJECT_ID,
+  VERYFRONT_AGENT_SERVICE_URL: env.VERYFRONT_AGENT_SERVICE_URL,
+  VERYFRONT_AGENT_SERVICE_KEY: env.VERYFRONT_AGENT_SERVICE_KEY,
+  VERYFRONT_AGENT_SERVICE_REGISTRATION: env.VERYFRONT_AGENT_SERVICE_REGISTRATION,
+  VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS: env.VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS,
+  VERYFRONT_AGENT_SERVICE_REGION: env.VERYFRONT_AGENT_SERVICE_REGION,
   VERYFRONT_STUDIO_MCP_URL: env.VERYFRONT_STUDIO_MCP_URL,
   VERYFRONT_ENABLE_DURABLE_INVOKE_AGENT: env.VERYFRONT_ENABLE_DURABLE_INVOKE_AGENT,
   VERYFRONT_ENABLE_DURABLE_TASK: env.VERYFRONT_ENABLE_DURABLE_TASK,

--- a/src/agent/agent-service-registration.test.ts
+++ b/src/agent/agent-service-registration.test.ts
@@ -1,0 +1,178 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  createAgentServiceRegistrationLifecycle,
+  resolveAgentServiceRegistrationInput,
+} from "./agent-service-registration.ts";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const serviceResponse = {
+  service: {
+    id: "22222222-2222-4222-a222-222222222222",
+    service_name: "docs-agent",
+    service_key: "docs-agent:generated",
+    scope_kind: "project",
+    scope_key: "11111111-1111-4111-a111-111111111111",
+    project_id: "11111111-1111-4111-a111-111111111111",
+    agent_id: "support",
+    base_url: "https://agent.example.com",
+    invoke_url: "https://agent.example.com/api/runs",
+    status: "active",
+    capabilities: null,
+    metadata: null,
+    version: "0.1.0",
+    runtime: "node",
+    region: "iad",
+    last_heartbeat_at: "2026-05-13T00:00:00.000Z",
+    created_at: "2026-05-13T00:00:00.000Z",
+    updated_at: "2026-05-13T00:00:00.000Z",
+  },
+};
+
+describe("agent/agent-service-registration", () => {
+  it("resolves auto registration only when token and public service URL are present", async () => {
+    const input = await resolveAgentServiceRegistrationInput({
+      config: {
+        VERYFRONT_API_URL: "https://api.example.com",
+        VERYFRONT_API_TOKEN: "token-1",
+        VERYFRONT_PROJECT_ID: "11111111-1111-4111-a111-111111111111",
+        VERYFRONT_AGENT_SERVICE_URL: "https://agent.example.com",
+        VERYFRONT_AGENT_SERVICE_KEY: undefined,
+        VERYFRONT_AGENT_SERVICE_REGISTRATION: "auto",
+        VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS: 30_000,
+        VERYFRONT_AGENT_SERVICE_REGION: "iad",
+      },
+      serviceName: "docs-agent",
+      agentId: "support",
+      version: "0.1.0",
+      runtime: "node",
+    });
+
+    assertEquals(input?.apiUrl, "https://api.example.com");
+    assertEquals(input?.authToken, "token-1");
+    assertEquals(input?.scopeKind, "project");
+    assertEquals(input?.projectId, "11111111-1111-4111-a111-111111111111");
+    assertEquals(input?.baseUrl, "https://agent.example.com");
+    assertEquals(input?.invokeUrl, "https://agent.example.com/api/runs");
+    assertEquals(input?.region, "iad");
+    assertEquals(input?.version, "0.1.0");
+    assertEquals(input?.runtime, "node");
+    assertEquals(input?.serviceKey.startsWith("docs-agent:"), true);
+  });
+
+  it("skips auto registration when the token or public URL is missing", async () => {
+    const withoutToken = await resolveAgentServiceRegistrationInput({
+      config: {
+        VERYFRONT_API_URL: "https://api.example.com",
+        VERYFRONT_API_TOKEN: undefined,
+        VERYFRONT_PROJECT_ID: undefined,
+        VERYFRONT_AGENT_SERVICE_URL: "https://agent.example.com",
+        VERYFRONT_AGENT_SERVICE_KEY: undefined,
+        VERYFRONT_AGENT_SERVICE_REGISTRATION: "auto",
+        VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS: 30_000,
+        VERYFRONT_AGENT_SERVICE_REGION: undefined,
+      },
+      serviceName: "docs-agent",
+      agentId: "support",
+      version: undefined,
+      runtime: "node",
+    });
+    const withoutUrl = await resolveAgentServiceRegistrationInput({
+      config: {
+        VERYFRONT_API_URL: "https://api.example.com",
+        VERYFRONT_API_TOKEN: "token-1",
+        VERYFRONT_PROJECT_ID: undefined,
+        VERYFRONT_AGENT_SERVICE_URL: undefined,
+        VERYFRONT_AGENT_SERVICE_KEY: undefined,
+        VERYFRONT_AGENT_SERVICE_REGISTRATION: "auto",
+        VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS: 30_000,
+        VERYFRONT_AGENT_SERVICE_REGION: undefined,
+      },
+      serviceName: "docs-agent",
+      agentId: "support",
+      version: undefined,
+      runtime: "node",
+    });
+
+    assertEquals(withoutToken, null);
+    assertEquals(withoutUrl, null);
+  });
+
+  it("fails explicit registration when required connection settings are missing", async () => {
+    await assertRejects(
+      () =>
+        resolveAgentServiceRegistrationInput({
+          config: {
+            VERYFRONT_API_URL: "https://api.example.com",
+            VERYFRONT_API_TOKEN: undefined,
+            VERYFRONT_PROJECT_ID: undefined,
+            VERYFRONT_AGENT_SERVICE_URL: undefined,
+            VERYFRONT_AGENT_SERVICE_KEY: undefined,
+            VERYFRONT_AGENT_SERVICE_REGISTRATION: "enabled",
+            VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS: 30_000,
+            VERYFRONT_AGENT_SERVICE_REGION: undefined,
+          },
+          serviceName: "docs-agent",
+          agentId: "support",
+          version: undefined,
+          runtime: "node",
+        }),
+      Error,
+      "VERYFRONT_API_TOKEN is required",
+    );
+  });
+
+  it("registers the push service and heartbeats with bearer auth", async () => {
+    const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+    const fetch: typeof globalThis.fetch = (input, init) => {
+      calls.push({ url: input.toString(), init });
+      return Promise.resolve(jsonResponse(serviceResponse));
+    };
+
+    const lifecycle = await createAgentServiceRegistrationLifecycle({
+      apiUrl: "https://api.example.com",
+      authToken: "token-1",
+      serviceName: "docs-agent",
+      serviceKey: "docs-agent:test",
+      scopeKind: "project",
+      projectId: "11111111-1111-4111-a111-111111111111",
+      agentId: "support",
+      baseUrl: "https://agent.example.com",
+      invokeUrl: "https://agent.example.com/api/runs",
+      version: "0.1.0",
+      runtime: "node",
+      region: "iad",
+      heartbeatIntervalMs: 60_000,
+      fetch,
+    });
+
+    await lifecycle.heartbeat();
+    lifecycle.stop();
+
+    assertEquals(calls.length, 2);
+    assertEquals(calls[0]?.url, "https://api.example.com/agent-runtimes/push-services");
+    assertEquals(
+      calls[1]?.url,
+      "https://api.example.com/agent-runtimes/push-services/22222222-2222-4222-a222-222222222222/heartbeat",
+    );
+    assertEquals(new Headers(calls[0]?.init?.headers).get("Authorization"), "Bearer token-1");
+    assertEquals(JSON.parse(String(calls[0]?.init?.body)), {
+      service_name: "docs-agent",
+      service_key: "docs-agent:test",
+      scope_kind: "project",
+      project_id: "11111111-1111-4111-a111-111111111111",
+      agent_id: "support",
+      base_url: "https://agent.example.com",
+      invoke_url: "https://agent.example.com/api/runs",
+      version: "0.1.0",
+      runtime: "node",
+      region: "iad",
+    });
+  });
+});

--- a/src/agent/agent-service-registration.ts
+++ b/src/agent/agent-service-registration.ts
@@ -1,0 +1,319 @@
+import { z } from "zod";
+
+export const agentServiceRegistrationModeSchema = z.enum([
+  "auto",
+  "enabled",
+  "disabled",
+]);
+
+export const agentServiceRegistrationConfigSchema = z.object({
+  VERYFRONT_API_URL: z.string().url(),
+  VERYFRONT_API_TOKEN: z.string().min(1).optional(),
+  VERYFRONT_PROJECT_ID: z.string().min(1).optional(),
+  VERYFRONT_AGENT_SERVICE_URL: z.string().url().optional(),
+  VERYFRONT_AGENT_SERVICE_KEY: z.string().min(1).max(128).optional(),
+  VERYFRONT_AGENT_SERVICE_REGISTRATION: agentServiceRegistrationModeSchema,
+  VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS: z.number().positive(),
+  VERYFRONT_AGENT_SERVICE_REGION: z.string().min(1).max(128).optional(),
+});
+
+export const resolvedAgentServiceRegistrationInputSchema = z.object({
+  apiUrl: z.string().url(),
+  authToken: z.string().min(1),
+  serviceName: z.string().min(1).max(128),
+  serviceKey: z.string().min(1).max(128),
+  scopeKind: z.enum(["global", "project"]),
+  projectId: z.string().min(1).optional(),
+  agentId: z.string().min(1).max(128).optional(),
+  baseUrl: z.string().url(),
+  invokeUrl: z.string().url(),
+  version: z.string().min(1).max(128).optional(),
+  runtime: z.string().min(1).max(128).optional(),
+  region: z.string().min(1).max(128).optional(),
+  heartbeatIntervalMs: z.number().positive(),
+});
+
+const agentPushRuntimeServiceRestSchema = z.object({
+  id: z.string().uuid(),
+  service_name: z.string(),
+  service_key: z.string(),
+  scope_kind: z.enum(["global", "project"]),
+  scope_key: z.string(),
+  project_id: z.string().nullable(),
+  agent_id: z.string().nullable(),
+  base_url: z.string().url(),
+  invoke_url: z.string().url(),
+  status: z.enum(["active", "disabled"]),
+  capabilities: z.unknown().nullable(),
+  metadata: z.unknown().nullable(),
+  version: z.string().nullable(),
+  runtime: z.string().nullable(),
+  region: z.string().nullable(),
+  last_heartbeat_at: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+const agentPushRuntimeServiceResponseSchema = z.object({
+  service: agentPushRuntimeServiceRestSchema,
+});
+
+const registerAgentPushRuntimeServiceRequestSchema = z.object({
+  service_name: z.string().min(1).max(128),
+  service_key: z.string().min(1).max(128),
+  scope_kind: z.enum(["global", "project"]),
+  project_id: z.string().optional(),
+  agent_id: z.string().optional(),
+  base_url: z.string().url(),
+  invoke_url: z.string().url(),
+  version: z.string().optional(),
+  runtime: z.string().optional(),
+  region: z.string().optional(),
+});
+
+export type AgentServiceRegistrationMode = z.infer<typeof agentServiceRegistrationModeSchema>;
+export type AgentServiceRegistrationConfig = z.infer<typeof agentServiceRegistrationConfigSchema>;
+export type ResolvedAgentServiceRegistrationInput = z.infer<
+  typeof resolvedAgentServiceRegistrationInputSchema
+>;
+export type AgentPushRuntimeServiceRest = z.infer<typeof agentPushRuntimeServiceRestSchema>;
+export type RegisterAgentPushRuntimeServiceRequest = z.infer<
+  typeof registerAgentPushRuntimeServiceRequestSchema
+>;
+
+export type AgentServiceRegistrationLogger = {
+  info?: (message: string, metadata?: Record<string, unknown>) => void;
+  warn?: (message: string, metadata?: Record<string, unknown>) => void;
+  error?: (message: string, metadata?: Record<string, unknown>) => void;
+};
+
+export type ResolveAgentServiceRegistrationInputOptions = {
+  config: AgentServiceRegistrationConfig;
+  serviceName: string;
+  agentId?: string;
+  version?: string;
+  runtime?: string;
+};
+
+export type AgentServiceRegistrationLifecycle = {
+  serviceId: string;
+  service: AgentPushRuntimeServiceRest;
+  heartbeat: () => Promise<void>;
+  stop: () => void;
+};
+
+export type CreateAgentServiceRegistrationLifecycleOptions =
+  & ResolvedAgentServiceRegistrationInput
+  & {
+    fetch?: typeof globalThis.fetch;
+    logger?: AgentServiceRegistrationLogger;
+  };
+
+function normalizeBaseUrl(value: string): string {
+  const url = new URL(value);
+  url.pathname = url.pathname.replace(/\/+$/, "");
+  url.search = "";
+  url.hash = "";
+  return url.toString().replace(/\/$/, "");
+}
+
+function defaultInvokeUrl(baseUrl: string): string {
+  return new URL("/api/runs", baseUrl).toString();
+}
+
+function getRegistrationEndpoint(apiUrl: string): string {
+  return new URL("/agent-runtimes/push-services", apiUrl).toString();
+}
+
+function getHeartbeatEndpoint(apiUrl: string, serviceId: string): string {
+  return new URL(`/agent-runtimes/push-services/${serviceId}/heartbeat`, apiUrl).toString();
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function stableServiceKey(input: {
+  serviceName: string;
+  agentId?: string;
+  baseUrl: string;
+  scopeKind: "global" | "project";
+  projectId?: string;
+}): Promise<string> {
+  const keySource = [
+    input.serviceName,
+    input.agentId ?? "default",
+    input.scopeKind,
+    input.projectId ?? "global",
+    input.baseUrl,
+  ].join("|");
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(keySource));
+  const hash = Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 32);
+  return `${input.serviceName}:${hash}`.slice(0, 128);
+}
+
+function requireExplicitRegistrationValue(
+  value: string | undefined,
+  envName: string,
+): string {
+  if (!value) {
+    throw new Error(`${envName} is required when VERYFRONT_AGENT_SERVICE_REGISTRATION=enabled`);
+  }
+  return value;
+}
+
+export async function resolveAgentServiceRegistrationInput(
+  options: ResolveAgentServiceRegistrationInputOptions,
+): Promise<ResolvedAgentServiceRegistrationInput | null> {
+  const config = agentServiceRegistrationConfigSchema.parse(options.config);
+  const enabled = config.VERYFRONT_AGENT_SERVICE_REGISTRATION === "enabled";
+  const token = enabled
+    ? requireExplicitRegistrationValue(config.VERYFRONT_API_TOKEN, "VERYFRONT_API_TOKEN")
+    : config.VERYFRONT_API_TOKEN;
+  const serviceUrl = enabled
+    ? requireExplicitRegistrationValue(
+      config.VERYFRONT_AGENT_SERVICE_URL,
+      "VERYFRONT_AGENT_SERVICE_URL",
+    )
+    : config.VERYFRONT_AGENT_SERVICE_URL;
+
+  if (config.VERYFRONT_AGENT_SERVICE_REGISTRATION === "disabled") {
+    return null;
+  }
+  if (!token || !serviceUrl) {
+    return null;
+  }
+
+  const scopeKind = config.VERYFRONT_PROJECT_ID ? "project" : "global";
+  const baseUrl = normalizeBaseUrl(serviceUrl);
+  const serviceKey = config.VERYFRONT_AGENT_SERVICE_KEY ?? await stableServiceKey({
+    serviceName: options.serviceName,
+    agentId: options.agentId,
+    baseUrl,
+    scopeKind,
+    projectId: config.VERYFRONT_PROJECT_ID,
+  });
+
+  return resolvedAgentServiceRegistrationInputSchema.parse({
+    apiUrl: config.VERYFRONT_API_URL,
+    authToken: token,
+    serviceName: options.serviceName,
+    serviceKey,
+    scopeKind,
+    projectId: config.VERYFRONT_PROJECT_ID,
+    agentId: options.agentId,
+    baseUrl,
+    invokeUrl: defaultInvokeUrl(baseUrl),
+    version: options.version,
+    runtime: options.runtime,
+    region: config.VERYFRONT_AGENT_SERVICE_REGION,
+    heartbeatIntervalMs: config.VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS,
+  });
+}
+
+async function readAgentPushRuntimeServiceResponse(
+  response: Response,
+): Promise<AgentPushRuntimeServiceRest> {
+  if (!response.ok) {
+    throw new Error(`Agent runtime registration request failed with HTTP ${response.status}`);
+  }
+
+  const parsed = agentPushRuntimeServiceResponseSchema.parse(await response.json());
+  return parsed.service;
+}
+
+function createHeaders(authToken: string): Headers {
+  const headers = new Headers();
+  headers.set("Authorization", `Bearer ${authToken}`);
+  headers.set("Content-Type", "application/json");
+  return headers;
+}
+
+function buildRegistrationRequest(
+  input: ResolvedAgentServiceRegistrationInput,
+): RegisterAgentPushRuntimeServiceRequest {
+  return registerAgentPushRuntimeServiceRequestSchema.parse({
+    service_name: input.serviceName,
+    service_key: input.serviceKey,
+    scope_kind: input.scopeKind,
+    project_id: input.projectId,
+    agent_id: input.agentId,
+    base_url: input.baseUrl,
+    invoke_url: input.invokeUrl,
+    version: input.version,
+    runtime: input.runtime,
+    region: input.region,
+  });
+}
+
+async function registerAgentPushRuntimeService(
+  input: ResolvedAgentServiceRegistrationInput,
+  fetchImpl: typeof globalThis.fetch,
+): Promise<AgentPushRuntimeServiceRest> {
+  const response = await fetchImpl(getRegistrationEndpoint(input.apiUrl), {
+    method: "POST",
+    headers: createHeaders(input.authToken),
+    body: JSON.stringify(buildRegistrationRequest(input)),
+  });
+  return await readAgentPushRuntimeServiceResponse(response);
+}
+
+async function heartbeatAgentPushRuntimeService(
+  input: { apiUrl: string; authToken: string; serviceId: string },
+  fetchImpl: typeof globalThis.fetch,
+): Promise<AgentPushRuntimeServiceRest> {
+  const response = await fetchImpl(getHeartbeatEndpoint(input.apiUrl, input.serviceId), {
+    method: "POST",
+    headers: createHeaders(input.authToken),
+  });
+  return await readAgentPushRuntimeServiceResponse(response);
+}
+
+export async function createAgentServiceRegistrationLifecycle(
+  options: CreateAgentServiceRegistrationLifecycleOptions,
+): Promise<AgentServiceRegistrationLifecycle> {
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const input = resolvedAgentServiceRegistrationInputSchema.parse(options);
+  const service = await registerAgentPushRuntimeService(input, fetchImpl);
+  let stopped = false;
+
+  const heartbeat = async () => {
+    if (stopped) {
+      return;
+    }
+    await heartbeatAgentPushRuntimeService({
+      apiUrl: input.apiUrl,
+      authToken: input.authToken,
+      serviceId: service.id,
+    }, fetchImpl);
+  };
+
+  const interval = setInterval(() => {
+    void heartbeat().catch((error: unknown) => {
+      options.logger?.warn?.("Agent service heartbeat failed", {
+        serviceId: service.id,
+        error: getErrorMessage(error),
+      });
+    });
+  }, input.heartbeatIntervalMs);
+
+  options.logger?.info?.("Agent service registered with control plane", {
+    serviceId: service.id,
+    serviceName: service.service_name,
+    scopeKind: service.scope_kind,
+    projectId: service.project_id,
+  });
+
+  return {
+    serviceId: service.id,
+    service,
+    heartbeat,
+    stop: () => {
+      stopped = true;
+      clearInterval(interval);
+    },
+  };
+}

--- a/src/agent/agent-service-runtime.ts
+++ b/src/agent/agent-service-runtime.ts
@@ -28,6 +28,7 @@ import type { AgUiResumeValue } from "./ag-ui-tool-shared.ts";
 import type { RuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
 import {
   type AgentServiceServer,
+  type AgentServiceServerLifecycle,
   type NodeAgentServiceServer,
   startAgentServiceServer,
   startNodeAgentServiceServer,
@@ -110,6 +111,7 @@ export type StartNodeHostedAgentServiceOptions<
   bindAddress?: string;
   hardShutdownTimeoutMs?: number;
   signals?: readonly NodeJS.Signals[];
+  lifecycle?: AgentServiceServerLifecycle;
 };
 
 export type StartNodeAgentServiceOptions<
@@ -124,6 +126,7 @@ export type StartAgentServiceRuntimeOptions<
   bindAddress?: string;
   hardShutdownTimeoutMs?: number;
   signals?: readonly NodeJS.Signals[];
+  lifecycle?: AgentServiceServerLifecycle;
 };
 
 export type StartNodeHostedAgentServiceResult<
@@ -150,6 +153,26 @@ function defaultTrace<TResult>(
   operation: () => Promise<TResult>,
 ): Promise<TResult> {
   return operation();
+}
+
+function combineAgentServiceLifecycle(
+  primary: AgentServiceServerLifecycle,
+  secondary: AgentServiceServerLifecycle | undefined,
+): AgentServiceServerLifecycle {
+  if (!secondary) {
+    return primary;
+  }
+
+  return {
+    setShuttingDown: () => {
+      primary.setShuttingDown?.();
+      secondary.setShuttingDown?.();
+    },
+    stop: async () => {
+      await primary.stop?.();
+      await secondary.stop?.();
+    },
+  };
 }
 
 export function createAgentServiceRuntime<
@@ -232,7 +255,7 @@ export async function startNodeAgentService<
   const nodeServer = await startNodeAgentServiceServer({
     runtime: bundle.runtime,
     serviceName: options.serviceName,
-    lifecycle: bundle.lifecycle,
+    lifecycle: combineAgentServiceLifecycle(bundle.lifecycle, options.lifecycle),
     port: bundle.config.PORT,
     bindAddress: options.bindAddress,
     signals: options.signals,
@@ -265,7 +288,7 @@ export async function startAgentServiceRuntime<
   const server = await startAgentServiceServer({
     runtime: bundle.runtime,
     serviceName: options.serviceName,
-    lifecycle: bundle.lifecycle,
+    lifecycle: combineAgentServiceLifecycle(bundle.lifecycle, options.lifecycle),
     port: bundle.config.PORT,
     bindAddress: options.bindAddress,
     signals: options.signals,

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -346,6 +346,21 @@ export {
   type VeryfrontMcpServerKind,
 } from "./veryfront-cloud-agent-service.ts";
 export {
+  type AgentPushRuntimeServiceRest,
+  type AgentServiceRegistrationConfig,
+  agentServiceRegistrationConfigSchema,
+  type AgentServiceRegistrationLifecycle,
+  type AgentServiceRegistrationLogger,
+  type AgentServiceRegistrationMode,
+  createAgentServiceRegistrationLifecycle,
+  type CreateAgentServiceRegistrationLifecycleOptions,
+  type RegisterAgentPushRuntimeServiceRequest,
+  resolveAgentServiceRegistrationInput,
+  type ResolveAgentServiceRegistrationInputOptions,
+  type ResolvedAgentServiceRegistrationInput,
+  resolvedAgentServiceRegistrationInputSchema,
+} from "./agent-service-registration.ts";
+export {
   type AgentServiceConfig,
   type AgentServiceConfigInput,
   agentServiceConfigSchema,

--- a/src/agent/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/veryfront-cloud-agent-service.test.ts
@@ -6,6 +6,7 @@ import { toolRegistry } from "#veryfront/tool";
 import { agentRegistry } from "./composition/index.ts";
 import {
   createNodeVeryfrontCloudAgentServiceRuntime,
+  startNodeVeryfrontCloudAgentService,
   veryfrontMcpServer,
 } from "./veryfront-cloud-agent-service.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
@@ -170,6 +171,7 @@ Deno.test("createNodeVeryfrontCloudAgentServiceRuntime defaults discovery to cwd
       const bundle = await createNodeVeryfrontCloudAgentServiceRuntime({
         serviceName: "cwd-agent-test",
         agentId: "veryfront",
+        signals: [],
         env: {
           NODE_ENV: "test",
           VERYFRONT_API_URL: "https://api.example.com",
@@ -207,6 +209,73 @@ Deno.test("createNodeVeryfrontCloudAgentServiceRuntime accepts entrypointUrl for
   });
 });
 
+Deno.test("startNodeVeryfrontCloudAgentService registers the service with the control plane", async () => {
+  await withTempDir(async (rootDir) => {
+    writeMarkdownAgentDefinition(rootDir, "support");
+    const originalFetch = globalThis.fetch;
+    const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+    globalThis.fetch = (input, init) => {
+      calls.push({ url: input.toString(), init });
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            service: {
+              id: "22222222-2222-4222-a222-222222222222",
+              service_name: "registered-service-test",
+              service_key: "registered-service-test:key",
+              scope_kind: "project",
+              scope_key: "11111111-1111-4111-a111-111111111111",
+              project_id: "11111111-1111-4111-a111-111111111111",
+              agent_id: "support",
+              base_url: "https://agent.example.com",
+              invoke_url: "https://agent.example.com/api/runs",
+              status: "active",
+              capabilities: null,
+              metadata: null,
+              version: "0.1.0",
+              runtime: "node",
+              region: null,
+              last_heartbeat_at: "2026-05-13T00:00:00.000Z",
+              created_at: "2026-05-13T00:00:00.000Z",
+              updated_at: "2026-05-13T00:00:00.000Z",
+            },
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    };
+
+    try {
+      const bundle = await startNodeVeryfrontCloudAgentService({
+        serviceName: "registered-service-test",
+        agentId: "support",
+        entrypointUrl: pathToFileURL(resolve(rootDir, "main.ts")),
+        signals: [],
+        env: {
+          NODE_ENV: "test",
+          VERYFRONT_API_URL: "https://api.example.com",
+          VERYFRONT_API_TOKEN: "token-1",
+          VERYFRONT_PROJECT_ID: "11111111-1111-4111-a111-111111111111",
+          VERYFRONT_AGENT_SERVICE_URL: "https://agent.example.com",
+          VERYFRONT_AGENT_SERVICE_KEY: "registered-service-test:key",
+          VERYFRONT_AGENT_SERVICE_REGISTRATION: "enabled",
+          VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS: "60000",
+          PORT: "0",
+          ALLOWED_ORIGINS: "https://studio.example.com",
+        },
+      });
+      await bundle.nodeServer.stop();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    assertEquals(calls.length, 1);
+    assertEquals(calls[0]?.url, "https://api.example.com/agent-runtimes/push-services");
+    assertEquals(new Headers(calls[0]?.init?.headers).get("Authorization"), "Bearer token-1");
+    assertEquals(JSON.parse(String(calls[0]?.init?.body)).scope_kind, "project");
+  });
+});
+
 Deno.test("veryfrontMcpServer creates explicit Veryfront MCP server configs", () => {
   assertEquals(veryfrontMcpServer(), { kind: "veryfront-api" });
   assertEquals(veryfrontMcpServer("studio"), { kind: "veryfront-studio" });
@@ -241,6 +310,7 @@ Deno.test({
         agentSource: "code",
         entrypointUrl: pathToFileURL(resolve(rootDir, "src", "main.ts")),
         createBashTool,
+        signals: [],
         env: {
           NODE_ENV: "test",
           VERYFRONT_API_URL: "https://api.example.com",
@@ -272,6 +342,7 @@ Deno.test({
         agentSource: "code",
         entrypointUrl: pathToFileURL(resolve(rootDir, "src", "main.ts")),
         createBashTool,
+        signals: [],
         env: {
           NODE_ENV: "test",
           VERYFRONT_API_URL: "https://api.example.com",
@@ -303,6 +374,7 @@ Deno.test({
         agentSource: "code",
         entrypointUrl: pathToFileURL(resolve(rootDir, "src", "main.ts")),
         createBashTool,
+        signals: [],
         env: {
           NODE_ENV: "test",
           VERYFRONT_API_URL: "https://api.example.com",

--- a/src/agent/veryfront-cloud-agent-service.ts
+++ b/src/agent/veryfront-cloud-agent-service.ts
@@ -85,6 +85,11 @@ import {
   startNodeAgentService,
   type StartNodeAgentServiceResult,
 } from "./agent-service-runtime.ts";
+import type { AgentServiceServerLifecycle } from "./agent-service-server.ts";
+import {
+  createAgentServiceRegistrationLifecycle,
+  resolveAgentServiceRegistrationInput,
+} from "./agent-service-registration.ts";
 import { createDetachedRunTracker } from "./detached-run-tracker.ts";
 import type { AgUiResumeValue } from "./ag-ui-tool-shared.ts";
 import type { ParsedHostedChatRequest } from "./hosted-chat-request-parser.ts";
@@ -158,6 +163,7 @@ export type NodeVeryfrontCloudAgentServiceOptions = {
   processTarget?: NodeVeryfrontCloudAgentServiceProcessTarget;
   drainTimeoutMs?: number;
   hardShutdownTimeoutMs?: number;
+  signals?: readonly NodeJS.Signals[];
 };
 
 export type VeryfrontCloudAgentServiceOptions = NodeVeryfrontCloudAgentServiceOptions;
@@ -837,6 +843,58 @@ function createPreparedExecutionRuntimeOptions(
   });
 }
 
+function resolveAgentServiceRuntimeName(): string {
+  if (Reflect.get(globalThis, "Bun")) {
+    return "bun";
+  }
+  if (Reflect.get(globalThis, "Deno")) {
+    return "deno";
+  }
+  return "node";
+}
+
+function getAgentServiceVersion(
+  context: NodeVeryfrontCloudAgentServiceContext,
+): string | undefined {
+  return context.options.env?.npm_package_version;
+}
+
+async function createControlPlaneRegistrationLifecycle(
+  context: NodeVeryfrontCloudAgentServiceContext,
+): Promise<AgentServiceServerLifecycle | undefined> {
+  const config = context.infrastructure.getConfig();
+  const registrationInput = await resolveAgentServiceRegistrationInput({
+    config,
+    serviceName: context.options.serviceName,
+    agentId: getDefaultAgentId(context),
+    version: getAgentServiceVersion(context),
+    runtime: resolveAgentServiceRuntimeName(),
+  });
+
+  if (!registrationInput) {
+    return undefined;
+  }
+
+  try {
+    const lifecycle = await createAgentServiceRegistrationLifecycle({
+      ...registrationInput,
+      logger: context.infrastructure.logger,
+    });
+    return {
+      stop: () => lifecycle.stop(),
+    };
+  } catch (error) {
+    if (config.VERYFRONT_AGENT_SERVICE_REGISTRATION === "enabled") {
+      throw error;
+    }
+
+    context.infrastructure.logger.warn("Agent service registration skipped", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+}
+
 function createNodeVeryfrontCloudAgentServiceRuntimeOptions(
   context: NodeVeryfrontCloudAgentServiceContext,
 ): CreateAgentServiceRuntimeOptions<NodeVeryfrontCloudAgentServicePreparedExecution> {
@@ -895,10 +953,18 @@ export async function startNodeVeryfrontCloudAgentService(
   const resolvedOptions = await resolveNodeVeryfrontCloudAgentServiceOptions(options);
   const context = createNodeVeryfrontCloudAgentServiceContext(resolvedOptions);
   await initializeNodeVeryfrontCloudAgentServiceContext(context);
-  return await startNodeAgentService({
-    ...createNodeVeryfrontCloudAgentServiceRuntimeOptions(context),
-    hardShutdownTimeoutMs: options.hardShutdownTimeoutMs ?? DEFAULT_HARD_SHUTDOWN_TIMEOUT_MS,
-  });
+  const registrationLifecycle = await createControlPlaneRegistrationLifecycle(context);
+  try {
+    return await startNodeAgentService({
+      ...createNodeVeryfrontCloudAgentServiceRuntimeOptions(context),
+      lifecycle: registrationLifecycle,
+      signals: options.signals,
+      hardShutdownTimeoutMs: options.hardShutdownTimeoutMs ?? DEFAULT_HARD_SHUTDOWN_TIMEOUT_MS,
+    });
+  } catch (error) {
+    await registrationLifecycle?.stop?.();
+    throw error;
+  }
 }
 
 export async function startAgentService(
@@ -933,10 +999,18 @@ export async function startAgentService(
       __registerTraceContextGetter(getter);
     },
     start: async () => {
-      await startAgentServiceRuntime({
-        ...createNodeVeryfrontCloudAgentServiceRuntimeOptions(context),
-        hardShutdownTimeoutMs: options.hardShutdownTimeoutMs ?? DEFAULT_HARD_SHUTDOWN_TIMEOUT_MS,
-      });
+      const registrationLifecycle = await createControlPlaneRegistrationLifecycle(context);
+      try {
+        await startAgentServiceRuntime({
+          ...createNodeVeryfrontCloudAgentServiceRuntimeOptions(context),
+          lifecycle: registrationLifecycle,
+          signals: options.signals,
+          hardShutdownTimeoutMs: options.hardShutdownTimeoutMs ?? DEFAULT_HARD_SHUTDOWN_TIMEOUT_MS,
+        });
+      } catch (error) {
+        await registrationLifecycle?.stop?.();
+        throw error;
+      }
     },
     onStartupError: (error) => {
       console.error("Error in server startup:", error);

--- a/src/discovery/auto-discovery.integration.test.ts
+++ b/src/discovery/auto-discovery.integration.test.ts
@@ -110,7 +110,7 @@ describe(
           `${tempDir}/tools/write-report.ts`,
           [
             'import { tool } from "veryfront/tool";',
-            'import { defineSchema } from "#veryfront/schemas/index.ts";',
+            'import { defineSchema } from "veryfront/schemas";',
             "",
             "export default tool({",
             '  id: "write-report",',
@@ -144,7 +144,7 @@ describe(
           `${tempDir}/tools/write-report.ts`,
           [
             'import { tool } from "veryfront/tool";',
-            'import { defineSchema } from "#veryfront/schemas/index.ts";',
+            'import { defineSchema } from "veryfront/schemas";',
             "",
             "export default tool({",
             '  id: "tool_2024_01",',
@@ -178,7 +178,7 @@ describe(
           `${tempDir}/tools/write-report.ts`,
           [
             'import { tool } from "veryfront/tool";',
-            'import { defineSchema } from "#veryfront/schemas/index.ts";',
+            'import { defineSchema } from "veryfront/schemas";',
             "",
             "const generated = tool({",
             '  description: "Write a markdown report",',

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.512";
+export const VERSION = "0.1.513";


### PR DESCRIPTION
## Summary
- Add agent service push runtime registration and heartbeat helpers for the control plane.
- Wire `startAgentService()` and `startNodeVeryfrontCloudAgentService()` to register when `VERYFRONT_API_TOKEN` and `VERYFRONT_AGENT_SERVICE_URL` are configured, with explicit enabled/disabled modes.
- Document the registration env contract and bump the framework patch version to 0.1.513.
- Fix auto-discovery integration fixtures to use the public schema import in temp projects.

## Verification
- `deno task verify`
- pre-push hook: fmt + lint + typecheck + `deno task test:unit`
- `deno fmt --check src/agent/agent-service-registration.ts src/agent/agent-service-registration.test.ts src/agent/agent-service-config.ts src/agent/agent-service-config.test.ts src/agent/agent-service-runtime.ts src/agent/veryfront-cloud-agent-service.ts src/agent/veryfront-cloud-agent-service.test.ts src/discovery/auto-discovery.integration.test.ts src/utils/version-constant.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/agent/agent-service-registration.ts src/agent/agent-service-registration.test.ts src/agent/agent-service-config.ts src/agent/agent-service-config.test.ts src/agent/agent-service-runtime.ts src/agent/veryfront-cloud-agent-service.ts src/agent/veryfront-cloud-agent-service.test.ts src/discovery/auto-discovery.integration.test.ts src/utils/version-constant.ts`
- `deno check src/agent/index.ts src/agent/agent-service-registration.ts src/agent/veryfront-cloud-agent-service.ts src/agent/agent-service-runtime.ts`
- `deno test --no-check --allow-all src/agent/agent-service-registration.test.ts src/agent/agent-service-config.test.ts src/agent/agent-service-runtime.test.ts src/agent/agent-service-server.test.ts src/agent/veryfront-cloud-agent-service.test.ts src/utils/version.test.ts src/utils/logger/logger.test.ts src/discovery/auto-discovery.integration.test.ts`
- `deno task docs:validate`
