### PR TITLE
Log dev error POST failures

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.730",
+  "version": "0.1.731",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/html/hydration-script-builder/dev-error-logger.test.ts
+++ b/src/html/hydration-script-builder/dev-error-logger.test.ts
@@ -46,6 +46,13 @@ describe("hydration-script-builder/dev-error-logger", () => {
       assertEquals(result.includes("/_veryfront/log"), true);
     });
 
+    it("should make failed log POSTs observable without blocking", () => {
+      const result = generateDevErrorLoggerScript();
+      assertEquals(result.includes(".catch((error) => {"), true);
+      assertEquals(result.includes("console.debug?.('[Veryfront] dev log POST failed'"), true);
+      assertEquals(result.includes(".catch(() => {})"), false);
+    });
+
     it("should override console.error", () => {
       const result = generateDevErrorLoggerScript();
       assertEquals(result.includes("console.error"), true);

--- a/src/html/hydration-script-builder/dev-error-logger.ts
+++ b/src/html/hydration-script-builder/dev-error-logger.ts
@@ -16,7 +16,9 @@ export function generateDevErrorLoggerScript(nonce?: string): string {
               details,
               timestamp: new Date().toISOString()
             })
-          }).catch(() => {});
+          }).catch((error) => {
+            console.debug?.('[Veryfront] dev log POST failed', error);
+          });
         } catch (_) { /* expected: fire-and-forget log, network errors ignored */ }
       };
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.730";
+export const VERSION = "0.1.731";


### PR DESCRIPTION
## Summary
- debug-log rejected fire-and-forget dev error log POSTs instead of swallowing them
- keep client error reporting non-blocking for page runtime behavior
- add a red-first generated-script regression preventing the no-op rejection handler from returning
- bump Veryfront Code release metadata to 0.1.731

## Verification
- Red first: `deno test --frozen --no-check --allow-all src/html/hydration-script-builder/dev-error-logger.test.ts` failed before implementation because the generated script still used `.catch(() => {})` and emitted no debug signal.
- `deno test --frozen --no-check --allow-all src/html/hydration-script-builder/dev-error-logger.test.ts`
- `deno check --frozen src/html/hydration-script-builder/dev-error-logger.ts src/html/hydration-script-builder/dev-error-logger.test.ts src/utils/version-constant.ts`
- `git diff --check`
- `deno task verify:quick`
- pre-push hook: format, lint, typecheck, unit tests (`2019 passed`, `0 failed`)

Part of #1987 and #1990.