### PR TITLE
Fix hosted child run budget and stream errors

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.660",
+  "version": "0.1.661",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted/child-fork-execution-runner.test.ts
+++ b/src/agent/hosted/child-fork-execution-runner.test.ts
@@ -280,7 +280,7 @@ Deno.test("executeHostedChildForkToolInput resolves runtime config and prepares 
       tools: ["noop"],
       model: "sonnet",
       thinking: 256,
-      max_steps: 7,
+      max_steps: 120,
     },
     toolCallId: "tool-call-1",
     defaultModel: "haiku",
@@ -303,7 +303,7 @@ Deno.test("executeHostedChildForkToolInput resolves runtime config and prepares 
       assertEquals(runtimeConfig.description, "Review checkout");
       assertEquals(runtimeConfig.forkModel, "resolved-sonnet");
       assertEquals(runtimeConfig.provider, "provider-resolved-sonnet");
-      assertEquals(runtimeConfig.maxSteps, 7);
+      assertEquals(runtimeConfig.maxSteps, 120);
       assertEquals(runtimeConfig.thinkingConfig, { enabled: true, budgetTokens: 256 });
       assertEquals(runtimeConfig.effectivePrompt.includes("Review the checkout flow."), true);
       return {
@@ -315,7 +315,7 @@ Deno.test("executeHostedChildForkToolInput resolves runtime config and prepares 
     startRuntime: (input) => {
       callbacks.push(`start:${input.forkModel}`);
       assertEquals(input.provider, "provider-resolved-sonnet");
-      assertEquals(input.maxSteps, 7);
+      assertEquals(input.maxSteps, 120);
       assertEquals(input.providerOptions, {
         forkModel: "resolved-sonnet",
         thinkingConfig: { enabled: true, budgetTokens: 256 },

--- a/src/agent/hosted/child-tool-input.test.ts
+++ b/src/agent/hosted/child-tool-input.test.ts
@@ -72,7 +72,7 @@ Deno.test("resolveHostedChildForkRuntimeConfig resolves reusable child fork runt
       tools: ["readFile"],
       model: "sonnet",
       thinking: 1024,
-      max_steps: 12,
+      max_steps: 120,
     },
     contextModel: "opus",
     defaultModel: "haiku",
@@ -86,12 +86,48 @@ Deno.test("resolveHostedChildForkRuntimeConfig resolves reusable child fork runt
   assertEquals(result.requestedTools, ["readFile"]);
   assertEquals(result.forkModel, "resolved-sonnet");
   assertEquals(result.provider, "provider-for-resolved-sonnet");
-  assertEquals(result.maxSteps, 12);
+  assertEquals(result.maxSteps, 120);
   assertEquals(result.thinkingConfig, { enabled: true, budgetTokens: 1024 });
   assertEquals(
     result.effectivePrompt.includes("/research/solar-panels/runs/run-1.report.md"),
     true,
   );
+});
+
+Deno.test("resolveHostedChildForkRuntimeConfig raises low requested child max steps to the hosted minimum", () => {
+  const result = resolveHostedChildForkRuntimeConfig({
+    forkInput: {
+      description: "research services",
+      prompt: "Research the available services and report findings.",
+      max_steps: 15,
+    },
+    contextModel: "opus",
+    defaultModel: "haiku",
+    defaultMaxSteps: 80,
+    runId: "tool-call-1",
+    resolveModelId: (modelId) => `resolved-${modelId}`,
+    resolveProvider: (modelId) => `provider-for-${modelId}`,
+  });
+
+  assertEquals(result.maxSteps, 80);
+});
+
+Deno.test("resolveHostedChildForkRuntimeConfig preserves high requested child max steps", () => {
+  const result = resolveHostedChildForkRuntimeConfig({
+    forkInput: {
+      description: "build feature",
+      prompt: "Build the requested feature.",
+      max_steps: 160,
+    },
+    contextModel: "opus",
+    defaultModel: "haiku",
+    defaultMaxSteps: 80,
+    runId: "tool-call-1",
+    resolveModelId: (modelId) => `resolved-${modelId}`,
+    resolveProvider: (modelId) => `provider-for-${modelId}`,
+  });
+
+  assertEquals(result.maxSteps, 160);
 });
 
 Deno.test("resolveHostedChildForkRuntimeConfig falls back to context model and default max steps", () => {

--- a/src/agent/hosted/child-tool-input.ts
+++ b/src/agent/hosted/child-tool-input.ts
@@ -22,7 +22,9 @@ export const getHostedChildForkToolInputSchema = defineSchema((v) =>
       .nonnegative()
       .optional()
       .describe("Thinking override in budget tokens. Use 0 to disable thinking."),
-    max_steps: v.number().optional().describe("Max steps override."),
+    max_steps: v.number().optional().describe(
+      "Max steps override. Omit for the hosted child default. Values below the default are raised to the default.",
+    ),
   })
 );
 
@@ -82,6 +84,7 @@ export function resolveHostedChildForkRuntimeConfig(
 ): HostedChildForkRuntimeConfig {
   const { description, prompt, tools, model, thinking, max_steps } = input.forkInput;
   const forkModel = input.resolveModelId(model || input.contextModel || input.defaultModel);
+  const requestedMaxSteps = typeof max_steps === "number" ? max_steps : undefined;
 
   return {
     description,
@@ -93,7 +96,7 @@ export function resolveHostedChildForkRuntimeConfig(
     requestedTools: tools,
     forkModel,
     provider: input.resolveProvider(forkModel),
-    maxSteps: max_steps || input.defaultMaxSteps,
+    maxSteps: Math.max(requestedMaxSteps ?? input.defaultMaxSteps, input.defaultMaxSteps),
     thinkingConfig: resolveHostedChildForkThinkingOverride(thinking),
   };
 }

--- a/src/agent/hosted/default-invoke-agent-tool.test.ts
+++ b/src/agent/hosted/default-invoke-agent-tool.test.ts
@@ -1,3 +1,4 @@
+import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import type { CreateSandboxBashTool } from "#veryfront/sandbox";
 import {
@@ -68,6 +69,7 @@ Deno.test("executeDefaultHostedInvokeAgentTool returns durable context failure b
     {
       description: "inspect auth",
       prompt: "Inspect auth flow.",
+      agent_id: undefined,
     },
     "security-reviewer",
     { toolCallId: "tool-call-1" },

--- a/src/agent/streaming/fork-runtime-stream.test.ts
+++ b/src/agent/streaming/fork-runtime-stream.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import type { AgentResponse, Message as AgentMessage } from "../schemas/index.ts";
 import {
+  applyPartToStreamedStepState,
   buildForkRuntimeStepFromResponse,
   buildRecoveredStepParts,
   createForkRuntimeStreamMappingState,
@@ -180,6 +181,29 @@ describe("agent/fork-runtime-stream", () => {
     );
     assertEquals(response.status, "completed");
     assertExists(response.messages.find((message) => message.role === "assistant"));
+  });
+
+  it("preserves a terminal stream error when a fork response never finishes", async () => {
+    const responsePromise = new Promise<never>(() => {});
+    const streamedStepState = createStreamedStepState();
+    applyPartToStreamedStepState(streamedStepState, {
+      type: "error",
+      error: new Error(
+        'veryfront-cloud request failed: {"slug":"insufficient-credits","error":"AI credit limit exceeded","suggestion":"Purchase credits."}',
+      ),
+    });
+
+    await assertRejects(
+      () =>
+        resolveForkStepResponse({
+          responsePromise,
+          responseTimeoutMs: 1,
+          currentMessages: [],
+          streamedStepState,
+        }),
+      Error,
+      "Purchase credits.",
+    );
   });
 
   it("builds fork runtime steps and continuation decisions from agent responses", () => {

--- a/src/agent/streaming/fork-runtime-stream.ts
+++ b/src/agent/streaming/fork-runtime-stream.ts
@@ -131,6 +131,7 @@ type StreamedStepState = {
   text: string;
   toolCalls: Map<string, StreamedToolCallState>;
   messages: StreamedMessage[];
+  streamError?: Error;
 };
 
 /** State for fork runtime stream mapping. */
@@ -800,6 +801,10 @@ export function applyPartToStreamedStepState(state: StreamedStepState, part: For
       });
       break;
     }
+    case "error": {
+      state.streamError = part.error;
+      break;
+    }
     default:
       break;
   }
@@ -927,6 +932,10 @@ export async function resolveForkStepResponse(input: {
 
   if (input.abortSignal?.aborted) {
     throw createAgentRuntimeForkAbortError(input.abortSignal);
+  }
+
+  if (input.streamedStepState.streamError) {
+    throw input.streamedStepState.streamError;
   }
 
   const fallbackState = hasFallbackStepContent(input.streamedStepState)

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.660";
+export const VERSION = "0.1.661";


### PR DESCRIPTION
## Summary
- raise low hosted `invoke_agent` child `max_steps` values to the child default floor
- document the child max_steps behavior in the tool schema description
- preserve terminal fork stream errors instead of replacing them with generic no-finish failures
- bump framework package version to 0.1.661

## Verification
- deno test --allow-all src/agent/hosted/child-tool-input.test.ts src/agent/hosted/child-fork-execution-runner.test.ts src/agent/hosted/child-fork-stream-execution.test.ts src/agent/hosted/default-invoke-agent-tool.test.ts src/agent/streaming/fork-runtime-stream.test.ts
- deno task verify:quick
- pre-push: 1995 unit tests passed
