### PR TITLE
Fix document upload extraction across Deno and Node builds

### DIFF
--- a/extensions/ext-document-kreuzberg/src/index.ts
+++ b/extensions/ext-document-kreuzberg/src/index.ts
@@ -10,6 +10,7 @@
 import type { ExtensionFactory } from "veryfront/extensions";
 import type { DocumentExtractor, KreuzbergExtractor } from "veryfront/extensions/compat";
 import { loadKreuzberg } from "./kreuzberg.ts";
+import { isDeno } from "./runtime.ts";
 
 /** Maximum time to wait for document text extraction before aborting. */
 const EXTRACTION_TIMEOUT_MS = 30_000;
@@ -19,9 +20,14 @@ function extractInWorkerDeno(
   mimeType: string,
 ): Promise<string> {
   return new Promise<string>((resolve, reject) => {
-    // Static URL literal so `deno compile` traces the worker script into
-    // the binary's embedded module graph.
-    const workerUrl = new URL("./upload-extraction-worker.ts", import.meta.url);
+    // The worker ships as raw TypeScript in the compiled binary and from source
+    // (where `compile-binary.ts` force-includes it), but as transpiled JS in the
+    // npm package consumed via `deno run npm:veryfront`. Pick the sibling that
+    // matches whichever build is executing this module.
+    const workerFile = import.meta.url.endsWith(".ts")
+      ? "./upload-extraction-worker.ts"
+      : "./upload-extraction-worker.js";
+    const workerUrl = new URL(workerFile, import.meta.url);
     const worker = new Worker(workerUrl, { type: "module" });
 
     const timer = setTimeout(() => {
@@ -62,7 +68,9 @@ export class KreuzbergDocumentExtractor implements DocumentExtractor {
   }
 
   async extractInWorker(buffer: ArrayBuffer, mimeType: string): Promise<string> {
-    const isDeno = typeof Deno !== "undefined";
+    // Only a real Deno runtime gets the isolated Worker; Node/Bun extract
+    // in-process via @kreuzberg/node. See ./runtime.ts for why a bare `Deno`
+    // check is unreliable in the dnt npm build.
     if (!isDeno) {
       const { extractBytes } = await loadKreuzberg();
       const result = await extractBytes(new Uint8Array(buffer), mimeType);

--- a/extensions/ext-document-kreuzberg/src/kreuzberg.ts
+++ b/extensions/ext-document-kreuzberg/src/kreuzberg.ts
@@ -10,6 +10,7 @@
  */
 
 import type { KreuzbergExtractor } from "veryfront/extensions/compat";
+import { isDeno } from "./runtime.ts";
 
 type KreuzbergModule = {
   initWasm?: () => Promise<void>;
@@ -33,8 +34,8 @@ async function loadKreuzbergNode(): Promise<any> {
 }
 
 export async function loadKreuzberg(): Promise<KreuzbergExtractor> {
-  const isDeno = typeof Deno !== "undefined";
-
+  // Node/Bun load the native @kreuzberg/node; only a real Deno runtime uses the
+  // WASM build. See ./runtime.ts for why a bare `Deno` check is unreliable here.
   if (!isDeno) {
     return loadKreuzbergNode();
   }

--- a/extensions/ext-document-kreuzberg/src/runtime.ts
+++ b/extensions/ext-document-kreuzberg/src/runtime.ts
@@ -1,0 +1,36 @@
+/**
+ * Runtime detection — inlined from src/platform/compat/runtime.ts so the
+ * extension stays dependency-free on core (mirrors ext-bundler-esbuild).
+ *
+ * The Node check is what makes this correct in the dnt npm build: dnt's
+ * `@deno/shim-deno` polyfill makes a bare `Deno` reference truthy on Node/Bun,
+ * but `hasNodeProcess()` short-circuits `isDeno` to false there regardless.
+ *
+ * @module extensions/ext-document-kreuzberg/runtime
+ */
+
+type GlobalWithRuntime = typeof globalThis & {
+  process?: { versions?: { node?: string; deno?: string } };
+  Bun?: unknown;
+};
+
+function hasRealDeno(): boolean {
+  return (
+    typeof Deno !== "undefined" &&
+    typeof Deno.version === "object" &&
+    typeof Deno.build === "object" &&
+    typeof Deno.build.os === "string"
+  );
+}
+
+function hasBunGlobal(): boolean {
+  return (globalThis as GlobalWithRuntime).Bun != null;
+}
+
+function hasNodeProcess(): boolean {
+  const g = globalThis as GlobalWithRuntime;
+  return g.process?.versions?.node != null && !g.process?.versions?.deno;
+}
+
+/** True only in a real Deno runtime — not the dnt shim on Node/Bun. */
+export const isDeno: boolean = !hasNodeProcess() && !hasBunGlobal() && hasRealDeno();

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -206,6 +206,31 @@ await build({
 		}
 		console.log(`📝 Copied ${rscClientFiles.length} RSC client files`);
 
+		// Transpile the kreuzberg upload-extraction worker into the npm package.
+		// It is spawned via `new Worker(new URL("./upload-extraction-worker.js"))`
+		// (see extensions/ext-document-kreuzberg/src/index.ts), so dnt never traces
+		// it as a static import and would otherwise omit it from the build. Strip
+		// the TypeScript types and rewrite the sibling `./kreuzberg.ts` import to the
+		// transpiled `./kreuzberg.js` that dnt emits next to it.
+		const esbuild = await import("npm:esbuild@0.27.4");
+		try {
+			const workerSrc = "./extensions/ext-document-kreuzberg/src/upload-extraction-worker.ts";
+			const workerDest =
+				"./npm/esm/extensions/ext-document-kreuzberg/src/upload-extraction-worker.js";
+			const transpiled = await esbuild.transform(await Deno.readTextFile(workerSrc), {
+				loader: "ts",
+				format: "esm",
+				target: "esnext",
+			});
+			await Deno.writeTextFile(
+				workerDest,
+				transpiled.code.replaceAll("./kreuzberg.ts", "./kreuzberg.js"),
+			);
+			console.log("📝 Transpiled ext-document-kreuzberg upload-extraction worker");
+		} finally {
+			await esbuild.stop();
+		}
+
 		// Fix dnt polyfill bug: process.argv[1] can be undefined in dynamic imports
 		patchFile(
 			"./npm/esm/_dnt.polyfills.js",

--- a/scripts/build/compile-binary.ts
+++ b/scripts/build/compile-binary.ts
@@ -12,6 +12,8 @@ const DEFAULT_INCLUDES = [
   "src/platform/polyfills",
   "src/proxy/main.ts",
   "src/security/sandbox/worker-script.ts",
+  // Spawned via `new Worker(new URL(...))`, which deno compile does not trace.
+  "extensions/ext-document-kreuzberg/src/upload-extraction-worker.ts",
   "src/rendering/rsc",
   "src/utils/clsx.ts",
   "dist/framework-src",


### PR DESCRIPTION
## Summary

Uploading a document (the `ext-document-kreuzberg` `DocumentExtractor`) failed on **every** runtime channel. This fixes all three.

| Channel | Bug | Fix |
|---|---|---|
| **Node/Bun** (npm) | `typeof Deno !== "undefined"` is rewritten by dnt to the `@deno/shim-deno` proxy (always truthy), so extraction took the Deno-only Worker path and threw `Worker is not defined` | `index.ts`/`kreuzberg.ts` now use an inlined `runtime.ts` check (mirroring `ext-bundler-esbuild`) whose `process.versions` test stays correct under the shim → Node/Bun extract in-process via `@kreuzberg/node` |
| **Compiled binary** (`deno compile`) | worker is spawned via `new Worker(new URL(...))`, which the module-graph tracer doesn't follow, so it was never embedded → `Module not found …upload-extraction-worker.ts` | added it to the `--include` list in `compile-binary.ts` |
| **`deno run npm:veryfront`** | dnt only emits statically-imported modules, so the worker was missing from `npm/esm` | `build-npm-dnt.ts` transpiles it to `upload-extraction-worker.js` (rewriting the `./kreuzberg` import to `.js`); the worker URL now resolves `.ts` (binary/source) or `.js` (npm) from `import.meta.url` |

### Files
- `extensions/ext-document-kreuzberg/src/runtime.ts` (new) — inlined runtime detection
- `extensions/ext-document-kreuzberg/src/index.ts` — use shared `isDeno`; runtime-aware worker URL
- `extensions/ext-document-kreuzberg/src/kreuzberg.ts` — use shared `isDeno`
- `scripts/build/compile-binary.ts` — embed worker in the binary
- `scripts/build/build-npm-dnt.ts` — emit transpiled worker into the npm package

## Root cause

Both detection sites root-cause to dnt's `@deno/shim-deno` proxy reporting a fake `Deno` (with `version.deno`) on Node. A bare `typeof Deno` — even `globalThis["Deno"]` — is rewritten to that proxy. The `process.versions`-based check (already used by `src/platform/compat/runtime.ts`) is the project's proven escape hatch.

## Test plan

- [x] `deno test extensions/ext-document-kreuzberg/src/index.test.ts` passes
- [x] `deno lint` clean on changed files
- [x] `deno task build:npm` succeeds; `npm/esm` now contains `runtime.js` + `upload-extraction-worker.js`; built `isDeno` is `false` on Node
- [x] End-to-end: real `.docx` upload → kreuzberg extraction → RAG index → agent review works under Node and the rebuilt npm package
- [ ] CI green
- [ ] Verify compiled-binary path on a `deno compile` build
- [ ] Confirm `@kreuzberg/wasm` availability for the `deno run npm:veryfront` Worker path (optional dep, orthogonal to this change)