### PR TITLE
Harden workflow executor and run manager coverage

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.699",
+  "version": "0.1.700",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.699";
+export const VERSION = "0.1.700";

--- a/src/workflow/executor/workflow-executor.test.ts
+++ b/src/workflow/executor/workflow-executor.test.ts
@@ -1,0 +1,119 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { Tool } from "#veryfront/tool";
+import { defineSchema } from "#veryfront/schemas/index.ts";
+import { MemoryBackend } from "../backends/memory.ts";
+import { step, workflow } from "../dsl/index.ts";
+import type { WorkflowRun } from "../types.ts";
+import { WorkflowExecutor } from "./workflow-executor.ts";
+
+function createTool(id: string, execute: (input: unknown) => unknown | Promise<unknown>): Tool {
+  return {
+    id,
+    type: "function",
+    description: `Test tool ${id}`,
+    inputSchema: defineSchema((v) => v.object({}).passthrough())(),
+    execute: (input) => Promise.resolve(execute(input)),
+  };
+}
+
+function createRun(workflowId: string): WorkflowRun {
+  return {
+    id: `run-${workflowId}`,
+    workflowId,
+    status: "pending",
+    input: {},
+    nodeStates: {},
+    currentNodes: [],
+    context: { input: {} },
+    checkpoints: [],
+    pendingApprovals: [],
+    createdAt: new Date(),
+  };
+}
+
+describe("workflow/executor/workflow-executor", () => {
+  it("acquires and releases the backend lock around successful execution", async () => {
+    const backend = new MemoryBackend();
+    const executor = new WorkflowExecutor({ backend, lockDuration: 5_000 });
+    executor.register(
+      workflow({
+        id: "locked-success",
+        steps: [
+          step("finish", {
+            tool: createTool("finish", () => ({ ok: true })),
+          }),
+        ],
+      }).definition,
+    );
+    const run = createRun("locked-success");
+    await backend.createRun(run);
+
+    await executor.executeAsync(run.id);
+
+    const updatedRun = await backend.getRun(run.id);
+    assertExists(updatedRun);
+    assertEquals(updatedRun.status, "completed");
+    assertEquals(updatedRun.output, { finish: { ok: true } });
+    assertEquals(await backend.isLocked(run.id), false);
+  });
+
+  it("does not execute a run when another worker already holds the lock", async () => {
+    const backend = new MemoryBackend();
+    const executor = new WorkflowExecutor({ backend, lockDuration: 5_000 });
+    executor.register(
+      workflow({
+        id: "locked-conflict",
+        steps: [
+          step("finish", {
+            tool: createTool("finish", () => ({ ok: true })),
+          }),
+        ],
+      }).definition,
+    );
+    const run = createRun("locked-conflict");
+    await backend.createRun(run);
+    await backend.acquireLock(run.id, 5_000);
+
+    await assertRejects(
+      () => executor.executeAsync(run.id),
+      Error,
+      "another worker is already executing it",
+    );
+
+    const updatedRun = await backend.getRun(run.id);
+    assertExists(updatedRun);
+    assertEquals(updatedRun.status, "pending");
+    assertEquals(updatedRun.output, undefined);
+    await backend.releaseLock(run.id);
+  });
+
+  it("marks failed runs and releases the lock when a step fails", async () => {
+    const backend = new MemoryBackend();
+    const executor = new WorkflowExecutor({ backend, lockDuration: 5_000 });
+    executor.register(
+      workflow({
+        id: "locked-failure",
+        steps: [
+          step("fail", {
+            tool: createTool("fail", () => {
+              throw new Error("tool exploded");
+            }),
+          }),
+        ],
+      }).definition,
+    );
+    const run = createRun("locked-failure");
+    await backend.createRun(run);
+
+    await executor.executeAsync(run.id);
+
+    const updatedRun = await backend.getRun(run.id);
+    assertExists(updatedRun);
+    assertEquals(updatedRun.status, "failed");
+    assertEquals(updatedRun.nodeStates.fail?.status, "failed");
+    assertEquals(updatedRun.error?.message, 'Node "fail" failed: tool exploded');
+    assertEquals(await backend.isLocked(run.id), false);
+  });
+});

--- a/src/workflow/worker/run-manager.test.ts
+++ b/src/workflow/worker/run-manager.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { MemoryBackend } from "../backends/memory.ts";
+import type { WorkflowRun } from "../types.ts";
 import type { RunExecutionConfig, RunExecutionInfo, RunExecutor } from "./executors/types.ts";
 import { createWorkflowRunManager, WorkflowRunManager } from "./run-manager.ts";
 
@@ -45,6 +46,12 @@ class FakeRunExecutor implements RunExecutor {
   }
 }
 
+class FailingRunExecutor extends FakeRunExecutor {
+  override createRunExecution(_config: RunExecutionConfig): Promise<string> {
+    return Promise.reject(new Error("spawn failed"));
+  }
+}
+
 // A poll interval large enough that the first scheduled poll never fires during
 // a test; stop() clears the pending timer, so no work runs and no timer leaks.
 const NO_POLL = 1_000_000;
@@ -53,6 +60,25 @@ function makeManager(executor: RunExecutor = new FakeRunExecutor()) {
   const backend = new MemoryBackend();
   const manager = new WorkflowRunManager({ backend, executor, pollInterval: NO_POLL });
   return { backend, executor, manager };
+}
+
+function createPendingRun(id: string): WorkflowRun {
+  return {
+    id,
+    workflowId: "workflow-1",
+    status: "pending",
+    input: {},
+    nodeStates: {},
+    currentNodes: [],
+    context: { input: {} },
+    checkpoints: [],
+    pendingApprovals: [],
+    createdAt: new Date(),
+  };
+}
+
+function pollOnce(manager: WorkflowRunManager): Promise<void> {
+  return (manager as unknown as { poll(): Promise<void> }).poll();
 }
 
 describe("workflow/worker/run-manager", () => {
@@ -161,6 +187,46 @@ describe("workflow/worker/run-manager", () => {
     const fresh = manager.getStats();
     assertEquals(fresh.pollCount, 0);
     assertEquals(fresh.status, "idle");
+  });
+
+  it("poll() claims a pending run, starts one isolated execution, and releases the pending lock", async () => {
+    const executor = new FakeRunExecutor();
+    const { backend, manager } = makeManager(executor);
+    track(manager);
+    const run = createPendingRun("run-pending");
+    await backend.createRun(run);
+    await manager.start();
+
+    await pollOnce(manager);
+
+    const updatedRun = await backend.getRun(run.id);
+    assertExists(updatedRun);
+    assertEquals(executor.created.length, 1);
+    assertEquals(executor.created[0]?.run.id, run.id);
+    assertEquals(updatedRun.status, "running");
+    assertEquals(updatedRun.workerId?.startsWith("run-execution:run_exec"), true);
+    assertEquals(await backend.isLocked(run.id), false);
+    assertEquals(manager.getActiveExecutions().length, 1);
+    assertEquals(manager.getStats().executionsCreated, 1);
+  });
+
+  it("poll() records execution creation failures in manager stats and failed run state", async () => {
+    const executor = new FailingRunExecutor();
+    const { backend, manager } = makeManager(executor);
+    track(manager);
+    const run = createPendingRun("run-create-failure");
+    await backend.createRun(run);
+    await manager.start();
+
+    await pollOnce(manager);
+
+    const updatedRun = await backend.getRun(run.id);
+    assertExists(updatedRun);
+    assertEquals(updatedRun.status, "failed");
+    assertEquals(updatedRun.error?.message.includes("RUN_EXECUTION_CREATION_FAILED"), true);
+    assertEquals(await backend.isLocked(run.id), false);
+    assertEquals(manager.getActiveExecutions(), []);
+    assertEquals(manager.getStats().executionsFailed, 1);
   });
 
   it("createWorkflowRunManager builds a WorkflowRunManager", () => {

--- a/src/workflow/worker/run-manager.ts
+++ b/src/workflow/worker/run-manager.ts
@@ -436,6 +436,7 @@ export class WorkflowRunManager {
       }
     } catch (error) {
       logger.error(`Failed to create run execution for ${run.id}:`, error);
+      this.stats.executionsFailed++;
 
       // Mark workflow as failed
       await this.config.backend.updateRun(run.id, {


### PR DESCRIPTION
## Summary
- Add focused WorkflowExecutor tests for lock acquisition, lock conflict handling, successful completion, and failed-step run state.
- Add WorkflowRunManager tests for pending-run claiming and execution-creation failure handling.
- Count execution creation failures in manager stats and bump release metadata to 0.1.700.

## Verification
- deno test --no-check --allow-all src/workflow/worker/run-entrypoint.test.ts src/workflow/worker/run-manager.test.ts src/workflow/executor/workflow-executor.test.ts
- deno check src/workflow/executor/workflow-executor.ts src/workflow/executor/workflow-executor.test.ts src/workflow/worker/run-manager.ts src/workflow/worker/run-manager.test.ts
- git diff --check
- deno task verify:quick
- pre-push hook: format, lint, typecheck, unit tests (2012 passed, 0 failed)

Related: #1984