### PR TITLE
Centralize HTTP cache brand boundary conversions

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.715",
+  "version": "0.1.716",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/transforms/esm/bundle-deps-validator.ts
+++ b/src/transforms/esm/bundle-deps-validator.ts
@@ -11,6 +11,7 @@ import { createFileSystem, exists } from "#veryfront/platform/compat/fs.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { rendererLogger } from "#veryfront/utils";
 import { httpBundleCache } from "./http-cache-wrapper.ts";
+import { unbrand } from "./http-cache-types.ts";
 import { extractSourceUrl } from "./source-url-embed.ts";
 import { ensureAbsoluteDir, hasIncompatibleFilePaths } from "./http-cache-helpers.ts";
 
@@ -118,7 +119,7 @@ export async function validateBundleDepsExist(
         return false;
       }
 
-      const code = localCode as unknown as string;
+      const code = unbrand(localCode);
 
       if (hasIncompatibleFilePaths(code, absoluteCacheDir)) {
         logger.debug("Dep has incompatible paths, rejecting cache", { hash });

--- a/src/transforms/esm/bundle-recovery.ts
+++ b/src/transforms/esm/bundle-recovery.ts
@@ -13,6 +13,7 @@ import { join } from "#veryfront/compat/path/index.ts";
 import { rendererLogger } from "#veryfront/utils/logger/logger.ts";
 import { simpleHash } from "#veryfront/utils/hash-utils.ts";
 import { httpBundleCache } from "./http-cache-wrapper.ts";
+import { unbrand } from "./http-cache-types.ts";
 import { VeryfrontError } from "./http-cache-invariants.ts";
 import { extractSourceUrl } from "./source-url-embed.ts";
 import {
@@ -48,7 +49,7 @@ export async function recoverHttpBundleByHash(
     const result = await httpBundleCache.getCodeByHash(hash);
 
     if (result.code) {
-      const cachedCode = result.code as unknown as string;
+      const cachedCode = unbrand(result.code);
 
       if (hasIncompatibleFilePaths(cachedCode, absoluteCacheDir)) {
         logger.warn("Cached code has incompatible file paths, will re-fetch", {
@@ -282,7 +283,7 @@ export async function ensureHttpBundlesExist(
           return;
         }
 
-        const code = localCode as unknown as string;
+        const code = unbrand(localCode);
 
         if (hasIncompatibleFilePaths(code, absoluteCacheDir)) {
           logger.warn(

--- a/src/transforms/esm/http-cache-invariants.ts
+++ b/src/transforms/esm/http-cache-invariants.ts
@@ -8,7 +8,13 @@
  */
 
 import { rendererLogger } from "#veryfront/utils";
-import type { BundleHash, LocalModuleCode, PortableModuleCode } from "./http-cache-types.ts";
+import {
+  brand,
+  type BundleHash,
+  type LocalModuleCode,
+  type PortableModuleCode,
+  unbrand,
+} from "./http-cache-types.ts";
 import {
   CACHE_DIR_TOKEN,
   CACHE_INVARIANT_VIOLATION,
@@ -53,7 +59,7 @@ function hasPortableTokens(code: string): boolean {
  * @throws VeryfrontError (cache-invariant-violation) if code contains hardcoded paths
  */
 export function assertPortable(code: PortableModuleCode): void {
-  const codeStr = code as unknown as string;
+  const codeStr = unbrand(code);
 
   if (hasHardcodedCachePaths(codeStr)) {
     logger.error("Invariant violation: hardcoded paths in portable code", {
@@ -75,7 +81,7 @@ export function assertPortable(code: PortableModuleCode): void {
  * @throws VeryfrontError (cache-invariant-violation) if code contains portable tokens
  */
 export function assertLocal(code: LocalModuleCode): void {
-  const codeStr = code as unknown as string;
+  const codeStr = unbrand(code);
 
   if (hasPortableTokens(codeStr)) {
     logger.error("Invariant violation: portable tokens in local code", {
@@ -106,7 +112,7 @@ export function asBundleHash(hash: string): BundleHash {
         `[CACHE INVARIANT VIOLATION] Invalid bundle hash format: "${hash}" (expected numeric)`,
     });
   }
-  return hash as unknown as BundleHash;
+  return brand<BundleHash>(hash);
 }
 
 /**
@@ -124,5 +130,5 @@ export function asLocalModuleCode(code: string): LocalModuleCode {
         `[CACHE INVARIANT VIOLATION] Cannot treat code as LocalModuleCode: contains ${CACHE_DIR_TOKEN} tokens`,
     });
   }
-  return code as unknown as LocalModuleCode;
+  return brand<LocalModuleCode>(code);
 }

--- a/src/transforms/esm/http-cache.ts
+++ b/src/transforms/esm/http-cache.ts
@@ -19,6 +19,7 @@ import { createBundleManifest, storeBundleManifest } from "./bundle-manifest.ts"
 import { HTTP_MODULE_DISTRIBUTED_TTL_SEC } from "#veryfront/utils/constants/cache.ts";
 import { HTTP_FETCH_TIMEOUT_MS } from "#veryfront/utils/constants/http.ts";
 import { httpBundleCache } from "./http-cache-wrapper.ts";
+import { unbrand } from "./http-cache-types.ts";
 import { asLocalModuleCode, VeryfrontError } from "./http-cache-invariants.ts";
 import {
   CACHE_DIR_TOKEN,
@@ -164,7 +165,7 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
     const cacheResult = await httpBundleCache.getCodeByUrl(String(hash));
 
     if (cacheResult.code) {
-      const cachedCode = cacheResult.code as unknown as string;
+      const cachedCode = unbrand(cacheResult.code);
       const deps = extractBundleDeps(cachedCode);
 
       if (deps.length > 0) {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.715";
+export const VERSION = "0.1.716";


### PR DESCRIPTION
## Summary
- route remaining HTTP bundle cache branded-code conversions through `brand`/`unbrand` helpers
- remove scattered `as unknown as string` / branded casts from recovery, dependency validation, and invariant helpers
- bump release version to `0.1.716`

## Verification
- `deno test --frozen --allow-all src/transforms/esm/http-cache-invariants.test.ts src/transforms/esm/http-cache-wrapper.test.ts src/transforms/esm/bundle-recovery.test.ts src/transforms/esm/bundle-deps-validator.test.ts src/transforms/esm/http-cache.test.ts`
- `deno check --frozen src/transforms/esm/http-cache-invariants.ts src/transforms/esm/http-cache.ts src/transforms/esm/bundle-recovery.ts src/transforms/esm/bundle-deps-validator.ts`
- `deno fmt --check src/transforms/esm/http-cache-invariants.ts src/transforms/esm/http-cache.ts src/transforms/esm/bundle-recovery.ts src/transforms/esm/bundle-deps-validator.ts deno.json src/utils/version-constant.ts`
- `git diff --check`
- `deno task verify:quick`
- pre-push hook: `2019 passed`, `0 failed`

Closes part of #1988.
Updates #1990.