### PR TITLE
docs: improve framework concept explanations

### DIFF
--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -5,13 +5,54 @@ order: 21
 ---
 
 An agent owns model reasoning for an interaction. It receives messages, applies
-instructions, calls tools, uses memory, and emits output.
+instructions, chooses whether to call tools, observes tool results, and emits
+output.
 
-Use an agent when the system needs to decide what to say or which tool to call.
+Agents follow the same idea as the ReAct prompting pattern: reasoning and
+acting. The model reasons about the current state, acts by calling a tool or
+producing a response, observes the result, then repeats the loop until it can
+finish.
+
+## Characteristics
+
+- Perception: reads messages, system instructions, memory, runtime state, and
+  tool results.
+- Reasoning: decides what the next useful step is.
+- Action: calls a tool, asks for more information, or emits output.
+- Goal direction: works toward the objective expressed by its instructions and
+  the current user message.
+- Autonomy: can choose the next step inside the limits of its tools, runtime
+  config, and guardrails.
+
+## Loop
+
+The loop has four parts:
+
+| Phase       | Meaning                                                       |
+| ----------- | ------------------------------------------------------------- |
+| Input       | User messages, system instructions, memory, and runtime data. |
+| Reasoning   | The model decides the next useful step.                       |
+| Action      | The agent calls a tool or emits output.                       |
+| Observation | Tool results or new messages are added back into context.     |
+
+Veryfront hides most loop plumbing behind the agent runtime. The important
+boundary is still visible: the agent decides what to do next, while tools,
+resources, jobs, and app routes own the deterministic work they perform.
+
+## Boundary
+
+Use an agent when the system needs judgment, language understanding, tool choice,
+or streamed conversational output. Agents usually pair with tools, memory, and a
+chat UI. AG-UI is the default streaming surface for interactive agent output.
+
 Do not use an agent for deterministic work that a tool, route, task, or workflow
-can own directly.
+can own directly. If the next step is always known, the model should not be in
+charge of it.
 
-Agents usually pair with tools, memory, and a chat UI. AG-UI is the default
-streaming surface for interactive agent output.
+## Wrong fit
+
+An agent is the wrong primitive for a fixed HTTP response, a scheduled sync, a
+single database write, or a multi-step process that needs durable state. Use an
+app route, task, tool, or workflow for those boundaries.
 
 For implementation steps, see [Agents](../guides/agents.md).

--- a/docs/concepts/app.md
+++ b/docs/concepts/app.md
@@ -1,0 +1,37 @@
+---
+title: "App"
+description: "How apps own routes, API routes, data loading, and rendering."
+order: 20
+---
+
+An app owns the user-facing surface of a Veryfront project. It contains pages,
+API routes, data loading, static content, and runtime configuration.
+
+The app is the entry point for browsers and HTTP clients. It decides which route
+handles a request, which data is loaded, which UI is rendered, and which runtime
+capability is invoked.
+
+## Characteristics
+
+- Routes turn URLs into pages or API handlers.
+- Data loading prepares the information a page needs.
+- Rendering turns React and MDX into the response sent to the client.
+- API routes expose HTTP entry points for clients, webhooks, and app backends.
+
+## Boundary
+
+An app route can call an agent, tool, workflow, task, job, integration, or
+sandbox. The app still owns the request and response boundary. The primitive it
+calls owns the work behind that boundary.
+
+This separation keeps routes readable. The route explains how the user or HTTP
+client enters the system. The primitive explains what capability runs.
+
+## Wrong fit
+
+Do not put long-running work, model reasoning, tool execution policy, or
+scheduled logic directly in a route. Use the route to start that work and let the
+right primitive own it.
+
+For implementation steps, see [Pages and routing](../guides/pages-and-routing.md)
+and [API routes](../guides/api-routes.md).

--- a/docs/concepts/cron-job.md
+++ b/docs/concepts/cron-job.md
@@ -6,10 +6,28 @@ order: 26
 
 A cron job owns a schedule. It creates job runs at configured times.
 
-Use a cron job when work should start automatically. The cron job should not own
-the business logic. Put the work in a task or workflow and let the cron job
-trigger it.
+Cron jobs exist because scheduled work has two separate concerns: when work
+starts and what work does. The cron job owns the schedule. The target owns the
+business logic.
+
+## Characteristics
+
+- A schedule defines when work starts.
+- A target defines what work runs.
+- Each trigger creates a job run.
+- Pausing or deleting the schedule affects future runs, not the task or workflow
+  definition.
+
+## Boundary
 
 This keeps scheduling separate from execution.
+
+Use a cron job when work should start automatically. Put the work in a task or
+workflow and let the cron job trigger it.
+
+## Wrong fit
+
+Do not put the work itself in the schedule definition. Do not use a cron job for
+one-off background work. Use a normal job for that.
 
 For implementation steps, see [Jobs](../guides/jobs.md).

--- a/docs/concepts/framework-conventions.md
+++ b/docs/concepts/framework-conventions.md
@@ -15,6 +15,13 @@ file is a callable operation. Keeping those roles separate lets Veryfront
 discover project entities without hiding them inside route trees or central
 registries.
 
+## Core idea
+
+The directory name communicates the role. `app/` and `pages/` contain entry
+points. `agents/`, `tools/`, `workflows/`, `tasks/`, `prompts/`, `resources/`,
+and `skills/` contain reusable capabilities. `veryfront.config.ts` wires
+framework behavior and extensions.
+
 ## Directory roles
 
 | Area                                                                   | Role                                                |
@@ -27,7 +34,7 @@ registries.
 | `public/`                                                              | Static assets served from the root path.            |
 | `veryfront.config.ts`                                                  | Framework configuration and extension registration. |
 
-## Discovery model
+## Why this matters
 
 Routes are user and HTTP entry points. Auto-discovered entities are capabilities
 that routes, jobs, workflows, MCP servers, and agent services can use. This is

--- a/docs/concepts/framework-extensions.md
+++ b/docs/concepts/framework-extensions.md
@@ -13,6 +13,10 @@ The extension system exists to keep infrastructure replaceable. Application code
 should depend on a cache, provider, parser, or auth contract, not on the package
 that happens to implement it.
 
+Extensions are framework primitives because they change how the runtime is
+assembled. They are not app features. They provide infrastructure that apps,
+agents, tools, workflows, and other primitives can use.
+
 ## Core concepts
 
 | Concept    | Meaning                                                                |
@@ -33,3 +37,9 @@ gives extensions a predictable place to open and release runtime resources.
 Contracts are the important boundary. Consumers depend on contracts, not on a
 specific package implementation. That keeps app code stable when a project swaps
 a local adapter for a hosted or third-party implementation.
+
+## Wrong fit
+
+Do not create an extension for code that belongs to one app. Use an extension
+when a runtime capability should be packaged, configured, and reused behind a
+contract.

--- a/docs/concepts/framework-overview.md
+++ b/docs/concepts/framework-overview.md
@@ -1,12 +1,13 @@
 ---
-title: "Framework overview"
+title: "Veryfront Code"
 description: "How Veryfront Code combines app surfaces, AI primitives, runtime services, and extensions."
 order: 1
 ---
 
 Veryfront Code is a Deno-first, full-stack framework for building AI-powered
-applications and agents in TypeScript and React. It treats agents, workflows,
-tools, pages, APIs, and rendering as framework primitives with shared project
+applications and agents in TypeScript and React. It treats apps, agents, tools,
+workflows, tasks, jobs, prompts, resources, skills, integrations, MCP servers,
+sandboxes, and extensions as framework primitives with shared project
 conventions.
 
 The framework exists because AI applications need normal app surfaces and AI
@@ -14,18 +15,23 @@ runtime surfaces to cooperate. A chat page, an AG-UI route, an agent, a tool, an
 a deployment target are separate concerns, but they belong to the same product
 and should be discoverable in the same project.
 
-## Primitive set
+## Main surfaces
 
 | Area                 | What it gives you                                                                                                  |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | Pages and APIs       | React routes, MDX pages, data loading, and HTTP handlers.                                                          |
-| Agents and tools     | Model reasoning, tool calling, memory, AG-UI streaming, and chat UI.                                               |
+| Agents and tools     | Model reasoning, tool calling, memory, AG-UI streaming, skills, and chat UI.                                       |
 | Workflows and jobs   | Durable multi-step execution, background tasks, cron jobs, and run history.                                        |
 | Integrations and MCP | Connector-backed tools, OAuth, prompts, resources, and assistant-facing protocol surfaces.                         |
 | Extensions           | Runtime contracts for providers, schema validation, bundling, content, auth, cache, observability, and sandboxing. |
 
+## Core idea
+
 The shared project model matters more than any single primitive. Routes decide
-how users and HTTP clients enter the system. Agents, tools, workflows, and jobs
-define capabilities that can be reused from those routes or from runtime
-services. Extensions provide infrastructure behind contracts so application code
-does not need to know which provider, cache, parser, or auth adapter is active.
+how users and HTTP clients enter the system. Agents, tools, workflows, tasks,
+jobs, prompts, resources, skills, integrations, and sandboxes define
+capabilities that routes and runtime services can reuse.
+
+Extensions provide infrastructure behind contracts so application code does not
+need to know which provider, cache, parser, auth adapter, or sandbox
+implementation is active.

--- a/docs/concepts/framework-primitives.md
+++ b/docs/concepts/framework-primitives.md
@@ -1,32 +1,48 @@
 ---
 title: "Framework primitives"
-description: "How Veryfront Code agents, tools, workflows, tasks, jobs, integrations, MCP, sandbox, and extensions fit together."
+description: "How Veryfront Code apps, agents, tools, workflows, tasks, jobs, prompts, resources, skills, integrations, MCP, sandbox, and extensions fit together."
 order: 2
 ---
 
-Veryfront Code uses primitives to separate responsibility. Each primitive owns a
-specific kind of work, lifecycle, and runtime boundary.
+Veryfront Code uses primitives to separate responsibility. A primitive is an
+ownership boundary: it names what kind of work is happening, what lifecycle owns
+that work, and where the runtime boundary sits.
+
+The goal is not to use every primitive. The goal is to pick the smallest one
+that explains the work clearly.
 
 ## Primitives
 
-| Primitive                                         | Owns                                            |
-| ------------------------------------------------- | ----------------------------------------------- |
-| [Agent](./agent.md)                               | Model reasoning, messages, tools, and output.   |
-| [Tool](./tool.md)                                 | One callable capability.                        |
-| [Workflow](./workflow.md)                         | Multi-step coordination.                        |
-| [Task](./task.md)                                 | A background work target.                       |
-| [Job](./job.md)                                   | Durable execution of work.                      |
-| [Cron job](./cron-job.md)                         | Scheduled job creation.                         |
-| [Integration](./integration.md)                   | External service capabilities.                  |
-| [MCP server](./mcp-server.md)                     | Assistant-facing tools, prompts, and resources. |
-| [Sandbox](./sandbox.md)                           | Isolated command and file execution.            |
-| [Framework extensions](./framework-extensions.md) | Replaceable runtime infrastructure.             |
+| Primitive                               | Owns                                            |
+| --------------------------------------- | ----------------------------------------------- |
+| [App](./app.md)                         | User-facing routes, APIs, data, and rendering.  |
+| [Agent](./agent.md)                     | Model reasoning, messages, tools, and output.   |
+| [Tool](./tool.md)                       | One callable capability.                        |
+| [Workflow](./workflow.md)               | Multi-step coordination.                        |
+| [Task](./task.md)                       | A background work target.                       |
+| [Job](./job.md)                         | Durable execution of work.                      |
+| [Cron job](./cron-job.md)               | Scheduled job creation.                         |
+| [Prompt](./prompt.md)                   | Reusable instruction templates.                 |
+| [Resource](./resource.md)               | Readable project data for MCP.                  |
+| [Skill](./skill.md)                     | Reusable agent instructions and tool policy.    |
+| [Integration](./integration.md)         | External service capabilities.                  |
+| [MCP server](./mcp-server.md)           | Assistant-facing tools, prompts, and resources. |
+| [Sandbox](./sandbox.md)                 | Isolated command and file execution.            |
+| [Extensions](./framework-extensions.md) | Replaceable runtime infrastructure.             |
 
-## Ownership boundaries
+## How primitives combine
 
 Features can combine primitives, but one primitive should own the triggering
 event and primary lifecycle.
 
-For example, an API route can receive a webhook. A workflow can coordinate the
+For example, an app route can receive a webhook. A workflow can coordinate the
 response. A task can run slow background work. An agent can reason about a
-user-facing decision.
+user-facing decision. A skill can give the agent task-specific instructions.
+
+This keeps the project understandable. The app owns entry points. Agents own
+model decisions. Tools own deterministic actions. Workflows own process. Jobs own
+durable execution. Extensions own replaceable runtime infrastructure.
+
+For task-focused selection, see [Choose a primitive](../guides/choose-a-primitive.md).
+For exact agent runtime APIs, see
+[veryfront/agent](../api-reference/veryfront/agent.md).

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -10,18 +10,22 @@ framework boundaries are not clear.
 
 ## Contents
 
-| Concept                                             | Explains                                                        |
-| --------------------------------------------------- | --------------------------------------------------------------- |
-| [Framework overview](./framework-overview.md)       | The framework model and its main surfaces.                      |
-| [Framework primitives](./framework-primitives.md)   | Agents, tools, workflows, jobs, integrations, MCP, and sandbox. |
-| [Agent](./agent.md)                                 | Model reasoning and streamed output.                            |
-| [Tool](./tool.md)                                   | One callable capability.                                        |
-| [Workflow](./workflow.md)                           | Multi-step coordination.                                        |
-| [Task](./task.md)                                   | Background work definition.                                     |
-| [Job](./job.md)                                     | Durable background execution.                                   |
-| [Cron job](./cron-job.md)                           | Scheduled job creation.                                         |
-| [Integration](./integration.md)                     | External service capabilities.                                  |
-| [MCP server](./mcp-server.md)                       | Assistant-facing protocol surface.                              |
-| [Sandbox](./sandbox.md)                             | Isolated command and file execution.                            |
-| [Framework conventions](./framework-conventions.md) | Routing, auto-discovery, shared code, content, and config.      |
-| [Framework extensions](./framework-extensions.md)   | Factories, contracts, capabilities, setup, and teardown.        |
+| Concept                                             | Explains                                                   |
+| --------------------------------------------------- | ---------------------------------------------------------- |
+| [Veryfront Code](./framework-overview.md)           | The framework model and its main surfaces.                 |
+| [Framework primitives](./framework-primitives.md)   | Apps, AI primitives, jobs, MCP, sandbox, and extensions.   |
+| [App](./app.md)                                     | User-facing routes, APIs, data, and rendering.             |
+| [Agent](./agent.md)                                 | Model reasoning and streamed output.                       |
+| [Tool](./tool.md)                                   | One callable capability.                                   |
+| [Workflow](./workflow.md)                           | Multi-step coordination.                                   |
+| [Task](./task.md)                                   | Background work definition.                                |
+| [Job](./job.md)                                     | Durable background execution.                              |
+| [Cron job](./cron-job.md)                           | Scheduled job creation.                                    |
+| [Prompt](./prompt.md)                               | Reusable instruction template.                             |
+| [Resource](./resource.md)                           | Readable project data for MCP.                             |
+| [Skill](./skill.md)                                 | Reusable agent instructions and tool policy.               |
+| [Integration](./integration.md)                     | External service capabilities.                             |
+| [MCP server](./mcp-server.md)                       | Assistant-facing protocol surface.                         |
+| [Sandbox](./sandbox.md)                             | Isolated command and file execution.                       |
+| [Framework conventions](./framework-conventions.md) | Routing, auto-discovery, shared code, content, and config. |
+| [Framework extensions](./framework-extensions.md)   | Factories, contracts, capabilities, setup, and teardown.   |

--- a/docs/concepts/integration.md
+++ b/docs/concepts/integration.md
@@ -1,17 +1,37 @@
 ---
 title: "Integration"
 description: "How integrations expose external service capabilities."
-order: 27
+order: 30
 ---
 
 An integration owns connector metadata, auth configuration, token state, and
 remote tool discovery for an external service.
 
+Integrations exist because external services have more than one concern. They
+need metadata, OAuth or token setup, tool definitions, prompts, and sometimes
+shared client code.
+
+## Characteristics
+
+- Metadata describes the external service.
+- Auth configuration defines how users or projects connect.
+- Token state records access for later calls.
+- Remote tools expose service actions.
+- Prompts and resources can describe common service workflows and context.
+
+## Boundary
+
 Use an integration when a project needs a third-party service such as GitHub,
-Slack, or Google Drive. The integration owns access to the service. Agents and
-tools use the capabilities it exposes.
+Slack, or Google Drive. The integration owns access to the service. Agents,
+tools, and workflows use the capabilities it exposes.
 
 Keep product logic outside the integration. The integration should describe and
 authorize the external capability.
+
+## Wrong fit
+
+Do not create an integration for one small local helper. Use a tool when the
+capability belongs only to one project and does not need shared auth, metadata,
+or discovery behavior.
 
 For implementation steps, see [Integrations](../guides/integrations.md).

--- a/docs/concepts/job.md
+++ b/docs/concepts/job.md
@@ -7,9 +7,29 @@ order: 25
 A job owns durable execution. It records status, events, logs, and result state
 for background work.
 
+Jobs exist because background work needs a durable runtime record. The caller can
+start work and later inspect whether it is queued, running, complete, or failed.
+
+## Characteristics
+
+- Status describes where the execution is in its lifecycle.
+- Events describe what happened during the run.
+- Logs explain operational details.
+- Results record the final output.
+- Target metadata points back to the task, workflow, or supported target that
+  ran.
+
+## Boundary
+
+The target defines what work is done. The job records that the work ran.
+
 Use a job when work needs to outlive an HTTP request or continue after the caller
 disconnects. A job can run a task, workflow, or other supported target.
 
-The target defines what work is done. The job records that the work ran.
+## Wrong fit
+
+Do not use a job for work that must return synchronously in the current request.
+Do not put business logic in the job record. Put the logic in the target the job
+runs.
 
 For implementation steps, see [Jobs](../guides/jobs.md).

--- a/docs/concepts/mcp-server.md
+++ b/docs/concepts/mcp-server.md
@@ -1,16 +1,36 @@
 ---
 title: "MCP server"
 description: "How MCP servers expose tools, prompts, and resources to assistants."
-order: 28
+order: 31
 ---
 
 An MCP server owns an assistant-facing protocol surface. It exposes tools,
 prompts, and resources through MCP.
 
-Use an MCP server when an assistant needs to inspect or operate on a project
-through a protocol, not through app routes. MCP is not the same as AG-UI or REST.
+MCP servers exist because assistants need a protocol surface that is not the same
+as a user-facing app route. MCP describes capabilities an assistant can inspect
+and call.
+
+## Characteristics
+
+- Tools expose actions.
+- Prompts expose reusable instructions.
+- Resources expose readable context.
+- Transport defines how the assistant connects.
+- Auth decides which clients can use the server.
+
+## Boundary
 
 MCP describes capabilities for assistants. App routes describe entry points for
 users and HTTP clients.
+
+Use an MCP server when an assistant needs to inspect or operate on a project
+through a protocol. MCP is not the same as AG-UI or REST. AG-UI streams agent
+output to app clients. MCP exposes tools, prompts, and resources to assistants.
+
+## Wrong fit
+
+Do not use MCP as the public API for normal app users. Use app routes or API
+routes for user-facing HTTP entry points.
 
 For implementation steps, see [MCP server](../guides/mcp-server.md).

--- a/docs/concepts/prompt.md
+++ b/docs/concepts/prompt.md
@@ -1,0 +1,34 @@
+---
+title: "Prompt"
+description: "How prompts define reusable instruction templates for MCP."
+order: 27
+---
+
+A prompt owns reusable instruction text. It can include template variables and
+can be exposed through MCP.
+
+Prompts exist because assistants often need named instructions that are not
+tools. A prompt tells an assistant what to do or how to frame a task. It does not
+execute code and does not own state.
+
+## Characteristics
+
+- Content contains the instruction text.
+- Variables let the caller fill in task-specific values.
+- A stable ID lets MCP clients discover the prompt.
+- The caller decides when the prompt is useful.
+
+## Boundary
+
+A prompt is read and applied by a caller. An agent or MCP client decides when to
+use it. A tool owns an action. A resource owns readable data. A prompt owns
+instructions.
+
+This keeps instruction templates separate from executable capabilities.
+
+## Wrong fit
+
+Do not use a prompt when the project needs to fetch data, mutate state, or call
+an external system. Use a resource for readable data and a tool for actions.
+
+For API details, see [veryfront/prompt](../api-reference/veryfront/prompt.md).

--- a/docs/concepts/resource.md
+++ b/docs/concepts/resource.md
@@ -1,0 +1,34 @@
+---
+title: "Resource"
+description: "How resources expose readable project data through MCP."
+order: 28
+---
+
+A resource owns readable project data. It defines a URI pattern, parameters, and
+a loader that returns content.
+
+Resources exist so assistants can inspect context without performing an action.
+They are useful for documentation, project state, generated summaries, or other
+data that should be loaded by name.
+
+## Characteristics
+
+- A URI pattern names the resource.
+- Parameters select the specific data to load.
+- A loader returns content.
+- Optional subscriptions can expose updates when the resource changes.
+
+## Boundary
+
+A resource is read. A tool is called. A prompt gives instructions. MCP servers
+can expose all three, but each has a different contract.
+
+This distinction matters because assistants should not need to call a mutating
+tool just to inspect context.
+
+## Wrong fit
+
+Do not use a resource for work that changes state, starts a process, or needs
+approval. Use a tool, workflow, task, or job for executable work.
+
+For API details, see [veryfront/resource](../api-reference/veryfront/resource.md).

--- a/docs/concepts/sandbox.md
+++ b/docs/concepts/sandbox.md
@@ -1,16 +1,35 @@
 ---
 title: "Sandbox"
 description: "How sandboxes isolate command and file execution."
-order: 29
+order: 32
 ---
 
 A sandbox owns isolated command and file execution. It gives agents, tools, or
 workflows a controlled place to run code.
 
-Use a sandbox when execution should be separated from the host process. This is
-useful for generated code, project inspection, tests, and command execution.
+Sandboxes exist because some work should not run directly in the app process.
+Generated code, project inspection, tests, and command execution need a
+controlled boundary.
+
+## Characteristics
+
+- Filesystem access is scoped to the sandbox.
+- Commands run outside the app process.
+- Streaming output can report progress.
+- Background commands can continue after the caller starts them.
+
+## Boundary
 
 The sandbox owns process and file isolation. The caller owns why the command
 runs.
+
+Use a sandbox when execution should be separated from the host process. Agents,
+tools, and workflows can use the sandbox, but they do not own its isolation
+model.
+
+## Wrong fit
+
+Do not use a sandbox as a general application module boundary. Use it when
+execution isolation is the point.
 
 For implementation steps, see [Sandbox](../guides/sandbox.md).

--- a/docs/concepts/skill.md
+++ b/docs/concepts/skill.md
@@ -1,0 +1,37 @@
+---
+title: "Skill"
+description: "How skills package reusable agent instructions, references, scripts, and tool policy."
+order: 29
+---
+
+A skill owns reusable agent instructions. It can include reference files,
+scripts, assets, and an allowed-tools policy.
+
+Skills exist because some agent behavior is larger than one prompt but smaller
+than a new runtime primitive. A skill packages a repeatable way of working, such
+as code review, data analysis, incident response, or repository maintenance.
+
+## Characteristics
+
+- `SKILL.md` contains the instructions and metadata.
+- References provide supporting material the agent can load.
+- Scripts provide optional executable helpers.
+- Assets provide optional files the skill can use.
+- Allowed tools limit which actions are available while the skill is active.
+
+## Boundary
+
+The agent owns the interaction and decides when to use a skill. The skill owns
+the instructions and supporting files for that capability. Tools still own
+actions. The skill policy limits which tools are available while the skill is
+active.
+
+This keeps task-specific agent behavior discoverable without hiding it inside a
+large system prompt.
+
+## Wrong fit
+
+Do not use a skill for deterministic work that should be a tool, background work
+that should be a task, or multi-step process state that should be a workflow.
+
+For implementation steps, see [Skills](../guides/skills.md).

--- a/docs/concepts/task.md
+++ b/docs/concepts/task.md
@@ -6,10 +6,29 @@ order: 24
 
 A task defines background work. It is the target that a job runs.
 
-Use a task when work should run outside a request or chat turn. Tasks are useful
-for sync jobs, imports, cleanup, and other background operations.
+Tasks exist because some work should be named and reusable before it is run. A
+task describes what background work does. A job records one durable execution of
+that work.
+
+## Characteristics
+
+- A task has a stable ID.
+- A task defines the function to run.
+- A task can receive input from a caller or job.
+- A task returns a result that the runner can record.
+
+## Boundary
 
 A task is the definition. A job is the durable execution of that definition. Keep
 that boundary clear.
+
+Use a task when work should run outside a request or chat turn. Tasks are useful
+for sync jobs, imports, cleanup, and other background operations.
+
+## Wrong fit
+
+Do not use a task for interactive model reasoning, streamed chat output, or work
+that must stay inside the current HTTP request. Use an agent or app route for
+those cases.
 
 For implementation steps, see [Tasks](../guides/tasks.md).

--- a/docs/concepts/tool.md
+++ b/docs/concepts/tool.md
@@ -6,11 +6,30 @@ order: 22
 
 A tool owns one callable capability. It defines input, output, and execution.
 
-Use a tool when a model or workflow needs to call deterministic code. Keep tools
-focused. A tool should do one thing and return a clear result.
+Tools exist because agents and workflows need safe ways to act. The model can
+choose a tool, but the tool owns the deterministic code that runs.
+
+## Characteristics
+
+- Typed input describes what the caller must provide.
+- Execution performs one operation.
+- Output returns a structured result the caller can use.
+- Errors describe why the operation could not complete.
+
+## Boundary
 
 Tools can be local project files, remote integration tools, or MCP-exposed
 capabilities. The caller chooses when to invoke them. The tool owns how the work
 runs.
+
+Keep tools focused. A tool should do one thing, validate its input, and return a
+clear result. If the operation grows into multiple stages, approvals, or retries,
+move the coordination into a workflow.
+
+## Wrong fit
+
+Do not use a tool as a hidden workflow, long-running job, or large integration
+layer. Use a workflow for process, a job for durable execution, and an
+integration for reusable external service access.
 
 For implementation steps, see [Tools](../guides/tools.md).

--- a/docs/concepts/workflow.md
+++ b/docs/concepts/workflow.md
@@ -7,11 +7,30 @@ order: 23
 A workflow owns multi-step coordination. It can run ordered, branching, or
 parallel steps and keep progress visible.
 
+Workflows exist because multi-step work needs structure outside a prompt. A
+workflow makes the process visible: which step runs first, which branches exist,
+what can retry, and where approval can happen.
+
+## Characteristics
+
+- Steps describe the units of work.
+- Branches describe alternate paths.
+- Parallel steps allow independent work to run together.
+- State keeps progress visible across the process.
+- Approvals make human decision points explicit.
+
+## Boundary
+
+Workflows can call agents, tools, and approval steps. The workflow owns the
+process. Each step owns its local work.
+
 Use a workflow when work has multiple stages or needs durable state between
 steps. Do not hide multi-step orchestration inside an agent prompt or a single
 tool.
 
-Workflows can call agents, tools, and approval steps. The workflow owns the
-process. Each step owns its local work.
+## Wrong fit
+
+Do not use a workflow when one route, one tool, or one agent turn is enough.
+Workflow structure should make a real process clearer, not add ceremony.
 
 For implementation steps, see [Workflows](../guides/workflows.md).

--- a/docs/guides/choose-a-primitive.md
+++ b/docs/guides/choose-a-primitive.md
@@ -9,27 +9,35 @@ clear and prevents overlapping agents, workflows, jobs, and integrations.
 
 ## Quick choice
 
-| If you need to...                                           | Use                    | Start with                        |
-| ----------------------------------------------------------- | ---------------------- | --------------------------------- |
-| Answer users with model reasoning, tools, memory, or skills | Agent                  | [Agents](./agents.md)             |
-| Give an agent one typed capability                          | Tool                   | [Tools](./tools.md)               |
-| Coordinate multiple steps, branches, approvals, or retries  | Workflow               | [Workflows](./workflows.md)       |
-| Define project-owned background work                        | Task                   | [Tasks](./tasks.md)               |
-| Run durable background work now or on a schedule            | Job or cron job        | [Jobs](./jobs.md)                 |
-| Connect agents to third-party services                      | Integration with OAuth | [Integrations](./integrations.md) |
-| Expose project capabilities to assistants over a protocol   | MCP server             | [MCP server](./mcp-server.md)     |
-| Run isolated commands or file operations                    | Sandbox                | [Sandbox](./sandbox.md)           |
-| Add reusable runtime capabilities                           | Extension              | [Extensions](./extensions.md)     |
+| If you need to...                                           | Use                    | Start with                                  |
+| ----------------------------------------------------------- | ---------------------- | ------------------------------------------- |
+| Receive browser, HTTP, or webhook traffic                   | App route or API route | [Pages and routing](./pages-and-routing.md) |
+| Answer users with model reasoning, tools, memory, or skills | Agent                  | [Agents](./agents.md)                       |
+| Give an agent one typed capability                          | Tool                   | [Tools](./tools.md)                         |
+| Coordinate multiple steps, branches, approvals, or retries  | Workflow               | [Workflows](./workflows.md)                 |
+| Define project-owned background work                        | Task                   | [Tasks](./tasks.md)                         |
+| Run durable background work now or on a schedule            | Job or cron job        | [Jobs](./jobs.md)                           |
+| Reuse assistant instructions                                | Prompt                 | [MCP server](./mcp-server.md)               |
+| Expose readable context to assistants                       | Resource               | [MCP server](./mcp-server.md)               |
+| Package reusable agent behavior                             | Skill                  | [Skills](./skills.md)                       |
+| Connect agents to third-party services                      | Integration with OAuth | [Integrations](./integrations.md)           |
+| Expose project capabilities to assistants over a protocol   | MCP server             | [MCP server](./mcp-server.md)               |
+| Run isolated commands or file operations                    | Sandbox                | [Sandbox](./sandbox.md)                     |
+| Add reusable runtime capabilities                           | Extension              | [Extensions](./extensions.md)               |
 
 ## Decision rules
 
 | Primitive   | Use this when                                                                 | Do not use this when                                                          |
 | ----------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| App route   | A browser, HTTP client, or webhook needs an entry point.                      | The work should outlive the request or be reused outside routing.             |
 | Agent       | The model must decide, explain, call tools, use memory, or stream a response. | The work is deterministic and can be a function, task, or workflow step.      |
 | Tool        | An agent needs a typed operation such as search, lookup, write, or transform. | The operation has multiple long-running states or human approval steps.       |
 | Workflow    | Work has ordered steps, parallel branches, retries, or human review.          | A single agent response or one background function is enough.                 |
 | Task        | You own a reusable background function in `tasks/`.                           | The user needs conversational reasoning or streaming output.                  |
 | Job         | You need durable execution, scheduling, batch status, or run history.         | The work can finish inside a request without durability.                      |
+| Prompt      | An assistant needs reusable instruction text.                                 | The project needs to execute code or read data.                               |
+| Resource    | An assistant needs readable project context.                                  | The operation changes state or starts work.                                   |
+| Skill       | An agent needs reusable instructions, references, scripts, and tool policy.   | The work is deterministic or needs durable process state.                     |
 | Integration | You need provider metadata, OAuth, tokens, or remote integration tools.       | A local custom API call is enough and no shared connector behavior is needed. |
 | MCP server  | External assistants or MCP clients need tools, prompts, or resources.         | The capability is only used inside one Veryfront app route.                   |
 | Sandbox     | Code or shell work needs isolation from the app process.                      | The code can run safely in your own trusted runtime.                          |
@@ -42,6 +50,8 @@ clear and prevents overlapping agents, workflows, jobs, and integrations.
 | Chat with company data                 | Agent + tools + memory + chat UI                   |
 | Human-approved content pipeline        | Workflow + agents + approval step                  |
 | Nightly sync from an external API      | Task + cron job + optional integration credentials |
+| Assistant help with a repeatable task  | Agent + skill + optional tools                     |
+| Assistant reads project context        | MCP server + resources                             |
 | User-authorized GitHub automation      | Integration + OAuth + tools                        |
 | Assistant-accessible project commands  | MCP server + tools                                 |
 | Isolated repo inspection or code edits | Agent + sandbox + tools                            |

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -12,12 +12,16 @@ const CONCEPT_FILES = new Set<string>([
   "concepts/framework-overview.md",
   "concepts/framework-primitives.md",
   "concepts/framework-conventions.md",
+  "concepts/app.md",
   "concepts/agent.md",
   "concepts/tool.md",
   "concepts/workflow.md",
   "concepts/task.md",
   "concepts/job.md",
   "concepts/cron-job.md",
+  "concepts/prompt.md",
+  "concepts/resource.md",
+  "concepts/skill.md",
   "concepts/integration.md",
   "concepts/mcp-server.md",
   "concepts/sandbox.md",
@@ -233,7 +237,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "Agents",
       "tools",
       "Workflows",
-      "Primitive set",
+      "Main surfaces",
     ],
   },
   "guides/index.md": {
@@ -256,6 +260,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "Framework primitives",
       "Framework conventions",
       "Framework extensions",
+      "Skill",
     ],
   },
   "concepts/framework-primitives.md": {
@@ -264,14 +269,18 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "../api-reference/veryfront/agent.md",
     ],
     snippets: [
+      "App",
       "Agent",
       "Tool",
       "Workflow",
       "Task",
       "Job",
       "Cron job",
+      "Prompt",
+      "Resource",
+      "Skill",
       "MCP server",
-      "Ownership boundaries",
+      "How primitives combine",
     ],
   },
   "concepts/framework-conventions.md": {
@@ -281,17 +290,24 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     ],
     snippets: [
       "Directory roles",
-      "Discovery model",
+      "Why this matters",
       "agents/",
       "tools/",
     ],
+  },
+  "concepts/app.md": {
+    references: [
+      "../guides/pages-and-routing.md",
+      "../guides/api-routes.md",
+    ],
+    snippets: ["user-facing surface", "routes", "request and response boundary"],
   },
   "concepts/agent.md": {
     references: [
       "../guides/agents.md",
       "../api-reference/veryfront/agent.md",
     ],
-    snippets: ["model reasoning", "tools", "AG-UI"],
+    snippets: ["ReAct", "Reasoning", "Observation", "AG-UI"],
   },
   "concepts/tool.md": {
     references: [
@@ -327,6 +343,18 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "../api-reference/veryfront/jobs.md",
     ],
     snippets: ["schedule", "job runs", "trigger"],
+  },
+  "concepts/prompt.md": {
+    references: ["../api-reference/veryfront/prompt.md"],
+    snippets: ["instruction text", "template variables", "MCP"],
+  },
+  "concepts/resource.md": {
+    references: ["../api-reference/veryfront/resource.md"],
+    snippets: ["readable project data", "URI pattern", "MCP"],
+  },
+  "concepts/skill.md": {
+    references: ["../guides/skills.md"],
+    snippets: ["agent instructions", "allowed-tools policy", "SKILL.md"],
   },
   "concepts/integration.md": {
     references: [


### PR DESCRIPTION
## Summary
- expand framework concept pages into Diataxis explanation pages
- add App, Prompt, Resource, and Skill primitive concept pages
- align the Framework primitives and Choose a primitive pages with the full primitive set

## Verification
- deno task docs:validate
- git diff --check
- pre-push: format, lint, typecheck, unit tests