### PR TITLE
Filter unavailable hosted agent tools

### DIFF
--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -1,0 +1,75 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { Agent } from "#veryfront/agent";
+import { AgentRunSessionManager } from "./session-manager.ts";
+import { createRuntimeAgentStreamResponse } from "./run-stream.ts";
+
+describe("internal-agents/run-stream", () => {
+  it("filters unavailable boolean source tool declarations before constructing the runtime", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedToolNames: string[] = [];
+
+    const agent = {
+      id: "test",
+      config: {
+        id: "test",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        tools: {
+          cancel_job: true,
+          web_search: true,
+          gmail__list_emails: true,
+        },
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "test",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [
+        {
+          name: "web_search",
+          description: "Search the web",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+      context: [],
+      forwardedProps: {
+        runtimeOverrides: {
+          allowedTools: ["gmail__list_emails"],
+          integrationToolDefinitions: [
+            {
+              name: "gmail__list_emails",
+              description: "List emails",
+              parameters: { type: "object", properties: {} },
+            },
+          ],
+        },
+      },
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        createRuntime: (_agent, mergedTools) => {
+          capturedToolNames = Object.keys(mergedTools ?? {}).sort();
+          return {
+            stream: async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+          };
+        },
+      },
+    );
+
+    assertEquals(capturedToolNames, ["gmail__list_emails", "web_search"]);
+  });
+});

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -91,6 +91,7 @@ function buildMergedTools(
   agent: Agent,
   input: RuntimeRunAgentInput,
   sessionManager: AgentRunSessionManager,
+  allowedRemoteToolNames?: string[],
 ) {
   const injectedTools = Object.fromEntries(
     input.tools.map((tool) => [
@@ -120,7 +121,22 @@ function buildMergedTools(
     return { ...merged, ...injectedTools };
   }
 
-  return { ...agent.config.tools, ...injectedTools };
+  const merged: Record<string, Tool | boolean> = {};
+  for (const [toolName, entry] of Object.entries(agent.config.tools)) {
+    if (entry === true) {
+      if (toolRegistry.get(toolName) || allowedRemoteToolNames?.includes(toolName)) {
+        merged[toolName] = true;
+      }
+      continue;
+    }
+
+    if (entry && typeof entry === "object") {
+      merged[toolName] = entry;
+    }
+  }
+
+  const filtered = { ...merged, ...injectedTools };
+  return Object.keys(filtered).length > 0 ? filtered : undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -190,9 +206,14 @@ export async function createRuntimeAgentStreamResponse(
     threadId: input.threadId,
   });
 
-  const mergedTools = buildMergedTools(agent, input, deps.sessionManager);
   const allowedRemoteToolNames = getAllowedRemoteToolNames(input.forwardedProps);
   const forwardedIntegrationToolDefs = getForwardedIntegrationToolDefinitions(input.forwardedProps);
+  const mergedTools = buildMergedTools(
+    agent,
+    input,
+    deps.sessionManager,
+    allowedRemoteToolNames,
+  );
   const runtimeAgent: RuntimeFilteredAgent = {
     ...agent,
     config: {


### PR DESCRIPTION
## Summary
- filter unavailable boolean `tools: { id: true }` declarations before internal hosted agent runtimes are constructed
- preserve executable local registry tools, injected Studio/control-plane tools, and allowlisted forwarded remote/integration tools
- add a regression test matching the staging failure shape: broad platform tool map + one injected tool + one forwarded integration tool

Fixes #1738

## Root cause
Project-agent source can contain documentation-style platform tool declarations (for example `cancel_job: true`, `create_sandbox_session: true`). The internal hosted runtime merged those booleans directly into `AgentRuntime`, where `getAvailableTools()` treated every unresolved boolean as a hard error before the provider call. If the request only forwarded a subset of executable tools, the run failed with `Unknown tool references: ... Available tools: (none)`.

## Verification
- `deno fmt --check src/internal-agents/run-stream.ts src/internal-agents/run-stream.test.ts`
- `deno lint src/internal-agents/run-stream.ts src/internal-agents/run-stream.test.ts`
- `deno test --allow-env --allow-read --allow-net src/internal-agents/run-stream.test.ts src/agent/runtime/tool-helpers.test.ts`
- `deno task build`

## Staging follow-up
After merge/release, rerun the provided staging conversation/debug snapshot and confirm the run advances past provider tool registration.