### PR TITLE
Treat partial tool-input streams as provisional

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.627",
+  "version": "0.1.628",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -310,17 +310,10 @@ describe("chat-stream-handler", () => {
 
       assertEquals(state.finishReason, "tool-calls");
       assertEquals(state.toolCalls.size, 1);
-      assertEquals(events, [
-        { type: "tool-input-start", toolCallId: "tc-1", toolName: "gmail__get_email" },
-        {
-          type: "tool-input-delta",
-          toolCallId: "tc-1",
-          inputTextDelta: '{"id":"msg-1"}',
-        },
-      ]);
+      assertEquals(events, []);
     });
 
-    it("processes tool-input-start and tool-input-delta", async () => {
+    it("buffers provisional tool-input-start and tool-input-delta until the tool call is committed", async () => {
       const { events, controller, encoder } = createSSECollector();
       const state = createStreamState();
 
@@ -337,18 +330,8 @@ describe("chat-stream-handler", () => {
       const tc = state.toolCalls.get("tc-1")!;
       assertEquals(tc.name, "search");
       assertEquals(tc.arguments, '{"query":"test"}');
-
-      assertEquals(events[0], { type: "tool-input-start", toolCallId: "tc-1", toolName: "search" });
-      assertEquals(events[1], {
-        type: "tool-input-delta",
-        toolCallId: "tc-1",
-        inputTextDelta: '{"query":',
-      });
-      assertEquals(events[2], {
-        type: "tool-input-delta",
-        toolCallId: "tc-1",
-        inputTextDelta: '"test"}',
-      });
+      assertEquals(tc.inputAvailable, false);
+      assertEquals(events, []);
     });
 
     it("replaces a transient empty-object placeholder when real streamed tool JSON begins", async () => {
@@ -367,22 +350,7 @@ describe("chat-stream-handler", () => {
 
       const tc = state.toolCalls.get("tc-placeholder")!;
       assertEquals(tc.arguments, '{"skillId":"plan"}');
-
-      assertEquals(events[1], {
-        type: "tool-input-delta",
-        toolCallId: "tc-placeholder",
-        inputTextDelta: "{}",
-      });
-      assertEquals(events[2], {
-        type: "tool-input-delta",
-        toolCallId: "tc-placeholder",
-        inputTextDelta: '{"skillId":"',
-      });
-      assertEquals(events[3], {
-        type: "tool-input-delta",
-        toolCallId: "tc-placeholder",
-        inputTextDelta: 'plan"}',
-      });
+      assertEquals(events, []);
     });
 
     it("dedupes cumulative streamed tool argument buffers instead of corrupting the JSON payload", async () => {
@@ -411,17 +379,7 @@ describe("chat-stream-handler", () => {
         tc.arguments,
         '{"path":"plans/report.md","content":"# Report\\n\\nExecutive summary"}',
       );
-
-      assertEquals(events[1], {
-        type: "tool-input-delta",
-        toolCallId: "tc-cumulative",
-        inputTextDelta: '{"path":"plans/report.md","content":"# Report',
-      });
-      assertEquals(events[2], {
-        type: "tool-input-delta",
-        toolCallId: "tc-cumulative",
-        inputTextDelta: '{"path":"plans/report.md","content":"# Report\\n\\nExecutive summary"}',
-      });
+      assertEquals(events, []);
     });
 
     it("dedupes repeated placeholder-style cumulative tool deltas without swallowing parse errors", async () => {
@@ -455,22 +413,7 @@ describe("chat-stream-handler", () => {
         tc.arguments,
         '{"path":"plans/report.md","content":"# Report\\n\\nExecutive summary"}',
       );
-
-      assertEquals(events[1], {
-        type: "tool-input-delta",
-        toolCallId: "tc-repeat-placeholder",
-        inputTextDelta: "{}",
-      });
-      assertEquals(events[2], {
-        type: "tool-input-delta",
-        toolCallId: "tc-repeat-placeholder",
-        inputTextDelta: '"path":"plans/report.md","content":"# Report',
-      });
-      assertEquals(events[3], {
-        type: "tool-input-delta",
-        toolCallId: "tc-repeat-placeholder",
-        inputTextDelta: '"path":"plans/report.md","content":"# Report\\n\\nExecutive summary"}',
-      });
+      assertEquals(events, []);
     });
 
     it("handles tool-call with full input object", async () => {
@@ -494,12 +437,16 @@ describe("chat-stream-handler", () => {
       assertEquals(tc.name, "weather");
       assertEquals(tc.arguments, '{"city":"Tokyo"}');
 
-      assertEquals(events[0], {
+      assertEquals(events, [{
+        type: "tool-input-start",
+        toolCallId: "tc-2",
+        toolName: "weather",
+      }, {
         type: "tool-input-available",
         toolCallId: "tc-2",
         toolName: "weather",
         input: { city: "Tokyo" },
-      });
+      }]);
     });
 
     it("normalizes quote-prefixed first tool-input deltas before a fallback empty tool-call payload arrives", async () => {
@@ -563,12 +510,16 @@ describe("chat-stream-handler", () => {
       const tc = state.toolCalls.get("tc-quoted")!;
       assertEquals(tc.arguments, '{"query":"Veryfront","maxUses":1}');
 
-      assertEquals(events[0], {
+      assertEquals(events, [{
+        type: "tool-input-start",
+        toolCallId: "tc-quoted",
+        toolName: "web_search",
+      }, {
         type: "tool-input-available",
         toolCallId: "tc-quoted",
         toolName: "web_search",
         input: { query: "Veryfront", maxUses: 1 },
-      });
+      }]);
     });
 
     it("keeps streamed tool JSON when the later tool-call payload is only an empty-object placeholder", async () => {
@@ -611,13 +562,17 @@ describe("chat-stream-handler", () => {
 
       const tc = state.toolCalls.get("tc-provider")!;
       assertEquals(tc.providerExecuted, true);
-      assertEquals(events[0], {
+      assertEquals(events, [{
+        type: "tool-input-start",
+        toolCallId: "tc-provider",
+        toolName: "web_search",
+      }, {
         type: "tool-input-available",
         toolCallId: "tc-provider",
         toolName: "web_search",
         input: { query: "Veryfront" },
         providerExecuted: true,
-      });
+      }]);
     });
 
     it("handles multiple tool calls in a single stream", async () => {
@@ -636,7 +591,7 @@ describe("chat-stream-handler", () => {
       assertEquals(state.toolCalls.get("tc-a")!.name, "search");
       assertEquals(state.toolCalls.get("tc-b")!.name, "fetch");
       assertEquals(state.finishReason, "tool-calls");
-      assertEquals(events.length, 2);
+      assertEquals(events.length, 4);
     });
 
     it("forwards tool results as tool-output-available SSE events", async () => {

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -29,6 +29,8 @@ export interface StreamingToolCall {
   id: string;
   name: string;
   arguments: string;
+  inputDeltas?: string[];
+  inputAnnounced?: boolean;
   inputAvailable?: boolean;
   providerExecuted?: boolean;
   dynamic?: boolean;
@@ -327,6 +329,30 @@ export function processStream(
       activeReasoningId = null;
     };
 
+    const announceToolInputStart = (toolCall: StreamingToolCall) => {
+      if (toolCall.inputAnnounced === true) {
+        return;
+      }
+
+      const dynamic = toolCall.dynamic ?? isDynamicTool(toolCall.name);
+      sendSSE(controller, encoder, {
+        type: "tool-input-start",
+        toolCallId: toolCall.id,
+        toolName: toolCall.name,
+        ...(dynamic ? { dynamic: true } : {}),
+      });
+
+      for (const delta of toolCall.inputDeltas ?? []) {
+        sendSSE(controller, encoder, {
+          type: "tool-input-delta",
+          toolCallId: toolCall.id,
+          inputTextDelta: delta,
+        });
+      }
+
+      toolCall.inputAnnounced = true;
+    };
+
     const ensureToolLifecycle = (part: {
       toolCallId: string;
       toolName: string;
@@ -348,6 +374,7 @@ export function processStream(
             ? { providerExecuted: part.providerExecuted }
             : {}),
           ...(dynamic ? { dynamic: true } : {}),
+          inputAnnounced: true,
         });
         sendSSE(controller, encoder, {
           type: "tool-input-start",
@@ -385,6 +412,7 @@ export function processStream(
         existing.dynamic = true;
       }
 
+      announceToolInputStart(existing);
       sendSSE(controller, encoder, {
         type: "tool-input-available",
         toolCallId: part.toolCallId,
@@ -486,14 +514,8 @@ export function processStream(
             inputAvailable: false,
             providerExecuted: typedPart.providerExecuted,
             dynamic: typedPart.dynamic,
-          });
-
-          const dynamic = isDynamicTool(typedPart.toolName);
-          sendSSE(controller, encoder, {
-            type: "tool-input-start",
-            toolCallId: toolId,
-            toolName: typedPart.toolName,
-            ...(dynamic ? { dynamic: true } : {}),
+            inputDeltas: [],
+            inputAnnounced: false,
           });
           break;
         }
@@ -505,11 +527,8 @@ export function processStream(
           if (!tc) break;
 
           tc.arguments = mergeToolInputDelta(tc.arguments, typedPart.delta);
-          sendSSE(controller, encoder, {
-            type: "tool-input-delta",
-            toolCallId: toolId,
-            inputTextDelta: typedPart.delta,
-          });
+          tc.inputDeltas ??= [];
+          tc.inputDeltas.push(typedPart.delta);
           break;
         }
 
@@ -519,19 +538,24 @@ export function processStream(
           // tool-call fires when the full tool call is available
           const toolId = typedPart.toolCallId;
           const inputStr = normalizeToolInputString(typedPart.input);
-          const previousArguments = state.toolCalls.get(toolId)?.arguments ?? "";
+          const previous = state.toolCalls.get(toolId);
+          const previousArguments = previous?.arguments ?? "";
           const resolvedArguments = mergeToolCallInput(previousArguments, inputStr);
-          state.toolCalls.set(toolId, {
+          const toolCall: StreamingToolCall = {
             id: toolId,
             name: typedPart.toolName,
             arguments: resolvedArguments,
+            inputDeltas: previous?.inputDeltas ?? [],
+            inputAnnounced: previous?.inputAnnounced ?? false,
             inputAvailable: true,
             providerExecuted: typedPart.providerExecuted,
             dynamic: typedPart.dynamic,
-          });
+          };
+          state.toolCalls.set(toolId, toolCall);
 
           const dynamic = isDynamicTool(typedPart.toolName);
           const inputObj = parseToolInputObject(typedPart.input);
+          announceToolInputStart(toolCall);
           sendSSE(controller, encoder, {
             type: "tool-input-available",
             toolCallId: toolId,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1234,14 +1234,16 @@ export class AgentRuntime {
             partialArgumentsLength: materialized.partialArgumentsLength,
             partialArgumentsPreview: materialized.partialArgumentsPreview,
           });
-          const dynamicIncomplete = isDynamicTool(tc.name);
-          sendSSE(controller, encoder, {
-            type: "tool-input-error",
-            toolCallId: tc.id,
-            errorText: `Stream terminated before tool-call event fired for "${tc.name}". ` +
-              `Received ${materialized.partialArgumentsLength} chars of partial tool-input deltas.`,
-            ...(dynamicIncomplete ? { dynamic: true } : {}),
-          });
+          if (tc.inputAnnounced === true) {
+            const dynamicIncomplete = isDynamicTool(tc.name);
+            sendSSE(controller, encoder, {
+              type: "tool-input-error",
+              toolCallId: tc.id,
+              errorText: `Stream terminated before tool-call event fired for "${tc.name}". ` +
+                `Received ${materialized.partialArgumentsLength} chars of partial tool-input deltas.`,
+              ...(dynamicIncomplete ? { dynamic: true } : {}),
+            });
+          }
         } else if (materialized.kind === "parse-error") {
           logger.warn("Failed to parse streamed tool arguments", {
             toolCallId: tc.id,
@@ -1331,6 +1333,7 @@ export class AgentRuntime {
             currentMessages,
             toolCalls,
             currentRunToolState,
+            { emitSse: tc.inputAnnounced === true },
           );
           continue;
         }
@@ -1508,18 +1511,21 @@ export class AgentRuntime {
     currentMessages: Message[],
     toolCalls: ToolCall[],
     currentRunToolState?: CurrentRunToolState,
+    options: { emitSse?: boolean } = {},
   ): Promise<void> {
     toolCall.status = "error";
     toolCall.error = errorStr;
     toolCalls.push(toolCall);
 
-    const dynamic = isDynamicTool(toolCall.name);
-    sendSSE(controller, encoder, {
-      type: "tool-output-error",
-      toolCallId: toolCall.id,
-      errorText: errorStr,
-      ...(dynamic ? { dynamic: true } : {}),
-    });
+    if (options.emitSse !== false) {
+      const dynamic = isDynamicTool(toolCall.name);
+      sendSSE(controller, encoder, {
+        type: "tool-output-error",
+        toolCallId: toolCall.id,
+        errorText: errorStr,
+        ...(dynamic ? { dynamic: true } : {}),
+      });
+    }
 
     const errorMessage = createToolErrorMessage(
       toolCall.id,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.627";
+export const VERSION = "0.1.628";

--- a/tests/chat/agent-runtime-streaming.test.ts
+++ b/tests/chat/agent-runtime-streaming.test.ts
@@ -5,7 +5,6 @@ import { deleteEnv, getEnv, setEnv } from "#veryfront/testing/deno-compat";
 import { tool } from "../../src/tool/factory.ts";
 import { type AgentConfig, type Message } from "../../src/agent/types.ts";
 import type { ModelRuntime } from "../../src/provider/types.ts";
-import { defineSchema } from "../../src/schemas/define.ts";
 
 function assert(condition: unknown, message?: string): void {
   if (!condition) throw new Error(message || "Assertion failed");
@@ -321,8 +320,13 @@ describe("AgentRuntime streaming", () => {
           "repeat-id": tool({
             id: "repeat-id",
             description: "Echoes the provided value",
-            inputSchema: defineSchema((v) => v.object({ value: v.number() }))(),
-            execute: async ({ value }) => {
+            inputSchema: {
+              type: "object",
+              properties: { value: { type: "number" } },
+              required: ["value"],
+              additionalProperties: false,
+            },
+            execute: async ({ value }: { value: number }) => {
               executedValues.push(value);
               return { seen: value };
             },
@@ -345,6 +349,144 @@ describe("AgentRuntime streaming", () => {
 
       assert(streamCallCount >= 3, "should request multiple model steps");
       assertEquals(executedValues, [1, 2]);
+
+      clearModelProviders();
+    } finally {
+      restoreEnv("LOG_LEVEL", originalLogLevel);
+      restoreEnv("NODE_ENV", originalNodeEnv);
+      restoreEnv("VF_DISABLE_LRU_INTERVAL", originalDisableLruInterval);
+    }
+  });
+
+  it("should not expose provisional streamed tool input as a failed activity", async () => {
+    const originalLogLevel = getEnv("LOG_LEVEL");
+    const originalNodeEnv = getEnv("NODE_ENV");
+    const originalDisableLruInterval = getEnv("VF_DISABLE_LRU_INTERVAL");
+
+    setEnv("LOG_LEVEL", "silent");
+    setEnv("NODE_ENV", "test");
+    setEnv("VF_DISABLE_LRU_INTERVAL", "1");
+
+    try {
+      const { AgentRuntime } = await import("../../src/agent/runtime/index.ts");
+      const { registerModelProvider, clearModelProviders } = await import(
+        "../../src/provider/model-registry.ts"
+      );
+      clearModelProviders();
+
+      let streamCallCount = 0;
+      const executedValues: number[] = [];
+
+      const mockModel = createMockStreamingModel(
+        "mock",
+        "mock-model",
+        async () => {
+          streamCallCount += 1;
+
+          if (streamCallCount === 1) {
+            return {
+              stream: ReadableStream.from([
+                { type: "tool-input-start", id: "tool-1", toolName: "review" },
+                { type: "tool-input-delta", id: "tool-1", delta: "{}" },
+                {
+                  type: "finish",
+                  finishReason: { unified: "tool-calls", raw: "tool_calls" },
+                },
+              ]),
+            };
+          }
+
+          if (streamCallCount === 2) {
+            return {
+              stream: ReadableStream.from([
+                { type: "tool-input-start", id: "tool-1", toolName: "review" },
+                { type: "tool-input-delta", id: "tool-1", delta: '{"value":1}' },
+                {
+                  type: "tool-call",
+                  toolCallId: "tool-1",
+                  toolName: "review",
+                  input: '{"value":1}',
+                },
+                {
+                  type: "finish",
+                  finishReason: { unified: "tool-calls", raw: "tool_calls" },
+                },
+              ]),
+            };
+          }
+
+          return {
+            stream: ReadableStream.from([
+              { type: "text-delta", delta: "done" },
+              {
+                type: "finish",
+                finishReason: { unified: "stop", raw: "stop" },
+                usage: {
+                  inputTokens: { total: 5 },
+                  outputTokens: { total: 1 },
+                },
+              },
+            ]),
+          };
+        },
+      );
+
+      registerModelProvider("mock", () => mockModel);
+
+      const runtime = new AgentRuntime("test", {
+        id: "test-agent",
+        model: "mock/mock-model",
+        system: "You are a tester",
+        memory: { type: "conversation", maxTokens: 4000 },
+        tools: {
+          review: tool({
+            id: "review",
+            description: "Reviews the provided value",
+            inputSchema: {
+              type: "object",
+              properties: { value: { type: "number" } },
+              required: ["value"],
+              additionalProperties: false,
+            },
+            execute: async ({ value }: { value: number }) => {
+              executedValues.push(value);
+              return { seen: value };
+            },
+          }),
+        },
+      });
+
+      const messages: Message[] = [{
+        id: "m1",
+        role: "user",
+        parts: [{ type: "text", text: "review" }],
+      }];
+
+      const stream = await runtime.stream(messages);
+      const reader = stream.getReader();
+      const decoder = new TextDecoder();
+      let output = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        output += decoder.decode(value, { stream: true });
+      }
+
+      assert(streamCallCount >= 3, "should recover with a committed tool call");
+      assertEquals(executedValues, [1]);
+      assert(
+        !output.includes("Stream terminated before tool-call event"),
+        "provisional tool input should not create a user-facing failure",
+      );
+      assert(
+        !output.includes('"type":"tool-input-error"'),
+        "provisional tool input should not emit tool-input-error",
+      );
+      assert(
+        !output.includes('"type":"tool-output-error"'),
+        "provisional tool input should not emit tool-output-error",
+      );
 
       clearModelProviders();
     } finally {


### PR DESCRIPTION
## Summary
- Buffer provider tool-input fragments until a committed tool-call or tool-result establishes the tool lifecycle.
- Suppress user-facing tool input/output error events for provisional fragments that terminate before commitment, while retaining runtime diagnostics and recovery state.
- Bump Veryfront package metadata to 0.1.628 for release of the streaming fix.

## Verification
- deno check src/agent/runtime/chat-stream-handler.ts src/agent/runtime/index.ts tests/chat/agent-runtime-streaming.test.ts
- deno test --no-check --allow-all src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/index.test.ts tests/chat/agent-runtime-streaming.test.ts tests/chat/use-chat-streaming.test.ts tests/chat/use-chat-ag-ui-streaming.test.ts tests/chat/chat-handler-fallback.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/index.test.ts tests/chat/agent-runtime-streaming.test.ts
- pre-push hook: formatting, lint, type check, and unit tests passed: 1940 passed, 0 failed
- git diff --check