### PR TITLE
fix(ssr-vf-modules): make depth-limit fallback emit loadable code

### DIFF
--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
@@ -171,6 +171,89 @@ describe("transformFrameworkCode depth-limit fallback", {
     }
   });
 
+  it("does not propagate a cycle placeholder from frameworkFileCache into the fallback cache file", async () => {
+    const { frameworkFileCache } = await import("./constants.ts");
+    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-cycle-" });
+    const srcDir = `${tmp}/src`;
+    await Deno.mkdir(srcDir, { recursive: true });
+    const depPath = `${srcDir}/dep.ts.src`;
+    // Real content for the dep on disk
+    await Deno.writeTextFile(depPath, "export const X = 42;\n");
+    // Simulate the main path having pre-cached a cycle placeholder for this dep
+    const placeholder = `/* Cycle detected: ${depPath} */\nexport {};`;
+    frameworkFileCache.set(depPath, placeholder);
+
+    const ownerPath = `${srcDir}/owner.ts.src`;
+    const ownerContent = 'import { X } from "./dep.js"; export const y = X;';
+    await Deno.writeTextFile(ownerPath, ownerContent);
+
+    try {
+      const transformed = await transformFrameworkCode(
+        ownerContent,
+        ownerPath,
+        { reactVersion: "19.1.1", projectDir: tmp, fs: createFileSystem() },
+        false,
+        MAX_RELATIVE_IMPORT_DEPTH + 1,
+      );
+
+      // The emitted cache file URL must not link to a file whose contents
+      // are the cycle-placeholder. Read it back and check for the real
+      // dep's content (`export const X = 42`).
+      const match = transformed.match(/from "file:\/\/([^"]+\.mjs)"/);
+      assert(match, `fallback did not emit a .mjs URL: ${transformed}`);
+      const cachePath = match[1]!;
+      const written = await Deno.readTextFile(cachePath);
+      assertEquals(
+        written.includes("Cycle detected"),
+        false,
+        `cycle placeholder leaked into fallback cache file: ${written}`,
+      );
+      assertStringIncludes(written, "X = 42");
+    } finally {
+      frameworkFileCache.delete(depPath);
+      await Deno.remove(tmp, { recursive: true });
+    }
+  });
+
+  it("survives one bad .src dep without aborting the whole parent fallback", async () => {
+    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-baddep-" });
+    const srcDir = `${tmp}/src`;
+    await Deno.mkdir(srcDir, { recursive: true });
+    // A dep whose content is invalid TypeScript — esbuild should reject it.
+    const badDep = `${srcDir}/bad.ts.src`;
+    await Deno.writeTextFile(badDep, "export const = ;;; not valid syntax @@@");
+    const goodDep = `${srcDir}/good.ts.src`;
+    await Deno.writeTextFile(goodDep, "export const G = 1;\n");
+
+    const ownerPath = `${srcDir}/owner.ts.src`;
+    const ownerContent = [
+      `import "./bad.js";`,
+      `import { G } from "./good.js";`,
+      `export const y = G;`,
+    ].join("\n");
+    await Deno.writeTextFile(ownerPath, ownerContent);
+
+    try {
+      // Must not throw: the bad dep is logged + left bare, the parent's
+      // own compilation still succeeds. The exact rewriting of the good
+      // dep depends on whether the test runtime has loaded the bundler
+      // extension; the load-bearing assertion is "did not throw".
+      const transformed = await transformFrameworkCode(
+        ownerContent,
+        ownerPath,
+        { reactVersion: "19.1.1", projectDir: tmp, fs: createFileSystem() },
+        false,
+        MAX_RELATIVE_IMPORT_DEPTH + 1,
+      );
+
+      // Survived: the parent file produced output. The bad-dep handling
+      // is verified by the absence of an unhandled exception above.
+      assert(transformed.length > 0, "fallback returned empty output");
+    } finally {
+      await Deno.remove(tmp, { recursive: true });
+    }
+  });
+
   it("leaves bare-package imports alone in the fallback output", async () => {
     const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-fallback-" });
     const srcDir = `${tmp}/src`;

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
@@ -52,6 +52,53 @@ describe("transformFrameworkCode depth-limit fallback", {
     }
   });
 
+  it("transforms and caches embedded .src dependencies so the fallback works in compiled binaries", async () => {
+    // In compiled binaries the resolver returns *.ts.src / *.js.src paths,
+    // which the runtime cannot import directly. The fallback must materialize
+    // a real .mjs cache file and link the import to that, not to the .src
+    // source.
+    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-src-fallback-" });
+    const srcDir = `${tmp}/src/utils`;
+    await Deno.mkdir(srcDir, { recursive: true });
+    // Only the .src copy exists (mirrors compiled-binary layout).
+    const helperSrcPath = `${srcDir}/helper.ts.src`;
+    await Deno.writeTextFile(helperSrcPath, "export const HELPER = 7;\n");
+
+    const ownerPath = `${srcDir}/owner.ts.src`;
+    const ownerContent = [
+      `import { HELPER } from "./helper.js";`,
+      `export const value = HELPER;`,
+    ].join("\n");
+    await Deno.writeTextFile(ownerPath, ownerContent);
+
+    try {
+      const transformed = await transformFrameworkCode(
+        ownerContent,
+        ownerPath,
+        { reactVersion: "19.1.1", projectDir: tmp, fs: createFileSystem() },
+        false,
+        MAX_RELATIVE_IMPORT_DEPTH + 1,
+      );
+
+      // The fallback must NOT embed the .src path as the import URL.
+      assert(
+        !transformed.includes(".src"),
+        `fallback emitted .src path: ${transformed}`,
+      );
+      assertEquals(transformed.includes('from "./helper.js"'), false);
+      // It must link to a real .mjs cache file that exists.
+      const match = transformed.match(/from "file:\/\/([^"]+\.mjs)"/);
+      assert(match, `fallback did not emit a .mjs file:// URL: ${transformed}`);
+      const cachePath = match[1]!;
+      assert(
+        await Deno.stat(cachePath).then(() => true).catch(() => false),
+        `cache file does not exist on disk: ${cachePath}`,
+      );
+    } finally {
+      await Deno.remove(tmp, { recursive: true });
+    }
+  });
+
   it("leaves bare-package imports alone in the fallback output", async () => {
     const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-fallback-" });
     const srcDir = `${tmp}/src`;

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
@@ -99,6 +99,78 @@ describe("transformFrameworkCode depth-limit fallback", {
     }
   });
 
+  it("does not poison frameworkFileCache with fallback output", async () => {
+    const { frameworkFileCache } = await import("./constants.ts");
+    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-cache-iso-" });
+    const srcDir = `${tmp}/src`;
+    await Deno.mkdir(srcDir, { recursive: true });
+    const depPath = `${srcDir}/dep.ts.src`;
+    await Deno.writeTextFile(depPath, "export const X = 1;\n");
+    const ownerPath = `${srcDir}/owner.ts.src`;
+    const ownerContent = 'import { X } from "./dep.js"; export const y = X;';
+    await Deno.writeTextFile(ownerPath, ownerContent);
+
+    const cacheKeysBefore = new Set(frameworkFileCache.keys());
+
+    try {
+      await transformFrameworkCode(
+        ownerContent,
+        ownerPath,
+        { reactVersion: "19.1.1", projectDir: tmp, fs: createFileSystem() },
+        false,
+        MAX_RELATIVE_IMPORT_DEPTH + 1,
+      );
+
+      // The fallback emits esbuild-only code (no `#veryfront/` / React
+      // rewriting). It must not write that into the cache the main
+      // transform path also reads — otherwise a later main-path call for
+      // the same dep would receive degraded output.
+      const newKeys = [...frameworkFileCache.keys()].filter((k) => !cacheKeysBefore.has(k));
+      assertEquals(
+        newKeys.includes(depPath),
+        false,
+        `fallback poisoned frameworkFileCache with ${depPath}`,
+      );
+      assertEquals(
+        newKeys.includes(ownerPath),
+        false,
+        `fallback poisoned frameworkFileCache with ${ownerPath}`,
+      );
+    } finally {
+      await Deno.remove(tmp, { recursive: true });
+    }
+  });
+
+  it("uses the ts loader for .mts and the js loader for .mjs / .cjs", async () => {
+    // Indirectly verify the loader picker via the fallback output: pass
+    // TypeScript-only syntax (`as const`) through a `.mts.src` source and
+    // confirm esbuild produced JS (would throw if loaded as `js`).
+    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-mts-" });
+    const srcDir = `${tmp}/src`;
+    await Deno.mkdir(srcDir, { recursive: true });
+    const sourcePath = `${srcDir}/uses-as-const.mts.src`;
+    const sourceContent = 'export const TAG = "x" as const;';
+    await Deno.writeTextFile(sourcePath, sourceContent);
+
+    try {
+      const transformed = await transformFrameworkCode(
+        sourceContent,
+        sourcePath,
+        { reactVersion: "19.1.1", projectDir: tmp, fs: createFileSystem() },
+        false,
+        MAX_RELATIVE_IMPORT_DEPTH + 1,
+      );
+
+      // `as const` is TS-only; if the loader had picked `js`, esbuild
+      // would have thrown a syntax error. Surviving transform proves the
+      // loader matched `.mts` to `ts`.
+      assertStringIncludes(transformed, 'const TAG = "x"');
+      assertEquals(transformed.includes("as const"), false);
+    } finally {
+      await Deno.remove(tmp, { recursive: true });
+    }
+  });
+
   it("leaves bare-package imports alone in the fallback output", async () => {
     const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-fallback-" });
     const srcDir = `${tmp}/src`;

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
@@ -1,0 +1,83 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
+import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { stop as stopEsbuild } from "veryfront/extensions/bundler";
+import { transformFrameworkCode } from "./transform.ts";
+import { MAX_RELATIVE_IMPORT_DEPTH } from "./constants.ts";
+
+// esbuild starts a child process that lives across tests, so we disable sanitizers
+describe("transformFrameworkCode depth-limit fallback", {
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, () => {
+  afterAll(async () => {
+    await stopEsbuild();
+  });
+
+  it("rewrites relative imports in the fallback to absolute file:// URLs so the cached output is loadable", async () => {
+    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-fallback-" });
+    const srcDir = `${tmp}/src/utils/constants`;
+    await Deno.mkdir(srcDir, { recursive: true });
+    const buildJs = `${srcDir}/build.js`;
+    await Deno.writeTextFile(buildJs, "export const DEFAULT_BUILD_CONCURRENCY = 4;\n");
+    const buffersJs = `${srcDir}/buffers.js`;
+    await Deno.writeTextFile(buffersJs, "export const BUFFER_SIZE_1_KB = 1024;\n");
+
+    const ownerPath = `${srcDir}/owner.js`;
+    const ownerContent = [
+      `import { DEFAULT_BUILD_CONCURRENCY } from "./build.js";`,
+      `import { BUFFER_SIZE_1_KB } from "./buffers.js";`,
+      `export const sum = DEFAULT_BUILD_CONCURRENCY + BUFFER_SIZE_1_KB;`,
+    ].join("\n");
+    await Deno.writeTextFile(ownerPath, ownerContent);
+
+    try {
+      const transformed = await transformFrameworkCode(
+        ownerContent,
+        ownerPath,
+        { reactVersion: "19.1.1", projectDir: tmp, fs: createFileSystem() },
+        false,
+        MAX_RELATIVE_IMPORT_DEPTH + 1,
+      );
+
+      // The fallback should not leave bare ./foo.js imports in cached output:
+      assertEquals(transformed.includes('from "./build.js"'), false);
+      assertEquals(transformed.includes('from "./buffers.js"'), false);
+      // It should rewrite them to file:// URLs pointing at the resolved sources:
+      assertStringIncludes(transformed, `from "file://${buildJs}"`);
+      assertStringIncludes(transformed, `from "file://${buffersJs}"`);
+    } finally {
+      await Deno.remove(tmp, { recursive: true });
+    }
+  });
+
+  it("leaves bare-package imports alone in the fallback output", async () => {
+    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-fallback-" });
+    const srcDir = `${tmp}/src`;
+    await Deno.mkdir(srcDir, { recursive: true });
+    const sourcePath = `${srcDir}/uses-react.js`;
+    const sourceContent = [
+      `import React from "react";`,
+      `export const cls = React;`,
+    ].join("\n");
+    await Deno.writeTextFile(sourcePath, sourceContent);
+
+    try {
+      const transformed = await transformFrameworkCode(
+        sourceContent,
+        sourcePath,
+        { reactVersion: "19.1.1", projectDir: tmp, fs: createFileSystem() },
+        false,
+        MAX_RELATIVE_IMPORT_DEPTH + 1,
+      );
+
+      // Bare specifier `react` is the runtime's responsibility — fallback
+      // must not invent a file:// URL for it.
+      assertStringIncludes(transformed, 'from "react"');
+      assert(!transformed.includes("file://"));
+    } finally {
+      await Deno.remove(tmp, { recursive: true });
+    }
+  });
+});

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
@@ -88,22 +88,102 @@ export async function cacheTransformedCode(
 }
 
 /**
+ * Pick an esbuild loader for a file path, honoring the embedded `.src`
+ * suffix used in compiled binaries (`foo.ts.src` → `ts`).
+ */
+function pickFallbackLoader(sourcePath: string): "tsx" | "ts" | "jsx" | "js" {
+  const ext = sourcePath.match(/\.(tsx?|jsx?)(?:\.src)?$/)?.[1] ?? "tsx";
+  if (ext === "tsx") return "tsx";
+  if (ext === "ts") return "ts";
+  if (ext === "jsx") return "jsx";
+  return "js";
+}
+
+/**
+ * Compile a framework source file with esbuild only (no recursive
+ * import resolution). Used by the depth-limit fallback and by its
+ * nested handling of embedded `.src` dependencies.
+ */
+async function compileFallbackSource(
+  content: string,
+  sourcePath: string,
+): Promise<string> {
+  const { transform } = await import("veryfront/extensions/bundler");
+  const result = await transform(content, {
+    loader: pickFallbackLoader(sourcePath),
+    jsx: "automatic",
+    jsxImportSource: "react",
+    format: "esm",
+    target: "es2022",
+  });
+  return result.code;
+}
+
+/**
+ * Transform and cache a single dependency referenced from the depth-limit
+ * fallback. Required for compiled binaries where the resolver returns
+ * embedded `.src` paths (e.g. `foo.ts.src`) — those are not loadable
+ * module URLs, so the fallback must materialize a real `.mjs` cache file.
+ *
+ * Recursion is bounded by `visited` (cycle guard) and by `frameworkFileCache`
+ * (per-process dedupe), the same primitives the main transform path uses.
+ */
+async function transformAndCacheFallbackDep(
+  resolvedPath: string,
+  ctx: TransformContext,
+  visited: Set<string>,
+): Promise<string | null> {
+  // Reuse already-transformed framework code when possible.
+  const cachedCode = frameworkFileCache.get(resolvedPath);
+  if (cachedCode) {
+    return await cacheTransformedCode(cachedCode, resolvedPath, ctx.fs);
+  }
+
+  if (visited.has(resolvedPath)) {
+    // Cycle: nothing safe to emit. Caller will log and leave the bare
+    // import alone (same as a failed resolve).
+    return null;
+  }
+  visited.add(resolvedPath);
+
+  let depContent: string;
+  try {
+    depContent = await ctx.fs.readTextFile(resolvedPath);
+  } catch (error) {
+    logger.warn(
+      `${LOG_PREFIX} Depth-limit fallback could not read dependency`,
+      { resolvedPath: resolvedPath.slice(-60), error: String(error) },
+    );
+    return null;
+  }
+
+  const compiled = await compileFallbackSource(depContent, resolvedPath);
+  const rewritten = await rewriteFallbackRelativeImports(compiled, resolvedPath, ctx, visited);
+  frameworkFileCache.set(resolvedPath, rewritten);
+  return await cacheTransformedCode(rewritten, resolvedPath, ctx.fs);
+}
+
+/**
  * Rewrite relative imports in the depth-limit fallback output. Each
  * `./foo.js` / `../bar.js` is resolved against `sourcePath` and emitted
  * as an absolute `file://` URL so the cached fallback module is
  * executable from the cache directory.
  *
- * The fallback path bypasses recursive transformation, so this
- * rewriting is the only thing keeping cached fallback files loadable.
- * Imports that fail to resolve are left untouched and a warning is
- * logged — they will fail at runtime, matching the previous behavior
- * for that specific case.
+ * In dev mode the resolver returns a `.ts` / `.js` path the runtime can
+ * load directly, so we point at the source file. In compiled binaries
+ * it returns a `.src` path the runtime cannot load — those deps are
+ * transformed and cached on the fly via {@link transformAndCacheFallbackDep}
+ * and the import is rewritten to the resulting cache URL. Imports that
+ * fail to resolve are left untouched and a warning is logged.
  */
 async function rewriteFallbackRelativeImports(
   code: string,
   sourcePath: string,
   ctx: TransformContext,
+  visited: Set<string> = new Set(),
 ): Promise<string> {
+  visited.add(sourcePath);
+
   const relativeImports = findRelativeImports(code);
   if (relativeImports.length === 0) return code;
 
@@ -121,7 +201,19 @@ async function rewriteFallbackRelativeImports(
       );
       continue;
     }
-    replacements.set(specifier, `file://${resolvedPath}`);
+
+    // Embedded sources (.tsx.src / .ts.src / .jsx.src / .js.src) used by
+    // compiled binaries are not loadable by the runtime. Materialize a
+    // cache file the runtime can import instead of linking at the .src
+    // source. Regular .ts/.tsx/.js/.jsx/.mjs paths are pointed at
+    // directly — the runtime handles them natively.
+    if (resolvedPath.endsWith(".src")) {
+      const cacheUrlPath = await transformAndCacheFallbackDep(resolvedPath, ctx, visited);
+      if (!cacheUrlPath) continue;
+      replacements.set(specifier, `file://${cacheUrlPath}`);
+    } else {
+      replacements.set(specifier, `file://${resolvedPath}`);
+    }
   }
 
   if (replacements.size === 0) return code;
@@ -153,27 +245,13 @@ export async function transformFrameworkCode(
       sourcePath: sourcePath.slice(-60),
       depth,
     });
-    // Compile the file, then rewrite its relative imports to absolute
-    // file:// URLs pointing at the resolved source files. The runtime can
-    // load those directly (they are already-published .js with sibling
-    // relative imports the loader resolves naturally). Without this
-    // rewriting the fallback would emit code with bare `./foo.js` imports
-    // and the caller would cache it under .cache/.../framework/, where
-    // those siblings do not exist — producing a runtime "Module not found".
-    const { transform } = await import("veryfront/extensions/bundler");
-    const ext = sourcePath.match(/\.(tsx?|jsx?)$/)?.[1] ?? "tsx";
-    let loader: "tsx" | "ts" | "jsx" | "js" = "js";
-    if (ext === "tsx") loader = "tsx";
-    else if (ext === "ts") loader = "ts";
-    else if (ext === "jsx") loader = "jsx";
-    const result = await transform(content, {
-      loader,
-      jsx: "automatic",
-      jsxImportSource: "react",
-      format: "esm",
-      target: "es2022",
-    });
-    return await rewriteFallbackRelativeImports(result.code, sourcePath, ctx);
+    // Compile the file, then rewrite its relative imports so the cached
+    // fallback module is loadable from the cache directory. Without this
+    // rewriting the fallback emits raw `./foo.js` imports that resolve
+    // against the cache dir (where those siblings do not exist), producing
+    // a runtime "Module not found".
+    const compiled = await compileFallbackSource(content, sourcePath);
+    return await rewriteFallbackRelativeImports(compiled, sourcePath, ctx);
   }
 
   // Check if already transformed (before cycle check to handle concurrent requests)

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
@@ -88,6 +88,53 @@ export async function cacheTransformedCode(
 }
 
 /**
+ * Rewrite relative imports in the depth-limit fallback output. Each
+ * `./foo.js` / `../bar.js` is resolved against `sourcePath` and emitted
+ * as an absolute `file://` URL so the cached fallback module is
+ * executable from the cache directory.
+ *
+ * The fallback path bypasses recursive transformation, so this
+ * rewriting is the only thing keeping cached fallback files loadable.
+ * Imports that fail to resolve are left untouched and a warning is
+ * logged — they will fail at runtime, matching the previous behavior
+ * for that specific case.
+ */
+async function rewriteFallbackRelativeImports(
+  code: string,
+  sourcePath: string,
+  ctx: TransformContext,
+): Promise<string> {
+  const relativeImports = findRelativeImports(code);
+  if (relativeImports.length === 0) return code;
+
+  const replacements = new Map<string, string>();
+  for (const specifier of relativeImports) {
+    // Skip non-code imports the runtime cannot load this way.
+    if (/\.(json|css|svg|png|jpg|jpeg|gif|ico|woff2?|ttf|eot)$/.test(specifier)) {
+      continue;
+    }
+    const resolvedPath = await resolveRelativeFrameworkImport(specifier, sourcePath, ctx.fs);
+    if (!resolvedPath) {
+      logger.warn(
+        `${LOG_PREFIX} Depth-limit fallback could not resolve relative import "${specifier}"`,
+        { sourcePath: sourcePath.slice(-60) },
+      );
+      continue;
+    }
+    replacements.set(specifier, `file://${resolvedPath}`);
+  }
+
+  if (replacements.size === 0) return code;
+
+  return await replaceSpecifiers(code, (specifier) => {
+    if (specifier.startsWith("./") || specifier.startsWith("../")) {
+      return replacements.get(specifier) ?? null;
+    }
+    return null;
+  });
+}
+
+/**
  * Core transformation logic for framework TypeScript/TSX files.
  * Compiles to JavaScript and recursively resolves all imports:
  * - #veryfront/ imports (internal framework imports)
@@ -106,7 +153,13 @@ export async function transformFrameworkCode(
       sourcePath: sourcePath.slice(-60),
       depth,
     });
-    // Return minimally transformed code - it will fail at runtime but won't hang
+    // Compile the file, then rewrite its relative imports to absolute
+    // file:// URLs pointing at the resolved source files. The runtime can
+    // load those directly (they are already-published .js with sibling
+    // relative imports the loader resolves naturally). Without this
+    // rewriting the fallback would emit code with bare `./foo.js` imports
+    // and the caller would cache it under .cache/.../framework/, where
+    // those siblings do not exist — producing a runtime "Module not found".
     const { transform } = await import("veryfront/extensions/bundler");
     const ext = sourcePath.match(/\.(tsx?|jsx?)$/)?.[1] ?? "tsx";
     let loader: "tsx" | "ts" | "jsx" | "js" = "js";
@@ -120,7 +173,7 @@ export async function transformFrameworkCode(
       format: "esm",
       target: "es2022",
     });
-    return result.code;
+    return await rewriteFallbackRelativeImports(result.code, sourcePath, ctx);
   }
 
   // Check if already transformed (before cycle check to handle concurrent requests)

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
@@ -87,14 +87,25 @@ export async function cacheTransformedCode(
   });
 }
 
+// Fallback-only cache for depth-limit fallback transforms. Kept separate
+// from `frameworkFileCache` so the fallback's esbuild-only output never
+// poisons the main path, which expects fully-resolved code (`#veryfront/`,
+// React, HTTP imports all rewritten). The fallback still reads
+// `frameworkFileCache` first, so when the main path has already produced
+// a high-quality entry the fallback prefers it.
+const fallbackTransformCache = new Map<string, string>();
+
 /**
  * Pick an esbuild loader for a file path, honoring the embedded `.src`
- * suffix used in compiled binaries (`foo.ts.src` → `ts`).
+ * suffix used in compiled binaries (`foo.ts.src` → `ts`). Recognizes
+ * `.mjs`/`.cjs` as plain JS and `.mts`/`.cts` as TypeScript.
  */
 function pickFallbackLoader(sourcePath: string): "tsx" | "ts" | "jsx" | "js" {
-  const ext = sourcePath.match(/\.(tsx?|jsx?)(?:\.src)?$/)?.[1] ?? "tsx";
+  const ext = sourcePath
+    .match(/\.(tsx?|jsx?|m[jt]s|c[jt]s)(?:\.src)?$/i)?.[1]
+    ?.toLowerCase();
   if (ext === "tsx") return "tsx";
-  if (ext === "ts") return "ts";
+  if (ext === "ts" || ext === "mts" || ext === "cts") return "ts";
   if (ext === "jsx") return "jsx";
   return "js";
 }
@@ -133,15 +144,25 @@ async function transformAndCacheFallbackDep(
   ctx: TransformContext,
   visited: Set<string>,
 ): Promise<string | null> {
-  // Reuse already-transformed framework code when possible.
-  const cachedCode = frameworkFileCache.get(resolvedPath);
-  if (cachedCode) {
-    return await cacheTransformedCode(cachedCode, resolvedPath, ctx.fs);
+  // Prefer the main path's fully-resolved cache entry when present —
+  // that output is strictly higher quality than what the fallback
+  // produces (no `#veryfront/` / React / HTTP rewriting here).
+  const mainCached = frameworkFileCache.get(resolvedPath);
+  if (mainCached) {
+    return await cacheTransformedCode(mainCached, resolvedPath, ctx.fs);
+  }
+  const fallbackCached = fallbackTransformCache.get(resolvedPath);
+  if (fallbackCached) {
+    return await cacheTransformedCode(fallbackCached, resolvedPath, ctx.fs);
   }
 
   if (visited.has(resolvedPath)) {
-    // Cycle: nothing safe to emit. Caller will log and leave the bare
-    // import alone (same as a failed resolve).
+    // Cycle: bail and leave the parent's import bare. Logged so a stuck
+    // dev server isn't silently producing un-loadable cache files.
+    logger.warn(
+      `${LOG_PREFIX} Depth-limit fallback skipping cycle`,
+      { resolvedPath: resolvedPath.slice(-60) },
+    );
     return null;
   }
   visited.add(resolvedPath);
@@ -159,7 +180,7 @@ async function transformAndCacheFallbackDep(
 
   const compiled = await compileFallbackSource(depContent, resolvedPath);
   const rewritten = await rewriteFallbackRelativeImports(compiled, resolvedPath, ctx, visited);
-  frameworkFileCache.set(resolvedPath, rewritten);
+  fallbackTransformCache.set(resolvedPath, rewritten);
   return await cacheTransformedCode(rewritten, resolvedPath, ctx.fs);
 }
 

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
@@ -146,9 +146,14 @@ async function transformAndCacheFallbackDep(
 ): Promise<string | null> {
   // Prefer the main path's fully-resolved cache entry when present —
   // that output is strictly higher quality than what the fallback
-  // produces (no `#veryfront/` / React / HTTP rewriting here).
+  // produces (no `#veryfront/` / React / HTTP rewriting here). But
+  // never propagate a cycle placeholder: the main path stores those
+  // mid-transform and treats them as invalid (see `isCyclePlaceholder`
+  // / the cache-invalidation branch upstream). If the fallback wrote
+  // a placeholder into a cache file, an importer would silently see
+  // `export {}` and any named import would be `undefined` at runtime.
   const mainCached = frameworkFileCache.get(resolvedPath);
-  if (mainCached) {
+  if (mainCached && !isCyclePlaceholder(mainCached)) {
     return await cacheTransformedCode(mainCached, resolvedPath, ctx.fs);
   }
   const fallbackCached = fallbackTransformCache.get(resolvedPath);
@@ -178,7 +183,21 @@ async function transformAndCacheFallbackDep(
     return null;
   }
 
-  const compiled = await compileFallbackSource(depContent, resolvedPath);
+  // Catch esbuild failures (bad syntax, encoding issues) so one bad
+  // `.src` dep does not abort the entire top-level fallback. The bare
+  // import is left in the parent and the runtime's own loader will
+  // surface a clear "Module not found" instead of a stack trace
+  // pointing at an unrelated parent file.
+  let compiled: string;
+  try {
+    compiled = await compileFallbackSource(depContent, resolvedPath);
+  } catch (error) {
+    logger.warn(
+      `${LOG_PREFIX} Depth-limit fallback could not compile dependency`,
+      { resolvedPath: resolvedPath.slice(-60), error: String(error) },
+    );
+    return null;
+  }
   const rewritten = await rewriteFallbackRelativeImports(compiled, resolvedPath, ctx, visited);
   fallbackTransformCache.set(resolvedPath, rewritten);
   return await cacheTransformedCode(rewritten, resolvedPath, ctx.fs);


### PR DESCRIPTION
## Summary

Every page render returns 500 on a cold cache in 0.1.593 because the SSR vfmod transform writes a broken module to the framework cache. Found while wiring up the DORA compliance agent example ([veryfront-examples#10](https://github.com/veryfront/veryfront-examples/pull/10)).

## Root cause

`transformFrameworkCode` (`src/transforms/pipeline/stages/ssr-vf-modules/transform.ts`) recursively walks the framework source tree and rewrites each file's relative imports (e.g. `./build.js`, `./define.js`) to absolute `file://` URLs pointing at cached deps. Each recursion bumps `depth`. When `depth > MAX_RELATIVE_IMPORT_DEPTH = 10`, the function falls back to *"minimally transformed code"* — raw esbuild output with **no import rewriting** — and returns it. The caller then writes that fallback to `.cache/veryfront-mdx-esm/framework/vfmod-vf-framework-*.mjs`.

The resulting cached file looks like:

```js
// .cache/veryfront-mdx-esm/framework/vfmod-vf-framework-…-33d2a43d.mjs
import { DEFAULT_BUILD_CONCURRENCY, IMAGE_OPTIMIZATION } from "./build.js";
import { BUFFER_SIZE_… } from "./buffers.js";
```

…but `./build.js` doesn't exist in the cache directory, so Node/Deno report `Module not found "…/.cache/veryfront-mdx-esm/framework/build.js"` and SSR fails. The veryfront source tree in 0.1.593 has multiple chains that exceed depth 10 (`src/errors/types.js`, `src/utils/constants/index.js`, `src/schemas/primitives.js` all hit depth 11), so every project on 0.1.593 with a cold cache 500s on the first request.

The existing comment in the fallback path is candid: *"Return minimally transformed code - it will fail at runtime but won't hang"*. So this was a known time-bomb; the source tree just grew past the limit.

## Fix

In the depth-limit fallback:

1. Compile the file with esbuild as before.
2. Then walk its relative imports with `findRelativeImports`.
3. Resolve each against `sourcePath` via `resolveRelativeFrameworkImport`.
4. Rewrite the import to `file://${resolvedPath}` via `replaceSpecifiers`.

The resolved sources are already-published `.js` files with only sibling relative imports, which the runtime resolves natively from `node_modules` — so the fallback module becomes loadable from the cache directory without further recursive transformation. Imports that fail to resolve are left untouched (and a warning is logged), matching the previous behavior for that specific case.

## Verification

Patched the published `transform.js` in a sample project's `node_modules/.deno/veryfront@0.1.593/.../transform.js` with the same fix and reran `deno task dev`:

| Before | After |
|---|---|
| `Module not found "…/framework/build.js"` | gone |
| `Module not found "…/framework/define.js"` | gone |
| 6 render errors | 0 render errors related to framework cache |

A separate `"transform capacity"` error then surfaces while loading `react@19.2.4.js` from esm.sh, but it's likely an artifact of the parallel pdf-parse / mammoth bundler failures saturating the transform queue — that path is fixed in #1901.

## Test plan

- [x] `deno test src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts` — 2 new cases pass:
  - "rewrites relative imports in the fallback to absolute file:// URLs so the cached output is loadable"
  - "leaves bare-package imports alone in the fallback output"
- [x] `deno check` on the modified file.
- [x] Pre-push full suite — green.
- [x] Manual: live `deno task dev` against the DORA example shows the cached `vfmod-vf-framework-*.mjs` files now contain absolute `file://` URLs in place of `./build.js` / `./define.js`, and the framework-not-found errors disappear.

## Related

- [veryfront-code#1901](https://github.com/veryfront/veryfront-code/pull/1901) — fixes the discovery bundler crashing on Node-only npm deps in tools. Both fixes are needed for the DORA example (and any non-trivial project on 0.1.593) to render end-to-end.