### PR TITLE
Keep runtime tool schemas provider-compatible

### DIFF
--- a/src/agent/runtime/model-tool-converter.test.ts
+++ b/src/agent/runtime/model-tool-converter.test.ts
@@ -23,6 +23,27 @@ function getRuntimeToolSchema(tool: unknown): unknown {
 }
 
 describe("model-tool-converter", () => {
+  it("mirrors JSON schema fields on runtime schema wrappers for provider compatibility", () => {
+    const result = convertToolsToRuntimeTools([
+      {
+        name: "outlook__search_emails",
+        description: "Search emails",
+        parameters: {
+          type: "object",
+          properties: {
+            "$search": { type: "string" },
+          },
+          required: ["$search"],
+        },
+      },
+    ], { model: "veryfront-cloud/anthropic/claude-opus-4-6" })!;
+
+    const inputSchema =
+      (result.outlook__search_emails as { inputSchema: Record<string, unknown> }).inputSchema;
+    assertEquals(inputSchema.type, "object");
+    assertEquals(inputSchema.jsonSchema, getRuntimeToolSchema(result.outlook__search_emails));
+  });
+
   it("returns undefined for empty tools array", () => {
     assertEquals(convertToolsToRuntimeTools([]), undefined);
   });

--- a/src/agent/runtime/runtime-tool-builder.ts
+++ b/src/agent/runtime/runtime-tool-builder.ts
@@ -1,7 +1,7 @@
 import type { JsonSchema } from "#veryfront/tool/schema";
 import type { RuntimeToolSet } from "./runtime-tool-types.ts";
 
-interface RuntimeJsonSchema<T = unknown> {
+interface RuntimeJsonSchema<T = unknown> extends Record<string, unknown> {
   readonly jsonSchema: JsonSchema | PromiseLike<JsonSchema>;
   validate?: (value: unknown) => T | PromiseLike<T>;
 }
@@ -36,6 +36,7 @@ interface RuntimeProviderToolDefinition {
 
 export function createRuntimeJsonSchema(json: JsonSchema): RuntimeJsonSchema {
   return {
+    ...json,
     jsonSchema: json,
   };
 }


### PR DESCRIPTION
## Summary\n- Mirror JSON schema fields onto runtime schema wrappers while preserving the canonical jsonSchema field\n- Add regression coverage for Outlook-style integration tool schemas passing through veryfront-cloud Anthropic runtime conversion\n\n## Testing\n- deno task test src/agent/runtime/model-tool-converter.test.ts\n- DENO_NO_PACKAGE_JSON=1 deno lint src/agent/runtime/runtime-tool-builder.ts src/agent/runtime/model-tool-converter.test.ts\n- pre-commit verify:quick ran until docs link check and failed on existing sibling-repo-relative docs links in docs/architecture/21-agent-tool-registration-current-state.md\n\nIssue: veryfront/veryfront-studio#4727