### PR TITLE
fix(cache): invalidate L1 tier on MultiTier deleteByPrefix/clear (#1989)

### DIFF
--- a/src/observability/tracing/api-shim.test.ts
+++ b/src/observability/tracing/api-shim.test.ts
@@ -1,0 +1,206 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  _resetShimForTests,
+  context,
+  defaultTextMapGetter,
+  defaultTextMapSetter,
+  getGlobalMetricsAPI,
+  getGlobalTracerProvider,
+  getTracer,
+  type MetricsAPI,
+  propagation,
+  setGlobalActiveSpanAccessor,
+  setGlobalMetricsAPI,
+  setGlobalTracerProvider,
+  type Span,
+  SpanKind,
+  SpanStatusCode,
+  type TextMapPropagator,
+  trace,
+  type Tracer,
+  type TracerProvider,
+} from "./api-shim.ts";
+
+describe("observability/tracing/api-shim", () => {
+  afterEach(() => {
+    // Restore global shim state so tests don't leak into each other.
+    _resetShimForTests();
+  });
+
+  describe("no-op defaults (extension not installed)", () => {
+    it("getTracer returns a no-op tracer whose spans are inert but chainable", () => {
+      const tracer = getTracer("test", "1.0");
+      const span = tracer.startSpan("op");
+
+      // All mutators are chainable no-ops and never throw.
+      assertEquals(span.setAttribute("k", "v"), span);
+      assertEquals(span.setAttributes({ a: 1 }), span);
+      assertEquals(span.setStatus({ code: SpanStatusCode.OK }), span);
+      assertEquals(span.addEvent("evt"), span);
+      span.recordException(new Error("x"));
+      span.updateName("renamed");
+      span.end();
+
+      // The no-op span context has all-zero ids.
+      const ctx = span.spanContext();
+      assertEquals(ctx.traceId, "00000000000000000000000000000000");
+      assertEquals(ctx.spanId, "0000000000000000");
+      assertEquals(ctx.traceFlags, 0);
+    });
+
+    it("startActiveSpan invokes the callback with a span (fn-as-2nd-arg form)", () => {
+      const tracer = getTracer("test");
+      let received: Span | undefined;
+      const result = tracer.startActiveSpan("op", (span) => {
+        received = span;
+        return 42;
+      });
+      assertEquals(result, 42);
+      assertExists(received);
+    });
+
+    it("startActiveSpan invokes the callback in the options + fn form", () => {
+      const tracer = getTracer("test");
+      const result = tracer.startActiveSpan("op", { kind: SpanKind.SERVER }, (span) => {
+        span.setAttribute("k", "v");
+        return "done";
+      });
+      assertEquals(result, "done");
+    });
+
+    it("trace.getActiveSpan / getSpan return undefined with no accessor wired", () => {
+      assertEquals(trace.getActiveSpan(), undefined);
+      assertEquals(trace.getSpan(context.active()), undefined);
+    });
+  });
+
+  describe("global tracer provider", () => {
+    it("setGlobalTracerProvider swaps the provider used by getTracer", () => {
+      const calls: Array<[string, string | undefined]> = [];
+      const fakeTracer = { startSpan: () => ({}) as Span } as unknown as Tracer;
+      const provider: TracerProvider = {
+        getTracer(name, version) {
+          calls.push([name, version]);
+          return fakeTracer;
+        },
+      };
+
+      setGlobalTracerProvider(provider);
+      assertEquals(getGlobalTracerProvider(), provider);
+      assertEquals(getTracer("svc", "2.0"), fakeTracer);
+      assertEquals(trace.getTracer("svc2"), fakeTracer);
+      assertEquals(calls, [["svc", "2.0"], ["svc2", undefined]]);
+    });
+
+    it("_resetShimForTests restores the no-op provider", () => {
+      setGlobalTracerProvider({ getTracer: () => ({}) as Tracer });
+      _resetShimForTests();
+      // Back to the no-op tracer, whose span has zero ids.
+      const span = getGlobalTracerProvider().getTracer("x").startSpan("s");
+      assertEquals(span.spanContext().traceId, "00000000000000000000000000000000");
+    });
+  });
+
+  describe("active-span accessor", () => {
+    it("returns real spans once an accessor is wired", () => {
+      const real = { updateName() {} } as unknown as Span;
+      setGlobalActiveSpanAccessor({
+        getActiveSpan: () => real,
+        getSpan: () => real,
+      });
+      assertEquals(trace.getActiveSpan(), real);
+      assertEquals(trace.getSpan(context.active()), real);
+    });
+  });
+
+  describe("context API", () => {
+    it("context.with sets the active context for the duration of fn then restores it", () => {
+      const base = context.active();
+      const scoped = base.setValue(Symbol("k"), "v");
+
+      const inner = context.with(scoped, () => context.active());
+      assertEquals(inner, scoped);
+      // Restored afterwards.
+      assertEquals(context.active(), base);
+    });
+
+    it("context.with restores the previous context even if fn throws", () => {
+      const base = context.active();
+      const scoped = base.setValue(Symbol("k"), "v");
+      let threw = false;
+      try {
+        context.with(scoped, () => {
+          throw new Error("boom");
+        });
+      } catch {
+        threw = true;
+      }
+      assertEquals(threw, true);
+      assertEquals(context.active(), base);
+    });
+  });
+
+  describe("propagation API", () => {
+    it("extract returns the context unchanged and inject is a no-op without a propagator", () => {
+      const ctx = context.active();
+      const carrier: Record<string, string> = {};
+      assertEquals(propagation.extract(ctx, carrier), ctx);
+      propagation.inject(ctx, carrier);
+      assertEquals(Object.keys(carrier).length, 0);
+    });
+
+    it("delegates to a registered propagator", () => {
+      const ctx = context.active();
+      const injected: Record<string, string> = {};
+      const propagator: TextMapPropagator = {
+        inject(_c, carrier) {
+          (carrier as Record<string, string>).traceparent = "abc";
+        },
+        extract(c) {
+          return c;
+        },
+        fields: () => ["traceparent"],
+      };
+      propagation.setGlobalPropagator(propagator);
+      propagation.inject(ctx, injected);
+      assertEquals(injected.traceparent, "abc");
+    });
+  });
+
+  describe("default TextMap getter/setter", () => {
+    it("getter reads keys and values from a record carrier", () => {
+      const carrier = { traceparent: "tp", baggage: "b" };
+      assertEquals(defaultTextMapGetter.keys(carrier).sort(), ["baggage", "traceparent"]);
+      assertEquals(defaultTextMapGetter.get(carrier, "traceparent"), "tp");
+      assertEquals(defaultTextMapGetter.get(carrier, "missing"), undefined);
+    });
+
+    it("setter writes a value into a record carrier", () => {
+      const carrier: Record<string, string> = {};
+      defaultTextMapSetter.set(carrier, "traceparent", "tp");
+      assertEquals(carrier.traceparent, "tp");
+    });
+  });
+
+  describe("metrics API registry", () => {
+    it("is null by default and round-trips a registered API", () => {
+      assertEquals(getGlobalMetricsAPI(), null);
+      const api = { getMeter: () => ({}) } as unknown as MetricsAPI;
+      setGlobalMetricsAPI(api);
+      assertEquals(getGlobalMetricsAPI(), api);
+    });
+  });
+
+  describe("constant maps", () => {
+    it("expose stable SpanKind and SpanStatusCode values", () => {
+      assertEquals(SpanKind.INTERNAL, 0);
+      assertEquals(SpanKind.SERVER, 1);
+      assertEquals(SpanKind.CLIENT, 2);
+      assertEquals(SpanStatusCode.UNSET, 0);
+      assertEquals(SpanStatusCode.OK, 1);
+      assertEquals(SpanStatusCode.ERROR, 2);
+    });
+  });
+});

--- a/src/repositories/cache/cache-repository.test.ts
+++ b/src/repositories/cache/cache-repository.test.ts
@@ -3,14 +3,17 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { MemoryCacheBackend } from "#veryfront/cache/backend.ts";
 import {
-  buildScopedKey,
-  createMemoryCacheRepository,
   createMultiTierCacheRepository,
   MemoryCacheRepository,
   MultiTierCacheRepository,
 } from "./cache-repository.ts";
 import type { RepositoryContext } from "../types.ts";
 
+// NOTE: basic MemoryCacheRepository behaviour (get/set, delete, deleteByPrefix,
+// stats/hitRate, has-expiry, buildScopedKey, memory factory) is already covered
+// by ../repositories.test.ts. This adjacent suite intentionally covers only the
+// gaps: MemoryCacheRepository TTL pruning + LRU eviction, and the entire
+// MultiTierCacheRepository (previously untested).
 const CTX: RepositoryContext = {
   projectId: "proj",
   environment: "production",
@@ -18,12 +21,6 @@ const CTX: RepositoryContext = {
 };
 
 describe("repositories/cache/cache-repository", () => {
-  describe("buildScopedKey", () => {
-    it("prefixes the key with project/environment/version", () => {
-      assertEquals(buildScopedKey(CTX, "page:home"), "proj:production:v1:page:home");
-    });
-  });
-
   describe("MemoryCacheRepository — TTL & eviction (untested paths)", () => {
     it("get() treats an expired entry as a miss and prunes it", async () => {
       const cache = new MemoryCacheRepository<string>({ context: CTX });
@@ -59,18 +56,6 @@ describe("repositories/cache/cache-repository", () => {
       assertEquals(cache.size, 2);
       assertEquals(await cache.get("a"), "1-updated");
       assertEquals(await cache.get("b"), "2");
-    });
-
-    it("computes hitRate from gets/hits", async () => {
-      const cache = new MemoryCacheRepository<string>({ context: CTX });
-      await cache.set("k", "v");
-      await cache.get("k"); // hit
-      await cache.get("missing"); // miss
-
-      const stats = cache.getStats();
-      assertEquals(stats.gets, 2);
-      assertEquals(stats.hits, 1);
-      assertEquals(stats.hitRate, 0.5);
     });
 
     it("clear() empties the repository", async () => {
@@ -122,9 +107,9 @@ describe("repositories/cache/cache-repository", () => {
 
     it("deleteByPrefix removes matching scoped keys via the backend pattern", async () => {
       const { backend, repo } = makeRepo();
-      // Seed the distributed (L3) backend directly: repo.set writes it
-      // fire-and-forget (asyncBackfill), so direct seeding keeps the test
-      // deterministic. deleteByPrefix targets the backend via delByPattern.
+      // deleteByPrefix operates on the L3 backend via delByPattern, so seed the
+      // backend directly and assert backend state — the cleanest unit of the
+      // method's contract.
       await backend.set("proj:production:v1:pages/a", "1");
       await backend.set("proj:production:v1:pages/b", "2");
       await backend.set("proj:production:v1:assets/c", "3");
@@ -164,24 +149,20 @@ describe("repositories/cache/cache-repository", () => {
     it("getStats surfaces multi-tier hit/miss accounting", async () => {
       const { repo } = makeRepo();
       await repo.set("k", "v");
-      await repo.get("k"); // hit
+      await repo.get("k"); // hit (from whichever tier; total still one hit)
       await repo.get("missing"); // miss
 
       const stats = repo.getStats();
-      assertEquals(stats.gets >= 2, true);
-      assertEquals(stats.hits >= 1, true);
-      assertEquals(stats.misses >= 1, true);
+      assertEquals(stats.sets, 1);
+      assertEquals(stats.gets, 2);
+      assertEquals(stats.hits, 1);
+      assertEquals(stats.misses, 1);
     });
   });
 
   describe("factory functions", () => {
-    it("createMemoryCacheRepository builds a MemoryCacheRepository", async () => {
-      const repo = createMemoryCacheRepository<string>(CTX, { maxEntries: 10 });
-      await repo.set("k", "v");
-      assertEquals(await repo.get("k"), "v");
-    });
-
-    it("createMultiTierCacheRepository builds a MultiTierCacheRepository", async () => {
+    // createMemoryCacheRepository is covered by ../repositories.test.ts.
+    it("createMultiTierCacheRepository builds a working MultiTierCacheRepository", async () => {
       const repo = createMultiTierCacheRepository(CTX, new MemoryCacheBackend());
       await repo.set("k", "v");
       assertEquals(await repo.get("k"), "v");

--- a/src/repositories/cache/cache-repository.test.ts
+++ b/src/repositories/cache/cache-repository.test.ts
@@ -158,6 +158,38 @@ describe("repositories/cache/cache-repository", () => {
       assertEquals(stats.hits, 1);
       assertEquals(stats.misses, 1);
     });
+
+    // Let fire-and-forget tier writes (asyncBackfill) settle before asserting.
+    const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    it("deleteByPrefix invalidates the L1 tier — no stale reads (#1989)", async () => {
+      const { repo } = makeRepo();
+      await repo.set("pages/a", "1");
+      await repo.set("assets/b", "2");
+      await flush();
+      // Both are cached (served from L1).
+      assertEquals(await repo.get("pages/a"), "1");
+
+      await repo.deleteByPrefix("pages/");
+
+      // Before the fix this returned the stale L1 value "1"; the backend-only
+      // pattern delete left L1 untouched.
+      assertEquals(await repo.get("pages/a"), null);
+      // A non-matching key is unaffected.
+      assertEquals(await repo.get("assets/b"), "2");
+    });
+
+    it("clear invalidates the L1 tier — no stale reads (#1989)", async () => {
+      const { repo } = makeRepo();
+      await repo.set("k", "v");
+      await flush();
+      assertEquals(await repo.get("k"), "v");
+
+      await repo.clear();
+
+      // Before the fix this returned the stale L1 value "v".
+      assertEquals(await repo.get("k"), null);
+    });
   });
 
   describe("factory functions", () => {

--- a/src/repositories/cache/cache-repository.test.ts
+++ b/src/repositories/cache/cache-repository.test.ts
@@ -1,0 +1,190 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { MemoryCacheBackend } from "#veryfront/cache/backend.ts";
+import {
+  buildScopedKey,
+  createMemoryCacheRepository,
+  createMultiTierCacheRepository,
+  MemoryCacheRepository,
+  MultiTierCacheRepository,
+} from "./cache-repository.ts";
+import type { RepositoryContext } from "../types.ts";
+
+const CTX: RepositoryContext = {
+  projectId: "proj",
+  environment: "production",
+  versionId: "v1",
+};
+
+describe("repositories/cache/cache-repository", () => {
+  describe("buildScopedKey", () => {
+    it("prefixes the key with project/environment/version", () => {
+      assertEquals(buildScopedKey(CTX, "page:home"), "proj:production:v1:page:home");
+    });
+  });
+
+  describe("MemoryCacheRepository — TTL & eviction (untested paths)", () => {
+    it("get() treats an expired entry as a miss and prunes it", async () => {
+      const cache = new MemoryCacheRepository<string>({ context: CTX });
+      // Negative TTL → already expired on read.
+      await cache.set("k", "v", -1);
+      assertEquals(await cache.get("k"), null);
+      // Expired entry is removed from the store.
+      assertEquals(cache.size, 0);
+      const stats = cache.getStats();
+      assertEquals(stats.gets, 1);
+      assertEquals(stats.misses, 1);
+      assertEquals(stats.hits, 0);
+    });
+
+    it("evicts the oldest entry once maxEntries is exceeded", async () => {
+      const cache = new MemoryCacheRepository<string>({ context: CTX, maxEntries: 2 });
+      await cache.set("a", "1");
+      await cache.set("b", "2");
+      await cache.set("c", "3"); // evicts "a" (oldest)
+
+      assertEquals(cache.size, 2);
+      assertEquals(await cache.get("a"), null);
+      assertEquals(await cache.get("b"), "2");
+      assertEquals(await cache.get("c"), "3");
+    });
+
+    it("re-setting an existing key does not trigger eviction", async () => {
+      const cache = new MemoryCacheRepository<string>({ context: CTX, maxEntries: 2 });
+      await cache.set("a", "1");
+      await cache.set("b", "2");
+      await cache.set("a", "1-updated"); // already present → no eviction
+
+      assertEquals(cache.size, 2);
+      assertEquals(await cache.get("a"), "1-updated");
+      assertEquals(await cache.get("b"), "2");
+    });
+
+    it("computes hitRate from gets/hits", async () => {
+      const cache = new MemoryCacheRepository<string>({ context: CTX });
+      await cache.set("k", "v");
+      await cache.get("k"); // hit
+      await cache.get("missing"); // miss
+
+      const stats = cache.getStats();
+      assertEquals(stats.gets, 2);
+      assertEquals(stats.hits, 1);
+      assertEquals(stats.hitRate, 0.5);
+    });
+
+    it("clear() empties the repository", async () => {
+      const cache = new MemoryCacheRepository<string>({ context: CTX });
+      await cache.set("a", "1");
+      await cache.set("b", "2");
+      await cache.clear();
+      assertEquals(await cache.get("a"), null);
+      assertEquals(await cache.get("b"), null);
+      assertEquals(cache.size, 0);
+    });
+  });
+
+  describe("MultiTierCacheRepository (previously untested)", () => {
+    function makeRepo() {
+      const backend = new MemoryCacheBackend();
+      const repo = new MultiTierCacheRepository({ context: CTX, backend, defaultTtlSeconds: 300 });
+      return { backend, repo };
+    }
+
+    it("set writes through to the backend under the scoped key, get reads it back", async () => {
+      const { backend, repo } = makeRepo();
+      await repo.set("page", "html");
+
+      assertEquals(await repo.get("page"), "html");
+      // Stored under the project-scoped key in the distributed backend.
+      assertEquals(await backend.get("proj:production:v1:page"), "html");
+    });
+
+    it("get returns null for a missing key", async () => {
+      const { repo } = makeRepo();
+      assertEquals(await repo.get("nope"), null);
+    });
+
+    it("has reflects presence", async () => {
+      const { repo } = makeRepo();
+      assertEquals(await repo.has("k"), false);
+      await repo.set("k", "v");
+      assertEquals(await repo.has("k"), true);
+    });
+
+    it("delete removes the entry and counts a local delete stat", async () => {
+      const { repo } = makeRepo();
+      await repo.set("k", "v");
+      await repo.delete("k");
+      assertEquals(await repo.get("k"), null);
+      assertEquals(repo.getStats().deletes, 1);
+    });
+
+    it("deleteByPrefix removes matching scoped keys via the backend pattern", async () => {
+      const { backend, repo } = makeRepo();
+      // Seed the distributed (L3) backend directly: repo.set writes it
+      // fire-and-forget (asyncBackfill), so direct seeding keeps the test
+      // deterministic. deleteByPrefix targets the backend via delByPattern.
+      await backend.set("proj:production:v1:pages/a", "1");
+      await backend.set("proj:production:v1:pages/b", "2");
+      await backend.set("proj:production:v1:assets/c", "3");
+
+      const deleted = await repo.deleteByPrefix("pages/");
+      assertEquals(deleted, 2);
+      assertEquals(await backend.get("proj:production:v1:pages/a"), null);
+      assertEquals(await backend.get("proj:production:v1:pages/b"), null);
+      // Non-matching key is left intact.
+      assertEquals(await backend.get("proj:production:v1:assets/c"), "3");
+    });
+
+    it("deleteByPrefix returns 0 when the backend has no delByPattern support", async () => {
+      // Backend without delByPattern (the method is optional on CacheBackend).
+      const backend = {
+        type: "memory" as const,
+        get: () => Promise.resolve(null),
+        set: () => Promise.resolve(),
+        del: () => Promise.resolve(),
+      };
+      const repo = new MultiTierCacheRepository({ context: CTX, backend });
+      assertEquals(await repo.deleteByPrefix("pages/"), 0);
+    });
+
+    it("clear removes only this scope's keys from the backend", async () => {
+      const { backend, repo } = makeRepo();
+      // Seed both an in-scope key and an out-of-scope key directly.
+      await backend.set("proj:production:v1:k", "v");
+      await backend.set("other:env:ver:k", "keep");
+
+      await repo.clear();
+      assertEquals(await backend.get("proj:production:v1:k"), null);
+      // A key outside this repo's scope is untouched.
+      assertEquals(await backend.get("other:env:ver:k"), "keep");
+    });
+
+    it("getStats surfaces multi-tier hit/miss accounting", async () => {
+      const { repo } = makeRepo();
+      await repo.set("k", "v");
+      await repo.get("k"); // hit
+      await repo.get("missing"); // miss
+
+      const stats = repo.getStats();
+      assertEquals(stats.gets >= 2, true);
+      assertEquals(stats.hits >= 1, true);
+      assertEquals(stats.misses >= 1, true);
+    });
+  });
+
+  describe("factory functions", () => {
+    it("createMemoryCacheRepository builds a MemoryCacheRepository", async () => {
+      const repo = createMemoryCacheRepository<string>(CTX, { maxEntries: 10 });
+      await repo.set("k", "v");
+      assertEquals(await repo.get("k"), "v");
+    });
+
+    it("createMultiTierCacheRepository builds a MultiTierCacheRepository", async () => {
+      const repo = createMultiTierCacheRepository(CTX, new MemoryCacheBackend());
+      await repo.set("k", "v");
+      assertEquals(await repo.get("k"), "v");
+    });
+  });
+});

--- a/src/repositories/cache/cache-repository.ts
+++ b/src/repositories/cache/cache-repository.ts
@@ -172,6 +172,7 @@ export class MultiTierCacheRepository implements CacheRepository<string> {
   readonly context: RepositoryContext;
   private readonly cache: MultiTierCache<string>;
   private readonly backend: CacheBackend;
+  private readonly l1: MemoryTier;
   private readonly name: string;
   private localStats: { deletes: number } = { deletes: 0 };
 
@@ -186,12 +187,12 @@ export class MultiTierCacheRepository implements CacheRepository<string> {
     this.backend = options.backend;
     this.name = options.name ?? "multi-tier-cache";
 
-    const l1 = new MemoryTier(options.maxL1Entries ?? 500);
+    this.l1 = new MemoryTier(options.maxL1Entries ?? 500);
     const l3 = new BackendTierAdapter("l3-distributed", options.backend);
 
     this.cache = new MultiTierCache({
       name: this.name,
-      l1,
+      l1: this.l1,
       l3,
       defaultTtlSeconds: options.defaultTtlSeconds ?? 300,
       backfillOnHit: true,
@@ -219,6 +220,11 @@ export class MultiTierCacheRepository implements CacheRepository<string> {
   async deleteByPrefix(prefix: string): Promise<number> {
     const scopedPrefix = this.getScopedKey(prefix);
 
+    // Invalidate the L1 tier too. The backend pattern delete only reaches L3;
+    // since get() consults L1 first, skipping this would keep serving stale
+    // matches from L1 until their TTL expires.
+    this.l1.deleteByPrefix(scopedPrefix);
+
     if (!this.backend.delByPattern) {
       logger.debug(`[${this.name}] deleteByPrefix not supported by backend`, { prefix });
       return 0;
@@ -236,6 +242,8 @@ export class MultiTierCacheRepository implements CacheRepository<string> {
   async clear(): Promise<void> {
     const prefix =
       `${this.context.projectId}:${this.context.environment}:${this.context.versionId}:`;
+    // Clear the L1 tier alongside the L3 backend (see deleteByPrefix).
+    this.l1.deleteByPrefix(prefix);
     await this.backend.delByPattern?.(`${prefix}*`);
   }
 
@@ -285,6 +293,14 @@ class MemoryTier implements CacheTier<string> {
 
   async delete(key: string): Promise<void> {
     this.store.delete(key);
+  }
+
+  /** Drop every entry whose key starts with `prefix` (used for tier-wide
+   * invalidation on deleteByPrefix/clear). */
+  deleteByPrefix(prefix: string): void {
+    for (const key of this.store.keys()) {
+      if (key.startsWith(prefix)) this.store.delete(key);
+    }
   }
 }
 


### PR DESCRIPTION
## What

Fixes a **stale-read bug** in `MultiTierCacheRepository` surfaced while writing tests in #2049: after `deleteByPrefix` or `clear`, `get()` kept returning deleted/cleared values for up to `defaultTtlSeconds` (5 min).

## Root cause

`deleteByPrefix`/`clear` only issued a pattern delete against the **L3 backend**. But `MultiTierCache.get()` consults **L1 first**, and the in-memory L1 tier was never invalidated — so it kept serving the stale entry until its TTL.

## Fix

`MultiTierCacheRepository` now holds a reference to its L1 `MemoryTier` and drops matching entries from it alongside the backend pattern delete. Adds `MemoryTier.deleteByPrefix(prefix)`. Contained to `cache-repository.ts` — no change to the shared `MultiTierCache`.

## Tests

Two regression tests (`deleteByPrefix`/`clear` invalidate L1 → no stale read), **red-green verified**: both fail against the pre-fix code and pass with the fix.

## Note on the second behaviour (asyncBackfill fire-and-forget set)

Investigated and **left as-is — it is not a correctness bug**. L1 (memory) writes are synchronous and `get()` reads L1 first, so read-after-write stays consistent (the existing `set`→`get` tests pass deterministically). `asyncBackfill` only makes the **L3 distributed write** best-effort, which is its intended purpose (write latency). Changing it would regress that deliberate design for no read-consistency benefit.

## Stacking

Based on `test/1989-missing-tests` (#2049), which creates `cache-repository.test.ts`. Merge #2049 first, or this rebases cleanly onto main after it lands.

Refs #1989