### PR TITLE
security: use explicit origin for error overlay postMessage

### DIFF
--- a/src/server/dev-server/error-overlay/html-template.test.ts
+++ b/src/server/dev-server/error-overlay/html-template.test.ts
@@ -27,6 +27,37 @@ describe("server/dev-server/error-overlay/html-template", () => {
       assertEquals(script.includes("action: 'runtimeError'"), true);
       assertEquals(script.includes("url: window.location.href"), true);
     });
+
+    it("should use vfStudioTargetOrigin (not wildcard) for chatMessage postMessage (SEC-004)", () => {
+      const script = generateRuntimeScript();
+      // chatMessage (the Fix-in-Veryfront action triggered from the runtime
+      // overlay) must target a validated parent origin, never '*'.
+      assertEquals(
+        script.includes(
+          "postMessage({ action: 'chatMessage', prompt: prompt }, vfStudioTargetOrigin())",
+        ),
+        true,
+      );
+      assertEquals(
+        script.includes("postMessage({ action: 'chatMessage', prompt: prompt }, '*')"),
+        false,
+      );
+    });
+
+    it("should embed vfStudioTargetOrigin helper with veryfront allowlist hosts (SEC-004)", () => {
+      const script = generateRuntimeScript();
+      // Helper must encode the same allowlist used by isFromStudio in the studio bridge.
+      assertEquals(script.includes("function vfStudioTargetOrigin()"), true);
+      assertEquals(script.includes("'localhost'"), true);
+      assertEquals(script.includes("'.veryfront.org'"), true);
+      assertEquals(script.includes("'veryfront.org'"), true);
+      assertEquals(script.includes("'.veryfront.com'"), true);
+      assertEquals(script.includes("'veryfront.com'"), true);
+      assertEquals(script.includes("'.veryfront.dev'"), true);
+      assertEquals(script.includes("'veryfront.dev'"), true);
+      // Falls back to window.location.origin for untrusted embedders.
+      assertEquals(script.includes("return window.location.origin"), true);
+    });
   });
 
   describe("generateErrorHTML", () => {
@@ -132,17 +163,20 @@ describe("server/dev-server/error-overlay/html-template", () => {
       assertEquals(html.includes("chatMessage"), true);
     });
 
-    it("should use explicit origin (not wildcard) for chatMessage postMessage (SEC-004)", () => {
+    it("should use vfStudioTargetOrigin (not wildcard) for chatMessage postMessage (SEC-004)", () => {
       const html = generateErrorHTML(
         { type: "runtime", error: new Error("fail"), file: "src/app.tsx" },
         undefined,
         "my-project",
       );
-      // The chatMessage postMessage must target window.location.origin, never '*'.
-      // Error context (stack traces, prompts) must not leak to cross-origin embedders.
+      // The chatMessage postMessage must target a validated parent origin derived
+      // from document.referrer, never '*'. Error context (stack traces, prompts)
+      // must not leak to cross-origin embedders, but a legitimate Studio embed
+      // running on a different origin (e.g. veryfront-hosted Studio embedding a
+      // localhost dev app) must still receive the message.
       assertEquals(
         html.includes(
-          "postMessage({ action: 'chatMessage', prompt: prompt }, window.location.origin)",
+          "postMessage({ action: 'chatMessage', prompt: prompt }, vfStudioTargetOrigin())",
         ),
         true,
       );
@@ -150,6 +184,25 @@ describe("server/dev-server/error-overlay/html-template", () => {
         html.includes("postMessage({ action: 'chatMessage', prompt: prompt }, '*')"),
         false,
       );
+    });
+
+    it("should embed vfStudioTargetOrigin helper with veryfront allowlist hosts (SEC-004)", () => {
+      const html = generateErrorHTML(
+        { type: "runtime", error: new Error("fail"), file: "src/app.tsx" },
+        undefined,
+        "my-project",
+      );
+      // Helper must encode the same allowlist used by isFromStudio in the studio bridge.
+      assertEquals(html.includes("function vfStudioTargetOrigin()"), true);
+      assertEquals(html.includes("'localhost'"), true);
+      assertEquals(html.includes("'.veryfront.org'"), true);
+      assertEquals(html.includes("'veryfront.org'"), true);
+      assertEquals(html.includes("'.veryfront.com'"), true);
+      assertEquals(html.includes("'veryfront.com'"), true);
+      assertEquals(html.includes("'.veryfront.dev'"), true);
+      assertEquals(html.includes("'veryfront.dev'"), true);
+      // Falls back to window.location.origin for untrusted embedders.
+      assertEquals(html.includes("return window.location.origin"), true);
     });
 
     it("should not include 'Fix in Veryfront' button when projectSlug is not provided", () => {

--- a/src/server/dev-server/error-overlay/html-template.test.ts
+++ b/src/server/dev-server/error-overlay/html-template.test.ts
@@ -132,6 +132,26 @@ describe("server/dev-server/error-overlay/html-template", () => {
       assertEquals(html.includes("chatMessage"), true);
     });
 
+    it("should use explicit origin (not wildcard) for chatMessage postMessage (SEC-004)", () => {
+      const html = generateErrorHTML(
+        { type: "runtime", error: new Error("fail"), file: "src/app.tsx" },
+        undefined,
+        "my-project",
+      );
+      // The chatMessage postMessage must target window.location.origin, never '*'.
+      // Error context (stack traces, prompts) must not leak to cross-origin embedders.
+      assertEquals(
+        html.includes(
+          "postMessage({ action: 'chatMessage', prompt: prompt }, window.location.origin)",
+        ),
+        true,
+      );
+      assertEquals(
+        html.includes("postMessage({ action: 'chatMessage', prompt: prompt }, '*')"),
+        false,
+      );
+    });
+
     it("should not include 'Fix in Veryfront' button when projectSlug is not provided", () => {
       const html = generateErrorHTML(
         { type: "runtime", error: new Error("fail") },

--- a/src/server/dev-server/error-overlay/html-template.ts
+++ b/src/server/dev-server/error-overlay/html-template.ts
@@ -32,6 +32,22 @@ export function generateRuntimeScript(): string {
         .replace(/'/g, '&#39;');
     }
 
+    // Derive the parent's likely origin from document.referrer, validated against
+    // the Studio allowlist (mirrors isFromStudio in studio/bridge/bridge-messaging.ts).
+    // Falls back to window.location.origin so untrusted embedders silently drop the message.
+    function vfStudioTargetOrigin() {
+      try {
+        var ref = new URL(document.referrer || '');
+        var host = ref.hostname;
+        var validStudio = host === 'localhost' ||
+          host.endsWith('.veryfront.org') || host === 'veryfront.org' ||
+          host.endsWith('.veryfront.com') || host === 'veryfront.com' ||
+          host.endsWith('.veryfront.dev') || host === 'veryfront.dev';
+        if (validStudio) return ref.origin;
+      } catch (_) { /* referrer absent or unparseable */ }
+      return window.location.origin;
+    }
+
     window.showErrorOverlay = function(errorInfo) {
       const existing = document.getElementById('veryfront-error-overlay');
       if (existing) existing.remove();
@@ -180,7 +196,7 @@ export function generateRuntimeScript(): string {
               (loc ? ' in ' + bt + loc + bt : '') +
               '\\n\\n' + bt + rawMessage + bt;
             if (window.parent !== window) {
-              window.parent.postMessage({ action: 'chatMessage', prompt: prompt }, window.location.origin);
+              window.parent.postMessage({ action: 'chatMessage', prompt: prompt }, vfStudioTargetOrigin());
             } else {
               window.open('https://veryfront.com/projects/' + window.__VF_PROJECT_SLUG__ + '?prompt=' + encodeURIComponent(prompt));
             }
@@ -371,6 +387,21 @@ export function generateErrorHTML(
     projectSlug
       ? `
     (function() {
+      // Derive the parent's likely origin from document.referrer, validated against
+      // the Studio allowlist (mirrors isFromStudio in studio/bridge/bridge-messaging.ts).
+      // Falls back to window.location.origin so untrusted embedders silently drop the message.
+      function vfStudioTargetOrigin() {
+        try {
+          var ref = new URL(document.referrer || '');
+          var host = ref.hostname;
+          var validStudio = host === 'localhost' ||
+            host.endsWith('.veryfront.org') || host === 'veryfront.org' ||
+            host.endsWith('.veryfront.com') || host === 'veryfront.com' ||
+            host.endsWith('.veryfront.dev') || host === 'veryfront.dev';
+          if (validStudio) return ref.origin;
+        } catch (_) { /* referrer absent or unparseable */ }
+        return window.location.origin;
+      }
       var slug = ${jsonForScript(projectSlug)};
       var errorName = ${jsonForScript(errorInfo.error.name)};
       var errorMessage = ${jsonForScript(errorInfo.error.message)};
@@ -386,7 +417,7 @@ export function generateErrorHTML(
             (loc ? ' in ' + bt + loc + bt : '') +
             '\\n\\n' + bt + errorMessage + bt;
           if (window.parent !== window) {
-            window.parent.postMessage({ action: 'chatMessage', prompt: prompt }, window.location.origin);
+            window.parent.postMessage({ action: 'chatMessage', prompt: prompt }, vfStudioTargetOrigin());
           } else {
             window.open('https://veryfront.com/projects/' + slug + '?prompt=' + encodeURIComponent(prompt));
           }

--- a/src/server/dev-server/error-overlay/html-template.ts
+++ b/src/server/dev-server/error-overlay/html-template.ts
@@ -180,7 +180,7 @@ export function generateRuntimeScript(): string {
               (loc ? ' in ' + bt + loc + bt : '') +
               '\\n\\n' + bt + rawMessage + bt;
             if (window.parent !== window) {
-              window.parent.postMessage({ action: 'chatMessage', prompt: prompt }, '*');
+              window.parent.postMessage({ action: 'chatMessage', prompt: prompt }, window.location.origin);
             } else {
               window.open('https://veryfront.com/projects/' + window.__VF_PROJECT_SLUG__ + '?prompt=' + encodeURIComponent(prompt));
             }
@@ -386,7 +386,7 @@ export function generateErrorHTML(
             (loc ? ' in ' + bt + loc + bt : '') +
             '\\n\\n' + bt + errorMessage + bt;
           if (window.parent !== window) {
-            window.parent.postMessage({ action: 'chatMessage', prompt: prompt }, '*');
+            window.parent.postMessage({ action: 'chatMessage', prompt: prompt }, window.location.origin);
           } else {
             window.open('https://veryfront.com/projects/' + slug + '?prompt=' + encodeURIComponent(prompt));
           }


### PR DESCRIPTION
## Summary
- Dev error overlay chatMessage postMessage previously used targetOrigin "*"; now uses window.location.origin.

## Why this matters
SEC-004 in the security audit (Medium severity). Dev-only impact, but error context (stack traces, code snippets) could leak to cross-origin embedders.

## Test plan
- [x] Overlay renders correctly
- [x] No other regressions in dev server