### PR TITLE
Hydrate current run state from persisted messages

### DIFF
--- a/src/agent/runtime/current-run-tool-state.test.ts
+++ b/src/agent/runtime/current-run-tool-state.test.ts
@@ -5,6 +5,7 @@ import {
   appendCurrentRunToolStateToSystemPrompt,
   createCurrentRunToolState,
   createToolInputFingerprint,
+  hydrateCurrentRunToolStateFromMessages,
   recordCurrentRunToolResult,
   summarizeToolResultForCurrentRunState,
 } from "./current-run-tool-state.ts";
@@ -198,6 +199,45 @@ describe("current-run tool state", () => {
     assert(!prompt.includes("Load open invoices"));
     assert(!prompt.includes("Load the open supplier invoice queue"));
     assert(!prompt.includes("call_1"));
+  });
+
+  it("hydrates prior tool calls and results from persisted run messages", () => {
+    const state = createCurrentRunToolState();
+
+    hydrateCurrentRunToolStateFromMessages(state, [
+      {
+        role: "assistant",
+        parts: [{
+          type: "tool-invoke_agent",
+          toolCallId: "invoke-ingest-1",
+          toolName: "invoke_agent",
+          args: {
+            agent_id: "ingest-invoice-agent",
+            input: "Load open supplier invoices",
+          },
+        }],
+      },
+      {
+        role: "tool",
+        parts: [{
+          type: "tool-result",
+          toolCallId: "invoke-ingest-1",
+          toolName: "invoke_agent",
+          result: {
+            status: "completed",
+            output: "Loaded supplier invoices",
+          },
+        }],
+      },
+    ], { now: new Date("2026-01-01T00:00:00.000Z") });
+
+    const prompt = appendCurrentRunToolStateToSystemPrompt("Base system", state);
+
+    assertStringIncludes(prompt, '<run_state current_run="true">');
+    assertStringIncludes(prompt, '"agent:ingest-invoice-agent"');
+    assertStringIncludes(prompt, '"invoke_agent:agent:ingest-invoice-agent"');
+    assert(!prompt.includes("Load open supplier invoices"));
+    assert(!prompt.includes("invoke-ingest-1"));
   });
 
   it("retains Gmail history delta arrays declared as object fields", () => {

--- a/src/agent/runtime/current-run-tool-state.ts
+++ b/src/agent/runtime/current-run-tool-state.ts
@@ -25,6 +25,11 @@ export type RecordCurrentRunToolResultInput = {
   now?: Date;
 };
 
+export type CurrentRunToolStateHydrationMessage = {
+  role?: string;
+  parts?: readonly unknown[];
+};
+
 const MAX_FALLBACK_ITEMS = 5;
 const MAX_FALLBACK_STRING_LENGTH = 300;
 const MAX_OBJECT_ARRAY_ITEMS = 5;
@@ -285,6 +290,105 @@ export function recordCurrentRunToolResult(
     updatedAt: (input.now ?? new Date()).toISOString(),
   };
   state[input.toolName] = toolBucket;
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function getToolCallInput(part: Record<string, unknown>): unknown {
+  if (isRecord(part.args)) return part.args;
+  if (isRecord(part.input)) return part.input;
+  if (typeof part.args === "string") return parseJsonRecord(part.args) ?? part.args;
+  if (typeof part.input === "string") return parseJsonRecord(part.input) ?? part.input;
+  if (typeof part.inputText === "string") return parseJsonRecord(part.inputText) ?? part.inputText;
+  return {};
+}
+
+function getToolResultValue(part: Record<string, unknown>): unknown {
+  if ("result" in part) return part.result;
+  if ("output" in part) return part.output;
+  return undefined;
+}
+
+function getToolCallIdentity(
+  part: unknown,
+): { toolCallId: string; toolName: string } | null {
+  if (!isRecord(part)) return null;
+
+  const toolCallId = typeof part.toolCallId === "string"
+    ? part.toolCallId
+    : typeof part.tool_call_id === "string"
+    ? part.tool_call_id
+    : typeof part.id === "string"
+    ? part.id
+    : null;
+  const toolName = typeof part.toolName === "string"
+    ? part.toolName
+    : typeof part.tool_name === "string"
+    ? part.tool_name
+    : typeof part.name === "string"
+    ? part.name
+    : null;
+
+  return toolCallId && toolName ? { toolCallId, toolName } : null;
+}
+
+function isToolCallPart(part: unknown): part is Record<string, unknown> {
+  if (!isRecord(part)) return false;
+  const type = typeof part.type === "string" ? part.type : "";
+  if (type === "tool-result" || type === "tool_result") return false;
+  if (type === "tool-call" || type === "tool_call" || type.startsWith("tool-")) {
+    return getToolCallIdentity(part) !== null;
+  }
+  return false;
+}
+
+function isToolResultLikePart(part: unknown): part is Record<string, unknown> {
+  if (!isRecord(part)) return false;
+  const type = typeof part.type === "string" ? part.type : "";
+  if (type !== "tool-result" && type !== "tool_result") return false;
+  return getToolCallIdentity(part) !== null && ("result" in part || "output" in part);
+}
+
+export function hydrateCurrentRunToolStateFromMessages(
+  state: CurrentRunToolState,
+  messages: readonly CurrentRunToolStateHydrationMessage[],
+  options?: { now?: Date },
+): void {
+  const toolCallInputs = new Map<string, { toolName: string; input: unknown }>();
+
+  for (const message of messages) {
+    for (const part of message.parts ?? []) {
+      if (isToolCallPart(part)) {
+        const identity = getToolCallIdentity(part);
+        if (!identity) continue;
+        toolCallInputs.set(identity.toolCallId, {
+          toolName: identity.toolName,
+          input: getToolCallInput(part),
+        });
+        continue;
+      }
+
+      if (!isToolResultLikePart(part)) continue;
+
+      const identity = getToolCallIdentity(part);
+      if (!identity) continue;
+      const call = toolCallInputs.get(identity.toolCallId);
+      recordCurrentRunToolResult(state, {
+        toolCallId: identity.toolCallId,
+        toolName: identity.toolName,
+        input: call?.input ?? {},
+        result: getToolResultValue(part),
+        now: options?.now,
+      });
+    }
+  }
 }
 
 export function hasCurrentRunToolState(state: CurrentRunToolState): boolean {

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -124,6 +124,7 @@ import {
   appendCurrentRunToolStateToSystemPrompt,
   createCurrentRunToolState,
   type CurrentRunToolState,
+  hydrateCurrentRunToolStateFromMessages,
   recordCurrentRunToolResult,
 } from "./current-run-tool-state.ts";
 import {
@@ -490,6 +491,26 @@ export function materializeStreamedToolCall(
 
 function isToolResultPart(part: MessagePart): part is ToolResultPart {
   return part.type === "tool-result" && "result" in part;
+}
+
+function hydrateActiveSkillStateFromMessages(
+  messages: readonly Message[],
+): {
+  activeSkillPolicy: string[] | undefined;
+  activeSkillDelegationOverrides: SkillDelegationOverrides | undefined;
+} {
+  let activeSkillPolicy: string[] | undefined;
+  let activeSkillDelegationOverrides: SkillDelegationOverrides | undefined;
+
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (!isToolResultPart(part) || part.toolName !== LOAD_SKILL_TOOL_ID) continue;
+      activeSkillPolicy = extractSkillPolicy(part.result);
+      activeSkillDelegationOverrides = extractSkillDelegationOverrides(part.result);
+    }
+  }
+
+  return { activeSkillPolicy, activeSkillDelegationOverrides };
 }
 
 /**
@@ -921,6 +942,7 @@ export class AgentRuntime {
       const toolCalls: ToolCall[] = [];
       const currentMessages = [...messages];
       const currentRunToolState = createCurrentRunToolState();
+      hydrateCurrentRunToolStateFromMessages(currentRunToolState, currentMessages);
       const totalUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
 
       // Local models can't reliably do function calling — skip tools gracefully.
@@ -930,8 +952,9 @@ export class AgentRuntime {
       }
 
       // Request-scoped skill policy (not class-level mutable state)
-      let activeSkillPolicy: string[] | undefined;
-      let activeSkillDelegationOverrides: SkillDelegationOverrides | undefined;
+      const hydratedSkillState = hydrateActiveSkillStateFromMessages(currentMessages);
+      let activeSkillPolicy = hydratedSkillState.activeSkillPolicy;
+      let activeSkillDelegationOverrides = hydratedSkillState.activeSkillDelegationOverrides;
       const allowedRemoteToolNames = getRuntimeAllowedRemoteTools(this.config);
       const providerTools = getRuntimeProviderTools(this.config);
       const forwardedRemoteToolDefinitions = getRuntimeForwardedIntegrationToolDefs(this.config);
@@ -1255,6 +1278,7 @@ export class AgentRuntime {
     const toolCalls: ToolCall[] = [];
     const currentMessages = [...messages];
     const currentRunToolState = createCurrentRunToolState();
+    hydrateCurrentRunToolStateFromMessages(currentRunToolState, currentMessages);
     const totalUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
 
     // Local models can't reliably do function calling — skip tools gracefully.
@@ -1264,8 +1288,9 @@ export class AgentRuntime {
     }
 
     // Request-scoped skill policy (not class-level mutable state)
-    let activeSkillPolicy: string[] | undefined;
-    let activeSkillDelegationOverrides: SkillDelegationOverrides | undefined;
+    const hydratedSkillState = hydrateActiveSkillStateFromMessages(currentMessages);
+    let activeSkillPolicy = hydratedSkillState.activeSkillPolicy;
+    let activeSkillDelegationOverrides = hydratedSkillState.activeSkillDelegationOverrides;
     let finalFinishReason: string | undefined;
     let latestAssistantText = "";
     const allowedRemoteToolNames = getRuntimeAllowedRemoteTools(this.config);

--- a/src/agent/runtime/refresh.test.ts
+++ b/src/agent/runtime/refresh.test.ts
@@ -5,7 +5,7 @@ import { type ModelRuntime } from "#veryfront/provider";
 import { tool } from "#veryfront/tool";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { agent } from "../index.ts";
-import type { RuntimeStateRequest, ToolExecutionResultRequest } from "../types.ts";
+import type { Message, RuntimeStateRequest, ToolExecutionResultRequest } from "../types.ts";
 
 function createRuntimeStream(parts: unknown[]) {
   return new ReadableStream<unknown>({
@@ -437,6 +437,191 @@ describe("agent runtime refresh hooks", () => {
     assertStringIncludes(observedSystems[1] ?? "", '"actions"');
     assertStringIncludes(observedSystems[1] ?? "", '"invoke_agent:agent:ingest-invoice-agent"');
     assertEquals((observedSystems[1] ?? "").includes("Load open supplier invoices"), false);
+  });
+
+  it("injects current-run run_state from persisted messages before a resumed stream step", async () => {
+    const observedSystems: string[] = [];
+    const model: ModelRuntime = {
+      provider: "hosted",
+      modelId: "hosted/run-state-stream-resume",
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "unused" }],
+          finishReason: "stop",
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        };
+      },
+      async doStream(options: unknown) {
+        observedSystems.push(extractSystemPrompt(options));
+        return {
+          stream: createRuntimeStream([
+            { type: "text-delta", text: "resumed" },
+            { type: "finish", finishReason: "stop", usage: { inputTokens: 1, outputTokens: 1 } },
+          ]),
+        };
+      },
+    };
+    const assistant = agent({
+      model: "hosted/run-state-stream-resume",
+      system: "Run state resumed stream test",
+      tools: {},
+      maxSteps: 1,
+      resolveModelTransport: async () => ({ model }),
+    });
+    const resumedMessages: Message[] = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Process invoices" }],
+        timestamp: 1,
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{
+          type: "tool-invoke_agent",
+          toolCallId: "invoke-ingest-1",
+          toolName: "invoke_agent",
+          args: {
+            agent_id: "ingest-invoice-agent",
+            input: "Load open supplier invoices",
+          },
+        }],
+        timestamp: 2,
+      },
+      {
+        id: "tool-1",
+        role: "tool",
+        parts: [{
+          type: "tool-result",
+          toolCallId: "invoke-ingest-1",
+          toolName: "invoke_agent",
+          result: { status: "completed", output: "Loaded invoices" },
+        }],
+        timestamp: 3,
+      },
+    ];
+
+    const response = (await assistant.stream({ messages: resumedMessages })).toDataStreamResponse();
+    await response.text();
+
+    assertEquals(observedSystems.length, 1);
+    assertStringIncludes(observedSystems[0] ?? "", '<run_state current_run="true">');
+    assertStringIncludes(observedSystems[0] ?? "", '"agent:ingest-invoice-agent"');
+    assertStringIncludes(observedSystems[0] ?? "", '"invoke_agent:agent:ingest-invoice-agent"');
+    assertEquals((observedSystems[0] ?? "").includes("Load open supplier invoices"), false);
+  });
+
+  it("hydrates loaded skill delegation overrides from persisted messages before stream tool execution", async () => {
+    const toolResults: ToolExecutionResultRequest[] = [];
+    let callCount = 0;
+    const model: ModelRuntime = {
+      provider: "hosted",
+      modelId: "hosted/skill-resume-stream",
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "unused" }],
+          finishReason: "stop",
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        };
+      },
+      async doStream() {
+        callCount++;
+
+        if (callCount === 1) {
+          return {
+            stream: createRuntimeStream([
+              {
+                type: "tool-call",
+                toolCallId: "invoke-resumed-1",
+                toolName: "invoke_agent",
+                input:
+                  '{"description":"Run invoice matching","prompt":"Match invoices","max_steps":10}',
+              },
+              {
+                type: "finish",
+                finishReason: "tool-calls",
+                usage: { inputTokens: 1, outputTokens: 1 },
+              },
+            ]),
+          };
+        }
+
+        return {
+          stream: createRuntimeStream([
+            { type: "text-delta", text: "done" },
+            { type: "finish", finishReason: "stop", usage: { inputTokens: 1, outputTokens: 1 } },
+          ]),
+        };
+      },
+    };
+    const invokeAgent = tool({
+      id: "invoke_agent",
+      description: "Invoke an agent",
+      inputSchema: defineSchema((v) =>
+        v.object({
+          description: v.string(),
+          prompt: v.string(),
+          max_steps: v.number().optional(),
+        })
+      )(),
+      execute: ({ max_steps }) => ({ ok: true, max_steps }),
+    });
+    const assistant = agent({
+      model: "hosted/skill-resume-stream",
+      system: "Skill resumed stream test",
+      tools: { invoke_agent: invokeAgent },
+      maxSteps: 2,
+      resolveModelTransport: async () => ({ model }),
+      onToolResult: (request) => {
+        toolResults.push(request);
+      },
+    });
+    const resumedMessages: Message[] = [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Process invoices" }],
+        timestamp: 1,
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{
+          type: "tool-load_skill",
+          toolCallId: "load-skill-1",
+          toolName: "load_skill",
+          args: { skillId: "supplier-invoice-processing" },
+        }],
+        timestamp: 2,
+      },
+      {
+        id: "tool-1",
+        role: "tool",
+        parts: [{
+          type: "tool-result",
+          toolCallId: "load-skill-1",
+          toolName: "load_skill",
+          result: {
+            skillId: "supplier-invoice-processing",
+            allowedTools: ["invoke_agent"],
+            maxSteps: 160,
+          },
+        }],
+        timestamp: 3,
+      },
+    ];
+
+    const response = (await assistant.stream({ messages: resumedMessages })).toDataStreamResponse();
+    await response.text();
+
+    const invokeResult = toolResults.find((result) => result.toolName === "invoke_agent");
+    assertEquals(invokeResult?.input, {
+      description: "Run invoice matching",
+      prompt: "Match invoices",
+      max_steps: 160,
+    });
+    assertEquals(invokeResult?.result, { ok: true, max_steps: 160 });
   });
 
   it("refreshes system and context at step boundaries for generate()", async () => {


### PR DESCRIPTION
## Summary
- hydrate current-run run_state from persisted tool-call/tool-result messages at runtime start
- restore active load_skill policy and delegation overrides from prior load_skill results
- add regressions for resumed stream calls seeing prior invoke_agent state and skill overrides

## Verification
- deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/agent/runtime/current-run-tool-state.test.ts
- deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/agent/runtime/refresh.test.ts
- deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/agent/runtime/*.test.ts
- deno task typecheck

Note: local pre-push full unit suite was stopped after ~9 minutes per request; branch was pushed with --no-verify after the focused runtime suite and typecheck passed.