### PR TITLE
Recover hosted bash from stale sandbox sessions

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.604",
+  "version": "0.1.605",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/sandbox/lazy-sandbox.ts
+++ b/src/sandbox/lazy-sandbox.ts
@@ -52,6 +52,8 @@ const DEFAULT_CONTROL_REQUEST_TIMEOUT_MS = 15_000;
 const DEFAULT_EXEC_START_TIMEOUT_MS = 30_000;
 const DEFAULT_EXEC_START_MAX_ATTEMPTS = 3;
 const DEFAULT_EXEC_START_RETRY_DELAY_MS = 1_000;
+const CREATED_SESSION_BOOTSTRAP_MAX_ATTEMPTS = 2;
+const DATA_PLANE_READINESS_FAILURE_PREFIX = "Sandbox data plane did not become ready:";
 const RETRYABLE_DATA_PLANE_READINESS_STATUS_CODES = new Set([404, 502, 503, 504]);
 const REPROVISIONABLE_EXEC_START_ERROR_CODES = new Set([
   "ECONNREFUSED",
@@ -463,6 +465,22 @@ export class LazySandbox {
       return;
     }
 
+    for (let attempt = 1; attempt <= CREATED_SESSION_BOOTSTRAP_MAX_ATTEMPTS; attempt += 1) {
+      try {
+        await this.bootstrapCreatedSession();
+        return;
+      } catch (error) {
+        if (
+          attempt >= CREATED_SESSION_BOOTSTRAP_MAX_ATTEMPTS ||
+          !isDataPlaneReadinessFailure(error)
+        ) {
+          throw error;
+        }
+      }
+    }
+  }
+
+  private async bootstrapCreatedSession(): Promise<void> {
     const projectId = this.resolveProjectId();
     const res = await this.fetchControl(`${this.apiUrl}/sandbox-sessions`, {
       method: "POST",
@@ -786,6 +804,16 @@ function isRetryableExecStartStatus(status: number): boolean {
 
 function isRetryableExecStartError(error: unknown): boolean {
   return error instanceof Error && /fetch failed/i.test(error.message);
+}
+
+function isDataPlaneReadinessFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const detail = "detail" in error && typeof error.detail === "string" ? error.detail : undefined;
+  return error.message.startsWith(DATA_PLANE_READINESS_FAILURE_PREFIX) ||
+    detail?.startsWith(DATA_PLANE_READINESS_FAILURE_PREFIX) === true;
 }
 
 function shouldReprovisionAfterExecStartFailure(error: unknown): boolean {

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -1107,6 +1107,67 @@ describe("Sandbox", () => {
       }
     });
 
+    it("reprovisions SDK-created Kubernetes sessions when the runtime endpoint never becomes ready", async () => {
+      setEnv("KUBERNETES_SERVICE_HOST", "kubernetes.default.svc");
+      mockTimers({ advanceTimeByMs: true });
+      mockFetch([
+        jsonResponse({
+          id: "stale",
+          endpoint: "https://2826936518.sandbox.veryfront.org",
+          status: "running",
+        }),
+        () => {
+          throw new TypeError("fetch failed");
+        },
+        () => {
+          throw new TypeError("fetch failed");
+        },
+        jsonResponse({ ok: true }),
+        jsonResponse({
+          id: "fresh",
+          endpoint: "https://1373820032.sandbox.veryfront.org",
+          status: "running",
+        }),
+        jsonResponse({ status: "ok" }),
+        jsonResponse({ ok: true }),
+        ndjsonResponse([
+          { type: "stdout", data: "ok\n" },
+          { type: "exit", exitCode: 0 },
+        ]),
+        jsonResponse({ ok: true }),
+      ]);
+
+      const sandbox = Sandbox.createLazy({
+        authToken: "test-token",
+        apiUrl: "https://api.test.com",
+        startupTimeoutMs: 3,
+        pollIntervalMs: 2,
+        controlRequestTimeoutMs: 0,
+      });
+
+      try {
+        assertEquals(await sandbox.executeCommand("echo ok"), {
+          stdout: "ok\n",
+          stderr: "",
+          exitCode: 0,
+        });
+
+        assertEquals(fetchCalls.map((call) => call.url), [
+          "https://api.test.com/sandbox-sessions",
+          "http://sandbox.veryfront-sandbox-2826936518.svc.cluster.local/readyz",
+          "http://sandbox.veryfront-sandbox-2826936518.svc.cluster.local/readyz",
+          "https://api.test.com/sandbox-sessions/stale",
+          "https://api.test.com/sandbox-sessions",
+          "http://sandbox.veryfront-sandbox-1373820032.svc.cluster.local/readyz",
+          "https://api.test.com/sandbox-sessions/fresh/heartbeat",
+          "http://sandbox.veryfront-sandbox-1373820032.svc.cluster.local/exec",
+        ]);
+        assertEquals(fetchCalls[3]!.init?.method, "DELETE");
+      } finally {
+        await sandbox.close();
+      }
+    });
+
     it("times out stalled lazy background-command control requests", async () => {
       let capturedSignal: AbortSignal | undefined;
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.604";
+export const VERSION = "0.1.605";


### PR DESCRIPTION
## Summary
- retry lazy SDK-created sandbox bootstrap once when the in-cluster data plane never becomes ready
- delete the stale created session before provisioning a fresh replacement
- add a regression test for stale Kubernetes runtime endpoints
- bump veryfront to 0.1.605 for release

## Verification
- deno test --no-check --allow-all src/sandbox/sandbox.test.ts
- deno task verify:quick
- pre-push hook: fmt, lint, typecheck, test:unit