### PR TITLE
Use bundler transform for compiled config loading

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.696",
+  "version": "0.1.697",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1,7 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
-import { clearConfigCache, getCachedConfigSync, getConfig } from "./loader.ts";
+import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
+import { stop as stopEsbuild } from "veryfront/extensions/bundler";
+import {
+  clearConfigCache,
+  getCachedConfigSync,
+  getConfig,
+  transpileConfigSourceForImport,
+} from "./loader.ts";
 import { createMockAdapter } from "../platform/adapters/mock.ts";
 
 function setup() {
@@ -10,6 +16,36 @@ function setup() {
 }
 
 describe("config/loader", () => {
+  describe("transpileConfigSourceForImport", () => {
+    afterAll(async () => {
+      await stopEsbuild();
+    });
+
+    it("should transpile typed config files without rewriting string literals", async () => {
+      const source = `
+type LocalConfig = { title: string; description: string };
+const literal = "keep as const text";
+const config: LocalConfig = {
+  title: "Typed Project",
+  description: literal as string,
+};
+
+export default config as const;
+`;
+
+      const result = await transpileConfigSourceForImport(source, "/app/veryfront.config.ts");
+      const module = await import(`data:application/javascript;base64,${btoa(result)}`) as {
+        default: { title: string; description: string };
+      };
+
+      assert(!result.includes("type LocalConfig"));
+      assert(!result.includes(": LocalConfig"));
+      assert(result.includes('"keep as const text"'));
+      assertEquals(module.default.title, "Typed Project");
+      assertEquals(module.default.description, "keep as const text");
+    });
+  });
+
   describe("clearConfigCache", () => {
     it("should not throw when called on empty cache", () => {
       clearConfigCache();

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -281,10 +281,12 @@ async function loadConfigFromTempFile(
   const originalExt = extname(configPath) || ".mjs";
 
   // In compiled Deno binaries, we can't import TypeScript directly.
-  // Convert .ts/.tsx to .mjs and strip TypeScript-specific syntax.
+  // Convert .ts/.tsx to .mjs after running it through the bundler transform.
   const needsTranspile = isDenoCompiled && (originalExt === ".ts" || originalExt === ".tsx");
   const extension = needsTranspile ? ".mjs" : originalExt;
-  const processedSource = needsTranspile ? stripTypeScriptSyntax(source) : source;
+  const processedSource = needsTranspile
+    ? await transpileConfigSourceForImport(source, configPath)
+    : source;
 
   const tempDir = await fs.makeTempDir({ prefix: "vf-config-" });
   const tempFile = join(tempDir, `config${extension}`);
@@ -298,23 +300,20 @@ async function loadConfigFromTempFile(
   }
 }
 
-/**
- * Strip TypeScript-specific syntax for runtime import in compiled binaries.
- * This is a simple transformation for config files which typically don't use complex TS features.
- */
-function stripTypeScriptSyntax(source: string): string {
-  return source
-    // Remove 'as const' assertions
-    .replace(/\s+as\s+const\b/g, "")
-    // Remove type annotations (: string, : number, etc.)
-    .replace(
-      /:\s*(?:string|number|boolean|any|unknown|never|void|null|undefined)(?:\[\])?(?=\s*[,;=\)\}])/g,
-      "",
-    )
-    // Remove 'as Type' assertions
-    .replace(/\s+as\s+[A-Z][a-zA-Z0-9]*(?:<[^>]+>)?/g, "")
-    // Remove generic type parameters from function calls
-    .replace(/<[A-Z][a-zA-Z0-9]*(?:\s*,\s*[A-Z][a-zA-Z0-9]*)*>/g, "");
+/** @internal */
+export async function transpileConfigSourceForImport(
+  source: string,
+  configPath: string,
+): Promise<string> {
+  const { transform } = await import("veryfront/extensions/bundler");
+  const extension = extname(configPath);
+  const loader = extension === ".tsx" ? "tsx" : "ts";
+  const result = await transform(source, {
+    format: "esm",
+    loader,
+    sourcemap: false,
+  });
+  return result.code;
 }
 
 /**

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.696";
+export const VERSION = "0.1.697";


### PR DESCRIPTION
## Summary
- Replace compiled-Deno config TypeScript regex stripping with the existing `veryfront/extensions/bundler` transform.
- Add a regression test that imports the transformed config module and verifies typed config output plus string-literal preservation.
- Bump release metadata to `0.1.697` in `deno.json` and `src/utils/version-constant.ts`.

## Issue
Part of #1986.

This addresses the config-loader task from the issue plan: remove the regex TypeScript stripper and use a real transform path for `.ts`/`.tsx` config files in compiled Deno mode.

## Verification
- `deno test --no-check --allow-all src/config/loader.test.ts`
- `deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/config/loader.test.ts`
- `deno check src/utils/version-constant.ts src/utils/version.ts src/utils/version.test.ts src/utils/logger/logger.test.ts src/config/loader.ts src/config/loader.test.ts`
- `deno task verify:quick`
- Pre-push hook: format, lint, typecheck, and unit tests (`2010 passed`, `0 failed`)
