### PR TITLE
docs(guides): renumber frontmatter order to match index.md reading order

### DIFF
--- a/docs/guides/agent-service-runtime.md
+++ b/docs/guides/agent-service-runtime.md
@@ -1,7 +1,7 @@
 ---
 title: "Agent service runtime"
 description: "Run Veryfront agents as separately deployed services."
-order: 11
+order: 15
 ---
 
 An agent service runs your agent as its own process, independent of the app server. Use it when you need a separate process boundary, direct control-plane registration, remote MCP tools, or service-level telemetry. Use a normal in-app route for everything else.

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -1,7 +1,7 @@
 ---
 title: "Agents"
 description: "Create an AI agent with a system prompt, tools, and memory."
-order: 10
+order: 14
 ---
 
 An agent is a file in `agents/` that exports a system prompt, optional tools, optional memory, and optional skills. The runtime auto-discovers it on startup and exposes it via `getAgent(id)` or an AG-UI route.

--- a/docs/guides/api-routes.md
+++ b/docs/guides/api-routes.md
@@ -1,7 +1,7 @@
 ---
 title: "API routes"
 description: "HTTP handlers, request parsing, and streaming responses."
-order: 6
+order: 10
 ---
 
 An API route is a file under `app/api/` (or `pages/api/`) that exports named HTTP method handlers. Handlers receive the standard Web `Request` and return a `Response`.

--- a/docs/guides/chat-composition.md
+++ b/docs/guides/chat-composition.md
@@ -1,7 +1,7 @@
 ---
 title: "Chat composition"
 description: "Build custom chat layouts with Chat and Message composition components."
-order: 15
+order: 19
 ---
 
 When the preset `Chat` component is too constrained, build a custom layout from `Chat.Root`, `Chat.MessageList`, `Chat.Composer`, and the `Message` compound components. Veryfront still owns the streaming, loading state, and message wiring.

--- a/docs/guides/chat-hooks.md
+++ b/docs/guides/chat-hooks.md
@@ -1,7 +1,7 @@
 ---
 title: "Chat hooks"
 description: "Use headless chat, agent, completion, voice, and thread hooks."
-order: 16
+order: 20
 ---
 
 Three headless hooks expose the chat runtime without the preset UI: `useChat` for AG-UI streaming chat, `useAgent` for direct agent invocation, and `useCompletion` for one-shot text generation. Use them when you want full control of the layout.

--- a/docs/guides/chat-theming.md
+++ b/docs/guides/chat-theming.md
@@ -1,7 +1,7 @@
 ---
 title: "Chat theming"
 description: "Customize chat theme, feature toggles, sources, attachments, and contexts."
-order: 17
+order: 21
 ---
 
 Customize the `Chat` component's theme, attachments, model selector, sources, and feedback actions through props. Each option is independent: turn on what you need and leave the rest at the defaults.

--- a/docs/guides/chat-ui.md
+++ b/docs/guides/chat-ui.md
@@ -1,7 +1,7 @@
 ---
 title: "Chat UI"
 description: "Use the preset Chat component with the useChat hook."
-order: 14
+order: 18
 ---
 
 `Chat` is a complete chat interface in one component: composer, message list, streaming, loading state, and scroll behavior. Drop it in a client page, pair it with `useChat` and an AG-UI route, and you have a working chat.

--- a/docs/guides/choose-a-primitive.md
+++ b/docs/guides/choose-a-primitive.md
@@ -1,7 +1,7 @@
 ---
 title: "Choose a primitive"
 description: "Pick the right Veryfront primitive before you write code."
-order: 34
+order: 4
 ---
 
 Pick the smallest Veryfront primitive that matches the job. Smaller primitives keep project structure clear and prevent agents, workflows, jobs, and integrations from collapsing into overlapping abstractions.

--- a/docs/guides/cli-knowledge-ingestion.md
+++ b/docs/guides/cli-knowledge-ingestion.md
@@ -1,7 +1,7 @@
 ---
 title: "CLI-first knowledge ingestion"
 description: "Turn uploads and local documents into project knowledge files with one command."
-order: 27
+order: 32
 ---
 
 `veryfront knowledge ingest` is the primary CLI workflow for getting documents into a project's knowledge base. It finds a source file, parses it, and writes generated markdown back into the project.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: "Configuration"
 description: "`veryfront.config.ts` options, environment variables, and runtime settings."
-order: 3
+order: 7
 ---
 
 Configure a Veryfront project in two places: `veryfront.config.ts` for project structure, build settings, and feature defaults; environment variables for secrets and deployment-specific values. The framework reads both automatically.

--- a/docs/guides/create-an-agent.md
+++ b/docs/guides/create-an-agent.md
@@ -1,7 +1,7 @@
 ---
 title: "Create an agent"
 description: "Define an AI agent and invoke it from server code in under five minutes."
-order: 37
+order: 3
 ---
 
 Define an agent in a Veryfront project, send it a message, and stream the response back. For tools, memory, skills, and hosted runs, see [Agents](./agents.md).

--- a/docs/guides/data-fetching.md
+++ b/docs/guides/data-fetching.md
@@ -1,7 +1,7 @@
 ---
 title: "Data fetching"
 description: "Server data, static generation, and client-side fetching."
-order: 5
+order: 9
 ---
 
 Veryfront pages can load data three ways: `getServerData` on every request, `getStaticData` at build time, or `fetch` from a client component. Each one has its place.

--- a/docs/guides/extension-authoring.md
+++ b/docs/guides/extension-authoring.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension authoring"
 description: "Write focused Veryfront extension factories, contracts, and capabilities."
-order: 30
+order: 34
 ---
 
 An extension should address one capability boundary. Keep the factory small, declare requirements explicitly, and expose contracts through `provides` or `setup()`.

--- a/docs/guides/extension-lifecycle.md
+++ b/docs/guides/extension-lifecycle.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension lifecycle"
 description: "Understand extension discovery, ordering, presets, setup, and teardown."
-order: 31
+order: 35
 ---
 
 Veryfront loads extensions in a fixed order: discover the configured factories, flatten any presets, topologically sort so providers come before consumers, call each `setup()`, run the app, then call each `teardown()` in reverse on shutdown or reload. Knowing this order lets you write extensions that share contracts safely.

--- a/docs/guides/extension-publishing.md
+++ b/docs/guides/extension-publishing.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension publishing"
 description: "Package and publish reusable Veryfront extensions."
-order: 33
+order: 37
 ---
 
 Publish an extension when it should be reused across projects or installed as a first-party or third-party package.

--- a/docs/guides/extension-testing.md
+++ b/docs/guides/extension-testing.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension testing"
 description: "Test Veryfront extension factories and contract implementations."
-order: 32
+order: 36
 ---
 
 Extension tests should prove that the factory returns a valid extension and that provided contracts work through the extension loader.

--- a/docs/guides/extensions.md
+++ b/docs/guides/extensions.md
@@ -1,7 +1,7 @@
 ---
 title: "Extensions"
 description: "Understand how extensions add focused capabilities to Veryfront."
-order: 29
+order: 33
 ---
 
 Extensions are factories that add focused capabilities to a Veryfront project: a cache store, an auth provider, a database adapter, a model provider, an MDX content pipeline. Each extension implements one or more contracts that the rest of the framework consumes.

--- a/docs/guides/head-and-seo.md
+++ b/docs/guides/head-and-seo.md
@@ -1,7 +1,7 @@
 ---
 title: "Head and SEO"
 description: "Declarative metadata, Open Graph, and structured data."
-order: 8
+order: 12
 ---
 
 Set page metadata with the `Head` component: title, description, Open Graph and Twitter cards, favicons, fonts, and JSON-LD. Multiple `Head` components in the tree merge; page-level tags override layout-level tags for duplicate keys.

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -1,7 +1,7 @@
 ---
 title: "Installation"
 description: "Install the Veryfront CLI and framework on macOS, Linux, or Windows."
-order: 36
+order: 1
 ---
 
 Install the `veryfront` CLI and framework so you can scaffold, run, and build Veryfront projects.

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -1,7 +1,7 @@
 ---
 title: "Integrations"
 description: "Config-driven integration tools with OAuth, token management, and API execution across the built-in connector catalog."
-order: 25
+order: 30
 ---
 
 Veryfront integrations let agents call third-party services (GitHub, Slack, Linear, Stripe, and 50+ more) on behalf of users.

--- a/docs/guides/jobs.md
+++ b/docs/guides/jobs.md
@@ -1,7 +1,7 @@
 ---
 title: "Jobs and cron jobs"
 description: "Run project-scoped background work now or on a schedule through the Veryfront platform."
-order: 21
+order: 25
 ---
 
 Veryfront jobs run durable, project-scoped background work on the platform. Create them through the SDK, REST API, or first-party Studio flows.

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -1,7 +1,7 @@
 ---
 title: "MCP server"
 description: "Expose tools, prompts, and resources over Model Context Protocol."
-order: 23
+order: 27
 ---
 
 Mount an MCP server route in your app to expose your project's tools, prompts, and resources to MCP clients like Claude Desktop. The runtime auto-discovers everything under `tools/`, `prompts/`, and `resources/`, so the route handler is essentially a thin auth shim.

--- a/docs/guides/memory-and-streaming.md
+++ b/docs/guides/memory-and-streaming.md
@@ -1,7 +1,7 @@
 ---
 title: "Memory and streaming"
 description: "Conversation memory strategies and streaming responses."
-order: 13
+order: 17
 ---
 
 Agents are stateless by default: each request gets the messages the client sends, and nothing else. Configure `memory` on the agent to persist history across requests, and use `createAgUiHandler` to stream the response back.

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -1,7 +1,7 @@
 ---
 title: "Middleware"
 description: "CORS, rate limiting, logging, and custom middleware pipelines."
-order: 7
+order: 11
 ---
 
 Middleware runs before your route handler. Use it for CORS headers, rate limits, logging, timeouts, and auth checks. A `MiddlewarePipeline` chains middleware together and short-circuits to a `Response` when one rejects the request.

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -1,7 +1,7 @@
 ---
 title: "Multi-agent"
 description: "Agent composition, delegation, and agent-as-tool patterns."
-order: 19
+order: 23
 ---
 
 Two ways to compose agents: wrap one agent as a tool the parent can call (`agentAsTool` / `getAgentsAsTools`), or run several agents as steps in a workflow. Use the first when the parent should decide the order at runtime. Use the second when the order is known in advance.

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -1,7 +1,7 @@
 ---
 title: "OAuth"
 description: "OAuth 2.0 helpers with a built-in provider catalog."
-order: 24
+order: 29
 ---
 
 Sign users in with OAuth 2.0 using `veryfront/oauth`. The module ships a catalog of pre-configured providers (GitHub, Google, Slack, Notion, and 30+ more) and the four helpers you need to wire a flow: `createOAuthInitHandler`, `createOAuthCallbackHandler`, `createOAuthStatusHandler`, and `createOAuthDisconnectHandler`. Each helper requires a `getUserId` function so tokens are stored per-user.

--- a/docs/guides/pages-and-routing.md
+++ b/docs/guides/pages-and-routing.md
@@ -1,7 +1,7 @@
 ---
 title: "Pages and routing"
 description: "File-based routing, layouts, dynamic routes, and MDX pages."
-order: 4
+order: 8
 ---
 
 Veryfront uses file-system based routing. Folders and files under `app/` (or `pages/`) define routes; layouts compose down the tree; brackets in path segments mark dynamic params.

--- a/docs/guides/production-path.md
+++ b/docs/guides/production-path.md
@@ -1,7 +1,7 @@
 ---
 title: "Production path"
 description: "Build one Veryfront route from local project to production verification."
-order: 35
+order: 5
 ---
 
 Take one Veryfront route from local dev to a deployed production check. Each step adds one piece: a project, a primitive, a user-visible surface, then the production verification loop.

--- a/docs/guides/project-structure.md
+++ b/docs/guides/project-structure.md
@@ -1,7 +1,7 @@
 ---
 title: "Project structure"
 description: "File conventions, directory layout, and how auto-discovery works."
-order: 2
+order: 6
 ---
 
 A Veryfront project keeps routing files in `app/` (or `pages/`) and AI primitives (agents, tools, prompts, workflows, resources, skills) at the project root. The framework auto-discovers each of those root directories on startup; you do not register anything by hand.

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -1,7 +1,7 @@
 ---
 title: "Providers"
 description: "Provider registry with runtime conventions and explicit overrides."
-order: 9
+order: 13
 ---
 
 An agent's `model` is a `"provider/model"` string. The provider registry resolves each string to a runtime: Veryfront Cloud, a direct vendor (OpenAI, Anthropic, Google), an OpenAI-compatible service like OpenRouter, or a local model. Omit `model` in most agents and let runtime conventions pick the right backend.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: "Quickstart"
 description: "Create and run a Veryfront project in under 2 minutes."
-order: 1
+order: 2
 ---
 
 Scaffold a Veryfront app, run it locally, and deploy it. The default deploy target is Veryfront Cloud. The same build can be self-hosted on other infrastructure. The npm package, CLI, and import name are all `veryfront`.

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -1,7 +1,7 @@
 ---
 title: "Sandbox"
 description: "Run isolated commands and file operations in ephemeral sandbox sessions."
-order: 26
+order: 31
 ---
 
 A sandbox is a short-lived, isolated workspace for executing commands and file operations away from your app process. Use it for code generation, repo inspection, file transformation, or script execution that you do not want to run in your trusted runtime.

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -1,7 +1,7 @@
 ---
 title: "Skills"
 description: "Define project-level agent capabilities as SKILL.md files with prompt augmentation, tool restrictions, and script execution."
-order: 20
+order: 24
 ---
 
 A skill is a directory under `skills/` containing a `SKILL.md` file. It bundles structured agent instructions, an `allowed_tools` policy, and optional reference files and executable scripts. The format follows the [agentskills.io](https://agentskills.io) specification.

--- a/docs/guides/tasks.md
+++ b/docs/guides/tasks.md
@@ -1,7 +1,7 @@
 ---
 title: "Tasks"
 description: "Define background task functions that can run locally or as cloud jobs."
-order: 22
+order: 26
 ---
 
 Tasks are user-defined functions in `tasks/` that can run locally via `veryfront task <name>` or in the cloud as Jobs and Cron Jobs.

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -1,7 +1,7 @@
 ---
 title: "Tools"
 description: "Define tools with schema-backed inputs that agents can call."
-order: 12
+order: 16
 ---
 
 A tool is a typed function an agent can call. Each tool declares an `inputSchema` (zod or any Veryfront schema), a `description` the model reads, and an `execute` function the framework runs when the model calls it.

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -1,7 +1,7 @@
 ---
 title: "Workflows"
 description: "DAG-based multi-step workflows with branching and parallelism."
-order: 18
+order: 22
 ---
 
 A workflow is a file in `workflows/` that declares ordered steps. Each step runs an agent or a tool, and the workflow runtime threads outputs between them. Steps support parallel execution, branches, loops, retries, timeouts, and human-in-the-loop approvals.


### PR DESCRIPTION
## Problem

Five guides added late in the last week (`installation`, `create-an-agent`, `choose-a-primitive`, `production-path`, `deploying`) ended up with frontmatter `order` values 33–38 because they were appended rather than inserted. The orders no longer match the reading order in `docs/guides/index.md`, where those guides appear at the **top** of "Get started".

## What changed

Renumber all 39 guides so the frontmatter `order` tracks the canonical sequence from `index.md`:

| New order | Guide |
| --- | --- |
| 0 | index |
| 1 | installation |
| 2 | quickstart |
| 3 | create-an-agent |
| 4 | choose-a-primitive |
| 5 | production-path |
| 6 | project-structure |
| 7 | configuration |
| 8 | pages-and-routing |
| 9 | data-fetching |
| 10 | api-routes |
| 11 | middleware |
| 12 | head-and-seo |
| 13–17 | providers, agents, agent-service-runtime, tools, memory-and-streaming |
| 18–21 | chat-ui, chat-composition, chat-hooks, chat-theming |
| 22–26 | workflows, multi-agent, skills, jobs, tasks |
| 27–32 | mcp-server, coding-agents, oauth, integrations, sandbox, cli-knowledge-ingestion |
| 33–37 | extensions, extension-authoring, extension-lifecycle, extension-testing, extension-publishing |
| 38 | deploying |

No content changes — only the `order` field shifts. Orders remain contiguous (0–38) and unique.

## Companion PR

The live Mintlify sidebar is driven by `veryfront-docs/docs/docs.json` rather than this frontmatter field, so the actual published sidebar order is fixed in [veryfront-docs#TBD](https://github.com/veryfront/veryfront-docs/pulls?q=docs%2Fsidebar-add-missing-guides) — opened in tandem. This PR keeps the `veryfront-code` source-of-truth aligned with the documented reading order for everything that does honor the frontmatter (validator, future sidebar generators, local renderers).

## Test plan

- [x] `deno run --allow-read scripts/docs/validate-guides.ts` — 39 guides pass, orders unique.
- [x] `deno run -A scripts/lint/check-doc-links.ts` — 845 links OK.
- [x] `guide-contracts.test.ts` and `guide-code-examples.test.ts` — pass.