### PR TITLE
Prevent provider-owned browser tools from replaying

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.644",
+  "version": "0.1.645",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted/chat-preparation.test.ts
+++ b/src/agent/hosted/chat-preparation.test.ts
@@ -1,3 +1,4 @@
+import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import type { ChatUiMessage } from "#veryfront/chat/types.ts";
 import type { ParsedHostedChatRequest } from "./chat-request-parser.ts";
@@ -335,4 +336,61 @@ Deno.test("prepareHostedChatRuntimeMessages refreshes uploaded file URLs through
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+Deno.test("prepareHostedChatRuntimeMessages omits provider-owned remote tool history", async () => {
+  const messages = await prepareHostedChatRuntimeMessages(
+    [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Explain Swedish tax residency." }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolName: "web_search",
+            toolCallId: "toolu_web_search",
+            input: { query: "site:skatteverket.se tax residency" },
+            state: "output-available",
+            providerExecuted: true,
+            output: null,
+          },
+          {
+            type: "text",
+            text: "Unlimited tax liability is based on Chapter 3 of the Income Tax Act.",
+          },
+        ],
+      },
+      {
+        id: "tool-1",
+        role: "tool",
+        parts: [
+          {
+            type: "tool_result",
+            tool_call_id: "toolu_web_search",
+            tool_name: "web_search",
+            output: null,
+          },
+        ],
+      },
+      {
+        id: "user-2",
+        role: "user",
+        parts: [{ type: "text", text: "Cite the official source." }],
+      },
+    ],
+    {
+      providerOwnedToolNames: ["web_search"],
+    },
+  );
+
+  assertEquals(messages.map((message) => message.role), ["user", "assistant", "user"]);
+  assertEquals(messages[1]?.parts, [{
+    type: "text",
+    text: "Unlimited tax liability is based on Chapter 3 of the Income Tax Act.",
+  }]);
 });

--- a/src/agent/hosted/chat-preparation.ts
+++ b/src/agent/hosted/chat-preparation.ts
@@ -39,7 +39,7 @@ export type NormalizedHostedChatRequest = {
 export type PrepareHostedChatRuntimeMessagesOptions =
   & Pick<
     PrepareAgentRuntimeMessagesFromUiMessagesOptions,
-    "emptyConversationPrompt"
+    "emptyConversationPrompt" | "providerOwnedToolNames"
   >
   & {
     authToken?: string;
@@ -77,6 +77,7 @@ export type HostedChatRuntimeCreationPreparationInput<TRuntimeAgentDefinition> =
     model?: string;
     thinking?: RuntimeAgentThinkingConfig;
     maxSteps?: number;
+    allowedRemoteTools?: unknown;
   };
   projectId: string | null;
   authToken: string;
@@ -110,6 +111,14 @@ export type HostedChatRuntimeCreationPreparationResult<TRuntimeAgentDefinition> 
   runtimeConfig: ResolvedHostedRuntimeRequestConfig;
 };
 
+function getAllowedRemoteToolNames(agentConfig: { allowedRemoteTools?: unknown }): string[] {
+  return Array.isArray(agentConfig.allowedRemoteTools)
+    ? agentConfig.allowedRemoteTools.filter((toolName): toolName is string =>
+      typeof toolName === "string" && toolName.length > 0
+    )
+    : [];
+}
+
 /** Options accepted by hosted chat execution preparation root run. */
 export type HostedChatExecutionPreparationRootRunOptions = Pick<
   PrepareHostedConversationRootRunContextInput,
@@ -127,6 +136,7 @@ export type HostedChatExecutionPreparationInput<
     model?: string;
     thinking?: RuntimeAgentThinkingConfig;
     maxSteps?: number;
+    allowedRemoteTools?: unknown;
   },
   TRuntimeResult extends HostedChatRuntimeCreationResult,
 > = {
@@ -281,6 +291,7 @@ export async function prepareHostedChatExecution<
     model?: string;
     thinking?: RuntimeAgentThinkingConfig;
     maxSteps?: number;
+    allowedRemoteTools?: unknown;
   },
   TRuntimeResult extends HostedChatRuntimeCreationResult,
 >(
@@ -330,6 +341,7 @@ export async function prepareHostedChatExecution<
       authToken: input.request.authToken,
       apiUrl: input.apiUrl,
       projectId: input.request.projectId,
+      providerOwnedToolNames: getAllowedRemoteToolNames(input.agentConfig),
     },
   );
 
@@ -352,6 +364,7 @@ export async function prepareHostedChatRuntimeMessages(
     return await prepareAgentRuntimeMessagesFromUiMessages({
       messages,
       emptyConversationPrompt: options.emptyConversationPrompt,
+      providerOwnedToolNames: options.providerOwnedToolNames,
     });
   }
   const authToken = options.authToken;
@@ -360,6 +373,7 @@ export async function prepareHostedChatRuntimeMessages(
   return await prepareAgentRuntimeMessagesFromUiMessages({
     messages,
     emptyConversationPrompt: options.emptyConversationPrompt,
+    providerOwnedToolNames: options.providerOwnedToolNames,
     resolveFileUrl: ({ uploadId }) =>
       getRuntimeUploadUrl({
         apiUrl,

--- a/src/agent/runtime/message-preparation.ts
+++ b/src/agent/runtime/message-preparation.ts
@@ -17,6 +17,7 @@ export type PrepareAgentRuntimeMessagesFromUiMessagesOptions = {
   messages: readonly ChatUiMessage[];
   emptyConversationPrompt?: string;
   resolveFileUrl?: RuntimeFileUrlResolver;
+  providerOwnedToolNames?: readonly string[];
 };
 
 /** Prepare agent runtime messages from UI messages. */
@@ -37,7 +38,9 @@ export async function prepareAgentRuntimeMessagesFromUiMessages(
     : [...options.messages];
 
   return convertProviderMessagesToAgentRuntimeMessages(
-    prepareProviderModelMessagesFromUiMessages(refreshedMessages),
+    prepareProviderModelMessagesFromUiMessages(refreshedMessages, {
+      providerOwnedToolNames: options.providerOwnedToolNames,
+    }),
   );
 }
 

--- a/src/chat/message-prep.test.ts
+++ b/src/chat/message-prep.test.ts
@@ -640,3 +640,70 @@ Deno.test("prepareProviderModelMessagesFromUiMessages prefers completed tool out
     },
   ]);
 });
+
+Deno.test("prepareProviderModelMessagesFromUiMessages omits provider-owned tool history", () => {
+  const prepared = prepareProviderModelMessagesFromUiMessages(
+    [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Explain Swedish tax residency." }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolName: "web_search",
+            toolCallId: "toolu_web_search",
+            input: { query: "site:skatteverket.se tax residency" },
+            state: "output-available",
+            providerExecuted: true,
+            output: null,
+          },
+          {
+            type: "text",
+            text: "Unlimited tax liability is based on Chapter 3 of the Income Tax Act.",
+          },
+        ],
+      },
+      {
+        id: "tool-1",
+        role: "tool",
+        parts: [
+          {
+            type: "tool_result",
+            tool_call_id: "toolu_web_search",
+            tool_name: "web_search",
+            output: null,
+          },
+        ],
+      },
+      {
+        id: "user-2",
+        role: "user",
+        parts: [{ type: "text", text: "Cite the official source." }],
+      },
+    ],
+    { providerOwnedToolNames: ["web_search"] },
+  );
+
+  assertEquals(prepared, [
+    {
+      role: "user",
+      content: [{ type: "text", text: "Explain Swedish tax residency." }],
+    },
+    {
+      role: "assistant",
+      content: [{
+        type: "text",
+        text: "Unlimited tax liability is based on Chapter 3 of the Income Tax Act.",
+      }],
+    },
+    {
+      role: "user",
+      content: [{ type: "text", text: "Cite the official source." }],
+    },
+  ]);
+});

--- a/src/chat/message-prep.ts
+++ b/src/chat/message-prep.ts
@@ -21,6 +21,11 @@ import type { IntegrationEndpointHistoricalSummary } from "../integrations/schem
 
 const CHARS_PER_TOKEN = 4;
 
+/** Options accepted by prepare provider model messages from UI messages. */
+export interface PrepareProviderModelMessagesFromUiMessagesOptions {
+  providerOwnedToolNames?: readonly string[];
+}
+
 /** Estimate tokens. */
 export function estimateTokens(value: unknown): number {
   return Math.ceil(JSON.stringify(value ?? "").length / CHARS_PER_TOKEN);
@@ -478,15 +483,84 @@ function filterValidMessages(messages: ProviderModelMessage[]): ProviderModelMes
   });
 }
 
+function getMessagePartToolCallId(part: unknown): string | undefined {
+  if (!part || typeof part !== "object" || Array.isArray(part)) return undefined;
+
+  return getStringField(part, "toolCallId", "") ||
+    getStringField(part, "tool_call_id", "") ||
+    getStringField(part, "id", "") ||
+    undefined;
+}
+
+function getMessagePartToolName(part: unknown): string | undefined {
+  if (!part || typeof part !== "object" || Array.isArray(part)) return undefined;
+
+  const record = part as Record<string, unknown>;
+  const explicitToolName = getStringField(part, "toolName", "") ||
+    getStringField(part, "tool_name", "") ||
+    getStringField(part, "name", "") ||
+    undefined;
+  if (explicitToolName) return explicitToolName;
+
+  const type = typeof record.type === "string" ? record.type : undefined;
+  return type?.startsWith("tool-") && type !== "tool-call" && type !== "tool-result"
+    ? type.replace(/^tool-/, "")
+    : undefined;
+}
+
+function stripProviderOwnedToolParts(
+  messages: ChatUiMessage[],
+  providerOwnedToolNames: readonly string[] | undefined,
+): ChatUiMessage[] {
+  if (!providerOwnedToolNames || providerOwnedToolNames.length === 0) {
+    return messages;
+  }
+
+  const providerOwnedNames = new Set(providerOwnedToolNames);
+  const providerOwnedToolCallIds = new Set<string>();
+
+  return messages.map((message) => {
+    if (message.role === "user" || message.role === "system") {
+      providerOwnedToolCallIds.clear();
+      return message;
+    }
+
+    let mutated = false;
+    const parts = message.parts.filter((part) => {
+      const toolName = getMessagePartToolName(part);
+      const toolCallId = getMessagePartToolCallId(part);
+      const ownedByName = toolName ? providerOwnedNames.has(toolName) : false;
+      const ownedByCallId = toolCallId ? providerOwnedToolCallIds.has(toolCallId) : false;
+
+      if (!ownedByName && !ownedByCallId) {
+        return true;
+      }
+
+      if (toolCallId) {
+        providerOwnedToolCallIds.add(toolCallId);
+      }
+      mutated = true;
+      return false;
+    });
+
+    return mutated ? { ...message, parts } : message;
+  });
+}
+
 /** Prepare provider model messages from UI messages. */
 export function prepareProviderModelMessagesFromUiMessages(
   messages: ChatUiMessage[],
+  options: PrepareProviderModelMessagesFromUiMessagesOptions = {},
 ): ProviderModelMessage[] {
   const validMessages = messages.filter((message) =>
     message && typeof message === "object" && "role" in message
   );
   const normalizedMessages = normalizeMessageFilePartMediaTypes(validMessages);
-  const strippedPendingToolMessages = stripPendingToolParts(normalizedMessages);
+  const strippedProviderOwnedToolMessages = stripProviderOwnedToolParts(
+    normalizedMessages,
+    options.providerOwnedToolNames,
+  );
+  const strippedPendingToolMessages = stripPendingToolParts(strippedProviderOwnedToolMessages);
   const strippedSupersededToolMessages = stripSupersededToolErrorParts(strippedPendingToolMessages);
   const rewrittenMessages = rewriteUnsupportedFilePartsAsAnnotations(
     strippedSupersededToolMessages,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.644";
+export const VERSION = "0.1.645";


### PR DESCRIPTION
## Summary\n- strip configured provider-owned remote tool history before hosted chat messages are replayed to the model\n- pass agent allowedRemoteTools into hosted message preparation\n- add regressions for the AG-UI follow-up failure seen with Anthropic web_search\n- bump package version to 0.1.645\n\n## Verification\n- deno fmt --check deno.json src/utils/version-constant.ts src/chat/message-prep.ts src/chat/message-prep.test.ts src/agent/runtime/message-preparation.ts src/agent/hosted/chat-preparation.ts src/agent/hosted/chat-preparation.test.ts\n- deno check src/chat/message-prep.ts src/agent/runtime/message-preparation.ts src/agent/hosted/chat-preparation.ts\n- deno test --no-check --allow-all src/chat/message-prep.test.ts src/agent/hosted/chat-preparation.test.ts src/agent/ag-ui/browser-encoder.test.ts src/chat/ag-ui.test.ts src/agent/runtime/text-generation-runtime-message-converter.test.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/message-preparation.test.ts