### PR TITLE
Release veryfront v0.1.542

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.541",
+  "version": "0.1.542",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.541";
+export const VERSION = "0.1.542";


### PR DESCRIPTION
## Summary
- release `veryfront` v0.1.542 with the internal agent runtime end-user propagation fix

## Verification
- `deno task release 0.1.542 --no-test --no-build --no-publish --yes`
- Source PR #1698 CI green before merge

## Critical review score
92/100 — release-only PR for a green, reviewed fix; remaining risk is publish/deploy propagation.
