### PR TITLE
Fix Anthropic provider tool streamed input

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.658",
+  "version": "0.1.659",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/extensions/ext-llm-anthropic/src/anthropic-provider.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-provider.test.ts
@@ -621,7 +621,7 @@ describe("anthropic-provider", () => {
                 'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":10}}}\n\n',
               ),
               encoder.encode(
-                'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtool_fetch_2","name":"web_fetch"}}\n\n',
+                'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtool_fetch_2","name":"web_fetch","input":{}}}\n\n',
               ),
               encoder.encode(
                 'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"url\\":\\"https://veryfront.com/docs\\"}"}}\n\n',

--- a/extensions/ext-llm-anthropic/src/anthropic-stream.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.ts
@@ -24,6 +24,15 @@ type AnthropicStreamReasoningState = {
   id: string;
 };
 
+function isEmptyRecord(value: unknown): value is Record<string, never> {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      Object.keys(value).length === 0,
+  );
+}
+
 export function normalizeAnthropicFinishReason(
   raw: unknown,
 ): string | { unified: string; raw: string } | null {
@@ -165,7 +174,7 @@ export async function* streamAnthropicCompatibleParts(
           };
 
           const initialInput = contentBlock.input;
-          if (initialInput !== undefined) {
+          if (initialInput !== undefined && !isEmptyRecord(initialInput)) {
             const serializedInput = stringifyJsonValue(initialInput);
             current.input += serializedInput;
             yield {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.658";
+export const VERSION = "0.1.659";


### PR DESCRIPTION
## Summary
- ignore empty Anthropic streamed tool input placeholders before provider input deltas
- keep provider-native web_fetch input JSON valid when Anthropic sends content_block_start input: {}
- bump veryfront package version to 0.1.659

## Tests
- deno test extensions/ext-llm-anthropic/src/anthropic-provider.test.ts
- deno test src/runtime/runtime-bridge.test.ts