### PR TITLE
Guard npm integration metadata for Jira search

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.588",
+  "version": "0.1.589",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "#std/assert";
+import { assertEquals, assertStringIncludes } from "#std/assert";
 import { describe, it } from "#std/testing/bdd";
 import { normalizeNpmPackageMetadata } from "./npm-package-metadata.ts";
 
@@ -103,5 +103,35 @@ describe("npm supply-chain policy", () => {
 		const source = await Deno.readTextFile("extensions/ext-sandbox-shell-tools/src/index.ts");
 
 		assertEquals(source.includes('from "bash-tool"'), true);
+	});
+});
+
+describe("npm generated integration artifacts", () => {
+	it("builds npm from regenerated integration metadata", async () => {
+		const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
+		const buildNpmTask = denoConfig.tasks?.["build:npm"];
+
+		assertEquals(typeof buildNpmTask, "string");
+		assertEquals(
+			buildNpmTask.indexOf("scripts/build/generate-integrations-module.ts") <
+				buildNpmTask.indexOf("scripts/build/build-npm-dnt.ts"),
+			true,
+		);
+	});
+
+	it("keeps the active Jira JQL search endpoint in the npm source artifact", async () => {
+		const source = await Deno.readTextFile("src/integrations/_data.ts");
+
+		assertStringIncludes(
+			source,
+			'"url":"https://api.atlassian.com/ex/jira/{cloudId}/rest/api/3/search/jql"',
+		);
+		assertStringIncludes(source, '"nextPageToken"');
+		assertEquals(
+			source.includes(
+				'"url":"https://api.atlassian.com/ex/jira/{cloudId}/rest/api/3/search"',
+			),
+			false,
+		);
 	});
 });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.588";
+export const VERSION = "0.1.589";


### PR DESCRIPTION
## Summary
- add regression coverage for npm-generated Jira endpoint metadata
- verify Jira search metadata uses GET /rest/api/3/search/jql with nextPageToken
- bump deno.json and runtime version to 0.1.589

## Tests
- deno test --config=scripts/test.deno.json --no-check --allow-read scripts/build/npm-package-metadata.test.ts
- deno test --no-check --allow-all src/integrations/_data.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- deno task verify:quick
- pre-push full verify