### PR TITLE
Preserve hosted project slugs and redact agent context payloads

### DIFF
--- a/src/agent/hosted/ag-ui-chat-request.test.ts
+++ b/src/agent/hosted/ag-ui-chat-request.test.ts
@@ -1,3 +1,4 @@
+import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { AgUiRuntimeRequest } from "../runtime/ag-ui-contract.ts";

--- a/src/agent/hosted/chat-request-parser.ts
+++ b/src/agent/hosted/chat-request-parser.ts
@@ -37,6 +37,7 @@ export type ParsedHostedChatRequest = {
   messages: ChatUiMessage[];
   validatedContext: ChatRequestContext;
   projectId: string | null;
+  projectSlug?: string;
   conversationId: string | undefined;
   parentRunId: string | undefined;
   upstreamParentConversationId: string | undefined;
@@ -121,6 +122,7 @@ export async function buildParsedHostedChatRequest(input: {
     durableRootRun,
   } = input.chatRequest;
   const projectId = chatContext.projectId;
+  const projectSlug = chatContext.projectSlug;
   const conversationId = chatContext.conversationId;
 
   const accessError = await verifyHostedChatProjectAccess({
@@ -139,6 +141,7 @@ export async function buildParsedHostedChatRequest(input: {
     messages: messages as ChatUiMessage[],
     validatedContext: chatContext,
     projectId,
+    projectSlug,
     conversationId,
     parentRunId: durableRootRun?.runId,
     upstreamParentConversationId: durableRootRun?.parentConversationId,

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -145,6 +145,7 @@ describe("agent/hosted-chat-request", () => {
     assertEquals(request.context, {
       conversationId,
       projectId,
+      projectSlug: "demo-project",
       branchId,
     });
     assertEquals(request.durableRootRun, {
@@ -238,12 +239,34 @@ describe("agent/hosted-chat-request", () => {
     assertEquals(parsed.userId, userId);
     assertEquals(parsed.authToken, "token_1");
     assertEquals(parsed.projectId, projectId);
+    assertEquals(parsed.projectSlug, undefined);
     assertEquals(parsed.conversationId, conversationId);
     assertEquals(parsed.parentRunId, "run_root_1");
     assertEquals(parsed.upstreamParentConversationId, "10000000-1000-4000-8000-100000000007");
     assertEquals(parsed.upstreamParentRunId, "run_parent_1");
     assertEquals(parsed.spawnedFromToolCallId, "tool_1");
     assertEquals(parsed.persistLatestUserMessageBeforeDurableRun, false);
+  });
+
+  it("preserves project slug when parsing runtime agent invocation hosted chat requests", async () => {
+    const parsed = await parseRuntimeAgentRunInvocationHostedChatRequestFromRequest(
+      new Request("https://agent.example.com/api/runs", {
+        method: "POST",
+        body: JSON.stringify(createRuntimeInvocation()),
+      }),
+      {
+        authenticate: () => Promise.resolve({ userId, authToken: "token_1" }),
+        verifyProjectAccess: () => Promise.resolve({ success: true }),
+      },
+    );
+
+    if (parsed instanceof Response) {
+      throw new Error("Expected parsed request");
+    }
+
+    assertEquals(parsed.projectId, projectId);
+    assertEquals(parsed.projectSlug, "demo-project");
+    assertEquals(parsed.validatedContext.projectSlug, "demo-project");
   });
 
   it("returns hosted chat project-access errors as stable JSON responses", async () => {

--- a/src/agent/hosted/chat-request.ts
+++ b/src/agent/hosted/chat-request.ts
@@ -134,6 +134,7 @@ export function buildHostedChatRequestInputFromRuntimeAgentInvocation(
     context: {
       conversationId: input.run.conversationId,
       projectId: input.run.project.projectId,
+      projectSlug: input.run.project.projectSlug,
       branchId: input.run.project.runtimeTargetBranchId ?? null,
       ...(environmentContext ? { environmentContext } : {}),
     },

--- a/src/agent/hosted/cloud-chat-execution-preparation.test.ts
+++ b/src/agent/hosted/cloud-chat-execution-preparation.test.ts
@@ -41,6 +41,7 @@ function createRuntimeAgent(): HostedChatRuntimeAgent {
 
 function createRequest(): ParsedHostedChatRequest {
   return {
+    agentId: undefined,
     userId: "user-1",
     authToken: "auth-token",
     messages: [

--- a/src/agent/hosted/context-summary-generator.test.ts
+++ b/src/agent/hosted/context-summary-generator.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import type { ModelRuntime } from "#veryfront/provider";
+import { getCurrentVeryfrontCloudContext } from "#veryfront/provider/veryfront-cloud/context.ts";
 import type { RuntimeGenerateTextResult } from "../runtime/runtime-tool-types.ts";
 import { createVeryfrontCloudContextSummaryGenerator } from "./context-summary-generator.ts";
 
@@ -14,10 +15,11 @@ function createModel(): ModelRuntime {
 
 Deno.test("createVeryfrontCloudContextSummaryGenerator rolls oversized history through bounded summaries", async () => {
   const prompts: string[] = [];
+  const projectSlugs: Array<string | undefined> = [];
   const generator = createVeryfrontCloudContextSummaryGenerator({
     apiUrl: "https://api.example.com",
     authToken: "token-1",
-    projectId: "project-1",
+    projectSlug: "demo-project",
     model: "openai/gpt-5.2",
     maxOutputTokens: 500,
     maxInputTokens: 40,
@@ -26,6 +28,7 @@ Deno.test("createVeryfrontCloudContextSummaryGenerator rolls oversized history t
       return createModel();
     },
     generateText: (options): PromiseLike<RuntimeGenerateTextResult> => {
+      projectSlugs.push(getCurrentVeryfrontCloudContext()?.projectSlug);
       const message = options.messages.find((candidate) => candidate.role === "user");
       prompts.push(typeof message?.content === "string" ? message.content : "");
       return Promise.resolve({
@@ -73,4 +76,68 @@ Deno.test("createVeryfrontCloudContextSummaryGenerator rolls oversized history t
   assertEquals(prompts[1]?.includes("Existing summary to update:\nsummary-1"), true);
   assertEquals(prompts[2]?.includes("Existing summary to update:\nsummary-2"), true);
   assertEquals(prompts[0]?.includes("Keep project constraints."), true);
+  assertEquals(projectSlugs, ["demo-project", "demo-project", "demo-project"]);
+});
+
+Deno.test("createVeryfrontCloudContextSummaryGenerator redacts sensitive tool data before summarization", async () => {
+  let prompt = "";
+  const generator = createVeryfrontCloudContextSummaryGenerator({
+    apiUrl: "https://api.example.com",
+    authToken: "token-1",
+    model: "openai/gpt-5.2",
+    maxOutputTokens: 500,
+    maxInputTokens: 1_000,
+    resolveModel: () => createModel(),
+    generateText: (options): PromiseLike<RuntimeGenerateTextResult> => {
+      const message = options.messages.find((candidate) => candidate.role === "user");
+      prompt = typeof message?.content === "string" ? message.content : "";
+      return Promise.resolve({
+        text: "safe summary",
+        usage: { inputTokens: 1, outputTokens: 1 },
+        finishReason: "stop",
+      });
+    },
+  });
+
+  await generator({
+    messagesToSummarize: [
+      {
+        id: "message-1",
+        role: "assistant",
+        timestamp: 1,
+        parts: [
+          {
+            type: "tool-call",
+            toolName: "call_api",
+            toolCallId: "tool-1",
+            args: {
+              authorization: "Bearer secret-token",
+              query: "status",
+              url: "https://api.example.test/path?access_token=query-secret",
+            },
+          },
+          {
+            type: "tool-result",
+            toolName: "call_api",
+            toolCallId: "tool-1",
+            result: {
+              ok: true,
+              access_token: "secret-access-token",
+              output: "Fetched postgres://user:password@db.example.test:5432/app",
+            },
+          },
+        ],
+      },
+    ],
+    retainedMessages: [],
+  });
+
+  assertEquals(prompt.includes("secret-token"), false);
+  assertEquals(prompt.includes("secret-access-token"), false);
+  assertEquals(prompt.includes("query-secret"), false);
+  assertEquals(prompt.includes("password"), false);
+  assertEquals(prompt.includes("[REDACTED]"), true);
+  assertEquals(prompt.includes("access_token=[REDACTED]"), true);
+  assertEquals(prompt.includes("postgres://user:[REDACTED]@db.example.test:5432/app"), true);
+  assertEquals(prompt.includes('"query":"status"'), true);
 });

--- a/src/agent/hosted/context-summary-generator.ts
+++ b/src/agent/hosted/context-summary-generator.ts
@@ -6,6 +6,7 @@ import {
   runWithVeryfrontCloudContextAsync,
 } from "../../provider/index.ts";
 import { generateText } from "../../runtime/runtime-bridge.ts";
+import { redactSensitive, sanitizeUrlCredentials } from "#veryfront/utils/logger/redact.ts";
 import type { TextGenerationRuntimeMessage } from "../runtime/text-generation-runtime-message-types.ts";
 import type { AgentRuntimeMessage, AgentRuntimeMessagePart } from "../runtime/message-adapter.ts";
 import type { ContextSummaryGenerator } from "./context-budget-manager.ts";
@@ -20,7 +21,7 @@ type ResolveModelFunction = typeof resolveModel;
 export type VeryfrontCloudContextSummaryGeneratorOptions = {
   apiUrl: string | URL;
   authToken: string;
-  projectId?: string | null;
+  projectSlug?: string | null;
   model?: string;
   maxOutputTokens: number;
   maxInputTokens: number;
@@ -39,7 +40,11 @@ function truncateText(text: string, maxCharacters: number): string {
 
 function stringifyUnknown(value: unknown): string {
   try {
-    return JSON.stringify(value);
+    return JSON.stringify(
+      redactSensitive(value),
+      (_key, candidate) =>
+        typeof candidate === "string" ? sanitizeUrlCredentials(candidate) : candidate,
+    );
   } catch {
     return "[unserializable]";
   }
@@ -162,7 +167,7 @@ async function summarizeSegment(input: {
     {
       apiBaseUrl: input.options.apiUrl.toString(),
       apiToken: input.options.authToken,
-      projectSlug: input.options.projectId ?? undefined,
+      projectSlug: input.options.projectSlug ?? undefined,
       serviceLayer: "cloud",
     },
     () =>

--- a/src/agent/hosted/durable-chat-run-start.test.ts
+++ b/src/agent/hosted/durable-chat-run-start.test.ts
@@ -22,6 +22,7 @@ function createParsedRequest(
 ): ParsedHostedChatRequest {
   const conversationId = crypto.randomUUID();
   return {
+    agentId: undefined,
     userId: "user-1",
     authToken: "token-1",
     messages: [userMessage],

--- a/src/agent/hosted/veryfront-cloud-agent-service.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.ts
@@ -846,7 +846,7 @@ function createHostedChatContextBudgetOptions(
     summaryGenerator: createVeryfrontCloudContextSummaryGenerator({
       apiUrl: config.VERYFRONT_API_URL,
       authToken: req.authToken,
-      projectId: req.projectId,
+      projectSlug: req.projectSlug,
       model: config.VERYFRONT_CONTEXT_COMPACTION_SUMMARY_MODEL ?? agentConfig.model,
       maxOutputTokens: config.VERYFRONT_CONTEXT_COMPACTION_MAX_SUMMARY_TOKENS,
       maxInputTokens: config.VERYFRONT_CONTEXT_COMPACTION_SUMMARY_INPUT_TOKENS,

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -2,7 +2,11 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createMockResult, createSSECollector } from "./chat-stream-handler.test-helpers.ts";
-import { createStreamState, processStream } from "./chat-stream-handler.ts";
+import {
+  createStreamState,
+  processStream,
+  summarizeProviderToolDebugValue,
+} from "./chat-stream-handler.ts";
 
 function emptyAsyncIterable() {
   return {
@@ -30,6 +34,32 @@ function pendingAsyncIterable() {
 }
 
 describe("chat-stream-handler", () => {
+  describe("summarizeProviderToolDebugValue", () => {
+    it("redacts sensitive provider tool debug fields", () => {
+      assertEquals(
+        summarizeProviderToolDebugValue({
+          query: "Swedish tax residency",
+          authorization: "Bearer secret-token",
+          nested: { apiKey: "sk-secret" },
+        }),
+        {
+          query: "Swedish tax residency",
+          authorization: "[REDACTED]",
+          nested: { apiKey: "[REDACTED]" },
+        },
+      );
+    });
+
+    it("sanitizes URL credentials in provider tool debug errors", () => {
+      const error = new Error("GET https://example.test/path?access_token=secret failed");
+      const summary = summarizeProviderToolDebugValue(error) as { message: string; stack: string };
+
+      assertEquals(summary.message.includes("secret"), false);
+      assertEquals(summary.message.includes("access_token=[REDACTED]"), true);
+      assertEquals(summary.stack.includes("access_token=secret"), false);
+    });
+  });
+
   describe("createStreamState", () => {
     it("returns a clean initial state", () => {
       const state = createStreamState();

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -22,6 +22,11 @@ import { isAnyDebugEnabled } from "#veryfront/utils/constants/env.ts";
 import { setActiveSpanAttributes, withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { stringifyToolError, throwIfAborted } from "./error-utils.ts";
+import {
+  redactSensitive,
+  sanitizeSerializedError,
+  sanitizeUrlCredentials,
+} from "#veryfront/utils/logger/redact.ts";
 
 const logger = serverLogger.component("agent");
 const LOCAL_TOOL_COMMIT_GRACE_MS = 250;
@@ -91,20 +96,21 @@ function tryParseToolInputObject(input: string): Record<string, unknown> | null 
   }
 }
 
-function summarizeDebugValue(value: unknown): unknown {
+export function summarizeProviderToolDebugValue(value: unknown): unknown {
   if (value instanceof Error) {
-    return {
+    return sanitizeSerializedError({
       name: value.name,
       message: value.message,
       stack: value.stack,
-    };
+    });
   }
 
   if (typeof value === "string") {
-    return value.length > 500 ? `${value.slice(0, 500)}…` : value;
+    const safe = sanitizeUrlCredentials(value);
+    return safe.length > 500 ? `${safe.slice(0, 500)}…` : safe;
   }
 
-  return value;
+  return redactSensitive(value);
 }
 
 function resolveToolResultOutput(part: RuntimeStreamPart): unknown {
@@ -160,9 +166,9 @@ function logProviderToolPart(
     outputType: typeof part.output,
     errorType: typeof part.error,
     inputType: typeof part.input,
-    output: summarizeDebugValue(part.output),
-    error: summarizeDebugValue(part.error),
-    input: summarizeDebugValue(part.input),
+    output: summarizeProviderToolDebugValue(part.output),
+    error: summarizeProviderToolDebugValue(part.error),
+    input: summarizeProviderToolDebugValue(part.input),
   });
 }
 

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -330,6 +330,7 @@ export const getChatRequestContextSchema = defineSchema((v) =>
   v.object({
     conversationId: v.string().optional(),
     projectId: v.string().nullable(),
+    projectSlug: v.string().optional(),
     branchId: v.string().nullable(),
     environmentContext: v.string().optional(),
   }).strict()


### PR DESCRIPTION
## Summary
- carry hosted runtime project slugs through chat request creation and parsing
- scope hosted context summaries with the project slug instead of a UUID-shaped project id
- redact sensitive tool inputs/results before context summary prompts and provider-tool debug metadata

## Verification
- deno test --no-check --allow-all src/agent/hosted/ag-ui-chat-request.test.ts src/agent/hosted/chat-request.test.ts src/agent/hosted/context-summary-generator.test.ts src/agent/runtime/chat-stream-handler.test.ts
- deno check src/agent/hosted/context-summary-generator.ts src/agent/hosted/chat-request.ts src/agent/hosted/chat-request-parser.ts src/agent/runtime/chat-stream-handler.ts src/chat/types.ts
- deno test --no-check --allow-all src/agent/hosted src/agent/runtime src/tool src/chat
- deno test --no-check --allow-all --unstable-worker-options --parallel '--ignore=tests,src/workflow/__tests__,cli/commands/*.integration.test.ts'
- deno check src/agent/hosted/chat-request-parser.ts src/agent/hosted/cloud-chat-execution-preparation.test.ts src/agent/hosted/chat-preparation.test.ts src/agent/hosted/durable-chat-run-start.test.ts
- deno test --no-check --allow-all src/agent/hosted/ag-ui-chat-request.test.ts src/agent/hosted/chat-request.test.ts src/agent/hosted/context-summary-generator.test.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/hosted/cloud-chat-execution-preparation.test.ts src/agent/hosted/durable-chat-run-start.test.ts
- deno fmt --check src/chat/types.ts src/agent/hosted/chat-request.ts src/agent/hosted/chat-request-parser.ts src/agent/hosted/veryfront-cloud-agent-service.ts src/agent/hosted/context-summary-generator.ts src/agent/runtime/chat-stream-handler.ts src/agent/hosted/ag-ui-chat-request.test.ts src/agent/hosted/chat-request.test.ts src/agent/hosted/context-summary-generator.test.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/hosted/cloud-chat-execution-preparation.test.ts src/agent/hosted/durable-chat-run-start.test.ts
- git diff --check
- deno task docs:validate
- pre-push hook: format, lint, type check, test