### PR TITLE
Reject invalid AG-UI text parts before streaming

### DIFF
--- a/src/agent/ag-ui/detached-start.test.ts
+++ b/src/agent/ag-ui/detached-start.test.ts
@@ -546,23 +546,15 @@ describe("agent/ag-ui-detached-start", () => {
     }
   });
 
-  it("drops oversize detached text parts the same way as the direct AG-UI handler", async () => {
+  it("rejects oversize detached text parts before background execution", async () => {
     const sessionManager = new RunResumeSessionManager<{
       result: unknown;
       isError: boolean;
     }>();
     const originalStream = AgentRuntime.prototype.stream;
 
-    AgentRuntime.prototype.stream = async function (
-      messages: Message[],
-    ): Promise<ReadableStream<Uint8Array>> {
-      assertEquals(messages[0]?.parts.length, 0);
-
-      return new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.close();
-        },
-      });
+    AgentRuntime.prototype.stream = async function (): Promise<ReadableStream<Uint8Array>> {
+      throw new Error("stream should not be called for invalid requests");
     };
 
     try {
@@ -579,10 +571,13 @@ describe("agent/ag-ui-detached-start", () => {
         }],
       }));
 
-      assertEquals(response.status, 202);
+      assertEquals(response.status, 400);
       const payload = await response.json();
-      assertEquals(payload.accepted, true);
-      assertEquals(payload.duplicate, false);
+      assertEquals(payload.error, "Invalid AG-UI detached start request");
+      assertStringIncludes(
+        payload.details[0]?.message ?? "",
+        "Text message parts must include text less than 10000 characters",
+      );
     } finally {
       AgentRuntime.prototype.stream = originalStream;
     }

--- a/src/agent/ag-ui/handler.test.ts
+++ b/src/agent/ag-ui/handler.test.ts
@@ -246,6 +246,35 @@ describe("agent/ag-ui-handler", () => {
     assertEquals(testAgent.capturedMessages.length, 0);
   });
 
+  it("rejects oversized text parts before the agent runs", async () => {
+    const testAgent = createTestAgent();
+    const handler = createAgUiHandler({ agent: testAgent.agent });
+
+    const response = await handler(
+      new Request("http://localhost/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [{
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "x".repeat(10_001) }],
+          }],
+        }),
+      }),
+    );
+
+    assertEquals(response.status, 400);
+    assertEquals(testAgent.clearMemoryCalls, 0);
+    assertEquals(testAgent.capturedMessages.length, 0);
+    const body = await response.json();
+    assertEquals(body.error, "Invalid AG-UI request");
+    assertStringIncludes(
+      body.details[0]?.message ?? "",
+      "Text message parts must include text less than 10000 characters",
+    );
+  });
+
   it("returns browser fallback metadata when no agent runtime is available", async () => {
     const testAgent = createTestAgent();
     const noAiAvailable = toError(createError({

--- a/src/agent/ag-ui/host-support.test.ts
+++ b/src/agent/ag-ui/host-support.test.ts
@@ -53,6 +53,31 @@ describe("agent/ag-ui-host-support", () => {
     assertEquals(Array.isArray(body.details), true);
   });
 
+  it("returns a 400 Response for oversized AG-UI text parts", async () => {
+    const request = new Request("http://localhost/api/ag-ui", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: [{
+          id: "msg-1",
+          role: "user",
+          parts: [{ type: "text", text: "x".repeat(10_001) }],
+        }],
+      }),
+    });
+
+    const result = await parseAgUiRequestOrError(request);
+
+    assertInstanceOf(result, Response);
+    assertEquals(result.status, 400);
+    const body = await result.json();
+    assertEquals(body.error, "Invalid AG-UI request");
+    assertStringIncludes(
+      body.details[0]?.message ?? "",
+      "Text message parts must include text less than 10000 characters",
+    );
+  });
+
   it("returns a 400 Response from parseAgUiRequestOrError for malformed JSON bodies", async () => {
     const request = new Request("http://localhost/api/ag-ui", {
       method: "POST",

--- a/src/agent/ag-ui/host-support.ts
+++ b/src/agent/ag-ui/host-support.ts
@@ -70,7 +70,14 @@ export const getAgUiContextItemSchema = defineSchema((v) =>
 );
 
 const getAgUiMessagePartSchema = defineSchema((v) =>
-  v.object({ type: v.string().min(1) }).passthrough()
+  v.object({ type: v.string().min(1) }).passthrough().refine(
+    (part) =>
+      part.type !== "text" ||
+      (typeof part.text === "string" && part.text.length <= MAX_TEXT_PART_LENGTH),
+    {
+      message: `Text message parts must include text less than ${MAX_TEXT_PART_LENGTH} characters`,
+    },
+  )
 );
 
 const getAgUiMessageSchema = defineSchema((v) =>


### PR DESCRIPTION
## Summary
- Validate AG-UI `type: \"text\"` message parts before normalization.
- Return the existing invalid-request 400 response for oversized or malformed text parts instead of silently dropping them before agent execution.
- Update parser, direct handler, and detached-start tests to lock the behavior.

## Review context
Fixes the issue raised on #1727: https://github.com/veryfront/veryfront-code/pull/1727#discussion_r3254468249

## Verification
- `deno test --no-check --allow-all src/agent/ag-ui/host-support.test.ts src/agent/ag-ui/handler.test.ts src/agent/ag-ui/detached-start.test.ts`
- `deno check src/agent/ag-ui/host-support.ts src/agent/ag-ui/handler.ts src/agent/ag-ui/detached-start.ts src/agent/ag-ui/host-support.test.ts src/agent/ag-ui/handler.test.ts src/agent/ag-ui/detached-start.test.ts`
- `deno fmt --check src/agent/ag-ui/detached-start.test.ts src/agent/ag-ui/handler.test.ts src/agent/ag-ui/host-support.ts src/agent/ag-ui/host-support.test.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/agent/ag-ui/host-support.ts src/agent/ag-ui/host-support.test.ts src/agent/ag-ui/handler.ts src/agent/ag-ui/handler.test.ts src/agent/ag-ui/detached-start.ts src/agent/ag-ui/detached-start.test.ts`
- `git diff --check`
- Pre-push hook: format, lint, typecheck, and unit tests passed (`1898 passed`, `0 failed`).