### PR TITLE
Keep runtime caches off read-only app roots

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.552",
+  "version": "0.1.553",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/cache-dir.test.ts
+++ b/src/utils/cache-dir.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { deleteEnv, getEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   getCacheBaseDir,
   getCacheDirFromContext,
@@ -9,7 +10,33 @@ import {
   runWithCacheDir,
 } from "./cache-dir.ts";
 
+const MANAGED_ENV_KEYS = [
+  "HOME",
+  "NODE_ENV",
+  "VERYFRONT_CACHE_DIR",
+  "VERYFRONT_MODE",
+  "VF_CACHE_DIR",
+];
+
+const originalEnv = new Map<string, string | undefined>(
+  MANAGED_ENV_KEYS.map((key) => [key, getEnv(key)]),
+);
+
+function restoreManagedEnv(): void {
+  for (const [key, value] of originalEnv) {
+    if (value === undefined) {
+      deleteEnv(key);
+    } else {
+      setEnv(key, value);
+    }
+  }
+}
+
 describe("cache-dir", () => {
+  afterEach(() => {
+    restoreManagedEnv();
+  });
+
   describe("getCacheDirFromContext", () => {
     it("should return undefined when not in a context", () => {
       assertEquals(getCacheDirFromContext(), undefined);
@@ -50,10 +77,53 @@ describe("cache-dir", () => {
       assertEquals(result, "/tmp/context-cache");
     });
 
-    it("should return a string ending with .cache when not in context and no env", () => {
+    it("should prefer context cache dir over explicit env", () => {
+      setEnv("VERYFRONT_CACHE_DIR", "/tmp/env-cache");
+      setEnv("NODE_ENV", "production");
+      setEnv("HOME", "/tmp/home");
+
+      const result = runWithCacheDir("/tmp/context-cache", getCacheBaseDir);
+
+      assertEquals(result, "/tmp/context-cache");
+    });
+
+    it("should prefer VERYFRONT_CACHE_DIR over production default", () => {
+      setEnv("VERYFRONT_CACHE_DIR", "/tmp/env-cache");
+      setEnv("NODE_ENV", "production");
+      setEnv("HOME", "/tmp/home");
+
+      assertEquals(getCacheBaseDir(), "/tmp/env-cache");
+    });
+
+    it("should prefer VF_CACHE_DIR over production default", () => {
+      deleteEnv("VERYFRONT_CACHE_DIR");
+      setEnv("VF_CACHE_DIR", "/tmp/vf-cache");
+      setEnv("NODE_ENV", "production");
+      setEnv("HOME", "/tmp/home");
+
+      assertEquals(getCacheBaseDir(), "/tmp/vf-cache");
+    });
+
+    it("should use a writable home cache in production", () => {
+      deleteEnv("VERYFRONT_CACHE_DIR");
+      deleteEnv("VF_CACHE_DIR");
+      setEnv("NODE_ENV", "production");
+      setEnv("VERYFRONT_MODE", "production");
+      setEnv("HOME", "/tmp");
+
+      assertEquals(getCacheBaseDir(), "/tmp/.cache/veryfront");
+    });
+
+    it("should return the local .cache dir when not in production and no env", () => {
+      deleteEnv("NODE_ENV");
+      deleteEnv("VERYFRONT_MODE");
+      deleteEnv("VERYFRONT_CACHE_DIR");
+      deleteEnv("VF_CACHE_DIR");
+
       const result = getCacheBaseDir();
       assertEquals(typeof result, "string");
       assert(result.length > 0);
+      assert(result.endsWith(".cache"));
     });
   });
 

--- a/src/utils/cache-dir.ts
+++ b/src/utils/cache-dir.ts
@@ -14,11 +14,23 @@ export function getCacheDirFromContext(): string | undefined {
   return cacheStorage.getStore();
 }
 
+function getDefaultCacheBaseDir(): string {
+  const home = getEnv("HOME");
+  const isProduction = getEnv("NODE_ENV") === "production" ||
+    getEnv("VERYFRONT_MODE") === "production";
+
+  if (home && isProduction) {
+    return join(home, ".cache", "veryfront");
+  }
+
+  return join(cwd(), ".cache");
+}
+
 export function getCacheBaseDir(): string {
   return (
     getCacheDirFromContext() ??
       getEnv("VERYFRONT_CACHE_DIR") ?? getEnv("VF_CACHE_DIR") ??
-      join(cwd(), ".cache")
+      getDefaultCacheBaseDir()
   );
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.552";
+export const VERSION = "0.1.553";


### PR DESCRIPTION
## Summary
- change the production cache fallback from cwd/.cache to HOME/.cache/veryfront
- preserve cache context, VERYFRONT_CACHE_DIR, and VF_CACHE_DIR override precedence
- bump veryfront-code to 0.1.553 for release

## Root cause
Authenticated preview rendering reached SSR and attempted to create framework cache directories under /app/.cache. The runtime container has a read-only app root, so mkdir failed before pages/index.tsx could be imported. Unauthenticated requests redirected before SSR, which is why they did not reproduce the 500.

## Verification
- deno test --no-check --allow-all src/utils/cache-dir.test.ts src/utils/version.test.ts src/modules/server/module-server.test.ts src/transforms/esm/http-cache.test.ts src/transforms/esm/http-cache-wrapper.test.ts src/transforms/esm/http-cache-utils.test.ts src/transforms/pipeline/stages/ssr-vf-modules.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/framework-validator.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/dependency-recovery.test.ts
- git diff --check
- pre-push hook: deno fmt check, lint, typecheck, generate, and unit tests: 1899 passed, 17520 steps, 0 failed