### PR TITLE
fix: skip unavailable integration tools

### DIFF
--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -340,6 +340,23 @@ describe("tool-helpers", () => {
       }
     });
 
+    it("skips explicit integration tools whose integration has no discovered tools for this run", async () => {
+      toolRegistry.clearAll();
+
+      try {
+        const defs = await withMockRemoteIntegrationTools([], () =>
+          getAvailableTools(
+            {
+              "github__get_pr_diff": true,
+            },
+          ));
+
+        assertEquals(defs.map((def) => def.name), []);
+      } finally {
+        toolRegistry.clearAll();
+      }
+    });
+
     it("only appends explicitly requested remote definitions for explicit tool maps", async () => {
       toolRegistry.clearAll();
 

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -100,6 +100,38 @@ function formatAvailableToolNames(names: Iterable<string>): string {
   return sorted.length > 0 ? sorted.join(", ") : "(none)";
 }
 
+function getRemoteIntegrationName(toolName: string): string | null {
+  if (!isRemoteIntegrationTool(toolName)) {
+    return null;
+  }
+
+  const separatorIndex = toolName.indexOf("__");
+  if (separatorIndex <= 0) {
+    return null;
+  }
+
+  return toolName.slice(0, separatorIndex);
+}
+
+function hasDiscoveredToolForIntegration(
+  remoteToolNames: Set<string>,
+  toolName: string,
+): boolean {
+  const integrationName = getRemoteIntegrationName(toolName);
+  if (!integrationName) {
+    return false;
+  }
+
+  const prefix = `${integrationName}__`;
+  for (const remoteToolName of remoteToolNames) {
+    if (remoteToolName.startsWith(prefix)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function throwUnknownConfiguredToolsError(
   unknownToolNames: string[],
   availableLocalToolNames: Iterable<string>,
@@ -389,6 +421,18 @@ export async function getAvailableTools(
 
       if (remoteToolNames.has(name)) {
         explicitlyRequestedRemoteToolNames.add(name);
+        continue;
+      }
+
+      // Integration tools are request-scoped: a template agent can declare a
+      // GitHub tool before the current project/user has connected GitHub. If no
+      // tools for that integration were discovered for this run, treat the
+      // configured integration tool as unavailable rather than as a local-tool
+      // typo. If the integration is present but this specific tool is missing,
+      // keep failing loudly below.
+      if (
+        isRemoteIntegrationTool(name) && !hasDiscoveredToolForIntegration(remoteToolNames, name)
+      ) {
         continue;
       }
 


### PR DESCRIPTION
## Summary
- Treat configured integration tools as request-scoped/optional when no tools for that integration were discovered for the current run.
- Preserve loud failures for actual tool-id mismatches when the integration is present but the specific configured tool is missing.
- Add a regression test for a template-style `github__get_pr_diff` declaration with no discovered GitHub tools.

## Why
Template agents such as PR Reviewer can declare GitHub tools before the current project/user has connected GitHub. In that state the runtime has no matching remote tool definitions, so treating the configured integration tool as an unknown local tool causes the run to fail before the agent can respond or ask for setup.

## Verification
- RED: `deno task test src/agent/runtime/tool-helpers.test.ts` failed before the implementation with `Unknown tool reference: github__get_pr_diff ... Available tools: gmail__list_emails`.
- GREEN: `deno task test src/agent/runtime/tool-helpers.test.ts` — 1 file / 30 steps passed.
- `deno check src/agent/runtime/tool-helpers.ts src/agent/runtime/tool-helpers.test.ts` — passed.
- `deno fmt src/agent/runtime/tool-helpers.ts src/agent/runtime/tool-helpers.test.ts` and `deno lint src/agent/runtime/tool-helpers.ts src/agent/runtime/tool-helpers.test.ts` — passed.
- `deno task typecheck` — passed.
- `deno task verify:quick` — passed.

## Related
- Complements veryfront-api PR https://github.com/veryfront/veryfront-api/pull/2532, which filters forwarded integration allowlists to resolved tool definitions.
