### PR TITLE
fix: proactively evict caches under memory pressure to prevent OOM

### DIFF
--- a/src/server/shared/renderer/memory/pressure.ts
+++ b/src/server/shared/renderer/memory/pressure.ts
@@ -17,11 +17,18 @@
 import { rendererLogger } from "#veryfront/utils";
 import { getHeapStats } from "#veryfront/utils/memory/index.ts";
 import { getEnvNumber, getEnvString } from "#veryfront/compat/process.ts";
+import { clearHttpBundleCaches } from "#veryfront/transforms/esm/http-cache-state.ts";
 
 const memoryPressureLog = rendererLogger.component("memory-pressure");
 const rendererLog = rendererLogger.component("renderer");
 
 type MemoryPressureLevel = "normal" | "warning" | "high" | "critical";
+
+/** Minimum interval between cache evictions to avoid thrashing (5 seconds) */
+const MIN_EVICTION_INTERVAL_MS = 5_000;
+
+/** Track last eviction time to prevent thrashing */
+let lastEvictionTime = 0;
 
 function parseEnvThreshold(name: string, fallback: number): number {
   const value = getEnvString(name);
@@ -52,8 +59,35 @@ function getMemoryPressure(): { level: MemoryPressureLevel; heapUsedPercent: num
   return { level: "normal", heapUsedPercent };
 }
 
+/**
+ * Evict caches when memory pressure is high or critical.
+ * Returns true if eviction was performed.
+ */
+function evictCachesIfNeeded(level: MemoryPressureLevel, heapUsedPercent: number): boolean {
+  if (level !== "high" && level !== "critical") return false;
+
+  const now = Date.now();
+  if (now - lastEvictionTime < MIN_EVICTION_INTERVAL_MS) return false;
+
+  lastEvictionTime = now;
+
+  const entriesCleared = clearHttpBundleCaches();
+
+  memoryPressureLog.warn("Evicted caches due to memory pressure", {
+    level,
+    heapUsedPercent,
+    entriesCleared,
+  });
+
+  return true;
+}
+
 export function shouldRejectDueToMemory(): boolean {
   const { level, heapUsedPercent } = getMemoryPressure();
+
+  // Proactively evict caches when memory pressure is high or critical
+  evictCachesIfNeeded(level, heapUsedPercent);
+
   if (level !== "critical") return false;
 
   rendererLog.warn("Rejecting request - memory critical", { heapUsedPercent });
@@ -66,4 +100,15 @@ export function shouldRejectDueToMemory(): boolean {
  */
 export function getMemoryPressureLevel(): MemoryPressureLevel {
   return getMemoryPressure().level;
+}
+
+/**
+ * Check memory pressure and evict caches if needed.
+ * Can be called periodically (e.g., from memory monitoring) to proactively
+ * reclaim memory before requests start failing.
+ */
+export function checkAndEvictCaches(): { level: MemoryPressureLevel; evicted: boolean } {
+  const { level, heapUsedPercent } = getMemoryPressure();
+  const evicted = evictCachesIfNeeded(level, heapUsedPercent);
+  return { level, evicted };
 }

--- a/src/transforms/esm/http-cache-state.ts
+++ b/src/transforms/esm/http-cache-state.ts
@@ -69,6 +69,21 @@ export function hasInjectedProcessingStack(): boolean {
 }
 
 /**
+ * Clear all HTTP bundle caches to reclaim memory.
+ * Called during memory pressure situations to prevent OOM.
+ * Returns the number of entries cleared.
+ */
+export function clearHttpBundleCaches(): number {
+  const pathsCleared = getCacheEntryCount(getCachedPaths());
+  const refreshCleared = getCacheEntryCount(getLastDistributedRefresh());
+
+  defaultCachedPaths.clear();
+  defaultLastDistributedRefresh.clear();
+
+  return pathsCleared + refreshCleared;
+}
+
+/**
  * Inject custom caches for testing.
  * Call with null to restore default behavior.
  */


### PR DESCRIPTION
## Summary

- Add proactive cache eviction when memory pressure reaches HIGH (75%) or CRITICAL (80%) thresholds
- Clear HTTP bundle caches (`http-bundle-paths`, `http-bundle-ttl-refreshes`) to reclaim memory before V8 GC fails
- Include 5-second throttle to prevent eviction thrashing

## Problem

veryfront-server pods in production are experiencing OOM crashes with the error:
```
Fatal JavaScript out of memory: Ineffective mark-compacts near heap limit
```

The `http-bundle-paths` cache (583 entries in the crash logs) was consuming significant memory. The existing memory pressure detection only rejected requests at critical level but didn't proactively clear caches.

## Solution

1. **`clearHttpBundleCaches()`** - New function in `http-cache-state.ts` to clear the HTTP bundle LRU caches
2. **`evictCachesIfNeeded()`** - Triggered when memory pressure is HIGH or CRITICAL, with a 5-second throttle to prevent thrashing
3. **`checkAndEvictCaches()`** - New exported function for periodic proactive eviction (can be called from memory monitoring)

The existing `shouldRejectDueToMemory()` function now also triggers cache eviction, so caches are cleared before requests start being rejected.

## Test plan

- [ ] Run unit tests for pressure.ts and http-cache-state.ts
- [ ] Verify cache clearing works correctly with manual testing
- [ ] Monitor production memory usage after deployment to confirm reduced OOM incidents

## References

Fixes veryfront/veryfront-api#3174