### PR TITLE
Fix workflow jobs branch source context

### DIFF
--- a/cli/shared/project-source-context.test.ts
+++ b/cli/shared/project-source-context.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { getProxyProjectSourceContext } from "./project-source-context.ts";
+
+const ENV_KEYS = [
+  "VERYFRONT_PROJECT_SLUG",
+  "VERYFRONT_API_TOKEN",
+  "VERYFRONT_PROJECT_ID",
+  "VERYFRONT_BRANCH_REF",
+  "TENANT_BRANCH_ID",
+];
+
+describe("getProxyProjectSourceContext", () => {
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      Deno.env.delete(key);
+    }
+  });
+
+  it("uses VERYFRONT_BRANCH_REF when it is set", () => {
+    Deno.env.set("VERYFRONT_PROJECT_SLUG", "example-project");
+    Deno.env.set("VERYFRONT_API_TOKEN", "test-token");
+    Deno.env.set("VERYFRONT_PROJECT_ID", "project-id");
+    Deno.env.set("VERYFRONT_BRANCH_REF", "preview");
+    Deno.env.set("TENANT_BRANCH_ID", "branch-id");
+
+    assertEquals(getProxyProjectSourceContext(), {
+      projectSlug: "example-project",
+      token: "test-token",
+      projectId: "project-id",
+      branchRef: "preview",
+    });
+  });
+
+  it("uses TENANT_BRANCH_ID when VERYFRONT_BRANCH_REF is not set", () => {
+    Deno.env.set("VERYFRONT_PROJECT_SLUG", "example-project");
+    Deno.env.set("VERYFRONT_API_TOKEN", "test-token");
+    Deno.env.set("TENANT_BRANCH_ID", "branch-id");
+
+    assertEquals(getProxyProjectSourceContext(), {
+      projectSlug: "example-project",
+      token: "test-token",
+      projectId: undefined,
+      branchRef: "branch-id",
+    });
+  });
+});

--- a/cli/shared/project-source-context.ts
+++ b/cli/shared/project-source-context.ts
@@ -22,7 +22,7 @@ export interface ProjectSourceExecutionContext {
   proxyContext?: ProxyProjectSourceContext;
 }
 
-function getProxyProjectSourceContext(): ProxyProjectSourceContext | null {
+export function getProxyProjectSourceContext(): ProxyProjectSourceContext | null {
   const projectSlug = getEnv("VERYFRONT_PROJECT_SLUG")?.trim();
   const token = getEnv("VERYFRONT_API_TOKEN")?.trim();
 
@@ -31,7 +31,8 @@ function getProxyProjectSourceContext(): ProxyProjectSourceContext | null {
   }
 
   const projectId = getEnv("VERYFRONT_PROJECT_ID")?.trim();
-  const branchRef = getEnv("VERYFRONT_BRANCH_REF")?.trim();
+  const branchRef = getEnv("VERYFRONT_BRANCH_REF")?.trim() ||
+    getEnv("TENANT_BRANCH_ID")?.trim();
 
   return {
     projectSlug,

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.565",
+  "version": "0.1.566",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.565";
+export const VERSION = "0.1.566";


### PR DESCRIPTION
## Summary
- Use TENANT_BRANCH_ID as a fallback branch ref for proxy project source context
- Add regression coverage for branch ref precedence and fallback
- Bump Veryfront Code version to 0.1.566

## Verification
- deno test --no-check --allow-all cli/shared/project-source-context.test.ts src/task/runner.test.ts src/workflow/discovery/workflow-discovery.test.ts
- deno test --no-check --allow-all cli/shared/project-source-context.test.ts src/utils/version.test.ts src/utils/logger/logger.test.ts
- pre-push: fmt, lint, typecheck, unit tests