### PR TITLE
Bump veryfront to 0.1.564

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.563",
+  "version": "0.1.564",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.563";
+export const VERSION = "0.1.564";


### PR DESCRIPTION
## Summary
- bump the public veryfront package version to 0.1.564
- update the generated version constant used by runtime/version helpers

## Verification
- git diff --check
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- pre-push hook: format, lint, typecheck, and unit tests passed