### PR TITLE
Prevent Anthropic replay of orphan tool results

### DIFF
--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
@@ -309,4 +309,81 @@ describe("ext-llm-anthropic/anthropic-request-builder", () => {
       { role: "user", content: [{ type: "text", text: "retry" }] },
     ]);
   });
+
+  it("drops orphaned tool results when their tool use was not emitted", () => {
+    const prompt: RuntimePromptMessage[] = [
+      {
+        role: "tool",
+        content: [{
+          type: "tool-result",
+          toolCallId: "srvtoolu_search_1",
+          toolName: "web_search",
+          output: { type: "json", value: { results: [] } },
+        }],
+      },
+      { role: "user", content: [{ type: "text", text: "Continue the conversation." }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I will use the current tools." },
+          {
+            type: "tool-call",
+            toolCallId: "toolu_lookup_1",
+            toolName: "lookup",
+            input: { query: "current" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "srvtoolu_search_1",
+            toolName: "web_search",
+            output: { type: "json", value: { stale: true } },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "toolu_lookup_1",
+            toolName: "lookup",
+            output: { type: "json", value: { ok: true } },
+          },
+        ],
+      },
+    ];
+    const warnings = createWarningCollector();
+
+    const body = buildAnthropicMessagesRequest(
+      "claude-sonnet-4-6",
+      "anthropic",
+      { prompt },
+      false,
+      warnings,
+    );
+
+    assertEquals(body.messages, [
+      { role: "user", content: [{ type: "text", text: "Continue the conversation." }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I will use the current tools." },
+          {
+            type: "tool_use",
+            id: "toolu_lookup_1",
+            name: "lookup",
+            input: { query: "current" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [{
+          type: "tool_result",
+          tool_use_id: "toolu_lookup_1",
+          content: '{"ok":true}',
+        }],
+      },
+    ]);
+  });
 });

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
@@ -214,17 +214,20 @@ function toAnthropicMessages(
     message.content.some((part) => part.type === "text" && part.text.length > 0)
   );
   let skippingHistoricalToolResults = false;
+  let pendingToolUseIds = new Set<string>();
 
   for (const [index, message] of prompt.entries()) {
     switch (message.role) {
       case "system":
         skippingHistoricalToolResults = false;
+        pendingToolUseIds = new Set();
         if (message.content.length > 0) {
           systemParts.push(message.content);
         }
         break;
       case "user":
         skippingHistoricalToolResults = false;
+        pendingToolUseIds = new Set();
         pushAnthropicUserContent(messages, toAnthropicUserContent(message.content));
         break;
       case "assistant": {
@@ -237,9 +240,13 @@ function toAnthropicMessages(
 
         if (assistantContent.length === 0) {
           skippingHistoricalToolResults = shouldCompactCompletedToolRound;
+          pendingToolUseIds = new Set();
           break;
         }
 
+        pendingToolUseIds = new Set(
+          assistantContent.flatMap((part) => part.type === "tool-call" ? [part.toolCallId] : []),
+        );
         messages.push({
           role: "assistant",
           content: assistantContent.map((part) => {
@@ -274,14 +281,23 @@ function toAnthropicMessages(
         if (skippingHistoricalToolResults) {
           break;
         }
+        const matchingToolResults = message.content.filter((part) =>
+          pendingToolUseIds.has(part.toolCallId)
+        );
+        if (matchingToolResults.length === 0) {
+          break;
+        }
         pushAnthropicUserContent(
           messages,
-          message.content.map((part) => ({
+          matchingToolResults.map((part) => ({
             type: "tool_result",
             tool_use_id: part.toolCallId,
             content: stringifyJsonValue(part.output.value),
           })),
         );
+        for (const part of matchingToolResults) {
+          pendingToolUseIds.delete(part.toolCallId);
+        }
         break;
     }
   }


### PR DESCRIPTION
## Summary
- filter Anthropic replayed `tool_result` blocks to only IDs from the latest emitted assistant `tool_use` turn
- drop stale/orphan server-tool results before they can create provider-invalid requests
- add a regression for a leading `srvtoolu_*` result and a mixed stale/current tool-result batch

## Root cause
The reported Studio failure included Anthropic `invalid_request_error`: a `tool_result` used `srvtoolu_...` without a corresponding `tool_use` block in the previous message. The Anthropic request builder could replay tool results even when their tool-use block had been compacted away or was absent from the emitted provider messages.

## Linked issue
- veryfront/veryfront-studio#4799

## Verification
- `deno fmt --check extensions/ext-llm-anthropic/src/anthropic-request-builder.ts extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts`
- `deno test --no-check --allow-all extensions/ext-llm-anthropic/src`
- `deno test --no-check --allow-all src/provider extensions/ext-llm-anthropic/src`
- pre-commit `deno task verify:quick` passed, including manifest checks, fmt, lint, docs validation, doc links, and typecheck

## Not tested
- Live Anthropic production retry against the reported conversation.