### PR TITLE
End Anthropic client-tool streams at the tool boundary

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.605",
+  "version": "0.1.606",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
@@ -12,6 +12,15 @@ function streamFromText(text: string): ReadableStream<Uint8Array> {
   });
 }
 
+function hangingStreamFromText(text: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+    },
+  });
+}
+
 async function collectParts(stream: ReadableStream<Uint8Array>): Promise<unknown[]> {
   const parts: unknown[] = [];
   for await (const part of streamAnthropicCompatibleParts(stream)) {
@@ -116,6 +125,47 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
       { type: "reasoning-start", id: "thinking-0" },
       { type: "reasoning-end", id: "thinking-0" },
       { type: "finish", finishReason: null },
+    ]);
+  });
+
+  it("ends a client tool-use step once the tool call is complete", async () => {
+    let timeoutId: number | undefined;
+    const parts = await Promise.race([
+      collectParts(hangingStreamFromText([
+        data({
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "tool_use", id: "toolu_1", name: "bash" },
+        }),
+        data({
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "input_json_delta", partial_json: '{"command":"pwd"}' },
+        }),
+        data({ type: "content_block_stop", index: 0 }),
+      ].join(""))),
+      new Promise<"timeout">((resolve) => {
+        timeoutId = setTimeout(() => resolve("timeout"), 50);
+      }),
+    ]).finally(() => {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    });
+
+    assertEquals(parts, [
+      { type: "tool-input-start", id: "toolu_1", toolName: "bash" },
+      { type: "tool-input-delta", id: "toolu_1", delta: '{"command":"pwd"}' },
+      {
+        type: "tool-call",
+        toolCallId: "toolu_1",
+        toolName: "bash",
+        input: '{"command":"pwd"}',
+      },
+      {
+        type: "finish",
+        finishReason: { unified: "tool-calls", raw: "tool_use" },
+      },
     ]);
   });
 });

--- a/extensions/ext-llm-anthropic/src/anthropic-stream.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.ts
@@ -77,6 +77,7 @@ export async function* streamAnthropicCompatibleParts(
   const reasoningBlocks = new Map<number, AnthropicStreamReasoningState>();
   let finishReason: string | { unified: string; raw: string } | null = null;
   let usage: RuntimeUsage | undefined;
+  let completedClientToolUseStep = false;
 
   for await (const chunk of stream) {
     buffer += decoder.decode(chunk, { stream: true });
@@ -277,6 +278,9 @@ export async function* streamAnthropicCompatibleParts(
           input: current.input.length > 0 ? current.input : "{}",
           ...(current.providerExecuted ? { providerExecuted: true } : {}),
         };
+        if (!current.providerExecuted) {
+          completedClientToolUseStep = true;
+        }
         toolCalls.delete(index);
         continue;
       }
@@ -288,6 +292,15 @@ export async function* streamAnthropicCompatibleParts(
           finishReason = normalizedFinishReason;
         }
       }
+    }
+
+    if (completedClientToolUseStep && toolCalls.size === 0) {
+      yield {
+        type: "finish",
+        finishReason: { unified: "tool-calls", raw: "tool_use" },
+        ...(usage ? { usage } : {}),
+      };
+      return;
     }
   }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.605";
+export const VERSION = "0.1.606";


### PR DESCRIPTION
## Summary
- finish Anthropic client-side tool-use turns as soon as a complete local tool call is emitted
- keep provider-executed server tools on the existing provider finish path
- bump veryfront to 0.1.606 for release rollout

## Root cause
Staging showed the Bash expert produced a correctly named `bash` tool call, but the runtime never crossed into sandbox execution because the Anthropic stream waited for a later provider terminal event and finalized as `stop` after client detach. The local runtime only executes tools on `tool-calls`, so the tool stayed pending until timeout.

## Testing
- `deno test --no-check --allow-all extensions/ext-llm-anthropic/src/anthropic-stream.test.ts`
- `deno test --no-check --allow-all extensions/ext-llm-anthropic/src/anthropic-stream.test.ts extensions/ext-llm-anthropic/src/anthropic-provider.test.ts src/runtime/runtime-bridge.test.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/index.test.ts`
- `deno task --quiet verify:quick`
- pre-push checks: `1918 passed (17667 steps) | 0 failed`