### PR TITLE
refactor: split openai responses stream adapter

### DIFF
--- a/extensions/ext-llm-openai/src/openai-provider.ts
+++ b/extensions/ext-llm-openai/src/openai-provider.ts
@@ -20,7 +20,6 @@ import {
   isNumberArray,
   mergeUsage,
   parseRetryAfterMs,
-  parseSseChunk,
   ProviderError,
   ProviderOverloadedError,
   ProviderQuotaError,
@@ -39,6 +38,11 @@ import {
 } from "./openai-chat-request-builder.ts";
 import { streamOpenAICompatibleParts } from "./openai-chat-stream.ts";
 import { buildOpenAIResponsesRequest } from "./openai-responses-request-builder.ts";
+import {
+  extractOpenAIResponsesUsage,
+  normalizeOpenAIResponsesFinishReason,
+  streamOpenAIResponsesParts,
+} from "./openai-responses-stream.ts";
 
 // Re-export error classes so extension tests can import from this module.
 export {
@@ -253,54 +257,6 @@ function buildOpenAIGenerateResult(payload: unknown): {
 // Responses API result helpers
 // ---------------------------------------------------------------------------
 
-/**
- * The Responses API uses `input_tokens` / `output_tokens` field names
- * instead of Chat Completions' `prompt_tokens` / `completion_tokens`.
- */
-function extractOpenAIResponsesUsage(payload: unknown): RuntimeUsage | undefined {
-  const record = readRecord(payload);
-  // Streaming usage lives on response.completed inside `response.usage`;
-  // non-streaming has it at the top level.
-  const responseRecord = readRecord(record?.response);
-  const usage = readRecord(responseRecord?.usage) ?? readRecord(record?.usage);
-  if (!usage) return undefined;
-
-  const inputTokens = typeof usage.input_tokens === "number" ? usage.input_tokens : undefined;
-  const outputTokens = typeof usage.output_tokens === "number" ? usage.output_tokens : undefined;
-  const totalTokens = typeof usage.total_tokens === "number"
-    ? usage.total_tokens
-    : (inputTokens !== undefined || outputTokens !== undefined
-      ? (inputTokens ?? 0) + (outputTokens ?? 0)
-      : undefined);
-  const inputDetails = readRecord(usage.input_tokens_details);
-  const cachedTokens = inputDetails?.cached_tokens;
-
-  return {
-    inputTokens,
-    outputTokens,
-    totalTokens,
-    ...(typeof cachedTokens === "number" ? { cacheReadInputTokens: cachedTokens } : {}),
-  };
-}
-
-function normalizeOpenAIResponsesFinishReason(
-  raw: unknown,
-): string | { unified: string; raw: string } | null {
-  if (typeof raw !== "string") return null;
-  switch (raw) {
-    case "completed":
-      return { unified: "stop", raw };
-    case "incomplete":
-      return { unified: "length", raw };
-    case "failed":
-      return { unified: "error", raw };
-    case "in_progress":
-      return null;
-    default:
-      return raw;
-  }
-}
-
 type OpenAIResponsesContentPart =
   | { type: "text"; text: string }
   | {
@@ -379,175 +335,6 @@ function buildOpenAIResponsesGenerateResult(payload: unknown): {
     content,
     finishReason: normalizeOpenAIResponsesFinishReason(record?.status),
     usage: extractOpenAIResponsesUsage(payload),
-  };
-}
-
-type OpenAIResponsesStreamReasoningState = {
-  id: string;
-  emittedStart: boolean;
-};
-
-type OpenAIResponsesStreamFunctionCallState = {
-  id: string;
-  toolCallId: string;
-  name: string;
-  arguments: string;
-};
-
-/**
- * Parse the Responses API streaming event grammar into the same UI part
- * shapes the existing OpenAI / Anthropic / Google streams emit.
- */
-async function* streamOpenAIResponsesParts(
-  stream: ReadableStream<Uint8Array>,
-): AsyncIterable<unknown> {
-  const decoder = new TextDecoder();
-  let buffer = "";
-  const reasoningBlocks = new Map<string, OpenAIResponsesStreamReasoningState>();
-  const functionCalls = new Map<string, OpenAIResponsesStreamFunctionCallState>();
-  const startedToolCalls = new Set<string>();
-  let finishReason: string | { unified: string; raw: string } | null = null;
-  let usage: RuntimeUsage | undefined;
-  let reasoningCounter = 0;
-
-  for await (const chunk of stream) {
-    buffer += decoder.decode(chunk, { stream: true });
-    const parsed = parseSseChunk(buffer);
-    buffer = parsed.remainder;
-
-    for (const event of parsed.events) {
-      if (event === "[DONE]") continue;
-      const record = readRecord(event);
-      const type = typeof record?.type === "string" ? record.type : undefined;
-      if (!type) continue;
-
-      // response.output_item.added: a new output item begins.
-      if (type === "response.output_item.added") {
-        const item = readRecord(record?.item);
-        const itemType = typeof item?.type === "string" ? item.type : undefined;
-        const itemId = typeof item?.id === "string" ? item.id : undefined;
-        if (itemType === "function_call" && itemId) {
-          const callId = typeof item?.call_id === "string" ? item.call_id : itemId;
-          const name = typeof item?.name === "string" ? item.name : "";
-          functionCalls.set(itemId, {
-            id: itemId,
-            toolCallId: callId,
-            name,
-            arguments: "",
-          });
-        }
-        if (itemType === "reasoning" && itemId) {
-          reasoningBlocks.set(itemId, {
-            id: `reasoning-${reasoningCounter++}`,
-            emittedStart: false,
-          });
-        }
-        continue;
-      }
-
-      // response.output_text.delta: text chunk for a message item.
-      if (type === "response.output_text.delta" && typeof record?.delta === "string") {
-        if (record.delta.length > 0) {
-          yield { type: "text-delta", delta: record.delta };
-        }
-        continue;
-      }
-
-      // response.reasoning_summary_text.delta: reasoning summary text chunk.
-      if (type === "response.reasoning_summary_text.delta" && typeof record?.delta === "string") {
-        const itemId = typeof record?.item_id === "string" ? record.item_id : undefined;
-        const state = itemId ? reasoningBlocks.get(itemId) : undefined;
-        if (state && record.delta.length > 0) {
-          if (!state.emittedStart) {
-            yield { type: "reasoning-start", id: state.id };
-            state.emittedStart = true;
-          }
-          yield { type: "reasoning-delta", id: state.id, delta: record.delta };
-        }
-        continue;
-      }
-
-      // response.function_call_arguments.delta: tool call argument chunk.
-      if (type === "response.function_call_arguments.delta" && typeof record?.delta === "string") {
-        const itemId = typeof record?.item_id === "string" ? record.item_id : undefined;
-        const state = itemId ? functionCalls.get(itemId) : undefined;
-        if (state && record.delta.length > 0) {
-          if (!startedToolCalls.has(state.id)) {
-            yield {
-              type: "tool-input-start",
-              id: state.toolCallId,
-              toolName: state.name,
-            };
-            startedToolCalls.add(state.id);
-          }
-          state.arguments += record.delta;
-          yield {
-            type: "tool-input-delta",
-            id: state.toolCallId,
-            delta: record.delta,
-          };
-        }
-        continue;
-      }
-
-      // response.output_item.done: an item has finished emitting deltas.
-      if (type === "response.output_item.done") {
-        const item = readRecord(record?.item);
-        const itemType = typeof item?.type === "string" ? item.type : undefined;
-        const itemId = typeof item?.id === "string" ? item.id : undefined;
-        if (itemType === "reasoning" && itemId) {
-          const state = reasoningBlocks.get(itemId);
-          if (state?.emittedStart) {
-            yield { type: "reasoning-end", id: state.id };
-          }
-          reasoningBlocks.delete(itemId);
-        }
-        if (itemType === "function_call" && itemId) {
-          const state = functionCalls.get(itemId);
-          if (state) {
-            yield {
-              type: "tool-call",
-              toolCallId: state.toolCallId,
-              toolName: state.name,
-              input: state.arguments,
-            };
-          }
-          functionCalls.delete(itemId);
-        }
-        continue;
-      }
-
-      // response.completed: terminal event with the final response object.
-      if (type === "response.completed") {
-        usage = extractOpenAIResponsesUsage(record) ?? usage;
-        const responseRecord = readRecord(record?.response);
-        finishReason = normalizeOpenAIResponsesFinishReason(responseRecord?.status);
-        continue;
-      }
-
-      if (type === "response.failed" || type === "response.incomplete") {
-        const responseRecord = readRecord(record?.response);
-        finishReason = normalizeOpenAIResponsesFinishReason(responseRecord?.status) ??
-          (type === "response.failed"
-            ? { unified: "error", raw: "failed" }
-            : { unified: "length", raw: "incomplete" });
-        usage = extractOpenAIResponsesUsage(record) ?? usage;
-        continue;
-      }
-    }
-  }
-
-  // Close any reasoning streams still open at end-of-stream (defensive).
-  for (const state of reasoningBlocks.values()) {
-    if (state.emittedStart) {
-      yield { type: "reasoning-end", id: state.id };
-    }
-  }
-
-  yield {
-    type: "finish",
-    finishReason,
-    ...(usage ? { usage } : {}),
   };
 }
 

--- a/extensions/ext-llm-openai/src/openai-responses-stream.test.ts
+++ b/extensions/ext-llm-openai/src/openai-responses-stream.test.ts
@@ -1,0 +1,127 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { streamOpenAIResponsesParts } from "./openai-responses-stream.ts";
+
+function streamFromText(text: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+}
+
+async function collectParts(stream: ReadableStream<Uint8Array>): Promise<unknown[]> {
+  const parts: unknown[] = [];
+  for await (const part of streamOpenAIResponsesParts(stream)) {
+    parts.push(part);
+  }
+  return parts;
+}
+
+function data(payload: unknown): string {
+  return `data: ${JSON.stringify(payload)}\r\n\r\n`;
+}
+
+describe("ext-llm-openai/openai-responses-stream", () => {
+  it("preserves reasoning, text, tool-call assembly, usage, and finish events", async () => {
+    const parts = await collectParts(streamFromText([
+      data({ type: "response.output_item.added", item: { id: "rs_1", type: "reasoning" } }),
+      data({
+        type: "response.reasoning_summary_text.delta",
+        item_id: "rs_1",
+        delta: "Thinking",
+      }),
+      data({ type: "response.output_item.done", item: { id: "rs_1", type: "reasoning" } }),
+      "data: {malformed\r\n\r\n",
+      data({
+        type: "response.output_item.added",
+        item: { id: "fc_1", type: "function_call", call_id: "call_1", name: "lookup" },
+      }),
+      data({
+        type: "response.function_call_arguments.delta",
+        item_id: "fc_1",
+        delta: '{"id":',
+      }),
+      data({
+        type: "response.function_call_arguments.delta",
+        item_id: "fc_1",
+        delta: '"abc"}',
+      }),
+      data({ type: "response.output_item.done", item: { id: "fc_1", type: "function_call" } }),
+      data({
+        type: "response.output_text.delta",
+        item_id: "msg_1",
+        delta: "Done.",
+      }),
+      data({
+        type: "response.completed",
+        response: {
+          status: "completed",
+          usage: {
+            input_tokens: 5,
+            output_tokens: 7,
+            total_tokens: 12,
+            input_tokens_details: { cached_tokens: 3 },
+          },
+        },
+      }),
+      "data: [DONE]\r\n\r\n",
+    ].join("")));
+
+    assertEquals(parts, [
+      { type: "reasoning-start", id: "reasoning-0" },
+      { type: "reasoning-delta", id: "reasoning-0", delta: "Thinking" },
+      { type: "reasoning-end", id: "reasoning-0" },
+      { type: "tool-input-start", id: "call_1", toolName: "lookup" },
+      { type: "tool-input-delta", id: "call_1", delta: '{"id":' },
+      { type: "tool-input-delta", id: "call_1", delta: '"abc"}' },
+      {
+        type: "tool-call",
+        toolCallId: "call_1",
+        toolName: "lookup",
+        input: '{"id":"abc"}',
+      },
+      { type: "text-delta", delta: "Done." },
+      {
+        type: "finish",
+        finishReason: { unified: "stop", raw: "completed" },
+        usage: {
+          inputTokens: 5,
+          outputTokens: 7,
+          totalTokens: 12,
+          cacheReadInputTokens: 3,
+        },
+      },
+    ]);
+  });
+
+  it("normalizes incomplete and failed terminal events", async () => {
+    const incomplete = await collectParts(streamFromText(data({
+      type: "response.incomplete",
+      response: {
+        status: "incomplete",
+        usage: { input_tokens: 2, output_tokens: 3 },
+      },
+    })));
+    const failed = await collectParts(streamFromText(data({
+      type: "response.failed",
+      response: { status: "failed" },
+    })));
+
+    assertEquals(incomplete, [{
+      type: "finish",
+      finishReason: { unified: "length", raw: "incomplete" },
+      usage: {
+        inputTokens: 2,
+        outputTokens: 3,
+        totalTokens: 5,
+      },
+    }]);
+    assertEquals(failed, [{
+      type: "finish",
+      finishReason: { unified: "error", raw: "failed" },
+    }]);
+  });
+});

--- a/extensions/ext-llm-openai/src/openai-responses-stream.ts
+++ b/extensions/ext-llm-openai/src/openai-responses-stream.ts
@@ -1,0 +1,226 @@
+import { parseSseChunk, readRecord } from "veryfront/provider/shared";
+
+type RuntimeUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+};
+
+type OpenAIResponsesStreamReasoningState = {
+  id: string;
+  emittedStart: boolean;
+};
+
+type OpenAIResponsesStreamFunctionCallState = {
+  id: string;
+  toolCallId: string;
+  name: string;
+  arguments: string;
+};
+
+/**
+ * The Responses API uses `input_tokens` / `output_tokens` field names
+ * instead of Chat Completions' `prompt_tokens` / `completion_tokens`.
+ */
+export function extractOpenAIResponsesUsage(payload: unknown): RuntimeUsage | undefined {
+  const record = readRecord(payload);
+  // Streaming usage lives on response.completed inside `response.usage`;
+  // non-streaming has it at the top level.
+  const responseRecord = readRecord(record?.response);
+  const usage = readRecord(responseRecord?.usage) ?? readRecord(record?.usage);
+  if (!usage) return undefined;
+
+  const inputTokens = typeof usage.input_tokens === "number" ? usage.input_tokens : undefined;
+  const outputTokens = typeof usage.output_tokens === "number" ? usage.output_tokens : undefined;
+  const totalTokens = typeof usage.total_tokens === "number"
+    ? usage.total_tokens
+    : (inputTokens !== undefined || outputTokens !== undefined
+      ? (inputTokens ?? 0) + (outputTokens ?? 0)
+      : undefined);
+  const inputDetails = readRecord(usage.input_tokens_details);
+  const cachedTokens = inputDetails?.cached_tokens;
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    ...(typeof cachedTokens === "number" ? { cacheReadInputTokens: cachedTokens } : {}),
+  };
+}
+
+export function normalizeOpenAIResponsesFinishReason(
+  raw: unknown,
+): string | { unified: string; raw: string } | null {
+  if (typeof raw !== "string") return null;
+  switch (raw) {
+    case "completed":
+      return { unified: "stop", raw };
+    case "incomplete":
+      return { unified: "length", raw };
+    case "failed":
+      return { unified: "error", raw };
+    case "in_progress":
+      return null;
+    default:
+      return raw;
+  }
+}
+
+/**
+ * Parse the Responses API streaming event grammar into the same UI part
+ * shapes the existing OpenAI / Anthropic / Google streams emit.
+ */
+export async function* streamOpenAIResponsesParts(
+  stream: ReadableStream<Uint8Array>,
+): AsyncIterable<unknown> {
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const reasoningBlocks = new Map<string, OpenAIResponsesStreamReasoningState>();
+  const functionCalls = new Map<string, OpenAIResponsesStreamFunctionCallState>();
+  const startedToolCalls = new Set<string>();
+  let finishReason: string | { unified: string; raw: string } | null = null;
+  let usage: RuntimeUsage | undefined;
+  let reasoningCounter = 0;
+
+  for await (const chunk of stream) {
+    buffer += decoder.decode(chunk, { stream: true });
+    const parsed = parseSseChunk(buffer);
+    buffer = parsed.remainder;
+
+    for (const event of parsed.events) {
+      if (event === "[DONE]") continue;
+      const record = readRecord(event);
+      const type = typeof record?.type === "string" ? record.type : undefined;
+      if (!type) continue;
+
+      // response.output_item.added: a new output item begins.
+      if (type === "response.output_item.added") {
+        const item = readRecord(record?.item);
+        const itemType = typeof item?.type === "string" ? item.type : undefined;
+        const itemId = typeof item?.id === "string" ? item.id : undefined;
+        if (itemType === "function_call" && itemId) {
+          const callId = typeof item?.call_id === "string" ? item.call_id : itemId;
+          const name = typeof item?.name === "string" ? item.name : "";
+          functionCalls.set(itemId, {
+            id: itemId,
+            toolCallId: callId,
+            name,
+            arguments: "",
+          });
+        }
+        if (itemType === "reasoning" && itemId) {
+          reasoningBlocks.set(itemId, {
+            id: `reasoning-${reasoningCounter++}`,
+            emittedStart: false,
+          });
+        }
+        continue;
+      }
+
+      // response.output_text.delta: text chunk for a message item.
+      if (type === "response.output_text.delta" && typeof record?.delta === "string") {
+        if (record.delta.length > 0) {
+          yield { type: "text-delta", delta: record.delta };
+        }
+        continue;
+      }
+
+      // response.reasoning_summary_text.delta: reasoning summary text chunk.
+      if (type === "response.reasoning_summary_text.delta" && typeof record?.delta === "string") {
+        const itemId = typeof record?.item_id === "string" ? record.item_id : undefined;
+        const state = itemId ? reasoningBlocks.get(itemId) : undefined;
+        if (state && record.delta.length > 0) {
+          if (!state.emittedStart) {
+            yield { type: "reasoning-start", id: state.id };
+            state.emittedStart = true;
+          }
+          yield { type: "reasoning-delta", id: state.id, delta: record.delta };
+        }
+        continue;
+      }
+
+      // response.function_call_arguments.delta: tool call argument chunk.
+      if (type === "response.function_call_arguments.delta" && typeof record?.delta === "string") {
+        const itemId = typeof record?.item_id === "string" ? record.item_id : undefined;
+        const state = itemId ? functionCalls.get(itemId) : undefined;
+        if (state && record.delta.length > 0) {
+          if (!startedToolCalls.has(state.id)) {
+            yield {
+              type: "tool-input-start",
+              id: state.toolCallId,
+              toolName: state.name,
+            };
+            startedToolCalls.add(state.id);
+          }
+          state.arguments += record.delta;
+          yield {
+            type: "tool-input-delta",
+            id: state.toolCallId,
+            delta: record.delta,
+          };
+        }
+        continue;
+      }
+
+      // response.output_item.done: an item has finished emitting deltas.
+      if (type === "response.output_item.done") {
+        const item = readRecord(record?.item);
+        const itemType = typeof item?.type === "string" ? item.type : undefined;
+        const itemId = typeof item?.id === "string" ? item.id : undefined;
+        if (itemType === "reasoning" && itemId) {
+          const state = reasoningBlocks.get(itemId);
+          if (state?.emittedStart) {
+            yield { type: "reasoning-end", id: state.id };
+          }
+          reasoningBlocks.delete(itemId);
+        }
+        if (itemType === "function_call" && itemId) {
+          const state = functionCalls.get(itemId);
+          if (state) {
+            yield {
+              type: "tool-call",
+              toolCallId: state.toolCallId,
+              toolName: state.name,
+              input: state.arguments,
+            };
+          }
+          functionCalls.delete(itemId);
+        }
+        continue;
+      }
+
+      // response.completed: terminal event with the final response object.
+      if (type === "response.completed") {
+        usage = extractOpenAIResponsesUsage(record) ?? usage;
+        const responseRecord = readRecord(record?.response);
+        finishReason = normalizeOpenAIResponsesFinishReason(responseRecord?.status);
+        continue;
+      }
+
+      if (type === "response.failed" || type === "response.incomplete") {
+        const responseRecord = readRecord(record?.response);
+        finishReason = normalizeOpenAIResponsesFinishReason(responseRecord?.status) ??
+          (type === "response.failed"
+            ? { unified: "error", raw: "failed" }
+            : { unified: "length", raw: "incomplete" });
+        usage = extractOpenAIResponsesUsage(record) ?? usage;
+        continue;
+      }
+    }
+  }
+
+  // Close any reasoning streams still open at end-of-stream (defensive).
+  for (const state of reasoningBlocks.values()) {
+    if (state.emittedStart) {
+      yield { type: "reasoning-end", id: state.id };
+    }
+  }
+
+  yield {
+    type: "finish",
+    finishReason,
+    ...(usage ? { usage } : {}),
+  };
+}


### PR DESCRIPTION
## Summary
- extract the OpenAI Responses streaming state machine into a dedicated stream adapter module
- reuse the extracted Responses usage and finish-reason helpers from both streaming and non-streaming result parsing
- add fixture coverage for CRLF SSE framing, malformed event tolerance, [DONE], reasoning, text deltas, multi-chunk function-call arguments, usage, completed, incomplete, and failed terminal events

Advances #1268.

## Verification
- deno test --allow-all extensions/ext-llm-openai/src/openai-responses-stream.test.ts extensions/ext-llm-openai/src/openai-provider.test.ts
- deno fmt --check extensions/ext-llm-openai/src/openai-provider.ts extensions/ext-llm-openai/src/openai-responses-stream.ts extensions/ext-llm-openai/src/openai-responses-stream.test.ts
- DENO_NO_PACKAGE_JSON=1 deno lint extensions/ext-llm-openai/src/openai-provider.ts extensions/ext-llm-openai/src/openai-responses-stream.ts extensions/ext-llm-openai/src/openai-responses-stream.test.ts
- deno task typecheck
- git diff --check
- git push pre-push hook: formatting, lint, typecheck, generated assets, and unit tests: 1903 passed, 0 failed
