### PR TITLE
fix: initialize schema validation for service config

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.521",
+  "version": "0.1.522",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/service/config.test.ts
+++ b/src/agent/service/config.test.ts
@@ -1,6 +1,6 @@
-import "#veryfront/schemas/_test-setup.ts";
+import { reset } from "../../extensions/contracts.ts";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   agentServiceConfigSchema,
   parseAgentServiceConfig,
@@ -8,6 +8,16 @@ import {
 } from "./config.ts";
 
 describe("agent/agent-service-config", () => {
+  afterEach(() => {
+    reset();
+  });
+
+  it("registers the built-in schema validator when used directly", () => {
+    const config = parseAgentServiceConfig({});
+
+    assertEquals(config.VERYFRONT_API_URL, "https://api.veryfront.com");
+  });
+
   it("exposes agent service aliases without the hosted prefix", () => {
     const config = parseAgentServiceConfig({
       VERYFRONT_API_URL: "https://api.example.com",

--- a/src/agent/service/config.ts
+++ b/src/agent/service/config.ts
@@ -1,3 +1,4 @@
+import { ensureBuiltinSchemaValidator } from "../../extensions/builtin-extensions.ts";
 import { defineSchema } from "../../schemas/define.ts";
 import { lazySchema } from "../../schemas/lazy.ts";
 
@@ -95,6 +96,7 @@ export type HostedAgentServiceConfigInput = AgentServiceConfigInput;
 export function parseAgentServiceConfig(
   input: AgentServiceConfigInput,
 ): AgentServiceConfig {
+  ensureBuiltinSchemaValidator();
   return agentServiceConfigSchema.parse(input);
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.521";
+export const VERSION = "0.1.522";


### PR DESCRIPTION
## Summary
- Initialize the built-in schema validator before direct service config parsing
- Add a regression test for direct config parsing without external schema setup
- Bump package version to 0.1.522 for the next framework release

## Verification
- deno test --no-check --allow-all src/agent/service/config.test.ts src/extensions/builtin-extensions.test.ts
- deno task verify:quick
- pre-push checks: format, lint, typecheck, unit tests