### PR TITLE
Require explicit invoke_agent target

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.695",
+  "version": "0.1.696",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted/default-invoke-agent-tool.test.ts
+++ b/src/agent/hosted/default-invoke-agent-tool.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import type { CreateSandboxBashTool } from "#veryfront/sandbox";
 import {
   createDefaultHostedInvokeAgentTool,
@@ -64,6 +64,33 @@ Deno.test("defaultHostedInvokeAgentInputSchema accepts child-agent selection", (
   );
 });
 
+Deno.test("defaultHostedInvokeAgentInputSchema requires explicit child-agent selection", async () => {
+  await assertRejects(
+    async () =>
+      defaultHostedInvokeAgentInputSchema.parse({
+        description: "inspect auth",
+        prompt: "Inspect auth flow.",
+        context: {},
+      }),
+    Error,
+    "agent_id",
+  );
+});
+
+Deno.test("defaultHostedInvokeAgentInputSchema rejects blank child-agent selection", async () => {
+  await assertRejects(
+    async () =>
+      defaultHostedInvokeAgentInputSchema.parse({
+        description: "inspect auth",
+        prompt: "Inspect auth flow.",
+        context: {},
+        agent_id: "   ",
+      }),
+    Error,
+    "agent_id must not be blank",
+  );
+});
+
 Deno.test("executeDefaultHostedInvokeAgentTool returns durable context failure before local execution", async () => {
   const traceAttributes: DefaultHostedInvokeAgentTraceAttributes[] = [];
   const result = await executeDefaultHostedInvokeAgentTool(
@@ -72,7 +99,7 @@ Deno.test("executeDefaultHostedInvokeAgentTool returns durable context failure b
       description: "inspect auth",
       prompt: "Inspect auth flow.",
       context: {},
-      agent_id: undefined,
+      agent_id: "security-reviewer",
     },
     "security-reviewer",
     { toolCallId: "tool-call-1" },
@@ -102,7 +129,7 @@ Deno.test("createDefaultHostedInvokeAgentTool adds child selection guidance and 
     createTestOptions({ traceAttributes }),
   );
 
-  assertStringIncludes(invokeTool.description, "Use agent_id to target");
+  assertStringIncludes(invokeTool.description, "agent_id is required");
 
   const result = await invokeTool.execute(
     {

--- a/src/agent/hosted/default-invoke-agent-tool.ts
+++ b/src/agent/hosted/default-invoke-agent-tool.ts
@@ -48,7 +48,6 @@ import {
 } from "./durable-child-fork-execution.ts";
 import type { HostedChildRunIdentifiers } from "./child-status.ts";
 import {
-  DEFAULT_HOSTED_CHILD_AGENT_ID,
   getHostedChildForkToolInputSchema,
   type HostedChildForkRuntimeConfig,
   type HostedChildForkToolInput,
@@ -147,7 +146,10 @@ export type DefaultHostedInvokeAgentToolOptions<TContext extends DefaultHostedIn
   };
 
 const defaultHostedInvokeAgentSelectionFields = (v: SchemaValidator) => ({
-  agent_id: v.string().optional().describe("Built-in child agent type or user-defined agent id."),
+  agent_id: v.string()
+    .min(1, "agent_id is required")
+    .regex(/\S/, "agent_id must not be blank")
+    .describe("Built-in child agent type or user-defined agent id."),
 });
 
 export const getDefaultHostedInvokeAgentSelectionSchema = defineSchema((v) =>
@@ -183,7 +185,7 @@ const DURABLE_INVOKE_CONTEXT_UNAVAILABLE = "DURABLE_INVOKE_CONTEXT_UNAVAILABLE";
 const DURABLE_INVOKE_SETUP_FAILED = "DURABLE_INVOKE_SETUP_FAILED";
 
 function resolveDefaultChildAgentId(input: DefaultHostedInvokeAgentInput): string {
-  return input.agent_id?.trim() || DEFAULT_HOSTED_CHILD_AGENT_ID;
+  return input.agent_id.trim();
 }
 
 function resolveChildAgentId(
@@ -580,7 +582,7 @@ export function createDefaultHostedInvokeAgentTool<
   >({
     inputSchema: defaultHostedInvokeAgentInputSchema,
     additionalDescriptionParts: [
-      "Use agent_id to target a specific built-in or custom child agent.",
+      "agent_id is required. Use it to target a specific built-in or custom child agent.",
     ],
     buildFailureResult: buildHostedDurableChildInvokeFailureResult,
     decorateResult: withRootOwnedChildResultHint,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.695";
+export const VERSION = "0.1.696";


### PR DESCRIPTION
## Summary

- Require `invoke_agent` calls to include a non-blank `agent_id` instead of silently falling back to a default child agent.
- Update the `invoke_agent` description to make the target requirement explicit.
- Bump `veryfront` to `0.1.696` for staging rollout.

## Why

A project-agent orchestrator can omit `agent_id` in an `invoke_agent` call. Before this change, the runtime silently used a fallback child agent id, which can create the wrong child run and recursive orchestration behavior instead of failing at the tool contract boundary.

## Verification

- `deno test -A --config deno.json src/agent/hosted/default-invoke-agent-tool.test.ts src/agent/runtime/refresh.test.ts`
- `deno task typecheck`

## Notes

- Local full pre-push unit suite was interrupted after it stopped producing output for several minutes; GitHub CI is the full gate for this PR.
