### PR TITLE
Bump veryfront to 0.1.525

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.524",
+  "version": "0.1.525",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [


### PR DESCRIPTION
## Summary
- bump `veryfront` package version to `0.1.525`
- publish a new npm artifact from main that includes the configured integration endpoints merged in #1665

## Why
The previous main release reused `0.1.524`, which was already published from #1664. npm still points `veryfront@0.1.524` at the pre-integration-endpoints commit, so API cannot consume the new connector catalog until a new package version is published.

## Verification
- `jq -r .version deno.json` → `0.1.525`
