### PR TITLE
Add dependency summary artifact

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -54,7 +54,9 @@ jobs:
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dependency-sboms
-          path: dist/dependency-sboms/*.json
+          path: |
+            dist/dependency-sboms/*.json
+            dist/dependency-sboms/*.md
           retention-days: 14
 
   submit-dependency-snapshot:

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -175,9 +175,10 @@ Each extension owns its third-party dependencies through its own `deno.json`.
 Run `deno task sbom:all --output-dir dist/dependency-sboms` from the repository
 root to generate one SBOM per extension plus aggregate, core, CLI, and React
 boundary views. Use `dependencies-by-manifest.json` in that output to inspect
-the grouped dependency list quickly. The React boundary is owned by
-`react/deno.json`; extensions should keep their own dependencies in their
-extension manifest.
+the machine-readable grouped dependency list. Use `dependency-summary.md` for a
+compact human-readable view with sensitive dependency boundaries highlighted.
+The React boundary is owned by `react/deno.json`; extensions should keep their
+own dependencies in their extension manifest.
 
 ## Sensitive dependency classes
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -49,7 +49,8 @@ Cross-runtime (Node/Bun) test infrastructure lives in `tests/node/` and
 Use `deno task sbom:all --output-dir dist/dependency-sboms` to generate
 segregated CycloneDX SBOMs for core, CLI, React, each extension, and the
 aggregate workspace. The same output includes `dependencies-by-manifest.json`,
-which is the fastest way to inspect dependencies grouped by boundary.
+which is the machine-readable dependency index grouped by boundary, and
+`dependency-summary.md`, which is the fastest human-readable view.
 
 `core.json` maps to the root framework boundary (`deno.json` and `src/`).
 `react.json` maps to `react/deno.json`, which owns the upstream React, React
@@ -59,7 +60,8 @@ SBOMs include npm imports from `deno.lock` and supported esm.sh aliases declared
 by the extension manifest.
 
 The security audit workflow uploads those files as the `dependency-sboms`
-artifact. It also runs `lint:deps`, `lint:core-deps`, and
+artifact. It includes the JSON SBOMs, `dependencies-by-manifest.json`, and
+`dependency-summary.md`. It also runs `lint:deps`, `lint:core-deps`, and
 `lint:dependency-boundaries` so dependency pins, source imports, and generated
 dependency groups are checked together.
 

--- a/scripts/build/generate-sbom.test.ts
+++ b/scripts/build/generate-sbom.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "#std/assert";
+import { assertEquals, assertStringIncludes, assertThrows } from "#std/assert";
 import { describe, it } from "jsr:@std/testing/bdd";
 import {
   componentsForManifestBoundary,
@@ -6,6 +6,7 @@ import {
   componentsFromLock,
   componentsFromLockForManifest,
   dependencyIndexForAllManifests,
+  dependencySummaryMarkdown,
   sbomOutputsForAllManifests,
   SUPPORTED_LOCK_VERSIONS,
 } from "./generate-sbom.ts";
@@ -359,6 +360,63 @@ describe("componentsFromLock", () => {
           componentNames: ["bash-tool"],
         },
       ],
+    );
+  });
+
+  it("renders a markdown dependency summary with sensitive boundaries highlighted", () => {
+    const summary = dependencySummaryMarkdown({
+      generatedBy: "generate-sbom",
+      manifests: [
+        {
+          sourceLocation: "deno.json",
+          group: "core",
+          componentCount: 0,
+          components: [],
+        },
+        {
+          sourceLocation: "cli/deno.json",
+          group: "cli",
+          componentCount: 0,
+          components: [],
+        },
+        {
+          sourceLocation: "react/deno.json",
+          group: "react",
+          componentCount: 3,
+          components: [
+            {
+              name: "react",
+              version: "19.2.4",
+              purl: "pkg:npm/react@19.2.4",
+            },
+          ],
+        },
+        {
+          sourceLocation: "extensions/ext-sandbox-shell-tools/deno.json",
+          group: "extension",
+          componentCount: 2,
+          components: [
+            {
+              name: "bash-tool",
+              version: "1.3.16",
+              purl: "pkg:npm/bash-tool@1.3.16",
+            },
+          ],
+        },
+      ],
+    });
+
+    assertStringIncludes(
+      summary,
+      "| Core | `deno.json` | 0 | Third-party free |",
+    );
+    assertStringIncludes(
+      summary,
+      "| Extension | `extensions/ext-sandbox-shell-tools/deno.json` | 2 | Sensitive: sandbox execution |",
+    );
+    assertStringIncludes(
+      summary,
+      "| Sandbox execution | `extensions/ext-sandbox-shell-tools/deno.json` | 2 | `bash-tool`, `just-bash` |",
     );
   });
 });

--- a/scripts/build/generate-sbom.ts
+++ b/scripts/build/generate-sbom.ts
@@ -60,6 +60,24 @@ export interface DependencyBoundaryInputs {
   manifestImportsByPath?: Record<string, Record<string, string>>;
 }
 
+export const SENSITIVE_DEPENDENCY_BOUNDARIES = [
+  {
+    label: "sandbox execution",
+    sourceLocation: "extensions/ext-sandbox-shell-tools/deno.json",
+    expectedComponents: ["bash-tool", "just-bash"],
+  },
+  {
+    label: "native SQLite storage",
+    sourceLocation: "extensions/ext-db-sqlite/deno.json",
+    expectedComponents: ["@types/better-sqlite3", "better-sqlite3"],
+  },
+  {
+    label: "document extraction",
+    sourceLocation: "extensions/ext-document-kreuzberg/deno.json",
+    expectedComponents: ["@kreuzberg/wasm"],
+  },
+] as const;
+
 const EXACT_SEMVER_RE = /^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$/;
 
 function hashFromIntegrity(
@@ -425,6 +443,97 @@ export function dependencyIndexForAllManifests(
   };
 }
 
+function boundaryLabel(manifest: DependencyIndexManifest): string {
+  if (manifest.group === "core") return "Core";
+  if (manifest.group === "cli") return "CLI";
+  if (manifest.group === "react") return "React";
+  if (manifest.group === "extension") return "Extension";
+  return "Workspace";
+}
+
+function titleCaseFirst(value: string): string {
+  return `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
+}
+
+function markdownTableCell(value: string): string {
+  return value.replaceAll("|", "\\|");
+}
+
+function markdownCode(value: string): string {
+  return `\`${value.replaceAll("`", "\\`")}\``;
+}
+
+function sensitiveBoundaryForSource(
+  sourceLocation: string,
+): typeof SENSITIVE_DEPENDENCY_BOUNDARIES[number] | undefined {
+  return SENSITIVE_DEPENDENCY_BOUNDARIES.find((boundary) =>
+    boundary.sourceLocation === sourceLocation
+  );
+}
+
+function dependencySummaryNote(manifest: DependencyIndexManifest): string {
+  const sensitiveBoundary = sensitiveBoundaryForSource(
+    manifest.sourceLocation,
+  );
+  if (sensitiveBoundary) return `Sensitive: ${sensitiveBoundary.label}`;
+  if (
+    (manifest.group === "core" || manifest.group === "cli") &&
+    manifest.componentCount === 0
+  ) {
+    return "Third-party free";
+  }
+  if (manifest.group === "react") return "React runtime boundary";
+  if (manifest.group === "extension") return "Extension boundary";
+  return "Workspace boundary";
+}
+
+export function dependencySummaryMarkdown(index: DependencyIndex): string {
+  const lines = [
+    "# Dependency summary",
+    "",
+    "Generated from `dependencies-by-manifest.json`.",
+    "",
+    "## Boundaries",
+    "",
+    "| Boundary | Source | Components | Notes |",
+    "| --- | --- | ---: | --- |",
+  ];
+
+  for (const manifest of index.manifests) {
+    lines.push(
+      `| ${boundaryLabel(manifest)} | ${
+        markdownCode(manifest.sourceLocation)
+      } | ${manifest.componentCount} | ${
+        markdownTableCell(dependencySummaryNote(manifest))
+      } |`,
+    );
+  }
+
+  lines.push(
+    "",
+    "## Sensitive boundaries",
+    "",
+    "| Class | Source | Components | Expected packages |",
+    "| --- | --- | ---: | --- |",
+  );
+
+  const manifestsBySource = new Map(
+    index.manifests.map((manifest) => [manifest.sourceLocation, manifest]),
+  );
+  for (const boundary of SENSITIVE_DEPENDENCY_BOUNDARIES) {
+    const manifest = manifestsBySource.get(boundary.sourceLocation);
+    lines.push(
+      `| ${titleCaseFirst(boundary.label)} | ${
+        markdownCode(boundary.sourceLocation)
+      } | ${manifest?.componentCount ?? 0} | ${
+        boundary.expectedComponents.map(markdownCode).join(", ")
+      } |`,
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
 export async function importsByWorkspaceManifest(
   workspaceMembers: string[],
 ): Promise<Record<string, Record<string, string>>> {
@@ -478,11 +587,18 @@ function buildSbom(
 }
 
 async function writeSbom(outputPath: string, sbom: unknown): Promise<void> {
+  await writeTextOutput(outputPath, JSON.stringify(sbom, null, 2) + "\n");
+}
+
+async function writeTextOutput(
+  outputPath: string,
+  text: string,
+): Promise<void> {
   const outputDir = outputPath.substring(0, outputPath.lastIndexOf("/"));
   if (outputDir) {
     await Deno.mkdir(outputDir, { recursive: true });
   }
-  await Deno.writeTextFile(outputPath, JSON.stringify(sbom, null, 2) + "\n");
+  await Deno.writeTextFile(outputPath, text);
 }
 
 if (import.meta.main) {
@@ -505,16 +621,26 @@ if (import.meta.main) {
       workspaceMembers,
       manifestImportsByPath,
     });
+    const dependencyIndex = dependencyIndexForAllManifests(lockText, {
+      workspaceMembers,
+      manifestImportsByPath,
+    });
     await writeSbom(
       joinOutputPath(args["output-dir"], "dependencies-by-manifest.json"),
-      dependencyIndexForAllManifests(lockText, {
-        workspaceMembers,
-        manifestImportsByPath,
-      }),
+      dependencyIndex,
     );
     console.log(
       `✅ Generated dependency index: ${
         joinOutputPath(args["output-dir"], "dependencies-by-manifest.json")
+      }`,
+    );
+    await writeTextOutput(
+      joinOutputPath(args["output-dir"], "dependency-summary.md"),
+      dependencySummaryMarkdown(dependencyIndex),
+    );
+    console.log(
+      `✅ Generated dependency summary: ${
+        joinOutputPath(args["output-dir"], "dependency-summary.md")
       }`,
     );
     for (const output of outputs) {

--- a/scripts/lint/audit-dependency-boundaries.ts
+++ b/scripts/lint/audit-dependency-boundaries.ts
@@ -3,6 +3,7 @@ import {
   dependencyIndexForAllManifests,
   type DependencyIndexManifest,
   importsByWorkspaceManifest,
+  SENSITIVE_DEPENDENCY_BOUNDARIES,
   workspaceMembersFromDenoConfig,
 } from "../build/generate-sbom.ts";
 
@@ -18,24 +19,6 @@ const REACT_BOUNDARY_COMPONENTS = new Set([
   "react",
   "react-dom",
 ]);
-
-const SENSITIVE_EXTENSION_BOUNDARIES = [
-  {
-    label: "sandbox execution",
-    sourceLocation: "extensions/ext-sandbox-shell-tools/deno.json",
-    expectedComponents: ["bash-tool", "just-bash"],
-  },
-  {
-    label: "native SQLite storage",
-    sourceLocation: "extensions/ext-db-sqlite/deno.json",
-    expectedComponents: ["@types/better-sqlite3", "better-sqlite3"],
-  },
-  {
-    label: "document extraction",
-    sourceLocation: "extensions/ext-document-kreuzberg/deno.json",
-    expectedComponents: ["@kreuzberg/wasm"],
-  },
-] as const;
 
 function componentNames(
   manifest: DependencyIndexManifest | undefined,
@@ -107,7 +90,7 @@ export function auditDependencyBoundaries(
     }
   }
 
-  for (const sensitiveBoundary of SENSITIVE_EXTENSION_BOUNDARIES) {
+  for (const sensitiveBoundary of SENSITIVE_DEPENDENCY_BOUNDARIES) {
     const manifest = manifests.get(sensitiveBoundary.sourceLocation);
     if (!manifest) {
       issues.push({


### PR DESCRIPTION
## Summary
- generate dependency-summary.md beside the per-boundary SBOMs
- include sensitive dependency boundaries in the summary
- upload markdown summaries in the security audit artifact
- document the new dependency visibility file

## Verification
- deno test --config=scripts/test.deno.json --no-check --allow-read scripts/build/generate-sbom.test.ts
- deno task test:scripts
- deno task lint:deps
- deno task lint:core-deps
- deno task lint:dependency-boundaries
- deno task --quiet sbom:all --output-dir $(mktemp -d)
- deno check --config=scripts/test.deno.json scripts/build/generate-sbom.test.ts scripts/lint/audit-dependency-boundaries.ts
- git diff --check
- pre-push hook: format, lint, type check, unit tests