### PR TITLE
Prevent provider-native tool history from replaying as local calls

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.641",
+  "version": "0.1.642",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/index.test.ts
+++ b/src/agent/runtime/index.test.ts
@@ -403,6 +403,28 @@ describe("agent runtime streamed tool result collection", () => {
     assertEquals(shouldContinue, true);
   });
 
+  it("does not recover provider-executed placeholders by re-calling the model", () => {
+    const shouldContinue = shouldContinueAfterStreamStep({
+      accumulatedText: "",
+      finishReason: "tool-calls",
+      toolCalls: new Map([
+        [
+          "toolu_provider_placeholder",
+          {
+            id: "toolu_provider_placeholder",
+            name: "web_search",
+            arguments: "{}",
+            inputAvailable: false,
+            providerExecuted: true,
+          },
+        ],
+      ]),
+      toolResults: [],
+    });
+
+    assertEquals(shouldContinue, false);
+  });
+
   it("materializes a complete streamed tool call into a ready-to-execute part", () => {
     const materialized = materializeStreamedToolCall({
       id: "toolu_complete",
@@ -424,6 +446,22 @@ describe("agent runtime streamed tool result collection", () => {
     assertEquals(
       (materialized.part as { inputText?: string }).inputText,
       '{"path":"/plans/report.md","content":"# Summary"}',
+    );
+  });
+
+  it("marks provider-executed streamed tool calls as provider-owned history", () => {
+    const materialized = materializeStreamedToolCall({
+      id: "toolu_provider",
+      name: "web_search",
+      arguments: '{"query":"Swedish tax residency"}',
+      inputAvailable: true,
+      providerExecuted: true,
+    });
+
+    assertEquals(materialized.kind, "complete");
+    assertEquals(
+      (materialized.part as { providerExecuted?: boolean }).providerExecuted,
+      true,
     );
   });
 

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -280,6 +280,9 @@ export function shouldContinueAfterStreamStep(
   const hasFinalizedClientToolCall = streamedToolCalls.some((toolCall) =>
     toolCall.inputAvailable === true && toolCall.providerExecuted !== true
   );
+  const hasProviderExecutedToolCall = streamedToolCalls.some((toolCall) =>
+    toolCall.providerExecuted === true
+  );
   // A non-finalized call whose only accumulated arguments are a bare
   // empty-object placeholder is provisional streamed input the model never
   // committed. We can recover by re-calling the model, so it must not block
@@ -295,6 +298,9 @@ export function shouldContinueAfterStreamStep(
 
   if (state.finishReason === "tool-calls") {
     if (hasIncompleteDeadToolCall) {
+      return false;
+    }
+    if (hasProviderExecutedToolCall && !hasFinalizedClientToolCall) {
       return false;
     }
     // Recover provisional placeholders by re-calling the model even when no
@@ -435,12 +441,16 @@ export type StreamedToolCallMaterialization =
 export function materializeStreamedToolCall(
   tc: StreamingToolCall,
 ): StreamedToolCallMaterialization {
-  const basePart: MessagePart = {
+  const providerExecutedPart: { providerExecuted?: true } = tc.providerExecuted === true
+    ? { providerExecuted: true }
+    : {};
+  const basePart: MessagePart & { providerExecuted?: true } = {
     type: `tool-${tc.name}`,
     toolCallId: tc.id,
     toolName: tc.name,
     args: {},
     ...(tc.arguments.length > 0 ? { inputText: tc.arguments } : {}),
+    ...providerExecutedPart,
   };
 
   if (isStreamedToolCallIncomplete(tc)) {
@@ -453,12 +463,13 @@ export function materializeStreamedToolCall(
   }
 
   const capturedInput = captureStreamedToolCallInput(tc);
-  const part: MessagePart = {
+  const part: MessagePart & { providerExecuted?: true } = {
     type: `tool-${tc.name}`,
     toolCallId: tc.id,
     toolName: tc.name,
     args: capturedInput.args,
     ...(capturedInput.inputText ? { inputText: capturedInput.inputText } : {}),
+    ...providerExecutedPart,
   };
 
   if (capturedInput.parseError) {

--- a/src/agent/runtime/text-generation-runtime-message-converter.test.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.test.ts
@@ -286,6 +286,30 @@ describe("text-generation-runtime-message-converter", () => {
       const firstPart = content[0];
       assertEquals(firstPart?.type, "text");
     });
+
+    it("skips provider-executed tool-call parts in assistant messages", () => {
+      const msg = {
+        id: "a-provider-tool",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-web_search",
+            toolCallId: "toolu_search",
+            toolName: "web_search",
+            args: { query: "Swedish tax residency" },
+            providerExecuted: true,
+          },
+          { type: "text", text: "The answer cites Skatteverket." },
+        ],
+      } as unknown as Message;
+
+      const result = convertToTextGenerationRuntimeMessage(msg);
+
+      assertEquals(result.role, "assistant");
+      assertEquals((result as TextGenerationRuntimeAssistantMessage).content, [
+        { type: "text", text: "The answer cites Skatteverket." },
+      ]);
+    });
   });
 
   describe("convertToTextGenerationRuntimeMessages", () => {
@@ -321,6 +345,29 @@ describe("text-generation-runtime-message-converter", () => {
 
       assertEquals(convertToTextGenerationRuntimeMessages(messages), [
         { role: "user", content: "list my repos" },
+        { role: "user", content: "try again" },
+      ]);
+    });
+
+    it("omits provider-executed tool-only assistant messages from replay", () => {
+      const messages = [
+        { id: "u1", role: "user", parts: [{ type: "text", text: "search tax guidance" }] },
+        {
+          id: "a1",
+          role: "assistant",
+          parts: [{
+            type: "tool-web_search",
+            toolCallId: "toolu_search",
+            toolName: "web_search",
+            args: { query: "site:skatteverket.se tax residency" },
+            providerExecuted: true,
+          }],
+        },
+        { id: "u2", role: "user", parts: [{ type: "text", text: "try again" }] },
+      ] as unknown as Message[];
+
+      assertEquals(convertToTextGenerationRuntimeMessages(messages), [
+        { role: "user", content: "search tax guidance" },
         { role: "user", content: "try again" },
       ]);
     });

--- a/src/agent/runtime/text-generation-runtime-message-converter.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.ts
@@ -47,6 +47,10 @@ function hasOwnField(part: Record<string, unknown>, key: string): boolean {
   return Object.hasOwn(part, key);
 }
 
+function isProviderExecutedToolPart(part: Record<string, unknown>): boolean {
+  return part.providerExecuted === true;
+}
+
 function getToolInputRecord(part: Record<string, unknown>): Record<string, unknown> {
   return getRecordPartField(part, "args") ?? getRecordPartField(part, "input") ?? {};
 }
@@ -63,6 +67,9 @@ function getTextGenerationToolCallPart(
     part.type !== "tool-call" &&
     !(part.type.startsWith("tool-") && part.type !== "tool-result")
   ) {
+    return null;
+  }
+  if (isProviderExecutedToolPart(part)) {
     return null;
   }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.641";
+export const VERSION = "0.1.642";


### PR DESCRIPTION
## Summary
- Mark provider-executed streamed tool calls as provider-owned persisted history
- Stop retrying provider-owned placeholder tool calls as if they were incomplete local tool calls
- Omit provider-owned tool-call parts from provider request replay so Anthropic does not receive orphaned `tool_use` blocks
- Bump the package version to 0.1.642

## Why
The Swedish Tax Adviser example can use Anthropic provider-native `web_search`. The first stream correctly shows the provider-native tool, but a follow-up request can replay that `tool_use` as a local client tool call without an adjacent `tool_result`. Anthropic then rejects the request with `messages.N: tool_use ids were found without tool_result blocks immediately after`.

Provider-native tool calls are provider-internal. Veryfront should show them in the UI and persist trace history, but it must not replay them as local executable tool calls.

## Verification
- `deno fmt --check src/agent/runtime/index.ts src/agent/runtime/index.test.ts src/agent/runtime/text-generation-runtime-message-converter.ts src/agent/runtime/text-generation-runtime-message-converter.test.ts deno.json src/utils/version-constant.ts`
- `deno check src/agent/runtime/index.ts src/agent/runtime/text-generation-runtime-message-converter.ts`
- `deno test --no-check --allow-all src/agent/runtime/index.test.ts src/agent/runtime/text-generation-runtime-message-converter.test.ts src/agent/runtime/chat-stream-handler.test.ts src/runtime/runtime-bridge.test.ts src/agent/runtime/model-tool-converter.test.ts src/agent/runtime/provider-native-tool-inventory.test.ts`
- Pre-push hook: formatting, lint, type check, generated assets, and unit suite passed: 1,968 tests, 17,992 steps, 0 failed
- `deno task build:npm`
