### PR TITLE
Load ESM-only API handler dependencies as real ES modules

### DIFF
--- a/src/routing/api/module-loader/external-import-rewriter.ts
+++ b/src/routing/api/module-loader/external-import-rewriter.ts
@@ -188,6 +188,83 @@ export async function resolveNodePackageToFileUrl(
   }
 }
 
+/** Location of an ESM-only user dependency, used to rewrite imports to real ES module URLs. */
+export interface EsmDependencyLocation {
+  /** file:// URL of the package's ESM entry point. */
+  entryUrl: string;
+  /** file:// URL of the package's root directory (for subpath imports). */
+  packageDirUrl: string;
+}
+
+/**
+ * Decide whether an installed package must be loaded as a real ES module.
+ *
+ * ESM-only packages (e.g. `"type": "module"` packages that use `import.meta` or
+ * top-level await) cannot be evaluated as CommonJS via the compiled-binary
+ * `new Function` shim. We treat a package as ESM when its package.json declares
+ * `"type": "module"` or its resolved entry point is a `.mjs` file.
+ */
+function isEsmPackage(pkgJson: Record<string, unknown>, entry: string): boolean {
+  if (pkgJson.type === "module") return true;
+  return entry.endsWith(".mjs");
+}
+
+/**
+ * Resolve a package's ESM entry point, preferring the conditional `import`
+ * export, then the `module` field, then `main`.
+ */
+function resolveEsmEntry(pkgJson: Record<string, unknown>): string | undefined {
+  const exportsField = pkgJson.exports;
+  if (exportsField && typeof exportsField === "object") {
+    const dot = (exportsField as Record<string, unknown>)["."];
+    const fromExports = resolveExportEntry(dot ?? exportsField);
+    if (fromExports) return fromExports;
+  } else if (typeof exportsField === "string") {
+    return exportsField;
+  }
+
+  const moduleField = pkgJson.module;
+  if (typeof moduleField === "string") return moduleField;
+  const mainField = pkgJson.main;
+  if (typeof mainField === "string") return mainField;
+  return "index.js";
+}
+
+/**
+ * Identify the subset of user dependencies that are ESM-only and resolve each
+ * to file:// URLs so the compiled-binary loader can import them as real ES
+ * modules instead of transpiling them to CommonJS. CJS dependencies are omitted
+ * and continue to load through the `createRequire`-based shim.
+ */
+export async function resolveEsmUserDependencies(
+  projectDir: string,
+  fs: FileSystem,
+  userDeps: Map<string, string>,
+): Promise<Map<string, EsmDependencyLocation>> {
+  const esmDeps = new Map<string, EsmDependencyLocation>();
+
+  for (const name of userDeps.keys()) {
+    const packagePath = pathHelper.join(projectDir, "node_modules", name);
+    try {
+      const pkgJson = JSON.parse(
+        await fs.readTextFile(pathHelper.join(packagePath, "package.json")),
+      ) as Record<string, unknown>;
+
+      const entry = resolveEsmEntry(pkgJson);
+      if (!entry || !isEsmPackage(pkgJson, entry)) continue;
+
+      esmDeps.set(name, {
+        entryUrl: pathHelper.toFileUrl(pathHelper.join(packagePath, entry)).href,
+        packageDirUrl: pathHelper.toFileUrl(packagePath).href,
+      });
+    } catch (_) {
+      /* expected: package.json missing/invalid → treat as CJS */
+    }
+  }
+
+  return esmDeps;
+}
+
 export async function loadVeryfrontExportsMap(
   projectDir: string,
   fs: FileSystem,
@@ -314,11 +391,37 @@ export function rewriteCompiledBinaryVeryfrontImports(code: string): string {
 export function rewriteCompiledBinaryUserDependencyImports(
   code: string,
   userDeps: Map<string, string>,
+  esmDeps: Map<string, EsmDependencyLocation> = new Map(),
 ): string {
   let transformed = code;
 
   for (const name of userDeps.keys()) {
     const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+    // ESM-only dependencies are rewritten to real ES module file:// URLs so that
+    // import.meta, top-level await, etc. work. They must NOT be transpiled to
+    // CommonJS and evaluated via the `new Function` shim (see __vf_loadCjs).
+    const esm = esmDeps.get(name);
+    if (esm) {
+      transformed = transformed.replace(
+        new RegExp(`from\\s+["']${escaped}(/[^"']+)["']`, "g"),
+        (_, subpath) => `from "${esm.packageDirUrl}${subpath}"`,
+      );
+      transformed = transformed.replace(
+        new RegExp(`from\\s+["']${escaped}["']`, "g"),
+        () => `from "${esm.entryUrl}"`,
+      );
+      transformed = transformed.replace(
+        new RegExp(`import\\s*\\(\\s*["']${escaped}(/[^"']+)["']\\s*\\)`, "g"),
+        (_, subpath) => `import("${esm.packageDirUrl}${subpath}")`,
+      );
+      transformed = transformed.replace(
+        new RegExp(`import\\s*\\(\\s*["']${escaped}["']\\s*\\)`, "g"),
+        () => `import("${esm.entryUrl}")`,
+      );
+      continue;
+    }
+
     transformed = transformed.replace(
       new RegExp(`import\\s+(\\w+)\\s+from\\s+["']${escaped}["']`, "g"),
       (_, localName) => `const ${localName} = __vf_interopDefault(require("${name}"))`,
@@ -445,7 +548,8 @@ export async function rewriteExternalImports(
     // injected by the esbuild banner) to load CJS packages from node_modules,
     // since npm: specifiers only work for packages embedded at compile time.
     if (isCompiledBinary()) {
-      transformed = rewriteCompiledBinaryUserDependencyImports(transformed, userDeps);
+      const esmDeps = await resolveEsmUserDependencies(projectDir, fs, userDeps);
+      transformed = rewriteCompiledBinaryUserDependencyImports(transformed, userDeps, esmDeps);
     } else {
       transformed = await rewriteDenoNpmDependencyImports(transformed, projectDir, fs, userDeps);
     }

--- a/src/routing/api/module-loader/external-import-rewriter.ts
+++ b/src/routing/api/module-loader/external-import-rewriter.ts
@@ -3,6 +3,7 @@ import type { FileSystem } from "#veryfront/platform/compat/fs.ts";
 import * as pathHelper from "#veryfront/compat/path";
 import { isDeno, isNode } from "#veryfront/platform/compat/runtime.ts";
 import { rewriteNpmImports } from "#veryfront/transforms/npm-import-rewrites.ts";
+import { isWithinDirectory } from "#veryfront/security/path-validation.ts";
 import { resolveExportEntry, toCjsDestructureBindings } from "./loader-helpers.ts";
 
 const logger = serverLogger.component("api");
@@ -192,8 +193,8 @@ export async function resolveNodePackageToFileUrl(
 export interface EsmDependencyLocation {
   /** file:// URL of the package's ESM entry point. */
   entryUrl: string;
-  /** file:// URL of the package's root directory (for subpath imports). */
-  packageDirUrl: string;
+  /** Absolute path of the package's root directory (used to contain subpath imports). */
+  packageDir: string;
 }
 
 /**
@@ -244,18 +245,30 @@ export async function resolveEsmUserDependencies(
   const esmDeps = new Map<string, EsmDependencyLocation>();
 
   for (const name of userDeps.keys()) {
-    const packagePath = pathHelper.join(projectDir, "node_modules", name);
+    const packageDir = pathHelper.resolve(pathHelper.join(projectDir, "node_modules", name));
     try {
       const pkgJson = JSON.parse(
-        await fs.readTextFile(pathHelper.join(packagePath, "package.json")),
+        await fs.readTextFile(pathHelper.join(packageDir, "package.json")),
       ) as Record<string, unknown>;
 
       const entry = resolveEsmEntry(pkgJson);
       if (!entry || !isEsmPackage(pkgJson, entry)) continue;
 
+      // The entry path comes from the dependency's own package.json, which is
+      // attacker-influenceable (a malicious/compromised package could set
+      // "main": "../../../etc/passwd"). Reject entries that resolve outside the
+      // package directory so a crafted package.json cannot turn into a file://
+      // import that escapes node_modules. This mirrors the containment guard the
+      // CJS loader shim enforces via __vf_assertContained.
+      const entryPath = pathHelper.resolve(pathHelper.join(packageDir, entry));
+      if (!isWithinDirectory(packageDir, entryPath)) {
+        logger.warn(`Skipping ESM dependency ${name}: entry escapes package directory (${entry})`);
+        continue;
+      }
+
       esmDeps.set(name, {
-        entryUrl: pathHelper.toFileUrl(pathHelper.join(packagePath, entry)).href,
-        packageDirUrl: pathHelper.toFileUrl(packagePath).href,
+        entryUrl: pathHelper.toFileUrl(entryPath).href,
+        packageDir,
       });
     } catch (_) {
       /* expected: package.json missing/invalid → treat as CJS */
@@ -403,9 +416,25 @@ export function rewriteCompiledBinaryUserDependencyImports(
     // CommonJS and evaluated via the `new Function` shim (see __vf_loadCjs).
     const esm = esmDeps.get(name);
     if (esm) {
+      // Resolve a subpath import to a contained file:// URL. The subpath comes
+      // from the handler source; reject any that escape the package directory
+      // (e.g. "pkg/../../secret") by leaving the import untouched so it fails to
+      // resolve rather than reading outside node_modules.
+      const subpathUrl = (subpath: string, original: string): string | null => {
+        const target = pathHelper.resolve(pathHelper.join(esm.packageDir, subpath));
+        if (!isWithinDirectory(esm.packageDir, target)) {
+          logger.warn(`Skipping ESM subpath import that escapes package directory: ${original}`);
+          return null;
+        }
+        return pathHelper.toFileUrl(target).href;
+      };
+
       transformed = transformed.replace(
         new RegExp(`from\\s+["']${escaped}(/[^"']+)["']`, "g"),
-        (_, subpath) => `from "${esm.packageDirUrl}${subpath}"`,
+        (match, subpath) => {
+          const url = subpathUrl(subpath, match);
+          return url ? `from "${url}"` : match;
+        },
       );
       transformed = transformed.replace(
         new RegExp(`from\\s+["']${escaped}["']`, "g"),
@@ -413,7 +442,10 @@ export function rewriteCompiledBinaryUserDependencyImports(
       );
       transformed = transformed.replace(
         new RegExp(`import\\s*\\(\\s*["']${escaped}(/[^"']+)["']\\s*\\)`, "g"),
-        (_, subpath) => `import("${esm.packageDirUrl}${subpath}")`,
+        (match, subpath) => {
+          const url = subpathUrl(subpath, match);
+          return url ? `import("${url}")` : match;
+        },
       );
       transformed = transformed.replace(
         new RegExp(`import\\s*\\(\\s*["']${escaped}["']\\s*\\)`, "g"),

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -409,7 +409,7 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
         "esm-lib",
         {
           entryUrl: "file:///proj/node_modules/esm-lib/index.mjs",
-          packageDirUrl: "file:///proj/node_modules/esm-lib",
+          packageDir: "/proj/node_modules/esm-lib",
         },
       ]]),
     );
@@ -451,7 +451,7 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
         "esm-lib",
         {
           entryUrl: "file:///proj/node_modules/esm-lib/index.mjs",
-          packageDirUrl: "file:///proj/node_modules/esm-lib",
+          packageDir: "/proj/node_modules/esm-lib",
         },
       ]]),
     );
@@ -500,6 +500,59 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
       esmDeps.get("exports-import-lib")?.entryUrl ?? "",
       /node_modules\/exports-import-lib\/dist\/index\.js$/,
     );
+  });
+
+  it("does not treat a dependency whose entry escapes its package dir as ESM", async () => {
+    const tmpDir = await makeTempDir();
+    const dir = join(tmpDir, "node_modules", "evil-lib");
+    await fs.mkdir(dir, { recursive: true });
+    // Malicious/compromised package: entry points outside node_modules.
+    await fs.writeTextFile(
+      join(dir, "package.json"),
+      JSON.stringify({ type: "module", main: "../../../../etc/passwd" }),
+    );
+
+    const esmDeps = await resolveEsmUserDependencies(
+      tmpDir,
+      fs,
+      new Map([["evil-lib", "^1.0.0"]]),
+    );
+
+    // The traversing entry must be rejected so no file:// import escaping the
+    // package directory is emitted (it falls back to the contained CJS shim).
+    assertEquals(esmDeps.has("evil-lib"), false);
+  });
+
+  it("leaves ESM subpath imports that escape the package dir unrewritten", () => {
+    const source = [
+      'import ok from "esm-lib/dist/ok.mjs";',
+      'import escape from "esm-lib/../../../../etc/passwd";',
+      'const dyn = import("esm-lib/../../secret");',
+    ].join("\n");
+
+    const rewritten = rewriteCompiledBinaryUserDependencyImports(
+      source,
+      new Map([["esm-lib", "^1.0.0"]]),
+      new Map([[
+        "esm-lib",
+        {
+          entryUrl: "file:///proj/node_modules/esm-lib/index.mjs",
+          packageDir: "/proj/node_modules/esm-lib",
+        },
+      ]]),
+    );
+
+    // Contained subpath is rewritten to a file:// URL within the package.
+    assertMatch(
+      rewritten,
+      /import ok from "file:\/\/\/proj\/node_modules\/esm-lib\/dist\/ok\.mjs"/,
+    );
+    // Traversing subpaths are left as the original bare specifier (which fails
+    // to resolve) — crucially, NO escaping file:// URL is emitted for them.
+    assertEquals(rewritten.includes("file:///etc/passwd"), false);
+    assertEquals(rewritten.includes("file:///proj/secret"), false);
+    assertMatch(rewritten, /import escape from "esm-lib\/\.\.\/\.\.\/\.\.\/\.\.\/etc\/passwd"/);
+    assertMatch(rewritten, /import\("esm-lib\/\.\.\/\.\.\/secret"\)/);
   });
 
   it("rewrites non-compiled deno user dependency imports to npm: specifiers with resolved versions", async () => {

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -6,6 +6,7 @@ import {
   generateCompiledBinaryRequireShim,
   getNodeExternalPackagesToResolve,
   loadHandlerModule,
+  resolveEsmUserDependencies,
   rewriteCompiledBinaryUserDependencyImports,
   rewriteCompiledBinaryVeryfrontImports,
   rewriteDenoNodeBuiltinImports,
@@ -389,6 +390,116 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
     );
     assertMatch(rewritten, /const widget = require\("my-lib\/subpath"\)/);
     assertMatch(rewritten, /Promise\.resolve\(require\("my-lib\/subpath"\)\)/);
+  });
+
+  it("rewrites ESM-only user dependency imports to real file:// module URLs", () => {
+    const source = [
+      'import thing from "esm-lib";',
+      'import { alpha } from "esm-lib";',
+      'import * as namespace from "esm-lib";',
+      'import widget from "esm-lib/subpath";',
+      'const loaded = import("esm-lib");',
+      'const sub = import("esm-lib/subpath");',
+    ].join("\n");
+
+    const rewritten = rewriteCompiledBinaryUserDependencyImports(
+      source,
+      new Map([["esm-lib", "^1.0.0"]]),
+      new Map([[
+        "esm-lib",
+        {
+          entryUrl: "file:///proj/node_modules/esm-lib/index.mjs",
+          packageDirUrl: "file:///proj/node_modules/esm-lib",
+        },
+      ]]),
+    );
+
+    // ESM deps keep native import syntax (no require / new Function path), so
+    // import.meta and top-level await inside the dependency stay valid.
+    assertMatch(
+      rewritten,
+      /import thing from "file:\/\/\/proj\/node_modules\/esm-lib\/index\.mjs"/,
+    );
+    assertMatch(
+      rewritten,
+      /import \{ alpha \} from "file:\/\/\/proj\/node_modules\/esm-lib\/index\.mjs"/,
+    );
+    assertMatch(
+      rewritten,
+      /import \* as namespace from "file:\/\/\/proj\/node_modules\/esm-lib\/index\.mjs"/,
+    );
+    assertMatch(
+      rewritten,
+      /import widget from "file:\/\/\/proj\/node_modules\/esm-lib\/subpath"/,
+    );
+    assertMatch(rewritten, /import\("file:\/\/\/proj\/node_modules\/esm-lib\/index\.mjs"\)/);
+    assertMatch(rewritten, /import\("file:\/\/\/proj\/node_modules\/esm-lib\/subpath"\)/);
+    // No CJS require shim should be emitted for the ESM dependency.
+    assertEquals(rewritten.includes('require("esm-lib")'), false);
+  });
+
+  it("keeps CJS deps on the require shim while ESM deps use file:// URLs", () => {
+    const source = [
+      'import esm from "esm-lib";',
+      'import cjs from "cjs-lib";',
+    ].join("\n");
+
+    const rewritten = rewriteCompiledBinaryUserDependencyImports(
+      source,
+      new Map([["esm-lib", "^1.0.0"], ["cjs-lib", "^1.0.0"]]),
+      new Map([[
+        "esm-lib",
+        {
+          entryUrl: "file:///proj/node_modules/esm-lib/index.mjs",
+          packageDirUrl: "file:///proj/node_modules/esm-lib",
+        },
+      ]]),
+    );
+
+    assertMatch(rewritten, /import esm from "file:\/\/\/proj\/node_modules\/esm-lib\/index\.mjs"/);
+    assertMatch(rewritten, /const cjs = __vf_interopDefault\(require\("cjs-lib"\)\)/);
+  });
+
+  it("detects ESM dependencies via type:module and .mjs entry points", async () => {
+    const tmpDir = await makeTempDir();
+
+    async function writePackage(name: string, pkg: Record<string, unknown>) {
+      const dir = join(tmpDir, "node_modules", name);
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeTextFile(join(dir, "package.json"), JSON.stringify(pkg));
+    }
+
+    await writePackage("type-module-lib", { type: "module", main: "index.js" });
+    await writePackage("mjs-main-lib", { main: "index.mjs" });
+    await writePackage("exports-import-lib", {
+      type: "module",
+      exports: { ".": { import: "./dist/index.js", require: "./dist/index.cjs" } },
+    });
+    await writePackage("cjs-lib", { main: "index.js" });
+
+    const esmDeps = await resolveEsmUserDependencies(
+      tmpDir,
+      fs,
+      new Map([
+        ["type-module-lib", "^1.0.0"],
+        ["mjs-main-lib", "^1.0.0"],
+        ["exports-import-lib", "^1.0.0"],
+        ["cjs-lib", "^1.0.0"],
+        ["missing-lib", "^1.0.0"],
+      ]),
+    );
+
+    assertEquals(esmDeps.has("type-module-lib"), true);
+    assertEquals(esmDeps.has("mjs-main-lib"), true);
+    assertEquals(esmDeps.has("exports-import-lib"), true);
+    // CommonJS and uninstalled packages are not treated as ESM.
+    assertEquals(esmDeps.has("cjs-lib"), false);
+    assertEquals(esmDeps.has("missing-lib"), false);
+
+    assertMatch(
+      esmDeps.get("exports-import-lib")?.entryUrl ?? "",
+      /node_modules\/exports-import-lib\/dist\/index\.js$/,
+    );
   });
 
   it("rewrites non-compiled deno user dependency imports to npm: specifiers with resolved versions", async () => {

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -27,6 +27,7 @@ export {
   generateCompiledBinaryRequireShim,
   getNodeExternalPackagesToResolve,
   loadVeryfrontExportsMap,
+  resolveEsmUserDependencies,
   resolveNodePackageToFileUrl,
   rewriteCompiledBinaryUserDependencyImports,
   rewriteCompiledBinaryVeryfrontImports,


### PR DESCRIPTION
## Description

The compiled-binary API-handler module loader rewrote **every** externalized user dependency import into CommonJS `require()` calls evaluated through `new Function` (`__vf_loadCjs` in `generateCompiledBinaryRequireShim`). That works for CJS packages, but ESM-only packages that use `import.meta` (or top-level `await`) fail to load:

```
SyntaxError: Cannot use 'import.meta' outside a module
    at new Function ()
    at __vf_loadCjs (/tmp/vf-api-XXXX/handler.mjs:64:12)
```

This PR makes the loader detect ESM-only user dependencies and rewrite their imports to **real `file://` ES module URLs** instead of transpiling them to CommonJS, matching the behavior already observed under `deno task dev` (where Deno loads them as native ES modules). CJS dependencies continue to use the `createRequire`-based shim.

### What changed

`src/routing/api/module-loader/external-import-rewriter.ts`:
- `resolveEsmUserDependencies()` — reads each user dependency's `package.json`, treats it as ESM when `"type": "module"` or the resolved entry is a `.mjs` file, and resolves its entry point (preferring the conditional `import` export, then `module`, then `main`).
- `rewriteCompiledBinaryUserDependencyImports()` — for ESM deps, rewrites `from "pkg"` / `from "pkg/sub"` / `import("pkg")` to the resolved `file://` URLs and **skips** the CJS `require()` path. CJS deps are unchanged.

### Security hardening (from review)

The `file://` URLs are built from a dependency's own `package.json` (`main`/`exports`/`module`) and from handler subpath imports — both partially attacker-influenceable. The new path now enforces containment to the package directory (mirroring the CJS shim's `__vf_assertContained`):
- A dependency whose entry resolves outside its package dir (e.g. `"main": "../../../etc/passwd"`) is rejected and falls back to the contained CJS shim.
- A handler subpath import that escapes the package dir (e.g. `pkg/../../secret`) is left unrewritten so it fails to resolve rather than reading outside `node_modules`.

## Related Issue(s)

Fixes #1969

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Testing

- New unit tests cover ESM rewriting, mixed ESM/CJS deps, ESM detection (`type:module`, `.mjs`, conditional `exports`), and the two containment guards (red-green verified).
- `deno test src/routing/api/module-loader/` → 7 files, 61 steps, 0 failures.
- `deno lint` clean on changed files.

> Note: this fixes the rewrite path. ESM dependencies with further *bare transitive* imports rely on the runtime's `node_modules` resolution and are out of scope here (the same as the existing Node `file://` path).