### PR TITLE
Preserve source ids for context compaction

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.668",
+  "version": "0.1.669",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted/chat-preparation.test.ts
+++ b/src/agent/hosted/chat-preparation.test.ts
@@ -403,9 +403,9 @@ Deno.test("prepareHostedChatExecution compacts oversized context and appends a d
 
     assertEquals(result.contextBudgetDiagnostics?.compacted, true);
     assertEquals(result.finalMessages.map((message) => message.id), [
-      "context_compaction_summary:agent-runtime-assistant-2",
-      "agent-runtime-assistant-2",
-      "agent-runtime-user-3",
+      "context_compaction_summary:assistant-old",
+      "assistant-old",
+      "user-latest",
     ]);
     assertEquals(appendedBodies.length, 1);
     assertEquals(
@@ -415,7 +415,7 @@ Deno.test("prepareHostedChatExecution compacts oversized context and appends a d
     assertEquals(
       (appendedBodies[0] as { events?: Array<{ firstKeptEntryId?: string }> }).events?.[0]
         ?.firstKeptEntryId,
-      "agent-runtime-assistant-2",
+      "assistant-old",
     );
   } finally {
     globalThis.fetch = originalFetch;

--- a/src/agent/runtime/message-adapter.ts
+++ b/src/agent/runtime/message-adapter.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "#veryfront/chat/conversation.ts";
+import { getProviderModelMessageSourceId, isRecord } from "#veryfront/chat/conversation.ts";
 import {
   buildDataFileAnnotation,
   type ChatModelFilePart,
@@ -126,7 +126,7 @@ function getOptionalStringField(part: unknown, key: string): string | undefined 
 }
 
 function createAgentRuntimeMessageId(message: ProviderModelMessage, index: number): string {
-  return `agent-runtime-${message.role}-${index + 1}`;
+  return getProviderModelMessageSourceId(message) ?? `agent-runtime-${message.role}-${index + 1}`;
 }
 
 function createTextAgentRuntimePart(text: string): AgentRuntimeMessagePart | null {

--- a/src/agent/runtime/message-preparation.test.ts
+++ b/src/agent/runtime/message-preparation.test.ts
@@ -28,6 +28,34 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages returns an empty-conversati
   assertEquals(messages[0]?.parts, [{ type: "text", text: "Suggest next steps." }]);
 });
 
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages preserves source message ids", async () => {
+  const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+    messages: [
+      {
+        id: "user-source-1",
+        role: "user",
+        parts: [{ type: "text", text: "First request" }],
+      },
+      {
+        id: "assistant-source-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "First answer" }],
+      },
+      {
+        id: "user-source-2",
+        role: "user",
+        parts: [{ type: "text", text: "Follow up" }],
+      },
+    ],
+  });
+
+  assertEquals(messages.map((message) => message.id), [
+    "user-source-1",
+    "assistant-source-1",
+    "user-source-2",
+  ]);
+});
+
 Deno.test("prepareAgentRuntimeMessagesFromUiMessages refreshes upload file URLs before conversion", async () => {
   const resolvedUploadIds: string[] = [];
   const messages = await prepareAgentRuntimeMessagesFromUiMessages({

--- a/src/chat/conversation.ts
+++ b/src/chat/conversation.ts
@@ -7,6 +7,41 @@ import type {
   ProviderModelMessage,
 } from "./types.ts";
 
+const PROVIDER_MODEL_MESSAGE_SOURCE_ID = Symbol.for("veryfront.providerModelMessageSourceId");
+
+/** Provider model message plus local-only source metadata. */
+export type ProviderModelMessageWithSourceId = ProviderModelMessage & {
+  [PROVIDER_MODEL_MESSAGE_SOURCE_ID]?: string;
+};
+
+/** Read the local-only source UI message id attached during provider conversion. */
+export function getProviderModelMessageSourceId(message: ProviderModelMessage): string | undefined {
+  return (message as ProviderModelMessageWithSourceId)[PROVIDER_MODEL_MESSAGE_SOURCE_ID];
+}
+
+/** Attach local-only source UI message id metadata to a provider message. */
+export function withProviderModelMessageSourceId(
+  message: ProviderModelMessage,
+  sourceId: string,
+): ProviderModelMessage {
+  Object.defineProperty(message, PROVIDER_MODEL_MESSAGE_SOURCE_ID, {
+    value: sourceId,
+    configurable: true,
+    enumerable: false,
+    writable: true,
+  });
+  return message;
+}
+
+/** Copy local-only source UI message id metadata when a provider message is cloned. */
+export function copyProviderModelMessageSourceId<T extends ProviderModelMessage>(
+  source: ProviderModelMessage,
+  target: T,
+): T {
+  const sourceId = getProviderModelMessageSourceId(source);
+  return sourceId ? withProviderModelMessageSourceId(target, sourceId) as T : target;
+}
+
 /** Zod schema for get message part. */
 export const getMessagePartSchema = defineSchema((v) =>
   v.discriminatedUnion("type", [
@@ -999,13 +1034,14 @@ export function convertUiMessagesToProviderModelMessages(
       }
     })();
 
-    for (const providerMessage of converted) {
+    for (const rawProviderMessage of converted) {
+      const providerMessage = withProviderModelMessageSourceId(rawProviderMessage, message.id);
       const previous = providerMessages.at(-1);
       if (previous?.role === "tool" && providerMessage.role === "tool") {
-        providerMessages[providerMessages.length - 1] = {
+        providerMessages[providerMessages.length - 1] = withProviderModelMessageSourceId({
           role: "tool",
           content: [...previous.content, ...providerMessage.content],
-        };
+        }, getProviderModelMessageSourceId(previous) ?? message.id);
         continue;
       }
 

--- a/src/chat/message-prep.ts
+++ b/src/chat/message-prep.ts
@@ -1,5 +1,6 @@
 import {
   convertUiMessagesToProviderModelMessages,
+  copyProviderModelMessageSourceId,
   getStringField,
   isReasoningPart,
   isToolCallPart,
@@ -454,13 +455,19 @@ export function sanitizeProviderModelMessages(
     if (Array.isArray(message.content)) {
       if (message.role === "user") {
         const cleaned = cleanContent(message.content);
-        if (cleaned.length > 0) result.push({ ...message, content: cleaned });
+        if (cleaned.length > 0) {
+          result.push(copyProviderModelMessageSourceId(message, { ...message, content: cleaned }));
+        }
       } else if (message.role === "assistant") {
         const cleaned = cleanContent(message.content);
-        if (cleaned.length > 0) result.push({ ...message, content: cleaned });
+        if (cleaned.length > 0) {
+          result.push(copyProviderModelMessageSourceId(message, { ...message, content: cleaned }));
+        }
       } else if (message.role === "tool") {
         const cleaned = cleanContent(message.content);
-        if (cleaned.length > 0) result.push({ ...message, content: cleaned });
+        if (cleaned.length > 0) {
+          result.push(copyProviderModelMessageSourceId(message, { ...message, content: cleaned }));
+        }
       }
       continue;
     }
@@ -828,7 +835,7 @@ export function maskOldToolOutputs(messages: ProviderModelMessage[]): ProviderMo
     if (msg.role === "assistant" && Array.isArray(msg.content)) {
       const filtered = msg.content.filter((part) => !isReasoningPart(part));
       if (filtered.length !== msg.content.length) {
-        return { ...msg, content: filtered };
+        return copyProviderModelMessageSourceId(msg, { ...msg, content: filtered });
       }
       return msg;
     }
@@ -882,7 +889,7 @@ export function maskOldToolOutputs(messages: ProviderModelMessage[]): ProviderMo
       return { ...part, output: wrapToolResultOutput(part.output, masked) };
     });
 
-    return { ...msg, content: newContent };
+    return copyProviderModelMessageSourceId(msg, { ...msg, content: newContent });
   });
 }
 
@@ -941,10 +948,10 @@ export function repairToolPairs(messages: ProviderModelMessage[]): ProviderModel
     }
 
     if (repairedContent.length !== message.content.length) {
-      result[index] = {
+      result[index] = copyProviderModelMessageSourceId(message, {
         ...message,
         content: repairedContent,
-      };
+      });
     }
 
     if (regularToolCalls.length === 0) {
@@ -1009,10 +1016,10 @@ export function repairToolPairs(messages: ProviderModelMessage[]): ProviderModel
         continue;
       }
 
-      result[laterIndex] = {
+      result[laterIndex] = copyProviderModelMessageSourceId(laterMessage, {
         ...laterMessage,
         content: keptLaterContent,
-      };
+      });
     }
 
     const repairedResults = unresolvedCalls.map(
@@ -1021,16 +1028,16 @@ export function repairToolPairs(messages: ProviderModelMessage[]): ProviderModel
     );
 
     if (nextMessage?.role === "tool" && Array.isArray(nextMessage.content)) {
-      result[index + 1] = {
+      result[index + 1] = copyProviderModelMessageSourceId(nextMessage, {
         ...nextMessage,
         content: [...repairedResults, ...nextMessage.content],
-      };
+      });
     } else {
       const toolMessage: ProviderModelMessage = {
         role: "tool",
         content: repairedResults,
       };
-      result.splice(index + 1, 0, toolMessage);
+      result.splice(index + 1, 0, copyProviderModelMessageSourceId(message, toolMessage));
     }
     mutated = true;
   }
@@ -1067,7 +1074,7 @@ export function ensureToolCallInputs(messages: ProviderModelMessage[]): Provider
 
     if (msgMutated) {
       mutated = true;
-      return { ...msg, content: newContent };
+      return copyProviderModelMessageSourceId(msg, { ...msg, content: newContent });
     }
     return msg;
   });
@@ -1134,21 +1141,27 @@ export function dedupeToolHistory(messages: ProviderModelMessage[]): ProviderMod
         deduped.push(message);
         continue;
       }
-      if (filtered.length > 0) deduped.push({ ...message, content: filtered });
+      if (filtered.length > 0) {
+        deduped.push(copyProviderModelMessageSourceId(message, { ...message, content: filtered }));
+      }
     } else if (message.role === "assistant" && Array.isArray(message.content)) {
       const { filtered, changed } = filterParts(message.content);
       if (!changed) {
         deduped.push(message);
         continue;
       }
-      if (filtered.length > 0) deduped.push({ ...message, content: filtered });
+      if (filtered.length > 0) {
+        deduped.push(copyProviderModelMessageSourceId(message, { ...message, content: filtered }));
+      }
     } else if (message.role === "tool") {
       const { filtered, changed } = filterParts(message.content);
       if (!changed) {
         deduped.push(message);
         continue;
       }
-      if (filtered.length > 0) deduped.push({ ...message, content: filtered });
+      if (filtered.length > 0) {
+        deduped.push(copyProviderModelMessageSourceId(message, { ...message, content: filtered }));
+      }
     } else {
       deduped.push(message);
     }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.668";
+export const VERSION = "0.1.669";


### PR DESCRIPTION
## Summary
- preserve source UI message ids through provider-message preparation using local-only non-enumerable symbol metadata
- use preserved ids for hosted runtime message ids so context compaction events can be replayed by API
- bump package version to 0.1.669

## Verification
- deno test --no-check --allow-env --allow-net --allow-read --allow-write src/chat/conversation.test.ts src/chat/message-prep.test.ts src/agent/runtime/message-preparation.test.ts src/agent/hosted/chat-preparation.test.ts src/agent/hosted/context-summary-generator.test.ts src/agent/service/config.test.ts
- deno task verify:quick