### PR TITLE
fix: preserve MCP structured auth errors

### DIFF
--- a/src/tool/remote-mcp.test.ts
+++ b/src/tool/remote-mcp.test.ts
@@ -93,6 +93,37 @@ describe("tool/remote-mcp", () => {
     });
   });
 
+  it("prefers structuredContent for MCP isError tool results", async () => {
+    const source = createRemoteMCPToolSource({
+      id: "docs",
+      endpoint: "https://mcp.test",
+      headers: { Authorization: "Bearer remote-token" },
+    });
+
+    const result = await withMockFetch(async () =>
+      Response.json({
+        jsonrpc: "2.0",
+        id: "docs:tools:call:search_docs",
+        result: {
+          isError: true,
+          structuredContent: {
+            error: "authentication_required",
+            integration: "github",
+            connectUrl: "/oauth/github",
+            message: "Authenticate GitHub to continue.",
+          },
+          content: [],
+        },
+      }), async () => await source.executeTool("search_docs", { query: "auth" }));
+
+    assertEquals(result, {
+      error: "authentication_required",
+      integration: "github",
+      connectUrl: "/oauth/github",
+      message: "Authenticate GitHub to continue.",
+    });
+  });
+
   it("normalizes remote MCP tool responses with generic error markers", async () => {
     const source = createRemoteMCPToolSource({
       id: "docs",

--- a/src/tool/remote-mcp.ts
+++ b/src/tool/remote-mcp.ts
@@ -278,12 +278,12 @@ function normalizeCallToolResult(result: unknown): unknown {
       rawContent.filter((item): item is JsonRpcCallToolContentItem => isRecord(item)),
     );
 
-    if (hasToolExecutionErrorMarker(result)) {
-      return parseJsonText(text) ?? { error: "tool_error", message: text };
-    }
-
     if ("structuredContent" in result) {
       return result.structuredContent;
+    }
+
+    if (hasToolExecutionErrorMarker(result)) {
+      return parseJsonText(text) ?? { error: "tool_error", message: text };
     }
 
     return parseJsonText(text) ?? text;


### PR DESCRIPTION
## Summary
- Preserves MCP `structuredContent` for `isError` tool results before falling back to generic error text parsing.
- Adds a regression test for auth-required structured errors flowing through remote MCP normalization.

## Evidence
- `deno task test src/tool/remote-mcp.test.ts` → 1 file / 7 steps passed.
- `deno lint src/tool/remote-mcp.ts src/tool/remote-mcp.test.ts` → passed.
- `deno fmt --check src/tool/remote-mcp.ts src/tool/remote-mcp.test.ts` → passed.

Related: veryfront/veryfront-studio#3836
