### PR TITLE
docs: enforce public docs quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ brew install veryfront/tap/veryfront
 
 </details>
 
-Follow the [Quickstart guide](https://veryfront.com/docs/code/guides/quickstart) for step-by-step setup, or use [Create a project](https://veryfront.com/docs/code/guides/create-a-project) to compare templates before you scaffold. For the full documentation, visit [veryfront.com/docs/code](https://veryfront.com/docs/code).
+Follow the [Quickstart guide](https://veryfront.com/docs/code/getting-started/quickstart) for step-by-step setup, or use [Create a project](https://veryfront.com/docs/code/getting-started/create-a-project) to compare templates before you scaffold. For the full documentation, visit [veryfront.com/docs/code](https://veryfront.com/docs/code).
 
 ## Project Structure
 

--- a/deno.json
+++ b/deno.json
@@ -338,7 +338,7 @@
     "docs": "deno run --allow-read --allow-write --allow-run --allow-env scripts/docs/generate-api-reference.ts",
     "docs:coverage": "deno run --allow-read scripts/docs/docs-coverage.ts",
     "docs:copy": "rm -rf ../../docs/docs/code/api-reference && cp -r docs/api-reference/ ../../docs/docs/code/api-reference/",
-    "docs:validate": "deno run --allow-read scripts/docs/validate-api-reference.ts && deno run --allow-read scripts/docs/validate-guides.ts && deno test --config=scripts/test.deno.json --no-check --allow-read scripts/docs/docs-coverage.test.ts && deno test --no-check --allow-read tests/docs/guide-contracts.test.ts tests/docs/guide-content.test.ts && deno test --no-check --allow-all tests/docs/guide-examples.test.ts tests/docs/guide-code-examples.test.ts && deno run -A scripts/lint/check-doc-links.ts",
+    "docs:validate": "deno run --allow-read scripts/docs/validate-api-reference.ts && deno run --allow-read scripts/docs/validate-guides.ts && deno run --allow-read scripts/docs/validate-public-docs.ts && deno test --config=scripts/test.deno.json --no-check --allow-read scripts/docs/docs-coverage.test.ts && deno test --no-check --allow-read tests/docs/guide-contracts.test.ts tests/docs/guide-content.test.ts && deno test --no-check --allow-all tests/docs/guide-examples.test.ts tests/docs/guide-code-examples.test.ts && deno run -A scripts/lint/check-doc-links.ts",
     "docs:verify-npm": "node scripts/docs/verify-npm-exports.mjs && node scripts/docs/verify-npm-node.mjs",
     "docs:check-links": "deno run -A scripts/lint/check-doc-links.ts",
     "lint:ban-zod": "deno run --allow-read scripts/lint/ban-zod-imports.ts",

--- a/docs/api-reference/README.md
+++ b/docs/api-reference/README.md
@@ -1,53 +1,18 @@
+---
+title: "API reference"
+description: "Exact imports, exported names, types, and module-level examples for Veryfront Code."
+order: 1
+---
+
 # Framework API reference
 
-These pages document every public import surface published by `veryfront`. They are the source for the public reference site.
+Use this reference when you need exact imports, exported names, types, and module-level examples for `veryfront`.
 
-## Source of truth
+## How to use this reference
 
-Reference pages are generated from the `exports` map in `deno.json`. Every top-level export becomes one page under `veryfront/`, and deep exports (e.g. `veryfront/agent/testing`) are documented as `Deep imports` sections on their parent page.
+Start with the module you import from. Each module page shows the recommended import form, examples, exported symbols, and related guides.
 
-```bash
-deno task docs           # regenerate this directory
-deno task docs:validate  # check structure and links
-```
-
-## Layout
-
-```text
-docs/api-reference/
-  README.md          # this file
-  veryfront/
-    index.md         # the root `veryfront` import
-    head.md
-    router.md
-    context.md
-    fonts.md
-    chat.md
-    markdown.md
-    mdx.md
-    agent.md
-    tool.md
-    workflow.md
-    schemas.md
-    prompt.md
-    resource.md
-    jobs.md
-    mcp.md
-    middleware.md
-    observability.md
-    utils.md
-    oauth.md
-    provider.md
-    fs.md
-    integrations.md
-    sandbox.md
-    embedding.md
-    extensions.md
-    testing.md
-    cli.md
-    server.md
-    channels.md
-```
+For task-based help, use the Getting Started and Guides sections first. Use API Reference when you already know which module or symbol you need.
 
 ## Module index
 
@@ -64,22 +29,22 @@ docs/api-reference/
 | [`veryfront/agent`](./veryfront/agent.md) | AI agents with memory, tools, and multi-agent composition. |
 | [`veryfront/tool`](./veryfront/tool.md) | Define tools with schema-backed inputs for agents and MCP. |
 | [`veryfront/workflow`](./veryfront/workflow.md) | DAG-based agentic workflows with human-in-the-loop support. |
-| [`veryfront/schemas`](./veryfront/schemas.md) | Reusable validation schemas — common types (email, slug, URL, UUID, pagination) and primitives (file paths, hex colors, semver, timestamps), plus the `defineSchema` lazy-factory helper. `defineSchema` resolves the `SchemaValidator` contract on first use. The default zod-backed implementation lives in `@veryfront/ext-schema-zod` and is registered at app bootstrap by `createBuiltinExtensions()`. Tests that exercise schemas without going through full bootstrap import `./_test-setup.ts` to register the adapter directly. |
+| [`veryfront/schemas`](./veryfront/schemas.md) | Reusable validation schemas: common types (email, slug, URL, UUID, pagination) and primitives (file paths, hex colors, semver, timestamps), plus the `defineSchema` lazy-factory helper. `defineSchema` resolves the `SchemaValidator` contract on first use. The default zod-backed implementation lives in `@veryfront/ext-schema-zod` and is registered at app bootstrap by `createBuiltinExtensions()`. |
 | [`veryfront/prompt`](./veryfront/prompt.md) | Declare and register prompts exposable over MCP. |
 | [`veryfront/resource`](./veryfront/resource.md) | Declare and register resources exposable over MCP. |
 | [`veryfront/jobs`](./veryfront/jobs.md) | Jobs module for durable project-scoped background execution. Provides a public SDK surface for one-off jobs, cron jobs, batch summaries, job target discovery, and the canonical split between user-visible `events` and raw debugging `logs`. Task definitions run as job runs with `task:<task-id>` targets. Workflow definitions run as workflow runs with `workflow:<workflow-id>` targets and are backed by jobs for queueing and dispatch. |
 | [`veryfront/mcp`](./veryfront/mcp.md) | MCP server exposing tools, prompts, and resources. |
 | [`veryfront/middleware`](./veryfront/middleware.md) | CORS, rate limiting, logging, and timeout middleware. |
 | [`veryfront/observability`](./veryfront/observability.md) | OpenTelemetry tracing, metrics collection, auto-instrumentation for fetch/HTTP/React, OTLP export, and structured error and log buffering. |
-| [`veryfront/utils`](./veryfront/utils.md) | Internal utilities — runtime detection, structured logging, constants (breakpoints, timeouts, HTTP codes), hashing, memoization, and feature flags. |
+| [`veryfront/utils`](./veryfront/utils.md) | Runtime utilities: runtime detection, structured logging, constants (breakpoints, timeouts, HTTP codes), hashing, memoization, and feature flags. |
 | [`veryfront/oauth`](./veryfront/oauth.md) | OAuth 2.0 with 37 pre-configured providers. |
 | [`veryfront/provider`](./veryfront/provider.md) | Provider registry. Maps "provider/model" strings to framework-compatible model runtimes. Auto-initializes built-in providers from environment variables on first use. |
 | [`veryfront/fs`](./veryfront/fs.md) | Public filesystem, path, and cwd utilities. |
 | [`veryfront/integrations`](./veryfront/integrations.md) | Integration metadata and SVG icons for all connectors. |
 | [`veryfront/sandbox`](./veryfront/sandbox.md) | Sandbox module for ephemeral compute environments. Provides the `Sandbox` class for creating and interacting with isolated execution environments. |
-| [`veryfront/embedding`](./veryfront/embedding.md) | Embedding — RAG primitives for chunking, embedding, and similarity search. Provides a facade over the framework's current embedding runtime and LangChain text splitting behind veryfront's own API. |
+| [`veryfront/embedding`](./veryfront/embedding.md) | Embedding - RAG primitives for chunking, embedding, and similarity search. Provides a facade over the framework's current embedding runtime and LangChain text splitting behind veryfront's own API. |
 | [`veryfront/extensions`](./veryfront/extensions.md) | Public extension API surface. Types used when authoring extensions (the scaffold template generated by `veryfront extension init` imports from this module), plus the runtime helpers consumers need to load, validate, and orchestrate extensions. |
-| [`veryfront/testing`](./veryfront/testing.md) | Cross-runtime test utilities — BDD framework (describe/it), assertions, test isolation, filesystem/env helpers, and timing utilities for Deno, Node, and Bun. |
+| [`veryfront/testing`](./veryfront/testing.md) | Cross-runtime test utilities - BDD framework (describe/it), assertions, test isolation, filesystem/env helpers, and timing utilities for Deno, Node, and Bun. |
 | [`veryfront/cli`](./veryfront/cli.md) | Veryfront CLI entry point. |
-| [`veryfront/server`](./veryfront/server.md) | Server Module Public API This module exports the public interface for the Veryfront server. For routing utilities, import from "#veryfront/routing" directly. For observability utilities, import from "#veryfront/observability" directly. |
-| [`veryfront/channels`](./veryfront/channels.md) | Channel transports for the Veryfront control plane and AG-UI invoke route. These are deep-import-only modules. |
+| [`veryfront/server`](./veryfront/server.md) | Server runtime APIs. Use this module to create and run a Veryfront server in tests, custom runtimes, and production adapters. |
+| [`veryfront/channels`](./veryfront/channels.md) | Channel transports for the Veryfront control plane and AG-UI invoke route. |

--- a/docs/api-reference/veryfront/channels.md
+++ b/docs/api-reference/veryfront/channels.md
@@ -1,10 +1,10 @@
 ---
 title: "veryfront/channels"
-description: "Channel transports for the Veryfront control plane and AG-UI invoke route. These are deep-import-only modules."
+description: "Channel transports for the Veryfront control plane and AG-UI invoke route."
 order: 30
 ---
 
-Channel transports for the Veryfront control plane and AG-UI invoke route. These are deep-import-only modules.
+Channel transports for the Veryfront control plane and AG-UI invoke route.
 
 `veryfront/channels` has no direct exports. Use the deep imports below.
 

--- a/docs/api-reference/veryfront/embedding.md
+++ b/docs/api-reference/veryfront/embedding.md
@@ -1,10 +1,10 @@
 ---
 title: "veryfront/embedding"
-description: "Embedding — RAG primitives for chunking, embedding, and similarity search. Provides a facade over the framework's current embedding runtime and LangChain text splitting behind veryfront's own API."
+description: "Embedding - RAG primitives for chunking, embedding, and similarity search. Provides a facade over the framework's current embedding runtime and LangChain text splitting behind veryfront's own API."
 order: 25
 ---
 
-Embedding — RAG primitives for chunking, embedding, and similarity search. Provides a facade over the framework's current embedding runtime and LangChain text splitting behind veryfront's own API.
+Embedding - RAG primitives for chunking, embedding, and similarity search. Provides a facade over the framework's current embedding runtime and LangChain text splitting behind veryfront's own API.
 
 ## Import
 

--- a/docs/api-reference/veryfront/extensions.md
+++ b/docs/api-reference/veryfront/extensions.md
@@ -101,7 +101,7 @@ These import paths group focused functionality under this module. Each is a sepa
 
 ### `veryfront/extensions/auth`
 
-Auth category barrel — AuthProvider contract and token shapes.
+Auth category barrel - AuthProvider contract and token shapes.
 
 ```ts
 import "veryfront/extensions/auth";
@@ -119,7 +119,7 @@ import "veryfront/extensions/auth";
 
 ### `veryfront/extensions/bundler`
 
-Bundler category barrel — Bundler contract, module lexer, and resolver helper.
+Bundler category barrel - Bundler contract, module lexer, and resolver helper.
 
 ```ts
 import { build, context, getBundler } from "veryfront/extensions/bundler";
@@ -171,7 +171,7 @@ import { build, context, getBundler } from "veryfront/extensions/bundler";
 
 ### `veryfront/extensions/cache`
 
-Cache category barrel — generic cache and proxy-grade token cache.
+Cache category barrel - generic cache and proxy-grade token cache.
 
 ```ts
 import "veryfront/extensions/cache";
@@ -188,7 +188,7 @@ import "veryfront/extensions/cache";
 
 ### `veryfront/extensions/compat`
 
-Compat category barrel — optional native runtime services.
+Compat category barrel - optional native runtime services.
 
 ```ts
 import "veryfront/extensions/compat";
@@ -225,7 +225,7 @@ import "veryfront/extensions/content";
 
 ### `veryfront/extensions/contracts`
 
-Contract registry — runtime resolution of extension-provided implementations.
+Contract registry - runtime resolution of extension-provided implementations.
 
 ```ts
 import { register, reset, resolve } from "veryfront/extensions/contracts";
@@ -243,7 +243,7 @@ import { register, reset, resolve } from "veryfront/extensions/contracts";
 
 ### `veryfront/extensions/css`
 
-CSS category barrel — CSS processor and compiler contracts.
+CSS category barrel - CSS processor and compiler contracts.
 
 ```ts
 import "veryfront/extensions/css";
@@ -261,7 +261,7 @@ import "veryfront/extensions/css";
 
 ### `veryfront/extensions/database`
 
-Database category barrel — DatabaseClient contract.
+Database category barrel - DatabaseClient contract.
 
 ```ts
 import "veryfront/extensions/database";
@@ -276,7 +276,7 @@ import "veryfront/extensions/database";
 
 ### `veryfront/extensions/llm`
 
-LLM category barrel — provider, embedding, and registry contracts. Interfaces re-exported with `export type { ... }` because Deno `--no-check` transpiles each file in isolation and would otherwise emit a runtime value re-export that fails ESM resolution. Reserve plain `export { ... }` for runtime values.
+LLM category barrel - provider, embedding, and registry contracts. Interfaces re-exported with `export type { ... }` because Deno `--no-check` transpiles each file in isolation and would otherwise emit a runtime value re-export that fails ESM resolution. Reserve plain `export { ... }` for runtime values.
 
 ```ts
 import { createLLMProviderRegistry, LLMProviderRegistryName } from "veryfront/extensions/llm";
@@ -334,7 +334,7 @@ import { NodeTelemetryProviderName } from "veryfront/extensions/observability";
 
 ### `veryfront/extensions/parser`
 
-Parser category barrel — CodeParser (AST traversal) contract.
+Parser category barrel - CodeParser (AST traversal) contract.
 
 ```ts
 import "veryfront/extensions/parser";
@@ -380,7 +380,7 @@ import { SandboxShellToolsProviderName } from "veryfront/extensions/sandbox";
 
 ### `veryfront/extensions/schema`
 
-Schema category barrel — SchemaValidator contract and inference helpers.
+Schema category barrel - SchemaValidator contract and inference helpers.
 
 ```ts
 import "veryfront/extensions/schema";

--- a/docs/api-reference/veryfront/index.md
+++ b/docs/api-reference/veryfront/index.md
@@ -70,7 +70,7 @@ export function getServerData(ctx: DataContext) {
 | `apiNotFound` | Create a 404 Not Found response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/platform/compat/http/responses.ts#L113) |
 | `apiRedirect` | Create an HTTP redirect response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/platform/compat/http/responses.ts#L91) |
 | `badRequest` | Create a 400 Bad Request response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/platform/compat/http/responses.ts#L118) |
-| `createHandler` | Create a Veryfront request handler for development or production. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L195) |
+| `createHandler` | Create a Veryfront request handler for development or production. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L194) |
 | `createValidatedHandler` | Create a validated API handler wrapper that auto-validates body/query with Zod schemas | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/input-validation/handler.ts#L20) |
 | `createValidationError` | Create an input validation error. Convenience wrapper around INPUT_VALIDATION_FAILED.create(). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/input-validation/errors.ts#L12) |
 | `defineConfig` | Define a Veryfront project configuration object. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/config/define-config.ts#L6) |
@@ -84,7 +84,7 @@ export function getServerData(ctx: DataContext) {
 | `redirect` | Return a redirect result from a data loader. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/data/helpers.ts#L4) |
 | `sanitizeData` | Sanitize data to prevent XSS and prototype pollution attacks. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/input-validation/sanitizers.ts#L2) |
 | `serverError` | Create a 500 Internal Server Error response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/platform/compat/http/responses.ts#L133) |
-| `startServer` | Start a Veryfront server in development or production mode. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L329) |
+| `startServer` | Start a Veryfront server in development or production mode. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L328) |
 | `toNodeHandler` | Convert a Web API request handler into a Node.js HTTP listener. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/node-handler.ts#L4) |
 | `unauthorized` | Create a 401 Unauthorized response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/platform/compat/http/responses.ts#L123) |
 
@@ -101,13 +101,13 @@ export function getServerData(ctx: DataContext) {
 | `MDXFrontmatter` | Parsed frontmatter values from an MDX page. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/types/index.ts#L88) |
 | `PageContext` | Runtime page context passed to page components. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/types/index.ts#L105) |
 | `PageWithData` | Page with data fetching capabilities | [source](https://github.com/veryfront/veryfront-code/blob/main/src/data/types.ts#L16) |
-| `StartServerOptions` | Server options. Defaults to development mode with HMR. Set `mode: "production"` for a production server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L127) |
+| `StartServerOptions` | Server options. Defaults to development mode with HMR. Set `mode: "production"` for a production server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L126) |
 | `StaticPathsResult` | Return type for `getStaticPaths()`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/data/schemas/data.schema.ts#L61) |
 | `ValidatedHandlerConfig` | Configuration for `createValidatedHandler()`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/input-validation/handler.ts#L7) |
 | `ValidatedHandlerFunction` | Handler signature that receives validated request data. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/security/input-validation/handler.ts#L14) |
 | `VeryfrontConfig` | Project configuration. The underlying zod schema stores `extensions` as `unknown[]`; this tightened alias surfaces the expected `ExtensionConfigEntry[]` shape to TypeScript consumers. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/config/schemas/index.ts#L25) |
-| `VeryfrontHandler` | Web API request handler with WebSocket upgrade and HMR helpers. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L142) |
-| `VeryfrontServer` | Running server instance with lifecycle controls. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L130) |
+| `VeryfrontHandler` | Web API request handler with WebSocket upgrade and HMR helpers. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L141) |
+| `VeryfrontServer` | Running server instance with lifecycle controls. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L129) |
 
 ## Related
 

--- a/docs/api-reference/veryfront/mcp.md
+++ b/docs/api-reference/veryfront/mcp.md
@@ -34,7 +34,7 @@ tool({
   execute: async ({ query }) => ({ results: [] }),
 });
 
-// Start MCP server — registered tools are exposed automatically.
+// Start MCP server - registered tools are exposed automatically.
 // `auth` is required: use bearer for production, or the explicit
 // `{ type: "none", allowUnauthenticated: true }` opt-in for local dev only.
 const server = createMCPServer({

--- a/docs/api-reference/veryfront/schemas.md
+++ b/docs/api-reference/veryfront/schemas.md
@@ -1,10 +1,10 @@
 ---
 title: "veryfront/schemas"
-description: "Reusable validation schemas — common types (email, slug, URL, UUID, pagination) and primitives (file paths, hex colors, semver, timestamps), plus the `defineSchema` lazy-factory helper. `defineSchema` resolves the `SchemaValidator` contract on first use. The default zod-backed implementation lives in `@veryfront/ext-schema-zod` and is registered at app bootstrap by `createBuiltinExtensions()`. Tests that exercise schemas without going through full bootstrap import `./_test-setup.ts` to register the adapter directly."
+description: "Reusable validation schemas: common types (email, slug, URL, UUID, pagination) and primitives (file paths, hex colors, semver, timestamps), plus the `defineSchema` lazy-factory helper. `defineSchema` resolves the `SchemaValidator` contract on first use. The default zod-backed implementation lives in `@veryfront/ext-schema-zod` and is registered at app bootstrap by `createBuiltinExtensions()`."
 order: 12
 ---
 
-Reusable validation schemas — common types (email, slug, URL, UUID, pagination) and primitives (file paths, hex colors, semver, timestamps), plus the `defineSchema` lazy-factory helper. `defineSchema` resolves the `SchemaValidator` contract on first use. The default zod-backed implementation lives in `@veryfront/ext-schema-zod` and is registered at app bootstrap by `createBuiltinExtensions()`. Tests that exercise schemas without going through full bootstrap import `./_test-setup.ts` to register the adapter directly.
+Reusable validation schemas: common types (email, slug, URL, UUID, pagination) and primitives (file paths, hex colors, semver, timestamps), plus the `defineSchema` lazy-factory helper. `defineSchema` resolves the `SchemaValidator` contract on first use. The default zod-backed implementation lives in `@veryfront/ext-schema-zod` and is registered at app bootstrap by `createBuiltinExtensions()`.
 
 ## Import
 

--- a/docs/api-reference/veryfront/server.md
+++ b/docs/api-reference/veryfront/server.md
@@ -1,10 +1,10 @@
 ---
 title: "veryfront/server"
-description: "Server Module Public API This module exports the public interface for the Veryfront server. For routing utilities, import from \"#veryfront/routing\" directly. For observability utilities, import from \"#veryfront/observability\" directly."
+description: "Server runtime APIs. Use this module to create and run a Veryfront server in tests, custom runtimes, and production adapters."
 order: 29
 ---
 
-Server Module Public API This module exports the public interface for the Veryfront server. For routing utilities, import from "#veryfront/routing" directly. For observability utilities, import from "#veryfront/observability" directly.
+Server runtime APIs. Use this module to create and run a Veryfront server in tests, custom runtimes, and production adapters.
 
 ## Import
 
@@ -48,12 +48,12 @@ await server.fetch(new Request("https://example.com/health"));
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `createHandler` | Create a Veryfront request handler for development or production. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L195) |
+| `createHandler` | Create a Veryfront request handler for development or production. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L194) |
 | `createVeryfrontServer` | Create veryfront server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/service-server.ts#L149) |
 | `startDevServer` | Starts dev server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/dev-server/index.ts#L15) |
 | `startNodeVeryfrontServer` | Starts node veryfront server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/service-server.ts#L559) |
 | `startProductionServer` | Starts production server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/production-server.ts#L167) |
-| `startServer` | Start a Veryfront server in development or production mode. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L329) |
+| `startServer` | Start a Veryfront server in development or production mode. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L328) |
 | `startVeryfrontServer` | Starts veryfront server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/service-server.ts#L539) |
 | `toNodeHandler` | Convert a Web API request handler into a Node.js HTTP listener. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/node-handler.ts#L4) |
 
@@ -76,14 +76,14 @@ await server.fetch(new Request("https://example.com/health"));
 | `NodeVeryfrontServiceServer` | Public API contract for node veryfront service server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/service-server.ts#L75) |
 | `RouteDirectory` | Public API contract for route directory. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/dev-server/types.ts#L27) |
 | `ServerHandle` | Public API contract for server handle. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/production-server.ts#L153) |
-| `StartDevModeOptions` | Options accepted by start dev mode. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L102) |
+| `StartDevModeOptions` | Options accepted by start dev mode. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L101) |
 | `StartNodeVeryfrontServerOptions` | Options accepted by start node veryfront server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/service-server.ts#L43) |
-| `StartProductionModeOptions` | Options accepted by start production mode. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L111) |
+| `StartProductionModeOptions` | Options accepted by start production mode. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L110) |
 | `StartProductionServerOptions` | Options accepted by start production server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/production-server.ts#L159) |
-| `StartServerOptions` | Server options. Defaults to development mode with HMR. Set `mode: "production"` for a production server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L127) |
+| `StartServerOptions` | Server options. Defaults to development mode with HMR. Set `mode: "production"` for a production server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L126) |
 | `StartVeryfrontServerOptions` | Options accepted by start veryfront server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/service-server.ts#L53) |
-| `VeryfrontHandler` | Web API request handler with WebSocket upgrade and HMR helpers. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L142) |
-| `VeryfrontServer` | Running server instance with lifecycle controls. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L130) |
+| `VeryfrontHandler` | Web API request handler with WebSocket upgrade and HMR helpers. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L141) |
+| `VeryfrontServer` | Running server instance with lifecycle controls. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/index.ts#L129) |
 | `VeryfrontServiceServer` | Public API contract for veryfront service server. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/service-server.ts#L66) |
 | `VeryfrontServiceServerFetch` | Public API contract for veryfront service server fetch. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/service-server.ts#L5) |
 | `VeryfrontServiceServerLogger` | Public API contract for veryfront service server logger. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/server/service-server.ts#L20) |

--- a/docs/api-reference/veryfront/testing.md
+++ b/docs/api-reference/veryfront/testing.md
@@ -1,10 +1,10 @@
 ---
 title: "veryfront/testing"
-description: "Cross-runtime test utilities — BDD framework (describe/it), assertions, test isolation, filesystem/env helpers, and timing utilities for Deno, Node, and Bun."
+description: "Cross-runtime test utilities - BDD framework (describe/it), assertions, test isolation, filesystem/env helpers, and timing utilities for Deno, Node, and Bun."
 order: 27
 ---
 
-Cross-runtime test utilities — BDD framework (describe/it), assertions, test isolation, filesystem/env helpers, and timing utilities for Deno, Node, and Bun.
+Cross-runtime test utilities - BDD framework (describe/it), assertions, test isolation, filesystem/env helpers, and timing utilities for Deno, Node, and Bun.
 
 ## Import
 

--- a/docs/api-reference/veryfront/utils.md
+++ b/docs/api-reference/veryfront/utils.md
@@ -1,10 +1,10 @@
 ---
 title: "veryfront/utils"
-description: "Internal utilities — runtime detection, structured logging, constants (breakpoints, timeouts, HTTP codes), hashing, memoization, and feature flags."
+description: "Runtime utilities: runtime detection, structured logging, constants (breakpoints, timeouts, HTTP codes), hashing, memoization, and feature flags."
 order: 19
 ---
 
-Internal utilities — runtime detection, structured logging, constants (breakpoints, timeouts, HTTP codes), hashing, memoization, and feature flags.
+Runtime utilities: runtime detection, structured logging, constants (breakpoints, timeouts, HTTP codes), hashing, memoization, and feature flags.
 
 ## Import
 

--- a/docs/api-reference/veryfront/workflow.md
+++ b/docs/api-reference/veryfront/workflow.md
@@ -214,7 +214,7 @@ These import paths group focused functionality under this module. Each is a sepa
 
 ### `veryfront/workflow/claude-code`
 
-Claude Agent SDK Integration Provides Claude Code agentic capabilities within Veryfront workflows. Uses your local Claude Code installation — no separate API key needed.
+Claude Agent SDK Integration Provides Claude Code agentic capabilities within Veryfront workflows. Uses your local Claude Code installation - no separate API key needed.
 
 ```ts
 import { createAgent, createClaudeCodeTool, createEventPublisher } from "veryfront/workflow/claude-code";

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -4,8 +4,8 @@ description: "Start here. A short tour of the Veryfront Code guides and what you
 order: 0
 ---
 
-Each guide is a focused, goal-oriented mini tutorial - pick the one
-that matches the outcome you want next.
+Each page is a guided, hands-on path. Pick the one that matches the
+outcome you want next.
 
 ## What is Veryfront Code
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -4,7 +4,7 @@ description: "Start here. A short tour of the Veryfront Code guides and what you
 order: 0
 ---
 
-Each guide is a focused, goal-oriented mini tutorial — pick the one
+Each guide is a focused, goal-oriented mini tutorial - pick the one
 that matches the outcome you want next.
 
 ## What is Veryfront Code
@@ -21,10 +21,10 @@ For the full feature tour and the catalog of every guide, see
 
 These guides assume you are comfortable with:
 
-- TypeScript — syntax and basic types.
-- React — components, props, and hooks.
-- A JavaScript runtime — Node.js, Deno, or Bun.
-- A terminal — running `npm`, `deno`, or shell commands.
+- TypeScript - syntax and basic types.
+- React - components, props, and hooks.
+- A JavaScript runtime - Node.js, Deno, or Bun.
+- A terminal - running `npm`, `deno`, or shell commands.
 
 You do not need prior experience with AI agents, model providers, or
 the Model Context Protocol. The guides introduce each concept where
@@ -38,11 +38,11 @@ section pointing to the natural follow-up.
 
 ## Start here
 
-- [**Quickstart**](./quickstart.md) — build an agent app end-to-end
+- [**Quickstart**](./quickstart.md) - build an agent app end-to-end
   in a single guide.
-- [**Veryfront Code**](./veryfront-code.md) — what the framework is,
+- [**Veryfront Code**](./veryfront-code.md) - what the framework is,
   why to use it, and a map of every guide.
-- [**Installation**](./installation.md) — install the CLI and set up
+- [**Installation**](./installation.md) - install the CLI and set up
   your first project.
 - Looking for a specific topic? See the
   [grouped guide catalog](./veryfront-code.md#guides) on the

--- a/docs/getting-started/veryfront-code.md
+++ b/docs/getting-started/veryfront-code.md
@@ -7,7 +7,7 @@ order: 1
 Veryfront Code is a Deno-first, full-stack framework for building
 AI-powered applications and agents in TypeScript and React. Agents,
 workflows, tools, pages, APIs, and rendering are all native primitives
-in one package — not glued together from separate libraries. Veryfront
+in one package - not glued together from separate libraries. Veryfront
 runs on Node.js, Deno, and Bun, and deploys anywhere or through
 Veryfront Cloud with built-in preview environments and production
 hosting.
@@ -18,59 +18,59 @@ Purpose-built for TypeScript and React, Veryfront Code gives you
 everything you need to build agentic full-stack applications
 out-of-the-box.
 
-- [**Agents**](../guides/agents.md) — Build autonomous agents with model
+- [**Agents**](../guides/agents.md) - Build autonomous agents with model
   routing, system prompts, hosted runs, and tool calling. Agents
   reason about goals and iterate until they reach a final answer.
   Supports AG-UI streaming, multi-agent composition, and hosted
   child-run orchestration.
 
-- [**Tools**](../guides/tools.md) — Define Zod-validated functions that
+- [**Tools**](../guides/tools.md) - Define Zod-validated functions that
   agents can call. Tools are auto-discovered from the file system
   with no registration needed.
 
-- [**Workflows**](../guides/workflows.md) — Orchestrate multi-step AI
+- [**Workflows**](../guides/workflows.md) - Orchestrate multi-step AI
   pipelines with branching, parallelism, human-in-the-loop approval
   gates, and durable crash recovery via Redis checkpoints.
 
-- [**Skills**](../guides/skills.md) — Project-level agent capabilities
+- [**Skills**](../guides/skills.md) - Project-level agent capabilities
   defined as `SKILL.md` files following the agentskills.io
   specification. Skills provide prompt augmentation, tool allowlists,
   and script invocation.
 
-- [**Jobs & Cron Jobs**](../guides/jobs.md) — Run durable project-scoped
+- [**Jobs & Cron Jobs**](../guides/jobs.md) - Run durable project-scoped
   background work now or on a schedule through the Veryfront
   platform.
 
-- [**Tasks**](../guides/tasks.md) — File-based background task definitions
+- [**Tasks**](../guides/tasks.md) - File-based background task definitions
   discovered automatically and runnable via the jobs system.
 
-- [**Multi-Agent**](../guides/multi-agent.md) — Compose agents that delegate
+- [**Multi-Agent**](../guides/multi-agent.md) - Compose agents that delegate
   to each other as tools for complex, coordinated tasks. AG-UI
   control-plane for hosted agent orchestration.
 
-- [**Memory & Streaming**](../guides/memory-and-streaming.md) — Give agents
+- [**Memory & Streaming**](../guides/memory-and-streaming.md) - Give agents
   conversation history and streaming responses. Built-in chat UI
   components for React with AG-UI protocol support.
 
-- [**MCP Server**](../guides/mcp-server.md) — Expose tools, prompts, and
+- [**MCP Server**](../guides/mcp-server.md) - Expose tools, prompts, and
   resources via the Model Context Protocol. Includes SSE transport,
   session management, and elicitation support.
 
-- [**Sandbox**](../guides/sandbox.md) — Ephemeral compute environments for
+- [**Sandbox**](../guides/sandbox.md) - Ephemeral compute environments for
   isolated code runs with shell tools and agent service
   integration.
 
-- [**Integrations**](../guides/integrations.md) — Pre-built connectors with
+- [**Integrations**](../guides/integrations.md) - Pre-built connectors with
   OAuth flows, remote tools, and metadata for third-party services.
 
-- [**Pages & Routing**](../guides/pages-and-routing.md) — File-based routing
+- [**Pages & Routing**](../guides/pages-and-routing.md) - File-based routing
   with React Server Components, layouts, and server-side rendering.
 
-- [**Data Fetching & API Routes**](../guides/data-fetching.md) — Server-side
+- [**Data Fetching & API Routes**](../guides/data-fetching.md) - Server-side
   data loading, API route handlers, and [middleware](../guides/middleware.md)
   with built-in [OAuth](../guides/oauth.md) support.
 
-- [**Extensions**](../guides/extensions.md) — Contract-based plugin system
+- [**Extensions**](../guides/extensions.md) - Contract-based plugin system
   with 12 first-party packages for LLM providers, bundling, CSS,
   tracing, caching, and more.
 

--- a/docs/getting-started/veryfront-code.md
+++ b/docs/getting-started/veryfront-code.md
@@ -76,8 +76,8 @@ out-of-the-box.
 
 ## Guides
 
-Topic-grouped catalog of every guide. Each guide is a mini tutorial
-for one concrete piece of the framework.
+Topic-grouped catalog of every guide. Each guide is a task-oriented
+walkthrough or decision guide for one concrete piece of the framework.
 
 ### Getting Started
 

--- a/scripts/docs/generate-api-reference.ts
+++ b/scripts/docs/generate-api-reference.ts
@@ -915,7 +915,7 @@ const DESCRIPTIONS: Record<string, Record<string, string>> = {
 const SYNTHETIC_PARENTS: Record<string, { description: string }> = {
   channels: {
     description:
-      "Channel transports for the Veryfront control plane and AG-UI invoke route. These are deep-import-only modules.",
+      "Channel transports for the Veryfront control plane and AG-UI invoke route.",
   },
 };
 
@@ -1069,8 +1069,15 @@ function parseBarrelJSDoc(content: string): BarrelJSDoc {
 
   finishExample();
 
-  const description = descLines.join(" ").replace(/\s+/g, " ").trim();
+  const description = normalizePublicDocText(descLines.join(" ").replace(/\s+/g, " ").trim());
   return { description, moduleName, examples };
+}
+
+function normalizePublicDocText(text: string): string {
+  return text
+    .replace(/[\u2013\u2014]/g, "-")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function finalizeExample(
@@ -2501,7 +2508,7 @@ function generateMD(
     }
   }
 
-  // CLI command catalog (only for veryfront/cli — generated from cli/help/command-definitions.ts)
+  // CLI command catalog (only for veryfront/cli - generated from cli/help/command-definitions.ts)
   if (entry.importPath === "veryfront/cli") {
     lines.push(...generateCLICommandCatalog());
   }
@@ -2655,35 +2662,25 @@ function generateReadmeMD(
 ): string {
   const lines: string[] = [];
 
+  lines.push("---");
+  lines.push('title: "API reference"');
+  lines.push('description: "Exact imports, exported names, types, and module-level examples for Veryfront Code."');
+  lines.push("order: 1");
+  lines.push("---");
+  lines.push("");
   lines.push("# Framework API reference");
   lines.push("");
   lines.push(
-    "These pages document every public import surface published by `veryfront`. They are the source for the public reference site.",
+    "Use this reference when you need exact imports, exported names, types, and module-level examples for `veryfront`.",
   );
   lines.push("");
-  lines.push("## Source of truth");
+  lines.push("## How to use this reference");
   lines.push("");
   lines.push(
-    "Reference pages are generated from the `exports` map in `deno.json`. Every top-level export becomes one page under `veryfront/`, and deep exports (e.g. `veryfront/agent/testing`) are documented as `Deep imports` sections on their parent page.",
+    "Start with the module you import from. Each module page shows the recommended import form, examples, exported symbols, and related guides.",
   );
   lines.push("");
-  lines.push("```bash");
-  lines.push("deno task docs           # regenerate this directory");
-  lines.push("deno task docs:validate  # check structure and links");
-  lines.push("```");
-  lines.push("");
-  lines.push("## Layout");
-  lines.push("");
-  lines.push("```text");
-  lines.push("docs/api-reference/");
-  lines.push("  README.md          # this file");
-  lines.push("  veryfront/");
-  lines.push("    index.md         # the root `veryfront` import");
-  for (const { entry } of entries) {
-    if (entry.slug === "index") continue;
-    lines.push(`    ${entry.slug}.md`);
-  }
-  lines.push("```");
+  lines.push("For task-based help, use the Getting Started and Guides sections first. Use API Reference when you already know which module or symbol you need.");
   lines.push("");
   lines.push("## Module index");
   lines.push("");
@@ -2693,7 +2690,7 @@ function generateReadmeMD(
     const desc = entry.isSynthetic
       ? (entry.syntheticDescription ?? "")
       : (jsdoc.description || "");
-    lines.push(`| [\`${entry.importPath}\`](./veryfront/${entry.slug}.md) | ${desc} |`);
+    lines.push(`| [\`${entry.importPath}\`](./veryfront/${entry.slug}.md) | ${normalizePublicDocText(desc)} |`);
   }
   lines.push("");
   return lines.join("\n");
@@ -2797,14 +2794,14 @@ async function main() {
     }
 
     const order = idx + 1;
-    const md = generateMD(entry, jsdoc, exports, nodes, order, deepRenders);
+    const md = normalizeGeneratedMarkdown(generateMD(entry, jsdoc, exports, nodes, order, deepRenders));
     const outPath = `${VERYFRONT_DIR}/${entry.slug}.md`;
     await Deno.writeTextFile(outPath, md);
     console.log(`  Wrote ${outPath}`);
   }
 
   // Write the structure README at the docs/api-reference root.
-  const readmeMD = generateReadmeMD(indexData);
+  const readmeMD = normalizeGeneratedMarkdown(generateReadmeMD(indexData));
   const readmePath = `${OUTPUT_DIR}/README.md`;
   await Deno.writeTextFile(readmePath, readmeMD);
   console.log(`\nWrote ${readmePath}`);
@@ -2815,3 +2812,7 @@ async function main() {
 }
 
 main();
+
+function normalizeGeneratedMarkdown(markdown: string): string {
+  return markdown.replace(/[\u2013\u2014]/g, "-");
+}

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -1,0 +1,143 @@
+#!/usr/bin/env -S deno run --allow-read
+/**
+ * Public docs quality validator.
+ *
+ * Checks published docs and the public README for style and boundary issues
+ * that are easy to regress during generation or sync.
+ */
+
+const ROOT = Deno.cwd();
+
+interface PublicDocIssue {
+  path: string;
+  line: number;
+  message: string;
+  text: string;
+}
+
+interface Rule {
+  pattern: RegExp;
+  message: string;
+}
+
+const PUBLIC_DOC_ROOTS = [
+  "README.md",
+  "docs/getting-started",
+  "docs/guides",
+  "docs/api-reference",
+];
+
+const MOVED_GETTING_STARTED_PAGES = [
+  "quickstart",
+  "installation",
+  "create-a-project",
+  "create-an-agent",
+  "create-an-api",
+  "create-a-frontend",
+  "deploy-a-project",
+  "veryfront-code",
+];
+
+const staleGettingStartedPath = new RegExp(
+  String.raw`(?:https://veryfront\.com)?/docs/code/guides/(?:${MOVED_GETTING_STARTED_PAGES.join("|")})\b`,
+);
+
+const RULES: Rule[] = [
+  {
+    pattern: /\u2013|\u2014/,
+    message: "Use ASCII punctuation in public docs. Replace en dash or em dash with '-' or punctuation.",
+  },
+  {
+    pattern: /#veryfront\//,
+    message: "Do not expose internal #veryfront imports in public docs.",
+  },
+  {
+    pattern: /_test-setup/,
+    message: "Do not expose test-only setup modules in public docs.",
+  },
+  {
+    pattern: /\bInternal utilities\b/,
+    message: "Do not describe public API pages as internal utilities.",
+  },
+  {
+    pattern: /\bdeep-import-only\b/,
+    message: "Do not expose implementation-only import taxonomy in public docs.",
+  },
+  {
+    pattern: staleGettingStartedPath,
+    message: "Use /docs/code/getting-started/ for moved Getting Started pages.",
+  },
+];
+
+async function* walkMarkdownFiles(path: string): AsyncGenerator<string> {
+  const absolute = `${ROOT}/${path}`;
+  let stat: Deno.FileInfo;
+  try {
+    stat = await Deno.stat(absolute);
+  } catch {
+    return;
+  }
+
+  if (stat.isFile) {
+    if (path.endsWith(".md") || path.endsWith(".mdx")) {
+      yield path;
+    }
+    return;
+  }
+
+  if (!stat.isDirectory) return;
+
+  for await (const entry of Deno.readDir(absolute)) {
+    if (entry.name.startsWith(".")) continue;
+    yield* walkMarkdownFiles(`${path}/${entry.name}`);
+  }
+}
+
+function collectIssues(path: string, content: string): PublicDocIssue[] {
+  const issues: PublicDocIssue[] = [];
+  const lines = content.split("\n");
+  for (const [index, text] of lines.entries()) {
+    for (const rule of RULES) {
+      if (!rule.pattern.test(text)) continue;
+      issues.push({
+        path,
+        line: index + 1,
+        message: rule.message,
+        text,
+      });
+    }
+  }
+  return issues;
+}
+
+async function main(): Promise<void> {
+  const files = new Set<string>();
+  for (const root of PUBLIC_DOC_ROOTS) {
+    for await (const file of walkMarkdownFiles(root)) {
+      files.add(file);
+    }
+  }
+
+  const issues: PublicDocIssue[] = [];
+  for (const file of [...files].sort()) {
+    const content = await Deno.readTextFile(`${ROOT}/${file}`);
+    issues.push(...collectIssues(file, content));
+  }
+
+  if (issues.length === 0) {
+    console.log(`Validated public docs quality across ${files.size} file(s).`);
+    return;
+  }
+
+  console.error(`${issues.length} public docs quality issue(s) found:\n`);
+  for (const issue of issues.slice(0, 60)) {
+    console.error(`${issue.path}:${issue.line}: ${issue.message}`);
+    console.error(`  ${issue.text}`);
+  }
+  if (issues.length > 60) {
+    console.error(`... ${issues.length - 60} more issue(s) omitted.`);
+  }
+  Deno.exit(1);
+}
+
+await main();

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -39,13 +39,16 @@ const MOVED_GETTING_STARTED_PAGES = [
 ];
 
 const staleGettingStartedPath = new RegExp(
-  String.raw`(?:https://veryfront\.com)?/docs/code/guides/(?:${MOVED_GETTING_STARTED_PAGES.join("|")})\b`,
+  String.raw`(?:https://veryfront\.com)?/docs/code/guides/(?:${
+    MOVED_GETTING_STARTED_PAGES.join("|")
+  })\b`,
 );
 
 const RULES: Rule[] = [
   {
     pattern: /\u2013|\u2014/,
-    message: "Use ASCII punctuation in public docs. Replace en dash or em dash with '-' or punctuation.",
+    message:
+      "Use ASCII punctuation in public docs. Replace en dash or em dash with '-' or punctuation.",
   },
   {
     pattern: /#veryfront\//,
@@ -61,7 +64,13 @@ const RULES: Rule[] = [
   },
   {
     pattern: /\bdeep-import-only\b/,
-    message: "Do not expose implementation-only import taxonomy in public docs.",
+    message:
+      "Do not expose implementation-only import taxonomy in public docs.",
+  },
+  {
+    pattern: /\bmini tutorial\b/i,
+    message:
+      "Do not describe how-to guides as mini tutorials. Keep Diataxis tutorial and guide modes distinct.",
   },
   {
     pattern: staleGettingStartedPath,

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,13 +1,11 @@
 /**
- * Reusable validation schemas — common types (email, slug, URL, UUID,
+ * Reusable validation schemas: common types (email, slug, URL, UUID,
  * pagination) and primitives (file paths, hex colors, semver, timestamps),
  * plus the `defineSchema` lazy-factory helper.
  *
  * `defineSchema` resolves the `SchemaValidator` contract on first use. The
  * default zod-backed implementation lives in `@veryfront/ext-schema-zod` and is
- * registered at app bootstrap by `createBuiltinExtensions()`. Tests that
- * exercise schemas without going through full bootstrap import
- * `./_test-setup.ts` to register the adapter directly.
+ * registered at app bootstrap by `createBuiltinExtensions()`.
  *
  * @example
  * ```ts

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,9 +1,8 @@
 /**
- * Server Module Public API
+ * Server runtime APIs.
  *
- * This module exports the public interface for the Veryfront server.
- * For routing utilities, import from "#veryfront/routing" directly.
- * For observability utilities, import from "#veryfront/observability" directly.
+ * Use this module to create and run a Veryfront server in tests,
+ * custom runtimes, and production adapters.
  *
  * @module server
  *
@@ -381,5 +380,4 @@ export async function startServer(
 }
 
 // Note: Wildcard re-exports removed to prevent circular dependency risks.
-// Import from "#veryfront/routing" for Route, RouteMatch, PageRouteMatcher, etc.
-// Import from "#veryfront/observability" for tracing and metrics utilities.
+// Use public routing, middleware, and observability modules for those surfaces.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 /**
- * Internal utilities — runtime detection, structured logging, constants
+ * Runtime utilities: runtime detection, structured logging, constants
  * (breakpoints, timeouts, HTTP codes), hashing, memoization, and feature flags.
  *
  * @module utils


### PR DESCRIPTION
## Summary
- add a public docs quality validator for stale paths, private imports, test-only setup, and non-ASCII dash characters
- sanitize generated API reference copy and public JSDoc so internal-only details do not leak into public docs
- refresh generated docs and update stale Getting Started links

## Verification
- deno task docs
- deno task docs:validate
- deno fmt --check scripts/docs/generate-api-reference.ts scripts/docs/validate-public-docs.ts src/server/index.ts src/schemas/index.ts src/utils/index.ts deno.json
- deno run --allow-read scripts/docs/validate-public-docs.ts
- git diff --check
- pre-push hook: formatting, lint, typecheck, generation, unit tests