### PR TITLE
Preserve durable child run lineage

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.693",
+  "version": "0.1.694",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/conversation/bootstrap.ts
+++ b/src/agent/conversation/bootstrap.ts
@@ -311,6 +311,7 @@ export async function bootstrapConversationAgentRun(input: {
   conversationBody: unknown;
   handoffMessageBody: unknown;
   runId?: string;
+  parentRunId?: string;
   agentId: string;
   implementationKind?: string | null;
   projectId?: string | null;
@@ -342,6 +343,7 @@ export async function bootstrapConversationAgentRun(input: {
     apiUrl: input.apiUrl,
     conversationId: conversation.id,
     runId: input.runId,
+    parentRunId: input.parentRunId,
     agentId: input.agentId,
     implementationKind: input.implementationKind,
     projectId: effectiveProjectId,

--- a/src/agent/conversation/durable.ts
+++ b/src/agent/conversation/durable.ts
@@ -366,6 +366,7 @@ export interface CreateConversationAgentRunInput {
   apiUrl: string;
   conversationId: string;
   runId?: string;
+  parentRunId?: string;
   agentId: string;
   implementationKind?: string | null;
   projectId?: string | null;
@@ -1394,6 +1395,7 @@ export async function createConversationAgentRun(
         id: input.conversationId,
       },
       public_id: runId,
+      ...(input.parentRunId ? { parent_run_id: input.parentRunId } : {}),
       request,
     },
     responseSchema: CreateConversationRunAcceptedSchema,

--- a/src/agent/hosted/child-bootstrap.test.ts
+++ b/src/agent/hosted/child-bootstrap.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { bootstrapHostedChildRun, buildHostedChildConversationBody } from "./child-bootstrap.ts";
 
@@ -125,7 +125,14 @@ describe("agent/hosted-child-bootstrap", () => {
       latestExternalEventSequence: 3,
       status: "running",
     });
-    assertEquals(requests[1].body, {
+    const childConversationRequest = requests[1];
+    const handoffMessageRequest = requests[2];
+    const childRunRequest = requests[3];
+    assertExists(childConversationRequest);
+    assertExists(handoffMessageRequest);
+    assertExists(childRunRequest);
+
+    assertEquals(childConversationRequest.body, {
       project_id: PROJECT_ID,
       type: "project_agent",
       title: "Inspect logs",
@@ -140,17 +147,18 @@ describe("agent/hosted-child-bootstrap", () => {
         },
       },
     });
-    assertEquals(requests[2].body, {
+    assertEquals(handoffMessageRequest.body, {
       role: "user",
       parts: [{ type: "text", text: "Find the latest logs." }],
     });
-    assertEquals(requests[3].body, {
+    assertEquals(childRunRequest.body, {
       kind: "agent",
       owner: {
         kind: "conversation",
         id: CHILD_CONVERSATION_ID,
       },
       public_id: "run_child_1",
+      parent_run_id: "parent-run-1",
       request: {
         mode: "agent",
         agent_id: "invoke-agent-child",
@@ -219,13 +227,17 @@ describe("agent/hosted-child-bootstrap", () => {
     });
 
     assertEquals(result.status, "pending");
-    assertEquals(requests[3].body, {
+    const childRunRequest = requests[3];
+    assertExists(childRunRequest);
+
+    assertEquals(childRunRequest.body, {
       kind: "agent",
       owner: {
         kind: "conversation",
         id: CHILD_CONVERSATION_ID,
       },
       public_id: "run_child_queued",
+      parent_run_id: "parent-run-1",
       request: {
         mode: "agent",
         agent_id: "invoke-agent-child",

--- a/src/agent/hosted/child-bootstrap.ts
+++ b/src/agent/hosted/child-bootstrap.ts
@@ -63,6 +63,7 @@ export async function bootstrapHostedChildRun(
       parts: [{ type: "text", text: input.prompt }],
     },
     runId: input.runId,
+    parentRunId: input.parentRunId,
     agentId: input.agentId,
     implementationKind: input.implementationKind,
     projectId: input.runProjectId ?? null,

--- a/src/agent/hosted/durable-child-fork-execution.test.ts
+++ b/src/agent/hosted/durable-child-fork-execution.test.ts
@@ -657,6 +657,7 @@ describe("agent/hosted-durable-child-fork-execution", () => {
         id: CHILD_CONVERSATION_ID,
       },
       public_id: getPublicId(createRunBody),
+      parent_run_id: "run_parent_1",
       request: {
         mode: "agent",
         agent_id: "invoke-agent-child",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.693";
+export const VERSION = "0.1.694";


### PR DESCRIPTION
## Summary
- pass parent_run_id when bootstrapping hosted durable child runs
- keep child run bootstrap tests aligned for direct and queued child runs
- bump veryfront package version to 0.1.694

## Verification
- deno test --allow-all src/agent/hosted/child-bootstrap.test.ts
- deno test --no-check --allow-all src/agent/hosted/child-bootstrap.test.ts src/agent/hosted/default-invoke-agent-tool.test.ts src/agent/hosted/durable-child-fork-execution.test.ts
- deno fmt --check deno.json src/agent/conversation/bootstrap.ts src/agent/conversation/durable.ts src/agent/hosted/child-bootstrap.ts src/agent/hosted/child-bootstrap.test.ts src/agent/hosted/durable-child-fork-execution.test.ts && deno check src/agent/index.ts
- deno task verify:quick
- pre-push hook: 2008 tests passed