### PR TITLE
Expose stale MDX cache cleanup failures

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.723",
+  "version": "0.1.724",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/transforms/mdx/esm-module-loader/cache/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path";
 import {
   clearModulePathCache,
+  getLocalFs,
   getModulePathCache,
   invalidateMdxEsmModule,
   invalidateModulePaths,
@@ -86,6 +87,66 @@ describe("MDX module path cache", () => {
       await Promise.all([
         remove(cacheDirA, { recursive: true }),
         remove(cacheDirB, { recursive: true }),
+      ]);
+      clearModulePathCache();
+    }
+  });
+
+  it("logs stale cached file removal failures during corrupted-cache invalidation", async () => {
+    clearModulePathCache();
+
+    const cacheDir = await makeTempDir({ prefix: "vf-mdx-remove-log-" });
+    const projectDir = await makeTempDir({ prefix: "vf-mdx-remove-log-project-" });
+    const filePath = join(projectDir, "app/page.tsx");
+    const cachedPath = join(cacheDir, buildMdxEsmModuleFileName("unresolved"));
+    const key = buildMdxEsmPathCacheKey("_vf_modules/app/page.js", "19.1.1");
+    const localFs = getLocalFs();
+    const originalRemove = localFs.remove.bind(localFs);
+    const originalDebug = log.debug.bind(log);
+    const debugEntries: Array<{ message: string; metadata: unknown[] }> = [];
+
+    try {
+      await writeTextFile(
+        cachedPath,
+        'import stale from "/_vf_modules/_veryfront/stale.mjs"; export default stale;',
+      );
+      await writeTextFile(join(cacheDir, "_index.json"), JSON.stringify({ [key]: cachedPath }));
+
+      localFs.remove = (path: string, options?: { recursive?: boolean }): Promise<void> => {
+        if (path === cachedPath) return Promise.reject(new Error("remove denied"));
+        return originalRemove(path, options);
+      };
+      log.debug = (message: string, ...metadata: unknown[]): void => {
+        debugEntries.push({ message, metadata });
+        originalDebug(message, ...metadata);
+      };
+
+      const result = await lookupMdxEsmCache(
+        filePath,
+        cacheDir,
+        projectDir,
+        undefined,
+        undefined,
+        "19.1.1",
+      );
+
+      assertEquals(result.status, "corrupted");
+      assertEquals(
+        debugEntries.some((entry) => {
+          const metadata = entry.metadata[0] as { error?: unknown } | undefined;
+          return entry.message.includes("Stale cached module cleanup failed") &&
+            metadata?.error instanceof Error &&
+            metadata.error.message === "remove denied";
+        }),
+        true,
+        "failed stale-file cleanup should be observable",
+      );
+    } finally {
+      localFs.remove = originalRemove;
+      log.debug = originalDebug;
+      await Promise.all([
+        remove(cacheDir, { recursive: true }).catch(() => {}),
+        remove(projectDir, { recursive: true }).catch(() => {}),
       ]);
       clearModulePathCache();
     }

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -511,7 +511,13 @@ export async function lookupMdxEsmCache(
       // Delete the stale file so it gets recreated
       try {
         await getLocalFs().remove(cachedPath);
-      } catch (_) { /* expected: stale cached file may already be removed */ }
+      } catch (error) {
+        logger.debug(`${LOG_PREFIX_MDX_LOADER} Stale cached module cleanup failed`, {
+          filePath,
+          cachedPath,
+          error,
+        });
+      }
       return {
         status: "corrupted",
         reason: "Unresolved _vf_modules imports in cached code",
@@ -547,7 +553,13 @@ export async function lookupMdxEsmCache(
       // Delete the stale file so it gets recreated
       try {
         await getLocalFs().remove(cachedPath);
-      } catch (_) { /* expected: stale cached file may already be removed */ }
+      } catch (error) {
+        logger.debug(`${LOG_PREFIX_MDX_LOADER} Stale cached module cleanup failed`, {
+          filePath,
+          cachedPath,
+          error,
+        });
+      }
       return {
         status: "corrupted",
         reason: `Missing file dependencies: ${missingDeps.slice(0, 3).join(", ")}`,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.723";
+export const VERSION = "0.1.724";


### PR DESCRIPTION
## Summary
- debug-log failed stale MDX ESM cache file cleanup in corrupted-cache invalidation paths
- add regression coverage for failed stale-file removal after unresolved _vf_modules detection
- bump Veryfront Code release metadata to 0.1.724

## Verification
- Red first: the new cache test failed before the production logging patch because failed stale-file cleanup was not observable
- deno test --frozen --no-check --allow-all src/transforms/mdx/esm-module-loader/cache/index.test.ts
- deno check --frozen src/transforms/mdx/esm-module-loader/cache/index.ts src/transforms/mdx/esm-module-loader/cache/index.test.ts src/utils/version-constant.ts
- deno task verify:quick
- git push pre-push hook: format, lint, typecheck, unit tests (2019 passed, 0 failed)

Part of #1988.