### PR TITLE
Make getting started docs streaming-first

### DIFF
--- a/docs/getting-started/create-agent.md
+++ b/docs/getting-started/create-agent.md
@@ -1,18 +1,15 @@
 ---
 title: "Create agent"
-description: "Define an AI agent and invoke it from server code in under five minutes."
+description: "Define an AI agent and stream its response in under five minutes."
 order: 4
 ---
 
-Define an agent in a Veryfront project. Send it a message and stream the
-response. For tools, memory, skills, and hosted runs, see
-[Agents](../guides/agents.md).
+Define one agent and expose it through a streaming chat endpoint.
 
 ## Prerequisites
 
 - [Veryfront installed](./installation.md) and a project created with
-  [Create project](./create-project.md). The `ai-agent` template gives you the
-  file layout below.
+  [Create project](./create-project.md).
 - An `agents/` directory in the project root. If you started from the `minimal`
   template, create one: `mkdir agents`.
 - A provider configured for inference. Set `OPENAI_API_KEY` or
@@ -33,23 +30,7 @@ export default agent({
 });
 ```
 
-The file name becomes the agent id. Veryfront discovers files under `agents/` at
-startup.
-
-For a one-shot persona without TypeScript, you can write the same agent as
-`agents/assistant.md`:
-
-```md
----
-name: Assistant
-description: Concise general-purpose assistant
----
-
-You are a concise assistant. Answer in one short paragraph.
-```
-
-Both forms register the same `assistant` id and are interchangeable from the
-call sites below.
+The file name becomes the agent id unless the agent config sets another `id`.
 
 ## Invoke the agent
 
@@ -63,29 +44,11 @@ export const POST = createAgUiHandler("assistant");
 ```
 
 The handler validates the request, runs the agent, and returns an AG-UI SSE
-response. Pair it with `useChat({ api: "/api/ag-ui" })` in a React client. See
-[Chat UI](../guides/chat-ui.md).
+response. Pair it with `useChat({ api: "/api/ag-ui" })` in a React client.
 
-For a buffered JSON response (cron jobs, batch calls, unit tests), resolve the
-agent yourself and call `generate`:
-
-```ts
-// app/api/ask/route.ts
-import { getAgent } from "veryfront/agent";
-
-export async function POST(request: Request) {
-  const { question } = await request.json();
-  const assistant = getAgent("assistant");
-
-  const result = await assistant.generate({ input: question });
-  return Response.json({ answer: result.text, usage: result.usage });
-}
-```
-
-App-router handlers receive the raw `Request`. Pages-router handlers live under
-`pages/api/` and receive an `APIContext`. See
-[API routes](../guides/api-routes.md). For non-chat streaming, see
-[Memory and streaming](../guides/memory-and-streaming.md).
+Use `agent.generate()` only for non-interactive work such as cron jobs, batch
+calls, and focused tests. See [Agents](../guides/agents.md#non-streaming-response).
+For non-chat streaming, see [Memory and streaming](../guides/memory-and-streaming.md).
 
 ## Run it
 
@@ -106,9 +69,8 @@ curl -N -X POST http://localhost:3000/api/ag-ui \
 
 ## Verify it worked
 
-The response is an AG-UI SSE stream. `data:` lines arrive progressively. A
-`message-start` event opens the run, text deltas stream the reply, and a
-`message-finish` event closes the message.
+The response is an AG-UI SSE stream. `data:` lines arrive progressively between
+`message-start` and `message-finish` events.
 
 If the whole body lands at once after a delay, curl or a TLS proxy may be
 buffering. Run the same request without `-N` to confirm.
@@ -118,8 +80,7 @@ set in the shell running `veryfront dev`.
 
 ## Next
 
-- [Agents](../guides/agents.md): tools, dynamic system prompts, memory, AG-UI
-  handlers, and hosted runs.
+- [Agents](../guides/agents.md): tools, prompts, memory, and hosted runs.
 - [Tools](../guides/tools.md): let the agent call typed functions.
 - [Chat UI](../guides/chat-ui.md): drop a streaming chat interface into a React
   page that talks to this agent.

--- a/docs/getting-started/create-api.md
+++ b/docs/getting-started/create-api.md
@@ -4,9 +4,7 @@ description: "Add an HTTP endpoint to a Veryfront project with a typed Request a
 order: 5
 ---
 
-Add an HTTP endpoint to a Veryfront project. This is the fourth step in the
-Getting Started flow, between [Create agent](./create-agent.md) and
-[Create frontend](./create-frontend.md).
+Add one HTTP endpoint to a Veryfront project.
 
 ## Prerequisites
 
@@ -24,9 +22,8 @@ export function GET() {
 }
 ```
 
-The file path maps to the URL. `app/api/hello/route.ts` exposes
-`GET /api/hello`. Named exports define the allowed HTTP methods. Each handler
-receives a `Request` and returns a `Response`.
+`app/api/hello/route.ts` maps to `GET /api/hello`. Named exports define the
+allowed HTTP methods.
 
 ## Try it
 
@@ -62,23 +59,18 @@ curl -X POST http://localhost:3000/api/echo \
 
 ## Verify it worked
 
-Each route file you add produces an endpoint at the matching URL. Hit it with
-`curl` and confirm:
+Confirm with `curl`:
 
-- 200 OK with the expected JSON body for the methods you exported.
-- 404 if the file path does not match the URL.
-- 405 if you call a method that has no exported handler in the file.
+- `GET /api/hello` returns the JSON body above.
+- Unknown paths return 404.
+- Methods without an export return 405.
 
 ## Next
 
-- [Create frontend](./create-frontend.md): add a page that calls this endpoint
+- [Create frontend](./create-frontend.md): add a page
 - [Deploy project](./deploy-project.md): ship the project to production
 
 ## Related
 
-- [API routes](../guides/api-routes.md): full surface (request parsing,
-  streaming, dynamic params, pages-router shape)
-- [Middleware](../guides/middleware.md): add CORS, rate limiting, logging, and
-  auth checks
-- [Agents](../guides/agents.md): wire an agent behind an API route with
-  `createAgUiHandler`
+- [API routes](../guides/api-routes.md): route patterns and streaming
+- [Middleware](../guides/middleware.md): CORS, rate limiting, logging, and auth

--- a/docs/getting-started/create-frontend.md
+++ b/docs/getting-started/create-frontend.md
@@ -4,9 +4,7 @@ description: "Add a page and a navigation link to a Veryfront project."
 order: 6
 ---
 
-Add a page to your Veryfront project and link to it from the home page. This is
-the fifth step in the Getting Started flow, between
-[Create API](./create-api.md) and [Deploy project](./deploy-project.md).
+Add one page and link to it from the home page.
 
 ## Prerequisites
 
@@ -29,9 +27,8 @@ export default function About() {
 }
 ```
 
-The file path maps to the URL. `app/about/page.tsx` is served at `/about`. The
-default export is the React component for the page. Add `"use client"` at the
-top of a file when it needs browser interactivity.
+`app/about/page.tsx` maps to `/about`. The default export is the page component.
+Add `"use client"` only when the page needs browser interactivity.
 
 Open [http://localhost:3000/about](http://localhost:3000/about). The page
 renders.
@@ -56,8 +53,7 @@ export default function Home() {
 }
 ```
 
-`Link` from `veryfront/router` performs client-side navigation. The browser does
-not reload the page when the user selects the link.
+`Link` from `veryfront/router` navigates without a full page reload.
 
 ## Verify it worked
 
@@ -68,13 +64,11 @@ not reload the page when the user selects the link.
 
 ## Next
 
-- [Deploy project](./deploy-project.md): ship the project to production
-- [Create agent](./create-agent.md): wire an AI agent into the project
+- [Deploy project](./deploy-project.md): ship the project
+- [Create agent](./create-agent.md): add an AI agent
 
 ## Related
 
-- [Pages and routing](../guides/pages-and-routing.md): full surface (layouts,
-  dynamic routes, MDX, navigation hooks)
-- [Head and SEO](../guides/head-and-seo.md): set page metadata, Open Graph tags,
-  and structured data
-- [Chat UI](../guides/chat-ui.md): drop a streaming chat interface into a page
+- [Pages and routing](../guides/pages-and-routing.md): layouts, dynamic routes,
+  MDX, and navigation hooks
+- [Head and SEO](../guides/head-and-seo.md): metadata and structured data

--- a/docs/getting-started/create-project.md
+++ b/docs/getting-started/create-project.md
@@ -4,9 +4,7 @@ description: "Scaffold a new Veryfront project from a template and run it locall
 order: 3
 ---
 
-Scaffold a new Veryfront project from a template, then run it locally on the dev
-server. This is the second step in the Getting Started flow, between
-[Installation](./installation.md) and [Create agent](./create-agent.md).
+Scaffold one Veryfront project and start the dev server.
 
 ## Prerequisites
 
@@ -20,9 +18,8 @@ veryfront init test-app
 cd test-app
 ```
 
-The CLI asks which template to use. Choose `minimal` for a blank app or
-`ai-agent` when you want an agent and chat route in the scaffold. To skip the
-prompt, pass `--template`:
+Choose `minimal` for a blank app or `ai-agent` for an agent and chat route. Pass
+`--template` to skip the prompt:
 
 ```bash
 veryfront init test-app --template ai-agent
@@ -34,12 +31,12 @@ veryfront init test-app --template ai-agent
 veryfront dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000). Changes to any file reload
-instantly.
+Open [http://localhost:3000](http://localhost:3000). File changes reload the
+browser.
 
 ## Inspect the scaffold
 
-After `init` with the `minimal` template, your project looks like this:
+The `minimal` template creates:
 
 ```
 test-app/
@@ -52,7 +49,7 @@ test-app/
   README.md
 ```
 
-If you picked the `ai-agent` template, you also get:
+The `ai-agent` template also creates:
 
 ```
 test-app/
@@ -69,26 +66,21 @@ test-app/
 ```
 
 Pages live in `app/`. The agent template also adds root-level `agents/` and
-`tools/` directories. For the convention behind these directories, see
+`tools/`. For the convention behind these directories, see
 [Project conventions](../concepts/project-conventions.md).
 
 ## Verify it worked
 
-`veryfront dev` prints `Ready on http://localhost:3000`. Open the URL: the
-template's home page should render, and saving any source file should hot-reload
-the browser within a second.
+`veryfront dev` prints `Ready on http://localhost:3000`. Open the URL and save a
+source file. The browser should hot-reload.
 
 ## Next
 
-- [Create agent](./create-agent.md): define an agent and expose it as a
-  streaming chat endpoint
+- [Create agent](./create-agent.md): define a streaming agent
 - [Create API](./create-api.md): add an HTTP endpoint to the project
 - [Create frontend](./create-frontend.md): add a new page
 
 ## Related
 
-- [Project structure](../guides/project-structure.md): the file conventions used
-  by `veryfront init`
-- [Configuration](../guides/configuration.md): customize `veryfront.config.ts`
-- [Coding agents](../guides/coding-agents.md): drive the project from Claude
-  Code, Cursor, or Codex
+- [Project structure](../guides/project-structure.md): file conventions
+- [Configuration](../guides/configuration.md): runtime and build options

--- a/docs/getting-started/deploy-project.md
+++ b/docs/getting-started/deploy-project.md
@@ -4,8 +4,7 @@ description: "Build a Veryfront project for production and ship it to Veryfront 
 order: 7
 ---
 
-Build a Veryfront project for production and ship it. This is the final step in
-the Getting Started flow.
+Build a Veryfront project and ship it.
 
 ## Prerequisites
 
@@ -25,8 +24,7 @@ Create a production build:
 veryfront build
 ```
 
-This compiles pages, bundles assets, pre-renders static routes, and writes the
-output to `dist/`.
+This writes the production output to `dist/`.
 
 ## Run the production build locally
 
@@ -37,7 +35,7 @@ veryfront start
 ```
 
 Open [http://localhost:3000](http://localhost:3000). Confirm the same pages and
-endpoints that worked in dev also work here.
+endpoints work.
 
 ## Deploy to Veryfront Cloud
 
@@ -45,42 +43,33 @@ endpoints that worked in dev also work here.
 veryfront deploy
 ```
 
-Use `veryfront open` to open the deployed project in a browser.
-
 For a preview deployment per branch:
 
 ```bash
 veryfront deploy --branch feature-x
 ```
 
-Use `veryfront open --branch feature-x` to open the preview.
-
 ## Deploy somewhere else
 
 For a non-Cloud target, run `veryfront build` and ship the `dist/` output. See
-[Building and deploying](../guides/deploying.md) for Docker and static export.
+[Building and deploying](../guides/deploying.md).
 
 ## Verify it worked
 
-After `veryfront deploy`:
+After `veryfront deploy`, run:
 
-- The CLI confirms the deployed release and environment.
-- `veryfront open` opens the deployed project in a browser.
-- Use `veryfront open --json` when you need the deployed URL in a script.
-- The home page and any API routes respond on the deployed host.
-- The Veryfront Cloud dashboard lists the new deployment under the project.
+```bash
+veryfront open
+```
+
+The deployed page and API routes should respond.
 
 ## Next
 
-- [Configuration](../guides/configuration.md): set runtime and build options
-- [Building and deploying](../guides/deploying.md): production-build internals,
-  static export, Docker
+- [Configuration](../guides/configuration.md): runtime and build options
+- [Building and deploying](../guides/deploying.md): static export and Docker
 
 ## Related
 
-- [`veryfront` (root)](../api-reference/veryfront/index.md): `defineConfig`,
-  build options
+- [`veryfront` (root)](../api-reference/veryfront/index.md): build options
 - [`veryfront/server`](../api-reference/veryfront/server.md): production server
-  APIs
-- [`veryfront/observability`](../api-reference/veryfront/observability.md):
-  tracing, metrics, runtime logs

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -5,9 +5,8 @@ description: "Guided onboarding for installing Veryfront Code, creating a projec
 order: 0
 ---
 
-Getting Started is the guided onboarding path for Veryfront Code. Use these
-pages when you are installing the framework, creating a first project, or
-building the first working pieces of an app.
+Use these pages to install Veryfront Code, create a project, and build the first
+working pieces of an app.
 
 ## Contents
 
@@ -23,18 +22,16 @@ building the first working pieces of an app.
 
 ## Before you start
 
-These pages assume you are comfortable with:
+You should know the basics of:
 
 - TypeScript - syntax and basic types.
 - React - components, props, and hooks.
 - A JavaScript runtime - Node.js, Deno, or Bun.
 - A terminal - running `npm`, `deno`, or shell commands.
 
-You do not need prior experience with AI agents, model providers, or the Model
-Context Protocol. The guides introduce each concept where it first comes up.
+You do not need prior AI agent or MCP experience.
 
 ## Next
 
-Start with [Quickstart](./quickstart.md) when you want the fastest end-to-end
-path. Start with [Installation](./installation.md) when you want the guided path
-one step at a time.
+Use [Quickstart](./quickstart.md) for the fastest path. Use
+[Installation](./installation.md) for the step-by-step path.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,17 +4,11 @@ description: "Install the Veryfront CLI and framework on macOS, Linux, or Window
 order: 2
 ---
 
-Install the `veryfront` CLI and framework so you can scaffold, run, and build
-Veryfront projects.
-
-The install methods below all produce the same `veryfront` CLI; pick the one
-that matches your toolchain. Once installed, continue with
-[Create project](./create-project.md).
+Install the `veryfront` CLI and framework.
 
 ## System requirements
 
-Veryfront ships as a standalone binary and as an npm package. Pick the rows that
-match how you plan to install it.
+Veryfront ships as a standalone binary and as an npm package.
 
 ### Operating system
 
@@ -26,11 +20,11 @@ match how you plan to install it.
 
 ### Runtime
 
-| Runtime | Minimum version | Notes                                                 |
-| ------- | --------------- | ----------------------------------------------------- |
-| Node.js | 18.18           | Required for `npm`, `npx`, and the framework runtime. |
-| Deno    | 1.45            | Optional; supports running the framework directly.    |
-| Bun     | 1.1             | Optional; supports running the framework directly.    |
+| Runtime | Minimum version | Notes                                      |
+| ------- | --------------- | ------------------------------------------ |
+| Node.js | 18.18           | Required for `npm`, `npx`, and app builds. |
+| Deno    | 1.45            | Optional direct runtime.                   |
+| Bun     | 1.1             | Optional direct runtime.                   |
 
 ### Hardware
 
@@ -40,9 +34,8 @@ match how you plan to install it.
 
 ## Supported browsers
 
-Veryfront renders React Server Components and ships modern ES2022 client
-bundles. The built-in chat UI, router, and head components are tested against
-the latest two stable releases of:
+Veryfront tests the built-in chat UI, router, and head components against the
+latest two stable releases of:
 
 - Chrome and Chromium-based browsers (Edge, Brave, Arc, Opera)
 - Firefox
@@ -52,8 +45,7 @@ Older browsers may work but are not part of the supported matrix.
 
 ## Install
 
-The tabs below give you the one-liner for each method; the sections that follow
-add detail and version-pinning options.
+Pick the command that matches your toolchain.
 
 <CodeGroup>
 
@@ -86,7 +78,6 @@ curl -fsSL https://veryfront.com/install.sh | sh
 ```
 
 Installs the latest standalone binary to `~/.veryfront/bin/veryfront`.
-Recommended for macOS and Linux when you mainly use the CLI and TUI.
 
 Pin a version or change the install directory:
 
@@ -101,8 +92,7 @@ irm https://veryfront.com/install.ps1 | iex
 ```
 
 Installs the latest standalone binary to
-`%USERPROFILE%\.veryfront\bin\veryfront.exe`. Supports Windows 10 or later on
-`x86_64` and `arm64`.
+`%USERPROFILE%\.veryfront\bin\veryfront.exe`.
 
 Pin a version or change the install directory:
 
@@ -116,8 +106,7 @@ Pin a version or change the install directory:
 brew install veryfront/tap/veryfront
 ```
 
-Same binary as the curl installer, managed by Homebrew. Works on macOS and
-Linux.
+Same binary as the curl installer, managed by Homebrew.
 
 ### npm (project scaffolder)
 
@@ -125,8 +114,7 @@ Linux.
 npm create veryfront
 ```
 
-Creates a new project using `create-veryfront`. The same command works with the
-other Node-compatible package managers:
+Creates a new project using `create-veryfront`. Other package managers:
 
 ```bash
 pnpm create veryfront
@@ -141,8 +129,7 @@ deno init --npm veryfront
 npx veryfront
 ```
 
-Runs the latest `veryfront` CLI without installing it globally. Useful for
-trying commands or one-off scripts in CI.
+Runs the latest `veryfront` CLI without installing it globally.
 
 ## Verify it worked
 
@@ -150,11 +137,8 @@ trying commands or one-off scripts in CI.
 veryfront --version
 ```
 
-You should see the installed version printed. If the command is not found after
-a fresh install, restart your shell so the new `PATH` entry takes effect.
-
-On Windows, run the same command in PowerShell or in a new terminal session so
-the updated `PATH` is picked up.
+You should see the installed version printed. If the command is not found,
+restart your shell so the new `PATH` entry takes effect.
 
 ## Next
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,11 +1,11 @@
 ---
 title: "Quickstart"
-description: "Build and run a Veryfront agent app with a tool, chat UI, and deploy path."
+description: "Scaffold, run, and test a streaming Veryfront agent app."
 order: -1
 ---
 
-Build a small agent app that can call a typed tool, stream through the chat UI,
-and follow the same deploy path as a production project.
+Scaffold a working agent app, run it locally, and confirm that responses stream.
+Use this path for the fastest first result.
 
 ## Prerequisites
 
@@ -14,14 +14,14 @@ and follow the same deploy path as a production project.
 - A model provider key for local inference. Use a placeholder in examples and
   put the real value in your local `.env` file.
 
-## Create project
+## Create the app
 
 ```bash
 veryfront init support-agent --template ai-agent
 cd support-agent
 ```
 
-The `ai-agent` template creates the three surfaces used in this guide:
+The `ai-agent` template creates a runnable chat app:
 
 ```text
 support-agent/
@@ -36,93 +36,17 @@ support-agent/
         route.ts
 ```
 
-Project primitives such as `agents/`, `tools/`, `skills/`, `workflows/`,
-`prompts/`, and `resources/` live at the project root. They are not placed
-inside `app/`.
+The template includes the agent, calculator tool, chat page, and AG-UI route.
 
 ## Configure a provider
 
-Create `.env` with the provider key you use locally:
+Create `.env`:
 
 ```bash
 OPENAI_API_KEY=<API_KEY>
 ```
 
-Veryfront picks a matching provider automatically. For direct vendor routing,
-local models, or Veryfront Cloud routing, see
-[Providers](../guides/providers.md).
-
-## Add a tool
-
-Create `tools/get-weather.ts`:
-
-```ts
-import { tool } from "veryfront/tool";
-import { z } from "zod";
-
-export default tool({
-  description: "Get the current weather for a city",
-  inputSchema: z.object({
-    city: z.string().describe("City name"),
-    units: z.enum(["celsius", "fahrenheit"]).default("celsius")
-      .describe("Temperature unit"),
-  }),
-  execute: async ({ city, units }) => {
-    const temperature = units === "fahrenheit" ? 72 : 22;
-    return { city, units, temperature, conditions: "sunny" };
-  },
-});
-```
-
-The filename provides the discovered tool id. In agent config, reference the
-tool as `getWeather`.
-
-## Add an agent
-
-Update `agents/assistant.ts`:
-
-```ts
-import { agent } from "veryfront/agent";
-
-export default agent({
-  id: "assistant",
-  system: "You are a concise support assistant. Use tools when they help.",
-  tools: { getWeather: true },
-  maxSteps: 5,
-});
-```
-
-`maxSteps` is required when an agent uses tools. It gives the model enough turns
-to call the tool, receive the result, and produce the final answer.
-
-## Expose the chat route
-
-Create or confirm `app/api/ag-ui/route.ts`:
-
-```ts
-import { createAgUiHandler } from "veryfront/agent";
-
-export const POST = createAgUiHandler("assistant");
-```
-
-The route returns an AG-UI Server-Sent Events stream for browser chat clients.
-
-## Render chat
-
-Create or confirm `app/page.tsx`:
-
-```tsx
-"use client";
-
-import { Chat, useChat } from "veryfront/chat";
-
-export default function Page() {
-  const chat = useChat({ api: "/api/ag-ui" });
-  return <Chat {...chat} placeholder="Ask about weather or your project" />;
-}
-```
-
-`"use client"` is required because `useChat` is a React hook.
+For local models or explicit provider routing, see [Providers](../guides/providers.md).
 
 ## Run it locally
 
@@ -133,7 +57,7 @@ veryfront dev
 Open `http://localhost:3000` and ask:
 
 ```text
-What is the weather in Tokyo in celsius?
+What is 128 divided by 8?
 ```
 
 To test the route without the UI:
@@ -141,20 +65,19 @@ To test the route without the UI:
 ```bash
 curl -N -X POST http://localhost:3000/api/ag-ui \
   -H "Content-Type: application/json" \
-  -d '{"messages":[{"id":"1","role":"user","parts":[{"type":"text","text":"What is the weather in Tokyo in celsius?"}]}]}'
+  -d '{"messages":[{"id":"1","role":"user","parts":[{"type":"text","text":"What is 128 divided by 8?"}]}]}'
 ```
 
 ## Verify it worked
 
-The browser should show a streamed assistant response that uses the weather tool
-result. The curl response should emit `data:` lines, including a start event,
-text deltas, and a finish event.
+The browser should show a streamed assistant response that uses the calculator
+tool. The curl response should emit `data:` lines as the answer is produced.
 
 If the route returns `Agent not found`, ensure `agents/assistant.ts` is in the
-project root. If the model answers without using the tool, ensure the agent has
-both `tools: { getWeather: true }` and `maxSteps`.
+project root. If the model skips the tool, ensure `tools: true` and `maxSteps`
+are still set in `agents/assistant.ts`.
 
-## Deploy
+## Build
 
 Build the project before deploying:
 
@@ -162,25 +85,14 @@ Build the project before deploying:
 veryfront build
 ```
 
-Create a release from Veryfront Studio or deploy through the CLI when your
-project is connected:
-
-```bash
-veryfront deploy
-```
-
-Preview environments update from Studio saves. Production deployments are
-created through the release flow.
-
 ## Next
 
-- [Agents](../guides/agents.md): add memory, skills, dynamic system prompts, and
-  hosted runs.
-- [Tools](../guides/tools.md): write production tool contracts and error
-  handling.
-- [Chat UI](../guides/chat-ui.md): customize the preset chat component.
-- [Deploy project](./deploy-project.md): ship and verify a production
-  deployment.
+- [Create project](./create-project.md): scaffold a project and inspect the file
+  layout.
+- [Create agent](./create-agent.md): define an agent and expose a streaming
+  chat endpoint yourself.
+- [Create API](./create-api.md): add a first HTTP endpoint.
+- [Deploy project](./deploy-project.md): ship and verify a production deploy.
 
 ## Related
 

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -525,7 +525,7 @@ describe("Guide: project-structure.md", () => {
 });
 
 describe("Guide: create-agent.md", () => {
-  it("uses the public AG-UI handler and agent.generate paths", async () => {
+  it("uses the public AG-UI handler and keeps generate as a non-interactive note", async () => {
     const guide = await readGuide("create-agent.md");
 
     for (
@@ -535,15 +535,22 @@ describe("Guide: create-agent.md", () => {
         'id: "assistant"',
         'import { createAgUiHandler } from "veryfront/agent"',
         'export const POST = createAgUiHandler("assistant")',
-        'import { getAgent } from "veryfront/agent"',
-        "export async function POST(request: Request)",
-        "const { question } = await request.json()",
-        'const assistant = getAgent("assistant")',
-        "await assistant.generate({ input: question })",
-        "Response.json({ answer: result.text",
+        "Use `agent.generate()` only for non-interactive work",
+        "curl -N -X POST",
+        "data:` lines arrive progressively",
       ]
     ) {
       assertStringIncludes(guide, snippet);
+    }
+
+    for (
+      const snippet of [
+        'import { getAgent } from "veryfront/agent"',
+        'const assistant = getAgent("assistant")',
+        "await assistant.generate({ input: question })",
+      ]
+    ) {
+      assertEquals(guide.includes(snippet), false);
     }
   });
 

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -150,9 +150,9 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     references: [
       "./installation.md",
       "../guides/providers.md",
-      "../guides/agents.md",
-      "../guides/tools.md",
-      "../guides/chat-ui.md",
+      "./create-project.md",
+      "./create-agent.md",
+      "./create-api.md",
       "./deploy-project.md",
       "../api-reference/veryfront/agent.md",
       "../api-reference/veryfront/tool.md",
@@ -160,13 +160,12 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     ],
     snippets: [
       "veryfront init support-agent --template ai-agent",
-      "tools/get-weather.ts",
-      "tools: { getWeather: true }",
-      "maxSteps: 5",
-      'createAgUiHandler("assistant")',
-      'useChat({ api: "/api/ag-ui" })',
+      "calculator.ts",
+      "What is 128 divided by 8?",
+      "curl -N -X POST",
+      "tools: true",
+      "maxSteps",
       "veryfront build",
-      "veryfront deploy",
     ],
   },
   "guides/configuration.md": {
@@ -223,7 +222,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     references: [],
     snippets: [
       "Veryfront Code",
-      "Getting Started",
+      "Getting started",
       "Contents",
       "Before you start",
       "Installation",
@@ -401,7 +400,6 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
   "getting-started/create-agent.md": {
     references: [
       "../guides/agents.md",
-      "../guides/api-routes.md",
       "../guides/tools.md",
       "../guides/chat-ui.md",
       "./installation.md",
@@ -413,8 +411,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "agents/assistant.ts",
       'import { agent } from "veryfront/agent"',
       'createAgUiHandler("assistant")',
-      'getAgent("assistant")',
-      "assistant.generate({ input: question })",
+      "Use `agent.generate()` only",
       "curl -N -X POST",
       "/api/ag-ui",
       "message-start",


### PR DESCRIPTION
## Summary
- make Getting Started source docs more Diataxis-focused and less repetitive
- make Quickstart a template-first smoke test instead of duplicating later pages
- make Create agent streaming-first with AG-UI and keep generate as a non-interactive note
- update docs contracts for the new source structure

## Verification
- deno task docs:validate
- pre-push checks: format, lint, typecheck, unit tests