### PR TITLE
Use runtime invocation end-user principal

### DIFF
--- a/src/agent/hosted/chat-request-parser.ts
+++ b/src/agent/hosted/chat-request-parser.ts
@@ -201,7 +201,7 @@ export async function parseRuntimeAgentRunInvocationHostedChatRequestFromRequest
 
   return await buildParsedHostedChatRequest({
     authToken: authenticatedRequest.authToken,
-    userId: authenticatedRequest.userId,
+    userId: invocation.data.run.requestedByUserId,
     chatRequest: chatRequest.data,
     agentId: invocation.data.run.agentId,
     verifyProjectAccess: options.verifyProjectAccess,

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -233,6 +233,7 @@ describe("agent/hosted-chat-request", () => {
     }
 
     assertEquals(parsed.messages, invocation.messages);
+    assertEquals(parsed.userId, userId);
     assertEquals(parsed.projectId, projectId);
     assertEquals(parsed.conversationId, conversationId);
     assertEquals(parsed.forwardedProps?.runtimeContext, invocation.context);


### PR DESCRIPTION
## Summary
- parse runtime-agent invocations with the run requested-by user as the hosted chat principal
- keeps the authenticated service token for project access, but makes runtime tool context represent the real end user
- fixes on-demand OAuth connect URLs for executor-managed project-agent runs

## Verification
- `deno task test src/agent/hosted/chat-request.test.ts src/agent/hosted/runtime-state-resolver.test.ts src/agent/hosted/project-remote-tool-source.test.ts`

## Critical review score
94/100. Scoped to runtime-agent invocation parsing; uses the API-signed runtime invocation `requestedByUserId` while preserving service-token project access.