### PR TITLE
Rename sandbox command jobs to background commands

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.577",
+  "version": "0.1.578",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/architecture/17-sandbox-runtime.md
+++ b/docs/architecture/17-sandbox-runtime.md
@@ -1,7 +1,7 @@
 # Sandbox runtime
 
 This page describes sandbox session clients, lazy provisioning, command
-execution, file operations, command jobs, heartbeats, and agent-service sandbox
+execution, file operations, background commands, heartbeats, and agent-service sandbox
 tools. It does not cover workflow execution or the backing sandbox service
 implementation.
 
@@ -35,11 +35,11 @@ flowchart TD
   attach --> ready
   ready --> exec[Execute buffered or streaming command]
   ready --> files[Read or write files]
-  ready --> jobs[Start, poll, or cancel command job]
+  ready --> commands[Start, poll, or cancel background command]
   ready --> heartbeat[Heartbeat active session]
   exec --> close[Close session]
   files --> close
-  jobs --> close
+  commands --> close
 ```
 
 1. Config helpers resolve sandbox API URL and auth token from explicit options
@@ -49,13 +49,13 @@ flowchart TD
 3. `Sandbox.createLazy()` defers provisioning until command or file operations
    need a session.
 4. Command helpers support buffered output, streamed NDJSON events, and async
-   command jobs.
+   background commands.
 5. Agent-service helpers adapt sandbox operations into shell and file tools.
 
 ## Boundaries
 
 - Sandbox runtime owns client behavior, lazy provisioning, command streaming,
-  command job polling, and agent-service tool adapters.
+  background command polling, and agent-service tool adapters.
 - The backing sandbox service owns container lifecycle, isolation, scheduling,
   and command execution internals.
 - Workflow runtime may call sandbox-backed tools, but workflow state belongs in
@@ -68,7 +68,7 @@ flowchart TD
 - Add sandbox client tests when changing session creation, attach, reconnect,
   file operations, command execution, or NDJSON parsing.
 - Add lazy sandbox tests when changing provisioning, endpoint resolution,
-  retries, heartbeat behavior, or command job tracking.
+  retries, heartbeat behavior, or background command tracking.
 - Add shell-tool tests when changing agent-facing tool names, schemas, or
   argument normalization.
 - Keep auth tokens server-side and redact backing service details from public

--- a/docs/reference/veryfront/sandbox.md
+++ b/docs/reference/veryfront/sandbox.md
@@ -86,35 +86,35 @@ Write files to the sandbox workspace.
 
 **Returns:** <code>Promise&lt;void&gt;</code>
 
-### `sandbox.startCommandJob(command, options)`
+### `sandbox.startBackgroundCommand(command, options)`
 
-Start an async command job in the sandbox.
+Start an async background command in the sandbox.
 
-**Returns:** <code>Promise&lt;CommandJob&gt;</code>
+**Returns:** <code>Promise&lt;BackgroundCommand&gt;</code>
 
-### `sandbox.getCommandJob(jobId)`
+### `sandbox.getBackgroundCommand(commandId)`
 
-Get the status of an async command job.
+Get the status of an async background command.
 
-**Returns:** <code>Promise&lt;CommandJob&gt;</code>
+**Returns:** <code>Promise&lt;BackgroundCommand&gt;</code>
 
-### `sandbox.getCommandJobOutput(jobId)`
+### `sandbox.getBackgroundCommandOutput(commandId)`
 
-Get the output of an async command job.
+Get the output of an async background command.
 
-**Returns:** <code>Promise&lt;CommandJobOutput&gt;</code>
+**Returns:** <code>Promise&lt;BackgroundCommandOutput&gt;</code>
 
-### `sandbox.listCommandJobs()`
+### `sandbox.listBackgroundCommands()`
 
-List all command jobs in the sandbox.
+List all background commands in the sandbox.
 
-**Returns:** <code>Promise&lt;CommandJob[]&gt;</code>
+**Returns:** <code>Promise&lt;BackgroundCommand[]&gt;</code>
 
-### `sandbox.cancelCommandJob(jobId)`
+### `sandbox.cancelBackgroundCommand(commandId)`
 
-Cancel an async command job.
+Cancel an async background command.
 
-**Returns:** <code>Promise&lt;CommandJob&gt;</code>
+**Returns:** <code>Promise&lt;BackgroundCommand&gt;</code>
 
 ### `sandbox.heartbeat()`
 
@@ -200,21 +200,21 @@ Streaming event emitted during command execution.
 |------|-------------|--------|
 | `AgentServiceSandboxClient` | Public API contract for agent service sandbox client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L25) |
 | `AgentServiceSandboxClientOptions` | Options accepted by agent service sandbox client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L35) |
-| `AgentServiceSandboxJobClient` | Public API contract for agent service sandbox job client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L17) |
+| `AgentServiceSandboxBackgroundCommandClient` | Public API contract for agent service sandbox background command client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L17) |
 | `AgentServiceSandboxToolsOptions` | Options accepted by agent service sandbox tools. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L38) |
 | `AgentServiceSandboxToolsResult` | Result returned from agent service sandbox tools. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L44) |
 | `BashToolSandboxLike` | Public API contract for sandbox shell client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/extensions/sandbox/shell-tools.ts#L30) |
-| `CommandJob` | An async command job running in a sandbox. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L44) |
-| `CommandJobHeartbeatStatus` | Heartbeat health status for a command job. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L41) |
-| `CommandJobOutput` | A command job with its captured output. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L58) |
-| `CommandJobStatus` | Status of an async command job. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L38) |
+| `BackgroundCommand` | An async background command running in a sandbox. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L44) |
+| `BackgroundCommandHeartbeatStatus` | Heartbeat health status for a background command. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L41) |
+| `BackgroundCommandOutput` | A background command with its captured output. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L58) |
+| `BackgroundCommandStatus` | Status of an async background command. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L38) |
 | `CreateSandboxBashTool` | Public API contract for sandbox shell tools provider. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/extensions/sandbox/shell-tools.ts#L47) |
 | `ExecOptions` | Options for command execution: working directory, timeout, environment variables, and optional project reference. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L2) |
 | `ExecResult` | Result of a command execution: stdout, stderr, and exit code. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L24) |
 | `ExecStreamEvent` | Streaming event emitted during command execution. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L31) |
 | `HostedSandboxClient` | Public API contract for hosted sandbox client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L189) |
 | `HostedSandboxClientOptions` | Options accepted by hosted sandbox client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L191) |
-| `HostedSandboxJobClient` | Public API contract for hosted sandbox job client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L187) |
+| `HostedSandboxBackgroundCommandClient` | Public API contract for hosted sandbox background command client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L187) |
 | `HostedSandboxToolsOptions` | Options accepted by hosted sandbox tools. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L193) |
 | `HostedSandboxToolsResult` | Result returned from hosted sandbox tools. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L195) |
 | `LazySandboxOptions` | Options accepted by lazy sandbox. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/lazy-sandbox.ts#L15) |

--- a/src/agent/hosted/child-fork-tool-sources.test.ts
+++ b/src/agent/hosted/child-fork-tool-sources.test.ts
@@ -1,9 +1,10 @@
+import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "@std/assert";
 import type {
   AgentServiceSandboxToolsOptions,
   AgentServiceSandboxToolsResult,
-  CommandJob,
-  CommandJobOutput,
+  BackgroundCommand,
+  BackgroundCommandOutput,
   CreateSandboxBashTool,
 } from "#veryfront/sandbox";
 import type {
@@ -64,9 +65,9 @@ function createRemoteSourceFixtures() {
   return { createdConfigs, executeCalls, createRemoteToolSource };
 }
 
-function commandJob(status: CommandJob["status"]): CommandJob {
+function commandPayload(status: BackgroundCommand["status"]): BackgroundCommand {
   return {
-    id: "job-1",
+    id: "command-1",
     status,
     exitCode: null,
     signal: null,
@@ -79,9 +80,9 @@ function commandJob(status: CommandJob["status"]): CommandJob {
   };
 }
 
-function commandJobOutput(): CommandJobOutput {
+function commandPayloadOutput(): BackgroundCommandOutput {
   return {
-    ...commandJob("completed"),
+    ...commandPayload("completed"),
     exitCode: 0,
     finishedAt: "2026-01-01T00:00:01.000Z",
     stdout: "",
@@ -101,10 +102,10 @@ function createSandboxToolsResult(input: {
       ensure: () => Promise.resolve(),
       close: () => Promise.resolve(),
       executeCommand: () => Promise.resolve({ stdout: "", stderr: "", exitCode: 0 }),
-      startCommandJob: () => Promise.resolve(commandJob("running")),
-      getCommandJob: () => Promise.resolve(commandJob("completed")),
-      getCommandJobOutput: () => Promise.resolve(commandJobOutput()),
-      cancelCommandJob: () => Promise.resolve(commandJob("canceled")),
+      startBackgroundCommand: () => Promise.resolve(commandPayload("running")),
+      getBackgroundCommand: () => Promise.resolve(commandPayload("completed")),
+      getBackgroundCommandOutput: () => Promise.resolve(commandPayloadOutput()),
+      cancelBackgroundCommand: () => Promise.resolve(commandPayload("canceled")),
       isActive: true,
       id: "sandbox-1",
       url: "https://sandbox.example",

--- a/src/sandbox/agent-service-tools.test.ts
+++ b/src/sandbox/agent-service-tools.test.ts
@@ -58,9 +58,9 @@ function createOkResponse(): Response {
   return jsonResponse({ ok: true });
 }
 
-function createJobPayload(overrides: Record<string, unknown> = {}) {
+function createCommandPayload(overrides: Record<string, unknown> = {}) {
   return {
-    id: "job-1",
+    id: "command-1",
     status: "running",
     exit_code: null,
     signal: null,
@@ -74,11 +74,11 @@ function createJobPayload(overrides: Record<string, unknown> = {}) {
   };
 }
 
-async function executeStartCommandJob(
+async function executeStartBackgroundCommand(
   tools: SandboxShellToolSet,
   command: string,
 ): Promise<unknown> {
-  const execute = tools.start_command_job?.execute;
+  const execute = tools.start_background_command?.execute;
   assertExists(execute);
   return await execute({ command });
 }
@@ -94,7 +94,7 @@ describe("sandbox/agent-service-tools", () => {
     clearSandboxEnv();
   });
 
-  it("creates shell tools and async command job tools", async () => {
+  it("creates shell tools and async background command tools", async () => {
     mockFetch([]);
 
     const { tools } = await createAgentServiceSandboxTools({
@@ -107,20 +107,20 @@ describe("sandbox/agent-service-tools", () => {
     assertExists(tools.bash);
     assertExists(tools.sandbox_read_file);
     assertExists(tools.sandbox_write_file);
-    assertExists(tools.start_command_job);
-    assertExists(tools.get_command_job);
-    assertExists(tools.get_command_job_output);
-    assertExists(tools.cancel_command_job);
+    assertExists(tools.start_background_command);
+    assertExists(tools.get_background_command);
+    assertExists(tools.get_background_command_output);
+    assertExists(tools.cancel_background_command);
     assertEquals(tools.readFile, undefined);
     assertEquals(tools.writeFile, undefined);
   });
 
-  it("passes the latest project reference through exec and command-job requests", async () => {
+  it("passes the latest project reference through exec and background-command requests", async () => {
     mockFetch([
       createSandboxSessionResponse(),
       createOkResponse(),
       ndjsonResponse([{ type: "stdout", data: "ok" }, { type: "exit", exitCode: 0 }]),
-      jsonResponse(createJobPayload()),
+      jsonResponse(createCommandPayload()),
     ]);
 
     let projectId = "project-1";
@@ -137,8 +137,8 @@ describe("sandbox/agent-service-tools", () => {
       stderr: "",
       exitCode: 0,
     });
-    assertEquals(await sandbox.startCommandJob("npm test"), {
-      id: "job-1",
+    assertEquals(await sandbox.startBackgroundCommand("npm test"), {
+      id: "command-1",
       status: "running",
       exitCode: null,
       signal: null,
@@ -162,11 +162,11 @@ describe("sandbox/agent-service-tools", () => {
     });
   });
 
-  it("strips bash-tool workspace prefixes from async command job tool commands", async () => {
+  it("strips bash-tool workspace prefixes from async background command tool commands", async () => {
     mockFetch([
       createSandboxSessionResponse(),
       createOkResponse(),
-      jsonResponse(createJobPayload()),
+      jsonResponse(createCommandPayload()),
     ]);
 
     const { tools } = await createAgentServiceSandboxTools({
@@ -176,7 +176,7 @@ describe("sandbox/agent-service-tools", () => {
       createBashTool,
     });
 
-    await executeStartCommandJob(
+    await executeStartBackgroundCommand(
       tools,
       'mkdir -p /tmp/bash-tool && cd "/workspace" && python3 process_pdf.py',
     );

--- a/src/sandbox/agent-service-tools.ts
+++ b/src/sandbox/agent-service-tools.ts
@@ -1,6 +1,6 @@
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { tool } from "#veryfront/tool";
-import type { CommandJob, CommandJobOutput, ExecOptions } from "./sandbox.ts";
+import type { BackgroundCommand, BackgroundCommandOutput, ExecOptions } from "./sandbox.ts";
 import { LazySandbox, type LazySandboxOptions } from "./lazy-sandbox.ts";
 import {
   type BashToolSandboxLike,
@@ -13,17 +13,17 @@ const SANDBOX_WORKING_DIRECTORY = "/workspace";
 const SANDBOX_WORKING_DIRECTORY_PREFIX_PATTERN =
   /^\s*(?:mkdir -p \/tmp\/bash-tool\s*&&\s*)?cd\s+"\/workspace"\s*&&\s*/i;
 
-/** Public API contract for agent service sandbox job client. */
-export interface AgentServiceSandboxJobClient {
-  startCommandJob(command: string): Promise<CommandJob>;
-  getCommandJob(jobId: string): Promise<CommandJob>;
-  getCommandJobOutput(jobId: string): Promise<CommandJobOutput>;
-  cancelCommandJob(jobId: string): Promise<CommandJob>;
+/** Public API contract for agent service sandbox background command client. */
+export interface AgentServiceSandboxBackgroundCommandClient {
+  startBackgroundCommand(command: string): Promise<BackgroundCommand>;
+  getBackgroundCommand(commandId: string): Promise<BackgroundCommand>;
+  getBackgroundCommandOutput(commandId: string): Promise<BackgroundCommandOutput>;
+  cancelBackgroundCommand(commandId: string): Promise<BackgroundCommand>;
 }
 
 /** Public API contract for agent service sandbox client. */
 export interface AgentServiceSandboxClient
-  extends BashToolSandboxLike, AgentServiceSandboxJobClient {
+  extends BashToolSandboxLike, AgentServiceSandboxBackgroundCommandClient {
   ensure(): Promise<void>;
   close(): Promise<void>;
   readonly isActive: boolean;
@@ -97,7 +97,7 @@ export function createAgentServiceSandboxClient(
   const sandbox = new LazySandbox({ ...input, getProjectId });
 
   const getExecOptions = () => createProjectScopedExecOptions(getProjectId());
-  const getCommandJobExecOptions = () => ({
+  const getBackgroundCommandExecOptions = () => ({
     ...getExecOptions(),
     cwd: SANDBOX_WORKING_DIRECTORY,
   });
@@ -109,14 +109,14 @@ export function createAgentServiceSandboxClient(
     },
     readFile: (path) => sandbox.readFile(path),
     writeFiles: (files) => sandbox.writeFiles(files.map((file) => normalizeSandboxWriteFile(file))),
-    startCommandJob: (command) =>
-      sandbox.startCommandJob(
+    startBackgroundCommand: (command) =>
+      sandbox.startBackgroundCommand(
         unwrapSandboxWorkingDirectoryCommand(command),
-        getCommandJobExecOptions(),
+        getBackgroundCommandExecOptions(),
       ),
-    getCommandJob: (jobId) => sandbox.getCommandJob(jobId),
-    getCommandJobOutput: (jobId) => sandbox.getCommandJobOutput(jobId),
-    cancelCommandJob: (jobId) => sandbox.cancelCommandJob(jobId),
+    getBackgroundCommand: (commandId) => sandbox.getBackgroundCommand(commandId),
+    getBackgroundCommandOutput: (commandId) => sandbox.getBackgroundCommandOutput(commandId),
+    cancelBackgroundCommand: (commandId) => sandbox.cancelBackgroundCommand(commandId),
     close: () => sandbox.close(),
     get isActive() {
       return sandbox.isActive;
@@ -130,15 +130,15 @@ export function createAgentServiceSandboxClient(
   };
 }
 
-const getStartCommandJobInputSchema = defineSchema((v) =>
+const getStartBackgroundCommandInputSchema = defineSchema((v) =>
   v.object({
     command: v.string().describe("Single shell command to run asynchronously in the sandbox"),
   })
 );
 
-const getCommandJobIdInputSchema = defineSchema((v) =>
+const getBackgroundCommandIdInputSchema = defineSchema((v) =>
   v.object({
-    jobId: v.string().describe("Sandbox command job ID"),
+    commandId: v.string().describe("Sandbox background command ID"),
   })
 );
 
@@ -151,28 +151,28 @@ export async function createAgentServiceSandboxTools(
 
   const tools: SandboxShellToolSet = {
     ...shellTools,
-    start_command_job: tool({
+    start_background_command: tool({
       description:
-        "Start a long-running sandbox command as an async job. Use this instead of bash for durable shell operations.",
-      inputSchema: getStartCommandJobInputSchema(),
-      execute: async ({ command }) => await sandbox.startCommandJob(command),
+        "Start a long-running sandbox command as an async background command. Use this instead of bash for durable shell operations.",
+      inputSchema: getStartBackgroundCommandInputSchema(),
+      execute: async ({ command }) => await sandbox.startBackgroundCommand(command),
     }),
-    get_command_job: tool({
+    get_background_command: tool({
       description:
-        "Get the current status for an async sandbox command job. Use this for polling while a long-running job is still running.",
-      inputSchema: getCommandJobIdInputSchema(),
-      execute: async ({ jobId }) => await sandbox.getCommandJob(jobId),
+        "Get the current status for an async sandbox background command. Use this for polling while a long-running command is still running.",
+      inputSchema: getBackgroundCommandIdInputSchema(),
+      execute: async ({ commandId }) => await sandbox.getBackgroundCommand(commandId),
     }),
-    get_command_job_output: tool({
+    get_background_command_output: tool({
       description:
-        "Get the captured stdout/stderr and terminal metadata for an async sandbox command job. Prefer calling this after the job reaches a terminal state.",
-      inputSchema: getCommandJobIdInputSchema(),
-      execute: async ({ jobId }) => await sandbox.getCommandJobOutput(jobId),
+        "Get the captured stdout/stderr and terminal metadata for an async sandbox background command. Prefer calling this after the command reaches a terminal state.",
+      inputSchema: getBackgroundCommandIdInputSchema(),
+      execute: async ({ commandId }) => await sandbox.getBackgroundCommandOutput(commandId),
     }),
-    cancel_command_job: tool({
-      description: "Cancel a running async sandbox command job.",
-      inputSchema: getCommandJobIdInputSchema(),
-      execute: async ({ jobId }) => await sandbox.cancelCommandJob(jobId),
+    cancel_background_command: tool({
+      description: "Cancel a running async sandbox background command.",
+      inputSchema: getBackgroundCommandIdInputSchema(),
+      execute: async ({ commandId }) => await sandbox.cancelBackgroundCommand(commandId),
     }),
   };
 
@@ -183,8 +183,8 @@ export async function createAgentServiceSandboxTools(
   };
 }
 
-/** Public API contract for hosted sandbox job client. */
-export type HostedSandboxJobClient = AgentServiceSandboxJobClient;
+/** Public API contract for hosted sandbox background command client. */
+export type HostedSandboxBackgroundCommandClient = AgentServiceSandboxBackgroundCommandClient;
 /** Public API contract for hosted sandbox client. */
 export type HostedSandboxClient = AgentServiceSandboxClient;
 /** Options accepted by hosted sandbox client. */

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -18,10 +18,10 @@
  */
 
 export {
-  type CommandJob,
-  type CommandJobHeartbeatStatus,
-  type CommandJobOutput,
-  type CommandJobStatus,
+  type BackgroundCommand,
+  type BackgroundCommandHeartbeatStatus,
+  type BackgroundCommandOutput,
+  type BackgroundCommandStatus,
   type ExecOptions,
   type ExecResult,
   type ExecStreamEvent,
@@ -47,9 +47,9 @@ export {
   type SandboxShellToolSet,
 } from "./shell-tools.ts";
 export {
+  type AgentServiceSandboxBackgroundCommandClient,
   type AgentServiceSandboxClient,
   type AgentServiceSandboxClientOptions,
-  type AgentServiceSandboxJobClient,
   type AgentServiceSandboxToolsOptions,
   type AgentServiceSandboxToolsResult,
   createAgentServiceSandboxClient,
@@ -57,9 +57,9 @@ export {
   createHostedSandboxClient,
   createHostedSandboxTools,
   createProjectScopedExecOptions,
+  type HostedSandboxBackgroundCommandClient,
   type HostedSandboxClient,
   type HostedSandboxClientOptions,
-  type HostedSandboxJobClient,
   type HostedSandboxToolsOptions,
   type HostedSandboxToolsResult,
   unwrapSandboxWorkingDirectoryCommand,

--- a/src/sandbox/lazy-sandbox.ts
+++ b/src/sandbox/lazy-sandbox.ts
@@ -2,9 +2,9 @@ import { REQUEST_ERROR } from "#veryfront/errors/error-registry.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { resolveSandboxApiUrl, resolveSandboxAuthToken } from "./config.ts";
 import {
-  type CommandJob,
-  type CommandJobOutput,
-  type CommandJobStatus,
+  type BackgroundCommand,
+  type BackgroundCommandOutput,
+  type BackgroundCommandStatus,
   type ExecOptions,
   type ExecResult,
   type ExecStreamEvent,
@@ -101,7 +101,7 @@ export class LazySandbox {
   private heartbeatPromise: PendingOperation | null = null;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private lastHeartbeatAt = 0;
-  private readonly activeCommandJobEndpoints = new Map<string, string>();
+  private readonly activeBackgroundCommandEndpoints = new Map<string, string>();
 
   constructor(options: LazySandboxOptions = {}) {
     this.apiUrl = resolveSandboxApiUrl(options);
@@ -236,11 +236,11 @@ export class LazySandbox {
     }
   }
 
-  async startCommandJob(command: string, options?: ExecOptions): Promise<CommandJob> {
+  async startBackgroundCommand(command: string, options?: ExecOptions): Promise<BackgroundCommand> {
     await this.touchSession();
     const endpoint = this.resolveRuntimeEndpoint();
 
-    const res = await this.fetchControl(`${endpoint}/exec/jobs`, {
+    const res = await this.fetchControl(`${endpoint}/exec/commands`, {
       method: "POST",
       headers: this.jsonHeaders(),
       body: JSON.stringify({ command, ...this.resolveExecOptions(options) }),
@@ -248,93 +248,93 @@ export class LazySandbox {
 
     if (!res.ok) {
       throw REQUEST_ERROR.create({
-        detail: `Start command job failed: ${res.status} ${await res.text()}`,
+        detail: `Start background command failed: ${res.status} ${await res.text()}`,
       });
     }
 
-    const job = mapCommandJob(await res.json());
-    this.updateTrackedCommandJob(job, endpoint);
-    return job;
+    const backgroundCommand = mapBackgroundCommand(await res.json());
+    this.updateTrackedBackgroundCommand(backgroundCommand, endpoint);
+    return backgroundCommand;
   }
 
-  async getCommandJob(jobId: string): Promise<CommandJob> {
-    const endpoint = await this.resolveCommandJobEndpoint(jobId);
+  async getBackgroundCommand(commandId: string): Promise<BackgroundCommand> {
+    const endpoint = await this.resolveBackgroundCommandEndpoint(commandId);
 
-    const res = await this.fetchControl(`${endpoint}/exec/jobs/${jobId}`, {
+    const res = await this.fetchControl(`${endpoint}/exec/commands/${commandId}`, {
       headers: this.authHeaders(),
     });
 
     if (!res.ok) {
       throw REQUEST_ERROR.create({
-        detail: `Get command job failed: ${res.status} ${await res.text()}`,
+        detail: `Get background command failed: ${res.status} ${await res.text()}`,
       });
     }
 
-    const job = mapCommandJob(await res.json());
-    this.updateTrackedCommandJob(job, endpoint);
-    return job;
+    const backgroundCommand = mapBackgroundCommand(await res.json());
+    this.updateTrackedBackgroundCommand(backgroundCommand, endpoint);
+    return backgroundCommand;
   }
 
-  async getCommandJobOutput(jobId: string): Promise<CommandJobOutput> {
-    const endpoint = await this.resolveCommandJobEndpoint(jobId);
+  async getBackgroundCommandOutput(commandId: string): Promise<BackgroundCommandOutput> {
+    const endpoint = await this.resolveBackgroundCommandEndpoint(commandId);
 
-    const res = await this.fetchControl(`${endpoint}/exec/jobs/${jobId}/output`, {
+    const res = await this.fetchControl(`${endpoint}/exec/commands/${commandId}/output`, {
       headers: this.authHeaders(),
     });
 
     if (!res.ok) {
       throw REQUEST_ERROR.create({
-        detail: `Get command job output failed: ${res.status} ${await res.text()}`,
+        detail: `Get background command output failed: ${res.status} ${await res.text()}`,
       });
     }
 
     const json = await res.json();
     const output = {
-      ...mapCommandJob(json),
+      ...mapBackgroundCommand(json),
       stdout: json.stdout,
       stderr: json.stderr,
       stdoutTruncated: json.stdout_truncated,
       stderrTruncated: json.stderr_truncated,
     };
-    this.updateTrackedCommandJob(output, endpoint);
+    this.updateTrackedBackgroundCommand(output, endpoint);
     return output;
   }
 
-  async listCommandJobs(): Promise<CommandJob[]> {
+  async listBackgroundCommands(): Promise<BackgroundCommand[]> {
     await this.ensure();
 
-    const res = await this.fetchControl(`${this.requireEndpoint()}/exec/jobs`, {
+    const res = await this.fetchControl(`${this.requireEndpoint()}/exec/commands`, {
       headers: this.authHeaders(),
     });
 
     if (!res.ok) {
       throw REQUEST_ERROR.create({
-        detail: `List command jobs failed: ${res.status} ${await res.text()}`,
+        detail: `List background commands failed: ${res.status} ${await res.text()}`,
       });
     }
 
     const json = await res.json();
-    const jobs = Array.isArray(json) ? json : (json.jobs ?? []);
-    return jobs.map((job: Record<string, unknown>) => mapCommandJob(job));
+    const commands = Array.isArray(json) ? json : (json.commands ?? []);
+    return commands.map((command: Record<string, unknown>) => mapBackgroundCommand(command));
   }
 
-  async cancelCommandJob(jobId: string): Promise<CommandJob> {
-    const endpoint = await this.resolveCommandJobEndpoint(jobId);
+  async cancelBackgroundCommand(commandId: string): Promise<BackgroundCommand> {
+    const endpoint = await this.resolveBackgroundCommandEndpoint(commandId);
 
-    const res = await this.fetchControl(`${endpoint}/exec/jobs/${jobId}/cancel`, {
+    const res = await this.fetchControl(`${endpoint}/exec/commands/${commandId}/cancel`, {
       method: "POST",
       headers: this.authHeaders(),
     });
 
     if (!res.ok) {
       throw REQUEST_ERROR.create({
-        detail: `Cancel command job failed: ${res.status} ${await res.text()}`,
+        detail: `Cancel background command failed: ${res.status} ${await res.text()}`,
       });
     }
 
-    const job = mapCommandJob(await res.json());
-    this.updateTrackedCommandJob(job, endpoint);
-    return job;
+    const backgroundCommand = mapBackgroundCommand(await res.json());
+    this.updateTrackedBackgroundCommand(backgroundCommand, endpoint);
+    return backgroundCommand;
   }
 
   async heartbeat(force = false): Promise<void> {
@@ -365,7 +365,7 @@ export class LazySandbox {
 
         if (!res.ok) {
           if (this.sessionId === currentSessionId) {
-            if (this.activeCommandJobEndpoints.size === 0) {
+            if (this.activeBackgroundCommandEndpoints.size === 0) {
               await this.deleteSession(currentSessionId);
               this.resetSessionState(currentSessionId);
             }
@@ -523,7 +523,9 @@ export class LazySandbox {
   }
 
   private startHeartbeatLoop(): void {
-    if (!this.sessionId || this.heartbeatTimer || this.activeCommandJobEndpoints.size > 0) return;
+    if (!this.sessionId || this.heartbeatTimer || this.activeBackgroundCommandEndpoints.size > 0) {
+      return;
+    }
 
     this.heartbeatTimer = setInterval(() => {
       void this.heartbeat().catch(() => {
@@ -559,7 +561,7 @@ export class LazySandbox {
   private resetSessionState(sessionId?: string): void {
     if (!sessionId || this.sessionId === sessionId) {
       this.stopHeartbeatLoop();
-      this.activeCommandJobEndpoints.clear();
+      this.activeBackgroundCommandEndpoints.clear();
       this.endpoint = null;
       this.sessionId = null;
       this.sessionProjectId = null;
@@ -573,8 +575,8 @@ export class LazySandbox {
     return projectReference ? { ...options, projectReference } : options;
   }
 
-  private async resolveCommandJobEndpoint(jobId: string): Promise<string> {
-    const trackedEndpoint = this.activeCommandJobEndpoints.get(jobId);
+  private async resolveBackgroundCommandEndpoint(commandId: string): Promise<string> {
+    const trackedEndpoint = this.activeBackgroundCommandEndpoints.get(commandId);
     if (trackedEndpoint) {
       return trackedEndpoint;
     }
@@ -583,18 +585,21 @@ export class LazySandbox {
     return this.resolveRuntimeEndpoint();
   }
 
-  private updateTrackedCommandJob(job: Pick<CommandJob, "id" | "status">, endpoint: string): void {
-    if (job.status === "running") {
-      this.activeCommandJobEndpoints.set(job.id, endpoint);
+  private updateTrackedBackgroundCommand(
+    backgroundCommand: Pick<BackgroundCommand, "id" | "status">,
+    endpoint: string,
+  ): void {
+    if (backgroundCommand.status === "running") {
+      this.activeBackgroundCommandEndpoints.set(backgroundCommand.id, endpoint);
       this.stopHeartbeatLoop();
       return;
     }
 
-    if (!this.activeCommandJobEndpoints.delete(job.id)) {
+    if (!this.activeBackgroundCommandEndpoints.delete(backgroundCommand.id)) {
       return;
     }
 
-    if (this.activeCommandJobEndpoints.size === 0 && this.endpoint) {
+    if (this.activeBackgroundCommandEndpoints.size === 0 && this.endpoint) {
       this.startHeartbeatLoop();
     }
   }
@@ -721,10 +726,10 @@ async function fetchWithTimeout(
   }
 }
 
-function mapCommandJob(json: Record<string, unknown>): CommandJob {
+function mapBackgroundCommand(json: Record<string, unknown>): BackgroundCommand {
   return {
     id: json.id as string,
-    status: json.status as CommandJobStatus,
+    status: json.status as BackgroundCommandStatus,
     exitCode: json.exit_code as number | null,
     signal: json.signal as string | null,
     startedAt: json.started_at as string,

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -530,12 +530,12 @@ describe("Sandbox", () => {
     });
   });
 
-  describe("startCommandJob() with ExecOptions", () => {
+  describe("startBackgroundCommand() with ExecOptions", () => {
     it("should pass options in the request body", async () => {
       mockFetch([
         jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
         jsonResponse({
-          id: "job-opts",
+          id: "command-opts",
           status: "running",
           exit_code: null,
           signal: null,
@@ -549,14 +549,14 @@ describe("Sandbox", () => {
       ]);
 
       const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
-      const job = await sandbox.startCommandJob("npm test", {
+      const command = await sandbox.startBackgroundCommand("npm test", {
         cwd: "/workspace",
         timeout_seconds: 120,
         env: { CI: "true" },
         projectReference: "project-789",
       });
 
-      assertEquals(job.id, "job-opts");
+      assertEquals(command.id, "command-opts");
       assertEquals(jsonBody(fetchCalls, 1), {
         command: "npm test",
         cwd: "/workspace",
@@ -958,7 +958,7 @@ describe("Sandbox", () => {
       }
     });
 
-    it("forwards projectReference from lazy project context for exec and async jobs", async () => {
+    it("forwards projectReference from lazy project context for exec and async commands", async () => {
       mockFetch([
         jsonResponse({
           id: "sandbox-1",
@@ -971,7 +971,7 @@ describe("Sandbox", () => {
           { type: "exit", exitCode: 0 },
         ]),
         jsonResponse({
-          id: "job-1",
+          id: "command-1",
           status: "completed",
           exit_code: 0,
           signal: null,
@@ -993,7 +993,7 @@ describe("Sandbox", () => {
 
       try {
         await sandbox.executeCommand("echo ok");
-        await sandbox.startCommandJob("npm test");
+        await sandbox.startBackgroundCommand("npm test");
 
         assertEquals(jsonBody(fetchCalls, 2), {
           command: "echo ok",
@@ -1008,7 +1008,7 @@ describe("Sandbox", () => {
       }
     });
 
-    it("uses the lazy runtime endpoint resolver for exec and async jobs", async () => {
+    it("uses the lazy runtime endpoint resolver for exec and async commands", async () => {
       mockFetch([
         jsonResponse({
           id: "sandbox-1",
@@ -1021,7 +1021,7 @@ describe("Sandbox", () => {
           { type: "exit", exitCode: 0 },
         ]),
         jsonResponse({
-          id: "job-1",
+          id: "command-1",
           status: "completed",
           exit_code: 0,
           signal: null,
@@ -1044,7 +1044,7 @@ describe("Sandbox", () => {
 
       try {
         await sandbox.executeCommand("echo ok");
-        await sandbox.startCommandJob("npm test");
+        await sandbox.startBackgroundCommand("npm test");
 
         assertEquals(
           fetchCalls[2]!.url,
@@ -1052,14 +1052,14 @@ describe("Sandbox", () => {
         );
         assertEquals(
           fetchCalls[3]!.url,
-          "http://sandbox.veryfront-sandbox-sandbox-1.svc.cluster.local/exec/jobs",
+          "http://sandbox.veryfront-sandbox-sandbox-1.svc.cluster.local/exec/commands",
         );
       } finally {
         await sandbox.close();
       }
     });
 
-    it("times out stalled lazy command-job control requests", async () => {
+    it("times out stalled lazy background-command control requests", async () => {
       let capturedSignal: AbortSignal | undefined;
 
       mockFetch([
@@ -1089,7 +1089,7 @@ describe("Sandbox", () => {
 
       try {
         await assertRejects(
-          () => sandbox.startCommandJob("npm test"),
+          () => sandbox.startBackgroundCommand("npm test"),
           Error,
         );
         assertEquals(capturedSignal?.aborted, true);
@@ -1204,7 +1204,7 @@ describe("Sandbox", () => {
       }
     });
 
-    it("pauses heartbeats while async jobs are active and resumes them after the job completes", async () => {
+    it("pauses heartbeats while async commands are active and resumes them after the command completes", async () => {
       const originalSetInterval = globalThis.setInterval;
       const originalClearInterval = globalThis.clearInterval;
       const intervalCallbacks = new Map<number, () => void>();
@@ -1234,7 +1234,7 @@ describe("Sandbox", () => {
         }),
         jsonResponse({ ok: true }),
         jsonResponse({
-          id: "job-1",
+          id: "command-1",
           status: "running",
           exit_code: null,
           signal: null,
@@ -1246,7 +1246,7 @@ describe("Sandbox", () => {
           heartbeat_failure_count: 0,
         }),
         jsonResponse({
-          id: "job-1",
+          id: "command-1",
           status: "completed",
           exit_code: 0,
           signal: null,
@@ -1270,17 +1270,17 @@ describe("Sandbox", () => {
       });
 
       try {
-        const job = await sandbox.startCommandJob("npm test");
-        assertEquals(job.status, "running");
+        const command = await sandbox.startBackgroundCommand("npm test");
+        assertEquals(command.status, "running");
         assertEquals(intervalCallbacks.size, 0);
 
-        const output = await sandbox.getCommandJobOutput("job-1");
+        const output = await sandbox.getBackgroundCommandOutput("command-1");
         assertEquals(output.status, "completed");
         assertEquals(output.stdout, "done\n");
         assertEquals(intervalCallbacks.size, 1);
         assertEquals(
           fetchCalls.some((call) =>
-            call.url === "https://sandbox-1.example.com/exec/jobs/job-1/output"
+            call.url === "https://sandbox-1.example.com/exec/commands/command-1/output"
           ),
           true,
         );
@@ -1291,7 +1291,7 @@ describe("Sandbox", () => {
       }
     });
 
-    it("preserves the current session when a heartbeat fails while async jobs are active", async () => {
+    it("preserves the current session when a heartbeat fails while async commands are active", async () => {
       mockFetch([
         jsonResponse({
           id: "sandbox-1",
@@ -1300,7 +1300,7 @@ describe("Sandbox", () => {
         }),
         jsonResponse({ ok: true }),
         jsonResponse({
-          id: "job-1",
+          id: "command-1",
           status: "running",
           exit_code: null,
           signal: null,
@@ -1313,7 +1313,7 @@ describe("Sandbox", () => {
         }),
         textResponse("upstream timeout", 503),
         jsonResponse({
-          id: "job-1",
+          id: "command-1",
           status: "completed",
           exit_code: 0,
           signal: null,
@@ -1337,7 +1337,7 @@ describe("Sandbox", () => {
       });
 
       try {
-        await sandbox.startCommandJob("npm test");
+        await sandbox.startBackgroundCommand("npm test");
 
         await assertRejects(
           () => sandbox.heartbeat(true),
@@ -1346,11 +1346,11 @@ describe("Sandbox", () => {
         );
 
         assertEquals(sandbox.isActive, true);
-        const output = await sandbox.getCommandJobOutput("job-1");
+        const output = await sandbox.getBackgroundCommandOutput("command-1");
         assertEquals(output.status, "completed");
         assertEquals(
           fetchCalls.some((call) =>
-            call.url === "https://sandbox-1.example.com/exec/jobs/job-1/output"
+            call.url === "https://sandbox-1.example.com/exec/commands/command-1/output"
           ),
           true,
         );
@@ -1435,12 +1435,12 @@ describe("Sandbox", () => {
     });
   });
 
-  describe("startCommandJob()", () => {
-    it("should start a command job", async () => {
+  describe("startBackgroundCommand()", () => {
+    it("should start a background command", async () => {
       mockFetch([
         jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
         jsonResponse({
-          id: "job-1",
+          id: "command-1",
           status: "running",
           exit_code: null,
           signal: null,
@@ -1454,17 +1454,17 @@ describe("Sandbox", () => {
       ]);
 
       const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
-      const job = await sandbox.startCommandJob("npm test");
+      const command = await sandbox.startBackgroundCommand("npm test");
 
-      assertEquals(job.id, "job-1");
-      assertEquals(job.status, "running");
-      assertEquals(job.exitCode, null);
-      assertEquals(job.startedAt, "2026-01-01T00:00:00Z");
-      assertEquals(job.heartbeatStatus, "disabled");
-      assertEquals(job.heartbeatFailureCount, 0);
+      assertEquals(command.id, "command-1");
+      assertEquals(command.status, "running");
+      assertEquals(command.exitCode, null);
+      assertEquals(command.startedAt, "2026-01-01T00:00:00Z");
+      assertEquals(command.heartbeatStatus, "disabled");
+      assertEquals(command.heartbeatFailureCount, 0);
 
       assertEquals(fetchCalls[1]!.init?.method, "POST");
-      assertStringIncludes(fetchCalls[1]!.url, "/exec/jobs");
+      assertStringIncludes(fetchCalls[1]!.url, "/exec/commands");
       assertEquals(headerValue(fetchCalls, 1, "Authorization"), "Bearer token");
       assertEquals(headerValue(fetchCalls, 1, "Content-Type"), "application/json");
       assertEquals(jsonBody(fetchCalls, 1), { command: "npm test" });
@@ -1478,19 +1478,19 @@ describe("Sandbox", () => {
 
       const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
       await assertRejects(
-        () => sandbox.startCommandJob("bad-cmd"),
+        () => sandbox.startBackgroundCommand("bad-cmd"),
         Error,
-        "Start command job failed",
+        "Start background command failed",
       );
     });
   });
 
-  describe("getCommandJob()", () => {
-    it("should get a command job by id", async () => {
+  describe("getBackgroundCommand()", () => {
+    it("should get a background command by id", async () => {
       mockFetch([
         jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
         jsonResponse({
-          id: "job-2",
+          id: "command-2",
           status: "completed",
           exit_code: 0,
           signal: null,
@@ -1504,16 +1504,16 @@ describe("Sandbox", () => {
       ]);
 
       const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
-      const job = await sandbox.getCommandJob("job-2");
+      const command = await sandbox.getBackgroundCommand("command-2");
 
-      assertEquals(job.id, "job-2");
-      assertEquals(job.status, "completed");
-      assertEquals(job.exitCode, 0);
-      assertEquals(job.finishedAt, "2026-01-01T00:01:00Z");
-      assertEquals(job.heartbeatStatus, "healthy");
-      assertEquals(job.lastHeartbeatAt, "2026-01-01T00:00:30Z");
+      assertEquals(command.id, "command-2");
+      assertEquals(command.status, "completed");
+      assertEquals(command.exitCode, 0);
+      assertEquals(command.finishedAt, "2026-01-01T00:01:00Z");
+      assertEquals(command.heartbeatStatus, "healthy");
+      assertEquals(command.lastHeartbeatAt, "2026-01-01T00:00:30Z");
 
-      assertStringIncludes(fetchCalls[1]!.url, "/exec/jobs/job-2");
+      assertStringIncludes(fetchCalls[1]!.url, "/exec/commands/command-2");
       assertEquals(headerValue(fetchCalls, 1, "Authorization"), "Bearer token");
     });
 
@@ -1525,19 +1525,19 @@ describe("Sandbox", () => {
 
       const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
       await assertRejects(
-        () => sandbox.getCommandJob("nonexistent"),
+        () => sandbox.getBackgroundCommand("nonexistent"),
         Error,
-        "Get command job failed",
+        "Get background command failed",
       );
     });
   });
 
-  describe("getCommandJobOutput()", () => {
-    it("should get command job output", async () => {
+  describe("getBackgroundCommandOutput()", () => {
+    it("should get background command output", async () => {
       mockFetch([
         jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
         jsonResponse({
-          id: "job-3",
+          id: "command-3",
           status: "completed",
           exit_code: 0,
           signal: null,
@@ -1555,16 +1555,16 @@ describe("Sandbox", () => {
       ]);
 
       const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
-      const output = await sandbox.getCommandJobOutput("job-3");
+      const output = await sandbox.getBackgroundCommandOutput("command-3");
 
-      assertEquals(output.id, "job-3");
+      assertEquals(output.id, "command-3");
       assertEquals(output.stdout, "hello world\n");
       assertEquals(output.stderr, "");
       assertEquals(output.stdoutTruncated, false);
       assertEquals(output.stderrTruncated, false);
       assertEquals(output.exitCode, 0);
 
-      assertStringIncludes(fetchCalls[1]!.url, "/exec/jobs/job-3/output");
+      assertStringIncludes(fetchCalls[1]!.url, "/exec/commands/command-3/output");
       assertEquals(headerValue(fetchCalls, 1, "Authorization"), "Bearer token");
     });
 
@@ -1576,21 +1576,21 @@ describe("Sandbox", () => {
 
       const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
       await assertRejects(
-        () => sandbox.getCommandJobOutput("nonexistent"),
+        () => sandbox.getBackgroundCommandOutput("nonexistent"),
         Error,
-        "Get command job output failed",
+        "Get background command output failed",
       );
     });
   });
 
-  describe("listCommandJobs()", () => {
-    it("should list command jobs", async () => {
+  describe("listBackgroundCommands()", () => {
+    it("should list background commands", async () => {
       mockFetch([
         jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
         jsonResponse({
-          jobs: [
+          commands: [
             {
-              id: "job-1",
+              id: "command-1",
               status: "running",
               exit_code: null,
               signal: null,
@@ -1602,7 +1602,7 @@ describe("Sandbox", () => {
               heartbeat_failure_count: 0,
             },
             {
-              id: "job-2",
+              id: "command-2",
               status: "completed",
               exit_code: 0,
               signal: null,
@@ -1618,16 +1618,16 @@ describe("Sandbox", () => {
       ]);
 
       const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
-      const jobs = await sandbox.listCommandJobs();
+      const commands = await sandbox.listBackgroundCommands();
 
-      assertEquals(jobs.length, 2);
-      assertEquals(jobs[0]!.id, "job-1");
-      assertEquals(jobs[0]!.status, "running");
-      assertEquals(jobs[1]!.id, "job-2");
-      assertEquals(jobs[1]!.status, "completed");
-      assertEquals(jobs[1]!.exitCode, 0);
+      assertEquals(commands.length, 2);
+      assertEquals(commands[0]!.id, "command-1");
+      assertEquals(commands[0]!.status, "running");
+      assertEquals(commands[1]!.id, "command-2");
+      assertEquals(commands[1]!.status, "completed");
+      assertEquals(commands[1]!.exitCode, 0);
 
-      assertStringIncludes(fetchCalls[1]!.url, "/exec/jobs");
+      assertStringIncludes(fetchCalls[1]!.url, "/exec/commands");
       assertEquals(headerValue(fetchCalls, 1, "Authorization"), "Bearer token");
     });
 
@@ -1636,7 +1636,7 @@ describe("Sandbox", () => {
         jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
         jsonResponse([
           {
-            id: "job-1",
+            id: "command-1",
             status: "running",
             exit_code: null,
             signal: null,
@@ -1651,10 +1651,10 @@ describe("Sandbox", () => {
       ]);
 
       const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
-      const jobs = await sandbox.listCommandJobs();
+      const commands = await sandbox.listBackgroundCommands();
 
-      assertEquals(jobs.length, 1);
-      assertEquals(jobs[0]!.id, "job-1");
+      assertEquals(commands.length, 1);
+      assertEquals(commands[0]!.id, "command-1");
     });
 
     it("should throw on list failure", async () => {
@@ -1665,19 +1665,19 @@ describe("Sandbox", () => {
 
       const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
       await assertRejects(
-        () => sandbox.listCommandJobs(),
+        () => sandbox.listBackgroundCommands(),
         Error,
-        "List command jobs failed",
+        "List background commands failed",
       );
     });
   });
 
-  describe("cancelCommandJob()", () => {
-    it("should cancel a command job", async () => {
+  describe("cancelBackgroundCommand()", () => {
+    it("should cancel a background command", async () => {
       mockFetch([
         jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
         jsonResponse({
-          id: "job-4",
+          id: "command-4",
           status: "canceled",
           exit_code: null,
           signal: "SIGTERM",
@@ -1691,13 +1691,13 @@ describe("Sandbox", () => {
       ]);
 
       const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
-      const job = await sandbox.cancelCommandJob("job-4");
+      const command = await sandbox.cancelBackgroundCommand("command-4");
 
-      assertEquals(job.id, "job-4");
-      assertEquals(job.status, "canceled");
-      assertEquals(job.signal, "SIGTERM");
+      assertEquals(command.id, "command-4");
+      assertEquals(command.status, "canceled");
+      assertEquals(command.signal, "SIGTERM");
 
-      assertStringIncludes(fetchCalls[1]!.url, "/exec/jobs/job-4/cancel");
+      assertStringIncludes(fetchCalls[1]!.url, "/exec/commands/command-4/cancel");
       assertEquals(fetchCalls[1]!.init?.method, "POST");
       assertEquals(headerValue(fetchCalls, 1, "Authorization"), "Bearer token");
     });
@@ -1710,9 +1710,9 @@ describe("Sandbox", () => {
 
       const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
       await assertRejects(
-        () => sandbox.cancelCommandJob("nonexistent"),
+        () => sandbox.cancelBackgroundCommand("nonexistent"),
         Error,
-        "Cancel command job failed",
+        "Cancel background command failed",
       );
     });
   });

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -15,10 +15,10 @@ import {
 import { LazySandbox, type LazySandboxOptions } from "./lazy-sandbox.ts";
 import { resolveSandboxApiUrl, resolveSandboxAuthToken } from "./config.ts";
 import type {
-  CommandJob,
-  CommandJobHeartbeatStatus,
-  CommandJobOutput,
-  CommandJobStatus,
+  BackgroundCommand,
+  BackgroundCommandHeartbeatStatus,
+  BackgroundCommandOutput,
+  BackgroundCommandStatus,
   ExecOptions,
   ExecResult,
   ExecStreamEvent,
@@ -29,10 +29,10 @@ import type {
 } from "./types.ts";
 export { resolveSandboxApiUrl, resolveSandboxAuthToken } from "./config.ts";
 export type {
-  CommandJob,
-  CommandJobHeartbeatStatus,
-  CommandJobOutput,
-  CommandJobStatus,
+  BackgroundCommand,
+  BackgroundCommandHeartbeatStatus,
+  BackgroundCommandOutput,
+  BackgroundCommandStatus,
   ExecOptions,
   ExecResult,
   ExecStreamEvent,
@@ -273,9 +273,9 @@ export class Sandbox {
     }
   }
 
-  /** Start an async command job in the sandbox. */
-  async startCommandJob(command: string, options?: ExecOptions): Promise<CommandJob> {
-    const res = await fetch(`${this.endpoint}/exec/jobs`, {
+  /** Start an async background command in the sandbox. */
+  async startBackgroundCommand(command: string, options?: ExecOptions): Promise<BackgroundCommand> {
+    const res = await fetch(`${this.endpoint}/exec/commands`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${this.authToken}`,
@@ -286,43 +286,43 @@ export class Sandbox {
 
     if (!res.ok) {
       throw REQUEST_ERROR.create({
-        detail: `Start command job failed: ${res.status} ${await res.text()}`,
+        detail: `Start background command failed: ${res.status} ${await res.text()}`,
       });
     }
 
-    return Sandbox.mapCommandJob(await res.json());
+    return Sandbox.mapBackgroundCommand(await res.json());
   }
 
-  /** Get the status of an async command job. */
-  async getCommandJob(jobId: string): Promise<CommandJob> {
-    const res = await fetch(`${this.endpoint}/exec/jobs/${jobId}`, {
+  /** Get the status of an async background command. */
+  async getBackgroundCommand(commandId: string): Promise<BackgroundCommand> {
+    const res = await fetch(`${this.endpoint}/exec/commands/${commandId}`, {
       headers: { Authorization: `Bearer ${this.authToken}` },
     });
 
     if (!res.ok) {
       throw REQUEST_ERROR.create({
-        detail: `Get command job failed: ${res.status} ${await res.text()}`,
+        detail: `Get background command failed: ${res.status} ${await res.text()}`,
       });
     }
 
-    return Sandbox.mapCommandJob(await res.json());
+    return Sandbox.mapBackgroundCommand(await res.json());
   }
 
-  /** Get the output of an async command job. */
-  async getCommandJobOutput(jobId: string): Promise<CommandJobOutput> {
-    const res = await fetch(`${this.endpoint}/exec/jobs/${jobId}/output`, {
+  /** Get the output of an async background command. */
+  async getBackgroundCommandOutput(commandId: string): Promise<BackgroundCommandOutput> {
+    const res = await fetch(`${this.endpoint}/exec/commands/${commandId}/output`, {
       headers: { Authorization: `Bearer ${this.authToken}` },
     });
 
     if (!res.ok) {
       throw REQUEST_ERROR.create({
-        detail: `Get command job output failed: ${res.status} ${await res.text()}`,
+        detail: `Get background command output failed: ${res.status} ${await res.text()}`,
       });
     }
 
     const json = await res.json();
     return {
-      ...Sandbox.mapCommandJob(json),
+      ...Sandbox.mapBackgroundCommand(json),
       stdout: json.stdout,
       stderr: json.stderr,
       stdoutTruncated: json.stdout_truncated,
@@ -330,48 +330,50 @@ export class Sandbox {
     };
   }
 
-  /** List all command jobs in the sandbox. */
-  async listCommandJobs(): Promise<CommandJob[]> {
-    const res = await fetch(`${this.endpoint}/exec/jobs`, {
+  /** List all background commands in the sandbox. */
+  async listBackgroundCommands(): Promise<BackgroundCommand[]> {
+    const res = await fetch(`${this.endpoint}/exec/commands`, {
       headers: { Authorization: `Bearer ${this.authToken}` },
     });
 
     if (!res.ok) {
       throw REQUEST_ERROR.create({
-        detail: `List command jobs failed: ${res.status} ${await res.text()}`,
+        detail: `List background commands failed: ${res.status} ${await res.text()}`,
       });
     }
 
     const json = await res.json();
-    const jobs = Array.isArray(json) ? json : (json.jobs ?? []);
-    return jobs.map((j: Record<string, unknown>) => Sandbox.mapCommandJob(j));
+    const commands = Array.isArray(json) ? json : (json.commands ?? []);
+    return commands.map((command: Record<string, unknown>) =>
+      Sandbox.mapBackgroundCommand(command)
+    );
   }
 
-  /** Cancel an async command job. */
-  async cancelCommandJob(jobId: string): Promise<CommandJob> {
-    const res = await fetch(`${this.endpoint}/exec/jobs/${jobId}/cancel`, {
+  /** Cancel an async background command. */
+  async cancelBackgroundCommand(commandId: string): Promise<BackgroundCommand> {
+    const res = await fetch(`${this.endpoint}/exec/commands/${commandId}/cancel`, {
       method: "POST",
       headers: { Authorization: `Bearer ${this.authToken}` },
     });
 
     if (!res.ok) {
       throw REQUEST_ERROR.create({
-        detail: `Cancel command job failed: ${res.status} ${await res.text()}`,
+        detail: `Cancel background command failed: ${res.status} ${await res.text()}`,
       });
     }
 
-    return Sandbox.mapCommandJob(await res.json());
+    return Sandbox.mapBackgroundCommand(await res.json());
   }
 
-  private static mapCommandJob(json: Record<string, unknown>): CommandJob {
+  private static mapBackgroundCommand(json: Record<string, unknown>): BackgroundCommand {
     return {
       id: json.id as string,
-      status: json.status as CommandJobStatus,
+      status: json.status as BackgroundCommandStatus,
       exitCode: json.exit_code as number | null,
       signal: json.signal as string | null,
       startedAt: json.started_at as string,
       finishedAt: json.finished_at as string | null,
-      heartbeatStatus: json.heartbeat_status as CommandJobHeartbeatStatus,
+      heartbeatStatus: json.heartbeat_status as BackgroundCommandHeartbeatStatus,
       lastHeartbeatAt: json.last_heartbeat_at as string | null,
       lastHeartbeatError: json.last_heartbeat_error as string | null,
       heartbeatFailureCount: json.heartbeat_failure_count as number,

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -34,28 +34,28 @@ export interface ExecStreamEvent {
   exitCode?: number;
 }
 
-/** Status of an async command job. */
-export type CommandJobStatus = "running" | "completed" | "failed" | "canceled";
+/** Status of an async background command. */
+export type BackgroundCommandStatus = "running" | "completed" | "failed" | "canceled";
 
-/** Heartbeat health status for a command job. */
-export type CommandJobHeartbeatStatus = "disabled" | "healthy" | "degraded";
+/** Heartbeat health status for a background command. */
+export type BackgroundCommandHeartbeatStatus = "disabled" | "healthy" | "degraded";
 
-/** An async command job running in a sandbox. */
-export interface CommandJob {
+/** An async background command running in a sandbox. */
+export interface BackgroundCommand {
   id: string;
-  status: CommandJobStatus;
+  status: BackgroundCommandStatus;
   exitCode: number | null;
   signal: string | null;
   startedAt: string;
   finishedAt: string | null;
-  heartbeatStatus: CommandJobHeartbeatStatus;
+  heartbeatStatus: BackgroundCommandHeartbeatStatus;
   lastHeartbeatAt: string | null;
   lastHeartbeatError: string | null;
   heartbeatFailureCount: number;
 }
 
-/** A command job with its captured output. */
-export interface CommandJobOutput extends CommandJob {
+/** A background command with its captured output. */
+export interface BackgroundCommandOutput extends BackgroundCommand {
   stdout: string;
   stderr: string;
   stdoutTruncated: boolean;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.577";
+export const VERSION = "0.1.578";


### PR DESCRIPTION
## Summary
- rename sandbox command-job SDK APIs to background-command terminology
- update hosted agent sandbox tools and docs to use background commands
- bump deno.json and runtime VERSION to 0.1.576 for release publishing

## Verification
- deno check src/sandbox/sandbox.ts src/sandbox/agent-service-tools.ts src/agent/hosted/child-fork-tool-sources.test.ts
- deno test --no-check --allow-all src/sandbox/sandbox.test.ts src/sandbox/agent-service-tools.test.ts src/agent/hosted/child-fork-tool-sources.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- pre-push checks: format, lint, type check, unit tests