### PR TITLE
Settle abandoned iterator.next() in child-stream watchdog (H2)

### DIFF
--- a/src/agent/hosted/child-stream-watchdog.test.ts
+++ b/src/agent/hosted/child-stream-watchdog.test.ts
@@ -196,6 +196,70 @@ Deno.test("withHostedChildStreamIdleTimeout settles an abandoned next() when the
   }
 });
 
+Deno.test("withHostedChildStreamIdleTimeout surfaces the original error when return() throws synchronously", async () => {
+  // A custom async iterable whose return() throws *synchronously* during
+  // cleanup must not let that throw escape the finally and replace the original
+  // idle-timeout error. Cleanup failures stay fire-and-forget.
+  let rejectPendingNext: ((reason: unknown) => void) | null = null;
+
+  const iterator: AsyncIterator<number> = {
+    next() {
+      return new Promise<IteratorResult<number>>((_resolve, reject) => {
+        rejectPendingNext = reject;
+      });
+    },
+    return() {
+      // Synchronous throw — evaluated before any Promise wraps it.
+      throw new Error("synchronous cleanup failure");
+    },
+  };
+
+  const stream: AsyncIterable<number> = {
+    [Symbol.asyncIterator]: () => iterator,
+  };
+
+  const unhandled: PromiseRejectionEvent[] = [];
+  const onUnhandled = (event: PromiseRejectionEvent) => {
+    unhandled.push(event);
+    event.preventDefault();
+  };
+  globalThis.addEventListener("unhandledrejection", onUnhandled);
+
+  try {
+    // Must reject with the ORIGINAL idle-timeout error, not the cleanup throw.
+    await assertRejects(
+      async () => {
+        for await (
+          const _value of withHostedChildStreamIdleTimeout({
+            stream,
+            getWatchdogState: () => ({
+              phase: "generic_idle",
+              timeoutMs: 5,
+            }),
+          })
+        ) {
+          // never yields; the iterator stalls until rejected below
+        }
+      },
+      HostedChildStreamIdleTimeoutError,
+    );
+
+    // Settle the abandoned next() so its rejection does not surface either.
+    rejectPendingNext?.(new Error("stream aborted after watchdog gave up"));
+
+    // Let microtasks/macrotasks flush so any unhandled rejection would surface.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    assertEquals(
+      unhandled.length,
+      0,
+      "synchronous return() failure must not escape as an unhandled rejection",
+    );
+  } finally {
+    globalThis.removeEventListener("unhandledrejection", onUnhandled);
+  }
+});
+
 Deno.test("withHostedChildStreamIdleTimeout continues when timeout callback asks to retry", async () => {
   async function* stallingThenResumingStream() {
     yield 1;

--- a/src/agent/hosted/child-stream-watchdog.test.ts
+++ b/src/agent/hosted/child-stream-watchdog.test.ts
@@ -131,6 +131,71 @@ Deno.test("withHostedChildStreamIdleTimeout throws when stream stalls", async ()
   assertEquals(values, [1]);
 });
 
+Deno.test("withHostedChildStreamIdleTimeout settles an abandoned next() when the watchdog throws", async () => {
+  // The underlying stream's pending next() rejects *after* the idle timeout
+  // fires. Without handling, this becomes an unhandled rejection that can crash
+  // the process. The watchdog must settle the abandoned iterator before throwing.
+  let rejectPendingNext: ((reason: unknown) => void) | null = null;
+  let returnCalled = false;
+
+  const iterator: AsyncIterator<number> = {
+    next() {
+      return new Promise<IteratorResult<number>>((_resolve, reject) => {
+        rejectPendingNext = reject;
+      });
+    },
+    return() {
+      returnCalled = true;
+      return Promise.resolve({ done: true, value: undefined });
+    },
+  };
+
+  const stream: AsyncIterable<number> = {
+    [Symbol.asyncIterator]: () => iterator,
+  };
+
+  const unhandled: PromiseRejectionEvent[] = [];
+  const onUnhandled = (event: PromiseRejectionEvent) => {
+    unhandled.push(event);
+    event.preventDefault();
+  };
+  globalThis.addEventListener("unhandledrejection", onUnhandled);
+
+  try {
+    await assertRejects(
+      async () => {
+        for await (
+          const _value of withHostedChildStreamIdleTimeout({
+            stream,
+            getWatchdogState: () => ({
+              phase: "generic_idle",
+              timeoutMs: 5,
+            }),
+          })
+        ) {
+          // never yields; the iterator stalls until rejected below
+        }
+      },
+      HostedChildStreamIdleTimeoutError,
+    );
+
+    // Now reject the promise the watchdog abandoned when it threw.
+    rejectPendingNext?.(new Error("stream aborted after watchdog gave up"));
+
+    // Let microtasks/macrotasks flush so any unhandled rejection would surface.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    assertEquals(
+      unhandled.length,
+      0,
+      "abandoned iterator.next() rejection must not escape as an unhandled rejection",
+    );
+    assert(returnCalled, "watchdog should settle the iterator via return()");
+  } finally {
+    globalThis.removeEventListener("unhandledrejection", onUnhandled);
+  }
+});
+
 Deno.test("withHostedChildStreamIdleTimeout continues when timeout callback asks to retry", async () => {
   async function* stallingThenResumingStream() {
     yield 1;

--- a/src/agent/hosted/child-stream-watchdog.ts
+++ b/src/agent/hosted/child-stream-watchdog.ts
@@ -137,7 +137,11 @@ export async function* withHostedChildStreamIdleTimeout<T>(input: {
     }
     // Fire-and-forget: do not await, because a stalled generator's return()
     // chains onto the unsettled next() body and would itself never resolve.
-    void Promise.resolve(iterator.return?.()).catch(() => {});
+    // Defer the call via Promise.resolve().then(...) so a *synchronous* throw
+    // from a custom iterator's return() becomes a rejected promise that the
+    // no-op catch swallows — otherwise it would escape this finally and mask
+    // the original idle-timeout/abort error (or a normal done return).
+    void Promise.resolve().then(() => iterator.return?.()).catch(() => {});
   }
 }
 

--- a/src/agent/hosted/child-stream-watchdog.ts
+++ b/src/agent/hosted/child-stream-watchdog.ts
@@ -83,48 +83,61 @@ export async function* withHostedChildStreamIdleTimeout<T>(input: {
   const iterator = input.stream[Symbol.asyncIterator]();
   let pendingNext: Promise<IteratorResult<T>> | null = null;
 
-  while (true) {
-    throwIfChildRunAborted(input.abortSignal);
+  try {
+    while (true) {
+      throwIfChildRunAborted(input.abortSignal);
 
-    let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
-    const watchdogState = input.getWatchdogState();
-    if (!pendingNext) {
-      pendingNext = iterator.next();
-    }
+      let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
+      const watchdogState = input.getWatchdogState();
+      if (!pendingNext) {
+        pendingNext = iterator.next();
+      }
 
-    try {
-      const result = await Promise.race<
-        IteratorResult<T> | typeof HOSTED_CHILD_STREAM_TIMEOUT_TOKEN
-      >([
-        pendingNext,
-        new Promise<typeof HOSTED_CHILD_STREAM_TIMEOUT_TOKEN>((resolve) => {
-          timeoutId = globalThis.setTimeout(() => {
-            resolve(HOSTED_CHILD_STREAM_TIMEOUT_TOKEN);
-          }, watchdogState.timeoutMs);
-        }),
-      ]);
+      try {
+        const result = await Promise.race<
+          IteratorResult<T> | typeof HOSTED_CHILD_STREAM_TIMEOUT_TOKEN
+        >([
+          pendingNext,
+          new Promise<typeof HOSTED_CHILD_STREAM_TIMEOUT_TOKEN>((resolve) => {
+            timeoutId = globalThis.setTimeout(() => {
+              resolve(HOSTED_CHILD_STREAM_TIMEOUT_TOKEN);
+            }, watchdogState.timeoutMs);
+          }),
+        ]);
 
-      if (result === HOSTED_CHILD_STREAM_TIMEOUT_TOKEN) {
-        const action = await input.onIdleTimeout?.(watchdogState);
-        if (action === "continue") {
-          continue;
+        if (result === HOSTED_CHILD_STREAM_TIMEOUT_TOKEN) {
+          const action = await input.onIdleTimeout?.(watchdogState);
+          if (action === "continue") {
+            continue;
+          }
+
+          throw new HostedChildStreamIdleTimeoutError(watchdogState);
         }
 
-        throw new HostedChildStreamIdleTimeoutError(watchdogState);
-      }
+        pendingNext = null;
 
-      pendingNext = null;
+        if (result.done) {
+          return;
+        }
 
-      if (result.done) {
-        return;
-      }
-
-      yield result.value;
-    } finally {
-      if (timeoutId) {
-        globalThis.clearTimeout(timeoutId);
+        yield result.value;
+      } finally {
+        if (timeoutId) {
+          globalThis.clearTimeout(timeoutId);
+        }
       }
     }
+  } finally {
+    // If we exit while an iterator.next() is still in flight (idle timeout or
+    // abort threw before it settled), attach a no-op catch so its eventual
+    // rejection — the caller typically aborts the stream — does not surface as
+    // an unhandled promise rejection, and settle the underlying iterator.
+    if (pendingNext) {
+      void pendingNext.catch(() => {});
+    }
+    // Fire-and-forget: do not await, because a stalled generator's return()
+    // chains onto the unsettled next() body and would itself never resolve.
+    void Promise.resolve(iterator.return?.()).catch(() => {});
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes bug H2: the hosted child-stream idle-timeout watchdog (`withHostedChildStreamIdleTimeout`) abandoned an in-flight `iterator.next()` when it threw on idle timeout or abort. Because nothing was attached to that pending promise, its eventual rejection (the caller typically aborts the underlying stream) surfaced as an unhandled promise rejection, which can crash the process.

The loop is now wrapped in a `try`/`finally`. On any exit while a `next()` is still pending, the watchdog:
- attaches a no-op `.catch()` to the abandoned `pendingNext` so its later rejection is swallowed instead of going unhandled, and
- fire-and-forget settles the underlying iterator via `iterator.return?.()` (not awaited, since a stalled generator's `return()` chains onto the unsettled `next()` body and would never resolve).

## Test plan

Command:
`VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net $(find src/agent/hosted -name '*.test.ts')`

Result: **209 passed (118 steps) | 0 failed**.

New regression test `withHostedChildStreamIdleTimeout settles an abandoned next() when the watchdog throws` installs an `unhandledrejection` listener, drives the watchdog to time out with a stalled `next()`, then rejects the abandoned promise and asserts no unhandled rejection escapes and that `return()` was called.

`deno fmt` and `DENO_NO_PACKAGE_JSON=1 deno lint` on the changed files are clean. The pre-push hook ran the full suite: **1924 passed | 0 failed**.

## Simplify pass

Reviewed `git diff main...HEAD`. The diff is minimal — the bulk is indentation churn from wrapping the existing `while` loop in `try`/`finally`. No dead code, no reuse or clarity improvements available; the comments are accurate and load-bearing. No simplification commit was needed.

## Security review

Reviewed `git diff main...HEAD` for newly-introduced, high-confidence, exploitable vulnerabilities (excluding DoS/resource/secrets). The change only suppresses an unhandled promise rejection and fire-and-forget settles an iterator — no new untrusted-input handling, no injection/auth/path/redirect surface. Verdict: **no new vulnerabilities**.