### PR TITLE
security: rate limiter fail-closed on store error

### DIFF
--- a/src/security/rate-limit/middleware.test.ts
+++ b/src/security/rate-limit/middleware.test.ts
@@ -3,6 +3,7 @@ import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createRateLimiter, RateLimitPresets } from "./middleware.ts";
 import { MemoryRateLimitStore } from "./memory-store.ts";
+import type { RateLimitStore } from "./types.ts";
 
 function createNext(): () => Promise<Response> {
   return () => Promise.resolve(new Response("OK"));
@@ -224,5 +225,37 @@ describe("Rate Limiting Middleware", () => {
       assertEquals(response.status, 200);
       assertEquals(response.headers.get("X-RateLimit-Limit"), "10");
     });
+  });
+
+  it("should fail closed with 503 when store throws (SEC-001)", async () => {
+    // Simulate a store outage (e.g. Redis down). The middleware must NOT
+    // call next() in the catch branch — that would silently bypass rate
+    // limiting and reopen brute-force / scraping / credential-stuffing
+    // surfaces. Expect a 503 with Retry-After: 60 instead.
+    const failingStore: RateLimitStore = {
+      increment: () => Promise.reject(new Error("store unavailable")),
+      get: () => Promise.reject(new Error("store unavailable")),
+      reset: () => Promise.reject(new Error("store unavailable")),
+      resetAll: () => Promise.reject(new Error("store unavailable")),
+    };
+
+    const limiter = createRateLimiter({
+      maxRequests: 5,
+      windowMs: 60000,
+      strategy: "fixed-window",
+      store: failingStore,
+    });
+
+    let nextCalled = false;
+    const next = () => {
+      nextCalled = true;
+      return Promise.resolve(new Response("OK"));
+    };
+
+    const response = await limiter(createRequest(), next);
+
+    assertEquals(response.status, 503);
+    assertEquals(response.headers.get("Retry-After"), "60");
+    assertEquals(nextCalled, false, "next() must not be invoked when the store fails");
   });
 });

--- a/src/security/rate-limit/middleware.test.ts
+++ b/src/security/rate-limit/middleware.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createRateLimiter, RateLimitPresets } from "./middleware.ts";
 import { MemoryRateLimitStore } from "./memory-store.ts";
@@ -257,5 +257,69 @@ describe("Rate Limiting Middleware", () => {
     assertEquals(response.status, 503);
     assertEquals(response.headers.get("Retry-After"), "60");
     assertEquals(nextCalled, false, "next() must not be invoked when the store fails");
+  });
+
+  it("should NOT swallow downstream handler errors", async () => {
+    // Downstream handler exceptions must propagate to the normal error handler
+    // rather than being reclassified as a rate-limit outage (503 + Retry-After).
+    // Masking application faults as rate-limit signals hides real problems and
+    // causes clients to back off incorrectly.
+    await withStore(async (store) => {
+      const limiter = createRateLimiter({
+        maxRequests: 5,
+        windowMs: 60000,
+        strategy: "fixed-window",
+        store,
+      });
+
+      let nextCalled = false;
+      const downstreamError = new Error("handler boom");
+      const next = () => {
+        nextCalled = true;
+        return Promise.reject(downstreamError);
+      };
+
+      const err = await assertRejects(
+        () => limiter(createRequest(), next),
+        Error,
+        "handler boom",
+      );
+      assertEquals(err, downstreamError, "the original error must propagate unchanged");
+      assertEquals(nextCalled, true, "next() must have been invoked");
+    });
+  });
+
+  it("should NOT swallow onRateLimitExceeded callback errors", async () => {
+    // User-supplied callback errors must propagate to the normal error handler
+    // rather than being masked as a 503 rate-limit outage.
+    await withStore(async (store) => {
+      const callbackError = new Error("callback boom");
+
+      const limiter = createRateLimiter({
+        maxRequests: 1,
+        windowMs: 60000,
+        strategy: "fixed-window",
+        store,
+        onRateLimitExceeded: () => {
+          throw callbackError;
+        },
+      });
+
+      const request = createRequest();
+      const next = createNext();
+
+      // First request consumes the only token allowed by the limit.
+      const ok = await limiter(request, next);
+      assertEquals(ok.status, 200);
+
+      // Second request triggers the callback, which throws — the error must
+      // propagate (NOT become a 503).
+      const err = await assertRejects(
+        () => limiter(request, next),
+        Error,
+        "callback boom",
+      );
+      assertEquals(err, callbackError, "the original callback error must propagate unchanged");
+    });
   });
 });

--- a/src/security/rate-limit/middleware.ts
+++ b/src/security/rate-limit/middleware.ts
@@ -123,11 +123,18 @@ export function createRateLimiter(
       applyRateLimitHeaders(response, headers);
       return response;
     } catch (error) {
-      logger.error("Rate limiting error", {
+      // Fail closed: if the rate-limit store throws (e.g. Redis outage), reject
+      // the request with 503 instead of letting it through. Failing open would
+      // silently disable rate limiting and expose brute-force, scraping, and
+      // credential-stuffing surfaces during transient store failures.
+      logger.error("Rate limiting error — failing closed", {
         error: error instanceof Error ? error.message : String(error),
       });
 
-      return next(request);
+      return new Response("Service temporarily unavailable", {
+        status: 503,
+        headers: { "Retry-After": "60" },
+      });
     }
   };
 }

--- a/src/security/rate-limit/middleware.ts
+++ b/src/security/rate-limit/middleware.ts
@@ -90,43 +90,26 @@ export function createRateLimiter(
     request: Request,
     next: (req: Request) => Promise<Response>,
   ): Promise<Response> {
+    if (skip && (await skip(request))) {
+      return next(request);
+    }
+
+    const key = resolvedKeyGenerator(request);
+
+    let result: Awaited<ReturnType<typeof strategyFn>>;
     try {
-      if (skip && (await skip(request))) {
-        return next(request);
-      }
-
-      const key = resolvedKeyGenerator(request);
-      const result = await strategyFn(key, { ...config, maxRequests, windowMs }, store);
-
-      const headers = new Headers({
-        "X-RateLimit-Limit": maxRequests.toString(),
-        "X-RateLimit-Remaining": result.remaining.toString(),
-        "X-RateLimit-Reset": result.resetTime.toString(),
-      });
-
-      if (!result.allowed) {
-        logger.warn(`Rate limit exceeded for key: ${key}`, {
-          key,
-          limit: maxRequests,
-          window: windowMs,
-        });
-
-        const response = onRateLimitExceeded
-          ? await onRateLimitExceeded(request, key)
-          : defaultRateLimitExceeded(request, key, message);
-
-        applyRateLimitHeaders(response, headers);
-        return response;
-      }
-
-      const response = await next(request);
-      applyRateLimitHeaders(response, headers);
-      return response;
+      result = await strategyFn(key, { ...config, maxRequests, windowMs }, store);
     } catch (error) {
-      // Fail closed: if the rate-limit store throws (e.g. Redis outage), reject
-      // the request with 503 instead of letting it through. Failing open would
-      // silently disable rate limiting and expose brute-force, scraping, and
-      // credential-stuffing surfaces during transient store failures.
+      // Fail closed: only the rate-limit store/strategy path triggers this.
+      // If the store throws (e.g. Redis outage), reject the request with 503
+      // instead of letting it through. Failing open would silently disable
+      // rate limiting and expose brute-force, scraping, and credential-stuffing
+      // surfaces during transient store failures.
+      //
+      // Downstream handler errors (from next(request)) and user-callback errors
+      // (skip, keyGenerator, onRateLimitExceeded) are intentionally NOT caught
+      // here so they remain observable as 5xx via the normal error handler and
+      // are not masked as rate-limit outages with Retry-After: 60.
       logger.error("Rate limiting error — failing closed", {
         error: error instanceof Error ? error.message : String(error),
       });
@@ -136,6 +119,31 @@ export function createRateLimiter(
         headers: { "Retry-After": "60" },
       });
     }
+
+    const headers = new Headers({
+      "X-RateLimit-Limit": maxRequests.toString(),
+      "X-RateLimit-Remaining": result.remaining.toString(),
+      "X-RateLimit-Reset": result.resetTime.toString(),
+    });
+
+    if (!result.allowed) {
+      logger.warn(`Rate limit exceeded for key: ${key}`, {
+        key,
+        limit: maxRequests,
+        window: windowMs,
+      });
+
+      const response = onRateLimitExceeded
+        ? await onRateLimitExceeded(request, key)
+        : defaultRateLimitExceeded(request, key, message);
+
+      applyRateLimitHeaders(response, headers);
+      return response;
+    }
+
+    const response = await next(request);
+    applyRateLimitHeaders(response, headers);
+    return response;
   };
 }
 


### PR DESCRIPTION
## Summary
- Rate limiter previously failed open: any error in the rate-limit store caused all requests to bypass rate limiting.
- Now fails closed with 503 Service Unavailable + Retry-After: 60.

## Why this matters
SEC-001 in the security audit (High severity). Brute-force, scraping, and credential-stuffing attacks were feasible during any transient Redis outage.

## Test plan
- [x] New/updated unit test covering store-error catch branch
- [x] Existing rate-limit tests still pass