### PR TITLE
Fix provider-native web tools for Anthropic agents

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.665",
+  "version": "0.1.666",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/model-tool-converter.test.ts
+++ b/src/agent/runtime/model-tool-converter.test.ts
@@ -238,7 +238,7 @@ describe("model-tool-converter", () => {
     assertEquals(result, undefined);
   });
 
-  it("does not override an explicit local tool named web_search", () => {
+  it("preserves an explicit local tool named web_search for non-Anthropic models", () => {
     const tools: ToolDefinition[] = [
       {
         name: "web_search",
@@ -248,12 +248,48 @@ describe("model-tool-converter", () => {
     ];
 
     const result = convertToolsToRuntimeTools(tools, {
-      model: "anthropic/claude-sonnet-4-6",
+      model: "openai/gpt-5.2",
       providerTools: ["web_search"],
     });
 
     assertEquals(result !== undefined, true);
     assertEquals(Object.keys(result!).filter((name) => name === "web_search").length, 1);
+    assertEquals((result?.web_search as { type?: unknown }).type, "function");
+  });
+
+  it("uses provider-native web tools for Anthropic even when Studio forwards tool definitions", () => {
+    const result = convertToolsToRuntimeTools([
+      {
+        name: "web_search",
+        description: "Search the web",
+        parameters: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+          },
+          required: ["query"],
+        },
+      },
+      {
+        name: "web_fetch",
+        description: "Fetch a web page",
+        parameters: {
+          type: "object",
+          properties: {
+            url: { type: "string" },
+          },
+          required: ["url"],
+        },
+      },
+    ], {
+      model: "veryfront-cloud/anthropic/claude-opus-4-6",
+      providerTools: ["web_search", "web_fetch"],
+    });
+
+    assertEquals((result?.web_search as { type?: unknown }).type, "provider");
+    assertEquals((result?.web_search as { id?: unknown }).id, "anthropic.web_search_20250305");
+    assertEquals((result?.web_fetch as { type?: unknown }).type, "provider");
+    assertEquals((result?.web_fetch as { id?: unknown }).id, "anthropic.web_fetch_20250910");
   });
 
   it("does not add provider-native web_search from remote tool allowlists", () => {

--- a/src/agent/runtime/model-tool-converter.ts
+++ b/src/agent/runtime/model-tool-converter.ts
@@ -68,11 +68,16 @@ export function convertToolsToRuntimeTools(
   options?: ConvertToolsToRuntimeToolsOptions,
 ): RuntimeToolSet | undefined {
   const toolSet: RuntimeToolSet = {};
+  const providerNativeTools = resolveProviderNativeTools(options);
+  const providerNativeToolNames = new Set(Object.keys(providerNativeTools ?? {}));
   const compatibleTools = selectProviderCompatibleTools(tools, {
     model: options?.model,
   });
 
   for (const def of compatibleTools) {
+    if (providerNativeToolNames.has(def.name)) {
+      continue;
+    }
     addRuntimeTool(
       toolSet,
       def.name,
@@ -87,12 +92,9 @@ export function convertToolsToRuntimeTools(
     );
   }
 
-  const providerNativeTools = resolveProviderNativeTools(options);
   if (providerNativeTools) {
     for (const [name, providerTool] of Object.entries(providerNativeTools)) {
-      if (!Object.hasOwn(toolSet, name)) {
-        toolSet[name] = providerTool;
-      }
+      toolSet[name] = providerTool;
     }
   }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.665";
+export const VERSION = "0.1.666";


### PR DESCRIPTION
## Summary
- keep Anthropic `web_search` and `web_fetch` as provider-native tools when Studio forwards same-named tool definitions
- preserve same-named custom tools for non-Anthropic models
- bump `veryfront` to `0.1.666`

## Verification
- `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/agent/runtime/model-tool-converter.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts src/agent/runtime/model-tool-converter.ts src/agent/runtime/model-tool-converter.test.ts`
- `deno check src/agent/runtime/model-tool-converter.ts src/agent/runtime/model-tool-converter.test.ts`
- `deno task build:npm`

Fixes veryfront/veryfront-studio#4732