### PR TITLE
Advance release line after incident runtime fixes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.659",
+  "version": "0.1.660",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.659";
+export const VERSION = "0.1.660";


### PR DESCRIPTION
## Summary
- Advance `veryfront-code` stable release line from `0.1.659` to `0.1.660` after the incident-fix PR merged.
- Keep `src/utils/version-constant.ts` synchronized with `deno.json`.

## Why
The previous main release run for PR #2107 failed at the release guard because `veryfront@0.1.659` had already been published to npm before the guard ran:

> v0.1.659 already exists on npm. Bump deno.json before releasing.

`veryfront@0.1.660` is currently unpublished, so this lets the already-merged fixes for Studio issues 4718/4719/4720 release cleanly.

## Validation
- `npm view veryfront@0.1.660 version` returns E404 (unpublished).
- `deno test --no-check --allow-all src/utils/logger/logger.test.ts`
- `deno task verify:quick`
- Subagent code review score: 96/100, no blockers.

Refs veryfront/veryfront-studio#4718
Refs veryfront/veryfront-studio#4719
Refs veryfront/veryfront-studio#4720
