### PR TITLE
Bump version to 0.1.608

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.607",
+  "version": "0.1.608",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.607";
+export const VERSION = "0.1.608";


### PR DESCRIPTION
Release the kreuzberg document-extraction fix (#1920) as a new package version.

Bumps `deno.json` and `src/utils/version-constant.ts` from `0.1.607` to `0.1.608` so the main release pipeline publishes an artifact containing the upload-extraction fix.

## Test plan
- [x] `deno fmt --check deno.json src/utils/version-constant.ts`
- [x] `deno test --allow-all src/utils/version.test.ts`
- [ ] CI green