### PR TITLE
Revert runtime integration tool skip

### DIFF
--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -340,6 +340,24 @@ describe("tool-helpers", () => {
       }
     });
 
+    it("fails loudly when an explicit integration tool has no discovered tools", async () => {
+      toolRegistry.clearAll();
+
+      try {
+        await assertRejects(
+          () =>
+            withMockRemoteIntegrationTools([], () =>
+              getAvailableTools({
+                "github__get_pr_diff": true,
+              })),
+          Error,
+          'Unknown tool reference: github__get_pr_diff. Tool names must exactly match tool({ id: "..." }). Available tools: (none)',
+        );
+      } finally {
+        toolRegistry.clearAll();
+      }
+    });
+
     it("only appends explicitly requested remote definitions for explicit tool maps", async () => {
       toolRegistry.clearAll();
 

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -340,23 +340,6 @@ describe("tool-helpers", () => {
       }
     });
 
-    it("skips explicit integration tools whose integration has no discovered tools for this run", async () => {
-      toolRegistry.clearAll();
-
-      try {
-        const defs = await withMockRemoteIntegrationTools([], () =>
-          getAvailableTools(
-            {
-              "github__get_pr_diff": true,
-            },
-          ));
-
-        assertEquals(defs.map((def) => def.name), []);
-      } finally {
-        toolRegistry.clearAll();
-      }
-    });
-
     it("only appends explicitly requested remote definitions for explicit tool maps", async () => {
       toolRegistry.clearAll();
 

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -100,38 +100,6 @@ function formatAvailableToolNames(names: Iterable<string>): string {
   return sorted.length > 0 ? sorted.join(", ") : "(none)";
 }
 
-function getRemoteIntegrationName(toolName: string): string | null {
-  if (!isRemoteIntegrationTool(toolName)) {
-    return null;
-  }
-
-  const separatorIndex = toolName.indexOf("__");
-  if (separatorIndex <= 0) {
-    return null;
-  }
-
-  return toolName.slice(0, separatorIndex);
-}
-
-function hasDiscoveredToolForIntegration(
-  remoteToolNames: Set<string>,
-  toolName: string,
-): boolean {
-  const integrationName = getRemoteIntegrationName(toolName);
-  if (!integrationName) {
-    return false;
-  }
-
-  const prefix = `${integrationName}__`;
-  for (const remoteToolName of remoteToolNames) {
-    if (remoteToolName.startsWith(prefix)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 function throwUnknownConfiguredToolsError(
   unknownToolNames: string[],
   availableLocalToolNames: Iterable<string>,
@@ -421,18 +389,6 @@ export async function getAvailableTools(
 
       if (remoteToolNames.has(name)) {
         explicitlyRequestedRemoteToolNames.add(name);
-        continue;
-      }
-
-      // Integration tools are request-scoped: a template agent can declare a
-      // GitHub tool before the current project/user has connected GitHub. If no
-      // tools for that integration were discovered for this run, treat the
-      // configured integration tool as unavailable rather than as a local-tool
-      // typo. If the integration is present but this specific tool is missing,
-      // keep failing loudly below.
-      if (
-        isRemoteIntegrationTool(name) && !hasDiscoveredToolForIntegration(remoteToolNames, name)
-      ) {
         continue;
       }
 


### PR DESCRIPTION
## Summary
- revert the runtime-side skip for configured integration tools that were not discovered
- restore the simple invariant: configured tool names must resolve to an available tool definition
- keep missing tool references loud instead of hiding them at runtime

## Verification
- `deno task test src/agent/runtime/tool-helpers.test.ts`
- `deno check src/agent/runtime/tool-helpers.ts src/agent/runtime/tool-helpers.test.ts`
- `deno fmt --check src/agent/runtime/tool-helpers.ts src/agent/runtime/tool-helpers.test.ts`
- `deno lint src/agent/runtime/tool-helpers.ts src/agent/runtime/tool-helpers.test.ts`
- `deno task typecheck`

Companion API setup fix: veryfront/veryfront-api#2532