### PR TITLE
refactor(platform): dedupe native-Deno access into shared getNativeDeno() helper (#1986)

### DIFF
--- a/src/platform/adapters/runtime/deno/adapter.ts
+++ b/src/platform/adapters/runtime/deno/adapter.ts
@@ -28,7 +28,11 @@ import {
   enqueueWatchEvent,
 } from "../shared/watcher-queue.ts";
 import { stopManagedServer } from "../shared/server-lifecycle.ts";
-import { getNativeResponse, toNativeResponse } from "../../../compat/http/native-response.ts";
+import {
+  getNativeDeno,
+  getNativeResponse,
+  toNativeResponse,
+} from "../../../compat/http/native-response.ts";
 
 const logger = serverLogger.component("deno");
 
@@ -293,7 +297,7 @@ class DenoServerAdapter implements ServerAdapter {
   upgradeWebSocket(request: Request): WebSocketUpgrade {
     // Access native Deno via `self` to bypass dnt shim transform.
     // dnt rewrites `globalThis.Deno` to @deno/shim-deno, which lacks upgradeWebSocket.
-    const nativeDeno = (self as unknown as Record<string, typeof Deno>)["Deno"];
+    const nativeDeno = getNativeDeno();
     if (typeof nativeDeno?.upgradeWebSocket !== "function") {
       throw NOT_SUPPORTED.create({
         detail: "DenoServerAdapter.upgradeWebSocket() can only be used in Deno runtime",
@@ -408,7 +412,7 @@ export class DenoAdapter implements RuntimeAdapter {
     // Access native Deno.serve via `self` to bypass dnt shim transform.
     // dnt rewrites both `Deno.*` and `globalThis.*` to use @deno/shim-deno which lacks .serve.
     // `self` is not shimmed by dnt and equals `globalThis` in Deno.
-    const nativeDeno = (self as unknown as Record<string, typeof Deno>)["Deno"]!;
+    const nativeDeno = getNativeDeno()!;
 
     // Access native Response via `self` to bypass dnt shim transform.
     // In npm packages, dnt replaces Response with undici's polyfill,

--- a/src/platform/compat/http/deno-server.ts
+++ b/src/platform/compat/http/deno-server.ts
@@ -1,6 +1,6 @@
 import type { Handler, HttpServer, ServeOptions } from "./types.ts";
 import { LOCALHOST } from "../constants.ts";
-import { getNativeResponse, toNativeResponse } from "./native-response.ts";
+import { getNativeDeno, getNativeResponse, toNativeResponse } from "./native-response.ts";
 
 export class DenoHttpServer implements HttpServer {
   private abortController?: AbortController;
@@ -14,7 +14,7 @@ export class DenoHttpServer implements HttpServer {
     onListen?.({ hostname, port });
 
     // Access native Deno.serve via `self` to bypass dnt shim transform.
-    const nativeDeno = (self as unknown as Record<string, typeof Deno>)["Deno"]!;
+    const nativeDeno = getNativeDeno()!;
 
     // Access native Response via `self` to bypass dnt shim transform.
     // In npm packages, dnt replaces Response with undici's polyfill,

--- a/src/platform/compat/http/native-response.test.ts
+++ b/src/platform/compat/http/native-response.test.ts
@@ -1,0 +1,67 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assert, assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { getNativeDeno, getNativeResponse, toNativeResponse } from "./native-response.ts";
+
+describe("getNativeResponse", () => {
+  it("returns the native Response constructor", () => {
+    const NativeResponse = getNativeResponse();
+    // In Deno, `self` equals `globalThis`, so this is the real Response.
+    assertStrictEquals(NativeResponse, Response);
+  });
+
+  it("produces instances that are real Response objects", () => {
+    const NativeResponse = getNativeResponse();
+    const res = new NativeResponse("hello", { status: 201 });
+    assert(res instanceof Response);
+    assertEquals(res.status, 201);
+  });
+});
+
+describe("getNativeDeno", () => {
+  it("returns the native Deno namespace in the Deno runtime", () => {
+    const nativeDeno = getNativeDeno();
+    assertStrictEquals(nativeDeno, Deno);
+  });
+
+  it("exposes native APIs absent from the dnt shim", () => {
+    const nativeDeno = getNativeDeno();
+    assert(nativeDeno !== undefined);
+    assertEquals(typeof nativeDeno.serve, "function");
+    assertEquals(typeof nativeDeno.upgradeWebSocket, "function");
+  });
+});
+
+describe("toNativeResponse", () => {
+  it("returns the same instance when already a native Response", () => {
+    const NativeResponse = getNativeResponse();
+    const original = new NativeResponse("body", { status: 200 });
+    const result = toNativeResponse(original, NativeResponse);
+    assertStrictEquals(result, original);
+  });
+
+  it("re-wraps a non-native Response preserving status, statusText and headers", async () => {
+    const NativeResponse = getNativeResponse();
+    // Model the dnt scenario: the runtime `Response` is a *different* constructor
+    // than the native one, so the input fails `instanceof NativeResponse` and the
+    // re-wrap path runs. We simulate "native" with a distinct subclass.
+    class FakeNativeResponse extends Response {}
+    const polyfilled = new NativeResponse("payload", {
+      status: 202,
+      statusText: "Accepted",
+      headers: { "x-test": "1" },
+    });
+
+    const result = toNativeResponse(
+      polyfilled,
+      FakeNativeResponse as unknown as typeof Response,
+    );
+
+    // Re-wrapped into the supplied "native" constructor.
+    assert(result instanceof FakeNativeResponse);
+    assertEquals(result.status, 202);
+    assertEquals(result.statusText, "Accepted");
+    assertEquals(result.headers.get("x-test"), "1");
+    assertEquals(await result.text(), "payload");
+  });
+});

--- a/src/platform/compat/http/native-response.ts
+++ b/src/platform/compat/http/native-response.ts
@@ -22,6 +22,23 @@ export function getNativeResponse(): typeof Response {
 }
 
 /**
+ * The native `Deno` namespace, accessed via `self` to bypass the dnt shim
+ * transform.
+ *
+ * In npm packages, dnt rewrites both `Deno.*` and `globalThis.Deno` to use
+ * `@deno/shim-deno`, which lacks native APIs such as `Deno.serve` and
+ * `Deno.upgradeWebSocket`. `self` is not shimmed by dnt and equals
+ * `globalThis` in Deno, so it yields the genuine native namespace.
+ *
+ * Returns `undefined` when no native `Deno` is present (e.g. Node without the
+ * shim), allowing callers to guard. Callers that have already established the
+ * Deno runtime can use a non-null assertion on the result.
+ */
+export function getNativeDeno(): typeof Deno | undefined {
+  return (self as unknown as Record<string, typeof Deno | undefined>)["Deno"];
+}
+
+/**
  * Re-wrap a (possibly polyfilled) `Response` as a native `Response` so it can be
  * returned from `Deno.serve`.
  *

--- a/src/platform/compat/http/websocket.ts
+++ b/src/platform/compat/http/websocket.ts
@@ -1,5 +1,6 @@
 import { isDeno } from "../runtime.ts";
 import type { WebSocketUpgradeOptions, WebSocketUpgradeResult } from "./types.ts";
+import { getNativeDeno } from "./native-response.ts";
 import { NOT_SUPPORTED } from "#veryfront/errors";
 
 export function upgradeWebSocket(
@@ -26,7 +27,7 @@ function upgradeWebSocketDeno(
 ): WebSocketUpgradeResult {
   // Access native Deno via `self` to bypass dnt shim transform.
   // dnt rewrites `globalThis.Deno` to @deno/shim-deno, which lacks upgradeWebSocket.
-  const nativeDeno = (self as unknown as Record<string, typeof Deno>)["Deno"];
+  const nativeDeno = getNativeDeno();
   if (typeof nativeDeno?.upgradeWebSocket !== "function") {
     throw NOT_SUPPORTED.create({
       detail: "Deno.upgradeWebSocket() is not available in this runtime.",


### PR DESCRIPTION
## Description

Focused, behavior-preserving "safe wins only" pass for the platform/build/runtime tech-debt cluster (#1986).

On reading the issue, most of the listed findings have **already been resolved** in earlier PRs (see Skipped section). The one genuine remaining slice of the 🔴 high-value finding was the duplicated native-`Deno` access cast. This PR finishes that dedupe and adds the missing unit coverage for the shared helper module.

### Changes mapped to findings

- **🔴 #1 — Duplicated native-Deno/Response unwrap** (partial; remaining slice): The `Response` re-wrap was already extracted to `compat/http/native-response.ts` (`getNativeResponse`/`toNativeResponse`). The native-`Deno` access `(self as unknown as Record<string, typeof Deno>)["Deno"]` was still copy-pasted at **4 sites**. Extracted a single `getNativeDeno()` helper into the same shared module (no new layering: both `compat/http` and the Deno runtime adapter already import from it). Replaced all 4 casts. Non-null sites keep their `!`; guarded sites keep `| undefined` narrowing — identical behavior.
  - Sites: `compat/http/deno-server.ts`, `compat/http/websocket.ts`, `adapters/runtime/deno/adapter.ts` (x2).
- **Missing tests for complex/untested file**: Added `compat/http/native-response.test.ts` covering `getNativeResponse`, `getNativeDeno`, and `toNativeResponse` (including the polyfilled re-wrap path). The module previously had zero direct coverage. Pure addition.

### Skipped findings (already fixed or out-of-scope per "safe wins only")

- **🔴 #1 Response re-wrap** — already extracted to `native-response.ts` before this PR; nothing to do.
- **🟡 #8 `as unknown as Map` cache wrapper** — already fixed: `createCacheRegistryWrapper` returns `CacheStatsSource` and `registerMapCache` accepts `CacheStatsSource` (no cast remains).
- **🟡 #3 `@ts-ignore` cluster in `compat/fs.ts`** — already reduced from 13 to 1; the `denoGlobal()` accessor work is effectively done.
- **🟢 Intentional-ignore catch logging** — `proxy-manager.ts` already logs `logger.debug`; `compat/fs.ts` intentionally does NOT log (documented: module must stay importable without `--allow-env`, logger reads env at import) — adding a log would break that constraint; `lazy-sandbox.ts` has no logger wired and its comment states the error is already handled by the caller path, so logging risks double-reporting. Skipped to stay behavior-preserving.
- **🔴 #2 FS-adapter → `src/html` layering inversion** — structural/risky; explicitly out of scope.
- **🟡 #5 `node:` imports in compat**, **🟡 #4 regex TS stripper**, **🟡 god-file decomposition**, **🟡 #6 WebSocket placeholder types**, **🟡 deprecated `getAdapter`** — larger refactors / not self-contained behavior-preserving; out of scope.

### Verification

- `deno check` on all four touched `.ts` files: the files themselves type-check (`Check ...` printed for each). The only error surfaced is a **pre-existing, unrelated** `TS2352` in `compat/process/lifecycle.ts` (`Deno.unrefTimer(timerId as number)`), confirmed present on `main` with these changes stashed — not introduced here.
- New test: `deno test ... native-response.test.ts` → **3 passed (6 steps), 0 failed**.
- Existing `deno-server.test.ts` integration cases fail in this sandbox because they bind real network ports (also fail on base) — environmental, not caused by this change.

## Related Issue(s)

Part of #1986

## Type of Change

- [x] Code refactoring
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
