### PR TITLE
Update Quickstart copy

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,65 +1,19 @@
 ---
 title: "Installation"
-description: "Install the Veryfront CLI and framework on macOS, Linux, or Windows."
+description: "Install Veryfront Code on macOS, Linux, or Windows."
 order: 2
 ---
 
 ## Requirements
 
 - macOS 12 or later, Linux x86_64 or arm64 (glibc), or Windows 10 or later.
-- Node.js 18.18 or later for `npm`, `npx`, and app builds.
-- Deno 1.45 or later, or Bun 1.1 or later, if you use those runtimes.
+- A JavaScript runtime: Node.js 18.18 or later, Deno 1.45 or later, or Bun
+  1.1 or later.
 - 1 GB of free disk space and 2 GB of RAM for local development.
 
-## Install
+## Blank or existing project
 
-Use a binary installer for a global CLI. Use a package manager when you already
-have an app. Use `npx` when you want to run the CLI once.
-
-<CodeGroup>
-
-```bash curl
-curl -fsSL https://veryfront.com/install.sh | sh
-```
-
-```powershell PowerShell
-irm https://veryfront.com/install.ps1 | iex
-```
-
-```bash Homebrew
-brew install veryfront/tap/veryfront
-```
-
-```bash npx
-npx veryfront
-```
-
-</CodeGroup>
-
-### macOS and Linux
-
-```bash
-curl -fsSL https://veryfront.com/install.sh | sh
-```
-
-This installs the latest standalone binary and adds it to your shell path.
-Homebrew installs the same binary:
-
-```bash
-brew install veryfront/tap/veryfront
-```
-
-### Windows
-
-```powershell
-irm https://veryfront.com/install.ps1 | iex
-```
-
-This installs the latest standalone binary and adds it to your user path.
-
-### Existing project
-
-Add Veryfront to an existing app when you do not want to scaffold a new project.
+Add Veryfront Code to an existing or blank Node.js, Deno, or Bun project.
 
 <CodeGroup>
 
@@ -85,6 +39,58 @@ deno add npm:veryfront
 
 </CodeGroup>
 
+## New scaffolded project
+
+Create a new Veryfront Code project when you want scaffolding and starter files.
+
+<CodeGroup>
+
+```bash npm
+npm create veryfront
+```
+
+```bash pnpm
+pnpm create veryfront
+```
+
+```bash yarn
+yarn create veryfront
+```
+
+```bash bun
+bun create veryfront
+```
+
+</CodeGroup>
+
+## Install the CLI
+
+Install the CLI globally when you use Veryfront commands often.
+
+### macOS and Linux
+
+Use the standalone installer:
+
+```bash
+curl -fsSL https://veryfront.com/install.sh | sh
+```
+
+This installs the latest standalone binary and adds it to your shell path.
+
+### Windows
+
+```powershell
+irm https://veryfront.com/install.ps1 | iex
+```
+
+This installs the latest standalone binary and adds it to your user path.
+
+### Homebrew
+
+```bash
+brew install veryfront/tap/veryfront
+```
+
 ### npx (one-shot)
 
 ```bash
@@ -93,7 +99,7 @@ npx veryfront
 
 Runs the latest `veryfront` CLI without installing it globally.
 
-## Verify it worked
+## Verify the CLI
 
 ```bash
 veryfront --version

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: "Quickstart"
-description: "Scaffold, run, and test your first Veryfront agent app."
+description: "Build your first Veryfront agent app."
 order: -1
 ---
 
@@ -41,9 +41,10 @@ From the project directory, authenticate with Veryfront Cloud:
 veryfront login
 ```
 
-This lets the app use the Veryfront Cloud gateway. You can also set
-`VERYFRONT_API_TOKEN` directly. Direct provider keys such as `OPENAI_API_KEY`
-or `ANTHROPIC_API_KEY` also work; see [Providers](../guides/providers.md).
+This lets the app use the Veryfront Cloud gateway for model inference. You can
+also set `VERYFRONT_API_TOKEN` directly. Direct provider keys such as
+`OPENAI_API_KEY` or `ANTHROPIC_API_KEY` also work; see
+[Providers](../guides/providers.md).
 
 ## Run it locally
 

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -572,12 +572,13 @@ describe("Guide: installation.md", () => {
     for (
       const heading of [
         "## Requirements",
-        "## Install",
+        "## Blank or existing project",
+        "## New scaffolded project",
+        "## Install the CLI",
         "### macOS and Linux",
         "### Windows",
-        "### Existing project",
         "### npx (one-shot)",
-        "## Verify it worked",
+        "## Verify the CLI",
       ]
     ) {
       assertStringIncludes(guide, heading);

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -580,9 +580,14 @@ describe("published guide contracts", () => {
       if (
         !CONCEPT_FILES.has(filename) &&
         filename !== "getting-started/index.md" &&
-        filename !== "guides/index.md"
+        filename !== "guides/index.md" &&
+        filename !== "getting-started/installation.md"
       ) {
         assertStringIncludes(guide, "## Verify it worked");
+      }
+
+      if (filename === "getting-started/installation.md") {
+        assertStringIncludes(guide, "## Verify the CLI");
       }
     });
   }


### PR DESCRIPTION
## Summary
- Shorten the Quickstart description.
- Clarify that Veryfront Cloud gateway auth is used for model inference.
- Restructure Installation around blank or existing projects, new scaffolded projects, and optional global CLI installation.

## Validation
- git diff --check
- deno fmt --check docs/getting-started/quickstart.md docs/getting-started/installation.md
- pre-push checks: format, lint, typecheck, unit tests (1909 passed)