### PR TITLE
Fail closed on OAuth token exchange errors (H11, H12)

### DIFF
--- a/src/oauth/providers/base.test.ts
+++ b/src/oauth/providers/base.test.ts
@@ -171,6 +171,103 @@ Deno.test(
   },
 );
 
+/**
+ * Replace globalThis.fetch so the token endpoint returns `status` with `body`
+ * JSON. Used to exercise exchangeCode token-validation behavior (H11/H12).
+ */
+async function withTokenFetch(
+  status: number,
+  body: unknown,
+  fn: () => Promise<unknown>,
+): Promise<void> {
+  const original = globalThis.fetch;
+  globalThis.fetch = ((): Promise<Response> => {
+    return Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  }) as typeof fetch;
+  try {
+    await fn();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+Deno.test(
+  "OAuthService.exchangeCode: 200 with no access_token is treated as failure (H11)",
+  async () => {
+    const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
+
+    let result: Awaited<ReturnType<typeof service.exchangeCode>> | undefined;
+    await withTokenFetch(200, { token_type: "Bearer" }, async () => {
+      result = await service.exchangeCode({ code: "abc", redirectUri: "https://app/cb" });
+    });
+
+    assert(result, "expected a result");
+    assertEquals(result!.success, false);
+    // Must not surface a usable (empty) token.
+    assertEquals(result!.tokens, undefined);
+    assertEquals(result!.error, "invalid_token_response");
+  },
+);
+
+Deno.test(
+  "OAuthService.exchangeCode: 200 with empty body is treated as failure (H11)",
+  async () => {
+    const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
+
+    let result: Awaited<ReturnType<typeof service.exchangeCode>> | undefined;
+    await withTokenFetch(200, {}, async () => {
+      result = await service.exchangeCode({ code: "abc", redirectUri: "https://app/cb" });
+    });
+
+    assert(result, "expected a result");
+    assertEquals(result!.success, false);
+    assertEquals(result!.tokens, undefined);
+  },
+);
+
+Deno.test(
+  "OAuthService.exchangeCode: 200 with body-level ok:false/error is a failure (H12)",
+  async () => {
+    const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
+
+    let result: Awaited<ReturnType<typeof service.exchangeCode>> | undefined;
+    await withTokenFetch(200, { ok: false, error: "invalid_code" }, async () => {
+      result = await service.exchangeCode({ code: "bad", redirectUri: "https://app/cb" });
+    });
+
+    assert(result, "expected a result");
+    assertEquals(result!.success, false);
+    assertEquals(result!.error, "invalid_code");
+    // No token persisted/returned.
+    assertEquals(result!.tokens, undefined);
+  },
+);
+
+Deno.test(
+  "OAuthService.exchangeCode: 200 with a valid access_token still succeeds",
+  async () => {
+    const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
+
+    let result: Awaited<ReturnType<typeof service.exchangeCode>> | undefined;
+    await withTokenFetch(
+      200,
+      { access_token: "real-token", token_type: "Bearer" },
+      async () => {
+        result = await service.exchangeCode({ code: "good", redirectUri: "https://app/cb" });
+      },
+    );
+
+    assert(result, "expected a result");
+    assertEquals(result!.success, true);
+    assertEquals(result!.tokens?.accessToken, "real-token");
+  },
+);
+
 Deno.test(
   "OAuthService.fetch: provider error body is not leaked into logs (SEC-010)",
   async () => {

--- a/src/oauth/providers/base.ts
+++ b/src/oauth/providers/base.ts
@@ -122,10 +122,19 @@ export class OAuthProvider {
     return headers;
   }
 
+  /**
+   * Parse a successful token-endpoint body into {@link OAuthTokens}.
+   *
+   * Returns `null` when the response carries no usable access token. A 2xx
+   * status alone is NOT sufficient evidence of success: some providers (e.g.
+   * Slack) signal errors with `200 {"ok": false, "error": ...}`, and a missing
+   * `access_token` must never be persisted as an empty-but-"connected" token.
+   * See bugs H11/H12.
+   */
   private parseTokenResponse(
     data: Record<string, unknown>,
     fallbackRefreshToken?: string,
-  ): OAuthTokens {
+  ): OAuthTokens | null {
     const mapping = this.config.tokenResponseMapping ?? {};
 
     const str = (key: string): string => {
@@ -138,6 +147,7 @@ export class OAuthProvider {
     };
 
     const accessToken = str(mapping.accessToken ?? "access_token");
+    if (!accessToken) return null;
     const refreshToken = optStr(mapping.refreshToken ?? "refresh_token") ??
       fallbackRefreshToken;
     const tokenType = str(mapping.tokenType ?? "token_type");
@@ -197,17 +207,27 @@ export class OAuthProvider {
     try {
       const { response, data } = await this.postTokenRequest(body, clientId, clientSecret);
 
-      if (!response.ok) {
+      // Some providers signal errors with a 2xx status and a body-level
+      // `ok: false` / `error` field (e.g. Slack oauth.v2.access). Treat those
+      // as failures even when the HTTP status is "ok". See bug H12.
+      const bodyError = typeof data.error === "string" ? data.error : "";
+      if (!response.ok || data.ok === false || bodyError) {
         return {
           success: false,
-          error: (typeof data.error === "string" ? data.error : "") || errorFallback,
+          error: bodyError || errorFallback,
           errorDescription:
             (typeof data.error_description === "string" ? data.error_description : "") ||
             (errorDescriptionFallback ? errorDescriptionFallback(response.status) : undefined),
         };
       }
 
-      return { success: true, tokens: this.parseTokenResponse(data, fallbackRefreshToken) };
+      // A 2xx without a usable access token is not a success. See bug H11.
+      const tokens = this.parseTokenResponse(data, fallbackRefreshToken);
+      if (!tokens) {
+        return { success: false, error: "invalid_token_response" };
+      }
+
+      return { success: true, tokens };
     } catch (error) {
       return {
         success: false,


### PR DESCRIPTION
## Summary

OAuth token exchange previously treated any 2xx HTTP response as success and coerced a missing `access_token` to `""`. This meant:

- **H11:** A malformed `200` response with no `access_token` (or an empty body) was treated as a successful connection, persisting an empty-but-"connected" token.
- **H12:** Providers that signal errors with a 2xx status and a body-level `ok: false` / `error` field (e.g. Slack `oauth.v2.access` returning `200 {"ok": false, ...}`) were treated as success.

This change makes token exchange **fail closed**:

- `parseTokenResponse` now returns `null` when the response carries no usable `access_token`; the caller converts that into `{ success: false, error: "invalid_token_response" }`. No empty token is ever returned or persisted.
- `exchangeToken` now treats a 2xx response as a failure when the body carries `ok: false` or a non-empty `error` string, surfacing the provider error code.

Scope is limited to `src/oauth/providers/base.ts` (+ tests). State/CSRF handling is untouched.

## Test plan

- `deno test` over `src/oauth/**` — 39 passed / 0 failed.
- New cases in `base.test.ts`:
  - 200 with no `access_token` → failure, `error: "invalid_token_response"`, no tokens (H11)
  - 200 with empty body → failure, no tokens (H11)
  - 200 with `{ ok: false, error: "invalid_code" }` → failure, `error: "invalid_code"`, no tokens (H12)
  - 200 with a valid `access_token` → still succeeds, token surfaced
- `deno fmt` + `deno lint` clean on changed files.
- Pre-push hook ran full suite: 1927 passed / 0 failed.

## Simplify pass

Reviewed the diff for behavior-preserving simplifications. The change is already minimal — `bodyError` is computed once and reused, every new branch leads to `success: false`, no dead/duplicate logic. Nothing to simplify.

## Security review

Auth-hardening (fail-closed) change. Verified it introduces no new fail-open path and does not weaken state/CSRF handling:

- Every new branch resolves to `success: false`; no path now returns `success: true` that wasn't already success before.
- Uses strict `data.ok === false`, so providers that omit `ok` are unaffected; only an explicit `false` rejects.
- `bodyError` triggers only on a non-empty `error` string (empty string stays falsy), so legitimate success bodies are not falsely rejected.
- No state/nonce/CSRF logic touched; this is post-state-validation token parsing.
- Error returns surface only provider error codes / static fallbacks — no token or secret material leaked.

Verdict: PASS — no newly introduced >80%-confidence exploitable vulnerability.