### PR TITLE
Make disk cache cleanup failures observable

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.706",
+  "version": "0.1.707",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/cache/backends/disk.test.ts
+++ b/src/cache/backends/disk.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "@std/assert";
 import { join } from "#veryfront/compat/path/index.ts";
+import { logger } from "#veryfront/utils";
 import { DiskCacheBackend } from "./disk.ts";
 import {
   runCacheInvariantTests,
@@ -12,6 +13,26 @@ const TEST_DIR = join(Deno.makeTempDirSync(), "disk-cache-test");
 
 function makeBackend(): DiskCacheBackend {
   return new DiskCacheBackend(TEST_DIR);
+}
+
+function captureDebugLogs(): {
+  entries: Array<{ message: string; args: unknown[] }>;
+  restore: () => void;
+} {
+  const entries: Array<{ message: string; args: unknown[] }> = [];
+  const target = logger as unknown as {
+    debug: (message: string, ...args: unknown[]) => void;
+  };
+  const original = target.debug;
+  target.debug = (message: string, ...args: unknown[]) => {
+    entries.push({ message, args });
+  };
+  return {
+    entries,
+    restore: () => {
+      target.debug = original;
+    },
+  };
 }
 
 /** Adapter: wraps DiskCacheBackend for the MinimalCache invariant test interface */
@@ -66,6 +87,33 @@ Deno.test("DiskCacheBackend", async (t) => {
     // TTL=0 means expiresAt = Date.now() + 0; wait 1ms to ensure it's expired
     await new Promise((r) => setTimeout(r, 5));
     assertEquals(await backend.get("ttl-zero"), null);
+  });
+
+  await t.step("logs expired-entry cleanup failures", async () => {
+    const backend = makeBackend();
+    const key = "expired-cleanup-fails";
+    await backend.set(key, "val", 0);
+    await new Promise((r) => setTimeout(r, 5));
+
+    const originalDel = backend.del.bind(backend);
+    (backend as unknown as { del: (entryKey: string) => Promise<void> }).del = (entryKey: string) =>
+      entryKey === key ? Promise.reject(new Error("delete rejected")) : originalDel(entryKey);
+
+    const debugCapture = captureDebugLogs();
+    try {
+      assertEquals(await backend.get(key), null);
+      await Promise.resolve();
+
+      assertEquals(debugCapture.entries.length, 1);
+      assertEquals(debugCapture.entries[0]?.message, "[DiskCache] Expired entry cleanup failed");
+      assertEquals(
+        (debugCapture.entries[0]?.args[0] as Record<string, unknown> | undefined)?.key,
+        key,
+      );
+    } finally {
+      debugCapture.restore();
+      (backend as unknown as { del: (entryKey: string) => Promise<void> }).del = originalDel;
+    }
   });
 
   await t.step("TTL non-expired returns value", async () => {

--- a/src/cache/backends/disk.ts
+++ b/src/cache/backends/disk.ts
@@ -53,7 +53,12 @@ export class DiskCacheBackend implements CacheBackend {
       const envelope: DiskCacheEnvelope = JSON.parse(raw);
       if (envelope.key !== key) return null;
       if (envelope.expiresAt != null && Date.now() > envelope.expiresAt) {
-        this.del(key).catch(() => {});
+        this.del(key).catch((cleanupError) => {
+          logger.debug("[DiskCache] Expired entry cleanup failed", {
+            key: key.slice(-60),
+            error: cleanupError,
+          });
+        });
         return null;
       }
       return envelope.value;
@@ -85,7 +90,13 @@ export class DiskCacheBackend implements CacheBackend {
       await writeFile(tmpPath, content, "utf-8");
       await rename(tmpPath, filePath);
     } catch (error) {
-      await unlink(tmpPath).catch(() => {});
+      await unlink(tmpPath).catch((cleanupError) => {
+        logger.debug("[DiskCache] Temp file cleanup failed", {
+          key: key.slice(-60),
+          tmpPath,
+          error: cleanupError,
+        });
+      });
       throw error;
     }
   }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.706";
+export const VERSION = "0.1.707";


### PR DESCRIPTION
## Summary

- Log disk cache expired-entry cleanup failures instead of silently swallowing them
- Log temp-file cleanup failures when disk cache writes fail and cleanup is best-effort
- Add a focused disk backend regression test for observable expired-entry cleanup failures
- Bump release version from `0.1.706` to `0.1.707`

## Related

- Related to #1987
- Related to #1988
- Related to #1990

## Notes

While checking the #1988 fire-and-forget cleanup item, the originally cited `module-writer` and RAG cleanup paths were already fixed on current `main`. This PR fixes the same observable-cleanup issue in the adjacent disk cache backend, where two `.catch(() => {})` cleanup paths remained silent.

## Verification

- Red first: `deno test --no-check --allow-all src/cache/backends/disk.test.ts` failed with `0` debug entries before implementation
- `deno test --no-check --allow-all src/cache/backends/disk.test.ts`
- `deno check src/cache/backends/disk.ts src/cache/backends/disk.test.ts src/utils/version-constant.ts`
- `deno task verify:quick`
- Pre-push: formatting, lint, typecheck, and unit tests (`2016 passed`, `0 failed`)
