### PR TITLE
Keep FS adapter bootstrap config typed

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.713",
+  "version": "0.1.714",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -312,25 +312,25 @@ export async function bootstrap(
 
     // Inject server-layer callbacks into FS config so the platform layer
     // doesn't need to import from the server layer
-    const configuredFs = config.fs as Partial<FSAdapterConfig> | undefined;
-    const fsWithCallbacks = {
-      ...config.fs,
+    const configuredFs = (config.fs ?? {}) as Partial<FSAdapterConfig>;
+    const fsWithCallbacks: FSAdapterConfig = {
+      ...configuredFs,
       invalidationCallbacks: {
         ...createServerStyleInvalidationCallbacks(),
-        ...configuredFs?.invalidationCallbacks,
+        ...configuredFs.invalidationCallbacks,
         triggerReload: (changedPaths?: string[], project?: InvalidationProjectContext) =>
           ReloadNotifier.triggerReload(changedPaths, project),
         clearDomainCache,
       },
       styleCallbacks: {
         ...createServerStyleCallbacks(),
-        ...configuredFs?.styleCallbacks,
+        ...configuredFs.styleCallbacks,
       },
     };
 
     const enhancedAdapter = await enhanceAdapterWithFS(
       adapter,
-      { ...config, fs: fsWithCallbacks } as any,
+      { fs: fsWithCallbacks },
       projectDir,
     );
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.713";
+export const VERSION = "0.1.714";


### PR DESCRIPTION
## Summary
- removes the `as any` cast from FS adapter bootstrap wiring
- passes the adapter integration layer only the typed `fs` config slice it needs
- bumps release metadata to `0.1.714`

## Verification
- `deno check src/server/bootstrap.ts src/utils/version-constant.ts`
- `deno fmt --check src/server/bootstrap.ts src/utils/version-constant.ts deno.json`
- `git diff --check`
- `deno task verify:quick`
- pre-push: `2019 passed | 0 failed`

## Related
- follows up the typed-boundary work tracked in #1985 / #1990
