### PR TITLE
Publish sandbox shell packaging fix

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.578",
+  "version": "0.1.579",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.578";
+export const VERSION = "0.1.579";


### PR DESCRIPTION
## Problem
The sandbox shell packaging fix is merged in veryfront-code, but the existing npm version `0.1.578` is already published with the old metadata where `bash-tool` remains a peer dependency. npm versions are immutable, so Studio/runtime consumers cannot receive the corrected optional dependency metadata from `0.1.578`.

## Solution
Bump the package version to `0.1.579` so CI can publish a package where `bash-tool` and `just-bash` are optional runtime dependencies for the auto-enabled sandbox shell extension.

## Verification
- `deno task build:npm`
- Verified generated `npm/package.json` version is `0.1.579`.
- Verified generated `npm/package.json` includes `optionalDependencies.bash-tool` and `optionalDependencies.just-bash`.
- `git diff --check`

Related: #1831; veryfront/veryfront-studio#4216