### PR TITLE
Make Veryfront Code guides practical and current

### DIFF
--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -134,6 +134,16 @@ export async function POST(request: Request) {
 }
 ```
 
+Try it with the dev server running:
+
+```bash
+curl -N http://localhost:3000/api/chat \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"id":"1","role":"user","parts":[{"type":"text","text":"Say hello in one sentence."}]}]}'
+```
+
+The response streams the agent output. If the route returns `Agent not found`, ensure the agent file is in `agents/` and its `id` matches the value passed to `getAgent()`.
+
 ## Non-streaming response
 
 For server-side generation (e.g., in `getServerData`), use `generate()`:

--- a/docs/guides/api-routes.md
+++ b/docs/guides/api-routes.md
@@ -8,7 +8,29 @@ order: 6
 
 HTTP handlers, request parsing, and streaming responses.
 
-Examples below use the default app router. Veryfront Code also supports API routes under `pages/api/**`, but the pages router uses a different handler module shape than `app/api/**/route.*`.
+Veryfront supports API routes in the app router and the pages router. The router changes the file location and handler arguments. The request and response APIs stay based on the standard Web `Request` and `Response` objects.
+
+## Router module shapes
+
+Use `app/api/**/route.ts` in the app router. Export named HTTP method handlers. Each handler receives the `Request` directly and receives route params in the second argument.
+
+```ts
+// app/api/hello/route.ts
+export function GET() {
+  return Response.json({ message: "Hello, world!" });
+}
+```
+
+Use `pages/api/**` in the pages router. Export named HTTP method handlers or a `default` fallback handler. Each handler receives an `APIContext` as `ctx`; use `ctx.request` for the raw request, `ctx.params` for route params, `ctx.query` for query parameters, and `ctx.json()` or `Response.json()` to return JSON.
+
+```ts
+// pages/api/hello.ts
+import type { APIContext } from "veryfront";
+
+export function GET(ctx: APIContext) {
+  return ctx.json({ message: "Hello, world!" });
+}
+```
 
 ## Basic route
 
@@ -27,40 +49,86 @@ Export any standard HTTP method:
 
 ```ts
 // app/api/users/route.ts
+const users = [{ id: "user_123", name: "Ada Lovelace" }];
+
 export async function GET() {
-  const users = await db.users.findMany();
   return Response.json(users);
 }
 
 export async function POST(request: Request) {
   const body = await request.json();
-  const user = await db.users.create(body);
+  const user = { id: "user_456", ...body };
   return Response.json(user, { status: 201 });
 }
 
 export async function DELETE(request: Request) {
   const { id } = await request.json();
-  await db.users.delete(id);
+  if (!id) return Response.json({ error: "Missing id" }, { status: 400 });
+  return new Response(null, { status: 204 });
+}
+```
+
+The same pages router route uses `ctx`:
+
+```ts
+// pages/api/users.ts
+import type { APIContext } from "veryfront";
+
+const users = [{ id: "user_123", name: "Ada Lovelace" }];
+
+export async function GET(ctx: APIContext) {
+  return ctx.json(users);
+}
+
+export async function POST(ctx: APIContext) {
+  const body = await ctx.request.json();
+  const user = { id: "user_456", ...body };
+  return ctx.json(user, { status: 201 });
+}
+
+export async function DELETE(ctx: APIContext) {
+  const { id } = await ctx.request.json();
+  if (!id) return ctx.json({ error: "Missing id" }, { status: 400 });
   return new Response(null, { status: 204 });
 }
 ```
 
 ## Dynamic parameters
 
-Use brackets in the path, then read params from the URL:
+Use brackets in the path, then read params from the route context:
 
 ```ts
 // app/api/users/[id]/route.ts
-export async function GET(request: Request) {
-  const url = new URL(request.url);
-  const id = url.pathname.split("/").pop();
-  const user = await db.users.findById(id);
+export async function GET(
+  _request: Request,
+  { params }: { params: Record<string, string> },
+) {
+  const id = params.id;
 
-  if (!user) {
+  if (!id) {
     return Response.json({ error: "Not found" }, { status: 404 });
   }
 
+  const user = { id, name: "Ada Lovelace" };
   return Response.json(user);
+}
+```
+
+In the pages router, params are available on `ctx.params`:
+
+```ts
+// pages/api/users/[id].ts
+import type { APIContext } from "veryfront";
+
+export async function GET(ctx: APIContext) {
+  const id = String(ctx.params.id ?? "");
+
+  if (!id) {
+    return ctx.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const user = { id, name: "Ada Lovelace" };
+  return ctx.json(user);
 }
 ```
 

--- a/docs/guides/api-routes.md
+++ b/docs/guides/api-routes.md
@@ -43,6 +43,18 @@ export function GET() {
 
 This creates `GET /api/hello`.
 
+Try it with the dev server running:
+
+```bash
+curl http://localhost:3000/api/hello
+```
+
+The response should be:
+
+```json
+{ "message": "Hello, world!" }
+```
+
 ## HTTP methods
 
 Export any standard HTTP method:

--- a/docs/guides/chat-composition.md
+++ b/docs/guides/chat-composition.md
@@ -8,6 +8,8 @@ order: 15
 
 Use composition when the preset `Chat` component is too constrained but you still want Veryfront to own the chat wiring.
 
+The examples use the same `useChat({ api: "/api/chat" })` setup as the [Chat UI](./chat-ui.md) guide. Create the chat route first, then render these components in a client page and verify them with `veryfront dev`.
+
 ## Layout components
 
 ```tsx

--- a/docs/guides/chat-hooks.md
+++ b/docs/guides/chat-hooks.md
@@ -8,6 +8,8 @@ order: 16
 
 Use chat hooks when you need state and runtime integration without the preset UI.
 
+The examples below assume your app has a chat endpoint at `/api/chat`. Use the route from [Chat UI](./chat-ui.md) or [Agents](./agents.md), then run `veryfront dev` and open the page that renders the hook.
+
 ## useChat
 
 ```tsx

--- a/docs/guides/chat-theming.md
+++ b/docs/guides/chat-theming.md
@@ -8,6 +8,8 @@ order: 17
 
 Use this guide for visual customization and optional chat UI features.
 
+Start from the working `Chat` example in [Chat UI](./chat-ui.md). Apply one option at a time, run `veryfront dev`, and verify the chat still sends messages through `/api/chat`.
+
 ## Theme overrides
 
 ```tsx

--- a/docs/guides/chat-ui.md
+++ b/docs/guides/chat-ui.md
@@ -12,6 +12,18 @@ Route examples below use the default app router. Veryfront Code also supports mo
 
 ## Quick setup
 
+Create an agent:
+
+```ts
+// agents/assistant.ts
+import { agent } from "veryfront/agent";
+
+export default agent({
+  id: "assistant",
+  system: "You are a helpful assistant. Answer concisely.",
+});
+```
+
 Create a client page:
 
 ```tsx
@@ -35,6 +47,14 @@ export const POST = createChatHandler("assistant");
 ```
 
 `createChatHandler` validates requests, prepares chat messages, and streams the agent response. The `Chat` component renders the input, message list, loading state, and scroll behavior.
+
+Run `veryfront dev`, open [http://localhost:3000](http://localhost:3000), and send a message. To test the route without the UI:
+
+```bash
+curl -N http://localhost:3000/api/chat \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"id":"1","role":"user","parts":[{"type":"text","text":"Say hello."}]}]}'
+```
 
 ## Add preprocessing
 

--- a/docs/guides/cli-knowledge-ingestion.md
+++ b/docs/guides/cli-knowledge-ingestion.md
@@ -56,9 +56,9 @@ veryfront login
 
 `veryfront knowledge ingest` requires `python3`.
 
-Inside the Veryfront sandbox image, the embedded parser uses `docling` for PDF, Office, and HTML extraction.
+Inside a Veryfront sandbox, `docling` and the fallback parser packages are already installed. The embedded parser uses `docling` first for PDF, Office, and HTML extraction.
 
-If you are running outside the Veryfront sandbox image, install `docling` to match the sandbox parsing path:
+If you run the CLI outside a Veryfront sandbox, install `docling` and the fallback parser packages to match the sandbox parsing path:
 
 ```bash
 pip install docling pandas openpyxl xlrd pdfplumber python-docx python-pptx beautifulsoup4 lxml
@@ -213,11 +213,11 @@ veryfront knowledge ingest uploads/contracts/q1.pdf --project my-project --json
 
 ### Python package errors
 
-Install the parser packages listed above, or run the command inside the Veryfront sandbox image where the knowledge-ingestion stack is already available.
+Install the parser packages listed above, or run the command inside a Veryfront sandbox where the knowledge-ingestion stack is already available.
 
 ### `docling` is not installed
 
-Inside the sandbox image, `docling` is preinstalled. Outside the sandbox, install `docling` if you want the same extraction path locally. If `docling` is not installed or extraction fails, the command falls back to the Python parser stack for supported formats.
+Inside a Veryfront sandbox, `docling` is already installed. Outside a Veryfront sandbox, install `docling` if you want the same extraction path locally. If `docling` is not installed or extraction fails, the command falls back to the Python parser stack for supported formats.
 
 ## Recommended agent flow
 

--- a/docs/guides/data-fetching.md
+++ b/docs/guides/data-fetching.md
@@ -18,16 +18,17 @@ Examples below use the default app router. Veryfront Code also supports the page
 // app/dashboard/page.tsx
 import type { DataContext } from "veryfront";
 
-export async function getServerData({ request, params }: DataContext) {
-  const token = request.headers.get("authorization");
-  const user = await fetchUser(token);
-  return { props: { user } };
+export async function getServerData({ query }: DataContext) {
+  const name = query.get("name") ?? "Ada";
+  return { props: { user: { name } } };
 }
 
-export default function Dashboard({ user }: { user: User }) {
+export default function Dashboard({ user }: { user: { name: string } }) {
   return <h1>Welcome, {user.name}</h1>;
 }
 ```
+
+Run `veryfront dev` and open [http://localhost:3000/dashboard?name=Grace](http://localhost:3000/dashboard?name=Grace). The page should render `Welcome, Grace`.
 
 The `DataContext` provides:
 
@@ -43,19 +44,23 @@ The `DataContext` provides:
 
 ```tsx
 // app/blog/[slug]/page.tsx
+const posts = [
+  { slug: "hello", title: "Hello" },
+  { slug: "workflow", title: "Workflow notes" },
+];
+
 export async function getStaticData({ params }: { params: { slug: string } }) {
-  const post = await getPost(params.slug);
+  const post = posts.find((item) => item.slug === params.slug);
   return { props: { post } };
 }
 
 export async function getStaticPaths() {
-  const posts = await getAllPosts();
   return {
     paths: posts.map((p) => ({ params: { slug: p.slug } })),
   };
 }
 
-export default function BlogPost({ post }: { post: Post }) {
+export default function BlogPost({ post }: { post: { title: string } }) {
   return <article>{post.title}</article>;
 }
 ```
@@ -67,15 +72,13 @@ For dynamic routes, pair `getStaticData` with `getStaticPaths` to tell the frame
 Return `redirect()` or `notFound()` from any data function:
 
 ```tsx
-import { notFound, redirect } from "veryfront";
+import { type DataContext, notFound, redirect } from "veryfront";
 
 export async function getServerData({ params }: DataContext) {
-  const post = await getPost(params.slug);
+  if (params.slug === "old-post") return redirect("/blog/hello");
+  if (params.slug !== "hello") return notFound();
 
-  if (!post) return notFound();
-  if (post.moved) return redirect(`/blog/${post.newSlug}`);
-
-  return { props: { post } };
+  return { props: { post: { title: "Hello" } } };
 }
 ```
 

--- a/docs/guides/extension-lifecycle.md
+++ b/docs/guides/extension-lifecycle.md
@@ -56,6 +56,14 @@ Extensions can also read project config through `ctx.config` during `setup()`.
 
 During development, changes to `veryfront.config.ts` trigger teardown, rediscovery, and setup. Extensions must release resources in `teardown()` so reloads do not leak connections, timers, or file handles.
 
+Verify reload behavior by adding a temporary log in the extension `setup()` and `teardown()` methods, then run:
+
+```bash
+veryfront dev
+```
+
+Save `veryfront.config.ts`. The dev server should run `teardown()` for the previous extension instance and `setup()` for the new one.
+
 ## Next
 
 - [Extension testing](./extension-testing.md): test factories and contracts

--- a/docs/guides/extensions.md
+++ b/docs/guides/extensions.md
@@ -45,6 +45,14 @@ export default defineConfig({
 });
 ```
 
+Verify the extension loads by running the dev server:
+
+```bash
+veryfront dev
+```
+
+If the extension factory throws during setup, the dev server reports the setup error. For local extensions, edit the extension source and save `veryfront.config.ts` to force reload during development.
+
 ## First-party extension areas
 
 | Area          | Example package                              | Contract family   |

--- a/docs/guides/jobs.md
+++ b/docs/guides/jobs.md
@@ -40,6 +40,15 @@ const jobs = createJobsClient({
 
 If you are already running inside a Veryfront request context, the client can also pick up request-scoped auth and project context automatically.
 
+Verify the connection before creating jobs:
+
+```ts
+const targets = await jobs.targets.list();
+console.log(targets.data.map((target) => target.target));
+```
+
+This call is read-only and confirms that the token, project reference, and API endpoint resolve correctly.
+
 ## Create a one-off job
 
 ```ts

--- a/docs/guides/jobs.md
+++ b/docs/guides/jobs.md
@@ -54,7 +54,6 @@ const job = await jobs.create({
   name: "Ingest 1 file to knowledge base",
   target: "task:knowledge-ingest",
   config: {
-    file_count: 1,
     upload_ids: ["11111111-1111-4111-8111-111111111111"],
   },
 });
@@ -95,6 +94,8 @@ for (const definition of targets.data) {
 ```
 
 This is the public source of truth for first-party target contracts such as `task:knowledge-ingest`.
+The `config` object is target-specific. Use target discovery to inspect the
+fields the selected target accepts.
 
 ## Work with batches
 
@@ -117,7 +118,6 @@ const cronJob = await jobs.cron.create({
   schedule: "0 2 * * *",
   timezone: "Europe/Stockholm",
   config: {
-    file_count: 1,
     upload_ids: ["11111111-1111-4111-8111-111111111111"],
   },
 });

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -13,6 +13,7 @@ This guide covers the application-facing MCP server exposed by `veryfront/mcp`. 
 ## Setup
 
 ```ts
+// app/api/mcp/route.ts
 import { createMCPServer } from "veryfront/mcp";
 
 const server = createMCPServer({
@@ -30,6 +31,23 @@ export const OPTIONS = handler;
 ```
 
 Mount the handler on your application-owned MCP route. All auto-discovered tools, prompts, and resources are then exposed through the app-facing MCP transport.
+
+Start the dev server with a local token:
+
+```bash
+MCP_TOKEN=dev-token veryfront dev
+```
+
+Smoke test the route by sending an MCP `initialize` request:
+
+```bash
+curl -i http://localhost:3000/api/mcp \
+  -H "Authorization: Bearer dev-token" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"curl","version":"0.0.0"}}}'
+```
+
+The response should include a `MCP-Session-Id` header and a JSON-RPC result with server capabilities.
 
 ### Auth is required
 

--- a/docs/guides/memory-and-streaming.md
+++ b/docs/guides/memory-and-streaming.md
@@ -13,6 +13,8 @@ Route examples below use the default app router. Veryfront Code also supports mo
 Memory configuration is independent of model selection, so these examples omit
 `model` and follow the runtime default.
 
+To test these examples, define the agent, expose it through the `/api/chat` route shown below, run `veryfront dev`, and send messages from the [Chat UI](./chat-ui.md) guide or with `curl`.
+
 ## Memory types
 
 Configure memory on your agent to persist messages across requests:

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -110,6 +110,14 @@ export async function GET(ctx: APIContext) {
 }
 ```
 
+Try it with the dev server running:
+
+```bash
+curl -i http://localhost:3000/api/users
+```
+
+The response should include any headers added by the middleware that matched the request. If a middleware returns a `Response`, the route handler stops there and returns that response.
+
 ### Cleanup callbacks
 
 Register teardown logic that runs after the response is sent:

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -8,7 +8,10 @@ order: 7
 
 CORS, rate limiting, logging, and custom middleware pipelines.
 
-Examples below use the default app router. Veryfront Code also supports API routes under `pages/api/**`, but the pages router uses a different handler module shape than `app/api/**/route.*`.
+The middleware pipeline works in both router styles. The route module wrapper changes:
+
+- App router API routes live at `app/api/**/route.ts` and export named HTTP method handlers such as `GET` or `POST`. The handler receives the `Request` directly.
+- Pages router API routes live at `pages/api/**` and export named HTTP method handlers or a `default` fallback handler. The handler receives an `APIContext` as `ctx`; use `ctx.request` when a middleware expects a `Request`.
 
 ## Built-in middleware
 
@@ -81,12 +84,29 @@ const pipeline = new MiddlewarePipeline()
 
 ```ts
 // app/api/users/route.ts
+const users = [{ id: "user_123", name: "Ada Lovelace" }];
+
 export async function GET(request: Request) {
   const result = await pipeline.execute(request);
   if (result) return result; // Middleware returned a response (e.g., rate limit exceeded)
 
-  const users = await db.users.findMany();
   return Response.json(users);
+}
+```
+
+The same pipeline can run in a pages router handler by passing `ctx.request`:
+
+```ts
+// pages/api/users.ts
+import type { APIContext } from "veryfront";
+
+const users = [{ id: "user_123", name: "Ada Lovelace" }];
+
+export async function GET(ctx: APIContext) {
+  const result = await pipeline.execute(ctx.request);
+  if (result) return result; // Middleware returned a response (e.g., rate limit exceeded)
+
+  return ctx.json(users);
 }
 ```
 

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -55,6 +55,27 @@ export default agent({
 
 `getAgentsAsTools()` wraps each agent as a tool. The orchestrator decides when to call each agent based on its system prompt. Each sub-agent runs its own tool loop independently.
 
+### Invoke the orchestrator
+
+Expose the orchestrator through a chat route:
+
+```ts
+// app/api/chat/route.ts
+import { createChatHandler } from "veryfront/agent";
+
+export const POST = createChatHandler("orchestrator");
+```
+
+Run the dev server and ask for an output that requires delegation:
+
+```bash
+curl -N http://localhost:3000/api/chat \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"id":"1","role":"user","parts":[{"type":"text","text":"Research Deno Deploy and write a short technical summary."}]}]}'
+```
+
+The orchestrator receives the user message, then calls `researcher` and `writer` as tools when the model decides they are needed.
+
 ### Single agent-as-tool
 
 For wrapping a single agent:
@@ -86,6 +107,8 @@ export default workflow({
   ],
 });
 ```
+
+Start this workflow from an API route, task, or tool. The [Workflows](./workflows.md) guide shows a copyable `createWorkflowClient()` start route.
 
 ## When to use which
 

--- a/docs/guides/pages-and-routing.md
+++ b/docs/guides/pages-and-routing.md
@@ -42,6 +42,8 @@ export default function Home() {
 }
 ```
 
+Run `veryfront dev` and open [http://localhost:3000](http://localhost:3000). The page should render `Welcome`.
+
 ## Layouts
 
 Layouts wrap pages and persist across navigation. Create `layout.tsx` at any level:
@@ -93,6 +95,8 @@ export default function BlogPost() {
   return <h1>Post: {params.slug}</h1>;
 }
 ```
+
+Open [http://localhost:3000/blog/hello](http://localhost:3000/blog/hello). The page should render `Post: hello`.
 
 ### Catch-all routes
 

--- a/docs/guides/project-structure.md
+++ b/docs/guides/project-structure.md
@@ -109,6 +109,14 @@ The filename becomes the ID for TypeScript primitives. For example, `agents/assi
 
 For skills, the directory name is the skill ID. For example, `skills/incident-response/SKILL.md` registers as `"incident-response"`.
 
+Verify discovery by starting the dev server after adding an agent, tool, or workflow file:
+
+```bash
+veryfront dev
+```
+
+Then open the dev dashboard or call a route that uses the primitive. For example, `getAgent("assistant")` should resolve after `agents/assistant.ts` exists and the server has reloaded.
+
 ### Customizing discovery paths
 
 Override the default directories in `veryfront.config.ts`:

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -21,6 +21,16 @@ export default agent({
 });
 ```
 
+Verify provider resolution through any chat route that uses this agent:
+
+```bash
+curl -N http://localhost:3000/api/chat \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"id":"1","role":"user","parts":[{"type":"text","text":"Reply with the active inference mode if available."}]}]}'
+```
+
+In a client UI, `useChat()` also exposes `inferenceMode` so you can confirm whether the response used cloud, server-local, or browser inference.
+
 By convention:
 
 - local development without cloud bootstrap uses local inference or explicit

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -29,6 +29,14 @@ import { Sandbox } from "veryfront/sandbox";
 const sandbox = await Sandbox.create();
 ```
 
+Verify the session with a command before doing longer work:
+
+```ts
+const result = await sandbox.executeCommand("pwd");
+console.log(result.exitCode);
+console.log(result.stdout);
+```
+
 You can also reconnect to an existing session:
 
 ```ts

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -15,8 +15,13 @@ The sandbox client talks to authenticated sandbox session APIs. In practice, tha
 ## Create a sandbox session
 
 Use `Sandbox.create()` with sandbox API credentials. In local development,
-`VERYFRONT_API_TOKEN` plus a reachable `VERYFRONT_API_URL` is the default path.
-In remote requests, request-scoped credentials can be used automatically.
+self-hosted apps, CI, and other runtimes outside a Veryfront-hosted request,
+provide credentials explicitly. Set `VERYFRONT_API_TOKEN`, and set
+`VERYFRONT_API_URL` when you need a non-default API endpoint.
+
+Inside a Veryfront-hosted request, the client can use request-scoped
+credentials automatically. In that path, you do not need to set
+`VERYFRONT_API_TOKEN` separately for the request.
 
 ```ts
 import { Sandbox } from "veryfront/sandbox";

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -87,6 +87,29 @@ When skills are available, agents get three built-in tools:
 | `load-skill-reference` | Read a reference file from a skill               |
 | `execute-skill-script` | Execute a script from a skill (5-minute timeout) |
 
+Enable skills on an agent:
+
+```ts
+// agents/assistant.ts
+import { agent } from "veryfront/agent";
+
+export default agent({
+  id: "assistant",
+  system: "Use project skills when they match the task.",
+  skills: ["code-review"],
+});
+```
+
+Expose the agent through a chat route, then ask it to use the skill:
+
+```bash
+curl -N http://localhost:3000/api/chat \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"id":"1","role":"user","parts":[{"type":"text","text":"Use the code-review skill and summarize what you would check first."}]}]}'
+```
+
+The agent should call `load-skill` before applying the skill instructions.
+
 ## Tool restrictions
 
 The `allowed_tools` field restricts which tools an agent can use while a skill is active. Use exact IDs or prefix wildcards:

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -26,14 +26,36 @@ export default tool({
     units: z.enum(["celsius", "fahrenheit"]).default("celsius"),
   }),
   execute: async ({ city, units }) => {
-    const response = await fetch(`https://api.weather.com/v1?city=${city}&units=${units}`);
-    const data = await response.json();
-    return { temperature: data.temp, conditions: data.conditions };
+    const temperature = units === "fahrenheit" ? 72 : 22;
+    return { city, temperature, units, conditions: "sunny" };
   },
 });
 ```
 
 The filename becomes the tool's ID. This tool registers as `"get-weather"` (hyphens from the filename are preserved).
+
+## Try a tool directly
+
+Agents usually invoke tools, but direct execution is useful for testing and for API routes that expose a specific action:
+
+```ts
+// app/api/weather/route.ts
+import getWeather from "../../../tools/get-weather.ts";
+
+export async function GET(request: Request) {
+  const city = new URL(request.url).searchParams.get("city") ?? "Tokyo";
+  const result = await getWeather.execute({ city, units: "celsius" });
+  return Response.json(result);
+}
+```
+
+Run the dev server and call the route:
+
+```bash
+curl "http://localhost:3000/api/weather?city=Tokyo"
+```
+
+Use this pattern to verify the tool contract before giving the tool to an agent.
 
 ## How agents use tools
 

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -28,6 +28,116 @@ export default workflow({
 
 Steps run in order. Each step's output is available to the next step via the workflow context.
 
+## Start a workflow
+
+Define workflows in `workflows/`, then start them from the surface that owns the user or system event. Common start points are:
+
+- an API route, when a user action or webhook starts the run
+- an agent tool, when an agent should decide whether to start the run
+- a task, when a scheduled job or background process starts the run
+- a client component, when the app exposes a workflow-start API route
+
+Use `createWorkflowClient()` to register and start a workflow from server code:
+
+```ts
+// app/api/start-content-workflow/route.ts
+import { agentRegistry } from "veryfront/agent";
+import { toolRegistry } from "veryfront/tool";
+import { createWorkflowClient } from "veryfront/workflow";
+import contentPipeline from "../../../workflows/content-pipeline.ts";
+
+const workflows = createWorkflowClient({
+  executor: {
+    stepExecutor: {
+      agentRegistry,
+      toolRegistry,
+    },
+  },
+});
+
+workflows.register(contentPipeline);
+
+export async function POST(request: Request) {
+  const input = await request.json();
+  const handle = await workflows.start("content-pipeline", input);
+
+  return Response.json({ runId: handle.runId });
+}
+```
+
+Ensure every `agent` and `tool` used by the workflow exists in `agents/` or `tools/`, then call the route:
+
+```bash
+curl http://localhost:3000/api/start-content-workflow \
+  -H "Content-Type: application/json" \
+  -d '{"topic":"AI agents"}'
+```
+
+The response contains the workflow run ID:
+
+```json
+{ "runId": "run_..." }
+```
+
+Call the API route from a client component:
+
+```tsx
+"use client";
+import { useState } from "react";
+
+export default function StartContentWorkflow() {
+  const [runId, setRunId] = useState<string | null>(null);
+
+  async function startWorkflow() {
+    const response = await fetch("/api/start-content-workflow", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ topic: "AI agents" }),
+    });
+    const data = await response.json();
+    setRunId(data.runId);
+  }
+
+  return (
+    <button type="button" onClick={startWorkflow}>
+      {runId ? `Run ${runId}` : "Start workflow"}
+    </button>
+  );
+}
+```
+
+Inside an agent tool, start the workflow from the tool's `execute` function:
+
+```ts
+// tools/start-content-workflow.ts
+import { z } from "zod";
+import { agentRegistry } from "veryfront/agent";
+import { tool, toolRegistry } from "veryfront/tool";
+import { createWorkflowClient } from "veryfront/workflow";
+import contentPipeline from "../workflows/content-pipeline.ts";
+
+const workflows = createWorkflowClient({
+  executor: {
+    stepExecutor: {
+      agentRegistry,
+      toolRegistry,
+    },
+  },
+});
+workflows.register(contentPipeline);
+
+export default tool({
+  description: "Start the article workflow for a topic",
+  inputSchema: z.object({ topic: z.string() }),
+  execute: async ({ topic }) => {
+    const handle = await workflows.start("content-pipeline", { topic });
+    return { runId: handle.runId };
+  },
+});
+```
+
+Use `handle.result()` only when the caller should wait for completion. Return the `runId` when the workflow can continue in the background.
+
 ## Steps
 
 A step runs an agent or a tool:
@@ -223,21 +333,33 @@ integration point. Storage implementations come from the host runtime.
 
 ## React hooks
 
-Track workflow progress from the client:
+Track workflow progress from the client when your app exposes workflow API routes that match the hook's `apiBase`:
 
 ```tsx
 "use client";
 import { useWorkflow, useWorkflowStart } from "veryfront/workflow";
 
 export default function PipelineDashboard() {
-  const { start, runId } = useWorkflowStart({ workflow: "pipeline" });
-  const { status, steps } = useWorkflow({ runId });
+  const { start, lastRunId } = useWorkflowStart({
+    workflowId: "pipeline",
+    apiBase: "/api/workflows",
+  });
 
   return (
     <div>
       <button onClick={() => start({ topic: "AI agents" })}>Run Pipeline</button>
+      {lastRunId ? <WorkflowStatus runId={lastRunId} /> : null}
+    </div>
+  );
+}
+
+function WorkflowStatus({ runId }: { runId: string }) {
+  const { status, nodeStates } = useWorkflow({ runId });
+
+  return (
+    <div>
       <p>Status: {status}</p>
-      {steps.map((s) => <div key={s.name}>{s.name}: {s.status}</div>)}
+      {Object.entries(nodeStates).map(([id, state]) => <div key={id}>{id}: {state.status}</div>)}
     </div>
   );
 }

--- a/docs/reference/jobs.md
+++ b/docs/reference/jobs.md
@@ -30,7 +30,6 @@ const job = await jobs.create({
   name: "Ingest 1 file",
   target: "task:knowledge-ingest",
   config: {
-    file_count: 1,
     upload_ids: ["11111111-1111-4111-8111-111111111111"],
   },
 });
@@ -48,7 +47,6 @@ const cronJob = await jobs.cron.create({
   schedule: "0 2 * * *",
   timezone: "UTC",
   config: {
-    file_count: 1,
     upload_ids: ["11111111-1111-4111-8111-111111111111"],
   },
 });

--- a/docs/reference/sandbox.md
+++ b/docs/reference/sandbox.md
@@ -153,7 +153,7 @@ Options for creating a sandbox session.
 
 | Property     | Type     | Description                                                                                                         |
 | ------------ | -------- | ------------------------------------------------------------------------------------------------------------------- |
-| `apiUrl?`    | `string` | Base URL of the Veryfront API. Defaults to VERYFRONT_API_URL env.                                                   |
+| `apiUrl?`    | `string` | Base URL of the Veryfront API. Defaults to `VERYFRONT_API_URL`, then the Veryfront Cloud API.                       |
 | `authToken?` | `string` | Explicit Veryfront auth token or API key override. Defaults to request-scoped credentials or `VERYFRONT_API_TOKEN`. |
 | `projectId?` | `string` | Optional project context for project-scoped or project-billed sandbox sessions.                                     |
 
@@ -165,7 +165,7 @@ Known sandbox session details for `Sandbox.attach(...)`.
 | ------------ | -------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `id`         | `string` | Existing sandbox session ID.                                                                                           |
 | `endpoint`   | `string` | Existing sandbox runtime endpoint URL.                                                                                 |
-| `apiUrl?`    | `string` | Base URL of the Veryfront API. Defaults to VERYFRONT_API_URL env.                                                      |
+| `apiUrl?`    | `string` | Base URL of the Veryfront API. Defaults to `VERYFRONT_API_URL`, then the Veryfront Cloud API.                          |
 | `authToken?` | `string` | Explicit Veryfront auth token or API key override. Defaults to request-scoped credentials or `VERYFRONT_API_TOKEN`.    |
 | `projectId?` | `string` | Optional project context metadata when the caller wants to preserve the same options shape as other sandbox factories. |
 

--- a/src/jobs/index.ts
+++ b/src/jobs/index.ts
@@ -20,7 +20,6 @@
  *   name: "Ingest 1 file",
  *   target: "task:knowledge-ingest",
  *   config: {
- *     file_count: 1,
  *     upload_ids: ["00000000-0000-0000-0000-000000000000"],
  *   },
  * });

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -12,7 +12,7 @@ export interface ExecOptions {
 
 /** Options for creating a sandbox session. */
 export interface SandboxOptions {
-  /** Base URL of the Veryfront API. Defaults to VERYFRONT_API_URL env. */
+  /** Base URL of the Veryfront API. Defaults to VERYFRONT_API_URL, then the Veryfront Cloud API. */
   apiUrl?: string;
   /** Explicit Veryfront auth token or API key override. */
   authToken?: string;

--- a/tests/docs/guide-examples.test.ts
+++ b/tests/docs/guide-examples.test.ts
@@ -282,7 +282,6 @@ describe("Guide: jobs.mdx", () => {
         status: "submitted",
         target: "task:knowledge-ingest",
         config: {
-          file_count: 1,
           upload_ids: ["33333333-3333-4333-8333-333333333333"],
         },
         context_id: null,
@@ -327,7 +326,6 @@ describe("Guide: jobs.mdx", () => {
         name: "Ingest 1 file to knowledge base",
         target: "task:knowledge-ingest",
         config: {
-          file_count: 1,
           upload_ids: ["33333333-3333-4333-8333-333333333333"],
         },
       });
@@ -353,7 +351,6 @@ describe("Guide: jobs.mdx", () => {
         schedule: "0 2 * * *",
         timezone: "Europe/Stockholm",
         config: {
-          file_count: 1,
           upload_ids: ["33333333-3333-4333-8333-333333333333"],
         },
         timeout_seconds: 300,
@@ -392,7 +389,6 @@ describe("Guide: jobs.mdx", () => {
         schedule: "0 2 * * *",
         timezone: "Europe/Stockholm",
         config: {
-          file_count: 1,
           upload_ids: ["33333333-3333-4333-8333-333333333333"],
         },
       });


### PR DESCRIPTION
## Summary
- Clarifies job and sandbox examples so config values map to task inputs and hosted/non-hosted credentials are described accurately.
- Adds practical try/verify steps across guides, including agent, workflow, tools, skills, MCP, router, and provider examples.
- Clarifies App Router and Pages Router API handler shapes, and removes implementation-specific sandbox image wording from public guide copy.

## Validation
- deno fmt --check docs/guides
- deno task docs:validate
- deno test --no-check --allow-all tests/docs/guide-examples.test.ts
- git diff --check
