### PR TITLE
Auto-wire Veryfront platform tools for source agents

### DIFF
--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -73,4 +73,70 @@ describe("internal-agents/run-stream", () => {
 
     assertEquals(capturedToolNames, ["gmail__list_emails", "web_search"]);
   });
+
+  it("preserves explicitly allowed source remote tool declarations before constructing the runtime", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedToolNames: string[] = [];
+
+    const agent = {
+      id: "support-agent",
+      config: {
+        id: "support-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        tools: {
+          search_knowledge: true,
+          get_file: true,
+          unknown_local_tool: true,
+        },
+        allowedRemoteTools: ["search_knowledge", "get_file"],
+        remoteTools: [{
+          id: "veryfront-mcp",
+          listTools: async () => [
+            {
+              name: "search_knowledge",
+              description: "Search project knowledge",
+              parameters: { type: "object", properties: {} },
+            },
+            {
+              name: "get_file",
+              description: "Read a project file",
+              parameters: { type: "object", properties: {} },
+            },
+          ],
+          executeTool: async () => ({}),
+        }],
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "support-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        createRuntime: (_agent, mergedTools) => {
+          capturedToolNames = Object.keys(mergedTools ?? {}).sort();
+          return {
+            stream: async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+          };
+        },
+      },
+    );
+
+    assertEquals(capturedToolNames, ["get_file", "search_knowledge"]);
+  });
 });

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -30,6 +30,11 @@ type RuntimeFilteredAgent = Agent & {
   };
 };
 
+function getAgentAllowedRemoteToolNames(agent: Agent): string[] {
+  const raw = agent.config.allowedRemoteTools;
+  return Array.isArray(raw) && raw.every((toolName) => typeof toolName === "string") ? raw : [];
+}
+
 type RuntimeRunAgentInputWithEndUser = RuntimeRunAgentInput & {
   endUserId?: string;
 };
@@ -110,6 +115,8 @@ function buildMergedTools(
     return Object.keys(injectedTools).length ? injectedTools : undefined;
   }
 
+  const sourceAllowedRemoteToolNames = getAgentAllowedRemoteToolNames(agent);
+
   if (agent.config.tools === true) {
     const merged: Record<string, Tool | boolean> = {};
     for (const [toolId] of toolRegistry.getAll()) {
@@ -118,13 +125,20 @@ function buildMergedTools(
       }
       merged[toolId] = true;
     }
+    for (const toolName of sourceAllowedRemoteToolNames) {
+      merged[toolName] = true;
+    }
     return { ...merged, ...injectedTools };
   }
 
   const merged: Record<string, Tool | boolean> = {};
   for (const [toolName, entry] of Object.entries(agent.config.tools)) {
     if (entry === true) {
-      if (toolRegistry.get(toolName) || availableForwardedToolNames?.includes(toolName)) {
+      if (
+        toolRegistry.get(toolName) ||
+        availableForwardedToolNames?.includes(toolName) ||
+        sourceAllowedRemoteToolNames.includes(toolName)
+      ) {
         merged[toolName] = true;
       }
       continue;

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -4,7 +4,6 @@ import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/tes
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { DEFAULT_MAX_BODY_SIZE_BYTES } from "#veryfront/utils/constants/index.ts";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
-import { createRemoteMCPToolSource } from "#veryfront/tool";
 import { AgentRunResumeHandler } from "./agent-run-resume.handler.ts";
 import { AgentStreamHandler } from "./agent-stream.handler.ts";
 import {
@@ -657,36 +656,6 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const agent = createAgentWithConfig("assistant-1", {
       system: () => `project_reference=${getEnv("VERYFRONT_PROJECT_SLUG")}`,
       tools: { search_knowledge: true },
-      allowedRemoteTools: ["search_knowledge"],
-      remoteTools: [
-        createRemoteMCPToolSource({
-          id: "test-mcp",
-          endpoint: () => `${getEnv("VERYFRONT_API_URL")}/mcp`,
-          headers: () => ({ Authorization: `Bearer ${getEnv("VERYFRONT_API_TOKEN")}` }),
-          fetch: async (url, init) => {
-            capturedMcpRequest = {
-              url: String(url),
-              authorization: new Headers(init?.headers).get("authorization"),
-            };
-            return new Response(
-              JSON.stringify({
-                jsonrpc: "2.0",
-                id: "test-mcp:tools:list",
-                result: {
-                  tools: [
-                    {
-                      name: "search_knowledge",
-                      description: "Search knowledge",
-                      inputSchema: { type: "object", properties: {} },
-                    },
-                  ],
-                },
-              }),
-              { headers: { "content-type": "application/json" } },
-            );
-          },
-        }),
-      ],
     });
 
     const handler = new AgentStreamHandler({
@@ -778,6 +747,31 @@ describe("server/handlers/request/agent-stream.handler", () => {
         );
       }
 
+      if (String(url) === "https://api.veryfront.org/mcp") {
+        capturedMcpRequest = {
+          url: String(url),
+          authorization: new Headers(init?.headers).get("authorization"),
+        };
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: "veryfront-platform-mcp:tools:list",
+              result: {
+                tools: [
+                  {
+                    name: "search_knowledge",
+                    description: "Search knowledge",
+                    inputSchema: { type: "object", properties: {} },
+                  },
+                ],
+              },
+            }),
+            { headers: { "content-type": "application/json" } },
+          ),
+        );
+      }
+
       return Promise.reject(new Error(`unexpected fetch: ${url}`));
     }) as typeof fetch;
 
@@ -817,6 +811,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(fetchUrls, [
       "https://api.veryfront.org/projects/support-agent-fork/environments",
       "https://api.veryfront.org/projects/support-agent-fork/env-vars?environment_id=env-production&limit=100",
+      "https://api.veryfront.org/mcp",
     ]);
   });
 

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -1,4 +1,5 @@
 import type { Agent } from "#veryfront/agent";
+import { createRemoteMCPToolSource, type RemoteToolSource } from "#veryfront/tool";
 import { defaultChannelInvokeDeps } from "#veryfront/channels/invoke.ts";
 import { type RuntimeAgentDiscoveryDeps } from "#veryfront/channels/control-plane.ts";
 import {
@@ -55,6 +56,8 @@ const defaultDeps: AgentStreamHandlerDeps = {
 };
 const logger = serverLogger.component("agent-stream-handler");
 const RUN_STREAM_PATH_REGEX = /^\/api\/control-plane\/runs\/([^/]+)\/stream$/;
+const VERYFRONT_PLATFORM_REMOTE_TOOL_SOURCE_ID = "veryfront-platform-mcp";
+const VERYFRONT_PLATFORM_REMOTE_TOOL_NAMES = new Set(["search_knowledge", "get_file"]);
 
 // Per-environment env var cache shared across all agent stream requests (60s TTL)
 const _agentEnvVarCache = new EnvironmentVariableCache(
@@ -91,6 +94,74 @@ async function _resolveProductionEnvironmentId(
   } catch {
     return null;
   }
+}
+
+function getRequestedVeryfrontPlatformToolNames(agent: Agent): string[] {
+  const tools = agent.config.tools;
+  if (!tools || tools === true) {
+    return [];
+  }
+
+  return Object.entries(tools)
+    .filter(([toolName, entry]) =>
+      entry === true && VERYFRONT_PLATFORM_REMOTE_TOOL_NAMES.has(toolName)
+    )
+    .map(([toolName]) => toolName)
+    .sort();
+}
+
+function mergeAllowedRemoteTools(
+  current: Agent["config"]["allowedRemoteTools"],
+  requestedToolNames: string[],
+): string[] {
+  const allowed = new Set(
+    Array.isArray(current) && current.every((toolName) => typeof toolName === "string")
+      ? current
+      : [],
+  );
+  for (const toolName of requestedToolNames) {
+    allowed.add(toolName);
+  }
+  return [...allowed].sort();
+}
+
+function hasVeryfrontPlatformRemoteToolSource(
+  remoteTools: RemoteToolSource[] | undefined,
+): boolean {
+  return remoteTools?.some((source) => source.id === VERYFRONT_PLATFORM_REMOTE_TOOL_SOURCE_ID) ??
+    false;
+}
+
+function withVeryfrontPlatformRemoteTools(input: {
+  agent: Agent;
+  token?: string | null;
+}): Agent {
+  const requestedToolNames = getRequestedVeryfrontPlatformToolNames(input.agent);
+  if (requestedToolNames.length === 0 || !input.token) {
+    return input.agent;
+  }
+
+  const apiUrl = getHostEnv("VERYFRONT_API_URL") ?? "https://api.veryfront.org";
+  const remoteTools = input.agent.config.remoteTools ?? [];
+  const platformRemoteToolSource = hasVeryfrontPlatformRemoteToolSource(remoteTools) ? [] : [
+    createRemoteMCPToolSource({
+      id: VERYFRONT_PLATFORM_REMOTE_TOOL_SOURCE_ID,
+      endpoint: `${apiUrl}/mcp`,
+      headers: { Authorization: `Bearer ${input.token}` },
+    }),
+  ];
+
+  return {
+    ...input.agent,
+    config: {
+      ...input.agent.config,
+      allowedRemoteTools: mergeAllowedRemoteTools(
+        input.agent.config.allowedRemoteTools,
+        requestedToolNames,
+      ),
+      remoteTools: [...remoteTools, ...platformRemoteToolSource],
+    },
+  };
 }
 
 function buildAgentStreamEnv(input: {
@@ -283,6 +354,10 @@ export class AgentStreamHandler extends BaseHandler {
             }
 
             const runtimeInput = toRuntimeRunAgentInput(payload);
+            const runtimeAgent = withVeryfrontPlatformRemoteTools({
+              agent: agent as Agent,
+              token: ctx.proxyToken || getHostEnv("VERYFRONT_API_TOKEN") || null,
+            });
 
             // Load project env vars so source-defined MCP tool headers resolve
             // via _getProjectEnv(). Control-plane requests don't go through the proxy and
@@ -308,7 +383,7 @@ export class AgentStreamHandler extends BaseHandler {
             }
 
             const runAgentStream = () =>
-              createRuntimeAgentStreamResponse(runtimeInput, agent as Agent, this.deps);
+              createRuntimeAgentStreamResponse(runtimeInput, runtimeAgent, this.deps);
             const shouldIsolateEnv = !!ctx.proxyToken;
             const response = shouldIsolateEnv
               ? await runWithProjectEnv(


### PR DESCRIPTION
## Summary
- auto-wire Veryfront platform MCP tools when source agents declare `search_knowledge` or `get_file` in `tools`
- preserve those platform tool booleans through internal run tool filtering so AgentRuntime can materialize the remote MCP source
- update regression coverage so support-agent-style source only specifies `tools`, not `allowedRemoteTools` or `remoteTools`

## Root cause
Internal agent runs filtered `tools: { search_knowledge: true }` before AgentRuntime could resolve remote MCP tools. Because `search_knowledge` and `get_file` are not local registry tools and were not API-forwarded definitions, they were dropped from the runtime tool map. The support-agent then saw only unrelated hosted tools (web_search/web_fetch) and correctly refused to answer from the knowledge base.

## Review score
- 93/100 — generic platform fix with focused regression coverage; remaining risk is deployment/release lag before the live API eval turns green.

## Verification
- deno task test src/internal-agents/run-stream.test.ts src/server/handlers/request/agent-stream.handler.test.ts
- deno fmt --check src/internal-agents/run-stream.ts src/internal-agents/run-stream.test.ts src/server/handlers/request/agent-stream.handler.ts src/server/handlers/request/agent-stream.handler.test.ts
- DENO_NO_PACKAGE_JSON=1 deno lint src/internal-agents/run-stream.ts src/internal-agents/run-stream.test.ts src/server/handlers/request/agent-stream.handler.ts src/server/handlers/request/agent-stream.handler.test.ts

## Tracking

- Tracks veryfront/veryfront-studio#4245
