### PR TITLE
Fix malformed child agent transcript sanitization

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.649",
+  "version": "0.1.650",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/child-run/result-summary.test.ts
+++ b/src/agent/child-run/result-summary.test.ts
@@ -44,6 +44,17 @@ describe("child-run-result-summary", () => {
         },
       );
     });
+
+    it("removes malformed function transcript wrappers while preserving function result content", () => {
+      assertEquals(
+        buildChildRunResultSummary(
+          '```\nbash\n```\n\n<function_calls>\n<invoke name="run_bash">\n<parameter name="command">curl -s "https://mckinsey.github.io/agents-at-scale-ark/" 2>&1 | head -5</parameter>\n</invoke>\n</function_calls>\n<function_result>\nAgents at Scale: ARK\nOverview\nArchitecture\n</parameter>\n</invoke>\n</function_calls>',
+        ),
+        {
+          text: "Agents at Scale: ARK\nOverview\nArchitecture",
+        },
+      );
+    });
   });
 
   describe("buildRootOwnedChildRunResultText", () => {

--- a/src/agent/child-run/result-summary.ts
+++ b/src/agent/child-run/result-summary.ts
@@ -2,10 +2,14 @@ const CHILD_RUN_RESULT_TEXT_LIMIT = 4_000;
 const CHILD_RUN_VALUE_STRING_LIMIT = 500;
 const CHILD_RUN_VALUE_SUMMARY_MAX_DEPTH = 5;
 const MALFORMED_TOOL_RESPONSE_PATTERN = /<tool_response(?:\s[^>]*)?>([\s\S]*?)<\/tool_response>/gi;
+const MALFORMED_TOOL_COMMAND_PREFIX_PATTERN =
+  /<(?:tool_call|function_calls|invoke)(?:\s[^>]*)?>[\s\S]*?(?=<(?:tool_response|function_result)(?:\s[^>]*)?>)/gi;
 const MALFORMED_TOOL_CALL_PATTERN =
   /<(tool_call|function_calls|invoke)(?:\s[^>]*)?>[\s\S]*?<\/\1>/gi;
 const MALFORMED_TOOL_TAG_PATTERN =
-  /<\/?(tool_call|tool_response|function_calls|invoke)(?:\s[^>]*)?>/gi;
+  /<\/?(tool_call|tool_response|function_calls|invoke|parameter|function_result)(?:\s[^>]*)?>/gi;
+const MALFORMED_TOOL_TRANSCRIPT_FENCE_PATTERN =
+  /```[ \t]*(?:\r?\n)?[ \t]*(?:bash|sh|shell|zsh)[ \t]*(?:\r?\n)?```(?=\s*<(?:tool_call|tool_response|function_calls|invoke|function_result)\b)/gi;
 const ROOT_RESPONSE_PROCESS_PREFIX_PATTERNS = [
   /^let me [^.?!]+[.?!]\s*/i,
   /^i(?:'|’)ll [^.?!]+[.?!]\s*/i,
@@ -20,7 +24,9 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 
 function sanitizeMalformedToolTranscriptText(text: string): string {
   return text
+    .replace(MALFORMED_TOOL_TRANSCRIPT_FENCE_PATTERN, "")
     .replace(MALFORMED_TOOL_RESPONSE_PATTERN, "\n$1\n")
+    .replace(MALFORMED_TOOL_COMMAND_PREFIX_PATTERN, "\n")
     .replace(MALFORMED_TOOL_CALL_PATTERN, "\n")
     .replace(MALFORMED_TOOL_TAG_PATTERN, "")
     .replace(/[ \t]+\n/g, "\n")

--- a/src/agent/hosted/durable-child-fork-execution.test.ts
+++ b/src/agent/hosted/durable-child-fork-execution.test.ts
@@ -191,6 +191,55 @@ describe("agent/hosted-durable-child-fork-execution", () => {
     );
   });
 
+  it("sanitizes malformed child transcript text in durable invoke success results", () => {
+    const identifiers = {
+      childConversationId: CHILD_CONVERSATION_ID,
+      childRunId: "run_child_1",
+      childMessageId: CHILD_MESSAGE_ID,
+      latestEventId: 7,
+      latestExternalEventSequence: 3,
+    };
+    const targets = {
+      sourceTargetKind: "preview_branch",
+      runtimeTargetKind: "preview_branch",
+      targetBranchId: BRANCH_ID,
+    } satisfies ConversationRunTargets;
+    const result: ChildRunExecutionResult = {
+      ...baseSuccessResult(),
+      summary: {
+        text:
+          '<function_calls><invoke name="run_bash"><parameter name="command">curl -s https://example.com</parameter></invoke></function_calls><function_result>Title: Example Content</parameter></invoke></function_calls>',
+      },
+    };
+
+    assertEquals(
+      buildHostedDurableChildInvokeSuccessResult({
+        result,
+        snapshot: buildChildRunExecutionSnapshot(result),
+        identifiers,
+        targets,
+      }),
+      {
+        ok: true,
+        status: "completed",
+        text: "Title: Example Content",
+        summary: { text: "Title: Example Content" },
+        steps: 2,
+        toolCalls: [],
+        toolResults: [],
+        usage: { inputTokens: 3, outputTokens: 4, totalTokens: 7 },
+        durationMs: 12,
+        childConversationId: CHILD_CONVERSATION_ID,
+        childRunId: "run_child_1",
+        childMessageId: CHILD_MESSAGE_ID,
+        sourceTargetKind: "preview_branch",
+        runtimeTargetKind: "preview_branch",
+        terminalErrorCode: null,
+        terminalErrorMessage: null,
+      },
+    );
+  });
+
   it("records standard hosted invoke trace attributes while building results", () => {
     const recordedAttributes: unknown[] = [];
     const identifiers = {

--- a/src/agent/hosted/durable-child-fork-execution.ts
+++ b/src/agent/hosted/durable-child-fork-execution.ts
@@ -169,14 +169,15 @@ export function buildHostedDurableChildInvokeSuccessResult<
 >(input: HostedDurableChildSuccess<TLocalResult>): HostedDurableChildInvokeResult {
   const summaryText = input.snapshot.fullResultText ??
     (input.result.success ? input.result.summary.text : input.result.error);
+  const summary = summaryText ? buildChildRunResultSummary(summaryText) : null;
 
   return {
     ok: input.snapshot.success,
     status: input.snapshot.success ? "completed" : "failed",
-    ...(summaryText
+    ...(summary
       ? {
-        text: summaryText,
-        summary: buildChildRunResultSummary(summaryText),
+        text: summary.text,
+        summary,
       }
       : {}),
     ...(input.snapshot.success ? {} : { error: input.snapshot.error ?? "invoke_agent failed" }),

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.649";
+export const VERSION = "0.1.650";


### PR DESCRIPTION
## Summary
- strip malformed function-call transcript wrappers around child function results
- return sanitized durable invoke_agent text, not only sanitized summary
- bump veryfront package version to 0.1.650 for release

## Verification
- deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/agent/child-run/result-summary.test.ts src/agent/hosted/durable-child-fork-execution.test.ts
- deno task verify:quick
- pre-push hook: full unit suite, 1978 passed