### PR TITLE
Drop legacy remote identity plumbing

### DIFF
--- a/src/agent/hosted/chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.ts
@@ -134,7 +134,6 @@ export async function prepareHostedChatRuntimeToolAssembly<
     createRemoteToolSource: input.createRemoteToolSource ?? createRemoteMCPToolSource,
     defaultProjectId: () => activeProjectId(input.taskContext),
     getProjectId: input.getProjectId ?? (() => activeProjectId(input.taskContext)),
-    getEndUserId: () => input.taskContext.userId ?? null,
     getActiveBranchId: input.getActiveBranchId ?? (() => activeBranchId(input.taskContext)),
     conversationId: input.conversationId,
     allowedToolNames,

--- a/src/agent/hosted/project-remote-tool-source.test.ts
+++ b/src/agent/hosted/project-remote-tool-source.test.ts
@@ -70,6 +70,29 @@ async function resolveTestHeaders(
   return typeof headers === "function" ? await headers() : headers;
 }
 
+Deno.test("hosted remote tool sources do not carry legacy end-user identity plumbing", async () => {
+  const forbidden = [
+    ["get", "End", "User", "Id"].join(""),
+    ["end", "user", "id"].join("_"),
+  ];
+  const productionFiles = [
+    "src/agent/hosted/project-remote-tool-source.ts",
+    "src/agent/hosted/chat-runtime-tool-assembly.ts",
+  ];
+  const offenders: string[] = [];
+
+  for (const file of productionFiles) {
+    const source = await Deno.readTextFile(file);
+    for (const token of forbidden) {
+      if (source.includes(token)) {
+        offenders.push(`${file}:${token}`);
+      }
+    }
+  }
+
+  assertEquals(offenders, []);
+});
+
 Deno.test("createHostedProjectRemoteToolSource scopes tool listings and hydrates project inputs", async () => {
   const executeCalls: Array<{ toolName: string; args: unknown; context?: ToolExecutionContext }> =
     [];
@@ -266,39 +289,6 @@ Deno.test("createHostedProjectRemoteToolSources defaults to the Veryfront API MC
 
   assertEquals(sources.map((source) => source.id), ["veryfront-mcp"]);
   assertEquals(configs.map((config) => config.endpoint), ["https://api.example/mcp"]);
-});
-
-Deno.test("createHostedProjectRemoteToolSources does not inject end_user_id for Veryfront API integration tools", async () => {
-  const executed: Array<{ toolName: string; args: unknown; context?: ToolExecutionContext }> = [];
-  const sources = createHostedProjectRemoteToolSources({
-    authToken: "token-1",
-    apiMcpUrl: "https://api.example/mcp",
-    mcpServers: [{ kind: "veryfront-api" }],
-    getProjectId: () => "project-1",
-    getEndUserId: () => "user-123",
-    createRemoteToolSource: (config) =>
-      createRemoteSource({
-        id: config.id,
-        tools: [simpleTool("github__list_issues")],
-        execute: (toolName, args, context) => {
-          executed.push({ toolName, args, context });
-          return { ok: true };
-        },
-      }),
-  });
-
-  await sources[0]?.executeTool("github__list_issues", {
-    repo: "veryfront",
-    end_user_id: "malicious-user",
-  });
-
-  assertEquals(executed, [
-    {
-      toolName: "github__list_issues",
-      args: { repo: "veryfront" },
-      context: undefined,
-    },
-  ]);
 });
 
 Deno.test("createHostedProjectRemoteToolSources filters Veryfront API MCP tools with the tool access profile", async () => {
@@ -562,7 +552,7 @@ Deno.test("createHostedProjectRemoteToolSources applies project wrapper policy t
   assertEquals(switchedProjects, ["project-2"]);
 });
 
-Deno.test("createHostedProjectRemoteToolSources composes API input preparation with integration end-user input", async () => {
+Deno.test("createHostedProjectRemoteToolSources composes API input preparation for integration tools", async () => {
   const executed: Array<{ toolName: string; args: unknown; context?: ToolExecutionContext }> = [];
   const sources = createHostedProjectRemoteToolSources({
     authToken: "token-1",
@@ -570,7 +560,6 @@ Deno.test("createHostedProjectRemoteToolSources composes API input preparation w
     mcpServers: [{ kind: "veryfront-api" }],
     defaultProjectId: () => "project-1",
     getProjectId: () => "project-1",
-    getEndUserId: () => "end-user-123",
     prepareToolInput: ({ toolInput }) => ({
       ...toolInput,
       prepared: true,

--- a/src/agent/hosted/project-remote-tool-source.ts
+++ b/src/agent/hosted/project-remote-tool-source.ts
@@ -206,38 +206,10 @@ export type CreateHostedProjectRemoteToolSourcesInput =
     mcpServers?: readonly AgentServiceMcpServerConfig[];
     clientProfile?: RuntimeClientProfile | null;
     getProjectId: () => string | null | undefined;
-    getEndUserId?: () => string | null | undefined;
     conversationId?: string;
     createRemoteToolSource?: (config: RemoteMCPToolSourceConfig) => RemoteToolSource;
     onStudioProjectSwitch?: HostedProjectRemoteToolSourceProjectSwitchHandler;
   };
-
-function isVeryfrontApiIntegrationTool(toolName: string): boolean {
-  return /^[a-zA-Z0-9_.-]+__[a-zA-Z0-9_.-]+$/.test(toolName);
-}
-
-function prepareVeryfrontApiToolInput(input: {
-  server: AgentServiceMcpServerConfig;
-  getEndUserId?: () => string | null | undefined;
-  prepareToolInput?: HostedProjectRemoteToolSourcePrepareToolInput;
-}): HostedProjectRemoteToolSourcePrepareToolInput | undefined {
-  if (input.server.kind !== "veryfront-api" && !input.prepareToolInput) {
-    return undefined;
-  }
-
-  return (toolInputContext) => {
-    const prepared = input.prepareToolInput?.(toolInputContext) ?? toolInputContext.toolInput;
-    if (
-      input.server.kind !== "veryfront-api" ||
-      !isVeryfrontApiIntegrationTool(toolInputContext.toolName)
-    ) {
-      return prepared;
-    }
-
-    const { end_user_id: _endUserId, ...trustedInput } = prepared;
-    return trustedInput;
-  };
-}
 
 function createHostedProjectRemoteToolSourceFromConfig(
   input: CreateHostedProjectRemoteToolSourcesInput,
@@ -245,12 +217,6 @@ function createHostedProjectRemoteToolSourceFromConfig(
   source: RemoteToolSource,
   onProjectSwitch?: HostedProjectRemoteToolSourceProjectSwitchHandler,
 ): RemoteToolSource {
-  const prepareToolInput = prepareVeryfrontApiToolInput({
-    server,
-    getEndUserId: input.getEndUserId,
-    prepareToolInput: input.prepareToolInput,
-  });
-
   return createHostedProjectRemoteToolSource({
     source,
     ...(input.defaultProjectId !== undefined ? { defaultProjectId: input.defaultProjectId } : {}),
@@ -272,7 +238,7 @@ function createHostedProjectRemoteToolSourceFromConfig(
           }),
       }
       : {}),
-    ...(prepareToolInput !== undefined ? { prepareToolInput } : {}),
+    ...(input.prepareToolInput !== undefined ? { prepareToolInput: input.prepareToolInput } : {}),
     ...(input.retryToolName !== undefined ? { retryToolName: input.retryToolName } : {}),
     ...(input.shouldRetryWithTool !== undefined
       ? { shouldRetryWithTool: input.shouldRetryWithTool }

--- a/src/integrations/remote-tools.test.ts
+++ b/src/integrations/remote-tools.test.ts
@@ -64,6 +64,13 @@ describe("integrations/remote-tools", () => {
     assertEquals(source.includes('typeof contextOrEndUserId === "string"'), false);
   });
 
+  it("does not keep legacy OAuth caller identity URL sanitizers in live remote tools", async () => {
+    const source = await Deno.readTextFile("src/integrations/remote-tools.ts");
+    const legacyCallerIdentityParam = ["end", "User", "Id"].join("");
+
+    assertEquals(source.includes(legacyCallerIdentityParam), false);
+  });
+
   it("skips remote tool discovery when API configuration is missing", async () => {
     setRemoteToolEnv({});
 
@@ -213,7 +220,7 @@ describe("integrations/remote-tools", () => {
         structuredContent: {
           error: "authentication_required",
           integration: "linear",
-          connectUrl: "/oauth/connect/linear?projectId=project-1&endUserId=user-1",
+          connectUrl: "/oauth/connect/linear?projectId=project-1",
           message: "Authentication required for Linear.",
         },
       }), async () => await executeRemoteIntegrationTool("linear__search_issues", { query: "*" }));
@@ -226,7 +233,7 @@ describe("integrations/remote-tools", () => {
     });
   });
 
-  it("preserves protocol-relative auth URL authority when stripping legacy end-user identity", async () => {
+  it("preserves protocol-relative auth URL authority from structured tool results", async () => {
     setRemoteToolEnv({
       VERYFRONT_API_BASE_URL: "https://api.test",
       VERYFRONT_API_TOKEN: "env-token",
@@ -237,8 +244,7 @@ describe("integrations/remote-tools", () => {
         content: [],
         structuredContent: {
           error: "authentication_required",
-          connectUrl:
-            "//auth.example.com/oauth/connect/github?projectId=project-1&endUserId=user-1",
+          connectUrl: "//auth.example.com/oauth/connect/github?projectId=project-1",
         },
       }), async () => await executeRemoteIntegrationTool("github__list_repos", {}));
 

--- a/src/integrations/remote-tools.ts
+++ b/src/integrations/remote-tools.ts
@@ -76,44 +76,6 @@ function parseJsonText(text: string): unknown | undefined {
   }
 }
 
-function stripLegacyEndUserIdFromConnectUrl(connectUrl: string): string {
-  try {
-    const isAbsolute = /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(connectUrl);
-    const isProtocolRelative = connectUrl.startsWith("//");
-    const isRootRelative = connectUrl.startsWith("/") && !isProtocolRelative;
-    const url = new URL(connectUrl, "https://veryfront.invalid");
-
-    if (!url.searchParams.has("endUserId")) return connectUrl;
-
-    url.searchParams.delete("endUserId");
-
-    if (isAbsolute) return url.toString();
-    if (isProtocolRelative) return `//${url.host}${url.pathname}${url.search}${url.hash}`;
-
-    const relativeUrl = `${url.pathname}${url.search}${url.hash}`;
-    return isRootRelative ? relativeUrl : relativeUrl.slice(1);
-  } catch {
-    return connectUrl;
-  }
-}
-
-function stripLegacyEndUserIdFromToolResult(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(stripLegacyEndUserIdFromToolResult);
-  }
-
-  if (!value || typeof value !== "object") return value;
-
-  return Object.fromEntries(
-    Object.entries(value).map(([key, entry]) => [
-      key,
-      key === "connectUrl" && typeof entry === "string"
-        ? stripLegacyEndUserIdFromConnectUrl(entry)
-        : stripLegacyEndUserIdFromToolResult(entry),
-    ]),
-  );
-}
-
 async function fetchToolList(
   baseUrl: string,
   token: string,
@@ -170,20 +132,20 @@ async function callRemoteTool(
     const text = joinCallToolText(result.content as CallToolTextContent[]);
 
     if (result.structuredContent) {
-      return stripLegacyEndUserIdFromToolResult(result.structuredContent);
+      return result.structuredContent;
     }
 
     if (result.isError) {
       // Try to preserve structured error data (e.g., authentication_required with connectUrl)
       const parsed = parseJsonText(text);
-      if (parsed && typeof parsed === "object") return stripLegacyEndUserIdFromToolResult(parsed);
+      if (parsed && typeof parsed === "object") return parsed;
       return { error: "tool_error", message: text };
     }
 
     return parseJsonText(text) ?? text;
   }
 
-  return stripLegacyEndUserIdFromToolResult(result);
+  return result;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove live remote OAuth connect URL identity sanitizing
- remove hosted remote tool source end-user identity compatibility plumbing
- keep source guards so legacy identity parameters stay out of production remote-tool code

## Test plan
- RED: source guard failed on legacy remote OAuth sanitizer and hosted getEndUserId/end_user_id plumbing
- GREEN: deno task test src/agent/hosted/project-remote-tool-source.test.ts src/integrations/remote-tools.test.ts
- deno task verify:quick
- pre-push checks: format, lint, typecheck, unit tests