### PR TITLE
refactor: split anthropic stream adapter

### DIFF
--- a/extensions/ext-llm-anthropic/src/anthropic-provider.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-provider.ts
@@ -18,7 +18,6 @@ import {
   isNumberArray,
   mergeUsage,
   parseRetryAfterMs,
-  parseSseChunk,
   ProviderError,
   ProviderOverloadedError,
   ProviderQuotaError,
@@ -35,6 +34,11 @@ import {
   buildAnthropicMessagesRequest,
   type OpenAICompatibleLanguageOptions,
 } from "./anthropic-request-builder.ts";
+import {
+  extractAnthropicUsage,
+  normalizeAnthropicFinishReason,
+  streamAnthropicCompatibleParts,
+} from "./anthropic-stream.ts";
 
 export {
   buildProviderError,
@@ -67,66 +71,8 @@ type RuntimeUsage = {
 };
 
 // ---------------------------------------------------------------------------
-// Anthropic-specific types
-// ---------------------------------------------------------------------------
-
-type AnthropicStreamToolCallState = {
-  id: string;
-  name: string;
-  input: string;
-  providerExecuted?: boolean;
-};
-type AnthropicStreamReasoningState = {
-  id: string;
-};
-
-// ---------------------------------------------------------------------------
 // Anthropic helper functions
 // ---------------------------------------------------------------------------
-
-function normalizeAnthropicFinishReason(
-  raw: unknown,
-): string | { unified: string; raw: string } | null {
-  if (typeof raw !== "string") {
-    return null;
-  }
-
-  switch (raw) {
-    case "tool_use":
-      return { unified: "tool-calls", raw };
-    case "end_turn":
-    case "stop_sequence":
-      return { unified: "stop", raw };
-    case "max_tokens":
-      return { unified: "length", raw };
-    default:
-      return raw;
-  }
-}
-
-function extractAnthropicUsage(payload: unknown): RuntimeUsage | undefined {
-  const record = readRecord(payload);
-  const usage = readRecord(record?.usage);
-  if (!usage) {
-    return undefined;
-  }
-
-  const inputTokens = usage.input_tokens;
-  const outputTokens = usage.output_tokens;
-  const cacheCreationInputTokens = usage.cache_creation_input_tokens;
-  const cacheReadInputTokens = usage.cache_read_input_tokens;
-
-  return {
-    inputTokens: typeof inputTokens === "number" ? inputTokens : undefined,
-    outputTokens: typeof outputTokens === "number" ? outputTokens : undefined,
-    totalTokens: typeof inputTokens === "number" || typeof outputTokens === "number"
-      ? (typeof inputTokens === "number" ? inputTokens : 0) +
-        (typeof outputTokens === "number" ? outputTokens : 0)
-      : undefined,
-    ...(typeof cacheCreationInputTokens === "number" ? { cacheCreationInputTokens } : {}),
-    ...(typeof cacheReadInputTokens === "number" ? { cacheReadInputTokens } : {}),
-  };
-}
 
 type AnthropicReasoningContent = {
   type: "reasoning";
@@ -291,247 +237,6 @@ function buildAnthropicGenerateResult(payload: unknown): {
     content: normalized,
     finishReason: normalizeAnthropicFinishReason(record?.stop_reason),
     usage: extractAnthropicUsage(payload),
-  };
-}
-
-async function* streamAnthropicCompatibleParts(
-  stream: ReadableStream<Uint8Array>,
-): AsyncIterable<unknown> {
-  const decoder = new TextDecoder();
-  let buffer = "";
-  const toolCalls = new Map<number, AnthropicStreamToolCallState>();
-  const reasoningBlocks = new Map<number, AnthropicStreamReasoningState>();
-  let finishReason: string | { unified: string; raw: string } | null = null;
-  let usage: RuntimeUsage | undefined;
-
-  for await (const chunk of stream) {
-    buffer += decoder.decode(chunk, { stream: true });
-    const parsed = parseSseChunk(buffer);
-    buffer = parsed.remainder;
-
-    for (const event of parsed.events) {
-      if (event === "[DONE]") {
-        continue;
-      }
-
-      const record = readRecord(event);
-      const eventType = typeof record?.type === "string" ? record.type : undefined;
-      usage = mergeUsage(usage, extractAnthropicUsage(record));
-
-      if (eventType === "message_start") {
-        usage = mergeUsage(usage, extractAnthropicUsage(record?.message));
-        continue;
-      }
-
-      if (eventType === "content_block_start") {
-        const index = typeof record?.index === "number" ? record.index : 0;
-        const contentBlock = readRecord(record?.content_block);
-        const blockType = typeof contentBlock?.type === "string" ? contentBlock.type : undefined;
-
-        if (
-          blockType === "text" && typeof contentBlock?.text === "string" &&
-          contentBlock.text.length > 0
-        ) {
-          yield { type: "text-delta", delta: contentBlock.text };
-          continue;
-        }
-
-        if (blockType === "thinking") {
-          const reasoningId = `thinking-${index}`;
-          reasoningBlocks.set(index, { id: reasoningId });
-          yield {
-            type: "reasoning-start",
-            id: reasoningId,
-          };
-
-          if (typeof contentBlock?.thinking === "string" && contentBlock.thinking.length > 0) {
-            yield {
-              type: "reasoning-delta",
-              id: reasoningId,
-              delta: contentBlock.thinking,
-            };
-          }
-          continue;
-        }
-
-        // Redacted thinking blocks arrive as opaque encrypted payloads when
-        // Claude's safety classifier flags the reasoning trace. Surface them
-        // as a zero-length reasoning block so callers know thinking happened
-        // without leaking the (legitimately hidden) contents.
-        if (blockType === "redacted_thinking") {
-          const reasoningId = `thinking-${index}`;
-          reasoningBlocks.set(index, { id: reasoningId });
-          yield {
-            type: "reasoning-start",
-            id: reasoningId,
-          };
-          continue;
-        }
-
-        if (
-          (blockType === "tool_use" || blockType === "server_tool_use") &&
-          typeof contentBlock?.id === "string" &&
-          typeof contentBlock?.name === "string"
-        ) {
-          const providerExecuted = blockType === "server_tool_use" ? true : undefined;
-          const current: AnthropicStreamToolCallState = {
-            id: contentBlock.id,
-            name: contentBlock.name,
-            input: "",
-            ...(providerExecuted ? { providerExecuted } : {}),
-          };
-
-          toolCalls.set(index, current);
-          yield {
-            type: "tool-input-start",
-            id: current.id,
-            toolName: current.name,
-            ...(providerExecuted ? { providerExecuted } : {}),
-          };
-
-          const initialInput = contentBlock.input;
-          if (initialInput !== undefined) {
-            const serializedInput = stringifyJsonValue(initialInput);
-            current.input += serializedInput;
-            yield {
-              type: "tool-input-delta",
-              id: current.id,
-              delta: serializedInput,
-            };
-          }
-          continue;
-        }
-
-        if (
-          blockType === "web_search_tool_result" &&
-          typeof contentBlock?.tool_use_id === "string" &&
-          Array.isArray(contentBlock?.content)
-        ) {
-          yield {
-            type: "tool-result",
-            toolCallId: contentBlock.tool_use_id,
-            toolName: "web_search",
-            result: contentBlock.content,
-            providerExecuted: true,
-          };
-        }
-
-        if (
-          blockType === "web_fetch_tool_result" &&
-          typeof contentBlock?.tool_use_id === "string" &&
-          readRecord(contentBlock?.content)
-        ) {
-          yield {
-            type: "tool-result",
-            toolCallId: contentBlock.tool_use_id,
-            toolName: "web_fetch",
-            result: contentBlock.content,
-            providerExecuted: true,
-          };
-        }
-
-        continue;
-      }
-
-      if (eventType === "content_block_delta") {
-        const index = typeof record?.index === "number" ? record.index : 0;
-        const delta = readRecord(record?.delta);
-        const deltaType = typeof delta?.type === "string" ? delta.type : undefined;
-
-        if (
-          deltaType === "text_delta" && typeof delta?.text === "string" && delta.text.length > 0
-        ) {
-          yield { type: "text-delta", delta: delta.text };
-          continue;
-        }
-
-        if (
-          deltaType === "thinking_delta" && typeof delta?.thinking === "string" &&
-          delta.thinking.length > 0
-        ) {
-          const current = reasoningBlocks.get(index);
-          if (!current) {
-            continue;
-          }
-
-          yield {
-            type: "reasoning-delta",
-            id: current.id,
-            delta: delta.thinking,
-          };
-          continue;
-        }
-
-        if (deltaType === "input_json_delta" && typeof delta?.partial_json === "string") {
-          const current = toolCalls.get(index);
-          if (!current) {
-            continue;
-          }
-
-          current.input += delta.partial_json;
-          yield {
-            type: "tool-input-delta",
-            id: current.id,
-            delta: delta.partial_json,
-          };
-        }
-
-        continue;
-      }
-
-      if (eventType === "content_block_stop") {
-        const index = typeof record?.index === "number" ? record.index : 0;
-        const reasoning = reasoningBlocks.get(index);
-        if (reasoning) {
-          yield {
-            type: "reasoning-end",
-            id: reasoning.id,
-          };
-          reasoningBlocks.delete(index);
-          continue;
-        }
-
-        const current = toolCalls.get(index);
-        if (!current) {
-          continue;
-        }
-
-        yield {
-          type: "tool-call",
-          toolCallId: current.id,
-          toolName: current.name,
-          input: current.input.length > 0 ? current.input : "{}",
-          ...(current.providerExecuted ? { providerExecuted: true } : {}),
-        };
-        toolCalls.delete(index);
-        continue;
-      }
-
-      if (eventType === "message_delta") {
-        const delta = readRecord(record?.delta);
-        const normalizedFinishReason = normalizeAnthropicFinishReason(delta?.stop_reason);
-        if (normalizedFinishReason) {
-          finishReason = normalizedFinishReason;
-        }
-      }
-    }
-  }
-
-  if (buffer.trim().length > 0) {
-    const parsed = parseSseChunk(`${buffer}\n\n`);
-    for (const event of parsed.events) {
-      if (event === "[DONE]") {
-        continue;
-      }
-      const record = readRecord(event);
-      usage = mergeUsage(usage, extractAnthropicUsage(record));
-    }
-  }
-
-  yield {
-    type: "finish",
-    finishReason,
-    ...(usage ? { usage } : {}),
   };
 }
 

--- a/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
@@ -1,0 +1,121 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { streamAnthropicCompatibleParts } from "./anthropic-stream.ts";
+
+function streamFromText(text: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+}
+
+async function collectParts(stream: ReadableStream<Uint8Array>): Promise<unknown[]> {
+  const parts: unknown[] = [];
+  for await (const part of streamAnthropicCompatibleParts(stream)) {
+    parts.push(part);
+  }
+  return parts;
+}
+
+function data(payload: unknown): string {
+  return `event: ${(payload as { type: string }).type}\r\ndata: ${JSON.stringify(payload)}\r\n\r\n`;
+}
+
+describe("ext-llm-anthropic/anthropic-stream", () => {
+  it("preserves thinking, text, tool-call assembly, usage, and finish events", async () => {
+    const parts = await collectParts(streamFromText([
+      data({
+        type: "message_start",
+        message: {
+          usage: {
+            input_tokens: 8,
+            cache_creation_input_tokens: 2,
+            cache_read_input_tokens: 3,
+          },
+        },
+      }),
+      data({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "thinking", thinking: "Think" },
+      }),
+      data({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "thinking_delta", thinking: " more" },
+      }),
+      data({ type: "content_block_stop", index: 0 }),
+      "data: {malformed\r\n\r\n",
+      data({
+        type: "content_block_start",
+        index: 1,
+        content_block: { type: "tool_use", id: "toolu_1", name: "lookup", input: { id: 1 } },
+      }),
+      data({
+        type: "content_block_delta",
+        index: 1,
+        delta: { type: "input_json_delta", partial_json: ', "next": true' },
+      }),
+      data({ type: "content_block_stop", index: 1 }),
+      data({
+        type: "content_block_delta",
+        index: 2,
+        delta: { type: "text_delta", text: "Done." },
+      }),
+      data({
+        type: "message_delta",
+        delta: { stop_reason: "tool_use" },
+        usage: { output_tokens: 5 },
+      }),
+      "data: [DONE]\r\n\r\n",
+    ].join("")));
+
+    assertEquals(parts, [
+      { type: "reasoning-start", id: "thinking-0" },
+      { type: "reasoning-delta", id: "thinking-0", delta: "Think" },
+      { type: "reasoning-delta", id: "thinking-0", delta: " more" },
+      { type: "reasoning-end", id: "thinking-0" },
+      { type: "tool-input-start", id: "toolu_1", toolName: "lookup" },
+      { type: "tool-input-delta", id: "toolu_1", delta: '{"id":1}' },
+      { type: "tool-input-delta", id: "toolu_1", delta: ', "next": true' },
+      {
+        type: "tool-call",
+        toolCallId: "toolu_1",
+        toolName: "lookup",
+        input: '{"id":1}, "next": true',
+      },
+      { type: "text-delta", delta: "Done." },
+      {
+        type: "finish",
+        finishReason: { unified: "tool-calls", raw: "tool_use" },
+        usage: {
+          inputTokens: 8,
+          outputTokens: 5,
+          totalTokens: 13,
+          cacheCreationInputTokens: 2,
+          cacheReadInputTokens: 3,
+        },
+      },
+    ]);
+  });
+
+  it("emits zero-length reasoning blocks for redacted thinking", async () => {
+    const parts = await collectParts(streamFromText([
+      data({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "redacted_thinking", data: "encrypted" },
+      }),
+      data({ type: "content_block_stop", index: 0 }),
+    ].join("")));
+
+    assertEquals(parts, [
+      { type: "reasoning-start", id: "thinking-0" },
+      { type: "reasoning-end", id: "thinking-0" },
+      { type: "finish", finishReason: null },
+    ]);
+  });
+});

--- a/extensions/ext-llm-anthropic/src/anthropic-stream.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.ts
@@ -1,0 +1,310 @@
+import {
+  mergeUsage,
+  parseSseChunk,
+  readRecord,
+  stringifyJsonValue,
+} from "veryfront/provider/shared";
+
+type RuntimeUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+};
+
+type AnthropicStreamToolCallState = {
+  id: string;
+  name: string;
+  input: string;
+  providerExecuted?: boolean;
+};
+
+type AnthropicStreamReasoningState = {
+  id: string;
+};
+
+export function normalizeAnthropicFinishReason(
+  raw: unknown,
+): string | { unified: string; raw: string } | null {
+  if (typeof raw !== "string") {
+    return null;
+  }
+
+  switch (raw) {
+    case "tool_use":
+      return { unified: "tool-calls", raw };
+    case "end_turn":
+    case "stop_sequence":
+      return { unified: "stop", raw };
+    case "max_tokens":
+      return { unified: "length", raw };
+    default:
+      return raw;
+  }
+}
+
+export function extractAnthropicUsage(payload: unknown): RuntimeUsage | undefined {
+  const record = readRecord(payload);
+  const usage = readRecord(record?.usage);
+  if (!usage) {
+    return undefined;
+  }
+
+  const inputTokens = usage.input_tokens;
+  const outputTokens = usage.output_tokens;
+  const cacheCreationInputTokens = usage.cache_creation_input_tokens;
+  const cacheReadInputTokens = usage.cache_read_input_tokens;
+
+  return {
+    inputTokens: typeof inputTokens === "number" ? inputTokens : undefined,
+    outputTokens: typeof outputTokens === "number" ? outputTokens : undefined,
+    totalTokens: typeof inputTokens === "number" || typeof outputTokens === "number"
+      ? (typeof inputTokens === "number" ? inputTokens : 0) +
+        (typeof outputTokens === "number" ? outputTokens : 0)
+      : undefined,
+    ...(typeof cacheCreationInputTokens === "number" ? { cacheCreationInputTokens } : {}),
+    ...(typeof cacheReadInputTokens === "number" ? { cacheReadInputTokens } : {}),
+  };
+}
+
+export async function* streamAnthropicCompatibleParts(
+  stream: ReadableStream<Uint8Array>,
+): AsyncIterable<unknown> {
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const toolCalls = new Map<number, AnthropicStreamToolCallState>();
+  const reasoningBlocks = new Map<number, AnthropicStreamReasoningState>();
+  let finishReason: string | { unified: string; raw: string } | null = null;
+  let usage: RuntimeUsage | undefined;
+
+  for await (const chunk of stream) {
+    buffer += decoder.decode(chunk, { stream: true });
+    const parsed = parseSseChunk(buffer);
+    buffer = parsed.remainder;
+
+    for (const event of parsed.events) {
+      if (event === "[DONE]") {
+        continue;
+      }
+
+      const record = readRecord(event);
+      const eventType = typeof record?.type === "string" ? record.type : undefined;
+      usage = mergeUsage(usage, extractAnthropicUsage(record));
+
+      if (eventType === "message_start") {
+        usage = mergeUsage(usage, extractAnthropicUsage(record?.message));
+        continue;
+      }
+
+      if (eventType === "content_block_start") {
+        const index = typeof record?.index === "number" ? record.index : 0;
+        const contentBlock = readRecord(record?.content_block);
+        const blockType = typeof contentBlock?.type === "string" ? contentBlock.type : undefined;
+
+        if (
+          blockType === "text" && typeof contentBlock?.text === "string" &&
+          contentBlock.text.length > 0
+        ) {
+          yield { type: "text-delta", delta: contentBlock.text };
+          continue;
+        }
+
+        if (blockType === "thinking") {
+          const reasoningId = `thinking-${index}`;
+          reasoningBlocks.set(index, { id: reasoningId });
+          yield {
+            type: "reasoning-start",
+            id: reasoningId,
+          };
+
+          if (typeof contentBlock?.thinking === "string" && contentBlock.thinking.length > 0) {
+            yield {
+              type: "reasoning-delta",
+              id: reasoningId,
+              delta: contentBlock.thinking,
+            };
+          }
+          continue;
+        }
+
+        // Redacted thinking blocks arrive as opaque encrypted payloads when
+        // Claude's safety classifier flags the reasoning trace. Surface them
+        // as a zero-length reasoning block so callers know thinking happened
+        // without leaking the (legitimately hidden) contents.
+        if (blockType === "redacted_thinking") {
+          const reasoningId = `thinking-${index}`;
+          reasoningBlocks.set(index, { id: reasoningId });
+          yield {
+            type: "reasoning-start",
+            id: reasoningId,
+          };
+          continue;
+        }
+
+        if (
+          (blockType === "tool_use" || blockType === "server_tool_use") &&
+          typeof contentBlock?.id === "string" &&
+          typeof contentBlock?.name === "string"
+        ) {
+          const providerExecuted = blockType === "server_tool_use" ? true : undefined;
+          const current: AnthropicStreamToolCallState = {
+            id: contentBlock.id,
+            name: contentBlock.name,
+            input: "",
+            ...(providerExecuted ? { providerExecuted } : {}),
+          };
+
+          toolCalls.set(index, current);
+          yield {
+            type: "tool-input-start",
+            id: current.id,
+            toolName: current.name,
+            ...(providerExecuted ? { providerExecuted } : {}),
+          };
+
+          const initialInput = contentBlock.input;
+          if (initialInput !== undefined) {
+            const serializedInput = stringifyJsonValue(initialInput);
+            current.input += serializedInput;
+            yield {
+              type: "tool-input-delta",
+              id: current.id,
+              delta: serializedInput,
+            };
+          }
+          continue;
+        }
+
+        if (
+          blockType === "web_search_tool_result" &&
+          typeof contentBlock?.tool_use_id === "string" &&
+          Array.isArray(contentBlock?.content)
+        ) {
+          yield {
+            type: "tool-result",
+            toolCallId: contentBlock.tool_use_id,
+            toolName: "web_search",
+            result: contentBlock.content,
+            providerExecuted: true,
+          };
+        }
+
+        if (
+          blockType === "web_fetch_tool_result" &&
+          typeof contentBlock?.tool_use_id === "string" &&
+          readRecord(contentBlock?.content)
+        ) {
+          yield {
+            type: "tool-result",
+            toolCallId: contentBlock.tool_use_id,
+            toolName: "web_fetch",
+            result: contentBlock.content,
+            providerExecuted: true,
+          };
+        }
+
+        continue;
+      }
+
+      if (eventType === "content_block_delta") {
+        const index = typeof record?.index === "number" ? record.index : 0;
+        const delta = readRecord(record?.delta);
+        const deltaType = typeof delta?.type === "string" ? delta.type : undefined;
+
+        if (
+          deltaType === "text_delta" && typeof delta?.text === "string" && delta.text.length > 0
+        ) {
+          yield { type: "text-delta", delta: delta.text };
+          continue;
+        }
+
+        if (
+          deltaType === "thinking_delta" && typeof delta?.thinking === "string" &&
+          delta.thinking.length > 0
+        ) {
+          const current = reasoningBlocks.get(index);
+          if (!current) {
+            continue;
+          }
+
+          yield {
+            type: "reasoning-delta",
+            id: current.id,
+            delta: delta.thinking,
+          };
+          continue;
+        }
+
+        if (deltaType === "input_json_delta" && typeof delta?.partial_json === "string") {
+          const current = toolCalls.get(index);
+          if (!current) {
+            continue;
+          }
+
+          current.input += delta.partial_json;
+          yield {
+            type: "tool-input-delta",
+            id: current.id,
+            delta: delta.partial_json,
+          };
+        }
+
+        continue;
+      }
+
+      if (eventType === "content_block_stop") {
+        const index = typeof record?.index === "number" ? record.index : 0;
+        const reasoning = reasoningBlocks.get(index);
+        if (reasoning) {
+          yield {
+            type: "reasoning-end",
+            id: reasoning.id,
+          };
+          reasoningBlocks.delete(index);
+          continue;
+        }
+
+        const current = toolCalls.get(index);
+        if (!current) {
+          continue;
+        }
+
+        yield {
+          type: "tool-call",
+          toolCallId: current.id,
+          toolName: current.name,
+          input: current.input.length > 0 ? current.input : "{}",
+          ...(current.providerExecuted ? { providerExecuted: true } : {}),
+        };
+        toolCalls.delete(index);
+        continue;
+      }
+
+      if (eventType === "message_delta") {
+        const delta = readRecord(record?.delta);
+        const normalizedFinishReason = normalizeAnthropicFinishReason(delta?.stop_reason);
+        if (normalizedFinishReason) {
+          finishReason = normalizedFinishReason;
+        }
+      }
+    }
+  }
+
+  if (buffer.trim().length > 0) {
+    const parsed = parseSseChunk(`${buffer}\n\n`);
+    for (const event of parsed.events) {
+      if (event === "[DONE]") {
+        continue;
+      }
+      const record = readRecord(event);
+      usage = mergeUsage(usage, extractAnthropicUsage(record));
+    }
+  }
+
+  yield {
+    type: "finish",
+    finishReason,
+    ...(usage ? { usage } : {}),
+  };
+}


### PR DESCRIPTION
## Summary
- extract the Anthropic streaming state machine into a dedicated stream adapter module
- reuse the extracted Anthropic usage and finish-reason helpers from streaming and non-streaming result parsing
- add fixture coverage for CRLF SSE framing, malformed event tolerance, [DONE], thinking, redacted thinking, text deltas, multi-chunk tool input assembly, usage, and finish normalization

Advances #1268.

## Verification
- deno test --allow-all extensions/ext-llm-anthropic/src/anthropic-stream.test.ts extensions/ext-llm-anthropic/src/anthropic-provider.test.ts
- deno fmt --check extensions/ext-llm-anthropic/src/anthropic-provider.ts extensions/ext-llm-anthropic/src/anthropic-stream.ts extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
- DENO_NO_PACKAGE_JSON=1 deno lint extensions/ext-llm-anthropic/src/anthropic-provider.ts extensions/ext-llm-anthropic/src/anthropic-stream.ts extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
- deno task typecheck
- git diff --check
- git push pre-push hook: formatting, lint, typecheck, generated assets, and unit tests: 1903 passed, 0 failed
