### PR TITLE
chore: release tool schema sanitizer

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.536",
+  "version": "0.1.537",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.536";
+export const VERSION = "0.1.537";


### PR DESCRIPTION
## Summary\n- bump Veryfront Code from 0.1.536 to 0.1.537 so the merged Anthropic tool-schema sanitizer can actually publish\n\n## Why\nPR #1688 merged the sanitizer, but main release skipped npm publish because v0.1.536 already existed. This version bump is required for downstream staging images to consume the fixed package.\n\n## Evidence\n- `deno fmt --check deno.json src/utils/version-constant.ts`\n- `deno task typecheck`\n- `deno task test src/agent/runtime/model-tool-converter.test.ts src/agent/runtime/provider-tool-compat.test.ts`