### PR TITLE
Preserve markdown provider tools in runtime agents

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.662",
+  "version": "0.1.663",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/agent-markdown-adapter.test.ts
+++ b/src/agent/runtime/agent-markdown-adapter.test.ts
@@ -1,0 +1,16 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { createRuntimeAgentFromMarkdownDefinition } from "./agent-markdown-adapter.ts";
+
+Deno.test("createRuntimeAgentFromMarkdownDefinition preserves provider-native tools", () => {
+  const runtimeAgent = createRuntimeAgentFromMarkdownDefinition({
+    id: "support",
+    name: "Support",
+    description: "Helps users",
+    instructions: "Use the configured tools.",
+    model: "anthropic/claude-sonnet-4-6",
+    providerTools: ["web_search", "web_fetch"],
+  });
+
+  assertEquals(runtimeAgent.config.providerTools, ["web_search", "web_fetch"]);
+});

--- a/src/agent/runtime/agent-markdown-adapter.ts
+++ b/src/agent/runtime/agent-markdown-adapter.ts
@@ -15,6 +15,7 @@ export function createRuntimeAgentFromMarkdownDefinition(
     system: definition.instructions,
     ...(definition.model ? { model: definition.model } : {}),
     ...(definition.maxSteps === undefined ? {} : { maxSteps: definition.maxSteps }),
+    ...(definition.providerTools ? { providerTools: definition.providerTools } : {}),
   });
 
   markdownDefinitionByAgent.set(runtimeAgent, definition);

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.662";
+export const VERSION = "0.1.663";


### PR DESCRIPTION
## Summary
- propagate markdown-declared provider tools into runtime agent config
- add a regression test for provider-native tool preservation
- bump veryfront package version to 0.1.663

## Verification
- focused deno test for agent markdown adapter and definition
- deno task verify:quick
- pre-push checks: fmt, lint, typecheck, unit tests