### PR TITLE
Tighten extension contract metadata

### DIFF
--- a/cli/commands/extension/init-command.test.ts
+++ b/cli/commands/extension/init-command.test.ts
@@ -55,6 +55,9 @@ describe("extension init command", () => {
       assertEquals(indexFile !== undefined, true);
       assertEquals(indexFile!.content.includes('"my-cache"'), true);
       assertEquals(indexFile!.content.includes("ExtensionFactory"), true);
+      assertEquals(indexFile!.content.includes("contracts: {"), true);
+      assertEquals(indexFile!.content.includes("provides: []"), true);
+      assertEquals(indexFile!.content.includes("requires: []"), true);
     });
 
     it("should generate a test file", () => {
@@ -70,6 +73,8 @@ describe("extension init command", () => {
       assertEquals(denoJson !== undefined, true);
       const parsed = JSON.parse(denoJson!.content);
       assertEquals(parsed.veryfront.extension, true);
+      assertEquals(parsed.veryfront.contracts.provides, []);
+      assertEquals(parsed.veryfront.contracts.requires, []);
     });
 
     it("should place files under extensions/<name>/", () => {
@@ -98,7 +103,7 @@ describe("extension init command", () => {
       const files = generateExtensionFiles("my-cache");
       const indexFile = files.find((f) => f.path.endsWith("src/index.ts"));
       const content = indexFile!.content;
-      // The factory takes no args in the scaffold — avoids TS7006 in strict
+      // The factory takes no args in the scaffold. This avoids TS7006 in strict
       // user projects (implicit-any on an unused `config?` parameter).
       assertEquals(content.includes("(config?)"), false);
       assertEquals(content.includes(": ExtensionFactory = ()"), true);

--- a/cli/commands/extension/init-command.ts
+++ b/cli/commands/extension/init-command.ts
@@ -1,5 +1,5 @@
 /**
- * Extension init command — scaffold a new extension.
+ * Extension init command: scaffold a new extension.
  *
  * @module cli/commands/extension/init-command
  */
@@ -26,7 +26,7 @@ export function validateExtensionName(name: string): string | undefined {
 
 /**
  * Generate the file contents for a new extension scaffold.
- * Does not write to disk — returns file path/content pairs.
+ * Does not write to disk. Returns file path/content pairs.
  */
 export function generateExtensionFiles(name: string): GeneratedFile[] {
   const base = `extensions/${name}`;
@@ -42,6 +42,12 @@ import type { ExtensionFactory } from "veryfront/extensions";
 const ${camelCase(name)}: ExtensionFactory = () => ({
   name: "${name}",
   version: "0.1.0",
+  // Use contracts.provides for dynamic ctx.provide() registrations.
+  // Use contracts.requires before calling ctx.require().
+  contracts: {
+    provides: [],
+    requires: [],
+  },
   capabilities: [],
 
   // Uncomment and modify to provide a contract implementation:
@@ -51,8 +57,8 @@ const ${camelCase(name)}: ExtensionFactory = () => ({
 
   // Uncomment for async setup:
   // async setup(ctx) {
-  //   // ctx.get<T>("ContractName") — consume another contract
-  //   // ctx.provide("ContractName", impl) — register a contract
+  //   // ctx.get<T>("ContractName"): consume another contract
+  //   // ctx.provide("ContractName", impl): register a contract
   // },
 
   // Uncomment for cleanup:
@@ -99,6 +105,10 @@ describe("${name} extension", () => {
       version: "0.1.0",
       veryfront: {
         extension: true,
+        contracts: {
+          provides: [],
+          requires: [],
+        },
         capabilities: [],
       },
     },

--- a/docs/architecture/06-discovery-extensions.md
+++ b/docs/architecture/06-discovery-extensions.md
@@ -94,7 +94,7 @@ The extension system is a lightweight contract-based runtime for wiring optional
 ```mermaid
 graph TB
     subgraph ExtDef["Extension Definition"]
-        ExtInterface["Extension Interface<br/>{name, version, capabilities,<br/>setup(), teardown(), provides?, extends?}"]
+        ExtInterface["Extension Interface<br/>{name, version, capabilities,<br/>contracts?, setup(), teardown(),<br/>provides?, extends?}"]
         Capability["Capability Declaration<br/>(required runtime features)"]
     end
 
@@ -153,7 +153,7 @@ graph TB
 
 The extension system currently provides:
 
-- **Extension Definitions:** An extension declares `name`, `version`, `capabilities`, and optional `setup()` / `teardown()` hooks, plus optional `provides` and `extends` fields.
+- **Extension Definitions:** An extension declares `name`, `version`, `capabilities`, optional `contracts` metadata for provided and required contracts, optional `setup()` / `teardown()` hooks, plus optional `provides` and `extends` fields.
 - **Extension Context:** `ExtensionContext` exposes `get()`, `require()`, `provide()`, a config bag, and a logger so extensions can register implementations into the runtime.
 - **Contract Registry:** The runtime registry is currently a small in-memory contract map with `register()`, `resolve()`, `tryResolve()`, and `reset()`.
 - **Recommendations:** Some contract names map to recommended first-party extension packages via `getRecommendation()`, which is used to improve missing-contract errors.

--- a/docs/guides/extensions.md
+++ b/docs/guides/extensions.md
@@ -1,12 +1,12 @@
 ---
 title: "Extensions"
-description: "Build custom extensions to add capabilities, integrate third-party services, and share reusable functionality."
+description: "Build custom extensions that add focused contracts, integrate third-party services, and share reusable functionality."
 order: 21
 ---
 
 # Extensions
 
-Build custom extensions to add capabilities, integrate third-party services, and share reusable functionality.
+Build custom extensions that add focused contracts, integrate third-party services, and share reusable functionality.
 
 Veryfront's extension system uses a **contract-based architecture**: core defines interfaces (contracts), and extensions provide implementations. This keeps the core lightweight while enabling an open ecosystem of pluggable functionality.
 
@@ -42,6 +42,36 @@ Validate your extension:
 veryfront extension validate extensions/my-cache
 ```
 
+## Enable an extension
+
+Add extension factories to `veryfront.config.ts`:
+
+```ts
+// veryfront.config.ts
+import { defineConfig } from "veryfront";
+import extRedis from "@veryfront/ext-cache-redis";
+
+export default defineConfig({
+  extensions: [
+    extRedis({ url: "redis://localhost:6379", prefix: "myapp:" }),
+  ],
+});
+```
+
+Use a local extension the same way:
+
+```ts
+// veryfront.config.ts
+import { defineConfig } from "veryfront";
+import memoryCache from "./extensions/memory-cache/src/index.ts";
+
+export default defineConfig({
+  extensions: [
+    memoryCache({ maxSize: 500 }),
+  ],
+});
+```
+
 ## Writing an extension
 
 An extension is a module that `export default`s an `ExtensionFactory` (a function returning an `Extension` object):
@@ -49,7 +79,7 @@ An extension is a module that `export default`s an `ExtensionFactory` (a functio
 ```ts
 import type { ExtensionFactory } from "veryfront/extensions";
 
-const myExtension: ExtensionFactory = (config?) => ({
+const myExtension: ExtensionFactory = () => ({
   name: "my-extension",
   version: "1.0.0",
   capabilities: [],
@@ -65,6 +95,10 @@ interface Extension {
   name: string;
   version: string;
   capabilities: Capability[];
+  contracts?: {
+    provides?: string[];
+    requires?: string[];
+  };
   setup?(ctx: ExtensionContext): Promise<void> | void;
   teardown?(): Promise<void> | void;
   provides?: Record<string, unknown>;
@@ -72,15 +106,16 @@ interface Extension {
 }
 ```
 
-| Field          | Required | Description                                                            |
-| -------------- | -------- | ---------------------------------------------------------------------- |
-| `name`         | Yes      | Unique identifier (lowercase, hyphens).                                |
-| `version`      | Yes      | Semver string.                                                         |
-| `capabilities` | Yes      | System resources the extension needs (can be empty `[]`).              |
-| `provides`     | No       | Static contract implementations (registered before `setup` runs).      |
-| `setup`        | No       | Async initialization. Connect to services, register dynamic contracts. |
-| `teardown`     | No       | Cleanup. Close connections, flush buffers. Runs in reverse load order. |
-| `extends`      | No       | Compose other extensions as a preset.                                  |
+| Field          | Required | Description                                                                              |
+| -------------- | -------- | ---------------------------------------------------------------------------------------- |
+| `name`         | Yes      | Unique identifier (lowercase, hyphens).                                                  |
+| `version`      | Yes      | Semver string.                                                                           |
+| `capabilities` | Yes      | System resources the extension needs (can be empty `[]`).                                |
+| `contracts`    | No       | Contract metadata for load ordering, especially dynamic `ctx.provide()` implementations. |
+| `provides`     | No       | Static contract implementations, registered before `setup` runs.                         |
+| `setup`        | No       | Async initialization. Connect to services, register dynamic contracts.                   |
+| `teardown`     | No       | Cleanup. Close connections, flush buffers. Runs in reverse load order.                   |
+| `extends`      | No       | Compose other extensions as a preset.                                                    |
 
 ## Providing contracts
 
@@ -100,9 +135,7 @@ const extJwt: ExtensionFactory = (config?) => {
   return {
     name: "ext-auth-jwt",
     version: "0.1.0",
-    capabilities: [
-      { type: "contract", name: "AuthProvider" },
-    ],
+    capabilities: [],
     provides: {
       AuthProvider: provider,
     },
@@ -125,8 +158,10 @@ const extRedis: ExtensionFactory = () => {
   return {
     name: "ext-cache-redis",
     version: "0.1.0",
+    contracts: {
+      provides: ["TokenCacheStore"],
+    },
     capabilities: [
-      { type: "contract", name: "TokenCacheStore" },
       { type: "net:outbound", hosts: ["*"] },
     ],
 
@@ -155,7 +190,7 @@ export default extRedis;
 
 ## Consuming contracts
 
-Extensions can depend on contracts provided by other extensions. Declare the dependency in `capabilities`, then resolve it in `setup()`:
+Extensions can depend on contracts provided by other extensions. Declare the dependency in `contracts.requires`, then resolve it in `setup()`:
 
 ```ts
 import type { ExtensionFactory } from "veryfront/extensions";
@@ -168,7 +203,10 @@ const extMyProvider: ExtensionFactory = () => {
   return {
     name: "ext-my-provider",
     version: "0.1.0",
-    capabilities: [{ type: "contract", name: "LLMProvider:my-provider" }],
+    contracts: {
+      requires: [LLMProviderRegistryName],
+    },
+    capabilities: [],
 
     setup(ctx) {
       registry = ctx.require<LLMProviderRegistry>(LLMProviderRegistryName);
@@ -185,7 +223,7 @@ const extMyProvider: ExtensionFactory = () => {
 export default extMyProvider;
 ```
 
-The `capabilities: [{ type: "contract", name: "..." }]` declaration tells the topological sort that this extension consumes a contract. When the provider uses a static `provides` field, the sort guarantees providers load before consumers. For contracts registered dynamically via `ctx.provide()`, ensure the provider is listed earlier in the config or has higher source priority.
+The `contracts.requires` declaration tells the topological sort that this extension consumes a contract. Static `provides` entries automatically declare provided contracts. Dynamic providers must list contract names in `contracts.provides` so consumers load after the provider.
 
 ### ExtensionContext API
 
@@ -209,20 +247,20 @@ capabilities: [
   { type: "net:listen", ports: [3000] },
   { type: "env:read", keys: ["DATABASE_URL", "API_KEY"] },
   { type: "process:spawn", commands: ["esbuild"] },
-  { type: "contract", name: "CacheStore" },
 ];
 ```
 
-| Type            | Scoping              | Deno flag                         |
-| --------------- | -------------------- | --------------------------------- |
-| `fs:read`       | `paths: string[]`    | `--allow-read=<paths>`            |
-| `fs:write`      | `paths: string[]`    | `--allow-write=<paths>`           |
-| `net:outbound`  | `hosts: string[]`    | `--allow-net=<hosts>`             |
-| `net:listen`    | `ports: number[]`    | `--allow-net=localhost:<port>`    |
-| `env:read`      | `keys: string[]`     | `--allow-env=<keys>`              |
-| `process:spawn` | `commands: string[]` | `--allow-run=<commands>`          |
-| `native:ffi`    | (none)               | `--allow-ffi`                     |
-| `contract`      | `name: string`       | (ordering hint, not a permission) |
+| Type            | Scoping              | Deno flag                      |
+| --------------- | -------------------- | ------------------------------ |
+| `fs:read`       | `paths: string[]`    | `--allow-read=<paths>`         |
+| `fs:write`      | `paths: string[]`    | `--allow-write=<paths>`        |
+| `net:outbound`  | `hosts: string[]`    | `--allow-net=<hosts>`          |
+| `net:listen`    | `ports: number[]`    | `--allow-net=localhost:<port>` |
+| `env:read`      | `keys: string[]`     | `--allow-env=<keys>`           |
+| `process:spawn` | `commands: string[]` | `--allow-run=<commands>`       |
+| `native:ffi`    | (none)               | `--allow-ffi`                  |
+
+Use `contracts.provides` and `contracts.requires` for contract metadata. Capabilities describe runtime resources, not contract ownership or dependency order.
 
 ## Available contracts
 
@@ -266,15 +304,17 @@ For published extensions (npm/JSR), declare extension metadata in `deno.json` or
   "exports": "./src/index.ts",
   "veryfront": {
     "extension": true,
+    "contracts": {
+      "provides": ["CacheStore"]
+    },
     "capabilities": [
-      { "type": "contract", "name": "CacheStore" },
       { "type": "net:outbound", "hosts": ["*"] }
     ]
   }
 }
 ```
 
-The `veryfront.extension: true` flag enables auto-discovery. Installed packages with this metadata are loaded automatically without explicit config.
+The `veryfront.extension: true` flag enables auto-discovery. Installed packages with this metadata are loaded automatically without explicit config. Package metadata advertises contracts and system capabilities for discovery and audit. Runtime contract metadata still lives in the factory object through `contracts` and `provides`.
 
 ## Discovery and priority
 
@@ -287,7 +327,7 @@ Extensions are discovered from four sources, in priority order:
 | 3           | Project    | `extensions/<name>/src/index.ts` in your project    |
 | 4 (lowest)  | Local file | `*.extension.ts` files in project root              |
 
-When multiple extensions provide the same contract via static `provides`, the higher-priority source wins. Contracts registered dynamically via `ctx.provide()` in `setup()` are not subject to priority arbitration, so prefer static `provides` when possible. You can explicitly disable a discovered extension:
+When multiple extensions provide the same contract, the higher-priority source wins. This applies to static `provides` and dynamic providers that declare `contracts.provides`. You can explicitly disable a discovered extension:
 
 ```ts
 // veryfront.config.ts
@@ -484,9 +524,7 @@ const memoryCache: ExtensionFactory = (config?: unknown) => {
   return {
     name: "memory-cache",
     version: "1.0.0",
-    capabilities: [
-      { type: "contract", name: "CacheStore" },
-    ],
+    capabilities: [],
     provides: {
       CacheStore: cache,
     },
@@ -550,9 +588,10 @@ When a required contract is missing, the error message suggests which package to
 To publish an extension as a package:
 
 1. Set `veryfront.extension: true` in your `deno.json`/`package.json`
-2. List capabilities in the package metadata
-3. Export your factory as the default export
-4. Publish to npm or JSR
+2. List system capabilities in the package metadata
+3. Declare contract metadata in the factory with `contracts` or static `provides`
+4. Export your factory as the default export
+5. Publish to npm or JSR
 
 Users install your package and it's auto-discovered, no config changes needed:
 
@@ -564,6 +603,7 @@ deno add @myorg/ext-custom-cache
 
 - **One contract per extension** - Keep extensions focused. Implement a single contract per package.
 - **Declare all capabilities** - Be explicit about filesystem, network, and env var access.
+- **Declare dynamic contracts** - Use `contracts.provides` for dynamic `ctx.provide()` calls and `contracts.requires` before `ctx.require()`.
 - **Handle missing config gracefully** - Log a warning and skip registration instead of throwing when optional config is absent.
 - **Clean up in teardown** - Close connections, cancel timers, flush buffers.
 - **Use `ctx.logger`** - Structured logging integrates with the project's log pipeline.

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -167,7 +167,34 @@ The `deno.json` declares:
 - **name**: `@veryfront/ext-<name>`
 - **version**: Semver string
 - **exports**: Entry point (`./src/index.ts`)
-- **veryfront.capabilities**: Contract registrations and runtime permissions
+- **veryfront.contracts**: Contract metadata for discovery and audit
+- **veryfront.capabilities**: Runtime permissions and audit metadata
+
+The extension factory also declares runtime contract metadata:
+
+```ts
+import type { ExtensionFactory } from "veryfront/extensions";
+
+const extCache: ExtensionFactory = () => ({
+  name: "ext-cache-memory",
+  version: "0.1.0",
+  contracts: {
+    provides: ["CacheStore"],
+    requires: [],
+  },
+  capabilities: [],
+  setup(ctx) {
+    ctx.provide("CacheStore", createMemoryCache());
+  },
+});
+
+export default extCache;
+```
+
+Static `provides` entries automatically declare provided contracts. Use
+`contracts.provides` when a contract is registered dynamically in `setup()`.
+Use `contracts.requires` before calling `ctx.require()` for contracts from
+other extensions.
 
 ## Dependency ownership
 

--- a/extensions/ext-auth-jwt/deno.json
+++ b/extensions/ext-auth-jwt/deno.json
@@ -4,8 +4,10 @@
   "exports": "./src/index.ts",
   "veryfront": {
     "extension": true,
+    "contracts": {
+      "provides": ["AuthProvider"]
+    },
     "capabilities": [
-      { "type": "contract", "name": "AuthProvider" },
       { "type": "net:outbound", "hosts": ["*"] }
     ]
   },

--- a/extensions/ext-auth-jwt/src/index.ts
+++ b/extensions/ext-auth-jwt/src/index.ts
@@ -186,7 +186,6 @@ const extJwt: ExtensionFactory = (config?: unknown) => {
     name: "ext-auth-jwt",
     version: "0.1.0",
     capabilities: [
-      { type: "contract", name: "AuthProvider" },
       { type: "net:outbound", hosts: ["*"] },
     ],
     provides: {

--- a/extensions/ext-bundler-esbuild/deno.json
+++ b/extensions/ext-bundler-esbuild/deno.json
@@ -4,10 +4,10 @@
   "exports": "./src/index.ts",
   "veryfront": {
     "extension": true,
-    "capabilities": [
-      { "type": "contract", "name": "Bundler" },
-      { "type": "contract", "name": "ModuleLexer" }
-    ]
+    "contracts": {
+      "provides": ["Bundler", "ModuleLexer"]
+    },
+    "capabilities": []
   },
   "imports": {
     "esbuild": "npm:esbuild@0.27.4",

--- a/extensions/ext-bundler-esbuild/src/index.test.ts
+++ b/extensions/ext-bundler-esbuild/src/index.test.ts
@@ -25,15 +25,8 @@ describe("ext-bundler-esbuild factory", () => {
     const ext = factory();
     assertEquals(ext.name, "ext-bundler-esbuild");
     assertEquals(ext.version, "0.1.0");
-    assertEquals(Array.isArray(ext.capabilities), true);
-    assertEquals(
-      ext.capabilities.some((c) => c.type === "contract" && c.name === "Bundler"),
-      true,
-    );
-    assertEquals(
-      ext.capabilities.some((c) => c.type === "contract" && c.name === "ModuleLexer"),
-      true,
-    );
+    assertEquals(ext.contracts?.provides, ["Bundler", "ModuleLexer"]);
+    assertEquals(ext.capabilities, []);
   });
 });
 

--- a/extensions/ext-bundler-esbuild/src/index.ts
+++ b/extensions/ext-bundler-esbuild/src/index.ts
@@ -23,10 +23,10 @@ const extEsbuild: ExtensionFactory = () => {
   return {
     name: "ext-bundler-esbuild",
     version: "0.1.0",
-    capabilities: [
-      { type: "contract", name: "Bundler" },
-      { type: "contract", name: "ModuleLexer" },
-    ],
+    contracts: {
+      provides: ["Bundler", "ModuleLexer"],
+    },
+    capabilities: [],
     setup(ctx) {
       if (!ctx.get("Bundler")) {
         ctx.provide("Bundler", bundler);

--- a/extensions/ext-cache-redis/deno.json
+++ b/extensions/ext-cache-redis/deno.json
@@ -4,8 +4,10 @@
   "exports": "./src/index.ts",
   "veryfront": {
     "extension": true,
+    "contracts": {
+      "provides": ["TokenCacheStore"]
+    },
     "capabilities": [
-      { "type": "contract", "name": "TokenCacheStore" },
       { "type": "net:outbound", "hosts": ["*"] }
     ]
   },

--- a/extensions/ext-cache-redis/src/index.test.ts
+++ b/extensions/ext-cache-redis/src/index.test.ts
@@ -56,12 +56,9 @@ describe("ext-cache-redis extension", () => {
       assertEquals(ext.version.length > 0, true);
     });
 
-    it("declares a TokenCacheStore contract capability", () => {
+    it("declares a TokenCacheStore contract", () => {
       const ext = factory();
-      const hasContract = ext.capabilities.some(
-        (c) => c.type === "contract" && c.name === "TokenCacheStore",
-      );
-      assertEquals(hasContract, true);
+      assertEquals(ext.contracts?.provides, ["TokenCacheStore"]);
     });
   });
 

--- a/extensions/ext-cache-redis/src/index.ts
+++ b/extensions/ext-cache-redis/src/index.ts
@@ -72,8 +72,10 @@ const extRedis: ExtensionFactory = () => {
   return {
     name: "ext-cache-redis",
     version: "0.1.0",
+    contracts: {
+      provides: ["TokenCacheStore"],
+    },
     capabilities: [
-      { type: "contract", name: "TokenCacheStore" },
       { type: "net:outbound", hosts: ["*"] },
     ],
 

--- a/extensions/ext-content-mdx/deno.json
+++ b/extensions/ext-content-mdx/deno.json
@@ -4,9 +4,10 @@
   "exports": "./src/index.ts",
   "veryfront": {
     "extension": true,
-    "capabilities": [
-      { "type": "contract", "name": "ContentProcessor" }
-    ]
+    "contracts": {
+      "provides": ["ContentProcessor"]
+    },
+    "capabilities": []
   },
   "imports": {
     "@mdx-js/mdx": "npm:@mdx-js/mdx@3.1.1",

--- a/extensions/ext-content-mdx/src/index.test.ts
+++ b/extensions/ext-content-mdx/src/index.test.ts
@@ -16,13 +16,10 @@ describe("ext-content-mdx factory", () => {
     assertEquals(ext.version, "0.1.0");
   });
 
-  it("declares the ContentProcessor contract capability", () => {
+  it("declares the ContentProcessor contract", () => {
     const ext = factory();
-    const contractCap = ext.capabilities.find((c) => c.type === "contract");
-    assertExists(contractCap);
-    if (contractCap?.type === "contract") {
-      assertEquals(contractCap.name, "ContentProcessor");
-    }
+    assertEquals(ext.contracts?.provides, ["ContentProcessor"]);
+    assertEquals(ext.capabilities, []);
   });
 
   it("registers ContentProcessor when setup runs", async () => {

--- a/extensions/ext-content-mdx/src/index.ts
+++ b/extensions/ext-content-mdx/src/index.ts
@@ -48,7 +48,10 @@ const extMdx: ExtensionFactory = () => {
   return {
     name: "ext-content-mdx",
     version: "0.1.0",
-    capabilities: [{ type: "contract", name: "ContentProcessor" }],
+    contracts: {
+      provides: ["ContentProcessor"],
+    },
+    capabilities: [],
     setup(ctx) {
       ctx.provide("ContentProcessor", impl);
       ctx.logger.info("[ext-content-mdx] ContentProcessor registered");

--- a/extensions/ext-css-tailwind/deno.json
+++ b/extensions/ext-css-tailwind/deno.json
@@ -4,8 +4,10 @@
   "exports": "./src/index.ts",
   "veryfront": {
     "extension": true,
+    "contracts": {
+      "provides": ["CSSProcessor"]
+    },
     "capabilities": [
-      { "type": "contract", "name": "CSSProcessor" },
       { "type": "net:outbound", "hosts": ["esm.sh"] }
     ]
   },

--- a/extensions/ext-css-tailwind/src/index.test.ts
+++ b/extensions/ext-css-tailwind/src/index.test.ts
@@ -21,10 +21,8 @@ describe("ext-css-tailwind factory", () => {
     const ext = factory();
     assertEquals(ext.name, "ext-css-tailwind");
     assertEquals(ext.version, "0.1.0");
-    assertEquals(
-      ext.capabilities.some((c) => c.type === "contract" && c.name === "CSSProcessor"),
-      true,
-    );
+    assertEquals(ext.contracts?.provides, ["CSSProcessor"]);
+    assertEquals(ext.capabilities, [{ type: "net:outbound", hosts: ["esm.sh"] }]);
   });
 });
 

--- a/extensions/ext-css-tailwind/src/index.ts
+++ b/extensions/ext-css-tailwind/src/index.ts
@@ -57,8 +57,10 @@ const extTailwind: ExtensionFactory = () => {
   return {
     name: "ext-css-tailwind",
     version: "0.1.0",
+    contracts: {
+      provides: ["CSSProcessor"],
+    },
     capabilities: [
-      { type: "contract", name: "CSSProcessor" },
       { type: "net:outbound", hosts: ["esm.sh"] },
     ],
     setup(ctx) {

--- a/extensions/ext-db-sqlite/deno.json
+++ b/extensions/ext-db-sqlite/deno.json
@@ -4,8 +4,10 @@
   "exports": "./src/index.ts",
   "veryfront": {
     "extension": true,
+    "contracts": {
+      "provides": ["SqliteStore"]
+    },
     "capabilities": [
-      { "type": "contract", "name": "SqliteStore" },
       { "type": "fs:read" },
       { "type": "fs:write" }
     ]

--- a/extensions/ext-db-sqlite/src/index.test.ts
+++ b/extensions/ext-db-sqlite/src/index.test.ts
@@ -40,13 +40,10 @@ function buildCtx(
 }
 
 describe("ext-db-sqlite extension", () => {
-  it("declares the expected name and capability", () => {
+  it("declares the expected name and contract", () => {
     const ext = factory();
     assertEquals(ext.name, "ext-db-sqlite");
-    assertEquals(
-      ext.capabilities.filter((c) => c.type === "contract").map((c) => c.name),
-      ["SqliteStore"],
-    );
+    assertEquals(ext.contracts?.provides, ["SqliteStore"]);
   });
 
   it("registers SqliteStore on setup", () => {

--- a/extensions/ext-db-sqlite/src/index.ts
+++ b/extensions/ext-db-sqlite/src/index.ts
@@ -29,8 +29,10 @@ const extDbSqlite: ExtensionFactory = () => {
   return {
     name: "ext-db-sqlite",
     version: "0.1.0",
+    contracts: {
+      provides: ["SqliteStore"],
+    },
     capabilities: [
-      { type: "contract", name: "SqliteStore" },
       { type: "fs:read" },
       { type: "fs:write" },
     ],

--- a/extensions/ext-document-kreuzberg/deno.json
+++ b/extensions/ext-document-kreuzberg/deno.json
@@ -4,8 +4,10 @@
   "exports": "./src/index.ts",
   "veryfront": {
     "extension": true,
+    "contracts": {
+      "provides": ["DocumentExtractor"]
+    },
     "capabilities": [
-      { "type": "contract", "name": "DocumentExtractor" },
       { "type": "fs:read" }
     ]
   },

--- a/extensions/ext-document-kreuzberg/src/index.test.ts
+++ b/extensions/ext-document-kreuzberg/src/index.test.ts
@@ -40,13 +40,10 @@ function buildCtx(
 }
 
 describe("ext-document-kreuzberg extension", () => {
-  it("declares the expected name and capability", () => {
+  it("declares the expected name and contract", () => {
     const ext = factory();
     assertEquals(ext.name, "ext-document-kreuzberg");
-    assertEquals(
-      ext.capabilities.filter((c) => c.type === "contract").map((c) => c.name),
-      ["DocumentExtractor"],
-    );
+    assertEquals(ext.contracts?.provides, ["DocumentExtractor"]);
   });
 
   it("registers DocumentExtractor on setup", () => {

--- a/extensions/ext-document-kreuzberg/src/index.ts
+++ b/extensions/ext-document-kreuzberg/src/index.ts
@@ -78,8 +78,10 @@ const extDocumentKreuzberg: ExtensionFactory = () => {
   return {
     name: "ext-document-kreuzberg",
     version: "0.1.0",
+    contracts: {
+      provides: ["DocumentExtractor"],
+    },
     capabilities: [
-      { type: "contract", name: "DocumentExtractor" },
       { type: "fs:read" },
     ],
 

--- a/extensions/ext-llm-anthropic/deno.json
+++ b/extensions/ext-llm-anthropic/deno.json
@@ -4,9 +4,11 @@
   "exports": "./src/index.ts",
   "veryfront": {
     "extension": true,
-    "capabilities": [
-      { "type": "contract", "name": "LLMProvider:anthropic" }
-    ]
+    "contracts": {
+      "provides": ["LLMProvider:anthropic"],
+      "requires": ["LLMProviderRegistry"]
+    },
+    "capabilities": []
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1",

--- a/extensions/ext-llm-anthropic/src/index.test.ts
+++ b/extensions/ext-llm-anthropic/src/index.test.ts
@@ -1,16 +1,14 @@
 import { describe, it } from "@std/testing/bdd";
 import { assert, assertEquals } from "@std/assert";
 import extAnthropic, { AnthropicProvider } from "./index.ts";
-import type { LLMProviderRegistry } from "veryfront/extensions/llm";
+import { type LLMProviderRegistry, LLMProviderRegistryName } from "veryfront/extensions/llm";
 
 describe("ext-llm-anthropic", () => {
-  it("factory descriptor advertises the LLMProvider:anthropic capability", () => {
+  it("factory descriptor requires the LLMProviderRegistry contract", () => {
     const ext = extAnthropic();
     assertEquals(ext.name, "ext-llm-anthropic");
-    assertEquals(ext.capabilities?.[0], {
-      type: "contract",
-      name: "LLMProvider:anthropic",
-    });
+    assertEquals(ext.contracts?.requires, [LLMProviderRegistryName]);
+    assertEquals(ext.capabilities, []);
   });
 
   it("setup registers the provider in the LLMProviderRegistry", () => {

--- a/extensions/ext-llm-anthropic/src/index.ts
+++ b/extensions/ext-llm-anthropic/src/index.ts
@@ -16,7 +16,10 @@ const extAnthropic: ExtensionFactory = () => {
   return {
     name: "ext-llm-anthropic",
     version: "0.1.0",
-    capabilities: [{ type: "contract", name: "LLMProvider:anthropic" }],
+    contracts: {
+      requires: [LLMProviderRegistryName],
+    },
+    capabilities: [],
     setup(ctx) {
       const registry = ctx.require<LLMProviderRegistry>(LLMProviderRegistryName);
       registry.register(provider);

--- a/extensions/ext-llm-google/deno.json
+++ b/extensions/ext-llm-google/deno.json
@@ -4,9 +4,11 @@
   "exports": "./src/index.ts",
   "veryfront": {
     "extension": true,
-    "capabilities": [
-      { "type": "contract", "name": "LLMProvider:google" }
-    ]
+    "contracts": {
+      "provides": ["LLMProvider:google"],
+      "requires": ["LLMProviderRegistry"]
+    },
+    "capabilities": []
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1",

--- a/extensions/ext-llm-google/src/index.test.ts
+++ b/extensions/ext-llm-google/src/index.test.ts
@@ -1,16 +1,14 @@
 import { describe, it } from "@std/testing/bdd";
 import { assert, assertEquals } from "@std/assert";
 import extGoogle, { GoogleProvider } from "./index.ts";
-import type { LLMProviderRegistry } from "veryfront/extensions/llm";
+import { type LLMProviderRegistry, LLMProviderRegistryName } from "veryfront/extensions/llm";
 
 describe("ext-llm-google", () => {
-  it("factory descriptor advertises the LLMProvider:google capability", () => {
+  it("factory descriptor requires the LLMProviderRegistry contract", () => {
     const ext = extGoogle();
     assertEquals(ext.name, "ext-llm-google");
-    assertEquals(ext.capabilities?.[0], {
-      type: "contract",
-      name: "LLMProvider:google",
-    });
+    assertEquals(ext.contracts?.requires, [LLMProviderRegistryName]);
+    assertEquals(ext.capabilities, []);
   });
 
   it("setup registers the provider in the LLMProviderRegistry", () => {

--- a/extensions/ext-llm-google/src/index.ts
+++ b/extensions/ext-llm-google/src/index.ts
@@ -15,7 +15,10 @@ const extGoogle: ExtensionFactory = () => {
   return {
     name: "ext-llm-google",
     version: "0.1.0",
-    capabilities: [{ type: "contract", name: "LLMProvider:google" }],
+    contracts: {
+      requires: [LLMProviderRegistryName],
+    },
+    capabilities: [],
     setup(ctx) {
       const registry = ctx.require<LLMProviderRegistry>(LLMProviderRegistryName);
       registry.register(provider);

--- a/extensions/ext-llm-openai/deno.json
+++ b/extensions/ext-llm-openai/deno.json
@@ -4,9 +4,11 @@
   "exports": "./src/index.ts",
   "veryfront": {
     "extension": true,
-    "capabilities": [
-      { "type": "contract", "name": "LLMProvider:openai" }
-    ]
+    "contracts": {
+      "provides": ["LLMProvider:openai"],
+      "requires": ["LLMProviderRegistry"]
+    },
+    "capabilities": []
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1",

--- a/extensions/ext-llm-openai/src/index.test.ts
+++ b/extensions/ext-llm-openai/src/index.test.ts
@@ -1,16 +1,14 @@
 import { describe, it } from "@std/testing/bdd";
 import { assert, assertEquals } from "@std/assert";
 import extOpenAI, { OpenAIProvider } from "./index.ts";
-import type { LLMProviderRegistry } from "veryfront/extensions/llm";
+import { type LLMProviderRegistry, LLMProviderRegistryName } from "veryfront/extensions/llm";
 
 describe("ext-llm-openai", () => {
-  it("factory descriptor advertises the LLMProvider:openai capability", () => {
+  it("factory descriptor requires the LLMProviderRegistry contract", () => {
     const ext = extOpenAI();
     assertEquals(ext.name, "ext-llm-openai");
-    assertEquals(ext.capabilities?.[0], {
-      type: "contract",
-      name: "LLMProvider:openai",
-    });
+    assertEquals(ext.contracts?.requires, [LLMProviderRegistryName]);
+    assertEquals(ext.capabilities, []);
   });
 
   it("setup registers the provider in the LLMProviderRegistry", () => {

--- a/extensions/ext-llm-openai/src/index.ts
+++ b/extensions/ext-llm-openai/src/index.ts
@@ -16,7 +16,10 @@ const extOpenAI: ExtensionFactory = () => {
   return {
     name: "ext-llm-openai",
     version: "0.1.0",
-    capabilities: [{ type: "contract", name: "LLMProvider:openai" }],
+    contracts: {
+      requires: [LLMProviderRegistryName],
+    },
+    capabilities: [],
     setup(ctx) {
       registry = ctx.require<LLMProviderRegistry>(LLMProviderRegistryName);
       registry.register(provider);

--- a/extensions/ext-observability-opentelemetry/deno.json
+++ b/extensions/ext-observability-opentelemetry/deno.json
@@ -4,9 +4,10 @@
   "exports": "./src/index.ts",
   "veryfront": {
     "extension": true,
+    "contracts": {
+      "provides": ["TracingExporter", "NodeTelemetryProvider"]
+    },
     "capabilities": [
-      { "type": "contract", "name": "TracingExporter" },
-      { "type": "contract", "name": "NodeTelemetryProvider" },
       { "type": "net:outbound", "hosts": ["*"] },
       {
         "type": "env:read",

--- a/extensions/ext-observability-opentelemetry/src/index.test.ts
+++ b/extensions/ext-observability-opentelemetry/src/index.test.ts
@@ -22,14 +22,10 @@ describe("ext-observability-opentelemetry factory", () => {
     assertEquals(ext.name, "ext-observability-opentelemetry");
     assertEquals(ext.version, "0.1.0");
     assertEquals(Array.isArray(ext.capabilities), true);
-    assertEquals(
-      ext.capabilities.some((c) => c.type === "contract" && c.name === "TracingExporter"),
-      true,
-    );
-    assertEquals(
-      ext.capabilities.some((c) => c.type === "contract" && c.name === "NodeTelemetryProvider"),
-      true,
-    );
+    assertEquals(ext.contracts?.provides, [
+      "TracingExporter",
+      "NodeTelemetryProvider",
+    ]);
   });
 });
 

--- a/extensions/ext-observability-opentelemetry/src/index.ts
+++ b/extensions/ext-observability-opentelemetry/src/index.ts
@@ -257,9 +257,10 @@ const extOpenTelemetry: ExtensionFactory = () => {
   return {
     name: "ext-observability-opentelemetry",
     version: "0.1.0",
+    contracts: {
+      provides: ["TracingExporter", "NodeTelemetryProvider"],
+    },
     capabilities: [
-      { type: "contract", name: "TracingExporter" },
-      { type: "contract", name: "NodeTelemetryProvider" },
       { type: "net:outbound", hosts: ["*"] },
       {
         type: "env:read",

--- a/extensions/ext-parser-babel/deno.json
+++ b/extensions/ext-parser-babel/deno.json
@@ -4,9 +4,10 @@
   "exports": "./src/index.ts",
   "veryfront": {
     "extension": true,
-    "capabilities": [
-      { "type": "contract", "name": "CodeParser" }
-    ]
+    "contracts": {
+      "provides": ["CodeParser"]
+    },
+    "capabilities": []
   },
   "imports": {
     "@babel/parser": "npm:@babel/parser@7.29.2",

--- a/extensions/ext-parser-babel/src/index.test.ts
+++ b/extensions/ext-parser-babel/src/index.test.ts
@@ -4,10 +4,11 @@ import extBabel, { BabelCodeParser } from "./index.ts";
 import type { CodeParser } from "veryfront/extensions/parser";
 
 describe("ext-parser-babel", () => {
-  it("factory returns a descriptor with the CodeParser capability", () => {
+  it("factory returns a descriptor with the CodeParser contract", () => {
     const ext = extBabel();
     assertEquals(ext.name, "ext-parser-babel");
-    assertEquals(ext.capabilities?.[0], { type: "contract", name: "CodeParser" });
+    assertEquals(ext.contracts?.provides, ["CodeParser"]);
+    assertEquals(ext.capabilities, []);
   });
 
   it("setup registers the CodeParser contract", () => {

--- a/extensions/ext-parser-babel/src/index.ts
+++ b/extensions/ext-parser-babel/src/index.ts
@@ -93,7 +93,10 @@ const extBabel: ExtensionFactory = () => {
   return {
     name: "ext-parser-babel",
     version: "0.1.0",
-    capabilities: [{ type: "contract", name: "CodeParser" }],
+    contracts: {
+      provides: ["CodeParser"],
+    },
+    capabilities: [],
     setup(ctx) {
       ctx.provide("CodeParser", impl);
       ctx.logger.info("[ext-parser-babel] CodeParser registered");

--- a/extensions/ext-sandbox-shell-tools/deno.json
+++ b/extensions/ext-sandbox-shell-tools/deno.json
@@ -4,9 +4,10 @@
   "exports": "./src/index.ts",
   "veryfront": {
     "extension": true,
-    "capabilities": [
-      { "type": "contract", "name": "SandboxShellToolsProvider" }
-    ]
+    "contracts": {
+      "provides": ["SandboxShellToolsProvider"]
+    },
+    "capabilities": []
   },
   "imports": {
     "bash-tool": "npm:bash-tool@1.3.16",

--- a/extensions/ext-sandbox-shell-tools/src/index.test.ts
+++ b/extensions/ext-sandbox-shell-tools/src/index.test.ts
@@ -8,9 +8,8 @@ describe("ext-sandbox-shell-tools", () => {
     const extension = extSandboxShellTools();
 
     assertEquals(extension.name, "ext-sandbox-shell-tools");
-    assertEquals(extension.capabilities, [
-      { type: "contract", name: SandboxShellToolsProviderName },
-    ]);
+    assertEquals(extension.contracts?.provides, [SandboxShellToolsProviderName]);
+    assertEquals(extension.capabilities, []);
   });
 
   it("registers a provider during setup", () => {

--- a/extensions/ext-sandbox-shell-tools/src/index.ts
+++ b/extensions/ext-sandbox-shell-tools/src/index.ts
@@ -27,7 +27,10 @@ const provider = createSandboxShellToolsProvider(createBashTool);
 const extSandboxShellTools: ExtensionFactory = () => ({
   name: "ext-sandbox-shell-tools",
   version: "0.1.0",
-  capabilities: [{ type: "contract", name: SandboxShellToolsProviderName }],
+  contracts: {
+    provides: [SandboxShellToolsProviderName],
+  },
+  capabilities: [],
   setup(ctx) {
     ctx.provide(SandboxShellToolsProviderName, provider);
     ctx.logger.info("[ext-sandbox-shell-tools] Sandbox shell tools provider registered");

--- a/extensions/ext-schema-zod/deno.json
+++ b/extensions/ext-schema-zod/deno.json
@@ -4,9 +4,10 @@
   "exports": "./src/index.ts",
   "veryfront": {
     "extension": true,
-    "capabilities": [
-      { "type": "contract", "name": "SchemaValidator" }
-    ]
+    "contracts": {
+      "provides": ["SchemaValidator"]
+    },
+    "capabilities": []
   },
   "imports": {
     "zod": "npm:zod@4.3.6",

--- a/extensions/ext-schema-zod/src/index.ts
+++ b/extensions/ext-schema-zod/src/index.ts
@@ -21,7 +21,10 @@ const extZod: ExtensionFactory = () => {
   return {
     name: "ext-schema-zod",
     version: "0.1.0",
-    capabilities: [{ type: "contract", name: "SchemaValidator" }],
+    contracts: {
+      provides: ["SchemaValidator"],
+    },
+    capabilities: [],
     setup(ctx) {
       ctx.provide("SchemaValidator", impl);
       ctx.logger.info("[ext-schema-zod] SchemaValidator registered");

--- a/src/extensions/builtin-extensions.ts
+++ b/src/extensions/builtin-extensions.ts
@@ -84,7 +84,10 @@ function createBuiltinLLMProviderExtension(
     extension: {
       name: definition.extensionName,
       version: "0.1.0",
-      capabilities: [{ type: "contract", name: `LLMProvider:${provider.id}` }],
+      contracts: {
+        requires: [LLMProviderRegistryName],
+      },
+      capabilities: [],
       setup(ctx) {
         const registry = ctx.require<LLMProviderRegistry>(LLMProviderRegistryName);
         didRegister = registerBuiltinLLMProvider(registry, provider);

--- a/src/extensions/capabilities.test.ts
+++ b/src/extensions/capabilities.test.ts
@@ -16,13 +16,13 @@ describe("capabilities", () => {
       const caps: Capability[] = [
         { type: "fs:read", paths: ["./src"] },
         { type: "net:outbound", hosts: ["api.example.com"] },
-        { type: "contract", name: "CacheStore" },
+        { type: "custom:metadata", name: "diagnostic" },
       ];
       const lines = formatCapabilities(caps);
       assertEquals(lines.length, 3);
       assertEquals(lines[0], 'fs:read (paths: ["./src"])');
       assertEquals(lines[1], 'net:outbound (hosts: ["api.example.com"])');
-      assertEquals(lines[2], "contract: CacheStore");
+      assertEquals(lines[2], 'custom:metadata (name: "diagnostic")');
     });
 
     it("should handle capabilities with no extra fields", () => {
@@ -79,8 +79,8 @@ describe("capabilities", () => {
       assertEquals(perms, ["--allow-read"]);
     });
 
-    it("should skip contract capabilities", () => {
-      const caps: Capability[] = [{ type: "contract", name: "Bundler" }];
+    it("should skip capabilities without a Deno permission mapping", () => {
+      const caps: Capability[] = [{ type: "custom:metadata", name: "diagnostic" }];
       const perms = mapToDenoPermissions(caps);
       assertEquals(perms, []);
     });

--- a/src/extensions/capabilities.ts
+++ b/src/extensions/capabilities.ts
@@ -11,10 +11,6 @@ import type { Capability, ExtensionLogger } from "./types.ts";
  */
 export function formatCapabilities(capabilities: Capability[]): string[] {
   return capabilities.map((cap) => {
-    if (cap.type === "contract") {
-      return `contract: ${cap.name as string}`;
-    }
-
     const { type, ...rest } = cap;
     const extras = Object.keys(rest);
     if (extras.length === 0) return type;
@@ -53,7 +49,7 @@ const DENO_PERMISSION_MAP: Record<string, PermissionMapping> = {
 
 /**
  * Map capabilities to Deno CLI permission flags.
- * Skips non-system capabilities (e.g., "contract").
+ * Skips capabilities without a Deno permission mapping.
  */
 export function mapToDenoPermissions(capabilities: Capability[]): string[] {
   const seen = new Set<string>();

--- a/src/extensions/discovery.test.ts
+++ b/src/extensions/discovery.test.ts
@@ -84,6 +84,36 @@ describe("parsePackageMetadata()", () => {
     assertEquals(result?.capabilities[1]?.type, "valid");
   });
 
+  it("should parse contract metadata", () => {
+    const result = parsePackageMetadata({
+      veryfront: {
+        extension: true,
+        capabilities: [{ type: "net:outbound", hosts: ["api.example.com"] }],
+        contracts: {
+          provides: ["CacheStore", ""],
+          requires: ["SchemaValidator", 42],
+        },
+      },
+    });
+
+    assertEquals(result?.contracts?.provides, ["CacheStore"]);
+    assertEquals(result?.contracts?.requires, ["SchemaValidator"]);
+  });
+
+  it("should ignore malformed contract metadata", () => {
+    const result = parsePackageMetadata({
+      veryfront: {
+        extension: true,
+        contracts: {
+          provides: ["", 42],
+          requires: "SchemaValidator",
+        },
+      },
+    });
+
+    assertEquals(result?.contracts, undefined);
+  });
+
   it("should treat non-array capabilities as empty", () => {
     const result = parsePackageMetadata({
       veryfront: { extension: true, capabilities: "not-an-array" },

--- a/src/extensions/discovery.ts
+++ b/src/extensions/discovery.ts
@@ -8,7 +8,7 @@
  */
 
 import { join } from "@std/path";
-import type { Capability, ResolvedExtension } from "./types.ts";
+import type { Capability, PackageContractMetadata, ResolvedExtension } from "./types.ts";
 
 /**
  * Metadata extracted from a package.json that declares itself
@@ -17,6 +17,7 @@ import type { Capability, ResolvedExtension } from "./types.ts";
 export interface PackageMetadata {
   isExtension: true;
   capabilities: Capability[];
+  contracts?: PackageContractMetadata;
 }
 
 function isCapability(value: unknown): value is Capability {
@@ -25,6 +26,27 @@ function isCapability(value: unknown): value is Capability {
   }
   const cap = value as Record<string, unknown>;
   return typeof cap.type === "string" && cap.type.length > 0;
+}
+
+function parseStringList(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const entries = value.filter((entry): entry is string =>
+    typeof entry === "string" && entry.length > 0
+  );
+  return entries.length > 0 ? entries : undefined;
+}
+
+function parseContractMetadata(value: unknown): PackageContractMetadata | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const raw = value as Record<string, unknown>;
+  const contracts: PackageContractMetadata = {};
+  const provides = parseStringList(raw.provides);
+  const requires = parseStringList(raw.requires);
+  if (provides) contracts.provides = provides;
+  if (requires) contracts.requires = requires;
+  return provides || requires ? contracts : undefined;
 }
 
 /**
@@ -53,8 +75,11 @@ export function parsePackageMetadata(
   const capabilities: Capability[] = Array.isArray(meta.capabilities)
     ? meta.capabilities.filter(isCapability)
     : [];
+  const contracts = parseContractMetadata(meta.contracts);
 
-  return { isExtension: true, capabilities };
+  return contracts
+    ? { isExtension: true, capabilities, contracts }
+    : { isExtension: true, capabilities };
 }
 
 /**

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -27,6 +27,7 @@ export type {
   Extension,
   ExtensionConfigEntry,
   ExtensionContext,
+  ExtensionContractMetadata,
   ExtensionFactory,
   ExtensionLogger,
   ExtensionSource,

--- a/src/extensions/integration.test.ts
+++ b/src/extensions/integration.test.ts
@@ -89,7 +89,7 @@ describe("extensions/integration", () => {
     });
 
     const consumer = makeExt("repo-layer", {
-      capabilities: [{ type: "contract", name: "DatabaseClient" }],
+      contracts: { requires: ["DatabaseClient"] },
       setup: () => {
         order.push("repo-layer");
       },

--- a/src/extensions/loader.test.ts
+++ b/src/extensions/loader.test.ts
@@ -38,7 +38,7 @@ describe("ExtensionLoader", () => {
     it("should sort providers before consumers", () => {
       const provider = makeExt("provider", { provides: { CacheStore: {} } });
       const consumer = makeExt("consumer", {
-        capabilities: [{ type: "contract", name: "CacheStore" }],
+        contracts: { requires: ["CacheStore"] },
       });
 
       const loader = new ExtensionLoader(noopLogger);
@@ -49,6 +49,28 @@ describe("ExtensionLoader", () => {
 
       assertEquals(sorted[0]?.extension.name, "provider");
       assertEquals(sorted[1]?.extension.name, "consumer");
+    });
+
+    it("sorts dynamic contract providers before explicit requires", () => {
+      const provider = makeExt("provider", {
+        contracts: { provides: ["CacheStore"] },
+        setup: (ctx) => ctx.provide("CacheStore", { id: "dynamic" }),
+      });
+      const consumer = makeExt("consumer", {
+        contracts: { requires: ["CacheStore"] },
+        setup: (ctx) => ctx.require("CacheStore"),
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      const sorted = loader.topologicalSort([
+        makeResolved(consumer),
+        makeResolved(provider),
+      ]);
+
+      assertEquals(sorted.map((entry) => entry.extension.name), [
+        "provider",
+        "consumer",
+      ]);
     });
 
     it("should keep original order when no dependencies exist", () => {
@@ -75,11 +97,11 @@ describe("ExtensionLoader", () => {
     it("should throw on circular dependencies", () => {
       const a = makeExt("ext-a", {
         provides: { A: {} },
-        capabilities: [{ type: "contract", name: "B" }],
+        contracts: { requires: ["B"] },
       });
       const b = makeExt("ext-b", {
         provides: { B: {} },
-        capabilities: [{ type: "contract", name: "A" }],
+        contracts: { requires: ["A"] },
       });
 
       const loader = new ExtensionLoader(noopLogger);
@@ -153,6 +175,29 @@ describe("ExtensionLoader", () => {
       const loader = new ExtensionLoader(noopLogger);
       await loader.setupAll([makeResolved(provider), makeResolved(consumer)], {});
       assertEquals((resolved as { id: string }).id, "redis");
+    });
+
+    it("should order setup by explicit contract metadata", async () => {
+      const order: string[] = [];
+      const provider = makeExt("provider", {
+        contracts: { provides: ["CacheStore"] },
+        setup: (ctx) => {
+          order.push("provider");
+          ctx.provide("CacheStore", { id: "dynamic" });
+        },
+      });
+      const consumer = makeExt("consumer", {
+        contracts: { requires: ["CacheStore"] },
+        setup: (ctx) => {
+          const cache = ctx.require<{ id: string }>("CacheStore");
+          order.push(`consumer:${cache.id}`);
+        },
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      await loader.setupAll([makeResolved(consumer), makeResolved(provider)], {});
+
+      assertEquals(order, ["provider", "consumer:dynamic"]);
     });
   });
 
@@ -277,6 +322,28 @@ describe("ExtensionLoader", () => {
 
       const loader = new ExtensionLoader(noopLogger);
       // Pass project first to prove order-insensitivity.
+      await loader.setupAll(
+        [
+          makeResolved(projectProvider, "project"),
+          makeResolved(configProvider, "config"),
+        ],
+        {},
+      );
+
+      assertEquals((tryResolve("Cache") as { id: string }).id, "config-impl");
+    });
+
+    it("should keep dynamic ctx.provide() source priority order-insensitive", async () => {
+      const configProvider = makeExt("config-cache", {
+        contracts: { provides: ["Cache"] },
+        setup: (ctx) => ctx.provide("Cache", { id: "config-impl" }),
+      });
+      const projectProvider = makeExt("project-cache", {
+        contracts: { provides: ["Cache"] },
+        setup: (ctx) => ctx.provide("Cache", { id: "project-impl" }),
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
       await loader.setupAll(
         [
           makeResolved(projectProvider, "project"),

--- a/src/extensions/loader.ts
+++ b/src/extensions/loader.ts
@@ -84,15 +84,11 @@ export class ExtensionLoader {
       const ext = resolved.extension;
       extByName.set(ext.name, resolved);
 
-      if (ext.provides) {
-        for (const contract of Object.keys(ext.provides)) {
-          providerOf.set(contract, ext.name);
-        }
+      for (const contract of providedContractNames(ext)) {
+        providerOf.set(contract, ext.name);
       }
 
-      const contracts = ext.capabilities
-        .filter((c) => c.type === "contract")
-        .map((c) => c.name as string);
+      const contracts = requiredContractNames(ext);
       if (contracts.length > 0) {
         consumesContracts.set(ext.name, contracts);
       }
@@ -168,8 +164,10 @@ export class ExtensionLoader {
       register(name, impl);
     }
 
+    const loadOrder = this.topologicalSort(this.flattenPresets(extensions));
+
     // Check for contract conflicts before loading
-    const conflicts = detectConflicts(extensions);
+    const conflicts = detectConflicts(loadOrder);
     if (conflicts.length > 0) {
       const details = conflicts
         .map((c) => `"${c.contract}" provided by: ${c.providers.map((p) => p.name).join(", ")}`)
@@ -183,9 +181,9 @@ export class ExtensionLoader {
     // provider later in the iteration order cannot overwrite the winning impl
     // via register(). Without this, merged inputs (config -> package ->
     // project -> local-file) silently invert the documented source priority.
-    const contractWinner = selectContractProviders(extensions);
+    const contractWinner = selectContractProviders(loadOrder);
 
-    for (const resolved of extensions) {
+    for (const resolved of loadOrder) {
       const ext = resolved.extension;
 
       const issues = validateExtension(ext);
@@ -209,7 +207,12 @@ export class ExtensionLoader {
         const ctx: ExtensionContext = {
           get: <T>(contract: string) => tryResolve<T>(contract),
           require: <T>(contract: string) => resolveContract<T>(contract),
-          provide: <T>(contract: string, impl: T) => register(contract, impl),
+          provide: <T>(contract: string, impl: T) => {
+            const winner = contractWinner.get(contract);
+            if (!winner || winner === resolved) {
+              register(contract, impl);
+            }
+          },
           config: projectConfig,
           logger: this.logger,
         };
@@ -261,4 +264,19 @@ export class ExtensionLoader {
     // harness in `tests/_helpers/contract-init.ts`).
     if (hadSetupExtensions) reset();
   }
+}
+
+function providedContractNames(ext: Extension): string[] {
+  const names = new Set<string>();
+  for (const contract of Object.keys(ext.provides ?? {})) {
+    names.add(contract);
+  }
+  for (const contract of ext.contracts?.provides ?? []) {
+    names.add(contract);
+  }
+  return [...names];
+}
+
+function requiredContractNames(ext: Extension): string[] {
+  return ext.contracts?.requires ?? [];
 }

--- a/src/extensions/orchestrate.test.ts
+++ b/src/extensions/orchestrate.test.ts
@@ -384,7 +384,7 @@ describe("orchestrateExtensions()", () => {
       },
     };
     const custom = stubExt("custom-anthropic", {
-      capabilities: [{ type: "contract", name: "LLMProvider:anthropic" }],
+      contracts: { requires: [LLMProviderRegistryName] },
       setup(ctx) {
         ctx.require<LLMProviderRegistry>(LLMProviderRegistryName).register(customProvider);
       },

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -13,6 +13,15 @@ export interface Capability {
   [key: string]: unknown;
 }
 
+export interface ExtensionContractMetadata {
+  /** Contracts this extension registers dynamically during setup(). */
+  provides?: string[];
+  /** Contracts this extension needs before setup() runs. */
+  requires?: string[];
+}
+
+export type PackageContractMetadata = ExtensionContractMetadata;
+
 export interface ExtensionContext {
   get<T>(contract: string): T | undefined;
   require<T>(contract: string): T;
@@ -32,6 +41,7 @@ export interface Extension {
   name: string;
   version: string;
   capabilities: Capability[];
+  contracts?: ExtensionContractMetadata;
   setup?(ctx: ExtensionContext): Promise<void> | void;
   teardown?(): Promise<void> | void;
   provides?: Record<string, unknown>;

--- a/src/extensions/validation.test.ts
+++ b/src/extensions/validation.test.ts
@@ -73,6 +73,41 @@ describe("validateExtension", () => {
     assertEquals(issues.some((i) => i.includes("capabilities[0]")), true);
   });
 
+  it("accepts explicit contract metadata", () => {
+    const issues = validateExtension({
+      name: "test-ext",
+      version: "1.0.0",
+      capabilities: [{ type: "net:outbound", hosts: ["api.example.com"] }],
+      contracts: {
+        provides: ["TokenCacheStore"],
+        requires: ["SchemaValidator"],
+      },
+    });
+
+    assertEquals(issues, []);
+  });
+
+  it("rejects malformed contract metadata", () => {
+    const issues = validateExtension({
+      name: "test-ext",
+      version: "1.0.0",
+      capabilities: [],
+      contracts: {
+        provides: ["TokenCacheStore", ""],
+        requires: [42],
+      },
+    });
+
+    assertEquals(
+      issues.some((issue) => issue.includes("contracts.provides[1]")),
+      true,
+    );
+    assertEquals(
+      issues.some((issue) => issue.includes("contracts.requires[0]")),
+      true,
+    );
+  });
+
   it("rejects null input", () => {
     const issues = validateExtension(null);
     assertEquals(issues.length, 1);
@@ -169,6 +204,34 @@ describe("detectConflicts", () => {
     assertEquals(conflicts.length, 2);
     const contracts = conflicts.map((c) => c.contract).sort();
     assertEquals(contracts, ["Bundler", "CacheStore"]);
+  });
+
+  it("reports conflicts for dynamically provided contracts", () => {
+    const conflicts = detectConflicts([
+      {
+        extension: {
+          name: "ext-a",
+          version: "1.0.0",
+          capabilities: [],
+          contracts: { provides: ["CacheStore"] },
+        },
+        source: "package",
+        origin: "node_modules/ext-a",
+      },
+      {
+        extension: {
+          name: "ext-b",
+          version: "1.0.0",
+          capabilities: [],
+          contracts: { provides: ["CacheStore"] },
+        },
+        source: "package",
+        origin: "node_modules/ext-b",
+      },
+    ]);
+
+    assertEquals(conflicts.length, 1);
+    assertEquals(conflicts[0]?.contract, "CacheStore");
   });
 
   it("returns empty for empty extension list", () => {

--- a/src/extensions/validation.ts
+++ b/src/extensions/validation.ts
@@ -37,9 +37,7 @@ export function selectContractProviders(
 ): Map<string, ResolvedExtension> {
   const winner = new Map<string, ResolvedExtension>();
   for (const resolved of extensions) {
-    const provides = resolved.extension.provides;
-    if (!provides) continue;
-    for (const contract of Object.keys(provides)) {
+    for (const contract of providedContractNames(resolved.extension)) {
       const current = winner.get(contract);
       if (
         !current ||
@@ -50,6 +48,30 @@ export function selectContractProviders(
     }
   }
   return winner;
+}
+
+function providedContractNames(extension: Extension): string[] {
+  return [
+    ...Object.keys(extension.provides ?? {}),
+    ...(extension.contracts?.provides ?? []),
+  ];
+}
+
+function validateContractList(
+  field: string,
+  value: unknown,
+  issues: string[],
+): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    issues.push(`${field} must be an array`);
+    return;
+  }
+  for (let i = 0; i < value.length; i++) {
+    if (typeof value[i] !== "string" || value[i].length === 0) {
+      issues.push(`${field}[${i}] must be a non-empty string`);
+    }
+  }
 }
 
 /**
@@ -93,6 +115,27 @@ export function validateExtension(ext: unknown): string[] {
     }
   }
 
+  if (candidate.contracts !== undefined) {
+    if (
+      typeof candidate.contracts !== "object" ||
+      candidate.contracts === null ||
+      Array.isArray(candidate.contracts)
+    ) {
+      issues.push("contracts must be an object");
+    } else {
+      validateContractList(
+        "contracts.provides",
+        candidate.contracts.provides,
+        issues,
+      );
+      validateContractList(
+        "contracts.requires",
+        candidate.contracts.requires,
+        issues,
+      );
+    }
+  }
+
   return issues;
 }
 
@@ -109,10 +152,7 @@ export function detectConflicts(extensions: ResolvedExtension[]): ConflictInfo[]
   >();
 
   for (const resolved of extensions) {
-    const provides = resolved.extension.provides;
-    if (!provides) continue;
-
-    for (const contract of Object.keys(provides)) {
+    for (const contract of providedContractNames(resolved.extension)) {
       let list = contractProviders.get(contract);
       if (!list) {
         list = [];


### PR DESCRIPTION
## Summary
- Add explicit `contracts.provides` / `contracts.requires` metadata for extension load ordering
- Apply topological sorting inside `setupAll()` and preserve source priority for dynamic `ctx.provide()` registrations
- Move first-party extension descriptors and manifests off contract-shaped capabilities
- Update extension authoring docs, README, and scaffold output

## Verification
- `deno test --no-check --allow-all src/extensions/loader.test.ts src/extensions/validation.test.ts src/extensions/discovery.test.ts src/extensions/capabilities.test.ts cli/commands/extension/init-command.test.ts`
- `deno test --no-check --allow-all extensions/ext-*/src/*.test.ts`
- `deno test --no-check --allow-all src/extensions/*.test.ts`
- `deno test --no-check --allow-all cli/commands/extension/*.test.ts`
- `deno check src/extensions/types.ts src/extensions/discovery.ts src/extensions/loader.ts src/extensions/validation.ts src/extensions/builtin-extensions.ts cli/commands/extension/init-command.ts`
- `deno task lint:dependency-boundaries`
- pre-push checks: format, lint, type check, unit tests (`1882 passed`)
