### PR TITLE
refactor: extract shared helpers to dedupe (batch 2)

### DIFF
--- a/src/cache/backends/api.ts
+++ b/src/cache/backends/api.ts
@@ -5,6 +5,7 @@ import { tryGetCacheKeyContext } from "../cache-key-builder.ts";
 import { CircuitBreakerOpen, getCircuitBreaker } from "#veryfront/utils/circuit-breaker.ts";
 import type { CacheBackend } from "../types.ts";
 import { getEnvValue } from "./helpers.ts";
+import { buildBatchResults } from "./batch-results.ts";
 import { REQUEST_ERROR } from "#veryfront/errors";
 
 const logger = baseLogger.component("api-cache-backend");
@@ -161,14 +162,13 @@ export class ApiCacheBackend implements CacheBackend {
   }
 
   async getBatch(keys: string[]): Promise<Map<string, string | null>> {
-    const results = new Map<string, string | null>();
-    if (keys.length === 0) return results;
+    if (keys.length === 0) return new Map<string, string | null>();
 
-    const prefixedKeys = keys.map((k) => this.prefixKey(k));
+    const prefixedByKey = new Map(keys.map((k) => [k, this.prefixKey(k)] as const));
     const response = await this.request<{ values: Record<string, string | null> }>(
       "POST",
       "/get-batch",
-      { keys: prefixedKeys },
+      { keys: keys.map((k) => prefixedByKey.get(k) as string) },
     );
 
     if (!response?.values) {
@@ -178,13 +178,10 @@ export class ApiCacheBackend implements CacheBackend {
       return this.getIndividually(keys);
     }
 
-    for (let i = 0; i < keys.length; i++) {
-      const originalKey = keys[i] as string;
-      const prefixedKey = prefixedKeys[i] as string;
-      results.set(originalKey, response.values[prefixedKey] ?? null);
-    }
-
-    return results;
+    return buildBatchResults(keys, (key) => {
+      const prefixedKey = prefixedByKey.get(key) as string;
+      return response.values[prefixedKey] ?? null;
+    });
   }
 
   private async getIndividually(keys: string[]): Promise<Map<string, string | null>> {

--- a/src/cache/backends/batch-results.ts
+++ b/src/cache/backends/batch-results.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared batch-result assembly for cache backends.
+ *
+ * Several backends implement `getBatch` by iterating the requested keys and
+ * building a `Map<string, string | null>` where each key resolves to its value
+ * (or `null` when missing/expired/unavailable). This helper centralizes that
+ * assembly so the per-backend code only supplies the resolver.
+ *
+ * @module cache/backends/batch-results
+ */
+
+/**
+ * Build a `Map` of batch results by resolving each key in order.
+ *
+ * The map preserves the requested keys' insertion order. `resolve` is invoked
+ * once per key and must return the resolved value or `null`.
+ *
+ * @param keys Requested cache keys.
+ * @param resolve Resolver mapping a key to its value (or `null`).
+ */
+export function buildBatchResults(
+  keys: string[],
+  resolve: (key: string) => string | null,
+): Map<string, string | null> {
+  const results = new Map<string, string | null>();
+  for (const key of keys) {
+    results.set(key, resolve(key));
+  }
+  return results;
+}

--- a/src/cache/backends/memory.ts
+++ b/src/cache/backends/memory.ts
@@ -3,6 +3,7 @@ import {
   MEMORY_CACHE_MAX_SIZE_BYTES,
 } from "#veryfront/utils/constants/cache.ts";
 import type { CacheBackend } from "../types.ts";
+import { buildBatchResults } from "./batch-results.ts";
 
 const DEFAULT_TTL_SECONDS = 300;
 const MAX_REGEX_CACHE_SIZE = 100;
@@ -46,25 +47,20 @@ export class MemoryCacheBackend implements CacheBackend {
   }
 
   getBatch(keys: string[]): Promise<Map<string, string | null>> {
-    const results = new Map<string, string | null>();
     const now = Date.now();
 
-    for (const key of keys) {
+    const results = buildBatchResults(keys, (key) => {
       const entry = this.store.get(key);
-      if (!entry) {
-        results.set(key, null);
-        continue;
-      }
+      if (!entry) return null;
 
       if (now > entry.expiresAt) {
         this.currentSizeBytes -= entry.sizeBytes;
         this.store.delete(key);
-        results.set(key, null);
-        continue;
+        return null;
       }
 
-      results.set(key, entry.value);
-    }
+      return entry.value;
+    });
 
     return Promise.resolve(results);
   }

--- a/src/cache/backends/redis.ts
+++ b/src/cache/backends/redis.ts
@@ -8,6 +8,7 @@ import {
   type RedisClient,
 } from "#veryfront/utils/redis-client.ts";
 import type { CacheBackend } from "../types.ts";
+import { buildBatchResults } from "./batch-results.ts";
 
 const logger = baseLogger.component("redis-cache-backend");
 
@@ -59,24 +60,21 @@ export class RedisCacheBackend implements CacheBackend {
   }
 
   async getBatch(keys: string[]): Promise<Map<string, string | null>> {
-    const results = new Map<string, string | null>();
-    if (keys.length === 0) return results;
+    if (keys.length === 0) return new Map<string, string | null>();
 
     if (!this.client) {
-      for (const key of keys) results.set(key, null);
-      return results;
+      return buildBatchResults(keys, () => null);
     }
 
     try {
       const fetched = await Promise.all(
         keys.map(async (key) => [key, await this.get(key)] as const),
       );
-      for (const [key, value] of fetched) results.set(key, value);
-      return results;
+      const values = new Map(fetched);
+      return buildBatchResults(keys, (key) => values.get(key) ?? null);
     } catch (error) {
       logger.debug("GetBatch failed", { keyCount: keys.length, error });
-      for (const key of keys) results.set(key, null);
-      return results;
+      return buildBatchResults(keys, () => null);
     }
   }
 

--- a/src/cache/testing/mock-backend.ts
+++ b/src/cache/testing/mock-backend.ts
@@ -8,6 +8,7 @@
  */
 
 import type { CacheBackend } from "../backend.ts";
+import { buildBatchResults } from "../backends/batch-results.ts";
 
 /**
  * Recorded cache operation for inspection.
@@ -196,23 +197,18 @@ export class MockCacheBackend implements CacheBackend {
       timestamp: Date.now(),
     };
 
-    const results = new Map<string, string | null>();
     const now = Date.now();
 
-    for (const key of keys) {
-      if (this.shouldFail(key, "get")) {
-        results.set(key, null);
-        continue;
-      }
+    const results = buildBatchResults(keys, (key) => {
+      if (this.shouldFail(key, "get")) return null;
 
       const entry = this.store.get(key);
       if (!entry || now > entry.expiresAt) {
         if (entry) this.store.delete(key);
-        results.set(key, null);
-      } else {
-        results.set(key, entry.value);
+        return null;
       }
-    }
+      return entry.value;
+    });
 
     operation.result = results;
     this._operations.push(operation);

--- a/src/platform/adapters/runtime/deno/adapter.ts
+++ b/src/platform/adapters/runtime/deno/adapter.ts
@@ -28,6 +28,7 @@ import {
   enqueueWatchEvent,
 } from "../shared/watcher-queue.ts";
 import { stopManagedServer } from "../shared/server-lifecycle.ts";
+import { getNativeResponse, toNativeResponse } from "../../../compat/http/native-response.ts";
 
 const logger = serverLogger.component("deno");
 
@@ -412,8 +413,7 @@ export class DenoAdapter implements RuntimeAdapter {
     // Access native Response via `self` to bypass dnt shim transform.
     // In npm packages, dnt replaces Response with undici's polyfill,
     // but Deno.serve requires native Response instances.
-    const NativeResponse = (self as unknown as { Response: typeof Response })
-      .Response;
+    const NativeResponse = getNativeResponse();
 
     const server = nativeDeno.serve({
       port,
@@ -422,17 +422,7 @@ export class DenoAdapter implements RuntimeAdapter {
       handler: async (request) => {
         try {
           const response: Response = await wrappedHandler(request);
-          // If already native (compiled binary), return as-is
-          if (response instanceof NativeResponse) return response;
-          // Re-wrap polyfilled Response as native Response.
-          // dnt replaces Response with undici's polyfill which fails
-          // Deno.serve's native instanceof check.
-          const r = response as unknown as Response;
-          return new NativeResponse(r.body, {
-            status: r.status,
-            statusText: r.statusText,
-            headers: r.headers,
-          });
+          return toNativeResponse(response, NativeResponse);
         } catch (error) {
           serverLogger.error("Request handler error:", error);
           return new NativeResponse("Internal Server Error", { status: 500 });

--- a/src/platform/compat/http/deno-server.ts
+++ b/src/platform/compat/http/deno-server.ts
@@ -1,5 +1,6 @@
 import type { Handler, HttpServer, ServeOptions } from "./types.ts";
 import { LOCALHOST } from "../constants.ts";
+import { getNativeResponse, toNativeResponse } from "./native-response.ts";
 
 export class DenoHttpServer implements HttpServer {
   private abortController?: AbortController;
@@ -18,22 +19,11 @@ export class DenoHttpServer implements HttpServer {
     // Access native Response via `self` to bypass dnt shim transform.
     // In npm packages, dnt replaces Response with undici's polyfill,
     // but Deno.serve requires native Response instances.
-    const NativeResponse = (self as unknown as { Response: typeof Response })
-      .Response;
+    const NativeResponse = getNativeResponse();
 
     const wrappedHandler: Handler = async (req) => {
       const response: Response = await handler(req);
-      // If already native (compiled binary or WebSocket upgrade), return as-is
-      if (response instanceof NativeResponse) return response;
-      // Re-wrap polyfilled Response as native Response.
-      // At runtime, `response` may be an undici Response (from dnt shim) that
-      // fails Deno's native instanceof check. Cast to access its properties.
-      const r = response as unknown as Response;
-      return new NativeResponse(r.body, {
-        status: r.status,
-        statusText: r.statusText,
-        headers: r.headers,
-      });
+      return toNativeResponse(response, NativeResponse);
     };
 
     const httpServer = nativeDeno.serve(

--- a/src/platform/compat/http/native-response.ts
+++ b/src/platform/compat/http/native-response.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared helpers for bridging polyfilled `Response` objects to native ones
+ * required by `Deno.serve`.
+ *
+ * In npm packages, dnt replaces the global `Response` with undici's polyfill,
+ * but `Deno.serve` requires native `Response` instances. These helpers access
+ * the native constructor via `self` (which dnt does not shim) and re-wrap
+ * polyfilled responses as needed.
+ *
+ * IMPORTANT: this module must remain importable without `--allow-env`. It must
+ * NOT read environment variables or import a logger at module load time.
+ *
+ * @module platform/compat/http/native-response
+ */
+
+/**
+ * The native `Response` constructor, accessed via `self` to bypass the dnt
+ * shim transform (dnt rewrites bare `Response` to undici's polyfill).
+ */
+export function getNativeResponse(): typeof Response {
+  return (self as unknown as { Response: typeof Response }).Response;
+}
+
+/**
+ * Re-wrap a (possibly polyfilled) `Response` as a native `Response` so it can be
+ * returned from `Deno.serve`.
+ *
+ * If `response` is already a native instance (compiled binary or WebSocket
+ * upgrade), it is returned as-is. Otherwise its body/status/headers are copied
+ * into a fresh native `Response`.
+ */
+export function toNativeResponse(
+  response: Response,
+  NativeResponse: typeof Response,
+): Response {
+  // If already native (compiled binary or WebSocket upgrade), return as-is.
+  if (response instanceof NativeResponse) return response;
+  // Re-wrap polyfilled Response as native Response.
+  // At runtime, `response` may be an undici Response (from the dnt shim) that
+  // fails Deno's native instanceof check. Cast to access its properties.
+  const r = response as unknown as Response;
+  return new NativeResponse(r.body, {
+    status: r.status,
+    statusText: r.statusText,
+    headers: r.headers,
+  });
+}

--- a/src/server/handlers/dev/dashboard/api.ts
+++ b/src/server/handlers/dev/dashboard/api.ts
@@ -26,6 +26,7 @@ import { getLogBuffer } from "#veryfront/observability/log-buffer.ts";
 import { validatePathSync } from "#veryfront/security";
 import { ReloadNotifier } from "../../../reload-notifier.ts";
 import type { HandlerContext } from "../../types.ts";
+import { errorResponse, jsonResponse } from "../http-helpers.ts";
 
 const WORKFLOW_EXECUTION_TIMEOUT_MS = 30_000;
 
@@ -50,11 +51,6 @@ function validateRelativePath(path: string, projectDir: string): string | null {
   return result.canonicalPath;
 }
 
-const JSON_HEADERS = {
-  "Content-Type": "application/json",
-  "Cache-Control": "no-cache",
-};
-
 const TEXT_EXTENSIONS = new Set([
   "ts",
   "tsx",
@@ -72,14 +68,6 @@ const TEXT_EXTENSIONS = new Set([
   "gitignore",
   "dockerignore",
 ]);
-
-function jsonResponse(data: unknown, status = 200): Response {
-  return new Response(JSON.stringify(data, null, 2), { status, headers: JSON_HEADERS });
-}
-
-function errorResponse(message: string, status = 500): Response {
-  return jsonResponse({ error: message }, status);
-}
 
 export function handleDashboardAPI(
   req: Request,

--- a/src/server/handlers/dev/http-helpers.ts
+++ b/src/server/handlers/dev/http-helpers.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared HTTP response helpers for dev handlers.
+ *
+ * Used by the dev dashboard and projects API handlers to build consistent
+ * JSON responses with no-cache headers.
+ *
+ * @module server/handlers/dev/http-helpers
+ */
+
+export const JSON_HEADERS = {
+  "Content-Type": "application/json",
+  "Cache-Control": "no-cache",
+};
+
+/** Build a pretty-printed JSON `Response` with no-cache headers. */
+export function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data, null, 2), { status, headers: JSON_HEADERS });
+}
+
+/** Build a JSON error `Response` of shape `{ error: message }`. */
+export function errorResponse(message: string, status = 500): Response {
+  return jsonResponse({ error: message }, status);
+}

--- a/src/server/handlers/dev/projects/api.ts
+++ b/src/server/handlers/dev/projects/api.ts
@@ -1,14 +1,6 @@
 import type { HandlerContext } from "../../types.ts";
 import { getEffectiveRequestHost } from "../../../utils/request-host.ts";
-
-const JSON_HEADERS = {
-  "Content-Type": "application/json",
-  "Cache-Control": "no-cache",
-};
-
-function jsonResponse(data: unknown, status = 200): Response {
-  return new Response(JSON.stringify(data, null, 2), { status, headers: JSON_HEADERS });
-}
+import { jsonResponse } from "../http-helpers.ts";
 
 export function handleProjectsAPI(req: Request, ctx: HandlerContext): Response | null {
   const { pathname } = new URL(req.url);


### PR DESCRIPTION
## Description

Tech-debt quick-win batch (epic #1990) — extract shared helpers to remove copy-paste. Behavior-preserving.

- **#2001** new `server/handlers/dev/http-helpers.ts` (`jsonResponse`/`errorResponse`/`JSON_HEADERS`); `dev/projects/api.ts` + `dev/dashboard/api.ts` now import it.
- **#2006** new `platform/compat/http/native-response.ts` (`getNativeResponse` + `toNativeResponse`); deduped between `compat/http/deno-server.ts` and `adapters/runtime/deno/adapter.ts`. Each call site keeps its own wrapping (the two had drifted). Helper reads no env / imports no logger → `deno-server.ts` stays importable without `--allow-env` (verified via `--deny-env`).
- **#2015** new `cache/backends/batch-results.ts` (`buildBatchResults`); shared across the 4 cache backends (`memory`, `redis`, `api`, `testing/mock-backend`) — index/dup/expiry semantics preserved.

## Verification
- `deno lint` clean (11 files); `deno task typecheck` — no new errors.
- Cache + dev-handler colocated tests pass (48 cache steps, dashboard api, deno adapter/index).
- `--deny-env` import of `compat/http/deno-server.ts` → OK.
- Note: a pre-existing `deno-server.test.ts` sandbox failure (loopback `Deno.serve` returns 500) reproduces identically on the original inline code — unrelated to this refactor.

Closes #2001, Closes #2006, Closes #2015

## Type of Change
- [x] Code refactoring