### PR TITLE
Fix Outlook Graph search query metadata

### DIFF
--- a/cli/templates/integrations/outlook/connector.json
+++ b/cli/templates/integrations/outlook/connector.json
@@ -223,7 +223,8 @@
             "type": "string",
             "in": "query",
             "queryName": "$search",
-            "description": "Microsoft Graph search query, for example \"subject:roadmap\"",
+            "queryValueFormat": "microsoft-graph-search",
+            "description": "Microsoft Graph message search query. Gmail-style AQS terms such as from:marcus or subject:Finanzplan are accepted; the runtime quotes them for Graph $search.",
             "required": true
           },
           "$top": {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.666",
+  "version": "0.1.667",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/scripts/build/generate-integrations-module.ts
+++ b/scripts/build/generate-integrations-module.ts
@@ -134,13 +134,13 @@ ${historicalToolSummaryLines}
 );
 
 const fmt = new Deno.Command(Deno.execPath(), {
-  args: ["fmt", summaryPath],
+  args: ["fmt", dataPath, summaryPath],
   stdout: "inherit",
   stderr: "inherit",
 });
 const fmtStatus = await fmt.output();
 if (!fmtStatus.success) {
-  throw new Error(`Failed to format generated ${summaryPath}`);
+  throw new Error(`Failed to format generated integration modules`);
 }
 
 console.log(

--- a/src/integrations/_data.test.ts
+++ b/src/integrations/_data.test.ts
@@ -1013,6 +1013,11 @@ describe("integration endpoint specs", () => {
       "https://graph.microsoft.com/v1.0/me/findMeetingTimes",
     );
     assertEquals(
+      getTool("outlook", "search_emails").endpoint?.params?.query
+        ?.queryValueFormat,
+      "microsoft-graph-search",
+    );
+    assertEquals(
       getTool("outlook", "list_conversation_messages").endpoint?.params?.["$orderby"],
       undefined,
     );

--- a/src/integrations/_data.ts
+++ b/src/integrations/_data.ts
@@ -7073,9 +7073,11 @@ export const connectors: IntegrationConfig[] = [
           "query": {
             "type": "string",
             "in": "query",
-            "queryName": "$search",
-            "description": 'Microsoft Graph search query, for example "subject:roadmap"',
+            "description":
+              "Microsoft Graph message search query. Gmail-style AQS terms such as from:marcus or subject:Finanzplan are accepted; the runtime quotes them for Graph $search.",
             "required": true,
+            "queryName": "$search",
+            "queryValueFormat": "microsoft-graph-search",
           },
           "$top": {
             "type": "number",

--- a/src/integrations/schema.ts
+++ b/src/integrations/schema.ts
@@ -124,6 +124,10 @@ export const getIntegrationEndpointParamSchema = defineSchema((v) =>
     // For query params only: the HTTP query parameter name to send when it differs
     // from the agent-facing parameter key (e.g. input query -> query param $search).
     queryName: v.string().optional(),
+    // For query params only: provider-specific formatting applied to the value
+    // before sending. Microsoft Graph message $search requires the entire AQS
+    // query to be enclosed in double quotes.
+    queryValueFormat: v.enum(["microsoft-graph-search"]).optional(),
     // For header params only: the HTTP header name to send when it differs from
     // the agent-facing parameter key (e.g. input account_id → header Harvest-Account-Id).
     headerName: v.string().optional(),

--- a/src/integrations/types.ts
+++ b/src/integrations/types.ts
@@ -10,6 +10,9 @@ export interface IntegrationEndpointParam {
   description: string;
   required?: boolean;
   default?: unknown;
+  queryName?: string;
+  queryValueFormat?: "microsoft-graph-search";
+  headerName?: string;
 }
 
 interface IntegrationEndpointBodyField {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.666";
+export const VERSION = "0.1.667";


### PR DESCRIPTION
## Summary
- Mark Outlook search_emails query values for Microsoft Graph $search quoting.
- Extend the integration schema/types with the query value format metadata.
- Keep generated integration data formatted during generation and bump veryfront to 0.1.667.

## Test Plan
- deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/integrations/_data.test.ts
- deno check scripts/build/generate-integrations-module.ts src/integrations/schema.ts src/integrations/types.ts src/integrations/_data.ts
- deno fmt --check cli/templates/integrations/outlook/connector.json scripts/build/generate-integrations-module.ts src/integrations/schema.ts src/integrations/types.ts src/integrations/_data.ts src/integrations/_data.test.ts deno.json src/utils/version-constant.ts
- deno task build:npm

Note: full local pre-push was started twice; it reached formatting/lint/typecheck/full unit tests, then hung locally with deno test idle. CI remains the full-suite gate.