### PR TITLE
security: redact env var names from OAuth not-configured response

### DIFF
--- a/src/oauth/handlers/init-handler.test.ts
+++ b/src/oauth/handlers/init-handler.test.ts
@@ -104,7 +104,7 @@ Deno.test("init handler: returns 401 when getUserId returns empty string", async
   assertEquals(response.status, 401);
 });
 
-Deno.test("init handler: returns 500 when oauth is not configured", async () => {
+Deno.test("init handler: returns 503 when oauth is not configured", async () => {
   const handler = createOAuthInitHandler(TEST_CONFIG, {
     env: makeEnv(),
     envReader: () => undefined,
@@ -113,11 +113,33 @@ Deno.test("init handler: returns 500 when oauth is not configured", async () => 
 
   const response = await handler(new Request("http://localhost:3000/api/auth/test-provider"));
 
-  assertEquals(response.status, 500);
+  // SEC-009: misconfiguration is Service Unavailable, not a generic 500.
+  assertEquals(response.status, 503);
   assertEquals(await response.json(), {
     error: "Test Provider OAuth not configured",
-    details: "Missing TEST_CLIENT_ID or TEST_CLIENT_SECRET",
   });
+});
+
+Deno.test("init handler: not-configured response does not leak env var names (SEC-009)", async () => {
+  const handler = createOAuthInitHandler(TEST_CONFIG, {
+    env: makeEnv(),
+    envReader: () => undefined,
+    getUserId: () => "alice",
+  });
+
+  const response = await handler(new Request("http://localhost:3000/api/auth/test-provider"));
+
+  assertEquals(response.status, 503);
+
+  const bodyText = await response.text();
+  // Internal env var names must NOT appear in the response body.
+  assertEquals(bodyText.includes(TEST_CONFIG.clientIdEnvVar), false);
+  assertEquals(bodyText.includes(TEST_CONFIG.clientSecretEnvVar), false);
+  // The body still surfaces a generic "not configured" message to the caller.
+  assertEquals(bodyText.includes("not configured"), true);
+
+  const body = JSON.parse(bodyText) as Record<string, unknown>;
+  assertEquals("details" in body, false);
 });
 
 Deno.test("init handler: stores state with userId and redirects to the provider", async () => {

--- a/src/oauth/handlers/init-handler.ts
+++ b/src/oauth/handlers/init-handler.ts
@@ -45,12 +45,17 @@ function resolveAppUrl(baseUrl: string | undefined, env: EnvironmentConfig): str
 }
 
 function createNotConfiguredResponse(config: OAuthServiceConfig): Response {
+  // SEC-009: Do NOT leak internal env var names in the HTTP response body.
+  // Operators still need the diagnostic, so log the missing env var names
+  // server-side via the existing logger.
+  logger.error("OAuth provider not configured", {
+    serviceId: config.serviceId,
+    displayName: config.displayName,
+    missingVars: [config.clientIdEnvVar, config.clientSecretEnvVar],
+  });
   return Response.json(
-    {
-      error: `${config.displayName} OAuth not configured`,
-      details: `Missing ${config.clientIdEnvVar} or ${config.clientSecretEnvVar}`,
-    },
-    { status: 500 },
+    { error: `${config.displayName} OAuth not configured` },
+    { status: 503 },
   );
 }
 


### PR DESCRIPTION
## Summary
- Drop the env-var-naming `details` field from the OAuth init handler's not-configured response, and switch the status to 503; log the missing env var names server-side via the existing logger so operators still get the diagnostic.
- Stops unauthenticated callers from enumerating internal env var naming conventions (e.g. `GITHUB_CLIENT_ID`) by probing `/api/auth/<service>` against a misconfigured provider.

## Why this matters
Returning the names of expected env vars in a 500 response body exposes internal naming conventions to any caller, giving an attacker a free hint about the host's configuration shape and the providers it intends to support. The fix keeps the operator-facing diagnostic intact via server-side logging while surfacing only a generic 503 to the network.

## Test plan
- [x] Updated existing not-configured test to assert status 503 and the redacted body shape.
- [x] Added a dedicated leak-check test that asserts the response body does not contain `clientIdEnvVar` / `clientSecretEnvVar` values and has no `details` field.