### PR TITLE
Sanitize malformed child tool transcripts

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.648",
+  "version": "0.1.649",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/child-run/result-summary.test.ts
+++ b/src/agent/child-run/result-summary.test.ts
@@ -32,6 +32,18 @@ describe("child-run-result-summary", () => {
     it("wraps text in a summary object", () => {
       assertEquals(buildChildRunResultSummary("done"), { text: "done" });
     });
+
+    it("removes malformed tool transcript wrappers while preserving result content", () => {
+      assertEquals(
+        buildChildRunResultSummary(
+          'I will fetch the docs.\n\n<tool_call>{"name":"web_fetch","parameters":{"url":"https://example.com"}}</tool_call><tool_response>Title: Example Content: Example Domain</tool_response>\n\nNow I can continue.',
+        ),
+        {
+          text:
+            "I will fetch the docs.\n\nTitle: Example Content: Example Domain\n\nNow I can continue.",
+        },
+      );
+    });
   });
 
   describe("buildRootOwnedChildRunResultText", () => {

--- a/src/agent/child-run/result-summary.ts
+++ b/src/agent/child-run/result-summary.ts
@@ -1,6 +1,11 @@
 const CHILD_RUN_RESULT_TEXT_LIMIT = 4_000;
 const CHILD_RUN_VALUE_STRING_LIMIT = 500;
 const CHILD_RUN_VALUE_SUMMARY_MAX_DEPTH = 5;
+const MALFORMED_TOOL_RESPONSE_PATTERN = /<tool_response(?:\s[^>]*)?>([\s\S]*?)<\/tool_response>/gi;
+const MALFORMED_TOOL_CALL_PATTERN =
+  /<(tool_call|function_calls|invoke)(?:\s[^>]*)?>[\s\S]*?<\/\1>/gi;
+const MALFORMED_TOOL_TAG_PATTERN =
+  /<\/?(tool_call|tool_response|function_calls|invoke)(?:\s[^>]*)?>/gi;
 const ROOT_RESPONSE_PROCESS_PREFIX_PATTERNS = [
   /^let me [^.?!]+[.?!]\s*/i,
   /^i(?:'|’)ll [^.?!]+[.?!]\s*/i,
@@ -13,16 +18,28 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function sanitizeMalformedToolTranscriptText(text: string): string {
+  return text
+    .replace(MALFORMED_TOOL_RESPONSE_PATTERN, "\n$1\n")
+    .replace(MALFORMED_TOOL_CALL_PATTERN, "\n")
+    .replace(MALFORMED_TOOL_TAG_PATTERN, "")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 /** Summarize child run result text helper. */
 export function summarizeChildRunResultText(
   text: string,
   maxLength = CHILD_RUN_RESULT_TEXT_LIMIT,
 ): string {
-  if (text.length <= maxLength) {
-    return text;
+  const normalized = sanitizeMalformedToolTranscriptText(text);
+
+  if (normalized.length <= maxLength) {
+    return normalized;
   }
 
-  return `${text.slice(0, maxLength)}… [truncated ${text.length - maxLength} chars]`;
+  return `${normalized.slice(0, maxLength)}… [truncated ${normalized.length - maxLength} chars]`;
 }
 
 /** Builds child run result summary. */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.648";
+export const VERSION = "0.1.649";


### PR DESCRIPTION
## Summary
- sanitize malformed XML-style tool transcript wrappers in child-run result summaries
- preserve embedded tool response content while removing synthetic tool call wrappers
- bump Veryfront framework version to 0.1.649

## Verification
- deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/agent/child-run/result-summary.test.ts
- deno task verify:quick
- pre-push checks: 1978 tests / 18011 steps passed