### PR TITLE
Execute committed AG-UI tool calls after neutral stops

### DIFF
--- a/src/agent/runtime/index.test.ts
+++ b/src/agent/runtime/index.test.ts
@@ -134,6 +134,27 @@ describe("agent runtime streamed tool result collection", () => {
     assertEquals(shouldContinue, true);
   });
 
+  it("continues finalized client-executed tool calls when the provider reports stop", () => {
+    const shouldContinue = shouldContinueAfterStreamStep({
+      accumulatedText: "",
+      finishReason: "stop",
+      toolCalls: new Map([
+        [
+          "toolu_client_stop_1",
+          {
+            id: "toolu_client_stop_1",
+            name: "number-generator",
+            arguments: '{"min":1,"max":100}',
+            inputAvailable: true,
+          },
+        ],
+      ]),
+      toolResults: [],
+    });
+
+    assertEquals(shouldContinue, true);
+  });
+
   it("ignores preliminary streamed tool results when a final result exists", () => {
     const finalToolResults = collectFinalStreamToolResults(
       createState([

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -262,7 +262,12 @@ export function shouldContinueAfterStreamStep(
 
   const finalToolResults = collectFinalStreamToolResults(state);
   if (!finalToolResults.size) {
-    return false;
+    for (const toolCall of state.toolCalls.values()) {
+      if (toolCall.inputAvailable !== true || toolCall.providerExecuted === true) {
+        return false;
+      }
+    }
+    return true;
   }
 
   for (const [toolCallId, toolCall] of state.toolCalls) {


### PR DESCRIPTION
## Summary
- Continue streaming agent loops for finalized client/project tool calls when the provider reports `stop` with no assistant text and no provider-side result.
- Add a regression test covering a committed `number-generator` tool call with `finishReason: stop`.

## Evidence
- Staging v0.1.618 live proof run `08697835-f6b1-4dd5-b886-769ee9bd9397` reached `TOOL_CALL_END` for `number-generator` but persisted no `TOOL_CALL_RESULT`, leaving status `waiting_for_tool`.
- This patch keeps incomplete streams gated by `inputAvailable`, and it does not continue if the assistant already emitted text.

## Verification
- `deno task test src/agent/runtime/index.test.ts src/agent/ag-ui/runtime-handler.test.ts src/agent/ag-ui/handler.test.ts src/agent/ag-ui/tool-shared.test.ts`
- `deno task verify:quick`

No secrets or user data are included.