### PR TITLE
Bundle sandbox shell tools in binary runtime

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.579",
+  "version": "0.1.580",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/extensions/ext-sandbox-shell-tools/src/index.ts
+++ b/extensions/ext-sandbox-shell-tools/src/index.ts
@@ -4,6 +4,7 @@
  * @module extensions/ext-sandbox-shell-tools
  */
 
+import { createBashTool as createBashToolImpl } from "bash-tool";
 import type { ExtensionFactory } from "veryfront/extensions";
 import {
   type CreateSandboxShellToolsInput,
@@ -22,29 +23,8 @@ export function createSandboxShellToolsProvider(
 }
 
 const provider = createSandboxShellToolsProvider(async (input) => {
-  const { createBashTool } = await importBashTool();
-  return await createBashTool(input);
+  return await createBashToolImpl(input);
 });
-
-async function importBashTool(): Promise<{ createBashTool: BashToolFactory }> {
-  try {
-    return await import("bash-tool") as { createBashTool: BashToolFactory };
-  } catch (error) {
-    if (!isMissingPackageError(error)) throw error;
-    throw new Error(
-      'Sandbox shell tools require the optional package "bash-tool". ' +
-        "Install bash-tool@1.3.16 or pass createBashTool explicitly.",
-    );
-  }
-}
-
-function isMissingPackageError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.includes("Cannot find package") ||
-    message.includes("Cannot find module") ||
-    message.includes("ERR_MODULE_NOT_FOUND") ||
-    message.includes("Module not found");
-}
 
 const extSandboxShellTools: ExtensionFactory = () => ({
   name: "ext-sandbox-shell-tools",

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -99,9 +99,9 @@ describe("normalizeNpmPackageMetadata", () => {
 });
 
 describe("npm supply-chain policy", () => {
-	it("does not statically load the shell execution dependency at module import time", async () => {
+	it("statically loads auto-enabled sandbox shell dependencies for binary builds", async () => {
 		const source = await Deno.readTextFile("extensions/ext-sandbox-shell-tools/src/index.ts");
 
-		assertEquals(source.includes('from "bash-tool"'), false);
+		assertEquals(source.includes('from "bash-tool"'), true);
 	});
 });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.579";
+export const VERSION = "0.1.580";


### PR DESCRIPTION
The hosted agent service runs from compiled Veryfront binaries as well as npm installs, so the auto-enabled sandbox shell extension must expose bash-tool as a static dependency. Keeping the import inside the extension preserves the ext-sandbox boundary while allowing deno compile to embed the runtime packages.

Constraint: Hosted agents auto-enable ext-sandbox-shell-tools and production server images run the compiled Veryfront binary.

Rejected: npm-only optional dependency packaging | It fixed package metadata but did not make the compiled binary include bash-tool.

Confidence: high

Scope-risk: narrow

Directive: Keep sandbox shell implementation dependencies in ext-sandbox-shell-tools, not core agent runtime.

Tested: deno test --config=scripts/test.deno.json --no-check --allow-read scripts/build/npm-package-metadata.test.ts; deno task test:scripts; deno test --allow-env src/utils/version.test.ts src/utils/logger/logger.test.ts; deno task build:npm; deno task build; ./bin/veryfront --version; strings ./bin/veryfront | rg 'bash-tool@1.3.16|just-bash@2.14.5'

Not-tested: remote staging e2e until the released binary deploys.
