### PR TITLE
fix(dev-server): stop HMR loop on tool-written artifacts (#1977)

### DIFF
--- a/src/server/dev-server/file-watch-setup.test.ts
+++ b/src/server/dev-server/file-watch-setup.test.ts
@@ -10,6 +10,14 @@ describe("shouldIgnorePath", () => {
     expect(shouldIgnorePath("/proj/.cache/bundle.js")).toBe(true);
     expect(shouldIgnorePath("/proj/.veryfront/manifest.json")).toBe(true);
     expect(shouldIgnorePath("/proj/dist/app.js")).toBe(true);
+    // Nested build output is also matched (watcher paths are absolute).
+    expect(shouldIgnorePath("/proj/packages/ui/dist/index.js")).toBe(true);
+  });
+
+  it("does not false-positive on source dirs whose names end in 'dist'", () => {
+    // Regression for the `dist/` substring trap flagged in review of #1977.
+    expect(shouldIgnorePath("/proj/mydist/app.tsx")).toBe(false);
+    expect(shouldIgnorePath("/proj/pages/wishlist-dist/index.tsx")).toBe(false);
   });
 
   it("ignores the Playwright MCP output directory (regression for #1977)", () => {

--- a/src/server/dev-server/file-watch-setup.test.ts
+++ b/src/server/dev-server/file-watch-setup.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { expect } from "#std/expect.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { shouldIgnorePath } from "./file-watch-setup.ts";
+import { isIgnoredOutputDir, shouldIgnorePath } from "./file-watch-setup.ts";
 
 describe("shouldIgnorePath", () => {
   it("ignores paths inside generated/output directories", () => {
@@ -9,15 +9,6 @@ describe("shouldIgnorePath", () => {
     expect(shouldIgnorePath("/proj/.git/HEAD")).toBe(true);
     expect(shouldIgnorePath("/proj/.cache/bundle.js")).toBe(true);
     expect(shouldIgnorePath("/proj/.veryfront/manifest.json")).toBe(true);
-    expect(shouldIgnorePath("/proj/dist/app.js")).toBe(true);
-    // Nested build output is also matched (watcher paths are absolute).
-    expect(shouldIgnorePath("/proj/packages/ui/dist/index.js")).toBe(true);
-  });
-
-  it("does not false-positive on source dirs whose names end in 'dist'", () => {
-    // Regression for the `dist/` substring trap flagged in review of #1977.
-    expect(shouldIgnorePath("/proj/mydist/app.tsx")).toBe(false);
-    expect(shouldIgnorePath("/proj/pages/wishlist-dist/index.tsx")).toBe(false);
   });
 
   it("ignores the Playwright MCP output directory (regression for #1977)", () => {
@@ -43,5 +34,32 @@ describe("shouldIgnorePath", () => {
     expect(shouldIgnorePath("/proj/content/post.mdx")).toBe(false);
     expect(shouldIgnorePath("/proj/README.md")).toBe(false);
     expect(shouldIgnorePath("/proj/resources/data.json")).toBe(false);
+  });
+});
+
+describe("isIgnoredOutputDir", () => {
+  const projectDir = "/proj";
+
+  it("ignores the project's build-output dir at any depth", () => {
+    expect(isIgnoredOutputDir(projectDir, "/proj/dist/app.js")).toBe(true);
+    expect(isIgnoredOutputDir(projectDir, "/proj/packages/ui/dist/index.js")).toBe(true);
+  });
+
+  it("does not match an ancestor dir named 'dist' (Codex review of #1977)", () => {
+    // The project itself is checked out under an ancestor `dist/`; source
+    // changes inside it must still trigger HMR — the match is project-relative.
+    const nested = "/workspace/dist/my-app";
+    expect(isIgnoredOutputDir(nested, "/workspace/dist/my-app/pages/index.tsx")).toBe(false);
+    expect(isIgnoredOutputDir(nested, "/workspace/dist/my-app/dist/app.js")).toBe(true);
+  });
+
+  it("does not match source dirs whose names merely end in 'dist'", () => {
+    expect(isIgnoredOutputDir(projectDir, "/proj/mydist/app.tsx")).toBe(false);
+    expect(isIgnoredOutputDir(projectDir, "/proj/pages/wishlist-dist/index.tsx")).toBe(false);
+  });
+
+  it("does not match legitimate source files", () => {
+    expect(isIgnoredOutputDir(projectDir, "/proj/pages/index.tsx")).toBe(false);
+    expect(isIgnoredOutputDir(projectDir, "/proj/styles/app.css")).toBe(false);
   });
 });

--- a/src/server/dev-server/file-watch-setup.test.ts
+++ b/src/server/dev-server/file-watch-setup.test.ts
@@ -1,0 +1,39 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { expect } from "#std/expect.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { shouldIgnorePath } from "./file-watch-setup.ts";
+
+describe("shouldIgnorePath", () => {
+  it("ignores paths inside generated/output directories", () => {
+    expect(shouldIgnorePath("/proj/node_modules/foo/index.js")).toBe(true);
+    expect(shouldIgnorePath("/proj/.git/HEAD")).toBe(true);
+    expect(shouldIgnorePath("/proj/.cache/bundle.js")).toBe(true);
+    expect(shouldIgnorePath("/proj/.veryfront/manifest.json")).toBe(true);
+    expect(shouldIgnorePath("/proj/dist/app.js")).toBe(true);
+  });
+
+  it("ignores the Playwright MCP output directory (regression for #1977)", () => {
+    expect(
+      shouldIgnorePath("/proj/.playwright-mcp/console-2026-06-01T09-33-43.log"),
+    ).toBe(true);
+    expect(shouldIgnorePath("/proj/.playwright-mcp/page-001.yml")).toBe(true);
+    expect(shouldIgnorePath("/proj/.playwright-mcp/screenshot.png")).toBe(true);
+  });
+
+  it("ignores generated-artifact extensions anywhere in the tree", () => {
+    // Defends against tools that write logs outside a known output directory.
+    expect(shouldIgnorePath("/proj/server.log")).toBe(true);
+    expect(shouldIgnorePath("/proj/pages/build.LOG")).toBe(true);
+    expect(shouldIgnorePath("/proj/scratch.tmp")).toBe(true);
+  });
+
+  it("does not ignore legitimate source files", () => {
+    expect(shouldIgnorePath("/proj/pages/index.tsx")).toBe(false);
+    expect(shouldIgnorePath("/proj/components/Button.jsx")).toBe(false);
+    expect(shouldIgnorePath("/proj/lib/util.ts")).toBe(false);
+    expect(shouldIgnorePath("/proj/styles/app.css")).toBe(false);
+    expect(shouldIgnorePath("/proj/content/post.mdx")).toBe(false);
+    expect(shouldIgnorePath("/proj/README.md")).toBe(false);
+    expect(shouldIgnorePath("/proj/resources/data.json")).toBe(false);
+  });
+});

--- a/src/server/dev-server/file-watch-setup.ts
+++ b/src/server/dev-server/file-watch-setup.ts
@@ -34,11 +34,6 @@ const IGNORED_PATH_PATTERNS = [
   // which would otherwise drive an open-ended HMR refresh loop.
   ".playwright-mcp/",
   ".playwright-mcp\\",
-  // Build output. Separator-anchored so it matches a real `dist` directory at
-  // any depth (watcher paths are absolute) without false-positiving on source
-  // directories whose names merely end in "dist" (e.g. `mydist/`, `wishlist-dist/`).
-  "/dist/",
-  "\\dist\\",
 ];
 
 /**
@@ -61,6 +56,18 @@ const IGNORED_ARTIFACT_EXTENSIONS = new Set([".log", ".tmp"]);
  */
 const IGNORED_RUNTIME_DIRS = new Set(["data"]);
 
+/**
+ * Generated build-output directory names. Matched as an exact path *segment*
+ * relative to projectDir (at any depth), so a real `dist/` inside the project
+ * is skipped while:
+ *   - an ancestor directory named `dist` (the project being checked out under
+ *     one, e.g. `/workspace/dist/my-app/`) does NOT suppress every source
+ *     change — the match is project-relative, and
+ *   - a source dir whose name merely ends in "dist" (e.g. `mydist/`,
+ *     `wishlist-dist/`) is NOT matched — segments are compared exactly.
+ */
+const IGNORED_OUTPUT_DIRS = new Set(["dist"]);
+
 /** Whether a path ends in a generated-artifact extension (case-insensitive). */
 function hasIgnoredArtifactExtension(path: string): boolean {
   const lower = path.toLowerCase();
@@ -79,6 +86,21 @@ function hasIgnoredArtifactExtension(path: string): boolean {
 export function shouldIgnorePath(path: string): boolean {
   return IGNORED_PATH_PATTERNS.some((pattern) => path.includes(pattern)) ||
     hasIgnoredArtifactExtension(path);
+}
+
+/**
+ * Whether a path lives inside a generated build-output directory, evaluated
+ * relative to `projectDir` so directories *above* the project (which the user
+ * cannot control, e.g. a checkout under `/some/dist/...`) are never matched.
+ *
+ * Exported for unit testing.
+ */
+export function isIgnoredOutputDir(projectDir: string, fullPath: string): boolean {
+  const rel = relative(projectDir, fullPath);
+  // A path outside the project root yields a `..`-prefixed relative path; such
+  // paths are not project output and are left to the absolute-pattern checks.
+  if (rel.startsWith("..")) return false;
+  return rel.split(sep).some((segment) => IGNORED_OUTPUT_DIRS.has(segment));
 }
 
 export class FileWatchSetup {
@@ -170,7 +192,8 @@ export class FileWatchSetup {
         try {
           // Filter out paths that shouldn't trigger HMR (cache, node_modules, runtime data, etc.)
           const relevantPaths = paths.filter((p) =>
-            !shouldIgnorePath(p) && !this.isRuntimeDataPath(p)
+            !shouldIgnorePath(p) && !this.isRuntimeDataPath(p) &&
+            !isIgnoredOutputDir(this.projectDir, p)
           );
           if (relevantPaths.length === 0) continue;
 

--- a/src/server/dev-server/file-watch-setup.ts
+++ b/src/server/dev-server/file-watch-setup.ts
@@ -29,7 +29,27 @@ const IGNORED_PATH_PATTERNS = [
   ".git\\",
   ".veryfront/",
   ".veryfront\\",
+  // Tool output directories that live inside the project root. Tools such as
+  // the Playwright MCP server write per-step artifacts here continuously,
+  // which would otherwise drive an open-ended HMR refresh loop.
+  ".playwright-mcp/",
+  ".playwright-mcp\\",
+  "dist/",
+  "dist\\",
 ];
+
+/**
+ * Generated-artifact file extensions that are never source and must never
+ * trigger an HMR update — even when written outside an ignored directory
+ * (e.g. a tool that drops a `.log` into the project root). This is the
+ * defensive guarantee against future tools writing to as-yet-unknown paths.
+ *
+ * Deliberately narrow: only extensions that are unambiguously machine output.
+ * veryfront hot-reloads more than JS (`.css`, `.mdx`/`.md`, and arbitrary
+ * primitive-directory resources), so an allowlist of "source" extensions
+ * would wrongly suppress legitimate updates.
+ */
+const IGNORED_ARTIFACT_EXTENSIONS = new Set([".log", ".tmp"]);
 
 /**
  * Project-root directory names that contain runtime data (not source code)
@@ -38,11 +58,24 @@ const IGNORED_PATH_PATTERNS = [
  */
 const IGNORED_RUNTIME_DIRS = new Set(["data"]);
 
+/** Whether a path ends in a generated-artifact extension (case-insensitive). */
+function hasIgnoredArtifactExtension(path: string): boolean {
+  const lower = path.toLowerCase();
+  for (const ext of IGNORED_ARTIFACT_EXTENSIONS) {
+    if (lower.endsWith(ext)) return true;
+  }
+  return false;
+}
+
 /**
- * Check if a path should be ignored for HMR purposes.
+ * Check if a path should be ignored for HMR purposes — either because it lives
+ * in a generated/output directory or because it is a generated-artifact file.
+ *
+ * Exported for unit testing.
  */
-function shouldIgnorePath(path: string): boolean {
-  return IGNORED_PATH_PATTERNS.some((pattern) => path.includes(pattern));
+export function shouldIgnorePath(path: string): boolean {
+  return IGNORED_PATH_PATTERNS.some((pattern) => path.includes(pattern)) ||
+    hasIgnoredArtifactExtension(path);
 }
 
 export class FileWatchSetup {

--- a/src/server/dev-server/file-watch-setup.ts
+++ b/src/server/dev-server/file-watch-setup.ts
@@ -34,8 +34,11 @@ const IGNORED_PATH_PATTERNS = [
   // which would otherwise drive an open-ended HMR refresh loop.
   ".playwright-mcp/",
   ".playwright-mcp\\",
-  "dist/",
-  "dist\\",
+  // Build output. Separator-anchored so it matches a real `dist` directory at
+  // any depth (watcher paths are absolute) without false-positiving on source
+  // directories whose names merely end in "dist" (e.g. `mydist/`, `wishlist-dist/`).
+  "/dist/",
+  "\\dist\\",
 ];
 
 /**


### PR DESCRIPTION
## Description

The dev-server file watcher watches the project root recursively, so per-step artifacts written by in-tree tools — e.g. the Playwright MCP server dropping `.log`/`.yml`/screenshots into `./.playwright-mcp/` — were picked up as source changes and pushed through the JS-module HMR pipeline, driving an open-ended browser refresh loop (observed: ~340 console lines from one navigate + click; 8.2k lines / 103k requests over 25 min).

### Changes
- Ignore `.playwright-mcp/` and `dist/` output directories (in addition to the existing `.cache`, `node_modules`, `.git`, `.veryfront`).
- Reject generated-artifact extensions (`.log`, `.tmp`) anywhere in the tree as a defensive guarantee against tools writing to as-yet-unknown paths.
- Export `shouldIgnorePath` and add unit tests covering ignored dirs, the `.playwright-mcp/` regression, artifact extensions, and that legitimate source files still pass.

### Design note
A source-extension **allowlist** (as the issue sketched) was intentionally **not** used: veryfront hot-reloads more than JS — `.css` (style swap), `.mdx`/`.md` (full reload), and arbitrary primitive-directory resources (`tools/`, `agents/`, `resources/`) that trigger rediscovery. An allowlist would wrongly suppress those legitimate updates. The directory ignore-list + narrow artifact denylist fixes the loop without that regression risk.

## Related Issue(s)

Fixes #1977

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works