### PR TITLE
refactor: split openai chat stream adapter

### DIFF
--- a/extensions/ext-llm-openai/src/openai-chat-stream.test.ts
+++ b/extensions/ext-llm-openai/src/openai-chat-stream.test.ts
@@ -1,0 +1,121 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { streamOpenAICompatibleParts } from "./openai-chat-stream.ts";
+
+function streamFromText(text: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+}
+
+async function collectParts(stream: ReadableStream<Uint8Array>): Promise<unknown[]> {
+  const parts: unknown[] = [];
+  for await (const part of streamOpenAICompatibleParts(stream)) {
+    parts.push(part);
+  }
+  return parts;
+}
+
+function data(payload: unknown): string {
+  return `data: ${JSON.stringify(payload)}\r\n\r\n`;
+}
+
+describe("ext-llm-openai/openai-chat-stream", () => {
+  it("preserves reasoning, text, tool-call assembly, usage, and finish events", async () => {
+    const parts = await collectParts(streamFromText([
+      data({
+        choices: [{
+          delta: { reasoning_content: "think" },
+        }],
+      }),
+      data({
+        choices: [{
+          delta: { content: "done" },
+        }],
+      }),
+      data({
+        choices: [{
+          delta: {
+            tool_calls: [{
+              index: 0,
+              id: "call_1",
+              function: { name: "lookup", arguments: '{"id":' },
+            }],
+          },
+        }],
+      }),
+      data({
+        choices: [{
+          delta: {
+            tool_calls: [{
+              index: 0,
+              function: { arguments: '"abc"}' },
+            }],
+          },
+          finish_reason: "tool_calls",
+        }],
+        usage: {
+          prompt_tokens: 3,
+          completion_tokens: 4,
+          total_tokens: 7,
+          prompt_tokens_details: { cached_tokens: 2 },
+        },
+      }),
+      "data: [DONE]\r\n\r\n",
+    ].join("")));
+
+    assertEquals(parts, [
+      { type: "reasoning-start", id: "reasoning-0" },
+      { type: "reasoning-delta", id: "reasoning-0", delta: "think" },
+      { type: "reasoning-end", id: "reasoning-0" },
+      { type: "text-delta", delta: "done" },
+      { type: "tool-input-start", id: "call_1", toolName: "lookup" },
+      { type: "tool-input-delta", id: "call_1", delta: '{"id":' },
+      { type: "tool-input-delta", id: "call_1", delta: '"abc"}' },
+      {
+        type: "tool-call",
+        toolCallId: "call_1",
+        toolName: "lookup",
+        input: '{"id":"abc"}',
+      },
+      {
+        type: "finish",
+        finishReason: { unified: "tool-calls", raw: "tool_calls" },
+        usage: {
+          inputTokens: 3,
+          outputTokens: 4,
+          totalTokens: 7,
+          cacheReadInputTokens: 2,
+        },
+      },
+    ]);
+  });
+
+  it("flushes trailing buffered usage records without a final delimiter", async () => {
+    const parts = await collectParts(streamFromText(
+      `data: ${
+        JSON.stringify({
+          usage: {
+            prompt_tokens: 1,
+            completion_tokens: 2,
+            total_tokens: 3,
+          },
+        })
+      }`,
+    ));
+
+    assertEquals(parts, [{
+      type: "finish",
+      finishReason: null,
+      usage: {
+        inputTokens: 1,
+        outputTokens: 2,
+        totalTokens: 3,
+      },
+    }]);
+  });
+});

--- a/extensions/ext-llm-openai/src/openai-chat-stream.ts
+++ b/extensions/ext-llm-openai/src/openai-chat-stream.ts
@@ -1,0 +1,251 @@
+import { parseSseChunk, readRecord } from "veryfront/provider/shared";
+
+type OpenAICompatibleChoice = {
+  message?: unknown;
+  delta?: unknown;
+  finish_reason?: unknown;
+};
+
+type OpenAIStreamToolCallState = {
+  id: string;
+  name: string;
+  arguments: string;
+  started: boolean;
+};
+
+type RuntimeUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+};
+
+function normalizeOpenAIFinishReason(
+  raw: unknown,
+): string | { unified: string; raw: string } | null {
+  if (typeof raw !== "string") {
+    return null;
+  }
+
+  if (raw === "tool_calls") {
+    return { unified: "tool-calls", raw };
+  }
+
+  if (raw === "content_filter") {
+    return { unified: "content-filter", raw };
+  }
+
+  return raw;
+}
+
+function extractOpenAIUsage(payload: unknown): RuntimeUsage | undefined {
+  const record = readRecord(payload);
+  const usage = readRecord(record?.usage);
+  if (!usage) {
+    return undefined;
+  }
+
+  const inputTokens = usage.prompt_tokens;
+  const outputTokens = usage.completion_tokens;
+  const totalTokens = usage.total_tokens;
+  const promptTokensDetails = readRecord(usage.prompt_tokens_details);
+  const cachedTokens = promptTokensDetails?.cached_tokens;
+
+  return {
+    inputTokens: typeof inputTokens === "number" ? inputTokens : undefined,
+    outputTokens: typeof outputTokens === "number" ? outputTokens : undefined,
+    totalTokens: typeof totalTokens === "number" ? totalTokens : undefined,
+    ...(typeof cachedTokens === "number" ? { cacheReadInputTokens: cachedTokens } : {}),
+  };
+}
+
+function extractOpenAIContentText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  let text = "";
+  for (const part of content) {
+    const record = readRecord(part);
+    const type = record?.type;
+    if (type === "text" && typeof record?.text === "string") {
+      text += record.text;
+    }
+  }
+
+  return text;
+}
+
+function extractFirstChoice(payload: unknown): OpenAICompatibleChoice | undefined {
+  const record = readRecord(payload);
+  const choices = record?.choices;
+  if (!Array.isArray(choices) || choices.length === 0) {
+    return undefined;
+  }
+
+  const first = readRecord(choices[0]);
+  if (!first) {
+    return undefined;
+  }
+
+  return first;
+}
+
+export async function* streamOpenAICompatibleParts(
+  stream: ReadableStream<Uint8Array>,
+): AsyncIterable<unknown> {
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const toolCalls = new Map<number, OpenAIStreamToolCallState>();
+  let reasoningId: string | null = null;
+  let reasoningIndex = 0;
+  let finishReason: string | { unified: string; raw: string } | null = null;
+  let usage: RuntimeUsage | undefined;
+
+  for await (const chunk of stream) {
+    buffer += decoder.decode(chunk, { stream: true });
+    const parsed = parseSseChunk(buffer);
+    buffer = parsed.remainder;
+
+    for (const event of parsed.events) {
+      if (event === "[DONE]") {
+        continue;
+      }
+
+      const record = readRecord(event);
+      usage = extractOpenAIUsage(record) ?? usage;
+      const choice = extractFirstChoice(record);
+      if (!choice) {
+        continue;
+      }
+
+      const delta = readRecord(choice.delta);
+      if (typeof delta?.reasoning_content === "string" && delta.reasoning_content.length > 0) {
+        if (!reasoningId) {
+          reasoningId = `reasoning-${reasoningIndex++}`;
+          yield {
+            type: "reasoning-start",
+            id: reasoningId,
+          };
+        }
+
+        yield {
+          type: "reasoning-delta",
+          id: reasoningId,
+          delta: delta.reasoning_content,
+        };
+      }
+
+      const textDelta = extractOpenAIContentText(delta?.content);
+      if (textDelta.length > 0) {
+        if (reasoningId) {
+          yield {
+            type: "reasoning-end",
+            id: reasoningId,
+          };
+          reasoningId = null;
+        }
+        yield { type: "text-delta", delta: textDelta };
+      }
+
+      const rawToolCalls = Array.isArray(delta?.tool_calls) ? delta.tool_calls : [];
+      for (const rawToolCall of rawToolCalls) {
+        if (reasoningId) {
+          yield {
+            type: "reasoning-end",
+            id: reasoningId,
+          };
+          reasoningId = null;
+        }
+
+        const toolCallRecord = readRecord(rawToolCall);
+        const index = typeof toolCallRecord?.index === "number" ? toolCallRecord.index : 0;
+        const current = toolCalls.get(index) ?? {
+          id: typeof toolCallRecord?.id === "string" ? toolCallRecord.id : `tool-${index}`,
+          name: "",
+          arguments: "",
+          started: false,
+        };
+
+        if (typeof toolCallRecord?.id === "string") {
+          current.id = toolCallRecord.id;
+        }
+
+        const fn = readRecord(toolCallRecord?.function);
+        if (typeof fn?.name === "string") {
+          current.name = fn.name;
+        }
+
+        if (!current.started && current.name.length > 0) {
+          current.started = true;
+          yield {
+            type: "tool-input-start",
+            id: current.id,
+            toolName: current.name,
+          };
+        }
+
+        if (typeof fn?.arguments === "string" && fn.arguments.length > 0) {
+          current.arguments += fn.arguments;
+          yield {
+            type: "tool-input-delta",
+            id: current.id,
+            delta: fn.arguments,
+          };
+        }
+
+        toolCalls.set(index, current);
+      }
+
+      const normalizedFinishReason = normalizeOpenAIFinishReason(choice.finish_reason);
+      if (normalizedFinishReason) {
+        finishReason = normalizedFinishReason;
+      }
+    }
+  }
+
+  if (buffer.trim().length > 0) {
+    const parsed = parseSseChunk(`${buffer}\n\n`);
+    for (const event of parsed.events) {
+      if (event === "[DONE]") {
+        continue;
+      }
+
+      const record = readRecord(event);
+      usage = extractOpenAIUsage(record) ?? usage;
+    }
+  }
+
+  if (reasoningId) {
+    yield {
+      type: "reasoning-end",
+      id: reasoningId,
+    };
+  }
+
+  if (
+    finishReason &&
+    typeof finishReason === "object" &&
+    finishReason.unified === "tool-calls"
+  ) {
+    for (const toolCall of toolCalls.values()) {
+      yield {
+        type: "tool-call",
+        toolCallId: toolCall.id,
+        toolName: toolCall.name,
+        input: toolCall.arguments,
+      };
+    }
+  }
+
+  yield {
+    type: "finish",
+    finishReason,
+    ...(usage ? { usage } : {}),
+  };
+}

--- a/extensions/ext-llm-openai/src/openai-provider.ts
+++ b/extensions/ext-llm-openai/src/openai-provider.ts
@@ -37,6 +37,7 @@ import {
   buildOpenAIChatRequest,
   type OpenAICompatibleLanguageOptions,
 } from "./openai-chat-request-builder.ts";
+import { streamOpenAICompatibleParts } from "./openai-chat-stream.ts";
 import { buildOpenAIResponsesRequest } from "./openai-responses-request-builder.ts";
 
 // Re-export error classes so extension tests can import from this module.
@@ -65,13 +66,6 @@ type OpenAICompatibleChoice = {
   message?: unknown;
   delta?: unknown;
   finish_reason?: unknown;
-};
-
-type OpenAIStreamToolCallState = {
-  id: string;
-  name: string;
-  arguments: string;
-  started: boolean;
 };
 
 type RuntimeUsage = {
@@ -208,10 +202,6 @@ function extractOpenAIToolCalls(message: Record<string, unknown>): Array<{
   return normalized;
 }
 
-// ---------------------------------------------------------------------------
-// Chat streaming
-// ---------------------------------------------------------------------------
-
 function extractFirstChoice(payload: unknown): OpenAICompatibleChoice | undefined {
   const record = readRecord(payload);
   const choices = record?.choices;
@@ -256,160 +246,6 @@ function buildOpenAIGenerateResult(payload: unknown): {
     ],
     finishReason: normalizeOpenAIFinishReason(choice?.finish_reason),
     usage: extractOpenAIUsage(payload),
-  };
-}
-
-async function* streamOpenAICompatibleParts(
-  stream: ReadableStream<Uint8Array>,
-): AsyncIterable<unknown> {
-  const decoder = new TextDecoder();
-  let buffer = "";
-  const toolCalls = new Map<number, OpenAIStreamToolCallState>();
-  let reasoningId: string | null = null;
-  let reasoningIndex = 0;
-  let finishReason: string | { unified: string; raw: string } | null = null;
-  let usage: RuntimeUsage | undefined;
-
-  for await (const chunk of stream) {
-    buffer += decoder.decode(chunk, { stream: true });
-    const parsed = parseSseChunk(buffer);
-    buffer = parsed.remainder;
-
-    for (const event of parsed.events) {
-      if (event === "[DONE]") {
-        continue;
-      }
-
-      const record = readRecord(event);
-      usage = extractOpenAIUsage(record) ?? usage;
-      const choice = extractFirstChoice(record);
-      if (!choice) {
-        continue;
-      }
-
-      const delta = readRecord(choice.delta);
-      if (typeof delta?.reasoning_content === "string" && delta.reasoning_content.length > 0) {
-        if (!reasoningId) {
-          reasoningId = `reasoning-${reasoningIndex++}`;
-          yield {
-            type: "reasoning-start",
-            id: reasoningId,
-          };
-        }
-
-        yield {
-          type: "reasoning-delta",
-          id: reasoningId,
-          delta: delta.reasoning_content,
-        };
-      }
-
-      const textDelta = extractOpenAIContentText(delta?.content);
-      if (textDelta.length > 0) {
-        if (reasoningId) {
-          yield {
-            type: "reasoning-end",
-            id: reasoningId,
-          };
-          reasoningId = null;
-        }
-        yield { type: "text-delta", delta: textDelta };
-      }
-
-      const rawToolCalls = Array.isArray(delta?.tool_calls) ? delta.tool_calls : [];
-      for (const rawToolCall of rawToolCalls) {
-        if (reasoningId) {
-          yield {
-            type: "reasoning-end",
-            id: reasoningId,
-          };
-          reasoningId = null;
-        }
-
-        const toolCallRecord = readRecord(rawToolCall);
-        const index = typeof toolCallRecord?.index === "number" ? toolCallRecord.index : 0;
-        const current = toolCalls.get(index) ?? {
-          id: typeof toolCallRecord?.id === "string" ? toolCallRecord.id : `tool-${index}`,
-          name: "",
-          arguments: "",
-          started: false,
-        };
-
-        if (typeof toolCallRecord?.id === "string") {
-          current.id = toolCallRecord.id;
-        }
-
-        const fn = readRecord(toolCallRecord?.function);
-        if (typeof fn?.name === "string") {
-          current.name = fn.name;
-        }
-
-        if (!current.started && current.name.length > 0) {
-          current.started = true;
-          yield {
-            type: "tool-input-start",
-            id: current.id,
-            toolName: current.name,
-          };
-        }
-
-        if (typeof fn?.arguments === "string" && fn.arguments.length > 0) {
-          current.arguments += fn.arguments;
-          yield {
-            type: "tool-input-delta",
-            id: current.id,
-            delta: fn.arguments,
-          };
-        }
-
-        toolCalls.set(index, current);
-      }
-
-      const normalizedFinishReason = normalizeOpenAIFinishReason(choice.finish_reason);
-      if (normalizedFinishReason) {
-        finishReason = normalizedFinishReason;
-      }
-    }
-  }
-
-  if (buffer.trim().length > 0) {
-    const parsed = parseSseChunk(`${buffer}\n\n`);
-    for (const event of parsed.events) {
-      if (event === "[DONE]") {
-        continue;
-      }
-
-      const record = readRecord(event);
-      usage = extractOpenAIUsage(record) ?? usage;
-    }
-  }
-
-  if (reasoningId) {
-    yield {
-      type: "reasoning-end",
-      id: reasoningId,
-    };
-  }
-
-  if (
-    finishReason &&
-    typeof finishReason === "object" &&
-    finishReason.unified === "tool-calls"
-  ) {
-    for (const toolCall of toolCalls.values()) {
-      yield {
-        type: "tool-call",
-        toolCallId: toolCall.id,
-        toolName: toolCall.name,
-        input: toolCall.arguments,
-      };
-    }
-  }
-
-  yield {
-    type: "finish",
-    finishReason,
-    ...(usage ? { usage } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary
- extract the OpenAI Chat Completions stream state machine into a dedicated stream adapter module
- add fixture coverage for reasoning, text deltas, multi-chunk tool input assembly, usage, finish reason normalization, [DONE], CRLF framing, and trailing buffered usage
- keep OpenAI provider focused on transport/result orchestration for chat streams

Advances #1268.

## Verification
- deno test --allow-all extensions/ext-llm-openai/src/openai-chat-stream.test.ts extensions/ext-llm-openai/src/openai-provider.test.ts
- deno fmt --check extensions/ext-llm-openai/src/openai-provider.ts extensions/ext-llm-openai/src/openai-chat-stream.ts extensions/ext-llm-openai/src/openai-chat-stream.test.ts
- DENO_NO_PACKAGE_JSON=1 deno lint extensions/ext-llm-openai/src/openai-provider.ts extensions/ext-llm-openai/src/openai-chat-stream.ts extensions/ext-llm-openai/src/openai-chat-stream.test.ts
- deno task typecheck
- git push pre-push hook: formatting, lint, typecheck, generated assets, and unit tests: 1903 passed, 0 failed
