### PR TITLE
fix: preserve grouped tool results in text runtime

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.568",
+  "version": "0.1.569",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/text-generation-runtime-message-converter.test.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.test.ts
@@ -325,7 +325,7 @@ describe("text-generation-runtime-message-converter", () => {
       ]);
     });
 
-    it("splits multiple tool results into one provider message per tool call", () => {
+    it("keeps multiple tool results from one replay message together for parallel tool calls", () => {
       const messages: Message[] = [{
         id: "tool_batch",
         role: "tool",
@@ -347,24 +347,23 @@ describe("text-generation-runtime-message-converter", () => {
 
       const result = convertToTextGenerationRuntimeMessages(messages);
 
-      assertEquals(result.length, 2);
+      assertEquals(result.length, 1);
       assertEquals(result[0], {
         role: "tool",
-        content: [{
-          type: "tool-result",
-          toolCallId: "tc1",
-          toolName: "a",
-          output: { type: "json", value: "r1" },
-        }],
-      });
-      assertEquals(result[1], {
-        role: "tool",
-        content: [{
-          type: "tool-result",
-          toolCallId: "tc2",
-          toolName: "b",
-          output: { type: "json", value: "r2" },
-        }],
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc1",
+            toolName: "a",
+            output: { type: "json", value: "r1" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tc2",
+            toolName: "b",
+            output: { type: "json", value: "r2" },
+          },
+        ],
       });
     });
 

--- a/src/agent/runtime/text-generation-runtime-message-converter.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.ts
@@ -192,20 +192,6 @@ export function convertToTextGenerationRuntimeMessage(msg: Message): TextGenerat
   }
 }
 
-function convertToolResultPart(
-  part: ToolResultPart,
-): TextGenerationRuntimeToolMessage {
-  return {
-    role: "tool",
-    content: [{
-      type: "tool-result",
-      toolCallId: part.toolCallId,
-      toolName: part.toolName ?? "unknown",
-      output: { type: "json", value: part.result },
-    }],
-  };
-}
-
 function hasProviderSendableAssistantContent(message: Message): boolean {
   if (message.role !== "assistant") return true;
 
@@ -233,23 +219,7 @@ export function convertToTextGenerationRuntimeMessages(
       continue;
     }
 
-    if (message.role !== "tool") {
-      textGenerationRuntimeMessages.push(convertToTextGenerationRuntimeMessage(message));
-      continue;
-    }
-
-    const toolResultParts = message.parts.filter((part): part is ToolResultPart =>
-      part.type === "tool-result"
-    );
-
-    if (toolResultParts.length === 0) {
-      textGenerationRuntimeMessages.push(convertToTextGenerationRuntimeMessage(message));
-      continue;
-    }
-
-    for (const toolResultPart of toolResultParts) {
-      textGenerationRuntimeMessages.push(convertToolResultPart(toolResultPart));
-    }
+    textGenerationRuntimeMessages.push(convertToTextGenerationRuntimeMessage(message));
   }
 
   return textGenerationRuntimeMessages;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.568";
+export const VERSION = "0.1.569";


### PR DESCRIPTION
## Summary
- keep multiple tool results from the same replayed tool message together when converting into text-generation runtime messages
- preserves separate tool result positions when the durable history has separate tool messages, but no longer splits parallel results out of one immediate provider tool-result message
- bump package version to `0.1.569` for staging release

## Verification
- `deno fmt --check deno.json src/utils/version-constant.ts src/agent/runtime/text-generation-runtime-message-converter.ts src/agent/runtime/text-generation-runtime-message-converter.test.ts src/chat/conversation.ts src/chat/conversation.test.ts`
- `deno check src/agent/runtime/text-generation-runtime-message-converter.ts src/chat/conversation.ts src/chat/message-prep.ts`
- `deno test --no-check --allow-all src/agent/runtime/text-generation-runtime-message-converter.test.ts src/agent/runtime/message-preparation.test.ts src/chat/conversation.test.ts src/chat/message-prep.test.ts`
