### PR TITLE
Make agent service registration replica-safe

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.559",
+  "version": "0.1.560",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/service/config.test.ts
+++ b/src/agent/service/config.test.ts
@@ -67,6 +67,9 @@ describe("agent/agent-service-config", () => {
       VERYFRONT_AGENT_SERVICE_REGISTRATION: "enabled",
       VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS: "45000",
       VERYFRONT_AGENT_SERVICE_REGION: "iad",
+      POD_NAME: "veryfront-agent-7dd7b6f4d8-a1b2c",
+      POD_UID: "11111111-1111-4111-a111-111111111111",
+      POD_IP: "10.192.4.10",
     });
 
     assertEquals(config.VERYFRONT_API_URL, "https://api.example.com");
@@ -87,6 +90,9 @@ describe("agent/agent-service-config", () => {
     assertEquals(config.VERYFRONT_AGENT_SERVICE_REGISTRATION, "enabled");
     assertEquals(config.VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS, 45000);
     assertEquals(config.VERYFRONT_AGENT_SERVICE_REGION, "iad");
+    assertEquals(config.POD_NAME, "veryfront-agent-7dd7b6f4d8-a1b2c");
+    assertEquals(config.POD_UID, "11111111-1111-4111-a111-111111111111");
+    assertEquals(config.POD_IP, "10.192.4.10");
   });
 
   it("rejects invalid API URLs", () => {

--- a/src/agent/service/config.ts
+++ b/src/agent/service/config.ts
@@ -23,6 +23,9 @@ export type AgentServiceConfig = {
   VERYFRONT_AGENT_SERVICE_REGISTRATION: AgentServiceRegistrationMode;
   VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS: number;
   VERYFRONT_AGENT_SERVICE_REGION?: string;
+  POD_NAME?: string;
+  POD_UID?: string;
+  POD_IP?: string;
   VERYFRONT_STUDIO_MCP_URL: string;
   VERYFRONT_ENABLE_DURABLE_INVOKE_AGENT: boolean;
   VERYFRONT_ENABLE_DURABLE_TASK: boolean;
@@ -57,6 +60,9 @@ const getAgentServiceConfigSchema = defineSchema<AgentServiceConfig>((v) => {
     VERYFRONT_AGENT_SERVICE_REGISTRATION: agentServiceRegistrationModeInputSchema,
     VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS: v.coerce.number().positive().default(30_000),
     VERYFRONT_AGENT_SERVICE_REGION: v.string().min(1).max(128).optional(),
+    POD_NAME: v.string().min(1).max(128).optional(),
+    POD_UID: v.string().min(1).max(128).optional(),
+    POD_IP: v.string().min(1).max(128).optional(),
     NODE_ENV: v.enum(["development", "test", "production"] as const).default("development"),
     PORT: v.coerce.number().default(3001),
     OAUTH_PUBLIC_KEY: v.string().optional(),
@@ -77,6 +83,9 @@ const getAgentServiceConfigSchema = defineSchema<AgentServiceConfig>((v) => {
     VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS:
       env.VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS,
     VERYFRONT_AGENT_SERVICE_REGION: env.VERYFRONT_AGENT_SERVICE_REGION,
+    POD_NAME: env.POD_NAME,
+    POD_UID: env.POD_UID,
+    POD_IP: env.POD_IP,
     VERYFRONT_STUDIO_MCP_URL: env.VERYFRONT_STUDIO_MCP_URL,
     VERYFRONT_ENABLE_DURABLE_INVOKE_AGENT: env.VERYFRONT_ENABLE_DURABLE_INVOKE_AGENT,
     VERYFRONT_ENABLE_DURABLE_TASK: env.VERYFRONT_ENABLE_DURABLE_TASK,

--- a/src/agent/service/registration.test.ts
+++ b/src/agent/service/registration.test.ts
@@ -36,6 +36,24 @@ const serviceResponse = {
   },
 };
 
+function globalAgentServiceConfig(podIdentity: {
+  POD_NAME?: string;
+  POD_UID?: string;
+  POD_IP?: string;
+}) {
+  return {
+    VERYFRONT_API_URL: "https://api.example.com",
+    VERYFRONT_API_TOKEN: "token-1",
+    VERYFRONT_PROJECT_ID: undefined,
+    VERYFRONT_AGENT_SERVICE_URL: "https://veryfront-agent.veryfront-staging.svc.cluster.local",
+    VERYFRONT_AGENT_SERVICE_KEY: undefined,
+    VERYFRONT_AGENT_SERVICE_REGISTRATION: "enabled" as const,
+    VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS: 30_000,
+    VERYFRONT_AGENT_SERVICE_REGION: "iad",
+    ...podIdentity,
+  };
+}
+
 describe("agent/agent-service-registration", () => {
   it("resolves auto registration only when token and public service URL are present", async () => {
     const input = await resolveAgentServiceRegistrationInput({
@@ -65,6 +83,36 @@ describe("agent/agent-service-registration", () => {
     assertEquals(input?.version, "0.1.0");
     assertEquals(input?.runtime, "node");
     assertEquals(input?.serviceKey.startsWith("docs-agent:"), true);
+  });
+
+  it("derives distinct default service keys for Kubernetes replicas behind the same service URL", async () => {
+    const firstReplica = await resolveAgentServiceRegistrationInput({
+      config: globalAgentServiceConfig({
+        POD_NAME: "veryfront-agent-7dd7b6f4d8-a1b2c",
+        POD_UID: "11111111-1111-4111-a111-111111111111",
+        POD_IP: "10.192.4.10",
+      }),
+      serviceName: "veryfront-agent",
+      agentId: "veryfront",
+      version: "0.1.0",
+      runtime: "node",
+    });
+    const secondReplica = await resolveAgentServiceRegistrationInput({
+      config: globalAgentServiceConfig({
+        POD_NAME: "veryfront-agent-7dd7b6f4d8-d4e5f",
+        POD_UID: "22222222-2222-4222-a222-222222222222",
+        POD_IP: "10.192.4.11",
+      }),
+      serviceName: "veryfront-agent",
+      agentId: "veryfront",
+      version: "0.1.0",
+      runtime: "node",
+    });
+
+    assertEquals(firstReplica?.baseUrl, secondReplica?.baseUrl);
+    assertEquals(firstReplica?.serviceKey.startsWith("veryfront-agent:"), true);
+    assertEquals(secondReplica?.serviceKey.startsWith("veryfront-agent:"), true);
+    assertEquals(firstReplica?.serviceKey !== secondReplica?.serviceKey, true);
   });
 
   it("skips auto registration when the token or public URL is missing", async () => {

--- a/src/agent/service/registration.ts
+++ b/src/agent/service/registration.ts
@@ -14,6 +14,9 @@ export type AgentServiceRegistrationConfig = {
   VERYFRONT_AGENT_SERVICE_REGISTRATION: AgentServiceRegistrationMode;
   VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS: number;
   VERYFRONT_AGENT_SERVICE_REGION?: string;
+  POD_NAME?: string;
+  POD_UID?: string;
+  POD_IP?: string;
 };
 /** Input payload for resolved agent service registration. */
 export type ResolvedAgentServiceRegistrationInput = {
@@ -88,6 +91,9 @@ export const agentServiceRegistrationConfigSchema = lazySchema(
       VERYFRONT_AGENT_SERVICE_REGISTRATION: agentServiceRegistrationMode(v),
       VERYFRONT_AGENT_SERVICE_HEARTBEAT_INTERVAL_MS: v.number().positive(),
       VERYFRONT_AGENT_SERVICE_REGION: v.string().min(1).max(128).optional(),
+      POD_NAME: v.string().min(1).max(128).optional(),
+      POD_UID: v.string().min(1).max(128).optional(),
+      POD_IP: v.string().min(1).max(128).optional(),
     })
   ),
 );
@@ -225,6 +231,7 @@ async function stableServiceKey(input: {
   baseUrl: string;
   scopeKind: "global" | "project";
   projectId?: string;
+  podIdentity?: string;
 }): Promise<string> {
   const keySource = [
     input.serviceName,
@@ -232,6 +239,7 @@ async function stableServiceKey(input: {
     input.scopeKind,
     input.projectId ?? "global",
     input.baseUrl,
+    input.podIdentity ?? "no-pod-identity",
   ].join("|");
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(keySource));
   const hash = Array.from(new Uint8Array(digest))
@@ -276,12 +284,14 @@ export async function resolveAgentServiceRegistrationInput(
 
   const scopeKind = config.VERYFRONT_PROJECT_ID ? "project" : "global";
   const baseUrl = normalizeBaseUrl(serviceUrl);
+  const podIdentity = config.POD_UID ?? config.POD_NAME ?? config.POD_IP;
   const serviceKey = config.VERYFRONT_AGENT_SERVICE_KEY ?? await stableServiceKey({
     serviceName: options.serviceName,
     agentId: options.agentId,
     baseUrl,
     scopeKind,
     projectId: config.VERYFRONT_PROJECT_ID,
+    podIdentity,
   });
 
   return resolvedAgentServiceRegistrationInputSchema.parse({

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.559";
+export const VERSION = "0.1.560";


### PR DESCRIPTION
## Summary
- include Kubernetes pod identity in generated agent service keys
- preserve explicit service key override behavior
- bump framework package version to 0.1.560 so CI can publish an immutable artifact with the fix

## Verification
- deno fmt --check targeted files
- DENO_NO_PACKAGE_JSON=1 deno lint targeted files
- deno test --no-check --allow-all src/agent/service/registration.test.ts src/agent/service/config.test.ts src/utils/version.test.ts
- deno task build:npm and verified the built npm artifact contains POD_NAME/POD_UID/POD_IP handling
- pre-push: format, lint, typecheck, unit tests (1900 passed)