### PR TITLE
Escape raw text nodes in RSC server HTML generation (H14)

### DIFF
--- a/src/rendering/rsc/server-renderer/tree-processor.test.ts
+++ b/src/rendering/rsc/server-renderer/tree-processor.test.ts
@@ -185,5 +185,63 @@ describe("rendering/rsc/server-renderer/tree-processor", {
       const result = await renderChildren(children, new Map(), new Map());
       assertEquals(result.length, 2);
     });
+
+    it("should HTML-escape raw text children (XSS H14)", async () => {
+      const result = await renderChildren(
+        "<img src=x onerror=alert(1)>",
+        new Map(),
+        new Map(),
+      );
+      assertEquals(result.length, 1);
+      assertEquals(result[0]!.type, "html");
+      const html = (result[0] as { html: string }).html;
+      assertEquals(html.includes("&lt;img"), true);
+      assertEquals(html.includes("<img"), false);
+    });
+  });
+
+  describe("XSS H14 - mixed text + client-component children", () => {
+    it("should escape a text sibling next to a client component", async () => {
+      function ClientWidget() {
+        return React.createElement("div", null, "widget");
+      }
+      (ClientWidget as any).__rsc_client = true;
+
+      const clientManifest = new Map<string, ClientComponentMeta>();
+      clientManifest.set("ClientWidget", {
+        id: "ClientWidget",
+        path: "./components/ClientWidget.tsx",
+        exports: ["default"],
+      });
+
+      const element = React.createElement(
+        "div",
+        null,
+        "<img src=x onerror=alert(1)>",
+        React.createElement(ClientWidget),
+      );
+
+      const result = await renderTree(
+        element as any,
+        {},
+        clientManifest,
+        new Map<string, string>(),
+      );
+
+      assertEquals(result.type, "html");
+      const html = (result as { html: string }).html;
+      assertEquals(html.includes("&lt;img"), true);
+      assertEquals(html.includes("onerror=alert(1)>"), false);
+    });
+
+    it("should not double-escape a normal text-only element (regression)", async () => {
+      const element = React.createElement("div", null, "hello & welcome");
+      const result = await renderTree(element as any, {}, new Map(), new Map());
+      assertEquals(result.type, "html");
+      const html = (result as { html: string }).html;
+      // text-only goes through React's fast path; should escape once, not twice
+      assertEquals(html.includes("hello &amp; welcome"), true);
+      assertEquals(html.includes("&amp;amp;"), false);
+    });
   });
 });

--- a/src/rendering/rsc/server-renderer/tree-processor.ts
+++ b/src/rendering/rsc/server-renderer/tree-processor.ts
@@ -8,7 +8,7 @@ import {
   registerClientRef,
   type RSCComponent,
 } from "./component-detector.ts";
-import { renderAttributes, treeToHTML } from "./html-generator.ts";
+import { escapeHtml, renderAttributes, treeToHTML } from "./html-generator.ts";
 import { serializeProps } from "./prop-serializer.ts";
 
 const logger = serverLogger.component("rsc");
@@ -22,7 +22,7 @@ export async function renderTree(
   clientRefs: Map<string, string>,
 ): Promise<RSCNode> {
   if (Component == null || typeof Component === "string" || typeof Component === "number") {
-    return { type: "html", html: Component == null ? "" : String(Component) };
+    return { type: "html", html: Component == null ? "" : escapeHtml(String(Component)) };
   }
 
   if (React.isValidElement(Component)) {
@@ -30,7 +30,7 @@ export async function renderTree(
   }
 
   if (typeof Component !== "function") {
-    return { type: "html", html: String(Component) };
+    return { type: "html", html: escapeHtml(String(Component)) };
   }
 
   const rscComponent = Component as RSCComponent;
@@ -54,7 +54,7 @@ export async function renderTree(
     if (!element) return { type: "html", html: "" };
     if (React.isValidElement(element)) return processElement(element, clientManifest, clientRefs);
 
-    return { type: "html", html: String(element) };
+    return { type: "html", html: escapeHtml(String(element)) };
   } catch (error) {
     logger.error("Error rendering component:", error);
     throw error;
@@ -120,7 +120,7 @@ export function renderChildren(
         return processElement(child, clientManifest, clientRefs);
       }
 
-      return Promise.resolve({ type: "html" as const, html: String(child) });
+      return Promise.resolve({ type: "html" as const, html: escapeHtml(String(child)) });
     }),
   );
 }


### PR DESCRIPTION
## Summary

Fixes XSS bug H14 in RSC server HTML generation. In `renderChildren`, non-element (raw text/number) children were emitted as `{ type: "html", html: String(child) }` with no escaping. React's escaping fast path in `processElement` only fires when *every* processed child is `html`-typed (`processedChildren.every((c) => c.type === "html")`), routing through `renderToStringAdapter`. When a raw text child is mixed with a client component (a `client`-typed node), the `.every()` check fails and rendering falls to the manual `treeToHTML` join path, emitting the unescaped text verbatim — injecting attacker-controlled markup.

The fix routes every raw text / non-element leaf value through `escapeHtml` at the four sinks in `tree-processor.ts` (`renderTree` string/number leaf, non-function fallback, non-element component result, and the `renderChildren` leaf). The text-only fast path is unchanged, so genuine element HTML still goes through React's single-pass escaping with no double-escaping.

## Test plan

- `deno test` on `src/rendering/rsc/**/*.test.ts`: 15 passed (192 steps), 0 failed.
- New tests in `tree-processor.test.ts`:
  - raw text child `<img src=x onerror=alert(1)>` is escaped to `&lt;img` (payload neutralized)
  - text sibling next to a client component is escaped (the exact H14 mixed-children path)
  - text-only element `hello & welcome` escapes once to `hello &amp; welcome`, not `&amp;amp;` (no double-escape regression)
- `deno fmt` + `deno lint` clean on changed files; full pre-push suite (1923 tests) passed.

## Simplify pass

Reviewed `git diff main...HEAD`. The diff is minimal — four call sites each wrap `String(...)` in `escapeHtml(...)`. Extracting a helper for these one-liners would add indirection without benefit. Nothing to simplify; no simplify commit.

## Security review

- Escaper (`src/html/html-escape.ts`) covers all five characters `& < > " '` and replaces `&` first, preventing entity double-encoding.
- All four raw-text sinks in the changed file are now escaped; no remaining unescaped raw-text sink in `tree-processor.ts`.
- No double-escaping: the text-only fast path bypasses the leaf escape and relies on React's single-pass escaping (confirmed by regression test).
- Verdict: PASS — the dangerous sink is escaped, no sink is missed, genuine child HTML is not double-escaped.