### PR TITLE
Prevent remote tools from running without required args

### DIFF
--- a/src/tool/project-scoped-remote-tools.test.ts
+++ b/src/tool/project-scoped-remote-tools.test.ts
@@ -264,6 +264,28 @@ Deno.test("createProjectScopedRemoteToolCatalog rejects disallowed execution", a
   );
 });
 
+Deno.test("createProjectScopedRemoteToolCatalog rejects missing required remote tool input", async () => {
+  const source: RemoteToolSource = {
+    id: "api",
+    async listTools() {
+      return [toolDefinition({ name: "outlook__search_emails", required: ["$search"] })];
+    },
+    async executeTool() {
+      return { ok: true };
+    },
+  };
+  const catalog = createProjectScopedRemoteToolCatalog({ source });
+
+  await assertRejectsWithMessage(
+    () =>
+      catalog.prepareExecution({
+        toolName: "outlook__search_emails",
+        toolInput: {},
+      }),
+    'Tool "outlook__search_emails" requires input: $search',
+  );
+});
+
 Deno.test("listProjectScopedRemoteToolNames returns sorted unique visible names", async () => {
   const sourceA: RemoteToolSource = {
     id: "api",

--- a/src/tool/project-scoped-remote-tools.ts
+++ b/src/tool/project-scoped-remote-tools.ts
@@ -99,6 +99,31 @@ function requiresProjectReference(toolDefinition: ToolDefinition): boolean {
   return getRequiredToolProperties(toolDefinition).includes("project_reference");
 }
 
+function isMissingRequiredToolInput(value: unknown): boolean {
+  return value === undefined || value === null ||
+    (typeof value === "string" && value.trim().length === 0);
+}
+
+function validateRequiredToolInput(input: {
+  toolDefinition: ToolDefinition | undefined;
+  toolInput: Record<string, unknown>;
+}): void {
+  if (!input.toolDefinition) {
+    return;
+  }
+
+  const missingProperties = getRequiredToolProperties(input.toolDefinition).filter((property) =>
+    isMissingRequiredToolInput(input.toolInput[property])
+  );
+  if (missingProperties.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `Tool "${input.toolDefinition.name}" requires input: ${missingProperties.join(", ")}`,
+  );
+}
+
 /** Check whether a remote tool is project-navigation scoped. */
 export function isProjectNavigationRemoteTool(
   toolName: string,
@@ -272,6 +297,7 @@ export function createProjectScopedRemoteToolCatalog(
         activeProjectId,
         toolInput: executionInput.toolInput,
       });
+      validateRequiredToolInput({ toolDefinition, toolInput });
 
       return {
         activeProjectId,


### PR DESCRIPTION
## Summary
- Reject remote tool execution when required provider-facing inputs are missing or blank.
- Add regression coverage for `outlook__search_emails` requiring `$search` before execution.

## Issue
Related to veryfront/veryfront-studio#4727.

## Test Plan
- [x] `deno test --no-check --allow-all src/tool/project-scoped-remote-tools.test.ts`
- [x] `deno fmt --check src/tool/project-scoped-remote-tools.ts src/tool/project-scoped-remote-tools.test.ts`
- [x] `deno check src/tool/project-scoped-remote-tools.ts`
- [x] Pre-commit `verify:quick` progressed through manifest, format, lint, style, docs tests; stopped at `check-doc-links` because the isolated worktree path makes existing `../../../veryfront-*` doc links resolve incorrectly.

## Notes
This keeps `project_reference` hydration before required-input validation, so project-scoped tools still receive the active project automatically.