### PR TITLE
docs(guides): replace stale Quickstart refs in installation

### DIFF
--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -6,9 +6,7 @@ order: 1
 
 Install the `veryfront` CLI and framework so you can scaffold, run, and build Veryfront projects.
 
-Most users want the Quickstart flow that follows. The install methods below all produce the same `veryfront` CLI; pick the one that matches your toolchain.
-
-For the terminal, runtime, and network access prerequisites, see the Veryfront Code docs landing page.
+The install methods below all produce the same `veryfront` CLI; pick the one that matches your toolchain. Once installed, continue with [Create a project](./create-a-project.md).
 
 ## System requirements
 
@@ -47,7 +45,7 @@ Older browsers may work but are not part of the supported matrix.
 
 ## Install
 
-Pick the method that matches your toolchain. All five produce the same `veryfront` CLI; the tabs below give you the one-liner, and the sections that follow add detail and version-pinning options.
+The tabs below give you the one-liner for each method; the sections that follow add detail and version-pinning options.
 
 <CodeGroup>
 


### PR DESCRIPTION
## Summary

- `installation.md` opened with a reference to "the Quickstart flow that follows" and "the Veryfront Code docs landing page" — both stale leftovers from the recent `quickstart.md` → `installation.md` restructure (#1793). The page has no Quickstart section, and "docs landing page" has no concrete link target.
- Replace both stale sentences with one direct lead-in that links forward to `create-a-project.md` (the actual next step).
- Trim a now-redundant lead-in to the `## Install` section that repeated the same "all methods produce the same CLI" claim.

## Test plan

- [x] `tests/docs/guide-contracts.test.ts` snippets for `installation.md` still match (`npm create veryfront`, `brew install veryfront/tap/veryfront`, etc. all preserved).
- [x] No new banned-voice tokens introduced; no duplicate H1.
- [ ] Visual: renders without orphaned references in the docs site preview.

Found by a calibration pass of the new `.claude/skills/vf-doc-review` skill against the Getting Started flow.