### PR TITLE
Extract MDX nested module resolution

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.736",
+  "version": "0.1.737",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
@@ -28,7 +28,7 @@ import { resolveModuleFile } from "../resolution/file-finder.ts";
 import { buildMissingModuleError } from "../missing-module.ts";
 import { getTransformCacheKey, getVersionedPathCacheKey } from "./cache-keys.ts";
 import { rewriteDntImports, rewriteVeryfrontImports } from "./import-rewriter.ts";
-import { findNestedImports, processNestedImports } from "./nested-imports.ts";
+import { resolveNestedModuleImports } from "./nested-imports.ts";
 import { readDistributedCache, writeDistributedCache } from "./distributed-cache.ts";
 import { fetchModuleViaHTTP } from "./http-fetcher.ts";
 import { cacheModule, normalizePath } from "./module-cache.ts";
@@ -343,69 +343,15 @@ async function doFetchAndCacheModule(
       needsDistributedCacheWrite = true;
     }
 
-    const { vfModules, relative } = findNestedImports(moduleCode);
-    log.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] found nested imports`, {
-      projectSlug,
-      normalizedPath,
-      vfModulesCount: vfModules.length,
-      relativeCount: relative.length,
-      vfModulePaths: vfModules.map((m) => m.path).slice(0, 5),
-      relativePaths: relative.map((m) => m.path).slice(0, 5),
-    });
-
-    log.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] processing vfModules START`, {
-      projectSlug,
-      normalizedPath,
-      count: vfModules.length,
-    });
-    const vfStart = performance.now();
-    const nestedResults = await Promise.all(
-      vfModules.map(async ({ original, path }) => ({
-        original,
-        nestedFilePath: await fetchAndCacheModuleFn(path, normalizedPath),
-        nestedPath: path,
-      })),
-    );
-    log.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] processing vfModules DONE`, {
-      projectSlug,
-      normalizedPath,
-      vfMs: (performance.now() - vfStart).toFixed(1),
-    });
-    moduleCode = await processNestedImports(
+    moduleCode = await resolveNestedModuleImports({
       moduleCode,
-      nestedResults,
       esmCacheDir,
-      context.strictMissingModules ?? true,
       normalizedPath,
+      strictMissingModules: context.strictMissingModules ?? true,
       projectSlug,
-    );
-
-    log.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] processing relative imports START`, {
-      projectSlug,
-      normalizedPath,
-      count: relative.length,
+      fetchAndCacheModule: fetchAndCacheModuleFn,
+      log,
     });
-    const relStart = performance.now();
-    const relativeResults = await Promise.all(
-      relative.map(async ({ original, path }) => ({
-        original,
-        nestedFilePath: await fetchAndCacheModuleFn(path, normalizedPath),
-        relativePath: path,
-      })),
-    );
-    log.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] processing relative imports DONE`, {
-      projectSlug,
-      normalizedPath,
-      relMs: (performance.now() - relStart).toFixed(1),
-    });
-    moduleCode = await processNestedImports(
-      moduleCode,
-      relativeResults,
-      esmCacheDir,
-      context.strictMissingModules ?? true,
-      normalizedPath,
-      projectSlug,
-    );
 
     // Write to distributed cache AFTER nested imports are resolved.
     // This ensures other pods get fully-resolved code without /_vf_modules/ paths.

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.test.ts
@@ -1,7 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { findNestedImports, hasUnresolvedImports } from "./nested-imports.ts";
+import {
+  findNestedImports,
+  hasUnresolvedImports,
+  resolveNestedModuleImports,
+} from "./nested-imports.ts";
 
 describe("transforms/mdx/esm-module-loader/module-fetcher/nested-imports", () => {
   describe("findNestedImports", () => {
@@ -84,6 +88,40 @@ import { bar } from "./local.js";
     it("returns empty for empty string", () => {
       const result = hasUnresolvedImports("");
       assertEquals(result.count, 0);
+    });
+  });
+
+  describe("resolveNestedModuleImports", () => {
+    it("resolves vf module imports before relative imports", async () => {
+      const calls: Array<{ path: string; parent?: string }> = [];
+      const result = await resolveNestedModuleImports({
+        moduleCode: [
+          `import { shared } from "/_vf_modules/lib/shared.js";`,
+          `import local from "./local.js";`,
+          `export { shared, local };`,
+        ].join("\n"),
+        esmCacheDir: "/tmp/veryfront-unused",
+        normalizedPath: "_vf_modules/pages/index.js",
+        projectSlug: "docs",
+        strictMissingModules: true,
+        fetchAndCacheModule: (path, parent) => {
+          calls.push({ path, parent });
+          return Promise.resolve(`/cache/${path.replaceAll("/", "__")}.mjs`);
+        },
+      });
+
+      assertEquals(calls, [
+        { path: "_vf_modules/lib/shared.js", parent: "_vf_modules/pages/index.js" },
+        { path: "./local.js", parent: "_vf_modules/pages/index.js" },
+      ]);
+      assertEquals(
+        result,
+        [
+          `import { shared } from "file:///cache/_vf_modules__lib__shared.js.mjs";`,
+          `import local from "file:///cache/.__local.js.mjs";`,
+          `export { shared, local };`,
+        ].join("\n"),
+      );
     });
   });
 });

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  LOG_PREFIX_MDX_LOADER,
   RELATIVE_IMPORT_PATTERN,
   UNRESOLVED_VF_MODULES_PATTERN,
   VF_MODULE_IMPORT_PATTERN,
@@ -12,6 +13,7 @@ import {
 import type { NestedImportResult } from "../types.ts";
 import { createStubModule } from "../utils/stub-module.ts";
 import { buildMissingModuleError } from "../missing-module.ts";
+import type { Logger } from "#veryfront/utils/logger/logger.ts";
 
 /**
  * Find nested module imports in code.
@@ -92,4 +94,93 @@ export async function processNestedImports(
   }
 
   return result;
+}
+
+export interface ResolveNestedModuleImportsInput {
+  moduleCode: string;
+  esmCacheDir: string;
+  normalizedPath: string;
+  projectSlug: string;
+  strictMissingModules: boolean;
+  fetchAndCacheModule: (path: string, parent?: string) => Promise<string | null>;
+  log?: Logger;
+}
+
+/**
+ * Resolve nested /_vf_modules and relative imports into local file:// cache paths.
+ */
+export async function resolveNestedModuleImports(
+  input: ResolveNestedModuleImportsInput,
+): Promise<string> {
+  let moduleCode = input.moduleCode;
+  const { vfModules, relative } = findNestedImports(moduleCode);
+
+  input.log?.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] found nested imports`, {
+    projectSlug: input.projectSlug,
+    normalizedPath: input.normalizedPath,
+    vfModulesCount: vfModules.length,
+    relativeCount: relative.length,
+    vfModulePaths: vfModules.map((module) => module.path).slice(0, 5),
+    relativePaths: relative.map((module) => module.path).slice(0, 5),
+  });
+
+  input.log?.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] processing vfModules START`, {
+    projectSlug: input.projectSlug,
+    normalizedPath: input.normalizedPath,
+    count: vfModules.length,
+  });
+  const vfStart = performance.now();
+  const nestedResults = await Promise.all(
+    vfModules.map(async ({ original, path }) => ({
+      original,
+      nestedFilePath: await input.fetchAndCacheModule(path, input.normalizedPath),
+      nestedPath: path,
+    })),
+  );
+  input.log?.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] processing vfModules DONE`, {
+    projectSlug: input.projectSlug,
+    normalizedPath: input.normalizedPath,
+    vfMs: (performance.now() - vfStart).toFixed(1),
+  });
+  moduleCode = await processNestedImports(
+    moduleCode,
+    nestedResults,
+    input.esmCacheDir,
+    input.strictMissingModules,
+    input.normalizedPath,
+    input.projectSlug,
+  );
+
+  input.log?.debug(
+    `${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] processing relative imports START`,
+    {
+      projectSlug: input.projectSlug,
+      normalizedPath: input.normalizedPath,
+      count: relative.length,
+    },
+  );
+  const relStart = performance.now();
+  const relativeResults = await Promise.all(
+    relative.map(async ({ original, path }) => ({
+      original,
+      nestedFilePath: await input.fetchAndCacheModule(path, input.normalizedPath),
+      relativePath: path,
+    })),
+  );
+  input.log?.debug(
+    `${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] processing relative imports DONE`,
+    {
+      projectSlug: input.projectSlug,
+      normalizedPath: input.normalizedPath,
+      relMs: (performance.now() - relStart).toFixed(1),
+    },
+  );
+  return await processNestedImports(
+    moduleCode,
+    relativeResults,
+    input.esmCacheDir,
+    input.strictMissingModules,
+    input.normalizedPath,
+    input.projectSlug,
+  );
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.736";
+export const VERSION = "0.1.737";


### PR DESCRIPTION
## Summary
- extract MDX module-fetcher nested import resolution into `resolveNestedModuleImports`
- preserve the existing vf-module-first, relative-import-second rewrite order and logging
- bump release metadata to `0.1.737`

## Tests
- Red first: `deno test --frozen --no-check --allow-all src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.test.ts` failed on the missing `resolveNestedModuleImports` export before implementation
- `deno test --frozen --no-check --allow-all src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts`
- `deno check --frozen src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.ts src/transforms/mdx/esm-module-loader/module-fetcher/index.ts src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.test.ts`
- `git diff --check`
- `deno task verify:quick`
- pre-push hook: format, lint, typecheck, unit tests (`2022 passed`, `0 failed`)

Related: #2220