### PR TITLE
Skip empty assistant history in provider requests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.537",
+  "version": "0.1.538",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/text-generation-runtime-message-converter.test.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.test.ts
@@ -304,6 +304,27 @@ describe("text-generation-runtime-message-converter", () => {
       assertEquals(convertToTextGenerationRuntimeMessages([]), []);
     });
 
+    it("omits assistant messages that have no provider-sendable content", () => {
+      const messages: Message[] = [
+        { id: "u1", role: "user", parts: [{ type: "text", text: "list my repos" }] },
+        {
+          id: "a1",
+          role: "assistant",
+          parts: [{
+            type: "error",
+            code: "agent-provider-error",
+            message: "veryfront-cloud request failed",
+          }],
+        } as unknown as Message,
+        { id: "u2", role: "user", parts: [{ type: "text", text: "try again" }] },
+      ];
+
+      assertEquals(convertToTextGenerationRuntimeMessages(messages), [
+        { role: "user", content: "list my repos" },
+        { role: "user", content: "try again" },
+      ]);
+    });
+
     it("splits multiple tool results into one provider message per tool call", () => {
       const messages: Message[] = [{
         id: "tool_batch",

--- a/src/agent/runtime/text-generation-runtime-message-converter.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.ts
@@ -206,6 +206,20 @@ function convertToolResultPart(
   };
 }
 
+function hasProviderSendableAssistantContent(message: Message): boolean {
+  if (message.role !== "assistant") return true;
+
+  return message.parts.some((part) => {
+    if (part.type === "text" && "text" in part) {
+      return typeof (part as { text?: unknown }).text === "string" &&
+        (part as { text: string }).text.length > 0;
+    }
+
+    return part.type === "tool-call" ||
+      (part.type.startsWith("tool-") && part.type !== "tool-result");
+  });
+}
+
 /**
  * Convert an array of veryfront Messages to the current text-generation runtime message format.
  */
@@ -216,6 +230,10 @@ export function convertToTextGenerationRuntimeMessages(
   const toolResultMessageIndexes = new Map<string, number>();
 
   for (const message of messages) {
+    if (!hasProviderSendableAssistantContent(message)) {
+      continue;
+    }
+
     if (message.role !== "tool") {
       textGenerationRuntimeMessages.push(convertToTextGenerationRuntimeMessage(message));
       continue;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.537";
+export const VERSION = "0.1.538";


### PR DESCRIPTION
## Summary
- skips assistant history messages that have no provider-sendable content before model requests
- prevents failed assistant/error-only history from becoming an empty Anthropic text block
- bumps the package to `0.1.538` so the fix publishes and downstream deploys consume it

## Why
After deploying the tool schema sanitizer, the original Anthropic property-key error stopped reproducing. Retrying the same failed conversation then exposed the next provider rejection: `messages: text content blocks must be non-empty`. The conversation history contains previous failed assistant messages with only `error` parts; the converter was serializing those as `{ type: "text", text: "" }`, which Anthropic rejects.

## Evidence
- Red: `deno task test src/agent/runtime/text-generation-runtime-message-converter.test.ts` failed before implementation with the error-only assistant still serialized as empty text.
- Green: `deno task test src/agent/runtime/text-generation-runtime-message-converter.test.ts` ✅
- Regression + adjacent tests: `deno task test src/agent/runtime/text-generation-runtime-message-converter.test.ts src/agent/runtime/provider-tool-compat.test.ts src/agent/runtime/model-tool-converter.test.ts` ✅
- `deno fmt --check deno.json src/utils/version-constant.ts src/agent/runtime/text-generation-runtime-message-converter.ts src/agent/runtime/text-generation-runtime-message-converter.test.ts` ✅
- `deno task typecheck` ✅
- `deno task build` ✅

## Staging observation
- Post-0.1.537 staging retest no longer produced the original `tools.12.custom.input_schema.properties` error for the new run.
- The new run failed with `messages: text content blocks must be non-empty`, which this PR addresses.
