### PR TITLE
Prevent provider-native tool results from replaying

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.642",
+  "version": "0.1.643",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -167,6 +167,7 @@ function createToolResultMessage(
   toolCallId: string,
   toolName: string,
   result: unknown,
+  providerExecuted = false,
 ): Message {
   return {
     id: `tool_${toolCallId}`,
@@ -177,6 +178,7 @@ function createToolResultMessage(
         toolCallId,
         toolName,
         result,
+        ...(providerExecuted ? { providerExecuted: true } : {}),
       },
     ],
     timestamp: Date.now(),
@@ -1023,6 +1025,7 @@ export class AgentRuntime {
             generatedToolResult.isError === true
               ? { error: stringifyToolError(generatedToolResult.result) }
               : generatedToolResult.result,
+            generatedToolResult.providerExecuted === true,
           );
           currentMessages.push(toolResultMessage);
           await this.memory.add(toolResultMessage);
@@ -1381,6 +1384,7 @@ export class AgentRuntime {
           toolResult.error === undefined
             ? toolResult.output
             : { error: stringifyToolError(toolResult.error) },
+          toolResult.providerExecuted === true,
         );
         currentMessages.push(toolResultMessage);
         await this.memory.add(toolResultMessage);

--- a/src/agent/runtime/runtime-tool-types.ts
+++ b/src/agent/runtime/runtime-tool-types.ts
@@ -20,6 +20,7 @@ export interface RuntimeGenerateToolResult {
   toolName: string;
   result: unknown;
   isError?: boolean;
+  providerExecuted?: boolean;
 }
 
 export interface RuntimeGenerateUsage {

--- a/src/agent/runtime/text-generation-runtime-message-converter.test.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.test.ts
@@ -372,6 +372,137 @@ describe("text-generation-runtime-message-converter", () => {
       ]);
     });
 
+    it("omits provider-executed tool result messages from replay", () => {
+      const messages = [
+        { id: "u1", role: "user", parts: [{ type: "text", text: "search tax guidance" }] },
+        {
+          id: "t1",
+          role: "tool",
+          parts: [{
+            type: "tool-result",
+            toolCallId: "toolu_search",
+            toolName: "web_search",
+            result: { results: [{ title: "Skatteverket" }] },
+            providerExecuted: true,
+          }],
+        },
+        { id: "u2", role: "user", parts: [{ type: "text", text: "try again" }] },
+      ] as unknown as Message[];
+
+      assertEquals(convertToTextGenerationRuntimeMessages(messages), [
+        { role: "user", content: "search tax guidance" },
+        { role: "user", content: "try again" },
+      ]);
+    });
+
+    it("omits provider-executed tool call and result history before a follow-up", () => {
+      const messages = [
+        { id: "u1", role: "user", parts: [{ type: "text", text: "search tax guidance" }] },
+        {
+          id: "a1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-web_search",
+              toolCallId: "toolu_search",
+              toolName: "web_search",
+              args: { query: "site:skatteverket.se tax residency" },
+              providerExecuted: true,
+            },
+            { type: "text", text: "Skatteverket explains unlimited tax liability." },
+          ],
+        },
+        {
+          id: "t1",
+          role: "tool",
+          parts: [{
+            type: "tool-result",
+            toolCallId: "toolu_search",
+            toolName: "web_search",
+            result: { results: [{ title: "Skatteverket" }] },
+          }],
+        },
+        { id: "u2", role: "user", parts: [{ type: "text", text: "cite the source" }] },
+      ] as unknown as Message[];
+
+      assertEquals(convertToTextGenerationRuntimeMessages(messages), [
+        { role: "user", content: "search tax guidance" },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Skatteverket explains unlimited tax liability." }],
+        },
+        { role: "user", content: "cite the source" },
+      ]);
+    });
+
+    it("keeps a later local tool result when its id matches an earlier provider tool call", () => {
+      const messages = [
+        { id: "u1", role: "user", parts: [{ type: "text", text: "search tax guidance" }] },
+        {
+          id: "a1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-web_search",
+              toolCallId: "toolu_reused",
+              toolName: "web_search",
+              args: { query: "site:skatteverket.se tax residency" },
+              providerExecuted: true,
+            },
+            { type: "text", text: "Skatteverket explains unlimited tax liability." },
+          ],
+        },
+        { id: "u2", role: "user", parts: [{ type: "text", text: "search local docs" }] },
+        {
+          id: "a2",
+          role: "assistant",
+          parts: [{
+            type: "tool-call",
+            toolCallId: "toolu_reused",
+            toolName: "searchDocs",
+            args: { query: "local source" },
+          }],
+        },
+        {
+          id: "t1",
+          role: "tool",
+          parts: [{
+            type: "tool-result",
+            toolCallId: "toolu_reused",
+            toolName: "searchDocs",
+            result: { results: [{ title: "Local source" }] },
+          }],
+        },
+      ] as unknown as Message[];
+
+      assertEquals(convertToTextGenerationRuntimeMessages(messages), [
+        { role: "user", content: "search tax guidance" },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Skatteverket explains unlimited tax liability." }],
+        },
+        { role: "user", content: "search local docs" },
+        {
+          role: "assistant",
+          content: [{
+            type: "tool-call",
+            toolCallId: "toolu_reused",
+            toolName: "searchDocs",
+            input: { query: "local source" },
+          }],
+        },
+        {
+          role: "tool",
+          content: [{
+            type: "tool-result",
+            toolCallId: "toolu_reused",
+            toolName: "searchDocs",
+            output: { type: "json", value: { results: [{ title: "Local source" }] } },
+          }],
+        },
+      ]);
+    });
+
     it("splits inline assistant tool results into provider-adjacent tool messages", () => {
       const messages = [
         { id: "u1", role: "user", parts: [{ type: "text", text: "search docs" }] },

--- a/src/agent/runtime/text-generation-runtime-message-converter.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.ts
@@ -51,6 +51,41 @@ function isProviderExecutedToolPart(part: Record<string, unknown>): boolean {
   return part.providerExecuted === true;
 }
 
+function getToolCallId(part: unknown): string | undefined {
+  return getStringPartField(part, "toolCallId") ??
+    getStringPartField(part, "tool_call_id") ??
+    getStringPartField(part, "id");
+}
+
+function getProviderExecutedToolCallId(part: unknown): string | undefined {
+  if (!isRecord(part) || !isProviderExecutedToolPart(part)) {
+    return undefined;
+  }
+
+  return getToolCallId(part);
+}
+
+function shouldSkipProviderExecutedToolResult(
+  part: unknown,
+  providerExecutedToolCallIds: Set<string>,
+): boolean {
+  if (!isRecord(part)) {
+    return false;
+  }
+
+  if (isProviderExecutedToolPart(part)) {
+    return true;
+  }
+
+  const toolCallId = getToolCallId(part);
+  if (!toolCallId || !providerExecutedToolCallIds.has(toolCallId)) {
+    return false;
+  }
+
+  providerExecutedToolCallIds.delete(toolCallId);
+  return true;
+}
+
 function getToolInputRecord(part: Record<string, unknown>): Record<string, unknown> {
   return getRecordPartField(part, "args") ?? getRecordPartField(part, "input") ?? {};
 }
@@ -73,9 +108,7 @@ function getTextGenerationToolCallPart(
     return null;
   }
 
-  const toolCallId = getStringPartField(part, "toolCallId") ??
-    getStringPartField(part, "tool_call_id") ??
-    getStringPartField(part, "id");
+  const toolCallId = getToolCallId(part);
   const toolName = getStringPartField(part, "toolName") ??
     getStringPartField(part, "tool_name") ??
     getStringPartField(part, "name") ??
@@ -103,8 +136,7 @@ function getTextGenerationToolResultPart(
     return null;
   }
 
-  const toolCallId = getStringPartField(part, "toolCallId") ??
-    getStringPartField(part, "tool_call_id");
+  const toolCallId = getToolCallId(part);
   if (!toolCallId) {
     return null;
   }
@@ -194,7 +226,12 @@ function getUserFileParts(parts: Message["parts"]): TextGenerationRuntimeFilePar
 /**
  * Convert a veryfront Message to the current text-generation runtime message format.
  */
-export function convertToTextGenerationRuntimeMessage(msg: Message): TextGenerationRuntimeMessage {
+export function convertToTextGenerationRuntimeMessage(
+  msg: Message,
+  options: { providerExecutedToolCallIds?: Set<string> } = {},
+): TextGenerationRuntimeMessage {
+  const providerExecutedToolCallIds = options.providerExecutedToolCallIds ?? new Set<string>();
+
   switch (msg.role) {
     case "system": {
       const text = getTextFromParts(msg.parts);
@@ -265,6 +302,11 @@ export function convertToTextGenerationRuntimeMessage(msg: Message): TextGenerat
         if (part.type !== "tool-result") continue;
 
         const resultPart = part as ToolResultPart;
+        if (
+          shouldSkipProviderExecutedToolResult(resultPart, providerExecutedToolCallIds)
+        ) {
+          continue;
+        }
         content.push({
           type: "tool-result",
           toolCallId: resultPart.toolCallId,
@@ -300,6 +342,7 @@ function hasProviderSendableAssistantContent(message: Message): boolean {
 
 function convertAssistantMessageToTextGenerationRuntimeMessages(
   message: Message,
+  providerExecutedToolCallIds: Set<string>,
 ): TextGenerationRuntimeMessage[] {
   const assistantContent: TextGenerationRuntimeAssistantMessage["content"] = [];
   const deferredAssistantContent: TextGenerationRuntimeAssistantMessage["content"] = [];
@@ -330,6 +373,8 @@ function convertAssistantMessageToTextGenerationRuntimeMessages(
     part: TextGenerationRuntimeTextPart | TextGenerationRuntimeToolCallPart,
   ) => {
     if (part.type === "tool-call") {
+      providerExecutedToolCallIds.delete(part.toolCallId);
+
       if (deferredAssistantContent.length > 0) {
         flushAssistantMessage(assistantContent);
         flushToolMessage();
@@ -366,6 +411,11 @@ function convertAssistantMessageToTextGenerationRuntimeMessages(
   };
 
   for (const part of message.parts) {
+    const providerExecutedToolCallId = getProviderExecutedToolCallId(part);
+    if (providerExecutedToolCallId) {
+      providerExecutedToolCallIds.add(providerExecutedToolCallId);
+    }
+
     if (part.type === "text" && "text" in part) {
       pushAssistantPart({ type: "text", text: (part as { text: string }).text });
       continue;
@@ -374,6 +424,10 @@ function convertAssistantMessageToTextGenerationRuntimeMessages(
     const toolCallPart = getTextGenerationToolCallPart(part);
     if (toolCallPart) {
       pushAssistantPart(toolCallPart);
+      continue;
+    }
+
+    if (shouldSkipProviderExecutedToolResult(part, providerExecutedToolCallIds)) {
       continue;
     }
 
@@ -397,17 +451,33 @@ export function convertToTextGenerationRuntimeMessages(
   messages: Message[],
 ): TextGenerationRuntimeMessage[] {
   const textGenerationRuntimeMessages: TextGenerationRuntimeMessage[] = [];
+  const providerExecutedToolCallIds = new Set<string>();
 
   for (const message of messages) {
+    if (message.role === "user" || message.role === "system") {
+      providerExecutedToolCallIds.clear();
+    }
+
+    for (const part of message.parts) {
+      const providerExecutedToolCallId = getProviderExecutedToolCallId(part);
+      if (providerExecutedToolCallId) {
+        providerExecutedToolCallIds.add(providerExecutedToolCallId);
+      }
+    }
+
     if (!hasProviderSendableAssistantContent(message)) {
       continue;
     }
 
     const convertedMessages = message.role === "assistant"
-      ? convertAssistantMessageToTextGenerationRuntimeMessages(message)
-      : [convertToTextGenerationRuntimeMessage(message)];
+      ? convertAssistantMessageToTextGenerationRuntimeMessages(message, providerExecutedToolCallIds)
+      : [convertToTextGenerationRuntimeMessage(message, { providerExecutedToolCallIds })];
 
     for (const convertedMessage of convertedMessages) {
+      if (convertedMessage.role === "tool" && convertedMessage.content.length === 0) {
+        continue;
+      }
+
       const previousMessage = textGenerationRuntimeMessages.at(-1);
 
       if (previousMessage?.role === "tool" && convertedMessage.role === "tool") {

--- a/src/agent/schemas/agent.schema.ts
+++ b/src/agent/schemas/agent.schema.ts
@@ -42,6 +42,7 @@ export const getToolCallPartWithArgsSchema = defineSchema((v) =>
     toolName: v.string(),
     args: v.record(v.string(), v.unknown()),
     inputText: v.string().optional(),
+    providerExecuted: v.boolean().optional(),
   })
 );
 
@@ -52,6 +53,7 @@ export const getToolCallPartWithInputSchema = defineSchema((v) =>
     toolName: v.string(),
     input: v.record(v.string(), v.unknown()),
     inputText: v.string().optional(),
+    providerExecuted: v.boolean().optional(),
   })
 );
 
@@ -68,6 +70,7 @@ export const getToolResultPartSchema = defineSchema((v) =>
     toolCallId: v.string(),
     toolName: v.string(),
     result: v.unknown(),
+    providerExecuted: v.boolean().optional(),
   })
 );
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.642";
+export const VERSION = "0.1.643";


### PR DESCRIPTION
## Summary
- skip provider-executed tool results when converting stored history for model replay
- infer provider-owned results from matching provider-executed tool call ids for older stored history
- mark newly persisted provider-native tool results and bump Veryfront to 0.1.643

## Verification
- deno fmt --check src/agent/runtime/index.ts src/agent/runtime/text-generation-runtime-message-converter.ts src/agent/runtime/text-generation-runtime-message-converter.test.ts src/agent/schemas/agent.schema.ts src/agent/runtime/runtime-tool-types.ts deno.json src/utils/version-constant.ts npm/package.json
- deno check src/agent/runtime/index.ts src/agent/runtime/text-generation-runtime-message-converter.ts src/agent/schemas/agent.schema.ts src/agent/runtime/runtime-tool-types.ts
- deno test --no-check --allow-all src/agent/runtime/text-generation-runtime-message-converter.test.ts src/agent/runtime/index.test.ts src/agent/runtime/chat-stream-handler.test.ts src/runtime/runtime-bridge.test.ts src/agent/runtime/provider-native-tool-inventory.test.ts src/agent/schemas/agent.schema.test.ts
- deno task build:npm
- pre-push hook: format, lint, typecheck, unit suite, 1,968 tests / 17,988 steps