### PR TITLE
fix(agent): ignore parent-only fork tool requests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.651",
+  "version": "0.1.652",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted/child-requested-tools.test.ts
+++ b/src/agent/hosted/child-requested-tools.test.ts
@@ -102,6 +102,7 @@ Deno.test("DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES excludes UI-only tools", () 
   assertEquals(DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES.has("studio_panel_control"), true);
   assertEquals(DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES.has("studio_suggestions"), true);
   assertEquals(DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES.has("form_input"), true);
+  assertEquals(DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES.has("invoke_agent"), true);
   assertEquals(DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES.has("bash"), false);
   assertEquals(DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES.has("create_file"), false);
 });
@@ -113,6 +114,15 @@ Deno.test("sanitizeDefaultHostedChildRequestedTools applies default exclusions a
   });
 
   assertEquals(result, ["bash", "create_file", "update_file"]);
+});
+
+Deno.test("sanitizeDefaultHostedChildRequestedTools removes parent-only delegation tools", () => {
+  const result = sanitizeDefaultHostedChildRequestedTools({
+    prompt: "Research the docs",
+    requestedTools: ["invoke_agent"],
+  });
+
+  assertEquals(result, []);
 });
 
 Deno.test("sanitizeDefaultHostedChildRequestedTools adds reverse file-writing companions", () => {
@@ -164,6 +174,26 @@ Deno.test("selectDefaultHostedChildForkRuntimeTools filters requested tools afte
       create_file: forkTools.create_file,
       update_file: forkTools.update_file,
     },
+  });
+});
+
+Deno.test("selectDefaultHostedChildForkRuntimeTools ignores parent-only delegation tool requests", () => {
+  const forkTools = {
+    web_fetch: { description: "Fetch a URL" },
+    web_search: { description: "Search the web" },
+  };
+
+  const result = selectDefaultHostedChildForkRuntimeTools({
+    provider: "anthropic",
+    forkModel: "claude-sonnet-4-5-20250929",
+    forkTools,
+    effectivePrompt: "Research the docs",
+    requestedTools: ["invoke_agent"],
+  });
+
+  assertEquals(result, {
+    ok: true,
+    forkTools,
   });
 });
 

--- a/src/agent/hosted/child-requested-tools.ts
+++ b/src/agent/hosted/child-requested-tools.ts
@@ -38,6 +38,7 @@ export const DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES: ReadonlySet<string> = new
   "studio_panel_control",
   "studio_suggestions",
   "form_input",
+  "invoke_agent",
 ]);
 
 /** Default value for hosted child requested tool companions. */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.651";
+export const VERSION = "0.1.652";


### PR DESCRIPTION
## Summary
- Treat invoke_agent as a parent-only orchestration tool when normalizing child fork requested tools
- Preserve child capabilities by falling back to the inherited child tool set when only parent-only tools were requested
- Bump veryfront package version to 0.1.652

## Verification
- deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/agent/hosted/child-requested-tools.test.ts src/agent/runtime/skill-delegation-overrides.test.ts src/agent/runtime/refresh.test.ts
- deno task verify:quick
- pre-push: full unit suite, 1981 passed / 0 failed
