### PR TITLE
Release veryfront 0.1.584

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.583",
+  "version": "0.1.584",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.583";
+export const VERSION = "0.1.584";


### PR DESCRIPTION
## Summary
- Bump deno.json and the shared VERSION constant to 0.1.584.
- Publishes a new framework release so merged PR #1856 is available to veryfront-server builds.

## Verification
- deno task verify:quick
- deno test --config deno.json --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- git pre-push hook: format, lint, typecheck, unit tests (1909 passed, 17579 steps, 0 failed)

## Notes
- No agent-browser run: this is a release metadata/runtime version bump, not a visual change.