### PR TITLE
Wait for sandbox data plane before hosted bash

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.603",
+  "version": "0.1.604",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/sandbox/lazy-sandbox.ts
+++ b/src/sandbox/lazy-sandbox.ts
@@ -52,6 +52,7 @@ const DEFAULT_CONTROL_REQUEST_TIMEOUT_MS = 15_000;
 const DEFAULT_EXEC_START_TIMEOUT_MS = 30_000;
 const DEFAULT_EXEC_START_MAX_ATTEMPTS = 3;
 const DEFAULT_EXEC_START_RETRY_DELAY_MS = 1_000;
+const RETRYABLE_DATA_PLANE_READINESS_STATUS_CODES = new Set([404, 502, 503, 504]);
 const REPROVISIONABLE_EXEC_START_ERROR_CODES = new Set([
   "ECONNREFUSED",
   "ECONNRESET",
@@ -495,11 +496,12 @@ export class LazySandbox {
   }
 
   private async resolveReadyEndpoint(session: SandboxSessionRecord): Promise<string> {
-    if (session.status === "running") {
-      return session.endpoint;
-    }
+    const readySession = session.status === "running"
+      ? session
+      : await this.waitForReadySession(session.id);
 
-    return (await this.waitForReadySession(session.id)).endpoint;
+    await this.waitForRuntimeDataPlaneReady(readySession);
+    return readySession.endpoint;
   }
 
   private async attachExistingSession(sessionId: string): Promise<void> {
@@ -560,6 +562,39 @@ export class LazySandbox {
     }
 
     throw REQUEST_ERROR.create({ detail: "Sandbox did not become ready within timeout" });
+  }
+
+  private async waitForRuntimeDataPlaneReady(session: SandboxSessionRecord): Promise<void> {
+    if (resolveDefaultSandboxRuntimeEndpoint({ endpoint: session.endpoint }) === session.endpoint) {
+      return;
+    }
+
+    const runtimeEndpoint = this.resolveRuntimeEndpointFor(session.endpoint, session.id);
+    const start = Date.now();
+    let lastFailure = `sandbox status is ${session.status}`;
+
+    while (Date.now() - start < this.startupTimeoutMs) {
+      try {
+        const res = await this.fetchControl(`${runtimeEndpoint}/readyz`);
+
+        if (res.ok) {
+          return;
+        }
+
+        lastFailure = `${res.status} ${await res.text()}`;
+        if (!RETRYABLE_DATA_PLANE_READINESS_STATUS_CODES.has(res.status)) {
+          break;
+        }
+      } catch (error) {
+        lastFailure = error instanceof Error ? error.message : String(error);
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, this.pollIntervalMs));
+    }
+
+    throw REQUEST_ERROR.create({
+      detail: `Sandbox data plane did not become ready: ${lastFailure}`,
+    });
   }
 
   private async touchSession(): Promise<void> {
@@ -717,6 +752,10 @@ export class LazySandbox {
   private resolveRuntimeEndpoint(): string {
     const endpoint = this.requireEndpoint();
     const sessionId = this.requireSessionId();
+    return this.resolveRuntimeEndpointFor(endpoint, sessionId);
+  }
+
+  private resolveRuntimeEndpointFor(endpoint: string, sessionId: string): string {
     return this.resolveRuntimeEndpointOption?.({ endpoint, sessionId }) ??
       resolveDefaultSandboxRuntimeEndpoint({ endpoint });
   }

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -1059,6 +1059,54 @@ describe("Sandbox", () => {
       }
     });
 
+    it("waits for Kubernetes runtime endpoint readiness even when the session is already running", async () => {
+      setEnv("KUBERNETES_SERVICE_HOST", "kubernetes.default.svc");
+      mockTimers({ advanceTimeByMs: true });
+      mockFetch([
+        jsonResponse({
+          id: "sandbox-1",
+          endpoint: "https://3912734599.sandbox.veryfront.org",
+          status: "running",
+        }),
+        (input) => {
+          const url = String(input);
+          assertStringIncludes(url, "/readyz");
+          throw new TypeError("fetch failed");
+        },
+        jsonResponse({ status: "ok" }),
+        jsonResponse({ ok: true }),
+        ndjsonResponse([
+          { type: "stdout", data: "ok\n" },
+          { type: "exit", exitCode: 0 },
+        ]),
+        jsonResponse({ ok: true }),
+      ]);
+
+      const sandbox = Sandbox.createLazy({
+        authToken: "test-token",
+        apiUrl: "https://api.test.com",
+        execStartRetryDelayMs: 1,
+      });
+
+      try {
+        assertEquals(await sandbox.executeCommand("echo ok"), {
+          stdout: "ok\n",
+          stderr: "",
+          exitCode: 0,
+        });
+
+        assertEquals(fetchCalls.map((call) => call.url), [
+          "https://api.test.com/sandbox-sessions",
+          "http://sandbox.veryfront-sandbox-3912734599.svc.cluster.local/readyz",
+          "http://sandbox.veryfront-sandbox-3912734599.svc.cluster.local/readyz",
+          "https://api.test.com/sandbox-sessions/sandbox-1/heartbeat",
+          "http://sandbox.veryfront-sandbox-3912734599.svc.cluster.local/exec",
+        ]);
+      } finally {
+        await sandbox.close();
+      }
+    });
+
     it("times out stalled lazy background-command control requests", async () => {
       let capturedSignal: AbortSignal | undefined;
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.603";
+export const VERSION = "0.1.604";


### PR DESCRIPTION
## Summary
- probe the in-cluster sandbox /readyz endpoint before hosted bash uses a newly running sandbox
- cover the Kubernetes startup race reproduced in staging
- bump veryfront SDK version to 0.1.604 for release

## Testing
- deno fmt src/sandbox/lazy-sandbox.ts src/sandbox/sandbox.test.ts deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all src/sandbox/sandbox.test.ts