### PR TITLE
Log data stream reader cancellation failures

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.728",
+  "version": "0.1.729",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/agent/streaming/data-stream.test.ts
+++ b/src/agent/streaming/data-stream.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { __resetLoggerConfigForTests, type LogEntry } from "#veryfront/utils/logger/logger.ts";
 import {
   mergeToolCallInput,
   mergeToolInputDelta,
@@ -12,8 +13,43 @@ import {
 
 const encoder = new TextEncoder();
 
+function captureConsoleLog(): { getOutput: () => string; restore: () => void } {
+  const originalLog = console.log;
+  const originalDebug = console.debug;
+  let capturedOutput = "";
+
+  const capture = (msg: string) => {
+    capturedOutput = msg;
+  };
+
+  console.log = capture;
+  console.debug = capture;
+
+  return {
+    getOutput: () => capturedOutput,
+    restore: () => {
+      console.log = originalLog;
+      console.debug = originalDebug;
+    },
+  };
+}
+
 function encodeEvent(payload: Record<string, unknown>): Uint8Array {
   return encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+async function withJsonDebugLogFormat<T>(fn: () => Promise<T>): Promise<T> {
+  Deno.env.set("LOG_FORMAT", "json");
+  Deno.env.set("LOG_LEVEL", "DEBUG");
+  __resetLoggerConfigForTests();
+
+  try {
+    return await fn();
+  } finally {
+    Deno.env.delete("LOG_FORMAT");
+    Deno.env.delete("LOG_LEVEL");
+    __resetLoggerConfigForTests();
+  }
 }
 
 describe("agent/data-stream", () => {
@@ -70,6 +106,35 @@ describe("agent/data-stream", () => {
       Error,
       "stream exploded",
     );
+  });
+
+  it("debug logs reader cancellation failures when the consumer stops early", async () => {
+    const { getOutput, restore } = captureConsoleLog();
+
+    try {
+      await withJsonDebugLogFormat(async () => {
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encodeEvent({ type: "message-start", messageId: "assistant-1" }));
+          },
+          cancel() {
+            throw new Error("cancel failed");
+          },
+        });
+
+        for await (const event of streamDataStreamEvents(stream)) {
+          assertEquals(event, { type: "message-start", messageId: "assistant-1" });
+          break;
+        }
+      });
+    } finally {
+      restore();
+    }
+
+    const entry = JSON.parse(getOutput()) as LogEntry;
+    assertEquals(entry.component, "agent-data-stream");
+    assertEquals(entry.level, "debug");
+    assertEquals(entry.message, "Data stream reader cancellation failed during cleanup");
   });
 
   it("normalizes streamed tool input placeholders consistently", () => {

--- a/src/agent/streaming/data-stream.ts
+++ b/src/agent/streaming/data-stream.ts
@@ -1,4 +1,7 @@
+import { serverLogger } from "#veryfront/utils";
 import type { AgUiRuntimeStreamEvent } from "../ag-ui/browser-encoder.ts";
+
+const logger = serverLogger.component("agent-data-stream");
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -208,7 +211,11 @@ export async function* streamDataStreamEvents(
     }
   } finally {
     if (!completed) {
-      await reader.cancel().catch(() => undefined);
+      try {
+        await reader.cancel();
+      } catch (error) {
+        logger.debug("Data stream reader cancellation failed during cleanup", { error });
+      }
     }
     reader.releaseLock();
   }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.728";
+export const VERSION = "0.1.729";


### PR DESCRIPTION
## Summary
- log data-stream reader cancellation failures during early-stop cleanup instead of swallowing them
- keep reader cancellation best-effort and preserve stream iteration behavior
- add a red-first regression that captures the debug log when underlying `cancel()` rejects
- bump Veryfront Code release metadata to 0.1.729

## Verification
- Red first: `deno test --frozen --no-check --allow-all src/agent/streaming/data-stream.test.ts` failed before implementation because no debug log was emitted for a rejecting `cancel()`.
- `deno test --frozen --no-check --allow-all src/agent/streaming/data-stream.test.ts`
- `deno check --frozen src/agent/streaming/data-stream.ts src/agent/streaming/data-stream.test.ts src/utils/version-constant.ts`
- `deno task verify:quick`

Part of #1983 and #1990.