### PR TITLE
Fix docs section overview routes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ boundaries, or docs structure.
 - `guides/`: Published task guides and decision guides.
 - `concepts/`: Published explanation docs for public mental models.
 - `api-reference/`: Generated public API reference. The public overview is
-  `api-reference/index.md`; do not use `README.md` for public pages.
+  `api-reference/overview.md`; do not use `README.md` for public pages.
 - `architecture/`: Private Veryfront Code architecture notes. These docs are
   not part of the public docs sync.
 

--- a/docs/api-reference/overview.md
+++ b/docs/api-reference/overview.md
@@ -1,5 +1,6 @@
 ---
 title: "API reference"
+sidebarTitle: "Overview"
 description: "Exact imports, exported names, types, and module-level examples for Veryfront Code."
 order: 1
 ---

--- a/docs/api-reference/veryfront/index.md
+++ b/docs/api-reference/veryfront/index.md
@@ -119,7 +119,7 @@ Reference modules:
 
 User guides:
 
-- [index](../../getting-started/index.md): Browse the guide map
+- [overview](../../guides/overview.md): Browse the guide map
 - [quickstart](../../getting-started/quickstart.md): Build and run a first agent app
 - [veryfront-code](../../concepts/veryfront-code.md): What Veryfront Code is and how guides fit together
 - [installation](../../getting-started/installation.md): Install the CLI and framework

--- a/docs/architecture/01-system-overview.md
+++ b/docs/architecture/01-system-overview.md
@@ -85,4 +85,4 @@ behavior to the owning domain and keep the bridge as composition code.
 
 ## Related reference
 
-- [Reference index](../api-reference/index.md)
+- [Reference index](../api-reference/overview.md)

--- a/docs/architecture/20-support-matrix.md
+++ b/docs/architecture/20-support-matrix.md
@@ -97,4 +97,4 @@ the full managed behavior by itself.
 
 ## Related reference
 
-- [Reference index](../api-reference/index.md)
+- [Reference index](../api-reference/overview.md)

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -4,7 +4,7 @@ This folder holds public explanation docs for Veryfront Code. Concepts help
 readers understand how parts of the framework relate, why boundaries exist, and
 how to reason about trade-offs.
 
-Use `index.md` as the public section overview. Keep `README.md` for
+Use `overview.md` as the public section overview. Keep `README.md` for
 repo-maintainer notes only.
 
 ## What belongs here

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -1,5 +1,6 @@
 ---
-title: "Overview"
+title: "Concepts"
+sidebarTitle: "Overview"
 description: "Conceptual explanations for how Veryfront Code primitives, project conventions, runtime services, and extension points fit together."
 order: 0
 ---

--- a/docs/concepts/veryfront-code.md
+++ b/docs/concepts/veryfront-code.md
@@ -23,10 +23,10 @@ conventions.
 
 | Section                                        | Use it when                                                                   |
 | ---------------------------------------------- | ----------------------------------------------------------------------------- |
-| [Getting Started](../getting-started/index.md) | You are installing Veryfront Code or building your first project.             |
-| [Guides](../guides/index.md)                   | You need to complete a specific task in an existing project.                  |
-| [Concepts](./index.md)                         | You need context, terminology, and mental models before choosing an approach. |
-| [API reference](../api-reference/index.md)     | You need exact imports, exported names, types, and examples.                  |
+| [Getting Started](../getting-started/overview.md) | You are installing Veryfront Code or building your first project.             |
+| [Guides](../guides/overview.md)                   | You need to complete a specific task in an existing project.                  |
+| [Concepts](./overview.md)                      | You need context, terminology, and mental models before choosing an approach. |
+| [API reference](../api-reference/overview.md)     | You need exact imports, exported names, types, and examples.                  |
 
 ## Related
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -9,7 +9,7 @@ the same order as the public docs navigation.
 
 ## Pages
 
-- `index.md`: Public section overview.
+- `overview.md`: Public section overview.
 - `quickstart.md`: End-to-end first app.
 - `installation.md`: CLI and framework installation.
 - `create-project.md`: Project scaffolding.

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -1,6 +1,7 @@
 ---
-title: "Overview"
-description: "Start here. A short tour of the Veryfront Code guides and what you need to know before building."
+title: "Getting started"
+sidebarTitle: "Overview"
+description: "Guided onboarding for installing Veryfront Code, creating a project, and building the first working pieces of an app."
 order: 0
 ---
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -3,7 +3,7 @@
 This folder holds the source content for the published Veryfront user guides.
 
 Guides help a reader finish one task with the Veryfront library or CLI.
-Use `index.md` as the public section overview. Keep `README.md` for
+Use `overview.md` as the public section overview. Keep `README.md` for
 repo-maintainer notes only.
 
 ## What belongs here

--- a/docs/guides/head-and-seo.md
+++ b/docs/guides/head-and-seo.md
@@ -166,7 +166,7 @@ Open the page in the browser and inspect the document `<head>`. Confirm:
 ## Next
 
 - [Providers](./providers.md): wire up an LLM provider for AI pages
-- [API reference](../api-reference/index.md): full module reference
+- [API reference](../api-reference/overview.md): full module reference
 
 ## Related
 

--- a/docs/guides/overview.md
+++ b/docs/guides/overview.md
@@ -1,5 +1,6 @@
 ---
-title: "Overview"
+title: "Guides"
+sidebarTitle: "Overview"
 description: "Task-focused guides for building, configuring, deploying, and operating Veryfront Code projects."
 order: 0
 ---

--- a/scripts/docs/docs-coverage.ts
+++ b/scripts/docs/docs-coverage.ts
@@ -163,7 +163,7 @@ function difference(expected: string[], actual: Set<string>): string[] {
 }
 
 function requiresReferenceBacklink(file: string): boolean {
-  return !file.endsWith("/index.md") && !file.startsWith("concepts/");
+  return !file.endsWith("/overview.md") && !file.startsWith("concepts/");
 }
 
 export async function collectDocsCoverage(

--- a/scripts/docs/generate-api-reference.ts
+++ b/scripts/docs/generate-api-reference.ts
@@ -443,7 +443,7 @@ const RELATED_MODULES: Record<string, Array<{ path: string; reason: string }>> =
 const RELATED_GUIDES: Record<string, Array<{ path: string; reason: string }>> =
   {
     "veryfront": [
-      { path: "index", reason: "Browse the guide map" },
+      { path: "overview", reason: "Browse the guide map" },
       { path: "quickstart", reason: "Build and run a first agent app" },
       {
         path: "veryfront-code",
@@ -2889,6 +2889,7 @@ function generateReadmeMD(
 
   lines.push("---");
   lines.push('title: "API reference"');
+  lines.push('sidebarTitle: "Overview"');
   lines.push(
     'description: "Exact imports, exported names, types, and module-level examples for Veryfront Code."',
   );
@@ -3040,15 +3041,20 @@ async function main() {
   }
 
   // Write the public overview at the docs/api-reference root.
-  const indexMD = normalizeGeneratedMarkdown(generateReadmeMD(indexData));
-  const indexPath = `${OUTPUT_DIR}/index.md`;
-  await Deno.writeTextFile(indexPath, indexMD);
+  const overviewMD = normalizeGeneratedMarkdown(generateReadmeMD(indexData));
+  const overviewPath = `${OUTPUT_DIR}/overview.md`;
+  await Deno.writeTextFile(overviewPath, overviewMD);
+  try {
+    await Deno.remove(`${OUTPUT_DIR}/index.md`);
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) throw err;
+  }
   try {
     await Deno.remove(`${OUTPUT_DIR}/README.md`);
   } catch (err) {
     if (!(err instanceof Deno.errors.NotFound)) throw err;
   }
-  console.log(`\nWrote ${indexPath}`);
+  console.log(`\nWrote ${overviewPath}`);
   console.log(`Generated ${groups.length} MD files in ${VERYFRONT_DIR}`);
   console.log(
     `Source JSDoc coverage: ${sourceDocStats.documented}/${sourceDocStats.total} public declarations documented (${sourceDocStats.missing} missing).`,

--- a/scripts/docs/validate-api-reference.ts
+++ b/scripts/docs/validate-api-reference.ts
@@ -11,7 +11,7 @@
  *    `docs/api-reference/veryfront/<slug>.md`. The root export maps to
  *    `index.md`. Synthetic parents that only own deep imports (e.g.
  *    `channels`) also require a page.
- * 3. The public `docs/api-reference/index.md` overview exists.
+ * 3. The public `docs/api-reference/overview.md` overview exists.
  * 4. Generated reference tables do not contain known placeholder wording.
  *
  * Runs as part of `deno task verify`.
@@ -191,7 +191,7 @@ function main(): void {
   }
 
   // Public overview that explains the section contents.
-  const indexPath = `${ROOT}/docs/api-reference/index.md`;
+  const indexPath = `${ROOT}/docs/api-reference/overview.md`;
   let indexMissing = false;
   try {
     Deno.statSync(indexPath);
@@ -212,7 +212,7 @@ function main(): void {
     console.log(
       `All ${requiredSlugs.size} reference pages exist under docs/api-reference/veryfront/.`,
     );
-    console.log("docs/api-reference/index.md exists.");
+    console.log("docs/api-reference/overview.md exists.");
     console.log("Generated reference pages passed placeholder wording checks.");
     Deno.exit(0);
   }
@@ -271,7 +271,7 @@ function main(): void {
 
   if (indexMissing) {
     console.error(
-      `\nMissing docs/api-reference/index.md (run \`deno task docs\`).`,
+      `\nMissing docs/api-reference/overview.md (run \`deno task docs\`).`,
     );
   }
 

--- a/scripts/docs/validate-guides.ts
+++ b/scripts/docs/validate-guides.ts
@@ -191,8 +191,8 @@ for (const file of guideFiles) {
     );
   }
 
-  // --- Required closing sections (skip index.md) ---
-  if (filename !== "index.md") {
+  // --- Required closing sections (skip section overview pages) ---
+  if (filename !== "overview.md") {
     const hasNext = body.includes("## Next");
     const hasRelated = body.includes("## Related");
     if (!hasNext && !hasRelated) {
@@ -212,9 +212,9 @@ for (const [key, files] of guideOrders) {
 
 // 2. Validate that every page is listed in a section overview.
 const catalogFiles = [
-  "getting-started/index.md",
-  "guides/index.md",
-  "concepts/index.md",
+  "getting-started/overview.md",
+  "guides/overview.md",
+  "concepts/overview.md",
 ];
 const listedSlugs = new Set<string>();
 
@@ -248,7 +248,7 @@ for (const file of guideFiles) {
   const slug = file.slug;
   if (!listedSlugs.has(slug)) {
     addWarning(
-      "getting-started/index.md",
+      "getting-started/overview.md",
       `Guide "${slug}" not listed in a section overview`,
     );
   }

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -11,7 +11,7 @@ interface GuideContract {
 
 const PUBLIC_DOC_DIRS = ["getting-started", "guides", "concepts"] as const;
 const CONCEPT_FILES = new Set<string>([
-  "concepts/index.md",
+  "concepts/overview.md",
   "concepts/veryfront-code.md",
   "concepts/runtime-primitives.md",
   "concepts/project-conventions.md",
@@ -219,7 +219,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     ],
     snippets: ["Head", "GoogleFonts", "JSON-LD"],
   },
-  "getting-started/index.md": {
+  "getting-started/overview.md": {
     references: [],
     snippets: [
       "Veryfront Code",
@@ -242,7 +242,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "Runtime primitives",
     ],
   },
-  "guides/index.md": {
+  "guides/overview.md": {
     references: [],
     snippets: [
       "Guides help you complete specific work",
@@ -254,7 +254,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "Building and deploying",
     ],
   },
-  "concepts/index.md": {
+  "concepts/overview.md": {
     references: [],
     snippets: [
       "Concepts explain the mental models",
@@ -535,8 +535,8 @@ describe("published guide contracts", () => {
 
       if (
         !CONCEPT_FILES.has(filename) &&
-        filename !== "getting-started/index.md" &&
-        filename !== "guides/index.md"
+        filename !== "getting-started/overview.md" &&
+        filename !== "guides/overview.md"
       ) {
         assertStringIncludes(guide, "## Verify it worked");
       }


### PR DESCRIPTION
## Summary\n- Rename public Code section index pages to explicit overview pages.\n- Add sidebarTitle: Overview to section overview pages.\n- Update generated API reference output, validators, and docs contracts for overview routes.\n\n## Verification\n- deno task docs\n- deno task docs:validate\n- git diff --check\n- pre-push: format, lint, typecheck, generation, unit tests