### PR TITLE
Extract MDX source transform phase

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.737",
+  "version": "0.1.738",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
@@ -15,10 +15,6 @@
 import { rendererLogger as globalLogger } from "#veryfront/utils";
 import type { Logger } from "#veryfront/utils/logger/logger.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
-import { transformToESM } from "../../../esm-transform.ts";
-import { cacheHttpImportsToLocal } from "../../../esm/http-cache.ts";
-import { loadImportMap } from "#veryfront/modules/import-map/index.ts";
-import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 import type { ModuleFetcherContext } from "../types.ts";
@@ -27,12 +23,12 @@ import { hashString } from "../utils/hash.ts";
 import { resolveModuleFile } from "../resolution/file-finder.ts";
 import { buildMissingModuleError } from "../missing-module.ts";
 import { getTransformCacheKey, getVersionedPathCacheKey } from "./cache-keys.ts";
-import { rewriteDntImports, rewriteVeryfrontImports } from "./import-rewriter.ts";
 import { resolveNestedModuleImports } from "./nested-imports.ts";
 import { readDistributedCache, writeDistributedCache } from "./distributed-cache.ts";
 import { fetchModuleViaHTTP } from "./http-fetcher.ts";
 import { cacheModule, normalizePath } from "./module-cache.ts";
 import { readValidCachedModulePath } from "./path-cache-lookup.ts";
+import { transformResolvedModuleSource } from "./source-transform.ts";
 
 // Re-export extracted modules for backward compatibility
 export { rewriteDntImports } from "./import-rewriter.ts";
@@ -280,63 +276,17 @@ async function doFetchAndCacheModule(
     }
 
     if (!moduleCode) {
-      log.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] transformToESM START`, {
-        projectSlug,
-        normalizedPath,
+      moduleCode = await transformResolvedModuleSource({
+        sourceCode,
         actualFilePath,
-        sourceLength: sourceCode.length,
-      });
-
-      // Rewrite veryfront/* imports to /_vf_modules/ paths BEFORE transform
-      // so that ssrVfModulesPlugin can resolve them to file:// paths.
-      // Cached files don't have access to import maps, so we need to do this mapping here.
-      const preprocessedSource = rewriteVeryfrontImports(sourceCode);
-
-      const transformStart = performance.now();
-      try {
-        moduleCode = await transformToESM(preprocessedSource, actualFilePath, projectDir, adapter, {
-          projectId,
-          dev: true,
-          ssr: true,
-          reactVersion: context.reactVersion,
-        });
-      } catch (transformError) {
-        log.error(`${LOG_PREFIX_MDX_LOADER} Transform failed for module`, {
-          normalizedPath,
-          actualFilePath,
-          sourceLength: sourceCode.length,
-          sourcePreview: sourceCode.slice(0, 200),
-          error: transformError instanceof Error ? transformError.message : String(transformError),
-        });
-        throw transformError;
-      }
-
-      log.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] transformToESM DONE`, {
-        projectSlug,
+        projectDir,
+        projectId,
         normalizedPath,
-        transformMs: (performance.now() - transformStart).toFixed(1),
-        outputLength: moduleCode.length,
+        projectSlug,
+        reactVersion: context.reactVersion,
+        adapter,
+        log,
       });
-
-      // Rewrite _dnt.polyfills.js / _dnt.shims.js relative imports to absolute file:// paths
-      moduleCode = await rewriteDntImports(moduleCode, actualFilePath);
-
-      // Cache HTTP imports (esm.sh URLs) to local file:// paths.
-      // This ensures the same cache works for both compiled and non-compiled Deno.
-      // Compiled binaries cannot do dynamic HTTP imports, but non-compiled Deno
-      // also works fine with file:// paths, so we always cache for consistency.
-      {
-        log.debug(`${LOG_PREFIX_MDX_LOADER} Caching HTTP imports to local files`, {
-          normalizedPath,
-        });
-        const importMap = await loadImportMap(projectDir);
-        const cacheResult = await cacheHttpImportsToLocal(moduleCode, {
-          cacheDir: getHttpBundleCacheDir(),
-          importMap,
-          reactVersion: context.reactVersion,
-        });
-        moduleCode = cacheResult.code;
-      }
 
       // Mark for distributed cache write AFTER nested imports are resolved.
       // This ensures we don't cache code with unresolved /_vf_modules/ paths.

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts
@@ -1,0 +1,65 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { transformResolvedModuleSource } from "./source-transform.ts";
+
+const noopLog = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as const;
+
+describe("module-fetcher/source-transform", () => {
+  it("preprocesses veryfront imports before transform and caches HTTP imports after transform", async () => {
+    const calls: string[] = [];
+    const adapter = {} as RuntimeAdapter;
+
+    const result = await transformResolvedModuleSource({
+      sourceCode: `import Head from "veryfront/head";\nexport default Head;`,
+      actualFilePath: "/project/app/page.tsx",
+      projectDir: "/project",
+      projectId: "project-1",
+      normalizedPath: "_vf_modules/app/page.tsx",
+      projectSlug: "docs",
+      reactVersion: "19.1.1",
+      adapter,
+      log: noopLog,
+      transformToEsm: (source, actualFilePath, projectDir, receivedAdapter, options) => {
+        calls.push("transform");
+        assertEquals(
+          source.includes(`from "/_vf_modules/_veryfront/react/runtime/core.js?ssr=true"`),
+          true,
+        );
+        assertEquals(source.includes(`from "veryfront/head"`), false);
+        assertEquals(actualFilePath, "/project/app/page.tsx");
+        assertEquals(projectDir, "/project");
+        assertEquals(receivedAdapter, adapter);
+        assertEquals(options, {
+          projectId: "project-1",
+          dev: true,
+          ssr: true,
+          reactVersion: "19.1.1",
+        });
+        return Promise.resolve(`import React from "https://esm.sh/react";\nexport default React;`);
+      },
+      loadImportMap: (projectDir) => {
+        calls.push("loadImportMap");
+        assertEquals(projectDir, "/project");
+        return Promise.resolve({ imports: {} });
+      },
+      cacheHttpImportsToLocal: (code, options) => {
+        calls.push("cacheHttpImportsToLocal");
+        assertEquals(code, `import React from "https://esm.sh/react";\nexport default React;`);
+        assertEquals(options.reactVersion, "19.1.1");
+        return Promise.resolve({
+          code: `import React from "file:///cache/react.mjs";\nexport default React;`,
+        });
+      },
+    });
+
+    assertEquals(calls, ["transform", "loadImportMap", "cacheHttpImportsToLocal"]);
+    assertEquals(result, `import React from "file:///cache/react.mjs";\nexport default React;`);
+  });
+});

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.ts
@@ -1,0 +1,99 @@
+/**
+ * Source-file transform phase for the MDX ESM module fetcher.
+ *
+ * @module transforms/mdx/esm-module-loader/module-fetcher/source-transform
+ */
+
+import { cacheHttpImportsToLocal } from "../../../esm/http-cache.ts";
+import { loadImportMap } from "#veryfront/modules/import-map/index.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { transformToESM } from "../../../esm-transform.ts";
+import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
+import type { Logger } from "#veryfront/utils/logger/logger.ts";
+import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
+import { rewriteDntImports, rewriteVeryfrontImports } from "./import-rewriter.ts";
+
+type TransformToEsmFn = typeof transformToESM;
+type LoadImportMapFn = typeof loadImportMap;
+type CacheHttpImportsToLocalFn = typeof cacheHttpImportsToLocal;
+type SourceTransformLogger = Pick<Logger, "debug" | "error">;
+
+export interface TransformResolvedModuleSourceInput {
+  sourceCode: string;
+  actualFilePath: string;
+  projectDir: string;
+  projectId: string;
+  normalizedPath: string;
+  projectSlug: string;
+  reactVersion?: string;
+  adapter: RuntimeAdapter;
+  log: SourceTransformLogger;
+  transformToEsm?: TransformToEsmFn;
+  loadImportMap?: LoadImportMapFn;
+  cacheHttpImportsToLocal?: CacheHttpImportsToLocalFn;
+}
+
+/**
+ * Transform a resolved source file into cache-safe ESM module code.
+ */
+export async function transformResolvedModuleSource(
+  input: TransformResolvedModuleSourceInput,
+): Promise<string> {
+  input.log.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] transformToESM START`, {
+    projectSlug: input.projectSlug,
+    normalizedPath: input.normalizedPath,
+    actualFilePath: input.actualFilePath,
+    sourceLength: input.sourceCode.length,
+  });
+
+  const preprocessedSource = rewriteVeryfrontImports(input.sourceCode);
+  const transform = input.transformToEsm ?? transformToESM;
+  const transformStart = performance.now();
+  let moduleCode: string;
+  try {
+    moduleCode = await transform(
+      preprocessedSource,
+      input.actualFilePath,
+      input.projectDir,
+      input.adapter,
+      {
+        projectId: input.projectId,
+        dev: true,
+        ssr: true,
+        reactVersion: input.reactVersion,
+      },
+    );
+  } catch (transformError) {
+    input.log.error(`${LOG_PREFIX_MDX_LOADER} Transform failed for module`, {
+      normalizedPath: input.normalizedPath,
+      actualFilePath: input.actualFilePath,
+      sourceLength: input.sourceCode.length,
+      sourcePreview: input.sourceCode.slice(0, 200),
+      error: transformError instanceof Error ? transformError.message : String(transformError),
+    });
+    throw transformError;
+  }
+
+  input.log.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] transformToESM DONE`, {
+    projectSlug: input.projectSlug,
+    normalizedPath: input.normalizedPath,
+    transformMs: (performance.now() - transformStart).toFixed(1),
+    outputLength: moduleCode.length,
+  });
+
+  moduleCode = await rewriteDntImports(moduleCode, input.actualFilePath);
+
+  input.log.debug(`${LOG_PREFIX_MDX_LOADER} Caching HTTP imports to local files`, {
+    normalizedPath: input.normalizedPath,
+  });
+  const readImportMap = input.loadImportMap ?? loadImportMap;
+  const cacheHttpImports = input.cacheHttpImportsToLocal ?? cacheHttpImportsToLocal;
+  const importMap = await readImportMap(input.projectDir);
+  const cacheResult = await cacheHttpImports(moduleCode, {
+    cacheDir: getHttpBundleCacheDir(),
+    importMap,
+    reactVersion: input.reactVersion,
+  });
+
+  return cacheResult.code;
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.737";
+export const VERSION = "0.1.738";


### PR DESCRIPTION
## Summary
- extract source preprocessing, `transformToESM`, DNT import rewrite, and HTTP import localization into `transformResolvedModuleSource`
- keep `doFetchAndCacheModule` focused on cache orchestration, nested resolution, distributed-cache write, and final persistence
- bump release metadata to `0.1.738`

## Tests
- Red first: `deno test --frozen --no-check --allow-all src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts` failed on the missing `source-transform.ts` module before implementation
- `deno test --frozen --no-check --allow-all src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts`
- `deno check --frozen src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.ts src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/index.ts`
- `git diff --check`
- `deno task verify:quick`
- pre-push hook: format, lint, typecheck, unit tests (`2023 passed`, `0 failed`)

Related: #2220