### PR TITLE
Keep CLI MCP out of production start

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,7 @@ Keep common CLI behavior consistent with the command router and `cli/AGENTS.md`.
 
 - Use `veryfront mcp` for stdio MCP sessions.
 - In `veryfront dev`, the HTTP MCP server starts on the app port plus `2`.
-- In `veryfront start`, the HTTP MCP server defaults to port `9999` unless configured otherwise.
+- `veryfront start` does not start the CLI MCP server or expose `vf_*` tools.
 - Prefer `vf_bootstrap` for initial context. It replaces separate project-context lookup calls for normal agent startup.
 - MCP help highlights `vf_list_local_projects`, `vf_list_templates`, `vf_list_integrations`, `vf_create_project`, `vf_get_errors`, `vf_preview_route`, `vf_scaffold`, `vf_list_routes`, and `vf_trigger_hmr`.
 - The standalone MCP runtime also exposes tools such as `vf_bootstrap`, `vf_get_project_context`, `vf_get_conventions`, `vf_get_status`, `vf_get_logs`, `vf_run_tests`, `vf_run_lint`, `vf_build`, and `vf_trigger_deploy`.

--- a/cli/app/index.ts
+++ b/cli/app/index.ts
@@ -1,8 +1,7 @@
 /**
  * CLI App Shell
  *
- * Interactive app-like CLI experience with dashboard, project navigation,
- * and MCP integration for coding agents.
+ * Interactive app-like CLI experience with dashboard and project navigation.
  */
 
 // Core app

--- a/cli/app/views/dashboard.ts
+++ b/cli/app/views/dashboard.ts
@@ -90,12 +90,11 @@ function renderBanner(state: AppState): string {
   textLines.push(`${brand("Veryfront")} ${dim("is now running")}`);
   textLines.push("");
 
-  // Server URL and MCP URL - always reserve both lines to prevent jumps
+  // Server URL and MCP URL, always reserve both lines to prevent jumps.
   textLines.push(`${dim("Url")} ${brand(state.server.url)}`);
 
-  if (state.mcp.enabled && state.mcp.transport === "http") {
-    const port = state.mcp.httpPort ?? 9999;
-    textLines.push(`${dim("Mcp")} ${brand(`http://veryfront.me:${port}/mcp`)}`);
+  if (state.mcp.enabled && state.mcp.transport === "http" && state.mcp.httpPort !== undefined) {
+    textLines.push(`${dim("Mcp")} ${brand(`http://veryfront.me:${state.mcp.httpPort}/mcp`)}`);
   } else {
     textLines.push("");
   }

--- a/cli/commands/mcp/command-help.ts
+++ b/cli/commands/mcp/command-help.ts
@@ -1,5 +1,5 @@
 import type { CommandHelp } from "../../help/types.ts";
-import { DEFAULT_DEV_MCP_PORT, DEFAULT_MCP_PORT } from "../../shared/constants.ts";
+import { DEFAULT_DEV_MCP_PORT } from "../../shared/constants.ts";
 
 export const mcpHelp: CommandHelp = {
   name: "mcp",
@@ -10,14 +10,13 @@ export const mcpHelp: CommandHelp = {
   examples: [
     "veryfront mcp                                  # Start stdio MCP server",
     `veryfront dev                                  # HTTP MCP on --port + 2 (default ${DEFAULT_DEV_MCP_PORT})`,
-    `deno task start                                # HTTP MCP on port ${DEFAULT_MCP_PORT}`,
   ],
   notes: [
     "Used by Claude Code, Cursor, and other AI coding assistants",
     "Two transport modes:",
     `  • HTTP: Auto-starts with 'veryfront dev' (--port + 2, default ${DEFAULT_DEV_MCP_PORT})`,
-    `          or 'veryfront start' (default ${DEFAULT_MCP_PORT})`,
     "  • stdio: Run 'veryfront mcp' for stdin/stdout communication",
+    "The CLI MCP server is development-only. Production start does not expose vf_* tools.",
     "",
     "Claude Code setup (~/.claude.json):",
     `  "mcpServers": { "veryfront": { "url": "http://veryfront.me:${DEFAULT_DEV_MCP_PORT}/mcp" } }`,

--- a/cli/commands/start/command-help.ts
+++ b/cli/commands/start/command-help.ts
@@ -3,18 +3,13 @@ import type { CommandHelp } from "../../help/types.ts";
 export const startHelp: CommandHelp = {
   name: "start",
   category: "project",
-  description: "Start development dashboard with proxy and MCP integration",
+  description: "Start the production dashboard and proxy server",
   usage: "veryfront start [options]",
   options: [
     {
       flag: "-p, --port <number>",
       description: "Port to run on",
       default: "8080",
-    },
-    {
-      flag: "--mcp-port <number>",
-      description: "MCP server port",
-      default: "9999",
     },
     {
       flag: "--project <path>",

--- a/cli/commands/start/command.test.ts
+++ b/cli/commands/start/command.test.ts
@@ -1,7 +1,9 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { readTextFile } from "veryfront/platform";
 import { startCommand } from "./command.ts";
+import { startHelp } from "./command-help.ts";
 import type { StartOptions } from "./command.ts";
 
 describe("commands/start/command", () => {
@@ -24,12 +26,10 @@ describe("commands/start/command", () => {
     it("supports all required fields", () => {
       const options: StartOptions = {
         port: 8080,
-        mcpPort: 9999,
         projectPath: null,
         headless: false,
       };
       assertEquals(options.port, 8080);
-      assertEquals(options.mcpPort, 9999);
       assertEquals(options.projectPath, null);
       assertEquals(options.headless, false);
     });
@@ -37,7 +37,6 @@ describe("commands/start/command", () => {
     it("accepts a string project path", () => {
       const options: StartOptions = {
         port: 8080,
-        mcpPort: 9999,
         projectPath: "/path/to/project",
         headless: false,
       };
@@ -47,7 +46,6 @@ describe("commands/start/command", () => {
     it("accepts headless mode enabled", () => {
       const options: StartOptions = {
         port: 3000,
-        mcpPort: 9000,
         projectPath: null,
         headless: true,
       };
@@ -57,12 +55,27 @@ describe("commands/start/command", () => {
     it("accepts custom port values", () => {
       const options: StartOptions = {
         port: 4000,
-        mcpPort: 5000,
         projectPath: null,
         headless: false,
       };
       assertEquals(options.port, 4000);
-      assertEquals(options.mcpPort, 5000);
+    });
+  });
+
+  describe("production MCP boundary", () => {
+    it("does not start the CLI MCP server from production start", async () => {
+      const source = await readTextFile("cli/commands/start/command.ts");
+
+      assertEquals(source.includes("../../mcp"), false);
+      assertEquals(source.includes("createMCPServer"), false);
+    });
+
+    it("does not advertise a production CLI MCP port", () => {
+      const optionText = startHelp.options?.map((option) => option.flag).join("\n") ?? "";
+      const helpText = JSON.stringify(startHelp);
+
+      assertEquals(optionText.includes("mcp-port"), false);
+      assertEquals(helpText.includes("9999"), false);
     });
   });
 });

--- a/cli/commands/start/command.ts
+++ b/cli/commands/start/command.ts
@@ -11,7 +11,6 @@ const logger = cliLogger.component("global");
 
 export interface StartOptions {
   port: number;
-  mcpPort: number;
   projectPath: string | null;
   headless: boolean;
 }
@@ -125,7 +124,7 @@ async function trySetupProxy(localProjects: Map<string, string>): Promise<ProxyS
 }
 
 export async function startCommand(options: StartOptions): Promise<void> {
-  const { port, mcpPort, projectPath, headless } = options;
+  const { port, projectPath, headless } = options;
 
   onGlobalError((error, type) => {
     const isFatal = (error.name === "RangeError" && error.message.includes("Maximum call stack")) ||
@@ -174,7 +173,6 @@ export async function startCommand(options: StartOptions): Promise<void> {
 
   const app = createApp({
     port,
-    mcpPort,
     headless,
     projects: discovered.projects,
     examples: discovered.examples,
@@ -225,9 +223,6 @@ export async function startCommand(options: StartOptions): Promise<void> {
 
   await server.ready;
 
-  const { createMCPServer } = await import("../../mcp/index.ts");
-  const mcpServer = await createMCPServer({ httpPort: mcpPort });
-
   app.setServerReady();
 
   let shuttingDown = false;
@@ -240,7 +235,6 @@ export async function startCommand(options: StartOptions): Promise<void> {
 
     try {
       app.stop();
-      await mcpServer.stop();
       shutdownController.abort();
       await server.stop();
       await proxy.close();

--- a/cli/commands/start/handler.test.ts
+++ b/cli/commands/start/handler.test.ts
@@ -34,26 +34,6 @@ describe("commands/start/handler", () => {
     });
   });
 
-  describe("mcp-port parsing via DEFAULT_MCP_PORT (9999)", () => {
-    it("uses default mcp port 9999 when not specified", () => {
-      const args: ParsedArgs = { _: ["start"] };
-      const mcpPort = typeof args["mcp-port"] === "number" ? args["mcp-port"] : 9999;
-      assertEquals(mcpPort, 9999);
-    });
-
-    it("uses explicit mcp-port when provided as number", () => {
-      const args: ParsedArgs = { _: ["start"], "mcp-port": 7000 };
-      const mcpPort = typeof args["mcp-port"] === "number" ? args["mcp-port"] : 9999;
-      assertEquals(mcpPort, 7000);
-    });
-
-    it("uses default mcp port when value is not a number", () => {
-      const args: ParsedArgs = { _: ["start"], "mcp-port": "invalid" };
-      const mcpPort = typeof args["mcp-port"] === "number" ? args["mcp-port"] : 9999;
-      assertEquals(mcpPort, 9999);
-    });
-  });
-
   describe("project path extraction", () => {
     it("extracts project path from --project flag", () => {
       const args: ParsedArgs = { _: ["start"], project: "my-project" };

--- a/cli/commands/start/handler.ts
+++ b/cli/commands/start/handler.ts
@@ -2,14 +2,12 @@ import { defineSchema, lazySchema } from "veryfront/schemas";
 import { startCommand } from "./command.ts";
 import { createArgParser, parseArgsOrThrow } from "#cli/shared/args";
 import type { ParsedArgs } from "#cli/shared/types";
-import { DEFAULT_MCP_PORT } from "#cli/shared/constants";
 
 const DEFAULT_START_PORT = 8080;
 
 const getStartArgsSchema = defineSchema((v) =>
   v.object({
     port: v.number().default(DEFAULT_START_PORT),
-    mcpPort: v.number().default(DEFAULT_MCP_PORT),
     project: v.string().optional(),
     headless: v.boolean().default(false),
   })
@@ -19,7 +17,6 @@ const StartArgsSchema = lazySchema(getStartArgsSchema);
 
 export const parseStartArgs = createArgParser(StartArgsSchema, {
   port: { keys: ["port", "p"], type: "number" },
-  mcpPort: { keys: ["mcp-port"], type: "number" },
   project: { keys: ["project"], type: "string" },
   headless: { keys: ["headless", "no-tui"], type: "boolean" },
 });
@@ -28,7 +25,6 @@ export async function handleStartCommand(args: ParsedArgs): Promise<void> {
   const opts = parseArgsOrThrow(parseStartArgs, "start", args);
   await startCommand({
     port: opts.port,
-    mcpPort: opts.mcpPort,
     projectPath: opts.project ?? null,
     headless: opts.headless,
   });

--- a/cli/mcp/skills/debug-runtime/SKILL.md
+++ b/cli/mcp/skills/debug-runtime/SKILL.md
@@ -8,7 +8,8 @@ Diagnose runtime errors by connecting to the dev server via MCP.
    ```bash
    veryfront dev
    ```
-   MCP is available on port 9999.
+   MCP is available on the dev server port plus 2. The default URL is
+   `http://localhost:3002/mcp`.
 
 2. **Check for errors** (via MCP)
    Use `vf_get_errors` to get current runtime errors.
@@ -31,5 +32,5 @@ Diagnose runtime errors by connecting to the dev server via MCP.
 ## Error Recovery
 
 - **Dev server not running**: Start with `veryfront dev`
-- **MCP not responding**: Check port 9999, restart dev server
+- **MCP not responding**: Check the printed MCP URL, restart dev server
 - **Error persists after fix**: Clear cache with `veryfront clean`, restart dev

--- a/cli/mcp/skills/scaffold-app/SKILL.md
+++ b/cli/mcp/skills/scaffold-app/SKILL.md
@@ -26,7 +26,8 @@ Create a new Veryfront application with proper structure and conventions.
    ```bash
    veryfront dev
    ```
-   Verify MCP is available on port 9999.
+   Verify MCP is available at the printed dev MCP URL. The default URL is
+   `http://localhost:3002/mcp`.
 
 ## Error Recovery
 

--- a/cli/skills/core-skills.ts
+++ b/cli/skills/core-skills.ts
@@ -184,7 +184,7 @@ Diagnose runtime errors via MCP.
 
 ## Steps
 
-1. Ensure \`veryfront dev\` is running (MCP on port 9999)
+1. Ensure \`veryfront dev\` is running (MCP on the dev server port plus 2)
 2. Use vf_get_errors for current runtime errors
 3. Use vf_get_debug_context for stack traces
 4. Read veryfront://logs resource for server logs
@@ -194,7 +194,7 @@ Diagnose runtime errors via MCP.
 ## Error Recovery
 
 - **Dev server not running**: Start with veryfront dev
-- **MCP not responding**: Check port 9999, restart
+- **MCP not responding**: Check the printed MCP URL, restart
 - **Error persists**: veryfront clean, restart dev`,
     directory: "core:debug-runtime",
   },

--- a/docs/api-reference/veryfront/cli.md
+++ b/docs/api-reference/veryfront/cli.md
@@ -55,7 +55,7 @@ The CLI groups commands by category. Each command supports `--help` for its full
 | `veryfront init` | Initialize a new Veryfront project |
 | `veryfront install` | Install AI assistant integrations (Cursor, Claude Code, etc.) |
 | `veryfront open` | Open project URLs in the browser |
-| `veryfront start` | Start development dashboard with proxy and MCP integration |
+| `veryfront start` | Start the production dashboard and proxy server |
 | `veryfront studio` | Open Veryfront Studio in browser |
 | `veryfront uninstall` | Remove AI assistant integrations |
 

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -8,6 +8,9 @@ Connect Claude Code, Cursor, Codex, or any MCP-aware coding agent to your Veryfr
 
 This is the CLI's built-in MCP server. It is separate from the application-facing MCP server (see [MCP server](./mcp-server.md)), which exposes _your_ tools to MCP clients. The CLI MCP exposes _Veryfront dev tools_ to your coding agent.
 
+The CLI MCP server is development-only. `veryfront start` does not expose
+`vf_*` tools in production.
+
 ## Prerequisites
 
 - A Veryfront project (see [Create project](../getting-started/create-project.md)).
@@ -23,11 +26,11 @@ The CLI MCP server supports two transports. Most agents work with HTTP.
 | HTTP      | Your agent supports remote MCP URLs (Claude Code, Cursor, Codex). | Auto-starts with `veryfront dev`.   |
 | stdio     | Your agent only supports stdio MCP servers.                       | Run `veryfront mcp` from the agent. |
 
-When you run `veryfront dev`, the HTTP MCP server listens on `--port + 2` (default `3002`). When you run `veryfront start`, it listens on `9999`. The endpoint is always `/mcp`.
+When you run `veryfront dev`, the HTTP MCP server listens on `--port + 2`
+(default `3002`). The endpoint is always `/mcp`.
 
 ```
 http://localhost:3002/mcp        # dev
-http://localhost:9999/mcp        # production
 ```
 
 The dev server also accepts the `veryfront.me` hostname, which resolves to `127.0.0.1` and is what the CLI prints by default.
@@ -114,7 +117,8 @@ From inside a connected coding agent, ask it to "list routes" or "show recent de
 
 ### The agent does not see Veryfront tools
 
-The dev server must be running. The HTTP MCP only listens while `veryfront dev` or `veryfront start` is active.
+The dev server must be running. The HTTP MCP only listens while `veryfront dev`
+is active.
 
 ### Port already in use
 

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -215,6 +215,13 @@ describe("Guide: coding-agents.md", () => {
     ) {
       assertStringIncludes(guide, snippet);
     }
+
+    assertEquals(guide.includes("http://localhost:9999/mcp"), false);
+    assertEquals(guide.includes("veryfront start`, it listens"), false);
+    assertEquals(
+      guide.includes("HTTP MCP only listens while `veryfront dev` or `veryfront start`"),
+      false,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- stop `veryfront start` from starting the CLI MCP server or accepting `--mcp-port`
- keep CLI MCP documented as dev-only through `veryfront dev` or explicit stdio `veryfront mcp`
- update coding-agent docs, CLI reference/help, embedded skills, and agent guidance to remove the production `9999/mcp` surface
- add regression guards so production start cannot reintroduce the CLI MCP import/help text silently

## Validation
- `deno test --no-check --allow-all cli/app cli/commands/start cli/commands/mcp cli/help cli/skills tests/docs/guide-code-examples.test.ts`
- `deno check cli/commands/start/command.ts cli/commands/start/handler.ts cli/commands/start/command-help.ts cli/commands/mcp/command-help.ts cli/app/index.ts cli/app/views/dashboard.ts`
- `deno task docs:validate`
- `deno fmt --check cli/app/index.ts cli/app/views/dashboard.ts cli/commands/mcp/command-help.ts cli/commands/start/command-help.ts cli/commands/start/command.test.ts cli/commands/start/command.ts cli/commands/start/handler.test.ts cli/commands/start/handler.ts cli/skills/core-skills.ts tests/docs/guide-code-examples.test.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint cli/app/index.ts cli/app/views/dashboard.ts cli/commands/mcp/command-help.ts cli/commands/start/command-help.ts cli/commands/start/command.test.ts cli/commands/start/command.ts cli/commands/start/handler.test.ts cli/commands/start/handler.ts cli/skills/core-skills.ts tests/docs/guide-code-examples.test.ts`
- pre-push hook: format, lint, typecheck, 1913 unit tests passed