### PR TITLE
Run timed-out local tool streams as tool calls

### DIFF
--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -161,7 +161,7 @@ describe("chat-stream-handler", () => {
       await processStream(result, state, controller, encoder, "t", undefined);
 
       assertEquals(returned, true);
-      assertEquals(state.finishReason, null);
+      assertEquals(state.finishReason, "tool-calls");
       const toolCall = state.toolCalls.get("tc-local");
       assertEquals(toolCall?.id, "tc-local");
       assertEquals(toolCall?.name, "number-generator");

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -396,6 +396,7 @@ export function processStream(
         )
         : await readNextStreamPart(streamIterator, state);
       if (next === "timeout") {
+        state.finishReason ??= "tool-calls";
         await streamIterator.return?.();
         break;
       }


### PR DESCRIPTION
## Summary
- synthesize a `tool-calls` finish reason only when a committed local tool stream stalls and times out
- keeps the preserved local tool call eligible for the existing runtime tool execution step
- updates the targeted stream handler regression expectation

## Evidence
- `deno test --no-check --allow-all src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/index.test.ts src/internal-agents/run-stream.test.ts src/agent/ag-ui/runtime-handler.test.ts`
- repo pre-commit `verify:quick` passed

## Staging failure this fixes
- On v0.1.621, proof run `proof-1780245985268` emitted `TOOL_CALL_START`, `TOOL_CALL_ARGS`, and `TOOL_CALL_END` for `number-generator`, then stayed `running` with no `TOOL_CALL_RESULT`.
- Root cause: the timeout path preserved the local tool call but left `finishReason` unset, so `shouldContinueAfterStreamStep` did not enter runtime tool execution.\n