### PR TITLE
Fix provider tool finalization

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.673",
+  "version": "0.1.674",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted/chat-execution-runtime.test.ts
+++ b/src/agent/hosted/chat-execution-runtime.test.ts
@@ -695,6 +695,58 @@ describe("agent/hosted-chat-execution-runtime", () => {
     assertEquals(terminalStates, [{ status: "completed" }]);
   });
 
+  it("completes response finalization with provider-owned tool input still open", async () => {
+    let streamOptions: HostedChatRuntimeToUiMessageStreamOptions | undefined;
+    const terminalStates: HostedLifecycleTerminalState[] = [];
+    const runtime = createHostedChatExecutionRuntime({
+      agentId: "agent-1",
+      modelId: "anthropic/claude-sonnet-4-5-20250929",
+      originalMessages: [],
+      runContext: { withContext: (fn) => fn() },
+      abortSignal: new AbortController().signal,
+      bootstrap: {
+        cleanup: async () => {},
+        lifecycleAdapter: createLifecycleAdapter({ terminalStates }),
+        rootStreamWatchdog: createRootStreamWatchdog(),
+        streamResult: createStreamResult({
+          finalStep: {},
+          captureOptions: (options) => {
+            streamOptions = options;
+          },
+        }),
+        streamingMessageId: "stream-message-1",
+        capturedMessageId: "stream-message-1",
+        capturedConversationId: "conversation-1",
+        mirroredToolChunkState: createMirroredToolChunkState(),
+      },
+    });
+    if (!streamOptions) {
+      throw new Error("stream options were not captured");
+    }
+
+    await streamOptions.onFinish?.({
+      messages: [],
+      isContinuation: false,
+      responseMessage: createResponseMessage({
+        parts: [
+          { type: "text", text: "done" },
+          {
+            type: "tool-web_fetch",
+            toolCallId: "srvtoolu-fetch",
+            input: { url: "https://example.com/docs" },
+            state: "input-available",
+            providerExecuted: true,
+          },
+        ],
+      }),
+      isAborted: false,
+      finishReason: "stop",
+    });
+    await runtime.waitForFinish();
+
+    assertEquals(terminalStates, [{ status: "completed" }]);
+  });
+
   it("records stream errors before detached finalization fallback", async () => {
     let streamOptions: HostedChatRuntimeToUiMessageStreamOptions | undefined;
     const terminalStates: HostedLifecycleTerminalState[] = [];

--- a/src/agent/hosted/finalized-message.test.ts
+++ b/src/agent/hosted/finalized-message.test.ts
@@ -25,6 +25,40 @@ Deno.test("buildFinalizedMessageState builds fallback parts for an empty finaliz
   assertEquals(result.hasIncompleteFinalizedToolParts, false);
 });
 
+Deno.test("buildFinalizedMessageState does not fail provider-owned input-available tools", () => {
+  const result = buildFinalizedMessageState({
+    responseMessage: {
+      id: "assistant-1",
+      role: "assistant",
+      parts: [
+        { type: "text", text: "Done" },
+        {
+          type: "tool-web_fetch",
+          toolCallId: "srvtoolu-fetch",
+          input: { url: "https://example.com/docs" },
+          state: "input-available",
+          providerExecuted: true,
+        },
+      ],
+    },
+    isAborted: false,
+    finalStep: { text: "Done" },
+    incompleteToolCallsPartErrorText: "tool error",
+  });
+
+  assertEquals(result.hasIncompleteFinalizedToolParts, false);
+  assertEquals(result.sanitizedFinalizedMessage.parts, [
+    { type: "text", text: "Done" },
+    {
+      type: "tool-web_fetch",
+      toolCallId: "srvtoolu-fetch",
+      input: { url: "https://example.com/docs" },
+      state: "input-available",
+      providerExecuted: true,
+    },
+  ]);
+});
+
 Deno.test("buildDetachedFallbackMessageState uses the captured message id for detached fallback messages", () => {
   const result = buildDetachedFallbackMessageState({
     capturedMessageId: "captured-1",

--- a/src/chat/conversation.test.ts
+++ b/src/chat/conversation.test.ts
@@ -155,6 +155,42 @@ describe("chat/conversation helpers", () => {
     ]);
   });
 
+  it("treats provider-owned input-available tools as complete", () => {
+    const message: ChatUiMessage = {
+      id: "assistant-provider-owned-tool",
+      role: "assistant",
+      parts: [
+        { type: "text", text: "I can answer with the fetched context." },
+        {
+          type: "tool-web_fetch",
+          toolCallId: "srvtoolu-fetch",
+          input: { url: "https://example.com/docs" },
+          state: "input-available",
+          providerExecuted: true,
+        },
+      ],
+    };
+
+    assertEquals(hasIncompleteToolParts(message), false);
+    assertEquals(markIncompleteToolPartsAsErrored(message, "Tool call did not complete"), message);
+    assertEquals(toConversationPartsFromUiMessage(message), [
+      { type: "text", text: "I can answer with the fetched context." },
+      {
+        type: "tool_call",
+        id: "srvtoolu-fetch",
+        name: "web_fetch",
+        input: { url: "https://example.com/docs" },
+        state: "completed",
+      },
+      {
+        type: "tool_result",
+        tool_call_id: "srvtoolu-fetch",
+        output: null,
+        is_error: false,
+      },
+    ]);
+  });
+
   it("maps UI messages into persistable conversation parts", () => {
     const message: ChatUiMessage = {
       id: "assistant-2",

--- a/src/chat/conversation.ts
+++ b/src/chat/conversation.ts
@@ -308,11 +308,14 @@ export function pushToolParts(
     input?: unknown;
     output?: unknown;
     errorText?: unknown;
+    providerExecuted?: unknown;
   },
 ): void {
   const input = toRecord(part.input);
   const isErroredState = state === "output-error" || state === "error" || state === "output-denied";
-  const hasResultState = state === "output-available" || state === "completed" || isErroredState;
+  const isProviderOwnedAvailable = part.providerExecuted === true && state === "input-available";
+  const hasResultState = state === "output-available" || state === "completed" ||
+    isErroredState || isProviderOwnedAvailable;
 
   if (hasResultState) {
     parts.push({
@@ -325,6 +328,8 @@ export function pushToolParts(
 
     const resultOutput = isErroredState
       ? part.output ?? part.errorText ?? "Tool error"
+      : isProviderOwnedAvailable
+      ? null
       : part.output ?? null;
     parts.push({
       type: "tool_result",
@@ -438,6 +443,10 @@ export function toConversationPartsFromUiMessage(message: ChatUiMessage): Messag
 }
 
 function isToolComplete(part: ToolUiPart): boolean {
+  if (part.providerExecuted === true && part.state === "input-available") {
+    return true;
+  }
+
   return part.state === "output-available" || part.state === "output-error" ||
     part.state === "output-denied" || part.state === "completed" ||
     part.state === "error";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.673";
+export const VERSION = "0.1.674";


### PR DESCRIPTION
## Summary
- treat provider-owned tool calls handed off to the model provider as complete for hosted finalization
- persist provider-owned input-available tool calls as completed with a null provider result instead of a fake incomplete-tool error
- bump package version to 0.1.674 for release

## Verification
- deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/chat/conversation.test.ts src/agent/hosted/finalized-message.test.ts src/agent/hosted/chat-execution-runtime.test.ts
- deno task typecheck
- deno task test:unit
- pre-push: fmt, lint, typecheck, test:unit