### PR TITLE
Stop forwarding caller end-user identity

### DIFF
--- a/src/agent/hosted/project-remote-tool-source.test.ts
+++ b/src/agent/hosted/project-remote-tool-source.test.ts
@@ -268,7 +268,7 @@ Deno.test("createHostedProjectRemoteToolSources defaults to the Veryfront API MC
   assertEquals(configs.map((config) => config.endpoint), ["https://api.example/mcp"]);
 });
 
-Deno.test("createHostedProjectRemoteToolSources injects end_user_id for Veryfront API integration tools", async () => {
+Deno.test("createHostedProjectRemoteToolSources does not inject end_user_id for Veryfront API integration tools", async () => {
   const executed: Array<{ toolName: string; args: unknown; context?: ToolExecutionContext }> = [];
   const sources = createHostedProjectRemoteToolSources({
     authToken: "token-1",
@@ -287,12 +287,15 @@ Deno.test("createHostedProjectRemoteToolSources injects end_user_id for Veryfron
       }),
   });
 
-  await sources[0]?.executeTool("github__list_issues", { repo: "veryfront" });
+  await sources[0]?.executeTool("github__list_issues", {
+    repo: "veryfront",
+    end_user_id: "malicious-user",
+  });
 
   assertEquals(executed, [
     {
       toolName: "github__list_issues",
-      args: { repo: "veryfront", end_user_id: "user-123" },
+      args: { repo: "veryfront" },
       context: undefined,
     },
   ]);
@@ -596,7 +599,6 @@ Deno.test("createHostedProjectRemoteToolSources composes API input preparation w
       args: {
         owner: "veryfront",
         prepared: true,
-        end_user_id: "end-user-123",
       },
       context: { projectId: "project-1" },
     },

--- a/src/agent/hosted/project-remote-tool-source.ts
+++ b/src/agent/hosted/project-remote-tool-source.ts
@@ -234,19 +234,8 @@ function prepareVeryfrontApiToolInput(input: {
       return prepared;
     }
 
-    if (typeof prepared.end_user_id === "string" && prepared.end_user_id.length > 0) {
-      return prepared;
-    }
-
-    const endUserId = input.getEndUserId?.() ?? toolInputContext.context?.endUserId;
-    if (typeof endUserId !== "string" || endUserId.length === 0) {
-      return prepared;
-    }
-
-    return {
-      ...prepared,
-      end_user_id: endUserId,
-    };
+    const { end_user_id: _endUserId, ...trustedInput } = prepared;
+    return trustedInput;
   };
 }
 

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -256,7 +256,6 @@ describe("tool-helpers", () => {
         assertEquals(requestBody, {
           name: "gmail__list_emails",
           arguments: { maxResults: 10 },
-          end_user_id: "user-123",
           run_id: "run-123",
           agent_id: "agent-123",
         });

--- a/src/integrations/remote-tools.test.ts
+++ b/src/integrations/remote-tools.test.ts
@@ -156,7 +156,6 @@ describe("integrations/remote-tools", () => {
     assertEquals(requestBody, {
       name: "github:list-repos",
       arguments: { visibility: "private" },
-      end_user_id: "end-user-123",
     });
     assertEquals(result, {
       error: "authentication_required",
@@ -164,7 +163,7 @@ describe("integrations/remote-tools", () => {
     });
   });
 
-  it("forwards run and agent context when executing remote integration tools", async () => {
+  it("forwards run and agent context without caller-supplied end-user identity", async () => {
     setRemoteToolEnv({
       VERYFRONT_API_BASE_URL: "https://api.test",
       VERYFRONT_API_TOKEN: "env-token",
@@ -190,7 +189,6 @@ describe("integrations/remote-tools", () => {
     assertEquals(requestBody, {
       name: "gmail__list_emails",
       arguments: { maxResults: 10 },
-      end_user_id: "end-user-123",
       run_id: "run-123",
       agent_id: "agent-123",
     });

--- a/src/integrations/remote-tools.ts
+++ b/src/integrations/remote-tools.ts
@@ -126,7 +126,6 @@ async function callRemoteTool(
     body: JSON.stringify({
       name: toolName,
       arguments: args,
-      end_user_id: context?.endUserId,
       run_id: context?.runId,
       agent_id: context?.agentId,
     }),

--- a/src/routing/api/openapi/mcp-tools.test.ts
+++ b/src/routing/api/openapi/mcp-tools.test.ts
@@ -230,5 +230,41 @@ describe("routing/api/openapi/mcp-tools", () => {
       assertEquals(ids.includes("api:getPosts"), true);
       assertEquals(ids.includes("api:createPost"), true);
     });
+
+    it("does not propagate caller-supplied end-user identity headers", async () => {
+      const originalFetch = globalThis.fetch;
+      let requestHeaders: Headers | undefined;
+
+      try {
+        globalThis.fetch = (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          requestHeaders = request.headers;
+          return Promise.resolve(
+            Response.json({ ok: true }, { status: 200 }),
+          );
+        };
+
+        const tools = generateTools(
+          makeSpec({
+            "/api/users": {
+              get: {
+                operationId: "getUsers",
+                responses: { "200": { description: "OK" } },
+              },
+            },
+          }),
+          { baseUrl: "http://localhost:3000" },
+        );
+
+        const first = tools[0];
+        assertExists(first);
+        await first.execute({}, { endUserId: "user-123" });
+
+        assertExists(requestHeaders);
+        assertEquals(requestHeaders.get("X-End-User-Id"), null);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
   });
 });

--- a/src/routing/api/openapi/mcp-tools.ts
+++ b/src/routing/api/openapi/mcp-tools.ts
@@ -156,7 +156,7 @@ async function executeAPICall(
   path: string,
   input: Record<string, unknown>,
   operation: OpenAPIOperation,
-  context?: ToolExecutionContext,
+  _context?: ToolExecutionContext,
 ): Promise<unknown> {
   let url = `${config.baseUrl}${path}`;
 
@@ -185,12 +185,6 @@ async function executeAPICall(
     ...config.headers,
     ...((input.headers as Record<string, string> | undefined) ?? {}),
   };
-
-  // Propagate end-user identity for per-user token resolution
-  const endUserId = context?.endUserId;
-  if (typeof endUserId === "string" && endUserId.length > 0) {
-    headers["X-End-User-Id"] = endUserId;
-  }
 
   const requestInit: RequestInit = {
     method: method.toUpperCase(),


### PR DESCRIPTION
## Summary
- stop injecting `end_user_id` into Veryfront API integration tool arguments
- stop forwarding top-level `end_user_id` through remote integration REST execution
- stop propagating `X-End-User-Id` from generated OpenAPI MCP tool context

Refs veryfront/veryfront-issue-inbox#61

## TDD
- RED: `deno test --no-check --allow-all src/agent/hosted/project-remote-tool-source.test.ts src/integrations/remote-tools.test.ts` failed while hosted integration calls and REST tool calls still included `end_user_id`
- RED: `deno test --no-check --allow-all src/routing/api/openapi/mcp-tools.test.ts` failed while generated OpenAPI tools still sent `X-End-User-Id`
- GREEN: focused identity forwarding tests passed after stripping/omitting caller-supplied identity

## Verification
- `deno test --no-check --allow-all src/agent/runtime/tool-helpers.test.ts src/agent/hosted/project-remote-tool-source.test.ts src/integrations/remote-tools.test.ts src/routing/api/openapi/mcp-tools.test.ts`
- `deno task verify:quick`
- pre-push hook: format, lint, typecheck, and `deno task test:unit` passed with 1909 tests / 17567 steps

## Critical review
- Score: 92/100
- Risk reviewed: this intentionally preserves run/agent metadata while removing caller-selected token-owner fields; remaining internal `endUserId` transport is left untouched where it is not forwarded to the API as token authority.
- No visual surface changed; agent-browser verification not applicable.