### PR TITLE
Add runtime user credentials

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.691",
+  "version": "0.1.692",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/agent-invocation-contract.test.ts
+++ b/src/agent/runtime/agent-invocation-contract.test.ts
@@ -57,6 +57,7 @@ function createInvocation(overrides: Record<string, unknown> = {}) {
       },
     }],
     context: [{ type: "text", text: "Current file: app.tsx" }],
+    credentials: { authToken: "request-scoped-user-token" },
     agentSource: { type: "branch", branch: "main" },
     forwardedProps: { activeChatId: "chat_123" },
     ...overrides,
@@ -72,6 +73,7 @@ describe("agent/runtime-agent-invocation-contract", () => {
     assertEquals(parsed.run.validatedClaims?.scopes, ["agent:run"]);
     assertEquals(parsed.messages.length, 2);
     assertEquals(parsed.tools[0]?.name, "studio_focus_component");
+    assertEquals(parsed.credentials?.authToken, "request-scoped-user-token");
   });
 
   it("accepts main branch runtime targets without branch or environment selectors", () => {
@@ -232,6 +234,7 @@ describe("agent/runtime-agent-invocation-contract", () => {
       messages: parsed.messages,
       tools: parsed.tools,
       context: parsed.context,
+      credentials: parsed.credentials,
       agentSource: parsed.agentSource,
       forwardedProps: parsed.forwardedProps,
     });

--- a/src/agent/runtime/agent-invocation-contract.ts
+++ b/src/agent/runtime/agent-invocation-contract.ts
@@ -9,6 +9,7 @@ const MAX_TOOL_PARAMETERS_BYTES = 16_384;
 const MAX_CONTEXT_ITEM_BYTES = 16_384;
 const MAX_CONTEXT_TOTAL_BYTES = 65_536;
 const MAX_FORWARDED_PROPS_BYTES = 196_608;
+const MAX_CREDENTIAL_BYTES = 16_384;
 const encoder = new TextEncoder();
 
 function isWithinJsonSizeLimit(value: unknown, maxBytes: number): boolean {
@@ -296,6 +297,12 @@ export const getRuntimeAgentRunContextSchema = defineSchema((v) =>
  */
 export const RuntimeAgentRunContextSchema = lazySchema(getRuntimeAgentRunContextSchema);
 
+export const getRuntimeAgentCredentialsSchema = defineSchema((v) =>
+  v.object({
+    authToken: v.string().min(1).max(MAX_CREDENTIAL_BYTES),
+  }).strict()
+);
+
 export const getRuntimeAgentRunInvocationSchema = defineSchema((v) =>
   v.object({
     run: getRuntimeAgentRunContextSchema(),
@@ -306,6 +313,7 @@ export const getRuntimeAgentRunInvocationSchema = defineSchema((v) =>
       { message: "context must be less than 64 KB total" },
     ),
     agentSource: getRuntimeAgentSourceContextSchema().optional(),
+    credentials: getRuntimeAgentCredentialsSchema().optional(),
     forwardedProps: v.record(v.string(), v.unknown()).optional().refine(
       (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_FORWARDED_PROPS_BYTES),
       { message: "forwardedProps must be less than 192 KB" },
@@ -358,6 +366,7 @@ export type RuntimeAgentControlPlaneStreamRequest = {
   messages: RuntimeAgentRunInvocation["messages"];
   tools: RuntimeAgentRunInvocation["tools"];
   context: RuntimeAgentRunInvocation["context"];
+  credentials?: RuntimeAgentRunInvocation["credentials"];
   agentSource?: RuntimeAgentRunInvocation["agentSource"];
   forwardedProps?: RuntimeAgentRunInvocation["forwardedProps"];
 };
@@ -374,6 +383,7 @@ export function buildRuntimeAgentControlPlaneStreamRequestFromInvocation(
     messages: input.messages,
     tools: input.tools,
     context: input.context,
+    ...(input.credentials ? { credentials: input.credentials } : {}),
     ...(input.agentSource ? { agentSource: input.agentSource } : {}),
     ...(input.forwardedProps ? { forwardedProps: input.forwardedProps } : {}),
   };

--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -15,6 +15,7 @@ import {
 import { stripLeadingEmptyObjectPlaceholder } from "#veryfront/agent/streaming/data-stream.ts";
 import {
   buildRuntimeAgentControlPlaneStreamRequestFromInvocation,
+  getRuntimeAgentCredentialsSchema,
   getRuntimeAgentRunInvocationSchema,
   getRuntimeAgentSourceContextSchema,
   type RuntimeAgentSourceContext,
@@ -73,6 +74,7 @@ export const getInternalAgentControlPlaneStreamRequestSchema = defineSchema((v) 
       { message: "context must be less than 64 KB total" },
     ),
     agentSource: getRuntimeAgentSourceContextSchema().optional(),
+    credentials: getRuntimeAgentCredentialsSchema().optional(),
     forwardedProps: v.record(v.string(), v.unknown()).optional().refine(
       (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_FORWARDED_PROPS_BYTES),
       { message: "forwardedProps must be less than 192 KB" },

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -135,7 +135,9 @@ describe("server/handlers/request/agent-stream.handler", () => {
       }),
     });
 
-    const body = createAgentStreamRequestBody();
+    const body = createAgentStreamRequestBody({
+      credentials: { authToken: "request-scoped-user-token" },
+    });
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
@@ -728,7 +730,10 @@ describe("server/handlers/request/agent-stream.handler", () => {
     Deno.env.set("VERYFRONT_API_URL", "https://api.veryfront.org");
     globalThis.fetch = ((url, init) => {
       assertEquals(String(url), "https://api.veryfront.org/mcp");
-      assertEquals(new Headers(init?.headers).get("authorization"), "Bearer run-scoped-token");
+      assertEquals(
+        new Headers(init?.headers).get("authorization"),
+        "Bearer request-scoped-user-token",
+      );
       return Promise.resolve(
         new Response(
           JSON.stringify({
@@ -801,7 +806,9 @@ describe("server/handlers/request/agent-stream.handler", () => {
         }),
       });
 
-      const body = createAgentStreamRequestBody();
+      const body = createAgentStreamRequestBody({
+        credentials: { authToken: "request-scoped-user-token" },
+      });
       const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
         audience: "support-agent-fork",
         requestId: "run_1",
@@ -890,7 +897,9 @@ describe("server/handlers/request/agent-stream.handler", () => {
       }),
     });
 
-    const body = createAgentStreamRequestBody();
+    const body = createAgentStreamRequestBody({
+      credentials: { authToken: "request-scoped-user-token" },
+    });
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
       audience: "support-agent-fork",
       requestId: "run_1",
@@ -906,7 +915,10 @@ describe("server/handlers/request/agent-stream.handler", () => {
     Deno.env.set("VERYFRONT_API_URL", "https://api.veryfront.org");
     globalThis.fetch = ((url, init) => {
       fetchUrls.push(String(url));
-      assertEquals(new Headers(init?.headers).get("authorization"), "Bearer run-scoped-token");
+      assertEquals(
+        new Headers(init?.headers).get("authorization"),
+        "Bearer request-scoped-user-token",
+      );
 
       if (String(url).endsWith("/projects/support-agent-fork/environments")) {
         return Promise.resolve(
@@ -994,7 +1006,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertExists(result.response);
     assertEquals(result.response.status, 200);
     assertEquals(capturedEnv, {
-      VERYFRONT_API_TOKEN: "run-scoped-token",
+      VERYFRONT_API_TOKEN: "request-scoped-user-token",
       VERYFRONT_API_URL: "https://api.veryfront.org",
       VERYFRONT_PROJECT_SLUG: "support-agent-fork",
       CUSTOM_PROJECT_ENV: "project-value",
@@ -1002,7 +1014,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(capturedSystem, "project_reference=support-agent-fork");
     assertEquals(capturedMcpRequest, {
       url: "https://api.veryfront.org/mcp",
-      authorization: "Bearer run-scoped-token",
+      authorization: "Bearer request-scoped-user-token",
     });
     assertEquals(capturedAllowedRemoteTools, ["list_projects", "search_knowledge"]);
     assertEquals(capturedRemoteToolNames, ["search_knowledge", "list_projects"]);

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -442,9 +442,11 @@ export class AgentStreamHandler extends BaseHandler {
             }
 
             const runtimeInput = toRuntimeRunAgentInput(payload);
+            const apiAuthToken = payload.credentials?.authToken || ctx.proxyToken ||
+              getHostEnv("VERYFRONT_API_TOKEN") || "";
             const runtimeAgent = await withVeryfrontPlatformRemoteTools({
               agent: agent as Agent,
-              token: ctx.proxyToken || getHostEnv("VERYFRONT_API_TOKEN") || null,
+              token: apiAuthToken || null,
               projectId: ctx.projectId ?? null,
               availableToolNames: runtimeInput.tools.map((tool) => tool.name),
             });
@@ -454,13 +456,13 @@ export class AgentStreamHandler extends BaseHandler {
             // therefore don't carry x-environment-id, so we discover the production env ID
             // from the API (one fetch per project per server lifetime, then cached).
             let envVarsForAgent: Record<string, string> = {};
-            if (ctx.projectSlug && ctx.proxyToken) {
+            if (ctx.projectSlug && apiAuthToken) {
               const environmentId = ctx.environmentId ??
-                await _resolveProductionEnvironmentId(ctx.projectSlug, ctx.proxyToken);
+                await _resolveProductionEnvironmentId(ctx.projectSlug, apiAuthToken);
               if (environmentId) {
                 envVarsForAgent = await _agentEnvVarCache.get(
                   environmentId,
-                  ctx.proxyToken,
+                  apiAuthToken,
                   ctx.projectSlug,
                 );
                 logger.debug("Agent stream env vars loaded", {
@@ -477,16 +479,16 @@ export class AgentStreamHandler extends BaseHandler {
                 ...this.deps,
                 projectAgentSandbox: {
                   apiUrl: getHostEnv("VERYFRONT_API_URL") ?? "https://api.veryfront.com",
-                  authToken: ctx.proxyToken || getHostEnv("VERYFRONT_API_TOKEN") || undefined,
+                  authToken: apiAuthToken || undefined,
                   projectId: ctx.projectId ?? null,
                 },
               });
-            const shouldIsolateEnv = !!ctx.proxyToken;
+            const shouldIsolateEnv = apiAuthToken.length > 0;
             const response = shouldIsolateEnv
               ? await runWithProjectEnv(
                 buildAgentStreamEnv({
                   envVars: envVarsForAgent,
-                  proxyToken: ctx.proxyToken,
+                  proxyToken: apiAuthToken,
                   projectSlug: ctx.projectSlug,
                 }),
                 runAgentStream,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.691";
+export const VERSION = "0.1.692";


### PR DESCRIPTION
Adds a typed runtime credentials payload so project-agent runs can receive request-scoped Veryfront API credentials separately from control-plane stream authentication.\n\nVerification:\n- deno test -A src/agent/runtime/agent-invocation-contract.test.ts src/server/handlers/request/agent-stream.handler.test.ts\n- deno task verify:quick