### PR TITLE
Log hosted lifecycle terminal hook failures

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.727",
+  "version": "0.1.728",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/agent/hosted/lifecycle.test.ts
+++ b/src/agent/hosted/lifecycle.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { __resetLoggerConfigForTests, type LogEntry } from "#veryfront/utils/logger/logger.ts";
 import {
   type HostedLifecycleAdapter,
   type HostedLifecycleTerminalState,
@@ -9,6 +10,41 @@ import {
 
 function createAbortSignal(): AbortSignal {
   return new AbortController().signal;
+}
+
+function captureConsoleLog(): { getOutput: () => string; restore: () => void } {
+  const originalLog = console.log;
+  const originalDebug = console.debug;
+  let capturedOutput = "";
+
+  const capture = (msg: string) => {
+    capturedOutput = msg;
+  };
+
+  console.log = capture;
+  console.debug = capture;
+
+  return {
+    getOutput: () => capturedOutput,
+    restore: () => {
+      console.log = originalLog;
+      console.debug = originalDebug;
+    },
+  };
+}
+
+async function withJsonDebugLogFormat<T>(fn: () => Promise<T>): Promise<T> {
+  Deno.env.set("LOG_FORMAT", "json");
+  Deno.env.set("LOG_LEVEL", "DEBUG");
+  __resetLoggerConfigForTests();
+
+  try {
+    return await fn();
+  } finally {
+    Deno.env.delete("LOG_FORMAT");
+    Deno.env.delete("LOG_LEVEL");
+    __resetLoggerConfigForTests();
+  }
 }
 
 describe("agent/hosted-lifecycle", () => {
@@ -224,39 +260,55 @@ describe("agent/hosted-lifecycle", () => {
   it("rethrows the original execution error even when terminal hooks fail", async () => {
     const calls: string[] = [];
     const executionError = new Error("stream exploded");
+    const { getOutput, restore } = captureConsoleLog();
 
-    await assertRejects(
-      () =>
-        runHostedLifecycle({
-          abortSignal: createAbortSignal(),
-          execution: {
-            stream: {
-              [Symbol.asyncIterator]() {
-                return {
-                  next: async () => {
-                    throw executionError;
+    try {
+      await withJsonDebugLogFormat(async () => {
+        await assertRejects(
+          () =>
+            runHostedLifecycle({
+              abortSignal: createAbortSignal(),
+              execution: {
+                stream: {
+                  [Symbol.asyncIterator]() {
+                    return {
+                      next: async () => {
+                        throw executionError;
+                      },
+                    };
                   },
-                };
+                },
+                waitForFinish: async () => {},
               },
-            },
-            waitForFinish: async () => {},
-          },
-          adapter: {
-            startRun: () => ({ runId: "run-1" }),
-            onTerminalState: () => {
-              calls.push("onTerminal");
-              throw new Error("observer failed");
-            },
-            finalizeRun: () => {
-              calls.push("finalize");
-            },
-          },
-          resolveTerminalState: () => ({ status: "completed" }),
-        }),
-      Error,
-      "stream exploded",
-    );
+              adapter: {
+                startRun: () => ({ runId: "run-1" }),
+                onTerminalState: () => {
+                  calls.push("onTerminal");
+                  throw new Error("observer failed");
+                },
+                finalizeRun: () => {
+                  calls.push("finalize");
+                },
+              },
+              resolveTerminalState: () => ({ status: "completed" }),
+            }),
+          Error,
+          "stream exploded",
+        );
+      });
+    } finally {
+      restore();
+    }
 
     assertEquals(calls, ["onTerminal", "finalize"]);
+    const entry = JSON.parse(getOutput()) as LogEntry;
+    assertEquals(entry.component, "hosted-lifecycle");
+    assertEquals(
+      entry.message,
+      "Hosted lifecycle terminal hooks failed while preserving execution error",
+    );
+    assertEquals(entry.level, "debug");
+    assertEquals(entry.context?.terminalStatus, "failed");
+    assertEquals(entry.context?.terminalErrorCode, "STREAM_ERROR");
   });
 });

--- a/src/agent/hosted/lifecycle.ts
+++ b/src/agent/hosted/lifecycle.ts
@@ -1,3 +1,7 @@
+import { serverLogger } from "#veryfront/utils";
+
+const logger = serverLogger.component("hosted-lifecycle");
+
 /** State for hosted lifecycle terminal. */
 export interface HostedLifecycleTerminalState {
   status: "completed" | "failed" | "cancelled";
@@ -149,7 +153,13 @@ export async function runHostedLifecycle<TRun, TChunk>(
       run,
       terminalState,
       adapter: options.adapter,
-    }).catch(() => undefined);
+    }).catch((terminalHookError) => {
+      logger.debug("Hosted lifecycle terminal hooks failed while preserving execution error", {
+        terminalStatus: terminalState.status,
+        terminalErrorCode: terminalState.terminalErrorCode ?? null,
+        terminalHookError,
+      });
+    });
 
     throw error;
   }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.727";
+export const VERSION = "0.1.728";


### PR DESCRIPTION
## Summary
- log hosted lifecycle terminal-hook failures during execution-error finalization instead of swallowing them
- preserve the original stream/execution error as the primary thrown error
- add focused lifecycle coverage that captures the debug log and verifies original-error precedence
- bump Veryfront Code release metadata to 0.1.728

## Verification
- `deno test --frozen --no-check --allow-all src/agent/hosted/lifecycle.test.ts`
- `deno check --frozen src/agent/hosted/lifecycle.ts src/agent/hosted/lifecycle.test.ts src/utils/version-constant.ts`
- `deno task verify:quick`
- pre-push hook: format, lint, typecheck, unit tests (`2019 passed`, `0 failed`)

Part of #1983 and #1990.