### PR TITLE
docs: clarify Getting Started install flow

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.585",
+  "version": "0.1.586",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/concepts/agent-memory.md
+++ b/docs/concepts/agent-memory.md
@@ -6,8 +6,8 @@ order: 4
 
 Agents are stateless unless a request supplies messages or the agent is
 configured with memory. Veryfront keeps message transport, model execution, and
-persisted memory as separate concerns so applications can choose the right state
-boundary.
+persisted memory separate because each concern answers a different question:
+what the user sees, what the model receives, and what survives the request.
 
 ## State boundaries
 
@@ -18,10 +18,10 @@ boundary.
 | Streaming transport | Token and AG-UI events sent back to the client.             |
 | Storage driver      | Persistence for memory across server instances or restarts. |
 
-Client-managed state stays in the request payload. Server-managed memory is
-useful when conversation state must survive reloads, move between clients, or be
-shared across server instances. Streaming does not decide where state lives; it
-only describes how output reaches the client.
+Client-managed state stays in the request payload. Server-managed memory matters
+when conversation state must survive reloads, move between clients, or be shared
+across server instances. Streaming does not decide where state lives; it only
+describes how output reaches the client.
 
 ## Memory strategies
 

--- a/docs/concepts/extension-system.md
+++ b/docs/concepts/extension-system.md
@@ -9,6 +9,10 @@ providers, storage, parsing, auth, schema validation, observability, and other
 infrastructure without changing the application code that consumes those
 capabilities.
 
+The extension system exists to keep infrastructure replaceable. Application code
+should depend on a cache, provider, parser, or auth contract, not on the package
+that happens to implement it.
+
 ## Core concepts
 
 | Concept    | Meaning                                                                |

--- a/docs/concepts/framework-primitives.md
+++ b/docs/concepts/framework-primitives.md
@@ -4,9 +4,9 @@ description: "How Veryfront Code agents, tools, workflows, tasks, jobs, integrat
 order: 2
 ---
 
-Veryfront Code exposes several primitives because different kinds of work need
-different ownership, durability, and user interaction. The boundary between them
-matters more than the number of primitives.
+Veryfront Code exposes several primitives because different kinds of work have
+different owners. The important questions are who starts the work, how long it
+lives, whether it streams to a user, and how it is observed.
 
 ## Concept map
 
@@ -33,3 +33,8 @@ authorization, not local business logic.
 Keeping these boundaries explicit makes projects easier to review. A feature can
 combine primitives, but one primitive should still own the triggering event and
 the primary lifecycle.
+
+For example, an API route can receive a webhook, a workflow can coordinate the
+multi-step response, a task can run slow background work, and an agent can reason
+about a user-facing decision. Each part remains understandable because the
+lifecycle owner stays clear.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -5,15 +5,15 @@ description: "Conceptual explanations for how Veryfront Code primitives, project
 order: 0
 ---
 
-Concepts explain the mental models behind Veryfront Code. Use this section when
-you need context before choosing an approach or when you want to understand how
-framework pieces relate.
+Concepts explain why Veryfront Code is shaped the way it is. Use this section
+when you need context before choosing an approach or when framework boundaries
+are not yet clear.
 
 ## Contents
 
 | Concept                                           | What it explains                                                                                      |
 | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| [Veryfront Code](./veryfront-code.md)             | What the framework is and how the public docs fit together.                                           |
+| [Veryfront Code](./veryfront-code.md)             | What the framework is and why its primitives share one project model.                                 |
 | [Framework primitives](./framework-primitives.md) | How agents, tools, workflows, tasks, jobs, integrations, MCP, sandbox, and extensions differ.         |
 | [Project conventions](./project-conventions.md)   | How Veryfront Code uses routing conventions, auto-discovery, shared code, content, and configuration. |
 | [Agent memory](./agent-memory.md)                 | How client state, server memory, streaming, and storage boundaries relate.                            |

--- a/docs/concepts/integration-runtime.md
+++ b/docs/concepts/integration-runtime.md
@@ -6,7 +6,7 @@ order: 6
 
 Integrations connect Veryfront agents and tools to external services. They keep
 connector metadata, authorization state, and remote execution separate from
-local agent behavior.
+local agent behavior so a model decision is not confused with account authority.
 
 ## Runtime flow
 

--- a/docs/concepts/job-execution-model.md
+++ b/docs/concepts/job-execution-model.md
@@ -8,6 +8,10 @@ Jobs are the durable execution surface for background work. Tasks and workflows
 define what can run. Jobs, cron jobs, and workflow runs define how that work is
 executed, scheduled, observed, and retried.
 
+The distinction keeps definitions separate from executions. A task or workflow
+can be reviewed as reusable product logic. A run can be inspected as one attempt
+to execute that logic.
+
 ## Execution identities
 
 | Concept      | Identity it owns                           |

--- a/docs/concepts/project-conventions.md
+++ b/docs/concepts/project-conventions.md
@@ -9,7 +9,13 @@ project entities such as agents, skills, tools, workflows, prompts, and
 resources. Common project directories keep shared code, content, and assets
 predictable.
 
-## Directory structure
+Conventions reduce configuration by making intent visible in the file tree. A
+route file is an entry point. An agent file is a reusable AI capability. A tool
+file is a callable operation. Keeping those roles separate lets Veryfront
+discover project entities without hiding them inside route trees or central
+registries.
+
+## Directory roles
 
 | Area                                                                   | Role                                                |
 | ---------------------------------------------------------------------- | --------------------------------------------------- |
@@ -21,8 +27,13 @@ predictable.
 | `public/`                                                              | Static assets served from the root path.            |
 | `veryfront.config.ts`                                                  | Framework configuration and extension registration. |
 
-## Auto-discovered entities
+## Discovery model
 
-Put pages and API routes in `app/` or `pages/`. Put agents, tools, workflows,
-prompts, resources, and skills in their root directories so Veryfront can
-auto-discover them.
+Routes are user and HTTP entry points. Auto-discovered entities are capabilities
+that routes, jobs, workflows, MCP servers, and agent services can use. This is
+why agents, tools, workflows, prompts, resources, and skills live at the project
+root instead of under a route directory.
+
+The convention keeps app structure predictable as a project grows. User-facing
+surfaces stay in router directories, while reusable capabilities stay visible at
+the same level as framework configuration.

--- a/docs/concepts/veryfront-code.md
+++ b/docs/concepts/veryfront-code.md
@@ -1,6 +1,6 @@
 ---
 title: "Veryfront Code"
-description: "What Veryfront Code is, which primitives it provides, and how its public docs fit together."
+description: "What Veryfront Code is and which framework primitives it provides."
 order: 1
 ---
 
@@ -8,6 +8,11 @@ Veryfront Code is a Deno-first, full-stack framework for building AI-powered
 applications and agents in TypeScript and React. It treats agents, workflows,
 tools, pages, APIs, and rendering as framework primitives with shared project
 conventions.
+
+The framework exists because AI applications need normal app surfaces and AI
+runtime surfaces to cooperate. A chat page, an AG-UI route, an agent, a tool, and
+a deployment target are separate concerns, but they belong to the same product
+and should be discoverable in the same project.
 
 ## Primitive set
 
@@ -19,11 +24,8 @@ conventions.
 | Integrations and MCP | Connector-backed tools, OAuth, prompts, resources, and assistant-facing protocol surfaces.                         |
 | Extensions           | Runtime contracts for providers, schema validation, bundling, content, auth, cache, observability, and sandboxing. |
 
-## Documentation map
-
-| Section                                        | Use it when                                                                   |
-| ---------------------------------------------- | ----------------------------------------------------------------------------- |
-| [Getting Started](../getting-started/index.md) | You are installing Veryfront Code or building your first project.             |
-| [Guides](../guides/index.md)                   | You need to complete a specific task in an existing project.                  |
-| [Concepts](./index.md)                      | You need context, terminology, and mental models before choosing an approach. |
-| [API reference](../api-reference/index.md)     | You need exact imports, exported names, types, and examples.                  |
+The shared project model matters more than any single primitive. Routes decide
+how users and HTTP clients enter the system. Agents, tools, workflows, and jobs
+define capabilities that can be reused from those routes or from runtime
+services. Extensions provide infrastructure behind contracts so application code
+does not need to know which provider, cache, parser, or auth adapter is active.

--- a/docs/getting-started/create-project.md
+++ b/docs/getting-started/create-project.md
@@ -23,6 +23,34 @@ Choose `minimal` for a blank app or `ai-agent` for an agent and chat route. Pass
 veryfront init test-app --template ai-agent
 ```
 
+### Use a package manager
+
+Use these commands when you do not have the Veryfront CLI installed globally.
+
+<CodeGroup>
+
+```bash npm
+npm create veryfront
+```
+
+```bash pnpm
+pnpm create veryfront
+```
+
+```bash yarn
+yarn create veryfront
+```
+
+```bash bun
+bun create veryfront
+```
+
+```bash deno
+deno init --npm veryfront
+```
+
+</CodeGroup>
+
 ## Run the dev server
 
 ```bash

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -15,7 +15,7 @@ plus a code editor and terminal. AI know-how is not required.
 | Page                                    | Use it when                                 |
 | --------------------------------------- | ------------------------------------------- |
 | [Quickstart](./quickstart.md)           | You want to build the first app end-to-end. |
-| [Installation](./installation.md)       | You want to install the CLI and framework.  |
+| [Installation](./installation.md)       | You want to install the CLI or framework.   |
 | [Create project](./create-project.md)   | You want to scaffold and run a project.     |
 | [Create agent](./create-agent.md)       | You want to define and invoke an agent.     |
 | [Create frontend](./create-frontend.md) | You want to add a chat UI for the agent.    |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -43,7 +43,8 @@ Older browsers may work but are not part of the supported matrix.
 
 ## Install
 
-Pick the command that matches your toolchain.
+Use a binary installer for a global CLI. Use a package manager when you already
+have an app. Use `npx` when you want to run the CLI once.
 
 <CodeGroup>
 
@@ -57,10 +58,6 @@ irm https://veryfront.com/install.ps1 | iex
 
 ```bash Homebrew
 brew install veryfront/tap/veryfront
-```
-
-```bash npm
-npm create veryfront
 ```
 
 ```bash npx
@@ -106,20 +103,33 @@ brew install veryfront/tap/veryfront
 
 Same binary as the curl installer, managed by Homebrew.
 
-### npm (project scaffolder)
+### Existing project
 
-```bash
-npm create veryfront
+Add Veryfront to an existing app when you do not want to scaffold a new project.
+
+<CodeGroup>
+
+```bash npm
+npm install veryfront
 ```
 
-Creates a new project using `create-veryfront`. Other package managers:
-
-```bash
-pnpm create veryfront
-yarn create veryfront
-bun create veryfront
-deno init --npm veryfront
+```bash pnpm
+pnpm add veryfront
 ```
+
+```bash yarn
+yarn add veryfront
+```
+
+```bash bun
+bun add veryfront
+```
+
+```bash deno
+deno add npm:veryfront
+```
+
+</CodeGroup>
 
 ### npx (one-shot)
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: "Quickstart"
-description: "Scaffold, run, and test a streaming Veryfront agent app."
+description: "Scaffold, run, and test your first Veryfront agent app."
 order: -1
 ---
 
@@ -68,15 +68,3 @@ curl -N -X POST http://localhost:3000/api/ag-ui \
 ```
 
 The answer should stream. The curl response should emit `data:` lines.
-
-If the route returns `Agent not found`, ensure `agents/assistant.ts` is in the
-project root. If the model skips the tool, ensure `tools: true` and `maxSteps`
-are still set in `agents/assistant.ts`.
-
-## Build
-
-Build the project before deploying:
-
-```bash
-veryfront build
-```

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.585";
+export const VERSION = "0.1.586";

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -560,7 +560,8 @@ describe("Guide: installation.md", () => {
       "curl -fsSL https://veryfront.com/install.sh | sh",
       "irm https://veryfront.com/install.ps1 | iex",
       "brew install veryfront/tap/veryfront",
-      "npm create veryfront",
+      "npm install veryfront",
+      "deno add npm:veryfront",
       "npx veryfront",
     ];
 

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -157,9 +157,6 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "calculator.ts",
       "What is 128 divided by 8?",
       "curl -N -X POST",
-      "tools: true",
-      "maxSteps",
-      "veryfront build",
     ],
   },
   "guides/configuration.md": {
@@ -230,8 +227,6 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "Agents",
       "tools",
       "Workflows",
-      "Getting Started",
-      "Documentation map",
       "Primitive set",
     ],
   },
@@ -250,7 +245,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
   "concepts/index.md": {
     references: [],
     snippets: [
-      "Concepts explain the mental models",
+      "Concepts explain why Veryfront Code is shaped",
       "Framework primitives",
       "Project conventions",
       "Agent memory",
@@ -279,8 +274,8 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "../api-reference/veryfront/index.md",
     ],
     snippets: [
-      "Directory structure",
-      "Auto-discovered entities",
+      "Directory roles",
+      "Discovery model",
       "agents/",
       "tools/",
     ],
@@ -385,7 +380,8 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
   "getting-started/installation.md": {
     references: [],
     snippets: [
-      "npm create veryfront",
+      "npm install veryfront",
+      "deno add npm:veryfront",
       "brew install veryfront/tap/veryfront",
       "veryfront.com/install.sh",
       "veryfront.com/install.ps1",
@@ -418,6 +414,8 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     references: ["./installation.md", "./create-agent.md"],
     snippets: [
       "veryfront init test-app",
+      "npm create veryfront",
+      "deno init --npm veryfront",
       "veryfront dev",
       "ai-agent",
       "minimal",


### PR DESCRIPTION
## Summary
- move package-manager project scaffolding from Installation to Create project
- document existing-project dependency install commands in Installation
- trim Quickstart to end at local streaming verification
- bump Veryfront Code version to 0.1.586

## Verification
- deno task docs:validate
- deno test --no-check --allow-read --allow-env src/utils/version.test.ts
- git diff --check
- pre-push: format, lint, type check, unit tests