### PR TITLE
Accept byte arrays in live eval uploads

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.530",
+  "version": "0.1.531",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/testing/live-evals/api-client.ts
+++ b/src/agent/testing/live-evals/api-client.ts
@@ -27,7 +27,7 @@ export interface LiveEvalConversationInput extends LiveEvalRequestTimeoutInput {
 export interface LiveEvalProjectUploadFixtureInput extends LiveEvalRequestTimeoutInput {
   filePath: string;
   contentType: string;
-  body: BodyInit;
+  body: BodyInit | Uint8Array;
   size?: number;
   pollIntervalMs?: number;
   maxAttempts?: number;
@@ -160,7 +160,10 @@ function createProjectUploadHeaders(
   return uploadHeaders;
 }
 
-function getProjectUploadBodySize(body: BodyInit, explicitSize: number | undefined): number {
+function getProjectUploadBodySize(
+  body: BodyInit | Uint8Array,
+  explicitSize: number | undefined,
+): number {
   if (typeof explicitSize === "number") {
     return explicitSize;
   }
@@ -182,12 +185,15 @@ function getProjectUploadBodySize(body: BodyInit, explicitSize: number | undefin
   throw new Error("Project upload fixtures require size when body length cannot be inferred");
 }
 
-function createProjectUploadBody(body: BodyInit, contentType: string): BodyInit {
+function createProjectUploadBody(body: BodyInit | Uint8Array, contentType: string): BodyInit {
   if (body instanceof Blob) {
     return body;
   }
   if (typeof body === "string") {
     return new Blob([body], { type: contentType });
+  }
+  if (body instanceof Uint8Array) {
+    return new Blob([body.slice()], { type: contentType });
   }
   return body;
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.530";
+export const VERSION = "0.1.531";


### PR DESCRIPTION
## Summary\n- allow live-eval project upload fixtures to accept byte-array bodies\n- preserve cross-runtime upload support while keeping Blob conversion internal\n\n## Verification\n- deno test -A src/agent/testing/live-evals/api-client.test.ts\n- deno task verify:quick