### PR TITLE
Accept runtime metadata in hosted chat requests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.669",
+  "version": "0.1.670",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -106,6 +106,32 @@ describe("agent/hosted-chat-request", () => {
     );
   });
 
+  it("accepts runtime context metadata on hosted chat request messages", () => {
+    const parsed = hostedChatRequestSchema.parse({
+      messages: [
+        {
+          id: "context_compaction_summary:user-kept",
+          role: "system",
+          parts: [{ type: "text", text: "Previous context summary:\nEarlier work." }],
+          metadata: {
+            veryfrontRuntimeContext: "context_compaction_summary",
+            firstKeptEntryId: "user-kept",
+          },
+        },
+      ],
+      context: {
+        conversationId,
+        projectId,
+        branchId,
+      },
+    });
+
+    assertEquals(parsed.messages[0]?.metadata, {
+      veryfrontRuntimeContext: "context_compaction_summary",
+      firstKeptEntryId: "user-kept",
+    });
+  });
+
   it("builds a hosted chat request from a runtime agent invocation", () => {
     const invocation = createRuntimeInvocation();
     const forwardedProps = buildHostedChatRequestForwardedPropsFromRuntimeAgentInvocation(

--- a/src/agent/hosted/chat-request.ts
+++ b/src/agent/hosted/chat-request.ts
@@ -1,5 +1,9 @@
 import type { ChatRuntimeOverrides, DurableRootRunDescriptor } from "#veryfront/chat/types.ts";
-import { getChatRequestContextSchema, getChatUiMessagesSchema } from "#veryfront/chat/types.ts";
+import {
+  getChatRequestContextSchema,
+  getChatUiMessagePartSchema,
+  getChatUiMessageRoleSchema,
+} from "#veryfront/chat/types.ts";
 import { defineSchema, lazySchema } from "#veryfront/schemas/index.ts";
 import type { InferSchema } from "#veryfront/extensions/schema/index.ts";
 import type { RuntimeAgentRunInvocation } from "../runtime/agent-invocation-contract.ts";
@@ -40,9 +44,22 @@ export const getHostedChatRuntimeOverridesSchema = defineSchema((v) =>
  */
 export const hostedChatRuntimeOverridesSchema = lazySchema(getHostedChatRuntimeOverridesSchema);
 
+const getHostedChatRequestMessageSchema = defineSchema((v) =>
+  v.object({
+    id: v.string().min(1),
+    role: getChatUiMessageRoleSchema(),
+    parts: v.array(getChatUiMessagePartSchema()),
+    metadata: v.record(v.string(), v.unknown()).optional(),
+  }).strip()
+);
+
+const getHostedChatRequestMessagesSchema = defineSchema((v) =>
+  v.array(getHostedChatRequestMessageSchema())
+);
+
 export const getHostedChatRequestSchema = defineSchema((v) =>
   v.object({
-    messages: getChatUiMessagesSchema(),
+    messages: getHostedChatRequestMessagesSchema(),
     context: getChatRequestContextSchema(),
     model: v.string().optional(),
     allowDelegation: v.boolean().optional(),

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.669";
+export const VERSION = "0.1.670";


### PR DESCRIPTION
## Summary
- allow hosted chat request messages to carry runtime metadata
- preserve compaction replay metadata instead of rejecting the run at validation
- bump veryfront package version to 0.1.670

## Tests
- deno fmt --check deno.json src/utils/version-constant.ts src/agent/hosted/chat-request.ts src/agent/hosted/chat-request.test.ts
- deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/agent/hosted/chat-request.test.ts
- pre-push: format, lint, typecheck, 2000 unit tests