### PR TITLE
Improve workflow load diagnostics

### DIFF
--- a/cli/commands/workflow/command.test.ts
+++ b/cli/commands/workflow/command.test.ts
@@ -1,0 +1,30 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { formatWorkflowDiscoveryErrors } from "./command.ts";
+
+describe("workflow command", () => {
+  it("formats workflow load errors for non-debug logs", () => {
+    const lines = formatWorkflowDiscoveryErrors([
+      {
+        filePath: "workflows/my-workflow.ts",
+        error: "Step \"start\" must specify either 'agent' or 'tool'",
+      },
+    ]);
+
+    assertEquals(lines, [
+      "  - workflows/my-workflow.ts: Step \"start\" must specify either 'agent' or 'tool'",
+    ]);
+  });
+
+  it("limits workflow load errors in logs", () => {
+    const lines = formatWorkflowDiscoveryErrors(
+      Array.from({ length: 6 }, (_, index) => ({
+        filePath: `workflows/workflow-${index}.ts`,
+        error: "Invalid workflow",
+      })),
+    );
+
+    assertEquals(lines.length, 6);
+    assertEquals(lines.at(-1), "  - 1 more workflow file failed to load");
+  });
+});

--- a/cli/commands/workflow/command.ts
+++ b/cli/commands/workflow/command.ts
@@ -7,8 +7,28 @@ import { getEnv } from "veryfront/platform";
 import type { WorkflowArgs } from "./handler.ts";
 
 const WORKFLOW_STATUS_POLL_INTERVAL_MS = 1_000;
+const MAX_DISCOVERY_ERRORS_TO_PRINT = 5;
 
 export interface WorkflowOptions extends WorkflowArgs {}
+
+export interface WorkflowDiscoveryError {
+  filePath: string;
+  error: string;
+}
+
+export function formatWorkflowDiscoveryErrors(
+  errors: WorkflowDiscoveryError[],
+): string[] {
+  const visibleErrors = errors.slice(0, MAX_DISCOVERY_ERRORS_TO_PRINT);
+  const lines = visibleErrors.map((err) => `  - ${err.filePath}: ${err.error}`);
+  const hiddenCount = errors.length - visibleErrors.length;
+  if (hiddenCount > 0) {
+    lines.push(
+      `  - ${hiddenCount} more workflow file${hiddenCount === 1 ? "" : "s"} failed to load`,
+    );
+  }
+  return lines;
+}
 
 async function createWorkflowClient(debug: boolean) {
   const { createWorkflowClient } = await import(
@@ -124,6 +144,12 @@ export async function workflowCommand(options: WorkflowOptions): Promise<void> {
     const workflow = discovery.workflows.find((candidate) => candidate.id === workflowId);
     if (!workflow) {
       cliLogger.error(`Workflow "${workflowId}" not found.`);
+      if (discovery.errors.length > 0 && !options.debug) {
+        cliLogger.warn("Some workflow files could not be loaded:");
+        for (const line of formatWorkflowDiscoveryErrors(discovery.errors)) {
+          cliLogger.warn(line);
+        }
+      }
       if (discovery.workflows.length > 0) {
         cliLogger.info("Available workflows:");
         for (const candidate of discovery.workflows) {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.571",
+  "version": "0.1.572",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.571";
+export const VERSION = "0.1.572";


### PR DESCRIPTION
## Summary
- show workflow discovery load errors when a requested workflow cannot be found
- cap discovery error output so invalid workflow files do not hide the actionable cause
- bump package version for release propagation

## Tests
- deno test --no-check --allow-all cli/commands/workflow/command.test.ts src/workflow/discovery/workflow-discovery.test.ts
- pre-push full checks