### PR TITLE
fix(ssr): resolve four SSR module-loading bugs blocking framework-heavy renders

### DIFF
--- a/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
@@ -106,6 +106,39 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
       const stats = getTransformStats();
       assertEquals(stats.activeProjects.has("test-drop-zero"), false);
     });
+
+    it("bypass=true always acquires, even past the per-project limit", () => {
+      resetState();
+      if (getTransformPerProjectLimit() <= 0) return; // limit disabled
+
+      const projectId = "test-bypass-proj";
+
+      // Fill the project to its limit with normal acquisitions.
+      for (let i = 0; i < getTransformPerProjectLimit(); i++) {
+        assertEquals(acquireTransformSlot(projectId), true);
+      }
+      // Normal acquisition is now refused...
+      assertEquals(acquireTransformSlot(projectId), false);
+      // ...but a bypassing caller (e.g. single-tenant dev) still gets through.
+      assertEquals(acquireTransformSlot(projectId, true), true);
+
+      for (let i = 0; i < getTransformPerProjectLimit(); i++) {
+        releaseTransformSlot(projectId);
+      }
+    });
+
+    it("bypass=true does not change the project's tracked count", () => {
+      resetState();
+      if (getTransformPerProjectLimit() <= 0) return;
+
+      const projectId = "test-bypass-count";
+      assertEquals(acquireTransformSlot(projectId, true), true);
+      // A bypassing acquire must not consume a tracked slot.
+      assertEquals(getTransformStats().activeProjects.has(projectId), false);
+      // A bypassing release must be a no-op (no underflow / phantom entry).
+      releaseTransformSlot(projectId, true);
+      assertEquals(getTransformStats().activeProjects.has(projectId), false);
+    });
   });
 
   describe("getTransformStats", () => {

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.ts
@@ -85,10 +85,15 @@ const RATE_LIMIT_BYPASS_PREFIXES = ["local-", "test_"];
  *
  * Note: The "__single__" project and projects with "local-" prefix bypass
  * rate limiting since there's no noisy-neighbor concern in single-project mode.
+ * `bypass` forces the same behavior for callers that know they are
+ * single-tenant (e.g. the dev server, whose projectId is the project slug and
+ * therefore does not match the prefix allowlist). When bypassing, no slot is
+ * tracked, so the matching {@link releaseTransformSlot} must also bypass.
  */
-export function acquireTransformSlot(projectId: string): boolean {
+export function acquireTransformSlot(projectId: string, bypass = false): boolean {
   const limit = getTransformPerProjectLimit();
   if (limit <= 0) return true;
+  if (bypass) return true;
   if (RATE_LIMIT_BYPASS_PROJECTS.has(projectId)) return true;
   if (RATE_LIMIT_BYPASS_PREFIXES.some((prefix) => projectId.startsWith(prefix))) return true;
 
@@ -110,23 +115,26 @@ const PROJECT_SLOT_RETRY_INTERVAL_MS = 50;
 export async function tryAcquireTransformSlot(
   projectId: string,
   timeoutMs: number,
+  bypass = false,
 ): Promise<boolean> {
-  if (acquireTransformSlot(projectId)) return true;
+  if (acquireTransformSlot(projectId, bypass)) return true;
 
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     await new Promise<void>((resolve) => setTimeout(resolve, PROJECT_SLOT_RETRY_INTERVAL_MS)); // no cleanup needed: one-shot
-    if (acquireTransformSlot(projectId)) return true;
+    if (acquireTransformSlot(projectId, bypass)) return true;
   }
 
   return false;
 }
 
 /**
- * Release a project-level transform slot.
+ * Release a project-level transform slot. `bypass` must match the value
+ * passed to the corresponding {@link acquireTransformSlot} so a bypassing
+ * caller never decrements another caller's tracked count.
  */
-export function releaseTransformSlot(projectId: string): void {
-  if (getTransformPerProjectLimit() <= 0) return;
+export function releaseTransformSlot(projectId: string, bypass = false): void {
+  if (bypass || getTransformPerProjectLimit() <= 0) return;
 
   const current = projectTransformCounts.get(projectId) ?? 0;
   if (current <= 1) {

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -95,7 +95,16 @@ export class SSRModuleLoader {
     const semaphore = useSemaphore ? getTransformSemaphore() : undefined;
     let semaphoreAcquired = false;
 
-    if (!await tryAcquireTransformSlot(projectId, TRANSFORM_ACQUIRE_TIMEOUT_MS)) {
+    // The per-project limit is noisy-neighbor protection for multi-tenant
+    // cloud. The dev server is single-tenant, so the limit only produces
+    // false "at capacity" failures when a cold-cache render fans out across
+    // the framework tree. Bypass it in dev; the global semaphore still bounds
+    // total concurrency.
+    const bypassProjectLimit = this.options.dev === true;
+
+    if (
+      !await tryAcquireTransformSlot(projectId, TRANSFORM_ACQUIRE_TIMEOUT_MS, bypassProjectLimit)
+    ) {
       throw createTransformCapacityError(
         mode,
         `Project ${projectId} at transform capacity. Consider reducing page complexity or request rate.`,
@@ -120,7 +129,7 @@ export class SSRModuleLoader {
       if (semaphore && semaphoreAcquired) {
         semaphore.release();
       }
-      releaseTransformSlot(projectId);
+      releaseTransformSlot(projectId, bypassProjectLimit);
     }
   }
 

--- a/src/transforms/esm/react-imports.test.ts
+++ b/src/transforms/esm/react-imports.test.ts
@@ -13,7 +13,7 @@ describe("react-imports", () => {
       const code = 'import React from "react"';
       const result = await resolveReactImports(code);
       expect(result).toBe(
-        'import React from "https://esm.sh/react@19.1.1?target=es2022&deps=csstype@3.2.3"',
+        'import React from "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3"',
       );
     });
 
@@ -21,7 +21,7 @@ describe("react-imports", () => {
       const code = "import React from 'react'";
       const result = await resolveReactImports(code);
       expect(result).toBe(
-        "import React from 'https://esm.sh/react@19.1.1?target=es2022&deps=csstype@3.2.3'",
+        "import React from 'https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3'",
       );
     });
 
@@ -29,7 +29,7 @@ describe("react-imports", () => {
       const code = 'import { jsx } from "react/jsx-runtime"';
       const result = await resolveReactImports(code);
       expect(result).toBe(
-        'import { jsx } from "https://esm.sh/react@19.1.1/jsx-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
+        'import { jsx } from "https://esm.sh/react@19.2.4/jsx-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
       );
     });
 
@@ -37,7 +37,7 @@ describe("react-imports", () => {
       const code = 'import { jsxDEV } from "react/jsx-dev-runtime"';
       const result = await resolveReactImports(code);
       expect(result).toBe(
-        'import { jsxDEV } from "https://esm.sh/react@19.1.1/jsx-dev-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
+        'import { jsxDEV } from "https://esm.sh/react@19.2.4/jsx-dev-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
       );
     });
 
@@ -45,7 +45,7 @@ describe("react-imports", () => {
       const code = 'import ReactDOM from "react-dom"';
       const result = await resolveReactImports(code);
       expect(result).toBe(
-        'import ReactDOM from "https://esm.sh/react-dom@19.1.1?external=react&target=es2022&deps=csstype@3.2.3"',
+        'import ReactDOM from "https://esm.sh/react-dom@19.2.4?external=react&target=es2022&deps=csstype@3.2.3"',
       );
     });
 
@@ -53,7 +53,7 @@ describe("react-imports", () => {
       const code = 'import { renderToString } from "react-dom/server"';
       const result = await resolveReactImports(code);
       expect(result).toBe(
-        'import { renderToString } from "https://esm.sh/react-dom@19.1.1/server?external=react&target=es2022&deps=csstype@3.2.3"',
+        'import { renderToString } from "https://esm.sh/react-dom@19.2.4/server?external=react&target=es2022&deps=csstype@3.2.3"',
       );
     });
 
@@ -61,7 +61,7 @@ describe("react-imports", () => {
       const code = 'import { createRoot } from "react-dom/client"';
       const result = await resolveReactImports(code);
       expect(result).toBe(
-        'import { createRoot } from "https://esm.sh/react-dom@19.1.1/client?external=react&target=es2022&deps=csstype@3.2.3"',
+        'import { createRoot } from "https://esm.sh/react-dom@19.2.4/client?external=react&target=es2022&deps=csstype@3.2.3"',
       );
     });
 
@@ -72,13 +72,13 @@ import ReactDOM from "react-dom"`;
       const result = await resolveReactImports(code);
 
       expect(result).toContain(
-        'from "https://esm.sh/react@19.1.1?target=es2022&deps=csstype@3.2.3"',
+        'from "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3"',
       );
       expect(result).toContain(
-        'from "https://esm.sh/react@19.1.1/jsx-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
+        'from "https://esm.sh/react@19.2.4/jsx-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
       );
       expect(result).toContain(
-        'from "https://esm.sh/react-dom@19.1.1?external=react&target=es2022&deps=csstype@3.2.3"',
+        'from "https://esm.sh/react-dom@19.2.4?external=react&target=es2022&deps=csstype@3.2.3"',
       );
     });
 
@@ -86,7 +86,7 @@ import ReactDOM from "react-dom"`;
       const code = 'import { jsx } from "react/jsx-runtime"';
       const result = await resolveReactImports(code);
       expect(result).toBe(
-        'import { jsx } from "https://esm.sh/react@19.1.1/jsx-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
+        'import { jsx } from "https://esm.sh/react@19.2.4/jsx-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
       );
       expect(result).not.toContain("/jsx-runtime@");
     });
@@ -95,13 +95,13 @@ import ReactDOM from "react-dom"`;
       const code = 'import   React   from   "react"';
       const result = await resolveReactImports(code);
       expect(result).toBe(
-        'import   React   from   "https://esm.sh/react@19.1.1?target=es2022&deps=csstype@3.2.3"',
+        'import   React   from   "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3"',
       );
     });
 
     it("should not modify already resolved React URLs", async () => {
       const code =
-        'import React from "https://esm.sh/react@19.1.1?target=es2022&deps=csstype@3.2.3"';
+        'import React from "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3"';
       const result = await resolveReactImports(code);
       expect(result).toBe(code);
     });
@@ -122,7 +122,7 @@ import ReactDOM from "react-dom"`;
       `;
       const result = await resolveReactImports(code);
       expect(result).toContain(
-        'import React from "https://esm.sh/react@19.1.1?target=es2022&deps=csstype@3.2.3"',
+        'import React from "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3"',
       );
       expect(result).toContain("export function MyComponent()");
     });
@@ -137,22 +137,22 @@ import { renderToString } from "react-dom/server"`;
       const result = await resolveReactImports(code);
 
       expect(result).toContain(
-        'from "https://esm.sh/react@19.1.1?target=es2022&deps=csstype@3.2.3"',
+        'from "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3"',
       );
       expect(result).toContain(
-        'from "https://esm.sh/react@19.1.1/jsx-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
+        'from "https://esm.sh/react@19.2.4/jsx-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
       );
       expect(result).toContain(
-        'from "https://esm.sh/react@19.1.1/jsx-dev-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
+        'from "https://esm.sh/react@19.2.4/jsx-dev-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
       );
       expect(result).toContain(
-        'from "https://esm.sh/react-dom@19.1.1?external=react&target=es2022&deps=csstype@3.2.3"',
+        'from "https://esm.sh/react-dom@19.2.4?external=react&target=es2022&deps=csstype@3.2.3"',
       );
       expect(result).toContain(
-        'from "https://esm.sh/react-dom@19.1.1/client?external=react&target=es2022&deps=csstype@3.2.3"',
+        'from "https://esm.sh/react-dom@19.2.4/client?external=react&target=es2022&deps=csstype@3.2.3"',
       );
       expect(result).toContain(
-        'from "https://esm.sh/react-dom@19.1.1/server?external=react&target=es2022&deps=csstype@3.2.3"',
+        'from "https://esm.sh/react-dom@19.2.4/server?external=react&target=es2022&deps=csstype@3.2.3"',
       );
     });
 
@@ -172,7 +172,7 @@ import { renderToString } from "react-dom/server"`;
         const code = 'import React from "react"';
         const result = await resolveReactImports(code, true);
         expect(result).toBe(
-          'import React from "https://esm.sh/react@19.1.1?target=es2022&deps=csstype@3.2.3"',
+          'import React from "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3"',
         );
       });
 
@@ -180,7 +180,7 @@ import { renderToString } from "react-dom/server"`;
         const code = 'import { jsx } from "react/jsx-runtime"';
         const result = await resolveReactImports(code, true);
         expect(result).toBe(
-          'import { jsx } from "https://esm.sh/react@19.1.1/jsx-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
+          'import { jsx } from "https://esm.sh/react@19.2.4/jsx-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
         );
       });
 
@@ -188,7 +188,7 @@ import { renderToString } from "react-dom/server"`;
         const code = 'import { jsxDEV } from "react/jsx-dev-runtime"';
         const result = await resolveReactImports(code, true);
         expect(result).toBe(
-          'import { jsxDEV } from "https://esm.sh/react@19.1.1/jsx-dev-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
+          'import { jsxDEV } from "https://esm.sh/react@19.2.4/jsx-dev-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
         );
       });
 
@@ -196,7 +196,7 @@ import { renderToString } from "react-dom/server"`;
         const code = 'import ReactDOM from "react-dom"';
         const result = await resolveReactImports(code, true);
         expect(result).toBe(
-          'import ReactDOM from "https://esm.sh/react-dom@19.1.1?external=react&target=es2022&deps=csstype@3.2.3"',
+          'import ReactDOM from "https://esm.sh/react-dom@19.2.4?external=react&target=es2022&deps=csstype@3.2.3"',
         );
       });
 
@@ -204,7 +204,7 @@ import { renderToString } from "react-dom/server"`;
         const code = 'import { renderToString } from "react-dom/server"';
         const result = await resolveReactImports(code, true);
         expect(result).toBe(
-          'import { renderToString } from "https://esm.sh/react-dom@19.1.1/server?external=react&target=es2022&deps=csstype@3.2.3"',
+          'import { renderToString } from "https://esm.sh/react-dom@19.2.4/server?external=react&target=es2022&deps=csstype@3.2.3"',
         );
       });
 
@@ -212,7 +212,7 @@ import { renderToString } from "react-dom/server"`;
         const code = 'import { createRoot } from "react-dom/client"';
         const result = await resolveReactImports(code, true);
         expect(result).toBe(
-          'import { createRoot } from "https://esm.sh/react-dom@19.1.1/client?external=react&target=es2022&deps=csstype@3.2.3"',
+          'import { createRoot } from "https://esm.sh/react-dom@19.2.4/client?external=react&target=es2022&deps=csstype@3.2.3"',
         );
       });
 
@@ -226,22 +226,22 @@ import { renderToString } from "react-dom/server"`;
         const result = await resolveReactImports(code, true);
 
         expect(result).toContain(
-          'from "https://esm.sh/react@19.1.1?target=es2022&deps=csstype@3.2.3"',
+          'from "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3"',
         );
         expect(result).toContain(
-          'from "https://esm.sh/react@19.1.1/jsx-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
+          'from "https://esm.sh/react@19.2.4/jsx-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
         );
         expect(result).toContain(
-          'from "https://esm.sh/react@19.1.1/jsx-dev-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
+          'from "https://esm.sh/react@19.2.4/jsx-dev-runtime?external=react&target=es2022&deps=csstype@3.2.3"',
         );
         expect(result).toContain(
-          'from "https://esm.sh/react-dom@19.1.1?external=react&target=es2022&deps=csstype@3.2.3"',
+          'from "https://esm.sh/react-dom@19.2.4?external=react&target=es2022&deps=csstype@3.2.3"',
         );
         expect(result).toContain(
-          'from "https://esm.sh/react-dom@19.1.1/client?external=react&target=es2022&deps=csstype@3.2.3"',
+          'from "https://esm.sh/react-dom@19.2.4/client?external=react&target=es2022&deps=csstype@3.2.3"',
         );
         expect(result).toContain(
-          'from "https://esm.sh/react-dom@19.1.1/server?external=react&target=es2022&deps=csstype@3.2.3"',
+          'from "https://esm.sh/react-dom@19.2.4/server?external=react&target=es2022&deps=csstype@3.2.3"',
         );
       });
 
@@ -285,16 +285,16 @@ import { renderToString } from "react-dom/server"`;
     });
 
     it("should skip React imports", async () => {
-      const code = 'import React from "https://esm.sh/react@19.1.1"';
+      const code = 'import React from "https://esm.sh/react@19.2.4"';
       const result = await addDepsToEsmShUrls(code);
       expect(result).toBe(code);
     });
 
     it("should skip react-dom imports", async () => {
-      const code = 'import ReactDOM from "https://esm.sh/react-dom@19.1.1"';
+      const code = 'import ReactDOM from "https://esm.sh/react-dom@19.2.4"';
       const result = await addDepsToEsmShUrls(code);
       expect(result).toBe(
-        'import ReactDOM from "https://esm.sh/react-dom@19.1.1?external=react,react-dom&target=es2022"',
+        'import ReactDOM from "https://esm.sh/react-dom@19.2.4?external=react,react-dom&target=es2022"',
       );
     });
 
@@ -307,12 +307,12 @@ import bar from "https://esm.sh/package-b@2.0.0"`;
     });
 
     it("should handle mixed URLs", async () => {
-      const code = `import React from "https://esm.sh/react@19.1.1"
+      const code = `import React from "https://esm.sh/react@19.2.4"
 import foo from "https://esm.sh/some-package@1.0.0"
 import bar from "https://example.com/package.js"`;
       const result = await addDepsToEsmShUrls(code);
 
-      expect(result).toContain('from "https://esm.sh/react@19.1.1"');
+      expect(result).toContain('from "https://esm.sh/react@19.2.4"');
       expect(result).toContain("some-package@1.0.0?external=react,react-dom&target=es2022");
       expect(result).toContain('from "https://example.com/package.js"');
     });
@@ -364,14 +364,14 @@ import { Button } from "some-ui-lib"`;
 
       code = await resolveReactImports(code);
       expect(code).toContain(
-        'from "https://esm.sh/react@19.1.1?target=es2022&deps=csstype@3.2.3"',
+        'from "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3"',
       );
 
       code = code.replace('from "some-ui-lib"', 'from "https://esm.sh/some-ui-lib@1.0.0"');
       code = await addDepsToEsmShUrls(code);
 
       expect(code).toContain(
-        'from "https://esm.sh/react@19.1.1?target=es2022&deps=csstype@3.2.3"',
+        'from "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3"',
       );
       expect(code).toContain("some-ui-lib@1.0.0?external=react,react-dom&target=es2022");
     });
@@ -382,7 +382,7 @@ import { Button } from "some-ui-lib"`;
       code = await addDepsToEsmShUrls(code);
 
       expect(code).toBe(
-        'import React from "https://esm.sh/react@19.1.1?target=es2022&deps=csstype@3.2.3"',
+        'import React from "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3"',
       );
       expect(code).not.toContain("?deps");
     });

--- a/src/transforms/import-rewriter/url-builder.ts
+++ b/src/transforms/import-rewriter/url-builder.ts
@@ -5,8 +5,15 @@
  * Ensures consistent URLs across SSR and browser for hydration parity.
  */
 
-/** Default React version - used when not specified */
-export const DEFAULT_REACT_VERSION = "19.1.1";
+/**
+ * Default React version - used when not specified.
+ *
+ * MUST match the React version the build bundles (see `react/deno.json`),
+ * because veryfront's framework React re-export is generated against that
+ * version and references its named exports. A drift guard in
+ * `src/utils/constants/cdn.test.ts` enforces this.
+ */
+export const DEFAULT_REACT_VERSION = "19.2.4";
 
 /** Tailwind CSS version */
 export const TAILWIND_VERSION = "4.1.8";

--- a/src/transforms/pipeline/stages/ssr-vf-modules/constants.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/constants.ts
@@ -52,8 +52,14 @@ export const frameworkFileCache = new Map<string, string>();
 // Track files currently being transformed to detect cycles
 export const transformingFiles = new Set<string>();
 
-// Maximum recursion depth for relative imports
-export const MAX_RELATIVE_IMPORT_DEPTH = 10;
+// Maximum recursion depth for chained relative imports within framework
+// source. veryfront's own framework tree has relative-import chains deeper
+// than 10 (e.g. errors/utils/schemas internals reach ~11), and crossing a
+// `#veryfront/` boundary resets the counter, so this only bounds consecutive
+// `./`/`../` nesting. Cycles are caught separately by `transformingFiles`;
+// this is purely a stack-safety bound, so it is set generously above the
+// framework's real depth. Exceeding it falls back to a degraded transform.
+export const MAX_RELATIVE_IMPORT_DEPTH = 64;
 
 export interface TransformContext {
   reactVersion: string;

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
@@ -254,14 +254,14 @@ describe("transformFrameworkCode depth-limit fallback", {
     }
   });
 
-  it("leaves bare-package imports alone in the fallback output", async () => {
+  it("leaves non-react bare-package imports alone in the fallback output", async () => {
     const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-fallback-" });
     const srcDir = `${tmp}/src`;
     await Deno.mkdir(srcDir, { recursive: true });
-    const sourcePath = `${srcDir}/uses-react.js`;
+    const sourcePath = `${srcDir}/uses-lodash.js`;
     const sourceContent = [
-      `import React from "react";`,
-      `export const cls = React;`,
+      `import { merge } from "lodash";`,
+      `export const fn = merge;`,
     ].join("\n");
     await Deno.writeTextFile(sourcePath, sourceContent);
 
@@ -269,15 +269,51 @@ describe("transformFrameworkCode depth-limit fallback", {
       const transformed = await transformFrameworkCode(
         sourceContent,
         sourcePath,
-        { reactVersion: "19.1.1", projectDir: tmp, fs: createFileSystem() },
+        { reactVersion: "19.2.4", projectDir: tmp, fs: createFileSystem() },
         false,
         MAX_RELATIVE_IMPORT_DEPTH + 1,
       );
 
-      // Bare specifier `react` is the runtime's responsibility — fallback
-      // must not invent a file:// URL for it.
-      assertStringIncludes(transformed, 'from "react"');
+      // Non-react bare specifiers are the runtime's responsibility — the
+      // fallback must not invent a URL for them.
+      assertStringIncludes(transformed, 'from "lodash"');
       assert(!transformed.includes("file://"));
+    } finally {
+      await Deno.remove(tmp, { recursive: true });
+    }
+  });
+
+  it("rewrites react imports in the fallback so SSR shares one React instance", async () => {
+    // Regression: when a deep framework file exceeds the relative-import
+    // depth limit, the fallback used to leave bare `react` imports. Those
+    // resolve to the project's own React copy, distinct from the esm.sh
+    // React bundle used elsewhere during SSR — two React instances, so the
+    // dispatcher is null and the first hook throws
+    // "Cannot read properties of null (reading 'useEffect')". The fallback
+    // must rewrite react/react-dom to the same esm.sh URLs the main path uses.
+    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-react-id-" });
+    const srcDir = `${tmp}/src`;
+    await Deno.mkdir(srcDir, { recursive: true });
+    const sourcePath = `${srcDir}/uses-react.js`;
+    const sourceContent = [
+      `import { useEffect } from "react";`,
+      `export const hook = useEffect;`,
+    ].join("\n");
+    await Deno.writeTextFile(sourcePath, sourceContent);
+
+    try {
+      const transformed = await transformFrameworkCode(
+        sourceContent,
+        sourcePath,
+        { reactVersion: "19.2.4", projectDir: tmp, fs: createFileSystem() },
+        false,
+        MAX_RELATIVE_IMPORT_DEPTH + 1,
+      );
+
+      // `react` must no longer be bare — it must point at the esm.sh bundle
+      // pinned to the requested version.
+      assertEquals(transformed.includes('from "react"'), false);
+      assertStringIncludes(transformed, "esm.sh/react@19.2.4");
     } finally {
       await Deno.remove(tmp, { recursive: true });
     }

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
@@ -40,6 +40,31 @@ describe("reactReExportToEsmUrl", () => {
     assertEquals(reactReExportToEsmUrl(join(FRAMEWORK_ROOT, "src", "foo.js"), "19.2.4"), null);
     assertEquals(reactReExportToEsmUrl(reactPath("not-a-reexport.js"), "19.2.4"), null);
   });
+
+  // Drift guard: every React re-export source module under `react/` must have
+  // a routing entry, otherwise SSR would link it to project React (the
+  // dual-instance bug) and nothing would catch the regression.
+  it("routes every React re-export source module to an esm.sh URL", async () => {
+    const reactSrcDir = new URL("../../../../../react/", import.meta.url);
+    const sources: string[] = [];
+    for await (const entry of Deno.readDir(reactSrcDir)) {
+      if (entry.isFile && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+        sources.push(entry.name);
+      }
+    }
+    // Sanity: the source dir was found and is non-trivial.
+    assertEquals(sources.length >= 6, true);
+
+    for (const name of sources) {
+      const compiled = name.replace(/\.ts$/, ".js");
+      const url = reactReExportToEsmUrl(reactPath(compiled), "19.2.4");
+      assertEquals(
+        typeof url === "string" && url.includes("esm.sh"),
+        true,
+        `react/${name} has no esm.sh routing entry in REACT_REEXPORT_SPECIFIERS`,
+      );
+    }
+  });
 });
 
 // esbuild starts a child process that lives across tests, so we disable sanitizers

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
@@ -315,7 +315,11 @@ describe("transformFrameworkCode depth-limit fallback", {
     }
   });
 
-  it("leaves non-react bare-package imports alone in the fallback output", async () => {
+  it("materializes bare npm imports to loadable file:// bundles in the fallback", async () => {
+    // The fallback runs the same http-cache pass as the main path, so bare
+    // npm specifiers are resolved to local file:// bundles rather than left
+    // for ad-hoc runtime resolution. This keeps the fallback's cached output
+    // self-contained and Node-loadable.
     const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-fallback-" });
     const srcDir = `${tmp}/src`;
     await Deno.mkdir(srcDir, { recursive: true });
@@ -335,23 +339,24 @@ describe("transformFrameworkCode depth-limit fallback", {
         MAX_RELATIVE_IMPORT_DEPTH + 1,
       );
 
-      // Non-react bare specifiers are the runtime's responsibility — the
-      // fallback must not invent a URL for them.
-      assertStringIncludes(transformed, 'from "lodash"');
-      assert(!transformed.includes("file://"));
+      // No bare specifier and no remote https: import left behind.
+      assertEquals(transformed.includes('from "lodash"'), false);
+      assertEquals(/from\s+["']https:\/\//.test(transformed), false);
     } finally {
       await Deno.remove(tmp, { recursive: true });
     }
   });
 
-  it("rewrites react imports in the fallback so SSR shares one React instance", async () => {
+  it("rewrites react imports in the fallback to a loadable, single-instance bundle", async () => {
     // Regression: when a deep framework file exceeds the relative-import
     // depth limit, the fallback used to leave bare `react` imports. Those
     // resolve to the project's own React copy, distinct from the esm.sh
     // React bundle used elsewhere during SSR — two React instances, so the
     // dispatcher is null and the first hook throws
     // "Cannot read properties of null (reading 'useEffect')". The fallback
-    // must rewrite react/react-dom to the same esm.sh URLs the main path uses.
+    // rewrites react/react-dom to the esm.sh bundle, then (like the main path)
+    // materializes it to a local file:// bundle so Node can load the cached
+    // fallback module (Node rejects `import ... from "https:"`).
     const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-react-id-" });
     const srcDir = `${tmp}/src`;
     await Deno.mkdir(srcDir, { recursive: true });
@@ -371,10 +376,12 @@ describe("transformFrameworkCode depth-limit fallback", {
         MAX_RELATIVE_IMPORT_DEPTH + 1,
       );
 
-      // `react` must no longer be bare — it must point at the esm.sh bundle
-      // pinned to the requested version.
+      // Not bare (dual-instance bug) and not a raw https: import (Node would
+      // reject it when the cached fallback module loads). It must be a local
+      // file:// bundle.
       assertEquals(transformed.includes('from "react"'), false);
-      assertStringIncludes(transformed, "esm.sh/react@19.2.4");
+      assertEquals(/from\s+["']https:\/\//.test(transformed), false);
+      assertStringIncludes(transformed, "file://");
     } finally {
       await Deno.remove(tmp, { recursive: true });
     }

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
@@ -3,8 +3,44 @@ import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/a
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
-import { transformFrameworkCode } from "./transform.ts";
-import { MAX_RELATIVE_IMPORT_DEPTH } from "./constants.ts";
+import { join } from "#veryfront/compat/path/index.ts";
+import { reactReExportToEsmUrl, transformFrameworkCode } from "./transform.ts";
+import { FRAMEWORK_ROOT, MAX_RELATIVE_IMPORT_DEPTH } from "./constants.ts";
+import { buildReactUrl } from "#veryfront/transforms/import-rewriter/url-builder.ts";
+
+describe("reactReExportToEsmUrl", () => {
+  const reactPath = (name: string) => join(FRAMEWORK_ROOT, "react", name);
+
+  it("maps the React re-export to the esm.sh react bundle URL", () => {
+    assertEquals(
+      reactReExportToEsmUrl(reactPath("react.js"), "19.2.4"),
+      buildReactUrl("react", "19.2.4"),
+    );
+  });
+
+  it("maps react-dom client/server re-exports", () => {
+    assertEquals(
+      reactReExportToEsmUrl(reactPath("react-dom-client.js"), "19.2.4"),
+      buildReactUrl("react-dom", "19.2.4", "/client", true),
+    );
+    assertEquals(
+      reactReExportToEsmUrl(reactPath("react-dom-server.js"), "19.2.4"),
+      buildReactUrl("react-dom", "19.2.4", "/server", true),
+    );
+  });
+
+  it("maps jsx-runtime re-exports", () => {
+    assertEquals(
+      reactReExportToEsmUrl(reactPath("jsx-runtime.js"), "19.2.4"),
+      buildReactUrl("react", "19.2.4", "/jsx-runtime", true),
+    );
+  });
+
+  it("returns null for non-react-re-export framework files", () => {
+    assertEquals(reactReExportToEsmUrl(join(FRAMEWORK_ROOT, "src", "foo.js"), "19.2.4"), null);
+    assertEquals(reactReExportToEsmUrl(reactPath("not-a-reexport.js"), "19.2.4"), null);
+  });
+});
 
 // esbuild starts a child process that lives across tests, so we disable sanitizers
 describe("transformFrameworkCode depth-limit fallback", {

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
@@ -96,6 +96,38 @@ export async function cacheTransformedCode(
 const fallbackTransformCache = new Map<string, string>();
 
 /**
+ * Resolve a bare `react` / `react-dom` (or subpath) specifier to its esm.sh
+ * URL for the given React version. Returns `null` for anything that is not a
+ * React specifier.
+ *
+ * Both the main transform path and the depth-limit fallback use this so a
+ * framework module always links against the single esm.sh React bundle used
+ * during SSR. Leaving `react` bare would resolve it to the project's own
+ * React copy — a second React instance whose dispatcher is null, which makes
+ * the first hook throw "Cannot read properties of null (reading 'useEffect')".
+ */
+function resolveReactSpecifier(
+  specifier: string,
+  reactVersion: string,
+  reactImportMap: Record<string, string> = getReactImportMap(reactVersion),
+): string | null {
+  const mapped = reactImportMap[specifier];
+  if (mapped) return mapped;
+  if (specifier.startsWith("react/")) {
+    return buildReactUrl("react", reactVersion, "/" + specifier.slice("react/".length), true);
+  }
+  if (specifier.startsWith("react-dom/")) {
+    return buildReactUrl(
+      "react-dom",
+      reactVersion,
+      "/" + specifier.slice("react-dom/".length),
+      true,
+    );
+  }
+  return null;
+}
+
+/**
  * Pick an esbuild loader for a file path, honoring the embedded `.src`
  * suffix used in compiled binaries (`foo.ts.src` → `ts`). Recognizes
  * `.mjs`/`.cjs` as plain JS and `.mts`/`.cts` as TypeScript.
@@ -224,8 +256,9 @@ async function rewriteFallbackRelativeImports(
 ): Promise<string> {
   visited.add(sourcePath);
 
+  // Note: we do not early-return when there are no relative imports, because
+  // react/react-dom specifiers still need rewriting below.
   const relativeImports = findRelativeImports(code);
-  if (relativeImports.length === 0) return code;
 
   const replacements = new Map<string, string>();
   for (const specifier of relativeImports) {
@@ -256,13 +289,16 @@ async function rewriteFallbackRelativeImports(
     }
   }
 
-  if (replacements.size === 0) return code;
+  // React imports must be rewritten even when there are no relative imports,
+  // so SSR links against the single esm.sh React bundle (see
+  // resolveReactSpecifier).
+  const reactImportMap = getReactImportMap(ctx.reactVersion);
 
   return await replaceSpecifiers(code, (specifier) => {
     if (specifier.startsWith("./") || specifier.startsWith("../")) {
       return replacements.get(specifier) ?? null;
     }
-    return null;
+    return resolveReactSpecifier(specifier, ctx.reactVersion, reactImportMap);
   });
 }
 
@@ -495,28 +531,7 @@ export async function transformFrameworkCode(
         return relativeReplacements.get(specifier) ?? null;
       }
 
-      const mapped = reactImportMap[specifier];
-      if (mapped) return mapped;
-
-      if (specifier.startsWith("react/")) {
-        return buildReactUrl(
-          "react",
-          ctx.reactVersion,
-          "/" + specifier.slice("react/".length),
-          true,
-        );
-      }
-
-      if (specifier.startsWith("react-dom/")) {
-        return buildReactUrl(
-          "react-dom",
-          ctx.reactVersion,
-          "/" + specifier.slice("react-dom/".length),
-          true,
-        );
-      }
-
-      return null;
+      return resolveReactSpecifier(specifier, ctx.reactVersion, reactImportMap);
     });
 
     // Cache HTTP imports to local filesystem

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
@@ -138,10 +138,12 @@ function resolveReactSpecifier(
  * Rewriting these imports straight to the esm.sh bundle keeps every SSR
  * module on a single React instance.
  *
- * Keys must match the re-export filenames the build emits under
- * `FRAMEWORK_ROOT/react/` (see `scripts/build/npm-react-shims.ts` and the
- * package's `react/` directory). If the build renames one, add it here too —
- * a stale key silently reintroduces the dual-React-instance bug.
+ * Keys must match the compiled re-export filenames under
+ * `FRAMEWORK_ROOT/react/`, which the build emits from the `react/*.ts` source
+ * modules (`react.ts`, `react-dom.ts`, `react-dom-client.ts`,
+ * `react-dom-server.ts`, `jsx-runtime.ts`, `jsx-dev-runtime.ts`). If one is
+ * renamed or added, update this map too: a stale key silently reintroduces
+ * the dual-React-instance bug.
  */
 const REACT_REEXPORT_SPECIFIERS: Record<string, string> = {
   "react.js": "react",

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
@@ -350,12 +350,25 @@ async function rewriteFallbackRelativeImports(
   // React imports must be rewritten even when there are no relative imports,
   // so SSR links against the single esm.sh React bundle (see
   // resolveReactSpecifier).
-  return await replaceSpecifiers(code, (specifier) => {
+  const rewritten = await replaceSpecifiers(code, (specifier) => {
     if (specifier.startsWith("./") || specifier.startsWith("../")) {
       return replacements.get(specifier) ?? null;
     }
     return resolveReactSpecifier(specifier, ctx.reactVersion, reactImportMap);
   });
+
+  // Materialize any `https://esm.sh/...` React imports as local file:// bundles
+  // (same pass the main path runs). The cached fallback module is later loaded
+  // from file://, and Node rejects `import ... from "https:"`
+  // (ERR_UNSUPPORTED_ESM_URL_SCHEME); leaving the remote specifier in would
+  // break SSR under Node whenever a deep framework file hits this fallback.
+  const importMap = await loadImportMap(ctx.projectDir);
+  const cacheResult = await cacheHttpImportsToLocal(rewritten, {
+    cacheDir: getHttpBundleCacheDir(),
+    importMap,
+    reactVersion: ctx.reactVersion,
+  });
+  return cacheResult.code;
 }
 
 /**

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
@@ -128,6 +128,42 @@ function resolveReactSpecifier(
 }
 
 /**
+ * veryfront's own React re-export modules under `FRAMEWORK_ROOT/react/`
+ * mapped to the bare specifier they stand in for. Each re-export bridges to
+ * project React via `export * from "react"` (etc.), which during SSR resolves
+ * to the project's `node_modules` copy — a *different* React instance than
+ * the esm.sh react-dom bundle uses. The dnt build rewrites framework
+ * `import ... from "react"` to a relative import of these files, so a
+ * framework module that does `useEffect` ends up reading a null dispatcher.
+ * Rewriting these imports straight to the esm.sh bundle keeps every SSR
+ * module on a single React instance.
+ */
+const REACT_REEXPORT_SPECIFIERS: Record<string, string> = {
+  "react.js": "react",
+  "react-dom.js": "react-dom",
+  "react-dom-client.js": "react-dom/client",
+  "react-dom-server.js": "react-dom/server",
+  "jsx-runtime.js": "react/jsx-runtime",
+  "jsx-dev-runtime.js": "react/jsx-dev-runtime",
+};
+
+/**
+ * If `resolvedPath` is one of veryfront's React re-export modules
+ * (`FRAMEWORK_ROOT/react/*.js`), return the esm.sh URL it should be rewritten
+ * to for the given React version. Returns `null` for anything else.
+ */
+export function reactReExportToEsmUrl(
+  resolvedPath: string,
+  reactVersion: string,
+): string | null {
+  const reactDir = join(FRAMEWORK_ROOT, "react") + "/";
+  if (!resolvedPath.startsWith(reactDir)) return null;
+  const specifier = REACT_REEXPORT_SPECIFIERS[resolvedPath.slice(reactDir.length)];
+  if (!specifier) return null;
+  return resolveReactSpecifier(specifier, reactVersion);
+}
+
+/**
  * Pick an esbuild loader for a file path, honoring the embedded `.src`
  * suffix used in compiled binaries (`foo.ts.src` → `ts`). Recognizes
  * `.mjs`/`.cjs` as plain JS and `.mts`/`.cts` as TypeScript.
@@ -272,6 +308,14 @@ async function rewriteFallbackRelativeImports(
         `${LOG_PREFIX} Depth-limit fallback could not resolve relative import "${specifier}"`,
         { sourcePath: sourcePath.slice(-60) },
       );
+      continue;
+    }
+
+    // Same React-instance fix as the main path: route React re-exports to the
+    // esm.sh bundle instead of linking veryfront's project-React bridge.
+    const reactUrl = reactReExportToEsmUrl(resolvedPath, ctx.reactVersion);
+    if (reactUrl) {
+      replacements.set(specifier, reactUrl);
       continue;
     }
 
@@ -431,6 +475,15 @@ export async function transformFrameworkCode(
           logger.warn(
             `${LOG_PREFIX} Could not resolve relative import "${specifier}" in ${sourcePath}`,
           );
+          continue;
+        }
+
+        // veryfront's own React re-exports bridge to project React, which is a
+        // different instance than the esm.sh react-dom bundle during SSR.
+        // Point these straight at the esm.sh bundle so SSR shares one React.
+        const reactUrl = reactReExportToEsmUrl(resolvedPath, ctx.reactVersion);
+        if (reactUrl) {
+          relativeReplacements.set(specifier, reactUrl);
           continue;
         }
 

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
@@ -137,6 +137,11 @@ function resolveReactSpecifier(
  * framework module that does `useEffect` ends up reading a null dispatcher.
  * Rewriting these imports straight to the esm.sh bundle keeps every SSR
  * module on a single React instance.
+ *
+ * Keys must match the re-export filenames the build emits under
+ * `FRAMEWORK_ROOT/react/` (see `scripts/build/npm-react-shims.ts` and the
+ * package's `react/` directory). If the build renames one, add it here too —
+ * a stale key silently reintroduces the dual-React-instance bug.
  */
 const REACT_REEXPORT_SPECIFIERS: Record<string, string> = {
   "react.js": "react",
@@ -147,6 +152,9 @@ const REACT_REEXPORT_SPECIFIERS: Record<string, string> = {
   "jsx-dev-runtime.js": "react/jsx-dev-runtime",
 };
 
+/** `FRAMEWORK_ROOT/react/` prefix, precomputed (invariant per process). */
+const REACT_REEXPORT_DIR = join(FRAMEWORK_ROOT, "react") + "/";
+
 /**
  * If `resolvedPath` is one of veryfront's React re-export modules
  * (`FRAMEWORK_ROOT/react/*.js`), return the esm.sh URL it should be rewritten
@@ -155,12 +163,12 @@ const REACT_REEXPORT_SPECIFIERS: Record<string, string> = {
 export function reactReExportToEsmUrl(
   resolvedPath: string,
   reactVersion: string,
+  reactImportMap?: Record<string, string>,
 ): string | null {
-  const reactDir = join(FRAMEWORK_ROOT, "react") + "/";
-  if (!resolvedPath.startsWith(reactDir)) return null;
-  const specifier = REACT_REEXPORT_SPECIFIERS[resolvedPath.slice(reactDir.length)];
+  if (!resolvedPath.startsWith(REACT_REEXPORT_DIR)) return null;
+  const specifier = REACT_REEXPORT_SPECIFIERS[resolvedPath.slice(REACT_REEXPORT_DIR.length)];
   if (!specifier) return null;
-  return resolveReactSpecifier(specifier, reactVersion);
+  return resolveReactSpecifier(specifier, reactVersion, reactImportMap);
 }
 
 /**
@@ -296,6 +304,10 @@ async function rewriteFallbackRelativeImports(
   // react/react-dom specifiers still need rewriting below.
   const relativeImports = findRelativeImports(code);
 
+  // Built once and reused for both the relative-import loop (React re-export
+  // rewriting) and the final specifier pass below.
+  const reactImportMap = getReactImportMap(ctx.reactVersion);
+
   const replacements = new Map<string, string>();
   for (const specifier of relativeImports) {
     // Skip non-code imports the runtime cannot load this way.
@@ -313,7 +325,7 @@ async function rewriteFallbackRelativeImports(
 
     // Same React-instance fix as the main path: route React re-exports to the
     // esm.sh bundle instead of linking veryfront's project-React bridge.
-    const reactUrl = reactReExportToEsmUrl(resolvedPath, ctx.reactVersion);
+    const reactUrl = reactReExportToEsmUrl(resolvedPath, ctx.reactVersion, reactImportMap);
     if (reactUrl) {
       replacements.set(specifier, reactUrl);
       continue;
@@ -336,8 +348,6 @@ async function rewriteFallbackRelativeImports(
   // React imports must be rewritten even when there are no relative imports,
   // so SSR links against the single esm.sh React bundle (see
   // resolveReactSpecifier).
-  const reactImportMap = getReactImportMap(ctx.reactVersion);
-
   return await replaceSpecifiers(code, (specifier) => {
     if (specifier.startsWith("./") || specifier.startsWith("../")) {
       return replacements.get(specifier) ?? null;
@@ -450,6 +460,10 @@ export async function transformFrameworkCode(
     // cycles, and frameworkFileCache deduplicates already-transformed files.
     const relativeReplacements = new Map<string, string>();
 
+    // Built once and reused for both the relative-import loop (React
+    // re-export rewriting) and the final specifier pass below.
+    const reactImportMap = getReactImportMap(ctx.reactVersion);
+
     // Prefixes for framework source directories - files outside these are
     // already-compiled JS (e.g. dnt shims) that should not be recursively transformed.
     const frameworkSrcDir = join(FRAMEWORK_ROOT, "src") + "/";
@@ -481,7 +495,7 @@ export async function transformFrameworkCode(
         // veryfront's own React re-exports bridge to project React, which is a
         // different instance than the esm.sh react-dom bundle during SSR.
         // Point these straight at the esm.sh bundle so SSR shares one React.
-        const reactUrl = reactReExportToEsmUrl(resolvedPath, ctx.reactVersion);
+        const reactUrl = reactReExportToEsmUrl(resolvedPath, ctx.reactVersion, reactImportMap);
         if (reactUrl) {
           relativeReplacements.set(specifier, reactUrl);
           continue;
@@ -550,9 +564,6 @@ export async function transformFrameworkCode(
         }
       }
     }
-
-    // Rewrite imports to resolved paths
-    const reactImportMap = getReactImportMap(ctx.reactVersion);
 
     // Handle Deno import-map aliases (e.g. #deno-config) that only exist in
     // the Deno runtime and cannot be resolved by esm.sh or the HTTP cache.

--- a/src/utils/constants/cdn.test.ts
+++ b/src/utils/constants/cdn.test.ts
@@ -1,7 +1,47 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { DENO_STD_BASE, ESM_CDN_BASE, getDenoStdNodeBase, getTailwindCSSUrl } from "./cdn.ts";
+import {
+  DENO_STD_BASE,
+  ESM_CDN_BASE,
+  getDenoStdNodeBase,
+  getTailwindCSSUrl,
+  REACT_DEFAULT_VERSION,
+} from "./cdn.ts";
+import { DEFAULT_REACT_VERSION } from "#veryfront/transforms/import-rewriter/url-builder.ts";
+
+/**
+ * Read the React version veryfront's build bundles from `react/deno.json`.
+ * The build generates the framework React re-export (`esm/react/react.js`)
+ * and its esm.sh shim against this exact version, so the runtime defaults
+ * must match it — otherwise the re-export references named exports (e.g.
+ * `Activity`, a React 19.2 API) that an older esm.sh bundle does not provide,
+ * producing a hard SSR module-link error.
+ */
+async function buildReactVersion(): Promise<string> {
+  const url = new URL("../../../react/deno.json", import.meta.url);
+  const config = JSON.parse(await Deno.readTextFile(url)) as {
+    imports?: Record<string, string>;
+  };
+  const reactImport = config.imports?.react ?? "";
+  const match = reactImport.match(/react@(\d+\.\d+\.\d+)/);
+  if (!match) throw new Error(`Could not parse react version from "${reactImport}"`);
+  return match[1]!;
+}
+
+describe("constants/cdn — React default version drift guard", () => {
+  it("REACT_DEFAULT_VERSION matches the version the build bundles (react/deno.json)", async () => {
+    assertEquals(REACT_DEFAULT_VERSION, await buildReactVersion());
+  });
+
+  it("DEFAULT_REACT_VERSION (url-builder) matches the build's React version", async () => {
+    assertEquals(DEFAULT_REACT_VERSION, await buildReactVersion());
+  });
+
+  it("the two React default constants agree with each other", () => {
+    assertEquals(REACT_DEFAULT_VERSION, DEFAULT_REACT_VERSION);
+  });
+});
 
 describe("constants/cdn", () => {
   describe("getDenoStdNodeBase", () => {

--- a/src/utils/constants/cdn.ts
+++ b/src/utils/constants/cdn.ts
@@ -6,7 +6,7 @@ export const REACT_VERSION_17 = "17.0.2";
 export const REACT_VERSION_18_2 = "18.2.0";
 export const REACT_VERSION_18_3 = "18.3.1";
 export const REACT_VERSION_19_RC = "19.0.0-rc.0";
-export const REACT_VERSION_19 = "19.1.1";
+export const REACT_VERSION_19 = "19.2.4";
 
 /** Shared React default version value. */
 export const REACT_DEFAULT_VERSION = REACT_VERSION_19;

--- a/tests/integration/module-loading/import-map-loader.test.ts
+++ b/tests/integration/module-loading/import-map-loader.test.ts
@@ -21,8 +21,8 @@ describe("import-map-loader", () => {
       await withImportMapTestContext("import-map-load-valid", async (context, adapter) => {
         const denoConfig = {
           imports: {
-            react: "https://esm.sh/react@19.1.1",
-            "react-dom": "https://esm.sh/react-dom@19.1.1",
+            react: "https://esm.sh/react@19.2.4",
+            "react-dom": "https://esm.sh/react-dom@19.2.4",
           },
         };
 
@@ -34,11 +34,11 @@ describe("import-map-loader", () => {
         assertExists(importMap.imports);
         assertEquals(
           importMap.imports!["react"],
-          "https://esm.sh/react@19.1.1?target=es2022&deps=csstype@3.2.3",
+          "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3",
         );
         assertEquals(
           importMap.imports!["react-dom"],
-          "https://esm.sh/react-dom@19.1.1?external=react&target=es2022&deps=csstype@3.2.3",
+          "https://esm.sh/react-dom@19.2.4?external=react&target=es2022&deps=csstype@3.2.3",
         );
       });
     });
@@ -47,7 +47,7 @@ describe("import-map-loader", () => {
       await withImportMapTestContext("import-map-load-scopes", async (context, adapter) => {
         const denoConfig = {
           imports: {
-            react: "https://esm.sh/react@19.1.1",
+            react: "https://esm.sh/react@19.2.4",
           },
           scopes: {
             "/vendor/": {
@@ -67,7 +67,7 @@ describe("import-map-loader", () => {
         assertExists(importMap.imports);
         assertEquals(
           importMap.imports!["react"],
-          "https://esm.sh/react@19.1.1?target=es2022&deps=csstype@3.2.3",
+          "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3",
         );
 
         assertExists(importMap.scopes);
@@ -122,7 +122,7 @@ describe("import-map-loader", () => {
       await withImportMapTestContext("import-map-load-traverse", async (context, adapter) => {
         const denoConfig = {
           imports: {
-            react: "https://esm.sh/react@19.1.1",
+            react: "https://esm.sh/react@19.2.4",
           },
         };
 
@@ -136,7 +136,7 @@ describe("import-map-loader", () => {
         assertExists(importMap);
         assertEquals(
           importMap.imports!["react"],
-          "https://esm.sh/react@19.1.1?target=es2022&deps=csstype@3.2.3",
+          "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3",
         );
       });
     });
@@ -179,7 +179,7 @@ describe("import-map-loader", () => {
 
           assertEquals(
             importMap.imports!["react"],
-            "https://esm.sh/react@19.1.1?target=es2022&deps=csstype@3.2.3",
+            "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3",
           );
         },
       );
@@ -915,9 +915,9 @@ function hello() { return 'world'; }
         const denoConfig = {
           imports: {
             "@/": "./src/",
-            react: "https://esm.sh/react@19.1.1",
-            "react-dom": "https://esm.sh/react-dom@19.1.1",
-            "react-dom/server": "https://esm.sh/react-dom@19.1.1/server",
+            react: "https://esm.sh/react@19.2.4",
+            "react-dom": "https://esm.sh/react-dom@19.2.4",
+            "react-dom/server": "https://esm.sh/react-dom@19.2.4/server",
             "std/": "https://deno.land/std@0.220.0/",
             preact: "https://esm.sh/preact@10.19.3",
           },

--- a/tests/integration/server/build/client-runtime.test.ts
+++ b/tests/integration/server/build/client-runtime.test.ts
@@ -137,11 +137,11 @@ describe(
         assertStringIncludes(html, "/jsx-dev-runtime");
       });
 
-      it("should use React 19.1.1", async () => {
+      it("should use React 19.2.4", async () => {
         const html = await generateImportMap();
 
-        assertStringIncludes(html, "react@19.1.1");
-        assertStringIncludes(html, "react-dom@19.1.1");
+        assertStringIncludes(html, "react@19.2.4");
+        assertStringIncludes(html, "react-dom@19.2.4");
       });
 
       it("should have valid JSON structure", async () => {
@@ -189,7 +189,7 @@ describe(
         const importMap = await generateImportMap();
         const appCode = generateAppModule();
 
-        assert(importMap.includes("19.1.1"));
+        assert(importMap.includes("19.2.4"));
         assertStringIncludes(appCode, "2.0.0");
       });
     });


### PR DESCRIPTION
## Summary

Fixes a chain of four SSR module-loading bugs that together prevented any
project pulling in a broad slice of the framework (agent + chat + head + react)
from rendering `GET /` — it returned 500. Surfaced by the
`dora-compliance-agent` example. Each bug masked the next, so they are fixed and
verified in order.

### 1. React default version was stale (`fix(react)`)

`REACT_DEFAULT_VERSION` (`cdn.ts`) and `DEFAULT_REACT_VERSION`
(`url-builder.ts`) were pinned at `19.1.1`, but the build bundles React `19.2.4`
(`react/deno.json`). veryfront's generated framework React re-export statically
re-exports 19.2 APIs (`Activity`, `cacheSignal`, `useEffectEvent`); loading
framework modules with the stale default fetched a 19.1.1 esm.sh bundle that
lacked them → hard SSR module-link error
(`does not provide an export named 'Activity'`). Bumped both defaults to
`19.2.4` and added a drift guard asserting they match `react/deno.json`.

### 2. Depth-limit fallback dropped React identity (`fix(ssr-vf-modules)`)

The framework tree has relative-import chains ~11 deep, tripping
`MAX_RELATIVE_IMPORT_DEPTH = 10`. The fallback rewrote only relative imports,
leaving bare `react` specifiers → a second React instance. Raised the limit to
64 (cycles are still caught by `transformingFiles`) and made the fallback
rewrite react/react-dom via a shared `resolveReactSpecifier` helper.

### 3. Per-project transform limit fired in dev (`fix(ssr)`)

The per-project slot limit (`ceil(50/3)=17`) is multi-tenant noisy-neighbor
protection. In single-tenant `veryfront dev`, a cold-cache render fans out
enough concurrent framework transforms to saturate it; the 500 ms acquire
timeout then turned transient contention into fatal "missing dependency" errors.
The existing `local-`/`test_` bypass never matched the dev server's slug
projectId — added a `bypass` flag threaded from `options.dev`.

### 4. Framework React re-exports resolved to project React (`fix(ssr-vf-modules)`)

veryfront ships React re-export modules (`esm/react/react.js`, `react-dom-*.js`,
`jsx-runtime.js`) that bridge to project React via `export * from "react"`. The
dnt build rewrites framework `import ... from "react"` into relative imports of
these files. Because they live outside `FRAMEWORK_ROOT/src`, the transform
linked them raw, so their bare specifier resolved to the project's
`node_modules` React — a different instance than the esm.sh react-dom bundle
used by `react-dom/server`. The mismatched instances left React's dispatcher
null, so the first hook in a framework component (Head's `useEffect`) threw
`Cannot read properties of null (reading 'useEffect')`. Added
`reactReExportToEsmUrl()` and rewrote these imports straight to the esm.sh URLs
in both the main and fallback paths.

## Test plan

- [x] New/updated unit tests: drift guard (`cdn.test.ts`), fallback react
      rewriting + `reactReExportToEsmUrl` (`transform.test.ts`), `bypass` slot
      behavior (`memory.test.ts`), default-resolved URLs
      (`react-imports.test.ts`).
- [x] Affected suites green: transforms + react-loader + constants + rendering
      (198 files / 2770 steps).
- [x] Pre-push full suite green (1918 tests / 17664 steps).
- [x] End-to-end: built veryfront with all four fixes, installed into the
      (refactored) `dora-compliance-agent` example, `GET /` returns **200** and
      renders — previously a hard 500. No `Activity` / `useEffect`-null /
      transform-capacity / depth errors in the dev log.
