### PR TITLE
Fix Node discovery runtime imports

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.574",
+  "version": "0.1.575",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/discovery/import-rewriter.test.ts
+++ b/src/discovery/import-rewriter.test.ts
@@ -1,7 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { rewriteForDeno } from "./import-rewriter.ts";
+import { rewriteDiscoveryImports, rewriteForDeno } from "./import-rewriter.ts";
 
 describe("discovery/import-rewriter", () => {
   it("rewrites veryfront public imports for Deno temp module imports", () => {
@@ -43,6 +44,24 @@ describe("discovery/import-rewriter", () => {
       transformed,
       'const { step, workflow } = globalThis.__VERYFRONT_MODULES__["veryfront/workflow"]',
     );
+    assertEquals(transformed.includes('from "veryfront/'), false);
+  });
+
+  it("resolves veryfront public imports for Node discovery modules without project-local dependencies", async () => {
+    const transformed = await rewriteDiscoveryImports(
+      [
+        'import { defineSchema } from "veryfront/schemas";',
+        'import { tool } from "veryfront/tool";',
+        'import { step, workflow } from "veryfront/workflow";',
+      ].join("\n"),
+      "/tmp/veryfront-project-without-node-modules",
+      createFileSystem(),
+      "/tmp/veryfront-project-without-node-modules/workflows",
+    );
+
+    assertStringIncludes(transformed, import.meta.resolve("veryfront/schemas"));
+    assertStringIncludes(transformed, import.meta.resolve("veryfront/tool"));
+    assertStringIncludes(transformed, import.meta.resolve("veryfront/workflow"));
     assertEquals(transformed.includes('from "veryfront/'), false);
   });
 });

--- a/src/discovery/import-rewriter.ts
+++ b/src/discovery/import-rewriter.ts
@@ -205,6 +205,29 @@ export async function rewriteDiscoveryImports(
       transformed = await rewritePackageImports(transformed, pkg);
     }
 
+    const resolveRuntimeSpecifierToFileUrl = (specifier: string): string | null => {
+      try {
+        const resolved = import.meta.resolve(specifier);
+        return resolved && resolved !== specifier ? resolved : null;
+      } catch (_) {
+        return null;
+      }
+    };
+
+    const rewriteResolvedSpecifierImports = (
+      input: string,
+      specifier: string,
+      resolvedUrl: string,
+    ): string => {
+      const escapedSpecifier = escapeRegExp(specifier);
+      return input
+        .replace(new RegExp(`from\\s*["']${escapedSpecifier}["']`, "g"), `from "${resolvedUrl}"`)
+        .replace(
+          new RegExp(`import\\s*\\(\\s*["']${escapedSpecifier}["']\\s*\\)`, "g"),
+          `import("${resolvedUrl}")`,
+        );
+    };
+
     // Handle veryfront package imports
     let vfPackagePath = pathHelper.join(projectDir, "node_modules", "veryfront");
     let exportsMap: Record<string, string | { import?: string }> = {};
@@ -239,6 +262,25 @@ export async function rewriteDiscoveryImports(
       if (typeof entry === "string") return entry;
       return entry.import ?? null;
     };
+
+    const veryfrontSpecifiers = new Set<string>();
+    for (const match of transformed.matchAll(/from\s+["'](veryfront(?:\/[^"']+)?)["']/g)) {
+      const specifier = match[1];
+      if (specifier) veryfrontSpecifiers.add(specifier);
+    }
+    for (
+      const match of transformed.matchAll(/import\s*\(\s*["'](veryfront(?:\/[^"']+)?)["']\s*\)/g)
+    ) {
+      const specifier = match[1];
+      if (specifier) veryfrontSpecifiers.add(specifier);
+    }
+
+    for (const specifier of veryfrontSpecifiers) {
+      const resolvedUrl = resolveRuntimeSpecifierToFileUrl(specifier);
+      if (resolvedUrl) {
+        transformed = rewriteResolvedSpecifierImports(transformed, specifier, resolvedUrl);
+      }
+    }
 
     // Rewrite veryfront subpath imports
     transformed = transformed.replace(

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.574";
+export const VERSION = "0.1.575";


### PR DESCRIPTION
## Summary
- resolve public veryfront/* imports through the runtime package in Node discovery modules
- add a regression test for project directories without local veryfront dependencies
- bump package version to 0.1.575 for release

## Verification
- deno test --no-check --allow-all src/discovery/import-rewriter.test.ts src/discovery/transpiler.test.ts src/workflow/discovery/workflow-discovery.test.ts cli/commands/workflow/command.test.ts
- deno fmt --check src/discovery/import-rewriter.ts src/discovery/import-rewriter.test.ts deno.json src/utils/version-constant.ts
- DENO_NO_PACKAGE_JSON=1 deno lint src/discovery/import-rewriter.ts src/discovery/import-rewriter.test.ts
- deno task typecheck
- git pre-push checks: format, lint, typecheck, unit tests