### PR TITLE
Release v0.1.621

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.620",
+  "version": "0.1.621",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.620";
+export const VERSION = "0.1.621";


### PR DESCRIPTION
## Summary
- bump `veryfront` from `0.1.620` to `0.1.621`
- publishes the runtime stream-boundary fix from #1957 so staging server deploys can consume it

## Evidence
- pre-commit `deno task verify:quick` passed
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `git diff --check`

## Release reason
The merged runtime fix is required for the staging proof that project agent `random` can execute the project `number-generator` tool instead of stalling after `TOOL_CALL_END`.