### PR TITLE
docs(guides): drop redundant Welcome line from Intro

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -4,8 +4,6 @@ description: "Start here. A short tour of the Veryfront Code guides and what you
 order: 0
 ---
 
-Welcome to the Veryfront Code guides.
-
 Each guide is a focused, goal-oriented mini tutorial — pick the one
 that matches the outcome you want next.
 


### PR DESCRIPTION
## Summary

Removes one line from `docs/guides/index.md` (the Intro page):

```
Welcome to the Veryfront Code guides.
```

The Intro already opens with its tagline sentence, and the welcome line reads like boilerplate. Matches the docs-site change in [veryfront/veryfront-docs#131](https://github.com/veryfront/veryfront-docs/pull/131), where `/code` was just rewritten as the Intro page without this line; this PR keeps the source in sync so the auto-sync workflow doesn't restore the welcome line on its next run.

## Test plan

- [x] `deno test --no-check --allow-all tests/docs/guide-contracts.test.ts` — 1 passed (46 steps).
- [x] `deno run --allow-read scripts/docs/validate-guides.ts` — "Validated 45 guide files. All guides passed validation."
- [ ] CI runs full test suite.