### PR TITLE
Reduce Redis socket-close error noise

### DIFF
--- a/extensions/ext-cache-redis/src/index.test.ts
+++ b/extensions/ext-cache-redis/src/index.test.ts
@@ -32,17 +32,35 @@ function silentLogger(): ExtensionLogger {
   };
 }
 
-function capturingLogger(): { logger: ExtensionLogger; info: string[] } {
-  const info: string[] = [];
+interface CapturedLog {
+  message: string;
+  args: unknown[];
+}
+
+function capturingLogger(): {
+  logger: ExtensionLogger;
+  info: CapturedLog[];
+  warn: CapturedLog[];
+  error: CapturedLog[];
+} {
+  const info: CapturedLog[] = [];
+  const warn: CapturedLog[] = [];
+  const error: CapturedLog[] = [];
   return {
     info,
+    warn,
+    error,
     logger: {
       debug: () => {},
-      info: (msg: string) => {
-        info.push(msg);
+      info: (message: string, ...args: unknown[]) => {
+        info.push({ message, args });
       },
-      warn: () => {},
-      error: () => {},
+      warn: (message: string, ...args: unknown[]) => {
+        warn.push({ message, args });
+      },
+      error: (message: string, ...args: unknown[]) => {
+        error.push({ message, args });
+      },
     },
   };
 }
@@ -147,6 +165,43 @@ describe("ext-cache-redis extension", () => {
       assertEquals(client._dump().size, 0);
       await store.close();
     });
+
+    it("logs expected redis socket disconnects below error level", async () => {
+      const { factory: clientFactory, client } = createStubClientFactory();
+      const { logger, info, error } = capturingLogger();
+      const store = new RedisTokenCacheStore(
+        { url: "redis://localhost:6379" },
+        { clientFactory, logger },
+      );
+
+      await store.stats();
+
+      client._emitError(new Error("Socket closed unexpectedly"));
+
+      assertEquals(error.length, 0);
+      assertEquals(
+        info.some((entry) => entry.message === "[RedisCache] Client disconnected"),
+        true,
+      );
+      await store.close();
+    });
+
+    it("keeps unexpected redis client errors at error level", async () => {
+      const { factory: clientFactory, client } = createStubClientFactory();
+      const { logger, error } = capturingLogger();
+      const store = new RedisTokenCacheStore(
+        { url: "redis://localhost:6379" },
+        { clientFactory, logger },
+      );
+
+      await store.stats();
+
+      client._emitError(new Error("ERR invalid password"));
+
+      assertEquals(error.length, 1);
+      assertEquals(error[0]?.message, "[RedisCache] Client error");
+      await store.close();
+    });
   });
 
   describe("extension setup/teardown", () => {
@@ -204,11 +259,11 @@ describe("ext-cache-redis extension", () => {
 
       await ext.setup!(ctx);
 
-      const line = info.find((m) => m.includes("TokenCacheStore registered"));
+      const line = info.find((entry) => entry.message.includes("TokenCacheStore registered"));
       assertExists(line);
-      assertEquals(line!.includes("s3cret"), false);
-      assertEquals(line!.includes("alice"), false);
-      const loggedUrl = line!.match(/\(url=(.*)\)$/)?.[1];
+      assertEquals(line!.message.includes("s3cret"), false);
+      assertEquals(line!.message.includes("alice"), false);
+      const loggedUrl = line!.message.match(/\(url=(.*)\)$/)?.[1];
       assertExists(loggedUrl);
       assertEquals(new URL(loggedUrl).hostname, "redis.example.com");
 
@@ -227,9 +282,9 @@ describe("ext-cache-redis extension", () => {
 
       await ext.setup!(ctx);
 
-      const line = info.find((m) => m.includes("TokenCacheStore registered"));
+      const line = info.find((entry) => entry.message.includes("TokenCacheStore registered"));
       assertExists(line);
-      assertEquals(line!.includes("<redacted>"), true);
+      assertEquals(line!.message.includes("<redacted>"), true);
 
       await ext.teardown!();
     });

--- a/extensions/ext-cache-redis/src/redis-cache.ts
+++ b/extensions/ext-cache-redis/src/redis-cache.ts
@@ -17,6 +17,13 @@ const DEFAULT_SCAN_COUNT = 100;
 const MAX_RECONNECT_RETRIES = 3;
 const RECONNECT_BACKOFF_BASE_MS = 100;
 const RECONNECT_BACKOFF_MAX_MS = 3_000;
+const EXPECTED_DISCONNECT_PATTERNS = [
+  "socket closed unexpectedly",
+  "connection closed",
+  "connection reset",
+  "econnreset",
+  "etimedout",
+];
 
 /** Constructor options for `RedisTokenCacheStore`. */
 export interface RedisTokenCacheStoreOptions {
@@ -42,6 +49,15 @@ const NOOP_LOGGER: RedisCacheLogger = {
   warn: () => {},
   error: () => {},
 };
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isExpectedDisconnect(error: unknown): boolean {
+  const message = getErrorMessage(error).toLowerCase();
+  return EXPECTED_DISCONNECT_PATTERNS.some((pattern) => message.includes(pattern));
+}
 
 /** Factory contract used by tests — swap in an in-memory stub. */
 export type RedisClientFactory = (
@@ -258,10 +274,13 @@ export class RedisTokenCacheStore implements TokenCacheStore {
 
     // deno-lint-ignore no-explicit-any
     (client as any).on?.("error", (err: unknown) => {
-      this.logger.error("[RedisCache] Client error", {
-        error: err instanceof Error ? err.message : String(err),
-      });
       this.connected = false;
+      const error = getErrorMessage(err);
+      if (isExpectedDisconnect(err)) {
+        this.logger.info("[RedisCache] Client disconnected", { error });
+        return;
+      }
+      this.logger.error("[RedisCache] Client error", { error });
     });
 
     this.client = client;

--- a/extensions/ext-cache-redis/src/test-utils.ts
+++ b/extensions/ext-cache-redis/src/test-utils.ts
@@ -29,6 +29,8 @@ export interface InMemoryRedisClient {
   on(event: string, handler: (err: unknown) => void): this;
   /** Test helper — exposes raw map for assertions. */
   _dump(): Map<string, { value: string; expiresAt: number | null }>;
+  /** Test helper — emits redis client errors registered through `on("error")`. */
+  _emitError(error: unknown): void;
 }
 
 function matchGlob(pattern: string, key: string): boolean {
@@ -54,6 +56,7 @@ function matchGlob(pattern: string, key: string): boolean {
  */
 export function createInMemoryRedisStub(): InMemoryRedisClient {
   const store = new Map<string, { value: string; expiresAt: number | null }>();
+  const errorHandlers: Array<(err: unknown) => void> = [];
 
   function pruneExpired(key: string): void {
     const entry = store.get(key);
@@ -106,11 +109,19 @@ export function createInMemoryRedisStub(): InMemoryRedisClient {
       }
       return { cursor: "0", keys };
     },
-    on(_event, _handler) {
+    on(event, handler) {
+      if (event === "error") {
+        errorHandlers.push(handler);
+      }
       return client;
     },
     _dump() {
       return store;
+    },
+    _emitError(error) {
+      for (const handler of errorHandlers) {
+        handler(error);
+      }
     },
   };
 


### PR DESCRIPTION
## Summary

- classify expected Redis socket disconnect events as lifecycle disconnects instead of client errors
- preserve error-level logging for unexpected Redis client failures
- add regression coverage for both expected socket closes and unexpected Redis errors

Related: veryfront/veryfront-api#2601

## Verification

- RED: `deno test --no-check --allow-all extensions/ext-cache-redis/src/index.test.ts` failed on error-level socket-close logging
- GREEN: `deno test --no-check --allow-all extensions/ext-cache-redis/src/index.test.ts`
- `deno fmt --check`
- `deno lint extensions/ext-cache-redis/src/redis-cache.ts extensions/ext-cache-redis/src/index.test.ts extensions/ext-cache-redis/src/test-utils.ts`
- `deno task lint && deno task lint:core-deps && deno task lint:dependency-boundaries && deno task lint:extension-contracts && deno task lint:extension-capabilities`
- `deno task typecheck`
- `deno task test:unit --no-lock`
- `deno task verify:quick`
- pre-push hook: format, lint, typecheck, unit tests passed

## Risk

Narrow logging-only behavior change for expected Redis disconnect events. Unexpected Redis client failures still log at error level.