### PR TITLE
Preserve agent stream replay metadata

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.686",
+  "version": "0.1.687",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/architecture/27-agent-message-stream-dataflow.md
+++ b/docs/architecture/27-agent-message-stream-dataflow.md
@@ -1,0 +1,173 @@
+# Agent message stream dataflow
+
+This page explains how a Veryfront agent run turns a conversation prompt into
+provider requests, streamed parts, tool calls, child runs, and durable replay
+state. The point is to make the runtime mental model explicit: models do not get
+hidden access to prior provider state. Each step is reconstructed from the
+messages, tools, run state, and provider replay metadata that Veryfront sends.
+
+## Responsibility
+
+Message stream dataflow spans four boundaries:
+
+- [`src/chat/`](../../src/chat/) owns canonical message parts, conversation
+  conversion, AG-UI-compatible chunks, and browser stream assembly.
+- [`src/agent/runtime/`](../../src/agent/runtime/) owns provider-neutral agent
+  execution, stream state, local tool execution, and final assistant message
+  materialization.
+- [`src/agent/hosted/`](../../src/agent/hosted/) owns hosted conversation runs,
+  child-run fork inputs, durable run state, and cloud runtime adaptation.
+- [`extensions/ext-llm-*`](../../extensions/) owns provider-specific request
+  shaping and provider-specific stream parsing.
+
+The API service persists hosted conversation and run state. Veryfront Code owns
+the runtime contracts that decide which parts exist and how they are replayed.
+
+## Prompt state
+
+A model request is built from explicit state:
+
+1. The current system instructions and runtime options.
+2. Conversation messages normalized into provider-model messages.
+3. Tool definitions visible to the selected model.
+4. Provider options such as reasoning, cache, native tools, and metadata.
+5. Durable child-run or hosted-run context when the run is hosted.
+
+The provider is not expected to remember prior turns outside this request. Even
+long-running streams are treated as a sequence of model turns. When a tool call
+interrupts assistant text, the runtime commits the tool call, runs the tool, and
+then sends a new provider request containing the assistant tool call and the
+tool result needed for the model to continue.
+
+## Stream shape
+
+Provider adapters translate provider-specific streaming frames into
+provider-neutral runtime parts:
+
+- `reasoning-start`, `reasoning-delta`, `reasoning-end`
+- `text-start`, `text-delta`, `text-end`
+- `tool-input-start`, `tool-input-delta`, `tool-input-available`
+- `tool-call`
+- `tool-result` or provider-executed tool result parts
+- `finish` with finish reason and usage
+
+The runtime stream handler keeps separate in-memory accumulators for text,
+reasoning, local tool input, provider-executed tool calls, usage, and finish
+reason. This separation matters because the model may stream partial JSON tool
+arguments, interrupt text with a tool call, or emit provider-native tool
+activity that should be visible in the UI but not executed locally.
+
+## Assistant message materialization
+
+At the end of a model step, the runtime writes one assistant message from the
+accumulated parts:
+
+1. Reasoning parts are materialized first when the provider exposed reasoning.
+2. Text parts are materialized next.
+3. Tool-call parts are materialized with stable `toolCallId`, `toolName`, and
+   parsed input.
+4. Provider-executed tool calls and results are preserved as renderable audit
+   parts.
+5. Usage metadata is attached to the final message metadata.
+
+For Anthropic extended thinking, clear thinking signatures and redacted
+thinking payloads are preserved on reasoning parts. Those fields are replay
+metadata, not display text. They let the next Anthropic request include valid
+thinking history instead of losing provider-required state between turns.
+
+## Tool calls
+
+Local tools and provider-native tools have different ownership.
+
+Local tools are executed by the Veryfront runtime:
+
+1. The provider streams a tool input.
+2. The runtime parses and validates the input.
+3. The runtime executes the local tool.
+4. The tool result becomes an explicit role `tool` message for the next model
+   step.
+
+Provider-native tools are executed by the provider:
+
+1. Veryfront includes the provider-native tool declaration in the provider
+   request.
+2. The provider streams tool activity and results.
+3. Veryfront records those parts for visibility and replay where the provider
+   supports it.
+4. Veryfront does not run a local tool with the same name unless the part is a
+   local tool call.
+
+This keeps web search, web fetch, code execution, and similar provider tools
+visible without conflating them with project-defined tools.
+
+## Child agent runs
+
+`invoke_agent` creates an isolated child run. The child receives its own
+conversation context and tool inventory. The parent transcript receives a compact
+summary/result and durable child-run identifiers, not the full child transcript.
+
+When the parent needs the child to use structured facts from prior tool results,
+it can pass generic `evidence_refs`. These refs point to prior run/message/tool
+evidence and are appended to the child prompt as structured context. They are
+also stored in child-run metadata. This avoids asking the parent model to
+rewrite critical facts as prose and lets the child prefer referenced evidence
+when prose conflicts with the refs.
+
+Child run events should remain inspectable and streamable through child-run
+views. They should not be dumped into the parent context, because that would
+inflate replay cost and make the parent responsible for another agent's full
+trajectory.
+
+## Browser presentation
+
+The browser receives canonical chat UI chunks. The React stream handler assembles
+those chunks into ordered message parts:
+
+- Partial text and reasoning parts are shown while streaming.
+- Tool input and output lifecycle states are updated in place.
+- Provider-native tool activity can be rendered as expandable audit parts.
+- Final message parts replace only the matching streamed part, not unrelated
+  visible text.
+
+Reasoning replay metadata can travel through `reasoning-end` and
+`reasoning` parts. UI components should treat that metadata as non-display
+state unless they intentionally expose a diagnostic view.
+
+## Replay and compaction
+
+Replay prepares historical conversation state for the next request. It can
+remove stale or overly large historical tool outputs, but it must keep the
+latest unresolved tool round coherent: assistant tool calls must be followed by
+matching tool results. Provider-specific replay rules also apply, such as
+Anthropic thinking signatures for thinking blocks.
+
+Compaction should summarize old context into an explicit message or event and
+then replay that summary as ordinary prompt state. It should not rely on hidden
+provider memory. Attachments with large binary payloads should be represented by
+stable references or summaries rather than repeated inline data.
+
+## Failure model
+
+Technical failures and business failures are different runtime facts.
+
+- A technical failure means the runtime, provider, transport, or tool execution
+  could not complete the requested operation. It should become terminal run
+  error state and user-facing retry guidance.
+- A business failure means the agent completed the operation and found a domain
+  outcome such as validation failure, policy rejection, missing evidence, or
+  mismatched data. It should be represented as ordinary assistant output or a
+  structured tool result, not as a transport error.
+
+This distinction lets the run be observable without treating every undesirable
+domain outcome as an infrastructure failure.
+
+## Change checks
+
+- Run provider-specific tests when changing request builders or stream parsers.
+- Run agent runtime stream tests when changing runtime parts or tool lifecycle
+  handling.
+- Run chat stream assembly tests when changing UI chunks or client message
+  materialization.
+- Run hosted child-run tests when changing `invoke_agent` or child fork inputs.
+- Verify that provider replay metadata remains non-display state but survives
+  request replay.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -46,6 +46,7 @@ one runtime concern. Architecture pages do not duplicate the user guides in
 | [24-context-compaction-current-state.md](./24-context-compaction-current-state.md)             | Current Code and API compaction review         |
 | [25-context-compaction-target-state.md](./25-context-compaction-target-state.md)               | Target context compaction design               |
 | [26-context-compaction-migration-plan.md](./26-context-compaction-migration-plan.md)           | Migration plan for context compaction          |
+| [27-agent-message-stream-dataflow.md](./27-agent-message-stream-dataflow.md)                   | Agent prompt, stream, tool, and replay flow    |
 
 ## Runtime boundaries
 

--- a/extensions/ext-llm-anthropic/src/anthropic-provider.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-provider.test.ts
@@ -843,6 +843,7 @@ describe("anthropic-provider", () => {
       {
         type: "reasoning-end",
         id: "thinking-0",
+        signature: "sig_123",
       },
       {
         type: "finish",
@@ -1891,7 +1892,7 @@ describe("anthropic-provider", () => {
       const parts = await collectAsync(result.stream);
       assertEquals(parts, [
         { type: "reasoning-start", id: "thinking-0" },
-        { type: "reasoning-end", id: "thinking-0" },
+        { type: "reasoning-end", id: "thinking-0", redactedData: "encrypted" },
         { type: "text-delta", delta: "Answer." },
         {
           type: "finish",

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
@@ -215,6 +215,40 @@ describe("ext-llm-anthropic/anthropic-request-builder", () => {
     ]);
   });
 
+  it("treats provider-option thinking as enabled while shaping sampling settings", () => {
+    const prompt: RuntimePromptMessage[] = [
+      { role: "user", content: [{ type: "text", text: "Think carefully." }] },
+    ];
+    const warnings = createWarningCollector();
+
+    const body = buildAnthropicMessagesRequest(
+      "claude-sonnet-4-6",
+      "anthropic",
+      {
+        prompt,
+        maxOutputTokens: 4096,
+        temperature: 0.2,
+        topP: 0.9,
+        providerOptions: {
+          anthropic: {
+            thinking: { type: "enabled", budget_tokens: 2048 },
+          },
+        },
+      },
+      false,
+      warnings,
+    );
+
+    assertEquals(body.temperature, undefined);
+    assertEquals(body.top_p, undefined);
+    assertEquals(body.thinking, { type: "enabled", budget_tokens: 2048 });
+    assertEquals(body.max_tokens, 6144);
+    assertEquals(warnings.drain().map((warning) => warning.setting), [
+      "temperature",
+      "topP",
+    ]);
+  });
+
   it("compacts completed historical tool rounds before replaying later user turns", () => {
     const prompt: RuntimePromptMessage[] = [
       { role: "user", content: [{ type: "text", text: "Build a briefing." }] },

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
@@ -453,6 +453,24 @@ function resolveAnthropicThinkingBudget(
   }
 }
 
+function resolveAnthropicProviderThinkingBudget(
+  options: Record<string, unknown>,
+): number | undefined {
+  const thinking = options.thinking;
+  if (thinking === null || typeof thinking !== "object" || Array.isArray(thinking)) {
+    return undefined;
+  }
+  const record = thinking as Record<string, unknown>;
+  if (record.type !== "enabled") {
+    return undefined;
+  }
+  const budgetTokens = record.budget_tokens;
+  if (typeof budgetTokens === "number" && Number.isFinite(budgetTokens) && budgetTokens >= 1024) {
+    return budgetTokens;
+  }
+  return undefined;
+}
+
 export function buildAnthropicMessagesRequest(
   modelId: string,
   providerName: string,
@@ -469,8 +487,15 @@ export function buildAnthropicMessagesRequest(
 
   const { system, messages } = toAnthropicMessages(options.prompt, systemCacheControl);
   const anthropicTools = toAnthropicTools(options.tools, toolsCacheControl);
+  const rawProviderOptions = readProviderOptions(
+    options.providerOptions,
+    "anthropic",
+    providerName,
+  );
   const thinkingBudget = resolveAnthropicThinkingBudget(options.reasoning);
-  const thinkingEnabled = thinkingBudget !== undefined;
+  const providerThinkingBudget = resolveAnthropicProviderThinkingBudget(rawProviderOptions);
+  const effectiveThinkingBudget = thinkingBudget ?? providerThinkingBudget;
+  const thinkingEnabled = effectiveThinkingBudget !== undefined;
 
   if (options.presencePenalty !== undefined) {
     warnings.push({
@@ -544,7 +569,7 @@ export function buildAnthropicMessagesRequest(
   const baseMaxTokens = resolveAnthropicMaxTokens(modelId, options.maxOutputTokens);
   const maxTokens = thinkingEnabled
     ? Math.min(
-      baseMaxTokens + (thinkingBudget ?? 0),
+      baseMaxTokens + (effectiveThinkingBudget ?? 0),
       getAnthropicModelCapabilities(modelId).maxOutputTokens,
     )
     : baseMaxTokens;
@@ -566,7 +591,9 @@ export function buildAnthropicMessagesRequest(
     ...(options.toolChoice !== undefined
       ? { tool_choice: normalizeAnthropicToolChoice(options.toolChoice) }
       : {}),
-    ...(thinkingEnabled ? { thinking: { type: "enabled", budget_tokens: thinkingBudget } } : {}),
+    ...(thinkingBudget !== undefined
+      ? { thinking: { type: "enabled", budget_tokens: thinkingBudget } }
+      : {}),
     ...(typeof options.userId === "string" && options.userId.length > 0
       ? { metadata: { user_id: options.userId } }
       : {}),
@@ -576,6 +603,6 @@ export function buildAnthropicMessagesRequest(
     ...(options.anthropicContainer !== undefined ? { container: options.anthropicContainer } : {}),
   };
 
-  Object.assign(body, readProviderOptions(options.providerOptions, "anthropic", providerName));
+  Object.assign(body, rawProviderOptions);
   return body;
 }

--- a/extensions/ext-llm-anthropic/src/anthropic-stream.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.ts
@@ -22,6 +22,9 @@ type AnthropicStreamToolCallState = {
 
 type AnthropicStreamReasoningState = {
   id: string;
+  text: string;
+  signature?: string;
+  redactedData?: string;
 };
 
 function isEmptyRecord(value: unknown): value is Record<string, never> {
@@ -122,13 +125,17 @@ export async function* streamAnthropicCompatibleParts(
 
         if (blockType === "thinking") {
           const reasoningId = `thinking-${index}`;
-          reasoningBlocks.set(index, { id: reasoningId });
+          reasoningBlocks.set(index, { id: reasoningId, text: "" });
           yield {
             type: "reasoning-start",
             id: reasoningId,
           };
 
           if (typeof contentBlock?.thinking === "string" && contentBlock.thinking.length > 0) {
+            const current = reasoningBlocks.get(index);
+            if (current) {
+              current.text += contentBlock.thinking;
+            }
             yield {
               type: "reasoning-delta",
               id: reasoningId,
@@ -144,7 +151,11 @@ export async function* streamAnthropicCompatibleParts(
         // without leaking the (legitimately hidden) contents.
         if (blockType === "redacted_thinking") {
           const reasoningId = `thinking-${index}`;
-          reasoningBlocks.set(index, { id: reasoningId });
+          reasoningBlocks.set(index, {
+            id: reasoningId,
+            text: "",
+            ...(typeof contentBlock?.data === "string" ? { redactedData: contentBlock.data } : {}),
+          });
           yield {
             type: "reasoning-start",
             id: reasoningId,
@@ -238,11 +249,20 @@ export async function* streamAnthropicCompatibleParts(
             continue;
           }
 
+          current.text += delta.thinking;
           yield {
             type: "reasoning-delta",
             id: current.id,
             delta: delta.thinking,
           };
+          continue;
+        }
+
+        if (deltaType === "signature_delta" && typeof delta?.signature === "string") {
+          const current = reasoningBlocks.get(index);
+          if (current) {
+            current.signature = delta.signature;
+          }
           continue;
         }
 
@@ -270,6 +290,8 @@ export async function* streamAnthropicCompatibleParts(
           yield {
             type: "reasoning-end",
             id: reasoning.id,
+            ...(reasoning.signature ? { signature: reasoning.signature } : {}),
+            ...(reasoning.redactedData ? { redactedData: reasoning.redactedData } : {}),
           };
           reasoningBlocks.delete(index);
           continue;

--- a/src/agent/hosted/child-fork-step-message-preparation.ts
+++ b/src/agent/hosted/child-fork-step-message-preparation.ts
@@ -4,6 +4,10 @@ import {
   type AgentRuntimeMessagePart,
   convertAgentRuntimeMessagesToProviderMessages,
   convertProviderMessagesToAgentRuntimeMessages,
+  getAgentRuntimeReasoningPart,
+  getAgentRuntimeTextPart,
+  getAgentRuntimeToolCallPart,
+  getAgentRuntimeToolResultPart,
 } from "../runtime/message-adapter.ts";
 import type { Message as AgentMessage, MessagePart } from "../schemas/index.ts";
 
@@ -30,40 +34,46 @@ export type HostedChildForkRuntimeStepMessages = {
 function convertAgentRuntimePartToChildForkMessagePart(
   part: AgentRuntimeMessagePart,
 ): MessagePart {
-  if ("text" in part) {
-    return {
-      type: "text",
-      text: part.text,
-    };
+  const textPart = getAgentRuntimeTextPart(part);
+  if (textPart) {
+    return textPart;
   }
 
-  if ("result" in part) {
+  const reasoningPart = getAgentRuntimeReasoningPart(part);
+  if (reasoningPart) {
+    return reasoningPart;
+  }
+
+  const toolResultPart = getAgentRuntimeToolResultPart(part);
+  if (toolResultPart) {
     return {
       type: "tool-result",
-      toolCallId: part.toolCallId,
-      toolName: part.toolName,
-      result: part.result,
+      toolCallId: toolResultPart.toolCallId,
+      toolName: toolResultPart.toolName,
+      result: toolResultPart.output,
     };
   }
 
-  if ("toolCallId" in part) {
+  const toolCallPart = getAgentRuntimeToolCallPart(part);
+  if (toolCallPart) {
     return {
-      type: `tool-${part.toolName}`,
-      toolCallId: part.toolCallId,
-      toolName: part.toolName,
-      args: part.args,
+      type: `tool-${toolCallPart.toolName}`,
+      toolCallId: toolCallPart.toolCallId,
+      toolName: toolCallPart.toolName,
+      args: toolCallPart.input,
     };
   }
 
-  // image/file parts have no equivalent in the child-fork AgentMessage schema — render as a placeholder
-  if (part.type === "image" || part.type === "file") {
+  if (
+    (part.type === "image" || part.type === "file") &&
+    "mediaType" in part &&
+    typeof part.mediaType === "string"
+  ) {
+    // Image/file parts have no equivalent in the child-fork AgentMessage schema.
     return { type: "text", text: `[file: ${part.mediaType}]` };
   }
 
-  const _exhaustive: never = part;
-  throw new Error(
-    `Unhandled AgentRuntimeMessagePart type: ${String((_exhaustive as { type: unknown }).type)}`,
-  );
+  throw new Error(`Unhandled AgentRuntimeMessagePart type: ${String(part.type)}`);
 }
 
 /** Convert compacted provider messages to child fork runtime messages. */

--- a/src/agent/hosted/child-tool-input.test.ts
+++ b/src/agent/hosted/child-tool-input.test.ts
@@ -11,6 +11,12 @@ Deno.test("hostedChildForkToolInputSchema accepts the hosted child fork fields",
   const parsed = hostedChildForkToolInputSchema.parse({
     description: "review auth flow",
     prompt: "Review the authentication flow and report issues.",
+    evidence_refs: [{
+      run_id: "run_123",
+      tool_call_id: "tool_123",
+      result_path: "$.records[0]",
+      label: "matched record",
+    }],
     project_id: "project-123",
     tools: ["readFile", "bash"],
     model: "sonnet",
@@ -21,12 +27,44 @@ Deno.test("hostedChildForkToolInputSchema accepts the hosted child fork fields",
   assertEquals(parsed, {
     description: "review auth flow",
     prompt: "Review the authentication flow and report issues.",
+    evidence_refs: [{
+      run_id: "run_123",
+      tool_call_id: "tool_123",
+      result_path: "$.records[0]",
+      label: "matched record",
+    }],
     project_id: "project-123",
     tools: ["readFile", "bash"],
     model: "sonnet",
     thinking: 1024,
     max_steps: 12,
   });
+});
+
+Deno.test("resolveHostedChildForkRuntimeConfig appends evidence refs as structured child context", () => {
+  const result = resolveHostedChildForkRuntimeConfig({
+    forkInput: {
+      description: "release matched record",
+      prompt: "Use the matched record and perform the requested action.",
+      evidence_refs: [{
+        run_id: "run_match",
+        tool_call_id: "tool_match",
+        result_path: "$.records[0]",
+        label: "matched source record",
+      }],
+    },
+    contextModel: "opus",
+    defaultModel: "haiku",
+    defaultMaxSteps: 80,
+    runId: "tool-call-1",
+    resolveModelId: (modelId) => `resolved-${modelId}`,
+    resolveProvider: (modelId) => `provider-for-${modelId}`,
+  });
+
+  assertEquals(result.effectivePrompt.includes("Use the matched record"), true);
+  assertEquals(result.effectivePrompt.includes("<evidence_refs>"), true);
+  assertEquals(result.effectivePrompt.includes('"run_id":"run_match"'), true);
+  assertEquals(result.effectivePrompt.includes('"result_path":"$.records[0]"'), true);
 });
 
 Deno.test("hostedChildForkToolInputSchema preserves omitted optional fork controls", () => {

--- a/src/agent/hosted/child-tool-input.ts
+++ b/src/agent/hosted/child-tool-input.ts
@@ -6,10 +6,26 @@ import type { RuntimeAgentThinkingConfig } from "../runtime/agent-definition.ts"
 /** Default value for hosted child agent ID. */
 export const DEFAULT_HOSTED_CHILD_AGENT_ID = "invoke-agent-child";
 
+const getHostedChildForkEvidenceRefSchema = defineSchema((v) =>
+  v.object({
+    id: v.string().optional().describe("Optional stable evidence reference id."),
+    run_id: v.string().optional().describe("Run id that produced the evidence."),
+    message_id: v.string().optional().describe("Message id that stores the evidence."),
+    tool_call_id: v.string().optional().describe("Tool call id that produced the evidence."),
+    result_path: v.string().optional().describe("JSONPath-style path into the structured result."),
+    label: v.string().optional().describe("Short human-readable label for this evidence."),
+    summary: v.string().optional().describe("Optional compact summary of the referenced evidence."),
+  })
+);
+
 export const getHostedChildForkToolInputSchema = defineSchema((v) =>
   v.object({
     description: v.string().describe("3-5 word task summary"),
     prompt: v.string().describe("Detailed instructions for the task"),
+    evidence_refs: v.array(getHostedChildForkEvidenceRefSchema()).optional().describe(
+      "Generic source-of-truth references for facts the child must preserve. " +
+        "Use run_id/message_id/tool_call_id plus result_path instead of copying critical facts as prose.",
+    ),
     project_id: v.string().optional().describe(
       "Override project context. Use after studio_open_project.",
     ),
@@ -53,7 +69,7 @@ export type HostedChildForkRuntimeConfig = {
 export type ResolveHostedChildForkRuntimeConfigInput = {
   forkInput: Pick<
     HostedChildForkToolInput,
-    "description" | "prompt" | "tools" | "model" | "thinking" | "max_steps"
+    "description" | "prompt" | "evidence_refs" | "tools" | "model" | "thinking" | "max_steps"
   >;
   contextModel?: string;
   defaultModel: string;
@@ -78,21 +94,35 @@ export function resolveHostedChildForkThinkingOverride(
   return undefined;
 }
 
+function appendEvidenceRefsToPrompt(
+  prompt: string,
+  evidenceRefs: HostedChildForkToolInput["evidence_refs"],
+): string {
+  if (!evidenceRefs || evidenceRefs.length === 0) {
+    return prompt;
+  }
+
+  return `${prompt}\n\n<evidence_refs>\n${
+    JSON.stringify(evidenceRefs)
+  }\n</evidence_refs>\nTreat these references as source-of-truth pointers. If prose conflicts with referenced evidence, prefer the referenced evidence and say what conflicted.`;
+}
+
 /** Configuration used by resolve hosted child fork runtime. */
 export function resolveHostedChildForkRuntimeConfig(
   input: ResolveHostedChildForkRuntimeConfigInput,
 ): HostedChildForkRuntimeConfig {
-  const { description, prompt, tools, model, thinking, max_steps } = input.forkInput;
+  const { description, prompt, evidence_refs, tools, model, thinking, max_steps } = input.forkInput;
   const forkModel = input.resolveModelId(model || input.contextModel || input.defaultModel);
   const requestedMaxSteps = typeof max_steps === "number" ? max_steps : undefined;
+  const promptWithArtifactPath = withDefaultResearchArtifactPath({
+    description,
+    prompt,
+    runId: input.runId,
+  });
 
   return {
     description,
-    effectivePrompt: withDefaultResearchArtifactPath({
-      description,
-      prompt,
-      runId: input.runId,
-    }),
+    effectivePrompt: appendEvidenceRefsToPrompt(promptWithArtifactPath, evidence_refs),
     requestedTools: tools,
     forkModel,
     provider: input.resolveProvider(forkModel),

--- a/src/agent/react/use-chat/streaming/handler.test.ts
+++ b/src/agent/react/use-chat/streaming/handler.test.ts
@@ -149,7 +149,7 @@ describe("use-chat streaming handler", () => {
         { type: "reasoning-start", id: "r1" },
         { type: "reasoning-delta", id: "r1", delta: "think " },
         { type: "reasoning-delta", id: "r1", delta: "more" },
-        { type: "reasoning-end", id: "r1" },
+        { type: "reasoning-end", id: "r1", signature: "sig_123" },
         { type: "message-finish" },
       ]),
       rec.callbacks,
@@ -158,6 +158,7 @@ describe("use-chat streaming handler", () => {
     assertExists(reasoning);
     assertEquals((reasoning as { text: string }).text, "think more");
     assertEquals((reasoning as { state: string }).state, "done");
+    assertEquals((reasoning as { signature: string }).signature, "sig_123");
   });
 
   it("forwards data events using data field then value fallback", async () => {

--- a/src/agent/react/use-chat/streaming/handler.ts
+++ b/src/agent/react/use-chat/streaming/handler.ts
@@ -594,10 +594,18 @@ function handleReasoningEnd(
   const reasoning = state.reasoningBlocks.get(reasoningId);
   if (!reasoning) return;
 
+  if (typeof parsed.signature === "string") {
+    reasoning.signature = parsed.signature;
+  }
+  if (typeof parsed.redactedData === "string") {
+    reasoning.redactedData = parsed.redactedData;
+  }
   reasoning.isComplete = true;
   state.messageParts.push({
     type: "reasoning",
     text: reasoning.text,
+    ...(typeof reasoning.signature === "string" ? { signature: reasoning.signature } : {}),
+    ...(typeof reasoning.redactedData === "string" ? { redactedData: reasoning.redactedData } : {}),
     state: "done",
   });
 

--- a/src/agent/react/use-chat/streaming/parts-builder.ts
+++ b/src/agent/react/use-chat/streaming/parts-builder.ts
@@ -58,12 +58,14 @@ function addReasoningParts(
   orderedParts: OrderedPart[],
   reasoningBlocks: Map<string, OrderedReasoning>,
 ): void {
-  for (const { order, text, isComplete } of reasoningBlocks.values()) {
+  for (const { order, text, signature, redactedData, isComplete } of reasoningBlocks.values()) {
     orderedParts.push({
       order,
       part: {
         type: "reasoning",
         text,
+        ...(typeof signature === "string" ? { signature } : {}),
+        ...(typeof redactedData === "string" ? { redactedData } : {}),
         state: isComplete ? "done" : "streaming",
       },
     });

--- a/src/agent/react/use-chat/streaming/types.ts
+++ b/src/agent/react/use-chat/streaming/types.ts
@@ -22,6 +22,8 @@ export interface StreamingToolCall {
 export interface StreamingReasoning {
   id: string;
   text: string;
+  signature?: string;
+  redactedData?: string;
   isComplete: boolean;
 }
 

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -64,6 +64,7 @@ describe("chat-stream-handler", () => {
     it("returns a clean initial state", () => {
       const state = createStreamState();
       assertEquals(state.accumulatedText, "");
+      assertEquals(state.reasoningParts, []);
       assertEquals(state.finishReason, null);
       assertEquals(state.toolCalls.size, 0);
       assertEquals(state.toolResults.length, 0);
@@ -110,6 +111,31 @@ describe("chat-stream-handler", () => {
         type: "data-tool-call-status",
         data: { toolCallId: "tool-1", status: "pending_input" },
       });
+    });
+
+    it("accumulates streamed reasoning text with Anthropic signatures", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        { type: "reasoning-start", id: "thinking-0" },
+        { type: "reasoning-delta", id: "thinking-0", delta: "Check evidence." },
+        { type: "reasoning-end", id: "thinking-0", signature: "sig_123" },
+        { type: "finish", finishReason: "stop", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "text-1", undefined);
+
+      assertEquals(state.reasoningParts, [{
+        id: "thinking-0",
+        text: "Check evidence.",
+        signature: "sig_123",
+      }]);
+      assertEquals(events, [
+        { type: "reasoning-start", id: "thinking-0" },
+        { type: "reasoning-delta", id: "thinking-0", delta: "Check evidence." },
+        { type: "reasoning-end", id: "thinking-0", signature: "sig_123" },
+      ]);
     });
 
     it("closes and reopens text segments when a tool interrupts assistant text", async () => {
@@ -206,7 +232,7 @@ describe("chat-stream-handler", () => {
           [Symbol.asyncIterator]() {
             return {
               async next() {
-                return { done: true, value: undefined };
+                return { done: true as const, value: undefined };
               },
             };
           },
@@ -416,7 +442,7 @@ describe("chat-stream-handler", () => {
           [Symbol.asyncIterator]() {
             return {
               async next() {
-                return { done: true, value: undefined };
+                return { done: true as const, value: undefined };
               },
             };
           },

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -55,8 +55,16 @@ export interface StreamingToolResult {
   preliminary?: boolean;
 }
 
+export interface StreamingReasoningPart {
+  id: string;
+  text: string;
+  signature?: string;
+  redactedData?: string;
+}
+
 export interface ChatStreamState {
   accumulatedText: string;
+  reasoningParts: StreamingReasoningPart[];
   finishReason: string | null;
   toolCalls: Map<string, StreamingToolCall>;
   toolResults: StreamingToolResult[];
@@ -277,6 +285,7 @@ function requestStreamIteratorReturn(iterator: AsyncIterator<unknown>): void {
 export function createStreamState(): ChatStreamState {
   return {
     accumulatedText: "",
+    reasoningParts: [],
     finishReason: null,
     toolCalls: new Map(),
     toolResults: [],
@@ -307,6 +316,7 @@ export function processStream(
     let eventCount = 0;
     let textOpen = false;
     let activeReasoningId: string | null = null;
+    const reasoningParts = new Map<string, StreamingReasoningPart>();
     let shouldStopForCommittedLocalToolCall = false;
     let hasActiveLocalToolInput = false;
     const providerExecutedToolNames = new Set(callbacks?.providerExecutedToolNames ?? []);
@@ -354,6 +364,11 @@ export function processStream(
       }
 
       activeReasoningId = reasoningId;
+      if (!reasoningParts.has(reasoningId)) {
+        const part = { id: reasoningId, text: "" };
+        reasoningParts.set(reasoningId, part);
+        state.reasoningParts.push(part);
+      }
       sendSSE(controller, encoder, {
         type: "reasoning-start",
         id: reasoningId,
@@ -365,9 +380,12 @@ export function processStream(
         return;
       }
 
+      const reasoningPart = reasoningParts.get(activeReasoningId);
       sendSSE(controller, encoder, {
         type: "reasoning-end",
         id: activeReasoningId,
+        ...(reasoningPart?.signature ? { signature: reasoningPart.signature } : {}),
+        ...(reasoningPart?.redactedData ? { redactedData: reasoningPart.redactedData } : {}),
       });
       activeReasoningId = null;
     };
@@ -586,10 +604,15 @@ export function processStream(
 
         case "reasoning-delta": {
           closeTextSegment();
-          openReasoningSegment(normalizeReasoningId(typedPart));
+          const reasoningId = normalizeReasoningId(typedPart);
+          openReasoningSegment(reasoningId);
+          const reasoningPart = reasoningParts.get(reasoningId);
+          if (reasoningPart) {
+            reasoningPart.text += typeof typedPart.delta === "string" ? typedPart.delta : "";
+          }
           sendSSE(controller, encoder, {
             type: "reasoning-delta",
-            id: normalizeReasoningId(typedPart),
+            id: reasoningId,
             delta: typeof typedPart.delta === "string" ? typedPart.delta : "",
           });
           break;
@@ -599,6 +622,15 @@ export function processStream(
           closeTextSegment();
           if (activeReasoningId === null) {
             activeReasoningId = normalizeReasoningId(typedPart);
+          }
+          const reasoningPart = reasoningParts.get(activeReasoningId);
+          if (reasoningPart) {
+            if (typeof typedPart.signature === "string") {
+              reasoningPart.signature = typedPart.signature;
+            }
+            if (typeof typedPart.redactedData === "string") {
+              reasoningPart.redactedData = typedPart.redactedData;
+            }
           }
           closeReasoningSegment();
           break;

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1389,6 +1389,21 @@ export class AgentRuntime {
       finalFinishReason = state.finishReason ?? finalFinishReason;
 
       const streamParts: MessagePart[] = [];
+      for (const reasoningPart of state.reasoningParts) {
+        if (
+          reasoningPart.text.length === 0 &&
+          !reasoningPart.signature &&
+          !reasoningPart.redactedData
+        ) {
+          continue;
+        }
+        streamParts.push({
+          type: "reasoning",
+          ...(reasoningPart.text.length > 0 ? { text: reasoningPart.text } : {}),
+          ...(reasoningPart.signature ? { signature: reasoningPart.signature } : {}),
+          ...(reasoningPart.redactedData ? { redactedData: reasoningPart.redactedData } : {}),
+        });
+      }
       if (state.accumulatedText) streamParts.push({ type: "text", text: state.accumulatedText });
 
       for (const tc of state.toolCalls.values()) {

--- a/src/agent/runtime/message-adapter.test.ts
+++ b/src/agent/runtime/message-adapter.test.ts
@@ -68,6 +68,12 @@ function agentRuntimeTextPart(text: string): AgentRuntimeMessagePart {
   return { type: "text", text };
 }
 
+function isRuntimeTextPart(
+  part: AgentRuntimeMessagePart | undefined,
+): part is { type: "text"; text: string } {
+  return part?.type === "text" && "text" in part && typeof part.text === "string";
+}
+
 function agentRuntimeToolCallPart(
   args: Record<string, unknown>,
   type = "tool-call",
@@ -114,7 +120,7 @@ describe("agent runtime message adapter", () => {
     ]);
   });
 
-  it("ignores reasoning-only parts when converting agent runtime messages", () => {
+  it("preserves reasoning parts when converting provider messages into agent runtime messages", () => {
     const agentRuntimeMessages = convertProviderMessagesToAgentRuntimeMessages([
       providerMessage({
         role: "assistant",
@@ -122,13 +128,17 @@ describe("agent runtime message adapter", () => {
           {
             type: "reasoning",
             text: "Hidden thinking",
+            signature: "sig_123",
           },
           providerTextPart("Visible answer"),
         ],
       }),
     ]);
 
-    assertEquals(agentRuntimeMessages[0]?.parts, [agentRuntimeTextPart("Visible answer")]);
+    assertEquals(agentRuntimeMessages[0]?.parts, [
+      { type: "reasoning", text: "Hidden thinking", signature: "sig_123" },
+      agentRuntimeTextPart("Visible answer"),
+    ]);
   });
 
   it("passes image and file parts with URLs as native AgentRuntimeMessage parts", () => {
@@ -254,7 +264,7 @@ describe("agent runtime message adapter", () => {
     assertEquals(agentRuntimeMessages[0]?.parts.length, 1);
     const firstPart = agentRuntimeMessages[0]?.parts[0];
     assertEquals(firstPart?.type, "text");
-    if (firstPart && "text" in firstPart) {
+    if (isRuntimeTextPart(firstPart)) {
       assertStringIncludes(firstPart.text, "<uploaded_files>");
       assertStringIncludes(firstPart.text, "diagram.png");
     }
@@ -324,6 +334,29 @@ describe("agent runtime message adapter", () => {
         role: "tool",
         content: [
           providerToolResultPart(jsonOutput({ matches: 2 })),
+        ],
+      },
+    ]);
+  });
+
+  it("preserves reasoning replay metadata when replaying agent runtime messages", () => {
+    const providerMessages = convertAgentRuntimeMessagesToProviderMessages([
+      agentRuntimeMessage(
+        "assistant",
+        [
+          { type: "reasoning", text: "Checked evidence.", signature: "sig_123" },
+          agentRuntimeTextPart("Done."),
+        ],
+        0,
+      ),
+    ]);
+
+    assertEquals(providerMessages, [
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "Checked evidence.", signature: "sig_123" },
+          providerTextPart("Done."),
         ],
       },
     ]);

--- a/src/agent/runtime/message-adapter.ts
+++ b/src/agent/runtime/message-adapter.ts
@@ -15,6 +15,7 @@ type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string
 
 type AgentRuntimeMessageLikePart =
   | { type: "text"; text: string }
+  | { type: "reasoning"; text?: string; signature?: string; redactedData?: string }
   | {
     type: string;
     toolCallId: string;
@@ -65,6 +66,7 @@ type AgentRuntimeMessageLikePart =
 /** Public API contract for agent runtime message part. */
 export type AgentRuntimeMessagePart =
   | { type: "text"; text: string }
+  | { type: "reasoning"; text?: string; signature?: string; redactedData?: string }
   | {
     type: string;
     toolCallId: string;
@@ -90,12 +92,19 @@ export interface AgentRuntimeMessage {
 
 interface AgentRuntimeProviderContentParts {
   textParts: ProviderTextPart[];
+  reasoningParts: ProviderReasoningPart[];
   toolCallParts: ProviderToolCallPart[];
   toolResultParts: ChatToolResultPart[];
   fileParts: ChatModelFilePart[];
 }
 
 type ProviderTextPart = { type: "text"; text: string };
+type ProviderReasoningPart = {
+  type: "reasoning";
+  text?: string;
+  signature?: string;
+  redactedData?: string;
+};
 
 type ProviderToolCallPart = {
   type: "tool-call";
@@ -157,7 +166,12 @@ function convertStructuredPart(part: StructuredProviderPart): AgentRuntimeMessag
       return createTextAgentRuntimePart(part.text);
 
     case "reasoning":
-      return null;
+      return {
+        type: "reasoning",
+        ...(typeof part.text === "string" ? { text: part.text } : {}),
+        ...(typeof part.signature === "string" ? { signature: part.signature } : {}),
+        ...(typeof part.redactedData === "string" ? { redactedData: part.redactedData } : {}),
+      };
 
     case "tool-call":
       return {
@@ -301,6 +315,25 @@ export function getAgentRuntimeTextPart(part: unknown): { type: "text"; text: st
     : null;
 }
 
+/** Return a runtime reasoning part when the value carries reasoning replay state. */
+export function getAgentRuntimeReasoningPart(part: unknown): ProviderReasoningPart | null {
+  if (!isRecord(part) || part.type !== "reasoning") {
+    return null;
+  }
+  const text = typeof part.text === "string" ? part.text : undefined;
+  const signature = typeof part.signature === "string" ? part.signature : undefined;
+  const redactedData = typeof part.redactedData === "string" ? part.redactedData : undefined;
+  if (!text && !signature && !redactedData) {
+    return null;
+  }
+  return {
+    type: "reasoning",
+    ...(text ? { text } : {}),
+    ...(signature ? { signature } : {}),
+    ...(redactedData ? { redactedData } : {}),
+  };
+}
+
 /** Return a runtime tool-call part when the value carries a tool call. */
 export function getAgentRuntimeToolCallPart(
   part: unknown,
@@ -380,6 +413,7 @@ function collectAgentRuntimeProviderContentParts(
   parts: ReadonlyArray<AgentRuntimeMessageLikePart>,
 ): AgentRuntimeProviderContentParts {
   const textParts: ProviderTextPart[] = [];
+  const reasoningParts: ProviderReasoningPart[] = [];
   const toolCallParts: ProviderToolCallPart[] = [];
   const toolResultParts: ChatToolResultPart[] = [];
   const fileParts: ChatModelFilePart[] = [];
@@ -388,6 +422,12 @@ function collectAgentRuntimeProviderContentParts(
     const textPart = getAgentRuntimeTextPart(part);
     if (textPart) {
       textParts.push(textPart);
+      continue;
+    }
+
+    const reasoningPart = getAgentRuntimeReasoningPart(part);
+    if (reasoningPart) {
+      reasoningParts.push(reasoningPart);
       continue;
     }
 
@@ -416,7 +456,7 @@ function collectAgentRuntimeProviderContentParts(
     }
   }
 
-  return { textParts, toolCallParts, toolResultParts, fileParts };
+  return { textParts, reasoningParts, toolCallParts, toolResultParts, fileParts };
 }
 
 function createProviderMessageFromAgentRuntimeMessage(
@@ -424,18 +464,18 @@ function createProviderMessageFromAgentRuntimeMessage(
     parts: ReadonlyArray<AgentRuntimeMessageLikePart>;
   },
 ): ProviderModelMessage | null {
-  const { textParts, toolCallParts, toolResultParts, fileParts } =
+  const { textParts, reasoningParts, toolCallParts, toolResultParts, fileParts } =
     collectAgentRuntimeProviderContentParts(message.parts);
 
   switch (message.role) {
     case "assistant":
-      if (textParts.length === 0 && toolCallParts.length === 0) {
+      if (reasoningParts.length === 0 && textParts.length === 0 && toolCallParts.length === 0) {
         return null;
       }
 
       return {
         role: "assistant",
-        content: [...textParts, ...toolCallParts],
+        content: [...reasoningParts, ...textParts, ...toolCallParts],
       };
 
     case "tool":

--- a/src/agent/runtime/runtime-tool-types.ts
+++ b/src/agent/runtime/runtime-tool-types.ts
@@ -62,7 +62,7 @@ export type RuntimeStreamPart =
   | { type: "text-delta"; text: string }
   | { type: "reasoning-start"; id: string }
   | { type: "reasoning-delta"; id: string; delta: string }
-  | { type: "reasoning-end"; id: string }
+  | { type: "reasoning-end"; id: string; signature?: string; redactedData?: string }
   | {
     type: `data-${string}`;
     data: unknown;

--- a/src/agent/schemas/agent.schema.ts
+++ b/src/agent/schemas/agent.schema.ts
@@ -91,6 +91,12 @@ export const getMessagePartSchema = defineSchema((v) =>
       type: v.literal("text"),
       text: v.string(),
     }),
+    v.object({
+      type: v.literal("reasoning"),
+      text: v.string().optional(),
+      signature: v.string().optional(),
+      redactedData: v.string().optional(),
+    }),
     getToolCallPartSchema(),
     inlineToolCallPartShape(v),
     getToolResultPartSchema(),

--- a/src/chat/conversation.ts
+++ b/src/chat/conversation.ts
@@ -74,8 +74,9 @@ export const getMessagePartSchema = defineSchema((v) =>
     }),
     v.object({
       type: v.literal("reasoning"),
-      text: v.string(),
+      text: v.string().optional(),
       signature: v.string().optional(),
+      redactedData: v.string().optional(),
     }),
     v.object({
       type: v.literal("citation"),
@@ -187,7 +188,9 @@ export interface TextPartLike {
 /** Reasoning-like provider message part. */
 export interface ReasoningPartLike {
   type: "reasoning";
-  text: string;
+  text?: string;
+  signature?: string;
+  redactedData?: string;
 }
 
 /** Chat UI tool part with a call ID and state. */
@@ -385,7 +388,12 @@ export function toConversationPartsFromUiMessage(message: ChatUiMessage): Messag
     }
 
     if (part.type === "reasoning") {
-      parts.push({ type: "reasoning", text: part.text });
+      parts.push({
+        type: "reasoning",
+        text: part.text,
+        ...(part.signature ? { signature: part.signature } : {}),
+        ...(part.redactedData ? { redactedData: part.redactedData } : {}),
+      });
       continue;
     }
 
@@ -536,7 +544,10 @@ export function isTextPart(value: unknown): value is TextPartLike {
 
 /** Check whether a value is a reasoning part. */
 export function isReasoningPart(value: unknown): value is ReasoningPartLike {
-  return isRecord(value) && value.type === "reasoning" && typeof value.text === "string";
+  return isRecord(value) && value.type === "reasoning" &&
+    (typeof value.text === "string" ||
+      typeof value.signature === "string" ||
+      typeof value.redactedData === "string");
 }
 
 /** Message shape for extract text from. */
@@ -832,7 +843,7 @@ function convertAssistantMessage(message: ChatUiMessage): ProviderModelMessage[]
   const rawToolNamesById = buildRawToolNameMap(message.parts);
   const assistantContent: Array<
     | { type: "text"; text: string }
-    | { type: "reasoning"; text: string }
+    | { type: "reasoning"; text?: string; signature?: string; redactedData?: string }
     | { type: "file" | "image"; mediaType: string; data: string; filename?: string }
     | { type: "tool-call"; toolCallId: string; toolName: string; input: Record<string, unknown> }
   > = [];
@@ -881,7 +892,7 @@ function convertAssistantMessage(message: ChatUiMessage): ProviderModelMessage[]
   const pushAssistantPart = (
     part:
       | { type: "text"; text: string }
-      | { type: "reasoning"; text: string }
+      | { type: "reasoning"; text?: string; signature?: string; redactedData?: string }
       | { type: "file" | "image"; mediaType: string; data: string; filename?: string }
       | { type: "tool-call"; toolCallId: string; toolName: string; input: Record<string, unknown> },
   ) => {
@@ -936,7 +947,12 @@ function convertAssistantMessage(message: ChatUiMessage): ProviderModelMessage[]
     }
 
     if (isReasoningPart(part)) {
-      pushAssistantPart({ type: "reasoning", text: part.text });
+      pushAssistantPart({
+        type: "reasoning",
+        text: part.text,
+        ...(typeof part.signature === "string" ? { signature: part.signature } : {}),
+        ...(typeof part.redactedData === "string" ? { redactedData: part.redactedData } : {}),
+      });
       continue;
     }
 

--- a/src/chat/hosted-ui-chunk-mapping.test.ts
+++ b/src/chat/hosted-ui-chunk-mapping.test.ts
@@ -50,6 +50,20 @@ describe("chat/hosted-ui-chunk-mapping", () => {
     );
 
     assertEquals(mapHostedStreamPartToChatUiChunks({ type: "abort" }), [{ type: "abort" }]);
+    assertEquals(
+      mapHostedStreamPartToChatUiChunks({
+        type: "reasoning-end",
+        id: "reasoning-1",
+        signature: "sig_123",
+        redactedData: "encrypted",
+      }),
+      [{
+        type: "reasoning-end",
+        id: "reasoning-1",
+        signature: "sig_123",
+        redactedData: "encrypted",
+      }],
+    );
     assertEquals(mapHostedStreamPartToChatUiChunks({ type: "finish" }), [{ type: "finish" }]);
   });
 });

--- a/src/chat/hosted-ui-chunk-mapping.ts
+++ b/src/chat/hosted-ui-chunk-mapping.ts
@@ -56,6 +56,8 @@ export type HostedStreamPartForUiChunkMapping =
   | {
     type: "reasoning-end";
     id: string;
+    signature?: string;
+    redactedData?: string;
   }
   | {
     type: "text-start";
@@ -250,7 +252,12 @@ export function mapHostedStreamPartToChatUiChunks(
         : [];
 
     case "reasoning-end":
-      return [{ type: "reasoning-end", id: options.reasoningMessageId ?? part.id }];
+      return [{
+        type: "reasoning-end",
+        id: options.reasoningMessageId ?? part.id,
+        ...(typeof part.signature === "string" ? { signature: part.signature } : {}),
+        ...(typeof part.redactedData === "string" ? { redactedData: part.redactedData } : {}),
+      }];
 
     case "text-start":
       return [{ type: "text-start", id: options.messageId ?? part.id }];

--- a/src/chat/protocol.ts
+++ b/src/chat/protocol.ts
@@ -18,6 +18,8 @@ export interface ChatTextPart {
 export interface ChatReasoningPart {
   type: "reasoning";
   text: string;
+  signature?: string;
+  redactedData?: string;
   state?: ChatPartState;
 }
 
@@ -199,6 +201,8 @@ export type ChatStreamEvent =
   | {
     type: "reasoning-end";
     id: string;
+    signature?: string;
+    redactedData?: string;
   }
   | ({
     type: "tool-input-start";
@@ -346,7 +350,12 @@ export type ChatUiMessageChunk<TMessageMetadata = ChatMessageMetadata> =
   }
   | IdChunk<"reasoning-start">
   | IdDeltaChunk<"reasoning-delta">
-  | IdChunk<"reasoning-end">
+  | {
+    type: "reasoning-end";
+    id: string;
+    signature?: string;
+    redactedData?: string;
+  }
   | IdChunk<"text-start">
   | IdDeltaChunk<"text-delta">
   | IdChunk<"text-end">

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -77,6 +77,8 @@ export type ChatTextUiPart = {
 export type ChatReasoningUiPart = {
   type: "reasoning";
   text: string;
+  signature?: string;
+  redactedData?: string;
 };
 
 /** Public API contract for chat step start UI part. */
@@ -193,7 +195,9 @@ export type ChatModelTextPart = {
 /** Provider model message part that carries reasoning text. */
 export type ChatModelReasoningPart = {
   type: "reasoning";
-  text: string;
+  text?: string;
+  signature?: string;
+  redactedData?: string;
 };
 
 /** Public API contract for chat model file part. */
@@ -455,6 +459,8 @@ const getChatReasoningUiPartSchema = defineSchema((v) =>
   v.object({
     type: v.literal("reasoning"),
     text: v.string(),
+    signature: v.string().optional(),
+    redactedData: v.string().optional(),
   }).strip()
 );
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.686";
+export const VERSION = "0.1.687";


### PR DESCRIPTION
## Summary
- Preserve Anthropic streamed reasoning signatures and redacted thinking through runtime, chat protocol, browser assembly, replay, and child-fork preparation.
- Treat Anthropic provider-option thinking as enabled when shaping sampling params and max_tokens.
- Add generic evidence_refs support to hosted child fork inputs.
- Add an agent message stream dataflow architecture note.
- Bump veryfront-code to 0.1.687 for release.

## Verification
- deno task fmt:check
- deno task lint
- deno task typecheck
- deno task docs:validate
- deno test --allow-env src/utils/version.test.ts src/utils/logger/logger.test.ts
- deno test --allow-env extensions/ext-llm-anthropic/src/anthropic-provider.test.ts extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/message-adapter.test.ts src/agent/hosted/child-tool-input.test.ts src/agent/hosted/child-fork-step-message-preparation.test.ts src/agent/react/use-chat/streaming/handler.test.ts
- deno test --allow-env extensions/ext-llm-openai/src/openai-provider.test.ts extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts extensions/ext-llm-openai/src/openai-responses-stream.test.ts extensions/ext-llm-google/src/google-provider.test.ts extensions/ext-llm-google/src/google-request-builder.test.ts src/provider/veryfront-cloud/model-catalog.test.ts src/provider/veryfront-cloud/provider.test.ts src/agent/runtime/provider-native-tool-inventory.test.ts src/agent/runtime/provider-tool-compat.test.ts
- deno test --no-check src/chat/conversation.test.ts src/chat/hosted-ui-chunk-mapping.test.ts src/chat/chat-ui-message-helpers.test.ts src/chat/ag-ui.test.ts
- pre-push hook: 2003 unit test files passed, 0 failed
