### PR TITLE
Load project skills from source paths

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.560",
+  "version": "0.1.561",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/project/steering-mutation.test.ts
+++ b/src/agent/project/steering-mutation.test.ts
@@ -38,6 +38,23 @@ Deno.test("getProjectSteeringMutation detects skill directory moves", () => {
         project_reference: "project-1",
         branch_id: "branch-1",
         source_path: "src/old.ts",
+        destination_path: "skills/react/SKILL.md",
+      },
+      activeProjectId: "project-1",
+      activeBranchId: "branch-1",
+    }),
+    { instructionsChanged: false, skillsChanged: true },
+  );
+});
+
+Deno.test("getProjectSteeringMutation detects legacy hidden skill directory moves", () => {
+  assertEquals(
+    getProjectSteeringMutation({
+      toolName: "move_file",
+      toolInput: {
+        project_reference: "project-1",
+        branch_id: "branch-1",
+        source_path: "src/old.ts",
         destination_path: ".veryfront/skills/react/SKILL.md",
       },
       activeProjectId: "project-1",

--- a/src/agent/project/steering-mutation.ts
+++ b/src/agent/project/steering-mutation.ts
@@ -1,7 +1,7 @@
 /** Default value for project steering paths. */
 export const DEFAULT_PROJECT_STEERING_PATHS = {
   instructions: ["AGENTS.md"],
-  skills: [".veryfront/skills"],
+  skills: ["skills", ".veryfront/skills"],
 } as const;
 
 /** Shared project steering file mutation tool names value. */

--- a/src/agent/runtime/project-skill-catalog.test.ts
+++ b/src/agent/runtime/project-skill-catalog.test.ts
@@ -115,11 +115,11 @@ Deno.test("getRuntimeProjectSkillCatalog returns builtin skills when project fil
 Deno.test("getRuntimeProjectSkillCatalog parses project directory skills and references", async () => {
   const { catalog, filesCalls, fileCalls } = createSkillCatalog({
     paths: [
-      ".veryfront/skills/research/SKILL.md",
-      ".veryfront/skills/research/references/checklists/checklist.md",
+      "skills/research/SKILL.md",
+      "skills/research/references/checklists/checklist.md",
     ],
     contentsByPath: {
-      ".veryfront/skills/research/SKILL.md":
+      "skills/research/SKILL.md":
         "---\ndescription: Research deeply\nmodel: sonnet\nthinking: false\nmax-steps: 7\nallowed-tools:\n  - bash\n---\n\n# Research",
     },
   });
@@ -138,7 +138,7 @@ Deno.test("getRuntimeProjectSkillCatalog parses project directory skills and ref
   assertEquals(fileCalls, [
     {
       ...PROJECT_CONTEXT,
-      path: ".veryfront/skills/research/SKILL.md",
+      path: "skills/research/SKILL.md",
     },
   ]);
 });
@@ -163,15 +163,14 @@ Deno.test("getRuntimeProjectSkillCatalog prefers directory skills and lets proje
   const { catalog } = createSkillCatalog({
     builtinSkills,
     paths: [
-      ".veryfront/skills/shared.md",
-      ".veryfront/skills/shared/SKILL.md",
-      ".veryfront/skills/zeta.md",
+      "skills/shared.md",
+      "skills/shared/SKILL.md",
+      "skills/zeta.md",
     ],
     contentsByPath: {
-      ".veryfront/skills/shared.md": "---\ndescription: Flat shared\n---\n\n# Shared flat",
-      ".veryfront/skills/shared/SKILL.md":
-        "---\ndescription: Directory shared\n---\n\n# Shared directory",
-      ".veryfront/skills/zeta.md": "---\ndescription: Zeta\n---\n\n# Zeta",
+      "skills/shared.md": "---\ndescription: Flat shared\n---\n\n# Shared flat",
+      "skills/shared/SKILL.md": "---\ndescription: Directory shared\n---\n\n# Shared directory",
+      "skills/zeta.md": "---\ndescription: Zeta\n---\n\n# Zeta",
     },
   });
 
@@ -181,4 +180,18 @@ Deno.test("getRuntimeProjectSkillCatalog prefers directory skills and lets proje
   assertExists(shared);
   assertEquals(shared.description, "Directory shared");
   assertEquals(skills.map((skill) => skill.id), ["alpha", "shared", "zeta"]);
+});
+
+Deno.test("getRuntimeProjectSkillCatalog still parses legacy hidden project skills", async () => {
+  const { catalog, fileCalls } = createSkillCatalog({
+    paths: [".veryfront/skills/legacy/SKILL.md"],
+    contentsByPath: {
+      ".veryfront/skills/legacy/SKILL.md": "---\ndescription: Legacy\n---\n\n# Legacy",
+    },
+  });
+
+  const skills = await catalog();
+
+  assertEquals(skills.map((skill) => skill.id), ["legacy"]);
+  assertEquals(fileCalls.map((call) => call.path), [".veryfront/skills/legacy/SKILL.md"]);
 });

--- a/src/agent/runtime/project-skill-loader.test.ts
+++ b/src/agent/runtime/project-skill-loader.test.ts
@@ -67,12 +67,12 @@ Deno.test("runtime project skill loader returns empty results without project co
 Deno.test("runtime project skill loader loads directory skills with normalized sorted references", async () => {
   const { loader } = createLoader({
     getProjectFile: async ({ path }) =>
-      path === ".veryfront/skills/research/SKILL.md" ? { path, content: "# Research" } : null,
+      path === "skills/research/SKILL.md" ? { path, content: "# Research" } : null,
     getProjectFiles: async () => [
-      { path: ".veryfront/skills/research/references/zeta.md" },
-      { path: ".veryfront/skills/research/references/checklists/checklist.md" },
-      { path: ".veryfront/skills/other/references/skip.md" },
-      { path: ".veryfront/skills/research/references//invalid.md" },
+      { path: "skills/research/references/zeta.md" },
+      { path: "skills/research/references/checklists/checklist.md" },
+      { path: "skills/other/references/skip.md" },
+      { path: "skills/research/references//invalid.md" },
     ],
   });
 
@@ -82,10 +82,36 @@ Deno.test("runtime project skill loader loads directory skills with normalized s
   });
 });
 
+Deno.test("runtime project skill loader isolates references to the selected skill source path", async () => {
+  const { loader } = createLoader({
+    getProjectFile: async ({ path }) =>
+      path === "skills/research/SKILL.md"
+        ? { path, content: "# Research" }
+        : path === ".veryfront/skills/research/SKILL.md"
+        ? { path, content: "# Legacy research" }
+        : null,
+    getProjectFiles: async () => [
+      { path: "skills/research/SKILL.md" },
+      { path: "skills/research/references/current.md" },
+      { path: ".veryfront/skills/research/SKILL.md" },
+      { path: ".veryfront/skills/research/references/stale.md" },
+    ],
+  });
+
+  assertEquals(await loader.loadProjectSkill(PROJECT_CONTEXT, "research"), {
+    instructions: "# Research",
+    references: ["references/current.md"],
+  });
+  assertEquals(
+    await loader.listProjectSkillReferences(PROJECT_CONTEXT, "research"),
+    ["references/current.md"],
+  );
+});
+
 Deno.test("runtime project skill loader falls back to flat project skills without references", async () => {
   const { loader, fileCalls } = createLoader({
     getProjectFile: async ({ path }) =>
-      path === ".veryfront/skills/custom.md" ? { path, content: "# Custom" } : null,
+      path === "skills/custom.md" ? { path, content: "# Custom" } : null,
   });
 
   assertEquals(await loader.loadProjectSkill(PROJECT_CONTEXT, "custom"), {
@@ -93,15 +119,17 @@ Deno.test("runtime project skill loader falls back to flat project skills withou
     references: [],
   });
   assertEquals(fileCalls.map((call) => call.path), [
-    ".veryfront/skills/custom/SKILL.md",
-    ".veryfront/skills/custom.md",
+    "skills/custom/SKILL.md",
+    "skills/custom.md",
   ]);
 });
 
 Deno.test("runtime project skill loader loads project skill reference content", async () => {
   const { loader } = createLoader({
     getProjectFile: async ({ path }) =>
-      path === ".veryfront/skills/research/references/guide.md"
+      path === "skills/research/SKILL.md"
+        ? { path, content: "# Research" }
+        : path === "skills/research/references/guide.md"
         ? { path, content: "# Guide" }
         : null,
   });
@@ -110,6 +138,39 @@ Deno.test("runtime project skill loader loads project skill reference content", 
     await loader.loadProjectSkillReference(PROJECT_CONTEXT, "research", "references/guide.md"),
     "# Guide",
   );
+});
+
+Deno.test("runtime project skill loader does not load stale legacy references for a source skill", async () => {
+  const { loader } = createLoader({
+    getProjectFile: async ({ path }) =>
+      path === "skills/research/SKILL.md"
+        ? { path, content: "# Research" }
+        : path === ".veryfront/skills/research/references/stale.md"
+        ? { path, content: "# Stale" }
+        : null,
+  });
+
+  assertEquals(
+    await loader.loadProjectSkillReference(PROJECT_CONTEXT, "research", "references/stale.md"),
+    null,
+  );
+});
+
+Deno.test("runtime project skill loader still loads legacy hidden skills", async () => {
+  const { loader, fileCalls } = createLoader({
+    getProjectFile: async ({ path }) =>
+      path === ".veryfront/skills/legacy/SKILL.md" ? { path, content: "# Legacy" } : null,
+  });
+
+  assertEquals(await loader.loadProjectSkill(PROJECT_CONTEXT, "legacy"), {
+    instructions: "# Legacy",
+    references: [],
+  });
+  assertEquals(fileCalls.map((call) => call.path), [
+    "skills/legacy/SKILL.md",
+    "skills/legacy.md",
+    ".veryfront/skills/legacy/SKILL.md",
+  ]);
 });
 
 Deno.test("runtime project skill loader returns null and logs when lookup is denied", async () => {

--- a/src/agent/runtime/project-skill-loader.ts
+++ b/src/agent/runtime/project-skill-loader.ts
@@ -67,13 +67,88 @@ function isAccessDeniedError(
   return options.isAccessDeniedError?.(error) ?? false;
 }
 
+type ProjectSkillSource =
+  | { kind: "directory"; skillsPath: string }
+  | { kind: "flat"; skillsPath: string };
+
+async function findProjectSkillSource(input: {
+  options: RuntimeProjectSkillLoaderOptions;
+  context: RuntimeProjectSkillContext;
+  skillId: string;
+}): Promise<ProjectSkillSource | null> {
+  const projectId = input.context.projectId;
+  if (!projectId) {
+    return null;
+  }
+
+  for (const skillsPath of getSkillPaths(input.options)) {
+    const directorySkill = await input.options.getProjectFile({
+      projectId,
+      authToken: input.context.authToken,
+      branchId: input.context.branchId,
+      path: `${skillsPath}/${input.skillId}/SKILL.md`,
+    });
+    if (directorySkill?.content) {
+      return { kind: "directory", skillsPath };
+    }
+
+    const flatSkill = await input.options.getProjectFile({
+      projectId,
+      authToken: input.context.authToken,
+      branchId: input.context.branchId,
+      path: `${skillsPath}/${input.skillId}.md`,
+    });
+    if (flatSkill?.content) {
+      return { kind: "flat", skillsPath };
+    }
+  }
+
+  return null;
+}
+
+function collectProjectSkillReferences(input: {
+  allFiles: readonly RuntimeProjectFileListItem[];
+  skillsPath: string;
+  skillId: string;
+}): string[] {
+  const skillPrefix = `${input.skillsPath}/${input.skillId}/`;
+  const refsPrefix = `${skillPrefix}references/`;
+  const references = new Set<string>();
+
+  for (const file of input.allFiles) {
+    if (!file.path.startsWith(refsPrefix)) {
+      continue;
+    }
+
+    const relativePath = file.path.slice(skillPrefix.length);
+    if (!relativePath.includes("/")) {
+      continue;
+    }
+
+    const normalizedReference = normalizeRuntimeSkillReferencePath(relativePath);
+    if (normalizedReference) {
+      references.add(normalizedReference);
+    }
+  }
+
+  return [...references].sort();
+}
+
 async function listProjectSkillReferences(input: {
   options: RuntimeProjectSkillLoaderOptions;
   context: RuntimeProjectSkillContext;
   skillId: string;
+  skillsPath?: string;
 }): Promise<string[]> {
   const projectId = input.context.projectId;
   if (!projectId) {
+    return [];
+  }
+
+  const source: ProjectSkillSource | null = input.skillsPath
+    ? { kind: "directory", skillsPath: input.skillsPath }
+    : await findProjectSkillSource(input);
+  if (source?.kind !== "directory") {
     return [];
   }
 
@@ -82,30 +157,12 @@ async function listProjectSkillReferences(input: {
     authToken: input.context.authToken,
     branchId: input.context.branchId,
   });
-  const references = new Set<string>();
 
-  for (const skillsPath of getSkillPaths(input.options)) {
-    const skillPrefix = `${skillsPath}/${input.skillId}/`;
-    const refsPrefix = `${skillPrefix}references/`;
-
-    for (const file of allFiles) {
-      if (!file.path.startsWith(refsPrefix)) {
-        continue;
-      }
-
-      const relativePath = file.path.slice(skillPrefix.length);
-      if (!relativePath.includes("/")) {
-        continue;
-      }
-
-      const normalizedReference = normalizeRuntimeSkillReferencePath(relativePath);
-      if (normalizedReference) {
-        references.add(normalizedReference);
-      }
-    }
-  }
-
-  return [...references].sort();
+  return collectProjectSkillReferences({
+    allFiles,
+    skillsPath: source.skillsPath,
+    skillId: input.skillId,
+  });
 }
 
 async function loadProjectSkill(input: {
@@ -130,7 +187,7 @@ async function loadProjectSkill(input: {
       if (directorySkill?.content) {
         return {
           instructions: directorySkill.content,
-          references: await listProjectSkillReferences(input),
+          references: await listProjectSkillReferences({ ...input, skillsPath }),
         };
       }
 
@@ -179,16 +236,19 @@ async function loadProjectSkillReference(input: {
   }
 
   try {
-    for (const skillsPath of getSkillPaths(input.options)) {
-      const projectFile = await input.options.getProjectFile({
-        projectId,
-        authToken: input.context.authToken,
-        branchId: input.context.branchId,
-        path: `${skillsPath}/${input.skillId}/${input.normalizedFile}`,
-      });
-      if (projectFile?.content) {
-        return projectFile.content;
-      }
+    const source = await findProjectSkillSource(input);
+    if (source?.kind !== "directory") {
+      return null;
+    }
+
+    const projectFile = await input.options.getProjectFile({
+      projectId,
+      authToken: input.context.authToken,
+      branchId: input.context.branchId,
+      path: `${source.skillsPath}/${input.skillId}/${input.normalizedFile}`,
+    });
+    if (projectFile?.content) {
+      return projectFile.content;
     }
   } catch (error) {
     if (!isAccessDeniedError(error, input.options)) {

--- a/src/tool/factory.test.ts
+++ b/src/tool/factory.test.ts
@@ -76,6 +76,19 @@ describe("tool factory", () => {
       assertEquals(t.inputSchemaJson?.required?.includes("age"), true);
     });
 
+    it("should preserve an output schema and converted JSON schema", () => {
+      const t = tool({
+        id: "output-schema-test",
+        description: "desc",
+        inputSchema: defineSchema((v) => v.object({ query: v.string() }))(),
+        outputSchema: defineSchema((v) => v.object({ result: v.string() }))(),
+        execute: async () => ({ result: "ok" }),
+      });
+
+      assertEquals(t.outputSchemaJson?.type, "object");
+      assertEquals(t.outputSchemaJson?.properties?.result, { type: "string" });
+    });
+
     it("should introspect schema-like objects by shape", () => {
       const t = tool({
         id: "shape-test",

--- a/src/tool/factory.ts
+++ b/src/tool/factory.ts
@@ -165,6 +165,14 @@ export function tool<TInput = unknown, TOutput = unknown>(
     "TOOL",
     config.allowUnknownSchema ?? false,
   );
+  const outputSchemaJson = config.outputSchema
+    ? convertSchemaToJson(
+      config.outputSchema,
+      id,
+      "TOOL_OUTPUT",
+      config.allowUnknownSchema ?? false,
+    )
+    : undefined;
 
   const createdTool: Tool<TInput, TOutput> = {
     id,
@@ -172,6 +180,8 @@ export function tool<TInput = unknown, TOutput = unknown>(
     description: config.description,
     inputSchema: config.inputSchema,
     inputSchemaJson,
+    outputSchema: config.outputSchema,
+    outputSchemaJson,
     execute: async (input: TInput, context?: ToolExecutionContext) => {
       if (hasSchemaParse(config.inputSchema)) {
         try {

--- a/src/tool/types.ts
+++ b/src/tool/types.ts
@@ -25,6 +25,12 @@ export interface ToolConfig<TInput = any, TOutput = any> {
   inputSchema: Schema<TInput>;
 
   /**
+   * Optional output schema. Hosts can use this to document or validate
+   * structured tool results.
+   */
+  outputSchema?: Schema<TOutput>;
+
+  /**
    * Allow unknown/non-contract schemas to fall back to a permissive JSON
    * schema. Use only for truly dynamic tools; prefer `v.unknown()` or
    * `v.any()` from the SchemaValidator DSL instead.
@@ -131,6 +137,12 @@ export interface Tool<TInput = any, TOutput = any> {
    * This is generated at tool creation time to avoid bundling issues
    */
   inputSchemaJson?: JsonSchema;
+
+  /** Optional pre-converted JSON Schema for tool outputs. */
+  outputSchemaJson?: JsonSchema;
+
+  /** Optional output schema produced by `defineSchema`. */
+  outputSchema?: Schema<TOutput>;
 
   /**
    * Execute the tool

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.560";
+export const VERSION = "0.1.561";


### PR DESCRIPTION
## Summary
- Load project skills from `skills/<id>/SKILL.md` source paths, while preserving legacy hidden-skill fallback behavior.
- Track skill-file mutations in project steering refresh logic.
- Include pending jobs/tool schema updates already present on this branch.

## Test Plan
- deno test --no-check --allow-all src/agent/project/steering-mutation.test.ts src/agent/runtime/project-skill-catalog.test.ts src/agent/runtime/project-skill-loader.test.ts src/jobs/jobs-client.test.ts src/tool/factory.test.ts
- deno check src/index.ts
- git diff --check origin/main...HEAD
- pre-push hook: format, lint, typecheck, unit tests