### PR TITLE
Surface empty AG-UI runs as errors

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.632",
+  "version": "0.1.633",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/ag-ui/browser-encoder.test.ts
+++ b/src/agent/ag-ui/browser-encoder.test.ts
@@ -435,6 +435,30 @@ describe("agent/ag-ui-browser-encoder", () => {
       }],
     );
   });
+
+  it("does not treat step lifecycle events as assistant-visible output", () => {
+    const state = createAgUiBrowserEncoderState();
+
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, { type: "step-start" }),
+      [{ event: "StepStarted", payload: { stepName: "step-1" } }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, { type: "step-end" }),
+      [{ event: "StepFinished", payload: { stepName: "step-1" } }],
+    );
+
+    assertEquals(
+      finalizeAgUiBrowserEvents(state, null),
+      [{
+        event: "RunError",
+        payload: {
+          code: "EMPTY_ASSISTANT_OUTPUT",
+          message: "Agent run produced no assistant-visible output",
+        },
+      }],
+    );
+  });
 });
 
 describe("buildAgUiBrowserFinalizeResponse", () => {

--- a/src/agent/ag-ui/browser-encoder.ts
+++ b/src/agent/ag-ui/browser-encoder.ts
@@ -467,7 +467,6 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
 
     case "step-start":
     case "start-step":
-      state.sawVisibleOutput = true;
       return [
         ...closeOpenTextEvent(state),
         ...closeOpenReasoningEvent(state),
@@ -476,7 +475,6 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
 
     case "step-end":
     case "finish-step":
-      state.sawVisibleOutput = true;
       return [
         ...closeOpenTextEvent(state),
         ...closeOpenReasoningEvent(state),

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.632";
+export const VERSION = "0.1.633";


### PR DESCRIPTION
## Summary
- stop treating AG-UI step lifecycle events as assistant-visible output
- surface lifecycle-only/empty runs through the existing empty assistant output path
- bump the framework package version to 0.1.633

## Verification
- git diff --check
- deno test --no-check --allow-all src/agent/ag-ui/browser-encoder.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/agent/ag-ui/browser-encoder.test.ts
- pre-push hook: format, lint, and full test suite passed (1950 passed, 0 failed)