### PR TITLE
Honor configured windowMs in fixed-window rate limiter (H1)

### DIFF
--- a/src/security/rate-limit/memory-store.ts
+++ b/src/security/rate-limit/memory-store.ts
@@ -14,14 +14,14 @@ export class MemoryRateLimitStore implements RateLimitStore {
     unrefTimer(this.cleanupInterval);
   }
 
-  increment(key: string): Promise<number> {
+  increment(key: string, windowMs: number = WINDOW_MS): Promise<number> {
     const now = Date.now();
     const state = this.store.get(key);
 
     if (!state || now > state.resetTime) {
       this.store.set(key, {
         count: 1,
-        resetTime: now + WINDOW_MS,
+        resetTime: now + windowMs,
         requestTimestamps: [now],
       });
       return Promise.resolve(1);
@@ -32,7 +32,7 @@ export class MemoryRateLimitStore implements RateLimitStore {
 
     const timestamps = state.requestTimestamps;
     if (timestamps?.length && timestamps.length > MAX_TIMESTAMPS_PER_KEY) {
-      const windowStart = state.resetTime - WINDOW_MS;
+      const windowStart = state.resetTime - windowMs;
       const filtered = timestamps.filter((t) => t >= windowStart);
       state.requestTimestamps = filtered.length > MAX_TIMESTAMPS_PER_KEY
         ? filtered.slice(-MAX_TIMESTAMPS_PER_KEY)

--- a/src/security/rate-limit/strategies.test.ts
+++ b/src/security/rate-limit/strategies.test.ts
@@ -82,6 +82,24 @@ describe("fixedWindowStrategy", () => {
       assertEquals(resultB.allowed, true);
     });
   });
+
+  it("should honor configured windowMs in the store state (not hardcoded 60s)", async () => {
+    await withStore(async (store) => {
+      const windowMs = 600_000; // 10 minutes
+      const config = createConfig({ maxRequests: 2, windowMs });
+      const before = Date.now();
+
+      await fixedWindowStrategy("window-key", config, store);
+
+      const state = store.getState("window-key");
+      // resetTime must reflect the configured 10-minute window, not the
+      // hardcoded 60s constant the store previously used.
+      assertEquals(
+        state !== undefined && state.resetTime >= before + windowMs,
+        true,
+      );
+    });
+  });
 });
 
 describe("slidingWindowStrategy", () => {

--- a/src/security/rate-limit/strategies.ts
+++ b/src/security/rate-limit/strategies.ts
@@ -17,7 +17,7 @@ export function fixedWindowStrategy(
   return withSpan(
     "security.rateLimit.fixedWindow",
     async () => {
-      const count = await store.increment(key);
+      const count = await store.increment(key, config.windowMs);
       const allowed = count <= config.maxRequests;
       const remaining = Math.max(0, config.maxRequests - count);
       const resetTime = Date.now() + config.windowMs;

--- a/src/security/rate-limit/types.ts
+++ b/src/security/rate-limit/types.ts
@@ -15,7 +15,7 @@ export interface RateLimitConfig {
 }
 
 export interface RateLimitStore {
-  increment(key: string): Promise<number>;
+  increment(key: string, windowMs?: number): Promise<number>;
   get(key: string): Promise<number>;
   reset(key: string): Promise<void>;
   resetAll(): Promise<void>;


### PR DESCRIPTION
## Summary

Bug H1: the fixed-window rate limiter hardcoded a 60s window. `MemoryRateLimitStore.increment()` always used the internal `WINDOW_MS = 60_000` constant for `resetTime` (and for the timestamp-pruning `windowStart`), silently ignoring `config.windowMs`. Any caller configuring a non-60s window (e.g. 10 minutes) got incorrect reset times and window boundaries.

The fix threads the configured window through:
- `RateLimitStore.increment()` now accepts an optional `windowMs` parameter (defaults to `WINDOW_MS` for backward compatibility).
- `MemoryRateLimitStore.increment()` uses the passed `windowMs` for both `resetTime` and the timestamp `windowStart` instead of the hardcoded constant.
- `fixedWindowStrategy` passes `config.windowMs` to `store.increment()`.

## Test plan

```
VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net $(find src/security/rate-limit -name '*.test.ts')
```

Result: **5 passed (34 steps) / 0 failed**. Includes a new regression test asserting `resetTime` reflects the configured 10-minute window rather than the hardcoded 60s. `deno fmt` and `deno lint` clean on changed files; full pre-push suite passed (1923 passed / 0 failed).

## Simplify pass

No changes needed — the fix is already minimal (a single parameter threaded through with a backward-compatible default). No dead code, redundant logic, or awkward naming introduced.

## Security review

No new vulnerabilities found. The change only parameterizes an existing arithmetic constant (`windowMs` is a trusted number from `RateLimitConfig`, used solely in time arithmetic). No new input parsing, authz, crypto, injection, XSS, or data-exposure surface is introduced.