### PR TITLE
Extract module loader dependency resolution

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.733",
+  "version": "0.1.734",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/rendering/orchestrator/module-loader/dependency-resolver.test.ts
+++ b/src/rendering/orchestrator/module-loader/dependency-resolver.test.ts
@@ -1,0 +1,90 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { dirname, join } from "#veryfront/compat/path/index.ts";
+import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
+import {
+  resolveModuleDependencies,
+  rewriteResolvedDependencyImports,
+} from "./dependency-resolver.ts";
+
+async function withDependencyFixture<T>(
+  files: Record<string, string>,
+  test: (fixture: { projectDir: string }) => Promise<T>,
+): Promise<T> {
+  const projectDir = await Deno.makeTempDir({ prefix: "vf-module-deps-project-" });
+
+  try {
+    for (const [relativePath, content] of Object.entries(files)) {
+      const absolutePath = join(projectDir, relativePath);
+      await Deno.mkdir(dirname(absolutePath), { recursive: true });
+      await Deno.writeTextFile(absolutePath, content);
+    }
+
+    return await test({ projectDir });
+  } finally {
+    await Deno.remove(projectDir, { recursive: true }).catch(() => undefined);
+  }
+}
+
+describe("module-loader/dependency-resolver", () => {
+  it("resolves alias and relative imports while ignoring already transformed file imports", async () => {
+    await withDependencyFixture(
+      {
+        "app/page.tsx": [
+          `import { Button } from "@/Button";`,
+          `import { value } from "../lib/value";`,
+          `import { cached } from "file:///tmp/cached.js";`,
+          `export const page = Button + value + cached;`,
+        ].join("\n"),
+        "components/Button.tsx": `export const Button = "button";`,
+        "lib/value.ts": `export const value = "value";`,
+      },
+      async ({ projectDir }) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.tsx");
+        const fileContent = await Deno.readTextFile(filePath);
+
+        const deps = await resolveModuleDependencies({
+          adapter,
+          fileContent,
+          filePath,
+          projectDir,
+        });
+
+        assertEquals(deps.length, 2);
+        assertStringIncludes(deps[0]?.depFilePath ?? "", "/components/Button.tsx");
+        assertStringIncludes(deps[1]?.depFilePath ?? "", "/lib/value.ts");
+      },
+    );
+  });
+
+  it("rewrites transformed dependency imports to file URLs", () => {
+    const source = [
+      `import { Button } from "@/Button";`,
+      `import { value } from "../lib/value";`,
+    ].join("\n");
+
+    const rewritten = rewriteResolvedDependencyImports(source, [
+      {
+        full: `from "@/Button"`,
+        path: "@/Button",
+        relativePath: "Button",
+        depFilePath: "/project/components/Button.tsx",
+        depTempPath: "/tmp/components/Button.abc.js",
+        isLocalLib: false,
+      },
+      {
+        full: `from "../lib/value"`,
+        path: "../lib/value",
+        relativePath: "../lib/value",
+        depFilePath: "/project/lib/value.ts",
+        depTempPath: "/tmp/lib/value.def.js",
+        isLocalLib: false,
+      },
+    ]);
+
+    assertStringIncludes(rewritten, `from "file:///tmp/components/Button.abc.js"`);
+    assertStringIncludes(rewritten, `from "file:///tmp/lib/value.def.js"`);
+  });
+});

--- a/src/rendering/orchestrator/module-loader/dependency-resolver.ts
+++ b/src/rendering/orchestrator/module-loader/dependency-resolver.ts
@@ -1,0 +1,149 @@
+import { dirname, join, normalize } from "#veryfront/compat/path/index.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { parallelMap, rendererLogger } from "#veryfront/utils";
+import { findSourceFile } from "../file-resolver/index.ts";
+
+const logger = rendererLogger.component("module-loader");
+
+type AliasImport = { full: string; path: string };
+type RelativeImport = { full: string; path: string; fromDir: string };
+
+/** Resolved local module dependency discovered in a source module. */
+export type ResolvedModuleDependency = {
+  full: string;
+  path: string;
+  relativePath: string;
+  depFilePath: string | null;
+  isLocalLib: boolean;
+};
+
+/** Resolved dependency after its source module has been transformed to a temp file. */
+export type TransformedModuleDependency = ResolvedModuleDependency & {
+  depTempPath: string;
+};
+
+/** Input for resolving local module dependencies from source code. */
+export interface ResolveModuleDependenciesInput {
+  fileContent: string;
+  filePath: string;
+  projectDir: string;
+  adapter: RuntimeAdapter;
+}
+
+function collectAliasImports(fileContent: string): AliasImport[] {
+  return [...fileContent.matchAll(/from\s+["'](@\/[^"']+)["']/g)].map((m) => ({
+    full: m[0],
+    path: m[1] ?? "",
+  }));
+}
+
+function collectRelativeImports(fileContent: string, fileDir: string): RelativeImport[] {
+  return [...fileContent.matchAll(/from\s+["'](\.\.?\/[^"']+)["']/g)]
+    .map((m) => ({ full: m[0], path: m[1] ?? "", fromDir: fileDir }))
+    // Ignore already-transformed file:// imports.
+    .filter((imp) => !imp.path.includes("file://"));
+}
+
+async function resolveAliasImport(
+  imp: AliasImport,
+  projectDir: string,
+  adapter: RuntimeAdapter,
+): Promise<ResolvedModuleDependency> {
+  const relativePath = imp.path.substring(2); // Remove @/ prefix.
+
+  const depFilePath = (await findSourceFile(relativePath, projectDir, adapter)) ??
+    (await findSourceFile(`components/${relativePath}`, projectDir, adapter));
+
+  return { ...imp, relativePath, depFilePath, isLocalLib: false };
+}
+
+async function resolveRelativeImport(
+  imp: RelativeImport,
+  adapter: RuntimeAdapter,
+): Promise<ResolvedModuleDependency> {
+  const basePath = normalize(join(imp.fromDir, imp.path));
+
+  logger.debug("Resolving relative import:", {
+    path: imp.path,
+    fromDir: imp.fromDir,
+    basePath,
+  });
+
+  const extensions = [".tsx", ".ts", ".jsx", ".js", ".mdx"];
+  let depFilePath: string | null = null;
+
+  if (await adapter.fs.exists(basePath)) {
+    const stat = await adapter.fs.stat(basePath);
+    if (!stat.isDirectory) {
+      depFilePath = basePath;
+    }
+  }
+
+  if (!depFilePath) {
+    for (const ext of extensions) {
+      const pathWithExt = basePath + ext;
+      if (await adapter.fs.exists(pathWithExt)) {
+        depFilePath = pathWithExt;
+        break;
+      }
+    }
+  }
+
+  if (!depFilePath) {
+    for (const ext of extensions) {
+      const indexPath = join(basePath, `index${ext}`);
+      if (await adapter.fs.exists(indexPath)) {
+        depFilePath = indexPath;
+        break;
+      }
+    }
+  }
+
+  return {
+    full: imp.full,
+    path: imp.path,
+    relativePath: imp.path,
+    depFilePath,
+    isLocalLib: false,
+  };
+}
+
+/** Resolves @/ alias and relative local imports from a source module. */
+export async function resolveModuleDependencies(
+  input: ResolveModuleDependenciesInput,
+): Promise<ResolvedModuleDependency[]> {
+  const fileDir = dirname(input.filePath);
+  const aliasImports = collectAliasImports(input.fileContent);
+  const relativeImports = collectRelativeImports(input.fileContent, fileDir);
+
+  logger.debug("Processing file:", {
+    filePath: input.filePath,
+    aliasImportsCount: aliasImports.length,
+    relativeImportsCount: relativeImports.length,
+    aliasImports: aliasImports.map((i) => i.path),
+    relativeImports: relativeImports.map((i) => i.path),
+  });
+
+  const resolvedAliasDeps = await parallelMap(
+    aliasImports,
+    (imp) => resolveAliasImport(imp, input.projectDir, input.adapter),
+  );
+  const resolvedRelativeDeps = await parallelMap(
+    relativeImports,
+    (imp) => resolveRelativeImport(imp, input.adapter),
+  );
+
+  return [...resolvedAliasDeps, ...resolvedRelativeDeps];
+}
+
+/** Rewrites resolved local imports to their transformed temp file URLs. */
+export function rewriteResolvedDependencyImports(
+  fileContent: string,
+  transformedDeps: TransformedModuleDependency[],
+): string {
+  let rewritten = fileContent;
+  for (const dep of transformedDeps) {
+    rewritten = rewritten.replace(dep.full, `from "file://${dep.depTempPath}"`);
+  }
+  return rewritten;
+}

--- a/src/rendering/orchestrator/module-loader/index.ts
+++ b/src/rendering/orchestrator/module-loader/index.ts
@@ -7,10 +7,9 @@
  * @module rendering/orchestrator/module-loader
  */
 
-import { parallelMap, rendererLogger } from "#veryfront/utils";
+import { rendererLogger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
-import { findSourceFile } from "../file-resolver/index.ts";
 import { transformToESM } from "#veryfront/transforms/esm-transform.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { getProjectTmpDir } from "#veryfront/modules/react-loader/index.ts";
@@ -23,7 +22,7 @@ import {
 import { TRANSFORM_DISTRIBUTED_TTL_SEC } from "#veryfront/utils/constants/cache.ts";
 import { validateCachedBundlesByManifestOrCode } from "#veryfront/transforms/esm/cached-bundle-validation.ts";
 import { getHttpBundleCacheDir, getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
-import { dirname, join, normalize } from "#veryfront/compat/path/index.ts";
+import { join } from "#veryfront/compat/path/index.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import {
   getModulePathCache,
@@ -32,6 +31,10 @@ import {
   saveModulePathCache,
 } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
 import { buildMdxEsmPathCacheKey } from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
+import {
+  resolveModuleDependencies,
+  rewriteResolvedDependencyImports,
+} from "./dependency-resolver.ts";
 
 const logger = rendererLogger.component("module-loader");
 
@@ -89,85 +92,6 @@ async function ensureDir(adapter: RuntimeAdapter, dir: string): Promise<void> {
     createdDirs.add(dir);
     pruneCreatedDirs();
   }
-}
-
-type AliasImport = { full: string; path: string };
-type RelativeImport = { full: string; path: string; fromDir: string };
-type ResolvedDep = {
-  full: string;
-  path: string;
-  relativePath: string;
-  depFilePath: string | null;
-  isLocalLib: boolean;
-};
-
-async function resolveAliasImport(
-  imp: AliasImport,
-  projectDir: string,
-  adapter: RuntimeAdapter,
-): Promise<ResolvedDep> {
-  const relativePath = imp.path.substring(2); // Remove @/ prefix
-
-  const depFilePath = (await findSourceFile(relativePath, projectDir, adapter)) ??
-    (await findSourceFile(`components/${relativePath}`, projectDir, adapter));
-
-  return { ...imp, relativePath, depFilePath, isLocalLib: false };
-}
-
-async function resolveRelativeImport(
-  imp: RelativeImport,
-  adapter: RuntimeAdapter,
-): Promise<ResolvedDep> {
-  // Resolve the path relative to the file's directory and normalize to resolve ..
-  const basePath = normalize(join(imp.fromDir, imp.path));
-
-  logger.debug("Resolving relative import:", {
-    path: imp.path,
-    fromDir: imp.fromDir,
-    basePath,
-  });
-
-  // Try to find the source file with various extensions
-  const extensions = [".tsx", ".ts", ".jsx", ".js", ".mdx"];
-  let depFilePath: string | null = null;
-
-  // First try the exact path (in case it already has an extension)
-  if (await adapter.fs.exists(basePath)) {
-    const stat = await adapter.fs.stat(basePath);
-    if (!stat.isDirectory) {
-      depFilePath = basePath;
-    }
-  }
-
-  // Try with extensions
-  if (!depFilePath) {
-    for (const ext of extensions) {
-      const pathWithExt = basePath + ext;
-      if (await adapter.fs.exists(pathWithExt)) {
-        depFilePath = pathWithExt;
-        break;
-      }
-    }
-  }
-
-  // Try index files if path is a directory
-  if (!depFilePath) {
-    for (const ext of extensions) {
-      const indexPath = join(basePath, `index${ext}`);
-      if (await adapter.fs.exists(indexPath)) {
-        depFilePath = indexPath;
-        break;
-      }
-    }
-  }
-
-  return {
-    full: imp.full,
-    path: imp.path,
-    relativePath: imp.path,
-    depFilePath,
-    isLocalLib: false,
-  };
 }
 
 /**
@@ -251,47 +175,15 @@ export async function transformModuleWithDeps(
   const readAdapter = useLocalAdapter ? localAdapter : adapter;
   let fileContent = decodeFileContent(await readAdapter.fs.readFile(filePath));
 
-  const fileDir = dirname(filePath);
-
-  // Match @/ alias imports
-  const aliasImports: AliasImport[] = [...fileContent.matchAll(/from\s+["'](@\/[^"']+)["']/g)].map(
-    (m) => ({ full: m[0], path: m[1] ?? "" }),
-  );
-
-  // Match relative imports (./ and ../) - exclude npm:, http://, https://, file://
-  const relativeImports: RelativeImport[] = [
-    ...fileContent.matchAll(/from\s+["'](\.\.?\/[^"']+)["']/g),
-  ]
-    .map((m) => ({ full: m[0], path: m[1] ?? "", fromDir: fileDir }))
-    // Filter out already-transformed file:// imports
-    .filter((imp) => !imp.path.includes("file://"));
-
-  logger.debug("Processing file:", {
+  const resolvedDeps = await resolveModuleDependencies({
+    adapter,
+    fileContent,
     filePath,
-    aliasImportsCount: aliasImports.length,
-    relativeImportsCount: relativeImports.length,
-    aliasImports: aliasImports.map((i) => i.path),
-    relativeImports: relativeImports.map((i) => i.path),
+    projectDir,
   });
 
-  // Resolve alias imports
-  const resolvedAliasDeps = await parallelMap(
-    aliasImports,
-    (imp) => resolveAliasImport(imp, projectDir, adapter),
-  );
-
-  // Resolve relative imports
-  const resolvedRelativeDeps = await parallelMap(
-    relativeImports,
-    (imp) => resolveRelativeImport(imp, adapter),
-  );
-
-  // Combine all resolved dependencies
-  const resolvedDeps = [...resolvedAliasDeps, ...resolvedRelativeDeps];
-
-  const transformedDeps = await parallelMap(
-    resolvedDeps.filter((d) => d.depFilePath),
-    async (dep) => {
+  const transformedDeps = await Promise.all(
+    resolvedDeps.filter((d) => d.depFilePath).map(async (dep) => {
       logger.debug("Found dependency:", {
         path: dep.path,
         depFilePath: dep.depFilePath,
@@ -307,11 +199,11 @@ export async function transformModuleWithDeps(
       );
 
       return { ...dep, depTempPath };
-    },
+    }),
   );
 
+  fileContent = rewriteResolvedDependencyImports(fileContent, transformedDeps);
   for (const dep of transformedDeps) {
-    fileContent = fileContent.replace(dep.full, `from "file://${dep.depTempPath}"`);
     logger.debug("Replaced import:", {
       path: dep.path,
       depTempPath: dep.depTempPath,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.733";
+export const VERSION = "0.1.734";


### PR DESCRIPTION
## Summary
- extract module-loader local dependency parse/resolve/rewrite logic into `dependency-resolver.ts`
- preserve `transformModuleWithDeps` public behavior and existing import rewrite flow
- add focused helper coverage for alias/relative dependency resolution and transformed import rewriting
- bump release metadata to `0.1.734`

## Verification
- Red first: focused dependency-resolver test failed before implementation because `dependency-resolver.ts` did not exist.
- `deno test --frozen --no-check --allow-all src/rendering/orchestrator/module-loader/dependency-resolver.test.ts src/rendering/orchestrator/module-loader/index.test.ts`
- `deno check --frozen src/rendering/orchestrator/module-loader/dependency-resolver.ts src/rendering/orchestrator/module-loader/dependency-resolver.test.ts src/rendering/orchestrator/module-loader/index.ts src/rendering/orchestrator/module-loader/index.test.ts src/utils/version-constant.ts`
- `git diff --check`
- `deno task verify:quick`
- pre-push hook: format, lint, typecheck, unit tests (`2020 passed`, `0 failed`)

Part of #2219.