### PR TITLE
fix(chat): pass through role:tool messages in convertUiMessagesToProviderModelMessages

### DIFF
--- a/src/chat/conversation.test.ts
+++ b/src/chat/conversation.test.ts
@@ -281,4 +281,93 @@ describe("convertUiMessagesToProviderModelMessages", () => {
       true,
     );
   });
+
+  it("passes through pre-split role:tool messages from normalized replay history", () => {
+    const messages: ChatUiMessage[] = [
+      {
+        id: "message-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool_call",
+            id: "tool-1",
+            name: "github__get_pr_diff",
+            input: { repo: "api", owner: "veryfront", pull_number: 1 },
+            state: "completed",
+          },
+          {
+            type: "tool_call",
+            id: "tool-2",
+            name: "github__list_prs",
+            input: { repo: "api", owner: "veryfront" },
+            state: "completed",
+          },
+        ],
+      },
+      {
+        id: "message-1:tool:tool-1",
+        role: "tool",
+        parts: [
+          {
+            type: "tool_result",
+            tool_call_id: "tool-1",
+            tool_name: "github__get_pr_diff",
+            output: { error: "authentication_required" },
+          },
+          {
+            type: "tool_result",
+            tool_call_id: "tool-2",
+            tool_name: "github__list_prs",
+            output: { error: "authentication_required" },
+          },
+        ],
+      },
+      {
+        id: "message-1:after-tool:1",
+        role: "assistant",
+        parts: [{ type: "text", text: "I don't have GitHub access." }],
+      },
+    ];
+
+    assertEquals(convertUiMessagesToProviderModelMessages(messages), [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "tool-1",
+            toolName: "github__get_pr_diff",
+            input: { repo: "api", owner: "veryfront", pull_number: 1 },
+          },
+          {
+            type: "tool-call",
+            toolCallId: "tool-2",
+            toolName: "github__list_prs",
+            input: { repo: "api", owner: "veryfront" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tool-1",
+            toolName: "github__get_pr_diff",
+            output: { type: "json", value: { error: "authentication_required" } },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tool-2",
+            toolName: "github__list_prs",
+            output: { type: "json", value: { error: "authentication_required" } },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "I don't have GitHub access." }],
+      },
+    ]);
+  });
 });

--- a/src/chat/conversation.ts
+++ b/src/chat/conversation.ts
@@ -1,6 +1,11 @@
 import { defineSchema, lazySchema } from "#veryfront/schemas/index.ts";
 import type { InferSchema } from "#veryfront/extensions/schema/index.ts";
-import type { ChatUiMessage, ChatUiMessagePart, ProviderModelMessage } from "./types.ts";
+import type {
+  ChatToolResultPart,
+  ChatUiMessage,
+  ChatUiMessagePart,
+  ProviderModelMessage,
+} from "./types.ts";
 
 /** Zod schema for get message part. */
 export const getMessagePartSchema = defineSchema((v) =>
@@ -962,6 +967,31 @@ function convertAssistantMessage(message: ChatUiMessage): ProviderModelMessage[]
   return messages;
 }
 
+function convertToolMessage(message: ChatUiMessage): ProviderModelMessage[] {
+  const rawToolNameMap = buildRawToolNameMap(message.parts);
+  const toolResults: ChatToolResultPart[] = [];
+
+  for (const part of message.parts) {
+    const rawResult = getRawToolResultPart(part);
+    if (!rawResult) {
+      continue;
+    }
+
+    toolResults.push({
+      type: "tool-result",
+      toolCallId: rawResult.toolCallId,
+      toolName: rawResult.toolName ?? rawToolNameMap.get(rawResult.toolCallId) ?? "unknown",
+      output: rawResult.output,
+    });
+  }
+
+  if (toolResults.length === 0) {
+    return [];
+  }
+
+  return [{ role: "tool", content: toolResults }];
+}
+
 /** Convert UI messages to provider model messages. */
 export function convertUiMessagesToProviderModelMessages(
   messages: ChatUiMessage[],
@@ -974,6 +1004,8 @@ export function convertUiMessagesToProviderModelMessages(
         return convertUserMessage(message);
       case "assistant":
         return convertAssistantMessage(message);
+      case "tool":
+        return convertToolMessage(message);
       default:
         return [];
     }

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -65,7 +65,7 @@ const INLINE_BINARY_MEDIA_TYPE = "application/octet-stream";
 const INLINE_PDF_MEDIA_TYPE = "application/pdf";
 
 /** Public API contract for chat UI message role. */
-export type ChatUiMessageRole = "system" | "user" | "assistant";
+export type ChatUiMessageRole = "system" | "user" | "assistant" | "tool";
 
 /** Public API contract for chat text UI part. */
 export type ChatTextUiPart = {


### PR DESCRIPTION
## Problem

When an agent makes parallel tool calls (e.g. two GitHub tools at once), `normalizeConversationMessagesForRuntimeReplay` in `veryfront-api` splits the stored interleaved pairs into separate `role: "tool"` messages for the Anthropic replay.

`convertUiMessagesToProviderModelMessages` in this repo had `default: return []` in its switch, silently dropping those `role: "tool"` messages before they reached the provider — causing the "AI provider returned an error" failure.

## Fix

Add `convertToolMessage` to handle `role: "tool"` messages by mapping `tool_result` parts to `ChatToolResultPart[]` and emitting a `{ role: "tool", content: [...] }` provider message.

Add `case "tool":` to the switch in `convertUiMessagesToProviderModelMessages`.

## Test

New test case: "passes through pre-split role:tool messages from normalized replay history" covers the full round-trip of a parallel-tool-call conversation (assistant with parallel `tool_call` parts → combined `role:tool` message → follow-up assistant message) through `convertUiMessagesToProviderModelMessages`.

## Related

Companion fix in `veryfront-api`: batch-aware rewrite of `normalizeConversationMessagesForRuntimeReplay` to group parallel tool calls into a single Anthropic turn.