### PR TITLE
Cover distributed bundle recovery paths

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.719",
+  "version": "0.1.720",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/transforms/esm/bundle-recovery.test.ts
+++ b/src/transforms/esm/bundle-recovery.test.ts
@@ -2,8 +2,37 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path/index.ts";
-import { ensureHttpBundlesExist, invalidateHttpBundle } from "./bundle-recovery.ts";
+import type { CacheBackend } from "#veryfront/cache/types.ts";
+import {
+  ensureHttpBundlesExist,
+  invalidateHttpBundle,
+  recoverHttpBundleByHash,
+} from "./bundle-recovery.ts";
+import { __injectCachesForTests } from "./http-cache-state.ts";
 import { __setDistributedCacheAccessorForTests } from "./http-cache-wrapper.ts";
+
+function createSuffixCacheBackend(entries: Record<string, string>): CacheBackend {
+  const values = new Map(Object.entries(entries));
+
+  function suffixKey(key: string): string {
+    const match = /^[^:]+:([^:]+):(.+)$/.exec(key);
+    if (!match) return key;
+    return `${match[1]}:${match[2]}`;
+  }
+
+  return {
+    type: "memory",
+    get: (key) => Promise.resolve(values.get(suffixKey(key)) ?? null),
+    set: (key, value) => {
+      values.set(suffixKey(key), value);
+      return Promise.resolve();
+    },
+    del: (key) => {
+      values.delete(suffixKey(key));
+      return Promise.resolve();
+    },
+  };
+}
 
 // Force the distributed cache to be unavailable so the recovery/invalidation
 // code paths are fully deterministic and never touch a real backend.
@@ -13,9 +42,67 @@ beforeEach(() => {
 
 afterEach(() => {
   __setDistributedCacheAccessorForTests(null);
+  __injectCachesForTests(null);
 });
 
 describe("transforms/esm/bundle-recovery", () => {
+  describe("recoverHttpBundleByHash", () => {
+    it("writes code recovered by hash from distributed cache and refreshes local path state", async () => {
+      const cacheDir = await Deno.makeTempDir();
+      const cachedPaths = new Map<string, string>();
+      __injectCachesForTests({ cachedPaths });
+      __setDistributedCacheAccessorForTests(() =>
+        Promise.resolve(createSuffixCacheBackend({
+          "code:123": "export const recovered = true;\n",
+          "hash:123": "https://esm.sh/recovered@1",
+        }))
+      );
+
+      try {
+        const recovered = await recoverHttpBundleByHash(
+          "123",
+          cacheDir,
+          () => Promise.resolve(null),
+        );
+
+        assertEquals(recovered, true);
+        assertEquals(
+          await Deno.readTextFile(join(cacheDir, "http-123.mjs")),
+          "export const recovered = true;\n",
+        );
+        assertEquals([...cachedPaths.values()], [join(cacheDir, "http-123.mjs")]);
+      } finally {
+        await Deno.remove(cacheDir, { recursive: true });
+      }
+    });
+
+    it("falls back to original URL re-fetch when distributed cache has URL metadata but no code", async () => {
+      const cacheDir = await Deno.makeTempDir();
+      const calls: Array<{ url: string; cacheDir: string }> = [];
+      __setDistributedCacheAccessorForTests(() =>
+        Promise.resolve(createSuffixCacheBackend({
+          "hash:404": "https://esm.sh/fallback@1",
+        }))
+      );
+
+      try {
+        const recovered = await recoverHttpBundleByHash(
+          "404",
+          cacheDir,
+          (url, options) => {
+            calls.push({ url, cacheDir: options.cacheDir });
+            return Promise.resolve(join(cacheDir, "http-404.mjs"));
+          },
+        );
+
+        assertEquals(recovered, true);
+        assertEquals(calls, [{ url: "https://esm.sh/fallback@1", cacheDir }]);
+      } finally {
+        await Deno.remove(cacheDir, { recursive: true });
+      }
+    });
+  });
+
   describe("ensureHttpBundlesExist", () => {
     it("returns an empty array for an empty bundle list without touching the cache", async () => {
       const failed = await ensureHttpBundlesExist(

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.719";
+export const VERSION = "0.1.720";


### PR DESCRIPTION
## Summary
- add deterministic coverage for recoverHttpBundleByHash direct distributed-cache code recovery
- cover original URL re-fetch fallback when hash metadata exists but code is missing
- bump Veryfront Code release metadata to 0.1.720

## Verification
- deno test --frozen --no-check --allow-all src/transforms/esm/bundle-recovery.test.ts
- deno check --frozen src/transforms/esm/bundle-recovery.ts src/transforms/esm/bundle-recovery.test.ts src/utils/version-constant.ts
- deno task verify:quick
- pre-push hook: format, lint, typecheck, unit tests 2019 passed / 0 failed

Part of #1988 and #1990.