### PR TITLE
Fix provider-native tools in child agent forks

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.653",
+  "version": "0.1.654",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/streaming/fork-runtime-stream.test.ts
+++ b/src/agent/streaming/fork-runtime-stream.test.ts
@@ -456,6 +456,58 @@ describe("agent/fork-runtime-stream", () => {
     assertEquals(parts, [{ type: "text-delta", text: "Done." }]);
   });
 
+  it("passes requested provider-native tools into child fork runtime steps", async () => {
+    const capturedInputs: RunAgentRuntimeForkStepInput[] = [];
+    const response: AgentResponse = {
+      text: "Done.",
+      messages: [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          timestamp: 2,
+          parts: [{ type: "text", text: "Done." }],
+        },
+      ],
+      toolCalls: [],
+      status: "completed",
+      usage: {
+        promptTokens: 1,
+        completionTokens: 2,
+        totalTokens: 3,
+      },
+      metadata: { finishReason: "stop" },
+    };
+
+    const { streamResult, forkToolNames } = startAgentRuntimeForkWithHostTools({
+      apiUrl: "https://api.example.com",
+      authToken: "auth-token",
+      projectId: "project-1",
+      provider: "anthropic",
+      forkModel: "anthropic/claude-sonnet-4",
+      maxSteps: 1,
+      prompt: "Research with web tools.",
+      forkTools: {},
+      forkToolNames: ["web_fetch", "web_search"],
+      runStep: async (input) => {
+        capturedInputs.push(input);
+        return {
+          stream: createRuntimeEventStream([{ type: "text-delta", delta: "Done." }]),
+          responsePromise: Promise.resolve(response),
+        };
+      },
+      buildInstructions: () => "Base instructions.",
+    });
+
+    for await (const _part of streamResult.fullStream) {
+      // Consume stream.
+    }
+
+    assertEquals(forkToolNames, ["web_fetch", "web_search"]);
+    assertEquals(capturedInputs[0]?.forkToolNames, ["web_fetch", "web_search"]);
+    assertEquals(capturedInputs[0]?.providerToolNames, ["web_fetch", "web_search"]);
+    assertEquals(Object.keys(capturedInputs[0]?.runtimeTools ?? {}), []);
+  });
+
   it("preserves typed trace attributes for high-level host-tool forks", () => {
     type NarrowTraceAttributes = {
       toolName: string;

--- a/src/agent/streaming/fork-runtime-stream.ts
+++ b/src/agent/streaming/fork-runtime-stream.ts
@@ -20,7 +20,10 @@ import {
   HOSTED_CHILD_STREAM_TIMEOUT_TOKEN,
   resolveHostedChildPromiseWithTimeout,
 } from "../hosted/child-stream-watchdog.ts";
-import { getForkRuntimeAllowedToolNames } from "../runtime/provider-native-tool-inventory.ts";
+import {
+  getForkRuntimeAllowedToolNames,
+  getProviderNativeToolNames,
+} from "../runtime/provider-native-tool-inventory.ts";
 import { AgentRuntime } from "../runtime/index.ts";
 import type { AgentResponse, Message as AgentMessage } from "../schemas/index.ts";
 
@@ -209,6 +212,7 @@ export type StartAgentRuntimeForkInput = {
   maxContinuationSteps?: number;
   abortSignal?: AbortSignal;
   forkToolNames: string[];
+  providerToolNames?: string[];
   runtimeTools: Record<string, Tool | boolean>;
   providerOptions?: Record<string, unknown>;
   buildInstructions: () => string;
@@ -256,6 +260,15 @@ export function startAgentRuntimeForkWithHostTools<
       forkModel: input.forkModel,
       forkTools: input.forkTools,
     });
+  const providerNativeToolNames = new Set(
+    getProviderNativeToolNames({
+      provider: input.provider,
+      model: input.forkModel,
+    }),
+  );
+  const providerToolNames = forkToolNames.filter((toolName) =>
+    providerNativeToolNames.has(toolName)
+  );
 
   return {
     streamResult: startAgentRuntimeFork({
@@ -268,6 +281,7 @@ export function startAgentRuntimeForkWithHostTools<
       maxContinuationSteps: input.maxContinuationSteps,
       abortSignal: input.abortSignal,
       forkToolNames,
+      providerToolNames,
       runtimeTools,
       providerOptions: input.providerOptions,
       buildInstructions: input.buildInstructions,
@@ -339,6 +353,7 @@ export type RunAgentRuntimeForkStepInput = {
   system: string;
   abortSignal?: AbortSignal;
   forkToolNames: string[];
+  providerToolNames?: string[];
   runtimeTools: Record<string, Tool | boolean>;
   providerOptions?: Record<string, unknown>;
 };
@@ -375,6 +390,7 @@ export async function runAgentRuntimeForkStep(input: RunAgentRuntimeForkStepInpu
     model: input.model,
     system: input.system,
     tools: input.runtimeTools,
+    providerTools: input.providerToolNames ?? [],
     maxSteps: 1,
     ...(input.providerOptions
       ? { resolveModelTransport: () => ({ providerOptions: input.providerOptions }) }
@@ -427,6 +443,7 @@ export function runFrameworkForkStep(input: RunFrameworkForkStepInput): Promise<
     system: input.system,
     ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
     forkToolNames: input.forkToolNames,
+    ...(input.providerToolNames ? { providerToolNames: input.providerToolNames } : {}),
     runtimeTools: input.frameworkTools,
     ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
   });
@@ -593,6 +610,7 @@ export function startAgentRuntimeFork(input: StartAgentRuntimeForkInput): ForkRu
             system: prepared.system,
             ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
             forkToolNames: input.forkToolNames,
+            ...(input.providerToolNames ? { providerToolNames: input.providerToolNames } : {}),
             runtimeTools: input.runtimeTools,
             ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
           });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.653";
+export const VERSION = "0.1.654";


### PR DESCRIPTION
## Summary
- pass requested provider-native tool names from hosted child fork selection into child AgentRuntime.providerTools
- keep provider-native names visible in child fork instructions without treating them as host tools
- bump veryfront package version to 0.1.654

## Verification
- deno test --no-check --allow-all src/agent/streaming/fork-runtime-stream.test.ts
- deno test --no-check --allow-all src/agent/runtime/model-tool-converter.test.ts src/agent/hosted/child-requested-tools.test.ts src/agent/hosted/child-fork-execution-runner.test.ts
- deno task verify:quick
- pre-push checks: fmt, lint, typecheck, unit suite (1981 passed)