### PR TITLE
Tighten RSC component prop boundary

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.725",
+  "version": "0.1.726",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/rendering/rsc/server-renderer/component-detector.test.ts
+++ b/src/rendering/rsc/server-renderer/component-detector.test.ts
@@ -1,5 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
+import { join } from "#veryfront/compat/path";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   getComponentId,
@@ -14,6 +15,31 @@ function makeComponent(overrides: Partial<RSCComponent> = {}): RSCComponent {
 }
 
 describe("rendering/rsc/server-renderer/component-detector", () => {
+  describe("type boundary", () => {
+    it("does not use explicit any for production RSC component props", async () => {
+      const sourceDir = join("src", "rendering", "rsc", "server-renderer");
+      const productionSources = [
+        "component-detector.ts",
+        "rsc-renderer.ts",
+        "tree-processor.ts",
+      ];
+
+      for (const source of productionSources) {
+        const contents = await Deno.readTextFile(join(sourceDir, source));
+        assertEquals(
+          contents.includes("React.ComponentType<any>"),
+          false,
+          `${source} should use the shared arbitrary-props component type`,
+        );
+        assertEquals(
+          contents.includes("no-explicit-any"),
+          false,
+          `${source} should not need an explicit-any lint suppression`,
+        );
+      }
+    });
+  });
+
   describe("isClientComponent", () => {
     it("should return false for null/undefined component", () => {
       assertEquals(isClientComponent(null as unknown as RSCComponent, new Map()), false);

--- a/src/rendering/rsc/server-renderer/component-detector.ts
+++ b/src/rendering/rsc/server-renderer/component-detector.ts
@@ -1,8 +1,9 @@
 import type * as React from "react";
 import type { ClientComponentMeta } from "../types.ts";
 
-// deno-lint-ignore no-explicit-any -- RSC components accept arbitrary props at runtime
-export type RSCComponent = React.ComponentType<any> & {
+export type RSCComponentProps = Record<string, unknown>;
+
+export type RSCComponent = React.ComponentType<RSCComponentProps> & {
   __rsc_client?: boolean;
   __rsc_id?: string;
   __rsc_path?: string;

--- a/src/rendering/rsc/server-renderer/rsc-renderer.ts
+++ b/src/rendering/rsc/server-renderer/rsc-renderer.ts
@@ -2,6 +2,7 @@ import type * as React from "react";
 import { serverLogger } from "#veryfront/utils";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import type { ClientComponentMeta, RSCPayload, RSCRendererOptions } from "../types.ts";
+import type { RSCComponentProps } from "./component-detector.ts";
 import { treeToHTML } from "./html-generator.ts";
 import { renderTree } from "./tree-processor.ts";
 
@@ -17,10 +18,9 @@ export class RSCRenderer {
     this.mode = options.mode ?? "development";
   }
 
-  renderToPayload(
-    // deno-lint-ignore no-explicit-any -- RSC components accept arbitrary props at runtime
-    Component: React.ComponentType<any> | React.ReactElement,
-    props: Record<string, unknown> = {},
+  renderToPayload<Props extends RSCComponentProps = RSCComponentProps>(
+    Component: React.ComponentType<Props> | React.ReactElement,
+    props: Props = {} as Props,
   ): Promise<RSCPayload> {
     return withSpan(
       "rsc.renderToPayload",

--- a/src/rendering/rsc/server-renderer/tree-processor.ts
+++ b/src/rendering/rsc/server-renderer/tree-processor.ts
@@ -7,6 +7,7 @@ import {
   isClientComponent,
   registerClientRef,
   type RSCComponent,
+  type RSCComponentProps,
 } from "./component-detector.ts";
 import { escapeHtml, renderAttributes, treeToHTML } from "./html-generator.ts";
 import { serializeProps } from "./prop-serializer.ts";
@@ -14,10 +15,9 @@ import { serializeProps } from "./prop-serializer.ts";
 const logger = serverLogger.component("rsc");
 
 /** Recursively renders a component tree to RSC nodes */
-export async function renderTree(
-  // deno-lint-ignore no-explicit-any -- RSC components accept arbitrary props at runtime
-  Component: React.ComponentType<any> | React.ReactElement | string | number | null | undefined,
-  props: Record<string, unknown>,
+export async function renderTree<Props extends RSCComponentProps = RSCComponentProps>(
+  Component: React.ComponentType<Props> | React.ReactElement | string | number | null | undefined,
+  props: Props,
   clientManifest: Map<string, ClientComponentMeta>,
   clientRefs: Map<string, string>,
 ): Promise<RSCNode> {
@@ -33,7 +33,7 @@ export async function renderTree(
     return { type: "html", html: escapeHtml(String(Component)) };
   }
 
-  const rscComponent = Component as RSCComponent;
+  const rscComponent = Component as unknown as RSCComponent;
 
   if (isClientComponent(rscComponent, clientManifest)) {
     const componentId = getComponentId(rscComponent);
@@ -48,8 +48,8 @@ export async function renderTree(
 
   try {
     const element = Component.prototype?.render
-      ? React.createElement(Component as React.ComponentClass, props)
-      : await (Component as React.FC)(props);
+      ? React.createElement(Component as React.ComponentClass<Props>, props)
+      : await (Component as React.FC<Props>)(props);
 
     if (!element) return { type: "html", html: "" };
     if (React.isValidElement(element)) return processElement(element, clientManifest, clientRefs);
@@ -100,7 +100,12 @@ export async function processElement(
   }
 
   if (typeof type === "function") {
-    return renderTree(type, props, clientManifest, clientRefs);
+    return renderTree(
+      type as React.ComponentType<RSCComponentProps>,
+      props,
+      clientManifest,
+      clientRefs,
+    );
   }
 
   const html = await renderToStringAdapter(element);

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.725";
+export const VERSION = "0.1.726";


### PR DESCRIPTION
## Summary
- replace production RSC `React.ComponentType<any>` boundaries with a named `Record<string, unknown>` props type
- keep `renderTree` and `renderToPayload` generic so strongly typed component callers still typecheck
- add a regression that scans production RSC server-renderer files for the old explicit-any boundary
- bump Veryfront Code release metadata to 0.1.726

## Verification
- Red first: `deno test --frozen --no-check --allow-read src/rendering/rsc/server-renderer/component-detector.test.ts` failed before implementation on `component-detector.ts` containing `React.ComponentType<any>`
- `deno test --frozen --no-check --allow-read src/rendering/rsc/server-renderer/component-detector.test.ts`
- `deno test --frozen --no-check --allow-all src/rendering/rsc/server-renderer/tree-processor.test.ts src/rendering/rsc/server-renderer/rsc-renderer.test.ts`
- `deno check --frozen src/rendering/rsc/server-renderer/component-detector.ts src/rendering/rsc/server-renderer/component-detector.test.ts src/rendering/rsc/server-renderer/tree-processor.ts src/rendering/rsc/server-renderer/tree-processor.test.ts src/rendering/rsc/server-renderer/rsc-renderer.ts src/rendering/rsc/server-renderer/rsc-renderer.test.ts src/utils/version-constant.ts`
- production source scan: no `React.ComponentType<any>` or old no-explicit-any RSC suppression remains in RSC server-renderer production files
- `deno task verify:quick`
- pre-push hook: format, lint, typecheck, unit tests (`2019 passed`, `0 failed`)

Part of #1987.