### PR TITLE
Initialize hosted service JWT auth by default

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.549",
+  "version": "0.1.550",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/service/auth.test.ts
+++ b/src/agent/service/auth.test.ts
@@ -227,6 +227,27 @@ describe("agent/agent-service-auth", () => {
     assertEquals(result.token, fixture.token);
   });
 
+  it("uses the built-in AuthProvider for configured public key JWTs", async () => {
+    const fixture = await createRs256JwtFixture({
+      userId: "user-1",
+      email: "user@example.test",
+    });
+    const auth = createHostedServiceAuth({
+      getConfig: () => ({
+        OAUTH_PUBLIC_KEY: fixture.publicKeyPem,
+        NODE_ENV: "production",
+        VERYFRONT_API_URL: "https://api.example.test",
+      }),
+    });
+
+    const result = await auth.verifyJwt(fixture.token);
+
+    assertEquals(result.success, true);
+    if (!result.success) throw new Error("Expected JWT verification to succeed");
+    assertEquals(result.userId, "user-1");
+    assertEquals(result.email, "user@example.test");
+  });
+
   it("uses an AuthProvider to verify configured public key JWTs", async () => {
     const calls: Array<{
       token: string;

--- a/src/agent/service/auth.ts
+++ b/src/agent/service/auth.ts
@@ -125,10 +125,20 @@ function getProjectAccessTimeoutMs(options: HostedServiceAuthOptions): number {
   return options.projectAccessTimeoutMs ?? 15_000;
 }
 
-function getAuthProvider(
+let defaultAuthProviderPromise: Promise<HostedServiceJwtVerifier> | undefined;
+
+async function getDefaultAuthProvider(): Promise<HostedServiceJwtVerifier> {
+  defaultAuthProviderPromise ??= import("../../../extensions/ext-auth-jwt/src/index.ts")
+    .then(({ createAuthProvider }) => createAuthProvider({}));
+  return await defaultAuthProviderPromise;
+}
+
+async function getAuthProvider(
   options: HostedServiceAuthOptions,
-): HostedServiceJwtVerifier | undefined {
-  return options.authProvider ?? tryResolve<HostedServiceJwtVerifier>("AuthProvider");
+): Promise<HostedServiceJwtVerifier | undefined> {
+  return options.authProvider ??
+    tryResolve<HostedServiceJwtVerifier>("AuthProvider") ??
+    await getDefaultAuthProvider();
 }
 
 export function getHostedServiceTokenFromRequest(request: Request): string | null {
@@ -267,7 +277,7 @@ export function createHostedServiceAuth(
       }
 
       try {
-        const authProvider = getAuthProvider(options);
+        const authProvider = await getAuthProvider(options);
         if (!authProvider) {
           return {
             success: false,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.549";
+export const VERSION = "0.1.550";


### PR DESCRIPTION
## Summary
- Lazy-load the built-in JWT AuthProvider in hosted agent-service auth when a public key is configured and no explicit provider is registered.
- Add a regression test for production RS256 JWT verification without injected authProvider.
- Bump framework version to 0.1.550 in deno.json and the synced VERSION constant.

## Verification
- deno test --no-check --allow-all src/agent/service/auth.test.ts
- deno test --no-check --allow-all src/agent/service/auth.test.ts src/agent/service/routes.test.ts
- deno test --no-check --allow-all src/agent/service/auth.test.ts src/utils/version.test.ts
- deno fmt --check src/agent/service/auth.ts src/agent/service/auth.test.ts
- deno lint src/agent/service/auth.ts src/agent/service/auth.test.ts
- deno task typecheck
- git push pre-push checks: formatting, lint, typecheck, generated manifests, and unit tests (1898 passed, 0 failed)