### PR TITLE
Restore HubSpot OAuth installability

### DIFF
--- a/cli/templates/integrations/hubspot/connector.json
+++ b/cli/templates/integrations/hubspot/connector.json
@@ -18,7 +18,6 @@
       "crm.objects.companies.write",
       "crm.schemas.contacts.read",
       "crm.schemas.companies.read",
-      "crm.schemas.leads.read",
       "crm.objects.owners.read",
       "forms"
     ],

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.675",
+  "version": "0.1.676",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/integrations/_data.test.ts
+++ b/src/integrations/_data.test.ts
@@ -119,7 +119,7 @@ describe("integration endpoint specs", () => {
     assertEquals(hubspot.auth.scopes?.includes("crm.objects.companies.write"), true);
     assertEquals(hubspot.auth.scopes?.includes("crm.schemas.contacts.read"), true);
     assertEquals(hubspot.auth.scopes?.includes("crm.schemas.companies.read"), true);
-    assertEquals(hubspot.auth.scopes?.includes("crm.schemas.leads.read"), true);
+    assertEquals(hubspot.auth.scopes?.includes("crm.schemas.leads.read"), false);
     assertEquals(hubspot.auth.scopes?.includes("crm.objects.owners.read"), true);
     assertEquals(hubspot.auth.scopes?.includes("forms"), true);
     assertEquals(toolIds.includes("get_contact"), true);

--- a/src/integrations/_data.ts
+++ b/src/integrations/_data.ts
@@ -5420,7 +5420,6 @@ export const connectors: IntegrationConfig[] = [
         "crm.objects.companies.write",
         "crm.schemas.contacts.read",
         "crm.schemas.companies.read",
-        "crm.schemas.leads.read",
         "crm.objects.owners.read",
         "forms",
       ],

--- a/src/oauth/providers/common.ts
+++ b/src/oauth/providers/common.ts
@@ -132,7 +132,6 @@ export const hubspotConfig: OAuthServiceConfig = {
     "crm.objects.companies.write",
     "crm.schemas.contacts.read",
     "crm.schemas.companies.read",
-    "crm.schemas.leads.read",
     "crm.objects.owners.read",
     "forms",
   ],

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.675";
+export const VERSION = "0.1.676";


### PR DESCRIPTION
## Summary
- remove invalid HubSpot OAuth scope `crm.schemas.leads.read`
- keep lead object read/write scopes for lead tools
- bump package to 0.1.676

## Verification
- `deno test --no-check --allow-all src/integrations/_data.test.ts src/oauth/providers/common.test.ts src/utils/version.test.ts`
- `deno task fmt:check`
- `deno task generate:manifests:check`
- `deno lint cli/templates/integration-loader.ts src/integrations/_data.test.ts src/oauth/providers/common.ts src/utils/version-constant.ts`
- pre-commit `deno task verify:quick`
