### PR TITLE
Keep AG-UI reference source link stable

### DIFF
--- a/docs/reference/agent-runtime-ag-ui.md
+++ b/docs/reference/agent-runtime-ag-ui.md
@@ -30,7 +30,7 @@ transport-neutral lifecycle operations. Do not mount run control under
 `/api/ag-ui`.
 
 `AgUiRuntimeRequestSchema` is defined in
-[`src/agent/runtime/ag-ui-contract.ts`](../../src/agent/runtime/ag-ui-contract.ts).
+[`src/agent/runtime/ag-ui-contract.ts`](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts).
 It accepts the AG-UI-aligned request fields used by the runtime:
 
 - `threadId`


### PR DESCRIPTION
## Summary
- Use a GitHub source URL for the AG-UI runtime contract link so the reference page works after veryfront-docs copies it.
- Leave the /api/ag-ui endpoint contract unchanged.

## Verification
- deno task docs:validate
- rg route/source-link audit
- git diff --check
- pre-push full Deno test suite: 1898 passed, 0 failed