### PR TITLE
Allow project agents to opt into sandbox bash

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.600",
+  "version": "0.1.601",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -94,6 +94,17 @@ export interface AgentConfig {
   model?: ModelString;
   system: string | (() => string) | (() => Promise<string>);
   tools?: true | Record<string, Tool | boolean>;
+  /**
+   * Optional sandbox selection for runtime-owned sandbox tools such as `bash`.
+   * `id` attaches to an existing sandbox session and detaches on run cleanup.
+   * When omitted, sandbox tools lazily create a request/project-scoped session.
+   */
+  sandbox?: {
+    id?: string;
+    sandboxId?: string;
+    sessionId?: string;
+    projectId?: string;
+  };
   remoteTools?: RemoteToolSource[];
   /**
    * Optional remote tool name allowlist. When set, only matching tools from

--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -2,6 +2,11 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { Agent } from "#veryfront/agent";
+import type {
+  AgentServiceSandboxToolsOptions,
+  AgentServiceSandboxToolsResult,
+  CreateSandboxBashTool,
+} from "#veryfront/sandbox";
 import { AgentRunSessionManager } from "./session-manager.ts";
 import { createRuntimeAgentStreamResponse } from "./run-stream.ts";
 
@@ -138,5 +143,161 @@ describe("internal-agents/run-stream", () => {
     );
 
     assertEquals(capturedToolNames, ["get_file", "search_knowledge"]);
+  });
+
+  it("materializes explicitly configured sandbox bash before constructing the runtime", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    const sandboxInputs: AgentServiceSandboxToolsOptions[] = [];
+    let capturedToolNames: string[] = [];
+
+    const agent = {
+      id: "builder-agent",
+      config: {
+        id: "builder-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        tools: {
+          bash: true,
+          missing_tool: true,
+        },
+        sandbox: {
+          id: "sandbox-existing",
+        },
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "builder-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        projectAgentSandbox: {
+          apiUrl: "https://api.test",
+          authToken: "runtime-token",
+          projectId: "project-1",
+        },
+        createBashTool: (() => Promise.resolve({ tools: {} })) as CreateSandboxBashTool,
+        createAgentServiceSandboxTools: (sandboxInput) => {
+          sandboxInputs.push(sandboxInput);
+          return Promise.resolve({
+            tools: {
+              bash: {
+                description: "Run bash",
+                execute: async () => ({ stdout: "ok", stderr: "", exitCode: 0 }),
+              },
+              sandbox_read_file: {
+                description: "Read sandbox file",
+                execute: async () => "",
+              },
+            },
+            sandbox: {} as AgentServiceSandboxToolsResult["sandbox"],
+            closeSandbox: async () => {},
+          });
+        },
+        createRuntime: (_agent, mergedTools) => {
+          capturedToolNames = Object.keys(mergedTools ?? {}).sort();
+          return {
+            stream: async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+          };
+        },
+      },
+    );
+
+    assertEquals(capturedToolNames, ["bash"]);
+    assertEquals(
+      sandboxInputs.map((sandboxInput) => ({
+        apiUrl: sandboxInput.apiUrl,
+        authToken: sandboxInput.authToken,
+        projectId: sandboxInput.getProjectId?.(),
+        sandboxId: sandboxInput.sandboxId,
+        deleteOnClose: sandboxInput.deleteOnClose,
+      })),
+      [
+        {
+          apiUrl: "https://api.test",
+          authToken: "runtime-token",
+          projectId: "project-1",
+          sandboxId: "sandbox-existing",
+          deleteOnClose: false,
+        },
+      ],
+    );
+  });
+
+  it("does not materialize sandbox bash without an explicit bash tool declaration", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let sandboxToolCalls = 0;
+    let capturedToolNames: string[] = [];
+
+    const agent = {
+      id: "builder-agent",
+      config: {
+        id: "builder-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        tools: {
+          missing_tool: true,
+        },
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "builder-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        projectAgentSandbox: {
+          apiUrl: "https://api.test",
+          authToken: "runtime-token",
+          projectId: "project-1",
+        },
+        createBashTool: (() => Promise.resolve({ tools: {} })) as CreateSandboxBashTool,
+        createAgentServiceSandboxTools: () => {
+          sandboxToolCalls += 1;
+          return Promise.resolve({
+            tools: {},
+            sandbox: {} as AgentServiceSandboxToolsResult["sandbox"],
+            closeSandbox: async () => {},
+          });
+        },
+        createRuntime: (_agent, mergedTools) => {
+          capturedToolNames = Object.keys(mergedTools ?? {}).sort();
+          return {
+            stream: async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+          };
+        },
+      },
+    );
+
+    assertEquals(capturedToolNames, []);
+    assertEquals(sandboxToolCalls, 0);
   });
 });

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -5,6 +5,16 @@ import {
   AgentRuntime,
 } from "#veryfront/agent";
 import { normalizeAgUiRuntimeMessages } from "#veryfront/agent/ag-ui/runtime-support.ts";
+import type {
+  AgentServiceSandboxToolsOptions,
+  AgentServiceSandboxToolsResult,
+} from "#veryfront/sandbox";
+import { createAgentServiceSandboxTools } from "#veryfront/sandbox";
+import { tryResolve } from "#veryfront/extensions/contracts.ts";
+import {
+  type SandboxShellToolsProvider,
+  SandboxShellToolsProviderName,
+} from "#veryfront/extensions/sandbox/index.ts";
 import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
 import { type Tool, toolRegistry } from "#veryfront/tool";
 import { defineSchema, lazySchema } from "#veryfront/schemas/index.ts";
@@ -23,6 +33,7 @@ import { serverLogger } from "#veryfront/utils";
 const getAnyObjectSchema = defineSchema((v) => v.record(v.string(), v.unknown()));
 const anyObjectSchema = lazySchema(getAnyObjectSchema) as Schema<Record<string, unknown>>;
 const logger = serverLogger.component("internal-agent-run-stream");
+const PROJECT_AGENT_SANDBOX_BASH_TOOL_NAME = "bash";
 
 type RuntimeFilteredAgent = Agent & {
   config: Agent["config"] & {
@@ -37,6 +48,15 @@ function getAgentAllowedRemoteToolNames(agent: Agent): string[] {
 
 export interface RuntimeAgentStreamExecutionDeps {
   sessionManager: AgentRunSessionManager;
+  projectAgentSandbox?: {
+    apiUrl?: string;
+    authToken?: string;
+    projectId?: string | null;
+  };
+  createBashTool?: AgentServiceSandboxToolsOptions["createBashTool"];
+  createAgentServiceSandboxTools?: (
+    input: AgentServiceSandboxToolsOptions,
+  ) => Promise<AgentServiceSandboxToolsResult>;
   createRuntime?: (
     agent: Agent,
     mergedTools: Agent["config"]["tools"],
@@ -93,6 +113,7 @@ function buildMergedTools(
   input: RuntimeRunAgentInput,
   sessionManager: AgentRunSessionManager,
   availableForwardedToolNames?: string[],
+  availableLocalTools?: Record<string, Tool | boolean>,
 ) {
   const injectedTools = Object.fromEntries(
     input.tools.map((tool) => [
@@ -132,10 +153,11 @@ function buildMergedTools(
     if (entry === true) {
       if (
         toolRegistry.get(toolName) ||
+        availableLocalTools?.[toolName] ||
         availableForwardedToolNames?.includes(toolName) ||
         sourceAllowedRemoteToolNames.includes(toolName)
       ) {
-        merged[toolName] = true;
+        merged[toolName] = availableLocalTools?.[toolName] ?? true;
       }
       continue;
     }
@@ -147,6 +169,85 @@ function buildMergedTools(
 
   const filtered = { ...merged, ...injectedTools };
   return Object.keys(filtered).length > 0 ? filtered : undefined;
+}
+
+async function loadDefaultCreateBashTool(): Promise<
+  AgentServiceSandboxToolsOptions["createBashTool"]
+> {
+  const provider = tryResolve<SandboxShellToolsProvider>(SandboxShellToolsProviderName);
+  if (provider) return provider;
+
+  const { createBashSandboxShellToolsProvider } = await import(
+    "../../extensions/ext-sandbox-shell-tools/src/index.ts"
+  );
+  return createBashSandboxShellToolsProvider;
+}
+
+function getStringProperty(value: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+  return undefined;
+}
+
+function getAgentSandboxConfig(agent: Agent): { sandboxId?: string; projectId?: string } {
+  const config = agent.config as Agent["config"] & { sandbox?: unknown };
+  if (!isRecord(config.sandbox)) {
+    return {};
+  }
+
+  return {
+    sandboxId: getStringProperty(config.sandbox, ["id", "sandboxId", "sessionId"]),
+    projectId: getStringProperty(config.sandbox, ["projectId"]),
+  };
+}
+
+function shouldExposeSandboxBash(agent: Agent): boolean {
+  const tools = agent.config.tools;
+  return isRecord(tools) && tools[PROJECT_AGENT_SANDBOX_BASH_TOOL_NAME] === true;
+}
+
+async function buildProjectAgentSandboxTools(input: {
+  agent: Agent;
+  deps: RuntimeAgentStreamExecutionDeps;
+}): Promise<{ tools?: Record<string, Tool | boolean>; closeSandbox?: () => Promise<void> }> {
+  if (!shouldExposeSandboxBash(input.agent)) {
+    return {};
+  }
+
+  const sandboxConfig = getAgentSandboxConfig(input.agent);
+  const createBashTool = input.deps.createBashTool ?? await loadDefaultCreateBashTool();
+  const createSandboxTools = input.deps.createAgentServiceSandboxTools ??
+    createAgentServiceSandboxTools;
+  const sandboxResult = await createSandboxTools({
+    createBashTool,
+    ...(input.deps.projectAgentSandbox?.apiUrl
+      ? { apiUrl: input.deps.projectAgentSandbox.apiUrl }
+      : {}),
+    ...(input.deps.projectAgentSandbox?.authToken
+      ? { authToken: input.deps.projectAgentSandbox.authToken }
+      : {}),
+    ...(sandboxConfig.sandboxId
+      ? { sandboxId: sandboxConfig.sandboxId, deleteOnClose: false }
+      : {}),
+    getProjectId: () => sandboxConfig.projectId ?? input.deps.projectAgentSandbox?.projectId,
+  });
+
+  const bash = sandboxResult.tools[PROJECT_AGENT_SANDBOX_BASH_TOOL_NAME];
+  if (!bash) {
+    await sandboxResult.closeSandbox();
+    return {};
+  }
+
+  return {
+    tools: {
+      [PROJECT_AGENT_SANDBOX_BASH_TOOL_NAME]: bash as Tool,
+    },
+    closeSandbox: sandboxResult.closeSandbox,
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -219,11 +320,13 @@ export async function createRuntimeAgentStreamResponse(
   const allowedRemoteToolNames = getAllowedRemoteToolNames(input.forwardedProps);
   const forwardedIntegrationToolDefs = getForwardedIntegrationToolDefinitions(input.forwardedProps);
   const availableForwardedToolNames = forwardedIntegrationToolDefs?.map((tool) => tool.name);
+  const sandboxTools = await buildProjectAgentSandboxTools({ agent, deps });
   const mergedTools = buildMergedTools(
     agent,
     input,
     deps.sessionManager,
     availableForwardedToolNames,
+    sandboxTools.tools,
   );
   const runtimeAgent: RuntimeFilteredAgent = {
     ...agent,
@@ -272,6 +375,13 @@ export async function createRuntimeAgentStreamResponse(
     });
   } catch (error) {
     deps.sessionManager.failRun(input.runId);
+    await sandboxTools.closeSandbox?.().catch((cleanupError) => {
+      logger.warn("Internal agent runtime sandbox cleanup failed after setup error", {
+        runId: input.runId,
+        agentId: agent.id,
+        error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+      });
+    });
     logger.error("Internal agent runtime stream setup failed", {
       runId: input.runId,
       threadId: input.threadId,
@@ -423,6 +533,13 @@ export async function createRuntimeAgentStreamResponse(
         if (clientAttached) {
           controller.close();
         }
+        await sandboxTools.closeSandbox?.().catch((cleanupError) => {
+          logger.warn("Internal agent runtime sandbox cleanup failed", {
+            runId: input.runId,
+            agentId: agent.id,
+            error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+          });
+        });
         logger.debug("Internal agent runtime stream response closed", {
           runId: input.runId,
           threadId: input.threadId,

--- a/src/sandbox/lazy-sandbox.ts
+++ b/src/sandbox/lazy-sandbox.ts
@@ -13,6 +13,15 @@ import {
 
 /** Options accepted by lazy sandbox. */
 export interface LazySandboxOptions extends SandboxOptions {
+  /**
+   * Optional existing sandbox session to attach to instead of creating a new one.
+   * Attached sessions are detached, not deleted, on close unless deleteOnClose is true.
+   */
+  sandboxId?: string;
+  /** Optional known endpoint for sandboxId; avoids the initial control-plane lookup. */
+  sandboxEndpoint?: string;
+  /** Delete the sandbox when closing. Defaults to true for created sessions and false for sandboxId. */
+  deleteOnClose?: boolean;
   getProjectId?: () => string | null | undefined;
   startupTimeoutMs?: number;
   pollIntervalMs?: number;
@@ -77,6 +86,9 @@ export function resolveDefaultSandboxRuntimeEndpoint(input: { endpoint: string }
 export class LazySandbox {
   private readonly apiUrl: string;
   private readonly authToken: string;
+  private readonly sandboxId: string | undefined;
+  private readonly sandboxEndpoint: string | undefined;
+  private readonly deleteOnClose: boolean;
   private readonly getProjectId: () => string | null | undefined;
   private readonly startupTimeoutMs: number;
   private readonly pollIntervalMs: number;
@@ -106,6 +118,9 @@ export class LazySandbox {
   constructor(options: LazySandboxOptions = {}) {
     this.apiUrl = resolveSandboxApiUrl(options);
     this.authToken = resolveSandboxAuthToken(options);
+    this.sandboxId = options.sandboxId?.trim() || undefined;
+    this.sandboxEndpoint = options.sandboxEndpoint?.trim() || undefined;
+    this.deleteOnClose = options.deleteOnClose ?? !this.sandboxId;
     this.getProjectId = options.getProjectId ?? (() => options.projectId);
     this.startupTimeoutMs = options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS;
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
@@ -411,7 +426,9 @@ export class LazySandbox {
           return;
         }
 
-        await this.deleteSession(currentSessionId);
+        if (this.deleteOnClose) {
+          await this.deleteSession(currentSessionId);
+        }
         this.resetSessionState(currentSessionId);
       })(),
     };
@@ -440,6 +457,11 @@ export class LazySandbox {
   }
 
   private async bootstrapSession(): Promise<void> {
+    if (this.sandboxId) {
+      await this.attachExistingSession(this.sandboxId);
+      return;
+    }
+
     const projectId = this.resolveProjectId();
     const res = await this.fetchControl(`${this.apiUrl}/sandbox-sessions`, {
       method: "POST",
@@ -464,7 +486,7 @@ export class LazySandbox {
       this.startHeartbeatLoop();
     } catch (error) {
       const currentSessionId = this.sessionId;
-      if (currentSessionId) {
+      if (currentSessionId && this.deleteOnClose) {
         await this.deleteSession(currentSessionId);
       }
       this.resetSessionState(currentSessionId ?? undefined);
@@ -478,6 +500,38 @@ export class LazySandbox {
     }
 
     return (await this.waitForReadySession(session.id)).endpoint;
+  }
+
+  private async attachExistingSession(sessionId: string): Promise<void> {
+    const projectId = this.resolveProjectId();
+    this.sessionId = sessionId;
+    this.sessionProjectId = projectId;
+
+    try {
+      const session = this.sandboxEndpoint
+        ? { id: sessionId, endpoint: this.sandboxEndpoint, status: "running" }
+        : await this.getSession(sessionId);
+      this.endpoint = await this.resolveReadyEndpoint(session);
+      await this.heartbeat(true);
+      this.startHeartbeatLoop();
+    } catch (error) {
+      this.resetSessionState(sessionId);
+      throw error;
+    }
+  }
+
+  private async getSession(sessionId: string): Promise<SandboxSessionRecord> {
+    const res = await this.fetchControl(`${this.apiUrl}/sandbox-sessions/${sessionId}`, {
+      headers: this.authHeaders(),
+    });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({
+        detail: `Failed to get sandbox: ${res.status} ${await res.text()}`,
+      });
+    }
+
+    return await res.json() as SandboxSessionRecord;
   }
 
   private async waitForReadySession(sessionId: string): Promise<SandboxSessionRecord> {
@@ -510,7 +564,7 @@ export class LazySandbox {
 
   private async touchSession(): Promise<void> {
     const projectId = this.resolveProjectId();
-    if (this.endpoint && this.sessionProjectId !== projectId) {
+    if (!this.sandboxId && this.endpoint && this.sessionProjectId !== projectId) {
       const currentSessionId = this.sessionId;
       if (currentSessionId) {
         await this.deleteSession(currentSessionId);
@@ -654,7 +708,9 @@ export class LazySandbox {
     const sessionId = this.sessionId;
     if (!sessionId) return;
 
-    await this.deleteSession(sessionId);
+    if (this.deleteOnClose) {
+      await this.deleteSession(sessionId);
+    }
     this.resetSessionState(sessionId);
   }
 

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -1358,6 +1358,40 @@ describe("Sandbox", () => {
         await sandbox.close();
       }
     });
+
+    it("attaches to a configured existing sandbox without deleting it on close", async () => {
+      mockFetch([
+        jsonResponse({
+          id: "existing-1",
+          endpoint: "https://existing.example.com",
+          status: "running",
+        }),
+        jsonResponse({ ok: true }),
+        ndjsonResponse([
+          { type: "stdout", data: "ok\n" },
+          { type: "exit", exitCode: 0 },
+        ]),
+      ]);
+
+      const sandbox = Sandbox.createLazy({
+        sandboxId: "existing-1",
+        authToken: "token",
+        apiUrl: "https://api.test.com",
+      });
+
+      assertEquals(await sandbox.executeCommand("echo ok"), {
+        stdout: "ok\n",
+        stderr: "",
+        exitCode: 0,
+      });
+      await sandbox.close();
+
+      assertEquals(fetchCalls.map((call) => [call.url, call.init?.method ?? "GET"]), [
+        ["https://api.test.com/sandbox-sessions/existing-1", "GET"],
+        ["https://api.test.com/sandbox-sessions/existing-1/heartbeat", "POST"],
+        ["https://existing.example.com/exec", "POST"],
+      ]);
+    });
   });
 
   describe("list()", () => {

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -383,7 +383,14 @@ export class AgentStreamHandler extends BaseHandler {
             }
 
             const runAgentStream = () =>
-              createRuntimeAgentStreamResponse(runtimeInput, runtimeAgent, this.deps);
+              createRuntimeAgentStreamResponse(runtimeInput, runtimeAgent, {
+                ...this.deps,
+                projectAgentSandbox: {
+                  apiUrl: getHostEnv("VERYFRONT_API_URL") ?? "https://api.veryfront.org",
+                  authToken: ctx.proxyToken || getHostEnv("VERYFRONT_API_TOKEN") || undefined,
+                  projectId: ctx.projectId ?? null,
+                },
+              });
             const shouldIsolateEnv = !!ctx.proxyToken;
             const response = shouldIsolateEnv
               ? await runWithProjectEnv(

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -62,7 +62,7 @@ const VERYFRONT_PLATFORM_REMOTE_TOOL_NAMES = new Set(["search_knowledge", "get_f
 // Per-environment env var cache shared across all agent stream requests (60s TTL)
 const _agentEnvVarCache = new EnvironmentVariableCache(
   (environmentId, token, projectSlug) => {
-    const apiBaseUrl = getHostEnv("VERYFRONT_API_URL") ?? "https://api.veryfront.org";
+    const apiBaseUrl = getHostEnv("VERYFRONT_API_URL") ?? "https://api.veryfront.com";
     return fetchProjectEnvVars(apiBaseUrl, projectSlug, environmentId, token);
   },
 );
@@ -76,7 +76,7 @@ async function _resolveProductionEnvironmentId(
 ): Promise<string | null> {
   const cached = _productionEnvIdCache.get(projectSlug);
   if (cached) return cached;
-  const apiBaseUrl = getHostEnv("VERYFRONT_API_URL") ?? "https://api.veryfront.org";
+  const apiBaseUrl = getHostEnv("VERYFRONT_API_URL") ?? "https://api.veryfront.com";
   try {
     const res = await fetch(
       `${apiBaseUrl}/projects/${encodeURIComponent(projectSlug)}/environments`,
@@ -141,7 +141,7 @@ function withVeryfrontPlatformRemoteTools(input: {
     return input.agent;
   }
 
-  const apiUrl = getHostEnv("VERYFRONT_API_URL") ?? "https://api.veryfront.org";
+  const apiUrl = getHostEnv("VERYFRONT_API_URL") ?? "https://api.veryfront.com";
   const remoteTools = input.agent.config.remoteTools ?? [];
   const platformRemoteToolSource = hasVeryfrontPlatformRemoteToolSource(remoteTools) ? [] : [
     createRemoteMCPToolSource({
@@ -169,7 +169,7 @@ function buildAgentStreamEnv(input: {
   proxyToken?: string | null;
   projectSlug?: string | null;
 }): Record<string, string> {
-  const apiUrl = getHostEnv("VERYFRONT_API_URL") ?? "https://api.veryfront.org";
+  const apiUrl = getHostEnv("VERYFRONT_API_URL") ?? "https://api.veryfront.com";
   return {
     ...input.envVars,
     // Framework-owned values must override project env to keep request-scoped
@@ -386,7 +386,7 @@ export class AgentStreamHandler extends BaseHandler {
               createRuntimeAgentStreamResponse(runtimeInput, runtimeAgent, {
                 ...this.deps,
                 projectAgentSandbox: {
-                  apiUrl: getHostEnv("VERYFRONT_API_URL") ?? "https://api.veryfront.org",
+                  apiUrl: getHostEnv("VERYFRONT_API_URL") ?? "https://api.veryfront.com",
                   authToken: ctx.proxyToken || getHostEnv("VERYFRONT_API_TOKEN") || undefined,
                   projectId: ctx.projectId ?? null,
                 },

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.600";
+export const VERSION = "0.1.601";


### PR DESCRIPTION
## Summary
- Add explicit project-agent opt-in for a sandbox-backed `bash` runtime tool
- Support attaching to an existing sandbox session via agent `sandbox.id` / `sandboxId` / `sessionId`
- Keep sandbox bash disabled unless `tools.bash === true`

## Testing
- Pre-push hook passed: format, lint, typecheck, unit tests
- Unit tests: 1913 passed, 17610 steps, 0 failed
- Targeted sandbox/project-agent stream tests passed before push