### PR TITLE
Expose project env through process.env

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.692",
+  "version": "0.1.693",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/platform/compat/process/env.ts
+++ b/src/platform/compat/process/env.ts
@@ -3,6 +3,7 @@ import { runtimeProcess } from "./runtime-process.ts";
 
 type EnvOverlayValue = string | null;
 type EnvOverlayStore = Map<string, EnvOverlayValue>;
+type HostProcessEnvGetter = (key: string) => string | undefined;
 
 export type EnvOverlayStorage = {
   getStore: () => unknown;
@@ -26,6 +27,11 @@ function getOverlayEnvValue(
 
   const value = store.get(key);
   return { hasValue: true, value: value ?? undefined };
+}
+
+function getHostProcessEnvFromProjectProxy(key: string): string | undefined {
+  const getter = (globalThis as Record<string, unknown>).__vfHostProcessEnvGetter;
+  return typeof getter === "function" ? (getter as HostProcessEnvGetter)(key) : undefined;
 }
 
 /** Read and write process environment variables. */
@@ -61,6 +67,8 @@ export function getHostEnv(key: string): string | undefined {
   }
 
   if (IS_DENO) return Deno.env.get(key);
+  const projectProxyHostValue = getHostProcessEnvFromProjectProxy(key);
+  if (projectProxyHostValue !== undefined) return projectProxyHostValue;
   if (runtimeProcess) return runtimeProcess.env[key];
   return undefined;
 }

--- a/src/server/project-env/storage.test.ts
+++ b/src/server/project-env/storage.test.ts
@@ -7,6 +7,7 @@ import {
   isProjectEnvActive,
   runWithProjectEnv,
 } from "./storage.ts";
+import { getEnv, getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 describe("project-env/storage", () => {
   it("returns undefined outside any context", () => {
@@ -95,5 +96,55 @@ describe("project-env/storage", () => {
 
     assertEquals(results.includes("task1:task1"), true);
     assertEquals(results.includes("task2:task2"), true);
+  });
+
+  it("exposes project-scoped env through process.env without host fallthrough", () => {
+    const hostKey = "__VF_PROJECT_ENV_HOST_ONLY__";
+    const projectKey = "__VF_PROJECT_ENV_PROJECT_ONLY__";
+    const originalHostValue = Deno.env.get(hostKey);
+    Deno.env.set(hostKey, "host-secret");
+
+    try {
+      runWithProjectEnv({ [projectKey]: "project-token" }, () => {
+        assertEquals(process.env[projectKey], "project-token");
+        assertEquals(process.env[hostKey], undefined);
+        assertEquals(getEnv(projectKey), "project-token");
+        assertEquals(getEnv(hostKey), undefined);
+        assertEquals(getHostEnv(hostKey), "host-secret");
+      });
+    } finally {
+      if (originalHostValue === undefined) {
+        Deno.env.delete(hostKey);
+      } else {
+        Deno.env.set(hostKey, originalHostValue);
+      }
+    }
+  });
+
+  it("keeps process.env isolated across concurrent project env contexts", async () => {
+    const results: string[] = [];
+
+    const task1 = new Promise<void>((resolve) => {
+      runWithProjectEnv({ VERYFRONT_API_TOKEN: "run-token-1" }, () => {
+        setTimeout(() => {
+          results.push(`task1:${process.env.VERYFRONT_API_TOKEN}`);
+          resolve();
+        }, 10);
+      });
+    });
+
+    const task2 = new Promise<void>((resolve) => {
+      runWithProjectEnv({ VERYFRONT_API_TOKEN: "run-token-2" }, () => {
+        setTimeout(() => {
+          results.push(`task2:${process.env.VERYFRONT_API_TOKEN}`);
+          resolve();
+        }, 5);
+      });
+    });
+
+    await Promise.all([task1, task2]);
+
+    assertEquals(results.includes("task1:run-token-1"), true);
+    assertEquals(results.includes("task2:run-token-2"), true);
   });
 });

--- a/src/server/project-env/storage.ts
+++ b/src/server/project-env/storage.ts
@@ -10,12 +10,129 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
 const projectEnvStorage = new AsyncLocalStorage<Record<string, string>>();
+const PROCESS_ENV_PROXY_FLAG = "__vfProjectEnvProcessProxyInstalled";
+const PROCESS_ENV_PROXY_REF = "__vfProjectEnvProcessProxy";
+const PROCESS_ENV_HOST_GETTER = "__vfHostProcessEnvGetter";
+
+type ProcessLike = {
+  env?: Record<string | symbol, string | undefined>;
+};
+
+function getGlobalProcess(): ProcessLike | undefined {
+  const candidate = (globalThis as { process?: unknown }).process;
+  return candidate && typeof candidate === "object" ? candidate as ProcessLike : undefined;
+}
+
+function getActiveStore(): Record<string, string> | undefined {
+  return projectEnvStorage.getStore();
+}
+
+function installProcessEnvProxy(): void {
+  const globals = globalThis as Record<string, unknown>;
+
+  const processLike = getGlobalProcess();
+  if (!processLike?.env) return;
+  if (globals[PROCESS_ENV_PROXY_FLAG] && globals[PROCESS_ENV_PROXY_REF] === processLike.env) return;
+
+  const hostEnv = processLike.env;
+  globals[PROCESS_ENV_HOST_GETTER] = (key: string): string | undefined => hostEnv[key];
+
+  const proxy = new Proxy(hostEnv, {
+    get(target, property, receiver) {
+      if (typeof property !== "string") {
+        return Reflect.get(target, property, receiver);
+      }
+
+      const store = getActiveStore();
+      if (store !== undefined) {
+        return Object.prototype.hasOwnProperty.call(store, property) ? store[property] : undefined;
+      }
+
+      return target[property];
+    },
+    set(target, property, value, receiver) {
+      if (typeof property !== "string") {
+        return Reflect.set(target, property, value, receiver);
+      }
+
+      const normalized = String(value);
+      const store = getActiveStore();
+      if (store !== undefined) {
+        store[property] = normalized;
+        return true;
+      }
+
+      target[property] = normalized;
+      return true;
+    },
+    deleteProperty(target, property) {
+      if (typeof property !== "string") {
+        return Reflect.deleteProperty(target, property);
+      }
+
+      const store = getActiveStore();
+      if (store !== undefined) {
+        delete store[property];
+        return true;
+      }
+
+      return Reflect.deleteProperty(target, property);
+    },
+    has(target, property) {
+      if (typeof property !== "string") {
+        return Reflect.has(target, property);
+      }
+
+      const store = getActiveStore();
+      if (store !== undefined) {
+        return Object.prototype.hasOwnProperty.call(store, property);
+      }
+
+      return property in target;
+    },
+    ownKeys(target) {
+      const store = getActiveStore();
+      return store !== undefined ? Reflect.ownKeys(store) : Reflect.ownKeys(target);
+    },
+    getOwnPropertyDescriptor(target, property) {
+      if (typeof property !== "string") {
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      }
+
+      const store = getActiveStore();
+      if (store !== undefined) {
+        if (!Object.prototype.hasOwnProperty.call(store, property)) {
+          return undefined;
+        }
+
+        return {
+          configurable: true,
+          enumerable: true,
+          writable: true,
+          value: store[property],
+        };
+      }
+
+      return Reflect.getOwnPropertyDescriptor(target, property);
+    },
+  });
+
+  Object.defineProperty(processLike, "env", {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: proxy,
+  });
+  globals[PROCESS_ENV_PROXY_FLAG] = true;
+  globals[PROCESS_ENV_PROXY_REF] = proxy;
+}
 
 /**
  * Run a function with project-specific environment variables.
  * Within the callback, `getProjectEnv()` will return values from `vars`.
  */
 export function runWithProjectEnv<T>(vars: Record<string, string>, fn: () => T): T {
+  installProcessEnvProxy();
   return projectEnvStorage.run(vars, fn);
 }
 
@@ -50,3 +167,4 @@ export function getProjectEnvSnapshot(): Record<string, string> | undefined {
 (globalThis as Record<string, unknown>).__vfProjectEnvGetter = getProjectEnv;
 (globalThis as Record<string, unknown>).__vfProjectEnvActiveChecker = isProjectEnvActive;
 (globalThis as Record<string, unknown>).__vfProjectEnvSnapshotGetter = getProjectEnvSnapshot;
+installProcessEnvProxy();

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.692";
+export const VERSION = "0.1.693";


### PR DESCRIPTION
## Summary
- expose request-scoped project env through direct process.env reads
- keep host env isolated from project code while preserving framework host env access
- bump veryfront to 0.1.693 for release

## Verification
- deno test -A src/server/project-env/storage.test.ts src/server/project-env/framework-env-bypass.test.ts src/platform/compat/process.test.ts
- deno test -A src/server/handlers/request/agent-stream.handler.test.ts src/agent/runtime/refresh.test.ts
- deno task verify:quick
- pre-push hook: full unit suite, 2008 passed / 0 failed
