### PR TITLE
Do not wait on stream cancel before local tool execution

### DIFF
--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -181,6 +181,57 @@ describe("chat-stream-handler", () => {
       ]);
     });
 
+    it("does not wait for provider stream cancellation after a committed local tool-call", async () => {
+      const { controller, encoder } = createSSECollector();
+      const state = createStreamState();
+      let returnCalled = false;
+      let index = 0;
+      const parts = [
+        { type: "tool-input-start", id: "tc-local", toolName: "number-generator" },
+        { type: "tool-input-delta", id: "tc-local", delta: '{"min":3,"max":9}' },
+        {
+          type: "tool-call",
+          toolCallId: "tc-local",
+          toolName: "number-generator",
+          input: { min: 3, max: 9 },
+        },
+      ];
+
+      const result = {
+        fullStream: {
+          [Symbol.asyncIterator]() {
+            return {
+              async next() {
+                if (index < parts.length) {
+                  return { done: false, value: parts[index++] };
+                }
+                return await new Promise<IteratorResult<unknown>>(() => {});
+              },
+              async return() {
+                returnCalled = true;
+                return await new Promise<IteratorResult<unknown>>(() => {});
+              },
+            };
+          },
+        },
+        textStream: {
+          [Symbol.asyncIterator]() {
+            return {
+              async next() {
+                return { done: true, value: undefined };
+              },
+            };
+          },
+        },
+      };
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      assertEquals(returnCalled, true);
+      assertEquals(state.finishReason, "tool-calls");
+      assertEquals(state.toolCalls.get("tc-local")?.inputAvailable, true);
+    });
+
     it("calls onChunk callback for each text delta", async () => {
       const { controller, encoder } = createSSECollector();
       const state = createStreamState();

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -221,6 +221,19 @@ async function readNextStreamPartWithTimeout(
   }
 }
 
+function requestStreamIteratorReturn(iterator: AsyncIterator<unknown>): void {
+  const returnResult = iterator.return?.();
+  if (!returnResult) {
+    return;
+  }
+
+  void Promise.resolve(returnResult).catch((error) => {
+    logger.warn("Runtime stream iterator return failed after local tool-call handoff", {
+      error: getStreamErrorMessage(error),
+    });
+  });
+}
+
 export function createStreamState(): ChatStreamState {
   return {
     accumulatedText: "",
@@ -397,7 +410,7 @@ export function processStream(
         : await readNextStreamPart(streamIterator, state);
       if (next === "timeout") {
         state.finishReason ??= "tool-calls";
-        await streamIterator.return?.();
+        requestStreamIteratorReturn(streamIterator);
         break;
       }
       if (next.done) {


### PR DESCRIPTION
## Summary
- make provider stream cancellation best-effort after a committed local tool-call handoff
- keep `finishReason=tool-calls` and return from `processStream` so the existing runtime loop can execute local tools
- add a regression where `streamIterator.return()` never resolves

## Evidence
- `deno fmt --check src/agent/runtime/chat-stream-handler.ts src/agent/runtime/chat-stream-handler.test.ts`
- `deno test --no-check --allow-all src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/index.test.ts src/internal-agents/run-stream.test.ts src/agent/ag-ui/runtime-handler.test.ts`
- pre-commit `verify:quick` passed

## Live failure this fixes
- v0.1.622 staging proof `proof-1780247880175` on conversation `76010251-7b5b-4f8c-a5a9-e1d62e500b67` still reached `TOOL_CALL_END` for `number-generator` but never emitted `TOOL_CALL_RESULT`.
- Server logs confirmed runtime version `0.1.622` and `number-generator` was in the runtime tool set.
- Follow-up root cause: after the committed local tool-call timeout, `processStream` awaited provider stream cancellation via `streamIterator.return()`; live cancellation did not resolve, so control never reached runtime tool execution.\n