### PR TITLE
refactor: centralize poke websocket parsing

### DIFF
--- a/src/platform/adapters/fs/veryfront/websocket-manager-helpers.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager-helpers.ts
@@ -71,3 +71,24 @@ export function buildContentSourceLabel(
     branch: getContentContext()?.branch ?? null,
   };
 }
+
+export type PokeWebSocketMessage = {
+  type: "poke" | "entity_updated";
+  payload: Record<string, unknown>;
+};
+
+export function parsePokeWebSocketMessage(data: string): PokeWebSocketMessage | null {
+  const raw: unknown = JSON.parse(data);
+  if (!raw || typeof raw !== "object") return null;
+
+  const message = raw as Record<string, unknown>;
+  const type = message.type;
+  if (type !== "poke" && type !== "entity_updated") return null;
+
+  return {
+    type,
+    payload: message.data && typeof message.data === "object"
+      ? message.data as Record<string, unknown>
+      : {},
+  };
+}

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -1,11 +1,15 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertThrows } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
 import type { FileCache } from "../cache/file-cache.ts";
 import type { InvalidationCallbacks } from "./types.ts";
 import { WebSocketManager } from "./websocket-manager.ts";
-import { buildReloadProjectContext, getReconnectDelay } from "./websocket-manager-helpers.ts";
+import {
+  buildReloadProjectContext,
+  getReconnectDelay,
+  parsePokeWebSocketMessage,
+} from "./websocket-manager-helpers.ts";
 import { __resetLoggerConfigForTests } from "#veryfront/utils/logger/logger.ts";
 
 interface TimerEntry {
@@ -145,6 +149,48 @@ describe("WebSocketManager", () => {
     assertEquals(getReconnectDelay(2), 10000);
     assertEquals(getReconnectDelay(6), 120000);
     assertEquals(getReconnectDelay(10), 120000);
+  });
+
+  describe("parsePokeWebSocketMessage", () => {
+    it("parses poke messages with object payloads", () => {
+      const parsed = parsePokeWebSocketMessage(JSON.stringify({
+        type: "poke",
+        data: {
+          changedPaths: ["app/page.tsx"],
+          branchName: "main",
+        },
+      }));
+
+      assertEquals(parsed, {
+        type: "poke",
+        payload: {
+          changedPaths: ["app/page.tsx"],
+          branchName: "main",
+        },
+      });
+    });
+
+    it("parses entity_updated messages and normalizes primitive payloads", () => {
+      assertEquals(
+        parsePokeWebSocketMessage(JSON.stringify({
+          type: "entity_updated",
+          data: "ignored",
+        })),
+        {
+          type: "entity_updated",
+          payload: {},
+        },
+      );
+    });
+
+    it("ignores non-poke messages and non-object frames", () => {
+      assertEquals(parsePokeWebSocketMessage(JSON.stringify({ type: "noop", data: {} })), null);
+      assertEquals(parsePokeWebSocketMessage(JSON.stringify(null)), null);
+    });
+
+    it("throws for malformed JSON so callers can keep parse-error logging", () => {
+      assertThrows(() => parsePokeWebSocketMessage("{"), SyntaxError);
+    });
   });
   let originalWebSocket: typeof WebSocket;
   let originalSetTimeout: typeof setTimeout;

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -20,6 +20,7 @@ import {
   getPreviewInvalidationPrefixes as getPreviewInvalidationPrefixesHelper,
   getReconnectDelay as getReconnectDelayHelper,
   INVALIDATION_DEBOUNCE_MS,
+  parsePokeWebSocketMessage,
   type PreviewStyleArtifactInfo,
   WS_HEARTBEAT_INTERVAL_MS,
   WS_HEARTBEAT_TIMEOUT_MS,
@@ -265,16 +266,9 @@ export class WebSocketManager {
 
   private handlePokeMessage(event: MessageEvent): void {
     try {
-      const raw: unknown = JSON.parse(event.data as string);
-      if (!raw || typeof raw !== "object") return;
-      const data = raw as Record<string, unknown>;
-      const isPoke = data.type === "poke" || data.type === "entity_updated";
-      if (!isPoke) return;
-
-      const payload = (data.data && typeof data.data === "object" ? data.data : {}) as Record<
-        string,
-        unknown
-      >;
+      const message = parsePokeWebSocketMessage(event.data as string);
+      if (!message) return;
+      const payload = message.payload;
       const changedPaths = payload.changedPaths as string[] | undefined;
       const contentContext = this.deps.getContentContext();
 
@@ -301,7 +295,7 @@ export class WebSocketManager {
       const isProductionPoke = !hasBranchScope;
 
       logger.debug("POKE RECEIVED - checking environment scope", {
-        type: data.type,
+        type: message.type,
         pokeBranchId: normalizedBranchId,
         pokeBranchName: normalizedBranchName,
         isProductionPoke,


### PR DESCRIPTION
## Summary
- add a tested `parsePokeWebSocketMessage` helper for Veryfront adapter poke frames
- cover poke, entity_updated, ignored frames, primitive payloads, and malformed JSON behavior
- delegate WebSocketManager poke parsing to the helper without changing invalidation flow

Advances #1271.

## Verification
- deno test --allow-all src/platform/adapters/fs/veryfront/websocket-manager.test.ts
- deno fmt --check src/platform/adapters/fs/veryfront/websocket-manager.ts src/platform/adapters/fs/veryfront/websocket-manager-helpers.ts src/platform/adapters/fs/veryfront/websocket-manager.test.ts
- DENO_NO_PACKAGE_JSON=1 deno lint src/platform/adapters/fs/veryfront/websocket-manager.ts src/platform/adapters/fs/veryfront/websocket-manager-helpers.ts src/platform/adapters/fs/veryfront/websocket-manager.test.ts
- deno task typecheck
- git push pre-push hook: formatting, lint, typecheck, generated assets, and unit tests: 1903 passed, 0 failed
