### PR TITLE
Forward parsed tool input to execute (H13)

### DIFF
--- a/src/tool/factory.test.ts
+++ b/src/tool/factory.test.ts
@@ -204,6 +204,30 @@ describe("tool factory", () => {
       const result = await t.execute({ x: 5 });
       assertEquals(result, 10);
     });
+
+    it("should forward parsed defaults and transforms to execute", async () => {
+      let received: unknown;
+      const t = tool({
+        id: "parsed-forward",
+        description: "desc",
+        inputSchema: defineSchema((v) =>
+          v.object({
+            limit: v.number().default(10),
+            tag: v.string().transform((s) => `tag:${s}`),
+          })
+        )(),
+        execute: (input) => {
+          received = input;
+          return input;
+        },
+      });
+      const result = await t.execute({ tag: "foo" } as unknown as {
+        limit: number;
+        tag: string;
+      });
+      assertEquals(received, { limit: 10, tag: "tag:foo" });
+      assertEquals(result, { limit: 10, tag: "tag:foo" });
+    });
   });
 
   describe("dynamicTool()", () => {
@@ -298,6 +322,27 @@ describe("tool factory", () => {
         () => t.execute({ query: 123 }),
         Error,
       );
+    });
+
+    it("should forward parsed defaults and transforms to execute", async () => {
+      let received: unknown;
+      const t = dynamicTool({
+        id: "dyn-parsed-forward",
+        description: "desc",
+        inputSchema: defineSchema((v) =>
+          v.object({
+            limit: v.number().default(10),
+            tag: v.string().transform((s) => `tag:${s}`),
+          })
+        )(),
+        execute: (input) => {
+          received = input;
+          return input;
+        },
+      });
+      const result = await t.execute({ tag: "foo" });
+      assertEquals(received, { limit: 10, tag: "tag:foo" });
+      assertEquals(result, { limit: 10, tag: "tag:foo" });
     });
 
     it("should accept valid object input without Zod schema", async () => {

--- a/src/tool/factory.ts
+++ b/src/tool/factory.ts
@@ -183,9 +183,10 @@ export function tool<TInput = unknown, TOutput = unknown>(
     outputSchema: config.outputSchema,
     outputSchemaJson,
     execute: async (input: TInput, context?: ToolExecutionContext) => {
+      let validated = input;
       if (hasSchemaParse(config.inputSchema)) {
         try {
-          config.inputSchema.parse(input);
+          validated = config.inputSchema.parse(input) as TInput;
         } catch (error) {
           throw toError(
             createError({
@@ -196,7 +197,7 @@ export function tool<TInput = unknown, TOutput = unknown>(
         }
       }
 
-      return await config.execute(input, context);
+      return await config.execute(validated, context);
     },
     mcp: config.mcp,
   };
@@ -231,7 +232,7 @@ export function dynamicTool(config: DynamicToolConfig): Tool<unknown, unknown> {
     inputSchemaJson,
     execute: async (input: unknown, context?: ToolExecutionContext) => {
       if (hasSchemaParse(config.inputSchema)) {
-        config.inputSchema.parse(input);
+        input = config.inputSchema.parse(input);
       } else if (input === undefined) {
         input = {};
       } else if (input === null || typeof input !== "object") {


### PR DESCRIPTION
## Summary
- `tool()` and `dynamicTool()` previously called `inputSchema.parse(input)` only for its throw side-effect and passed the **raw** input to `execute`, discarding schema-applied defaults, transforms, and coercions.
- This fix forwards the parsed value to `execute`, so defaults/transforms/coercions reach the execution sink. (Bug H13)
- File: `src/tool/factory.ts` (+ `factory.test.ts`).

## Test plan
- `deno test` over `src/tool/*.test.ts`: **33 passed (112 steps) | 0 failed**, including two new tests verifying that parsed defaults and transforms are forwarded to `execute` for both `tool()` and `dynamicTool()`.
- `deno fmt` + `deno lint` on changed files: clean.

## Simplify pass
- Reviewed the diff; the change is already minimal and readable. No behavior-preserving simplifications warranted. Nothing to do.

## Security review
- Reviewed `git diff main...HEAD` for newly-introduced, high-confidence exploitable vulnerabilities (excluding DoS/resource/secrets).
- The change is a hardening improvement: validated/coerced data now reaches `execute` instead of raw untrusted input. The `parse()` call already existed; only its return value is now used. Error handling unchanged, no new sinks. No new issues found.