### PR TITLE
docs: clarify task workflow run model

### DIFF
--- a/docs/architecture/08-workflow-runtime.md
+++ b/docs/architecture/08-workflow-runtime.md
@@ -1,7 +1,7 @@
 # Workflow runtime
 
 This page describes workflow definition and execution. It does not cover agent
-streaming, background task definitions, or job queue infrastructure.
+streaming, background task definitions, or job queue internals.
 
 ## Responsibility
 
@@ -50,9 +50,26 @@ flowchart TD
 5. Worker entrypoints run workflow jobs in process, subprocess, or Kubernetes
    execution profiles.
 
+## Platform execution model
+
+When the platform starts a workflow, it creates a canonical workflow run and a
+bound job:
+
+- The public run has `kind = "workflow"`.
+- The bound job target is `workflow:<workflow-id>`.
+- The job service owns queueing, dispatch, retry, cancellation, logs, and worker
+  lifecycle.
+- The workflow runtime owns step graph execution, checkpoint state, approvals,
+  and workflow result state.
+
+This keeps workflow state distinct from background job mechanics while still
+using the jobs infrastructure for durable execution.
+
 ## Boundaries
 
 - A workflow is a step graph. It is not a job, task, cron job, or agent run.
+- A workflow run may be backed by a job. The workflow run remains the canonical
+  public execution record for workflow APIs.
 - Workflow API clients expose workflow run operations. They do not own step
   execution semantics.
 - Agent steps may call the agent runtime, but workflow state remains owned by the

--- a/docs/architecture/09-jobs-and-tasks.md
+++ b/docs/architecture/09-jobs-and-tasks.md
@@ -2,7 +2,7 @@
 
 This page describes job client operations, cron job scheduling surfaces, task
 definition discovery, and local task execution. It does not cover workflow DAG
-execution or the external service that persists and runs cloud jobs.
+execution internals.
 
 ## Responsibility
 
@@ -31,7 +31,7 @@ flowchart TD
   taskContext --> result[Task result or sanitized error]
 
   client[Jobs client] --> api[Jobs API]
-  api --> create[Create one-off job]
+  api --> create[Create one-off job run]
   api --> cron[Create or update cron job]
   api --> events[List events and logs]
   api --> targets[List supported targets]
@@ -49,14 +49,31 @@ flowchart TD
    shapes.
 5. Cloud job execution is delegated to the configured backing service.
 
+## Canonical run model
+
+Job execution is represented through canonical runs:
+
+- Running a task definition creates `run.kind = "job"` and a bound job whose
+  target is `task:<task-id>`.
+- Running a workflow definition creates `run.kind = "workflow"` and a bound job
+  whose target is `workflow:<workflow-id>`.
+- Triggering a cron job creates the run kind implied by its target. A
+  `task:<task-id>` target creates a job run. A `workflow:<workflow-id>` target
+  creates a workflow run.
+
+The job row owns queueing, worker dispatch, logs, retry, cancellation, and
+runtime metadata. The canonical run row owns the public execution identity and
+kind-specific API shape.
+
 ## Boundaries
 
 - A task is a developer-defined function. It is not a job run.
-- A job is durable background execution of a target. It is not a workflow DAG.
-- Cron jobs create job runs over time. They are not job runs themselves.
+- A job is durable background execution of a target. It is not a task
+  definition or workflow definition.
+- Cron jobs create runs over time. They are not runs themselves.
 - Workflow worker execution belongs in [workflow runtime](./08-workflow-runtime.md).
-- The managed job service is outside this package; this package owns the client,
-  schemas, discovery, and local task runner.
+- The managed job service owns queueing and dispatch. This package owns the
+  client, schemas, discovery, and local task runner.
 
 ## Change checks
 

--- a/docs/guides/jobs.md
+++ b/docs/guides/jobs.md
@@ -6,12 +6,16 @@ order: 29
 
 Veryfront jobs run durable, project-scoped background work on the platform. Create them through the SDK, REST API, or first-party Studio flows.
 
-- A **job** runs once.
-- A **cron job** runs on a schedule and creates jobs over time.
-- A **target** names the capability being executed (for example, `task:knowledge-ingest`).
+- A **job** runs one target.
+- A **cron job** runs on a schedule and creates runs over time.
+- A **target** names the capability being executed, for example `task:knowledge-ingest` or `workflow:content-pipeline`.
 - **events** are the canonical user-visible output stream.
 - **logs** are raw debugging output.
 - A **batch** groups related jobs together.
+
+Jobs are the platform execution surface. Task and workflow files are
+definitions. Starting a task creates a job run. Starting a workflow creates a
+workflow run backed by a job.
 
 ## Prerequisites
 
@@ -77,6 +81,26 @@ console.log(job.id);
 console.log(job.status);
 ```
 
+Use a task target to run a task definition:
+
+```ts
+await jobs.create({
+  name: "Sync data",
+  target: "task:sync-data",
+  config: { batchSize: 100 },
+});
+```
+
+Use a workflow target when the target is a workflow definition:
+
+```ts
+await jobs.create({
+  name: "Run content pipeline",
+  target: "workflow:content-pipeline",
+  config: { topic: "AI agents" },
+});
+```
+
 ## Observe a job
 
 Prefer `events()` for progress and user-visible activity:
@@ -140,6 +164,9 @@ const cronJob = await jobs.cron.create({
 console.log(cronJob.id);
 console.log(cronJob.schedule);
 ```
+
+Cron jobs use the same target model. A `task:<task-id>` cron job creates job
+runs. A `workflow:<workflow-id>` cron job creates workflow runs.
 
 You can later inspect or update it:
 

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -6,6 +6,10 @@ order: 25
 
 A workflow is a file in `workflows/` that declares ordered steps. Each step runs an agent or a tool, and the workflow runtime threads outputs between them. Steps support parallel execution, branches, loops, retries, timeouts, and human-in-the-loop approvals.
 
+Workflow files are definitions. Starting a workflow creates a workflow run. On
+the Veryfront platform, that workflow run is backed by a job so it can be
+queued, retried, canceled, logged, and observed in the Jobs panel.
+
 ## Prerequisites
 
 - A Veryfront project with the `workflows/` directory available (see
@@ -154,6 +158,29 @@ export default tool({
 ```
 
 Use `handle.result()` only when the caller should wait for completion. Return the `runId` when the workflow can continue in the background.
+
+## Schedule a workflow
+
+Use a cron job with a workflow target when a workflow must run on a schedule:
+
+```ts
+import { createJobsClient } from "veryfront/jobs";
+
+const jobs = createJobsClient({
+  authToken: process.env.VERYFRONT_API_TOKEN,
+  projectReference: "dreamy-haven",
+});
+
+await jobs.cron.create({
+  name: "Daily content pipeline",
+  target: "workflow:content-pipeline",
+  schedule: "0 8 * * *",
+  timezone: "Europe/Stockholm",
+  config: { topic: "Daily update" },
+});
+```
+
+Each scheduled trigger creates a workflow run backed by a job.
 
 ## Steps
 


### PR DESCRIPTION
## Summary\n- Clarify that task definitions create job runs and workflow definitions create workflow runs backed by jobs.\n- Document target syntax for task and workflow job targets.\n- Align jobs and workflows guides with the platform execution model.\n\n## Verification\n- git diff --check\n- deno fmt --check docs/architecture/09-jobs-and-tasks.md docs/architecture/08-workflow-runtime.md docs/guides/jobs.md docs/guides/workflows.md\n- push hook: full pre-push checks