### PR TITLE
Move CSS pregeneration out of the platform adapter

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.705",
+  "version": "0.1.706",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -456,6 +456,9 @@ describe("VeryfrontFSAdapter", () => {
           getProjectId: () => string;
           getCachedProject: () => { provider: string; layout: string };
           listAllFiles: () => Promise<Array<{ path: string; content?: string }>>;
+          listAllEnvironmentFiles: (
+            environmentName: string,
+          ) => Promise<Array<{ path: string; content?: string }>>;
         };
       }).client;
 
@@ -517,6 +520,9 @@ describe("VeryfrontFSAdapter", () => {
           getProjectId: () => string;
           getCachedProject: () => { provider: string; layout: string };
           listAllFiles: () => Promise<Array<{ path: string; content?: string }>>;
+          listAllEnvironmentFiles: (
+            environmentName: string,
+          ) => Promise<Array<{ path: string; content?: string }>>;
         };
       }).client;
 
@@ -553,6 +559,71 @@ describe("VeryfrontFSAdapter", () => {
       await adapter.initialize();
 
       assertEquals(pregenerationCalls, 0);
+    });
+
+    it("uses injected style pregeneration during published initialization", async () => {
+      let pregenerationCalls = 0;
+      const files = [{
+        path: "pages/index.tsx",
+        content: "export default function Page() { return <main /> }",
+      }];
+
+      const adapter = createAdapter({
+        projectDir: "/tmp/test-project",
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          cache: { enabled: true },
+        },
+        styleCallbacks: {
+          pregenerateStyles: async (receivedFiles, context) => {
+            pregenerationCalls++;
+            assertEquals(receivedFiles, files);
+            assertEquals(context.projectSlug, "test-project");
+            assertEquals(context.projectDir, "/tmp/test-project");
+            assertEquals(context.contentContext?.sourceType, "environment");
+            return { hash: "hash-1", assetPath: "/_vf/css/hash-1.css" };
+          },
+        },
+      });
+
+      const client = (adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          listAllFiles: () => Promise<Array<{ path: string; content?: string }>>;
+          listAllEnvironmentFiles: (
+            environmentName: string,
+          ) => Promise<Array<{ path: string; content?: string }>>;
+        };
+      }).client;
+
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+      client.listAllFiles = () => Promise.resolve(files);
+      client.listAllEnvironmentFiles = (environmentName) => {
+        assertEquals(environmentName, "production");
+        return Promise.resolve(files);
+      };
+
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      adapter.setContentContext({
+        sourceType: "environment",
+        projectSlug: "test-project",
+        environmentName: "production",
+        releaseId: "release-123",
+      });
+
+      await adapter.initialize();
+
+      await waitFor(async () => pregenerationCalls === 1);
     });
 
     it("does not pregenerate CSS during branch cache warmup", async () => {

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -8,6 +8,8 @@ import type {
   FSAdapterConfig,
   InvalidationCallbacks,
   ResolvedContentContext,
+  StyleCallbacks,
+  StylePregenerationFile,
 } from "./types.ts";
 import type { FileInfo, ResolveFileOptions } from "../../base.ts";
 import { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
@@ -55,6 +57,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
   private apiToken: string;
   private projectSlug: string;
   private invalidationCallbacks: InvalidationCallbacks;
+  private styleCallbacks: StyleCallbacks;
   private wsManager: WebSocketManager;
 
   /** Per-request branch override (for branch preview URLs) */
@@ -107,6 +110,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
   constructor(config: FSAdapterConfig) {
     this.invalidationCallbacks = config.invalidationCallbacks ?? {};
+    this.styleCallbacks = config.styleCallbacks ?? {};
     const vf = config.veryfront;
     if (!vf) {
       throw toError(
@@ -692,71 +696,29 @@ export class VeryfrontFSAdapter implements FSAdapter {
    * Uses dynamic import to avoid circular dependencies.
    */
   private async triggerCSSPregeneration(
-    files: Array<{ path: string; content?: string }>,
+    files: StylePregenerationFile[],
   ): Promise<{ hash: string; assetPath: string } | undefined> {
-    try {
-      const { buildPreparedCSSArtifactFromFiles, findStylesheetFromFiles } = await import(
-        "../../../../html/styles-builder/css-pregeneration.ts"
-      );
-      const { resolveStyleContentVersion } = await import(
-        "../../../../html/styles-builder/content-version.ts"
-      );
-      const { createStyleScopeProfile } = await import(
-        "../../../../html/styles-builder/style-scope-profile.ts"
-      );
-
-      let stylesheetPath: string | undefined;
-      let styleProfile = createStyleScopeProfile();
-      const projectDir = this.normalizer.getProjectDir();
-
-      if (!projectDir) {
-        logger.debug("Skipping CSS pre-generation without projectDir", {
-          projectSlug: this.projectSlug,
-        });
-        return undefined;
-      }
-
-      try {
-        const { runtime } = await import("#veryfront/platform/adapters/registry.ts");
-        const { getConfig } = await import("#veryfront/config");
-        const adapter = await runtime.get();
-        const cacheKey = this.client.getProjectId() || this.projectSlug;
-        const config = await getConfig(projectDir, adapter, { cacheKey });
-        stylesheetPath = config?.tailwind?.stylesheet;
-        styleProfile = createStyleScopeProfile(config);
-      } catch (error) {
-        logger.debug("Failed to load config for CSS pre-generation", {
-          projectSlug: this.projectSlug,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-
-      const stylesheet = findStylesheetFromFiles(files, stylesheetPath);
-      const projectVersion = resolveStyleContentVersion(this.contentContext, {
-        branch: this.contentContext?.branch ?? null,
-        releaseId: this.contentContext?.releaseId ?? null,
-        environmentName: this.contentContext?.environmentName ?? null,
-      });
-
-      const result = await buildPreparedCSSArtifactFromFiles({
+    const pregenerateStyles = this.styleCallbacks.pregenerateStyles;
+    if (!pregenerateStyles) {
+      logger.debug("Skipping CSS pre-generation without style callback", {
         projectSlug: this.projectSlug,
-        projectVersion,
-        projectDir,
-        files,
-        styleProfile,
-        stylesheet,
-        stylesheetPath,
-        minify: true,
-        environment: "preview",
-        buildMode: "production",
       });
+      return undefined;
+    }
+
+    try {
+      const projectDir = this.normalizer.getProjectDir();
+      const result = await pregenerateStyles(files, {
+        projectSlug: this.projectSlug,
+        projectDir,
+        contentContext: this.contentContext,
+      });
+
+      if (!result) return undefined;
 
       logger.debug("CSS pre-generation complete", {
         projectSlug: this.projectSlug,
-        projectVersion,
         cssHash: result.hash,
-        candidateCount: result.candidateCount,
-        fromCache: result.fromCache,
       });
 
       return {

--- a/src/platform/adapters/fs/veryfront/default-invalidation-callbacks.ts
+++ b/src/platform/adapters/fs/veryfront/default-invalidation-callbacks.ts
@@ -44,23 +44,6 @@ export function createDefaultInvalidationCallbacks(
       }>("#veryfront/rendering/renderer.ts");
       return clearRendererCacheForProject(projectId);
     },
-    clearProjectCSSCache: (projectSlug: string) => {
-      void Promise.all([
-        loadModule<{ invalidateProjectCSS: (projectSlug: string) => void }>(
-          "#veryfront/html/styles-builder/tailwind-compiler.ts",
-        ),
-        loadModule<{ invalidatePreparedProjectCSS: (projectSlug: string) => void }>(
-          "#veryfront/html/styles-builder/prepared-project-css-cache.ts",
-        ),
-        loadModule<{ invalidateProjectCandidateManifests: (projectSlug: string) => void }>(
-          "#veryfront/rendering/orchestrator/css-candidate-manifest.ts",
-        ),
-      ]).then(([tailwind, prepared, manifest]) => {
-        tailwind.invalidateProjectCSS(projectSlug);
-        prepared.invalidatePreparedProjectCSS(projectSlug);
-        manifest.invalidateProjectCandidateManifests(projectSlug);
-      });
-    },
     ...callbacks,
   };
 }

--- a/src/platform/adapters/fs/veryfront/platform-boundary.test.ts
+++ b/src/platform/adapters/fs/veryfront/platform-boundary.test.ts
@@ -1,0 +1,21 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { walk } from "#std/fs/walk";
+
+describe("veryfront platform adapter boundaries", () => {
+  it("does not import html style-builder internals from platform code", async () => {
+    const violations: string[] = [];
+
+    for await (const entry of walk("src/platform", { includeFiles: true, exts: [".ts"] })) {
+      if (!entry.isFile || entry.name.includes(".test.")) continue;
+
+      const source = await Deno.readTextFile(entry.path);
+      if (source.includes("html/styles-builder")) {
+        violations.push(entry.path);
+      }
+    }
+
+    assertEquals(violations, []);
+  });
+});

--- a/src/platform/adapters/fs/veryfront/types.ts
+++ b/src/platform/adapters/fs/veryfront/types.ts
@@ -68,6 +68,29 @@ export interface ResolvedContentContext {
   releaseId?: string;
 }
 
+export interface StylePregenerationFile {
+  path: string;
+  content?: string;
+}
+
+export interface PreviewStyleArtifactInfo {
+  hash: string;
+  assetPath: string;
+}
+
+export interface StylePregenerationContext {
+  projectSlug: string;
+  projectDir?: string;
+  contentContext: ResolvedContentContext | null;
+}
+
+export interface StyleCallbacks {
+  pregenerateStyles?: (
+    files: StylePregenerationFile[],
+    context: StylePregenerationContext,
+  ) => Promise<PreviewStyleArtifactInfo | undefined>;
+}
+
 export interface FSAdapterConfig {
   type?: "local" | "veryfront-api" | "memory" | "github";
   projectDir?: string;
@@ -89,6 +112,7 @@ export interface FSAdapterConfig {
   };
   github?: GitHubConfig;
   invalidationCallbacks?: InvalidationCallbacks;
+  styleCallbacks?: StyleCallbacks;
 }
 
 export interface VeryfrontFSState {

--- a/src/platform/adapters/fs/veryfront/websocket-manager-helpers.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager-helpers.ts
@@ -1,4 +1,4 @@
-import type { ContentSource, ResolvedContentContext } from "./types.ts";
+import type { ContentSource, PreviewStyleArtifactInfo, ResolvedContentContext } from "./types.ts";
 import { buildFileCacheKeyPrefix } from "./cache-keys.ts";
 
 export const INVALIDATION_DEBOUNCE_MS = 100;
@@ -7,11 +7,6 @@ export const WS_RECONNECT_MAX_DELAY_MS = 120000;
 export const WS_RECONNECT_MAX_FAILURES = 10;
 export const WS_HEARTBEAT_INTERVAL_MS = 60000;
 export const WS_HEARTBEAT_TIMEOUT_MS = 300000;
-
-export interface PreviewStyleArtifactInfo {
-  hash: string;
-  assetPath: string;
-}
 
 export function getConnectionLogContext(
   projectSlug: string | undefined,

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -1,7 +1,12 @@
 import { getBaseLogger } from "#veryfront/utils/logger/logger.ts";
 import type { FileCache } from "../cache/file-cache.ts";
 import type { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
-import type { ContentSource, InvalidationCallbacks, ResolvedContentContext } from "./types.ts";
+import type {
+  ContentSource,
+  InvalidationCallbacks,
+  PreviewStyleArtifactInfo,
+  ResolvedContentContext,
+} from "./types.ts";
 import {
   buildDirCacheKeyPrefix,
   buildFileCacheKeyPrefix,
@@ -21,7 +26,6 @@ import {
   getReconnectDelay as getReconnectDelayHelper,
   INVALIDATION_DEBOUNCE_MS,
   parsePokeWebSocketMessage,
-  type PreviewStyleArtifactInfo,
   WS_HEARTBEAT_INTERVAL_MS,
   WS_HEARTBEAT_TIMEOUT_MS,
   WS_RECONNECT_MAX_DELAY_MS,

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -1,6 +1,9 @@
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
-import type { InvalidationProjectContext } from "#veryfront/platform/adapters/fs/veryfront/types.ts";
+import type {
+  FSAdapterConfig,
+  InvalidationProjectContext,
+} from "#veryfront/platform/adapters/fs/veryfront/types.ts";
 import { clearConfigCache, getConfig } from "#veryfront/config";
 import { type ExtensionLoader, orchestrateExtensions, tryResolve } from "veryfront/extensions";
 import {
@@ -45,6 +48,10 @@ import {
   type FileLogSubscriber,
 } from "#veryfront/observability/file-log-subscriber.ts";
 import { ReloadNotifier } from "./reload-notifier.ts";
+import {
+  createServerStyleCallbacks,
+  createServerStyleInvalidationCallbacks,
+} from "./style-callbacks.ts";
 import { clearDomainCache } from "./utils/domain-lookup.ts";
 
 const bootstrapLog = logger.component("bootstrap");
@@ -305,12 +312,19 @@ export async function bootstrap(
 
     // Inject server-layer callbacks into FS config so the platform layer
     // doesn't need to import from the server layer
+    const configuredFs = config.fs as Partial<FSAdapterConfig> | undefined;
     const fsWithCallbacks = {
       ...config.fs,
       invalidationCallbacks: {
+        ...createServerStyleInvalidationCallbacks(),
+        ...configuredFs?.invalidationCallbacks,
         triggerReload: (changedPaths?: string[], project?: InvalidationProjectContext) =>
           ReloadNotifier.triggerReload(changedPaths, project),
         clearDomainCache,
+      },
+      styleCallbacks: {
+        ...createServerStyleCallbacks(),
+        ...configuredFs?.styleCallbacks,
       },
     };
 

--- a/src/server/style-callbacks.ts
+++ b/src/server/style-callbacks.ts
@@ -1,0 +1,101 @@
+import { getConfig } from "#veryfront/config";
+import {
+  invalidateProjectCandidateManifests,
+} from "#veryfront/rendering/orchestrator/css-candidate-manifest.ts";
+import { runtime } from "#veryfront/platform/adapters/registry.ts";
+import type {
+  InvalidationCallbacks,
+  StyleCallbacks,
+  StylePregenerationContext,
+  StylePregenerationFile,
+} from "#veryfront/platform/adapters/fs/veryfront/types.ts";
+import { logger } from "#veryfront/utils";
+import {
+  buildPreparedCSSArtifactFromFiles,
+  findStylesheetFromFiles,
+} from "#veryfront/html/styles-builder/css-pregeneration.ts";
+import { resolveStyleContentVersion } from "#veryfront/html/styles-builder/content-version.ts";
+import {
+  invalidatePreparedProjectCSS,
+} from "#veryfront/html/styles-builder/prepared-project-css-cache.ts";
+import { createStyleScopeProfile } from "#veryfront/html/styles-builder/style-scope-profile.ts";
+import { invalidateProjectCSS } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
+
+const styleCallbackLog = logger.component("server-style-callbacks");
+
+async function pregenerateProjectStyles(
+  files: StylePregenerationFile[],
+  context: StylePregenerationContext,
+): Promise<{ hash: string; assetPath: string } | undefined> {
+  const { projectDir, projectSlug, contentContext } = context;
+
+  if (!projectDir) {
+    styleCallbackLog.debug("Skipping CSS pre-generation without projectDir", {
+      projectSlug,
+    });
+    return undefined;
+  }
+
+  let stylesheetPath: string | undefined;
+  let styleProfile = createStyleScopeProfile();
+
+  try {
+    const adapter = await runtime.get();
+    const cacheKey = contentContext?.releaseId || projectSlug;
+    const config = await getConfig(projectDir, adapter, { cacheKey });
+    stylesheetPath = config?.tailwind?.stylesheet;
+    styleProfile = createStyleScopeProfile(config);
+  } catch (error) {
+    styleCallbackLog.debug("Failed to load config for CSS pre-generation", {
+      projectSlug,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const stylesheet = findStylesheetFromFiles(files, stylesheetPath);
+  const projectVersion = resolveStyleContentVersion(contentContext, {
+    branch: contentContext?.branch ?? null,
+    releaseId: contentContext?.releaseId ?? null,
+    environmentName: contentContext?.environmentName ?? null,
+  });
+
+  const result = await buildPreparedCSSArtifactFromFiles({
+    projectSlug,
+    projectVersion,
+    projectDir,
+    files,
+    styleProfile,
+    stylesheet,
+    stylesheetPath,
+    minify: true,
+    environment: "preview",
+    buildMode: "production",
+  });
+
+  styleCallbackLog.debug("CSS pre-generation complete", {
+    projectSlug,
+    projectVersion,
+    cssHash: result.hash,
+    candidateCount: result.candidateCount,
+    fromCache: result.fromCache,
+  });
+
+  return { hash: result.hash, assetPath: `/_vf/css/${result.hash}.css` };
+}
+
+export function createServerStyleCallbacks(): StyleCallbacks {
+  return { pregenerateStyles: pregenerateProjectStyles };
+}
+
+export function createServerStyleInvalidationCallbacks(): Pick<
+  InvalidationCallbacks,
+  "clearProjectCSSCache"
+> {
+  return {
+    clearProjectCSSCache: (projectSlug) => {
+      invalidateProjectCSS(projectSlug);
+      invalidatePreparedProjectCSS(projectSlug);
+      invalidateProjectCandidateManifests(projectSlug);
+    },
+  };
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.705";
+export const VERSION = "0.1.706";


### PR DESCRIPTION
## Summary

- Move Veryfront FS adapter CSS pregeneration behind injected `StyleCallbacks`
- Move server-owned CSS pregeneration/cache invalidation wiring into `src/server/style-callbacks.ts`
- Add a platform boundary regression test that rejects non-test `src/platform` references to `html/styles-builder`
- Bump release version from `0.1.705` to `0.1.706`

## Related

- Closes part of #1986
- Related to #1990

## Verification

- Red first: boundary and injected-pregeneration tests failed before implementation
- `deno test --no-check --allow-all src/platform/adapters/fs/veryfront/platform-boundary.test.ts src/platform/adapters/fs/veryfront/adapter.test.ts`
- `deno test --no-check --allow-all src/platform/adapters/fs/veryfront/websocket-manager.test.ts`
- Touched-file `deno check`
- `deno task verify:quick`
- Pre-push: formatting, lint, typecheck, and unit tests (`2016 passed`, `0 failed`)
