### PR TITLE
Support provider tools in agent markdown

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.661",
+  "version": "0.1.662",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/agent-definition.test.ts
+++ b/src/agent/runtime/agent-definition.test.ts
@@ -14,6 +14,9 @@ description: Helps users resolve issues
 model: gpt-5.4
 thinking: 1200
 max-steps: 8
+provider-tools:
+  - web_search
+  - web_fetch
 ---
 
 Follow the support runbook.
@@ -27,6 +30,7 @@ Follow the support runbook.
     model: "gpt-5.4",
     thinking: { enabled: true, budgetTokens: 1200 },
     maxSteps: 8,
+    providerTools: ["web_search", "web_fetch"],
     instructions: "Follow the support runbook.",
   });
 });

--- a/src/agent/runtime/agent-definition.ts
+++ b/src/agent/runtime/agent-definition.ts
@@ -34,6 +34,7 @@ export const getRuntimeAgentMarkdownDefinitionSchema = defineSchema((v) =>
     thinking: getRuntimeAgentThinkingConfigSchema().optional(),
     model: v.string().min(1).optional(),
     maxSteps: v.number().optional(),
+    providerTools: v.array(v.string().min(1)).optional(),
   })
 );
 
@@ -94,6 +95,14 @@ function parseThinking(value: unknown): RuntimeAgentThinkingConfig | undefined {
   return undefined;
 }
 
+function parseProviderTools(value: unknown): unknown[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value;
+}
+
 /** Definition for parse runtime agent markdown. */
 export function parseRuntimeAgentMarkdownDefinition(
   input: ParseRuntimeAgentMarkdownDefinitionInput,
@@ -105,6 +114,7 @@ export function parseRuntimeAgentMarkdownDefinition(
   const model = typeof attrs.model === "string" && attrs.model.trim() ? attrs.model : undefined;
   const thinking = parseThinking(attrs.thinking);
   const maxSteps = typeof attrs["max-steps"] === "number" ? attrs["max-steps"] : undefined;
+  const providerTools = parseProviderTools(attrs["provider-tools"]);
 
   return getRuntimeAgentMarkdownDefinitionSchema().parse({
     id: parsedInput.id,
@@ -114,6 +124,7 @@ export function parseRuntimeAgentMarkdownDefinition(
     ...(model ? { model } : {}),
     ...(thinking ? { thinking } : {}),
     ...(maxSteps === undefined ? {} : { maxSteps }),
+    ...(providerTools ? { providerTools } : {}),
   });
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.661";
+export const VERSION = "0.1.662";


### PR DESCRIPTION
## Summary
- parse provider-tools frontmatter into runtime agent providerTools
- bump veryfront package version to 0.1.662
- cover provider tool parsing with a regression test

## Verification
- VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/agent/runtime/agent-definition.test.ts
- deno task verify:quick
- pre-push checks: formatting, lint, typecheck, unit tests (1995 passed)