### PR TITLE
Bump version to 0.1.605

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.604",
+  "version": "0.1.605",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.604";
+export const VERSION = "0.1.605";


### PR DESCRIPTION
## Summary

Bumps `veryfront` from 0.1.604 to 0.1.605 (`deno.json` + `src/utils/version-constant.ts`).

Cuts a release containing the SSR module-loading fixes from #1914, which merged to main after the 0.1.604 tag and are otherwise unreleased:

- React default-version sync (19.1.1 → 19.2.4)
- depth-limit fallback React identity + http-caching of fallback bundles
- dev-mode bypass of the per-project transform limit
- framework React re-export routing to the esm.sh bundle

This unblocks the `dora-compliance-agent` example (veryfront-examples#10), which renders `GET /` against a build with these fixes.

## Test plan

- [x] `deno fmt --check deno.json src/utils/version-constant.ts`
- [x] `src/utils/version.test.ts` passes
- [x] deno.json and version-constant.ts agree at 0.1.605
- [x] Pre-push full suite green