### PR TITLE
Fix npm React ecosystem shims

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.532",
+  "version": "0.1.533",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [
@@ -354,7 +354,7 @@
     "lint:wildcard-exports": "deno run --allow-read scripts/lint/ban-wildcard-exports.ts",
     "lint:deps": "deno run --allow-read scripts/lint/audit-deps.ts",
     "lint:barrel-jsdoc": "deno run --allow-read scripts/lint/check-barrel-jsdoc.ts",
-    "test:scripts": "deno test --config=scripts/test.deno.json --no-check --allow-read scripts/build/generate-sbom.test.ts scripts/lint/audit-core-deps.test.ts scripts/lint/audit-dependency-boundaries.test.ts scripts/lint/audit-deps.test.ts scripts/security/audit-npm.test.ts scripts/security/submit-dependency-snapshot.test.ts",
+    "test:scripts": "deno test --config=scripts/test.deno.json --no-check --allow-read --allow-write scripts/build/generate-sbom.test.ts scripts/build/npm-react-shims.test.ts scripts/lint/audit-core-deps.test.ts scripts/lint/audit-dependency-boundaries.test.ts scripts/lint/audit-deps.test.ts scripts/security/audit-npm.test.ts scripts/security/submit-dependency-snapshot.test.ts",
     "test:cross-runtime": "deno run --allow-all src/platform/compat/cross-runtime.test.ts",
     "test:node": "node ./tests/node/run-tests.mjs 'src/**/*.test.ts'",
     "test:bun": "node ./tests/bun/run-tests.mjs src/",

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -18,6 +18,7 @@ import {
 	BROWSER_SAFE_EXPORTS,
 } from "./browser-safe-exports.mjs";
 import { normalizeNpmPackageMetadata } from "./npm-package-metadata.ts";
+import { normalizeEsmShReactNpmShims } from "./npm-react-shims.ts";
 
 const denoJson = JSON.parse(await Deno.readTextFile("./deno.json"));
 const version = denoJson.version;
@@ -134,6 +135,7 @@ await build({
 		dependencies: {
 			"@types/react": "^19.0.0",
 			"@types/react-dom": "^19.0.0",
+			"ai": "^6.0.0",
 			"ws": "^8.18.0",
 			"@kreuzberg/node": "^4.4.2",
 		},
@@ -205,6 +207,11 @@ await build({
 			'(process.argv[1] ?? "").replace',
 			"dnt polyfill process.argv[1] fix",
 		);
+
+		const patchedReactShimCount = normalizeEsmShReactNpmShims("./npm/esm/deps/esm.sh");
+		if (patchedReactShimCount > 0) {
+			console.log(`📝 Patched ${patchedReactShimCount} React ecosystem esm.sh npm shims`);
+		}
 
 		// Keep browser-safe client exports free of dnt Node polyfill imports.
 		// These modules are consumed directly in browser bundles and do not rely on

--- a/scripts/build/npm-react-shims.test.ts
+++ b/scripts/build/npm-react-shims.test.ts
@@ -1,0 +1,81 @@
+import { assertEquals, assertThrows } from "#std/assert";
+import { normalizeEsmShReactNpmShims } from "./npm-react-shims.ts";
+
+Deno.test("normalizeEsmShReactNpmShims rewrites React ecosystem esm.sh shims to npm package exports", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await Deno.mkdir(`${root}/react@19.2.4`);
+    await Deno.mkdir(`${root}/react-dom@19.2.4`);
+    await Deno.writeTextFile(
+      `${root}/react@19.2.4.js`,
+      'export * from "react/X-ZGNzc3R5cGVAMy4yLjM/es2022/react.mjs";\n',
+    );
+    await Deno.writeTextFile(
+      `${root}/react@19.2.4/jsx-runtime.js`,
+      'export * from "react/X-ZGNzc3R5cGVAMy4yLjMKZXJlYWN0/es2022/jsx-runtime.mjs";\n',
+    );
+    await Deno.writeTextFile(
+      `${root}/react@19.2.4/jsx-dev-runtime.js`,
+      'export * from "react/X-ZGNzc3R5cGVAMy4yLjMKZXJlYWN0/es2022/jsx-dev-runtime.development.mjs";\n',
+    );
+    await Deno.writeTextFile(
+      `${root}/react-dom@19.2.4/client.js`,
+      'import "react-dom/X-ZGNzc3R5cGVAMy4yLjMKZXJlYWN0/es2022/react-dom.mjs";\n',
+    );
+    await Deno.writeTextFile(
+      `${root}/react-dom@19.2.4/server.js`,
+      'export * from "react-dom/X-ZGNzc3R5cGVAMy4yLjMKZXJlYWN0/es2022/server.mjs";\n',
+    );
+    await Deno.writeTextFile(
+      `${root}/scheduler@^0.27.0.js`,
+      'export * from "scheduler/es2022/scheduler.mjs";\n',
+    );
+
+    assertEquals(normalizeEsmShReactNpmShims(root), 6);
+    assertEquals(
+      await Deno.readTextFile(`${root}/react@19.2.4.js`),
+      '/* npm package shim for esm.sh react@19.2.4.js */\nexport * from "react";\nexport { default } from "react";\n',
+    );
+    assertEquals(
+      await Deno.readTextFile(`${root}/react@19.2.4/jsx-runtime.js`),
+      '/* npm package shim for esm.sh react@19.2.4/jsx-runtime.js */\nexport * from "react/jsx-runtime";\nexport { default } from "react/jsx-runtime";\n',
+    );
+    assertEquals(
+      await Deno.readTextFile(`${root}/react@19.2.4/jsx-dev-runtime.js`),
+      '/* npm package shim for esm.sh react@19.2.4/jsx-dev-runtime.js */\nexport * from "react/jsx-dev-runtime";\nexport { default } from "react/jsx-dev-runtime";\n',
+    );
+    assertEquals(
+      await Deno.readTextFile(`${root}/react-dom@19.2.4/client.js`),
+      '/* npm package shim for esm.sh react-dom@19.2.4/client.js */\nexport * from "react-dom/client";\nexport { default } from "react-dom/client";\n',
+    );
+    assertEquals(
+      await Deno.readTextFile(`${root}/react-dom@19.2.4/server.js`),
+      '/* npm package shim for esm.sh react-dom@19.2.4/server.js */\nexport * from "react-dom/server";\nexport { default } from "react-dom/server";\n',
+    );
+    assertEquals(
+      await Deno.readTextFile(`${root}/scheduler@^0.27.0.js`),
+      '/* npm package shim for esm.sh scheduler@^0.27.0.js */\nexport * from "scheduler";\nexport { default } from "scheduler";\n',
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("normalizeEsmShReactNpmShims rejects unhandled React internal imports", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await Deno.mkdir(`${root}/unhandled`);
+    await Deno.writeTextFile(
+      `${root}/unhandled/entry.js`,
+      'export * from "react-dom/X-ZGNzc3R5cGVAMy4yLjMKZXJlYWN0/es2022/unknown.mjs";\n',
+    );
+
+    assertThrows(
+      () => normalizeEsmShReactNpmShims(root),
+      Error,
+      "esm.sh React internals",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});

--- a/scripts/build/npm-react-shims.ts
+++ b/scripts/build/npm-react-shims.ts
@@ -1,0 +1,141 @@
+const REACT_ROOT_PREFIX = "react@";
+const REACT_DOM_ROOT_PREFIX = "react-dom@";
+const SCHEDULER_ROOT_PREFIX = "scheduler@";
+
+export function normalizeEsmShReactNpmShims(root: string): number {
+  let patchedCount = 0;
+
+  for (const entry of Deno.readDirSync(root)) {
+    if (
+      entry.isFile && entry.name.startsWith(REACT_ROOT_PREFIX) &&
+      entry.name.endsWith(".js")
+    ) {
+      patchedCount += writeNpmShim(
+        `${root}/${entry.name}`,
+        "react",
+        entry.name,
+      );
+      continue;
+    }
+
+    if (
+      entry.isFile && entry.name.startsWith(SCHEDULER_ROOT_PREFIX) &&
+      entry.name.endsWith(".js")
+    ) {
+      patchedCount += writeNpmShim(
+        `${root}/${entry.name}`,
+        "scheduler",
+        entry.name,
+      );
+      continue;
+    }
+
+    if (!entry.isDirectory) continue;
+
+    if (entry.name.startsWith(REACT_ROOT_PREFIX)) {
+      const packageRoot = `${root}/${entry.name}`;
+      patchedCount += writeNpmShimIfExists(
+        `${packageRoot}/jsx-runtime.js`,
+        "react/jsx-runtime",
+        `${entry.name}/jsx-runtime.js`,
+      );
+      patchedCount += writeNpmShimIfExists(
+        `${packageRoot}/jsx-dev-runtime.js`,
+        "react/jsx-dev-runtime",
+        `${entry.name}/jsx-dev-runtime.js`,
+      );
+      continue;
+    }
+
+    if (entry.name.startsWith(REACT_DOM_ROOT_PREFIX)) {
+      const packageRoot = `${root}/${entry.name}`;
+      patchedCount += writeNpmShimIfExists(
+        `${packageRoot}/client.js`,
+        "react-dom/client",
+        `${entry.name}/client.js`,
+      );
+      patchedCount += writeNpmShimIfExists(
+        `${packageRoot}/server.js`,
+        "react-dom/server",
+        `${entry.name}/server.js`,
+      );
+    }
+  }
+
+  assertNoReactInternalPackageImports(root);
+  return patchedCount;
+}
+
+function writeNpmShimIfExists(
+  path: string,
+  specifier: string,
+  label: string,
+): number {
+  try {
+    Deno.statSync(path);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return 0;
+    throw error;
+  }
+
+  return writeNpmShim(path, specifier, label);
+}
+
+function writeNpmShim(path: string, specifier: string, label: string): number {
+  const current = Deno.readTextFileSync(path);
+  const patched =
+    `/* npm package shim for esm.sh ${label} */\nexport * from "${specifier}";\nexport { default } from "${specifier}";\n`;
+  if (current === patched) return 0;
+
+  Deno.writeTextFileSync(path, patched);
+  return 1;
+}
+
+function assertNoReactInternalPackageImports(root: string): void {
+  const remaining = findReactInternalPackageImports(root);
+  if (remaining.length === 0) return;
+
+  throw new Error(
+    `Generated npm package still imports esm.sh React internals that Node package exports do not expose: ${
+      remaining.join(", ")
+    }`,
+  );
+}
+
+function findReactInternalPackageImports(root: string): string[] {
+  const matches: string[] = [];
+  for (const path of walkFiles(root)) {
+    if (!path.endsWith(".js")) continue;
+
+    const content = Deno.readTextFileSync(path);
+    if (content.includes('from "react/') && content.includes("/es2022/")) {
+      matches.push(path);
+      continue;
+    }
+
+    if (content.includes('from "react-dom/') && content.includes("/es2022/")) {
+      matches.push(path);
+      continue;
+    }
+
+    if (content.includes('from "scheduler/') && content.includes("/es2022/")) {
+      matches.push(path);
+    }
+  }
+
+  return matches;
+}
+
+function* walkFiles(root: string): Generator<string> {
+  for (const entry of Deno.readDirSync(root)) {
+    const path = `${root}/${entry.name}`;
+    if (entry.isDirectory) {
+      yield* walkFiles(path);
+      continue;
+    }
+
+    if (entry.isFile) {
+      yield path;
+    }
+  }
+}

--- a/scripts/docs/verify-npm-exports.mjs
+++ b/scripts/docs/verify-npm-exports.mjs
@@ -50,7 +50,7 @@ const REQUIRED_EXPORTS = {
     "RunResumeSessionManager",
     "createAgUiHandler",
     "waitForHumanInput",
-    "HumanInputRequestSchema",
+    "getHumanInputRequestSchema",
     "registerAgent",
     "getAgentsAsTools",
     "agentAsTool",

--- a/scripts/docs/verify-npm-node.mjs
+++ b/scripts/docs/verify-npm-node.mjs
@@ -102,7 +102,7 @@ try {
   assertType(agentMod.createMemory, "function", "createMemory is function");
   assert(agentMod.AgentRuntime !== undefined, "AgentRuntime exists");
   assert(agentMod.RunResumeSessionManager !== undefined, "RunResumeSessionManager exists");
-  assert(agentMod.HumanInputRequestSchema !== undefined, "HumanInputRequestSchema exists");
+  assertType(agentMod.getHumanInputRequestSchema, "function", "getHumanInputRequestSchema is function");
   console.log("  OK    agent — 10 checks");
 } catch (err) {
   failed++;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.532";
+export const VERSION = "0.1.533";


### PR DESCRIPTION
## Summary\n- Rewrite generated esm.sh React, React DOM, and scheduler npm shims to package export entrypoints so Node consumers do not import non-exported internal package paths.\n- Include the AI SDK dependency required by the built-in sandbox shell tools package graph.\n- Update npm smoke checks to use the current human-input schema accessor export.\n- Bump framework patch version to 0.1.533 for CI publish.\n\n## Verification\n- deno task verify:quick\n- deno task test:scripts\n- deno task build:npm\n- node scripts/docs/verify-npm-exports.mjs\n- node scripts/docs/verify-npm-node.mjs\n- pre-push checks: 1882 passed (17489 steps)