### PR TITLE
Keep source tools out of AG-UI browser waits

### DIFF
--- a/src/agent/ag-ui/handler.ts
+++ b/src/agent/ag-ui/handler.ts
@@ -297,9 +297,6 @@ async function createAgUiInjectedToolsStreamResponse(
     onError: () => {
       sessionManager.failRun(runId);
     },
-    onToolCallSeen: (toolCallId) => {
-      sessionManager.prepareForSignal(runId, toolCallId);
-    },
   });
 }
 

--- a/src/agent/ag-ui/runtime-handler.test.ts
+++ b/src/agent/ag-ui/runtime-handler.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { defineSchema } from "#veryfront/schemas/index.ts";
 import { RunResumeSessionManager } from "../index.ts";
 import { createAgUiRuntimeHandler } from "./runtime-handler.ts";
 import { AgentRuntime } from "../runtime/index.ts";
@@ -553,6 +554,138 @@ describe("agent/ag-ui-runtime-handler", () => {
       assertStringIncludes(body, "event: ToolCallStart");
       assertEquals(seenToolCallId, "tool-call-1");
       assertEquals(finishedRunId, "run_runtime_4");
+    } finally {
+      AgentRuntime.prototype.stream = originalStream;
+    }
+  });
+
+  it("does not prepare browser resume waits for source project tools", async () => {
+    class TrackingSessionManager extends RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }> {
+      prepareCalls: Array<{ runId: string; waitKey: string }> = [];
+
+      override prepareForSignal(runId: string, waitKey: string): void {
+        this.prepareCalls.push({ runId, waitKey });
+        super.prepareForSignal(runId, waitKey);
+      }
+    }
+
+    const sessionManager = new TrackingSessionManager();
+    const originalStream = AgentRuntime.prototype.stream;
+    const agent = createTestAgent().agent;
+    let sourceToolCalled = false;
+
+    agent.config = {
+      ...agent.config,
+      tools: {
+        "number-generator": {
+          id: "number-generator",
+          description: "Generate a number.",
+          inputSchema: defineSchema((v) =>
+            v.object({
+              min: v.number(),
+              max: v.number(),
+            })
+          )(),
+          execute: () => {
+            sourceToolCalled = true;
+            return { randomNumber: 42 };
+          },
+        },
+      },
+    } as Agent["config"];
+
+    AgentRuntime.prototype.stream = async function (): Promise<ReadableStream<Uint8Array>> {
+      const runtimeConfig = this as unknown as {
+        config: {
+          tools?: Record<string, {
+            execute: (
+              input: Record<string, unknown>,
+              context?: { toolCallId?: string },
+            ) => Promise<unknown> | unknown;
+          }>;
+        };
+      };
+
+      const sourceTool = runtimeConfig.config.tools?.["number-generator"];
+      if (!sourceTool) {
+        throw new Error("Expected source project tool to be preserved in the runtime config");
+      }
+
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          void (async () => {
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "message-start",
+                messageId: "assistant-msg-1",
+              }),
+            );
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "tool-input-start",
+                toolCallId: "tool-call-source-1",
+                toolName: "number-generator",
+              }),
+            );
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "tool-input-delta",
+                toolCallId: "tool-call-source-1",
+                inputTextDelta: '{"min":1,"max":100}',
+              }),
+            );
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "tool-input-available",
+                toolCallId: "tool-call-source-1",
+              }),
+            );
+
+            const result = await sourceTool.execute(
+              { min: 1, max: 100 },
+              { toolCallId: "tool-call-source-1" },
+            );
+
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "tool-output-available",
+                toolCallId: "tool-call-source-1",
+                output: result,
+              }),
+            );
+            controller.close();
+          })();
+        },
+      });
+    };
+
+    try {
+      const handler = createAgUiRuntimeHandler({
+        agent,
+        sessionManager,
+      });
+
+      const response = await handler(
+        new Request("http://localhost/api/ag-ui", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            threadId: crypto.randomUUID(),
+            runId: "run_runtime_source_tool_1",
+            messages: [{ id: "msg-1", role: "user", content: "generate" }],
+            tools: [{ name: "number-generator" }],
+          }),
+        }),
+      );
+
+      const body = await response.text();
+      assertStringIncludes(body, "event: ToolCallResult");
+      assertStringIncludes(body, '"randomNumber":42');
+      assertEquals(sourceToolCalled, true);
+      assertEquals(sessionManager.prepareCalls, []);
     } finally {
       AgentRuntime.prototype.stream = originalStream;
     }

--- a/src/agent/ag-ui/runtime-handler.ts
+++ b/src/agent/ag-ui/runtime-handler.ts
@@ -304,7 +304,6 @@ async function createAgUiRuntimeInjectedToolsStreamResponse(
       void lifecycle?.onError?.(error);
     },
     onToolCallSeen: (toolCallId) => {
-      sessionManager.prepareForSignal(request.runId, toolCallId);
       void lifecycle?.onToolCallSeen?.(toolCallId);
     },
   });


### PR DESCRIPTION
## Summary
- stop generic AG-UI tool stream events from preparing browser resume waits
- leave resume wait preparation inside injected client-tool execution
- add a regression for a source `number-generator` tool that emits `ToolCallResult` without any browser-wait preparation

## Evidence
- Staging v0.1.619 failure before this fix: conversation `73f684a8-5a0a-4e8d-93ea-fde36a4f4f74`, run `977ee096-6200-473b-8c4b-69449b0de6ce` reached `ToolCallEnd` for `number-generator` and remained `waiting_for_tool` with no `ToolCallResult`.
- Targeted tests: `deno task test src/agent/ag-ui/runtime-handler.test.ts src/agent/ag-ui/handler.test.ts src/agent/ag-ui/tool-shared.test.ts src/agent/runtime/index.test.ts`
- Quick verification: `deno task verify:quick`

## Notes
- This is intentionally narrow: request-provided AG-UI tools still wait through their injected tool executor; source/project tools are no longer classified as browser-managed solely because they emit tool-call stream events.