### PR TITLE
Package sandbox shell runtime for hosted agents

### DIFF
--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -149,6 +149,10 @@ await build({
 		// Native binary deps that should not block install if they fail
 		optionalDependencies: {
 			"@huggingface/transformers": `^${OPAQUE_DEPENDENCY_VERSIONS["@huggingface/transformers"]}`,
+			// ext-sandbox-shell-tools is auto-enabled by the hosted agent service,
+			// so its runtime implementation must be installable with the npm package.
+			"bash-tool": npmDependencyRange(denoConfigSet, "bash-tool"),
+			"just-bash": npmDependencyRange(denoConfigSet, "just-bash"),
 		},
 		keywords: [
 			"react",

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -18,8 +18,6 @@ describe("normalizeNpmPackageMetadata", () => {
 				"@kreuzberg/wasm": "4.5.2",
 				"@opentelemetry/api": "1.9.1",
 				"@opentelemetry/sdk-node": "0.218.0",
-				"bash-tool": "1.3.16",
-				"just-bash": "2.14.5",
 				"zod": "4.3.6",
 			},
 			optionalDependencies: {
@@ -36,18 +34,36 @@ describe("normalizeNpmPackageMetadata", () => {
 			"@kreuzberg/wasm": "4.5.2",
 			"@opentelemetry/api": "1.9.1",
 			"@opentelemetry/sdk-node": "0.218.0",
-			"bash-tool": "1.3.16",
 			"better-sqlite3": ">=9.0.0",
-			"just-bash": "2.14.5",
 		});
 		assertEquals(pkg.peerDependenciesMeta, {
 			"@kreuzberg/node": { optional: true },
 			"@kreuzberg/wasm": { optional: true },
 			"@opentelemetry/api": { optional: true },
 			"@opentelemetry/sdk-node": { optional: true },
-			"bash-tool": { optional: true },
 			"better-sqlite3": { optional: true },
-			"just-bash": { optional: true },
+		});
+	});
+
+	it("keeps auto-enabled sandbox shell extension packages installable at runtime", () => {
+		const pkg = normalizeNpmPackageMetadata({
+			dependencies: {
+				"bash-tool": "1.3.16",
+				"just-bash": "2.14.5",
+				zod: "4.3.6",
+			},
+		});
+
+		assertEquals(pkg.dependencies, { zod: "4.3.6" });
+		assertEquals(pkg.optionalDependencies, {
+			"bash-tool": "1.3.16",
+			"just-bash": "2.14.5",
+		});
+		assertEquals(pkg.peerDependencies, {
+			"better-sqlite3": ">=9.0.0",
+		});
+		assertEquals(pkg.peerDependenciesMeta, {
+			"better-sqlite3": { optional: true },
 		});
 	});
 

--- a/scripts/build/npm-package-metadata.ts
+++ b/scripts/build/npm-package-metadata.ts
@@ -27,6 +27,9 @@ const OPTIONAL_FEATURE_PEERS = [
 	"@opentelemetry/sdk-node",
 	"@opentelemetry/sdk-trace-base",
 	"@opentelemetry/semantic-conventions",
+] as const;
+
+const AUTO_ENABLED_EXTENSION_OPTIONAL_DEPENDENCIES = [
 	"bash-tool",
 	"just-bash",
 ] as const;
@@ -64,6 +67,10 @@ export function normalizeNpmPackageMetadata(pkg: PackageJson): PackageJson {
 		movePackageToOptionalPeer(pkg, name);
 	}
 
+	for (const name of AUTO_ENABLED_EXTENSION_OPTIONAL_DEPENDENCIES) {
+		movePackageToOptionalDependency(pkg, name);
+	}
+
 	for (const name of STALE_DIRECT_DEPENDENCIES) {
 		delete pkg.dependencies?.[name];
 		delete pkg.optionalDependencies?.[name];
@@ -96,6 +103,18 @@ function movePackageToOptionalPeer(pkg: PackageJson, name: string): void {
 
 	pkg.peerDependenciesMeta ??= {};
 	pkg.peerDependenciesMeta[name] = { optional: true };
+}
+
+function movePackageToOptionalDependency(pkg: PackageJson, name: string): void {
+	const range = pkg.dependencies?.[name] ?? pkg.optionalDependencies?.[name];
+	if (!range) return;
+
+	delete pkg.dependencies?.[name];
+	delete pkg.peerDependencies?.[name];
+	delete pkg.peerDependenciesMeta?.[name];
+
+	pkg.optionalDependencies ??= {};
+	pkg.optionalDependencies[name] = range;
 }
 
 function deleteIfEmpty(


### PR DESCRIPTION
## Problem
Staging e2e agent runs fail with `INVOKE_AGENT_FAILED: Sandbox shell tools require optional package \"bash-tool\"`. The hosted agent service auto-enables `ext-sandbox-shell-tools`, but the npm package metadata normalized `bash-tool` and `just-bash` into optional peer dependencies, so package consumers do not install the runtime implementation needed by the auto-enabled extension.

## Solution
- Keep shell execution inside `ext-sandbox-shell-tools` and preserve the dynamic `bash-tool` import boundary.
- Add `bash-tool` and `just-bash` to generated npm `optionalDependencies`.
- Update package metadata normalization so those auto-enabled extension runtime packages remain installable, while other opt-in feature packages stay optional peers.

## Red / Green / Refactor
- Red: added a failing metadata test proving auto-enabled sandbox shell packages must remain installable at runtime.
- Green: moved `bash-tool` and `just-bash` into generated npm optional dependencies and normalized them there.
- Refactor: kept the dependency policy explicit via a named auto-enabled extension list.

## Verification
- `deno test --config=scripts/test.deno.json --no-check --allow-read scripts/build/npm-package-metadata.test.ts`
- `deno task test:scripts`
- `deno check --config=scripts/test.deno.json scripts/build/build-npm-dnt.ts scripts/build/npm-package-metadata.ts`
- `deno task build:npm`
- Verified `npm/package.json` includes `optionalDependencies.bash-tool` and `optionalDependencies.just-bash`.
- `git diff --check`

Related: veryfront/veryfront-studio#4216