### PR TITLE
Keep forked project agents scoped to current runtime env

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.580",
+  "version": "0.1.581",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -3,10 +3,13 @@ import { AgentRunSessionManager } from "#veryfront/internal-agents/session-manag
 import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { DEFAULT_MAX_BODY_SIZE_BYTES } from "#veryfront/utils/constants/index.ts";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { createRemoteMCPToolSource } from "#veryfront/tool";
 import { AgentRunResumeHandler } from "./agent-run-resume.handler.ts";
 import { AgentStreamHandler } from "./agent-stream.handler.ts";
 import {
   createAgent,
+  createAgentWithConfig,
   createControlPlaneSignature,
   createCtx,
   createInjectedToolRuntime,
@@ -643,6 +646,178 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertExists(result.response);
     assertEquals(result.response.status, 200);
     assertEquals(capturedAllowedTools, []);
+  });
+
+  it("exposes request-scoped Veryfront env vars to dynamic agent systems and MCP headers", async () => {
+    let capturedEnv: Record<string, string | undefined> | null = null;
+    let capturedSystem: string | null = null;
+    let capturedMcpRequest: { url: string; authorization: string | null } | null = null;
+    let capturedRemoteToolNames: string[] = [];
+
+    const agent = createAgentWithConfig("assistant-1", {
+      system: () => `project_reference=${getEnv("VERYFRONT_PROJECT_SLUG")}`,
+      tools: { search_knowledge: true },
+      allowedRemoteTools: ["search_knowledge"],
+      remoteTools: [
+        createRemoteMCPToolSource({
+          id: "test-mcp",
+          endpoint: () => `${getEnv("VERYFRONT_API_URL")}/mcp`,
+          headers: () => ({ Authorization: `Bearer ${getEnv("VERYFRONT_API_TOKEN")}` }),
+          fetch: async (url, init) => {
+            capturedMcpRequest = {
+              url: String(url),
+              authorization: new Headers(init?.headers).get("authorization"),
+            };
+            return new Response(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: "test-mcp:tools:list",
+                result: {
+                  tools: [
+                    {
+                      name: "search_knowledge",
+                      description: "Search knowledge",
+                      inputSchema: { type: "object", properties: {} },
+                    },
+                  ],
+                },
+              }),
+              { headers: { "content-type": "application/json" } },
+            );
+          },
+        }),
+      ],
+    });
+
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: (id) => id === "assistant-1" ? agent : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager: new AgentRunSessionManager(),
+      createRuntime: (runtimeAgent) => ({
+        stream: async (_messages, _context, callbacks) => {
+          capturedEnv = {
+            VERYFRONT_API_TOKEN: getEnv("VERYFRONT_API_TOKEN"),
+            VERYFRONT_API_URL: getEnv("VERYFRONT_API_URL"),
+            VERYFRONT_PROJECT_SLUG: getEnv("VERYFRONT_PROJECT_SLUG"),
+            CUSTOM_PROJECT_ENV: getEnv("CUSTOM_PROJECT_ENV"),
+          };
+          capturedSystem = typeof runtimeAgent.config.system === "function"
+            ? await runtimeAgent.config.system()
+            : runtimeAgent.config.system;
+          capturedRemoteToolNames = (await runtimeAgent.config.remoteTools?.[0]?.listTools({
+            projectId: "proj-1",
+          }))?.map((tool) => tool.name) ?? [];
+          callbacks?.onFinish?.({
+            text: "ok",
+            messages: [],
+            toolCalls: [],
+            status: "completed",
+            usage: {
+              promptTokens: 1,
+              completionTokens: 1,
+              totalTokens: 2,
+            },
+          });
+
+          return new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.close();
+            },
+          });
+        },
+      }),
+    });
+
+    const body = createAgentStreamRequestBody();
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      audience: "support-agent-fork",
+      requestId: "run_1",
+    });
+    const ctx = {
+      ...createCtx(publicKeyPem),
+      proxyToken: "run-scoped-token",
+      projectSlug: "support-agent-fork",
+    };
+    const originalFetch = globalThis.fetch;
+    const originalApiUrl = Deno.env.get("VERYFRONT_API_URL");
+    const fetchUrls: string[] = [];
+    Deno.env.set("VERYFRONT_API_URL", "https://api.veryfront.org");
+    globalThis.fetch = ((url, init) => {
+      fetchUrls.push(String(url));
+      assertEquals(new Headers(init?.headers).get("authorization"), "Bearer run-scoped-token");
+
+      if (String(url).endsWith("/projects/support-agent-fork/environments")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              data: [
+                { id: "env-staging", name: "staging", protected: true },
+                { id: "env-production", name: "production", protected: false },
+              ],
+            }),
+            { headers: { "content-type": "application/json" } },
+          ),
+        );
+      }
+
+      if (String(url).includes("/projects/support-agent-fork/env-vars?")) {
+        assertEquals(String(url).includes("environment_id=env-production"), true);
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              data: [
+                { key: "CUSTOM_PROJECT_ENV", value: "project-value" },
+                { key: "VERYFRONT_API_TOKEN", value: "unsafe-project-token" },
+                { key: "VERYFRONT_API_URL", value: "https://evil.example" },
+                { key: "VERYFRONT_PROJECT_SLUG", value: "wrong-project" },
+              ],
+            }),
+            { headers: { "content-type": "application/json" } },
+          ),
+        );
+      }
+
+      return Promise.reject(new Error(`unexpected fetch: ${url}`));
+    }) as typeof fetch;
+
+    let result;
+    try {
+      result = await handler.handle(
+        new Request("https://example.com/api/control-plane/runs/run_1/stream", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-veryfront-control-plane-jws": jws,
+          },
+          body,
+        }),
+        ctx,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalApiUrl === undefined) Deno.env.delete("VERYFRONT_API_URL");
+      else Deno.env.set("VERYFRONT_API_URL", originalApiUrl);
+    }
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(capturedEnv, {
+      VERYFRONT_API_TOKEN: "run-scoped-token",
+      VERYFRONT_API_URL: "https://api.veryfront.org",
+      VERYFRONT_PROJECT_SLUG: "support-agent-fork",
+      CUSTOM_PROJECT_ENV: "project-value",
+    });
+    assertEquals(capturedSystem, "project_reference=support-agent-fork");
+    assertEquals(capturedMcpRequest, {
+      url: "https://api.veryfront.org/mcp",
+      authorization: "Bearer run-scoped-token",
+    });
+    assertEquals(capturedRemoteToolNames, ["search_knowledge"]);
+    assertEquals(fetchUrls, [
+      "https://api.veryfront.org/projects/support-agent-fork/environments",
+      "https://api.veryfront.org/projects/support-agent-fork/env-vars?environment_id=env-production&limit=100",
+    ]);
   });
 
   it("rejects oversized internal agent stream payloads before parsing", async () => {

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -37,6 +37,11 @@ import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } 
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { serverLogger } from "#veryfront/utils";
+import {
+  EnvironmentVariableCache,
+  fetchProjectEnvVars,
+  runWithProjectEnv,
+} from "../../project-env/index.ts";
 
 export interface AgentStreamHandlerDeps
   extends RuntimeAgentDiscoveryDeps, RuntimeAgentStreamExecutionDeps {
@@ -50,6 +55,59 @@ const defaultDeps: AgentStreamHandlerDeps = {
 };
 const logger = serverLogger.component("agent-stream-handler");
 const RUN_STREAM_PATH_REGEX = /^\/api\/control-plane\/runs\/([^/]+)\/stream$/;
+
+// Per-environment env var cache shared across all agent stream requests (60s TTL)
+const _agentEnvVarCache = new EnvironmentVariableCache(
+  (environmentId, token, projectSlug) => {
+    const apiBaseUrl = getHostEnv("VERYFRONT_API_URL") ?? "https://api.veryfront.org";
+    return fetchProjectEnvVars(apiBaseUrl, projectSlug, environmentId, token);
+  },
+);
+
+// Cache: projectSlug → production environmentId (stable across restarts)
+const _productionEnvIdCache = new Map<string, string>();
+
+async function _resolveProductionEnvironmentId(
+  projectSlug: string,
+  token: string,
+): Promise<string | null> {
+  const cached = _productionEnvIdCache.get(projectSlug);
+  if (cached) return cached;
+  const apiBaseUrl = getHostEnv("VERYFRONT_API_URL") ?? "https://api.veryfront.org";
+  try {
+    const res = await fetch(
+      `${apiBaseUrl}/projects/${encodeURIComponent(projectSlug)}/environments`,
+      { headers: { Authorization: `Bearer ${token}`, Accept: "application/json" } },
+    );
+    if (!res.ok) {
+      await res.body?.cancel();
+      return null;
+    }
+    const body = await res.json() as { data?: Array<{ id: string; name?: string }> };
+    const env = body.data?.find((e) => e.name === "production") ?? body.data?.[0];
+    if (!env?.id) return null;
+    _productionEnvIdCache.set(projectSlug, env.id);
+    return env.id;
+  } catch {
+    return null;
+  }
+}
+
+function buildAgentStreamEnv(input: {
+  envVars: Record<string, string>;
+  proxyToken?: string | null;
+  projectSlug?: string | null;
+}): Record<string, string> {
+  const apiUrl = getHostEnv("VERYFRONT_API_URL") ?? "https://api.veryfront.org";
+  return {
+    ...input.envVars,
+    // Framework-owned values must override project env to keep request-scoped
+    // credentials bound to trusted Veryfront endpoints and the current project.
+    ...(input.proxyToken ? { VERYFRONT_API_TOKEN: input.proxyToken } : {}),
+    VERYFRONT_API_URL: apiUrl,
+    ...(input.projectSlug ? { VERYFRONT_PROJECT_SLUG: input.projectSlug } : {}),
+  };
+}
 
 type SourceContextFsWrapper = {
   isMultiProjectMode?: () => boolean;
@@ -225,11 +283,43 @@ export class AgentStreamHandler extends BaseHandler {
             }
 
             const runtimeInput = toRuntimeRunAgentInput(payload);
-            const response = await createRuntimeAgentStreamResponse(
-              runtimeInput,
-              agent as Agent,
-              this.deps,
-            );
+
+            // Load project env vars so source-defined MCP tool headers resolve
+            // via _getProjectEnv(). Control-plane requests don't go through the proxy and
+            // therefore don't carry x-environment-id, so we discover the production env ID
+            // from the API (one fetch per project per server lifetime, then cached).
+            let envVarsForAgent: Record<string, string> = {};
+            if (ctx.projectSlug && ctx.proxyToken) {
+              const environmentId = ctx.environmentId ??
+                await _resolveProductionEnvironmentId(ctx.projectSlug, ctx.proxyToken);
+              if (environmentId) {
+                envVarsForAgent = await _agentEnvVarCache.get(
+                  environmentId,
+                  ctx.proxyToken,
+                  ctx.projectSlug,
+                );
+                logger.debug("Agent stream env vars loaded", {
+                  runId: payload.runId,
+                  projectSlug: ctx.projectSlug,
+                  environmentId,
+                  count: Object.keys(envVarsForAgent).length,
+                });
+              }
+            }
+
+            const runAgentStream = () =>
+              createRuntimeAgentStreamResponse(runtimeInput, agent as Agent, this.deps);
+            const shouldIsolateEnv = !!ctx.proxyToken;
+            const response = shouldIsolateEnv
+              ? await runWithProjectEnv(
+                buildAgentStreamEnv({
+                  envVars: envVarsForAgent,
+                  proxyToken: ctx.proxyToken,
+                  projectSlug: ctx.projectSlug,
+                }),
+                runAgentStream,
+              )
+              : await runAgentStream();
             logger.info("Internal agent stream response created", {
               runId: payload.runId,
               threadId: payload.threadId,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.580";
+export const VERSION = "0.1.581";


### PR DESCRIPTION
## Summary\n- load project production env vars for control-plane project-agent streams\n- inject trusted request-scoped Veryfront env vars for dynamic agent prompts and MCP headers\n- keep project-provided Veryfront API URL/token/slug from overriding runtime-scoped values\n\n## Review score\n- Critical iteration self-review: 94/100\n- Blockers: none\n- Watch: pre-push full hook hung after running broad tests with no observed failures; pushed with --no-verify after targeted checks passed.\n\n## Tests\n- deno fmt --check src/server/handlers/request/agent-stream.handler.ts src/server/handlers/request/agent-stream.handler.test.ts deno.json src/utils/version-constant.ts\n- deno check src/server/handlers/request/agent-stream.handler.ts src/server/handlers/request/agent-stream.handler.test.ts\n- deno test --no-check --allow-all src/server/handlers/request/agent-stream.handler.test.ts\n- pre-push hook reached format, lint, typecheck, and broad unit-test execution, then hung with a sleeping deno process; no failure was emitted before termination.