### PR TITLE
fix(confluence): migrate page CRUD to Confluence v2 REST API

### DIFF
--- a/cli/templates/integrations/confluence/files/lib/confluence-client.ts
+++ b/cli/templates/integrations/confluence/files/lib/confluence-client.ts
@@ -26,7 +26,7 @@ export interface ConfluenceSpace {
 
 export interface ConfluencePage {
   id: string;
-  type: "page" | "blogpost";
+  type?: "page" | "blogpost";
   status: string;
   title: string;
   spaceId?: string;
@@ -126,6 +126,15 @@ export async function listSpaces(options?: {
   return response.results ?? [];
 }
 
+async function getSpaceIdByKey(spaceKey: string): Promise<string> {
+  const spaces = await listSpaces({ limit: 250 });
+  const space = spaces.find((s) => s.key === spaceKey);
+  if (!space) {
+    throw new Error(`Confluence space not found: ${spaceKey}`);
+  }
+  return space.id;
+}
+
 export async function searchContent(
   query: string,
   options?: {
@@ -149,44 +158,43 @@ export async function searchContent(
   return response.results ?? [];
 }
 
-export function getPage(pageId: string, expand?: string[]): Promise<ConfluencePage> {
-  const params = new URLSearchParams();
-  if (expand?.length) params.set("expand", expand.join(","));
-
-  return confluenceFetch<ConfluencePage>(buildEndpoint(`/wiki/rest/api/content/${pageId}`, params));
+// Uses Confluence v2 API — v1 /wiki/rest/api/content is deprecated and returns 410 on newer instances
+export function getPage(pageId: string, _expand?: string[]): Promise<ConfluencePage> {
+  return confluenceFetch<ConfluencePage>(`/wiki/api/v2/pages/${pageId}?body-format=storage`);
 }
 
 export function getPageContent(pageId: string): Promise<ConfluencePage> {
-  return getPage(pageId, ["body.storage", "body.view", "version", "space"]);
+  return getPage(pageId);
 }
 
-export function createPage(options: {
+export async function createPage(options: {
   spaceKey: string;
   title: string;
   content: string;
   parentId?: string;
   type?: "page" | "blogpost";
 }): Promise<ConfluencePage> {
-  const body = {
-    type: options.type ?? "page",
+  const spaceId = await getSpaceIdByKey(options.spaceKey);
+
+  const body: Record<string, unknown> = {
+    spaceId,
     title: options.title,
-    space: { key: options.spaceKey },
+    status: "current",
     body: {
-      storage: {
-        value: options.content,
-        representation: "storage" as const,
-      },
+      representation: "storage",
+      value: options.content,
     },
-    ...(options.parentId ? { ancestors: [{ id: options.parentId }] } : {}),
   };
 
-  return confluenceFetch<ConfluencePage>("/wiki/rest/api/content", {
+  if (options.parentId) body.parentId = options.parentId;
+
+  return confluenceFetch<ConfluencePage>("/wiki/api/v2/pages", {
     method: "POST",
     body: JSON.stringify(body),
   });
 }
 
-export async function updatePage(
+export function updatePage(
   pageId: string,
   options: {
     title?: string;
@@ -195,28 +203,25 @@ export async function updatePage(
     versionMessage?: string;
   },
 ): Promise<ConfluencePage> {
-  await getPage(pageId, ["version"]);
-
   const body: Record<string, unknown> = {
+    id: pageId,
+    status: "current",
     version: {
       number: options.version,
       message: options.versionMessage,
     },
-    type: "page",
   };
 
   if (options.title) body.title = options.title;
 
   if (options.content) {
     body.body = {
-      storage: {
-        value: options.content,
-        representation: "storage",
-      },
+      representation: "storage",
+      value: options.content,
     };
   }
 
-  return confluenceFetch<ConfluencePage>(`/wiki/rest/api/content/${pageId}`, {
+  return confluenceFetch<ConfluencePage>(`/wiki/api/v2/pages/${pageId}`, {
     method: "PUT",
     body: JSON.stringify(body),
   });

--- a/cli/templates/integrations/confluence/files/tools/create-page.ts
+++ b/cli/templates/integrations/confluence/files/tools/create-page.ts
@@ -42,7 +42,7 @@ export default tool({
     return {
       id: page.id,
       title: page.title,
-      type: page.type,
+      type: page.type ?? "page",
       url: page._links.webui,
       version: page.version.number,
       spaceId: page.spaceId,

--- a/cli/templates/integrations/confluence/files/tools/get-page.ts
+++ b/cli/templates/integrations/confluence/files/tools/get-page.ts
@@ -17,7 +17,7 @@ export default tool({
 
     return {
       id: page.id,
-      type: page.type,
+      type: page.type ?? "page",
       title: page.title,
       content,
       htmlContent,

--- a/cli/templates/integrations/confluence/files/tools/update-page.ts
+++ b/cli/templates/integrations/confluence/files/tools/update-page.ts
@@ -44,7 +44,7 @@ export default tool({
     return {
       id: updatedPage.id,
       title: updatedPage.title,
-      type: updatedPage.type,
+      type: updatedPage.type ?? "page",
       url: updatedPage._links.webui,
       version: updatedPage.version.number,
       versionMessage: updatedPage.version.message,


### PR DESCRIPTION
## Summary

- The v1 `/wiki/rest/api/content` endpoint returns **410 Gone** on newer Atlassian cloud instances, breaking `create_page` and `update_page` tools
- Migrate `getPage`, `createPage`, and `updatePage` to Confluence v2 API (`/wiki/api/v2/pages`)
- Add `getSpaceIdByKey` helper to resolve `spaceKey→spaceId` (required by v2 create endpoint)
- Keep `listSpaces` and `searchContent` on v1 (still functional, confirmed in testing)
- Remove redundant `getPage` call inside `updatePage` (tool layer already manages version)
- Add `?? "page"` fallback for `type` field (v2 API does not return it)

## Fixes

Closes #4059

## Test plan

- [ ] `list_spaces` — returns accessible spaces
- [ ] `search_content` — finds pages by keyword
- [ ] `get_page` — retrieves page content via v2
- [ ] `create_page` — creates a new page via v2 (resolves spaceKey to spaceId)
- [ ] `update_page` — updates page content/title via v2