### PR TITLE
Simplify Getting Started docs copy

### DIFF
--- a/docs/getting-started/create-agent.md
+++ b/docs/getting-started/create-agent.md
@@ -10,9 +10,9 @@ order: 4
   [Create project](./create-project.md).
 - An `agents/` directory in the project root. If you started from the `minimal`
   template, create one: `mkdir agents`.
-- A provider configured for inference. Set `OPENAI_API_KEY` or
-  `ANTHROPIC_API_KEY` in `.env`. See [Providers](../guides/providers.md) for
-  other options.
+- Veryfront Cloud access for inference. Run `veryfront login` or set
+  `VERYFRONT_API_TOKEN`. Direct provider keys such as `OPENAI_API_KEY` or
+  `ANTHROPIC_API_KEY` also work.
 
 ## Define the agent
 
@@ -41,13 +41,6 @@ import { createAgUiHandler } from "veryfront/agent";
 export const POST = createAgUiHandler("assistant");
 ```
 
-The handler validates the request, runs the agent, and returns an AG-UI SSE
-response. Pair it with `useChat({ api: "/api/ag-ui" })` in a React client.
-
-Use `agent.generate()` only for non-interactive work such as cron jobs, batch
-calls, and focused tests. See [Agents](../guides/agents.md#non-streaming-response).
-For non-chat streaming, see [Memory and streaming](../guides/memory-and-streaming.md).
-
 ## Run it
 
 Start the dev server:
@@ -55,6 +48,8 @@ Start the dev server:
 ```bash
 veryfront dev
 ```
+
+## Verify it worked
 
 Send a chat message from another terminal. The `-N` flag tells curl to flush
 each chunk as it arrives:
@@ -65,16 +60,14 @@ curl -N -X POST http://localhost:3000/api/ag-ui \
   -d '{"messages":[{"id":"1","role":"user","parts":[{"type":"text","text":"What is Veryfront in one sentence?"}]}]}'
 ```
 
-## Verify it worked
-
-The response is an AG-UI SSE stream. `data:` lines arrive progressively between
-`message-start` and `message-finish` events.
+The curl response should emit `data:` lines as the answer streams.
 
 If the whole body lands at once after a delay, curl or a TLS proxy may be
 buffering. Run the same request without `-N` to confirm.
 
-If the dev server logs a missing-provider error, check that the provider key is
-set in the shell running `veryfront dev`.
+If the dev server logs a missing-provider error, run `veryfront login`, then
+restart `veryfront dev`. If you prefer direct provider keys or local models,
+see [Providers](../guides/providers.md).
 
 ## Next
 

--- a/docs/getting-started/create-api.md
+++ b/docs/getting-started/create-api.md
@@ -23,7 +23,7 @@ export function GET() {
 `app/api/hello/route.ts` maps to `GET /api/hello`. Named exports define the
 allowed HTTP methods.
 
-## Try it
+## Verify it worked
 
 With the dev server running:
 
@@ -55,13 +55,7 @@ curl -X POST http://localhost:3000/api/echo \
   -d '{"hello":"world"}'
 ```
 
-## Verify it worked
-
-Confirm with `curl`:
-
-- `GET /api/hello` returns the JSON body above.
-- Unknown paths return 404.
-- Methods without an export return 405.
+The response should echo the JSON body.
 
 ## Next
 

--- a/docs/getting-started/create-frontend.md
+++ b/docs/getting-started/create-frontend.md
@@ -28,9 +28,6 @@ export default function About() {
 `app/about/page.tsx` maps to `/about`. The default export is the page component.
 Add `"use client"` only when the page needs browser interactivity.
 
-Open [http://localhost:3000/about](http://localhost:3000/about). The page
-renders.
-
 ## Link to it
 
 Edit `app/page.tsx` to add a `Link` to the new page:
@@ -55,10 +52,11 @@ export default function Home() {
 
 ## Verify it worked
 
-1. Open [http://localhost:3000/](http://localhost:3000/) and select the **About
+1. Open [http://localhost:3000/about](http://localhost:3000/about). The page
+   renders.
+2. Open [http://localhost:3000/](http://localhost:3000/) and select the **About
    this project** link.
-2. The URL updates to `/about` without a full page reload.
-3. Open the browser back button and confirm history works.
+3. The URL updates to `/about` without a full page reload.
 
 ## Next
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -7,26 +7,20 @@ order: 0
 
 ## Before you start
 
-You should know the basics of:
-
-- TypeScript - syntax and basic types.
-- React - components, props, and hooks.
-- A JavaScript runtime - Node.js, Deno, or Bun.
-- A terminal - running `npm`, `deno`, or shell commands.
-
-You do not need prior AI agent or MCP experience.
+These pages assume basic TypeScript, React, a JavaScript runtime, and terminal
+usage. You do not need prior AI agent or MCP experience.
 
 ## Contents
 
 | Page                                    | Use it when                                 |
 | --------------------------------------- | ------------------------------------------- |
 | [Quickstart](./quickstart.md)           | You want to build the first app end-to-end. |
-| [Installation](./installation.md)       | You need to install the CLI and framework.  |
-| [Create project](./create-project.md)   | You need to scaffold and run a project.     |
-| [Create agent](./create-agent.md)       | You need to define and invoke an agent.     |
-| [Create API](./create-api.md)           | You need to add the first HTTP endpoint.    |
-| [Create frontend](./create-frontend.md) | You need to add a page and navigation.      |
-| [Deploy project](./deploy-project.md)   | You need to build and ship the project.     |
+| [Installation](./installation.md)       | You want to install the CLI and framework.  |
+| [Create project](./create-project.md)   | You want to scaffold and run a project.     |
+| [Create agent](./create-agent.md)       | You want to define and invoke an agent.     |
+| [Create API](./create-api.md)           | You want to add the first HTTP endpoint.    |
+| [Create frontend](./create-frontend.md) | You want to add a page and navigation.      |
+| [Deploy project](./deploy-project.md)   | You want to build and ship the project.     |
 
 ## Next
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -8,8 +8,6 @@ order: -1
 
 - Node.js 18.18 or later.
 - The Veryfront CLI installed. See [Installation](./installation.md).
-- A model provider key for local inference. Use a placeholder in examples and
-  put the real value in your local `.env` file.
 
 ## Create the app
 
@@ -35,21 +33,25 @@ support-agent/
 
 The template includes the agent, calculator tool, chat page, and AG-UI route.
 
-## Configure a provider
+## Authenticate
 
-Create `.env`:
+From the project directory, authenticate with Veryfront Cloud:
 
 ```bash
-OPENAI_API_KEY=<API_KEY>
+veryfront login
 ```
 
-For local models or explicit provider routing, see [Providers](../guides/providers.md).
+This lets the app use the Veryfront Cloud gateway. You can also set
+`VERYFRONT_API_TOKEN` directly. Direct provider keys such as `OPENAI_API_KEY`
+or `ANTHROPIC_API_KEY` also work; see [Providers](../guides/providers.md).
 
 ## Run it locally
 
 ```bash
 veryfront dev
 ```
+
+## Verify it worked
 
 Open `http://localhost:3000` and ask:
 
@@ -65,10 +67,7 @@ curl -N -X POST http://localhost:3000/api/ag-ui \
   -d '{"messages":[{"id":"1","role":"user","parts":[{"type":"text","text":"What is 128 divided by 8?"}]}]}'
 ```
 
-## Verify it worked
-
-The browser should show a streamed assistant response that uses the calculator
-tool. The curl response should emit `data:` lines as the answer is produced.
+The answer should stream. The curl response should emit `data:` lines.
 
 If the route returns `Agent not found`, ensure `agents/assistant.ts` is in the
 project root. If the model skips the tool, ensure `tools: true` and `maxSteps`

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -525,7 +525,7 @@ describe("Guide: project-structure.md", () => {
 });
 
 describe("Guide: create-agent.md", () => {
-  it("uses the public AG-UI handler and keeps generate as a non-interactive note", async () => {
+  it("uses the public AG-UI handler for the first agent route", async () => {
     const guide = await readGuide("create-agent.md");
 
     for (
@@ -535,9 +535,8 @@ describe("Guide: create-agent.md", () => {
         'id: "assistant"',
         'import { createAgUiHandler } from "veryfront/agent"',
         'export const POST = createAgUiHandler("assistant")',
-        "Use `agent.generate()` only for non-interactive work",
         "curl -N -X POST",
-        "data:` lines arrive progressively",
+        "data:` lines as the answer streams",
       ]
     ) {
       assertStringIncludes(guide, snippet);

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -396,8 +396,6 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
   },
   "getting-started/create-agent.md": {
     references: [
-      "../guides/agents.md",
-      "../guides/memory-and-streaming.md",
       "./create-api.md",
       "./installation.md",
       "./create-project.md",
@@ -407,11 +405,9 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "agents/assistant.ts",
       'import { agent } from "veryfront/agent"',
       'createAgUiHandler("assistant")',
-      "Use `agent.generate()` only",
       "curl -N -X POST",
       "/api/ag-ui",
-      "message-start",
-      "message-finish",
+      "data:` lines",
       "veryfront dev",
     ],
   },


### PR DESCRIPTION
## Summary\n- simplify Getting Started overview prerequisites and table wording\n- make Veryfront Cloud token the primary agent auth path\n- remove extra explanation from Create agent and tighten verification sections\n- consolidate verification flow on API and frontend starter pages\n\n## Verification\n- deno task docs:validate\n- pre-push checks: format, lint, typecheck, unit tests