### PR TITLE
chore: bump framework version to 0.1.520

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.519",
+  "version": "0.1.520",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.519";
+export const VERSION = "0.1.520";


### PR DESCRIPTION
## Summary
- bump the framework package version to 0.1.520
- keep the runtime VERSION constant in sync

## Verification
- deno task verify:quick
- pre-push checks passed, including unit tests: 1868 passed
