### PR TITLE
Bump veryfront-code to 0.1.551

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.550",
+  "version": "0.1.551",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.550";
+export const VERSION = "0.1.551";


### PR DESCRIPTION
## Summary\n- Bump veryfront-code release version from 0.1.550 to 0.1.551 so the hosted-agent tool filtering fix from #1739 can publish and deploy.\n\n## Verification\n- deno fmt --check deno.json src/utils/version-constant.ts\n- deno lint src/utils/version-constant.ts\n- git diff --check