### PR TITLE
docs: keep coding agent setup public

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -12,12 +12,13 @@ plus a code editor and terminal. AI know-how is not required.
 
 ## Contents
 
-| Page                                    | Goal                            |
-| --------------------------------------- | ------------------------------- |
-| [Quickstart](./quickstart.md)           | Build the first app end-to-end. |
-| [Installation](./installation.md)       | Install the CLI or framework.   |
-| [Create project](./create-project.md)   | Scaffold and run a project.     |
-| [Create agent](./create-agent.md)       | Define and invoke an agent.     |
-| [Create API](./create-api.md)           | Expose the agent route.         |
-| [Create frontend](./create-frontend.md) | Add a chat UI for the agent.    |
-| [Deploy project](./deploy-project.md)   | Build and ship the project.     |
+| Page                                        | Goal                                       |
+| ------------------------------------------- | ------------------------------------------ |
+| [Quickstart](./quickstart.md)               | Build the first app end-to-end.            |
+| [Installation](./installation.md)           | Install the CLI or framework.              |
+| [Create project](./create-project.md)       | Scaffold and run a project.                |
+| [Create agent](./create-agent.md)           | Define and invoke an agent.                |
+| [Create API](./create-api.md)               | Expose the agent route.                    |
+| [Create frontend](./create-frontend.md)     | Add a chat UI for the agent.               |
+| [Coding agents](../guides/coding-agents.md) | Connect an editor agent to the dev server. |
+| [Deploy project](./deploy-project.md)       | Build and ship the project.                |

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -127,12 +127,3 @@ The dev MCP port follows the dev server port (`--port + 2`). If you start the de
 ### CORS error from a browser-based agent
 
 The HTTP MCP only accepts requests from `localhost`, `127.0.0.1`, and `veryfront.me`. Browser agents that run from any other origin are rejected by design.
-
-### `Unknown command: mcp`
-
-Your installed CLI is older than the version that added MCP. Update with `npm install -g veryfront@latest`, or run from source:
-
-```bash
-cd veryfront-code
-deno run -A cli/main.ts mcp
-```

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -218,6 +218,8 @@ describe("Guide: coding-agents.md", () => {
 
     assertEquals(guide.includes("http://localhost:9999/mcp"), false);
     assertEquals(guide.includes("veryfront start`, it listens"), false);
+    assertEquals(guide.includes("Unknown command: mcp"), false);
+    assertEquals(guide.includes("deno run -A cli/main.ts mcp"), false);
     assertEquals(
       guide.includes("HTTP MCP only listens while `veryfront dev` or `veryfront start`"),
       false,

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -212,6 +212,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "Contents",
       "Before you start",
       "Installation",
+      "Coding agents",
       "TypeScript",
       "React",
     ],


### PR DESCRIPTION
## Summary
- remove the internal source-checkout fallback from the coding agents troubleshooting section
- link Coding agents from the Getting Started overview
- add docs tests to keep the removed internal fallback out

## Verification
- deno fmt docs/getting-started/index.md docs/guides/coding-agents.md tests/docs/guide-code-examples.test.ts tests/docs/guide-contracts.test.ts
- deno task docs:validate
- pre-push checks: format, lint, typecheck, generated manifests, 1913 unit tests