### PR TITLE
Label agent traces with deployment environment

### DIFF
--- a/src/agent/service/node-telemetry.test.ts
+++ b/src/agent/service/node-telemetry.test.ts
@@ -70,6 +70,30 @@ describe("agent/node-agent-service-telemetry", () => {
     });
   });
 
+  it("prefers deployment and app environment labels over NODE_ENV", () => {
+    const appConfig = resolveNodeHostedAgentServiceTelemetryConfig({
+      env: {
+        NODE_ENV: "production",
+        APP_ENVIRONMENT: "staging",
+      },
+      defaultServiceName: "agent-service",
+    });
+
+    assertEquals(appConfig.deploymentEnvironment, "staging");
+
+    const explicitConfig = resolveNodeHostedAgentServiceTelemetryConfig({
+      env: {
+        NODE_ENV: "production",
+        APP_ENVIRONMENT: "staging",
+        VERYFRONT_ENVIRONMENT: "preview",
+        OTEL_DEPLOYMENT_ENVIRONMENT: "canary",
+      },
+      defaultServiceName: "agent-service",
+    });
+
+    assertEquals(explicitConfig.deploymentEnvironment, "canary");
+  });
+
   it("supports Basic authorization headers and clamps sampling ratio", () => {
     const config = resolveNodeHostedAgentServiceTelemetryConfig({
       env: {

--- a/src/agent/service/node-telemetry.ts
+++ b/src/agent/service/node-telemetry.ts
@@ -85,6 +85,14 @@ function resolveSamplingRatio(env: NodeHostedAgentServiceTelemetryEnv): number {
   return Math.min(Math.max(ratio, 0), 1);
 }
 
+function resolveDeploymentEnvironment(env: NodeHostedAgentServiceTelemetryEnv): string {
+  return env.OTEL_DEPLOYMENT_ENVIRONMENT ??
+    env.APP_ENVIRONMENT ??
+    env.VERYFRONT_ENVIRONMENT ??
+    env.NODE_ENV ??
+    "development";
+}
+
 function parseExporterHeaders(headersEnv: string | undefined): Record<string, string> | undefined {
   if (!headersEnv) return undefined;
 
@@ -124,7 +132,7 @@ export function resolveNodeHostedAgentServiceTelemetryConfig(
     enabled: resolveEnabled(options.env, defaultEnabled),
     serviceName: options.env.OTEL_SERVICE_NAME ?? options.defaultServiceName,
     serviceVersion: options.env.npm_package_version ?? options.defaultServiceVersion ?? "0.1.0",
-    deploymentEnvironment: options.env.NODE_ENV ?? "development",
+    deploymentEnvironment: resolveDeploymentEnvironment(options.env),
     samplingRatio: resolveSamplingRatio(options.env),
     exporterHeaders: parseExporterHeaders(options.env.OTEL_EXPORTER_OTLP_HEADERS),
     instrumentation: resolveInstrumentationConfig(options.env),


### PR DESCRIPTION
## Summary
- resolve hosted agent telemetry deploymentEnvironment from explicit deployment/app env before NODE_ENV
- keep NODE_ENV as fallback for local/dev behavior
- add resolver precedence coverage

## Verification
- deno test --no-check --allow-all src/agent/service/node-telemetry.test.ts
- deno fmt --check src/agent/service/node-telemetry.ts src/agent/service/node-telemetry.test.ts
- deno check src/agent/service/node-telemetry.ts src/agent/service/node-telemetry.test.ts
- pre-push hook: 2000 tests / 18050 steps passed