### PR TITLE
Default missing invoke_agent context

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.739",
+  "version": "0.1.740",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/agent/hosted/child-tool-input.test.ts
+++ b/src/agent/hosted/child-tool-input.test.ts
@@ -103,13 +103,17 @@ Deno.test("resolveHostedChildForkRuntimeConfig does not append evidence refs", (
   assertEquals(result.effectivePrompt.includes('"result_path":"$.records[0]"'), false);
 });
 
-Deno.test("hostedChildForkToolInputSchema requires structured child context", () => {
-  const result = hostedChildForkToolInputSchema.safeParse({
+Deno.test("hostedChildForkToolInputSchema defaults omitted structured child context", () => {
+  const parsed = hostedChildForkToolInputSchema.parse({
     description: "write tests",
     prompt: "Add focused tests for the changed helper.",
   });
 
-  assertEquals(result.success, false);
+  assertEquals(parsed, {
+    description: "write tests",
+    prompt: "Add focused tests for the changed helper.",
+    context: {},
+  });
 });
 
 Deno.test("hostedChildForkToolInputSchema preserves omitted optional fork controls", () => {

--- a/src/agent/hosted/child-tool-input.ts
+++ b/src/agent/hosted/child-tool-input.ts
@@ -10,8 +10,8 @@ export const getHostedChildForkToolInputSchema = defineSchema((v) =>
   v.object({
     description: v.string().describe("3-5 word task summary"),
     prompt: v.string().describe("Detailed instructions for the task"),
-    context: v.record(v.string(), getJsonValueSchema()).describe(
-      "Required structured data payload for the child task. Use this for critical facts, records, ids, decisions, and values the child must act on. Use {} only when the delegation has no record or evidence payload.",
+    context: v.record(v.string(), getJsonValueSchema()).default({}).describe(
+      "Structured data payload for the child task. Use this for critical facts, records, ids, decisions, and values the child must act on. Defaults to {} when the delegation has no record or evidence payload.",
     ),
     project_id: v.string().optional().describe(
       "Override project context. Use after studio_open_project.",

--- a/src/agent/hosted/default-invoke-agent-tool.test.ts
+++ b/src/agent/hosted/default-invoke-agent-tool.test.ts
@@ -156,3 +156,36 @@ Deno.test("createDefaultHostedInvokeAgentTool adds child selection guidance and 
   });
   assertEquals(traceAttributes.at(-1)?.["child.agent.id"], "custom-child");
 });
+
+Deno.test("createDefaultHostedInvokeAgentTool treats omitted context as empty structured context", async () => {
+  const traceAttributes: DefaultHostedInvokeAgentTraceAttributes[] = [];
+  const invokeTool = createDefaultHostedInvokeAgentTool(
+    createTestOptions({ traceAttributes }),
+  );
+
+  const result = await invokeTool.execute(
+    {
+      description: "load invoices",
+      prompt: "Load the current supplier invoice working list.",
+      agent_id: "ingest-invoice-agent",
+      max_steps: 10,
+    } as never,
+    { toolCallId: "tool-call-missing-context" },
+  );
+
+  assertEquals(result, {
+    ok: false,
+    status: "failed",
+    text:
+      "invoke_agent failed: invoke_agent requires durable conversation context when durable child runs are enabled.",
+    summary: {
+      text:
+        "invoke_agent failed: invoke_agent requires durable conversation context when durable child runs are enabled.",
+    },
+    terminalErrorCode: "DURABLE_INVOKE_CONTEXT_UNAVAILABLE",
+    terminalErrorMessage:
+      "invoke_agent requires durable conversation context when durable child runs are enabled.",
+  });
+  assertEquals(traceAttributes.at(-1)?.["child.agent.id"], "ingest-invoice-agent");
+  assertEquals(traceAttributes.at(-1)?.["tool.call.id"], "tool-call-missing-context");
+});

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.739";
+export const VERSION = "0.1.740";


### PR DESCRIPTION
## Summary
- Default omitted invoke_agent structured context to `{}` instead of failing validation before child-run setup
- Add regression coverage for provider/tool calls that omit top-level `context`
- Bump Veryfront framework version to `0.1.738`

## Test Plan
- `deno test --config=deno.json --node-modules-dir=auto --allow-env src/agent/hosted/default-invoke-agent-tool.test.ts`
- `deno task verify:quick`

Note: local pre-push reached the full `deno task test:unit` phase and then sat idle for several minutes with no output; I stopped it and am relying on GitHub PR checks for the full-suite signal.