### PR TITLE
Fix Deno npm HMR WebSocket upgrades

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.626",
+  "version": "0.1.627",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/platform/adapters/runtime/deno/adapter.ts
+++ b/src/platform/adapters/runtime/deno/adapter.ts
@@ -290,12 +290,15 @@ class DenoEnvironmentAdapter implements EnvironmentAdapter {
 
 class DenoServerAdapter implements ServerAdapter {
   upgradeWebSocket(request: Request): WebSocketUpgrade {
-    if (typeof Deno === "undefined") {
+    // Access native Deno via `self` to bypass dnt shim transform.
+    // dnt rewrites `globalThis.Deno` to @deno/shim-deno, which lacks upgradeWebSocket.
+    const nativeDeno = (self as unknown as Record<string, typeof Deno>)["Deno"];
+    if (typeof nativeDeno?.upgradeWebSocket !== "function") {
       throw NOT_SUPPORTED.create({
         detail: "DenoServerAdapter.upgradeWebSocket() can only be used in Deno runtime",
       });
     }
-    const { socket, response } = Deno.upgradeWebSocket(request);
+    const { socket, response } = nativeDeno.upgradeWebSocket(request);
     return { socket, response };
   }
 }

--- a/src/platform/compat/http/websocket.ts
+++ b/src/platform/compat/http/websocket.ts
@@ -24,10 +24,19 @@ function upgradeWebSocketDeno(
   request: Request,
   options?: WebSocketUpgradeOptions,
 ): WebSocketUpgradeResult {
+  // Access native Deno via `self` to bypass dnt shim transform.
+  // dnt rewrites `globalThis.Deno` to @deno/shim-deno, which lacks upgradeWebSocket.
+  const nativeDeno = (self as unknown as Record<string, typeof Deno>)["Deno"];
+  if (typeof nativeDeno?.upgradeWebSocket !== "function") {
+    throw NOT_SUPPORTED.create({
+      detail: "Deno.upgradeWebSocket() is not available in this runtime.",
+    });
+  }
+
   const denoOptions: Deno.UpgradeWebSocketOptions | undefined = options?.protocol
     ? { protocol: options.protocol }
     : undefined;
 
-  const { socket, response } = Deno.upgradeWebSocket(request, denoOptions);
+  const { socket, response } = nativeDeno.upgradeWebSocket(request, denoOptions);
   return { socket, response };
 }

--- a/src/server/handlers/preview/hmr.handler.test.ts
+++ b/src/server/handlers/preview/hmr.handler.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { NOT_SUPPORTED } from "#veryfront/errors";
 import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
 import type { HandlerContext } from "../types.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
@@ -411,6 +412,25 @@ describe("server/handlers/preview/hmr.handler", () => {
       });
       const result = await handler.handle(req, ctx);
       assertEquals(result.response!.status, 500);
+    });
+
+    it("returns 501 when upgradeWebSocket is unsupported by the runtime", async () => {
+      const handler = new HMRHandler();
+      const req = new Request("http://localhost/_ws", {
+        headers: { upgrade: "websocket" },
+      });
+      const ctx = makeCtx({
+        isLocalProject: true,
+        adapter: createMockAdapter({
+          upgradeWebSocket: () => {
+            throw NOT_SUPPORTED.create({
+              detail: "Deno.upgradeWebSocket() is not available in this runtime.",
+            });
+          },
+        }),
+      });
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.response!.status, 501);
     });
   });
 });

--- a/src/server/handlers/preview/hmr.handler.ts
+++ b/src/server/handlers/preview/hmr.handler.ts
@@ -1,5 +1,6 @@
 import { HMR_MAX_MESSAGES_PER_MINUTE, serverLogger } from "#veryfront/utils";
 import { RateLimiter } from "#veryfront/modules/server/index.ts";
+import { VeryfrontError } from "#veryfront/errors";
 import { BaseHandler } from "../response/base.ts";
 import {
   type HandlerContext,
@@ -215,6 +216,11 @@ export class HMRHandler extends BaseHandler {
 
       return this.respond(response);
     } catch (error) {
+      if (error instanceof VeryfrontError && error.status === 501) {
+        logger.warn("WebSocket upgrade not supported by runtime", { error });
+        return this.respond(new Response("WebSocket not supported", { status: 501 }));
+      }
+
       logger.error("WebSocket upgrade failed", { error });
       return this.respond(new Response("WebSocket upgrade failed", { status: 500 }));
     }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.626";
+export const VERSION = "0.1.627";


### PR DESCRIPTION
## Summary
- use native Deno access for npm-built WebSocket upgrades so dnt does not route HMR through `dntShim.Deno`
- preserve 501 responses for unsupported WebSocket runtimes while keeping real upgrade errors as 500
- bump framework package version to 0.1.627

## Verification
- `deno test --no-check --allow-all src/server/handlers/preview/hmr.handler.test.ts src/platform/compat/http/websocket.test.ts src/platform/adapters/runtime/deno/adapter.test.ts src/utils/version.test.ts`
- `deno check src/server/handlers/preview/hmr.handler.ts src/server/handlers/preview/hmr.handler.test.ts src/platform/adapters/runtime/deno/adapter.ts src/platform/compat/http/websocket.ts src/utils/version-constant.ts`
- `deno lint src/server/handlers/preview/hmr.handler.ts src/server/handlers/preview/hmr.handler.test.ts src/platform/adapters/runtime/deno/adapter.ts src/platform/compat/http/websocket.ts src/utils/version-constant.ts`
- `deno task build:npm`
- generated npm WebSocket paths use `nativeDeno.upgradeWebSocket`, not `dntShim.Deno.upgradeWebSocket`
- local generated package smoke: DORA app loads, `/_ws` returns `101 Switching Protocols`
- pre-push hook: `1940 passed`, `0 failed`
