### PR TITLE
Fix npm agent service tool dependency

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.518",
+  "version": "0.1.519",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -134,6 +134,7 @@ await build({
 		dependencies: {
 			"@types/react": "^19.0.0",
 			"@types/react-dom": "^19.0.0",
+			"ai": "^6.0.13",
 			"bash-tool": "^1.3.16",
 			"ws": "^8.18.0",
 			"@kreuzberg/node": "^4.4.2",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.518";
+export const VERSION = "0.1.519";


### PR DESCRIPTION
## Summary
- add `ai` to generated npm dependencies because the default sandbox tool factory loads `bash-tool`, whose skill tool imports `ai` at runtime
- bump framework patch version to 0.1.519

## Verification
- deno task build:npm
- deno test --no-check --allow-all --unstable-worker-options src/utils/version.test.ts
- pre-push checks: format, lint, typecheck, unit tests
