### PR TITLE
Allow job-managed workflow resume

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.562",
+  "version": "0.1.563",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.562";
+export const VERSION = "0.1.563";

--- a/src/workflow/executor/workflow-executor.ts
+++ b/src/workflow/executor/workflow-executor.ts
@@ -230,10 +230,10 @@ export class WorkflowExecutor {
     const run = await this.config.backend.getRun(runId);
     if (!run) throw RESOURCE_NOT_FOUND.create({ detail: `Run not found: ${runId}` });
 
-    if (run.status !== "waiting" && run.status !== "pending") {
+    if (run.status !== "waiting" && run.status !== "pending" && run.status !== "running") {
       throw ORCHESTRATION_ERROR.create({
         detail: `Cannot resume workflow run "${runId}": current status is "${run.status}". ` +
-          `Only runs in "waiting" or "pending" status can be resumed.`,
+          `Only runs in "waiting", "pending", or "running" status can be resumed.`,
       });
     }
 

--- a/src/workflow/worker/job-entrypoint.test.ts
+++ b/src/workflow/worker/job-entrypoint.test.ts
@@ -1,8 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { getCurrentRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
+import { defineSchema } from "#veryfront/schemas/index.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import type { Tool } from "#veryfront/tool";
 import { MemoryBackend } from "../backends/memory.ts";
+import { dependsOn, step, workflow } from "../dsl/index.ts";
+import { WorkflowExecutor } from "../executor/workflow-executor.ts";
 import type { WorkflowRun } from "../types.ts";
 import { EXIT_CODES, runWorkflowJob } from "./job-entrypoint.ts";
 
@@ -34,6 +38,16 @@ function restoreEnv(): void {
     }
   }
   savedEnv.clear();
+}
+
+function createMockTool(name: string, handler: (input: unknown) => unknown): Tool {
+  return {
+    id: name,
+    type: "function",
+    description: `Mock tool: ${name}`,
+    inputSchema: defineSchema((v) => v.object({}).passthrough())(),
+    execute: (input) => Promise.resolve(handler(input)),
+  };
 }
 
 describe("runWorkflowJob", () => {
@@ -177,5 +191,126 @@ describe("runWorkflowJob", () => {
     assertExists(updatedRun);
     assertEquals(updatedRun.status, "failed");
     assertEquals(updatedRun.error?.message, "EXECUTION_ERROR: boom");
+  });
+
+  it("executes workflow runs already marked running by the job manager", async () => {
+    rememberEnv();
+
+    const backend = new MemoryBackend();
+    const executor = new WorkflowExecutor({ backend, enableLocking: false });
+    const workflowDefinition = workflow({
+      id: "running-workflow",
+      steps: [
+        step("finish", {
+          tool: createMockTool("finish-tool", () => ({ ok: true })),
+        }),
+      ],
+    });
+    executor.register(workflowDefinition.definition);
+
+    const run: WorkflowRun = {
+      id: "run-running",
+      workflowId: "running-workflow",
+      status: "running",
+      input: {},
+      nodeStates: {},
+      currentNodes: [],
+      context: { input: {} },
+      checkpoints: [],
+      pendingApprovals: [],
+      createdAt: new Date(),
+      startedAt: new Date(),
+      workerId: "job:job-1",
+    };
+    await backend.createRun(run);
+
+    Deno.env.set("WORKFLOW_RUN_ID", run.id);
+
+    const exitCode = await runWorkflowJob({
+      backend,
+      executor,
+    });
+
+    const updatedRun = await backend.getRun(run.id);
+
+    assertEquals(exitCode, EXIT_CODES.SUCCESS);
+    assertExists(updatedRun);
+    assertEquals(updatedRun.status, "completed");
+    assertEquals(updatedRun.output, { finish: { ok: true } });
+  });
+
+  it("resumes job-managed workflow runs from the latest checkpoint", async () => {
+    rememberEnv();
+
+    const backend = new MemoryBackend();
+    const executor = new WorkflowExecutor({ backend, enableLocking: false });
+    let firstExecuted = false;
+    let secondExecuted = false;
+    const workflowDefinition = workflow({
+      id: "checkpointed-workflow",
+      steps: [
+        step("first", {
+          tool: createMockTool("first-tool", () => {
+            firstExecuted = true;
+            return { first: true };
+          }),
+        }),
+        dependsOn(
+          step("second", {
+            tool: createMockTool("second-tool", () => {
+              secondExecuted = true;
+              return { second: true };
+            }),
+          }),
+          "first",
+        ),
+      ],
+    });
+    executor.register(workflowDefinition.definition);
+
+    const firstNodeState = {
+      nodeId: "first",
+      status: "completed" as const,
+      output: { first: true },
+      attempt: 1,
+    };
+    const run: WorkflowRun = {
+      id: "run-checkpointed",
+      workflowId: "checkpointed-workflow",
+      status: "running",
+      input: {},
+      nodeStates: { first: firstNodeState },
+      currentNodes: [],
+      context: { input: {}, first: { first: true } },
+      checkpoints: [],
+      pendingApprovals: [],
+      createdAt: new Date(),
+      startedAt: new Date(),
+      workerId: "job:job-2",
+    };
+    await backend.createRun(run);
+    await backend.saveCheckpoint(run.id, {
+      id: "cp-first",
+      nodeId: "first",
+      timestamp: new Date(),
+      context: { input: {}, first: { first: true } },
+      nodeStates: { first: firstNodeState },
+    });
+
+    Deno.env.set("WORKFLOW_RUN_ID", run.id);
+
+    const exitCode = await runWorkflowJob({
+      backend,
+      executor,
+    });
+
+    const updatedRun = await backend.getRun(run.id);
+
+    assertEquals(exitCode, EXIT_CODES.SUCCESS);
+    assertEquals(firstExecuted, false);
+    assertEquals(secondExecuted, true);
+    assertExists(updatedRun);
+    assertEquals(updatedRun.status, "completed");
+    assertEquals(updatedRun.output, { first: { first: true }, second: { second: true } });
   });
 });


### PR DESCRIPTION
## Summary
- allow workflow executor resume when the job manager has already marked the run as running
- add regression coverage for job-managed workflow runs and checkpoint resume
- bump the veryfront-code package version for release

## Verification
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/workflow/worker/job-entrypoint.test.ts src/workflow/executor/dag-executor.test.ts src/workflow/backends/memory.test.ts src/jobs/index.test.ts src/task/runner.test.ts
- pre-push: formatting, lint, typecheck, generated assets, and full unit suite passed