### PR TITLE
Keep agent-as-tool execution streaming

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.628",
+  "version": "0.1.629",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/composition/composition.test.ts
+++ b/src/agent/composition/composition.test.ts
@@ -11,9 +11,10 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { Agent, AgentResponse, AgentStreamResult } from "../types.ts";
 
 // Side-effect import: registers the globalThis bridges
-import "./composition.ts";
+import { agentAsTool } from "./composition.ts";
 
 const BRIDGE_KEYS = ["__vfGetAgent", "__vfRegisterAgent", "__vfGetAllAgentIds"] as const;
 
@@ -76,4 +77,63 @@ describe("globalThis agent registry bridges", () => {
       });
     });
   }
+});
+
+describe("agentAsTool", () => {
+  it("executes child agents through the streaming path", async () => {
+    let generated = false;
+    let streamedInput: string | undefined;
+
+    const childResponse: AgentResponse = {
+      text: "streamed child result",
+      messages: [],
+      toolCalls: [],
+      status: "completed",
+    };
+
+    const childAgent: Agent = {
+      id: "child",
+      config: {
+        model: "anthropic/claude-sonnet-4-6",
+        system: "Child agent",
+      },
+      async generate() {
+        generated = true;
+        return childResponse;
+      },
+      async stream(input): Promise<AgentStreamResult> {
+        streamedInput = input.input;
+        input.onFinish?.(childResponse);
+        return {
+          toDataStreamResponse() {
+            return new Response("data: {}\n\n", {
+              headers: { "Content-Type": "text/event-stream" },
+            });
+          },
+        };
+      },
+      respond: () => Promise.resolve(new Response(null)),
+      getMemory() {
+        throw new Error("not used");
+      },
+      getMemoryStats: () =>
+        Promise.resolve({
+          totalMessages: 0,
+          estimatedTokens: 0,
+          type: "test",
+        }),
+      clearMemory: () => Promise.resolve(),
+    };
+
+    const tool = agentAsTool(childAgent, "Review with child agent");
+    const result = await tool.execute({ input: "Review article 30" });
+
+    assertEquals(generated, false);
+    assertEquals(streamedInput, "Review article 30");
+    assertEquals(result, {
+      text: "streamed child result",
+      toolCalls: 0,
+      status: "completed",
+    });
+  });
 });

--- a/src/agent/composition/composition.ts
+++ b/src/agent/composition/composition.ts
@@ -7,7 +7,7 @@
  * @module
  */
 
-import type { Agent } from "../types.ts";
+import type { Agent, AgentResponse } from "../types.ts";
 import type { Tool } from "#veryfront/tool";
 import { setActiveSpanAttributes, withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { ScopedRegistryFacade } from "#veryfront/registry/scoped-registry-facade.ts";
@@ -15,6 +15,24 @@ import { ProjectScopedRegistryManager } from "#veryfront/registry/project-scoped
 import { getAgentToolInputSchema } from "../schemas/index.ts";
 
 /** Agent as tool helper. */
+async function runAgentAsStreamingTool(agent: Agent, input: string): Promise<AgentResponse> {
+  let finalResponse: AgentResponse | undefined;
+  const stream = await agent.stream({
+    input,
+    onFinish: (response) => {
+      finalResponse = response;
+    },
+  });
+
+  await stream.toDataStreamResponse().arrayBuffer();
+
+  if (!finalResponse) {
+    throw new Error(`Agent "${agent.id}" stream completed without a final response.`);
+  }
+
+  return finalResponse;
+}
+
 export function agentAsTool(agent: Agent, description: string): Tool {
   return {
     id: `agent_${agent.id}`,
@@ -25,7 +43,7 @@ export function agentAsTool(agent: Agent, description: string): Tool {
       return withSpan(
         "agent.composition.agentAsTool.execute",
         async () => {
-          const response = await agent.generate({ input });
+          const response = await runAgentAsStreamingTool(agent, input);
 
           setActiveSpanAttributes({
             "agent.tool_calls": response.toolCalls.length,

--- a/src/agent/factory-security-middleware.test.ts
+++ b/src/agent/factory-security-middleware.test.ts
@@ -1,7 +1,9 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ModelRuntime } from "#veryfront/provider";
 import { agent, resolveSecurityMiddleware } from "./factory.ts";
+import { agentAsTool } from "./composition/composition.ts";
 import { AgentRuntime } from "./runtime/index.ts";
 import type { AgentContext, AgentMiddleware, AgentResponse } from "./types.ts";
 
@@ -27,6 +29,15 @@ function createAgentResponse(input: { text: string }): AgentResponse {
       totalTokens: 0,
     },
   };
+}
+
+function createTextStream(parts: Array<{ type: "text-delta"; text: string } | { type: "finish" }>) {
+  return new ReadableStream<unknown>({
+    start(controller) {
+      for (const part of parts) controller.enqueue(part);
+      controller.close();
+    },
+  });
 }
 
 describe("resolveSecurityMiddleware", () => {
@@ -136,6 +147,43 @@ describe("resolveSecurityMiddleware", () => {
     assertEquals(result.text.includes("[EMAIL]"), true);
     assertEquals(result.text.includes("123-45-6789"), false);
     assertEquals(result.text.includes("[SSN]"), true);
+  });
+
+  it("applies child agent middleware when the agent is called as a streaming tool", async () => {
+    const model: ModelRuntime = {
+      provider: "hosted",
+      modelId: "hosted/middleware-stream-tool",
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "unused" }],
+          finishReason: "stop",
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        };
+      },
+      async doStream() {
+        return {
+          stream: createTextStream([
+            { type: "text-delta", text: "User email is john@example.com." },
+            { type: "finish" },
+          ]),
+        };
+      },
+    };
+
+    const childAgent = agent({
+      model: "hosted/middleware-stream-tool",
+      system: "Return a test response.",
+      resolveModelTransport: async () => ({ model }),
+    });
+
+    const tool = agentAsTool(childAgent, "Run child agent");
+    const result = await tool.execute({ input: "Run the child agent" });
+
+    assertEquals(result, {
+      text: "User email is [EMAIL].",
+      toolCalls: 0,
+      status: "completed",
+    });
   });
 
   it("forwards abortSignal and onFinish through agent.stream", async () => {

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -727,6 +727,15 @@ export class AgentRuntime {
     // instead of swallowing it as an in-band SSE error in a 200 response.
     await ensureModelReady(languageModel);
 
+    const agentContext: AgentContext = {
+      agentId: this.id,
+      model: resolvedModelString,
+      input: messages,
+      data: context,
+      platform: detectPlatform(),
+    };
+    const chain = new MiddlewareChain(this.config.middleware);
+
     return new ReadableStream<Uint8Array>({
       start: async (controller) => {
         try {
@@ -748,21 +757,25 @@ export class AgentRuntime {
               model: effectiveModel,
             },
           });
-          const response = await this.executeAgentLoopStreaming(
-            systemPrompt,
-            memoryMessages,
-            controller,
-            encoder,
-            callbacks,
-            textPartId,
-            toolContext,
-            context,
-            resolvedModelString,
-            languageModel,
-            transport.headers,
-            transport.providerOptions,
-            maxOutputTokensOverride,
-            streamAbortSignal,
+          const response = await chain.execute(
+            agentContext,
+            () =>
+              this.executeAgentLoopStreaming(
+                systemPrompt,
+                memoryMessages,
+                controller,
+                encoder,
+                callbacks,
+                textPartId,
+                toolContext,
+                context,
+                resolvedModelString,
+                languageModel,
+                transport.headers,
+                transport.providerOptions,
+                maxOutputTokensOverride,
+                streamAbortSignal,
+              ),
           );
           throwIfAborted(streamAbortSignal);
           callbacks?.onFinish?.(response);

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.628";
+export const VERSION = "0.1.629";


### PR DESCRIPTION
## Summary
- Route `agentAsTool` through `agent.stream()` instead of `agent.generate()` so child-agent tools use the provider streaming path.
- Drain the streamed response while preserving the existing tool result shape (`text`, `toolCalls`, `status`).
- Keep streaming final responses under the agent middleware chain so child-agent security and user middleware still apply when exposed as tools.
- Bump the package version to `0.1.629` and keep the runtime version constant in sync.

## Why
Long-running child-agent tools can exceed Cloudflare's first-byte timeout when the underlying provider call is non-streaming. Streaming sends provider SSE bytes before the timeout and keeps long reviews, including DORA article review batches, on the intended gateway path.

## Verification
- `deno check src/agent/runtime/index.ts src/agent/factory-security-middleware.test.ts src/agent/composition/composition.ts src/agent/composition/composition.test.ts`
- `deno test --no-check --allow-all src/agent/factory-security-middleware.test.ts src/agent/composition/composition.test.ts src/agent/runtime/refresh.test.ts src/agent/runtime/provider-transport.test.ts extensions/ext-llm-anthropic/src/anthropic-provider.test.ts`
- Pre-push hook: `deno fmt --check`, `deno lint`, `deno check src/index.ts`, `deno task test:unit` (`1943 passed, 0 failed`)

## Notes
The first revision used streaming but did not preserve child-agent middleware. This revision adds a regression test for the reviewed case and applies the middleware chain to the streaming final response.
