### PR TITLE
Publish unified agent tool config package

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.645",
+  "version": "0.1.646",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.645";
+export const VERSION = "0.1.646";


### PR DESCRIPTION
## Summary
- bump framework version to 0.1.646 so npm publishes a package that includes the unified agent tool registration exports
- unblock veryfront-agent from consuming the new veryfrontApiMcpServer and veryfrontStudioMcpServer helpers

## Verification
- pre-push: formatting, lint, typecheck, 1,978 unit tests

## Context
veryfront@0.1.645 was published before PR #2083 merged, so that immutable npm package does not contain the new exports.