### PR TITLE
Fix Deno Redis module loading for workflow backend

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.636",
+  "version": "0.1.637",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/platform/adapters/redis/modules.test.ts
+++ b/src/platform/adapters/redis/modules.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { isDeno } from "#veryfront/platform/compat/runtime.ts";
 import { clearModuleCache, getRedisModule } from "./modules.ts";
 
 describe("platform/adapters/redis/modules", () => {
@@ -41,6 +42,17 @@ describe("platform/adapters/redis/modules", () => {
       // Exactly one should be loaded: DenoRedis on Deno, NodeRedis on Node/Bun
       const hasExactlyOne = (result.DenoRedis !== null) !== (result.NodeRedis !== null);
       assertEquals(hasExactlyOne, true);
+    });
+
+    it("should use the pinned npm Redis client in Deno", async () => {
+      if (!isDeno) return;
+
+      clearModuleCache();
+      const result = await getRedisModule();
+
+      assertEquals(result.DenoRedis, null);
+      assertExists(result.NodeRedis);
+      assertEquals(typeof result.NodeRedis.createClient, "function");
     });
   });
 

--- a/src/platform/adapters/redis/modules.ts
+++ b/src/platform/adapters/redis/modules.ts
@@ -19,25 +19,17 @@ export function getRedisModule(): Promise<{
     async () => {
       try {
         if (isDeno) {
-          const denoRedisUrl = "https://deno.land/x/redis@v0.32.1/mod.ts";
-          // @ts-ignore - Deno global
-          DenoRedis = await import(denoRedisUrl);
+          NodeRedis = (await import("npm:redis@5.11.0")) as unknown as NodeRedisModule;
         } else {
           NodeRedis = (await import("redis")) as unknown as NodeRedisModule;
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-
-        if (isDeno) {
-          throw INITIALIZATION_ERROR.create({
-            detail: `Failed to load Deno Redis module. Error: ${message}`,
-            cause: error instanceof Error ? error : undefined,
-          });
-        }
+        const packageName = isDeno ? "npm:redis@5.11.0" : "redis";
 
         throw INITIALIZATION_ERROR.create({
           detail:
-            `Failed to load 'redis' package. Please install it with: npm install redis\nError: ${message}`,
+            `Failed to load '${packageName}' package. Please install it with: npm install redis\nError: ${message}`,
           cause: error instanceof Error ? error : undefined,
         });
       }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.636";
+export const VERSION = "0.1.637";


### PR DESCRIPTION
## Summary
- switch the Deno Redis module loader from the unavailable remote `deno.land/x/redis@v0.32.1` import to the pinned npm Redis client
- keep the existing Redis backend adapter path intact so Studio webhook-triggered workflow runs no longer fail while loading the workflow backend
- add a regression test that Deno uses the pinned npm Redis client, not the remote Deno Redis module
- bump `deno.json` and `src/utils/version-constant.ts` to `0.1.637` for release

Refs veryfront/veryfront-studio#4671.

## Investigation Notes
The API already creates durable workflow runs and dispatches them to the runtime. The failure happens after dispatch inside the workflow runtime when the Redis workflow backend loads `https://deno.land/x/redis@v0.32.1/mod.ts`, which currently resolves as module not found. Durable runs are the canonical API run record; Redis is still the current workflow backend state/checkpoint/queue/lock implementation.

## Test Plan
- `deno test --allow-env --allow-read --allow-net src/platform/adapters/redis/modules.test.ts src/workflow/backends/redis/index.test.ts src/utils/version.test.ts src/utils/logger/logger.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts src/platform/adapters/redis/modules.ts src/platform/adapters/redis/modules.test.ts`
- `deno check src/platform/adapters/index.ts src/workflow/index.ts`
- pre-push hook passed: format, lint, typecheck, generate, unit tests (`1962 passed`, `0 failed`)
