### PR TITLE
Help users choose the right Veryfront primitive

### DIFF
--- a/docs/guides/choose-a-primitive.md
+++ b/docs/guides/choose-a-primitive.md
@@ -1,0 +1,82 @@
+---
+title: "Choose a primitive"
+description: "Pick the right Veryfront primitive before you write code."
+order: 34
+---
+
+# Choose a primitive
+
+Pick the smallest Veryfront primitive that matches the job. This keeps project
+structure clear and avoids turning agents, workflows, jobs, and integrations
+into overlapping abstractions.
+
+## Quick choice
+
+| If you need to...                                           | Use                    | Start with                        |
+| ----------------------------------------------------------- | ---------------------- | --------------------------------- |
+| Answer users with model reasoning, tools, memory, or skills | Agent                  | [Agents](./agents.md)             |
+| Give an agent one typed capability                          | Tool                   | [Tools](./tools.md)               |
+| Coordinate multiple steps, branches, approvals, or retries  | Workflow               | [Workflows](./workflows.md)       |
+| Run durable background work now or on a schedule            | Job or cron job        | [Jobs](./jobs.md)                 |
+| Define project-owned background work                        | Task                   | [Tasks](./tasks.md)               |
+| Connect agents to third-party services                      | Integration with OAuth | [Integrations](./integrations.md) |
+| Expose project capabilities to assistants over a protocol   | MCP server             | [MCP server](./mcp-server.md)     |
+| Run isolated commands or file operations                    | Sandbox                | [Sandbox](./sandbox.md)           |
+| Add reusable runtime capabilities                           | Extension              | [Extensions](./extensions.md)     |
+
+## Decision rules
+
+| Primitive   | Use this when                                                                 | Do not use this when                                                          |
+| ----------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Agent       | The model must decide, explain, call tools, use memory, or stream a response. | The work is deterministic and can be a function, task, or workflow step.      |
+| Tool        | An agent needs a typed operation such as search, lookup, write, or transform. | The operation has multiple long-running states or human approval steps.       |
+| Workflow    | Work has ordered steps, parallel branches, retries, or human review.          | A single agent response or one background function is enough.                 |
+| Task        | You own a reusable background function in `tasks/`.                           | The user needs conversational reasoning or streaming output.                  |
+| Job         | You need durable execution, scheduling, batch status, or run history.         | The work can finish inside a request without durability.                      |
+| Integration | You need provider metadata, OAuth, tokens, or remote integration tools.       | A local custom API call is enough and no shared connector behavior is needed. |
+| MCP server  | External assistants or MCP clients need tools, prompts, or resources.         | The capability is only used inside one Veryfront app route.                   |
+| Sandbox     | Code or shell work needs isolation from the app process.                      | The code can run safely in your own trusted runtime.                          |
+| Extension   | A capability should be packaged and reused across projects.                   | The code belongs to one app and can stay local.                               |
+
+## Common pairings
+
+| Goal                                   | Typical shape                                      |
+| -------------------------------------- | -------------------------------------------------- |
+| Chat with company data                 | Agent + tools + memory + chat UI                   |
+| Human-approved content pipeline        | Workflow + agents + approval step                  |
+| Nightly sync from an external API      | Task + cron job + optional integration credentials |
+| User-authorized GitHub automation      | Integration + OAuth + tools                        |
+| Assistant-accessible project commands  | MCP server + tools                                 |
+| Isolated repo inspection or code edits | Agent + sandbox + tools                            |
+| Reusable Redis cache support           | Extension + CacheStore contract                    |
+
+## Verify it worked
+
+Before building, write down the primitive you chose and one sentence explaining
+why. Then check the matching guide:
+
+- If the guide's first example solves your shape, continue there.
+- If you need two or more primitives, start with the primitive that owns the
+  triggering event.
+- If you are choosing between `Task` and `Job`, remember that a task defines
+  the work and a job runs it durably.
+
+Run the relevant guide example or validation command before adding more
+primitives.
+
+## Next
+
+- [Quickstart](./quickstart.md): create a project
+- [Agents](./agents.md): define an agent
+- [Workflows](./workflows.md): orchestrate multi-step work
+- [Jobs](./jobs.md): run durable background work
+
+## Related
+
+- [`veryfront/agent`](../reference/veryfront/agent.md): agent API reference
+- [`veryfront/tool`](../reference/veryfront/tool.md): tool API reference
+- [`veryfront/workflow`](../reference/veryfront/workflow.md): workflow API reference
+- [`veryfront/jobs`](../reference/veryfront/jobs.md): jobs API reference
+- [`veryfront/integrations`](../reference/veryfront/integrations.md): integrations API reference
+- [`veryfront/mcp`](../reference/veryfront/mcp.md): MCP API reference
+- [`veryfront/sandbox`](../reference/veryfront/sandbox.md): sandbox API reference

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -15,11 +15,12 @@ matches your goal.
 
 ## Get started
 
-| Guide                                       | What you will do                                                              |
-| ------------------------------------------- | ----------------------------------------------------------------------------- |
-| [Quickstart](./quickstart.md)               | Install Veryfront, create a project, and run the dev server.                  |
-| [Project structure](./project-structure.md) | Learn the file conventions and how auto-discovery wires your project up.      |
-| [Configuration](./configuration.md)         | Configure `veryfront.config.ts`, environment variables, and runtime settings. |
+| Guide                                         | What you will do                                                              |
+| --------------------------------------------- | ----------------------------------------------------------------------------- |
+| [Quickstart](./quickstart.md)                 | Install Veryfront, create a project, and run the dev server.                  |
+| [Choose a primitive](./choose-a-primitive.md) | Pick the smallest Veryfront primitive that matches the work.                  |
+| [Project structure](./project-structure.md)   | Learn the file conventions and how auto-discovery wires your project up.      |
+| [Configuration](./configuration.md)           | Configure `veryfront.config.ts`, environment variables, and runtime settings. |
 
 ## Build pages and APIs
 

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -39,6 +39,18 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     references: ["../reference/veryfront/cli.md"],
     snippets: ["knowledge_ingest", "jq '.ingested'", "veryfront knowledge ingest"],
   },
+  "choose-a-primitive.md": {
+    references: [
+      "../reference/veryfront/agent.md",
+      "../reference/veryfront/tool.md",
+      "../reference/veryfront/workflow.md",
+      "../reference/veryfront/jobs.md",
+      "../reference/veryfront/integrations.md",
+      "../reference/veryfront/mcp.md",
+      "../reference/veryfront/sandbox.md",
+    ],
+    snippets: ["Agent", "Tool", "Workflow", "Task", "Job", "Integration", "MCP", "Sandbox"],
+  },
   "configuration.md": {
     references: ["../reference/veryfront/index.md"],
     snippets: ["defineConfig", "VERYFRONT_API_TOKEN", "getEnv"],
@@ -81,7 +93,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
   },
   "index.md": {
     references: [],
-    snippets: ["Quickstart", "Build pages and APIs", "Ship to production"],
+    snippets: ["Quickstart", "Choose a primitive", "Build pages and APIs", "Ship to production"],
   },
   "integrations.md": {
     references: ["../reference/veryfront/integrations.md"],


### PR DESCRIPTION
## Summary
- Add a compact `Choose a primitive` guide for deciding between Agent, Tool, Workflow, Task, Job, Integration, MCP server, Sandbox, and Extension.
- Link it from the guide index get-started path.
- Add a guide contract so the new guide and index link stay covered by `docs:validate`.

## Anti-bloat notes
- New guide is 82 lines and table-driven.
- Did not renumber all guide orders; used `order: 34` to avoid broad churn while surfacing the guide from `docs/guides/index.md`.
- No API catalog duplication; guide links to generated reference pages.

## Verification
- `deno test --no-check --allow-read tests/docs/guide-contracts.test.ts`
- `deno task docs:validate`
- `deno fmt --check docs/guides/choose-a-primitive.md docs/guides/index.md tests/docs/guide-contracts.test.ts`
- `git diff --check`
- Pre-push hook: format, lint, typecheck, and unit tests passed (`1900 passed`, `17543 steps`, `0 failed`).