### PR TITLE
feat(agent): extract project runtime discovery

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.515",
+  "version": "0.1.516",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -859,6 +859,18 @@ Project discovery uses this helper for `agents/*.md`, so markdown-defined
 agents are listed and invoked through the same registry and control-plane paths
 as code-defined agents.
 
+### `discoverProjectAgentRuntime(options)`
+
+Discover a project runtime's agent-facing primitives from `veryfront.config.ts`
+and the conventional `agents/`, `tools/`, `skills/`, `resources/`, `prompts/`,
+`workflows/`, and `tasks/` directories. The helper clears stale runtime
+registries before discovery, so project-agent runtimes and separately deployed
+agent services use the same discovery and default-agent selection semantics.
+
+Use `getProjectAgentRuntimeAgentIdCandidates()` plus
+`resolveSingleProjectAgentRuntimeAgentId()` when a host needs the convention
+where exactly one code or markdown agent becomes the default agent.
+
 ### `filterAgentTraceAttributes(attributes)`
 
 Filter an unknown attribute record down to OpenTelemetry-safe agent trace
@@ -1189,6 +1201,9 @@ Clear all stored messages from memory.
 | `parseAgentServiceChatRequestFromRequest`                             | Parse the agent-service chat request body and auth context               |
 | `loadRuntimeAgentMarkdownDefinitionFromFile`                          | Load and parse a markdown agent definition from an agents directory      |
 | `createRuntimeAgentFromMarkdownDefinition`                            | Convert a markdown agent definition into a runtime agent                 |
+| `discoverProjectAgentRuntime`                                         | Discover project agents and primitives for runtime hosts                 |
+| `getProjectAgentRuntimeAgentIdCandidates`                             | Split discovered runtime agents into code and markdown candidates        |
+| `resolveSingleProjectAgentRuntimeAgentId`                             | Resolve the single default runtime agent for a source policy             |
 | `parseAgentServiceConfig`                                             | Parse default agent service environment config                           |
 | `resolveAgentServiceRegistrationInput`                                | Resolve push runtime registration input from service config              |
 | `resolveNodeAgentServiceTelemetryConfig`                              | Resolve Node service OpenTelemetry config from environment               |

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -176,6 +176,19 @@ export {
 } from "./hosted-child-fork-tool-sources.ts";
 
 export {
+  clearProjectAgentRuntimeRegistries,
+  createRuntimeAgentDefinitionFromAgent,
+  describeProjectAgentRuntimeAgentIdCandidates,
+  discoverProjectAgentRuntime,
+  type DiscoverProjectAgentRuntimeInput,
+  doesProjectAgentRuntimeAgentMatchSource,
+  getProjectAgentRuntimeAgentIdCandidates,
+  type ProjectAgentRuntimeAgentIdCandidates,
+  type ProjectAgentRuntimeAgentSource,
+  resolveSingleProjectAgentRuntimeAgentId,
+} from "./project-agent-runtime.ts";
+
+export {
   createRuntimeAgentFromMarkdownDefinition,
   getRuntimeAgentMarkdownDefinition,
   isRuntimeAgentMarkdownAgent,

--- a/src/agent/project-agent-runtime.test.ts
+++ b/src/agent/project-agent-runtime.test.ts
@@ -1,0 +1,177 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { resolve } from "node:path";
+import { getMCPRegistry, registerPrompt, registerResource } from "#veryfront/mcp";
+import { nodeAdapter } from "#veryfront/platform/adapters/node.ts";
+import { defineSchema } from "#veryfront/schemas/index.ts";
+import { registerWorkflow, workflowRegistry } from "#veryfront/workflow/registry.ts";
+import { stop as stopEsbuild } from "veryfront/extensions/bundler";
+import { agent } from "./factory.ts";
+import {
+  createRuntimeAgentDefinitionFromAgent,
+  describeProjectAgentRuntimeAgentIdCandidates,
+  discoverProjectAgentRuntime,
+  doesProjectAgentRuntimeAgentMatchSource,
+  getProjectAgentRuntimeAgentIdCandidates,
+  resolveSingleProjectAgentRuntimeAgentId,
+} from "./project-agent-runtime.ts";
+import { createRuntimeAgentFromMarkdownDefinition } from "./runtime-agent-markdown-adapter.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void> | void): Promise<void> {
+  const dir = Deno.makeTempDirSync();
+  try {
+    await fn(dir);
+  } finally {
+    await stopEsbuild();
+    Deno.removeSync(dir, { recursive: true });
+  }
+}
+
+Deno.test("project agent runtime resolves code and markdown agent candidates", async () => {
+  const codeAgent = agent({
+    id: "coder",
+    name: "Coder",
+    description: "Code-defined agent",
+    model: "openai/gpt-5.4",
+    maxSteps: 7,
+    system: () => "Help from code.",
+  });
+  const markdownAgent = createRuntimeAgentFromMarkdownDefinition({
+    id: "writer",
+    name: "Writer",
+    description: "Markdown-defined agent",
+    instructions: "Help from markdown.",
+    model: "anthropic/claude-sonnet-4-5",
+    maxSteps: 4,
+  });
+
+  const candidates = getProjectAgentRuntimeAgentIdCandidates({
+    agents: new Map([
+      [markdownAgent.id, markdownAgent],
+      [codeAgent.id, codeAgent],
+    ]),
+  });
+
+  assertEquals(candidates, {
+    codeAgentIds: ["coder"],
+    markdownAgentIds: ["writer"],
+  });
+  assertEquals(describeProjectAgentRuntimeAgentIdCandidates(candidates), "coder, writer");
+  assertEquals(
+    resolveSingleProjectAgentRuntimeAgentId({ candidates, source: "code" }),
+    "coder",
+  );
+  assertEquals(
+    resolveSingleProjectAgentRuntimeAgentId({ candidates, source: "markdown" }),
+    "writer",
+  );
+  assertEquals(
+    resolveSingleProjectAgentRuntimeAgentId({ candidates, source: "auto" }),
+    null,
+  );
+  assertEquals(doesProjectAgentRuntimeAgentMatchSource(codeAgent, "code"), true);
+  assertEquals(doesProjectAgentRuntimeAgentMatchSource(codeAgent, "markdown"), false);
+  assertEquals(doesProjectAgentRuntimeAgentMatchSource(markdownAgent, "markdown"), true);
+
+  assertEquals(await createRuntimeAgentDefinitionFromAgent(codeAgent), {
+    id: "coder",
+    name: "Coder",
+    description: "Code-defined agent",
+    instructions: "Help from code.",
+    model: "openai/gpt-5.4",
+    maxSteps: 7,
+  });
+  assertEquals(await createRuntimeAgentDefinitionFromAgent(markdownAgent), {
+    id: "writer",
+    name: "Writer",
+    description: "Markdown-defined agent",
+    instructions: "Help from markdown.",
+    model: "anthropic/claude-sonnet-4-5",
+    maxSteps: 4,
+  });
+});
+
+Deno.test("discoverProjectAgentRuntime clears stale runtime registries before rediscovery", async () => {
+  await withTempDir(async (rootDir) => {
+    registerResource("stale-resource", {
+      id: "stale-resource",
+      pattern: "stale://resource",
+      description: "Stale resource",
+      paramsSchema: defineSchema((v) => v.object({}))(),
+      load: () => Promise.resolve({ ok: true }),
+    });
+    registerPrompt("stale-prompt", {
+      id: "stale-prompt",
+      description: "Stale prompt",
+      getContent: () => Promise.resolve("stale"),
+    });
+    registerWorkflow({ id: "stale-workflow", steps: [] });
+
+    await discoverProjectAgentRuntime({
+      projectDir: rootDir,
+      adapter: nodeAdapter,
+    });
+
+    assertEquals(getMCPRegistry().resources.has("stale-resource"), false);
+    assertEquals(getMCPRegistry().prompts.has("stale-prompt"), false);
+    assertEquals(workflowRegistry.has("stale-workflow"), false);
+  });
+});
+
+Deno.test("discoverProjectAgentRuntime discovers configured project agent paths", async () => {
+  await withTempDir(async (rootDir) => {
+    const agentsDir = resolve(rootDir, "crew");
+    const toolsDir = resolve(rootDir, "toolbox");
+    Deno.mkdirSync(agentsDir, { recursive: true });
+    Deno.mkdirSync(toolsDir, { recursive: true });
+    Deno.writeTextFileSync(
+      resolve(agentsDir, "support.md"),
+      `---
+name: Support
+model: openai/gpt-5.4
+---
+
+Help from configured markdown.
+`,
+    );
+    Deno.writeTextFileSync(
+      resolve(toolsDir, "echo.ts"),
+      [
+        'import { tool } from "veryfront/tool";',
+        'import { z } from "zod";',
+        "",
+        "export default tool({",
+        '  id: "echo",',
+        '  description: "Echo input",',
+        "  inputSchema: z.object({ text: z.string() }),",
+        "  execute: ({ text }) => ({ text }),",
+        "});",
+        "",
+      ].join("\n"),
+    );
+    Deno.writeTextFileSync(
+      resolve(rootDir, "veryfront.config.ts"),
+      [
+        "export default {",
+        "  ai: {",
+        '    agents: { discovery: { paths: ["crew"] } },',
+        '    tools: { discovery: { paths: ["toolbox"] } },',
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    const result = await discoverProjectAgentRuntime({
+      projectDir: rootDir,
+      adapter: nodeAdapter,
+    });
+
+    assertEquals([...result.agents.keys()], ["support"]);
+    assertEquals([...result.tools.keys()], ["echo"]);
+    assertEquals(getProjectAgentRuntimeAgentIdCandidates(result), {
+      codeAgentIds: [],
+      markdownAgentIds: ["support"],
+    });
+  });
+});

--- a/src/agent/project-agent-runtime.ts
+++ b/src/agent/project-agent-runtime.ts
@@ -1,0 +1,139 @@
+import type { DiscoveryResult } from "#veryfront/discovery";
+import {
+  clearTrackedAgents,
+  clearTranspileCache,
+  createProjectDiscoveryConfig,
+  discoverAll,
+} from "#veryfront/discovery";
+import { getConfig } from "#veryfront/config";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { clearMCPRegistry } from "#veryfront/mcp";
+import { workflowRegistry } from "#veryfront/workflow/registry.ts";
+import { agentRegistry } from "./composition/index.ts";
+import type { RuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
+import {
+  getRuntimeAgentMarkdownDefinition,
+  isRuntimeAgentMarkdownAgent,
+} from "./runtime-agent-markdown-adapter.ts";
+import type { Agent, AgentConfig } from "./types.ts";
+
+export type ProjectAgentRuntimeAgentSource = "auto" | "code" | "markdown";
+
+export type ProjectAgentRuntimeAgentIdCandidates = {
+  codeAgentIds: string[];
+  markdownAgentIds: string[];
+};
+
+export type DiscoverProjectAgentRuntimeInput = {
+  projectDir: string;
+  adapter: RuntimeAdapter;
+  verbose?: boolean;
+};
+
+function resolveAgentSystem(system: AgentConfig["system"]): Promise<string> | string {
+  return typeof system === "function" ? system() : system;
+}
+
+export function clearProjectAgentRuntimeRegistries(): void {
+  clearTrackedAgents();
+  clearTranspileCache();
+  agentRegistry.clear();
+  clearMCPRegistry();
+  workflowRegistry.clear();
+}
+
+export async function discoverProjectAgentRuntime(
+  input: DiscoverProjectAgentRuntimeInput,
+): Promise<DiscoveryResult> {
+  clearProjectAgentRuntimeRegistries();
+
+  const config = await getConfig(input.projectDir, input.adapter);
+  const discoveryOptions = createProjectDiscoveryConfig({
+    projectDir: input.projectDir,
+    config,
+    verbose: input.verbose,
+  });
+
+  return await discoverAll(discoveryOptions);
+}
+
+export function doesProjectAgentRuntimeAgentMatchSource(
+  runtimeAgent: Agent,
+  source: ProjectAgentRuntimeAgentSource,
+): boolean {
+  if (source === "auto") {
+    return true;
+  }
+
+  const markdownAgent = isRuntimeAgentMarkdownAgent(runtimeAgent);
+  return source === "markdown" ? markdownAgent : !markdownAgent;
+}
+
+export async function createRuntimeAgentDefinitionFromAgent(
+  runtimeAgent: Agent,
+): Promise<RuntimeAgentMarkdownDefinition> {
+  const markdownDefinition = getRuntimeAgentMarkdownDefinition(runtimeAgent);
+  if (markdownDefinition) {
+    return markdownDefinition;
+  }
+
+  return {
+    id: runtimeAgent.id,
+    name: runtimeAgent.config.name ?? runtimeAgent.id,
+    description: runtimeAgent.config.description ?? "",
+    instructions: await resolveAgentSystem(runtimeAgent.config.system),
+    model: runtimeAgent.config.model,
+    maxSteps: runtimeAgent.config.maxSteps,
+  };
+}
+
+export function getProjectAgentRuntimeAgentIdCandidates(
+  discoveryResult: Pick<DiscoveryResult, "agents"> | null | undefined,
+): ProjectAgentRuntimeAgentIdCandidates {
+  const codeAgentIds: string[] = [];
+  const markdownAgentIds: string[] = [];
+
+  for (const [agentId, runtimeAgent] of discoveryResult?.agents.entries() ?? []) {
+    if (isRuntimeAgentMarkdownAgent(runtimeAgent)) {
+      markdownAgentIds.push(agentId);
+    } else {
+      codeAgentIds.push(agentId);
+    }
+  }
+
+  return {
+    codeAgentIds: codeAgentIds.sort((left, right) => left.localeCompare(right)),
+    markdownAgentIds: markdownAgentIds.sort((left, right) => left.localeCompare(right)),
+  };
+}
+
+export function describeProjectAgentRuntimeAgentIdCandidates(
+  input: ProjectAgentRuntimeAgentIdCandidates,
+): string {
+  const ids = [...new Set([...input.codeAgentIds, ...input.markdownAgentIds])]
+    .sort((left, right) => left.localeCompare(right));
+
+  return ids.length > 0 ? ids.join(", ") : "none";
+}
+
+export function resolveSingleProjectAgentRuntimeAgentId(input: {
+  candidates: ProjectAgentRuntimeAgentIdCandidates;
+  source: ProjectAgentRuntimeAgentSource;
+}): string | null {
+  if (input.source === "code") {
+    return input.candidates.codeAgentIds.length === 1
+      ? input.candidates.codeAgentIds[0] ?? null
+      : null;
+  }
+
+  if (input.source === "markdown") {
+    return input.candidates.markdownAgentIds.length === 1
+      ? input.candidates.markdownAgentIds[0] ?? null
+      : null;
+  }
+
+  const candidateIds = [
+    ...new Set([...input.candidates.codeAgentIds, ...input.candidates.markdownAgentIds]),
+  ];
+  return candidateIds.length === 1 ? candidateIds[0] ?? null : null;
+}

--- a/src/agent/veryfront-cloud-agent-service.ts
+++ b/src/agent/veryfront-cloud-agent-service.ts
@@ -12,14 +12,7 @@ import {
   toolRegistry,
 } from "#veryfront/tool";
 import { parseProviderError } from "../chat/provider-errors.ts";
-import { getConfig } from "../config/index.ts";
-import {
-  clearTrackedAgents,
-  clearTranspileCache,
-  createProjectDiscoveryConfig,
-  DEFAULT_PROJECT_DISCOVERY_DIRS,
-  discoverAll,
-} from "../discovery/index.ts";
+import { DEFAULT_PROJECT_DISCOVERY_DIRS } from "../discovery/index.ts";
 import type { DiscoveryResult } from "../discovery/types.ts";
 import { nodeAdapter } from "../platform/adapters/node.ts";
 import {
@@ -70,9 +63,14 @@ import type { RuntimeProjectSteeringLookup } from "./runtime-project-skill-catal
 import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
 import type { RuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
 import {
-  getRuntimeAgentMarkdownDefinition,
-  isRuntimeAgentMarkdownAgent,
-} from "./runtime-agent-markdown-adapter.ts";
+  createRuntimeAgentDefinitionFromAgent,
+  describeProjectAgentRuntimeAgentIdCandidates,
+  discoverProjectAgentRuntime,
+  doesProjectAgentRuntimeAgentMatchSource,
+  getProjectAgentRuntimeAgentIdCandidates,
+  type ProjectAgentRuntimeAgentSource,
+  resolveSingleProjectAgentRuntimeAgentId,
+} from "./project-agent-runtime.ts";
 import {
   buildVeryfrontCloudRuntimeInstructions,
 } from "./veryfront-cloud-runtime-system-messages.ts";
@@ -109,8 +107,7 @@ import {
   prepareVeryfrontCloudHostedChatExecution,
 } from "./veryfront-cloud-hosted-chat-execution-preparation.ts";
 import { applyAgentProjectContextChange } from "./project-context.ts";
-import type { Agent, AgentConfig } from "./types.ts";
-import { agentRegistry, getAgent } from "./composition/index.ts";
+import { getAgent } from "./composition/index.ts";
 
 export type NodeVeryfrontCloudAgentServiceProcessTarget =
   & NonNullable<RunAgentServiceMainOptions["processTarget"]>
@@ -120,7 +117,7 @@ export type NodeVeryfrontCloudAgentServiceProcessTarget =
     exit?: (code: number) => never | void;
   };
 
-export type NodeVeryfrontCloudAgentServiceAgentSource = "auto" | "code" | "markdown";
+export type NodeVeryfrontCloudAgentServiceAgentSource = ProjectAgentRuntimeAgentSource;
 
 export type VeryfrontMcpServerKind = "api" | "studio";
 
@@ -394,23 +391,6 @@ function createNodeVeryfrontCloudAgentServiceContext(
   };
 }
 
-function resolveAgentSystem(system: AgentConfig["system"]): Promise<string> | string {
-  return typeof system === "function" ? system() : system;
-}
-
-async function createRuntimeAgentDefinitionFromCodeAgent(
-  codeAgent: Agent,
-): Promise<RuntimeAgentMarkdownDefinition> {
-  return {
-    id: codeAgent.id,
-    name: codeAgent.config.name ?? codeAgent.id,
-    description: codeAgent.config.description ?? "",
-    instructions: await resolveAgentSystem(codeAgent.config.system),
-    model: codeAgent.config.model,
-    maxSteps: codeAgent.config.maxSteps,
-  };
-}
-
 function getMarkdownAgentConfig(
   context: NodeVeryfrontCloudAgentServiceContext,
   agentId: string,
@@ -437,22 +417,14 @@ async function resolveAgentConfig(
   const source = context.options.agentSource ?? "auto";
   const codeAgent = getAgent(agentId);
 
-  if (source !== "markdown" && codeAgent && !isRuntimeAgentMarkdownAgent(codeAgent)) {
-    const agentConfig = await createRuntimeAgentDefinitionFromCodeAgent(codeAgent);
+  if (codeAgent && doesProjectAgentRuntimeAgentMatchSource(codeAgent, source)) {
+    const agentConfig = await createRuntimeAgentDefinitionFromAgent(codeAgent);
     context.agentConfigs.set(agentConfig.id, agentConfig);
     return agentConfig;
   }
 
   if (source === "code") {
     throw new Error(`Code agent "${agentId}" was not discovered.`);
-  }
-
-  const discoveredMarkdownDefinition = codeAgent
-    ? getRuntimeAgentMarkdownDefinition(codeAgent)
-    : null;
-  if (discoveredMarkdownDefinition) {
-    context.agentConfigs.set(discoveredMarkdownDefinition.id, discoveredMarkdownDefinition);
-    return discoveredMarkdownDefinition;
   }
 
   const agentConfig = loadMarkdownAgentConfig(context, agentId);
@@ -472,59 +444,10 @@ function getResolvedAgentConfig(
 async function discoverProjectPrimitives(
   context: NodeVeryfrontCloudAgentServiceContext,
 ): Promise<void> {
-  clearTrackedAgents();
-  clearTranspileCache();
-  agentRegistry.clear();
-  toolRegistry.clear();
-
-  const config = await getConfig(context.projectDir, nodeAdapter);
-  const discoveryOptions = createProjectDiscoveryConfig({
+  context.discoveryResult = await discoverProjectAgentRuntime({
     projectDir: context.projectDir,
-    config,
+    adapter: nodeAdapter,
   });
-
-  context.discoveryResult = await discoverAll(discoveryOptions);
-}
-
-function getDiscoveredCodeAgentIds(context: NodeVeryfrontCloudAgentServiceContext): string[] {
-  return [...(context.discoveryResult?.agents.entries() ?? [])]
-    .filter(([, discoveredAgent]) => !isRuntimeAgentMarkdownAgent(discoveredAgent))
-    .map(([id]) => id)
-    .sort((left, right) => left.localeCompare(right));
-}
-
-function getDiscoveredMarkdownAgentIds(context: NodeVeryfrontCloudAgentServiceContext): string[] {
-  return [...(context.discoveryResult?.agents.entries() ?? [])]
-    .filter(([, discoveredAgent]) => isRuntimeAgentMarkdownAgent(discoveredAgent))
-    .map(([id]) => id)
-    .sort((left, right) => left.localeCompare(right));
-}
-
-function describeAgentIdCandidates(input: {
-  codeAgentIds: string[];
-  markdownAgentIds: string[];
-}): string {
-  const ids = [...new Set([...input.codeAgentIds, ...input.markdownAgentIds])]
-    .sort((left, right) => left.localeCompare(right));
-
-  return ids.length > 0 ? ids.join(", ") : "none";
-}
-
-function resolveSingleAgentId(input: {
-  codeAgentIds: string[];
-  markdownAgentIds: string[];
-  source: NodeVeryfrontCloudAgentServiceAgentSource;
-}): string | null {
-  if (input.source === "code") {
-    return input.codeAgentIds.length === 1 ? input.codeAgentIds[0] ?? null : null;
-  }
-
-  if (input.source === "markdown") {
-    return input.markdownAgentIds.length === 1 ? input.markdownAgentIds[0] ?? null : null;
-  }
-
-  const candidateIds = [...new Set([...input.codeAgentIds, ...input.markdownAgentIds])];
-  return candidateIds.length === 1 ? candidateIds[0] ?? null : null;
 }
 
 function resolveDefaultAgentId(context: NodeVeryfrontCloudAgentServiceContext): string {
@@ -533,9 +456,8 @@ function resolveDefaultAgentId(context: NodeVeryfrontCloudAgentServiceContext): 
   }
 
   const source = context.options.agentSource ?? "auto";
-  const codeAgentIds = getDiscoveredCodeAgentIds(context);
-  const markdownAgentIds = getDiscoveredMarkdownAgentIds(context);
-  const agentId = resolveSingleAgentId({ codeAgentIds, markdownAgentIds, source });
+  const candidates = getProjectAgentRuntimeAgentIdCandidates(context.discoveryResult);
+  const agentId = resolveSingleProjectAgentRuntimeAgentId({ candidates, source });
 
   if (agentId) {
     return agentId;
@@ -544,7 +466,7 @@ function resolveDefaultAgentId(context: NodeVeryfrontCloudAgentServiceContext): 
   throw new Error(
     [
       "agentId is required when agent discovery does not resolve to exactly one agent.",
-      `Discovered agents: ${describeAgentIdCandidates({ codeAgentIds, markdownAgentIds })}.`,
+      `Discovered agents: ${describeProjectAgentRuntimeAgentIdCandidates(candidates)}.`,
     ].join(" "),
   );
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.515";
+export const VERSION = "0.1.516";


### PR DESCRIPTION
## Summary
- add reusable project-agent runtime discovery helpers for project agents and service runtimes
- make the Veryfront Cloud agent service use the shared discovery/default-agent resolution path
- document the new runtime discovery helpers and bump version to 0.1.516

## Verification
- deno fmt --check deno.json docs/reference/agent.md src/utils/version-constant.ts src/agent/index.ts src/agent/project-agent-runtime.ts src/agent/project-agent-runtime.test.ts src/agent/veryfront-cloud-agent-service.ts
- deno lint src/agent/project-agent-runtime.ts src/agent/project-agent-runtime.test.ts src/agent/veryfront-cloud-agent-service.ts src/agent/index.ts
- deno check src/agent/project-agent-runtime.ts src/agent/project-agent-runtime.test.ts src/agent/veryfront-cloud-agent-service.ts src/agent/index.ts
- deno test --no-check --allow-all --parallel src/agent/project-agent-runtime.test.ts src/agent/veryfront-cloud-agent-service.test.ts
- deno task verify:quick
- pre-push checks