### PR TITLE
Improve HTTP cache memory diagnostics

### DIFF
--- a/src/transforms/esm/http-cache-state.test.ts
+++ b/src/transforms/esm/http-cache-state.test.ts
@@ -73,7 +73,13 @@ describe("transforms/esm/http-cache-state", () => {
       try {
         const stats = getCacheStats();
 
-        assertEquals(stats.find((s) => s.name === "http-bundle-paths")?.entries, 2);
+        const bundlePathStats = stats.find((s) => s.name === "http-bundle-paths");
+        assertEquals(bundlePathStats?.entries, 2);
+        assertEquals(
+          bundlePathStats?.estimatedSizeBytes,
+          "cache-dir:https://esm.sh/react".length + "/tmp/http-1.mjs".length +
+            "cache-dir:https://esm.sh/react-dom".length + "/tmp/http-2.mjs".length,
+        );
         assertEquals(stats.find((s) => s.name === "http-bundle-ttl-refreshes")?.entries, 1);
         assertEquals(stats.find((s) => s.name === "http-bundle-in-flight")?.entries, 1);
       } finally {

--- a/src/transforms/esm/http-cache-state.ts
+++ b/src/transforms/esm/http-cache-state.ts
@@ -33,10 +33,27 @@ function getCacheEntryCount(cache: unknown): number {
   return typeof size === "number" ? size : -1;
 }
 
+function estimateStringCacheBytes(cache: unknown): number | undefined {
+  const entries = (cache as { entries?: unknown }).entries;
+  if (typeof entries !== "function") return undefined;
+
+  let total = 0;
+  try {
+    for (const [key, value] of entries.call(cache) as Iterable<[unknown, unknown]>) {
+      total += String(key).length + String(value).length;
+    }
+  } catch (_) {
+    return undefined;
+  }
+
+  return total;
+}
+
 registerCache("http-bundle-paths", () => ({
   name: "http-bundle-paths",
   entries: getCacheEntryCount(getCachedPaths()),
   maxEntries: HTTP_MODULE_CACHE_MAX_ENTRIES,
+  estimatedSizeBytes: estimateStringCacheBytes(getCachedPaths()),
 }));
 
 registerCache("http-bundle-ttl-refreshes", () => ({


### PR DESCRIPTION
## Summary\n- report estimatedSizeBytes for the http-bundle-paths memory-profiler cache entry\n- keep cache behavior unchanged while making rapid heap-growth warnings more actionable\n- cover the profiler registration output with a regression assertion\n\n## Verification\n- deno test --no-check --allow-all src/transforms/esm/http-cache-state.test.ts\n- deno test --no-check --allow-all src/utils/memory/profiler.test.ts\n- deno check src/transforms/esm/http-cache-state.ts\n- deno fmt --check src/transforms/esm/http-cache-state.ts src/transforms/esm/http-cache-state.test.ts\n- git diff --check\n- pre-push hook: format, lint, typecheck, generated manifests/bundles, unit tests (2010 passed)\n\nCloses #1944