### PR TITLE
Preserve AG-UI tool-result pairing during replay

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.646",
+  "version": "0.1.647",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/ag-ui/host-support.test.ts
+++ b/src/agent/ag-ui/host-support.test.ts
@@ -9,6 +9,8 @@ import {
   parseAgUiRequest,
   parseAgUiRequestOrError,
 } from "./host-support.ts";
+import { convertToTextGenerationRuntimeMessages } from "../runtime/text-generation-runtime-message-converter.ts";
+import type { Message } from "../types.ts";
 
 describe("agent/ag-ui-host-support", () => {
   it("parses a valid AG-UI request body through the public helper", async () => {
@@ -233,6 +235,97 @@ describe("agent/ag-ui-host-support", () => {
         id: "user-2",
         role: "user",
         parts: [{ type: "text", text: "Summarize that result" }],
+      },
+    ]);
+  });
+
+  it("pairs replayed assistant tool outputs before trailing assistant text", () => {
+    const normalized = normalizeAgUiMessages([
+      { id: "user-1", role: "user", parts: [{ type: "text", text: "Question one" }] },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-load-skill",
+            toolCallId: "tool-load",
+            toolName: "load-skill",
+            state: "output-available",
+            input: { skill: "tax" },
+            output: { ok: true },
+          },
+          {
+            type: "tool-search_docs",
+            toolCallId: "tool-search",
+            toolName: "search_docs",
+            state: "output-available",
+            input: { query: "residency" },
+            output: { matches: 2 },
+          },
+          { type: "text", text: "Here is the answer." },
+        ],
+      },
+      { id: "user-2", role: "user", parts: [{ type: "text", text: "Follow-up" }] },
+    ]);
+
+    assertEquals(normalized.map((message) => message.role), [
+      "user",
+      "assistant",
+      "tool",
+      "assistant",
+      "tool",
+      "assistant",
+      "user",
+    ]);
+
+    const wireMessages = convertToTextGenerationRuntimeMessages(normalized as Message[]);
+    for (let index = 0; index < wireMessages.length; index += 1) {
+      const message = wireMessages[index];
+      if (!message) continue;
+      if (message.role !== "tool") continue;
+
+      const previous = wireMessages[index - 1];
+      const previousToolCallIds = new Set<string>();
+      if (previous?.role === "assistant" && Array.isArray(previous.content)) {
+        for (const part of previous.content) {
+          if (part.type === "tool-call") previousToolCallIds.add(part.toolCallId);
+        }
+      }
+
+      if (Array.isArray(message.content)) {
+        for (const part of message.content) {
+          if (part.type === "tool-result") {
+            assertEquals(previousToolCallIds.has(part.toolCallId), true);
+          }
+        }
+      }
+    }
+  });
+
+  it("does not synthesize tool results for provider-owned assistant tool parts", () => {
+    const messages = normalizeAgUiMessages([
+      {
+        id: "assistant-search",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "I checked the source." },
+          {
+            type: "tool-web_search",
+            toolCallId: "tool-search",
+            toolName: "web_search",
+            state: "output-available",
+            input: { query: "site:skatteverket.se tax residency" },
+            output: { results: [{ title: "Skatteverket" }] },
+          },
+        ],
+      },
+    ], { providerOwnedToolNames: ["web_search"] });
+
+    assertEquals(messages, [
+      {
+        id: "assistant-search",
+        role: "assistant",
+        parts: [{ type: "text", text: "I checked the source." }],
       },
     ]);
   });

--- a/src/agent/ag-ui/host-support.ts
+++ b/src/agent/ag-ui/host-support.ts
@@ -271,35 +271,72 @@ function normalizeMessagePart(part: Record<string, unknown>): Message["parts"][n
   return null;
 }
 
-function extractAssistantToolOutputMessages(
-  message: AgUiRequest["messages"][number],
+type AgUiMessage = AgUiRequest["messages"][number];
+
+function buildMessageMetadataFields(message: AgUiMessage): Partial<Message> {
+  return {
+    ...(message.createdAt ? { timestamp: Date.parse(message.createdAt) || undefined } : {}),
+    ...(message.metadata ? { metadata: message.metadata } : {}),
+  } as Partial<Message>;
+}
+
+function normalizeAssistantMessage(
+  message: AgUiMessage,
   providerOwnedToolNames: ReadonlySet<string>,
   providerOwnedToolCallIds: Set<string>,
 ): Message[] {
-  if (message.role !== "assistant") return [];
+  const messages: Message[] = [];
+  const metadataFields = buildMessageMetadataFields(message);
+  let segmentParts: Message["parts"] = [];
+  let segmentIndex = 0;
 
-  return message.parts.flatMap((part) => {
-    if (!isToolPartWithOutput(part) || hasToolResultPart(message.parts, part.toolCallId)) {
-      return [];
-    }
+  const flushAssistantSegment = () => {
+    if (segmentParts.length === 0) return;
+    messages.push({
+      id: segmentIndex === 0 ? message.id : `${message.id}-${segmentIndex}`,
+      role: "assistant",
+      parts: segmentParts,
+      ...metadataFields,
+    } as Message);
+    segmentParts = [];
+    segmentIndex += 1;
+  };
+
+  for (const part of message.parts) {
+    const normalizedPart = normalizeMessagePart(part);
+    if (!normalizedPart) continue;
+
     if (
-      providerOwnedToolNames.has(part.toolName) || providerOwnedToolCallIds.has(part.toolCallId)
+      !shouldKeepProviderVisibleToolPart(
+        normalizedPart,
+        providerOwnedToolNames,
+        providerOwnedToolCallIds,
+      )
     ) {
-      providerOwnedToolCallIds.add(part.toolCallId);
-      return [];
+      continue;
     }
 
-    return [{
-      id: `tool_${part.toolCallId}`,
-      role: "tool",
-      parts: [{
-        type: "tool-result",
-        toolCallId: part.toolCallId,
-        toolName: part.toolName,
-        result: part.output,
-      }],
-    }];
-  }) as Message[];
+    if (isToolPartWithOutput(part) && !hasToolResultPart(message.parts, part.toolCallId)) {
+      segmentParts.push(normalizedPart);
+      flushAssistantSegment();
+      messages.push({
+        id: `tool_${part.toolCallId}`,
+        role: "tool",
+        parts: [{
+          type: "tool-result",
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          result: part.output,
+        }],
+      } as Message);
+      continue;
+    }
+
+    segmentParts.push(normalizedPart);
+  }
+
+  flushAssistantSegment();
+  return messages;
 }
 
 /** Request payload for parse AG-UI. */
@@ -330,6 +367,14 @@ export function normalizeAgUiMessages(
       providerOwnedToolCallIds.clear();
     }
 
+    if (message.role === "assistant") {
+      return normalizeAssistantMessage(
+        message,
+        providerOwnedToolNames,
+        providerOwnedToolCallIds,
+      );
+    }
+
     const normalizedMessage = {
       id: message.id,
       role: message.role,
@@ -343,18 +388,10 @@ export function normalizeAgUiMessages(
             providerOwnedToolCallIds,
           )
         ),
-      ...(message.createdAt ? { timestamp: Date.parse(message.createdAt) || undefined } : {}),
-      ...(message.metadata ? { metadata: message.metadata } : {}),
+      ...buildMessageMetadataFields(message),
     } as Message;
 
-    return [
-      ...(normalizedMessage.parts.length > 0 ? [normalizedMessage] : []),
-      ...extractAssistantToolOutputMessages(
-        message,
-        providerOwnedToolNames,
-        providerOwnedToolCallIds,
-      ),
-    ];
+    return normalizedMessage.parts.length > 0 ? [normalizedMessage] : [];
   });
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.646";
+export const VERSION = "0.1.647";


### PR DESCRIPTION
## Summary

- segment replayed AG-UI assistant messages so local inline tool outputs stay immediately paired with their tool calls
- keep provider-owned tools such as `web_search` stripped from replay history
- bump package version to `0.1.647`

## Relation to #2086

This keeps the usable part of #2086, the ordered assistant/tool pairing, but applies it on top of the provider-owned tool replay fix already merged in #2085. It intentionally does not preserve empty assistant messages after all parts are stripped.

## Verification

- `deno test --no-check --allow-all src/agent/ag-ui/host-support.test.ts src/agent/ag-ui/handler.test.ts src/chat/message-prep.test.ts src/agent/hosted/chat-preparation.test.ts src/agent/runtime/message-preparation.test.ts src/agent/runtime/model-tool-converter.test.ts`
- `deno check src/agent/ag-ui/host-support.ts src/agent/ag-ui/host-support.test.ts src/agent/ag-ui/handler.ts src/agent/ag-ui/handler.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts src/agent/ag-ui/host-support.ts src/agent/ag-ui/host-support.test.ts`
- pre-push hook: format, lint, type-check, full unit suite (`1978 passed`, `0 failed`)
