### PR TITLE
fix(workflow): scrub tenant metadata from run output

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.639",
+  "version": "0.1.640",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.639";
+export const VERSION = "0.1.640";

--- a/src/workflow/api/workflow-client.test.ts
+++ b/src/workflow/api/workflow-client.test.ts
@@ -2,11 +2,24 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { VeryfrontError } from "#veryfront/errors";
+import { defineSchema } from "#veryfront/schemas/index.ts";
+import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
+import type { Tool } from "#veryfront/tool";
 import { createWorkflowClient, WorkflowClient } from "./workflow-client.ts";
 import { MemoryBackend } from "../backends/memory.ts";
 import { workflow } from "../dsl/workflow.ts";
 import { step } from "../dsl/step.ts";
 import { waitForApproval } from "../dsl/wait.ts";
+
+function createMockTool(name: string, output: unknown): Tool {
+  return {
+    id: name,
+    type: "function",
+    description: `Mock tool: ${name}`,
+    inputSchema: defineSchema((v) => v.object({}).passthrough())(),
+    execute: () => Promise.resolve(output),
+  };
+}
 
 describe("WorkflowClient", () => {
   let client: WorkflowClient;
@@ -134,6 +147,40 @@ describe("WorkflowClient", () => {
           Deno.env.set("VERYFRONT_PROJECT_API_URL", originalProjectApiUrl);
         }
       }
+    });
+
+    it("does not expose captured tenant metadata in completed output or context", async () => {
+      const tenantWorkflow = workflow({
+        id: "tenant-output-workflow",
+        steps: [
+          step("tenant-step", {
+            tool: createMockTool("tenant-tool", { result: "ok" }),
+          }),
+        ],
+      });
+
+      client.register(tenantWorkflow);
+
+      const handle = await runWithRequestContext(
+        {
+          projectSlug: "tests-1d0745b0",
+          projectId: "project-1",
+          token: "internal-runtime-token",
+          productionMode: false,
+          branch: "main",
+        },
+        () => client.start("tenant-output-workflow", { topic: "test" }),
+      );
+
+      const output = await handle.result();
+      const run = await backend.getRun(handle.runId);
+
+      assertExists(run);
+      assertEquals(run._tenant?.token, "internal-runtime-token");
+      assertEquals((output as Record<string, unknown>)["_tenant"], undefined);
+      assertEquals((run.output as Record<string, unknown>)["_tenant"], undefined);
+      assertEquals((run.context as Record<string, unknown>)["_tenant"], undefined);
+      assertEquals(run.output, { "tenant-step": { result: "ok" } });
     });
   });
 

--- a/src/workflow/executor/workflow-executor.ts
+++ b/src/workflow/executor/workflow-executor.ts
@@ -494,12 +494,13 @@ export class WorkflowExecutor {
     context: WorkflowContext,
     nodeStates: Record<string, NodeState>,
   ): Promise<WorkflowRun> {
-    const output = this.determineOutput(context);
+    const publicContext = this.toPublicContext(context);
+    const output = this.determineOutput(publicContext);
 
     await this.config.backend.updateRun(runId, {
       status: "completed",
       output,
-      context,
+      context: publicContext,
       nodeStates,
       completedAt: new Date(),
     });
@@ -516,9 +517,11 @@ export class WorkflowExecutor {
     context: WorkflowContext,
     nodeStates: Record<string, NodeState>,
   ): Promise<void> {
+    const publicContext = this.toPublicContext(context);
+
     await this.config.backend.updateRun(runId, {
       status: "failed",
-      context,
+      context: publicContext,
       nodeStates,
       error: {
         message: error.message,
@@ -537,19 +540,29 @@ export class WorkflowExecutor {
     context: WorkflowContext,
     nodeStates: Record<string, NodeState>,
   ): Promise<void> {
+    const publicContext = this.toPublicContext(context);
+
     await this.config.backend.updateRun(runId, {
       status: "waiting",
       currentNodes: [waitingNode],
-      context,
+      context: publicContext,
       nodeStates,
     });
+  }
+
+  /**
+   * Remove execution-only metadata before exposing or persisting workflow context.
+   */
+  private toPublicContext(context: WorkflowContext): WorkflowContext {
+    const { _tenant: _tenant, ...publicContext } = context;
+    return publicContext;
   }
 
   /**
    * Determine workflow output from context
    */
   private determineOutput(context: WorkflowContext): unknown {
-    const { input: _input, ...rest } = context;
+    const { input: _input, _tenant: _tenant, ...rest } = context;
     return rest;
   }
 


### PR DESCRIPTION
## Summary
- scrub execution-only _tenant metadata before persisting completed, failed, or waiting workflow run context
- derive completed workflow output from sanitized public context
- add a regression test proving tenant routing remains captured internally but is not exposed in output/context
- bump version to 0.1.640

## Verification
- deno test --allow-env --allow-read --allow-net src/workflow/api/workflow-client.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts src/workflow/api/workflow-client.test.ts src/workflow/executor/workflow-executor.ts
- deno check src/workflow/api/workflow-client.test.ts src/workflow/executor/workflow-executor.ts
- deno task verify:quick
- pre-push: 1964 passed, 0 failed
