### PR TITLE
Extract module fetcher path-cache lookup

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.735",
+  "version": "0.1.736",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
@@ -22,18 +22,17 @@ import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 import type { ModuleFetcherContext } from "../types.ts";
-import { getLocalFs, getModulePathCache } from "../cache/index.ts";
+import { getModulePathCache } from "../cache/index.ts";
 import { hashString } from "../utils/hash.ts";
 import { resolveModuleFile } from "../resolution/file-finder.ts";
 import { buildMissingModuleError } from "../missing-module.ts";
 import { getTransformCacheKey, getVersionedPathCacheKey } from "./cache-keys.ts";
 import { rewriteDntImports, rewriteVeryfrontImports } from "./import-rewriter.ts";
 import { findNestedImports, processNestedImports } from "./nested-imports.ts";
-import { validateCachedModule } from "./framework-validator.ts";
-import { recordModuleToSession } from "./render-sessions.ts";
 import { readDistributedCache, writeDistributedCache } from "./distributed-cache.ts";
 import { fetchModuleViaHTTP } from "./http-fetcher.ts";
 import { cacheModule, normalizePath } from "./module-cache.ts";
+import { readValidCachedModulePath } from "./path-cache-lookup.ts";
 
 // Re-export extracted modules for backward compatibility
 export { rewriteDntImports } from "./import-rewriter.ts";
@@ -196,38 +195,19 @@ async function doFetchAndCacheModule(
 
   const pathCache = await getModulePathCache(esmCacheDir);
   const versionedKey = getVersionedPathCacheKey(normalizedPath, effectiveReactVersion);
-  const cachedPath = pathCache.get(versionedKey);
-
-  if (cachedPath) {
-    try {
-      const stat = await getLocalFs().stat(cachedPath);
-      if (stat?.isFile) {
-        const cachedCode = await getLocalFs().readTextFile(cachedPath);
-        if (
-          await validateCachedModule(
-            normalizedPath,
-            cachedPath,
-            cachedCode,
-            log,
-            pathCache,
-            versionedKey,
-            context.contentSourceId
-              ? {
-                projectId: context.projectId,
-                contentSourceId: context.contentSourceId,
-              }
-              : undefined,
-          )
-        ) {
-          recordModuleToSession(normalizedPath);
-          return cachedPath;
-        }
+  const cachedPath = await readValidCachedModulePath({
+    normalizedPath,
+    pathCache,
+    versionedKey,
+    log,
+    recoveryOptions: context.contentSourceId
+      ? {
+        projectId: context.projectId,
+        contentSourceId: context.contentSourceId,
       }
-    } catch (_) {
-      /* expected: cached file may no longer exist on disk */
-      pathCache.delete(versionedKey);
-    }
-  }
+      : undefined,
+  });
+  if (cachedPath) return cachedPath;
 
   try {
     const resolved = await resolveModuleFile(normalizedPath, adapter, projectDir);

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/path-cache-lookup.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/path-cache-lookup.test.ts
@@ -1,0 +1,52 @@
+import "#veryfront/schemas/_test-setup.ts";
+
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { join } from "#veryfront/compat/path";
+import { rendererLogger } from "#veryfront/utils";
+import { readValidCachedModulePath } from "./path-cache-lookup.ts";
+
+async function withTempCache<T>(
+  test: (fixture: { cacheDir: string }) => Promise<T>,
+): Promise<T> {
+  const cacheDir = await Deno.makeTempDir({ prefix: "vf-path-cache-lookup-" });
+  try {
+    return await test({ cacheDir });
+  } finally {
+    await Deno.remove(cacheDir, { recursive: true }).catch(() => undefined);
+  }
+}
+
+describe("module-fetcher/path-cache-lookup", () => {
+  it("returns the cached path when the path-cache entry points at a valid cached file", async () => {
+    await withTempCache(async ({ cacheDir }) => {
+      const cachedPath = join(cacheDir, "module.mjs");
+      await Deno.writeTextFile(cachedPath, "export const value = 1;\n");
+      const pathCache = new Map([["cache-key", cachedPath]]);
+
+      const result = await readValidCachedModulePath({
+        normalizedPath: "_vf_modules/page.js",
+        pathCache,
+        versionedKey: "cache-key",
+        log: rendererLogger.component("path-cache-lookup-test"),
+      });
+
+      assertEquals(result, cachedPath);
+      assertEquals(pathCache.get("cache-key"), cachedPath);
+    });
+  });
+
+  it("deletes stale path-cache entries when the cached file is missing", async () => {
+    const pathCache = new Map([["cache-key", "/tmp/veryfront-missing-module.mjs"]]);
+
+    const result = await readValidCachedModulePath({
+      normalizedPath: "_vf_modules/missing.js",
+      pathCache,
+      versionedKey: "cache-key",
+      log: rendererLogger.component("path-cache-lookup-test"),
+    });
+
+    assertEquals(result, null);
+    assertEquals(pathCache.has("cache-key"), false);
+  });
+});

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/path-cache-lookup.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/path-cache-lookup.ts
@@ -1,0 +1,60 @@
+/**
+ * Validated path-cache lookups for MDX ESM module fetching.
+ *
+ * @module transforms/mdx/esm-module-loader/module-fetcher/path-cache-lookup
+ */
+
+import type { Logger } from "#veryfront/utils/logger/logger.ts";
+import { getLocalFs } from "../cache/index.ts";
+import { validateCachedModule } from "./framework-validator.ts";
+import { recordModuleToSession } from "./render-sessions.ts";
+
+interface MdxRecoveryOptions {
+  projectId: string;
+  contentSourceId: string;
+}
+
+export interface ReadValidCachedModulePathInput {
+  normalizedPath: string;
+  pathCache: Map<string, string>;
+  versionedKey: string;
+  log: Logger;
+  recoveryOptions?: MdxRecoveryOptions;
+}
+
+/**
+ * Return a cached module path only when the path-cache entry points to an
+ * existing file whose contents pass the full cached-module validator.
+ */
+export async function readValidCachedModulePath(
+  input: ReadValidCachedModulePathInput,
+): Promise<string | null> {
+  const cachedPath = input.pathCache.get(input.versionedKey);
+  if (!cachedPath) return null;
+
+  try {
+    const stat = await getLocalFs().stat(cachedPath);
+    if (!stat?.isFile) return null;
+
+    const cachedCode = await getLocalFs().readTextFile(cachedPath);
+    if (
+      await validateCachedModule(
+        input.normalizedPath,
+        cachedPath,
+        cachedCode,
+        input.log,
+        input.pathCache,
+        input.versionedKey,
+        input.recoveryOptions,
+      )
+    ) {
+      recordModuleToSession(input.normalizedPath);
+      return cachedPath;
+    }
+  } catch (_) {
+    /* expected: cached file may no longer exist on disk */
+    input.pathCache.delete(input.versionedKey);
+  }
+
+  return null;
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.735";
+export const VERSION = "0.1.736";


### PR DESCRIPTION
## Summary
- extract MDX module-fetcher path-cache hit validation into `path-cache-lookup.ts`
- preserve `doFetchAndCacheModule` behavior while reducing the first cache-hit phase
- add focused helper coverage for valid cached module paths and stale path-cache entries
- bump release metadata to `0.1.736`

## Verification
- Red first: focused path-cache-lookup test failed before implementation because `path-cache-lookup.ts` did not exist.
- `deno test --frozen --no-check --allow-all src/transforms/mdx/esm-module-loader/module-fetcher/path-cache-lookup.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts`
- `deno check --frozen src/transforms/mdx/esm-module-loader/module-fetcher/path-cache-lookup.ts src/transforms/mdx/esm-module-loader/module-fetcher/path-cache-lookup.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/index.ts src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts src/utils/version-constant.ts`
- `git diff --check`
- `deno task verify:quick`
- pre-push hook: format, lint, typecheck, unit tests (`2022 passed`, `0 failed`)

Part of #2220.