### PR TITLE
Bump veryfront-code to 0.1.665

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.664",
+  "version": "0.1.665",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.664";
+export const VERSION = "0.1.665";


### PR DESCRIPTION
## Summary
- Bump `veryfront-code` from `0.1.664` to `0.1.665` so the merged provider-tool schema normalization fix can publish as a new stable release.
- Keep `src/utils/version-constant.ts` in sync with `deno.json`.

## Test Plan
- [x] `deno task test src/utils/version.test.ts`
- [x] `jq -r .version deno.json` → `0.1.665`
- [x] `npm view veryfront@0.1.665 version` → not published
- [x] `git diff --check`
