### PR TITLE
Tighten npm dependency metadata sources

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.546",
+  "version": "0.1.547",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [
@@ -357,7 +357,7 @@
     "lint:wildcard-exports": "deno run --allow-read scripts/lint/ban-wildcard-exports.ts",
     "lint:deps": "deno run --allow-read scripts/lint/audit-deps.ts",
     "lint:barrel-jsdoc": "deno run --allow-read scripts/lint/check-barrel-jsdoc.ts",
-    "test:scripts": "deno test --config=scripts/test.deno.json --no-check --allow-read --allow-write scripts/build/generate-sbom.test.ts scripts/build/npm-package-metadata.test.ts scripts/build/npm-react-shims.test.ts scripts/lint/audit-core-deps.test.ts scripts/lint/audit-dependency-boundaries.test.ts scripts/lint/audit-extension-capabilities.test.ts scripts/lint/audit-extension-contracts.test.ts scripts/lint/audit-deps.test.ts scripts/lint/check-circular-baseline.test.ts scripts/security/audit-npm.test.ts scripts/security/submit-dependency-snapshot.test.ts",
+    "test:scripts": "deno test --config=scripts/test.deno.json --no-check --allow-read --allow-write scripts/build/generate-sbom.test.ts scripts/build/npm-dependency-sources.test.ts scripts/build/npm-package-metadata.test.ts scripts/build/npm-react-shims.test.ts scripts/lint/audit-core-deps.test.ts scripts/lint/audit-dependency-boundaries.test.ts scripts/lint/audit-extension-capabilities.test.ts scripts/lint/audit-extension-contracts.test.ts scripts/lint/audit-deps.test.ts scripts/lint/check-circular-baseline.test.ts scripts/security/audit-npm.test.ts scripts/security/submit-dependency-snapshot.test.ts",
     "test:cross-runtime": "deno run --allow-all src/platform/compat/cross-runtime.test.ts",
     "test:node": "node ./tests/node/run-tests.mjs 'src/**/*.test.ts'",
     "test:bun": "node ./tests/bun/run-tests.mjs src/",

--- a/extensions/ext-document-kreuzberg/deno.json
+++ b/extensions/ext-document-kreuzberg/deno.json
@@ -12,6 +12,7 @@
     ]
   },
   "imports": {
+    "@kreuzberg/node": "npm:@kreuzberg/node@4.4.2",
     "@kreuzberg/wasm": "npm:@kreuzberg/wasm@4.5.2",
     "#kreuzberg-wasm-glue": "npm:@kreuzberg/wasm@4.5.2/dist/pkg/kreuzberg_wasm.js"
   },

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -17,8 +17,13 @@ import {
 	BROWSER_SAFE_DNT_TIMER_MODULES,
 	BROWSER_SAFE_EXPORTS,
 } from "./browser-safe-exports.mjs";
+import {
+	npmDependencyRange,
+	readDenoConfigSet,
+} from "./npm-dependency-sources.ts";
 import { normalizeNpmPackageMetadata } from "./npm-package-metadata.ts";
 import { normalizeEsmShReactNpmShims } from "./npm-react-shims.ts";
+import { OPAQUE_DEPENDENCY_VERSIONS } from "../../src/platform/compat/opaque-dependency-versions.ts";
 
 const denoJson = JSON.parse(await Deno.readTextFile("./deno.json"));
 const version = denoJson.version;
@@ -29,6 +34,7 @@ const license = denoJson.license;
 if (!license) {
 	throw new Error("deno.json must have a 'license' field");
 }
+const denoConfigSet = await readDenoConfigSet(".", denoJson);
 
 console.log(`\n📦 Building Veryfront v${version} for npm using dnt...\n`);
 
@@ -133,15 +139,16 @@ await build({
 		},
 		// dnt can't detect dynamic imports, so we add them explicitly
 		dependencies: {
-			"@types/react": "^19.0.0",
-			"@types/react-dom": "^19.0.0",
-			"ai": "^6.0.0",
+			"@types/react": npmDependencyRange(denoConfigSet, "@types/react"),
+			"@types/react-dom": npmDependencyRange(denoConfigSet, "@types/react-dom"),
+			// Root deno.json intentionally rejects core npm imports; ws is a
+			// Node-only dynamic import used by the npm server/HMR path.
 			"ws": "^8.18.0",
-			"@kreuzberg/node": "^4.4.2",
+			"@kreuzberg/node": npmDependencyRange(denoConfigSet, "@kreuzberg/node"),
 		},
 		// Native binary deps that should not block install if they fail
 		optionalDependencies: {
-			"@huggingface/transformers": "^3.4.2",
+			"@huggingface/transformers": `^${OPAQUE_DEPENDENCY_VERSIONS["@huggingface/transformers"]}`,
 		},
 		keywords: [
 			"react",
@@ -160,11 +167,6 @@ await build({
 		},
 		peerDependenciesMeta: {
 			"better-sqlite3": { optional: true },
-		},
-		devDependencies: {
-			"@types/ws": "^8.5.0",
-			"@types/better-sqlite3": "^7.6.0",
-			"@types/mime-types": "^2.1.0",
 		},
 		// postinstall added in postBuild after files are copied
 	},

--- a/scripts/build/npm-dependency-sources.test.ts
+++ b/scripts/build/npm-dependency-sources.test.ts
@@ -1,0 +1,61 @@
+import { assertEquals, assertThrows } from "#std/assert";
+import { describe, it } from "#std/testing/bdd";
+import {
+	npmDependencyRange,
+	parseNpmImport,
+	readDenoConfigSet,
+} from "./npm-dependency-sources.ts";
+
+describe("npm dependency source helpers", () => {
+	it("parses npm import map entries", () => {
+		assertEquals(parseNpmImport("npm:ws@8.18.0"), {
+			name: "ws",
+			version: "8.18.0",
+		});
+		assertEquals(parseNpmImport("npm:@kreuzberg/wasm@4.5.2/dist/pkg/kreuzberg_wasm.js"), {
+			name: "@kreuzberg/wasm",
+			version: "4.5.2",
+		});
+	});
+
+	it("parses esm.sh import map entries", () => {
+		assertEquals(parseNpmImport("https://esm.sh/@types/react@19.2.14?deps=csstype@3.2.3"), {
+			name: "@types/react",
+			version: "19.2.14",
+		});
+		assertEquals(parseNpmImport("https://esm.sh/tailwindcss@4.2.2/plugin"), {
+			name: "tailwindcss",
+			version: "4.2.2",
+		});
+	});
+
+	it("derives npm ranges from import maps", () => {
+		const configs = [{
+			imports: {
+				ws: "npm:ws@8.18.0",
+				react: "https://esm.sh/react@19.2.4?target=es2022",
+			},
+		}];
+
+		assertEquals(npmDependencyRange(configs, "ws"), "^8.18.0");
+		assertEquals(npmDependencyRange(configs, "react", ""), "19.2.4");
+	});
+
+	it("loads dependency sources from workspace deno configs", async () => {
+		const rootConfig = JSON.parse(await Deno.readTextFile("deno.json"));
+		const configs = await readDenoConfigSet(".", rootConfig);
+
+		assertEquals(npmDependencyRange(configs, "@types/react"), "^19.2.14");
+		assertEquals(npmDependencyRange(configs, "@types/react-dom"), "^19.2.3");
+		assertEquals(npmDependencyRange(configs, "@kreuzberg/node"), "^4.4.2");
+		assertEquals(npmDependencyRange(configs, "better-sqlite3", ""), "9.6.0");
+	});
+
+	it("fails when an explicit npm dependency has no config source", () => {
+		assertThrows(
+			() => npmDependencyRange([{ imports: {} }], "ws"),
+			Error,
+			'Missing npm dependency source for "ws"',
+		);
+	});
+});

--- a/scripts/build/npm-dependency-sources.ts
+++ b/scripts/build/npm-dependency-sources.ts
@@ -1,0 +1,70 @@
+type DenoConfig = {
+	imports?: Record<string, string>;
+	workspace?: string[];
+};
+
+type NpmImport = {
+	name: string;
+	version: string;
+};
+
+export async function readDenoConfigSet(
+	rootDir: string,
+	rootConfig: DenoConfig,
+): Promise<DenoConfig[]> {
+	const configs = [rootConfig];
+	for (const workspaceEntry of rootConfig.workspace ?? []) {
+		const configPath = `${rootDir}/${workspaceEntry.replace(/^\.\//, "")}/deno.json`;
+		try {
+			configs.push(JSON.parse(await Deno.readTextFile(configPath)));
+		} catch (error) {
+			if (!(error instanceof Deno.errors.NotFound)) {
+				throw error;
+			}
+		}
+	}
+	return configs;
+}
+
+export function npmDependencyRange(
+	configs: DenoConfig[],
+	specifier: string,
+	rangePrefix: "" | "^" = "^",
+): string {
+	const target = configs
+		.map((config) => config.imports?.[specifier])
+		.find((value): value is string => typeof value === "string");
+	if (!target) {
+		throw new Error(`Missing npm dependency source for "${specifier}" in deno.json imports`);
+	}
+
+	const parsed = parseNpmImport(target);
+	if (!parsed) {
+		throw new Error(`Import "${specifier}" does not resolve to a versioned npm package: ${target}`);
+	}
+
+	return `${rangePrefix}${parsed.version}`;
+}
+
+export function parseNpmImport(target: string): NpmImport | null {
+	if (target.startsWith("npm:")) {
+		return parsePackageAndVersion(target.slice("npm:".length));
+	}
+
+	if (target.startsWith("https://esm.sh/")) {
+		const pathPart = target.replace("https://esm.sh/", "").split("?")[0]!;
+		return parsePackageAndVersion(pathPart);
+	}
+
+	return null;
+}
+
+function parsePackageAndVersion(specifier: string): NpmImport | null {
+	const match = specifier.match(/^(@[^/]+\/[^@/]+|[^@/]+)@([^/]+)(?:\/.*)?$/);
+	if (!match) return null;
+
+	return {
+		name: match[1]!,
+		version: match[2]!,
+	};
+}

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -50,6 +50,36 @@ describe("normalizeNpmPackageMetadata", () => {
 			"just-bash": { optional: true },
 		});
 	});
+
+	it("removes stale direct AI SDK metadata from automatic npm installs", () => {
+		const pkg = normalizeNpmPackageMetadata({
+			dependencies: {
+				ai: "^6.0.0",
+				zod: "4.3.6",
+			},
+		});
+
+		assertEquals(pkg.dependencies, { zod: "4.3.6" });
+		assertEquals(pkg.peerDependencies, {
+			"better-sqlite3": ">=9.0.0",
+		});
+		assertEquals(pkg.peerDependenciesMeta, {
+			"better-sqlite3": { optional: true },
+		});
+	});
+
+	it("removes stale npm-only type dev dependencies", () => {
+		const pkg = normalizeNpmPackageMetadata({
+			devDependencies: {
+				"@types/better-sqlite3": "^7.6.0",
+				"@types/mime-types": "^2.1.0",
+				"@types/ws": "^8.5.0",
+				"@types/node": "^20.9.0",
+			},
+		});
+
+		assertEquals(pkg.devDependencies, { "@types/node": "^20.9.0" });
+	});
 });
 
 describe("npm supply-chain policy", () => {

--- a/scripts/build/npm-package-metadata.ts
+++ b/scripts/build/npm-package-metadata.ts
@@ -7,6 +7,7 @@ type PackageJson = {
 	optionalDependencies?: Record<string, string>;
 	peerDependencies?: Record<string, string>;
 	peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+	devDependencies?: Record<string, string>;
 	overrides?: Record<string, string>;
 };
 
@@ -30,6 +31,16 @@ const OPTIONAL_FEATURE_PEERS = [
 	"just-bash",
 ] as const;
 
+const STALE_DIRECT_DEPENDENCIES = [
+	"ai",
+] as const;
+
+const STALE_DEV_DEPENDENCIES = [
+	"@types/better-sqlite3",
+	"@types/mime-types",
+	"@types/ws",
+] as const;
+
 const REQUIRED_NPM_OVERRIDES = {
 	protobufjs: "8.2.0",
 } as const;
@@ -51,6 +62,15 @@ export function normalizeNpmPackageMetadata(pkg: PackageJson): PackageJson {
 
 	for (const name of OPTIONAL_FEATURE_PEERS) {
 		movePackageToOptionalPeer(pkg, name);
+	}
+
+	for (const name of STALE_DIRECT_DEPENDENCIES) {
+		delete pkg.dependencies?.[name];
+		delete pkg.optionalDependencies?.[name];
+	}
+
+	for (const name of STALE_DEV_DEPENDENCIES) {
+		delete pkg.devDependencies?.[name];
 	}
 
 	deleteIfEmpty(pkg, "dependencies");

--- a/src/platform/compat/opaque-dependency-versions.ts
+++ b/src/platform/compat/opaque-dependency-versions.ts
@@ -1,0 +1,4 @@
+export const OPAQUE_DEPENDENCY_VERSIONS = {
+  "@anthropic-ai/claude-agent-sdk": "0.2.37",
+  "@huggingface/transformers": "3.4.2",
+} as const;

--- a/src/platform/compat/opaque-deps.ts
+++ b/src/platform/compat/opaque-deps.ts
@@ -19,6 +19,7 @@ import { tryResolve } from "#veryfront/extensions/contracts.ts";
 import { isDeno } from "./runtime.ts";
 import { dynamicImport } from "./dynamic-import.ts";
 import type { DocumentExtractor } from "#veryfront/extensions/compat/native-services.ts";
+import { OPAQUE_DEPENDENCY_VERSIONS } from "./opaque-dependency-versions.ts";
 
 function resolve(pkg: string, version: string): string {
   return isDeno ? `npm:${pkg}@${version}` : pkg;
@@ -29,7 +30,10 @@ type OpaqueModule = any;
 
 /** Lazily import `@huggingface/transformers` (+ onnxruntime, ~500MB). */
 export function importTransformers(): Promise<OpaqueModule> {
-  return dynamicImport(resolve("@huggingface/transformers", "3.4.2"));
+  return dynamicImport(resolve(
+    "@huggingface/transformers",
+    OPAQUE_DEPENDENCY_VERSIONS["@huggingface/transformers"],
+  ));
 }
 
 /** Lazily import `@anthropic-ai/claude-agent-sdk` (~69MB). */
@@ -37,7 +41,10 @@ export function importClaudeAgentSDK(): Promise<OpaqueModule> {
   // Allow tests to inject a mock SDK without loading the real 69 MB package.
   const mock = (globalThis as Record<string, unknown>).__vfMockClaudeSDK;
   if (mock && typeof mock === "object" && "query" in mock) return Promise.resolve(mock);
-  return dynamicImport(resolve("@anthropic-ai/claude-agent-sdk", "0.2.37"));
+  return dynamicImport(resolve(
+    "@anthropic-ai/claude-agent-sdk",
+    OPAQUE_DEPENDENCY_VERSIONS["@anthropic-ai/claude-agent-sdk"],
+  ));
 }
 
 /**

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.546";
+export const VERSION = "0.1.547";


### PR DESCRIPTION
## Summary
- remove stale direct AI SDK and npm-only type metadata from generated npm package metadata
- derive explicit dnt dependency versions from workspace deno configs where possible
- keep opaque optional dependency versions in one source constant and bump package version to 0.1.547

## Verification
- deno test --config=scripts/test.deno.json --no-check --allow-read --allow-write scripts/build/npm-dependency-sources.test.ts scripts/build/npm-package-metadata.test.ts
- deno task build:npm
- deno task test:scripts
- node scripts/docs/verify-npm-exports.mjs && node scripts/docs/verify-npm-node.mjs
- deno check src/server/index.ts src/platform/compat/opaque-deps.ts extensions/ext-document-kreuzberg/src/kreuzberg.ts
- npm pack --dry-run --json