### PR TITLE
Preserve structured integration auth errors

### DIFF
--- a/src/integrations/remote-tools.test.ts
+++ b/src/integrations/remote-tools.test.ts
@@ -164,6 +164,32 @@ describe("integrations/remote-tools", () => {
     });
   });
 
+  it("prefers structuredContent for MCP error results without text content", async () => {
+    setRemoteToolEnv({
+      VERYFRONT_API_BASE_URL: "https://api.test",
+      VERYFRONT_API_TOKEN: "env-token",
+    });
+
+    const result = await withMockFetch(async () =>
+      Response.json({
+        isError: true,
+        content: [],
+        structuredContent: {
+          error: "authentication_required",
+          integration: "linear",
+          connectUrl: "/oauth/connect/linear?projectId=project-1&endUserId=user-1",
+          message: "Authentication required for Linear.",
+        },
+      }), async () => await executeRemoteIntegrationTool("linear__search_issues", { query: "*" }));
+
+    assertEquals(result, {
+      error: "authentication_required",
+      integration: "linear",
+      connectUrl: "/oauth/connect/linear?projectId=project-1&endUserId=user-1",
+      message: "Authentication required for Linear.",
+    });
+  });
+
   it("returns structured content from remote tool calls and detects remote names", async () => {
     setRemoteToolEnv({
       VERYFRONT_API_BASE_URL: "https://api.test",

--- a/src/integrations/remote-tools.ts
+++ b/src/integrations/remote-tools.ts
@@ -122,14 +122,14 @@ async function callRemoteTool(
   if (result?.content && Array.isArray(result.content)) {
     const text = joinCallToolText(result.content as CallToolTextContent[]);
 
+    if (result.structuredContent) return result.structuredContent;
+
     if (result.isError) {
       // Try to preserve structured error data (e.g., authentication_required with connectUrl)
       const parsed = parseJsonText(text);
       if (parsed && typeof parsed === "object") return parsed;
       return { error: "tool_error", message: text };
     }
-
-    if (result.structuredContent) return result.structuredContent;
 
     return parseJsonText(text) ?? text;
   }


### PR DESCRIPTION
## Summary
- Preserve MCP `structuredContent` before generic `tool_error` fallback in remote integration tool execution.
- Adds regression coverage for `authentication_required` results with empty MCP content arrays.

## Why
Staging project-agent integration calls returned `{ error: "tool_error", message: "" }` instead of the structured auth-required payload. Studio can only show the on-demand integration auth card when the tool result keeps `error: "authentication_required"` and `connectUrl`.

## Evidence
- Reproduced against `inbox-helper-4nus3f` with new canary script: conversation `82774f7a-a526-4dac-8c1c-99788d3760c3`, run `d1c937a7-d5ec-4b46-83e1-f3c7be461e39`, result `missing` on current staging.
- Test: `deno task test src/integrations/remote-tools.test.ts`
