### PR TITLE
Fix provider-native web search streaming

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.640",
+  "version": "0.1.641",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -28,11 +28,16 @@ import { agent } from "veryfront/agent";
 
 export default agent({
   id: "researcher",
+  model: "veryfront-cloud/anthropic/claude-sonnet-4-6",
   system: "Research topics thoroughly using web search.",
-  tools: { webSearch: true },
+  allowedRemoteTools: ["web_search"],
   maxSteps: 5,
 });
 ```
+
+Provider-native web search uses the `web_search` tool name and requires a
+provider/model that supports it. Use `allowedRemoteTools` for provider-native
+tools. Use `tools` for local tools that your app defines.
 
 ```ts
 // agents/writer.ts

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -984,6 +984,116 @@ describe("chat-stream-handler", () => {
       }]);
     });
 
+    it("marks configured provider-native tool calls as provider-executed when the provider omits the flag", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        {
+          type: "tool-call",
+          toolCallId: "tc-provider-inferred",
+          toolName: "web_search",
+          input: { query: "Veryfront" },
+        },
+        { type: "finish", finishReason: "tool-calls", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "t", {
+        providerExecutedToolNames: ["web_search"],
+      });
+
+      const tc = state.toolCalls.get("tc-provider-inferred")!;
+      assertEquals(tc.providerExecuted, true);
+      assertEquals(events, [{
+        type: "tool-input-start",
+        toolCallId: "tc-provider-inferred",
+        toolName: "web_search",
+      }, {
+        type: "tool-input-available",
+        toolCallId: "tc-provider-inferred",
+        toolName: "web_search",
+        input: { query: "Veryfront" },
+        providerExecuted: true,
+      }]);
+    });
+
+    it("does not infer provider execution for same-name local tools without provider metadata", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        {
+          type: "tool-call",
+          toolCallId: "tc-local-web-search",
+          toolName: "web_search",
+          input: { query: "Veryfront" },
+        },
+        { type: "finish", finishReason: "tool-calls", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      const tc = state.toolCalls.get("tc-local-web-search")!;
+      assertEquals(tc.providerExecuted, undefined);
+      assertEquals(events, [{
+        type: "tool-input-start",
+        toolCallId: "tc-local-web-search",
+        toolName: "web_search",
+      }, {
+        type: "tool-input-available",
+        toolCallId: "tc-local-web-search",
+        toolName: "web_search",
+        input: { query: "Veryfront" },
+      }]);
+    });
+
+    it("marks configured provider-native tool results as provider-executed when the provider omits the flag", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        {
+          type: "tool-result",
+          toolCallId: "tc-provider-result-inferred",
+          toolName: "web_search",
+          input: { query: "Veryfront" },
+          output: { results: [{ title: "Veryfront" }] },
+        },
+        { type: "finish", finishReason: "stop", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "t", {
+        providerExecutedToolNames: ["web_search"],
+      });
+
+      assertEquals(state.toolResults, [{
+        toolCallId: "tc-provider-result-inferred",
+        toolName: "web_search",
+        output: { results: [{ title: "Veryfront" }] },
+        providerExecuted: true,
+      }]);
+      assertEquals(events, [
+        {
+          type: "tool-input-start",
+          toolCallId: "tc-provider-result-inferred",
+          toolName: "web_search",
+        },
+        {
+          type: "tool-input-available",
+          toolCallId: "tc-provider-result-inferred",
+          toolName: "web_search",
+          input: { query: "Veryfront" },
+          providerExecuted: true,
+        },
+        {
+          type: "tool-output-available",
+          toolCallId: "tc-provider-result-inferred",
+          output: { results: [{ title: "Veryfront" }] },
+          providerExecuted: true,
+        },
+      ]);
+    });
+
     it("handles multiple tool calls in a single stream", async () => {
       const { events, controller, encoder } = createSSECollector();
       const state = createStreamState();

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -65,6 +65,7 @@ export interface ChatStreamCallbacks {
     completionTokens?: number;
     totalTokens?: number;
   }) => void;
+  providerExecutedToolNames?: readonly string[];
   localToolInputIdleTimeoutMs?: number;
   streamIdleTimeoutMs?: number;
 }
@@ -286,6 +287,10 @@ export function processStream(
     let activeReasoningId: string | null = null;
     let shouldStopForCommittedLocalToolCall = false;
     let hasActiveLocalToolInput = false;
+    const providerExecutedToolNames = new Set(callbacks?.providerExecutedToolNames ?? []);
+
+    const resolveProviderExecuted = (toolName: string, providerExecuted?: boolean) =>
+      providerExecuted ?? (providerExecutedToolNames.has(toolName) ? true : undefined);
 
     const normalizeReasoningId = (part: { id?: string }) =>
       typeof part.id === "string" && part.id.length > 0 ? part.id : "reasoning";
@@ -414,6 +419,7 @@ export function processStream(
       dynamic?: boolean;
     }) => {
       const dynamic = part.dynamic ?? isDynamicTool(part.toolName);
+      const providerExecuted = resolveProviderExecuted(part.toolName, part.providerExecuted);
       const existing = state.toolCalls.get(part.toolCallId);
 
       if (!existing) {
@@ -423,9 +429,7 @@ export function processStream(
           name: part.toolName,
           arguments: normalizeToolInputString(part.input),
           inputAvailable: true,
-          ...(part.providerExecuted !== undefined
-            ? { providerExecuted: part.providerExecuted }
-            : {}),
+          ...(providerExecuted !== undefined ? { providerExecuted } : {}),
           ...(dynamic ? { dynamic: true } : {}),
           inputAnnounced: true,
         });
@@ -440,9 +444,7 @@ export function processStream(
           toolCallId: part.toolCallId,
           toolName: part.toolName,
           input: normalizedInput,
-          ...(part.providerExecuted !== undefined
-            ? { providerExecuted: part.providerExecuted }
-            : {}),
+          ...(providerExecuted !== undefined ? { providerExecuted } : {}),
           ...(dynamic ? { dynamic: true } : {}),
         });
         return;
@@ -458,8 +460,8 @@ export function processStream(
       const resolvedInput = parseToolInputObject(resolvedArguments);
       existing.arguments = resolvedArguments;
       existing.inputAvailable = true;
-      if (part.providerExecuted !== undefined) {
-        existing.providerExecuted = part.providerExecuted;
+      if (providerExecuted !== undefined) {
+        existing.providerExecuted = providerExecuted;
       }
       if (dynamic) {
         existing.dynamic = true;
@@ -584,14 +586,18 @@ export function processStream(
           closeTextSegment();
           closeReasoningSegment();
           shouldStopForCommittedLocalToolCall = false;
-          hasActiveLocalToolInput = true;
           const toolId = typedPart.id;
+          const providerExecuted = resolveProviderExecuted(
+            typedPart.toolName,
+            typedPart.providerExecuted,
+          );
+          hasActiveLocalToolInput = providerExecuted !== true;
           state.toolCalls.set(toolId, {
             id: toolId,
             name: typedPart.toolName,
             arguments: "",
             inputAvailable: false,
-            providerExecuted: typedPart.providerExecuted,
+            providerExecuted,
             dynamic: typedPart.dynamic,
             inputDeltas: [],
             inputAnnounced: false,
@@ -646,6 +652,10 @@ export function processStream(
           if (!toolId) {
             break;
           }
+          const providerExecuted = resolveProviderExecuted(
+            typedPart.toolName,
+            typedPart.providerExecuted,
+          );
           hasActiveLocalToolInput = false;
           const inputStr = normalizeToolInputString(typedPart.input);
           const previous = state.toolCalls.get(toolId);
@@ -658,7 +668,7 @@ export function processStream(
             name: typedPart.toolName,
             arguments: resolvedArguments,
             inputAvailable: true,
-            providerExecuted: typedPart.providerExecuted,
+            providerExecuted,
             dynamic,
           });
 
@@ -668,13 +678,11 @@ export function processStream(
               toolCallId: toolId,
               toolName: typedPart.toolName,
               input: parseToolInputObject(resolvedArguments),
-              ...(typedPart.providerExecuted !== undefined
-                ? { providerExecuted: typedPart.providerExecuted }
-                : {}),
+              ...(providerExecuted !== undefined ? { providerExecuted } : {}),
               ...(dynamic ? { dynamic: true } : {}),
             });
           }
-          if (typedPart.providerExecuted !== true) {
+          if (providerExecuted !== true) {
             shouldStopForCommittedLocalToolCall = true;
           }
           break;
@@ -685,6 +693,10 @@ export function processStream(
           closeReasoningSegment();
           // tool-call fires when the full tool call is available
           const toolId = typedPart.toolCallId;
+          const providerExecuted = resolveProviderExecuted(
+            typedPart.toolName,
+            typedPart.providerExecuted,
+          );
           hasActiveLocalToolInput = false;
           const inputStr = normalizeToolInputString(typedPart.input);
           const previous = state.toolCalls.get(toolId);
@@ -698,7 +710,7 @@ export function processStream(
             inputDeltas: previous?.inputDeltas ?? [],
             inputAnnounced: previous?.inputAnnounced ?? false,
             inputAvailable: true,
-            providerExecuted: typedPart.providerExecuted,
+            providerExecuted,
             dynamic: typedPart.dynamic,
           };
           state.toolCalls.set(toolId, toolCall);
@@ -712,13 +724,11 @@ export function processStream(
               toolCallId: toolId,
               toolName: typedPart.toolName,
               input: inputObj,
-              ...(typedPart.providerExecuted !== undefined
-                ? { providerExecuted: typedPart.providerExecuted }
-                : {}),
+              ...(providerExecuted !== undefined ? { providerExecuted } : {}),
               ...(dynamic ? { dynamic: true } : {}),
             });
           }
-          if (typedPart.providerExecuted !== true) {
+          if (providerExecuted !== true) {
             shouldStopForCommittedLocalToolCall = true;
           }
           break;
@@ -727,18 +737,22 @@ export function processStream(
         case "tool-result": {
           closeTextSegment();
           closeReasoningSegment();
+          const providerExecuted = resolveProviderExecuted(
+            typedPart.toolName,
+            typedPart.providerExecuted,
+          );
           ensureToolLifecycle({
             toolCallId: typedPart.toolCallId,
             toolName: typedPart.toolName,
             input: typedPart.input,
-            providerExecuted: typedPart.providerExecuted,
+            providerExecuted,
             dynamic: typedPart.dynamic,
           });
           const isError = typedPart.isError === true;
           logProviderToolPart("tool-result", {
             toolCallId: typedPart.toolCallId,
             toolName: typedPart.toolName,
-            providerExecuted: typedPart.providerExecuted,
+            providerExecuted,
             dynamic: typedPart.dynamic,
             output: typedPart.output,
             input: typedPart.input,
@@ -750,18 +764,14 @@ export function processStream(
               toolCallId: typedPart.toolCallId,
               toolName: typedPart.toolName,
               error: typedPart.output,
-              ...(typedPart.providerExecuted !== undefined
-                ? { providerExecuted: typedPart.providerExecuted }
-                : {}),
+              ...(providerExecuted !== undefined ? { providerExecuted } : {}),
               ...(typedPart.dynamic ? { dynamic: true } : {}),
             });
             sendSSE(controller, encoder, {
               type: "tool-output-error",
               toolCallId: typedPart.toolCallId,
               errorText: stringifyToolError(typedPart.output),
-              ...(typedPart.providerExecuted !== undefined
-                ? { providerExecuted: typedPart.providerExecuted }
-                : {}),
+              ...(providerExecuted !== undefined ? { providerExecuted } : {}),
               ...(typedPart.dynamic ? { dynamic: true } : {}),
             });
             break;
@@ -771,9 +781,7 @@ export function processStream(
             toolCallId: typedPart.toolCallId,
             toolName: typedPart.toolName,
             output: typedPart.output,
-            ...(typedPart.providerExecuted !== undefined
-              ? { providerExecuted: typedPart.providerExecuted }
-              : {}),
+            ...(providerExecuted !== undefined ? { providerExecuted } : {}),
             ...(typedPart.dynamic ? { dynamic: true } : {}),
             ...(typedPart.preliminary !== undefined ? { preliminary: typedPart.preliminary } : {}),
           });
@@ -781,9 +789,7 @@ export function processStream(
             type: "tool-output-available",
             toolCallId: typedPart.toolCallId,
             output: typedPart.output,
-            ...(typedPart.providerExecuted !== undefined
-              ? { providerExecuted: typedPart.providerExecuted }
-              : {}),
+            ...(providerExecuted !== undefined ? { providerExecuted } : {}),
             ...(typedPart.dynamic ? { dynamic: true } : {}),
             ...(typedPart.preliminary !== undefined ? { preliminary: typedPart.preliminary } : {}),
           });
@@ -793,17 +799,21 @@ export function processStream(
         case "tool-error": {
           closeTextSegment();
           closeReasoningSegment();
+          const providerExecuted = resolveProviderExecuted(
+            typedPart.toolName,
+            typedPart.providerExecuted,
+          );
           ensureToolLifecycle({
             toolCallId: typedPart.toolCallId,
             toolName: typedPart.toolName,
             input: typedPart.input,
-            providerExecuted: typedPart.providerExecuted,
+            providerExecuted,
             dynamic: typedPart.dynamic,
           });
           logProviderToolPart("tool-error", {
             toolCallId: typedPart.toolCallId,
             toolName: typedPart.toolName,
-            providerExecuted: typedPart.providerExecuted,
+            providerExecuted,
             dynamic: typedPart.dynamic,
             error: typedPart.error,
             input: typedPart.input,
@@ -812,18 +822,14 @@ export function processStream(
             toolCallId: typedPart.toolCallId,
             toolName: typedPart.toolName,
             error: typedPart.error,
-            ...(typedPart.providerExecuted !== undefined
-              ? { providerExecuted: typedPart.providerExecuted }
-              : {}),
+            ...(providerExecuted !== undefined ? { providerExecuted } : {}),
             ...(typedPart.dynamic ? { dynamic: true } : {}),
           });
           sendSSE(controller, encoder, {
             type: "tool-output-error",
             toolCallId: typedPart.toolCallId,
             errorText: stringifyToolError(typedPart.error),
-            ...(typedPart.providerExecuted !== undefined
-              ? { providerExecuted: typedPart.providerExecuted }
-              : {}),
+            ...(providerExecuted !== undefined ? { providerExecuted } : {}),
             ...(typedPart.dynamic ? { dynamic: true } : {}),
           });
           break;

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -52,6 +52,7 @@ import { tryGetCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
 import type { ToolDefinition, ToolExecutionContext } from "#veryfront/tool";
 import { isLocalModelRuntime } from "#veryfront/provider/runtime-inspection.ts";
 import { generateText, streamText } from "#veryfront/runtime/runtime-bridge.ts";
+import type { RuntimeToolSet } from "./runtime-tool-types.ts";
 
 // Re-export from submodules
 export { closeSSEStream, generateMessageId, sendSSE } from "./sse-utils.ts";
@@ -196,6 +197,25 @@ function createToolErrorMessage(toolCallId: string, toolName: string, error: str
     ],
     timestamp: Date.now(),
   };
+}
+
+function getProviderExecutedToolNames(runtimeTools: RuntimeToolSet | undefined): string[] {
+  if (!runtimeTools) {
+    return [];
+  }
+
+  return Object.entries(runtimeTools).flatMap(([toolName, definition]) => {
+    if (
+      definition &&
+      typeof definition === "object" &&
+      "type" in definition &&
+      definition.type === "provider"
+    ) {
+      return [toolName];
+    }
+
+    return [];
+  });
 }
 
 export function collectFinalStreamToolResults(
@@ -1255,14 +1275,16 @@ export class AgentRuntime {
         currentRunToolState,
       );
 
+      const runtimeTools = convertToolsToRuntimeTools(tools, {
+        model: effectiveModel,
+        allowedToolNames: allowedRemoteToolNames,
+      });
+
       const result = streamText({
         model: languageModel,
         system: modelSystemPrompt,
         messages: convertToTextGenerationRuntimeMessages(currentMessages),
-        tools: convertToolsToRuntimeTools(tools, {
-          model: effectiveModel,
-          allowedToolNames: allowedRemoteToolNames,
-        }),
+        tools: runtimeTools,
         experimental_repairToolCall: repairToolCall,
         maxOutputTokens: this.resolveMaxOutputTokens(effectiveModel, maxOutputTokensOverride),
         temperature: DEFAULT_TEMPERATURE,
@@ -1275,6 +1297,7 @@ export class AgentRuntime {
       await processStream(result, state, controller, encoder, textPartId, {
         onChunk: callbacks?.onChunk,
         onUsage: (usage) => accumulateUsage(totalUsage, usage),
+        providerExecutedToolNames: getProviderExecutedToolNames(runtimeTools),
       }, abortSignal);
       throwIfAborted(abortSignal);
       finalFinishReason = state.finishReason ?? finalFinishReason;
@@ -1443,6 +1466,12 @@ export class AgentRuntime {
           toolCall.status = persistedError === undefined ? "completed" : "error";
           toolCall.result = persistedResult.result;
           toolCall.error = persistedError;
+          toolCalls.push(toolCall);
+          continue;
+        }
+
+        if (tc.providerExecuted === true) {
+          toolCall.status = "completed";
           toolCalls.push(toolCall);
           continue;
         }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.640";
+export const VERSION = "0.1.641";


### PR DESCRIPTION
## Summary
- keep configured provider-native tool calls marked as provider-executed when streamed provider chunks omit that flag
- skip local tool execution for completed provider-native tool calls, preventing web_search from falling through to the local registry
- update multi-agent docs to use allowedRemoteTools: ["web_search"] instead of a local webSearch tool reference
- bump veryfront to 0.1.641 for release

## Verification
- deno fmt --check docs/guides/multi-agent.md src/agent/runtime/chat-stream-handler.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/index.ts deno.json src/utils/version-constant.ts
- deno check src/agent/runtime/index.ts src/agent/runtime/chat-stream-handler.ts
- deno test --no-check --allow-all src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/index.test.ts src/runtime/runtime-bridge.test.ts src/agent/runtime/model-tool-converter.test.ts src/agent/runtime/provider-native-tool-inventory.test.ts
- deno task build:npm
- pre-push full test suite: 1968 passed, 0 failed