### PR TITLE
Recommend current Node.js LTS in docs

### DIFF
--- a/cli/commands/doctor/version-checks.test.ts
+++ b/cli/commands/doctor/version-checks.test.ts
@@ -39,7 +39,7 @@ describe("doctor/version-checks", () => {
       const result = await checkDenoVersion();
 
       // In test environment (Deno 2.x), should pass
-      // If running in Node.js 18+, should also pass
+      // If running in a supported Node.js runtime, should also pass
       assertEquals(["pass", "warn"].includes(result.status), true);
     });
   });

--- a/cli/commands/doctor/version-checks.ts
+++ b/cli/commands/doctor/version-checks.ts
@@ -28,7 +28,9 @@ export function checkDenoVersion(): Promise<DiagnosticResult> {
       const versionNum = runtimeVersion.replace("Node.js v", "");
       const major = parseInt(versionNum.split(".")[0] ?? "0", 10);
       const isSupported = major >= 18;
-      const message = isSupported ? runtimeVersion : `${runtimeVersion} (recommended: Node.js 18+)`;
+      const message = isSupported
+        ? runtimeVersion
+        : `${runtimeVersion} (recommended: current Node.js LTS)`;
 
       return Promise.resolve(
         createRuntimeResult(isSupported ? "pass" : "warn", message),

--- a/cli/templates/features/mdx/files/app/docs/getting-started/page.mdx
+++ b/cli/templates/features/mdx/files/app/docs/getting-started/page.mdx
@@ -6,7 +6,7 @@ This guide will help you get up and running with your new project.
 
 ## Prerequisites
 
-- Node.js 18+
+- The current Node.js LTS
 - npm or yarn
 
 ## Installation

--- a/docs/guides/production-path.md
+++ b/docs/guides/production-path.md
@@ -14,7 +14,7 @@ prove the same app works in production.
 
 ## Prerequisites
 
-- Node.js 18 or later.
+- The current Node.js LTS.
 - A terminal that can run the Veryfront CLI.
 - Production credentials for any provider, integration, or deployment target
   your project uses.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -13,7 +13,7 @@ The npm package, CLI, and import name remain `veryfront`.
 
 ## Prerequisites
 
-- Node.js 18 or later, with `npm`, `pnpm`, or `yarn` on your PATH.
+- The current Node.js LTS, with `npm`, `pnpm`, or `yarn` on your PATH.
 - A terminal in which you can run global `npm install` (use `npx veryfront` if
   global installs aren't possible).
 

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -27,4 +27,20 @@ describe("guide content contracts", () => {
       assertStringIncludes(guide, "veryfront open");
     }
   });
+
+  it("recommends the current Node.js LTS in onboarding docs", async () => {
+    const docs = [
+      "docs/guides/quickstart.md",
+      "docs/guides/production-path.md",
+      "cli/templates/features/mdx/files/app/docs/getting-started/page.mdx",
+    ];
+
+    for (const path of docs) {
+      const text = await Deno.readTextFile(path);
+
+      assertStringIncludes(text, "current Node.js LTS");
+      assertEquals(text.includes("Node.js 18"), false);
+      assertEquals(text.includes("Node.js 18+"), false);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- replace Node.js 18 onboarding prerequisites with current Node.js LTS wording
- update the MDX starter template prerequisite to match
- update the doctor fallback recommendation away from Node.js 18+
- add a guide content contract so onboarding docs do not reintroduce Node.js 18 copy

## Verification
- deno test --no-check --allow-read tests/docs/guide-content.test.ts
- deno task docs:validate
- deno test --no-check --allow-all cli/commands/doctor/version-checks.test.ts
- deno task generate:manifests:check
- DENO_NO_PACKAGE_JSON=1 deno lint cli/commands/doctor/version-checks.ts cli/commands/doctor/version-checks.test.ts tests/docs/guide-content.test.ts
- deno check cli/commands/doctor/version-checks.ts
- git diff --check
- pre-push hook: format, lint, typecheck, unit tests (1900 passed)