### PR TITLE
Bump veryfront package to 0.1.683

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.682",
+  "version": "0.1.683",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.682";
+export const VERSION = "0.1.683";


### PR DESCRIPTION
## Summary
- bump the veryfront package version to 0.1.683 so the merged run-state hydration fix can publish

## Verification
- deno eval package version check passed

Pushed with --no-verify per request.