### PR TITLE
Add reusable live eval metadata taxonomy

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.531",
+  "version": "0.1.532",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/testing/index.ts
+++ b/src/agent/testing/index.ts
@@ -36,6 +36,8 @@ export {
 
 export {
   buildFailureSuffix,
+  buildLiveEvalCaseMetadata,
+  type BuildLiveEvalCaseMetadataInput,
   buildLiveEvalCaseTagSummary,
   buildLiveEvalRequestBody,
   type BuildLiveEvalRequestBodyInput,
@@ -56,6 +58,8 @@ export {
   createPassedEvalResult,
   createPlainTextPdf,
   createSkippedEvalResult,
+  DEFAULT_LIVE_EVAL_AREA_TAG_RULES,
+  DEFAULT_LIVE_EVAL_OPTIONAL_JUDGE_CASE_PREFIXES,
   deleteLiveEvalConversation,
   deleteLiveEvalProjectFile,
   getLiveEvalProjectFile,
@@ -66,7 +70,10 @@ export {
   type LiveEvalApiContext,
   type LiveEvalCase,
   type LiveEvalCaseMetadata,
+  type LiveEvalCaseMetadataOptions,
   type LiveEvalCaseSelectionInput,
+  type LiveEvalCaseSurface,
+  type LiveEvalCaseTagRule,
   type LiveEvalContext,
   type LiveEvalConversationInput,
   type LiveEvalCreateConversationInput,
@@ -94,4 +101,5 @@ export {
   selectLiveEvalCases,
   submitLiveEvalInputResponse,
   waitForOpenLiveEvalInputRequest,
+  withLiveEvalMetadata,
 } from "./live-evals/index.ts";

--- a/src/agent/testing/live-evals/index.ts
+++ b/src/agent/testing/live-evals/index.ts
@@ -37,6 +37,16 @@ export {
   type RuntimePerformanceSummary,
 } from "./performance.ts";
 export {
+  buildLiveEvalCaseMetadata,
+  type BuildLiveEvalCaseMetadataInput,
+  DEFAULT_LIVE_EVAL_AREA_TAG_RULES,
+  DEFAULT_LIVE_EVAL_OPTIONAL_JUDGE_CASE_PREFIXES,
+  type LiveEvalCaseMetadataOptions,
+  type LiveEvalCaseSurface,
+  type LiveEvalCaseTagRule,
+  withLiveEvalMetadata,
+} from "./metadata.ts";
+export {
   buildLiveEvalRequestBody,
   type BuildLiveEvalRequestBodyInput,
   type LiveEvalRequestBody,

--- a/src/agent/testing/live-evals/metadata.test.ts
+++ b/src/agent/testing/live-evals/metadata.test.ts
@@ -1,0 +1,90 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { buildLiveEvalCaseMetadata, withLiveEvalMetadata } from "./metadata.ts";
+import { buildLiveEvalCaseTagSummary } from "./report.ts";
+
+Deno.test("buildLiveEvalCaseMetadata marks deterministic stable cases for CI", () => {
+  const metadata = buildLiveEvalCaseMetadata({
+    caseId: "starter-plan",
+    surface: "read-only",
+    requireProject: false,
+    releaseGateCaseIds: ["starter-plan"],
+  });
+
+  assertEquals(metadata.tags.includes("gate:ci"), true);
+  assertEquals(metadata.tags.includes("gate:nightly"), true);
+  assertEquals(metadata.tags.includes("gate:release"), true);
+  assertEquals(metadata.tags.includes("grading:deterministic-only"), true);
+  assertEquals(metadata.tags.includes("area:starter-routing"), true);
+  assertEquals(metadata.tags.includes("behavior:conversation-first"), true);
+});
+
+Deno.test("buildLiveEvalCaseMetadata separates optional judge cases from deterministic CI", () => {
+  const metadata = buildLiveEvalCaseMetadata({
+    caseId: "knowledge-api-routes",
+    surface: "read-only",
+    requireProject: false,
+  });
+
+  assertEquals(metadata.tags.includes("grading:deterministic-plus-optional-llm"), true);
+  assertEquals(metadata.tags.includes("gate:nightly"), true);
+  assertEquals(metadata.tags.includes("gate:ci"), false);
+  assertEquals(metadata.tags.includes("area:knowledge"), true);
+});
+
+Deno.test("buildLiveEvalCaseMetadata marks experimental cases outside stable gates", () => {
+  const metadata = buildLiveEvalCaseMetadata({
+    caseId: "research-prototype",
+    surface: "experimental",
+    requireProject: true,
+    releaseGateCaseIds: ["research-prototype"],
+  });
+
+  assertEquals(metadata.tags.includes("stability:experimental"), true);
+  assertEquals(metadata.tags.includes("project:required"), true);
+  assertEquals(metadata.tags.includes("gate:nightly"), false);
+  assertEquals(metadata.tags.includes("gate:ci"), false);
+  assertEquals(metadata.tags.includes("gate:release"), true);
+});
+
+Deno.test("buildLiveEvalCaseMetadata accepts custom judge prefixes and tag rules", () => {
+  const metadata = buildLiveEvalCaseMetadata({
+    caseId: "retrieval-audit",
+    surface: "write",
+    requireProject: true,
+    optionalJudgeCasePrefixes: ["retrieval-"],
+    areaTagRules: [
+      { startsWith: "retrieval-", tag: "area:retrieval" },
+      { includes: "audit", tag: "area:audit" },
+    ],
+  });
+
+  assertEquals(metadata.tags.includes("grading:deterministic-plus-optional-llm"), true);
+  assertEquals(metadata.tags.includes("area:retrieval"), true);
+  assertEquals(metadata.tags.includes("area:audit"), true);
+  assertEquals(metadata.tags.includes("area:knowledge"), false);
+});
+
+Deno.test("withLiveEvalMetadata attaches metadata and preserves case fields", () => {
+  const taggedCases = withLiveEvalMetadata(
+    [
+      {
+        id: "starter-plan",
+        label: "Starter",
+        verify: () => null,
+      },
+      {
+        id: "workflow-build-and-deploy",
+        label: "Workflow",
+        requireProject: true,
+        verify: () => null,
+      },
+    ],
+    "write",
+    { releaseGateCaseIds: new Set(["starter-plan", "workflow-build-and-deploy"]) },
+  );
+
+  assertEquals(taggedCases[0]?.label, "Starter");
+  assertEquals(taggedCases[0]?.metadata.tags.includes("gate:release"), true);
+  assertEquals(taggedCases[1]?.metadata.tags.includes("project:required"), true);
+  assertEquals(buildLiveEvalCaseTagSummary(taggedCases)["gate:release"], 2);
+});

--- a/src/agent/testing/live-evals/metadata.ts
+++ b/src/agent/testing/live-evals/metadata.ts
@@ -1,0 +1,167 @@
+import type { LiveEvalCaseMetadata } from "./report.ts";
+import type { LiveEvalCase } from "./runner.ts";
+
+export type LiveEvalCaseSurface = "read-only" | "write" | "experimental";
+
+export interface LiveEvalCaseTagRule {
+  tag: string;
+  equals?: string | readonly string[];
+  startsWith?: string | readonly string[];
+  includes?: string | readonly string[];
+}
+
+export interface LiveEvalCaseMetadataOptions {
+  releaseGateCaseIds?: readonly string[] | ReadonlySet<string>;
+  optionalJudgeCasePrefixes?: readonly string[];
+  areaTagRules?: readonly LiveEvalCaseTagRule[];
+}
+
+export interface BuildLiveEvalCaseMetadataInput extends LiveEvalCaseMetadataOptions {
+  caseId: string;
+  surface: LiveEvalCaseSurface;
+  requireProject: boolean;
+}
+
+export const DEFAULT_LIVE_EVAL_OPTIONAL_JUDGE_CASE_PREFIXES: readonly string[] = [
+  "knowledge-",
+  "grounded-",
+  "judged-",
+];
+
+export const DEFAULT_LIVE_EVAL_AREA_TAG_RULES: readonly LiveEvalCaseTagRule[] = [
+  { startsWith: "starter-", tag: "area:starter-routing" },
+  { startsWith: "starter-task-", tag: "area:starter-artifact-flow" },
+  { startsWith: "starter-", tag: "behavior:conversation-first" },
+  { startsWith: "workflow-", tag: "area:workflow" },
+  { startsWith: "platform-", tag: "area:platform" },
+  { startsWith: "security-", tag: "area:security" },
+  { startsWith: ["knowledge-", "grounded-", "judged-"], tag: "area:knowledge" },
+  { startsWith: "tool-truthfulness", tag: "area:tool-truthfulness" },
+  { startsWith: "degraded-", tag: "area:resilience" },
+  { equals: "error-recovery-missing-file", tag: "area:resilience" },
+  { includes: "deploy", tag: "area:deployment" },
+  { includes: "sandbox", tag: "area:sandbox" },
+  { includes: "debug", tag: "area:debugging" },
+  { includes: "operate", tag: "area:operations" },
+  { includes: "research", tag: "area:research" },
+  { includes: "knowledge", tag: "area:knowledge-lifecycle" },
+  { includes: "agent", tag: "area:agent-authoring" },
+  { includes: "form-input", tag: "area:interactive-input" },
+  { includes: ["invoke-agent", "delegation"], tag: "area:delegation" },
+  { includes: ["create-page", "create-api-route", "create-skill"], tag: "area:file-generation" },
+];
+
+function toStringArray(value: string | readonly string[] | undefined): readonly string[] {
+  if (!value) {
+    return [];
+  }
+
+  return typeof value === "string" ? [value] : value;
+}
+
+function caseIdCollectionHas(
+  collection: readonly string[] | ReadonlySet<string> | undefined,
+  caseId: string,
+): boolean {
+  if (!collection) {
+    return false;
+  }
+
+  if ("has" in collection) {
+    return collection.has(caseId);
+  }
+
+  return collection.includes(caseId);
+}
+
+function matchesTagRule(caseId: string, rule: LiveEvalCaseTagRule): boolean {
+  for (const value of toStringArray(rule.equals)) {
+    if (caseId === value) {
+      return true;
+    }
+  }
+
+  for (const value of toStringArray(rule.startsWith)) {
+    if (caseId.startsWith(value)) {
+      return true;
+    }
+  }
+
+  for (const value of toStringArray(rule.includes)) {
+    if (caseId.includes(value)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isOptionalJudgeCase(caseId: string, prefixes: readonly string[]): boolean {
+  return prefixes.some((prefix) => caseId.startsWith(prefix));
+}
+
+function buildAreaTags(caseId: string, rules: readonly LiveEvalCaseTagRule[]): string[] {
+  const tags = new Set<string>();
+
+  for (const rule of rules) {
+    if (matchesTagRule(caseId, rule)) {
+      tags.add(rule.tag);
+    }
+  }
+
+  return [...tags];
+}
+
+export function buildLiveEvalCaseMetadata(
+  input: BuildLiveEvalCaseMetadataInput,
+): LiveEvalCaseMetadata {
+  const optionalJudgeCasePrefixes = input.optionalJudgeCasePrefixes ??
+    DEFAULT_LIVE_EVAL_OPTIONAL_JUDGE_CASE_PREFIXES;
+  const areaTagRules = input.areaTagRules ?? DEFAULT_LIVE_EVAL_AREA_TAG_RULES;
+  const gradingTag = isOptionalJudgeCase(input.caseId, optionalJudgeCasePrefixes)
+    ? "grading:deterministic-plus-optional-llm"
+    : "grading:deterministic-only";
+
+  const tags = new Set<string>([
+    `surface:${input.surface}`,
+    input.requireProject ? "project:required" : "project:optional",
+    input.surface === "experimental" ? "stability:experimental" : "stability:stable",
+    gradingTag,
+  ]);
+
+  if (input.surface !== "experimental") {
+    tags.add("gate:nightly");
+  }
+
+  if (gradingTag === "grading:deterministic-only" && input.surface !== "experimental") {
+    tags.add("gate:ci");
+  }
+
+  if (caseIdCollectionHas(input.releaseGateCaseIds, input.caseId)) {
+    tags.add("gate:release");
+  }
+
+  for (const tag of buildAreaTags(input.caseId, areaTagRules)) {
+    tags.add(tag);
+  }
+
+  return {
+    tags: [...tags].sort(),
+  };
+}
+
+export function withLiveEvalMetadata<TCase extends LiveEvalCase>(
+  cases: readonly TCase[],
+  surface: LiveEvalCaseSurface,
+  options: LiveEvalCaseMetadataOptions = {},
+): Array<TCase & { metadata: LiveEvalCaseMetadata }> {
+  return cases.map((testCase) => ({
+    ...testCase,
+    metadata: buildLiveEvalCaseMetadata({
+      ...options,
+      caseId: testCase.id,
+      surface,
+      requireProject: testCase.requireProject === true,
+    }),
+  }));
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.531";
+export const VERSION = "0.1.532";


### PR DESCRIPTION
## Summary\n- add configurable live-eval metadata taxonomy helpers under agent testing\n- export metadata builders through veryfront/agent/testing\n- bump package version to 0.1.532\n\n## Verification\n- deno test -A src/agent/testing/live-evals/metadata.test.ts src/agent/testing/live-evals/report.test.ts\n- deno task verify:quick