### PR TITLE
Log lazy sandbox startup failures during close

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.724",
+  "version": "0.1.725",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/sandbox/lazy-sandbox.ts
+++ b/src/sandbox/lazy-sandbox.ts
@@ -1,5 +1,6 @@
 import { REQUEST_ERROR } from "#veryfront/errors/error-registry.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
+import { logger } from "#veryfront/utils";
 import { resolveSandboxApiUrl, resolveSandboxAuthToken } from "./config.ts";
 import {
   type BackgroundCommand,
@@ -418,8 +419,11 @@ export class LazySandbox {
         if (this.ensurePromise) {
           try {
             await this.ensurePromise.promise;
-          } catch {
+          } catch (error) {
             // startup failure already handled by the caller path
+            logger.debug("Lazy sandbox startup failed while closing; continuing cleanup", {
+              error,
+            });
           }
         }
 

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -20,6 +20,7 @@ import { runWithProjectEnv } from "../server/project-env/storage.ts";
 import type { ExecStreamEvent } from "./sandbox.ts";
 import { Sandbox } from "./sandbox.ts";
 import { resolveDefaultSandboxRuntimeEndpoint } from "./lazy-sandbox.ts";
+import { logger } from "#veryfront/utils";
 
 // Mock fetch for testing
 const originalFetch = globalThis.fetch;
@@ -894,6 +895,75 @@ describe("Sandbox", () => {
       assertStringIncludes(fetchCalls[2]!.url, "/sandbox-sessions/sandbox-1");
       assertEquals(fetchCalls[2]!.init?.method, "DELETE");
       assertEquals(sandbox.isActive, false);
+    });
+
+    it("logs startup failures observed while close waits for in-flight ensure", async () => {
+      let resolveCreate!: (response: Response) => void;
+      let hasResolveCreate = false;
+      const originalDebug = logger.debug.bind(logger);
+      const debugEntries: Array<{ message: string; metadata: unknown[] }> = [];
+
+      logger.debug = (message: string, ...metadata: unknown[]): void => {
+        debugEntries.push({ message, metadata });
+        originalDebug(message, ...metadata);
+      };
+
+      try {
+        globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+          const url = typeof input === "string"
+            ? input
+            : input instanceof URL
+            ? input.toString()
+            : input.url;
+          fetchCalls.push({ url, init });
+
+          if (fetchCalls.length === 1) {
+            return new Promise<Response>((resolve) => {
+              resolveCreate = resolve;
+              hasResolveCreate = true;
+            });
+          }
+
+          throw new Error(`Unexpected fetch call: ${url}`);
+        }) as typeof fetch;
+
+        const sandbox = Sandbox.createLazy({
+          authToken: "test-token",
+          apiUrl: "https://api.test.com",
+        });
+
+        const ensurePromise = sandbox.ensure();
+        await Promise.resolve();
+
+        const closePromise = sandbox.close();
+
+        if (!hasResolveCreate) {
+          throw new Error("Expected create promise resolver to be captured");
+        }
+
+        resolveCreate(textResponse("create failed", 503));
+
+        await assertRejects(
+          () => ensurePromise,
+          Error,
+          "Failed to create sandbox",
+        );
+        await closePromise;
+
+        assertEquals(sandbox.isActive, false);
+        assertEquals(
+          debugEntries.some((entry) => {
+            const metadata = entry.metadata[0] as { error?: unknown } | undefined;
+            return entry.message.includes("startup failed while closing") &&
+              metadata?.error instanceof Error &&
+              metadata.error.message.includes("Failed to create sandbox");
+          }),
+          true,
+          "close should log the already-handled startup failure",
+        );
+      } finally {
+        logger.debug = originalDebug;
+      }
     });
 
     it("keeps an active sandbox session heartbeating until close", async () => {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.724";
+export const VERSION = "0.1.725";


### PR DESCRIPTION
## Summary
- debug-log lazy sandbox startup failures observed by close() while waiting for an in-flight ensure()
- add regression coverage for concurrent ensure()/close() when startup fails
- bump Veryfront Code release metadata to 0.1.725

## Verification
- Red first: the new sandbox close test failed before the logging patch because the handled startup failure was not observable
- deno test --frozen --no-check --allow-all src/sandbox/sandbox.test.ts
- deno check --frozen src/sandbox/lazy-sandbox.ts src/sandbox/sandbox.test.ts src/utils/version-constant.ts
- deno task verify:quick

Part of #1986.