### PR TITLE
Publish AG-UI project tool fix as 0.1.618

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.617",
+  "version": "0.1.618",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.617";
+export const VERSION = "0.1.618";


### PR DESCRIPTION
## Summary
- bump Veryfront package version from 0.1.617 to 0.1.618 so the merged AG-UI project-tool fix is publishable and deployable

## Evidence
- PR #1951 merged the AG-UI source-tool preservation fix, but staging server image `20260531141138-175497ba8ccd` still reported `VERYFRONT_VERSION=v0.1.617` and reproduced `waiting_for_tool` on clean run `4522f34c-4a1b-4fe7-8755-33b577839d1a` for `number-generator`.
- Pre-commit `verify:quick` passed for this version bump.

## Risk
Narrow: version-only change to force a new package artifact for the already-merged runtime fix.