### PR TITLE
Propagate MCP task cancellation

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.543",
+  "version": "0.1.544",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/testing/live-evals/result.ts
+++ b/src/agent/testing/live-evals/result.ts
@@ -16,6 +16,47 @@ export interface LiveEvalResultRecord {
   textPreview?: string;
 }
 
+type EvalResultStatus = LiveEvalResultRecord["status"];
+
+interface BaseEvalResultInput {
+  id: string;
+  label: string;
+  runtime: LiveEvalRuntime;
+  details: string;
+  startedAt: number;
+}
+
+interface EvalResultInputWithContext extends BaseEvalResultInput {
+  conversationId?: string;
+  runId?: string;
+  artifactPaths?: string[];
+  traceSignature?: string;
+  toolStarts?: string[];
+  toolArgsPreview?: string;
+  textPreview?: string;
+}
+
+function createEvalResult(
+  status: EvalResultStatus,
+  input: EvalResultInputWithContext,
+): LiveEvalResultRecord {
+  return {
+    id: input.id,
+    label: input.label,
+    runtime: input.runtime,
+    status,
+    details: input.details,
+    durationMs: Date.now() - input.startedAt,
+    ...(input.conversationId ? { conversationId: input.conversationId } : {}),
+    ...(input.runId ? { runId: input.runId } : {}),
+    ...(input.artifactPaths?.length ? { artifactPaths: input.artifactPaths } : {}),
+    ...(input.traceSignature ? { traceSignature: input.traceSignature } : {}),
+    ...(input.toolStarts ? { toolStarts: input.toolStarts } : {}),
+    ...(input.toolArgsPreview ? { toolArgsPreview: input.toolArgsPreview } : {}),
+    ...(input.textPreview ? { textPreview: input.textPreview } : {}),
+  };
+}
+
 export function createSkippedEvalResult(input: {
   id: string;
   label: string;
@@ -47,21 +88,7 @@ export function createFailedEvalResult(input: {
   toolArgsPreview?: string;
   textPreview?: string;
 }): LiveEvalResultRecord {
-  return {
-    id: input.id,
-    label: input.label,
-    runtime: input.runtime,
-    status: "fail",
-    details: input.details,
-    durationMs: Date.now() - input.startedAt,
-    ...(input.conversationId ? { conversationId: input.conversationId } : {}),
-    ...(input.runId ? { runId: input.runId } : {}),
-    ...(input.artifactPaths?.length ? { artifactPaths: input.artifactPaths } : {}),
-    ...(input.traceSignature ? { traceSignature: input.traceSignature } : {}),
-    ...(input.toolStarts ? { toolStarts: input.toolStarts } : {}),
-    ...(input.toolArgsPreview ? { toolArgsPreview: input.toolArgsPreview } : {}),
-    ...(input.textPreview ? { textPreview: input.textPreview } : {}),
-  };
+  return createEvalResult("fail", input);
 }
 
 export function createPassedEvalResult(input: {
@@ -78,19 +105,5 @@ export function createPassedEvalResult(input: {
   toolArgsPreview?: string;
   textPreview?: string;
 }): LiveEvalResultRecord {
-  return {
-    id: input.id,
-    label: input.label,
-    runtime: input.runtime,
-    status: "pass",
-    details: input.details,
-    durationMs: Date.now() - input.startedAt,
-    ...(input.conversationId ? { conversationId: input.conversationId } : {}),
-    ...(input.runId ? { runId: input.runId } : {}),
-    ...(input.artifactPaths?.length ? { artifactPaths: input.artifactPaths } : {}),
-    ...(input.traceSignature ? { traceSignature: input.traceSignature } : {}),
-    ...(input.toolStarts ? { toolStarts: input.toolStarts } : {}),
-    ...(input.toolArgsPreview ? { toolArgsPreview: input.toolArgsPreview } : {}),
-    ...(input.textPreview ? { textPreview: input.textPreview } : {}),
-  };
+  return createEvalResult("pass", input);
 }

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1836,6 +1836,63 @@ describe("mcp/server", () => {
     await server.waitForPendingTasks();
   });
 
+  it("tasks/cancel aborts the in-flight async tool", async () => {
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
+    let resolveAbort!: () => void;
+    const abortObserved = new Promise<void>((resolve) => {
+      resolveAbort = resolve;
+    });
+    registerTool(
+      "test:abortable",
+      dynamicTool({
+        id: "test:abortable",
+        description: "Abortable tool",
+        inputSchema: defineSchema((v) => v.object({}))(),
+        execute: (_input, context) =>
+          new Promise((resolve) => {
+            context?.abortSignal?.addEventListener("abort", () => {
+              resolveAbort();
+              resolve({ aborted: true });
+            });
+            setTimeout(() => resolve({ aborted: false }), 200);
+          }),
+      }),
+    );
+    const createResult = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "test:abortable", arguments: {}, task: { ttl: 60000 } },
+    });
+    const taskId = (createResult.result as { task: { taskId: string } }).task.taskId;
+
+    await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tasks/cancel",
+      params: { taskId },
+    });
+
+    await Promise.race([
+      abortObserved,
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("cancel did not abort tool execution")), 50)
+      ),
+    ]);
+    await server.waitForPendingTasks();
+
+    const getResult = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tasks/get",
+      params: { taskId },
+    });
+    assertEquals((getResult.result as Record<string, unknown>).status, "cancelled");
+  });
+
   it("tasks/result returns completed task result", async () => {
     const server = createMCPServer({
       enabled: true,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -80,6 +80,11 @@ interface JSONRPCResponse {
   };
 }
 
+interface PendingTaskRun {
+  promise: Promise<void>;
+  abortController: AbortController;
+}
+
 export interface IntegrationLoaderConfig {
   integrations: Record<string, IntegrationRuntimeConfig | undefined>;
   apiBaseUrl: string;
@@ -105,7 +110,7 @@ export class MCPServer {
   private integrationsLoaded = false;
   private sessionManager = new SessionManager();
   private taskStore = new TaskStore();
-  private pendingTasks = new Map<string, Promise<void>>();
+  private pendingTasks = new Map<string, PendingTaskRun>();
   private clientCapabilities: Record<string, unknown> = {};
   private sessionCapabilities = new Map<string, Record<string, unknown>>();
 
@@ -387,19 +392,33 @@ export class MCPServer {
       const rawTtl = typeof taskParam.ttl === "number" ? taskParam.ttl : 60000;
       const ttl = Math.max(MIN_TTL, Math.min(MAX_TTL, rawTtl));
       const task = this.taskStore.create(ttl);
+      const abortController = new AbortController();
+      const outerAbortSignal = toolContext?.abortSignal;
+      const abortFromOuterSignal = () => abortController.abort();
+      if (outerAbortSignal?.aborted) {
+        abortController.abort();
+      } else {
+        outerAbortSignal?.addEventListener("abort", abortFromOuterSignal, { once: true });
+      }
+      const taskToolContext: ToolExecutionContext = {
+        ...toolContext,
+        abortSignal: abortController.signal,
+      };
 
       // Run tool in background, update task on completion
-      // TODO(#842): wire AbortController so that tasks/cancel actually aborts the running tool execution
       const pending = withSpan(
         "mcp.callTool.async",
         async () => {
           try {
-            const result = await executeTool(toolName, args, toolContext);
+            const result = await executeTool(toolName, args, taskToolContext);
             this.taskStore.complete(task.taskId, {
               content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
               isError: false,
             });
           } catch (error) {
+            if (this.taskStore.get(task.taskId)?.status === "cancelled") {
+              return;
+            }
             const message = error instanceof Error ? error.message : String(error);
             logger.warn("Async tool execution failed", {
               tool: toolName,
@@ -410,10 +429,11 @@ export class MCPServer {
           }
         },
         { "mcp.tool.name": toolName, "mcp.task.id": task.taskId },
-      ).then(() => {
+      ).finally(() => {
+        outerAbortSignal?.removeEventListener("abort", abortFromOuterSignal);
         this.pendingTasks.delete(task.taskId);
       });
-      this.pendingTasks.set(task.taskId, pending);
+      this.pendingTasks.set(task.taskId, { promise: pending, abortController });
 
       return Promise.resolve({ task });
     }
@@ -648,6 +668,7 @@ export class MCPServer {
     if (!cancelled) {
       throw new JsonRpcError(-32002, `Cannot cancel task: ${taskId}`);
     }
+    this.pendingTasks.get(String(taskId))?.abortController.abort();
     const task = this.taskStore.get(String(taskId));
     return Promise.resolve({ ...task });
   }
@@ -658,7 +679,7 @@ export class MCPServer {
 
   /** Wait for all background task executions to settle. Useful in tests. */
   waitForPendingTasks(): Promise<void> {
-    return Promise.all(this.pendingTasks.values()).then(() => {});
+    return Promise.all(Array.from(this.pendingTasks.values(), (run) => run.promise)).then(() => {});
   }
 
   createHTTPHandler(): (request: Request) => Promise<Response> {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.543";
+export const VERSION = "0.1.544";


### PR DESCRIPTION
## Summary
- Propagates `tasks/cancel` to async MCP tool execution with a per-task `AbortController`.
- Keeps cancelled tasks terminal while preventing late tool completion from overwriting status.
- Deduplicates live eval result construction for pass/fail records.
- Bumps Veryfront from `0.1.543` to `0.1.544` for the next release.

## Risk
- Low. The cancellation change is scoped to async MCP task execution. Existing synchronous tool calls keep the same context flow.

## Test Plan
- `deno test --no-check --allow-all src/mcp/server.test.ts src/agent/testing/live-evals/result.test.ts --no-lock`
- `deno test --no-check --allow-all src/utils/version.test.ts --no-lock`
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno check src/utils/version.ts src/utils/version-constant.ts`
- `deno task verify:quick`
- `VF_DISABLE_LRU_INTERVAL=1 deno task test:unit --no-lock`
- Pre-push hook: format, lint, typecheck, generated artifacts, and unit tests