### PR TITLE
Preserve hosted deployment URL for protected auth redirects

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.576",
+  "version": "0.1.577",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -1103,6 +1103,51 @@ describe("Proxy Handler", () => {
       }
     });
 
+    it("preserves the full protected deployment URL for hosted production sign-in redirects", async () => {
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") return createTokenResponse();
+
+        if (pathname.startsWith("/projects/")) {
+          return Response.json({
+            id: "proj-123",
+            slug: "landing-page-6ec5f6e3",
+            name: "Landing Page",
+            environments: [{
+              id: "env-1",
+              name: "production",
+              active_release_id: "rel-123",
+              protected: true,
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+        const deploymentUrl = "https://landing-page-6ec5f6e3.production.veryfront.org/";
+        const req = new Request(deploymentUrl, {
+          headers: { host: "landing-page-6ec5f6e3.production.veryfront.org" },
+        });
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error?.status, 302);
+        assertEquals(ctx.error?.message, "Authentication required");
+        assertEquals(
+          ctx.error?.redirectUrl,
+          `https://veryfront.com/sign-in?from=${encodeURIComponent(deploymentUrl)}`,
+        );
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
     it("returns 404 for missing preview project without auth token", async () => {
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -423,7 +423,11 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
       returnPath = "/";
     }
 
-    return `https://veryfront.com/sign-in?from=${encodeURIComponent(returnPath)}`;
+    const isHostedProductionDeployment = url.hostname.endsWith(".production.veryfront.org") ||
+      url.hostname.endsWith(".production.veryfront.com");
+    const returnTarget = isHostedProductionDeployment ? url.toString() : returnPath;
+
+    return `https://veryfront.com/sign-in?from=${encodeURIComponent(returnTarget)}`;
   }
 
   function makeProjectNotFoundContext(

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.576";
+export const VERSION = "0.1.577";


### PR DESCRIPTION
## Summary
- Preserve full hosted production deployment URLs in protected-environment sign-in redirects
- Keep custom domains and preview redirects constrained to relative paths
- Bump veryfront-code version to 0.1.577 and keep VERSION in sync

Fixes #1794

## Tests
- deno test --no-check --allow-all src/proxy/handler.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/proxy/handler.test.ts
- deno task fmt:check
- deno task typecheck
- pre-push checks: format, lint, typecheck, unit tests (1909 passed, 0 failed)