### PR TITLE
Improve dependency SBOM boundaries

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -333,7 +333,7 @@ jobs:
       - name: Generate SBOM
         env:
           VERSION: ${{ steps.version.outputs.version }}
-        run: deno task sbom --output "dist/sbom-${VERSION}.json"
+        run: deno task sbom:all --output-dir "dist/sbom-${VERSION}"
 
       - name: Create GitHub pre-release
         env:
@@ -345,7 +345,12 @@ jobs:
           for f in binaries/veryfront-*/veryfront-*; do
             [ -f "$f" ] && BINARIES="$BINARIES $f"
           done
+          SBOMS=""
+          for f in dist/sbom-${VERSION}/*.json; do
+            [ -f "$f" ] && SBOMS="$SBOMS $f"
+          done
           echo "Available binaries: $BINARIES"
+          echo "Available SBOMs: $SBOMS"
 
           # Delete previous rc release if it exists (from earlier merge)
           gh release delete "v${VERSION}" --repo veryfront/veryfront --yes --cleanup-tag 2>/dev/null || true
@@ -360,7 +365,7 @@ jobs:
           ```' \
             $BINARIES \
             scripts/install.sh \
-            "dist/sbom-${VERSION}.json"
+            $SBOMS
 
       - name: Trigger server deploy
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
@@ -435,7 +440,7 @@ jobs:
       - name: Generate SBOM
         env:
           VERSION: ${{ steps.version.outputs.version }}
-        run: deno task sbom --output "dist/sbom-${VERSION}.json"
+        run: deno task sbom:all --output-dir "dist/sbom-${VERSION}"
 
       - name: Create git tag
         env:
@@ -460,7 +465,12 @@ jobs:
           for f in binaries/veryfront-*/veryfront-*; do
             [ -f "$f" ] && BINARIES="$BINARIES $f"
           done
+          SBOMS=""
+          for f in dist/sbom-${VERSION}/*.json; do
+            [ -f "$f" ] && SBOMS="$SBOMS $f"
+          done
           echo "Available binaries: $BINARIES"
+          echo "Available SBOMs: $SBOMS"
 
           # Clean up rc pre-releases (created by the prerelease job on main pushes)
           gh release list --repo veryfront/veryfront --json tagName -q ".[].tagName" \
@@ -486,7 +496,7 @@ jobs:
               $BINARIES \
               scripts/install.sh \
               scripts/install.ps1 \
-              "dist/sbom-${VERSION}.json"
+              $SBOMS
           fi
 
       - name: Create source repo release

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
     paths:
       - "deno.json"
+      - "cli/deno.json"
+      - "extensions/**/deno.json"
+      - "scripts/build/generate-sbom.ts"
+      - "scripts/lib/deno-lock.ts"
+      - "scripts/lint/audit-deps.ts"
+      - "scripts/security/**"
+      - ".github/workflows/security-audit.yml"
   push:
     # No path filter: deno.lock is gitignored, and `npm:` specifiers live both
     # in deno.json and inline in source files. A broad trigger keeps the
@@ -31,6 +38,15 @@ jobs:
 
       - name: Run dependency lint
         run: deno task lint:deps
+
+      - name: Generate separated dependency SBOMs
+        run: deno task sbom:all --output-dir dist/dependency-sboms
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: dependency-sboms
+          path: dist/dependency-sboms/*.json
+          retention-days: 14
 
   submit-dependency-snapshot:
     # Only push/schedule/manual — PRs from forks lack write access.

--- a/deno.json
+++ b/deno.json
@@ -358,7 +358,7 @@
     "lint:wildcard-exports": "deno run --allow-read scripts/lint/ban-wildcard-exports.ts",
     "lint:deps": "deno run --allow-read scripts/lint/audit-deps.ts",
     "lint:barrel-jsdoc": "deno run --allow-read scripts/lint/check-barrel-jsdoc.ts",
-    "test:scripts": "deno test --config=scripts/test.deno.json --no-check --allow-read scripts/build/generate-sbom.test.ts scripts/lint/audit-core-deps.test.ts scripts/lint/audit-deps.test.ts scripts/security/submit-dependency-snapshot.test.ts",
+    "test:scripts": "deno test --config=scripts/test.deno.json --no-check --allow-read scripts/build/generate-sbom.test.ts scripts/lint/audit-core-deps.test.ts scripts/lint/audit-deps.test.ts scripts/security/audit-npm.test.ts scripts/security/submit-dependency-snapshot.test.ts",
     "test:cross-runtime": "deno run --allow-all src/platform/compat/cross-runtime.test.ts",
     "test:node": "node ./tests/node/run-tests.mjs 'src/**/*.test.ts'",
     "test:bun": "node ./tests/bun/run-tests.mjs src/",
@@ -384,6 +384,7 @@
     "start-split": "deno task generate && deno run --allow-all cli/main.ts serve --split",
     "start-split:binary": "deno task generate && deno run --allow-all cli/main.ts serve --split --binary",
     "sbom": "deno run --allow-read --allow-write scripts/build/generate-sbom.ts",
+    "sbom:all": "deno run --allow-read --allow-write scripts/build/generate-sbom.ts --all-manifests",
     "submit-deps": "deno run --allow-read --allow-env --allow-net=api.github.com scripts/security/submit-dependency-snapshot.ts",
     "audit": "deno run --allow-read --allow-run --allow-write scripts/security/audit-npm.ts"
   },

--- a/scripts/build/generate-sbom.test.ts
+++ b/scripts/build/generate-sbom.test.ts
@@ -3,6 +3,8 @@ import { describe, it } from "jsr:@std/testing/bdd";
 import {
   componentsFromLock,
   componentsFromLockForManifest,
+  dependencyIndexForAllManifests,
+  sbomOutputsForAllManifests,
   SUPPORTED_LOCK_VERSIONS,
 } from "./generate-sbom.ts";
 
@@ -123,6 +125,120 @@ describe("componentsFromLock", () => {
         "extensions/ext-sandbox-shell-tools/deno.json",
       ).map((component) => component.name),
       ["bash-tool"],
+    );
+  });
+
+  it("plans an aggregate SBOM plus one SBOM per workspace manifest", () => {
+    const lock = JSON.stringify({
+      version: "5",
+      specifiers: {
+        "npm:react@19.2.4": "19.2.4",
+        "npm:bash-tool@1.3.16": "1.3.16",
+      },
+      npm: {
+        "react@19.2.4": { integrity: "sha512-react", dependencies: [] },
+        "bash-tool@1.3.16": { integrity: "sha512-shell", dependencies: [] },
+      },
+      workspace: {
+        dependencies: ["npm:react@19.2.4"],
+        members: {
+          "extensions/ext-sandbox-shell-tools": {
+            dependencies: ["npm:bash-tool@1.3.16"],
+          },
+        },
+      },
+    });
+
+    const outputs = sbomOutputsForAllManifests(lock, {
+      outputDir: "dist/sbom-0.1.519",
+      workspaceMembers: [
+        "cli",
+        "extensions/ext-sandbox-shell-tools",
+      ],
+    });
+
+    assertEquals(
+      outputs.map((output) => output.path),
+      [
+        "dist/sbom-0.1.519/all.json",
+        "dist/sbom-0.1.519/core.json",
+        "dist/sbom-0.1.519/cli.json",
+        "dist/sbom-0.1.519/ext-sandbox-shell-tools.json",
+      ],
+    );
+    assertEquals(
+      outputs.map((output) => output.componentName),
+      [
+        "veryfront",
+        "veryfront:deno.json",
+        "veryfront:cli/deno.json",
+        "veryfront:extensions/ext-sandbox-shell-tools/deno.json",
+      ],
+    );
+    assertEquals(outputs[0].components.map((component) => component.name), [
+      "bash-tool",
+      "react",
+    ]);
+    assertEquals(outputs[1].components.map((component) => component.name), [
+      "react",
+    ]);
+    assertEquals(outputs[2].components, []);
+    assertEquals(outputs[3].components.map((component) => component.name), [
+      "bash-tool",
+    ]);
+  });
+
+  it("builds a dependency index grouped by core, cli, and extension manifests", () => {
+    const lock = JSON.stringify({
+      version: "5",
+      specifiers: {
+        "npm:react@19.2.4": "19.2.4",
+        "npm:bash-tool@1.3.16": "1.3.16",
+      },
+      npm: {
+        "react@19.2.4": { integrity: "sha512-react", dependencies: [] },
+        "bash-tool@1.3.16": { integrity: "sha512-shell", dependencies: [] },
+      },
+      workspace: {
+        dependencies: ["npm:react@19.2.4"],
+        members: {
+          "extensions/ext-sandbox-shell-tools": {
+            dependencies: ["npm:bash-tool@1.3.16"],
+          },
+        },
+      },
+    });
+
+    const index = dependencyIndexForAllManifests(lock, {
+      workspaceMembers: [
+        "cli",
+        "extensions/ext-sandbox-shell-tools",
+      ],
+    });
+
+    assertEquals(
+      index.manifests.map((manifest) => ({
+        sourceLocation: manifest.sourceLocation,
+        group: manifest.group,
+        componentNames: manifest.components.map((component) => component.name),
+      })),
+      [
+        {
+          sourceLocation: "deno.json",
+          group: "core",
+          componentNames: ["react"],
+        },
+        {
+          sourceLocation: "cli/deno.json",
+          group: "cli",
+          componentNames: [],
+        },
+        {
+          sourceLocation: "extensions/ext-sandbox-shell-tools/deno.json",
+          group: "extension",
+          componentNames: ["bash-tool"],
+        },
+      ],
     );
   });
 });

--- a/scripts/build/generate-sbom.ts
+++ b/scripts/build/generate-sbom.ts
@@ -3,6 +3,8 @@
  *
  * Usage: deno run --allow-read --allow-write scripts/build/generate-sbom.ts [--output path]
  *        deno run --allow-read --allow-write scripts/build/generate-sbom.ts \
+ *          --all-manifests --output-dir dist/sbom
+ *        deno run --allow-read --allow-write scripts/build/generate-sbom.ts \
  *          --manifest extensions/ext-sandbox-shell-tools/deno.json \
  *          --output dist/sbom-ext-sandbox-shell-tools.json
  *
@@ -17,7 +19,10 @@ import {
   purl,
   SUPPORTED_LOCK_VERSIONS,
 } from "../lib/deno-lock.ts";
-import { manifestsFromLock } from "../security/submit-dependency-snapshot.ts";
+import {
+  type ManifestGenerationOptions,
+  manifestsFromLock,
+} from "../security/submit-dependency-snapshot.ts";
 
 export { SUPPORTED_LOCK_VERSIONS };
 
@@ -27,6 +32,28 @@ export interface CycloneDXComponent {
   version: string;
   purl: string;
   hashes?: Array<{ alg: string; content: string }>;
+}
+
+export interface SbomOutput {
+  path: string;
+  componentName: string;
+  components: CycloneDXComponent[];
+}
+
+export interface DependencyIndexManifest {
+  sourceLocation: string;
+  group: "core" | "cli" | "extension" | "workspace";
+  componentCount: number;
+  components: Array<{
+    name: string;
+    version: string;
+    purl: string;
+  }>;
+}
+
+export interface DependencyIndex {
+  generatedBy: string;
+  manifests: DependencyIndexManifest[];
 }
 
 function hashFromIntegrity(
@@ -58,7 +85,7 @@ export function componentsFromLock(lockText: string): CycloneDXComponent[] {
       ...(hash ? { hashes: [hash] } : {}),
     });
   }
-  return components;
+  return sortComponents(components);
 }
 
 function parsePurlNameVersion(
@@ -112,22 +139,138 @@ export function componentsFromLockForManifest(
   );
 }
 
-if (import.meta.main) {
-  const args = parseArgs(Deno.args, {
-    string: ["manifest", "output"],
-    default: { output: "dist/sbom.json" },
+function sortComponents(
+  components: CycloneDXComponent[],
+): CycloneDXComponent[] {
+  return components.toSorted((a, b) =>
+    a.name.localeCompare(b.name) || a.version.localeCompare(b.version)
+  );
+}
+
+function normalizeWorkspaceMemberPath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "").replace(/\/+$/, "");
+}
+
+function workspaceMembersFromDenoConfig(
+  config: { workspace?: unknown },
+): string[] {
+  if (!Array.isArray(config.workspace)) return [];
+  return config.workspace
+    .filter((entry): entry is string => typeof entry === "string")
+    .map(normalizeWorkspaceMemberPath)
+    .filter((entry) => entry.length > 0)
+    .sort();
+}
+
+function outputFileNameForManifest(manifestPath: string): string {
+  if (manifestPath === "deno.json") return "core.json";
+  if (manifestPath === "cli/deno.json") return "cli.json";
+  const extensionMatch = manifestPath.match(
+    /^extensions\/([^/]+)\/deno\.json$/,
+  );
+  if (extensionMatch) return `${extensionMatch[1]}.json`;
+  return `${
+    manifestPath.replace(/\/deno\.json$/, "").replaceAll("/", "-")
+  }.json`;
+}
+
+function joinOutputPath(outputDir: string, fileName: string): string {
+  return `${outputDir.replace(/\/+$/, "")}/${fileName}`;
+}
+
+export function sbomOutputsForAllManifests(
+  lockText: string,
+  options: ManifestGenerationOptions & { outputDir: string },
+): SbomOutput[] {
+  const manifests = manifestsFromLock(lockText, {
+    sha: "local",
+    ref: "local",
+    correlator: "local",
+    runId: "local",
+  }, { workspaceMembers: options.workspaceMembers });
+
+  const manifestPaths = Object.keys(manifests).sort((left, right) => {
+    if (left === "deno.json") return -1;
+    if (right === "deno.json") return 1;
+    if (left === "cli/deno.json") return -1;
+    if (right === "cli/deno.json") return 1;
+    return left.localeCompare(right);
   });
 
-  const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
-  const lockText = await Deno.readTextFile("deno.lock");
-  const components = args.manifest
-    ? componentsFromLockForManifest(lockText, args.manifest)
-    : componentsFromLock(lockText);
-  const componentName = args.manifest
-    ? `${denoConfig.name ?? "veryfront"}:${args.manifest}`
-    : denoConfig.name ?? "veryfront";
+  return [
+    {
+      path: joinOutputPath(options.outputDir, "all.json"),
+      componentName: "veryfront",
+      components: componentsFromLock(lockText),
+    },
+    ...manifestPaths.map((manifestPath) => ({
+      path: joinOutputPath(
+        options.outputDir,
+        outputFileNameForManifest(manifestPath),
+      ),
+      componentName: `veryfront:${manifestPath}`,
+      components: componentsFromLockForManifest(lockText, manifestPath),
+    })),
+  ];
+}
 
-  const sbom = {
+function manifestGroup(
+  manifestPath: string,
+): DependencyIndexManifest["group"] {
+  if (manifestPath === "deno.json") return "core";
+  if (manifestPath === "cli/deno.json") return "cli";
+  if (manifestPath.startsWith("extensions/")) return "extension";
+  return "workspace";
+}
+
+function manifestPathsFromLock(
+  lockText: string,
+  options: ManifestGenerationOptions = {},
+): string[] {
+  const manifests = manifestsFromLock(lockText, {
+    sha: "local",
+    ref: "local",
+    correlator: "local",
+    runId: "local",
+  }, { workspaceMembers: options.workspaceMembers });
+
+  return Object.keys(manifests).sort((left, right) => {
+    if (left === "deno.json") return -1;
+    if (right === "deno.json") return 1;
+    if (left === "cli/deno.json") return -1;
+    if (right === "cli/deno.json") return 1;
+    return left.localeCompare(right);
+  });
+}
+
+export function dependencyIndexForAllManifests(
+  lockText: string,
+  options: ManifestGenerationOptions = {},
+): DependencyIndex {
+  return {
+    generatedBy: "generate-sbom",
+    manifests: manifestPathsFromLock(lockText, options).map((manifestPath) => {
+      const components = componentsFromLockForManifest(lockText, manifestPath);
+      return {
+        sourceLocation: manifestPath,
+        group: manifestGroup(manifestPath),
+        componentCount: components.length,
+        components: components.map((component) => ({
+          name: component.name,
+          version: component.version,
+          purl: component.purl,
+        })),
+      };
+    }),
+  };
+}
+
+function buildSbom(
+  denoConfig: { name?: string; version?: string },
+  componentName: string,
+  components: CycloneDXComponent[],
+) {
+  return {
     bomFormat: "CycloneDX",
     specVersion: "1.5",
     version: 1,
@@ -140,7 +283,7 @@ if (import.meta.main) {
         name: componentName,
         version: denoConfig.version ?? "0.0.0",
       },
-      tools: [{ name: "generate-sbom", version: "1.1.0" }],
+      tools: [{ name: "generate-sbom", version: "1.2.0" }],
     },
     components: components.map((c) => ({
       "bom-ref": `${c.name}@${c.version}`,
@@ -153,13 +296,64 @@ if (import.meta.main) {
       },
     ],
   };
+}
 
-  const outputPath = args.output;
+async function writeSbom(outputPath: string, sbom: unknown): Promise<void> {
   const outputDir = outputPath.substring(0, outputPath.lastIndexOf("/"));
   if (outputDir) {
     await Deno.mkdir(outputDir, { recursive: true });
   }
   await Deno.writeTextFile(outputPath, JSON.stringify(sbom, null, 2) + "\n");
+}
+
+if (import.meta.main) {
+  const args = parseArgs(Deno.args, {
+    boolean: ["all-manifests"],
+    string: ["manifest", "output", "output-dir"],
+    default: { output: "dist/sbom.json", "output-dir": "dist/sbom" },
+  });
+
+  const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
+  const lockText = await Deno.readTextFile("deno.lock");
+
+  if (args["all-manifests"]) {
+    const workspaceMembers = workspaceMembersFromDenoConfig(denoConfig);
+    const outputs = sbomOutputsForAllManifests(lockText, {
+      outputDir: args["output-dir"],
+      workspaceMembers,
+    });
+    await writeSbom(
+      joinOutputPath(args["output-dir"], "dependencies-by-manifest.json"),
+      dependencyIndexForAllManifests(lockText, { workspaceMembers }),
+    );
+    console.log(
+      `✅ Generated dependency index: ${
+        joinOutputPath(args["output-dir"], "dependencies-by-manifest.json")
+      }`,
+    );
+    for (const output of outputs) {
+      await writeSbom(
+        output.path,
+        buildSbom(denoConfig, output.componentName, output.components),
+      );
+      console.log(
+        `✅ Generated SBOM: ${output.path}`,
+      );
+      console.log(
+        `   ${output.components.length} components, CycloneDX 1.5 format`,
+      );
+    }
+    Deno.exit(0);
+  }
+
+  const components = args.manifest
+    ? componentsFromLockForManifest(lockText, args.manifest)
+    : componentsFromLock(lockText);
+  const componentName = args.manifest
+    ? `${denoConfig.name ?? "veryfront"}:${args.manifest}`
+    : denoConfig.name ?? "veryfront";
+  const outputPath = args.output;
+  await writeSbom(outputPath, buildSbom(denoConfig, componentName, components));
 
   console.log(`✅ Generated SBOM: ${outputPath}`);
   console.log(`   ${components.length} components, CycloneDX 1.5 format`);

--- a/scripts/lint/audit-deps.test.ts
+++ b/scripts/lint/audit-deps.test.ts
@@ -1,10 +1,17 @@
 import { assertEquals } from "#std/assert";
 import { describe, it } from "jsr:@std/testing/bdd";
-import { auditEsmShPin, auditNpmPin } from "./audit-deps.ts";
+import {
+  auditDependencyImports,
+  auditEsmShPin,
+  auditNpmPin,
+} from "./audit-deps.ts";
 
 describe("auditEsmShPin", () => {
   it("accepts exact x.y.z pins", () => {
-    assertEquals(auditEsmShPin("https://esm.sh/react@19.2.4?target=es2022"), null);
+    assertEquals(
+      auditEsmShPin("https://esm.sh/react@19.2.4?target=es2022"),
+      null,
+    );
   });
 
   it("rejects major-only pins", () => {
@@ -46,7 +53,9 @@ describe("auditEsmShPin", () => {
   });
 
   it("rejects scoped packages with major-only pins", () => {
-    const issue = auditEsmShPin("https://esm.sh/@types/react@19?deps=csstype@3.2.3");
+    const issue = auditEsmShPin(
+      "https://esm.sh/@types/react@19?deps=csstype@3.2.3",
+    );
     assertEquals(issue?.severity, "error");
   });
 });
@@ -96,5 +105,34 @@ describe("auditNpmPin", () => {
   it("returns null for non-npm targets", () => {
     assertEquals(auditNpmPin("https://esm.sh/react@19.2.4"), null);
     assertEquals(auditNpmPin("jsr:@std/assert@1.0.0"), null);
+  });
+});
+
+describe("auditDependencyImports", () => {
+  it("audits root and extension import maps with source locations", () => {
+    const issues = auditDependencyImports([
+      {
+        sourceLocation: "deno.json",
+        imports: {
+          "react": "npm:react@19.2.4",
+        },
+      },
+      {
+        sourceLocation: "extensions/ext-example/deno.json",
+        imports: {
+          "zod": "npm:zod@4",
+        },
+      },
+    ]);
+
+    assertEquals(issues, [
+      {
+        sourceLocation: "extensions/ext-example/deno.json",
+        specifier: "zod",
+        target: "npm:zod@4",
+        severity: "error",
+        message: 'Unpinned npm version — specify exact x.y.z (got "4")',
+      },
+    ]);
   });
 });

--- a/scripts/lint/audit-deps.ts
+++ b/scripts/lint/audit-deps.ts
@@ -14,10 +14,16 @@
 export type Severity = "error" | "warning";
 
 export interface AuditIssue {
+  sourceLocation?: string;
   specifier: string;
   target: string;
   severity: Severity;
   message: string;
+}
+
+export interface ImportMapManifest {
+  sourceLocation: string;
+  imports: Record<string, string>;
 }
 
 // Shared by auditEsmShPin and auditNpmPin so both CDN paths apply the same
@@ -31,7 +37,10 @@ const EXACT_SEMVER_RE = /^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$/;
  * - esm.sh URL missing version → error
  * - esm.sh URL not pinned to exact x.y.z (no caret, tilde, major-only) → error
  */
-export function auditEsmShPin(target: string, specifier = ""): AuditIssue | null {
+export function auditEsmShPin(
+  target: string,
+  specifier = "",
+): AuditIssue | null {
   if (!target.startsWith("https://esm.sh/")) {
     if (target.startsWith("https://")) {
       // jsr.io is managed by Deno (handled by the jsr: branch in main loop);
@@ -49,7 +58,9 @@ export function auditEsmShPin(target: string, specifier = ""): AuditIssue | null
 
   const path = target.split("?")[0];
   // Match either scoped (@scope/name) or unscoped (name) before @version
-  const versionMatch = path.match(/esm\.sh\/(?:@[^/@]+\/[^@/]+|[^@/]+)@([^/]+)/);
+  const versionMatch = path.match(
+    /esm\.sh\/(?:@[^/@]+\/[^@/]+|[^@/]+)@([^/]+)/,
+  );
   if (!versionMatch) {
     return {
       specifier,
@@ -96,57 +107,97 @@ export function auditNpmPin(target: string, specifier = ""): AuditIssue | null {
   return null;
 }
 
-if (import.meta.main) {
-  const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
-  const imports: Record<string, string> = denoConfig.imports ?? {};
-
+export function auditDependencyImports(
+  manifests: ImportMapManifest[],
+): AuditIssue[] {
   const issues: AuditIssue[] = [];
 
-  for (const [specifier, target] of Object.entries(imports)) {
-    if (target.startsWith("./") || target.startsWith("../")) continue;
-    if (target.startsWith("jsr:")) continue;
+  for (const manifest of manifests) {
+    for (const [specifier, target] of Object.entries(manifest.imports)) {
+      if (target.startsWith("./") || target.startsWith("../")) continue;
+      if (target.startsWith("jsr:")) continue;
 
-    if (target.startsWith("git://") || target.startsWith("git+")) {
-      issues.push({
-        specifier,
-        target,
-        severity: "error",
-        message: "Git URL import — vulnerable to repo compromise",
+      const withSource = (issue: AuditIssue): AuditIssue => ({
+        sourceLocation: manifest.sourceLocation,
+        ...issue,
       });
-      continue;
-    }
 
-    if (target.match(/\.(tar\.gz|tgz|tar)([?#]|$)/)) {
-      issues.push({
-        specifier,
-        target,
-        severity: "error",
-        message: "Tarball import — cannot verify integrity",
-      });
-      continue;
-    }
+      if (target.startsWith("git://") || target.startsWith("git+")) {
+        issues.push(withSource({
+          specifier,
+          target,
+          severity: "error",
+          message: "Git URL import — vulnerable to repo compromise",
+        }));
+        continue;
+      }
 
-    if (target.startsWith("npm:")) {
-      const issue = auditNpmPin(target, specifier);
-      if (issue) issues.push(issue);
-      continue;
-    }
+      if (target.match(/\.(tar\.gz|tgz|tar)([?#]|$)/)) {
+        issues.push(withSource({
+          specifier,
+          target,
+          severity: "error",
+          message: "Tarball import — cannot verify integrity",
+        }));
+        continue;
+      }
 
-    if (target.startsWith("https://")) {
-      const issue = auditEsmShPin(target, specifier);
-      if (issue) issues.push(issue);
-      continue;
-    }
+      if (target.startsWith("npm:")) {
+        const issue = auditNpmPin(target, specifier);
+        if (issue) issues.push(withSource(issue));
+        continue;
+      }
 
-    if (target.startsWith("http://")) {
-      issues.push({
-        specifier,
-        target,
-        severity: "error",
-        message: "Non-HTTPS import — vulnerable to MITM attacks",
+      if (target.startsWith("https://")) {
+        const issue = auditEsmShPin(target, specifier);
+        if (issue) issues.push(withSource(issue));
+        continue;
+      }
+
+      if (target.startsWith("http://")) {
+        issues.push(withSource({
+          specifier,
+          target,
+          severity: "error",
+          message: "Non-HTTPS import — vulnerable to MITM attacks",
+        }));
+      }
+    }
+  }
+
+  return issues;
+}
+
+function normalizeWorkspaceMemberPath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "").replace(/\/+$/, "");
+}
+
+async function readImportMapManifests(): Promise<ImportMapManifest[]> {
+  const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
+  const manifests: ImportMapManifest[] = [{
+    sourceLocation: "deno.json",
+    imports: denoConfig.imports ?? {},
+  }];
+
+  if (Array.isArray(denoConfig.workspace)) {
+    for (const entry of denoConfig.workspace) {
+      if (typeof entry !== "string") continue;
+      const memberPath = normalizeWorkspaceMemberPath(entry);
+      if (!memberPath) continue;
+      const sourceLocation = `${memberPath}/deno.json`;
+      const memberConfig = JSON.parse(await Deno.readTextFile(sourceLocation));
+      manifests.push({
+        sourceLocation,
+        imports: memberConfig.imports ?? {},
       });
     }
   }
+
+  return manifests;
+}
+
+if (import.meta.main) {
+  const issues = auditDependencyImports(await readImportMapManifests());
 
   if (issues.length === 0) {
     console.log("✅ No supply chain issues found in dependency imports.");
@@ -159,7 +210,9 @@ if (import.meta.main) {
   if (warnings.length > 0) {
     console.log(`\n⚠️  ${warnings.length} warning(s):`);
     for (const w of warnings) {
-      console.log(`  ${w.specifier}: ${w.message}`);
+      console.log(
+        `  ${w.sourceLocation ?? "deno.json"}: ${w.specifier}: ${w.message}`,
+      );
       console.log(`    → ${w.target}`);
     }
   }
@@ -167,7 +220,9 @@ if (import.meta.main) {
   if (errors.length > 0) {
     console.log(`\n❌ ${errors.length} error(s):`);
     for (const e of errors) {
-      console.log(`  ${e.specifier}: ${e.message}`);
+      console.log(
+        `  ${e.sourceLocation ?? "deno.json"}: ${e.specifier}: ${e.message}`,
+      );
       console.log(`    → ${e.target}`);
     }
     Deno.exit(1);

--- a/scripts/security/audit-npm.test.ts
+++ b/scripts/security/audit-npm.test.ts
@@ -1,0 +1,70 @@
+import { assertEquals } from "#std/assert";
+import { describe, it } from "jsr:@std/testing/bdd";
+import { buildAuditPackageJson, collectNpmDependencies } from "./audit-npm.ts";
+
+describe("collectNpmDependencies", () => {
+  it("collects pinned npm imports across root and extension manifests", () => {
+    const deps = collectNpmDependencies([
+      {
+        sourceLocation: "deno.json",
+        imports: {
+          "react": "npm:react@19.2.4",
+        },
+      },
+      {
+        sourceLocation: "extensions/ext-schema-zod/deno.json",
+        imports: {
+          "zod": "npm:zod@4.3.6",
+        },
+      },
+      {
+        sourceLocation: "extensions/ext-empty/deno.json",
+        imports: {
+          "#local": "./src/index.ts",
+          "@std/path": "jsr:@std/path@1.1.2",
+        },
+      },
+    ]);
+
+    assertEquals(deps, {
+      "react": "19.2.4",
+      "zod": "4.3.6",
+    });
+  });
+
+  it("preserves multiple versions of the same package with audit aliases", () => {
+    const deps = collectNpmDependencies([
+      {
+        sourceLocation: "extensions/ext-old/deno.json",
+        imports: {
+          "zod": "npm:zod@3.25.76",
+        },
+      },
+      {
+        sourceLocation: "extensions/ext-new/deno.json",
+        imports: {
+          "zod": "npm:zod@4.3.6",
+        },
+      },
+    ]);
+
+    assertEquals(deps, {
+      "zod": "3.25.76",
+      "vf-audit-zod-4-3-6": "npm:zod@4.3.6",
+    });
+  });
+});
+
+describe("buildAuditPackageJson", () => {
+  it("keeps native runtime dependencies in the temporary audit package", () => {
+    const pkg = buildAuditPackageJson({
+      "better-sqlite3": "12.4.6",
+    });
+
+    assertEquals(pkg.dependencies, {
+      "better-sqlite3": "12.4.6",
+    });
+    assertEquals(pkg.peerDependencies, undefined);
+    assertEquals(pkg.peerDependenciesMeta, undefined);
+  });
+});

--- a/scripts/security/audit-npm.ts
+++ b/scripts/security/audit-npm.ts
@@ -7,128 +7,218 @@
  * Usage: deno run --allow-read --allow-run --allow-write scripts/security/audit-npm.ts
  */
 
-import { normalizeNpmPackageMetadata } from "../build/npm-package-metadata.ts";
-
-const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
-const imports: Record<string, string> = denoConfig.imports ?? {};
-
-// Extract npm package names and versions
-const npmDeps: Record<string, string> = {};
-for (const [_specifier, target] of Object.entries(imports)) {
-  if (!target.startsWith("npm:")) continue;
-  const match = target.match(/^npm:(.+)@(\d[^/]*)/);
-  if (!match) continue;
-  const [, name, version] = match;
-  npmDeps[name] = version;
+export interface AuditPackageJson {
+  name: string;
+  version: string;
+  private: boolean;
+  dependencies: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
 }
 
-if (Object.keys(npmDeps).length === 0) {
-  console.log("No npm dependencies found in deno.json.");
-  Deno.exit(0);
+export interface ImportMapManifest {
+  sourceLocation: string;
+  imports: Record<string, string>;
 }
 
-// Create a temporary package.json for npm audit
-const tmpDir = await Deno.makeTempDir({ prefix: "vf-audit-" });
-const packageJson = normalizeNpmPackageMetadata({
-  name: "veryfront-audit",
-  version: "0.0.0",
-  private: true,
-  dependencies: npmDeps,
-});
+export function collectNpmDependencies(
+  manifests: ImportMapManifest[],
+): Record<string, string> {
+  const versionsByName = new Map<string, Set<string>>();
 
-await Deno.writeTextFile(
-  `${tmpDir}/package.json`,
-  JSON.stringify(packageJson, null, 2),
-);
+  for (const manifest of manifests) {
+    for (const [_specifier, target] of Object.entries(manifest.imports)) {
+      if (!target.startsWith("npm:")) continue;
+      const match = target.match(/^npm:(.+)@(\d[^/]*)/);
+      if (!match) continue;
+      const [, name, version] = match;
+      const versions = versionsByName.get(name) ?? new Set<string>();
+      versions.add(version);
+      versionsByName.set(name, versions);
+    }
+  }
 
-console.log(`Auditing ${Object.keys(npmDeps).length} npm dependencies...\n`);
+  const npmDeps: Record<string, string> = {};
+  for (
+    const [name, versions] of [...versionsByName].sort(([left], [right]) =>
+      left.localeCompare(right)
+    )
+  ) {
+    const sortedVersions = [...versions].sort();
+    const [primaryVersion, ...additionalVersions] = sortedVersions;
+    npmDeps[name] = primaryVersion;
+    for (const version of additionalVersions) {
+      npmDeps[auditAliasName(name, version)] = `npm:${name}@${version}`;
+    }
+  }
 
-// Run npm audit --json
-const cmd = new Deno.Command("npm", {
-  args: ["audit", "--json", "--omit=dev", "--package-lock-only"],
-  cwd: tmpDir,
-  stdout: "piped",
-  stderr: "piped",
-});
-
-// First generate package-lock.json
-const installCmd = new Deno.Command("npm", {
-  args: ["install", "--package-lock-only", "--ignore-scripts"],
-  cwd: tmpDir,
-  stdout: "piped",
-  stderr: "piped",
-});
-
-const installResult = await installCmd.output();
-if (!installResult.success) {
-  const stderr = new TextDecoder().decode(installResult.stderr);
-  console.error("Failed to generate package-lock.json:", stderr);
-  await Deno.remove(tmpDir, { recursive: true });
-  Deno.exit(1);
+  return Object.fromEntries(
+    Object.entries(npmDeps).sort(([left], [right]) =>
+      left.localeCompare(right)
+    ),
+  );
 }
 
-const result = await cmd.output();
-const stdout = new TextDecoder().decode(result.stdout);
+function auditAliasName(name: string, version: string): string {
+  return `vf-audit-${
+    `${name}-${version}`
+      .toLowerCase()
+      .replace(/^@/, "")
+      .replace(/[^a-z0-9-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+  }`;
+}
 
-// Clean up
-await Deno.remove(tmpDir, { recursive: true });
-
-// Parse audit results
-let audit: {
-  vulnerabilities?: Record<
-    string,
-    { severity: string; via: unknown[]; fixAvailable?: boolean }
-  >;
-  metadata?: {
-    vulnerabilities: Record<string, number>;
-    totalDependencies: number;
+export function buildAuditPackageJson(
+  dependencies: Record<string, string>,
+): AuditPackageJson {
+  return {
+    name: "veryfront-audit",
+    version: "0.0.0",
+    private: true,
+    dependencies,
   };
-};
-
-try {
-  audit = JSON.parse(stdout);
-} catch {
-  // Fail closed: non-JSON output means npm audit errored (network, auth, registry)
-  console.error("❌ npm audit failed — non-JSON output (possible network/registry error).");
-  console.error("stdout:", stdout.slice(0, 500));
-  Deno.exit(1);
 }
 
-const meta = audit.metadata?.vulnerabilities;
-const vulns = audit.vulnerabilities ?? {};
-
-if (!meta || Object.values(meta).every((v) => v === 0)) {
-  console.log("✅ No vulnerabilities found.");
-  Deno.exit(0);
+function normalizeWorkspaceMemberPath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "").replace(/\/+$/, "");
 }
 
-// Report
-console.log("Vulnerability Summary:");
-console.log(`  Critical: ${meta.critical ?? 0}`);
-console.log(`  High:     ${meta.high ?? 0}`);
-console.log(`  Moderate: ${meta.moderate ?? 0}`);
-console.log(`  Low:      ${meta.low ?? 0}`);
-console.log(`  Info:     ${meta.info ?? 0}`);
-console.log(`  Total:    ${meta.total ?? 0}`);
-console.log();
+async function readImportMapManifests(): Promise<ImportMapManifest[]> {
+  const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
+  const manifests: ImportMapManifest[] = [{
+    sourceLocation: "deno.json",
+    imports: denoConfig.imports ?? {},
+  }];
 
-// List affected packages
-const sevOrder = ["critical", "high", "moderate", "low", "info"];
-const sortedVulns = Object.entries(vulns).sort(
-  ([, a], [, b]) => sevOrder.indexOf(a.severity) - sevOrder.indexOf(b.severity),
-);
+  if (Array.isArray(denoConfig.workspace)) {
+    for (const entry of denoConfig.workspace) {
+      if (typeof entry !== "string") continue;
+      const memberPath = normalizeWorkspaceMemberPath(entry);
+      if (!memberPath) continue;
+      const sourceLocation = `${memberPath}/deno.json`;
+      const memberConfig = JSON.parse(await Deno.readTextFile(sourceLocation));
+      manifests.push({
+        sourceLocation,
+        imports: memberConfig.imports ?? {},
+      });
+    }
+  }
 
-for (const [pkg, info] of sortedVulns) {
-  const fix = info.fixAvailable ? " (fix available)" : "";
-  console.log(`  ${info.severity.toUpperCase().padEnd(10)} ${pkg}${fix}`);
+  return manifests;
 }
 
-// Exit with error if high or critical vulnerabilities found
-const hasBlocking = (meta.critical ?? 0) > 0 || (meta.high ?? 0) > 0;
-if (hasBlocking) {
-  console.log("\n❌ High/critical vulnerabilities found. Audit failed.");
-  Deno.exit(1);
-} else {
-  console.log("\n⚠️  Non-blocking vulnerabilities found (moderate/low/info only).");
-  Deno.exit(0);
+if (import.meta.main) {
+  const npmDeps = collectNpmDependencies(await readImportMapManifests());
+
+  if (Object.keys(npmDeps).length === 0) {
+    console.log("No npm dependencies found in workspace manifests.");
+    Deno.exit(0);
+  }
+
+  // Create a temporary package.json for npm audit
+  const tmpDir = await Deno.makeTempDir({ prefix: "vf-audit-" });
+  const packageJson = buildAuditPackageJson(npmDeps);
+
+  await Deno.writeTextFile(
+    `${tmpDir}/package.json`,
+    JSON.stringify(packageJson, null, 2),
+  );
+
+  console.log(`Auditing ${Object.keys(npmDeps).length} npm dependencies...\n`);
+
+  // Run npm audit --json
+  const cmd = new Deno.Command("npm", {
+    args: ["audit", "--json", "--omit=dev", "--package-lock-only"],
+    cwd: tmpDir,
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  // First generate package-lock.json
+  const installCmd = new Deno.Command("npm", {
+    args: ["install", "--package-lock-only", "--ignore-scripts"],
+    cwd: tmpDir,
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const installResult = await installCmd.output();
+  if (!installResult.success) {
+    const stderr = new TextDecoder().decode(installResult.stderr);
+    console.error("Failed to generate package-lock.json:", stderr);
+    await Deno.remove(tmpDir, { recursive: true });
+    Deno.exit(1);
+  }
+
+  const result = await cmd.output();
+  const stdout = new TextDecoder().decode(result.stdout);
+
+  // Clean up
+  await Deno.remove(tmpDir, { recursive: true });
+
+  // Parse audit results
+  let audit: {
+    vulnerabilities?: Record<
+      string,
+      { severity: string; via: unknown[]; fixAvailable?: boolean }
+    >;
+    metadata?: {
+      vulnerabilities: Record<string, number>;
+      totalDependencies: number;
+    };
+  };
+
+  try {
+    audit = JSON.parse(stdout);
+  } catch {
+    // Fail closed: non-JSON output means npm audit errored (network, auth, registry)
+    console.error(
+      "❌ npm audit failed — non-JSON output (possible network/registry error).",
+    );
+    console.error("stdout:", stdout.slice(0, 500));
+    Deno.exit(1);
+  }
+
+  const meta = audit.metadata?.vulnerabilities;
+  const vulns = audit.vulnerabilities ?? {};
+
+  if (!meta || Object.values(meta).every((v) => v === 0)) {
+    console.log("✅ No vulnerabilities found.");
+    Deno.exit(0);
+  }
+
+  // Report
+  console.log("Vulnerability Summary:");
+  console.log(`  Critical: ${meta.critical ?? 0}`);
+  console.log(`  High:     ${meta.high ?? 0}`);
+  console.log(`  Moderate: ${meta.moderate ?? 0}`);
+  console.log(`  Low:      ${meta.low ?? 0}`);
+  console.log(`  Info:     ${meta.info ?? 0}`);
+  console.log(`  Total:    ${meta.total ?? 0}`);
+  console.log();
+
+  // List affected packages
+  const sevOrder = ["critical", "high", "moderate", "low", "info"];
+  const sortedVulns = Object.entries(vulns).sort(
+    ([, a], [, b]) =>
+      sevOrder.indexOf(a.severity) - sevOrder.indexOf(b.severity),
+  );
+
+  for (const [pkg, info] of sortedVulns) {
+    const fix = info.fixAvailable ? " (fix available)" : "";
+    console.log(`  ${info.severity.toUpperCase().padEnd(10)} ${pkg}${fix}`);
+  }
+
+  // Exit with error if high or critical vulnerabilities found
+  const hasBlocking = (meta.critical ?? 0) > 0 || (meta.high ?? 0) > 0;
+  if (hasBlocking) {
+    console.log("\n❌ High/critical vulnerabilities found. Audit failed.");
+    Deno.exit(1);
+  } else {
+    console.log(
+      "\n⚠️  Non-blocking vulnerabilities found (moderate/low/info only).",
+    );
+    Deno.exit(0);
+  }
 }


### PR DESCRIPTION
## Summary
- add `deno task sbom:all` to generate an aggregate SBOM plus core, CLI, and per-extension SBOM files from `deno.lock`
- publish separated SBOM artifacts in security audit CI and attach separated SBOMs to release jobs
- extend dependency pin/audit scripts to inspect workspace manifests, not only root `deno.json`
- preserve duplicate npm package versions in the npm audit package via npm aliases

## Verification
- `deno task test:scripts`
- `deno check --config=scripts/test.deno.json scripts/build/generate-sbom.ts scripts/build/generate-sbom.test.ts scripts/lint/audit-deps.ts scripts/lint/audit-deps.test.ts scripts/security/audit-npm.ts scripts/security/audit-npm.test.ts`
- `deno task lint:deps && deno task lint:core-deps`
- `deno task sbom:all --output-dir dist/test-dependency-sboms && rm -rf dist/test-dependency-sboms`
- `deno task audit`
- `deno task verify:quick`
- pre-push hook: formatting, lint, type check, unit tests
