### PR TITLE
Log SSR HEAD response cancellation failures

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.729",
+  "version": "0.1.730",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/server/handlers/request/ssr/ssr-response-builder.test.ts
+++ b/src/server/handlers/request/ssr/ssr-response-builder.test.ts
@@ -1,11 +1,47 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { __resetLoggerConfigForTests, type LogEntry } from "#veryfront/utils/logger/logger.ts";
 import { buildSSRResponse } from "./ssr-response-builder.ts";
 import type { SSRRenderResult } from "../../../services/rendering/ssr.service.ts";
 import { ResponseBuilder } from "#veryfront/security/http/response/builder.ts";
 import type { HandlerContext } from "../../types.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+
+function captureConsoleLog(): { getOutput: () => string; restore: () => void } {
+  const originalLog = console.log;
+  const originalDebug = console.debug;
+  let capturedOutput = "";
+
+  const capture = (msg: string) => {
+    capturedOutput = msg;
+  };
+
+  console.log = capture;
+  console.debug = capture;
+
+  return {
+    getOutput: () => capturedOutput,
+    restore: () => {
+      console.log = originalLog;
+      console.debug = originalDebug;
+    },
+  };
+}
+
+async function withJsonDebugLogFormat<T>(fn: () => Promise<T>): Promise<T> {
+  Deno.env.set("LOG_FORMAT", "json");
+  Deno.env.set("LOG_LEVEL", "DEBUG");
+  __resetLoggerConfigForTests();
+
+  try {
+    return await fn();
+  } finally {
+    Deno.env.delete("LOG_FORMAT");
+    Deno.env.delete("LOG_LEVEL");
+    __resetLoggerConfigForTests();
+  }
+}
 
 function createMockAdapter(): RuntimeAdapter {
   return {
@@ -200,6 +236,38 @@ describe("server/handlers/request/ssr/ssr-response-builder", () => {
       const response = await buildSSRResponse(req, ctx, result, builder);
       assertEquals(response.status, 200);
       assertEquals(response.body, null);
+    });
+
+    it("debug logs streaming HEAD body cancellation failures", async () => {
+      const { getOutput, restore } = captureConsoleLog();
+
+      try {
+        await withJsonDebugLogFormat(async () => {
+          const stream = new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("<p>Streamed</p>"));
+            },
+            cancel() {
+              throw new Error("head cancel failed");
+            },
+          });
+          const req = new Request("http://localhost/", { method: "HEAD" });
+          const ctx = makeCtx();
+          const result = makeResult({ isStreaming: true, stream, html: undefined });
+          const builder = new ResponseBuilder();
+
+          const response = await buildSSRResponse(req, ctx, result, builder);
+          assertEquals(response.status, 200);
+          assertEquals(response.body, null);
+        });
+      } finally {
+        restore();
+      }
+
+      const entry = JSON.parse(getOutput()) as LogEntry;
+      assertEquals(entry.component, "ssr-response-builder");
+      assertEquals(entry.level, "debug");
+      assertEquals(entry.message, "SSR response body cancellation failed during HEAD cleanup");
     });
 
     it("includes etag header when etag is provided (buffered)", async () => {

--- a/src/server/handlers/request/ssr/ssr-response-builder.ts
+++ b/src/server/handlers/request/ssr/ssr-response-builder.ts
@@ -14,6 +14,19 @@ import type { SSRRenderResult } from "../../../services/rendering/ssr.service.ts
 import { ErrorPages } from "../../../utils/error-html.ts";
 import type { ResponseBuilder } from "#veryfront/security/http/response/builder.ts";
 import { addNonceToHtmlStream, addNonceToHtmlTags } from "#veryfront/html/nonce-injection.ts";
+import { serverLogger } from "#veryfront/utils";
+
+const logger = serverLogger.component("ssr-response-builder");
+
+async function cancelHeadResponseBody(body: ReadableStream<Uint8Array> | null): Promise<void> {
+  if (!body) return;
+
+  try {
+    await body.cancel();
+  } catch (error) {
+    logger.debug("SSR response body cancellation failed during HEAD cleanup", { error });
+  }
+}
 
 /**
  * Build an HTTP response from an SSR render result.
@@ -45,7 +58,7 @@ export async function buildSSRResponse(
 
     if (!isHeadRequest) return response;
 
-    await response.body?.cancel().catch(() => {});
+    await cancelHeadResponseBody(response.body);
     return new Response(null, { status: response.status, headers: response.headers });
   }
 
@@ -83,6 +96,6 @@ export async function buildSSRResponse(
 
   if (!isHeadRequest || !finalResponse.body) return finalResponse;
 
-  await finalResponse.body.cancel().catch(() => {});
+  await cancelHeadResponseBody(finalResponse.body);
   return new Response(null, { status: finalResponse.status, headers: finalResponse.headers });
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.729";
+export const VERSION = "0.1.730";


### PR DESCRIPTION
## Summary
- log SSR HEAD response-body cancellation failures instead of swallowing them in cleanup
- keep HEAD response cleanup best-effort and preserve null-body/status semantics
- add a red-first regression for rejecting streaming-body cancellation
- bump Veryfront Code release metadata to 0.1.730

## Verification
- Red first: `deno test --frozen --no-check --allow-all src/server/handlers/request/ssr/ssr-response-builder.test.ts` failed before implementation because no debug log was emitted.
- `deno test --frozen --no-check --allow-all src/server/handlers/request/ssr/ssr-response-builder.test.ts`
- `deno check --frozen src/server/handlers/request/ssr/ssr-response-builder.ts src/server/handlers/request/ssr/ssr-response-builder.test.ts src/utils/version-constant.ts`
- `deno task verify:quick`
- pre-push hook: format, lint, typecheck, unit tests (`2019 passed`, `0 failed`)

Part of #1985 and #1990.