### PR TITLE
fix: route ad-hoc errors through registry; bound proxy map; validate manifest

### DIFF
--- a/src/agent/hosted/veryfront-cloud-agent-service.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.ts
@@ -8,6 +8,7 @@ import { dirname, resolve } from "#veryfront/platform/compat/path/index.ts";
 import { cwd, env } from "#veryfront/platform/compat/process.ts";
 import type { AuthProvider } from "#veryfront/extensions/auth/index.ts";
 import type { SchemaValidator } from "#veryfront/extensions/schema/index.ts";
+import { defineSchema } from "#veryfront/schemas/index.ts";
 import {
   type NodeTelemetryProvider,
   NodeTelemetryProviderName,
@@ -277,7 +278,23 @@ function resolveProjectDir(
   return candidates.find(hasDiscoveryRoot) ?? baseDir;
 }
 
+/**
+ * Schema for the subset of a project manifest (package.json / deno.json) we
+ * read. Only `name` is consumed; extra fields are tolerated via passthrough so
+ * arbitrary manifests validate. Defined lazily via `defineSchema` so the zod
+ * extension is resolved at call time — the cloud-agent options resolver calls
+ * `ensureDefaultSchemaValidator()` before reaching service-name resolution, so
+ * a validator is registered by the time this runs.
+ */
+const getProjectManifestSchema = defineSchema((v) =>
+  v.object({
+    name: v.string().optional(),
+  }).passthrough()
+);
+
 function readProjectManifestName(projectDir: string): string | null {
+  const manifestSchema = getProjectManifestSchema();
+
   for (const fileName of ["package.json", "deno.json"]) {
     const filePath = resolve(projectDir, fileName);
     if (!existsSync(filePath)) {
@@ -285,9 +302,9 @@ function readProjectManifestName(projectDir: string): string | null {
     }
 
     try {
-      const parsed = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
-      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) continue;
-      const name = (parsed as { name?: unknown }).name;
+      const result = manifestSchema.safeParse(JSON.parse(readFileSync(filePath, "utf8")));
+      if (!result.success) continue;
+      const name = result.data.name;
       if (typeof name !== "string") continue;
       const trimmedName = name.trim();
       if (trimmedName) return trimmedName;

--- a/src/errors/error-registry.test.ts
+++ b/src/errors/error-registry.test.ts
@@ -27,9 +27,9 @@ describe("error-registry", () => {
       assertEquals(slugs.length, uniqueSlugs.size, "Duplicate slugs detected");
     });
 
-    it("should have 79 registered errors", () => {
+    it("should have 81 registered errors", () => {
       const slugs = getAllSlugs();
-      assertEquals(slugs.length, 79);
+      assertEquals(slugs.length, 81);
     });
   });
 
@@ -294,7 +294,7 @@ describe("error-registry", () => {
       RUNTIME: 7,
       ROUTE: 6,
       MODULE: 6,
-      SERVER: 13,
+      SERVER: 15,
       BOUNDARY: 6,
       DEV: 5,
       DEPLOY: 4,

--- a/src/errors/error-registry.ts
+++ b/src/errors/error-registry.ts
@@ -359,6 +359,22 @@ export const SERVICE_OVERLOADED = defineError({
   suggestion: "Reduce load or scale up resources",
 });
 
+export const SEMAPHORE_TIMEOUT = defineError({
+  slug: "semaphore-timeout",
+  category: "SERVER",
+  status: 503,
+  title: "Semaphore acquire timeout",
+  suggestion: "Reduce concurrency or increase the semaphore acquire timeout",
+});
+
+export const CIRCUIT_BREAKER_OPEN = defineError({
+  slug: "circuit-breaker-open",
+  category: "SERVER",
+  status: 503,
+  title: "Circuit breaker is open",
+  suggestion: "Wait for the breaker reset timeout before retrying",
+});
+
 export const CACHE_PATH_MISMATCH = defineError({
   slug: "cache-path-mismatch",
   category: "SERVER",

--- a/src/errors/error-registry.ts
+++ b/src/errors/error-registry.ts
@@ -766,6 +766,8 @@ export const ERROR_REGISTRY = {
   "file-watch-error": FILE_WATCH_ERROR,
   "request-error": REQUEST_ERROR,
   "service-overloaded": SERVICE_OVERLOADED,
+  "semaphore-timeout": SEMAPHORE_TIMEOUT,
+  "circuit-breaker-open": CIRCUIT_BREAKER_OPEN,
   "cache-path-mismatch": CACHE_PATH_MISMATCH,
   "network-error": NETWORK_ERROR,
   "api-client-error": API_CLIENT_ERROR,

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -340,11 +340,17 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     const mapped = localProjects[slug];
     if (mapped) return mapped;
 
-    const cached = discoveredLocalProjects.get(slug);
-    if (cached) return cached;
-
     const projectDirs = ["projects", "data/projects", "examples"];
     const basePath = cwd();
+    // Key the discovery cache by the filesystem root as well as the slug: the
+    // cache is process-wide, so the same slug can resolve to different paths
+    // across handlers/workspaces or after a cwd change. Keying by basePath
+    // prevents a stale entry from one root being proxied for another.
+    const cacheKey = `${basePath} ${slug}`;
+
+    const cached = discoveredLocalProjects.get(cacheKey);
+    if (cached) return cached;
+
     const candidatePaths = projectDirs.map((dir) => join(basePath, dir, slug));
 
     const existingPaths = await Promise.all(
@@ -370,7 +376,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
         if (!hasApp && !hasPages && !hasComponents) continue;
 
-        discoveredLocalProjects.set(slug, projectPath);
+        discoveredLocalProjects.set(cacheKey, projectPath);
         logger?.debug("Dynamically discovered local project", { slug, projectPath });
         return projectPath;
       } catch (_) {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -8,6 +8,19 @@ import { injectContext, ProxySpanNames, withSpan } from "./tracing.ts";
 import { computeContentSourceId } from "#veryfront/cache/keys.ts";
 import { resolve as resolveContract } from "../extensions/contracts.ts";
 import type { AuthProvider } from "../extensions/auth/index.ts";
+import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
+import { registerLRUCache } from "#veryfront/cache";
+
+/**
+ * Bounded cache for project paths discovered dynamically at request time
+ * (slug → absolute path). Previously these were written into the per-handler
+ * `localProjects` config map, which grew without bound. Using a registered
+ * LRU keeps the working set capped and exposes it to cache monitoring, while
+ * the static `config.localProjects` map continues to reflect *configured*
+ * projects for the public `ProxyHandler.localProjects` surface.
+ */
+const discoveredLocalProjects = new LRUCache<string, string>({ maxEntries: 100 });
+registerLRUCache("proxy-discovered-local-projects", discoveredLocalProjects);
 
 /**
  * Cache the resolved AuthProvider at module scope so the proxy does not pay
@@ -327,6 +340,9 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     const mapped = localProjects[slug];
     if (mapped) return mapped;
 
+    const cached = discoveredLocalProjects.get(slug);
+    if (cached) return cached;
+
     const projectDirs = ["projects", "data/projects", "examples"];
     const basePath = cwd();
     const candidatePaths = projectDirs.map((dir) => join(basePath, dir, slug));
@@ -354,7 +370,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
         if (!hasApp && !hasPages && !hasComponents) continue;
 
-        localProjects[slug] = projectPath;
+        discoveredLocalProjects.set(slug, projectPath);
         logger?.debug("Dynamically discovered local project", { slug, projectPath });
         return projectPath;
       } catch (_) {

--- a/src/utils/circuit-breaker.ts
+++ b/src/utils/circuit-breaker.ts
@@ -8,6 +8,8 @@
  */
 
 import { logger as baseLogger } from "#veryfront/utils";
+import { CIRCUIT_BREAKER_OPEN } from "#veryfront/errors/error-registry.ts";
+import { VeryfrontError } from "#veryfront/errors/types.ts";
 
 const logger = baseLogger.component("circuit-breaker");
 
@@ -36,7 +38,14 @@ interface CircuitBreakerOptions {
   name?: string;
 }
 
-export class CircuitBreakerOpen extends Error {
+/**
+ * Thrown when an operation is attempted while the circuit breaker is open.
+ *
+ * Extends {@link VeryfrontError} so it carries registry slug/status/category
+ * and RFC-9457 fields, while remaining `instanceof CircuitBreakerOpen` for
+ * existing catch sites.
+ */
+export class CircuitBreakerOpen extends VeryfrontError {
   readonly breakerName: string;
   readonly nextAttemptMs: number;
 
@@ -44,7 +53,14 @@ export class CircuitBreakerOpen extends Error {
     breakerName: string,
     nextAttemptMs: number,
   ) {
-    super(`Circuit breaker '${breakerName}' is open. Retry after ${nextAttemptMs}ms`);
+    super(`Circuit breaker '${breakerName}' is open. Retry after ${nextAttemptMs}ms`, {
+      slug: CIRCUIT_BREAKER_OPEN.slug,
+      category: CIRCUIT_BREAKER_OPEN.category,
+      status: CIRCUIT_BREAKER_OPEN.status,
+      title: CIRCUIT_BREAKER_OPEN.title,
+      suggestion: CIRCUIT_BREAKER_OPEN.suggestion,
+      context: { breakerName, nextAttemptMs },
+    });
     this.name = "CircuitBreakerOpen";
     this.breakerName = breakerName;
     this.nextAttemptMs = nextAttemptMs;

--- a/src/utils/semaphore.ts
+++ b/src/utils/semaphore.ts
@@ -6,9 +6,26 @@
  * @module utils/semaphore
  */
 
-export class SemaphoreTimeoutError extends Error {
+import { SEMAPHORE_TIMEOUT } from "#veryfront/errors/error-registry.ts";
+import { VeryfrontError } from "#veryfront/errors/types.ts";
+
+/**
+ * Thrown when a semaphore acquire exceeds its configured timeout.
+ *
+ * Extends {@link VeryfrontError} so it carries registry slug/status/category
+ * and RFC-9457 fields, while remaining `instanceof SemaphoreTimeoutError` for
+ * existing catch sites.
+ */
+export class SemaphoreTimeoutError extends VeryfrontError {
   constructor(name: string, timeoutMs: number) {
-    super(`Semaphore '${name}' acquire timeout after ${timeoutMs}ms`);
+    super(`Semaphore '${name}' acquire timeout after ${timeoutMs}ms`, {
+      slug: SEMAPHORE_TIMEOUT.slug,
+      category: SEMAPHORE_TIMEOUT.category,
+      status: SEMAPHORE_TIMEOUT.status,
+      title: SEMAPHORE_TIMEOUT.title,
+      suggestion: SEMAPHORE_TIMEOUT.suggestion,
+      context: { name, timeoutMs },
+    });
     this.name = "SemaphoreTimeoutError";
   }
 }


### PR DESCRIPTION
## Description

Tech-debt quick-win batch (epic #1990) — error-registry consistency, a bounded map, and schema validation. No behavior change; `instanceof`/public APIs preserved.

- **#2026** `SemaphoreTimeoutError` (`utils/semaphore.ts`) and `CircuitBreakerOpen` (`utils/circuit-breaker.ts`) now `extend VeryfrontError` with registry definitions (`SEMAPHORE_TIMEOUT`, `CIRCUIT_BREAKER_OPEN`; SERVER/503, slugs, RFC-9457). Chosen over the "replace every `instanceof`" migration so existing catch sites (`data/*`, `cache/backends/api.ts`, tests) keep working unchanged while gaining slug/status/`toRFC9457()`.
- **#2003** `proxy/handler.ts` — dynamically-discovered local projects now go through a **registered LRU** (`registerLRUCache`, cap 100), same mechanism as `defaultDiscoveryCache`, instead of an unbounded object. The configured-projects surface (`ProxyHandler.localProjects`, read in `main.ts`) is intentionally unchanged.
- **#1994** `agent/hosted/veryfront-cloud-agent-service.ts` — validate the project manifest via a `defineSchema` `.safeParse()` instead of `JSON.parse(...) as unknown` (validator is registered before this runs).

## Verification
- `deno lint` clean (5 files); `deno task typecheck` — no new errors.
- Error-class/registry tests (`semaphore`, `circuit-breaker`, `parallel`, `api-search-circuit-breaker`, `error-registry`) + `veryfront-cloud-agent-service` manifest tests pass.
- Pre-existing proxy `handler.test.ts` sandbox failures reproduce identically on the unmodified code (auth/network-dependent) — unrelated to this change.

Closes #2026, Closes #2003, Closes #1994

## Type of Change
- [x] Bug fix / refactoring