### PR TITLE
Release v0.1.622

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.621",
+  "version": "0.1.622",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.621";
+export const VERSION = "0.1.622";


### PR DESCRIPTION
## Summary
- bump `veryfront` from `0.1.621` to `0.1.622`
- publish the merged runtime fix from #1959 so staging can execute local project tool calls after stream timeout

## Evidence
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `git diff --check`
- pre-commit `verify:quick` passed, including manifest checks, format, lint, docs validation, and typecheck

## Deployment target
- v0.1.621 still heartbeats after `TOOL_CALL_END` for `number-generator` and never emits `TOOL_CALL_RESULT`.
- v0.1.622 includes #1959, which marks that committed local-tool timeout boundary as `tool-calls` so the existing execution loop can run the tool.\n