### PR TITLE
Remove stale timer-handle casts from resume tests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.722",
+  "version": "0.1.723",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/agent/runtime/resume-session.test.ts
+++ b/src/agent/runtime/resume-session.test.ts
@@ -8,6 +8,28 @@ import {
   WaitNotPendingError,
 } from "./resume-session.ts";
 
+function createManualTimers(): {
+  callbacks: Array<() => void>;
+  setTimeoutFn: typeof setTimeout;
+  clearTimeoutFn: typeof clearTimeout;
+} {
+  const callbacks: Array<() => void> = [];
+  const setTimeoutFn: typeof setTimeout = (callback, _delay, ...args) => {
+    callbacks.push(() => {
+      if (typeof callback !== "function") {
+        throw new TypeError("String timer handlers are unsupported in resume-session tests");
+      }
+      callback(...args);
+    });
+    return globalThis.setTimeout(() => {}, 60_000);
+  };
+  return {
+    callbacks,
+    setTimeoutFn,
+    clearTimeoutFn: globalThis.clearTimeout.bind(globalThis),
+  };
+}
+
 describe("agent/runtime/resume-session", () => {
   it("accepts duplicate resume values and rejects conflicting ones", async () => {
     const manager = new RunResumeSessionManager<{ ok: boolean }>({
@@ -89,21 +111,18 @@ describe("agent/runtime/resume-session", () => {
   });
 
   it("expires waiting runs after the configured TTL", async () => {
-    const timerCallbacks: Array<() => void> = [];
+    const timers = createManualTimers();
     const manager = new RunResumeSessionManager<{ ok: boolean }>({
       waitingTtlMs: 1,
-      setTimeoutFn: ((callback: () => void) => {
-        timerCallbacks.push(callback);
-        return timerCallbacks.length as unknown as number;
-      }) as typeof setTimeout,
-      clearTimeoutFn: (() => {}) as typeof clearTimeout,
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
     });
     manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
 
     const pending = manager.waitForSignal("run_1", "tool_1");
     assertEquals(manager.getRunStatus("run_1"), "waiting");
 
-    timerCallbacks[0]?.();
+    timers.callbacks[0]?.();
 
     await assertRejects(
       async () => {
@@ -115,20 +134,17 @@ describe("agent/runtime/resume-session", () => {
   });
 
   it("evicts stale running sessions after the configured session TTL", () => {
-    const timerCallbacks: Array<() => void> = [];
+    const timers = createManualTimers();
     const manager = new RunResumeSessionManager<{ ok: boolean }>({
       sessionTtlMs: 1,
-      setTimeoutFn: ((callback: () => void) => {
-        timerCallbacks.push(callback);
-        return timerCallbacks.length as unknown as number;
-      }) as typeof setTimeout,
-      clearTimeoutFn: (() => {}) as typeof clearTimeout,
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
     });
 
     manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
     assertEquals(manager.getRunStatus("run_1"), "running");
 
-    timerCallbacks[0]?.();
+    timers.callbacks[0]?.();
 
     assertEquals(manager.getRunStatus("run_1"), null);
   });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.722";
+export const VERSION = "0.1.723";


### PR DESCRIPTION
## Summary
- Replace numeric fake timer handles in resume-session tests with a reusable manual timer helper that returns real dormant timer handles.
- Bind the injected clearTimeout function so the test stubs exercise the same receiver-sensitive clear path as production.
- Bump release metadata to 0.1.723.

Part of #1983.

## Verification
- deno test --frozen --no-check --allow-all src/agent/runtime/resume-session.test.ts
- deno check --frozen src/agent/runtime/resume-session.ts src/agent/runtime/resume-session.test.ts src/utils/version-constant.ts
- deno task verify:quick
- git push pre-push hook: format, lint, typecheck, unit tests (2019 passed, 0 failed)