### PR TITLE
Log file log subscriber write failures

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.732",
+  "version": "0.1.733",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/observability/file-log-subscriber.test.ts
+++ b/src/observability/file-log-subscriber.test.ts
@@ -230,7 +230,7 @@ describe("observability/file-log-subscriber", () => {
       const content = await Deno.readTextFile(logPath);
       const lines = content.trim().split("\n");
       assertEquals(lines.length, 1);
-      assertEquals(JSON.parse(lines[0]).message, "before");
+      assertEquals(JSON.parse(lines[0] ?? "").message, "before");
     });
 
     it("should include data field in text format", async () => {
@@ -248,6 +248,34 @@ describe("observability/file-log-subscriber", () => {
       assertEquals(content.includes('"key":"value"'), true);
 
       await sub.close();
+    });
+
+    it("should log non-permission write queue failures", async () => {
+      const dir = await makeTempDir();
+      const sub = new FileLogSubscriber(makeConfig({ path: dir }));
+      const originalError = console.error;
+      const errors: string[] = [];
+      console.error = (...args: unknown[]) => {
+        errors.push(args.map(String).join(" "));
+      };
+
+      try {
+        const buf = new LogBuffer();
+        buf.subscribe(sub.getSubscriber());
+
+        buf.info("cannot write to a directory", "test");
+        await sub.flush();
+      } finally {
+        console.error = originalError;
+      }
+
+      assertEquals(
+        errors.some((line) =>
+          line.includes("[FileLogSubscriber] Failed writing to") &&
+          line.includes("File logging will continue")
+        ),
+        true,
+      );
     });
   });
 });

--- a/src/observability/file-log-subscriber.ts
+++ b/src/observability/file-log-subscriber.ts
@@ -77,7 +77,12 @@ export class FileLogSubscriber {
   }
 
   private enqueue(entry: LogEntry): void {
-    this.writeQueue = this.writeQueue.then(() => this.writeEntry(entry)).catch(() => {});
+    this.writeQueue = this.writeQueue.then(() => this.writeEntry(entry)).catch((error) => {
+      console.error(
+        `[FileLogSubscriber] Failed writing to ${this.config.path}. File logging will continue.`,
+        error instanceof Error ? error.message : String(error),
+      );
+    });
   }
 
   private async writeEntry(entry: LogEntry): Promise<void> {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.732";
+export const VERSION = "0.1.733";


### PR DESCRIPTION
## Summary
- report non-permission file-log write/open failures instead of swallowing the queue rejection
- keep the file-log queue recoverable so subscriber failures still do not break callers or log buffering
- add a red-first regression for a file log target that cannot be opened as a file
- bump Veryfront Code release metadata to `0.1.733`

## Verification
- Red first: `deno test --frozen --no-check --allow-all src/observability/file-log-subscriber.test.ts` failed before implementation because no write-failure diagnostic was emitted.
- `deno test --frozen --no-check --allow-all src/observability/file-log-subscriber.test.ts`
- `deno check --frozen src/observability/file-log-subscriber.ts src/observability/file-log-subscriber.test.ts src/utils/version-constant.ts`
- `git diff --check`
- pre-push hook: format, lint, typecheck, unit tests (`2019 passed`, `0 failed`)

Part of #1990.
