### PR TITLE
Close docs cross-link coverage gaps

### DIFF
--- a/docs/guides/agent-service-runtime.md
+++ b/docs/guides/agent-service-runtime.md
@@ -199,3 +199,4 @@ service list after the first heartbeat
 
 - [Agent service runtime reference](../reference/veryfront/agent.md): complete service runtime API reference
 - [`veryfront/agent`](../reference/veryfront/agent.md): agent API reference
+- [`veryfront/channels`](../reference/veryfront/channels.md): control-plane and invoke channel contracts

--- a/docs/guides/chat-ui.md
+++ b/docs/guides/chat-ui.md
@@ -127,3 +127,4 @@ agent errors and confirm the AG-UI route is mounted at `/api/ag-ui`.
 
 - [`veryfront/chat`](../reference/veryfront/chat.md): chat reference
 - [`veryfront/agent`](../reference/veryfront/agent.md): agent API reference
+- [`veryfront/markdown`](../reference/veryfront/markdown.md): markdown rendering helpers

--- a/docs/guides/choose-a-primitive.md
+++ b/docs/guides/choose-a-primitive.md
@@ -80,3 +80,4 @@ primitives.
 - [`veryfront/integrations`](../reference/veryfront/integrations.md): integrations API reference
 - [`veryfront/mcp`](../reference/veryfront/mcp.md): MCP API reference
 - [`veryfront/sandbox`](../reference/veryfront/sandbox.md): sandbox API reference
+- [`veryfront/extensions`](../reference/veryfront/extensions.md): extension API reference

--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -127,3 +127,6 @@ After `veryfront deploy`:
 ## Related
 
 - [`veryfront` (root)](../reference/veryfront/index.md): `defineConfig`, build options
+- [`veryfront/server`](../reference/veryfront/server.md): production server APIs
+- [`veryfront/observability`](../reference/veryfront/observability.md): tracing, metrics, and runtime logs
+- [`veryfront/utils`](../reference/veryfront/utils.md): runtime constants and logging helpers

--- a/docs/guides/pages-and-routing.md
+++ b/docs/guides/pages-and-routing.md
@@ -223,3 +223,4 @@ to confirm the React component renders without console errors.
 
 - [`veryfront/router`](../reference/veryfront/router.md): router API reference
 - [`veryfront/context`](../reference/veryfront/context.md): params, page data, and frontmatter hooks
+- [`veryfront/mdx`](../reference/veryfront/mdx.md): MDX component overrides

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -185,3 +185,4 @@ whether the call used cloud, server-local, or browser inference.
 ## Related
 
 - [`veryfront/provider`](../reference/veryfront/provider.md): provider API reference
+- [`veryfront/embedding`](../reference/veryfront/embedding.md): embedding model configuration

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -159,3 +159,4 @@ id and close it manually.
 ## Related
 
 - [`veryfront/sandbox`](../reference/veryfront/sandbox.md): sandbox API reference
+- [`veryfront/fs`](../reference/veryfront/fs.md): filesystem helpers used with isolated workspaces

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -161,3 +161,4 @@ veryfront skills validate skills/my-skill
 ## Related
 
 - [agentskills.io specification](https://agentskills.io)
+- [`veryfront/agent`](../reference/veryfront/agent.md): agent API reference

--- a/docs/guides/tasks.md
+++ b/docs/guides/tasks.md
@@ -148,3 +148,4 @@ a `succeeded` status. See the verification block in
 ## Related
 
 - [Jobs and cron jobs](./jobs.md): the jobs system that executes scheduled tasks
+- [`veryfront/jobs`](../reference/veryfront/jobs.md): jobs API reference

--- a/docs/reference/veryfront/agent.md
+++ b/docs/reference/veryfront/agent.md
@@ -1950,6 +1950,7 @@ User guides:
 - [multi-agent](../../guides/multi-agent.md): Compose multi-agent systems
 - [memory-and-streaming](../../guides/memory-and-streaming.md): Memory, streaming, and lifecycle
 - [agent-service-runtime](../../guides/agent-service-runtime.md): Deploy agents as standalone services
+- [skills](../../guides/skills.md): Attach project skills to agents
 
 Architecture:
 

--- a/docs/reference/veryfront/index.md
+++ b/docs/reference/veryfront/index.md
@@ -121,6 +121,10 @@ Reference modules:
 
 User guides:
 
+- [index](../../guides/index.md): Browse the guide map
+- [quickstart](../../guides/quickstart.md): Create and run a project
+- [choose-a-primitive](../../guides/choose-a-primitive.md): Choose the right primitive
+- [production-path](../../guides/production-path.md): Move a route toward production checks
 - [configuration](../../guides/configuration.md): Configure your Veryfront project
 - [project-structure](../../guides/project-structure.md): Project layout and conventions
 - [data-fetching](../../guides/data-fetching.md): Server data, static data, params

--- a/docs/reference/veryfront/jobs.md
+++ b/docs/reference/veryfront/jobs.md
@@ -133,6 +133,7 @@ const events = await jobs.events(job.id);
 User guides:
 
 - [jobs](../../guides/jobs.md): Schedule and run background jobs
+- [tasks](../../guides/tasks.md): Define task targets for jobs
 
 Architecture:
 

--- a/scripts/docs/docs-coverage.test.ts
+++ b/scripts/docs/docs-coverage.test.ts
@@ -22,6 +22,8 @@ Deno.test("collectDocsCoverage reports generated reference and guide coverage", 
   );
   assertEquals(report.referencePages.missing, []);
   assertEquals(report.referencePages.extra, []);
+  assertEquals(report.links.referenceModulesMissingGuideLinks, []);
+  assertEquals(report.links.guidesMissingReferenceLinks, []);
   assertEquals(report.guides.withContracts, report.guides.total);
   assertEquals(
     report.guides.withCodeExampleTests,

--- a/scripts/docs/generate-api-reference.ts
+++ b/scripts/docs/generate-api-reference.ts
@@ -347,6 +347,10 @@ const RELATED_MODULES: Record<string, Array<{ path: string; reason: string }>> =
 
 const RELATED_GUIDES: Record<string, Array<{ path: string; reason: string }>> = {
   "veryfront": [
+    { path: "index", reason: "Browse the guide map" },
+    { path: "quickstart", reason: "Create and run a project" },
+    { path: "choose-a-primitive", reason: "Choose the right primitive" },
+    { path: "production-path", reason: "Move a route toward production checks" },
     { path: "configuration", reason: "Configure your Veryfront project" },
     { path: "project-structure", reason: "Project layout and conventions" },
     { path: "data-fetching", reason: "Server data, static data, params" },
@@ -380,6 +384,7 @@ const RELATED_GUIDES: Record<string, Array<{ path: string; reason: string }>> = 
     { path: "multi-agent", reason: "Compose multi-agent systems" },
     { path: "memory-and-streaming", reason: "Memory, streaming, and lifecycle" },
     { path: "agent-service-runtime", reason: "Deploy agents as standalone services" },
+    { path: "skills", reason: "Attach project skills to agents" },
   ],
   "veryfront/tool": [
     { path: "tools", reason: "Define and call tools" },
@@ -396,6 +401,7 @@ const RELATED_GUIDES: Record<string, Array<{ path: string; reason: string }>> = 
   ],
   "veryfront/jobs": [
     { path: "jobs", reason: "Schedule and run background jobs" },
+    { path: "tasks", reason: "Define task targets for jobs" },
   ],
   "veryfront/mcp": [
     { path: "mcp-server", reason: "Build and host MCP servers" },

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -8,7 +8,7 @@ interface GuideContract {
 
 const GUIDE_CONTRACTS: Record<string, GuideContract> = {
   "agent-service-runtime.md": {
-    references: ["../reference/veryfront/agent.md"],
+    references: ["../reference/veryfront/agent.md", "../reference/veryfront/channels.md"],
     snippets: ["startAgentService", "VERYFRONT_AGENT_SERVICE_URL", "/api/runs"],
   },
   "agents.md": {
@@ -32,7 +32,11 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     snippets: ["theme", "attachments", "Context providers"],
   },
   "chat-ui.md": {
-    references: ["../reference/veryfront/chat.md", "../reference/veryfront/agent.md"],
+    references: [
+      "../reference/veryfront/chat.md",
+      "../reference/veryfront/agent.md",
+      "../reference/veryfront/markdown.md",
+    ],
     snippets: ["Chat", "useChat", "createAgUiHandler"],
   },
   "cli-knowledge-ingestion.md": {
@@ -48,6 +52,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "../reference/veryfront/integrations.md",
       "../reference/veryfront/mcp.md",
       "../reference/veryfront/sandbox.md",
+      "../reference/veryfront/extensions.md",
     ],
     snippets: ["Agent", "Tool", "Workflow", "Task", "Job", "Integration", "MCP", "Sandbox"],
   },
@@ -79,7 +84,12 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     snippets: ["getServerData", "getStaticData", "redirect"],
   },
   "deploying.md": {
-    references: ["../reference/veryfront/index.md"],
+    references: [
+      "../reference/veryfront/index.md",
+      "../reference/veryfront/server.md",
+      "../reference/veryfront/observability.md",
+      "../reference/veryfront/utils.md",
+    ],
     snippets: ["veryfront build", "veryfront start", "veryfront deploy", "veryfront open"],
   },
   "extension-authoring.md": {
@@ -154,7 +164,11 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     snippets: ["createOAuthInitHandler", "getTokens", "OAuthService"],
   },
   "pages-and-routing.md": {
-    references: ["../reference/veryfront/router.md", "../reference/veryfront/context.md"],
+    references: [
+      "../reference/veryfront/router.md",
+      "../reference/veryfront/context.md",
+      "../reference/veryfront/mdx.md",
+    ],
     snippets: ["app router", "useRouter", "Link"],
   },
   "project-structure.md": {
@@ -162,7 +176,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     snippets: ["app/", "agents/", "tools/"],
   },
   "providers.md": {
-    references: ["../reference/veryfront/provider.md"],
+    references: ["../reference/veryfront/provider.md", "../reference/veryfront/embedding.md"],
     snippets: ["provider/model", "OPENAI_API_KEY", "registerModelProvider"],
   },
   "quickstart.md": {
@@ -170,15 +184,15 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     snippets: ["veryfront init", "veryfront dev", "veryfront build"],
   },
   "sandbox.md": {
-    references: ["../reference/veryfront/sandbox.md"],
+    references: ["../reference/veryfront/sandbox.md", "../reference/veryfront/fs.md"],
     snippets: ["Sandbox.create", "executeCommand", "sandbox.close"],
   },
   "skills.md": {
-    references: [],
+    references: ["../reference/veryfront/agent.md"],
     snippets: ["SKILL.md", "allowed_tools", "veryfront skills validate"],
   },
   "tasks.md": {
-    references: [],
+    references: ["../reference/veryfront/jobs.md"],
     snippets: ["veryfront task sync-data", "schedulable", "VeryfrontJobsClient"],
   },
   "tools.md": {


### PR DESCRIPTION
## Summary
- add missing guide-side links for public reference modules reported by docs coverage
- add generator-owned reverse links for guide pages that were missing from generated references
- enforce zero cross-link gaps in docs coverage tests

## Verification
- deno task docs
- deno task docs:coverage (reference modules linked from guides: 29/29; guides linked from reference pages: 36/36)
- deno task docs:validate
- deno task test:scripts
- git diff --check
- pre-push hook: format, lint, typecheck, unit tests (1900 passed)