### PR TITLE
Connect docs from first project to production

### DIFF
--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -112,9 +112,11 @@ After `veryfront build`:
 
 After `veryfront deploy`:
 
-- The CLI prints a production URL such as
-  `https://<slug>.production.veryfront.com`.
-- Open the URL and confirm the home page and any API routes respond.
+- The CLI confirms the deployed release and environment.
+- Run `veryfront open` to open the deployed project in a browser.
+- Use `veryfront open --json` when you need the deployed URL in terminal
+  output or automation.
+- Confirm the home page and any API routes respond on the deployed host.
 - The Cloud dashboard lists the new deployment under the project.
 
 ## Next

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -19,6 +19,7 @@ matches your goal.
 | --------------------------------------------- | ----------------------------------------------------------------------------- |
 | [Quickstart](./quickstart.md)                 | Install Veryfront, create a project, and run the dev server.                  |
 | [Choose a primitive](./choose-a-primitive.md) | Pick the smallest Veryfront primitive that matches the work.                  |
+| [Production path](./production-path.md)       | Build one route from local project to production verification.                |
 | [Project structure](./project-structure.md)   | Learn the file conventions and how auto-discovery wires your project up.      |
 | [Configuration](./configuration.md)           | Configure `veryfront.config.ts`, environment variables, and runtime settings. |
 
@@ -85,4 +86,5 @@ matches your goal.
 
 | Guide                                    | What you will do                                                |
 | ---------------------------------------- | --------------------------------------------------------------- |
+| [Production path](./production-path.md)  | Follow the shortest route from dev server to production checks. |
 | [Building and deploying](./deploying.md) | Build for production, configure static export, and pick a host. |

--- a/docs/guides/production-path.md
+++ b/docs/guides/production-path.md
@@ -104,11 +104,13 @@ Use the same checks at each stage:
 | ------------------- | --------------------------------------------------------------------------------- |
 | Dev                 | `veryfront dev` prints a local URL and the route responds.                        |
 | Local production    | `veryfront build` exits successfully and `veryfront start` serves the same route. |
-| Deployed production | `veryfront deploy` prints a URL and the deployed route responds.                  |
+| Deployed production | `veryfront deploy` completes, then `veryfront open` opens the deployed route.     |
 
 For API routes, compare the dev and production responses with `curl`. For pages,
-open the same path in both environments. For agents, workflows, tasks, jobs, or
-integrations, trigger one minimal run and confirm the expected output or status.
+open the same path in both environments. Use `veryfront open --json` when you
+need the deployed URL for scripts or a terminal-only check. For agents,
+workflows, tasks, jobs, or integrations, trigger one minimal run and confirm the
+expected output or status.
 
 ## Next
 

--- a/docs/guides/production-path.md
+++ b/docs/guides/production-path.md
@@ -1,0 +1,124 @@
+---
+title: "Production path"
+description: "Build one Veryfront route from local project to production verification."
+order: 35
+---
+
+# Production path
+
+Build one Veryfront route from local project to production verification.
+
+Use this guide when you want the shortest complete path through the docs:
+create a project, choose the right primitive, add one user-visible surface, then
+prove the same app works in production.
+
+## Prerequisites
+
+- Node.js 18 or later.
+- A terminal that can run the Veryfront CLI.
+- Production credentials for any provider, integration, or deployment target
+  your project uses.
+
+## Path overview
+
+| Step | Goal                                            | Guide                                                                                        |
+| ---- | ----------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| 1    | Create and run a local app.                     | [Quickstart](./quickstart.md)                                                                |
+| 2    | Pick the smallest primitive for the work.       | [Choose a primitive](./choose-a-primitive.md)                                                |
+| 3    | Add the user-visible route or API boundary.     | [Pages and routing](./pages-and-routing.md), [API routes](./api-routes.md)                   |
+| 4    | Add the primitive only when the route needs it. | [Agents](./agents.md), [Tools](./tools.md), [Workflows](./workflows.md), [Tasks](./tasks.md) |
+| 5    | Build, run, and deploy the production app.      | [Building and deploying](./deploying.md)                                                     |
+
+## Create the project
+
+Start from a template that matches the product shape you want to test.
+
+```bash
+veryfront init production-path --template minimal
+cd production-path
+veryfront dev
+```
+
+Open `http://localhost:3000` and keep the dev server running while you add the
+first route.
+
+## Choose the primitive
+
+Before adding an agent, workflow, job, or integration, check the smallest
+matching primitive:
+
+| Need                             | Start with             |
+| -------------------------------- | ---------------------- |
+| Render UI or content             | Page                   |
+| Return HTTP data                 | API route              |
+| Let a model use typed capability | Tool                   |
+| Run a conversational model       | Agent                  |
+| Coordinate multiple steps        | Workflow               |
+| Run background or scheduled work | Task, job, or cron job |
+
+Use [Choose a primitive](./choose-a-primitive.md) when more than one option
+looks valid. Add only the primitive that the route needs now.
+
+## Add one route boundary
+
+Pick one boundary and make it observable in both dev and production.
+
+| Boundary                 | Add                                          | Verify locally                                |
+| ------------------------ | -------------------------------------------- | --------------------------------------------- |
+| Page                     | `app/page.tsx` or another route under `app/` | Open the route in the browser.                |
+| API route                | `app/api/<name>/route.ts`                    | Run `curl http://localhost:3000/api/<name>`.  |
+| Agent chat               | Page plus `app/api/ag-ui/route.ts`           | Send one message and confirm streamed output. |
+| Workflow or task trigger | API route or CLI command                     | Trigger one run and inspect the result.       |
+
+Keep the first production path narrow. Once this path is proven, add more pages,
+agents, integrations, or jobs behind the same verification loop.
+
+## Build and run production locally
+
+Stop the dev server, then run the production build locally:
+
+```bash
+veryfront build
+veryfront start
+```
+
+Open `http://localhost:3000` again and test the same route or API endpoint you
+tested in dev.
+
+## Deploy
+
+Deploy after the local production server matches the dev behavior:
+
+```bash
+veryfront deploy
+```
+
+For a non-Cloud target, use the build output from `veryfront build` and follow
+the target host's runtime requirements.
+
+## Verify it worked
+
+Use the same checks at each stage:
+
+| Stage               | Check                                                                             |
+| ------------------- | --------------------------------------------------------------------------------- |
+| Dev                 | `veryfront dev` prints a local URL and the route responds.                        |
+| Local production    | `veryfront build` exits successfully and `veryfront start` serves the same route. |
+| Deployed production | `veryfront deploy` prints a URL and the deployed route responds.                  |
+
+For API routes, compare the dev and production responses with `curl`. For pages,
+open the same path in both environments. For agents, workflows, tasks, jobs, or
+integrations, trigger one minimal run and confirm the expected output or status.
+
+## Next
+
+- [Building and deploying](./deploying.md): configure production builds and deployment targets
+- [Configuration](./configuration.md): set runtime and build options
+- [Head and SEO](./head-and-seo.md): prepare public pages for search and previews
+
+## Related
+
+- [`veryfront` root reference](../reference/veryfront/index.md): config and runtime exports
+- [Project structure](./project-structure.md): file conventions and auto-discovery
+- [Pages and routing](./pages-and-routing.md): route files, layouts, and navigation
+- [API routes](./api-routes.md): HTTP handlers and streaming responses

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -81,6 +81,7 @@ const THIS_GUIDE_EXAMPLE_SUITE = [
   "head-and-seo.md",
   "integrations.md",
   "pages-and-routing.md",
+  "production-path.md",
   "project-structure.md",
   "quickstart.md",
   "sandbox.md",
@@ -428,6 +429,24 @@ describe("Guide: pages-and-routing.md", () => {
 
     assertEquals(link.type, Link);
     assertEquals(router.type, RouterProvider);
+  });
+});
+
+describe("Guide: production-path.md", () => {
+  it("keeps the production path command sequence aligned with the CLI guides", async () => {
+    const guide = await readGuide("production-path.md");
+
+    for (
+      const command of [
+        "veryfront init",
+        "veryfront dev",
+        "veryfront build",
+        "veryfront start",
+        "veryfront deploy",
+      ]
+    ) {
+      assertStringIncludes(guide, command);
+    }
   });
 });
 

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -443,6 +443,7 @@ describe("Guide: production-path.md", () => {
         "veryfront build",
         "veryfront start",
         "veryfront deploy",
+        "veryfront open",
       ]
     ) {
       assertStringIncludes(guide, command);

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -17,4 +17,14 @@ describe("guide content contracts", () => {
     assertStringIncludes(guide, "tokenStore.getTokens(githubConfig.serviceId, userId)");
     assertEquals(guide.includes("tokenStore.get(userId, githubConfig.id)"), false);
   });
+
+  it("does not claim deploy prints the production URL", async () => {
+    for (const filename of ["deploying.md", "production-path.md"]) {
+      const guide = await Deno.readTextFile(`docs/guides/${filename}`);
+
+      assertEquals(guide.includes("deploy` prints a URL"), false);
+      assertEquals(guide.includes("CLI prints a production URL"), false);
+      assertStringIncludes(guide, "veryfront open");
+    }
+  });
 });

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -66,6 +66,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "veryfront build",
       "veryfront start",
       "veryfront deploy",
+      "veryfront open",
       "production path",
     ],
   },
@@ -79,7 +80,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
   },
   "deploying.md": {
     references: ["../reference/veryfront/index.md"],
-    snippets: ["veryfront build", "veryfront start", "veryfront deploy"],
+    snippets: ["veryfront build", "veryfront start", "veryfront deploy", "veryfront open"],
   },
   "extension-authoring.md": {
     references: ["../reference/veryfront/extensions.md"],

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -51,6 +51,24 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     ],
     snippets: ["Agent", "Tool", "Workflow", "Task", "Job", "Integration", "MCP", "Sandbox"],
   },
+  "production-path.md": {
+    references: [
+      "./quickstart.md",
+      "./choose-a-primitive.md",
+      "./pages-and-routing.md",
+      "./api-routes.md",
+      "./deploying.md",
+      "../reference/veryfront/index.md",
+    ],
+    snippets: [
+      "veryfront init",
+      "veryfront dev",
+      "veryfront build",
+      "veryfront start",
+      "veryfront deploy",
+      "production path",
+    ],
+  },
   "configuration.md": {
     references: ["../reference/veryfront/index.md"],
     snippets: ["defineConfig", "VERYFRONT_API_TOKEN", "getEnv"],
@@ -93,7 +111,13 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
   },
   "index.md": {
     references: [],
-    snippets: ["Quickstart", "Choose a primitive", "Build pages and APIs", "Ship to production"],
+    snippets: [
+      "Quickstart",
+      "Choose a primitive",
+      "Production path",
+      "Build pages and APIs",
+      "Ship to production",
+    ],
   },
   "integrations.md": {
     references: ["../reference/veryfront/integrations.md"],


### PR DESCRIPTION
## Summary
- Add a compact `Production path` guide that links quickstart, primitive selection, route/API boundaries, local production, and deployment verification.
- Surface the guide from both the get-started and ship-to-production sections of the guide index.
- Add guide contract and code-example coverage for the new guide.

## Anti-bloat notes
- The new guide is 124 lines and table-driven.
- It links to focused guides and generated reference pages instead of duplicating API details.
- It keeps this benchmark improvement to one journey guide plus tests.

## Verification
- `deno test --no-check --allow-read tests/docs/guide-contracts.test.ts` failed first for the missing guide/index link as expected.
- `deno test --no-check --allow-read --allow-env tests/docs/guide-contracts.test.ts tests/docs/guide-code-examples.test.ts`
- `deno task docs:validate`
- `deno fmt --check docs/guides/production-path.md docs/guides/index.md tests/docs/guide-contracts.test.ts tests/docs/guide-code-examples.test.ts`
- `git diff --check`
- Pre-push hook: format, lint, typecheck, and unit tests passed (`1900 passed`, `17543 steps`, `0 failed`).