### PR TITLE
Ensure agent schemas have builtin validator

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.525",
+  "version": "0.1.526",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/agent-invocation-contract.consumer.test.ts
+++ b/src/agent/runtime/agent-invocation-contract.consumer.test.ts
@@ -1,0 +1,29 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { RuntimeAgentRunInvocationSchema } from "./agent-invocation-contract.ts";
+
+describe("agent/runtime-agent-invocation-contract consumer defaults", () => {
+  it("parses exported schemas without requiring consumers to bootstrap extensions first", () => {
+    const parsed = RuntimeAgentRunInvocationSchema.parse({
+      run: {
+        agentServiceId: "veryfront-platform-agent",
+        agentId: "assistant",
+        conversationId: "10000000-1000-4000-8000-100000000001",
+        runId: "run-1",
+        messageId: "10000000-1000-4000-8000-100000000002",
+        inputAnchorMessageId: "10000000-1000-4000-8000-100000000002",
+        requestedByUserId: "10000000-1000-4000-8000-100000000003",
+        project: {
+          projectId: "10000000-1000-4000-8000-100000000004",
+          projectSlug: "demo-project",
+        },
+      },
+      messages: [{ id: "message-1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
+      tools: [],
+      context: [],
+      agentSource: { type: "branch", branch: "main" },
+    });
+
+    assertEquals(parsed.run.agentId, "assistant");
+  });
+});

--- a/src/agent/runtime/agent-invocation-contract.ts
+++ b/src/agent/runtime/agent-invocation-contract.ts
@@ -1,6 +1,9 @@
 import { defineSchema, lazySchema } from "#veryfront/schemas/index.ts";
 import type { InferSchema, RefinementCtx } from "#veryfront/extensions/schema/index.ts";
+import { ensureBuiltinSchemaValidator } from "#veryfront/extensions/builtin-extensions.ts";
 import { parseAgUiJsonRequestOrError } from "../ag-ui/request-shared.ts";
+
+ensureBuiltinSchemaValidator();
 
 const MAX_TOOL_PARAMETERS_BYTES = 16_384;
 const MAX_CONTEXT_ITEM_BYTES = 16_384;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.525";
+export const VERSION = "0.1.526";


### PR DESCRIPTION
## Summary
- initialize the builtin schema validator when runtime agent invocation schemas are imported
- add a consumer-style test that parses the public runtime invocation schema without requiring extension bootstrap first
- bump package version to `0.1.526` so API can consume the fixed package

## Verification
- `deno task test src/agent/runtime/agent-invocation-contract.consumer.test.ts src/agent/runtime/agent-invocation-contract.test.ts src/utils/version.test.ts src/utils/logger/logger.test.ts` → 4 files / 78 steps passed

## Context
`veryfront-api` PR #2519 exposed that `veryfront@0.1.525` can throw `Missing extension for contract "SchemaValidator"` when API imports and parses `RuntimeAgentRunInvocationSchema` outside framework bootstrap.