### PR TITLE
Release veryfront v0.1.541

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.540",
+  "version": "0.1.541",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.540";
+export const VERSION = "0.1.541";


### PR DESCRIPTION
## Summary
- release veryfront v0.1.541 so the runtime invocation end-user principal fix is publishable
- includes veryfront-code#1695, which uses `requestedByUserId` for hosted runtime tool context on executor-managed runs

## Evidence
- `deno task release 0.1.541 --no-test --no-build --no-publish --yes`
- fix PR CI passed

## Critical review score
92/100 — version-only release PR; risk is release pipeline duration, not code scope.