### PR TITLE
Keep platform runtime detection typed

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.714",
+  "version": "0.1.715",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/platform/core-platform.ts
+++ b/src/platform/core-platform.ts
@@ -11,24 +11,33 @@ interface PlatformCapabilities {
   displayName: string;
 }
 
+type RuntimeGlobal = typeof globalThis & {
+  Deno?: { version?: { deno?: string } };
+  Bun?: { version?: string };
+  caches?: unknown;
+  navigator?: { userAgent?: string };
+  process?: { versions?: { node?: string } };
+};
+
+function runtimeGlobal(): RuntimeGlobal {
+  return globalThis as RuntimeGlobal;
+}
+
 export function detectPlatform(): Platform {
-  // @ts-ignore - Deno global may not exist
-  if (typeof Deno !== "undefined" && Deno.version?.deno) return "deno";
+  const global = runtimeGlobal();
 
-  // @ts-ignore - Bun global may not exist
-  if (typeof Bun !== "undefined" && Bun.version) return "bun";
+  if (global.Deno?.version?.deno) return "deno";
 
-  // @ts-ignore - caches global specific to CF Workers
+  if (global.Bun?.version) return "bun";
+
   if (
-    typeof caches !== "undefined" &&
-    typeof navigator !== "undefined" &&
-    navigator.userAgent === "Cloudflare-Workers"
+    global.caches !== undefined &&
+    global.navigator?.userAgent === "Cloudflare-Workers"
   ) {
     return "cloudflare-workers";
   }
 
-  const globalProcess = (globalThis as { process?: { versions?: { node?: string } } }).process;
-  if (globalProcess?.versions?.node) return "node";
+  if (global.process?.versions?.node) return "node";
 
   return "unknown";
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.714";
+export const VERSION = "0.1.715";


### PR DESCRIPTION
## Summary
- replaces `@ts-ignore` runtime-global probes in `src/platform/core-platform.ts` with a typed local `RuntimeGlobal` shape
- keeps Deno/Bun/Cloudflare Workers/Node detection behavior unchanged
- bumps release metadata to `0.1.715`

## Verification
- `deno test --no-check --allow-all src/platform/core-platform.test.ts`
- `deno check src/platform/core-platform.ts src/platform/core-platform.test.ts src/utils/version-constant.ts`
- `deno fmt --check src/platform/core-platform.ts src/platform/core-platform.test.ts src/utils/version-constant.ts deno.json`
- `no core-platform runtime-global ts-ignore comments`
- `deno task verify:quick`
- pre-push: `2019 passed | 0 failed`

## Related
- closes a small current slice from #1986 / #1990
