### PR TITLE
Fix provider-native web tool result persistence

### DIFF
--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -1151,6 +1151,52 @@ describe("chat-stream-handler", () => {
       ]);
     });
 
+    it("accepts provider-native tool-result.result payloads as tool output", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const providerResult = {
+        type: "web_search_result",
+        results: [{ title: "Pasta", url: "https://example.test/pasta" }],
+      };
+      const result = createMockResult([
+        {
+          type: "tool-result",
+          toolCallId: "tc-provider-search",
+          toolName: "web_search",
+          input: { query: "pasta" },
+          result: providerResult,
+          providerExecuted: true,
+        },
+        { type: "finish", finishReason: "stop", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      assertEquals(state.toolResults, [{
+        toolCallId: "tc-provider-search",
+        toolName: "web_search",
+        output: providerResult,
+        providerExecuted: true,
+      }]);
+      assertEquals(events, [
+        { type: "tool-input-start", toolCallId: "tc-provider-search", toolName: "web_search" },
+        {
+          type: "tool-input-available",
+          toolCallId: "tc-provider-search",
+          toolName: "web_search",
+          input: { query: "pasta" },
+          providerExecuted: true,
+        },
+        {
+          type: "tool-output-available",
+          toolCallId: "tc-provider-search",
+          output: providerResult,
+          providerExecuted: true,
+        },
+      ]);
+    });
+
     it("forwards errored tool results as tool-output-error SSE events", async () => {
       const { events, controller, encoder } = createSSECollector();
       const state = createStreamState();

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -107,6 +107,22 @@ function summarizeDebugValue(value: unknown): unknown {
   return value;
 }
 
+function resolveToolResultOutput(part: RuntimeStreamPart): unknown {
+  if (!isRecord(part) || part.type !== "tool-result") {
+    return undefined;
+  }
+
+  if ("output" in part) {
+    return part.output;
+  }
+
+  if ("result" in part) {
+    return part.result;
+  }
+
+  return undefined;
+}
+
 function logProviderToolPart(
   partType: "tool-result" | "tool-error",
   part: {
@@ -748,13 +764,14 @@ export function processStream(
             providerExecuted,
             dynamic: typedPart.dynamic,
           });
+          const toolResultOutput = resolveToolResultOutput(typedPart);
           const isError = typedPart.isError === true;
           logProviderToolPart("tool-result", {
             toolCallId: typedPart.toolCallId,
             toolName: typedPart.toolName,
             providerExecuted,
             dynamic: typedPart.dynamic,
-            output: typedPart.output,
+            output: toolResultOutput,
             input: typedPart.input,
             preliminary: typedPart.preliminary,
             isError,
@@ -763,14 +780,14 @@ export function processStream(
             state.toolResults.push({
               toolCallId: typedPart.toolCallId,
               toolName: typedPart.toolName,
-              error: typedPart.output,
+              error: toolResultOutput,
               ...(providerExecuted !== undefined ? { providerExecuted } : {}),
               ...(typedPart.dynamic ? { dynamic: true } : {}),
             });
             sendSSE(controller, encoder, {
               type: "tool-output-error",
               toolCallId: typedPart.toolCallId,
-              errorText: stringifyToolError(typedPart.output),
+              errorText: stringifyToolError(toolResultOutput),
               ...(providerExecuted !== undefined ? { providerExecuted } : {}),
               ...(typedPart.dynamic ? { dynamic: true } : {}),
             });
@@ -780,7 +797,7 @@ export function processStream(
           state.toolResults.push({
             toolCallId: typedPart.toolCallId,
             toolName: typedPart.toolName,
-            output: typedPart.output,
+            output: toolResultOutput,
             ...(providerExecuted !== undefined ? { providerExecuted } : {}),
             ...(typedPart.dynamic ? { dynamic: true } : {}),
             ...(typedPart.preliminary !== undefined ? { preliminary: typedPart.preliminary } : {}),
@@ -788,7 +805,7 @@ export function processStream(
           sendSSE(controller, encoder, {
             type: "tool-output-available",
             toolCallId: typedPart.toolCallId,
-            output: typedPart.output,
+            output: toolResultOutput,
             ...(providerExecuted !== undefined ? { providerExecuted } : {}),
             ...(typedPart.dynamic ? { dynamic: true } : {}),
             ...(typedPart.preliminary !== undefined ? { preliminary: typedPart.preliminary } : {}),

--- a/src/agent/runtime/runtime-tool-types.ts
+++ b/src/agent/runtime/runtime-tool-types.ts
@@ -97,7 +97,13 @@ export type RuntimeStreamPart =
     type: "tool-result";
     toolCallId: string;
     toolName: string;
+    /**
+     * Normalized tool result payload used by Veryfront-owned runtime code.
+     * Some provider SDK stream parts call the same payload `result`; callers
+     * should accept both names at stream boundaries.
+     */
     output?: unknown;
+    result?: unknown;
     error?: unknown;
     input?: unknown;
     providerExecuted?: boolean;


### PR DESCRIPTION
## Summary
- Accept provider SDK `tool-result.result` payloads at the runtime stream boundary in addition to Veryfront's normalized `output` field.
- Preserve provider-native `web_search`/`web_fetch` results in SSE `tool-output-available` events and downstream durable run events instead of persisting null output.
- Add a regression covering provider-executed `web_search` result payloads.

## Staging evidence before fix
Conversation `6e9e467d-1d7c-441d-8d7d-6dd7c6bd5de3` on staging showed Anthropic provider-native tools executed, but stored result payloads were null/missing:
- run `67058f90-94a3-4a26-80df-66b955e0b2dc`: `web_search`, completed, no tool error, `TOOL_CALL_RESULT` result null/missing.
- run `9f3cea22-5fec-4618-8a65-f0d6aad9560f`: `web_fetch`, completed, no invalid URL/tool error, `TOOL_CALL_RESULT` result null/missing.
- run `c070f76c-4581-4ecf-8e78-b47f65c6a845`: `web_search`, completed, no tool error, `TOOL_CALL_RESULT` result null/missing.

Root cause: provider stream parts carry native tool payloads as `result`, while `processStream` forwarded only `output`.

## Verification
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/agent/runtime/chat-stream-handler.test.ts`
- `deno lint src/agent/runtime/chat-stream-handler.ts src/agent/runtime/runtime-tool-types.ts src/agent/runtime/chat-stream-handler.test.ts`
- `deno check src/agent/runtime/chat-stream-handler.ts src/agent/runtime/runtime-tool-types.ts`

## Known verification gap
- Full pre-commit `verify:quick` is blocked by pre-existing broken links in `docs/architecture/21-agent-tool-registration-current-state.md`, unrelated to this runtime change.
- Staging live run needs to be repeated after this framework fix is deployed.

Refs veryfront/veryfront-studio#4705
