### PR TITLE
Make hosted chat context survive long runs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.657",
+  "version": "0.1.658",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/architecture/24-context-compaction-current-state.md
+++ b/docs/architecture/24-context-compaction-current-state.md
@@ -1,0 +1,145 @@
+# Context compaction pre-v1 baseline
+
+This document records the pre-v1 context compaction behavior in Veryfront Code
+and Veryfront API as reviewed on 2026-06-04. It focuses on hosted chat runs,
+internal runtime runs, API request snapshots, and the gap against durable
+compaction before the v1 implementation lands.
+
+## Summary
+
+Veryfront currently has size-reduction paths, not real context compaction.
+
+The existing code can trim old messages, synthesize a simple topic summary,
+compress old turns before a model call, and shrink API event payloads before
+persistence. Those behaviors are useful guards, but they do not create a durable
+compaction event, do not track `firstKeptEntryId`, do not preserve a structured
+verbatim tail by policy, and do not rebuild future context from summary plus
+retained tail.
+
+## Veryfront Code
+
+### Local memory implementations
+
+`src/agent/memory/memory.ts` contains three memory implementations:
+
+- `ConversationMemory` keeps an in-memory message list, slices by
+  `maxMessages`, then removes oldest messages until the estimated token count
+  fits `maxTokens`.
+- `BufferMemory` keeps only the last configured number of messages.
+- `SummaryMemory` keeps a string summary and a message tail. When the message
+  count crosses the threshold, it summarizes the oldest half by extracting user
+  topics and replaces the summary with text shaped like `Discussed: ...`.
+
+This is lossy and local. It does not validate the summary through a schema, does
+not call a model, does not record token state, and does not store a durable
+compaction marker.
+
+### Provider message budget guards
+
+`src/chat/message-prep.ts` performs provider-message cleanup before model
+execution:
+
+- Tool outputs can be masked.
+- Old turns can be compressed into short text.
+- Old compressed turns can be dropped to fit the effective token budget.
+- Trailing assistant messages and tool-call pairing issues are repaired before
+  dispatch.
+
+This protects model calls from oversized history, but it is still a preflight
+transformation. The result is not persisted as a compaction event and is not
+available as a rebuild source for future turns.
+
+### Internal runtime stream compaction
+
+`src/internal-agents/run-stream.ts` converts runtime messages to provider
+messages, calls `compactForStep`, and converts the result back before streaming.
+The current regression test proves that oversized internal runtime history is
+reduced before streaming and that the latest user message survives.
+
+This path is valuable, but it remains a runtime guard. It does not emit a
+durable compaction record and does not expose the cut point to API or future chat
+preparation.
+
+### Hosted chat preparation
+
+`src/agent/hosted/chat-preparation.ts` normalizes hosted chat requests, prepares
+a root run, creates the runtime, and builds final runtime messages through
+`prepareHostedChatRuntimeMessages`.
+
+The hosted chat preparation path currently has no dedicated context-budget
+manager. It prepares messages, but it does not own durable compaction, event
+emission, summary validation, custom instructions, or summary-plus-tail
+rebuilding.
+
+## Veryfront API
+
+### Request snapshot event compaction
+
+`src/usecases/agent-runs/request-snapshot-compaction.ts` keeps agent-run event
+payloads inside event-size limits:
+
+- Long text is truncated.
+- Base64 image payloads are replaced with a notice.
+- Tool-result output is replaced with a truncation notice.
+- Runtime options and replay-only fields are removed from oversized snapshots.
+- If the payload still does not fit, the message list is narrowed to the last
+  messages, then latest user message, then minimal latest message.
+
+This is payload-size protection for event persistence. It is not conversation
+context compaction. It intentionally removes details to keep the event writable.
+
+### Runtime invocation transport compaction
+
+`src/usecases/agents/runtime-agent-run-client.ts` compacts runtime invocation
+messages before sending them over transport when the JSON body is too large. It
+reuses Veryfront Code message-prep helpers and logs before and after body sizes
+and message counts.
+
+This protects the runtime call boundary. It does not create a reusable
+conversation summary and does not update event history with a compaction
+boundary.
+
+### Event model baseline
+
+`src/usecases/agent-runs/internal-events.ts` defines internal agent-run event
+types such as request enqueueing, tool-result submission, and runtime-owner
+binding. At the baseline point for this review, there was no context-compacted
+event type.
+
+Existing event-size constants in `src/lib/types/agent-run.types.ts` distinguish
+normal events from large request-snapshot events. A real compaction event should
+fit the normal event limit by keeping the payload focused on summary text, ids,
+and token state.
+
+## Durable compaction comparison
+
+A durable operational compaction flow should provide these properties:
+
+- It appends a durable compaction entry with `summary`, `firstKeptEntryId`,
+  `tokensBefore`, optional details, and hook metadata.
+- It keeps a recent verbatim tail instead of only dropping old turns.
+- It supports custom compaction instructions.
+- It tracks token state and cut points.
+- It rebuilds later session context from the latest summary plus retained
+  messages.
+
+## Gap list
+
+| Capability               | Current Veryfront behavior                                                      | Gap                                                                      |
+| ------------------------ | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Durable compaction event | No dedicated event in Code or API                                               | Future runs cannot identify a compaction boundary                        |
+| `firstKeptEntryId`       | Not tracked                                                                     | Summary cannot be paired with the exact retained tail                    |
+| Recent verbatim tail     | Kept only as an incidental result of trimming or compression                    | No explicit policy for preserving recent user, assistant, and tool turns |
+| Token state              | Estimated locally for trimming and logged for transport compaction              | No durable `tokensBefore`, `tokensAfter`, budget, or reserve state       |
+| Custom instructions      | Not supported in hosted chat compaction                                         | Product or system-specific summary rules cannot be injected              |
+| Schema validation        | Existing message schemas are used, but summary output is free text or heuristic | Summary payload is not validated as a compaction artifact                |
+| Future context rebuild   | Not implemented                                                                 | Future context cannot be rebuilt as summary plus retained tail           |
+
+## Current-state conclusion
+
+Veryfront has the right low-level ingredients: message schemas, token
+estimation, provider-message compaction, runtime-message adapters, API event
+persistence, and request snapshot guards. The missing piece is a small
+hosted-chat compaction coordinator that turns size pressure into a durable,
+schema-validated event and a deterministic summary-plus-tail context for later
+execution.

--- a/docs/architecture/25-context-compaction-target-state.md
+++ b/docs/architecture/25-context-compaction-target-state.md
@@ -1,0 +1,252 @@
+# Context compaction target state
+
+This document defines the target state for real context compaction in Veryfront
+Code and Veryfront API. The goal is to make compaction operationally useful
+without adding a large new memory subsystem.
+
+## Design guardrail
+
+Keep the implementation small.
+
+Context compaction should replace the relevant hosted-chat trimming path with
+one clear coordinator. It should not introduce a new storage backend, a parallel
+event log, a global memory framework, a provider abstraction layer, or a
+compatibility flag that keeps old and new hosted-chat behavior alive at the same
+time.
+
+## Ownership
+
+Veryfront Code owns the context budget decision and the compacted runtime
+message list.
+
+Veryfront API owns durable event validation, persistence, and read access.
+
+The boundary is an explicit compaction event payload. Code decides when and how
+to compact. API validates and stores the event.
+
+## ContextBudgetManager
+
+Add a `ContextBudgetManager` for hosted chat runs in Veryfront Code. The first
+implementation can be a small module with pure functions. A class is not
+required unless stateful ownership becomes useful later.
+
+The manager should accept:
+
+- Runtime messages after hosted chat request normalization.
+- Token-budget settings, including context window, reserve tokens, and
+  recent-tail target.
+- Optional custom compaction instructions.
+- A summary generator dependency.
+
+The manager should return:
+
+- The runtime messages to send to the model.
+- A token-state summary.
+- A compaction event payload when compaction happened.
+- No event when the context already fits.
+
+The manager should make one decision per hosted chat preparation pass. It should
+not mutate global memory state or persist events directly. The hosted-chat
+caller should persist the returned event payload through the existing API path.
+
+## Compaction policy
+
+When estimated context tokens exceed the usable budget, the manager should:
+
+1. Walk backward through messages to select a recent verbatim tail.
+2. Preserve recent user, assistant, and tool turns.
+3. Keep tool-call and tool-result pairs together where possible.
+4. Set `firstKeptEntryId` to the id of the first retained runtime message.
+5. Summarize the prefix before that id.
+6. Validate the summary through a Zod schema.
+7. Build model context as summary message plus retained tail.
+8. Emit a durable compaction event.
+
+The first implementation should use a simple tail budget and existing token
+estimation. It should not attempt semantic ranking, vector recall, or multi-pass
+compression.
+
+## Summary schema
+
+Use a minimal summary artifact.
+
+Recommended shape:
+
+```ts
+{
+  text: string;
+}
+```
+
+The schema can add tightly scoped optional metadata later, but only when a caller
+uses it. The first version should not create unused fields for files, tasks,
+decisions, or entities.
+
+The generated summary must be validated before it is inserted into runtime
+context or sent to API as an event payload.
+
+## Durable event
+
+Add an API event for context compaction.
+
+Suggested event type:
+
+```ts
+"AGENT_RUN_CONTEXT_COMPACTED";
+```
+
+Suggested payload:
+
+```ts
+{
+  summary: {
+    text: string;
+  }
+  firstKeptEntryId: string;
+  tokensBefore: number;
+  tokensAfter: number;
+  tokenBudget: number;
+  reserveTokens: number;
+  reason: "context_window" | "transport_body";
+}
+```
+
+The payload should stay under the normal agent-run event size limit. Request
+snapshot compaction should remain an emergency size guard for snapshots, not the
+main context-memory mechanism.
+
+## Rebuild rule
+
+Future hosted-chat context should rebuild from the latest compaction event:
+
+1. Find the latest context-compacted event for the run or conversation scope.
+2. Insert the validated summary as a synthetic context message.
+3. Append the retained messages starting at `firstKeptEntryId` from the stable
+   message order.
+4. Append all later messages after the compaction event.
+
+If no compaction event exists, use the normal message history.
+
+This keeps future context deterministic and auditable: summary first, retained
+verbatim tail second, newer turns last.
+
+When another compaction happens later, it should summarize the currently
+effective context, including the prior summary and retained tail. Rebuild should
+use only the latest compaction event. Do not chain every historical summary into
+model context.
+
+## Synthetic summary message
+
+The rebuilt summary should enter runtime context as one synthetic context
+message:
+
+- Use a stable id prefix such as `context_compaction_summary:<firstKeptEntryId>`.
+- Use a system or developer-context role according to the existing runtime
+  message conventions.
+- Prefix the text with `Previous context summary:`.
+- Do not treat the synthetic summary as a user turn.
+
+## Summary prompt contract
+
+The summarizer prompt should stay small but explicit. It must preserve:
+
+- The active user goal.
+- Explicit decisions and constraints.
+- Unresolved tasks and next steps.
+- Tool results that affect future work.
+- Custom compaction instructions.
+
+It should omit stale logs, repeated tool noise, and details that are no longer
+needed after the retained tail.
+
+## Failure policy
+
+If summary generation fails while compaction is required:
+
+- Log the summary failure with the compaction token state.
+- Emit no successful compaction event unless the summary schema was validated.
+- Fail hosted-chat preparation with a clear context-compaction error.
+
+Do not silently continue with a reduced context. It would hide the fact that
+durable compaction did not happen and would make later rebuild behavior
+ambiguous.
+
+## Observability
+
+Record structured logs or metrics for each compaction decision:
+
+- Whether compaction happened.
+- `tokensBefore`, `tokensAfter`, `tokenBudget`, and `reserveTokens`.
+- Summary token count.
+- Retained tail token count.
+- Compaction reason.
+- Summary generation failure reason when applicable.
+- Whether emergency provider or transport compaction still fired afterward.
+
+These signals are required for production-grade v1 because they prove whether
+context compaction is reducing pressure or hiding a downstream budget problem.
+
+## Budget defaults and caps
+
+The first implementation should define conservative defaults:
+
+- Reserve tokens.
+- Recent-tail token target.
+- Minimum retained recent turns.
+- Maximum summary characters or tokens.
+- Maximum compaction event payload size.
+
+These values should be config-driven where the hosted runtime already has a
+configuration path, but hardcoded safe defaults are acceptable for the initial
+module tests.
+
+## API target behavior
+
+Veryfront API should:
+
+- Validate the new event payload with Zod.
+- Store the event through the existing agent-run event repository.
+- Keep the event payload focused enough to fit the normal event limit.
+- Expose the event anywhere existing run-event reads are used for rebuild or
+  diagnostics.
+- Keep request-snapshot compaction as a write-size guard only.
+
+API should not generate the summary unless API owns the model execution for that
+path. Hosted chat compaction should be decided by Veryfront Code.
+
+## Veryfront Code target behavior
+
+Veryfront Code should:
+
+- Run `ContextBudgetManager` after hosted chat runtime messages are prepared and
+  before model execution.
+- Use existing runtime-message adapters and token estimation where possible.
+- Preserve the recent tail as runtime messages, not provider-only messages.
+- Validate summary output before use.
+- Emit a single durable event when compaction occurs.
+- Record compaction metrics and structured logs.
+- Keep existing hard budget guards as final safety checks, not as the primary
+  hosted-chat compaction story.
+
+## Non-goals
+
+- No new database tables for the first implementation.
+- No vector memory or retrieval layer.
+- No semantic dedupe system.
+- No compatibility flag for old hosted-chat compaction.
+- No broad rewrite of `src/agent/memory/memory.ts`.
+- No new dependency.
+- No attempt to make request snapshot compaction produce conversation memory.
+- No cross-project or user-level long-term memory.
+
+## Success criteria
+
+The target state is reached when an oversized hosted chat run produces a
+validated compaction event, sends summary-plus-tail context to the model, stores
+`firstKeptEntryId` and token state, and can rebuild later context from that event
+without relying on the old lossy hosted-chat trimming behavior.
+
+Production-grade v1 also requires clear summary-failure errors,
+latest-compaction replacement, observable token metrics, conservative budget
+caps, and realistic tests for long histories, tools, uploads, previous
+compaction, and summarizer failure.

--- a/docs/architecture/26-context-compaction-migration-plan.md
+++ b/docs/architecture/26-context-compaction-migration-plan.md
@@ -1,0 +1,211 @@
+# Context compaction migration plan
+
+This plan migrates hosted chat context handling to real compaction without
+maintaining a legacy hosted-chat path. Each step should be small, test-backed,
+and reversible.
+
+## Step 1: Add shared contracts
+
+Add the smallest useful contracts first.
+
+In Veryfront Code:
+
+- Add a Zod schema for the summary artifact, initially `{ text: string }`.
+- Add a Zod schema or typed contract for the compaction result returned by
+  `ContextBudgetManager`.
+- Reuse existing runtime message schemas and adapters instead of creating a
+  parallel message model.
+
+In Veryfront API:
+
+- Add `AGENT_RUN_CONTEXT_COMPACTED` to the internal event type list.
+- Add a payload schema with `summary`, `firstKeptEntryId`, `tokensBefore`,
+  `tokensAfter`, `tokenBudget`, `reserveTokens`, and `reason`.
+- Validate the new event payload through the same event path used by other
+  internal events.
+
+Tests:
+
+- Code schema tests for accepted and rejected summary artifacts.
+- API event schema tests for accepted and rejected compaction payloads.
+
+## Step 2: Implement ContextBudgetManager in Veryfront Code
+
+Create a hosted-chat `ContextBudgetManager` that:
+
+- Estimates token pressure with existing token helpers.
+- Returns unchanged messages when the context fits.
+- Selects a recent verbatim tail by walking backward through runtime messages.
+- Keeps recent user, assistant, and tool turns intact where possible.
+- Sets `firstKeptEntryId` from the first retained message.
+- Summarizes the prefix with an injected summary generator.
+- Validates the summary output.
+- Returns summary-plus-tail runtime messages.
+- Records token-state diagnostics for the caller to log or emit.
+
+Keep the summary generator injectable so unit tests do not call a live model.
+
+Tests:
+
+- No compaction when under budget.
+- Compaction when over budget.
+- Latest user turn is retained.
+- Tool-call and tool-result pairs are retained together when they are in the
+  tail.
+- `firstKeptEntryId` and token fields are set.
+- Invalid summary output fails before event emission.
+- Summary generation failure emits no compaction event and returns a clear
+  context-compaction error.
+
+## Step 3: Wire hosted chat preparation
+
+Call `ContextBudgetManager` in `src/agent/hosted/chat-preparation.ts` after
+`prepareHostedChatRuntimeMessages` and before runtime execution.
+
+Behavior after cutover:
+
+- Hosted chat uses the manager output as the runtime message list.
+- If compaction happened, Code emits the API event through the existing
+  run-event path.
+- If summary generation failed, Code logs the failure and emits no successful
+  compaction event.
+- The old hosted-chat trimming behavior is not kept behind a flag.
+- Existing final hard guards can remain only as safety checks for provider or
+  transport limits.
+
+Tests:
+
+- Hosted chat over budget emits one compaction event.
+- Hosted chat under budget emits no compaction event.
+- The runtime receives summary-plus-tail messages after compaction.
+- The API event sink receives the validated payload.
+- Summary generation failure produces a clear preparation error.
+- Emergency provider or transport compaction after hosted-chat compaction is
+  logged as a safety-guard hit.
+
+## Step 4: Add API persistence and rebuild support
+
+Extend API event handling so the new compaction event is persisted and readable
+through existing run-event access.
+
+Then add latest-compaction rebuild at the hosted-chat boundary:
+
+- Locate the latest `AGENT_RUN_CONTEXT_COMPACTED` event.
+- Read `firstKeptEntryId`.
+- Rebuild context as summary message plus retained tail from stable message order
+  plus later messages.
+- Use normal message history when no compaction event exists.
+
+Do not create a second event store, a new table, or a dedicated API replay
+service for the first version.
+
+Tests:
+
+- Compaction events persist with validated payloads.
+- Latest compaction event wins when multiple events exist.
+- Rebuild includes summary first, retained tail second, later turns last.
+- Rebuild uses normal message history when no compaction event exists.
+
+## Step 5: Add production observability
+
+Add structured logs or metrics for:
+
+- Whether compaction happened.
+- `tokensBefore`, `tokensAfter`, `tokenBudget`, and `reserveTokens`.
+- Summary token count.
+- Retained tail token count.
+- Compaction reason.
+- Summary generation failure reason.
+- Emergency provider or transport compaction after hosted-chat compaction.
+
+Tests:
+
+- Compaction logs include token state.
+- Summary failure logs include failure reason.
+- Emergency downstream compaction logs include enough data to identify the
+  missed budget.
+
+## Step 6: Add realistic fixtures
+
+Add tests that cover realistic histories:
+
+- Long user and assistant back-and-forth.
+- Tool-call and tool-result pairs.
+- Uploaded file references.
+- Provider-owned remote tool history.
+- Previous compaction event.
+- Summary generator failure.
+
+Avoid relying only on repeated-character oversized strings. Keep those tests for
+hard size limits, but use realistic histories for behavior coverage.
+
+## Step 7: Align runtime transport guards
+
+Keep API transport compaction and request snapshot compaction as emergency
+guards, but stop treating them as conversation memory.
+
+Adjust tests and names where needed so the distinction is clear:
+
+- `request-snapshot-compaction.ts` protects event payload size.
+- `runtime-agent-run-client.ts` protects transport body size.
+- `ContextBudgetManager` owns hosted-chat conversation context compaction.
+
+If runtime transport compaction still fires after hosted-chat compaction, log it
+as a safety guard hit. Do not generate a second durable context-compaction event
+from transport-only truncation unless the runtime path has the same
+summary-plus-tail inputs.
+
+## Step 8: Remove superseded hosted-chat behavior
+
+After the manager is wired and tests pass:
+
+- Remove old hosted-chat-specific trimming or summary behavior that is now
+  bypassed.
+- Keep generic memory classes only if other callers still use them.
+- Delete tests that assert the old hosted-chat trimming shape.
+- Replace them with tests that assert durable compaction and summary-plus-tail
+  rebuilding.
+
+No legacy mode should remain for hosted chat. The migration is a cutover, not an
+old/new switch.
+
+## Verification commands
+
+Run the narrow Code tests first:
+
+```sh
+deno test --no-check --allow-all \
+  src/agent/hosted/context-budget-manager.test.ts \
+  src/agent/hosted/chat-preparation.test.ts \
+  src/internal-agents/run-stream.test.ts \
+  src/chat/message-prep.test.ts \
+  src/agent/runtime/message-adapter.test.ts
+```
+
+Run the narrow API tests next:
+
+```sh
+pnpm run test:unit -- \
+  src/usecases/conversations/agent-runs/start-external-default-chat-run.test.ts \
+  src/usecases/runs/create-run.test.ts \
+  src/usecases/agents/runtime-agent-run-client.test.ts \
+  src/lib/types/agent-run.types.test.ts \
+  src/usecases/agent-runs/internal-events.test.ts
+```
+
+Before merging implementation work, run the repo-required quick gates:
+
+```sh
+deno task check
+pnpm run verify:quick
+```
+
+Use broader test suites if the event persistence or replay code touches shared
+repository behavior.
+
+## Stop condition
+
+Stop when hosted chat can compact an oversized run into a validated summary plus
+retained tail, API stores the compaction event with `firstKeptEntryId` and token
+state, and replay can rebuild later context from the latest compaction event
+without a legacy hosted-chat path.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -43,6 +43,9 @@ one runtime concern. Architecture pages do not duplicate the user guides in
 | [21-agent-tool-registration-current-state.md](./21-agent-tool-registration-current-state.md)   | Current agent tool and MCP registration review |
 | [22-agent-tool-registration-target-state.md](./22-agent-tool-registration-target-state.md)     | Target agent tool and MCP registration design  |
 | [23-agent-tool-registration-migration-plan.md](./23-agent-tool-registration-migration-plan.md) | Migration plan for agent tool registration     |
+| [24-context-compaction-current-state.md](./24-context-compaction-current-state.md)             | Current Code and API compaction review         |
+| [25-context-compaction-target-state.md](./25-context-compaction-target-state.md)               | Target context compaction design               |
+| [26-context-compaction-migration-plan.md](./26-context-compaction-migration-plan.md)           | Migration plan for context compaction          |
 
 ## Runtime boundaries
 

--- a/src/agent/conversation/run-chunk-mirror.ts
+++ b/src/agent/conversation/run-chunk-mirror.ts
@@ -4,6 +4,7 @@ import {
   type ConversationRunMirror,
   type ConversationRunMirrorHighBacklogState,
   type ConversationRunMirrorRetryScheduledState,
+  type ConversationRunMirrorSnapshot,
   type ConversationRunMirrorStoppedState,
   createConversationRunMirror,
 } from "./run-mirror.ts";
@@ -25,7 +26,7 @@ const DEFAULT_HOSTED_CHUNK_MIRROR_HIGH_BACKLOG_EVENT_COUNT = 500;
 export interface ConversationRunChunkMirror {
   handleChunk(chunk: ChatUiMessageChunk<ChatMessageMetadata>): Promise<void>;
   appendEvents(events: ConversationRunEvent[]): Promise<void>;
-  flush(): Promise<void>;
+  flush(): Promise<ConversationRunMirrorSnapshot>;
   getSnapshot(): ReturnType<ConversationRunMirror["getSnapshot"]>;
   dispose(): void;
 }

--- a/src/agent/conversation/run-mirror.ts
+++ b/src/agent/conversation/run-mirror.ts
@@ -45,7 +45,7 @@ export interface ConversationRunMirrorHighBacklogState {
 /** Public API contract for conversation run mirror. */
 export interface ConversationRunMirror {
   enqueue(events: unknown[]): void;
-  flush(): Promise<void>;
+  flush(): Promise<ConversationRunMirrorSnapshot>;
   getSnapshot(): ConversationRunMirrorSnapshot;
   dispose(): void;
 }
@@ -260,11 +260,12 @@ export function createConversationRunMirror(input: {
       clearRetryTimer();
       const snapshot = getSnapshot();
       if (snapshot.disabled || (snapshot.pendingEventCount === 0 && !snapshot.inFlight)) {
-        return;
+        return snapshot;
       }
 
       startFlushLoop();
       await inFlightFlush;
+      return getSnapshot();
     },
     getSnapshot,
     dispose() {

--- a/src/agent/conversation/run-stream-mirror.ts
+++ b/src/agent/conversation/run-stream-mirror.ts
@@ -4,6 +4,7 @@ import {
   type ConversationRunMirror,
   type ConversationRunMirrorHighBacklogState,
   type ConversationRunMirrorRetryScheduledState,
+  type ConversationRunMirrorSnapshot,
   type ConversationRunMirrorStoppedState,
   createConversationRunMirror,
 } from "./run-mirror.ts";
@@ -14,7 +15,7 @@ import { type ConversationRunEventQueueController } from "./durable.ts";
 export interface ConversationRunStreamMirror {
   handleStreamEvent(event: ChatStreamEvent): void;
   appendEvents(events: ConversationRunEvent[]): void;
-  flush(): Promise<void>;
+  flush(): Promise<ConversationRunMirrorSnapshot>;
   getSnapshot(): ReturnType<ConversationRunMirror["getSnapshot"]>;
   dispose(): void;
 }

--- a/src/agent/hosted/chat-execution-runtime.test.ts
+++ b/src/agent/hosted/chat-execution-runtime.test.ts
@@ -50,6 +50,16 @@ function createDurableRunMirror(input: {
     appendEvents: async () => {},
     flush: async () => {
       input.flushes.push("flush");
+      return {
+        latestEventId: 0,
+        latestExternalEventSequence: 0,
+        pendingEventCount: 0,
+        consecutiveFailures: 0,
+        disabled: false,
+        hasFlushTimer: false,
+        hasRetryTimer: false,
+        inFlight: false,
+      };
     },
     getSnapshot: () => ({
       latestEventId: 0,

--- a/src/agent/hosted/chat-execution-runtime.ts
+++ b/src/agent/hosted/chat-execution-runtime.ts
@@ -347,7 +347,9 @@ export function createHostedChatStreamFinalizationHooks(input: {
     ) => getEmptyHostedFinalizedMessageTerminalError({ finalStep, streamError }),
     appendFallbackChunk: (chunk: ChatUiMessageChunk<MessageMetadata>) =>
       input.lifecycleAdapter.durableRunMirror?.handleChunk(chunk),
-    flushMirror: () => input.lifecycleAdapter.durableRunMirror?.flush(),
+    flushMirror: async () => {
+      await input.lifecycleAdapter.durableRunMirror?.flush();
+    },
     dispatchTerminalState: async (terminalState) => {
       await dispatchConversationHostedTerminalState(input.lifecycleAdapter, terminalState);
     },

--- a/src/agent/hosted/chat-preparation.test.ts
+++ b/src/agent/hosted/chat-preparation.test.ts
@@ -1,7 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import type { ChatUiMessage } from "#veryfront/chat/types.ts";
 import type { ParsedHostedChatRequest } from "./chat-request-parser.ts";
+import { ContextCompactionError } from "./context-budget-manager.ts";
 import {
   normalizeParsedHostedChatRequest,
   prepareHostedChatExecution,
@@ -21,10 +22,20 @@ const assistantMessage: ChatUiMessage = {
   parts: [{ type: "text", text: "Hi" }],
 };
 
+function isRuntimeFilePart(
+  part: unknown,
+): part is { type: "file"; url: string; mediaType: string } {
+  return typeof part === "object" && part !== null &&
+    "type" in part && part.type === "file" &&
+    "url" in part && typeof part.url === "string" &&
+    "mediaType" in part && typeof part.mediaType === "string";
+}
+
 function createParsedHostedChatRequest(
   overrides: Partial<ParsedHostedChatRequest> = {},
 ): ParsedHostedChatRequest {
   return {
+    agentId: undefined,
     userId: "user-1",
     authToken: "auth-token",
     messages: [userMessage],
@@ -288,6 +299,225 @@ Deno.test("prepareHostedChatExecution prepares root run, runtime, and final mess
   ]);
 });
 
+Deno.test("prepareHostedChatExecution compacts oversized context and appends a durable event", async () => {
+  const originalFetch = globalThis.fetch;
+  const appendedBodies: unknown[] = [];
+  globalThis.fetch = (input, init): Promise<Response> => {
+    if (input.toString().endsWith("/events")) {
+      appendedBodies.push(JSON.parse(String(init?.body ?? "{}")));
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            latest_event_id: 4,
+            latest_external_event_sequence: 3,
+            appended_count: 1,
+            run: {
+              run_id: "run-1",
+              conversation_id: "11111111-1111-4111-a111-111111111111",
+              latest_event_id: 4,
+              latest_external_event_sequence: 3,
+            },
+          }),
+          { status: 200 },
+        ),
+      );
+    }
+
+    return Promise.resolve(new Response("{}", { status: 404 }));
+  };
+
+  try {
+    const result = await prepareHostedChatExecution({
+      request: createParsedHostedChatRequest({
+        conversationId: "11111111-1111-4111-a111-111111111111",
+        projectId: "project-1",
+        validatedContext: {
+          conversationId: "11111111-1111-4111-a111-111111111111",
+          projectId: "project-1",
+          branchId: "branch-1",
+        },
+        messages: [
+          {
+            id: "user-old",
+            role: "user",
+            parts: [{ type: "text", text: "Older request ".repeat(200) }],
+          },
+          {
+            id: "assistant-old",
+            role: "assistant",
+            parts: [{ type: "text", text: "Recent answer." }],
+          },
+          {
+            id: "user-latest",
+            role: "user",
+            parts: [{ type: "text", text: "Continue from the latest requirement." }],
+          },
+        ],
+        durableRootRun: {
+          runId: "run-1",
+          messageId: "message-1",
+          latestEventId: 3,
+          latestExternalEventSequence: 2,
+        },
+      }),
+      agentConfig: {
+        id: "agent-1",
+        model: "configured-model",
+        maxSteps: 25,
+      },
+      apiUrl: "https://api.example.com",
+      abortSignal: new AbortController().signal,
+      resolveModelId: (modelId) => modelId ? `resolved:${modelId}` : undefined,
+      fetchSteering: () =>
+        Promise.resolve({
+          instructions: "Project instructions",
+          skills: [],
+        }),
+      buildInstructions: (input) => [
+        {
+          role: "system",
+          content: `${input.agentConfig.id}:${input.instructions}`,
+        },
+      ],
+      createRuntime: (options) =>
+        Promise.resolve({
+          runtimeKind: "framework",
+          modelId: options.model ?? "resolved:configured-model",
+          cleanup: () => Promise.resolve(),
+          agent: {
+            stream: () =>
+              Promise.resolve({
+                steps: Promise.resolve([]),
+                toUIMessageStream: async function* () {},
+              }),
+          },
+        }),
+      contextBudget: {
+        tokenBudget: 220,
+        reserveTokens: 20,
+        recentTailTokens: 20,
+        now: () => 123,
+        summaryGenerator: () => ({ text: "Older context summarized." }),
+      },
+    });
+
+    assertEquals(result.contextBudgetDiagnostics?.compacted, true);
+    assertEquals(result.finalMessages.map((message) => message.id), [
+      "context_compaction_summary:agent-runtime-assistant-2",
+      "agent-runtime-assistant-2",
+      "agent-runtime-user-3",
+    ]);
+    assertEquals(appendedBodies.length, 1);
+    assertEquals(
+      (appendedBodies[0] as { events?: Array<{ type?: string }> }).events?.[0]?.type,
+      "AGENT_RUN_CONTEXT_COMPACTED",
+    );
+    assertEquals(
+      (appendedBodies[0] as { events?: Array<{ firstKeptEntryId?: string }> }).events?.[0]
+        ?.firstKeptEntryId,
+      "agent-runtime-assistant-2",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("prepareHostedChatExecution rejects compacted context when durable event persistence is not complete", async () => {
+  const originalFetch = globalThis.fetch;
+  let createRuntimeCalls = 0;
+  globalThis.fetch = (input): Promise<Response> => {
+    if (input.toString().endsWith("/events")) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ detail: "append failed" }), {
+          status: 500,
+        }),
+      );
+    }
+
+    return Promise.resolve(new Response("{}", { status: 404 }));
+  };
+
+  try {
+    await assertRejects(
+      () =>
+        prepareHostedChatExecution({
+          request: createParsedHostedChatRequest({
+            conversationId: "11111111-1111-4111-a111-111111111111",
+            projectId: "project-1",
+            validatedContext: {
+              conversationId: "11111111-1111-4111-a111-111111111111",
+              projectId: "project-1",
+              branchId: "branch-1",
+            },
+            messages: [
+              {
+                id: "user-old",
+                role: "user",
+                parts: [{ type: "text", text: "Older request ".repeat(200) }],
+              },
+              {
+                id: "user-latest",
+                role: "user",
+                parts: [{ type: "text", text: "Continue from the latest requirement." }],
+              },
+            ],
+            durableRootRun: {
+              runId: "run-1",
+              messageId: "message-1",
+              latestEventId: 3,
+              latestExternalEventSequence: 2,
+            },
+          }),
+          agentConfig: {
+            id: "agent-1",
+            model: "configured-model",
+            maxSteps: 25,
+          },
+          apiUrl: "https://api.example.com",
+          abortSignal: new AbortController().signal,
+          resolveModelId: (modelId) => modelId ? `resolved:${modelId}` : undefined,
+          fetchSteering: () =>
+            Promise.resolve({
+              instructions: "Project instructions",
+              skills: [],
+            }),
+          buildInstructions: (input) => [
+            {
+              role: "system",
+              content: `${input.agentConfig.id}:${input.instructions}`,
+            },
+          ],
+          createRuntime: (options) => {
+            createRuntimeCalls += 1;
+            return Promise.resolve({
+              runtimeKind: "framework",
+              modelId: options.model ?? "resolved:configured-model",
+              cleanup: () => Promise.resolve(),
+              agent: {
+                stream: () =>
+                  Promise.resolve({
+                    steps: Promise.resolve([]),
+                    toUIMessageStream: async function* () {},
+                  }),
+              },
+            });
+          },
+          contextBudget: {
+            tokenBudget: 220,
+            reserveTokens: 20,
+            recentTailTokens: 20,
+            summaryGenerator: () => ({ text: "Older context summarized." }),
+          },
+        }),
+      ContextCompactionError,
+      "Context compaction event was not durably persisted before model execution",
+    );
+    assertEquals(createRuntimeCalls, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 Deno.test("prepareHostedChatRuntimeMessages refreshes uploaded file URLs through the hosted API", async () => {
   const requestedUrls: string[] = [];
   const originalFetch = globalThis.fetch;
@@ -327,7 +557,7 @@ Deno.test("prepareHostedChatRuntimeMessages refreshes uploaded file URLs through
     ]);
     assertEquals(
       messages[0]?.parts.some((part) =>
-        part.type === "file" &&
+        isRuntimeFilePart(part) &&
         part.url === "https://signed.example.com/notes.txt" &&
         part.mediaType === "text/plain"
       ),
@@ -370,9 +600,11 @@ Deno.test("prepareHostedChatRuntimeMessages omits provider-owned remote tool his
         role: "tool",
         parts: [
           {
-            type: "tool_result",
-            tool_call_id: "toolu_web_search",
-            tool_name: "web_search",
+            type: "tool-web_search",
+            toolCallId: "toolu_web_search",
+            toolName: "web_search",
+            input: { query: "site:skatteverket.se tax residency" },
+            state: "output-available",
             output: null,
           },
         ],

--- a/src/agent/hosted/chat-preparation.ts
+++ b/src/agent/hosted/chat-preparation.ts
@@ -27,6 +27,12 @@ import {
 } from "./runtime-request-config.ts";
 import { getRuntimeUploadUrl } from "../runtime/upload-url-client.ts";
 import type { RuntimeSkillDefinition } from "../runtime/skill-metadata.ts";
+import {
+  applyContextBudget,
+  type ContextBudgetDiagnostics,
+  type ContextBudgetManagerOptions,
+  ContextCompactionError,
+} from "./context-budget-manager.ts";
 
 /** Request payload for normalized hosted chat. */
 export type NormalizedHostedChatRequest = {
@@ -119,6 +125,26 @@ function getAllowedRemoteToolNames(agentConfig: { allowedRemoteTools?: unknown }
     : [];
 }
 
+async function flushRequiredContextCompactionEvent(
+  rootRunContext: HostedConversationRootRunContext,
+  eventPayload: ConversationRunEvent,
+): Promise<void> {
+  if (!rootRunContext.durableRunMirror) {
+    throw new ContextCompactionError(
+      "Context compaction produced an event but no durable run mirror is available",
+    );
+  }
+
+  await rootRunContext.durableRunMirror.appendEvents([eventPayload]);
+  const snapshot = await rootRunContext.durableRunMirror.flush();
+  if (snapshot.disabled || snapshot.pendingEventCount > 0 || snapshot.inFlight) {
+    rootRunContext.durableRunMirror.dispose();
+    throw new ContextCompactionError(
+      "Context compaction event was not durably persisted before model execution",
+    );
+  }
+}
+
 /** Options accepted by hosted chat execution preparation root run. */
 export type HostedChatExecutionPreparationRootRunOptions = Pick<
   PrepareHostedConversationRootRunContextInput,
@@ -128,6 +154,17 @@ export type HostedChatExecutionPreparationRootRunOptions = Pick<
   | "onPersistLatestUserMessageFailure"
   | "instrumentation"
 >;
+
+/** Public API contract for hosted chat context budget logging. */
+export type HostedChatContextBudgetLogger = {
+  debug?: (message: string, metadata?: Record<string, unknown>) => void;
+  error?: (message: string, metadata?: Record<string, unknown>) => void;
+};
+
+/** Options accepted by hosted chat context budget management. */
+export type HostedChatContextBudgetOptions = ContextBudgetManagerOptions & {
+  logger?: HostedChatContextBudgetLogger;
+};
 
 /** Input payload for hosted chat execution preparation. */
 export type HostedChatExecutionPreparationInput<
@@ -163,6 +200,7 @@ export type HostedChatExecutionPreparationInput<
       RuntimeAgentThinkingConfig
     >,
   ) => Promise<TRuntimeResult>;
+  contextBudget?: HostedChatContextBudgetOptions;
 };
 
 /** Result returned from hosted chat execution preparation. */
@@ -173,6 +211,7 @@ export type HostedChatExecutionPreparationResult<
   rootRunContext: HostedConversationRootRunContext;
   runtime: TRuntimeResult;
   finalMessages: AgentRuntimeMessage[];
+  contextBudgetDiagnostics?: ContextBudgetDiagnostics;
   steering: HostedChatRuntimeCreationPreparationResult<
     TRuntimeAgentDefinition
   >["steering"];
@@ -334,7 +373,6 @@ export async function prepareHostedChatExecution<
     fetchSteering: input.fetchSteering,
     buildInstructions: input.buildInstructions,
   });
-  const runtime = await input.createRuntime(runtimePreparation.creationOptions);
   const finalMessages = await prepareHostedChatRuntimeMessages(
     normalized.effectiveMessages,
     {
@@ -344,12 +382,37 @@ export async function prepareHostedChatExecution<
       providerOwnedToolNames: getAllowedRemoteToolNames(input.agentConfig),
     },
   );
+  let budgetedContext: Awaited<ReturnType<typeof applyContextBudget>> | undefined;
+  if (input.contextBudget) {
+    try {
+      budgetedContext = await applyContextBudget(finalMessages, input.contextBudget);
+    } catch (error) {
+      input.contextBudget.logger?.error?.("Hosted chat context compaction failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+
+  if (budgetedContext?.eventPayload) {
+    input.contextBudget?.logger?.debug?.("Hosted chat context compacted", {
+      ...budgetedContext.diagnostics,
+      firstKeptEntryId: budgetedContext.eventPayload.firstKeptEntryId,
+    });
+    await flushRequiredContextCompactionEvent(rootRunContext, budgetedContext.eventPayload);
+  } else if (budgetedContext) {
+    input.contextBudget?.logger?.debug?.("Hosted chat context compaction skipped", {
+      ...budgetedContext.diagnostics,
+    });
+  }
+  const runtime = await input.createRuntime(runtimePreparation.creationOptions);
 
   return {
     ...normalized,
     rootRunContext,
     runtime,
-    finalMessages,
+    finalMessages: budgetedContext?.messages ?? finalMessages,
+    contextBudgetDiagnostics: budgetedContext?.diagnostics,
     steering: runtimePreparation.steering,
     runtimeConfig: runtimePreparation.runtimeConfig,
   };

--- a/src/agent/hosted/child-fork-execution-runner.ts
+++ b/src/agent/hosted/child-fork-execution-runner.ts
@@ -397,7 +397,9 @@ export async function executeHostedChildForkWithPreparedTools<
       runContext,
       monitorAbortController: childRunMonitorAbortController,
       monitorPromise: childRunMonitorPromise,
-      flushMirror: () => runContext.durableRunMirror?.flush() ?? Promise.resolve(),
+      flushMirror: async () => {
+        await runContext.durableRunMirror?.flush();
+      },
       closeTooling,
       closeRuntime,
     });

--- a/src/agent/hosted/context-budget-manager.test.ts
+++ b/src/agent/hosted/context-budget-manager.test.ts
@@ -1,0 +1,229 @@
+import "#veryfront/schemas/_test-setup.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
+import type { AgentRuntimeMessage } from "../runtime/message-adapter.ts";
+import {
+  AGENT_RUN_CONTEXT_COMPACTED_EVENT_TYPE,
+  applyContextBudget,
+  ContextCompactionError,
+  getContextCompactionEventPayloadSchema,
+} from "./context-budget-manager.ts";
+
+function message(
+  id: string,
+  role: AgentRuntimeMessage["role"],
+  text: string,
+  timestamp = 1,
+): AgentRuntimeMessage {
+  return {
+    id,
+    role,
+    parts: [{ type: "text", text }],
+    timestamp,
+  };
+}
+
+function isTextPart(part: unknown): part is { type: "text"; text: string } {
+  return typeof part === "object" && part !== null &&
+    "type" in part && part.type === "text" &&
+    "text" in part && typeof part.text === "string";
+}
+
+function toolCallMessage(id: string, toolCallId: string): AgentRuntimeMessage {
+  return {
+    id,
+    role: "assistant",
+    parts: [{
+      type: "tool-call",
+      toolCallId,
+      toolName: "search_docs",
+      args: { query: "context compaction" },
+    }],
+    timestamp: 1,
+  };
+}
+
+function toolResultMessage(id: string, toolCallId: string): AgentRuntimeMessage {
+  return {
+    id,
+    role: "tool",
+    parts: [{
+      type: "tool-result",
+      toolCallId,
+      toolName: "search_docs",
+      result: { ok: true },
+    }],
+    timestamp: 1,
+  };
+}
+
+Deno.test("applyContextBudget returns unchanged messages when under budget", async () => {
+  const messages = [
+    message("user-1", "user", "Hello"),
+    message("assistant-1", "assistant", "Hi"),
+  ];
+
+  const result = await applyContextBudget(messages, {
+    tokenBudget: 10_000,
+    reserveTokens: 1_000,
+    recentTailTokens: 1_000,
+    summaryGenerator: () => ({ text: "unused" }),
+  });
+
+  assertEquals(result.messages, messages);
+  assertEquals(result.eventPayload, undefined);
+  assertEquals(result.diagnostics.compacted, false);
+});
+
+Deno.test("applyContextBudget compacts oversized history into summary plus retained tail", async () => {
+  const messages = [
+    message("user-1", "user", "Older goal ".repeat(200)),
+    message("assistant-1", "assistant", "Recent answer"),
+    message("user-2", "user", "Latest user request"),
+  ];
+
+  const result = await applyContextBudget(messages, {
+    tokenBudget: 260,
+    reserveTokens: 20,
+    recentTailTokens: 20,
+    now: () => 123,
+    summaryGenerator: ({ messagesToSummarize, retainedMessages }) => ({
+      text: `Summarized ${messagesToSummarize.length}; retained ${retainedMessages.length}`,
+    }),
+  });
+
+  assertExists(result.eventPayload);
+  assertEquals(result.eventPayload.type, AGENT_RUN_CONTEXT_COMPACTED_EVENT_TYPE);
+  assertEquals(result.eventPayload.firstKeptEntryId, "assistant-1");
+  assertEquals(result.messages.map((entry) => entry.id), [
+    "context_compaction_summary:assistant-1",
+    "assistant-1",
+    "user-2",
+  ]);
+  assertEquals(result.messages[0]?.role, "system");
+  const summaryPart = result.messages[0]?.parts[0];
+  assertStringIncludes(
+    isTextPart(summaryPart) ? summaryPart.text : "",
+    "Previous context summary:",
+  );
+  assertEquals(result.diagnostics.compacted, true);
+});
+
+Deno.test("applyContextBudget retains the latest assistant and user exchange", async () => {
+  const messages = [
+    message("user-1", "user", "Older goal ".repeat(200)),
+    message("assistant-1", "assistant", "Older answer ".repeat(200)),
+    message("assistant-2", "assistant", "Recent answer"),
+    message("user-2", "user", "Latest user request"),
+  ];
+
+  const result = await applyContextBudget(messages, {
+    tokenBudget: 260,
+    reserveTokens: 20,
+    recentTailTokens: 20,
+    summaryGenerator: () => ({ text: "Earlier context summarized." }),
+  });
+
+  assertExists(result.eventPayload);
+  assertEquals(result.eventPayload.firstKeptEntryId, "assistant-2");
+  assertEquals(result.messages.map((entry) => entry.id), [
+    "context_compaction_summary:assistant-2",
+    "assistant-2",
+    "user-2",
+  ]);
+});
+
+Deno.test("applyContextBudget keeps tool call and result pairs in the retained tail", async () => {
+  const messages = [
+    message("user-1", "user", "Older goal ".repeat(200)),
+    toolCallMessage("assistant-tool-1", "tool-1"),
+    toolResultMessage("tool-result-1", "tool-1"),
+    message("user-2", "user", "Use that result"),
+  ];
+
+  const result = await applyContextBudget(messages, {
+    tokenBudget: 220,
+    reserveTokens: 20,
+    recentTailTokens: 80,
+    summaryGenerator: () => ({ text: "Tool context summarized." }),
+  });
+
+  assertExists(result.eventPayload);
+  assertEquals(result.eventPayload.firstKeptEntryId, "assistant-tool-1");
+  assertEquals(result.messages.map((entry) => entry.id), [
+    "context_compaction_summary:assistant-tool-1",
+    "assistant-tool-1",
+    "tool-result-1",
+    "user-2",
+  ]);
+});
+
+Deno.test("applyContextBudget rejects invalid summary output", async () => {
+  await assertRejects(
+    () =>
+      applyContextBudget([
+        message("user-1", "user", "Older goal ".repeat(200)),
+        message("user-2", "user", "Latest"),
+      ], {
+        tokenBudget: 180,
+        reserveTokens: 20,
+        recentTailTokens: 20,
+        summaryGenerator: () => ({ text: "" }),
+      }),
+    ContextCompactionError,
+    "Context compaction summary generation failed",
+  );
+});
+
+Deno.test("applyContextBudget rejects compacted context that still exceeds the usable budget", async () => {
+  await assertRejects(
+    () =>
+      applyContextBudget([
+        message("user-1", "user", "Older goal ".repeat(200)),
+        message("user-2", "user", "Latest request ".repeat(200)),
+      ], {
+        tokenBudget: 120,
+        reserveTokens: 20,
+        recentTailTokens: 20,
+        summaryGenerator: () => ({ text: "Older context summarized." }),
+      }),
+    ContextCompactionError,
+    "Context compaction result exceeded usable token budget",
+  );
+});
+
+Deno.test("applyContextBudget rejects invalid budget options before compaction", async () => {
+  await assertRejects(
+    () =>
+      applyContextBudget([
+        message("user-1", "user", "Older goal ".repeat(200)),
+        message("user-2", "user", "Latest request"),
+      ], {
+        tokenBudget: 100,
+        reserveTokens: 100,
+        recentTailTokens: 20,
+        summaryGenerator: () => ({ text: "unused" }),
+      }),
+    ContextCompactionError,
+    "reserveTokens must be lower than tokenBudget",
+  );
+});
+
+Deno.test("context compaction event schema rejects inconsistent token accounting", () => {
+  const result = getContextCompactionEventPayloadSchema().safeParse({
+    type: AGENT_RUN_CONTEXT_COMPACTED_EVENT_TYPE,
+    summary: { text: "Earlier context summarized." },
+    firstKeptEntryId: "message-2",
+    tokensBefore: 1_000,
+    tokensAfter: 900,
+    tokenBudget: 800,
+    reserveTokens: 100,
+    reason: "context_window",
+  });
+
+  assertEquals(result.success, false);
+});

--- a/src/agent/hosted/context-budget-manager.ts
+++ b/src/agent/hosted/context-budget-manager.ts
@@ -1,0 +1,407 @@
+import { estimateTokens } from "../../chat/message-prep.ts";
+import { defineSchema } from "../../schemas/index.ts";
+import type { InferSchema } from "../../extensions/schema/index.ts";
+import type { AgentRuntimeMessage } from "../runtime/message-adapter.ts";
+
+export const AGENT_RUN_CONTEXT_COMPACTED_EVENT_TYPE = "AGENT_RUN_CONTEXT_COMPACTED" as const;
+
+export const getContextCompactionSummarySchema = defineSchema((v) =>
+  v.object({
+    text: v.string().min(1),
+  })
+);
+
+export const getContextCompactionEventPayloadSchema = defineSchema((v) =>
+  v.object({
+    type: v.literal(AGENT_RUN_CONTEXT_COMPACTED_EVENT_TYPE),
+    summary: getContextCompactionSummarySchema(),
+    firstKeptEntryId: v.string().min(1),
+    tokensBefore: v.number().int().nonnegative(),
+    tokensAfter: v.number().int().nonnegative(),
+    tokenBudget: v.number().int().positive(),
+    reserveTokens: v.number().int().nonnegative(),
+    reason: v.enum(["context_window", "transport_body"]),
+  }).superRefine((event, ctx) => {
+    const usableBudget = event.tokenBudget - event.reserveTokens;
+    if (usableBudget <= 0) {
+      ctx.addIssue({
+        code: "custom",
+        message: "reserveTokens must be lower than tokenBudget",
+        path: ["reserveTokens"],
+      });
+    }
+    if (event.tokensAfter > usableBudget) {
+      ctx.addIssue({
+        code: "custom",
+        message: "tokensAfter must fit within the usable token budget",
+        path: ["tokensAfter"],
+      });
+    }
+    if (event.tokensAfter > event.tokensBefore) {
+      ctx.addIssue({
+        code: "custom",
+        message: "tokensAfter cannot exceed tokensBefore",
+        path: ["tokensAfter"],
+      });
+    }
+  })
+);
+
+export type ContextCompactionSummary = InferSchema<
+  ReturnType<typeof getContextCompactionSummarySchema>
+>;
+
+export type ContextCompactionEventPayload = InferSchema<
+  ReturnType<typeof getContextCompactionEventPayloadSchema>
+>;
+
+export type ContextCompactionReason = ContextCompactionEventPayload["reason"];
+
+export type ContextSummaryGenerator = (input: {
+  messagesToSummarize: AgentRuntimeMessage[];
+  retainedMessages: AgentRuntimeMessage[];
+  customInstructions?: string;
+}) => Promise<ContextCompactionSummary> | ContextCompactionSummary;
+
+export type ContextBudgetManagerOptions = {
+  tokenBudget: number;
+  reserveTokens: number;
+  recentTailTokens: number;
+  minimumRecentTurns?: number;
+  maxSummaryTokens?: number;
+  customInstructions?: string;
+  reason?: ContextCompactionReason;
+  now?: () => number;
+  summaryGenerator: ContextSummaryGenerator;
+};
+
+export type ContextBudgetDiagnostics = {
+  compacted: boolean;
+  tokensBefore: number;
+  tokensAfter: number;
+  tokenBudget: number;
+  reserveTokens: number;
+  summaryTokens: number;
+  retainedTailTokens: number;
+  reason: ContextCompactionReason;
+};
+
+export type ContextBudgetManagerResult = {
+  messages: AgentRuntimeMessage[];
+  eventPayload?: ContextCompactionEventPayload;
+  diagnostics: ContextBudgetDiagnostics;
+};
+
+export class ContextCompactionError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "ContextCompactionError";
+  }
+}
+
+function getUsableTokenBudget(
+  options: Pick<ContextBudgetManagerOptions, "tokenBudget" | "reserveTokens">,
+): number {
+  return options.tokenBudget - options.reserveTokens;
+}
+
+function getMessageTokens(message: AgentRuntimeMessage): number {
+  return estimateTokens(message);
+}
+
+function getMessageListTokens(messages: readonly AgentRuntimeMessage[]): number {
+  return estimateTokens(messages);
+}
+
+function isUserMessage(message: AgentRuntimeMessage): boolean {
+  return message.role === "user";
+}
+
+function getToolCallIds(message: AgentRuntimeMessage): string[] {
+  return message.parts.flatMap((part) =>
+    "toolCallId" in part && typeof part.toolCallId === "string" &&
+      part.type !== "tool-result"
+      ? [part.toolCallId]
+      : []
+  );
+}
+
+function getToolResultIds(message: AgentRuntimeMessage): string[] {
+  return message.parts.flatMap((part) =>
+    part.type === "tool-result" && typeof part.toolCallId === "string" ? [part.toolCallId] : []
+  );
+}
+
+function collectToolCallIds(messages: readonly AgentRuntimeMessage[]): Set<string> {
+  const ids = new Set<string>();
+  for (const message of messages) {
+    for (const id of getToolCallIds(message)) {
+      ids.add(id);
+    }
+  }
+  return ids;
+}
+
+function collectToolResultIds(messages: readonly AgentRuntimeMessage[]): Set<string> {
+  const ids = new Set<string>();
+  for (const message of messages) {
+    for (const id of getToolResultIds(message)) {
+      ids.add(id);
+    }
+  }
+  return ids;
+}
+
+function findLatestUserMessageIndex(messages: readonly AgentRuntimeMessage[]): number {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message && isUserMessage(message)) {
+      return index;
+    }
+  }
+  return Math.max(0, messages.length - 1);
+}
+
+function findRecentTailStartIndex(
+  messages: readonly AgentRuntimeMessage[],
+  options: Pick<ContextBudgetManagerOptions, "recentTailTokens" | "minimumRecentTurns">,
+): number {
+  const latestUserIndex = findLatestUserMessageIndex(messages);
+  const minimumRecentTurns = Math.max(1, options.minimumRecentTurns ?? 1);
+  let tokenTotal = 0;
+  let userTurnCount = 0;
+  let startIndex = messages.length - 1;
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message) {
+      continue;
+    }
+
+    tokenTotal += getMessageTokens(message);
+    if (isUserMessage(message)) {
+      userTurnCount += 1;
+    }
+    startIndex = index;
+
+    if (
+      tokenTotal >= options.recentTailTokens &&
+      startIndex <= latestUserIndex &&
+      userTurnCount >= minimumRecentTurns
+    ) {
+      break;
+    }
+  }
+
+  return startIndex;
+}
+
+function expandTailForToolPairs(
+  messages: readonly AgentRuntimeMessage[],
+  initialStartIndex: number,
+): number {
+  let startIndex = initialStartIndex;
+  let changed = true;
+
+  while (changed) {
+    changed = false;
+    const tail = messages.slice(startIndex);
+    const tailCallIds = collectToolCallIds(tail);
+    const tailResultIds = collectToolResultIds(tail);
+
+    for (let index = startIndex - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (!message) {
+        continue;
+      }
+
+      const messageCallIds = getToolCallIds(message);
+      const messageResultIds = getToolResultIds(message);
+      const tailNeedsCall = messageCallIds.some((id) => tailResultIds.has(id));
+      const tailNeedsResult = messageResultIds.some((id) => tailCallIds.has(id));
+
+      if (tailNeedsCall || tailNeedsResult) {
+        startIndex = index;
+        changed = true;
+      }
+    }
+  }
+
+  return startIndex;
+}
+
+function expandTailForRecentAssistantTurn(
+  messages: readonly AgentRuntimeMessage[],
+  initialStartIndex: number,
+): number {
+  const firstRetainedMessage = messages[initialStartIndex];
+  const previousMessage = messages[initialStartIndex - 1];
+  return firstRetainedMessage?.role === "user" && previousMessage?.role === "assistant"
+    ? initialStartIndex - 1
+    : initialStartIndex;
+}
+
+function createSyntheticSummaryMessage(input: {
+  text: string;
+  firstKeptEntryId: string;
+  timestamp: number;
+}): AgentRuntimeMessage {
+  return {
+    id: `context_compaction_summary:${input.firstKeptEntryId}`,
+    role: "system",
+    parts: [{
+      type: "text",
+      text: `Previous context summary:\n${input.text}`,
+    }],
+    timestamp: input.timestamp,
+  };
+}
+
+function enforceSummaryLimit(
+  summary: ContextCompactionSummary,
+  maxSummaryTokens?: number,
+): ContextCompactionSummary {
+  if (!maxSummaryTokens || estimateTokens(summary.text) <= maxSummaryTokens) {
+    return summary;
+  }
+
+  throw new ContextCompactionError("Context compaction summary exceeded maxSummaryTokens");
+}
+
+function assertValidContextBudgetOptions(options: ContextBudgetManagerOptions): void {
+  if (!Number.isInteger(options.tokenBudget) || options.tokenBudget <= 0) {
+    throw new ContextCompactionError("Context compaction tokenBudget must be a positive integer");
+  }
+  if (!Number.isInteger(options.reserveTokens) || options.reserveTokens < 0) {
+    throw new ContextCompactionError(
+      "Context compaction reserveTokens must be a nonnegative integer",
+    );
+  }
+  if (options.reserveTokens >= options.tokenBudget) {
+    throw new ContextCompactionError(
+      "Context compaction reserveTokens must be lower than tokenBudget",
+    );
+  }
+  if (!Number.isInteger(options.recentTailTokens) || options.recentTailTokens <= 0) {
+    throw new ContextCompactionError(
+      "Context compaction recentTailTokens must be a positive integer",
+    );
+  }
+  if (
+    options.minimumRecentTurns !== undefined &&
+    (!Number.isInteger(options.minimumRecentTurns) || options.minimumRecentTurns <= 0)
+  ) {
+    throw new ContextCompactionError(
+      "Context compaction minimumRecentTurns must be a positive integer",
+    );
+  }
+  if (
+    options.maxSummaryTokens !== undefined &&
+    (!Number.isInteger(options.maxSummaryTokens) || options.maxSummaryTokens <= 0)
+  ) {
+    throw new ContextCompactionError(
+      "Context compaction maxSummaryTokens must be a positive integer",
+    );
+  }
+}
+
+/** Apply hosted-chat context budget management. */
+export async function applyContextBudget(
+  messages: readonly AgentRuntimeMessage[],
+  options: ContextBudgetManagerOptions,
+): Promise<ContextBudgetManagerResult> {
+  assertValidContextBudgetOptions(options);
+  const reason = options.reason ?? "context_window";
+  const tokensBefore = getMessageListTokens(messages);
+  const usableBudget = getUsableTokenBudget(options);
+
+  if (tokensBefore <= usableBudget) {
+    return {
+      messages: [...messages],
+      diagnostics: {
+        compacted: false,
+        tokensBefore,
+        tokensAfter: tokensBefore,
+        tokenBudget: options.tokenBudget,
+        reserveTokens: options.reserveTokens,
+        summaryTokens: 0,
+        retainedTailTokens: tokensBefore,
+        reason,
+      },
+    };
+  }
+
+  if (messages.length === 0) {
+    throw new ContextCompactionError("Context compaction requires at least one message");
+  }
+
+  const initialTailStartIndex = findRecentTailStartIndex(messages, options);
+  const conversationTailStartIndex = expandTailForRecentAssistantTurn(
+    messages,
+    initialTailStartIndex,
+  );
+  const tailStartIndex = expandTailForToolPairs(messages, conversationTailStartIndex);
+  const messagesToSummarize = messages.slice(0, tailStartIndex);
+  const retainedMessages = messages.slice(tailStartIndex);
+  const firstKeptEntryId = retainedMessages[0]?.id;
+
+  if (!firstKeptEntryId) {
+    throw new ContextCompactionError("Context compaction could not select a retained tail");
+  }
+
+  let summary: ContextCompactionSummary;
+  try {
+    summary = getContextCompactionSummarySchema().parse(
+      await options.summaryGenerator({
+        messagesToSummarize,
+        retainedMessages,
+        customInstructions: options.customInstructions,
+      }),
+    );
+    summary = enforceSummaryLimit(summary, options.maxSummaryTokens);
+  } catch (error) {
+    if (error instanceof ContextCompactionError) {
+      throw error;
+    }
+    throw new ContextCompactionError("Context compaction summary generation failed", {
+      cause: error,
+    });
+  }
+
+  const summaryMessage = createSyntheticSummaryMessage({
+    text: summary.text,
+    firstKeptEntryId,
+    timestamp: options.now?.() ?? Date.now(),
+  });
+  const compactedMessages = [summaryMessage, ...retainedMessages];
+  const tokensAfter = getMessageListTokens(compactedMessages);
+  if (tokensAfter > usableBudget) {
+    throw new ContextCompactionError("Context compaction result exceeded usable token budget");
+  }
+
+  const eventPayload = getContextCompactionEventPayloadSchema().parse({
+    type: AGENT_RUN_CONTEXT_COMPACTED_EVENT_TYPE,
+    summary,
+    firstKeptEntryId,
+    tokensBefore,
+    tokensAfter,
+    tokenBudget: options.tokenBudget,
+    reserveTokens: options.reserveTokens,
+    reason,
+  });
+
+  return {
+    messages: compactedMessages,
+    eventPayload,
+    diagnostics: {
+      compacted: true,
+      tokensBefore,
+      tokensAfter,
+      tokenBudget: options.tokenBudget,
+      reserveTokens: options.reserveTokens,
+      summaryTokens: estimateTokens(summary.text),
+      retainedTailTokens: getMessageListTokens(retainedMessages),
+      reason,
+    },
+  };
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.657";
+export const VERSION = "0.1.658";


### PR DESCRIPTION
## Summary
- Add a hosted ContextBudgetManager that compacts oversized chat history into a validated summary plus retained recent tail.
- Persist durable compaction events before runtime creation and fail closed if persistence/accounting is invalid.
- Bump Veryfront Code patch version to 0.1.658 and document current, target, and migration states without external-source references.

## Release order
Merge after the API compaction-event PR is deployed, because this runtime emits AGENT_RUN_CONTEXT_COMPACTED events.

## Verification
- deno task fmt:check
- deno lint
- deno check src/index.ts
- deno task typecheck
- deno task test:unit
- focused hosted context/mirror tests