### PR TITLE
Centralize cache batch result assembly

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.704",
+  "version": "0.1.705",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/cache/backends/api.ts
+++ b/src/cache/backends/api.ts
@@ -5,7 +5,7 @@ import { tryGetCacheKeyContext } from "../cache-key-builder.ts";
 import { CircuitBreakerOpen, getCircuitBreaker } from "#veryfront/utils/circuit-breaker.ts";
 import type { CacheBackend } from "../types.ts";
 import { getEnvValue } from "./helpers.ts";
-import { buildBatchResults } from "./batch-results.ts";
+import { buildBatchResults } from "../batch-results.ts";
 import { REQUEST_ERROR } from "#veryfront/errors";
 
 const logger = baseLogger.component("api-cache-backend");

--- a/src/cache/backends/batch-results.ts
+++ b/src/cache/backends/batch-results.ts
@@ -1,30 +1,7 @@
 /**
- * Shared batch-result assembly for cache backends.
- *
- * Several backends implement `getBatch` by iterating the requested keys and
- * building a `Map<string, string | null>` where each key resolves to its value
- * (or `null` when missing/expired/unavailable). This helper centralizes that
- * assembly so the per-backend code only supplies the resolver.
+ * Compatibility re-export for cache backend batch-result assembly.
  *
  * @module cache/backends/batch-results
  */
 
-/**
- * Build a `Map` of batch results by resolving each key in order.
- *
- * The map preserves the requested keys' insertion order. `resolve` is invoked
- * once per key and must return the resolved value or `null`.
- *
- * @param keys Requested cache keys.
- * @param resolve Resolver mapping a key to its value (or `null`).
- */
-export function buildBatchResults(
-  keys: string[],
-  resolve: (key: string) => string | null,
-): Map<string, string | null> {
-  const results = new Map<string, string | null>();
-  for (const key of keys) {
-    results.set(key, resolve(key));
-  }
-  return results;
-}
+export { buildBatchResults } from "../batch-results.ts";

--- a/src/cache/backends/memory.ts
+++ b/src/cache/backends/memory.ts
@@ -3,7 +3,7 @@ import {
   MEMORY_CACHE_MAX_SIZE_BYTES,
 } from "#veryfront/utils/constants/cache.ts";
 import type { CacheBackend } from "../types.ts";
-import { buildBatchResults } from "./batch-results.ts";
+import { buildBatchResults } from "../batch-results.ts";
 
 const DEFAULT_TTL_SECONDS = 300;
 const MAX_REGEX_CACHE_SIZE = 100;

--- a/src/cache/backends/redis.ts
+++ b/src/cache/backends/redis.ts
@@ -8,7 +8,7 @@ import {
   type RedisClient,
 } from "#veryfront/utils/redis-client.ts";
 import type { CacheBackend } from "../types.ts";
-import { buildBatchResults } from "./batch-results.ts";
+import { buildBatchResults } from "../batch-results.ts";
 
 const logger = baseLogger.component("redis-cache-backend");
 

--- a/src/cache/batch-results.ts
+++ b/src/cache/batch-results.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared batch-result assembly for cache reads.
+ *
+ * Cache backends and cache gateways often resolve a requested key list into a
+ * `Map<string, string | null>` where each requested key is present and missing
+ * values resolve to `null`. This helper centralizes that assembly so callers
+ * only supply the resolver.
+ *
+ * @module cache/batch-results
+ */
+
+/**
+ * Build a `Map` of batch results by resolving each key in order.
+ *
+ * The map preserves the requested keys' insertion order. `resolve` is invoked
+ * once per key and must return the resolved value or `null`.
+ *
+ * @param keys Requested cache keys.
+ * @param resolve Resolver mapping a key to its value (or `null`).
+ */
+export function buildBatchResults(
+  keys: string[],
+  resolve: (key: string) => string | null,
+): Map<string, string | null> {
+  const results = new Map<string, string | null>();
+  for (const key of keys) {
+    results.set(key, resolve(key));
+  }
+  return results;
+}

--- a/src/cache/portability.test.ts
+++ b/src/cache/portability.test.ts
@@ -30,6 +30,14 @@ class MockDistributedBackend implements CacheBackend {
     return Promise.resolve(this.store.get(key) ?? null);
   }
 
+  getBatch(keys: string[]): Promise<Map<string, string | null>> {
+    const results = new Map<string, string | null>();
+    for (const key of keys) {
+      results.set(key, this.store.get(key) ?? null);
+    }
+    return Promise.resolve(results);
+  }
+
   set(key: string, value: string, _ttl?: number): Promise<void> {
     this.store.set(key, value);
     return Promise.resolve();
@@ -247,6 +255,21 @@ describe("Cache Portability", () => {
 
       assert(!code?.includes(CACHE_DIR_TOKEN), "Retrieved code should not contain token");
       assert(code?.includes(localCacheDir), "Retrieved code should contain local dir");
+    });
+
+    it("detokenizes batch results and preserves missing keys", async () => {
+      const tokenizedCode =
+        `import x from "file://${CACHE_DIR_TOKEN}/veryfront-http-bundle/http-123.mjs"`;
+      await mockBackend.set("first", tokenizedCode);
+      await mockBackend.set("third", "export const value = 1;");
+
+      const results = await gateway.getCodeBatch?.(["first", "missing", "third"]);
+
+      assertEquals([...results?.keys() ?? []], ["first", "missing", "third"]);
+      assert(!results?.get("first")?.includes(CACHE_DIR_TOKEN));
+      assert(results?.get("first")?.includes(localCacheDir));
+      assertEquals(results?.get("missing"), null);
+      assertEquals(results?.get("third"), "export const value = 1;");
     });
 
     it("provides isDistributed() = true for distributed backends", () => {

--- a/src/cache/request-cache-batcher.test.ts
+++ b/src/cache/request-cache-batcher.test.ts
@@ -254,6 +254,38 @@ describe("cache/request-cache-batcher", () => {
       });
     });
 
+    it("should preserve requested keys when falling back to individual batch gets", async () => {
+      const store = new Map([["a", "val-a"], ["c", "val-c"]]);
+      const getCalls: string[] = [];
+
+      const backend: CacheBackend = {
+        type: "memory",
+        get(key: string) {
+          getCalls.push(key);
+          return Promise.resolve(store.get(key) ?? null);
+        },
+        set() {
+          return Promise.resolve();
+        },
+        del() {
+          return Promise.resolve();
+        },
+      };
+
+      await runWithCacheBatching(async () => {
+        const [a, b, c] = await Promise.all([
+          getCachedWithBatching(backend, "a"),
+          getCachedWithBatching(backend, "b"),
+          getCachedWithBatching(backend, "c"),
+        ]);
+
+        assertEquals(a, "val-a");
+        assertEquals(b, null);
+        assertEquals(c, "val-c");
+        assertEquals(getCalls, ["a", "b", "c"]);
+      });
+    });
+
     it("should handle backend errors by rejecting pending requests", async () => {
       const backend: CacheBackend = {
         type: "memory",

--- a/src/cache/request-cache-batcher.ts
+++ b/src/cache/request-cache-batcher.ts
@@ -3,6 +3,7 @@ import { ensureError } from "#veryfront/errors/veryfront-error.ts";
 import { logger as baseLogger } from "#veryfront/utils";
 import { MAX_BATCH_SIZE } from "#veryfront/utils/constants/limits.ts";
 import type { CacheBackend } from "./backend.ts";
+import { buildBatchResults } from "./batch-results.ts";
 
 const logger = baseLogger.component("request-cache-batcher");
 
@@ -122,13 +123,11 @@ async function getIndividually(
   backend: CacheBackend,
   keys: string[],
 ): Promise<Map<string, string | null>> {
-  const results = new Map<string, string | null>();
+  const entries = new Map<string, string | null>();
   await Promise.all(
-    keys.map(async (key) => {
-      results.set(key, await backend.get(key));
-    }),
+    keys.map(async (key) => entries.set(key, await backend.get(key))),
   );
-  return results;
+  return buildBatchResults(keys, (key) => entries.get(key) ?? null);
 }
 
 export function setInRequestCache(key: string, value: string | null): void {

--- a/src/cache/tokenizing-gateway.ts
+++ b/src/cache/tokenizing-gateway.ts
@@ -15,6 +15,7 @@
 
 import { logger } from "#veryfront/utils";
 import type { CacheBackend } from "./types.ts";
+import { buildBatchResults } from "./batch-results.ts";
 import { assertPortableCode, detokenizeAllCachePaths, tokenizeAllVeryFrontPaths } from "./paths.ts";
 
 /**
@@ -131,35 +132,30 @@ export class TokenizingCacheGateway implements CodeCacheGateway {
    * Get multiple codes from cache with automatic detokenization.
    */
   async getCodeBatch(keys: string[]): Promise<Map<string, string | null>> {
-    const results = new Map<string, string | null>();
-    if (keys.length === 0) return results;
+    if (keys.length === 0) return new Map<string, string | null>();
 
     if (!this.backend.getBatch) {
-      // Fallback to individual gets
-      for (const key of keys) {
-        results.set(key, await this.getCode(key));
-      }
-      return results;
+      const values = new Map<string, string | null>();
+      await Promise.all(
+        keys.map(async (key) => values.set(key, await this.getCode(key))),
+      );
+      return buildBatchResults(keys, (key) => values.get(key) ?? null);
     }
 
     const rawResults = await this.backend.getBatch(keys);
-
-    for (const [key, raw] of rawResults) {
+    return buildBatchResults(keys, (key) => {
+      const raw = rawResults.get(key) ?? null;
       if (!raw) {
-        results.set(key, null);
-        continue;
+        return null;
       }
 
       // Only detokenize for distributed backends
       if (!this.isDistributed()) {
-        results.set(key, raw);
-        continue;
+        return raw;
       }
 
-      results.set(key, detokenizeAllCachePaths(raw));
-    }
-
-    return results;
+      return detokenizeAllCachePaths(raw);
+    });
   }
 
   /**

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.704";
+export const VERSION = "0.1.705";


### PR DESCRIPTION
## Description

Centralizes cache batch result map assembly in `src/cache/batch-results.ts` so cache backends, request-cache batching, and the tokenizing gateway share the same requested-key semantics. The old backend helper path remains as a compatibility re-export.

This also updates the release version from `0.1.704` to `0.1.705`.

## Related Issue(s)

Related to #1987
Related to #1990

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Verification

- `deno test --no-check --allow-all src/cache/request-cache-batcher.test.ts src/cache/portability.test.ts`
- `deno check src/cache/batch-results.ts src/cache/backends/batch-results.ts src/cache/backends/memory.ts src/cache/backends/api.ts src/cache/backends/redis.ts src/cache/request-cache-batcher.ts src/cache/request-cache-batcher.test.ts src/cache/tokenizing-gateway.ts src/cache/portability.test.ts src/utils/version-constant.ts`
- `deno task verify:quick`
- pre-push hook: format, lint, typecheck, unit tests (`2015 passed`, `0 failed`)
