### PR TITLE
Use typed OAuth token errors for proxy status handling

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.708",
+  "version": "0.1.709",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/proxy/oauth-client.test.ts
+++ b/src/proxy/oauth-client.test.ts
@@ -23,7 +23,7 @@ describe("OAuth Client", () => {
     });
 
     it("throws on HTTP error", async () => {
-      const { fetchOAuthToken } = await import("./oauth-client.ts");
+      const { fetchOAuthToken, OAuthTokenRequestError } = await import("./oauth-client.ts");
       const { server, port } = createMockServer(
         () => new Response("Unauthorized", { status: 401 }),
       );
@@ -36,9 +36,36 @@ describe("OAuth Client", () => {
               apiClientId: "test",
               apiClientSecret: "test",
             }),
-          Error,
+          OAuthTokenRequestError,
           "401",
         );
+      } finally {
+        await server.shutdown();
+      }
+    });
+
+    it("exposes HTTP status and response text on token request errors", async () => {
+      const { fetchOAuthToken, OAuthTokenRequestError } = await import("./oauth-client.ts");
+      const { server, port } = createMockServer(
+        () => new Response("Project missing", { status: 404 }),
+      );
+
+      try {
+        const error = await assertRejects(
+          () =>
+            fetchOAuthToken({
+              apiBaseUrl: `http://127.0.0.1:${port}`,
+              apiClientId: "test",
+              apiClientSecret: "test",
+            }),
+          OAuthTokenRequestError,
+        );
+
+        if (!(error instanceof OAuthTokenRequestError)) {
+          throw new Error("Expected OAuthTokenRequestError");
+        }
+        assertEquals(error.status, 404);
+        assertEquals(error.responseText, "Project missing");
       } finally {
         await server.shutdown();
       }

--- a/src/proxy/oauth-client.ts
+++ b/src/proxy/oauth-client.ts
@@ -3,7 +3,7 @@
  */
 
 import { injectContext, ProxySpanNames, withSpan } from "./tracing.ts";
-import { REQUEST_ERROR, TIMEOUT_ERROR } from "#veryfront/errors";
+import { TIMEOUT_ERROR } from "#veryfront/errors";
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 
@@ -11,6 +11,16 @@ export interface TokenResponse {
   access_token: string;
   token_type: "Bearer";
   expires_in?: number;
+}
+
+export class OAuthTokenRequestError extends Error {
+  constructor(
+    readonly status: number,
+    readonly responseText: string,
+  ) {
+    super(`OAuth token request failed: ${status} - ${responseText}`);
+    this.name = "OAuthTokenRequestError";
+  }
 }
 
 interface OAuthTokenConfig {
@@ -69,9 +79,7 @@ export async function fetchOAuthToken(
         }
 
         const errorText = await response.text().catch((): string => "Unknown error");
-        throw REQUEST_ERROR.create({
-          detail: `OAuth token request failed: ${response.status} - ${errorText}`,
-        });
+        throw new OAuthTokenRequestError(response.status, errorText);
       } catch (error) {
         if (error instanceof Error && error.name === "AbortError") {
           throw TIMEOUT_ERROR.create({

--- a/src/proxy/token-manager.test.ts
+++ b/src/proxy/token-manager.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd";
 import { TokenManager } from "./token-manager.ts";
 import type { TokenCache, TokenCacheEntry } from "./cache/types.ts";
@@ -28,8 +28,12 @@ class SpyCache implements TokenCache {
     this.store.clear();
   }
 
-  async stats() {
-    return { hits: 0, misses: 0, size: this.store.size, type: "spy" };
+  has(key: string): Promise<boolean> {
+    return Promise.resolve(this.store.has(key));
+  }
+
+  async stats(): Promise<{ hits: number; misses: number; size: number; type: "memory" }> {
+    return { hits: 0, misses: 0, size: this.store.size, type: "memory" };
   }
 
   async close(): Promise<void> {}
@@ -60,7 +64,7 @@ describe("TokenManager", () => {
         }, 50);
       });
     });
-    serverPort = mockServer.addr.port;
+    serverPort = (mockServer.addr as Deno.NetAddr).port;
   });
 
   afterEach(async () => {
@@ -118,6 +122,42 @@ describe("TokenManager", () => {
     // Different keys should result in separate fetches
     assertEquals(fetchCount, 2);
     assertEquals(cache.setCount, 2);
+
+    await manager.close();
+  });
+
+  it("negative-caches typed 404 token failures", async () => {
+    await mockServer?.shutdown();
+    mockServer = Deno.serve({ port: 0, onListen() {} }, () => {
+      fetchCount++;
+      return new Response("Project missing", { status: 404 });
+    });
+    serverPort = (mockServer.addr as Deno.NetAddr).port;
+
+    const cache = new SpyCache();
+    const manager = new TokenManager(
+      {
+        apiBaseUrl: `http://localhost:${serverPort}`,
+        apiClientId: "id",
+        apiClientSecret: "secret",
+        previewApiClientId: "pid",
+        previewApiClientSecret: "psecret",
+      },
+      { cache },
+    );
+
+    await assertRejects(
+      () => manager.getToken("production", "missing-project"),
+      Error,
+      "404",
+    );
+    await assertRejects(
+      () => manager.getToken("production", "missing-project"),
+      Error,
+      "404",
+    );
+
+    assertEquals(fetchCount, 1);
 
     await manager.close();
   });

--- a/src/proxy/token-manager.ts
+++ b/src/proxy/token-manager.ts
@@ -1,4 +1,4 @@
-import { fetchOAuthToken, type TokenResponse } from "./oauth-client.ts";
+import { fetchOAuthToken, OAuthTokenRequestError, type TokenResponse } from "./oauth-client.ts";
 import type { TokenCache, TokenCacheEntry } from "./cache/types.ts";
 import { MemoryCache } from "./cache/memory-cache.ts";
 import { ProxySpanNames, withSpan } from "./tracing.ts";
@@ -140,7 +140,7 @@ export class TokenManager {
         customDomain,
       });
     } catch (error) {
-      const status = this.parseStatusFromError(error);
+      const status = error instanceof OAuthTokenRequestError ? error.status : null;
       if (status === 400 || status === 404) {
         const projectKey = projectSlug || customDomain;
         const cacheKey = this.getCacheKey(scope, projectKey);
@@ -167,12 +167,6 @@ export class TokenManager {
     });
 
     return response.access_token;
-  }
-
-  private parseStatusFromError(error: unknown): number | null {
-    const message = error instanceof Error ? error.message : String(error);
-    const match = message.match(/failed: (\d+)/);
-    return match ? Number(match[1]) : null;
   }
 
   private calculateExpiresAt(response: TokenResponse): number {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.708";
+export const VERSION = "0.1.709";


### PR DESCRIPTION
## Summary
- Add a typed OAuthTokenRequestError that carries upstream token HTTP status and response text.
- Stop negative-caching token failures by parsing status from the OAuth error message.
- Preserve the existing OAuth token failure message text while letting TokenManager read status directly.
- Bump release metadata to 0.1.709 in deno.json and src/utils/version-constant.ts.

## Verification
- Red first: deno test --no-check --allow-all src/proxy/oauth-client.test.ts failed on the new status contract with actual 500 instead of expected 404.
- deno test --no-check --allow-all src/proxy/oauth-client.test.ts src/proxy/token-manager.test.ts
- deno check src/proxy/oauth-client.ts src/proxy/oauth-client.test.ts src/proxy/token-manager.ts src/proxy/token-manager.test.ts src/utils/version-constant.ts
- git diff --check
- deno task verify:quick
- Pre-push hook: format, lint, typecheck, unit tests: 2016 passed, 0 failed

Related: #1985
