### PR TITLE
Keep Deno env shim typed

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.717",
+  "version": "0.1.718",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/platform/compat/shims/deno-env.test.ts
+++ b/src/platform/compat/shims/deno-env.test.ts
@@ -10,6 +10,11 @@ describe("platform/compat/shims/deno-env", () => {
   describe("Deno.env.get/set/delete/has/toObject", () => {
     const testKey = "__VF_TEST_DENO_ENV_SHIM__";
 
+    it("does not rely on TypeScript ignore comments for the shim global", async () => {
+      const source = await Deno.readTextFile(new URL("./deno-env.ts", import.meta.url));
+      assertEquals(source.includes("@ts-ignore"), false);
+    });
+
     it("should get undefined for a missing key", () => {
       assertEquals(Deno.env.get(testKey), undefined);
     });

--- a/src/platform/compat/shims/deno-env.ts
+++ b/src/platform/compat/shims/deno-env.ts
@@ -1,5 +1,20 @@
-// @ts-ignore - Global Deno shim for Node.js
-globalThis.Deno ??= {
+type DenoEnvShim = {
+  env: {
+    get(key: string): string | undefined;
+    set(key: string, value: string): void;
+    delete(key: string): void;
+    has(key: string): boolean;
+    toObject(): Record<string, string>;
+  };
+};
+
+type DenoEnvShimGlobal = Omit<typeof globalThis, "Deno"> & {
+  Deno?: DenoEnvShim;
+};
+
+const global = globalThis as DenoEnvShimGlobal;
+
+global.Deno ??= {
   env: {
     get(key: string): string | undefined {
       return process.env[key];

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.717";
+export const VERSION = "0.1.718";


### PR DESCRIPTION
## Summary
- Replace the Deno env shim ts-ignore with a narrow env-only global type.
- Add a regression assertion that the shim does not rely on ts-ignore comments.
- Bump release version to 0.1.718 in deno.json and src/utils/version-constant.ts.

## Verification
- deno test --frozen --no-check --allow-all src/platform/compat/shims/deno-env.test.ts
- deno check --frozen src/platform/compat/shims/deno-env.ts src/platform/compat/shims/deno-env.test.ts src/utils/version-constant.ts
- git diff --check
- deno task verify:quick
- Pre-push hook: format, lint, typecheck, unit tests

Related: #1986
Related: #1990