### PR TITLE
Bump stable release version

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.631",
+  "version": "0.1.632",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.631";
+export const VERSION = "0.1.632";


### PR DESCRIPTION
## Summary
- bump the stable release version from 0.1.631 to 0.1.632
- keep deno.json and src/utils/version-constant.ts in sync

## Verification
- deno fmt --check deno.json src/utils/version-constant.ts
- deno check src/utils/version-constant.ts
- git diff --check
- npm view veryfront@0.1.632 version returned unpublished
- git ls-remote found no v0.1.632 tag
- pre-push hook passed: format, lint, typecheck, unit tests (1950 passed)
- GitHub PR checks passed: format, lint, typecheck, unit, integration, rsc browser e2e, binary e2e, coverage gate, CodeQL, dependency audit, CLA