### PR TITLE
Guard starter templates across init modes

### DIFF
--- a/cli/commands/init/init.integration.test.ts
+++ b/cli/commands/init/init.integration.test.ts
@@ -14,8 +14,19 @@ import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { exists, makeTempDir, readTextFile, remove, stat } from "#veryfront/testing/deno-compat.ts";
 import { runCommand } from "#veryfront/compat/process.ts";
+import type { TemplateName } from "../../templates/types.ts";
 
 const TEST_DIR = await makeTempDir({ prefix: "veryfront-init-test-" });
+
+const STARTER_TEMPLATES: TemplateName[] = [
+  "minimal",
+  "ai-agent",
+  "docs-agent",
+  "agentic-workflow",
+  "multi-agent-system",
+  "coding-agent",
+  "saas-starter",
+];
 
 function randomSuffix(): string {
   return Math.random().toString(36).substring(2, 8);
@@ -242,6 +253,90 @@ describe("init command integration", () => {
       assertEquals(result.code, 0);
       assertEquals(await exists(join(projectDir, "package.json")), false);
       assertEquals(await exists(join(projectDir, "app", "page.tsx")), true);
+    });
+
+    it("does not write package.json in quiet mode for any starter template", async () => {
+      for (const template of STARTER_TEMPLATES) {
+        const name = `quiet-${template}-${randomSuffix()}`;
+        const dir = join(TEST_DIR, name);
+
+        try {
+          const result = await runQuietInitCommand({
+            name,
+            template,
+            skipInstall: true,
+            skipEnvPrompt: true,
+            quiet: true,
+          });
+          const output = (result.stdout ?? "") + (result.stderr ?? "");
+
+          assertEquals(result.code, 0, `${template} quiet init failed: ${output}`);
+          assertEquals(
+            await exists(join(dir, "package.json")),
+            false,
+            `${template} quiet init must not leave a package.json`,
+          );
+          assertEquals(
+            await exists(join(dir, "app")),
+            true,
+            `${template} quiet init should scaffold app files`,
+          );
+        } finally {
+          await remove(dir, { recursive: true }).catch(() => {});
+        }
+      }
+    });
+
+    it("generates complete package metadata for every starter template and runtime", async () => {
+      const runtimes = ["node", "bun", "deno"] as const;
+
+      for (const template of STARTER_TEMPLATES) {
+        for (const runtime of runtimes) {
+          const name = `pkg-${runtime}-${template}-${randomSuffix()}`;
+          const dir = join(TEST_DIR, name);
+
+          try {
+            const result = await runInitCommand([
+              name,
+              "-t",
+              template,
+              "--runtime",
+              runtime,
+              "--skip-install",
+              "--skip-env-prompt",
+            ]);
+            const output = (result.stdout ?? "") + (result.stderr ?? "");
+
+            assertEquals(
+              result.code,
+              0,
+              `${template} ${runtime} init failed: ${output}`,
+            );
+
+            const pkg = JSON.parse(await readTextFile(join(dir, "package.json")));
+            assertEquals(pkg.scripts.dev, "veryfront dev");
+            assertEquals(pkg.scripts.build, "veryfront build");
+            assertEquals(pkg.scripts.preview, "veryfront preview");
+            assertExists(pkg.dependencies.veryfront);
+            assertExists(pkg.dependencies.react);
+            assertExists(pkg.dependencies["react-dom"]);
+            assertEquals(pkg.dependencies.zod, "^3.24.0");
+
+            if (template === "docs-agent") {
+              assertEquals(pkg.dependencies["@kreuzberg/node"], "^4.4.2");
+              assertEquals(pkg.dependencies["@kreuzberg/wasm"], "4.5.2");
+            }
+
+            assertEquals(
+              await exists(join(dir, "deno.json")),
+              runtime === "deno",
+              `${template} ${runtime} should only write deno.json for deno runtime`,
+            );
+          } finally {
+            await remove(dir, { recursive: true }).catch(() => {});
+          }
+        }
+      }
     });
   });
 

--- a/cli/templates/index.test.ts
+++ b/cli/templates/index.test.ts
@@ -2,7 +2,18 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 
+import { getTemplate, templateConfigs } from "./index.ts";
 import type { TemplateName } from "./types.ts";
+
+const STARTER_TEMPLATES: TemplateName[] = [
+  "ai-agent",
+  "docs-agent",
+  "multi-agent-system",
+  "agentic-workflow",
+  "coding-agent",
+  "saas-starter",
+  "minimal",
+];
 
 const STYLED_STARTER_TEMPLATES: TemplateName[] = [
   "ai-agent",
@@ -30,6 +41,29 @@ async function collectTemplateTsFiles(dir: URL): Promise<URL[]> {
 }
 
 describe("cli/templates", () => {
+  it("keeps starter npm dependencies out of root package template files", async () => {
+    const offenders: string[] = [];
+
+    for (const templateName of STARTER_TEMPLATES) {
+      const files = await getTemplate(templateName);
+      assertExists(files, `${templateName} should load from the template registry`);
+
+      if (files.some((file) => file.path === "package.json")) {
+        offenders.push(templateName);
+      }
+    }
+
+    assertEquals(
+      offenders,
+      [],
+      `Starter templates must use template config for npm dependencies, not root package.json files. Offenders: ${
+        offenders.join(", ")
+      }`,
+    );
+    assertEquals(templateConfigs["docs-agent"]?.npmDependencies?.["@kreuzberg/node"], "^4.4.2");
+    assertEquals(templateConfigs["docs-agent"]?.npmDependencies?.["@kreuzberg/wasm"], "4.5.2");
+  });
+
   it("ships a Tailwind entry stylesheet for styled starter templates", async () => {
     for (const templateName of STYLED_STARTER_TEMPLATES) {
       const globalsPath = new URL(`./files/${templateName}/globals.css`, import.meta.url);

--- a/tests/integration/templates/starter-templates-smoke.test.ts
+++ b/tests/integration/templates/starter-templates-smoke.test.ts
@@ -50,6 +50,18 @@ describe("starter templates smoke", {
           200,
           `${templateName} should render / successfully`,
         );
+
+        const html = await response.text();
+        assertEquals(
+          html.includes("Module not found"),
+          false,
+          `${templateName} should not render a module resolution error`,
+        );
+        assertEquals(
+          html.includes("Internal Server Error"),
+          false,
+          `${templateName} should not render a server error`,
+        );
       });
     });
   }


### PR DESCRIPTION
## Summary
- add template registry coverage that forbids root package.json files in starter templates and keeps docs-agent npm dependencies in template config
- add quiet-init coverage for every starter template so TUI/quiet scaffolds cannot leave partial package files
- add node, bun, and deno runtime package metadata coverage for every starter template
- strengthen starter-template dev-server smoke coverage to reject rendered module-resolution and server-error output

## Verification
- deno test --no-check --allow-all cli/templates/index.test.ts cli/commands/init/init.integration.test.ts tests/integration/templates/starter-templates-smoke.test.ts
- deno fmt --check cli/templates/index.test.ts cli/commands/init/init.integration.test.ts tests/integration/templates/starter-templates-smoke.test.ts
- git diff --check
- pre-push hook on this diff family ran format, lint, typecheck, and unit tests: 1920 passed, 0 failed

Stacked on #1923 because docs-agent template npm dependency config is introduced there.