### PR TITLE
Preserve AG-UI source tools over forwarded metadata

### DIFF
--- a/src/agent/ag-ui/tool-shared.test.ts
+++ b/src/agent/ag-ui/tool-shared.test.ts
@@ -1,0 +1,80 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { defineSchema } from "#veryfront/schemas/index.ts";
+import type { Tool } from "#veryfront/tool/types.ts";
+import type { Agent } from "../types.ts";
+import { RunResumeSessionManager } from "../runtime/index.ts";
+import { type AgUiResumeValue, buildMergedAgUiTools } from "./tool-shared.ts";
+
+const inputSchema = defineSchema((v) =>
+  v.object({
+    min: v.number(),
+    max: v.number(),
+  })
+);
+
+describe("buildMergedAgUiTools", () => {
+  it("preserves concrete source tools when forwarded metadata uses the same name", async () => {
+    const sourceTool: Tool = {
+      id: "number-generator",
+      type: "function",
+      description: "Generates a random number.",
+      inputSchema: inputSchema(),
+      inputSchemaJson: {
+        type: "object",
+        required: ["min", "max"],
+        properties: {
+          min: { type: "number" },
+          max: { type: "number" },
+        },
+      },
+      execute: async () => ({ randomNumber: 7 }),
+    };
+    const agent = {
+      config: {
+        tools: {
+          "number-generator": sourceTool,
+        },
+      },
+    } as unknown as Agent;
+    const sessionManager = new RunResumeSessionManager<AgUiResumeValue>();
+
+    const mergedTools = buildMergedAgUiTools(agent, "run_1", [
+      {
+        name: "number-generator",
+        description: "Forwarded project tool metadata.",
+        parameters: { type: "object", properties: {} },
+      },
+      { name: "studio_open_preview" },
+    ], sessionManager) as Record<string, Tool>;
+
+    const preservedTool = mergedTools["number-generator"]!;
+    assertEquals(preservedTool, sourceTool);
+    assertEquals(await preservedTool.execute?.({ min: 1, max: 100 }), {
+      randomNumber: 7,
+    });
+    assertEquals(typeof mergedTools.studio_open_preview?.execute, "function");
+  });
+
+  it("preserves source-declared tool references when forwarded metadata uses the same name", () => {
+    const agent = {
+      config: {
+        tools: {
+          "number-generator": true,
+        },
+      },
+    } as unknown as Agent;
+    const sessionManager = new RunResumeSessionManager<AgUiResumeValue>();
+
+    const mergedTools = buildMergedAgUiTools(agent, "run_1", [
+      {
+        name: "number-generator",
+        description: "Forwarded project tool metadata.",
+        parameters: { type: "object", properties: {} },
+      },
+    ], sessionManager) as Record<string, Tool | boolean>;
+
+    assertEquals(mergedTools["number-generator"], true);
+  });
+});

--- a/src/agent/ag-ui/tool-shared.ts
+++ b/src/agent/ag-ui/tool-shared.ts
@@ -55,11 +55,16 @@ export function buildMergedAgUiTools(
   tools: AgUiInjectedToolLike[],
   sessionManager: RunResumeSessionManager<AgUiResumeValue>,
 ): Agent["config"]["tools"] {
+  const sourceToolNames = agent.config.tools && agent.config.tools !== true
+    ? new Set(Object.keys(agent.config.tools))
+    : new Set<string>();
   const injectedTools = Object.fromEntries(
-    tools.map((tool) => [
-      tool.name,
-      createInjectedAgUiTool(runId, tool, sessionManager),
-    ]),
+    tools
+      .filter((tool) => !sourceToolNames.has(tool.name))
+      .map((tool) => [
+        tool.name,
+        createInjectedAgUiTool(runId, tool, sessionManager),
+      ]),
   );
 
   if (!agent.config.tools) {


### PR DESCRIPTION
## Summary
- keep AG-UI forwarded tool metadata from shadowing source-declared runtime tools with the same name
- add regression coverage for concrete and source-declared project tools such as `number-generator`

## Evidence
- Local regression: `deno task test src/agent/ag-ui/handler.test.ts src/agent/ag-ui/runtime-handler.test.ts src/agent/ag-ui/detached-start.test.ts src/agent/ag-ui/tool-shared.test.ts` passed.
- Typecheck regression: `deno test --preload=src/schemas/_test-setup.ts --allow-all --unstable-worker-options --unstable-net src/agent/ag-ui/tool-shared.test.ts` passed.
- Pre-commit `verify:quick` passed.
- Staging after PR #1950 still reproduced the deployed AG-UI path: clean run `f20987b4-4614-4780-ad25-bd2826b5fdd1` saw `number-generator`, emitted `TOOL_CALL_END`, then remained `waiting_for_tool` with `waiting_tool_name=number-generator`. That showed the internal-agent fix was necessary but not sufficient for the AG-UI runtime handler.

## Risk
Narrow: only changes AG-UI injected tool merging so a request-provided injected tool is skipped when the agent source already declares that tool name.