### PR TITLE
chore: delete dead deprecated discovery-cache aliases (#2002)

### DIFF
--- a/src/build/production-build/README.md
+++ b/src/build/production-build/README.md
@@ -64,9 +64,9 @@ server/build/
 
 ```typescript
 import { buildProduction } from "#server/build/build";
-import { getAdapter } from "../../adapters/index.ts";
+import { runtime } from "#veryfront/platform/adapters/registry.ts";
 
-const adapter = await getAdapter();
+const adapter = await runtime.get();
 
 const stats = await buildProduction({
   projectDir: "./my-app",

--- a/src/server/runtime-handler/adapter-factory.test.ts
+++ b/src/server/runtime-handler/adapter-factory.test.ts
@@ -4,11 +4,10 @@ import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
 import { resolveAdapter } from "./adapter-factory.ts";
-import {
-  localAdapterCache,
-  localProjectCache,
-  ProjectDiscoveryCache,
-} from "./local-project-discovery.ts";
+import { defaultDiscoveryCache, ProjectDiscoveryCache } from "./local-project-discovery.ts";
+
+const localProjectCache = defaultDiscoveryCache.projects;
+const localAdapterCache = defaultDiscoveryCache.adapters;
 
 const encoder = new TextEncoder();
 

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -95,7 +95,7 @@ import {
   startIsolatedRequest,
 } from "./isolation.ts";
 import { resolveAdapter } from "./adapter-factory.ts";
-import { localProjectCache } from "./local-project-discovery.ts";
+import { defaultDiscoveryCache } from "./local-project-discovery.ts";
 import { resolveEnvironment } from "./environment-resolution.ts";
 import { buildHandlerContext, buildMinimalContext } from "./handler-context-builder.ts";
 import { handleProjectsRequest, shouldHandleProjectsUI } from "./projects-handler.ts";
@@ -295,7 +295,7 @@ export function createVeryfrontHandler(
   // Seed local project cache from explicit mappings (for tests and capability injection)
   if (opts.localProjects) {
     for (const [slug, path] of Object.entries(opts.localProjects)) {
-      localProjectCache.set(slug, path);
+      defaultDiscoveryCache.projects.set(slug, path);
     }
     logDebug("[runtime-handler] Seeded local project cache", {
       projects: Object.keys(opts.localProjects),

--- a/src/server/runtime-handler/local-project-discovery.test.ts
+++ b/src/server/runtime-handler/local-project-discovery.test.ts
@@ -3,12 +3,14 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import {
+  defaultDiscoveryCache,
   findLocalProjectPath,
-  localAdapterCache,
-  localProjectCache,
   ProjectDiscoveryCache,
   standardProjectDirs,
 } from "./local-project-discovery.ts";
+
+const localProjectCache = defaultDiscoveryCache.projects;
+const localAdapterCache = defaultDiscoveryCache.adapters;
 
 describe("local-project-discovery", () => {
   // Clear caches after each test to prevent state leakage
@@ -24,16 +26,16 @@ describe("local-project-discovery", () => {
   });
 
   describe("cache exports", () => {
-    it("exports localAdapterCache with Map-like interface", () => {
-      assertEquals(typeof localAdapterCache.get, "function");
-      assertEquals(typeof localAdapterCache.set, "function");
-      assertEquals(typeof localAdapterCache.clear, "function");
+    it("exports defaultDiscoveryCache.adapters with Map-like interface", () => {
+      assertEquals(typeof defaultDiscoveryCache.adapters.get, "function");
+      assertEquals(typeof defaultDiscoveryCache.adapters.set, "function");
+      assertEquals(typeof defaultDiscoveryCache.adapters.clear, "function");
     });
 
-    it("exports localProjectCache with Map-like interface", () => {
-      assertEquals(typeof localProjectCache.get, "function");
-      assertEquals(typeof localProjectCache.set, "function");
-      assertEquals(typeof localProjectCache.clear, "function");
+    it("exports defaultDiscoveryCache.projects with Map-like interface", () => {
+      assertEquals(typeof defaultDiscoveryCache.projects.get, "function");
+      assertEquals(typeof defaultDiscoveryCache.projects.set, "function");
+      assertEquals(typeof defaultDiscoveryCache.projects.clear, "function");
     });
   });
 

--- a/src/server/runtime-handler/local-project-discovery.ts
+++ b/src/server/runtime-handler/local-project-discovery.ts
@@ -53,18 +53,6 @@ export const defaultDiscoveryCache = new ProjectDiscoveryCache();
 registerLRUCache("local-project-cache", defaultDiscoveryCache.projects);
 registerLRUCache("local-adapter-cache", defaultDiscoveryCache.adapters);
 
-/**
- * @deprecated Use `defaultDiscoveryCache.adapters` instead.
- * Kept for backward compatibility with existing consumers.
- */
-export const localAdapterCache = defaultDiscoveryCache.adapters;
-
-/**
- * @deprecated Use `defaultDiscoveryCache.projects` instead.
- * Kept for backward compatibility with existing consumers.
- */
-export const localProjectCache = defaultDiscoveryCache.projects;
-
 /** Standard directories to search for local projects */
 export const standardProjectDirs = ["data/projects", "projects"];
 

--- a/src/server/runtime-handler/projects-handler.ts
+++ b/src/server/runtime-handler/projects-handler.ts
@@ -11,7 +11,7 @@ import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { cwd } from "#veryfront/platform/compat/process.ts";
 import { serverLogger } from "#veryfront/utils";
 import type { HandlerContext } from "../handlers/types.ts";
-import { localProjectCache, standardProjectDirs } from "./local-project-discovery.ts";
+import { defaultDiscoveryCache, standardProjectDirs } from "./local-project-discovery.ts";
 import type { ParsedDomain } from "../utils/domain-parser.ts";
 
 const logger = serverLogger.component("projects-handler");
@@ -102,7 +102,7 @@ async function handleLocalProjectsDiscovery(): Promise<Response> {
           ]);
 
           if (hasApp || hasPages || hasComponents) {
-            localProjectCache.set(entry.name, projectPath);
+            defaultDiscoveryCache.projects.set(entry.name, projectPath);
           }
         } catch (error) {
           logger.warn("Failed to stat project directory entry", {
@@ -119,7 +119,9 @@ async function handleLocalProjectsDiscovery(): Promise<Response> {
     }
   }
 
-  const localProjects = Array.from(localProjectCache.entries()).map(([slug, path]) => ({
+  const localProjects = Array.from(defaultDiscoveryCache.projects.entries()).map((
+    [slug, path],
+  ) => ({
     id: slug,
     name: slug,
     slug,

--- a/src/server/services/rsc/endpoints/endpoint-router.ts
+++ b/src/server/services/rsc/endpoints/endpoint-router.ts
@@ -44,7 +44,11 @@ export async function handleRSCEndpoint(
   }
 
   // Always return 410 Gone for deprecated flight_page endpoint
-  // regardless of RSC being enabled
+  // regardless of RSC being enabled.
+  // NOTE: NOT dead. This branch is actively asserted by endpoint-router.test.ts
+  // and several integration tests (tests/integration/server/rsc/*, flight-smoke)
+  // that verify clients hitting /_veryfront/rsc/flight_page receive 410 Gone.
+  // Do not remove until those clients/tests stop exercising the endpoint.
   if (sub === "flight_page") {
     return new Response("Flight endpoint removed. Use custom RSC endpoints.", { status: 410 });
   }


### PR DESCRIPTION
## Description

Tech-debt cleanup (epic #1990).

- **#2002** — delete the two **non-public** `@deprecated` aliases (`localAdapterCache`, `localProjectCache`) in `local-project-discovery.ts` after migrating internal callers (`projects-handler.ts`, `runtime-handler/index.ts`) to `defaultDiscoveryCache.{projects,adapters}`. Identity-equivalent — the aliases were already `= defaultDiscoveryCache.*`.
- Documents that the RSC `flight_page` 410 branch is **live** (asserted by unit + integration tests), not dead — added a code note (investigation outcome for #2005).
- Migrates the deprecated `getAdapter()` README example to `runtime.get()` (doc part of #2010).

## Dropped from this PR
- **#1996** (consolidate 21 `@deprecated` chat aliases into `chat/compat.ts`) — **reverted**. The consolidation creates a circular import (`compat.ts` ↔ chat modules) that builds fine in raw Deno but **breaks template SSR under CI's bundler** (the `starter-templates-smoke` integration + rsc-browser-e2e failures on the first push, all templates → 500). Low value (relocating deprecated code) vs. real regression risk, so deferred — see #1996.

## Verification
- `deno lint` clean; remaining diff is behavior-neutral (#2002 identity-equivalent + a comment + a doc edit).
- `src/server/runtime-handler/` unit tests pass.

Closes #2002