### PR TITLE
Publish clean AG-UI runtime route contract

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.547",
+  "version": "0.1.548",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.547";
+export const VERSION = "0.1.548";


### PR DESCRIPTION
## Summary
- bump Veryfront package metadata to 0.1.548 so CI publishes the clean AG-UI route contract
- keep the generated version constant in sync with deno.json

## Why
The current main source no longer exposes POST /api/ag-ui/messages/stream, but npm veryfront@0.1.547 still does. A new package version is required before downstream runtime consumers can assert the alias is gone.

## Verification
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/agent/service/routes.test.ts src/agent/service/runtime.test.ts
- deno task build:npm
- rg ag-ui/messages and messages/stream in src npm/esm npm/src
- git diff --check