### PR TITLE
Cover module loader dependency rewrite paths

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.721",
+  "version": "0.1.722",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/rendering/orchestrator/module-loader/index.test.ts
+++ b/src/rendering/orchestrator/module-loader/index.test.ts
@@ -1,7 +1,112 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { isMissingModuleError } from "./index.ts";
+import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
+import { dirname, join } from "#veryfront/compat/path/index.ts";
+import { isMissingModuleError, type ModuleLoaderConfig, transformModuleWithDeps } from "./index.ts";
+
+async function withModuleLoaderFixture<T>(
+  files: Record<string, string>,
+  test: (fixture: { projectDir: string; tmpDir: string; config: ModuleLoaderConfig }) => Promise<T>,
+): Promise<T> {
+  const projectDir = await Deno.makeTempDir({ prefix: "vf-module-loader-project-" });
+  const tmpDir = await Deno.makeTempDir({ prefix: "vf-module-loader-out-" });
+  const adapter = await getLocalAdapter();
+
+  try {
+    for (const [relativePath, content] of Object.entries(files)) {
+      const absolutePath = join(projectDir, relativePath);
+      await Deno.mkdir(dirname(absolutePath), { recursive: true });
+      await Deno.writeTextFile(absolutePath, content);
+    }
+
+    return await test({
+      projectDir,
+      tmpDir,
+      config: {
+        projectDir,
+        adapter,
+        mode: "development",
+        moduleCache: new Map(),
+        esmCache: new Map(),
+      },
+    });
+  } finally {
+    await Deno.remove(projectDir, { recursive: true }).catch(() => undefined);
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => undefined);
+  }
+}
+
+function assertTransformedImportPath(code: string, expectedPathPart: string): string {
+  const match = code.match(/from\s+"file:\/\/([^"]+)"/);
+  assert(match, `expected transformed import in code:\n${code}`);
+  const importPath = match[1]!;
+  assertStringIncludes(importPath, expectedPathPart);
+  return importPath;
+}
+
+describe("module-loader/transformModuleWithDeps", () => {
+  it("transforms @/ alias dependencies before rewriting the import to a file URL", async () => {
+    await withModuleLoaderFixture(
+      {
+        "app/page.json": [
+          `import { label } from "@/components/Label";`,
+          `export const pageLabel = label;`,
+        ].join("\n"),
+        "components/Label.json": `export const label = "alias-label";`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const fsWithJsonResolve = Object.assign(Object.create(config.adapter.fs), {
+          async resolveFile(basePath: string): Promise<string | null> {
+            const jsonPath = `${basePath}.json`;
+            return await config.adapter.fs.exists(jsonPath) ? jsonPath : null;
+          },
+        });
+        const resolveJsonAdapter = {
+          ...config.adapter,
+          fs: fsWithJsonResolve,
+        };
+        const jsonConfig = { ...config, adapter: resolveJsonAdapter };
+        const transformedPath = await transformModuleWithDeps(
+          join(projectDir, "app/page.json"),
+          tmpDir,
+          resolveJsonAdapter,
+          jsonConfig,
+        );
+        const transformedCode = await Deno.readTextFile(transformedPath);
+        const depPath = assertTransformedImportPath(transformedCode, "/components/Label.json");
+
+        assertStringIncludes(transformedPath, "/app/page.json");
+        assertEquals((await Deno.stat(depPath)).isFile, true);
+      },
+    );
+  });
+
+  it("resolves relative imports before rewriting them to file URLs", async () => {
+    await withModuleLoaderFixture(
+      {
+        "app/page.json": [
+          `import { value } from "../lib/value.json";`,
+          `export const pageValue = value;`,
+        ].join("\n"),
+        "lib/value.json": `export const value = "relative-value";`,
+      },
+      async ({ projectDir, tmpDir, config }) => {
+        const transformedPath = await transformModuleWithDeps(
+          join(projectDir, "app/page.json"),
+          tmpDir,
+          config.adapter,
+          config,
+        );
+        const transformedCode = await Deno.readTextFile(transformedPath);
+        const depPath = assertTransformedImportPath(transformedCode, "/lib/value.json");
+
+        assertStringIncludes(transformedPath, "/app/page.json");
+        assertEquals((await Deno.stat(depPath)).isFile, true);
+      },
+    );
+  });
+});
 
 describe("module-loader/isMissingModuleError (#2077)", () => {
   it("matches Node/Deno ERR_MODULE_NOT_FOUND by code", () => {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.721";
+export const VERSION = "0.1.722";


### PR DESCRIPTION

## Summary
- Add direct `transformModuleWithDeps` regression coverage for alias dependency rewriting.
- Add direct coverage for relative dependency rewriting to transformed file URLs.
- Keep the transform stage bypassed in fixtures so the tests do not require sanitizer opt-outs.
- Bump Veryfront Code release metadata to 0.1.722.

Part of #1987 and #1990.

## Verification
- deno test --frozen --no-check --allow-all src/rendering/orchestrator/module-loader/index.test.ts
- deno check --frozen src/rendering/orchestrator/module-loader/index.ts src/rendering/orchestrator/module-loader/index.test.ts src/utils/version-constant.ts
- deno task verify:quick
- git push pre-push hook: format, lint, typecheck, unit tests (2020 passed, 0 failed)
