### PR TITLE
Rename content extension contract to ContentProcessor

### DIFF
--- a/cli/commands/build/command.ts
+++ b/cli/commands/build/command.ts
@@ -8,7 +8,7 @@ import { handleBuildError } from "./error-handler.ts";
 import { displayBuildSuccess } from "./stats-display.ts";
 import type { BuildOptions } from "./types.ts";
 import { isJsonMode, streamJsonLine } from "../../shared/json-output.ts";
-import { ensureBuiltinContentTransformer } from "../../shared/ensure-content-transformer.ts";
+import { ensureBuiltinContentProcessor } from "../../shared/ensure-content-processor.ts";
 
 export function buildCommand(options: BuildOptions): Promise<void> {
   return withSpan(
@@ -27,7 +27,7 @@ export function buildCommand(options: BuildOptions): Promise<void> {
 
         const adapter = await runtime.get();
         await getConfig(options.projectDir, adapter);
-        ensureBuiltinContentTransformer();
+        ensureBuiltinContentProcessor();
 
         if (isJsonMode()) {
           streamJsonLine({ type: "step", name: "config", status: "completed" });

--- a/cli/shared/ensure-content-processor.ts
+++ b/cli/shared/ensure-content-processor.ts
@@ -1,17 +1,17 @@
 import { tryResolve } from "veryfront/extensions";
 import { register } from "../../src/extensions/contracts.ts";
-import type { ContentTransformer } from "veryfront/extensions/transform";
-import { MdxContentTransformer } from "../../extensions/ext-transform-mdx/src/index.ts";
+import type { ContentProcessor } from "veryfront/extensions/transform";
+import { MdxContentProcessor } from "../../extensions/ext-transform-mdx/src/index.ts";
 
 /**
  * The CLI ships ext-mdx baked in so the compiled binary can render MDX/Markdown
  * pages out of the box. Library consumers (programmatic `startProductionServer`)
  * still opt in via `veryfront.config.ts` extensions. Bootstrap's
- * `setupAll → teardownAll → reset()` clears the contract registry, so this
+ * `setupAll` to `teardownAll` to `reset()` clears the contract registry, so this
  * must run *after* the server-start (or `getConfig`) call returns. We skip
  * registration when a user-provided extension already supplied the contract.
  */
-export function ensureBuiltinContentTransformer(): void {
-  if (tryResolve<ContentTransformer>("ContentTransformer")) return;
-  register<ContentTransformer>("ContentTransformer", new MdxContentTransformer());
+export function ensureBuiltinContentProcessor(): void {
+  if (tryResolve<ContentProcessor>("ContentProcessor")) return;
+  register<ContentProcessor>("ContentProcessor", new MdxContentProcessor());
 }

--- a/cli/shared/server-startup.ts
+++ b/cli/shared/server-startup.ts
@@ -7,7 +7,7 @@ import {
   type StartProductionServerOptions,
 } from "veryfront/server";
 import type { RuntimeAdapter } from "veryfront/platform";
-import { ensureBuiltinContentTransformer } from "./ensure-content-transformer.ts";
+import { ensureBuiltinContentProcessor } from "./ensure-content-processor.ts";
 
 export interface StartCliProxyModeServerOptions {
   port: number;
@@ -53,7 +53,7 @@ export async function startCliProxyModeServer(
     defaultProjectId: options.defaultProjectId,
     discoveryConfig: buildDiscoveryConfig(options),
   });
-  ensureBuiltinContentTransformer();
+  ensureBuiltinContentProcessor();
   return result;
 }
 
@@ -76,7 +76,7 @@ export async function startCliDevServer(
     signal: options.signal,
   };
   const result = await startDevServer(devOptions);
-  ensureBuiltinContentTransformer();
+  ensureBuiltinContentProcessor();
   return result;
 }
 
@@ -114,6 +114,6 @@ export async function startCliProductionServer(
     // `localProjects` entry is required for the compiled binary to work.
   };
   const result = await startProductionServer(serverOptions);
-  ensureBuiltinContentTransformer();
+  ensureBuiltinContentProcessor();
   return result;
 }

--- a/docs/architecture/06-discovery-extensions.md
+++ b/docs/architecture/06-discovery-extensions.md
@@ -104,7 +104,7 @@ graph TB
         CacheStore["CacheStore"]
         TokenCacheStore["TokenCacheStore"]
         CSSProcessor["CSSProcessor"]
-        ContentTx["ContentTransformer"]
+        ContentTx["ContentProcessor"]
         DatabaseClient["DatabaseClient"]
         AuthProvider["AuthProvider"]
         TracingExporter["TracingExporter"]
@@ -157,7 +157,7 @@ The extension system currently provides:
 - **Contract Registry:** The runtime registry is currently a small in-memory contract map with `register()`, `resolve()`, `tryResolve()`, and `reset()`.
 - **Recommendations:** Some contract names map to recommended first-party extension packages via `getRecommendation()`, which is used to improve missing-contract errors.
 
-Current first-party extension packages: `@veryfront/ext-zod` (SchemaValidator), `@veryfront/ext-llm-anthropic` (LLMProvider), `@veryfront/ext-llm-google` (LLMProvider), `@veryfront/ext-llm-openai` (LLMProvider), `@veryfront/ext-auth-jwt` (AuthProvider), `@veryfront/ext-bundler-esbuild` (Bundler + ModuleLexer), `@veryfront/ext-cache-redis` (TokenCacheStore), `@veryfront/ext-css-tailwind` (CSSProcessor), `@veryfront/ext-node-compatibility` (NodeCompat), `@veryfront/ext-parser-babel` (CodeParser), `@veryfront/ext-tracing-opentelemetry` (TracingExporter), `@veryfront/ext-transform-mdx` (ContentTransformer).
+Current first-party extension packages: `@veryfront/ext-zod` (SchemaValidator), `@veryfront/ext-llm-anthropic` (LLMProvider), `@veryfront/ext-llm-google` (LLMProvider), `@veryfront/ext-llm-openai` (LLMProvider), `@veryfront/ext-auth-jwt` (AuthProvider), `@veryfront/ext-bundler-esbuild` (Bundler + ModuleLexer), `@veryfront/ext-cache-redis` (TokenCacheStore), `@veryfront/ext-css-tailwind` (CSSProcessor), `@veryfront/ext-node-compatibility` (NodeCompat), `@veryfront/ext-parser-babel` (CodeParser), `@veryfront/ext-tracing-opentelemetry` (TracingExporter), `@veryfront/ext-transform-mdx` (ContentProcessor).
 
 ---
 

--- a/docs/architecture/08-support-matrix.md
+++ b/docs/architecture/08-support-matrix.md
@@ -50,22 +50,22 @@ This matrix separates open-core framework support from capabilities that depend 
 
 ## Extension Contract Matrix
 
-These contracts are backed by first-party extension packages. Without the extension installed, the framework throws an install-suggestion error at first use.
+These contracts are backed by first-party extension packages. A contract is required only when a feature resolves it. Built-in packages are auto-enabled by core bootstrap; optional packages must be configured by the project.
 
-| Contract                 | Package                                | Runtime requirement          |
-| ------------------------ | -------------------------------------- | ---------------------------- |
-| `SchemaValidator`        | `@veryfront/ext-zod`                   | None (pure JS)               |
-| `AuthProvider`           | `@veryfront/ext-auth-jwt`              | None (jose library)          |
-| `Bundler`, `ModuleLexer` | `@veryfront/ext-bundler-esbuild`       | esbuild binary               |
-| `CSSProcessor`           | `@veryfront/ext-css-tailwind`          | Network (esm.sh for plugins) |
-| `ContentTransformer`     | `@veryfront/ext-transform-mdx`         | None (unified ecosystem)     |
-| `CodeParser`             | `@veryfront/ext-parser-babel`          | None (Babel)                 |
-| `TracingExporter`        | `@veryfront/ext-tracing-opentelemetry` | Network (OTLP endpoint)      |
-| `TokenCacheStore`        | `@veryfront/ext-cache-redis`           | Network (Redis)              |
-| `NodeCompat`             | `@veryfront/ext-node-compatibility`    | FS (SQLite, WASM)            |
-| `LLMProvider`            | `@veryfront/ext-llm-openai`            | Network (OpenAI API)         |
-| `LLMProvider`            | `@veryfront/ext-llm-anthropic`         | Network (Anthropic API)      |
-| `LLMProvider`            | `@veryfront/ext-llm-google`            | Network (Google AI API)      |
+| Contract                 | Package                                | Availability | Required by                             | Runtime requirement          |
+| ------------------------ | -------------------------------------- | ------------ | --------------------------------------- | ---------------------------- |
+| `SchemaValidator`        | `@veryfront/ext-zod`                   | Built-in     | Schema-backed runtime validation        | None (pure JS)               |
+| `Bundler`, `ModuleLexer` | `@veryfront/ext-bundler-esbuild`       | Built-in     | Build, import analysis, module bundling | esbuild binary               |
+| `CSSProcessor`           | `@veryfront/ext-css-tailwind`          | Built-in     | Tailwind CSS processing                 | Network (esm.sh for plugins) |
+| `ContentProcessor`       | `@veryfront/ext-transform-mdx`         | Built-in     | MDX or Markdown content compilation     | None (unified ecosystem)     |
+| `CodeParser`             | `@veryfront/ext-parser-babel`          | Built-in     | AST parsing or build-time code analysis | None (Babel)                 |
+| `NodeCompat`             | `@veryfront/ext-node-compatibility`    | Built-in     | Node compatibility or document parsing  | FS (SQLite, WASM)            |
+| `LLMProvider`            | `@veryfront/ext-llm-openai`            | Built-in     | OpenAI provider selection               | Network (OpenAI API)         |
+| `LLMProvider`            | `@veryfront/ext-llm-anthropic`         | Built-in     | Anthropic provider selection            | Network (Anthropic API)      |
+| `LLMProvider`            | `@veryfront/ext-llm-google`            | Built-in     | Google provider selection               | Network (Google AI API)      |
+| `AuthProvider`           | `@veryfront/ext-auth-jwt`              | Optional     | Auth signing or verification            | None (jose library)          |
+| `TracingExporter`        | `@veryfront/ext-tracing-opentelemetry` | Optional     | OTLP tracing export                     | Network (OTLP endpoint)      |
+| `TokenCacheStore`        | `@veryfront/ext-cache-redis`           | Optional     | Redis-backed token cache                | Network (Redis)              |
 
 ## Documentation Rule
 

--- a/docs/guides/extensions.md
+++ b/docs/guides/extensions.md
@@ -226,7 +226,7 @@ capabilities: [
 
 ## Available contracts
 
-These are the built-in contracts your extension can implement or consume:
+These are first-party contracts your extension can implement or consume. Some default implementations are auto-enabled by core bootstrap, while optional contracts are required only when a feature resolves them.
 
 | Contract              | Description                   | Default package                                |
 | --------------------- | ----------------------------- | ---------------------------------------------- |
@@ -237,11 +237,11 @@ These are the built-in contracts your extension can implement or consume:
 | `Bundler`             | JS/TS bundling and transforms | `@veryfront/ext-bundler-esbuild`               |
 | `ModuleLexer`         | ESM import/export analysis    | `@veryfront/ext-bundler-esbuild`               |
 | `CSSProcessor`        | CSS compilation and utilities | `@veryfront/ext-css-tailwind`                  |
-| `ContentTransformer`  | MDX/markdown to HTML/React    | `@veryfront/ext-transform-mdx`                 |
+| `ContentProcessor`    | MDX/markdown processing       | `@veryfront/ext-transform-mdx`                 |
 | `SchemaValidator`     | Runtime validation (schemas)  | `@veryfront/ext-zod`                           |
 | `TracingExporter`     | OpenTelemetry span export     | `@veryfront/ext-tracing-opentelemetry`         |
-| `LLMProviderRegistry` | LLM provider registry          | (built-in, created by framework)                |
-| `LLMProvider`          | Individual LLM provider        | `@veryfront/ext-llm-{anthropic,google,openai}` |
+| `LLMProviderRegistry` | LLM provider registry         | (built-in, created by framework)               |
+| `LLMProvider`         | Individual LLM provider       | `@veryfront/ext-llm-{anthropic,google,openai}` |
 | `EmbeddingProvider`   | Vector embeddings             | `@veryfront/ext-llm-google`                    |
 | `CodeParser`          | AST parsing and transforms    | `@veryfront/ext-parser-babel`                  |
 | `NodeCompat`          | Node.js compatibility shims   | `@veryfront/ext-node-compatibility`            |

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -2,54 +2,90 @@
 
 First-party extension packages that provide pluggable capabilities to the Veryfront framework through the [contract-based extension system](../docs/guides/extensions.md).
 
-Each extension registers one or more **contracts** — typed interfaces that the framework resolves lazily at first use. Extensions are either **built-in** (auto-loaded by the framework) or **optional** (user-installed when needed).
+Each extension registers one or more **contracts**. A contract is a typed interface that Veryfront resolves lazily at first use.
+
+Extension availability is separate from contract requirement:
+
+- Built-in extensions are auto-enabled by core bootstrap. You do not need to add them to `veryfront.config.ts`.
+- Optional extensions are user-installed and configured when a project needs the feature.
+- A contract becomes required only when a feature or extension resolves it. Missing required contracts throw an install-suggestion error at first use.
 
 ## Extension Catalog
 
 ### AI / LLM
 
-| Package | Contract | Required | Description |
-|---------|----------|----------|-------------|
-| [`@veryfront/ext-llm-anthropic`](./ext-llm-anthropic) | `LLMProvider` | Built-in | Anthropic Claude models via `@anthropic-ai/sdk` |
-| [`@veryfront/ext-llm-google`](./ext-llm-google) | `LLMProvider` | Built-in | Google Gemini models via `@google/generative-ai` |
-| [`@veryfront/ext-llm-openai`](./ext-llm-openai) | `LLMProvider` | Built-in | OpenAI models via `openai` SDK |
+| Package | Contract | Description |
+|---------|----------|-------------|
+| [`@veryfront/ext-llm-anthropic`](./ext-llm-anthropic) | `LLMProvider` | Anthropic Claude models via `@anthropic-ai/sdk` |
+| [`@veryfront/ext-llm-google`](./ext-llm-google) | `LLMProvider` | Google Gemini models via `@google/generative-ai` |
+| [`@veryfront/ext-llm-openai`](./ext-llm-openai) | `LLMProvider` | OpenAI models via `openai` SDK |
 
 ### Security
 
-| Package | Contract | Required | Description |
-|---------|----------|----------|-------------|
-| [`@veryfront/ext-auth-jwt`](./ext-auth-jwt) | `AuthProvider` | Optional | JWT sign/verify (HS256) and remote JWKS validation via `jose` |
+| Package | Contract | Description |
+|---------|----------|-------------|
+| [`@veryfront/ext-auth-jwt`](./ext-auth-jwt) | `AuthProvider` | JWT sign/verify (HS256) and remote JWKS validation via `jose` |
 
 ### Build Pipeline
 
-| Package | Contract | Required | Description |
-|---------|----------|----------|-------------|
-| [`@veryfront/ext-bundler-esbuild`](./ext-bundler-esbuild) | `Bundler`, `ModuleLexer` | Built-in | ESM bundling and module analysis via `esbuild` and `es-module-lexer` |
-| [`@veryfront/ext-parser-babel`](./ext-parser-babel) | `CodeParser` | Built-in | AST parsing, traversal, and code generation via Babel |
-| [`@veryfront/ext-css-tailwind`](./ext-css-tailwind) | `CSSProcessor` | Built-in | Tailwind CSS v4 compilation with dynamic plugin loading |
+| Package | Contract | Description |
+|---------|----------|-------------|
+| [`@veryfront/ext-bundler-esbuild`](./ext-bundler-esbuild) | `Bundler`, `ModuleLexer` | ESM bundling and module analysis via `esbuild` and `es-module-lexer` |
+| [`@veryfront/ext-parser-babel`](./ext-parser-babel) | `CodeParser` | AST parsing, traversal, and code generation via Babel |
+| [`@veryfront/ext-css-tailwind`](./ext-css-tailwind) | `CSSProcessor` | Tailwind CSS v4 compilation with dynamic plugin loading |
 
 ### Content
 
-| Package | Contract | Required | Description |
-|---------|----------|----------|-------------|
-| [`@veryfront/ext-transform-mdx`](./ext-transform-mdx) | `ContentTransformer` | Built-in | MDX and Markdown compilation via unified/remark/rehype |
+| Package | Contract | Description |
+|---------|----------|-------------|
+| [`@veryfront/ext-transform-mdx`](./ext-transform-mdx) | `ContentProcessor` | MDX and Markdown processing via unified/remark/rehype |
 
 ### Validation
 
-| Package | Contract | Required | Description |
-|---------|----------|----------|-------------|
-| [`@veryfront/ext-zod`](./ext-zod) | `SchemaValidator` | Built-in | Schema-first validation DSL backed by Zod |
+| Package | Contract | Description |
+|---------|----------|-------------|
+| [`@veryfront/ext-zod`](./ext-zod) | `SchemaValidator` | Schema-first validation DSL backed by Zod |
 
 ### Infrastructure
 
-| Package | Contract | Required | Description |
-|---------|----------|----------|-------------|
-| [`@veryfront/ext-cache-redis`](./ext-cache-redis) | `TokenCacheStore` | Optional | Redis-backed token and cache persistence |
-| [`@veryfront/ext-tracing-opentelemetry`](./ext-tracing-opentelemetry) | `TracingExporter` | Optional | OpenTelemetry trace export via OTLP/HTTP |
-| [`@veryfront/ext-node-compatibility`](./ext-node-compatibility) | `NodeCompat` | Built-in | SQLite persistence and document text extraction (Kreuzberg) |
+| Package | Contract | Description |
+|---------|----------|-------------|
+| [`@veryfront/ext-cache-redis`](./ext-cache-redis) | `TokenCacheStore` | Redis-backed token and cache persistence |
+| [`@veryfront/ext-tracing-opentelemetry`](./ext-tracing-opentelemetry) | `TracingExporter` | OpenTelemetry trace export via OTLP/HTTP |
+| [`@veryfront/ext-node-compatibility`](./ext-node-compatibility) | `NodeCompat` | SQLite persistence and document text extraction (Kreuzberg) |
 
-> **Built-in** extensions are auto-loaded by `createBuiltinExtensions()` at app bootstrap — no configuration needed.
-> **Optional** extensions must be installed and added to `veryfront.config.ts`. Without them, the framework falls back gracefully or throws an install-suggestion error at first use of the missing contract.
+## Auto-enabled core extensions
+
+These extensions are loaded by `createBuiltinExtensions()` during app bootstrap unless a project disables or overrides them by name.
+
+| Package | Contracts |
+|---------|-----------|
+| `@veryfront/ext-zod` | `SchemaValidator` |
+| `@veryfront/ext-bundler-esbuild` | `Bundler`, `ModuleLexer` |
+| `@veryfront/ext-parser-babel` | `CodeParser` |
+| `@veryfront/ext-transform-mdx` | `ContentProcessor` |
+| `@veryfront/ext-css-tailwind` | `CSSProcessor` |
+| `@veryfront/ext-node-compatibility` | `NodeCompat` |
+| `@veryfront/ext-llm-openai` | `LLMProvider:openai` |
+| `@veryfront/ext-llm-anthropic` | `LLMProvider:anthropic` |
+| `@veryfront/ext-llm-google` | `LLMProvider:google` |
+
+## Contract requirements
+
+Veryfront treats contracts as required at the call site, not at the package list level.
+
+| Contract | Required when | Default source |
+|----------|---------------|----------------|
+| `SchemaValidator` | Schema-backed runtime validation runs | Auto-enabled core extension |
+| `Bundler`, `ModuleLexer` | Build, import analysis, or module bundling runs | Auto-enabled core extension |
+| `CodeParser` | AST parsing or build-time code analysis runs | Auto-enabled core extension |
+| `ContentProcessor` | MDX or Markdown content compilation runs | Auto-enabled core extension |
+| `CSSProcessor` | Tailwind CSS processing runs | Auto-enabled core extension |
+| `NodeCompat` | Node compatibility, SQLite persistence, or document extraction runs | Auto-enabled core extension |
+| `LLMProvider:*` | A matching model provider is selected | Auto-enabled core extension |
+| `AuthProvider` | Auth signing or verification is configured | User-installed extension |
+| `TokenCacheStore` | Redis-backed token cache is configured | User-installed extension |
+| `TracingExporter` | OTLP tracing export is configured | User-installed extension |
 
 ## Architecture
 
@@ -59,7 +95,7 @@ veryfront.config.ts          extensions/ext-*/deno.json
         ▼                              ▼
 ┌──────────────────────────────────────────┐
 │         Extension Discovery              │
-│  (config → packages → project → local)   │
+│  (config -> packages -> project -> local) │
 └──────────────┬───────────────────────────┘
                ▼
 ┌──────────────────────────────────────────┐
@@ -74,7 +110,7 @@ veryfront.config.ts          extensions/ext-*/deno.json
                ▼
 ┌──────────────────────────────────────────┐
 │         Runtime                          │
-│  ctx.require("ContractName") → impl      │
+│  ctx.require("ContractName") -> impl     │
 └──────────────┬───────────────────────────┘
                ▼
 ┌──────────────────────────────────────────┐

--- a/extensions/ext-bundler-esbuild/README.md
+++ b/extensions/ext-bundler-esbuild/README.md
@@ -11,9 +11,9 @@ Registers two contracts:
 
 Without this extension, both surfaces throw an install-suggestion error.
 
-## Installation
+## Registration
 
-Add the extension to your project's `veryfront.config.ts`:
+This extension is auto-enabled by core bootstrap. Add it to `veryfront.config.ts` only when you need to override the built-in registration:
 
 ```ts
 import extEsbuild from "@veryfront/ext-bundler-esbuild";

--- a/extensions/ext-css-tailwind/README.md
+++ b/extensions/ext-css-tailwind/README.md
@@ -4,9 +4,9 @@
 
 Provides Tailwind CSS v4 compilation for Veryfront. Compiles stylesheets at render time and supports dynamic plugin loading from CDN.
 
-## Installation
+## Registration
 
-Add the extension to your project's `veryfront.config.ts`:
+This extension is auto-enabled by core bootstrap. Add it to `veryfront.config.ts` only when you need to override the built-in registration:
 
 ```ts
 import extTailwind from "@veryfront/ext-css-tailwind";

--- a/extensions/ext-llm-google/README.md
+++ b/extensions/ext-llm-google/README.md
@@ -4,9 +4,9 @@
 
 Provides Google Gemini models for Veryfront agents and chat, enabling `google/*` models for chat and embeddings via the `LLMProviderRegistry`.
 
-## Installation
+## Registration
 
-Add the extension to your project's `veryfront.config.ts`:
+This extension is auto-enabled by core bootstrap. Add it to `veryfront.config.ts` only when you need to override the built-in registration:
 
 ```ts
 import extGoogle from "@veryfront/ext-llm-google";
@@ -25,7 +25,7 @@ export default defineConfig({
 
 ## Usage
 
-Once installed, use `google/*` model strings anywhere Veryfront expects a model identifier:
+Once credentials are configured, use `google/*` model strings anywhere Veryfront expects a model identifier:
 
 ```ts
 const response = await ai.chat("google/gemini-2.5-pro", {

--- a/extensions/ext-llm-openai/README.md
+++ b/extensions/ext-llm-openai/README.md
@@ -4,9 +4,9 @@
 
 Provides OpenAI models for Veryfront agents and chat, enabling `openai/*` models for chat, embeddings, and the Responses API via the `LLMProviderRegistry`.
 
-## Installation
+## Registration
 
-Add the extension to your project's `veryfront.config.ts`:
+This extension is auto-enabled by core bootstrap. Add it to `veryfront.config.ts` only when you need to override the built-in registration:
 
 ```ts
 import extOpenAI from "@veryfront/ext-llm-openai";
@@ -25,7 +25,7 @@ export default defineConfig({
 
 ## Usage
 
-Once installed, use `openai/*` model strings anywhere Veryfront expects a model identifier:
+Once credentials are configured, use `openai/*` model strings anywhere Veryfront expects a model identifier:
 
 ```ts
 const response = await ai.chat("openai/gpt-4.1", {

--- a/extensions/ext-node-compatibility/README.md
+++ b/extensions/ext-node-compatibility/README.md
@@ -4,9 +4,9 @@
 
 Provides Node.js compatibility shims for Veryfront — SQLite-backed persistence and document text extraction (PDF, DOCX, images) via Kreuzberg.
 
-## Installation
+## Registration
 
-Add the extension to your project's `veryfront.config.ts`:
+This extension is auto-enabled by core bootstrap. Add it to `veryfront.config.ts` only when you need to override the built-in registration:
 
 ```ts
 import extNodeCompat from "@veryfront/ext-node-compatibility";
@@ -26,7 +26,7 @@ export default defineConfig({
 
 ## When you need this
 
-- The Veryfront proxy / KV layer falls back to in-memory storage without this extension. Install it for persistent local development storage or any production deployment that doesn't have an external KV backing.
+- The Veryfront proxy / KV layer falls back to in-memory storage when this contract is unavailable. Use this extension for persistent local development storage or any production deployment that does not have an external KV backing.
 - Document upload and text-extraction features (PDF, DOCX, images, etc.) are unavailable without it.
 
 ## Capabilities

--- a/extensions/ext-parser-babel/README.md
+++ b/extensions/ext-parser-babel/README.md
@@ -4,9 +4,9 @@
 
 Provides JavaScript/TypeScript AST parsing, traversal, and code generation for Veryfront, backed by `@babel/parser`, `@babel/traverse`, `@babel/generator`, and `@babel/types`. Used by the transform pipeline and Studio Navigator.
 
-## Installation
+## Registration
 
-Add the extension to your project's `veryfront.config.ts`:
+This extension is auto-enabled by core bootstrap. Add it to `veryfront.config.ts` only when you need to override the built-in registration:
 
 ```ts
 import extBabel from "@veryfront/ext-parser-babel";

--- a/extensions/ext-transform-mdx/README.md
+++ b/extensions/ext-transform-mdx/README.md
@@ -1,12 +1,12 @@
 # @veryfront/ext-transform-mdx
 
-> **Category:** Content | **Contract:** `ContentTransformer` | **Built-in**
+> **Category:** Content | **Contract:** `ContentProcessor` | **Built-in**
 
-Provides MDX and Markdown compilation for Veryfront, backed by [`@mdx-js/mdx`](https://github.com/mdx-js/mdx) and the [`unified`](https://unifiedjs.com/) ecosystem. Compiles content into runtime React bundles with sanitized HTML output, frontmatter extraction, and heading collection.
+Provides MDX and Markdown processing for Veryfront, backed by [`@mdx-js/mdx`](https://github.com/mdx-js/mdx) and the [`unified`](https://unifiedjs.com/) ecosystem. It returns compiled React modules with sanitized HTML output, frontmatter extraction, and heading collection.
 
-## Installation
+## Registration
 
-Add the extension to your project's `veryfront.config.ts`:
+This extension is auto-enabled by core bootstrap. Add it to `veryfront.config.ts` only when you need to override the built-in registration:
 
 ```ts
 import extMdx from "@veryfront/ext-transform-mdx";
@@ -18,11 +18,11 @@ export default defineConfig({
 
 ## Provided contract
 
-`ContentTransformer` — exposes:
+`ContentProcessor` exposes:
 
-- `compileMdx(options)` — runs `@mdx-js/mdx` through Veryfront's bundled remark + rehype plugin stack and returns compiled ESM, extracted headings, and frontmatter.
-- `compileMarkdown(options)` — runs a unified Markdown pipeline (`remark-parse` → `remark-rehype` → `rehype-sanitize` → `rehype-stringify`) producing sanitized HTML wrapped in a React component.
-- `getRemarkPlugins()` / `getRehypePlugins()` — returns the configured plugin list so callers can build a custom pipeline.
+- `compileMdx(options)` runs `@mdx-js/mdx` through Veryfront's bundled remark + rehype plugin stack and returns compiled ESM, extracted headings, and frontmatter.
+- `compileMarkdown(options)` runs a unified Markdown pipeline (`remark-parse` to `remark-rehype` to `rehype-sanitize` to `rehype-stringify`) producing sanitized HTML wrapped in a React component.
+- `getRemarkPlugins()` / `getRehypePlugins()` returns the configured plugin list so callers can build a custom pipeline.
 
 ## Default plugin stack
 
@@ -39,4 +39,4 @@ No factory options. The extension reads no environment variables and takes no co
 
 ## Behavior when missing
 
-If the extension is not installed and core's MDX or Markdown transformer is invoked, Veryfront throws an actionable install message pointing to `@veryfront/ext-transform-mdx`.
+If the extension is not installed and core's MDX or Markdown processor is invoked, Veryfront throws an actionable install message pointing to `@veryfront/ext-transform-mdx`.

--- a/extensions/ext-transform-mdx/deno.json
+++ b/extensions/ext-transform-mdx/deno.json
@@ -5,7 +5,7 @@
   "veryfront": {
     "extension": true,
     "capabilities": [
-      { "type": "contract", "name": "ContentTransformer" }
+      { "type": "contract", "name": "ContentProcessor" }
     ]
   },
   "imports": {

--- a/extensions/ext-transform-mdx/src/compiler/markdown-compile.ts
+++ b/extensions/ext-transform-mdx/src/compiler/markdown-compile.ts
@@ -12,7 +12,10 @@ import { visit } from "unist-util-visit";
 import { toString } from "mdast-util-to-string";
 import Slugger from "github-slugger";
 import type { Heading, Root as MdastRoot } from "mdast";
-import type { ContentCompileOptions, ContentRuntimeBundle } from "veryfront/extensions/transform";
+import type {
+  ContentCompileOptions,
+  ContentProcessingResult,
+} from "veryfront/extensions/transform";
 import { extractFrontmatter } from "veryfront/transforms/frontmatter";
 import { isMarkdownPreview } from "veryfront/transforms/md-utils";
 import { rehypeNodePositions } from "../plugins/rehype-node-positions.ts";
@@ -64,7 +67,7 @@ export default function MDContent({ components, params, className, ...props }) {
 
 export async function compileMarkdown(
   options: ContentCompileOptions,
-): Promise<ContentRuntimeBundle> {
+): Promise<ContentProcessingResult> {
   const { content, frontmatter: providedFrontmatter, filePath, studioEmbed } = options;
 
   const { body, frontmatter: extractedFrontmatter } = extractFrontmatter(

--- a/extensions/ext-transform-mdx/src/compiler/mdx-compile.ts
+++ b/extensions/ext-transform-mdx/src/compiler/mdx-compile.ts
@@ -1,6 +1,9 @@
 import { compile } from "@mdx-js/mdx";
 import type { Pluggable } from "unified";
-import type { ContentCompileOptions, ContentRuntimeBundle } from "veryfront/extensions/transform";
+import type {
+  ContentCompileOptions,
+  ContentProcessingResult,
+} from "veryfront/extensions/transform";
 import { extractFrontmatter } from "veryfront/transforms/frontmatter";
 import { rewriteBodyImports, rewriteCompiledImports } from "veryfront/transforms/import-rewriter";
 import { getRehypePlugins, getRemarkPlugins } from "../plugins/plugin-loader.ts";
@@ -8,7 +11,7 @@ import { rehypeNodePositions } from "../plugins/rehype-node-positions.ts";
 
 type PluggableList = Pluggable[];
 
-export async function compileMdx(options: ContentCompileOptions): Promise<ContentRuntimeBundle> {
+export async function compileMdx(options: ContentCompileOptions): Promise<ContentProcessingResult> {
   const {
     projectDir,
     content,

--- a/extensions/ext-transform-mdx/src/index.test.ts
+++ b/extensions/ext-transform-mdx/src/index.test.ts
@@ -7,7 +7,7 @@
 import { assertEquals, assertExists, assertStringIncludes } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 
-import factory, { MdxContentTransformer } from "./index.ts";
+import factory, { MdxContentProcessor } from "./index.ts";
 
 describe("ext-mdx factory", () => {
   it("produces an extension whose name is ext-mdx", () => {
@@ -16,16 +16,16 @@ describe("ext-mdx factory", () => {
     assertEquals(ext.version, "0.1.0");
   });
 
-  it("declares the ContentTransformer contract capability", () => {
+  it("declares the ContentProcessor contract capability", () => {
     const ext = factory();
     const contractCap = ext.capabilities.find((c) => c.type === "contract");
     assertExists(contractCap);
     if (contractCap?.type === "contract") {
-      assertEquals(contractCap.name, "ContentTransformer");
+      assertEquals(contractCap.name, "ContentProcessor");
     }
   });
 
-  it("registers ContentTransformer when setup runs", async () => {
+  it("registers ContentProcessor when setup runs", async () => {
     const ext = factory();
     let registered: unknown = null;
     const ctx = {
@@ -41,13 +41,13 @@ describe("ext-mdx factory", () => {
     };
     await ext.setup?.(ctx as never);
     assertExists(registered);
-    assertEquals(registered instanceof MdxContentTransformer, true);
+    assertEquals(registered instanceof MdxContentProcessor, true);
   });
 });
 
-describe("MdxContentTransformer.compileMarkdown", () => {
+describe("MdxContentProcessor.compileMarkdown", () => {
   it("compiles a trivial markdown document to an ESM module", async () => {
-    const impl = new MdxContentTransformer();
+    const impl = new MdxContentProcessor();
     const result = await impl.compileMarkdown({
       mode: "production",
       projectDir: "/tmp",
@@ -60,7 +60,7 @@ describe("MdxContentTransformer.compileMarkdown", () => {
   });
 
   it("exposes rawHtml for markdown preview consumers", async () => {
-    const impl = new MdxContentTransformer();
+    const impl = new MdxContentProcessor();
     const result = await impl.compileMarkdown({
       mode: "production",
       projectDir: "/tmp",
@@ -71,9 +71,9 @@ describe("MdxContentTransformer.compileMarkdown", () => {
   });
 });
 
-describe("MdxContentTransformer.compileMdx", () => {
+describe("MdxContentProcessor.compileMdx", () => {
   it("compiles trivial mdx content", async () => {
-    const impl = new MdxContentTransformer();
+    const impl = new MdxContentProcessor();
     const result = await impl.compileMdx({
       mode: "production",
       projectDir: "/tmp",

--- a/extensions/ext-transform-mdx/src/index.ts
+++ b/extensions/ext-transform-mdx/src/index.ts
@@ -1,12 +1,12 @@
 /**
- * ext-mdx — ContentTransformer implementation backed by MDX + remark/rehype.
+ * ext-mdx: ContentProcessor implementation backed by MDX + remark/rehype.
  *
- * Provides the `ContentTransformer` contract:
- *  - `compileMdx(options)`  — runs @mdx-js/mdx through veryfront's remark +
+ * Provides the `ContentProcessor` contract:
+ *  - `compileMdx(options)` runs @mdx-js/mdx through Veryfront's remark +
  *    rehype plugin stack and returns compiled ESM plus extracted headings
  *    and frontmatter.
- *  - `compileMarkdown(options)` — runs a unified markdown pipeline
- *    (remark-parse → remark-rehype → rehype-sanitize → rehype-stringify)
+ *  - `compileMarkdown(options)` runs a unified markdown pipeline
+ *    (remark-parse to remark-rehype to rehype-sanitize to rehype-stringify)
  *    producing sanitized HTML wrapped in a React component.
  *
  * Core's `src/transforms/md/compiler` and `src/transforms/mdx/compiler`
@@ -21,18 +21,18 @@ import type { ExtensionFactory } from "veryfront/extensions";
 import type {
   ContentCompileOptions,
   ContentPlugin,
-  ContentRuntimeBundle,
-  ContentTransformer,
+  ContentProcessingResult,
+  ContentProcessor,
 } from "veryfront/extensions/transform";
 import { compileMdx } from "./compiler/mdx-compile.ts";
 import { compileMarkdown } from "./compiler/markdown-compile.ts";
 import { getRehypePlugins, getRemarkPlugins } from "./plugins/plugin-loader.ts";
 
-class MdxContentTransformer implements ContentTransformer {
-  compileMdx(options: ContentCompileOptions): Promise<ContentRuntimeBundle> {
+class MdxContentProcessor implements ContentProcessor {
+  compileMdx(options: ContentCompileOptions): Promise<ContentProcessingResult> {
     return compileMdx(options);
   }
-  compileMarkdown(options: ContentCompileOptions): Promise<ContentRuntimeBundle> {
+  compileMarkdown(options: ContentCompileOptions): Promise<ContentProcessingResult> {
     return compileMarkdown(options);
   }
   getRemarkPlugins(): ContentPlugin[] {
@@ -44,14 +44,14 @@ class MdxContentTransformer implements ContentTransformer {
 }
 
 const extMdx: ExtensionFactory = () => {
-  const impl = new MdxContentTransformer();
+  const impl = new MdxContentProcessor();
   return {
     name: "ext-transform-mdx",
     version: "0.1.0",
-    capabilities: [{ type: "contract", name: "ContentTransformer" }],
+    capabilities: [{ type: "contract", name: "ContentProcessor" }],
     setup(ctx) {
-      ctx.provide("ContentTransformer", impl);
-      ctx.logger.info("[ext-mdx] ContentTransformer registered");
+      ctx.provide("ContentProcessor", impl);
+      ctx.logger.info("[ext-mdx] ContentProcessor registered");
     },
     teardown() {
       // No resources to release.
@@ -60,4 +60,4 @@ const extMdx: ExtensionFactory = () => {
 };
 
 export default extMdx;
-export { MdxContentTransformer };
+export { MdxContentProcessor };

--- a/src/build/compiler/mdx-compiler/compiler.test.ts
+++ b/src/build/compiler/mdx-compiler/compiler.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import "../../../transforms/mdx/compiler/__tests__/content-transformer-setup.ts";
+import "../../../transforms/mdx/compiler/__tests__/content-processor-setup.ts";
 import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import * as esbuild from "veryfront/extensions/bundler";

--- a/src/build/compiler/mdx-compiler/mdx-processor.test.ts
+++ b/src/build/compiler/mdx-compiler/mdx-processor.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import "../../../transforms/mdx/compiler/__tests__/content-transformer-setup.ts";
+import "../../../transforms/mdx/compiler/__tests__/content-processor-setup.ts";
 import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { compileMDX } from "./mdx-processor.ts";

--- a/src/build/renderer/services/mdx-bundler.test.ts
+++ b/src/build/renderer/services/mdx-bundler.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import "../../../transforms/mdx/compiler/__tests__/content-transformer-setup.ts";
+import "../../../transforms/mdx/compiler/__tests__/content-processor-setup.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { bundleMdx, bundleMDXWithOptions } from "./mdx-bundler.ts";

--- a/src/extensions/builtin-extensions.ts
+++ b/src/extensions/builtin-extensions.ts
@@ -115,7 +115,7 @@ export function createBuiltinExtensions(): ResolvedExtension[] {
     },
     {
       source: "builtin",
-      origin: "veryfront/ext-mdx",
+      origin: "veryfront/ext-transform-mdx",
       extension: extMdx(),
     },
     {

--- a/src/extensions/recommendations.ts
+++ b/src/extensions/recommendations.ts
@@ -12,7 +12,7 @@ const recommendations = new Map<string, string>([
   ["CacheStore", "@veryfront/ext-cache-redis"],
   ["TokenCacheStore", "@veryfront/ext-cache-redis"],
   ["CSSProcessor", "@veryfront/ext-css-tailwind"],
-  ["ContentTransformer", "@veryfront/ext-transform-mdx"],
+  ["ContentProcessor", "@veryfront/ext-transform-mdx"],
   ["DatabaseClient", "@veryfront/ext-postgres"],
   ["AuthProvider", "@veryfront/ext-auth-jwt"],
   ["TracingExporter", "@veryfront/ext-tracing-opentelemetry"],

--- a/src/extensions/transform/content-processor.ts
+++ b/src/extensions/transform/content-processor.ts
@@ -1,10 +1,10 @@
 /**
- * Contract interface for content transformation pipelines.
+ * Contract interface for content processing pipelines.
  *
  * Default implementation: `@veryfront/ext-transform-mdx`
  *
- * Implementations compile MDX / Markdown source into renderable JavaScript
- * modules. Core's `src/transforms/md/compiler` and
+ * Implementations process MDX / Markdown source into renderable JavaScript
+ * modules plus extracted metadata. Core's `src/transforms/md/compiler` and
  * `src/transforms/mdx/compiler` delegate to the registered implementation;
  * when none is registered, the compile paths throw an actionable install
  * message pointing at `@veryfront/ext-transform-mdx`.
@@ -12,21 +12,21 @@
  * The two compile methods have the same option shape on purpose so a single
  * dispatcher (see `src/transforms/mdx/compiler/index.ts::compileContent`)
  * can route on file extension. Options match the long-standing
- * `compileMDXRuntime` / `compileMarkdownRuntime` signatures — option order
+ * `compileMDXRuntime` / `compileMarkdownRuntime` signatures. Option order
  * and defaults are preserved so the extension boundary is a pure refactor,
  * not a behavior change.
  *
- * @module extensions/transform/content-transformer
+ * @module extensions/transform/content-processor
  */
 
-/** Compilation mode — dev surfaces extra diagnostics. */
+/** Compilation mode. Dev surfaces extra diagnostics. */
 export type CompilationMode = "development" | "production";
 
-/** Where the output is destined — server-side RSC or browser bundle. */
+/** Where the output is destined: server-side RSC or browser bundle. */
 export type CompilationTarget = "browser" | "server";
 
-/** Runtime bundle returned by the compilation pipeline. */
-export interface ContentRuntimeBundle {
+/** Processing result returned by the content pipeline. */
+export interface ContentProcessingResult {
   /** Compiled ESM source containing the default MDX/MD component export. */
   compiledCode: string;
   /** Front-matter extracted from the source document. */
@@ -41,9 +41,9 @@ export interface ContentRuntimeBundle {
   rawHtml?: string;
 }
 
-/** Options for {@link ContentTransformer.compileMdx} and {@link ContentTransformer.compileMarkdown}. */
+/** Options for {@link ContentProcessor.compileMdx} and {@link ContentProcessor.compileMarkdown}. */
 export interface ContentCompileOptions {
-  /** Compilation mode — defaults to "production" when omitted. */
+  /** Compilation mode. Defaults to "production" when omitted. */
   mode?: CompilationMode;
   /** Absolute project root (used for resolving relative import rewrites). */
   projectDir: string;
@@ -53,7 +53,7 @@ export interface ContentCompileOptions {
   frontmatter?: Record<string, unknown>;
   /** Source file path hint (used in error messages + import resolution). */
   filePath?: string;
-  /** Compile target — defaults to "server". */
+  /** Compile target. Defaults to "server". */
   target?: CompilationTarget;
   /** Base URL used when rewriting bare-specifier imports. */
   baseUrl?: string;
@@ -64,27 +64,27 @@ export interface ContentCompileOptions {
 /**
  * Opaque unified-compatible plugin entry. Kept as `unknown[] | unknown` so
  * the contract surface doesn't require consumers to depend on the `unified`
- * package directly — callers cast to the plugin-list shape they need.
+ * package directly. Callers cast to the plugin-list shape they need.
  */
 export type ContentPlugin = unknown | [unknown, ...unknown[]];
 
 /**
- * ContentTransformer contract — compiles MDX/Markdown to runtime-ready JS.
+ * ContentProcessor contract for MDX/Markdown processing.
  *
  * Implementations own the entire pipeline (parser, remark/rehype plugins,
  * MDX compile step, sanitization, HTML wrapping). Core only dispatches by
- * file extension and post-processes the returned bundle.
+ * file extension and post-processes the returned result.
  *
  * `getRemarkPlugins()` / `getRehypePlugins()` are exposed so build-time MDX
  * compilers (which run their own @mdx-js/mdx invocations) can borrow the
  * canonical plugin list without duplicating it. Runtime compile paths
  * should prefer `compileMdx` / `compileMarkdown`.
  */
-export interface ContentTransformer {
-  /** Compile MDX source into a runtime bundle. */
-  compileMdx(options: ContentCompileOptions): Promise<ContentRuntimeBundle>;
-  /** Compile plain Markdown into a runtime bundle. */
-  compileMarkdown(options: ContentCompileOptions): Promise<ContentRuntimeBundle>;
+export interface ContentProcessor {
+  /** Process MDX source into compiled code and extracted metadata. */
+  compileMdx(options: ContentCompileOptions): Promise<ContentProcessingResult>;
+  /** Process plain Markdown into compiled code and extracted metadata. */
+  compileMarkdown(options: ContentCompileOptions): Promise<ContentProcessingResult>;
   /** Return the canonical remark plugin list. */
   getRemarkPlugins(): ContentPlugin[];
   /** Return the canonical rehype plugin list. */

--- a/src/extensions/transform/index.ts
+++ b/src/extensions/transform/index.ts
@@ -1,15 +1,15 @@
 /**
- * Content category barrel — content transformer (MDX/Markdown) contract.
+ * Content category barrel for the MDX/Markdown content processor contract.
  *
  * @module extensions/transform
  */
 
 // Type aliases (unions / shape aliases)
-export type { CompilationMode, CompilationTarget, ContentPlugin } from "./content-transformer.ts";
+export type { CompilationMode, CompilationTarget, ContentPlugin } from "./content-processor.ts";
 
 // Interfaces
 export type {
   ContentCompileOptions,
-  ContentRuntimeBundle,
-  ContentTransformer,
-} from "./content-transformer.ts";
+  ContentProcessingResult,
+  ContentProcessor,
+} from "./content-processor.ts";

--- a/src/rendering/layouts/utils/compiler.test.ts
+++ b/src/rendering/layouts/utils/compiler.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import "../../../transforms/mdx/compiler/__tests__/content-transformer-setup.ts";
+import "../../../transforms/mdx/compiler/__tests__/content-processor-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { compileMDXLayouts } from "./compiler.ts";

--- a/src/rendering/orchestrator/compiler-service.test.ts
+++ b/src/rendering/orchestrator/compiler-service.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import "../../transforms/mdx/compiler/__tests__/content-transformer-setup.ts";
+import "../../transforms/mdx/compiler/__tests__/content-processor-setup.ts";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { CompilerService } from "./compiler-service.ts";

--- a/src/rendering/page-rendering.test.ts
+++ b/src/rendering/page-rendering.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import "../transforms/mdx/compiler/__tests__/content-transformer-setup.ts";
+import "../transforms/mdx/compiler/__tests__/content-processor-setup.ts";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { EntityInfo } from "#veryfront/types";

--- a/src/server/services/rendering/ssr.service.test.ts
+++ b/src/server/services/rendering/ssr.service.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import "../../../transforms/mdx/compiler/__tests__/content-transformer-setup.ts";
+import "../../../transforms/mdx/compiler/__tests__/content-processor-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { SSRService } from "./ssr.service.ts";

--- a/src/transforms/md/compiler/md-compiler.test.ts
+++ b/src/transforms/md/compiler/md-compiler.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import "../../mdx/compiler/__tests__/content-transformer-setup.ts";
+import "../../mdx/compiler/__tests__/content-processor-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { compileMarkdownRuntime } from "./md-compiler.ts";

--- a/src/transforms/md/compiler/md-compiler.ts
+++ b/src/transforms/md/compiler/md-compiler.ts
@@ -3,8 +3,8 @@ import { resolve as resolveContract } from "#veryfront/extensions/contracts.ts";
 import type {
   CompilationMode,
   CompilationTarget,
-  ContentRuntimeBundle,
-  ContentTransformer,
+  ContentProcessingResult,
+  ContentProcessor,
 } from "#veryfront/extensions/transform/index.ts";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
@@ -20,13 +20,13 @@ export function compileMarkdownRuntime(
   target: CompilationTarget = "server",
   baseUrl?: string,
   studioEmbed?: boolean,
-): Promise<ContentRuntimeBundle> {
+): Promise<ContentProcessingResult> {
   return withSpan(
     "transforms.compileMarkdownRuntime",
-    async (): Promise<ContentRuntimeBundle> => {
+    async (): Promise<ContentProcessingResult> => {
       try {
-        const transformer = resolveContract<ContentTransformer>("ContentTransformer");
-        return await transformer.compileMarkdown({
+        const processor = resolveContract<ContentProcessor>("ContentProcessor");
+        return await processor.compileMarkdown({
           mode,
           projectDir,
           content,

--- a/src/transforms/mdx/compiler/__tests__/content-processor-setup.ts
+++ b/src/transforms/mdx/compiler/__tests__/content-processor-setup.ts
@@ -1,16 +1,16 @@
 /**
  * Shared test helper: activates the `@veryfront/ext-transform-mdx` extension so core
  * tests that exercise the MDX / Markdown compile paths can resolve the
- * `ContentTransformer` contract.
+ * `ContentProcessor` contract.
  *
  * Importing this module runs `registerExtMdx()` once for its side effect,
  * which covers tests that simply import the helper. Call `registerExtMdx()`
- * again after any operation that resets the contract registry — e.g. after
+ * again after any operation that resets the contract registry. For example, after
  * `bootstrap.setupAll` / `teardownAll` (which wipe registrations via
  * `reset()`), after `startProductionServer` / `startDevServer`, or after
  * `resetAllTestState()` in integration test helpers.
  *
- * @module transforms/mdx/compiler/__tests__/content-transformer-setup
+ * @module transforms/mdx/compiler/__tests__/content-processor-setup
  */
 
 import { register as registerContract } from "#veryfront/extensions/contracts.ts";

--- a/src/transforms/mdx/compiler/index.test.ts
+++ b/src/transforms/mdx/compiler/index.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import "./__tests__/content-transformer-setup.ts";
+import "./__tests__/content-processor-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { compileContent } from "./index.ts";

--- a/src/transforms/mdx/compiler/index.ts
+++ b/src/transforms/mdx/compiler/index.ts
@@ -10,7 +10,7 @@ export { rewriteBodyImports, rewriteCompiledImports } from "./import-rewriter.ts
 export type {
   CompilationMode,
   CompilationTarget,
-  ContentRuntimeBundle,
+  ContentProcessingResult,
 } from "#veryfront/extensions/transform/index.ts";
 export type { FrontmatterExtractionResult } from "./frontmatter-extractor.ts";
 export type { ImportRewriterConfig } from "./import-rewriter.ts";
@@ -20,7 +20,7 @@ import { compileMarkdownRuntime } from "../../md/compiler/index.ts";
 import type {
   CompilationMode,
   CompilationTarget,
-  ContentRuntimeBundle,
+  ContentProcessingResult,
 } from "#veryfront/extensions/transform/index.ts";
 
 function isMarkdownFile(filePath?: string): boolean {
@@ -36,7 +36,7 @@ export function compileContent(
   target: CompilationTarget = "server",
   baseUrl?: string,
   studioEmbed?: boolean,
-): Promise<ContentRuntimeBundle> {
+): Promise<ContentProcessingResult> {
   if (isMarkdownFile(filePath)) {
     return compileMarkdownRuntime(
       mode,

--- a/src/transforms/mdx/compiler/mdx-compiler.test.ts
+++ b/src/transforms/mdx/compiler/mdx-compiler.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import "./__tests__/content-transformer-setup.ts";
+import "./__tests__/content-processor-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { compileMDXRuntime } from "./mdx-compiler.ts";

--- a/src/transforms/mdx/compiler/mdx-compiler.ts
+++ b/src/transforms/mdx/compiler/mdx-compiler.ts
@@ -3,8 +3,8 @@ import { resolve as resolveContract } from "#veryfront/extensions/contracts.ts";
 import type {
   CompilationMode,
   CompilationTarget,
-  ContentRuntimeBundle,
-  ContentTransformer,
+  ContentProcessingResult,
+  ContentProcessor,
 } from "#veryfront/extensions/transform/index.ts";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
@@ -20,13 +20,13 @@ export function compileMDXRuntime(
   target: CompilationTarget = "server",
   baseUrl?: string,
   studioEmbed?: boolean,
-): Promise<ContentRuntimeBundle> {
+): Promise<ContentProcessingResult> {
   return withSpan(
     "transforms.compileMDXRuntime",
     async () => {
       try {
-        const transformer = resolveContract<ContentTransformer>("ContentTransformer");
-        return await transformer.compileMdx({
+        const processor = resolveContract<ContentProcessor>("ContentProcessor");
+        return await processor.compileMdx({
           mode,
           projectDir,
           content,

--- a/src/transforms/plugins/index.ts
+++ b/src/transforms/plugins/index.ts
@@ -2,7 +2,7 @@
  * Transforms Plugins
  *
  * `getRemarkPlugins` / `getRehypePlugins` are thin shims that resolve the
- * `ContentTransformer` contract (default implementation: `@veryfront/ext-transform-mdx`).
+ * `ContentProcessor` contract (default implementation: `@veryfront/ext-transform-mdx`).
  * The actual plugin modules (remark-headings, remark-mdx-utils, rehype-mermaid,
  * rehype-node-positions) now live inside the extension.
  *

--- a/src/transforms/plugins/plugin-loader.ts
+++ b/src/transforms/plugins/plugin-loader.ts
@@ -1,12 +1,12 @@
 /**
- * Shim that routes MDX plugin lookups through the `ContentTransformer`
+ * Shim that routes MDX plugin lookups through the `ContentProcessor`
  * extension contract (default implementation: `@veryfront/ext-transform-mdx`).
  *
  * Build-time MDX compilers (`src/build/compiler/mdx-compiler/mdx-processor.ts`,
  * `src/build/renderer/services/mdx-bundler.ts`, `layout-applicator.ts`)
  * historically imported `getRemarkPlugins` / `getRehypePlugins` directly.
  * Now those callers get the canonical plugin list from whichever
- * `ContentTransformer` implementation is registered.
+ * `ContentProcessor` implementation is registered.
  *
  * When no implementation is registered, the lookup throws with an
  * actionable install message pointing at `@veryfront/ext-transform-mdx`.
@@ -16,14 +16,14 @@
 
 import type { Pluggable } from "unified";
 import { resolve as resolveContract } from "#veryfront/extensions/contracts.ts";
-import type { ContentTransformer } from "#veryfront/extensions/transform/index.ts";
+import type { ContentProcessor } from "#veryfront/extensions/transform/index.ts";
 
 export function getRemarkPlugins(): Pluggable[] {
-  const transformer = resolveContract<ContentTransformer>("ContentTransformer");
-  return transformer.getRemarkPlugins() as unknown as Pluggable[];
+  const processor = resolveContract<ContentProcessor>("ContentProcessor");
+  return processor.getRemarkPlugins() as unknown as Pluggable[];
 }
 
 export function getRehypePlugins(): Pluggable[] {
-  const transformer = resolveContract<ContentTransformer>("ContentTransformer");
-  return transformer.getRehypePlugins() as unknown as Pluggable[];
+  const processor = resolveContract<ContentProcessor>("ContentProcessor");
+  return processor.getRehypePlugins() as unknown as Pluggable[];
 }

--- a/tests/_helpers/context.ts
+++ b/tests/_helpers/context.ts
@@ -29,7 +29,6 @@ import {
   makeTempDir,
   mkdir,
   remove,
-  symlink,
   writeTextFile,
 } from "../../src/platform/compat/fs.ts";
 import { resolve as resolvePath } from "#veryfront/compat/path";
@@ -73,7 +72,8 @@ try {
 export async function registerExtBabelForTests(): Promise<void> {
   try {
     const { register } = await import("../../src/extensions/contracts.ts");
-    const extBabelFactory = (await import("../../extensions/ext-parser-babel/src/index.ts")).default;
+    const extBabelFactory =
+      (await import("../../extensions/ext-parser-babel/src/index.ts")).default;
     const ext = extBabelFactory();
     const noopLogger = {
       debug: () => {},
@@ -136,13 +136,13 @@ export async function registerExtOpenAIForTests(): Promise<void> {
   }
 }
 
-// Register the ext-mdx ContentTransformer contract. Delegates to the same
+// Register the ext-mdx ContentProcessor contract. Delegates to the same
 // helper used by unit-test side-effect imports — must run again after
 // resetAllTestState() or teardownAll().
 export async function registerExtMdxForTests(): Promise<void> {
   try {
     const { registerExtMdx } = await import(
-      "../../src/transforms/mdx/compiler/__tests__/content-transformer-setup.ts"
+      "../../src/transforms/mdx/compiler/__tests__/content-processor-setup.ts"
     );
     await registerExtMdx();
   } catch {
@@ -657,7 +657,7 @@ export class TestContext {
     }
 
     // Materialize ext-mdx into the project's extensions/ dir so that
-    // `discoverProjectExtensions` re-registers ContentTransformer after
+    // `discoverProjectExtensions` re-registers ContentProcessor after
     // bootstrap's teardownAll() wipes the contract registry.
     try {
       const extMdxDir = join(this.projectDir, "extensions", "ext-transform-mdx");

--- a/tests/integration/adapters/node.test.ts
+++ b/tests/integration/adapters/node.test.ts
@@ -6,7 +6,7 @@ import { NodeAdapter, nodeAdapter } from "#veryfront/platform/adapters/runtime/n
 import { startProductionServer } from "../../../src/server/production-server.ts";
 import { getFreePort } from "../../_helpers/utils.ts";
 import { makeTempDir, mkdir, remove, writeTextFile } from "#veryfront/testing/deno-compat";
-import { registerExtMdx } from "../../../src/transforms/mdx/compiler/__tests__/content-transformer-setup.ts";
+import { registerExtMdx } from "../../../src/transforms/mdx/compiler/__tests__/content-processor-setup.ts";
 
 // Note: Sanitizers disabled due to React 19 SSR MessagePort cleanup issue
 // See: https://github.com/facebook/react/issues/24669

--- a/tests/integration/server/module-handler-cache.test.ts
+++ b/tests/integration/server/module-handler-cache.test.ts
@@ -8,7 +8,7 @@ import { getAdapter } from "#veryfront/platform/adapters/detect.ts";
 import { ResponseBuilder } from "#veryfront/security/index.ts";
 import { cleanupBundler } from "../../../src/rendering/cleanup.ts";
 import { getConfig } from "#veryfront/config";
-import { registerExtMdx } from "../../../src/transforms/mdx/compiler/__tests__/content-transformer-setup.ts";
+import { registerExtMdx } from "../../../src/transforms/mdx/compiler/__tests__/content-processor-setup.ts";
 
 async function setupProject(): Promise<string> {
   const dir = await makeTempDir({ prefix: "vf_module_cache_" });


### PR DESCRIPTION
## Summary
- Rename the content extension contract from ContentTransformer to ContentProcessor and ContentRuntimeBundle to ContentProcessingResult across runtime code, extension metadata, tests, and CLI bootstrap.
- Update ext-transform-mdx docs and package metadata to describe content processing, including extraction of frontmatter and headings.
- Clarify extension docs by separating auto-enabled core extensions from contract requirements at call sites.

## Test Plan
- deno lint touched TS files
- deno check extensions/ext-transform-mdx/src/index.ts src/extensions/transform/index.ts src/transforms/mdx/compiler/index.ts src/transforms/md/compiler/md-compiler.ts cli/shared/ensure-content-processor.ts cli/commands/build/command.ts
- deno test --no-check --allow-all extensions/ext-transform-mdx/src/index.test.ts src/transforms/mdx/compiler/mdx-compiler.test.ts src/transforms/md/compiler/md-compiler.test.ts src/transforms/mdx/compiler/index.test.ts src/extensions/validation.test.ts src/extensions/orchestrate.test.ts src/extensions/loader.test.ts
- git diff --check
- pre-push hook: format, lint, type check, generate, and unit tests: 1849 passed, 0 failed

## Notes
- This is a public contract rename. External code using ContentTransformer will need to migrate to ContentProcessor.