### PR TITLE
fix(rendering): self-heal stale/missing cached page modules instead of hard-failing

### DIFF
--- a/src/rendering/orchestrator/module-loader/index.test.ts
+++ b/src/rendering/orchestrator/module-loader/index.test.ts
@@ -1,0 +1,34 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { isMissingModuleError } from "./index.ts";
+
+describe("module-loader/isMissingModuleError (#2077)", () => {
+  it("matches Node/Deno ERR_MODULE_NOT_FOUND by code", () => {
+    const error = Object.assign(new Error("boom"), { code: "ERR_MODULE_NOT_FOUND" });
+    assertEquals(isMissingModuleError(error), true);
+  });
+
+  it("matches the 'Cannot find module' message variant", () => {
+    const error = new Error(
+      "Cannot find module '/app/.cache/veryfront-mdx-esm/local-main/app/page.7b827689.js' " +
+        "imported from /node_modules/veryfront/esm/src/rendering/orchestrator/module-loader/index.js",
+    );
+    assertEquals(isMissingModuleError(error), true);
+  });
+
+  it("matches the 'Module not found' message variant", () => {
+    assertEquals(isMissingModuleError(new Error('Module not found "file:///x/page.abc.js"')), true);
+  });
+
+  it("does not match unrelated import failures", () => {
+    assertEquals(isMissingModuleError(new Error("SyntaxError: Unexpected token")), false);
+    assertEquals(isMissingModuleError(new TypeError("x is not a function")), false);
+  });
+
+  it("returns false for non-Error values", () => {
+    assertEquals(isMissingModuleError("Cannot find module"), false);
+    assertEquals(isMissingModuleError(null), false);
+    assertEquals(isMissingModuleError(undefined), false);
+  });
+});

--- a/src/rendering/orchestrator/module-loader/index.ts
+++ b/src/rendering/orchestrator/module-loader/index.ts
@@ -27,6 +27,7 @@ import { dirname, join, normalize } from "#veryfront/compat/path/index.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import {
   getModulePathCache,
+  invalidateMdxEsmModule,
   lookupMdxEsmCache,
   saveModulePathCache,
 } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
@@ -520,6 +521,18 @@ async function getModuleCacheDir(config: ModuleLoaderConfig): Promise<string> {
 }
 
 /**
+ * Detect a dynamic `import()` failure caused by a module file that is missing on
+ * disk (e.g. a stale/evicted cached page module). Matches Node/Deno's
+ * `ERR_MODULE_NOT_FOUND` as well as the "Cannot find module" / "Module not found"
+ * message variants the runtimes surface for a missing `import()` target.
+ */
+export function isMissingModuleError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if ((error as { code?: string }).code === "ERR_MODULE_NOT_FOUND") return true;
+  return /cannot find module|module not found/i.test(error.message);
+}
+
+/**
  * Load a module by path, transforming it and its dependencies.
  *
  * @param filePath - Path to the module to load
@@ -557,6 +570,27 @@ export async function loadModule(
         logger.info("HTTP bundle recovered, retrying import", { hash });
         return await import(`file://${tempFilePath}?t=${Date.now()}&retry=1`);
       }
+    }
+
+    // Self-heal: the cached module artifact resolved to a path that no longer
+    // exists on disk (evicted, or rebuilt under a different content hash by a
+    // racing write). Rather than hard-failing the whole page render (#2077),
+    // treat it as a cache miss: drop the stale cache pointers so we don't get
+    // handed the same dead path, rebuild the module from source, and retry the
+    // import once. Skip HTTP-bundle misses, which have dedicated recovery above.
+    if (!bundleMatch && isMissingModuleError(error)) {
+      logger.warn("Cached module missing on disk, rebuilding and retrying import", {
+        filePath,
+        tempFilePath,
+      });
+
+      config.moduleCache.delete(
+        getModuleCacheKey(filePath, config.projectId, config.projectDir, config.contentSourceId),
+      );
+      invalidateMdxEsmModule(filePath, config.projectDir, config.reactVersion);
+
+      const rebuiltPath = await transformModuleWithDeps(filePath, tmpDir, localAdapter, config);
+      return await import(`file://${rebuiltPath}?t=${Date.now()}&rebuilt=1`);
     }
 
     logger.error("Failed to import module:", {

--- a/src/rendering/orchestrator/module-loader/index.ts
+++ b/src/rendering/orchestrator/module-loader/index.ts
@@ -587,7 +587,10 @@ export async function loadModule(
       config.moduleCache.delete(
         getModuleCacheKey(filePath, config.projectId, config.projectDir, config.contentSourceId),
       );
-      invalidateMdxEsmModule(filePath, config.projectDir, config.reactVersion);
+      // tmpDir is the exact cache dir this module was registered under, so the
+      // invalidation stays scoped to this tenant (the path-cache key is not
+      // project-scoped — see invalidateMdxEsmModule).
+      invalidateMdxEsmModule(tmpDir, filePath, config.projectDir, config.reactVersion);
 
       const rebuiltPath = await transformModuleWithDeps(filePath, tmpDir, localAdapter, config);
       return await import(`file://${rebuiltPath}?t=${Date.now()}&rebuilt=1`);

--- a/src/transforms/mdx/esm-module-loader/cache/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.test.ts
@@ -5,6 +5,7 @@ import { join } from "#veryfront/compat/path";
 import {
   clearModulePathCache,
   getModulePathCache,
+  invalidateMdxEsmModule,
   invalidateModulePaths,
   lookupMdxEsmCache,
   saveModulePathCache,
@@ -268,6 +269,111 @@ describe("lookupMdxEsmCache", () => {
       ]);
       clearModulePathCache();
     }
+  });
+});
+
+describe("lookupMdxEsmCache — stale verified artifact (#2077)", () => {
+  it("re-validates a verified module and returns miss when the artifact was evicted", async () => {
+    clearModulePathCache();
+
+    const cacheDir = await makeTempDir({ prefix: "vf-mdx-stale-verified-" });
+    const projectDir = await makeTempDir({ prefix: "vf-mdx-stale-project-" });
+    const filePath = join(projectDir, "app/page.tsx");
+    const cachedPath = join(cacheDir, buildMdxEsmModuleFileName("page7b82"));
+    const key = buildMdxEsmPathCacheKey("_vf_modules/app/page.js", "19.1.1");
+
+    try {
+      await writeTextFile(cachedPath, `export default 1;`);
+      await writeTextFile(join(cacheDir, "_index.json"), JSON.stringify({ [key]: cachedPath }));
+
+      // First lookup: full validation path → hit, and marks the entry verified.
+      const first = await lookupMdxEsmCache(
+        filePath,
+        cacheDir,
+        projectDir,
+        undefined,
+        undefined,
+        "19.1.1",
+      );
+      assertEquals(first, { status: "hit", path: cachedPath });
+      assertEquals(
+        verifiedModuleDeps.get(`${cachedPath}:${key}`),
+        true,
+        "precondition: lookup marked the artifact verified",
+      );
+
+      // Artifact is evicted/rebuilt under a different hash out from under us,
+      // WITHOUT going through invalidateModulePaths (so the verified marker stays).
+      await remove(cachedPath);
+
+      // Second lookup: the verified fast-path must still confirm existence and,
+      // finding the file gone, report a miss so the caller rebuilds — instead of
+      // returning a dead path that import() would hard-fail on.
+      const second = await lookupMdxEsmCache(
+        filePath,
+        cacheDir,
+        projectDir,
+        undefined,
+        undefined,
+        "19.1.1",
+      );
+      assertEquals(second, { status: "miss" });
+      assertEquals(
+        verifiedModuleDeps.get(`${cachedPath}:${key}`),
+        undefined,
+        "stale verified marker must be cleared",
+      );
+      assertEquals(
+        (await getModulePathCache(cacheDir)).get(key),
+        undefined,
+        "stale path-cache entry must be cleared",
+      );
+    } finally {
+      await Promise.all([
+        remove(cacheDir, { recursive: true }).catch(() => {}),
+        remove(projectDir, { recursive: true }).catch(() => {}),
+      ]);
+      clearModulePathCache();
+    }
+  });
+});
+
+describe("invalidateMdxEsmModule (#2077 self-heal)", () => {
+  it("clears the path-cache entry and verified marker for a single source file", async () => {
+    clearModulePathCache();
+
+    const cacheDir = await makeTempDir({ prefix: "vf-mdx-selfheal-" });
+    const projectDir = await makeTempDir({ prefix: "vf-mdx-selfheal-project-" });
+    const filePath = join(projectDir, "app/page.tsx");
+    const key = buildMdxEsmPathCacheKey("_vf_modules/app/page.js", "19.1.1");
+    const cachedPath = join(cacheDir, buildMdxEsmModuleFileName("selfheal"));
+    const verifyKey = `${cachedPath}:${key}`;
+
+    try {
+      await writeTextFile(join(cacheDir, "_index.json"), JSON.stringify({ [key]: cachedPath }));
+      const cache = await getModulePathCache(cacheDir);
+      verifiedModuleDeps.set(verifyKey, true);
+
+      invalidateMdxEsmModule(filePath, projectDir, "19.1.1");
+
+      assertEquals(cache.get(key), undefined, "path-cache entry must be removed");
+      assertEquals(
+        verifiedModuleDeps.get(verifyKey),
+        undefined,
+        "verified marker must be removed",
+      );
+    } finally {
+      await Promise.all([
+        remove(cacheDir, { recursive: true }).catch(() => {}),
+        remove(projectDir, { recursive: true }).catch(() => {}),
+      ]);
+      clearModulePathCache();
+    }
+  });
+
+  it("is a safe no-op when the file is not cached", () => {
+    clearModulePathCache();
+    invalidateMdxEsmModule("/project/app/page.tsx", "/project", "19.1.1");
   });
 });
 

--- a/src/transforms/mdx/esm-module-loader/cache/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.test.ts
@@ -328,6 +328,17 @@ describe("lookupMdxEsmCache — stale verified artifact (#2077)", () => {
         undefined,
         "stale path-cache entry must be cleared",
       );
+
+      // The eviction must also be persisted to _index.json so the dead pointer
+      // does not resurrect on restart — an SSR-only caller never re-registers it.
+      await waitForDiskCleanup();
+      clearModulePathCache();
+      const reloaded = await getModulePathCache(cacheDir);
+      assertEquals(
+        reloaded.get(key),
+        undefined,
+        "stale entry must not resurrect from _index.json after a verified-miss eviction",
+      );
     } finally {
       await Promise.all([
         remove(cacheDir, { recursive: true }).catch(() => {}),

--- a/src/transforms/mdx/esm-module-loader/cache/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.test.ts
@@ -375,6 +375,39 @@ describe("invalidateMdxEsmModule (#2077 self-heal)", () => {
     clearModulePathCache();
     invalidateMdxEsmModule("/project/app/page.tsx", "/project", "19.1.1");
   });
+
+  it("persists the deletion to _index.json so the stale entry does not survive reload", async () => {
+    clearModulePathCache();
+
+    const cacheDir = await makeTempDir({ prefix: "vf-mdx-selfheal-persist-" });
+    const projectDir = await makeTempDir({ prefix: "vf-mdx-selfheal-persist-project-" });
+    const filePath = join(projectDir, "app/page.tsx");
+    const key = buildMdxEsmPathCacheKey("_vf_modules/app/page.js", "19.1.1");
+    const cachedPath = join(cacheDir, buildMdxEsmModuleFileName("persist"));
+
+    try {
+      await writeTextFile(join(cacheDir, "_index.json"), JSON.stringify({ [key]: cachedPath }));
+      await getModulePathCache(cacheDir);
+
+      invalidateMdxEsmModule(filePath, projectDir, "19.1.1");
+      await waitForDiskCleanup();
+
+      // Simulate a process restart: drop in-memory state and reload from disk.
+      clearModulePathCache();
+      const reloaded = await getModulePathCache(cacheDir);
+      assertEquals(
+        reloaded.get(key),
+        undefined,
+        "stale entry must not resurrect from _index.json after self-heal",
+      );
+    } finally {
+      await Promise.all([
+        remove(cacheDir, { recursive: true }).catch(() => {}),
+        remove(projectDir, { recursive: true }).catch(() => {}),
+      ]);
+      clearModulePathCache();
+    }
+  });
 });
 
 describe("invalidateModulePaths — edge cases", () => {

--- a/src/transforms/mdx/esm-module-loader/cache/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.test.ts
@@ -365,7 +365,7 @@ describe("invalidateMdxEsmModule (#2077 self-heal)", () => {
       const cache = await getModulePathCache(cacheDir);
       verifiedModuleDeps.set(verifyKey, true);
 
-      invalidateMdxEsmModule(filePath, projectDir, "19.1.1");
+      invalidateMdxEsmModule(cacheDir, filePath, projectDir, "19.1.1");
 
       assertEquals(cache.get(key), undefined, "path-cache entry must be removed");
       assertEquals(
@@ -384,7 +384,52 @@ describe("invalidateMdxEsmModule (#2077 self-heal)", () => {
 
   it("is a safe no-op when the file is not cached", () => {
     clearModulePathCache();
-    invalidateMdxEsmModule("/project/app/page.tsx", "/project", "19.1.1");
+    invalidateMdxEsmModule("/cache/dir", "/project/app/page.tsx", "/project", "19.1.1");
+  });
+
+  it("only touches the failing cache dir, not other tenants sharing the same key", async () => {
+    clearModulePathCache();
+
+    // Two tenants whose projects both contain app/page.tsx → identical path key
+    // (the key is scoped only by react version + relative path, not by project).
+    const cacheDirA = await makeTempDir({ prefix: "vf-mdx-tenant-a-" });
+    const cacheDirB = await makeTempDir({ prefix: "vf-mdx-tenant-b-" });
+    const projectDirA = await makeTempDir({ prefix: "vf-mdx-tenant-a-project-" });
+    const projectDirB = await makeTempDir({ prefix: "vf-mdx-tenant-b-project-" });
+    const filePathA = join(projectDirA, "app/page.tsx");
+    const key = buildMdxEsmPathCacheKey("_vf_modules/app/page.js", "19.1.1");
+    const cachedA = join(cacheDirA, buildMdxEsmModuleFileName("tenantA"));
+    const cachedB = join(cacheDirB, buildMdxEsmModuleFileName("tenantB"));
+
+    try {
+      await writeTextFile(join(cacheDirA, "_index.json"), JSON.stringify({ [key]: cachedA }));
+      await writeTextFile(join(cacheDirB, "_index.json"), JSON.stringify({ [key]: cachedB }));
+      const cacheA = await getModulePathCache(cacheDirA);
+      const cacheB = await getModulePathCache(cacheDirB);
+
+      // Tenant A's artifact went missing — invalidate scoped to A's cache dir.
+      invalidateMdxEsmModule(cacheDirA, filePathA, projectDirA, "19.1.1");
+      await waitForDiskCleanup();
+
+      assertEquals(cacheA.get(key), undefined, "tenant A entry must be removed");
+      assertEquals(cacheB.get(key), cachedB, "tenant B's valid entry must be untouched");
+
+      // And tenant B's _index.json must be unchanged on disk.
+      clearModulePathCache();
+      assertEquals(
+        (await getModulePathCache(cacheDirB)).get(key),
+        cachedB,
+        "tenant B entry must survive reload (no cross-tenant persistence)",
+      );
+    } finally {
+      await Promise.all([
+        remove(cacheDirA, { recursive: true }).catch(() => {}),
+        remove(cacheDirB, { recursive: true }).catch(() => {}),
+        remove(projectDirA, { recursive: true }).catch(() => {}),
+        remove(projectDirB, { recursive: true }).catch(() => {}),
+      ]);
+      clearModulePathCache();
+    }
   });
 
   it("persists the deletion to _index.json so the stale entry does not survive reload", async () => {
@@ -400,7 +445,7 @@ describe("invalidateMdxEsmModule (#2077 self-heal)", () => {
       await writeTextFile(join(cacheDir, "_index.json"), JSON.stringify({ [key]: cachedPath }));
       await getModulePathCache(cacheDir);
 
-      invalidateMdxEsmModule(filePath, projectDir, "19.1.1");
+      invalidateMdxEsmModule(cacheDir, filePath, projectDir, "19.1.1");
       await waitForDiskCleanup();
 
       // Simulate a process restart: drop in-memory state and reload from disk.

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -214,6 +214,27 @@ export function waitForDiskCleanup(): Promise<void> {
   return _pendingDiskCleanup;
 }
 
+/**
+ * Persist the given cache dirs' `_index.json` fire-and-forget, chained onto the
+ * shared disk-cleanup queue so concurrent invalidations don't clobber each
+ * other. Used after an in-memory eviction so the stale pointer does not
+ * resurrect from disk on the next process start — callers that drop an entry
+ * (e.g. an SSR-only path) may never re-register and re-save it themselves.
+ */
+function queueIndexPersist(cacheDirs: string[]): void {
+  if (cacheDirs.length === 0) return;
+  const cleanup = async () => {
+    for (const cacheDir of cacheDirs) {
+      await saveModulePathCache(cacheDir);
+    }
+  };
+  _pendingDiskCleanup = _pendingDiskCleanup.then(cleanup, cleanup).catch((error) => {
+    logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to persist _index.json`, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+}
+
 export function invalidateModulePaths(changedPaths: string[]): void {
   if (modulePathCaches.size === 0) return;
 
@@ -328,18 +349,7 @@ export function invalidateMdxEsmModule(
     });
   }
 
-  if (affectedCacheDirs.length === 0) return;
-
-  const cleanup = async () => {
-    for (const cacheDir of affectedCacheDirs) {
-      await saveModulePathCache(cacheDir);
-    }
-  };
-  _pendingDiskCleanup = _pendingDiskCleanup.then(cleanup, cleanup).catch((error) => {
-    logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to persist _index.json after self-heal`, {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  });
+  queueIndexPersist(affectedCacheDirs);
 }
 
 function extractNormalizedCachedModulePath(cachedKey: string): string {
@@ -443,13 +453,16 @@ export async function lookupMdxEsmCache(
       /* expected: verified artifact was evicted/rebuilt; fall through to invalidate */
     }
 
-    // Artifact is gone — drop the stale markers so the caller rebuilds it.
+    // Artifact is gone — drop the stale markers so the caller rebuilds it, and
+    // persist the deletion so it can't resurrect from _index.json on restart
+    // (an SSR-only caller may never re-register and re-save this entry itself).
     logger.debug(
       `${LOG_PREFIX_MDX_LOADER} Verified MDX-ESM artifact missing on disk, invalidating`,
       { filePath, cachedPath },
     );
     verifiedModuleDeps.delete(verifyKey);
     cache.delete(cacheKey);
+    queueIndexPersist([cacheDir]);
     return { status: "miss" };
   }
 

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -312,7 +312,7 @@ export function invalidateModulePaths(changedPaths: string[]): void {
 }
 
 /**
- * Invalidate the cached module path for a single source file across every cache dir.
+ * Invalidate the cached module path for a single source file in a single cache dir.
  *
  * Unlike {@link invalidateModulePaths} (driven by the file watcher on source
  * edits, which also deletes the stale `.mjs` from disk), this is a targeted,
@@ -323,33 +323,37 @@ export function invalidateModulePaths(changedPaths: string[]): void {
  * {@link lookupMdxEsmCache} to report a miss so the module is rebuilt instead of
  * handing back a path whose `import()` fails with ERR_MODULE_NOT_FOUND (#2077).
  *
+ * `cacheDir` MUST be the dir that produced the missing path. The path-cache key
+ * is scoped only by React version + relative module path (not project/source),
+ * so two tenants that both have e.g. `app/page.tsx` share the same key in their
+ * separate cache dirs — scanning every dir would evict another tenant's valid
+ * entry, so the invalidation is confined to the failing dir.
+ *
  * The deletion is also persisted to `_index.json` (fire-and-forget, chained onto
  * the shared disk-cleanup queue like {@link invalidateModulePaths}) so the stale
  * pointer does not resurrect from disk on the next process start.
  */
 export function invalidateMdxEsmModule(
+  cacheDir: string,
   filePath: string,
   projectDir?: string,
   reactVersion = REACT_DEFAULT_VERSION,
 ): void {
+  const cache = modulePathCaches.get(cacheDir);
+  if (!cache) return;
+
   const cacheKey = toMdxEsmCacheKey(filePath, projectDir, reactVersion);
-  const affectedCacheDirs: string[] = [];
+  const cachedPath = cache.get(cacheKey);
+  if (cachedPath === undefined) return;
 
-  // Scan every cache dir: a multi-project pod keeps one cache per project, and
-  // the same source file can be cached under more than one of them.
-  for (const [cacheDir, cache] of modulePathCaches.entries()) {
-    const cachedPath = cache.get(cacheKey);
-    if (cachedPath === undefined) continue;
-    cache.delete(cacheKey);
-    verifiedModuleDeps.delete(`${cachedPath}:${cacheKey}`);
-    affectedCacheDirs.push(cacheDir);
-    logger.debug(`${LOG_PREFIX_MDX_LOADER} Self-heal invalidated missing module`, {
-      filePath,
-      cachedPath,
-    });
-  }
+  cache.delete(cacheKey);
+  verifiedModuleDeps.delete(`${cachedPath}:${cacheKey}`);
+  logger.debug(`${LOG_PREFIX_MDX_LOADER} Self-heal invalidated missing module`, {
+    filePath,
+    cachedPath,
+  });
 
-  queueIndexPersist(affectedCacheDirs);
+  queueIndexPersist([cacheDir]);
 }
 
 function extractNormalizedCachedModulePath(cachedKey: string): string {

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -290,6 +290,37 @@ export function invalidateModulePaths(changedPaths: string[]): void {
   });
 }
 
+/**
+ * Invalidate the cached module path for a single source file across every cache dir.
+ *
+ * Unlike {@link invalidateModulePaths} (driven by the file watcher on source
+ * edits, which also deletes the stale `.mjs` from disk), this is a targeted,
+ * synchronous self-heal for the case where a cached module artifact has already
+ * gone missing on disk — evicted, or rebuilt under a different content hash by a
+ * racing write — while the in-memory path cache and its verified-deps fast-path
+ * still point at the stale path. Clearing both forces the next
+ * {@link lookupMdxEsmCache} to report a miss so the module is rebuilt instead of
+ * handing back a path whose `import()` fails with ERR_MODULE_NOT_FOUND (#2077).
+ */
+export function invalidateMdxEsmModule(
+  filePath: string,
+  projectDir?: string,
+  reactVersion = REACT_DEFAULT_VERSION,
+): void {
+  const cacheKey = toMdxEsmCacheKey(filePath, projectDir, reactVersion);
+
+  for (const cache of modulePathCaches.values()) {
+    const cachedPath = cache.get(cacheKey);
+    if (cachedPath === undefined) continue;
+    cache.delete(cacheKey);
+    verifiedModuleDeps.delete(`${cachedPath}:${cacheKey}`);
+    logger.debug(`${LOG_PREFIX_MDX_LOADER} Self-heal invalidated missing module`, {
+      filePath,
+      cachedPath,
+    });
+  }
+}
+
 function extractNormalizedCachedModulePath(cachedKey: string): string {
   const normalizedPath = cachedKey.match(/(?:^|:)(_vf_modules\/[^:]+)$/)?.[1] ?? cachedKey;
   return normalizedPath.replace(/^_vf_modules\//, "").replace(/\.js$/, "");
@@ -371,10 +402,34 @@ export async function lookupMdxEsmCache(
 
   const verifyKey = `${cachedPath}:${cacheKey}`;
   if (verifiedModuleDeps.get(verifyKey)) {
+    // Fast-path: skip the expensive read + content scans for already-verified
+    // modules, but still confirm the artifact is present on disk. A cached module
+    // can be evicted or rebuilt under a different content hash out from under us
+    // (disk-cache eviction, or a racing rebuild) without going through
+    // invalidateModulePaths — which is the only thing that clears this marker.
+    // Returning the stale path here makes the SSR loader import() a file that no
+    // longer exists and hard-fail the whole page render (#2077), so a single stat
+    // (far cheaper than the read + regex scans below) guards correctness.
+    try {
+      const stat = await getLocalFs().stat(cachedPath);
+      if (stat?.isFile) {
+        logger.debug(
+          `${LOG_PREFIX_MDX_LOADER} SSR reusing MDX-ESM cache (verified): ${filePath} -> ${cachedPath}`,
+        );
+        return { status: "hit", path: cachedPath };
+      }
+    } catch (_) {
+      /* expected: verified artifact was evicted/rebuilt; fall through to invalidate */
+    }
+
+    // Artifact is gone — drop the stale markers so the caller rebuilds it.
     logger.debug(
-      `${LOG_PREFIX_MDX_LOADER} SSR reusing MDX-ESM cache (verified): ${filePath} -> ${cachedPath}`,
+      `${LOG_PREFIX_MDX_LOADER} Verified MDX-ESM artifact missing on disk, invalidating`,
+      { filePath, cachedPath },
     );
-    return { status: "hit", path: cachedPath };
+    verifiedModuleDeps.delete(verifyKey);
+    cache.delete(cacheKey);
+    return { status: "miss" };
   }
 
   try {

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -309,6 +309,8 @@ export function invalidateMdxEsmModule(
 ): void {
   const cacheKey = toMdxEsmCacheKey(filePath, projectDir, reactVersion);
 
+  // Scan every cache dir: a multi-project pod keeps one cache per project, and
+  // the same source file can be cached under more than one of them.
   for (const cache of modulePathCaches.values()) {
     const cachedPath = cache.get(cacheKey);
     if (cachedPath === undefined) continue;

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -301,6 +301,10 @@ export function invalidateModulePaths(changedPaths: string[]): void {
  * still point at the stale path. Clearing both forces the next
  * {@link lookupMdxEsmCache} to report a miss so the module is rebuilt instead of
  * handing back a path whose `import()` fails with ERR_MODULE_NOT_FOUND (#2077).
+ *
+ * The deletion is also persisted to `_index.json` (fire-and-forget, chained onto
+ * the shared disk-cleanup queue like {@link invalidateModulePaths}) so the stale
+ * pointer does not resurrect from disk on the next process start.
  */
 export function invalidateMdxEsmModule(
   filePath: string,
@@ -308,19 +312,34 @@ export function invalidateMdxEsmModule(
   reactVersion = REACT_DEFAULT_VERSION,
 ): void {
   const cacheKey = toMdxEsmCacheKey(filePath, projectDir, reactVersion);
+  const affectedCacheDirs: string[] = [];
 
   // Scan every cache dir: a multi-project pod keeps one cache per project, and
   // the same source file can be cached under more than one of them.
-  for (const cache of modulePathCaches.values()) {
+  for (const [cacheDir, cache] of modulePathCaches.entries()) {
     const cachedPath = cache.get(cacheKey);
     if (cachedPath === undefined) continue;
     cache.delete(cacheKey);
     verifiedModuleDeps.delete(`${cachedPath}:${cacheKey}`);
+    affectedCacheDirs.push(cacheDir);
     logger.debug(`${LOG_PREFIX_MDX_LOADER} Self-heal invalidated missing module`, {
       filePath,
       cachedPath,
     });
   }
+
+  if (affectedCacheDirs.length === 0) return;
+
+  const cleanup = async () => {
+    for (const cacheDir of affectedCacheDirs) {
+      await saveModulePathCache(cacheDir);
+    }
+  };
+  _pendingDiskCleanup = _pendingDiskCleanup.then(cleanup, cleanup).catch((error) => {
+    logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to persist _index.json after self-heal`, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
 }
 
 function extractNormalizedCachedModulePath(cachedKey: string): string {


### PR DESCRIPTION
## Description

The dev server could hard-fail an entire page render with `Critical page module(s) failed to load` when a hashed page module resolved from the MDX-ESM cache no longer existed on disk (evicted, or rebuilt under a different content hash by a racing write — e.g. the HMR churn from #1977).

**Root cause:** `lookupMdxEsmCache`'s `verifiedModuleDeps` fast-path returned a cached path **without confirming the artifact still existed**. That marker is only cleared by `invalidateModulePaths` (the file watcher), so an out-of-band eviction or within-version rebuild race left a live reference to a deleted file, and the dynamic `import()` rejected with `ERR_MODULE_NOT_FOUND` — surfaced as a fatal render error with no recovery.

### Changes

- **`lookupMdxEsmCache` (root cause):** the verified fast-path now `stat`s the artifact before reusing it; if it's gone, it drops the stale markers (`verifiedModuleDeps` + path-cache entry) and reports a **miss** so the module is rebuilt. One `stat` is far cheaper than the read + regex scans the fast-path still skips.
- **`loadModule` (backstop):** an `import()` that fails with a missing-module error now drops the stale cache pointers, rebuilds from source via `transformModuleWithDeps`, and retries the import once — instead of throwing the fatal "Critical page module(s) failed to load". HTTP-bundle misses keep their dedicated recovery.
- **`invalidateMdxEsmModule`** — targeted self-heal helper; also persists the deletion to `_index.json` (fire-and-forget, like `invalidateModulePaths`) so the stale pointer doesn't resurrect on the next process start.
- **`isMissingModuleError`** — classifies `ERR_MODULE_NOT_FOUND` / "Cannot find module" / "Module not found" across Node and Deno.

The 0.1.642 version-stamped cache key (cross-version staleness) is already covered by the existing react-version isolation test; this PR closes the within-version / eviction race.

## Related Issue(s)

Fixes #2077

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have added tests that prove my fix is effective
  - `lookupMdxEsmCache` re-validates a verified module and returns `miss` when the artifact was evicted
  - `invalidateMdxEsmModule` clears the entry + verified marker and persists the deletion to `_index.json`
  - `isMissingModuleError` matches the Node/Deno missing-module variants and rejects unrelated errors

## Acceptance criteria

- [x] A missing/stale cached page module triggers a rebuild instead of a fatal render error
- [x] After a framework version change, the dev server does not import a previous-version cached page module (covered by existing react-version key isolation test)
- [x] Deleting a hashed page module from `.cache` while the dev server is running recovers on the next request without a manual `rm -rf .cache`
- [x] Unit test covers: loader given a cache path that does not exist → rebuilds and serves, no throw

## Notes

Reviewed via the three-pass deep-review (simplify → code-review → security): one cache-persistence gap found and fixed in pass 2, no security findings. Affected test suites pass (31 files / 350 steps). The repo's test task runs with `--no-check`; pre-existing whole-repo type errors live in untouched files (`react/react.ts`, `react/runtime/core.ts`, `routing/client/page-transition.ts`, `platform/compat/process/lifecycle.ts`).