### PR TITLE
Accept API runtime invocation stream payloads

### DIFF
--- a/src/agent/runtime/ag-ui-contract.ts
+++ b/src/agent/runtime/ag-ui-contract.ts
@@ -36,6 +36,12 @@ const agUiRuntimeInjectedToolNameSchema = (v: SchemaValidator) =>
     "Tool names must start with a letter and use a valid client-tool format",
   );
 
+const agUiRuntimeToolJsonSchemaDocumentSchema = (v: SchemaValidator) =>
+  v.record(v.string(), v.unknown()).refine(
+    (value) => isWithinJsonSizeLimit(value, MAX_TOOL_PARAMETERS_BYTES),
+    { message: "Tool schema metadata must be less than 16 KB" },
+  );
+
 export const getAgUiRuntimeInjectedToolSchema = defineSchema((v) =>
   v.object({
     name: agUiRuntimeInjectedToolNameSchema(v),
@@ -44,6 +50,8 @@ export const getAgUiRuntimeInjectedToolSchema = defineSchema((v) =>
       (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_TOOL_PARAMETERS_BYTES),
       { message: "Tool parameters must be less than 16 KB" },
     ),
+    inputSchema: agUiRuntimeToolJsonSchemaDocumentSchema(v).optional(),
+    outputSchema: agUiRuntimeToolJsonSchemaDocumentSchema(v).optional(),
   })
 );
 

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -95,7 +95,7 @@ function buildMergedTools(
         input.runId,
         tool.name,
         tool.description,
-        tool.parameters,
+        tool.inputSchema ?? tool.parameters,
         sessionManager,
       ),
     ]),

--- a/src/internal-agents/schema.test.ts
+++ b/src/internal-agents/schema.test.ts
@@ -150,6 +150,64 @@ describe("internal-agents/schema", () => {
     assertEquals(parsed.context, [{ description: "Current file", value: "src/main.ts" }]);
   });
 
+  it("accepts canonical runtime invocation payloads posted by the API executor", () => {
+    const internalRequest = getInternalAgentStreamRequestSchema().parse({
+      run: {
+        agentServiceId: "veryfront-platform-agent",
+        agentId: "incident-responder",
+        conversationId: "10000000-1000-4000-8000-100000000001",
+        runId: "run_1",
+        messageId: "10000000-1000-4000-8000-100000000002",
+        inputAnchorMessageId: "10000000-1000-4000-8000-100000000002",
+        requestedByUserId: "10000000-1000-4000-8000-100000000003",
+        project: {
+          projectId: "10000000-1000-4000-8000-100000000004",
+          projectSlug: "incident-responder-cwy27d",
+          runtimeTargetKind: "preview_branch",
+          runtimeTargetEnvironmentId: null,
+          runtimeTargetBranchId: "10000000-1000-4000-8000-100000000005",
+        },
+        validatedClaims: {
+          subject: "10000000-1000-4000-8000-100000000003",
+          projectId: "10000000-1000-4000-8000-100000000004",
+          projectSlug: "incident-responder-cwy27d",
+          scopes: [],
+        },
+      },
+      messages: [{
+        id: "msg_1",
+        role: "user",
+        parts: [{ type: "text", text: "hi" }],
+      }],
+      tools: [{
+        name: "studio_search_files",
+        description: "Search files",
+        inputSchema: { type: "object", properties: { query: { type: "string" } } },
+      }],
+      context: [{ type: "text", text: "Current project context" }],
+      agentSource: { type: "branch", branch: "main" },
+      forwardedProps: { runtimeOverrides: { allowedTools: ["studio_search_files"] } },
+    });
+
+    assertEquals(internalRequest.agentId, "incident-responder");
+    assertEquals(internalRequest.threadId, "10000000-1000-4000-8000-100000000001");
+    assertEquals(internalRequest.runId, "run_1");
+    assertEquals(internalRequest.messages, [{
+      id: "msg_1",
+      role: "user",
+      parts: [{ type: "text", text: "hi" }],
+    }]);
+    assertEquals(internalRequest.tools[0], {
+      name: "studio_search_files",
+      description: "Search files",
+      inputSchema: { type: "object", properties: { query: { type: "string" } } },
+    });
+    assertEquals(
+      toRuntimeRunAgentInput(internalRequest).threadId,
+      "10000000-1000-4000-8000-100000000001",
+    );
+  });
+
   it("normalizes legacy internal stream payloads into the canonical runtime input", () => {
     const internalRequest = getInternalAgentStreamRequestSchema().parse({
       agentId: "agent_1",

--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -14,6 +14,8 @@ import {
 } from "#veryfront/agent/runtime/ag-ui-contract.ts";
 import { stripLeadingEmptyObjectPlaceholder } from "#veryfront/agent/data-stream.ts";
 import {
+  buildRuntimeAgentControlPlaneStreamRequestFromInvocation,
+  getRuntimeAgentRunInvocationSchema,
   getRuntimeAgentSourceContextSchema,
   type RuntimeAgentSourceContext,
 } from "#veryfront/agent/runtime/agent-invocation-contract.ts";
@@ -55,7 +57,7 @@ export const getInternalAgentCompatibilityMessageSchema = defineSchema((v) =>
   })
 );
 
-export const getInternalAgentStreamRequestSchema = defineSchema((v) =>
+export const getInternalAgentControlPlaneStreamRequestSchema = defineSchema((v) =>
   v.object({
     agentId: getAgentIdSchema(),
     threadId: v.string().uuid(),
@@ -77,6 +79,17 @@ export const getInternalAgentStreamRequestSchema = defineSchema((v) =>
     ),
   })
 );
+
+export const getInternalAgentStreamRequestSchema = defineSchema((v) => {
+  const controlPlaneStreamRequestSchema = getInternalAgentControlPlaneStreamRequestSchema();
+
+  return v.union([
+    controlPlaneStreamRequestSchema,
+    getRuntimeAgentRunInvocationSchema()
+      .transform(buildRuntimeAgentControlPlaneStreamRequestFromInvocation)
+      .pipe(controlPlaneStreamRequestSchema),
+  ]);
+});
 
 type RuntimeMessage = AgUiRuntimeMessage;
 type InternalAgentCompatibilityMessage = InferSchema<

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -275,6 +275,136 @@ describe("server/handlers/request/agent-stream.handler", () => {
     });
   });
 
+  it("accepts canonical runtime invocation payloads from the API executor", async () => {
+    let streamContext: Record<string, unknown> | undefined;
+    let streamMessages: Array<Record<string, unknown>> | undefined;
+    let injectedToolSchema: unknown;
+
+    const inputSchema = {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+      },
+      required: ["query"],
+    };
+
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: (id) => id === "incident-responder" ? createAgent("incident-responder") : undefined,
+      getAllAgentIds: () => ["incident-responder"],
+      sessionManager: new AgentRunSessionManager(),
+      createRuntime: (_agent, mergedTools) => {
+        const tools = mergedTools as Record<string, { inputSchemaJson?: unknown }> | undefined;
+        injectedToolSchema = tools?.studio_search_files?.inputSchemaJson;
+
+        return {
+          stream: async (messages, context, callbacks) => {
+            streamMessages = messages as Array<Record<string, unknown>>;
+            streamContext = context;
+            callbacks?.onFinish?.({
+              text: "hello from runtime",
+              messages: [],
+              toolCalls: [],
+              status: "completed",
+              usage: {
+                promptTokens: 2,
+                completionTokens: 3,
+                totalTokens: 5,
+              },
+              metadata: {
+                finishReason: "stop",
+              },
+            });
+
+            return new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(
+                  encodeDataStreamEvent({ type: "message-start", messageId: "assistant-msg-1" }),
+                );
+                controller.enqueue(encodeDataStreamEvent({ type: "text-start", id: "text-1" }));
+                controller.enqueue(
+                  encodeDataStreamEvent({
+                    type: "text-delta",
+                    id: "text-1",
+                    delta: "hello from runtime",
+                  }),
+                );
+                controller.enqueue(encodeDataStreamEvent({ type: "text-end", id: "text-1" }));
+                controller.close();
+              },
+            });
+          },
+        };
+      },
+    });
+
+    const body = JSON.stringify({
+      run: {
+        agentServiceId: "veryfront-platform-agent",
+        agentId: "incident-responder",
+        conversationId: "10000000-1000-4000-8000-100000000001",
+        runId: "run_1",
+        messageId: "20000000-2000-4000-8000-200000000001",
+        inputAnchorMessageId: "20000000-2000-4000-8000-200000000001",
+        requestedByUserId: "30000000-3000-4000-8000-300000000001",
+        project: {
+          projectId: "40000000-4000-4000-8000-400000000001",
+          projectSlug: "incident-responder-cwy27d",
+          runtimeTargetKind: "preview_branch",
+          runtimeTargetBranchId: "50000000-5000-4000-8000-500000000001",
+        },
+      },
+      messages: [
+        {
+          id: "msg_1",
+          role: "user",
+          parts: [{ type: "text", text: "hi" }],
+        },
+      ],
+      tools: [
+        {
+          name: "studio_search_files",
+          description: "Search files",
+          inputSchema,
+        },
+      ],
+      context: [{ type: "text", text: "Current file: app.tsx" }],
+      forwardedProps: {
+        runtimeOverrides: {
+          allowedTools: ["studio_search_files"],
+        },
+      },
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/api/control-plane/agents/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(streamContext, {
+      threadId: "10000000-1000-4000-8000-100000000001",
+      runId: "run_1",
+      context: [{ type: "text", text: "Current file: app.tsx" }],
+      forwardedProps: {
+        runtimeOverrides: {
+          allowedTools: ["studio_search_files"],
+        },
+      },
+    });
+    assertEquals(streamMessages?.[0]?.role, "user");
+    assertEquals(injectedToolSchema, inputSchema);
+  });
+
   it("passes runtime integration tool allowlists from forwarded props into the runtime agent config", async () => {
     let capturedAllowedTools: string[] | undefined;
 


### PR DESCRIPTION
## Summary
- accept the API executor's canonical `RuntimeAgentRunInvocation` payload on `/api/control-plane/agents/stream`
- transform that payload into the existing internal control-plane stream shape before auth/runtime execution
- preserve forwarded tool `inputSchema` / `outputSchema`, and use `inputSchema` for injected Studio tool JSON schemas

## Root cause
The API executor now posts a `RuntimeAgentRunInvocation` body with a top-level `run` object to the runtime stream endpoint. The runtime still only accepted the older internal body with top-level `agentId`, `threadId`, and `runId`, so Zod rejected valid API requests with `400 Invalid internal agent stream request`.

Related Studio issue: https://github.com/veryfront/veryfront-studio/issues/3826

## Verification
- Reproduced from local Studio via agent-browser against the Incident Responder project: retrying run `a4aafc9a-98d8-46e6-a75c-cd0703b1071d` produced the same runtime `400 Invalid internal agent stream request`.
- `deno task test src/internal-agents/schema.test.ts src/server/handlers/request/agent-stream.handler.test.ts`
- `deno task typecheck`
- `deno task fmt:check src/agent/runtime/ag-ui-contract.ts src/internal-agents/run-stream.ts src/internal-agents/schema.ts src/internal-agents/schema.test.ts src/server/handlers/request/agent-stream.handler.test.ts`
