### PR TITLE
Strip legacy end user IDs from remote tool auth URLs

### DIFF
--- a/src/integrations/remote-tools.test.ts
+++ b/src/integrations/remote-tools.test.ts
@@ -215,8 +215,30 @@ describe("integrations/remote-tools", () => {
     assertEquals(result, {
       error: "authentication_required",
       integration: "linear",
-      connectUrl: "/oauth/connect/linear?projectId=project-1&endUserId=user-1",
+      connectUrl: "/oauth/connect/linear?projectId=project-1",
       message: "Authentication required for Linear.",
+    });
+  });
+
+  it("preserves protocol-relative auth URL authority when stripping legacy end-user identity", async () => {
+    setRemoteToolEnv({
+      VERYFRONT_API_BASE_URL: "https://api.test",
+      VERYFRONT_API_TOKEN: "env-token",
+    });
+
+    const result = await withMockFetch(async () =>
+      Response.json({
+        content: [],
+        structuredContent: {
+          error: "authentication_required",
+          connectUrl:
+            "//auth.example.com/oauth/connect/github?projectId=project-1&endUserId=user-1",
+        },
+      }), async () => await executeRemoteIntegrationTool("github__list_repos", {}));
+
+    assertEquals(result, {
+      error: "authentication_required",
+      connectUrl: "//auth.example.com/oauth/connect/github?projectId=project-1",
     });
   });
 

--- a/src/integrations/remote-tools.ts
+++ b/src/integrations/remote-tools.ts
@@ -87,6 +87,44 @@ function parseJsonText(text: string): unknown | undefined {
   }
 }
 
+function stripLegacyEndUserIdFromConnectUrl(connectUrl: string): string {
+  try {
+    const isAbsolute = /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(connectUrl);
+    const isProtocolRelative = connectUrl.startsWith("//");
+    const isRootRelative = connectUrl.startsWith("/") && !isProtocolRelative;
+    const url = new URL(connectUrl, "https://veryfront.invalid");
+
+    if (!url.searchParams.has("endUserId")) return connectUrl;
+
+    url.searchParams.delete("endUserId");
+
+    if (isAbsolute) return url.toString();
+    if (isProtocolRelative) return `//${url.host}${url.pathname}${url.search}${url.hash}`;
+
+    const relativeUrl = `${url.pathname}${url.search}${url.hash}`;
+    return isRootRelative ? relativeUrl : relativeUrl.slice(1);
+  } catch {
+    return connectUrl;
+  }
+}
+
+function stripLegacyEndUserIdFromToolResult(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripLegacyEndUserIdFromToolResult);
+  }
+
+  if (!value || typeof value !== "object") return value;
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      key === "connectUrl" && typeof entry === "string"
+        ? stripLegacyEndUserIdFromConnectUrl(entry)
+        : stripLegacyEndUserIdFromToolResult(entry),
+    ]),
+  );
+}
+
 async function fetchToolList(
   baseUrl: string,
   token: string,
@@ -142,19 +180,21 @@ async function callRemoteTool(
   if (result?.content && Array.isArray(result.content)) {
     const text = joinCallToolText(result.content as CallToolTextContent[]);
 
-    if (result.structuredContent) return result.structuredContent;
+    if (result.structuredContent) {
+      return stripLegacyEndUserIdFromToolResult(result.structuredContent);
+    }
 
     if (result.isError) {
       // Try to preserve structured error data (e.g., authentication_required with connectUrl)
       const parsed = parseJsonText(text);
-      if (parsed && typeof parsed === "object") return parsed;
+      if (parsed && typeof parsed === "object") return stripLegacyEndUserIdFromToolResult(parsed);
       return { error: "tool_error", message: text };
     }
 
     return parseJsonText(text) ?? text;
   }
 
-  return result;
+  return stripLegacyEndUserIdFromToolResult(result);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Strips legacy `endUserId` query parameters from remote integration tool `connectUrl` results before returning them to the agent runtime.
- Applies the sanitizer to structured MCP content, parsed structured error text, and direct JSON results.
- Preserves absolute, root-relative, bare-relative, and protocol-relative URL forms while removing only the legacy selector.
- Keeps run/agent context forwarding behavior unchanged and continues not forwarding caller-supplied end-user identity to the API.

## Red/Green TDD
- RED: `deno task test src/integrations/remote-tools.test.ts` failed because the returned auth `connectUrl` still included `endUserId=user-1`.
- GREEN: focused remote-tools test passed: 1 file / 9 steps.
- RED review follow-up: protocol-relative regression failed because `//auth.example.com/...` was reconstructed as `/oauth/connect/...`.
- GREEN review follow-up: focused remote-tools test passed: 1 file / 10 steps.
- GREEN: related identity/remote-tool tests passed: 3 files / 23 steps.
- GREEN: `deno task verify:quick` passed, including format, lint, docs validation, and typecheck.
- GREEN: full `deno task verify` passed before the review follow-up: main suite 2237 tests / 20718 steps with 24 skipped/ignored steps; compiled-binary E2E 58 steps.
- GREEN: pre-push checks passed after the review follow-up: format, lint, typecheck, and unit tests 1909 tests / 17568 steps.

## Visual Verification
- Not applicable; remote tool result sanitization only, no UI/rendered surface changed.

## Review
Self-review score: 94/100. The sanitizer is scoped to `connectUrl` fields in remote tool JSON results and only removes the legacy `endUserId` query parameter while preserving URL authority.

Refs veryfront/veryfront-issue-inbox#61