### PR TITLE
Remove @veryfront/ext-bundler-esbuild from scaffolded package.json

### DIFF
--- a/cli/commands/init/config-generator.test.ts
+++ b/cli/commands/init/config-generator.test.ts
@@ -64,7 +64,6 @@ describe("config-generator", () => {
         });
         const pkg = JSON.parse(await Deno.readTextFile(join(tmpDir, "package.json")));
         assertEquals(Object.keys(pkg.dependencies).sort(), [
-          "@veryfront/ext-bundler-esbuild",
           "react",
           "react-dom",
           "veryfront",

--- a/cli/commands/init/config-generator.ts
+++ b/cli/commands/init/config-generator.ts
@@ -70,7 +70,6 @@ export async function createPackageJson(
       react: `^${DEFAULT_INIT_REACT_VERSION}`,
       "react-dom": `^${DEFAULT_INIT_REACT_VERSION}`,
       veryfront: `^${VERSION}`,
-      "@veryfront/ext-bundler-esbuild": `^${VERSION}`,
       zod: "^3.24.0",
     },
   };


### PR DESCRIPTION
## Summary
- Drop `@veryfront/ext-bundler-esbuild` from the dependencies written by `createPackageJson` during `veryfront init`.
- The npm-published `veryfront` already depends on `esbuild` directly, and the dynamic `@veryfront/ext-*` imports in `cli/main.ts` are stripped by the dnt build (`npm/esm/cli/main.js` has no such import). Scaffolded projects don't need this dep.
- Update the corresponding assertion in `config-generator.test.ts`.

## Test plan
- [x] `deno test --allow-all --no-check cli/commands/init/config-generator.test.ts`
- [x] Pre-push hooks (full suite) pass