### PR TITLE
Propagate branch context for workflow jobs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.568",
+  "version": "0.1.569",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
@@ -200,6 +200,16 @@ describe("runWithRequestContext", () => {
     );
   });
 
+  it("should set branch from options", async () => {
+    await runWithRequestContext(
+      { projectSlug: "proj", token: "tok", branch: "feature-branch" },
+      async () => {
+        const ctx = getCurrentRequestContext();
+        assertEquals(ctx!.branch, "feature-branch");
+      },
+    );
+  });
+
   it("should default releaseId to null", async () => {
     await runWithRequestContext(
       { projectSlug: "proj", token: "tok" },

--- a/src/platform/adapters/fs/veryfront/request-context.ts
+++ b/src/platform/adapters/fs/veryfront/request-context.ts
@@ -63,15 +63,20 @@ export function runWithRequestContext<T>(
     projectId?: string;
     productionMode?: boolean;
     releaseId?: string | null;
+    branch?: string | null;
+    environmentName?: string | null;
   },
   fn: () => Promise<T>,
 ): Promise<T> {
+  const productionMode = options.productionMode ?? false;
   const context: RequestContext = {
     projectSlug: options.projectSlug,
     projectId: options.projectId,
     token: options.token,
-    productionMode: options.productionMode ?? false,
+    productionMode,
     releaseId: options.releaseId ?? null,
+    branch: productionMode ? null : (options.branch ?? null),
+    environmentName: options.environmentName ?? null,
     fileCache: new Map<string, string>(),
   };
   return asyncLocalStorage.run(context, fn);

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.568";
+export const VERSION = "0.1.569";

--- a/src/workflow/executor/workflow-executor.ts
+++ b/src/workflow/executor/workflow-executor.ts
@@ -192,6 +192,8 @@ export class WorkflowExecutor {
         projectId: requestCtx.projectId,
         productionMode: requestCtx.productionMode ?? false,
         releaseId: requestCtx.releaseId ?? null,
+        branch: requestCtx.branch ?? null,
+        environmentName: requestCtx.environmentName ?? null,
       }
       : undefined;
     const injectedProjectEnv = mergeInjectedWorkflowEnv(undefined, getProcessEnv());

--- a/src/workflow/types.ts
+++ b/src/workflow/types.ts
@@ -242,6 +242,10 @@ export interface CapturedTenantContext {
   productionMode: boolean;
   /** Release ID for production deployments */
   releaseId?: string | null;
+  /** Branch name or ID for preview mode */
+  branch?: string | null;
+  /** Environment name associated with this tenant context */
+  environmentName?: string | null;
 }
 
 /**

--- a/src/workflow/worker/executors/k8s.ts
+++ b/src/workflow/worker/executors/k8s.ts
@@ -271,14 +271,31 @@ export class K8sJobExecutor implements JobExecutor {
       return [];
     }
 
-    const { projectSlug, token, projectId, productionMode, releaseId } = run._tenant;
-    return [
+    const { projectSlug, token, projectId, productionMode, releaseId, branch, environmentName } =
+      run._tenant;
+    const env = [
       { name: "TENANT_PROJECT_SLUG", value: projectSlug },
       { name: "TENANT_TOKEN", value: token },
       { name: "TENANT_PROJECT_ID", value: projectId ?? "" },
       { name: "TENANT_PRODUCTION_MODE", value: productionMode ? "1" : "0" },
       { name: "TENANT_RELEASE_ID", value: releaseId ?? "" },
     ];
+
+    if (branch) {
+      env.push(
+        { name: "TENANT_BRANCH_ID", value: branch },
+        { name: "VERYFRONT_BRANCH_REF", value: branch },
+      );
+    }
+
+    if (environmentName) {
+      env.push(
+        { name: "TENANT_ENVIRONMENT_NAME", value: environmentName },
+        { name: "VERYFRONT_ENVIRONMENT_NAME", value: environmentName },
+      );
+    }
+
+    return env;
   }
 
   /**

--- a/src/workflow/worker/executors/process.ts
+++ b/src/workflow/worker/executors/process.ts
@@ -108,6 +108,14 @@ export class ProcessJobExecutor implements JobExecutor {
       processEnv.TENANT_PROJECT_ID = run._tenant.projectId ?? "";
       processEnv.TENANT_PRODUCTION_MODE = run._tenant.productionMode ? "1" : "0";
       processEnv.TENANT_RELEASE_ID = run._tenant.releaseId ?? "";
+      if (run._tenant.branch) {
+        processEnv.TENANT_BRANCH_ID = run._tenant.branch;
+        processEnv.VERYFRONT_BRANCH_REF = run._tenant.branch;
+      }
+      if (run._tenant.environmentName) {
+        processEnv.TENANT_ENVIRONMENT_NAME = run._tenant.environmentName;
+        processEnv.VERYFRONT_ENVIRONMENT_NAME = run._tenant.environmentName;
+      }
     }
 
     // Spawn the process

--- a/src/workflow/worker/shared.test.ts
+++ b/src/workflow/worker/shared.test.ts
@@ -1,7 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
+import {
+  getCurrentRequestContext,
+} from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
-import { getFinalRunExitCode, getTenantFromEnv } from "./shared.ts";
+import { getFinalRunExitCode, getTenantFromEnv, runWithTenantContext } from "./shared.ts";
 
 const ENV_KEYS = [
   "TENANT_PROJECT_SLUG",
@@ -9,6 +12,10 @@ const ENV_KEYS = [
   "TENANT_PROJECT_ID",
   "TENANT_PRODUCTION_MODE",
   "TENANT_RELEASE_ID",
+  "TENANT_BRANCH_ID",
+  "VERYFRONT_BRANCH_REF",
+  "TENANT_ENVIRONMENT_NAME",
+  "VERYFRONT_ENVIRONMENT_NAME",
 ] as const;
 
 const savedEnv = new Map<string, string | undefined>();
@@ -58,6 +65,7 @@ describe("workflow worker shared helpers", () => {
     Deno.env.set("TENANT_PROJECT_ID", "project-123");
     Deno.env.set("TENANT_PRODUCTION_MODE", "1");
     Deno.env.set("TENANT_RELEASE_ID", "release-1");
+    Deno.env.set("TENANT_BRANCH_ID", "branch-123");
 
     assertEquals(getTenantFromEnv(), {
       projectSlug: "acme",
@@ -65,7 +73,36 @@ describe("workflow worker shared helpers", () => {
       projectId: "project-123",
       productionMode: true,
       releaseId: "release-1",
+      branch: "branch-123",
     });
+  });
+
+  it("prefers the explicit Veryfront branch ref over the tenant branch id", () => {
+    rememberEnv();
+
+    Deno.env.set("TENANT_PROJECT_SLUG", "acme");
+    Deno.env.set("TENANT_TOKEN", "secret");
+    Deno.env.set("TENANT_BRANCH_ID", "branch-123");
+    Deno.env.set("VERYFRONT_BRANCH_REF", "feature/ref");
+
+    assertEquals(getTenantFromEnv()?.branch, "feature/ref");
+  });
+
+  it("restores branch context while executing workflow work", async () => {
+    await runWithTenantContext(
+      {
+        projectSlug: "acme",
+        token: "secret",
+        projectId: "project-123",
+        productionMode: false,
+        releaseId: null,
+        branch: "branch-123",
+      },
+      async () => {
+        const context = getCurrentRequestContext();
+        assertEquals(context?.branch, "branch-123");
+      },
+    );
   });
 
   it("maps waiting and unexpected statuses to success exit codes", () => {

--- a/src/workflow/worker/shared.ts
+++ b/src/workflow/worker/shared.ts
@@ -19,6 +19,9 @@ interface EntrypointExitCodes {
 export function getTenantFromEnv(): CapturedTenantContext | undefined {
   const projectSlug = getEnv("TENANT_PROJECT_SLUG");
   const token = getEnv("TENANT_TOKEN");
+  const branch = getEnv("VERYFRONT_BRANCH_REF") || getEnv("TENANT_BRANCH_ID");
+  const environmentName = getEnv("VERYFRONT_ENVIRONMENT_NAME") ||
+    getEnv("TENANT_ENVIRONMENT_NAME");
 
   if (!projectSlug || !token) {
     return undefined;
@@ -30,6 +33,8 @@ export function getTenantFromEnv(): CapturedTenantContext | undefined {
     projectId: getEnv("TENANT_PROJECT_ID"),
     productionMode: getEnv("TENANT_PRODUCTION_MODE") === "1",
     releaseId: getEnv("TENANT_RELEASE_ID"),
+    ...(branch ? { branch } : {}),
+    ...(environmentName ? { environmentName } : {}),
   };
 }
 
@@ -121,6 +126,8 @@ export function runWithTenantContext<T>(
       projectId: tenant.projectId,
       productionMode: tenant.productionMode,
       releaseId: tenant.releaseId,
+      branch: tenant.branch,
+      environmentName: tenant.environmentName,
     },
     fn,
   );


### PR DESCRIPTION
## Summary\n- preserve branch and environment context for workflow/job execution\n- pass branch context through process and Kubernetes job executors\n- bump package version to 0.1.567 for release\n\n## Verification\n- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts\n- deno test --no-check --allow-all src/workflow/worker/job-entrypoint.test.ts src/workflow/worker/shared.test.ts src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts\n- pre-push checks: format, lint, typecheck, unit tests