### PR TITLE
fix(channels): type control-plane surface properly, drop `as any` (#2000)

### DIFF
--- a/src/channels/control-plane.ts
+++ b/src/channels/control-plane.ts
@@ -23,10 +23,11 @@ const getCompactJwsHeaderSchema = defineSchema((v) =>
 );
 const compactJwsHeaderSchema = lazySchema(getCompactJwsHeaderSchema);
 
+/** Allowed control-plane surfaces — source of truth for the schema and {@link ControlPlaneSurface}. */
+export const CONTROL_PLANE_SURFACES = ["studio", "channels", "a2a", "mcp"] as const;
+
 /** Zod schema for get control plane surface. */
-export const getControlPlaneSurfaceSchema = defineSchema((v) =>
-  v.enum(["studio", "channels", "a2a", "mcp"])
-);
+export const getControlPlaneSurfaceSchema = defineSchema((v) => v.enum(CONTROL_PLANE_SURFACES));
 /** Zod schema for control plane surface. */
 export const ControlPlaneSurfaceSchema = lazySchema(getControlPlaneSurfaceSchema);
 
@@ -141,8 +142,8 @@ const getControlPlaneClaimsSchema = defineSchema((v) =>
 );
 const controlPlaneClaimsSchema = lazySchema(getControlPlaneClaimsSchema);
 
-/** Public API contract for control plane surface. */
-export type ControlPlaneSurface = InferSchema<ReturnType<typeof getControlPlaneSurfaceSchema>>;
+/** Public API contract for control plane surface (literal union, not widened to `string`). */
+export type ControlPlaneSurface = (typeof CONTROL_PLANE_SURFACES)[number];
 /** Request payload for control plane agents list. */
 export type ControlPlaneAgentsListRequest = InferSchema<
   ReturnType<typeof getControlPlaneAgentsListRequestSchema>

--- a/src/internal-agents/control-plane-auth.ts
+++ b/src/internal-agents/control-plane-auth.ts
@@ -1,4 +1,7 @@
-import { verifyControlPlaneJws } from "#veryfront/channels/control-plane.ts";
+import {
+  type ControlPlaneSurface,
+  verifyControlPlaneJws,
+} from "#veryfront/channels/control-plane.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import type { HandlerContext } from "#veryfront/types";
 import { serverLogger } from "#veryfront/utils";
@@ -39,7 +42,7 @@ export async function verifyControlPlaneRequest(
   rawBody: string,
   options: {
     expectedSubject?: string;
-    expectedSurface?: "studio" | "channels" | "a2a" | "mcp";
+    expectedSurface?: ControlPlaneSurface;
   } = {},
 ) {
   const publicKeyPem = getControlPlaneVerificationPublicKey(ctx);

--- a/src/server/handlers/request/internal-agents-list.handler.ts
+++ b/src/server/handlers/request/internal-agents-list.handler.ts
@@ -4,6 +4,7 @@ import {
   CONTROL_PLANE_AGENTS_LIST_PATH,
   type ControlPlaneAgentsListRequest,
   ControlPlaneAgentsListRequestSchema,
+  type ControlPlaneSurface,
   listRuntimeAgents,
   type RuntimeAgentDiscoveryDeps,
 } from "../../../channels/control-plane.ts";
@@ -52,7 +53,8 @@ export class InternalAgentsListHandler extends BaseHandler {
         );
         const claims = await verifyControlPlaneRequest(req, ctx, rawBody, {
           expectedSubject: payload.requestId,
-          expectedSurface: payload.surface as any,
+          // Validated by `.parse()` above; narrow back to the union (object inference widens it to `string`).
+          expectedSurface: payload.surface as ControlPlaneSurface,
         });
 
         if (


### PR DESCRIPTION
## Description

The internal-agents control-plane list handler passed `payload.surface as any` to `verifyControlPlaneRequest`'s `expectedSurface`. That `as any` masked a **real compile-time type hole on an auth/control-plane path**: object-schema inference widens the validated enum field to `string`, which is not assignable to the verifier's narrow `"studio" | "channels" | "a2a" | "mcp"` union.

Proof (reproduced locally): replacing the cast with a bare `payload.surface` makes `deno check` fail with:

```
TS2322: Type 'string' is not assignable to type '"mcp" | "studio" | "channels" | "a2a" | undefined'.
```

Runtime values were always Zod-validated, so this was never an exploit — but `as any` silenced a genuine type error and would hide future signature/shape drift on a security-sensitive surface.

### Changes
- Add a single source of truth `CONTROL_PLANE_SURFACES` const tuple that feeds **both** the runtime `v.enum(...)` schema and the `ControlPlaneSurface` type, so they can't drift.
- Derive `ControlPlaneSurface` from the tuple (the exact literal union) instead of `InferSchema<…>` (which widens enum fields to `string`).
- Use `ControlPlaneSurface` for `verifyControlPlaneRequest`'s `expectedSurface` param (was a duplicated inline union).
- Replace `as any` with a sound `as ControlPlaneSurface` narrowing of the already-`.parse()`-validated value.

### Verification
- `deno task typecheck`: my change introduces **zero** new errors (diffed against clean `origin/main` — identical pre-existing error set), and the previously-masked `TS2322` now type-checks soundly.
- `deno lint` clean on all 3 changed files.
- Tests: `src/channels/control-plane.test.ts`, `src/internal-agents/control-plane-auth.test.ts`, `src/server/handlers/request/internal-agents-list.handler.test.ts` and the rest of `src/server/handlers/request/` — **33 files / 322 steps pass**.

## Related Issue(s)

Closes #2000 (part of the `src/` tech-debt audit epic #1990 — top quick win)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Code refactoring

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] Existing tests cover the change (control-plane / auth / handler suites pass; behavior is unchanged — same 4 surfaces validated at runtime)