### PR TITLE
Let style jobs consume webhook payload wrappers

### DIFF
--- a/cli/commands/styles/command.test.ts
+++ b/cli/commands/styles/command.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { getUnderlyingVeryfrontClient } from "./command.ts";
+import { getUnderlyingVeryfrontClient, normalizeStyleArtifactBuildConfigInput } from "./command.ts";
 
 describe("getUnderlyingVeryfrontClient", () => {
   it("binds getAllSourceFiles to the underlying adapter", async () => {
@@ -37,5 +37,25 @@ describe("getUnderlyingVeryfrontClient", () => {
     assertEquals(sourceAdapter.client, client as never);
     assertEquals(sourceAdapter.contentContext, { branch: "main" });
     assertEquals(await sourceAdapter.getAllSourceFiles(), files);
+  });
+});
+
+describe("normalizeStyleArtifactBuildConfigInput", () => {
+  it("uses the webhook payload as the style build config", () => {
+    assertEquals(
+      normalizeStyleArtifactBuildConfigInput({
+        source: "webhook",
+        payload: { branch: "main", style_profile_hash: "profile-1" },
+        webhook_id: "whk_example",
+      }),
+      { branch: "main", style_profile_hash: "profile-1" },
+    );
+  });
+
+  it("leaves direct style build config unchanged", () => {
+    assertEquals(
+      normalizeStyleArtifactBuildConfigInput({ branch: "main", style_profile_hash: "profile-1" }),
+      { branch: "main", style_profile_hash: "profile-1" },
+    );
   });
 });

--- a/cli/commands/styles/command.ts
+++ b/cli/commands/styles/command.ts
@@ -70,6 +70,22 @@ type StyleArtifactSelector =
   }
   | { branch?: never; environmentName?: never; releaseId: string; type: "release"; value: string };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function normalizeStyleArtifactBuildConfigInput(parsed: unknown): unknown {
+  if (!isRecord(parsed)) {
+    return parsed;
+  }
+
+  if (parsed.source === "webhook" && isRecord(parsed.payload)) {
+    return parsed.payload;
+  }
+
+  return parsed;
+}
+
 function parseStyleArtifactBuildConfig(rawConfig: string | undefined): StyleArtifactBuildConfig {
   if (!rawConfig) {
     throw new Error("Missing --config JSON");
@@ -82,7 +98,7 @@ function parseStyleArtifactBuildConfig(rawConfig: string | undefined): StyleArti
     throw new Error("Invalid --config JSON");
   }
 
-  return StyleArtifactBuildConfigSchema.parse(parsed);
+  return StyleArtifactBuildConfigSchema.parse(normalizeStyleArtifactBuildConfigInput(parsed));
 }
 
 function resolveStyleArtifactSelector(

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.590",
+  "version": "0.1.591",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.590";
+export const VERSION = "0.1.591";


### PR DESCRIPTION
## Summary
- unwrap explicit webhook delivery envelopes before validating `veryfront styles build-artifact --config`
- keep direct style build configs unchanged
- bump package version to 0.1.591

## Validation
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all cli/commands/styles/command.test.ts`
- `deno fmt --check cli/commands/styles/command.ts cli/commands/styles/command.test.ts deno.json`
- pre-push started full format/lint/typecheck/unit suite; format/lint/typecheck and many unit tests passed, but the local hook hung without producing a final summary and was stopped

## Staging finding
Webhook-triggered `task:style-artifact-build` jobs on staging still reached the runtime with a `{ source: "webhook", payload: { branch: "main" }, ... }` envelope. This makes the command consume the task payload from that envelope so existing queued webhook jobs can run.