### PR TITLE
Route hosted Gemini and Kimi models through cloud gateway

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.514",
+  "version": "0.1.515",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/constants.test.ts
+++ b/src/agent/runtime/constants.test.ts
@@ -17,6 +17,11 @@ describe("getModelMaxOutputTokens", () => {
     assertEquals(getModelMaxOutputTokens("veryfront-cloud/openai/gpt-5.2"), 16_384);
   });
 
+  it("uses Gemini limits for direct Google runtime model ids", () => {
+    assertEquals(getModelMaxOutputTokens("google/gemini-2.5-pro"), 65_536);
+    assertEquals(getModelMaxOutputTokens("google/gemini-2.5-flash"), 8_192);
+  });
+
   it("returns undefined for unknown models", () => {
     assertEquals(getModelMaxOutputTokens("unknown/model"), undefined);
   });

--- a/src/agent/runtime/constants.ts
+++ b/src/agent/runtime/constants.ts
@@ -15,10 +15,15 @@ const MODEL_MAX_OUTPUT_TOKENS: Record<string, number> = {
   "google-ai-studio/gemini-2.5-flash": 8_192,
 };
 
+const MODEL_MAX_OUTPUT_TOKEN_ALIASES: Record<string, string> = {
+  "google/gemini-2.5-pro": "google-ai-studio/gemini-2.5-pro",
+  "google/gemini-2.5-flash": "google-ai-studio/gemini-2.5-flash",
+};
+
 /** Look up max output tokens for a model, stripping the `veryfront-cloud/` prefix. */
 export function getModelMaxOutputTokens(modelString: string): number | undefined {
   const normalized = modelString.startsWith("veryfront-cloud/")
     ? modelString.slice("veryfront-cloud/".length)
     : modelString;
-  return MODEL_MAX_OUTPUT_TOKENS[normalized];
+  return MODEL_MAX_OUTPUT_TOKENS[MODEL_MAX_OUTPUT_TOKEN_ALIASES[normalized] ?? normalized];
 }

--- a/src/agent/runtime/model-resolution.test.ts
+++ b/src/agent/runtime/model-resolution.test.ts
@@ -72,6 +72,10 @@ describe("agent/runtime/model-resolution", () => {
       resolveConfiguredAgentModel("gpt-5.2"),
       "openai/gpt-5.2",
     );
+    assertEquals(
+      resolveConfiguredAgentModel("kimi-k2.5"),
+      "moonshotai/kimi-k2.5",
+    );
   });
 
   it("upgrades auto/local models to the default Veryfront cloud model when bootstrap is present", () => {
@@ -94,6 +98,24 @@ describe("agent/runtime/model-resolution", () => {
     );
   });
 
+  it("routes catalog Gemini and Kimi models through veryfront-cloud when only hosted bootstrap is available", () => {
+    setEnv("VERYFRONT_API_TOKEN", "vf_test_runtime");
+    setEnv("VERYFRONT_PROJECT_SLUG", "demo-project");
+
+    assertEquals(
+      resolveRuntimeModel("google-ai-studio/gemini-2.5-flash"),
+      "veryfront-cloud/google-ai-studio/gemini-2.5-flash",
+    );
+    assertEquals(
+      resolveRuntimeModel("moonshotai/kimi-k2.5"),
+      "veryfront-cloud/moonshotai/kimi-k2.5",
+    );
+    assertEquals(
+      resolveRuntimeModel("kimi-k2.5"),
+      "veryfront-cloud/moonshotai/kimi-k2.5",
+    );
+  });
+
   it("keeps explicit provider models unchanged when native credentials are configured", () => {
     setEnv("VERYFRONT_API_TOKEN", "vf_test_runtime");
     setEnv("VERYFRONT_PROJECT_SLUG", "demo-project");
@@ -102,6 +124,17 @@ describe("agent/runtime/model-resolution", () => {
     assertEquals(
       resolveRuntimeModel("openai/gpt-5.4"),
       "openai/gpt-5.4",
+    );
+  });
+
+  it("routes explicit Gemini models through the direct Google provider when native credentials are configured", () => {
+    setEnv("VERYFRONT_API_TOKEN", "vf_test_runtime");
+    setEnv("VERYFRONT_PROJECT_SLUG", "demo-project");
+    setEnv("GOOGLE_API_KEY", "google-test");
+
+    assertEquals(
+      resolveRuntimeModel("google-ai-studio/gemini-2.5-flash"),
+      "google/gemini-2.5-flash",
     );
   });
 

--- a/src/agent/runtime/model-resolution.ts
+++ b/src/agent/runtime/model-resolution.ts
@@ -9,7 +9,19 @@ import { isVeryfrontCloudEnabled } from "#veryfront/platform/cloud/resolver.ts";
 
 export const AUTO_AGENT_MODEL = "auto";
 
-const HOSTED_PROVIDER_NAMES = new Set(["anthropic", "google", "openai"]);
+const HOSTED_PROVIDER_NAMES = new Set([
+  "anthropic",
+  "google",
+  "google-ai-studio",
+  "moonshotai",
+  "openai",
+]);
+const DIRECT_CREDENTIAL_PROVIDER_ALIASES: Record<string, string> = {
+  "google-ai-studio": "google",
+};
+const DIRECT_RUNTIME_PROVIDER_ALIASES: Record<string, string> = {
+  "google-ai-studio": "google",
+};
 const LEGACY_MODEL_ALIASES: Record<string, string> = {
   opus: "anthropic/claude-opus-4-6",
   sonnet: "anthropic/claude-sonnet-4-6",
@@ -25,6 +37,7 @@ const LEGACY_MODEL_ALIASES: Record<string, string> = {
   "gemini-3.1-pro": "google-ai-studio/gemini-2.5-pro",
   "gemini-2.5-pro": "google-ai-studio/gemini-2.5-pro",
   "gemini-2.5-flash": "google-ai-studio/gemini-2.5-flash",
+  "kimi-k2.5": "moonshotai/kimi-k2.5",
 };
 
 export function normalizeAgentModelConfig(model?: string): string {
@@ -46,7 +59,7 @@ export function resolveConfiguredAgentModel(model?: string): string {
 }
 
 function hasDirectProviderCredentials(provider: string): boolean {
-  switch (provider) {
+  switch (DIRECT_CREDENTIAL_PROVIDER_ALIASES[provider] ?? provider) {
     case "anthropic":
       return Boolean(getAnthropicEnvConfig().apiKey);
     case "google":
@@ -92,7 +105,8 @@ export function resolveRuntimeModel(model?: string): string {
   }
 
   if (!isVeryfrontCloudEnabled() || hasDirectProviderCredentials(provider)) {
-    return configuredModel;
+    const runtimeProvider = DIRECT_RUNTIME_PROVIDER_ALIASES[provider] ?? provider;
+    return `${runtimeProvider}/${modelId}`;
   }
 
   return `veryfront-cloud/${provider}/${modelId}`;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.514";
+export const VERSION = "0.1.515";


### PR DESCRIPTION
## Summary
- route Studio catalog Gemini and Kimi model IDs through veryfront-cloud when hosted bootstrap is available
- keep google-ai-studio model IDs compatible with direct Google credentials by rewriting them to the direct google provider
- bump release version from 0.1.514 to 0.1.515 in deno.json and the matching VERSION constant

## Test plan
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/agent/runtime/model-resolution.test.ts src/provider/veryfront-cloud/provider.test.ts src/provider/veryfront-cloud/model-catalog.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts src/agent/runtime/model-resolution.ts src/agent/runtime/model-resolution.test.ts
- deno lint src/utils/version-constant.ts src/agent/runtime/model-resolution.ts src/agent/runtime/model-resolution.test.ts
- git diff --check HEAD
- pre-push hook: format, lint, typecheck, full unit suite: 1849 passed / 0 failed