### PR TITLE
Fix compiled esbuild discovery fallback

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.694",
+  "version": "0.1.695",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
+++ b/extensions/ext-bundler-esbuild/src/esbuild-bundler.ts
@@ -72,6 +72,12 @@ function mapOptions(options: BundleOptions): Record<string, unknown> {
   return mapped;
 }
 
+function isCompiledRuntimeUnrefError(error: unknown): boolean {
+  return error instanceof Error &&
+    error.message.includes("Cannot read properties of undefined") &&
+    error.message.includes("unref");
+}
+
 /** esbuild-backed {@link Bundler} implementation. */
 export class EsbuildBundler implements Bundler {
   async bundle(options: BundleOptions): Promise<BundleResult> {
@@ -88,7 +94,15 @@ export class EsbuildBundler implements Bundler {
   async transform(options: TransformOptions): Promise<TransformResult> {
     const esbuild = await getEsbuild();
     const { code, ...rest } = options;
-    const result = await esbuild.transform(code, rest);
+    let result;
+    try {
+      result = await esbuild.transform(code, rest);
+    } catch (error) {
+      if (!isCompiledRuntimeUnrefError(error) || typeof esbuild.transformSync !== "function") {
+        throw error;
+      }
+      result = esbuild.transformSync(code, rest);
+    }
     return {
       code: result.code,
       map: result.map,

--- a/src/discovery/transpiler.ts
+++ b/src/discovery/transpiler.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Plugin, PluginBuild } from "veryfront/extensions/bundler";
+import type { BundleOptions } from "veryfront/extensions/bundler";
 import { isDeno, isDenoCompiled } from "#veryfront/platform/compat/runtime.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import * as pathHelper from "#veryfront/compat/path";
@@ -184,7 +185,7 @@ export async function importModule(
   // Use fsAdapter plugin whenever a VFS adapter is available (regardless of runtime)
   const plugins = hasFsAdapter ? [createFsAdapterPlugin(context.fsAdapter!)] : [];
 
-  const result = await build({
+  const buildOptions: BundleOptions = {
     bundle: true,
     write: false,
     format: "esm",
@@ -217,7 +218,36 @@ export async function importModule(
       resolveDir: fileDir,
       sourcefile: filePath,
     },
-  });
+  };
+
+  let result;
+  try {
+    result = await build(buildOptions);
+  } catch (error) {
+    if (
+      !isCompiledRuntimeUnrefError(error) ||
+      hasRelativeRuntimeImports(source)
+    ) {
+      throw error;
+    }
+
+    const { transform } = await import("veryfront/extensions/bundler");
+    const transformed = await transform(source, {
+      loader,
+      format: "esm",
+      target: "es2022",
+      jsx: "automatic",
+      jsxImportSource: "react",
+    });
+    result = {
+      errors: [],
+      outputFiles: [{
+        path: filePath,
+        contents: new TextEncoder().encode(transformed.code),
+        text: transformed.code,
+      }],
+    };
+  }
 
   if (result.errors.length > 0) {
     throw COMPILATION_ERROR.create({
@@ -253,4 +283,15 @@ export async function importModule(
  */
 export function clearTranspileCache(): void {
   transpileCache.clear();
+}
+
+function isCompiledRuntimeUnrefError(error: unknown): boolean {
+  return error instanceof Error &&
+    error.message.includes("Cannot read properties of undefined") &&
+    error.message.includes("unref");
+}
+
+function hasRelativeRuntimeImports(source: string): boolean {
+  return /\b(?:import|export)\s+(?:[^"']*from\s*)?["']\.\.?\//.test(source) ||
+    /\bimport\s*\(\s*["']\.\.?\//.test(source);
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.694";
+export const VERSION = "0.1.695";


### PR DESCRIPTION
## Summary
- add a compiled-runtime fallback for esbuild transform when the async service path throws `Cannot read properties of undefined (reading 'unref')`
- allow primitive discovery to use transform fallback for source files without relative runtime imports, preserving normal build behavior for files that need bundling
- keeps the fix narrow to unblock project primitive discovery and TSX transforms in compiled staging runtime

## Evidence
- Staging `veryfront-server` logs for ai-operations root runs showed primitive discovery returning 0 agents/tools with repeated `Cannot read properties of undefined (reading 'unref')`, followed by `Internal agent stream request referenced unknown agent` HTTP 404.
- Same staging image also logged TSX render transform failures from `/app/components/layout.tsx` with the same `unref` error.
- Local discovery against `<local-path>` found 7 agents, 7 tools, 2 skills, and 0 discovery errors.

## Verification
- `deno check --config deno.json src/discovery/transpiler.ts extensions/ext-bundler-esbuild/src/esbuild-bundler.ts`
- `deno test -A --config deno.json src/discovery/transpiler.test.ts src/discovery/auto-discovery.integration.test.ts extensions/ext-bundler-esbuild/src/esbuild-bundler.test.ts`

## Follow-up
After merge and staging deploy, rerun the ai-operations Supplier Invoice Orchestrator demo to confirm project agents are discovered and the orchestrator completes.
