### PR TITLE
Use canonical job runtime target fields

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.564",
+  "version": "0.1.565",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/veryfront/jobs.md
+++ b/docs/reference/veryfront/jobs.md
@@ -40,91 +40,93 @@ const events = await jobs.events(job.id);
 
 ### Components
 
-| Name | Description | Source |
-|------|-------------|--------|
-| `CronJobSchema` | Zod schema for cron job. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L400) |
-| `CronJobStatusSchema` | Zod schema for cron job status. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L340) |
-| `JobBatchResultSchema` | Zod schema for job batch result. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L392) |
-| `JobBatchSchema` | Zod schema for job batch. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L394) |
-| `JobBatchStatusCountsSchema` | Zod schema for job batch status counts. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L390) |
-| `JobEventSchema` | Zod schema for job event. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L378) |
-| `JobEventsResponseSchema` | Zod schema for job events response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L380) |
-| `JobKindSchema` | Zod schema for job kind. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L342) |
-| `JobListItemSchema` | Zod schema for job list item. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L374) |
-| `JobLogsResponseSchema` | Zod schema for job logs response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L382) |
-| `JobResultSchema` | Zod schema for job result. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L368) |
-| `JobResultSummarySchema` | Zod schema for job result summary. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L370) |
-| `JobSchema` | Zod schema for job. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L372) |
-| `JobStatusSchema` | Zod schema for job status. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L338) |
-| `JobTargetDefinitionSchema` | Zod schema for job target definition. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L396) |
-| `JobTargetDefinitionsResponseSchema` | Zod schema for job target definitions response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L398) |
-| `KnowledgeIngestBatchSourceSchema` | Zod schema for knowledge ingest batch source. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L384) |
+| Name                                          | Description                                                | Source                                                                                   |
+| --------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `CronJobSchema`                               | Zod schema for cron job.                                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L400) |
+| `CronJobStatusSchema`                         | Zod schema for cron job status.                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L340) |
+| `JobBatchResultSchema`                        | Zod schema for job batch result.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L392) |
+| `JobBatchSchema`                              | Zod schema for job batch.                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L394) |
+| `JobBatchStatusCountsSchema`                  | Zod schema for job batch status counts.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L390) |
+| `JobEventSchema`                              | Zod schema for job event.                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L378) |
+| `JobEventsResponseSchema`                     | Zod schema for job events response.                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L380) |
+| `JobKindSchema`                               | Zod schema for job kind.                                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L342) |
+| `JobListItemSchema`                           | Zod schema for job list item.                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L374) |
+| `JobLogsResponseSchema`                       | Zod schema for job logs response.                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L382) |
+| `JobResultSchema`                             | Zod schema for job result.                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L368) |
+| `JobResultSummarySchema`                      | Zod schema for job result summary.                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L370) |
+| `JobSchema`                                   | Zod schema for job.                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L372) |
+| `JobStatusSchema`                             | Zod schema for job status.                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L338) |
+| `JobTargetDefinitionSchema`                   | Zod schema for job target definition.                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L396) |
+| `JobTargetDefinitionsResponseSchema`          | Zod schema for job target definitions response.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L398) |
+| `KnowledgeIngestBatchSourceSchema`            | Zod schema for knowledge ingest batch source.              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L384) |
 | `KnowledgeIngestBatchSourceWithMessageSchema` | Zod schema for knowledge ingest batch source with message. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L386) |
-| `KnowledgeIngestFailedFileResultSchema` | Zod schema for knowledge ingest failed file result. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L354) |
-| `KnowledgeIngestFileResultSchema` | Zod schema for knowledge ingest file result. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L348) |
-| `KnowledgeIngestJobResultCountsSchema` | Zod schema for knowledge ingest job result counts. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L362) |
-| `KnowledgeIngestJobResultMetadataSchema` | Zod schema for knowledge ingest job result metadata. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L358) |
-| `KnowledgeIngestJobResultSchema` | Zod schema for knowledge ingest job result. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L366) |
-| `KnowledgeIngestSkippedFileResultSchema` | Zod schema for knowledge ingest skipped file result. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L350) |
-| `PageInfoSchema` | Zod schema for page info. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L346) |
-| `PaginatedCronJobsResponseSchema` | Zod schema for paginated cron jobs response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L402) |
-| `PaginatedJobsResponseSchema` | Zod schema for paginated jobs response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L376) |
-| `ReservedJobTargetFamilySchema` | Zod schema for reserved job target family. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L344) |
+| `KnowledgeIngestFailedFileResultSchema`       | Zod schema for knowledge ingest failed file result.        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L354) |
+| `KnowledgeIngestFileResultSchema`             | Zod schema for knowledge ingest file result.               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L348) |
+| `KnowledgeIngestJobResultCountsSchema`        | Zod schema for knowledge ingest job result counts.         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L362) |
+| `KnowledgeIngestJobResultMetadataSchema`      | Zod schema for knowledge ingest job result metadata.       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L358) |
+| `KnowledgeIngestJobResultSchema`              | Zod schema for knowledge ingest job result.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L366) |
+| `KnowledgeIngestSkippedFileResultSchema`      | Zod schema for knowledge ingest skipped file result.       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L350) |
+| `PageInfoSchema`                              | Zod schema for page info.                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L346) |
+| `PaginatedCronJobsResponseSchema`             | Zod schema for paginated cron jobs response.               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L402) |
+| `PaginatedJobsResponseSchema`                 | Zod schema for paginated jobs response.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L376) |
+| `ReservedJobTargetFamilySchema`               | Zod schema for reserved job target family.                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L344) |
 
 ### Functions
 
-| Name | Description | Source |
-|------|-------------|--------|
+| Name               | Description         | Source                                                                                       |
+| ------------------ | ------------------- | -------------------------------------------------------------------------------------------- |
 | `createJobsClient` | Create jobs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L578) |
 
 ### Classes
 
-| Name | Description | Source |
-|------|-------------|--------|
+| Name                  | Description                      | Source                                                                                       |
+| --------------------- | -------------------------------- | -------------------------------------------------------------------------------------------- |
 | `VeryfrontJobsClient` | Implement veryfront jobs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L171) |
 
 ### Types
 
-| Name | Description | Source |
-|------|-------------|--------|
-| `CreateCronJobInput` | Input payload for create cron job. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L116) |
-| `CreateJobInput` | Input payload for create job. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L74) |
-| `CronJob` | Public API contract for cron job. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L478) |
-| `CronJobStatus` | Public API contract for cron job status. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L408) |
-| `Job` | Public API contract for job. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L443) |
-| `JobBatch` | Public API contract for job batch. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L468) |
-| `JobBatchResult` | Result returned from job batch. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L466) |
-| `JobBatchStatusCounts` | Public API contract for job batch status counts. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L464) |
-| `JobEvent` | Event emitted for job. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L449) |
-| `JobEventsResponse` | Response payload for job events. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L451) |
-| `JobKind` | Public API contract for job kind. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L410) |
-| `JobListItem` | Public API contract for job list item. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L445) |
-| `JobLogsResponse` | Response payload for job logs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L453) |
-| `JobResult` | Result returned from job. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L439) |
-| `JobResultSummary` | Public API contract for job result summary. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L441) |
-| `JobStatus` | Public API contract for job status. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L406) |
-| `JobTargetDefinition` | Definition for job target. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L471) |
-| `JobTargetDefinitionsResponse` | Response payload for job target definitions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L473) |
-| `KnowledgeIngestBatchSource` | Public API contract for knowledge ingest batch source. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L456) |
-| `KnowledgeIngestBatchSourceWithMessage` | Message shape for knowledge ingest batch source with. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L460) |
-| `KnowledgeIngestByUploadIdsInput` | Input payload for knowledge ingest by upload IDs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L94) |
-| `KnowledgeIngestByUploadPathsInput` | Input payload for knowledge ingest by upload paths. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L99) |
-| `KnowledgeIngestByUploadPrefixInput` | Input payload for knowledge ingest by upload prefix. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L104) |
-| `KnowledgeIngestFailedFileResult` | Result returned from knowledge ingest failed file. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L425) |
-| `KnowledgeIngestFileResult` | Result returned from knowledge ingest file. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L417) |
-| `KnowledgeIngestJobOptions` | Options accepted by knowledge ingest job. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L85) |
-| `KnowledgeIngestJobResult` | Result returned from knowledge ingest job. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L435) |
-| `KnowledgeIngestSkippedFileResult` | Result returned from knowledge ingest skipped file. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L421) |
-| `ListBatchJobsOptions` | Options accepted by list batch jobs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L109) |
-| `ListCronJobsOptions` | Options accepted by list cron jobs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L129) |
-| `ListJobEventsOptions` | Options accepted by list job events. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L67) |
-| `ListJobsOptions` | Options accepted by list jobs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L57) |
-| `PaginatedCronJobsResponse` | Response payload for paginated cron jobs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L480) |
-| `PaginatedJobsResponse` | Response payload for paginated jobs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L447) |
-| `ProjectScopedOptions` | Options accepted by project scoped. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L52) |
-| `ReservedJobTargetFamily` | Public API contract for reserved job target family. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L412) |
-| `UpdateCronJobInput` | Input payload for update cron job. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L137) |
-| `VeryfrontJobsClientConfig` | Configuration used by veryfront jobs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L44) |
+| Name                                    | Description                                            | Source                                                                                       |
+| --------------------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `CreateCronJobInput`                    | Input payload for create cron job.                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L116) |
+| `CreateJobInput`                        | Input payload for create job.                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L74)  |
+| `CronJob`                               | Public API contract for cron job.                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L478)     |
+| `CronJobStatus`                         | Public API contract for cron job status.               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L408)     |
+| `Job`                                   | Public API contract for job.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L443)     |
+| `JobBatch`                              | Public API contract for job batch.                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L468)     |
+| `JobBatchResult`                        | Result returned from job batch.                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L466)     |
+| `JobBatchStatusCounts`                  | Public API contract for job batch status counts.       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L464)     |
+| `JobEvent`                              | Event emitted for job.                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L449)     |
+| `JobEventsResponse`                     | Response payload for job events.                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L451)     |
+| `JobKind`                               | Public API contract for job kind.                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L410)     |
+| `JobListItem`                           | Public API contract for job list item.                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L445)     |
+| `JobLogsResponse`                       | Response payload for job logs.                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L453)     |
+| `JobResult`                             | Result returned from job.                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L439)     |
+| `JobResultSummary`                      | Public API contract for job result summary.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L441)     |
+| `JobRuntimeTargetKind`                  | Runtime target for a job or cron job definition.       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L77)  |
+| `JobRuntimeTargetOptions`               | Runtime target fields accepted by job creation APIs.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L80)  |
+| `JobStatus`                             | Public API contract for job status.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L406)     |
+| `JobTargetDefinition`                   | Definition for job target.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L471)     |
+| `JobTargetDefinitionsResponse`          | Response payload for job target definitions.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L473)     |
+| `KnowledgeIngestBatchSource`            | Public API contract for knowledge ingest batch source. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L456)     |
+| `KnowledgeIngestBatchSourceWithMessage` | Message shape for knowledge ingest batch source with.  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L460)     |
+| `KnowledgeIngestByUploadIdsInput`       | Input payload for knowledge ingest by upload IDs.      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L94)  |
+| `KnowledgeIngestByUploadPathsInput`     | Input payload for knowledge ingest by upload paths.    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L99)  |
+| `KnowledgeIngestByUploadPrefixInput`    | Input payload for knowledge ingest by upload prefix.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L104) |
+| `KnowledgeIngestFailedFileResult`       | Result returned from knowledge ingest failed file.     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L425)     |
+| `KnowledgeIngestFileResult`             | Result returned from knowledge ingest file.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L417)     |
+| `KnowledgeIngestJobOptions`             | Options accepted by knowledge ingest job.              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L85)  |
+| `KnowledgeIngestJobResult`              | Result returned from knowledge ingest job.             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L435)     |
+| `KnowledgeIngestSkippedFileResult`      | Result returned from knowledge ingest skipped file.    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L421)     |
+| `ListBatchJobsOptions`                  | Options accepted by list batch jobs.                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L109) |
+| `ListCronJobsOptions`                   | Options accepted by list cron jobs.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L129) |
+| `ListJobEventsOptions`                  | Options accepted by list job events.                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L67)  |
+| `ListJobsOptions`                       | Options accepted by list jobs.                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L57)  |
+| `PaginatedCronJobsResponse`             | Response payload for paginated cron jobs.              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L480)     |
+| `PaginatedJobsResponse`                 | Response payload for paginated jobs.                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L447)     |
+| `ProjectScopedOptions`                  | Options accepted by project scoped.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L52)  |
+| `ReservedJobTargetFamily`               | Public API contract for reserved job target family.    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/schemas.ts#L412)     |
+| `UpdateCronJobInput`                    | Input payload for update cron job.                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L137) |
+| `VeryfrontJobsClientConfig`             | Configuration used by veryfront jobs client.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/jobs/jobs-client.ts#L44)  |
 
 ## Related
 

--- a/src/jobs/index.ts
+++ b/src/jobs/index.ts
@@ -32,6 +32,8 @@ export {
   type CreateCronJobInput,
   type CreateJobInput,
   createJobsClient,
+  type JobRuntimeTargetKind,
+  type JobRuntimeTargetOptions,
   type KnowledgeIngestByUploadIdsInput,
   type KnowledgeIngestByUploadPathsInput,
   type KnowledgeIngestByUploadPrefixInput,

--- a/src/jobs/jobs-client.test.ts
+++ b/src/jobs/jobs-client.test.ts
@@ -196,6 +196,32 @@ describe("VeryfrontJobsClient", () => {
     });
   });
 
+  it("creates one-off jobs with canonical runtime target inputs", async () => {
+    mockFetch([jsonResponse(makeJob())]);
+
+    const client = new VeryfrontJobsClient({
+      apiUrl: "https://api.test.com",
+      authToken: "test-token",
+      projectReference: "dreamy-haven",
+    });
+
+    await client.create({
+      name: "Run preview task",
+      target: "task:preview-task",
+      runtimeTargetKind: "preview_branch",
+      runtimeTargetBranchId: "55555555-5555-4555-8555-555555555555",
+      config: {},
+    });
+
+    assertEquals(jsonBody(0), {
+      name: "Run preview task",
+      target: "task:preview-task",
+      runtime_target_kind: "preview_branch",
+      runtime_target_branch_id: "55555555-5555-4555-8555-555555555555",
+      config: {},
+    });
+  });
+
   it("creates knowledge ingest jobs by upload ids", async () => {
     mockFetch([jsonResponse(makeJob())]);
 

--- a/src/jobs/jobs-client.ts
+++ b/src/jobs/jobs-client.ts
@@ -73,11 +73,20 @@ export interface ListJobEventsOptions extends ProjectScopedOptions {
   direction?: "forward" | "backward";
 }
 
+/** Runtime target for a job or cron job definition. */
+export type JobRuntimeTargetKind = "main_branch" | "environment" | "preview_branch";
+
+/** Runtime target fields accepted by job creation APIs. */
+export interface JobRuntimeTargetOptions {
+  runtimeTargetKind?: JobRuntimeTargetKind;
+  runtimeTargetEnvironmentId?: string;
+  runtimeTargetBranchId?: string;
+}
+
 /** Input payload for create job. */
-export interface CreateJobInput extends ProjectScopedOptions {
+export interface CreateJobInput extends ProjectScopedOptions, JobRuntimeTargetOptions {
   name: string;
   target: string;
-  environmentId?: string;
   batchId?: string;
   config?: Record<string, unknown>;
   timeoutSeconds?: number;
@@ -85,9 +94,8 @@ export interface CreateJobInput extends ProjectScopedOptions {
 }
 
 /** Options accepted by knowledge ingest job. */
-export interface KnowledgeIngestJobOptions extends ProjectScopedOptions {
+export interface KnowledgeIngestJobOptions extends ProjectScopedOptions, JobRuntimeTargetOptions {
   name?: string;
-  environmentId?: string;
   batchId?: string;
   timeoutSeconds?: number;
   backoffLimit?: number;
@@ -116,10 +124,9 @@ export interface ListBatchJobsOptions extends ProjectScopedOptions {
 }
 
 /** Input payload for create cron job. */
-export interface CreateCronJobInput extends ProjectScopedOptions {
+export interface CreateCronJobInput extends ProjectScopedOptions, JobRuntimeTargetOptions {
   name: string;
   target: string;
-  environmentId?: string;
   schedule: string;
   timezone?: string;
   config?: Record<string, unknown>;
@@ -258,8 +265,16 @@ export class VeryfrontJobsClient {
   }
 
   create(input: CreateJobInput): Promise<Job> {
-    const { projectReference, environmentId, batchId, timeoutSeconds, backoffLimit, ...rest } =
-      input;
+    const {
+      projectReference,
+      runtimeTargetKind,
+      runtimeTargetEnvironmentId,
+      runtimeTargetBranchId,
+      batchId,
+      timeoutSeconds,
+      backoffLimit,
+      ...rest
+    } = input;
 
     return this.requestProjectJson(
       projectReference,
@@ -269,7 +284,9 @@ export class VeryfrontJobsClient {
         method: "POST",
         body: {
           ...rest,
-          environment_id: environmentId,
+          runtime_target_kind: runtimeTargetKind,
+          runtime_target_environment_id: runtimeTargetEnvironmentId,
+          runtime_target_branch_id: runtimeTargetBranchId,
           batch_id: batchId,
           timeout_seconds: timeoutSeconds,
           backoff_limit: backoffLimit,
@@ -376,7 +393,9 @@ export class VeryfrontJobsClient {
   private createCronJob(input: CreateCronJobInput): Promise<CronJob> {
     const {
       projectReference,
-      environmentId,
+      runtimeTargetKind,
+      runtimeTargetEnvironmentId,
+      runtimeTargetBranchId,
       timeoutSeconds,
       backoffLimit,
       concurrencyPolicy,
@@ -391,7 +410,9 @@ export class VeryfrontJobsClient {
         method: "POST",
         body: {
           ...rest,
-          environment_id: environmentId,
+          runtime_target_kind: runtimeTargetKind,
+          runtime_target_environment_id: runtimeTargetEnvironmentId,
+          runtime_target_branch_id: runtimeTargetBranchId,
           timeout_seconds: timeoutSeconds,
           backoff_limit: backoffLimit,
           concurrency_policy: concurrencyPolicy,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.564";
+export const VERSION = "0.1.565";


### PR DESCRIPTION
## Summary
- expose canonical job runtime target options in the public jobs client
- send runtime_target_kind plus scoped target ids when creating jobs and cron jobs
- remove legacy create-job target fields from the public create inputs
- bump the package version to 0.1.565 and update generated reference docs

## Verification
- deno fmt --check deno.json src/utils/version-constant.ts src/jobs/jobs-client.ts src/jobs/jobs-client.test.ts src/jobs/index.ts docs/reference/veryfront/jobs.md
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/jobs/jobs-client.test.ts src/jobs/index.test.ts
- pre-push verify: format, lint, typecheck, and unit tests