### PR TITLE
workflow: type guard, retry validation, ApprovalManager bind fix + tests

### DIFF
--- a/src/workflow/blob/guards.test.ts
+++ b/src/workflow/blob/guards.test.ts
@@ -1,0 +1,35 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { expect } from "#std/expect.ts";
+import { isBlobRef } from "./guards.ts";
+
+describe("workflow/blob/guards", () => {
+  describe("isBlobRef", () => {
+    it("accepts a well-formed blob ref", () => {
+      const ref = {
+        __kind: "blob",
+        id: "b1",
+        size: 42,
+        mimeType: "text/plain",
+        createdAt: new Date(),
+      };
+      expect(isBlobRef(ref)).toBe(true);
+    });
+
+    it("rejects objects missing required fields", () => {
+      expect(isBlobRef({ __kind: "blob" })).toBe(false);
+      expect(isBlobRef({ __kind: "blob", id: "b1" })).toBe(false);
+      expect(isBlobRef({ id: "b1", size: 1, mimeType: "x", createdAt: new Date() })).toBe(false);
+    });
+
+    it("rejects objects whose __kind is not 'blob'", () => {
+      expect(isBlobRef({ __kind: "other", id: "x", size: 1, mimeType: "y", createdAt: new Date() })).toBe(false);
+    });
+
+    it("rejects primitives, null, undefined, arrays, functions", () => {
+      for (const v of [null, undefined, "blob", 1, true, [], () => {}]) {
+        expect(isBlobRef(v)).toBe(false);
+      }
+    });
+  });
+});

--- a/src/workflow/blob/guards.test.ts
+++ b/src/workflow/blob/guards.test.ts
@@ -23,7 +23,8 @@ describe("workflow/blob/guards", () => {
     });
 
     it("rejects objects whose __kind is not 'blob'", () => {
-      expect(isBlobRef({ __kind: "other", id: "x", size: 1, mimeType: "y", createdAt: new Date() })).toBe(false);
+      expect(isBlobRef({ __kind: "other", id: "x", size: 1, mimeType: "y", createdAt: new Date() }))
+        .toBe(false);
     });
 
     it("rejects primitives, null, undefined, arrays, functions", () => {

--- a/src/workflow/blob/guards.ts
+++ b/src/workflow/blob/guards.ts
@@ -10,9 +10,9 @@ import type { BlobRef } from "./types.ts";
 export function isBlobRef(value: unknown): value is BlobRef {
   if (typeof value !== "object" || value === null) return false;
   const v = value as Record<string, unknown>;
-  return v.__kind === "blob"
-    && typeof v.id === "string"
-    && typeof v.size === "number"
-    && typeof v.mimeType === "string"
-    && v.createdAt instanceof Date;
+  return v.__kind === "blob" &&
+    typeof v.id === "string" &&
+    typeof v.size === "number" &&
+    typeof v.mimeType === "string" &&
+    v.createdAt instanceof Date;
 }

--- a/src/workflow/blob/guards.ts
+++ b/src/workflow/blob/guards.ts
@@ -1,0 +1,18 @@
+import type { BlobRef } from "./types.ts";
+
+/**
+ * Type guard verifying that an unknown value is a BlobRef.
+ *
+ * Checks structural shape rather than relying on `__kind` alone, so
+ * user data that happens to contain `{ __kind: "blob" }` does not
+ * incorrectly route through the blob resolver.
+ */
+export function isBlobRef(value: unknown): value is BlobRef {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return v.__kind === "blob"
+    && typeof v.id === "string"
+    && typeof v.size === "number"
+    && typeof v.mimeType === "string"
+    && v.createdAt instanceof Date;
+}

--- a/src/workflow/executor/step-executor.test.ts
+++ b/src/workflow/executor/step-executor.test.ts
@@ -1,0 +1,85 @@
+import "#veryfront/schemas/_test-setup.ts";
+/**
+ * Step Executor Tests
+ */
+
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { step } from "../dsl/step.ts";
+import type { RetryConfig, WorkflowContext, WorkflowNode } from "../types.ts";
+import { StepExecutor } from "./step-executor.ts";
+
+function makeContext(): WorkflowContext {
+  return { input: {} };
+}
+
+function makeStepNode(retry: RetryConfig): WorkflowNode {
+  // Cast through unknown because RetryConfig in tests may intentionally carry
+  // invalid values that the step DSL's narrower types would reject at compile time.
+  return step("test-step", {
+    tool: {
+      id: "noop",
+      description: "noop tool",
+      // deno-lint-ignore require-await
+      execute: async () => ({ ok: true }),
+      // deno-lint-ignore no-explicit-any
+    } as any,
+    retry,
+  });
+}
+
+describe("StepExecutor retry validation", () => {
+  it("rejects negative maxAttempts before executing the step", async () => {
+    const executor = new StepExecutor({});
+    const node = makeStepNode({ maxAttempts: -1 } as RetryConfig);
+
+    await assertRejects(
+      () => executor.execute(node, makeContext()),
+      Error,
+      "maxAttempts",
+    );
+  });
+
+  it("rejects when initialDelay is greater than maxDelay", async () => {
+    const executor = new StepExecutor({});
+    const node = makeStepNode({
+      maxAttempts: 3,
+      initialDelay: 5_000,
+      maxDelay: 1_000,
+    } as RetryConfig);
+
+    await assertRejects(
+      () => executor.execute(node, makeContext()),
+      Error,
+      "initialDelay",
+    );
+  });
+
+  it("rejects invalid backoff strategy", async () => {
+    const executor = new StepExecutor({});
+    const node = makeStepNode({
+      maxAttempts: 2,
+      // deno-lint-ignore no-explicit-any
+      backoff: "geometric" as any,
+    });
+
+    await assertRejects(
+      () => executor.execute(node, makeContext()),
+      Error,
+      "backoff",
+    );
+  });
+
+  it("accepts a valid retry config", async () => {
+    const executor = new StepExecutor({});
+    const node = makeStepNode({
+      maxAttempts: 3,
+      backoff: "exponential",
+      initialDelay: 100,
+      maxDelay: 1_000,
+    });
+
+    const result = await executor.execute(node, makeContext());
+    assertEquals(result.success, true);
+  });
+});

--- a/src/workflow/executor/step-executor.ts
+++ b/src/workflow/executor/step-executor.ts
@@ -18,7 +18,7 @@ import type {
   WorkflowContext,
   WorkflowNode,
 } from "../types.ts";
-import { parseDuration } from "../types.ts";
+import { parseDuration, validateRetryConfig } from "../types.ts";
 import type { BlobStorage } from "../blob/types.ts";
 
 /**
@@ -110,6 +110,10 @@ export class StepExecutor {
           `StepExecutor can only execute 'step' nodes, but node "${node.id}" has type '${config.type}'. ` +
           `This is likely a bug in the DAG executor routing.`,
       });
+    }
+
+    if (config.retry) {
+      validateRetryConfig(config.retry);
     }
 
     const retryConfig = { ...DEFAULT_RETRY, ...config.retry };

--- a/src/workflow/executor/workflow-executor.ts
+++ b/src/workflow/executor/workflow-executor.ts
@@ -30,6 +30,7 @@ import { mergeInjectedWorkflowEnv } from "#veryfront/jobs/runtime-env.ts";
 import { DAGExecutor } from "./dag-executor.ts";
 import { CheckpointManager } from "./checkpoint-manager.ts";
 import { runWithWorkflowTenant, StepExecutor, type StepExecutorConfig } from "./step-executor.ts";
+import { isBlobRef } from "../blob/guards.ts";
 import type { BlobStorage } from "../blob/types.ts";
 
 const logger = baseLogger.component("workflow-executor");
@@ -135,10 +136,7 @@ export class WorkflowExecutor {
       fn: (id: string) => Promise<T>,
       fallback: T,
     ): Promise<T> => {
-      const blob = ref as Record<string, unknown> | null | undefined;
-      return blob?.__kind === "blob" && typeof blob.id === "string"
-        ? fn(blob.id)
-        : Promise.resolve(fallback);
+      return isBlobRef(ref) ? fn(ref.id) : Promise.resolve(fallback);
     };
 
     this.blobResolver = {

--- a/src/workflow/runtime/approval-manager.test.ts
+++ b/src/workflow/runtime/approval-manager.test.ts
@@ -1,0 +1,278 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { ApprovalManager } from "./approval-manager.ts";
+import { MemoryBackend } from "../backends/memory.ts";
+import type { PendingApproval, WaitNodeConfig, WorkflowContext, WorkflowRun } from "../types.ts";
+
+describe("ApprovalManager", () => {
+  let backend: MemoryBackend;
+  let manager: ApprovalManager;
+
+  function createTestRun(id: string, overrides: Partial<WorkflowRun> = {}): WorkflowRun {
+    return {
+      id,
+      workflowId: "test-workflow",
+      status: "running",
+      input: { topic: "test" },
+      nodeStates: {},
+      currentNodes: [],
+      context: { runId: id, workflowId: "test-workflow", input: { topic: "test" } },
+      checkpoints: [],
+      pendingApprovals: [],
+      createdAt: new Date(),
+      ...overrides,
+    };
+  }
+
+  function createContext(runId: string): WorkflowContext {
+    return { input: { topic: "test" }, runId, workflowId: "test-workflow" };
+  }
+
+  function pastDate(msAgo = 1000): Date {
+    return new Date(Date.now() - msAgo);
+  }
+
+  beforeEach(() => {
+    backend = new MemoryBackend();
+  });
+
+  afterEach(() => {
+    manager?.stop();
+  });
+
+  describe("constructor", () => {
+    it("does not auto-expire approvals when expirationCheckInterval is 0", async () => {
+      manager = new ApprovalManager({ backend, expirationCheckInterval: 0 });
+
+      const runId = "run-no-timer";
+      await backend.createRun(createTestRun(runId));
+
+      const expiredApproval: PendingApproval = {
+        id: "apr-expired",
+        nodeId: "review",
+        message: "Old approval",
+        payload: {},
+        requestedAt: pastDate(2000),
+        expiresAt: pastDate(1000),
+        status: "pending",
+      };
+      await backend.savePendingApproval(runId, expiredApproval);
+
+      // Wait briefly. Without a timer the approval must remain pending.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      const stillPending = await backend.getPendingApproval(runId, "apr-expired");
+      assertEquals(stillPending?.status, "pending");
+
+      // stop() should be safe (no timer to clear).
+      manager.stop();
+      manager = undefined as unknown as ApprovalManager;
+    });
+  });
+
+  describe("checkExpiredApprovals", () => {
+    // NOTE: currently fails because ApprovalManager detaches `this` when calling
+    // `backend.listPendingApprovals` (approval-manager.ts:274). The same shape
+    // exists in listAllPending() at approval-manager.ts:257. Both break for any
+    // backend whose listPendingApprovals reads `this` (MemoryBackend does).
+    it("expires only approvals past their expiresAt", async () => {
+      manager = new ApprovalManager({ backend, expirationCheckInterval: 0 });
+
+      await backend.createRun(createTestRun("run-a"));
+      await backend.createRun(createTestRun("run-b"));
+      await backend.createRun(createTestRun("run-c"));
+
+      const expiredA: PendingApproval = {
+        id: "apr-a",
+        nodeId: "review",
+        message: "expired a",
+        payload: {},
+        requestedAt: pastDate(3000),
+        expiresAt: pastDate(2000),
+        status: "pending",
+      };
+      const expiredB: PendingApproval = {
+        id: "apr-b",
+        nodeId: "review",
+        message: "expired b",
+        payload: {},
+        requestedAt: pastDate(3000),
+        expiresAt: pastDate(1500),
+        status: "pending",
+      };
+      const futureC: PendingApproval = {
+        id: "apr-c",
+        nodeId: "review",
+        message: "still valid",
+        payload: {},
+        requestedAt: new Date(),
+        expiresAt: new Date(Date.now() + 60_000),
+        status: "pending",
+      };
+
+      await backend.savePendingApproval("run-a", expiredA);
+      await backend.savePendingApproval("run-b", expiredB);
+      await backend.savePendingApproval("run-c", futureC);
+
+      await manager.checkExpiredApprovals();
+
+      const a = await backend.getPendingApproval("run-a", "apr-a");
+      const b = await backend.getPendingApproval("run-b", "apr-b");
+      const c = await backend.getPendingApproval("run-c", "apr-c");
+
+      // Expired approvals get flipped to "rejected" (decision approved=false)
+      assertEquals(a?.status, "rejected");
+      assertEquals(a?.decidedBy, "system");
+      assertEquals(b?.status, "rejected");
+      assertEquals(b?.decidedBy, "system");
+
+      // The future approval is untouched
+      assertEquals(c?.status, "pending");
+
+      // Expired runs marked as failed
+      const runA = await backend.getRun("run-a");
+      const runB = await backend.getRun("run-b");
+      const runC = await backend.getRun("run-c");
+      assertEquals(runA?.status, "failed");
+      assertEquals(runB?.status, "failed");
+      assertEquals(runC?.status, "running");
+    });
+  });
+
+  describe("createApproval", () => {
+    it("persists approval with computed expiresAt and resolved payload", async () => {
+      manager = new ApprovalManager({ backend, expirationCheckInterval: 0 });
+
+      const runId = "run-create";
+      await backend.createRun(createTestRun(runId));
+
+      const before = Date.now();
+      const waitConfig: WaitNodeConfig = {
+        type: "wait",
+        waitType: "approval",
+        message: "Please approve",
+        payload: (ctx) => ({
+          data: "resolved",
+          inputTopic: (ctx.input as { topic: string }).topic,
+        }),
+        approvers: ["alice@example.com", "bob@example.com"],
+        timeout: "1h",
+      };
+
+      const request = await manager.createApproval(
+        await backend.getRun(runId) as WorkflowRun,
+        "review-node",
+        waitConfig,
+        createContext(runId),
+      );
+
+      const after = Date.now();
+
+      assertExists(request.approvalId);
+      assertEquals(request.runId, runId);
+      assertEquals(request.nodeId, "review-node");
+      assertEquals(request.message, "Please approve");
+
+      const persisted = await backend.getPendingApproval(runId, request.approvalId);
+      assertExists(persisted);
+      assertEquals(persisted.status, "pending");
+      assertEquals(persisted.nodeId, "review-node");
+      assertEquals(persisted.message, "Please approve");
+      assertEquals(persisted.approvers, ["alice@example.com", "bob@example.com"]);
+      assertEquals(persisted.payload, { data: "resolved", inputTopic: "test" });
+
+      assertExists(persisted.expiresAt);
+      const expiresMs = persisted.expiresAt.getTime();
+      // 1 hour from "before" .. "after" (small clock drift tolerance)
+      const minExpected = before + 60 * 60 * 1000;
+      const maxExpected = after + 60 * 60 * 1000;
+      if (expiresMs < minExpected || expiresMs > maxExpected) {
+        throw new Error(
+          `expiresAt ${expiresMs} not within [${minExpected}, ${maxExpected}]`,
+        );
+      }
+    });
+
+    it("omits expiresAt when no timeout is supplied", async () => {
+      manager = new ApprovalManager({ backend, expirationCheckInterval: 0 });
+
+      const runId = "run-no-timeout";
+      await backend.createRun(createTestRun(runId));
+
+      const waitConfig: WaitNodeConfig = {
+        type: "wait",
+        waitType: "approval",
+        message: "No timeout",
+        payload: { foo: "bar" },
+        approvers: ["alice"],
+      };
+
+      const request = await manager.createApproval(
+        await backend.getRun(runId) as WorkflowRun,
+        "node-x",
+        waitConfig,
+        createContext(runId),
+      );
+
+      assertEquals(request.expiresAt, undefined);
+
+      const persisted = await backend.getPendingApproval(runId, request.approvalId);
+      assertExists(persisted);
+      assertEquals(persisted.expiresAt, undefined);
+      assertEquals(persisted.payload, { foo: "bar" });
+    });
+  });
+
+  describe("processDecision", () => {
+    it("updates approval and run state without an executor", async () => {
+      manager = new ApprovalManager({ backend, expirationCheckInterval: 0 });
+
+      const runId = "run-decide";
+      await backend.createRun(createTestRun(runId));
+
+      const waitConfig: WaitNodeConfig = {
+        type: "wait",
+        waitType: "approval",
+        message: "Approve please",
+        payload: { ticket: 1 },
+        approvers: ["alice"],
+      };
+
+      const request = await manager.createApproval(
+        await backend.getRun(runId) as WorkflowRun,
+        "decision-node",
+        waitConfig,
+        createContext(runId),
+      );
+
+      await manager.processDecision(runId, request.approvalId, {
+        approved: true,
+        approver: "alice",
+        comment: "looks good",
+      });
+
+      const updated = await backend.getPendingApproval(runId, request.approvalId);
+      assertExists(updated);
+      assertEquals(updated.status, "approved");
+      assertEquals(updated.decidedBy, "alice");
+      assertEquals(updated.comment, "looks good");
+
+      const run = await backend.getRun(runId);
+      assertExists(run);
+      // No executor was provided, so the run stays in "running" (resume short-circuited).
+      assertEquals(run.status, "running");
+      // The decision node state is recorded as completed.
+      const nodeState = run.nodeStates["decision-node"];
+      assertExists(nodeState);
+      assertEquals(nodeState.status, "completed");
+      const output = nodeState.output as { approved: boolean; approver: string; comment: string };
+      assertEquals(output.approved, true);
+      assertEquals(output.approver, "alice");
+      assertEquals(output.comment, "looks good");
+      // Decision context recorded on the run context.
+      const decisionContext = run.context["decision-node"] as { approved: boolean };
+      assertEquals(decisionContext.approved, true);
+    });
+  });
+});

--- a/src/workflow/runtime/approval-manager.ts
+++ b/src/workflow/runtime/approval-manager.ts
@@ -254,7 +254,9 @@ export class ApprovalManager {
     workflowId?: string;
     approver?: string;
   }): Promise<Array<{ runId: string; approval: PendingApproval }>> {
-    const list = this.config.backend.listPendingApprovals;
+    const list = this.config.backend.listPendingApprovals?.bind(
+      this.config.backend,
+    );
     if (!list) {
       logger.warn(
         "[ApprovalManager] listPendingApprovals not supported by backend",
@@ -271,7 +273,9 @@ export class ApprovalManager {
       return;
     }
 
-    const list = this.config.backend.listPendingApprovals;
+    const list = this.config.backend.listPendingApprovals?.bind(
+      this.config.backend,
+    );
     if (!list) {
       return;
     }


### PR DESCRIPTION
## Summary

Small, focused improvements to `src/workflow/` surfaced by a code-level audit and a new test suite for `ApprovalManager`. All changes are additive or local; no public-API breaks.

- **`isBlobRef` type guard** (`src/workflow/blob/guards.ts`): replaces the duck-typed `__kind === "blob"` check in the workflow executor's blob resolver. The guard verifies the full `BlobRef` shape (`__kind`, `id`, `size`, `mimeType`, `createdAt`) so user payloads that happen to contain a `__kind: "blob"` field are no longer routed through the blob resolver.
- **Validate retry config before executing steps** (`src/workflow/executor/step-executor.ts`): `validateRetryConfig` already existed in `src/workflow/types.ts` but was never called from the step executor, so invalid configs (e.g. `maxAttempts: -1`) were silently merged with defaults. Now validated before the merge so errors surface with the offending field name.
- **Bind backend method in ApprovalManager to preserve `this`** (`src/workflow/runtime/approval-manager.ts`): `checkExpiredApprovals` and `listAllPending` extracted `backend.listPendingApprovals` into a local variable, detaching it from its instance. Both paths crashed when the backend implementation referenced `this` (e.g. `MemoryBackend` reading `this.approvals`). The bug was surfaced by the new test suite.
- **New `ApprovalManager` test suite** (`src/workflow/runtime/approval-manager.test.ts`): 5 cases covering timer-disabled mode, `checkExpiredApprovals` selectivity, `createApproval` persistence (with and without timeout), and `processDecision` without an executor.

## Test plan

- [x] `deno task test --filter="workflow/blob/guards"` — green
- [x] `deno task test --filter="step-executor"` — green
- [x] `deno task test --filter="ApprovalManager"` — 5/5 green
- [x] `deno task test --filter="workflow"` — 14 tests / 60 steps, no regressions
- [x] `deno task lint` — clean
- [x] `deno task fmt:check` — clean
- [x] Full pre-push suite — 1912 passed, 0 failed