### PR TITLE
Add React dependency boundary reporting

### DIFF
--- a/docs/architecture/08-support-matrix.md
+++ b/docs/architecture/08-support-matrix.md
@@ -29,7 +29,8 @@ These are the runtime capability profiles currently modeled by the framework.
 
 ## Capability Boundaries
 
-This matrix separates open-core framework support from capabilities that depend on a backing API or cloud bootstrap.
+This matrix separates open-core framework support from capabilities that depend
+on a backing API or cloud bootstrap.
 
 | Capability                                                            | Current support shape                             | Notes                                                                                 |
 | --------------------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------- |
@@ -50,7 +51,9 @@ This matrix separates open-core framework support from capabilities that depend 
 
 ## Extension Contract Matrix
 
-These contracts are backed by first-party extension packages. A contract is required only when a feature resolves it. Built-in packages are auto-enabled by core bootstrap; optional packages must be configured by the project.
+These contracts are backed by first-party extension packages. A contract is
+required only when a feature resolves it. Built-in packages are auto-enabled by
+core bootstrap; optional packages must be configured by the project.
 
 | Contract                 | Package                                      | Availability | Required by                             | Runtime requirement          |
 | ------------------------ | -------------------------------------------- | ------------ | --------------------------------------- | ---------------------------- |
@@ -69,6 +72,20 @@ These contracts are backed by first-party extension packages. A contract is requ
 | `NodeTelemetryProvider`  | `@veryfront/ext-observability-opentelemetry` | Built-in     | Node OpenTelemetry SDK bootstrap        | Network (OTLP endpoint)      |
 | `TokenCacheStore`        | `@veryfront/ext-cache-redis`                 | Optional     | Redis-backed token cache                | Network (Redis)              |
 
+## Dependency boundaries
+
+Veryfront tracks third-party dependency ownership by boundary.
+
+| Boundary  | Source                                       | SBOM output                                 | Notes                                                                                      |
+| --------- | -------------------------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Core      | Root `deno.json` and `src/`                  | `core.json`                                 | The root framework boundary. `src/` is not renamed to `core`; `core` is a reporting label. |
+| CLI       | `cli/deno.json`                              | `cli.json`                                  | Command-line runtime boundary.                                                             |
+| React     | Root React import aliases and esm.sh deps    | `react.json`                                | Tracks React and React DOM separately from core until React has a dedicated package split. |
+| Extension | `extensions/ext-*/deno.json`                 | One file per extension package              | Each extension owns its npm and supported esm.sh dependencies.                             |
+| Aggregate | `deno.lock` plus boundary-specific manifests | `all.json`, `dependencies-by-manifest.json` | Use this view for full supply-chain inventory.                                             |
+
 ## Documentation Rule
 
-When a feature depends on a backing API, managed service, or cloud bootstrap, docs should say so directly instead of implying the open-core runtime provides the full managed behavior by itself.
+When a feature depends on a backing API, managed service, or cloud bootstrap,
+docs should say so directly instead of implying the open-core runtime provides
+the full managed behavior by itself.

--- a/docs/superpowers/plans/2026-05-14-react-dependency-boundary.md
+++ b/docs/superpowers/plans/2026-05-14-react-dependency-boundary.md
@@ -1,0 +1,39 @@
+# React dependency boundary Ralph plan
+
+## Decision
+
+Use `react` as the dependency boundary name. Do not rename `src/` to `core` in
+this pass. The repository keeps `src/` as the implementation tree, while
+dependency tooling reports the root framework boundary as `core`.
+
+## Goal
+
+Make React dependencies visible separately from core dependencies, keep
+extension dependencies segregated, and document how to inspect the resulting
+dependency graph.
+
+## Implementation steps
+
+1. Add a `react` boundary to SBOM and dependency-index generation.
+2. Parse supported esm.sh import aliases into npm package components.
+3. Keep root framework SBOM output as `core.json`.
+4. Emit React imports into `react.json`.
+5. Emit extension esm.sh imports into the owning extension SBOM.
+6. Update focused tests for core, CLI, React, and extension grouping.
+7. Update repository docs and extension README dependency-ownership guidance.
+8. Run script tests, dependency guards, SBOM generation, formatting checks, and
+   diff checks.
+
+## Verification
+
+Run these commands before completion:
+
+```bash
+deno test --config=scripts/test.deno.json --no-check --allow-read scripts/build/generate-sbom.test.ts
+deno task test:scripts
+deno task lint:core-deps
+deno task lint:deps
+deno task sbom:all --output-dir dist/dependency-sboms-check
+deno fmt --check scripts/build/generate-sbom.ts scripts/build/generate-sbom.test.ts scripts/README.md extensions/README.md docs/architecture/08-support-matrix.md docs/superpowers/plans/2026-05-14-react-dependency-boundary.md
+git diff --check
+```

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -1,113 +1,121 @@
 # Veryfront Extensions
 
-First-party extension packages that provide pluggable capabilities to the Veryfront framework through the [contract-based extension system](../docs/guides/extensions.md).
+First-party extension packages that provide pluggable capabilities to the
+Veryfront framework through the
+[contract-based extension system](../docs/guides/extensions.md).
 
-Each extension registers one or more **contracts**. A contract is a typed interface that Veryfront resolves lazily at first use.
+Each extension registers one or more **contracts**. A contract is a typed
+interface that Veryfront resolves lazily at first use.
 
 Extension availability is separate from contract requirement:
 
-- Built-in extensions are auto-enabled by core bootstrap. You do not need to add them to `veryfront.config.ts`.
-- Optional extensions are user-installed and configured when a project needs the feature.
-- A contract becomes required only when a feature or extension resolves it. Missing required contracts throw an install-suggestion error at first use.
+- Built-in extensions are auto-enabled by core bootstrap. You do not need to add
+  them to `veryfront.config.ts`.
+- Optional extensions are user-installed and configured when a project needs the
+  feature.
+- A contract becomes required only when a feature or extension resolves it.
+  Missing required contracts throw an install-suggestion error at first use.
 
 ## Extension catalog
 
 ### LLM
 
-| Package | Contract | Description |
-|---------|----------|-------------|
-| [`@veryfront/ext-llm-anthropic`](./ext-llm-anthropic) | `LLMProvider` | Anthropic Claude models via `@anthropic-ai/sdk` |
-| [`@veryfront/ext-llm-google`](./ext-llm-google) | `LLMProvider` | Google Gemini models via `@google/generative-ai` |
-| [`@veryfront/ext-llm-openai`](./ext-llm-openai) | `LLMProvider` | OpenAI models via `openai` SDK |
+| Package                                               | Contract      | Description                                      |
+| ----------------------------------------------------- | ------------- | ------------------------------------------------ |
+| [`@veryfront/ext-llm-anthropic`](./ext-llm-anthropic) | `LLMProvider` | Anthropic Claude models via `@anthropic-ai/sdk`  |
+| [`@veryfront/ext-llm-google`](./ext-llm-google)       | `LLMProvider` | Google Gemini models via `@google/generative-ai` |
+| [`@veryfront/ext-llm-openai`](./ext-llm-openai)       | `LLMProvider` | OpenAI models via `openai` SDK                   |
 
 ### Auth
 
-| Package | Contract | Description |
-|---------|----------|-------------|
+| Package                                     | Contract       | Description                                                   |
+| ------------------------------------------- | -------------- | ------------------------------------------------------------- |
 | [`@veryfront/ext-auth-jwt`](./ext-auth-jwt) | `AuthProvider` | JWT sign/verify (HS256) and remote JWKS validation via `jose` |
 
 ### Build
 
-| Package | Contract | Description |
-|---------|----------|-------------|
-| [`@veryfront/ext-bundler-esbuild`](./ext-bundler-esbuild) | `Bundler`, `ModuleLexer` | ESM bundling and module analysis via `esbuild` and `es-module-lexer` |
-| [`@veryfront/ext-parser-babel`](./ext-parser-babel) | `CodeParser` | JS/TS AST parsing, traversal, and JSX source-position injection via Babel |
-| [`@veryfront/ext-css-tailwind`](./ext-css-tailwind) | `CSSProcessor` | Tailwind CSS v4 compilation with dynamic plugin loading |
+| Package                                                   | Contract                 | Description                                                               |
+| --------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------- |
+| [`@veryfront/ext-bundler-esbuild`](./ext-bundler-esbuild) | `Bundler`, `ModuleLexer` | ESM bundling and module analysis via `esbuild` and `es-module-lexer`      |
+| [`@veryfront/ext-parser-babel`](./ext-parser-babel)       | `CodeParser`             | JS/TS AST parsing, traversal, and JSX source-position injection via Babel |
+| [`@veryfront/ext-css-tailwind`](./ext-css-tailwind)       | `CSSProcessor`           | Tailwind CSS v4 compilation with dynamic plugin loading                   |
 
 ### Content
 
-| Package | Contract | Description |
-|---------|----------|-------------|
+| Package                                           | Contract           | Description                                           |
+| ------------------------------------------------- | ------------------ | ----------------------------------------------------- |
 | [`@veryfront/ext-content-mdx`](./ext-content-mdx) | `ContentProcessor` | MDX and Markdown processing via unified/remark/rehype |
 
 ### Document extraction
 
-| Package | Contract | Description |
-|---------|----------|-------------|
+| Package                                                         | Contract            | Description              |
+| --------------------------------------------------------------- | ------------------- | ------------------------ |
 | [`@veryfront/ext-document-kreuzberg`](./ext-document-kreuzberg) | `DocumentExtractor` | Document text extraction |
 
 ### Schema
 
-| Package | Contract | Description |
-|---------|----------|-------------|
+| Package                                         | Contract          | Description                         |
+| ----------------------------------------------- | ----------------- | ----------------------------------- |
 | [`@veryfront/ext-schema-zod`](./ext-schema-zod) | `SchemaValidator` | Schema validation DSL backed by Zod |
 
 ### Storage
 
-| Package | Contract | Description |
-|---------|----------|-------------|
+| Package                                           | Contract          | Description                              |
+| ------------------------------------------------- | ----------------- | ---------------------------------------- |
 | [`@veryfront/ext-cache-redis`](./ext-cache-redis) | `TokenCacheStore` | Redis-backed token and cache persistence |
-| [`@veryfront/ext-db-sqlite`](./ext-db-sqlite) | `SqliteStore` | SQLite persistence |
+| [`@veryfront/ext-db-sqlite`](./ext-db-sqlite)     | `SqliteStore`     | SQLite persistence                       |
 
 ### Observability
 
-| Package | Contract | Description |
-|---------|----------|-------------|
+| Package                                                                           | Contract                                   | Description                                                                  |
+| --------------------------------------------------------------------------------- | ------------------------------------------ | ---------------------------------------------------------------------------- |
 | [`@veryfront/ext-observability-opentelemetry`](./ext-observability-opentelemetry) | `TracingExporter`, `NodeTelemetryProvider` | OpenTelemetry trace export, metrics API bridge, and Node telemetry bootstrap |
 
 ### Sandbox
 
-| Package | Contract | Description |
-|---------|----------|-------------|
+| Package                                                           | Contract                    | Description                                 |
+| ----------------------------------------------------------------- | --------------------------- | ------------------------------------------- |
 | [`@veryfront/ext-sandbox-shell-tools`](./ext-sandbox-shell-tools) | `SandboxShellToolsProvider` | Sandbox shell tool creation via `bash-tool` |
 
 ## Auto-enabled core extensions
 
-These extensions are loaded by `createBuiltinExtensions()` during app bootstrap unless a project disables or overrides them by name.
+These extensions are loaded by `createBuiltinExtensions()` during app bootstrap
+unless a project disables or overrides them by name.
 
-| Package | Contracts |
-|---------|-----------|
-| `@veryfront/ext-schema-zod` | `SchemaValidator` |
-| `@veryfront/ext-bundler-esbuild` | `Bundler`, `ModuleLexer` |
-| `@veryfront/ext-parser-babel` | `CodeParser` |
-| `@veryfront/ext-content-mdx` | `ContentProcessor` |
-| `@veryfront/ext-css-tailwind` | `CSSProcessor` |
-| `@veryfront/ext-document-kreuzberg` | `DocumentExtractor` |
-| `@veryfront/ext-db-sqlite` | `SqliteStore` |
+| Package                              | Contracts                   |
+| ------------------------------------ | --------------------------- |
+| `@veryfront/ext-schema-zod`          | `SchemaValidator`           |
+| `@veryfront/ext-bundler-esbuild`     | `Bundler`, `ModuleLexer`    |
+| `@veryfront/ext-parser-babel`        | `CodeParser`                |
+| `@veryfront/ext-content-mdx`         | `ContentProcessor`          |
+| `@veryfront/ext-css-tailwind`        | `CSSProcessor`              |
+| `@veryfront/ext-document-kreuzberg`  | `DocumentExtractor`         |
+| `@veryfront/ext-db-sqlite`           | `SqliteStore`               |
 | `@veryfront/ext-sandbox-shell-tools` | `SandboxShellToolsProvider` |
-| `@veryfront/ext-llm-openai` | `LLMProvider:openai` |
-| `@veryfront/ext-llm-anthropic` | `LLMProvider:anthropic` |
-| `@veryfront/ext-llm-google` | `LLMProvider:google` |
+| `@veryfront/ext-llm-openai`          | `LLMProvider:openai`        |
+| `@veryfront/ext-llm-anthropic`       | `LLMProvider:anthropic`     |
+| `@veryfront/ext-llm-google`          | `LLMProvider:google`        |
 
 ## Contract requirements
 
-Veryfront treats contracts as required at the call site, not at the package list level.
+Veryfront treats contracts as required at the call site, not at the package list
+level.
 
-| Contract | Required when | Default source |
-|----------|---------------|----------------|
-| `SchemaValidator` | Schema-backed runtime validation runs | Auto-enabled core extension |
-| `Bundler`, `ModuleLexer` | Build, import analysis, or module bundling runs | Auto-enabled core extension |
-| `CodeParser` | AST parsing or build-time code analysis runs | Auto-enabled core extension |
-| `ContentProcessor` | MDX or Markdown content compilation runs | Auto-enabled core extension |
-| `CSSProcessor` | Tailwind CSS processing runs | Auto-enabled core extension |
-| `DocumentExtractor` | Document text extraction runs | Auto-enabled native service extension |
-| `SqliteStore` | SQLite-backed persistence runs | Auto-enabled native service extension |
-| `SandboxShellToolsProvider` | Sandbox shell tools are created | Auto-enabled core extension |
-| `LLMProvider:*` | A matching model provider is selected | Auto-enabled core extension |
-| `AuthProvider` | Auth signing or verification is configured | User-installed extension |
-| `TokenCacheStore` | Redis-backed token cache is configured | User-installed extension |
-| `TracingExporter` | OTLP tracing export is configured | User-installed extension |
-| `NodeTelemetryProvider` | Node agent service telemetry is enabled | Auto-enabled agent service extension |
+| Contract                    | Required when                                   | Default source                        |
+| --------------------------- | ----------------------------------------------- | ------------------------------------- |
+| `SchemaValidator`           | Schema-backed runtime validation runs           | Auto-enabled core extension           |
+| `Bundler`, `ModuleLexer`    | Build, import analysis, or module bundling runs | Auto-enabled core extension           |
+| `CodeParser`                | AST parsing or build-time code analysis runs    | Auto-enabled core extension           |
+| `ContentProcessor`          | MDX or Markdown content compilation runs        | Auto-enabled core extension           |
+| `CSSProcessor`              | Tailwind CSS processing runs                    | Auto-enabled core extension           |
+| `DocumentExtractor`         | Document text extraction runs                   | Auto-enabled native service extension |
+| `SqliteStore`               | SQLite-backed persistence runs                  | Auto-enabled native service extension |
+| `SandboxShellToolsProvider` | Sandbox shell tools are created                 | Auto-enabled core extension           |
+| `LLMProvider:*`             | A matching model provider is selected           | Auto-enabled core extension           |
+| `AuthProvider`              | Auth signing or verification is configured      | User-installed extension              |
+| `TokenCacheStore`           | Redis-backed token cache is configured          | User-installed extension              |
+| `TracingExporter`           | OTLP tracing export is configured               | User-installed extension              |
+| `NodeTelemetryProvider`     | Node agent service telemetry is enabled         | Auto-enabled agent service extension  |
 
 ## Architecture
 
@@ -155,10 +163,19 @@ ext-<name>/
 ```
 
 The `deno.json` declares:
+
 - **name**: `@veryfront/ext-<name>`
 - **version**: Semver string
 - **exports**: Entry point (`./src/index.ts`)
 - **veryfront.capabilities**: Contract registrations and runtime permissions
+
+## Dependency ownership
+
+Each extension owns its third-party dependencies through its own `deno.json`.
+Run `deno task sbom:all --output-dir dist/dependency-sboms` from the repository
+root to generate one SBOM per extension plus aggregate, core, CLI, and React
+boundary views. Use `dependencies-by-manifest.json` in that output to inspect
+the grouped dependency list quickly.
 
 ## Creating an Extension
 
@@ -166,4 +183,5 @@ The `deno.json` declares:
 veryfront extension init my-extension
 ```
 
-See the [Extensions Guide](../docs/guides/extensions.md) for the full development workflow.
+See the [Extensions Guide](../docs/guides/extensions.md) for the full
+development workflow.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,40 +14,48 @@ scripts/
   rlm-ts/         # RLM tooling
 ```
 
-Cross-runtime (Node/Bun) test infrastructure lives in `tests/node/` and `tests/bun/`.
+Cross-runtime (Node/Bun) test infrastructure lives in `tests/node/` and
+`tests/bun/`.
 
 ## build/
 
-| Script | Task | Purpose |
-|--------|------|---------|
-| `generate-templates-manifest.ts` | `build` | Generates template manifest for CLI scaffolding |
-| `generate-dev-ui-manifest.ts` | `build` | Generates dev UI asset manifest |
-| `prepare-framework-sources.ts` | `build` | Prepares framework `.src` files for SSR transforms |
-| `build-all.js` | — | Cross-compiles CLI binary for all platforms |
-| `build-npm-dnt.ts` | `build:npm` | Builds npm package via dnt (Deno-to-Node transform) |
+| Script                           | Task        | Purpose                                             |
+| -------------------------------- | ----------- | --------------------------------------------------- |
+| `generate-templates-manifest.ts` | `build`     | Generates template manifest for CLI scaffolding     |
+| `generate-dev-ui-manifest.ts`    | `build`     | Generates dev UI asset manifest                     |
+| `prepare-framework-sources.ts`   | `build`     | Prepares framework `.src` files for SSR transforms  |
+| `build-all.js`                   | —           | Cross-compiles CLI binary for all platforms         |
+| `build-npm-dnt.ts`               | `build:npm` | Builds npm package via dnt (Deno-to-Node transform) |
 
 ## lint/
 
-| Script | Task | Purpose |
-|--------|------|---------|
-| `audit-core-deps.ts` | `lint:core-deps` | Prevents root `npm:` literals and direct third-party imports from leaking into core source |
-| `audit-deps.ts` | `lint:deps` | Checks dependency import pins across root and extension manifests |
-| `ban-console.ts` | `lint:ban-console` | Lints for inappropriate console usage |
-| `ban-deep-imports.ts` | `lint:ban-deep-imports` | Prevents deep imports from internal modules |
-| `ban-internal-root-imports.ts` | `lint:ban-internal-root-imports` | Prevents root-level imports in internal modules |
-| `check-unawaited-promises.ts` | `lint:check-awaits` | Detects unawaited async cleanup calls |
-| `find-duplicate-functions.ts` | `dupes` | Finds exact and near-duplicate functions, plus semantic AST-based matches via `--semantic` |
-| `lint-platform-agnostic.ts` | `lint:platform` | Checks platform-agnostic code boundaries |
-| `validate-architecture.ts` | `validate:architecture` | Validates module dependency boundaries |
-| `check-doc-links.ts` | `docs:check-links` | Validates documentation links |
-| `check-coverage.ts` | `coverage:report` | Validates test coverage thresholds |
+| Script                         | Task                             | Purpose                                                                                    |
+| ------------------------------ | -------------------------------- | ------------------------------------------------------------------------------------------ |
+| `audit-core-deps.ts`           | `lint:core-deps`                 | Prevents root `npm:` literals and direct third-party imports from leaking into core source |
+| `audit-deps.ts`                | `lint:deps`                      | Checks dependency import pins across root and extension manifests                          |
+| `ban-console.ts`               | `lint:ban-console`               | Lints for inappropriate console usage                                                      |
+| `ban-deep-imports.ts`          | `lint:ban-deep-imports`          | Prevents deep imports from internal modules                                                |
+| `ban-internal-root-imports.ts` | `lint:ban-internal-root-imports` | Prevents root-level imports in internal modules                                            |
+| `check-unawaited-promises.ts`  | `lint:check-awaits`              | Detects unawaited async cleanup calls                                                      |
+| `find-duplicate-functions.ts`  | `dupes`                          | Finds exact and near-duplicate functions, plus semantic AST-based matches via `--semantic` |
+| `lint-platform-agnostic.ts`    | `lint:platform`                  | Checks platform-agnostic code boundaries                                                   |
+| `validate-architecture.ts`     | `validate:architecture`          | Validates module dependency boundaries                                                     |
+| `check-doc-links.ts`           | `docs:check-links`               | Validates documentation links                                                              |
+| `check-coverage.ts`            | `coverage:report`                | Validates test coverage thresholds                                                         |
 
 ## Dependency visibility
 
 Use `deno task sbom:all --output-dir dist/dependency-sboms` to generate
-segregated CycloneDX SBOMs for core, CLI, each extension, and the aggregate
-workspace. The same output includes `dependencies-by-manifest.json`, which is
-the fastest way to inspect dependencies grouped by boundary.
+segregated CycloneDX SBOMs for core, CLI, React, each extension, and the
+aggregate workspace. The same output includes `dependencies-by-manifest.json`,
+which is the fastest way to inspect dependencies grouped by boundary.
+
+`core.json` maps to the root framework boundary (`deno.json` and `src/`).
+`react.json` maps to the React import aliases in the root import map, including
+supported esm.sh `deps=` package pins. This keeps React visible as its own
+boundary while `src/` remains the implementation tree. Extension SBOMs include
+npm imports from `deno.lock` and supported esm.sh aliases declared by the
+extension manifest.
 
 The security audit workflow uploads those files as the `dependency-sboms`
 artifact. It also runs `lint:deps` and `lint:core-deps` so dependency pins and
@@ -55,13 +63,13 @@ core dependency boundaries are checked together.
 
 ## Root-level scripts
 
-| Script | Task | Purpose |
-|--------|------|---------|
-| `release.ts` | `release` | Automated release workflow |
-| `setup.ts` | `setup` | Project setup and initialization |
-| `server.ts` | `typecheck` | Entry point for typecheck |
-| `install.sh` / `install.ps1` | — | Binary installer (curl/PowerShell) |
-| `postinstall.js` | — | npm postinstall hook (copied into npm package) |
-| `update-homebrew-formula.sh` | — | Updates Homebrew formula after release |
-| `debug-production.sh` | — | Quick production debugging helper |
-| `test-production-fix.ts` | — | Tests production fixes locally |
+| Script                       | Task        | Purpose                                        |
+| ---------------------------- | ----------- | ---------------------------------------------- |
+| `release.ts`                 | `release`   | Automated release workflow                     |
+| `setup.ts`                   | `setup`     | Project setup and initialization               |
+| `server.ts`                  | `typecheck` | Entry point for typecheck                      |
+| `install.sh` / `install.ps1` | —           | Binary installer (curl/PowerShell)             |
+| `postinstall.js`             | —           | npm postinstall hook (copied into npm package) |
+| `update-homebrew-formula.sh` | —           | Updates Homebrew formula after release         |
+| `debug-production.sh`        | —           | Quick production debugging helper              |
+| `test-production-fix.ts`     | —           | Tests production fixes locally                 |

--- a/scripts/build/generate-sbom.test.ts
+++ b/scripts/build/generate-sbom.test.ts
@@ -202,6 +202,14 @@ describe("componentsFromLock", () => {
     );
   });
 
+  it("ignores non-exact esm.sh deps query packages", () => {
+    const components = componentsFromEsmShImports({
+      "main": "https://esm.sh/main@1.0.0?deps=range-only@^1,latest-tag@latest",
+    });
+
+    assertEquals(components.map((component) => component.name), ["main"]);
+  });
+
   it("plans an aggregate SBOM plus one SBOM per workspace manifest", () => {
     const lock = JSON.stringify({
       version: "5",

--- a/scripts/build/generate-sbom.test.ts
+++ b/scripts/build/generate-sbom.test.ts
@@ -1,6 +1,8 @@
 import { assertEquals, assertThrows } from "#std/assert";
 import { describe, it } from "jsr:@std/testing/bdd";
 import {
+  componentsForManifestBoundary,
+  componentsFromEsmShImports,
   componentsFromLock,
   componentsFromLockForManifest,
   dependencyIndexForAllManifests,
@@ -128,20 +130,93 @@ describe("componentsFromLock", () => {
     );
   });
 
+  it("can emit lock and esm.sh components for one workspace manifest boundary", () => {
+    const lock = JSON.stringify({
+      version: "5",
+      specifiers: {
+        "npm:bash-tool@1.3.16": "1.3.16",
+      },
+      npm: {
+        "bash-tool@1.3.16": { integrity: "sha512-shell", dependencies: [] },
+      },
+      workspace: {
+        dependencies: [],
+        members: {
+          "extensions/ext-css-tailwind": {
+            dependencies: ["npm:bash-tool@1.3.16"],
+          },
+        },
+      },
+    });
+
+    const components = componentsForManifestBoundary(
+      lock,
+      "extensions/ext-css-tailwind/deno.json",
+      {
+        manifestImportsByPath: {
+          "extensions/ext-css-tailwind/deno.json": {
+            tailwindcss: "https://esm.sh/tailwindcss@4.2.2",
+          },
+        },
+      },
+    );
+
+    assertEquals(components.map((component) => component.name), [
+      "bash-tool",
+      "tailwindcss",
+    ]);
+  });
+
+  it("emits npm package components from esm.sh import aliases", () => {
+    const components = componentsFromEsmShImports({
+      "@types/react": "https://esm.sh/@types/react@19.2.14?deps=csstype@3.2.3",
+      "react/jsx-runtime":
+        "https://esm.sh/react@19.2.4/jsx-runtime?external=react&target=es2022",
+      "react": "https://esm.sh/react@19.2.4?target=es2022",
+      "std/path": "jsr:@std/path@1.2.3",
+    });
+
+    assertEquals(
+      components.map((component) => ({
+        name: component.name,
+        version: component.version,
+        purl: component.purl,
+      })),
+      [
+        {
+          name: "@types/react",
+          version: "19.2.14",
+          purl: "pkg:npm/%40types/react@19.2.14",
+        },
+        {
+          name: "csstype",
+          version: "3.2.3",
+          purl: "pkg:npm/csstype@3.2.3",
+        },
+        {
+          name: "react",
+          version: "19.2.4",
+          purl: "pkg:npm/react@19.2.4",
+        },
+      ],
+    );
+  });
+
   it("plans an aggregate SBOM plus one SBOM per workspace manifest", () => {
     const lock = JSON.stringify({
       version: "5",
       specifiers: {
-        "npm:react@19.2.4": "19.2.4",
         "npm:bash-tool@1.3.16": "1.3.16",
       },
       npm: {
-        "react@19.2.4": { integrity: "sha512-react", dependencies: [] },
         "bash-tool@1.3.16": { integrity: "sha512-shell", dependencies: [] },
       },
       workspace: {
-        dependencies: ["npm:react@19.2.4"],
+        dependencies: [],
         members: {
+          "extensions/ext-css-tailwind": {
+            dependencies: [],
+          },
           "extensions/ext-sandbox-shell-tools": {
             dependencies: ["npm:bash-tool@1.3.16"],
           },
@@ -153,8 +228,22 @@ describe("componentsFromLock", () => {
       outputDir: "dist/sbom-0.1.519",
       workspaceMembers: [
         "cli",
+        "extensions/ext-css-tailwind",
         "extensions/ext-sandbox-shell-tools",
       ],
+      reactImports: {
+        react: "https://esm.sh/react@19.2.4?target=es2022",
+        "react-dom":
+          "https://esm.sh/react-dom@19.2.4?external=react&target=es2022",
+        "react/jsx-runtime":
+          "https://esm.sh/react@19.2.4/jsx-runtime?deps=csstype@3.2.3&external=react&target=es2022",
+      },
+      manifestImportsByPath: {
+        "extensions/ext-css-tailwind/deno.json": {
+          tailwindcss: "https://esm.sh/tailwindcss@4.2.2",
+          "tailwindcss/plugin": "https://esm.sh/tailwindcss@4.2.2/plugin",
+        },
+      },
     });
 
     assertEquals(
@@ -163,6 +252,8 @@ describe("componentsFromLock", () => {
         "dist/sbom-0.1.519/all.json",
         "dist/sbom-0.1.519/core.json",
         "dist/sbom-0.1.519/cli.json",
+        "dist/sbom-0.1.519/react.json",
+        "dist/sbom-0.1.519/ext-css-tailwind.json",
         "dist/sbom-0.1.519/ext-sandbox-shell-tools.json",
       ],
     );
@@ -172,35 +263,44 @@ describe("componentsFromLock", () => {
         "veryfront",
         "veryfront:deno.json",
         "veryfront:cli/deno.json",
+        "veryfront:react",
+        "veryfront:extensions/ext-css-tailwind/deno.json",
         "veryfront:extensions/ext-sandbox-shell-tools/deno.json",
       ],
     );
     assertEquals(outputs[0].components.map((component) => component.name), [
       "bash-tool",
+      "csstype",
       "react",
+      "react-dom",
+      "tailwindcss",
     ]);
-    assertEquals(outputs[1].components.map((component) => component.name), [
-      "react",
-    ]);
+    assertEquals(outputs[1].components, []);
     assertEquals(outputs[2].components, []);
     assertEquals(outputs[3].components.map((component) => component.name), [
+      "csstype",
+      "react",
+      "react-dom",
+    ]);
+    assertEquals(outputs[4].components.map((component) => component.name), [
+      "tailwindcss",
+    ]);
+    assertEquals(outputs[5].components.map((component) => component.name), [
       "bash-tool",
     ]);
   });
 
-  it("builds a dependency index grouped by core, cli, and extension manifests", () => {
+  it("builds a dependency index grouped by core, cli, react, and extension manifests", () => {
     const lock = JSON.stringify({
       version: "5",
       specifiers: {
-        "npm:react@19.2.4": "19.2.4",
         "npm:bash-tool@1.3.16": "1.3.16",
       },
       npm: {
-        "react@19.2.4": { integrity: "sha512-react", dependencies: [] },
         "bash-tool@1.3.16": { integrity: "sha512-shell", dependencies: [] },
       },
       workspace: {
-        dependencies: ["npm:react@19.2.4"],
+        dependencies: [],
         members: {
           "extensions/ext-sandbox-shell-tools": {
             dependencies: ["npm:bash-tool@1.3.16"],
@@ -214,6 +314,9 @@ describe("componentsFromLock", () => {
         "cli",
         "extensions/ext-sandbox-shell-tools",
       ],
+      reactImports: {
+        react: "https://esm.sh/react@19.2.4?target=es2022",
+      },
     });
 
     assertEquals(
@@ -226,12 +329,17 @@ describe("componentsFromLock", () => {
         {
           sourceLocation: "deno.json",
           group: "core",
-          componentNames: ["react"],
+          componentNames: [],
         },
         {
           sourceLocation: "cli/deno.json",
           group: "cli",
           componentNames: [],
+        },
+        {
+          sourceLocation: "react",
+          group: "react",
+          componentNames: ["react"],
         },
         {
           sourceLocation: "extensions/ext-sandbox-shell-tools/deno.json",

--- a/scripts/build/generate-sbom.ts
+++ b/scripts/build/generate-sbom.ts
@@ -42,7 +42,7 @@ export interface SbomOutput {
 
 export interface DependencyIndexManifest {
   sourceLocation: string;
-  group: "core" | "cli" | "extension" | "workspace";
+  group: "core" | "cli" | "react" | "extension" | "workspace";
   componentCount: number;
   components: Array<{
     name: string;
@@ -55,6 +55,22 @@ export interface DependencyIndex {
   generatedBy: string;
   manifests: DependencyIndexManifest[];
 }
+
+export interface DependencyBoundaryInputs {
+  reactImports?: Record<string, string>;
+  manifestImportsByPath?: Record<string, Record<string, string>>;
+}
+
+const REACT_BOUNDARY_IMPORTS = new Set([
+  "@types/react",
+  "@types/react-dom",
+  "react",
+  "react-dom",
+  "react-dom/client",
+  "react-dom/server",
+  "react/jsx-dev-runtime",
+  "react/jsx-runtime",
+]);
 
 function hashFromIntegrity(
   integrity: string | undefined,
@@ -139,6 +155,114 @@ export function componentsFromLockForManifest(
   );
 }
 
+function parseNpmPackageSpec(
+  packageSpec: string,
+): { name: string; version: string } | null {
+  const versionIndex = packageSpec.lastIndexOf("@");
+  if (versionIndex <= 0) return null;
+
+  const name = packageSpec.slice(0, versionIndex);
+  const version = packageSpec.slice(versionIndex + 1);
+  if (!name || !version) return null;
+  return { name, version };
+}
+
+function packageSpecFromEsmShPath(pathname: string): string | null {
+  const segments = decodeURIComponent(pathname)
+    .replace(/^\/+/, "")
+    .split("/")
+    .filter(Boolean);
+  if (segments.length === 0) return null;
+  return segments[0].startsWith("@")
+    ? `${segments[0]}/${segments[1] ?? ""}`
+    : segments[0];
+}
+
+function parseEsmShNpmPackages(
+  target: string,
+): Array<{ name: string; version: string }> {
+  let url: URL;
+  try {
+    url = new URL(target);
+  } catch {
+    return [];
+  }
+
+  if (url.protocol !== "https:" || url.hostname !== "esm.sh") return [];
+
+  const packages: Array<{ name: string; version: string }> = [];
+  const packageSpec = packageSpecFromEsmShPath(url.pathname);
+  if (packageSpec) {
+    const npmPackage = parseNpmPackageSpec(packageSpec);
+    if (npmPackage) packages.push(npmPackage);
+  }
+
+  for (const depsValue of url.searchParams.getAll("deps")) {
+    for (const depSpec of depsValue.split(",")) {
+      const npmPackage = parseNpmPackageSpec(depSpec.trim());
+      if (npmPackage) packages.push(npmPackage);
+    }
+  }
+
+  return packages;
+}
+
+export function componentsFromEsmShImports(
+  imports: Record<string, string> = {},
+  options: { onlySpecifiers?: Set<string> } = {},
+): CycloneDXComponent[] {
+  const components = new Map<string, CycloneDXComponent>();
+
+  for (const [specifier, target] of Object.entries(imports)) {
+    if (options.onlySpecifiers && !options.onlySpecifiers.has(specifier)) {
+      continue;
+    }
+    for (const npmPackage of parseEsmShNpmPackages(target)) {
+      const key = `${npmPackage.name}@${npmPackage.version}`;
+      if (components.has(key)) continue;
+      components.set(key, {
+        type: "library",
+        name: npmPackage.name,
+        version: npmPackage.version,
+        purl: purl(npmPackage.name, npmPackage.version),
+      });
+    }
+  }
+
+  return sortComponents([...components.values()]);
+}
+
+export function componentsForManifestBoundary(
+  lockText: string,
+  manifestPath: string,
+  inputs: DependencyBoundaryInputs = {},
+): CycloneDXComponent[] {
+  return dedupeComponents([
+    ...componentsFromLockForManifest(lockText, manifestPath),
+    ...componentsFromEsmShImports(
+      inputs.manifestImportsByPath?.[manifestPath] ?? {},
+    ),
+  ]);
+}
+
+function componentsForReactBoundary(
+  inputs: DependencyBoundaryInputs = {},
+): CycloneDXComponent[] {
+  return componentsFromEsmShImports(inputs.reactImports ?? {}, {
+    onlySpecifiers: REACT_BOUNDARY_IMPORTS,
+  });
+}
+
+function dedupeComponents(
+  components: CycloneDXComponent[],
+): CycloneDXComponent[] {
+  const byPurl = new Map<string, CycloneDXComponent>();
+  for (const component of components) {
+    byPurl.set(component.purl, component);
+  }
+  return sortComponents([...byPurl.values()]);
+}
+
 function sortComponents(
   components: CycloneDXComponent[],
 ): CycloneDXComponent[] {
@@ -165,6 +289,7 @@ function workspaceMembersFromDenoConfig(
 function outputFileNameForManifest(manifestPath: string): string {
   if (manifestPath === "deno.json") return "core.json";
   if (manifestPath === "cli/deno.json") return "cli.json";
+  if (manifestPath === "react") return "react.json";
   const extensionMatch = manifestPath.match(
     /^extensions\/([^/]+)\/deno\.json$/,
   );
@@ -180,7 +305,9 @@ function joinOutputPath(outputDir: string, fileName: string): string {
 
 export function sbomOutputsForAllManifests(
   lockText: string,
-  options: ManifestGenerationOptions & { outputDir: string },
+  options: ManifestGenerationOptions & DependencyBoundaryInputs & {
+    outputDir: string;
+  },
 ): SbomOutput[] {
   const manifests = manifestsFromLock(lockText, {
     sha: "local",
@@ -197,20 +324,46 @@ export function sbomOutputsForAllManifests(
     return left.localeCompare(right);
   });
 
+  const reactComponents = componentsForReactBoundary(options);
+  const boundaryOutputs = manifestPaths.map((manifestPath) => ({
+    path: joinOutputPath(
+      options.outputDir,
+      outputFileNameForManifest(manifestPath),
+    ),
+    componentName: `veryfront:${manifestPath}`,
+    components: componentsForManifestBoundary(lockText, manifestPath, options),
+  }));
+  const allComponents = dedupeComponents([
+    ...componentsFromLock(lockText),
+    ...reactComponents,
+    ...boundaryOutputs.flatMap((output) => output.components),
+  ]);
+
+  const leadingOutputs = boundaryOutputs.filter((output) =>
+    output.componentName === "veryfront:deno.json" ||
+    output.componentName === "veryfront:cli/deno.json"
+  );
+  const remainingOutputs = boundaryOutputs.filter((output) =>
+    output.componentName !== "veryfront:deno.json" &&
+    output.componentName !== "veryfront:cli/deno.json"
+  );
+
   return [
     {
       path: joinOutputPath(options.outputDir, "all.json"),
       componentName: "veryfront",
-      components: componentsFromLock(lockText),
+      components: allComponents,
     },
-    ...manifestPaths.map((manifestPath) => ({
+    ...leadingOutputs,
+    {
       path: joinOutputPath(
         options.outputDir,
-        outputFileNameForManifest(manifestPath),
+        outputFileNameForManifest("react"),
       ),
-      componentName: `veryfront:${manifestPath}`,
-      components: componentsFromLockForManifest(lockText, manifestPath),
-    })),
+      componentName: "veryfront:react",
+      components: reactComponents,
+    },
+    ...remainingOutputs,
   ];
 }
 
@@ -219,6 +372,7 @@ function manifestGroup(
 ): DependencyIndexManifest["group"] {
   if (manifestPath === "deno.json") return "core";
   if (manifestPath === "cli/deno.json") return "cli";
+  if (manifestPath === "react") return "react";
   if (manifestPath.startsWith("extensions/")) return "extension";
   return "workspace";
 }
@@ -245,12 +399,34 @@ function manifestPathsFromLock(
 
 export function dependencyIndexForAllManifests(
   lockText: string,
-  options: ManifestGenerationOptions = {},
+  options: ManifestGenerationOptions & DependencyBoundaryInputs = {},
 ): DependencyIndex {
+  const reactComponents = componentsForReactBoundary(options);
+  const manifestEntries = manifestPathsFromLock(lockText, options).map(
+    (manifestPath) => ({
+      manifestPath,
+      components: componentsForManifestBoundary(
+        lockText,
+        manifestPath,
+        options,
+      ),
+    }),
+  );
+  const leadingEntries = manifestEntries.filter(({ manifestPath }) =>
+    manifestPath === "deno.json" || manifestPath === "cli/deno.json"
+  );
+  const remainingEntries = manifestEntries.filter(({ manifestPath }) =>
+    manifestPath !== "deno.json" && manifestPath !== "cli/deno.json"
+  );
+  const orderedEntries = [
+    ...leadingEntries,
+    { manifestPath: "react", components: reactComponents },
+    ...remainingEntries,
+  ];
+
   return {
     generatedBy: "generate-sbom",
-    manifests: manifestPathsFromLock(lockText, options).map((manifestPath) => {
-      const components = componentsFromLockForManifest(lockText, manifestPath);
+    manifests: orderedEntries.map(({ manifestPath, components }) => {
       return {
         sourceLocation: manifestPath,
         group: manifestGroup(manifestPath),
@@ -263,6 +439,25 @@ export function dependencyIndexForAllManifests(
       };
     }),
   };
+}
+
+async function importsByWorkspaceManifest(
+  workspaceMembers: string[],
+): Promise<Record<string, Record<string, string>>> {
+  const importsByManifest: Record<string, Record<string, string>> = {};
+  for (const workspaceMember of workspaceMembers) {
+    const manifestPath = `${workspaceMember}/deno.json`;
+    try {
+      const manifest = JSON.parse(await Deno.readTextFile(manifestPath));
+      if (manifest.imports && typeof manifest.imports === "object") {
+        importsByManifest[manifestPath] = manifest.imports;
+      }
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) continue;
+      throw error;
+    }
+  }
+  return importsByManifest;
 }
 
 function buildSbom(
@@ -318,13 +513,22 @@ if (import.meta.main) {
 
   if (args["all-manifests"]) {
     const workspaceMembers = workspaceMembersFromDenoConfig(denoConfig);
+    const manifestImportsByPath = await importsByWorkspaceManifest(
+      workspaceMembers,
+    );
     const outputs = sbomOutputsForAllManifests(lockText, {
       outputDir: args["output-dir"],
       workspaceMembers,
+      reactImports: denoConfig.imports,
+      manifestImportsByPath,
     });
     await writeSbom(
       joinOutputPath(args["output-dir"], "dependencies-by-manifest.json"),
-      dependencyIndexForAllManifests(lockText, { workspaceMembers }),
+      dependencyIndexForAllManifests(lockText, {
+        workspaceMembers,
+        reactImports: denoConfig.imports,
+        manifestImportsByPath,
+      }),
     );
     console.log(
       `✅ Generated dependency index: ${
@@ -346,8 +550,18 @@ if (import.meta.main) {
     Deno.exit(0);
   }
 
+  const workspaceMembers = workspaceMembersFromDenoConfig(denoConfig);
+  const manifestImportsByPath = args.manifest
+    ? await importsByWorkspaceManifest(workspaceMembers)
+    : {};
+  const boundaryInputs = {
+    reactImports: denoConfig.imports,
+    manifestImportsByPath,
+  };
   const components = args.manifest
-    ? componentsFromLockForManifest(lockText, args.manifest)
+    ? args.manifest === "react"
+      ? componentsForReactBoundary(boundaryInputs)
+      : componentsForManifestBoundary(lockText, args.manifest, boundaryInputs)
     : componentsFromLock(lockText);
   const componentName = args.manifest
     ? `${denoConfig.name ?? "veryfront"}:${args.manifest}`

--- a/scripts/build/generate-sbom.ts
+++ b/scripts/build/generate-sbom.ts
@@ -72,6 +72,8 @@ const REACT_BOUNDARY_IMPORTS = new Set([
   "react/jsx-runtime",
 ]);
 
+const EXACT_SEMVER_RE = /^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$/;
+
 function hashFromIntegrity(
   integrity: string | undefined,
 ): { alg: string; content: string } | undefined {
@@ -163,7 +165,7 @@ function parseNpmPackageSpec(
 
   const name = packageSpec.slice(0, versionIndex);
   const version = packageSpec.slice(versionIndex + 1);
-  if (!name || !version) return null;
+  if (!name || !EXACT_SEMVER_RE.test(version)) return null;
   return { name, version };
 }
 

--- a/scripts/lint/audit-deps.test.ts
+++ b/scripts/lint/audit-deps.test.ts
@@ -52,6 +52,31 @@ describe("auditEsmShPin", () => {
     );
   });
 
+  it("accepts exact deps query pins", () => {
+    assertEquals(
+      auditEsmShPin("https://esm.sh/react@19.2.4?deps=csstype@3.2.3"),
+      null,
+    );
+  });
+
+  it("rejects range deps query pins", () => {
+    const issue = auditEsmShPin("https://esm.sh/react@19.2.4?deps=foo@^1");
+    assertEquals(issue?.severity, "error");
+    assertEquals(
+      issue?.message,
+      'esm.sh deps not pinned to exact x.y.z (got "^1")',
+    );
+  });
+
+  it("rejects tag deps query pins", () => {
+    const issue = auditEsmShPin("https://esm.sh/react@19.2.4?deps=foo@latest");
+    assertEquals(issue?.severity, "error");
+    assertEquals(
+      issue?.message,
+      'esm.sh deps not pinned to exact x.y.z (got "latest")',
+    );
+  });
+
   it("rejects scoped packages with major-only pins", () => {
     const issue = auditEsmShPin(
       "https://esm.sh/@types/react@19?deps=csstype@3.2.3",

--- a/scripts/lint/audit-deps.ts
+++ b/scripts/lint/audit-deps.ts
@@ -30,6 +30,12 @@ export interface ImportMapManifest {
 // definition of "pinned". Allows pre-release suffixes (e.g., 1.2.3-rc.1).
 const EXACT_SEMVER_RE = /^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$/;
 
+function packageVersionFromSpec(packageSpec: string): string | null {
+  const versionIndex = packageSpec.lastIndexOf("@");
+  if (versionIndex <= 0) return null;
+  return packageSpec.slice(versionIndex + 1);
+}
+
 /**
  * Inspect an https:// import target. Returns null when the target is fine
  * (or non-https, which is handled elsewhere). Reports:
@@ -78,6 +84,24 @@ export function auditEsmShPin(
       severity: "error",
       message: `esm.sh URL not pinned to exact x.y.z (got "${ver}")`,
     };
+  }
+
+  const url = new URL(target);
+  for (const depsValue of url.searchParams.getAll("deps")) {
+    for (const depSpec of depsValue.split(",")) {
+      const dep = decodeURIComponent(depSpec.trim());
+      const depVersion = packageVersionFromSpec(dep);
+      if (!depVersion || !EXACT_SEMVER_RE.test(depVersion)) {
+        return {
+          specifier,
+          target,
+          severity: "error",
+          message: depVersion
+            ? `esm.sh deps not pinned to exact x.y.z (got "${depVersion}")`
+            : "esm.sh deps missing version pin",
+        };
+      }
+    }
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- add a virtual `react` dependency boundary to SBOM and dependency-index generation
- report supported esm.sh npm packages, including `deps=` pins, under React or the owning extension manifest
- document core, CLI, React, and extension dependency ownership without renaming `src/`

## Verification
- `deno task test:scripts`
- `deno task lint:core-deps`
- `deno task lint:deps`
- `deno check --config=scripts/test.deno.json scripts/build/generate-sbom.ts scripts/build/generate-sbom.test.ts`
- `deno task docs:validate`
- `deno task lint:style`
- `deno fmt --check --config=scripts/test.deno.json scripts/build/generate-sbom.ts scripts/build/generate-sbom.test.ts scripts/README.md extensions/README.md docs/architecture/08-support-matrix.md docs/superpowers/plans/2026-05-14-react-dependency-boundary.md`
- `git diff --check`
- `deno task sbom:all --output-dir dist/dependency-sboms-check`
- `deno task sbom --manifest extensions/ext-css-tailwind/deno.json --output dist/sbom-ext-css-tailwind-check.json`
- `deno task sbom --manifest react --output dist/sbom-react-check.json`
- pre-push hook: format, lint, typecheck, generate, and unit tests (1873 passed)