### PR TITLE
Add reusable agent eval CLI runners

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.534",
+  "version": "0.1.535",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/testing/durable-run-canaries/cli-runner.test.ts
+++ b/src/agent/testing/durable-run-canaries/cli-runner.test.ts
@@ -1,0 +1,57 @@
+import { join } from "node:path";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { runDurableRunCanaryCli } from "./cli-runner.ts";
+import type { DurableRunCanaryCase } from "./runner.ts";
+import type { createDurableRunCanaryRunner } from "./runner.ts";
+
+const conversationId = "11111111-1111-4111-8111-111111111111";
+
+describe("agent testing durable run canary CLI runner", () => {
+  it("runs canary cases, writes a report, and returns success", async () => {
+    const cwd = await Deno.makeTempDir();
+    const reportPath = join(cwd, "durable-report.json");
+    const logs: string[] = [];
+    const testCase: DurableRunCanaryCase = {
+      id: "canary-a",
+      label: "Canary A",
+      prepare: async () => ({
+        cleanup: async () => {},
+        conversationId,
+        prompt: "hello",
+        title: "Canary A",
+        validate: () => {},
+      }),
+    };
+    const runner: ReturnType<typeof createDurableRunCanaryRunner> = {
+      runCase: async (currentCase) => ({
+        id: currentCase.id,
+        label: currentCase.label,
+        status: "pass",
+        details: "OK",
+        durationMs: 10,
+        conversationId,
+        runId: "run_1",
+      }),
+    };
+
+    const exitCode = await runDurableRunCanaryCli({
+      cwd,
+      agentId: "veryfront",
+      env: {
+        VERYFRONT_TOKEN: "token",
+        AG_UI_EVAL_PROJECT_ID: "project-1",
+        DURABLE_CANARY_REPORT_PATH: reportPath,
+      },
+      createCases: () => [testCase],
+      createRunner: () => runner,
+      log: (message) => logs.push(message),
+    });
+
+    assertEquals(exitCode, 0);
+    assertEquals(logs.some((entry) => entry.includes("[pass] canary-a: OK")), true);
+    const report = await Deno.readTextFile(reportPath);
+    assertStringIncludes(report, '"canary-a"');
+    assertStringIncludes(report, '"passed": 1');
+  });
+});

--- a/src/agent/testing/durable-run-canaries/cli-runner.ts
+++ b/src/agent/testing/durable-run-canaries/cli-runner.ts
@@ -1,0 +1,117 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { cwd as getProcessCwd } from "node:process";
+import { type LiveEvalApiContext } from "../live-evals/api-client.ts";
+import { resolveDurableRunCanaryEnvironment } from "./environment.ts";
+import {
+  createDurableRunCanaryRunner,
+  type DurableRunCanaryCase,
+  type DurableRunCanaryResult,
+  type DurableRunCanaryRunnerConfig,
+} from "./runner.ts";
+
+type EnvRecord = Record<string, string | undefined>;
+
+export interface DurableRunCanaryCliCaseFactoryInput {
+  context: LiveEvalApiContext;
+  requestTimeoutMs: number;
+}
+
+export interface RunDurableRunCanaryCliInput {
+  env: EnvRecord;
+  agentId: string;
+  createCases: (input: DurableRunCanaryCliCaseFactoryInput) => DurableRunCanaryCase[];
+  cwd?: string;
+  log?: (message: string) => void;
+  createRunner?: (
+    config: DurableRunCanaryRunnerConfig,
+  ) => ReturnType<typeof createDurableRunCanaryRunner>;
+}
+
+function createTimestampedReportPath(input: {
+  cwd: string;
+  directory: string;
+}): string {
+  return resolve(
+    input.cwd,
+    ".omx/logs",
+    input.directory,
+    `${new Date().toISOString().replaceAll(":", "-").replaceAll(".", "-")}.json`,
+  );
+}
+
+export async function runDurableRunCanaryCli(
+  input: RunDurableRunCanaryCliInput,
+): Promise<number> {
+  const log = input.log ?? console.log;
+  const cwd = input.cwd ?? getProcessCwd();
+  const { apiUrl, authToken, projectId, requestTimeoutMs, keepSuccessfulEvidence } =
+    resolveDurableRunCanaryEnvironment(input.env);
+  const reportPath = input.env.DURABLE_CANARY_REPORT_PATH ??
+    createTimestampedReportPath({ cwd, directory: "durable-run-staging-canaries" });
+
+  if (!authToken) {
+    throw new Error("Missing VERYFRONT_TOKEN");
+  }
+  if (!projectId) {
+    throw new Error("Missing AG_UI_EVAL_PROJECT_ID");
+  }
+
+  const context: LiveEvalApiContext = {
+    apiUrl,
+    authToken,
+    projectId: projectId || null,
+  };
+  const createRunner = input.createRunner ?? createDurableRunCanaryRunner;
+  const { runCase } = createRunner({
+    apiUrl,
+    authToken,
+    agentId: input.agentId,
+    projectId: projectId || null,
+    requestTimeoutMs,
+    keepSuccessfulEvidence,
+  });
+  const testCases = input.createCases({
+    context,
+    requestTimeoutMs,
+  });
+
+  log(`Durable run canaries -> ${apiUrl}`);
+  log(`Project scope -> ${projectId}`);
+
+  const results: DurableRunCanaryResult[] = [];
+  for (const testCase of testCases) {
+    log(`\n[run] ${testCase.label}`);
+    const result = await runCase(testCase);
+    results.push(result);
+    log(`[${result.status}] ${result.id}: ${result.details}`);
+  }
+
+  const summary = {
+    passed: results.filter((result) => result.status === "pass").length,
+    failed: results.filter((result) => result.status === "fail").length,
+  };
+
+  await mkdir(dirname(reportPath), { recursive: true });
+  await writeFile(
+    reportPath,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        apiUrl,
+        projectId,
+        results,
+        summary,
+      },
+      null,
+      2,
+    ),
+  );
+
+  log("\nSummary");
+  log(`passed: ${summary.passed}`);
+  log(`failed: ${summary.failed}`);
+  log(`report: ${reportPath}`);
+
+  return summary.failed > 0 ? 1 : 0;
+}

--- a/src/agent/testing/durable-run-canaries/index.ts
+++ b/src/agent/testing/durable-run-canaries/index.ts
@@ -1,4 +1,9 @@
 export {
+  type DurableRunCanaryCliCaseFactoryInput,
+  runDurableRunCanaryCli,
+  type RunDurableRunCanaryCliInput,
+} from "./cli-runner.ts";
+export {
   DEFAULT_DURABLE_RUN_CANARY_TIMEOUT_MS,
   type DurableRunCanaryEnvironment,
   resolveDurableRunCanaryEnvironment,

--- a/src/agent/testing/live-evals/cli-runner.test.ts
+++ b/src/agent/testing/live-evals/cli-runner.test.ts
@@ -1,0 +1,66 @@
+import { join } from "node:path";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { runLiveEvalCli } from "./cli-runner.ts";
+import type { LiveEvalCase } from "./runner.ts";
+import type { createLiveEvalCaseSupport } from "./runner.ts";
+
+const reportPath = "live-report.json";
+
+describe("agent testing live eval CLI runner", () => {
+  it("runs selected cases, writes a report, and returns success", async () => {
+    const cwd = await Deno.makeTempDir();
+    const logs: string[] = [];
+    const readOnlyCase: LiveEvalCase = {
+      id: "case-a",
+      label: "Case A",
+      metadata: { tags: ["gate:ci"] },
+      verify: () => null,
+    };
+    const skippedWriteCase: LiveEvalCase = {
+      id: "case-b",
+      label: "Case B",
+      metadata: { tags: ["gate:nightly"] },
+      verify: () => null,
+    };
+    const caseSupport: ReturnType<typeof createLiveEvalCaseSupport> = {
+      judgeLlm: async () => ({ pass: true, reason: "PASS" }),
+      runEval: async (testCase, runtime) => ({
+        id: testCase.id,
+        label: testCase.label,
+        runtime,
+        status: "pass",
+        details: "OK",
+        durationMs: 10,
+      }),
+      verifyFileExists: async () => null,
+      withJudge: () => async () => null,
+    };
+
+    const exitCode = await runLiveEvalCli({
+      cwd,
+      env: {
+        VERYFRONT_TOKEN: "token",
+        AG_UI_EVAL_PROJECT_ID: "project-1",
+        AG_UI_EVAL_REPORT_PATH: join(cwd, reportPath),
+        AG_UI_EVAL_TAGS: "gate:ci",
+        AG_UI_EVAL_WRITE: "1",
+      },
+      caseSets: {},
+      createCaseSupport: () => caseSupport,
+      createCases: () => ({
+        readOnlyCases: [readOnlyCase],
+        writeCases: [skippedWriteCase],
+        experimentalWriteCases: [],
+      }),
+      log: (message) => logs.push(message),
+    });
+
+    assertEquals(exitCode, 0);
+    assertEquals(logs.some((entry) => entry.includes("[pass] OK")), true);
+    const report = await Deno.readTextFile(join(cwd, reportPath));
+    assertStringIncludes(report, '"case-a"');
+    assertStringIncludes(report, '"passed": 1');
+    assertEquals(report.includes('"case-b"'), false);
+  });
+});

--- a/src/agent/testing/live-evals/cli-runner.ts
+++ b/src/agent/testing/live-evals/cli-runner.ts
@@ -1,0 +1,234 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { cwd as getProcessCwd } from "node:process";
+import { buildRuntimePerformanceSummary, type LiveEvalRuntime } from "./performance.ts";
+import {
+  buildLiveEvalCaseTagSummary,
+  buildLiveEvalRuntimeSummary,
+  buildLiveEvalStatusSummary,
+  resolveLiveEvalRequestedCaseIds,
+  selectLiveEvalCases,
+} from "./report.ts";
+import {
+  containsSkillLoad,
+  countStepStartedEvents,
+  createLiveEvalCaseSupport,
+  hasFinished,
+  type LiveEvalCase,
+  type LiveEvalRunnerConfig,
+} from "./runner.ts";
+import { getLiveEvalProjectFile, type LiveEvalApiContext } from "./api-client.ts";
+import { resolveLiveEvalEnvironment } from "./environment.ts";
+import type { LiveEvalResultRecord } from "./result.ts";
+
+type EnvRecord = Record<string, string | undefined>;
+
+export interface LiveEvalCliCaseGroups {
+  readOnlyCases: LiveEvalCase[];
+  writeCases: LiveEvalCase[];
+  experimentalWriteCases: LiveEvalCase[];
+}
+
+export interface LiveEvalCliCaseFactoryInput {
+  authToken: string;
+  endpoint: string;
+  projectId: string | null;
+  branchId: string | null;
+  model: string | null;
+  requestTimeoutMs: number;
+  enableLlmJudge: boolean;
+  hasFinished: typeof hasFinished;
+  containsSkillLoad: typeof containsSkillLoad;
+  countStepStartedEvents: typeof countStepStartedEvents;
+  verifyFileExists: ReturnType<typeof createLiveEvalCaseSupport>["verifyFileExists"];
+  withJudge: ReturnType<typeof createLiveEvalCaseSupport>["withJudge"];
+  judgeLlm: ReturnType<typeof createLiveEvalCaseSupport>["judgeLlm"];
+}
+
+export interface RunLiveEvalCliInput {
+  env: EnvRecord;
+  caseSets: Record<string, readonly string[]>;
+  createCases: (input: LiveEvalCliCaseFactoryInput) => LiveEvalCliCaseGroups;
+  runtimes?: readonly LiveEvalRuntime[];
+  cwd?: string;
+  log?: (message: string) => void;
+  error?: (message: string) => void;
+  createCaseSupport?: (
+    config: LiveEvalRunnerConfig,
+  ) => ReturnType<typeof createLiveEvalCaseSupport>;
+}
+
+function splitCsvEnv(value: string | undefined): Set<string> {
+  return new Set(
+    (value ?? "")
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0),
+  );
+}
+
+function createTimestampedReportPath(input: {
+  cwd: string;
+  directory: string;
+}): string {
+  return resolve(
+    input.cwd,
+    ".omx/logs",
+    input.directory,
+    `${new Date().toISOString().replaceAll(":", "-").replaceAll(".", "-")}.json`,
+  );
+}
+
+export async function runLiveEvalCli(input: RunLiveEvalCliInput): Promise<number> {
+  const log = input.log ?? console.log;
+  const error = input.error ?? console.error;
+  const cwd = input.cwd ?? getProcessCwd();
+  const { endpoint, authToken, apiUrl, projectId, branchId, model } = resolveLiveEvalEnvironment(
+    input.env,
+  );
+  const requestedRuntimeSelection = input.runtimes ?? ["framework"];
+  const runWriteEvals = input.env.AG_UI_EVAL_WRITE === "1";
+  const runExperimentalWriteEvals = input.env.AG_UI_EVAL_EXPERIMENTAL === "1";
+  const requestTimeoutMs = Number(input.env.AG_UI_EVAL_TIMEOUT_MS ?? "240000");
+  const progressLogIntervalMs = Number(input.env.AG_UI_EVAL_PROGRESS_MS ?? "15000");
+  const reportPath = input.env.AG_UI_EVAL_REPORT_PATH ??
+    createTimestampedReportPath({ cwd, directory: "ag-ui-live-evals" });
+  const requestedCaseIds = splitCsvEnv(input.env.AG_UI_EVAL_CASES);
+  const requestedCaseTags = splitCsvEnv(input.env.AG_UI_EVAL_TAGS);
+  const requestedCaseSetId = input.env.AG_UI_EVAL_CASE_SET?.trim() || null;
+  const enableLlmJudge = input.env.AG_UI_EVAL_LLM_JUDGE === "1";
+
+  const apiContext: LiveEvalApiContext = {
+    apiUrl,
+    authToken,
+    projectId: projectId ?? null,
+  };
+  const createCaseSupport = input.createCaseSupport ?? createLiveEvalCaseSupport;
+  const { judgeLlm, runEval, verifyFileExists, withJudge } = createCaseSupport({
+    endpoint,
+    authToken,
+    apiUrl,
+    projectId: projectId ?? null,
+    branchId: branchId ?? null,
+    model: model ?? null,
+    requestTimeoutMs,
+    progressLogIntervalMs,
+    enableLlmJudge,
+    readProjectFile: (readerInput) => getLiveEvalProjectFile(apiContext, readerInput),
+  });
+
+  const { readOnlyCases, writeCases, experimentalWriteCases } = input.createCases({
+    authToken,
+    endpoint,
+    projectId: projectId ?? null,
+    branchId: branchId ?? null,
+    model: model ?? null,
+    requestTimeoutMs,
+    enableLlmJudge,
+    hasFinished,
+    containsSkillLoad,
+    countStepStartedEvents,
+    verifyFileExists,
+    withJudge,
+    judgeLlm,
+  });
+
+  if (authToken.length === 0) {
+    error("Missing VERYFRONT_TOKEN");
+    return 1;
+  }
+
+  log(`AG-UI live evals -> ${endpoint}`);
+  log(`Veryfront API -> ${apiUrl}`);
+  log(`Project scope -> ${projectId ?? "none"}`);
+  log(`Runtime -> ${requestedRuntimeSelection.join(", ")}`);
+  log(`Write evals -> ${runWriteEvals ? "enabled" : "disabled"}`);
+  log(`Experimental evals -> ${runExperimentalWriteEvals ? "enabled" : "disabled"}`);
+  log(`Case set -> ${requestedCaseSetId ?? "none"}`);
+  log(`Case tags -> ${requestedCaseTags.size > 0 ? [...requestedCaseTags].join(", ") : "none"}`);
+
+  const allCases = [...readOnlyCases, ...writeCases, ...experimentalWriteCases];
+  const resolvedRequestedCaseIds = resolveLiveEvalRequestedCaseIds({
+    caseSets: input.caseSets,
+    requestedCaseIds,
+    requestedCaseSetId,
+  });
+  const cases = selectLiveEvalCases({
+    allCases,
+    readOnlyCases,
+    writeCases,
+    experimentalWriteCases,
+    requestedCaseIds: resolvedRequestedCaseIds,
+    requestedCaseTags,
+    runWriteEvals,
+    runExperimentalWriteEvals,
+  });
+  const selectedCaseTagSummary = buildLiveEvalCaseTagSummary(cases);
+
+  if (cases.length === 0) {
+    error("No eval cases selected.");
+    return 1;
+  }
+
+  const results: LiveEvalResultRecord[] = [];
+
+  for (const runtime of requestedRuntimeSelection) {
+    log(`\n[runtime] ${runtime}`);
+    for (const testCase of cases) {
+      log(`\n[run] ${runtime} :: ${testCase.label}`);
+      const result = await runEval(testCase, runtime);
+      results.push(result);
+      log(`[${runtime}] [${result.status}] ${result.details}`);
+    }
+  }
+
+  const summary = buildLiveEvalStatusSummary(results);
+  const runtimeSummary = buildLiveEvalRuntimeSummary(requestedRuntimeSelection, results);
+  const runtimePerformanceSummary = buildRuntimePerformanceSummary(results);
+
+  log("\nSummary");
+  log(`passed: ${summary.passed}`);
+  log(`failed: ${summary.failed}`);
+  log(`skipped: ${summary.skipped}`);
+  for (const runtime of requestedRuntimeSelection) {
+    const currentRuntimeSummary = runtimeSummary[runtime];
+    log(
+      `${runtime}: passed=${currentRuntimeSummary.passed} failed=${currentRuntimeSummary.failed} skipped=${currentRuntimeSummary.skipped}`,
+    );
+    const performance = runtimePerformanceSummary[runtime];
+    log(
+      `${runtime}: avg=${performance.avgDurationMs}ms p50=${performance.p50DurationMs}ms p95=${performance.p95DurationMs}ms min=${performance.minDurationMs}ms max=${performance.maxDurationMs}ms`,
+    );
+  }
+
+  await mkdir(dirname(reportPath), { recursive: true });
+  await writeFile(
+    reportPath,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        endpoint,
+        apiUrl,
+        projectId: projectId ?? null,
+        runtimes: requestedRuntimeSelection,
+        writeEvals: runWriteEvals,
+        requestedCaseIds: [...resolvedRequestedCaseIds],
+        requestedCaseTags: [...requestedCaseTags],
+        requestedCaseSetId,
+        caseMetadata: Object.fromEntries(
+          cases.map((testCase) => [testCase.id, testCase.metadata ?? { tags: [] }]),
+        ),
+        selectedCaseTagSummary,
+        results,
+        summary,
+        runtimeSummary,
+        runtimePerformanceSummary,
+      },
+      null,
+      2,
+    ),
+  );
+  log(`report: ${reportPath}`);
+
+  return summary.failed > 0 ? 1 : 0;
+}

--- a/src/agent/testing/live-evals/index.ts
+++ b/src/agent/testing/live-evals/index.ts
@@ -1,4 +1,10 @@
 export {
+  type LiveEvalCliCaseFactoryInput,
+  type LiveEvalCliCaseGroups,
+  runLiveEvalCli,
+  type RunLiveEvalCliInput,
+} from "./cli-runner.ts";
+export {
   DEFAULT_LIVE_EVAL_ENDPOINT,
   type LiveEvalEnvironment,
   resolveLiveEvalEnvironment,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.534";
+export const VERSION = "0.1.535";


### PR DESCRIPTION
## Summary\n- add reusable live AG-UI eval CLI runner orchestration\n- add reusable durable run canary CLI runner orchestration\n- export the runner helpers from veryfront/agent/testing\n- bump framework package version to 0.1.535\n\n## Verification\n- deno test --no-check --allow-all src/agent/testing/live-evals/*.test.ts src/agent/testing/durable-run-canaries/*.test.ts\n- deno task verify:quick\n- pre-push checks