### PR TITLE
Separate fork runtime step state recovery

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.703",
+  "version": "0.1.704",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/agent/streaming/fork-runtime-step-state.test.ts
+++ b/src/agent/streaming/fork-runtime-step-state.test.ts
@@ -1,0 +1,58 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
+import type { Message as AgentMessage } from "../schemas/index.ts";
+import {
+  applyPartToStreamedStepState,
+  createStreamedStepState,
+  resolveForkStepResponse,
+} from "./fork-runtime-step-state.ts";
+
+describe("agent/fork-runtime-step-state", () => {
+  it("builds a fallback agent response from streamed text and tool parts", async () => {
+    const currentMessages: AgentMessage[] = [{
+      id: "user-1",
+      role: "user",
+      timestamp: 1,
+      parts: [{ type: "text", text: "Create the plan." }],
+    }];
+    const state = createStreamedStepState();
+
+    applyPartToStreamedStepState(state, { type: "text-delta", text: "Created." });
+    applyPartToStreamedStepState(state, {
+      type: "tool-call",
+      toolCallId: "tool-1",
+      toolName: "create_file",
+      input: { path: "plan.md" },
+    });
+    applyPartToStreamedStepState(state, {
+      type: "tool-result",
+      toolCallId: "tool-1",
+      toolName: "create_file",
+      input: { path: "plan.md" },
+      output: { path: "plan.md", ok: true },
+    });
+
+    const response = await resolveForkStepResponse({
+      responsePromise: new Promise<never>(() => {}),
+      responseTimeoutMs: 1,
+      currentMessages,
+      streamedStepState: state,
+    });
+
+    assertEquals(response.text, "Created.");
+    assertEquals(response.status, "completed");
+    assertEquals(response.toolCalls, [{
+      id: "tool-1",
+      name: "create_file",
+      args: { path: "plan.md" },
+      status: "completed",
+      result: { path: "plan.md", ok: true },
+    }]);
+    assertEquals(response.messages.map((message) => message.role), [
+      "user",
+      "assistant",
+      "tool",
+    ]);
+  });
+});

--- a/src/agent/streaming/fork-runtime-step-state.ts
+++ b/src/agent/streaming/fork-runtime-step-state.ts
@@ -1,0 +1,320 @@
+import { isRecord } from "#veryfront/chat/conversation.ts";
+import type { AgentResponse, Message as AgentMessage } from "../schemas/index.ts";
+import {
+  HOSTED_CHILD_STREAM_TIMEOUT_TOKEN,
+  resolveHostedChildPromiseWithTimeout,
+} from "../hosted/child-stream-watchdog.ts";
+import { mergeToolInputDelta, parseToolInputObject } from "./data-stream.ts";
+import { getParsedStreamedToolInput } from "./fork-runtime-part-mapper.ts";
+import type { ForkPart } from "./fork-runtime-stream.ts";
+
+type StreamedToolCallState = {
+  toolCallId: string;
+  toolName: string;
+  inputText: string;
+  input: unknown;
+  status: "pending" | "completed" | "error";
+  output?: unknown;
+  errorText?: string;
+};
+
+type StreamedMessage = {
+  role: "assistant" | "tool";
+  parts: AgentMessage["parts"];
+};
+
+export type StreamedStepState = {
+  text: string;
+  toolCalls: Map<string, StreamedToolCallState>;
+  messages: StreamedMessage[];
+  streamError?: Error;
+};
+
+export function createAgentRuntimeForkAbortError(abortSignal?: AbortSignal): Error {
+  if (abortSignal?.reason instanceof Error) {
+    return abortSignal.reason;
+  }
+
+  return new DOMException("Agent runtime fork aborted before completion.", "AbortError");
+}
+
+/** State for create streamed step. */
+export function createStreamedStepState(): StreamedStepState {
+  return {
+    text: "",
+    toolCalls: new Map(),
+    messages: [],
+  };
+}
+
+function appendStreamedMessagePart(
+  state: StreamedStepState,
+  role: "assistant" | "tool",
+  part: AgentMessage["parts"][number],
+): void {
+  const lastMessage = state.messages.at(-1);
+  if (lastMessage?.role === role) {
+    lastMessage.parts.push(part);
+    return;
+  }
+
+  state.messages.push({
+    role,
+    parts: [part],
+  });
+}
+
+function isFrameworkTextPart(
+  part: AgentMessage["parts"][number],
+): part is Extract<AgentMessage["parts"][number], { type: "text" }> {
+  return part.type === "text";
+}
+
+/** State for apply part to streamed step. */
+export function applyPartToStreamedStepState(state: StreamedStepState, part: ForkPart) {
+  switch (part.type) {
+    case "tool-input-start": {
+      const existing = state.toolCalls.get(part.toolCallId);
+      state.toolCalls.set(part.toolCallId, {
+        toolCallId: part.toolCallId,
+        toolName: part.toolName,
+        inputText: existing?.inputText ?? "",
+        input: existing?.input ?? {},
+        status: existing?.status ?? "pending",
+        ...(existing?.output !== undefined ? { output: existing.output } : {}),
+        ...(existing?.errorText ? { errorText: existing.errorText } : {}),
+      });
+      break;
+    }
+    case "text-delta": {
+      state.text += part.text;
+      const lastAssistantMessage = state.messages.at(-1);
+      const lastAssistantPart = lastAssistantMessage?.role === "assistant"
+        ? lastAssistantMessage.parts.at(-1)
+        : null;
+      if (lastAssistantMessage && lastAssistantPart && isFrameworkTextPart(lastAssistantPart)) {
+        lastAssistantPart.text += part.text;
+      } else {
+        appendStreamedMessagePart(state, "assistant", {
+          type: "text",
+          text: part.text,
+        });
+      }
+      break;
+    }
+    case "tool-input-delta": {
+      const existing = state.toolCalls.get(part.toolCallId);
+      if (!existing) {
+        break;
+      }
+
+      existing.inputText = mergeToolInputDelta(existing.inputText, part.delta);
+      const parsedInput = getParsedStreamedToolInput(existing.inputText);
+      if (parsedInput) {
+        existing.input = parsedInput;
+      }
+      break;
+    }
+    case "tool-call": {
+      const existing = state.toolCalls.get(part.toolCallId);
+      state.toolCalls.set(part.toolCallId, {
+        toolCallId: part.toolCallId,
+        toolName: part.toolName,
+        input: part.input,
+        inputText: existing?.inputText ?? "",
+        status: "pending",
+        ...(existing?.output !== undefined ? { output: existing.output } : {}),
+        ...(existing?.errorText ? { errorText: existing.errorText } : {}),
+      });
+      appendStreamedMessagePart(state, "assistant", {
+        type: `tool-${part.toolName}`,
+        toolCallId: part.toolCallId,
+        toolName: part.toolName,
+        args: parseToolInputObject(part.input),
+      });
+      break;
+    }
+    case "tool-result": {
+      const existing = state.toolCalls.get(part.toolCallId);
+      state.toolCalls.set(part.toolCallId, {
+        toolCallId: part.toolCallId,
+        toolName: part.toolName,
+        input: part.input,
+        inputText: existing?.inputText ?? "",
+        status: "completed",
+        output: part.output,
+        ...(existing?.errorText ? { errorText: existing.errorText } : {}),
+      });
+      appendStreamedMessagePart(state, "tool", {
+        type: "tool-result",
+        toolCallId: part.toolCallId,
+        toolName: part.toolName,
+        result: part.output,
+      });
+      break;
+    }
+    case "tool-error": {
+      const existing = state.toolCalls.get(part.toolCallId);
+      state.toolCalls.set(part.toolCallId, {
+        toolCallId: part.toolCallId,
+        toolName: part.toolName,
+        input: part.input,
+        inputText: existing?.inputText ?? "",
+        status: "error",
+        ...(existing?.output !== undefined ? { output: existing.output } : {}),
+        errorText: part.error.message,
+      });
+      break;
+    }
+    case "error": {
+      state.streamError = part.error;
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+function buildFallbackAgentRuntimeMessages(
+  baseMessages: readonly AgentMessage[],
+  state: StreamedStepState,
+): AgentMessage[] {
+  const messages: AgentMessage[] = baseMessages.map((message) => ({
+    ...message,
+    parts: [...message.parts],
+  }));
+
+  if (state.messages.length > 0) {
+    messages.push(
+      ...state.messages.map((message) => ({
+        id: crypto.randomUUID(),
+        role: message.role,
+        timestamp: Date.now(),
+        parts: structuredClone(message.parts),
+      })),
+    );
+  } else if (state.text.trim().length > 0) {
+    messages.push({
+      id: crypto.randomUUID(),
+      role: "assistant",
+      timestamp: Date.now(),
+      parts: [{ type: "text", text: state.text }],
+    });
+  }
+
+  return messages;
+}
+
+function collectToolResultPaths(messages: readonly AgentMessage[]): string[] {
+  const paths = new Set<string>();
+
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (part.type !== "tool-result") {
+        continue;
+      }
+
+      const partResult = "result" in part ? part.result : null;
+      const result = isRecord(partResult) ? partResult : null;
+      const path = typeof result?.path === "string" ? result.path : null;
+      if (path) {
+        paths.add(path);
+      }
+    }
+  }
+
+  return [...paths];
+}
+
+function buildRecoverablePriorWorkState(
+  messages: readonly AgentMessage[],
+): StreamedStepState | null {
+  const paths = collectToolResultPaths(messages);
+  if (paths.length === 0) {
+    return null;
+  }
+
+  const previewPaths = paths.slice(0, 8);
+  const suffix = paths.length > previewPaths.length
+    ? ` and ${paths.length - previewPaths.length} more`
+    : "";
+  const text = `Completed child tool work. Project artifact(s): ${
+    previewPaths.join(", ")
+  }${suffix}.`;
+
+  return {
+    text,
+    toolCalls: new Map(),
+    messages: [
+      {
+        role: "assistant",
+        parts: [{ type: "text", text }],
+      },
+    ],
+  };
+}
+
+function hasFallbackStepContent(state: StreamedStepState): boolean {
+  return state.text.trim().length > 0 || state.toolCalls.size > 0;
+}
+
+function buildFallbackAgentResponse(input: {
+  baseMessages: readonly AgentMessage[];
+  state: StreamedStepState;
+}): AgentResponse {
+  return {
+    text: input.state.text,
+    messages: buildFallbackAgentRuntimeMessages(input.baseMessages, input.state),
+    toolCalls: [...input.state.toolCalls.values()].map((toolCall) => ({
+      id: toolCall.toolCallId,
+      name: toolCall.toolName,
+      args: parseToolInputObject(toolCall.input),
+      status: toolCall.status,
+      ...(toolCall.status === "completed" ? { result: toolCall.output } : {}),
+      ...(toolCall.status === "error" && toolCall.errorText ? { error: toolCall.errorText } : {}),
+    })),
+    metadata: {},
+    status: "completed",
+  } satisfies AgentResponse;
+}
+
+/** Response payload for resolve fork step. */
+export async function resolveForkStepResponse(input: {
+  responsePromise: Promise<AgentResponse>;
+  responseTimeoutMs: number;
+  abortSignal?: AbortSignal;
+  currentMessages: readonly AgentMessage[];
+  streamedStepState: StreamedStepState;
+}): Promise<AgentResponse> {
+  const resolvedResponse = await resolveHostedChildPromiseWithTimeout(
+    input.responsePromise,
+    input.responseTimeoutMs,
+  );
+
+  if (resolvedResponse !== HOSTED_CHILD_STREAM_TIMEOUT_TOKEN) {
+    return resolvedResponse;
+  }
+
+  if (input.abortSignal?.aborted) {
+    throw createAgentRuntimeForkAbortError(input.abortSignal);
+  }
+
+  if (input.streamedStepState.streamError) {
+    throw input.streamedStepState.streamError;
+  }
+
+  const fallbackState = hasFallbackStepContent(input.streamedStepState)
+    ? input.streamedStepState
+    : buildRecoverablePriorWorkState(input.currentMessages);
+
+  if (!fallbackState) {
+    throw new Error(
+      "Agent runtime fork stream ended without onFinish and without recoverable output.",
+    );
+  }
+
+  return buildFallbackAgentResponse({
+    baseMessages: input.currentMessages,
+    state: fallbackState,
+  });
+}

--- a/src/agent/streaming/fork-runtime-stream.ts
+++ b/src/agent/streaming/fork-runtime-stream.ts
@@ -6,23 +6,19 @@ import {
   traceHostTools,
   type TraceHostToolsOptions,
 } from "#veryfront/tool";
-import { isRecord } from "#veryfront/chat/conversation.ts";
 import { runWithVeryfrontCloudContextAsync } from "#veryfront/provider/veryfront-cloud/context.ts";
-import {
-  mergeToolInputDelta,
-  parseToolInputObject,
-  streamDataStreamEvents,
-} from "./data-stream.ts";
+import { streamDataStreamEvents } from "./data-stream.ts";
 import {
   buildRecoveredStepParts,
   createForkRuntimeStreamMappingState,
-  getParsedStreamedToolInput,
   mapAgUiRuntimeEventToForkParts,
 } from "./fork-runtime-part-mapper.ts";
 import {
-  HOSTED_CHILD_STREAM_TIMEOUT_TOKEN,
-  resolveHostedChildPromiseWithTimeout,
-} from "../hosted/child-stream-watchdog.ts";
+  applyPartToStreamedStepState,
+  createAgentRuntimeForkAbortError,
+  createStreamedStepState,
+  resolveForkStepResponse,
+} from "./fork-runtime-step-state.ts";
 import {
   getForkRuntimeAllowedToolNames,
   getProviderNativeToolNames,
@@ -37,12 +33,18 @@ export {
   mapAgUiRuntimeEventToForkParts,
   mapFrameworkEventToForkParts,
 } from "./fork-runtime-part-mapper.ts";
+export {
+  applyPartToStreamedStepState,
+  createStreamedStepState,
+  resolveForkStepResponse,
+} from "./fork-runtime-step-state.ts";
 export type {
   ForkRecoveredPartsState,
   ForkRuntimeStreamMappingState,
   FrameworkStreamState,
   RecoveredToolObservation,
 } from "./fork-runtime-part-mapper.ts";
+export type { StreamedStepState } from "./fork-runtime-step-state.ts";
 
 interface ForkStreamPart {
   type: "reasoning-delta" | "text-delta";
@@ -106,28 +108,6 @@ export interface ForkRuntimeStep {
   }>;
   finishReason: string | null;
 }
-
-type StreamedToolCallState = {
-  toolCallId: string;
-  toolName: string;
-  inputText: string;
-  input: unknown;
-  status: "pending" | "completed" | "error";
-  output?: unknown;
-  errorText?: string;
-};
-
-type StreamedMessage = {
-  role: "assistant" | "tool";
-  parts: AgentMessage["parts"];
-};
-
-type StreamedStepState = {
-  text: string;
-  toolCalls: Map<string, StreamedToolCallState>;
-  messages: StreamedMessage[];
-  streamError?: Error;
-};
 
 /** Public API contract for fork part. */
 export type ForkPart =
@@ -316,14 +296,6 @@ async function prepareForkRuntimeStep(input: {
     messages: input.messages,
     system: input.buildInstructions(),
   };
-}
-
-function createAgentRuntimeForkAbortError(abortSignal?: AbortSignal): Error {
-  if (abortSignal?.reason instanceof Error) {
-    return abortSignal.reason;
-  }
-
-  return new DOMException("Agent runtime fork aborted before completion.", "AbortError");
 }
 
 /** Input payload for run agent runtime fork step. */
@@ -653,285 +625,4 @@ export function startAgentRuntimeFork(input: StartAgentRuntimeForkInput): ForkRu
     steps: stepsDeferred.promise,
     totalUsage: totalUsageDeferred.promise,
   };
-}
-
-/** State for create streamed step. */
-export function createStreamedStepState(): StreamedStepState {
-  return {
-    text: "",
-    toolCalls: new Map(),
-    messages: [],
-  };
-}
-
-function appendStreamedMessagePart(
-  state: StreamedStepState,
-  role: "assistant" | "tool",
-  part: AgentMessage["parts"][number],
-): void {
-  const lastMessage = state.messages.at(-1);
-  if (lastMessage?.role === role) {
-    lastMessage.parts.push(part);
-    return;
-  }
-
-  state.messages.push({
-    role,
-    parts: [part],
-  });
-}
-
-function isFrameworkTextPart(
-  part: AgentMessage["parts"][number],
-): part is Extract<AgentMessage["parts"][number], { type: "text" }> {
-  return part.type === "text";
-}
-
-/** State for apply part to streamed step. */
-export function applyPartToStreamedStepState(state: StreamedStepState, part: ForkPart) {
-  switch (part.type) {
-    case "tool-input-start": {
-      const existing = state.toolCalls.get(part.toolCallId);
-      state.toolCalls.set(part.toolCallId, {
-        toolCallId: part.toolCallId,
-        toolName: part.toolName,
-        inputText: existing?.inputText ?? "",
-        input: existing?.input ?? {},
-        status: existing?.status ?? "pending",
-        ...(existing?.output !== undefined ? { output: existing.output } : {}),
-        ...(existing?.errorText ? { errorText: existing.errorText } : {}),
-      });
-      break;
-    }
-    case "text-delta": {
-      state.text += part.text;
-      const lastAssistantMessage = state.messages.at(-1);
-      const lastAssistantPart = lastAssistantMessage?.role === "assistant"
-        ? lastAssistantMessage.parts.at(-1)
-        : null;
-      if (lastAssistantMessage && lastAssistantPart && isFrameworkTextPart(lastAssistantPart)) {
-        lastAssistantPart.text += part.text;
-      } else {
-        appendStreamedMessagePart(state, "assistant", {
-          type: "text",
-          text: part.text,
-        });
-      }
-      break;
-    }
-    case "tool-input-delta": {
-      const existing = state.toolCalls.get(part.toolCallId);
-      if (!existing) {
-        break;
-      }
-
-      existing.inputText = mergeToolInputDelta(existing.inputText, part.delta);
-      const parsedInput = getParsedStreamedToolInput(existing.inputText);
-      if (parsedInput) {
-        existing.input = parsedInput;
-      }
-      break;
-    }
-    case "tool-call": {
-      const existing = state.toolCalls.get(part.toolCallId);
-      state.toolCalls.set(part.toolCallId, {
-        toolCallId: part.toolCallId,
-        toolName: part.toolName,
-        input: part.input,
-        inputText: existing?.inputText ?? "",
-        status: "pending",
-        ...(existing?.output !== undefined ? { output: existing.output } : {}),
-        ...(existing?.errorText ? { errorText: existing.errorText } : {}),
-      });
-      appendStreamedMessagePart(state, "assistant", {
-        type: `tool-${part.toolName}`,
-        toolCallId: part.toolCallId,
-        toolName: part.toolName,
-        args: parseToolInputObject(part.input),
-      });
-      break;
-    }
-    case "tool-result": {
-      const existing = state.toolCalls.get(part.toolCallId);
-      state.toolCalls.set(part.toolCallId, {
-        toolCallId: part.toolCallId,
-        toolName: part.toolName,
-        input: part.input,
-        inputText: existing?.inputText ?? "",
-        status: "completed",
-        output: part.output,
-        ...(existing?.errorText ? { errorText: existing.errorText } : {}),
-      });
-      appendStreamedMessagePart(state, "tool", {
-        type: "tool-result",
-        toolCallId: part.toolCallId,
-        toolName: part.toolName,
-        result: part.output,
-      });
-      break;
-    }
-    case "tool-error": {
-      const existing = state.toolCalls.get(part.toolCallId);
-      state.toolCalls.set(part.toolCallId, {
-        toolCallId: part.toolCallId,
-        toolName: part.toolName,
-        input: part.input,
-        inputText: existing?.inputText ?? "",
-        status: "error",
-        ...(existing?.output !== undefined ? { output: existing.output } : {}),
-        errorText: part.error.message,
-      });
-      break;
-    }
-    case "error": {
-      state.streamError = part.error;
-      break;
-    }
-    default:
-      break;
-  }
-}
-
-function buildFallbackAgentRuntimeMessages(
-  baseMessages: readonly AgentMessage[],
-  state: StreamedStepState,
-): AgentMessage[] {
-  const messages: AgentMessage[] = baseMessages.map((message) => ({
-    ...message,
-    parts: [...message.parts],
-  }));
-
-  if (state.messages.length > 0) {
-    messages.push(
-      ...state.messages.map((message) => ({
-        id: crypto.randomUUID(),
-        role: message.role,
-        timestamp: Date.now(),
-        parts: structuredClone(message.parts),
-      })),
-    );
-  } else if (state.text.trim().length > 0) {
-    messages.push({
-      id: crypto.randomUUID(),
-      role: "assistant",
-      timestamp: Date.now(),
-      parts: [{ type: "text", text: state.text }],
-    });
-  }
-
-  return messages;
-}
-
-function collectToolResultPaths(messages: readonly AgentMessage[]): string[] {
-  const paths = new Set<string>();
-
-  for (const message of messages) {
-    for (const part of message.parts) {
-      if (part.type !== "tool-result") {
-        continue;
-      }
-
-      const partResult = "result" in part ? part.result : null;
-      const result = isRecord(partResult) ? partResult : null;
-      const path = typeof result?.path === "string" ? result.path : null;
-      if (path) {
-        paths.add(path);
-      }
-    }
-  }
-
-  return [...paths];
-}
-
-function buildRecoverablePriorWorkState(
-  messages: readonly AgentMessage[],
-): StreamedStepState | null {
-  const paths = collectToolResultPaths(messages);
-  if (paths.length === 0) {
-    return null;
-  }
-
-  const previewPaths = paths.slice(0, 8);
-  const suffix = paths.length > previewPaths.length
-    ? ` and ${paths.length - previewPaths.length} more`
-    : "";
-  const text = `Completed child tool work. Project artifact(s): ${
-    previewPaths.join(", ")
-  }${suffix}.`;
-
-  return {
-    text,
-    toolCalls: new Map(),
-    messages: [
-      {
-        role: "assistant",
-        parts: [{ type: "text", text }],
-      },
-    ],
-  };
-}
-
-function hasFallbackStepContent(state: StreamedStepState): boolean {
-  return state.text.trim().length > 0 || state.toolCalls.size > 0;
-}
-
-function buildFallbackAgentResponse(input: {
-  baseMessages: readonly AgentMessage[];
-  state: StreamedStepState;
-}): AgentResponse {
-  return {
-    text: input.state.text,
-    messages: buildFallbackAgentRuntimeMessages(input.baseMessages, input.state),
-    toolCalls: [...input.state.toolCalls.values()].map((toolCall) => ({
-      id: toolCall.toolCallId,
-      name: toolCall.toolName,
-      args: parseToolInputObject(toolCall.input),
-      status: toolCall.status,
-      ...(toolCall.status === "completed" ? { result: toolCall.output } : {}),
-      ...(toolCall.status === "error" && toolCall.errorText ? { error: toolCall.errorText } : {}),
-    })),
-    metadata: {},
-    status: "completed",
-  } satisfies AgentResponse;
-}
-
-/** Response payload for resolve fork step. */
-export async function resolveForkStepResponse(input: {
-  responsePromise: Promise<AgentResponse>;
-  responseTimeoutMs: number;
-  abortSignal?: AbortSignal;
-  currentMessages: readonly AgentMessage[];
-  streamedStepState: StreamedStepState;
-}): Promise<AgentResponse> {
-  const resolvedResponse = await resolveHostedChildPromiseWithTimeout(
-    input.responsePromise,
-    input.responseTimeoutMs,
-  );
-
-  if (resolvedResponse !== HOSTED_CHILD_STREAM_TIMEOUT_TOKEN) {
-    return resolvedResponse;
-  }
-
-  if (input.abortSignal?.aborted) {
-    throw createAgentRuntimeForkAbortError(input.abortSignal);
-  }
-
-  if (input.streamedStepState.streamError) {
-    throw input.streamedStepState.streamError;
-  }
-
-  const fallbackState = hasFallbackStepContent(input.streamedStepState)
-    ? input.streamedStepState
-    : buildRecoverablePriorWorkState(input.currentMessages);
-
-  if (!fallbackState) {
-    throw new Error(
-      "Agent runtime fork stream ended without onFinish and without recoverable output.",
-    );
-  }
-
-  return buildFallbackAgentResponse({
-    baseMessages: input.currentMessages,
-    state: fallbackState,
-  });
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.703";
+export const VERSION = "0.1.704";


### PR DESCRIPTION
## Summary
- Extract streamed fork step-state mutation and fallback response recovery into `src/agent/streaming/fork-runtime-step-state.ts`.
- Preserve existing public imports by re-exporting `createStreamedStepState`, `applyPartToStreamedStepState`, and `resolveForkStepResponse` from `fork-runtime-stream.ts`.
- Add focused step-state coverage for streamed text/tool fallback response recovery.
- Bump release metadata from `0.1.703` to `0.1.704`.

## Verification
- Red: `deno test --no-check --allow-all src/agent/streaming/fork-runtime-step-state.test.ts` failed on missing `fork-runtime-step-state.ts` before implementation.
- `deno test --no-check --allow-all src/agent/streaming/fork-runtime-step-state.test.ts src/agent/streaming/fork-runtime-stream.test.ts src/agent/streaming/fork-runtime-part-mapper.test.ts`
- `deno check src/agent/streaming/fork-runtime-step-state.ts src/agent/streaming/fork-runtime-step-state.test.ts src/agent/streaming/fork-runtime-stream.ts src/agent/streaming/fork-runtime-stream.test.ts src/agent/streaming/fork-runtime-part-mapper.ts src/agent/streaming/fork-runtime-part-mapper.test.ts src/utils/version-constant.ts`
- `git diff --check`
- `deno task verify:quick`
- Pre-push hook: format, lint, typecheck, unit tests (`2015 passed, 0 failed`)

Related: #1983, #1990