### PR TITLE
fix: sanitize provider tool schema property keys

### DIFF
--- a/src/agent/runtime/provider-tool-compat.test.ts
+++ b/src/agent/runtime/provider-tool-compat.test.ts
@@ -153,4 +153,48 @@ describe("provider-tool-compat", () => {
     assertEquals(sanitized.properties?.labelIds?.type, "array");
     assertEquals(sanitized.properties?.labelIds?.items, {});
   });
+
+  it("removes Anthropic-incompatible property keys and matching required entries", () => {
+    const sanitized = sanitizeProviderToolSchema(
+      {
+        type: "object",
+        properties: {
+          ok_name: { type: "string" },
+          "bad key": { type: "string" },
+          "nested-object": {
+            type: "object",
+            properties: {
+              "also/bad": { type: "string" },
+              fine: { type: "number" },
+            },
+            required: ["also/bad", "fine"],
+          },
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: {
+            type: "boolean",
+          },
+        },
+        required: [
+          "ok_name",
+          "bad key",
+          "nested-object",
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ],
+      } as never,
+      { model: "veryfront-cloud/anthropic/claude-sonnet-4-6" },
+    );
+
+    assertEquals(Object.keys(sanitized.properties ?? {}), ["ok_name", "nested-object"]);
+    assertEquals(sanitized.required, ["ok_name", "nested-object"]);
+    assertEquals(
+      Object.keys(
+        (sanitized.properties?.["nested-object"] as { properties?: Record<string, unknown> })
+          .properties ?? {},
+      ),
+      ["fine"],
+    );
+    assertEquals(
+      (sanitized.properties?.["nested-object"] as { required?: unknown[] }).required,
+      ["fine"],
+    );
+  });
 });

--- a/src/agent/runtime/provider-tool-compat.ts
+++ b/src/agent/runtime/provider-tool-compat.ts
@@ -20,6 +20,8 @@ export interface ProviderToolCompatOptions {
 }
 
 const OPENAI_MAX_TOOLS = 128;
+const PROVIDER_TOOL_PROPERTY_KEY_PATTERN = /^[a-zA-Z0-9_.-]{1,64}$/;
+
 const GOOGLE_UNSUPPORTED_SCHEMA_KEYS = new Set([
   "$id",
   "$ref",
@@ -51,7 +53,7 @@ export function getProviderToolProfile(model?: string): ProviderToolProfile {
   }
 
   if (provider === "anthropic") {
-    return { provider: "anthropic", sanitizeSchema: false };
+    return { provider: "anthropic", sanitizeSchema: true };
   }
 
   if (provider === "moonshot") {
@@ -184,6 +186,44 @@ function getGoogleCompatibleSchemaType(type: unknown): unknown {
   return nonNullTypes.length === 1 ? nonNullTypes[0] : undefined;
 }
 
+function sanitizeProviderSchemaPropertyKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeProviderSchemaPropertyKeys(item));
+  }
+
+  if (!isPlainRecord(value)) {
+    return value;
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  const rawProperties = isPlainRecord(value.properties) ? value.properties : undefined;
+  const retainedPropertyNames = rawProperties ? new Set<string>() : undefined;
+
+  for (const [key, child] of Object.entries(value)) {
+    if (key === "properties" && rawProperties) {
+      const properties: Record<string, unknown> = {};
+      for (const [propertyName, propertySchema] of Object.entries(rawProperties)) {
+        if (!PROVIDER_TOOL_PROPERTY_KEY_PATTERN.test(propertyName)) continue;
+        retainedPropertyNames?.add(propertyName);
+        properties[propertyName] = sanitizeProviderSchemaPropertyKeys(propertySchema);
+      }
+      sanitized.properties = properties;
+      continue;
+    }
+
+    if (key === "required" && Array.isArray(child)) {
+      sanitized.required = retainedPropertyNames
+        ? child.filter((item) => typeof item === "string" && retainedPropertyNames.has(item))
+        : child.filter((item) => typeof item === "string");
+      continue;
+    }
+
+    sanitized[key] = sanitizeProviderSchemaPropertyKeys(child);
+  }
+
+  return sanitized;
+}
+
 function sanitizeGoogleSchemaValue(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map((item) => sanitizeGoogleSchemaValue(item));
@@ -254,5 +294,11 @@ export function sanitizeProviderToolSchema(
   const profile = getProviderToolProfile(options.model);
   if (!profile.sanitizeSchema) return schema;
 
-  return sanitizeGoogleSchemaValue(schema) as JsonSchema;
+  const propertyKeySafeSchema = sanitizeProviderSchemaPropertyKeys(schema);
+
+  if (profile.provider === "google") {
+    return sanitizeGoogleSchemaValue(propertyKeySafeSchema) as JsonSchema;
+  }
+
+  return propertyKeySafeSchema as JsonSchema;
 }


### PR DESCRIPTION
## Summary\n- sanitize Anthropic/veryfront-cloud tool schemas so invalid JSON Schema property names are removed before model requests\n- keep Google schema cleanup and run property-key filtering before provider-specific cleanup\n- filter matching required entries when properties are removed\n\n## Evidence\n- Red: provider-tool-compat regression test failed before the implementation with invalid property keys still present\n- Green: `deno task test src/agent/runtime/model-tool-converter.test.ts src/agent/runtime/provider-tool-compat.test.ts`\n- Typecheck: `deno task typecheck`\n- Format/lint: `deno fmt --check src/agent/runtime/provider-tool-compat.ts src/agent/runtime/provider-tool-compat.test.ts` and `DENO_NO_PACKAGE_JSON=1 deno lint src/agent/runtime/provider-tool-compat.ts src/agent/runtime/provider-tool-compat.test.ts`\n- Build: `deno task build`\n\nFixes the provider error: `tools.*.custom.input_schema.properties: Property keys should match pattern '^[a-zA-Z0-9_.-]{1,64}$'`.