### PR TITLE
Preserve Studio date context for hosted agent runs

### DIFF
--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -129,6 +129,48 @@ describe("agent/hosted-chat-request", () => {
       spawnedFromToolCallId: "tool_1",
     });
   });
+  it("carries Studio environment context from runtime context into hosted chat context", () => {
+    const invocation = RuntimeAgentRunInvocationSchema.parse({
+      ...createRuntimeInvocation(),
+      context: [
+        {
+          type: "json",
+          title: "studio_context",
+          data: {
+            projectId,
+            branchId,
+            environmentContext: "<date_time>\nToday's date is 2026-06-03\n</date_time>",
+          },
+        },
+      ],
+    });
+
+    const request = buildHostedChatRequestFromRuntimeAgentInvocation(invocation);
+
+    assertEquals(
+      request.context.environmentContext,
+      "<date_time>\nToday's date is 2026-06-03\n</date_time>",
+    );
+  });
+
+  it("ignores non-Studio JSON context environment fields", () => {
+    const invocation = RuntimeAgentRunInvocationSchema.parse({
+      ...createRuntimeInvocation(),
+      context: [
+        {
+          type: "json",
+          title: "other_context",
+          data: {
+            environmentContext: "Unrelated context",
+          },
+        },
+      ],
+    });
+
+    const request = buildHostedChatRequestFromRuntimeAgentInvocation(invocation);
+
+    assertEquals(request.context.environmentContext, undefined);
+  });
 
   it("parses hosted chat requests with auth and project-access callbacks", async () => {
     const parsed = await parseHostedChatRequestFromRequest(

--- a/src/agent/hosted/chat-request.ts
+++ b/src/agent/hosted/chat-request.ts
@@ -74,6 +74,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+function getStudioRuntimeEnvironmentContext(input: RuntimeAgentRunInvocation): string | undefined {
+  for (const item of input.context) {
+    if (item.type !== "json" || item.title !== "studio_context") continue;
+
+    const environmentContext = item.data.environmentContext;
+    if (typeof environmentContext === "string" && environmentContext.trim().length > 0) {
+      return environmentContext;
+    }
+  }
+
+  return undefined;
+}
+
 /** Builds hosted chat request forwarded props from runtime agent invocation. */
 export function buildHostedChatRequestForwardedPropsFromRuntimeAgentInvocation(
   input: RuntimeAgentRunInvocation,
@@ -97,12 +110,15 @@ export function buildHostedChatRequestForwardedPropsFromRuntimeAgentInvocation(
 export function buildHostedChatRequestInputFromRuntimeAgentInvocation(
   input: RuntimeAgentRunInvocation,
 ): HostedChatRequestInput {
+  const environmentContext = getStudioRuntimeEnvironmentContext(input);
+
   return {
     messages: input.messages,
     context: {
       conversationId: input.run.conversationId,
       projectId: input.run.project.projectId,
       branchId: input.run.project.runtimeTargetBranchId ?? null,
+      ...(environmentContext ? { environmentContext } : {}),
     },
     forwardedProps: buildHostedChatRequestForwardedPropsFromRuntimeAgentInvocation(input),
     durableRootRun: {


### PR DESCRIPTION
## Summary
- Preserve `environmentContext` from runtime context items when adapting runtime agent invocations into hosted chat requests.
- Add a regression for the Studio `studio_context` payload shape from veryfront/veryfront-studio#4689.

## Why
Studio already sent the current date block in the project-agent request snapshot, but the hosted chat conversion dropped that field before building runtime system messages. This keeps the date block agent-visible so daily briefing tool calls can use the Studio-provided current date.

## Tests
- `deno test --no-check --allow-all src/agent/hosted/chat-request.test.ts`
- `deno check src/agent/hosted/chat-request.ts`
- Pre-commit `deno task verify:quick` passed.

## Notes
- A broader ad-hoc hosted slice including `chat-preparation.test.ts` still hits the existing missing `SchemaValidator` extension setup in that test file; it is unrelated to this diff.

Refs veryfront/veryfront-studio#4689
