### PR TITLE
Prevent late provider stream tail errors from failing agent runs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.591",
+  "version": "0.1.592",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -161,6 +161,37 @@ describe("chat-stream-handler", () => {
       assertEquals(state.usage, { promptTokens: 0, completionTokens: 0, totalTokens: 0 });
     });
 
+    it("ignores a late provider body read error after a completed tool-call step", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+      const result = {
+        fullStream: {
+          async *[Symbol.asyncIterator]() {
+            yield { type: "tool-input-start", id: "tc-1", toolName: "gmail__get_email" };
+            yield { type: "tool-input-delta", id: "tc-1", delta: '{"id":"msg-1"}' };
+            yield { type: "finish", finishReason: "tool-calls", totalUsage: null };
+            throw new Error("error reading a body from connection");
+          },
+        },
+        textStream: {
+          async *[Symbol.asyncIterator]() {},
+        },
+      };
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      assertEquals(state.finishReason, "tool-calls");
+      assertEquals(state.toolCalls.size, 1);
+      assertEquals(events, [
+        { type: "tool-input-start", toolCallId: "tc-1", toolName: "gmail__get_email" },
+        {
+          type: "tool-input-delta",
+          toolCallId: "tc-1",
+          inputTextDelta: '{"id":"msg-1"}',
+        },
+      ]);
+    });
+
     it("processes tool-input-start and tool-input-delta", async () => {
       const { events, controller, encoder } = createSSECollector();
       const state = createStreamState();

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -131,6 +131,75 @@ function logProviderToolPart(
   });
 }
 
+function getStreamErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  if (
+    typeof error === "object" && error !== null && "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+function isLateProviderBodyReadError(error: unknown): boolean {
+  return /error reading a body from connection/i.test(getStreamErrorMessage(error));
+}
+
+function hasCompletedStepSignal(finishReason: string | null): boolean {
+  switch (finishReason) {
+    case "stop":
+    case "length":
+    case "tool-calls":
+    case "content-filter":
+    case "other":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function hasStreamOutput(state: ChatStreamState): boolean {
+  return state.accumulatedText.length > 0 || state.toolCalls.size > 0 ||
+    state.toolResults.length > 0;
+}
+
+function shouldIgnoreLateProviderBodyReadError(state: ChatStreamState, error: unknown): boolean {
+  return hasStreamOutput(state) && hasCompletedStepSignal(state.finishReason) &&
+    isLateProviderBodyReadError(error);
+}
+
+async function readNextStreamPart(
+  iterator: AsyncIterator<unknown>,
+  state: ChatStreamState,
+): Promise<IteratorResult<unknown>> {
+  try {
+    return await iterator.next();
+  } catch (error) {
+    if (!shouldIgnoreLateProviderBodyReadError(state, error)) {
+      throw error;
+    }
+
+    logger.warn("Ignoring late provider body read error after completed stream step", {
+      finishReason: state.finishReason,
+      toolCallCount: state.toolCalls.size,
+      toolResultCount: state.toolResults.length,
+      textLength: state.accumulatedText.length,
+      error: getStreamErrorMessage(error),
+    });
+
+    return { done: true, value: undefined };
+  }
+}
+
 export function createStreamState(): ChatStreamState {
   return {
     accumulatedText: "",
@@ -295,7 +364,14 @@ export function processStream(
 
     throwIfAborted(abortSignal);
 
-    for await (const part of result.fullStream) {
+    const streamIterator = result.fullStream[Symbol.asyncIterator]();
+    while (true) {
+      const next = await readNextStreamPart(streamIterator, state);
+      if (next.done) {
+        break;
+      }
+
+      const part = next.value;
       throwIfAborted(abortSignal);
       eventCount++;
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.591";
+export const VERSION = "0.1.592";


### PR DESCRIPTION
## Summary
- Treat the known late provider body-read failure as recoverable only after a completed stream step has already produced output or tool state.
- Add a regression test that reproduces the staging failure shape: tool input, tool-call finish, then a provider body-read exception.
- Bump the package metadata to `0.1.592` in `deno.json` and the shared runtime version constant.

## Evidence
- Staging API and runtime logs showed an agent run entering the runtime stream successfully, emitting visible output/tool activity, then failing at stream tail with a provider body-read exception.
- Conversations API persisted the matching terminal run error, which is what surfaced as the selected-agent provider error in the UI.

## Testing
- `deno test --no-check --allow-all src/agent/runtime/chat-stream-handler.test.ts`
- `deno test --no-check --allow-all src/internal-agents/run-stream.test.ts src/agent/runtime/index.test.ts`
- `deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts`
- `deno lint src/agent/runtime/chat-stream-handler.ts src/agent/runtime/chat-stream-handler.test.ts`
- `deno fmt --check deno.json src/agent/runtime/chat-stream-handler.ts src/agent/runtime/chat-stream-handler.test.ts src/utils/version-constant.ts`
- `deno check src/agent/runtime/chat-stream-handler.ts`
- `deno task build:npm`
- `npm pack ./npm --dry-run`
- `deno task docs:verify-npm`
- Pre-push hook: formatting, linter, typecheck, generated manifests/bundles, and full unit suite: 1913 passed / 0 failed.

## Rollout
- Publish `veryfront@0.1.592` after merge/release.
- Then refresh downstream lockfiles for API, Studio, Agent, and Codex Agent. Manifest bumps are prepared locally, but lockfile updates are blocked until the package is available in the registry.
