### PR TITLE
Sharpen Code docs copy

### DIFF
--- a/docs/concepts/resource.md
+++ b/docs/concepts/resource.md
@@ -23,8 +23,8 @@ data that should be loaded by name.
 A resource is read. A tool is called. A prompt gives instructions. MCP servers
 can expose all three, but each has a different contract.
 
-This distinction matters because assistants should not need to call a mutating
-tool just to inspect context.
+This distinction matters because assistants should read context without calling
+a mutating tool.
 
 ## Wrong fit
 

--- a/docs/guides/choose-a-primitive.md
+++ b/docs/guides/choose-a-primitive.md
@@ -9,7 +9,7 @@ clear and prevents overlapping agents, workflows, jobs, and integrations.
 
 ## Quick choice
 
-| If you need to...                                           | Use                    | Start with                                  |
+| Goal                                                        | Use                    | Start with                                  |
 | ----------------------------------------------------------- | ---------------------- | ------------------------------------------- |
 | Receive browser, HTTP, or webhook traffic                   | App route or API route | [Pages and routing](./pages-and-routing.md) |
 | Answer users with model reasoning, tools, memory, or skills | Agent                  | [Agents](./agents.md)                       |
@@ -27,7 +27,7 @@ clear and prevents overlapping agents, workflows, jobs, and integrations.
 
 ## Decision rules
 
-| Primitive   | Use this when                                                                 | Do not use this when                                                          |
+| Primitive   | Use for                                                                       | Do not use for                                                                |
 | ----------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | App route   | A browser, HTTP client, or webhook needs an entry point.                      | The work should outlive the request or be reused outside routing.             |
 | Agent       | The model must decide, explain, call tools, use memory, or stream a response. | The work is deterministic and can be a function, task, or workflow step.      |

--- a/docs/guides/cli-knowledge-ingestion.md
+++ b/docs/guides/cli-knowledge-ingestion.md
@@ -22,7 +22,7 @@ veryfront knowledge ingest uploads/contracts/a.pdf uploads/contracts/b.pdf uploa
 
 ## Prerequisites
 
-Authenticate with the CLI and make sure the target project is known:
+Authenticate with the CLI and set the target project:
 
 ```bash
 export VERYFRONT_API_TOKEN=<TOKEN>
@@ -191,8 +191,8 @@ deno run -A cli/main.ts knowledge ingest uploads/contracts/q1.pdf --json
 
 ### `Missing API token`
 
-Set `VERYFRONT_API_TOKEN`, run `veryfront login`, or make sure your local CLI
-config already has a saved token.
+Set `VERYFRONT_API_TOKEN`, run `veryfront login`, or use a local CLI config with
+a saved token.
 
 ### `Could not determine project slug`
 

--- a/docs/guides/jobs.md
+++ b/docs/guides/jobs.md
@@ -177,14 +177,14 @@ await jobs.cron.trigger(cronJob.id);
 
 Use **Studio** when:
 
-- you are using a first-party flow that already creates jobs for you
-- you want to inspect status, events, batches, and retries visually
+- A first-party flow already creates jobs for you.
+- You want to inspect status, events, batches, and retries visually.
 
 Use the **SDK / API** when:
 
-- you need to create jobs directly
-- you need cron scheduling
-- you are building automation or agent-driven project operations
+- You create jobs directly.
+- You need cron scheduling.
+- You are building automation or agent-driven project operations.
 
 ## Verify it worked
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -70,10 +70,11 @@ const sandbox = Sandbox.createLazy({
 });
 ```
 
-If you need to override the resolved credentials, pass `authToken`
-explicitly. This can be a JWT or a Studio-generated API key.
+To override the resolved credentials, pass `authToken` explicitly. This can be a
+JWT or a Studio-generated API key.
 
-If you need project-scoped billing or isolation, pass `projectId` when creating the session.
+For project-scoped billing or isolation, pass `projectId` when creating the
+session.
 
 ```ts
 const sandbox = await Sandbox.create({


### PR DESCRIPTION
## Summary\n- trim wording in selected Code guide and concept pages\n- replace weak headings and instruction forms with direct copy\n- keep synced Code docs source aligned with veryfront-docs\n\n## Verification\n- git diff --check\n- pre-push checks: formatting, lint, type check, unit tests (1909 passed)