### PR TITLE
Ignore untrusted MCP end-user headers

### DIFF
--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -77,7 +77,7 @@ describe("mcp/server", () => {
     globalThis.fetch = originalFetch;
   });
 
-  it("extracts end-user and project IDs from HTTP headers into tool context", async () => {
+  it("does not trust caller-supplied end-user IDs from HTTP headers", async () => {
     const server = createMCPServer({
       enabled: true,
       auth: { type: "none", allowUnauthenticated: true },
@@ -115,7 +115,7 @@ describe("mcp/server", () => {
     const response = await handler(request);
     assertEquals(response.status, 200);
     assertExists(capturedContext);
-    assertEquals(capturedContext?.endUserId, "user_123");
+    assertEquals(capturedContext?.endUserId, undefined);
     assertEquals(capturedContext?.projectId, "proj-abc_123");
   });
 
@@ -160,7 +160,7 @@ describe("mcp/server", () => {
     assertEquals(capturedContext, undefined);
   });
 
-  it("includes integration context headers in CORS preflight response", async () => {
+  it("only includes trusted integration context headers in CORS preflight response", async () => {
     const server = createMCPServer({
       enabled: true,
       auth: { type: "none", allowUnauthenticated: true },
@@ -175,7 +175,7 @@ describe("mcp/server", () => {
     assertEquals(response.status, 204);
     const allowHeaders = response.headers.get("Access-Control-Allow-Headers");
     assertExists(allowHeaders);
-    assertStringIncludes(allowHeaders, "X-End-User-Id");
+    assertEquals(allowHeaders.includes("X-End-User-Id"), false);
     assertStringIncludes(allowHeaders, "X-Project-Id");
   });
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -16,7 +16,6 @@ import { TaskStore } from "./task-store.ts";
 
 const logger = baseLogger.component("mcp-server");
 const MAX_CONTEXT_HEADER_LENGTH = 255;
-const END_USER_ID_PATTERN = /^[a-zA-Z0-9._@-]+$/;
 const PROJECT_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
 
 type JSONRPCParams = Record<string, unknown> | unknown[];
@@ -704,11 +703,6 @@ export class MCPServer {
   private extractRequestContext(request: Request): ToolExecutionContext | undefined {
     const context: ToolExecutionContext = {};
 
-    const endUserId = readAllowedHeader(request, "x-end-user-id", END_USER_ID_PATTERN);
-    if (endUserId) {
-      context.endUserId = endUserId;
-    }
-
     const projectId = readAllowedHeader(request, "x-project-id", PROJECT_ID_PATTERN);
     if (projectId) {
       context.projectId = projectId;
@@ -753,8 +747,7 @@ export class MCPServer {
     return {
       "Access-Control-Allow-Origin": matchedOrigin,
       "Access-Control-Allow-Methods": "POST, GET, DELETE, OPTIONS",
-      "Access-Control-Allow-Headers":
-        "Content-Type, Authorization, MCP-Session-Id, X-End-User-Id, X-Project-Id",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization, MCP-Session-Id, X-Project-Id",
       "Vary": "Origin",
     };
   }


### PR DESCRIPTION
## Summary
- Stop deriving MCP tool `endUserId` from caller-supplied `X-End-User-Id` HTTP headers.
- Keep trusted project context via `X-Project-Id`.
- Stop advertising `X-End-User-Id` in MCP HTTP CORS allowed headers.

## TDD
RED:
- `deno task test src/mcp/server.test.ts` failed before implementation because `capturedContext.endUserId` was still `"user_123"` and CORS still included `X-End-User-Id`.

GREEN:
- `deno task test src/mcp/server.test.ts` passed: 1 file, 113 steps.
- `deno task verify:quick` passed.
- Pre-push hook passed formatting, lint, typecheck, and unit tests: 1909 tests / 17567 steps.

## Visual Testing
- Not applicable: this is HTTP MCP server identity-context behavior only; no UI/visual surface changed.

## Review
- Local critical review score: 93/100. The change is scoped to the untrusted HTTP header extraction path and leaves trusted runtime `endUserId` context types intact.

Refs veryfront/veryfront-issue-inbox#61