### PR TITLE
Remove internal agent endUserId propagation

### DIFF
--- a/src/agent/hosted/runtime-state-resolver.test.ts
+++ b/src/agent/hosted/runtime-state-resolver.test.ts
@@ -47,7 +47,7 @@ describe("agent/hosted-runtime-state-resolver", () => {
     assertEquals(refreshCount, 1);
   });
 
-  it("preserves the authenticated user as endUserId in runtime tool context", async () => {
+  it("does not expose the authenticated user as legacy endUserId in runtime tool context", async () => {
     const resolver = createHostedRuntimeStateResolver({
       taskContext: {
         projectId: "project-1",
@@ -58,7 +58,7 @@ describe("agent/hosted-runtime-state-resolver", () => {
 
     assertEquals(await resolver({ system: "system", messages: [], step: 1 }), {
       system: "system",
-      context: { endUserId: "user-123" },
+      context: {},
     });
   });
 

--- a/src/agent/hosted/runtime-state-resolver.ts
+++ b/src/agent/hosted/runtime-state-resolver.ts
@@ -66,10 +66,6 @@ function steeringRevision(context: HostedRuntimeStateResolverContext): number {
   return context.steeringRevision ?? 0;
 }
 
-function hasValidUserId(userId: string | null | undefined): userId is string {
-  return typeof userId === "string" && userId.length > 0;
-}
-
 /** Create hosted runtime state resolver. */
 export function createHostedRuntimeStateResolver<
   TContext extends HostedRuntimeStateResolverContext,
@@ -90,9 +86,6 @@ export function createHostedRuntimeStateResolver<
 
     let nextSystem = system;
     const nextContextRecord = { ...(context ?? {}) };
-    if (hasValidUserId(options.taskContext.userId)) {
-      nextContextRecord.endUserId = options.taskContext.userId;
-    }
 
     if (steeringChanged && options.refreshSystem) {
       nextSystem = await options.refreshSystem({

--- a/src/agent/runtime/agent-invocation-contract.test.ts
+++ b/src/agent/runtime/agent-invocation-contract.test.ts
@@ -229,7 +229,6 @@ describe("agent/runtime-agent-invocation-contract", () => {
       threadId: conversationId,
       runId: "run_child_1",
       parentRunId: "run_root_1",
-      endUserId: userId,
       messages: parsed.messages,
       tools: parsed.tools,
       context: parsed.context,

--- a/src/agent/runtime/agent-invocation-contract.ts
+++ b/src/agent/runtime/agent-invocation-contract.ts
@@ -355,7 +355,6 @@ export type RuntimeAgentControlPlaneStreamRequest = {
   threadId: RuntimeAgentRunContext["conversationId"];
   runId: RuntimeAgentRunContext["runId"];
   parentRunId?: Exclude<RuntimeAgentRunContext["parentRunId"], null | undefined>;
-  endUserId?: RuntimeAgentRunContext["requestedByUserId"];
   messages: RuntimeAgentRunInvocation["messages"];
   tools: RuntimeAgentRunInvocation["tools"];
   context: RuntimeAgentRunInvocation["context"];
@@ -372,7 +371,6 @@ export function buildRuntimeAgentControlPlaneStreamRequestFromInvocation(
     threadId: input.run.conversationId,
     runId: input.run.runId,
     ...(input.run.parentRunId ? { parentRunId: input.run.parentRunId } : {}),
-    endUserId: input.run.requestedByUserId,
     messages: input.messages,
     tools: input.tools,
     context: input.context,

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -246,7 +246,6 @@ describe("tool-helpers", () => {
                 toolCallId: "tool-4",
                 runId: "run-123",
                 agentId: "agent-123",
-                endUserId: "user-123",
               },
               ["gmail__list_emails"],
             ),

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -35,10 +35,6 @@ function getAgentAllowedRemoteToolNames(agent: Agent): string[] {
   return Array.isArray(raw) && raw.every((toolName) => typeof toolName === "string") ? raw : [];
 }
 
-type RuntimeRunAgentInputWithEndUser = RuntimeRunAgentInput & {
-  endUserId?: string;
-};
-
 export interface RuntimeAgentStreamExecutionDeps {
   sessionManager: AgentRunSessionManager;
   createRuntime?: (
@@ -203,7 +199,7 @@ function getForwardedIntegrationToolDefinitions(
 }
 
 export async function createRuntimeAgentStreamResponse(
-  input: RuntimeRunAgentInputWithEndUser,
+  input: RuntimeRunAgentInput,
   agent: Agent,
   deps: RuntimeAgentStreamExecutionDeps,
 ): Promise<Response> {
@@ -257,7 +253,6 @@ export async function createRuntimeAgentStreamResponse(
         runId: input.runId,
         ...(input.parentRunId ? { parentRunId: input.parentRunId } : {}),
         ...(input.state !== undefined ? { state: input.state } : {}),
-        ...(input.endUserId ? { endUserId: input.endUserId } : {}),
         context: input.context,
         forwardedProps: input.forwardedProps,
       },

--- a/src/internal-agents/schema.test.ts
+++ b/src/internal-agents/schema.test.ts
@@ -327,19 +327,48 @@ describe("internal-agents/schema", () => {
     });
   });
 
-  it("preserves endUserId on internal stream payloads for on-demand integration auth", () => {
-    const internalRequest = getInternalAgentStreamRequestSchema().parse({
-      agentId: "agent_1",
-      threadId: "10000000-1000-4000-8000-100000000001",
-      runId: "run_1",
-      endUserId: "10000000-1000-4000-8000-100000000004",
-      messages: [],
-      context: [],
-    });
+  it("rejects legacy endUserId on internal stream payloads", () => {
+    assertThrows(() =>
+      getInternalAgentStreamRequestSchema().parse({
+        agentId: "agent_1",
+        threadId: "10000000-1000-4000-8000-100000000001",
+        runId: "run_1",
+        endUserId: "10000000-1000-4000-8000-100000000004",
+        messages: [],
+        context: [],
+      })
+    );
+  });
 
-    assertEquals(
-      (toRuntimeRunAgentInput(internalRequest) as unknown as { endUserId?: string }).endUserId,
-      "10000000-1000-4000-8000-100000000004",
+  it("rejects legacy endUserId on invocation-shaped internal stream payloads", () => {
+    assertThrows(() =>
+      getInternalAgentStreamRequestSchema().parse({
+        run: {
+          agentServiceId: "veryfront-platform-agent",
+          agentId: "incident-responder",
+          conversationId: "10000000-1000-4000-8000-100000000001",
+          runId: "run_1",
+          messageId: "10000000-1000-4000-8000-100000000002",
+          inputAnchorMessageId: "10000000-1000-4000-8000-100000000002",
+          requestedByUserId: "10000000-1000-4000-8000-100000000003",
+          project: {
+            projectId: "10000000-1000-4000-8000-100000000004",
+            projectSlug: "incident-responder-cwy27d",
+            runtimeTargetKind: "preview_branch",
+            runtimeTargetEnvironmentId: null,
+            runtimeTargetBranchId: "10000000-1000-4000-8000-100000000005",
+          },
+          validatedClaims: {
+            subject: "10000000-1000-4000-8000-100000000003",
+            projectId: "10000000-1000-4000-8000-100000000004",
+            projectSlug: "incident-responder-cwy27d",
+            scopes: [],
+          },
+        },
+        endUserId: "10000000-1000-4000-8000-100000000004",
+        messages: [],
+        context: [],
+      })
     );
   });
 

--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -63,7 +63,6 @@ export const getInternalAgentControlPlaneStreamRequestSchema = defineSchema((v) 
     threadId: v.string().uuid(),
     runId: getRunIdSchema(),
     parentRunId: getRunIdSchema().optional(),
-    endUserId: v.string().uuid().optional(),
     state: v.unknown().optional(),
     messages: v.array(
       v.union([getRuntimeMessageSchema(), getInternalAgentCompatibilityMessageSchema()]),
@@ -78,7 +77,7 @@ export const getInternalAgentControlPlaneStreamRequestSchema = defineSchema((v) 
       (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_FORWARDED_PROPS_BYTES),
       { message: "forwardedProps must be less than 192 KB" },
     ),
-  })
+  }).strict()
 );
 
 export const getInternalAgentStreamRequestSchema = defineSchema((v) => {
@@ -87,6 +86,7 @@ export const getInternalAgentStreamRequestSchema = defineSchema((v) => {
   return v.union([
     controlPlaneStreamRequestSchema,
     getRuntimeAgentRunInvocationSchema()
+      .strict()
       .transform(buildRuntimeAgentControlPlaneStreamRequestFromInvocation)
       .pipe(controlPlaneStreamRequestSchema),
   ]);
@@ -310,7 +310,6 @@ export function toRuntimeRunAgentInput(
     threadId: input.threadId,
     runId: input.runId,
     ...(input.parentRunId ? { parentRunId: input.parentRunId } : {}),
-    ...(input.endUserId ? { endUserId: input.endUserId } : {}),
     ...(input.state !== undefined ? { state: input.state } : {}),
     messages: input.messages.map(toRuntimeMessage),
     tools: input.tools,

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -513,7 +513,6 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(streamContext, {
       threadId: "10000000-1000-4000-8000-100000000001",
       runId: "run_1",
-      endUserId: "30000000-3000-4000-8000-300000000001",
       context: [{ type: "text", text: "Current file: app.tsx" }],
       forwardedProps: {
         runtimeOverrides: {

--- a/src/tool/types.ts
+++ b/src/tool/types.ts
@@ -72,8 +72,6 @@ export interface ToolExecutionContext {
   toolCallId?: string;
   /** Project identity used by integration token resolution */
   projectId?: string;
-  /** Trusted runtime user identity supplied by hosted integration tooling */
-  endUserId?: string;
   /** Abort signal for cooperative cancellation during long-running tool execution */
   abortSignal?: AbortSignal;
   /** Progress token for sending progress notifications (MCP 2025-11-25) */


### PR DESCRIPTION
Refs veryfront/veryfront-issue-inbox#61

## Summary
- remove legacy `endUserId` from the internal agent control-plane stream contract
- make the internal stream schema strict so caller-supplied `endUserId` is rejected
- stop injecting authenticated users into runtime tool context as `endUserId`
- remove `endUserId` from the public tool execution context type

## TDD
- RED: `deno task test src/internal-agents/schema.test.ts src/agent/runtime/agent-invocation-contract.test.ts` failed because the schema still accepted `endUserId` and the control-plane request still emitted it
- GREEN: focused runtime suite passed after removing propagation

## Verification
- `deno task test src/internal-agents/schema.test.ts src/agent/runtime/agent-invocation-contract.test.ts src/agent/hosted/runtime-state-resolver.test.ts src/agent/runtime/tool-helpers.test.ts src/server/handlers/request/agent-stream.handler.test.ts` passed: 5 files, 76 steps
- `deno task verify:quick` passed
- `deno task verify` passed: 2,237 tests / 20,737 steps, plus compiled-binary e2e 58 steps
- pre-push checks passed: format, lint, typecheck, 1,909 unit tests / 17,577 steps

## Visual testing
- Not applicable: runtime/schema/type cleanup only; no rendered UI surface changed.