### PR TITLE
docs: tighten getting started pages

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.586",
+  "version": "0.1.587",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/getting-started/create-agent.md
+++ b/docs/getting-started/create-agent.md
@@ -59,9 +59,6 @@ curl -N -X POST http://localhost:3000/api/ag-ui \
 
 The curl response should emit `data:` lines as the answer streams.
 
-If the whole body lands at once after a delay, curl or a TLS proxy may be
-buffering. Run the same request without `-N` to confirm.
-
 If the dev server logs a missing-provider error, run `veryfront login`, then
 restart `veryfront dev`. If you prefer direct provider keys or local models,
 see [Providers](../guides/providers.md).

--- a/docs/getting-started/create-api.md
+++ b/docs/getting-started/create-api.md
@@ -31,28 +31,11 @@ With the dev server running:
 curl http://localhost:3000/api/hello
 ```
 
-The response is:
+The response should be:
 
 ```json
 { "message": "Hello, world!" }
 ```
 
-## Read the request body
-
-For a `POST` endpoint that echoes its input:
-
-```ts
-// app/api/echo/route.ts
-export async function POST(request: Request) {
-  const body = await request.json();
-  return Response.json({ received: body });
-}
-```
-
-```bash
-curl -X POST http://localhost:3000/api/echo \
-  -H "Content-Type: application/json" \
-  -d '{"hello":"world"}'
-```
-
-The response should echo the JSON body.
+For request parsing, dynamic routes, and streaming responses, see
+[API routes](../guides/api-routes.md).

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -12,12 +12,12 @@ plus a code editor and terminal. AI know-how is not required.
 
 ## Contents
 
-| Page                                    | Use it when                                 |
-| --------------------------------------- | ------------------------------------------- |
-| [Quickstart](./quickstart.md)           | You want to build the first app end-to-end. |
-| [Installation](./installation.md)       | You want to install the CLI or framework.   |
-| [Create project](./create-project.md)   | You want to scaffold and run a project.     |
-| [Create agent](./create-agent.md)       | You want to define and invoke an agent.     |
-| [Create frontend](./create-frontend.md) | You want to add a chat UI for the agent.    |
-| [Create API](./create-api.md)           | You want to add the first HTTP endpoint.    |
-| [Deploy project](./deploy-project.md)   | You want to build and ship the project.     |
+| Page                                    | Goal                            |
+| --------------------------------------- | ------------------------------- |
+| [Quickstart](./quickstart.md)           | Build the first app end-to-end. |
+| [Installation](./installation.md)       | Install the CLI or framework.   |
+| [Create project](./create-project.md)   | Scaffold and run a project.     |
+| [Create agent](./create-agent.md)       | Define and invoke an agent.     |
+| [Create frontend](./create-frontend.md) | Add a chat UI for the agent.    |
+| [Create API](./create-api.md)           | Add the first HTTP endpoint.    |
+| [Deploy project](./deploy-project.md)   | Build and ship the project.     |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,42 +4,12 @@ description: "Install the Veryfront CLI and framework on macOS, Linux, or Window
 order: 2
 ---
 
-## System requirements
+## Requirements
 
-Veryfront ships as a standalone binary and as an npm package.
-
-### Operating system
-
-| OS                                          | Binary installer               | npm / npx |
-| ------------------------------------------- | ------------------------------ | --------- |
-| macOS 12 or later (Intel and Apple Silicon) | Yes (`curl` or Homebrew)       | Yes       |
-| Linux x86_64 and arm64 (glibc)              | Yes (`curl` or Homebrew)       | Yes       |
-| Windows 10 or later, x86_64 and arm64       | Yes (PowerShell `install.ps1`) | Yes       |
-
-### Runtime
-
-| Runtime | Minimum version | Notes                                      |
-| ------- | --------------- | ------------------------------------------ |
-| Node.js | 18.18           | Required for `npm`, `npx`, and app builds. |
-| Deno    | 1.45            | Optional direct runtime.                   |
-| Bun     | 1.1             | Optional direct runtime.                   |
-
-### Hardware
-
-- 1 GB of free disk space for the CLI, framework, and `node_modules`.
-- 2 GB of RAM for development; 4 GB or more is recommended when running an AI
-  agent locally.
-
-## Supported browsers
-
-Veryfront tests the built-in chat UI, router, and head components against the
-latest two stable releases of:
-
-- Chrome and Chromium-based browsers (Edge, Brave, Arc, Opera)
-- Firefox
-- Safari (macOS 14 and iOS 16 or later)
-
-Older browsers may work but are not part of the supported matrix.
+- macOS 12 or later, Linux x86_64 or arm64 (glibc), or Windows 10 or later.
+- Node.js 18.18 or later for `npm`, `npx`, and app builds.
+- Deno 1.45 or later, or Bun 1.1 or later, if you use those runtimes.
+- 1 GB of free disk space and 2 GB of RAM for local development.
 
 ## Install
 
@@ -66,42 +36,26 @@ npx veryfront
 
 </CodeGroup>
 
-### curl (standalone binary, macOS and Linux)
+### macOS and Linux
 
 ```bash
 curl -fsSL https://veryfront.com/install.sh | sh
 ```
 
-Installs the latest standalone binary to `~/.veryfront/bin/veryfront`.
-
-Pin a version or change the install directory:
-
-```bash
-curl -fsSL https://veryfront.com/install.sh | sh -s -- --version 0.1.0 --dir /usr/local/bin
-```
-
-### PowerShell (standalone binary, Windows)
-
-```powershell
-irm https://veryfront.com/install.ps1 | iex
-```
-
-Installs the latest standalone binary to
-`%USERPROFILE%\.veryfront\bin\veryfront.exe`.
-
-Pin a version or change the install directory:
-
-```powershell
-& ([scriptblock]::Create((irm https://veryfront.com/install.ps1))) -Version 0.1.0 -Dir C:\Tools\veryfront
-```
-
-### Homebrew
+This installs the latest standalone binary and adds it to your shell path.
+Homebrew installs the same binary:
 
 ```bash
 brew install veryfront/tap/veryfront
 ```
 
-Same binary as the curl installer, managed by Homebrew.
+### Windows
+
+```powershell
+irm https://veryfront.com/install.ps1 | iex
+```
+
+This installs the latest standalone binary and adds it to your user path.
 
 ### Existing project
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.586";
+export const VERSION = "0.1.587";

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -570,17 +570,17 @@ describe("Guide: installation.md", () => {
     }
   });
 
-  it("documents the runtime, OS, browser, and verify-it-worked sections", async () => {
+  it("documents requirements, install choices, and verification", async () => {
     const guide = await readGuide("installation.md");
 
     for (
       const heading of [
-        "## System requirements",
-        "### Operating system",
-        "### Runtime",
-        "### Hardware",
-        "## Supported browsers",
+        "## Requirements",
         "## Install",
+        "### macOS and Linux",
+        "### Windows",
+        "### Existing project",
+        "### npx (one-shot)",
         "## Verify it worked",
       ]
     ) {


### PR DESCRIPTION
## Summary\n- make the Getting Started overview table goal-oriented\n- trim reference-style install and troubleshooting content from onboarding pages\n- point deeper API route material to the API routes guide\n- bump the framework version to 0.1.587\n\n## Verification\n- deno fmt docs/getting-started/*.md tests/docs/guide-code-examples.test.ts deno.json src/utils/version-constant.ts\n- deno task docs:validate\n- deno test --no-check --allow-read --allow-env src/utils/version.test.ts\n- git diff --check\n- pre-push checks: format, lint, typecheck, unit tests