### PR TITLE
Add structured context to agent delegation

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.689",
+  "version": "0.1.690",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/architecture/27-agent-message-stream-dataflow.md
+++ b/docs/architecture/27-agent-message-stream-dataflow.md
@@ -168,12 +168,16 @@ when the tool input is complete enough to commit.
 conversation context and tool inventory. The parent transcript receives a compact
 summary/result and durable child-run identifiers, not the full child transcript.
 
-When the parent needs the child to use structured facts from prior tool results,
-it can pass generic `evidence_refs`. These refs point to prior run/message/tool
-evidence and are appended to the child prompt as structured context. They are
-also stored in child-run metadata. This avoids asking the parent model to
-rewrite critical facts as prose and lets the child prefer referenced evidence
-when prose conflicts with the refs.
+When the parent needs the child to act on critical facts from prior tool
+results, it should pass generic `context`. This is the child execution payload:
+records, ids, decisions, and other structured values the child must preserve.
+The prompt explains the task, but `context` carries the data to act on.
+
+The parent can also pass generic `evidence_refs`. These refs point to prior
+run/message/tool evidence and are stored with the child-run metadata for audit
+and replay. `context` is enough for execution correctness; `evidence_refs`
+explain where the context came from. The child prompt receives both blocks and
+is instructed to prefer `structured_context` when prose conflicts with it.
 
 Child run events should remain inspectable and streamable through child-run
 views. They should not be dumped into the parent context, because that would

--- a/src/agent/hosted/child-tool-input.test.ts
+++ b/src/agent/hosted/child-tool-input.test.ts
@@ -11,6 +11,13 @@ Deno.test("hostedChildForkToolInputSchema accepts the hosted child fork fields",
   const parsed = hostedChildForkToolInputSchema.parse({
     description: "review auth flow",
     prompt: "Review the authentication flow and report issues.",
+    context: {
+      matched_invoice: {
+        invoice_id: "INV-2026-00491",
+        supplier: "Meyer Papier GmbH",
+        amount: 2180,
+      },
+    },
     evidence_refs: [{
       run_id: "run_123",
       tool_call_id: "tool_123",
@@ -27,6 +34,13 @@ Deno.test("hostedChildForkToolInputSchema accepts the hosted child fork fields",
   assertEquals(parsed, {
     description: "review auth flow",
     prompt: "Review the authentication flow and report issues.",
+    context: {
+      matched_invoice: {
+        invoice_id: "INV-2026-00491",
+        supplier: "Meyer Papier GmbH",
+        amount: 2180,
+      },
+    },
     evidence_refs: [{
       run_id: "run_123",
       tool_call_id: "tool_123",
@@ -39,6 +53,49 @@ Deno.test("hostedChildForkToolInputSchema accepts the hosted child fork fields",
     thinking: 1024,
     max_steps: 12,
   });
+});
+
+Deno.test("resolveHostedChildForkRuntimeConfig appends structured context before evidence refs", () => {
+  const result = resolveHostedChildForkRuntimeConfig({
+    forkInput: {
+      description: "release invoice",
+      prompt: "Release the invoice if the structured context is valid.",
+      context: {
+        matched_invoice: {
+          invoice_id: "INV-2026-00491",
+          supplier: "Meyer Papier GmbH",
+          amount: 2180,
+          currency: "EUR",
+        },
+      },
+      evidence_refs: [{
+        run_id: "run_match",
+        tool_call_id: "tool_match",
+        result_path: "$.matched_invoices[1]",
+      }],
+    },
+    contextModel: "opus",
+    defaultModel: "haiku",
+    defaultMaxSteps: 80,
+    runId: "tool-call-1",
+    resolveModelId: (modelId) => `resolved-${modelId}`,
+    resolveProvider: (modelId) => `provider-for-${modelId}`,
+  });
+
+  assertEquals(result.effectivePrompt.includes("<structured_context>"), true);
+  assertEquals(result.effectivePrompt.includes('"supplier":"Meyer Papier GmbH"'), true);
+  assertEquals(result.effectivePrompt.includes("<evidence_refs>"), true);
+  assertEquals(
+    result.effectivePrompt.indexOf("<structured_context>") <
+      result.effectivePrompt.indexOf("<evidence_refs>"),
+    true,
+  );
+  assertEquals(
+    result.effectivePrompt.includes(
+      "Treat structured_context as the authoritative data payload for the child task.",
+    ),
+    true,
+  );
 });
 
 Deno.test("resolveHostedChildForkRuntimeConfig appends evidence refs as structured child context", () => {

--- a/src/agent/hosted/child-tool-input.ts
+++ b/src/agent/hosted/child-tool-input.ts
@@ -1,4 +1,4 @@
-import { defineSchema, lazySchema } from "#veryfront/schemas/index.ts";
+import { defineSchema, getJsonValueSchema, lazySchema } from "#veryfront/schemas/index.ts";
 import type { InferSchema } from "#veryfront/extensions/schema/index.ts";
 import { withDefaultResearchArtifactPath } from "../artifacts/default-research-artifact-policy.ts";
 import type { RuntimeAgentThinkingConfig } from "../runtime/agent-definition.ts";
@@ -22,6 +22,9 @@ export const getHostedChildForkToolInputSchema = defineSchema((v) =>
   v.object({
     description: v.string().describe("3-5 word task summary"),
     prompt: v.string().describe("Detailed instructions for the task"),
+    context: v.record(v.string(), getJsonValueSchema()).optional().describe(
+      "Structured data payload for the child task. Use this for critical facts and records the child must act on.",
+    ),
     evidence_refs: v.array(getHostedChildForkEvidenceRefSchema()).optional().describe(
       "Generic source-of-truth references for facts the child must preserve. " +
         "Use run_id/message_id/tool_call_id plus result_path instead of copying critical facts as prose.",
@@ -69,7 +72,14 @@ export type HostedChildForkRuntimeConfig = {
 export type ResolveHostedChildForkRuntimeConfigInput = {
   forkInput: Pick<
     HostedChildForkToolInput,
-    "description" | "prompt" | "evidence_refs" | "tools" | "model" | "thinking" | "max_steps"
+    | "description"
+    | "prompt"
+    | "context"
+    | "evidence_refs"
+    | "tools"
+    | "model"
+    | "thinking"
+    | "max_steps"
   >;
   contextModel?: string;
   defaultModel: string;
@@ -107,11 +117,29 @@ function appendEvidenceRefsToPrompt(
   }\n</evidence_refs>\nTreat these references as source-of-truth pointers. If prose conflicts with referenced evidence, prefer the referenced evidence and say what conflicted.`;
 }
 
+function hasStructuredContext(context: HostedChildForkToolInput["context"]): boolean {
+  return context !== undefined && Object.keys(context).length > 0;
+}
+
+function appendStructuredContextToPrompt(
+  prompt: string,
+  context: HostedChildForkToolInput["context"],
+): string {
+  if (!hasStructuredContext(context)) {
+    return prompt;
+  }
+
+  return `${prompt}\n\n<structured_context>\n${
+    JSON.stringify(context)
+  }\n</structured_context>\nTreat structured_context as the authoritative data payload for the child task. If prose conflicts with structured_context, use structured_context and say what conflicted.`;
+}
+
 /** Configuration used by resolve hosted child fork runtime. */
 export function resolveHostedChildForkRuntimeConfig(
   input: ResolveHostedChildForkRuntimeConfigInput,
 ): HostedChildForkRuntimeConfig {
-  const { description, prompt, evidence_refs, tools, model, thinking, max_steps } = input.forkInput;
+  const { description, prompt, context, evidence_refs, tools, model, thinking, max_steps } =
+    input.forkInput;
   const forkModel = input.resolveModelId(model || input.contextModel || input.defaultModel);
   const requestedMaxSteps = typeof max_steps === "number" ? max_steps : undefined;
   const promptWithArtifactPath = withDefaultResearchArtifactPath({
@@ -122,7 +150,10 @@ export function resolveHostedChildForkRuntimeConfig(
 
   return {
     description,
-    effectivePrompt: appendEvidenceRefsToPrompt(promptWithArtifactPath, evidence_refs),
+    effectivePrompt: appendEvidenceRefsToPrompt(
+      appendStructuredContextToPrompt(promptWithArtifactPath, context),
+      evidence_refs,
+    ),
     requestedTools: tools,
     forkModel,
     provider: input.resolveProvider(forkModel),

--- a/src/agent/runtime/current-run-tool-state.test.ts
+++ b/src/agent/runtime/current-run-tool-state.test.ts
@@ -298,6 +298,36 @@ describe("current-run tool state", () => {
     );
   });
 
+  it("derives delegated agent semantic record keys from structured context", () => {
+    const state = createCurrentRunToolState();
+    const now = new Date("2026-01-01T00:00:00.000Z");
+
+    recordCurrentRunToolResult(state, {
+      toolCallId: "call_1",
+      toolName: "invoke_agent",
+      input: {
+        agent_id: "payment-approval-agent",
+        prompt: "Approve the matched invoice from structured context.",
+        context: {
+          matched_invoice: {
+            invoice_id: "INV-2026-00491",
+            supplier: "Meyer Papier GmbH",
+          },
+        },
+      },
+      result: { status: "completed", output: "Approved INV-2026-00491" },
+      now,
+    });
+
+    const prompt = appendCurrentRunToolStateToSystemPrompt("Base system", state);
+
+    assertStringIncludes(prompt, '"agent:payment-approval-agent:record:INV-2026-00491"');
+    assertStringIncludes(
+      prompt,
+      '"parameters":{"agent_id":"payment-approval-agent","record_id":"INV-2026-00491"}',
+    );
+  });
+
   it("blocks invoke_agent inputs that contradict prior current-run tool evidence", () => {
     const state = createCurrentRunToolState();
 

--- a/src/agent/runtime/current-run-tool-state.ts
+++ b/src/agent/runtime/current-run-tool-state.ts
@@ -754,6 +754,40 @@ function compactStringParameter(value: unknown): string | null {
   return null;
 }
 
+function findRecordIdInStructuredContext(value: unknown): string | null {
+  if (typeof value === "string") {
+    return getRecordIds(value)[0] ?? null;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findRecordIdInStructuredContext(item);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  for (const key of ["record_id", "recordId", "entity_id", "entityId", "id"] as const) {
+    const found = compactStringParameter(value[key]);
+    if (found && getRecordIds(found).length > 0) return found;
+  }
+
+  for (const entry of Object.values(value)) {
+    const found = findRecordIdInStructuredContext(entry);
+    if (found) return found;
+  }
+
+  return null;
+}
+
 function getSemanticToolCall(input: {
   toolName: string;
   call: CurrentRunToolStateCall;
@@ -781,7 +815,8 @@ function getSemanticToolCall(input: {
         compactStringParameter(input.call.input.invoice_id) ??
         compactStringParameter(input.call.input.invoiceId) ??
         compactStringParameter(input.call.input.entity_id) ??
-        compactStringParameter(input.call.input.entityId);
+        compactStringParameter(input.call.input.entityId) ??
+        findRecordIdInStructuredContext(input.call.input.context);
       const keySuffix = recordId
         ? `:record:${recordId}`
         : stepId

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.689";
+export const VERSION = "0.1.690";


### PR DESCRIPTION
## Summary
- add a generic structured context payload to hosted child agent delegation
- append context to child prompts before evidence refs and document the handoff contract
- derive delegated semantic replay keys from structured context so repeated child calls stay distinct
- bump Veryfront Code to 0.1.690 for release

## Verification
- deno test --no-check --allow-all src/agent/hosted/child-tool-input.test.ts src/agent/runtime/current-run-tool-state.test.ts
- deno check src/agent/hosted/child-tool-input.ts src/agent/runtime/current-run-tool-state.ts
- deno lint src/agent/hosted/child-tool-input.ts src/agent/hosted/child-tool-input.test.ts src/agent/runtime/current-run-tool-state.ts src/agent/runtime/current-run-tool-state.test.ts
- deno task build:npm