### PR TITLE
docs(guides): replace ASCII diagram with Mermaid in integrations

### DIFF
--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -36,7 +36,8 @@ flowchart LR
 
     subgraph Service["API / service layer"]
         specs["Connector specs (JSON)"]
-        oauth["OAuth / token flows<br/>Token storage<br/>Remote tool execution"]
+        exec["Remote tool execution<br/>(/integrations/tools/call)"]
+        oauth["OAuth / token flows<br/>Token storage"]
         authState["Provider auth state"]
     end
 
@@ -47,10 +48,12 @@ flowchart LR
     step2 --> specs
     specs --> step3
     step3 --> step4
-    step4 -- "Auth token" --> oauth
+    step4 -- "Auth token + tool call" --> exec
+    exec --> oauth
     oauth --> authState
-    step4 --> api
-    api -- "Tool response" --> step4
+    exec --> api
+    api -- "Tool response" --> exec
+    exec --> step4
 ```
 
 **Key points:**

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -21,22 +21,36 @@ tool definitions and execute calls through the configured API layer.
 
 ## How it works
 
-```
-veryfront.config.ts            Runtime helpers                    API / service layer
-┌──────────────────┐     ┌────────────────────────────┐     ┌────────────────────────┐
-│ integrations:    │────▶│ 1. Read config             │     │ Connector specs (JSON) │
-│   github: {}     │     │ 2. Sync integration config │────▶│ OAuth / token flows    │
-│   slack:         │     │ 3. Fetch remote tools      │     │ Token storage          │
-│     tools:       │     │    and schemas             │     │ Remote tool execution  │
-│       - send-msg │     │ 4. On tool call:           │     │                        │
-│   linear:        │     │    a. Resolve API auth     │────▶│ Provider auth state    │
-│     perUser: true│     │    b. Call remote tool     │     │ Tool response          │
-└──────────────────┘     └─────────────┬──────────────┘     └────────────────────────┘
-                                       │ Auth token
-                                       ▼
-                         ┌────────────────────────────┐
-                         │ External API (GitHub, etc.) │
-                         └────────────────────────────┘
+```mermaid
+flowchart LR
+    subgraph Project["veryfront.config.ts"]
+        cfg["integrations:<br/>&nbsp;&nbsp;github: {}<br/>&nbsp;&nbsp;slack: { tools: [&quot;send-message&quot;] }<br/>&nbsp;&nbsp;linear: { perUser: true }"]
+    end
+
+    subgraph Runtime["Runtime helpers"]
+        step1["1. Read config"]
+        step2["2. Sync integration config"]
+        step3["3. Fetch remote tools and schemas"]
+        step4["4. On tool call:<br/>a. Resolve API auth<br/>b. Call remote tool"]
+    end
+
+    subgraph Service["API / service layer"]
+        specs["Connector specs (JSON)"]
+        oauth["OAuth / token flows<br/>Token storage<br/>Remote tool execution"]
+        authState["Provider auth state"]
+    end
+
+    api["External API<br/>(GitHub, Slack, Linear, ...)"]
+
+    cfg --> step1
+    step1 --> step2
+    step2 --> specs
+    specs --> step3
+    step3 --> step4
+    step4 -- "Auth token" --> oauth
+    oauth --> authState
+    step4 --> api
+    api -- "Tool response" --> step4
 ```
 
 **Key points:**


### PR DESCRIPTION
Replace the box-drawing diagram in the integrations guide "How it works" section with a Mermaid flowchart.

## Why

The original ASCII diagram relied on fixed-width box characters and em-dash-style arrows that this project's docs style rules already discourage. A Mermaid flowchart renders as a proper diagram on github.com and Mintlify, scales on mobile, and is easier to update without re-aligning columns.

## Content preserved

- All four runtime steps (read config, sync, fetch tools, on tool call).
- All three subgraph groupings (`veryfront.config.ts`, Runtime helpers, API / service layer).
- The labeled `Auth token` edge to the service layer and `Tool response` return edge to the runtime.
- The Key points list immediately below the diagram is untouched.

## Test plan

- [x] `deno test tests/docs/guide-contracts.test.ts` — passes; guide contract snippets (`integrations`, `perUser`, `Available integrations`) remain present in the file.
- [x] Pre-push checks (1900 tests) — pass.

## After merge

Sync workflow mirrors the guide to `veryfront-docs/docs/code/guides/integrations.md`. Mermaid blocks render in both renderers (github.com natively since 2022, Mintlify out of the box).