### PR TITLE
refactor(types): drop unsafe `as any` / lossy casts across hot paths

### DIFF
--- a/src/agent/conversation/durable.ts
+++ b/src/agent/conversation/durable.ts
@@ -1267,7 +1267,7 @@ export async function monitorConversationRunStatus(input: {
       await input.onTerminal(
         new ConversationRunTerminalStateError(
           run,
-          run.status as any,
+          run.status,
         ),
       );
     }

--- a/src/agent/hosted/child-fork-step-message-preparation.ts
+++ b/src/agent/hosted/child-fork-step-message-preparation.ts
@@ -83,9 +83,18 @@ export function prepareHostedChildForkRuntimeStepMessages(
   input: PrepareHostedChildForkRuntimeStepMessagesInput,
 ): HostedChildForkRuntimeStepMessages {
   const currentInstructions = input.buildInstructions();
+  // `convertAgentRuntimeMessagesToProviderMessages` reads each part defensively
+  // (via `"result" in part` / accessor helpers), so an AgentMessage is a valid
+  // runtime input. The only gap is a schema-inference nuance: the `tool-result`
+  // part's `result` is inferred optional from `v.unknown()`, while the
+  // converter's parameter type declares it required. Narrow to the converter's
+  // own parameter element type rather than `any` to keep the call type-checked.
+  type ConvertibleMessage = Parameters<
+    typeof convertAgentRuntimeMessagesToProviderMessages
+  >[0][number];
   const compactedMessages = compactForStep(
     convertAgentRuntimeMessagesToProviderMessages(
-      input.messages as any,
+      input.messages as readonly ConvertibleMessage[],
     ),
     estimateOverhead(currentInstructions, input.forkToolNames.length),
   );

--- a/src/agent/hosted/durable-child-fork-execution.ts
+++ b/src/agent/hosted/durable-child-fork-execution.ts
@@ -516,8 +516,8 @@ async function executeHostedDurableChildLifecycle<
       childRunId: identifiers.childRunId,
       childMessageId: identifiers.childMessageId,
       description: input.forkInput.description,
-      sourceTargetKind: targets.sourceTargetKind as any,
-      runtimeTargetKind: targets.runtimeTargetKind as any,
+      sourceTargetKind: targets.sourceTargetKind,
+      runtimeTargetKind: targets.runtimeTargetKind,
       targetBranchId: targets.targetBranchId,
     },
     model: bootstrapContext.resolvedModel,
@@ -549,7 +549,7 @@ async function executeHostedDurableChildLifecycle<
     }
 
     return input.buildTerminalFailureResult({
-      status: lifecycleResult.terminalState.status as any,
+      status: lifecycleResult.terminalState.status,
       identifiers,
       targets,
       terminalErrorCode: lifecycleResult.terminalState.terminalErrorCode ??

--- a/src/agent/runtime/resume-session.ts
+++ b/src/agent/runtime/resume-session.ts
@@ -65,8 +65,8 @@ type RunSession<T> = {
   waitingState: WaitingState<T> | null;
   preparedWaitKeys: Set<string>;
   submittedValues: Map<string, SubmittedValue<T>>;
-  waitingTimeoutId: number | null;
-  sessionTimeoutId: number | null;
+  waitingTimeoutId: ReturnType<typeof setTimeout> | null;
+  sessionTimeoutId: ReturnType<typeof setTimeout> | null;
 };
 
 const DEFAULT_WAITING_TTL_MS = 5 * 60 * 1000;
@@ -136,14 +136,14 @@ export class RunResumeSessionManager<T> {
     this.clearSessionTimeout(session);
     session.sessionTimeoutId = this.setTimeoutFn(() => {
       this.cancelRun(session.runId);
-    }, this.sessionTtlMs) as unknown as number;
+    }, this.sessionTtlMs);
   }
 
   private scheduleWaitingTimeout(session: RunSession<T>): void {
     this.clearWaitingTimeout(session);
     session.waitingTimeoutId = this.setTimeoutFn(() => {
       this.cancelRun(session.runId);
-    }, this.waitingTtlMs) as unknown as number;
+    }, this.waitingTtlMs);
   }
 
   private touchSession(session: RunSession<T>): void {

--- a/src/cache/registry.ts
+++ b/src/cache/registry.ts
@@ -36,7 +36,7 @@ export class MapCacheStore implements CacheStore {
 
   constructor(
     name: string,
-    private readonly map: Map<string, unknown>,
+    private readonly map: CacheStatsSource,
   ) {
     this.name = name;
   }
@@ -62,6 +62,18 @@ interface LRULike {
   get(key: string): unknown;
   keys(): Iterable<string>;
   size: number;
+  delete(key: string): boolean;
+}
+
+/**
+ * Narrow view of a key/value store sufficient for cache stats + inspection.
+ * Both native `Map` and the LRU cache wrapper structurally satisfy this, so
+ * callers can register lightweight wrappers without unsound `Map` casts.
+ */
+export interface CacheStatsSource {
+  get(key: string): unknown;
+  keys(): Iterable<string>;
+  readonly size: number;
   delete(key: string): boolean;
 }
 
@@ -578,7 +590,7 @@ function isKeyForContentSource(
 
 export const cacheRegistry = new CacheRegistry();
 
-export function registerMapCache(name: string, map: Map<string, unknown>): void {
+export function registerMapCache(name: string, map: CacheStatsSource): void {
   cacheRegistry.register(new MapCacheStore(name, map));
 }
 

--- a/src/channels/invoke.ts
+++ b/src/channels/invoke.ts
@@ -33,7 +33,7 @@ const getChannelAttachmentSchema = defineSchema((v) =>
 const getChannelInvokeHistoryMessageSchema = defineSchema((v) =>
   v.object({
     id: v.string(),
-    role: v.enum(["user", "assistant", "system", "tool"]),
+    role: v.enum(["user", "assistant", "system", "tool"] as const),
     parts: v.array(getRawHistoryPartSchema()),
     metadata: v.record(v.string(), v.unknown()).optional(),
     createdAt: v.string().optional(),
@@ -259,7 +259,7 @@ function normalizeConversationPart(
 export function normalizeConversationHistoryForRuntime(
   messages: ChannelInvokeRequest["conversationHistory"],
 ): Message[] {
-  return messages.map((message) => ({
+  return messages.map((message): Message => ({
     id: message.id,
     role: message.role,
     parts: message.parts
@@ -267,7 +267,7 @@ export function normalizeConversationHistoryForRuntime(
       .filter((part): part is NonNullable<typeof part> => part !== null),
     ...(message.createdAt ? { timestamp: Date.parse(message.createdAt) || undefined } : {}),
     ...(message.metadata ? { metadata: message.metadata } : {}),
-  })) as any;
+  }));
 }
 
 /** Resolves channel invoke agent. */

--- a/src/html/hydration-script-builder/hydration-data-generator.ts
+++ b/src/html/hydration-script-builder/hydration-data-generator.ts
@@ -5,6 +5,11 @@ import { determineClientModuleStrategy } from "#veryfront/rendering/rsc/client-m
 import type { HTMLGenerationOptions } from "../types.ts";
 import type { HydrationDataStructure } from "./types.ts";
 
+type HydrationPageType = NonNullable<HydrationDataStructure["pageType"]>;
+type HydrationEnvironment = NonNullable<
+  Parameters<typeof determineClientModuleStrategy>[0]["environment"]
+>;
+
 function toProjectRelativePath(absolutePath: string, projectDir?: string): string {
   if (!absolutePath) return "";
 
@@ -61,10 +66,14 @@ export function generateHydrationData(
     pagePath: options.pagePath
       ? toProjectRelativePath(options.pagePath, options.projectDir)
       : undefined,
-    pageType: (options.pageType || inferPageType(options.pagePath)) as any,
+    // `options.pageType`/`options.environment` are validated against literal
+    // enum schemas (see html.schema.ts), but the schema inference widens them
+    // to `string`. Narrow back to the real literal unions rather than `any`.
+    pageType: (options.pageType as HydrationPageType | undefined) ||
+      inferPageType(options.pagePath),
     clientModuleStrategy: determineClientModuleStrategy({
       isLocalProject: options.isLocalProject,
-      environment: options.environment as any,
+      environment: options.environment as HydrationEnvironment | undefined,
     }),
     frontmatter: options.frontmatter,
     layoutProps: options.layoutProps,

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.ts
@@ -15,6 +15,7 @@
 
 import { registerCache } from "#veryfront/utils/memory/index.ts";
 import { isKeyForProject, registerMapCache } from "#veryfront/cache/keys.ts";
+import type { CacheStatsSource } from "#veryfront/cache/registry.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import { rendererLogger } from "#veryfront/utils";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
@@ -190,14 +191,15 @@ registerCache("ssr-transform-semaphore", () => {
 
 function createCacheRegistryWrapper<T>(
   cache: LRUCache<string, T>,
-): Map<string, unknown> {
+): CacheStatsSource {
   return {
+    get: (key: string) => cache.get(key),
     keys: () => cache.keys(),
     get size() {
       return cache.size;
     },
     delete: (key: string) => cache.delete(key),
-  } as unknown as Map<string, unknown>;
+  };
 }
 
 registerMapCache("ssr-module-cache", createCacheRegistryWrapper(globalModuleCache));


### PR DESCRIPTION
## Description

Tech-debt quick-win batch (epic #1990) — replace unsafe `as any` / lossy casts with sound narrow types. No runtime behavior change.

- **#2014** `hydration-data-generator.ts` — type `pageType`/`environment` (literal unions) instead of `as any`.
- **#2021** `channels/invoke.ts` — add `as const` to the role enum schema so the inferred `Message` role is the proper union; type the map callback; drop `as any`.
- **#2007** `ssr-module-loader/cache/memory.ts` — replace `as unknown as Map` with a narrow `CacheStatsSource` interface (added to `cache/registry.ts`); native `Map` satisfies it structurally.
- **#1992** agent fork/durable — remove 5 `as any` status/target casts via typed narrowing (one kept as a narrow, commented assertion where a schema-inference nuance makes a plain drop impossible — see code comment).
- **#1993** `resume-session.ts` — type timer handles as `ReturnType<typeof setTimeout>`; drop the double-casts.

## Verification
- `deno lint` clean (8 files); `deno task typecheck` introduces **no new errors** (diffed against the known pre-existing baseline; none reference changed files).
- Colocated tests pass (15 files / 171 steps).

Closes #2014, Closes #2021, Closes #2007, Closes #1992, Closes #1993

## Type of Change
- [x] Bug fix / code refactoring (type safety)

## Checklist
- [x] Covered by existing colocated tests; behavior unchanged