### PR TITLE
Filter API MCP tools by access profile

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.517",
+  "version": "0.1.518",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -318,6 +318,13 @@ If `mcpServers` is omitted, the Veryfront Cloud preset includes
 `veryfrontMcpServer()` by default. Pass `mcpServers: []` to run without remote
 MCP tools.
 
+For `veryfrontMcpServer()`, the runtime reads the control-plane
+`tool_access` profile for the active project and filters mapped gated MCP tools
+before exposing them to the model. If the profile is stale or unavailable, the
+runtime hides mapped gated tools and leaves execution-time authorization to the
+API. Third-party MCP servers are not affected by this Veryfront-specific
+visibility profile.
+
 Control-plane registration is convention-first and explicit through environment
 variables. In `auto` mode, `startAgentService()` registers the service only when
 `VERYFRONT_API_TOKEN` and `VERYFRONT_AGENT_SERVICE_URL` are present. Set

--- a/src/agent/hosted/child-fork-tool-sources.test.ts
+++ b/src/agent/hosted/child-fork-tool-sources.test.ts
@@ -156,6 +156,12 @@ Deno.test("prepareDefaultHostedChildForkToolSources loads API, live Studio, and 
   assertEquals(switchedProjects, ["project-2"]);
   assertEquals(fixtures.executeCalls, [
     {
+      sourceId: "veryfront-mcp-fork",
+      toolName: "get_tool_access_profile",
+      args: { project_reference: "project-1" },
+      context: undefined,
+    },
+    {
       sourceId: "studio-mcp-live-tools",
       toolName: "studio_open_project",
       args: { project_id: "project-2" },
@@ -164,6 +170,62 @@ Deno.test("prepareDefaultHostedChildForkToolSources loads API, live Studio, and 
   ]);
 
   await result.closeStudioMcpTools?.();
+});
+
+Deno.test("prepareDefaultHostedChildForkToolSources filters API MCP tools with the tool access profile", async () => {
+  const createRemoteToolSource = (config: RemoteMCPToolSourceConfig): RemoteToolSource => ({
+    id: config.id ?? "source",
+    listTools: () =>
+      Promise.resolve([
+        remoteTool("create_server"),
+        remoteTool("delete_server"),
+        remoteTool("update_file"),
+      ]),
+    executeTool: (toolName, args) => {
+      if (toolName === "get_tool_access_profile") {
+        return Promise.resolve({
+          version: 1,
+          freshness: {
+            resolved_at: "2999-01-01T00:00:00.000Z",
+            valid_for_ms: 60_000,
+            fail_closed_on_expiry: true,
+          },
+          families: [
+            {
+              family: "runtime",
+              default_decision: {
+                visibility: "hidden",
+                reason_code: "billing_plan_restriction",
+              },
+              action_overrides: [
+                {
+                  action: "delete_server",
+                  decision: { visibility: "visible", reason_code: "allowed" },
+                },
+              ],
+            },
+          ],
+        });
+      }
+
+      return Promise.resolve({ success: true, project_id: args.project_id });
+    },
+  });
+
+  const result = await prepareDefaultHostedChildForkToolSources({
+    authToken: "token-1",
+    apiMcpUrl: "https://api.example/mcp",
+    mcpServers: [{ kind: "veryfront-api" }],
+    getProjectId: () => "project-1",
+    createRemoteToolSource,
+  });
+
+  assertEquals(result.ok, true);
+  if (!result.ok) {
+    return;
+  }
+
+  assertEquals(Object.keys(result.forkTools), ["delete_server", "update_file"]);
 });
 
 Deno.test("prepareDefaultHostedChildForkToolSources reports Studio setup failures", async () => {

--- a/src/agent/hosted/child-fork-tool-sources.ts
+++ b/src/agent/hosted/child-fork-tool-sources.ts
@@ -28,6 +28,7 @@ import {
   buildDefaultHostedChildForkToolSet,
   type DefaultHostedChildForkToolAssemblySourceResult,
 } from "./child-requested-tools.ts";
+import { filterVeryfrontApiToolDefinitionsWithAccessProfile } from "./veryfront-api-tool-access.ts";
 
 export type HostedChildForkToolSourcesLogger = {
   error: (message: string, metadata?: Record<string, unknown>) => void;
@@ -120,7 +121,14 @@ export async function prepareDefaultHostedChildForkToolSources(
         continue;
       }
       const remoteSource = createRemoteToolSource(remoteConfig);
-      const definitions = await remoteSource.listTools();
+      const rawDefinitions = await remoteSource.listTools();
+      const definitions = server.kind === "veryfront-api"
+        ? await filterVeryfrontApiToolDefinitionsWithAccessProfile({
+          source: remoteSource,
+          toolDefinitions: rawDefinitions,
+          projectId: input.getProjectId() ?? null,
+        })
+        : rawDefinitions;
       remoteMcpTools = {
         ...remoteMcpTools,
         ...materializeRemoteTools(remoteSource, definitions),

--- a/src/agent/hosted/project-remote-tool-source.test.ts
+++ b/src/agent/hosted/project-remote-tool-source.test.ts
@@ -39,6 +39,14 @@ function navigationTool(name: string): ToolDefinition {
   };
 }
 
+function simpleTool(name: string): ToolDefinition {
+  return {
+    name,
+    description: `${name} description`,
+    parameters: { type: "object", properties: {} },
+  };
+}
+
 function createRemoteSource(input: {
   id?: string;
   tools: ToolDefinition[];
@@ -260,6 +268,94 @@ Deno.test("createHostedProjectRemoteToolSources defaults to the Veryfront API MC
   assertEquals(configs.map((config) => config.endpoint), ["https://api.example/mcp"]);
 });
 
+Deno.test("createHostedProjectRemoteToolSources filters Veryfront API MCP tools with the tool access profile", async () => {
+  const executed: Array<{ toolName: string; args: unknown }> = [];
+  const sources = createHostedProjectRemoteToolSources({
+    authToken: "token-1",
+    apiMcpUrl: "https://api.example/mcp",
+    mcpServers: [{ kind: "veryfront-api" }],
+    getProjectId: () => "project-1",
+    createRemoteToolSource: (config) =>
+      createRemoteSource({
+        id: config.id,
+        tools: [
+          simpleTool("create_server"),
+          simpleTool("delete_server"),
+          simpleTool("update_file"),
+        ],
+        execute: (toolName, args) => {
+          executed.push({ toolName, args });
+          if (toolName === "get_tool_access_profile") {
+            return {
+              version: 1,
+              freshness: {
+                resolved_at: "2999-01-01T00:00:00.000Z",
+                valid_for_ms: 60_000,
+                fail_closed_on_expiry: true,
+              },
+              families: [
+                {
+                  family: "runtime",
+                  default_decision: {
+                    visibility: "hidden",
+                    reason_code: "billing_plan_restriction",
+                  },
+                  action_overrides: [
+                    {
+                      action: "delete_server",
+                      decision: { visibility: "visible", reason_code: "allowed" },
+                    },
+                  ],
+                },
+              ],
+            };
+          }
+          return { ok: true };
+        },
+      }),
+  });
+
+  assertEquals(
+    (await sources[0]?.listTools({ projectId: "project-1" }))?.map((tool) => tool.name),
+    ["delete_server", "update_file"],
+  );
+  assertEquals(executed, [
+    {
+      toolName: "get_tool_access_profile",
+      args: { project_reference: "project-1" },
+    },
+  ]);
+});
+
+Deno.test("createHostedProjectRemoteToolSources fails closed for mapped API tools when profile resolution fails", async () => {
+  const sources = createHostedProjectRemoteToolSources({
+    authToken: "token-1",
+    apiMcpUrl: "https://api.example/mcp",
+    mcpServers: [{ kind: "veryfront-api" }],
+    getProjectId: () => "project-1",
+    createRemoteToolSource: (config) =>
+      createRemoteSource({
+        id: config.id,
+        tools: [
+          simpleTool("create_invite"),
+          simpleTool("delete_member"),
+          simpleTool("update_file"),
+        ],
+        execute: (toolName) => {
+          if (toolName === "get_tool_access_profile") {
+            throw new Error("profile unavailable");
+          }
+          return { ok: true };
+        },
+      }),
+  });
+
+  assertEquals(
+    (await sources[0]?.listTools({ projectId: "project-1" }))?.map((tool) => tool.name),
+    ["update_file"],
+  );
+});
+
 Deno.test("createHostedProjectRemoteToolSources builds API and explicit gated Studio MCP sources", async () => {
   const configs: RemoteMCPToolSourceConfig[] = [];
   let activeProjectId = "project-1";
@@ -413,6 +509,11 @@ Deno.test("createHostedProjectRemoteToolSources applies project wrapper policy t
   await sources[1]?.executeTool("studio_open_project", { project_id: "project-2" });
 
   assertEquals(executed, [
+    {
+      toolName: "get_tool_access_profile",
+      args: { project_reference: "project-1" },
+      context: { projectId: "project-1" },
+    },
     {
       toolName: "update_file",
       args: { path: "AGENTS.md", prepared: true, project_reference: "project-1" },

--- a/src/agent/hosted/project-remote-tool-source.ts
+++ b/src/agent/hosted/project-remote-tool-source.ts
@@ -2,6 +2,7 @@ import {
   createProjectScopedRemoteToolCatalog,
   createRemoteMCPToolSource,
   isProjectNavigationRemoteTool,
+  type ProjectScopedRemoteToolCatalogOptions,
   type ProjectScopedRemoteToolDefaultProjectId,
   type ProjectScopedRemoteToolOptions,
   type RemoteMCPToolSourceConfig,
@@ -22,6 +23,7 @@ import {
   type ProjectSteeringMutationResult,
   type ProjectSteeringPaths,
 } from "../project-steering-mutation.ts";
+import { filterVeryfrontApiToolDefinitionsWithAccessProfile } from "./veryfront-api-tool-access.ts";
 
 export type HostedProjectRemoteToolSourceMutationHandler = (
   mutation: ProjectSteeringMutationResult,
@@ -51,6 +53,7 @@ export type CreateHostedProjectRemoteToolSourceInput = {
   getActiveBranchId?: () => string | null | undefined;
   allowedToolNames?: ReadonlySet<string> | null;
   projectScopedRemoteToolOptions?: ProjectScopedRemoteToolOptions;
+  filterToolDefinitions?: ProjectScopedRemoteToolCatalogOptions["filterToolDefinitions"];
   prepareToolInput?: HostedProjectRemoteToolSourcePrepareToolInput;
   retryToolName?: string;
   shouldRetryWithTool?: HostedProjectRemoteToolSourceRetryPolicy;
@@ -73,6 +76,7 @@ export function createHostedProjectRemoteToolSource(
     defaultProjectId: input.defaultProjectId,
     allowedToolNames: input.allowedToolNames,
     projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions,
+    filterToolDefinitions: input.filterToolDefinitions,
   });
   const retryToolName = input.retryToolName ?? "update_file";
 
@@ -202,6 +206,7 @@ export type CreateHostedProjectRemoteToolSourcesInput =
 
 function createHostedProjectRemoteToolSourceFromConfig(
   input: CreateHostedProjectRemoteToolSourcesInput,
+  server: AgentServiceMcpServerConfig,
   source: RemoteToolSource,
   onProjectSwitch?: HostedProjectRemoteToolSourceProjectSwitchHandler,
 ): RemoteToolSource {
@@ -214,6 +219,17 @@ function createHostedProjectRemoteToolSourceFromConfig(
     ...(input.allowedToolNames !== undefined ? { allowedToolNames: input.allowedToolNames } : {}),
     ...(input.projectScopedRemoteToolOptions !== undefined
       ? { projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions }
+      : {}),
+    ...(server.kind === "veryfront-api"
+      ? {
+        filterToolDefinitions: ({ source, toolDefinitions, activeProjectId, context }) =>
+          filterVeryfrontApiToolDefinitionsWithAccessProfile({
+            source,
+            toolDefinitions,
+            projectId: activeProjectId,
+            context,
+          }),
+      }
       : {}),
     ...(input.prepareToolInput !== undefined ? { prepareToolInput: input.prepareToolInput } : {}),
     ...(input.retryToolName !== undefined ? { retryToolName: input.retryToolName } : {}),
@@ -252,6 +268,7 @@ export function createHostedProjectRemoteToolSources(
     sources.push(
       createHostedProjectRemoteToolSourceFromConfig(
         input,
+        server,
         createRemoteToolSource(remoteConfig),
         server.kind === "veryfront-studio" ? input.onStudioProjectSwitch : undefined,
       ),

--- a/src/agent/hosted/veryfront-api-tool-access.test.ts
+++ b/src/agent/hosted/veryfront-api-tool-access.test.ts
@@ -1,0 +1,149 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import type { ToolDefinition } from "#veryfront/tool";
+import {
+  filterVeryfrontApiToolDefinitionsByAccessProfile,
+  filterVeryfrontApiToolDefinitionsWithAccessProfile,
+  parseVeryfrontApiToolAccessProfile,
+} from "./veryfront-api-tool-access.ts";
+
+function remoteTool(name: string): ToolDefinition {
+  return {
+    name,
+    description: `${name} description`,
+    parameters: { type: "object", properties: {} },
+  };
+}
+
+function profile(input: {
+  createServerVisibility: "visible" | "hidden";
+  deleteServerVisibility: "visible" | "hidden";
+  resolvedAt?: string;
+  validForMs?: number;
+}) {
+  return {
+    version: 1,
+    freshness: {
+      resolved_at: input.resolvedAt ?? "2026-01-01T00:00:00.000Z",
+      valid_for_ms: input.validForMs ?? 60_000,
+      fail_closed_on_expiry: true,
+    },
+    families: [
+      {
+        family: "runtime",
+        default_decision: {
+          visibility: "hidden",
+          reason_code: "billing_plan_restriction",
+        },
+        action_overrides: [
+          {
+            action: "create_server",
+            decision: {
+              visibility: input.createServerVisibility,
+              reason_code: input.createServerVisibility === "visible"
+                ? "allowed"
+                : "billing_plan_restriction",
+            },
+          },
+          {
+            action: "delete_server",
+            decision: {
+              visibility: input.deleteServerVisibility,
+              reason_code: input.deleteServerVisibility === "visible"
+                ? "allowed"
+                : "billing_plan_restriction",
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+Deno.test("parseVeryfrontApiToolAccessProfile parses the API-owned snake_case contract", () => {
+  assertEquals(
+    parseVeryfrontApiToolAccessProfile(profile({
+      createServerVisibility: "hidden",
+      deleteServerVisibility: "visible",
+    })),
+    {
+      version: 1,
+      freshness: {
+        resolvedAt: "2026-01-01T00:00:00.000Z",
+        validForMs: 60_000,
+        failClosedOnExpiry: true,
+      },
+      families: [
+        {
+          family: "runtime",
+          defaultDecision: {
+            visibility: "hidden",
+            reasonCode: "billing_plan_restriction",
+          },
+          actionOverrides: [
+            {
+              action: "create_server",
+              decision: {
+                visibility: "hidden",
+                reasonCode: "billing_plan_restriction",
+              },
+            },
+            {
+              action: "delete_server",
+              decision: {
+                visibility: "visible",
+                reasonCode: "allowed",
+              },
+            },
+          ],
+        },
+      ],
+    },
+  );
+});
+
+Deno.test("filterVeryfrontApiToolDefinitionsByAccessProfile applies action overrides only to mapped API tools", () => {
+  const parsed = parseVeryfrontApiToolAccessProfile(profile({
+    createServerVisibility: "hidden",
+    deleteServerVisibility: "visible",
+  }));
+
+  assertEquals(
+    filterVeryfrontApiToolDefinitionsByAccessProfile({
+      toolDefinitions: [
+        remoteTool("create_server"),
+        remoteTool("delete_server"),
+        remoteTool("update_file"),
+      ],
+      profile: parsed,
+    }).map((tool) => tool.name),
+    ["delete_server", "update_file"],
+  );
+});
+
+Deno.test("filterVeryfrontApiToolDefinitionsWithAccessProfile fails closed for mapped tools when the profile is stale", async () => {
+  const source = {
+    id: "veryfront-mcp",
+    listTools: () => Promise.resolve([]),
+    executeTool: () =>
+      Promise.resolve(profile({
+        createServerVisibility: "visible",
+        deleteServerVisibility: "visible",
+        resolvedAt: "2026-01-01T00:00:00.000Z",
+        validForMs: 1,
+      })),
+  };
+
+  assertEquals(
+    (await filterVeryfrontApiToolDefinitionsWithAccessProfile({
+      source,
+      projectId: "project-1",
+      nowMs: Date.parse("2026-01-01T00:00:01.000Z"),
+      toolDefinitions: [
+        remoteTool("create_server"),
+        remoteTool("delete_server"),
+        remoteTool("update_file"),
+      ],
+    })).map((tool) => tool.name),
+    ["update_file"],
+  );
+});

--- a/src/agent/hosted/veryfront-api-tool-access.ts
+++ b/src/agent/hosted/veryfront-api-tool-access.ts
@@ -1,0 +1,293 @@
+import type { RemoteToolSource, ToolDefinition, ToolExecutionContext } from "#veryfront/tool";
+
+export type VeryfrontApiToolAccessVisibility = "visible" | "hidden";
+export type VeryfrontApiToolAccessFamily = "collaboration" | "runtime" | "domains" | "export";
+export type VeryfrontApiToolAccessAction =
+  | "create_invite"
+  | "delete_member"
+  | "create_server"
+  | "delete_server"
+  | "create_domain"
+  | "download_release";
+
+export type VeryfrontApiToolAccessDecision = {
+  visibility: VeryfrontApiToolAccessVisibility;
+  reasonCode: string;
+};
+
+export type VeryfrontApiToolAccessActionOverride = {
+  action: VeryfrontApiToolAccessAction;
+  decision: VeryfrontApiToolAccessDecision;
+};
+
+export type VeryfrontApiToolAccessFamilyProfile = {
+  family: VeryfrontApiToolAccessFamily;
+  defaultDecision: VeryfrontApiToolAccessDecision;
+  actionOverrides: VeryfrontApiToolAccessActionOverride[];
+};
+
+export type VeryfrontApiToolAccessProfile = {
+  version: 1;
+  freshness: {
+    resolvedAt: string;
+    validForMs: number;
+    failClosedOnExpiry: true;
+  };
+  families: VeryfrontApiToolAccessFamilyProfile[];
+};
+
+type VeryfrontApiToolAccessRule = {
+  family: VeryfrontApiToolAccessFamily;
+  action: VeryfrontApiToolAccessAction;
+};
+
+type FilterMode = "open" | "closed";
+
+const TOOL_ACCESS_PROFILE_TOOL_NAME = "get_tool_access_profile";
+
+const toolAccessRules = new Map<string, VeryfrontApiToolAccessRule>([
+  ["create_invite", { family: "collaboration", action: "create_invite" }],
+  ["delete_member", { family: "collaboration", action: "delete_member" }],
+  ["create_server", { family: "runtime", action: "create_server" }],
+  ["delete_server", { family: "runtime", action: "delete_server" }],
+  ["create_domain", { family: "domains", action: "create_domain" }],
+  ["download_release", { family: "export", action: "download_release" }],
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function getStringProperty(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" ? value : null;
+}
+
+function getNumberProperty(record: Record<string, unknown>, key: string): number | null {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function parseVisibility(value: string | null): VeryfrontApiToolAccessVisibility | null {
+  return value === "visible" || value === "hidden" ? value : null;
+}
+
+function parseFamily(value: string | null): VeryfrontApiToolAccessFamily | null {
+  return value === "collaboration" || value === "runtime" || value === "domains" ||
+      value === "export"
+    ? value
+    : null;
+}
+
+function parseAction(value: string | null): VeryfrontApiToolAccessAction | null {
+  return value === "create_invite" || value === "delete_member" ||
+      value === "create_server" || value === "delete_server" || value === "create_domain" ||
+      value === "download_release"
+    ? value
+    : null;
+}
+
+function parseDecision(value: unknown): VeryfrontApiToolAccessDecision | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const visibility = parseVisibility(getStringProperty(value, "visibility"));
+  const reasonCode = getStringProperty(value, "reason_code");
+  if (!visibility || !reasonCode) {
+    return null;
+  }
+
+  return { visibility, reasonCode };
+}
+
+function parseActionOverride(value: unknown): VeryfrontApiToolAccessActionOverride | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const action = parseAction(getStringProperty(value, "action"));
+  const decision = parseDecision(value.decision);
+  if (!action || !decision) {
+    return null;
+  }
+
+  return { action, decision };
+}
+
+function parseActionOverrides(value: unknown): VeryfrontApiToolAccessActionOverride[] | null {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const overrides: VeryfrontApiToolAccessActionOverride[] = [];
+  for (const entry of value) {
+    const override = parseActionOverride(entry);
+    if (!override) {
+      return null;
+    }
+    overrides.push(override);
+  }
+  return overrides;
+}
+
+function parseFamilyProfile(value: unknown): VeryfrontApiToolAccessFamilyProfile | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const family = parseFamily(getStringProperty(value, "family"));
+  const defaultDecision = parseDecision(value.default_decision);
+  const actionOverrides = parseActionOverrides(value.action_overrides);
+  if (!family || !defaultDecision || !actionOverrides) {
+    return null;
+  }
+
+  return {
+    family,
+    defaultDecision,
+    actionOverrides,
+  };
+}
+
+function parseFamilies(value: unknown): VeryfrontApiToolAccessFamilyProfile[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const families: VeryfrontApiToolAccessFamilyProfile[] = [];
+  for (const entry of value) {
+    const family = parseFamilyProfile(entry);
+    if (!family) {
+      return null;
+    }
+    families.push(family);
+  }
+  return families;
+}
+
+export function parseVeryfrontApiToolAccessProfile(
+  value: unknown,
+): VeryfrontApiToolAccessProfile | null {
+  if (!isRecord(value) || value.version !== 1 || !isRecord(value.freshness)) {
+    return null;
+  }
+
+  const resolvedAt = getStringProperty(value.freshness, "resolved_at");
+  const validForMs = getNumberProperty(value.freshness, "valid_for_ms");
+  const failClosedOnExpiry = value.freshness.fail_closed_on_expiry;
+  const families = parseFamilies(value.families);
+  if (!resolvedAt || validForMs === null || failClosedOnExpiry !== true || !families) {
+    return null;
+  }
+
+  return {
+    version: 1,
+    freshness: {
+      resolvedAt,
+      validForMs,
+      failClosedOnExpiry,
+    },
+    families,
+  };
+}
+
+export function isVeryfrontApiToolAccessProfileFresh(
+  profile: VeryfrontApiToolAccessProfile,
+  nowMs = Date.now(),
+): boolean {
+  const resolvedAtMs = Date.parse(profile.freshness.resolvedAt);
+  if (!Number.isFinite(resolvedAtMs)) {
+    return false;
+  }
+
+  return nowMs <= resolvedAtMs + profile.freshness.validForMs;
+}
+
+function getToolAccessDecision(
+  profile: VeryfrontApiToolAccessProfile,
+  rule: VeryfrontApiToolAccessRule,
+): VeryfrontApiToolAccessDecision | null {
+  const family = profile.families.find((candidate) => candidate.family === rule.family);
+  if (!family) {
+    return null;
+  }
+
+  return family.actionOverrides.find((override) => override.action === rule.action)?.decision ??
+    family.defaultDecision;
+}
+
+export function shouldExposeVeryfrontApiTool(
+  profile: VeryfrontApiToolAccessProfile | null,
+  toolName: string,
+  mode: FilterMode = "open",
+): boolean {
+  const rule = toolAccessRules.get(toolName);
+  if (!rule) {
+    return true;
+  }
+
+  if (!profile) {
+    return mode === "open";
+  }
+
+  const decision = getToolAccessDecision(profile, rule);
+  return decision?.visibility === "visible";
+}
+
+export function filterVeryfrontApiToolDefinitionsByAccessProfile(input: {
+  toolDefinitions: readonly ToolDefinition[];
+  profile: VeryfrontApiToolAccessProfile | null;
+  mode?: FilterMode;
+}): ToolDefinition[] {
+  return input.toolDefinitions.filter((toolDefinition) =>
+    shouldExposeVeryfrontApiTool(input.profile, toolDefinition.name, input.mode ?? "open")
+  );
+}
+
+export async function fetchVeryfrontApiToolAccessProfile(input: {
+  source: RemoteToolSource;
+  projectId: string;
+  context?: ToolExecutionContext;
+}): Promise<VeryfrontApiToolAccessProfile | null> {
+  const rawProfile = await input.source.executeTool(
+    TOOL_ACCESS_PROFILE_TOOL_NAME,
+    { project_reference: input.projectId },
+    input.context,
+  );
+  return parseVeryfrontApiToolAccessProfile(rawProfile);
+}
+
+export async function filterVeryfrontApiToolDefinitionsWithAccessProfile(input: {
+  source: RemoteToolSource;
+  toolDefinitions: readonly ToolDefinition[];
+  projectId: string | null;
+  context?: ToolExecutionContext;
+  nowMs?: number;
+}): Promise<ToolDefinition[]> {
+  if (!input.projectId) {
+    return [...input.toolDefinitions];
+  }
+
+  try {
+    const profile = await fetchVeryfrontApiToolAccessProfile({
+      source: input.source,
+      projectId: input.projectId,
+      context: input.context,
+    });
+    if (profile && isVeryfrontApiToolAccessProfileFresh(profile, input.nowMs)) {
+      return filterVeryfrontApiToolDefinitionsByAccessProfile({
+        toolDefinitions: input.toolDefinitions,
+        profile,
+      });
+    }
+  } catch {
+    // Fall through to fail-closed visibility for mapped API-owned tools.
+  }
+
+  return filterVeryfrontApiToolDefinitionsByAccessProfile({
+    toolDefinitions: input.toolDefinitions,
+    profile: null,
+    mode: "closed",
+  });
+}

--- a/src/tool/project-scoped-remote-tools.ts
+++ b/src/tool/project-scoped-remote-tools.ts
@@ -15,6 +15,12 @@ export type ProjectScopedRemoteToolCatalogOptions = {
   defaultProjectId?: ProjectScopedRemoteToolDefaultProjectId;
   allowedToolNames?: ReadonlySet<string> | null;
   projectScopedRemoteToolOptions?: ProjectScopedRemoteToolOptions;
+  filterToolDefinitions?: (input: {
+    source: RemoteToolSource;
+    toolDefinitions: readonly ToolDefinition[];
+    activeProjectId: string | null;
+    context?: ToolExecutionContext;
+  }) => Promise<ToolDefinition[]> | ToolDefinition[];
 };
 
 export type ProjectScopedRemoteToolDefinitions = {
@@ -191,7 +197,10 @@ export function createProjectScopedRemoteToolCatalog(
       resolveDefaultProjectId(input.defaultProjectId),
     );
 
-    if (cachedToolDefinitions && cachedProjectId === activeProjectId) {
+    if (
+      !input.filterToolDefinitions && cachedToolDefinitions &&
+      cachedProjectId === activeProjectId
+    ) {
       return {
         activeProjectId,
         toolDefinitions: cachedToolDefinitions,
@@ -199,14 +208,24 @@ export function createProjectScopedRemoteToolCatalog(
     }
 
     const sourceContext = withActiveProjectContext(context, activeProjectId);
-    const toolDefinitions = filterProjectScopedRemoteToolDefinitions(
+    const scopedToolDefinitions = filterProjectScopedRemoteToolDefinitions(
       await input.source.listTools(sourceContext),
       activeProjectId,
       input.projectScopedRemoteToolOptions,
     );
+    const toolDefinitions = input.filterToolDefinitions
+      ? await input.filterToolDefinitions({
+        source: input.source,
+        toolDefinitions: scopedToolDefinitions,
+        activeProjectId,
+        context: sourceContext,
+      })
+      : scopedToolDefinitions;
 
-    cachedProjectId = activeProjectId;
-    cachedToolDefinitions = toolDefinitions;
+    if (!input.filterToolDefinitions) {
+      cachedProjectId = activeProjectId;
+      cachedToolDefinitions = toolDefinitions;
+    }
 
     return {
       activeProjectId,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.517";
+export const VERSION = "0.1.518";


### PR DESCRIPTION
## Summary
- add a Veryfront API tool access profile consumer for hosted remote MCP tool listings
- filter mapped gated API MCP tools in parent and child runtime tool assembly, with fail-closed behavior for stale or unavailable profiles
- document the control-plane visibility profile behavior and bump the package patch version to 0.1.518

## Testing
- deno test --no-check --allow-all src/agent/hosted/veryfront-api-tool-access.test.ts src/agent/hosted/project-remote-tool-source.test.ts src/agent/hosted/child-fork-tool-sources.test.ts src/agent/hosted/chat-runtime-tool-assembly.test.ts
- deno check src/agent/hosted/veryfront-api-tool-access.ts src/agent/hosted/project-remote-tool-source.ts src/agent/hosted/child-fork-tool-sources.ts src/tool/project-scoped-remote-tools.ts
- VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --parallel --unstable-worker-options --ignore=tests --ignore=src/workflow/__tests__ --ignore=cli/commands/*.integration.test.ts
- deno lint src/agent/hosted/veryfront-api-tool-access.ts src/agent/hosted/veryfront-api-tool-access.test.ts src/agent/hosted/project-remote-tool-source.ts src/agent/hosted/project-remote-tool-source.test.ts src/agent/hosted/child-fork-tool-sources.ts src/agent/hosted/child-fork-tool-sources.test.ts src/tool/project-scoped-remote-tools.ts
- git diff --check
