### PR TITLE
Keep provider-native tools inside explicit allowlists

### DIFF
--- a/src/agent/hosted/child-fork-execution-runner.test.ts
+++ b/src/agent/hosted/child-fork-execution-runner.test.ts
@@ -130,7 +130,7 @@ Deno.test("executeHostedChildForkWithPreparedTools executes a prepared child for
     },
     runStep: async (input) => {
       assertEquals(input.model, "anthropic/claude-sonnet-4");
-      assertEquals(input.forkToolNames, ["noop", "web_fetch", "web_search"]);
+      assertEquals(input.forkToolNames, ["noop"]);
       assertEquals(input.providerOptions, undefined);
       assertEquals(input.system.includes('project_reference: "project-1"'), true);
       assertEquals(input.system.includes("Available Skills"), true);

--- a/src/agent/hosted/child-fork-execution-runner.ts
+++ b/src/agent/hosted/child-fork-execution-runner.ts
@@ -330,6 +330,7 @@ export async function executeHostedChildForkWithPreparedTools<
       maxContinuationSteps: input.maxContinuationSteps ?? 0,
       abortSignal: input.abortSignal,
       forkTools: input.toolAssembly.forkTools,
+      forkToolNames: input.toolAssembly.availableToolNames,
       providerOptions: input.providerOptions,
       buildInstructions,
       onBeforeStop: input.onBeforeStop ?? (() => null),

--- a/src/agent/hosted/child-fork-tool-selection.test.ts
+++ b/src/agent/hosted/child-fork-tool-selection.test.ts
@@ -61,6 +61,7 @@ Deno.test("selectHostedChildForkRuntimeTools accepts provider-native requested t
 
   assertEquals(result, {
     ok: true,
+    availableToolNames: ["web_search", "create_file"],
     forkTools: {
       create_file: createFileTool,
     },

--- a/src/agent/hosted/child-requested-tools.ts
+++ b/src/agent/hosted/child-requested-tools.ts
@@ -9,7 +9,10 @@ import {
   type HostedChildSteeringMutationHandler,
   wrapHostedChildSteeringMutationTool,
 } from "./child-steering-tools.ts";
-import { getForkRuntimeAllowedToolNames } from "../runtime/provider-native-tool-inventory.ts";
+import {
+  getForkRuntimeAllowedToolNames,
+  getProviderNativeToolNames,
+} from "../runtime/provider-native-tool-inventory.ts";
 import {
   PROJECT_STEERING_FILE_MUTATION_TOOL_NAMES,
   type ProjectSteeringPaths,
@@ -154,6 +157,7 @@ export type HostedChildForkRuntimeToolSelectionResult =
   | {
     ok: true;
     forkTools: HostToolSet;
+    availableToolNames?: string[];
   }
   | {
     ok: false;
@@ -213,13 +217,20 @@ export function selectHostedChildForkRuntimeTools(input: {
     };
   }
 
-  const availableNames = new Set(
-    getForkRuntimeAllowedToolNames({
+  const providerNativeNames = new Set(
+    getProviderNativeToolNames({
+      provider: input.provider,
+      model: input.forkModel,
+    }),
+  );
+  const availableNames = new Set([
+    ...getForkRuntimeAllowedToolNames({
       provider: input.provider,
       forkModel: input.forkModel,
       forkTools: input.forkTools,
     }),
-  );
+    ...providerNativeNames,
+  ]);
   const unavailableRequested = input.requestedTools.filter((toolName) =>
     !availableNames.has(toolName)
   );
@@ -240,9 +251,15 @@ export function selectHostedChildForkRuntimeTools(input: {
     }
   }
 
+  const requestedAvailableToolNames = [...new Set(input.requestedTools)];
+  const includesProviderNativeTool = requestedAvailableToolNames.some((toolName) =>
+    providerNativeNames.has(toolName)
+  );
+
   return {
     ok: true,
     forkTools,
+    ...(includesProviderNativeTool ? { availableToolNames: requestedAvailableToolNames } : {}),
   };
 }
 
@@ -307,7 +324,7 @@ export function prepareDefaultHostedChildForkRuntimeTools(input: {
   }
 
   let forkTools = selectedTools.forkTools;
-  const availableToolNames = Object.keys(forkTools);
+  const availableToolNames = selectedTools.availableToolNames ?? Object.keys(forkTools);
   forkTools = withHostedChildRerunnableFileWriteFallbacks({
     tools: forkTools,
     logger: input.logger,

--- a/src/agent/runtime/provider-native-tool-inventory.test.ts
+++ b/src/agent/runtime/provider-native-tool-inventory.test.ts
@@ -36,13 +36,13 @@ describe("provider-native-tool-inventory", () => {
     assertEquals(getProviderNativeToolNames({ model: "openai/gpt-4o-mini" }), []);
   });
 
-  it("expands a fork/runtime allowlist with provider-native tools", () => {
+  it("preserves a fork/runtime allowlist without adding undeclared provider-native tools", () => {
     assertEquals(
       expandAllowedRemoteToolNames({
         provider: "anthropic",
         toolNames: ["create_file", "web_search"],
       }),
-      ["create_file", "web_fetch", "web_search"],
+      ["create_file", "web_search"],
     );
   });
 
@@ -68,7 +68,7 @@ describe("provider-native-tool-inventory", () => {
         forkModel: "claude-sonnet-4-6",
         forkTools,
       }),
-      ["create_file", "web_fetch", "web_search"],
+      ["create_file", "web_search"],
     );
   });
 });

--- a/src/agent/runtime/provider-native-tool-inventory.ts
+++ b/src/agent/runtime/provider-native-tool-inventory.ts
@@ -52,16 +52,11 @@ export function getProviderNativeToolNames(
   }
 }
 
-/** Expand allowed remote tool names helper. */
+/** Normalize allowed remote tool names without adding undeclared provider-native tools. */
 export function expandAllowedRemoteToolNames(
   options: ExpandAllowedRemoteToolNamesOptions,
 ): string[] {
-  return [
-    ...new Set([
-      ...options.toolNames,
-      ...getProviderNativeToolNames(options),
-    ]),
-  ].sort();
+  return [...new Set(options.toolNames)].sort();
 }
 
 /** Return fork runtime allowed tool names. */

--- a/src/agent/streaming/fork-runtime-stream.test.ts
+++ b/src/agent/streaming/fork-runtime-stream.test.ts
@@ -448,7 +448,7 @@ describe("agent/fork-runtime-stream", () => {
       parts.push(part);
     }
 
-    assertEquals(forkToolNames, ["create_file", "web_fetch", "web_search"]);
+    assertEquals(forkToolNames, ["create_file"]);
     assertEquals(capturedInputs[0]?.forkToolNames, forkToolNames);
     assertEquals(Object.keys(capturedInputs[0]?.runtimeTools ?? {}), ["create_file"]);
     assertEquals(traceCalls, ["tool.create_file"]);

--- a/src/agent/streaming/fork-runtime-stream.ts
+++ b/src/agent/streaming/fork-runtime-stream.ts
@@ -232,6 +232,7 @@ export type StartAgentRuntimeForkWithHostToolsInput<
     provider: string;
     forkModel: string;
     forkTools: HostToolSet;
+    forkToolNames?: readonly string[];
     traceTools?: TraceHostToolsOptions<TAttributes>;
   };
 
@@ -248,11 +249,13 @@ export function startAgentRuntimeForkWithHostTools<
     ? traceHostTools(input.forkTools, input.traceTools)
     : input.forkTools;
   const runtimeTools = createToolsFromHostDefinitions(forkTools);
-  const forkToolNames = getForkRuntimeAllowedToolNames({
-    provider: input.provider,
-    forkModel: input.forkModel,
-    forkTools: input.forkTools,
-  });
+  const forkToolNames = input.forkToolNames
+    ? [...input.forkToolNames]
+    : getForkRuntimeAllowedToolNames({
+      provider: input.provider,
+      forkModel: input.forkModel,
+      forkTools: input.forkTools,
+    });
 
   return {
     streamResult: startAgentRuntimeFork({


### PR DESCRIPTION
## Summary
- Fixes the runtime-side provider-native tool leak from veryfront/veryfront-studio#4626.
- Keeps fork/runtime provider-native tools bounded by the explicit allowlist instead of expanding to every provider-native inventory tool.
- Updates runtime tests to prove `web_fetch` is not added when only `web_search` is declared.

## Test Plan
- [x] `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/agent/runtime/provider-native-tool-inventory.test.ts src/agent/runtime/model-tool-converter.test.ts`
- [x] `deno fmt --check src/agent/runtime/provider-native-tool-inventory.ts src/agent/runtime/provider-native-tool-inventory.test.ts src/agent/runtime/model-tool-converter.test.ts`
- [x] `deno lint src/agent/runtime/provider-native-tool-inventory.ts src/agent/runtime/provider-native-tool-inventory.test.ts src/agent/runtime/model-tool-converter.test.ts`
- [x] `deno check src/agent/runtime/provider-native-tool-inventory.ts`
- [x] pre-commit `deno task verify:quick`