### PR TITLE
Add knowledge ingest job helpers

### DIFF
--- a/src/jobs/index.ts
+++ b/src/jobs/index.ts
@@ -16,12 +16,8 @@
  *   projectReference: "my-project",
  * });
  *
- * const job = await jobs.create({
- *   name: "Ingest 1 file",
- *   target: "task:knowledge-ingest",
- *   config: {
- *     upload_ids: ["00000000-0000-0000-0000-000000000000"],
- *   },
+ * const job = await jobs.knowledge.ingestByUploadIds({
+ *   uploadIds: ["00000000-0000-0000-0000-000000000000"],
  * });
  *
  * const events = await jobs.events(job.id);
@@ -32,6 +28,10 @@ export {
   type CreateCronJobInput,
   type CreateJobInput,
   createJobsClient,
+  type KnowledgeIngestByUploadIdsInput,
+  type KnowledgeIngestByUploadPathsInput,
+  type KnowledgeIngestByUploadPrefixInput,
+  type KnowledgeIngestJobOptions,
   type ListBatchJobsOptions,
   type ListCronJobsOptions,
   type ListJobEventsOptions,

--- a/src/jobs/jobs-client.test.ts
+++ b/src/jobs/jobs-client.test.ts
@@ -73,7 +73,6 @@ function makeJob(overrides: Record<string, unknown> = {}) {
     status: "submitted",
     target: "task:knowledge-ingest",
     config: {
-      file_count: 1,
       upload_ids: ["33333333-3333-4333-8333-333333333333"],
     },
     context_id: null,
@@ -115,7 +114,6 @@ function makeCronJob(overrides: Record<string, unknown> = {}) {
     schedule: "0 2 * * *",
     timezone: "Europe/Stockholm",
     config: {
-      file_count: 1,
       upload_ids: ["33333333-3333-4333-8333-333333333333"],
     },
     timeout_seconds: 300,
@@ -178,7 +176,6 @@ describe("VeryfrontJobsClient", () => {
       timeoutSeconds: 900,
       backoffLimit: 0,
       config: {
-        file_count: 1,
         upload_ids: ["33333333-3333-4333-8333-333333333333"],
       },
     });
@@ -194,8 +191,74 @@ describe("VeryfrontJobsClient", () => {
       timeout_seconds: 900,
       backoff_limit: 0,
       config: {
-        file_count: 1,
         upload_ids: ["33333333-3333-4333-8333-333333333333"],
+      },
+    });
+  });
+
+  it("creates knowledge ingest jobs by upload ids", async () => {
+    mockFetch([jsonResponse(makeJob())]);
+
+    const client = new VeryfrontJobsClient({
+      apiUrl: "https://api.test.com",
+      authToken: "test-token",
+      projectReference: "dreamy-haven",
+    });
+
+    await client.knowledge.ingestByUploadIds({
+      uploadIds: ["33333333-3333-4333-8333-333333333333"],
+      batchId: "66666666-6666-4666-8666-666666666666",
+    });
+
+    assertEquals(jsonBody(0), {
+      target: "task:knowledge-ingest",
+      batch_id: "66666666-6666-4666-8666-666666666666",
+      config: {
+        upload_ids: ["33333333-3333-4333-8333-333333333333"],
+      },
+    });
+  });
+
+  it("creates knowledge ingest jobs by upload paths", async () => {
+    mockFetch([jsonResponse(makeJob())]);
+
+    const client = new VeryfrontJobsClient({
+      apiUrl: "https://api.test.com",
+      authToken: "test-token",
+      projectReference: "dreamy-haven",
+    });
+
+    await client.knowledge.ingestByUploadPaths({
+      uploadPaths: ["uploads/contracts/q1.pdf"],
+    });
+
+    assertEquals(jsonBody(0), {
+      target: "task:knowledge-ingest",
+      config: {
+        paths: ["uploads/contracts/q1.pdf"],
+      },
+    });
+  });
+
+  it("creates knowledge ingest jobs by upload prefix", async () => {
+    mockFetch([jsonResponse(makeJob())]);
+
+    const client = new VeryfrontJobsClient({
+      apiUrl: "https://api.test.com",
+      authToken: "test-token",
+      projectReference: "dreamy-haven",
+    });
+
+    await client.knowledge.ingestByUploadPrefix({
+      uploadPrefix: "uploads/contracts",
+      name: "Ingest contracts",
+    });
+
+    assertEquals(jsonBody(0), {
+      name: "Ingest contracts",
+      target: "task:knowledge-ingest",
+      config: {
+        path_prefix: "uploads/contracts",
       },
     });
   });
@@ -639,7 +702,7 @@ describe("VeryfrontJobsClient", () => {
       timezone: "Europe/Stockholm",
       concurrencyPolicy: "Forbid",
       config: {
-        file_count: 1,
+        paths: ["uploads/contracts/q1.pdf"],
       },
     });
     const listed = await client.cron.list({ status: "active" });

--- a/src/jobs/jobs-client.test.ts
+++ b/src/jobs/jobs-client.test.ts
@@ -211,6 +211,7 @@ describe("VeryfrontJobsClient", () => {
     });
 
     assertEquals(jsonBody(0), {
+      name: "Ingest knowledge",
       target: "task:knowledge-ingest",
       batch_id: "66666666-6666-4666-8666-666666666666",
       config: {
@@ -233,6 +234,7 @@ describe("VeryfrontJobsClient", () => {
     });
 
     assertEquals(jsonBody(0), {
+      name: "Ingest knowledge",
       target: "task:knowledge-ingest",
       config: {
         paths: ["uploads/contracts/q1.pdf"],

--- a/src/jobs/jobs-client.ts
+++ b/src/jobs/jobs-client.ts
@@ -38,6 +38,7 @@ import {
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_INITIAL_RETRY_DELAY_MS = 1_000;
 const DEFAULT_MAX_RETRY_DELAY_MS = 10_000;
+const DEFAULT_KNOWLEDGE_INGEST_JOB_NAME = "Ingest knowledge";
 
 export interface VeryfrontJobsClientConfig {
   apiUrl?: string;
@@ -66,7 +67,7 @@ export interface ListJobEventsOptions extends ProjectScopedOptions {
 }
 
 export interface CreateJobInput extends ProjectScopedOptions {
-  name?: string;
+  name: string;
   target: string;
   environmentId?: string;
   batchId?: string;
@@ -345,8 +346,11 @@ export class VeryfrontJobsClient {
     options: KnowledgeIngestJobOptions,
     config: Record<string, unknown>,
   ): Promise<Job> {
+    const { name = DEFAULT_KNOWLEDGE_INGEST_JOB_NAME, ...rest } = options;
+
     return this.create({
-      ...options,
+      ...rest,
+      name,
       target: "task:knowledge-ingest",
       config,
     });

--- a/src/jobs/jobs-client.ts
+++ b/src/jobs/jobs-client.ts
@@ -66,13 +66,33 @@ export interface ListJobEventsOptions extends ProjectScopedOptions {
 }
 
 export interface CreateJobInput extends ProjectScopedOptions {
-  name: string;
+  name?: string;
   target: string;
   environmentId?: string;
   batchId?: string;
   config?: Record<string, unknown>;
   timeoutSeconds?: number;
   backoffLimit?: number;
+}
+
+export interface KnowledgeIngestJobOptions extends ProjectScopedOptions {
+  name?: string;
+  environmentId?: string;
+  batchId?: string;
+  timeoutSeconds?: number;
+  backoffLimit?: number;
+}
+
+export interface KnowledgeIngestByUploadIdsInput extends KnowledgeIngestJobOptions {
+  uploadIds: string[];
+}
+
+export interface KnowledgeIngestByUploadPathsInput extends KnowledgeIngestJobOptions {
+  uploadPaths: string[];
+}
+
+export interface KnowledgeIngestByUploadPrefixInput extends KnowledgeIngestJobOptions {
+  uploadPrefix: string;
 }
 
 export interface ListBatchJobsOptions extends ProjectScopedOptions {
@@ -138,6 +158,12 @@ export class VeryfrontJobsClient {
   private requestToken?: string;
   private requestProjectReference?: string;
 
+  readonly knowledge: {
+    ingestByUploadIds: NamespaceMethod<[KnowledgeIngestByUploadIdsInput], Job>;
+    ingestByUploadPaths: NamespaceMethod<[KnowledgeIngestByUploadPathsInput], Job>;
+    ingestByUploadPrefix: NamespaceMethod<[KnowledgeIngestByUploadPrefixInput], Job>;
+  };
+
   readonly cron: {
     create: NamespaceMethod<[CreateCronJobInput], CronJob>;
     list: NamespaceMethod<[ListCronJobsOptions?], PaginatedCronJobsResponse>;
@@ -165,6 +191,12 @@ export class VeryfrontJobsClient {
       maxRetries: config.retry?.maxRetries ?? DEFAULT_MAX_RETRIES,
       initialDelay: config.retry?.initialDelay ?? DEFAULT_INITIAL_RETRY_DELAY_MS,
       maxDelay: config.retry?.maxDelay ?? DEFAULT_MAX_RETRY_DELAY_MS,
+    };
+
+    this.knowledge = {
+      ingestByUploadIds: (input) => this.ingestKnowledgeByUploadIds(input),
+      ingestByUploadPaths: (input) => this.ingestKnowledgeByUploadPaths(input),
+      ingestByUploadPrefix: (input) => this.ingestKnowledgeByUploadPrefix(input),
     };
 
     this.cron = {
@@ -292,6 +324,32 @@ export class VeryfrontJobsClient {
       JobSchema,
       { method: "POST" },
     );
+  }
+
+  private ingestKnowledgeByUploadIds(input: KnowledgeIngestByUploadIdsInput): Promise<Job> {
+    const { uploadIds, ...options } = input;
+    return this.createKnowledgeIngestJob(options, { upload_ids: uploadIds });
+  }
+
+  private ingestKnowledgeByUploadPaths(input: KnowledgeIngestByUploadPathsInput): Promise<Job> {
+    const { uploadPaths, ...options } = input;
+    return this.createKnowledgeIngestJob(options, { paths: uploadPaths });
+  }
+
+  private ingestKnowledgeByUploadPrefix(input: KnowledgeIngestByUploadPrefixInput): Promise<Job> {
+    const { uploadPrefix, ...options } = input;
+    return this.createKnowledgeIngestJob(options, { path_prefix: uploadPrefix });
+  }
+
+  private createKnowledgeIngestJob(
+    options: KnowledgeIngestJobOptions,
+    config: Record<string, unknown>,
+  ): Promise<Job> {
+    return this.create({
+      ...options,
+      target: "task:knowledge-ingest",
+      config,
+    });
   }
 
   private createCronJob(input: CreateCronJobInput): Promise<CronJob> {


### PR DESCRIPTION
Summary:
- make JobsClient create input name optional
- add jobs.knowledge.ingestByUploadIds, ingestByUploadPaths, and ingestByUploadPrefix helpers
- update jobs tests and docs examples for the simplified config

Tests:
- deno fmt --check src/jobs/jobs-client.ts src/jobs/jobs-client.test.ts src/jobs/index.ts
- DENO_NO_PACKAGE_JSON=1 deno lint src/jobs/jobs-client.ts src/jobs/jobs-client.test.ts src/jobs/index.ts
- deno test --no-check --allow-all src/jobs/jobs-client.test.ts
- pre-push checks