### PR TITLE
Unify Claude Code React event state handling

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.701",
+  "version": "0.1.702",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.701";
+export const VERSION = "0.1.702";

--- a/src/workflow/claude-code/react/event-state-reducer.test.ts
+++ b/src/workflow/claude-code/react/event-state-reducer.test.ts
@@ -1,0 +1,164 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  type ClaudeCodeAllToolCall,
+  type ClaudeCodeEventState,
+  createClaudeCodeEventState,
+  isClaudeCodeCoreEvent,
+  reduceClaudeCodeEventState,
+} from "./event-state-reducer.ts";
+import type { ClaudeCodeEvent, ClaudeCodeEventExtended, ClaudeCodeResult } from "../types.ts";
+
+function result(overrides: Partial<ClaudeCodeResult> = {}): ClaudeCodeResult {
+  return {
+    success: true,
+    iterations: 1,
+    response: "done",
+    filesModified: [],
+    commandsExecuted: [],
+    executionTime: 12,
+    ...overrides,
+  };
+}
+
+describe("workflow/claude-code/react/event-state-reducer", () => {
+  it("reduces shared iteration, text, tool, and completion events", () => {
+    const finalResult = result();
+    const events: ClaudeCodeEvent[] = [
+      {
+        type: "iteration_start",
+        timestamp: 1,
+        iteration: 2,
+        maxIterations: 5,
+      },
+      {
+        type: "text_delta",
+        timestamp: 2,
+        content: "hel",
+      },
+      {
+        type: "text_delta",
+        timestamp: 3,
+        content: "lo",
+      },
+      {
+        type: "tool_call_start",
+        timestamp: 4,
+        toolCallId: "tool-1",
+        toolName: "read",
+      },
+      {
+        type: "tool_call_complete",
+        timestamp: 5,
+        toolCallId: "tool-1",
+        toolName: "read",
+        input: { path: "README.md" },
+      },
+      {
+        type: "tool_result",
+        timestamp: 6,
+        toolCallId: "tool-1",
+        toolName: "read",
+        output: "contents",
+        isError: false,
+      },
+      {
+        type: "complete",
+        timestamp: 7,
+        result: finalResult,
+      },
+    ];
+    const state = events.reduce(
+      (previous, event) => reduceClaudeCodeEventState(previous, event),
+      createClaudeCodeEventState(),
+    );
+
+    assertEquals(state, {
+      isRunning: false,
+      currentIteration: 2,
+      maxIterations: 5,
+      text: "hello",
+      currentTool: null,
+      toolCalls: [
+        {
+          id: "tool-1",
+          name: "read",
+          input: { path: "README.md" },
+          output: "contents",
+          isError: false,
+        },
+      ],
+      result: finalResult,
+      error: null,
+    });
+  });
+
+  it("keeps bounded event history and all-iteration tool calls when requested", () => {
+    const events: ClaudeCodeEvent[] = [
+      {
+        type: "iteration_start",
+        timestamp: 1,
+        iteration: 3,
+        maxIterations: 8,
+      },
+      {
+        type: "tool_call_complete",
+        timestamp: 2,
+        toolCallId: "tool-2",
+        toolName: "bash",
+        input: { command: "deno test" },
+      },
+      {
+        type: "tool_result",
+        timestamp: 3,
+        toolCallId: "tool-2",
+        toolName: "bash",
+        output: "ok",
+        isError: false,
+      },
+    ];
+    const initialState: ClaudeCodeEventState & {
+      events: ClaudeCodeEvent[];
+      allToolCalls: ClaudeCodeAllToolCall[];
+    } = {
+      ...createClaudeCodeEventState(),
+      events: [],
+      allToolCalls: [],
+    };
+    const state = events.reduce(
+      (previous, event) =>
+        reduceClaudeCodeEventState(previous, event, {
+          keepEventHistory: true,
+          maxEventHistory: 2,
+          trackAllToolCalls: true,
+        }),
+      initialState,
+    );
+
+    assertEquals(
+      state.events.map((event) => event.type),
+      ["tool_call_complete", "tool_result"],
+    );
+    assertEquals(state.allToolCalls, [
+      {
+        iteration: 3,
+        id: "tool-2",
+        name: "bash",
+        input: { command: "deno test" },
+        output: "ok",
+        isError: false,
+      },
+    ]);
+  });
+
+  it("identifies core events and rejects websocket-only events", () => {
+    const events: ClaudeCodeEventExtended[] = [
+      { type: "pong", timestamp: 1 },
+      { type: "cancelled", timestamp: 2 },
+      { type: "text_complete", timestamp: 3, content: "done" },
+    ];
+
+    assertEquals(events.map(isClaudeCodeCoreEvent), [false, false, true]);
+  });
+});

--- a/src/workflow/claude-code/react/event-state-reducer.ts
+++ b/src/workflow/claude-code/react/event-state-reducer.ts
@@ -1,0 +1,172 @@
+import type { ClaudeCodeEvent, ClaudeCodeEventExtended, ClaudeCodeResult } from "../types.ts";
+
+export interface ClaudeCodeCurrentTool {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export interface ClaudeCodeToolCall extends ClaudeCodeCurrentTool {
+  output?: string;
+  isError?: boolean;
+}
+
+export interface ClaudeCodeAllToolCall extends ClaudeCodeToolCall {
+  iteration: number;
+}
+
+export interface ClaudeCodeEventState {
+  isRunning: boolean;
+  currentIteration: number;
+  maxIterations: number;
+  text: string;
+  currentTool: ClaudeCodeCurrentTool | null;
+  toolCalls: ClaudeCodeToolCall[];
+  result: ClaudeCodeResult | null;
+  error: string | null;
+}
+
+export interface ClaudeCodeEventReducerOptions {
+  keepEventHistory?: boolean;
+  maxEventHistory?: number;
+  trackAllToolCalls?: boolean;
+}
+
+type ClaudeCodeEventStateWithOptionalTracking = ClaudeCodeEventState & {
+  events?: ClaudeCodeEvent[];
+  allToolCalls?: ClaudeCodeAllToolCall[];
+};
+
+const CLAUDE_CODE_CORE_EVENT_TYPES = new Set<ClaudeCodeEvent["type"]>([
+  "iteration_start",
+  "text_delta",
+  "text_complete",
+  "tool_call_start",
+  "tool_call_input",
+  "tool_call_complete",
+  "tool_result",
+  "iteration_complete",
+  "thinking_start",
+  "thinking_delta",
+  "thinking_complete",
+  "complete",
+  "error",
+]);
+
+export function createClaudeCodeEventState(): ClaudeCodeEventState {
+  return {
+    isRunning: false,
+    currentIteration: 0,
+    maxIterations: 20,
+    text: "",
+    currentTool: null,
+    toolCalls: [],
+    result: null,
+    error: null,
+  };
+}
+
+export function isClaudeCodeCoreEvent(
+  event: ClaudeCodeEventExtended,
+): event is ClaudeCodeEvent {
+  return CLAUDE_CODE_CORE_EVENT_TYPES.has(event.type as ClaudeCodeEvent["type"]);
+}
+
+export function reduceClaudeCodeEventState<
+  TState extends ClaudeCodeEventStateWithOptionalTracking,
+>(
+  previous: TState,
+  event: ClaudeCodeEvent,
+  options: ClaudeCodeEventReducerOptions = {},
+): TState {
+  const next = { ...previous };
+
+  if (options.keepEventHistory && Array.isArray(next.events)) {
+    next.events = [...(previous.events ?? []), event].slice(
+      -(options.maxEventHistory ?? 100),
+    );
+  }
+
+  switch (event.type) {
+    case "iteration_start":
+      next.isRunning = true;
+      next.currentIteration = event.iteration;
+      next.maxIterations = event.maxIterations;
+      next.toolCalls = [];
+      next.currentTool = null;
+      break;
+
+    case "text_delta":
+      next.text = previous.text + event.content;
+      break;
+
+    case "text_complete":
+      next.text = event.content;
+      break;
+
+    case "tool_call_start":
+      next.currentTool = {
+        id: event.toolCallId,
+        name: event.toolName,
+        input: {},
+      };
+      break;
+
+    case "tool_call_complete":
+      next.currentTool = null;
+      next.toolCalls = [
+        ...previous.toolCalls,
+        {
+          id: event.toolCallId,
+          name: event.toolName,
+          input: event.input,
+        },
+      ];
+      break;
+
+    case "tool_result": {
+      next.toolCalls = previous.toolCalls.map((toolCall) =>
+        toolCall.id === event.toolCallId
+          ? { ...toolCall, output: event.output, isError: event.isError }
+          : toolCall
+      );
+
+      if (options.trackAllToolCalls && Array.isArray(next.allToolCalls)) {
+        const matchingToolCall = previous.toolCalls.find((toolCall) =>
+          toolCall.id === event.toolCallId
+        );
+        next.allToolCalls = [
+          ...(previous.allToolCalls ?? []),
+          {
+            iteration: event.iteration ?? previous.currentIteration,
+            id: event.toolCallId,
+            name: event.toolName,
+            input: matchingToolCall?.input ?? {},
+            output: event.output,
+            isError: event.isError,
+          },
+        ];
+      }
+      break;
+    }
+
+    case "iteration_complete":
+      next.currentTool = null;
+      break;
+
+    case "complete":
+      next.isRunning = false;
+      next.result = event.result;
+      next.currentTool = null;
+      break;
+
+    case "error":
+      next.error = event.message;
+      if (!event.recoverable) {
+        next.isRunning = false;
+      }
+      break;
+  }
+
+  return next;
+}

--- a/src/workflow/claude-code/react/use-claude-code-stream.ts
+++ b/src/workflow/claude-code/react/use-claude-code-stream.ts
@@ -6,6 +6,12 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ClaudeCodeEvent, ClaudeCodeResult } from "../types.ts";
+import {
+  type ClaudeCodeAllToolCall,
+  type ClaudeCodeEventState,
+  createClaudeCodeEventState,
+  reduceClaudeCodeEventState,
+} from "./event-state-reducer.ts";
 import { REQUEST_ERROR } from "#veryfront/errors";
 
 /** Default delay before reconnecting after disconnect */
@@ -17,53 +23,12 @@ const DEFAULT_MAX_EVENT_HISTORY = 100;
 /**
  * State for Claude Code streaming
  */
-export interface UseClaudeCodeStreamState {
+export interface UseClaudeCodeStreamState extends ClaudeCodeEventState {
   /** Whether currently connected to stream */
   isConnected: boolean;
 
-  /** Whether agent is currently executing */
-  isRunning: boolean;
-
-  /** Current iteration number */
-  currentIteration: number;
-
-  /** Maximum iterations allowed */
-  maxIterations: number;
-
-  /** Accumulated text output */
-  text: string;
-
-  /** Current tool being executed (if any) */
-  currentTool: {
-    id: string;
-    name: string;
-    input: Record<string, unknown>;
-  } | null;
-
-  /** Tool calls in current iteration */
-  toolCalls: Array<{
-    id: string;
-    name: string;
-    input: Record<string, unknown>;
-    output?: string;
-    isError?: boolean;
-  }>;
-
   /** All tool calls across all iterations */
-  allToolCalls: Array<{
-    iteration: number;
-    id: string;
-    name: string;
-    input: Record<string, unknown>;
-    output?: string;
-    isError?: boolean;
-  }>;
-
-  /** Final result (when complete) */
-  result: ClaudeCodeResult | null;
-
-  /** Error message (if any) */
-  error: string | null;
+  allToolCalls: ClaudeCodeAllToolCall[];
 
   /** Raw events (for debugging) */
   events: ClaudeCodeEvent[];
@@ -163,16 +128,9 @@ export function useClaudeCodeStream(
   } = options;
 
   const [state, setState] = useState<UseClaudeCodeStreamState>({
+    ...createClaudeCodeEventState(),
     isConnected: false,
-    isRunning: false,
-    currentIteration: 0,
-    maxIterations: 20,
-    text: "",
-    currentTool: null,
-    toolCalls: [],
     allToolCalls: [],
-    result: null,
-    error: null,
     events: [],
   });
 
@@ -186,88 +144,14 @@ export function useClaudeCodeStream(
       onEvent?.(event);
 
       setState((prev) => {
-        const newState = { ...prev };
+        const newState = reduceClaudeCodeEventState(prev, event, {
+          keepEventHistory,
+          maxEventHistory,
+          trackAllToolCalls: true,
+        });
 
-        // Keep event history if enabled
-        if (keepEventHistory) {
-          newState.events = [...prev.events, event].slice(-maxEventHistory);
-        }
-
-        switch (event.type) {
-          case "iteration_start":
-            newState.isRunning = true;
-            newState.currentIteration = event.iteration;
-            newState.maxIterations = event.maxIterations;
-            newState.toolCalls = [];
-            newState.currentTool = null;
-            break;
-
-          case "text_delta":
-            newState.text = prev.text + event.content;
-            break;
-
-          case "text_complete":
-            newState.text = event.content;
-            break;
-
-          case "tool_call_start":
-            newState.currentTool = {
-              id: event.toolCallId,
-              name: event.toolName,
-              input: {},
-            };
-            break;
-
-          case "tool_call_complete":
-            newState.currentTool = null;
-            newState.toolCalls = [
-              ...prev.toolCalls,
-              {
-                id: event.toolCallId,
-                name: event.toolName,
-                input: event.input,
-              },
-            ];
-            break;
-
-          case "tool_result":
-            // Update the tool call with its result
-            newState.toolCalls = prev.toolCalls.map((tc) =>
-              tc.id === event.toolCallId
-                ? { ...tc, output: event.output, isError: event.isError }
-                : tc
-            );
-            // Add to all tool calls
-            newState.allToolCalls = [
-              ...prev.allToolCalls,
-              {
-                iteration: event.iteration || prev.currentIteration,
-                id: event.toolCallId,
-                name: event.toolName,
-                input: prev.toolCalls.find((tc) => tc.id === event.toolCallId)?.input || {},
-                output: event.output,
-                isError: event.isError,
-              },
-            ];
-            break;
-
-          case "iteration_complete":
-            newState.currentTool = null;
-            break;
-
-          case "complete":
-            newState.isRunning = false;
-            newState.result = event.result;
-            newState.currentTool = null;
-            onComplete?.(event.result);
-            break;
-
-          case "error":
-            newState.error = event.message;
-            if (!event.recoverable) {
-              newState.isRunning = false;
-            }
-            break;
+        if (event.type === "complete") {
+          onComplete?.(event.result);
         }
 
         return newState;

--- a/src/workflow/claude-code/react/use-claude-code-websocket.ts
+++ b/src/workflow/claude-code/react/use-claude-code-websocket.ts
@@ -12,6 +12,12 @@ import type {
   ClaudeCodeResult,
   InputRequestEvent,
 } from "../types.ts";
+import {
+  type ClaudeCodeEventState,
+  createClaudeCodeEventState,
+  isClaudeCodeCoreEvent,
+  reduceClaudeCodeEventState,
+} from "./event-state-reducer.ts";
 import { NETWORK_ERROR, REQUEST_ERROR } from "#veryfront/errors";
 
 /** Default delay before reconnecting after disconnect */
@@ -45,52 +51,18 @@ export interface PendingInput {
 /**
  * State for Claude Code WebSocket
  */
-export interface UseClaudeCodeWebSocketState {
+export interface UseClaudeCodeWebSocketState extends ClaudeCodeEventState {
   /** Whether currently connected */
   isConnected: boolean;
 
-  /** Whether agent is currently executing */
-  isRunning: boolean;
-
   /** Whether agent was cancelled */
   isCancelled: boolean;
-
-  /** Current iteration number */
-  currentIteration: number;
-
-  /** Maximum iterations allowed */
-  maxIterations: number;
-
-  /** Accumulated text output */
-  text: string;
-
-  /** Current tool being executed (if any) */
-  currentTool: {
-    id: string;
-    name: string;
-    input: Record<string, unknown>;
-  } | null;
-
-  /** Tool calls in current iteration */
-  toolCalls: Array<{
-    id: string;
-    name: string;
-    input: Record<string, unknown>;
-    output?: string;
-    isError?: boolean;
-  }>;
 
   /** Pending approval requests */
   pendingApprovals: PendingApproval[];
 
   /** Pending input request (if any) */
   pendingInput: PendingInput | null;
-
-  /** Final result (when complete) */
-  result: ClaudeCodeResult | null;
-
-  /** Error message (if any) */
-  error: string | null;
 }
 
 /**
@@ -211,18 +183,11 @@ export function useClaudeCodeWebSocket(
   } = options;
 
   const [state, setState] = useState<UseClaudeCodeWebSocketState>({
+    ...createClaudeCodeEventState(),
     isConnected: false,
-    isRunning: false,
     isCancelled: false,
-    currentIteration: 0,
-    maxIterations: 20,
-    text: "",
-    currentTool: null,
-    toolCalls: [],
     pendingApprovals: [],
     pendingInput: null,
-    result: null,
-    error: null,
   });
 
   const socketRef = useRef<WebSocket | null>(null);
@@ -236,71 +201,15 @@ export function useClaudeCodeWebSocket(
       onEvent?.(event);
 
       setState((prev) => {
-        const newState = { ...prev };
+        const newState = isClaudeCodeCoreEvent(event)
+          ? reduceClaudeCodeEventState(prev, event)
+          : { ...prev };
 
         switch (event.type) {
-          case "iteration_start":
-            newState.isRunning = true;
-            newState.currentIteration = event.iteration;
-            newState.maxIterations = event.maxIterations;
-            newState.toolCalls = [];
-            newState.currentTool = null;
-            break;
-
-          case "text_delta":
-            newState.text = prev.text + event.content;
-            break;
-
-          case "text_complete":
-            newState.text = event.content;
-            break;
-
-          case "tool_call_start":
-            newState.currentTool = {
-              id: event.toolCallId,
-              name: event.toolName,
-              input: {},
-            };
-            break;
-
-          case "tool_call_complete":
-            newState.currentTool = null;
-            newState.toolCalls = [
-              ...prev.toolCalls,
-              {
-                id: event.toolCallId,
-                name: event.toolName,
-                input: event.input,
-              },
-            ];
-            break;
-
-          case "tool_result":
-            newState.toolCalls = prev.toolCalls.map((tc) =>
-              tc.id === event.toolCallId
-                ? { ...tc, output: event.output, isError: event.isError }
-                : tc
-            );
-            break;
-
-          case "iteration_complete":
-            newState.currentTool = null;
-            break;
-
           case "complete":
-            newState.isRunning = false;
-            newState.result = event.result;
-            newState.currentTool = null;
             newState.pendingApprovals = [];
             newState.pendingInput = null;
             onComplete?.(event.result);
-            break;
-
-          case "error":
-            newState.error = event.message;
-            if (!event.recoverable) {
-              newState.isRunning = false;
-            }
             break;
 
           case "cancelled":


### PR DESCRIPTION
## Summary

- Extract the shared Claude Code React event-state reducer used by SSE and WebSocket hooks.
- Keep SSE-specific event history/all-tool-call tracking and WebSocket approval/input/cancel handling in their transport hooks.
- Add reducer coverage for core streaming state, SSE tracking, and websocket-only event guarding.
- Bump release version to `0.1.702`.

## Verification

- `deno test --no-check --allow-all src/workflow/claude-code/react/event-state-reducer.test.ts`
- `deno check src/workflow/claude-code/react/event-state-reducer.ts src/workflow/claude-code/react/event-state-reducer.test.ts src/workflow/claude-code/react/use-claude-code-stream.ts src/workflow/claude-code/react/use-claude-code-websocket.ts src/utils/version-constant.ts`
- `git diff --check`
- `deno task verify:quick`
- Pre-push hook: format, lint, typecheck, unit tests (`2013 passed, 0 failed`)

Related to #1984 and #1990.
