### PR TITLE
Fix hosted integration end-user auth context

### DIFF
--- a/src/agent/hosted/chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.ts
@@ -36,6 +36,7 @@ export type HostedChatRuntimeToolAssemblyContext = DefaultResearchArtifactContex
   model?: string;
   clientProfile?: RuntimeClientProfile | null;
   availableToolNames?: string[];
+  userId?: string | null;
 };
 
 export type HostedChatRuntimeAllowedToolNames = readonly string[] | ReadonlySet<string> | null;
@@ -127,6 +128,7 @@ export async function prepareHostedChatRuntimeToolAssembly<
     createRemoteToolSource: input.createRemoteToolSource ?? createRemoteMCPToolSource,
     defaultProjectId: () => activeProjectId(input.taskContext),
     getProjectId: input.getProjectId ?? (() => activeProjectId(input.taskContext)),
+    getEndUserId: () => input.taskContext.userId ?? null,
     getActiveBranchId: input.getActiveBranchId ?? (() => activeBranchId(input.taskContext)),
     conversationId: input.conversationId,
     allowedToolNames,

--- a/src/agent/hosted/project-remote-tool-source.test.ts
+++ b/src/agent/hosted/project-remote-tool-source.test.ts
@@ -268,6 +268,36 @@ Deno.test("createHostedProjectRemoteToolSources defaults to the Veryfront API MC
   assertEquals(configs.map((config) => config.endpoint), ["https://api.example/mcp"]);
 });
 
+Deno.test("createHostedProjectRemoteToolSources injects end_user_id for Veryfront API integration tools", async () => {
+  const executed: Array<{ toolName: string; args: unknown; context?: ToolExecutionContext }> = [];
+  const sources = createHostedProjectRemoteToolSources({
+    authToken: "token-1",
+    apiMcpUrl: "https://api.example/mcp",
+    mcpServers: [{ kind: "veryfront-api" }],
+    getProjectId: () => "project-1",
+    getEndUserId: () => "user-123",
+    createRemoteToolSource: (config) =>
+      createRemoteSource({
+        id: config.id,
+        tools: [simpleTool("github__list_issues")],
+        execute: (toolName, args, context) => {
+          executed.push({ toolName, args, context });
+          return { ok: true };
+        },
+      }),
+  });
+
+  await sources[0]?.executeTool("github__list_issues", { repo: "veryfront" });
+
+  assertEquals(executed, [
+    {
+      toolName: "github__list_issues",
+      args: { repo: "veryfront", end_user_id: "user-123" },
+      context: undefined,
+    },
+  ]);
+});
+
 Deno.test("createHostedProjectRemoteToolSources filters Veryfront API MCP tools with the tool access profile", async () => {
   const executed: Array<{ toolName: string; args: unknown }> = [];
   const sources = createHostedProjectRemoteToolSources({

--- a/src/agent/hosted/project-remote-tool-source.ts
+++ b/src/agent/hosted/project-remote-tool-source.ts
@@ -199,10 +199,49 @@ export type CreateHostedProjectRemoteToolSourcesInput =
     mcpServers?: readonly AgentServiceMcpServerConfig[];
     clientProfile?: RuntimeClientProfile | null;
     getProjectId: () => string | null | undefined;
+    getEndUserId?: () => string | null | undefined;
     conversationId?: string;
     createRemoteToolSource?: (config: RemoteMCPToolSourceConfig) => RemoteToolSource;
     onStudioProjectSwitch?: HostedProjectRemoteToolSourceProjectSwitchHandler;
   };
+
+function isVeryfrontApiIntegrationTool(toolName: string): boolean {
+  return /^[a-zA-Z0-9_.-]+__[a-zA-Z0-9_.-]+$/.test(toolName);
+}
+
+function prepareVeryfrontApiToolInput(input: {
+  server: AgentServiceMcpServerConfig;
+  getEndUserId?: () => string | null | undefined;
+  prepareToolInput?: HostedProjectRemoteToolSourcePrepareToolInput;
+}): HostedProjectRemoteToolSourcePrepareToolInput | undefined {
+  if (input.server.kind !== "veryfront-api" && !input.prepareToolInput) {
+    return undefined;
+  }
+
+  return (toolInputContext) => {
+    const prepared = input.prepareToolInput?.(toolInputContext) ?? toolInputContext.toolInput;
+    if (
+      input.server.kind !== "veryfront-api" ||
+      !isVeryfrontApiIntegrationTool(toolInputContext.toolName)
+    ) {
+      return prepared;
+    }
+
+    if (typeof prepared.end_user_id === "string" && prepared.end_user_id.length > 0) {
+      return prepared;
+    }
+
+    const endUserId = input.getEndUserId?.() ?? toolInputContext.context?.endUserId;
+    if (typeof endUserId !== "string" || endUserId.length === 0) {
+      return prepared;
+    }
+
+    return {
+      ...prepared,
+      end_user_id: endUserId,
+    };
+  };
+}
 
 function createHostedProjectRemoteToolSourceFromConfig(
   input: CreateHostedProjectRemoteToolSourcesInput,
@@ -210,6 +249,12 @@ function createHostedProjectRemoteToolSourceFromConfig(
   source: RemoteToolSource,
   onProjectSwitch?: HostedProjectRemoteToolSourceProjectSwitchHandler,
 ): RemoteToolSource {
+  const prepareToolInput = prepareVeryfrontApiToolInput({
+    server,
+    getEndUserId: input.getEndUserId,
+    prepareToolInput: input.prepareToolInput,
+  });
+
   return createHostedProjectRemoteToolSource({
     source,
     ...(input.defaultProjectId !== undefined ? { defaultProjectId: input.defaultProjectId } : {}),
@@ -231,7 +276,7 @@ function createHostedProjectRemoteToolSourceFromConfig(
           }),
       }
       : {}),
-    ...(input.prepareToolInput !== undefined ? { prepareToolInput: input.prepareToolInput } : {}),
+    ...(prepareToolInput !== undefined ? { prepareToolInput } : {}),
     ...(input.retryToolName !== undefined ? { retryToolName: input.retryToolName } : {}),
     ...(input.shouldRetryWithTool !== undefined
       ? { shouldRetryWithTool: input.shouldRetryWithTool }

--- a/src/agent/hosted/runtime-state-resolver.test.ts
+++ b/src/agent/hosted/runtime-state-resolver.test.ts
@@ -47,6 +47,21 @@ describe("agent/hosted-runtime-state-resolver", () => {
     assertEquals(refreshCount, 1);
   });
 
+  it("preserves the authenticated user as endUserId in runtime tool context", async () => {
+    const resolver = createHostedRuntimeStateResolver({
+      taskContext: {
+        projectId: "project-1",
+        branchId: null,
+        userId: "user-123",
+      },
+    });
+
+    assertEquals(await resolver({ system: "system", messages: [], step: 1 }), {
+      system: "system",
+      context: { endUserId: "user-123" },
+    });
+  });
+
   it("applies starter-intent blocking context only while required", async () => {
     const taskContext = {
       projectId: null,

--- a/src/agent/hosted/runtime-state-resolver.ts
+++ b/src/agent/hosted/runtime-state-resolver.ts
@@ -17,6 +17,7 @@ export type HostedRuntimeStateResolverContext = DefaultResearchArtifactContext &
   branchId?: string | null;
   steeringRevision?: number;
   slashCommandArtifactPathSeen?: boolean;
+  userId?: string | null;
 };
 
 export type HostedRuntimeStateResolverInput = {
@@ -78,6 +79,9 @@ export function createHostedRuntimeStateResolver<
 
     let nextSystem = system;
     const nextContextRecord = { ...(context ?? {}) };
+    if (typeof options.taskContext.userId === "string" && options.taskContext.userId.length > 0) {
+      nextContextRecord.endUserId = options.taskContext.userId;
+    }
 
     if (steeringChanged && options.refreshSystem) {
       nextSystem = await options.refreshSystem({


### PR DESCRIPTION
## Summary
- pass the authenticated hosted chat user id into runtime tool context
- inject `end_user_id` into Veryfront API integration MCP tool calls so OAuth connect URLs target the actual end user instead of the service-account sentinel
- preserve existing explicit `end_user_id` behavior

## Verification
- `deno task test src/agent/hosted/runtime-state-resolver.test.ts src/agent/hosted/project-remote-tool-source.test.ts`

## Critical review score
93/100. Scoped to hosted Veryfront API integration tools; remaining risk is the integration tool-name heuristic, but it is constrained to the Veryfront API server and covered by regression tests.