### PR TITLE
Improve agent service convention defaults

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.513",
+  "version": "0.1.514",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -186,9 +186,7 @@ lives in `agents/<agent-id>.md` or a discovered code agent such as
 ```ts
 import { startAgentService } from "veryfront/agent";
 
-await startAgentService({
-  serviceName: "support-agent",
-});
+await startAgentService();
 ```
 
 To let the Veryfront control plane discover this separately deployed push
@@ -202,6 +200,10 @@ VERYFRONT_API_TOKEN=<TOKEN>
 VERYFRONT_PROJECT_ID=<PROJECT_ID>
 VERYFRONT_AGENT_SERVICE_URL=https://agent.example.com
 ```
+
+The service name defaults to `VERYFRONT_AGENT_SERVICE_NAME`, then the nearest
+`package.json` or `deno.json` `name`, then `veryfront-agent-service`. Pass
+`serviceName` only when code should override that convention.
 
 Use `VERYFRONT_AGENT_SERVICE_REGISTRATION=enabled` when startup must fail if the
 service cannot register. Use `disabled` to opt out.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -195,6 +195,7 @@ Set environment variables in `.env` files or your deployment platform:
 | `VERYFRONT_PROJECT_ID`                          | Project id used for project-scoped agent service registration                                                                            |
 | `VERYFRONT_PROJECT_SLUG`                        | Project slug used by Veryfront Cloud-aware features                                                                                      |
 | `VERYFRONT_API_URL`                             | Override the hosted API URL for self-hosted API deployments                                                                              |
+| `VERYFRONT_AGENT_SERVICE_NAME`                  | Optional agent service name. Defaults to the nearest project manifest name, then `veryfront-agent-service`                               |
 | `VERYFRONT_AGENT_SERVICE_URL`                   | Public URL for a separately deployed agent service that should register with the control plane                                           |
 | `VERYFRONT_AGENT_SERVICE_KEY`                   | Optional stable key for this agent service instance. Defaults to a deterministic key derived from service name, agent id, scope, and URL |
 | `VERYFRONT_AGENT_SERVICE_REGISTRATION`          | Agent service registration mode: `auto`, `enabled`, or `disabled`. Defaults to `auto`                                                    |

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -278,14 +278,16 @@ agent behavior in `agents/<agent-id>.md` or `agents/<agent-id>.ts`:
 import { startAgentService, veryfrontMcpServer } from "veryfront/agent";
 
 await startAgentService({
-  serviceName: "support-agent",
   mcpServers: [veryfrontMcpServer()],
 });
 ```
 
-By default, discovery is rooted at the process cwd. Pass `baseDir` only when the
-service may start from another working directory. `entrypointUrl` is a
-convenience fallback for deriving `baseDir` from an entry module URL.
+By default, discovery is rooted at the process cwd and the service name comes
+from `VERYFRONT_AGENT_SERVICE_NAME`, the nearest `package.json` or `deno.json`
+`name`, or `veryfront-agent-service`. Pass `serviceName` only when code should
+override that convention. Pass `baseDir` only when the service may start from
+another working directory. `entrypointUrl` is a convenience fallback for
+deriving `baseDir` from an entry module URL.
 If the service discovers exactly one code or markdown agent, that agent becomes
 the default automatically. Set `agentId` when the service exposes multiple
 agents or when direct `/api/runs` requests should use a specific default.
@@ -889,11 +891,13 @@ project tools, and `invoke_agent`), sandbox tools, explicit remote MCP servers,
 prepared chat execution, AG-UI streaming, and detached
 durable-run execution.
 
-Hosts provide the service name and agent id. Discovery defaults to cwd; hosts
-can pass `baseDir` when cwd is not the project root, or `entrypointUrl` when it
-is more convenient to derive the base directory from a module URL. Use this
-helper when tests or custom hosts need the runtime bundle without starting the
-service server.
+Hosts can provide the service name and agent id. The service name defaults to
+`VERYFRONT_AGENT_SERVICE_NAME`, then the nearest `package.json` or `deno.json`
+`name`, then `veryfront-agent-service`. Discovery defaults to cwd; hosts can
+pass `baseDir` when cwd is not the project root, or `entrypointUrl` when it is
+more convenient to derive the base directory from a module URL. Use this helper
+when tests or custom hosts need the runtime bundle without starting the service
+server.
 
 ### `startNodeVeryfrontCloudAgentService(options)`
 
@@ -902,9 +906,9 @@ server and graceful shutdown handling. This helper remains available for
 Node-specific hosts; use `startAgentService()` for the default cross-runtime
 process entrypoint.
 
-### `startAgentService(options)`
+### `startAgentService(options?)`
 
-Run the default cross-runtime bootstrap for a Veryfront Cloud agent service. The
+Run the default cross-runtime bootstrap for a Veryfront agent service. The
 helper loads `.env` files, initializes OpenTelemetry where supported, registers
 trace-context logging, optionally registers and heartbeats the push runtime
 service with the control plane, starts the service server, and handles startup

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -334,6 +334,9 @@ export {
   type StartNodeHostedAgentServiceResult,
 } from "./agent-service-runtime.ts";
 export {
+  type AgentServiceOptions,
+  type AgentServicePreparedExecution,
+  type AgentServiceProcessTarget,
   createNodeVeryfrontCloudAgentServiceRuntime,
   type NodeVeryfrontCloudAgentServiceMcpServer,
   type NodeVeryfrontCloudAgentServiceOptions,

--- a/src/agent/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/veryfront-cloud-agent-service.test.ts
@@ -139,6 +139,53 @@ Deno.test("createNodeVeryfrontCloudAgentServiceRuntime defaults to the single ma
   });
 });
 
+Deno.test("createNodeVeryfrontCloudAgentServiceRuntime derives serviceName from project manifest", async () => {
+  await withTempDir(async (rootDir) => {
+    writeMarkdownAgentDefinition(rootDir, "support");
+    Deno.writeTextFileSync(
+      resolve(rootDir, "package.json"),
+      JSON.stringify({ name: "support-agent-service" }),
+    );
+
+    const bundle = await createNodeVeryfrontCloudAgentServiceRuntime({
+      entrypointUrl: pathToFileURL(resolve(rootDir, "main.ts")),
+      env: {
+        NODE_ENV: "test",
+        VERYFRONT_API_URL: "https://api.example.com",
+        PORT: "3149",
+        ALLOWED_ORIGINS: "https://studio.example.com",
+      },
+    });
+
+    assertEquals(bundle.runtime.contract.serviceName, "support-agent-service");
+    assertEquals(bundle.runtime.contract.defaultAgentId, "support");
+  });
+});
+
+Deno.test("createNodeVeryfrontCloudAgentServiceRuntime lets env override manifest serviceName", async () => {
+  await withTempDir(async (rootDir) => {
+    writeMarkdownAgentDefinition(rootDir, "support");
+    Deno.writeTextFileSync(
+      resolve(rootDir, "deno.json"),
+      JSON.stringify({ name: "manifest-agent-service" }),
+    );
+
+    const bundle = await createNodeVeryfrontCloudAgentServiceRuntime({
+      entrypointUrl: pathToFileURL(resolve(rootDir, "main.ts")),
+      env: {
+        NODE_ENV: "test",
+        VERYFRONT_API_URL: "https://api.example.com",
+        VERYFRONT_AGENT_SERVICE_NAME: "env-agent-service",
+        PORT: "3150",
+        ALLOWED_ORIGINS: "https://studio.example.com",
+      },
+    });
+
+    assertEquals(bundle.runtime.contract.serviceName, "env-agent-service");
+    assertEquals(bundle.runtime.contract.defaultAgentId, "support");
+  });
+});
+
 Deno.test("createNodeVeryfrontCloudAgentServiceRuntime requires agentId for multiple markdown agents", async () => {
   await withTempDir(async (rootDir) => {
     writeMarkdownAgentDefinition(rootDir, "support");

--- a/src/agent/veryfront-cloud-agent-service.ts
+++ b/src/agent/veryfront-cloud-agent-service.ts
@@ -1,6 +1,7 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { z } from "zod";
 import type { AgentServiceSandboxToolsOptions } from "#veryfront/sandbox";
 import { createAgentServiceSandboxTools } from "#veryfront/sandbox";
 import {
@@ -135,7 +136,12 @@ export function veryfrontMcpServer(
 type AgentServicePathOption = string | URL;
 
 export type NodeVeryfrontCloudAgentServiceOptions = {
-  serviceName: string;
+  /**
+   * Stable service identity used by the control plane and service runtime.
+   * Defaults to VERYFRONT_AGENT_SERVICE_NAME, then the nearest project
+   * package.json or deno.json name, then "veryfront-agent-service".
+   */
+  serviceName?: string;
   /**
    * Default agent served by requests that do not provide an agent id. When
    * omitted, the service selects the only discovered code or markdown agent.
@@ -167,11 +173,13 @@ export type NodeVeryfrontCloudAgentServiceOptions = {
 };
 
 export type VeryfrontCloudAgentServiceOptions = NodeVeryfrontCloudAgentServiceOptions;
+export type AgentServiceOptions = NodeVeryfrontCloudAgentServiceOptions;
 
 type ResolvedNodeVeryfrontCloudAgentServiceOptions =
-  & NodeVeryfrontCloudAgentServiceOptions
+  & Omit<NodeVeryfrontCloudAgentServiceOptions, "createBashTool" | "serviceName">
   & {
     createBashTool: AgentServiceSandboxToolsOptions["createBashTool"];
+    serviceName: string;
   };
 
 export type NodeVeryfrontCloudAgentServicePreparedExecution = PreparedHostedChatExecution & {
@@ -182,6 +190,8 @@ export type NodeVeryfrontCloudAgentServicePreparedExecution = PreparedHostedChat
   messages: PreparedHostedChatExecution["messages"];
   rootRunContext: HostedConversationRootRunContext;
 };
+export type AgentServicePreparedExecution = NodeVeryfrontCloudAgentServicePreparedExecution;
+export type AgentServiceProcessTarget = NodeVeryfrontCloudAgentServiceProcessTarget;
 
 type NodeVeryfrontCloudAgentServiceContext = ReturnType<
   typeof createNodeVeryfrontCloudAgentServiceContext
@@ -193,12 +203,16 @@ type ChildRunContext = DefaultHostedInvokeAgentContext & {
 const DEFAULT_FORWARDED_CONFIG_NAMESPACE = "veryfront";
 const DEFAULT_DRAIN_TIMEOUT_MS = 15_000;
 const DEFAULT_HARD_SHUTDOWN_TIMEOUT_MS = 20_000;
+const DEFAULT_AGENT_SERVICE_NAME = "veryfront-agent-service";
 const DEFAULT_PROJECT_NAVIGATION_TOOL_NAMES = ["studio_open_project"];
 const PROJECT_CONFIG_FILES = [
   "veryfront.config.js",
   "veryfront.config.ts",
   "veryfront.config.mjs",
 ];
+const ProjectManifestNameSchema = z.object({
+  name: z.string().trim().min(1).optional(),
+}).passthrough();
 
 function pathOptionToPath(pathOption: AgentServicePathOption): string {
   return pathOption instanceof URL ? fileURLToPath(pathOption) : pathOption;
@@ -252,6 +266,47 @@ function resolveProjectDir(
   return candidates.find(hasDiscoveryRoot) ?? baseDir;
 }
 
+function readProjectManifestName(projectDir: string): string | null {
+  for (const fileName of ["package.json", "deno.json"]) {
+    const filePath = resolve(projectDir, fileName);
+    if (!existsSync(filePath)) {
+      continue;
+    }
+
+    try {
+      const parsed = ProjectManifestNameSchema.parse(
+        JSON.parse(readFileSync(filePath, "utf8")),
+      );
+      if (parsed.name) {
+        return parsed.name;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+function resolveServiceName(
+  options: Pick<
+    NodeVeryfrontCloudAgentServiceOptions,
+    "baseDir" | "entrypointUrl" | "env" | "processTarget" | "projectDir" | "serviceName"
+  >,
+): string {
+  if (options.serviceName?.trim()) {
+    return options.serviceName.trim();
+  }
+
+  const env = resolveEnvironment(options);
+  const envServiceName = env.VERYFRONT_AGENT_SERVICE_NAME?.trim();
+  if (envServiceName) {
+    return envServiceName;
+  }
+
+  return readProjectManifestName(resolveProjectDir(options)) ?? DEFAULT_AGENT_SERVICE_NAME;
+}
+
 function resolveDefaultProcessTarget(): NodeVeryfrontCloudAgentServiceProcessTarget | undefined {
   if (typeof process === "undefined") {
     return undefined;
@@ -277,6 +332,7 @@ async function resolveNodeVeryfrontCloudAgentServiceOptions(
 ): Promise<ResolvedNodeVeryfrontCloudAgentServiceOptions> {
   return {
     ...options,
+    serviceName: resolveServiceName(options),
     createBashTool: options.createBashTool ?? await loadDefaultCreateBashTool(),
   };
 }
@@ -939,7 +995,7 @@ function createNodeVeryfrontCloudAgentServiceRuntimeOptions(
 }
 
 export async function createNodeVeryfrontCloudAgentServiceRuntime(
-  options: NodeVeryfrontCloudAgentServiceOptions,
+  options: NodeVeryfrontCloudAgentServiceOptions = {},
 ): Promise<AgentServiceRuntimeBundle<NodeVeryfrontCloudAgentServicePreparedExecution>> {
   const resolvedOptions = await resolveNodeVeryfrontCloudAgentServiceOptions(options);
   const context = createNodeVeryfrontCloudAgentServiceContext(resolvedOptions);
@@ -948,7 +1004,7 @@ export async function createNodeVeryfrontCloudAgentServiceRuntime(
 }
 
 export async function startNodeVeryfrontCloudAgentService(
-  options: NodeVeryfrontCloudAgentServiceOptions,
+  options: NodeVeryfrontCloudAgentServiceOptions = {},
 ): Promise<StartNodeAgentServiceResult<NodeVeryfrontCloudAgentServicePreparedExecution>> {
   const resolvedOptions = await resolveNodeVeryfrontCloudAgentServiceOptions(options);
   const context = createNodeVeryfrontCloudAgentServiceContext(resolvedOptions);
@@ -968,7 +1024,7 @@ export async function startNodeVeryfrontCloudAgentService(
 }
 
 export async function startAgentService(
-  options: NodeVeryfrontCloudAgentServiceOptions,
+  options: NodeVeryfrontCloudAgentServiceOptions = {},
 ): Promise<void> {
   const processTarget = options.processTarget ?? resolveDefaultProcessTarget();
   let getRuntimeTraceContext: NonNullable<BootstrapAgentServiceOptions["getTraceContext"]> =

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.513";
+export const VERSION = "0.1.514";


### PR DESCRIPTION
## Summary\n- make agent service options convention-first by allowing startAgentService() without explicit options\n- derive serviceName from VERYFRONT_AGENT_SERVICE_NAME, project manifests, or a stable fallback\n- expose shorter agent-service option type aliases and document the default service entrypoint shape\n- bump deno.json and version constant to 0.1.514 for CI/CD publication\n\n## Verification\n- deno fmt --check deno.json src/utils/version-constant.ts src/agent/veryfront-cloud-agent-service.ts src/agent/veryfront-cloud-agent-service.test.ts src/agent/index.ts docs/guides/agents.md docs/reference/agent.md docs/guides/configuration.md\n- deno check src/agent/veryfront-cloud-agent-service.ts src/agent/index.ts\n- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts\n- deno test --no-check --allow-all --parallel src/agent/agent-service-runtime.test.ts src/agent/agent-service-config.test.ts src/agent/node-agent-service-runtime-infrastructure.test.ts src/agent/veryfront-cloud-agent-service.test.ts src/agent/agent-service-mcp-server-config.test.ts