### PR TITLE
Default-enable provider-native web tools for the hosted root agent

### DIFF
--- a/src/agent/hosted/chat-runtime-tool-assembly.test.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.test.ts
@@ -135,6 +135,52 @@ Deno.test("prepareHostedChatRuntimeToolAssembly separates provider tools from re
   assertEquals(taskContext.availableToolNames, ["create_file", "web_search"]);
 });
 
+Deno.test("prepareHostedChatRuntimeToolAssembly enables provider tools by default without an allowlist", async () => {
+  const taskContext: HostedChatRuntimeToolAssemblyContext = {
+    authToken: "token",
+    projectId: "project-1",
+    model: "anthropic/claude-sonnet-4-6",
+  };
+
+  const toolAssembly = await prepareHostedChatRuntimeToolAssembly({
+    taskContext,
+    instructions: "Base instructions",
+    localTools: {},
+    apiUrl: "https://api.example.com",
+    apiMcpUrl: "https://api.example.com/mcp",
+    mcpServers: [{ kind: "veryfront-api" }],
+    createRemoteToolSource: remoteSourceFromConfig,
+    preloadLatestConversationUserText: false,
+  });
+
+  assertEquals(toolAssembly.remoteToolNames, ["create_file"]);
+  assertEquals(toolAssembly.compatibleRemoteToolNames, ["create_file"]);
+  assertEquals(toolAssembly.providerToolNames, ["web_fetch", "web_search"]);
+  assertEquals(taskContext.availableToolNames, ["create_file", "web_fetch", "web_search"]);
+});
+
+Deno.test("prepareHostedChatRuntimeToolAssembly omits provider tools by default for non-anthropic models", async () => {
+  const taskContext: HostedChatRuntimeToolAssemblyContext = {
+    authToken: "token",
+    projectId: "project-1",
+    model: "openai/gpt-4.1",
+  };
+
+  const toolAssembly = await prepareHostedChatRuntimeToolAssembly({
+    taskContext,
+    instructions: "Base instructions",
+    localTools: {},
+    apiUrl: "https://api.example.com",
+    apiMcpUrl: "https://api.example.com/mcp",
+    mcpServers: [{ kind: "veryfront-api" }],
+    createRemoteToolSource: remoteSourceFromConfig,
+    preloadLatestConversationUserText: false,
+  });
+
+  assertEquals(toolAssembly.providerToolNames, []);
+  assertEquals(taskContext.availableToolNames, ["create_file"]);
+});
+
 Deno.test("prepareHostedChatRuntimeToolAssembly preloads default research artifacts", async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = () =>

--- a/src/agent/hosted/chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.ts
@@ -149,8 +149,12 @@ export async function prepareHostedChatRuntimeToolAssembly<
     projectId: activeProjectId(input.taskContext),
     projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions,
   });
+  // Provider-native tools (web_search, web_fetch) are opt-in when an explicit
+  // allowlist is present (e.g. a loaded skill restricting tools), preserving the
+  // #2034 boundary. When no allowlist is set — the hosted root agent — they
+  // default on so the platform agent can search and fetch the web inline.
   const providerToolNames = getProviderNativeToolNames({ model: input.taskContext.model }).filter(
-    (toolName) => allowedToolNames ? allowedToolNames.has(toolName) : false,
+    (toolName) => allowedToolNames ? allowedToolNames.has(toolName) : true,
   );
   const localToolNames = Object.keys(localHostTools);
   const availableToolNames = selectProviderCompatibleToolNames(


### PR DESCRIPTION
## Summary

Ensures the hosted **root** agent — e.g. the `veryfront` platform agent served by `veryfront-agent` — has the Anthropic provider-native tools `web_search` and `web_fetch` available, so it can search and fetch the web inline as its system prompt expects.

## Background

#2034 ("Keep provider-native tools inside explicit allowlists", issue #4626) made provider-native tools strictly opt-in: `model-tool-converter` only authorizes them when they appear in the runtime `providerTools` list, which the hosted path derives from `prepareHostedChatRuntimeToolAssembly`.

That assembly filtered provider-native tools by the request/skill allowlist and fell back to **`: false`** when no allowlist was present:

```ts
const providerToolNames = getProviderNativeToolNames({ model }).filter(
  (toolName) => allowedToolNames ? allowedToolNames.has(toolName) : false,
);
```

The hosted root agent runs with **no explicit allowlist**, so it received neither web tool. Loaded skills (e.g. `research`, `plan`) still worked because they set an explicit allowlist that declares the web tools.

## Change

Flip the no-allowlist fallback to **`: true`**:

- **No allowlist** (hosted root agent) → anthropic provider-native tools default on.
- **Explicit allowlist** (skill-restricted runs) → unchanged; still opt-in only, preserving the #2034 boundary.
- **Non-anthropic models** → still resolve to no provider-native tools.

One-line behavioral change plus two regression tests.

## Tests

- `deno test` — `chat-runtime-tool-assembly`, `model-tool-converter`, `provider-native-tool-inventory` (incl. 2 new cases: default-on without allowlist; non-anthropic default-off)
- `deno fmt --check`, `deno lint`, `deno check` — clean on changed files

(Pre-existing, unrelated schema-validator-setup failures in `default-invoke-agent-tool` / `hosted-ag-ui-chat-request` when running files in isolation reproduce on `main` without this change.)