### PR TITLE
fix(cache): invalidate MultiTier L1 on deleteByPrefix/clear, race-safe (#1989)

### DIFF
--- a/src/repositories/cache/cache-repository.test.ts
+++ b/src/repositories/cache/cache-repository.test.ts
@@ -76,6 +76,10 @@ describe("repositories/cache/cache-repository", () => {
       return { backend, repo };
     }
 
+    // set() backfills tiers fire-and-forget (asyncBackfill); let the L1 write
+    // settle before asserting on it.
+    const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
     it("set writes through to the backend under the scoped key, get reads it back", async () => {
       const { backend, repo } = makeRepo();
       await repo.set("page", "html");
@@ -122,8 +126,9 @@ describe("repositories/cache/cache-repository", () => {
       assertEquals(await backend.get("proj:production:v1:assets/c"), "3");
     });
 
-    it("deleteByPrefix returns 0 when the backend has no delByPattern support", async () => {
+    it("deleteByPrefix returns 0 but still wipes L1 when backend has no delByPattern", async () => {
       // Backend without delByPattern (the method is optional on CacheBackend).
+      // get always returns null, so any post-delete hit can only come from L1.
       const backend = {
         type: "memory" as const,
         get: () => Promise.resolve(null),
@@ -131,7 +136,67 @@ describe("repositories/cache/cache-repository", () => {
         del: () => Promise.resolve(),
       };
       const repo = new MultiTierCacheRepository({ context: CTX, backend });
+      await repo.set("pages/a", "1");
+      await flush();
+      assertEquals(await repo.get("pages/a"), "1"); // served from L1
+
+      // L3 can't pattern-delete (returns 0), but L1 must still be invalidated.
       assertEquals(await repo.deleteByPrefix("pages/"), 0);
+      assertEquals(await repo.get("pages/a"), null);
+    });
+
+    it("deleteByPrefix invalidates L1 so a deleted key is not served stale", async () => {
+      const { repo } = makeRepo();
+      await repo.set("pages/a", "1");
+      await repo.set("assets/b", "2");
+      await flush();
+      assertEquals(await repo.get("pages/a"), "1");
+
+      await repo.deleteByPrefix("pages/");
+      assertEquals(await repo.get("pages/a"), null); // gone from both tiers
+      assertEquals(await repo.get("assets/b"), "2"); // non-matching key kept
+    });
+
+    it("clear invalidates L1 so cleared keys are not served stale", async () => {
+      const { repo } = makeRepo();
+      await repo.set("k", "v");
+      await flush();
+      assertEquals(await repo.get("k"), "v");
+
+      await repo.clear();
+      assertEquals(await repo.get("k"), null);
+    });
+
+    it("deleteByPrefix wipes L1 AFTER L3 so a racing backfill cannot re-poison it", async () => {
+      // Wrap the backend so delByPattern blocks on a deferred. While it is
+      // in flight we fire a concurrent get() that would (pre-fix) backfill the
+      // still-present L3 value into L1. The post-delete L1 wipe must remove it.
+      const inner = new MemoryCacheBackend();
+      let release!: () => void;
+      const gate = new Promise<void>((r) => (release = r));
+      const backend = {
+        type: "memory" as const,
+        get: (k: string) => inner.get(k),
+        set: (k: string, v: string, ttl?: number) => inner.set(k, v, ttl),
+        del: (k: string) => inner.del(k),
+        delByPattern: async (pattern: string) => {
+          await gate; // hold the L3 delete open
+          return inner.delByPattern(pattern);
+        },
+      };
+      const repo = new MultiTierCacheRepository({ context: CTX, backend });
+      await repo.set("pages/a", "1");
+      await flush();
+
+      const deletePromise = repo.deleteByPrefix("pages/"); // wipes L1, then awaits L3
+      // Concurrent read during the L3-delete window: L1 was wiped, L3 still has
+      // the value, so this backfills "1" into L1.
+      assertEquals(await repo.get("pages/a"), "1");
+      release(); // let L3 delete complete; repo then wipes L1 again
+      await deletePromise;
+
+      // The racing backfill must have been cleared by the post-L3 L1 wipe.
+      assertEquals(await repo.get("pages/a"), null);
     });
 
     it("clear removes only this scope's keys from the backend", async () => {

--- a/src/repositories/cache/cache-repository.ts
+++ b/src/repositories/cache/cache-repository.ts
@@ -172,6 +172,7 @@ export class MultiTierCacheRepository implements CacheRepository<string> {
   readonly context: RepositoryContext;
   private readonly cache: MultiTierCache<string>;
   private readonly backend: CacheBackend;
+  private readonly l1: MemoryTier;
   private readonly name: string;
   private localStats: { deletes: number } = { deletes: 0 };
 
@@ -186,12 +187,12 @@ export class MultiTierCacheRepository implements CacheRepository<string> {
     this.backend = options.backend;
     this.name = options.name ?? "multi-tier-cache";
 
-    const l1 = new MemoryTier(options.maxL1Entries ?? 500);
+    this.l1 = new MemoryTier(options.maxL1Entries ?? 500);
     const l3 = new BackendTierAdapter("l3-distributed", options.backend);
 
     this.cache = new MultiTierCache({
       name: this.name,
-      l1,
+      l1: this.l1,
       l3,
       defaultTtlSeconds: options.defaultTtlSeconds ?? 300,
       backfillOnHit: true,
@@ -219,12 +220,21 @@ export class MultiTierCacheRepository implements CacheRepository<string> {
   async deleteByPrefix(prefix: string): Promise<number> {
     const scopedPrefix = this.getScopedKey(prefix);
 
+    // Wipe L1 up-front so concurrent reads during the (async) L3 delete miss
+    // L1 quickly. We wipe again after L3 resolves (below) to drop any entry a
+    // racing get() backfilled from a not-yet-deleted L3 value — otherwise that
+    // stale entry would survive in L1 until its TTL (the bug #1989 fixes).
+    this.l1.deleteByPrefix(scopedPrefix);
+
     if (!this.backend.delByPattern) {
       logger.debug(`[${this.name}] deleteByPrefix not supported by backend`, { prefix });
       return 0;
     }
 
     const deleted = await this.backend.delByPattern(`${scopedPrefix}*`);
+    // Second wipe: L3 is now gone, so anything re-backfilled into L1 during the
+    // await window is removed and cannot be repopulated from L3.
+    this.l1.deleteByPrefix(scopedPrefix);
     this.localStats.deletes += deleted;
     return deleted;
   }
@@ -236,7 +246,11 @@ export class MultiTierCacheRepository implements CacheRepository<string> {
   async clear(): Promise<void> {
     const prefix =
       `${this.context.projectId}:${this.context.environment}:${this.context.versionId}:`;
+    // Wipe L1 before and after the L3 delete (see deleteByPrefix) so racing
+    // backfills can't leave a stale entry in the in-memory tier.
+    this.l1.deleteByPrefix(prefix);
     await this.backend.delByPattern?.(`${prefix}*`);
+    this.l1.deleteByPrefix(prefix);
   }
 
   getStats(): CacheStats {
@@ -285,6 +299,14 @@ class MemoryTier implements CacheTier<string> {
 
   async delete(key: string): Promise<void> {
     this.store.delete(key);
+  }
+
+  /** Drop every entry whose key starts with `prefix` (tier-wide invalidation
+   * for the repository's deleteByPrefix/clear). */
+  deleteByPrefix(prefix: string): void {
+    for (const key of this.store.keys()) {
+      if (key.startsWith(prefix)) this.store.delete(key);
+    }
   }
 }
 


### PR DESCRIPTION
Supersedes #2050 (rebased onto current main after #2049 merged, with both review findings incorporated).

## What
`MultiTierCacheRepository.deleteByPrefix`/`clear` only pattern-deleted the L3 backend, but `get()` reads L1 first — so deleted entries were served stale from the in-memory L1 tier until TTL.

## Both #2050 review findings incorporated
1. **Race (HIGH):** invalidate L1 **both before and after** the awaited L3 delete. Before-wipe makes concurrent reads miss L1 fast; after-wipe drops any entry a racing `get()` backfilled from a not-yet-deleted L3 value (which would otherwise survive to TTL — the exact bug).
2. **No-`delByPattern` branch:** wipe L1 *before* the early return, so a backend lacking `delByPattern` still gets L1 invalidated (previously skipped).

Adds `MemoryTier.deleteByPrefix` and 4 tests including a **deferred-gated race test** and a **no-delByPattern L1-wipe test**. Red-green verified: each finding's test fails on the corresponding broken variant and passes with the fix.

Refs #1989