### PR TITLE
Clarify project conventions overview

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.584",
+  "version": "0.1.585",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -11,12 +11,12 @@ framework pieces relate.
 
 ## Contents
 
-| Concept                                           | What it explains                                                                              |
-| ------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| [Veryfront Code](./veryfront-code.md)             | What the framework is and how the public docs fit together.                                   |
-| [Framework primitives](./framework-primitives.md) | How agents, tools, workflows, tasks, jobs, integrations, MCP, sandbox, and extensions differ. |
-| [Project conventions](./project-conventions.md)   | Why Veryfront separates routes, AI primitives, shared code, and configuration.                |
-| [Agent memory](./agent-memory.md)                 | How client state, server memory, streaming, and storage boundaries relate.                    |
-| [Job execution model](./job-execution-model.md)   | How tasks, jobs, cron jobs, workflow runs, events, and logs fit together.                     |
-| [Integration runtime](./integration-runtime.md)   | How connector config, OAuth, token state, and remote tool execution interact.                 |
-| [Extension system](./extension-system.md)         | How factories, contracts, capabilities, setup, and teardown compose runtime behavior.         |
+| Concept                                           | What it explains                                                                                      |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| [Veryfront Code](./veryfront-code.md)             | What the framework is and how the public docs fit together.                                           |
+| [Framework primitives](./framework-primitives.md) | How agents, tools, workflows, tasks, jobs, integrations, MCP, sandbox, and extensions differ.         |
+| [Project conventions](./project-conventions.md)   | How Veryfront Code uses routing conventions, auto-discovery, shared code, content, and configuration. |
+| [Agent memory](./agent-memory.md)                 | How client state, server memory, streaming, and storage boundaries relate.                            |
+| [Job execution model](./job-execution-model.md)   | How tasks, jobs, cron jobs, workflow runs, events, and logs fit together.                             |
+| [Integration runtime](./integration-runtime.md)   | How connector config, OAuth, token state, and remote tool execution interact.                         |
+| [Extension system](./extension-system.md)         | How factories, contracts, capabilities, setup, and teardown compose runtime behavior.                 |

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.584";
+export const VERSION = "0.1.585";


### PR DESCRIPTION
## Summary
- Clarify the Concepts overview description for Project conventions
- Bump the framework version to keep version metadata in sync

## Verification
- deno fmt docs/concepts/index.md deno.json src/utils/version-constant.ts
- deno test --no-check --allow-read --allow-env src/utils/version.test.ts
- deno task docs:validate
- pre-push checks: format, lint, typecheck, unit tests