### PR TITLE
Release server-resolved project tool fix as v0.1.624

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.623",
+  "version": "0.1.624",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -446,7 +446,7 @@ describe("internal-agents/run-stream", () => {
       toolRegistry.delete("number-generator");
     }
 
-    assertEquals(capturedToolEntry, true);
+    assertEquals(capturedToolEntry, projectTool);
   });
 
   it("emits comment heartbeats while the runtime stream is idle", async () => {

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -169,14 +169,17 @@ function buildMergedTools(
   const merged: Record<string, Tool | boolean> = {};
   for (const [toolName, entry] of Object.entries(agent.config.tools)) {
     if (entry === true) {
+      const serverResolvedProjectTool = serverResolvedProjectToolNames.has(toolName)
+        ? toolRegistry.get(toolName)
+        : undefined;
       if (
+        serverResolvedProjectTool ||
         toolRegistry.get(toolName) ||
         availableLocalTools?.[toolName] ||
         availableForwardedToolNames?.includes(toolName) ||
-        serverResolvedProjectToolNames.has(toolName) ||
         sourceAllowedRemoteToolNames.includes(toolName)
       ) {
-        merged[toolName] = availableLocalTools?.[toolName] ?? true;
+        merged[toolName] = availableLocalTools?.[toolName] ?? serverResolvedProjectTool ?? true;
       }
       continue;
     }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.623";
+export const VERSION = "0.1.624";


### PR DESCRIPTION
## Summary
- Bump Veryfront Code to `v0.1.624` so the merged server-resolved project tool fix can be built and deployed to staging.

## Evidence
- Fix PR #1964 merged after all required checks passed.
- Local release commit hook ran `deno task verify:quick` successfully.

## Verification
- `deno task verify:quick`

No user tokens, cookies, or PII included.