### PR TITLE
Discover markdown agents in project runtime

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.514",
+  "version": "0.1.515",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/architecture/06-discovery-extensions.md
+++ b/docs/architecture/06-discovery-extensions.md
@@ -77,7 +77,7 @@ flowchart TD
 
 The discovery engine follows a convention-over-configuration approach:
 
-1. **Scan:** Each primitive type has a convention-based directory (`tools/`, `agents/`, `workflows/`, etc.). Files matching `**/*.ts` and `**/*.tsx` are collected. Note: test files in discovery directories will be imported -- place tests outside these directories or use separate test directories.
+1. **Scan:** Each primitive type has a convention-based directory (`tools/`, `agents/`, `workflows/`, etc.). Files matching `**/*.ts` and `**/*.tsx` are collected. Agent discovery also accepts `agents/**/*.md` persona definitions and converts them into runtime agents. Note: test files in discovery directories will be imported -- place tests outside these directories or use separate test directories.
 2. **Process:** TypeScript files are transpiled via esbuild, dynamically imported, and their exports (default or named) are extracted.
 3. **Validate:** Each handler validates that the export is a valid instance of its type (e.g., a `Tool` with an `execute` function and `inputSchema`). IDs are derived from the handler's `getId()` method or fall back to the export/file name.
 4. **Register:** Valid primitives are registered in project-scoped registries. Registration makes them available to agents, the MCP server, and the workflow engine.

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -30,6 +30,21 @@ export default agent({
 
 The `id` is how you reference the agent later with `getAgent("assistant")`.
 
+You can also define an agent with markdown when the agent only needs persona, model, and step configuration:
+
+```md
+---
+name: Support
+description: Helps users with support questions
+model: openai/gpt-5.4
+max-steps: 6
+---
+
+You are a support assistant. Answer clearly and ask for missing details before acting.
+```
+
+The file path provides the agent id. For example, `agents/support.md` registers `support` and can be invoked through the same project runtime and control-plane surfaces as `agents/support.ts`.
+
 ## Add tools
 
 Agents call tools to take actions or fetch data. Reference tools by name — the framework resolves them from the `tools/` directory:
@@ -230,6 +245,8 @@ integrations on a predictable default.
 | Property              | Type                                                                                                   | Description                                                                  |
 | --------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
 | `id`                  | `string`                                                                                               | Unique identifier used with `getAgent()`                                     |
+| `name`                | `string`                                                                                               | Human-readable display name for listings                                     |
+| `description`         | `string`                                                                                               | Optional summary for listings                                                |
 | `model`               | `string`                                                                                               | Optional provider/model override. Omit or use `"auto"` for runtime defaults. |
 | `system`              | `string \| () => string \| Promise<string>`                                                            | System prompt                                                                |
 | `resolveRuntimeState` | `(request: RuntimeStateRequest) => ResolvedRuntimeState \| Promise<ResolvedRuntimeState \| undefined>` | Refresh system/context before later model steps in the same run              |

--- a/docs/guides/project-structure.md
+++ b/docs/guides/project-structure.md
@@ -65,12 +65,12 @@ my-app/
 
 The `app/` directory contains pages and API routes for the default app router. The file path maps directly to the URL:
 
-| File | URL |
-|------|-----|
-| `app/page.tsx` | `/` |
-| `app/about/page.tsx` | `/about` |
+| File                       | URL           |
+| -------------------------- | ------------- |
+| `app/page.tsx`             | `/`           |
+| `app/about/page.tsx`       | `/about`      |
 | `app/blog/[slug]/page.tsx` | `/blog/:slug` |
-| `app/api/users/route.ts` | `/api/users` |
+| `app/api/users/route.ts`   | `/api/users`  |
 
 Pages use `page.tsx` (or `page.mdx`). API routes use `route.ts`. Layouts use `layout.tsx`.
 
@@ -96,16 +96,16 @@ These directories are scanned automatically at startup.
 For TypeScript-based primitives, files with a default export are registered.
 For skills, directories containing `SKILL.md` are registered.
 
-| Directory | Purpose | Import |
-|-----------|---------|--------|
-| `agents/` | AI agent definitions | `veryfront/agent` |
-| `tools/` | Tool definitions with Zod schemas | `veryfront/tool` |
-| `prompts/` | Prompt templates | `veryfront/prompt` |
-| `workflows/` | Multi-step workflow DAGs | `veryfront/workflow` |
-| `resources/` | MCP-exposable resources | `veryfront/resource` |
-| `skills/` | Skill packs for agent skill tools | Enabled via `agent({ skills: ... })` |
+| Directory    | Purpose                           | Import                               |
+| ------------ | --------------------------------- | ------------------------------------ |
+| `agents/`    | AI agent definitions              | `veryfront/agent`                    |
+| `tools/`     | Tool definitions with Zod schemas | `veryfront/tool`                     |
+| `prompts/`   | Prompt templates                  | `veryfront/prompt`                   |
+| `workflows/` | Multi-step workflow DAGs          | `veryfront/workflow`                 |
+| `resources/` | MCP-exposable resources           | `veryfront/resource`                 |
+| `skills/`    | Skill packs for agent skill tools | Enabled via `agent({ skills: ... })` |
 
-The filename becomes the ID for TypeScript primitives. For example, `agents/assistant.ts` registers as `"assistant"` and can be retrieved with `getAgent("assistant")`.
+The filename becomes the ID for TypeScript primitives. For example, `agents/assistant.ts` registers as `"assistant"` and can be retrieved with `getAgent("assistant")`. Agent discovery also supports `agents/assistant.md` for markdown-defined agents that use frontmatter for metadata and the markdown body as the system instructions.
 
 For skills, the directory name is the skill ID. For example, `skills/incident-response/SKILL.md` registers as `"incident-response"`.
 
@@ -132,24 +132,24 @@ export default defineConfig({
 
 These directories aren't auto-discovered but follow standard conventions:
 
-| Directory | Purpose |
-|-----------|---------|
-| `components/` | Shared React components |
-| `lib/` | Shared utilities and business logic |
-| `content/` | Static content (MDX, JSON, YAML) |
-| `public/` | Static assets served at root path |
-| `styles/` | Global CSS files |
-| `middleware/` | Custom middleware functions |
+| Directory     | Purpose                             |
+| ------------- | ----------------------------------- |
+| `components/` | Shared React components             |
+| `lib/`        | Shared utilities and business logic |
+| `content/`    | Static content (MDX, JSON, YAML)    |
+| `public/`     | Static assets served at root path   |
+| `styles/`     | Global CSS files                    |
+| `middleware/` | Custom middleware functions         |
 
 ## Special files
 
-| File | Purpose |
-|------|---------|
-| `app/layout.tsx` | Root layout wrapping all pages |
-| `app/error.tsx` | Error boundary for the app |
-| `app/not-found.tsx` | Custom 404 page |
-| `veryfront.config.ts` | Framework configuration |
-| `package.json` | Dependencies and metadata |
+| File                  | Purpose                        |
+| --------------------- | ------------------------------ |
+| `app/layout.tsx`      | Root layout wrapping all pages |
+| `app/error.tsx`       | Error boundary for the app     |
+| `app/not-found.tsx`   | Custom 404 page                |
+| `veryfront.config.ts` | Framework configuration        |
+| `package.json`        | Dependencies and metadata      |
 
 ## Why flat?
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -480,6 +480,8 @@ when bootstrap credentials are present.
 | Property                 | Type                                                                                                                                                | Description                                                                          |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | `id?`                    | `string`                                                                                                                                            | Unique identifier (auto-generated if omitted)                                        |
+| `name?`                  | `string`                                                                                                                                            | Human-readable display name for listings                                             |
+| `description?`           | `string`                                                                                                                                            | Optional summary for listings                                                        |
 | `model?`                 | `ModelString`                                                                                                                                       | Provider/model override. Omit or use `"auto"` for runtime defaults.                  |
 | `system`                 | <code>string &#124; (() =&gt; string) &#124; (() =&gt; Promise&lt;string&gt;)</code>                                                                | System prompt — string, function, or async function                                  |
 | `tools?`                 | <code>true &#124; Record&lt;string, Tool &#124; boolean&gt;</code>                                                                                  | Tools available to the agent                                                         |
@@ -850,6 +852,13 @@ frontmatter plus body with `parseRuntimeAgentMarkdownDefinition()`. This keeps
 file loading, traversal-prone file-name validation, and markdown parsing
 consistent across separately deployed agents.
 
+### `createRuntimeAgentFromMarkdownDefinition(definition)`
+
+Convert a parsed markdown agent definition into a normal runtime `Agent`.
+Project discovery uses this helper for `agents/*.md`, so markdown-defined
+agents are listed and invoked through the same registry and control-plane paths
+as code-defined agents.
+
 ### `filterAgentTraceAttributes(attributes)`
 
 Filter an unknown attribute record down to OpenTelemetry-safe agent trace
@@ -1179,6 +1188,7 @@ Clear all stored messages from memory.
 | `initializeNodeAgentServiceOpenTelemetry`                             | Initialize Node OpenTelemetry for an agent service                       |
 | `parseAgentServiceChatRequestFromRequest`                             | Parse the agent-service chat request body and auth context               |
 | `loadRuntimeAgentMarkdownDefinitionFromFile`                          | Load and parse a markdown agent definition from an agents directory      |
+| `createRuntimeAgentFromMarkdownDefinition`                            | Convert a markdown agent definition into a runtime agent                 |
 | `parseAgentServiceConfig`                                             | Parse default agent service environment config                           |
 | `resolveAgentServiceRegistrationInput`                                | Resolve push runtime registration input from service config              |
 | `resolveNodeAgentServiceTelemetryConfig`                              | Resolve Node service OpenTelemetry config from environment               |

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -176,6 +176,12 @@ export {
 } from "./hosted-child-fork-tool-sources.ts";
 
 export {
+  createRuntimeAgentFromMarkdownDefinition,
+  getRuntimeAgentMarkdownDefinition,
+  isRuntimeAgentMarkdownAgent,
+} from "./runtime-agent-markdown-adapter.ts";
+
+export {
   loadRuntimeAgentMarkdownDefinitionFromFile,
   type LoadRuntimeAgentMarkdownDefinitionFromFileInput,
   loadRuntimeAgentMarkdownDefinitionFromFileInputSchema,

--- a/src/agent/runtime-agent-markdown-adapter.ts
+++ b/src/agent/runtime-agent-markdown-adapter.ts
@@ -1,0 +1,31 @@
+import { agent } from "./factory.ts";
+import type { Agent } from "./types.ts";
+import type { RuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
+
+const markdownDefinitionByAgent = new WeakMap<Agent, RuntimeAgentMarkdownDefinition>();
+
+export function createRuntimeAgentFromMarkdownDefinition(
+  definition: RuntimeAgentMarkdownDefinition,
+): Agent {
+  const runtimeAgent = agent({
+    id: definition.id,
+    name: definition.name,
+    description: definition.description,
+    system: definition.instructions,
+    ...(definition.model ? { model: definition.model } : {}),
+    ...(definition.maxSteps === undefined ? {} : { maxSteps: definition.maxSteps }),
+  });
+
+  markdownDefinitionByAgent.set(runtimeAgent, definition);
+  return runtimeAgent;
+}
+
+export function getRuntimeAgentMarkdownDefinition(
+  runtimeAgent: Agent,
+): RuntimeAgentMarkdownDefinition | null {
+  return markdownDefinitionByAgent.get(runtimeAgent) ?? null;
+}
+
+export function isRuntimeAgentMarkdownAgent(runtimeAgent: Agent): boolean {
+  return markdownDefinitionByAgent.has(runtimeAgent);
+}

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -68,6 +68,10 @@ export interface AgentSuggestions {
 
 export interface AgentConfig {
   id?: string;
+  /** Human-readable display name for registry and control-plane listings. */
+  name?: string;
+  /** Optional summary shown in registry and control-plane listings. */
+  description?: string;
   /**
    * Optional model string in "provider/model" format.
    *

--- a/src/agent/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/veryfront-cloud-agent-service.test.ts
@@ -186,6 +186,53 @@ Deno.test("createNodeVeryfrontCloudAgentServiceRuntime lets env override manifes
   });
 });
 
+Deno.test("createNodeVeryfrontCloudAgentServiceRuntime uses configured markdown agent paths", async () => {
+  await withTempDir(async (rootDir) => {
+    const agentsDir = resolve(rootDir, "crew");
+    Deno.mkdirSync(agentsDir, { recursive: true });
+    Deno.writeTextFileSync(
+      resolve(agentsDir, "support.md"),
+      `---
+name: Support
+model: openai/gpt-5.4
+max-steps: 6
+---
+
+Help users from configured markdown.
+`,
+    );
+    Deno.writeTextFileSync(
+      resolve(rootDir, "veryfront.config.ts"),
+      [
+        "export default {",
+        "  ai: {",
+        '    agents: { discovery: { paths: ["crew"] } },',
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    const bundle = await createNodeVeryfrontCloudAgentServiceRuntime({
+      serviceName: "configured-markdown-agent-test",
+      entrypointUrl: pathToFileURL(resolve(rootDir, "src", "main.ts")),
+      createBashTool,
+      signals: [],
+      env: {
+        NODE_ENV: "test",
+        VERYFRONT_API_URL: "https://api.example.com",
+        PORT: "3151",
+        ALLOWED_ORIGINS: "https://studio.example.com",
+      },
+    });
+
+    assertEquals(bundle.runtime.contract.defaultAgentId, "support");
+    const runtimeAgent = getRuntimeAgent(bundle, "support");
+    assertEquals(runtimeAgent.config.system, "Help users from configured markdown.");
+    assertEquals(runtimeAgent.config.maxSteps, 6);
+  });
+});
+
 Deno.test("createNodeVeryfrontCloudAgentServiceRuntime requires agentId for multiple markdown agents", async () => {
   await withTempDir(async (rootDir) => {
     writeMarkdownAgentDefinition(rootDir, "support");

--- a/src/agent/veryfront-cloud-agent-service.ts
+++ b/src/agent/veryfront-cloud-agent-service.ts
@@ -68,8 +68,11 @@ import type { AgentServiceMcpServerConfig } from "./agent-service-mcp-server-con
 import type { RuntimeLoadSkillToolContext } from "./runtime-load-skill-tool.ts";
 import type { RuntimeProjectSteeringLookup } from "./runtime-project-skill-catalog.ts";
 import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
-import { listRuntimeAgentMarkdownDefinitionIds } from "./runtime-agent-definition-files.ts";
 import type { RuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
+import {
+  getRuntimeAgentMarkdownDefinition,
+  isRuntimeAgentMarkdownAgent,
+} from "./runtime-agent-markdown-adapter.ts";
 import {
   buildVeryfrontCloudRuntimeInstructions,
 } from "./veryfront-cloud-runtime-system-messages.ts";
@@ -400,8 +403,8 @@ async function createRuntimeAgentDefinitionFromCodeAgent(
 ): Promise<RuntimeAgentMarkdownDefinition> {
   return {
     id: codeAgent.id,
-    name: codeAgent.id,
-    description: "",
+    name: codeAgent.config.name ?? codeAgent.id,
+    description: codeAgent.config.description ?? "",
     instructions: await resolveAgentSystem(codeAgent.config.system),
     model: codeAgent.config.model,
     maxSteps: codeAgent.config.maxSteps,
@@ -434,7 +437,7 @@ async function resolveAgentConfig(
   const source = context.options.agentSource ?? "auto";
   const codeAgent = getAgent(agentId);
 
-  if (source !== "markdown" && codeAgent) {
+  if (source !== "markdown" && codeAgent && !isRuntimeAgentMarkdownAgent(codeAgent)) {
     const agentConfig = await createRuntimeAgentDefinitionFromCodeAgent(codeAgent);
     context.agentConfigs.set(agentConfig.id, agentConfig);
     return agentConfig;
@@ -442,6 +445,14 @@ async function resolveAgentConfig(
 
   if (source === "code") {
     throw new Error(`Code agent "${agentId}" was not discovered.`);
+  }
+
+  const discoveredMarkdownDefinition = codeAgent
+    ? getRuntimeAgentMarkdownDefinition(codeAgent)
+    : null;
+  if (discoveredMarkdownDefinition) {
+    context.agentConfigs.set(discoveredMarkdownDefinition.id, discoveredMarkdownDefinition);
+    return discoveredMarkdownDefinition;
   }
 
   const agentConfig = loadMarkdownAgentConfig(context, agentId);
@@ -476,15 +487,17 @@ async function discoverProjectPrimitives(
 }
 
 function getDiscoveredCodeAgentIds(context: NodeVeryfrontCloudAgentServiceContext): string[] {
-  return [...(context.discoveryResult?.agents.keys() ?? [])].sort((left, right) =>
-    left.localeCompare(right)
-  );
+  return [...(context.discoveryResult?.agents.entries() ?? [])]
+    .filter(([, discoveredAgent]) => !isRuntimeAgentMarkdownAgent(discoveredAgent))
+    .map(([id]) => id)
+    .sort((left, right) => left.localeCompare(right));
 }
 
 function getDiscoveredMarkdownAgentIds(context: NodeVeryfrontCloudAgentServiceContext): string[] {
-  return listRuntimeAgentMarkdownDefinitionIds({
-    baseDir: resolveBaseDir(context.options),
-  });
+  return [...(context.discoveryResult?.agents.entries() ?? [])]
+    .filter(([, discoveredAgent]) => isRuntimeAgentMarkdownAgent(discoveredAgent))
+    .map(([id]) => id)
+    .sort((left, right) => left.localeCompare(right));
 }
 
 function describeAgentIdCandidates(input: {

--- a/src/channels/control-plane.test.ts
+++ b/src/channels/control-plane.test.ts
@@ -1,5 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import type { Agent, AgentSuggestions } from "#veryfront/agent";
+import { createRuntimeAgentFromMarkdownDefinition } from "#veryfront/agent";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { registerSkill, skillRegistry } from "#veryfront/skill/registry.ts";
@@ -296,6 +297,37 @@ describe("channels/control-plane", () => {
             name: "researcher",
             description: null,
             model: null,
+            version: null,
+            skills: [],
+          }],
+        }),
+      );
+    });
+
+    it("returns markdown-defined runtime agents from the same registry contract", async () => {
+      const markdownAgent = createRuntimeAgentFromMarkdownDefinition({
+        id: "support",
+        name: "Support",
+        description: "Helps users",
+        model: "openai/gpt-5.4",
+        maxSteps: 4,
+        instructions: "Help users from markdown.",
+      });
+
+      const response = await listRuntimeAgents(createHandlerContext(), {
+        ensureProjectDiscovery: async () => {},
+        getAgent: (id) => id === "support" ? markdownAgent : undefined,
+        getAllAgentIds: () => ["support"],
+      });
+
+      assertEquals(
+        response,
+        RuntimeAgentListResponseSchema.parse({
+          agents: [{
+            id: "support",
+            name: "Support",
+            description: "Helps users",
+            model: "openai/gpt-5.4",
             version: null,
             skills: [],
           }],

--- a/src/discovery/auto-discovery.integration.test.ts
+++ b/src/discovery/auto-discovery.integration.test.ts
@@ -265,5 +265,38 @@ describe(
         await Deno.remove(tempDir, { recursive: true });
       }
     });
+    it("discovers markdown agents from agents directory", async () => {
+      const tempDir = await Deno.makeTempDir({ prefix: "vf-discovery-markdown-agent-" });
+
+      try {
+        await Deno.mkdir(`${tempDir}/agents`, { recursive: true });
+        await Deno.writeTextFile(
+          `${tempDir}/agents/support.md`,
+          [
+            "---",
+            "name: Support",
+            "description: Helps users",
+            "model: openai/gpt-5.4",
+            "max-steps: 4",
+            "---",
+            "",
+            "Help users from markdown.",
+          ].join("\n"),
+        );
+
+        const result = await discoverAll({
+          baseDir: tempDir,
+          verbose: false,
+        });
+
+        const discoveredAgent = result.agents.get("support");
+        assertExists(discoveredAgent);
+        assertEquals(discoveredAgent.config.system, "Help users from markdown.");
+        assertEquals(discoveredAgent.config.model, "openai/gpt-5.4");
+        assertEquals(discoveredAgent.config.maxSteps, 4);
+      } finally {
+        await Deno.remove(tempDir, { recursive: true });
+      }
+    });
   },
 );

--- a/src/discovery/discovery-engine.ts
+++ b/src/discovery/discovery-engine.ts
@@ -26,6 +26,7 @@ import {
   toolHandler,
   workflowHandler,
 } from "./handlers/index.ts";
+import { discoverRuntimeAgentMarkdownDefinitions } from "./handlers/runtime-agent-markdown-handler.ts";
 import { filenameToId } from "./discovery-utils.ts";
 import { join } from "#veryfront/compat/path";
 
@@ -178,6 +179,7 @@ export async function discoverAll(config: DiscoveryConfig): Promise<DiscoveryRes
   // Discover agents
   for (const dir of config.agentDirs ?? ["agents"]) {
     await discoverItems(`${baseDir}/${dir}`, result, context, agentHandler, config.verbose);
+    await discoverRuntimeAgentMarkdownDefinitions(`${baseDir}/${dir}`, result, context);
   }
 
   // Discover resources

--- a/src/discovery/file-discovery.ts
+++ b/src/discovery/file-discovery.ts
@@ -9,9 +9,10 @@ import type { FileDiscoveryContext } from "./types.ts";
 /**
  * Find all TypeScript files in a directory recursively
  */
-export async function findTypeScriptFiles(
+async function findFilesByExtension(
   dir: string,
   context: FileDiscoveryContext,
+  extensions: readonly string[],
 ): Promise<string[]> {
   const files: string[] = [];
 
@@ -22,13 +23,13 @@ export async function findTypeScriptFiles(
       for await (const entry of context.fsAdapter.readDir(dir)) {
         const filePath = `${dir}/${entry.name}`;
 
-        if (entry.isFile && (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx"))) {
+        if (entry.isFile && extensions.some((extension) => entry.name.endsWith(extension))) {
           files.push(`file://${filePath}`);
           continue;
         }
 
         if (entry.isDirectory) {
-          files.push(...(await findTypeScriptFiles(filePath, context)));
+          files.push(...(await findFilesByExtension(filePath, context, extensions)));
         }
       }
 
@@ -41,13 +42,13 @@ export async function findTypeScriptFiles(
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
       const filePath = path.join(dir, entry.name);
 
-      if (entry.isFile() && (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx"))) {
+      if (entry.isFile() && extensions.some((extension) => entry.name.endsWith(extension))) {
         files.push(`file://${path.resolve(filePath)}`);
         continue;
       }
 
       if (entry.isDirectory()) {
-        files.push(...(await findTypeScriptFiles(filePath, context)));
+        files.push(...(await findFilesByExtension(filePath, context, extensions)));
       }
     }
   } catch (_) {
@@ -71,4 +72,38 @@ async function getNodeDeps(
   const [fsModule, pathModule] = await Promise.all([import("node:fs"), import("node:path")]);
   context.nodeDeps = { fs: fsModule, path: pathModule };
   return context.nodeDeps;
+}
+
+/**
+ * Find all TypeScript files in a directory recursively.
+ */
+export function findTypeScriptFiles(
+  dir: string,
+  context: FileDiscoveryContext,
+): Promise<string[]> {
+  return findFilesByExtension(dir, context, [".ts", ".tsx"]);
+}
+
+/**
+ * Find all Markdown files in a directory recursively.
+ */
+export function findMarkdownFiles(
+  dir: string,
+  context: FileDiscoveryContext,
+): Promise<string[]> {
+  return findFilesByExtension(dir, context, [".md"]);
+}
+
+export async function readDiscoveryTextFile(
+  fileUrl: string,
+  context: FileDiscoveryContext,
+): Promise<string> {
+  const path = fileUrl.replace(/^file:\/\//, "");
+
+  if (context.fsAdapter) {
+    return await context.fsAdapter.readFile(path);
+  }
+
+  const { fs } = await getNodeDeps(context);
+  return fs.readFileSync(path, "utf-8");
 }

--- a/src/discovery/handlers/runtime-agent-markdown-handler.ts
+++ b/src/discovery/handlers/runtime-agent-markdown-handler.ts
@@ -1,0 +1,78 @@
+import { createRuntimeAgentFromMarkdownDefinition } from "../../agent/runtime-agent-markdown-adapter.ts";
+import {
+  parseRuntimeAgentMarkdownDefinition,
+  type RuntimeAgentMarkdownDefinition,
+} from "../../agent/runtime-agent-definition.ts";
+import { agentRegistry, registerAgent } from "../../agent/composition/index.ts";
+import { ensureError } from "#veryfront/errors/veryfront-error.ts";
+import type { DiscoveryResult, FileDiscoveryContext } from "../types.ts";
+import { trackAgentPath } from "../discovery-utils.ts";
+import { findMarkdownFiles, readDiscoveryTextFile } from "../file-discovery.ts";
+
+const MARKDOWN_AGENT_FILE_PATTERN = /^[A-Za-z0-9._-]+\.md$/;
+
+type MarkdownAgentCandidate = {
+  id: string;
+  file: string;
+};
+
+function getFileName(file: string): string {
+  return file.split("/").pop() ?? "";
+}
+
+function getMarkdownAgentCandidate(file: string): MarkdownAgentCandidate | null {
+  const fileName = getFileName(file);
+  if (!MARKDOWN_AGENT_FILE_PATTERN.test(fileName)) {
+    return null;
+  }
+
+  return {
+    id: fileName.slice(0, -".md".length),
+    file,
+  };
+}
+
+function registerMarkdownAgent(
+  definition: RuntimeAgentMarkdownDefinition,
+  file: string,
+  result: DiscoveryResult,
+): void {
+  if (result.agents.has(definition.id)) {
+    return;
+  }
+
+  const runtimeAgent = createRuntimeAgentFromMarkdownDefinition(definition);
+  if (runtimeAgent.id !== definition.id) {
+    agentRegistry.delete(runtimeAgent.id);
+  }
+  registerAgent(definition.id, runtimeAgent);
+  trackAgentPath(definition.id, file);
+  result.agents.set(definition.id, runtimeAgent);
+}
+
+export async function discoverRuntimeAgentMarkdownDefinitions(
+  dir: string,
+  result: DiscoveryResult,
+  context: FileDiscoveryContext,
+): Promise<void> {
+  const files = (await findMarkdownFiles(dir, context)).sort((left, right) =>
+    left.localeCompare(right)
+  );
+
+  for (const file of files) {
+    const candidate = getMarkdownAgentCandidate(file);
+    if (!candidate) {
+      continue;
+    }
+
+    try {
+      const definition = parseRuntimeAgentMarkdownDefinition({
+        id: candidate.id,
+        content: await readDiscoveryTextFile(candidate.file, context),
+      });
+      registerMarkdownAgent(definition, candidate.file, result);
+    } catch (error) {
+      result.errors.push({ file: candidate.file, error: ensureError(error) });
+    }
+  }
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.514";
+export const VERSION = "0.1.515";


### PR DESCRIPTION
## Summary\n- discover agents/*.md as runtime agents through the normal project discovery engine\n- preserve code-vs-markdown source selection for agent service runtimes\n- expose markdown definition adapters and document markdown agent discovery\n\n## Verification\n- deno test --no-check --allow-all --parallel src/discovery/auto-discovery.integration.test.ts src/agent/veryfront-cloud-agent-service.test.ts src/channels/control-plane.test.ts\n- deno task verify:quick\n- pre-push checks: format, lint, typecheck, test:unit