### PR TITLE
fix(workflow): await run finalization before destroy

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.637",
+  "version": "0.1.638",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -204,6 +204,51 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     });
   });
 
+  it("waits for async workflow finalization before destroying the workflow client", async () => {
+    const order: string[] = [];
+    const handler = new ProjectRunExecuteHandler(createDeps({
+      createWorkflowClient: () => ({
+        register: () => {},
+        start: async (_workflowId: string, _input: unknown, options?: { runId?: string }) => ({
+          runId: options?.runId ?? "workflow-run",
+          settled: async () => {
+            order.push("settled");
+          },
+        }),
+        getRun: async () => ({
+          status: "failed",
+          error: { message: "step failed" },
+        }),
+        destroy: async () => {
+          order.push("destroy");
+        },
+      }),
+    }));
+    const body = {
+      runId: "run_workflow_failed_1",
+      kind: "workflow",
+      target: "workflow:publish",
+      projectId: "proj-1",
+      input: { release: "v1" },
+    };
+    const { request, publicKeyPem } = await signedRequest(
+      "/api/control-plane/runs/run_workflow_failed_1/execute",
+      body,
+    );
+
+    const result = await handler.handle(request, createCtx(publicKeyPem));
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(await result.response.json(), {
+      success: false,
+      error: "step failed",
+      logs: null,
+      duration_ms: 0,
+    });
+    assertEquals(order, ["settled", "destroy"]);
+  });
+
   it("treats waiting workflow runs as successful pause boundaries", async () => {
     let destroyed = false;
     const handler = new ProjectRunExecuteHandler(createDeps({

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -51,6 +51,11 @@ interface WorkflowRunView {
   error?: { message?: string } | null;
 }
 
+interface WorkflowStartHandle {
+  runId: string;
+  settled?(): Promise<void>;
+}
+
 interface WorkflowClientView {
   readonly statePersistence?: "durable" | "ephemeral";
   register(workflow: unknown): void;
@@ -58,7 +63,7 @@ interface WorkflowClientView {
     workflowId: string,
     input: unknown,
     options?: { runId?: string },
-  ): Promise<{ runId: string }>;
+  ): Promise<WorkflowStartHandle>;
   getRun(runId: string): Promise<WorkflowRunView | null>;
   destroy(): Promise<void>;
 }
@@ -272,6 +277,7 @@ async function executeWorkflowRun(
     client.register(workflow.definition);
     const handle = await client.start(workflow.id, request.input ?? {}, { runId: request.runId });
     const run = await waitForWorkflowResult(client, handle.runId, deps);
+    await handle.settled?.();
     const durationMs = Math.max(0, deps.now() - startedAt);
 
     if (run.status === "waiting") {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.637";
+export const VERSION = "0.1.638";

--- a/src/workflow/executor/workflow-executor.ts
+++ b/src/workflow/executor/workflow-executor.ts
@@ -70,6 +70,8 @@ export interface WorkflowExecutorConfig {
 export interface WorkflowHandle<TOutput = unknown> {
   /** Run ID */
   runId: string;
+  /** Wait for background workflow execution and cleanup to finish */
+  settled(): Promise<void>;
   /** Get current status */
   status(): Promise<WorkflowRun>;
   /** Wait for completion and get result */
@@ -216,11 +218,11 @@ export class WorkflowExecutor {
 
     await this.config.backend.createRun(run);
 
-    this.executeAsync(run.id).catch((error) => {
+    const settled = this.executeAsync(run.id).catch((error) => {
       logger.error("Workflow failed", { runId: run.id }, error);
     });
 
-    return this.createHandle<TOutput>(run.id);
+    return this.createHandle<TOutput>(run.id, settled);
   }
 
   /**
@@ -554,9 +556,10 @@ export class WorkflowExecutor {
   /**
    * Create a handle for a workflow run
    */
-  private createHandle<TOutput>(runId: string): WorkflowHandle<TOutput> {
+  private createHandle<TOutput>(runId: string, settled: Promise<void>): WorkflowHandle<TOutput> {
     return {
       runId,
+      settled: () => settled,
       status: () => this.config.backend.getRun(runId) as Promise<WorkflowRun>,
       result: () => this.waitForResult<TOutput>(runId),
       cancel: () => this.cancel(runId),


### PR DESCRIPTION
## Summary
- expose a workflow handle finalization hook backed by the executor background promise
- wait for workflow finalization before destroying the control-plane runtime client
- bump release version to 0.1.638

## Verification
- deno test --allow-env --allow-read --allow-net src/server/handlers/request/project-run-execute.handler.test.ts
- deno test --allow-env --allow-read --allow-net src/server/handlers/request/project-run-execute.handler.test.ts src/workflow/api/workflow-client.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts src/server/handlers/request/project-run-execute.handler.ts src/server/handlers/request/project-run-execute.handler.test.ts src/workflow/executor/workflow-executor.ts
- deno check src/server/handlers/request/project-run-execute.handler.ts src/workflow/api/workflow-client.ts src/workflow/executor/workflow-executor.ts src/workflow/index.ts
- deno task verify:quick
- pre-push hook: format, lint, typecheck, unit tests (1963 passed, 0 failed)