### PR TITLE
Tighten npm optional feature dependencies

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.545",
+  "version": "0.1.546",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [
@@ -357,7 +357,7 @@
     "lint:wildcard-exports": "deno run --allow-read scripts/lint/ban-wildcard-exports.ts",
     "lint:deps": "deno run --allow-read scripts/lint/audit-deps.ts",
     "lint:barrel-jsdoc": "deno run --allow-read scripts/lint/check-barrel-jsdoc.ts",
-    "test:scripts": "deno test --config=scripts/test.deno.json --no-check --allow-read --allow-write scripts/build/generate-sbom.test.ts scripts/build/npm-react-shims.test.ts scripts/lint/audit-core-deps.test.ts scripts/lint/audit-dependency-boundaries.test.ts scripts/lint/audit-extension-capabilities.test.ts scripts/lint/audit-extension-contracts.test.ts scripts/lint/audit-deps.test.ts scripts/lint/check-circular-baseline.test.ts scripts/security/audit-npm.test.ts scripts/security/submit-dependency-snapshot.test.ts",
+    "test:scripts": "deno test --config=scripts/test.deno.json --no-check --allow-read --allow-write scripts/build/generate-sbom.test.ts scripts/build/npm-package-metadata.test.ts scripts/build/npm-react-shims.test.ts scripts/lint/audit-core-deps.test.ts scripts/lint/audit-dependency-boundaries.test.ts scripts/lint/audit-extension-capabilities.test.ts scripts/lint/audit-extension-contracts.test.ts scripts/lint/audit-deps.test.ts scripts/lint/check-circular-baseline.test.ts scripts/security/audit-npm.test.ts scripts/security/submit-dependency-snapshot.test.ts",
     "test:cross-runtime": "deno run --allow-all src/platform/compat/cross-runtime.test.ts",
     "test:node": "node ./tests/node/run-tests.mjs 'src/**/*.test.ts'",
     "test:bun": "node ./tests/bun/run-tests.mjs src/",

--- a/extensions/ext-document-kreuzberg/src/kreuzberg.ts
+++ b/extensions/ext-document-kreuzberg/src/kreuzberg.ts
@@ -21,7 +21,15 @@ type KreuzbergModule = {
 
 // deno-lint-ignore no-explicit-any
 async function loadKreuzbergNode(): Promise<any> {
-  return await import("@kreuzberg/node");
+  try {
+    return await import("@kreuzberg/node");
+  } catch (error) {
+    if (!isMissingPackageError(error)) throw error;
+    throw new Error(
+      'Document extraction on Node requires the optional package "@kreuzberg/node". ' +
+        "Install @kreuzberg/node@^4.4.2 or disable document extraction.",
+    );
+  }
 }
 
 export async function loadKreuzberg(): Promise<KreuzbergExtractor> {
@@ -31,7 +39,7 @@ export async function loadKreuzberg(): Promise<KreuzbergExtractor> {
     return loadKreuzbergNode();
   }
 
-  const mod = await import("@kreuzberg/wasm") as unknown as KreuzbergModule;
+  const mod = await importKreuzbergWasm();
 
   const mainModule = typeof (Deno as { mainModule?: string }).mainModule === "string"
     ? (Deno as { mainModule?: string }).mainModule!
@@ -51,4 +59,24 @@ export async function loadKreuzberg(): Promise<KreuzbergExtractor> {
 
   await mod.initWasm?.();
   return mod;
+}
+
+async function importKreuzbergWasm(): Promise<KreuzbergModule> {
+  try {
+    return await import("@kreuzberg/wasm") as unknown as KreuzbergModule;
+  } catch (error) {
+    if (!isMissingPackageError(error)) throw error;
+    throw new Error(
+      'Document extraction on Deno requires the optional package "@kreuzberg/wasm". ' +
+        "Install @kreuzberg/wasm@4.5.2 or disable document extraction.",
+    );
+  }
+}
+
+function isMissingPackageError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("Cannot find package") ||
+    message.includes("Cannot find module") ||
+    message.includes("ERR_MODULE_NOT_FOUND") ||
+    message.includes("Module not found");
 }

--- a/extensions/ext-sandbox-shell-tools/src/index.ts
+++ b/extensions/ext-sandbox-shell-tools/src/index.ts
@@ -10,7 +10,6 @@ import {
   type SandboxShellToolsProvider,
   SandboxShellToolsProviderName,
 } from "veryfront/extensions/sandbox";
-import { createBashTool } from "bash-tool";
 
 type BashToolFactory = (
   input: CreateSandboxShellToolsInput,
@@ -22,7 +21,30 @@ export function createSandboxShellToolsProvider(
   return async (input) => await createBashToolImpl(input);
 }
 
-const provider = createSandboxShellToolsProvider(createBashTool);
+const provider = createSandboxShellToolsProvider(async (input) => {
+  const { createBashTool } = await importBashTool();
+  return await createBashTool(input);
+});
+
+async function importBashTool(): Promise<{ createBashTool: BashToolFactory }> {
+  try {
+    return await import("bash-tool") as { createBashTool: BashToolFactory };
+  } catch (error) {
+    if (!isMissingPackageError(error)) throw error;
+    throw new Error(
+      'Sandbox shell tools require the optional package "bash-tool". ' +
+        "Install bash-tool@1.3.16 or pass createBashTool explicitly.",
+    );
+  }
+}
+
+function isMissingPackageError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("Cannot find package") ||
+    message.includes("Cannot find module") ||
+    message.includes("ERR_MODULE_NOT_FOUND") ||
+    message.includes("Module not found");
+}
 
 const extSandboxShellTools: ExtensionFactory = () => ({
   name: "ext-sandbox-shell-tools",

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -272,13 +272,13 @@ await build({
 
 		// Update package.json with bin entry and type
 		const pkg = JSON.parse(await Deno.readTextFile(pkgPath));
-		normalizeNpmPackageMetadata(pkg);
 		pkg.type = "module"; // Required for ESM imports without warnings
 		pkg.types = "./esm/src/index.d.ts";
 		pkg.bin = { veryfront: "bin/veryfront.js" };
-		pkg.files = ["esm", "script", "src", "bin", "tsconfig.json", "LICENSE", "README.md"];
+		pkg.files = ["esm", "script", "bin", "tsconfig.json", "LICENSE", "README.md"];
 		pkg.exports["./tsconfig.json"] = "./tsconfig.json";
 		addTypesExportEntries(pkg.exports);
+		normalizeNpmPackageMetadata(pkg);
 		await Deno.writeTextFile(pkgPath, JSON.stringify(pkg, null, 2));
 	},
 });

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -1,0 +1,61 @@
+import { assertEquals } from "#std/assert";
+import { describe, it } from "#std/testing/bdd";
+import { normalizeNpmPackageMetadata } from "./npm-package-metadata.ts";
+
+describe("normalizeNpmPackageMetadata", () => {
+	it("removes source files from the published npm file list", () => {
+		const pkg = normalizeNpmPackageMetadata({
+			files: ["esm", "script", "src", "bin", "README.md"],
+		});
+
+		assertEquals(pkg.files, ["esm", "script", "bin", "README.md"]);
+	});
+
+	it("keeps opt-in feature packages out of automatic npm installs", () => {
+		const pkg = normalizeNpmPackageMetadata({
+			dependencies: {
+				"@kreuzberg/node": "^4.4.2",
+				"@kreuzberg/wasm": "4.5.2",
+				"@opentelemetry/api": "1.9.1",
+				"@opentelemetry/sdk-node": "0.218.0",
+				"bash-tool": "1.3.16",
+				"just-bash": "2.14.5",
+				"zod": "4.3.6",
+			},
+			optionalDependencies: {
+				"@huggingface/transformers": "^3.4.2",
+			},
+		});
+
+		assertEquals(pkg.dependencies, { zod: "4.3.6" });
+		assertEquals(pkg.optionalDependencies, {
+			"@huggingface/transformers": "^3.4.2",
+		});
+		assertEquals(pkg.peerDependencies, {
+			"@kreuzberg/node": "^4.4.2",
+			"@kreuzberg/wasm": "4.5.2",
+			"@opentelemetry/api": "1.9.1",
+			"@opentelemetry/sdk-node": "0.218.0",
+			"bash-tool": "1.3.16",
+			"better-sqlite3": ">=9.0.0",
+			"just-bash": "2.14.5",
+		});
+		assertEquals(pkg.peerDependenciesMeta, {
+			"@kreuzberg/node": { optional: true },
+			"@kreuzberg/wasm": { optional: true },
+			"@opentelemetry/api": { optional: true },
+			"@opentelemetry/sdk-node": { optional: true },
+			"bash-tool": { optional: true },
+			"better-sqlite3": { optional: true },
+			"just-bash": { optional: true },
+		});
+	});
+});
+
+describe("npm supply-chain policy", () => {
+	it("does not statically load the shell execution dependency at module import time", async () => {
+		const source = await Deno.readTextFile("extensions/ext-sandbox-shell-tools/src/index.ts");
+
+		assertEquals(source.includes('from "bash-tool"'), false);
+	});
+});

--- a/scripts/build/npm-package-metadata.ts
+++ b/scripts/build/npm-package-metadata.ts
@@ -2,6 +2,7 @@ type PackageJson = {
 	name?: string;
 	version?: string;
 	private?: boolean;
+	files?: string[];
 	dependencies?: Record<string, string>;
 	optionalDependencies?: Record<string, string>;
 	peerDependencies?: Record<string, string>;
@@ -13,11 +14,31 @@ const OPTIONAL_NATIVE_PEERS = {
 	"better-sqlite3": ">=9.0.0",
 } as const;
 
+const OPTIONAL_FEATURE_PEERS = [
+	"@kreuzberg/node",
+	"@kreuzberg/wasm",
+	"@opentelemetry/api",
+	"@opentelemetry/auto-instrumentations-node",
+	"@opentelemetry/context-async-hooks",
+	"@opentelemetry/core",
+	"@opentelemetry/exporter-trace-otlp-http",
+	"@opentelemetry/resources",
+	"@opentelemetry/sdk-node",
+	"@opentelemetry/sdk-trace-base",
+	"@opentelemetry/semantic-conventions",
+	"bash-tool",
+	"just-bash",
+] as const;
+
 const REQUIRED_NPM_OVERRIDES = {
 	protobufjs: "8.2.0",
 } as const;
 
 export function normalizeNpmPackageMetadata(pkg: PackageJson): PackageJson {
+	if (pkg.files) {
+		pkg.files = pkg.files.filter((entry) => entry !== "src" && entry !== "/src");
+	}
+
 	for (const [name, range] of Object.entries(OPTIONAL_NATIVE_PEERS)) {
 		delete pkg.dependencies?.[name];
 
@@ -28,10 +49,40 @@ export function normalizeNpmPackageMetadata(pkg: PackageJson): PackageJson {
 		pkg.peerDependenciesMeta[name] = { optional: true };
 	}
 
+	for (const name of OPTIONAL_FEATURE_PEERS) {
+		movePackageToOptionalPeer(pkg, name);
+	}
+
+	deleteIfEmpty(pkg, "dependencies");
+	deleteIfEmpty(pkg, "optionalDependencies");
+
 	pkg.overrides ??= {};
 	for (const [name, version] of Object.entries(REQUIRED_NPM_OVERRIDES)) {
 		pkg.overrides[name] = version;
 	}
 
 	return pkg;
+}
+
+function movePackageToOptionalPeer(pkg: PackageJson, name: string): void {
+	const range = pkg.dependencies?.[name] ?? pkg.optionalDependencies?.[name];
+	if (!range) return;
+
+	delete pkg.dependencies?.[name];
+	delete pkg.optionalDependencies?.[name];
+
+	pkg.peerDependencies ??= {};
+	pkg.peerDependencies[name] = range;
+
+	pkg.peerDependenciesMeta ??= {};
+	pkg.peerDependenciesMeta[name] = { optional: true };
+}
+
+function deleteIfEmpty(
+	pkg: PackageJson,
+	key: "dependencies" | "optionalDependencies",
+): void {
+	if (pkg[key] && Object.keys(pkg[key]).length === 0) {
+		delete pkg[key];
+	}
 }

--- a/src/agent/hosted/veryfront-cloud-agent-service.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.ts
@@ -371,13 +371,32 @@ async function ensureDefaultAuthProvider(): Promise<void> {
 
 async function ensureDefaultNodeTelemetryProvider(): Promise<void> {
   if (tryResolve<NodeTelemetryProvider>(NodeTelemetryProviderName)) return;
-  const { OpenTelemetryNodeTelemetryProvider } = await import(
-    "../../../extensions/ext-observability-opentelemetry/src/index.ts"
-  );
+  const OpenTelemetryNodeTelemetryProvider = await importOpenTelemetryNodeTelemetryProvider();
+  if (!OpenTelemetryNodeTelemetryProvider) return;
   register<NodeTelemetryProvider>(
     NodeTelemetryProviderName,
     new OpenTelemetryNodeTelemetryProvider(),
   );
+}
+
+async function importOpenTelemetryNodeTelemetryProvider() {
+  try {
+    const { OpenTelemetryNodeTelemetryProvider } = await import(
+      "../../../extensions/ext-observability-opentelemetry/src/index.ts"
+    );
+    return OpenTelemetryNodeTelemetryProvider;
+  } catch (error) {
+    if (!isMissingOptionalPackageError(error)) throw error;
+    return null;
+  }
+}
+
+function isMissingOptionalPackageError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("Cannot find package") ||
+    message.includes("Cannot find module") ||
+    message.includes("ERR_MODULE_NOT_FOUND") ||
+    message.includes("Module not found");
 }
 
 function resolveEnvironment(

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.545";
+export const VERSION = "0.1.546";

--- a/tests/build/npm-package-metadata.test.ts
+++ b/tests/build/npm-package-metadata.test.ts
@@ -11,13 +11,13 @@ Deno.test("keeps native sqlite support optional for npm consumers", () => {
     peerDependenciesMeta: {},
   });
 
-  assertEquals(pkg.dependencies, {
-    "@kreuzberg/node": "^4.4.2",
-  });
+  assertEquals(pkg.dependencies, undefined);
   assertEquals(pkg.peerDependencies, {
+    "@kreuzberg/node": "^4.4.2",
     "better-sqlite3": ">=9.0.0",
   });
   assertEquals(pkg.peerDependenciesMeta, {
+    "@kreuzberg/node": { optional: true },
     "better-sqlite3": { optional: true },
   });
   assertEquals(pkg.overrides, {


### PR DESCRIPTION
## Summary
- Keeps opt-in feature engines out of the default npm install graph and marks them as optional peer dependencies.
- Keeps the generated npm package from publishing the duplicate `src/` source tree.
- Lazy-loads sandbox shell, document parsing, and OpenTelemetry extension engines with actionable missing-dependency behavior.
- Bumps the release version to `0.1.546`.

## Verification
- `deno test --config=scripts/test.deno.json --no-check --allow-read scripts/build/npm-package-metadata.test.ts`
- `deno test --no-check --allow-all extensions/ext-sandbox-shell-tools/src/index.test.ts extensions/ext-document-kreuzberg/src/index.test.ts src/agent/hosted/veryfront-cloud-agent-service.test.ts`
- `deno task test:scripts`
- `deno task build:npm`
- `node scripts/docs/verify-npm-exports.mjs`
- `node scripts/docs/verify-npm-node.mjs`
- Pre-push gate: format, lint, type check, generate, and unit tests: `1898 passed`, `0 failed`

## Socket follow-up
This does not assert a Socket score of 100 before release. The change reduces the default npm package install graph and published tarball surface honestly, without ignore rules or metric suppression. Socket can still report supply-chain alerts for dependencies that remain part of normal framework behavior. The package score must be checked after `0.1.546` is released and Socket rescans the published artifact.
