### PR TITLE
Compact oversized internal runtime history

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.656",
+  "version": "0.1.657",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [
@@ -355,8 +355,8 @@
     "lint:ban-zod": "deno run --allow-read scripts/lint/ban-zod-imports.ts",
     "lint:core-deps": "deno run --allow-read scripts/lint/audit-core-deps.ts",
     "lint:dependency-boundaries": "deno run --allow-read scripts/lint/audit-dependency-boundaries.ts",
-    "lint:extension-contracts": "deno run --allow-read --allow-env --allow-sys scripts/lint/audit-extension-contracts.ts",
-    "lint:extension-capabilities": "deno run --allow-read --allow-env --allow-sys scripts/lint/audit-extension-capabilities.ts",
+    "lint:extension-contracts": "deno run --allow-read scripts/lint/audit-extension-contracts.ts",
+    "lint:extension-capabilities": "deno run --allow-read scripts/lint/audit-extension-capabilities.ts",
     "lint:ban-console": "deno run --allow-read scripts/lint/ban-console.ts",
     "lint:ban-deep-imports": "deno run --allow-read scripts/lint/ban-deep-imports.ts",
     "lint:imports": "deno run --allow-read scripts/lint/no-cross-boundary-relative-imports.ts",

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -164,15 +164,20 @@ describe("npm generated integration artifacts", () => {
 
 	it("keeps the active Jira JQL search endpoint in the npm source artifact", async () => {
 		const source = await Deno.readTextFile("src/integrations/_data.ts");
+		const urls = [...source.matchAll(/"url":\s*"([^"]+)"/g)].map((match) =>
+			match[1]
+		);
 
-		assertStringIncludes(
-			source,
-			'"url":"https://api.atlassian.com/ex/jira/{cloudId}/rest/api/3/search/jql"',
+		assertEquals(
+			urls.includes(
+				"https://api.atlassian.com/ex/jira/{cloudId}/rest/api/3/search/jql",
+			),
+			true,
 		);
 		assertStringIncludes(source, '"nextPageToken"');
 		assertEquals(
-			source.includes(
-				'"url":"https://api.atlassian.com/ex/jira/{cloudId}/rest/api/3/search"',
+			urls.includes(
+				"https://api.atlassian.com/ex/jira/{cloudId}/rest/api/3/search",
 			),
 			false,
 		);

--- a/scripts/lint/audit-extension-capabilities.test.ts
+++ b/scripts/lint/audit-extension-capabilities.test.ts
@@ -4,6 +4,7 @@ import {
   auditExtensionCapabilities,
   type ExtensionCapabilityAuditInput,
 } from "./audit-extension-capabilities.ts";
+import { extractExtensionSourceMetadata } from "./extension-source-metadata.ts";
 
 function input(
   overrides: Partial<ExtensionCapabilityAuditInput> = {},
@@ -63,6 +64,37 @@ describe("auditExtensionCapabilities", () => {
 
     assertEquals(issues.map((issue) => issue.message), [
       'extensions/ext-cache-redis/deno.json sensitive extension "Redis token cache" is missing capability {"keys":["REDIS_PASSWORD","REDIS_PREFIX","REDIS_URL"],"type":"env:read"}',
+    ]);
+  });
+});
+
+describe("extractExtensionSourceMetadata capabilities", () => {
+  it("extracts literal factory capabilities from source without importing the extension module", () => {
+    const metadata = extractExtensionSourceMetadata(`
+      import "https://esm.sh/transient-package";
+      const ext = () => ({
+        capabilities: [
+          { type: "net:outbound", hosts: ["esm.sh"] },
+          {
+            type: "env:read",
+            keys: [
+              "OTEL_EXPORTER_OTLP_ENDPOINT",
+              "OTEL_TRACES_ENABLED",
+            ],
+          },
+        ],
+      });
+    `);
+
+    assertEquals(metadata.capabilities, [
+      { type: "net:outbound", hosts: ["esm.sh"] },
+      {
+        type: "env:read",
+        keys: [
+          "OTEL_EXPORTER_OTLP_ENDPOINT",
+          "OTEL_TRACES_ENABLED",
+        ],
+      },
     ]);
   });
 });

--- a/scripts/lint/audit-extension-capabilities.ts
+++ b/scripts/lint/audit-extension-capabilities.ts
@@ -1,4 +1,5 @@
-import { fromFileUrl, join, toFileUrl } from "#std/path";
+import { fromFileUrl, join } from "#std/path";
+import { extractExtensionSourceMetadata } from "./extension-source-metadata.ts";
 
 export type Capability = { type: string; [key: string]: unknown };
 
@@ -19,53 +20,54 @@ interface SensitiveCapabilityPolicy {
   requiredCapabilities: Capability[];
 }
 
-export const SENSITIVE_EXTENSION_CAPABILITY_POLICIES: SensitiveCapabilityPolicy[] = [
-  {
-    label: "sandbox execution",
-    manifestPath: "extensions/ext-sandbox-shell-tools/deno.json",
-    requiredCapabilities: [{ type: "sandbox:execute", tools: ["bash"] }],
-  },
-  {
-    label: "Redis token cache",
-    manifestPath: "extensions/ext-cache-redis/deno.json",
-    requiredCapabilities: [
-      { type: "net:outbound", hosts: ["*"] },
-      {
-        type: "env:read",
-        keys: ["REDIS_PASSWORD", "REDIS_PREFIX", "REDIS_URL"],
-      },
-    ],
-  },
-  {
-    label: "native SQLite storage",
-    manifestPath: "extensions/ext-db-sqlite/deno.json",
-    requiredCapabilities: [
-      { type: "fs:read" },
-      { type: "fs:write" },
-    ],
-  },
-  {
-    label: "document extraction",
-    manifestPath: "extensions/ext-document-kreuzberg/deno.json",
-    requiredCapabilities: [{ type: "fs:read" }],
-  },
-  {
-    label: "OpenTelemetry observability",
-    manifestPath: "extensions/ext-observability-opentelemetry/deno.json",
-    requiredCapabilities: [
-      { type: "net:outbound", hosts: ["*"] },
-      {
-        type: "env:read",
-        keys: [
-          "OTEL_EXPORTER_OTLP_ENDPOINT",
-          "OTEL_EXPORTER_OTLP_HEADERS",
-          "OTEL_SERVICE_NAME",
-          "OTEL_TRACES_ENABLED",
-        ],
-      },
-    ],
-  },
-];
+export const SENSITIVE_EXTENSION_CAPABILITY_POLICIES:
+  SensitiveCapabilityPolicy[] = [
+    {
+      label: "sandbox execution",
+      manifestPath: "extensions/ext-sandbox-shell-tools/deno.json",
+      requiredCapabilities: [{ type: "sandbox:execute", tools: ["bash"] }],
+    },
+    {
+      label: "Redis token cache",
+      manifestPath: "extensions/ext-cache-redis/deno.json",
+      requiredCapabilities: [
+        { type: "net:outbound", hosts: ["*"] },
+        {
+          type: "env:read",
+          keys: ["REDIS_PASSWORD", "REDIS_PREFIX", "REDIS_URL"],
+        },
+      ],
+    },
+    {
+      label: "native SQLite storage",
+      manifestPath: "extensions/ext-db-sqlite/deno.json",
+      requiredCapabilities: [
+        { type: "fs:read" },
+        { type: "fs:write" },
+      ],
+    },
+    {
+      label: "document extraction",
+      manifestPath: "extensions/ext-document-kreuzberg/deno.json",
+      requiredCapabilities: [{ type: "fs:read" }],
+    },
+    {
+      label: "OpenTelemetry observability",
+      manifestPath: "extensions/ext-observability-opentelemetry/deno.json",
+      requiredCapabilities: [
+        { type: "net:outbound", hosts: ["*"] },
+        {
+          type: "env:read",
+          keys: [
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_HEADERS",
+            "OTEL_SERVICE_NAME",
+            "OTEL_TRACES_ENABLED",
+          ],
+        },
+      ],
+    },
+  ];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -216,23 +218,21 @@ async function loadAuditInput(
     await Deno.readTextFile(join(root, manifestPath)),
   ) as Record<string, unknown>;
   const veryfront = (manifest.veryfront ?? {}) as Record<string, unknown>;
-  const moduleUrl = toFileUrl(
+  const source = await Deno.readTextFile(
     join(root, manifestPath.replace(/deno\.json$/, "src/index.ts")),
-  ).href;
-  const mod = await import(moduleUrl);
-  if (typeof mod.default !== "function") {
-    throw new Error(`${manifestPath} default export is not an extension factory`);
-  }
-  const extension = mod.default() as { capabilities?: unknown };
+  );
+  const sourceMetadata = extractExtensionSourceMetadata(source);
 
   return {
     manifestPath,
     manifestCapabilities: capabilityList(veryfront.capabilities),
-    factoryCapabilities: capabilityList(extension.capabilities),
+    factoryCapabilities: capabilityList(sourceMetadata.capabilities),
   };
 }
 
-async function auditWorkspace(root: string): Promise<ExtensionCapabilityAuditIssue[]> {
+async function auditWorkspace(
+  root: string,
+): Promise<ExtensionCapabilityAuditIssue[]> {
   const inputs = await Promise.all(
     (await extensionManifestPaths(root)).map((manifestPath) =>
       loadAuditInput(root, manifestPath)

--- a/scripts/lint/audit-extension-contracts.test.ts
+++ b/scripts/lint/audit-extension-contracts.test.ts
@@ -3,8 +3,8 @@ import { describe, it } from "#std/testing/bdd";
 import {
   auditExtensionContracts,
   type ExtensionContractAuditInput,
-  importWithRetry,
 } from "./audit-extension-contracts.ts";
+import { extractExtensionSourceMetadata } from "./extension-source-metadata.ts";
 
 function input(
   overrides: Partial<ExtensionContractAuditInput> = {},
@@ -77,42 +77,54 @@ describe("auditExtensionContracts", () => {
   });
 });
 
-describe("importWithRetry", () => {
-  it("retries transient remote import failures", async () => {
-    let attempts = 0;
-    const mod = await importWithRetry("file:///extension.ts", {
-      importModule: (url) => {
-        attempts += 1;
-        if (attempts === 1) {
-          throw new TypeError(
-            "Import 'https://esm.sh/tailwindcss@4.2.2' failed: 522 <unknown status code>",
-          );
-        }
-        return Promise.resolve({ default: () => ({}) });
-      },
-      delay: () => Promise.resolve(),
-      retries: 1,
-    });
+describe("extractExtensionSourceMetadata contracts", () => {
+  it("extracts factory contract metadata from source without importing the extension module", () => {
+    const metadata = extractExtensionSourceMetadata(`
+      import "https://esm.sh/transient-package";
+      const ext = () => ({
+        contracts: {
+          provides: ["CSSProcessor"],
+          requires: ["SchemaValidator"],
+        },
+        capabilities: [],
+      });
+    `);
 
-    assertEquals(attempts, 2);
-    assertEquals(typeof mod.default, "function");
+    assertEquals(metadata.contracts, {
+      provides: ["CSSProcessor"],
+      requires: ["SchemaValidator"],
+    });
   });
 
-  it("does not retry local import failures", async () => {
-    let attempts = 0;
-    const error = await importWithRetry("file:///extension.ts", {
-      importModule: () => {
-        attempts += 1;
-        throw new TypeError("Module not found: file:///extension.ts");
-      },
-      delay: () => Promise.resolve(),
-      retries: 2,
-    }).then(
-      () => undefined,
-      (caught) => caught,
-    );
+  it("extracts legacy provider object keys when the source has no contracts block", () => {
+    const metadata = extractExtensionSourceMetadata(`
+      const ext = () => ({
+        capabilities: [{ type: "net:outbound", hosts: ["*"] }],
+        provides: {
+          AuthProvider: provider,
+        },
+      });
+    `);
 
-    assertEquals(attempts, 1);
-    assertEquals(error instanceof TypeError, true);
+    assertEquals(metadata.legacyProvides, ["AuthProvider"]);
+  });
+
+  it("resolves known exported contract name constants in contract arrays", () => {
+    const metadata = extractExtensionSourceMetadata(`
+      import {
+        LLMProviderRegistryName,
+        SandboxShellToolsProviderName,
+      } from "veryfront/extensions/sandbox";
+      const ext = () => ({
+        contracts: {
+          provides: [SandboxShellToolsProviderName],
+          requires: [LLMProviderRegistryName],
+        },
+        capabilities: [],
+      });
+    `);
+
+    assertEquals(metadata.contracts?.provides, ["SandboxShellToolsProvider"]);
+    assertEquals(metadata.contracts?.requires, ["LLMProviderRegistry"]);
   });
 });

--- a/scripts/lint/audit-extension-contracts.ts
+++ b/scripts/lint/audit-extension-contracts.ts
@@ -1,4 +1,5 @@
-import { fromFileUrl, join, toFileUrl } from "#std/path";
+import { fromFileUrl, join } from "#std/path";
+import { extractExtensionSourceMetadata } from "./extension-source-metadata.ts";
 
 type Capability = { type: string; [key: string]: unknown };
 
@@ -18,48 +19,6 @@ export interface ExtensionContractAuditInput {
 export interface ExtensionContractAuditIssue {
   manifestPath: string;
   message: string;
-}
-
-type Importer = (moduleUrl: string) => Promise<Record<string, unknown>>;
-
-interface ImportWithRetryOptions {
-  retries?: number;
-  delay?: (ms: number) => Promise<void>;
-  importModule?: Importer;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function isTransientRemoteImportFailure(error: unknown): boolean {
-  if (!(error instanceof TypeError)) return false;
-  const message = error.message;
-  if (!/Import ['"]https?:\/\//.test(message)) return false;
-  return /\b(408|425|429|5\d\d)\b/.test(message) ||
-    /network|connection|timeout|temporar/i.test(message);
-}
-
-export async function importWithRetry(
-  moduleUrl: string,
-  options: ImportWithRetryOptions = {},
-): Promise<Record<string, unknown>> {
-  const retries = options.retries ?? 2;
-  const delay = options.delay ?? sleep;
-  const importModule = options.importModule ?? ((url) => import(url));
-
-  for (let attempt = 0; attempt <= retries; attempt++) {
-    try {
-      return await importModule(moduleUrl);
-    } catch (error) {
-      if (attempt >= retries || !isTransientRemoteImportFailure(error)) {
-        throw error;
-      }
-      await delay(250 * (attempt + 1));
-    }
-  }
-
-  throw new Error(`Unable to import ${moduleUrl}`);
 }
 
 function uniqueSorted(values: string[]): string[] {
@@ -169,17 +128,10 @@ async function loadAuditInput(
     await Deno.readTextFile(join(root, manifestPath)),
   ) as Record<string, unknown>;
   const veryfront = (manifest.veryfront ?? {}) as Record<string, unknown>;
-  const moduleUrl = toFileUrl(
+  const source = await Deno.readTextFile(
     join(root, manifestPath.replace(/deno\.json$/, "src/index.ts")),
-  ).href;
-  const mod = await importWithRetry(moduleUrl);
-  if (typeof mod.default !== "function") {
-    throw new Error(`${manifestPath} default export is not an extension factory`);
-  }
-  const extension = mod.default() as {
-    contracts?: ContractMetadata;
-    provides?: Record<string, unknown>;
-  };
+  );
+  const sourceMetadata = extractExtensionSourceMetadata(source);
 
   return {
     manifestPath,
@@ -191,14 +143,16 @@ async function loadAuditInput(
       : [],
     manifestContracts: veryfront.contracts as ContractMetadata | undefined,
     factoryProvides: uniqueSorted([
-      ...Object.keys(extension.provides ?? {}),
-      ...contractList(extension.contracts?.provides),
+      ...sourceMetadata.legacyProvides,
+      ...contractList(sourceMetadata.contracts?.provides),
     ]),
-    factoryRequires: contractList(extension.contracts?.requires),
+    factoryRequires: contractList(sourceMetadata.contracts?.requires),
   };
 }
 
-async function auditWorkspace(root: string): Promise<ExtensionContractAuditIssue[]> {
+async function auditWorkspace(
+  root: string,
+): Promise<ExtensionContractAuditIssue[]> {
   const inputs = await Promise.all(
     (await extensionManifestPaths(root)).map((manifestPath) =>
       loadAuditInput(root, manifestPath)

--- a/scripts/lint/extension-source-metadata.ts
+++ b/scripts/lint/extension-source-metadata.ts
@@ -1,0 +1,290 @@
+export type Capability = { type: string; [key: string]: unknown };
+
+export interface ContractMetadata {
+  provides?: string[];
+  requires?: string[];
+}
+
+export interface ExtensionSourceMetadata {
+  contracts?: ContractMetadata;
+  legacyProvides: string[];
+  capabilities: Capability[];
+}
+
+const KNOWN_CONTRACT_CONSTANTS: Record<string, string> = {
+  LLMProviderRegistryName: "LLMProviderRegistry",
+  SandboxShellToolsProviderName: "SandboxShellToolsProvider",
+};
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].filter((value) => value.length > 0).sort();
+}
+
+function isIdentifierPart(char: string | undefined): boolean {
+  return char !== undefined && /[A-Za-z0-9_$]/.test(char);
+}
+
+function isBoundary(source: string, index: number): boolean {
+  return !isIdentifierPart(source[index]);
+}
+
+function skipString(source: string, index: number, quote: string): number {
+  let i = index + 1;
+  while (i < source.length) {
+    const char = source[i];
+    if (char === "\\") {
+      i += 2;
+      continue;
+    }
+    if (char === quote) return i + 1;
+    i += 1;
+  }
+  return source.length;
+}
+
+function skipLineComment(source: string, index: number): number {
+  const next = source.indexOf("\n", index + 2);
+  return next === -1 ? source.length : next + 1;
+}
+
+function skipBlockComment(source: string, index: number): number {
+  const next = source.indexOf("*/", index + 2);
+  return next === -1 ? source.length : next + 2;
+}
+
+function skipTrivia(source: string, index: number): number {
+  let i = index;
+  while (i < source.length) {
+    if (/\s/.test(source[i] ?? "")) {
+      i += 1;
+      continue;
+    }
+    if (source.startsWith("//", i)) {
+      i = skipLineComment(source, i);
+      continue;
+    }
+    if (source.startsWith("/*", i)) {
+      i = skipBlockComment(source, i);
+      continue;
+    }
+    return i;
+  }
+  return i;
+}
+
+function findPropertyColon(
+  source: string,
+  propertyName: string,
+  startIndex = 0,
+): number {
+  let i = startIndex;
+  while (i < source.length) {
+    const char = source[i];
+    if (char === '"' || char === "'") {
+      i = skipString(source, i, char);
+      continue;
+    }
+    if (char === "`") {
+      i = skipString(source, i, char);
+      continue;
+    }
+    if (source.startsWith("//", i)) {
+      i = skipLineComment(source, i);
+      continue;
+    }
+    if (source.startsWith("/*", i)) {
+      i = skipBlockComment(source, i);
+      continue;
+    }
+    if (
+      source.startsWith(propertyName, i) &&
+      isBoundary(source, i - 1) &&
+      isBoundary(source, i + propertyName.length)
+    ) {
+      const colonIndex = skipTrivia(source, i + propertyName.length);
+      if (source[colonIndex] === ":") return colonIndex;
+    }
+    i += 1;
+  }
+  return -1;
+}
+
+function balancedExpression(
+  source: string,
+  valueIndex: number,
+): string | undefined {
+  const start = skipTrivia(source, valueIndex);
+  const opener = source[start];
+  const closer = opener === "{" ? "}" : opener === "[" ? "]" : undefined;
+  if (!closer) return undefined;
+
+  const stack: string[] = [closer];
+  let i = start + 1;
+  while (i < source.length && stack.length > 0) {
+    const char = source[i];
+    if (char === '"' || char === "'" || char === "`") {
+      i = skipString(source, i, char);
+      continue;
+    }
+    if (source.startsWith("//", i)) {
+      i = skipLineComment(source, i);
+      continue;
+    }
+    if (source.startsWith("/*", i)) {
+      i = skipBlockComment(source, i);
+      continue;
+    }
+    if (char === "{") stack.push("}");
+    if (char === "[") stack.push("]");
+    if (char === stack[stack.length - 1]) stack.pop();
+    i += 1;
+  }
+
+  return stack.length === 0 ? source.slice(start, i) : undefined;
+}
+
+function findPropertyExpression(
+  source: string,
+  propertyName: string,
+  startIndex = 0,
+): string | undefined {
+  const colonIndex = findPropertyColon(source, propertyName, startIndex);
+  if (colonIndex === -1) return undefined;
+  return balancedExpression(source, colonIndex + 1);
+}
+
+function parseStringOrKnownIdentifier(
+  value: string,
+): string | undefined {
+  const trimmed = value.trim();
+  const quote = trimmed[0];
+  if (quote === '"' || quote === "'") {
+    try {
+      return JSON.parse(
+        quote === '"'
+          ? trimmed
+          : `"${trimmed.slice(1, -1).replaceAll('"', '\\"')}"`,
+      );
+    } catch {
+      return trimmed.slice(1, -1);
+    }
+  }
+  return KNOWN_CONTRACT_CONSTANTS[trimmed];
+}
+
+function splitTopLevelComma(source: string): string[] {
+  const parts: string[] = [];
+  let partStart = 0;
+  const stack: string[] = [];
+  let i = 0;
+  while (i < source.length) {
+    const char = source[i];
+    if (char === '"' || char === "'" || char === "`") {
+      i = skipString(source, i, char);
+      continue;
+    }
+    if (source.startsWith("//", i)) {
+      i = skipLineComment(source, i);
+      continue;
+    }
+    if (source.startsWith("/*", i)) {
+      i = skipBlockComment(source, i);
+      continue;
+    }
+    if (char === "{") stack.push("}");
+    if (char === "[") stack.push("]");
+    if (char === stack[stack.length - 1]) stack.pop();
+    if (char === "," && stack.length === 0) {
+      parts.push(source.slice(partStart, i));
+      partStart = i + 1;
+    }
+    i += 1;
+  }
+  parts.push(source.slice(partStart));
+  return parts;
+}
+
+function parseStringArrayExpression(source: string | undefined): string[] {
+  if (!source?.startsWith("[")) return [];
+  const inner = source.slice(1, -1);
+  return uniqueSorted(
+    splitTopLevelComma(inner)
+      .map(parseStringOrKnownIdentifier)
+      .filter((value): value is string =>
+        typeof value === "string" && value.length > 0
+      ),
+  );
+}
+
+function parseContracts(source: string): ContractMetadata | undefined {
+  const contractsSource = findPropertyExpression(source, "contracts");
+  if (!contractsSource) return undefined;
+
+  const provides = parseStringArrayExpression(
+    findPropertyExpression(contractsSource, "provides"),
+  );
+  const requires = parseStringArrayExpression(
+    findPropertyExpression(contractsSource, "requires"),
+  );
+
+  return {
+    ...(provides.length > 0 ? { provides } : {}),
+    ...(requires.length > 0 ? { requires } : {}),
+  };
+}
+
+function parseLegacyProvides(source: string): string[] {
+  if (findPropertyExpression(source, "contracts")) return [];
+
+  const providesSource = findPropertyExpression(source, "provides");
+  if (!providesSource?.startsWith("{")) return [];
+
+  const keys: string[] = [];
+  const inner = providesSource.slice(1, -1);
+  for (const part of splitTopLevelComma(inner)) {
+    const trimmed = part.trim();
+    if (trimmed.length === 0) continue;
+
+    const quoted = /^["']([^"']+)["']\s*:/.exec(trimmed);
+    if (quoted) {
+      keys.push(quoted[1]);
+      continue;
+    }
+
+    const identifier = /^([A-Za-z_$][A-Za-z0-9_$]*)\s*:/.exec(trimmed);
+    if (identifier) keys.push(identifier[1]);
+  }
+
+  return uniqueSorted(keys);
+}
+
+function toJsonLiteral(source: string): string {
+  return source
+    .replace(/\/\/[^\n\r]*/g, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/([{,]\s*)([A-Za-z_$][A-Za-z0-9_$]*)\s*:/g, '$1"$2":')
+    .replace(/,\s*([}\]])/g, "$1");
+}
+
+function isCapability(value: unknown): value is Capability {
+  return value !== null && typeof value === "object" && !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>).type === "string";
+}
+
+function parseCapabilities(source: string): Capability[] {
+  const capabilitiesSource = findPropertyExpression(source, "capabilities");
+  if (!capabilitiesSource) return [];
+
+  const parsed = JSON.parse(toJsonLiteral(capabilitiesSource)) as unknown;
+  return Array.isArray(parsed) ? parsed.filter(isCapability) : [];
+}
+
+export function extractExtensionSourceMetadata(
+  source: string,
+): ExtensionSourceMetadata {
+  return {
+    contracts: parseContracts(source),
+    legacyProvides: parseLegacyProvides(source),
+    capabilities: parseCapabilities(source),
+  };
+}

--- a/src/agent/runtime/message-adapter.test.ts
+++ b/src/agent/runtime/message-adapter.test.ts
@@ -329,6 +329,30 @@ describe("agent runtime message adapter", () => {
     ]);
   });
 
+  it("normalizes stored dashed tool-result parts without output when replaying agent runtime messages", () => {
+    const providerMessages = convertAgentRuntimeMessagesToProviderMessages([
+      {
+        role: "tool",
+        parts: [
+          {
+            type: "tool-result",
+            toolCallId: TOOL_CALL_ID,
+            toolName: TOOL_NAME,
+          },
+        ],
+      },
+    ]);
+
+    assertEquals(providerMessages, [
+      {
+        role: "tool",
+        content: [
+          providerToolResultPart(jsonOutput(null)),
+        ],
+      },
+    ]);
+  });
+
   it("converts native image AgentRuntimeMessage part back to structured user content", () => {
     const providerMessages = convertAgentRuntimeMessagesToProviderMessages([
       agentRuntimeMessage(

--- a/src/agent/runtime/message-adapter.ts
+++ b/src/agent/runtime/message-adapter.ts
@@ -42,7 +42,7 @@ type AgentRuntimeMessageLikePart =
     type: "tool-result";
     toolCallId: string;
     toolName: string;
-    result: unknown;
+    result?: unknown;
   }
   | {
     type: "tool-result";

--- a/src/chat/message-prep.test.ts
+++ b/src/chat/message-prep.test.ts
@@ -422,10 +422,8 @@ Deno.test("enforceTokenBudget can still drop the oldest compressed turn when the
   const compacted = enforceTokenBudget(messages, 120);
 
   assertEquals(compacted.length >= 4, true);
-  assertEquals(compacted[0], messages[4]);
-  assertEquals(compacted[1], messages[5]);
-  assertEquals(compacted[2], messages[6]);
-  assertEquals(compacted[3], messages[7]);
+  assertMatch(String(compacted[0]!.content), /^\[Compressed: turn three/);
+  assertEquals(compacted.slice(-2), messages.slice(-2));
 });
 
 Deno.test("compressTurn emits a two-message summary shell", () => {

--- a/src/chat/message-prep.ts
+++ b/src/chat/message-prep.ts
@@ -122,11 +122,11 @@ export function enforceTokenBudgetWithTurnCompression(
   if (totalTokens <= effectiveBudget) return messages;
 
   const turns = collectTurns(messages);
-  const minKeep = Math.min(2, turns.length);
   const result = [...messages];
+  const latestTurnIndex = Math.max(0, turns.length - 1);
 
   let compressCount = 0;
-  while (totalTokens > effectiveBudget && compressCount < turns.length - minKeep) {
+  while (totalTokens > effectiveBudget && compressCount < latestTurnIndex) {
     const turn = turns[compressCount];
     if (!turn) break;
 

--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -222,6 +222,69 @@ describe("internal-agents/run-stream", () => {
     assertEquals(capturedToolNames, ["gmail__list_emails", "list_projects"]);
   });
 
+  it("compacts oversized internal runtime message history before streaming", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedMessages: Message[] = [];
+
+    const agent = {
+      id: "research-agent",
+      config: {
+        id: "research-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "research-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [
+        {
+          id: "old-user",
+          role: "user",
+          content: "Research the target architecture.",
+        },
+        {
+          id: "old-assistant",
+          role: "assistant",
+          content: "Large research artifact ".repeat(720_000),
+        },
+        {
+          id: "latest-user",
+          role: "user",
+          content: "Continue and finish the diagram.",
+        },
+      ],
+      tools: [],
+      context: [],
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        createRuntime: () => ({
+          stream: async (messages) => {
+            capturedMessages = messages;
+            return new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.close();
+              },
+            });
+          },
+        }),
+      },
+    );
+
+    assertEquals(capturedMessages.length, 3);
+    assertEquals(capturedMessages[0]?.role, "user");
+    const firstText = capturedMessages[0]?.parts.find((part) => part.type === "text");
+    assertStringIncludes(firstText && "text" in firstText ? firstText.text : "", "[Compressed:");
+    assertStringIncludes(JSON.stringify(capturedMessages), "Continue and finish the diagram.");
+  });
+
   it("materializes explicitly configured sandbox bash before constructing the runtime", async () => {
     const sessionManager = new AgentRunSessionManager();
     const sandboxInputs: AgentServiceSandboxToolsOptions[] = [];

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -5,7 +5,12 @@ import {
   AgentRuntime,
 } from "#veryfront/agent";
 import { normalizeAgUiRuntimeMessages } from "#veryfront/agent/ag-ui/runtime-support.ts";
+import { compactForStep, estimateOverhead } from "#veryfront/chat/message-prep.ts";
 import type { RuntimeRemoteToolConfig } from "#veryfront/agent/runtime/mcp-server-tool-sources.ts";
+import {
+  convertAgentRuntimeMessagesToProviderMessages,
+  convertProviderMessagesToAgentRuntimeMessages,
+} from "#veryfront/agent/runtime/message-adapter.ts";
 import type {
   AgentServiceSandboxToolsOptions,
   AgentServiceSandboxToolsResult,
@@ -358,6 +363,19 @@ function getForwardedIntegrationToolDefinitions(
   }));
 }
 
+function compactRuntimeMessagesForStream(
+  messages: Message[],
+  mergedTools: Agent["config"]["tools"],
+): Message[] {
+  const toolCount = mergedTools && mergedTools !== true ? Object.keys(mergedTools).length : 0;
+  return convertProviderMessagesToAgentRuntimeMessages(
+    compactForStep(
+      convertAgentRuntimeMessagesToProviderMessages(messages),
+      estimateOverhead("", toolCount),
+    ),
+  ) as Message[];
+}
+
 export async function createRuntimeAgentStreamResponse(
   input: RuntimeRunAgentInput,
   agent: Agent,
@@ -411,7 +429,10 @@ export async function createRuntimeAgentStreamResponse(
     new AgentRuntime(runtimeAgent.id, runtimeAgent.config);
 
   let completedResponse: AgentResponse | null = null;
-  const runtimeMessages = normalizeAgUiRuntimeMessages(input.messages);
+  const runtimeMessages = compactRuntimeMessagesForStream(
+    normalizeAgUiRuntimeMessages(input.messages),
+    mergedTools,
+  );
   let runtimeStream: ReadableStream<Uint8Array>;
   let clientAttached = true;
   try {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.656";
+export const VERSION = "0.1.657";

--- a/tests/e2e/regressions/rsc-proxy-hydration.test.ts
+++ b/tests/e2e/regressions/rsc-proxy-hydration.test.ts
@@ -270,9 +270,37 @@ async function withProxyBrowserPage(
 
 async function assertCounterHydration(
   page: import("npm:playwright").Page,
+  diagnostics: import("../../_helpers/playwright.ts").BrowserDiagnostics,
   options: { expectedStrategy: string; expectedModulePath: string },
 ): Promise<void> {
-  await page.waitForSelector('#counter[data-hydrated="yes"]');
+  try {
+    await page.waitForSelector('#counter[data-hydrated="yes"]', {
+      timeout: 60_000,
+    });
+  } catch (error) {
+    const state = await page.evaluate(() => {
+      const counter = document.querySelector("#counter");
+      const hydrationData = document.querySelector("#veryfront-hydration-data");
+      return {
+        url: location.href,
+        counterHtml: counter?.outerHTML ?? null,
+        hydrationDataText: hydrationData?.textContent ?? null,
+        scripts: [...document.scripts].map((script) => script.src).filter(Boolean),
+        resources: performance.getEntriesByType("resource").map((entry) => entry.name),
+      };
+    });
+    throw new Error(
+      [
+        "Counter did not hydrate before the timeout.",
+        `Expected module path: ${options.expectedModulePath}`,
+        `Page state: ${JSON.stringify(state, null, 2)}`,
+        `Browser diagnostics: ${
+          JSON.stringify(getBrowserDiagnosticMessages(diagnostics), null, 2)
+        }`,
+        `Original error: ${error instanceof Error ? error.message : String(error)}`,
+      ].join("\n"),
+    );
+  }
 
   const initialText = await page.textContent("#counter");
   assertEquals(initialText?.trim(), "Count: 0");
@@ -394,7 +422,7 @@ describe(
             const response = await page.goto(`http://127.0.0.1:${port}/`);
             assertEquals(response?.status(), 200);
 
-            await assertCounterHydration(page, {
+            await assertCounterHydration(page, diagnostics, {
               expectedStrategy: "fs",
               expectedModulePath: "/_veryfront/fs/",
             });
@@ -428,7 +456,7 @@ describe(
             context,
             getProxyHeaders("production"),
             async (page, diagnostics) => {
-              await assertCounterHydration(page, {
+              await assertCounterHydration(page, diagnostics, {
                 expectedStrategy: "rsc-module",
                 expectedModulePath: "/_veryfront/rsc/module?",
               });
@@ -466,7 +494,7 @@ describe(
               // loader are dev-only surfaces gated on `isLocalProject` under
               // VULN-SRV-1/2 — a trusted `x-environment: preview` header
               // cannot unlock them because they serve raw project source.
-              await assertCounterHydration(page, {
+              await assertCounterHydration(page, diagnostics, {
                 expectedStrategy: "rsc-module",
                 expectedModulePath: "/_veryfront/rsc/module?",
               });


### PR DESCRIPTION
## Summary
- compact oversized internal runtime message history before streaming to the model
- allow the latest user turn to remain while older oversized turns are summarized
- normalize stored tool-result parts without output during runtime message replay
- bump veryfront package version to 0.1.657

## Verification
- deno test --no-check --allow-all src/internal-agents/run-stream.test.ts src/chat/message-prep.test.ts src/agent/hosted/child-fork-step-message-preparation.test.ts src/agent/runtime/message-preparation.test.ts src/agent/runtime/message-adapter.test.ts
- deno task fmt:check
- deno task lint
- deno task typecheck
- deno task test:unit