### PR TITLE
Scope project env overlays in sandbox workers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.697",
+  "version": "0.1.698",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/security/sandbox/project-worker.test.ts
+++ b/src/security/sandbox/project-worker.test.ts
@@ -17,6 +17,16 @@ const TEST_PERMISSIONS: WorkerPermissions = {
   sys: false,
 };
 
+const REAL_WORKER_PERMISSIONS: WorkerPermissions = {
+  read: true,
+  write: false,
+  net: false,
+  env: true,
+  run: false,
+  ffi: false,
+  sys: false,
+};
+
 const TEST_WORKER_SCRIPT_URL = `data:application/typescript,${
   encodeURIComponent(`
     self.onmessage = (event) => {
@@ -135,6 +145,7 @@ testSuite("ProjectWorker - error handling", () => {
           body: null,
         },
         params: {},
+        projectDir: Deno.cwd(),
       });
       assertEquals(true, false, "Should have thrown");
     } catch (error) {
@@ -167,6 +178,104 @@ testSuite("ProjectWorker - clearModuleCache", () => {
     const worker = createTestWorker("test-clear-cache");
     worker.clearModuleCache();
     // Should not throw
+  });
+});
+
+testSuite("ProjectWorker - real worker request isolation", () => {
+  it("returns a serialized error for unknown worker request types", async () => {
+    const worker = new ProjectWorker({
+      projectId: "test-unknown-request",
+      permissions: REAL_WORKER_PERMISSIONS,
+      requestTimeoutMs: 10_000,
+    });
+
+    worker.start();
+    try {
+      const response = await worker.execute(
+        {
+          type: "unknown-request",
+          id: "unknown",
+        } as unknown as Parameters<ProjectWorker["execute"]>[0],
+      );
+
+      assertEquals(response.type, "error");
+      if (response.type !== "error") throw new Error("expected error response");
+      assertEquals(response.id, "unknown");
+      assertEquals(response.error.name, "Error");
+      assertEquals(response.error.message, "Unknown request type: unknown-request");
+    } finally {
+      worker.terminate();
+    }
+  });
+
+  it("does not leak projectEnv overlays across requests in the same worker", async () => {
+    const projectDir = await Deno.makeTempDir();
+    const modulePath = await Deno.makeTempFile({ dir: projectDir, suffix: ".mjs" });
+    await Deno.writeTextFile(
+      modulePath,
+      `
+        export function GET() {
+          return Response.json({ value: Deno.env.get("VERYFRONT_TEST_TENANT_SECRET") ?? null });
+        }
+      `,
+    );
+
+    const worker = new ProjectWorker({
+      projectId: "test-env-overlay-scope",
+      permissions: REAL_WORKER_PERMISSIONS,
+      requestTimeoutMs: 10_000,
+    });
+
+    worker.start();
+    try {
+      const first = await worker.execute({
+        type: "execute-app-route",
+        id: "first",
+        modulePath,
+        method: "GET",
+        request: {
+          url: "http://localhost/api/env",
+          method: "GET",
+          headers: [],
+          body: null,
+        },
+        params: {},
+        projectDir,
+        projectEnv: { VERYFRONT_TEST_TENANT_SECRET: "tenant-a" },
+      });
+
+      assertEquals(first.type, "result");
+      if (first.type !== "result") throw new Error("expected result response");
+      assertEquals(
+        JSON.parse(new TextDecoder().decode(first.response.body ?? new Uint8Array())),
+        { value: "tenant-a" },
+      );
+
+      const second = await worker.execute({
+        type: "execute-app-route",
+        id: "second",
+        modulePath,
+        method: "GET",
+        request: {
+          url: "http://localhost/api/env",
+          method: "GET",
+          headers: [],
+          body: null,
+        },
+        params: {},
+        projectDir,
+      });
+
+      assertEquals(second.type, "result");
+      if (second.type !== "result") throw new Error("expected result response");
+      assertEquals(
+        JSON.parse(new TextDecoder().decode(second.response.body ?? new Uint8Array())),
+        { value: null },
+      );
+    } finally {
+      worker.terminate();
+      await Deno.remove(projectDir, { recursive: true });
+    }
   });
 });
 

--- a/src/security/sandbox/worker-script.ts
+++ b/src/security/sandbox/worker-script.ts
@@ -126,14 +126,53 @@ export function clearModuleCache(): void {
   moduleCache.clear();
 }
 
+function getMethodExport(mod: Record<string, unknown>, method: string): unknown {
+  switch (method.toUpperCase()) {
+    case "DELETE":
+      return mod.DELETE;
+    case "GET":
+      return mod.GET;
+    case "HEAD":
+      return mod.HEAD;
+    case "OPTIONS":
+      return mod.OPTIONS;
+    case "PATCH":
+      return mod.PATCH;
+    case "POST":
+      return mod.POST;
+    case "PUT":
+      return mod.PUT;
+    default:
+      return undefined;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Project Env Overlay
 // ---------------------------------------------------------------------------
 
-function applyProjectEnv(env: Record<string, string> | undefined): void {
-  if (!env) return;
+async function withProjectEnv<T>(
+  env: Record<string, string> | undefined,
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (!env) return await operation();
+
+  const previousValues = new Map<string, string | undefined>();
   for (const [key, value] of Object.entries(env)) {
+    previousValues.set(key, Deno.env.get(key));
     Deno.env.set(key, value);
+  }
+
+  try {
+    return await operation();
+  } finally {
+    for (const [key, value] of previousValues) {
+      if (value === undefined) {
+        Deno.env.delete(key);
+      } else {
+        Deno.env.set(key, value);
+      }
+    }
   }
 }
 
@@ -174,29 +213,29 @@ async function ensureAgentDiscovery(projectDir: string): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function handleAppRoute(req: ExecuteAppRouteRequest): Promise<SerializedResponse> {
-  applyProjectEnv(req.projectEnv);
-  await ensureAgentDiscovery(req.projectDir);
-  const mod = await loadModule(req.modulePath);
-  const method = req.method.toUpperCase();
+  return await withProjectEnv(req.projectEnv, async () => {
+    await ensureAgentDiscovery(req.projectDir);
+    const mod = await loadModule(req.modulePath);
 
-  const handlerFn = (mod[method] ?? mod.default) as
-    | ((
-      request: Request,
-      context: { params: Record<string, string | string[]> },
-    ) => Promise<Response> | Response)
-    | undefined;
+    const handlerFn = (getMethodExport(mod, req.method) ?? mod.default) as
+      | ((
+        request: Request,
+        context: { params: Record<string, string | string[]> },
+      ) => Promise<Response> | Response)
+      | undefined;
 
-  if (!handlerFn) {
-    return {
-      status: 405,
-      statusText: "Method Not Allowed",
-      headers: [["content-type", "application/json"]],
-      body: encoder.encode(JSON.stringify({ error: "Method not allowed" })),
-    };
-  }
+    if (!handlerFn) {
+      return {
+        status: 405,
+        statusText: "Method Not Allowed",
+        headers: [["content-type", "application/json"]],
+        body: encoder.encode(JSON.stringify({ error: "Method not allowed" })),
+      };
+    }
 
-  const response = await handlerFn(deserializeRequest(req.request), { params: req.params ?? {} });
-  return serializeResponse(response);
+    const response = await handlerFn(deserializeRequest(req.request), { params: req.params ?? {} });
+    return serializeResponse(response);
+  });
 }
 
 function deserializeDataContext(
@@ -240,80 +279,80 @@ async function handleFetchData(req: FetchDataRequest): Promise<SerializedDataRes
 }
 
 async function handlePagesRoute(req: ExecutePagesRouteRequest): Promise<SerializedResponse> {
-  applyProjectEnv(req.projectEnv);
-  await ensureAgentDiscovery(req.projectDir);
-  const mod = await loadModule(req.modulePath);
-  const method = req.method as string;
+  return await withProjectEnv(req.projectEnv, async () => {
+    await ensureAgentDiscovery(req.projectDir);
+    const mod = await loadModule(req.modulePath);
 
-  const handlerFn = (mod[method] ?? mod.default) as
-    | ((ctx: unknown) => Promise<Response> | Response)
-    | undefined;
+    const handlerFn = (getMethodExport(mod, req.method) ?? mod.default) as
+      | ((ctx: unknown) => Promise<Response> | Response)
+      | undefined;
 
-  if (!handlerFn) {
-    return {
-      status: 405,
-      statusText: "Method Not Allowed",
-      headers: [["content-type", "application/json"]],
-      body: encoder.encode(JSON.stringify({ error: "Method not allowed" })),
-    };
-  }
-
-  const { request, params, cookies } = deserializePagesRequest(req.context);
-  const url = new URL(request.url);
-
-  // Build a minimal read-only fs adapter scoped to the project directory
-  const workerFs = {
-    readTextFile: (path: string) => Deno.readTextFile(path),
-    readFile: (path: string) => Deno.readFile(path),
-    exists: async (path: string) => {
-      try {
-        await Deno.stat(path);
-        return true;
-      } catch {
-        return false;
-      }
-    },
-    stat: async (path: string) => {
-      const info = await Deno.stat(path);
+    if (!handlerFn) {
       return {
-        isFile: info.isFile,
-        isDirectory: info.isDirectory,
-        isSymlink: info.isSymlink,
-        size: info.size,
-        mtime: info.mtime,
+        status: 405,
+        statusText: "Method Not Allowed",
+        headers: [["content-type", "application/json"]],
+        body: encoder.encode(JSON.stringify({ error: "Method not allowed" })),
       };
-    },
-    readDir: async function* (path: string) {
-      for await (const entry of Deno.readDir(path)) {
-        yield { name: entry.name, isFile: entry.isFile, isDirectory: entry.isDirectory };
-      }
-    },
-  };
+    }
 
-  // Build a minimal APIContext (subset of the full context)
-  const ctx = {
-    request,
-    req: request,
-    params,
-    query: url.searchParams,
-    cookies,
-    headers: request.headers,
-    url,
-    json: (data: unknown, init?: ResponseInit): Response =>
-      new Response(JSON.stringify(data), {
-        ...init,
-        headers: { "Content-Type": "application/json", ...init?.headers },
-      }),
-    text: (data: string, init?: ResponseInit): Response =>
-      new Response(data, {
-        ...init,
-        headers: { "Content-Type": "text/plain", ...init?.headers },
-      }),
-    fs: workerFs,
-  };
+    const { request, params, cookies } = deserializePagesRequest(req.context);
+    const url = new URL(request.url);
 
-  const response = await handlerFn(ctx);
-  return serializeResponse(response);
+    // Build a minimal read-only fs adapter scoped to the project directory
+    const workerFs = {
+      readTextFile: (path: string) => Deno.readTextFile(path),
+      readFile: (path: string) => Deno.readFile(path),
+      exists: async (path: string) => {
+        try {
+          await Deno.stat(path);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      stat: async (path: string) => {
+        const info = await Deno.stat(path);
+        return {
+          isFile: info.isFile,
+          isDirectory: info.isDirectory,
+          isSymlink: info.isSymlink,
+          size: info.size,
+          mtime: info.mtime,
+        };
+      },
+      readDir: async function* (path: string) {
+        for await (const entry of Deno.readDir(path)) {
+          yield { name: entry.name, isFile: entry.isFile, isDirectory: entry.isDirectory };
+        }
+      },
+    };
+
+    // Build a minimal APIContext (subset of the full context)
+    const ctx = {
+      request,
+      req: request,
+      params,
+      query: url.searchParams,
+      cookies,
+      headers: request.headers,
+      url,
+      json: (data: unknown, init?: ResponseInit): Response =>
+        new Response(JSON.stringify(data), {
+          ...init,
+          headers: { "Content-Type": "application/json", ...init?.headers },
+        }),
+      text: (data: string, init?: ResponseInit): Response =>
+        new Response(data, {
+          ...init,
+          headers: { "Content-Type": "text/plain", ...init?.headers },
+        }),
+      fs: workerFs,
+    };
+
+    const response = await handlerFn(ctx);
+    return serializeResponse(response);
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.697";
+export const VERSION = "0.1.698";


### PR DESCRIPTION
## Summary
- Scope per-request projectEnv overlays inside the worker script and restore prior env values after app/pages route execution
- Add real ProjectWorker coverage for unknown request serialization and env overlay isolation across reused workers
- Bump release metadata to 0.1.698

## Verification
- deno test --no-check --allow-all --unstable-worker-options src/security/sandbox/project-worker.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts
- deno check src/security/sandbox/worker-script.ts src/security/sandbox/project-worker.test.ts src/utils/version-constant.ts src/utils/version.ts src/utils/version.test.ts
- deno task verify:quick
- pre-push hook: format, lint, typecheck, unit tests (2011 passed, 0 failed)

Refs #1989