### PR TITLE
Release agent temperature defaults

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.685",
+  "version": "0.1.686",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.685";
+export const VERSION = "0.1.686";


### PR DESCRIPTION
## Summary
- bump veryfront-code release version from 0.1.685 to 0.1.686
- keep src/utils/version-constant.ts synchronized with deno.json
- lets CI publish the already-merged agent temperature default/customization change as a new stable release

## Verification
- deno eval version sync check
- deno task fmt:check
- deno task lint
- deno task typecheck
- pre-push hook: format, lint, typecheck, unit tests (2002 files, 18087 steps)