### PR TITLE
Simplify Code docs next actions

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -23,6 +23,4 @@ framework pieces relate.
 
 ## Next
 
-Start with [Veryfront Code](./veryfront-code.md) for the product model, or
-[Runtime primitives](./runtime-primitives.md) when you are deciding which
-Veryfront concept owns a piece of work.
+Continue with [Veryfront Code](./veryfront-code.md).

--- a/docs/getting-started/create-agent.md
+++ b/docs/getting-started/create-agent.md
@@ -4,8 +4,6 @@ description: "Define an AI agent and stream its response in under five minutes."
 order: 4
 ---
 
-Define one agent and expose it through a streaming chat endpoint.
-
 ## Prerequisites
 
 - [Veryfront installed](./installation.md) and a project created with
@@ -80,7 +78,4 @@ set in the shell running `veryfront dev`.
 
 ## Next
 
-- [Agents](../guides/agents.md): tools, prompts, memory, and hosted runs.
-- [Tools](../guides/tools.md): let the agent call typed functions.
-- [Chat UI](../guides/chat-ui.md): drop a streaming chat interface into a React
-  page that talks to this agent.
+Continue with [Create API](./create-api.md).

--- a/docs/getting-started/create-api.md
+++ b/docs/getting-started/create-api.md
@@ -4,8 +4,6 @@ description: "Add an HTTP endpoint to a Veryfront project with a typed Request a
 order: 5
 ---
 
-Add one HTTP endpoint to a Veryfront project.
-
 ## Prerequisites
 
 - A project created with [Create project](./create-project.md).
@@ -67,8 +65,7 @@ Confirm with `curl`:
 
 ## Next
 
-- [Create frontend](./create-frontend.md): add a page
-- [Deploy project](./deploy-project.md): ship the project to production
+Continue with [Create frontend](./create-frontend.md).
 
 ## Related
 

--- a/docs/getting-started/create-frontend.md
+++ b/docs/getting-started/create-frontend.md
@@ -4,8 +4,6 @@ description: "Add a page and a navigation link to a Veryfront project."
 order: 6
 ---
 
-Add one page and link to it from the home page.
-
 ## Prerequisites
 
 - A project created with [Create project](./create-project.md).
@@ -64,8 +62,7 @@ export default function Home() {
 
 ## Next
 
-- [Deploy project](./deploy-project.md): ship the project
-- [Create agent](./create-agent.md): add an AI agent
+Continue with [Deploy project](./deploy-project.md).
 
 ## Related
 

--- a/docs/getting-started/create-project.md
+++ b/docs/getting-started/create-project.md
@@ -4,8 +4,6 @@ description: "Scaffold a new Veryfront project from a template and run it locall
 order: 3
 ---
 
-Scaffold one Veryfront project and start the dev server.
-
 ## Prerequisites
 
 - The Veryfront CLI installed (see [Installation](./installation.md)).
@@ -76,9 +74,7 @@ source file. The browser should hot-reload.
 
 ## Next
 
-- [Create agent](./create-agent.md): define a streaming agent
-- [Create API](./create-api.md): add an HTTP endpoint to the project
-- [Create frontend](./create-frontend.md): add a new page
+Continue with [Create agent](./create-agent.md).
 
 ## Related
 

--- a/docs/getting-started/deploy-project.md
+++ b/docs/getting-started/deploy-project.md
@@ -4,8 +4,6 @@ description: "Build a Veryfront project for production and ship it to Veryfront 
 order: 7
 ---
 
-Build a Veryfront project and ship it.
-
 ## Prerequisites
 
 - A project that runs locally with `veryfront dev` (see
@@ -66,8 +64,7 @@ The deployed page and API routes should respond.
 
 ## Next
 
-- [Configuration](../guides/configuration.md): runtime and build options
-- [Building and deploying](../guides/deploying.md): static export and Docker
+Continue with [Building and deploying](../guides/deploying.md).
 
 ## Related
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,12 +1,20 @@
 ---
 title: "Getting started"
 sidebarTitle: "Overview"
-description: "Guided onboarding for installing Veryfront Code, creating a project, and building the first working pieces of an app."
+description: "Build and deploy your first Veryfront app."
 order: 0
 ---
 
-Use these pages to install Veryfront Code, create a project, and build the first
-working pieces of an app.
+## Before you start
+
+You should know the basics of:
+
+- TypeScript - syntax and basic types.
+- React - components, props, and hooks.
+- A JavaScript runtime - Node.js, Deno, or Bun.
+- A terminal - running `npm`, `deno`, or shell commands.
+
+You do not need prior AI agent or MCP experience.
 
 ## Contents
 
@@ -20,18 +28,6 @@ working pieces of an app.
 | [Create frontend](./create-frontend.md) | You need to add a page and navigation.      |
 | [Deploy project](./deploy-project.md)   | You need to build and ship the project.     |
 
-## Before you start
-
-You should know the basics of:
-
-- TypeScript - syntax and basic types.
-- React - components, props, and hooks.
-- A JavaScript runtime - Node.js, Deno, or Bun.
-- A terminal - running `npm`, `deno`, or shell commands.
-
-You do not need prior AI agent or MCP experience.
-
 ## Next
 
-Use [Quickstart](./quickstart.md) for the fastest path. Use
-[Installation](./installation.md) for the step-by-step path.
+Start with [Quickstart](./quickstart.md).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,8 +4,6 @@ description: "Install the Veryfront CLI and framework on macOS, Linux, or Window
 order: 2
 ---
 
-Install the `veryfront` CLI and framework.
-
 ## System requirements
 
 Veryfront ships as a standalone binary and as an npm package.
@@ -142,9 +140,4 @@ restart your shell so the new `PATH` entry takes effect.
 
 ## Next
 
-- [Create project](./create-project.md): create and run your first Veryfront
-  project in under two minutes.
-- [Project structure](../guides/project-structure.md): learn the conventions the
-  CLI scaffolds.
-- [Configuration](../guides/configuration.md): wire up environment variables and
-  runtime options.
+Continue with [Create project](./create-project.md).

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -4,9 +4,6 @@ description: "Scaffold, run, and test a streaming Veryfront agent app."
 order: -1
 ---
 
-Scaffold a working agent app, run it locally, and confirm that responses stream.
-Use this path for the fastest first result.
-
 ## Prerequisites
 
 - Node.js 18.18 or later.
@@ -87,12 +84,7 @@ veryfront build
 
 ## Next
 
-- [Create project](./create-project.md): scaffold a project and inspect the file
-  layout.
-- [Create agent](./create-agent.md): define an agent and expose a streaming
-  chat endpoint yourself.
-- [Create API](./create-api.md): add a first HTTP endpoint.
-- [Deploy project](./deploy-project.md): ship and verify a production deploy.
+Continue with [Create project](./create-project.md).
 
 ## Related
 

--- a/docs/guides/agent-service-runtime.md
+++ b/docs/guides/agent-service-runtime.md
@@ -185,9 +185,7 @@ service list after the first heartbeat
 
 ## Next
 
-- [Agents](./agents.md): define the agents the service discovers
-- [Tools](./tools.md): define tools the service can expose to agents
-- [MCP server](./mcp-server.md): expose tools, prompts, and resources over MCP
+Continue with [Agents](./agents.md).
 
 ## Related
 

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -238,10 +238,7 @@ with a `RunFinished` event.
 
 ## Next
 
-- [Agent service runtime](./agent-service-runtime.md): run agents as separate
-  services
-- [Tools](./tools.md): define the tools your agent calls
-- [Memory and streaming](./memory-and-streaming.md): add conversation memory
+Continue with [Tools](./tools.md).
 
 ## Related
 

--- a/docs/guides/api-routes.md
+++ b/docs/guides/api-routes.md
@@ -249,8 +249,7 @@ HTTP method handler is not exported.
 
 ## Next
 
-- [Agents](./agents.md): the agent behind the `/api/ag-ui` endpoint
-- [Middleware](./middleware.md): add CORS, rate limiting, and auth checks
+Continue with [Middleware](./middleware.md).
 
 ## Related
 

--- a/docs/guides/chat-composition.md
+++ b/docs/guides/chat-composition.md
@@ -91,8 +91,7 @@ Render your composed layout in a client page, run `veryfront dev`, and:
 
 ## Next
 
-- [Chat hooks](./chat-hooks.md): manage chat state without preset components
-- [Chat theming](./chat-theming.md): customize chat features and visuals
+Continue with [Chat hooks](./chat-hooks.md).
 
 ## Related
 

--- a/docs/guides/chat-hooks.md
+++ b/docs/guides/chat-hooks.md
@@ -110,8 +110,7 @@ your API and the dev-server log for handler errors.
 
 ## Next
 
-- [Chat theming](./chat-theming.md): customize chat features and visuals
-- [Workflows](./workflows.md): orchestrate multi-step AI execution
+Continue with [Chat theming](./chat-theming.md).
 
 ## Related
 

--- a/docs/guides/chat-theming.md
+++ b/docs/guides/chat-theming.md
@@ -91,8 +91,7 @@ After applying each option:
 
 ## Next
 
-- [Workflows](./workflows.md): orchestrate multi-step AI execution
-- [Multi-agent](./multi-agent.md): compose agents and delegation patterns
+Continue with [Workflows](./workflows.md).
 
 ## Related
 

--- a/docs/guides/chat-ui.md
+++ b/docs/guides/chat-ui.md
@@ -98,11 +98,7 @@ agent errors and confirm the AG-UI route is mounted at `/api/ag-ui`.
 
 ## Next
 
-- [Chat composition](./chat-composition.md): build a custom layout with
-  `Chat.Root` and child components
-- [Chat hooks](./chat-hooks.md): use `useChat`, `useAgent`, and `useCompletion`
-- [Chat theming](./chat-theming.md): customize themes, contexts, and visual
-  behavior
+Continue with [Chat composition](./chat-composition.md).
 
 ## Related
 

--- a/docs/guides/choose-a-primitive.md
+++ b/docs/guides/choose-a-primitive.md
@@ -60,11 +60,7 @@ Run the guide's example or validation command before adding another primitive.
 
 ## Next
 
-- [Create project](../getting-started/create-project.md): create a project
-- [Agents](./agents.md): define an agent
-- [Workflows](./workflows.md): orchestrate multi-step work
-- [Tasks](./tasks.md): define background task functions
-- [Jobs](./jobs.md): run durable background work
+Continue with [Create project](../getting-started/create-project.md).
 
 ## Related
 

--- a/docs/guides/cli-knowledge-ingestion.md
+++ b/docs/guides/cli-knowledge-ingestion.md
@@ -238,10 +238,7 @@ output for the reason.
 
 ## Next
 
-- [Sandbox](./sandbox.md): run CLI workflows inside isolated workspaces
-- [Agents](./agents.md): build agent workflows that can call tools and shell
-  commands
-- [Workflows](./workflows.md): orchestrate repeatable multi-step automation
+Continue with [Sandbox](./sandbox.md).
 
 ## Related
 

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -135,9 +135,7 @@ deno run -A cli/main.ts mcp
 
 ## Next
 
-- [MCP server](./mcp-server.md): expose _your_ app's tools, prompts, and resources to MCP clients
-- [Skills](./skills.md): give agents project-level instructions as `SKILL.md` files
-- [Create project](../getting-started/create-project.md): scaffold a project the agent can drive
+Continue with [MCP server](./mcp-server.md).
 
 ## Related
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -285,8 +285,7 @@ it once you have confirmed the value resolves.
 
 ## Next
 
-- [Building and deploying](./deploying.md): production builds and deployment
-- [Head and SEO](./head-and-seo.md): metadata and Open Graph tags
+Continue with [Building and deploying](./deploying.md).
 
 ## Related
 

--- a/docs/guides/data-fetching.md
+++ b/docs/guides/data-fetching.md
@@ -128,8 +128,7 @@ export default function Search() {
 
 ## Next
 
-- [API routes](./api-routes.md): create the endpoints your pages fetch from
-- [Agents](./agents.md): load AI-generated data server-side
+Continue with [API routes](./api-routes.md).
 
 ## Related
 

--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -128,8 +128,7 @@ After `veryfront deploy`:
 
 ## Next
 
-- [Head and SEO](./head-and-seo.md): optimize for search engines
-- [Configuration](./configuration.md): all configuration options
+Continue with [Head and SEO](./head-and-seo.md).
 
 ## Related
 

--- a/docs/guides/extension-authoring.md
+++ b/docs/guides/extension-authoring.md
@@ -123,8 +123,7 @@ For first-party extensions, also mirror the same `capabilities` array in `deno.j
 
 ## Next
 
-- [Extension lifecycle](./extension-lifecycle.md): understand discovery and loading
-- [Extension testing](./extension-testing.md): test factories and contracts
+Continue with [Extension lifecycle](./extension-lifecycle.md).
 
 ## Related
 

--- a/docs/guides/extension-lifecycle.md
+++ b/docs/guides/extension-lifecycle.md
@@ -81,8 +81,7 @@ Remove the temporary logs before publishing the extension.
 
 ## Next
 
-- [Extension testing](./extension-testing.md): test factories and contracts
-- [Extension publishing](./extension-publishing.md): package reusable extensions
+Continue with [Extension testing](./extension-testing.md).
 
 ## Related
 

--- a/docs/guides/extension-publishing.md
+++ b/docs/guides/extension-publishing.md
@@ -47,8 +47,7 @@ After publishing:
 
 ## Next
 
-- [Building and deploying](./deploying.md): production builds and deployment
-- [Configuration](./configuration.md): project configuration options
+Continue with [Building and deploying](./deploying.md).
 
 ## Related
 

--- a/docs/guides/extension-testing.md
+++ b/docs/guides/extension-testing.md
@@ -82,8 +82,7 @@ contract name (`"CacheStore"`) the consumer requests.
 
 ## Next
 
-- [Extension publishing](./extension-publishing.md): package reusable extensions
-- [Building and deploying](./deploying.md): production builds and deployment
+Continue with [Extension publishing](./extension-publishing.md).
 
 ## Related
 

--- a/docs/guides/extensions.md
+++ b/docs/guides/extensions.md
@@ -83,10 +83,7 @@ Restart `veryfront dev` after editing `veryfront.config.ts`:
 
 ## Next
 
-- [Extension authoring](./extension-authoring.md): write factories, contracts, and capabilities
-- [Extension lifecycle](./extension-lifecycle.md): understand discovery, ordering, presets, and teardown
-- [Extension testing](./extension-testing.md): test extension factories and contract implementations
-- [Extension publishing](./extension-publishing.md): publish reusable extension packages
+Continue with [Extension authoring](./extension-authoring.md).
 
 ## Related
 

--- a/docs/guides/head-and-seo.md
+++ b/docs/guides/head-and-seo.md
@@ -165,8 +165,7 @@ Open the page in the browser and inspect the document `<head>`. Confirm:
 
 ## Next
 
-- [Providers](./providers.md): wire up an LLM provider for AI pages
-- [API reference](../api-reference/index.md): full module reference
+Continue with [Providers](./providers.md).
 
 ## Related
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -23,6 +23,4 @@ Use this section when you already know the outcome you want.
 
 ## Next
 
-Start with [Configuration](./configuration.md) when you are preparing a project,
-or [Choose a primitive](./choose-a-primitive.md) when you need to decide which
-Veryfront surface owns the work.
+Continue with [Configuration](./configuration.md).

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -105,9 +105,7 @@ After enabling an integration:
 
 ## Next
 
-- [Sandbox](./sandbox.md): run isolated commands and file operations
-- [CLI-first knowledge ingestion](./cli-knowledge-ingestion.md): ingest
-  documents into project knowledge
+Continue with [Sandbox](./sandbox.md).
 
 ## Related
 

--- a/docs/guides/jobs.md
+++ b/docs/guides/jobs.md
@@ -217,8 +217,7 @@ the jobs panel.
 
 ## Next
 
-- [Tasks](./tasks.md): define background task functions
-- [MCP server](./mcp-server.md): expose job operations through MCP tools
+Continue with [Tasks](./tasks.md).
 
 ## Related
 

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -179,8 +179,7 @@ tool. Calling without the bearer token should return `401 Unauthorized`.
 
 ## Next
 
-- [Configuration](./configuration.md): framework configuration options
-- [Tools](./tools.md): define the tools MCP exposes
+Continue with [Tools](./tools.md).
 
 ## Related
 

--- a/docs/guides/memory-and-streaming.md
+++ b/docs/guides/memory-and-streaming.md
@@ -207,8 +207,7 @@ tokens arrive incrementally rather than in one chunk.
 
 ## Next
 
-- [Chat UI](./chat-ui.md): pre-built components for chat interfaces
-- [Workflows](./workflows.md): orchestrate multiple agents
+Continue with [Chat UI](./chat-ui.md).
 
 ## Related
 

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -175,8 +175,7 @@ For CORS, include an `Origin` header and confirm
 
 ## Next
 
-- [OAuth](./oauth.md): add social login to your app
-- [API routes](./api-routes.md): the routes that middleware protects
+Continue with [OAuth](./oauth.md).
 
 ## Related
 

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -159,8 +159,7 @@ For workflows, hit the workflow start route from
 
 ## Next
 
-- [Providers](./providers.md): configure OpenAI, Anthropic, and Google
-- [Middleware](./middleware.md): add auth and rate limiting to your agents
+Continue with [Providers](./providers.md).
 
 ## Related
 

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -325,9 +325,7 @@ A working setup:
 
 ## Next
 
-- [MCP server](./mcp-server.md): expose your tools over the Model Context
-  Protocol
-- [Configuration](./configuration.md): environment variables and secrets
+Continue with [MCP server](./mcp-server.md).
 
 ## Related
 

--- a/docs/guides/pages-and-routing.md
+++ b/docs/guides/pages-and-routing.md
@@ -214,8 +214,7 @@ to confirm the React component renders without console errors.
 
 ## Next
 
-- [Data fetching](./data-fetching.md): load data on the server or at build time
-- [API routes](./api-routes.md): create backend endpoints
+Continue with [Data fetching](./data-fetching.md).
 
 ## Related
 

--- a/docs/guides/production-path.md
+++ b/docs/guides/production-path.md
@@ -87,9 +87,7 @@ Use `veryfront open --json` when you need the deployed URL in a script or a term
 
 ## Next
 
-- [Building and deploying](./deploying.md): configure production builds and deployment targets
-- [Configuration](./configuration.md): set runtime and build options
-- [Head and SEO](./head-and-seo.md): prepare public pages for search and previews
+Continue with [Building and deploying](./deploying.md).
 
 ## Related
 

--- a/docs/guides/project-structure.md
+++ b/docs/guides/project-structure.md
@@ -193,9 +193,7 @@ should resolve from a route or test.
 
 ## Next
 
-- [Pages and routing](./pages-and-routing.md): file-based routing, layouts, and dynamic routes
-- [Agents](./agents.md): create your first AI agent
-- [Project conventions](../concepts/project-conventions.md): why routes and primitives live in separate directories
+Continue with [Pages and routing](./pages-and-routing.md).
 
 ## Related
 

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -186,8 +186,7 @@ whether the call used cloud, server-local, or browser inference.
 
 ## Next
 
-- [Middleware](./middleware.md): add CORS, rate limiting, and logging
-- [Agents](./agents.md): agents use providers for AI models
+Continue with [Agents](./agents.md).
 
 ## Related
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -149,8 +149,7 @@ id and close it manually.
 
 ## Next
 
-- [MCP server](./mcp-server.md): expose tools, prompts, and resources over MCP
-- [Agents](./agents.md): orchestrate sandbox-backed workflows with agents
+Continue with [MCP server](./mcp-server.md).
 
 ## Related
 

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -153,8 +153,7 @@ veryfront skills validate skills/my-skill
 
 ## Next
 
-- [Agents](./agents.md): agents use skills for structured instructions
-- [Tools](./tools.md): define custom tools that skills can reference
+Continue with [Agents](./agents.md).
 
 ## Related
 

--- a/docs/guides/tasks.md
+++ b/docs/guides/tasks.md
@@ -140,8 +140,7 @@ a `succeeded` status. See the verification block in
 
 ## Next
 
-- [Jobs and cron jobs](./jobs.md): schedule tasks as cloud jobs
-- [Agents](./agents.md): agents can invoke tasks as tools
+Continue with [Jobs and cron jobs](./jobs.md).
 
 ## Related
 

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -230,8 +230,7 @@ debug route before deploying.
 
 ## Next
 
-- [Memory and streaming](./memory-and-streaming.md): persist conversations across requests
-- [MCP server](./mcp-server.md): expose tools over Model Context Protocol
+Continue with [Memory and streaming](./memory-and-streaming.md).
 
 ## Related
 

--- a/docs/guides/workflows-advanced.md
+++ b/docs/guides/workflows-advanced.md
@@ -121,9 +121,7 @@ individual `nodeStates` entries update.
 
 ## Next
 
-- [Workflows](./workflows.md): core workflow API (define, run, branch, parallel,
-  human approval)
-- [Multi-agent](./multi-agent.md): compose agents in workflows and tools
+Continue with [Multi-agent](./multi-agent.md).
 
 ## Related
 

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -337,9 +337,7 @@ A working run reaches `status: "completed"` and exposes a `nodeStates` map with 
 
 ## Next
 
-- [Workflows: loops, blob storage, React hooks](./workflows-advanced.md): repeat-until-done loops, large-artifact storage, and React progress hooks
-- [Multi-agent](./multi-agent.md): compose agents in workflows and tools
-- [Providers](./providers.md): configure the LLM providers that power your agents
+Continue with [Workflows: loops, blob storage, React hooks](./workflows-advanced.md).
 
 ## Related
 

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -151,9 +151,6 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "./installation.md",
       "../guides/providers.md",
       "./create-project.md",
-      "./create-agent.md",
-      "./create-api.md",
-      "./deploy-project.md",
       "../api-reference/veryfront/agent.md",
       "../api-reference/veryfront/tool.md",
       "../api-reference/veryfront/chat.md",
@@ -400,12 +397,11 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
   "getting-started/create-agent.md": {
     references: [
       "../guides/agents.md",
-      "../guides/tools.md",
-      "../guides/chat-ui.md",
+      "../guides/memory-and-streaming.md",
+      "./create-api.md",
       "./installation.md",
       "./create-project.md",
       "../guides/providers.md",
-      "../guides/memory-and-streaming.md",
     ],
     snippets: [
       "agents/assistant.ts",

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -221,7 +221,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
   "getting-started/index.md": {
     references: [],
     snippets: [
-      "Veryfront Code",
+      "Veryfront app",
       "Getting started",
       "Contents",
       "Before you start",


### PR DESCRIPTION
## Summary
- shorten the Getting Started overview subtitle and remove redundant lead copy
- move Before you start above Contents on the Getting Started overview
- remove redundant lead sentences from Getting Started pages
- make every Veryfront Code `## Next` section a single recommended next action
- update docs contracts for the new single-action rule

## Verification
- deno task docs:validate
- pre-push checks: format, lint, typecheck, unit tests