### PR TITLE
Release veryfront v0.1.539

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.538",
+  "version": "0.1.539",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.538";
+export const VERSION = "0.1.539";


### PR DESCRIPTION
## Summary
- release veryfront v0.1.539 so the merged structured integration auth error fix is publishable
- includes veryfront-code#1691, which preserves MCP structuredContent authentication_required results for chat rendering

## Evidence
- deno task test (ran before release bump; unrelated existing failures observed in auto-discovery and metrics config under local env, while 2228 tests passed)
- deno task release 0.1.539 --no-test --no-build --no-publish --yes

## Critical review score
92/100 — minimal version-only release PR; risk is release pipeline duration, not code scope.
