### PR TITLE
refactor(types): replace casts / @ts-ignore with proper types (batch 2)

### DIFF
--- a/src/react/components/chat/markdown.tsx
+++ b/src/react/components/chat/markdown.tsx
@@ -42,23 +42,52 @@ type MermaidModule = {
   };
 };
 
+/**
+ * Opaque remark/rehype plugin handle. The plugin internals are not used
+ * directly; they are only passed through to react-markdown.
+ */
+type MarkdownPlugin = unknown;
+
+/** Props passed by react-markdown to a custom `code` renderer. */
+interface CodeRendererProps {
+  className?: string;
+  children?: React.ReactNode;
+  node?: { position?: { start?: { line?: number } } };
+}
+
+/** Props passed by react-markdown to a custom `a` (anchor) renderer. */
+interface AnchorRendererProps {
+  href?: string;
+  children?: React.ReactNode;
+}
+
+/** Props passed by react-markdown to block-level renderers (table, blockquote). */
+interface BlockRendererProps {
+  children?: React.ReactNode;
+}
+
+/** Minimal shape of the react-markdown default export used here. */
+interface ReactMarkdownProps {
+  remarkPlugins?: MarkdownPlugin[];
+  rehypePlugins?: MarkdownPlugin[];
+  components?: Record<string, (props: never) => React.ReactNode>;
+  children?: string;
+}
+
+type ReactMarkdownComponent = (props: ReactMarkdownProps) => React.ReactElement;
+
 async function importFromUrl<T>(url: string): Promise<T> {
   return await import(/* @vite-ignore */ url) as T;
 }
 
-// deno-lint-ignore no-explicit-any
-let ReactMarkdown: any = null;
-// deno-lint-ignore no-explicit-any
-let remarkGfm: any = null;
-// deno-lint-ignore no-explicit-any
-let rehypeHighlight: any = null;
+let ReactMarkdown: ReactMarkdownComponent | null = null;
+let remarkGfm: MarkdownPlugin | null = null;
+let rehypeHighlight: MarkdownPlugin | null = null;
 
-// deno-lint-ignore no-explicit-any
 let mermaidPromise: Promise<MermaidModule> | null = null;
-// deno-lint-ignore no-explicit-any
-let mermaidModule: any = null;
+let mermaidModule: MermaidModule | null = null;
 
-async function loadMermaid(): Promise<any | null> {
+async function loadMermaid(): Promise<MermaidModule | null> {
   if (!isBrowserEnvironment()) return null;
   if (mermaidModule) return mermaidModule;
 
@@ -203,7 +232,7 @@ export function Markdown({
           importFromUrl<DefaultModule<unknown>>(ESM_REHYPE_HIGHLIGHT),
         ]);
 
-        ReactMarkdown = rmModule.default;
+        ReactMarkdown = rmModule.default as ReactMarkdownComponent;
         remarkGfm = gfmModule.default;
         rehypeHighlight = highlightModule.default;
       }
@@ -229,8 +258,7 @@ export function Markdown({
         remarkPlugins={remarkGfm ? [remarkGfm] : []}
         rehypePlugins={rehypeHighlight ? [rehypeHighlight] : []}
         components={{
-          // deno-lint-ignore no-explicit-any
-          code(props: any) {
+          code(props: CodeRendererProps) {
             const { className: codeClassName, children: codeChildren, node } = props;
             const match = /language-(\w+)/.exec(codeClassName || "");
             const language = match ? match[1] : undefined;
@@ -247,8 +275,7 @@ export function Markdown({
               />
             );
           },
-          // deno-lint-ignore no-explicit-any
-          table(props: any) {
+          table(props: BlockRendererProps) {
             return (
               <div className="my-4 overflow-auto">
                 <table className="min-w-full divide-y divide-[var(--border)]">
@@ -257,8 +284,7 @@ export function Markdown({
               </div>
             );
           },
-          // deno-lint-ignore no-explicit-any
-          a(props: any) {
+          a(props: AnchorRendererProps) {
             return (
               <a
                 href={props.href}
@@ -270,15 +296,14 @@ export function Markdown({
               </a>
             );
           },
-          // deno-lint-ignore no-explicit-any
-          blockquote(props: any) {
+          blockquote(props: BlockRendererProps) {
             return (
               <blockquote className="border-l-4 border-[var(--border)] pl-4 my-4 text-[var(--card-foreground)] italic">
                 {props.children}
               </blockquote>
             );
           },
-        }}
+        } as ReactMarkdownProps["components"]}
       >
         {children}
       </ReactMarkdown>

--- a/src/security/sandbox/permission-system.ts
+++ b/src/security/sandbox/permission-system.ts
@@ -22,6 +22,32 @@ interface PermissionDescriptor {
   path?: string;
 }
 
+/**
+ * Narrow view of the subset of the Deno permissions API this module uses.
+ *
+ * Typed locally (rather than via lib.deno.d.ts) so this permission-sensitive
+ * module stays free of broad ambient globals and avoids importing anything
+ * that reads the environment at module load.
+ */
+interface DenoPermissions {
+  request(descriptor: PermissionDescriptor): Promise<{ state: PermissionResult["state"] }>;
+}
+
+interface DenoLike {
+  permissions?: Partial<DenoPermissions>;
+}
+
+/**
+ * Access the Deno permissions API through a narrow, typed view.
+ * Returns null when not running under Deno or the API is unavailable.
+ */
+function getDenoPermissions(): DenoPermissions | null {
+  const denoGlobal = (globalThis as { Deno?: DenoLike }).Deno;
+  const permissions = denoGlobal?.permissions;
+  if (!permissions || typeof permissions.request !== "function") return null;
+  return permissions as DenoPermissions;
+}
+
 function createPermissionDescriptor(
   request: PermissionRequest,
 ): PermissionDescriptor | null {
@@ -48,19 +74,16 @@ function requestDenoPermission(
   return withSpan(
     "security.permissions.requestDeno",
     async () => {
-      // @ts-ignore - Deno permissions API
-      const canRequest = typeof Deno?.permissions?.request === "function";
-      if (!isDeno || !canRequest) return { state: "denied" };
+      const permissions = getDenoPermissions();
+      if (!isDeno || !permissions) return { state: "denied" };
 
       if (request.name === "fs") {
         const path = request.path;
 
-        // @ts-ignore - Deno permissions API
-        const readStatus = await Deno.permissions.request({ name: "read", path });
+        const readStatus = await permissions.request({ name: "read", path });
         if (readStatus.state !== "granted") return { state: readStatus.state };
 
-        // @ts-ignore - Deno permissions API
-        const writeStatus = await Deno.permissions.request({ name: "write", path });
+        const writeStatus = await permissions.request({ name: "write", path });
         return { state: writeStatus.state };
       }
 
@@ -70,8 +93,7 @@ function requestDenoPermission(
         return { state: "denied" };
       }
 
-      // @ts-ignore - Deno permissions API
-      const status = await Deno.permissions.request(descriptor);
+      const status = await permissions.request(descriptor);
       return { state: status.state };
     },
     { "permission.name": request.name },

--- a/src/transforms/esm/http-cache-types.ts
+++ b/src/transforms/esm/http-cache-types.ts
@@ -44,6 +44,40 @@ export type BundleHash = Brand<string, "BundleHash">;
 export type NormalizedUrl = Brand<string, "NormalizedUrl">;
 
 /**
+ * Apply a branded-type marker to a raw value.
+ *
+ * Centralizes the (otherwise unsafe) widening cast used to attach a
+ * compile-time brand. Use this instead of scattering `as unknown as Branded`
+ * across the codebase so the single point of unsoundness is auditable.
+ *
+ * The brand string is inferred from the requested branded type, so callers
+ * write `brand<PortableModuleCode>(str)` and get full checking on the base.
+ *
+ * @param value - The underlying (unbranded) value
+ * @returns The same value, typed as the requested branded type
+ */
+export function brand<TBranded extends Brand<string, string>>(
+  value: string,
+): TBranded {
+  // Single, centralized unsound widening: attaching a phantom brand to a
+  // runtime value. This is the only place this cast should occur.
+  return value as unknown as TBranded;
+}
+
+/**
+ * Strip the branded-type marker from a value, recovering the underlying type.
+ *
+ * Fully type-safe: it only forgets the brand. Accepts the raw underlying type
+ * as well so callers can pass `Branded | Raw` unions (e.g. `BundleHash | string`).
+ *
+ * @param value - The branded (or already-raw) value
+ * @returns The value typed as its underlying (unbranded) type
+ */
+export function unbrand<TBase>(value: Brand<TBase, string> | TBase): TBase {
+  return value as TBase;
+}
+
+/**
  * Result of attempting to decode potentially gzip-compressed code.
  */
 export interface DecodeResult {

--- a/src/transforms/esm/http-cache-wrapper.ts
+++ b/src/transforms/esm/http-cache-wrapper.ts
@@ -18,12 +18,14 @@ import { getCacheBaseDir } from "#veryfront/utils/cache-dir.ts";
 import { CacheBackends, createDistributedCacheAccessor } from "#veryfront/cache/backend.ts";
 import type { CacheBackend } from "#veryfront/cache/types.ts";
 import { HTTP_MODULE_DISTRIBUTED_TTL_SEC } from "#veryfront/utils/constants/cache.ts";
-import type {
-  BundleHash,
-  DecodeResult,
-  LocalModuleCode,
-  NormalizedUrl,
-  PortableModuleCode,
+import {
+  brand,
+  type BundleHash,
+  type DecodeResult,
+  type LocalModuleCode,
+  type NormalizedUrl,
+  type PortableModuleCode,
+  unbrand,
 } from "./http-cache-types.ts";
 import {
   asBundleHash,
@@ -70,7 +72,7 @@ export async function initializeHttpModuleDistributedCache(): Promise<boolean> {
  * Format: {VERSION}:{prefix}:{hash}
  */
 function distributedKey(prefix: string, hash: string | BundleHash): string {
-  const hashStr = typeof hash === "string" ? hash : (hash as unknown as string);
+  const hashStr = typeof hash === "string" ? hash : unbrand(hash);
   return `${VERSION}:${prefix}:${hashStr}`;
 }
 
@@ -84,7 +86,7 @@ function distributedKey(prefix: string, hash: string | BundleHash): string {
 function tokenize(code: LocalModuleCode): PortableModuleCode {
   const cacheDir = getCacheBaseDir();
   const normalized = cacheDir.endsWith("/") ? cacheDir.slice(0, -1) : cacheDir;
-  let codeStr = code as unknown as string;
+  let codeStr: string = unbrand(code);
 
   // First, tokenize current environment's paths (fast path)
   codeStr = codeStr.replaceAll(`file://${normalized}`, `file://${CACHE_DIR_TOKEN}`);
@@ -100,7 +102,7 @@ function tokenize(code: LocalModuleCode): PortableModuleCode {
     `file://${CACHE_DIR_TOKEN}/veryfront-mdx-esm/`,
   );
 
-  return codeStr as unknown as PortableModuleCode;
+  return brand<PortableModuleCode>(codeStr);
 }
 
 /**
@@ -110,9 +112,9 @@ function tokenize(code: LocalModuleCode): PortableModuleCode {
 function detokenize(code: PortableModuleCode | string): LocalModuleCode {
   const cacheDir = getCacheBaseDir();
   const normalized = cacheDir.endsWith("/") ? cacheDir.slice(0, -1) : cacheDir;
-  const codeStr = typeof code === "string" ? code : (code as unknown as string);
+  const codeStr = typeof code === "string" ? code : unbrand(code);
   const result = codeStr.replaceAll(`file://${CACHE_DIR_TOKEN}`, `file://${normalized}`);
-  return result as unknown as LocalModuleCode;
+  return brand<LocalModuleCode>(result);
 }
 
 /**
@@ -184,7 +186,7 @@ class HttpBundleCache {
       return { code: null, wasGzipped: false, failReason: "not_found" };
     }
 
-    const hashStr = typeof hash === "string" ? hash : (hash as unknown as string);
+    const hashStr = typeof hash === "string" ? hash : unbrand(hash);
 
     try {
       const rawCode = await distributed.get(distributedKey("code", hashStr));
@@ -240,7 +242,7 @@ class HttpBundleCache {
       return { code: null, wasGzipped: false, failReason: "not_found" };
     }
 
-    const hashStr = typeof hash === "string" ? hash : (hash as unknown as string);
+    const hashStr = typeof hash === "string" ? hash : unbrand(hash);
 
     try {
       const rawCode = await distributed.get(distributedKey("url", hashStr));
@@ -289,8 +291,8 @@ class HttpBundleCache {
     const distributed = await resolveDistributedCache();
     if (!distributed) return;
 
-    const hashStr = typeof hash === "string" ? hash : (hash as unknown as string);
-    const urlStr = typeof url === "string" ? url : (url as unknown as string);
+    const hashStr = typeof hash === "string" ? hash : unbrand(hash);
+    const urlStr = typeof url === "string" ? url : unbrand(url);
 
     try {
       // CRITICAL: Always tokenize before storing
@@ -299,7 +301,7 @@ class HttpBundleCache {
       // Validate invariant
       assertPortable(portableCode);
 
-      const portableStr = portableCode as unknown as string;
+      const portableStr = unbrand(portableCode);
 
       await Promise.all([
         distributed.set(distributedKey("url", hashStr), portableStr, ttl),
@@ -330,7 +332,7 @@ class HttpBundleCache {
     if (!distributed) return new Map();
 
     const results = new Map<string, LocalModuleCode>();
-    const hashStrs = hashes.map((h) => (typeof h === "string" ? h : (h as unknown as string)));
+    const hashStrs = hashes.map((h) => (typeof h === "string" ? h : unbrand(h)));
 
     const codeKeys = hashStrs.map((h) => distributedKey("code", h));
     const keyToHash = new Map(hashStrs.map((h, i) => [codeKeys[i], h]));
@@ -381,7 +383,7 @@ class HttpBundleCache {
     const distributed = await resolveDistributedCache();
     if (!distributed) return null;
 
-    const hashStr = typeof hash === "string" ? hash : (hash as unknown as string);
+    const hashStr = typeof hash === "string" ? hash : unbrand(hash);
 
     try {
       return await distributed.get(distributedKey("hash", hashStr));
@@ -402,7 +404,7 @@ class HttpBundleCache {
     const distributed = await resolveDistributedCache();
     if (!distributed) return false;
 
-    const hashStr = typeof hash === "string" ? hash : (hash as unknown as string);
+    const hashStr = typeof hash === "string" ? hash : unbrand(hash);
 
     try {
       // Delete all keys associated with this hash

--- a/src/workflow/blob/s3-storage.ts
+++ b/src/workflow/blob/s3-storage.ts
@@ -34,6 +34,19 @@ async function getS3Module(): Promise<typeof import("@aws-sdk/client-s3")> {
   }
 }
 
+/**
+ * Wrap a readable stream in a `Response` for body consumption.
+ *
+ * Centralizes the single, well-understood type mismatch between Deno's
+ * `ReadableStream` and the DOM `ReadableStream` that `Response` accepts. The
+ * AWS SDK returns a `ReadableStream` whose generic type does not line up with
+ * the lib that `Response` is typed against, but the runtime objects are
+ * interchangeable. We narrow to `BodyInit` here so callers stay type-safe.
+ */
+function streamToResponse(stream: ReadableStream): Response {
+  return new Response(stream as unknown as BodyInit);
+}
+
 export interface S3BlobStorageConfig {
   /** AWS Region */
   region: string;
@@ -200,15 +213,13 @@ export class S3BlobStorage implements BlobStorage {
   async getText(id: string): Promise<string | null> {
     const stream = await this.getStream(id);
     if (!stream) return null;
-    // @ts-ignore - Deno's ReadableStream vs Web ReadableStream type mismatch
-    return new Response(stream).text();
+    return streamToResponse(stream).text();
   }
 
   async getBytes(id: string): Promise<Uint8Array | null> {
     const stream = await this.getStream(id);
     if (!stream) return null;
-    // @ts-ignore - Deno's ReadableStream vs Web ReadableStream type mismatch
-    const buffer = await new Response(stream).arrayBuffer();
+    const buffer = await streamToResponse(stream).arrayBuffer();
     return new Uint8Array(buffer);
   }
 


### PR DESCRIPTION
## Description

Tech-debt quick-win batch (epic #1990) — remove unsafe casts / `@ts-ignore` via proper narrow types. No behavior change; no env/logger imports added to low-level modules.

- **#2016** `react/components/chat/markdown.tsx` — type the lazy markdown modules + the code/table/anchor/blockquote renderers; drop 9 `any` (and the `deno-lint-ignore no-explicit-any` comments).
- **#2019** `transforms/esm/http-cache-wrapper.ts` — add centralized `brand`/`unbrand` helpers in `http-cache-types.ts`; replace all 13 `as unknown as` casts (the single unsound cast is now isolated + commented in `brand`).
- **#2023** `security/sandbox/permission-system.ts` — narrow `DenoPermissions` interface + typed accessor; drop 4 `@ts-ignore` (pure typing, no env/logger import — stays sandbox-safe).
- **#1999** `workflow/blob/s3-storage.ts` — typed `streamToResponse` helper; drop 2 `@ts-ignore`.

## Verification
- `deno lint` clean (5 files); `deno task typecheck` — **no new errors** (none in changed files; baseline-only errors unchanged).
- Colocated tests pass (`permission-system`, `http-cache-wrapper`, `http-cache-invariants`, `local-storage`).

Closes #2016, Closes #2019, Closes #2023, Closes #1999

## Type of Change
- [x] Code refactoring (type safety)