### PR TITLE
Match HubSpot required OAuth scopes

### DIFF
--- a/cli/templates/integrations/hubspot/connector.json
+++ b/cli/templates/integrations/hubspot/connector.json
@@ -10,8 +10,8 @@
     "authorizationUrl": "https://app.hubspot.com/oauth/authorize",
     "tokenUrl": "https://api.hubapi.com/oauth/v1/token",
     "scopes": [
-      "crm.objects.contacts.read",
-      "crm.objects.contacts.write"
+      "oauth",
+      "crm.objects.contacts.read"
     ],
     "optionalScopes": [
       "crm.objects.leads.read",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.678",
+  "version": "0.1.679",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/integrations/_data.test.ts
+++ b/src/integrations/_data.test.ts
@@ -111,8 +111,9 @@ describe("integration endpoint specs", () => {
     const toolIds = hubspot.tools.map((tool) => tool.id);
 
     assertEquals(hubspot.auth.provider, "hubspot");
+    assertEquals(hubspot.auth.scopes?.includes("oauth"), true);
     assertEquals(hubspot.auth.scopes?.includes("crm.objects.contacts.read"), true);
-    assertEquals(hubspot.auth.scopes?.includes("crm.objects.contacts.write"), true);
+    assertEquals(hubspot.auth.scopes?.includes("crm.objects.contacts.write"), false);
     assertEquals(hubspot.auth.scopes?.includes("crm.objects.leads.read"), false);
     assertEquals(hubspot.auth.scopes?.includes("crm.objects.leads.write"), false);
     assertEquals(hubspot.auth.optionalScopes?.includes("crm.objects.leads.read"), true);

--- a/src/integrations/_data.ts
+++ b/src/integrations/_data.ts
@@ -5411,7 +5411,7 @@ export const connectors: IntegrationConfig[] = [
       "provider": "hubspot",
       "authorizationUrl": "https://app.hubspot.com/oauth/authorize",
       "tokenUrl": "https://api.hubapi.com/oauth/v1/token",
-      "scopes": ["crm.objects.contacts.read", "crm.objects.contacts.write"],
+      "scopes": ["oauth", "crm.objects.contacts.read"],
       "optionalScopes": ["crm.objects.leads.read", "crm.objects.leads.write"],
       "tokenAuthMethod": "request_body",
       "supportsRefreshToken": true,

--- a/src/oauth/providers/common.ts
+++ b/src/oauth/providers/common.ts
@@ -124,8 +124,8 @@ export const hubspotConfig: OAuthServiceConfig = {
   clientSecretEnvVar: "HUBSPOT_CLIENT_SECRET",
   apiBaseUrl: "https://api.hubapi.com",
   defaultScopes: [
+    "oauth",
     "crm.objects.contacts.read",
-    "crm.objects.contacts.write",
   ],
 };
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.678";
+export const VERSION = "0.1.679";


### PR DESCRIPTION
## Summary
- change HubSpot install scopes to match the current HubSpot app config: oauth + crm.objects.contacts.read
- keep lead optional-scope metadata and tools visible without requesting them
- bump veryfront to 0.1.679

## Validation
- deno test --no-check --allow-all src/oauth/providers/common.test.ts src/integrations/_data.test.ts src/utils/version.test.ts
- deno task build:npm

## Context
The HubSpot Auth tab currently shows required scopes `oauth` and `crm.objects.contacts.read`. HubSpot rejects install URLs that omit required scopes or include unconfigured scopes, so `crm.objects.contacts.write` must not be requested until the app config includes it.