### PR TITLE
Link all generated API declarations to source

### DIFF
--- a/docs/reference/veryfront/agent.md
+++ b/docs/reference/veryfront/agent.md
@@ -129,29 +129,29 @@ const orchestrator = agent({
 
 Agent helper.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `id?` | `string` | Unique identifier (auto-generated if omitted) |
-| `name?` | `string` | Human-readable display name for registry and control-plane listings. |
-| `description?` | `string` | Optional summary shown in registry and control-plane listings. |
-| `model?` | `ModelString` | Optional model string in "provider/model" format. |
-| `system` | <code>string &#124; (() =&gt; string) &#124; (() =&gt; Promise&lt;string&gt;)</code> | System prompt: string, function, or async function |
-| `tools?` | <code>true &#124; Record&lt;string, Tool &#124; boolean&gt;</code> | Tools available to the agent |
-| `remoteTools?` | `RemoteToolSource[]` |  |
-| `allowedRemoteTools?` | `string[]` | Optional remote tool name allowlist. When set, only matching tools from `remoteTools` are exposed to the model and executable at runtime. |
-| `maxSteps?` | `number` | Max tool-call iterations per request |
-| `streaming?` | `boolean` | Enable streaming responses |
-| `memory?` | `MemoryConfig` | Conversation memory settings |
-| `middleware?` | `AgentMiddleware[]` | Execution middleware pipeline |
-| `edge?` | `EdgeConfig` | Edge runtime configuration |
-| `multimodal?` | <code>&#123; vision?: boolean; audio?: boolean &#125;</code> | Enable vision and/or audio |
-| `allowedModels?` | `ModelString[]` | Restrict runtime model overrides to these "provider/model" strings. |
-| `resolveModelTransport?` | `ModelTransportResolver` | Optional request-aware hook for overriding the resolved model runtime and provider transport options on a per-call basis. |
-| `resolveRuntimeState?` | `RuntimeStateResolver` | Optional step-boundary hook for refreshing the runtime system prompt and host-owned context during a long-lived run. |
-| `onToolResult?` | `ToolExecutionResultHandler` | Optional hook invoked after the runtime executes a configured local, registry, integration, or remote tool and before the tool result is persisted or streamed back to callers. |
-| `skills?` | `true \| string[]` | Enable skills for this agent. |
-| `suggestions?` | `Suggestions` |  |
-| `security?` | `false` | Set to false to disable the default security middleware |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `id?` | `string` | Unique identifier (auto-generated if omitted) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L81) |
+| `name?` | `string` | Human-readable display name for registry and control-plane listings. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L83) |
+| `description?` | `string` | Optional summary shown in registry and control-plane listings. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L85) |
+| `model?` | `ModelString` | Optional model string in "provider/model" format. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L93) |
+| `system` | <code>string &#124; (() =&gt; string) &#124; (() =&gt; Promise&lt;string&gt;)</code> | System prompt: string, function, or async function | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L94) |
+| `tools?` | <code>true &#124; Record&lt;string, Tool &#124; boolean&gt;</code> | Tools available to the agent | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L95) |
+| `remoteTools?` | `RemoteToolSource[]` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L96) |
+| `allowedRemoteTools?` | `string[]` | Optional remote tool name allowlist. When set, only matching tools from `remoteTools` are exposed to the model and executable at runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L101) |
+| `maxSteps?` | `number` | Max tool-call iterations per request | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L102) |
+| `streaming?` | `boolean` | Enable streaming responses | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L103) |
+| `memory?` | `MemoryConfig` | Conversation memory settings | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L104) |
+| `middleware?` | `AgentMiddleware[]` | Execution middleware pipeline | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L105) |
+| `edge?` | `EdgeConfig` | Edge runtime configuration | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L106) |
+| `multimodal?` | <code>&#123; vision?: boolean; audio?: boolean &#125;</code> | Enable vision and/or audio | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L107) |
+| `allowedModels?` | `ModelString[]` | Restrict runtime model overrides to these "provider/model" strings. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L112) |
+| `resolveModelTransport?` | `ModelTransportResolver` | Optional request-aware hook for overriding the resolved model runtime and provider transport options on a per-call basis. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L117) |
+| `resolveRuntimeState?` | `RuntimeStateResolver` | Optional step-boundary hook for refreshing the runtime system prompt and host-owned context during a long-lived run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L122) |
+| `onToolResult?` | `ToolExecutionResultHandler` | Optional hook invoked after the runtime executes a configured local, registry, integration, or remote tool and before the tool result is persisted or streamed back to callers. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L128) |
+| `skills?` | `true \| string[]` | Enable skills for this agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L138) |
+| `suggestions?` | `Suggestions` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L139) |
+| `security?` | `false` | Set to false to disable the default security middleware | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L141) |
 
 **Returns:** `Agent`
 
@@ -159,12 +159,12 @@ Agent helper.
 
 Run the agent and return a complete response. Accepts a string or message array as input.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `input` | `string \| Message[]` | Prompt string or message history |
-| `context?` | <code>Record&lt;string, unknown&gt;</code> | Additional context passed to the agent |
-| `model?` | `ModelString` | Override the agent's default model for this request. Must be in `allowedModels` if configured. |
-| `maxOutputTokens?` | `number` | Override the maximum model output tokens for this request. |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `input` | `string \| Message[]` | Prompt string or message history | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L258) |
+| `context?` | <code>Record&lt;string, unknown&gt;</code> | Additional context passed to the agent | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L259) |
+| `model?` | `ModelString` | Override the agent's default model for this request. Must be in `allowedModels` if configured. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L261) |
+| `maxOutputTokens?` | `number` | Override the maximum model output tokens for this request. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L263) |
 
 **Returns:** <code>Promise&lt;AgentResponse&gt;</code>
 
@@ -172,17 +172,17 @@ Run the agent and return a complete response. Accepts a string or message array 
 
 Run the agent and stream the response. Returns a result with `.toDataStreamResponse()` for API routes.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `input?` | `string` | Prompt string |
-| `messages?` | `Message[]` | Conversation message history |
-| `context?` | <code>Record&lt;string, unknown&gt;</code> | Additional context passed to the agent |
-| `model?` | `ModelString` | Override the agent's default model for this request. Must be in `allowedModels` if configured. |
-| `maxOutputTokens?` | `number` | Override the maximum model output tokens for this request. |
-| `onToolCall?` | <code>(toolCall: ToolCall) =&gt; void</code> | Callback fired when a tool is invoked |
-| `onChunk?` | <code>(chunk: string) =&gt; void</code> | Callback fired for each text chunk |
-| `onFinish?` | <code>(response: AgentResponse) =&gt; void</code> |  |
-| `abortSignal?` | `AbortSignal` |  |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `input?` | `string` | Prompt string | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L267) |
+| `messages?` | `Message[]` | Conversation message history | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L268) |
+| `context?` | <code>Record&lt;string, unknown&gt;</code> | Additional context passed to the agent | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L269) |
+| `model?` | `ModelString` | Override the agent's default model for this request. Must be in `allowedModels` if configured. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L271) |
+| `maxOutputTokens?` | `number` | Override the maximum model output tokens for this request. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L273) |
+| `onToolCall?` | <code>(toolCall: ToolCall) =&gt; void</code> | Callback fired when a tool is invoked | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L274) |
+| `onChunk?` | <code>(chunk: string) =&gt; void</code> | Callback fired for each text chunk | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L275) |
+| `onFinish?` | <code>(response: AgentResponse) =&gt; void</code> |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L276) |
+| `abortSignal?` | `AbortSignal` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L277) |
 
 **Returns:** <code>Promise&lt;AgentStreamResult&gt;</code>
 

--- a/docs/reference/veryfront/chat.md
+++ b/docs/reference/veryfront/chat.md
@@ -76,78 +76,78 @@ import { Message } from "veryfront/chat";
 
 Options accepted by use chat.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `api` | `string` | Chat API endpoint URL |
-| `transport?` | `"ag-ui"` | Streaming response protocol used by the endpoint. AG-UI is the default. |
-| `initialMessages?` | `ChatMessage[]` | Pre-populated messages |
-| `body?` | <code>Record&lt;string, unknown&gt;</code> | Extra body fields sent with each request |
-| `headers?` | <code>Record&lt;string, string&gt;</code> | Custom request headers |
-| `credentials?` | `RequestCredentials` | Fetch credentials mode |
-| `model?` | `string` | Override model at runtime (e.g. "openai/gpt-4o", "Anthropic/claude-sonnet-4-5-20250929") |
-| `systemPrompt?` | `string` | System prompt for browser-side inference (server uses agent config) |
-| `browserFallback?` | `boolean` | Enable/disable browser fallback when server can't provide a runtime. Default: true |
-| `onResponse?` | <code>(response: Response) =&gt; void</code> | Raw response callback |
-| `onFinish?` | <code>(message: ChatMessage) =&gt; void</code> | Completion callback |
-| `onError?` | <code>(error: Error) =&gt; void</code> | Error callback |
-| `onToolCall?` | <code>(arg: OnToolCallArg) =&gt; void &#124; Promise&lt;void&gt;</code> | Tool call handler for client-side execution |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `api` | `string` | Chat API endpoint URL | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L59) |
+| `transport?` | `"ag-ui"` | Streaming response protocol used by the endpoint. AG-UI is the default. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L61) |
+| `initialMessages?` | `ChatMessage[]` | Pre-populated messages | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L62) |
+| `body?` | <code>Record&lt;string, unknown&gt;</code> | Extra body fields sent with each request | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L63) |
+| `headers?` | <code>Record&lt;string, string&gt;</code> | Custom request headers | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L64) |
+| `credentials?` | `RequestCredentials` | Fetch credentials mode | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L65) |
+| `model?` | `string` | Override model at runtime (e.g. "openai/gpt-4o", "Anthropic/claude-sonnet-4-5-20250929") | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L67) |
+| `systemPrompt?` | `string` | System prompt for browser-side inference (server uses agent config) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L69) |
+| `browserFallback?` | `boolean` | Enable/disable browser fallback when server can't provide a runtime. Default: true | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L71) |
+| `onResponse?` | <code>(response: Response) =&gt; void</code> | Raw response callback | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L72) |
+| `onFinish?` | <code>(message: ChatMessage) =&gt; void</code> | Completion callback | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L73) |
+| `onError?` | <code>(error: Error) =&gt; void</code> | Error callback | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L74) |
+| `onToolCall?` | <code>(arg: OnToolCallArg) =&gt; void &#124; Promise&lt;void&gt;</code> | Tool call handler for client-side execution | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L75) |
 
 ### `UseChatResult`
 
 Result returned from use chat.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `messages` | `ChatMessage[]` | All messages in the conversation |
-| `input` | `string` | Current input value |
-| `isLoading` | `boolean` | Whether a request is in flight |
-| `error` | `Error \| null` | Last error (if any) |
-| `model` | `string \| undefined` | Current model override (undefined = use agent default) |
-| `activeModel` | `string \| undefined` | The actual model being used after auto-upgrade (e.g. "Anthropic/claude-sonnet-4-20250514") |
-| `inferenceMode` | `InferenceMode` | Where inference is currently happening |
-| `browserStatus` | `BrowserInferenceStatus \| null` | Browser-side model loading/inference status (null when not using browser fallback) |
-| `setInput` | <code>(input: string) =&gt; void</code> | Set input value |
-| `setModel` | <code>(model: string &#124; undefined) =&gt; void</code> | Change the model for subsequent requests |
-| `sendMessage` | <code>(message: &#123; text: string &#125;) =&gt; Promise&lt;void&gt;</code> | Send a message programmatically |
-| `editMessage` | <code>(messageId: string, newText: string) =&gt; Promise&lt;void&gt;</code> | Edit a user message and resubmit - truncates history to that point |
-| `getBranches` | <code>(messageId: string) =&gt; BranchInfo</code> | Get branch info for a message (returns { current, total }; total=1 if no branches) |
-| `switchBranch` | <code>(messageId: string, branchIndex: number) =&gt; void</code> | Switch to a different branch at a given message |
-| `reload` | <code>() =&gt; Promise&lt;void&gt;</code> | Re-send last user message |
-| `stop` | <code>() =&gt; void</code> | Abort current request |
-| `setMessages` | <code>(messages: ChatMessage[]) =&gt; void</code> | Replace message history |
-| `addToolOutput` | <code>(output: ToolOutput) =&gt; void</code> | Submit client-side tool result |
-| `data?` | `unknown` | Extra data from server response |
-| `handleInputChange` | <code>(e: React.ChangeEvent&lt;HTMLInputElement &#124; HTMLTextAreaElement&gt;) =&gt; void</code> | Bind to input onChange |
-| `handleSubmit` | <code>(e: React.FormEvent) =&gt; Promise&lt;void&gt;</code> | Submit current input |
-| `onChange` | <code>(e: React.ChangeEvent&lt;HTMLInputElement &#124; HTMLTextAreaElement&gt;) =&gt; void</code> | Alias for `handleInputChange` - matches `ChatProps.onChange` for easy spreading |
-| `onSubmit` | <code>(e: React.FormEvent) =&gt; Promise&lt;void&gt;</code> | Alias for `handleSubmit` - matches `ChatProps.onSubmit` for easy spreading |
-| `onModelChange` | <code>(model: string &#124; undefined) =&gt; void</code> | Alias for `setModel` - matches `ChatProps.onModelChange` for easy spreading |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `messages` | `ChatMessage[]` | All messages in the conversation | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L86) |
+| `input` | `string` | Current input value | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L87) |
+| `isLoading` | `boolean` | Whether a request is in flight | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L88) |
+| `error` | `Error \| null` | Last error (if any) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L89) |
+| `model` | `string \| undefined` | Current model override (undefined = use agent default) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L91) |
+| `activeModel` | `string \| undefined` | The actual model being used after auto-upgrade (e.g. "Anthropic/claude-sonnet-4-20250514") | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L93) |
+| `inferenceMode` | `InferenceMode` | Where inference is currently happening | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L95) |
+| `browserStatus` | `BrowserInferenceStatus \| null` | Browser-side model loading/inference status (null when not using browser fallback) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L97) |
+| `setInput` | <code>(input: string) =&gt; void</code> | Set input value | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L98) |
+| `setModel` | <code>(model: string &#124; undefined) =&gt; void</code> | Change the model for subsequent requests | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L100) |
+| `sendMessage` | <code>(message: &#123; text: string &#125;) =&gt; Promise&lt;void&gt;</code> | Send a message programmatically | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L101) |
+| `editMessage` | <code>(messageId: string, newText: string) =&gt; Promise&lt;void&gt;</code> | Edit a user message and resubmit - truncates history to that point | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L103) |
+| `getBranches` | <code>(messageId: string) =&gt; BranchInfo</code> | Get branch info for a message (returns { current, total }; total=1 if no branches) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L105) |
+| `switchBranch` | <code>(messageId: string, branchIndex: number) =&gt; void</code> | Switch to a different branch at a given message | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L107) |
+| `reload` | <code>() =&gt; Promise&lt;void&gt;</code> | Re-send last user message | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L108) |
+| `stop` | <code>() =&gt; void</code> | Abort current request | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L109) |
+| `setMessages` | <code>(messages: ChatMessage[]) =&gt; void</code> | Replace message history | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L110) |
+| `addToolOutput` | <code>(output: ToolOutput) =&gt; void</code> | Submit client-side tool result | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L111) |
+| `data?` | `unknown` | Extra data from server response | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L112) |
+| `handleInputChange` | <code>(e: React.ChangeEvent&lt;HTMLInputElement &#124; HTMLTextAreaElement&gt;) =&gt; void</code> | Bind to input onChange | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L113) |
+| `handleSubmit` | <code>(e: React.FormEvent) =&gt; Promise&lt;void&gt;</code> | Submit current input | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L114) |
+| `onChange` | <code>(e: React.ChangeEvent&lt;HTMLInputElement &#124; HTMLTextAreaElement&gt;) =&gt; void</code> | Alias for `handleInputChange` - matches `ChatProps.onChange` for easy spreading | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L116) |
+| `onSubmit` | <code>(e: React.FormEvent) =&gt; Promise&lt;void&gt;</code> | Alias for `handleSubmit` - matches `ChatProps.onSubmit` for easy spreading | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L118) |
+| `onModelChange` | <code>(model: string &#124; undefined) =&gt; void</code> | Alias for `setModel` - matches `ChatProps.onModelChange` for easy spreading | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-chat/types.ts#L120) |
 
 ### `UseAgentOptions`
 
 Options accepted by use agent.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `agent` | `string` | Agent ID or endpoint |
-| `onToolCall?` | <code>(toolCall: ToolCall) =&gt; void</code> | Callback when tool is called |
-| `onToolResult?` | <code>(toolCall: ToolCall, result: unknown) =&gt; void</code> | Callback when tool result received |
-| `onError?` | <code>(error: Error) =&gt; void</code> | Callback when error occurs |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `agent` | `string` | Agent ID or endpoint | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-agent.ts#L7) |
+| `onToolCall?` | <code>(toolCall: ToolCall) =&gt; void</code> | Callback when tool is called | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-agent.ts#L10) |
+| `onToolResult?` | <code>(toolCall: ToolCall, result: unknown) =&gt; void</code> | Callback when tool result received | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-agent.ts#L13) |
+| `onError?` | <code>(error: Error) =&gt; void</code> | Callback when error occurs | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-agent.ts#L16) |
 
 ### `UseAgentResult`
 
 Result returned from use agent.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `messages` | `AgentMessage[]` | Message history |
-| `toolCalls` | `ToolCall[]` | Active tool calls |
-| `status` | `AgentStatus` | Agent status |
-| `thinking?` | `string` | Thinking/reasoning text |
-| `invoke` | <code>(input: string) =&gt; Promise&lt;void&gt;</code> | Invoke the agent |
-| `stop` | <code>() =&gt; void</code> | Stop agent execution |
-| `isLoading` | `boolean` | Loading state |
-| `error` | `Error \| null` | Error state |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `messages` | `AgentMessage[]` | Message history | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-agent.ts#L22) |
+| `toolCalls` | `ToolCall[]` | Active tool calls | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-agent.ts#L25) |
+| `status` | `AgentStatus` | Agent status | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-agent.ts#L28) |
+| `thinking?` | `string` | Thinking/reasoning text | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-agent.ts#L31) |
+| `invoke` | <code>(input: string) =&gt; Promise&lt;void&gt;</code> | Invoke the agent | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-agent.ts#L34) |
+| `stop` | <code>() =&gt; void</code> | Stop agent execution | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-agent.ts#L37) |
+| `isLoading` | `boolean` | Loading state | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-agent.ts#L40) |
+| `error` | `Error \| null` | Error state | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/react/use-agent.ts#L43) |
 
 ## Exports
 

--- a/docs/reference/veryfront/middleware.md
+++ b/docs/reference/veryfront/middleware.md
@@ -99,45 +99,45 @@ List registered middleware with metadata.
 
 Options accepted by cors.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `origin?` | `string \| string[] \| OriginValidator` | Allowed origins (string, regex, array, or function) |
-| `methods?` | `string[]` | Allowed HTTP methods |
-| `allowedHeaders?` | `string[]` | Allowed request headers |
-| `exposedHeaders?` | `string[]` | Headers exposed to client |
-| `credentials?` | `boolean` | Allow credentials |
-| `maxAge?` | `number` | Preflight cache duration (seconds) |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `origin?` | `string \| string[] \| OriginValidator` | Allowed origins (string, regex, array, or function) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/middleware/builtin/types.ts#L26) |
+| `methods?` | `string[]` | Allowed HTTP methods | [source](https://github.com/veryfront/veryfront-code/blob/main/src/middleware/builtin/types.ts#L27) |
+| `allowedHeaders?` | `string[]` | Allowed request headers | [source](https://github.com/veryfront/veryfront-code/blob/main/src/middleware/builtin/types.ts#L28) |
+| `exposedHeaders?` | `string[]` | Headers exposed to client | [source](https://github.com/veryfront/veryfront-code/blob/main/src/middleware/builtin/types.ts#L29) |
+| `credentials?` | `boolean` | Allow credentials | [source](https://github.com/veryfront/veryfront-code/blob/main/src/middleware/builtin/types.ts#L30) |
+| `maxAge?` | `number` | Preflight cache duration (seconds) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/middleware/builtin/types.ts#L31) |
 
 ### `RateLimitOptions`
 
 Options accepted by rate limit.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `maxRequests?` | `number` | Max requests per window |
-| `windowMs?` | `number` | Time window (ms) |
-| `store?` | `RateLimitStore` | Storage backend |
-| `keyGenerator?` | <code>(req: Request) =&gt; string</code> | Function to derive rate limit key from request |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `maxRequests?` | `number` | Max requests per window | [source](https://github.com/veryfront/veryfront-code/blob/main/src/middleware/builtin/security/rate-limit.ts#L79) |
+| `windowMs?` | `number` | Time window (ms) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/middleware/builtin/security/rate-limit.ts#L80) |
+| `store?` | `RateLimitStore` | Storage backend | [source](https://github.com/veryfront/veryfront-code/blob/main/src/middleware/builtin/security/rate-limit.ts#L81) |
+| `keyGenerator?` | <code>(req: Request) =&gt; string</code> | Function to derive rate limit key from request | [source](https://github.com/veryfront/veryfront-code/blob/main/src/middleware/builtin/security/rate-limit.ts#L82) |
 
 ### `LoggerOptions`
 
 Options accepted by logger.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `format?` | `LogFormat` | Log format (combined, common, dev, short) |
-| `skip?` | <code>(req: Request) =&gt; boolean</code> | Skip logging for matching requests |
-| `log?` | <code>(message: string) =&gt; void</code> | Custom log output function |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `format?` | `LogFormat` | Log format (combined, common, dev, short) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/middleware/builtin/logger.ts#L17) |
+| `skip?` | <code>(req: Request) =&gt; boolean</code> | Skip logging for matching requests | [source](https://github.com/veryfront/veryfront-code/blob/main/src/middleware/builtin/logger.ts#L18) |
+| `log?` | <code>(message: string) =&gt; void</code> | Custom log output function | [source](https://github.com/veryfront/veryfront-code/blob/main/src/middleware/builtin/logger.ts#L19) |
 
 ### `TimeoutOptions`
 
 Options accepted by timeout.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `timeoutMs?` | `number` | Timeout in milliseconds (default: 60000) |
-| `message?` | `string` | Custom message for timeout response |
-| `exclude?` | `string[]` | Paths to exclude from timeout (e.g., health checks) |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `timeoutMs?` | `number` | Timeout in milliseconds (default: 60000) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/middleware/builtin/timeout.ts#L18) |
+| `message?` | `string` | Custom message for timeout response | [source](https://github.com/veryfront/veryfront-code/blob/main/src/middleware/builtin/timeout.ts#L21) |
+| `exclude?` | `string[]` | Paths to exclude from timeout (e.g., health checks) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/middleware/builtin/timeout.ts#L24) |
 
 ## Exports
 

--- a/docs/reference/veryfront/resource.md
+++ b/docs/reference/veryfront/resource.md
@@ -43,15 +43,15 @@ const result = await docs.load({ section: "agents" });
 
 Create a typed resource definition.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `pattern?` | `string` | URI template pattern for parameterized resources |
-| `description` | `string` | Resource description |
-| `title?` | `string` |  |
-| `paramsSchema` | <code>Schema&lt;TParams&gt;</code> | Zod schema for URI parameters |
-| `load` | <code>(params: TParams) =&gt; Promise&lt;TData&gt; &#124; TData</code> | Function returning resource content |
-| `subscribe?` | <code>(params: TParams) =&gt; AsyncIterable&lt;TData&gt;</code> | Async iterable for real-time resource updates |
-| `mcp?` | `McpConfig` | MCP server configuration |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `pattern?` | `string` | URI template pattern for parameterized resources | [source](https://github.com/veryfront/veryfront-code/blob/main/src/resource/types.ts#L18) |
+| `description` | `string` | Resource description | [source](https://github.com/veryfront/veryfront-code/blob/main/src/resource/types.ts#L19) |
+| `title?` | `string` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/resource/types.ts#L20) |
+| `paramsSchema` | <code>Schema&lt;TParams&gt;</code> | Zod schema for URI parameters | [source](https://github.com/veryfront/veryfront-code/blob/main/src/resource/types.ts#L21) |
+| `load` | <code>(params: TParams) =&gt; Promise&lt;TData&gt; &#124; TData</code> | Function returning resource content | [source](https://github.com/veryfront/veryfront-code/blob/main/src/resource/types.ts#L22) |
+| `subscribe?` | <code>(params: TParams) =&gt; AsyncIterable&lt;TData&gt;</code> | Async iterable for real-time resource updates | [source](https://github.com/veryfront/veryfront-code/blob/main/src/resource/types.ts#L23) |
+| `mcp?` | `McpConfig` | MCP server configuration | [source](https://github.com/veryfront/veryfront-code/blob/main/src/resource/types.ts#L24) |
 
 **Returns:** <code>Resource&lt;TParams, TData&gt;</code>
 

--- a/docs/reference/veryfront/sandbox.md
+++ b/docs/reference/veryfront/sandbox.md
@@ -148,31 +148,31 @@ Get the sandbox endpoint URL.
 
 Options for creating a sandbox session.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `apiUrl?` | `string` | Base URL of the Veryfront API. Defaults to VERYFRONT_API_URL, then the Veryfront Cloud API. |
-| `authToken?` | `string` | Explicit Veryfront auth token or API key override. |
-| `projectId?` | `string` | Optional project context for project-billed / project-scoped sandbox sessions. |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `apiUrl?` | `string` | Base URL of the Veryfront API. Defaults to VERYFRONT_API_URL, then the Veryfront Cloud API. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L15) |
+| `authToken?` | `string` | Explicit Veryfront auth token or API key override. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L17) |
+| `projectId?` | `string` | Optional project context for project-billed / project-scoped sandbox sessions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L19) |
 
 ### `ExecResult`
 
 Result of a command execution: stdout, stderr, and exit code.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `stdout` | `string` | Buffered standard output from command execution. |
-| `stderr` | `string` | Buffered standard error from command execution. |
-| `exitCode` | `number` | Process exit code. |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `stdout` | `string` | Buffered standard output from command execution. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L24) |
+| `stderr` | `string` | Buffered standard error from command execution. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L25) |
+| `exitCode` | `number` | Process exit code. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L26) |
 
 ### `ExecStreamEvent`
 
 Streaming event emitted during command execution.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `type` | `"stdout" \| "stderr" \| "exit" \| "error"` | Event type (`stdout`, `stderr`, `exit`, `error`). |
-| `data?` | `string` | Chunk payload for stdout/stderr/error events. |
-| `exitCode?` | `number` | Exit code for `exit` events. |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `type` | `"stdout" \| "stderr" \| "exit" \| "error"` | Event type (`stdout`, `stderr`, `exit`, `error`). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L31) |
+| `data?` | `string` | Chunk payload for stdout/stderr/error events. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L32) |
+| `exitCode?` | `number` | Exit code for `exit` events. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L33) |
 
 ## Exports
 

--- a/docs/reference/veryfront/tool.md
+++ b/docs/reference/veryfront/tool.md
@@ -95,14 +95,14 @@ const result = await assistant.generate({
 
 Create a typed tool definition.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `id?` | `string` | Tool identifier (optional, inferred from filename) |
-| `description` | `string` | Tool description for the AI model |
-| `inputSchema` | <code>Schema&lt;TInput&gt;</code> | Input schema produced via `defineSchema((v) => …)` (or any `SchemaValidator`-backed builder). Validates input before `execute` runs and seeds the JSON Schema exposed to AI providers. |
-| `allowUnknownSchema?` | `boolean` | Allow unknown/non-contract schemas to fall back to a permissive JSON schema. Use only for truly dynamic tools; prefer `v.unknown()` or `v.any()` from the SchemaValidator DSL instead. |
-| `execute` | <code>(input: TInput, context?: ToolExecutionContext) =&gt; Promise&lt;TOutput&gt; &#124; TOutput</code> | Tool execution function |
-| `mcp?` | `object` | MCP configuration |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `id?` | `string` | Tool identifier (optional, inferred from filename) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/tool/types.ts#L14) |
+| `description` | `string` | Tool description for the AI model | [source](https://github.com/veryfront/veryfront-code/blob/main/src/tool/types.ts#L17) |
+| `inputSchema` | <code>Schema&lt;TInput&gt;</code> | Input schema produced via `defineSchema((v) => …)` (or any `SchemaValidator`-backed builder). Validates input before `execute` runs and seeds the JSON Schema exposed to AI providers. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/tool/types.ts#L24) |
+| `allowUnknownSchema?` | `boolean` | Allow unknown/non-contract schemas to fall back to a permissive JSON schema. Use only for truly dynamic tools; prefer `v.unknown()` or `v.any()` from the SchemaValidator DSL instead. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/tool/types.ts#L31) |
+| `execute` | <code>(input: TInput, context?: ToolExecutionContext) =&gt; Promise&lt;TOutput&gt; &#124; TOutput</code> | Tool execution function | [source](https://github.com/veryfront/veryfront-code/blob/main/src/tool/types.ts#L36) |
+| `mcp?` | `object` | MCP configuration | [source](https://github.com/veryfront/veryfront-code/blob/main/src/tool/types.ts#L39) |
 
 **Returns:** <code>Tool&lt;TInput, TOutput&gt;</code>
 

--- a/docs/reference/veryfront/workflow.md
+++ b/docs/reference/veryfront/workflow.md
@@ -65,19 +65,19 @@ const contentPipeline = workflow({
 
 Create a workflow definition.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `id` | `string` | Unique workflow identifier |
-| `description?` | `string` | Human-readable description |
-| `version?` | `string` | Semantic version string |
-| `inputSchema?` | <code>Schema&lt;TInput&gt;</code> | Zod schema for workflow input validation |
-| `outputSchema?` | <code>Schema&lt;TOutput&gt;</code> | Zod schema for workflow output validation |
-| `retry?` | `RetryConfig` | Retry configuration for failed steps |
-| `timeout?` | `string \| number` | Max execution time (ms) |
-| `introspect?` | `boolean` | Enable runtime introspection for debugging |
-| `steps` | <code>WorkflowNode[] &#124; ((context: StepBuilderContext&lt;TInput&gt;) =&gt; WorkflowNode[])</code> | Workflow step definitions |
-| `onError?` | <code>(error: Error, context: WorkflowContext) =&gt; void &#124; Promise&lt;void&gt;</code> | Error handler called when a step fails |
-| `onComplete?` | <code>(result: TOutput, context: WorkflowContext) =&gt; void &#124; Promise&lt;void&gt;</code> | Callback fired after workflow completes |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `id` | `string` | Unique workflow identifier | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/workflow.ts#L22) |
+| `description?` | `string` | Human-readable description | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/workflow.ts#L23) |
+| `version?` | `string` | Semantic version string | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/workflow.ts#L24) |
+| `inputSchema?` | <code>Schema&lt;TInput&gt;</code> | Zod schema for workflow input validation | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/workflow.ts#L25) |
+| `outputSchema?` | <code>Schema&lt;TOutput&gt;</code> | Zod schema for workflow output validation | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/workflow.ts#L26) |
+| `retry?` | `RetryConfig` | Retry configuration for failed steps | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/workflow.ts#L27) |
+| `timeout?` | `string \| number` | Max execution time (ms) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/workflow.ts#L28) |
+| `introspect?` | `boolean` | Enable runtime introspection for debugging | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/workflow.ts#L29) |
+| `steps` | <code>WorkflowNode[] &#124; ((context: StepBuilderContext&lt;TInput&gt;) =&gt; WorkflowNode[])</code> | Workflow step definitions | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/workflow.ts#L30) |
+| `onError?` | <code>(error: Error, context: WorkflowContext) =&gt; void &#124; Promise&lt;void&gt;</code> | Error handler called when a step fails | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/workflow.ts#L33) |
+| `onComplete?` | <code>(result: TOutput, context: WorkflowContext) =&gt; void &#124; Promise&lt;void&gt;</code> | Callback fired after workflow completes | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/workflow.ts#L34) |
 
 **Returns:** <code>Workflow&lt;TInput, TOutput&gt;</code>
 
@@ -87,41 +87,41 @@ Create a workflow definition.
 
 Options accepted by step.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `agent?` | `string \| Agent` | Agent to run (by ID or instance) |
-| `tool?` | `string \| Tool` | Tool to execute (by ID or instance) |
-| `input?` | <code>string &#124; Record&lt;string, unknown&gt; &#124; ((context: WorkflowContext) =&gt; unknown)</code> | Step input: static value or function of workflow context |
-| `checkpoint?` | `boolean` | Persist state after this step |
-| `retry?` | `RetryConfig` | Retry configuration for this step |
-| `timeout?` | `string \| number` | Step timeout (ms) |
-| `skip?` | <code>(context: WorkflowContext) =&gt; boolean &#124; Promise&lt;boolean&gt;</code> | Predicate: skip this step if returns true |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `agent?` | `string \| Agent` | Agent to run (by ID or instance) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/step.ts#L14) |
+| `tool?` | `string \| Tool` | Tool to execute (by ID or instance) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/step.ts#L15) |
+| `input?` | <code>string &#124; Record&lt;string, unknown&gt; &#124; ((context: WorkflowContext) =&gt; unknown)</code> | Step input: static value or function of workflow context | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/step.ts#L16) |
+| `checkpoint?` | `boolean` | Persist state after this step | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/step.ts#L17) |
+| `retry?` | `RetryConfig` | Retry configuration for this step | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/step.ts#L18) |
+| `timeout?` | `string \| number` | Step timeout (ms) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/step.ts#L19) |
+| `skip?` | <code>(context: WorkflowContext) =&gt; boolean &#124; Promise&lt;boolean&gt;</code> | Predicate: skip this step if returns true | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/step.ts#L20) |
 
 ### `BranchOptions`
 
 Options accepted by branch.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `condition` | <code>(context: WorkflowContext) =&gt; boolean &#124; Promise&lt;boolean&gt;</code> | Branch predicate function |
-| `then` | `WorkflowNode[]` | Steps when condition is true |
-| `else?` | `WorkflowNode[]` | Steps when condition is false |
-| `checkpoint?` | `boolean` | Persist state after this node |
-| `retry?` | `RetryConfig` | Retry configuration |
-| `timeout?` | `string \| number` | Node timeout (ms or duration string) |
-| `skip?` | <code>(context: WorkflowContext) =&gt; boolean &#124; Promise&lt;boolean&gt;</code> | Predicate: skip if returns true |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `condition` | <code>(context: WorkflowContext) =&gt; boolean &#124; Promise&lt;boolean&gt;</code> | Branch predicate function | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/branch.ts#L12) |
+| `then` | `WorkflowNode[]` | Steps when condition is true | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/branch.ts#L13) |
+| `else?` | `WorkflowNode[]` | Steps when condition is false | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/branch.ts#L14) |
+| `checkpoint?` | `boolean` | Persist state after this node | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/branch.ts#L15) |
+| `retry?` | `RetryConfig` | Retry configuration | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/branch.ts#L16) |
+| `timeout?` | `string \| number` | Node timeout (ms or duration string) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/branch.ts#L17) |
+| `skip?` | <code>(context: WorkflowContext) =&gt; boolean &#124; Promise&lt;boolean&gt;</code> | Predicate: skip if returns true | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/branch.ts#L18) |
 
 ### `ParallelOptions`
 
 Options accepted by parallel.
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `strategy?` | `"all" \| "race" \| "allSettled"` | Completion strategy (`"all"`, `"race"`, `"allSettled"`) |
-| `checkpoint?` | `boolean` | Persist state after this node |
-| `retry?` | `RetryConfig` | Retry configuration |
-| `timeout?` | `string \| number` | Node timeout (ms or duration string) |
-| `skip?` | <code>(context: WorkflowContext) =&gt; boolean &#124; Promise&lt;boolean&gt;</code> | Predicate: skip if returns true |
+| Property | Type | Description | Source |
+|----------|------|-------------|--------|
+| `strategy?` | `"all" \| "race" \| "allSettled"` | Completion strategy (`"all"`, `"race"`, `"allSettled"`) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/parallel.ts#L12) |
+| `checkpoint?` | `boolean` | Persist state after this node | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/parallel.ts#L13) |
+| `retry?` | `RetryConfig` | Retry configuration | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/parallel.ts#L14) |
+| `timeout?` | `string \| number` | Node timeout (ms or duration string) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/parallel.ts#L15) |
+| `skip?` | <code>(context: WorkflowContext) =&gt; boolean &#124; Promise&lt;boolean&gt;</code> | Predicate: skip if returns true | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/parallel.ts#L16) |
 
 ## Exports
 

--- a/scripts/docs/docs-coverage.test.ts
+++ b/scripts/docs/docs-coverage.test.ts
@@ -3,8 +3,8 @@ import { collectDocsCoverage, formatDocsCoverage } from "./docs-coverage.ts";
 
 const API_DECLARATION_BASELINE = {
   total: 3282,
-  withSourceLinks: 3131,
-  withoutSourceLinks: 151,
+  withSourceLinks: 3282,
+  withoutSourceLinks: 0,
 } as const;
 
 Deno.test("collectDocsCoverage reports generated reference and guide coverage", async () => {
@@ -20,6 +20,7 @@ Deno.test("collectDocsCoverage reports generated reference and guide coverage", 
     report.apiDeclarations.withoutSourceLinks <=
       API_DECLARATION_BASELINE.withoutSourceLinks,
   );
+  assertEquals(report.apiDeclarations.missingSourceLinkSamples, []);
   assertEquals(report.referencePages.missing, []);
   assertEquals(report.referencePages.extra, []);
   assertEquals(report.links.referenceModulesMissingGuideLinks, []);

--- a/scripts/docs/generate-api-reference.ts
+++ b/scripts/docs/generate-api-reference.ts
@@ -87,7 +87,7 @@ interface TsType {
     typeParams?: unknown[];
   };
   typeLiteral?: {
-    properties: Array<{ name: string; optional: boolean; tsType?: TsType; jsDoc?: { doc?: string }; params?: unknown[]; typeParams?: unknown[] }>;
+    properties: InterfaceProperty[];
     callSignatures?: unknown[];
     indexSignatures?: unknown[];
     constructors?: unknown[];
@@ -129,6 +129,7 @@ interface InterfaceProperty {
   jsDoc?: { doc?: string };
   params?: unknown[];
   typeParams?: unknown[];
+  location?: DenoDocLocation;
 }
 
 interface InterfaceMethod {
@@ -1335,6 +1336,7 @@ function normalizeProperties(properties: unknown): InterfaceProperty[] {
     const record = asRecord(property) ?? {};
     return {
       ...record,
+      location: normalizeLocation(record.location),
       tsType: normalizeTsType(record.tsType),
     } as InterfaceProperty;
   });
@@ -1483,10 +1485,14 @@ function getNodeDescription(node: DocNode): string {
 }
 
 function getNodeSourceHref(node: DocNode): string {
-  const relativePath = getRelativeSourcePath(node.location);
+  return getSourceHref(node.location);
+}
+
+function getSourceHref(location: DenoDocLocation | undefined): string {
+  const relativePath = getRelativeSourcePath(location);
   if (!relativePath) return "";
 
-  const lineNumber = node.location?.line;
+  const lineNumber = location?.line;
   const line = typeof lineNumber === "number" && lineNumber > 0 ? `#L${lineNumber}` : "";
   return `${SOURCE_BASE_URL}/${relativePath}${line}`;
 }
@@ -2091,15 +2097,18 @@ function oneLineDoc(doc: string): string {
 function renderPropertyTable(
   typeName: string,
   properties: InterfaceProperty[],
+  fallbackLocation?: DenoDocLocation,
 ): string[] {
   const lines: string[] = [];
-  lines.push("| Property | Type | Description |");
-  lines.push("|----------|------|-------------|");
+  lines.push("| Property | Type | Description | Source |");
+  lines.push("|----------|------|-------------|--------|");
   for (const prop of properties) {
     const name = prop.optional ? `${prop.name}?` : prop.name;
     const rawType = renderType(prop.tsType);
     const desc = getPropertyDescription(typeName, prop.name, prop);
-    lines.push(`| \`${name}\` | ${mdxType(rawType)} | ${desc} |`);
+    const sourceHref = getSourceHref(prop.location ?? fallbackLocation);
+    const source = sourceHref ? `[source](${sourceHref})` : "";
+    lines.push(`| \`${name}\` | ${mdxType(rawType)} | ${desc} | ${source} |`);
   }
   return lines;
 }
@@ -2142,7 +2151,13 @@ function generateAPISection(nodes: DocNode[], importPath: string): string[] {
       if (fnSpec.configType) {
         const configNode = findNode(nodes, fnSpec.configType);
         if (configNode?.interfaceDef?.properties && configNode.interfaceDef.properties.length > 0) {
-          lines.push(...renderPropertyTable(fnSpec.configType, configNode.interfaceDef.properties));
+          lines.push(
+            ...renderPropertyTable(
+              fnSpec.configType,
+              configNode.interfaceDef.properties,
+              configNode.location,
+            ),
+          );
           lines.push("");
         }
       }
@@ -2196,8 +2211,15 @@ function generateAPISection(nodes: DocNode[], importPath: string): string[] {
                 tsType: p.tsType,
                 // Prefer curated param description, then upstream JSDoc
                 jsDoc: paramDescs[p.name] ? { doc: paramDescs[p.name] } : p.jsDoc,
+                location: p.location,
               }));
-              lines.push(...renderPropertyTable(`${typeName}.${method.name}`, interfaceProps));
+              lines.push(
+                ...renderPropertyTable(
+                  `${typeName}.${method.name}`,
+                  interfaceProps,
+                  node.location,
+                ),
+              );
               lines.push("");
             }
           }
@@ -2287,6 +2309,8 @@ function generateTypeReference(nodes: DocNode[], importPath: string): string[] {
         name: p.name,
         optional: p.optional,
         tsType: p.tsType,
+        jsDoc: p.jsDoc,
+        location: p.location,
       }));
     }
 
@@ -2309,7 +2333,7 @@ function generateTypeReference(nodes: DocNode[], importPath: string): string[] {
       lines.push("");
     }
 
-    lines.push(...renderPropertyTable(typeName, properties));
+    lines.push(...renderPropertyTable(typeName, properties, node?.location));
     lines.push("");
   }
 


### PR DESCRIPTION
## Summary
- carry Deno doc locations through generated property/type rows
- render Source links for nested API declaration tables
- raise docs coverage baseline to require 3282/3282 source-linked declarations and no missing samples

## Verification
- deno task docs
- deno task docs:coverage
- deno task docs:validate
- deno task test:scripts
- deno check --config=scripts/test.deno.json scripts/docs/generate-api-reference.ts scripts/docs/docs-coverage.test.ts
- deno fmt --check --config=scripts/test.deno.json scripts/docs/docs-coverage.test.ts
- git diff --check
- pre-push hook: format, lint, type check, unit tests: 1900 passed