### PR TITLE
chore: bump version to 0.1.567

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.566",
+  "version": "0.1.567",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.566";
+export const VERSION = "0.1.567";


### PR DESCRIPTION
## Summary
- Bump `deno.json` from `0.1.566` to `0.1.567`.
- Keep `src/utils/version-constant.ts` in sync so the merged chat replay fix can publish/deploy as a new package version.

## Test Plan
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno check src/utils/version.ts`
