### PR TITLE
Clarify RAG embedding model overrides

### DIFF
--- a/docs/guides/build-a-rag-app.md
+++ b/docs/guides/build-a-rag-app.md
@@ -212,8 +212,10 @@ With cloud bootstrap:
   through AI Gateway.
 
 The default cloud embedding model is
-`veryfront-cloud/openai/text-embedding-3-small`. Override it only when you need a
-specific embedding model:
+`veryfront-cloud/openai/text-embedding-3-small`. Set
+`VERYFRONT_DEFAULT_EMBEDDING_MODEL` to `provider/model`, such as
+`google/text-embedding-004`; Cloud bootstrap routes it as
+`veryfront-cloud/google/text-embedding-004`:
 
 ```bash title="Terminal"
 export VERYFRONT_DEFAULT_EMBEDDING_MODEL=google/text-embedding-004


### PR DESCRIPTION
## Summary
- Clarify that Cloud bootstrap accepts `provider/model` embedding overrides.
- Show that `google/text-embedding-004` routes as `veryfront-cloud/google/text-embedding-004`.

## Verification
- `git diff --check`
- `deno fmt --check docs/guides/build-a-rag-app.md`
- Pre-push checks: formatting, lint, typecheck, unit tests (`1913 passed`, `17604 steps`, `0 failed`)

Constraint: Keep the RAG guide concise and avoid adding a separate configuration section.
Confidence: high
Scope-risk: narrow
Tested: git diff --check
Tested: deno fmt --check docs/guides/build-a-rag-app.md
Tested: Pre-push formatting, lint, typecheck, and unit tests
Not-tested: Docs site preview; wording-only change.