### PR TITLE
Preserve executable project tools in agent runs

### DIFF
--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -8,6 +8,7 @@ import type {
   AgentServiceSandboxToolsResult,
   CreateSandboxBashTool,
 } from "#veryfront/sandbox";
+import type { Tool } from "#veryfront/tool";
 import { AgentRunSessionManager } from "./session-manager.ts";
 import { createRuntimeAgentStreamResponse } from "./run-stream.ts";
 
@@ -305,6 +306,72 @@ describe("internal-agents/run-stream", () => {
     assertEquals(sandboxToolCalls, 0);
   });
 
+  it("keeps concrete project source tools executable when forwarded metadata has the same name", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    const projectTool = {
+      id: "number-generator",
+      type: "function",
+      description: "Generate a number",
+      inputSchema: {} as never,
+      inputSchemaJson: { type: "object", properties: {} },
+      execute: () => ({ randomNumber: 7 }),
+    };
+    let capturedToolResult: unknown;
+
+    const agent = {
+      id: "random",
+      config: {
+        id: "random",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        tools: {
+          "number-generator": projectTool,
+        },
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "random",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [
+        {
+          name: "number-generator",
+          description: "Generates a random number within a specified range.",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+      context: [],
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        createRuntime: (_agent, mergedTools) => {
+          if (mergedTools && mergedTools !== true) {
+            const tool = mergedTools["number-generator"];
+            if (tool && tool !== true) {
+              capturedToolResult = (tool as Tool).execute?.({});
+            }
+          }
+          return {
+            stream: async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+          };
+        },
+      },
+    );
+
+    assertEquals(capturedToolResult, { randomNumber: 7 });
+  });
+
   it("emits comment heartbeats while the runtime stream is idle", async () => {
     using time = new FakeTime();
     const sessionManager = new AgentRunSessionManager();
@@ -325,7 +392,7 @@ describe("internal-agents/run-stream", () => {
       tools: [],
       context: [],
     } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
-    let runtimeController: ReadableStreamDefaultController<Uint8Array> | null = null;
+    const runtimeControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
 
     const response = await createRuntimeAgentStreamResponse(
       input,
@@ -336,7 +403,7 @@ describe("internal-agents/run-stream", () => {
           stream: async () =>
             new ReadableStream<Uint8Array>({
               start(controller) {
-                runtimeController = controller;
+                runtimeControllers.push(controller);
                 // Keep the stream idle so the control-plane response must stay alive.
               },
             }),
@@ -361,7 +428,7 @@ describe("internal-agents/run-stream", () => {
       ": internal-agent-runtime-heartbeat\n\n",
     );
 
-    runtimeController?.close();
+    runtimeControllers[0]?.close();
     await reader.cancel();
   });
 });

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -120,17 +120,26 @@ function buildMergedTools(
   availableForwardedToolNames?: string[],
   availableLocalTools?: Record<string, Tool | boolean>,
 ) {
+  const concreteSourceToolNames = agent.config.tools && agent.config.tools !== true
+    ? new Set(
+      Object.entries(agent.config.tools)
+        .filter(([, entry]) => entry && typeof entry === "object")
+        .map(([toolName]) => toolName),
+    )
+    : new Set<string>();
   const injectedTools = Object.fromEntries(
-    input.tools.map((tool) => [
-      tool.name,
-      createInjectedStudioTool(
-        input.runId,
+    input.tools
+      .filter((tool) => !concreteSourceToolNames.has(tool.name))
+      .map((tool) => [
         tool.name,
-        tool.description,
-        tool.inputSchema ?? tool.parameters,
-        sessionManager,
-      ),
-    ]),
+        createInjectedStudioTool(
+          input.runId,
+          tool.name,
+          tool.description,
+          tool.inputSchema ?? tool.parameters,
+          sessionManager,
+        ),
+      ]),
   );
 
   if (!agent.config.tools) {


### PR DESCRIPTION
## Summary
- Keep concrete project source tool implementations when the control plane forwards metadata for the same selected tool name.
- Continue injecting wait-for-client shims only for forwarded tools that do not already have a concrete source implementation.
- Add a regression test for `number-generator`-style project tools so forwarded metadata cannot replace the executable tool.

## Failure Evidence
- Staging DB run `f2706100-56bb-4578-89fd-b9ae39f21a22` for conversation `bff1d6ec-26ec-4fe3-9509-535b88d4af5e` reached `TOOL_CALL_END` for `number-generator` / `toolu_01CmqsrNniWD65Zr27yv4vPx`.
- No `TOOL_CALL_RESULT` event was persisted after that call.
- The run later ended with `WAITING_FOR_TOOL_TIMEOUT` and message `Waiting for tool result timed out`.
- The request snapshot included the forwarded `number-generator` tool contract, so the model could see/call it, but runtime execution was replaced by the client-result shim.

## Verification
- `deno task test src/internal-agents/run-stream.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --allow-all --unstable-worker-options --unstable-net src/internal-agents/run-stream.test.ts`
- Pre-commit `verify:quick` passed during commit/amend.
