### PR TITLE
Preserve multi-value Set-Cookie in Node handler (H3)

### DIFF
--- a/src/server/node-handler.test.ts
+++ b/src/server/node-handler.test.ts
@@ -1,0 +1,107 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { toNodeHandler } from "./node-handler.ts";
+
+type FakeRes = {
+  statusCode?: number;
+  writeHeadHeaders?: Record<string, unknown>;
+  setHeaderCalls: Array<[string, unknown]>;
+  chunks: Uint8Array[];
+  ended: boolean;
+  writeHead(status: number, headers?: Record<string, unknown>): void;
+  setHeader(name: string, value: unknown): void;
+  write(chunk: Uint8Array): void;
+  end(body?: string): void;
+};
+
+function createFakeRes(): FakeRes {
+  return {
+    setHeaderCalls: [],
+    chunks: [],
+    ended: false,
+    writeHead(status, headers) {
+      this.statusCode = status;
+      this.writeHeadHeaders = headers;
+    },
+    setHeader(name, value) {
+      this.setHeaderCalls.push([name, value]);
+    },
+    write(chunk) {
+      this.chunks.push(chunk);
+    },
+    end(_body) {
+      this.ended = true;
+    },
+  };
+}
+
+function createFakeReq(
+  init: { method?: string; url?: string; headers?: Record<string, string | string[] | undefined> },
+): import("node:http").IncomingMessage {
+  return {
+    method: init.method ?? "GET",
+    url: init.url ?? "/",
+    headers: { host: "localhost", ...(init.headers ?? {}) },
+  } as unknown as import("node:http").IncomingMessage;
+}
+
+function collectSetCookies(res: FakeRes): string[] {
+  // Prefer setHeader("Set-Cookie", [...]) emission.
+  const cookies: string[] = [];
+  for (const [name, value] of res.setHeaderCalls) {
+    if (name.toLowerCase() === "set-cookie") {
+      if (Array.isArray(value)) cookies.push(...(value as string[]));
+      else cookies.push(String(value));
+    }
+  }
+  // Fall back to writeHead headers (single comma-joined value triggers failure).
+  const headers = res.writeHeadHeaders;
+  if (headers) {
+    for (const key of Object.keys(headers)) {
+      if (key.toLowerCase() === "set-cookie") {
+        const value = headers[key];
+        if (Array.isArray(value)) cookies.push(...(value as string[]));
+        else cookies.push(String(value));
+      }
+    }
+  }
+  return cookies;
+}
+
+Deno.test("toNodeHandler preserves multiple Set-Cookie headers as distinct values", async () => {
+  const handler = () => {
+    const headers = new Headers();
+    headers.append("Set-Cookie", "a=1; Path=/");
+    headers.append("Set-Cookie", "b=2; Path=/");
+    return new Response("ok", { status: 200, headers });
+  };
+
+  const nodeHandler = toNodeHandler(handler);
+  const res = createFakeRes();
+  await nodeHandler(
+    createFakeReq({ url: "/" }),
+    res as unknown as import("node:http").ServerResponse,
+  );
+
+  const cookies = collectSetCookies(res);
+  assertEquals(cookies.length, 2);
+  assertEquals(cookies.includes("a=1; Path=/"), true);
+  assertEquals(cookies.includes("b=2; Path=/"), true);
+});
+
+Deno.test("toNodeHandler passes array-valued request headers through to the Request", async () => {
+  let seen: string | null = null;
+  const handler = (req: Request) => {
+    seen = req.headers.get("x-multi");
+    return new Response("ok", { status: 200 });
+  };
+
+  const nodeHandler = toNodeHandler(handler);
+  const res = createFakeRes();
+  await nodeHandler(
+    createFakeReq({ url: "/", headers: { "x-multi": ["one", "two"] } }),
+    res as unknown as import("node:http").ServerResponse,
+  );
+
+  // A collapsed-to-first-element bug would yield only "one".
+  assertEquals(seen, "one, two");
+});

--- a/src/server/node-handler.test.ts
+++ b/src/server/node-handler.test.ts
@@ -96,6 +96,53 @@ Deno.test("toNodeHandler preserves multiple Set-Cookie headers as distinct value
   assertEquals(cookies.includes("b=2; Path=/"), true);
 });
 
+Deno.test("toNodeHandler does not throw when getSetCookie is unavailable (early Node 18)", async () => {
+  // Simulate a runtime whose Headers predates Headers.prototype.getSetCookie
+  // (Node < ~18.14). We wrap a real Headers in a Proxy that hides getSetCookie
+  // while still exposing an iterator that yields each Set-Cookie as a distinct
+  // entry (matching undici's iteration behaviour). A real Response is returned
+  // but with its `headers` accessor pointed at the legacy-like object.
+  const realHeaders = new Headers();
+  realHeaders.append("Set-Cookie", "a=1; Path=/");
+  realHeaders.append("Set-Cookie", "b=2; Path=/");
+  realHeaders.set("content-type", "text/plain");
+
+  const legacyHeaders = new Proxy(realHeaders, {
+    get(target, prop, receiver) {
+      // Pretend getSetCookie does not exist on this runtime.
+      if (prop === "getSetCookie") return undefined;
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  }) as unknown as Headers;
+
+  const handler = () => {
+    const response = new Response("ok", { status: 200 });
+    Object.defineProperty(response, "headers", {
+      get: () => legacyHeaders,
+      configurable: true,
+    });
+    return response;
+  };
+
+  const nodeHandler = toNodeHandler(handler);
+  const res = createFakeRes();
+  await nodeHandler(
+    createFakeReq({ url: "/" }),
+    res as unknown as import("node:http").ServerResponse,
+  );
+
+  // Must not have fallen into the catch block and emitted a 500.
+  assertEquals(res.statusCode, 200);
+  assertEquals(res.ended, true);
+
+  // Fallback preserves both cookies when the iterator exposes them separately.
+  const cookies = collectSetCookies(res);
+  assertEquals(cookies.length, 2);
+  assertEquals(cookies.includes("a=1; Path=/"), true);
+  assertEquals(cookies.includes("b=2; Path=/"), true);
+});
+
 Deno.test("toNodeHandler passes array-valued request headers through to the Request", async () => {
   let seen: string | null = null;
   const handler = (req: Request) => {

--- a/src/server/node-handler.test.ts
+++ b/src/server/node-handler.test.ts
@@ -3,6 +3,7 @@ import { toNodeHandler } from "./node-handler.ts";
 
 type FakeRes = {
   statusCode?: number;
+  headersSent: boolean;
   writeHeadHeaders?: Record<string, unknown>;
   setHeaderCalls: Array<[string, unknown]>;
   chunks: Uint8Array[];
@@ -15,14 +16,21 @@ type FakeRes = {
 
 function createFakeRes(): FakeRes {
   return {
+    headersSent: false,
     setHeaderCalls: [],
     chunks: [],
     ended: false,
     writeHead(status, headers) {
+      // Mirror Node: the head can only be written once, and never after
+      // headers have already been flushed.
+      if (this.headersSent) throw new Error("ERR_HTTP_HEADERS_SENT");
       this.statusCode = status;
       this.writeHeadHeaders = headers;
+      this.headersSent = true;
     },
     setHeader(name, value) {
+      // Mirror Node: headers cannot be mutated once they have been sent.
+      if (this.headersSent) throw new Error("ERR_HTTP_HEADERS_SENT");
       this.setHeaderCalls.push([name, value]);
     },
     write(chunk) {

--- a/src/server/node-handler.ts
+++ b/src/server/node-handler.ts
@@ -26,14 +26,14 @@ export function toNodeHandler(
       const response = await handler(new Request(url.toString(), init));
 
       if (response.status === 101) return;
-      const outHeaders: Record<string, string> = {};
+      const outHeaders: Record<string, string | string[]> = {};
       for (const [key, value] of response.headers) {
         if (key.toLowerCase() === "set-cookie") continue;
         outHeaders[key] = value;
       }
-      res.writeHead(response.status, outHeaders);
       const setCookies = response.headers.getSetCookie();
-      if (setCookies.length > 0) res.setHeader("Set-Cookie", setCookies);
+      if (setCookies.length > 0) outHeaders["Set-Cookie"] = setCookies;
+      res.writeHead(response.status, outHeaders);
       if (response.body) {
         const reader = response.body.getReader();
         while (true) {

--- a/src/server/node-handler.ts
+++ b/src/server/node-handler.ts
@@ -7,10 +7,12 @@ export function toNodeHandler(
   return async (req, res) => {
     try {
       const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
-      const headers: Record<string, string> = {};
+      const headers = new Headers();
       for (const [key, value] of Object.entries(req.headers)) {
-        if (typeof value === "string") headers[key] = value;
-        else if (Array.isArray(value)) headers[key] = value[0] ?? "";
+        if (typeof value === "string") headers.append(key, value);
+        else if (Array.isArray(value)) {
+          for (const entry of value) headers.append(key, entry);
+        }
       }
       const method = req.method ?? "GET";
       const body = method === "GET" || method === "HEAD" ? null : req;
@@ -24,7 +26,14 @@ export function toNodeHandler(
       const response = await handler(new Request(url.toString(), init));
 
       if (response.status === 101) return;
-      res.writeHead(response.status, Object.fromEntries(response.headers));
+      const outHeaders: Record<string, string> = {};
+      for (const [key, value] of response.headers) {
+        if (key.toLowerCase() === "set-cookie") continue;
+        outHeaders[key] = value;
+      }
+      res.writeHead(response.status, outHeaders);
+      const setCookies = response.headers.getSetCookie();
+      if (setCookies.length > 0) res.setHeader("Set-Cookie", setCookies);
       if (response.body) {
         const reader = response.body.getReader();
         while (true) {

--- a/src/server/node-handler.ts
+++ b/src/server/node-handler.ts
@@ -27,11 +27,34 @@ export function toNodeHandler(
 
       if (response.status === 101) return;
       const outHeaders: Record<string, string | string[]> = {};
-      for (const [key, value] of response.headers) {
-        if (key.toLowerCase() === "set-cookie") continue;
-        outHeaders[key] = value;
+      const setCookies: string[] = [];
+      // Headers.prototype.getSetCookie landed in Node ~18.14, but our published
+      // engines.node is ">=18.0.0". On early 18.x it is undefined, so calling it
+      // unconditionally throws for every response and turns valid requests into
+      // 500s. Feature-detect it and fall back to the header iterator.
+      const getSetCookie = response.headers.getSetCookie;
+      if (typeof getSetCookie === "function") {
+        // Modern path: getSetCookie returns each Set-Cookie as a distinct value.
+        setCookies.push(...getSetCookie.call(response.headers));
+        for (const [key, value] of response.headers) {
+          if (key.toLowerCase() === "set-cookie") continue;
+          outHeaders[key] = value;
+        }
+      } else {
+        // Fallback for runtimes without getSetCookie. The undici-based Headers
+        // iterator yields each Set-Cookie as its own entry (it is the one header
+        // that is NOT comma-joined during iteration), so iterating preserves
+        // multiples where the platform allows it. If a runtime does collapse
+        // them into a single comma-joined string we still pass that one value
+        // through unchanged rather than throwing — degrade gracefully, never 500.
+        for (const [key, value] of response.headers) {
+          if (key.toLowerCase() === "set-cookie") {
+            setCookies.push(value);
+            continue;
+          }
+          outHeaders[key] = value;
+        }
       }
-      const setCookies = response.headers.getSetCookie();
       if (setCookies.length > 0) outHeaders["Set-Cookie"] = setCookies;
       res.writeHead(response.status, outHeaders);
       if (response.body) {


### PR DESCRIPTION
## Summary
- Fixes bug H3: the Node handler used `Object.fromEntries(response.headers)`, which collapsed repeated headers (corrupting multiple `Set-Cookie`) and dropped array-valued request headers via `value[0]`.
- Request headers are now built into a `Headers` object, appending every value of array-valued headers (e.g. duplicated request headers) instead of keeping only the first.
- Response `Set-Cookie` headers are read via `response.headers.getSetCookie()` and emitted as a distinct array so each cookie is sent as its own header line.

## Test plan
- `deno test src/server/node-handler.test.ts` plus `service-server*.test.ts` — 6 passed, 0 failed.
- New tests assert (a) multiple `Set-Cookie` headers survive as distinct values and (b) array-valued request headers reach the `Request` (`x-multi: ["one","two"]` -> `"one, two"`).
- `deno fmt` + `deno lint` clean on changed files.
- Full suite ran green via the pre-push hook (1925 passed, 0 failed).

## Simplify pass
- Found that emitting `Set-Cookie` via `res.setHeader("Set-Cookie", ...)` *after* `res.writeHead()` throws `ERR_HTTP_HEADERS_SENT` in real Node and silently drops the cookies — the original fix only passed because the test mock did not enforce Node's headers-sent invariant.
- Simplified and corrected by placing the `Set-Cookie` array directly into the `writeHead` headers object (Node preserves array header values as distinct lines), removing the separate post-`writeHead` `setHeader` call.
- Hardened the test mock to throw on `writeHead`/`setHeader` after headers are sent, so this regression class is caught going forward.

## Security review
- Reviewed `git diff main...HEAD` for newly introduced, exploitable vulnerabilities, focused on header / response-splitting injection.
- No injection path: request header values flow through the Web `Headers` API and response values originate from a Web `Response`'s `Headers`; both reject CR/LF, so header/response splitting cannot be introduced. Malformed input throws and is caught, returning 500.
- Verdict: PASS (no newly introduced exploitable vulnerabilities).