### PR TITLE
Preserve current-run evidence through compaction

### DIFF
--- a/src/agent/hosted/context-budget-manager.test.ts
+++ b/src/agent/hosted/context-budget-manager.test.ts
@@ -5,7 +5,17 @@ import {
   assertRejects,
   assertStringIncludes,
 } from "#veryfront/testing/assert.ts";
-import type { AgentRuntimeMessage } from "../runtime/message-adapter.ts";
+import {
+  type AgentRuntimeMessage,
+  convertAgentRuntimeMessagesToProviderMessages,
+} from "../runtime/message-adapter.ts";
+import {
+  createCurrentRunToolState,
+  createCurrentRunToolStateRuntimeContextPart,
+  hydrateCurrentRunToolStateFromMessages,
+  recordCurrentRunToolResult,
+  validateInvokeAgentInputAgainstCurrentRunEvidence,
+} from "../runtime/current-run-tool-state.ts";
 import {
   AGENT_RUN_CONTEXT_COMPACTED_EVENT_TYPE,
   applyContextBudget,
@@ -56,6 +66,26 @@ function toolResultMessage(id: string, toolCallId: string): AgentRuntimeMessage 
       toolCallId,
       toolName: "search_docs",
       result: { ok: true },
+    }],
+    timestamp: 1,
+  };
+}
+
+function invoiceEvidenceToolResultMessage(id: string, toolCallId: string): AgentRuntimeMessage {
+  return {
+    id,
+    role: "tool",
+    parts: [{
+      type: "tool-result",
+      toolCallId,
+      toolName: "invoke_agent",
+      result: {
+        summary: {
+          text: "| Invoice | Supplier | Amount | PO |\n" +
+            "| --- | --- | --- | --- |\n" +
+            "| INV-2026-00491 | Meyer Papier GmbH | €2,180.00 | PO-2026-1197 |\n",
+        },
+      },
     }],
     timestamp: 1,
   };
@@ -160,6 +190,107 @@ Deno.test("applyContextBudget keeps tool call and result pairs in the retained t
     "tool-result-1",
     "user-2",
   ]);
+});
+
+Deno.test("applyContextBudget blocks contradicted handoffs after provider-visible evidence is compacted", async () => {
+  const result = await applyContextBudget([
+    message("user-1", "user", "Older goal ".repeat(200)),
+    toolCallMessage("assistant-tool-1", "tool-1"),
+    invoiceEvidenceToolResultMessage("tool-result-1", "tool-1"),
+    message("assistant-1", "assistant", "Older answer ".repeat(100)),
+    message("user-2", "user", "Different follow-up ".repeat(100)),
+    message("assistant-2", "assistant", "Recent answer"),
+    message("user-3", "user", "Schedule the invoice"),
+  ], {
+    tokenBudget: 420,
+    reserveTokens: 20,
+    recentTailTokens: 20,
+    now: () => 123,
+    summaryGenerator: () => ({ text: "Earlier context summarized." }),
+  });
+
+  const providerReplayText = convertAgentRuntimeMessagesToProviderMessages(result.messages)
+    .map((message) => typeof message.content === "string" ? message.content : "")
+    .join("\n");
+  assertEquals(providerReplayText.includes("Meyer Papier GmbH"), false);
+  assertEquals(providerReplayText.includes("PO-2026-1197"), false);
+
+  const state = createCurrentRunToolState();
+  hydrateCurrentRunToolStateFromMessages(state, result.messages);
+
+  const invalid = validateInvokeAgentInputAgainstCurrentRunEvidence(state, {
+    agent_id: "payment-schedule-agent",
+    prompt: "Schedule invoice INV-2026-00491 from supplier Wolff & Partner Consulting GmbH.",
+    context: {
+      invoice: {
+        invoice_id: "INV-2026-00491",
+        supplier: "Wolff & Partner Consulting GmbH",
+      },
+    },
+  });
+
+  assertEquals(invalid.ok, false);
+});
+
+Deno.test("applyContextBudget strips internal runtime context before summary generation", async () => {
+  const compactedState = createCurrentRunToolState();
+  recordCurrentRunToolResult(compactedState, {
+    toolCallId: "invoke-ingest-1",
+    toolName: "invoke_agent",
+    input: { agent_id: "ingest-records-agent", prompt: "Load open records" },
+    result: {
+      summary: {
+        text: "| Invoice | Supplier |\n" +
+          "| --- | --- |\n" +
+          "| INV-2026-00491 | Meyer Papier GmbH |\n",
+      },
+    },
+  });
+  const statePart = createCurrentRunToolStateRuntimeContextPart(compactedState);
+  assertExists(statePart);
+
+  let summaryInputHadRuntimeContext = false;
+  const result = await applyContextBudget([
+    {
+      id: "context_compaction_summary:old-tail",
+      role: "system",
+      parts: [
+        { type: "text", text: "Previous context summary." },
+        statePart,
+      ],
+      timestamp: 1,
+    },
+    message("assistant-1", "assistant", "Older answer ".repeat(100)),
+    message("user-1", "user", "Different follow-up ".repeat(100)),
+    message("assistant-2", "assistant", "Recent answer"),
+    message("user-2", "user", "Schedule the invoice"),
+  ], {
+    tokenBudget: 320,
+    reserveTokens: 20,
+    recentTailTokens: 20,
+    now: () => 123,
+    summaryGenerator: ({ messagesToSummarize }) => {
+      summaryInputHadRuntimeContext = messagesToSummarize.some((entry) =>
+        entry.parts.some((part) => part.type === "runtime-context")
+      );
+      return { text: "Earlier compacted context summarized again." };
+    },
+  });
+
+  assertEquals(summaryInputHadRuntimeContext, false);
+
+  const hydratedState = createCurrentRunToolState();
+  hydrateCurrentRunToolStateFromMessages(hydratedState, result.messages);
+  const invalid = validateInvokeAgentInputAgainstCurrentRunEvidence(hydratedState, {
+    agent_id: "payment-schedule-agent",
+    context: {
+      invoice: {
+        invoice_id: "INV-2026-00491",
+        supplier: "Wolff & Partner Consulting GmbH",
+      },
+    },
+  });
+  assertEquals(invalid.ok, false);
 });
 
 Deno.test("applyContextBudget rejects invalid summary output", async () => {

--- a/src/agent/hosted/context-budget-manager.ts
+++ b/src/agent/hosted/context-budget-manager.ts
@@ -2,6 +2,11 @@ import { estimateTokens } from "../../chat/message-prep.ts";
 import { defineSchema } from "../../schemas/index.ts";
 import type { InferSchema } from "../../extensions/schema/index.ts";
 import type { AgentRuntimeMessage } from "../runtime/message-adapter.ts";
+import {
+  createCurrentRunToolState,
+  createCurrentRunToolStateRuntimeContextPart,
+  hydrateCurrentRunToolStateFromMessages,
+} from "../runtime/current-run-tool-state.ts";
 
 export const AGENT_RUN_CONTEXT_COMPACTED_EVENT_TYPE = "AGENT_RUN_CONTEXT_COMPACTED" as const;
 
@@ -105,12 +110,19 @@ function getUsableTokenBudget(
   return options.tokenBudget - options.reserveTokens;
 }
 
+function getBudgetedMessage(message: AgentRuntimeMessage): AgentRuntimeMessage {
+  return {
+    ...message,
+    parts: message.parts.filter((part) => part.type !== "runtime-context"),
+  };
+}
+
 function getMessageTokens(message: AgentRuntimeMessage): number {
-  return estimateTokens(message);
+  return estimateTokens(getBudgetedMessage(message));
 }
 
 function getMessageListTokens(messages: readonly AgentRuntimeMessage[]): number {
-  return estimateTokens(messages);
+  return estimateTokens(messages.map(getBudgetedMessage));
 }
 
 function isUserMessage(message: AgentRuntimeMessage): boolean {
@@ -245,14 +257,22 @@ function createSyntheticSummaryMessage(input: {
   text: string;
   firstKeptEntryId: string;
   timestamp: number;
+  messagesToSummarize: readonly AgentRuntimeMessage[];
 }): AgentRuntimeMessage {
+  const compactedState = createCurrentRunToolState();
+  hydrateCurrentRunToolStateFromMessages(compactedState, input.messagesToSummarize);
+  const statePart = createCurrentRunToolStateRuntimeContextPart(compactedState);
+
   return {
     id: `context_compaction_summary:${input.firstKeptEntryId}`,
     role: "system",
-    parts: [{
-      type: "text",
-      text: `Previous context summary:\n${input.text}`,
-    }],
+    parts: [
+      {
+        type: "text",
+        text: `Previous context summary:\n${input.text}`,
+      },
+      ...(statePart ? [statePart] : []),
+    ],
     timestamp: input.timestamp,
   };
 }
@@ -343,6 +363,8 @@ export async function applyContextBudget(
   const tailStartIndex = expandTailForToolPairs(messages, conversationTailStartIndex);
   const messagesToSummarize = messages.slice(0, tailStartIndex);
   const retainedMessages = messages.slice(tailStartIndex);
+  const summaryMessagesToSummarize = messagesToSummarize.map(getBudgetedMessage);
+  const summaryRetainedMessages = retainedMessages.map(getBudgetedMessage);
   const firstKeptEntryId = retainedMessages[0]?.id;
 
   if (!firstKeptEntryId) {
@@ -353,8 +375,8 @@ export async function applyContextBudget(
   try {
     summary = getContextCompactionSummarySchema().parse(
       await options.summaryGenerator({
-        messagesToSummarize,
-        retainedMessages,
+        messagesToSummarize: summaryMessagesToSummarize,
+        retainedMessages: summaryRetainedMessages,
         customInstructions: options.customInstructions,
       }),
     );
@@ -372,6 +394,7 @@ export async function applyContextBudget(
     text: summary.text,
     firstKeptEntryId,
     timestamp: options.now?.() ?? Date.now(),
+    messagesToSummarize,
   });
   const compactedMessages = [summaryMessage, ...retainedMessages];
   const tokensAfter = getMessageListTokens(compactedMessages);

--- a/src/agent/runtime/current-run-tool-state.test.ts
+++ b/src/agent/runtime/current-run-tool-state.test.ts
@@ -405,6 +405,81 @@ describe("current-run tool state", () => {
     }
   });
 
+  it("blocks invoke_agent context fields that contradict prior evidence for the same record", () => {
+    const state = createCurrentRunToolState();
+
+    recordCurrentRunToolResult(state, {
+      toolCallId: "invoke-ingest-1",
+      toolName: "invoke_agent",
+      input: { agent_id: "ingest-records-agent", prompt: "Load open records" },
+      result: {
+        status: "completed",
+        summary: {
+          text: "| Record | Supplier | Amount | PO | Due date |\n" +
+            "| --- | --- | --- | --- | --- |\n" +
+            "| INV-2026-00491 | Meyer Papier GmbH | €2,180.00 | PO-2026-1197 | 2026-06-18 |\n",
+        },
+      },
+    });
+
+    const invalidAmount = validateInvokeAgentInputAgainstCurrentRunEvidence(state, {
+      agent_id: "payment-schedule-agent",
+      prompt: "Schedule record INV-2026-00491 from structured context.",
+      context: {
+        record: {
+          record_id: "INV-2026-00491",
+          supplier: "Meyer Papier GmbH",
+          amount: 47250,
+          po_reference: "PO-2026-1197",
+          due_date: "2026-06-18",
+        },
+      },
+    });
+
+    assertEquals(invalidAmount.ok, false);
+    if (!invalidAmount.ok) {
+      assertStringIncludes(invalidAmount.error, 'INV-2026-00491 amount is "€2,180.00"');
+      assertStringIncludes(invalidAmount.error, "47250");
+    }
+
+    const invalidPo = validateInvokeAgentInputAgainstCurrentRunEvidence(state, {
+      agent_id: "payment-schedule-agent",
+      prompt: "Schedule record INV-2026-00491 from structured context.",
+      context: {
+        record: {
+          record_id: "INV-2026-00491",
+          supplier: "Meyer Papier GmbH",
+          amount: 2180,
+          po_reference: "PO-2026-1192",
+          due_date: "2026-06-18",
+        },
+      },
+    });
+
+    assertEquals(invalidPo.ok, false);
+    if (!invalidPo.ok) {
+      assertStringIncludes(invalidPo.error, 'INV-2026-00491 po is "PO-2026-1197"');
+      assertStringIncludes(invalidPo.error, "PO-2026-1192");
+    }
+
+    assertEquals(
+      validateInvokeAgentInputAgainstCurrentRunEvidence(state, {
+        agent_id: "payment-schedule-agent",
+        prompt: "Schedule record INV-2026-00491 from structured context.",
+        context: {
+          record: {
+            record_id: "INV-2026-00491",
+            supplier: "Meyer Papier GmbH",
+            amount: 2180,
+            po_reference: "PO-2026-1197",
+            due_date: "2026-06-18",
+          },
+        },
+      }),
+      { ok: true },
+    );
+  });
+
   it("keeps hidden evidence out of the projected current-run prompt state", () => {
     const state = createCurrentRunToolState();
 
@@ -496,6 +571,26 @@ describe("current-run tool state", () => {
         fields: {
           supplier: "Meyer Papier GmbH",
           purchase_order_id: "PO-2026-1197",
+        },
+      }],
+    );
+  });
+
+  it("treats secondary ids in row tables as field values, not records", () => {
+    assertEquals(
+      extractCurrentRunEvidence({
+        summary: {
+          text: "| Invoice | Supplier | Amount | PO |\n" +
+            "| --- | --- | --- | --- |\n" +
+            "| INV-2026-00491 | Meyer Papier GmbH | €2,180.00 | PO-2026-1197 |\n",
+        },
+      }),
+      [{
+        recordId: "INV-2026-00491",
+        fields: {
+          supplier: "Meyer Papier GmbH",
+          amount: "€2,180.00",
+          po: "PO-2026-1197",
         },
       }],
     );

--- a/src/agent/runtime/current-run-tool-state.ts
+++ b/src/agent/runtime/current-run-tool-state.ts
@@ -35,6 +35,11 @@ export type CurrentRunToolStateHydrationMessage = {
   role?: string;
   parts?: readonly unknown[];
 };
+export type CurrentRunToolStateRuntimeContextPart = {
+  type: "runtime-context";
+  name: "current-run-tool-state";
+  state: CurrentRunToolState;
+};
 
 const MAX_FALLBACK_ITEMS = 5;
 const MAX_FALLBACK_STRING_LENGTH = 300;
@@ -45,7 +50,6 @@ const MAX_EVIDENCE_RECORDS = 25;
 const MAX_EVIDENCE_FIELDS_PER_RECORD = 12;
 const MAX_STRUCTURED_ASSERTION_LINES = 80;
 const RECORD_ID_PATTERN = /\b[A-Z][A-Z0-9]+-\d{4}-\d{3,}\b/g;
-const NEXT_RECORD_ID_PATTERN = /\b[A-Z][A-Z0-9]+-\d{4}-\d{3,}\b/;
 const GUARDED_FACT_ALIASES: Record<string, string[]> = {
   supplier: ["supplier", "vendor"],
   vendor: ["vendor", "supplier"],
@@ -60,6 +64,16 @@ const NON_EVIDENCE_TOOL_NAMES = new Set([
   "load_skill",
   "load_skill_reference",
   "execute_skill_script",
+]);
+const WEAK_FIELD_MATCH_TOKENS = new Set([
+  "id",
+  "ids",
+  "name",
+  "names",
+  "ref",
+  "refs",
+  "reference",
+  "references",
 ]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -180,13 +194,13 @@ function extractEvidenceFromMarkdownTable(
   }
 
   for (const row of rows) {
-    const rowIds = row.flatMap(getRecordIds);
-    for (const recordId of rowIds) {
-      for (const [index, value] of row.entries()) {
-        const field = headers[index] ?? "";
-        if (!field || getRecordIds(value).includes(recordId)) continue;
-        mergeEvidenceField(evidenceByRecordId, recordId, field, value);
-      }
+    const recordId = row.flatMap(getRecordIds)[0];
+    if (!recordId) continue;
+
+    for (const [index, value] of row.entries()) {
+      const field = headers[index] ?? "";
+      if (!field || getRecordIds(value).includes(recordId)) continue;
+      mergeEvidenceField(evidenceByRecordId, recordId, field, value);
     }
   }
 
@@ -238,6 +252,35 @@ function getExpectedEvidenceField(
   return null;
 }
 
+function getCompatibleEvidenceField(
+  fields: Record<string, string>,
+  field: string,
+): { field: string; value: string } | null {
+  const expected = getExpectedEvidenceField(fields, field);
+  if (expected) return expected;
+
+  const fieldTokens = getComparableFieldTokens(field);
+  if (fieldTokens.length === 0) return null;
+
+  for (const [evidenceField, value] of Object.entries(fields)) {
+    const evidenceTokens = getComparableFieldTokens(evidenceField);
+    if (evidenceTokens.length === 0) continue;
+    if (
+      fieldTokens.length === evidenceTokens.length && fieldTokens.every((token, index) => {
+        return token === evidenceTokens[index];
+      })
+    ) {
+      return { field: evidenceField, value };
+    }
+  }
+
+  return null;
+}
+
+function getComparableFieldTokens(field: string): string[] {
+  return field.split("_").filter((token) => token && !WEAK_FIELD_MATCH_TOKENS.has(token));
+}
+
 function hasCompanyLikeShape(value: string): boolean {
   if (getRecordIds(value).length > 0) return false;
   if (/[€$£¥]\s?\d|\d{4,}/.test(value)) return false;
@@ -250,6 +293,7 @@ function hasCompanyLikeShape(value: string): boolean {
 
 function extractAssertedFieldValues(text: string): Array<{ field: string; value: string }> {
   const assertions: Array<{ field: string; value: string }> = [];
+
   for (const field of Object.keys(GUARDED_FACT_ALIASES)) {
     const aliases = GUARDED_FACT_ALIASES[field] ?? [field];
     for (const alias of aliases) {
@@ -269,25 +313,50 @@ function extractAssertedFieldValues(text: string): Array<{ field: string; value:
 }
 
 function valuesConflict(actual: string, expected: string): boolean {
-  const normalize = (value: string) => normalizeWhitespace(value).toLowerCase();
-  const left = normalize(actual);
-  const right = normalize(expected);
+  const left = normalizeComparableValue(actual);
+  const right = normalizeComparableValue(expected);
   return left !== right && !left.includes(right) && !right.includes(left);
+}
+
+function normalizeComparableValue(value: string): string {
+  const normalized = normalizeWhitespace(value).toLowerCase();
+  const numeric = normalizeNumericValue(value);
+  return numeric ?? normalized;
+}
+
+function normalizeNumericValue(value: string): string | null {
+  const compact = normalizeWhitespace(value)
+    .replace(/\p{Sc}/gu, "")
+    .replace(/,/g, "")
+    .replace(/\s+/g, "");
+  if (!/^[+-]?\d+(?:\.\d+)?$/.test(compact)) return null;
+
+  const parsed = Number.parseFloat(compact);
+  return Number.isFinite(parsed) ? parsed.toFixed(2) : null;
 }
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function getRecordTextWindows(text: string, recordId: string): string[] {
+function getRecordBoundaryPattern(recordIds: readonly string[]): RegExp {
+  return new RegExp(`\\b(?:${recordIds.map(escapeRegExp).join("|")})\\b`, "g");
+}
+
+function getRecordTextWindows(
+  text: string,
+  recordId: string,
+  boundaryRecordIds: readonly string[],
+): string[] {
   const windows: string[] = [];
   const pattern = new RegExp(escapeRegExp(recordId), "g");
+  const boundaryPattern = getRecordBoundaryPattern(boundaryRecordIds);
 
   for (const match of text.matchAll(pattern)) {
     const index = match.index ?? 0;
     const before = text.slice(0, index);
     const after = text.slice(index + recordId.length);
-    const previousRecordMatches = Array.from(before.matchAll(RECORD_ID_PATTERN));
+    const previousRecordMatches = Array.from(before.matchAll(boundaryPattern));
     const previousRecordMatch = previousRecordMatches.at(-1);
     const previousRecordEnd = previousRecordMatch && typeof previousRecordMatch.index === "number"
       ? previousRecordMatch.index + previousRecordMatch[0].length
@@ -297,7 +366,8 @@ function getRecordTextWindows(text: string, recordId: string): string[] {
       before.lastIndexOf("\n"),
       before.lastIndexOf(";"),
     );
-    const nextRecordMatch = after.match(NEXT_RECORD_ID_PATTERN);
+    boundaryPattern.lastIndex = 0;
+    const nextRecordMatch = boundaryPattern.exec(after);
     const nextRecordIndex = nextRecordMatch?.index;
     const windowEnd = typeof nextRecordIndex === "number"
       ? Math.max(0, nextRecordIndex)
@@ -356,6 +426,57 @@ function collectStructuredAssertionLines(
   return lines;
 }
 
+type StructuredContextFieldAssertion = {
+  recordId: string;
+  field: string;
+  value: string;
+};
+
+function directRecordIdsFromRecord(value: Record<string, unknown>): string[] {
+  const ids: string[] = [];
+  for (const entry of Object.values(value)) {
+    const primitiveValue = primitiveStructuredValueToString(entry);
+    if (primitiveValue !== null) ids.push(...getRecordIds(primitiveValue));
+  }
+  return Array.from(new Set(ids));
+}
+
+function collectStructuredContextFieldAssertions(
+  value: unknown,
+  assertions: StructuredContextFieldAssertion[] = [],
+  activeRecordIds: readonly string[] = [],
+  fieldName?: string,
+): StructuredContextFieldAssertion[] {
+  const primitiveValue = primitiveStructuredValueToString(value);
+  if (primitiveValue !== null) {
+    if (fieldName) {
+      const field = normalizeEvidenceField(fieldName);
+      for (const recordId of activeRecordIds) {
+        if (primitiveValue === recordId) continue;
+        assertions.push({ recordId, field, value: primitiveValue });
+      }
+    }
+    return assertions;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectStructuredContextFieldAssertions(item, assertions, activeRecordIds, fieldName);
+    }
+    return assertions;
+  }
+
+  if (!isRecord(value)) return assertions;
+
+  const directRecordIds = directRecordIdsFromRecord(value);
+  const recordIds = directRecordIds.length > 0 ? directRecordIds : activeRecordIds;
+  for (const [key, entry] of Object.entries(value)) {
+    collectStructuredContextFieldAssertions(entry, assertions, recordIds, key);
+  }
+
+  return assertions;
+}
+
 export function validateInvokeAgentInputAgainstCurrentRunEvidence(
   state: CurrentRunToolState,
   input: unknown,
@@ -373,9 +494,12 @@ export function validateInvokeAgentInputAgainstCurrentRunEvidence(
   );
   if (!text) return { ok: true };
 
-  for (const recordId of getRecordIds(text)) {
+  const recordIds = getRecordIds(text).filter((recordId) =>
+    Object.keys(getEvidenceFieldsForRecord(state, recordId)).length > 0
+  );
+  for (const recordId of recordIds) {
     const evidenceFields = getEvidenceFieldsForRecord(state, recordId);
-    for (const window of getRecordTextWindows(text, recordId)) {
+    for (const window of getRecordTextWindows(text, recordId, recordIds)) {
       for (const assertion of extractAssertedFieldValues(window)) {
         const expected = getExpectedEvidenceField(evidenceFields, assertion.field);
         if (!expected || !valuesConflict(assertion.value, expected.value)) continue;
@@ -388,6 +512,20 @@ export function validateInvokeAgentInputAgainstCurrentRunEvidence(
         };
       }
     }
+  }
+
+  for (const assertion of collectStructuredContextFieldAssertions(input.context)) {
+    const evidenceFields = getEvidenceFieldsForRecord(state, assertion.recordId);
+    const expected = getCompatibleEvidenceField(evidenceFields, assertion.field);
+    if (!expected || !valuesConflict(assertion.value, expected.value)) continue;
+
+    return {
+      ok: false,
+      error:
+        `invoke_agent context conflicts with current run evidence: ${assertion.recordId} ${expected.field} is ` +
+        `"${expected.value}", but context.${assertion.field} is "${assertion.value}". ` +
+        "Regenerate the tool call from recorded evidence, or delegate only the record id.",
+    };
   }
 
   return { ok: true };
@@ -711,6 +849,37 @@ function isToolResultLikePart(part: unknown): part is Record<string, unknown> {
   return getToolCallIdentity(part) !== null && ("result" in part || "output" in part);
 }
 
+function isCurrentRunToolStateRuntimeContextPart(
+  part: unknown,
+): part is CurrentRunToolStateRuntimeContextPart {
+  return isRecord(part) && part.type === "runtime-context" &&
+    part.name === "current-run-tool-state" && isRecord(part.state);
+}
+
+function mergeCurrentRunToolState(target: CurrentRunToolState, source: CurrentRunToolState): void {
+  for (const [toolName, bucket] of Object.entries(source)) {
+    const targetBucket = target[toolName] ?? { calls: {} };
+    for (const [fingerprint, call] of Object.entries(bucket.calls ?? {})) {
+      const existing = targetBucket.calls[fingerprint];
+      targetBucket.calls[fingerprint] = existing
+        ? {
+          ...call,
+          toolCallIds: Array.from(new Set([...existing.toolCallIds, ...call.toolCallIds])),
+        }
+        : call;
+    }
+    target[toolName] = targetBucket;
+  }
+}
+
+export function createCurrentRunToolStateRuntimeContextPart(
+  state: CurrentRunToolState,
+): CurrentRunToolStateRuntimeContextPart | null {
+  return hasCurrentRunToolState(state)
+    ? { type: "runtime-context", name: "current-run-tool-state", state }
+    : null;
+}
+
 export function hydrateCurrentRunToolStateFromMessages(
   state: CurrentRunToolState,
   messages: readonly CurrentRunToolStateHydrationMessage[],
@@ -720,6 +889,11 @@ export function hydrateCurrentRunToolStateFromMessages(
 
   for (const message of messages) {
     for (const part of message.parts ?? []) {
+      if (isCurrentRunToolStateRuntimeContextPart(part)) {
+        mergeCurrentRunToolState(state, part.state);
+        continue;
+      }
+
       if (isToolCallPart(part)) {
         const identity = getToolCallIdentity(part);
         if (!identity) continue;

--- a/src/agent/runtime/message-adapter.test.ts
+++ b/src/agent/runtime/message-adapter.test.ts
@@ -467,4 +467,21 @@ describe("agent runtime message adapter", () => {
 
     assertEquals(providerMessages, []);
   });
+
+  it("omits internal runtime context parts from provider messages", () => {
+    assertEquals(
+      convertAgentRuntimeMessagesToProviderMessages([{
+        role: "system",
+        parts: [
+          { type: "text", text: "Previous context summary." },
+          {
+            type: "runtime-context",
+            name: "current-run-tool-state",
+            state: { invoke_agent: { calls: {} } },
+          },
+        ],
+      }]),
+      [{ role: "system", content: "Previous context summary." }],
+    );
+  });
 });

--- a/src/agent/runtime/message-adapter.ts
+++ b/src/agent/runtime/message-adapter.ts
@@ -60,6 +60,7 @@ type AgentRuntimeMessageLikePart =
     result?: unknown;
     output?: unknown;
   }
+  | { type: "runtime-context"; name: string; state: Record<string, unknown> }
   | { type: "image"; url: string; mediaType: string }
   | { type: "file"; url: string; mediaType: string };
 
@@ -79,6 +80,7 @@ export type AgentRuntimeMessagePart =
     toolName: string;
     result: unknown;
   }
+  | { type: "runtime-context"; name: string; state: Record<string, unknown> }
   | { type: "image"; url: string; mediaType: string }
   | { type: "file"; url: string; mediaType: string };
 

--- a/src/agent/schemas/agent.schema.test.ts
+++ b/src/agent/schemas/agent.schema.test.ts
@@ -183,6 +183,15 @@ describe("agent/schema", () => {
       assertEquals(result.success, true);
     });
 
+    it("should accept internal runtime context part", () => {
+      const result = getMessagePartSchema().safeParse({
+        type: "runtime-context",
+        name: "current-run-tool-state",
+        state: { invoke_agent: { calls: {} } },
+      });
+      assertEquals(result.success, true);
+    });
+
     it("should reject invalid part type", () => {
       const result = getMessagePartSchema().safeParse({
         type: "unknown",

--- a/src/agent/schemas/agent.schema.ts
+++ b/src/agent/schemas/agent.schema.ts
@@ -101,6 +101,11 @@ export const getMessagePartSchema = defineSchema((v) =>
     inlineToolCallPartShape(v),
     getToolResultPartSchema(),
     v.object({
+      type: v.literal("runtime-context"),
+      name: v.string(),
+      state: v.record(v.string(), v.unknown()),
+    }),
+    v.object({
       type: v.literal("image"),
       url: v.string(),
       mediaType: v.string(),


### PR DESCRIPTION
## Summary

- preserve current-run tool evidence inside an internal runtime-context part when hosted context compaction summarizes older messages
- hydrate that internal state during replay while omitting it from provider-visible model messages
- validate structured invoke_agent context fields against evidence for the same record using generic normalized field matching and numeric normalization
- keep row-table evidence grouped by the primary record id so secondary ids remain field values, not separate records

## Local repro

I also ran a temporary live repro script outside the repo in /tmp against the Veryfront AI gateway. It faked the prior tool trajectory, compacted the replay, then asked a live gateway model to produce the next invoke_agent handoff. The provider-visible replay did not include the correct supplier or PO after compaction; the live model emitted unsupported placeholder/not-provided context fields, and the new runtime guard blocked the handoff from the compacted hidden run evidence.

This supports the root-cause hypothesis: after compaction/replay, the model does not necessarily have the exact structured evidence in provider-visible context. The fix does not assume invoice/SAP specifics; it preserves generic current-run evidence and validates handoff facts by record id.

## Verification

- VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options src/agent/schemas/agent.schema.test.ts src/agent/hosted/context-budget-manager.test.ts src/agent/runtime/current-run-tool-state.test.ts src/agent/runtime/message-adapter.test.ts src/agent/runtime/refresh.test.ts
- deno check src/agent/schemas/agent.schema.ts src/agent/schemas/agent.schema.test.ts src/agent/hosted/context-budget-manager.ts src/agent/hosted/context-budget-manager.test.ts src/agent/runtime/current-run-tool-state.ts src/agent/runtime/current-run-tool-state.test.ts src/agent/runtime/message-adapter.ts src/agent/runtime/message-adapter.test.ts src/agent/hosted/chat-runtime-agent-adapter.ts
- deno fmt --check src/agent/schemas/agent.schema.ts src/agent/schemas/agent.schema.test.ts src/agent/hosted/context-budget-manager.ts src/agent/hosted/context-budget-manager.test.ts src/agent/runtime/current-run-tool-state.ts src/agent/runtime/current-run-tool-state.test.ts src/agent/runtime/message-adapter.ts src/agent/runtime/message-adapter.test.ts
- git diff --check
- pre-push hook: formatting, lint, typecheck, unit tests: 2013 passed, 0 failed
