### PR TITLE
Advance release version to 0.1.634

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.633",
+  "version": "0.1.634",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.633";
+export const VERSION = "0.1.634";


### PR DESCRIPTION
Bumps `deno.json` and `src/utils/version-constant.ts` to `0.1.634` so the next main release can publish PR #2052 (configurable agent `inputMaxCharacterLimit`; built-in default raised from 50k → 100k).

## Test plan

- [x] `deno fmt --check deno.json src/utils/version-constant.ts`
- [x] `deno check src/utils/version-constant.ts`
- [x] Full test suite via pre-push hook (1,950 passed, 0 failed)