### PR TITLE
Add shared agent identity contracts

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.615",
+  "version": "0.1.616",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [
@@ -46,6 +46,7 @@
     "./markdown": "./src/markdown/index.ts",
     "./mdx": "./src/mdx/index.ts",
     "./agent": "./src/agent/index.ts",
+    "./agent/identity": "./src/agent/identity-contracts.ts",
     "./agent/testing": "./src/agent/testing/index.ts",
     "./agent/conversation-bootstrap": "./src/agent/conversation/bootstrap.ts",
     "./agent/durable": "./src/agent/conversation/durable.ts",
@@ -122,6 +123,7 @@
     "veryfront/sandbox": "./src/sandbox/index.ts",
     "veryfront/embedding": "./src/embedding/index.ts",
     "veryfront/jobs": "./src/jobs/index.ts",
+    "veryfront/agent/identity": "./src/agent/identity-contracts.ts",
     "veryfront/agent/react": "./src/agent/react/index.ts",
     "veryfront/agent/testing": "./src/agent/testing/index.ts",
     "veryfront/agent/middleware": "./src/agent/middleware/index.ts",
@@ -185,6 +187,7 @@
     "veryfront/extensions/observability": "./src/extensions/observability/index.ts",
     "#veryfront": "./src/index.ts",
     "#veryfront/agent": "./src/agent/index.ts",
+    "#veryfront/agent/identity": "./src/agent/identity-contracts.ts",
     "#veryfront/agent/react": "./src/agent/react/index.ts",
     "#veryfront/chat/protocol": "./src/chat/protocol.ts",
     "#veryfront/build": "./src/build/index.ts",

--- a/docs/api-reference/veryfront/agent.md
+++ b/docs/api-reference/veryfront/agent.md
@@ -1734,6 +1734,46 @@ import { appendConversationRunEvents, createConversationAgentRun, createConversa
 | `getConversationRunTargetsSchema` | Zod schema for get conversation run targets. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/conversation/durable.ts#L34) |
 | `getCreateConversationRunAcceptedSchema` | Zod schema for get create conversation run accepted. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/conversation/durable.ts#L238) |
 
+### `veryfront/agent/identity`
+
+```ts
+import { isAgentCatalogKind, isProjectAgentKind } from "veryfront/agent/identity";
+```
+
+#### Components
+
+| Name | Description | Source |
+|------|-------------|--------|
+| `AGENT_CATALOG_ACTIONS` | Public catalog action wire values: `fork` and `install`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L8) |
+| `AGENT_CATALOG_KINDS` | Public catalog discovery wire values: `template_agent` and `installable_agent`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L1) |
+| `PROJECT_AGENT_EXECUTION_KINDS` | Runtime identity wire values used by execution snapshots: `source` and `installed`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L19) |
+| `PROJECT_AGENT_KINDS` | Runnable project-agent card wire values: `source_project_agent` and `installed_project_agent`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L12) |
+
+#### Functions
+
+| Name | Description | Source |
+|------|-------------|--------|
+| `isAgentCatalogAction` | Type guard for public catalog action wire values. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L65) |
+| `isAgentCatalogKind` | Type guard for public catalog discovery kind wire values. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L61) |
+| `isInstalledProjectAgentKind` | Type guard for installed runnable project-agent cards. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L75) |
+| `isProjectAgentExecutionKind` | Type guard for runtime execution identity wire values. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L81) |
+| `isProjectAgentKind` | Type guard for runnable project-agent card wire values. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L71) |
+
+#### Types
+
+| Name | Description | Source |
+|------|-------------|--------|
+| `AgentCatalogAction` | Union of public catalog action wire values. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L10) |
+| `AgentCatalogKind` | Union of public catalog discovery kind wire values. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L6) |
+| `InstalledProjectAgentExecutionIdentity` | Runtime identity for an installed project agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L29) |
+| `InstalledProjectAgentRunSnapshot` | Snake-case run snapshot for an installed project agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L48) |
+| `ProjectAgentExecutionIdentity` | Runtime identity union for source and installed project agents. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L38) |
+| `ProjectAgentExecutionKind` | Union of runtime execution identity wire values. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L21) |
+| `ProjectAgentKind` | Union of runnable project-agent card wire values. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L17) |
+| `ProjectAgentRunSnapshot` | Snake-case run snapshot union for source and installed project agents. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L57) |
+| `SourceProjectAgentExecutionIdentity` | Runtime identity for a source project agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L23) |
+| `SourceProjectAgentRunSnapshot` | Snake-case run snapshot for a source project agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/identity-contracts.ts#L42) |
+
 ### `veryfront/agent/invoke-agent-child-runs`
 
 ```ts

--- a/scripts/build/browser-safe-exports.mjs
+++ b/scripts/build/browser-safe-exports.mjs
@@ -13,6 +13,7 @@ export const BROWSER_SAFE_EXPORTS = [
   "./chat/provider-errors",
   "./markdown",
   "./mdx",
+  "./agent/identity",
 ];
 
 export const BROWSER_SAFE_DNT_TIMER_MODULES = [

--- a/src/agent/identity-contracts.test.ts
+++ b/src/agent/identity-contracts.test.ts
@@ -1,0 +1,43 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+
+import {
+  AGENT_CATALOG_ACTIONS,
+  AGENT_CATALOG_KINDS,
+  isAgentCatalogAction,
+  isAgentCatalogKind,
+  isInstalledProjectAgentKind,
+  isProjectAgentExecutionKind,
+  isProjectAgentKind,
+  PROJECT_AGENT_EXECUTION_KINDS,
+  PROJECT_AGENT_KINDS,
+} from "./identity-contracts.ts";
+
+Deno.test("agent identity constants preserve public wire values", () => {
+  assertEquals(AGENT_CATALOG_KINDS, [
+    "template_agent",
+    "installable_agent",
+  ]);
+  assertEquals(AGENT_CATALOG_ACTIONS, ["fork", "install"]);
+  assertEquals(PROJECT_AGENT_KINDS, [
+    "source_project_agent",
+    "installed_project_agent",
+  ]);
+  assertEquals(PROJECT_AGENT_EXECUTION_KINDS, ["source", "installed"]);
+});
+
+Deno.test("agent identity guards accept current wire values only", () => {
+  assertEquals(isAgentCatalogKind("template_agent"), true);
+  assertEquals(isAgentCatalogKind("catalog_entry"), false);
+
+  assertEquals(isAgentCatalogAction("install"), true);
+  assertEquals(isAgentCatalogAction("run"), false);
+
+  assertEquals(isProjectAgentKind("installed_project_agent"), true);
+  assertEquals(isProjectAgentKind("installable_agent"), false);
+
+  assertEquals(isInstalledProjectAgentKind("installed_project_agent"), true);
+  assertEquals(isInstalledProjectAgentKind("source_project_agent"), false);
+
+  assertEquals(isProjectAgentExecutionKind("source"), true);
+  assertEquals(isProjectAgentExecutionKind("source_project_agent"), false);
+});

--- a/src/agent/identity-contracts.ts
+++ b/src/agent/identity-contracts.ts
@@ -1,0 +1,87 @@
+export const AGENT_CATALOG_KINDS = [
+  "template_agent",
+  "installable_agent",
+] as const;
+
+export type AgentCatalogKind = (typeof AGENT_CATALOG_KINDS)[number];
+
+export const AGENT_CATALOG_ACTIONS = ["fork", "install"] as const;
+
+export type AgentCatalogAction = (typeof AGENT_CATALOG_ACTIONS)[number];
+
+export const PROJECT_AGENT_KINDS = [
+  "source_project_agent",
+  "installed_project_agent",
+] as const;
+
+export type ProjectAgentKind = (typeof PROJECT_AGENT_KINDS)[number];
+
+export const PROJECT_AGENT_EXECUTION_KINDS = ["source", "installed"] as const;
+
+export type ProjectAgentExecutionKind = (typeof PROJECT_AGENT_EXECUTION_KINDS)[number];
+
+export type SourceProjectAgentExecutionIdentity = {
+  kind: "source";
+  projectId: string;
+  agentId: string;
+};
+
+export type InstalledProjectAgentExecutionIdentity = {
+  kind: "installed";
+  projectId: string;
+  agentId: string;
+  catalogEntryId: string;
+  agentAccessGrantId: string;
+  serviceAccountId: string;
+};
+
+export type ProjectAgentExecutionIdentity =
+  | SourceProjectAgentExecutionIdentity
+  | InstalledProjectAgentExecutionIdentity;
+
+export type SourceProjectAgentRunSnapshot = {
+  kind: "source";
+  project_id: string;
+  agent_id: string;
+};
+
+export type InstalledProjectAgentRunSnapshot = {
+  kind: "installed";
+  project_id: string;
+  agent_id: string;
+  catalog_entry_id: string;
+  agent_access_grant_id: string;
+  service_account_id: string;
+};
+
+export type ProjectAgentRunSnapshot =
+  | SourceProjectAgentRunSnapshot
+  | InstalledProjectAgentRunSnapshot;
+
+export function isAgentCatalogKind(value: string): value is AgentCatalogKind {
+  return AGENT_CATALOG_KINDS.includes(value as AgentCatalogKind);
+}
+
+export function isAgentCatalogAction(
+  value: string,
+): value is AgentCatalogAction {
+  return AGENT_CATALOG_ACTIONS.includes(value as AgentCatalogAction);
+}
+
+export function isProjectAgentKind(value: string): value is ProjectAgentKind {
+  return PROJECT_AGENT_KINDS.includes(value as ProjectAgentKind);
+}
+
+export function isInstalledProjectAgentKind(
+  value: ProjectAgentKind,
+): value is "installed_project_agent" {
+  return value === "installed_project_agent";
+}
+
+export function isProjectAgentExecutionKind(
+  value: string,
+): value is ProjectAgentExecutionKind {
+  return PROJECT_AGENT_EXECUTION_KINDS.includes(
+    value as ProjectAgentExecutionKind,
+  );
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1001,6 +1001,27 @@ export {
   getAgentRuntimeToolResultPart,
 } from "./runtime/message-adapter.ts";
 export {
+  AGENT_CATALOG_ACTIONS,
+  AGENT_CATALOG_KINDS,
+  type AgentCatalogAction,
+  type AgentCatalogKind,
+  type InstalledProjectAgentExecutionIdentity,
+  type InstalledProjectAgentRunSnapshot,
+  isAgentCatalogAction,
+  isAgentCatalogKind,
+  isInstalledProjectAgentKind,
+  isProjectAgentExecutionKind,
+  isProjectAgentKind,
+  PROJECT_AGENT_EXECUTION_KINDS,
+  PROJECT_AGENT_KINDS,
+  type ProjectAgentExecutionIdentity,
+  type ProjectAgentExecutionKind,
+  type ProjectAgentKind,
+  type ProjectAgentRunSnapshot,
+  type SourceProjectAgentExecutionIdentity,
+  type SourceProjectAgentRunSnapshot,
+} from "./identity-contracts.ts";
+export {
   resolveRuntimeMessageFileUrls,
   type RuntimeFileUrlResolver,
   type RuntimeFileUrlResolverInput,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.615";
+export const VERSION = "0.1.616";


### PR DESCRIPTION
## Summary
- adds canonical shared agent identity wire values and runtime identity types
- exports veryfront/agent/identity and re-exports the contracts from veryfront/agent
- bumps veryfront-code to 0.1.616 for the new public contract surface

## Verification
- deno fmt
- deno test --allow-all src/agent/identity-contracts.test.ts
- deno task typecheck
- deno task build:npm
- node scripts/docs/verify-npm-exports.mjs
- deno test --config=scripts/test.deno.json --no-check --allow-read --allow-write --allow-run scripts/build/npm-package-metadata.test.ts
- pre-push checks: format, lint, typecheck, unit tests passed