### PR TITLE
Request server function files for runtime discovery

### DIFF
--- a/src/platform/adapters/veryfront-api-client/operations.test.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.test.ts
@@ -1,7 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
 
-import { assertEquals, assertExists, assertThrows } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertStringIncludes,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { VeryfrontAPIOperations } from "./operations.ts";
 
 function createOps(
@@ -23,6 +28,24 @@ function assertMethodExists<T extends object>(obj: T, key: keyof T): void {
 }
 
 describe("VeryfrontAPIOperations", () => {
+  const originalFetch = globalThis.fetch;
+
+  function stubJsonFetch(handler: (url: string, init?: RequestInit) => unknown): void {
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const body = handler(String(input), init);
+      return Promise.resolve(
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }) as typeof fetch;
+  }
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
   describe("class", () => {
     it("should export VeryfrontAPIOperations class", () => {
       assertExists(VeryfrontAPIOperations);
@@ -113,6 +136,47 @@ describe("VeryfrontAPIOperations", () => {
 
     it("should have lookupProjectByDomain method", () => {
       assertMethodExists(createOps(), "lookupProjectByDomain");
+    });
+  });
+
+  describe("published server function access", () => {
+    it("requests release file lists with server functions for runtime route discovery", async () => {
+      let requestedUrl = "";
+      stubJsonFetch((url) => {
+        requestedUrl = url;
+        return {
+          data: [],
+          page_info: { self: null, first: null, next: null, prev: null },
+          release_id: "release-id",
+          release_version: "v1",
+        };
+      });
+
+      await createOps().listReleaseFiles("project-slug", "release-id");
+
+      assertStringIncludes(requestedUrl, "include_server_functions=true");
+    });
+
+    it("requests release file content with server functions for runtime handlers", async () => {
+      let requestedUrl = "";
+      stubJsonFetch((url) => {
+        requestedUrl = url;
+        return {
+          id: "file-id",
+          version_id: "version-id",
+          path: "pages/api/articles-2.ts",
+          content: "export default () => {}",
+          size: 21,
+          type: "function",
+          updated_at: "2026-04-23T00:00:00.000Z",
+          release_id: "release-id",
+          release_version: "v1",
+        };
+      });
+
+      await createOps().getReleaseFile("project-slug", "release-id", "pages/api/articles-2.ts");
+
+      assertStringIncludes(requestedUrl, "include_server_functions=true");
     });
   });
 });

--- a/src/platform/adapters/veryfront-api-client/operations.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.ts
@@ -105,6 +105,11 @@ function buildListParams(options: ListFilesOptions): URLSearchParams {
   return params;
 }
 
+function addRuntimeServerFunctionAccess(params: URLSearchParams): URLSearchParams {
+  params.set("include_server_functions", "true");
+  return params;
+}
+
 function mapProjectFile<T extends ProjectFile>(file: T): ProjectFile {
   return {
     id: file.id,
@@ -290,7 +295,7 @@ export class VeryfrontAPIOperations {
     environmentName = "production",
     options: ListFilesOptions = {},
   ): Promise<FileListResult> {
-    const params = buildListParams(options);
+    const params = addRuntimeServerFunctionAccess(buildListParams(options));
     const url = `/projects/${encodeURIComponent(projectRef)}/environments/${
       encodeURIComponent(environmentName)
     }/files?${params}`;
@@ -343,9 +348,10 @@ export class VeryfrontAPIOperations {
     return withSpan(
       SpanNames.API_GET_FILE,
       async () => {
+        const params = addRuntimeServerFunctionAccess(new URLSearchParams());
         const url = `/projects/${encodeURIComponent(projectRef)}/environments/${
           encodeURIComponent(environmentName)
-        }/files/${encodeURIComponent(pathOrId)}`;
+        }/files/${encodeURIComponent(pathOrId)}?${params}`;
         logger.debug("getEnvironmentFile", { projectRef, environmentName, pathOrId });
 
         const raw = await this.request(url);
@@ -374,7 +380,7 @@ export class VeryfrontAPIOperations {
     version = "latest",
     options: ListFilesOptions = {},
   ): Promise<FileListResult> {
-    const params = buildListParams(options);
+    const params = addRuntimeServerFunctionAccess(buildListParams(options));
     const url = `/projects/${encodeURIComponent(projectRef)}/releases/${
       encodeURIComponent(version)
     }/files?${params}`;
@@ -405,9 +411,10 @@ export class VeryfrontAPIOperations {
     return withSpan(
       SpanNames.API_GET_FILE,
       async () => {
+        const params = addRuntimeServerFunctionAccess(new URLSearchParams());
         const url = `/projects/${encodeURIComponent(projectRef)}/releases/${
           encodeURIComponent(version)
-        }/files/${encodeURIComponent(pathOrId)}`;
+        }/files/${encodeURIComponent(pathOrId)}?${params}`;
         logger.debug("getReleaseFile", { projectRef, version, pathOrId });
 
         const raw = await this.request(url);


### PR DESCRIPTION
## Summary
- Adds `include_server_functions=true` to published release/environment file reads.
- Covers runtime API route discovery and direct runtime handler content fetches.
- Keeps the opt-in paired with API-side project-scoped token authorization.

## Test Plan
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/platform/adapters/veryfront-api-client/operations.test.ts`
- `deno check src/platform/adapters/veryfront-api-client/operations.ts`
- pre-push checks: format, lint, type check, unit tests (`1916 passed`, with OTEL exporter env unset to avoid local observability default override)