### PR TITLE
Close provider-owned tools in browser streams

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.643",
+  "version": "0.1.644",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/ag-ui/browser-encoder.test.ts
+++ b/src/agent/ag-ui/browser-encoder.test.ts
@@ -170,6 +170,49 @@ describe("agent/ag-ui-browser-encoder", () => {
     );
   });
 
+  it("marks provider-executed tools complete when the provider owns execution", () => {
+    const state = createAgUiBrowserEncoderState();
+
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "tool-input-start",
+        toolCallId: "tool-provider",
+        toolName: "web_search",
+      }),
+      [{
+        event: "ToolCallStart",
+        payload: { toolCallId: "tool-provider", toolCallName: "web_search" },
+      }],
+    );
+
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "tool-input-available",
+        toolCallId: "tool-provider",
+        toolName: "web_search",
+        input: { query: "Swedish tax residency" },
+        providerExecuted: true,
+      }),
+      [
+        {
+          event: "ToolCallArgs",
+          payload: {
+            toolCallId: "tool-provider",
+            delta: '{"query":"Swedish tax residency"}',
+          },
+        },
+        {
+          event: "ToolCallEnd",
+          payload: { toolCallId: "tool-provider" },
+        },
+        {
+          event: "ToolCallResult",
+          payload: { toolCallId: "tool-provider", result: null },
+        },
+      ],
+    );
+  });
+
   it("closes open text before orphan tool-input-delta is forwarded", () => {
     const state = createAgUiBrowserEncoderState();
 

--- a/src/agent/ag-ui/browser-encoder.ts
+++ b/src/agent/ag-ui/browser-encoder.ts
@@ -414,11 +414,15 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
 
     case "tool-input-available": {
       state.sawVisibleOutput = true;
-      return [
+      const events = [
         ...closeOpenTextEvent(state),
         ...closeOpenReasoningEvent(state),
         ...completeToolInput(state, event),
       ];
+      if (event.providerExecuted === true) {
+        events.push(createToolResultEvent(event.toolCallId, null));
+      }
+      return events;
     }
 
     case "tool-input-error": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.643";
+export const VERSION = "0.1.644";


### PR DESCRIPTION
## Summary
- mark provider-executed tool calls complete in the AG-UI browser encoder
- add a regression test for provider-owned web_search lifecycle completion
- bump Veryfront to 0.1.644 for release

## Verification
- deno fmt --check src/agent/ag-ui/browser-encoder.ts src/agent/ag-ui/browser-encoder.test.ts deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all src/agent/ag-ui/browser-encoder.test.ts src/agent/ag-ui/runtime-event-encoder.test.ts src/chat/ag-ui.test.ts src/agent/react/use-chat/streaming/handler.test.ts
- deno check src/agent/ag-ui/browser-encoder.ts