### PR TITLE
Release veryfront 0.1.590

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.589",
+  "version": "0.1.590",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.589";
+export const VERSION = "0.1.590";


### PR DESCRIPTION
## Summary
- bump veryfront package version to 0.1.590 so current integration metadata is released
- keep runtime VERSION in sync with deno.json

## Verification
- deno test --no-check --allow-all --parallel src/utils/version.test.ts src/utils/logger/logger.test.ts scripts/build/npm-package-metadata.test.ts src/integrations/_data.test.ts
- git diff --check