### PR TITLE
Bump veryfront package to 0.1.559

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.558",
+  "version": "0.1.559",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.558";
+export const VERSION = "0.1.559";


### PR DESCRIPTION
## Summary
- bump `veryfront` from 0.1.558 to 0.1.559
- keep `src/utils/version-constant.ts` in sync with `deno.json`

## Why
veryfront-code#1768 merged the runtime forwardedProps budget fix, but `deno.json` was still 0.1.558. The main release workflow skips publishing when an npm version already exists, so a new package version is required for downstream staging runtime deploys to actually pick up the fix.

Refs veryfront/veryfront-studio#3983 and follows veryfront-code#1768.

## Verification
- `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/utils/version.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno check src/utils/version.ts src/utils/version-constant.ts`
- `git diff --check`
