### PR TITLE
Preserve hosted provider tool inventory

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.663",
+  "version": "0.1.664",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted/chat-runtime-tool-assembly.test.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import type {
   RemoteMCPToolSourceConfig,
   RemoteToolSource,
@@ -133,6 +133,34 @@ Deno.test("prepareHostedChatRuntimeToolAssembly separates provider tools from re
   assertEquals(toolAssembly.compatibleRemoteToolNames, ["create_file"]);
   assertEquals(toolAssembly.providerToolNames, ["web_search"]);
   assertEquals(taskContext.availableToolNames, ["create_file", "web_search"]);
+});
+
+Deno.test("prepareHostedChatRuntimeToolAssembly includes source provider tools outside forwarded allowed tools", async () => {
+  const taskContext: HostedChatRuntimeToolAssemblyContext = {
+    authToken: "token",
+    projectId: "project-1",
+    model: "anthropic/claude-sonnet-4-6",
+  };
+
+  const toolAssembly = await prepareHostedChatRuntimeToolAssembly({
+    taskContext,
+    instructions: "Base instructions",
+    localTools: {
+      sleep: localTool("Sleep"),
+    },
+    apiUrl: "https://api.example.com",
+    apiMcpUrl: "https://api.example.com/mcp",
+    allowedToolNames: ["sleep"],
+    sourceProviderToolNames: ["web_search", "web_fetch"],
+    createRemoteToolSource: remoteSourceFromConfig,
+    preloadLatestConversationUserText: false,
+  });
+
+  assertEquals(toolAssembly.localToolNames, ["sleep"]);
+  assertEquals(toolAssembly.providerToolNames, ["web_fetch", "web_search"]);
+  assertEquals(taskContext.availableToolNames, ["sleep", "web_fetch", "web_search"]);
+  assertStringIncludes(toolAssembly.systemInstructions, "- web_fetch");
+  assertStringIncludes(toolAssembly.systemInstructions, "- web_search");
 });
 
 Deno.test("prepareHostedChatRuntimeToolAssembly preloads default research artifacts", async () => {

--- a/src/agent/hosted/chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.ts
@@ -69,6 +69,7 @@ export type PrepareHostedChatRuntimeToolAssemblyInput<
   mcpServers?: readonly AgentServiceMcpServerConfig[];
   conversationId?: string;
   allowedToolNames?: HostedChatRuntimeAllowedToolNames;
+  sourceProviderToolNames?: readonly string[];
   projectScopedRemoteToolOptions?: ProjectScopedRemoteToolOptions;
   createRemoteToolSource?: (config: RemoteMCPToolSourceConfig) => RemoteToolSource;
   traceLocalTools?: TraceHostToolsOptions<TTraceAttributes>;
@@ -149,8 +150,11 @@ export async function prepareHostedChatRuntimeToolAssembly<
     projectId: activeProjectId(input.taskContext),
     projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions,
   });
+  const sourceProviderToolNames = new Set(input.sourceProviderToolNames ?? []);
   const providerToolNames = getProviderNativeToolNames({ model: input.taskContext.model }).filter(
-    (toolName) => allowedToolNames ? allowedToolNames.has(toolName) : false,
+    (toolName) =>
+      sourceProviderToolNames.has(toolName) ||
+      (allowedToolNames ? allowedToolNames.has(toolName) : false),
   );
   const localToolNames = Object.keys(localHostTools);
   const availableToolNames = selectProviderCompatibleToolNames(

--- a/src/agent/hosted/default-chat-runtime.ts
+++ b/src/agent/hosted/default-chat-runtime.ts
@@ -168,6 +168,7 @@ async function buildToolAssembly(
     mcpServers: input.config.mcpServers,
     conversationId: input.options.conversationId,
     allowedToolNames: input.options.allowedTools ?? null,
+    sourceProviderToolNames: input.options.liveProjectSteering?.agent.providerTools,
     projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions,
     createRemoteToolSource: input.createRemoteToolSource,
     traceLocalTools: input.traceLocalTools,

--- a/src/agent/hosted/default-project-steering-refresh.test.ts
+++ b/src/agent/hosted/default-project-steering-refresh.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { DefaultHostedChatRuntimeSystemRefreshInput } from "./default-chat-runtime.ts";
 import {
@@ -144,6 +144,39 @@ describe("agent/default-hosted-project-steering-refresh", () => {
       true,
     );
     assertEquals(system.includes("Current run tool inventory:"), true);
+  });
+
+  it("keeps provider-native tools in refreshed runtime inventory", async () => {
+    const refresh = createDefaultHostedProjectSteeringRefresh({
+      fetchProjectInstructions: () => Promise.resolve("Fresh instructions"),
+      fetchSkills: () => Promise.resolve([]),
+      buildInstructions: (input) => input.instructions,
+    });
+
+    const input = createRefreshInput({
+      taskContext: {
+        authToken: "auth-token",
+        projectId: "project-1",
+        branchId: "branch-1",
+        model: "anthropic/claude-sonnet-4-6",
+      },
+      toolAssembly: {
+        runtimeTools: {},
+        remoteToolSources: [],
+        localToolNames: ["sleep"],
+        remoteToolNames: [],
+        providerToolNames: ["web_fetch", "web_search"],
+        availableToolNames: [],
+        compatibleRemoteToolNames: [],
+        systemInstructions: "",
+      },
+    });
+
+    const system = await refresh(input);
+
+    assertEquals(input.taskContext.availableToolNames, ["sleep", "web_fetch", "web_search"]);
+    assertStringIncludes(system, "- web_fetch");
+    assertStringIncludes(system, "- web_search");
   });
 
   it("falls back to initial steering when refresh lookups fail", async () => {

--- a/src/agent/hosted/default-project-steering-refresh.ts
+++ b/src/agent/hosted/default-project-steering-refresh.ts
@@ -212,7 +212,11 @@ export function createDefaultHostedProjectSteeringRefresh(
       allowedSkillIds: input.taskContext.availableSkillIds,
     });
     const allToolNames = [
-      ...new Set([...input.toolAssembly.localToolNames, ...remoteToolNames]),
+      ...new Set([
+        ...input.toolAssembly.localToolNames,
+        ...remoteToolNames,
+        ...input.toolAssembly.providerToolNames,
+      ]),
     ].sort();
     const toolNames = selectProviderCompatibleToolNames(allToolNames, {
       model: input.taskContext.model,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.663";
+export const VERSION = "0.1.664";


### PR DESCRIPTION
## Summary
- include source-declared provider-native tools in hosted chat runtime tool assembly even when Studio forwards a narrower allowed-tools list
- keep provider-native tools in refreshed project steering runtime inventory
- bump veryfront package version to 0.1.664 for release

## Verification
- VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/agent/hosted/chat-runtime-tool-assembly.test.ts src/agent/hosted/default-project-steering-refresh.test.ts src/agent/hosted/default-chat-runtime.test.ts
- deno task verify:quick
- pre-push hook: formatting, lint, typecheck, unit tests (1998 passed, 0 failed)
