### PR TITLE
Send canonical durable agent run create requests

### DIFF
--- a/src/agent/conversation/bootstrap.test.ts
+++ b/src/agent/conversation/bootstrap.test.ts
@@ -370,7 +370,7 @@ describe("agent/conversation-bootstrap", () => {
       },
       public_id: "run_child_targeted",
       request: {
-        mode: "default_chat",
+        mode: "agent",
         agent_id: "invoke-agent-child",
         initial_status: "running",
         source_target_kind: "preview_branch",

--- a/src/agent/conversation/durable.test.ts
+++ b/src/agent/conversation/durable.test.ts
@@ -157,7 +157,7 @@ describe("agent/durable", () => {
         },
         public_id: "run_root_1",
         request: {
-          mode: "default_chat",
+          mode: "agent",
           agent_id: "default-chat",
           initial_status: "running",
         },
@@ -198,7 +198,7 @@ describe("agent/durable", () => {
         },
         public_id: "run_child_1",
         request: {
-          mode: "default_chat",
+          mode: "agent",
           agent_id: "invoke-agent-child",
           initial_status: "running",
           source_target_kind: "preview_branch",

--- a/src/agent/conversation/durable.ts
+++ b/src/agent/conversation/durable.ts
@@ -1370,7 +1370,7 @@ export async function createConversationAgentRun(
         : {}),
     }
     : {
-      mode: "default_chat" as const,
+      mode: "agent" as const,
       agent_id: input.agentId,
       initial_status: "running" as const,
       ...(targets.sourceTargetKind ? { source_target_kind: targets.sourceTargetKind } : {}),

--- a/src/agent/hosted/child-bootstrap.test.ts
+++ b/src/agent/hosted/child-bootstrap.test.ts
@@ -152,7 +152,7 @@ describe("agent/hosted-child-bootstrap", () => {
       },
       public_id: "run_child_1",
       request: {
-        mode: "default_chat",
+        mode: "agent",
         agent_id: "invoke-agent-child",
         initial_status: "running",
         source_target_kind: "preview_branch",

--- a/src/agent/hosted/durable-child-fork-execution.test.ts
+++ b/src/agent/hosted/durable-child-fork-execution.test.ts
@@ -568,7 +568,7 @@ describe("agent/hosted-durable-child-fork-execution", () => {
       },
       public_id: getPublicId(createRunBody),
       request: {
-        mode: "default_chat",
+        mode: "agent",
         agent_id: "invoke-agent-child",
         initial_status: "running",
         source_target_kind: "preview_branch",

--- a/src/agent/testing/durable-run-canaries/runner.test.ts
+++ b/src/agent/testing/durable-run-canaries/runner.test.ts
@@ -245,7 +245,7 @@ describe("agent testing durable run canary runner", () => {
         owner: { kind: "conversation", id: conversationId },
         public_id: "run_1",
         request: {
-          mode: "default_chat",
+          mode: "agent",
           agent_id: "agent-b",
           initial_status: "pending",
           source_target_kind: "preview_branch",
@@ -266,7 +266,7 @@ describe("agent testing durable run canary runner", () => {
       owner: { kind: "conversation", id: conversationId },
       public_id: "run_1",
       request: {
-        mode: "default_chat",
+        mode: "agent",
         agent_id: "agent-b",
         input: {
           messages: [
@@ -329,7 +329,7 @@ describe("agent testing durable run canary runner", () => {
         owner: { kind: "conversation", id: conversationId },
         public_id: "run_1",
         request: {
-          mode: "default_chat",
+          mode: "agent",
           agent_id: "agent-b",
           initial_status: "pending",
           source_target_kind: "project",

--- a/src/agent/testing/durable-run-canaries/runner.ts
+++ b/src/agent/testing/durable-run-canaries/runner.ts
@@ -199,7 +199,7 @@ function buildCreateRootRunBody(
     },
     public_id: input.runId,
     request: {
-      mode: "default_chat",
+      mode: "agent",
       agent_id: config.agentId,
       initial_status: "pending",
       ...buildCreateRootRunTargetFields(config),
@@ -219,7 +219,7 @@ function buildStartRunBody(
     },
     public_id: input.runId,
     request: {
-      mode: "default_chat",
+      mode: "agent",
       agent_id: config.agentId,
       input: {
         messages: [


### PR DESCRIPTION
## Summary
- Updates Code durable conversation creation to send `request.mode: "agent"` for hosted/default durable agent runs.
- Updates durable run canaries and behavior-test expectations to match the canonical runs API.
- Leaves runtime-worker agent requests unchanged; they already used the canonical `agent` mode.

## Coordination
Pair with the API PR that removes `default_chat` / `project_agent` run-create request modes and the Studio PR that updates hosted agent callers.

## Verification
- `deno test --no-check --allow-all src/agent/conversation/durable.test.ts src/agent/conversation/bootstrap.test.ts src/agent/testing/durable-run-canaries/runner.test.ts src/agent/hosted/durable-child-fork-execution.test.ts src/agent/hosted/child-bootstrap.test.ts`
- `deno fmt --check src/agent/conversation/durable.ts src/agent/conversation/durable.test.ts src/agent/conversation/bootstrap.test.ts src/agent/hosted/child-bootstrap.test.ts src/agent/hosted/durable-child-fork-execution.test.ts src/agent/testing/durable-run-canaries/runner.ts src/agent/testing/durable-run-canaries/runner.test.ts`
- `deno lint src/agent/conversation/durable.ts src/agent/testing/durable-run-canaries/runner.ts`
- Pre-push checks: format, lint, type check, and Deno unit tests passed (`1900 passed`, `17544 steps`).
- Cross-repo grep found no run-create request bodies with `mode: "default_chat"` or `mode: "project_agent"` in API, Studio, Code, or Agent.

## Note
Earlier checked focused Deno tests showed unrelated type errors in existing test files; the repository pre-push type check passed before push.