### PR TITLE
docs(guides): add Coding agents guide for Claude Code, Cursor, Codex

### DIFF
--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -1,0 +1,147 @@
+---
+title: "Coding agents"
+description: "Connect Claude Code, Cursor, Codex, and other MCP-aware coding agents to the Veryfront dev server."
+order: 28
+---
+
+# Coding agents
+
+Connect a coding agent like Claude Code, Cursor, or Codex to your Veryfront project so it can scaffold pages, read live errors and logs, run tests, and preview routes without leaving its chat surface.
+
+The CLI ships a built-in MCP server for this. It is separate from the application-facing MCP server you might mount in your app (see [MCP server](./mcp-server.md)), which exposes _your_ tools to MCP clients. The CLI MCP exposes _Veryfront dev tools_ to your coding agent.
+
+## Prerequisites
+
+- A Veryfront project (see [Quickstart](./quickstart.md)).
+- An MCP-aware coding agent such as Claude Code, Cursor, or any client that
+  speaks Model Context Protocol over HTTP or stdio.
+
+## Choose a transport
+
+The CLI MCP server supports two transports. Most agents work with HTTP.
+
+| Transport | When to use it                                                    | How to start                        |
+| --------- | ----------------------------------------------------------------- | ----------------------------------- |
+| HTTP      | Your agent supports remote MCP URLs (Claude Code, Cursor, Codex). | Auto-starts with `veryfront dev`.   |
+| stdio     | Your agent only supports stdio MCP servers.                       | Run `veryfront mcp` from the agent. |
+
+When you run `veryfront dev`, the HTTP MCP server listens on `--port + 2` (default `3002`). When you run `veryfront start`, it listens on `9999`. The endpoint is always `/mcp`.
+
+```
+http://localhost:3002/mcp        # dev
+http://localhost:9999/mcp        # production
+```
+
+The dev server also accepts the `veryfront.me` hostname, which resolves to `127.0.0.1` and is what the CLI prints by default.
+
+## Connect Claude Code
+
+Add an `mcpServers` entry in `~/.claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "veryfront": {
+      "url": "http://veryfront.me:3002/mcp"
+    }
+  }
+}
+```
+
+Restart Claude Code, then run `veryfront dev` in your project. Claude Code discovers the Veryfront tools and prefixes them with `mcp__veryfront__` in its tool list.
+
+## Connect Cursor
+
+Open Cursor settings, find the **Model Context Protocol** section, and add a new server with:
+
+- **Name:** `veryfront`
+- **URL:** `http://localhost:3002/mcp`
+- **Transport:** HTTP
+
+Save and reload. Cursor's agent can now call Veryfront tools while you edit.
+
+## Connect Codex (or any other MCP-aware client)
+
+For any MCP-aware client that supports HTTP transport, point it at `http://localhost:3002/mcp` while `veryfront dev` is running. The CLI also exposes a stdio MCP server, so clients that require stdio can launch it as a subprocess:
+
+```bash
+veryfront mcp
+```
+
+The stdio transport reads JSON-RPC requests on `stdin` and writes responses on `stdout`. Agents that only accept a command path can use the binary that `npm install -g veryfront` puts on `PATH`.
+
+## What the agent can do
+
+The CLI MCP exposes a focused toolset for the development loop. The names below are stable and prefix-namespaced with `vf_`:
+
+| Tool                     | What it does                                                 |
+| ------------------------ | ------------------------------------------------------------ |
+| `vf_get_errors`          | Read live compile, runtime, bundle, HMR, and module errors.  |
+| `vf_get_logs`            | Read dev-server logs with level, source, and pattern filter. |
+| `vf_get_status`          | Inspect dev-server uptime, ports, and active features.       |
+| `vf_list_routes`         | List every route the dev server has registered.              |
+| `vf_preview_route`       | Render a route's HTTP response without opening a browser.    |
+| `vf_scaffold`            | Generate a page, API route, component, tool, or agent.       |
+| `vf_run_tests`           | Run the project's test suite.                                |
+| `vf_run_lint`            | Run the linter.                                              |
+| `vf_trigger_hmr`         | Force a browser refresh after an external file change.       |
+| `vf_list_templates`      | Browse the templates `veryfront init` supports.              |
+| `vf_list_integrations`   | Browse the available integration connectors.                 |
+| `vf_create_project`      | Bootstrap a new project from a template.                     |
+| `vf_list_local_projects` | Find Veryfront projects on the filesystem.                   |
+
+Use `vf_get_schema` from the agent (or `veryfront schema --json` from your shell) to enumerate the full toolset and current argument shapes — that command is the source of truth and stays in sync with the CLI you have installed.
+
+## Verify it worked
+
+Start the dev server:
+
+```bash
+veryfront dev
+```
+
+Smoke-test the MCP endpoint with a `tools/list` request:
+
+```bash
+curl -s -X POST http://localhost:3002/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | head -c 500
+```
+
+A working server returns a JSON-RPC response whose `result.tools` array lists `vf_get_errors`, `vf_scaffold`, and the other tools above. If you get a connection-refused error, the dev server is not running or is on a non-default port; check the dashboard for the printed MCP URL.
+
+From inside a connected coding agent, ask it to "list routes" or "show recent dev errors" — it should call the matching `vf_*` tool and stream the result back as text.
+
+## Troubleshooting
+
+### The agent does not see Veryfront tools
+
+The dev server must be running. The HTTP MCP only listens while `veryfront dev` or `veryfront start` is active.
+
+### Port already in use
+
+The dev MCP port follows the dev server port (`--port + 2`). If you start the dev server with `--port 4000`, the MCP server moves to `4002`. Update the URL in your agent config to match.
+
+### CORS error from a browser-based agent
+
+The HTTP MCP only accepts requests from `localhost`, `127.0.0.1`, and `veryfront.me`. Browser agents that run from any other origin are rejected by design.
+
+### `Unknown command: mcp`
+
+Your installed CLI is older than the version that added MCP. Update with `npm install -g veryfront@latest`, or run from source:
+
+```bash
+cd veryfront-code
+deno run -A cli/main.ts mcp
+```
+
+## Next
+
+- [MCP server](./mcp-server.md): expose _your_ app's tools, prompts, and resources to MCP clients
+- [Skills](./skills.md): give agents project-level instructions as `SKILL.md` files
+- [Quickstart](./quickstart.md): scaffold a project the agent can drive
+
+## Related
+
+- [`veryfront/mcp`](../reference/veryfront/mcp.md): MCP server API reference
+- [`veryfront/cli`](../reference/veryfront/cli.md): CLI entry point reference

--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -1,7 +1,7 @@
 ---
 title: "Building and deploying"
 description: "Production builds, static export, and deployment targets."
-order: 33
+order: 38
 ---
 
 # Building and deploying

--- a/docs/guides/extension-authoring.md
+++ b/docs/guides/extension-authoring.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension authoring"
 description: "Write focused Veryfront extension factories, contracts, and capabilities."
-order: 29
+order: 30
 ---
 
 # Extension authoring

--- a/docs/guides/extension-lifecycle.md
+++ b/docs/guides/extension-lifecycle.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension lifecycle"
 description: "Understand extension discovery, ordering, presets, setup, and teardown."
-order: 30
+order: 31
 ---
 
 # Extension lifecycle

--- a/docs/guides/extension-publishing.md
+++ b/docs/guides/extension-publishing.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension publishing"
 description: "Package and publish reusable Veryfront extensions."
-order: 32
+order: 33
 ---
 
 # Extension publishing

--- a/docs/guides/extension-testing.md
+++ b/docs/guides/extension-testing.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension testing"
 description: "Test Veryfront extension factories and contract implementations."
-order: 31
+order: 32
 ---
 
 # Extension testing

--- a/docs/guides/extensions.md
+++ b/docs/guides/extensions.md
@@ -1,7 +1,7 @@
 ---
 title: "Extensions"
 description: "Understand how extensions add focused capabilities to Veryfront."
-order: 28
+order: 29
 ---
 
 # Extensions

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -69,6 +69,7 @@ matches your goal.
 | Guide                                                   | What you will do                                                                      |
 | ------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | [MCP server](./mcp-server.md)                           | Expose tools, prompts, and resources over Model Context Protocol.                     |
+| [Coding agents](./coding-agents.md)                     | Connect Claude Code, Cursor, Codex, and other MCP-aware agents to the dev server.     |
 | [OAuth](./oauth.md)                                     | Sign users in with OAuth 2.0 and the built-in provider catalog.                       |
 | [Integrations](./integrations.md)                       | Wire config-driven integration tools with OAuth, token management, and API execution. |
 | [Sandbox](./sandbox.md)                                 | Run isolated commands and file operations in an ephemeral sandbox session.            |

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -122,3 +122,4 @@ any source file should hot-reload within a second.
 - [Pages and routing](./pages-and-routing.md): file-based routing and layouts
 - [Agents](./agents.md): create your first AI agent
 - [API routes](./api-routes.md): backend HTTP handlers
+- [Coding agents](./coding-agents.md): drive the project from Claude Code, Cursor, or Codex

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -72,6 +72,7 @@ const THIS_GUIDE_EXAMPLE_SUITE = [
   "chat-theming.md",
   "chat-ui.md",
   "cli-knowledge-ingestion.md",
+  "coding-agents.md",
   "create-an-agent.md",
   "deploying.md",
   "extension-authoring.md",
@@ -186,6 +187,29 @@ describe("Guide: chat-theming.md", () => {
     assertExists(ComposerContextProvider);
     assertExists(MessageContextProvider);
     assertEquals(typeof useChatContextOptional, "function");
+  });
+});
+
+describe("Guide: coding-agents.md", () => {
+  it("documents both MCP transports, per-client config, and the vf_* tool surface", async () => {
+    const guide = await readGuide("coding-agents.md");
+
+    for (
+      const snippet of [
+        "veryfront dev",
+        "veryfront mcp",
+        "http://localhost:3002/mcp",
+        "~/.claude.json",
+        "mcpServers",
+        "vf_get_errors",
+        "vf_scaffold",
+        "vf_get_schema",
+        "veryfront schema --json",
+        "tools/list",
+      ]
+    ) {
+      assertStringIncludes(guide, snippet);
+    }
   });
 });
 
@@ -466,17 +490,19 @@ describe("Guide: create-an-agent.md", () => {
   it("uses the public agent factory and getAgent.generate path", async () => {
     const guide = await readGuide("create-an-agent.md");
 
-    for (const snippet of [
-      'import { agent } from "veryfront/agent"',
-      'export default agent({',
-      'id: "assistant"',
-      'import { getAgent } from "veryfront/agent"',
-      'export async function POST(request: Request)',
-      'const { question } = await request.json()',
-      'const assistant = getAgent("assistant")',
-      'await assistant.generate({ input: question })',
-      'Response.json({',
-    ]) {
+    for (
+      const snippet of [
+        'import { agent } from "veryfront/agent"',
+        "export default agent({",
+        'id: "assistant"',
+        'import { getAgent } from "veryfront/agent"',
+        "export async function POST(request: Request)",
+        "const { question } = await request.json()",
+        'const assistant = getAgent("assistant")',
+        "await assistant.generate({ input: question })",
+        "Response.json({",
+      ]
+    ) {
       assertStringIncludes(guide, snippet);
     }
   });
@@ -511,16 +537,18 @@ describe("Guide: installation.md", () => {
   it("documents the runtime, OS, browser, and verify-it-worked sections", async () => {
     const guide = await readGuide("installation.md");
 
-    for (const heading of [
-      "## Prerequisites",
-      "## System requirements",
-      "### Operating system",
-      "### Runtime",
-      "### Hardware",
-      "## Supported browsers",
-      "## Install",
-      "## Verify it worked",
-    ]) {
+    for (
+      const heading of [
+        "## Prerequisites",
+        "## System requirements",
+        "### Operating system",
+        "### Runtime",
+        "### Hardware",
+        "## Supported browsers",
+        "## Install",
+        "## Verify it worked",
+      ]
+    ) {
       assertStringIncludes(guide, heading);
     }
   });

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -43,6 +43,21 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     references: ["../reference/veryfront/cli.md"],
     snippets: ["knowledge_ingest", "jq '.ingested'", "veryfront knowledge ingest"],
   },
+  "coding-agents.md": {
+    references: [
+      "../reference/veryfront/mcp.md",
+      "../reference/veryfront/cli.md",
+    ],
+    snippets: [
+      "veryfront mcp",
+      "veryfront dev",
+      "mcpServers",
+      "~/.claude.json",
+      "vf_get_errors",
+      "vf_scaffold",
+      "tools/list",
+    ],
+  },
   "choose-a-primitive.md": {
     references: [
       "../reference/veryfront/agent.md",
@@ -197,9 +212,9 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     ],
     snippets: [
       "agents/assistant.ts",
-      "import { agent } from \"veryfront/agent\"",
+      'import { agent } from "veryfront/agent"',
       "export async function POST(request: Request)",
-      "getAgent(\"assistant\")",
+      'getAgent("assistant")',
       "assistant.generate({ input: question })",
       "veryfront dev",
     ],


### PR DESCRIPTION
## Summary

- Adds `docs/guides/coding-agents.md` documenting how to connect MCP-aware coding agents (Claude Code, Cursor, Codex, etc.) to the Veryfront CLI's dev MCP server.
- Distinguishes the **CLI MCP** (dev tools like `vf_get_errors`, `vf_scaffold`, `vf_run_tests`, `vf_preview_route`) from the existing application-facing **`mcp-server.md`** (which exposes _your_ app's tools to MCP clients) — the two surfaces were being conflated.
- Covers both transports: HTTP (auto-starts on dev port + 2, default `3002`) and stdio (`veryfront mcp`).
- Provides per-client config blocks for Claude Code (`~/.claude.json`) and Cursor (settings UI), and a generic HTTP/stdio path for Codex and other MCP-aware clients.
- Lists the stable `vf_*` tool surface and points at `vf_get_schema` / `veryfront schema --json` as the canonical schema source.
- Slots the guide as **order 28** in the "Connect external systems" section. Bumps `extensions`, `extension-authoring`, `extension-lifecycle`, `extension-testing`, `extension-publishing` up by one, and `deploying` to 38 (last) to keep all orders unique on top of recent main additions.
- Adds a cross-link from `quickstart.md` so newcomers find the guide early.

## Why

The CLI's `veryfront mcp` and the auto-started HTTP MCP server are arguably the most leveraged features for a developer adopting Veryfront alongside an AI coding agent, but they were only documented via inline `--help` text and a one-line cross-reference inside `mcp-server.md`. New users were asking how to wire Claude Code up; this fills the gap.

## Test plan

- [x] `deno run --allow-read scripts/docs/validate-guides.ts` — 39 guides pass.
- [x] `deno run -A scripts/lint/check-doc-links.ts` — 843 doc links OK.
- [x] Pre-push hook (1900 tests) — pass.
- [x] Verified order uniqueness across all guides (0–38, no duplicates).
- [x] Verified the new guide is linked from `index.md` and from `quickstart.md` Related section.

## After merge

The sync workflow mirrors the new guide to `veryfront-docs/docs/code/guides/coding-agents.md`. The tool list in the guide intentionally avoids hardcoding every `vf_*` tool — it points readers at `veryfront schema --json` so the doc doesn't drift when the CLI gains tools.