### PR TITLE
Keep SSR cache paths in host runtime env

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.553",
+  "version": "0.1.554",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/cache-dir.test.ts
+++ b/src/utils/cache-dir.test.ts
@@ -9,6 +9,7 @@ import {
   getMdxEsmCacheDir,
   runWithCacheDir,
 } from "./cache-dir.ts";
+import { runWithProjectEnv } from "#veryfront/server/project-env/storage.ts";
 
 const MANAGED_ENV_KEYS = [
   "HOME",
@@ -112,6 +113,21 @@ describe("cache-dir", () => {
       setEnv("HOME", "/tmp");
 
       assertEquals(getCacheBaseDir(), "/tmp/.cache/veryfront");
+    });
+
+    it("should use host runtime env while a project env overlay is active", () => {
+      deleteEnv("VERYFRONT_CACHE_DIR");
+      deleteEnv("VF_CACHE_DIR");
+      setEnv("NODE_ENV", "production");
+      setEnv("VERYFRONT_MODE", "production");
+      setEnv("HOME", "/tmp");
+
+      const result = runWithProjectEnv(
+        { HOME: "/tenant", VF_CACHE_DIR: "/tenant/cache" },
+        () => getCacheBaseDir(),
+      );
+
+      assertEquals(result, "/tmp/.cache/veryfront");
     });
 
     it("should return the local .cache dir when not in production and no env", () => {

--- a/src/utils/cache-dir.ts
+++ b/src/utils/cache-dir.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { join } from "#veryfront/compat/path/index.ts";
-import { cwd, getEnv } from "#veryfront/platform/compat/process.ts";
+import { cwd, getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { isNode } from "#veryfront/platform/compat/runtime.ts";
 
 const cacheStorage = new AsyncLocalStorage<string>();
@@ -15,9 +15,9 @@ export function getCacheDirFromContext(): string | undefined {
 }
 
 function getDefaultCacheBaseDir(): string {
-  const home = getEnv("HOME");
-  const isProduction = getEnv("NODE_ENV") === "production" ||
-    getEnv("VERYFRONT_MODE") === "production";
+  const home = getHostEnv("HOME");
+  const isProduction = getHostEnv("NODE_ENV") === "production" ||
+    getHostEnv("VERYFRONT_MODE") === "production";
 
   if (home && isProduction) {
     return join(home, ".cache", "veryfront");
@@ -29,7 +29,7 @@ function getDefaultCacheBaseDir(): string {
 export function getCacheBaseDir(): string {
   return (
     getCacheDirFromContext() ??
-      getEnv("VERYFRONT_CACHE_DIR") ?? getEnv("VF_CACHE_DIR") ??
+      getHostEnv("VERYFRONT_CACHE_DIR") ?? getHostEnv("VF_CACHE_DIR") ??
       getDefaultCacheBaseDir()
   );
 }
@@ -46,7 +46,7 @@ export function getHttpBundleCacheDir(): string {
  * Ensure cached ESM modules can resolve bare specifiers (e.g. `import 'react'`)
  * when running on Node.js.
  *
- * Cached .mjs files live under getCacheBaseDir() (e.g. /app/.cache/). Node.js
+ * Cached .mjs files live under getCacheBaseDir(). Node.js
  * resolves bare specifiers by walking up from the importing file looking for
  * node_modules/. Because the cache directory has no node_modules ancestor,
  * packages like `react` cannot be found.

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.553";
+export const VERSION = "0.1.554";


### PR DESCRIPTION
## Summary
- read framework cache directory env from host runtime env so tenant project env overlays cannot hide production cache settings
- keep production fallback on `<local-path>` for read-only app roots
- bump package version to `0.1.554` for release

## Root cause
Remote project rendering activates the project env overlay. `getEnv()` correctly hides host process env while that overlay is active, but cache directory resolution is framework-owned runtime configuration. During staging SSR, `NODE_ENV` and `HOME` were hidden from `getCacheBaseDir()`, so the HTTP bundle cache fell back to `/app/.cache` and failed on the read-only app root.

## Verification
- `deno test --no-check --allow-all src/utils/cache-dir.test.ts src/utils/version.test.ts`
- `deno test --no-check --allow-all src/transforms/esm/http-cache.test.ts src/transforms/esm/http-cache-wrapper.test.ts src/transforms/esm/http-cache-utils.test.ts src/transforms/pipeline/stages/ssr-vf-modules.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/framework-validator.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/dependency-recovery.test.ts src/modules/server/module-server.test.ts`
- pre-push hook: format, lint, typecheck, generate, unit tests: `1899 passed (17521 steps), 0 failed`