### PR TITLE
Fix Outlook attachment and conversation tools

### DIFF
--- a/cli/templates/integrations/outlook/connector.json
+++ b/cli/templates/integrations/outlook/connector.json
@@ -1263,10 +1263,29 @@
           }
         },
         "body": {
-          "attachment": {
-            "type": "object",
-            "description": "Microsoft Graph attachment object",
+          "@odata.type": {
+            "type": "string",
+            "description": "Microsoft Graph attachment type",
+            "default": "#microsoft.graph.fileAttachment"
+          },
+          "name": {
+            "type": "string",
+            "description": "Attachment filename",
             "required": true
+          },
+          "contentBytes": {
+            "type": "string",
+            "description": "Base64-encoded attachment content",
+            "required": true
+          },
+          "contentType": {
+            "type": "string",
+            "description": "Attachment MIME type"
+          },
+          "isInline": {
+            "type": "boolean",
+            "description": "Whether the attachment is inline",
+            "default": false
           }
         }
       }
@@ -1297,12 +1316,6 @@
             "in": "query",
             "description": "Comma-separated message fields to return",
             "default": "id,conversationId,internetMessageId,subject,from,sender,toRecipients,ccRecipients,receivedDateTime,sentDateTime,bodyPreview,categories,isRead,importance,hasAttachments,webLink,flag"
-          },
-          "$orderby": {
-            "type": "string",
-            "in": "query",
-            "description": "Sort expression",
-            "default": "receivedDateTime desc"
           }
         },
         "response": {
@@ -2165,10 +2178,29 @@
           }
         },
         "body": {
-          "attachment": {
-            "type": "object",
-            "description": "Microsoft Graph attachment object",
+          "@odata.type": {
+            "type": "string",
+            "description": "Microsoft Graph attachment type",
+            "default": "#microsoft.graph.fileAttachment"
+          },
+          "name": {
+            "type": "string",
+            "description": "Attachment filename",
             "required": true
+          },
+          "contentBytes": {
+            "type": "string",
+            "description": "Base64-encoded attachment content",
+            "required": true
+          },
+          "contentType": {
+            "type": "string",
+            "description": "Attachment MIME type"
+          },
+          "isInline": {
+            "type": "boolean",
+            "description": "Whether the attachment is inline",
+            "default": false
           }
         }
       }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.655",
+  "version": "0.1.656",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/integrations/_data.test.ts
+++ b/src/integrations/_data.test.ts
@@ -1012,6 +1012,40 @@ describe("integration endpoint specs", () => {
       getTool("outlook", "find_meeting_times").endpoint?.url,
       "https://graph.microsoft.com/v1.0/me/findMeetingTimes",
     );
+    assertEquals(
+      getTool("outlook", "list_conversation_messages").endpoint?.params?.["$orderby"],
+      undefined,
+    );
+    assertEquals(getTool("outlook", "add_attachment_to_message").endpoint?.body, {
+      "@odata.type": {
+        type: "string",
+        description: "Microsoft Graph attachment type",
+        default: "#microsoft.graph.fileAttachment",
+      },
+      name: {
+        type: "string",
+        description: "Attachment filename",
+        required: true,
+      },
+      contentBytes: {
+        type: "string",
+        description: "Base64-encoded attachment content",
+        required: true,
+      },
+      contentType: {
+        type: "string",
+        description: "Attachment MIME type",
+      },
+      isInline: {
+        type: "boolean",
+        description: "Whether the attachment is inline",
+        default: false,
+      },
+    });
+    assertEquals(
+      getTool("outlook", "add_event_attachment").endpoint?.body,
+      getTool("outlook", "add_attachment_to_message").endpoint?.body,
+    );
   });
 
   it("publishes provider-declared historical summary contracts for email list/search tools", () => {

--- a/src/integrations/_data.ts
+++ b/src/integrations/_data.ts
@@ -7849,10 +7849,22 @@ export const connectors: IntegrationConfig[] = [
           },
         },
         "body": {
-          "attachment": {
-            "type": "object",
-            "description": "Microsoft Graph attachment object",
+          "@odata.type": {
+            "type": "string",
+            "description": "Microsoft Graph attachment type",
+            "default": "#microsoft.graph.fileAttachment",
+          },
+          "name": { "type": "string", "description": "Attachment filename", "required": true },
+          "contentBytes": {
+            "type": "string",
+            "description": "Base64-encoded attachment content",
             "required": true,
+          },
+          "contentType": { "type": "string", "description": "Attachment MIME type" },
+          "isInline": {
+            "type": "boolean",
+            "description": "Whether the attachment is inline",
+            "default": false,
           },
         },
       },
@@ -7884,12 +7896,6 @@ export const connectors: IntegrationConfig[] = [
             "description": "Comma-separated message fields to return",
             "default":
               "id,conversationId,internetMessageId,subject,from,sender,toRecipients,ccRecipients,receivedDateTime,sentDateTime,bodyPreview,categories,isRead,importance,hasAttachments,webLink,flag",
-          },
-          "$orderby": {
-            "type": "string",
-            "in": "query",
-            "description": "Sort expression",
-            "default": "receivedDateTime desc",
           },
         },
         "response": {
@@ -8463,10 +8469,22 @@ export const connectors: IntegrationConfig[] = [
           },
         },
         "body": {
-          "attachment": {
-            "type": "object",
-            "description": "Microsoft Graph attachment object",
+          "@odata.type": {
+            "type": "string",
+            "description": "Microsoft Graph attachment type",
+            "default": "#microsoft.graph.fileAttachment",
+          },
+          "name": { "type": "string", "description": "Attachment filename", "required": true },
+          "contentBytes": {
+            "type": "string",
+            "description": "Base64-encoded attachment content",
             "required": true,
+          },
+          "contentType": { "type": "string", "description": "Attachment MIME type" },
+          "isInline": {
+            "type": "boolean",
+            "description": "Whether the attachment is inline",
+            "default": false,
           },
         },
       },

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.655";
+export const VERSION = "0.1.656";


### PR DESCRIPTION
## Summary
- send Outlook attachment create requests as raw Microsoft Graph fileAttachment bodies instead of nesting under `attachment`
- remove the default `$orderby` from conversation message lookup because Graph rejects that filter/sort combination
- bump veryfront package version to 0.1.656

## Evidence before PR
- `deno run -A scripts/build/generate-integrations-module.ts`
- `deno fmt src/integrations/_data.ts src/integrations/_data.test.ts cli/templates/integrations/outlook/connector.json`
- `deno test --allow-env --allow-read src/integrations/_data.test.ts`
- `deno task typecheck`
- `git diff --check`

## Live staging context
The previous staging smoke test found `outlook__add_attachment_to_message` and `outlook__add_event_attachment` failing with Graph abstract attachment input errors, and `outlook__list_conversation_messages` failing with a Graph filter/sort complexity error. This PR fixes those connector contracts before rerunning the full Outlook tool smoke suite.