### PR TITLE
Bump framework version to 0.1.721

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.720",
+  "version": "0.1.721",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.720";
+export const VERSION = "0.1.721";


### PR DESCRIPTION
## Summary

Bumps the Veryfront framework release version to 0.1.721.

Updates:
- root deno.json version
- src/utils/version-constant.ts runtime fallback version

## Verification

- deno fmt --check deno.json
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- deno check src/utils/version.ts src/utils/version.test.ts src/utils/logger/logger.test.ts
- git diff --check
- Pre-push checks passed: formatting, lint, type check, unit tests: 2019 passed, 0 failed