### PR TITLE
refactor(imports): hash-alias deep relative imports + typed Deno accessor

### DIFF
--- a/src/platform/compat/fs.ts
+++ b/src/platform/compat/fs.ts
@@ -2,6 +2,18 @@ import type { FileInfo } from "#veryfront/platform/adapters/base.ts";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import { isBun, isDeno, isNode } from "./runtime.ts";
 
+/**
+ * Typed accessor for the Deno global.
+ *
+ * This is pure typing only — it reads no environment variables and performs no
+ * side effects, so this module stays importable without `--allow-env`. It
+ * exists to retire the `@ts-ignore` comments that were previously required to
+ * access `Deno.*` APIs from runtime-agnostic compat code.
+ */
+function denoGlobal(): typeof Deno {
+  return (globalThis as { Deno: typeof Deno }).Deno;
+}
+
 /** Public API contract for file system. */
 export interface FileSystem {
   readTextFile(path: string): Promise<string>;
@@ -182,40 +194,33 @@ class NodeFileSystem implements FileSystem {
 
 class DenoFileSystem implements FileSystem {
   readTextFile(path: string): Promise<string> {
-    // @ts-ignore - Deno global
-    return Deno.readTextFile(path);
+    return denoGlobal().readTextFile(path);
   }
 
   readFile(path: string): Promise<Uint8Array> {
-    // @ts-ignore - Deno global
-    return Deno.readFile(path);
+    return denoGlobal().readFile(path);
   }
 
   async writeTextFile(path: string, data: string): Promise<void> {
-    // @ts-ignore - Deno global
-    await Deno.writeTextFile(path, data);
+    await denoGlobal().writeTextFile(path, data);
   }
 
   async writeFile(path: string, data: Uint8Array): Promise<void> {
-    // @ts-ignore - Deno global
-    await Deno.writeFile(path, data);
+    await denoGlobal().writeFile(path, data);
   }
 
   async exists(path: string): Promise<boolean> {
     try {
-      // @ts-ignore - Deno global
-      await Deno.stat(path);
+      await denoGlobal().stat(path);
       return true;
     } catch (error: unknown) {
-      // @ts-ignore - Deno global
-      if (error instanceof Deno.errors.NotFound) return false;
+      if (error instanceof denoGlobal().errors.NotFound) return false;
       throw error;
     }
   }
 
   async stat(path: string): Promise<FileInfo> {
-    // @ts-ignore - Deno global
-    const stat = await Deno.stat(path);
+    const stat = await denoGlobal().stat(path);
     return {
       isFile: stat.isFile,
       isDirectory: stat.isDirectory,
@@ -226,33 +231,28 @@ class DenoFileSystem implements FileSystem {
   }
 
   async mkdir(path: string, options?: { recursive?: boolean }): Promise<void> {
-    // @ts-ignore - Deno global
-    await Deno.mkdir(path, { recursive: options?.recursive ?? false });
+    await denoGlobal().mkdir(path, { recursive: options?.recursive ?? false });
   }
 
   async *readDir(
     path: string,
   ): AsyncIterable<{ name: string; isFile: boolean; isDirectory: boolean }> {
-    // @ts-ignore - Deno global
-    for await (const entry of Deno.readDir(path)) {
+    for await (const entry of denoGlobal().readDir(path)) {
       yield { name: entry.name, isFile: entry.isFile, isDirectory: entry.isDirectory };
     }
   }
 
   async remove(path: string, options?: { recursive?: boolean }): Promise<void> {
-    // @ts-ignore - Deno global
-    await Deno.remove(path, { recursive: options?.recursive ?? false });
+    await denoGlobal().remove(path, { recursive: options?.recursive ?? false });
   }
 
   makeTempDir(options?: { prefix?: string }): Promise<string> {
-    // @ts-ignore - Deno global
-    return Deno.makeTempDir({ prefix: options?.prefix });
+    return denoGlobal().makeTempDir({ prefix: options?.prefix });
   }
 
   async chmod(path: string, mode: number): Promise<void> {
     try {
-      // @ts-ignore - Deno global
-      await Deno.chmod(path, mode);
+      await denoGlobal().chmod(path, mode);
     } catch (_) {
       /* expected: chmod is not fully supported on Windows */
     }
@@ -330,8 +330,7 @@ export function chmod(path: string, mode: number): Promise<void> {
 
 export async function symlink(target: string, path: string): Promise<void> {
   if (isDeno) {
-    // @ts-ignore - Deno global
-    await Deno.symlink(target, path);
+    await denoGlobal().symlink(target, path);
     return;
   }
 

--- a/src/react/components/chat/chat/composition/chat-composer.tsx
+++ b/src/react/components/chat/chat/composition/chat-composer.tsx
@@ -5,7 +5,7 @@
  */
 
 import * as React from "react";
-import { InputBox, SubmitButton } from "../../../../primitives/index.ts";
+import { InputBox, SubmitButton } from "#veryfront/react/primitives/index.ts";
 import { cn } from "../../theme.ts";
 import { PlusIcon } from "../../icons/index.ts";
 import { type ModelOption, ModelSelector } from "../../model-selector.tsx";

--- a/src/react/components/chat/chat/composition/chat-message-list.tsx
+++ b/src/react/components/chat/chat/composition/chat-message-list.tsx
@@ -8,7 +8,7 @@
  */
 
 import * as React from "react";
-import { MessageItem, MessageList } from "../../../../primitives/index.ts";
+import { MessageItem, MessageList } from "#veryfront/react/primitives/index.ts";
 import type {
   BranchInfo,
   BrowserInferenceStatus,

--- a/src/react/components/chat/chat/composition/chat-root.tsx
+++ b/src/react/components/chat/chat/composition/chat-root.tsx
@@ -8,7 +8,7 @@
  */
 
 import * as React from "react";
-import { ChatContainer } from "../../../../primitives/index.ts";
+import { ChatContainer } from "#veryfront/react/primitives/index.ts";
 import type { ChatMessage } from "#veryfront/agent/react";
 import type { ChatTheme } from "../../theme.ts";
 import { getDocumentNonce } from "../../csp-nonce.ts";

--- a/src/react/components/chat/chat/composition/message.tsx
+++ b/src/react/components/chat/chat/composition/message.tsx
@@ -27,7 +27,7 @@ import type {
 } from "#veryfront/agent/react";
 import { cn } from "../../theme.ts";
 import { Markdown } from "../../markdown.tsx";
-import { MessageItem } from "../../../../primitives/index.ts";
+import { MessageItem } from "#veryfront/react/primitives/index.ts";
 import { MessageContextProvider, useMessageContext } from "../contexts/message-context.tsx";
 import type { MessageContextValue } from "../contexts/message-context.tsx";
 import { useChatContextOptional } from "../contexts/chat-context.tsx";

--- a/src/utils/cache/stores/memory/lru-cache-adapter.ts
+++ b/src/utils/cache/stores/memory/lru-cache-adapter.ts
@@ -1,4 +1,4 @@
-import { serverLogger } from "../../../logger/logger.ts";
+import { serverLogger } from "#veryfront/utils/logger/logger.ts";
 import type { CacheAdapter, LRUCacheOptions, LRUCacheStats, LRUEntry } from "./types.ts";
 import { LRUNode } from "./lru-node.ts";
 import { LRUListManager } from "./lru-list-manager.ts";


### PR DESCRIPTION
## Description

Tech-debt quick-win batch (epic #1990) — import hygiene + retire `@ts-ignore`.

- **#2022** `utils/cache/stores/memory/lru-cache-adapter.ts` — deep relative `../../../logger/logger.ts` → `#veryfront/utils/logger/logger.ts` hash alias.
- **#2013** four `../../../../primitives` deep imports in `react/components/chat/chat/composition/*` → `#veryfront/react/primitives/index.ts`.
- **#2009** `platform/compat/fs.ts` — introduce one pure-typing `denoGlobal(): typeof Deno` accessor and retire all **13** `@ts-ignore`. The accessor performs no env reads / no logger import, so the module stays importable without `--allow-env` (verified via `--deny-env`).

## Verification
- `deno lint` clean (6 files); `deno task lint:ban-deep-imports` / `lint:imports` — no new violations from changed files.
- `deno task typecheck` — no new errors; `compat/fs.ts` (not in baseline) is error-free.
- `deno run --allow-read --deny-env` importing `compat/fs.ts` → OK (no env permission required at import).
- Colocated tests pass (`fs.test.ts`, `lru-cache-adapter.test.ts`, `chat-composer.test.tsx`).

Closes #2022, Closes #2013, Closes #2009

## Type of Change
- [x] Code refactoring

## Checklist
- [x] Covered by existing colocated tests; behavior unchanged