### PR TITLE
fix(agent): enforce loaded skill delegation overrides

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.650",
+  "version": "0.1.651",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -126,6 +126,11 @@ import {
   type CurrentRunToolState,
   recordCurrentRunToolResult,
 } from "./current-run-tool-state.ts";
+import {
+  applySkillDelegationOverridesToToolInput,
+  extractSkillDelegationOverrides,
+  type SkillDelegationOverrides,
+} from "./skill-delegation-overrides.ts";
 
 const logger = serverLogger.component("agent");
 const LOAD_SKILL_TOOL_ID = "load_skill";
@@ -926,6 +931,7 @@ export class AgentRuntime {
 
       // Request-scoped skill policy (not class-level mutable state)
       let activeSkillPolicy: string[] | undefined;
+      let activeSkillDelegationOverrides: SkillDelegationOverrides | undefined;
       const allowedRemoteToolNames = getRuntimeAllowedRemoteTools(this.config);
       const providerTools = getRuntimeProviderTools(this.config);
       const forwardedRemoteToolDefinitions = getRuntimeForwardedIntegrationToolDefs(this.config);
@@ -1125,6 +1131,11 @@ export class AgentRuntime {
               const startTime = Date.now();
 
               const cacheCtx = tryGetCacheKeyContext();
+              toolCall.args = applySkillDelegationOverridesToToolInput(
+                tc.toolName,
+                toolCall.args,
+                activeSkillDelegationOverrides,
+              );
               const executionContext = {
                 toolCallId: tc.toolCallId,
                 ...toolContext,
@@ -1160,6 +1171,7 @@ export class AgentRuntime {
               // Track skill policy from load_skill results
               if (tc.toolName === LOAD_SKILL_TOOL_ID) {
                 activeSkillPolicy = extractSkillPolicy(result);
+                activeSkillDelegationOverrides = extractSkillDelegationOverrides(result);
                 mustLoadSkillFirst = false;
               }
 
@@ -1253,6 +1265,7 @@ export class AgentRuntime {
 
     // Request-scoped skill policy (not class-level mutable state)
     let activeSkillPolicy: string[] | undefined;
+    let activeSkillDelegationOverrides: SkillDelegationOverrides | undefined;
     let finalFinishReason: string | undefined;
     let latestAssistantText = "";
     const allowedRemoteToolNames = getRuntimeAllowedRemoteTools(this.config);
@@ -1541,6 +1554,11 @@ export class AgentRuntime {
         try {
           toolCall.status = "executing";
           const startTime = Date.now();
+          toolCall.args = applySkillDelegationOverridesToToolInput(
+            tc.name,
+            toolCall.args,
+            activeSkillDelegationOverrides,
+          );
 
           callbacks?.onToolCall?.(toolCall);
 
@@ -1580,6 +1598,7 @@ export class AgentRuntime {
           // Track skill policy from load_skill results
           if (tc.name === LOAD_SKILL_TOOL_ID) {
             activeSkillPolicy = extractSkillPolicy(result);
+            activeSkillDelegationOverrides = extractSkillDelegationOverrides(result);
             mustLoadSkillFirst = false;
           }
 

--- a/src/agent/runtime/refresh.test.ts
+++ b/src/agent/runtime/refresh.test.ts
@@ -188,6 +188,194 @@ describe("agent runtime refresh hooks", () => {
     assertEquals(toolResults[0]?.context?.projectId, "project-stream");
   });
 
+  it("applies loaded skill maxSteps overrides to generate() invoke_agent calls", async () => {
+    const toolResults: ToolExecutionResultRequest[] = [];
+    let callCount = 0;
+    const model: ModelRuntime = {
+      provider: "hosted",
+      modelId: "hosted/skill-invoke-generate",
+      async doGenerate() {
+        callCount++;
+
+        if (callCount === 1) {
+          return {
+            content: [{
+              type: "tool-call",
+              toolCallId: "load-build-1",
+              toolName: "load_skill",
+              input: '{"skillId":"build"}',
+            }],
+            finishReason: "tool-calls",
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          };
+        }
+
+        if (callCount === 2) {
+          return {
+            content: [{
+              type: "tool-call",
+              toolCallId: "invoke-1",
+              toolName: "invoke_agent",
+              input:
+                '{"description":"Research reference system","prompt":"Research reference docs","max_steps":10}',
+            }],
+            finishReason: "tool-calls",
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          };
+        }
+
+        return {
+          content: [{ type: "text", text: "done" }],
+          finishReason: "stop",
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        };
+      },
+      async doStream() {
+        return { stream: createRuntimeStream([{ type: "finish", finishReason: "stop" }]) };
+      },
+    };
+    const loadSkill = tool({
+      id: "load_skill",
+      description: "Load a skill",
+      inputSchema: defineSchema((v) => v.object({ skillId: v.string() }))(),
+      execute: () => ({ skillId: "build", maxSteps: 160 }),
+    });
+    const invokeAgent = tool({
+      id: "invoke_agent",
+      description: "Invoke an agent",
+      inputSchema: defineSchema((v) =>
+        v.object({
+          description: v.string(),
+          prompt: v.string(),
+          max_steps: v.number().optional(),
+        })
+      )(),
+      execute: ({ max_steps }) => ({ ok: true, max_steps }),
+    });
+    const assistant = agent({
+      model: "hosted/skill-invoke-generate",
+      system: "Skill override generate test",
+      tools: { load_skill: loadSkill, invoke_agent: invokeAgent },
+      maxSteps: 3,
+      resolveModelTransport: async () => ({ model }),
+      onToolResult: (request) => {
+        toolResults.push(request);
+      },
+    });
+
+    await assistant.generate({ input: "Build a report" });
+
+    const invokeResult = toolResults.find((result) => result.toolName === "invoke_agent");
+    assertEquals(invokeResult?.input, {
+      description: "Research reference system",
+      prompt: "Research reference docs",
+      max_steps: 160,
+    });
+    assertEquals(invokeResult?.result, { ok: true, max_steps: 160 });
+  });
+
+  it("applies loaded skill maxSteps overrides to stream() invoke_agent calls", async () => {
+    const toolResults: ToolExecutionResultRequest[] = [];
+    let callCount = 0;
+    const model: ModelRuntime = {
+      provider: "hosted",
+      modelId: "hosted/skill-invoke-stream",
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "unused" }],
+          finishReason: "stop",
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        };
+      },
+      async doStream() {
+        callCount++;
+
+        if (callCount === 1) {
+          return {
+            stream: createRuntimeStream([
+              {
+                type: "tool-call",
+                toolCallId: "load-build-stream-1",
+                toolName: "load_skill",
+                input: '{"skillId":"build"}',
+              },
+              {
+                type: "finish",
+                finishReason: "tool-calls",
+                usage: { inputTokens: 1, outputTokens: 1 },
+              },
+            ]),
+          };
+        }
+
+        if (callCount === 2) {
+          return {
+            stream: createRuntimeStream([
+              {
+                type: "tool-call",
+                toolCallId: "invoke-stream-1",
+                toolName: "invoke_agent",
+                input:
+                  '{"description":"Research reference system","prompt":"Research reference docs","max_steps":10}',
+              },
+              {
+                type: "finish",
+                finishReason: "tool-calls",
+                usage: { inputTokens: 1, outputTokens: 1 },
+              },
+            ]),
+          };
+        }
+
+        return {
+          stream: createRuntimeStream([
+            { type: "text-delta", text: "done" },
+            { type: "finish", finishReason: "stop", usage: { inputTokens: 1, outputTokens: 1 } },
+          ]),
+        };
+      },
+    };
+    const loadSkill = tool({
+      id: "load_skill",
+      description: "Load a skill",
+      inputSchema: defineSchema((v) => v.object({ skillId: v.string() }))(),
+      execute: () => ({ skillId: "build", maxSteps: 160 }),
+    });
+    const invokeAgent = tool({
+      id: "invoke_agent",
+      description: "Invoke an agent",
+      inputSchema: defineSchema((v) =>
+        v.object({
+          description: v.string(),
+          prompt: v.string(),
+          max_steps: v.number().optional(),
+        })
+      )(),
+      execute: ({ max_steps }) => ({ ok: true, max_steps }),
+    });
+    const assistant = agent({
+      model: "hosted/skill-invoke-stream",
+      system: "Skill override stream test",
+      tools: { load_skill: loadSkill, invoke_agent: invokeAgent },
+      maxSteps: 3,
+      resolveModelTransport: async () => ({ model }),
+      onToolResult: (request) => {
+        toolResults.push(request);
+      },
+    });
+
+    const response = (await assistant.stream({ input: "Build a report" })).toDataStreamResponse();
+    await response.text();
+
+    const invokeResult = toolResults.find((result) => result.toolName === "invoke_agent");
+    assertEquals(invokeResult?.input, {
+      description: "Research reference system",
+      prompt: "Research reference docs",
+      max_steps: 160,
+    });
+    assertEquals(invokeResult?.result, { ok: true, max_steps: 160 });
+  });
+
   it("refreshes system and context at step boundaries for generate()", async () => {
     const runtimeRequests: RuntimeStateRequest[] = [];
     const observedSystems: string[] = [];

--- a/src/agent/runtime/skill-delegation-overrides.test.ts
+++ b/src/agent/runtime/skill-delegation-overrides.test.ts
@@ -1,0 +1,91 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  applySkillDelegationOverridesToToolInput,
+  extractSkillDelegationOverrides,
+} from "./skill-delegation-overrides.ts";
+
+describe("skill delegation overrides", () => {
+  it("extracts loaded skill model, thinking, and max step overrides", () => {
+    assertEquals(
+      extractSkillDelegationOverrides({
+        model: "opus",
+        thinking: false,
+        maxSteps: 160,
+      }),
+      {
+        model: "opus",
+        thinking: false,
+        maxSteps: 160,
+      },
+    );
+  });
+
+  it("raises invoke_agent max_steps to the active skill maxSteps floor", () => {
+    assertEquals(
+      applySkillDelegationOverridesToToolInput(
+        "invoke_agent",
+        {
+          prompt: "Research reference system",
+          description: "Research reference system",
+          max_steps: 10,
+        },
+        { maxSteps: 160 },
+      ),
+      {
+        prompt: "Research reference system",
+        description: "Research reference system",
+        max_steps: 160,
+      },
+    );
+  });
+
+  it("keeps larger explicit invoke_agent max_steps and ignores other tools", () => {
+    assertEquals(
+      applySkillDelegationOverridesToToolInput(
+        "invoke_agent",
+        {
+          prompt: "Research reference system",
+          description: "Research reference system",
+          max_steps: 200,
+        },
+        { maxSteps: 160 },
+      ),
+      {
+        prompt: "Research reference system",
+        description: "Research reference system",
+        max_steps: 200,
+      },
+    );
+
+    assertEquals(
+      applySkillDelegationOverridesToToolInput(
+        "bash",
+        { command: "echo ok" },
+        { maxSteps: 160 },
+      ),
+      { command: "echo ok" },
+    );
+  });
+
+  it("maps skill model and thinking defaults onto invoke_agent when omitted", () => {
+    assertEquals(
+      applySkillDelegationOverridesToToolInput(
+        "invoke_agent",
+        {
+          prompt: "Research reference system",
+          description: "Research reference system",
+        },
+        { model: "opus", thinking: false, maxSteps: 160 },
+      ),
+      {
+        prompt: "Research reference system",
+        description: "Research reference system",
+        model: "opus",
+        thinking: 0,
+        max_steps: 160,
+      },
+    );
+  });
+});

--- a/src/agent/runtime/skill-delegation-overrides.ts
+++ b/src/agent/runtime/skill-delegation-overrides.ts
@@ -1,0 +1,69 @@
+/** Delegation overrides from the active loaded skill. */
+export type SkillDelegationOverrides = {
+  model?: string;
+  thinking?: false | number;
+  maxSteps?: number;
+};
+
+const INVOKE_AGENT_TOOL_ID = "invoke_agent";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getPositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+/** Extract active skill delegation overrides from a load_skill result. */
+export function extractSkillDelegationOverrides(result: unknown): SkillDelegationOverrides {
+  if (!isRecord(result)) {
+    return {};
+  }
+
+  const model = typeof result.model === "string" && result.model.trim().length > 0
+    ? result.model.trim()
+    : undefined;
+  const thinking = result.thinking === false
+    ? result.thinking
+    : getPositiveInteger(result.thinking);
+  const maxSteps = getPositiveInteger(result.maxSteps);
+
+  return {
+    ...(model ? { model } : {}),
+    ...(thinking !== undefined ? { thinking } : {}),
+    ...(maxSteps !== undefined ? { maxSteps } : {}),
+  };
+}
+
+function isBlankString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length === 0;
+}
+
+/** Apply active skill delegation overrides to invoke_agent tool input. */
+export function applySkillDelegationOverridesToToolInput(
+  toolName: string,
+  input: Record<string, unknown>,
+  overrides: SkillDelegationOverrides | undefined,
+): Record<string, unknown> {
+  if (toolName !== INVOKE_AGENT_TOOL_ID || !overrides) {
+    return input;
+  }
+
+  const next = { ...input };
+
+  if (overrides.model && (typeof next.model !== "string" || isBlankString(next.model))) {
+    next.model = overrides.model;
+  }
+
+  if (overrides.thinking !== undefined && next.thinking === undefined) {
+    next.thinking = overrides.thinking === false ? 0 : overrides.thinking;
+  }
+
+  if (overrides.maxSteps !== undefined) {
+    const requestedMaxSteps = getPositiveInteger(next.max_steps);
+    next.max_steps = Math.max(requestedMaxSteps ?? 0, overrides.maxSteps);
+  }
+
+  return next;
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.650";
+export const VERSION = "0.1.651";


### PR DESCRIPTION
## Summary
- Track delegation overrides returned by loaded skills during runtime execution
- Apply those overrides to subsequent invoke_agent tool inputs in both generate and stream paths
- Bump veryfront to 0.1.651 for release

## Verification
- deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/agent/runtime/skill-delegation-overrides.test.ts src/agent/runtime/refresh.test.ts
- deno task verify:quick