### PR TITLE
Harden route param decoding and optional catch-all matching (H4, H5)

### DIFF
--- a/src/routing/api/api-route-matcher.test.ts
+++ b/src/routing/api/api-route-matcher.test.ts
@@ -16,6 +16,26 @@ afterEach((): void => {
 });
 
 describe("ApiRouteMatcher", () => {
+  describe("Malformed percent-encoding", () => {
+    it("does not throw on malformed encoding in a dynamic segment", () => {
+      const router = createRouter();
+      router.addRoute("/api/users/[id]", "pages/api/users/[id].ts");
+
+      const match = router.match("/api/users/%zz");
+      assertExists(match);
+      assertEquals(match.params.id, "%zz");
+    });
+
+    it("does not throw on malformed encoding in a catch-all segment", () => {
+      const router = createRouter();
+      router.addRoute("/api/files/[...path]", "pages/api/files/[...path].ts");
+
+      const match = router.match("/api/files/ok/%zz");
+      assertExists(match);
+      assertEquals(match.params.path, ["ok", "%zz"]);
+    });
+  });
+
   describe("Static routes", () => {
     it("matches exact static routes", () => {
       const router = createRouter();

--- a/src/routing/api/api-route-matcher.ts
+++ b/src/routing/api/api-route-matcher.ts
@@ -1,6 +1,7 @@
 import type { Route, RouteMatch } from "#veryfront/routing/matchers/types.ts";
 import { getDisableLruIntervalEnv } from "#veryfront/config/env.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
+import { safeDecodeParam } from "#veryfront/routing/matchers/decode-param.ts";
 
 /** Max entries in the route-match LRU cache */
 const ROUTE_CACHE_MAX_ENTRIES = 500;
@@ -155,11 +156,11 @@ export class ApiRouteMatcher {
 
       if (catchAllParamNames.has(paramName)) {
         const segments = value ? value.split("/").filter((segment) => segment.length > 0) : [];
-        params[paramName] = segments.map((segment) => decodeURIComponent(segment));
+        params[paramName] = segments.map((segment) => safeDecodeParam(segment));
         continue;
       }
 
-      params[paramName] = decodeURIComponent(value ?? "");
+      params[paramName] = safeDecodeParam(value ?? "");
     }
 
     return params;

--- a/src/routing/matchers/decode-param.ts
+++ b/src/routing/matchers/decode-param.ts
@@ -1,0 +1,15 @@
+/**
+ * Decode a single URL path segment, tolerating malformed percent-encoding.
+ *
+ * `decodeURIComponent` throws `URIError` on invalid sequences (e.g. `%zz`).
+ * For route param extraction we prefer to fall back to the raw value so a
+ * malformed request yields a normal route miss / 4xx instead of crashing.
+ */
+export function safeDecodeParam(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch (error) {
+    if (error instanceof URIError) return value;
+    throw error;
+  }
+}

--- a/src/routing/matchers/route-matcher.test.ts
+++ b/src/routing/matchers/route-matcher.test.ts
@@ -70,5 +70,19 @@ describe("route-matcher", () => {
 
       assertEquals(match?.params.id, "42");
     });
+
+    it("should not throw on malformed percent-encoding in dynamic param", () => {
+      const route = parseRoute("/users/[id]", "user.tsx");
+      const match = matchRoute("/users/%zz", route);
+
+      assertEquals(match?.params.id, "%zz");
+    });
+
+    it("should not throw on malformed percent-encoding in catch-all segment", () => {
+      const route = parseRoute("/files/[...path]", "files.tsx");
+      const match = matchRoute("/files/ok/%zz", route);
+
+      assertEquals(match?.params.path, ["ok", "%zz"]);
+    });
   });
 });

--- a/src/routing/matchers/route-matcher.ts
+++ b/src/routing/matchers/route-matcher.ts
@@ -1,4 +1,5 @@
 import type { Route, RouteMatch } from "./types.ts";
+import { safeDecodeParam } from "./decode-param.ts";
 
 const CATCH_ALL_PATTERN = /\[\[?\.\.\.(\w+)\]\]?/g;
 
@@ -20,7 +21,7 @@ function decodeCatchAllValue(value?: string): string[] {
   return value
     .split("/")
     .filter(Boolean)
-    .map((segment) => decodeURIComponent(segment));
+    .map((segment) => safeDecodeParam(segment));
 }
 
 export function matchRoute(pathname: string, route: Route): RouteMatch | null {
@@ -32,9 +33,7 @@ export function matchRoute(pathname: string, route: Route): RouteMatch | null {
 
   for (const [index, name] of (route.paramNames ?? []).entries()) {
     const value = match[index + 1] ?? "";
-    params[name] = catchAllParams.has(name)
-      ? decodeCatchAllValue(value)
-      : decodeURIComponent(value);
+    params[name] = catchAllParams.has(name) ? decodeCatchAllValue(value) : safeDecodeParam(value);
   }
 
   return { params, route };

--- a/src/routing/slug-mapper/dynamic-route-matcher.test.ts
+++ b/src/routing/slug-mapper/dynamic-route-matcher.test.ts
@@ -199,6 +199,18 @@ describe("dynamic-route-matcher", () => {
     it("should handle empty slug with non-empty pattern", () => {
       expect(extractParams("blog/[slug]", "")).toBeNull();
     });
+
+    it("should extract optional catch-all with zero segments", () => {
+      expect(extractParams("/blog/[[...slug]]", "/blog")).toEqual({ slug: [] });
+    });
+
+    it("should extract optional catch-all with multiple segments", () => {
+      expect(extractParams("/blog/[[...slug]]", "/blog/a/b")).toEqual({ slug: ["a", "b"] });
+    });
+
+    it("should extract optional catch-all without leading slashes", () => {
+      expect(extractParams("blog/[[...slug]]", "blog/a/b/c")).toEqual({ slug: ["a", "b", "c"] });
+    });
   });
 
   describe("matchesPattern", () => {

--- a/src/routing/slug-mapper/dynamic-route-matcher.ts
+++ b/src/routing/slug-mapper/dynamic-route-matcher.ts
@@ -1,12 +1,20 @@
 import type { RouteParams } from "./types.ts";
 export { isDynamicRoute } from "#veryfront/utils/route-path-utils.ts";
 
+function isOptionalSpreadParam(part: string): boolean {
+  return part.startsWith("[[...") && part.endsWith("]]");
+}
+
 function isSpreadParam(part: string): boolean {
-  return part.startsWith("[...") && part.endsWith("]");
+  return isOptionalSpreadParam(part) || (part.startsWith("[...") && part.endsWith("]"));
 }
 
 function isDynamicParam(part: string): boolean {
   return part.startsWith("[") && part.endsWith("]");
+}
+
+function spreadParamName(part: string): string {
+  return isOptionalSpreadParam(part) ? part.slice(5, -2) : part.slice(4, -1);
 }
 
 export function extractParams(pattern: string, slug: string): RouteParams | null {
@@ -23,7 +31,7 @@ export function extractParams(pattern: string, slug: string): RouteParams | null
 
   for (const patternPart of patternParts) {
     if (isSpreadParam(patternPart)) {
-      const paramName = patternPart.slice(4, -1);
+      const paramName = spreadParamName(patternPart);
       params[paramName] = slugParts.slice(slugIndex);
       return params;
     }


### PR DESCRIPTION
## Summary

Two routing correctness/robustness fixes:

- **H4 — malformed percent-encoding crashed requests.** `decodeURIComponent` throws `URIError` on inputs like `%zz`; the page matcher (`route-matcher.ts`) and `ApiRouteMatcher.extractParams` called it unguarded, and `APIRouteHandler.handle` did not wrap `match()`, so `GET /api/users/%zz` produced an unhandled error / 500. Added `src/routing/matchers/decode-param.ts` (`safeDecodeParam`) which falls back to the raw value on `URIError`, so a malformed segment yields a normal route value/miss (4xx) instead of an exception. Used by both matchers.
- **H5 — optional catch-all `[[...slug]]` never matched.** `isSpreadParam` was false for `[[...slug]]`, so it was misclassified as a single dynamic segment with a garbage param name (`[...slug`) and the length guard rejected zero/multi-segment inputs. Now detected explicitly, allows zero remaining segments, and strips the correct brackets for the param name. Normal `[...slug]` and `[id]` behavior unchanged.

## Test plan

`deno test ... $(find src/routing -name '*.test.ts')` → **37 passed (897 steps) / 0 failed**. New tests cover: matchers do not throw on `%zz` in dynamic and catch-all segments; `extractParams("/blog/[[...slug]]", "/blog")` → `{ slug: [] }` and `.../a/b` → `{ slug: ["a","b"] }`. `deno fmt --check` and `deno lint` clean on all 7 changed files.

## Simplify pass

No changes needed — the fix is minimal: one shared `safeDecodeParam` helper reused by both matchers, and a focused change in the slug-mapper. No duplication or dead code to remove.

## Security review

No new vulnerabilities. The `safeDecodeParam` raw-value fallback triggers only on `URIError` from malformed encoding; valid encodings such as `%2e%2e%2f` (`../`) decode identically to before, and the fallback string retains a literal `%` and is not re-decoded — so no new path-traversal or route-matching bypass is introduced.