### PR TITLE
Keep project-agent runtime streams alive while tools run

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.606",
+  "version": "0.1.607",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { FakeTime } from "jsr:@std/testing@1.0.17/time";
 import type { Agent } from "#veryfront/agent";
 import type {
   AgentServiceSandboxToolsOptions,
@@ -162,6 +163,7 @@ describe("internal-agents/run-stream", () => {
         },
         sandbox: {
           id: "sandbox-existing",
+          endpoint: "https://sandbox-existing.example.test",
         },
       },
     } as unknown as Agent;
@@ -224,6 +226,7 @@ describe("internal-agents/run-stream", () => {
         authToken: sandboxInput.authToken,
         projectId: sandboxInput.getProjectId?.(),
         sandboxId: sandboxInput.sandboxId,
+        sandboxEndpoint: sandboxInput.sandboxEndpoint,
         deleteOnClose: sandboxInput.deleteOnClose,
       })),
       [
@@ -232,6 +235,7 @@ describe("internal-agents/run-stream", () => {
           authToken: "runtime-token",
           projectId: "project-1",
           sandboxId: "sandbox-existing",
+          sandboxEndpoint: "https://sandbox-existing.example.test",
           deleteOnClose: false,
         },
       ],
@@ -299,5 +303,65 @@ describe("internal-agents/run-stream", () => {
 
     assertEquals(capturedToolNames, []);
     assertEquals(sandboxToolCalls, 0);
+  });
+
+  it("emits comment heartbeats while the runtime stream is idle", async () => {
+    using time = new FakeTime();
+    const sessionManager = new AgentRunSessionManager();
+    const agent = {
+      id: "idle-agent",
+      config: {
+        id: "idle-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "idle-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+    let runtimeController: ReadableStreamDefaultController<Uint8Array> | null = null;
+
+    const response = await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        createRuntime: () => ({
+          stream: async () =>
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                runtimeController = controller;
+                // Keep the stream idle so the control-plane response must stay alive.
+              },
+            }),
+        }),
+      },
+    );
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error("Expected a runtime response body");
+    }
+
+    const decoder = new TextDecoder();
+    const started = await reader.read();
+    assertStringIncludes(decoder.decode(started.value), "event: RunStarted");
+
+    const heartbeat = reader.read();
+    time.tick(25_000);
+    const heartbeatChunk = await heartbeat;
+    assertEquals(
+      decoder.decode(heartbeatChunk.value),
+      ": internal-agent-runtime-heartbeat\n\n",
+    );
+
+    runtimeController?.close();
+    await reader.cancel();
   });
 });

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -34,6 +34,10 @@ const getAnyObjectSchema = defineSchema((v) => v.record(v.string(), v.unknown())
 const anyObjectSchema = lazySchema(getAnyObjectSchema) as Schema<Record<string, unknown>>;
 const logger = serverLogger.component("internal-agent-run-stream");
 const PROJECT_AGENT_SANDBOX_BASH_TOOL_NAME = "bash";
+const INTERNAL_AGENT_RUNTIME_HEARTBEAT_INTERVAL_MS = 25_000;
+const INTERNAL_AGENT_RUNTIME_HEARTBEAT_FRAME = new TextEncoder().encode(
+  ": internal-agent-runtime-heartbeat\n\n",
+);
 
 type RuntimeFilteredAgent = Agent & {
   config: Agent["config"] & {
@@ -52,6 +56,7 @@ export interface RuntimeAgentStreamExecutionDeps {
     apiUrl?: string;
     authToken?: string;
     projectId?: string | null;
+    sandboxEndpoint?: string;
   };
   createBashTool?: AgentServiceSandboxToolsOptions["createBashTool"];
   createAgentServiceSandboxTools?: (
@@ -193,7 +198,9 @@ function getStringProperty(value: Record<string, unknown>, keys: string[]): stri
   return undefined;
 }
 
-function getAgentSandboxConfig(agent: Agent): { sandboxId?: string; projectId?: string } {
+function getAgentSandboxConfig(
+  agent: Agent,
+): { sandboxId?: string; sandboxEndpoint?: string; projectId?: string } {
   const config = agent.config as Agent["config"] & { sandbox?: unknown };
   if (!isRecord(config.sandbox)) {
     return {};
@@ -201,6 +208,7 @@ function getAgentSandboxConfig(agent: Agent): { sandboxId?: string; projectId?: 
 
   return {
     sandboxId: getStringProperty(config.sandbox, ["id", "sandboxId", "sessionId"]),
+    sandboxEndpoint: getStringProperty(config.sandbox, ["endpoint", "sandboxEndpoint"]),
     projectId: getStringProperty(config.sandbox, ["projectId"]),
   };
 }
@@ -232,6 +240,12 @@ async function buildProjectAgentSandboxTools(input: {
       : {}),
     ...(sandboxConfig.sandboxId
       ? { sandboxId: sandboxConfig.sandboxId, deleteOnClose: false }
+      : {}),
+    ...(sandboxConfig.sandboxEndpoint ?? input.deps.projectAgentSandbox?.sandboxEndpoint
+      ? {
+        sandboxEndpoint: sandboxConfig.sandboxEndpoint ??
+          input.deps.projectAgentSandbox?.sandboxEndpoint,
+      }
       : {}),
     getProjectId: () => sandboxConfig.projectId ?? input.deps.projectAgentSandbox?.projectId,
   });
@@ -391,6 +405,7 @@ export async function createRuntimeAgentStreamResponse(
     throw error;
   }
 
+  let stopHeartbeat: (() => void) | undefined;
   const response = new ReadableStream<Uint8Array>({
     start: async (controller) => {
       const state = createStreamTransformState();
@@ -398,6 +413,13 @@ export async function createRuntimeAgentStreamResponse(
       const decoder = new TextDecoder();
       let remainder = "";
       let aborted = false;
+      let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+      stopHeartbeat = () => {
+        if (heartbeatTimer) {
+          clearInterval(heartbeatTimer);
+          heartbeatTimer = undefined;
+        }
+      };
 
       const enqueueIfAttached = (event: string, payload: Record<string, unknown>) => {
         const encodedEvent = formatAgUiEvent(event, payload);
@@ -407,6 +429,17 @@ export async function createRuntimeAgentStreamResponse(
 
         try {
           controller.enqueue(encodedEvent);
+        } catch {
+          clientAttached = false;
+        }
+      };
+      const enqueueHeartbeatIfAttached = () => {
+        if (!clientAttached) {
+          return;
+        }
+
+        try {
+          controller.enqueue(INTERNAL_AGENT_RUNTIME_HEARTBEAT_FRAME);
         } catch {
           clientAttached = false;
         }
@@ -449,6 +482,10 @@ export async function createRuntimeAgentStreamResponse(
         threadId: input.threadId,
         agentId: agent.id,
       });
+      heartbeatTimer = setInterval(
+        enqueueHeartbeatIfAttached,
+        INTERNAL_AGENT_RUNTIME_HEARTBEAT_INTERVAL_MS,
+      );
 
       try {
         while (true) {
@@ -529,6 +566,8 @@ export async function createRuntimeAgentStreamResponse(
           });
         }
       } finally {
+        stopHeartbeat?.();
+        stopHeartbeat = undefined;
         abortSignal.removeEventListener("abort", abortHandler);
         if (clientAttached) {
           controller.close();
@@ -550,6 +589,8 @@ export async function createRuntimeAgentStreamResponse(
     },
     cancel() {
       clientAttached = false;
+      stopHeartbeat?.();
+      stopHeartbeat = undefined;
       logger.info("Internal agent runtime client detached", {
         runId: input.runId,
         threadId: input.threadId,

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -1135,10 +1135,14 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertExists(firstResult.response);
     assertEquals(firstResult.response.status, 200);
 
-    const secondResult = await handler.handle(request, createCtx(publicKeyPem));
-    assertExists(secondResult.response);
-    assertEquals(secondResult.response.status, 409);
-    assertEquals(await secondResult.response.json(), { error: 'Run "run_1" is already active' });
+    try {
+      const secondResult = await handler.handle(request, createCtx(publicKeyPem));
+      assertExists(secondResult.response);
+      assertEquals(secondResult.response.status, 409);
+      assertEquals(await secondResult.response.json(), { error: 'Run "run_1" is already active' });
+    } finally {
+      await firstResult.response.body?.cancel();
+    }
   });
 
   it("returns 500 when runtime execution setup fails unexpectedly", async () => {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.606";
+export const VERSION = "0.1.607";


### PR DESCRIPTION
## Summary
- send SSE comment heartbeats on internal project-agent runtime streams while long-running tools are quiet
- keep sandbox bash opt-in behavior, and pass optional sandboxEndpoint from agent config/deps alongside sandboxId
- add regression coverage for heartbeat emission, sandbox endpoint forwarding, and cleanup of open stream tests

## Verification
- deno fmt src/internal-agents/run-stream.ts src/internal-agents/run-stream.test.ts src/server/handlers/request/agent-stream.handler.test.ts
- deno test --no-check --allow-all src/internal-agents/run-stream.test.ts
- deno test --no-check --allow-all --trace-leaks --filter "agent-stream.handler" src/server/handlers/request/agent-stream.handler.test.ts
- deno task --quiet verify:quick
- pre-push hook: format, lint, typecheck, unit tests (1918 passed)

## Notes
Requires the paired API parser change so comment-only frames are ignored instead of persisted as custom events.

Known local dirt intentionally excluded from this PR: src/server/services/rsc/endpoints/rsc-bundles.generated.ts was already dirty and is unrelated to this fix.