### PR TITLE
Fix sandbox bash tool name for project agents

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.601",
+  "version": "0.1.602",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/scripts/build/generate-templates-manifest.ts
+++ b/scripts/build/generate-templates-manifest.ts
@@ -115,6 +115,8 @@ async function generateManifest(): Promise<TemplateManifest> {
 			files[mappedPath] = content;
 		}
 
+		if (Object.keys(files).length === 0) continue;
+
 		manifest.templates[`integration:${integrationName}`] = { files };
 	}
 

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -468,6 +468,24 @@ describe("tool-helpers", () => {
       }
     });
 
+    it("exposes inline configured tools under the configured map key", async () => {
+      const upstreamTool = tool({
+        id: "upstream-bash",
+        description: "Run bash",
+        inputSchema: defineSchema((v) => v.object({ command: v.string() }))(),
+        execute: async () => ({ ok: true }),
+      });
+
+      const defs = await getAvailableTools(
+        {
+          bash: upstreamTool,
+        },
+        { includeIntegrationTools: false },
+      );
+
+      assertEquals(defs.map((def) => def.name), ["bash"]);
+    });
+
     it("forwarded definitions are filtered by allowedRemoteToolNames", async () => {
       toolRegistry.clearAll();
 

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -288,7 +288,7 @@ function addToolDefinition(
   // deno-lint-ignore no-explicit-any -- generic erasure: accepts Tool with any input/output types
   tool: Tool<any, any>,
 ): void {
-  const def = toolToProviderDefinition(tool);
+  const def = toolToProviderDefinition({ ...tool, id: name });
   logToolDefinition(name, def);
   tools.push(def);
 }

--- a/src/sandbox/shell-tools.test.ts
+++ b/src/sandbox/shell-tools.test.ts
@@ -106,9 +106,27 @@ describe("sandbox/shell-tools", () => {
     assertEquals(receivedToolCallId, "call_123");
   });
 
+  it("uses the tool map key when bash-tool definitions omit an id", () => {
+    const normalized = normalizeBashToolSet({
+      bash: {
+        description: "Run commands",
+        inputSchemaJson: {
+          type: "object",
+          properties: {
+            command: { type: "string" },
+          },
+        },
+      },
+    });
+
+    assertEquals(normalized.bash?.id, "bash");
+  });
+
   it("handles invalid definitions gracefully", () => {
-    assertEquals(normalizeBashToolSet({ bad: "not-an-object" }), { bad: {} });
-    assertEquals(normalizeBashToolSet({ bad: null }), { bad: {} });
-    assertEquals(normalizeBashToolSet({ tool: { inputSchemaJson: "bad" } }), { tool: {} });
+    assertEquals(normalizeBashToolSet({ bad: "not-an-object" }), { bad: { id: "bad" } });
+    assertEquals(normalizeBashToolSet({ bad: null }), { bad: { id: "bad" } });
+    assertEquals(normalizeBashToolSet({ tool: { inputSchemaJson: "bad" } }), {
+      tool: { id: "tool" },
+    });
   });
 });

--- a/src/sandbox/shell-tools.ts
+++ b/src/sandbox/shell-tools.ts
@@ -118,12 +118,15 @@ function normalizeJsonSchema(value: unknown): JsonSchema | undefined {
   return schema;
 }
 
-function normalizeBashTool(toolDefinition: unknown): SandboxShellToolDefinition {
+function normalizeBashTool(
+  toolName: string,
+  toolDefinition: unknown,
+): SandboxShellToolDefinition {
   if (!isRecord(toolDefinition)) {
-    return {};
+    return { id: toolName };
   }
 
-  const normalized: SandboxShellToolDefinition = {};
+  const normalized: SandboxShellToolDefinition = { id: toolName };
   const id = toolDefinition.id;
   const type = toolDefinition.type;
   const description = toolDefinition.description;
@@ -163,7 +166,7 @@ export function normalizeBashToolSet(bashTools: Record<string, unknown>): Sandbo
   return Object.fromEntries(
     Object.entries(bashTools).map((
       [name, toolDefinition],
-    ) => [name, normalizeBashTool(toolDefinition)]),
+    ) => [name, normalizeBashTool(name, toolDefinition)]),
   );
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.601";
+export const VERSION = "0.1.602";


### PR DESCRIPTION
## Summary
- Preserve configured map names when exposing inline runtime tools to model providers, so project-agent sandbox bash is advertised as `bash` instead of `undefined`.
- Normalize bash-tool sandbox definitions with a stable id fallback from the tool map key.
- Bump veryfront-code release metadata to `0.1.602` and refresh the generated template manifest.

## Why
Project agents can opt into bash with `tools: { bash: true }`, but when the sandbox bash definition had no explicit id, provider conversion exposed the tool as `undefined`. The model then called `undefined`, and runtime execution failed with `Tool "undefined" not found` even though bash was configured.

## Testing
- `deno test --allow-all src/sandbox/shell-tools.test.ts`
- `deno test --allow-all src/agent/runtime/tool-helpers.test.ts`
- `deno test --allow-all src/internal-agents/run-stream.test.ts`
- `deno test --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts`
- `deno fmt --check` on touched files
- `DENO_NO_PACKAGE_JSON=1 deno lint` on touched files
- `deno check` on touched runtime files
- `deno task generate:manifests:check`
- Pre-push hook: format, lint, typecheck, generate, and full unit suite: 1,914 passed / 17,632 steps / 0 failed