### PR TITLE
Fix workflow resume re-execution and Redis lock ownership (H8, H9, H10)

### DIFF
--- a/src/platform/adapters/redis/deno.ts
+++ b/src/platform/adapters/redis/deno.ts
@@ -110,6 +110,12 @@ export class DenoRedisAdapter implements RedisAdapter {
     return this.client.get(key);
   }
 
+  // Redis server-side Lua (EVAL). Not JavaScript eval; runs the given script
+  // atomically inside Redis for compare-and-delete / compare-and-pexpire.
+  eval(script: string, keys: string[], args: string[]): Promise<unknown> {
+    return this.client.eval(script, keys, args);
+  }
+
   async quit(): Promise<void> {
     await this.client.close();
   }

--- a/src/platform/adapters/redis/interface.ts
+++ b/src/platform/adapters/redis/interface.ts
@@ -37,6 +37,12 @@ export interface RedisAdapter {
   ): Promise<string | null>;
   get(key: string): Promise<string | null>;
 
+  /**
+   * Run a Lua script atomically (EVAL). Used for compare-and-delete and
+   * compare-and-pexpire so lock ownership checks cannot race (Redlock).
+   */
+  eval(script: string, keys: string[], args: string[]): Promise<unknown>;
+
   quit(): Promise<void>;
   disconnect(): Promise<void>;
 }

--- a/src/platform/adapters/redis/node.ts
+++ b/src/platform/adapters/redis/node.ts
@@ -115,6 +115,12 @@ export class NodeRedisAdapter implements RedisAdapter {
     return this.client.get(key);
   }
 
+  // Redis server-side Lua (EVAL). Not JavaScript eval; runs the given script
+  // atomically inside Redis for compare-and-delete / compare-and-pexpire.
+  eval(script: string, keys: string[], args: string[]): Promise<unknown> {
+    return this.client.eval(script, { keys, arguments: args });
+  }
+
   quit(): Promise<void> {
     // redis v5: quit() renamed to close()
     return this.client.close();

--- a/src/platform/adapters/redis/types.ts
+++ b/src/platform/adapters/redis/types.ts
@@ -31,6 +31,7 @@ export interface DenoRedisClient {
     options?: { nx?: boolean; px?: number; ex?: number },
   ): Promise<string | null>;
   get(key: string): Promise<string | null>;
+  eval(script: string, keys: string[], args: string[]): Promise<unknown>;
   close(): Promise<void>;
 }
 
@@ -79,6 +80,10 @@ export interface NodeRedisClient {
     options?: { NX?: boolean; PX?: number; EX?: number },
   ): Promise<string | null>;
   get(key: string): Promise<string | null>;
+  eval(
+    script: string,
+    options?: { keys?: string[]; arguments?: string[] },
+  ): Promise<unknown>;
   close(): Promise<void>;
   destroy(): Promise<void>;
 }

--- a/src/workflow/backends/redis/index.test.ts
+++ b/src/workflow/backends/redis/index.test.ts
@@ -122,6 +122,30 @@ class MockRedisAdapter implements RedisAdapter {
     return Promise.resolve(this.store.get(key) ?? null);
   }
 
+  // Emulates the two Redlock Lua scripts used by the backend. Both are
+  // compare-against-token guards on KEYS[1] / ARGV[1]: release deletes the key
+  // and extend (P)EXPIREs it, atomically with respect to the JS event loop.
+  eval(script: string, keys: string[], args: string[]): Promise<unknown> {
+    const key = keys[0]!;
+    const token = args[0];
+    const owns = this.store.get(key) === token;
+
+    if (script.includes("del")) {
+      if (!owns) return Promise.resolve(0);
+      this.store.delete(key);
+      this.expiries.delete(key);
+      return Promise.resolve(1);
+    }
+
+    if (script.includes("pexpire")) {
+      if (!owns) return Promise.resolve(0);
+      this.expiries.set(key, Number(args[1]));
+      return Promise.resolve(1);
+    }
+
+    throw new Error(`MockRedisAdapter.eval: unsupported script: ${script}`);
+  }
+
   rpush(key: string, ...values: string[]): Promise<number> {
     let list = this.lists.get(key);
     if (!list) {
@@ -591,6 +615,62 @@ describe("RedisBackend", () => {
 
       // Worker A tries to extend -- it must NOT succeed.
       assertEquals(await backend.extendLock("run-own2", 10000), false);
+    });
+
+    it("releaseLock runs an atomic compare-and-delete script (no GET+DEL race)", async () => {
+      // Spy on eval to prove release goes through a single atomic Lua call and
+      // never falls back to a separate GET then DEL.
+      const evalCalls: Array<{ script: string; keys: string[]; args: string[] }> = [];
+      const realEval = mockRedis.eval.bind(mockRedis);
+      let getCalls = 0;
+      let delCalls = 0;
+      mockRedis.eval = (script: string, keys: string[], args: string[]) => {
+        evalCalls.push({ script, keys, args });
+        return realEval(script, keys, args);
+      };
+      const realGet = mockRedis.get.bind(mockRedis);
+      mockRedis.get = (key: string) => {
+        getCalls++;
+        return realGet(key);
+      };
+      const realDel = mockRedis.del.bind(mockRedis);
+      mockRedis.del = (...keys: string[]) => {
+        delCalls++;
+        return realDel(...keys);
+      };
+
+      assertEquals(await backend.acquireLock("run-atomic", 5000), true);
+      await backend.releaseLock("run-atomic");
+
+      // One atomic eval, and no separate get/del round-trips for the release.
+      assertEquals(evalCalls.length, 1);
+      assertEquals(evalCalls[0]!.script.includes("del"), true);
+      assertEquals(getCalls, 0);
+      assertEquals(delCalls, 0);
+      assertEquals(await backend.isLocked("run-atomic"), false);
+    });
+
+    it("compare-and-delete deletes only on a matching token", async () => {
+      const key = "test:lock:cad";
+
+      // Mismatched token -> script must be a no-op and return 0.
+      mockRedis.store.set(key, "owner-token");
+      const noop = await mockRedis.eval(
+        "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
+        [key],
+        ["other-token"],
+      );
+      assertEquals(noop, 0);
+      assertEquals(mockRedis.store.get(key), "owner-token");
+
+      // Matching token -> script deletes and returns 1.
+      const deleted = await mockRedis.eval(
+        "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
+        [key],
+        ["owner-token"],
+      );
+      assertEquals(deleted, 1);
+      assertEquals(mockRedis.store.get(key), undefined);
     });
   });
 

--- a/src/workflow/backends/redis/index.test.ts
+++ b/src/workflow/backends/redis/index.test.ts
@@ -565,6 +565,33 @@ describe("RedisBackend", () => {
     it("should fail to extend non-existent lock", async () => {
       assertEquals(await backend.extendLock("no-such-lock", 10000), false);
     });
+
+    it("releaseLock should not delete a lock owned by another worker", async () => {
+      // Worker A acquires the lock.
+      assertEquals(await backend.acquireLock("run-own", 5000), true);
+      const lockKey = "test:lock:run-own";
+
+      // Simulate lock expiry + worker B acquiring it: overwrite the stored
+      // value with worker B's token.
+      mockRedis.store.set(lockKey, "worker-B-token");
+
+      // Worker A tries to release -- it must NOT delete worker B's lock.
+      await backend.releaseLock("run-own");
+
+      assertEquals(mockRedis.store.get(lockKey), "worker-B-token");
+    });
+
+    it("extendLock should not extend a lock owned by another worker", async () => {
+      // Worker A acquires the lock.
+      assertEquals(await backend.acquireLock("run-own2", 5000), true);
+      const lockKey = "test:lock:run-own2";
+
+      // Simulate worker B taking over the lock.
+      mockRedis.store.set(lockKey, "worker-B-token");
+
+      // Worker A tries to extend -- it must NOT succeed.
+      assertEquals(await backend.extendLock("run-own2", 10000), false);
+    });
   });
 
   describe("stalled run recovery", () => {

--- a/src/workflow/backends/redis/index.ts
+++ b/src/workflow/backends/redis/index.ts
@@ -35,6 +35,21 @@ import type { RedisBackendConfig, RedisBackendInternalConfig } from "./types.ts"
 
 const logger = agentLogger.component("redis-backend");
 
+/**
+ * Atomic compare-and-delete: delete the lock only if it still holds our token.
+ * Server-side Lua (Redis EVAL) so the GET and DEL are one indivisible step,
+ * preventing a stale owner from deleting another worker's reacquired lock.
+ */
+const RELEASE_LOCK_SCRIPT =
+  "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end";
+
+/**
+ * Atomic compare-and-pexpire: extend the lock TTL only if it still holds our
+ * token. Same TOCTOU protection as the release script.
+ */
+const EXTEND_LOCK_SCRIPT =
+  "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('pexpire', KEYS[1], ARGV[2]) else return 0 end";
+
 /** Implement redis backend. */
 export class RedisBackend implements WorkflowBackend {
   private client: RedisAdapter | null = null;
@@ -571,10 +586,9 @@ export class RedisBackend implements WorkflowBackend {
     // known token we never owned it, so do nothing.
     if (ourValue === undefined) return;
 
-    const current = await client.get(key);
-    if (current === ourValue) {
-      await client.del(key);
-    }
+    // Atomic GET + DEL via Lua so a stale owner cannot delete a lock that was
+    // reacquired by another worker between the check and the delete (TOCTOU).
+    await client.eval(RELEASE_LOCK_SCRIPT, [key], [ourValue]);
     this.lockValues.delete(runId);
   }
 
@@ -586,11 +600,13 @@ export class RedisBackend implements WorkflowBackend {
     // Only extend if we still own the lock (compare-and-pexpire).
     if (ourValue === undefined) return false;
 
-    const current = await client.get(key);
-    if (current !== ourValue) return false;
-
-    await client.expire(key, Math.ceil(duration / 1000));
-    return true;
+    // Atomic GET + PEXPIRE via Lua. PEXPIRE returns 1 when the key existed and
+    // the TTL was set, 0 otherwise (e.g. our token no longer owns the lock).
+    const result = await client.eval(EXTEND_LOCK_SCRIPT, [key], [
+      ourValue,
+      String(duration),
+    ]);
+    return Number(result) === 1;
   }
 
   async isLocked(runId: string): Promise<boolean> {

--- a/src/workflow/backends/redis/index.ts
+++ b/src/workflow/backends/redis/index.ts
@@ -41,6 +41,8 @@ export class RedisBackend implements WorkflowBackend {
   private connectionPromise: Promise<RedisAdapter> | null = null;
   private config: RedisBackendInternalConfig;
   private initialized = false;
+  /** Per-run lock tokens for ownership-checked release/extend (Redlock pattern). */
+  private lockValues = new Map<string, string>();
 
   constructor(config: RedisBackendConfig = {}) {
     this.config = {
@@ -552,20 +554,40 @@ export class RedisBackend implements WorkflowBackend {
     const lockValue = crypto.randomUUID();
 
     const result = await client.set(this.lockKey(runId), lockValue, { nx: true, px: duration });
-    return result === "OK";
+    if (result === "OK") {
+      // Remember our token so release/extend can verify ownership (Redlock).
+      this.lockValues.set(runId, lockValue);
+      return true;
+    }
+    return false;
   }
 
   async releaseLock(runId: string): Promise<void> {
     const client = await this.ensureClient();
-    await client.del(this.lockKey(runId));
+    const key = this.lockKey(runId);
+    const ourValue = this.lockValues.get(runId);
+
+    // Only release if we still own the lock (compare-and-delete). Without a
+    // known token we never owned it, so do nothing.
+    if (ourValue === undefined) return;
+
+    const current = await client.get(key);
+    if (current === ourValue) {
+      await client.del(key);
+    }
+    this.lockValues.delete(runId);
   }
 
   async extendLock(runId: string, duration: number): Promise<boolean> {
     const client = await this.ensureClient();
     const key = this.lockKey(runId);
+    const ourValue = this.lockValues.get(runId);
 
-    const exists = await client.exists(key);
-    if (exists === 0) return false;
+    // Only extend if we still own the lock (compare-and-pexpire).
+    if (ourValue === undefined) return false;
+
+    const current = await client.get(key);
+    if (current !== ourValue) return false;
 
     await client.expire(key, Math.ceil(duration / 1000));
     return true;

--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -329,6 +329,65 @@ describe("DAGExecutor", () => {
     });
   });
 
+  describe("composite resume (H8)", () => {
+    it("should not re-run completed children of a parallel node on resume", async () => {
+      let stepARuns = 0;
+      const trackingExecutor = new MockStepExecutor(new Map(), (node) => {
+        if (node.id === "p-step") stepARuns++;
+        return { success: true, output: node.id, executionTime: 1 };
+      });
+      const exec = new DAGExecutor({ stepExecutor: trackingExecutor });
+
+      const nodes: WorkflowNode[] = [
+        {
+          id: "par1",
+          dependsOn: [],
+          config: {
+            type: "parallel",
+            nodes: [
+              { id: "p-step", dependsOn: [], config: { type: "step" } as any },
+              {
+                id: "p-wait",
+                dependsOn: [],
+                config: { type: "wait", waitType: "approval", message: "approve?" } as any,
+              },
+            ],
+          } as any,
+        },
+      ];
+
+      // First run: should suspend on the wait node, p-step runs once.
+      const run = createTestRun();
+      const first = await exec.execute(nodes, run);
+      assertEquals(first.waiting, true);
+      // The composite node is the waiting node reported to the executor.
+      assertEquals(first.waitingNode, "par1");
+      assertEquals(stepARuns, 1);
+      assertEquals(first.nodeStates["p-step"]!.status, "completed");
+
+      // Resume: mark the wait node completed (approval granted) and re-run with
+      // the accumulated nodeStates from the first run. The real executor resumes
+      // by passing the waiting node id as startFromNode.
+      const resumedStates = {
+        ...first.nodeStates,
+        "p-wait": {
+          ...first.nodeStates["p-wait"]!,
+          status: "completed" as const,
+          completedAt: new Date(),
+        },
+      };
+      const resumeRun = createTestRun({
+        nodeStates: resumedStates,
+        context: { ...first.context },
+      });
+
+      const second = await exec.execute(nodes, resumeRun, "par1");
+      assertEquals(second.completed, true);
+      // p-step must NOT have run a second time.
+      assertEquals(stepARuns, 1);
+    });
+  });
+
   describe("map node", () => {
     it("should execute map over items", async () => {
       const nodes: WorkflowNode[] = [
@@ -429,6 +488,70 @@ describe("DAGExecutor", () => {
       assertEquals(result.completed, true);
       const output = result.nodeStates["loop-max"]!.output as any;
       assertEquals(output.iterations, 2);
+    });
+  });
+
+  describe("loop resume (H9)", () => {
+    it("should not re-run completed steps of an in-flight loop iteration on resume", async () => {
+      let incrRuns = 0;
+      const trackingExecutor = new MockStepExecutor(new Map(), (node) => {
+        if (node.id === "l-incr") incrRuns++;
+        return { success: true, output: node.id, executionTime: 1 };
+      });
+      const exec = new DAGExecutor({ stepExecutor: trackingExecutor });
+
+      const nodes: WorkflowNode[] = [
+        {
+          id: "loop1",
+          dependsOn: [],
+          config: {
+            type: "loop",
+            maxIterations: 1,
+            while: () => true,
+            steps: [
+              { id: "l-incr", dependsOn: [], config: { type: "step" } as any },
+              {
+                id: "l-wait",
+                dependsOn: ["l-incr"],
+                config: { type: "wait", waitType: "approval", message: "approve?" } as any,
+              },
+            ],
+          } as any,
+        },
+      ];
+
+      // First run: increments once, then suspends on the wait.
+      const run = createTestRun();
+      const first = await exec.execute(nodes, run);
+      assertEquals(first.waiting, true);
+      assertEquals(first.waitingNode, "loop1");
+      assertEquals(incrRuns, 1);
+      assertEquals(first.nodeStates["l-incr"]!.status, "completed");
+
+      // Resume: approve the wait and re-run from the loop node, carrying the
+      // accumulated state. The pre-wait step must NOT run again for this
+      // iteration.
+      const resumedStates = {
+        ...first.nodeStates,
+        "l-wait": {
+          ...first.nodeStates["l-wait"]!,
+          status: "completed" as const,
+          completedAt: new Date(),
+        },
+      };
+      const resumeRun = createTestRun({
+        nodeStates: resumedStates,
+        context: { ...first.context },
+      });
+
+      const second = await exec.execute(nodes, resumeRun, "loop1");
+      // The in-flight iteration's l-incr must NOT have run a second time.
+      assertEquals(
+        incrRuns,
+        1,
+        `expected exactly 1 increment (no double-run on resume), got ${incrRuns}`,
+      );
+      assertEquals(second.completed, true);
     });
   });
 

--- a/src/workflow/executor/dag/index.ts
+++ b/src/workflow/executor/dag/index.ts
@@ -238,7 +238,9 @@ export class DAGExecutor {
       workflowId: "",
       status: "running",
       input: context.input,
-      nodeStates: {},
+      // Carry already-accumulated child states so completed children are
+      // skipped on resume instead of re-executing (H8).
+      nodeStates,
       currentNodes: [],
       context,
       checkpoints: [],
@@ -332,7 +334,9 @@ export class DAGExecutor {
         workflowId: "",
         status: "running",
         input: context.input,
-        nodeStates: {},
+        // Carry already-accumulated child states so completed children are
+        // skipped on resume instead of re-executing (H8).
+        nodeStates,
         currentNodes: [],
         context: { ...context },
         checkpoints: [],
@@ -395,7 +399,9 @@ export class DAGExecutor {
       workflowId: "",
       status: "running",
       input: context.input,
-      nodeStates: {},
+      // Carry already-accumulated child states so completed children are
+      // skipped on resume instead of re-executing (H8).
+      nodeStates,
       currentNodes: [],
       context,
       checkpoints: [],
@@ -533,12 +539,23 @@ export class DAGExecutor {
     let lastError: string | undefined;
 
     const existingLoopState = context[`${node.id}_loop_state`] as
-      | { iteration: number; previousResults: unknown[] }
+      | {
+        iteration: number;
+        previousResults: unknown[];
+        iterationNodeStates?: Record<string, NodeState>;
+      }
       | undefined;
+
+    // Child node states for the in-flight (resumed) iteration, so its already
+    // completed steps are not re-executed on resume (H9).
+    let resumeIterationNodeStates: Record<string, NodeState> | undefined;
+    let resumeIteration: number | undefined;
 
     if (existingLoopState) {
       iteration = existingLoopState.iteration;
       previousResults.push(...existingLoopState.previousResults);
+      resumeIterationNodeStates = existingLoopState.iterationNodeStates;
+      resumeIteration = existingLoopState.iteration;
     }
 
     while (iteration < config.maxIterations) {
@@ -559,12 +576,20 @@ export class DAGExecutor {
         ? config.steps(context, loopContext)
         : config.steps;
 
+      // On resume, rehydrate the in-flight iteration's child node states so its
+      // already-completed steps are skipped instead of re-executed (H9).
+      const iterationNodeStates = resumeIteration === iteration && resumeIterationNodeStates
+        ? { ...resumeIterationNodeStates }
+        : {};
+      // Only rehydrate once; subsequent iterations start fresh.
+      resumeIterationNodeStates = undefined;
+
       const result = await this.execute(steps, {
         id: `${node.id}_iter_${iteration}`,
         workflowId: "",
         status: "running",
         input: context.input,
-        nodeStates: {},
+        nodeStates: iterationNodeStates,
         currentNodes: [],
         context: { ...context, _loop: loopContext },
         checkpoints: [],
@@ -587,7 +612,13 @@ export class DAGExecutor {
           state,
           contextUpdates: {
             ...result.context,
-            [`${node.id}_loop_state`]: { iteration, previousResults },
+            [`${node.id}_loop_state`]: {
+              iteration,
+              previousResults,
+              // Persist the in-flight iteration's child states so completed
+              // steps are not re-executed when this iteration resumes (H9).
+              iterationNodeStates: result.nodeStates,
+            },
           },
           waiting: true,
         };


### PR DESCRIPTION
## Summary

Fixes three related workflow bugs around suspend/resume and distributed locking:

- **H8 — Composite nodes re-executed completed children on resume.** `executeParallelNode`, `executeMapNode`, and `executeBranchNode` each started their child sub-run with an empty `nodeStates: {}`, so on resume the child DAG had no record of already-completed children and re-ran them. Fix: seed each child sub-run with the parent's already-accumulated `nodeStates` so completed children are skipped. `Object.assign(nodeStates, result.nodeStates)` already merges results back, so this is symmetric.

- **H9 — In-flight loop iteration re-executed completed steps on resume.** A suspended loop iteration persisted only `{ iteration, previousResults }`, losing the iteration's child step states; on resume the iteration restarted from scratch. Fix: persist the in-flight iteration's child `nodeStates` into the loop state (`iterationNodeStates`) and rehydrate them for the matching resumed iteration only. Subsequent iterations start fresh (rehydration is consumed once).

- **H10 — Redis lock release/extend ignored ownership.** `releaseLock` did an unconditional `DEL` and `extendLock` only checked key existence, so any caller could release or extend a lock held by another holder. Fix: store a per-`runId` random token on acquire (`lockValues` map) and do compare-and-act (Redlock pattern) — release only deletes when the stored token matches the current value, extend only renews when it matches. Unknown token = never owned = no-op.

Files: `src/workflow/executor/dag/index.ts`, `src/workflow/backends/redis/index.ts` (+ matching `*.test.ts`).

## Test plan

- Workflow suite (targeted): `deno test $(find src/workflow -name '*.test.ts')` with the project env flags — 49 passed (395 steps), 0 failed.
- Full pre-push suite (husky): 1923 passed (17700 steps), 0 failed. (An initial run hit a flaky `AddrInUse` port race in the unrelated `cli/mcp/server.test.ts`; a clean re-run passed with the workflow files green throughout.)
- `deno fmt` + `deno lint` on changed files: clean.

## Simplify pass

Reviewed `git diff main...HEAD`. No simplifications applied — the diff is already minimal and the resume/lock semantics are intentionally explicit (e.g. the `resumeIteration === iteration` guard and the one-shot rehydration consumption). Given these are the highest-risk fixes, no behavior-touching change was warranted. Nothing to commit.

## Security review

Reviewed `git diff main...HEAD` for newly-introduced, high-confidence exploitable vulnerabilities (DoS/resource/secrets excluded).

- **nodeStates seeding — no cross-run leakage.** The seeded `nodeStates` is a per-run local object (`const nodeStates = { ...run.nodeStates }` at the top of `execute()`), threaded as a function argument through the executor. It is never stored on the instance, so there is no shared mutable state across concurrent runs and no path for one run's state (or auth data) to bleed into another. Each child sub-run is scoped to the same run's execution stack.
- **Lock token map degrades safely.** `lockValues` is keyed by `runId` and holds opaque random UUID tokens, only ever read for the same `runId`. On process restart the map is empty, so `releaseLock`/`extendLock` return early (no-op / `false`) and stale locks expire via their existing TTL rather than being force-released by a non-owner. The change strictly tightens lock semantics versus the prior unconditional delete.

Verdict: no findings.