### PR TITLE
Keep server-resolved project tools in runtime execution

### DIFF
--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -8,7 +8,7 @@ import type {
   AgentServiceSandboxToolsResult,
   CreateSandboxBashTool,
 } from "#veryfront/sandbox";
-import type { Tool } from "#veryfront/tool";
+import { type Tool, toolRegistry } from "#veryfront/tool";
 import { AgentRunSessionManager } from "./session-manager.ts";
 import { createRuntimeAgentStreamResponse } from "./run-stream.ts";
 
@@ -370,6 +370,83 @@ describe("internal-agents/run-stream", () => {
     );
 
     assertEquals(capturedToolResult, { randomNumber: 7 });
+  });
+
+  it("keeps server-resolved project source tools out of injected studio waits", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    const projectTool = {
+      id: "number-generator",
+      type: "function",
+      description: "Generate a number",
+      inputSchema: {} as never,
+      inputSchemaJson: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      execute: () => ({ randomNumber: 7 }),
+    } as Tool;
+    let capturedToolEntry: Tool | boolean | undefined;
+
+    toolRegistry.register("number-generator", projectTool);
+    try {
+      const agent = {
+        id: "random",
+        config: {
+          id: "random",
+          model: "anthropic/claude-opus-4-6",
+          system: "test",
+          tools: {
+            "number-generator": true,
+          },
+        },
+      } as unknown as Agent;
+
+      const input = {
+        agentId: "random",
+        threadId: crypto.randomUUID(),
+        runId: "run_1",
+        messages: [],
+        tools: [
+          {
+            name: "number-generator",
+            description: "Generates a random number within a specified range.",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+        context: [],
+        forwardedProps: {
+          runtimeOverrides: {
+            serverResolvedProjectTools: ["number-generator"],
+          },
+        },
+      } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+      await createRuntimeAgentStreamResponse(
+        input,
+        agent,
+        {
+          sessionManager,
+          createRuntime: (_agent, mergedTools) => {
+            if (mergedTools && mergedTools !== true) {
+              capturedToolEntry = mergedTools["number-generator"];
+            }
+            return {
+              stream: async () =>
+                new ReadableStream<Uint8Array>({
+                  start(controller) {
+                    controller.close();
+                  },
+                }),
+            };
+          },
+        },
+      );
+    } finally {
+      toolRegistry.delete("number-generator");
+    }
+
+    assertEquals(capturedToolEntry, true);
   });
 
   it("emits comment heartbeats while the runtime stream is idle", async () => {

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -120,6 +120,7 @@ function buildMergedTools(
   availableForwardedToolNames?: string[],
   availableLocalTools?: Record<string, Tool | boolean>,
 ) {
+  const serverResolvedProjectToolNames = getServerResolvedProjectToolNames(input.forwardedProps);
   const concreteSourceToolNames = agent.config.tools && agent.config.tools !== true
     ? new Set(
       Object.entries(agent.config.tools)
@@ -129,7 +130,10 @@ function buildMergedTools(
     : new Set<string>();
   const injectedTools = Object.fromEntries(
     input.tools
-      .filter((tool) => !concreteSourceToolNames.has(tool.name))
+      .filter((tool) =>
+        !concreteSourceToolNames.has(tool.name) &&
+        !serverResolvedProjectToolNames.has(tool.name)
+      )
       .map((tool) => [
         tool.name,
         createInjectedStudioTool(
@@ -169,6 +173,7 @@ function buildMergedTools(
         toolRegistry.get(toolName) ||
         availableLocalTools?.[toolName] ||
         availableForwardedToolNames?.includes(toolName) ||
+        serverResolvedProjectToolNames.has(toolName) ||
         sourceAllowedRemoteToolNames.includes(toolName)
       ) {
         merged[toolName] = availableLocalTools?.[toolName] ?? true;
@@ -291,6 +296,22 @@ function getAllowedRemoteToolNames(
     return [];
   }
   return allowedTools.every((toolName) => typeof toolName === "string") ? allowedTools : [];
+}
+
+function getServerResolvedProjectToolNames(
+  forwardedProps: RuntimeRunAgentInput["forwardedProps"],
+): Set<string> {
+  const runtimeOverrides = isRecord(forwardedProps?.runtimeOverrides)
+    ? forwardedProps.runtimeOverrides
+    : null;
+  if (!runtimeOverrides) return new Set();
+  const toolNames = runtimeOverrides.serverResolvedProjectTools;
+  if (!Array.isArray(toolNames)) return new Set();
+  return new Set(
+    toolNames.filter((toolName): toolName is string =>
+      typeof toolName === "string" && toolName.length > 0
+    ),
+  );
 }
 
 interface ForwardedToolDef {


### PR DESCRIPTION
## Summary
- Prevent internal agent runs from wrapping API-marked `serverResolvedProjectTools` as injected Studio wait tools.
- Keep boolean project-source tool declarations, such as `number-generator: true`, on the runtime registry execution path.
- Add a regression for the exact forwarded metadata shape observed in staging.

## Evidence
- Staging v0.1.623 proof `proof-1780249895117` reached `TOOL_CALL_END` for `number-generator` but remained `running` with no `TOOL_CALL_RESULT`.
- Request snapshot included `forwardedProps.runtimeOverrides.serverResolvedProjectTools: ["number-generator"]`.
- Server logs showed the project runtime had a pre-converted `number-generator` tool definition, so replacing it with an injected wait tool was the broken boundary.

## Verification
- `deno fmt --check src/internal-agents/run-stream.ts src/internal-agents/run-stream.test.ts`
- `deno test --no-check --allow-all src/internal-agents/run-stream.test.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/index.test.ts`
- `deno task verify:quick`

No user tokens, cookies, or PII included in this PR.