### PR TITLE
Return feedback text for failed child invocations

### DIFF
--- a/src/agent/hosted/default-invoke-agent-tool.test.ts
+++ b/src/agent/hosted/default-invoke-agent-tool.test.ts
@@ -76,6 +76,12 @@ Deno.test("executeDefaultHostedInvokeAgentTool returns durable context failure b
   assertEquals(result, {
     ok: false,
     status: "failed",
+    text:
+      "invoke_agent failed: invoke_agent requires durable conversation context when durable child runs are enabled.",
+    summary: {
+      text:
+        "invoke_agent failed: invoke_agent requires durable conversation context when durable child runs are enabled.",
+    },
     terminalErrorCode: "DURABLE_INVOKE_CONTEXT_UNAVAILABLE",
     terminalErrorMessage:
       "invoke_agent requires durable conversation context when durable child runs are enabled.",
@@ -105,6 +111,12 @@ Deno.test("createDefaultHostedInvokeAgentTool adds child selection guidance and 
   assertEquals(result, {
     ok: false,
     status: "failed",
+    text:
+      "invoke_agent failed: invoke_agent requires durable conversation context when durable child runs are enabled.",
+    summary: {
+      text:
+        "invoke_agent failed: invoke_agent requires durable conversation context when durable child runs are enabled.",
+    },
     terminalErrorCode: "DURABLE_INVOKE_CONTEXT_UNAVAILABLE",
     terminalErrorMessage:
       "invoke_agent requires durable conversation context when durable child runs are enabled.",

--- a/src/agent/hosted/durable-child-fork-execution.test.ts
+++ b/src/agent/hosted/durable-child-fork-execution.test.ts
@@ -130,6 +130,8 @@ describe("agent/hosted-durable-child-fork-execution", () => {
       {
         ok: false,
         status: "failed",
+        text: "invoke_agent failed: setup failed",
+        summary: { text: "invoke_agent failed: setup failed" },
         childConversationId: CHILD_CONVERSATION_ID,
         sourceTargetKind: "preview_branch",
         runtimeTargetKind: "preview_branch",
@@ -149,6 +151,8 @@ describe("agent/hosted-durable-child-fork-execution", () => {
       {
         ok: false,
         status: "failed",
+        text: "invoke_agent failed: child failed",
+        summary: { text: "invoke_agent failed: child failed" },
         childConversationId: CHILD_CONVERSATION_ID,
         childRunId: "run_child_1",
         childMessageId: CHILD_MESSAGE_ID,
@@ -270,6 +274,8 @@ describe("agent/hosted-durable-child-fork-execution", () => {
       {
         ok: false,
         status: "failed",
+        text: "invoke_agent failed: setup failed",
+        summary: { text: "invoke_agent failed: setup failed" },
         childConversationId: CHILD_CONVERSATION_ID,
         childRunId: "run_child_1",
         childMessageId: CHILD_MESSAGE_ID,

--- a/src/agent/hosted/durable-child-fork-execution.ts
+++ b/src/agent/hosted/durable-child-fork-execution.ts
@@ -128,9 +128,13 @@ export type ExecuteHostedLocalChildInvokeInput = {
 export function buildHostedDurableChildInvokeFailureResult(
   input: BuildHostedDurableChildInvokeFailureResultInput,
 ): HostedDurableChildInvokeResult {
+  const failureText = `invoke_agent failed: ${input.terminalErrorMessage}`;
+
   return {
     ok: false,
     status: "failed",
+    text: failureText,
+    summary: buildChildRunResultSummary(failureText),
     ...(input.childConversationId ? { childConversationId: input.childConversationId } : {}),
     ...(input.childRunId ? { childRunId: input.childRunId } : {}),
     ...(input.childMessageId ? { childMessageId: input.childMessageId } : {}),


### PR DESCRIPTION
## Summary
- Add parent-readable text and summary fields to failed durable child invoke results.
- Preserve existing terminal error code/message fields for machine handling and run diagnostics.
- Update durable child and default invoke-agent tests to cover the failure feedback shape.

## Test Plan
- deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/agent/hosted/durable-child-fork-execution.test.ts src/agent/hosted/default-invoke-agent-tool.test.ts
- deno task verify:quick
- git push pre-push checks: format, lint, typecheck, test:unit