### PR TITLE
chore(skills): augment vf-ext-development with source priority, MISSING_EXTENSION_ERROR consequence, SBOM, and guide links

### DIFF
--- a/.claude/skills/vf-ext-development/SKILL.md
+++ b/.claude/skills/vf-ext-development/SKILL.md
@@ -121,7 +121,7 @@ export default extCacheRedis;
 - Default export is the factory (a function), not the extension object.
 - `name`, `version`, `capabilities` are required. Empty `capabilities: []` is valid.
 - `contracts.provides` is what `setup()` will register via `ctx.provide()` — list it even though `ctx.provide()` works at runtime, because the lint task checks manifest ↔ factory parity.
-- `contracts.requires` lists contracts you will `ctx.require()` — providers load before consumers via topological sort.
+- `contracts.requires` lists contracts you will `ctx.require()` — `src/extensions/loader.ts` builds the topological sort from this field. Without it, the consumer can load before its provider and `ctx.require()` throws `MISSING_EXTENSION_ERROR`.
 
 ## Capability types — use these names
 
@@ -159,6 +159,20 @@ async setup(ctx) {
 ```
 
 Don't combine — pick one mechanism per contract.
+
+## Source priority (conflict resolution)
+
+When two extensions provide the same contract, the framework picks the one with the lowest source priority number. Defined in `src/extensions/validation.ts`:
+
+| Source       | Priority | Where it comes from                           |
+| ------------ | -------- | --------------------------------------------- |
+| `config`     | 0        | Listed in `veryfront.config.ts` `extensions:` |
+| `package`    | 1        | Discovered through installed packages         |
+| `project`    | 2        | Project-level discovery                       |
+| `local-file` | 3        | Files under `extensions/` discovered by glob  |
+| `builtin`    | 4        | `createBuiltinExtensions()`                   |
+
+To override a builtin (e.g. swap `ext-schema-zod` for a custom validator), add a factory call to your project's `veryfront.config.ts` — it ships at `config` priority and wins. If multiple providers tie at the same priority, `detectConflicts()` reports the conflict and refuses to start.
 
 ## Sensitive extension policies
 
@@ -275,9 +289,10 @@ deno task lint:dependency-boundaries      # sensitive deps stay inside named ext
 deno task test:scripts                    # runs audit-extension-*.test.ts
 deno test --no-check --allow-all extensions/ext-<name>/src/
 veryfront extension validate extensions/ext-<name>
+deno task sbom:all --output-dir dist/dependency-sboms   # per-extension SBOM + aggregate
 ```
 
-A clean extension passes all six.
+A clean extension passes all seven. Run `sbom:all` only when adding or changing third-party dependencies — the output lands in `dist/dependency-sboms/` with one manifest per extension plus the aggregate, core, CLI, and React boundary views.
 
 ## Common Mistakes
 
@@ -299,3 +314,11 @@ A clean extension passes all six.
 | Missing `recommendations.ts` entry for a new contract                  | Add the contract → `@veryfront/ext-*` mapping so missing-extension errors are actionable |
 | Importing `../../src/...` from extension source                        | Use the `veryfront/extensions[/<area>]` alias from the local imports map                 |
 | Test leaves `REDIS_URL` (etc.) set                                     | Save the prior value, set/delete inside `try`, restore in `finally`                      |
+
+## Related
+
+- [`docs/guides/extensions.md`](../../../docs/guides/extensions.md) — enabling an extension
+- [`docs/guides/extension-authoring.md`](../../../docs/guides/extension-authoring.md) — factory basics
+- [`docs/guides/extension-lifecycle.md`](../../../docs/guides/extension-lifecycle.md) — discovery, ordering, teardown
+- [`docs/guides/extension-testing.md`](../../../docs/guides/extension-testing.md) — factory + contract tests
+- [`docs/guides/extension-publishing.md`](../../../docs/guides/extension-publishing.md) — package and release


### PR DESCRIPTION
## Context

#1807 landed `vf-ext-development` while this branch was open. Rather than open a separate follow-up, this PR is rebased onto the merged skill and adds the four pieces of information that the initial version omits.

## Changes (+25 / −2)

- **Source priority table** under a new "Source priority (conflict resolution)" H2. Documents `config (0) > package (1) > project (2) > local-file (3) > builtin (4)` and explains how to override a builtin via `veryfront.config.ts`. Source: `src/extensions/validation.ts`.
- **`MISSING_EXTENSION_ERROR` consequence** wedged into the `contracts.requires` bullet under Factory shape. Names the concrete failure mode when the field is missing (consumer loads before its provider; `ctx.require()` throws). Source: `src/extensions/loader.ts:79-150`.
- **`deno task sbom:all` line** in the Verification block plus a one-line note on when to run it and where output lands.
- **"Related" footer** linking the five `docs/guides/extension-*.md` guides for orientation.

No restructuring. All other content from #1807 stays as-is.

## Verification

- `deno fmt --check` passes
- All five new doc-link paths resolve on disk
- Pre-push hook ran the full test suite — 1906 passed, 0 failed
- Topo-sort and source-priority claims verified against `src/extensions/loader.ts` and `src/extensions/validation.ts`

## Test plan

- [ ] Skill loads and remains discoverable via the `Skill` tool
- [ ] The new "Source priority" section answers "how do I swap a builtin?" without leaving the skill
- [ ] The five `Related` links navigate to the right guides
