### PR TITLE
Contain agent runtime incident failures before chat display

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.658",
+  "version": "0.1.659",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/load-skill-tool.test.ts
+++ b/src/agent/runtime/load-skill-tool.test.ts
@@ -147,7 +147,7 @@ Deno.test("createRuntimeLoadSkillTool loads project and builtin reference files"
   });
 });
 
-Deno.test("createRuntimeLoadSkillTool rejects unsafe inputs and reports known skills", async () => {
+Deno.test("createRuntimeLoadSkillTool rejects unsafe and unknown manifest skill inputs", async () => {
   const tool = createRuntimeLoadSkillTool({
     context: {
       ...PROJECT_CONTEXT,
@@ -162,11 +162,48 @@ Deno.test("createRuntimeLoadSkillTool rejects unsafe inputs and reports known sk
   assertEquals(await tool.execute({ skillId: "plan", file: "../secret.md" }), {
     error: "Invalid reference file path: ../secret.md",
   });
-  assertEquals(await tool.execute({ skillId: "missing" }), {
-    error: "Skill not found: missing. Available skills: build, plan, project-only",
-  });
+  await assertRejects(
+    () => tool.execute({ skillId: "missing" }),
+    Error,
+    "input validation failed",
+  );
   await assertRejects(
     () => tool.execute({ skillId: "bad/path" }),
+    Error,
+    "input validation failed",
+  );
+});
+
+Deno.test("createRuntimeLoadSkillTool advertises the runtime skill manifest instead of inviting invented skill IDs", () => {
+  const tool = createRuntimeLoadSkillTool({
+    context: {
+      ...PROJECT_CONTEXT,
+      availableSkillIds: ["daily-briefing"],
+    },
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({}),
+    builtinSkillIds: [],
+    builtinStore: createBuiltinStore({}),
+  });
+
+  assertStringIncludes(tool.description, "Available skill IDs: daily-briefing.");
+  assertStringIncludes(tool.description, "Do not invent skill IDs");
+});
+
+Deno.test("createRuntimeLoadSkillTool rejects invented skill IDs before tool execution when manifest is known", async () => {
+  const tool = createRuntimeLoadSkillTool({
+    context: {
+      ...PROJECT_CONTEXT,
+      availableSkillIds: ["daily-briefing"],
+    },
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({}),
+    builtinSkillIds: [],
+    builtinStore: createBuiltinStore({}),
+  });
+
+  await assertRejects(
+    () => tool.execute({ skillId: "skill-sales-agent" }),
     Error,
     "input validation failed",
   );

--- a/src/agent/runtime/load-skill-tool.ts
+++ b/src/agent/runtime/load-skill-tool.ts
@@ -171,6 +171,57 @@ function buildMissingSkillError(
   };
 }
 
+function buildRuntimeLoadSkillDescription(options: RuntimeLoadSkillToolOptions): string {
+  if (options.description) {
+    return options.description;
+  }
+
+  if (!options.context.availableSkillIds && !options.builtinSkillIds) {
+    return RUNTIME_LOAD_SKILL_DESCRIPTION;
+  }
+
+  const knownIds = new Set([
+    ...(options.context.availableSkillIds ?? []),
+    ...(options.builtinSkillIds ?? []),
+  ]);
+  const available = [...knownIds].sort().join(", ") || "none";
+
+  return `${RUNTIME_LOAD_SKILL_DESCRIPTION} Available skill IDs: ${available}. Do not invent skill IDs. Only call load_skill with one of these IDs.`;
+}
+
+function getKnownRuntimeSkillIds(options: RuntimeLoadSkillToolOptions): string[] | null {
+  if (!options.context.availableSkillIds && !options.builtinSkillIds) {
+    return null;
+  }
+
+  return [
+    ...new Set([
+      ...(options.context.availableSkillIds ?? []),
+      ...(options.builtinSkillIds ?? []),
+    ]),
+  ].sort();
+}
+
+function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) {
+  const knownIds = getKnownRuntimeSkillIds(options);
+  if (!knownIds || knownIds.length === 0) {
+    return runtimeLoadSkillToolInputSchema;
+  }
+
+  const [first, ...rest] = knownIds as [string, ...string[]];
+  const enumValues = [first, ...rest] as [string, ...string[]];
+  return defineSchema((v) =>
+    v.object({
+      skillId: v.enum(enumValues).describe(
+        `The skill ID to load. Available skill IDs: ${knownIds.join(", ")}`,
+      ),
+      file: v.string().optional().describe(
+        'Optional reference file to load (e.g. "references/quickstart.md")',
+      ),
+    })
+  )();
+}
+
 async function loadRuntimeSkillReferenceFile(
   options: RuntimeLoadSkillToolOptions,
   skillId: string,
@@ -217,8 +268,8 @@ export function createRuntimeLoadSkillTool(
 
   return tool({
     id: "load_skill",
-    description: options.description ?? RUNTIME_LOAD_SKILL_DESCRIPTION,
-    inputSchema: runtimeLoadSkillToolInputSchema,
+    description: buildRuntimeLoadSkillDescription(options),
+    inputSchema: buildRuntimeLoadSkillInputSchema(options),
     execute: async ({ skillId, file }) => {
       if (file) {
         return await loadRuntimeSkillReferenceFile(options, skillId, file);

--- a/src/chat/provider-errors.test.ts
+++ b/src/chat/provider-errors.test.ts
@@ -51,6 +51,23 @@ describe("chat/provider-errors", () => {
     });
   });
 
+  it("classifies invalid Veryfront schema errors as project code validation failures", () => {
+    const expected = {
+      code: "PROJECT_SCHEMA_ERROR",
+      message:
+        "Project code has an invalid Veryfront schema. Update the schema to use defineSchema(), then run the agent again.",
+    };
+
+    assertEquals(
+      parseProviderError(new Error("Invalid Veryfront schema: use defineSchema()")),
+      expected,
+    );
+    assertEquals(
+      parseProviderError({ responseBody: "Invalid Veryfront schema: use defineSchema()" }),
+      expected,
+    );
+  });
+
   it("walks nested lastError chains without stack overflows or cycles", () => {
     const errorA: Record<string, unknown> = { message: "outer", lastError: null };
     const errorB: Record<string, unknown> = { message: "inner", lastError: errorA };

--- a/src/chat/provider-errors.ts
+++ b/src/chat/provider-errors.ts
@@ -10,6 +10,12 @@ const DEFAULT_EXTERNAL_SERVICE_ERROR = {
   message: "LLM provider service error",
 } as const;
 
+const PROJECT_SCHEMA_ERROR = {
+  code: "PROJECT_SCHEMA_ERROR",
+  message:
+    "Project code has an invalid Veryfront schema. Update the schema to use defineSchema(), then run the agent again.",
+} as const;
+
 function isErrorRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -172,6 +178,11 @@ function parseProviderErrorInner(error: unknown, seen: WeakSet<object>): ParsedP
 
   const responseBody = extractResponseBody(error);
   if (responseBody) {
+    const normalizedResponseBody = responseBody.toLowerCase();
+    if (normalizedResponseBody.includes("invalid veryfront schema")) {
+      return PROJECT_SCHEMA_ERROR;
+    }
+
     const parsedBody = parseErrorJson(responseBody);
     const parsedError = parseKnownProviderBody(parsedBody);
     if (parsedError) {
@@ -231,6 +242,9 @@ function parseProviderErrorInner(error: unknown, seen: WeakSet<object>): ParsedP
       normalizedMessage.includes("too many tokens")
     ) {
       return { code: "CONTEXT_LENGTH_EXCEEDED", message: "Conversation is too long" };
+    }
+    if (normalizedMessage.includes("invalid veryfront schema")) {
+      return PROJECT_SCHEMA_ERROR;
     }
   }
 

--- a/src/tool/remote-mcp.test.ts
+++ b/src/tool/remote-mcp.test.ts
@@ -148,6 +148,93 @@ describe("tool/remote-mcp", () => {
     });
   });
 
+  it("normalizes OAuth invalid_grant refresh failures into reconnect-required tool output", async () => {
+    const source = createRemoteMCPToolSource({
+      id: "veryfront-mcp",
+      endpoint: "https://api.example.com/mcp",
+      headers: { Authorization: "Bearer remote-token" },
+    });
+
+    const result = await withMockFetch(
+      async () =>
+        Response.json({
+          jsonrpc: "2.0",
+          id: "veryfront-mcp:tools:call:calendar__list_events",
+          result: {
+            isError: true,
+            content: [{
+              text: JSON.stringify({
+                error: "tool_error",
+                message:
+                  'Token refresh failed (400): { "error": "invalid_grant", "error_description": "Token has been expired or revoked." }',
+              }),
+            }],
+          },
+        }),
+      async () => await source.executeTool("calendar__list_events", {}, { projectId: "project-1" }),
+    );
+
+    assertEquals(result, {
+      error: "reconnect_required",
+      code: "OAUTH_TOKEN_EXPIRED",
+      integration: "calendar",
+      connectUrl: "https://api.example.com/oauth/connect/calendar?projectId=project-1",
+      message: "Calendar needs to be reconnected before this tool can run.",
+    });
+  });
+
+  it("normalizes JSON-RPC invalid_grant errors into reconnect-required tool output", async () => {
+    const source = createRemoteMCPToolSource({
+      id: "veryfront-mcp",
+      endpoint: "https://api.example.com/mcp",
+    });
+
+    const result = await withMockFetch(
+      async () =>
+        Response.json({
+          jsonrpc: "2.0",
+          id: "veryfront-mcp:tools:call:calendar__list_events",
+          error: {
+            code: -32603,
+            message: 'Token refresh failed (400): { "error": "invalid_grant" }',
+          },
+        }),
+      async () => await source.executeTool("calendar__list_events", {}, { projectId: "project-1" }),
+    );
+
+    assertEquals(result, {
+      error: "reconnect_required",
+      code: "OAUTH_TOKEN_EXPIRED",
+      integration: "calendar",
+      connectUrl: "https://api.example.com/oauth/connect/calendar?projectId=project-1",
+      message: "Calendar needs to be reconnected before this tool can run.",
+    });
+  });
+
+  it("normalizes HTTP invalid_grant failures into reconnect-required tool output", async () => {
+    const source = createRemoteMCPToolSource({
+      id: "veryfront-mcp",
+      endpoint: "https://api.example.com/mcp",
+    });
+
+    const result = await withMockFetch(
+      async () =>
+        new Response('{ "error": "invalid_grant" }', {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+      async () => await source.executeTool("calendar__list_events", {}, { projectId: "project-1" }),
+    );
+
+    assertEquals(result, {
+      error: "reconnect_required",
+      code: "OAUTH_TOKEN_EXPIRED",
+      integration: "calendar",
+      connectUrl: "https://api.example.com/oauth/connect/calendar?projectId=project-1",
+      message: "Calendar needs to be reconnected before this tool can run.",
+    });
+  });
+
   it("preserves caller accept types while adding the MCP-required media types", async () => {
     let acceptHeader = "";
 

--- a/src/tool/remote-mcp.ts
+++ b/src/tool/remote-mcp.ts
@@ -113,6 +113,85 @@ function parseJsonText(text: string): unknown | undefined {
   }
 }
 
+function isOauthInvalidGrantMessage(value: unknown): boolean {
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  const normalized = text.toLowerCase();
+  return normalized.includes("invalid_grant");
+}
+
+function getIntegrationIdFromToolName(toolName: string): string {
+  const separatorIndex = toolName.indexOf("__");
+  const rawIntegration = separatorIndex > 0 ? toolName.slice(0, separatorIndex) : toolName;
+  return rawIntegration || "integration";
+}
+
+function formatIntegrationName(integration: string): string {
+  return integration
+    .split(/[_-]+/)
+    .filter((part) => part.length > 0)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(" ") || "Integration";
+}
+
+function buildOauthConnectUrl(
+  endpoint: string,
+  integration: string,
+  context?: ToolExecutionContext,
+): string {
+  const encodedIntegration = encodeURIComponent(integration);
+  const projectId = typeof context?.projectId === "string" && context.projectId.length > 0
+    ? context.projectId
+    : null;
+
+  try {
+    const url = new URL(`/oauth/connect/${encodedIntegration}`, endpoint);
+    if (projectId) {
+      url.searchParams.set("projectId", projectId);
+    }
+    return url.toString();
+  } catch {
+    return projectId
+      ? `/oauth/connect/${encodedIntegration}?projectId=${encodeURIComponent(projectId)}`
+      : `/oauth/connect/${encodedIntegration}`;
+  }
+}
+
+function normalizeKnownToolError(
+  value: unknown,
+  toolName: string,
+  endpoint: string,
+  context?: ToolExecutionContext,
+): unknown {
+  if (!isOauthInvalidGrantMessage(value)) {
+    return value;
+  }
+
+  const integration = getIntegrationIdFromToolName(toolName);
+  const label = formatIntegrationName(integration);
+  return {
+    error: "reconnect_required",
+    code: "OAUTH_TOKEN_EXPIRED",
+    integration,
+    connectUrl: buildOauthConnectUrl(endpoint, integration, context),
+    message: `${label} needs to be reconnected before this tool can run.`,
+  };
+}
+
+function isReconnectRequiredToolOutput(value: unknown): value is Record<string, unknown> {
+  return isRecord(value) && value.error === "reconnect_required";
+}
+
+function normalizeKnownToolException(
+  error: unknown,
+  toolName: string,
+  endpoint: string,
+  context?: ToolExecutionContext,
+): Record<string, unknown> | null {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = normalizeKnownToolError(message, toolName, endpoint, context);
+  return isReconnectRequiredToolOutput(normalized) ? normalized : null;
+}
+
 function extractJsonRpcErrorMessage(payload: Record<string, unknown>): string {
   const rawError = payload.error;
   if (!isRecord(rawError)) return "Remote MCP server returned an error";
@@ -270,7 +349,13 @@ function getJsonRpcResult(payload: unknown): unknown {
   return payload.result;
 }
 
-function normalizeCallToolResult(result: unknown): unknown {
+function normalizeCallToolResult(input: {
+  result: unknown;
+  toolName: string;
+  endpoint: string;
+  context?: ToolExecutionContext;
+}): unknown {
+  const result = input.result;
   if (!isRecord(result)) return result;
 
   const rawContent = result.content;
@@ -280,21 +365,36 @@ function normalizeCallToolResult(result: unknown): unknown {
     );
 
     if ("structuredContent" in result) {
-      return result.structuredContent;
+      return normalizeKnownToolError(
+        result.structuredContent,
+        input.toolName,
+        input.endpoint,
+        input.context,
+      );
     }
 
     if (hasToolExecutionErrorMarker(result)) {
-      return parseJsonText(text) ?? { error: "tool_error", message: text };
+      return normalizeKnownToolError(
+        parseJsonText(text) ?? { error: "tool_error", message: text },
+        input.toolName,
+        input.endpoint,
+        input.context,
+      );
     }
 
     return parseJsonText(text) ?? text;
   }
 
   if ("structuredContent" in result) {
-    return result.structuredContent;
+    return normalizeKnownToolError(
+      result.structuredContent,
+      input.toolName,
+      input.endpoint,
+      input.context,
+    );
   }
 
-  return result;
+  return normalizeKnownToolError(result, input.toolName, input.endpoint, input.context);
 }
 
 /** Create remote MCP tool source. */
@@ -327,22 +427,37 @@ export function createRemoteMCPToolSource(
     async executeTool(toolName, args, context) {
       const endpoint = await resolveValue(config.endpoint, context);
       const headers = await resolveHeaders(config.headers, context);
-      const payload = await postJsonRpc(
-        endpoint,
-        headers,
-        {
-          jsonrpc: "2.0",
-          id: `${id}:tools:call:${toolName}`,
-          method: callMethod,
-          params: {
-            name: toolName,
-            arguments: args,
-          },
-        },
-        config.fetch ?? globalThis.fetch,
-      );
 
-      return normalizeCallToolResult(getJsonRpcResult(payload));
+      try {
+        const payload = await postJsonRpc(
+          endpoint,
+          headers,
+          {
+            jsonrpc: "2.0",
+            id: `${id}:tools:call:${toolName}`,
+            method: callMethod,
+            params: {
+              name: toolName,
+              arguments: args,
+            },
+          },
+          config.fetch ?? globalThis.fetch,
+        );
+
+        return normalizeCallToolResult({
+          result: getJsonRpcResult(payload),
+          toolName,
+          endpoint,
+          context,
+        });
+      } catch (error) {
+        const normalizedError = normalizeKnownToolException(error, toolName, endpoint, context);
+        if (normalizedError) {
+          return normalizedError;
+        }
+
+        throw error;
+      }
     },
   };
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.658";
+export const VERSION = "0.1.659";


### PR DESCRIPTION
## Summary

Contains agent runtime incident failures before they reach Studio chat rendering:

- #4718: constrains `load_skill` to known manifest/builtin IDs when available and tells the model not to invent skill IDs.
- #4719: normalizes remote MCP OAuth `invalid_grant` failures into structured `reconnect_required` output across MCP result, JSON-RPC error, and HTTP error paths.
- #4720: classifies `Invalid Veryfront schema: use defineSchema()` as actionable project schema error instead of generic provider error.
- Bumps `veryfront` package version to `0.1.659` because `0.1.658` is already published.

Refs veryfront/veryfront-studio#4718
Refs veryfront/veryfront-studio#4719
Refs veryfront/veryfront-studio#4720

## Review score gate

- Code-review subagent score: **93/100**
- Must-fix blockers: none

## Verification

- `deno test --no-check --allow-all src/agent/runtime/load-skill-tool.test.ts src/tool/remote-mcp.test.ts src/chat/provider-errors.test.ts src/tool/factory.test.ts src/agent/runtime/model-tool-converter.test.ts src/tool/schema/zod-json-schema.test.ts`
- `deno task verify:quick`

Note: local isolated worktree needed temporary sibling links for existing docs cross-repo link validation; product files were not changed for that shim.
