### PR TITLE
security: sanitize request header values in logger (SEC-011)

### DIFF
--- a/src/middleware/builtin/logger.test.ts
+++ b/src/middleware/builtin/logger.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { devLogger, logger, prodLogger } from "./logger.ts";
+import { devLogger, logger, prodLogger, sanitizeHeaderForLog } from "./logger.ts";
 
 function makeCtx(
   url = "http://localhost/api/data",
@@ -294,6 +294,68 @@ describe("middleware/builtin/logger", () => {
 
       assertEquals(logs.length, 1);
       assert(getFirstLog(logs).includes("\x1b["));
+    });
+
+    // SEC-011 — long user-agent reaches the logger via a normal Request and
+    // must be truncated to 256 chars in the log output. CRLF cases for the
+    // sanitizer itself are covered in the `sanitizeHeaderForLog` suite below
+    // (Deno's `Request` constructor rejects CR/LF in header values, so the
+    // helper has to be exercised directly).
+    it("should cap user-agent length at 256 characters", async () => {
+      const logs: string[] = [];
+      const mw = logger({ format: "json", log: (msg) => logs.push(msg) });
+
+      const longUa = "A".repeat(1000);
+      await mw(
+        makeCtx("http://localhost/", { "user-agent": longUa }),
+        nextOk,
+      );
+
+      const entry = JSON.parse(getFirstLog(logs));
+      assertEquals(entry.http.userAgent.length, 256);
+      assertEquals(entry.http.userAgent, "A".repeat(256));
+    });
+  });
+
+  // SEC-011 — log injection via unsanitized request headers (CWE-117)
+  describe("sanitizeHeaderForLog", () => {
+    it("strips CR and LF from header values", () => {
+      assertEquals(
+        sanitizeHeaderForLog("evil\r\n[ERROR] fake-audit-line"),
+        "evil[ERROR] fake-audit-line",
+      );
+    });
+
+    it("strips tab characters", () => {
+      assertEquals(sanitizeHeaderForLog("a\tb\tc"), "abc");
+    });
+
+    it("strips C0 control characters and DEL", () => {
+      assertEquals(sanitizeHeaderForLog("\x00\x01\x07x\x1fy\x7fz"), "xyz");
+    });
+
+    it("preserves ordinary printable characters", () => {
+      const ua = "Mozilla/5.0 (X11; Linux x86_64) Chrome/120.0.0.0";
+      assertEquals(sanitizeHeaderForLog(ua), ua);
+    });
+
+    it("truncates at 256 characters", () => {
+      const long = "A".repeat(1000);
+      const result = sanitizeHeaderForLog(long);
+      assertEquals(result.length, 256);
+      assertEquals(result, "A".repeat(256));
+    });
+
+    it("handles empty string", () => {
+      assertEquals(sanitizeHeaderForLog(""), "");
+    });
+
+    it("produces output safe to embed in a single log line", () => {
+      const malicious = "ua\r\n[FAKE]\tline";
+      const sanitized = sanitizeHeaderForLog(malicious);
+      assert(!sanitized.includes("\r"), `Sanitized must not contain CR: ${sanitized}`);
+      assert(!sanitized.includes("\n"), `Sanitized must not contain LF: ${sanitized}`);
+      assert(!sanitized.includes("\t"), `Sanitized must not contain tab: ${sanitized}`);
     });
   });
 

--- a/src/middleware/builtin/logger.ts
+++ b/src/middleware/builtin/logger.ts
@@ -67,8 +67,28 @@ function getTimestamp(): string {
   return new Date().toISOString().replace("T", " ").replace("Z", "");
 }
 
+// deno-lint-ignore no-control-regex -- intentionally matching control chars to strip them
+const HEADER_LOG_CONTROL_CHARS = /[\r\n\t\x00-\x1f\x7f]/g;
+const HEADER_LOG_MAX_LENGTH = 256;
+
+/**
+ * Strip CR/LF/tab/other control characters and cap length before a user-controlled
+ * header value is written to a log entry. Prevents log injection (CWE-117).
+ *
+ * Exported for direct unit testing — Deno's `Request` constructor rejects CR/LF
+ * in header values, so the helper must be tested without going through `Request`.
+ */
+export function sanitizeHeaderForLog(value: string): string {
+  return value.replace(HEADER_LOG_CONTROL_CHARS, "").slice(0, HEADER_LOG_MAX_LENGTH);
+}
+
+function readHeaderForLog(req: Request, name: string): string | null {
+  const value = req.headers.get(name);
+  return value === null ? null : sanitizeHeaderForLog(value);
+}
+
 function getRemoteAddr(req: Request): string {
-  return req.headers.get("x-forwarded-for") ?? req.headers.get("x-real-ip") ?? "-";
+  return readHeaderForLog(req, "x-forwarded-for") ?? readHeaderForLog(req, "x-real-ip") ?? "-";
 }
 
 function getRequestLogDetails(req: Request): RequestLogDetails {
@@ -76,11 +96,12 @@ function getRequestLogDetails(req: Request): RequestLogDetails {
     method: req.method,
     pathname: new URL(req.url).pathname,
     remoteAddr: getRemoteAddr(req),
-    referer: req.headers.get("referer") ?? undefined,
-    requestId: req.headers.get("x-request-id") ?? undefined,
-    traceId: req.headers.get("x-trace-id") ?? req.headers.get("traceparent") ?? undefined,
-    projectSlug: req.headers.get("x-project-slug") ?? undefined,
-    userAgent: req.headers.get("user-agent") ?? undefined,
+    referer: readHeaderForLog(req, "referer") ?? undefined,
+    requestId: readHeaderForLog(req, "x-request-id") ?? undefined,
+    traceId: readHeaderForLog(req, "x-trace-id") ?? readHeaderForLog(req, "traceparent") ??
+      undefined,
+    projectSlug: readHeaderForLog(req, "x-project-slug") ?? undefined,
+    userAgent: readHeaderForLog(req, "user-agent") ?? undefined,
   };
 }
 
@@ -141,8 +162,8 @@ function formatLog(format: LogFormat, req: Request, status: number, duration: nu
   const { method } = req;
   const remoteAddr = getRemoteAddr(req);
   const timestamp = getTimestamp();
-  const userAgent = req.headers.get("user-agent") ?? "-";
-  const referer = req.headers.get("referer") ?? "-";
+  const userAgent = readHeaderForLog(req, "user-agent") ?? "-";
+  const referer = readHeaderForLog(req, "referer") ?? "-";
   const durationText = formatDuration(duration);
 
   switch (format) {


### PR DESCRIPTION
## Summary
- Add `sanitizeHeaderForLog()` that strips CR/LF/tab and C0/DEL control chars and caps length at 256.
- Route every user-controlled header read in `src/middleware/builtin/logger.ts` through a `readHeaderForLog()` wrapper that preserves the existing nullish semantics: `x-forwarded-for`, `x-real-ip`, `referer`, `x-request-id`, `x-trace-id`, `traceparent`, `x-project-slug`, `user-agent`.
- Affects both text formats (`combined`, `common`, `short`, `tiny`, `dev`) and the JSON formatter.

Fixes audit finding **SEC-011** (Low, CWE-117, OWASP A09:2021).

## Test plan
- [x] New `sanitizeHeaderForLog` unit tests: strips CR/LF, tab, C0 range, DEL; preserves printable; truncates at 256; handles empty
- [x] Existing logger integration test extended: 1000-char `user-agent` is capped at 256 chars in JSON log output
- [x] All existing logger tests still pass (24 prior + 9 new = 33 steps green)
- [x] `deno task lint` / `deno task fmt` clean on changed files

## Notes for reviewer
- The helper is exported because Deno's `Request` constructor rejects CR/LF in header values, so CRLF coverage has to be exercised against the helper directly rather than through a synthetic `Request`.
- `// deno-lint-ignore no-control-regex` is required on the strip pattern (the rule fires on the very chars we're stripping).