### PR TITLE
docs: tighten concepts overview

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,22 +1,21 @@
 ---
 title: "Concepts"
 sidebarTitle: "Overview"
-description: "Conceptual explanations for how Veryfront Code primitives, project conventions, runtime services, and extension points fit together."
+description: "How Veryfront framework primitives, conventions, and runtime fit together."
 order: 0
 ---
 
-Concepts explain why Veryfront Code is shaped the way it is. Use this section
-when you need context before choosing an approach or when framework boundaries
-are not yet clear.
+Use this section when you need context before choosing an approach. Use it when
+framework boundaries are not clear.
 
 ## Contents
 
-| Concept                                           | What it explains                                                                                      |
-| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| [Veryfront Code](./veryfront-code.md)             | What the framework is and why its primitives share one project model.                                 |
-| [Framework primitives](./framework-primitives.md) | How agents, tools, workflows, tasks, jobs, integrations, MCP, sandbox, and extensions differ.         |
-| [Project conventions](./project-conventions.md)   | How Veryfront Code uses routing conventions, auto-discovery, shared code, content, and configuration. |
-| [Agent memory](./agent-memory.md)                 | How client state, server memory, streaming, and storage boundaries relate.                            |
-| [Job execution model](./job-execution-model.md)   | How tasks, jobs, cron jobs, workflow runs, events, and logs fit together.                             |
-| [Integration runtime](./integration-runtime.md)   | How connector config, OAuth, token state, and remote tool execution interact.                         |
-| [Extension system](./extension-system.md)         | How factories, contracts, capabilities, setup, and teardown compose runtime behavior.                 |
+| Concept                                           | Explains                                                        |
+| ------------------------------------------------- | --------------------------------------------------------------- |
+| [Veryfront Code](./veryfront-code.md)             | The framework model and its main surfaces.                      |
+| [Framework primitives](./framework-primitives.md) | Agents, tools, workflows, jobs, integrations, MCP, and sandbox. |
+| [Project conventions](./project-conventions.md)   | Routing, auto-discovery, shared code, content, and config.      |
+| [Agent memory](./agent-memory.md)                 | Client state, server memory, streaming, and storage boundaries. |
+| [Job execution model](./job-execution-model.md)   | Tasks, jobs, cron jobs, workflow runs, events, and logs.        |
+| [Integration runtime](./integration-runtime.md)   | Connector config, OAuth, token state, and remote tools.         |
+| [Extension system](./extension-system.md)         | Factories, contracts, capabilities, setup, and teardown.        |

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -245,7 +245,8 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
   "concepts/index.md": {
     references: [],
     snippets: [
-      "Concepts explain why Veryfront Code is shaped",
+      "How Veryfront framework primitives",
+      "Use this section when you need context",
       "Framework primitives",
       "Project conventions",
       "Agent memory",


### PR DESCRIPTION
## Summary
- shorten the Concepts overview description and intro
- simplify the contents table descriptions
- update the docs contract for the new wording

## Verification
- deno fmt docs/concepts/index.md tests/docs/guide-contracts.test.ts
- deno task docs:validate
- git diff --check
- pre-push hook: format, lint, typecheck, unit tests