### PR TITLE
fix: initialize durable canary schemas

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.526",
+  "version": "0.1.527",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/testing/durable-run-canaries/runner.test.ts
+++ b/src/agent/testing/durable-run-canaries/runner.test.ts
@@ -1,5 +1,3 @@
-import "#veryfront/schemas/_test-setup.ts";
-
 import { assertEquals, assertMatch } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {

--- a/src/agent/testing/durable-run-canaries/runner.ts
+++ b/src/agent/testing/durable-run-canaries/runner.ts
@@ -1,5 +1,8 @@
 import { defineSchema } from "#veryfront/schemas/index.ts";
+import { ensureBuiltinSchemaValidator } from "#veryfront/extensions/builtin-extensions.ts";
 import type { InferSchema } from "#veryfront/extensions/schema/index.ts";
+
+ensureBuiltinSchemaValidator();
 
 export interface DurableRunCanaryApiConfig {
   apiUrl: string;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.526";
+export const VERSION = "0.1.527";


### PR DESCRIPTION
## Summary
- initialize the built-in schema validator in the durable run canary runner so package consumers can parse canary summaries without test-only schema setup
- keep the canary runner test independent from schema test preload coverage
- bump package version to 0.1.527 for CI/CD publish

## Verification
- `deno test -A src/agent/testing/durable-run-canaries/runner.test.ts`
- `deno task verify:quick`
- pre-push hook: fmt, lint, typecheck, unit tests (`1876 passed`, `0 failed`)