### PR TITLE
Preserve provider tool results through project-agent replays

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.608",
+  "version": "0.1.609",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/index.test.ts
+++ b/src/agent/runtime/index.test.ts
@@ -8,6 +8,7 @@ import {
   collectPersistedToolResults,
   isStreamedToolCallIncomplete,
   materializeStreamedToolCall,
+  shouldContinueAfterStreamStep,
 } from "./index.ts";
 import type { ChatStreamState } from "./chat-stream-handler.ts";
 import type { Message } from "../types.ts";
@@ -19,6 +20,120 @@ function createState(
 }
 
 describe("agent runtime streamed tool result collection", () => {
+  it("continues after provider-executed tool results arrive without assistant text", () => {
+    const shouldContinue = shouldContinueAfterStreamStep({
+      accumulatedText: "",
+      finishReason: "stop",
+      toolCalls: new Map([
+        [
+          "toolu_provider_1",
+          {
+            id: "toolu_provider_1",
+            name: "gmail__get_email",
+            arguments: '{"messageId":"missing-message"}',
+            inputAvailable: true,
+            providerExecuted: true,
+            dynamic: true,
+          },
+        ],
+      ]),
+      toolResults: [
+        {
+          toolCallId: "toolu_provider_1",
+          toolName: "gmail__get_email",
+          output: { error: "tool_error", message: "Requested entity was not found." },
+          providerExecuted: true,
+          dynamic: true,
+        },
+      ],
+    });
+
+    assertEquals(shouldContinue, true);
+  });
+
+  it("stops after provider-executed tool results when the assistant already answered", () => {
+    const shouldContinue = shouldContinueAfterStreamStep({
+      accumulatedText: "I found two likely junk messages.",
+      finishReason: "stop",
+      toolCalls: new Map([
+        [
+          "toolu_provider_2",
+          {
+            id: "toolu_provider_2",
+            name: "gmail__list_emails",
+            arguments: '{"labelIds":["INBOX"]}',
+            inputAvailable: true,
+            providerExecuted: true,
+            dynamic: true,
+          },
+        ],
+      ]),
+      toolResults: [
+        {
+          toolCallId: "toolu_provider_2",
+          toolName: "gmail__list_emails",
+          output: { data: [] },
+          providerExecuted: true,
+          dynamic: true,
+        },
+      ],
+    });
+
+    assertEquals(shouldContinue, false);
+  });
+
+  it("stops after provider-executed tool errors when the stream finished with error", () => {
+    const shouldContinue = shouldContinueAfterStreamStep({
+      accumulatedText: "",
+      finishReason: "error",
+      toolCalls: new Map([
+        [
+          "toolu_provider_error",
+          {
+            id: "toolu_provider_error",
+            name: "web_search",
+            arguments: '{"query":"Veryfront"}',
+            inputAvailable: true,
+            providerExecuted: true,
+            dynamic: true,
+          },
+        ],
+      ]),
+      toolResults: [
+        {
+          toolCallId: "toolu_provider_error",
+          toolName: "web_search",
+          error: "Provider timeout",
+          providerExecuted: true,
+          dynamic: true,
+        },
+      ],
+    });
+
+    assertEquals(shouldContinue, false);
+  });
+
+  it("continues normal client-executed tool-call steps", () => {
+    const shouldContinue = shouldContinueAfterStreamStep({
+      accumulatedText: "",
+      finishReason: "tool-calls",
+      toolCalls: new Map([
+        [
+          "toolu_client_1",
+          {
+            id: "toolu_client_1",
+            name: "read_file",
+            arguments: '{"path":"app/page.tsx"}',
+            inputAvailable: true,
+          },
+        ],
+      ]),
+      toolResults: [],
+    });
+
+    assertEquals(shouldContinue, true);
+  });
+
   it("ignores preliminary streamed tool results when a final result exists", () => {
     const finalToolResults = collectFinalStreamToolResults(
       createState([

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -241,6 +241,44 @@ export function collectGeneratedToolResults(
   return generatedToolResults;
 }
 
+export function shouldContinueAfterStreamStep(
+  state: Pick<ChatStreamState, "accumulatedText" | "finishReason" | "toolCalls" | "toolResults">,
+): boolean {
+  if (!state.toolCalls.size) {
+    return false;
+  }
+
+  if (state.finishReason === "tool-calls") {
+    return true;
+  }
+
+  if (state.finishReason !== "stop") {
+    return false;
+  }
+
+  if (state.accumulatedText.trim().length > 0) {
+    return false;
+  }
+
+  const finalToolResults = collectFinalStreamToolResults(state);
+  if (!finalToolResults.size) {
+    return false;
+  }
+
+  for (const [toolCallId, toolCall] of state.toolCalls) {
+    const toolResult = finalToolResults.get(toolCallId);
+    if (!toolResult) {
+      return false;
+    }
+
+    if (toolCall.providerExecuted !== true && toolResult.providerExecuted !== true) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 export function captureStreamedToolCallInput(
   toolCall: Pick<StreamingToolCall, "arguments">,
 ): {
@@ -1194,7 +1232,7 @@ export class AgentRuntime {
         );
       };
 
-      if (state.finishReason !== "tool-calls" || !state.toolCalls.size) {
+      if (!shouldContinueAfterStreamStep(state)) {
         for (const toolResult of finalToolResults.values()) {
           await persistToolResult(toolResult);
         }

--- a/src/agent/runtime/message-adapter.test.ts
+++ b/src/agent/runtime/message-adapter.test.ts
@@ -289,6 +289,46 @@ describe("agent runtime message adapter", () => {
     ]);
   });
 
+  it("preserves stored snake_case tool-call and tool-result parts when replaying agent runtime messages", () => {
+    const providerMessages = convertAgentRuntimeMessagesToProviderMessages([
+      {
+        role: "assistant",
+        parts: [
+          {
+            type: "tool_call",
+            id: TOOL_CALL_ID,
+            name: TOOL_NAME,
+            input: { query: "rollout" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        parts: [
+          {
+            type: "tool_result",
+            tool_call_id: TOOL_CALL_ID,
+            tool_name: TOOL_NAME,
+            output: { matches: 2 },
+          },
+        ],
+      },
+    ]);
+
+    assertEquals(providerMessages, [
+      {
+        role: "assistant",
+        content: [providerToolCallPart({ query: "rollout" })],
+      },
+      {
+        role: "tool",
+        content: [
+          providerToolResultPart(jsonOutput({ matches: 2 })),
+        ],
+      },
+    ]);
+  });
+
   it("converts native image AgentRuntimeMessage part back to structured user content", () => {
     const providerMessages = convertAgentRuntimeMessagesToProviderMessages([
       agentRuntimeMessage(

--- a/src/agent/runtime/message-adapter.ts
+++ b/src/agent/runtime/message-adapter.ts
@@ -28,6 +28,17 @@ type AgentRuntimeMessageLikePart =
     input: Record<string, unknown>;
   }
   | {
+    type: "tool_call";
+    id?: string;
+    name?: string;
+    tool_call_id?: string;
+    tool_name?: string;
+    toolCallId?: string;
+    toolName?: string;
+    input?: Record<string, unknown>;
+    args?: Record<string, unknown>;
+  }
+  | {
     type: "tool-result";
     toolCallId: string;
     toolName: string;
@@ -38,6 +49,15 @@ type AgentRuntimeMessageLikePart =
     toolCallId: string;
     toolName: string;
     output: unknown;
+  }
+  | {
+    type: "tool_result";
+    tool_call_id?: string;
+    tool_name?: string;
+    toolCallId?: string;
+    toolName?: string;
+    result?: unknown;
+    output?: unknown;
   }
   | { type: "image"; url: string; mediaType: string }
   | { type: "file"; url: string; mediaType: string };
@@ -289,12 +309,17 @@ export function getAgentRuntimeToolCallPart(
     return null;
   }
 
-  if (part.type !== "tool-call" && !part.type.startsWith("tool-")) {
+  if (part.type !== "tool_call" && part.type !== "tool-call" && !part.type.startsWith("tool-")) {
     return null;
   }
 
-  const toolCallId = getOptionalStringField(part, "toolCallId");
-  const toolName = getOptionalStringField(part, "toolName") ?? part.type.replace(/^tool-/, "");
+  const toolCallId = getOptionalStringField(part, "toolCallId") ??
+    getOptionalStringField(part, "tool_call_id") ??
+    getOptionalStringField(part, "id");
+  const toolName = getOptionalStringField(part, "toolName") ??
+    getOptionalStringField(part, "tool_name") ??
+    getOptionalStringField(part, "name") ??
+    part.type.replace(/^tool-/, "");
   if (!toolCallId || toolName.length === 0) {
     return null;
   }
@@ -310,12 +335,14 @@ export function getAgentRuntimeToolCallPart(
 export function getAgentRuntimeToolResultPart(
   part: unknown,
 ): { toolCallId: string; toolName: string; output: unknown } | null {
-  if (!isRecord(part) || part.type !== "tool-result") {
+  if (!isRecord(part) || part.type !== "tool-result" && part.type !== "tool_result") {
     return null;
   }
 
-  const toolCallId = getOptionalStringField(part, "toolCallId");
-  const toolName = getOptionalStringField(part, "toolName");
+  const toolCallId = getOptionalStringField(part, "toolCallId") ??
+    getOptionalStringField(part, "tool_call_id");
+  const toolName = getOptionalStringField(part, "toolName") ??
+    getOptionalStringField(part, "tool_name");
   if (!toolCallId || !toolName) {
     return null;
   }
@@ -323,7 +350,11 @@ export function getAgentRuntimeToolResultPart(
   return {
     toolCallId,
     toolName,
-    output: Object.hasOwn(part, "result") ? part.result : null,
+    output: Object.hasOwn(part, "result")
+      ? part.result
+      : Object.hasOwn(part, "output")
+      ? part.output
+      : null,
   };
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.608";
+export const VERSION = "0.1.609";


### PR DESCRIPTION
## Summary
- Continue agent runtime loops when provider-executed tool results arrive as the final stream step with no assistant text yet.
- Preserve persisted snake_case tool_call/tool_result parts when replaying project-agent history to providers.
- Bump veryfront release metadata from 0.1.608 to 0.1.609.

## Verification
- deno test --no-check --allow-all src/agent/runtime/index.test.ts src/agent/runtime/message-adapter.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts src/agent/runtime/index.ts src/agent/runtime/index.test.ts src/agent/runtime/message-adapter.ts src/agent/runtime/message-adapter.test.ts
- deno lint src/agent/runtime/index.ts src/agent/runtime/index.test.ts src/agent/runtime/message-adapter.ts src/agent/runtime/message-adapter.test.ts
- deno check src/agent/runtime/index.ts src/agent/runtime/index.test.ts src/agent/runtime/message-adapter.ts src/agent/runtime/message-adapter.test.ts
- pre-push hook: fmt, lint, typecheck, generate, full unit suite: 1920 passed / 17688 steps / 0 failed