### PR TITLE
Standardize signed runtime control on run routes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.548",
+  "version": "0.1.549",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/architecture/09-control-plane-channels.md
+++ b/docs/architecture/09-control-plane-channels.md
@@ -8,14 +8,14 @@ MCP server protocol handling or browser AG-UI chunk encoding.
 Control-plane channels move signed management requests between Veryfront
 services and project runtimes.
 
-Project runtimes expose these signed agent control-plane paths:
+Project runtimes expose these signed control-plane paths:
 
-| Path                                                | Purpose                                               |
-| --------------------------------------------------- | ----------------------------------------------------- |
-| `POST /api/control-plane/agents/list`               | List project agents available to the control plane.   |
-| `POST /api/control-plane/agents/stream`             | Invoke a project agent with a signed runtime request. |
-| `POST /api/control-plane/agents/runs/:runId/resume` | Resume a waiting project agent run.                   |
-| `DELETE /api/control-plane/agents/runs/:runId`      | Cancel a project agent run.                           |
+| Path                                         | Purpose                                                   |
+| -------------------------------------------- | --------------------------------------------------------- |
+| `POST /api/control-plane/agents/list`        | List project agents available to the control plane.       |
+| `POST /api/control-plane/runs/:runId/stream` | Invoke a project agent run with a signed runtime request. |
+| `POST /api/control-plane/runs/:runId/resume` | Resume a waiting project agent run.                       |
+| `DELETE /api/control-plane/runs/:runId`      | Cancel a project agent run.                               |
 
 Primary source areas:
 

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -8,7 +8,7 @@ order: 23
 
 Expose tools, prompts, and resources over Model Context Protocol.
 
-This guide covers the application-facing MCP server exposed by `veryfront/mcp`. It is separate from the internal AG-UI transport used by Veryfront Studio and internal agent control-plane flows.
+This guide covers the application-facing MCP server exposed by `veryfront/mcp`. It is separate from the internal AG-UI transport and signed control-plane run flows used by Veryfront Studio.
 
 ## Setup
 

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -8,7 +8,7 @@ order: 20
 
 MCP server exposing tools, prompts, and resources.
 
-This is the application-facing MCP surface. It is separate from the internal AG-UI transport used by Veryfront Studio and internal agent control-plane flows.
+This is the application-facing MCP surface. It is separate from the internal AG-UI transport and signed control-plane run flows used by Veryfront Studio.
 
 ## Import
 

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -218,7 +218,7 @@ describe("agent/hosted-chat-request", () => {
   it("parses runtime agent invocations into hosted chat requests", async () => {
     const invocation = createRuntimeInvocation();
     const parsed = await parseRuntimeAgentRunInvocationHostedChatRequestFromRequest(
-      new Request("https://agent.example.com/api/control-plane/agents/stream", {
+      new Request("https://agent.example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         body: JSON.stringify(invocation),
       }),

--- a/src/agent/runtime/agent-invocation-contract.test.ts
+++ b/src/agent/runtime/agent-invocation-contract.test.ts
@@ -240,7 +240,7 @@ describe("agent/runtime-agent-invocation-contract", () => {
 
   it("parses runtime agent invocation request bodies through the public helper", async () => {
     const parsed = await parseRuntimeAgentRunInvocation(
-      new Request("http://localhost/api/control-plane/agents/stream", {
+      new Request("http://localhost/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(createInvocation()),
@@ -253,7 +253,7 @@ describe("agent/runtime-agent-invocation-contract", () => {
 
   it("returns a 400 response for malformed runtime agent invocation payloads", async () => {
     const result = await parseRuntimeAgentRunInvocationOrError(
-      new Request("http://localhost/api/control-plane/agents/stream", {
+      new Request("http://localhost/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ run: { runId: "run_1" } }),

--- a/src/agent/service/routes.test.ts
+++ b/src/agent/service/routes.test.ts
@@ -95,7 +95,7 @@ Deno.test("agent service routes expose the default paths", () => {
     "POST /api/ag-ui",
     "DELETE /api/runs/:runId",
     "POST /api/runs",
-    "POST /api/control-plane/agents/stream",
+    "POST /api/control-plane/runs/:runId/stream",
   ]);
 });
 
@@ -129,9 +129,10 @@ Deno.test("agent service routes preserve control-plane target agent ids", async 
   const { routeSet, preparedRequests } = createRouteSet();
   const response = await routeSet.handleRuntimeAgentRunInvocationExecuteRequest({
     request: createAuthenticatedRequest(
-      "/api/control-plane/agents/stream",
+      "/api/control-plane/runs/run-1/stream",
       createRuntimeAgentInvocationBody(),
     ),
+    runId: "run-1",
   });
 
   assertEquals(response.status, 202);

--- a/src/agent/service/routes.ts
+++ b/src/agent/service/routes.ts
@@ -1,5 +1,5 @@
 import { parseProviderError } from "../../chat/provider-errors.ts";
-import { CONTROL_PLANE_AGENT_STREAM_PATH } from "../../channels/control-plane.ts";
+import { CONTROL_PLANE_RUN_STREAM_PATH } from "../../channels/control-plane.ts";
 import type { AgentServiceRoute } from "./definition.ts";
 import { createAgUiRunErrorEvent, createAgUiSseErrorResponse } from "../ag-ui/host-support.ts";
 import { createAgUiRuntimeHandler } from "../ag-ui/runtime-handler.ts";
@@ -118,6 +118,7 @@ export type HostedAgentServiceRouteSet<TExecution extends object> = {
   handleRuntimeAgentRunInvocationExecuteRequest: (input: {
     request: Request;
     requestOrCtx?: unknown;
+    runId?: string;
   }) => Promise<Response>;
   handleDurableChatRunCancelRequest: (input: {
     request: Request;
@@ -298,6 +299,7 @@ export function createHostedAgentServiceRouteSet<TExecution extends object>(
   async function handleRuntimeAgentRunInvocationExecuteRequest(input: {
     request: Request;
     requestOrCtx?: unknown;
+    runId?: string;
   }): Promise<Response> {
     return trace("handler.runtimeAgentRunInvocationExecute", async () => {
       const req = await parseRuntimeAgentRunInvocationHostedChatRequestFromRequest(input.request, {
@@ -307,6 +309,10 @@ export function createHostedAgentServiceRouteSet<TExecution extends object>(
       });
       if (req instanceof Response) {
         return req;
+      }
+
+      if (input.runId && req.durableRootRun?.runId !== input.runId) {
+        return Response.json({ errorCode: "CONTROL_PLANE_RUN_ID_MISMATCH" }, { status: 400 });
       }
 
       return executeParsedDurableChatRun({
@@ -361,8 +367,9 @@ export function createHostedAgentServiceRouteSet<TExecution extends object>(
     },
     {
       method: "POST",
-      path: CONTROL_PLANE_AGENT_STREAM_PATH,
-      handler: (request: Request) => handleRuntimeAgentRunInvocationExecuteRequest({ request }),
+      path: CONTROL_PLANE_RUN_STREAM_PATH,
+      handler: (request: Request, params: Record<string, string>) =>
+        handleRuntimeAgentRunInvocationExecuteRequest({ request, runId: params.runId }),
     },
   ];
 

--- a/src/agent/service/runtime.test.ts
+++ b/src/agent/service/runtime.test.ts
@@ -74,7 +74,7 @@ describe("agent/agent-service-runtime", () => {
       "/api/ag-ui",
       "/api/runs/:runId",
       "/api/runs",
-      "/api/control-plane/agents/stream",
+      "/api/control-plane/runs/:runId/stream",
     ]);
 
     const ready = await bundle.runtime.request("/readiness");

--- a/src/channels/control-plane.ts
+++ b/src/channels/control-plane.ts
@@ -8,8 +8,8 @@ import type { InferSchema, Schema } from "#veryfront/extensions/schema/index.ts"
 const SIGNATURE_SKEW_SECONDS = 5;
 
 export const CONTROL_PLANE_AGENTS_LIST_PATH = "/api/control-plane/agents/list";
-export const CONTROL_PLANE_AGENT_STREAM_PATH = "/api/control-plane/agents/stream";
-export const CONTROL_PLANE_AGENT_RUNS_PATH_PREFIX = "/api/control-plane/agents/runs/";
+export const CONTROL_PLANE_RUNS_PATH_PREFIX = "/api/control-plane/runs/";
+export const CONTROL_PLANE_RUN_STREAM_PATH = "/api/control-plane/runs/:runId/stream";
 
 const getCompactJwsHeaderSchema = defineSchema((v) =>
   v.object({

--- a/src/internal-agents/control-plane-auth.test.ts
+++ b/src/internal-agents/control-plane-auth.test.ts
@@ -61,7 +61,7 @@ describe("internal-agents/control-plane-auth", () => {
       requestId: "run-1",
       surface: "studio",
     });
-    const request = new Request("https://veryfront.test/api/control-plane/agents/stream", {
+    const request = new Request("https://veryfront.test/api/control-plane/runs/run_1/stream", {
       headers: { "x-veryfront-control-plane-jws": jws },
     });
 
@@ -84,7 +84,7 @@ describe("internal-agents/control-plane-auth", () => {
       const error = await assertRejects(
         () =>
           verifyControlPlaneRequest(
-            new Request("https://veryfront.test/api/control-plane/agents/stream"),
+            new Request("https://veryfront.test/api/control-plane/runs/run_1/stream"),
             createVerificationCtx(),
             "{}",
           ),
@@ -111,7 +111,7 @@ describe("internal-agents/control-plane-auth", () => {
     const error = await assertRejects(
       () =>
         verifyControlPlaneRequest(
-          new Request("https://veryfront.test/api/control-plane/agents/stream"),
+          new Request("https://veryfront.test/api/control-plane/runs/run_1/stream"),
           ctx,
           "{}",
         ),
@@ -126,7 +126,7 @@ describe("internal-agents/control-plane-auth", () => {
     const error = await assertRejects(
       () =>
         verifyControlPlaneRequest(
-          new Request("https://veryfront.test/api/control-plane/agents/stream"),
+          new Request("https://veryfront.test/api/control-plane/runs/run_1/stream"),
           createVerificationCtx("test-key"),
           "{}",
         ),
@@ -143,7 +143,7 @@ describe("internal-agents/control-plane-auth", () => {
       requestId: "run-1",
       surface: "studio",
     });
-    const request = new Request("https://veryfront.test/api/control-plane/agents/stream", {
+    const request = new Request("https://veryfront.test/api/control-plane/runs/run_1/stream", {
       headers: { "x-veryfront-control-plane-jws": jws },
     });
 

--- a/src/internal-agents/request-body.test.ts
+++ b/src/internal-agents/request-body.test.ts
@@ -8,13 +8,13 @@ import {
 
 describe("internal-agents/request-body", () => {
   it("returns an empty string when the request has no body", async () => {
-    const request = new Request("https://veryfront.test/api/control-plane/agents/stream");
+    const request = new Request("https://veryfront.test/api/control-plane/runs/run_1/stream");
 
     assertEquals(await readInternalAgentRequestBody(request), "");
   });
 
   it("reads request bodies that stay within the configured limit", async () => {
-    const request = new Request("https://veryfront.test/api/control-plane/agents/stream", {
+    const request = new Request("https://veryfront.test/api/control-plane/runs/run_1/stream", {
       method: "POST",
       body: "ok",
     });
@@ -23,7 +23,7 @@ describe("internal-agents/request-body", () => {
   });
 
   it("maps oversized request bodies to an internal-agent-specific error", async () => {
-    const request = new Request("https://veryfront.test/api/control-plane/agents/stream", {
+    const request = new Request("https://veryfront.test/api/control-plane/runs/run_1/stream", {
       method: "POST",
       body: "too-large",
     });

--- a/src/internal-agents/runtime-owner.test.ts
+++ b/src/internal-agents/runtime-owner.test.ts
@@ -17,7 +17,7 @@ function createDynamicImportStub(
 describe("internal-agents/runtime-owner", () => {
   it("prefers explicit pod env overrides for the runtime owner url", async () => {
     const request = new Request(
-      "https://demo-project.preview.veryfront.org/api/control-plane/agents/stream",
+      "https://demo-project.preview.veryfront.org/api/control-plane/runs/run_1/stream",
     );
 
     const ownerUrl = await resolveRuntimeOwnerInvokeUrl(request, {
@@ -37,7 +37,7 @@ describe("internal-agents/runtime-owner", () => {
 
   it("falls back to detected runtime interfaces when no explicit pod host is configured", async () => {
     const request = new Request(
-      "https://demo-project.preview.veryfront.org/api/control-plane/agents/stream",
+      "https://demo-project.preview.veryfront.org/api/control-plane/runs/run_1/stream",
     );
 
     const ownerUrl = await resolveRuntimeOwnerInvokeUrl(request, {
@@ -59,7 +59,7 @@ describe("internal-agents/runtime-owner", () => {
 
   it("does not let a generic PORT env override the runtime listener port", async () => {
     const request = new Request(
-      "https://demo-project.preview.veryfront.org:21000/api/control-plane/agents/stream",
+      "https://demo-project.preview.veryfront.org:21000/api/control-plane/runs/run_1/stream",
     );
 
     const ownerUrl = await resolveRuntimeOwnerInvokeUrl(request, {
@@ -80,7 +80,7 @@ describe("internal-agents/runtime-owner", () => {
 
   it("returns a null owner url when Deno interface probing throws", async () => {
     const request = new Request(
-      "https://demo-project.preview.veryfront.org/api/control-plane/agents/stream",
+      "https://demo-project.preview.veryfront.org/api/control-plane/runs/run_1/stream",
     );
 
     const ownerUrl = await resolveRuntimeOwnerInvokeUrl(request, {
@@ -100,7 +100,7 @@ describe("internal-agents/runtime-owner", () => {
 
   it("returns null when no routable runtime owner host can be determined", async () => {
     const request = new Request(
-      "https://demo-project.preview.veryfront.org/api/control-plane/agents/stream",
+      "https://demo-project.preview.veryfront.org/api/control-plane/runs/run_1/stream",
     );
 
     const ownerUrl = await resolveRuntimeOwnerInvokeUrl(request, {

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -1181,7 +1181,7 @@ describe("Proxy Handler", () => {
       }
     });
 
-    it("allows signed internal agent stream requests through protected preview using inbound token", async () => {
+    it("allows signed control-plane run stream requests through protected preview using inbound token", async () => {
       let tokenEndpointHits = 0;
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);
@@ -1212,7 +1212,7 @@ describe("Proxy Handler", () => {
         const handler = createHandler(port);
 
         const req = new Request(
-          "http://protected-project.preview.veryfront.com/api/control-plane/agents/stream",
+          "http://protected-project.preview.veryfront.com/api/control-plane/runs/run_1/stream",
           {
             headers: {
               host: "protected-project.preview.veryfront.com",

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -70,7 +70,7 @@ const INTERNAL_CONTROL_PLANE_SIGNATURE_HEADERS = [
 
 function isInternalControlPlanePath(pathname: string): boolean {
   return pathname === "/channels/invoke" ||
-    pathname.startsWith("/api/control-plane/agents/") ||
+    pathname.startsWith("/api/control-plane/") ||
     pathname.startsWith("/internal/tasks/") ||
     pathname.startsWith("/internal/workflows/");
 }

--- a/src/server/handlers/request/agent-run-cancel.handler.test.ts
+++ b/src/server/handlers/request/agent-run-cancel.handler.test.ts
@@ -15,7 +15,7 @@ describe("server/handlers/request/agent-run-cancel.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1", {
+      new Request("https://example.com/api/control-plane/runs/run_1", {
         method: "DELETE",
         headers: {
           "content-type": "application/json",
@@ -41,7 +41,7 @@ describe("server/handlers/request/agent-run-cancel.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1", {
+      new Request("https://example.com/api/control-plane/runs/run_1", {
         method: "DELETE",
         headers: {
           "content-type": "application/json",
@@ -63,7 +63,7 @@ describe("server/handlers/request/agent-run-cancel.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1", {
+      new Request("https://example.com/api/control-plane/runs/run_1", {
         method: "DELETE",
         headers: {
           "content-type": "application/json",
@@ -89,7 +89,7 @@ describe("server/handlers/request/agent-run-cancel.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1", {
+      new Request("https://example.com/api/control-plane/runs/run_1", {
         method: "DELETE",
         headers: {
           "content-type": "application/json",
@@ -109,7 +109,7 @@ describe("server/handlers/request/agent-run-cancel.handler", () => {
     const handler = new AgentRunCancelHandler(new AgentRunSessionManager());
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1", {
+      new Request("https://example.com/api/control-plane/runs/run_1", {
         method: "DELETE",
         headers: {
           "content-type": "application/json",
@@ -127,7 +127,7 @@ describe("server/handlers/request/agent-run-cancel.handler", () => {
   it("ignores non-matching cancel routes", async () => {
     const handler = new AgentRunCancelHandler(new AgentRunSessionManager());
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1/extra", {
+      new Request("https://example.com/api/control-plane/runs/run_1/extra", {
         method: "DELETE",
       }),
       createCtx(),

--- a/src/server/handlers/request/agent-run-cancel.handler.ts
+++ b/src/server/handlers/request/agent-run-cancel.handler.ts
@@ -1,4 +1,4 @@
-import { CONTROL_PLANE_AGENT_RUNS_PATH_PREFIX } from "#veryfront/channels/control-plane.ts";
+import { CONTROL_PLANE_RUNS_PATH_PREFIX } from "#veryfront/channels/control-plane.ts";
 import {
   ControlPlaneRequestError,
   verifyControlPlaneRequest,
@@ -16,7 +16,7 @@ import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 
-const CANCEL_PATH_REGEX = /^\/api\/control-plane\/agents\/runs\/([^/]+)$/;
+const CANCEL_PATH_REGEX = /^\/api\/control-plane\/runs\/([^/]+)$/;
 
 function getRunId(pathname: string): string | null {
   return CANCEL_PATH_REGEX.exec(pathname)?.[1] ?? null;
@@ -27,7 +27,7 @@ export class AgentRunCancelHandler extends BaseHandler {
     name: "AgentRunCancelHandler",
     priority: PRIORITY_MEDIUM_API as HandlerPriority,
     patterns: [
-      { pattern: CONTROL_PLANE_AGENT_RUNS_PATH_PREFIX, prefix: true, method: "DELETE" },
+      { pattern: CONTROL_PLANE_RUNS_PATH_PREFIX, prefix: true, method: "DELETE" },
     ],
   };
 

--- a/src/server/handlers/request/agent-run-resume.handler.test.ts
+++ b/src/server/handlers/request/agent-run-resume.handler.test.ts
@@ -21,7 +21,7 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1/resume", {
+      new Request("https://example.com/api/control-plane/runs/run_1/resume", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -52,7 +52,7 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1/resume", {
+      new Request("https://example.com/api/control-plane/runs/run_1/resume", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -84,7 +84,7 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1/resume", {
+      new Request("https://example.com/api/control-plane/runs/run_1/resume", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -110,7 +110,7 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1/resume", {
+      new Request("https://example.com/api/control-plane/runs/run_1/resume", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -132,7 +132,7 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1/resume", {
+      new Request("https://example.com/api/control-plane/runs/run_1/resume", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -164,7 +164,7 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1/resume", {
+      new Request("https://example.com/api/control-plane/runs/run_1/resume", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -194,7 +194,7 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1/resume", {
+      new Request("https://example.com/api/control-plane/runs/run_1/resume", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -229,7 +229,7 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1/resume", {
+      new Request("https://example.com/api/control-plane/runs/run_1/resume", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -257,7 +257,7 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1/resume", {
+      new Request("https://example.com/api/control-plane/runs/run_1/resume", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -287,7 +287,7 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1/resume", {
+      new Request("https://example.com/api/control-plane/runs/run_1/resume", {
         method: "POST",
         headers: {
           "content-type": "application/json",

--- a/src/server/handlers/request/agent-run-resume.handler.ts
+++ b/src/server/handlers/request/agent-run-resume.handler.ts
@@ -1,4 +1,4 @@
-import { CONTROL_PLANE_AGENT_RUNS_PATH_PREFIX } from "#veryfront/channels/control-plane.ts";
+import { CONTROL_PLANE_RUNS_PATH_PREFIX } from "#veryfront/channels/control-plane.ts";
 import {
   ControlPlaneRequestError,
   verifyControlPlaneRequest,
@@ -20,7 +20,7 @@ import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 
-const RESUME_PATH_REGEX = /^\/api\/control-plane\/agents\/runs\/([^/]+)\/resume$/;
+const RESUME_PATH_REGEX = /^\/api\/control-plane\/runs\/([^/]+)\/resume$/;
 
 function getRunId(pathname: string): string | null {
   return RESUME_PATH_REGEX.exec(pathname)?.[1] ?? null;
@@ -31,7 +31,7 @@ export class AgentRunResumeHandler extends BaseHandler {
     name: "AgentRunResumeHandler",
     priority: PRIORITY_MEDIUM_API as HandlerPriority,
     patterns: [
-      { pattern: CONTROL_PLANE_AGENT_RUNS_PATH_PREFIX, prefix: true, method: "POST" },
+      { pattern: CONTROL_PLANE_RUNS_PATH_PREFIX, prefix: true, method: "POST" },
     ],
   };
 

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -136,7 +136,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/stream", {
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -225,7 +225,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/stream", {
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -278,7 +278,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/stream", {
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -293,7 +293,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(result.response.status, 200);
   });
 
-  it("accepts the canonical runtime AG-UI request shape on the existing internal stream route", async () => {
+  it("accepts the canonical runtime AG-UI request shape on the control-plane run stream route", async () => {
     let streamContext: Record<string, unknown> | undefined;
 
     const handler = new AgentStreamHandler({
@@ -366,7 +366,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/stream", {
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -495,7 +495,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/stream", {
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -568,7 +568,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/stream", {
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -629,7 +629,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/stream", {
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -659,7 +659,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/stream", {
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -687,7 +687,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/stream", {
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -715,7 +715,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/stream", {
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -749,7 +749,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/stream", {
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -815,7 +815,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/stream", {
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -913,7 +913,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     };
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/stream", {
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -953,7 +953,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
 
     const body = createAgentStreamRequestBody();
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
-    const request = new Request("https://example.com/api/control-plane/agents/stream", {
+    const request = new Request("https://example.com/api/control-plane/runs/run_1/stream", {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -987,7 +987,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/stream", {
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -1024,7 +1024,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/stream", {
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -1071,7 +1071,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/stream", {
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -1108,7 +1108,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const resumeSignature = await createControlPlaneSignature(resumeBody, { requestId: "run_1" });
 
     const resumeResult = await resumeHandler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1/resume", {
+      new Request("https://example.com/api/control-plane/runs/run_1/resume", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -1217,7 +1217,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/agents/stream", {
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -1244,7 +1244,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const resumeSignature = await createControlPlaneSignature(resumeBody, { requestId: "run_1" });
 
     const resumeResult = await resumeHandler.handle(
-      new Request("https://example.com/api/control-plane/agents/runs/run_1/resume", {
+      new Request("https://example.com/api/control-plane/runs/run_1/resume", {
         method: "POST",
         headers: {
           "content-type": "application/json",

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -1,9 +1,6 @@
 import type { Agent } from "#veryfront/agent";
 import { defaultChannelInvokeDeps } from "#veryfront/channels/invoke.ts";
-import {
-  CONTROL_PLANE_AGENT_STREAM_PATH,
-  type RuntimeAgentDiscoveryDeps,
-} from "#veryfront/channels/control-plane.ts";
+import { type RuntimeAgentDiscoveryDeps } from "#veryfront/channels/control-plane.ts";
 import {
   createRuntimeAgentStreamResponse,
   type RuntimeAgentStreamExecutionDeps,
@@ -52,6 +49,7 @@ const defaultDeps: AgentStreamHandlerDeps = {
   resolveRuntimeOwnerInvokeUrl,
 };
 const logger = serverLogger.component("agent-stream-handler");
+const RUN_STREAM_PATH_REGEX = /^\/api\/control-plane\/runs\/([^/]+)\/stream$/;
 
 type SourceContextFsWrapper = {
   isMultiProjectMode?: () => boolean;
@@ -132,12 +130,17 @@ function parseAgentStreamPayload(rawPayload: unknown): InternalAgentStreamReques
   return internalAgentStreamRequestSchema.parse(rawPayload);
 }
 
+function getPathRunId(pathname: string): string | null {
+  const match = RUN_STREAM_PATH_REGEX.exec(pathname);
+  return match?.[1] ? decodeURIComponent(match[1]) : null;
+}
+
 export class AgentStreamHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "AgentStreamHandler",
     priority: PRIORITY_MEDIUM_API as HandlerPriority,
     patterns: [
-      { pattern: CONTROL_PLANE_AGENT_STREAM_PATH, exact: true, method: "POST" },
+      { pattern: RUN_STREAM_PATH_REGEX, method: "POST" },
     ],
   };
 
@@ -180,11 +183,15 @@ export class AgentStreamHandler extends BaseHandler {
         .withSecurity(ctx.securityConfig ?? undefined, req);
 
       try {
+        const pathRunId = getPathRunId(new URL(req.url).pathname);
         const rawBody = await readInternalAgentRequestBody(
           req,
           INTERNAL_AGENT_STREAM_MAX_BODY_BYTES,
         );
         const payload = parseAgentStreamPayload(JSON.parse(rawBody));
+        if (!pathRunId || pathRunId !== payload.runId) {
+          return this.respond(builder.json({ error: "CONTROL_PLANE_RUN_ID_MISMATCH" }, 400));
+        }
         await verifyControlPlaneRequest(req, ctx, rawBody, {
           expectedSubject: payload.runId,
           expectedSurface: "studio",

--- a/src/server/runtime-handler/environment-resolution.test.ts
+++ b/src/server/runtime-handler/environment-resolution.test.ts
@@ -47,7 +47,7 @@ describe("environment-resolution", () => {
     assertEquals(result.releaseId, undefined);
   });
 
-  it("allows signed internal agent control-plane paths without releaseId in proxy production", () => {
+  it("allows signed control-plane run paths without releaseId in proxy production", () => {
     const result = resolveEnvironment({
       proxyEnv: "production",
       reqCtxMode: "production",
@@ -58,7 +58,7 @@ describe("environment-resolution", () => {
       host: "10.192.2.245:20000",
       isLocalProject: false,
       isProxyMode: true,
-      pathname: "/api/control-plane/agents/runs/run_1",
+      pathname: "/api/control-plane/runs/run_1",
       defaultEnvironment: undefined,
     });
 
@@ -67,7 +67,7 @@ describe("environment-resolution", () => {
     assertEquals(result.releaseId, undefined);
   });
 
-  it("allows public control-plane agent paths without releaseId in proxy production", () => {
+  it("allows public control-plane paths without releaseId in proxy production", () => {
     const result = resolveEnvironment({
       proxyEnv: "production",
       reqCtxMode: "production",
@@ -78,7 +78,7 @@ describe("environment-resolution", () => {
       host: "10.192.2.245:20000",
       isLocalProject: false,
       isProxyMode: true,
-      pathname: "/api/control-plane/agents/runs/run_1",
+      pathname: "/api/control-plane/runs/run_1",
       defaultEnvironment: undefined,
     });
 

--- a/src/server/runtime-handler/environment-resolution.ts
+++ b/src/server/runtime-handler/environment-resolution.ts
@@ -64,13 +64,13 @@ export function resolveEnvironment(
 
   // Some framework control-plane surfaces are routed directly to a runtime owner pod and
   // rely on signed control-plane auth instead of a user-facing release address.
-  const isAgentControlPlanePath = opts.pathname.startsWith("/api/control-plane/agents/");
+  const isControlPlanePath = opts.pathname.startsWith("/api/control-plane/");
 
   // Skip releaseId validation for development assets and signed control-plane
   // requests because they do not require a user-facing release context.
   const canSkipReleaseIdValidation = opts.pathname === "/_ws" ||
     opts.pathname.startsWith("/_veryfront/") ||
-    isAgentControlPlanePath;
+    isControlPlanePath;
 
   // Validate releaseId in proxy mode production
   if (

--- a/src/server/runtime-handler/request-utils.test.ts
+++ b/src/server/runtime-handler/request-utils.test.ts
@@ -138,13 +138,13 @@ describe("request-utils", () => {
       assertEquals(shouldSkipEnrichedContext("/api/bench/status"), true);
     });
 
-    it("returns true for agent control-plane routes", () => {
+    it("returns true for control-plane agent discovery routes", () => {
       assertEquals(shouldSkipEnrichedContext("/api/control-plane/agents/list"), true);
     });
 
-    it("returns true for public control-plane agent routes", () => {
+    it("returns true for control-plane run routes", () => {
       assertEquals(shouldSkipEnrichedContext("/api/control-plane/agents/list"), true);
-      assertEquals(shouldSkipEnrichedContext("/api/control-plane/agents/runs/run_1"), true);
+      assertEquals(shouldSkipEnrichedContext("/api/control-plane/runs/run_1"), true);
     });
 
     it("returns false for render routes", () => {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.548";
+export const VERSION = "0.1.549";


### PR DESCRIPTION
## Summary
- move signed control-plane stream, resume, and cancel routes to /api/control-plane/runs/:runId
- keep agent discovery at /api/control-plane/agents/list
- reject mismatched run IDs between the route and payload
- update current-state architecture/MCP docs and bump veryfront to 0.1.549

## Verification
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/agent/service/routes.test.ts src/agent/service/runtime.test.ts src/server/handlers/request/agent-stream.handler.test.ts src/server/handlers/request/agent-run-resume.handler.test.ts src/server/handlers/request/agent-run-cancel.handler.test.ts src/server/runtime-handler/request-utils.test.ts src/server/runtime-handler/environment-resolution.test.ts
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/proxy/handler.test.ts
- deno task build:npm
- deno task docs:verify-npm
- pre-push hook: formatting, lint, typecheck, test:unit (1898 passed)
- rg old control-plane agent stream/run route strings across src docs npm output