### PR TITLE
Make module cache iterators type-honest

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.707",
+  "version": "0.1.708",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/cache/module-cache.ts
+++ b/src/cache/module-cache.ts
@@ -106,6 +106,18 @@ function createMapInterface(cache: LRUCache<string, string>): ModuleCacheMap {
   return new LRUBackedMap(cache);
 }
 
+function toMapIterator<T>(source: IterableIterator<T>): MapIterator<T> {
+  if (typeof Iterator !== "undefined") {
+    return Iterator.from(source);
+  }
+
+  const snapshot = new Map<number, T>();
+  for (const value of source) {
+    snapshot.set(snapshot.size, value);
+  }
+  return snapshot.values();
+}
+
 class LRUBackedMap implements ModuleCacheMap {
   readonly [Symbol.toStringTag] = "Map";
 
@@ -155,29 +167,29 @@ class LRUBackedMap implements ModuleCacheMap {
   }
 
   keys(): MapIterator<string> {
-    return this.cache.keys() as unknown as MapIterator<string>;
+    return toMapIterator(this.cache.keys());
   }
 
   values(): MapIterator<string> {
     const keysIter = this.cache.keys();
     const cacheRef = this.cache;
-    return (function* () {
+    return toMapIterator((function* () {
       for (const key of keysIter) {
         const value = cacheRef.get(key);
         if (value !== undefined) yield value;
       }
-    })() as unknown as MapIterator<string>;
+    })());
   }
 
   entries(): MapIterator<[string, string]> {
     const keysIter = this.cache.keys();
     const cacheRef = this.cache;
-    return (function* () {
+    return toMapIterator((function* () {
       for (const key of keysIter) {
         const value = cacheRef.get(key);
         if (value !== undefined) yield [key, value] as [string, string];
       }
-    })() as unknown as MapIterator<[string, string]>;
+    })());
   }
 
   forEach(

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.707";
+export const VERSION = "0.1.708";


### PR DESCRIPTION
## Summary
- Replace module-cache MapIterator double-casts with a typed toMapIterator adapter.
- Preserve the existing ModuleCacheMap extends Map public surface and runtime Map-compatible behavior.
- Bump release metadata to 0.1.708 in deno.json and src/utils/version-constant.ts.

## Verification
- deno test --no-check --allow-all src/cache/module-cache.test.ts
- deno check src/cache/module-cache.ts src/cache/module-cache.test.ts src/utils/version-constant.ts
- git diff --check
- deno task verify:quick
- Pre-push hook: format, lint, typecheck, unit tests: 2016 passed, 0 failed

Related: #1987