### PR TITLE
refactor: split provider and HMR message helpers

### DIFF
--- a/extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts
+++ b/extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts
@@ -1,0 +1,140 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { RuntimePromptMessage } from "veryfront/provider/shared";
+import { buildOpenAIChatRequest } from "./openai-chat-request-builder.ts";
+
+function createWarningCollector() {
+  const warnings: Array<{
+    type: "unsupported-setting" | "other";
+    setting?: string;
+    details?: string;
+    provider: string;
+  }> = [];
+
+  return {
+    push(warning: {
+      type: "unsupported-setting" | "other";
+      setting?: string;
+      details?: string;
+      provider: string;
+    }) {
+      warnings.push(warning);
+    },
+    drain() {
+      return warnings.slice();
+    },
+  };
+}
+
+describe("ext-llm-openai/openai-chat-request-builder", () => {
+  it("preserves chat request shaping, provider option merge order, and warnings", () => {
+    const prompt: RuntimePromptMessage[] = [
+      { role: "system", content: "You are concise." },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Inspect this." },
+          { type: "image", mediaType: "image/png", url: "https://example.test/image.png" },
+        ],
+      },
+    ];
+    const warnings = createWarningCollector();
+
+    const body = buildOpenAIChatRequest(
+      "gpt-4o-mini",
+      "azure",
+      {
+        prompt,
+        maxOutputTokens: 123,
+        temperature: 0.2,
+        topP: 0.8,
+        topK: 5,
+        stopSequences: ["END"],
+        tools: [{
+          type: "function",
+          name: "lookup",
+          description: "Look up a value",
+          inputSchema: { jsonSchema: { type: "object", properties: { id: { type: "string" } } } },
+        }],
+        toolChoice: "auto",
+        seed: 7,
+        presencePenalty: 0.1,
+        frequencyPenalty: 0.2,
+        reasoning: { enabled: true, effort: "high" },
+        userId: "user_123",
+        serviceTier: "flex",
+        parallelToolCalls: false,
+        responseFormat: {
+          type: "json_schema",
+          name: "lookup_result",
+          schema: { jsonSchema: { type: "object", properties: { value: { type: "string" } } } },
+          description: "Lookup result",
+          strict: true,
+        },
+        providerOptions: {
+          openai: {
+            custom_openai: true,
+            max_tokens: 456,
+          },
+          azure: {
+            custom_azure: true,
+            temperature: 0.9,
+          },
+        },
+      },
+      true,
+      warnings,
+    );
+
+    assertEquals(body, {
+      model: "gpt-4o-mini",
+      messages: [
+        { role: "system", content: "You are concise." },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Inspect this." },
+            { type: "image_url", image_url: { url: "https://example.test/image.png" } },
+          ],
+        },
+      ],
+      stream: true,
+      stream_options: { include_usage: true },
+      max_completion_tokens: 456,
+      stop: ["END"],
+      tools: [{
+        type: "function",
+        function: {
+          name: "lookup",
+          parameters: { type: "object", properties: { id: { type: "string" } } },
+          description: "Look up a value",
+        },
+      }],
+      tool_choice: "auto",
+      seed: 7,
+      reasoning_effort: "high",
+      user: "user_123",
+      service_tier: "flex",
+      parallel_tool_calls: false,
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "lookup_result",
+          description: "Lookup result",
+          schema: { type: "object", properties: { value: { type: "string" } } },
+          strict: true,
+        },
+      },
+      custom_openai: true,
+      custom_azure: true,
+      temperature: 0.9,
+    });
+    assertEquals(warnings.drain().map((warning) => warning.setting), [
+      "topK",
+      "temperature",
+      "topP",
+      "presencePenalty",
+      "frequencyPenalty",
+    ]);
+  });
+});

--- a/extensions/ext-llm-openai/src/openai-chat-request-builder.ts
+++ b/extensions/ext-llm-openai/src/openai-chat-request-builder.ts
@@ -1,0 +1,220 @@
+import {
+  readProviderOptions,
+  toOpenAICompatibleMessages,
+  toOpenAICompatibleTools,
+  unwrapToolInputSchema,
+} from "veryfront/provider/shared";
+import type { OpenAICompatibleChatRequest, RuntimePromptMessage } from "veryfront/provider/shared";
+
+type ProviderReasoningEffort = "low" | "medium" | "high" | "max";
+
+type ProviderReasoningOption = {
+  enabled?: boolean;
+  effort?: ProviderReasoningEffort;
+  budgetTokens?: number;
+};
+
+export type RuntimeToolDefinition =
+  | {
+    type: "function";
+    name: string;
+    description?: string;
+    inputSchema: unknown;
+  }
+  | {
+    type: "provider";
+    name: string;
+    id: `${string}.${string}`;
+    args: Record<string, unknown>;
+  };
+
+export type OpenAICompatibleLanguageOptions = {
+  prompt: RuntimePromptMessage[];
+  maxOutputTokens?: number;
+  temperature?: number;
+  topP?: number;
+  topK?: number;
+  stopSequences?: string[];
+  tools?: RuntimeToolDefinition[];
+  toolChoice?: unknown;
+  seed?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  headers?: HeadersInit;
+  providerOptions?: Record<string, unknown>;
+  includeRawChunks?: boolean;
+  abortSignal?: AbortSignal;
+  reasoning?: ProviderReasoningOption;
+  userId?: string;
+  serviceTier?: "auto" | "default" | "flex" | "scale";
+  parallelToolCalls?: boolean;
+  responseFormat?:
+    | { type: "text" }
+    | { type: "json" }
+    | {
+      type: "json_schema";
+      name: string;
+      schema: unknown;
+      description?: string;
+      strict?: boolean;
+    };
+};
+
+type WarningCollector = {
+  push(warning: {
+    type: "unsupported-setting" | "other";
+    setting?: string;
+    details?: string;
+    provider: string;
+  }): void;
+  drain(): Array<{
+    type: "unsupported-setting" | "other";
+    setting?: string;
+    details?: string;
+    provider: string;
+  }>;
+};
+
+function isOpenAIReasoningModel(modelId: string): boolean {
+  return /^o[134](-|$)/.test(modelId);
+}
+
+function isNativeOpenAIModel(modelId: string): boolean {
+  return /^(gpt-|o[134](-|$)|chatgpt-)/.test(modelId);
+}
+
+function isFixedSamplingModel(modelId: string): boolean {
+  return /^kimi-k2\.5/.test(modelId);
+}
+
+function resolveOpenAIReasoningEffort(
+  option: ProviderReasoningOption | undefined,
+): "low" | "medium" | "high" | undefined {
+  if (!option || option.enabled !== true) {
+    return undefined;
+  }
+  switch (option.effort) {
+    case "low":
+      return "low";
+    case "high":
+    case "max":
+      return "high";
+    case "medium":
+    default:
+      return "medium";
+  }
+}
+
+export function buildOpenAIChatRequest(
+  modelId: string,
+  providerName: string,
+  options: OpenAICompatibleLanguageOptions,
+  stream: boolean,
+  warnings: WarningCollector,
+): OpenAICompatibleChatRequest {
+  const isReasoningModel = isOpenAIReasoningModel(modelId);
+  const reasoningEffort = resolveOpenAIReasoningEffort(options.reasoning);
+  const reasoningEnabled = isReasoningModel || reasoningEffort !== undefined;
+  const fixedSampling = isFixedSamplingModel(modelId);
+  const dropSamplingParams = reasoningEnabled || fixedSampling;
+
+  // OpenAI Chat Completions has no top_k surface.
+  if (options.topK !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "openai",
+      setting: "topK",
+      details: "OpenAI Chat Completions does not expose top_k; the value was dropped.",
+    });
+  }
+
+  // Reasoning models (o1 / o3 / o4) and models with fixed sampling params
+  // reject sampling params outright. Emit warnings.
+  if (dropSamplingParams) {
+    const dropped: Array<[keyof typeof options, string]> = [
+      ["temperature", "temperature"],
+      ["topP", "top_p"],
+      ["presencePenalty", "presence_penalty"],
+      ["frequencyPenalty", "frequency_penalty"],
+    ];
+    for (const [key, openaiName] of dropped) {
+      if (options[key] !== undefined) {
+        warnings.push({
+          type: "unsupported-setting",
+          provider: "openai",
+          setting: key,
+          details: fixedSampling
+            ? `Dropped because this model uses fixed sampling parameters.`
+            : `Dropped because OpenAI reasoning models reject ${openaiName}. Reasoning was active for this request.`,
+        });
+      }
+    }
+  }
+
+  const body: OpenAICompatibleChatRequest = {
+    model: modelId,
+    messages: toOpenAICompatibleMessages(options.prompt),
+    ...(stream ? { stream: true, stream_options: { include_usage: true } } : {}),
+    ...(options.maxOutputTokens !== undefined
+      ? isNativeOpenAIModel(modelId)
+        ? { max_completion_tokens: options.maxOutputTokens }
+        : { max_tokens: options.maxOutputTokens }
+      : {}),
+    ...(!dropSamplingParams && options.temperature !== undefined
+      ? { temperature: options.temperature }
+      : {}),
+    ...(!dropSamplingParams && options.topP !== undefined ? { top_p: options.topP } : {}),
+    ...(options.stopSequences && options.stopSequences.length > 0
+      ? { stop: options.stopSequences }
+      : {}),
+    ...(toOpenAICompatibleTools(options.tools)
+      ? { tools: toOpenAICompatibleTools(options.tools) }
+      : {}),
+    ...(options.toolChoice !== undefined ? { tool_choice: options.toolChoice } : {}),
+    ...(options.seed !== undefined ? { seed: options.seed } : {}),
+    ...(!dropSamplingParams && options.presencePenalty !== undefined
+      ? { presence_penalty: options.presencePenalty }
+      : {}),
+    ...(!dropSamplingParams && options.frequencyPenalty !== undefined
+      ? { frequency_penalty: options.frequencyPenalty }
+      : {}),
+    ...(reasoningEffort !== undefined ? { reasoning_effort: reasoningEffort } : {}),
+    ...(typeof options.userId === "string" && options.userId.length > 0
+      ? { user: options.userId }
+      : {}),
+    ...(options.serviceTier !== undefined ? { service_tier: options.serviceTier } : {}),
+    ...(options.parallelToolCalls !== undefined
+      ? { parallel_tool_calls: options.parallelToolCalls }
+      : {}),
+    ...(options.responseFormat && options.responseFormat.type !== "text"
+      ? {
+        response_format: options.responseFormat.type === "json" ? { type: "json_object" } : {
+          type: "json_schema",
+          json_schema: {
+            name: options.responseFormat.name,
+            ...(typeof options.responseFormat.description === "string"
+              ? { description: options.responseFormat.description }
+              : {}),
+            schema: unwrapToolInputSchema(options.responseFormat.schema),
+            ...(options.responseFormat.strict !== undefined
+              ? { strict: options.responseFormat.strict }
+              : {}),
+          },
+        },
+      }
+      : {}),
+  };
+
+  const providerOpts = readProviderOptions(options.providerOptions, "openai", providerName);
+
+  // Normalize max_tokens to max_completion_tokens for native OpenAI models.
+  if (isNativeOpenAIModel(modelId) && "max_tokens" in providerOpts) {
+    if (!("max_completion_tokens" in providerOpts)) {
+      providerOpts.max_completion_tokens = providerOpts.max_tokens;
+    }
+    delete providerOpts.max_tokens;
+  }
+
+  Object.assign(body, providerOpts);
+  return body;
+}

--- a/extensions/ext-llm-openai/src/openai-provider.ts
+++ b/extensions/ext-llm-openai/src/openai-provider.ts
@@ -1,5 +1,5 @@
 /**
- * OpenAI provider — implements the {@link LLMProvider} contract for OpenAI,
+ * OpenAI provider, implements the {@link LLMProvider} contract for OpenAI,
  * OpenAI-compatible endpoints (Azure OpenAI, Moonshot AI), and OpenAI's
  * Responses API.
  *
@@ -20,6 +20,7 @@ import {
   isNumberArray,
   mergeUsage,
   parseRetryAfterMs,
+  parseSseChunk,
   ProviderError,
   ProviderOverloadedError,
   ProviderQuotaError,
@@ -31,11 +32,14 @@ import {
   requestStream,
   stringifyJsonValue,
   TOOL_INPUT_PENDING_THRESHOLD_MS,
-  toOpenAICompatibleMessages,
-  toOpenAICompatibleTools,
   withToolInputStatusTransitions,
 } from "veryfront/provider/shared";
-import type { OpenAICompatibleChatRequest, RuntimePromptMessage } from "veryfront/provider/shared";
+import type { RuntimePromptMessage } from "veryfront/provider/shared";
+import {
+  buildOpenAIChatRequest,
+  type OpenAICompatibleLanguageOptions,
+  type RuntimeToolDefinition,
+} from "./openai-chat-request-builder.ts";
 
 // Re-export error classes so extension tests can import from this module.
 export {
@@ -82,52 +86,6 @@ type OpenAIStreamToolCallState = {
   name: string;
   arguments: string;
   started: boolean;
-};
-
-type RuntimeToolDefinition =
-  | {
-    type: "function";
-    name: string;
-    description?: string;
-    inputSchema: unknown;
-  }
-  | {
-    type: "provider";
-    name: string;
-    id: `${string}.${string}`;
-    args: Record<string, unknown>;
-  };
-
-type OpenAICompatibleLanguageOptions = {
-  prompt: RuntimePromptMessage[];
-  maxOutputTokens?: number;
-  temperature?: number;
-  topP?: number;
-  topK?: number;
-  stopSequences?: string[];
-  tools?: RuntimeToolDefinition[];
-  toolChoice?: unknown;
-  seed?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  headers?: HeadersInit;
-  providerOptions?: Record<string, unknown>;
-  includeRawChunks?: boolean;
-  abortSignal?: AbortSignal;
-  reasoning?: ProviderReasoningOption;
-  userId?: string;
-  serviceTier?: "auto" | "default" | "flex" | "scale";
-  parallelToolCalls?: boolean;
-  responseFormat?:
-    | { type: "text" }
-    | { type: "json" }
-    | {
-      type: "json_schema";
-      name: string;
-      schema: unknown;
-      description?: string;
-      strict?: boolean;
-    };
 };
 
 type RuntimeUsage = {
@@ -275,27 +233,8 @@ function isOpenAIReasoningModel(modelId: string): boolean {
 }
 
 /**
- * Detect native OpenAI models (gpt-*, o-series, chatgpt-*) vs third-party
- * OpenAI-compatible providers (Kimi, etc.). Native OpenAI models require
- * `max_completion_tokens` (the old `max_tokens` is rejected by newer models
- * like gpt-5.2), while third-party providers still expect `max_tokens`.
- */
-function isNativeOpenAIModel(modelId: string): boolean {
-  return /^(gpt-|o[134](-|$)|chatgpt-)/.test(modelId);
-}
-
-/**
- * Kimi K2.5 fixes sampling parameters (temperature, top_p, presence_penalty,
- * frequency_penalty) to predetermined values and rejects any other values.
- * See https://platform.moonshot.cn/docs/guide/kimi-k2-5-quickstart
- */
-function isFixedSamplingModel(modelId: string): boolean {
-  return /^kimi-k2\.5/.test(modelId);
-}
-
-/**
  * Map the unified reasoning effort to OpenAI's `reasoning_effort` enum.
- * OpenAI doesn't accept "max" — we collapse it to "high".
+ * OpenAI doesn't accept "max", so collapse it to "high".
  */
 function resolveOpenAIReasoningEffort(
   option: ProviderReasoningOption | undefined,
@@ -348,153 +287,9 @@ type WarningCollector = {
   }>;
 };
 
-function buildOpenAIChatRequest(
-  modelId: string,
-  providerName: string,
-  options: OpenAICompatibleLanguageOptions,
-  stream: boolean,
-  warnings: WarningCollector,
-): OpenAICompatibleChatRequest {
-  const isReasoningModel = isOpenAIReasoningModel(modelId);
-  const reasoningEffort = resolveOpenAIReasoningEffort(options.reasoning);
-  const reasoningEnabled = isReasoningModel || reasoningEffort !== undefined;
-  const fixedSampling = isFixedSamplingModel(modelId);
-  const dropSamplingParams = reasoningEnabled || fixedSampling;
-
-  // OpenAI Chat Completions has no top_k surface.
-  if (options.topK !== undefined) {
-    warnings.push({
-      type: "unsupported-setting",
-      provider: "openai",
-      setting: "topK",
-      details: "OpenAI Chat Completions does not expose top_k; the value was dropped.",
-    });
-  }
-
-  // Reasoning models (o1 / o3 / o4) and models with fixed sampling params
-  // reject sampling params outright. Emit warnings.
-  if (dropSamplingParams) {
-    const dropped: Array<[keyof typeof options, string]> = [
-      ["temperature", "temperature"],
-      ["topP", "top_p"],
-      ["presencePenalty", "presence_penalty"],
-      ["frequencyPenalty", "frequency_penalty"],
-    ];
-    for (const [key, openaiName] of dropped) {
-      if (options[key] !== undefined) {
-        warnings.push({
-          type: "unsupported-setting",
-          provider: "openai",
-          setting: key,
-          details: fixedSampling
-            ? `Dropped because this model uses fixed sampling parameters.`
-            : `Dropped because OpenAI reasoning models reject ${openaiName}. Reasoning was active for this request.`,
-        });
-      }
-    }
-  }
-
-  const body: OpenAICompatibleChatRequest = {
-    model: modelId,
-    messages: toOpenAICompatibleMessages(options.prompt),
-    ...(stream ? { stream: true, stream_options: { include_usage: true } } : {}),
-    ...(options.maxOutputTokens !== undefined
-      ? isNativeOpenAIModel(modelId)
-        ? { max_completion_tokens: options.maxOutputTokens }
-        : { max_tokens: options.maxOutputTokens }
-      : {}),
-    ...(!dropSamplingParams && options.temperature !== undefined
-      ? { temperature: options.temperature }
-      : {}),
-    ...(!dropSamplingParams && options.topP !== undefined ? { top_p: options.topP } : {}),
-    ...(options.stopSequences && options.stopSequences.length > 0
-      ? { stop: options.stopSequences }
-      : {}),
-    ...(toOpenAICompatibleTools(options.tools)
-      ? { tools: toOpenAICompatibleTools(options.tools) }
-      : {}),
-    ...(options.toolChoice !== undefined ? { tool_choice: options.toolChoice } : {}),
-    ...(options.seed !== undefined ? { seed: options.seed } : {}),
-    ...(!dropSamplingParams && options.presencePenalty !== undefined
-      ? { presence_penalty: options.presencePenalty }
-      : {}),
-    ...(!dropSamplingParams && options.frequencyPenalty !== undefined
-      ? { frequency_penalty: options.frequencyPenalty }
-      : {}),
-    ...(reasoningEffort !== undefined ? { reasoning_effort: reasoningEffort } : {}),
-    ...(typeof options.userId === "string" && options.userId.length > 0
-      ? { user: options.userId }
-      : {}),
-    ...(options.serviceTier !== undefined ? { service_tier: options.serviceTier } : {}),
-    ...(options.parallelToolCalls !== undefined
-      ? { parallel_tool_calls: options.parallelToolCalls }
-      : {}),
-    ...(options.responseFormat && options.responseFormat.type !== "text"
-      ? {
-        response_format: options.responseFormat.type === "json" ? { type: "json_object" } : {
-          type: "json_schema",
-          json_schema: {
-            name: options.responseFormat.name,
-            ...(typeof options.responseFormat.description === "string"
-              ? { description: options.responseFormat.description }
-              : {}),
-            schema: unwrapToolInputSchema(options.responseFormat.schema),
-            ...(options.responseFormat.strict !== undefined
-              ? { strict: options.responseFormat.strict }
-              : {}),
-          },
-        },
-      }
-      : {}),
-  };
-
-  const providerOpts = readProviderOptions(options.providerOptions, "openai", providerName);
-
-  // Normalize max_tokens → max_completion_tokens for native OpenAI models.
-  if (isNativeOpenAIModel(modelId) && "max_tokens" in providerOpts) {
-    if (!("max_completion_tokens" in providerOpts)) {
-      providerOpts.max_completion_tokens = providerOpts.max_tokens;
-    }
-    delete providerOpts.max_tokens;
-  }
-
-  Object.assign(body, providerOpts);
-  return body;
-}
-
 // ---------------------------------------------------------------------------
 // Chat streaming
 // ---------------------------------------------------------------------------
-
-function parseSseChunk(chunk: string): {
-  events: Array<unknown | "[DONE]">;
-  remainder: string;
-} {
-  const blocks = chunk.split(/\r?\n\r?\n/);
-  const remainder = blocks.pop() ?? "";
-  const events = blocks.flatMap((block) => {
-    const dataLines = block.split(/\r?\n/)
-      .filter((line) => line.startsWith("data:"))
-      .map((line) => line.slice(5).trimStart());
-
-    if (!dataLines.length) {
-      return [];
-    }
-
-    const payload = dataLines.join("\n").trim();
-    if (payload === "[DONE]") {
-      return ["[DONE]" as const];
-    }
-
-    try {
-      return [JSON.parse(payload) as unknown];
-    } catch {
-      return [];
-    }
-  });
-
-  return { events, remainder };
-}
 
 function extractFirstChoice(payload: unknown): OpenAICompatibleChoice | undefined {
   const record = readRecord(payload);
@@ -762,7 +557,7 @@ function toOpenAIResponsesInput(
           }
           if (part.type === "reasoning") {
             // Reasoning items are top-level entries in the input array,
-            // not nested inside the assistant message — flush whatever
+            // not nested inside the assistant message. Flush whatever
             // text we've accumulated first, then push the reasoning item.
             if (messageContent.length > 0) {
               input.push({ role: "assistant", content: [...messageContent] });

--- a/src/server/handlers/preview/hmr-client-message.test.ts
+++ b/src/server/handlers/preview/hmr-client-message.test.ts
@@ -1,0 +1,114 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  HMR_CLOSE_MESSAGE_TOO_LARGE,
+  HMR_CLOSE_RATE_LIMIT,
+  HMR_MAX_MESSAGE_SIZE_BYTES,
+} from "#veryfront/utils";
+import { getHmrWebSocketMessageSize, handleHmrClientMessage } from "./hmr-client-message.ts";
+
+class MockSocket {
+  readonly sent: string[] = [];
+  readonly closed: Array<{ code?: number; reason?: string }> = [];
+
+  send(message: string): void {
+    this.sent.push(message);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closed.push({ code, reason });
+  }
+}
+
+describe("server/handlers/preview/hmr-client-message", () => {
+  it("reports inbound WebSocket message size across supported payloads", () => {
+    assertEquals(getHmrWebSocketMessageSize("ping"), 4);
+    assertEquals(getHmrWebSocketMessageSize(new Uint8Array([1, 2, 3])), 3);
+    assertEquals(getHmrWebSocketMessageSize(new ArrayBuffer(5)), 5);
+    assertEquals(getHmrWebSocketMessageSize(new Blob(["hello"])), 5);
+    assertEquals(getHmrWebSocketMessageSize({ type: "ping" }), 0);
+  });
+
+  it("responds to ping messages and records activity", () => {
+    const socket = new MockSocket();
+    let activityCount = 0;
+
+    handleHmrClientMessage({
+      socket,
+      data: JSON.stringify({ type: "ping" }),
+      rateLimiter: { check: () => true },
+      onActivity: () => {
+        activityCount += 1;
+      },
+    });
+
+    assertEquals(socket.sent, [JSON.stringify({ type: "pong" })]);
+    assertEquals(socket.closed, []);
+    assertEquals(activityCount, 1);
+  });
+
+  it("closes oversized messages before rate limiting or activity updates", () => {
+    const socket = new MockSocket();
+    let checkedRateLimit = false;
+    let activityCount = 0;
+
+    handleHmrClientMessage({
+      socket,
+      data: "x".repeat(HMR_MAX_MESSAGE_SIZE_BYTES + 1),
+      rateLimiter: {
+        check: () => {
+          checkedRateLimit = true;
+          return true;
+        },
+      },
+      onActivity: () => {
+        activityCount += 1;
+      },
+    });
+
+    assertEquals(socket.sent, []);
+    assertEquals(socket.closed, [
+      { code: HMR_CLOSE_MESSAGE_TOO_LARGE, reason: "Message too large" },
+    ]);
+    assertEquals(checkedRateLimit, false);
+    assertEquals(activityCount, 0);
+  });
+
+  it("closes rate-limited messages before activity updates", () => {
+    const socket = new MockSocket();
+    let activityCount = 0;
+
+    handleHmrClientMessage({
+      socket,
+      data: JSON.stringify({ type: "ping" }),
+      rateLimiter: { check: () => false },
+      onActivity: () => {
+        activityCount += 1;
+      },
+    });
+
+    assertEquals(socket.sent, []);
+    assertEquals(socket.closed, [
+      { code: HMR_CLOSE_RATE_LIMIT, reason: "Rate limit exceeded" },
+    ]);
+    assertEquals(activityCount, 0);
+  });
+
+  it("ignores malformed JSON after rate limiting and activity updates", () => {
+    const socket = new MockSocket();
+    let activityCount = 0;
+
+    handleHmrClientMessage({
+      socket,
+      data: "{",
+      rateLimiter: { check: () => true },
+      onActivity: () => {
+        activityCount += 1;
+      },
+    });
+
+    assertEquals(socket.sent, []);
+    assertEquals(socket.closed, []);
+    assertEquals(activityCount, 1);
+  });
+});

--- a/src/server/handlers/preview/hmr-client-message.ts
+++ b/src/server/handlers/preview/hmr-client-message.ts
@@ -1,0 +1,63 @@
+import {
+  HMR_CLOSE_MESSAGE_TOO_LARGE,
+  HMR_CLOSE_RATE_LIMIT,
+  HMR_MAX_MESSAGE_SIZE_BYTES,
+} from "#veryfront/utils";
+
+export type HmrClientMessageSocket = {
+  send(message: string): void;
+  close(code?: number, reason?: string): void;
+};
+
+type HmrClientRateLimiter<TSocket> = {
+  check(socket: TSocket): boolean;
+};
+
+export function getHmrWebSocketMessageSize(data: unknown): number {
+  if (typeof data === "string") return data.length;
+  if (data instanceof ArrayBuffer) return data.byteLength;
+  if (ArrayBuffer.isView(data)) return data.byteLength;
+  if (data instanceof Blob) return data.size;
+  return 0;
+}
+
+export function handleHmrClientMessage<TSocket extends HmrClientMessageSocket>(
+  input: {
+    socket: TSocket;
+    data: unknown;
+    rateLimiter: HmrClientRateLimiter<TSocket>;
+    onActivity?: () => void;
+  },
+): void {
+  const messageSize = getHmrWebSocketMessageSize(input.data);
+  if (messageSize > HMR_MAX_MESSAGE_SIZE_BYTES) {
+    try {
+      input.socket.close(HMR_CLOSE_MESSAGE_TOO_LARGE, "Message too large");
+    } catch (_) {
+      /* expected: socket may already be closed */
+    }
+    return;
+  }
+
+  if (!input.rateLimiter.check(input.socket)) {
+    try {
+      input.socket.close(HMR_CLOSE_RATE_LIMIT, "Rate limit exceeded");
+    } catch (_) {
+      /* expected: socket may already be closed */
+    }
+    return;
+  }
+
+  input.onActivity?.();
+
+  if (typeof input.data !== "string") return;
+
+  try {
+    const data = JSON.parse(input.data);
+    if (data?.type === "ping") {
+      input.socket.send(JSON.stringify({ type: "pong" }));
+    }
+  } catch (_) {
+    /* expected: ignore malformed JSON from client */
+  }
+}

--- a/src/server/handlers/preview/hmr.handler.ts
+++ b/src/server/handlers/preview/hmr.handler.ts
@@ -1,10 +1,4 @@
-import {
-  HMR_CLOSE_MESSAGE_TOO_LARGE,
-  HMR_CLOSE_RATE_LIMIT,
-  HMR_MAX_MESSAGE_SIZE_BYTES,
-  HMR_MAX_MESSAGES_PER_MINUTE,
-  serverLogger,
-} from "#veryfront/utils";
+import { HMR_MAX_MESSAGES_PER_MINUTE, serverLogger } from "#veryfront/utils";
 import { RateLimiter } from "#veryfront/modules/server/index.ts";
 import { BaseHandler } from "../response/base.ts";
 import {
@@ -25,6 +19,7 @@ import {
   getClientDetails,
   removeClient,
 } from "./hmr-client-manager.ts";
+import { handleHmrClientMessage } from "./hmr-client-message.ts";
 import { getPingIntervalMs, startPingInterval, stopPingInterval } from "./hmr-ping-keepalive.ts";
 import { broadcastUpdate, getMetrics } from "./hmr-message-router.ts";
 import { getEffectiveRequestHost } from "../../utils/request-host.ts";
@@ -101,7 +96,7 @@ export class HMRHandler extends BaseHandler {
     // Honouring it unconditionally lets any remote client present `x-forwarded-host: localhost`
     // and unlock the localhost short-circuit that opens HMR (VULN-SRV-4). Only consult
     // forwarded headers when the request is proxy-trusted; otherwise use Host / url.host.
-    // Proxy trust requires a verifiable dispatch JWS (or operator opt-in) — mere header
+    // Proxy trust requires a verifiable dispatch JWS (or operator opt-in). Mere header
     // presence is not enough, since `x-veryfront-dispatch-jws` is not stripped on ingress.
     const publicKeyPem = ctx.adapter?.env?.get("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY") ??
       getHostEnv("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
@@ -191,40 +186,17 @@ export class HMRHandler extends BaseHandler {
 
       // Handle incoming messages (size/rate guard, ping/pong, activity tracking)
       socket.addEventListener("message", (event) => {
-        const messageSize = HMRHandler.getMessageSize(event.data);
-        if (messageSize > HMR_MAX_MESSAGE_SIZE_BYTES) {
-          try {
-            socket.close(HMR_CLOSE_MESSAGE_TOO_LARGE, "Message too large");
-          } catch (_) {
-            /* expected: socket may already be closed */
-          }
-          return;
-        }
-
-        if (!HMRHandler.rateLimiter.check(socket)) {
-          try {
-            socket.close(HMR_CLOSE_RATE_LIMIT, "Rate limit exceeded");
-          } catch (_) {
-            /* expected: socket may already be closed */
-          }
-          return;
-        }
-
-        const client = getClient(clientId);
-        if (client) {
-          client.lastActivity = Date.now();
-        }
-
-        if (typeof event.data !== "string") return;
-
-        try {
-          const data = JSON.parse(event.data);
-          if (data?.type === "ping") {
-            socket.send(JSON.stringify({ type: "pong" }));
-          }
-        } catch (_) {
-          /* expected: ignore malformed JSON from client */
-        }
+        handleHmrClientMessage({
+          socket,
+          data: event.data,
+          rateLimiter: HMRHandler.rateLimiter,
+          onActivity: () => {
+            const client = getClient(clientId);
+            if (client) {
+              client.lastActivity = Date.now();
+            }
+          },
+        });
       });
 
       // Clean up on close or error
@@ -329,13 +301,5 @@ export class HMRHandler extends BaseHandler {
     HMRHandler.initialized = false;
 
     logger.debug("Shutdown complete");
-  }
-
-  private static getMessageSize(data: unknown): number {
-    if (typeof data === "string") return data.length;
-    if (data instanceof ArrayBuffer) return data.byteLength;
-    if (ArrayBuffer.isView(data)) return data.byteLength;
-    if (data instanceof Blob) return data.size;
-    return 0;
   }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -43,13 +43,9 @@ import { cwd } from "#veryfront/platform/compat/process.ts";
 import { bootstrapProd } from "./bootstrap.ts";
 import { createVeryfrontHandler } from "./runtime-handler/index.ts";
 import { addClient, getClient, removeClient } from "./handlers/preview/hmr-client-manager.ts";
+import { handleHmrClientMessage } from "./handlers/preview/hmr-client-message.ts";
 import { RateLimiter } from "#veryfront/modules/server/index.ts";
-import {
-  HMR_CLOSE_MESSAGE_TOO_LARGE,
-  HMR_CLOSE_RATE_LIMIT,
-  HMR_MAX_MESSAGE_SIZE_BYTES,
-  HMR_MAX_MESSAGES_PER_MINUTE,
-} from "#veryfront/utils";
+import { HMR_MAX_MESSAGES_PER_MINUTE } from "#veryfront/utils";
 
 /** Default server port when no port is specified */
 const DEFAULT_SERVER_PORT = 3_000;
@@ -193,14 +189,6 @@ function toNativeResponse(res: Response): Response {
   });
 }
 
-function getWebSocketMessageSize(data: unknown): number {
-  if (typeof data === "string") return data.length;
-  if (data instanceof ArrayBuffer) return data.byteLength;
-  if (ArrayBuffer.isView(data)) return data.byteLength;
-  if (data instanceof Blob) return data.size;
-  return 0;
-}
-
 export async function createHandler(
   options: { projectDir?: string; mode?: "development" | "production"; port?: number } = {},
 ): Promise<VeryfrontHandler> {
@@ -214,7 +202,7 @@ export async function createHandler(
     return Object.assign(handler, { upgrade: () => {}, connectHMR: () => {} });
   }
 
-  // Development mode (default) — includes file watching, HMR, cache invalidation
+  // Development mode (default), includes file watching, HMR, cache invalidation
   const port = options.port ?? DEFAULT_SERVER_PORT;
   const devServer = new DevServer({
     port,
@@ -226,7 +214,7 @@ export async function createHandler(
   await devServer.start();
 
   // ReloadNotifier subscription for HMR broadcast is now handled eagerly
-  // inside DevServer.start() — no additional subscription needed here.
+  // inside DevServer.start(), no additional subscription needed here.
 
   const internalFetch = devServer.handler;
   const fetch = async (req: Request) => toNativeResponse(await internalFetch(req));
@@ -289,38 +277,15 @@ export async function createHandler(
     ws.addEventListener("error", cleanup);
 
     ws.addEventListener("message", (event) => {
-      const messageSize = getWebSocketMessageSize(event.data);
-      if (messageSize > HMR_MAX_MESSAGE_SIZE_BYTES) {
-        try {
-          ws.close(HMR_CLOSE_MESSAGE_TOO_LARGE, "Message too large");
-        } catch (_) {
-          /* expected: socket may already be closed */
-        }
-        return;
-      }
-
-      if (!hmrRateLimiter.check(ws)) {
-        try {
-          ws.close(HMR_CLOSE_RATE_LIMIT, "Rate limit exceeded");
-        } catch (_) {
-          /* expected: socket may already be closed */
-        }
-        return;
-      }
-
-      const client = getClient(clientId);
-      if (client) client.lastActivity = Date.now();
-
-      if (typeof event.data !== "string") return;
-
-      try {
-        const data = JSON.parse(event.data);
-        if (data?.type === "ping") {
-          ws.send(JSON.stringify({ type: "pong" }));
-        }
-      } catch (_) {
-        /* expected: ignore malformed JSON from client */
-      }
+      handleHmrClientMessage({
+        socket: ws,
+        data: event.data,
+        rateLimiter: hmrRateLimiter,
+        onActivity: () => {
+          const client = getClient(clientId);
+          if (client) client.lastActivity = Date.now();
+        },
+      });
     });
 
     const sendConnected = () => {


### PR DESCRIPTION
## Summary
- Extract OpenAI Chat Completions request building into a focused builder module with a request-shape contract test.
- Reuse the shared provider SSE parser in the OpenAI provider.
- Centralize inbound HMR WebSocket message size/rate/ping handling behind fixture tests and use it from both runtime HMR entry points.

## Issues
- Advances #1267 with the first provider/API-family request-builder slice.
- Advances #1268 by removing OpenAI's duplicated SSE parser and keeping existing stream fixtures green.
- Advances #1271 with a shared WebSocket message handling helper and protocol fixtures.

## Verification
- deno test --allow-all extensions/ext-llm-openai/src/openai-provider.test.ts extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts
- deno test --allow-all src/server/handlers/preview/hmr-client-message.test.ts src/server/handlers/preview/hmr.handler.test.ts src/server/handlers/preview/hmr-message-router.test.ts
- deno fmt --check extensions/ext-llm-openai/src/openai-provider.ts extensions/ext-llm-openai/src/openai-chat-request-builder.ts extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts src/server/index.ts src/server/handlers/preview/hmr.handler.ts src/server/handlers/preview/hmr-client-message.ts src/server/handlers/preview/hmr-client-message.test.ts
- DENO_NO_PACKAGE_JSON=1 deno lint extensions/ext-llm-openai/src/openai-provider.ts extensions/ext-llm-openai/src/openai-chat-request-builder.ts extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts src/server/index.ts src/server/handlers/preview/hmr.handler.ts src/server/handlers/preview/hmr-client-message.ts src/server/handlers/preview/hmr-client-message.test.ts
- deno task typecheck
- pre-push hooks: fmt, lint, typecheck, unit tests (1903 passed)