### PR TITLE
Expose Outlook search query input

### DIFF
--- a/cli/templates/integrations/outlook/connector.json
+++ b/cli/templates/integrations/outlook/connector.json
@@ -219,9 +219,10 @@
         "method": "GET",
         "url": "https://graph.microsoft.com/v1.0/me/messages",
         "params": {
-          "$search": {
+          "query": {
             "type": "string",
             "in": "query",
+            "queryName": "$search",
             "description": "Microsoft Graph search query, for example \"subject:roadmap\"",
             "required": true
           },

--- a/src/integrations/_data.ts
+++ b/src/integrations/_data.ts
@@ -7070,9 +7070,10 @@ export const connectors: IntegrationConfig[] = [
         "method": "GET",
         "url": "https://graph.microsoft.com/v1.0/me/messages",
         "params": {
-          "$search": {
+          "query": {
             "type": "string",
             "in": "query",
+            "queryName": "$search",
             "description": 'Microsoft Graph search query, for example "subject:roadmap"',
             "required": true,
           },

--- a/src/integrations/schema.ts
+++ b/src/integrations/schema.ts
@@ -121,6 +121,9 @@ export const getIntegrationEndpointParamSchema = defineSchema((v) =>
     description: v.string(),
     required: v.boolean().optional(),
     default: v.unknown().optional(),
+    // For query params only: the HTTP query parameter name to send when it differs
+    // from the agent-facing parameter key (e.g. input query -> query param $search).
+    queryName: v.string().optional(),
     // For header params only: the HTTP header name to send when it differs from
     // the agent-facing parameter key (e.g. input account_id → header Harvest-Account-Id).
     headerName: v.string().optional(),


### PR DESCRIPTION
Fixes the Outlook email search tool schema for agents.\n\n- Exposes a model-facing `query` parameter instead of Microsoft Graph's provider-specific ``.\n- Adds `queryName` metadata so the runtime can send `` to Graph.\n- Updates generated integration data.\n\nVerification:\n- `deno task test src/integrations/_data.test.ts` passed.\n- Full pre-push checks passed with OTEL env cleared: 1997 passed, 0 failed.\n\nRelated: veryfront/veryfront-studio#4727