### PR TITLE
refactor: split google stream adapter

### DIFF
--- a/extensions/ext-llm-google/src/google-provider.ts
+++ b/extensions/ext-llm-google/src/google-provider.ts
@@ -38,6 +38,13 @@ import {
   buildGoogleGenerateContentRequest,
   type OpenAICompatibleLanguageOptions,
 } from "./google-request-builder.ts";
+import {
+  extractFirstGoogleCandidate,
+  extractGoogleCandidateParts,
+  extractGoogleUsage,
+  normalizeGoogleFinishReason,
+  streamGoogleCompatibleParts,
+} from "./google-stream.ts";
 
 // Re-export error classes so extension tests can import them from this module
 // and from `veryfront/provider/shared` interchangeably.
@@ -100,72 +107,6 @@ function extractGoogleUsageTokens(payload: unknown): number | undefined {
   return typeof promptTokenCount === "number" ? promptTokenCount : undefined;
 }
 
-function normalizeGoogleFinishReason(
-  raw: unknown,
-): string | { unified: string; raw: string } | null {
-  if (typeof raw !== "string") {
-    return null;
-  }
-
-  switch (raw) {
-    case "STOP":
-      return { unified: "stop", raw };
-    case "MAX_TOKENS":
-      return { unified: "length", raw };
-    case "SAFETY":
-    case "RECITATION":
-      return { unified: "content-filter", raw };
-    default:
-      return raw.toLowerCase();
-  }
-}
-
-function extractGoogleUsage(payload: unknown): RuntimeUsage | undefined {
-  const record = readRecord(payload);
-  const usage = readRecord(record?.usageMetadata);
-  if (!usage) {
-    return undefined;
-  }
-
-  const inputTokens = usage.promptTokenCount;
-  const outputTokens = usage.candidatesTokenCount;
-  const totalTokens = usage.totalTokenCount;
-  const cachedContentTokenCount = usage.cachedContentTokenCount;
-
-  return {
-    inputTokens: typeof inputTokens === "number" ? inputTokens : undefined,
-    outputTokens: typeof outputTokens === "number" ? outputTokens : undefined,
-    totalTokens: typeof totalTokens === "number" ? totalTokens : undefined,
-    ...(typeof cachedContentTokenCount === "number"
-      ? { cacheReadInputTokens: cachedContentTokenCount }
-      : {}),
-  };
-}
-
-function extractFirstGoogleCandidate(payload: unknown): Record<string, unknown> | undefined {
-  const record = readRecord(payload);
-  const candidates = record?.candidates;
-  if (!Array.isArray(candidates) || candidates.length === 0) {
-    return undefined;
-  }
-
-  return readRecord(candidates[0]);
-}
-
-function extractGoogleCandidateParts(payload: unknown): Array<Record<string, unknown>> {
-  const candidate = extractFirstGoogleCandidate(payload);
-  const content = readRecord(candidate?.content);
-  const parts = content?.parts;
-  if (!Array.isArray(parts)) {
-    return [];
-  }
-
-  return parts.flatMap((part) => {
-    const record = readRecord(part);
-    return record ? [record] : [];
-  });
-}
-
 function buildGoogleGenerateResult(payload: unknown): {
   content: Array<
     | { type: "text"; text: string }
@@ -211,122 +152,6 @@ function buildGoogleGenerateResult(payload: unknown): {
     finishReason: normalizeGoogleFinishReason(candidate?.finishReason),
     usage: extractGoogleUsage(payload),
     ...(groundingMetadata ? { groundingMetadata } : {}),
-  };
-}
-
-async function* streamGoogleCompatibleParts(
-  stream: ReadableStream<Uint8Array>,
-): AsyncIterable<unknown> {
-  const decoder = new TextDecoder();
-  let buffer = "";
-  const seenToolCalls = new Set<string>();
-  let reasoningId: string | null = null;
-  let reasoningIndex = 0;
-  let finishReason: string | { unified: string; raw: string } | null = null;
-  let usage: RuntimeUsage | undefined;
-
-  for await (const chunk of stream) {
-    buffer += decoder.decode(chunk, { stream: true });
-    const parsed = parseSseChunk(buffer);
-    buffer = parsed.remainder;
-
-    for (const event of parsed.events) {
-      if (event === "[DONE]") {
-        continue;
-      }
-
-      usage = extractGoogleUsage(event) ?? usage;
-      const candidate = extractFirstGoogleCandidate(event);
-      const normalizedFinishReason = normalizeGoogleFinishReason(candidate?.finishReason);
-      if (normalizedFinishReason) {
-        finishReason = normalizedFinishReason;
-      }
-
-      for (const [index, part] of extractGoogleCandidateParts(event).entries()) {
-        const isThought = part.thought === true;
-        if (isThought && typeof part.text === "string" && part.text.length > 0) {
-          if (!reasoningId) {
-            reasoningId = `reasoning-${reasoningIndex++}`;
-            yield {
-              type: "reasoning-start",
-              id: reasoningId,
-            };
-          }
-
-          yield {
-            type: "reasoning-delta",
-            id: reasoningId,
-            delta: part.text,
-          };
-          continue;
-        }
-
-        if (reasoningId) {
-          yield {
-            type: "reasoning-end",
-            id: reasoningId,
-          };
-          reasoningId = null;
-        }
-
-        if (typeof part.text === "string" && part.text.length > 0) {
-          yield { type: "text-delta", delta: part.text };
-          continue;
-        }
-
-        const functionCall = readRecord(part.functionCall);
-        if (typeof functionCall?.name !== "string") {
-          continue;
-        }
-
-        const toolCallId = typeof functionCall.id === "string" ? functionCall.id : `tool-${index}`;
-        if (seenToolCalls.has(toolCallId)) {
-          continue;
-        }
-
-        const serializedInput = stringifyJsonValue(functionCall.args ?? {});
-        seenToolCalls.add(toolCallId);
-        yield {
-          type: "tool-input-start",
-          id: toolCallId,
-          toolName: functionCall.name,
-        };
-        yield {
-          type: "tool-input-delta",
-          id: toolCallId,
-          delta: serializedInput,
-        };
-        yield {
-          type: "tool-call",
-          toolCallId,
-          toolName: functionCall.name,
-          input: serializedInput,
-        };
-      }
-    }
-  }
-
-  if (buffer.trim().length > 0) {
-    const parsed = parseSseChunk(`${buffer}\n\n`);
-    for (const event of parsed.events) {
-      if (event === "[DONE]") {
-        continue;
-      }
-      usage = extractGoogleUsage(event) ?? usage;
-    }
-  }
-
-  if (reasoningId) {
-    yield {
-      type: "reasoning-end",
-      id: reasoningId,
-    };
-  }
-
-  yield {
-    type: "finish",
-    finishReason,
-    ...(usage ? { usage } : {}),
   };
 }
 

--- a/extensions/ext-llm-google/src/google-stream.test.ts
+++ b/extensions/ext-llm-google/src/google-stream.test.ts
@@ -1,0 +1,124 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { streamGoogleCompatibleParts } from "./google-stream.ts";
+
+function streamFromText(text: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+}
+
+async function collectParts(stream: ReadableStream<Uint8Array>): Promise<unknown[]> {
+  const parts: unknown[] = [];
+  for await (const part of streamGoogleCompatibleParts(stream)) {
+    parts.push(part);
+  }
+  return parts;
+}
+
+function data(payload: unknown): string {
+  return `data: ${JSON.stringify(payload)}\r\n\r\n`;
+}
+
+describe("ext-llm-google/google-stream", () => {
+  it("preserves thought, text, tool-call, usage, and finish events", async () => {
+    const parts = await collectParts(streamFromText([
+      data({
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ text: "Think", thought: true }],
+          },
+        }],
+      }),
+      data({
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ text: "Done." }],
+          },
+        }],
+      }),
+      "data: {malformed\r\n\r\n",
+      data({
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ functionCall: { id: "tool_1", name: "lookup", args: { id: "abc" } } }],
+          },
+        }],
+      }),
+      data({
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ functionCall: { id: "tool_1", name: "lookup", args: { id: "abc" } } }],
+          },
+        }],
+      }),
+      data({
+        candidates: [{ finishReason: "STOP" }],
+        usageMetadata: {
+          promptTokenCount: 5,
+          candidatesTokenCount: 7,
+          totalTokenCount: 12,
+          cachedContentTokenCount: 3,
+        },
+      }),
+      "data: [DONE]\r\n\r\n",
+    ].join("")));
+
+    assertEquals(parts, [
+      { type: "reasoning-start", id: "reasoning-0" },
+      { type: "reasoning-delta", id: "reasoning-0", delta: "Think" },
+      { type: "reasoning-end", id: "reasoning-0" },
+      { type: "text-delta", delta: "Done." },
+      { type: "tool-input-start", id: "tool_1", toolName: "lookup" },
+      { type: "tool-input-delta", id: "tool_1", delta: '{"id":"abc"}' },
+      {
+        type: "tool-call",
+        toolCallId: "tool_1",
+        toolName: "lookup",
+        input: '{"id":"abc"}',
+      },
+      {
+        type: "finish",
+        finishReason: { unified: "stop", raw: "STOP" },
+        usage: {
+          inputTokens: 5,
+          outputTokens: 7,
+          totalTokens: 12,
+          cacheReadInputTokens: 3,
+        },
+      },
+    ]);
+  });
+
+  it("flushes trailing buffered usage records without a final delimiter", async () => {
+    const parts = await collectParts(streamFromText(
+      `data: ${
+        JSON.stringify({
+          usageMetadata: {
+            promptTokenCount: 1,
+            candidatesTokenCount: 2,
+            totalTokenCount: 3,
+          },
+        })
+      }`,
+    ));
+
+    assertEquals(parts, [{
+      type: "finish",
+      finishReason: null,
+      usage: {
+        inputTokens: 1,
+        outputTokens: 2,
+        totalTokens: 3,
+      },
+    }]);
+  });
+});

--- a/extensions/ext-llm-google/src/google-stream.ts
+++ b/extensions/ext-llm-google/src/google-stream.ts
@@ -1,0 +1,188 @@
+import {
+  parseSseChunk,
+  readRecord,
+  type RuntimeUsage,
+  stringifyJsonValue,
+} from "veryfront/provider/shared";
+
+export function normalizeGoogleFinishReason(
+  raw: unknown,
+): string | { unified: string; raw: string } | null {
+  if (typeof raw !== "string") {
+    return null;
+  }
+
+  switch (raw) {
+    case "STOP":
+      return { unified: "stop", raw };
+    case "MAX_TOKENS":
+      return { unified: "length", raw };
+    case "SAFETY":
+    case "RECITATION":
+      return { unified: "content-filter", raw };
+    default:
+      return raw.toLowerCase();
+  }
+}
+
+export function extractGoogleUsage(payload: unknown): RuntimeUsage | undefined {
+  const record = readRecord(payload);
+  const usage = readRecord(record?.usageMetadata);
+  if (!usage) {
+    return undefined;
+  }
+
+  const inputTokens = usage.promptTokenCount;
+  const outputTokens = usage.candidatesTokenCount;
+  const totalTokens = usage.totalTokenCount;
+  const cachedContentTokenCount = usage.cachedContentTokenCount;
+
+  return {
+    inputTokens: typeof inputTokens === "number" ? inputTokens : undefined,
+    outputTokens: typeof outputTokens === "number" ? outputTokens : undefined,
+    totalTokens: typeof totalTokens === "number" ? totalTokens : undefined,
+    ...(typeof cachedContentTokenCount === "number"
+      ? { cacheReadInputTokens: cachedContentTokenCount }
+      : {}),
+  };
+}
+
+export function extractFirstGoogleCandidate(payload: unknown): Record<string, unknown> | undefined {
+  const record = readRecord(payload);
+  const candidates = record?.candidates;
+  if (!Array.isArray(candidates) || candidates.length === 0) {
+    return undefined;
+  }
+
+  return readRecord(candidates[0]);
+}
+
+export function extractGoogleCandidateParts(payload: unknown): Array<Record<string, unknown>> {
+  const candidate = extractFirstGoogleCandidate(payload);
+  const content = readRecord(candidate?.content);
+  const parts = content?.parts;
+  if (!Array.isArray(parts)) {
+    return [];
+  }
+
+  return parts.flatMap((part) => {
+    const record = readRecord(part);
+    return record ? [record] : [];
+  });
+}
+
+export async function* streamGoogleCompatibleParts(
+  stream: ReadableStream<Uint8Array>,
+): AsyncIterable<unknown> {
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const seenToolCalls = new Set<string>();
+  let reasoningId: string | null = null;
+  let reasoningIndex = 0;
+  let finishReason: string | { unified: string; raw: string } | null = null;
+  let usage: RuntimeUsage | undefined;
+
+  for await (const chunk of stream) {
+    buffer += decoder.decode(chunk, { stream: true });
+    const parsed = parseSseChunk(buffer);
+    buffer = parsed.remainder;
+
+    for (const event of parsed.events) {
+      if (event === "[DONE]") {
+        continue;
+      }
+
+      usage = extractGoogleUsage(event) ?? usage;
+      const candidate = extractFirstGoogleCandidate(event);
+      const normalizedFinishReason = normalizeGoogleFinishReason(candidate?.finishReason);
+      if (normalizedFinishReason) {
+        finishReason = normalizedFinishReason;
+      }
+
+      for (const [index, part] of extractGoogleCandidateParts(event).entries()) {
+        const isThought = part.thought === true;
+        if (isThought && typeof part.text === "string" && part.text.length > 0) {
+          if (!reasoningId) {
+            reasoningId = `reasoning-${reasoningIndex++}`;
+            yield {
+              type: "reasoning-start",
+              id: reasoningId,
+            };
+          }
+
+          yield {
+            type: "reasoning-delta",
+            id: reasoningId,
+            delta: part.text,
+          };
+          continue;
+        }
+
+        if (reasoningId) {
+          yield {
+            type: "reasoning-end",
+            id: reasoningId,
+          };
+          reasoningId = null;
+        }
+
+        if (typeof part.text === "string" && part.text.length > 0) {
+          yield { type: "text-delta", delta: part.text };
+          continue;
+        }
+
+        const functionCall = readRecord(part.functionCall);
+        if (typeof functionCall?.name !== "string") {
+          continue;
+        }
+
+        const toolCallId = typeof functionCall.id === "string" ? functionCall.id : `tool-${index}`;
+        if (seenToolCalls.has(toolCallId)) {
+          continue;
+        }
+
+        const serializedInput = stringifyJsonValue(functionCall.args ?? {});
+        seenToolCalls.add(toolCallId);
+        yield {
+          type: "tool-input-start",
+          id: toolCallId,
+          toolName: functionCall.name,
+        };
+        yield {
+          type: "tool-input-delta",
+          id: toolCallId,
+          delta: serializedInput,
+        };
+        yield {
+          type: "tool-call",
+          toolCallId,
+          toolName: functionCall.name,
+          input: serializedInput,
+        };
+      }
+    }
+  }
+
+  if (buffer.trim().length > 0) {
+    const parsed = parseSseChunk(`${buffer}\n\n`);
+    for (const event of parsed.events) {
+      if (event === "[DONE]") {
+        continue;
+      }
+      usage = extractGoogleUsage(event) ?? usage;
+    }
+  }
+
+  if (reasoningId) {
+    yield {
+      type: "reasoning-end",
+      id: reasoningId,
+    };
+  }
+
+  yield {
+    type: "finish",
+    finishReason,
+    ...(usage ? { usage } : {}),
+  };
+}

--- a/src/agent/project-agent-runtime.test.ts
+++ b/src/agent/project-agent-runtime.test.ts
@@ -118,60 +118,68 @@ Deno.test("discoverProjectAgentRuntime clears stale runtime registries before re
   });
 });
 
-Deno.test("discoverProjectAgentRuntime discovers configured project agent paths", async () => {
-  await withTempDir(async (rootDir) => {
-    const agentsDir = resolve(rootDir, "crew");
-    const toolsDir = resolve(rootDir, "toolbox");
-    Deno.mkdirSync(agentsDir, { recursive: true });
-    Deno.mkdirSync(toolsDir, { recursive: true });
-    Deno.writeTextFileSync(
-      resolve(agentsDir, "support.md"),
-      `---
+Deno.test({
+  name: "discoverProjectAgentRuntime discovers configured project agent paths",
+  // Code primitive discovery invokes the esbuild-backed transpiler, which starts
+  // an esbuild child process. This matches the sanitizer policy in the other
+  // discovery tests that import TypeScript project primitives.
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withTempDir(async (rootDir) => {
+      const agentsDir = resolve(rootDir, "crew");
+      const toolsDir = resolve(rootDir, "toolbox");
+      Deno.mkdirSync(agentsDir, { recursive: true });
+      Deno.mkdirSync(toolsDir, { recursive: true });
+      Deno.writeTextFileSync(
+        resolve(agentsDir, "support.md"),
+        `---
 name: Support
 model: openai/gpt-5.4
 ---
 
 Help from configured markdown.
 `,
-    );
-    Deno.writeTextFileSync(
-      resolve(toolsDir, "echo.ts"),
-      [
-        'import { tool } from "veryfront/tool";',
-        'import { defineSchema } from "veryfront/schemas";',
-        "",
-        "export default tool({",
-        '  id: "echo",',
-        '  description: "Echo input",',
-        "  inputSchema: defineSchema((v) => v.object({ text: v.string() }))(),",
-        "  execute: ({ text }) => ({ text }),",
-        "});",
-        "",
-      ].join("\n"),
-    );
-    Deno.writeTextFileSync(
-      resolve(rootDir, "veryfront.config.ts"),
-      [
-        "export default {",
-        "  ai: {",
-        '    agents: { discovery: { paths: ["crew"] } },',
-        '    tools: { discovery: { paths: ["toolbox"] } },',
-        "  },",
-        "};",
-        "",
-      ].join("\n"),
-    );
+      );
+      Deno.writeTextFileSync(
+        resolve(toolsDir, "echo.ts"),
+        [
+          'import { tool } from "veryfront/tool";',
+          'import { defineSchema } from "veryfront/schemas";',
+          "",
+          "export default tool({",
+          '  id: "echo",',
+          '  description: "Echo input",',
+          "  inputSchema: defineSchema((v) => v.object({ text: v.string() }))(),",
+          "  execute: ({ text }) => ({ text }),",
+          "});",
+          "",
+        ].join("\n"),
+      );
+      Deno.writeTextFileSync(
+        resolve(rootDir, "veryfront.config.ts"),
+        [
+          "export default {",
+          "  ai: {",
+          '    agents: { discovery: { paths: ["crew"] } },',
+          '    tools: { discovery: { paths: ["toolbox"] } },',
+          "  },",
+          "};",
+          "",
+        ].join("\n"),
+      );
 
-    const result = await discoverProjectAgentRuntime({
-      projectDir: rootDir,
-      adapter: nodeAdapter,
-    });
+      const result = await discoverProjectAgentRuntime({
+        projectDir: rootDir,
+        adapter: nodeAdapter,
+      });
 
-    assertEquals([...result.agents.keys()], ["support"]);
-    assertEquals([...result.tools.keys()], ["echo"]);
-    assertEquals(getProjectAgentRuntimeAgentIdCandidates(result), {
-      codeAgentIds: [],
-      markdownAgentIds: ["support"],
+      assertEquals([...result.agents.keys()], ["support"]);
+      assertEquals([...result.tools.keys()], ["echo"]);
+      assertEquals(getProjectAgentRuntimeAgentIdCandidates(result), {
+        codeAgentIds: [],
+        markdownAgentIds: ["support"],
+      });
     });
-  });
+  },
 });


### PR DESCRIPTION
## Summary
- extract the Google streaming state machine into a dedicated stream adapter module
- reuse Google candidate, usage, and finish-reason helpers from streaming and non-streaming result parsing
- add fixture coverage for CRLF SSE framing, malformed event tolerance, [DONE], thought/reasoning parts, text deltas, duplicate tool-call suppression, usage, finish normalization, and trailing buffered usage

Closes #1268.

## Verification
- deno test --allow-all extensions/ext-llm-google/src/google-stream.test.ts extensions/ext-llm-google/src/google-provider.test.ts
- deno fmt --check extensions/ext-llm-google/src/google-provider.ts extensions/ext-llm-google/src/google-stream.ts extensions/ext-llm-google/src/google-stream.test.ts
- DENO_NO_PACKAGE_JSON=1 deno lint extensions/ext-llm-google/src/google-provider.ts extensions/ext-llm-google/src/google-stream.ts extensions/ext-llm-google/src/google-stream.test.ts
- deno task typecheck
- git diff --check
- git push pre-push hook: formatting, lint, typecheck, generated assets, and unit tests: 1903 passed, 0 failed
