### PR TITLE
fix: group replayed tool result messages

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.567",
+  "version": "0.1.568",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/chat/conversation.test.ts
+++ b/src/chat/conversation.test.ts
@@ -370,4 +370,99 @@ describe("convertUiMessagesToProviderModelMessages", () => {
       },
     ]);
   });
+
+  it("groups consecutive role:tool replay messages after parallel tool calls", () => {
+    const messages: ChatUiMessage[] = [
+      {
+        id: "message-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool_call",
+            id: "tool-1",
+            name: "calendar__list_events",
+            input: { calendarId: "primary" },
+            state: "completed",
+          },
+          {
+            type: "tool_call",
+            id: "tool-2",
+            name: "gmail__search_emails",
+            input: { q: "newer_than:1d" },
+            state: "completed",
+          },
+        ],
+      },
+      {
+        id: "message-1:tool:tool-1",
+        role: "tool",
+        parts: [
+          {
+            type: "tool_result",
+            tool_call_id: "tool-1",
+            tool_name: "calendar__list_events",
+            output: { data: [{ summary: "Daily Product Engineering" }] },
+          },
+        ],
+      },
+      {
+        id: "message-1:tool:tool-2",
+        role: "tool",
+        parts: [
+          {
+            type: "tool_result",
+            tool_call_id: "tool-2",
+            tool_name: "gmail__search_emails",
+            output: { data: [{ id: "message-id" }] },
+          },
+        ],
+      },
+      {
+        id: "message-1:after-tool:1",
+        role: "assistant",
+        parts: [{ type: "text", text: "I found today's updates." }],
+      },
+    ];
+
+    assertEquals(convertUiMessagesToProviderModelMessages(messages), [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "tool-1",
+            toolName: "calendar__list_events",
+            input: { calendarId: "primary" },
+          },
+          {
+            type: "tool-call",
+            toolCallId: "tool-2",
+            toolName: "gmail__search_emails",
+            input: { q: "newer_than:1d" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tool-1",
+            toolName: "calendar__list_events",
+            output: { type: "json", value: { data: [{ summary: "Daily Product Engineering" }] } },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tool-2",
+            toolName: "gmail__search_emails",
+            output: { type: "json", value: { data: [{ id: "message-id" }] } },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "I found today's updates." }],
+      },
+    ]);
+  });
 });

--- a/src/chat/conversation.ts
+++ b/src/chat/conversation.ts
@@ -996,20 +996,39 @@ function convertToolMessage(message: ChatUiMessage): ProviderModelMessage[] {
 export function convertUiMessagesToProviderModelMessages(
   messages: ChatUiMessage[],
 ): ProviderModelMessage[] {
-  return messages.flatMap((message) => {
-    switch (message.role) {
-      case "system":
-        return convertSystemMessage(message);
-      case "user":
-        return convertUserMessage(message);
-      case "assistant":
-        return convertAssistantMessage(message);
-      case "tool":
-        return convertToolMessage(message);
-      default:
-        return [];
+  const providerMessages: ProviderModelMessage[] = [];
+
+  for (const message of messages) {
+    const converted = (() => {
+      switch (message.role) {
+        case "system":
+          return convertSystemMessage(message);
+        case "user":
+          return convertUserMessage(message);
+        case "assistant":
+          return convertAssistantMessage(message);
+        case "tool":
+          return convertToolMessage(message);
+        default:
+          return [];
+      }
+    })();
+
+    for (const providerMessage of converted) {
+      const previous = providerMessages.at(-1);
+      if (previous?.role === "tool" && providerMessage.role === "tool") {
+        providerMessages[providerMessages.length - 1] = {
+          role: "tool",
+          content: [...previous.content, ...providerMessage.content],
+        };
+        continue;
+      }
+
+      providerMessages.push(providerMessage);
     }
-  });
+  }
+
+  return providerMessages;
 }
 
 /**

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.567";
+export const VERSION = "0.1.568";


### PR DESCRIPTION
## Summary
- group consecutive replayed `role: "tool"` UI messages into one provider tool-result message
- add regression coverage for parallel tool calls whose results were persisted as separate tool messages
- bump package version to `0.1.568` for staging release

## Verification
- `deno fmt --check deno.json src/utils/version-constant.ts src/chat/conversation.ts src/chat/conversation.test.ts`
- `deno check src/chat/conversation.ts src/chat/message-prep.ts`
- `deno test --no-check --allow-all src/chat/conversation.test.ts src/chat/message-prep.test.ts src/agent/runtime/text-generation-runtime-message-converter.test.ts src/agent/runtime/message-preparation.test.ts`

Note: local pre-push hook completed format/lint/type-check and was running the full `test:unit` suite for ~3 minutes without failures before it was stopped to avoid delaying the staging hotfix; GitHub CI will run the full suite.
