### PR TITLE
Fix workflow discovery public import resolution

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.573",
+  "version": "0.1.574",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [
@@ -58,6 +58,7 @@
     "./workflow/claude-code": "./src/workflow/claude-code/index.ts",
     "./workflow/claude-code/react": "./src/workflow/claude-code/react/index.ts",
     "./workflow/discovery": "./src/workflow/discovery/index.ts",
+    "./schemas": "./src/schemas/index.ts",
     "./prompt": "./src/prompt/index.ts",
     "./resource": "./src/resource/index.ts",
     "./jobs": "./src/jobs/index.ts",

--- a/src/discovery/import-rewriter.test.ts
+++ b/src/discovery/import-rewriter.test.ts
@@ -1,0 +1,48 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { rewriteForDeno } from "./import-rewriter.ts";
+
+describe("discovery/import-rewriter", () => {
+  it("rewrites veryfront public imports for Deno temp module imports", () => {
+    const transformed = rewriteForDeno(
+      [
+        'import { defineSchema } from "veryfront/schemas";',
+        'import { tool } from "veryfront/tool";',
+        'import { step, workflow } from "veryfront/workflow";',
+      ].join("\n"),
+      "/project/workflows",
+    );
+
+    assertStringIncludes(transformed, import.meta.resolve("veryfront/schemas"));
+    assertStringIncludes(transformed, import.meta.resolve("veryfront/tool"));
+    assertStringIncludes(transformed, import.meta.resolve("veryfront/workflow"));
+    assertEquals(transformed.includes('from "veryfront/'), false);
+  });
+
+  it("rewrites supported veryfront public imports to globals in compiled Deno binaries", () => {
+    const transformed = rewriteForDeno(
+      [
+        'import { defineSchema } from "veryfront/schemas";',
+        'import { tool } from "veryfront/tool";',
+        'import { step, workflow } from "veryfront/workflow";',
+      ].join("\n"),
+      "/project/workflows",
+      { compiled: true },
+    );
+
+    assertStringIncludes(
+      transformed,
+      'const { defineSchema } = globalThis.__VERYFRONT_MODULES__["veryfront/schemas"]',
+    );
+    assertStringIncludes(
+      transformed,
+      'const { tool } = globalThis.__VERYFRONT_MODULES__["veryfront/tool"]',
+    );
+    assertStringIncludes(
+      transformed,
+      'const { step, workflow } = globalThis.__VERYFRONT_MODULES__["veryfront/workflow"]',
+    );
+    assertEquals(transformed.includes('from "veryfront/'), false);
+  });
+});

--- a/src/discovery/import-rewriter.ts
+++ b/src/discovery/import-rewriter.ts
@@ -9,13 +9,96 @@ import { isDenoCompiled } from "#veryfront/platform/compat/runtime.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import * as pathHelper from "#veryfront/compat/path";
 
+export const DISCOVERY_GLOBAL_VERYFRONT_MODULES = [
+  "veryfront/agent",
+  "veryfront/tool",
+  "veryfront/platform",
+  "veryfront/prompt",
+  "veryfront/resource",
+  "veryfront/embedding",
+  "veryfront/workflow",
+  "veryfront/schemas",
+] as const;
+
+interface DenoRewriteOptions {
+  compiled?: boolean;
+  resolveSpecifier?: (specifier: string) => string;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function toDestructuredBindings(imports: string): string {
+  return imports
+    .split(",")
+    .map((part) => part.trim().replace(/\s+as\s+/g, ": "))
+    .filter(Boolean)
+    .join(", ");
+}
+
+function rewriteDenoPublicVeryfrontImports(
+  code: string,
+  resolveSpecifier: (specifier: string) => string,
+): string {
+  const resolve = (specifier: string): string | null => {
+    try {
+      return resolveSpecifier(specifier);
+    } catch (_) {
+      return null;
+    }
+  };
+
+  return code
+    .replace(/from\s+["'](veryfront(?:\/[^"']+)?)["']/g, (match, specifier: string) => {
+      const resolved = resolve(specifier);
+      return resolved ? `from "${resolved}"` : match;
+    })
+    .replace(/import\s*\(\s*["'](veryfront(?:\/[^"']+)?)["']\s*\)/g, (match, specifier: string) => {
+      const resolved = resolve(specifier);
+      return resolved ? `import("${resolved}")` : match;
+    });
+}
+
+function rewriteDenoCompiledVeryfrontImports(code: string): string {
+  let transformed = code;
+
+  for (const mod of DISCOVERY_GLOBAL_VERYFRONT_MODULES) {
+    const escapedMod = escapeRegExp(mod);
+
+    const importPattern = new RegExp(
+      `import\\s*\\{([^}]+)\\}\\s*from\\s*["']${escapedMod}["'];?`,
+      "g",
+    );
+    transformed = transformed.replace(importPattern, (_match, imports: string) => {
+      return `const { ${
+        toDestructuredBindings(imports)
+      } } = globalThis.__VERYFRONT_MODULES__["${mod}"];`;
+    });
+
+    const namespacePattern = new RegExp(
+      `import\\s*\\*\\s*as\\s+(\\w+)\\s*from\\s*["']${escapedMod}["'];?`,
+      "g",
+    );
+    transformed = transformed.replace(namespacePattern, (_match, name: string) => {
+      return `const ${name} = globalThis.__VERYFRONT_MODULES__["${mod}"];`;
+    });
+  }
+
+  return transformed;
+}
+
 /**
  * Rewrite imports for Deno runtime
  * - Converts npm package imports to npm: specifier format
  * - Resolves relative imports to absolute file:// URLs
  * - For compiled binaries, rewrites veryfront imports to use globals
  */
-export function rewriteForDeno(code: string, fileDir: string): string {
+export function rewriteForDeno(
+  code: string,
+  fileDir: string,
+  options: DenoRewriteOptions = {},
+): string {
   const npmReplacements: Array<[RegExp, string]> = [
     [/from\s+["']zod["']/g, 'from "npm:zod"'],
     [/import\s*\(\s*["']zod["']\s*\)/g, 'import("npm:zod")'],
@@ -33,36 +116,14 @@ export function rewriteForDeno(code: string, fileDir: string): string {
   );
 
   // For compiled binaries, rewrite veryfront imports to use globals
-  if (isDenoCompiled) {
-    const veryfrontModules = [
-      "veryfront/agent",
-      "veryfront/tool",
-      "veryfront/platform",
-      "veryfront/prompt",
-      "veryfront/resource",
-    ];
-
-    for (const mod of veryfrontModules) {
-      const escapedMod = mod.replace(/\//g, "\\/");
-
-      // Match: import { ... } from "veryfront/..."
-      const importPattern = new RegExp(
-        `import\\s*\\{([^}]+)\\}\\s*from\\s*["']${escapedMod}["']`,
-        "g",
-      );
-      transformed = transformed.replace(importPattern, (_match, imports: string) => {
-        return `const {${imports}} = globalThis.__VERYFRONT_MODULES__["${mod}"]`;
-      });
-
-      // Match: import * as X from "veryfront/..."
-      const namespacePattern = new RegExp(
-        `import\\s*\\*\\s*as\\s+(\\w+)\\s*from\\s*["']${escapedMod}["']`,
-        "g",
-      );
-      transformed = transformed.replace(namespacePattern, (_match, name: string) => {
-        return `const ${name} = globalThis.__VERYFRONT_MODULES__["${mod}"]`;
-      });
-    }
+  const compiled = options.compiled ?? isDenoCompiled;
+  if (compiled) {
+    transformed = rewriteDenoCompiledVeryfrontImports(transformed);
+  } else {
+    transformed = rewriteDenoPublicVeryfrontImports(
+      transformed,
+      options.resolveSpecifier ?? ((specifier) => import.meta.resolve(specifier)),
+    );
   }
 
   return transformed;

--- a/src/discovery/transpiler.ts
+++ b/src/discovery/transpiler.ts
@@ -12,13 +12,22 @@ import * as pathHelper from "#veryfront/compat/path";
 import { getEsbuildLoader } from "#veryfront/utils/path-utils.ts";
 import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { FileDiscoveryContext } from "./types.ts";
-import { rewriteDiscoveryImports, rewriteForDeno } from "./import-rewriter.ts";
+import {
+  DISCOVERY_GLOBAL_VERYFRONT_MODULES,
+  rewriteDiscoveryImports,
+  rewriteForDeno,
+} from "./import-rewriter.ts";
 import { COMPILATION_ERROR, FILE_NOT_FOUND } from "#veryfront/errors/error-registry.ts";
 import { wrapWithCurrentContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
-// Static import ensures deno compile includes embedding in the binary.
-// Other modules (agent, tool, etc.) are statically imported elsewhere;
-// embedding is only referenced here.
+// Static imports ensure deno compile includes public discovery modules in the binary.
+import * as agentMod from "#veryfront/agent";
+import * as toolMod from "#veryfront/tool";
+import * as platformMod from "#veryfront/platform";
+import * as promptMod from "#veryfront/prompt";
+import * as resourceMod from "#veryfront/resource";
 import * as embeddingMod from "#veryfront/embedding/index.ts";
+import * as workflowMod from "#veryfront/workflow";
+import * as schemasMod from "#veryfront/schemas";
 
 const transpileCache = new Map<string, unknown>();
 
@@ -31,23 +40,18 @@ let veryfrontGlobalsInitialized = false;
 async function ensureVeryfrontGlobals(): Promise<void> {
   if (veryfrontGlobalsInitialized || !isDenoCompiled) return;
 
-  const loadModule = (specifier: string): Promise<unknown> => import(specifier);
-  const [agentMod, toolMod, platformMod, promptMod, resourceMod] = await Promise.all([
-    loadModule("#veryfront/agent"),
-    loadModule("#veryfront/tool"),
-    loadModule("#veryfront/platform"),
-    loadModule("#veryfront/prompt"),
-    loadModule("#veryfront/resource"),
-  ]);
-
-  (globalThis as Record<string, unknown>).__VERYFRONT_MODULES__ = {
+  const modules = {
     "veryfront/agent": agentMod,
     "veryfront/tool": toolMod,
     "veryfront/platform": platformMod,
     "veryfront/prompt": promptMod,
     "veryfront/resource": resourceMod,
     "veryfront/embedding": embeddingMod,
-  };
+    "veryfront/workflow": workflowMod,
+    "veryfront/schemas": schemasMod,
+  } satisfies Record<(typeof DISCOVERY_GLOBAL_VERYFRONT_MODULES)[number], unknown>;
+
+  (globalThis as Record<string, unknown>).__VERYFRONT_MODULES__ = modules;
 
   veryfrontGlobalsInitialized = true;
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.573";
+export const VERSION = "0.1.574";

--- a/src/workflow/discovery/workflow-discovery.test.ts
+++ b/src/workflow/discovery/workflow-discovery.test.ts
@@ -135,6 +135,39 @@ describe(
       assertEquals(result.workflows[0]?.exportName, "default");
     });
 
+    it("discovers workflow files that import public tool and schema APIs", async () => {
+      const adapter = createRuntimeAdapter({
+        "/project/workflows/smoke.ts": [
+          'import { defineSchema } from "veryfront/schemas";',
+          'import { tool } from "veryfront/tool";',
+          'import { step, workflow } from "veryfront/workflow";',
+          "",
+          "const startTool = tool({",
+          '  id: "smoke-start",',
+          '  description: "Complete the smoke workflow start step.",',
+          "  inputSchema: defineSchema((v) => v.object({}).passthrough())(),",
+          "  execute: async (input) => ({ ok: true, input }),",
+          "});",
+          "",
+          "export default workflow({",
+          '  id: "smoke",',
+          '  description: "Smoke workflow",',
+          "  steps: [step('start', { tool: startTool })],",
+          "});",
+        ].join("\n"),
+      });
+
+      const result = await discoverWorkflows({
+        projectDir: "/project",
+        adapter,
+        config: { fs: { type: "veryfront-api" } } as never,
+      });
+
+      assertEquals(result.errors, []);
+      assertEquals(result.workflows.map((workflow) => workflow.id), ["smoke"]);
+      assertEquals(result.workflows[0]?.definition.steps.length, 1);
+    });
+
     it("finds workflows by id through the discovery module loader", async () => {
       const adapter = createRuntimeAdapter({
         "/project/workflows/ping.ts": [


### PR DESCRIPTION
## Summary
- rewrite public veryfront imports before Deno temp-module discovery imports
- expose veryfront/schemas as a public export for generated workflow source
- include workflow/schema/tool public modules in compiled discovery globals
- bump package version to 0.1.574

## Verification
- deno test --no-check --allow-all cli/commands/workflow/command.test.ts src/discovery/import-rewriter.test.ts src/workflow/discovery/workflow-discovery.test.ts src/task/discovery.test.ts
- deno test --no-check --allow-all src/channels/invoke.test.ts src/server/handlers/request/channel-dispatch-request.test.ts src/server/handlers/request/channel-invoke.handler.test.ts src/server/handlers/request/internal-agents-list.handler.test.ts
- deno task typecheck
- pre-push checks: 1909 tests passed