### PR TITLE
Make agent temperature deterministic by default

### DIFF
--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -67,10 +67,14 @@ import { agent } from "veryfront/agent";
 export default agent({
   id: "assistant",
   system: "You are a weather assistant.",
+  temperature: 0,
   tools: { getWeather: true },
   maxSteps: 5,
 });
 ```
+
+`temperature` controls model sampling and defaults to `0` for deterministic
+agent runs.
 
 `maxSteps` limits how many tool-call iterations the agent can perform per
 request. See [Tools](./tools.md) for how to define `getWeather`.
@@ -271,6 +275,7 @@ export default agent({
 | `providerTools`       | `string[]`                                                                                             | Provider-executed tools such as `web_search`                                 |
 | `mcpServers`          | `AgentMcpServerConfig[]`                                                                               | Remote MCP-compatible tool servers                                           |
 | `skills`              | `true \| string[]`                                                                                     | Enable all skills (`true`) or selected skill IDs                             |
+| `temperature`         | `number`                                                                                               | Sampling temperature for model generation (default: `0`)                     |
 | `maxSteps`            | `number`                                                                                               | Max tool-call iterations per request                                         |
 | `memory`              | `MemoryConfig`                                                                                         | Conversation memory settings                                                 |
 | `streaming`           | `boolean`                                                                                              | Enable streaming (default: `true`)                                           |

--- a/src/agent/hosted/chat-preparation.ts
+++ b/src/agent/hosted/chat-preparation.ts
@@ -287,6 +287,9 @@ export async function prepareHostedChatRuntimeCreationOptions<
       ...(input.branchId !== undefined ? { branchId: input.branchId } : {}),
       ...(runtimeConfig.requestedModel ? { model: runtimeConfig.requestedModel } : {}),
       ...(runtimeConfig.requestedThinking ? { thinking: runtimeConfig.requestedThinking } : {}),
+      ...(runtimeConfig.requestedTemperature !== undefined
+        ? { temperature: runtimeConfig.requestedTemperature }
+        : {}),
       ...(runtimeConfig.requestedMaxSteps !== undefined
         ? { maxSteps: runtimeConfig.requestedMaxSteps }
         : {}),

--- a/src/agent/hosted/chat-runtime-contract.ts
+++ b/src/agent/hosted/chat-runtime-contract.ts
@@ -96,6 +96,7 @@ export type HostedChatRuntimeCreationOptions<TRuntimeAgentDefinition, TThinkingC
   authToken: string;
   instructions: string | ChatSystemMessage[];
   model?: string;
+  temperature?: number;
   maxSteps?: number;
   allowedTools?: string[];
   allowDelegation?: boolean;

--- a/src/agent/hosted/default-chat-runtime.ts
+++ b/src/agent/hosted/default-chat-runtime.ts
@@ -226,6 +226,7 @@ function createRuntimeAgentConfig(input: {
     providerTools: input.toolAssembly.providerToolNames,
     __vfRemoteToolSources: input.toolAssembly.remoteToolSources,
     __vfAllowedRemoteTools: input.toolAssembly.compatibleRemoteToolNames,
+    temperature: input.options.temperature,
     maxSteps: input.options.maxSteps ?? 50,
     resolveModelTransport: ({ resolvedModel }) => {
       const providerOptions = resolveVeryfrontCloudThinkingProviderOptions(

--- a/src/agent/hosted/runtime-request-config.ts
+++ b/src/agent/hosted/runtime-request-config.ts
@@ -18,7 +18,7 @@ export type HostedRuntimeRequestConfigRequest = Pick<
 /** Public API contract for hosted runtime request config agent. */
 export type HostedRuntimeRequestConfigAgent = Pick<
   RuntimeAgentMarkdownDefinition,
-  "model" | "thinking" | "maxSteps"
+  "model" | "thinking" | "temperature" | "maxSteps"
 >;
 
 /** Input payload for resolve hosted runtime request config. */
@@ -37,6 +37,7 @@ export type ResolvedHostedRuntimeRequestConfig = {
   requestedModel: string | undefined;
   clientProfile: RuntimeClientProfile | null;
   requestedThinking: RuntimeAgentThinkingConfig | undefined;
+  requestedTemperature: number | undefined;
   requestedMaxSteps: number | undefined;
 };
 
@@ -114,6 +115,7 @@ export function resolveHostedRuntimeRequestConfig(
         input.agentConfig.thinking,
       requestedThinking: effectiveRuntimeOverrides?.thinking,
     }),
+    requestedTemperature: input.agentConfig.temperature,
     requestedMaxSteps: effectiveRuntimeOverrides?.maxSteps ??
       input.agentConfig.maxSteps,
   };

--- a/src/agent/project/agent-runtime.ts
+++ b/src/agent/project/agent-runtime.ts
@@ -90,6 +90,9 @@ export async function createRuntimeAgentDefinitionFromAgent(
     description: runtimeAgent.config.description ?? "",
     instructions: await resolveAgentSystem(runtimeAgent.config.system),
     model: runtimeAgent.config.model,
+    ...(runtimeAgent.config.temperature === undefined
+      ? {}
+      : { temperature: runtimeAgent.config.temperature }),
     maxSteps: runtimeAgent.config.maxSteps,
   };
 }

--- a/src/agent/runtime/agent-definition.test.ts
+++ b/src/agent/runtime/agent-definition.test.ts
@@ -12,6 +12,7 @@ Deno.test("parseRuntimeAgentMarkdownDefinition normalizes frontmatter and instru
 name: Support Agent
 description: Helps users resolve issues
 model: gpt-5.4
+temperature: 0.2
 thinking: 1200
 max-steps: 8
 provider-tools:
@@ -28,6 +29,7 @@ Follow the support runbook.
     name: "Support Agent",
     description: "Helps users resolve issues",
     model: "gpt-5.4",
+    temperature: 0.2,
     thinking: { enabled: true, budgetTokens: 1200 },
     maxSteps: 8,
     providerTools: ["web_search", "web_fetch"],

--- a/src/agent/runtime/agent-definition.ts
+++ b/src/agent/runtime/agent-definition.ts
@@ -33,6 +33,7 @@ export const getRuntimeAgentMarkdownDefinitionSchema = defineSchema((v) =>
     instructions: v.string(),
     thinking: getRuntimeAgentThinkingConfigSchema().optional(),
     model: v.string().min(1).optional(),
+    temperature: v.number().min(0).max(2).optional(),
     maxSteps: v.number().optional(),
     providerTools: v.array(v.string().min(1)).optional(),
   })
@@ -113,6 +114,7 @@ export function parseRuntimeAgentMarkdownDefinition(
   const description = typeof attrs.description === "string" ? attrs.description : "";
   const model = typeof attrs.model === "string" && attrs.model.trim() ? attrs.model : undefined;
   const thinking = parseThinking(attrs.thinking);
+  const temperature = typeof attrs.temperature === "number" ? attrs.temperature : undefined;
   const maxSteps = typeof attrs["max-steps"] === "number" ? attrs["max-steps"] : undefined;
   const providerTools = parseProviderTools(attrs["provider-tools"]);
 
@@ -123,6 +125,7 @@ export function parseRuntimeAgentMarkdownDefinition(
     instructions: body.trim(),
     ...(model ? { model } : {}),
     ...(thinking ? { thinking } : {}),
+    ...(temperature === undefined ? {} : { temperature }),
     ...(maxSteps === undefined ? {} : { maxSteps }),
     ...(providerTools ? { providerTools } : {}),
   });

--- a/src/agent/runtime/agent-markdown-adapter.ts
+++ b/src/agent/runtime/agent-markdown-adapter.ts
@@ -14,6 +14,7 @@ export function createRuntimeAgentFromMarkdownDefinition(
     description: definition.description,
     system: definition.instructions,
     ...(definition.model ? { model: definition.model } : {}),
+    ...(definition.temperature === undefined ? {} : { temperature: definition.temperature }),
     ...(definition.maxSteps === undefined ? {} : { maxSteps: definition.maxSteps }),
     ...(definition.providerTools ? { providerTools: definition.providerTools } : {}),
   });

--- a/src/agent/runtime/defaults.ts
+++ b/src/agent/runtime/defaults.ts
@@ -1,6 +1,6 @@
 export const AGENT_DEFAULTS = {
   maxTokens: 4_096,
-  temperature: 0.7,
+  temperature: 0,
   maxSteps: 20,
   memoryType: "conversation",
   memoryMaxTokens: 4_000,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1011,7 +1011,7 @@ export class AgentRuntime {
             }),
             experimental_repairToolCall: repairToolCall,
             maxOutputTokens: this.resolveMaxOutputTokens(effectiveModel, maxOutputTokensOverride),
-            temperature: DEFAULT_TEMPERATURE,
+            temperature: this.resolveTemperature(),
             ...(headers ? { headers } : {}),
             ...(providerOptions ? { providerOptions } : {}),
           });
@@ -1373,7 +1373,7 @@ export class AgentRuntime {
         tools: runtimeTools,
         experimental_repairToolCall: repairToolCall,
         maxOutputTokens: this.resolveMaxOutputTokens(effectiveModel, maxOutputTokensOverride),
-        temperature: DEFAULT_TEMPERATURE,
+        temperature: this.resolveTemperature(),
         ...(headers ? { headers } : {}),
         ...(providerOptions ? { providerOptions } : {}),
         abortSignal,
@@ -1779,6 +1779,10 @@ export class AgentRuntime {
   private computeMaxSteps(platformLimit: number): number {
     const edgeMaxSteps = this.config.edge?.enabled ? this.config.edge.maxSteps : undefined;
     return getMaxSteps(this.config.maxSteps, edgeMaxSteps, platformLimit);
+  }
+
+  private resolveTemperature(): number {
+    return this.config.temperature ?? DEFAULT_TEMPERATURE;
   }
 
   private resolveMaxOutputTokens(modelString?: string, maxOutputTokensOverride?: number): number {

--- a/src/agent/runtime/provider-transport.test.ts
+++ b/src/agent/runtime/provider-transport.test.ts
@@ -71,6 +71,7 @@ describe("agent provider transport hooks", () => {
     });
 
     assertExists(captured.generateOptions);
+    assertEquals(captured.generateOptions.temperature, 0);
     assertEquals(
       new Headers(captured.generateOptions.headers as HeadersInit).get("Authorization"),
       "Bearer vf_test",
@@ -78,6 +79,40 @@ describe("agent provider transport hooks", () => {
     assertEquals(captured.generateOptions.providerOptions, {
       veryfront: { projectSlug: "demo-project" },
     });
+  });
+
+  it("uses the agent-configured temperature for generate()", async () => {
+    const captured: {
+      generateOptions?: Record<string, unknown>;
+    } = {};
+
+    const transportModel: ModelRuntime = {
+      provider: "hosted",
+      modelId: "hosted/gateway-model",
+      async doGenerate(options: unknown) {
+        captured.generateOptions = options as Record<string, unknown>;
+        return {
+          content: [{ type: "text", text: "custom temperature" }],
+          finishReason: "stop",
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        };
+      },
+      async doStream() {
+        return { stream: createTextStream([{ type: "finish" }]) };
+      },
+    };
+
+    const assistant = agent({
+      model: "host/test-model",
+      system: "You are a helpful assistant.",
+      temperature: 0.2,
+      resolveModelTransport: () => ({ model: transportModel }),
+    });
+
+    await assistant.generate({ input: "Hello" });
+
+    assertExists(captured.generateOptions);
+    assertEquals(captured.generateOptions.temperature, 0.2);
   });
 
   it("lets hosts attach request-aware transport options while still using the registered provider runtime for stream()", async () => {

--- a/src/agent/service/runtime.ts
+++ b/src/agent/service/runtime.ts
@@ -226,6 +226,7 @@ export function createAgentServiceRuntime<
       id: agentConfig.id,
       system: agentConfig.instructions,
       model: agentConfig.model,
+      temperature: agentConfig.temperature,
       maxSteps: agentConfig.maxSteps,
     }),
     server: {

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -160,6 +160,8 @@ export interface AgentConfig {
   /** Remote MCP servers available to this agent. */
   mcpServers?: AgentMcpServerConfig[];
   maxSteps?: number;
+  /** Sampling temperature for model generation. Defaults to 0. */
+  temperature?: number;
   streaming?: boolean;
   memory?: MemoryConfig;
   middleware?: AgentMiddleware[];


### PR DESCRIPTION
## Summary
- default agent runtime temperature to 0
- carry explicit agent temperature through markdown, hosted chat, service runtime, and project runtime export
- document agent temperature frontmatter/config

## Verification
- deno test --no-check --allow-all src/agent/runtime/provider-transport.test.ts src/agent/runtime/agent-definition.test.ts src/agent/hosted/runtime-request-config.test.ts src/agent/project/agent-runtime.test.ts src/agent/service/runtime.test.ts
- deno task fmt:check && deno task lint && deno task typecheck
- deno task docs:validate

## Notes
- Local pre-push full unit hook previously failed before rebase on an unrelated Tailwind plugin resolution test. After rebasing onto current main, the targeted gates above pass.