### PR TITLE
fix(agent): remove input character limit from security middleware

### DIFF
--- a/docs/api-reference/veryfront/agent.md
+++ b/docs/api-reference/veryfront/agent.md
@@ -153,7 +153,6 @@ Agent helper.
 | `skills?` | `true \| string[]` | Enable skills for this agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L150) |
 | `suggestions?` | `Suggestions` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L151) |
 | `security?` | `false` | Set to false to disable the default security middleware | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L153) |
-| `inputMaxCharacterLimit?` | `number` | Maximum input character length enforced by the default security middleware. The middleware JSON-stringifies the agent input (latest user message plus any conversation history and structured tool results carried with it) and rejects anything longer. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/types.ts#L162) |
 
 **Returns:** `Agent`
 

--- a/src/agent/factory-security-middleware.test.ts
+++ b/src/agent/factory-security-middleware.test.ts
@@ -126,35 +126,15 @@ describe("resolveSecurityMiddleware", () => {
     assertEquals(result.text, "It is sunny.");
   });
 
-  it("enforces the default 100k input character limit", async () => {
+  it("does not enforce any input character limit", async () => {
     const middleware = resolveSecurityMiddleware({});
     const securityFn = middleware[0]!;
 
     const context: AgentContext = {
       agentId: "test",
       model: "test/model",
-      input: "x".repeat(100_001),
-      data: {},
-      platform: "deno",
-    };
-
-    let error: Error | undefined;
-    try {
-      await securityFn(context, async () => createAgentResponse({ text: "ok" }));
-    } catch (err) {
-      error = err as Error;
-    }
-    assertEquals(error?.message.includes("maximum length of 100000"), true);
-  });
-
-  it("honours per-agent inputMaxCharacterLimit override", async () => {
-    const middleware = resolveSecurityMiddleware({ inputMaxCharacterLimit: 200_000 });
-    const securityFn = middleware[0]!;
-
-    const context: AgentContext = {
-      agentId: "test",
-      model: "test/model",
-      input: "x".repeat(150_000),
+      // Far larger than the former 100k default — must pass through untouched.
+      input: "x".repeat(500_000),
       data: {},
       platform: "deno",
     };
@@ -165,57 +145,6 @@ describe("resolveSecurityMiddleware", () => {
     );
     assertEquals(result.text, "ok");
   });
-
-  it("rejects input above per-agent inputMaxCharacterLimit", async () => {
-    const middleware = resolveSecurityMiddleware({ inputMaxCharacterLimit: 25_000 });
-    const securityFn = middleware[0]!;
-
-    const context: AgentContext = {
-      agentId: "test",
-      model: "test/model",
-      input: "x".repeat(25_001),
-      data: {},
-      platform: "deno",
-    };
-
-    let error: Error | undefined;
-    try {
-      await securityFn(context, async () => createAgentResponse({ text: "ok" }));
-    } catch (err) {
-      error = err as Error;
-    }
-    assertEquals(error?.message.includes("maximum length of 25000"), true);
-  });
-
-  for (
-    const [label, value] of [
-      ["NaN", Number.NaN],
-      ["Infinity", Number.POSITIVE_INFINITY],
-      ["zero", 0],
-      ["negative", -1],
-    ] as const
-  ) {
-    it(`falls back to the default when inputMaxCharacterLimit is ${label}`, async () => {
-      const middleware = resolveSecurityMiddleware({ inputMaxCharacterLimit: value });
-      const securityFn = middleware[0]!;
-
-      const context: AgentContext = {
-        agentId: "test",
-        model: "test/model",
-        input: "x".repeat(100_001),
-        data: {},
-        platform: "deno",
-      };
-
-      let error: Error | undefined;
-      try {
-        await securityFn(context, async () => createAgentResponse({ text: "ok" }));
-      } catch (err) {
-        error = err as Error;
-      }
-      assertEquals(error?.message.includes("maximum length of 100000"), true);
-    });
-  }
 
   it("security middleware filters PII from output", async () => {
     const middleware = resolveSecurityMiddleware({});

--- a/src/agent/factory.ts
+++ b/src/agent/factory.ts
@@ -275,44 +275,21 @@ if (!("__vfAgentFactory" in globalThis)) {
 }
 
 /**
- * Default maximum agent input character length used by the built-in
- * security middleware when the agent does not set `inputMaxCharacterLimit`.
- */
-export const DEFAULT_AGENT_INPUT_MAX_CHARACTER_LIMIT = 100_000;
-
-/**
- * Resolve `inputMaxCharacterLimit` to a usable positive integer. Guards
- * against `NaN`, `Infinity`, and non-positive values that would otherwise
- * silently disable the input length check inside `InputValidator`
- * (it compares with `input.length > maxLength`, which is always false for
- * `NaN`/`Infinity`). Invalid overrides fall back to the default and emit a
- * warning so misconfiguration is visible.
- */
-function resolveInputMaxCharacterLimit(override: number | undefined): number {
-  if (override == null) return DEFAULT_AGENT_INPUT_MAX_CHARACTER_LIMIT;
-  if (!Number.isFinite(override) || override <= 0) {
-    agentLogger.warn(
-      `Ignoring invalid inputMaxCharacterLimit=${String(override)}; ` +
-        `falling back to default ${DEFAULT_AGENT_INPUT_MAX_CHARACTER_LIMIT}. ` +
-        `Expected a finite positive number.`,
-    );
-    return DEFAULT_AGENT_INPUT_MAX_CHARACTER_LIMIT;
-  }
-  return override;
-}
-
-/**
  * Resolve the middleware array for an agent, prepending security middleware
  * unless explicitly opted out with `security: false`.
+ *
+ * The security middleware does not impose any input character limit: agent
+ * input (latest user message plus conversation history and structured tool
+ * results) can be arbitrarily large. Prompt-injection pattern blocking and
+ * output PII filtering still apply.
  */
 export function resolveSecurityMiddleware(
-  config: Pick<AgentConfig, "security" | "middleware" | "inputMaxCharacterLimit">,
+  config: Pick<AgentConfig, "security" | "middleware">,
 ): AgentMiddleware[] {
   if (config.security === false) return config.middleware ?? [];
   return [
     securityMiddleware({
       input: {
-        maxLength: resolveInputMaxCharacterLimit(config.inputMaxCharacterLimit),
         blockedPatterns: COMMON_BLOCKED_PATTERNS.promptInjection,
       },
       output: {

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -151,15 +151,6 @@ export interface AgentConfig {
   suggestions?: Suggestions;
   /** Set to false to disable the default security middleware */
   security?: false;
-  /**
-   * Maximum input character length enforced by the default security
-   * middleware. The middleware JSON-stringifies the agent input (latest
-   * user message plus any conversation history and structured tool
-   * results carried with it) and rejects anything longer.
-   *
-   * Defaults to 100_000. Ignored when `security: false`.
-   */
-  inputMaxCharacterLimit?: number;
 }
 
 /** Configuration used by resolved agent. */


### PR DESCRIPTION
## Description

The default agent security middleware enforced a **100,000-character cap** on input (configurable via `inputMaxCharacterLimit`, default `100_000`). The middleware JSON-stringifies the *entire* agent input — the latest user message **plus conversation history and structured tool results** — so longer chats accumulate past the cap. When that happens the middleware **throws** (`Input exceeds maximum length of 100000`), which surfaces in the frontend chat as an error and prevents the conversation from continuing.

This removes the input character limit entirely — agent input is now unbounded.

### Changes
- **`src/agent/types.ts`** — remove the `inputMaxCharacterLimit?` field from `AgentConfig`.
- **`src/agent/factory.ts`** — remove `DEFAULT_AGENT_INPUT_MAX_CHARACTER_LIMIT` and the `resolveInputMaxCharacterLimit` resolver; stop passing `maxLength` to the security middleware (drop it from the `resolveSecurityMiddleware` `Pick`).
- **`src/agent/factory-security-middleware.test.ts`** — replace the four limit/override/fallback tests with a regression test asserting a 500k-char input passes through untouched.
- **`docs/api-reference/veryfront/agent.md`** — drop the `inputMaxCharacterLimit` row.

The `InputValidator` already treats `maxLength` as optional and **skips the length check when it is absent** (`src/agent/middleware/security/validator.ts:122`), so no validator change is needed. **Prompt-injection pattern blocking and output PII filtering are unchanged.**

## Related Issue(s)

Fixes the "frontend chat errors and cannot continue" report on large/long conversations.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

> **Note:** Technically API-breaking — the public `inputMaxCharacterLimit` agent-config option and the exported `DEFAULT_AGENT_INPUT_MAX_CHARACTER_LIMIT` constant are removed. Any agent setting `inputMaxCharacterLimit` will now fail typecheck and should drop the option.

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Verification
- `deno lint` clean on touched files; `deno check` shows only pre-existing baseline errors in untouched files (`react/react.ts`, `compat/process/lifecycle.ts`) — CI typecheck is authoritative and green.
- `deno test src/agent/factory-security-middleware.test.ts` → **1 passed (12 steps), 0 failed**, including the new "does not enforce any input character limit" case.

## Security note
This intentionally removes a DoS/unbounded-input guard on agent input. Prompt-injection blocking and PII output filtering remain in place; if a bound is ever wanted again it should live at the transport/request layer rather than silently throwing mid-conversation.