### PR TITLE
Harden dependency boundary checks

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -179,6 +179,22 @@ the grouped dependency list quickly. The React boundary is owned by
 `react/deno.json`; extensions should keep their own dependencies in their
 extension manifest.
 
+## Sensitive dependency classes
+
+Some extensions own dependencies that need extra review because they execute
+commands, load native modules, or parse untrusted files. Keep these dependencies
+inside their named extension boundaries.
+
+| Class               | Extension                 | Boundary components                       | Capability surface             |
+| ------------------- | ------------------------- | ----------------------------------------- | ------------------------------ |
+| Sandbox execution   | `ext-sandbox-shell-tools` | `bash-tool`, `just-bash`                  | `SandboxShellToolsProvider`    |
+| Native SQLite store | `ext-db-sqlite`           | `better-sqlite3`, `@types/better-sqlite3` | `SqliteStore`, filesystem I/O  |
+| Document extraction | `ext-document-kreuzberg`  | `@kreuzberg/wasm`                         | `DocumentExtractor`, file read |
+
+`deno task lint:dependency-boundaries` fails when one of these sensitive
+boundaries is missing from the generated dependency index or no longer contains
+its expected package components.
+
 ## Creating an Extension
 
 ```bash

--- a/extensions/ext-db-sqlite/README.md
+++ b/extensions/ext-db-sqlite/README.md
@@ -4,8 +4,15 @@
 
 SQLite-backed storage for Veryfront via better-sqlite3.
 
-This extension registers the `SqliteStore` contract and keeps better-sqlite3
-out of core.
+This extension registers the `SqliteStore` contract and keeps better-sqlite3 out
+of core.
+
+## Supply-chain boundary
+
+This extension is a sensitive native storage boundary. Keep `better-sqlite3`,
+`@types/better-sqlite3`, and related native SQLite dependencies in this
+extension instead of importing them from core, CLI, React, or unrelated
+extensions.
 
 ```ts
 import extDbSqlite from "@veryfront/ext-db-sqlite";

--- a/extensions/ext-document-kreuzberg/README.md
+++ b/extensions/ext-document-kreuzberg/README.md
@@ -1,11 +1,18 @@
 # @veryfront/ext-document-kreuzberg
 
-> **Category:** Document extraction | **Contract:** `DocumentExtractor` | **Built-in**
+> **Category:** Document extraction | **Contract:** `DocumentExtractor` |
+> **Built-in**
 
 Document text extraction for Veryfront via kreuzberg.
 
 This extension registers the `DocumentExtractor` contract and keeps kreuzberg
 out of core.
+
+## Supply-chain boundary
+
+This extension is a sensitive document extraction boundary. Keep
+`@kreuzberg/wasm` and related document parsing dependencies in this extension
+instead of importing them from core, CLI, React, or unrelated extensions.
 
 ```ts
 import extDocumentKreuzberg from "@veryfront/ext-document-kreuzberg";

--- a/extensions/ext-sandbox-shell-tools/README.md
+++ b/extensions/ext-sandbox-shell-tools/README.md
@@ -1,9 +1,16 @@
 # @veryfront/ext-sandbox-shell-tools
 
-> **Category:** Sandbox | **Contract:** `SandboxShellToolsProvider` | **Built-in**
+> **Category:** Sandbox | **Contract:** `SandboxShellToolsProvider` |
+> **Built-in**
 
 Provides the `SandboxShellToolsProvider` contract using `bash-tool`.
 
 Core Veryfront code depends on the sandbox shell tools contract only. This
 extension owns the third-party shell tool implementation and its transitive
 dependencies.
+
+## Supply-chain boundary
+
+This extension is a sensitive sandbox execution boundary. Keep `bash-tool`,
+`just-bash`, and related shell execution dependencies in this extension instead
+of importing them from core, CLI, React, or unrelated extensions.

--- a/react/react.test.ts
+++ b/react/react.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertExists } from "#std/assert";
+import * as ReactShim from "./react.ts";
 import { cloneElement, createElement, createRef, useLayoutEffect, useReducer } from "./react.ts";
 
 Deno.test("react shim forwards the upstream React surface", () => {
@@ -11,4 +12,19 @@ Deno.test("react shim forwards the upstream React surface", () => {
   const cloned = cloneElement(element, { title: "after" });
   assertExists(cloned);
   assertEquals(cloned.props.title, "after");
+});
+
+Deno.test("react shim exports every upstream runtime export", async () => {
+  const config = JSON.parse(
+    await Deno.readTextFile(new URL("./deno.json", import.meta.url)),
+  ) as { imports?: Record<string, string> };
+  const upstreamTarget = config.imports?.["@veryfront/react-upstream"];
+  assertExists(upstreamTarget);
+
+  const upstream = await import(upstreamTarget);
+
+  assertEquals(
+    Object.keys(ReactShim).toSorted(),
+    Object.keys(upstream).toSorted(),
+  );
 });

--- a/scripts/lint/audit-dependency-boundaries.test.ts
+++ b/scripts/lint/audit-dependency-boundaries.test.ts
@@ -9,6 +9,57 @@ function issueMessages(issues: DependencyBoundaryAuditIssue[]): string[] {
   return issues.map((issue) => issue.message);
 }
 
+function sensitiveExtensionManifests() {
+  return [
+    {
+      sourceLocation: "extensions/ext-sandbox-shell-tools/deno.json",
+      group: "extension" as const,
+      componentCount: 2,
+      components: [
+        {
+          name: "bash-tool",
+          version: "1.3.16",
+          purl: "pkg:npm/bash-tool@1.3.16",
+        },
+        {
+          name: "just-bash",
+          version: "2.14.5",
+          purl: "pkg:npm/just-bash@2.14.5",
+        },
+      ],
+    },
+    {
+      sourceLocation: "extensions/ext-db-sqlite/deno.json",
+      group: "extension" as const,
+      componentCount: 2,
+      components: [
+        {
+          name: "@types/better-sqlite3",
+          version: "7.6.13",
+          purl: "pkg:npm/%40types/better-sqlite3@7.6.13",
+        },
+        {
+          name: "better-sqlite3",
+          version: "9.6.0",
+          purl: "pkg:npm/better-sqlite3@9.6.0",
+        },
+      ],
+    },
+    {
+      sourceLocation: "extensions/ext-document-kreuzberg/deno.json",
+      group: "extension" as const,
+      componentCount: 1,
+      components: [
+        {
+          name: "@kreuzberg/wasm",
+          version: "4.5.2",
+          purl: "pkg:npm/%40kreuzberg/wasm@4.5.2",
+        },
+      ],
+    },
+  ];
+}
+
 describe("auditDependencyBoundaries", () => {
   it("accepts empty core and CLI boundaries with React isolated separately", () => {
     const issues = auditDependencyBoundaries({
@@ -58,6 +109,7 @@ describe("auditDependencyBoundaries", () => {
             },
           ],
         },
+        ...sensitiveExtensionManifests(),
       ],
     });
 
@@ -124,6 +176,7 @@ describe("auditDependencyBoundaries", () => {
             },
           ],
         },
+        ...sensitiveExtensionManifests(),
       ],
     });
 
@@ -161,6 +214,7 @@ describe("auditDependencyBoundaries", () => {
             },
           ],
         },
+        ...sensitiveExtensionManifests(),
       ],
     });
 
@@ -169,6 +223,76 @@ describe("auditDependencyBoundaries", () => {
       "react boundary is missing expected component @types/react-dom",
       "react boundary is missing expected component csstype",
       "react boundary is missing expected component react-dom",
+    ]);
+  });
+
+  it("flags missing sensitive extension dependency boundaries", () => {
+    const issues = auditDependencyBoundaries({
+      generatedBy: "test",
+      manifests: [
+        {
+          sourceLocation: "deno.json",
+          group: "core",
+          componentCount: 0,
+          components: [],
+        },
+        {
+          sourceLocation: "cli/deno.json",
+          group: "cli",
+          componentCount: 0,
+          components: [],
+        },
+        {
+          sourceLocation: "react/deno.json",
+          group: "react",
+          componentCount: 5,
+          components: [
+            {
+              name: "@types/react",
+              version: "19.2.14",
+              purl: "pkg:npm/%40types/react@19.2.14",
+            },
+            {
+              name: "@types/react-dom",
+              version: "19.2.3",
+              purl: "pkg:npm/%40types/react-dom@19.2.3",
+            },
+            {
+              name: "csstype",
+              version: "3.2.3",
+              purl: "pkg:npm/csstype@3.2.3",
+            },
+            {
+              name: "react",
+              version: "19.2.4",
+              purl: "pkg:npm/react@19.2.4",
+            },
+            {
+              name: "react-dom",
+              version: "19.2.4",
+              purl: "pkg:npm/react-dom@19.2.4",
+            },
+          ],
+        },
+        {
+          sourceLocation: "extensions/ext-sandbox-shell-tools/deno.json",
+          group: "extension",
+          componentCount: 1,
+          components: [
+            {
+              name: "bash-tool",
+              version: "1.3.16",
+              purl: "pkg:npm/bash-tool@1.3.16",
+            },
+          ],
+        },
+      ],
+    });
+
+    assertEquals(issueMessages(issues), [
+      "sensitive extension sandbox execution boundary is missing expected component just-bash",
+      "sensitive extension native SQLite storage boundary is missing from dependency index",
+      "sensitive extension document extraction boundary is missing from dependency index",
     ]);
   });
 });

--- a/scripts/lint/audit-dependency-boundaries.ts
+++ b/scripts/lint/audit-dependency-boundaries.ts
@@ -19,6 +19,24 @@ const REACT_BOUNDARY_COMPONENTS = new Set([
   "react-dom",
 ]);
 
+const SENSITIVE_EXTENSION_BOUNDARIES = [
+  {
+    label: "sandbox execution",
+    sourceLocation: "extensions/ext-sandbox-shell-tools/deno.json",
+    expectedComponents: ["bash-tool", "just-bash"],
+  },
+  {
+    label: "native SQLite storage",
+    sourceLocation: "extensions/ext-db-sqlite/deno.json",
+    expectedComponents: ["@types/better-sqlite3", "better-sqlite3"],
+  },
+  {
+    label: "document extraction",
+    sourceLocation: "extensions/ext-document-kreuzberg/deno.json",
+    expectedComponents: ["@kreuzberg/wasm"],
+  },
+] as const;
+
 function componentNames(
   manifest: DependencyIndexManifest | undefined,
 ): string[] {
@@ -89,6 +107,29 @@ export function auditDependencyBoundaries(
     }
   }
 
+  for (const sensitiveBoundary of SENSITIVE_EXTENSION_BOUNDARIES) {
+    const manifest = manifests.get(sensitiveBoundary.sourceLocation);
+    if (!manifest) {
+      issues.push({
+        boundary: sensitiveBoundary.sourceLocation,
+        message:
+          `sensitive extension ${sensitiveBoundary.label} boundary is missing from dependency index`,
+      });
+      continue;
+    }
+
+    const componentSet = new Set(componentNames(manifest));
+    for (const expectedComponent of sensitiveBoundary.expectedComponents) {
+      if (!componentSet.has(expectedComponent)) {
+        issues.push({
+          boundary: sensitiveBoundary.sourceLocation,
+          message:
+            `sensitive extension ${sensitiveBoundary.label} boundary is missing expected component ${expectedComponent}`,
+        });
+      }
+    }
+  }
+
   return issues;
 }
 
@@ -97,7 +138,6 @@ async function dependencyIndexFromWorkspace(): Promise<DependencyIndex> {
   const workspaceMembers = workspaceMembersFromDenoConfig(denoConfig);
   return dependencyIndexForAllManifests(await Deno.readTextFile("deno.lock"), {
     workspaceMembers,
-    reactImports: denoConfig.imports ?? {},
     manifestImportsByPath: await importsByWorkspaceManifest(workspaceMembers),
   });
 }


### PR DESCRIPTION
## Summary
- add a React shim export-parity regression test against the upstream React runtime target
- enforce sensitive extension boundaries for sandbox shell tools, native SQLite, and document extraction
- document the sensitive dependency classes in extension READMEs

## Verification
- `deno task test:scripts`
- `deno test --no-check --allow-read react/react.test.ts`
- `deno task lint:core-deps`
- `deno task lint:dependency-boundaries`
- `deno task lint:deps`
- `deno task sbom:all --output-dir $(mktemp -d)`
- `deno fmt --check src/ cli/ react/`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/ cli/ react/`
- `deno fmt --config=/dev/null --check extensions/README.md extensions/ext-sandbox-shell-tools/README.md extensions/ext-db-sqlite/README.md extensions/ext-document-kreuzberg/README.md`
- pre-push hook: format, lint, typecheck, generation, unit tests (`1877 passed`, `0 failed`)
