### PR TITLE
Forward run context for integration tool calls

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.554",
+  "version": "0.1.555",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -222,6 +222,52 @@ describe("tool-helpers", () => {
       );
     });
 
+    it("passes runtime run and agent context to remote integration tool execution", async () => {
+      const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_URL");
+      const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+      let requestBody: Record<string, unknown> | undefined;
+
+      try {
+        Deno.env.set("VERYFRONT_API_URL", "https://api.test");
+        Deno.env.set("VERYFRONT_API_TOKEN", "token");
+
+        const result = await withMockFetch(
+          async (input: string | URL | Request, init?: RequestInit) => {
+            const request = input instanceof Request ? input : new Request(input, init);
+            requestBody = await request.json();
+            return Response.json({ structuredContent: { ok: true } });
+          },
+          async () =>
+            await executeConfiguredTool(
+              "gmail__list_emails",
+              { maxResults: 10 },
+              undefined,
+              {
+                toolCallId: "tool-4",
+                runId: "run-123",
+                agentId: "agent-123",
+                endUserId: "user-123",
+              },
+              ["gmail__list_emails"],
+            ),
+        );
+
+        assertEquals(result, { structuredContent: { ok: true } });
+        assertEquals(requestBody, {
+          name: "gmail__list_emails",
+          arguments: { maxResults: 10 },
+          end_user_id: "user-123",
+          run_id: "run-123",
+          agent_id: "agent-123",
+        });
+      } finally {
+        if (originalApiBaseUrl === undefined) Deno.env.delete("VERYFRONT_API_URL");
+        else Deno.env.set("VERYFRONT_API_URL", originalApiBaseUrl);
+        if (originalApiToken === undefined) Deno.env.delete("VERYFRONT_API_TOKEN");
+        else Deno.env.set("VERYFRONT_API_TOKEN", originalApiToken);
+      }
+    });
+
     it("executes remote MCP tools from configured remote tool sources", async () => {
       const remoteSource = createRemoteMCPToolSource({
         id: "docs",

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -269,11 +269,7 @@ export async function executeConfiguredTool(
     if (allowedRemoteToolNames && !allowedRemoteToolNames.includes(toolName)) {
       throw new Error(`Tool "${toolName}" is not allowed for this run`);
     }
-    return await executeRemoteIntegrationTool(
-      toolName,
-      input,
-      context?.endUserId as string | undefined,
-    );
+    return await executeRemoteIntegrationTool(toolName, input, context);
   }
 
   return await executeTool(toolName, input, context);

--- a/src/integrations/remote-tools.test.ts
+++ b/src/integrations/remote-tools.test.ts
@@ -164,6 +164,38 @@ describe("integrations/remote-tools", () => {
     });
   });
 
+  it("forwards run and agent context when executing remote integration tools", async () => {
+    setRemoteToolEnv({
+      VERYFRONT_API_BASE_URL: "https://api.test",
+      VERYFRONT_API_TOKEN: "env-token",
+    });
+
+    let requestBody: Record<string, unknown> | undefined;
+
+    await withMockFetch(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        requestBody = await request.json();
+
+        return Response.json({ structuredContent: { ok: true } });
+      },
+      async () =>
+        await executeRemoteIntegrationTool(
+          "gmail__list_emails",
+          { maxResults: 10 },
+          { endUserId: "end-user-123", runId: "run-123", agentId: "agent-123" },
+        ),
+    );
+
+    assertEquals(requestBody, {
+      name: "gmail__list_emails",
+      arguments: { maxResults: 10 },
+      end_user_id: "end-user-123",
+      run_id: "run-123",
+      agent_id: "agent-123",
+    });
+  });
+
   it("prefers structuredContent for MCP error results without text content", async () => {
     setRemoteToolEnv({
       VERYFRONT_API_BASE_URL: "https://api.test",

--- a/src/integrations/remote-tools.ts
+++ b/src/integrations/remote-tools.ts
@@ -28,6 +28,22 @@ interface CallToolTextContent {
   text?: string;
 }
 
+type RemoteIntegrationToolExecutionContext = {
+  endUserId?: string;
+  runId?: string;
+  agentId?: string;
+};
+
+function normalizeRemoteExecutionContext(
+  contextOrEndUserId?: string | RemoteIntegrationToolExecutionContext,
+): RemoteIntegrationToolExecutionContext | undefined {
+  if (typeof contextOrEndUserId === "string") {
+    return { endUserId: contextOrEndUserId };
+  }
+
+  return contextOrEndUserId;
+}
+
 // ---------------------------------------------------------------------------
 // Per-request token resolution
 // ---------------------------------------------------------------------------
@@ -99,7 +115,7 @@ async function callRemoteTool(
   token: string,
   toolName: string,
   args: Record<string, unknown>,
-  endUserId?: string,
+  context?: RemoteIntegrationToolExecutionContext,
 ): Promise<unknown> {
   const response = await fetch(`${baseUrl}/integrations/tools/call`, {
     method: "POST",
@@ -110,7 +126,9 @@ async function callRemoteTool(
     body: JSON.stringify({
       name: toolName,
       arguments: args,
-      end_user_id: endUserId,
+      end_user_id: context?.endUserId,
+      run_id: context?.runId,
+      agent_id: context?.agentId,
     }),
   });
 
@@ -194,7 +212,7 @@ export function isRemoteIntegrationTool(toolName: string): boolean {
 export async function executeRemoteIntegrationTool(
   toolName: string,
   args: Record<string, unknown>,
-  endUserId?: string,
+  contextOrEndUserId?: string | RemoteIntegrationToolExecutionContext,
 ): Promise<unknown> {
   const baseUrl = getApiBaseUrlEnv();
   const token = resolveRequestToken();
@@ -202,7 +220,13 @@ export async function executeRemoteIntegrationTool(
     return { error: "no_api_token", message: "No API token available" };
   }
 
-  return callRemoteTool(baseUrl, token, toolName, args, endUserId);
+  return callRemoteTool(
+    baseUrl,
+    token,
+    toolName,
+    args,
+    normalizeRemoteExecutionContext(contextOrEndUserId),
+  );
 }
 
 /**

--- a/src/tool/types.ts
+++ b/src/tool/types.ts
@@ -60,6 +60,8 @@ export interface ToolConfig<TInput = any, TOutput = any> {
 export interface ToolExecutionContext {
   /** ID of the agent calling the tool (if any) */
   agentId?: string;
+  /** ID of the current agent run when the runtime is tracking run lifecycles */
+  runId?: string;
   /** Stable ID for the current tool call when the runtime is tracking tool lifecycles */
   toolCallId?: string;
   /** Project identity used by integration token resolution */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.554";
+export const VERSION = "0.1.555";


### PR DESCRIPTION
## Summary
- Forward runtime tool execution context (`run_id`, `agent_id`, and existing `end_user_id`) when remote integration tools call the API.
- Preserve the existing string `endUserId` call signature for compatibility.
- Add `runId` to `ToolExecutionContext` so agent runtime context is explicit and typed.

## Test Plan
- [x] RED: targeted Deno tests failed before implementation because `run_id`/`agent_id` were not forwarded.
- [x] `deno fmt src/integrations/remote-tools.ts src/integrations/remote-tools.test.ts src/agent/runtime/tool-helpers.ts src/agent/runtime/tool-helpers.test.ts src/tool/types.ts`
- [x] `deno check src/tool/types.ts src/integrations/remote-tools.ts src/agent/runtime/tool-helpers.ts`
- [x] `deno lint src/tool/types.ts src/integrations/remote-tools.ts src/integrations/remote-tools.test.ts src/agent/runtime/tool-helpers.ts src/agent/runtime/tool-helpers.test.ts`
- [x] `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/integrations/remote-tools.test.ts src/agent/runtime/tool-helpers.test.ts`

## Related
- Required companion to API PR: https://github.com/veryfront/veryfront-api/pull/2551
- Fixes runtime-forwarding half of https://github.com/veryfront/veryfront-studio/issues/3895
