### PR TITLE
feat(oauth): bound MemoryTokenStore + warn on production use (#1989)

### DIFF
--- a/docs/api-reference/veryfront/oauth.md
+++ b/docs/api-reference/veryfront/oauth.md
@@ -45,7 +45,7 @@ export const GET = createOAuthCallbackHandler(gmailConfig);
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `MemoryTokenStore` | In-memory TokenStore keyed by `(serviceId, userId)`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/token-store/memory.ts#L12) |
+| `MemoryTokenStore` | In-memory TokenStore keyed by `(serviceId, userId)`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/token-store/memory.ts#L42) |
 | `OAuthProvider` | Implement oauth provider. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/base.ts#L46) |
 | `OAuthService` | Implement oauth service. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/base.ts#L314) |
 
@@ -54,6 +54,7 @@ export const GET = createOAuthCallbackHandler(gmailConfig);
 | Name | Description | Source |
 |------|-------------|--------|
 | `AuthorizationUrlOptions` | Options accepted by authorization URL. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/schemas/oauth.schema.ts#L99) |
+| `MemoryTokenStoreOptions` | Options for {@link MemoryTokenStore}. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/token-store/memory.ts#L20) |
 | `OAuthCallbackHandlerOptions` | Options accepted by oauth callback handler. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/handlers/callback-handler.ts#L13) |
 | `OAuthInitHandlerOptions` | Options accepted by oauth init handler. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/handlers/init-handler.ts#L75) |
 | `OAuthProviderConfig` | Configuration used by oauth provider. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/schemas/oauth.schema.ts#L89) |

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -72,6 +72,7 @@ export {
 } from "./providers/index.ts";
 
 export { MemoryTokenStore } from "./token-store/index.ts";
+export type { MemoryTokenStoreOptions } from "./token-store/index.ts";
 
 export {
   createOAuthCallbackHandler,

--- a/src/oauth/token-store/index.ts
+++ b/src/oauth/token-store/index.ts
@@ -5,4 +5,5 @@
  */
 
 export { MemoryTokenStore, memoryTokenStore } from "./memory.ts";
+export type { MemoryTokenStoreOptions } from "./memory.ts";
 export type { OAuthState, OAuthTokens, StoredOAuthState, TokenStore } from "../types.ts";

--- a/src/oauth/token-store/memory.test.ts
+++ b/src/oauth/token-store/memory.test.ts
@@ -1,0 +1,121 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#std/assert";
+import { MemoryTokenStore } from "./memory.ts";
+import type { OAuthTokens, StoredOAuthState } from "../types.ts";
+
+function tokens(accessToken: string, extra: Partial<OAuthTokens> = {}): OAuthTokens {
+  return { accessToken, ...extra };
+}
+
+Deno.test("MemoryTokenStore stores and retrieves tokens per (serviceId, userId)", async () => {
+  const store = new MemoryTokenStore();
+  await store.setTokens("svc", "alice", tokens("a-token"));
+  await store.setTokens("svc", "bob", tokens("b-token"));
+
+  assertEquals((await store.getTokens("svc", "alice"))?.accessToken, "a-token");
+  assertEquals((await store.getTokens("svc", "bob"))?.accessToken, "b-token");
+  assertEquals(await store.getTokens("svc", "carol"), null);
+});
+
+Deno.test("MemoryTokenStore clears a single user's tokens", async () => {
+  const store = new MemoryTokenStore();
+  await store.setTokens("svc", "alice", tokens("a-token"));
+  await store.clearTokens("svc", "alice");
+  assertEquals(await store.getTokens("svc", "alice"), null);
+});
+
+Deno.test("MemoryTokenStore isConnected: fresh, expired-without-refresh, expired-with-refresh", async () => {
+  const store = new MemoryTokenStore();
+  await store.setTokens("svc", "fresh", tokens("t", { expiresAt: Date.now() + 60_000 }));
+  await store.setTokens("svc", "stale", tokens("t", { expiresAt: Date.now() - 1 }));
+  await store.setTokens(
+    "svc",
+    "refreshable",
+    tokens("t", { expiresAt: Date.now() - 1, refreshToken: "r" }),
+  );
+
+  assertEquals(store.isConnected("svc", "fresh"), true);
+  assertEquals(store.isConnected("svc", "stale"), false);
+  assertEquals(store.isConnected("svc", "refreshable"), true);
+  assertEquals(store.isConnected("svc", "unknown"), false);
+});
+
+Deno.test("MemoryTokenStore consumeState is one-shot and rejects expired/unknown", async () => {
+  const store = new MemoryTokenStore();
+  const meta: StoredOAuthState = { userId: "alice", serviceId: "svc", createdAt: Date.now() };
+  await store.setState("state-1", meta);
+
+  assertEquals((await store.consumeState("state-1"))?.userId, "alice");
+  // One-shot: second read returns null.
+  assertEquals(await store.consumeState("state-1"), null);
+  assertEquals(await store.consumeState("never-set"), null);
+
+  // Expired state (createdAt older than the 10-minute window) is rejected.
+  await store.setState("old", {
+    userId: "x",
+    serviceId: "svc",
+    createdAt: Date.now() - 11 * 60_000,
+  });
+  assertEquals(await store.consumeState("old"), null);
+});
+
+Deno.test("MemoryTokenStore scopes keys by projectId", async () => {
+  const a = new MemoryTokenStore("project-a");
+  const b = new MemoryTokenStore("project-b");
+  await a.setTokens("svc", "alice", tokens("a-token"));
+  // A different store instance for a different project never sees it.
+  assertEquals(await b.getTokens("svc", "alice"), null);
+  assertEquals(a.getConnectedServices(), ["svc:alice"]);
+});
+
+Deno.test("MemoryTokenStore bounds the token map via LRU eviction (#1989)", async () => {
+  const store = new MemoryTokenStore("default", { maxEntries: 3 });
+
+  for (const user of ["u1", "u2", "u3"]) {
+    await store.setTokens("svc", user, tokens(`${user}-token`));
+  }
+  // Touch u1 so it becomes most-recently-used; u2 is now the LRU slot.
+  await store.getTokens("svc", "u1");
+
+  // Inserting a 4th slot evicts the least-recently-used (u2), not u1.
+  await store.setTokens("svc", "u4", tokens("u4-token"));
+
+  assertEquals(await store.getTokens("svc", "u2"), null);
+  assertEquals((await store.getTokens("svc", "u1"))?.accessToken, "u1-token");
+  assertEquals((await store.getTokens("svc", "u4"))?.accessToken, "u4-token");
+  // Never exceeds the cap.
+  assertEquals(store.getConnectedServices().length, 3);
+});
+
+Deno.test("MemoryTokenStore clearAll empties tokens and states", async () => {
+  const store = new MemoryTokenStore();
+  await store.setTokens("svc", "alice", tokens("a-token"));
+  await store.setState("s", { userId: "alice", serviceId: "svc", createdAt: Date.now() });
+  store.clearAll();
+  assertEquals(await store.getTokens("svc", "alice"), null);
+  assertEquals(await store.consumeState("s"), null);
+  assertEquals(store.getConnectedServices().length, 0);
+});
+
+Deno.test("MemoryTokenStore warns once when persisting tokens in production (#1989)", async () => {
+  const prevNodeEnv = Deno.env.get("NODE_ENV");
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(" "));
+  };
+  try {
+    Deno.env.set("NODE_ENV", "production");
+    const store = new MemoryTokenStore();
+    await store.setTokens("svc", "alice", tokens("a-token"));
+    await store.setTokens("svc", "bob", tokens("b-token"));
+
+    const matched = warnings.filter((w) => w.includes("MemoryTokenStore"));
+    // Warned exactly once despite two writes.
+    assertEquals(matched.length, 1);
+  } finally {
+    console.warn = originalWarn;
+    if (prevNodeEnv === undefined) Deno.env.delete("NODE_ENV");
+    else Deno.env.set("NODE_ENV", prevNodeEnv);
+  }
+});

--- a/src/oauth/token-store/memory.ts
+++ b/src/oauth/token-store/memory.ts
@@ -1,33 +1,86 @@
+import { logger as baseLogger } from "#veryfront/utils";
+import { isProduction } from "#veryfront/platform/environment.ts";
+import { LRUCacheAdapter } from "#veryfront/utils/cache/stores/memory/lru-cache-adapter.ts";
 import type { OAuthTokens, StoredOAuthState, TokenStore } from "../types.ts";
+
+const logger = baseLogger.component("o-auth");
 
 /** State expiry window: reject any state older than this (10 minutes). */
 const STATE_EXPIRY_MS = 10 * 60 * 1_000;
 
 /**
+ * Default cap on stored token slots. Bounds memory in long-lived processes;
+ * past this, the least-recently-used `(serviceId, userId)` slot is evicted
+ * (the affected user simply re-authenticates). Tokens are NOT given a TTL —
+ * an expired access token may still be refreshable via its refresh token, so
+ * eviction is by capacity/recency only.
+ */
+const DEFAULT_MAX_TOKEN_ENTRIES = 10_000;
+
+/** Options for {@link MemoryTokenStore}. */
+export interface MemoryTokenStoreOptions {
+  /**
+   * Maximum number of `(serviceId, userId)` token slots to retain before
+   * least-recently-used eviction kicks in. Defaults to
+   * {@link DEFAULT_MAX_TOKEN_ENTRIES}.
+   */
+  maxEntries?: number;
+}
+
+/**
  * In-memory TokenStore keyed by `(serviceId, userId)`.
  *
- * Suitable for development and tests. For production use a persistent store
- * (Redis, Postgres, ...) keyed the same way. Never share a single slot per
- * service across users — see VULN-AUTH-2.
+ * Suitable for development and tests ONLY. It is process-local and not
+ * durable: tokens are lost on restart and not shared across instances or
+ * workers, and the exported {@link memoryTokenStore} singleton shares one
+ * keyspace process-wide. For production inject a persistent, scoped store
+ * (Redis, Postgres, ...) keyed the same way.
+ *
+ * The token map is bounded (see {@link MemoryTokenStoreOptions.maxEntries}) so
+ * it cannot grow without limit. Never share a single slot per service across
+ * users — see VULN-AUTH-2.
  */
 export class MemoryTokenStore implements TokenStore {
-  private tokens = new Map<string, OAuthTokens>();
+  private tokens: LRUCacheAdapter;
   private states = new Map<string, StoredOAuthState>();
   private projectId: string;
+  private warnedProductionUse = false;
 
-  constructor(projectId = "default") {
+  constructor(projectId = "default", options: MemoryTokenStoreOptions = {}) {
     this.projectId = projectId;
+    this.tokens = new LRUCacheAdapter({
+      maxEntries: options.maxEntries ?? DEFAULT_MAX_TOKEN_ENTRIES,
+    });
   }
 
   private scopedKey(serviceId: string, userId: string): string {
     return `${this.projectId}:${serviceId}:${userId}`;
   }
 
+  /**
+   * Warn once if this non-durable store is used to persist tokens in
+   * production — almost always a misconfiguration (a persistent TokenStore
+   * should have been injected).
+   */
+  private warnIfProductionUse(): void {
+    if (this.warnedProductionUse || !isProduction()) return;
+    this.warnedProductionUse = true;
+    logger.warn(
+      "MemoryTokenStore is persisting OAuth tokens in production. It is " +
+        "process-local and not durable (tokens are lost on restart and not " +
+        "shared across instances). Inject a persistent, scoped TokenStore " +
+        "(Redis/Postgres/...) instead.",
+    );
+  }
+
   getTokens(serviceId: string, userId: string): Promise<OAuthTokens | null> {
-    return Promise.resolve(this.tokens.get(this.scopedKey(serviceId, userId)) ?? null);
+    return Promise.resolve(
+      this.tokens.get<OAuthTokens>(this.scopedKey(serviceId, userId)) ?? null,
+    );
   }
 
   setTokens(serviceId: string, userId: string, tokens: OAuthTokens): Promise<void> {
+    this.warnIfProductionUse();
     this.tokens.set(this.scopedKey(serviceId, userId), tokens);
     return Promise.resolve();
   }
@@ -76,7 +129,7 @@ export class MemoryTokenStore implements TokenStore {
 
   /** Whether a given user has usable tokens for a service. */
   isConnected(serviceId: string, userId: string): boolean {
-    const tokens = this.tokens.get(this.scopedKey(serviceId, userId));
+    const tokens = this.tokens.get<OAuthTokens>(this.scopedKey(serviceId, userId));
     if (!tokens) return false;
 
     const isExpired = tokens.expiresAt != null && Date.now() > tokens.expiresAt;


### PR DESCRIPTION
## What

Hardens the in-memory OAuth `TokenStore`, closing the `#1989` finding that its `tokens` map was **unbounded** (only explicit overwrite/clear — no eviction), so a long-lived process could grow it without limit. The exported `memoryTokenStore` singleton is also process-shared under the `"default"` projectId.

## How

- **Bound the token map** by backing it with the existing, tested `LRUCacheAdapter` (`maxEntries` cap, default 10k, configurable via a new constructor options arg). Eviction is **recency-only** — no TTL is applied, because an expired access token may still be refreshable via its refresh token (matching the existing `isConnected` semantics).
- **Warn once** (via the `o-auth` logger) when the non-durable store is used to persist tokens in **production** — surfaces the missing persistent-store injection without changing behavior.
- **Strengthen docs** on the dev-only, non-durable, process-local nature of the class and singleton.

`states` is already TTL-pruned on every write, so it is left as-is.

## Compatibility

Backward compatible: `new MemoryTokenStore()` and `new MemoryTokenStore(projectId)` still work; the new `options` arg is optional. Existing handlers that default to `memoryTokenStore` and all OAuth handler tests still pass.

## Tests

New `memory.test.ts`: per-user scoping, clear, `isConnected` (fresh / expired / expired-but-refreshable), one-shot `consumeState` + expiry, projectId scoping, **LRU eviction past the cap**, `clearAll`, and **warn-once in production**.

Refs #1989