### PR TITLE
Forward end-user principal to internal agent runtime

### DIFF
--- a/src/agent/hosted/project-remote-tool-source.test.ts
+++ b/src/agent/hosted/project-remote-tool-source.test.ts
@@ -558,3 +558,47 @@ Deno.test("createHostedProjectRemoteToolSources applies project wrapper policy t
   assertEquals(mutations, [{ instructionsChanged: true, skillsChanged: false }]);
   assertEquals(switchedProjects, ["project-2"]);
 });
+
+Deno.test("createHostedProjectRemoteToolSources composes API input preparation with integration end-user input", async () => {
+  const executed: Array<{ toolName: string; args: unknown; context?: ToolExecutionContext }> = [];
+  const sources = createHostedProjectRemoteToolSources({
+    authToken: "token-1",
+    apiMcpUrl: "https://api.example/mcp",
+    mcpServers: [{ kind: "veryfront-api" }],
+    defaultProjectId: () => "project-1",
+    getProjectId: () => "project-1",
+    getEndUserId: () => "end-user-123",
+    prepareToolInput: ({ toolInput }) => ({
+      ...toolInput,
+      prepared: true,
+    }),
+    createRemoteToolSource: (config) =>
+      createRemoteSource({
+        id: config.id,
+        tools: [simpleTool("github__list_issues")],
+        execute: (toolName, args, context) => {
+          executed.push({ toolName, args, context });
+          return { ok: true };
+        },
+      }),
+  });
+
+  await sources[0]?.executeTool("github__list_issues", { owner: "veryfront" });
+
+  assertEquals(executed, [
+    {
+      toolName: "get_tool_access_profile",
+      args: { project_reference: "project-1" },
+      context: { projectId: "project-1" },
+    },
+    {
+      toolName: "github__list_issues",
+      args: {
+        owner: "veryfront",
+        prepared: true,
+        end_user_id: "end-user-123",
+      },
+      context: { projectId: "project-1" },
+    },
+  ]);
+});

--- a/src/agent/runtime/agent-invocation-contract.test.ts
+++ b/src/agent/runtime/agent-invocation-contract.test.ts
@@ -183,6 +183,7 @@ describe("agent/runtime-agent-invocation-contract", () => {
       threadId: conversationId,
       runId: "run_child_1",
       parentRunId: "run_root_1",
+      endUserId: userId,
       messages: parsed.messages,
       tools: parsed.tools,
       context: parsed.context,

--- a/src/agent/runtime/agent-invocation-contract.ts
+++ b/src/agent/runtime/agent-invocation-contract.ts
@@ -319,6 +319,7 @@ export type RuntimeAgentControlPlaneStreamRequest = {
   threadId: RuntimeAgentRunContext["conversationId"];
   runId: RuntimeAgentRunContext["runId"];
   parentRunId?: Exclude<RuntimeAgentRunContext["parentRunId"], null | undefined>;
+  endUserId?: RuntimeAgentRunContext["requestedByUserId"];
   messages: RuntimeAgentRunInvocation["messages"];
   tools: RuntimeAgentRunInvocation["tools"];
   context: RuntimeAgentRunInvocation["context"];
@@ -334,6 +335,7 @@ export function buildRuntimeAgentControlPlaneStreamRequestFromInvocation(
     threadId: input.run.conversationId,
     runId: input.run.runId,
     ...(input.run.parentRunId ? { parentRunId: input.run.parentRunId } : {}),
+    endUserId: input.run.requestedByUserId,
     messages: input.messages,
     tools: input.tools,
     context: input.context,

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -30,6 +30,10 @@ type RuntimeFilteredAgent = Agent & {
   };
 };
 
+type RuntimeRunAgentInputWithEndUser = RuntimeRunAgentInput & {
+  endUserId?: string;
+};
+
 export interface RuntimeAgentStreamExecutionDeps {
   sessionManager: AgentRunSessionManager;
   createRuntime?: (
@@ -169,7 +173,7 @@ function getForwardedIntegrationToolDefinitions(
 }
 
 export async function createRuntimeAgentStreamResponse(
-  input: RuntimeRunAgentInput,
+  input: RuntimeRunAgentInputWithEndUser,
   agent: Agent,
   deps: RuntimeAgentStreamExecutionDeps,
 ): Promise<Response> {
@@ -217,6 +221,7 @@ export async function createRuntimeAgentStreamResponse(
         runId: input.runId,
         ...(input.parentRunId ? { parentRunId: input.parentRunId } : {}),
         ...(input.state !== undefined ? { state: input.state } : {}),
+        ...(input.endUserId ? { endUserId: input.endUserId } : {}),
         context: input.context,
         forwardedProps: input.forwardedProps,
       },

--- a/src/internal-agents/schema.test.ts
+++ b/src/internal-agents/schema.test.ts
@@ -206,6 +206,22 @@ describe("internal-agents/schema", () => {
     });
   });
 
+  it("preserves endUserId on internal stream payloads for on-demand integration auth", () => {
+    const internalRequest = getInternalAgentStreamRequestSchema().parse({
+      agentId: "agent_1",
+      threadId: "10000000-1000-4000-8000-100000000001",
+      runId: "run_1",
+      endUserId: "10000000-1000-4000-8000-100000000004",
+      messages: [],
+      context: [],
+    });
+
+    assertEquals(
+      (toRuntimeRunAgentInput(internalRequest) as unknown as { endUserId?: string }).endUserId,
+      "10000000-1000-4000-8000-100000000004",
+    );
+  });
+
   it("prefers streamed inputText over empty fallback args when normalizing legacy assistant tool calls", () => {
     const internalRequest = getInternalAgentStreamRequestSchema().parse({
       agentId: "agent_1",

--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -61,6 +61,7 @@ export const getInternalAgentStreamRequestSchema = defineSchema((v) =>
     threadId: v.string().uuid(),
     runId: getRunIdSchema(),
     parentRunId: getRunIdSchema().optional(),
+    endUserId: v.string().uuid().optional(),
     state: v.unknown().optional(),
     messages: v.array(
       v.union([getRuntimeMessageSchema(), getInternalAgentCompatibilityMessageSchema()]),
@@ -290,6 +291,7 @@ export function toRuntimeRunAgentInput(
     threadId: input.threadId,
     runId: input.runId,
     ...(input.parentRunId ? { parentRunId: input.parentRunId } : {}),
+    ...(input.endUserId ? { endUserId: input.endUserId } : {}),
     ...(input.state !== undefined ? { state: input.state } : {}),
     messages: input.messages.map(toRuntimeMessage),
     tools: input.tools,


### PR DESCRIPTION
## Summary
- include the run requested-by user as `endUserId` in internal agent control-plane stream requests
- pass that `endUserId` into runtime tool context so forwarded integration tools use the real chat user for on-demand OAuth
- add regression coverage for the internal runtime path and for composed API integration tool input preparation

## Verification
- `deno task test src/agent/runtime/agent-invocation-contract.test.ts src/internal-agents/schema.test.ts src/agent/hosted/project-remote-tool-source.test.ts src/agent/hosted/runtime-state-resolver.test.ts src/agent/hosted/chat-request.test.ts`
- `deno fmt --check src/agent/runtime/agent-invocation-contract.ts src/agent/runtime/agent-invocation-contract.test.ts src/internal-agents/schema.ts src/internal-agents/schema.test.ts src/internal-agents/run-stream.ts src/agent/hosted/project-remote-tool-source.test.ts`

## Critical review score
94/100 — small, contract-preserving internal control-plane propagation fix with regression tests. Remaining risk is release/deploy propagation, which I will verify with staging canary and agent-browser after merge.
