### PR TITLE
Release v0.1.623

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.622",
+  "version": "0.1.623",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.622";
+export const VERSION = "0.1.623";


### PR DESCRIPTION
## Summary
- bump `veryfront` from `0.1.622` to `0.1.623`
- publish #1962 so staging can execute local tools after a committed tool-call without waiting on provider stream cancellation

## Evidence
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `git diff --check`
- pre-commit `verify:quick` passed, including manifest checks, format, lint, docs validation, and typecheck

## Deployment target
- v0.1.622 proof `proof-1780247880175` reached `TOOL_CALL_END` for `number-generator` but never emitted `TOOL_CALL_RESULT`.
- v0.1.623 includes #1962, which makes provider stream cancellation best-effort after local tool handoff.\n