### PR TITLE
Use canonical environment variable API path

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.612",
+  "version": "0.1.613",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -729,7 +729,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
         );
       }
 
-      if (String(url).includes("/projects/support-agent-fork/env-vars?")) {
+      if (String(url).includes("/projects/support-agent-fork/environment-variables?")) {
         assertEquals(String(url).includes("environment_id=env-production"), true);
         return Promise.resolve(
           new Response(
@@ -809,7 +809,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(capturedRemoteToolNames, ["search_knowledge"]);
     assertEquals(fetchUrls, [
       "https://api.veryfront.org/projects/support-agent-fork/environments",
-      "https://api.veryfront.org/projects/support-agent-fork/env-vars?environment_id=env-production&limit=100",
+      "https://api.veryfront.org/projects/support-agent-fork/environment-variables?environment_id=env-production&limit=100",
       "https://api.veryfront.org/mcp",
     ]);
   });

--- a/src/server/project-env/fetcher.test.ts
+++ b/src/server/project-env/fetcher.test.ts
@@ -9,7 +9,7 @@ describe("project-env/fetcher", () => {
     const { server, port } = createMockServer((req: Request) => {
       const url = new URL(req.url);
 
-      assertEquals(url.pathname, "/projects/my-project/env-vars");
+      assertEquals(url.pathname, "/projects/my-project/environment-variables");
       assertEquals(url.searchParams.get("environment_id"), "env-123");
       assertEquals(url.searchParams.get("limit"), "100");
       assertEquals(req.headers.get("authorization"), "Bearer test-token");

--- a/src/server/project-env/fetcher.ts
+++ b/src/server/project-env/fetcher.ts
@@ -17,7 +17,7 @@ const ENV_VARS_FETCH_LIMIT = 100;
 /**
  * Fetch environment variables for a project from the Veryfront API.
  *
- * Calls: GET {apiBaseUrl}/projects/{projectSlug}/env-vars?environment_id={environmentId}&limit=100
+ * Calls: GET {apiBaseUrl}/projects/{projectSlug}/environment-variables?environment_id={environmentId}&limit=100
  * Response: { data: [{ key: string, value: string }] }
  */
 export async function fetchProjectEnvVars(
@@ -26,7 +26,9 @@ export async function fetchProjectEnvVars(
   environmentId: string,
   token: string,
 ): Promise<Record<string, string>> {
-  const url = `${apiBaseUrl}/projects/${encodeURIComponent(projectSlug)}/env-vars?environment_id=${
+  const url = `${apiBaseUrl}/projects/${
+    encodeURIComponent(projectSlug)
+  }/environment-variables?environment_id=${
     encodeURIComponent(environmentId)
   }&limit=${ENV_VARS_FETCH_LIMIT}`;
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.612";
+export const VERSION = "0.1.613";

--- a/tests/_examples/integration-server.example.ts
+++ b/tests/_examples/integration-server.example.ts
@@ -102,7 +102,7 @@ describe("Example Integration Test - Environment Variables", () => {
     "should use custom environment variables",
     { timeout: TEST_TIMEOUTS.INTEGRATION },
     async () => {
-      await withTestContext("env-vars-example", async (context) => {
+      await withTestContext("environment-variables-example", async (context) => {
         context.setEnv({
           TEST_MODE: "enabled",
           API_KEY: "test-key-123",


### PR DESCRIPTION
## Summary
- switch runtime environment-variable fetches to `/environment-variables`
- update tests and examples away from `/env-vars`
- bump package version to 0.1.613 for release

## Verification
- deno task typecheck
- deno task lint
- deno fmt --check
- targeted Deno tests
- pre-push full Deno unit suite
- git diff --check