### PR TITLE
Use public agent registry helpers in workflow docs

### DIFF
--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -41,10 +41,15 @@ Use `createWorkflowClient()` to register and start a workflow from server code:
 
 ```ts
 // app/api/start-content-workflow/route.ts
-import { agentRegistry } from "veryfront/agent";
+import { getAgent, getAllAgentIds } from "veryfront/agent";
 import { toolRegistry } from "veryfront/tool";
 import { createWorkflowClient } from "veryfront/workflow";
 import contentPipeline from "../../../workflows/content-pipeline.ts";
+
+const agentRegistry = {
+  get: getAgent,
+  list: getAllAgentIds,
+};
 
 const workflows = createWorkflowClient({
   executor: {
@@ -111,10 +116,15 @@ Inside an agent tool, start the workflow from the tool's `execute` function:
 ```ts
 // tools/start-content-workflow.ts
 import { z } from "zod";
-import { agentRegistry } from "veryfront/agent";
+import { getAgent, getAllAgentIds } from "veryfront/agent";
 import { tool, toolRegistry } from "veryfront/tool";
 import { createWorkflowClient } from "veryfront/workflow";
 import contentPipeline from "../workflows/content-pipeline.ts";
+
+const agentRegistry = {
+  get: getAgent,
+  list: getAllAgentIds,
+};
 
 const workflows = createWorkflowClient({
   executor: {


### PR DESCRIPTION
## Summary
- Replaces non-exported `agentRegistry` imports in workflow startup examples.
- Uses a small public registry facade built from `getAgent` and `getAllAgentIds`, while keeping `toolRegistry` from `veryfront/tool`.
- Keeps the API route and agent-tool workflow examples copyable from public `veryfront/*` exports.

## Validation
- deno fmt --check docs/guides/workflows.md
- deno task docs:validate
- deno test --no-check --allow-all tests/docs/guide-examples.test.ts
- git diff --check
- pre-push: format, lint, typecheck, unit tests (1,898 passed)
