### PR TITLE
Keep HubSpot lead scopes optional

### DIFF
--- a/cli/templates/integrations/hubspot/connector.json
+++ b/cli/templates/integrations/hubspot/connector.json
@@ -12,14 +12,16 @@
     "scopes": [
       "crm.objects.contacts.read",
       "crm.objects.contacts.write",
-      "crm.objects.leads.read",
-      "crm.objects.leads.write",
       "crm.objects.companies.read",
       "crm.objects.companies.write",
       "crm.schemas.contacts.read",
       "crm.schemas.companies.read",
       "crm.objects.owners.read",
       "forms"
+    ],
+    "optionalScopes": [
+      "crm.objects.leads.read",
+      "crm.objects.leads.write"
     ],
     "callbackPath": "/oauth/callback/hubspot",
     "tokenAuthMethod": "request_body",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.676",
+  "version": "0.1.677",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/integrations/_data.test.ts
+++ b/src/integrations/_data.test.ts
@@ -113,8 +113,10 @@ describe("integration endpoint specs", () => {
     assertEquals(hubspot.auth.provider, "hubspot");
     assertEquals(hubspot.auth.scopes?.includes("crm.objects.contacts.read"), true);
     assertEquals(hubspot.auth.scopes?.includes("crm.objects.contacts.write"), true);
-    assertEquals(hubspot.auth.scopes?.includes("crm.objects.leads.read"), true);
-    assertEquals(hubspot.auth.scopes?.includes("crm.objects.leads.write"), true);
+    assertEquals(hubspot.auth.scopes?.includes("crm.objects.leads.read"), false);
+    assertEquals(hubspot.auth.scopes?.includes("crm.objects.leads.write"), false);
+    assertEquals(hubspot.auth.optionalScopes?.includes("crm.objects.leads.read"), true);
+    assertEquals(hubspot.auth.optionalScopes?.includes("crm.objects.leads.write"), true);
     assertEquals(hubspot.auth.scopes?.includes("crm.objects.companies.read"), true);
     assertEquals(hubspot.auth.scopes?.includes("crm.objects.companies.write"), true);
     assertEquals(hubspot.auth.scopes?.includes("crm.schemas.contacts.read"), true);

--- a/src/integrations/_data.ts
+++ b/src/integrations/_data.ts
@@ -5414,8 +5414,6 @@ export const connectors: IntegrationConfig[] = [
       "scopes": [
         "crm.objects.contacts.read",
         "crm.objects.contacts.write",
-        "crm.objects.leads.read",
-        "crm.objects.leads.write",
         "crm.objects.companies.read",
         "crm.objects.companies.write",
         "crm.schemas.contacts.read",
@@ -5423,6 +5421,7 @@ export const connectors: IntegrationConfig[] = [
         "crm.objects.owners.read",
         "forms",
       ],
+      "optionalScopes": ["crm.objects.leads.read", "crm.objects.leads.write"],
       "tokenAuthMethod": "request_body",
       "supportsRefreshToken": true,
       "requiredApis": [{

--- a/src/integrations/schema.ts
+++ b/src/integrations/schema.ts
@@ -91,6 +91,7 @@ export const getOAuthConfigSchema = defineSchema((v) =>
     authorizationUrl: v.string().optional(),
     tokenUrl: v.string().optional(),
     scopes: v.array(v.string()).optional(),
+    optionalScopes: v.array(v.string()).optional(),
     callbackPath: v.string().optional(),
     tokenAuthMethod: v.string().optional(),
     pkce: v.boolean().optional(),

--- a/src/oauth/providers/common.test.ts
+++ b/src/oauth/providers/common.test.ts
@@ -30,6 +30,13 @@ async function readHubSpotConnectorScopes(): Promise<string[]> {
   return connector.auth.scopes;
 }
 
+async function readHubSpotConnectorOptionalScopes(): Promise<string[]> {
+  const connector = JSON.parse(
+    await Deno.readTextFile("cli/templates/integrations/hubspot/connector.json"),
+  ) as { auth: { optionalScopes: string[] } };
+  return connector.auth.optionalScopes;
+}
+
 describe("oauth provider configs", () => {
   it("does not expose removed Discord or Dropbox OAuth provider configs", () => {
     assertEquals("discord" in commonServices, false);
@@ -48,6 +55,10 @@ describe("oauth provider configs", () => {
 
   it("keeps the HubSpot runtime scopes aligned with the connector surface", async () => {
     assertEquals(hubspotConfig.defaultScopes, await readHubSpotConnectorScopes());
+    assertEquals(await readHubSpotConnectorOptionalScopes(), [
+      "crm.objects.leads.read",
+      "crm.objects.leads.write",
+    ]);
   });
 
   it("keeps Slack setup documentation aligned with runtime OAuth scopes", async () => {

--- a/src/oauth/providers/common.ts
+++ b/src/oauth/providers/common.ts
@@ -126,8 +126,6 @@ export const hubspotConfig: OAuthServiceConfig = {
   defaultScopes: [
     "crm.objects.contacts.read",
     "crm.objects.contacts.write",
-    "crm.objects.leads.read",
-    "crm.objects.leads.write",
     "crm.objects.companies.read",
     "crm.objects.companies.write",
     "crm.schemas.contacts.read",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.676";
+export const VERSION = "0.1.677";


### PR DESCRIPTION
## Summary\n- move HubSpot lead read/write permissions to connector optionalScopes\n- keep required HubSpot OAuth scopes aligned with the previously working app install URL\n- bump veryfront to 0.1.677 for API consumption\n\n## Validation\n- deno test --no-check --allow-all src/integrations/_data.test.ts src/oauth/providers/common.test.ts src/utils/version.test.ts\n- deno fmt --check targeted files\n- deno task generate:manifests:check\n- pre-commit deno task verify:quick