### PR TITLE
Release hosted agent tool filtering

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.551",
+  "version": "0.1.552",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -18,6 +18,7 @@ describe("internal-agents/run-stream", () => {
         system: "test",
         tools: {
           cancel_job: true,
+          create_file: true,
           web_search: true,
           gmail__list_emails: true,
         },
@@ -39,7 +40,7 @@ describe("internal-agents/run-stream", () => {
       context: [],
       forwardedProps: {
         runtimeOverrides: {
-          allowedTools: ["gmail__list_emails"],
+          allowedTools: ["create_file", "gmail__list_emails"],
           integrationToolDefinitions: [
             {
               name: "gmail__list_emails",

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -91,7 +91,7 @@ function buildMergedTools(
   agent: Agent,
   input: RuntimeRunAgentInput,
   sessionManager: AgentRunSessionManager,
-  allowedRemoteToolNames?: string[],
+  availableForwardedToolNames?: string[],
 ) {
   const injectedTools = Object.fromEntries(
     input.tools.map((tool) => [
@@ -124,7 +124,7 @@ function buildMergedTools(
   const merged: Record<string, Tool | boolean> = {};
   for (const [toolName, entry] of Object.entries(agent.config.tools)) {
     if (entry === true) {
-      if (toolRegistry.get(toolName) || allowedRemoteToolNames?.includes(toolName)) {
+      if (toolRegistry.get(toolName) || availableForwardedToolNames?.includes(toolName)) {
         merged[toolName] = true;
       }
       continue;
@@ -208,11 +208,12 @@ export async function createRuntimeAgentStreamResponse(
 
   const allowedRemoteToolNames = getAllowedRemoteToolNames(input.forwardedProps);
   const forwardedIntegrationToolDefs = getForwardedIntegrationToolDefinitions(input.forwardedProps);
+  const availableForwardedToolNames = forwardedIntegrationToolDefs?.map((tool) => tool.name);
   const mergedTools = buildMergedTools(
     agent,
     input,
     deps.sessionManager,
-    allowedRemoteToolNames,
+    availableForwardedToolNames,
   );
   const runtimeAgent: RuntimeFilteredAgent = {
     ...agent,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.551";
+export const VERSION = "0.1.552";


### PR DESCRIPTION
## Summary\n- bump veryfront version to v0.1.551 so the already-merged hosted-agent tool filtering fix is published\n- unblocks staging project-agent chat runs that reference unavailable source tools\n\nFixes #1741\n\n## Verification\n- `deno test -A src/internal-agents/run-stream.test.ts --no-lock`