### PR TITLE
Prevent AG-UI from replaying provider-owned tools

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.645",
+  "version": "0.1.646",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/ag-ui/handler.test.ts
+++ b/src/agent/ag-ui/handler.test.ts
@@ -175,6 +175,130 @@ describe("agent/ag-ui-handler", () => {
     assertStringIncludes(body, '"delta":"hello from runtime"');
   });
 
+  it("omits provider-owned remote tool history before direct streaming", async () => {
+    const testAgent = createTestAgent();
+    testAgent.agent.config.providerTools = ["web_search"];
+    const handler = createAgUiHandler({ agent: testAgent.agent });
+
+    const response = await handler(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [
+            {
+              id: "user-1",
+              role: "user",
+              parts: [{ type: "text", text: "Explain Swedish tax residency." }],
+            },
+            {
+              id: "assistant-1",
+              role: "assistant",
+              parts: [
+                { type: "text", text: "I searched official sources." },
+                {
+                  type: "tool-web_search",
+                  toolCallId: "toolu_search_1",
+                  toolName: "web_search",
+                  args: { query: "site:skatteverket.se tax residency" },
+                  output: { results: [{ title: "Skatteverket" }] },
+                },
+              ],
+            },
+            {
+              id: "user-2",
+              role: "user",
+              parts: [{ type: "text", text: "Cite the official source." }],
+            },
+          ],
+        }),
+      }),
+    );
+
+    await response.text();
+
+    assertEquals(testAgent.capturedMessages, [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Explain Swedish tax residency." }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "I searched official sources." }],
+      },
+      {
+        id: "user-2",
+        role: "user",
+        parts: [{ type: "text", text: "Cite the official source." }],
+      },
+    ]);
+  });
+
+  it("omits provider-owned remote tool-only messages before direct streaming", async () => {
+    const testAgent = createTestAgent();
+    testAgent.agent.config.providerTools = ["web_search"];
+    const handler = createAgUiHandler({ agent: testAgent.agent });
+
+    const response = await handler(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [
+            {
+              id: "user-1",
+              role: "user",
+              parts: [{ type: "text", text: "Explain Swedish tax residency." }],
+            },
+            {
+              id: "assistant-search",
+              role: "assistant",
+              parts: [{
+                type: "tool-web_search",
+                toolCallId: "toolu_search_1",
+                toolName: "web_search",
+                args: { query: "site:skatteverket.se tax residency" },
+                output: { results: [{ title: "Skatteverket" }] },
+              }],
+            },
+            {
+              id: "assistant-1",
+              role: "assistant",
+              parts: [{ type: "text", text: "I found the official guidance." }],
+            },
+            {
+              id: "user-2",
+              role: "user",
+              parts: [{ type: "text", text: "Cite the official source." }],
+            },
+          ],
+        }),
+      }),
+    );
+
+    await response.text();
+
+    assertEquals(testAgent.capturedMessages, [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Explain Swedish tax residency." }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "I found the official guidance." }],
+      },
+      {
+        id: "user-2",
+        role: "user",
+        parts: [{ type: "text", text: "Cite the official source." }],
+      },
+    ]);
+  });
+
   it("bridges direct tool data events into the AG-UI stream", async () => {
     const testAgent = createTestAgent();
     testAgent.agent.stream = async (input) => {

--- a/src/agent/ag-ui/handler.ts
+++ b/src/agent/ag-ui/handler.ts
@@ -54,6 +54,14 @@ function generateRunId(): string {
   return `run_${crypto.randomUUID().replaceAll("-", "")}`;
 }
 
+function getProviderToolNames(agent: Agent): string[] {
+  return Array.isArray(agent.config.providerTools)
+    ? agent.config.providerTools.filter((toolName): toolName is string =>
+      typeof toolName === "string" && toolName.length > 0
+    )
+    : [];
+}
+
 function createToolDataEventBridge() {
   const pendingEvents: ToolExecutionDataEvent[] = [];
   let publishDataEvent: ToolExecutionDataEventPublisher = (event) => {
@@ -226,7 +234,9 @@ async function createAgUiDirectStreamResponse(
   const threadId = request.threadId ?? crypto.randomUUID();
   const runId = request.runId ?? generateRunId();
   const context = buildStreamContext(request, baseContext, threadId, runId);
-  let messages = normalizeAgUiMessages(request.messages);
+  let messages = normalizeAgUiMessages(request.messages, {
+    providerOwnedToolNames: getProviderToolNames(agent),
+  });
 
   const beforeStreamResult = await beforeStream?.({
     request: rawRequest,
@@ -276,7 +286,9 @@ async function createAgUiInjectedToolsStreamResponse(
   const threadId = request.threadId ?? crypto.randomUUID();
   const runId = request.runId ?? generateRunId();
   const context = buildStreamContext(request, baseContext, threadId, runId);
-  let messages = normalizeAgUiMessages(request.messages);
+  let messages = normalizeAgUiMessages(request.messages, {
+    providerOwnedToolNames: getProviderToolNames(agent),
+  });
 
   const beforeStreamResult = await beforeStream?.({
     request: rawRequest,

--- a/src/agent/ag-ui/host-support.ts
+++ b/src/agent/ag-ui/host-support.ts
@@ -126,6 +126,10 @@ export type AgUiContextItem = InferSchema<ReturnType<typeof getAgUiContextItemSc
 /** Request payload for AG-UI. */
 export type AgUiRequest = InferSchema<ReturnType<typeof getAgUiRequestSchema>>;
 
+export interface NormalizeAgUiMessagesOptions {
+  providerOwnedToolNames?: readonly string[];
+}
+
 function normalizeToolArgs(part: Record<string, unknown>): Record<string, unknown> {
   if (isRecord(part.args)) return part.args;
   if (isRecord(part.input)) return part.input;
@@ -157,6 +161,48 @@ function hasToolResultPart(
     (part.type === "tool-result" && part.toolCallId === toolCallId) ||
     (part.type === "tool_result" && part.tool_call_id === toolCallId)
   );
+}
+
+function getMessagePartToolCallId(part: Message["parts"][number]): string | undefined {
+  const record = part as Record<string, unknown>;
+  const value = record.toolCallId ?? record.tool_call_id ?? record.id;
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function getMessagePartToolName(part: Message["parts"][number]): string | undefined {
+  const record = part as Record<string, unknown>;
+  const explicitToolName = record.toolName ?? record.tool_name ?? record.name;
+  if (typeof explicitToolName === "string" && explicitToolName.length > 0) {
+    return explicitToolName;
+  }
+
+  return part.type.startsWith("tool-") && part.type !== "tool-call" && part.type !== "tool-result"
+    ? part.type.replace(/^tool-/, "")
+    : undefined;
+}
+
+function shouldKeepProviderVisibleToolPart(
+  part: Message["parts"][number],
+  providerOwnedToolNames: ReadonlySet<string>,
+  providerOwnedToolCallIds: Set<string>,
+): boolean {
+  if (providerOwnedToolNames.size === 0) {
+    return true;
+  }
+
+  const toolName = getMessagePartToolName(part);
+  const toolCallId = getMessagePartToolCallId(part);
+  const ownedByName = toolName ? providerOwnedToolNames.has(toolName) : false;
+  const ownedByCallId = toolCallId ? providerOwnedToolCallIds.has(toolCallId) : false;
+
+  if (!ownedByName && !ownedByCallId) {
+    return true;
+  }
+
+  if (toolCallId) {
+    providerOwnedToolCallIds.add(toolCallId);
+  }
+  return false;
 }
 
 function normalizeMessagePart(part: Record<string, unknown>): Message["parts"][number] | null {
@@ -225,11 +271,21 @@ function normalizeMessagePart(part: Record<string, unknown>): Message["parts"][n
   return null;
 }
 
-function extractAssistantToolOutputMessages(message: AgUiRequest["messages"][number]): Message[] {
+function extractAssistantToolOutputMessages(
+  message: AgUiRequest["messages"][number],
+  providerOwnedToolNames: ReadonlySet<string>,
+  providerOwnedToolCallIds: Set<string>,
+): Message[] {
   if (message.role !== "assistant") return [];
 
   return message.parts.flatMap((part) => {
     if (!isToolPartWithOutput(part) || hasToolResultPart(message.parts, part.toolCallId)) {
+      return [];
+    }
+    if (
+      providerOwnedToolNames.has(part.toolName) || providerOwnedToolCallIds.has(part.toolCallId)
+    ) {
+      providerOwnedToolCallIds.add(part.toolCallId);
       return [];
     }
 
@@ -262,21 +318,42 @@ export async function parseAgUiRequestOrError(
 }
 
 /** Normalizes AG-UI messages. */
-export function normalizeAgUiMessages(messages: AgUiRequest["messages"]): Message[] {
+export function normalizeAgUiMessages(
+  messages: AgUiRequest["messages"],
+  options: NormalizeAgUiMessagesOptions = {},
+): Message[] {
+  const providerOwnedToolNames = new Set(options.providerOwnedToolNames ?? []);
+  const providerOwnedToolCallIds = new Set<string>();
+
   return messages.flatMap((message) => {
+    if (message.role === "user" || message.role === "system") {
+      providerOwnedToolCallIds.clear();
+    }
+
     const normalizedMessage = {
       id: message.id,
       role: message.role,
       parts: message.parts
         .map((part) => normalizeMessagePart(part))
-        .filter((part): part is Message["parts"][number] => part !== null),
+        .filter((part): part is Message["parts"][number] => part !== null)
+        .filter((part) =>
+          shouldKeepProviderVisibleToolPart(
+            part,
+            providerOwnedToolNames,
+            providerOwnedToolCallIds,
+          )
+        ),
       ...(message.createdAt ? { timestamp: Date.parse(message.createdAt) || undefined } : {}),
       ...(message.metadata ? { metadata: message.metadata } : {}),
     } as Message;
 
     return [
-      normalizedMessage,
-      ...extractAssistantToolOutputMessages(message),
+      ...(normalizedMessage.parts.length > 0 ? [normalizedMessage] : []),
+      ...extractAssistantToolOutputMessages(
+        message,
+        providerOwnedToolNames,
+        providerOwnedToolCallIds,
+      ),
     ];
   });
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.645";
+export const VERSION = "0.1.646";


### PR DESCRIPTION
## Summary\n- Strip provider-owned tool calls and synthesized tool outputs from direct AG-UI history before streaming to the agent.\n- Key the stripping from the current providerTools config so local and injected tools keep normal replay behavior.\n- Bump Veryfront to 0.1.646.\n\n## Verification\n- deno test --no-check --allow-all src/agent/ag-ui/handler.test.ts src/chat/message-prep.test.ts src/agent/hosted/chat-preparation.test.ts src/agent/runtime/message-preparation.test.ts src/agent/runtime/model-tool-converter.test.ts\n- deno check src/agent/ag-ui/handler.ts src/agent/ag-ui/host-support.ts\n- deno fmt --check deno.json src/utils/version-constant.ts src/agent/ag-ui/handler.ts src/agent/ag-ui/host-support.ts src/agent/ag-ui/handler.test.ts\n- pre-push: format, lint, typecheck, unit tests: 1978 passed\n\n## Reproduction fixed\nA Swedish Tax Adviser AG-UI chat using providerTools: ["web_search"] failed on the second turn because browser-visible provider-owned web_search output was replayed as a local tool_result without a matching provider tool_use. This PR strips that provider-owned history at AG-UI normalization.