### PR TITLE
docs(guides): correct capability type names in extension-authoring

### DIFF
--- a/docs/guides/extension-authoring.md
+++ b/docs/guides/extension-authoring.md
@@ -35,7 +35,7 @@ Validate the extension shape:
 veryfront extension validate extensions/my-cache
 ```
 
-For a **first-party** extension that lives in the Veryfront monorepo, use an `ext-` prefix on the directory name (e.g. `veryfront extension init ext-my-cache`). The capability and contract audits in `scripts/lint/audit-extension-{capabilities,contracts}.ts` only scan directories whose name starts with `ext-`; an extension named without the prefix is silently excluded from those CI gates. The prefix is optional for local extensions inside a downstream project.
+For a **first-party** extension that lives in the Veryfront monorepo, use an `ext-` prefix on the directory name (e.g. `veryfront extension init ext-my-cache`). The capability and contract audits run by `deno task lint:extension-capabilities` and `deno task lint:extension-contracts` only check extensions whose directory name starts with `ext-`. Without the prefix the extension is silently excluded from those CI gates. The prefix is optional for local extensions inside a downstream project.
 
 ## Write a factory
 
@@ -84,7 +84,7 @@ Use `setup(ctx)` when the implementation needs async initialization or dynamic c
 
 ## Declare capabilities
 
-Capabilities document what the extension needs at runtime. The `type` string and its scope field both come from `src/extensions/capabilities.ts` — these are also the names the Deno permission map and the CI capability audit recognize.
+Capabilities document what the extension needs at runtime. Use a recognized `type` string and its matching scope field so the framework can map the capability to a Deno permission flag and audit it in CI.
 
 ```ts
 const extension: ExtensionFactory = () => ({
@@ -107,7 +107,7 @@ Recognized capability types:
 | `net:listen`      | `host`, `ports[]`    | `--allow-net=host:port,...`   |
 | `env:read`        | `keys: string[]`     | `--allow-env[=keys]`          |
 | `process:spawn`   | `commands: string[]` | `--allow-run[=commands]`      |
-| `native:ffi`      | —                    | `--allow-ffi`                 |
+| `native:ffi`      | (none)               | `--allow-ffi`                 |
 | `sandbox:execute` | `tools: string[]`    | (audit-only, no Deno mapping) |
 
 For first-party extensions, also mirror the same `capabilities` array in `deno.json` under `veryfront.capabilities`; `deno task lint:extension-capabilities` fails the build if the two drift.

--- a/docs/guides/extension-authoring.md
+++ b/docs/guides/extension-authoring.md
@@ -35,6 +35,8 @@ Validate the extension shape:
 veryfront extension validate extensions/my-cache
 ```
 
+For a **first-party** extension that lives in the Veryfront monorepo, use an `ext-` prefix on the directory name (e.g. `veryfront extension init ext-my-cache`). The capability and contract audits in `scripts/lint/audit-extension-{capabilities,contracts}.ts` only scan directories whose name starts with `ext-`; an extension named without the prefix is silently excluded from those CI gates. The prefix is optional for local extensions inside a downstream project.
+
 ## Write a factory
 
 ```ts
@@ -82,18 +84,33 @@ Use `setup(ctx)` when the implementation needs async initialization or dynamic c
 
 ## Declare capabilities
 
-Capabilities document what the extension needs:
+Capabilities document what the extension needs at runtime. The `type` string and its scope field both come from `src/extensions/capabilities.ts` — these are also the names the Deno permission map and the CI capability audit recognize.
 
 ```ts
 const extension: ExtensionFactory = () => ({
   name: "redis-cache",
   version: "1.0.0",
   capabilities: [
-    { type: "network", hosts: ["redis.example.com"] },
-    { type: "env", names: ["REDIS_URL"] },
+    { type: "net:outbound", hosts: ["redis.example.com"] },
+    { type: "env:read", keys: ["REDIS_URL"] },
   ],
 });
 ```
+
+Recognized capability types:
+
+| Type              | Scope field          | Deno permission               |
+| ----------------- | -------------------- | ----------------------------- |
+| `fs:read`         | `paths: string[]`    | `--allow-read[=paths]`        |
+| `fs:write`        | `paths: string[]`    | `--allow-write[=paths]`       |
+| `net:outbound`    | `hosts: string[]`    | `--allow-net[=hosts]`         |
+| `net:listen`      | `host`, `ports[]`    | `--allow-net=host:port,...`   |
+| `env:read`        | `keys: string[]`     | `--allow-env[=keys]`          |
+| `process:spawn`   | `commands: string[]` | `--allow-run[=commands]`      |
+| `native:ffi`      | —                    | `--allow-ffi`                 |
+| `sandbox:execute` | `tools: string[]`    | (audit-only, no Deno mapping) |
+
+For first-party extensions, also mirror the same `capabilities` array in `deno.json` under `veryfront.capabilities`; `deno task lint:extension-capabilities` fails the build if the two drift.
 
 ## Verify it worked
 


### PR DESCRIPTION
## Summary

- The "Declare capabilities" example in `docs/guides/extension-authoring.md` used capability `type` strings (`network`, `env`) and a scope field (`names`) that don't exist anywhere in the code. Following the guide literally produced extensions that are silently dropped by `mapToDenoPermissions` and that fail `deno task lint:extension-capabilities` for manifest/factory drift the moment someone tries to mirror them.
- Replaced the stale names with the actual values from `src/extensions/capabilities.ts`: `net:outbound` / `hosts`, `env:read` / `keys`.
- Added a full table of recognized capability types, their scope field, and the Deno permission flag each maps to — so the next reader doesn't have to grep `capabilities.ts` to find out.
- Added a note pointing out that `deno task lint:extension-capabilities` enforces manifest ↔ factory parity for first-party extensions.
- Added an `ext-` prefix note in the Scaffold section: `scripts/lint/audit-extension-{capabilities,contracts}.ts` only scan directories whose name starts with `ext-`, so a first-party extension scaffolded without the prefix silently misses those CI gates. The prefix remains optional for local extensions in a downstream project.

## Why now

Surfaced while building the `vf-ext-development` skill in #1807. The Codex review on that PR also flagged the `ext-` prefix gotcha, so the same accuracy fix is being landed in the canonical guide here.

## Test plan

- [x] `grep -n` confirms `network`/`env`/`names` capability names appear nowhere in `src/`, `scripts/`, or `extensions/` — they only existed in this doc.
- [x] Recognized types in the new table were copied directly from `DENO_PERMISSION_MAP` in `src/extensions/capabilities.ts`.
- [x] `ext-` prefix claim verified at `scripts/lint/audit-extension-capabilities.ts:198` and `audit-extension-contracts.ts:116` (`if (!entry.isDirectory || !entry.name.startsWith("ext-")) continue;`).
- [x] Pre-push hooks pass locally (fmt, lint, typecheck, 1905 unit tests).