### PR TITLE
Propagate provider terminal errors from child runs

### DIFF
--- a/src/agent/hosted/child-lifecycle.test.ts
+++ b/src/agent/hosted/child-lifecycle.test.ts
@@ -262,6 +262,39 @@ describe("agent/hosted-child-lifecycle", () => {
     assertEquals(result.terminalState.usage?.totalTokens, 3);
   });
 
+  it("maps known provider errors from failed child snapshots to terminal failed states", async () => {
+    const calls: string[] = [];
+    const adapter: HostedChildLifecycleAdapter = {
+      failed: (terminalState) => {
+        calls.push(
+          `failed:${terminalState.terminalErrorCode}:${terminalState.terminalErrorMessage}`,
+        );
+      },
+    };
+    const localResult: ChildRunExecutionResult = {
+      success: false,
+      description: "Search docs",
+      error:
+        'veryfront-cloud request failed: {"slug":"insufficient-credits","error":"AI credit limit exceeded","suggestion":"Purchase credits."}',
+      steps: 0,
+      toolCalls: [],
+      toolResults: [],
+      durationMs: 4,
+    };
+
+    const result = await runHostedChildExecutionLifecycle({
+      adapter,
+      executionFailedCode: "INVOKE_AGENT_FAILED",
+      execute: () => localResult,
+      getExecutionSnapshot: () => null,
+    });
+
+    assertEquals(calls, ["failed:INSUFFICIENT_CREDITS:Purchase credits."]);
+    assertEquals(result.status, "failed");
+    assertEquals(result.terminalState.terminalErrorCode, "INSUFFICIENT_CREDITS");
+    assertEquals(result.terminalState.terminalErrorMessage, "Purchase credits.");
+  });
+
   it("skips selected terminal persistence while preserving failure state", async () => {
     const calls: string[] = [];
     const adapter: HostedChildLifecycleAdapter = {

--- a/src/agent/hosted/child-lifecycle.ts
+++ b/src/agent/hosted/child-lifecycle.ts
@@ -4,6 +4,7 @@ import {
   type ChildRunExecutionSnapshot,
   getChildRunSnapshotUsage,
 } from "../child-run/execution-snapshot.ts";
+import { parseProviderError } from "../../chat/provider-errors.ts";
 import { isChildRunAbortError } from "../child-run/execution-support.ts";
 import {
   HostedChildTerminalStateError,
@@ -126,6 +127,24 @@ class HostedChildExecutionFailure extends Error {
     super(message);
     this.name = "HostedChildExecutionFailure";
   }
+}
+
+function resolveKnownProviderTerminalError(error: unknown): {
+  code: string;
+  message: string;
+} | null {
+  const parsedError = parseProviderError(error);
+  if (
+    parsedError.code === "EXTERNAL_SERVICE_ERROR" &&
+    parsedError.message === "LLM provider service error"
+  ) {
+    return null;
+  }
+
+  return {
+    code: parsedError.code,
+    message: parsedError.message,
+  };
 }
 
 async function dispatchTerminalState(
@@ -252,10 +271,11 @@ function resolveHostedChildExecutionErrorState(
   }
 
   if (error instanceof HostedChildExecutionFailure) {
+    const providerError = resolveKnownProviderTerminalError(error);
     return {
       status: "failed",
-      terminalErrorCode: input.executionFailedCode,
-      terminalErrorMessage: error.message,
+      terminalErrorCode: providerError?.code ?? input.executionFailedCode,
+      terminalErrorMessage: providerError?.message ?? error.message,
       usage: toHostedChildLifecycleUsage(error.usage),
     };
   }

--- a/src/agent/hosted/durable-child-fork-execution.test.ts
+++ b/src/agent/hosted/durable-child-fork-execution.test.ts
@@ -191,6 +191,41 @@ describe("agent/hosted-durable-child-fork-execution", () => {
     );
   });
 
+  it("maps known provider errors from failed snapshots into durable invoke terminal codes", () => {
+    const identifiers = {
+      childConversationId: CHILD_CONVERSATION_ID,
+      childRunId: "run_child_1",
+      childMessageId: CHILD_MESSAGE_ID,
+      latestEventId: 7,
+      latestExternalEventSequence: 3,
+    };
+    const targets = {
+      sourceTargetKind: "preview_branch",
+      runtimeTargetKind: "preview_branch",
+      targetBranchId: BRANCH_ID,
+    } satisfies ConversationRunTargets;
+    const result: ChildRunExecutionResult = {
+      success: false,
+      description: "Inspect logs",
+      error:
+        'veryfront-cloud request failed: {"slug":"insufficient-credits","error":"AI credit limit exceeded","suggestion":"Purchase credits."}',
+      steps: 0,
+      toolCalls: [],
+      toolResults: [],
+      durationMs: 12,
+    };
+
+    const durableResult = buildHostedDurableChildInvokeSuccessResult({
+      result,
+      snapshot: buildChildRunExecutionSnapshot(result),
+      identifiers,
+      targets,
+    });
+
+    assertEquals(durableResult.terminalErrorCode, "INSUFFICIENT_CREDITS");
+    assertEquals(durableResult.terminalErrorMessage, "Purchase credits.");
+  });
+
   it("sanitizes malformed child transcript text in durable invoke success results", () => {
     const identifiers = {
       childConversationId: CHILD_CONVERSATION_ID,

--- a/src/agent/hosted/durable-child-fork-execution.ts
+++ b/src/agent/hosted/durable-child-fork-execution.ts
@@ -2,6 +2,7 @@ import type {
   ChildRunExecutionResult,
   ChildRunExecutionSnapshot,
 } from "../child-run/execution-snapshot.ts";
+import { parseProviderError } from "../../chat/provider-errors.ts";
 import { buildChildRunResultSummary } from "../child-run/result-summary.ts";
 import {
   type ConversationRunTargets,
@@ -163,6 +164,24 @@ export function buildHostedDurableChildInvokeTerminalFailureResult(
   });
 }
 
+function resolveKnownProviderTerminalError(error: unknown): {
+  code: string;
+  message: string;
+} | null {
+  const parsedError = parseProviderError(error);
+  if (
+    parsedError.code === "EXTERNAL_SERVICE_ERROR" &&
+    parsedError.message === "LLM provider service error"
+  ) {
+    return null;
+  }
+
+  return {
+    code: parsedError.code,
+    message: parsedError.message,
+  };
+}
+
 /** Result returned from build hosted durable child invoke success. */
 export function buildHostedDurableChildInvokeSuccessResult<
   TLocalResult extends ChildRunExecutionResult,
@@ -170,6 +189,9 @@ export function buildHostedDurableChildInvokeSuccessResult<
   const summaryText = input.snapshot.fullResultText ??
     (input.result.success ? input.result.summary.text : input.result.error);
   const summary = summaryText ? buildChildRunResultSummary(summaryText) : null;
+  const terminalError = input.snapshot.success
+    ? null
+    : resolveKnownProviderTerminalError(input.snapshot.error);
 
   return {
     ok: input.snapshot.success,
@@ -191,8 +213,10 @@ export function buildHostedDurableChildInvokeSuccessResult<
     childMessageId: input.identifiers.childMessageId,
     sourceTargetKind: input.targets.sourceTargetKind,
     runtimeTargetKind: input.targets.runtimeTargetKind,
-    terminalErrorCode: input.snapshot.success ? null : "INVOKE_AGENT_FAILED",
-    terminalErrorMessage: input.snapshot.success ? null : input.snapshot.error,
+    terminalErrorCode: input.snapshot.success ? null : terminalError?.code ?? "INVOKE_AGENT_FAILED",
+    terminalErrorMessage: input.snapshot.success
+      ? null
+      : terminalError?.message ?? input.snapshot.error,
   };
 }
 

--- a/src/chat/provider-errors.ts
+++ b/src/chat/provider-errors.ts
@@ -31,6 +31,15 @@ function parseErrorJson(value: string): unknown | null {
   return parsed.ok ? parsed.value : null;
 }
 
+function parseEmbeddedErrorJson(value: string): unknown | null {
+  const jsonStart = value.indexOf("{");
+  if (jsonStart < 0) {
+    return null;
+  }
+
+  return parseErrorJson(value.slice(jsonStart));
+}
+
 /** Parses known problem body. */
 export function parseKnownProblemBody(body: unknown): ParsedProviderError | null {
   if (!isErrorRecord(body)) {
@@ -191,6 +200,12 @@ function parseProviderErrorInner(error: unknown, seen: WeakSet<object>): ParsedP
     const parsedMessageError = parseKnownProviderBody(parsedMessage);
     if (parsedMessageError) {
       return parsedMessageError;
+    }
+
+    const parsedEmbeddedMessage = parseEmbeddedErrorJson(message);
+    const parsedEmbeddedMessageError = parseKnownProviderBody(parsedEmbeddedMessage);
+    if (parsedEmbeddedMessageError) {
+      return parsedEmbeddedMessageError;
     }
 
     const normalizedMessage = message.toLowerCase();


### PR DESCRIPTION
## Summary\n- Parse provider problem JSON embedded in prefixed runtime error messages\n- Map known provider errors from child failure snapshots into hosted child terminal state\n- Return structured terminal codes in durable invoke_agent results so API/Studio can show the correct user-facing panel\n\n## Verification\n- deno test --no-check --allow-all src/chat/provider-errors.test.ts src/agent/hosted/child-lifecycle.test.ts src/agent/hosted/durable-child-fork-execution.test.ts\n- pre-push hook: format, lint, type check, unit tests