### PR TITLE
refactor(protocol): centralize channel dispatch request guard

### DIFF
--- a/src/server/handlers/request/channel-assistants.handler.ts
+++ b/src/server/handlers/request/channel-assistants.handler.ts
@@ -1,21 +1,13 @@
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import {
-  type ChannelAssistantsRequest,
   ChannelAssistantsRequestSchema,
   type ChannelInvokeDeps,
   defaultChannelInvokeDeps,
   listChannelAssistants,
-  verifyDispatchJws,
 } from "../../../channels/invoke.ts";
-import { getControlPlaneVerificationPublicKey } from "#veryfront/internal-agents/control-plane-auth.ts";
-import {
-  HTTP_INTERNAL_SERVER_ERROR,
-  PRIORITY_MEDIUM_API,
-} from "#veryfront/utils/constants/index.ts";
-
-const DISPATCH_JWS_HEADER = "x-veryfront-dispatch-jws";
-const MAX_DISPATCH_SIGNATURE_AGE_SECONDS = 60;
+import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
+import { readSignedChannelDispatchRequest } from "./channel-dispatch-request.ts";
 
 export class ChannelAssistantsHandler extends BaseHandler {
   metadata: HandlerMetadata = {
@@ -38,70 +30,31 @@ export class ChannelAssistantsHandler extends BaseHandler {
         .withCORS(req, ctx.securityConfig?.cors)
         .withSecurity(ctx.securityConfig ?? undefined, req);
 
-      const publicKeyPem = getControlPlaneVerificationPublicKey(ctx);
-      if (!publicKeyPem) {
-        this.logWarn("Missing CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY for channel assistants endpoint");
-        return this.respond(
-          builder.json(
-            { error: "Channel dispatch verification is not configured" },
-            HTTP_INTERNAL_SERVER_ERROR,
-          ),
-        );
+      const dispatchRequest = await readSignedChannelDispatchRequest(req, ctx, {
+        builder,
+        endpointName: "channel assistants",
+        invalidRequestError: "Invalid channel assistants request",
+        logLabel: "Channel assistants",
+        logWarn: (message, extra) => this.logWarn(message, extra),
+        schema: ChannelAssistantsRequestSchema,
+      });
+      if (!dispatchRequest.ok) {
+        return this.respond(dispatchRequest.response);
       }
 
-      const projectSlug = ctx.projectSlug;
-      if (!projectSlug) {
-        this.logWarn("Channel assistants request arrived without resolved project slug");
-        return this.respond(builder.json({ error: "Project context is unavailable" }, 400));
-      }
-
-      const dispatchJws = req.headers.get(DISPATCH_JWS_HEADER);
-      if (!dispatchJws) {
-        return this.respond(builder.json({ error: "Missing dispatch signature" }, 401));
-      }
-
-      const rawBody = await req.text();
-      let claims: Awaited<ReturnType<typeof verifyDispatchJws>> | undefined;
-      try {
-        claims = await verifyDispatchJws(dispatchJws, rawBody, {
-          audience: projectSlug,
-          expectedProjectId: ctx.projectId,
-          publicKeyPem,
-          maxAgeSeconds: MAX_DISPATCH_SIGNATURE_AGE_SECONDS,
-        });
-      } catch (error) {
-        this.logWarn("Channel assistants signature verification failed", {
-          error: error instanceof Error ? error.message : String(error),
-          projectSlug,
-          projectId: ctx.projectId,
-        });
-        return this.respond(builder.json({ error: "Invalid dispatch signature" }, 401));
-      }
-
-      let payload: ChannelAssistantsRequest;
-      try {
-        payload = ChannelAssistantsRequestSchema.parse(JSON.parse(rawBody));
-      } catch (error) {
-        this.logWarn("Channel assistants request validation failed", {
-          error: error instanceof Error ? error.message : String(error),
-          projectSlug,
-          projectId: ctx.projectId,
-        });
-        return this.respond(builder.json({ error: "Invalid channel assistants request" }, 400));
-      }
+      const { claims, payload } = dispatchRequest;
 
       if (
-        !claims ||
         payload.projectId !== claims.project_id ||
         (ctx.projectId !== undefined && payload.projectId !== ctx.projectId) ||
         payload.requestId !== claims.sub ||
         payload.platform !== claims.platform
       ) {
         this.logWarn("Channel assistants request body did not match signed claims", {
-          projectSlug,
+          projectSlug: ctx.projectSlug,
           projectId: ctx.projectId,
           requestId: payload.requestId,
-          signedRequestId: claims?.sub,
+          signedRequestId: claims.sub,
         });
         return this.respond(builder.json({ error: "Invalid dispatch signature" }, 401));
       }

--- a/src/server/handlers/request/channel-dispatch-request.test.ts
+++ b/src/server/handlers/request/channel-dispatch-request.test.ts
@@ -1,0 +1,205 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { ChannelInvokeRequestSchema } from "#veryfront/channels/invoke.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+import { ResponseBuilder } from "#veryfront/security/index.ts";
+import { readSignedChannelDispatchRequest } from "./channel-dispatch-request.ts";
+
+const encoder = new TextEncoder();
+
+function encodePem(label: string, der: ArrayBuffer): string {
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = base64.match(/.{1,64}/g) ?? [base64];
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
+}
+
+async function sha256Base64url(body: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(body));
+  return base64urlEncodeBytes(new Uint8Array(digest));
+}
+
+async function createDispatchSignature(
+  body: string,
+): Promise<{ jws: string; publicKeyPem: string }> {
+  const keyPair = await crypto.subtle.generateKey("Ed25519", true, [
+    "sign",
+    "verify",
+  ]) as CryptoKeyPair;
+  const publicKeyDer = await crypto.subtle.exportKey("spki", keyPair.publicKey);
+  const publicKeyPem = encodePem("PUBLIC KEY", publicKeyDer);
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64urlEncode(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
+  const payload = base64urlEncode(JSON.stringify({
+    iss: "veryfront-api",
+    aud: "demo-project",
+    sub: "dispatch-1",
+    project_id: "proj-1",
+    platform: "slack",
+    body_sha256: await sha256Base64url(body),
+    iat: now,
+    exp: now + 60,
+  }));
+  const signingInput = encoder.encode(`${header}.${payload}`);
+  const signature = await crypto.subtle.sign("Ed25519", keyPair.privateKey, signingInput);
+  return {
+    publicKeyPem,
+    jws: `${header}.${payload}.${base64urlEncodeBytes(new Uint8Array(signature))}`,
+  };
+}
+
+function createCtx(publicKeyPem?: string): HandlerContext {
+  return {
+    adapter: {
+      env: {
+        get: (key: string) =>
+          key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? publicKeyPem : undefined,
+      },
+      fs: {},
+    },
+    securityConfig: null,
+    cspUserHeader: null,
+    projectSlug: "demo-project",
+    projectId: "proj-1",
+    isLocalProject: false,
+  } as unknown as HandlerContext;
+}
+
+function createValidBody(): string {
+  return JSON.stringify({
+    dispatchId: "dispatch-1",
+    conversationId: "conversation-1",
+    projectId: "proj-1",
+    assistantId: "agent-1",
+    platform: "slack",
+    inboundMessage: {
+      text: "Hello from Slack",
+      userId: "U123",
+      userName: "Alice",
+      isDirectMessage: false,
+    },
+    conversationHistory: [],
+  });
+}
+
+async function readFixture(req: Request, ctx: HandlerContext) {
+  return await readSignedChannelDispatchRequest(req, ctx, {
+    builder: new ResponseBuilder(),
+    endpointName: "channel invoke",
+    invalidRequestError: "Invalid channel invoke request",
+    schema: ChannelInvokeRequestSchema,
+    logWarn: () => {},
+  });
+}
+
+describe("server/handlers/request/channel-dispatch-request", () => {
+  it("returns parsed payload and signed claims for a valid dispatch request", async () => {
+    const body = createValidBody();
+    const { jws, publicKeyPem } = await createDispatchSignature(body);
+
+    const result = await readFixture(
+      new Request("https://example.com/channels/invoke", {
+        method: "POST",
+        headers: { "x-veryfront-dispatch-jws": jws },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.rawBody, body);
+      assertEquals(result.payload.dispatchId, "dispatch-1");
+      assertEquals(result.claims.sub, "dispatch-1");
+    }
+  });
+
+  it("preserves the shared setup error responses", async () => {
+    const missingKey = await readFixture(
+      new Request("https://example.com/channels/invoke", {
+        method: "POST",
+        body: createValidBody(),
+      }),
+      createCtx(),
+    );
+
+    assertEquals(missingKey.ok, false);
+    if (!missingKey.ok) {
+      assertEquals(missingKey.response.status, 500);
+      assertEquals(await missingKey.response.json(), {
+        error: "Channel dispatch verification is not configured",
+      });
+    }
+
+    const missingProject = await readFixture(
+      new Request("https://example.com/channels/invoke", {
+        method: "POST",
+        body: createValidBody(),
+      }),
+      {
+        ...createCtx("-----BEGIN PUBLIC KEY-----\nZmFrZQ==\n-----END PUBLIC KEY-----"),
+        projectSlug: "",
+      },
+    );
+
+    assertEquals(missingProject.ok, false);
+    if (!missingProject.ok) {
+      assertEquals(missingProject.response.status, 400);
+      assertEquals(await missingProject.response.json(), {
+        error: "Project context is unavailable",
+      });
+    }
+  });
+
+  it("preserves dispatch signature error responses", async () => {
+    const missingSignature = await readFixture(
+      new Request("https://example.com/channels/invoke", {
+        method: "POST",
+        body: createValidBody(),
+      }),
+      createCtx("-----BEGIN PUBLIC KEY-----\nZmFrZQ==\n-----END PUBLIC KEY-----"),
+    );
+
+    assertEquals(missingSignature.ok, false);
+    if (!missingSignature.ok) {
+      assertEquals(missingSignature.response.status, 401);
+      assertEquals(await missingSignature.response.json(), { error: "Missing dispatch signature" });
+    }
+
+    const invalidSignature = await readFixture(
+      new Request("https://example.com/channels/invoke", {
+        method: "POST",
+        headers: { "x-veryfront-dispatch-jws": "invalid.signature.value" },
+        body: createValidBody(),
+      }),
+      createCtx("-----BEGIN PUBLIC KEY-----\nZmFrZQ==\n-----END PUBLIC KEY-----"),
+    );
+
+    assertEquals(invalidSignature.ok, false);
+    if (!invalidSignature.ok) {
+      assertEquals(invalidSignature.response.status, 401);
+      assertEquals(await invalidSignature.response.json(), { error: "Invalid dispatch signature" });
+    }
+  });
+
+  it("preserves caller-specific schema error responses", async () => {
+    const body = JSON.stringify({ dispatchId: "dispatch-1" });
+    const { jws, publicKeyPem } = await createDispatchSignature(body);
+
+    const result = await readFixture(
+      new Request("https://example.com/channels/invoke", {
+        method: "POST",
+        headers: { "x-veryfront-dispatch-jws": jws },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertEquals(result.ok, false);
+    if (!result.ok) {
+      assertEquals(result.response.status, 400);
+      assertEquals(await result.response.json(), { error: "Invalid channel invoke request" });
+    }
+  });
+});

--- a/src/server/handlers/request/channel-dispatch-request.ts
+++ b/src/server/handlers/request/channel-dispatch-request.ts
@@ -1,0 +1,113 @@
+import { verifyDispatchJws } from "#veryfront/channels/invoke.ts";
+import { getControlPlaneVerificationPublicKey } from "#veryfront/internal-agents/control-plane-auth.ts";
+import type { ResponseBuilder } from "#veryfront/security/index.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { HTTP_INTERNAL_SERVER_ERROR } from "#veryfront/utils/constants/index.ts";
+
+const DISPATCH_JWS_HEADER = "x-veryfront-dispatch-jws";
+const MAX_DISPATCH_SIGNATURE_AGE_SECONDS = 60;
+
+type ParseSchema<T> = {
+  parse(value: unknown): T;
+};
+
+type LogWarn = (message: string, extra?: Record<string, unknown>) => void;
+
+export type SignedChannelDispatchRequest<T> =
+  | {
+    ok: true;
+    claims: Awaited<ReturnType<typeof verifyDispatchJws>>;
+    payload: T;
+    rawBody: string;
+  }
+  | {
+    ok: false;
+    response: Response;
+  };
+
+export interface ReadSignedChannelDispatchRequestOptions<T> {
+  builder: ResponseBuilder;
+  endpointName: string;
+  invalidRequestError: string;
+  logLabel?: string;
+  logWarn: LogWarn;
+  schema: ParseSchema<T>;
+}
+
+export async function readSignedChannelDispatchRequest<T>(
+  req: Request,
+  ctx: HandlerContext,
+  options: ReadSignedChannelDispatchRequestOptions<T>,
+): Promise<SignedChannelDispatchRequest<T>> {
+  const logLabel = options.logLabel ?? options.endpointName;
+  const publicKeyPem = getControlPlaneVerificationPublicKey(ctx);
+  if (!publicKeyPem) {
+    options.logWarn(
+      `Missing CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY for ${options.endpointName} endpoint`,
+    );
+    return {
+      ok: false,
+      response: options.builder.json(
+        { error: "Channel dispatch verification is not configured" },
+        HTTP_INTERNAL_SERVER_ERROR,
+      ),
+    };
+  }
+
+  const projectSlug = ctx.projectSlug;
+  if (!projectSlug) {
+    options.logWarn(`${logLabel} request arrived without resolved project slug`);
+    return {
+      ok: false,
+      response: options.builder.json({ error: "Project context is unavailable" }, 400),
+    };
+  }
+
+  const dispatchJws = req.headers.get(DISPATCH_JWS_HEADER);
+  if (!dispatchJws) {
+    return {
+      ok: false,
+      response: options.builder.json({ error: "Missing dispatch signature" }, 401),
+    };
+  }
+
+  const rawBody = await req.text();
+  let claims: Awaited<ReturnType<typeof verifyDispatchJws>>;
+  try {
+    claims = await verifyDispatchJws(dispatchJws, rawBody, {
+      audience: projectSlug,
+      expectedProjectId: ctx.projectId,
+      publicKeyPem,
+      maxAgeSeconds: MAX_DISPATCH_SIGNATURE_AGE_SECONDS,
+    });
+  } catch (error) {
+    options.logWarn(`${logLabel} signature verification failed`, {
+      error: error instanceof Error ? error.message : String(error),
+      projectSlug,
+      projectId: ctx.projectId,
+    });
+    return {
+      ok: false,
+      response: options.builder.json({ error: "Invalid dispatch signature" }, 401),
+    };
+  }
+
+  try {
+    return {
+      ok: true,
+      claims,
+      payload: options.schema.parse(JSON.parse(rawBody)),
+      rawBody,
+    };
+  } catch (error) {
+    options.logWarn(`${logLabel} request validation failed`, {
+      error: error instanceof Error ? error.message : String(error),
+      projectSlug,
+      projectId: ctx.projectId,
+    });
+    return {
+      ok: false,
+      response: options.builder.json({ error: options.invalidRequestError }, 400),
+    };
+  }
+}

--- a/src/server/handlers/request/channel-invoke.handler.ts
+++ b/src/server/handlers/request/channel-invoke.handler.ts
@@ -5,16 +5,9 @@ import {
   ChannelInvokeRequestSchema,
   defaultChannelInvokeDeps,
   executeChannelInvoke,
-  verifyDispatchJws,
 } from "../../../channels/invoke.ts";
-import { getControlPlaneVerificationPublicKey } from "#veryfront/internal-agents/control-plane-auth.ts";
-import {
-  HTTP_INTERNAL_SERVER_ERROR,
-  PRIORITY_MEDIUM_API,
-} from "#veryfront/utils/constants/index.ts";
-
-const DISPATCH_JWS_HEADER = "x-veryfront-dispatch-jws";
-const MAX_DISPATCH_SIGNATURE_AGE_SECONDS = 60;
+import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
+import { readSignedChannelDispatchRequest } from "./channel-dispatch-request.ts";
 
 export class ChannelInvokeHandler extends BaseHandler {
   metadata: HandlerMetadata = {
@@ -37,58 +30,19 @@ export class ChannelInvokeHandler extends BaseHandler {
         .withCORS(req, ctx.securityConfig?.cors)
         .withSecurity(ctx.securityConfig ?? undefined, req);
 
-      const publicKeyPem = getControlPlaneVerificationPublicKey(ctx);
-      if (!publicKeyPem) {
-        this.logWarn("Missing CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY for channel invoke endpoint");
-        return this.respond(
-          builder.json(
-            { error: "Channel dispatch verification is not configured" },
-            HTTP_INTERNAL_SERVER_ERROR,
-          ),
-        );
+      const dispatchRequest = await readSignedChannelDispatchRequest(req, ctx, {
+        builder,
+        endpointName: "channel invoke",
+        invalidRequestError: "Invalid channel invoke request",
+        logLabel: "Channel invoke",
+        logWarn: (message, extra) => this.logWarn(message, extra),
+        schema: ChannelInvokeRequestSchema,
+      });
+      if (!dispatchRequest.ok) {
+        return this.respond(dispatchRequest.response);
       }
 
-      const projectSlug = ctx.projectSlug;
-      if (!projectSlug) {
-        this.logWarn("Channel invoke request arrived without resolved project slug");
-        return this.respond(builder.json({ error: "Project context is unavailable" }, 400));
-      }
-
-      const dispatchJws = req.headers.get(DISPATCH_JWS_HEADER);
-      if (!dispatchJws) {
-        return this.respond(builder.json({ error: "Missing dispatch signature" }, 401));
-      }
-
-      const rawBody = await req.text();
-      try {
-        await verifyDispatchJws(dispatchJws, rawBody, {
-          audience: projectSlug,
-          expectedProjectId: ctx.projectId,
-          publicKeyPem,
-          maxAgeSeconds: MAX_DISPATCH_SIGNATURE_AGE_SECONDS,
-        });
-      } catch (error) {
-        this.logWarn("Channel invoke signature verification failed", {
-          error: error instanceof Error ? error.message : String(error),
-          projectSlug,
-          projectId: ctx.projectId,
-        });
-        return this.respond(builder.json({ error: "Invalid dispatch signature" }, 401));
-      }
-
-      let payload;
-      try {
-        payload = ChannelInvokeRequestSchema.parse(JSON.parse(rawBody));
-      } catch (error) {
-        this.logWarn("Channel invoke request validation failed", {
-          error: error instanceof Error ? error.message : String(error),
-          projectSlug,
-          projectId: ctx.projectId,
-        });
-        return this.respond(builder.json({ error: "Invalid channel invoke request" }, 400));
-      }
-
-      const response = await executeChannelInvoke(payload, ctx, this.deps);
+      const response = await executeChannelInvoke(dispatchRequest.payload, ctx, this.deps);
       return this.respond(builder.json(response, 200));
     });
   }


### PR DESCRIPTION
## Summary
- Add a shared signed channel dispatch request guard for /channels/invoke and /channels/assistants.
- Preserve existing 400/401/500 response bodies and status codes with protocol fixture coverage.
- Keep assistants-specific signed-claims/body consistency validation in the assistants handler.

Refs #1271

## Verification
- deno test --no-check --allow-all src/server/handlers/request/channel-dispatch-request.test.ts src/server/handlers/request/channel-invoke.handler.test.ts src/server/handlers/request/channel-assistants.handler.test.ts
- deno fmt --check src/server/handlers/request/channel-dispatch-request.ts src/server/handlers/request/channel-dispatch-request.test.ts src/server/handlers/request/channel-invoke.handler.ts src/server/handlers/request/channel-assistants.handler.ts
- deno lint src/server/handlers/request/channel-dispatch-request.ts src/server/handlers/request/channel-dispatch-request.test.ts src/server/handlers/request/channel-invoke.handler.ts src/server/handlers/request/channel-assistants.handler.ts
- deno check src/server/handlers/request/channel-dispatch-request.ts src/server/handlers/request/channel-dispatch-request.test.ts src/server/handlers/request/channel-invoke.handler.ts src/server/handlers/request/channel-assistants.handler.ts
- deno task typecheck
- pre-push hook: format, lint, typecheck, generated artifacts, 1903 unit tests