### PR TITLE
Release veryfront v0.1.540

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.539",
+  "version": "0.1.540",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.539";
+export const VERSION = "0.1.540";


### PR DESCRIPTION
## Summary
- release veryfront v0.1.540 so the hosted integration end-user auth context fix is publishable
- includes veryfront-code#1693, which passes the authenticated hosted chat user id into Veryfront API integration MCP tool calls as `end_user_id`

## Evidence
- `deno task release 0.1.540 --no-test --no-build --no-publish --yes`
- code fix PR CI passed after rerunning transient esm.sh 522 typecheck failure

## Critical review score
92/100 — version-only release PR; risk is release pipeline duration, not code scope.