### PR TITLE
Allow chat composer Enter to submit multiline input

### DIFF
--- a/src/react/components/chat/chat/composition/chat-composer.test.tsx
+++ b/src/react/components/chat/chat/composition/chat-composer.test.tsx
@@ -15,6 +15,7 @@ function installDomGlobals(dom: JSDOM): () => void {
     Node: globalThis.Node,
     Element: globalThis.Element,
     HTMLElement: globalThis.HTMLElement,
+    KeyboardEvent: globalThis.KeyboardEvent,
     MouseEvent: globalThis.MouseEvent,
   };
 
@@ -26,6 +27,7 @@ function installDomGlobals(dom: JSDOM): () => void {
     Node: window.Node,
     Element: window.Element,
     HTMLElement: window.HTMLElement,
+    KeyboardEvent: window.KeyboardEvent,
     MouseEvent: window.MouseEvent,
   });
 
@@ -91,6 +93,70 @@ describe("react/components/chat/chat/composition/chat-composer", () => {
       });
 
       assertEquals(selectCalls, 1);
+      root.unmount();
+    } finally {
+      restore();
+    }
+  });
+
+  it("submits multiline input on Enter and keeps Shift+Enter for newlines", () => {
+    const dom = new JSDOM(
+      '<!doctype html><html><body><div id="root"></div></body></html>',
+      { url: "https://example.com/" },
+    );
+    const restore = installDomGlobals(dom);
+    let submitCalls = 0;
+
+    try {
+      const rootElement = document.getElementById("root");
+      assert(rootElement, "Expected root element to exist");
+
+      const root = createRoot(rootElement);
+      flushSync(() => {
+        root.render(
+          <ChatComposer
+            input="Review Article 30"
+            onChange={() => {}}
+            onSubmit={() => {
+              submitCalls += 1;
+            }}
+          />,
+        );
+      });
+
+      const textarea = document.querySelector("textarea");
+      assert(textarea, "Expected multiline composer input to render");
+      const reactPropsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps$"));
+      assert(reactPropsKey, "Expected React props to be attached");
+      const reactProps = (textarea as unknown as Record<string, unknown>)[
+        reactPropsKey
+      ] as {
+        onKeyDown?: (
+          event: { key: string; shiftKey?: boolean; preventDefault: () => void },
+        ) => void;
+      };
+      assert(reactProps.onKeyDown, "Expected input keydown handler to exist");
+      let preventDefaultCalls = 0;
+
+      reactProps.onKeyDown({
+        key: "Enter",
+        shiftKey: true,
+        preventDefault: () => {
+          preventDefaultCalls += 1;
+        },
+      });
+      assertEquals(submitCalls, 0);
+      assertEquals(preventDefaultCalls, 0);
+
+      reactProps.onKeyDown({
+        key: "Enter",
+        preventDefault: () => {
+          preventDefaultCalls += 1;
+        },
+      });
+
+      assertEquals(submitCalls, 1);
+      assertEquals(preventDefaultCalls, 1);
       root.unmount();
     } finally {
       restore();

--- a/src/react/components/chat/chat/composition/chat-composer.tsx
+++ b/src/react/components/chat/chat/composition/chat-composer.tsx
@@ -19,7 +19,7 @@ import type { ChatMessage } from "#veryfront/agent/react";
 export interface ChatComposerProps {
   input: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
-  onSubmit?: (e: React.FormEvent) => void;
+  onSubmit?: (e?: React.FormEvent) => void;
   isLoading?: boolean;
   placeholder?: string;
   theme?: ChatTheme;
@@ -195,6 +195,7 @@ export const ChatComposer = React.forwardRef<HTMLDivElement, ChatComposerProps>(
                 <InputBox
                   value={isListening ? transcript || input : input}
                   onChange={onChange}
+                  onSubmit={() => onSubmit?.()}
                   placeholder={isListening ? "Listening..." : placeholder}
                   disabled={isLoading || isListening}
                   multiline


### PR DESCRIPTION
## Summary
- Forward ChatComposer submit handling into the multiline InputBox
- Preserve Shift+Enter for newlines while plain Enter submits
- Add regression coverage for the reusable chat composer

## Verification
- deno test --no-check --allow-all src/react/components/chat/chat/composition/chat-composer.test.tsx
- deno check src/react/components/chat/chat/composition/chat-composer.tsx src/react/components/chat/chat/composition/chat-composer.test.tsx
- git diff --check
- Pre-push hook: format, type check, unit tests (1950 passed, 0 failed)