### PR TITLE
Release veryfront 0.1.653

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.652",
+  "version": "0.1.653",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.652";
+export const VERSION = "0.1.653";


### PR DESCRIPTION
## Summary
- Bump `veryfront` from `0.1.652` to `0.1.653` so the provider-native web tool result persistence fix can publish.
- Required before `veryfront-agent` can consume the fix and staging can be verified.

## Why
PR #2095 fixed source code, but staging `veryfront-agent` currently runs an image built from `veryfront-agent@80e0818`, which only updated its framework dependency to `veryfront@0.1.652`. The runtime needs a published package version containing #2095.

## Verification
- `npm view veryfront@0.1.653` returned unpublished before bump.
- Pre-commit `verify:quick` reached docs link validation; format/lint/docs tests passed before failing on pre-existing broken links in `docs/architecture/21-agent-tool-registration-current-state.md`.

## Follow-up
After this merges/publishes, update `veryfront-agent` to `veryfront@0.1.653`, deploy staging, then rerun `web_search` and `web_fetch` evidence.

Refs veryfront/veryfront-studio#4705
