### PR TITLE
refactor(types): drop remaining as-any / ts-ignore in cross-cutting infra (#1989)

### DIFF
--- a/src/security/sandbox/project-worker.ts
+++ b/src/security/sandbox/project-worker.ts
@@ -23,9 +23,10 @@ import type {
 const logger = serverLogger.component("project-worker");
 const textEncoder = new TextEncoder();
 
-type ExtendedWorkerOptions = {
-  type: "module";
-  name?: string;
+// Intersection with the DOM `WorkerOptions` so the value is assignable to the
+// `Worker` constructor without suppression — Deno reads the extra `deno` field
+// at runtime even though the DOM lib type doesn't declare it.
+type ExtendedWorkerOptions = WorkerOptions & {
   deno?: { permissions: WorkerPermissions };
 };
 
@@ -103,7 +104,6 @@ export class ProjectWorker {
       deno: { permissions: this.permissions },
     };
 
-    // @ts-ignore - Deno Worker accepts extended options
     this.worker = new Worker(workerUrl, workerOptions);
     this._status = "idle";
 

--- a/src/utils/redis-client.ts
+++ b/src/utils/redis-client.ts
@@ -28,6 +28,18 @@ export interface RedisClientOptions {
   username?: string;
 }
 
+/**
+ * Minimal subset of `@redis/client`'s `createClient` options that we actually
+ * pass. Declared locally so we don't depend on the untyped npm surface (the
+ * module is loaded via a dynamic `import()` and is otherwise `any`).
+ */
+interface RedisClientFactoryOptions {
+  url?: string;
+  socket?: { tls?: boolean };
+  password?: string;
+  username?: string;
+}
+
 let sharedClient: RedisClient | null = null;
 let connectionPromise: Promise<RedisClient> | null = null;
 let isConnecting = false;
@@ -67,14 +79,12 @@ export async function getRedisClient(options: RedisClientOptions = {}): Promise<
 }
 
 async function createClient(options: RedisClientOptions): Promise<RedisClient> {
-  // deno-lint-ignore no-explicit-any
-  let createClientFn: ((opts: Record<string, any>) => RedisClient) | undefined;
+  let createClientFn: ((opts: RedisClientFactoryOptions) => RedisClient) | undefined;
 
   try {
     const redisClientModule = "npm:@redis/client@1.5.8";
     const mod = await import(redisClientModule);
-    // deno-lint-ignore no-explicit-any
-    createClientFn = mod.createClient as (opts: Record<string, any>) => RedisClient;
+    createClientFn = mod.createClient as (opts: RedisClientFactoryOptions) => RedisClient;
   } catch (error) {
     logger.debug("Failed to load @redis/client module", { error });
     throw DEPENDENCY_MISSING.create({
@@ -92,8 +102,7 @@ async function createClient(options: RedisClientOptions): Promise<RedisClient> {
     );
   }
 
-  // deno-lint-ignore no-explicit-any
-  const clientOpts: Record<string, any> = { url };
+  const clientOpts: RedisClientFactoryOptions = { url };
   if (useTls) {
     clientOpts.socket = { tls: true };
   }


### PR DESCRIPTION
## What

Closes the last weak-typing items from the `#1989` audit (findings #2 weak typing + #6 `@ts-ignore` cluster). Pure type-level cleanup — no runtime behavior change.

## Changes

**`src/utils/redis-client.ts`** — replace 3× `Record<string, any>` (and their `deno-lint-ignore no-explicit-any` directives) with a local `RedisClientFactoryOptions` interface describing the subset of `@redis/client`'s `createClient` options we actually pass (`url`, `socket.tls`, `password`, `username`). The npm module is loaded via dynamic `import()` and is otherwise `any`, so the typed boundary lives on our side.

**`src/security/sandbox/project-worker.ts`** — drop the `@ts-ignore` on `new Worker(...)` by making `ExtendedWorkerOptions` an intersection with the DOM `WorkerOptions` (`WorkerOptions & { deno?: { permissions } }`), matching the pattern already used in `deno-sandbox.ts`. The value is now assignable to the `Worker` constructor without suppressing the whole line (Deno still reads the extra `deno` field at runtime).

## Tests

Pure type changes — the typecheck is the gate. Existing `project-worker.test.ts` still passes (it constructs a real Worker), confirming the suppression removal is runtime-safe. No adjacent redis-client test exists; the runtime `createClient` call is unchanged.

Refs #1989