### PR TITLE
fix(embedding): correct chunk() overlap:0 cascade + add tests (#1988)

### DIFF
--- a/src/embedding/chunk.test.ts
+++ b/src/embedding/chunk.test.ts
@@ -1,0 +1,79 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { chunk } from "./chunk.ts";
+
+describe("embedding/chunk", () => {
+  it("returns the whole text as one chunk when within maxChars", async () => {
+    assertEquals(await chunk("short text", { maxChars: 100 }), ["short text"]);
+  });
+
+  it("returns text under the default maxChars (2000) as a single chunk", async () => {
+    const text = "a".repeat(1999);
+    assertEquals(await chunk(text), [text]);
+  });
+
+  it("handles empty input", async () => {
+    assertEquals(await chunk(""), [""]);
+  });
+
+  it("prefers the paragraph separator and keeps paragraphs intact", async () => {
+    // maxChars large enough for one paragraph but not two → split on "\n\n".
+    const chunks = await chunk("para-one\n\npara-two", { maxChars: 10, overlap: 0 });
+    assertEquals(chunks, ["para-one", "para-two"]);
+  });
+
+  it("splits on lines when there are no paragraph breaks", async () => {
+    const chunks = await chunk("line-one\nline-two\nline-three", { maxChars: 10, overlap: 0 });
+    // Each emitted chunk is within the limit and built from whole lines.
+    for (const c of chunks) assertEquals(c.length <= 10, true);
+    assertEquals(chunks.join("").includes("line-one"), true);
+  });
+
+  it("recurses to finer separators so no chunk exceeds maxChars", async () => {
+    // A single paragraph far larger than maxChars forces recursion
+    // paragraph → line → word → character.
+    const text = Array.from({ length: 50 }, (_, i) => `word${i}`).join(" ");
+    const maxChars = 12;
+    const chunks = await chunk(text, { maxChars, overlap: 0 });
+    assertEquals(chunks.length > 1, true);
+    for (const c of chunks) assertEquals(c.length <= maxChars, true);
+  });
+
+  it("falls back to character splitting when a single token exceeds maxChars", async () => {
+    // No separators present and one long token → char-level split (sep = "").
+    const text = "x".repeat(25);
+    const chunks = await chunk(text, { maxChars: 10, overlap: 0, separators: [""] });
+    assertEquals(chunks.length > 1, true);
+    for (const c of chunks) assertEquals(c.length <= 10, true);
+    // Char-split chunks are substrings that reconstruct the original.
+    assertEquals(chunks.join(""), text);
+  });
+
+  it("carries an overlap tail from each chunk into the next", async () => {
+    const overlap = 3;
+    const text = "abcdefghijklmnopqrstuvwxyz";
+    const chunks = await chunk(text, { maxChars: 8, overlap, separators: [""] });
+    assertEquals(chunks.length > 1, true);
+    // Each non-first chunk begins with the trailing `overlap` chars of the prior chunk.
+    for (let i = 1; i < chunks.length; i++) {
+      const prevTail = chunks[i - 1].slice(-overlap);
+      assertEquals(chunks[i].startsWith(prevTail), true, `chunk ${i} should carry overlap`);
+    }
+  });
+
+  it("overlap: 0 produces clean, non-cascading chunks (regression)", async () => {
+    // Regression for the `slice(-0)` bug: with overlap 0 the splitter must NOT
+    // carry the whole previous chunk forward (which cascaded into an explosion
+    // of ever-growing duplicated chunks).
+    const chunks = await chunk("a".repeat(30), { maxChars: 10, overlap: 0, separators: [""] });
+    assertEquals(chunks, ["aaaaaaaaaa", "aaaaaaaaaa", "aaaaaaaaaa"]);
+  });
+
+  it("respects a custom separators list", async () => {
+    // Only split on '|'; spaces are not separators here.
+    const chunks = await chunk("aa|bb|cc", { maxChars: 4, overlap: 0, separators: ["|", ""] });
+    for (const c of chunks) assertEquals(c.length <= 4, true);
+    assertEquals(chunks.includes("aa"), true);
+  });
+});

--- a/src/embedding/chunk.ts
+++ b/src/embedding/chunk.ts
@@ -47,8 +47,10 @@ function splitRecursive(
     const candidate = current ? current + sep + part : part;
     if (candidate.length > maxChars && current) {
       chunks.push(current);
-      // Overlap: keep the tail of the current chunk
-      const tail = current.slice(-overlap);
+      // Overlap: keep the last `overlap` chars of the current chunk. Guard
+      // `overlap === 0` explicitly — `slice(-0)` is `slice(0)`, which returns
+      // the WHOLE chunk and would cascade it into every subsequent chunk.
+      const tail = overlap > 0 ? current.slice(-overlap) : "";
       current = tail ? tail + sep + part : part;
     } else {
       current = candidate;


### PR DESCRIPTION
## What

Adds the missing test for the previously-untested `chunk()` text splitter (`src/embedding/chunk.ts`) — a `#1988` test gap — and in doing so **found and fixed a real bug**.

## The bug

`splitRecursive` computes the overlap tail as `current.slice(-overlap)`. When `overlap === 0`, `slice(-0)` is `slice(0)` — it returns the **whole** current chunk instead of an empty tail (JS coerces `-0` → `0`). So with `overlap: 0`, every chunk was carried forward in full, cascading into an explosion of ever-growing, duplicated chunks. A 30-char input at `maxChars: 10` produced 20+ chunks instead of 3.

**Fix:** guard `overlap > 0` before slicing.

## Tests (10)

`chunk.test.ts`: within-limit single chunk, default 2000 maxChars, empty input, paragraph-separator preference, line splitting, recursion to finer separators, character-split fallback, overlap-tail carry, custom separators, and a **regression** pinning the `overlap: 0` behavior (`"a".repeat(30)` → exactly three 10-char chunks).

**Red-green verified:** the suite fails against the pre-fix code (cascade) and passes after the fix. Existing `rag-store.test.ts` (a `chunk` consumer) still passes.

Refs #1988