### PR TITLE
Fix terminal provider tool states

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.670",
+  "version": "0.1.671",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/chat/conversation.test.ts
+++ b/src/chat/conversation.test.ts
@@ -89,6 +89,72 @@ describe("chat/conversation helpers", () => {
     ]);
   });
 
+  it("treats terminal provider tool states as complete", () => {
+    const message: ChatUiMessage = {
+      id: "assistant-provider-tools",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-web_search",
+          toolCallId: "srvtoolu-search",
+          input: { query: "Veryfront" },
+          state: "completed",
+          providerExecuted: true,
+          output: { results: [] },
+        },
+        {
+          type: "tool-web_fetch",
+          toolCallId: "srvtoolu-fetch",
+          input: { url: "https://example.com" },
+          state: "error",
+          providerExecuted: true,
+          errorText: "404 / Not Found",
+        },
+      ],
+    };
+
+    const parts: Array<ReturnType<typeof messagePartSchema.parse>> = [];
+    for (const part of message.parts) {
+      if (part.type === "tool-web_search") {
+        pushToolParts(parts, "web_search", part.toolCallId, part.state, part);
+      }
+      if (part.type === "tool-web_fetch") {
+        pushToolParts(parts, "web_fetch", part.toolCallId, part.state, part);
+      }
+    }
+
+    assertEquals(hasIncompleteToolParts(message), false);
+    assertEquals(markIncompleteToolPartsAsErrored(message, "Tool call did not complete"), message);
+    assertEquals(parts, [
+      {
+        type: "tool_call",
+        id: "srvtoolu-search",
+        name: "web_search",
+        input: { query: "Veryfront" },
+        state: "completed",
+      },
+      {
+        type: "tool_result",
+        tool_call_id: "srvtoolu-search",
+        output: { results: [] },
+        is_error: false,
+      },
+      {
+        type: "tool_call",
+        id: "srvtoolu-fetch",
+        name: "web_fetch",
+        input: { url: "https://example.com" },
+        state: "completed",
+      },
+      {
+        type: "tool_result",
+        tool_call_id: "srvtoolu-fetch",
+        output: "404 / Not Found",
+        is_error: true,
+      },
+    ]);
+  });
+
   it("maps UI messages into persistable conversation parts", () => {
     const message: ChatUiMessage = {
       id: "assistant-2",

--- a/src/chat/conversation.ts
+++ b/src/chat/conversation.ts
@@ -312,7 +312,7 @@ export function pushToolParts(
 ): void {
   const input = toRecord(part.input);
   const isErroredState = state === "output-error" || state === "error" || state === "output-denied";
-  const hasResultState = state === "output-available" || isErroredState;
+  const hasResultState = state === "output-available" || state === "completed" || isErroredState;
 
   if (hasResultState) {
     parts.push({
@@ -439,7 +439,8 @@ export function toConversationPartsFromUiMessage(message: ChatUiMessage): Messag
 
 function isToolComplete(part: ToolUiPart): boolean {
   return part.state === "output-available" || part.state === "output-error" ||
-    part.state === "output-denied";
+    part.state === "output-denied" || part.state === "completed" ||
+    part.state === "error";
 }
 
 /** Check whether incomplete tool parts is present. */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.670";
+export const VERSION = "0.1.671";


### PR DESCRIPTION
## Summary
- treat provider-executed terminal tool states (`completed`/`error`) as complete during hosted chat finalization
- persist terminal provider tool parts as canonical `tool_call` + `tool_result` pairs
- bump veryfront package version to 0.1.671

## Root cause
Staging runs failed with `INCOMPLETE_TOOL_CALLS` even though every provider web_search/web_fetch call had a matching result. The finalizer only recognized UI output states (`output-available`, `output-error`, `output-denied`) as complete, so terminal provider tool states were incorrectly marked incomplete.

## Verification
- `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/chat/conversation.test.ts`
- `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/utils/version.test.ts src/utils/logger/logger.test.ts`
- pre-push hook: formatting, lint, typecheck, `deno task test:unit` (`2000` passed)
