### PR TITLE
Expose hosted stream timeouts as terminal failures

### DIFF
--- a/src/agent/hosted/cloud-prepared-chat-execution-runtime.test.ts
+++ b/src/agent/hosted/cloud-prepared-chat-execution-runtime.test.ts
@@ -3,7 +3,10 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createChatStreamWatchdog } from "#veryfront/chat/stream-watchdog.ts";
 import type { AgentTraceAttributes } from "./trace-attributes.ts";
 import type { HostedAgentRunTracer } from "./agent-run-lifecycle.ts";
-import { createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions } from "./cloud-prepared-chat-execution-runtime.ts";
+import {
+  createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions,
+  resolveVeryfrontCloudChatStreamWatchdogOptions,
+} from "./cloud-prepared-chat-execution-runtime.ts";
 
 function createTracer(): HostedAgentRunTracer {
   return {
@@ -59,5 +62,28 @@ describe("agent/veryfront-cloud-prepared-hosted-chat-execution-runtime", () => {
     });
 
     assertStrictEquals(options.createRootStreamWatchdog, createRootStreamWatchdog);
+  });
+
+  it("resolves chat stream watchdog timeouts from environment values", () => {
+    assertEquals(
+      resolveVeryfrontCloudChatStreamWatchdogOptions({
+        VERYFRONT_CHAT_STREAM_IDLE_TIMEOUT_MS: "45000",
+        VERYFRONT_CHAT_STREAM_TOOL_TIMEOUT_MS: "180000",
+      }),
+      {
+        idleTimeoutMs: 45_000,
+        toolRunningTimeoutMs: 180_000,
+      },
+    );
+  });
+
+  it("ignores invalid chat stream watchdog timeout environment values", () => {
+    assertEquals(
+      resolveVeryfrontCloudChatStreamWatchdogOptions({
+        VERYFRONT_CHAT_STREAM_IDLE_TIMEOUT_MS: "0",
+        VERYFRONT_CHAT_STREAM_TOOL_TIMEOUT_MS: "not-a-number",
+      }),
+      {},
+    );
   });
 });

--- a/src/agent/hosted/cloud-prepared-chat-execution-runtime.ts
+++ b/src/agent/hosted/cloud-prepared-chat-execution-runtime.ts
@@ -1,8 +1,44 @@
-import { createChatStreamWatchdog } from "#veryfront/chat/stream-watchdog.ts";
+import {
+  type ChatStreamWatchdogOptions,
+  createChatStreamWatchdog,
+} from "#veryfront/chat/stream-watchdog.ts";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
 import { getVeryfrontCloudProviderFromModelId } from "#veryfront/provider";
 import type { AgentTraceAttributes } from "./trace-attributes.ts";
 import type { HostedChatExecutionRuntimeLogger } from "./chat-execution-runtime.ts";
 import type { PreparedHostedChatExecutionRuntimeOptions } from "./prepared-chat-execution.ts";
+
+/** Environment key for hosted chat stream idle timeout. */
+export const VERYFRONT_CHAT_STREAM_IDLE_TIMEOUT_ENV = "VERYFRONT_CHAT_STREAM_IDLE_TIMEOUT_MS";
+/** Environment key for hosted chat stream active tool timeout. */
+export const VERYFRONT_CHAT_STREAM_TOOL_TIMEOUT_ENV = "VERYFRONT_CHAT_STREAM_TOOL_TIMEOUT_MS";
+
+type ChatStreamWatchdogEnv = Record<string, string | undefined>;
+
+function parsePositiveInteger(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+/** Resolve Veryfront Cloud chat stream watchdog timeout overrides from environment values. */
+export function resolveVeryfrontCloudChatStreamWatchdogOptions(
+  env: ChatStreamWatchdogEnv = {
+    [VERYFRONT_CHAT_STREAM_IDLE_TIMEOUT_ENV]: getEnv(VERYFRONT_CHAT_STREAM_IDLE_TIMEOUT_ENV),
+    [VERYFRONT_CHAT_STREAM_TOOL_TIMEOUT_ENV]: getEnv(VERYFRONT_CHAT_STREAM_TOOL_TIMEOUT_ENV),
+  },
+): Pick<ChatStreamWatchdogOptions, "idleTimeoutMs" | "toolRunningTimeoutMs"> {
+  const idleTimeoutMs = parsePositiveInteger(env[VERYFRONT_CHAT_STREAM_IDLE_TIMEOUT_ENV]);
+  const toolRunningTimeoutMs = parsePositiveInteger(env[VERYFRONT_CHAT_STREAM_TOOL_TIMEOUT_ENV]);
+
+  return {
+    ...(idleTimeoutMs !== undefined ? { idleTimeoutMs } : {}),
+    ...(toolRunningTimeoutMs !== undefined ? { toolRunningTimeoutMs } : {}),
+  };
+}
 
 /** Input payload for create Veryfront Cloud prepared hosted chat execution runtime options. */
 export type CreateVeryfrontCloudPreparedHostedChatExecutionRuntimeOptionsInput = {
@@ -28,6 +64,7 @@ export function createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions(
     createRootStreamWatchdog: input.createRootStreamWatchdog ??
       (() =>
         createChatStreamWatchdog({
+          ...resolveVeryfrontCloudChatStreamWatchdogOptions(),
           setTimeoutFn: globalThis.setTimeout,
           clearTimeoutFn: globalThis.clearTimeout,
         })),

--- a/src/agent/hosted/stream-terminal-error.test.ts
+++ b/src/agent/hosted/stream-terminal-error.test.ts
@@ -22,6 +22,13 @@ Deno.test("getHostedStreamErrorText recognizes credit limit errors", () => {
   assertStringIncludes(getHostedStreamErrorText(new Error("AI credit limit exceeded")), "credit");
 });
 
+Deno.test("getHostedStreamErrorText makes hosted stream timeouts transparent", () => {
+  assertEquals(
+    getHostedStreamErrorText(new Error("Stream timed out after 5 minutes")),
+    "This run timed out after 5 minutes before the agent finished. Try again to continue, or narrow the request.",
+  );
+});
+
 Deno.test("getEmptyHostedFinalizedMessageTerminalError returns default empty response error", () => {
   const result = getEmptyHostedFinalizedMessageTerminalError({ finalStep: null });
   assertEquals(result.code, "EMPTY_RESPONSE");
@@ -35,6 +42,20 @@ Deno.test("getEmptyHostedFinalizedMessageTerminalError returns stream error when
       streamError: new Error("connection lost"),
     }),
     { code: "STREAM_ERROR", message: "connection lost" },
+  );
+});
+
+Deno.test("getEmptyHostedFinalizedMessageTerminalError returns stream timeout when present", () => {
+  assertEquals(
+    getEmptyHostedFinalizedMessageTerminalError({
+      finalStep: null,
+      streamError: new Error("Chat stream idle timeout after 300000ms during tool_running"),
+    }),
+    {
+      code: "STREAM_TIMEOUT",
+      message:
+        "This run timed out after 5 minutes before the agent finished. Try again to continue, or narrow the request.",
+    },
   );
 });
 

--- a/src/agent/hosted/stream-terminal-error.ts
+++ b/src/agent/hosted/stream-terminal-error.ts
@@ -7,6 +7,52 @@ const EMPTY_RESPONSE_TERMINAL_ERROR_MESSAGE = "Assistant completed without produ
 const EXTERNAL_SERVICE_ERROR_CODE = "EXTERNAL_SERVICE_ERROR";
 const EXTERNAL_SERVICE_ERROR_MESSAGE = "LLM provider service error";
 const STREAM_ERROR_TERMINAL_ERROR_CODE = "STREAM_ERROR";
+const STREAM_TIMEOUT_TERMINAL_ERROR_CODE = "STREAM_TIMEOUT";
+
+function formatTimeoutDuration(input: string): string | null {
+  const minuteMatch = input.match(/after\s+(\d+)\s+minutes?/i);
+  if (minuteMatch) {
+    const minutes = Number.parseInt(minuteMatch[1] ?? "", 10);
+    if (Number.isFinite(minutes) && minutes > 0) {
+      return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+    }
+  }
+
+  const millisecondMatch = input.match(/after\s+(\d+)\s*ms/i);
+  if (millisecondMatch) {
+    const milliseconds = Number.parseInt(millisecondMatch[1] ?? "", 10);
+    if (Number.isFinite(milliseconds) && milliseconds > 0) {
+      const seconds = Math.round(milliseconds / 1000);
+      if (seconds >= 60 && seconds % 60 === 0) {
+        const minutes = seconds / 60;
+        return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+      }
+      return `${seconds} ${seconds === 1 ? "second" : "seconds"}`;
+    }
+  }
+
+  return null;
+}
+
+function getHostedStreamTimeoutTerminalError(error: unknown): HostedStreamTerminalError | null {
+  const message = getUnknownErrorMessage(error).trim();
+  const normalized = message.toLowerCase();
+  const isTimeout = normalized.includes("stream timed out") ||
+    normalized.includes("chat stream idle timeout") ||
+    normalized.includes("stream timeout");
+
+  if (!isTimeout) {
+    return null;
+  }
+
+  const duration = formatTimeoutDuration(message);
+  return {
+    code: STREAM_TIMEOUT_TERMINAL_ERROR_CODE,
+    message: duration
+      ? `This run timed out after ${duration} before the agent finished. Try again to continue, or narrow the request.`
+      : "This run timed out before the agent finished. Try again to continue, or narrow the request.",
+  };
+}
 
 /** Error shape for hosted stream terminal. */
 export type HostedStreamTerminalError = {
@@ -33,6 +79,11 @@ function getUnknownErrorMessage(error: unknown): string {
 function getHostedStreamTerminalError(streamError: unknown): HostedStreamTerminalError | null {
   if (streamError == null) {
     return null;
+  }
+
+  const timeoutError = getHostedStreamTimeoutTerminalError(streamError);
+  if (timeoutError) {
+    return timeoutError;
   }
 
   const parsedError = parseProviderError(streamError);


### PR DESCRIPTION
Adds configurable hosted chat stream watchdog timeouts and maps stream timeout failures to STREAM_TIMEOUT with transparent retry guidance.

Verification:
- deno test --no-check --allow-all src/agent/hosted/cloud-prepared-chat-execution-runtime.test.ts src/agent/hosted/stream-terminal-error.test.ts src/chat/stream-watchdog.test.ts src/agent/hosted/chat-execution-runtime.test.ts src/agent/hosted/prepared-chat-execution.test.ts
- deno check src/agent/hosted/cloud-prepared-chat-execution-runtime.ts src/agent/hosted/cloud-prepared-chat-execution-runtime.test.ts src/agent/hosted/stream-terminal-error.ts src/agent/hosted/stream-terminal-error.test.ts
- deno fmt --check touched files
- git diff --check
- pre-push hook: 1937 passed (17732 steps), 0 failed