### PR TITLE
Preserve hosted runtime essentials under narrowed tools

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.689",
+  "version": "0.1.690",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted/chat-runtime-tool-assembly.test.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.test.ts
@@ -56,6 +56,87 @@ Deno.test("filterHostedChatRuntimeLocalTools filters and sorts local tools", () 
   assertEquals(Object.keys(result), ["invoke_agent", "sleep"]);
 });
 
+Deno.test("prepareHostedChatRuntimeToolAssembly preserves runtime-essential skill tools under non-empty allowed tools", async () => {
+  const taskContext: HostedChatRuntimeToolAssemblyContext = {
+    authToken: "token",
+    projectId: "project-1",
+    model: "anthropic/claude-sonnet-4-6",
+    availableSkillIds: ["plan"],
+  };
+
+  const toolAssembly = await prepareHostedChatRuntimeToolAssembly({
+    taskContext,
+    instructions: "Base instructions",
+    localTools: {
+      invoke_agent: localTool("Invoke agent"),
+      load_skill: localTool("Load skill"),
+      sleep: localTool("Sleep"),
+    },
+    apiUrl: "https://api.example.com",
+    apiMcpUrl: "https://api.example.com/mcp",
+    allowedToolNames: ["sleep"],
+    createRemoteToolSource: remoteSourceFromConfig,
+    preloadLatestConversationUserText: false,
+  });
+
+  assertEquals(toolAssembly.localToolNames, ["invoke_agent", "load_skill", "sleep"]);
+  assertEquals(taskContext.availableToolNames, ["invoke_agent", "load_skill", "sleep"]);
+});
+
+Deno.test("prepareHostedChatRuntimeToolAssembly keeps empty allowed tools as explicit deny-all", async () => {
+  const taskContext: HostedChatRuntimeToolAssemblyContext = {
+    authToken: "token",
+    projectId: "project-1",
+    model: "anthropic/claude-sonnet-4-6",
+    availableSkillIds: ["plan"],
+  };
+
+  const toolAssembly = await prepareHostedChatRuntimeToolAssembly({
+    taskContext,
+    instructions: "Base instructions",
+    localTools: {
+      invoke_agent: localTool("Invoke agent"),
+      load_skill: localTool("Load skill"),
+      sleep: localTool("Sleep"),
+    },
+    apiUrl: "https://api.example.com",
+    apiMcpUrl: "https://api.example.com/mcp",
+    allowedToolNames: [],
+    createRemoteToolSource: remoteSourceFromConfig,
+    preloadLatestConversationUserText: false,
+  });
+
+  assertEquals(toolAssembly.localToolNames, []);
+  assertEquals(taskContext.availableToolNames, []);
+});
+
+Deno.test("prepareHostedChatRuntimeToolAssembly does not add skill tools when no skills are active", async () => {
+  const taskContext: HostedChatRuntimeToolAssemblyContext = {
+    authToken: "token",
+    projectId: "project-1",
+    model: "anthropic/claude-sonnet-4-6",
+    availableSkillIds: [],
+  };
+
+  const toolAssembly = await prepareHostedChatRuntimeToolAssembly({
+    taskContext,
+    instructions: "Base instructions",
+    localTools: {
+      invoke_agent: localTool("Invoke agent"),
+      load_skill: localTool("Load skill"),
+      sleep: localTool("Sleep"),
+    },
+    apiUrl: "https://api.example.com",
+    apiMcpUrl: "https://api.example.com/mcp",
+    allowedToolNames: ["sleep"],
+    createRemoteToolSource: remoteSourceFromConfig,
+    preloadLatestConversationUserText: false,
+  });
+
+  assertEquals(toolAssembly.localToolNames, ["sleep"]);
+  assertEquals(taskContext.availableToolNames, ["sleep"]);
+});
+
 Deno.test("prepareHostedChatRuntimeToolAssembly builds provider-compatible runtime inventory", async () => {
   const taskContext: HostedChatRuntimeToolAssemblyContext = {
     authToken: "token",

--- a/src/agent/hosted/chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.ts
@@ -29,6 +29,11 @@ import { type RuntimeClientProfile } from "../runtime/client-profile.ts";
 import { selectProviderCompatibleToolNames } from "../runtime/provider-tool-compat.ts";
 import { getProviderNativeToolNames } from "../runtime/provider-native-tool-inventory.ts";
 import { flattenSystemInstructions, withRuntimeToolInventory } from "../runtime/tool-inventory.ts";
+import {
+  type HostedRuntimeAllowedToolNames,
+  normalizeHostedRuntimeAllowedToolNames,
+  resolveHostedRuntimeAllowedToolNames,
+} from "./runtime-essential-tools.ts";
 
 /** Context for hosted chat runtime tool assembly. */
 export type HostedChatRuntimeToolAssemblyContext = DefaultResearchArtifactContext & {
@@ -38,11 +43,12 @@ export type HostedChatRuntimeToolAssemblyContext = DefaultResearchArtifactContex
   model?: string;
   clientProfile?: RuntimeClientProfile | null;
   availableToolNames?: string[];
+  availableSkillIds?: readonly string[];
   userId?: string | null;
 };
 
 /** Public API contract for hosted chat runtime allowed tool names. */
-export type HostedChatRuntimeAllowedToolNames = readonly string[] | ReadonlySet<string> | null;
+export type HostedChatRuntimeAllowedToolNames = HostedRuntimeAllowedToolNames;
 
 /** Result returned from hosted chat runtime tool assembly. */
 export type HostedChatRuntimeToolAssemblyResult = {
@@ -82,16 +88,6 @@ export type PrepareHostedChatRuntimeToolAssemblyInput<
   preloadLatestConversationUserText?: boolean;
 };
 
-function normalizeAllowedToolNames(
-  toolNames: HostedChatRuntimeAllowedToolNames | undefined,
-): ReadonlySet<string> | null {
-  if (!toolNames) {
-    return null;
-  }
-
-  return new Set(toolNames);
-}
-
 function activeProjectId(taskContext: HostedChatRuntimeToolAssemblyContext): string | null {
   return taskContext.projectId || null;
 }
@@ -105,7 +101,7 @@ export function filterHostedChatRuntimeLocalTools(input: {
   tools: HostToolSet;
   allowedToolNames?: HostedChatRuntimeAllowedToolNames;
 }): HostToolSet {
-  const allowedToolNames = normalizeAllowedToolNames(input.allowedToolNames);
+  const allowedToolNames = normalizeHostedRuntimeAllowedToolNames(input.allowedToolNames);
   const entries = Object.entries(input.tools).filter(([toolName]) =>
     allowedToolNames ? allowedToolNames.has(toolName) : true
   );
@@ -119,7 +115,11 @@ export async function prepareHostedChatRuntimeToolAssembly<
 >(
   input: PrepareHostedChatRuntimeToolAssemblyInput<TTraceAttributes>,
 ): Promise<HostedChatRuntimeToolAssemblyResult> {
-  const allowedToolNames = normalizeAllowedToolNames(input.allowedToolNames);
+  const allowedToolNames = resolveHostedRuntimeAllowedToolNames({
+    allowedToolNames: input.allowedToolNames,
+    localToolNames: Object.keys(input.localTools),
+    availableSkillIds: input.taskContext.availableSkillIds,
+  });
   const sortedLocalTools = filterHostedChatRuntimeLocalTools({
     tools: input.localTools,
     allowedToolNames,

--- a/src/agent/hosted/runtime-essential-tools.ts
+++ b/src/agent/hosted/runtime-essential-tools.ts
@@ -1,0 +1,54 @@
+/** Public API contract for hosted runtime allowed tool names. */
+export type HostedRuntimeAllowedToolNames = readonly string[] | ReadonlySet<string> | null;
+
+/** Input payload for resolving hosted runtime allowed tools. */
+export type ResolveHostedRuntimeAllowedToolNamesInput = {
+  allowedToolNames?: HostedRuntimeAllowedToolNames;
+  localToolNames: Iterable<string>;
+  availableSkillIds?: readonly string[];
+};
+
+const SKILL_RUNTIME_TOOL_NAMES = ["load_skill", "load_skill_reference"] as const;
+const SKILL_DELEGATION_TOOL_NAMES = ["invoke_agent"] as const;
+
+/** Normalize hosted runtime allowed tools. */
+export function normalizeHostedRuntimeAllowedToolNames(
+  toolNames: HostedRuntimeAllowedToolNames | undefined,
+): ReadonlySet<string> | null {
+  if (!toolNames) {
+    return null;
+  }
+
+  return new Set(toolNames);
+}
+
+/** Resolve allowed tools after applying runtime-essential hosted tool policy. */
+export function resolveHostedRuntimeAllowedToolNames(
+  input: ResolveHostedRuntimeAllowedToolNamesInput,
+): ReadonlySet<string> | null {
+  const allowedToolNames = normalizeHostedRuntimeAllowedToolNames(input.allowedToolNames);
+  if (!allowedToolNames || allowedToolNames.size === 0) {
+    return allowedToolNames;
+  }
+
+  if (!input.availableSkillIds?.length) {
+    return allowedToolNames;
+  }
+
+  const localToolNames = new Set(input.localToolNames);
+  const resolvedToolNames = new Set(allowedToolNames);
+
+  for (const toolName of SKILL_RUNTIME_TOOL_NAMES) {
+    if (localToolNames.has(toolName)) {
+      resolvedToolNames.add(toolName);
+    }
+  }
+
+  for (const toolName of SKILL_DELEGATION_TOOL_NAMES) {
+    if (localToolNames.has(toolName)) {
+      resolvedToolNames.add(toolName);
+    }
+  }
+
+  return resolvedToolNames;
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.689";
+export const VERSION = "0.1.690";


### PR DESCRIPTION
## Summary
- Preserve hosted skill runtime-essential local tools when a non-empty allowedTools list narrows hosted tool assembly.
- Keep allowedTools: [] as an explicit deny-all and leave non-skill runs narrowed.
- Bump the release version from 0.1.689 to 0.1.690 for veryfront-code.

## Issue Assessment
Fixes #2074. This was worth patching because hosted skill-enabled runs could advertise skill workflows while filtering out the local tools required to execute them.

## Verification
- deno test --no-check --allow-all src/agent/hosted/chat-runtime-tool-assembly.test.ts src/agent/hosted/default-chat-runtime.test.ts src/agent/hosted/chat-preparation.test.ts src/agent/hosted/runtime-request-config.test.ts src/agent/hosted/project-steering-adapter.test.ts src/agent/hosted/agent-project-steering.test.ts
- deno task verify:quick
- deno task test:unit
- pre-push hook: format, lint, typecheck, unit tests all passed