### PR TITLE
Let local project tools execute after stream commits

### DIFF
--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -69,12 +69,14 @@ describe("chat-stream-handler", () => {
           toolCallId: "tc-form",
           toolName: "form_input",
           input: { title: "Need more detail" },
+          providerExecuted: true,
         },
         {
           type: "tool-result",
           toolCallId: "tc-form",
           toolName: "form_input",
           output: { submitted: false },
+          providerExecuted: true,
         },
         { type: "text-delta", text: " After tool." },
         { type: "finish", finishReason: "stop", totalUsage: null },
@@ -92,15 +94,90 @@ describe("chat-stream-handler", () => {
           toolCallId: "tc-form",
           toolName: "form_input",
           input: { title: "Need more detail" },
+          providerExecuted: true,
         },
         {
           type: "tool-output-available",
           toolCallId: "tc-form",
           output: { submitted: false },
+          providerExecuted: true,
         },
         { type: "text-start", id: "text-1" },
         { type: "text-delta", id: "text-1", delta: " After tool." },
         { type: "text-end", id: "text-1" },
+      ]);
+    });
+
+    it("stops reading after a committed local tool-call so the runtime can execute it", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+      let returned = false;
+      let index = 0;
+      let resolvePendingNext: ((value: IteratorResult<unknown>) => void) | undefined;
+      const parts = [
+        { type: "tool-input-start", id: "tc-local", toolName: "number-generator" },
+        { type: "tool-input-delta", id: "tc-local", delta: '{"min":3' },
+        { type: "tool-input-delta", id: "tc-local", delta: ',"max":9}' },
+        {
+          type: "tool-call",
+          toolCallId: "tc-local",
+          toolName: "number-generator",
+          input: { min: 3, max: 9 },
+        },
+      ];
+
+      const result = {
+        fullStream: {
+          [Symbol.asyncIterator]() {
+            return {
+              async next() {
+                if (index < parts.length) {
+                  return { done: false, value: parts[index++] };
+                }
+                return await new Promise<IteratorResult<unknown>>((resolve) => {
+                  resolvePendingNext = resolve;
+                });
+              },
+              async return() {
+                resolvePendingNext?.({ done: true, value: undefined });
+                resolvePendingNext = undefined;
+                returned = true;
+                return { done: true, value: undefined };
+              },
+            };
+          },
+        },
+        textStream: {
+          [Symbol.asyncIterator]() {
+            return {
+              async next() {
+                return { done: true, value: undefined };
+              },
+            };
+          },
+        },
+      };
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      assertEquals(returned, true);
+      assertEquals(state.finishReason, null);
+      const toolCall = state.toolCalls.get("tc-local");
+      assertEquals(toolCall?.id, "tc-local");
+      assertEquals(toolCall?.name, "number-generator");
+      assertEquals(toolCall?.arguments, '{"min":3,"max":9}');
+      assertEquals(toolCall?.inputAvailable, true);
+      assertEquals(toolCall?.providerExecuted, undefined);
+      assertEquals(events, [
+        { type: "tool-input-start", toolCallId: "tc-local", toolName: "number-generator" },
+        { type: "tool-input-delta", toolCallId: "tc-local", inputTextDelta: '{"min":3' },
+        { type: "tool-input-delta", toolCallId: "tc-local", inputTextDelta: ',"max":9}' },
+        {
+          type: "tool-input-available",
+          toolCallId: "tc-local",
+          toolName: "number-generator",
+          input: { min: 3, max: 9 },
+        },
       ]);
     });
 

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -23,6 +23,7 @@ import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { stringifyToolError, throwIfAborted } from "./error-utils.ts";
 
 const logger = serverLogger.component("agent");
+const LOCAL_TOOL_COMMIT_GRACE_MS = 250;
 
 export interface StreamingToolCall {
   id: string;
@@ -200,6 +201,26 @@ async function readNextStreamPart(
   }
 }
 
+async function readNextStreamPartWithTimeout(
+  iterator: AsyncIterator<unknown>,
+  state: ChatStreamState,
+  timeoutMs: number,
+): Promise<IteratorResult<unknown> | "timeout"> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      readNextStreamPart(iterator, state),
+      new Promise<"timeout">((resolve) => {
+        timeoutId = setTimeout(() => resolve("timeout"), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
 export function createStreamState(): ChatStreamState {
   return {
     accumulatedText: "",
@@ -233,6 +254,7 @@ export function processStream(
     let eventCount = 0;
     let textOpen = false;
     let activeReasoningId: string | null = null;
+    let shouldStopForCommittedLocalToolCall = false;
 
     const normalizeReasoningId = (part: { id?: string }) =>
       typeof part.id === "string" && part.id.length > 0 ? part.id : "reasoning";
@@ -366,7 +388,17 @@ export function processStream(
 
     const streamIterator = result.fullStream[Symbol.asyncIterator]();
     while (true) {
-      const next = await readNextStreamPart(streamIterator, state);
+      const next = shouldStopForCommittedLocalToolCall
+        ? await readNextStreamPartWithTimeout(
+          streamIterator,
+          state,
+          LOCAL_TOOL_COMMIT_GRACE_MS,
+        )
+        : await readNextStreamPart(streamIterator, state);
+      if (next === "timeout") {
+        await streamIterator.return?.();
+        break;
+      }
       if (next.done) {
         break;
       }
@@ -496,6 +528,9 @@ export function processStream(
               : {}),
             ...(dynamic ? { dynamic: true } : {}),
           });
+          if (typedPart.providerExecuted !== true) {
+            shouldStopForCommittedLocalToolCall = true;
+          }
           break;
         }
 


### PR DESCRIPTION
## Summary
- stop reading a model stream after a non-provider-executed local tool call has committed and the stream stalls
- keep provider-executed tool calls/results streaming normally
- add a regression for a committed local `number-generator` tool call whose provider stream never closes

## Evidence
- `deno test --no-check --allow-all src/agent/runtime/chat-stream-handler.test.ts src/internal-agents/run-stream.test.ts src/agent/ag-ui/runtime-handler.test.ts`
- pre-commit `deno task verify:quick` passed

## Staging context
- API PR veryfront/veryfront-api#3188 proved the durable executor no longer parks `number-generator` as a browser-resumed tool.
- Post-API staging proof run `86dc57c4-c3ba-40ba-9602-e6b0be65c1c3` showed `TOOL_CALL_START`/`TOOL_CALL_ARGS`/`TOOL_CALL_END` for `number-generator` but no `TOOL_CALL_RESULT`; the run stayed `running` with `waiting_tool_name=null`. This change addresses that runtime stream boundary.