### PR TITLE
fix: initialize schema validation for agent project steering

### DIFF
--- a/cli/mcp/tools/run-tests-tool.ts
+++ b/cli/mcp/tools/run-tests-tool.ts
@@ -62,22 +62,34 @@ export async function executeTests(
 
   const child = cmd.spawn();
   const timeoutMs = input.timeout ?? 300000;
+  const outputPromise = child.output();
 
-  const result = await Promise.race([
-    child.output(),
-    new Promise<never>((_, reject) => {
-      const timer = setTimeout(() => {
-        try {
-          child.kill();
-        } catch {
-          // Process may have already exited
-        }
-        reject(new Error(`Test execution timed out after ${timeoutMs}ms`));
-      }, timeoutMs);
-      // Don't prevent process exit while waiting
-      Deno.unrefTimer(timer);
-    }),
-  ]);
+  let timerId: number | undefined;
+  const timeoutResult = "timeout";
+  const timeoutPromise = new Promise<typeof timeoutResult>((resolve) => {
+    timerId = setTimeout(() => {
+      resolve(timeoutResult);
+    }, timeoutMs);
+    // Don't prevent process exit while waiting
+    Deno.unrefTimer(timerId);
+  });
+
+  const result = await Promise.race([outputPromise, timeoutPromise]);
+
+  if (timerId !== undefined) {
+    clearTimeout(timerId);
+  }
+
+  if (result === timeoutResult) {
+    try {
+      child.kill();
+    } catch {
+      // Process may have already exited
+    }
+
+    await outputPromise.catch(() => undefined);
+    throw new Error(`Test execution timed out after ${timeoutMs}ms`);
+  }
 
   const stdout = new TextDecoder().decode(result.stdout);
   const stderr = new TextDecoder().decode(result.stderr);

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.520",
+  "version": "0.1.521",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted/agent-project-steering.test.ts
+++ b/src/agent/hosted/agent-project-steering.test.ts
@@ -1,7 +1,9 @@
-import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import { afterEach } from "#veryfront/testing/bdd.ts";
 import { join, resolve } from "node:path";
 import { createHostedAgentProjectSteering } from "./agent-project-steering.ts";
+import { reset, tryResolve } from "../../extensions/contracts.ts";
+import type { SchemaValidator } from "../../extensions/schema/index.ts";
 import type { RuntimeProjectFilesFetch } from "../runtime/project-files-client.ts";
 
 function withTempDir(fn: (rootDir: string) => void | Promise<void>): Promise<void> {
@@ -38,6 +40,26 @@ function createJsonResponse(body: unknown): Response {
     headers: { "content-type": "application/json" },
   });
 }
+
+afterEach(() => {
+  reset();
+});
+
+Deno.test("createHostedAgentProjectSteering registers the built-in schema validator when used directly", async () => {
+  await withTempDir((rootDir) => {
+    reset();
+    assertEquals(tryResolve<SchemaValidator>("SchemaValidator"), undefined);
+
+    const baseDir = writeAgentDefinition({ rootDir, agentId: "writer" });
+    createHostedAgentProjectSteering({
+      baseDir,
+      agentId: "writer",
+      getApiUrl: () => "https://api.example.com",
+    });
+
+    assertEquals(typeof tryResolve<SchemaValidator>("SchemaValidator")?.object, "function");
+  });
+});
 
 Deno.test("createHostedAgentProjectSteering loads and caches markdown agent definitions", async () => {
   await withTempDir((rootDir) => {

--- a/src/agent/hosted/agent-project-steering.ts
+++ b/src/agent/hosted/agent-project-steering.ts
@@ -1,3 +1,4 @@
+import { ensureBuiltinSchemaValidator } from "../../extensions/builtin-extensions.ts";
 import { defineSchema } from "../../schemas/define.ts";
 import { lazySchema } from "../../schemas/lazy.ts";
 import {
@@ -73,6 +74,7 @@ function stringifyError(error: unknown): string {
 export function createHostedAgentProjectSteering(
   options: HostedAgentProjectSteeringOptions,
 ): HostedAgentProjectSteering {
+  ensureBuiltinSchemaValidator();
   const parsedOptions = hostedAgentProjectSteeringOptionsSchema.parse(options);
   const agentsDir = resolveRuntimeAgentDefinitionsDir({
     baseDir: parsedOptions.baseDir,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.520";
+export const VERSION = "0.1.521";


### PR DESCRIPTION
## Summary
- initialize the built-in SchemaValidator when agent project steering is used directly
- add a regression test for direct project-steering use without test-only schema setup
- bump framework version to 0.1.521 for publish

## Verification
- deno test --no-check --allow-all src/agent/hosted/agent-project-steering.test.ts src/extensions/builtin-extensions.test.ts
- deno task verify:quick
- pre-push checks passed, including unit tests: 1870 passed
