### PR TITLE
fix(workflow): wire project agents for run execution

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.638",
+  "version": "0.1.639",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -52,6 +52,7 @@ function createDeps(
       logs: "knowledge ingest completed",
       duration_ms: 51,
     }),
+    ensureProjectDiscovery: async () => {},
     sleep: async () => {},
     now: () => 0,
     ...overrides,
@@ -202,6 +203,65 @@ describe("server/handlers/request/project-run-execute.handler", () => {
       input: { release: "v1" },
       options: { runId: "run_workflow_1" },
     });
+  });
+
+  it("discovers project agents and tools before starting workflow agent steps", async () => {
+    const order: string[] = [];
+    let hasAgentRegistry = false;
+    let hasToolRegistry = false;
+    const handler = new ProjectRunExecuteHandler(createDeps({
+      ensureProjectDiscovery: async () => {
+        order.push("discover");
+      },
+      createWorkflowClient: (config) => {
+        hasAgentRegistry = typeof config?.executor?.stepExecutor?.agentRegistry?.get ===
+          "function";
+        hasToolRegistry = typeof config?.executor?.stepExecutor?.toolRegistry?.get ===
+          "function";
+        order.push("create-client");
+        return {
+          register: () => {},
+          start: async (
+            _workflowId: string,
+            _input: unknown,
+            options?: { runId?: string },
+          ) => {
+            order.push("start");
+            return { runId: options?.runId ?? "workflow-run" };
+          },
+          getRun: async () => ({
+            status: "completed",
+            output: { agent: "ok" },
+          }),
+          destroy: async () => {},
+        };
+      },
+    }));
+    const body = {
+      runId: "run_workflow_agent_1",
+      kind: "workflow",
+      target: "workflow:publish",
+      projectId: "proj-1",
+      input: { release: "v1" },
+    };
+    const { request, publicKeyPem } = await signedRequest(
+      "/api/control-plane/runs/run_workflow_agent_1/execute",
+      body,
+    );
+
+    const result = await handler.handle(request, createCtx(publicKeyPem));
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(await result.response.json(), {
+      success: true,
+      result: { agent: "ok" },
+      duration_ms: 0,
+      logs: null,
+    });
+    assertEquals(hasAgentRegistry, true);
+    assertEquals(hasToolRegistry, true);
+    assertEquals(order, ["discover", "create-client", "start"]);
   });
 
   it("waits for async workflow finalization before destroying the workflow client", async () => {

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -15,8 +15,12 @@ import type { VeryfrontConfig } from "#veryfront/config";
 import { type DiscoveredTask, findTaskById } from "#veryfront/task/discovery.ts";
 import { runTask, type RunTaskOptions, type TaskRunResult } from "#veryfront/task/runner.ts";
 import type { Logger } from "#veryfront/utils";
+import { agentRegistry } from "#veryfront/agent/composition/index.ts";
 import { type DiscoveredWorkflow, findWorkflowById } from "#veryfront/workflow/discovery";
 import { createWorkflowClient, RedisBackend } from "#veryfront/workflow";
+import type { WorkflowClientConfig } from "#veryfront/workflow";
+import { toolRegistry } from "#veryfront/tool/registry.ts";
+import { ensureProjectDiscovery } from "./api/project-discovery.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { BaseHandler } from "../response/base.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
@@ -89,8 +93,9 @@ export interface ProjectRunExecuteHandlerDeps {
     },
   ): Promise<DiscoveredWorkflow | null>;
   createWorkflowClient(
-    config?: { debug?: boolean },
+    config?: WorkflowClientConfig,
   ): WorkflowClientView | Promise<WorkflowClientView>;
+  ensureProjectDiscovery(ctx: HandlerContext): Promise<void>;
   executeKnowledgeIngest(input: {
     request: ProjectRunExecuteRequest;
     ctx: HandlerContext;
@@ -160,11 +165,12 @@ function createExecutionFailure(error: unknown, durationMs: number): ProjectRunE
 }
 
 async function createRuntimeWorkflowClient(
-  config?: { debug?: boolean },
+  config?: WorkflowClientConfig,
 ): Promise<WorkflowClientView> {
+  const clientConfig = withRuntimeStepRegistries(config);
   const redisUrl = getHostEnv("REDIS_URL")?.trim();
   if (!redisUrl) {
-    return Object.assign(createWorkflowClient(config), {
+    return Object.assign(createWorkflowClient(clientConfig), {
       statePersistence: "ephemeral" as const,
     });
   }
@@ -174,9 +180,23 @@ async function createRuntimeWorkflowClient(
     await backend.initialize();
   }
 
-  return Object.assign(createWorkflowClient({ backend, debug: config?.debug }), {
+  return Object.assign(createWorkflowClient({ ...clientConfig, backend, debug: config?.debug }), {
     statePersistence: "durable" as const,
   });
+}
+
+function withRuntimeStepRegistries(config?: WorkflowClientConfig): WorkflowClientConfig {
+  return {
+    ...config,
+    executor: {
+      ...config?.executor,
+      stepExecutor: {
+        ...config?.executor?.stepExecutor,
+        agentRegistry: config?.executor?.stepExecutor?.agentRegistry ?? agentRegistry,
+        toolRegistry: config?.executor?.stepExecutor?.toolRegistry ?? toolRegistry,
+      },
+    },
+  };
 }
 
 async function executeTaskRun(
@@ -256,6 +276,7 @@ async function executeWorkflowRun(
 ): Promise<ProjectRunExecuteResponse> {
   const startedAt = deps.now();
   const workflowId = stripTargetPrefix(request.target, "workflow:");
+  await deps.ensureProjectDiscovery(ctx);
   const workflow = await deps.findWorkflowById(workflowId, {
     projectDir: ctx.projectDir,
     adapter: ctx.adapter,
@@ -272,7 +293,7 @@ async function executeWorkflowRun(
     };
   }
 
-  const client = await deps.createWorkflowClient({ debug: ctx.debug });
+  const client = await deps.createWorkflowClient(withRuntimeStepRegistries({ debug: ctx.debug }));
   try {
     client.register(workflow.definition);
     const handle = await client.start(workflow.id, request.input ?? {}, { runId: request.runId });
@@ -574,6 +595,7 @@ const defaultDeps: ProjectRunExecuteHandlerDeps = {
   runTask,
   findWorkflowById,
   createWorkflowClient: createRuntimeWorkflowClient,
+  ensureProjectDiscovery,
   executeKnowledgeIngest: executeKnowledgeIngestRun,
   sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   now: () => Date.now(),

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.638";
+export const VERSION = "0.1.639";


### PR DESCRIPTION
## Summary
- run project primitive discovery before control-plane workflow execution
- pass project agent/tool registries into runtime workflow clients
- bump veryfront to 0.1.639 for release

## Verification
- deno test --allow-env --allow-read --allow-net src/server/handlers/request/project-run-execute.handler.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts src/server/handlers/request/project-run-execute.handler.ts src/server/handlers/request/project-run-execute.handler.test.ts
- deno check src/server/handlers/request/project-run-execute.handler.ts
- deno task verify:quick
- pre-push hook: 1964 passed, 0 failed

## Staging context
The public webhook-triggered workflow with an agent step currently fails on staging with `Agent registry not configured`; this PR wires the registries needed for that path.