### PR TITLE
docs(guides): split workflows into core + advanced (loops, blob, hooks)

### DIFF
--- a/docs/guides/cli-knowledge-ingestion.md
+++ b/docs/guides/cli-knowledge-ingestion.md
@@ -1,7 +1,7 @@
 ---
 title: "CLI-first knowledge ingestion"
 description: "Turn uploads and local documents into project knowledge files with one command."
-order: 32
+order: 33
 ---
 
 `veryfront knowledge ingest` is the primary CLI workflow for getting documents into a project's knowledge base. It finds a source file, parses it, and writes generated markdown back into the project.

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -1,7 +1,7 @@
 ---
 title: "Coding agents"
 description: "Connect Claude Code, Cursor, Codex, and other MCP-aware coding agents to the Veryfront dev server."
-order: 28
+order: 29
 ---
 
 Connect Claude Code, Cursor, Codex, or any MCP-aware coding agent to your Veryfront dev server. The agent gets a focused dev toolset: live errors and logs, route listing, route preview, scaffolding, test and lint runners.

--- a/docs/guides/create-an-agent.md
+++ b/docs/guides/create-an-agent.md
@@ -97,6 +97,6 @@ If the dev server logs a missing-provider error, check that `OPENAI_API_KEY` (or
 
 ## Next
 
-- [Agents](./agents.md): full agent surface — tools, dynamic system prompts, multi-step runs, memory, AG-UI handlers, hosted runs.
+- [Agents](./agents.md): full agent surface (tools, dynamic system prompts, multi-step runs, memory, AG-UI handlers, hosted runs).
 - [Tools](./tools.md): let the agent call typed functions.
 - [Chat UI](./chat-ui.md): drop a streaming chat interface into a React page that talks to this agent.

--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -1,7 +1,7 @@
 ---
 title: "Building and deploying"
 description: "Production builds, static export, and deployment targets."
-order: 38
+order: 39
 ---
 
 Build a Veryfront project for production with `veryfront build`, run the production server locally with `veryfront start`, then ship the build with `veryfront deploy` (Veryfront Cloud) or to any host that can run your chosen runtime.

--- a/docs/guides/extension-authoring.md
+++ b/docs/guides/extension-authoring.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension authoring"
 description: "Write focused Veryfront extension factories, contracts, and capabilities."
-order: 34
+order: 35
 ---
 
 An extension should address one capability boundary. Keep the factory small, declare requirements explicitly, and expose contracts through `provides` or `setup()`.

--- a/docs/guides/extension-lifecycle.md
+++ b/docs/guides/extension-lifecycle.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension lifecycle"
 description: "Understand extension discovery, ordering, presets, setup, and teardown."
-order: 35
+order: 36
 ---
 
 Veryfront loads extensions in a fixed order: discover the configured factories, flatten any presets, topologically sort so providers come before consumers, call each `setup()`, run the app, then call each `teardown()` in reverse on shutdown or reload. Knowing this order lets you write extensions that share contracts safely.

--- a/docs/guides/extension-publishing.md
+++ b/docs/guides/extension-publishing.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension publishing"
 description: "Package and publish reusable Veryfront extensions."
-order: 37
+order: 38
 ---
 
 Publish an extension when it should be reused across projects or installed as a first-party or third-party package.

--- a/docs/guides/extension-testing.md
+++ b/docs/guides/extension-testing.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension testing"
 description: "Test Veryfront extension factories and contract implementations."
-order: 36
+order: 37
 ---
 
 Extension tests should prove that the factory returns a valid extension and that provided contracts work through the extension loader.

--- a/docs/guides/extensions.md
+++ b/docs/guides/extensions.md
@@ -8,10 +8,10 @@ Extensions are factories that add focused capabilities to a Veryfront project: a
 
 This page is the overview. From here:
 
-- [Extension authoring](./extension-authoring.md) — write a factory, declare capabilities, provide a contract.
-- [Extension lifecycle](./extension-lifecycle.md) — discovery, ordering, presets, setup, teardown.
-- [Extension testing](./extension-testing.md) — verify the factory and the contracts it provides.
-- [Extension publishing](./extension-publishing.md) — package an extension for reuse.
+- [Extension authoring](./extension-authoring.md): write a factory, declare capabilities, provide a contract.
+- [Extension lifecycle](./extension-lifecycle.md): discovery, ordering, presets, setup, teardown.
+- [Extension testing](./extension-testing.md): verify the factory and the contracts it provides.
+- [Extension publishing](./extension-publishing.md): package an extension for reuse.
 
 ## Prerequisites
 

--- a/docs/guides/extensions.md
+++ b/docs/guides/extensions.md
@@ -1,7 +1,7 @@
 ---
 title: "Extensions"
 description: "Understand how extensions add focused capabilities to Veryfront."
-order: 33
+order: 34
 ---
 
 Extensions are factories that add focused capabilities to a Veryfront project: a cache store, an auth provider, a database adapter, a model provider, an MDX content pipeline. Each extension implements one or more contracts that the rest of the framework consumes.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -54,13 +54,14 @@ matches your goal.
 
 ## Orchestrate work across agents and time
 
-| Guide                           | What you will do                                                        |
-| ------------------------------- | ----------------------------------------------------------------------- |
-| [Workflows](./workflows.md)     | Define a DAG-based workflow with branches, retries, and parallel steps. |
-| [Multi-agent](./multi-agent.md) | Compose agents with delegation and agent-as-tool patterns.              |
-| [Skills](./skills.md)           | Add project-level skills from `SKILL.md` files with tool restrictions.  |
-| [Jobs](./jobs.md)               | Run one-off jobs, schedule cron jobs, and inspect batch summaries.      |
-| [Tasks](./tasks.md)             | Write background task functions that run locally or as cloud jobs.      |
+| Guide                                          | What you will do                                                        |
+| ---------------------------------------------- | ----------------------------------------------------------------------- |
+| [Workflows](./workflows.md)                    | Define a DAG-based workflow with branches, retries, and parallel steps. |
+| [Workflows: advanced](./workflows-advanced.md) | Loops, blob storage for large artifacts, and React hooks for progress.  |
+| [Multi-agent](./multi-agent.md)                | Compose agents with delegation and agent-as-tool patterns.              |
+| [Skills](./skills.md)                          | Add project-level skills from `SKILL.md` files with tool restrictions.  |
+| [Jobs](./jobs.md)                              | Run one-off jobs, schedule cron jobs, and inspect batch summaries.      |
+| [Tasks](./tasks.md)                            | Write background task functions that run locally or as cloud jobs.      |
 
 ## Connect external systems
 

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -1,7 +1,7 @@
 ---
 title: "Integrations"
 description: "Config-driven integration tools with OAuth, token management, and API execution across the built-in connector catalog."
-order: 30
+order: 31
 ---
 
 Veryfront integrations let agents call third-party services (GitHub, Slack, Linear, Stripe, and 50+ more) on behalf of users.

--- a/docs/guides/jobs.md
+++ b/docs/guides/jobs.md
@@ -1,7 +1,7 @@
 ---
 title: "Jobs and cron jobs"
 description: "Run project-scoped background work now or on a schedule through the Veryfront platform."
-order: 25
+order: 26
 ---
 
 Veryfront jobs run durable, project-scoped background work on the platform. Create them through the SDK, REST API, or first-party Studio flows.

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -1,7 +1,7 @@
 ---
 title: "MCP server"
 description: "Expose tools, prompts, and resources over Model Context Protocol."
-order: 27
+order: 28
 ---
 
 Mount an MCP server route in your app to expose your project's tools, prompts, and resources to MCP clients like Claude Desktop. The runtime auto-discovers everything under `tools/`, `prompts/`, and `resources/`, so the route handler is essentially a thin auth shim.

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -1,7 +1,7 @@
 ---
 title: "Multi-agent"
 description: "Agent composition, delegation, and agent-as-tool patterns."
-order: 23
+order: 24
 ---
 
 Two ways to compose agents: wrap one agent as a tool the parent can call (`agentAsTool` / `getAgentsAsTools`), or run several agents as steps in a workflow. Use the first when the parent should decide the order at runtime. Use the second when the order is known in advance.

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -1,7 +1,7 @@
 ---
 title: "OAuth"
 description: "OAuth 2.0 helpers with a built-in provider catalog."
-order: 29
+order: 30
 ---
 
 Sign users in with OAuth 2.0 using `veryfront/oauth`. The module ships a catalog of pre-configured providers (GitHub, Google, Slack, Notion, and 30+ more) and the four helpers you need to wire a flow: `createOAuthInitHandler`, `createOAuthCallbackHandler`, `createOAuthStatusHandler`, and `createOAuthDisconnectHandler`. Each helper requires a `getUserId` function so tokens are stored per-user.

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -1,7 +1,7 @@
 ---
 title: "Sandbox"
 description: "Run isolated commands and file operations in ephemeral sandbox sessions."
-order: 31
+order: 32
 ---
 
 A sandbox is a short-lived, isolated workspace for executing commands and file operations away from your app process. Use it for code generation, repo inspection, file transformation, or script execution that you do not want to run in your trusted runtime.

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -1,7 +1,7 @@
 ---
 title: "Skills"
 description: "Define project-level agent capabilities as SKILL.md files with prompt augmentation, tool restrictions, and script execution."
-order: 24
+order: 25
 ---
 
 A skill is a directory under `skills/` containing a `SKILL.md` file. It bundles structured agent instructions, an `allowed_tools` policy, and optional reference files and executable scripts. The format follows the [agentskills.io](https://agentskills.io) specification.

--- a/docs/guides/tasks.md
+++ b/docs/guides/tasks.md
@@ -1,7 +1,7 @@
 ---
 title: "Tasks"
 description: "Define background task functions that can run locally or as cloud jobs."
-order: 26
+order: 27
 ---
 
 Tasks are user-defined functions in `tasks/` that can run locally via `veryfront task <name>` or in the cloud as Jobs and Cron Jobs.

--- a/docs/guides/workflows-advanced.md
+++ b/docs/guides/workflows-advanced.md
@@ -45,7 +45,7 @@ map("process", (ctx) => ctx.input.urls, [
 
 ## Blob storage
 
-For large workflow artifacts (uploaded files, generated reports, intermediate datasets), configure `blobStorage` on the executor with a host-provided storage adapter. The public workflow export exposes the executor integration point. Storage implementations come from the host runtime — typical hosts wire S3, GCS, or Vercel Blob behind this adapter.
+For large workflow artifacts (uploaded files, generated reports, intermediate datasets), configure `blobStorage` on the executor with a host-provided storage adapter. The public workflow export exposes the executor integration point. Storage implementations come from the host runtime: typical hosts wire S3, GCS, or Vercel Blob behind this adapter.
 
 Without `blobStorage`, large values still flow through step inputs and outputs in memory, which becomes the bottleneck once individual artifacts exceed a few hundred kilobytes.
 
@@ -95,7 +95,7 @@ For React hooks, render the dashboard component above, click **Run Pipeline**, a
 
 ## Next
 
-- [Workflows](./workflows.md): core workflow API — define, run, branch, parallel, human approval
+- [Workflows](./workflows.md): core workflow API (define, run, branch, parallel, human approval)
 - [Multi-agent](./multi-agent.md): compose agents in workflows and tools
 
 ## Related

--- a/docs/guides/workflows-advanced.md
+++ b/docs/guides/workflows-advanced.md
@@ -1,0 +1,103 @@
+---
+title: "Workflows: loops, blob storage, React hooks"
+description: "Repeat steps based on conditions, store large workflow artifacts, and track workflow progress from a React client."
+order: 23
+---
+
+Three patterns that reach past a single-pass DAG: looping until a condition is met, storing artifacts that are too large to thread through step inputs, and surfacing workflow progress in a React UI. Pick the section that matches what the base workflow can't do yet.
+
+## Prerequisites
+
+- A working workflow defined and runnable per [Workflows](./workflows.md).
+- For React hooks: a client page that can render React components and an API route that matches the hook's `apiBase`.
+
+## Loops
+
+Repeat steps based on conditions:
+
+```ts
+import { delay, doWhile, loop, map, times } from "veryfront/workflow";
+
+// Repeat while condition is true
+loop("refine", (ctx) => ctx.results.review.score < 0.9, [
+  step("rewrite", { agent: "writer" }),
+  step("review", { agent: "reviewer" }),
+]);
+
+// Execute once, then repeat while true
+doWhile("poll", (ctx) => !ctx.results.check.done, [
+  step("check", { tool: "statusChecker" }),
+  delay("wait", "5s"),
+]);
+
+// Fixed iterations
+times("generate", 3, [
+  step("variant", { agent: "writer" }),
+]);
+
+// Map over array items
+map("process", (ctx) => ctx.input.urls, [
+  step("scrape", { tool: "webScraper" }),
+]);
+```
+
+`loop` checks the condition before each iteration. `doWhile` runs the body once before checking. `times` runs a fixed number of iterations. `map` runs the body once per item in an array.
+
+## Blob storage
+
+For large workflow artifacts (uploaded files, generated reports, intermediate datasets), configure `blobStorage` on the executor with a host-provided storage adapter. The public workflow export exposes the executor integration point. Storage implementations come from the host runtime — typical hosts wire S3, GCS, or Vercel Blob behind this adapter.
+
+Without `blobStorage`, large values still flow through step inputs and outputs in memory, which becomes the bottleneck once individual artifacts exceed a few hundred kilobytes.
+
+## React hooks
+
+Track workflow progress from the client when your app exposes workflow API routes that match the hook's `apiBase`:
+
+```tsx
+"use client";
+import { useWorkflow, useWorkflowStart } from "veryfront/workflow";
+
+export default function PipelineDashboard() {
+  const { start, lastRunId } = useWorkflowStart({
+    workflowId: "pipeline",
+    apiBase: "/api/workflows",
+  });
+
+  return (
+    <div>
+      <button onClick={() => start({ topic: "AI agents" })}>Run Pipeline</button>
+      {lastRunId ? <WorkflowStatus runId={lastRunId} /> : null}
+    </div>
+  );
+}
+
+function WorkflowStatus({ runId }: { runId: string }) {
+  const { status, nodeStates } = useWorkflow({ runId });
+
+  return (
+    <div>
+      <p>Status: {status}</p>
+      {Object.entries(nodeStates).map(([id, state]) => <div key={id}>{id}: {state.status}</div>)}
+    </div>
+  );
+}
+```
+
+`useWorkflowStart` posts to `${apiBase}/${workflowId}/start`. `useWorkflow` subscribes to `${apiBase}/runs/${runId}` and keeps `status` and `nodeStates` in sync with the server's run state.
+
+## Verify it worked
+
+For loops, run the workflow with an input that triggers the loop condition (a low review score, an unfinished check, an array of URLs). The dev-server log shows the loop body executing once per iteration. The final run status reaches `completed` after the condition flips.
+
+For blob storage, configure an adapter, run a workflow that writes a large artifact, and confirm the storage backend received it. The step output should reference a blob handle rather than the inline payload.
+
+For React hooks, render the dashboard component above, click **Run Pipeline**, and confirm the status string moves through `running` to `completed` while individual `nodeStates` entries update.
+
+## Next
+
+- [Workflows](./workflows.md): core workflow API — define, run, branch, parallel, human approval
+- [Multi-agent](./multi-agent.md): compose agents in workflows and tools
+
+## Related
+
+- [`veryfront/workflow`](../reference/veryfront/workflow.md): workflow API reference

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -286,36 +286,6 @@ waitForEvent("payment-confirmed", {
 });
 ```
 
-## Loops
-
-Repeat steps based on conditions:
-
-```ts
-import { doWhile, loop, map, times } from "veryfront/workflow";
-
-// Repeat while condition is true
-loop("refine", (ctx) => ctx.results.review.score < 0.9, [
-  step("rewrite", { agent: "writer" }),
-  step("review", { agent: "reviewer" }),
-]);
-
-// Execute once, then repeat while true
-doWhile("poll", (ctx) => !ctx.results.check.done, [
-  step("check", { tool: "statusChecker" }),
-  delay("wait", "5s"),
-]);
-
-// Fixed iterations
-times("generate", 3, [
-  step("variant", { agent: "writer" }),
-]);
-
-// Map over array items
-map("process", (ctx) => ctx.input.urls, [
-  step("scrape", { tool: "webScraper" }),
-]);
-```
-
 ## Workflow configuration
 
 ```ts
@@ -342,46 +312,6 @@ export default workflow({
 });
 ```
 
-## Blob storage
-
-For large workflow artifacts, configure `blobStorage` on the executor with a
-host-provided storage adapter. The public workflow export exposes the executor
-integration point. Storage implementations come from the host runtime.
-
-## React hooks
-
-Track workflow progress from the client when your app exposes workflow API routes that match the hook's `apiBase`:
-
-```tsx
-"use client";
-import { useWorkflow, useWorkflowStart } from "veryfront/workflow";
-
-export default function PipelineDashboard() {
-  const { start, lastRunId } = useWorkflowStart({
-    workflowId: "pipeline",
-    apiBase: "/api/workflows",
-  });
-
-  return (
-    <div>
-      <button onClick={() => start({ topic: "AI agents" })}>Run Pipeline</button>
-      {lastRunId ? <WorkflowStatus runId={lastRunId} /> : null}
-    </div>
-  );
-}
-
-function WorkflowStatus({ runId }: { runId: string }) {
-  const { status, nodeStates } = useWorkflow({ runId });
-
-  return (
-    <div>
-      <p>Status: {status}</p>
-      {Object.entries(nodeStates).map(([id, state]) => <div key={id}>{id}: {state.status}</div>)}
-    </div>
-  );
-}
-```
-
 ## Verify it worked
 
 Start the workflow from the start route, then poll the run state until it
@@ -403,14 +333,11 @@ while true; do
 done
 ```
 
-A working run reaches `status: "completed"` and exposes a `nodeStates` map
-with one `completed` entry per step. From the React side, `useWorkflow`
-keeps `status` and `nodeStates` in sync with the same endpoint. If `status`
-ends in `failed`, inspect the matching node entry in `nodeStates` for the
-underlying error.
+A working run reaches `status: "completed"` and exposes a `nodeStates` map with one `completed` entry per step. If `status` ends in `failed`, inspect the matching node entry in `nodeStates` for the underlying error.
 
 ## Next
 
+- [Workflows: loops, blob storage, React hooks](./workflows-advanced.md): repeat-until-done loops, large-artifact storage, and React progress hooks
 - [Multi-agent](./multi-agent.md): compose agents in workflows and tools
 - [Providers](./providers.md): configure the LLM providers that power your agents
 

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -90,6 +90,7 @@ const THIS_GUIDE_EXAMPLE_SUITE = [
   "sandbox.md",
   "skills.md",
   "tasks.md",
+  "workflows-advanced.md",
 ] as const;
 
 const GUIDE_CODE_EXAMPLE_COVERAGE = new Set<string>([
@@ -608,6 +609,28 @@ describe("Guide: skills.md", () => {
       "allowed_tools: load-skill load-skill-reference execute-skill-script",
     );
     assertStringIncludes(guide, "veryfront skills validate skills/my-skill");
+  });
+});
+
+describe("Guide: workflows-advanced.md", () => {
+  it("documents loop helpers, blob storage, and React hook surface", async () => {
+    const guide = await readGuide("workflows-advanced.md");
+
+    for (
+      const snippet of [
+        'import { delay, doWhile, loop, map, times } from "veryfront/workflow"',
+        'loop("refine"',
+        'doWhile("poll"',
+        'times("generate"',
+        'map("process"',
+        "blobStorage",
+        'import { useWorkflow, useWorkflowStart } from "veryfront/workflow"',
+        "useWorkflowStart({",
+        "useWorkflow({ runId })",
+      ]
+    ) {
+      assertStringIncludes(guide, snippet);
+    }
   });
 });
 

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -251,6 +251,10 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     references: ["../reference/veryfront/workflow.md"],
     snippets: ["workflow", "parallel", "waitForApproval"],
   },
+  "workflows-advanced.md": {
+    references: ["../reference/veryfront/workflow.md"],
+    snippets: ["loop", "doWhile", "blobStorage", "useWorkflow", "useWorkflowStart"],
+  },
 };
 
 describe("published guide contracts", () => {


### PR DESCRIPTION
## Problem

`workflows.md` was the longest guide at **419 lines**, covering the core declarative API alongside three more specialized concerns (looping, large-artifact storage, React progress hooks) that most readers do not reach for until later. Length made the page hard to scan and the mental model harder to load.

## What changed

**Split into two guides.**

### `docs/guides/workflows.md` — core (346 lines, was 419)

The declarative API a reader needs to build a real workflow:

- Define a workflow
- Start a workflow (API route, agent tool, client component patterns)
- Steps (with options table)
- Parallel execution (with strategies)
- Branching (`branch`, `when`, `unless`)
- Human-in-the-loop (`waitForApproval`, `waitForEvent`)
- Workflow configuration (`inputSchema`, `retry`, `timeout`, `onError`, `onComplete`)
- Verify it worked

### `docs/guides/workflows-advanced.md` — new (103 lines)

Patterns that reach past a single-pass DAG:

- **Loops** — `loop`, `doWhile`, `times`, `map` with notes on the semantic each helper provides
- **Blob storage** — when to wire the executor `blobStorage` adapter for artifacts that would otherwise bottleneck step inputs
- **React hooks** — `useWorkflow`, `useWorkflowStart` for progress UI
- Per-section Verify it worked plus its own Next/Related

`workflows.md` keeps its Next section pointing at `workflows-advanced.md` so readers can jump there once the basic shape is in place.

## Knock-on changes

- Frontmatter `order:` 23..38 shifted to 24..39 to keep slot 23 next to `workflows` (= 22) for `workflows-advanced`. Orders remain unique and contiguous 0–39 (40 guides total).
- `docs/guides/index.md`: new row in "Orchestrate work across agents and time" pointing at `workflows-advanced.md`.
- `tests/docs/guide-contracts.test.ts`: new `GUIDE_CONTRACTS` entry for `workflows-advanced.md` pinning the loop helpers, `blobStorage`, and the React hook names.
- `tests/docs/guide-code-examples.test.ts`: `workflows-advanced.md` added to `THIS_GUIDE_EXAMPLE_SUITE` and a describe block asserts the loop import line, every loop variant, `blobStorage`, and both React hooks remain documented.

## Test plan

- [x] `validate-guides.ts` — 40 guides pass.
- [x] `guide-contracts.test.ts` — 41 steps pass.
- [x] `guide-code-examples.test.ts` — 29 steps pass.
- [x] `guide-content.test.ts` — 4 steps pass.
- [x] `check-doc-links.ts` — 851 links OK (up from 845; new cross-links).
- [x] Pre-push hook (1905 tests) — green.

## Scope note on the other length outliers

The status report flagged `configuration.md` (293 lines) and `integrations.md` (388 lines) as length candidates too. On closer reading, both are long but **cohesive**:

- `configuration.md` pairs each config snippet with the env var table that affects it. Splitting forces readers to navigate between the snippet and its env var.
- `integrations.md`'s value is the full connector catalog **inline with** the enable instructions — splitting the catalog into a sibling guide doubles the navigation cost for the most common task (find a connector → enable it).

Leaving both as-is. If you want to revisit either, happy to take a separate pass.