### PR TITLE
Remove legacy end user ID from tools guide

### DIFF
--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -141,24 +141,26 @@ The `execute` function receives an optional second argument with runtime context
 import { z } from "zod";
 
 export default tool({
-  description: "List repos for the current user",
+  description: "List repos for the current account",
   inputSchema: z.object({
     sort: z.enum(["created", "updated"]).default("updated")
       .describe("Repository sort order"),
   }),
   execute: async ({ sort }, context) => {
-    const userId = context?.endUserId ?? "anonymous";
-    return await fetchRepos(userId, { sort });
+    const accountId = typeof context?.accountId === "string" ? context.accountId : "anonymous";
+    return await fetchRepos(accountId, { sort });
   },
 });
 ```
 
-| Context field | Type          | Description                                     |
-| ------------- | ------------- | ----------------------------------------------- |
-| `agentId`     | `string`      | ID of the agent that called the tool            |
-| `projectId`   | `string`      | Current project identifier                      |
-| `endUserId`   | `string`      | End-user identity for per-user token resolution |
-| `blobStorage` | `BlobStorage` | Blob storage access (if configured in workflow) |
+| Context field | Type          | Description                                      |
+| ------------- | ------------- | ------------------------------------------------ |
+| `agentId`     | `string`      | ID of the agent that called the tool             |
+| `projectId`   | `string`      | Current project identifier                       |
+| `runId`       | `string`      | Current agent run identifier                     |
+| `toolCallId`  | `string`      | Current tool call identifier                     |
+| `blobStorage` | `BlobStorage` | Blob storage access (if configured in workflow)  |
+| custom fields | `unknown`     | Host-provided application metadata for the tool  |
 
 Pass context from the API route:
 
@@ -168,7 +170,7 @@ import { createAgUiHandler } from "veryfront/agent";
 
 export const POST = createAgUiHandler("assistant", {
   context: {
-    endUserId: "user-123",
+    accountId: "account-123",
   },
 });
 ```

--- a/src/tool/types.ts
+++ b/src/tool/types.ts
@@ -72,7 +72,7 @@ export interface ToolExecutionContext {
   toolCallId?: string;
   /** Project identity used by integration token resolution */
   projectId?: string;
-  /** End-user identity for per-user token resolution in integration tools */
+  /** Trusted runtime user identity supplied by hosted integration tooling */
   endUserId?: string;
   /** Abort signal for cooperative cancellation during long-running tool execution */
   abortSignal?: AbortSignal;

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -18,6 +18,14 @@ describe("guide content contracts", () => {
     assertEquals(guide.includes("tokenStore.get(userId, githubConfig.id)"), false);
   });
 
+  it("does not document caller-provided endUserId as tool context authority", async () => {
+    const guide = await Deno.readTextFile("docs/guides/tools.md");
+
+    assertEquals(guide.includes("context?.endUserId"), false);
+    assertEquals(guide.includes("endUserId: \"user-123\""), false);
+    assertEquals(guide.includes("End-user identity for per-user token resolution"), false);
+  });
+
   it("does not claim deploy prints the production URL", async () => {
     for (const filename of ["deploying.md", "production-path.md"]) {
       const guide = await Deno.readTextFile(`docs/guides/${filename}`);


### PR DESCRIPTION
## Summary
- Removes the public Tools guide example that taught callers to pass `endUserId` through tool context.
- Documents app-defined context metadata instead of OAuth token-owner authority.
- Clarifies the `ToolExecutionContext.endUserId` comment as trusted runtime identity supplied by hosted integration tooling.

## Red/Green TDD
- RED: `deno test --no-check --allow-read tests/docs/guide-content.test.ts` failed because `docs/guides/tools.md` still documented `context?.endUserId`.
- GREEN: focused guide-content test passed: 1 file / 5 steps.
- GREEN: `deno task docs:validate` passed, including guide contracts/content/examples and 929 doc links.
- GREEN: `deno task verify:quick` passed, including format, lint, docs validation, and typecheck.
- GREEN: pre-push checks passed: format, lint, typecheck, and unit tests with 1909 passed / 17568 steps / 0 failed.

## Visual Verification
- Not applicable; documentation/type-comment-only change, no UI/rendered surface changed.

## Review
Self-review score: 93/100. Scope is limited to public guide wording and a type comment; the runtime-compatible `endUserId` field remains for trusted hosted integration contexts.

Refs veryfront/veryfront-issue-inbox#61