### PR TITLE
Extract DAG map and loop execution strategies

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.700",
+  "version": "0.1.701",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.700";
+export const VERSION = "0.1.701";

--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -407,6 +407,36 @@ describe("DAGExecutor", () => {
       assertEquals(result.nodeStates["map1"]!.status, "completed");
     });
 
+    it("should pass each item as processor input and preserve ordered outputs", async () => {
+      const items = [{ value: "a" }, { value: "b" }, { value: "c" }];
+      const seenInputs: unknown[] = [];
+      const trackingExecutor = new MockStepExecutor(new Map(), (node) => {
+        const input = (node.config as { input?: unknown }).input;
+        seenInputs.push(input);
+        return { success: true, output: { processed: input }, executionTime: 1 };
+      });
+      const exec = new DAGExecutor({ stepExecutor: trackingExecutor, maxConcurrency: 1 });
+      const nodes: WorkflowNode[] = [
+        {
+          id: "map-inputs",
+          dependsOn: [],
+          config: {
+            type: "map",
+            items,
+            processor: { id: "proc", config: { type: "step" } as any },
+          } as any,
+        },
+      ];
+
+      const result = await exec.execute(nodes, createTestRun());
+
+      const expected = items.map((item) => ({ processed: item }));
+      assertEquals(result.completed, true);
+      assertEquals(seenInputs, items);
+      assertEquals(result.nodeStates["map-inputs"]!.output, expected);
+      assertEquals(result.context["map-inputs"], expected);
+    });
+
     it("should handle empty items array", async () => {
       const nodes: WorkflowNode[] = [
         {
@@ -488,6 +518,36 @@ describe("DAGExecutor", () => {
       assertEquals(result.completed, true);
       const output = result.nodeStates["loop-max"]!.output as any;
       assertEquals(output.iterations, 2);
+    });
+
+    it("should record failed loop output when an iteration step fails", async () => {
+      const failingExecutor = new MockStepExecutor(
+        new Map([["bad-step", { success: false, error: "bad step" }]]),
+      );
+      const exec = new DAGExecutor({ stepExecutor: failingExecutor });
+      const nodes: WorkflowNode[] = [
+        {
+          id: "loop-error",
+          dependsOn: [],
+          config: {
+            type: "loop",
+            maxIterations: 3,
+            while: () => true,
+            steps: [{ id: "bad-step", config: { type: "step" } as any }],
+          } as any,
+        },
+      ];
+
+      const result = await exec.execute(nodes, createTestRun());
+
+      const state = result.nodeStates["loop-error"]!;
+      const output = state.output as { exitReason: string; iterations: number };
+      assertEquals(result.completed, false);
+      assertEquals(state.status, "failed");
+      assertEquals(state.error, 'Node "bad-step" failed: bad step');
+      assertEquals(output.exitReason, "error");
+      assertEquals(output.iterations, 0);
+      assertEquals(result.context["loop-error"], output);
     });
   });
 

--- a/src/workflow/executor/dag/index.ts
+++ b/src/workflow/executor/dag/index.ts
@@ -9,20 +9,16 @@
 import type {
   BranchNodeConfig,
   Checkpoint,
-  LoopExecutionContext,
-  LoopNodeConfig,
-  MapNodeConfig,
   NodeState,
   ParallelNodeConfig,
   SubWorkflowNodeConfig,
   WaitNodeConfig,
   WorkflowContext,
-  WorkflowDefinition,
   WorkflowNode,
   WorkflowNodeConfig,
   WorkflowRun,
 } from "../../types.ts";
-import { generateId, parseDuration } from "../../types.ts";
+import { generateId } from "../../types.ts";
 import { INVALID_ARGUMENT, NOT_SUPPORTED } from "#veryfront/errors";
 
 export type { DAGExecutionResult, DAGExecutorConfig, NodeExecutionResult } from "./types.ts";
@@ -33,8 +29,11 @@ import type {
   DAGExecutorInternalConfig,
   NodeExecutionResult,
 } from "./types.ts";
-import { deriveNodeStatus, shouldCheckpoint, sleep } from "./utils.ts";
+import { deriveNodeStatus, shouldCheckpoint } from "./utils.ts";
 import { buildGraph, getReadyNodes, hasCycle, updateInDegreesForCompletedNodes } from "./graph.ts";
+import { executeLoopNodeStrategy } from "./loop-node-strategy.ts";
+import { executeMapNodeStrategy } from "./map-node-strategy.ts";
+import type { ChildGraphExecutionOptions } from "./node-strategy-types.ts";
 
 export class DAGExecutor {
   private config: DAGExecutorInternalConfig;
@@ -181,7 +180,16 @@ export class DAGExecutor {
       case "parallel":
         return this.executeParallelNode(node, config, context, nodeStates);
       case "map":
-        return this.executeMapNode(node, config, context, nodeStates);
+        return executeMapNodeStrategy({
+          node,
+          config,
+          context,
+          nodeStates,
+          runtime: {
+            executeChildGraph: (nodes, run, options) => this.executeChildGraph(nodes, run, options),
+            onNodeComplete: this.config.onNodeComplete,
+          },
+        });
       case "branch":
         return this.executeBranchNode(node, config, context, nodeStates);
       case "wait":
@@ -189,7 +197,16 @@ export class DAGExecutor {
       case "subWorkflow":
         return this.executeSubWorkflowNode(node, config, context);
       case "loop":
-        return this.executeLoopNode(node, config, context, nodeStates);
+        return executeLoopNodeStrategy({
+          node,
+          config,
+          context,
+          nodeStates,
+          runtime: {
+            executeChildGraph: (nodes, run) => this.executeChildGraph(nodes, run),
+            onNodeComplete: this.config.onNodeComplete,
+          },
+        });
       default:
         throw INVALID_ARGUMENT.create({
           detail:
@@ -267,107 +284,6 @@ export class DAGExecutor {
       contextUpdates: result.context,
       waiting: result.waiting,
     };
-  }
-
-  private async executeMapNode(
-    node: WorkflowNode,
-    config: MapNodeConfig,
-    context: WorkflowContext,
-    nodeStates: Record<string, NodeState>,
-  ): Promise<NodeExecutionResult> {
-    const startTime = Date.now();
-
-    const items = typeof config.items === "function" ? await config.items(context) : config.items;
-
-    if (!Array.isArray(items)) {
-      throw INVALID_ARGUMENT.create({ detail: `Map node "${node.id}" items must be an array` });
-    }
-
-    if (items.length === 0) {
-      const state: NodeState = {
-        nodeId: node.id,
-        status: "completed",
-        output: [],
-        attempt: 1,
-        startedAt: new Date(startTime),
-        completedAt: new Date(),
-      };
-      return { state, contextUpdates: { [node.id]: [] }, waiting: false };
-    }
-
-    const isWorkflowDef = (p: unknown): p is WorkflowDefinition =>
-      typeof p === "object" && p !== null && "steps" in p;
-
-    const childNodes: WorkflowNode[] = items.map((item, i) => {
-      const childId = `${node.id}_${i}`;
-
-      if (isWorkflowDef(config.processor)) {
-        return {
-          id: childId,
-          config: {
-            type: "subWorkflow",
-            workflow: config.processor,
-            input: item,
-            retry: config.retry,
-            checkpoint: false,
-          },
-        };
-      }
-
-      const processorConfig: WorkflowNodeConfig = { ...(config.processor as WorkflowNode).config };
-
-      if (processorConfig.type === "step") {
-        processorConfig.input = item as Record<string, unknown>;
-      }
-
-      return { id: childId, config: processorConfig };
-    });
-
-    const originalConcurrency = this.config.maxConcurrency;
-    if (config.concurrency) {
-      this.config.maxConcurrency = config.concurrency;
-    }
-
-    try {
-      const result = await this.execute(childNodes, {
-        id: `${node.id}_map`,
-        workflowId: "",
-        status: "running",
-        input: context.input,
-        // Carry already-accumulated child states so completed children are
-        // skipped on resume instead of re-executing (H8).
-        nodeStates,
-        currentNodes: [],
-        context: { ...context },
-        checkpoints: [],
-        pendingApprovals: [],
-        createdAt: new Date(),
-      });
-
-      Object.assign(nodeStates, result.nodeStates);
-
-      const outputs = childNodes.map((child) => result.nodeStates[child.id]?.output);
-
-      const state: NodeState = {
-        nodeId: node.id,
-        status: deriveNodeStatus(result.completed, result.waiting),
-        output: outputs,
-        error: result.error,
-        attempt: 1,
-        startedAt: new Date(startTime),
-        completedAt: result.completed ? new Date() : undefined,
-      };
-
-      this.config.onNodeComplete?.(node.id, state);
-
-      return {
-        state,
-        contextUpdates: result.completed ? { [node.id]: outputs } : {},
-        waiting: result.waiting,
-      };
-    } finally {
-      this.config.maxConcurrency = originalConcurrency;
-    }
   }
 
   private async executeBranchNode(
@@ -526,172 +442,6 @@ export class DAGExecutor {
     };
   }
 
-  private async executeLoopNode(
-    node: WorkflowNode,
-    config: LoopNodeConfig,
-    context: WorkflowContext,
-    nodeStates: Record<string, NodeState>,
-  ): Promise<NodeExecutionResult> {
-    const startTime = Date.now();
-    const previousResults: unknown[] = [];
-    let iteration = 0;
-    let exitReason: "condition" | "maxIterations" | "error" = "condition";
-    let lastError: string | undefined;
-
-    const existingLoopState = context[`${node.id}_loop_state`] as
-      | {
-        iteration: number;
-        previousResults: unknown[];
-        iterationNodeStates?: Record<string, NodeState>;
-      }
-      | undefined;
-
-    // Child node states for the in-flight (resumed) iteration, so its already
-    // completed steps are not re-executed on resume (H9).
-    let resumeIterationNodeStates: Record<string, NodeState> | undefined;
-    let resumeIteration: number | undefined;
-
-    if (existingLoopState) {
-      iteration = existingLoopState.iteration;
-      previousResults.push(...existingLoopState.previousResults);
-      resumeIterationNodeStates = existingLoopState.iterationNodeStates;
-      resumeIteration = existingLoopState.iteration;
-    }
-
-    while (iteration < config.maxIterations) {
-      const loopContext: LoopExecutionContext = {
-        iteration,
-        totalIterations: iteration,
-        previousResults: [...previousResults],
-        isFirstIteration: iteration === 0,
-        isLastAllowedIteration: iteration === config.maxIterations - 1,
-      };
-
-      if (!(await config.while(context, loopContext))) {
-        exitReason = "condition";
-        break;
-      }
-
-      const steps = typeof config.steps === "function"
-        ? config.steps(context, loopContext)
-        : config.steps;
-
-      // On resume, rehydrate the in-flight iteration's child node states so its
-      // already-completed steps are skipped instead of re-executed (H9).
-      const iterationNodeStates = resumeIteration === iteration && resumeIterationNodeStates
-        ? { ...resumeIterationNodeStates }
-        : {};
-      // Only rehydrate once; subsequent iterations start fresh.
-      resumeIterationNodeStates = undefined;
-
-      const result = await this.execute(steps, {
-        id: `${node.id}_iter_${iteration}`,
-        workflowId: "",
-        status: "running",
-        input: context.input,
-        nodeStates: iterationNodeStates,
-        currentNodes: [],
-        context: { ...context, _loop: loopContext },
-        checkpoints: [],
-        pendingApprovals: [],
-        createdAt: new Date(),
-      });
-
-      if (result.waiting) {
-        Object.assign(nodeStates, result.nodeStates);
-
-        const state: NodeState = {
-          nodeId: node.id,
-          status: "running",
-          output: { iteration, waiting: true, previousResults },
-          attempt: 1,
-          startedAt: new Date(startTime),
-        };
-
-        return {
-          state,
-          contextUpdates: {
-            ...result.context,
-            [`${node.id}_loop_state`]: {
-              iteration,
-              previousResults,
-              // Persist the in-flight iteration's child states so completed
-              // steps are not re-executed when this iteration resumes (H9).
-              iterationNodeStates: result.nodeStates,
-            },
-          },
-          waiting: true,
-        };
-      }
-
-      if (result.error) {
-        lastError = result.error;
-        exitReason = "error";
-        break;
-      }
-
-      previousResults.push(result.context);
-      Object.assign(context, result.context);
-      Object.assign(nodeStates, result.nodeStates);
-
-      if (config.delay && iteration < config.maxIterations - 1) {
-        const delayMs = typeof config.delay === "number"
-          ? config.delay
-          : parseDuration(config.delay);
-        await sleep(delayMs);
-      }
-
-      iteration++;
-    }
-
-    if (iteration >= config.maxIterations && exitReason !== "condition") {
-      exitReason = "maxIterations";
-    }
-
-    const finalLoopContext: LoopExecutionContext = {
-      iteration,
-      totalIterations: iteration,
-      previousResults,
-      isFirstIteration: false,
-      isLastAllowedIteration: true,
-    };
-
-    let completionUpdates: Record<string, unknown> = {};
-    if (exitReason === "maxIterations" && config.onMaxIterations) {
-      completionUpdates = await config.onMaxIterations(context, finalLoopContext);
-    } else if (exitReason === "condition" && config.onComplete) {
-      completionUpdates = await config.onComplete(context, finalLoopContext);
-    }
-
-    const output = {
-      exitReason,
-      iterations: iteration,
-      previousResults,
-      ...completionUpdates,
-    };
-
-    const state: NodeState = {
-      nodeId: node.id,
-      status: exitReason === "error" ? "failed" : "completed",
-      output,
-      error: lastError,
-      attempt: 1,
-      startedAt: new Date(startTime),
-      completedAt: new Date(),
-    };
-
-    this.config.onNodeComplete?.(node.id, state);
-
-    return {
-      state,
-      contextUpdates: {
-        [node.id]: output,
-        ...completionUpdates,
-      },
-      waiting: false,
-    };
-  }
-
   private async checkpoint(
     runId: string,
     nodeId: string,
@@ -711,5 +461,23 @@ export class DAGExecutor {
     };
 
     await this.config.checkpointManager.save(runId, checkpoint);
+  }
+
+  private async executeChildGraph(
+    nodes: WorkflowNode[],
+    run: WorkflowRun,
+    options?: ChildGraphExecutionOptions,
+  ): Promise<DAGExecutionResult> {
+    if (!options?.maxConcurrency) {
+      return await this.execute(nodes, run);
+    }
+
+    const originalConcurrency = this.config.maxConcurrency;
+    this.config.maxConcurrency = options.maxConcurrency;
+    try {
+      return await this.execute(nodes, run);
+    } finally {
+      this.config.maxConcurrency = originalConcurrency;
+    }
   }
 }

--- a/src/workflow/executor/dag/loop-node-strategy.ts
+++ b/src/workflow/executor/dag/loop-node-strategy.ts
@@ -1,0 +1,181 @@
+import type {
+  LoopExecutionContext,
+  LoopNodeConfig,
+  NodeState,
+  WorkflowContext,
+  WorkflowNode,
+} from "../../types.ts";
+import { parseDuration } from "../../types.ts";
+import type { NodeExecutionResult } from "./types.ts";
+import { sleep } from "./utils.ts";
+import type { NodeStrategyRuntime } from "./node-strategy-types.ts";
+
+interface ExecuteLoopNodeStrategyInput {
+  node: WorkflowNode;
+  config: LoopNodeConfig;
+  context: WorkflowContext;
+  nodeStates: Record<string, NodeState>;
+  runtime: NodeStrategyRuntime;
+}
+
+interface PersistedLoopState {
+  iteration: number;
+  previousResults: unknown[];
+  iterationNodeStates?: Record<string, NodeState>;
+}
+
+export async function executeLoopNodeStrategy(
+  input: ExecuteLoopNodeStrategyInput,
+): Promise<NodeExecutionResult> {
+  const { node, config, context, nodeStates, runtime } = input;
+  const startTime = Date.now();
+  const previousResults: unknown[] = [];
+  let iteration = 0;
+  let exitReason: "condition" | "maxIterations" | "error" = "condition";
+  let lastError: string | undefined;
+
+  const existingLoopState = context[`${node.id}_loop_state`] as PersistedLoopState | undefined;
+
+  // Child node states for the in-flight (resumed) iteration, so its already
+  // completed steps are not re-executed on resume (H9).
+  let resumeIterationNodeStates: Record<string, NodeState> | undefined;
+  let resumeIteration: number | undefined;
+
+  if (existingLoopState) {
+    iteration = existingLoopState.iteration;
+    previousResults.push(...existingLoopState.previousResults);
+    resumeIterationNodeStates = existingLoopState.iterationNodeStates;
+    resumeIteration = existingLoopState.iteration;
+  }
+
+  while (iteration < config.maxIterations) {
+    const loopContext: LoopExecutionContext = {
+      iteration,
+      totalIterations: iteration,
+      previousResults: [...previousResults],
+      isFirstIteration: iteration === 0,
+      isLastAllowedIteration: iteration === config.maxIterations - 1,
+    };
+
+    if (!(await config.while(context, loopContext))) {
+      exitReason = "condition";
+      break;
+    }
+
+    const steps = typeof config.steps === "function"
+      ? config.steps(context, loopContext)
+      : config.steps;
+
+    // On resume, rehydrate the in-flight iteration's child node states so its
+    // already-completed steps are skipped instead of re-executed (H9).
+    const iterationNodeStates = resumeIteration === iteration && resumeIterationNodeStates
+      ? { ...resumeIterationNodeStates }
+      : {};
+    // Only rehydrate once; subsequent iterations start fresh.
+    resumeIterationNodeStates = undefined;
+
+    const result = await runtime.executeChildGraph(steps, {
+      id: `${node.id}_iter_${iteration}`,
+      workflowId: "",
+      status: "running",
+      input: context.input,
+      nodeStates: iterationNodeStates,
+      currentNodes: [],
+      context: { ...context, _loop: loopContext },
+      checkpoints: [],
+      pendingApprovals: [],
+      createdAt: new Date(),
+    });
+
+    if (result.waiting) {
+      Object.assign(nodeStates, result.nodeStates);
+
+      const state: NodeState = {
+        nodeId: node.id,
+        status: "running",
+        output: { iteration, waiting: true, previousResults },
+        attempt: 1,
+        startedAt: new Date(startTime),
+      };
+
+      return {
+        state,
+        contextUpdates: {
+          ...result.context,
+          [`${node.id}_loop_state`]: {
+            iteration,
+            previousResults,
+            // Persist the in-flight iteration's child states so completed
+            // steps are not re-executed when this iteration resumes (H9).
+            iterationNodeStates: result.nodeStates,
+          },
+        },
+        waiting: true,
+      };
+    }
+
+    if (result.error) {
+      lastError = result.error;
+      exitReason = "error";
+      break;
+    }
+
+    previousResults.push(result.context);
+    Object.assign(context, result.context);
+    Object.assign(nodeStates, result.nodeStates);
+
+    if (config.delay && iteration < config.maxIterations - 1) {
+      const delayMs = typeof config.delay === "number" ? config.delay : parseDuration(config.delay);
+      await sleep(delayMs);
+    }
+
+    iteration++;
+  }
+
+  if (iteration >= config.maxIterations && exitReason !== "condition") {
+    exitReason = "maxIterations";
+  }
+
+  const finalLoopContext: LoopExecutionContext = {
+    iteration,
+    totalIterations: iteration,
+    previousResults,
+    isFirstIteration: false,
+    isLastAllowedIteration: true,
+  };
+
+  let completionUpdates: Record<string, unknown> = {};
+  if (exitReason === "maxIterations" && config.onMaxIterations) {
+    completionUpdates = await config.onMaxIterations(context, finalLoopContext);
+  } else if (exitReason === "condition" && config.onComplete) {
+    completionUpdates = await config.onComplete(context, finalLoopContext);
+  }
+
+  const output = {
+    exitReason,
+    iterations: iteration,
+    previousResults,
+    ...completionUpdates,
+  };
+
+  const state: NodeState = {
+    nodeId: node.id,
+    status: exitReason === "error" ? "failed" : "completed",
+    output,
+    error: lastError,
+    attempt: 1,
+    startedAt: new Date(startTime),
+    completedAt: new Date(),
+  };
+
+  runtime.onNodeComplete?.(node.id, state);
+
+  return {
+    state,
+    contextUpdates: {
+      [node.id]: output,
+      ...completionUpdates,
+    },
+    waiting: false,
+  };
+}

--- a/src/workflow/executor/dag/map-node-strategy.ts
+++ b/src/workflow/executor/dag/map-node-strategy.ts
@@ -1,0 +1,123 @@
+import type {
+  MapNodeConfig,
+  NodeState,
+  WorkflowContext,
+  WorkflowDefinition,
+  WorkflowNode,
+  WorkflowNodeConfig,
+} from "../../types.ts";
+import { INVALID_ARGUMENT } from "#veryfront/errors";
+import type { NodeExecutionResult } from "./types.ts";
+import { deriveNodeStatus } from "./utils.ts";
+import type { NodeStrategyRuntime } from "./node-strategy-types.ts";
+
+interface ExecuteMapNodeStrategyInput {
+  node: WorkflowNode;
+  config: MapNodeConfig;
+  context: WorkflowContext;
+  nodeStates: Record<string, NodeState>;
+  runtime: NodeStrategyRuntime;
+}
+
+function isWorkflowDefinition(processor: unknown): processor is WorkflowDefinition {
+  return typeof processor === "object" && processor !== null && "steps" in processor;
+}
+
+function createMapChildNodes(
+  node: WorkflowNode,
+  config: MapNodeConfig,
+  items: unknown[],
+): WorkflowNode[] {
+  return items.map((item, i) => {
+    const childId = `${node.id}_${i}`;
+
+    if (isWorkflowDefinition(config.processor)) {
+      return {
+        id: childId,
+        config: {
+          type: "subWorkflow",
+          workflow: config.processor,
+          input: item,
+          retry: config.retry,
+          checkpoint: false,
+        },
+      };
+    }
+
+    const processorConfig: WorkflowNodeConfig = { ...(config.processor as WorkflowNode).config };
+
+    if (processorConfig.type === "step") {
+      processorConfig.input = item as Record<string, unknown>;
+    }
+
+    return { id: childId, config: processorConfig };
+  });
+}
+
+export async function executeMapNodeStrategy(
+  input: ExecuteMapNodeStrategyInput,
+): Promise<NodeExecutionResult> {
+  const { node, config, context, nodeStates, runtime } = input;
+  const startTime = Date.now();
+
+  const items = typeof config.items === "function" ? await config.items(context) : config.items;
+
+  if (!Array.isArray(items)) {
+    throw INVALID_ARGUMENT.create({ detail: `Map node "${node.id}" items must be an array` });
+  }
+
+  if (items.length === 0) {
+    const state: NodeState = {
+      nodeId: node.id,
+      status: "completed",
+      output: [],
+      attempt: 1,
+      startedAt: new Date(startTime),
+      completedAt: new Date(),
+    };
+    return { state, contextUpdates: { [node.id]: [] }, waiting: false };
+  }
+
+  const childNodes = createMapChildNodes(node, config, items);
+
+  const result = await runtime.executeChildGraph(
+    childNodes,
+    {
+      id: `${node.id}_map`,
+      workflowId: "",
+      status: "running",
+      input: context.input,
+      // Carry already-accumulated child states so completed children are
+      // skipped on resume instead of re-executing (H8).
+      nodeStates,
+      currentNodes: [],
+      context: { ...context },
+      checkpoints: [],
+      pendingApprovals: [],
+      createdAt: new Date(),
+    },
+    config.concurrency ? { maxConcurrency: config.concurrency } : undefined,
+  );
+
+  Object.assign(nodeStates, result.nodeStates);
+
+  const outputs = childNodes.map((child) => result.nodeStates[child.id]?.output);
+
+  const state: NodeState = {
+    nodeId: node.id,
+    status: deriveNodeStatus(result.completed, result.waiting),
+    output: outputs,
+    error: result.error,
+    attempt: 1,
+    startedAt: new Date(startTime),
+    completedAt: result.completed ? new Date() : undefined,
+  };
+
+  runtime.onNodeComplete?.(node.id, state);
+
+  return {
+    state,
+    contextUpdates: result.completed ? { [node.id]: outputs } : {},
+    waiting: result.waiting,
+  };
+}

--- a/src/workflow/executor/dag/node-strategy-types.ts
+++ b/src/workflow/executor/dag/node-strategy-types.ts
@@ -1,0 +1,17 @@
+import type { NodeState, WorkflowNode, WorkflowRun } from "../../types.ts";
+import type { DAGExecutionResult } from "./types.ts";
+
+export interface ChildGraphExecutionOptions {
+  maxConcurrency?: number;
+}
+
+export type ExecuteChildGraph = (
+  nodes: WorkflowNode[],
+  run: WorkflowRun,
+  options?: ChildGraphExecutionOptions,
+) => Promise<DAGExecutionResult>;
+
+export interface NodeStrategyRuntime {
+  executeChildGraph: ExecuteChildGraph;
+  onNodeComplete?: (nodeId: string, state: NodeState) => void;
+}


### PR DESCRIPTION
## Summary
- Extract map and loop node execution from `DAGExecutor` into internal strategy modules.
- Add regression coverage for map item input/output ordering and loop error output semantics.
- Keep child-graph recursion and map concurrency override scoped through a DAG-owned callback.
- Bump release metadata to 0.1.701.

## Verification
- deno test --no-check --allow-all src/workflow/executor/dag/index.test.ts
- deno test --no-check --allow-all src/workflow/executor/dag/index.test.ts src/workflow/executor/dag-executor.test.ts src/workflow/executor/workflow-executor.test.ts src/workflow/__tests__/workflow.integration.test.ts
- deno check src/workflow/executor/dag/index.ts src/workflow/executor/dag/index.test.ts src/workflow/executor/dag/map-node-strategy.ts src/workflow/executor/dag/loop-node-strategy.ts src/workflow/executor/dag/node-strategy-types.ts
- git diff --check
- deno task verify:quick
- pre-push hook: format, lint, typecheck, unit tests (2012 passed, 0 failed)

Related: #1984