### PR TITLE
docs(guides): split index.md into Intro and Veryfront Code

### DIFF
--- a/docs/guides/agent-service-runtime.md
+++ b/docs/guides/agent-service-runtime.md
@@ -1,7 +1,7 @@
 ---
 title: "Agent service runtime"
 description: "Run Veryfront agents as separately deployed services."
-order: 18
+order: 19
 ---
 
 An agent service runs your agent as its own process, independent of the app server. Use it when you need a separate process boundary, direct control-plane registration, remote MCP tools, or service-level telemetry. Use a normal in-app route for everything else.

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -1,7 +1,7 @@
 ---
 title: "Agents"
 description: "Create an AI agent with a system prompt, tools, and memory."
-order: 17
+order: 18
 ---
 
 An agent is a file in `agents/` that exports a system prompt, optional tools, optional memory, and optional skills. The runtime auto-discovers it on startup and exposes it via `getAgent(id)` or a route created with `createAgUiHandler()`.

--- a/docs/guides/api-routes.md
+++ b/docs/guides/api-routes.md
@@ -1,7 +1,7 @@
 ---
 title: "API routes"
 description: "HTTP handlers, request parsing, and streaming responses."
-order: 13
+order: 14
 ---
 
 An API route is a file under `app/api/` (or `pages/api/`) that exports named HTTP method handlers. Handlers receive the standard Web `Request` and return a `Response`.

--- a/docs/guides/chat-composition.md
+++ b/docs/guides/chat-composition.md
@@ -1,7 +1,7 @@
 ---
 title: "Chat composition"
 description: "Build custom chat layouts with Chat and Message composition components."
-order: 22
+order: 23
 ---
 
 When the preset `Chat` component is too constrained, build a custom layout from `Chat.Root`, `Chat.MessageList`, `Chat.Composer`, and the `Message` compound components. Veryfront still owns the streaming, loading state, and message wiring.

--- a/docs/guides/chat-hooks.md
+++ b/docs/guides/chat-hooks.md
@@ -1,7 +1,7 @@
 ---
 title: "Chat hooks"
 description: "Use headless chat, agent, completion, voice, and thread hooks."
-order: 23
+order: 24
 ---
 
 Headless hooks expose the chat runtime without the preset UI.

--- a/docs/guides/chat-theming.md
+++ b/docs/guides/chat-theming.md
@@ -1,7 +1,7 @@
 ---
 title: "Chat theming"
 description: "Customize chat theme, feature toggles, sources, attachments, and contexts."
-order: 24
+order: 25
 ---
 
 Customize the `Chat` component's theme, attachments, model selector, sources, and feedback actions through props. Each option is independent: turn on what you need and leave the rest at the defaults.

--- a/docs/guides/chat-ui.md
+++ b/docs/guides/chat-ui.md
@@ -1,7 +1,7 @@
 ---
 title: "Chat UI"
 description: "Use the preset Chat component with the useChat hook."
-order: 21
+order: 22
 ---
 
 `Chat` is a complete chat interface in one component. It includes a composer, message list, streaming state, loading state, and scroll behavior.

--- a/docs/guides/choose-a-primitive.md
+++ b/docs/guides/choose-a-primitive.md
@@ -1,7 +1,7 @@
 ---
 title: "Choose a primitive"
 description: "Choose the smallest Veryfront primitive for the work."
-order: 9
+order: 10
 ---
 
 Pick the smallest primitive that matches the job. This keeps project structure

--- a/docs/guides/cli-knowledge-ingestion.md
+++ b/docs/guides/cli-knowledge-ingestion.md
@@ -1,7 +1,7 @@
 ---
 title: "CLI-first knowledge ingestion"
 description: "Turn uploads and local documents into project knowledge files with one command."
-order: 36
+order: 37
 ---
 
 `veryfront knowledge ingest` is the primary CLI workflow for getting documents into a project's knowledge base. It finds a source file, parses it, and writes generated markdown back into the project.

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -1,7 +1,7 @@
 ---
 title: "Coding agents"
 description: "Connect Claude Code, Cursor, Codex, and other MCP-aware coding agents to the Veryfront dev server."
-order: 32
+order: 33
 ---
 
 Connect Claude Code, Cursor, Codex, or any MCP-aware coding agent to your Veryfront dev server. The agent gets a focused dev toolset: live errors and logs, route listing, route preview, scaffolding, test and lint runners.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: "Configuration"
 description: "`veryfront.config.ts` options, environment variables, and runtime settings."
-order: 8
+order: 9
 ---
 
 Configure a Veryfront project in two places: `veryfront.config.ts` for project structure, build settings, and feature defaults; environment variables for secrets and deployment-specific values. The framework reads both automatically.

--- a/docs/guides/create-a-frontend.md
+++ b/docs/guides/create-a-frontend.md
@@ -1,7 +1,7 @@
 ---
 title: "Create a frontend"
 description: "Add a page and a navigation link to a Veryfront project."
-order: 5
+order: 6
 ---
 
 Add a page to your Veryfront project and link to it from the home page. This is the fifth step in the Getting Started flow, between [Create an API](./create-an-api.md) and [Deploy a project](./deploy-a-project.md).

--- a/docs/guides/create-a-project.md
+++ b/docs/guides/create-a-project.md
@@ -1,7 +1,7 @@
 ---
 title: "Create a project"
 description: "Scaffold a new Veryfront project from a template and run it locally."
-order: 2
+order: 3
 ---
 
 Scaffold a new Veryfront project from a template, then run it locally on the dev server. This is the second step in the Getting Started flow, between [Installation](./installation.md) and [Create an agent](./create-an-agent.md).

--- a/docs/guides/create-an-agent.md
+++ b/docs/guides/create-an-agent.md
@@ -1,7 +1,7 @@
 ---
 title: "Create an agent"
 description: "Define an AI agent and invoke it from server code in under five minutes."
-order: 3
+order: 4
 ---
 
 Define an agent in a Veryfront project, send it a message, and stream the response back. For tools, memory, skills, and hosted runs, see [Agents](./agents.md).

--- a/docs/guides/create-an-api.md
+++ b/docs/guides/create-an-api.md
@@ -1,7 +1,7 @@
 ---
 title: "Create an API"
 description: "Add an HTTP endpoint to a Veryfront project with a typed Request and Response."
-order: 4
+order: 5
 ---
 
 Add an HTTP endpoint to a Veryfront project. This is the fourth step in the Getting Started flow, between [Create an agent](./create-an-agent.md) and [Create a frontend](./create-a-frontend.md).

--- a/docs/guides/data-fetching.md
+++ b/docs/guides/data-fetching.md
@@ -1,7 +1,7 @@
 ---
 title: "Data fetching"
 description: "Server data, static generation, and client-side fetching."
-order: 12
+order: 13
 ---
 
 Veryfront pages can load data three ways: `getServerData` on every request, `getStaticData` at build time, or `fetch` from a client component. Each one has its place.

--- a/docs/guides/deploy-a-project.md
+++ b/docs/guides/deploy-a-project.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy a project"
 description: "Build a Veryfront project for production and ship it to Veryfront Cloud or another host."
-order: 6
+order: 7
 ---
 
 Build a Veryfront project for production and ship it. This is the final step in the Getting Started flow.

--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -1,7 +1,7 @@
 ---
 title: "Building and deploying"
 description: "Production builds, static export, and deployment targets."
-order: 42
+order: 43
 ---
 
 Build a Veryfront project for production with `veryfront build`, run the production server locally with `veryfront start`, then ship the build with `veryfront deploy` (Veryfront Cloud) or to any host that can run your chosen runtime.

--- a/docs/guides/extension-authoring.md
+++ b/docs/guides/extension-authoring.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension authoring"
 description: "Write focused Veryfront extension factories, contracts, and capabilities."
-order: 38
+order: 39
 ---
 
 An extension should address one capability boundary. Keep the factory small, declare requirements explicitly, and expose contracts through `provides` or `setup()`.

--- a/docs/guides/extension-lifecycle.md
+++ b/docs/guides/extension-lifecycle.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension lifecycle"
 description: "Understand extension discovery, ordering, presets, setup, and teardown."
-order: 39
+order: 40
 ---
 
 Veryfront loads extensions in a fixed order: discover the configured factories, flatten any presets, topologically sort so providers come before consumers, call each `setup()`, run the app, then call each `teardown()` in reverse on shutdown or reload. Knowing this order lets you write extensions that share contracts safely.

--- a/docs/guides/extension-publishing.md
+++ b/docs/guides/extension-publishing.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension publishing"
 description: "Package and publish reusable Veryfront extensions."
-order: 41
+order: 42
 ---
 
 Publish an extension when it should be reused across projects or installed as a first-party or third-party package.

--- a/docs/guides/extension-testing.md
+++ b/docs/guides/extension-testing.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension testing"
 description: "Test Veryfront extension factories and contract implementations."
-order: 40
+order: 41
 ---
 
 Extension tests should prove that the factory returns a valid extension and that provided contracts work through the extension loader.

--- a/docs/guides/extensions.md
+++ b/docs/guides/extensions.md
@@ -1,7 +1,7 @@
 ---
 title: "Extensions"
 description: "Understand how extensions add focused capabilities to Veryfront."
-order: 37
+order: 38
 ---
 
 Extensions are factories that add focused capabilities to a Veryfront project: a cache store, an auth provider, a database adapter, a model provider, an MDX content pipeline. Each extension implements one or more contracts that the rest of the framework consumes.

--- a/docs/guides/head-and-seo.md
+++ b/docs/guides/head-and-seo.md
@@ -1,7 +1,7 @@
 ---
 title: "Head and SEO"
 description: "Declarative metadata, Open Graph, and structured data."
-order: 15
+order: 16
 ---
 
 Set page metadata with the `Head` component: title, description, Open Graph and Twitter cards, favicons, fonts, and JSON-LD. Multiple `Head` components in the tree merge; page-level tags override layout-level tags for duplicate keys.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,106 +1,51 @@
 ---
-title: "Guides"
-description: "Task-based guides for building Veryfront apps, agents, workflows, and integrations."
+title: "Intro"
+description: "Start here. A short tour of the Veryfront Code guides and what you need to know before building."
 order: 0
 ---
 
-Use this index to pick the next task.
+Welcome to the Veryfront Code guides.
 
-New to Veryfront? Start with [Quickstart](./quickstart.md) to build a working
-agent app, then use the [Getting Started](#getting-started) sequence for each
-core task.
+Each guide is a focused, goal-oriented mini tutorial — pick the one
+that matches the outcome you want next.
 
-## Getting Started
+## What is Veryfront Code
 
-Quickstart gives you the full path in one guide. The six guides below split
-that path into focused tasks.
+Veryfront Code is a full-stack framework for building AI-powered
+applications and agents with TypeScript and React. Agents, workflows,
+tools, pages, and APIs are native primitives, not glued-together
+libraries.
 
-| Step                                        | Task                                                                 |
-| ------------------------------------------- | -------------------------------------------------------------------- |
-| [Quickstart](./quickstart.md)               | Build an agent app with a tool, chat UI, and deploy path.            |
-| [Installation](./installation.md)           | Install the Veryfront CLI and framework on macOS, Linux, or Windows. |
-| [Create a project](./create-a-project.md)   | Scaffold a project from a template and run it on the dev server.     |
-| [Create an agent](./create-an-agent.md)     | Define an agent and expose it as a streaming chat endpoint.          |
-| [Create an API](./create-an-api.md)         | Add an HTTP endpoint with a typed Request and Response.              |
-| [Create a frontend](./create-a-frontend.md) | Add a page and a navigation link.                                    |
-| [Deploy a project](./deploy-a-project.md)   | Build and ship to Veryfront Cloud or another host.                   |
+For the full feature tour and the catalog of every guide, see
+[Veryfront Code](./veryfront-code.md).
 
-## Guides
+## Prerequisite knowledge
 
-Use these guides when the quick start is not enough.
+These guides assume you are comfortable with:
 
-### Foundations
+- TypeScript — syntax and basic types.
+- React — components, props, and hooks.
+- A JavaScript runtime — Node.js, Deno, or Bun.
+- A terminal — running `npm`, `deno`, or shell commands.
 
-| Guide                                         | Task                                                                          |
-| --------------------------------------------- | ----------------------------------------------------------------------------- |
-| [Project structure](./project-structure.md)   | Place routes, agents, tools, workflows, skills, and shared code.              |
-| [Configuration](./configuration.md)           | Configure `veryfront.config.ts`, environment variables, and runtime settings. |
-| [Choose a primitive](./choose-a-primitive.md) | Pick the smallest Veryfront primitive that matches the work.                  |
-| [Production path](./production-path.md)       | Build one route from local project to production verification.                |
+You do not need prior experience with AI agents, model providers, or
+the Model Context Protocol. The guides introduce each concept where
+it first comes up.
 
-### Pages and APIs
+## How to use these guides
 
-| Guide                                       | Task                                                                        |
-| ------------------------------------------- | --------------------------------------------------------------------------- |
-| [Pages and routing](./pages-and-routing.md) | Add file-based pages, layouts, dynamic routes, and MDX content.             |
-| [Data fetching](./data-fetching.md)         | Load data on the server, prerender static pages, and fetch from the client. |
-| [API routes](./api-routes.md)               | Build HTTP handlers with request parsing and streaming responses.           |
-| [Middleware](./middleware.md)               | Add CORS, rate limiting, logging, and custom middleware pipelines.          |
-| [Head and SEO](./head-and-seo.md)           | Set page metadata, Open Graph tags, and structured data.                    |
+Each guide states what you will achieve, lists prerequisites, walks
+through a working example, and ends with a `## Next` or `## Related`
+section pointing to the natural follow-up.
 
-### AI primitives
+## Start here
 
-| Guide                                               | Task                                                                            |
-| --------------------------------------------------- | ------------------------------------------------------------------------------- |
-| [Providers](./providers.md)                         | Pick a model provider for local inference, Veryfront Cloud, or a direct vendor. |
-| [Agents](./agents.md)                               | Define an agent with a system prompt, tools, and memory.                        |
-| [Agent service runtime](./agent-service-runtime.md) | Run agents as separately deployed services.                                     |
-| [Tools](./tools.md)                                 | Define typed tools that agents can call.                                        |
-| [Memory and streaming](./memory-and-streaming.md)   | Add conversation memory and stream model output to the client.                  |
-
-### Chat UI
-
-| Guide                                     | Task                                                                        |
-| ----------------------------------------- | --------------------------------------------------------------------------- |
-| [Chat UI](./chat-ui.md)                   | Drop in the preset chat component with one hook and one API route.          |
-| [Chat composition](./chat-composition.md) | Build a custom chat layout with the composition components.                 |
-| [Chat hooks](./chat-hooks.md)             | Drive chat from headless hooks: chat, agent, completion, voice, and thread. |
-| [Chat theming](./chat-theming.md)         | Theme chat features, attachments, sources, models, and visuals.             |
-
-### Orchestration
-
-| Guide                                          | Task                                                                    |
-| ---------------------------------------------- | ----------------------------------------------------------------------- |
-| [Workflows](./workflows.md)                    | Define a DAG-based workflow with branches, retries, and parallel steps. |
-| [Workflows: advanced](./workflows-advanced.md) | Loops, blob storage for large artifacts, and React hooks for progress.  |
-| [Multi-agent](./multi-agent.md)                | Compose agents with delegation and agent-as-tool patterns.              |
-| [Skills](./skills.md)                          | Add project-level skills from `SKILL.md` files with tool restrictions.  |
-| [Tasks](./tasks.md)                            | Write background task functions that run locally or as cloud jobs.      |
-| [Jobs](./jobs.md)                              | Run one-off jobs, schedule cron jobs, and inspect batch summaries.      |
-
-### External systems
-
-| Guide                                                   | Task                                                                                  |
-| ------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| [MCP server](./mcp-server.md)                           | Expose tools, prompts, and resources over Model Context Protocol.                     |
-| [Coding agents](./coding-agents.md)                     | Connect Claude Code, Cursor, Codex, and other MCP-aware agents to the dev server.     |
-| [OAuth](./oauth.md)                                     | Sign users in with OAuth 2.0 and the built-in provider catalog.                       |
-| [Integrations](./integrations.md)                       | Wire config-driven integration tools with OAuth, token management, and API execution. |
-| [Sandbox](./sandbox.md)                                 | Run isolated commands and file operations in an ephemeral sandbox session.            |
-| [CLI knowledge ingestion](./cli-knowledge-ingestion.md) | Turn uploads and local documents into project knowledge files from the CLI.           |
-
-### Extensions
-
-| Guide                                             | Task                                                                       |
-| ------------------------------------------------- | -------------------------------------------------------------------------- |
-| [Extensions](./extensions.md)                     | Understand how extensions add focused capabilities to a Veryfront project. |
-| [Extension authoring](./extension-authoring.md)   | Write a focused extension factory, contract, and capability.               |
-| [Extension lifecycle](./extension-lifecycle.md)   | Trace extension discovery, ordering, setup, and teardown.                  |
-| [Extension testing](./extension-testing.md)       | Test an extension factory and the contracts it implements.                 |
-| [Extension publishing](./extension-publishing.md) | Package and publish a reusable extension.                                  |
-
-### Ship to production
-
-| Guide                                    | Task                                                            |
-| ---------------------------------------- | --------------------------------------------------------------- |
-| [Building and deploying](./deploying.md) | Production-build internals, static export, Docker, and targets. |
+- [**Quickstart**](./quickstart.md) — build an agent app end-to-end
+  in a single guide.
+- [**Veryfront Code**](./veryfront-code.md) — what the framework is,
+  why to use it, and a map of every guide.
+- [**Installation**](./installation.md) — install the CLI and set up
+  your first project.
+- Looking for a specific topic? See the
+  [grouped guide catalog](./veryfront-code.md#guides) on the
+  Veryfront Code page.

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -1,7 +1,7 @@
 ---
 title: "Installation"
 description: "Install the Veryfront CLI and framework on macOS, Linux, or Windows."
-order: 1
+order: 2
 ---
 
 Install the `veryfront` CLI and framework so you can scaffold, run, and build Veryfront projects.

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -1,7 +1,7 @@
 ---
 title: "Integrations"
 description: "Config-driven integration tools with OAuth, token management, and API execution across the built-in connector catalog."
-order: 34
+order: 35
 ---
 
 Veryfront integrations let agents call third-party services (GitHub, Slack, Linear, Stripe, and 50+ more) on behalf of users.

--- a/docs/guides/jobs.md
+++ b/docs/guides/jobs.md
@@ -1,7 +1,7 @@
 ---
 title: "Jobs and cron jobs"
 description: "Run project-scoped background work now or on a schedule through the Veryfront platform."
-order: 30
+order: 31
 ---
 
 Veryfront jobs run durable, project-scoped background work on the platform. Create them through the SDK, REST API, or first-party Studio flows.

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -1,7 +1,7 @@
 ---
 title: "MCP server"
 description: "Expose tools, prompts, and resources over Model Context Protocol."
-order: 31
+order: 32
 ---
 
 Mount an MCP server route in your app to expose your project's tools, prompts, and resources to MCP clients like Claude Desktop. The runtime auto-discovers everything under `tools/`, `prompts/`, and `resources/`, so the route handler is essentially a thin auth shim.

--- a/docs/guides/memory-and-streaming.md
+++ b/docs/guides/memory-and-streaming.md
@@ -1,7 +1,7 @@
 ---
 title: "Memory and streaming"
 description: "Conversation memory strategies and streaming responses."
-order: 20
+order: 21
 ---
 
 Agents are stateless by default: each request gets the messages the client sends, and nothing else. Configure `memory` on the agent to persist history across requests, and use `createAgUiHandler` to stream the response back.

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -1,7 +1,7 @@
 ---
 title: "Middleware"
 description: "CORS, rate limiting, logging, and custom middleware pipelines."
-order: 14
+order: 15
 ---
 
 Middleware runs before your route handler. Use it for CORS headers, rate limits, logging, timeouts, and auth checks. A `MiddlewarePipeline` chains middleware together and short-circuits to a `Response` when one rejects the request.

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -1,7 +1,7 @@
 ---
 title: "Multi-agent"
 description: "Agent composition, delegation, and agent-as-tool patterns."
-order: 27
+order: 28
 ---
 
 Veryfront supports two agent composition patterns:

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -1,7 +1,7 @@
 ---
 title: "OAuth"
 description: "OAuth 2.0 helpers with a built-in provider catalog."
-order: 33
+order: 34
 ---
 
 Sign users in with OAuth 2.0 using `veryfront/oauth`.

--- a/docs/guides/pages-and-routing.md
+++ b/docs/guides/pages-and-routing.md
@@ -1,7 +1,7 @@
 ---
 title: "Pages and routing"
 description: "File-based routing, layouts, dynamic routes, and MDX pages."
-order: 11
+order: 12
 ---
 
 Veryfront uses file-system based routing. Folders and files under `app/` (or `pages/`) define routes; layouts compose down the tree; brackets in path segments mark dynamic params.

--- a/docs/guides/production-path.md
+++ b/docs/guides/production-path.md
@@ -1,7 +1,7 @@
 ---
 title: "Production path"
 description: "Build one Veryfront route from local project to production verification."
-order: 10
+order: 11
 ---
 
 Take one Veryfront route from local dev to a deployed production check.

--- a/docs/guides/project-structure.md
+++ b/docs/guides/project-structure.md
@@ -1,7 +1,7 @@
 ---
 title: "Project structure"
 description: "Where to put routes, AI primitives, shared code, and configuration."
-order: 7
+order: 8
 ---
 
 A Veryfront project keeps routes in `app/` or `pages/`. Keep AI primitives at

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -1,7 +1,7 @@
 ---
 title: "Providers"
 description: "Provider registry with runtime conventions and explicit overrides."
-order: 16
+order: 17
 ---
 
 An agent's `model` is a `"provider/model"` string.

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -1,7 +1,7 @@
 ---
 title: "Sandbox"
 description: "Run isolated commands and file operations in ephemeral sandbox sessions."
-order: 35
+order: 36
 ---
 
 A sandbox is a short-lived, isolated workspace for executing commands and file operations away from your app process. Use it for code generation, repo inspection, file transformation, or script execution that you do not want to run in your trusted runtime.

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -1,7 +1,7 @@
 ---
 title: "Skills"
 description: "Define project-level agent capabilities as SKILL.md files with prompt augmentation, tool restrictions, and script execution."
-order: 28
+order: 29
 ---
 
 A skill is a directory under `skills/` containing a `SKILL.md` file. It bundles structured agent instructions, an `allowed_tools` policy, and optional reference files and executable scripts. The format follows the [agentskills.io](https://agentskills.io) specification.

--- a/docs/guides/tasks.md
+++ b/docs/guides/tasks.md
@@ -1,7 +1,7 @@
 ---
 title: "Tasks"
 description: "Define background task functions that can run locally or as cloud jobs."
-order: 29
+order: 30
 ---
 
 Tasks are user-defined functions in `tasks/`. Run them locally with `veryfront task <name>` or in the cloud as job runs.

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -1,7 +1,7 @@
 ---
 title: "Tools"
 description: "Define tools with schema-backed inputs that agents can call."
-order: 19
+order: 20
 ---
 
 A tool is a typed function an agent can call. It declares input, describes when to use it, and runs server-side code.

--- a/docs/guides/veryfront-code.md
+++ b/docs/guides/veryfront-code.md
@@ -1,0 +1,176 @@
+---
+title: "Veryfront Code"
+description: "What Veryfront Code is, why to use it, and a map of every guide grouped by topic."
+order: 1
+---
+
+Veryfront Code is a Deno-first, full-stack framework for building
+AI-powered applications and agents in TypeScript and React. Agents,
+workflows, tools, pages, APIs, and rendering are all native primitives
+in one package — not glued together from separate libraries. Veryfront
+runs on Node.js, Deno, and Bun, and deploys anywhere or through
+Veryfront Cloud with built-in preview environments and production
+hosting.
+
+## Why Veryfront Code
+
+Purpose-built for TypeScript and React, Veryfront Code gives you
+everything you need to build agentic full-stack applications
+out-of-the-box.
+
+- [**Agents**](./agents.md) — Build autonomous agents with model
+  routing, system prompts, hosted runs, and tool calling. Agents
+  reason about goals and iterate until they reach a final answer.
+  Supports AG-UI streaming, multi-agent composition, and hosted
+  child-run orchestration.
+
+- [**Tools**](./tools.md) — Define Zod-validated functions that
+  agents can call. Tools are auto-discovered from the file system
+  with no registration needed.
+
+- [**Workflows**](./workflows.md) — Orchestrate multi-step AI
+  pipelines with branching, parallelism, human-in-the-loop approval
+  gates, and durable crash recovery via Redis checkpoints.
+
+- [**Skills**](./skills.md) — Project-level agent capabilities
+  defined as `SKILL.md` files following the agentskills.io
+  specification. Skills provide prompt augmentation, tool allowlists,
+  and script invocation.
+
+- [**Jobs & Cron Jobs**](./jobs.md) — Run durable project-scoped
+  background work now or on a schedule through the Veryfront
+  platform.
+
+- [**Tasks**](./tasks.md) — File-based background task definitions
+  discovered automatically and runnable via the jobs system.
+
+- [**Multi-Agent**](./multi-agent.md) — Compose agents that delegate
+  to each other as tools for complex, coordinated tasks. AG-UI
+  control-plane for hosted agent orchestration.
+
+- [**Memory & Streaming**](./memory-and-streaming.md) — Give agents
+  conversation history and streaming responses. Built-in chat UI
+  components for React with AG-UI protocol support.
+
+- [**MCP Server**](./mcp-server.md) — Expose tools, prompts, and
+  resources via the Model Context Protocol. Includes SSE transport,
+  session management, and elicitation support.
+
+- [**Sandbox**](./sandbox.md) — Ephemeral compute environments for
+  isolated code runs with shell tools and agent service
+  integration.
+
+- [**Integrations**](./integrations.md) — Pre-built connectors with
+  OAuth flows, remote tools, and metadata for third-party services.
+
+- [**Pages & Routing**](./pages-and-routing.md) — File-based routing
+  with React Server Components, layouts, and server-side rendering.
+
+- [**Data Fetching & API Routes**](./data-fetching.md) — Server-side
+  data loading, API route handlers, and [middleware](./middleware.md)
+  with built-in [OAuth](./oauth.md) support.
+
+- [**Extensions**](./extensions.md) — Contract-based plugin system
+  with 12 first-party packages for LLM providers, bundling, CSS,
+  tracing, caching, and more.
+
+## Guides
+
+Topic-grouped catalog of every guide. Each guide is a mini tutorial
+for one concrete piece of the framework.
+
+### Getting Started
+
+Quickstart gives you the full path in one guide. The six guides below
+split that path into focused tasks.
+
+| Step                                        | What you will do                                                     |
+| ------------------------------------------- | -------------------------------------------------------------------- |
+| [Quickstart](./quickstart.md)               | Build an agent app with a tool, chat UI, and deploy path.            |
+| [Installation](./installation.md)           | Install the Veryfront CLI and framework on macOS, Linux, or Windows. |
+| [Create a project](./create-a-project.md)   | Scaffold a project from a template and run it on the dev server.     |
+| [Create an agent](./create-an-agent.md)     | Define an agent and expose it as a streaming chat endpoint.          |
+| [Create an API](./create-an-api.md)         | Add an HTTP endpoint with a typed Request and Response.              |
+| [Create a frontend](./create-a-frontend.md) | Add a page and a navigation link.                                    |
+| [Deploy a project](./deploy-a-project.md)   | Build and ship to Veryfront Cloud or another host.                   |
+
+### Foundations
+
+| Guide                                         | What you will do                                                              |
+| --------------------------------------------- | ----------------------------------------------------------------------------- |
+| [Project structure](./project-structure.md)   | Learn the file conventions and how auto-discovery wires your project up.      |
+| [Configuration](./configuration.md)           | Configure `veryfront.config.ts`, environment variables, and runtime settings. |
+| [Choose a primitive](./choose-a-primitive.md) | Pick the smallest Veryfront primitive that matches the work.                  |
+| [Production path](./production-path.md)       | Build one route from local project to production verification.                |
+
+### Pages and APIs
+
+| Guide                                       | What you will do                                                            |
+| ------------------------------------------- | --------------------------------------------------------------------------- |
+| [Pages and routing](./pages-and-routing.md) | Add file-based pages, layouts, dynamic routes, and MDX content.             |
+| [Data fetching](./data-fetching.md)         | Load data on the server, prerender static pages, and fetch from the client. |
+| [API routes](./api-routes.md)               | Build HTTP handlers with request parsing and streaming responses.           |
+| [Middleware](./middleware.md)               | Add CORS, rate limiting, logging, and custom middleware pipelines.          |
+| [Head and SEO](./head-and-seo.md)           | Set page metadata, Open Graph tags, and structured data.                    |
+
+### AI primitives
+
+| Guide                                               | What you will do                                                                |
+| --------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [Providers](./providers.md)                         | Pick a model provider for local inference, Veryfront Cloud, or a direct vendor. |
+| [Agents](./agents.md)                               | Define an agent with a system prompt, tools, and memory.                        |
+| [Agent service runtime](./agent-service-runtime.md) | Run agents as separately deployed services.                                     |
+| [Tools](./tools.md)                                 | Define typed tools that agents can call.                                        |
+| [Memory and streaming](./memory-and-streaming.md)   | Add conversation memory and stream model output to the client.                  |
+
+### Chat UI
+
+| Guide                                     | What you will do                                                            |
+| ----------------------------------------- | --------------------------------------------------------------------------- |
+| [Chat UI](./chat-ui.md)                   | Drop in the preset chat component with one hook and one API route.          |
+| [Chat composition](./chat-composition.md) | Build a custom chat layout with the composition components.                 |
+| [Chat hooks](./chat-hooks.md)             | Drive chat from headless hooks: chat, agent, completion, voice, and thread. |
+| [Chat theming](./chat-theming.md)         | Theme chat features, attachments, sources, models, and visuals.             |
+
+### Orchestration
+
+| Guide                                          | What you will do                                                        |
+| ---------------------------------------------- | ----------------------------------------------------------------------- |
+| [Workflows](./workflows.md)                    | Define a DAG-based workflow with branches, retries, and parallel steps. |
+| [Workflows: advanced](./workflows-advanced.md) | Loops, blob storage for large artifacts, and React hooks for progress.  |
+| [Multi-agent](./multi-agent.md)                | Compose agents with delegation and agent-as-tool patterns.              |
+| [Skills](./skills.md)                          | Add project-level skills from `SKILL.md` files with tool restrictions.  |
+| [Jobs](./jobs.md)                              | Run one-off jobs, schedule cron jobs, and inspect batch summaries.      |
+| [Tasks](./tasks.md)                            | Write background task functions that run locally or as cloud jobs.      |
+
+### External systems
+
+| Guide                                                   | What you will do                                                                      |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [MCP server](./mcp-server.md)                           | Expose tools, prompts, and resources over Model Context Protocol.                     |
+| [Coding agents](./coding-agents.md)                     | Connect Claude Code, Cursor, Codex, and other MCP-aware agents to the dev server.     |
+| [OAuth](./oauth.md)                                     | Sign users in with OAuth 2.0 and the built-in provider catalog.                       |
+| [Integrations](./integrations.md)                       | Wire config-driven integration tools with OAuth, token management, and API execution. |
+| [Sandbox](./sandbox.md)                                 | Run isolated commands and file operations in an ephemeral sandbox session.            |
+| [CLI knowledge ingestion](./cli-knowledge-ingestion.md) | Turn uploads and local documents into project knowledge files from the CLI.           |
+
+### Extensions
+
+| Guide                                             | What you will do                                                           |
+| ------------------------------------------------- | -------------------------------------------------------------------------- |
+| [Extensions](./extensions.md)                     | Understand how extensions add focused capabilities to a Veryfront project. |
+| [Extension authoring](./extension-authoring.md)   | Write a focused extension factory, contract, and capability.               |
+| [Extension lifecycle](./extension-lifecycle.md)   | Trace extension discovery, ordering, setup, and teardown.                  |
+| [Extension testing](./extension-testing.md)       | Test an extension factory and the contracts it implements.                 |
+| [Extension publishing](./extension-publishing.md) | Package and publish a reusable extension.                                  |
+
+### Ship to production
+
+| Guide                                    | What you will do                                                |
+| ---------------------------------------- | --------------------------------------------------------------- |
+| [Building and deploying](./deploying.md) | Production-build internals, static export, Docker, and targets. |
+
+## Next
+
+Ready to build? Start with [Installation](./installation.md) to set up
+the Veryfront CLI, then walk through Getting Started in order.

--- a/docs/guides/workflows-advanced.md
+++ b/docs/guides/workflows-advanced.md
@@ -1,7 +1,7 @@
 ---
 title: "Workflows: loops, blob storage, React hooks"
 description: "Repeat steps based on conditions, store large workflow artifacts, and track workflow progress from a React client."
-order: 26
+order: 27
 ---
 
 Three patterns that reach past a single-pass DAG: looping until a condition is met, storing artifacts that are too large to thread through step inputs, and surfacing workflow progress in a React UI. Pick the section that matches what the base workflow can't do yet.

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -1,7 +1,7 @@
 ---
 title: "Workflows"
 description: "DAG-based multi-step workflows with branching and parallelism."
-order: 25
+order: 26
 ---
 
 A workflow is a file in `workflows/` that declares ordered steps. Each step runs an agent or a tool. The workflow runtime passes outputs between steps.

--- a/scripts/docs/validate-guides.ts
+++ b/scripts/docs/validate-guides.ts
@@ -160,29 +160,50 @@ for (const [order, files] of guideOrders) {
   }
 }
 
-// 2. Validate index.md lists all guide files
-const indexPath = `${GUIDES_DIR}/index.md`;
-try {
-  const indexContent = Deno.readTextFileSync(indexPath);
-  for (const filename of guideFiles) {
-    if (filename === "index.md") continue;
-    const slug = filename.replace(".md", "");
-    if (!indexContent.includes(`./${slug}.md`)) {
-      addWarning(`guides/index.md`, `Guide "${slug}" not listed in index`);
+// 2. Validate that every guide is listed in either index.md or
+//    veryfront-code.md. Both files act as catalog roots: the Intro page
+//    links onward to Veryfront Code, and Veryfront Code carries the
+//    topic-grouped tables.
+const catalogFiles = ["index.md", "veryfront-code.md"];
+const listedSlugs = new Set<string>();
+
+for (const catalogFile of catalogFiles) {
+  const filepath = `${GUIDES_DIR}/${catalogFile}`;
+  let content: string;
+  try {
+    content = Deno.readTextFileSync(filepath);
+  } catch {
+    // index.md must exist; veryfront-code.md is optional until the split
+    // lands. Only the missing index.md is treated as a hard error.
+    if (catalogFile === "index.md") {
+      addIssue(`guides/${catalogFile}`, `Could not read ${catalogFile}`);
     }
+    continue;
   }
 
-  // Check index links point to real files
-  const indexLinkRe = /\(\.\/([a-z0-9-]+)\.md\)/g;
+  const linkRe = /\(\.\/([a-z0-9-]+)\.md\)/g;
   let m: RegExpExecArray | null;
-  while ((m = indexLinkRe.exec(indexContent))) {
+  while ((m = linkRe.exec(content))) {
     const slug = m[1];
+    listedSlugs.add(slug);
     if (!GUIDE_SLUG_TO_FILE[slug]) {
-      addIssue("guides/index.md", `Index links to ./${slug}.md but no file exists`);
+      addIssue(
+        `guides/${catalogFile}`,
+        `Catalog links to ./${slug}.md but no file exists`,
+      );
     }
   }
-} catch {
-  addIssue("guides/index.md", "Could not read index.md");
+}
+
+for (const filename of guideFiles) {
+  if (catalogFiles.includes(filename)) continue;
+  const slug = filename.replace(".md", "");
+  if (!listedSlugs.has(slug)) {
+    addWarning(
+      "guides/index.md",
+      `Guide "${slug}" not listed in index.md or veryfront-code.md`,
+    );
+  }
 }
 
 // 3. Check imports in code examples reference public package modules.

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -161,11 +161,29 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
   "index.md": {
     references: [],
     snippets: [
+      "Veryfront Code",
+      "Prerequisite knowledge",
+      "How to use these guides",
+      "Installation",
+      "TypeScript",
+      "React",
+    ],
+  },
+  "veryfront-code.md": {
+    references: [],
+    snippets: [
+      "Why Veryfront Code",
+      "Agents",
+      "Tools",
+      "Workflows",
+      "Pages & Routing",
       "Getting Started",
-      "Create a project",
-      "Create an agent",
-      "Choose a primitive",
-      "Pages and APIs",
+      "Foundations",
+      "AI primitives",
+      "Chat UI",
+      "Orchestration",
+      "External systems",
+      "Extensions",
       "Ship to production",
     ],
   },
@@ -327,7 +345,7 @@ describe("published guide contracts", () => {
         assertStringIncludes(guide, snippet);
       }
 
-      if (filename !== "index.md") {
+      if (filename !== "index.md" && filename !== "veryfront-code.md") {
         assertStringIncludes(guide, "## Verify it worked");
       }
     });


### PR DESCRIPTION
## Summary

- Splits `docs/guides/index.md` into a short Next.js-style **Intro** page and a new **Veryfront Code** page that owns the "Why Veryfront Code" framing and the topic-grouped catalog of every guide.
- Bumps every non-index guide's `order:` frontmatter by +1 to free `order: 1` for the new page.
- Updates `scripts/docs/validate-guides.ts` so either `index.md` or `veryfront-code.md` counts as a catalog root for guide-listing checks.
- Updates `tests/docs/guide-contracts.test.ts` with a `veryfront-code.md` entry, refreshes the `index.md` snippets to match the new Intro content, and exempts the new page from the trailing `## Verify it worked` assertion (it is an overview, not a tutorial).

The 14-bullet capability list inside `veryfront-code.md` is lifted from the root `README.md` "Why Veryfront?" section with absolute `https://veryfront.com/...` URLs rewritten to relative `./X.md` form so the guide validator can verify them.

## Commits

| SHA | Subject |
|---|---|
| `9082e19fa` | docs(validate): scan both index.md and veryfront-code.md for guide listings |
| `e40222cae` | docs(guides): bump frontmatter order +1 on every non-index guide |
| `be3480c5f` | docs(guides): split index.md into Intro and Veryfront Code |

## Out of scope

`scripts/docs/validate-api-reference.ts` reports a pre-existing failure on `main` for `src/schemas` (missing `@example` JSDoc and a missing `docs/reference/veryfront/schemas.md`). The chained `deno task docs:validate` was already red before this branch — fix is out of scope here. The guide-side checks (`scripts/docs/validate-guides.ts` directly, plus `tests/docs/`) are all green.

## Test plan

- [x] `deno run --allow-read scripts/docs/validate-guides.ts` → "Validated 44 guide files. All guides passed validation."
- [x] `deno test --no-check --allow-all tests/docs/` → 44 passed, 0 failed.
- [x] `grep -H '^order:' docs/guides/*.md | sort -t: -k3 -n` → contiguous `0, 1, 2, …, 43`, no duplicates, no gaps.
- [x] Pre-push hook (full test suite): 1909 passed.
- [ ] No merge conflicts with `#1822` / `#1823` (recently-merged docs PRs that touched `docs/guides/`). To verify on the PR page.