### PR TITLE
refactor(cache): invert distributed-cache-init layering via injected initializers (#1987)

### DIFF
--- a/cli/commands/serve/command.ts
+++ b/cli/commands/serve/command.ts
@@ -59,9 +59,12 @@ async function runProductionServer(options: ServeOptions): Promise<void> {
   const { initializeDistributedCaches } = await import(
     "veryfront/cache"
   );
+  const { defaultDistributedCacheInitializers } = await import(
+    "veryfront/server"
+  );
   await Promise.allSettled([
     initializeOTLPWithApis(),
-    initializeDistributedCaches(),
+    initializeDistributedCaches(defaultDistributedCacheInitializers),
   ]);
 
   const projectDir = cwd();

--- a/src/cache/distributed-cache-init.test.ts
+++ b/src/cache/distributed-cache-init.test.ts
@@ -2,6 +2,27 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#std/assert";
 import { __runDistributedCacheInitializationForTests } from "./distributed-cache-init.ts";
 
+Deno.test("distributed-cache-init does not import higher layers (rendering/transform/platform)", async () => {
+  // Layering guard (#1987): src/cache is a low-level layer and must not reach
+  // up into html / transforms / modules / platform. The concrete initializers
+  // are injected from the server composition root instead. If this fails, a
+  // cross-layer import was re-introduced into distributed-cache-init.ts.
+  const source = await Deno.readTextFile(new URL("./distributed-cache-init.ts", import.meta.url));
+  const forbidden = [
+    "#veryfront/html/",
+    "#veryfront/transforms/",
+    "#veryfront/modules/",
+    "#veryfront/platform/",
+  ];
+  for (const specifier of forbidden) {
+    assertEquals(
+      source.includes(specifier),
+      false,
+      `distributed-cache-init.ts must not import ${specifier} (inject initializers from the server layer instead)`,
+    );
+  }
+});
+
 Deno.test("distributed cache init includes httpModule cache status", async () => {
   const status = await __runDistributedCacheInitializationForTests("api", {
     transformCache: async () => true,

--- a/src/cache/distributed-cache-init.ts
+++ b/src/cache/distributed-cache-init.ts
@@ -1,10 +1,5 @@
-import { initializeFileCacheBackend } from "#veryfront/platform/adapters/fs/cache/file-cache.ts";
-import { initializeSSRDistributedCache } from "#veryfront/modules/react-loader/ssr-module-loader/index.ts";
-import { initializeTransformCache } from "#veryfront/transforms/esm/transform-cache.ts";
-import { initializeHttpModuleDistributedCache } from "#veryfront/transforms/esm/http-cache-wrapper.ts";
 import { SpanNames } from "#veryfront/observability/tracing/span-names.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
-import { initializeProjectCSSCache } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
 import { logger as baseLogger } from "#veryfront/utils/logger/logger.ts";
 import { isRedisConfigured } from "#veryfront/utils/redis-client.ts";
 import { isApiCacheAvailable, isDiskCacheConfigured } from "./backend.ts";
@@ -20,20 +15,21 @@ interface DistributedCacheStatus {
   httpModuleCache: boolean;
 }
 
-type DistributedCacheInitializers = {
+/**
+ * Per-cache initialization functions, injected by the composition root.
+ *
+ * The concrete initializers live in higher layers (`transforms`, `modules`,
+ * `html`, `platform`). They are passed in rather than imported here so that
+ * `src/cache` stays a low-level layer that does not depend on the rendering /
+ * transform / platform layers it would otherwise have to reach up into. See
+ * `src/server/distributed-cache-initializers.ts` for the default wiring.
+ */
+export type DistributedCacheInitializers = {
   transformCache: () => Promise<boolean>;
   ssrModuleCache: () => Promise<boolean>;
   fileCache: () => Promise<boolean>;
   projectCSSCache: () => Promise<boolean>;
   httpModuleCache: () => Promise<boolean>;
-};
-
-const defaultInitializers: DistributedCacheInitializers = {
-  transformCache: initializeTransformCache,
-  ssrModuleCache: initializeSSRDistributedCache,
-  fileCache: initializeFileCacheBackend,
-  projectCSSCache: initializeProjectCSSCache,
-  httpModuleCache: initializeHttpModuleDistributedCache,
 };
 
 function determineBackend(): DistributedCacheStatus["backend"] {
@@ -122,7 +118,9 @@ export function __runDistributedCacheInitializationForTests(
   return initializeDistributedCachesWithInitializers(backend, initializers);
 }
 
-export function initializeDistributedCaches(): Promise<DistributedCacheStatus> {
+export function initializeDistributedCaches(
+  initializers: DistributedCacheInitializers,
+): Promise<DistributedCacheStatus> {
   const backend = determineBackend();
 
   if (backend === "memory") {
@@ -138,7 +136,7 @@ export function initializeDistributedCaches(): Promise<DistributedCacheStatus> {
 
   return withSpan(
     SpanNames.CACHE_DISTRIBUTED_INIT,
-    () => initializeDistributedCachesWithInitializers(backend, defaultInitializers),
+    () => initializeDistributedCachesWithInitializers(backend, initializers),
     { "cache.backend": backend },
   );
 }

--- a/src/server/dev-server/server.ts
+++ b/src/server/dev-server/server.ts
@@ -24,6 +24,7 @@ import {
 } from "#veryfront/rendering/ssr-globals.ts";
 import { setEnv } from "#veryfront/platform/compat/process.ts";
 import { initializeDistributedCaches } from "#veryfront/cache/distributed-cache-init.ts";
+import { defaultDistributedCacheInitializers } from "#veryfront/server/distributed-cache-initializers.ts";
 import { isDiskCacheConfigured } from "#veryfront/cache/backend.ts";
 import { clearTranspileCache, discoverAll } from "#veryfront/discovery";
 import type { DiscoveryConfig } from "#veryfront/discovery";
@@ -139,9 +140,11 @@ export class DevServer {
 
     // Initialize disk cache in dev mode when explicitly configured
     if (isDiskCacheConfigured()) {
-      void initializeDistributedCaches().catch((error: unknown) => {
-        logger.debug("[DevServer] Cache initialization failed, using memory fallback", { error });
-      });
+      void initializeDistributedCaches(defaultDistributedCacheInitializers).catch(
+        (error: unknown) => {
+          logger.debug("[DevServer] Cache initialization failed, using memory fallback", { error });
+        },
+      );
     }
 
     // Auto-discover runtime primitives (tools, agents, workflows, prompts, resources)

--- a/src/server/distributed-cache-initializers.ts
+++ b/src/server/distributed-cache-initializers.ts
@@ -1,0 +1,24 @@
+import type { DistributedCacheInitializers } from "#veryfront/cache/distributed-cache-init.ts";
+import { initializeFileCacheBackend } from "#veryfront/platform/adapters/fs/cache/file-cache.ts";
+import { initializeSSRDistributedCache } from "#veryfront/modules/react-loader/ssr-module-loader/index.ts";
+import { initializeTransformCache } from "#veryfront/transforms/esm/transform-cache.ts";
+import { initializeHttpModuleDistributedCache } from "#veryfront/transforms/esm/http-cache-wrapper.ts";
+import { initializeProjectCSSCache } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
+
+/**
+ * Default wiring of distributed-cache initializers, assembled at the server
+ * composition root.
+ *
+ * The concrete initializers live in the `transforms`, `modules`, `html`, and
+ * `platform` layers. Keeping this wiring in `src/server` (which is free to
+ * depend on every layer) lets `src/cache/distributed-cache-init.ts` remain a
+ * low-level orchestrator that takes its initializers as an injected dependency
+ * instead of reaching up into those layers itself.
+ */
+export const defaultDistributedCacheInitializers: DistributedCacheInitializers = {
+  transformCache: initializeTransformCache,
+  ssrModuleCache: initializeSSRDistributedCache,
+  fileCache: initializeFileCacheBackend,
+  projectCSSCache: initializeProjectCSSCache,
+  httpModuleCache: initializeHttpModuleDistributedCache,
+};

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -74,6 +74,7 @@ export type {
 import { ReloadNotifier } from "./reload-notifier.ts";
 export { ReloadNotifier };
 export type { BuildOptions, BuildStats } from "./build-types.ts";
+export { defaultDistributedCacheInitializers } from "./distributed-cache-initializers.ts";
 
 /** Shared options for both development and production server modes. */
 interface BaseServerOptions {

--- a/src/server/production-server.ts
+++ b/src/server/production-server.ts
@@ -16,6 +16,7 @@ import {
   stopMemoryMonitoring,
 } from "#veryfront/utils/memory/index.ts";
 import { initializeDistributedCaches } from "#veryfront/cache/distributed-cache-init.ts";
+import { defaultDistributedCacheInitializers } from "#veryfront/server/distributed-cache-initializers.ts";
 import { getConfig } from "#veryfront/config";
 import { resolveStyleContentVersion } from "#veryfront/html/styles-builder/content-version.ts";
 import {
@@ -350,7 +351,7 @@ if (import.meta.main) {
     // Backend: API (production) > Redis (local dev) > Memory (fallback)
     const [otlpResult, cacheResult] = await Promise.allSettled([
       initializeOTLPWithApis(),
-      initializeDistributedCaches(),
+      initializeDistributedCaches(defaultDistributedCacheInitializers),
     ]);
 
     if (otlpResult.status === "rejected") {


### PR DESCRIPTION
## What

Fixes the layering inversion flagged in epic **#1987** (Report 05): `src/cache/distributed-cache-init.ts` reached up into the rendering / transform / modules / platform layers to build its `defaultInitializers` — most notably a static import of `#veryfront/html/styles-builder/tailwind-compiler.ts`. `src/cache` is meant to be a low-level layer.

## How

The module already had `DistributedCacheInitializers` dependency-injection scaffolding (the test-only entrypoint used it). This change makes the production path use it too:

- `initializeDistributedCaches(initializers)` now takes the initializers as an **injected argument**. `distributed-cache-init.ts` no longer imports `html` / `transforms` / `modules` / `platform` at all — only `observability`, `utils`, and its sibling `backend.ts`.
- The default wiring moves up to a new **`src/server/distributed-cache-initializers.ts`** (the composition root, which is free to depend on every layer).
- Both callers — `production-server.ts` and `dev-server/server.ts` — pass `defaultDistributedCacheInitializers`.

Net effect: the `src/cache → src/html` (and `→ transforms`/`modules`/`platform`) edges are gone; the dependency now points the correct way (`server → cache`, `server → html`).

## Why this is low-risk

- **Behavior is identical** — the same five initializers run in the same order via the same `Promise.allSettled` path. Only *where the functions are wired* changed.
- The lint `dependency-boundaries` already passed before/after (this edge wasn't lint-enforced); this is an architectural cleanup, not a build-breaking fix.

## Tests

- Added a **source-level regression test** in `distributed-cache-init.test.ts` asserting the file imports none of `#veryfront/{html,transforms,modules,platform}/…`, so the inversion can't silently regress.
- `deno test src/cache/distributed-cache-init.test.ts` → 3 passed.
- `deno lint`, `deno fmt --check`, `deno task lint:dependency-boundaries` → clean. Typecheck of the changed files surfaces only the 3 pre-existing `react`/`platform/compat/process/lifecycle.ts` errors present on `main`.

Refs #1987. Draft pending `/deep-review`.