### PR TITLE
Log token API response cleanup failures

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.726",
+  "version": "0.1.727",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/platform/adapters/token/veryfront/api-client.test.ts
+++ b/src/platform/adapters/token/veryfront/api-client.test.ts
@@ -17,6 +17,25 @@ function createConfig(overrides: Partial<VeryfrontTokenConfig> = {}): VeryfrontT
 }
 
 describe("platform/adapters/token/veryfront/api-client", () => {
+  describe("cleanup observability", () => {
+    it("does not swallow failed response body cancellation without debug logging", async () => {
+      const contents = await Deno.readTextFile(
+        "src/platform/adapters/token/veryfront/api-client.ts",
+      );
+
+      assertEquals(
+        contents.includes("response.body?.cancel().catch(() => {})"),
+        false,
+        "non-OK response cleanup should not use an empty catch",
+      );
+      assertEquals(
+        contents.includes("cancelResponseBody"),
+        true,
+        "non-OK response cleanup should go through the shared debug-logging helper",
+      );
+    });
+  });
+
   describe("constructor", () => {
     it("should create client with valid config", () => {
       const client = new TokenStorageApiClient(createConfig());

--- a/src/platform/adapters/token/veryfront/api-client.ts
+++ b/src/platform/adapters/token/veryfront/api-client.ts
@@ -9,6 +9,20 @@ const logger = baseLogger.component("token-storage-api-client");
 /** Default timeout for token storage API requests (30 seconds) */
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
+async function cancelResponseBody(response: Response, operation: string): Promise<void> {
+  if (!response.body) return;
+
+  try {
+    await response.body.cancel();
+  } catch (error) {
+    logger.debug("Response body cancellation failed during token storage cleanup", {
+      operation,
+      status: response.status,
+      error,
+    });
+  }
+}
+
 export class TokenStorageApiClient {
   private config: VeryfrontTokenConfig;
 
@@ -30,7 +44,7 @@ export class TokenStorageApiClient {
       }
 
       if (!response.ok) {
-        await response.body?.cancel().catch(() => {});
+        await cancelResponseBody(response, "get");
         throw TOKEN_STORAGE_ERROR.create({
           detail: `Failed to get token: ${response.statusText}`,
           status: response.status,
@@ -58,7 +72,7 @@ export class TokenStorageApiClient {
       });
 
       if (!response.ok) {
-        await response.body?.cancel().catch(() => {});
+        await cancelResponseBody(response, "set");
         throw TOKEN_STORAGE_ERROR.create({
           detail: `Failed to set token: ${response.statusText}`,
           status: response.status,
@@ -82,7 +96,7 @@ export class TokenStorageApiClient {
         return;
       }
 
-      await response.body?.cancel().catch(() => {});
+      await cancelResponseBody(response, "delete");
       throw TOKEN_STORAGE_ERROR.create({
         detail: `Failed to delete token: ${response.statusText}`,
         status: response.status,
@@ -109,7 +123,7 @@ export class TokenStorageApiClient {
       });
 
       if (!response.ok) {
-        await response.body?.cancel().catch(() => {});
+        await cancelResponseBody(response, "list");
         throw TOKEN_STORAGE_ERROR.create({
           detail: `Failed to list tokens: ${response.statusText}`,
           status: response.status,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.726";
+export const VERSION = "0.1.727";


### PR DESCRIPTION
## Summary
- route token storage API response-body cleanup through a shared debug-logging helper
- keep cleanup best-effort and preserve the original token-storage errors
- add a regression that prevents empty response-body cancellation catches from returning
- bump Veryfront Code release metadata to 0.1.727

## Verification
- Red first: `deno test --frozen --no-check --allow-all src/platform/adapters/token/veryfront/api-client.test.ts` failed before implementation because `response.body?.cancel().catch(() => {})` was still present.
- `deno test --frozen --no-check --allow-all src/platform/adapters/token/veryfront/api-client.test.ts`
- `deno check --frozen src/platform/adapters/token/veryfront/api-client.ts src/platform/adapters/token/veryfront/api-client.test.ts src/utils/version-constant.ts`
- production source scan confirmed the token API client no longer contains `response.body?.cancel().catch(() => {})`
- `deno task verify:quick`
- pre-push hook: format, lint, typecheck, unit tests (`2019 passed`, `0 failed`)

Part of #1986 and #1990.