### PR TITLE
Raise runtime forwarded props budget

### DIFF
--- a/src/agent/ag-ui/host-support.test.ts
+++ b/src/agent/ag-ui/host-support.test.ts
@@ -78,6 +78,47 @@ describe("agent/ag-ui-host-support", () => {
     );
   });
 
+  it("accepts forwarded props above the old 64 KB AG-UI budget", async () => {
+    const forwardedProps = {
+      runtimeOverrides: {
+        integrationToolDefinitions: Array.from({ length: 8 }, (_, index) => ({
+          name: `github__bulk_tool_${index}`,
+          description: `Definition for github__bulk_tool_${index} `.repeat(300),
+          inputSchema: {
+            type: "object",
+            properties: {
+              query: {
+                type: "string",
+                description: `Input for github__bulk_tool_${index} `.repeat(300),
+              },
+            },
+          },
+        })),
+      },
+    };
+    const request = new Request("http://localhost/api/ag-ui", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: [{
+          id: "msg-1",
+          role: "user",
+          parts: [{ type: "text", text: "hello" }],
+        }],
+        forwardedProps,
+      }),
+    });
+
+    assertEquals(
+      new TextEncoder().encode(JSON.stringify(forwardedProps)).byteLength > 64 * 1024,
+      true,
+    );
+
+    const parsed = await parseAgUiRequest(request);
+
+    assertEquals(parsed.forwardedProps, forwardedProps);
+  });
+
   it("returns a 400 Response from parseAgUiRequestOrError for malformed JSON bodies", async () => {
     const request = new Request("http://localhost/api/ag-ui", {
       method: "POST",

--- a/src/agent/ag-ui/host-support.ts
+++ b/src/agent/ag-ui/host-support.ts
@@ -8,7 +8,7 @@ const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const MAX_TOOL_PARAMETERS_BYTES = 16_384;
 const MAX_CONTEXT_ITEM_BYTES = 16_384;
 const MAX_CONTEXT_TOTAL_BYTES = 65_536;
-const MAX_FORWARDED_PROPS_BYTES = 65_536;
+const MAX_FORWARDED_PROPS_BYTES = 196_608;
 const MAX_TEXT_PART_LENGTH = 10_000;
 const MAX_MESSAGES_PER_REQUEST = 100;
 const encoder = new TextEncoder();
@@ -103,7 +103,7 @@ export const getAgUiRequestSchema = defineSchema((v) =>
     ),
     forwardedProps: v.record(v.string(), v.unknown()).optional().refine(
       (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_FORWARDED_PROPS_BYTES),
-      { message: "forwardedProps must be less than 64 KB" },
+      { message: "forwardedProps must be less than 192 KB" },
     ),
     model: v.string().optional(),
     maxOutputTokens: v.number().int().positive().optional(),

--- a/src/agent/runtime/ag-ui-contract.ts
+++ b/src/agent/runtime/ag-ui-contract.ts
@@ -6,7 +6,7 @@ const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const MAX_TOOL_PARAMETERS_BYTES = 16_384;
 const MAX_CONTEXT_ITEM_BYTES = 16_384;
 const MAX_CONTEXT_TOTAL_BYTES = 65_536;
-const MAX_FORWARDED_PROPS_BYTES = 65_536;
+const MAX_FORWARDED_PROPS_BYTES = 196_608;
 const MAX_RUNTIME_MESSAGES = 100;
 
 const encoder = new TextEncoder();
@@ -177,7 +177,7 @@ export const getAgUiRuntimeRequestSchema = defineSchema((v) =>
     ),
     forwardedProps: v.record(v.string(), v.unknown()).optional().refine(
       (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_FORWARDED_PROPS_BYTES),
-      { message: "forwardedProps must be less than 64 KB" },
+      { message: "forwardedProps must be less than 192 KB" },
     ),
   })
 );

--- a/src/agent/runtime/agent-invocation-contract.ts
+++ b/src/agent/runtime/agent-invocation-contract.ts
@@ -8,7 +8,7 @@ ensureBuiltinSchemaValidator();
 const MAX_TOOL_PARAMETERS_BYTES = 16_384;
 const MAX_CONTEXT_ITEM_BYTES = 16_384;
 const MAX_CONTEXT_TOTAL_BYTES = 65_536;
-const MAX_FORWARDED_PROPS_BYTES = 65_536;
+const MAX_FORWARDED_PROPS_BYTES = 196_608;
 const encoder = new TextEncoder();
 
 function isWithinJsonSizeLimit(value: unknown, maxBytes: number): boolean {
@@ -308,7 +308,7 @@ export const getRuntimeAgentRunInvocationSchema = defineSchema((v) =>
     agentSource: getRuntimeAgentSourceContextSchema().optional(),
     forwardedProps: v.record(v.string(), v.unknown()).optional().refine(
       (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_FORWARDED_PROPS_BYTES),
-      { message: "forwardedProps must be less than 64 KB" },
+      { message: "forwardedProps must be less than 192 KB" },
     ),
   })
 );

--- a/src/internal-agents/schema.test.ts
+++ b/src/internal-agents/schema.test.ts
@@ -54,6 +54,69 @@ describe("internal-agents/schema", () => {
     );
   });
 
+  it("accepts server-resolved integration metadata above the old 64 KB forwarded props budget", () => {
+    const largeIntegrationDefinitions = Array.from({ length: 8 }, (_, index) => ({
+      name: `github__bulk_tool_${index}`,
+      description: `Definition for github__bulk_tool_${index} `.repeat(300),
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: `Input for github__bulk_tool_${index} `.repeat(300),
+          },
+        },
+      },
+    }));
+    const forwardedProps = {
+      runtimeOverrides: {
+        allowedTools: largeIntegrationDefinitions.map((definition) => definition.name),
+        serverResolvedIntegrationTools: largeIntegrationDefinitions.map((definition) =>
+          definition.name
+        ),
+        integrationToolDefinitions: largeIntegrationDefinitions,
+      },
+    };
+
+    assertEquals(
+      new TextEncoder().encode(JSON.stringify(forwardedProps)).byteLength > 64 * 1024,
+      true,
+    );
+
+    const parsed = getInternalAgentStreamRequestSchema().parse({
+      agentId: "agent_1",
+      threadId: "10000000-1000-4000-8000-100000000001",
+      runId: "run_1",
+      messages: [],
+      forwardedProps,
+    });
+
+    assertEquals(parsed.forwardedProps, forwardedProps);
+  });
+
+  it("rejects forwarded props above the 192 KB runtime budget", () => {
+    assertThrows(
+      () =>
+        getInternalAgentStreamRequestSchema().parse({
+          agentId: "agent_1",
+          threadId: "10000000-1000-4000-8000-100000000001",
+          runId: "run_1",
+          messages: [],
+          forwardedProps: {
+            runtimeOverrides: {
+              integrationToolDefinitions: [{
+                name: "github__large_tool",
+                description: "x".repeat(192 * 1024),
+                inputSchema: { type: "object" },
+              }],
+            },
+          },
+        }),
+      Error,
+      "forwardedProps must be less than 192 KB",
+    );
+  });
+
   it("defaults resume signals to non-error tool results", () => {
     assertEquals(
       getResumeSignalSchema().parse({

--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -21,7 +21,7 @@ import {
 } from "#veryfront/agent/runtime/agent-invocation-contract.ts";
 
 const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
-const MAX_FORWARDED_PROPS_BYTES = 65_536;
+const MAX_FORWARDED_PROPS_BYTES = 196_608;
 const MAX_TOOL_RESULT_BYTES = 65_536;
 const MAX_RUNTIME_MESSAGES = 100;
 
@@ -76,7 +76,7 @@ export const getInternalAgentControlPlaneStreamRequestSchema = defineSchema((v) 
     agentSource: getRuntimeAgentSourceContextSchema().optional(),
     forwardedProps: v.record(v.string(), v.unknown()).optional().refine(
       (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_FORWARDED_PROPS_BYTES),
-      { message: "forwardedProps must be less than 64 KB" },
+      { message: "forwardedProps must be less than 192 KB" },
     ),
   })
 );


### PR DESCRIPTION
## Summary
- raise the runtime/internal `forwardedProps` budget from 64 KB to 192 KB to match the API's project-agent run request envelope
- keep malformed/too-large payloads rejected above the new runtime budget
- add regression coverage for server-resolved integration tool metadata above the old 64 KB cap

## Why
Staging canary project-agent runs for `oauth-jit-canary-mpb97x3m` were accepted by `POST /api/runs` after API fixes, then failed when the preview runtime returned HTTP 400 `Invalid internal agent stream request`. The runtime schemas still enforced the old 64 KB `forwardedProps` limit while the API now validates the full durable event payload separately and allows forwarded props up to 192 KB.

Fixes veryfront/veryfront-studio#3983 after veryfront-api#2569 and veryfront-api#2570.

## Verification
- `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/internal-agents/schema.test.ts src/agent/runtime/ag-ui-contract.test.ts src/agent/runtime/agent-invocation-contract.test.ts src/server/handlers/request/agent-stream.handler.test.ts src/agent/ag-ui/host-support.test.ts`
- `deno fmt --check src/internal-agents/schema.ts src/internal-agents/schema.test.ts src/agent/runtime/ag-ui-contract.ts src/agent/runtime/agent-invocation-contract.ts src/agent/ag-ui/host-support.ts src/agent/ag-ui/host-support.test.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/internal-agents/schema.ts src/internal-agents/schema.test.ts src/agent/runtime/ag-ui-contract.ts src/agent/runtime/agent-invocation-contract.ts src/agent/ag-ui/host-support.ts src/agent/ag-ui/host-support.test.ts`
- `deno check src/internal-agents/schema.ts src/agent/runtime/ag-ui-contract.ts src/agent/runtime/agent-invocation-contract.ts src/agent/ag-ui/host-support.ts`
- `deno task typecheck`
- subagent review: no findings, merge recommendation
