### PR TITLE
Expose typed render cache stats contracts

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.709",
+  "version": "0.1.710",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/rendering/cache/stores/api-store.ts
+++ b/src/rendering/cache/stores/api-store.ts
@@ -1,4 +1,4 @@
-import type { CachePayload, CacheStore } from "../types.ts";
+import type { CachePayload, CacheStore, CacheStoreStats } from "../types.ts";
 import { MemoryCacheStore } from "./memory-store.ts";
 import { rendererLogger } from "#veryfront/utils";
 import { type CacheBackend, createCacheBackend } from "#veryfront/cache/backend.ts";
@@ -218,5 +218,9 @@ export class APICacheStore implements CacheStore {
     await this.localCache?.destroy();
     this.backend = null;
     this.backendInitPromise = null;
+  }
+
+  getStats(): CacheStoreStats {
+    return this.localCache?.getStats() ?? { size: 0 };
   }
 }

--- a/src/rendering/cache/stores/memory-store.ts
+++ b/src/rendering/cache/stores/memory-store.ts
@@ -9,7 +9,7 @@
 
 import { getDisableLruIntervalEnv } from "#veryfront/config/env.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
-import type { CachePayload, CacheStore } from "../types.ts";
+import type { CachePayload, CacheStore, CacheStoreStats } from "../types.ts";
 
 const DEFAULT_MAX_ENTRIES = 100;
 
@@ -86,6 +86,10 @@ export class MemoryCacheStore implements CacheStore {
     let count = 0;
     for (const _ of this.cache.keys()) count++;
     return count;
+  }
+
+  getStats(): CacheStoreStats {
+    return { size: this.size() };
   }
 }
 

--- a/src/rendering/cache/stores/redis-store.ts
+++ b/src/rendering/cache/stores/redis-store.ts
@@ -1,4 +1,4 @@
-import type { CachePayload, CacheStore } from "../types.ts";
+import type { CachePayload, CacheStore, CacheStoreStats } from "../types.ts";
 import { rendererLogger } from "#veryfront/utils";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import { MemoryCacheStore } from "./memory-store.ts";
@@ -263,5 +263,9 @@ export class RedisCacheStore implements CacheStore {
 
     await this.client.disconnect();
     this.client = null;
+  }
+
+  getStats(): CacheStoreStats {
+    return this.fallbackStore?.getStats() ?? { size: 0 };
   }
 }

--- a/src/rendering/cache/types.ts
+++ b/src/rendering/cache/types.ts
@@ -8,6 +8,10 @@ export interface CachePayload {
   nodeMapEntries?: Array<[number, unknown]>;
 }
 
+export interface CacheStoreStats {
+  size: number;
+}
+
 export interface CacheStore {
   get(key: string): Promise<CachePayload | undefined>;
   set(key: string, value: CachePayload): Promise<void>;
@@ -16,6 +20,8 @@ export interface CacheStore {
   deleteByPrefix?(prefix: string): Promise<number>;
   clear(): Promise<void>;
   destroy(): Promise<void>;
+  /** Optional stats contract for stores that can report entry counts */
+  getStats?(): CacheStoreStats;
   /** Optional size accessor for cache stats */
   size?(): number;
 }

--- a/src/rendering/shared/context-aware-cache.test.ts
+++ b/src/rendering/shared/context-aware-cache.test.ts
@@ -2,18 +2,18 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { ContextAwareCacheCoordinator } from "./context-aware-cache.ts";
-import type { CacheStore } from "../cache/types.ts";
+import type { CachePayload, CacheStore } from "../cache/types.ts";
 import type { RenderContext } from "../context/render-context.ts";
 
-function createInMemoryStore(): CacheStore & { data: Map<string, unknown> } {
-  const data = new Map<string, unknown>();
+function createInMemoryStore(): CacheStore & { data: Map<string, CachePayload> } {
+  const data = new Map<string, CachePayload>();
 
   return {
     data,
     get(key: string) {
       return Promise.resolve(data.get(key));
     },
-    set(key: string, value: unknown) {
+    set(key: string, value: CachePayload) {
       data.set(key, value);
       return Promise.resolve();
     },
@@ -257,11 +257,11 @@ describe("rendering/shared/context-aware-cache", () => {
 
     it("should clear slug without deleteByPrefix (fallback to individual deletes)", async () => {
       // Create a store WITHOUT deleteByPrefix
-      const data = new Map<string, unknown>();
+      const data = new Map<string, CachePayload>();
       const deletedKeys: string[] = [];
       const storeWithoutPrefix: CacheStore = {
         get: (key: string) => Promise.resolve(data.get(key)),
-        set: (key: string, value: unknown) => {
+        set: (key: string, value: CachePayload) => {
           data.set(key, value);
           return Promise.resolve();
         },
@@ -306,16 +306,15 @@ describe("rendering/shared/context-aware-cache", () => {
       assertEquals(lookup.hit, false);
     });
 
-    it("should return stats with populated store that has size property", async () => {
+    it("should return stats with populated store that has size method", async () => {
       const baseStore = createInMemoryStore();
-      // Add a size getter that getStats() can read
-      Object.defineProperty(baseStore, "size", {
-        get() {
+      const store = {
+        ...baseStore,
+        size() {
           return baseStore.data.size;
         },
-        enumerable: true,
-      });
-      const cache = new ContextAwareCacheCoordinator({ store: baseStore });
+      };
+      const cache = new ContextAwareCacheCoordinator({ store });
       const ctx = makeMockCtx();
 
       const result = {
@@ -331,7 +330,19 @@ describe("rendering/shared/context-aware-cache", () => {
       assertEquals(stats.size >= 1, true);
     });
 
-    it("should return size 0 when store has no size property", () => {
+    it("should read stats from the cache store stats contract", () => {
+      const store = {
+        ...createInMemoryStore(),
+        getStats() {
+          return { size: 7 };
+        },
+      };
+      const cache = new ContextAwareCacheCoordinator({ store });
+
+      assertEquals(cache.getStats(), { size: 7 });
+    });
+
+    it("should return size 0 when store has no stats contract", () => {
       const cache = new ContextAwareCacheCoordinator();
       const stats = cache.getStats();
       assertEquals(stats.size, 0);

--- a/src/rendering/shared/context-aware-cache.ts
+++ b/src/rendering/shared/context-aware-cache.ts
@@ -216,11 +216,9 @@ export class ContextAwareCacheCoordinator {
   }
 
   getStats(): { size: number } {
-    const storeWithSize = this.store as unknown as { size?: number | (() => number) };
-    const sizeValue = storeWithSize.size;
-    // Call size() with the correct `this` context to avoid "undefined" errors
-    if (typeof sizeValue === "function") return { size: sizeValue.call(this.store) };
-    if (typeof sizeValue === "number") return { size: sizeValue };
+    const stats = this.store.getStats?.();
+    if (stats) return stats;
+    if (this.store.size) return { size: this.store.size() };
     return { size: 0 };
   }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.709";
+export const VERSION = "0.1.710";


### PR DESCRIPTION
## Summary
- Add a typed CacheStoreStats contract for render cache stores.
- Have ContextAwareCacheCoordinator read store getStats() before falling back to size().
- Add stats implementations for memory, API-local, and Redis fallback cache stores.
- Bump release metadata to 0.1.710 in deno.json and src/utils/version-constant.ts.

## Verification
- Red first: deno test --no-check --allow-all src/rendering/shared/context-aware-cache.test.ts failed on the new store stats contract with actual size 0 instead of expected size 7.
- deno test --no-check --allow-all src/rendering/shared/context-aware-cache.test.ts src/rendering/cache/stores/memory-store.test.ts src/rendering/cache/stores/api-store.test.ts src/rendering/cache/stores/redis-store.test.ts
- deno check src/rendering/cache/types.ts src/rendering/shared/context-aware-cache.ts src/rendering/shared/context-aware-cache.test.ts src/rendering/cache/stores/memory-store.ts src/rendering/cache/stores/api-store.ts src/rendering/cache/stores/redis-store.ts
- deno fmt --check on touched files
- git diff --check
- deno task verify:quick
- Pre-push hook: format, lint, typecheck, unit tests: 2016 passed, 0 failed

Related: #1987
