### PR TITLE
fix(discovery): externalize npm deps in tool/agent discovery bundler

### DIFF
--- a/src/discovery/import-rewriter.test.ts
+++ b/src/discovery/import-rewriter.test.ts
@@ -47,6 +47,42 @@ describe("discovery/import-rewriter", () => {
     assertEquals(transformed.includes('from "veryfront/'), false);
   });
 
+  it("prefixes arbitrary bare npm imports with npm: for Deno temp module imports", () => {
+    const transformed = rewriteForDeno(
+      [
+        'import pdfParse from "pdf-parse";',
+        'import mammoth from "mammoth";',
+        'const pdf = await import("pdf-parse");',
+        'import { z } from "zod";',
+      ].join("\n"),
+      "/project/tools",
+    );
+
+    assertStringIncludes(transformed, 'from "npm:pdf-parse"');
+    assertStringIncludes(transformed, 'from "npm:mammoth"');
+    assertStringIncludes(transformed, 'import("npm:pdf-parse")');
+    assertStringIncludes(transformed, 'from "npm:zod"');
+    assertEquals(transformed.includes('from "pdf-parse"'), false);
+    assertEquals(transformed.includes('from "mammoth"'), false);
+  });
+
+  it("leaves node:, file:, relative, and veryfront specifiers untouched", () => {
+    const transformed = rewriteForDeno(
+      [
+        'import fs from "node:fs";',
+        'import path from "node:path";',
+        'import local from "./helpers.ts";',
+        'import remote from "https://esm.sh/some-pkg";',
+      ].join("\n"),
+      "/project/tools",
+    );
+
+    assertStringIncludes(transformed, 'from "node:fs"');
+    assertStringIncludes(transformed, 'from "node:path"');
+    assertStringIncludes(transformed, 'from "./helpers.ts"');
+    assertStringIncludes(transformed, 'from "https://esm.sh/some-pkg"');
+  });
+
   it("resolves veryfront public imports for Node discovery modules without project-local dependencies", async () => {
     const transformed = await rewriteDiscoveryImports(
       [

--- a/src/discovery/import-rewriter.test.ts
+++ b/src/discovery/import-rewriter.test.ts
@@ -94,6 +94,39 @@ describe("discovery/import-rewriter", () => {
     assertStringIncludes(transformed, 'import "./side-effects.ts"');
   });
 
+  it("rewrites `export … from` re-exports of bare npm packages for Deno", () => {
+    const transformed = rewriteForDeno(
+      [
+        'export { z } from "zod";',
+        'export * from "pdf-parse";',
+        'export { type ZodSchema } from "zod";',
+      ].join("\n"),
+      "/project/tools",
+    );
+
+    assertStringIncludes(transformed, 'export { z } from "npm:zod"');
+    assertStringIncludes(transformed, 'export * from "npm:pdf-parse"');
+    assertEquals(transformed.includes('from "zod";'), false);
+    assertEquals(transformed.includes('from "pdf-parse";'), false);
+  });
+
+  it("does not rewrite `import type` / `export type` lines for Deno", () => {
+    const transformed = rewriteForDeno(
+      [
+        'import type { ZodSchema } from "zod";',
+        'export type { ZodSchema } from "zod";',
+        'import { z, type ZodTypeAny } from "zod";',
+      ].join("\n"),
+      "/project/tools",
+    );
+
+    // type-only lines are erased by TS; they must not gain an npm: prefix
+    assertStringIncludes(transformed, 'import type { ZodSchema } from "zod"');
+    assertStringIncludes(transformed, 'export type { ZodSchema } from "zod"');
+    // The value-bearing `import { z, type ZodTypeAny }` is still rewritten
+    assertStringIncludes(transformed, 'import { z, type ZodTypeAny } from "npm:zod"');
+  });
+
   it("leaves node:, file:, relative, and veryfront specifiers untouched", () => {
     const transformed = rewriteForDeno(
       [
@@ -184,6 +217,58 @@ describe("discovery/import-rewriter", () => {
       assertStringIncludes(transformed, "dotenv/lib/main.js");
       assertEquals(transformed.includes('import "dotenv/config"'), false);
       assertEquals(transformed.includes('from "dotenv"'), false);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("rewrites `export … from` re-exports of bare npm packages in the Node discovery path", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
+    const zodDir = `${projectDir}/node_modules/zod`;
+    await Deno.mkdir(zodDir, { recursive: true });
+    await Deno.writeTextFile(
+      `${zodDir}/package.json`,
+      JSON.stringify({ name: "zod", version: "3.24.0", main: "./index.js" }),
+    );
+    await Deno.writeTextFile(`${zodDir}/index.js`, "");
+
+    try {
+      const transformed = await rewriteDiscoveryImports(
+        [
+          'export { z } from "zod";',
+          'export * from "zod";',
+        ].join("\n"),
+        projectDir,
+        createFileSystem(),
+        `${projectDir}/app`,
+      );
+
+      assertStringIncludes(transformed, "zod/index.js");
+      assertEquals(transformed.includes('export { z } from "zod"'), false);
+      assertEquals(transformed.includes('export * from "zod"'), false);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("does not resolve `import type` lines in the Node discovery path", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
+    // Intentionally no node_modules — a real resolution would fail.
+    // The rewriter must not even try, because `import type` is erased.
+
+    try {
+      const transformed = await rewriteDiscoveryImports(
+        [
+          'import type { Foo } from "some-pkg-not-installed";',
+          'export type { Bar } from "another-missing-pkg";',
+        ].join("\n"),
+        projectDir,
+        createFileSystem(),
+        `${projectDir}/app`,
+      );
+
+      assertStringIncludes(transformed, 'import type { Foo } from "some-pkg-not-installed"');
+      assertStringIncludes(transformed, 'export type { Bar } from "another-missing-pkg"');
     } finally {
       await Deno.remove(projectDir, { recursive: true });
     }

--- a/src/discovery/import-rewriter.test.ts
+++ b/src/discovery/import-rewriter.test.ts
@@ -353,6 +353,40 @@ describe("discovery/import-rewriter", () => {
     }
   });
 
+  it("refuses to resolve a package whose exports map escapes the package directory", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
+    const pkgDir = `${projectDir}/node_modules/evil`;
+    const outside = `${projectDir}/SECRET.js`;
+    await Deno.mkdir(pkgDir, { recursive: true });
+    // The malicious exports value attempts to point the bare import at
+    // `<projectDir>/SECRET.js`, which sits outside `node_modules/evil`.
+    await Deno.writeTextFile(
+      `${pkgDir}/package.json`,
+      JSON.stringify({
+        name: "evil",
+        version: "1.0.0",
+        exports: { ".": "../../SECRET.js" },
+      }),
+    );
+    await Deno.writeTextFile(outside, 'throw new Error("you should never load me");');
+
+    try {
+      const transformed = await rewriteDiscoveryImports(
+        'import x from "evil";',
+        projectDir,
+        createFileSystem(),
+        `${projectDir}/app`,
+      );
+
+      // The rewriter must refuse the resolution — the import must be left
+      // bare (or otherwise NOT point at the file outside the package dir).
+      assertEquals(transformed.includes("SECRET.js"), false);
+      assertStringIncludes(transformed, 'from "evil"');
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
   it("resolves veryfront public imports for Node discovery modules without project-local dependencies", async () => {
     const transformed = await rewriteDiscoveryImports(
       [

--- a/src/discovery/import-rewriter.test.ts
+++ b/src/discovery/import-rewriter.test.ts
@@ -66,6 +66,34 @@ describe("discovery/import-rewriter", () => {
     assertEquals(transformed.includes('from "mammoth"'), false);
   });
 
+  it("prefixes bare side-effect imports for Deno temp module imports", () => {
+    const transformed = rewriteForDeno(
+      [
+        'import "reflect-metadata";',
+        'import "dotenv/config";',
+        'import { z } from "zod";',
+      ].join("\n"),
+      "/project/tools",
+    );
+
+    assertStringIncludes(transformed, 'import "npm:reflect-metadata"');
+    assertStringIncludes(transformed, 'import "npm:dotenv/config"');
+    assertStringIncludes(transformed, 'from "npm:zod"');
+  });
+
+  it("leaves node: and relative side-effect imports untouched", () => {
+    const transformed = rewriteForDeno(
+      [
+        'import "node:crypto";',
+        'import "./side-effects.ts";',
+      ].join("\n"),
+      "/project/tools",
+    );
+
+    assertStringIncludes(transformed, 'import "node:crypto"');
+    assertStringIncludes(transformed, 'import "./side-effects.ts"');
+  });
+
   it("leaves node:, file:, relative, and veryfront specifiers untouched", () => {
     const transformed = rewriteForDeno(
       [
@@ -81,6 +109,84 @@ describe("discovery/import-rewriter", () => {
     assertStringIncludes(transformed, 'from "node:path"');
     assertStringIncludes(transformed, 'from "./helpers.ts"');
     assertStringIncludes(transformed, 'from "https://esm.sh/some-pkg"');
+  });
+
+  it("resolves bare-package subpath imports via package.json#exports in the Node discovery path", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
+    const reactDir = `${projectDir}/node_modules/react`;
+    await Deno.mkdir(reactDir, { recursive: true });
+    await Deno.writeTextFile(
+      `${reactDir}/package.json`,
+      JSON.stringify({
+        name: "react",
+        version: "19.0.0",
+        exports: {
+          ".": "./index.js",
+          "./jsx-runtime": "./jsx-runtime.js",
+        },
+      }),
+    );
+    await Deno.writeTextFile(`${reactDir}/index.js`, "");
+    await Deno.writeTextFile(`${reactDir}/jsx-runtime.js`, "");
+
+    try {
+      const transformed = await rewriteDiscoveryImports(
+        [
+          'import { jsx } from "react/jsx-runtime";',
+          'import React from "react";',
+        ].join("\n"),
+        projectDir,
+        createFileSystem(),
+        `${projectDir}/app`,
+      );
+
+      assertStringIncludes(transformed, "react/jsx-runtime.js");
+      assertStringIncludes(transformed, "react/index.js");
+      assertEquals(transformed.includes('from "react/jsx-runtime"'), false);
+      assertEquals(transformed.includes('from "react"'), false);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("resolves side-effect imports via the project's node_modules in the Node discovery path", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
+    const dotenvDir = `${projectDir}/node_modules/dotenv`;
+    await Deno.mkdir(dotenvDir, { recursive: true });
+    await Deno.writeTextFile(
+      `${dotenvDir}/package.json`,
+      JSON.stringify({
+        name: "dotenv",
+        version: "16.0.0",
+        exports: {
+          ".": "./lib/main.js",
+          "./config": "./config.js",
+        },
+      }),
+    );
+    await Deno.writeTextFile(`${dotenvDir}/config.js`, "");
+    await Deno.mkdir(`${dotenvDir}/lib`, { recursive: true });
+    await Deno.writeTextFile(`${dotenvDir}/lib/main.js`, "");
+
+    try {
+      const transformed = await rewriteDiscoveryImports(
+        [
+          'import "dotenv/config";',
+          'import { config } from "dotenv";',
+        ].join("\n"),
+        projectDir,
+        createFileSystem(),
+        `${projectDir}/app`,
+      );
+
+      assertStringIncludes(transformed, 'import "file://');
+      assertStringIncludes(transformed, "dotenv/config.js");
+      assertStringIncludes(transformed, "dotenv/lib/main.js");
+      assertEquals(transformed.includes('import "dotenv/config"'), false);
+      assertEquals(transformed.includes('from "dotenv"'), false);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
   });
 
   it("resolves veryfront public imports for Node discovery modules without project-local dependencies", async () => {

--- a/src/discovery/import-rewriter.test.ts
+++ b/src/discovery/import-rewriter.test.ts
@@ -1,6 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { rewriteDiscoveryImports, rewriteForDeno } from "./import-rewriter.ts";
 
@@ -269,6 +269,85 @@ describe("discovery/import-rewriter", () => {
 
       assertStringIncludes(transformed, 'import type { Foo } from "some-pkg-not-installed"');
       assertStringIncludes(transformed, 'export type { Bar } from "another-missing-pkg"');
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("resolves bare-package subpath imports via package.json#exports glob patterns (lodash-es style)", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
+    const pkgDir = `${projectDir}/node_modules/lodash-es`;
+    await Deno.mkdir(pkgDir, { recursive: true });
+    await Deno.writeTextFile(
+      `${pkgDir}/package.json`,
+      JSON.stringify({
+        name: "lodash-es",
+        version: "4.17.21",
+        type: "module",
+        exports: {
+          ".": "./lodash.js",
+          "./*": "./*.js",
+        },
+      }),
+    );
+    await Deno.writeTextFile(`${pkgDir}/lodash.js`, "");
+    await Deno.writeTextFile(`${pkgDir}/debounce.js`, "");
+    await Deno.writeTextFile(`${pkgDir}/throttle.js`, "");
+
+    try {
+      const transformed = await rewriteDiscoveryImports(
+        [
+          'import debounce from "lodash-es/debounce";',
+          'import throttle from "lodash-es/throttle";',
+        ].join("\n"),
+        projectDir,
+        createFileSystem(),
+        `${projectDir}/app`,
+      );
+
+      // Glob pattern `./*` → `./*.js` must produce `debounce.js`, not bare `debounce`
+      assertStringIncludes(transformed, "lodash-es/debounce.js");
+      assertStringIncludes(transformed, "lodash-es/throttle.js");
+      assertEquals(transformed.includes('"lodash-es/debounce"'), false);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("does not cache missing-package lookups, so a later install is picked up without restart", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-rewriter-test-" });
+    const pkgDir = `${projectDir}/node_modules/late-installed`;
+    const code = 'import x from "late-installed";';
+
+    try {
+      // First pass: package not present yet → should leave bare import alone.
+      const before = await rewriteDiscoveryImports(
+        code,
+        projectDir,
+        createFileSystem(),
+        `${projectDir}/app`,
+      );
+      assertStringIncludes(before, 'from "late-installed"');
+      assert(!before.includes("file://"));
+
+      // Simulate `npm install` between passes.
+      await Deno.mkdir(pkgDir, { recursive: true });
+      await Deno.writeTextFile(
+        `${pkgDir}/package.json`,
+        JSON.stringify({ name: "late-installed", main: "./index.js" }),
+      );
+      await Deno.writeTextFile(`${pkgDir}/index.js`, "");
+
+      // Second pass: must now resolve — null lookups are intentionally
+      // NOT cached so dev servers recover after `npm install` without a
+      // process restart.
+      const after = await rewriteDiscoveryImports(
+        code,
+        projectDir,
+        createFileSystem(),
+        `${projectDir}/app`,
+      );
+      assertStringIncludes(after, "late-installed/index.js");
     } finally {
       await Deno.remove(projectDir, { recursive: true });
     }

--- a/src/discovery/import-rewriter.ts
+++ b/src/discovery/import-rewriter.ts
@@ -250,7 +250,7 @@ function resolveExportPath(exports: unknown, subpath: string): string | null {
   );
   const template = pickExportEntry(map[bestKey]);
   if (!template) return null;
-  return template.replace("*", captured);
+  return template.replaceAll("*", captured);
 }
 
 /**

--- a/src/discovery/import-rewriter.ts
+++ b/src/discovery/import-rewriter.ts
@@ -121,7 +121,17 @@ function rewriteBareNpmImportsForDeno(code: string): string {
     })
     .replace(/import\s*\(\s*["']([^"']+)["']\s*\)/g, (match, specifier: string) => {
       return isUnprefixedNpmSpecifier(specifier) ? `import("npm:${specifier}")` : match;
-    });
+    })
+    // Side-effect-only imports: `import "reflect-metadata";`, `import "dotenv/config";`.
+    // Match `import` not followed by `(` and without a `from` clause.
+    .replace(
+      /(^|[\n;{}])(\s*)import\s+["']([^"']+)["'](\s*;?)/g,
+      (match, lead: string, indent: string, specifier: string, tail: string) => {
+        return isUnprefixedNpmSpecifier(specifier)
+          ? `${lead}${indent}import "npm:${specifier}"${tail}`
+          : match;
+      },
+    );
 }
 
 export function rewriteForDeno(
@@ -181,8 +191,24 @@ export async function rewriteDiscoveryImports(
         `from "${pathToFileURL(pathHelper.resolve(fileDir, relativePath)).href}"`,
     );
 
-    // Resolve npm package to file URL
-    const resolvePackageToFileUrl = async (packageName: string): Promise<string | null> => {
+    // Split `react/jsx-runtime` → { name: "react", subpath: "./jsx-runtime" } and
+    // `@scope/pkg/sub/path` → { name: "@scope/pkg", subpath: "./sub/path" }.
+    // The bare package name resolves to a single package.json; the subpath
+    // is then read from the package's `exports` map or, failing that,
+    // joined onto the package directory.
+    const splitPackageSubpath = (specifier: string): { name: string; subpath: string } => {
+      const parts = specifier.split("/");
+      const segments = specifier.startsWith("@") ? parts.slice(0, 2) : parts.slice(0, 1);
+      const name = segments.join("/");
+      const rest = parts.slice(segments.length).join("/");
+      return { name, subpath: rest ? `./${rest}` : "." };
+    };
+
+    // Resolve a bare specifier (optionally with subpath) to a file:// URL,
+    // honoring the package's `exports` map for subpath imports such as
+    // `react/jsx-runtime` or `lodash-es/debounce`.
+    const resolvePackageToFileUrl = async (specifier: string): Promise<string | null> => {
+      const { name: packageName, subpath } = splitPackageSubpath(specifier);
       let searchDir = projectDir;
 
       for (let i = 0; i < 10; i++) {
@@ -191,12 +217,17 @@ export async function rewriteDiscoveryImports(
 
         try {
           const pkgJson = JSON.parse(await fs.readTextFile(packageJsonPath));
-          const dotExport = pkgJson.exports?.["."];
-          const entryPoint =
-            (typeof dotExport === "string" ? dotExport : dotExport?.import ?? dotExport?.default) ??
-              pkgJson.module ??
-              pkgJson.main ??
-              "index.js";
+          const exportEntry = pkgJson.exports?.[subpath];
+          const exportPath = typeof exportEntry === "string"
+            ? exportEntry
+            : exportEntry?.import ?? exportEntry?.default;
+
+          const entryPoint = exportPath ??
+            (subpath === "."
+              ? (pkgJson.module ?? pkgJson.main ?? "index.js")
+              // No exports entry for this subpath: fall back to joining the
+              // subpath onto the package dir (e.g. `dotenv/config.js`).
+              : subpath.replace(/^\.\//, ""));
 
           return pathToFileURL(pathHelper.join(packagePath, entryPoint)).href;
         } catch (_) {
@@ -210,28 +241,43 @@ export async function rewriteDiscoveryImports(
       return null;
     };
 
-    // Rewrite package imports
+    // Rewrite package imports — covers `from "spec"`, `import("spec")`, and
+    // side-effect `import "spec";` forms for the given (possibly-subpathed)
+    // specifier.
     const rewritePackageImports = async (input: string, pkg: string): Promise<string> => {
       const escapedPkg = pkg.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const staticImportRegex = new RegExp(`from\\s*["']${escapedPkg}["']`, "g");
       const dynamicImportRegex = new RegExp(`import\\s*\\(\\s*["']${escapedPkg}["']\\s*\\)`, "g");
+      const sideEffectRegex = new RegExp(
+        `(^|[\\n;{}])(\\s*)import\\s+["']${escapedPkg}["'](\\s*;?)`,
+        "g",
+      );
 
-      if (!staticImportRegex.test(input) && !dynamicImportRegex.test(input)) return input;
+      if (
+        !staticImportRegex.test(input) &&
+        !dynamicImportRegex.test(input) &&
+        !sideEffectRegex.test(input)
+      ) return input;
 
       const resolvedUrl = await resolvePackageToFileUrl(pkg);
       if (!resolvedUrl) return input;
 
       return input
         .replace(staticImportRegex, `from "${resolvedUrl}"`)
-        .replace(dynamicImportRegex, `import("${resolvedUrl}")`);
+        .replace(dynamicImportRegex, `import("${resolvedUrl}")`)
+        .replace(
+          sideEffectRegex,
+          (_m, lead: string, indent: string, tail: string) =>
+            `${lead}${indent}import "${resolvedUrl}"${tail}`,
+        );
     };
 
     // Collect every bare specifier the transformed source still imports,
     // then resolve each to a file:// URL in the project's node_modules.
     // With `packages: "external"` in the discovery bundler, npm packages a
-    // tool/agent depends on (e.g. `pdf-parse`, `mammoth`) survive as bare
-    // imports here and need explicit resolution before the temp module is
-    // loaded from outside the project's resolution root.
+    // tool/agent depends on (e.g. `pdf-parse`, `mammoth`, `react/jsx-runtime`)
+    // survive as bare imports here and need explicit resolution before the
+    // temp module is loaded from outside the project's resolution root.
     const collectBareSpecifiers = (input: string): string[] => {
       const specifiers = new Set<string>();
       for (const match of input.matchAll(/from\s*["']([^"']+)["']/g)) {
@@ -239,6 +285,15 @@ export async function rewriteDiscoveryImports(
         if (s && isUnprefixedNpmSpecifier(s)) specifiers.add(s);
       }
       for (const match of input.matchAll(/import\s*\(\s*["']([^"']+)["']\s*\)/g)) {
+        const s = match[1];
+        if (s && isUnprefixedNpmSpecifier(s)) specifiers.add(s);
+      }
+      // Side-effect imports: `import "reflect-metadata";`, `import "dotenv/config";`.
+      for (
+        const match of input.matchAll(
+          /(?:^|[\n;{}])\s*import\s+["']([^"']+)["']\s*;?/g,
+        )
+      ) {
         const s = match[1];
         if (s && isUnprefixedNpmSpecifier(s)) specifiers.add(s);
       }

--- a/src/discovery/import-rewriter.ts
+++ b/src/discovery/import-rewriter.ts
@@ -89,12 +89,6 @@ function rewriteDenoCompiledVeryfrontImports(code: string): string {
 }
 
 /**
- * Rewrite imports for Deno runtime
- * - Converts npm package imports to npm: specifier format
- * - Resolves relative imports to absolute file:// URLs
- * - For compiled binaries, rewrites veryfront imports to use globals
- */
-/**
  * True for bare npm imports that need an `npm:` prefix for Deno to resolve
  * them when the discovery module is loaded from a temp directory. Excludes
  * relative paths, absolute URLs, Node built-ins, and the veryfront package
@@ -114,16 +108,25 @@ function isUnprefixedNpmSpecifier(specifier: string): boolean {
   return true;
 }
 
+// `import type` / `export type` lines reference types only; they get erased
+// by TypeScript and must not trigger filesystem resolution.
+const TYPE_ONLY_STATIC_RE = /(?:^|[\s;{}])(?:import|export)\s+type\b/;
+
 function rewriteBareNpmImportsForDeno(code: string): string {
   return code
-    .replace(/from\s+["']([^"']+)["']/g, (match, specifier: string) => {
-      return isUnprefixedNpmSpecifier(specifier) ? `from "npm:${specifier}"` : match;
-    })
+    // `import x from "spec"`, `export { x } from "spec"`, `export * from "spec"`.
+    // The leading-context capture lets us skip `import type` / `export type`.
+    .replace(
+      /(^|[\s;{}])((?:import|export)\b[^"']*?\bfrom\s+)["']([^"']+)["']/g,
+      (match, lead: string, head: string, specifier: string) => {
+        if (TYPE_ONLY_STATIC_RE.test(lead + head)) return match;
+        return isUnprefixedNpmSpecifier(specifier) ? `${lead}${head}"npm:${specifier}"` : match;
+      },
+    )
     .replace(/import\s*\(\s*["']([^"']+)["']\s*\)/g, (match, specifier: string) => {
       return isUnprefixedNpmSpecifier(specifier) ? `import("npm:${specifier}")` : match;
     })
     // Side-effect-only imports: `import "reflect-metadata";`, `import "dotenv/config";`.
-    // Match `import` not followed by `(` and without a `from` clause.
     .replace(
       /(^|[\n;{}])(\s*)import\s+["']([^"']+)["'](\s*;?)/g,
       (match, lead: string, indent: string, specifier: string, tail: string) => {
@@ -133,6 +136,13 @@ function rewriteBareNpmImportsForDeno(code: string): string {
       },
     );
 }
+
+/**
+ * Rewrite imports for Deno runtime
+ * - Converts npm package imports to npm: specifier format
+ * - Resolves relative imports to absolute file:// URLs
+ * - For compiled binaries, rewrites veryfront imports to use globals
+ */
 
 export function rewriteForDeno(
   code: string,
@@ -167,6 +177,23 @@ export function rewriteForDeno(
   return transformed;
 }
 
+// Memoizes resolved bare-specifier → file:// URL lookups across all
+// `rewriteDiscoveryImports` calls. Keyed by `${projectDir}::${specifier}`.
+// Most projects re-resolve the same handful of packages (react, zod,
+// pdf-parse, …) across every discovered tool/agent file — without this
+// cache, each discovery pass re-reads the same package.json files.
+const resolvedSpecifierCache = new Map<string, string | null>();
+
+// Split `react/jsx-runtime` → { name: "react", subpath: "./jsx-runtime" } and
+// `@scope/pkg/sub/path` → { name: "@scope/pkg", subpath: "./sub/path" }.
+function splitPackageSubpath(specifier: string): { name: string; subpath: string } {
+  const parts = specifier.split("/");
+  const segments = specifier.startsWith("@") ? parts.slice(0, 2) : parts.slice(0, 1);
+  const name = segments.join("/");
+  const rest = parts.slice(segments.length).join("/");
+  return { name, subpath: rest ? `./${rest}` : "." };
+}
+
 /**
  * Rewrite imports for Node.js runtime
  * - Resolves relative imports to file:// URLs
@@ -191,23 +218,15 @@ export async function rewriteDiscoveryImports(
         `from "${pathToFileURL(pathHelper.resolve(fileDir, relativePath)).href}"`,
     );
 
-    // Split `react/jsx-runtime` → { name: "react", subpath: "./jsx-runtime" } and
-    // `@scope/pkg/sub/path` → { name: "@scope/pkg", subpath: "./sub/path" }.
-    // The bare package name resolves to a single package.json; the subpath
-    // is then read from the package's `exports` map or, failing that,
-    // joined onto the package directory.
-    const splitPackageSubpath = (specifier: string): { name: string; subpath: string } => {
-      const parts = specifier.split("/");
-      const segments = specifier.startsWith("@") ? parts.slice(0, 2) : parts.slice(0, 1);
-      const name = segments.join("/");
-      const rest = parts.slice(segments.length).join("/");
-      return { name, subpath: rest ? `./${rest}` : "." };
-    };
-
     // Resolve a bare specifier (optionally with subpath) to a file:// URL,
     // honoring the package's `exports` map for subpath imports such as
-    // `react/jsx-runtime` or `lodash-es/debounce`.
+    // `react/jsx-runtime` or `lodash-es/debounce`. Results are memoized per
+    // (projectDir, specifier).
     const resolvePackageToFileUrl = async (specifier: string): Promise<string | null> => {
+      const cacheKey = `${projectDir}::${specifier}`;
+      const cached = resolvedSpecifierCache.get(cacheKey);
+      if (cached !== undefined) return cached;
+
       const { name: packageName, subpath } = splitPackageSubpath(specifier);
       let searchDir = projectDir;
 
@@ -229,7 +248,9 @@ export async function rewriteDiscoveryImports(
               // subpath onto the package dir (e.g. `dotenv/config.js`).
               : subpath.replace(/^\.\//, ""));
 
-          return pathToFileURL(pathHelper.join(packagePath, entryPoint)).href;
+          const resolved = pathToFileURL(pathHelper.join(packagePath, entryPoint)).href;
+          resolvedSpecifierCache.set(cacheKey, resolved);
+          return resolved;
         } catch (_) {
           /* expected: package.json not found at this level, walk up */
           const parent = pathHelper.dirname(searchDir);
@@ -238,32 +259,27 @@ export async function rewriteDiscoveryImports(
         }
       }
 
+      resolvedSpecifierCache.set(cacheKey, null);
       return null;
     };
 
-    // Rewrite package imports — covers `from "spec"`, `import("spec")`, and
-    // side-effect `import "spec";` forms for the given (possibly-subpathed)
-    // specifier.
-    const rewritePackageImports = async (input: string, pkg: string): Promise<string> => {
+    const rewritePackageImports = (input: string, pkg: string, resolvedUrl: string): string => {
       const escapedPkg = pkg.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const staticImportRegex = new RegExp(`from\\s*["']${escapedPkg}["']`, "g");
+      const staticImportRegex = new RegExp(
+        `(^|[\\s;{}])((?:import|export)\\b[^"']*?\\bfrom\\s+)["']${escapedPkg}["']`,
+        "g",
+      );
       const dynamicImportRegex = new RegExp(`import\\s*\\(\\s*["']${escapedPkg}["']\\s*\\)`, "g");
       const sideEffectRegex = new RegExp(
         `(^|[\\n;{}])(\\s*)import\\s+["']${escapedPkg}["'](\\s*;?)`,
         "g",
       );
 
-      if (
-        !staticImportRegex.test(input) &&
-        !dynamicImportRegex.test(input) &&
-        !sideEffectRegex.test(input)
-      ) return input;
-
-      const resolvedUrl = await resolvePackageToFileUrl(pkg);
-      if (!resolvedUrl) return input;
-
       return input
-        .replace(staticImportRegex, `from "${resolvedUrl}"`)
+        .replace(staticImportRegex, (match, lead: string, head: string) => {
+          if (TYPE_ONLY_STATIC_RE.test(lead + head)) return match;
+          return `${lead}${head}"${resolvedUrl}"`;
+        })
         .replace(dynamicImportRegex, `import("${resolvedUrl}")`)
         .replace(
           sideEffectRegex,
@@ -280,8 +296,18 @@ export async function rewriteDiscoveryImports(
     // temp module is loaded from outside the project's resolution root.
     const collectBareSpecifiers = (input: string): string[] => {
       const specifiers = new Set<string>();
-      for (const match of input.matchAll(/from\s*["']([^"']+)["']/g)) {
-        const s = match[1];
+      // Matches `import x from "spec"`, `export { x } from "spec"`,
+      // `export * from "spec"`. The leading-context capture lets us skip
+      // `import type` / `export type` lines, which TypeScript erases at
+      // emit time and must not trigger filesystem resolution.
+      for (
+        const match of input.matchAll(
+          /(?:^|[\s;{}])((?:import|export)\b[^"']*?\bfrom\s+)["']([^"']+)["']/g,
+        )
+      ) {
+        const head = match[1] ?? "";
+        const s = match[2];
+        if (TYPE_ONLY_STATIC_RE.test(head)) continue;
         if (s && isUnprefixedNpmSpecifier(s)) specifiers.add(s);
       }
       for (const match of input.matchAll(/import\s*\(\s*["']([^"']+)["']\s*\)/g)) {
@@ -300,8 +326,16 @@ export async function rewriteDiscoveryImports(
       return [...specifiers];
     };
 
-    for (const pkg of collectBareSpecifiers(transformed)) {
-      transformed = await rewritePackageImports(transformed, pkg);
+    // Resolve every bare specifier in parallel — each lookup is independent
+    // node_modules I/O. Apply the resulting rewrites sequentially against
+    // the same source string.
+    const specifiers = collectBareSpecifiers(transformed);
+    const resolvedPairs = await Promise.all(
+      specifiers.map(async (pkg) => [pkg, await resolvePackageToFileUrl(pkg)] as const),
+    );
+    for (const [pkg, resolvedUrl] of resolvedPairs) {
+      if (!resolvedUrl) continue;
+      transformed = rewritePackageImports(transformed, pkg, resolvedUrl);
     }
 
     const resolveRuntimeSpecifierToFileUrl = (specifier: string): string | null => {

--- a/src/discovery/import-rewriter.ts
+++ b/src/discovery/import-rewriter.ts
@@ -307,7 +307,21 @@ export async function rewriteDiscoveryImports(
               // onto the package dir (e.g. `dotenv/config.js`).
               : subpath.replace(/^\.\//, ""));
 
-          const resolved = pathToFileURL(pathHelper.join(packagePath, entryPoint)).href;
+          // Defense in depth: refuse resolved paths that escape the package
+          // directory. A malicious package shipping `exports: { ".": "../foo" }`
+          // would otherwise yield a `file://` URL outside `node_modules/<pkg>`
+          // that the discovery loader would still `import()`. `path.resolve`
+          // (unlike `path.join`) normalizes `..` segments, so the prefix
+          // check correctly catches escape attempts.
+          const normalized = pathHelper.resolve(packagePath, entryPoint);
+          const packagePathPrefix = packagePath.endsWith(pathHelper.SEPARATOR)
+            ? packagePath
+            : packagePath + pathHelper.SEPARATOR;
+          if (normalized !== packagePath && !normalized.startsWith(packagePathPrefix)) {
+            return null;
+          }
+
+          const resolved = pathToFileURL(normalized).href;
           resolvedSpecifierCache.set(cacheKey, resolved);
           return resolved;
         } catch (_) {

--- a/src/discovery/import-rewriter.ts
+++ b/src/discovery/import-rewriter.ts
@@ -143,7 +143,6 @@ function rewriteBareNpmImportsForDeno(code: string): string {
  * - Resolves relative imports to absolute file:// URLs
  * - For compiled binaries, rewrites veryfront imports to use globals
  */
-
 export function rewriteForDeno(
   code: string,
   fileDir: string,
@@ -338,7 +337,7 @@ export async function rewriteDiscoveryImports(
     };
 
     const rewritePackageImports = (input: string, pkg: string, resolvedUrl: string): string => {
-      const escapedPkg = pkg.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const escapedPkg = escapeRegExp(pkg);
       const staticImportRegex = new RegExp(
         `(^|[\\s;{}])((?:import|export)\\b[^"']*?\\bfrom\\s+)["']${escapedPkg}["']`,
         "g",

--- a/src/discovery/import-rewriter.ts
+++ b/src/discovery/import-rewriter.ts
@@ -94,20 +94,42 @@ function rewriteDenoCompiledVeryfrontImports(code: string): string {
  * - Resolves relative imports to absolute file:// URLs
  * - For compiled binaries, rewrites veryfront imports to use globals
  */
+/**
+ * True for bare npm imports that need an `npm:` prefix for Deno to resolve
+ * them when the discovery module is loaded from a temp directory. Excludes
+ * relative paths, absolute URLs, Node built-ins, and the veryfront package
+ * (handled by the dedicated rewrites above).
+ */
+function isUnprefixedNpmSpecifier(specifier: string): boolean {
+  if (!specifier) return false;
+  if (specifier.startsWith(".") || specifier.startsWith("/")) return false;
+  if (specifier.startsWith("npm:") || specifier.startsWith("jsr:")) return false;
+  if (specifier.startsWith("node:")) return false;
+  if (
+    specifier.startsWith("file:") ||
+    specifier.startsWith("http:") ||
+    specifier.startsWith("https:")
+  ) return false;
+  if (specifier === "veryfront" || specifier.startsWith("veryfront/")) return false;
+  return true;
+}
+
+function rewriteBareNpmImportsForDeno(code: string): string {
+  return code
+    .replace(/from\s+["']([^"']+)["']/g, (match, specifier: string) => {
+      return isUnprefixedNpmSpecifier(specifier) ? `from "npm:${specifier}"` : match;
+    })
+    .replace(/import\s*\(\s*["']([^"']+)["']\s*\)/g, (match, specifier: string) => {
+      return isUnprefixedNpmSpecifier(specifier) ? `import("npm:${specifier}")` : match;
+    });
+}
+
 export function rewriteForDeno(
   code: string,
   fileDir: string,
   options: DenoRewriteOptions = {},
 ): string {
-  const npmReplacements: Array<[RegExp, string]> = [
-    [/from\s+["']zod["']/g, 'from "npm:zod"'],
-    [/import\s*\(\s*["']zod["']\s*\)/g, 'import("npm:zod")'],
-  ];
-
   let transformed = code;
-  for (const [pattern, replacement] of npmReplacements) {
-    transformed = transformed.replace(pattern, replacement);
-  }
 
   // Handle relative imports
   transformed = transformed.replace(
@@ -125,6 +147,12 @@ export function rewriteForDeno(
       options.resolveSpecifier ?? ((specifier) => import.meta.resolve(specifier)),
     );
   }
+
+  // Prefix any remaining bare npm specifiers with `npm:` so Deno can resolve
+  // them from the temp directory the discovery module is loaded from. Covers
+  // `zod` plus arbitrary npm packages a tool/agent depends on, after the
+  // discovery bundler externalizes them via `packages: "external"`.
+  transformed = rewriteBareNpmImportsForDeno(transformed);
 
   return transformed;
 }
@@ -198,10 +226,26 @@ export async function rewriteDiscoveryImports(
         .replace(dynamicImportRegex, `import("${resolvedUrl}")`);
     };
 
-    // Rewrite external package imports
-    const externalPackages = ["zod"];
+    // Collect every bare specifier the transformed source still imports,
+    // then resolve each to a file:// URL in the project's node_modules.
+    // With `packages: "external"` in the discovery bundler, npm packages a
+    // tool/agent depends on (e.g. `pdf-parse`, `mammoth`) survive as bare
+    // imports here and need explicit resolution before the temp module is
+    // loaded from outside the project's resolution root.
+    const collectBareSpecifiers = (input: string): string[] => {
+      const specifiers = new Set<string>();
+      for (const match of input.matchAll(/from\s*["']([^"']+)["']/g)) {
+        const s = match[1];
+        if (s && isUnprefixedNpmSpecifier(s)) specifiers.add(s);
+      }
+      for (const match of input.matchAll(/import\s*\(\s*["']([^"']+)["']\s*\)/g)) {
+        const s = match[1];
+        if (s && isUnprefixedNpmSpecifier(s)) specifiers.add(s);
+      }
+      return [...specifiers];
+    };
 
-    for (const pkg of externalPackages) {
+    for (const pkg of collectBareSpecifiers(transformed)) {
       transformed = await rewritePackageImports(transformed, pkg);
     }
 

--- a/src/discovery/import-rewriter.ts
+++ b/src/discovery/import-rewriter.ts
@@ -194,6 +194,66 @@ function splitPackageSubpath(specifier: string): { name: string; subpath: string
   return { name, subpath: rest ? `./${rest}` : "." };
 }
 
+// Pick the relative file path from a `package.json#exports` entry, which can
+// be a string, a conditional object (`{ import, default, ... }`), or an
+// array of those.
+function pickExportEntry(entry: unknown): string | null {
+  if (typeof entry === "string") return entry;
+  if (Array.isArray(entry)) {
+    for (const e of entry) {
+      const v = pickExportEntry(e);
+      if (v) return v;
+    }
+    return null;
+  }
+  if (entry && typeof entry === "object") {
+    const obj = entry as Record<string, unknown>;
+    const candidate = obj.import ?? obj.node ?? obj.default;
+    return candidate ? pickExportEntry(candidate) : null;
+  }
+  return null;
+}
+
+// Resolve a subpath (`.` or `./foo/bar`) against a `package.json#exports`
+// map. Honors literal keys first, then matches `./*`-style glob patterns
+// where the trailing `*` is substituted with the captured remainder.
+// Returns the resolved relative path (e.g. `./debounce.js`) or null when
+// no entry matches.
+function resolveExportPath(exports: unknown, subpath: string): string | null {
+  if (!exports || typeof exports !== "object") return null;
+  const map = exports as Record<string, unknown>;
+
+  // Literal key (covers "." and exact subpaths like "./jsx-runtime").
+  if (subpath in map) return pickExportEntry(map[subpath]);
+
+  // Glob keys like "./*", "./feature/*", "./lib/*.js". Pick the longest
+  // matching prefix so more specific patterns win over `./*`.
+  let bestKey: string | null = null;
+  let bestPrefixLen = -1;
+  for (const key of Object.keys(map)) {
+    const star = key.indexOf("*");
+    if (star === -1) continue;
+    const prefix = key.slice(0, star);
+    const suffix = key.slice(star + 1);
+    if (!subpath.startsWith(prefix) || !subpath.endsWith(suffix)) continue;
+    if (subpath.length < prefix.length + suffix.length) continue;
+    if (prefix.length > bestPrefixLen) {
+      bestKey = key;
+      bestPrefixLen = prefix.length;
+    }
+  }
+  if (!bestKey) return null;
+
+  const star = bestKey.indexOf("*");
+  const captured = subpath.slice(
+    bestKey.slice(0, star).length,
+    subpath.length - bestKey.slice(star + 1).length,
+  );
+  const template = pickExportEntry(map[bestKey]);
+  if (!template) return null;
+  return template.replace("*", captured);
+}
+
 /**
  * Rewrite imports for Node.js runtime
  * - Resolves relative imports to file:// URLs
@@ -220,8 +280,10 @@ export async function rewriteDiscoveryImports(
 
     // Resolve a bare specifier (optionally with subpath) to a file:// URL,
     // honoring the package's `exports` map for subpath imports such as
-    // `react/jsx-runtime` or `lodash-es/debounce`. Results are memoized per
-    // (projectDir, specifier).
+    // `react/jsx-runtime` or `lodash-es/debounce`. Successful resolutions
+    // are memoized per (projectDir, specifier); failures are NOT cached
+    // so a subsequent `npm install` of the missing dep is picked up
+    // without a process restart.
     const resolvePackageToFileUrl = async (specifier: string): Promise<string | null> => {
       const cacheKey = `${projectDir}::${specifier}`;
       const cached = resolvedSpecifierCache.get(cacheKey);
@@ -236,16 +298,13 @@ export async function rewriteDiscoveryImports(
 
         try {
           const pkgJson = JSON.parse(await fs.readTextFile(packageJsonPath));
-          const exportEntry = pkgJson.exports?.[subpath];
-          const exportPath = typeof exportEntry === "string"
-            ? exportEntry
-            : exportEntry?.import ?? exportEntry?.default;
+          const exportPath = resolveExportPath(pkgJson.exports, subpath);
 
           const entryPoint = exportPath ??
             (subpath === "."
               ? (pkgJson.module ?? pkgJson.main ?? "index.js")
-              // No exports entry for this subpath: fall back to joining the
-              // subpath onto the package dir (e.g. `dotenv/config.js`).
+              // No exports entry matched: fall back to joining the subpath
+              // onto the package dir (e.g. `dotenv/config.js`).
               : subpath.replace(/^\.\//, ""));
 
           const resolved = pathToFileURL(pathHelper.join(packagePath, entryPoint)).href;
@@ -259,7 +318,8 @@ export async function rewriteDiscoveryImports(
         }
       }
 
-      resolvedSpecifierCache.set(cacheKey, null);
+      // Intentionally do NOT cache nulls — a missing-then-installed package
+      // should be resolvable on the next pass without a process restart.
       return null;
     };
 

--- a/src/discovery/transpiler.ts
+++ b/src/discovery/transpiler.ts
@@ -194,6 +194,14 @@ export async function importModule(
     jsxImportSource: "react",
     resolveExtensions: [".ts", ".tsx", ".js", ".jsx", ".mjs"],
     plugins,
+    // Externalize all bare-specifier imports so npm packages a tool/agent file
+    // depends on (e.g. `pdf-parse`, `mammoth`) are not pulled into the
+    // discovery bundle. Discovery only needs the module's exports; the
+    // implementation runs server-side at request time and can resolve npm
+    // packages natively via the project's node_modules / import map.
+    // Without this, esbuild under platform: "neutral" tries to bundle CJS
+    // npm packages and fails on their Node built-in references (fs, http, ...).
+    packages: "external",
     external: [
       "zod",
       "node:*",


### PR DESCRIPTION
## Summary

The discovery transpiler bundles tool/agent/skill files with esbuild under `platform: "neutral"`. That platform has no Node built-ins, so a tool that imports an npm package referencing `fs` / `http` / `https` / `url` (e.g. `pdf-parse`, `mammoth`) blew up the bundle and prevented `deno task dev` from rendering any page in the project.

- Add `packages: "external"` to the discovery bundler — discovery only needs module exports, not a self-contained bundle.
- Generalize `rewriteForDeno` to `npm:`-prefix any remaining bare specifier (not relative, not `node:`, not absolute URL, not `veryfront`) so Deno can resolve from the temp dir the discovery module loads from.
- Generalize `rewriteDiscoveryImports` (Node path) to collect every bare specifier the bundled source still references and resolve each via the project's `node_modules`, instead of only a hard-coded `["zod"]` list.

## Repro

Inside any project, add a tool that imports a CJS npm package with Node built-in references:

```ts
// tools/parse-contract.ts
import pdfParse from "pdf-parse";
import mammoth from "mammoth";
// ...
```

`deno task dev` previously printed dozens of `✘ [ERROR] Could not resolve "fs" / "http" / ...` errors and every page returned 500. After this change the discovery bundle keeps `import("pdf-parse")` as `npm:pdf-parse` (Deno) or a file:// URL into `node_modules` (Node), and the dev server starts.

This was found while wiring up the DORA Compliance Agent example in `veryfront-examples`, which uses `pdf-parse` and `mammoth` for contract parsing.

## Test plan

- [x] `deno test src/discovery/import-rewriter.test.ts` — 5 cases pass, including two new cases:
  - "prefixes arbitrary bare npm imports with `npm:` for Deno temp module imports"
  - "leaves `node:`, `file:`, relative, and veryfront specifiers untouched"
- [x] `deno test src/discovery/` — full discovery suite green.
- [x] Pre-push full test suite — 1913 passed, 0 failed.
- [x] Manual verification with the DORA example: previously failing `deno task dev` no longer emits bundler errors for `pdf-parse` / `mammoth`.