### PR TITLE
Log router background fetch failures

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.718",
+  "version": "0.1.719",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/html/hydration-script-builder/templates/router.test.ts
+++ b/src/html/hydration-script-builder/templates/router.test.ts
@@ -70,6 +70,13 @@ describe("hydration-script-builder/templates/router", () => {
       assertIncludes(result, "const logError = console.error");
     });
 
+    it("should log non-blocking background page-data fetch failures", () => {
+      const result = getRouterScript();
+      assertIncludes(result, "function logBackgroundFetchFailure(reason, path, error)");
+      assertIncludes(result, "logBackgroundFetchFailure('Stale page data refresh', path, error)");
+      assertIncludes(result, "logBackgroundFetchFailure('Page data prefetch', path, error)");
+    });
+
     it("should define version tracking for cache invalidation", () => {
       const result = getRouterScript();
       assertIncludes(result, "function checkVersionMismatch(newVersion)");

--- a/src/html/hydration-script-builder/templates/router.ts
+++ b/src/html/hydration-script-builder/templates/router.ts
@@ -42,6 +42,11 @@ export const getRouterScript = () => `
     const log = DEBUG ? console.log.bind(console, '[Veryfront]') : () => {};
     const logError = console.error.bind(console, '[Veryfront]');
 
+    function logBackgroundFetchFailure(reason, path, error) {
+      const message = error?.message ?? String(error);
+      log(reason + ' failed:', path, message);
+    }
+
     function getDocumentNonce() {
       const element = document.querySelector('script[nonce], style[nonce], link[nonce]');
       if (!element) return undefined;
@@ -290,7 +295,9 @@ export const getRouterScript = () => `
       const cached = getCachedPageData(path);
       if (cached) {
         log('Using cached page data:', path);
-        fetchPageDataFresh(path, null).catch(() => {});
+        fetchPageDataFresh(path, null).catch((error) => {
+          logBackgroundFetchFailure('Stale page data refresh', path, error);
+        });
         return cached;
       }
 
@@ -299,7 +306,9 @@ export const getRouterScript = () => `
 
     async function fetchPageDataForPrefetch(path) {
       if (getCachedPageData(path)) return;
-      return fetchPageDataFresh(path, null).catch(() => {});
+      return fetchPageDataFresh(path, null).catch((error) => {
+        logBackgroundFetchFailure('Page data prefetch', path, error);
+      });
     }
 
     // ============================================

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.718";
+export const VERSION = "0.1.719";


### PR DESCRIPTION
## Summary
- Keep stale page-data refresh and prefetch failures non-blocking, but route them through the router debug logger.
- Add a router template regression assertion for both background fetch failure paths.
- Bump release version to 0.1.719 in deno.json and src/utils/version-constant.ts.

## Verification
- deno test --frozen --no-check --allow-all src/html/hydration-script-builder/templates/router.test.ts
- deno check --frozen src/html/hydration-script-builder/templates/router.ts src/html/hydration-script-builder/templates/router.test.ts src/utils/version-constant.ts
- deno fmt --check deno.json src/utils/version-constant.ts src/html/hydration-script-builder/templates/router.ts src/html/hydration-script-builder/templates/router.test.ts
- git diff --check
- deno task verify:quick
- Pre-push hook: format, lint, typecheck, unit tests: 2019 passed, 0 failed

Related: #1987
Related: #1990