### PR TITLE
fix(http): stream Node request body with duplex: half (#1976)

### DIFF
--- a/src/platform/compat/http/node-types.ts
+++ b/src/platform/compat/http/node-types.ts
@@ -5,6 +5,10 @@ export interface NodeIncomingMessage {
   on(event: "data", handler: (chunk: Uint8Array) => void): void;
   on(event: "end", handler: () => void): void;
   on(event: "error", handler: (error: Error) => void): void;
+  /** Pause flowing mode — used to apply backpressure to the request body. */
+  pause?(): void;
+  /** Resume flowing mode once the body stream consumer asks for more. */
+  resume?(): void;
 }
 
 export interface NodeServerResponse {

--- a/src/platform/compat/http/request-adapter.test.ts
+++ b/src/platform/compat/http/request-adapter.test.ts
@@ -1,10 +1,22 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { Readable } from "node:stream";
 import { convertNodeRequestToWebRequest } from "./request-adapter.ts";
 
-function createMockReq(method: string, headers: Record<string, string>) {
-  return { method, headers };
+/**
+ * Build a mock that mirrors a Node `http.IncomingMessage`: a readable stream
+ * carrying body bytes, plus the `method`/`headers` properties.
+ */
+function createMockReq(
+  method: string,
+  headers: Record<string, string>,
+  bodyChunks: string[] = [],
+) {
+  const stream = Readable.from(
+    bodyChunks.map((chunk) => new TextEncoder().encode(chunk)),
+  );
+  return Object.assign(stream, { method, headers });
 }
 
 describe("convertNodeRequestToWebRequest", () => {
@@ -13,26 +25,56 @@ describe("convertNodeRequestToWebRequest", () => {
     assertEquals(typeof convertNodeRequestToWebRequest, "function");
   });
 
-  it("should convert a GET request", () => {
+  it("should convert a GET request with no body", () => {
     const result = convertNodeRequestToWebRequest(
-      createMockReq("GET", { "content-type": "application/json" }) as any,
+      createMockReq("GET", { "content-type": "application/json" }) as never,
       "http://localhost/test",
     );
 
     assertExists(result);
     assertEquals(result.method, "GET");
     assertEquals(result.url, "http://localhost/test");
+    assertEquals(result.body, null);
   });
 
-  it("should convert a POST request", () => {
+  it("should not attach a body for HEAD requests", () => {
     const result = convertNodeRequestToWebRequest(
-      createMockReq("POST", { "content-type": "application/json" }) as any,
-      "http://localhost/api",
+      createMockReq("HEAD", {}) as never,
+      "http://localhost/test",
+    );
+
+    assertEquals(result.method, "HEAD");
+    assertEquals(result.body, null);
+  });
+
+  it("should not attach a body for OPTIONS (CORS preflight) requests", () => {
+    // Regression test: OPTIONS previously hit the body path and threw the
+    // undici `duplex` TypeError, surfacing as a 500 on every preflight.
+    const result = convertNodeRequestToWebRequest(
+      createMockReq("OPTIONS", {}) as never,
+      "http://localhost/mcp",
+    );
+
+    assertEquals(result.method, "OPTIONS");
+    assertEquals(result.body, null);
+  });
+
+  it("should attach a readable streaming body for POST requests", async () => {
+    // Regression test for the missing `duplex: "half"` option: constructing a
+    // Request with a stream body must not throw, and the body must be readable.
+    const result = convertNodeRequestToWebRequest(
+      createMockReq(
+        "POST",
+        { "content-type": "application/json" },
+        ['{"jsonrpc":"2.0",', '"method":"initialize"}'],
+      ) as never,
+      "http://localhost/mcp",
     );
 
     assertExists(result);
     assertEquals(result.method, "POST");
-    assertEquals(result.url, "http://localhost/api");
+    assertExists(result.body);
+    assertEquals(await result.text(), '{"jsonrpc":"2.0","method":"initialize"}');
   });
 
   it("should preserve headers", () => {
@@ -40,7 +82,7 @@ describe("convertNodeRequestToWebRequest", () => {
       createMockReq("GET", {
         "x-custom-header": "custom-value",
         authorization: "Bearer token",
-      }) as any,
+      }) as never,
       "http://localhost/test",
     );
 

--- a/src/platform/compat/http/request-adapter.ts
+++ b/src/platform/compat/http/request-adapter.ts
@@ -48,9 +48,18 @@ function nodeRequestToReadableStream(
 ): ReadableStream<Uint8Array> {
   return new ReadableStream<Uint8Array>({
     start(controller) {
-      req.on("data", (chunk) => controller.enqueue(chunk));
+      req.on("data", (chunk) => {
+        controller.enqueue(chunk);
+        // Apply backpressure: once the stream's internal queue is full, pause
+        // the Node request so it stops buffering the whole body in memory.
+        if ((controller.desiredSize ?? 1) <= 0) req.pause?.();
+      });
       req.on("end", () => controller.close());
       req.on("error", (error) => controller.error(error));
+    },
+    pull() {
+      // The consumer asked for more — resume flowing mode.
+      req.resume?.();
     },
   });
 }

--- a/src/platform/compat/http/request-adapter.ts
+++ b/src/platform/compat/http/request-adapter.ts
@@ -1,16 +1,56 @@
 import type { NodeIncomingMessage } from "./node-types.ts";
 
+/** HTTP methods that never carry a request body. */
+const BODYLESS_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+/**
+ * Convert a Node `http.IncomingMessage` into a WHATWG `Request`.
+ *
+ * A Node request is a readable stream of body bytes. When a streaming body is
+ * supplied to the `Request` constructor (e.g. under Node's built-in fetch /
+ * undici), the spec requires `duplex: "half"` — without it the constructor
+ * throws `TypeError: RequestInit: duplex option is required when sending a
+ * body.`, which previously surfaced as a generic 500 for every POST/PUT/etc.
+ *
+ * Bodyless methods (`GET`/`HEAD`/`OPTIONS`) must not attach a body at all;
+ * `OPTIONS` in particular is used for CORS preflights and carries no body.
+ */
 export function convertNodeRequestToWebRequest(
   req: NodeIncomingMessage,
   url: string,
 ): Request {
-  const method = req.method;
+  const method = req.method ?? "GET";
+  const hasBody = !BODYLESS_METHODS.has(method.toUpperCase());
 
-  const body = method !== "GET" && method !== "HEAD" ? (req as unknown as BodyInit) : undefined;
-
-  return new Request(url, {
+  // `duplex` is part of the WHATWG fetch spec but not yet in the lib.dom
+  // `RequestInit` type, hence the intersection.
+  const init: RequestInit & { duplex?: "half" } = {
     method,
     headers: req.headers as HeadersInit,
-    body,
+  };
+
+  if (hasBody) {
+    init.body = nodeRequestToReadableStream(req);
+    init.duplex = "half";
+  }
+
+  return new Request(url, init);
+}
+
+/**
+ * Adapt a Node readable request into a web `ReadableStream` using only the
+ * event interface declared on {@link NodeIncomingMessage}, so this stays free
+ * of a hard `node:stream` dependency (consistent with the rest of the compat
+ * layer, which avoids static Node imports for non-Node runtimes).
+ */
+function nodeRequestToReadableStream(
+  req: NodeIncomingMessage,
+): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      req.on("data", (chunk) => controller.enqueue(chunk));
+      req.on("end", () => controller.close());
+      req.on("error", (error) => controller.error(error));
+    },
   });
 }


### PR DESCRIPTION
## Description

The Node→Web request adapter (`convertNodeRequestToWebRequest`) passed a Node `http.IncomingMessage` straight into the WHATWG `Request` constructor as the `body`. Under Node's built-in fetch (undici), a `Request` with a stream body requires `duplex: "half"`. Without it the constructor throws `TypeError: RequestInit: duplex option is required when sending a body.`, which `NodeHttpServer.serve`'s outer `try/catch` swallowed into a generic `500 Internal Server Error`.

This broke **every** non-`GET`/`HEAD` request to the dev MCP endpoint — `initialize` (POST), tool calls (POST), and CORS preflights (OPTIONS) — so no MCP client could connect.

### Changes
- Build a web `ReadableStream` from the `IncomingMessage` event interface (`data`/`end`/`error`) and set `duplex: "half"` whenever a body is attached. Uses only the declared `NodeIncomingMessage` interface, so it stays free of a hard `node:stream` dependency (consistent with the rest of the compat layer).
- Treat `OPTIONS` as bodyless alongside `GET`/`HEAD`, so CORS preflights no longer hit the body path.
- Expanded unit tests: POST attaches a readable body, `GET`/`HEAD`/`OPTIONS` attach no body, headers preserved.

## Related Issue(s)

Fixes #1976

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works