### PR TITLE
Preserve email summaries in historical tool context

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.610",
+  "version": "0.1.611",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/chat/message-prep.test.ts
+++ b/src/chat/message-prep.test.ts
@@ -109,6 +109,85 @@ Deno.test("maskOldToolOutputs masks large historical tool outputs and removes st
   assertEquals(masked[3], messages[3]);
 });
 
+Deno.test("maskOldToolOutputs keeps compact email metadata for historical email list results", () => {
+  const messages = [
+    { role: "user", content: "check my inbox" },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "call-email-list",
+          toolName: "gmail__list_emails",
+          input: { labelIds: ["INBOX"], maxResults: 30 },
+        },
+      ],
+    },
+    {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "call-email-list",
+          toolName: "gmail__list_emails",
+          output: {
+            type: "json",
+            value: {
+              messages: [
+                {
+                  id: "msg-1",
+                  threadId: "thread-1",
+                  from: "Sender <sender@example.com>",
+                  to: "koji@example.com",
+                  subject: "Suspicious offer",
+                  date: "Thu, 28 May 2026 10:00:00 +0000",
+                  snippet: "This is enough to identify the email.",
+                  labelIds: ["INBOX"],
+                  body: "large message body ".repeat(100),
+                  payload: { headers: Array.from({ length: 40 }, (_, index) => ({ index })) },
+                },
+              ],
+              nextPageToken: "next-page",
+              resultSizeEstimate: 201,
+              debug: "internal detail ".repeat(100),
+            },
+          },
+        },
+      ],
+    },
+    { role: "user", content: "archive the suspicious one" },
+  ] satisfies ProviderModelMessage[];
+
+  const masked = maskOldToolOutputs(messages);
+  const toolMessage = masked[2];
+  if (toolMessage?.role !== "tool") {
+    throw new Error("expected tool message");
+  }
+  const output = toolMessage.content[0]?.output;
+  if (output?.type !== "text") {
+    throw new Error("expected compacted text output");
+  }
+  const compacted = JSON.parse(output.value);
+
+  assertEquals(compacted.messages, [
+    {
+      id: "msg-1",
+      threadId: "thread-1",
+      from: "Sender <sender@example.com>",
+      to: "koji@example.com",
+      subject: "Suspicious offer",
+      date: "Thu, 28 May 2026 10:00:00 +0000",
+      snippet: "This is enough to identify the email.",
+      labelIds: ["INBOX"],
+    },
+  ]);
+  assertEquals(compacted.nextPageToken, "next-page");
+  assertEquals(compacted.resultSizeEstimate, 201);
+  assertEquals(compacted.messages[0].body, undefined);
+  assertEquals(compacted.messages[0].payload, undefined);
+  assertEquals(compacted.debug, undefined);
+});
+
 Deno.test("enforceTokenBudget compresses the oldest turn before dropping later turns", () => {
   const messages = [
     { role: "user" as const, content: "old request ".repeat(100) },

--- a/src/chat/message-prep.ts
+++ b/src/chat/message-prep.ts
@@ -572,6 +572,98 @@ function maskGeneric(toolName: string, charCount: number): string {
   return `[${toolName} output omitted (${charCount} chars)]`;
 }
 
+const EMAIL_SUMMARY_TOOL_RE = /(?:^|__)(?:list_emails|search_emails)$/;
+const EMAIL_SUMMARY_FIELDS = [
+  "id",
+  "threadId",
+  "from",
+  "sender",
+  "to",
+  "subject",
+  "date",
+  "receivedDateTime",
+  "snippet",
+  "labelIds",
+  "isUnread",
+  "unread",
+] as const;
+
+function isEmailSummaryTool(toolName: string): boolean {
+  return EMAIL_SUMMARY_TOOL_RE.test(toolName);
+}
+
+function compactEmailContactValue(value: Record<string, unknown>): Record<string, unknown> | null {
+  const compact: Record<string, unknown> = {};
+  const emailAddress = value.emailAddress;
+
+  if (isRecord(emailAddress)) {
+    if (typeof emailAddress.name === "string") compact.name = emailAddress.name;
+    if (typeof emailAddress.address === "string") compact.address = emailAddress.address;
+  }
+
+  for (const field of ["name", "address", "email"] as const) {
+    if (typeof value[field] === "string") compact[field] = value[field];
+  }
+
+  return Object.keys(compact).length > 0 ? compact : null;
+}
+
+function compactEmailMessageValue(value: unknown): Record<string, unknown> | null {
+  if (!isRecord(value)) return null;
+
+  const compact: Record<string, unknown> = {};
+  for (const field of EMAIL_SUMMARY_FIELDS) {
+    const fieldValue = value[field];
+    if (typeof fieldValue === "string") {
+      compact[field] = field === "snippet" ? truncate(fieldValue, 300) : fieldValue;
+    } else if (typeof fieldValue === "boolean" || typeof fieldValue === "number") {
+      compact[field] = fieldValue;
+    } else if (Array.isArray(fieldValue)) {
+      compact[field] = fieldValue.filter((item) => typeof item === "string");
+    } else if (isRecord(fieldValue) && (field === "from" || field === "sender")) {
+      const contact = compactEmailContactValue(fieldValue);
+      if (contact) compact[field] = contact;
+    }
+  }
+
+  return Object.keys(compact).length > 0 ? compact : null;
+}
+
+function compactEmailSummaryOutput(rawValue: unknown): Record<string, unknown> | null {
+  const parsed = tryParseJson(rawValue);
+  const output = isRecord(parsed) ? parsed : null;
+  const sourceMessages = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(output?.messages)
+    ? output.messages
+    : Array.isArray(output?.value)
+    ? output.value
+    : null;
+
+  if (!sourceMessages) return null;
+
+  const messages = sourceMessages
+    .map((message) => compactEmailMessageValue(message))
+    .filter((message): message is Record<string, unknown> => message !== null);
+
+  if (messages.length === 0) return null;
+
+  const compacted: Record<string, unknown> = {
+    messageCount: messages.length,
+    messages,
+    omitted: "large email bodies and provider-specific payload fields",
+  };
+
+  if (output && "nextPageToken" in output) {
+    compacted.nextPageToken = output.nextPageToken;
+  }
+  if (output && "resultSizeEstimate" in output) {
+    compacted.resultSizeEstimate = output.resultSizeEstimate;
+  }
+
+  return compacted;
+}
+
 function getOutputValue(output: unknown): unknown {
   if (!isRecord(output)) return output;
   if ((output.type === "text" || output.type === "json") && "value" in output) {
@@ -638,26 +730,30 @@ export function maskOldToolOutputs(messages: ProviderModelMessage[]): ProviderMo
 
       let masked: unknown;
 
-      switch (toolName) {
-        case "readFile":
-        case "get_file":
-          masked = maskReadFile(input, charCount);
-          break;
-        case "bash":
-          masked = maskBash(input, rawValue, charCount);
-          break;
-        case "web_search":
-          masked = maskWebSearch(rawValue);
-          break;
-        case "web_fetch":
-          masked = maskWebFetch(input, charCount);
-          break;
-        case "task":
-          masked = maskTask(rawValue, charCount);
-          break;
-        default:
-          masked = maskGeneric(toolName, charCount);
-          break;
+      if (isEmailSummaryTool(toolName)) {
+        masked = compactEmailSummaryOutput(rawValue) ?? maskGeneric(toolName, charCount);
+      } else {
+        switch (toolName) {
+          case "readFile":
+          case "get_file":
+            masked = maskReadFile(input, charCount);
+            break;
+          case "bash":
+            masked = maskBash(input, rawValue, charCount);
+            break;
+          case "web_search":
+            masked = maskWebSearch(rawValue);
+            break;
+          case "web_fetch":
+            masked = maskWebFetch(input, charCount);
+            break;
+          case "task":
+            masked = maskTask(rawValue, charCount);
+            break;
+          default:
+            masked = maskGeneric(toolName, charCount);
+            break;
+        }
       }
 
       return { ...part, output: wrapToolResultOutput(part.output, masked) };

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.610";
+export const VERSION = "0.1.611";


### PR DESCRIPTION
## Summary
- Preserve compact email list/search metadata when historical tool outputs are masked before a follow-up user turn
- Keep message IDs, thread IDs, sender/recipient, subject, date, snippets, labels, and pagination metadata while omitting large bodies and provider payloads
- Bump Veryfront package version to 0.1.611

## Why
Follow-up agent runs could not act on previously listed Gmail messages because large historical `gmail__list_emails` results were replaced with a generic omitted-output marker before model invocation. The API persisted the tool output, but the runtime context prep removed the action-critical message IDs.

## Verification
- `deno fmt src/chat/message-prep.ts src/chat/message-prep.test.ts`
- `deno lint src/chat/message-prep.ts src/chat/message-prep.test.ts`
- `deno check src/chat/message-prep.ts`
- `deno test --no-check --allow-all --parallel src/chat/message-prep.test.ts src/chat/conversation.test.ts src/agent/runtime/index.test.ts`
- pre-push hook: formatting, lint, type-check, generated manifests, and unit suite: 1921 passed, 0 failed