### PR TITLE
chore(release): bump veryfront to 0.1.556

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.555",
+  "version": "0.1.556",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.555";
+export const VERSION = "0.1.556";


### PR DESCRIPTION
Bumps the Veryfront package version so the merged Symphony integration changes publish as a new npm release and can be deployed for staging canary verification.\n\nIncluded integration changes waiting on this release:\n- Airtable expanded tool surface (#1753)\n- Google Sheets write_range endpoint (#1755)\n- Slack conversation OAuth scope alignment (#1754)\n\nVerification:\n- `deno test --allow-read --allow-env src/utils/version.test.ts cli/commands/doctor/version-checks.test.ts scripts/build/npm-package-metadata.test.ts` ✅\n- `deno check src/utils/version.ts src/utils/version-constant.ts` ✅\n- `DENO_NO_PACKAGE_JSON=1 deno lint deno.json src/utils/version-constant.ts src/utils/version.test.ts` ✅\n- `git diff --check` ✅\n- `npm view veryfront@0.1.556 version` confirmed not published yet\n\nTracking issues stay open until post-release staging canary proves all tool calls.