### PR TITLE
Release sandbox bash fix as 0.1.603

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.602",
+  "version": "0.1.603",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.602";
+export const VERSION = "0.1.603";


### PR DESCRIPTION
## Summary
- bump the Veryfront package version to 0.1.603 so the merged project-agent sandbox bash fix can be published under a new npm version
- keep the release bump scoped to deno.json and the generated version constant

## Why
0.1.602 is already published, so the bash fix merged after that version needs a fresh package version before downstream services can consume it.

## Verification
- deno fmt --check deno.json src/utils/version-constant.ts
- deno test --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- deno check src/utils/version-constant.ts
- git diff --check
- pre-push: format, lint, typecheck, full Deno test suite: 1916 passed, 0 failed