### PR TITLE
Require structured child handoff context

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.690",
+  "version": "0.1.691",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted/child-tool-input.test.ts
+++ b/src/agent/hosted/child-tool-input.test.ts
@@ -103,6 +103,7 @@ Deno.test("resolveHostedChildForkRuntimeConfig appends evidence refs as structur
     forkInput: {
       description: "release matched record",
       prompt: "Use the matched record and perform the requested action.",
+      context: {},
       evidence_refs: [{
         run_id: "run_match",
         tool_call_id: "tool_match",
@@ -119,20 +120,32 @@ Deno.test("resolveHostedChildForkRuntimeConfig appends evidence refs as structur
   });
 
   assertEquals(result.effectivePrompt.includes("Use the matched record"), true);
+  assertEquals(result.effectivePrompt.includes("<structured_context>\n{}"), true);
   assertEquals(result.effectivePrompt.includes("<evidence_refs>"), true);
   assertEquals(result.effectivePrompt.includes('"run_id":"run_match"'), true);
   assertEquals(result.effectivePrompt.includes('"result_path":"$.records[0]"'), true);
+});
+
+Deno.test("hostedChildForkToolInputSchema requires structured child context", () => {
+  const result = hostedChildForkToolInputSchema.safeParse({
+    description: "write tests",
+    prompt: "Add focused tests for the changed helper.",
+  });
+
+  assertEquals(result.success, false);
 });
 
 Deno.test("hostedChildForkToolInputSchema preserves omitted optional fork controls", () => {
   const parsed = hostedChildForkToolInputSchema.parse({
     description: "write tests",
     prompt: "Add focused tests for the changed helper.",
+    context: {},
   });
 
   assertEquals(parsed, {
     description: "write tests",
     prompt: "Add focused tests for the changed helper.",
+    context: {},
   });
 });
 
@@ -140,6 +153,7 @@ Deno.test("hostedChildForkToolInputSchema rejects negative thinking budgets", ()
   const result = hostedChildForkToolInputSchema.safeParse({
     description: "bad budget",
     prompt: "Try an invalid budget.",
+    context: {},
     thinking: -1,
   });
 
@@ -164,6 +178,7 @@ Deno.test("resolveHostedChildForkRuntimeConfig resolves reusable child fork runt
     forkInput: {
       description: "research solar panels",
       prompt: "Research solar panels and save the report to the project.",
+      context: {},
       tools: ["readFile"],
       model: "sonnet",
       thinking: 1024,
@@ -194,6 +209,7 @@ Deno.test("resolveHostedChildForkRuntimeConfig raises low requested child max st
     forkInput: {
       description: "research services",
       prompt: "Research the available services and report findings.",
+      context: {},
       max_steps: 15,
     },
     contextModel: "opus",
@@ -212,6 +228,7 @@ Deno.test("resolveHostedChildForkRuntimeConfig preserves high requested child ma
     forkInput: {
       description: "build feature",
       prompt: "Build the requested feature.",
+      context: {},
       max_steps: 160,
     },
     contextModel: "opus",
@@ -230,6 +247,7 @@ Deno.test("resolveHostedChildForkRuntimeConfig falls back to context model and d
     forkInput: {
       description: "write tests",
       prompt: "Write focused tests.",
+      context: {},
     },
     contextModel: "opus",
     defaultModel: "haiku",
@@ -243,5 +261,6 @@ Deno.test("resolveHostedChildForkRuntimeConfig falls back to context model and d
   assertEquals(result.provider, "provider-for-resolved-opus");
   assertEquals(result.maxSteps, 80);
   assertEquals(result.thinkingConfig, undefined);
-  assertEquals(result.effectivePrompt, "Write focused tests.");
+  assertEquals(result.effectivePrompt.includes("Write focused tests."), true);
+  assertEquals(result.effectivePrompt.includes("<structured_context>\n{}"), true);
 });

--- a/src/agent/hosted/child-tool-input.ts
+++ b/src/agent/hosted/child-tool-input.ts
@@ -22,8 +22,8 @@ export const getHostedChildForkToolInputSchema = defineSchema((v) =>
   v.object({
     description: v.string().describe("3-5 word task summary"),
     prompt: v.string().describe("Detailed instructions for the task"),
-    context: v.record(v.string(), getJsonValueSchema()).optional().describe(
-      "Structured data payload for the child task. Use this for critical facts and records the child must act on.",
+    context: v.record(v.string(), getJsonValueSchema()).describe(
+      "Required structured data payload for the child task. Use this for critical facts, records, ids, decisions, and values the child must act on. Use {} only when the delegation has no record or evidence payload.",
     ),
     evidence_refs: v.array(getHostedChildForkEvidenceRefSchema()).optional().describe(
       "Generic source-of-truth references for facts the child must preserve. " +
@@ -117,18 +117,10 @@ function appendEvidenceRefsToPrompt(
   }\n</evidence_refs>\nTreat these references as source-of-truth pointers. If prose conflicts with referenced evidence, prefer the referenced evidence and say what conflicted.`;
 }
 
-function hasStructuredContext(context: HostedChildForkToolInput["context"]): boolean {
-  return context !== undefined && Object.keys(context).length > 0;
-}
-
 function appendStructuredContextToPrompt(
   prompt: string,
   context: HostedChildForkToolInput["context"],
 ): string {
-  if (!hasStructuredContext(context)) {
-    return prompt;
-  }
-
   return `${prompt}\n\n<structured_context>\n${
     JSON.stringify(context)
   }\n</structured_context>\nTreat structured_context as the authoritative data payload for the child task. If prose conflicts with structured_context, use structured_context and say what conflicted.`;

--- a/src/agent/hosted/default-invoke-agent-tool.test.ts
+++ b/src/agent/hosted/default-invoke-agent-tool.test.ts
@@ -52,11 +52,13 @@ Deno.test("defaultHostedInvokeAgentInputSchema accepts child-agent selection", (
     defaultHostedInvokeAgentInputSchema.parse({
       description: "inspect auth",
       prompt: "Inspect auth flow.",
+      context: {},
       agent_id: "security-reviewer",
     }),
     {
       description: "inspect auth",
       prompt: "Inspect auth flow.",
+      context: {},
       agent_id: "security-reviewer",
     },
   );
@@ -69,6 +71,7 @@ Deno.test("executeDefaultHostedInvokeAgentTool returns durable context failure b
     {
       description: "inspect auth",
       prompt: "Inspect auth flow.",
+      context: {},
       agent_id: undefined,
     },
     "security-reviewer",
@@ -105,6 +108,7 @@ Deno.test("createDefaultHostedInvokeAgentTool adds child selection guidance and 
     {
       description: "inspect auth",
       prompt: "Inspect auth flow.",
+      context: {},
       agent_id: "custom-child",
     },
     { toolCallId: "tool-call-2" },

--- a/src/agent/runtime/current-run-tool-state.test.ts
+++ b/src/agent/runtime/current-run-tool-state.test.ts
@@ -370,6 +370,41 @@ describe("current-run tool state", () => {
     );
   });
 
+  it("blocks invoke_agent structured context that contradicts prior current-run evidence", () => {
+    const state = createCurrentRunToolState();
+
+    recordCurrentRunToolResult(state, {
+      toolCallId: "invoke-ingest-1",
+      toolName: "invoke_agent",
+      input: { agent_id: "ingest-invoice-agent", prompt: "Load open invoices" },
+      result: {
+        status: "completed",
+        summary: {
+          text: "| Invoice | Supplier | Route |\n" +
+            "| --- | --- | --- |\n" +
+            "| INV-2026-00491 | Meyer Papier GmbH | Matching (valid) |\n",
+        },
+      },
+    });
+
+    const invalid = validateInvokeAgentInputAgainstCurrentRunEvidence(state, {
+      agent_id: "payment-approval-agent",
+      prompt: "Approve the matched invoice INV-2026-00491 from the structured context.",
+      context: {
+        invoice: {
+          invoice_id: "INV-2026-00491",
+          supplier: "Brenntag Schweizerhall AG",
+        },
+      },
+    });
+
+    assertEquals(invalid.ok, false);
+    if (!invalid.ok) {
+      assertStringIncludes(invalid.error, 'INV-2026-00491 supplier is "Meyer Papier GmbH"');
+      assertStringIncludes(invalid.error, "Brenntag Schweizerhall AG");
+    }
+  });
+
   it("keeps hidden evidence out of the projected current-run prompt state", () => {
     const state = createCurrentRunToolState();
 

--- a/src/agent/runtime/current-run-tool-state.ts
+++ b/src/agent/runtime/current-run-tool-state.ts
@@ -43,6 +43,7 @@ const MAX_EVIDENCE_TEXT_LENGTH = 20_000;
 const MAX_EVIDENCE_STRINGS = 12;
 const MAX_EVIDENCE_RECORDS = 25;
 const MAX_EVIDENCE_FIELDS_PER_RECORD = 12;
+const MAX_STRUCTURED_ASSERTION_LINES = 80;
 const RECORD_ID_PATTERN = /\b[A-Z][A-Z0-9]+-\d{4}-\d{3,}\b/g;
 const NEXT_RECORD_ID_PATTERN = /\b[A-Z][A-Z0-9]+-\d{4}-\d{3,}\b/;
 const GUARDED_FACT_ALIASES: Record<string, string[]> = {
@@ -317,13 +318,56 @@ function getRecordTextWindows(text: string, recordId: string): string[] {
   return windows;
 }
 
+function primitiveStructuredValueToString(value: unknown): string | null {
+  if (typeof value === "string") return value.trim() || null;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  if (typeof value === "boolean") return String(value);
+  return null;
+}
+
+function collectStructuredAssertionLines(
+  value: unknown,
+  lines: string[] = [],
+  path: string[] = [],
+): string[] {
+  if (lines.length >= MAX_STRUCTURED_ASSERTION_LINES) return lines;
+
+  const primitiveValue = primitiveStructuredValueToString(value);
+  if (primitiveValue !== null && path.length > 0) {
+    lines.push(`${path.join(".")}: ${truncate(primitiveValue, 300)}`);
+    return lines;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectStructuredAssertionLines(item, lines, path);
+      if (lines.length >= MAX_STRUCTURED_ASSERTION_LINES) break;
+    }
+    return lines;
+  }
+
+  if (!isRecord(value)) return lines;
+
+  for (const [key, entry] of Object.entries(value)) {
+    collectStructuredAssertionLines(entry, lines, [...path, key]);
+    if (lines.length >= MAX_STRUCTURED_ASSERTION_LINES) break;
+  }
+
+  return lines;
+}
+
 export function validateInvokeAgentInputAgainstCurrentRunEvidence(
   state: CurrentRunToolState,
   input: unknown,
 ): { ok: true } | { ok: false; error: string } {
   if (!isRecord(input)) return { ok: true };
   const text = normalizeWhitespace(
-    [input.prompt, input.description, input.input]
+    [
+      input.prompt,
+      input.description,
+      input.input,
+      ...collectStructuredAssertionLines(input.context),
+    ]
       .filter((value): value is string => typeof value === "string")
       .join("\n"),
   );

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.690";
+export const VERSION = "0.1.691";


### PR DESCRIPTION
## Summary
- require invoke_agent child handoffs to include an explicit structured context object
- always append structured context to child prompts and persist it in child run metadata
- validate structured handoff context against current-run evidence to catch cross-record contradictions
- bump veryfront package version to 0.1.691

## Tests
- deno test -A src/agent/runtime/current-run-tool-state.test.ts
- deno test -A src/agent/hosted/default-invoke-agent-tool.test.ts src/agent/hosted/child-tool-input.test.ts
- deno task verify:quick
- pre-push hook: fmt, lint, typecheck, unit tests (2008 passed)