### PR TITLE
Release 0.1.682 chat final-answer rendering

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.681",
+  "version": "0.1.682",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/react/components/chat/README.md
+++ b/src/react/components/chat/README.md
@@ -318,6 +318,8 @@ export default function AgentChat() {
 
 ### Working with Chat Message Parts
 
+The built-in message renderer keeps raw message parts available, but assistant answer rendering prefers the final text emitted after tool activity. This prevents pre-tool progress narration from becoming part of the final visible answer while preserving tool calls and results for evidence, sources, and custom UI. Custom renderers should apply the same split when they present a final assistant answer.
+
 ```tsx
 import { Chat } from "veryfront/react";
 import { useChat } from "veryfront/agent/react";

--- a/src/react/components/chat/chat/composition/message.tsx
+++ b/src/react/components/chat/chat/composition/message.tsx
@@ -44,7 +44,8 @@ import type { Source } from "../components/sources.tsx";
 import { ModelAvatar as AvatarImpl } from "./model-avatar.tsx";
 import {
   extractSourcesFromParts,
-  getTextContent,
+  getAnswerPartsForRendering,
+  getTextContentFromParts,
   groupPartsInOrder,
   isSkillToolPart,
 } from "../utils/message-parts.ts";
@@ -75,8 +76,12 @@ const MessageRoot = React.forwardRef<HTMLDivElement, MessageRootProps>(
   ) {
     const chat = useChatContextOptional();
     const role = message.role as MessageContextValue["role"];
-    const parts = React.useMemo(() => groupPartsInOrder(message.parts), [message.parts]);
-    const textContent = React.useMemo(() => getTextContent(message), [message]);
+    const answerParts = React.useMemo(
+      () => getAnswerPartsForRendering(message.parts, { isAssistant: role !== "user" }),
+      [message.parts, role],
+    );
+    const parts = React.useMemo(() => groupPartsInOrder(answerParts), [answerParts]);
+    const textContent = React.useMemo(() => getTextContentFromParts(answerParts), [answerParts]);
 
     const editMessage = overrides.editMessage ?? chat?.editMessage;
     const getBranches = overrides.getBranches ?? chat?.getBranches;

--- a/src/react/components/chat/chat/utils/message-parts.test.ts
+++ b/src/react/components/chat/chat/utils/message-parts.test.ts
@@ -1,7 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { getTextContent, groupPartsInOrder, isReasoningPart, isToolPart } from "./message-parts.ts";
+import {
+  getAnswerPartsForRendering,
+  getTextContent,
+  groupPartsInOrder,
+  isReasoningPart,
+  isToolPart,
+} from "./message-parts.ts";
 import type { ChatMessage, ChatMessagePart } from "#veryfront/agent/react";
 
 function makeMessage(parts: ChatMessagePart[]): ChatMessage {
@@ -177,6 +183,72 @@ describe("message-parts", () => {
 
     it("handles empty parts array", () => {
       assertEquals(groupPartsInOrder([]).length, 0);
+    });
+  });
+
+  describe("getAnswerPartsForRendering", () => {
+    it("uses the post-tool text as the assistant answer while preserving tool cards", () => {
+      const parts: ChatMessagePart[] = [
+        { type: "text", text: "I'll check the current queue." },
+        {
+          type: "tool-search",
+          toolCallId: "tc1",
+          toolName: "search",
+          state: "input-available",
+          input: {},
+        },
+        { type: "tool-result", toolCallId: "tc1", toolName: "search", result: {} },
+        { type: "text", text: "I found one urgent incident." },
+        {
+          type: "tool-search",
+          toolCallId: "tc2",
+          toolName: "search",
+          state: "input-available",
+          input: {},
+        },
+        { type: "tool-result", toolCallId: "tc2", toolName: "search", result: {} },
+        { type: "text", text: "Selected INC-2026-0714 for triage." },
+      ];
+
+      const answerParts = getAnswerPartsForRendering(parts, { isAssistant: true });
+
+      assertEquals(
+        answerParts.map((part) => part.type),
+        ["tool-search", "tool-result", "tool-search", "tool-result", "text"],
+      );
+      assertEquals(getTextContent(makeMessage(answerParts)), "Selected INC-2026-0714 for triage.");
+    });
+
+    it("keeps assistant progress text when no final answer exists yet", () => {
+      const parts: ChatMessagePart[] = [
+        { type: "text", text: "I'll inspect the incident first." },
+        {
+          type: "tool-search",
+          toolCallId: "tc1",
+          toolName: "search",
+          state: "input-available",
+          input: {},
+        },
+        { type: "tool-result", toolCallId: "tc1", toolName: "search", result: {} },
+      ];
+
+      assertEquals(getAnswerPartsForRendering(parts, { isAssistant: true }), parts);
+    });
+
+    it("does not rewrite user text around tool-shaped attachments", () => {
+      const parts: ChatMessagePart[] = [
+        { type: "text", text: "Use this payload." },
+        {
+          type: "tool-search",
+          toolCallId: "tc1",
+          toolName: "search",
+          state: "input-available",
+          input: {},
+        },
+        { type: "text", text: "Keep both text parts." },
+      ];
+
+      assertEquals(getAnswerPartsForRendering(parts, { isAssistant: false }), parts);
     });
   });
 });

--- a/src/react/components/chat/chat/utils/message-parts.ts
+++ b/src/react/components/chat/chat/utils/message-parts.ts
@@ -13,9 +13,14 @@ import type { Source } from "../components/sources.tsx";
 
 /** Get text content from chat message parts */
 export function getTextContent(message: ChatMessage): string {
+  return getTextContentFromParts(message.parts);
+}
+
+/** Get text content from a list of chat message parts. */
+export function getTextContentFromParts(parts: ChatMessagePart[]): string {
   let text = "";
 
-  for (const part of message.parts) {
+  for (const part of parts) {
     if (part.type === "text") text += part.text;
   }
 
@@ -26,6 +31,39 @@ export function getTextContent(message: ChatMessage): string {
 export function isToolPart(part: ChatMessagePart): part is ChatToolPart | ChatDynamicToolPart {
   if (part.type === "dynamic-tool") return true;
   return part.type.startsWith("tool-") && part.type !== "tool-result";
+}
+
+function isToolEvidencePart(part: ChatMessagePart): boolean {
+  return isToolPart(part) || part.type === "tool-result";
+}
+
+function isNonEmptyTextPart(part: ChatMessagePart): boolean {
+  return part.type === "text" && part.text.trim().length > 0;
+}
+
+/**
+ * Select assistant answer parts for client rendering.
+ * Tool evidence remains available, while pre-tool progress text is hidden
+ * once a final post-tool answer is present.
+ */
+export function getAnswerPartsForRendering(
+  parts: ChatMessagePart[],
+  options: { isAssistant: boolean },
+): ChatMessagePart[] {
+  if (!options.isAssistant) return parts;
+
+  let lastToolIndex = -1;
+  for (let index = 0; index < parts.length; index += 1) {
+    const part = parts[index];
+    if (part && isToolEvidencePart(part)) lastToolIndex = index;
+  }
+
+  if (lastToolIndex === -1) return parts;
+
+  const hasFinalText = parts.slice(lastToolIndex + 1).some(isNonEmptyTextPart);
+  if (!hasFinalText) return parts;
+
+  return parts.filter((part, index) => part.type !== "text" || index > lastToolIndex);
 }
 
 const SKILL_TOOL_NAMES: ReadonlySet<string> = new Set([

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.681";
+export const VERSION = "0.1.682";


### PR DESCRIPTION
## Summary
- Patches deno.json and version constant to 0.1.682.
- Adds shared chat message-part utilities that render final assistant answers after tool activity while retaining tool evidence.
- Documents the raw-parts versus rendered-answer behavior.

## Verification
- deno test --no-check --allow-all src/react/components/chat/chat/utils/message-parts.test.ts src/utils/version.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts src/react/components/chat/chat/utils/message-parts.ts src/react/components/chat/chat/utils/message-parts.test.ts src/react/components/chat/chat/composition/message.tsx src/react/components/chat/README.md
- deno check src/react/components/chat/chat/utils/message-parts.ts src/react/components/chat/chat/utils/message-parts.test.ts src/react/components/chat/chat/composition/message.tsx src/utils/version.ts src/utils/version-constant.ts
- git diff --check
- pre-push checks passed: 2,002 tests and 18,067 steps.