### PR TITLE
Make architecture and reference docs current-state navigable

### DIFF
--- a/docs/architecture/01-system-overview.md
+++ b/docs/architecture/01-system-overview.md
@@ -8,39 +8,73 @@ runtime support.
 This page is the domain map. Focused runtime and transport details live in the
 linked architecture pages.
 
+## Domain map
+
+```mermaid
+flowchart LR
+  request[HTTP request] --> server[Server runtime]
+  server --> rendering[Rendering runtime]
+  server --> protocols[Protocol surfaces]
+  server --> ai[AI primitives]
+  server --> workflow[Workflow and background work]
+
+  ai --> primitives[Tools, prompts, and resources]
+  ai --> skills[Skills runtime]
+  ai --> provider[Provider runtime]
+  ai --> rag[Embedding and RAG]
+  workflow --> jobs[Jobs and tasks]
+  external[External service capabilities] --> oauth[OAuth runtime]
+  external --> integration[Integration runtime]
+  external --> sandbox[Sandbox runtime]
+  protocols --> mcp[MCP runtime]
+  protocols --> agui[AG-UI transport]
+  protocols --> channels[Control-plane channels]
+
+  discovery[Discovery and registries] --> ai
+  discovery --> workflow
+  extensions[Extension system] --> ai
+  extensions --> rendering
+  extensions --> external
+  platform[Runtime platform] --> server
+  build[Build system] --> rendering
+  observability[Observability] --> server
+  observability --> ai
+```
+
 ## Domains
 
-| Domain                         | Source areas                                                                                 | Focused docs                                                                                                                             |
-| ------------------------------ | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| App framework                  | `src/routing/`, `src/middleware/`, `src/react/`, `src/html/`, `src/data/`                    | [server runtime](./11-server-runtime.md), [rendering runtime](./12-rendering-runtime.md)                                                 |
-| AI primitives                  | `src/agent/`, `src/tool/`, `src/prompt/`, `src/resource/`, `src/provider/`, `src/embedding/` | [agent runtime](./03-agent-runtime.md), [provider runtime](./04-provider-runtime.md), [embedding and RAG](./06-embedding-rag.md)         |
-| Workflow and background work   | `src/workflow/`, `src/jobs/`, `src/task/`                                                    | [workflow runtime](./05-workflow-runtime.md)                                                                                             |
-| Protocol surfaces              | `src/mcp/`, `src/agent/ag-ui/`, `src/channels/`                                              | [MCP runtime](./07-mcp-runtime.md), [AG-UI transport](./10-ag-ui-transport.md), [control-plane channels](./09-control-plane-channels.md) |
-| Runtime platform               | `src/platform/`, `src/fs/`, `src/server/project-env/`                                        | [runtime adapters](./13-runtime-adapters.md)                                                                                             |
-| Build system                   | `src/build/`, `src/transforms/`, `src/modules/`                                              | [build pipeline](./14-build-pipeline.md)                                                                                                 |
-| Discovery and extension points | `src/discovery/`, `src/registry/`, `src/extensions/`                                         | [discovery and registries](./15-discovery-and-registries.md), [extension system](./16-extension-system.md)                               |
-| Cross-cutting systems          | `src/security/`, `src/cache/`, `src/observability/`, `src/errors/`                           | [observability](./17-observability.md), [runtime boundaries](./19-runtime-boundaries.md)                                                 |
+| Domain                         | Source areas                                                                                                                                                                                                                                                     | Focused docs                                                                                                                                                                                                     |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| App framework                  | [`src/routing/`](../../src/routing/), [`src/middleware/`](../../src/middleware/), [`src/react/`](../../src/react/), [`src/html/`](../../src/html/), [`src/data/`](../../src/data/)                                                                               | [server runtime](./11-server-runtime.md), [rendering runtime](./12-rendering-runtime.md)                                                                                                                         |
+| AI primitives                  | [`src/agent/`](../../src/agent/), [`src/tool/`](../../src/tool/), [`src/prompt/`](../../src/prompt/), [`src/resource/`](../../src/resource/), [`src/skill/`](../../src/skill/), [`src/provider/`](../../src/provider/), [`src/embedding/`](../../src/embedding/) | [agent runtime](./03-agent-runtime.md), [AI primitives](./24-ai-primitives.md), [skill runtime](./25-skill-runtime.md), [provider runtime](./04-provider-runtime.md), [embedding and RAG](./06-embedding-rag.md) |
+| Workflow and background work   | [`src/workflow/`](../../src/workflow/), [`src/jobs/`](../../src/jobs/), [`src/task/`](../../src/task/)                                                                                                                                                           | [workflow runtime](./05-workflow-runtime.md), [jobs and tasks](./20-jobs-and-tasks.md)                                                                                                                           |
+| Protocol surfaces              | [`src/mcp/`](../../src/mcp/), [`src/agent/ag-ui/`](../../src/agent/ag-ui/), [`src/channels/`](../../src/channels/)                                                                                                                                               | [MCP runtime](./07-mcp-runtime.md), [AG-UI transport](./10-ag-ui-transport.md), [control-plane channels](./09-control-plane-channels.md)                                                                         |
+| External service capabilities  | [`src/oauth/`](../../src/oauth/), [`src/integrations/`](../../src/integrations/), [`src/sandbox/`](../../src/sandbox/)                                                                                                                                           | [OAuth runtime](./21-oauth-runtime.md), [integration runtime](./22-integration-runtime.md), [sandbox runtime](./23-sandbox-runtime.md)                                                                           |
+| Runtime platform               | [`src/platform/`](../../src/platform/), [`src/fs/`](../../src/fs/), [`src/server/project-env/`](../../src/server/project-env/)                                                                                                                                   | [runtime adapters](./13-runtime-adapters.md)                                                                                                                                                                     |
+| Build system                   | [`src/build/`](../../src/build/), [`src/transforms/`](../../src/transforms/), [`src/modules/`](../../src/modules/)                                                                                                                                               | [build pipeline](./14-build-pipeline.md)                                                                                                                                                                         |
+| Discovery and extension points | [`src/discovery/`](../../src/discovery/), [`src/registry/`](../../src/registry/), [`src/extensions/`](../../src/extensions/)                                                                                                                                     | [discovery and registries](./15-discovery-and-registries.md), [extension system](./16-extension-system.md)                                                                                                       |
+| Cross-cutting systems          | [`src/security/`](../../src/security/), [`src/cache/`](../../src/cache/), [`src/observability/`](../../src/observability/), [`src/errors/`](../../src/errors/)                                                                                                   | [observability](./17-observability.md), [runtime boundaries](./19-runtime-boundaries.md)                                                                                                                         |
 
 ## Bridge modules
 
 Some source areas intentionally connect domains:
 
-- `src/chat/` connects UI components, agent streaming, and runtime hooks.
-- `src/internal-agents/` connects Studio-facing agent surfaces with runtime
+- [`src/chat/`](../../src/chat/) connects UI components, agent streaming, and runtime hooks.
+- [`src/internal-agents/`](../../src/internal-agents/) connects Studio-facing agent surfaces with runtime
   primitives.
-- `src/discovery/` connects project source files with registries.
-- `src/server/` composes routing, rendering, protocols, static files, and
+- [`src/discovery/`](../../src/discovery/) connects project source files with registries.
+- [`src/server/`](../../src/server/) composes routing, rendering, protocols, static files, and
   runtime services.
-- `src/build/` composes route collection, transforms, bundling, and production
+- [`src/build/`](../../src/build/) composes route collection, transforms, bundling, and production
   output.
 
-Bridge modules should stay thin. When they grow domain-specific behavior, move
+Bridge modules stay thin. When they grow domain-specific behavior, move
 that behavior to the owning domain and keep the bridge as composition code.
 
 ## Dependency posture
 
-- Shared contracts and utilities should stay broadly reusable.
-- Runtime adapters should avoid owning app, agent, or workflow behavior.
-- Entrypoints should compose domains instead of becoming hidden owners.
-- Protocol surfaces should keep MCP, AG-UI, and control-plane channels separate.
-- Public terminology should match the guide and reference docs.
+- Shared contracts and utilities stay broadly reusable.
+- Runtime adapters avoid owning app, agent, or workflow behavior.
+- Entrypoints compose domains instead of becoming hidden owners.
+- Protocol surfaces keep MCP, AG-UI, and control-plane channels separate.
+- Public terminology matches the guide and reference docs.

--- a/docs/architecture/02-request-pipeline.md
+++ b/docs/architecture/02-request-pipeline.md
@@ -11,11 +11,11 @@ middleware and handler path, and returns a normalized `Response`.
 
 Primary source areas:
 
-- `src/server/handlers/`
-- `src/server/handlers/request/`
-- `src/server/handlers/dev/`
-- `src/routing/`
-- `src/middleware/`
+- [`src/server/handlers/`](../../src/server/handlers/)
+- [`src/server/handlers/request/`](../../src/server/handlers/request/)
+- [`src/server/handlers/dev/`](../../src/server/handlers/dev/)
+- [`src/routing/`](../../src/routing/)
+- [`src/middleware/`](../../src/middleware/)
 
 ## Request classes
 
@@ -32,6 +32,34 @@ Primary source areas:
 | Dev-only endpoints    | Dev server and dashboard handlers           |
 
 ## Flow
+
+```mermaid
+flowchart TD
+  request[Incoming Request] --> context[Parse host, path, proxy, and domain context]
+  context --> classify{Classify path}
+  classify --> assets[Static asset handler]
+  classify --> modules[Runtime module handler]
+  classify --> api[API route handler]
+  classify --> page[Rendering service]
+  classify --> mcp[MCP runtime handler]
+  classify --> agui[AG-UI stream or run-control handler]
+  classify --> channel[Signed control-plane handler]
+  classify --> health[Monitoring or health handler]
+  classify --> dev[Dev-only handler]
+
+  api --> middleware[Configured middleware pipeline]
+  page --> middleware
+  middleware --> appResponse[App Response]
+
+  assets --> normalize[Normalize response headers and errors]
+  modules --> normalize
+  appResponse --> normalize
+  mcp --> normalize
+  agui --> normalize
+  channel --> normalize
+  health --> normalize
+  dev --> normalize
+```
 
 1. The runtime server receives a `Request`.
 2. Request helpers parse host, path, proxy, and domain context.

--- a/docs/architecture/03-agent-runtime.md
+++ b/docs/architecture/03-agent-runtime.md
@@ -10,14 +10,28 @@ and runtime options into streamed model execution.
 
 Primary source areas:
 
-- `src/agent/runtime/`
-- `src/agent/factory.ts`
-- `src/agent/types.ts`
-- `src/tool/`
-- `src/prompt/`
-- `src/resource/`
+- [`src/agent/runtime/`](../../src/agent/runtime/)
+- [`src/agent/factory.ts`](../../src/agent/factory.ts)
+- [`src/agent/types.ts`](../../src/agent/types.ts)
 
 ## Runtime flow
+
+```mermaid
+sequenceDiagram
+  participant Handler as Route or service handler
+  participant Runtime as Agent runtime
+  participant Tools as Tool inventory
+  participant Provider as Provider runtime
+  participant Stream as Stream encoder
+
+  Handler->>Runtime: Agent definition, messages, context, options
+  Runtime->>Tools: Resolve tools, skills, prompts, resources
+  Tools-->>Runtime: Normalized inventory
+  Runtime->>Provider: Provider-neutral request
+  Provider-->>Runtime: Provider stream events
+  Runtime->>Stream: Text, tool, data, and final chunks
+  Stream-->>Handler: Response stream
+```
 
 1. Agent definitions declare instructions, model preferences, tools, and runtime
    behavior.
@@ -33,6 +47,10 @@ Primary source areas:
 ## Boundaries
 
 - Provider and model resolution belong in [provider runtime](./04-provider-runtime.md).
+- Tool, prompt, and resource definitions belong in
+  [AI primitives](./24-ai-primitives.md).
+- Skill parsing and allowed-tool policy belong in
+  [skill runtime](./25-skill-runtime.md).
 - Browser AG-UI encoding belongs in [AG-UI transport](./10-ag-ui-transport.md).
 - Hosted child-run behavior belongs in [hosted agent runs](./08-hosted-agent-runs.md).
 - Workflow DAG execution belongs in [workflow runtime](./05-workflow-runtime.md).
@@ -41,5 +59,5 @@ Primary source areas:
 
 - Keep tool inventory construction separate from provider transport adapters.
 - Keep streamed runtime chunks separate from durable hosted run state.
-- Add focused tests next to `src/agent/runtime/` when changing message
+- Add focused tests next to [`src/agent/runtime/`](../../src/agent/runtime/) when changing message
   normalization, tool conversion, streaming, or provider compatibility.

--- a/docs/architecture/04-provider-runtime.md
+++ b/docs/architecture/04-provider-runtime.md
@@ -10,11 +10,11 @@ provider responses, and exposes local or Veryfront Cloud provider adapters.
 
 Primary source areas:
 
-- `src/provider/`
-- `src/provider/runtime-loader/`
-- `src/provider/local/`
-- `src/provider/veryfront-cloud/`
-- `src/agent/runtime/model-resolution.ts`
+- [`src/provider/`](../../src/provider/)
+- [`src/provider/runtime-loader/`](../../src/provider/runtime-loader/)
+- [`src/provider/local/`](../../src/provider/local/)
+- [`src/provider/veryfront-cloud/`](../../src/provider/veryfront-cloud/)
+- [`src/agent/runtime/model-resolution.ts`](../../src/agent/runtime/model-resolution.ts)
 
 ## Runtime flow
 

--- a/docs/architecture/05-workflow-runtime.md
+++ b/docs/architecture/05-workflow-runtime.md
@@ -10,14 +10,35 @@ tracks approvals, and persists workflow run state through configured backends.
 
 Primary source areas:
 
-- `src/workflow/dsl/`
-- `src/workflow/executor/`
-- `src/workflow/runtime/`
-- `src/workflow/backends/`
-- `src/workflow/worker/`
-- `src/workflow/api/`
+- [`src/workflow/dsl/`](../../src/workflow/dsl/)
+- [`src/workflow/executor/`](../../src/workflow/executor/)
+- [`src/workflow/runtime/`](../../src/workflow/runtime/)
+- [`src/workflow/backends/`](../../src/workflow/backends/)
+- [`src/workflow/worker/`](../../src/workflow/worker/)
+- [`src/workflow/api/`](../../src/workflow/api/)
 
 ## Runtime flow
+
+```mermaid
+flowchart TD
+  definition[Workflow definition] --> graph[Build step graph]
+  graph --> validate[Validate dependencies and graph shape]
+  validate --> ready{Ready steps}
+  ready --> agentStep[Agent step]
+  ready --> toolStep[Tool step]
+  ready --> waitStep[Wait or approval step]
+  ready --> parallel[Parallel, map, or loop group]
+
+  agentStep --> checkpoint[Checkpoint and backend state]
+  toolStep --> checkpoint
+  waitStep --> checkpoint
+  parallel --> ready
+  checkpoint --> complete{More ready steps?}
+  complete -->|yes| ready
+  complete -->|no| result[Workflow result]
+
+  worker[Worker profile] --> ready
+```
 
 1. Workflow DSL helpers build step graphs, branches, loops, maps, parallel
    groups, waits, and sub-workflows.

--- a/docs/architecture/06-embedding-rag.md
+++ b/docs/architecture/06-embedding-rag.md
@@ -10,10 +10,10 @@ stores vectors, and exposes retrieval helpers for agent and application code.
 
 Primary source areas:
 
-- `src/embedding/`
-- `src/embedding/react/`
-- `src/embedding/veryfront-cloud/`
-- `src/provider/local/local-embedding-engine.ts`
+- [`src/embedding/`](../../src/embedding/)
+- [`src/embedding/react/`](../../src/embedding/react/)
+- [`src/embedding/veryfront-cloud/`](../../src/embedding/veryfront-cloud/)
+- [`src/provider/local/local-embedding-engine.ts`](../../src/provider/local/local-embedding-engine.ts)
 
 ## Runtime flow
 

--- a/docs/architecture/07-mcp-runtime.md
+++ b/docs/architecture/07-mcp-runtime.md
@@ -10,12 +10,12 @@ SSE, HTTP transport, and task storage through the Model Context Protocol.
 
 Primary source areas:
 
-- `src/mcp/server.ts`
-- `src/mcp/http-transport.ts`
-- `src/mcp/sse.ts`
-- `src/mcp/session.ts`
-- `src/mcp/registry.ts`
-- `src/mcp/task-store.ts`
+- [`src/mcp/server.ts`](../../src/mcp/server.ts)
+- [`src/mcp/http-transport.ts`](../../src/mcp/http-transport.ts)
+- [`src/mcp/sse.ts`](../../src/mcp/sse.ts)
+- [`src/mcp/session.ts`](../../src/mcp/session.ts)
+- [`src/mcp/registry.ts`](../../src/mcp/registry.ts)
+- [`src/mcp/task-store.ts`](../../src/mcp/task-store.ts)
 
 ## Runtime flow
 

--- a/docs/architecture/08-hosted-agent-runs.md
+++ b/docs/architecture/08-hosted-agent-runs.md
@@ -12,11 +12,11 @@ state, and cloud runtime services.
 
 Primary source areas:
 
-- `src/agent/hosted/`
-- `src/agent/conversation/`
-- `src/agent/child-run/`
-- `src/agent/project/`
-- `src/agent/artifacts/`
+- [`src/agent/hosted/`](../../src/agent/hosted/)
+- [`src/agent/conversation/`](../../src/agent/conversation/)
+- [`src/agent/child-run/`](../../src/agent/child-run/)
+- [`src/agent/project/`](../../src/agent/project/)
+- [`src/agent/artifacts/`](../../src/agent/artifacts/)
 
 ## Runtime flow
 

--- a/docs/architecture/09-control-plane-channels.md
+++ b/docs/architecture/09-control-plane-channels.md
@@ -10,10 +10,10 @@ services and project runtimes.
 
 Primary source areas:
 
-- `src/channels/control-plane.ts`
-- `src/channels/invoke.ts`
-- `src/server/handlers/request/channel-dispatch-request.ts`
-- `src/server/handlers/request/channel-invoke.handler.ts`
+- [`src/channels/control-plane.ts`](../../src/channels/control-plane.ts)
+- [`src/channels/invoke.ts`](../../src/channels/invoke.ts)
+- [`src/server/handlers/request/channel-dispatch-request.ts`](../../src/server/handlers/request/channel-dispatch-request.ts)
+- [`src/server/handlers/request/channel-invoke.handler.ts`](../../src/server/handlers/request/channel-invoke.handler.ts)
 
 ## Runtime flow
 

--- a/docs/architecture/10-ag-ui-transport.md
+++ b/docs/architecture/10-ag-ui-transport.md
@@ -10,12 +10,29 @@ AG-UI transport adapts agent runtime events to browser-facing AG-UI streams.
 
 Primary source areas:
 
-- `src/agent/ag-ui/`
-- `src/server/handlers/request/agent-stream.handler.ts`
-- `src/server/handlers/request/agent-run-resume.handler.ts`
-- `src/server/handlers/request/agent-run-cancel.handler.ts`
+- [`src/agent/ag-ui/`](../../src/agent/ag-ui/)
+- [`src/server/handlers/request/agent-stream.handler.ts`](../../src/server/handlers/request/agent-stream.handler.ts)
+- [`src/server/handlers/request/agent-run-resume.handler.ts`](../../src/server/handlers/request/agent-run-resume.handler.ts)
+- [`src/server/handlers/request/agent-run-cancel.handler.ts`](../../src/server/handlers/request/agent-run-cancel.handler.ts)
 
 ## Runtime flow
+
+```mermaid
+sequenceDiagram
+  participant Browser
+  participant Handler as AG-UI request handler
+  participant Runtime as Agent runtime
+  participant Encoder as AG-UI encoder
+  participant Control as Run control
+
+  Browser->>Handler: Chat, resume, cancel, or detached-start request
+  Handler->>Handler: Parse body and forwarded context
+  Handler->>Runtime: Invoke with AG-UI-aware stream context
+  Runtime-->>Encoder: Runtime chunks
+  Encoder-->>Browser: AG-UI events
+  Browser->>Control: Resume or cancellation request
+  Control->>Handler: Run-control operation
+```
 
 1. Request handlers parse AG-UI request bodies and forwarded context.
 2. Tool merging combines request tools, agent tools, and session-managed tools.

--- a/docs/architecture/11-server-runtime.md
+++ b/docs/architecture/11-server-runtime.md
@@ -11,12 +11,12 @@ API-route, MCP, AG-UI, and monitoring handlers.
 
 Primary source areas:
 
-- `src/server/`
-- `src/server/dev-server/`
-- `src/server/handlers/`
-- `src/server/services/`
-- `src/routing/`
-- `src/middleware/`
+- [`src/server/`](../../src/server/)
+- [`src/server/dev-server/`](../../src/server/dev-server/)
+- [`src/server/handlers/`](../../src/server/handlers/)
+- [`src/server/services/`](../../src/server/services/)
+- [`src/routing/`](../../src/routing/)
+- [`src/middleware/`](../../src/middleware/)
 
 ## Runtime flow
 

--- a/docs/architecture/12-rendering-runtime.md
+++ b/docs/architecture/12-rendering-runtime.md
@@ -10,11 +10,11 @@ boundaries, renders React output, handles RSC paths, and assembles HTML.
 
 Primary source areas:
 
-- `src/rendering/`
-- `src/server/services/rendering/`
-- `src/server/services/rsc/`
-- `src/react/`
-- `src/html/`
+- [`src/rendering/`](../../src/rendering/)
+- [`src/server/services/rendering/`](../../src/server/services/rendering/)
+- [`src/server/services/rsc/`](../../src/server/services/rsc/)
+- [`src/react/`](../../src/react/)
+- [`src/html/`](../../src/html/)
 
 ## Runtime flow
 

--- a/docs/architecture/13-runtime-adapters.md
+++ b/docs/architecture/13-runtime-adapters.md
@@ -10,11 +10,11 @@ capabilities behind shared server, filesystem, and environment access patterns.
 
 Primary source areas:
 
-- `src/platform/`
-- `src/platform/adapters/`
-- `src/platform/cloud/`
-- `src/fs/`
-- `src/server/project-env/`
+- [`src/platform/`](../../src/platform/)
+- [`src/platform/adapters/`](../../src/platform/adapters/)
+- [`src/platform/cloud/`](../../src/platform/cloud/)
+- [`src/fs/`](../../src/fs/)
+- [`src/server/project-env/`](../../src/server/project-env/)
 
 ## Runtime flow
 

--- a/docs/architecture/14-build-pipeline.md
+++ b/docs/architecture/14-build-pipeline.md
@@ -11,12 +11,12 @@ output.
 
 Primary source areas:
 
-- `src/build/`
-- `src/build/production-build/`
-- `src/build/bundler/`
-- `src/build/compiler/`
-- `src/build/asset-pipeline/`
-- `src/transforms/`
+- [`src/build/`](../../src/build/)
+- [`src/build/production-build/`](../../src/build/production-build/)
+- [`src/build/bundler/`](../../src/build/bundler/)
+- [`src/build/compiler/`](../../src/build/compiler/)
+- [`src/build/asset-pipeline/`](../../src/build/asset-pipeline/)
+- [`src/transforms/`](../../src/transforms/)
 
 ## Build flow
 

--- a/docs/architecture/15-discovery-and-registries.md
+++ b/docs/architecture/15-discovery-and-registries.md
@@ -10,16 +10,18 @@ tools, agents, workflows, prompts, resources, and related runtime definitions.
 
 Primary source areas:
 
-- `src/discovery/`
-- `src/registry/`
-- `src/modules/`
-- `src/tool/registry.ts`
-- `src/resource/registry.ts`
-- `src/workflow/registry.ts`
+- [`src/discovery/`](../../src/discovery/)
+- [`src/registry/`](../../src/registry/)
+- [`src/modules/`](../../src/modules/)
+- [`src/tool/registry.ts`](../../src/tool/registry.ts)
+- [`src/resource/registry.ts`](../../src/resource/registry.ts)
+- [`src/workflow/registry.ts`](../../src/workflow/registry.ts)
+- [`src/skill/registry.ts`](../../src/skill/registry.ts)
 
 ## Runtime flow
 
-1. Discovery scans configured project directories.
+1. Discovery scans configured project directories for project primitives such as
+   agents, tools, skills, prompts, resources, workflows, and tasks.
 2. Module loading and transpilation prepare TypeScript or framework source for
    import.
 3. Handlers identify supported primitive exports.

--- a/docs/architecture/16-extension-system.md
+++ b/docs/architecture/16-extension-system.md
@@ -11,13 +11,13 @@ lifecycle hooks.
 
 Primary source areas:
 
-- `src/extensions/`
-- `src/extensions/schema/`
-- `src/extensions/bundler/`
-- `src/extensions/auth/`
-- `src/extensions/cache/`
-- `src/extensions/llm/`
-- `src/extensions/observability/`
+- [`src/extensions/`](../../src/extensions/)
+- [`src/extensions/schema/`](../../src/extensions/schema/)
+- [`src/extensions/bundler/`](../../src/extensions/bundler/)
+- [`src/extensions/auth/`](../../src/extensions/auth/)
+- [`src/extensions/cache/`](../../src/extensions/cache/)
+- [`src/extensions/llm/`](../../src/extensions/llm/)
+- [`src/extensions/observability/`](../../src/extensions/observability/)
 
 ## Runtime flow
 

--- a/docs/architecture/17-observability.md
+++ b/docs/architecture/17-observability.md
@@ -11,12 +11,12 @@ cache, and agent paths.
 
 Primary source areas:
 
-- `src/observability/`
-- `src/observability/metrics/`
-- `src/observability/tracing/`
-- `src/observability/instruments/`
-- `src/observability/auto-instrument/`
-- `src/errors/`
+- [`src/observability/`](../../src/observability/)
+- [`src/observability/metrics/`](../../src/observability/metrics/)
+- [`src/observability/tracing/`](../../src/observability/tracing/)
+- [`src/observability/instruments/`](../../src/observability/instruments/)
+- [`src/observability/auto-instrument/`](../../src/observability/auto-instrument/)
+- [`src/errors/`](../../src/errors/)
 
 ## Runtime flow
 
@@ -28,9 +28,9 @@ Primary source areas:
 
 ## Boundaries
 
-- Observability records behavior. It should not own business logic.
+- Observability records behavior. It does not own business logic.
 - Public monitoring routes belong in [server runtime](./11-server-runtime.md).
-- Error type definitions and registry patterns belong in `src/errors/`.
+- Error type definitions and registry patterns belong in [`src/errors/`](../../src/errors/).
 
 ## Change checks
 

--- a/docs/architecture/18-support-matrix.md
+++ b/docs/architecture/18-support-matrix.md
@@ -1,10 +1,10 @@
-# Support Matrix
+# Support matrix
 
 This page keeps fast-moving support details short and explicit.
 
 Use it for supported behavior.
 
-## Router Modes
+## Router modes
 
 Veryfront supports both router modes.
 
@@ -15,7 +15,7 @@ Veryfront supports both router modes.
 | Router preference | `router: "app"` or `router: "pages"` in `veryfront.config.ts`                                       | The preferred router can be configured explicitly.                         |
 | Fallback behavior | If the preferred router directory is missing, Veryfront falls back to the other router when present | This is a runtime convenience, not a reason to mix router styles casually. |
 
-## Runtime Targets
+## Runtime targets
 
 These are the runtime capability profiles modeled by the framework.
 
@@ -27,7 +27,7 @@ These are the runtime capability profiles modeled by the framework.
 | Cloudflare Workers | No         | No         | Limited                       | Streaming is recommended; the runtime uses conservative step, CPU, and memory limits. |
 | Unknown runtime    | No         | No         | Limited                       | Falls back to a constrained compatibility profile.                                    |
 
-## Capability Boundaries
+## Capability boundaries
 
 This matrix separates open-core framework support from capabilities that depend
 on a backing API or cloud bootstrap.
@@ -49,7 +49,7 @@ on a backing API or cloud bootstrap.
 | Remote integration tools                                              | Requires backing API/service layer                | Tool definitions and execution are fetched per request from the configured API layer. |
 | Control-plane agent routing                                           | Requires Veryfront Cloud bootstrap                | EdDSA-signed request validation for hosted agent orchestration.                       |
 
-## Extension Contract Matrix
+## Extension contract matrix
 
 These contracts are backed by first-party extension packages. A contract is
 required only when a feature resolves it. Built-in packages are auto-enabled by
@@ -76,16 +76,16 @@ core bootstrap; optional packages must be configured by the project.
 
 Veryfront tracks third-party dependency ownership by boundary.
 
-| Boundary  | Source                                       | SBOM output                                 | Notes                                                                                      |
-| --------- | -------------------------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| Core      | Root `deno.json` and `src/`                  | `core.json`                                 | The root framework boundary. `src/` is not renamed to `core`; `core` is a reporting label. |
-| CLI       | `cli/deno.json`                              | `cli.json`                                  | Command-line runtime boundary.                                                             |
-| React     | Root React import aliases and esm.sh deps    | `react.json`                                | Tracks React and React DOM separately from core until React has a dedicated package split. |
-| Extension | `extensions/ext-*/deno.json`                 | One file per extension package              | Each extension owns its npm and supported esm.sh dependencies.                             |
-| Aggregate | `deno.lock` plus boundary-specific manifests | `all.json`, `dependencies-by-manifest.json` | Use this view for full supply-chain inventory.                                             |
+| Boundary  | Source                                                          | SBOM output                                 | Notes                                                                                                    |
+| --------- | --------------------------------------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Core      | Root [`deno.json`](../../deno.json) and [`src/`](../../src/)    | `core.json`                                 | The root framework boundary. [`src/`](../../src/) is not renamed to `core`; `core` is a reporting label. |
+| CLI       | [`cli/deno.json`](../../cli/deno.json)                          | `cli.json`                                  | Command-line runtime boundary.                                                                           |
+| React     | Root React import aliases and esm.sh deps                       | `react.json`                                | Tracks React and React DOM separately from core until React has a dedicated package split.               |
+| Extension | `extensions/ext-*/deno.json`                                    | One file per extension package              | Each extension owns its npm and supported esm.sh dependencies.                                           |
+| Aggregate | [`deno.lock`](../../deno.lock) plus boundary-specific manifests | `all.json`, `dependencies-by-manifest.json` | Use this view for full supply-chain inventory.                                                           |
 
-## Documentation Rule
+## Documentation rule
 
 When a feature depends on a backing API, managed service, or cloud bootstrap,
-docs should say so directly instead of implying the open-core runtime provides
+docs must say so directly instead of implying the open-core runtime provides
 the full managed behavior by itself.

--- a/docs/architecture/19-runtime-boundaries.md
+++ b/docs/architecture/19-runtime-boundaries.md
@@ -7,9 +7,9 @@ changing them.
 
 Source areas:
 
-- `src/provider/`
-- `src/agent/runtime/model-resolution.ts`
-- `src/embedding/model-resolution.ts`
+- [`src/provider/`](../../src/provider/)
+- [`src/agent/runtime/model-resolution.ts`](../../src/agent/runtime/model-resolution.ts)
+- [`src/embedding/model-resolution.ts`](../../src/embedding/model-resolution.ts)
 
 Verify model defaults, provider-specific request construction, streaming,
 embedding model resolution, and sanitized errors.
@@ -18,9 +18,9 @@ embedding model resolution, and sanitized errors.
 
 Source areas:
 
-- `src/modules/`
-- `src/discovery/`
-- `src/server/handlers/request/module/`
+- [`src/modules/`](../../src/modules/)
+- [`src/discovery/`](../../src/discovery/)
+- [`src/server/handlers/request/module/`](../../src/server/handlers/request/module/)
 
 Verify app-router and pages-router imports, generated module handlers, virtual
 filesystem behavior, and discovery fixture coverage.
@@ -29,20 +29,33 @@ filesystem behavior, and discovery fixture coverage.
 
 Source areas:
 
-- `src/agent/ag-ui/`
-- `src/agent/hosted/`
-- `src/agent/conversation/`
+- [`src/agent/ag-ui/`](../../src/agent/ag-ui/)
+- [`src/agent/hosted/`](../../src/agent/hosted/)
+- [`src/agent/conversation/`](../../src/agent/conversation/)
 
 Verify chunk encoding, finalization, resume, cancellation, durable mirrors, and
 child-run snapshots.
+
+## AI primitives and skills
+
+Source areas:
+
+- [`src/tool/`](../../src/tool/)
+- [`src/prompt/`](../../src/prompt/)
+- [`src/resource/`](../../src/resource/)
+- [`src/skill/`](../../src/skill/)
+
+Verify primitive factories, schema conversion, registry scoping, tool execution,
+remote tool materialization, skill metadata parsing, allowed-tool filtering,
+path safety, and skill script execution.
 
 ## Rendering and RSC
 
 Source areas:
 
-- `src/rendering/`
-- `src/server/services/rsc/`
-- `src/server/services/rendering/`
+- [`src/rendering/`](../../src/rendering/)
+- [`src/server/services/rsc/`](../../src/server/services/rsc/)
+- [`src/server/services/rendering/`](../../src/server/services/rendering/)
 
 Verify page resolution, layout ordering, RSC endpoint behavior, SSR responses,
 and error fallback output.
@@ -51,13 +64,44 @@ and error fallback output.
 
 Source areas:
 
-- `src/workflow/dsl/`
-- `src/workflow/executor/`
-- `src/workflow/backends/`
-- `src/workflow/worker/`
+- [`src/workflow/dsl/`](../../src/workflow/dsl/)
+- [`src/workflow/executor/`](../../src/workflow/executor/)
+- [`src/workflow/backends/`](../../src/workflow/backends/)
+- [`src/workflow/worker/`](../../src/workflow/worker/)
 
 Verify graph validation, step ordering, approvals, checkpointing, and worker
 execution profiles.
+
+## Jobs and tasks
+
+Source areas:
+
+- [`src/jobs/`](../../src/jobs/)
+- [`src/task/`](../../src/task/)
+
+Verify jobs client request shape, job and cron schemas, project scoping, task
+discovery, task context construction, and env allowlisting.
+
+## OAuth and integrations
+
+Source areas:
+
+- [`src/oauth/`](../../src/oauth/)
+- [`src/integrations/`](../../src/integrations/)
+
+Verify OAuth user binding, one-shot state consumption, token-store keying,
+connector schemas, request-scoped remote tool visibility, and remote tool result
+normalization.
+
+## Sandbox sessions
+
+Source areas:
+
+- [`src/sandbox/`](../../src/sandbox/)
+
+Verify sandbox credential resolution, session creation, attach and reconnect
+paths, lazy provisioning, command streaming, command jobs, heartbeats, file
+operations, and agent-facing shell tool schemas.
 
 ## Change standard
 

--- a/docs/architecture/20-jobs-and-tasks.md
+++ b/docs/architecture/20-jobs-and-tasks.md
@@ -1,0 +1,69 @@
+# Jobs and tasks
+
+This page describes job client operations, cron job scheduling surfaces, task
+definition discovery, and local task execution. It does not cover workflow DAG
+execution or the external service that persists and runs cloud jobs.
+
+## Responsibility
+
+Jobs code exposes the public client for project-scoped one-off jobs, cron jobs,
+batches, events, logs, and target discovery. Task code discovers project task
+definitions and runs them with a sanitized task context.
+
+Primary source areas:
+
+- [`src/jobs/`](../../src/jobs/)
+- [`src/jobs/jobs-client.ts`](../../src/jobs/jobs-client.ts)
+- [`src/jobs/schemas.ts`](../../src/jobs/schemas.ts)
+- [`src/jobs/runtime-env.ts`](../../src/jobs/runtime-env.ts)
+- [`src/task/`](../../src/task/)
+- [`src/task/discovery.ts`](../../src/task/discovery.ts)
+- [`src/task/runner.ts`](../../src/task/runner.ts)
+
+## Runtime flow
+
+```mermaid
+flowchart TD
+  taskFile[Project task file] --> discovery[Task discovery]
+  discovery --> taskDef[Task definition]
+  taskDef --> localRun[Local task runner]
+  localRun --> taskContext[Task context: env, config, project id]
+  taskContext --> result[Task result or sanitized error]
+
+  client[Jobs client] --> api[Jobs API]
+  api --> create[Create one-off job]
+  api --> cron[Create or update cron job]
+  api --> events[List events and logs]
+  api --> targets[List supported targets]
+  create --> backing[Backing job service]
+  cron --> backing
+```
+
+1. Task discovery scans configured `tasks/` directories and imports supported
+   task files.
+2. The task runner builds a scoped context and calls the task definition's
+   `run()` function.
+3. The jobs client builds authenticated project-scoped requests for jobs, cron
+   jobs, batches, events, logs, and target metadata.
+4. Public schemas validate job, cron, batch, event, log, and target response
+   shapes.
+5. Cloud job execution is delegated to the configured backing service.
+
+## Boundaries
+
+- A task is a developer-defined function. It is not a job run.
+- A job is durable background execution of a target. It is not a workflow DAG.
+- Cron jobs create job runs over time. They are not job runs themselves.
+- Workflow worker execution belongs in [workflow runtime](./05-workflow-runtime.md).
+- The managed job service is outside this package; this package owns the client,
+  schemas, discovery, and local task runner.
+
+## Change checks
+
+- Add client tests when changing request paths, query params, auth headers, or
+  response parsing.
+- Add schema tests when changing job, cron, batch, event, log, or target shapes.
+- Add discovery or runner tests when changing task file detection, import
+  behavior, context construction, or env allowlisting.
+- Update [Jobs and cron jobs](../guides/jobs.md) and [Tasks](../guides/tasks.md)
+  when public behavior changes.

--- a/docs/architecture/21-oauth-runtime.md
+++ b/docs/architecture/21-oauth-runtime.md
@@ -1,0 +1,70 @@
+# OAuth runtime
+
+This page describes OAuth provider configuration, authorization redirects,
+callback handling, token exchange, token storage, status checks, and disconnect
+handlers. It does not cover integration tool execution.
+
+## Responsibility
+
+OAuth code provides provider configs, OAuth service helpers, route handlers,
+state validation, token exchange, refresh support, and token store contracts.
+
+Primary source areas:
+
+- [`src/oauth/`](../../src/oauth/)
+- [`src/oauth/providers/`](../../src/oauth/providers/)
+- [`src/oauth/handlers/`](../../src/oauth/handlers/)
+- [`src/oauth/token-store/`](../../src/oauth/token-store/)
+- [`src/oauth/schemas/`](../../src/oauth/schemas/)
+- [`src/oauth/types.ts`](../../src/oauth/types.ts)
+
+## Runtime flow
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Init as Init handler
+  participant Store as Token store
+  participant Provider as OAuth provider
+  participant Callback as Callback handler
+
+  User->>Init: Start OAuth flow
+  Init->>Init: Resolve authenticated user id
+  Init->>Store: Persist one-shot state with user id
+  Init-->>User: Redirect to provider
+  User->>Provider: Authorize
+  Provider-->>Callback: code and state
+  Callback->>Store: Consume state atomically
+  Callback->>Provider: Exchange code for tokens
+  Callback->>Store: Store tokens by service id and user id
+  Callback-->>User: Redirect to success or error path
+```
+
+1. Init handlers require a user id and reject anonymous requests.
+2. Provider helpers create authorization URLs and persist one-shot state rows.
+3. Callback handlers consume state, validate the service id, exchange codes for
+   tokens, and store tokens under the initiating user.
+4. Status and disconnect handlers act on the authenticated user's own token
+   slot.
+5. Provider catalogs supply common service configs, scopes, URLs, and client env
+   variable names.
+
+## Boundaries
+
+- OAuth owns authorization, callback, token exchange, and token storage
+  contracts.
+- Integration metadata can reference OAuth provider configs, but integration
+  tool execution belongs in [integration runtime](./22-integration-runtime.md).
+- Public route ownership belongs to the application route that mounts the OAuth
+  handlers.
+- Persistent token storage is supplied by the application or backing service.
+
+## Change checks
+
+- Add handler tests for state validation, user binding, redirect behavior, and
+  provider errors.
+- Add provider tests when changing auth URL, token URL, scope, PKCE, or token
+  exchange behavior.
+- Add token-store tests when changing state consumption or token keying.
+- Keep tokens, secrets, and provider responses out of public logs and errors.
+- Update [OAuth](../guides/oauth.md) when public handler behavior changes.

--- a/docs/architecture/22-integration-runtime.md
+++ b/docs/architecture/22-integration-runtime.md
@@ -1,0 +1,64 @@
+# Integration runtime
+
+This page describes the connector catalog, integration metadata schemas, and
+remote integration tool loading and execution. It does not cover OAuth route
+handlers or local tool definitions.
+
+## Responsibility
+
+Integration code exposes connector metadata, icons, schema-backed integration
+configuration, and per-request remote tools fetched from the configured API
+layer.
+
+Primary source areas:
+
+- [`src/integrations/`](../../src/integrations/)
+- [`src/integrations/index.ts`](../../src/integrations/index.ts)
+- [`src/integrations/schema.ts`](../../src/integrations/schema.ts)
+- [`src/integrations/_data.ts`](../../src/integrations/_data.ts)
+- [`src/integrations/remote-tools.ts`](../../src/integrations/remote-tools.ts)
+- [`src/integrations/types.ts`](../../src/integrations/types.ts)
+
+## Runtime flow
+
+```mermaid
+flowchart TD
+  catalog[Connector catalog] --> schema[Integration schemas]
+  schema --> config[Project integration config]
+  config --> sync[Config sync to API]
+
+  request[Agent request context] --> token[Resolve project or request token]
+  token --> list[Fetch remote tool definitions]
+  list --> inventory[Merge into agent tool inventory]
+  inventory --> call[Model calls integration tool]
+  call --> execute[Execute via integrations tools API]
+  execute --> result[Structured tool result or sanitized error]
+```
+
+1. Connector metadata defines supported providers, auth requirements, tools,
+   prompts, icons, and environment requirements.
+2. Schema helpers validate integration config and connector metadata.
+3. Remote tool helpers resolve request-scoped or environment API credentials.
+4. Tool definitions are fetched per request so enabled integrations remain
+   project-scoped.
+5. Tool execution is delegated to the configured API layer and normalized for
+   the agent runtime.
+
+## Boundaries
+
+- Integration runtime owns connector metadata and remote tool bridge behavior.
+- OAuth runtime owns provider redirects, callbacks, and token storage.
+- Local project tools belong in [agent runtime](./03-agent-runtime.md) and the
+  public [Tools](../guides/tools.md) guide.
+- The backing API owns actual third-party API calls and provider token access.
+
+## Change checks
+
+- Add schema tests when changing connector, auth, endpoint, tool, or prompt
+  metadata.
+- Add remote-tool tests when changing request-scoped token resolution, tool
+  listing, call payloads, or result normalization.
+- Keep per-project tool visibility scoped to the active request or environment
+  token.
+- Update [Integrations](../guides/integrations.md) when catalog behavior or
+  public config changes.

--- a/docs/architecture/23-sandbox-runtime.md
+++ b/docs/architecture/23-sandbox-runtime.md
@@ -1,0 +1,76 @@
+# Sandbox runtime
+
+This page describes sandbox session clients, lazy provisioning, command
+execution, file operations, command jobs, heartbeats, and agent-service sandbox
+tools. It does not cover workflow execution or the backing sandbox service
+implementation.
+
+## Responsibility
+
+Sandbox code provides the public client for authenticated sandbox sessions and
+the tool adapters that let agents run isolated shell and file operations.
+
+Primary source areas:
+
+- [`src/sandbox/`](../../src/sandbox/)
+- [`src/sandbox/sandbox.ts`](../../src/sandbox/sandbox.ts)
+- [`src/sandbox/lazy-sandbox.ts`](../../src/sandbox/lazy-sandbox.ts)
+- [`src/sandbox/shell-tools.ts`](../../src/sandbox/shell-tools.ts)
+- [`src/sandbox/agent-service-tools.ts`](../../src/sandbox/agent-service-tools.ts)
+- [`src/sandbox/types.ts`](../../src/sandbox/types.ts)
+- [`src/sandbox/config.ts`](../../src/sandbox/config.ts)
+
+## Runtime flow
+
+```mermaid
+flowchart TD
+  options[Sandbox options] --> config[Resolve API URL and auth token]
+  config --> session{Session mode}
+  session --> create[Create or reconnect session]
+  session --> attach[Attach known session and endpoint]
+  session --> lazy[Lazy provisioning]
+
+  create --> ready[Wait for ready session]
+  lazy --> ready
+  attach --> ready
+  ready --> exec[Execute buffered or streaming command]
+  ready --> files[Read or write files]
+  ready --> jobs[Start, poll, or cancel command job]
+  ready --> heartbeat[Heartbeat active session]
+  exec --> close[Close session]
+  files --> close
+  jobs --> close
+```
+
+1. Config helpers resolve sandbox API URL and auth token from explicit options
+   or environment.
+2. `Sandbox.create()`, `Sandbox.get()`, and `Sandbox.attach()` establish a
+   session endpoint.
+3. `Sandbox.createLazy()` defers provisioning until command or file operations
+   need a session.
+4. Command helpers support buffered output, streamed NDJSON events, and async
+   command jobs.
+5. Agent-service helpers adapt sandbox operations into shell and file tools.
+
+## Boundaries
+
+- Sandbox runtime owns client behavior, lazy provisioning, command streaming,
+  command job polling, and agent-service tool adapters.
+- The backing sandbox service owns container lifecycle, isolation, scheduling,
+  and command execution internals.
+- Workflow runtime may call sandbox-backed tools, but workflow state belongs in
+  [workflow runtime](./05-workflow-runtime.md).
+- MCP may expose sandbox-backed tools, but MCP transport belongs in
+  [MCP runtime](./07-mcp-runtime.md).
+
+## Change checks
+
+- Add sandbox client tests when changing session creation, attach, reconnect,
+  file operations, command execution, or NDJSON parsing.
+- Add lazy sandbox tests when changing provisioning, endpoint resolution,
+  retries, heartbeat behavior, or command job tracking.
+- Add shell-tool tests when changing agent-facing tool names, schemas, or
+  argument normalization.
+- Keep auth tokens server-side and redact backing service details from public
+  errors.
+- Update [Sandbox](../guides/sandbox.md) when public client behavior changes.

--- a/docs/architecture/24-ai-primitives.md
+++ b/docs/architecture/24-ai-primitives.md
@@ -1,0 +1,78 @@
+# AI primitives
+
+This page describes tool, prompt, and resource definitions. It does not cover
+agent message execution, provider request transport, MCP JSON-RPC dispatch, or
+skill policy.
+
+## Responsibility
+
+Tool, prompt, and resource code define reusable AI primitives, validate their
+schemas, register project-scoped definitions, and adapt definitions for agent
+and MCP runtime use.
+
+Primary source areas:
+
+- [`src/tool/`](../../src/tool/)
+- [`src/tool/factory.ts`](../../src/tool/factory.ts)
+- [`src/tool/executor.ts`](../../src/tool/executor.ts)
+- [`src/tool/registry.ts`](../../src/tool/registry.ts)
+- [`src/tool/remote-source-tools.ts`](../../src/tool/remote-source-tools.ts)
+- [`src/tool/remote-mcp.ts`](../../src/tool/remote-mcp.ts)
+- [`src/tool/schema/`](../../src/tool/schema/)
+- [`src/prompt/`](../../src/prompt/)
+- [`src/prompt/factory.ts`](../../src/prompt/factory.ts)
+- [`src/prompt/registry.ts`](../../src/prompt/registry.ts)
+- [`src/resource/`](../../src/resource/)
+- [`src/resource/factory.ts`](../../src/resource/factory.ts)
+- [`src/resource/registry.ts`](../../src/resource/registry.ts)
+
+## Runtime flow
+
+```mermaid
+flowchart TD
+  project[Project primitive files] --> discovery[Discovery and module loading]
+  discovery --> factory[Factory helpers]
+  factory --> schema[Schema normalization and validation]
+  schema --> registry[Project-scoped registries]
+
+  registry --> agent[Agent runtime inventory]
+  registry --> mcp[MCP runtime surface]
+  remote[Remote tool sources] --> agent
+  agent --> execute[Tool execution]
+  mcp --> load[Prompt or resource loading]
+```
+
+1. Discovery imports project files and identifies tool, prompt, and resource
+   exports.
+2. Factory helpers normalize ids, schemas, execution functions, generated
+   content, and resource loaders.
+3. Registry facades store project-scoped primitives for runtime lookup.
+4. Agent runtime consumes tool definitions and executes selected tools.
+5. MCP runtime can expose tools, prompts, and resources through protocol
+   handlers.
+6. Remote tool sources materialize project-scoped or MCP-backed tools without
+   global registration.
+
+## Boundaries
+
+- Agent runtime owns model loops, message state, and provider-neutral streaming.
+- Tool execution owns callable capability behavior and execution context.
+- Prompt and resource definitions own reusable prompt content and loadable
+  resource data.
+- MCP runtime owns JSON-RPC transport, session behavior, and protocol response
+  shapes.
+- Skill policy belongs in [skill runtime](./25-skill-runtime.md).
+
+## Change checks
+
+- Add factory and registry tests when changing primitive shape, id generation,
+  schema normalization, or project scoping.
+- Add executor tests when changing tool context, errors, result markers, or
+  tracing.
+- Add remote-source tests when changing remote tool filtering, materialization,
+  or project id hydration.
+- Add prompt and resource tests when changing interpolation, loader behavior,
+  params validation, or registry lookup.
+- Update [Tools](../guides/tools.md), [`veryfront/tool`](../reference/tool.md),
+  [`veryfront/prompt`](../reference/prompt.md), or
+  [`veryfront/resource`](../reference/resource.md) when public behavior changes.

--- a/docs/architecture/25-skill-runtime.md
+++ b/docs/architecture/25-skill-runtime.md
@@ -1,0 +1,77 @@
+# Skill runtime
+
+This page describes skill parsing, registration, prompt augmentation, allowed
+tool policy, path-safe reference loading, and script execution. It does not
+cover local tool definitions or provider request transport.
+
+## Responsibility
+
+Skill code turns `SKILL.md` directories into agent-usable instruction packs with
+metadata validation, optional reference files, optional executable scripts, and
+tool restrictions.
+
+Primary source areas:
+
+- [`src/skill/`](../../src/skill/)
+- [`src/skill/types.ts`](../../src/skill/types.ts)
+- [`src/skill/parser.ts`](../../src/skill/parser.ts)
+- [`src/skill/registry.ts`](../../src/skill/registry.ts)
+- [`src/skill/prompt-augmentation.ts`](../../src/skill/prompt-augmentation.ts)
+- [`src/skill/allowed-tools.ts`](../../src/skill/allowed-tools.ts)
+- [`src/skill/path-safety.ts`](../../src/skill/path-safety.ts)
+- [`src/skill/tools.ts`](../../src/skill/tools.ts)
+- [`src/skill/executor.ts`](../../src/skill/executor.ts)
+
+## Runtime flow
+
+```mermaid
+flowchart TD
+  skillDir[Skill directory] --> parse[Parse SKILL.md frontmatter and content]
+  parse --> validate[Validate metadata and allowed tool patterns]
+  validate --> registry[Register skill]
+  registry --> manifest[Build skill manifest prompt]
+  manifest --> agent[Agent runtime]
+  agent --> load[load-skill]
+  load --> active[Active skill context]
+  active --> reference[load-skill-reference]
+  active --> script[execute-skill-script]
+  active --> filter[Allowed tool filtering]
+  reference --> safety[Path safety checks]
+  script --> executor[Local or cloud script executor]
+```
+
+1. Skill discovery reads `SKILL.md`, parses frontmatter, and validates metadata.
+2. Registry helpers store project-scoped skills for lookup.
+3. Prompt augmentation summarizes available skills for agent planning.
+4. Built-in skill tools load instructions, read reference files, and execute
+   scripts.
+5. Allowed-tool policy filters callable tools while a skill is active.
+6. Path-safety helpers reject traversal and symlink escapes before reading
+   skill files.
+7. Script execution selects local subprocess execution or cloud sandbox
+   execution based on runtime credentials.
+
+## Boundaries
+
+- Skills provide instruction packs and tool policy. They are not workflows,
+  jobs, or local tool definitions.
+- Skills are configured through project discovery and `agent({ skills })`;
+  there is no top-level `veryfront/skill` import path in the current public
+  export map.
+- Local and remote tool definitions belong in [AI primitives](./24-ai-primitives.md).
+- Agent runtime decides when to call skill tools during model execution.
+- Sandbox client behavior belongs in [sandbox runtime](./23-sandbox-runtime.md).
+- Skill discovery paths are part of
+  [discovery and registries](./15-discovery-and-registries.md).
+
+## Change checks
+
+- Add parser tests when changing frontmatter shape, validation, defaults, or
+  metadata limits.
+- Add allowed-tool tests when changing exact-match or prefix-match policy.
+- Add path-safety tests when changing reference, asset, or script file access.
+- Add tool tests when changing `load-skill`, `load-skill-reference`, or
+  `execute-skill-script`.
+- Add executor tests when changing local execution, cloud execution, timeout
+  handling, or environment forwarding.
+- Update [Skills](../guides/skills.md) when public skill behavior changes.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -10,6 +10,20 @@ owns one boundary so docs stay easier to update when code changes.
   implementation details.
 - Runtime behavior, transport protocols, build output, and hosted control-plane
   behavior stay on separate pages.
+- Primary source areas use markdown links so GitHub readers can open the
+  owning code directly.
+- Add Mermaid diagrams only when they clarify ownership, branching, or sequence
+  better than prose or tables.
+
+## Page standard
+
+Each focused page gives the reader enough context to make a safe change:
+
+- Responsibility: what the boundary owns.
+- Primary source areas: the code entrypoints to inspect first.
+- Runtime or build flow: the execution sequence or lifecycle.
+- Boundaries: what this page does not own.
+- Change checks: the focused verification expected after a change.
 
 ## Architecture outline
 
@@ -34,6 +48,12 @@ owns one boundary so docs stay easier to update when code changes.
 | [17-observability.md](./17-observability.md)                       | Metrics, traces, logs, profiling, and errors |
 | [18-support-matrix.md](./18-support-matrix.md)                     | Runtime and capability support matrix        |
 | [19-runtime-boundaries.md](./19-runtime-boundaries.md)             | High-risk boundary change checklist          |
+| [20-jobs-and-tasks.md](./20-jobs-and-tasks.md)                     | Jobs client and task execution               |
+| [21-oauth-runtime.md](./21-oauth-runtime.md)                       | OAuth provider, state, and token flow        |
+| [22-integration-runtime.md](./22-integration-runtime.md)           | Integration catalog and remote tools         |
+| [23-sandbox-runtime.md](./23-sandbox-runtime.md)                   | Sandbox session and command execution        |
+| [24-ai-primitives.md](./24-ai-primitives.md)                       | Tool, prompt, and resource definitions       |
+| [25-skill-runtime.md](./25-skill-runtime.md)                       | Skill parsing, restrictions, and execution   |
 
 ## Update policy
 

--- a/docs/reference/agent-conversation-control-plane.md
+++ b/docs/reference/agent-conversation-control-plane.md
@@ -184,7 +184,7 @@ Keep these pieces host-local:
 
 When a host keeps local append retry or cursor recovery logic, use
 `isAppendableConversationRunProjection()` after a fresh `getConversationRun()`
-read to decide whether it should keep retrying appends or stop because the run
+read to decide whether it keeps retrying appends or stops because the run
 is already waiting for a tool result or has reached a terminal state.
 
 If the host specifically needs to recover from an append cursor mismatch, use
@@ -194,7 +194,7 @@ stayed unchanged but still appendable, or reached a non-appendable state.
 
 If the host also wants a reusable retry-limit gate around cursor mismatches,
 `recoverConversationRunCursorMismatch()` packages that decision and returns
-whether the host should resume, stop, or bubble the failure while still using
+whether the host resumes, stops, or bubbles the failure while still using
 the canonical conversation-run state model.
 
 For the broader append-failure branch, `recoverConversationRunAppendFailure()`
@@ -286,7 +286,7 @@ project policy in the host while keeping the control-plane contract shared.
 
 Child and delegated runs must preserve tool lifecycle state from the provider
 stream through durable events and host UI replay. On the happy path, downstream
-layers should not infer missing tool state.
+layers must not infer missing tool state.
 
 The canonical lifecycle is:
 
@@ -303,7 +303,7 @@ materialization. Wrappers can enrich behavior, but they must not silently
 replace a specific schema with permissive `{}` input.
 
 When streamed input is malformed, surface the first failure as
-`tool-input-error`. Later artifact checks can still fail, but they should not
+`tool-input-error`. Later artifact checks can still fail, but they must not
 mask the original malformed input failure.
 
 When changing this contract, run or add tests for:

--- a/docs/reference/agent-runtime-ag-ui.md
+++ b/docs/reference/agent-runtime-ag-ui.md
@@ -42,7 +42,7 @@ of the contract. Runtime context supports text, JSON, and resource entries.
 
 Signed control-plane invocation uses `RuntimeAgentRunInvocationSchema` around
 the runtime request when a trusted control plane owns durable run identity,
-project context, and validated claims. Public AG-UI runtime routes should use
+project context, and validated claims. Public AG-UI runtime routes use
 `AgUiRuntimeRequestSchema`.
 
 ## Package API

--- a/docs/reference/agent-service-runtime.md
+++ b/docs/reference/agent-service-runtime.md
@@ -47,7 +47,7 @@ Veryfront service server with graceful shutdown.
 
 ## Veryfront Cloud bootstrap
 
-Use `startAgentService()` from a process entrypoint when the service should use
+Use `startAgentService()` from a process entrypoint when the service uses
 the default Veryfront Cloud configuration, telemetry, model routing, sandbox,
 project steering, durable-run, and prepared-execution wiring.
 
@@ -63,14 +63,14 @@ await startAgentService({
 
 Discovery is rooted at the process cwd by default. The service name comes from
 `VERYFRONT_AGENT_SERVICE_NAME`, the nearest `package.json` or `deno.json`
-`name`, or `veryfront-agent-service`. Pass `serviceName` only when code should
+`name`, or `veryfront-agent-service`. Pass `serviceName` only when code must
 override that convention. Pass `baseDir` when the service may start from a
 different working directory. Pass `entrypointUrl` when deriving `baseDir` from
 a module URL is more convenient.
 
 If the service discovers exactly one code or markdown agent, that agent becomes
 the default automatically. Set `agentId` when the service exposes multiple
-agents or direct `/api/runs` requests should use a specific default.
+agents or direct `/api/runs` requests use a specific default.
 
 ## Remote MCP tools
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -76,6 +76,30 @@ const assistant = agent({
 });
 ```
 
+### Agent with materialized runtime tools
+
+```ts
+import { agent } from "veryfront/agent";
+import { createRemoteMCPToolSource, loadRemoteToolsFromSource } from "veryfront/tool";
+
+const docsTools = createRemoteMCPToolSource({
+  id: "docs-mcp",
+  endpoint: "https://docs.example.com/mcp",
+  headers: { Authorization: "Bearer <TOKEN>" },
+});
+
+const runtimeTools = await loadRemoteToolsFromSource(docsTools, {
+  context: { projectId: "proj_123" },
+  toolNameAliases: { search_docs: "docs_search" },
+});
+
+const assistant = agent({
+  system: "Use the docs tools when the answer needs project documentation.",
+  tools: runtimeTools,
+  maxSteps: 5,
+});
+```
+
 ### Agent with skills
 
 ```ts

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -58,3 +58,4 @@ Reference pages cover top-level public import surfaces. Deep public exports, suc
 - [Agent runtime AG-UI](./agent-runtime-ag-ui.md) covers package-hosted AG-UI runtime contracts and endpoint conventions.
 - [Agent service runtime](./agent-service-runtime.md) covers separately deployed agent services.
 - [Agent tooling and runtime state](./agent-tooling.md) covers tool allowlists, provider-native tool discovery, and runtime state hooks.
+- [Skills](../guides/skills.md) covers project-level `SKILL.md` capabilities. Skills are configured through agent discovery and `agent({ skills })`; there is no top-level `veryfront/skill` import path.

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -17,10 +17,17 @@ import { getConnector, getConnectorNames, getIcon, listConnectors } from "veryfr
 ## Examples
 
 ```ts
-import { getIcon, listConnectors } from "veryfront/integrations";
+import {
+  getConnector,
+  getIcon,
+  getRemoteIntegrationToolDefinitions,
+  listConnectors,
+} from "veryfront/integrations";
 
 const connectors = listConnectors();
+const slack = getConnector("slack");
 const slackIcon = getIcon("slack"); // raw SVG string
+const runtimeTools = await getRemoteIntegrationToolDefinitions();
 ```
 
 ## Exports

--- a/docs/reference/prompt.md
+++ b/docs/reference/prompt.md
@@ -24,6 +24,11 @@ const summarize = prompt({
   description: "Summarize text in a chosen style",
   content: "Summarize the following text in {style} style:\n\n{text}",
 });
+
+const content = await summarize.getContent({
+  style: "technical",
+  text: "The runtime loads tools before an agent step starts.",
+});
 ```
 
 ## API

--- a/docs/reference/resource.md
+++ b/docs/reference/resource.md
@@ -20,14 +20,21 @@ import { resource, resourceRegistry } from "veryfront/resource";
 import { resource } from "veryfront/resource";
 import { z } from "zod";
 
+const docsBySection: Record<string, string> = {
+  agents: "Agents accept messages, tools, context, and runtime options.",
+  tools: "Tools expose schema-backed callable capabilities.",
+};
+
 const docs = resource({
   pattern: "docs/:section",
   description: "API documentation",
   paramsSchema: z.object({ section: z.string() }),
-  load: async ({ section }) => {
-    return { content: await readDocs(section) };
+  load: ({ section }) => {
+    return { content: docsBySection[section] ?? "Section not found." };
   },
 });
+
+const result = await docs.load({ section: "agents" });
 ```
 
 ## API

--- a/docs/reference/tool.md
+++ b/docs/reference/tool.md
@@ -15,6 +15,7 @@ import {
   createRemoteMCPToolSource,
   dynamicTool,
   executeTool,
+  loadRemoteToolsFromSource,
   tool,
   toolRegistry,
 } from "veryfront/tool";
@@ -28,13 +29,12 @@ import {
 import { tool } from "veryfront/tool";
 import { z } from "zod";
 
-const weather = tool({
-  id: "weather",
-  description: "Get current weather for a city",
-  inputSchema: z.object({ city: z.string() }),
-  execute: async ({ city }) => {
-    const res = await fetch(`https://api.weather.com/${city}`);
-    return res.json();
+const convertLength = tool({
+  id: "convert_length",
+  description: "Convert meters to feet",
+  inputSchema: z.object({ meters: z.number().nonnegative() }),
+  execute: ({ meters }) => {
+    return { feet: meters * 3.28084 };
   },
 });
 ```
@@ -42,29 +42,29 @@ const weather = tool({
 ### Use with an agent
 
 ```ts
-import { tool } from "veryfront/tool";
 import { agent } from "veryfront/agent";
+import { tool } from "veryfront/tool";
 import { z } from "zod";
 
-const weather = tool({
-  id: "weather",
-  description: "Get current weather for a city",
-  inputSchema: z.object({ city: z.string() }),
-  execute: async ({ city }) => {
-    const res = await fetch(`https://api.weather.com/${city}`);
-    return res.json();
+const convertLength = tool({
+  id: "convert_length",
+  description: "Convert meters to feet",
+  inputSchema: z.object({ meters: z.number().nonnegative() }),
+  execute: ({ meters }) => {
+    return { feet: meters * 3.28084 };
   },
 });
 
 const assistant = agent({
-  system: "You help with weather questions.",
-  tools: [weather],
+  system: "You answer unit-conversion questions.",
+  tools: { convert_length: convertLength },
 });
 ```
 
-### Remote MCP tool source
+### Load remote tools for an agent
 
 ```ts
+import { agent } from "veryfront/agent";
 import { createRemoteMCPToolSource, loadRemoteToolsFromSource } from "veryfront/tool";
 
 const docsTools = createRemoteMCPToolSource({
@@ -76,6 +76,16 @@ const docsTools = createRemoteMCPToolSource({
 const runtimeTools = await loadRemoteToolsFromSource(docsTools, {
   context: { projectId: "proj_123" },
   toolNameAliases: { search_docs: "docs_search" },
+});
+
+const assistant = agent({
+  system: "Use the docs tools when a question needs project documentation.",
+  tools: runtimeTools,
+  maxSteps: 5,
+});
+
+const result = await assistant.generate({
+  input: "Find the deployment guide for this project.",
 });
 ```
 

--- a/scripts/docs/generate-api-reference.ts
+++ b/scripts/docs/generate-api-reference.ts
@@ -170,7 +170,7 @@ const EMPTY_BARREL_JSDOC: BarrelJSDoc = {
 };
 
 // ---------------------------------------------------------------------------
-// Curated import snippets — show the most representative imports per module
+// Curated import snippets: show the most representative imports per module
 // ---------------------------------------------------------------------------
 
 const IMPORT_PRIORITY: Record<string, string[]> = {
@@ -187,7 +187,7 @@ const IMPORT_PRIORITY: Record<string, string[]> = {
   "veryfront/agent": [
     "agent", "AgentRuntime", "registerAgent", "getAgentsAsTools", "createMemory",
   ],
-  "veryfront/tool": ["tool", "dynamicTool", "toolRegistry"],
+  "veryfront/tool": ["tool", "dynamicTool", "loadRemoteToolsFromSource", "toolRegistry"],
   "veryfront/workflow": [
     "workflow", "step", "parallel", "branch", "waitForApproval", "createWorkflowClient",
   ],
@@ -202,7 +202,7 @@ const IMPORT_PRIORITY: Record<string, string[]> = {
     "registerModelProvider", "resolveModel", "hasModelProvider", "getRegisteredModelProviders",
   ],
   "veryfront/fs": ["readTextFile", "writeTextFile", "join", "resolve", "exists", "mkdir"],
-  // CLI is an executable entry point, not an importable module — skip import snippet
+  // CLI is an executable entry point, not an importable module. Skip import snippet.
   "veryfront/cli": [],
 };
 
@@ -1225,7 +1225,7 @@ const PROPERTY_DESCRIPTIONS: Record<string, Record<string, string>> = {
   AgentConfig: {
     id: "Unique identifier (auto-generated if omitted)",
     model: "Provider and model (e.g. `\"openai/gpt-4o\"`)",
-    system: "System prompt — string, function, or async function",
+    system: "System prompt: string, function, or async function",
     tools: "Tools available to the agent",
     maxSteps: "Max tool-call iterations per request",
     streaming: "Enable streaming responses",
@@ -1338,12 +1338,12 @@ const PROPERTY_DESCRIPTIONS: Record<string, Record<string, string>> = {
     execute: "Step handler function",
     agent: "Agent to run (by ID or instance)",
     tool: "Tool to execute (by ID or instance)",
-    input: "Step input — static value or function of workflow context",
+    input: "Step input: static value or function of workflow context",
     checkpoint: "Persist state after this step",
     retry: "Retry configuration for this step",
     retries: "Retry attempts on failure",
     timeout: "Step timeout (ms)",
-    skip: "Predicate — skip this step if returns true",
+    skip: "Predicate: skip this step if returns true",
   },
   BranchOptions: {
     condition: "Branch predicate function",
@@ -1352,7 +1352,7 @@ const PROPERTY_DESCRIPTIONS: Record<string, Record<string, string>> = {
     checkpoint: "Persist state after this node",
     retry: "Retry configuration",
     timeout: "Node timeout (ms or duration string)",
-    skip: "Predicate — skip if returns true",
+    skip: "Predicate: skip if returns true",
   },
   ParallelOptions: {
     steps: "Steps to run concurrently",
@@ -1361,7 +1361,7 @@ const PROPERTY_DESCRIPTIONS: Record<string, Record<string, string>> = {
     checkpoint: "Persist state after this node",
     retry: "Retry configuration",
     timeout: "Node timeout (ms or duration string)",
-    skip: "Predicate — skip if returns true",
+    skip: "Predicate: skip if returns true",
   },
   CorsOptions: {
     origin: "Allowed origins (string, regex, array, or function)",
@@ -1528,7 +1528,7 @@ function generateAPISection(nodes: DocNode[], importPath: string): string[] {
           lines.push(`### \`${typeName.charAt(0).toLowerCase() + typeName.slice(1)}.${method.name}(${paramNames})\``);
           lines.push("");
 
-          // Method description — upstream JSDoc first, then curated fallback
+          // Method description: upstream JSDoc first, then curated fallback
           const methodDesc = method.jsDoc?.doc?.split("\n")[0] ?? methodMeta[method.name]?.desc ?? "";
           if (methodDesc) {
             lines.push(methodDesc);
@@ -1694,7 +1694,7 @@ function generateMD(
     lines.push("");
   }
 
-  // Import snippet — use curated priority list
+  // Import snippet: use curated priority list
   const priorityNames = IMPORT_PRIORITY[entry.importPath];
   const allExportNames = new Set([
     ...exports.functions.map((e) => e.name),
@@ -1794,7 +1794,7 @@ function generateMD(
     lines.push("");
     for (const r of related) {
       const displayName = r.path === "root" ? "veryfront" : `veryfront/${r.path}`;
-      lines.push(`- [\`${displayName}\`](./${r.path}.md) — ${r.reason}`);
+      lines.push(`- [\`${displayName}\`](./${r.path}.md): ${r.reason}`);
     }
     lines.push("");
   }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -16,14 +16,12 @@
  * ```ts
  * import { agent } from "veryfront/agent";
  * import { tool } from "veryfront/tool";
- * import { defineSchema, lazySchema } from "veryfront/schemas";
- *
- * const getSearchInput = defineSchema((v) => v.object({ query: v.string() }));
+ * import { z } from "zod";
  *
  * const searchTool = tool({
  *   id: "search",
  *   description: "Search the knowledge base",
- *   inputSchema: lazySchema(getSearchInput),
+ *   inputSchema: z.object({ query: z.string() }),
  *   execute: async ({ query }) => ({ results: [] }),
  * });
  *
@@ -31,6 +29,29 @@
  *   system: "You are a helpful assistant.",
  *   tools: { search: searchTool },
  *   memory: { type: "conversation", maxMessages: 50 },
+ * });
+ * ```
+ *
+ * @example Agent with materialized runtime tools
+ * ```ts
+ * import { agent } from "veryfront/agent";
+ * import { createRemoteMCPToolSource, loadRemoteToolsFromSource } from "veryfront/tool";
+ *
+ * const docsTools = createRemoteMCPToolSource({
+ *   id: "docs-mcp",
+ *   endpoint: "https://docs.example.com/mcp",
+ *   headers: { Authorization: "Bearer <TOKEN>" },
+ * });
+ *
+ * const runtimeTools = await loadRemoteToolsFromSource(docsTools, {
+ *   context: { projectId: "proj_123" },
+ *   toolNameAliases: { search_docs: "docs_search" },
+ * });
+ *
+ * const assistant = agent({
+ *   system: "Use the docs tools when the answer needs project documentation.",
+ *   tools: runtimeTools,
+ *   maxSteps: 5,
  * });
  * ```
  *

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -4,10 +4,17 @@
  *
  * @example
  * ```ts
- * import { listConnectors, getIcon } from "veryfront/integrations";
+ * import {
+ *   getConnector,
+ *   getIcon,
+ *   getRemoteIntegrationToolDefinitions,
+ *   listConnectors,
+ * } from "veryfront/integrations";
  *
  * const connectors = listConnectors();
+ * const slack = getConnector("slack");
  * const slackIcon = getIcon("slack"); // raw SVG string
+ * const runtimeTools = await getRemoteIntegrationToolDefinitions();
  * ```
  */
 export type {

--- a/src/prompt/index.ts
+++ b/src/prompt/index.ts
@@ -12,6 +12,11 @@
  *   description: "Summarize text in a chosen style",
  *   content: "Summarize the following text in {style} style:\n\n{text}",
  * });
+ *
+ * const content = await summarize.getContent({
+ *   style: "technical",
+ *   text: "The runtime loads tools before an agent step starts.",
+ * });
  * ```
  */
 

--- a/src/resource/index.ts
+++ b/src/resource/index.ts
@@ -8,14 +8,21 @@
  * import { resource } from "veryfront/resource";
  * import { z } from "zod";
  *
+ * const docsBySection: Record<string, string> = {
+ *   agents: "Agents accept messages, tools, context, and runtime options.",
+ *   tools: "Tools expose schema-backed callable capabilities.",
+ * };
+ *
  * const docs = resource({
  *   pattern: "docs/:section",
  *   description: "API documentation",
  *   paramsSchema: z.object({ section: z.string() }),
- *   load: async ({ section }) => {
- *     return { content: await readDocs(section) };
+ *   load: ({ section }) => {
+ *     return { content: docsBySection[section] ?? "Section not found." };
  *   },
  * });
+ *
+ * const result = await docs.load({ section: "agents" });
  * ```
  */
 

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -8,37 +8,61 @@
  * import { tool } from "veryfront/tool";
  * import { z } from "zod";
  *
- * const weather = tool({
- *   id: "weather",
- *   description: "Get current weather for a city",
- *   inputSchema: z.object({ city: z.string() }),
- *   execute: async ({ city }) => {
- *     const res = await fetch(`https://api.weather.com/${city}`);
- *     return res.json();
+ * const convertLength = tool({
+ *   id: "convert_length",
+ *   description: "Convert meters to feet",
+ *   inputSchema: z.object({ meters: z.number().nonnegative() }),
+ *   execute: ({ meters }) => {
+ *     return { feet: meters * 3.28084 };
  *   },
  * });
  * ```
  *
  * @example Use with an agent
  * ```ts
- * import { tool } from "veryfront/tool";
  * import { agent } from "veryfront/agent";
+ * import { tool } from "veryfront/tool";
  * import { z } from "zod";
  *
- * const weather = tool({
- *   id: "weather",
- *   description: "Get current weather for a city",
- *   inputSchema: z.object({ city: z.string() }),
- *   execute: async ({ city }) => {
- *     const res = await fetch(`https://api.weather.com/${city}`);
- *     return res.json();
+ * const convertLength = tool({
+ *   id: "convert_length",
+ *   description: "Convert meters to feet",
+ *   inputSchema: z.object({ meters: z.number().nonnegative() }),
+ *   execute: ({ meters }) => {
+ *     return { feet: meters * 3.28084 };
  *   },
  * });
  *
  * const assistant = agent({
- *   model: "openai/gpt-4o",
- *   system: "You help with weather questions.",
- *   tools: [weather],
+ *   system: "You answer unit-conversion questions.",
+ *   tools: { convert_length: convertLength },
+ * });
+ * ```
+ *
+ * @example Load remote tools for an agent
+ * ```ts
+ * import { agent } from "veryfront/agent";
+ * import { createRemoteMCPToolSource, loadRemoteToolsFromSource } from "veryfront/tool";
+ *
+ * const docsTools = createRemoteMCPToolSource({
+ *   id: "docs-mcp",
+ *   endpoint: "https://docs.example.com/mcp",
+ *   headers: { Authorization: "Bearer <TOKEN>" },
+ * });
+ *
+ * const runtimeTools = await loadRemoteToolsFromSource(docsTools, {
+ *   context: { projectId: "proj_123" },
+ *   toolNameAliases: { search_docs: "docs_search" },
+ * });
+ *
+ * const assistant = agent({
+ *   system: "Use the docs tools when a question needs project documentation.",
+ *   tools: runtimeTools,
+ *   maxSteps: 5,
+ * });
+ *
+ * const result = await assistant.generate({
+ *   input: "Find the deployment guide for this project.",
  * });
  * ```
  */


### PR DESCRIPTION
## Summary
- Add missing architecture pages for jobs/tasks, OAuth, integrations, sandbox, AI primitives, and skills.
- Add Mermaid flow diagrams where they clarify runtime ownership and convert architecture source paths to GitHub-clickable links.
- Update reference examples for tools, agents, prompts, resources, and integrations, including materialized remote runtime tools passed to an agent.

## Verification
- `deno fmt --check docs/architecture docs/reference src/agent/index.ts src/tool/index.ts src/resource/index.ts src/prompt/index.ts src/integrations/index.ts scripts/docs/generate-api-reference.ts`
- `deno task validate:architecture` (0 errors, 8 existing handler-size warnings)
- `deno check src/agent/index.ts src/tool/index.ts src/resource/index.ts src/prompt/index.ts src/integrations/index.ts scripts/docs/generate-api-reference.ts`
- `deno task docs:validate`
- `git diff --check`
- `deno task lint:barrel-jsdoc`
- `deno run --allow-read --allow-write --allow-run scripts/docs/generate-api-reference.ts --output /tmp/veryfront-reference-check`
