### PR TITLE
Code review batch 2: medium-severity bugs, security hardening, memory bounds

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.739",
+  "version": "0.1.740",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/mcp/http-transport.test.ts
+++ b/src/mcp/http-transport.test.ts
@@ -1,0 +1,66 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createMCPHTTPHandler } from "./http-transport.ts";
+import { SessionManager } from "./session.ts";
+
+const JSON_HEADERS = { "Content-Type": "application/json" };
+
+function jsonRpcRequest(
+  payload: Record<string, unknown>,
+  headers: HeadersInit = JSON_HEADERS,
+): Request {
+  return new Request("http://localhost/mcp", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+  });
+}
+
+describe("mcp/http-transport", () => {
+  it("continues requiring MCP-Session-Id after issued sessions expire", async () => {
+    let clock = 1_000;
+    let handledRequests = 0;
+    const sessionManager = new SessionManager({ ttlMs: 5_000, now: () => clock });
+    const handler = createMCPHTTPHandler({
+      authEnabled: false,
+      getCORSHeaders: () => ({}),
+      validateAuth: async () => true,
+      handleRequest: async (request) => {
+        handledRequests++;
+        return { jsonrpc: "2.0", id: request.id, result: {} };
+      },
+      extractRequestContext: () => undefined,
+      isOriginAllowed: () => true,
+      sessionCapabilities: new Map(),
+      sessionManager,
+    });
+
+    const initResponse = await handler(jsonRpcRequest({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { capabilities: {} },
+    }));
+    const sessionId = initResponse.headers.get("MCP-Session-Id");
+    assertEquals(initResponse.status, 200);
+    assertEquals(typeof sessionId, "string");
+
+    clock += 6_000;
+    assertEquals(sessionManager.size, 0);
+
+    const missingHeaderResponse = await handler(jsonRpcRequest({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+    }));
+    assertEquals(missingHeaderResponse.status, 400);
+
+    const expiredSessionResponse = await handler(jsonRpcRequest(
+      { jsonrpc: "2.0", id: 3, method: "tools/list" },
+      { ...JSON_HEADERS, "MCP-Session-Id": String(sessionId) },
+    ));
+    assertEquals(expiredSessionResponse.status, 404);
+    assertEquals(handledRequests, 1);
+  });
+});

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -141,7 +141,7 @@ export function createMCPHTTPHandler(
     }
 
     let sessionId: string | undefined;
-    if (sessionManager.size > 0) {
+    if (sessionManager.requiresSessionHeader()) {
       sessionId = request.headers.get("MCP-Session-Id") ?? undefined;
       if (!sessionId) {
         return createJSONRPCErrorResponse(400, -32600, "Missing MCP-Session-Id header");

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -60,11 +60,13 @@ describe("mcp/session", () => {
     let clock = 1_000;
     const manager = new SessionManager({ ttlMs: 5_000, now: () => clock });
     const id = manager.create();
+    assertEquals(manager.requiresSessionHeader(), true);
     assertEquals(manager.isValid(id), true);
 
     clock += 6_000; // advance past the TTL
     assertEquals(manager.isValid(id), false);
     assertEquals(manager.size, 0); // pruned, not leaked
+    assertEquals(manager.requiresSessionHeader(), true);
   });
 
   it("refreshes the inactivity window on access", () => {
@@ -76,5 +78,14 @@ describe("mcp/session", () => {
     assertEquals(manager.isValid(id), true); // touch refreshes lastSeen
     clock += 4_000; // 8s since create, but only 4s since last access
     assertEquals(manager.isValid(id), true);
+  });
+
+  it("resets the session header requirement after explicit termination", () => {
+    const manager = new SessionManager();
+    const id = manager.create();
+    assertEquals(manager.requiresSessionHeader(), true);
+
+    manager.terminate(id);
+    assertEquals(manager.requiresSessionHeader(), false);
   });
 });

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -55,4 +55,26 @@ describe("mcp/session", () => {
     const id = manager.create();
     assertEquals(/^[\x21-\x7E]+$/.test(id), true);
   });
+
+  it("expires sessions after the inactivity TTL", () => {
+    let clock = 1_000;
+    const manager = new SessionManager({ ttlMs: 5_000, now: () => clock });
+    const id = manager.create();
+    assertEquals(manager.isValid(id), true);
+
+    clock += 6_000; // advance past the TTL
+    assertEquals(manager.isValid(id), false);
+    assertEquals(manager.size, 0); // pruned, not leaked
+  });
+
+  it("refreshes the inactivity window on access", () => {
+    let clock = 1_000;
+    const manager = new SessionManager({ ttlMs: 5_000, now: () => clock });
+    const id = manager.create();
+
+    clock += 4_000;
+    assertEquals(manager.isValid(id), true); // touch refreshes lastSeen
+    clock += 4_000; // 8s since create, but only 4s since last access
+    assertEquals(manager.isValid(id), true);
+  });
 });

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -1,18 +1,51 @@
 /**
  * Manages MCP sessions for the Streamable HTTP transport.
  * Sessions are created during initialization and validated on subsequent requests.
+ *
+ * Sessions expire after a period of inactivity so that clients which disconnect
+ * uncleanly (closed tab, crash, dropped network) don't leak entries forever.
+ * Expiry is lazy: stale entries are pruned on access, so no background timer is
+ * required.
  */
+
+/** Default inactivity window before a session is considered expired (30 min). */
+const DEFAULT_SESSION_TTL_MS = 30 * 60_000;
+
+export interface SessionManagerOptions {
+  /** Inactivity TTL in ms (default 30 minutes). */
+  ttlMs?: number;
+  /** Clock, injectable for tests. Defaults to Date.now. */
+  now?: () => number;
+}
+
 export class SessionManager {
-  private sessions = new Set<string>();
+  /** id -> last-seen timestamp (ms). */
+  private sessions = new Map<string, number>();
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+
+  constructor(options: SessionManagerOptions = {}) {
+    this.ttlMs = options.ttlMs ?? DEFAULT_SESSION_TTL_MS;
+    this.now = options.now ?? Date.now;
+  }
 
   create(): string {
+    this.pruneExpired();
     const id = crypto.randomUUID();
-    this.sessions.add(id);
+    this.sessions.set(id, this.now());
     return id;
   }
 
   isValid(id: string): boolean {
-    return this.sessions.has(id);
+    const lastSeen = this.sessions.get(id);
+    if (lastSeen === undefined) return false;
+    if (this.isExpired(lastSeen)) {
+      this.sessions.delete(id);
+      return false;
+    }
+    // Touch: activity refreshes the inactivity window.
+    this.sessions.set(id, this.now());
+    return true;
   }
 
   terminate(id: string): void {
@@ -20,10 +53,22 @@ export class SessionManager {
   }
 
   get size(): number {
+    this.pruneExpired();
     return this.sessions.size;
   }
 
   clear(): void {
     this.sessions.clear();
+  }
+
+  private isExpired(lastSeen: number): boolean {
+    return this.now() - lastSeen > this.ttlMs;
+  }
+
+  private pruneExpired(): void {
+    const cutoff = this.now() - this.ttlMs;
+    for (const [id, lastSeen] of this.sessions) {
+      if (lastSeen < cutoff) this.sessions.delete(id);
+    }
   }
 }

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -23,6 +23,7 @@ export class SessionManager {
   private sessions = new Map<string, number>();
   private readonly ttlMs: number;
   private readonly now: () => number;
+  private sessionHeaderRequired = false;
 
   constructor(options: SessionManagerOptions = {}) {
     this.ttlMs = options.ttlMs ?? DEFAULT_SESSION_TTL_MS;
@@ -33,6 +34,7 @@ export class SessionManager {
     this.pruneExpired();
     const id = crypto.randomUUID();
     this.sessions.set(id, this.now());
+    this.sessionHeaderRequired = true;
     return id;
   }
 
@@ -50,6 +52,7 @@ export class SessionManager {
 
   terminate(id: string): void {
     this.sessions.delete(id);
+    if (this.sessions.size === 0) this.sessionHeaderRequired = false;
   }
 
   get size(): number {
@@ -59,6 +62,11 @@ export class SessionManager {
 
   clear(): void {
     this.sessions.clear();
+    this.sessionHeaderRequired = false;
+  }
+
+  requiresSessionHeader(): boolean {
+    return this.sessionHeaderRequired;
   }
 
   private isExpired(lastSeen: number): boolean {

--- a/src/middleware/builtin/security/cors-simple.ts
+++ b/src/middleware/builtin/security/cors-simple.ts
@@ -12,14 +12,17 @@ export function corsSimple(options: CORSOptions | string = "*"): Middleware {
     const validation = validateOriginSync(req.headers.get("origin"), { origin });
 
     if (req.method === "OPTIONS") {
-      return new Response(null, {
-        status: HTTP_NO_CONTENT,
-        headers: {
-          "Access-Control-Allow-Origin": validation.allowedOrigin || origin,
-          "Access-Control-Allow-Methods": "GET,POST,PUT,PATCH,DELETE,OPTIONS",
-          "Access-Control-Allow-Headers": "Content-Type,Authorization",
-        },
-      });
+      // Only echo Access-Control-Allow-Origin when the origin actually passed
+      // validation. Falling back to the configured origin (e.g. "*") here would
+      // grant a permissive preflight to an origin we just rejected.
+      const headers: Record<string, string> = {
+        "Access-Control-Allow-Methods": "GET,POST,PUT,PATCH,DELETE,OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type,Authorization",
+      };
+      if (validation.allowedOrigin) {
+        headers["Access-Control-Allow-Origin"] = validation.allowedOrigin;
+      }
+      return new Response(null, { status: HTTP_NO_CONTENT, headers });
     }
 
     const res = await next();

--- a/src/modules/manifest/route-module-manifest.ts
+++ b/src/modules/manifest/route-module-manifest.ts
@@ -11,8 +11,14 @@
  */
 
 import { serverLogger } from "#veryfront/utils";
+import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 
 const logger = serverLogger.component("route-module-manifest");
+
+/** Bound on tracked routes; manifests are a regenerable preload optimization. */
+const MAX_TRACKED_ROUTES = 2_000;
+/** Bound on in-flight collections; abandoned ones (render errors) get evicted. */
+const MAX_PENDING_COLLECTIONS = 2_000;
 
 interface ModuleEntry {
   path: string;
@@ -30,8 +36,10 @@ interface RouteManifest {
   renderCount: number;
 }
 
-const manifestStore = new Map<string, RouteManifest>();
-const pendingCollections = new Map<string, Set<string>>();
+const manifestStore = new LRUCache<string, RouteManifest>({ maxEntries: MAX_TRACKED_ROUTES });
+const pendingCollections = new LRUCache<string, Set<string>>({
+  maxEntries: MAX_PENDING_COLLECTIONS,
+});
 
 function buildKey(projectSlug: string | undefined, route: string): string {
   return `${projectSlug ?? "default"}:${route || "index"}`;
@@ -207,7 +215,7 @@ export function getManifestStats(): {
   const routes: Array<{ route: string; moduleCount: number; renderCount: number }> = [];
   let totalModules = 0;
 
-  for (const [key, manifest] of manifestStore) {
+  for (const [key, manifest] of manifestStore.entries()) {
     routes.push({
       route: key,
       moduleCount: manifest.moduleCount,
@@ -222,7 +230,8 @@ export function getManifestStats(): {
 export function clearProjectManifests(projectSlug: string): void {
   const prefix = `${projectSlug}:`;
 
-  for (const key of manifestStore.keys()) {
+  // Snapshot keys before deleting to avoid mutating during iteration.
+  for (const key of [...manifestStore.keys()]) {
     if (!key.startsWith(prefix)) continue;
     manifestStore.delete(key);
   }

--- a/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.test.ts
@@ -130,7 +130,7 @@ describe("modules/react-loader/ssr-module-loader/cross-project-import-loader", (
       },
       fetchImpl: async (input, init) => {
         fetchedUrl = String(input);
-        fetchedHeaders = init?.headers as Headers;
+        fetchedHeaders = (init as { headers?: Headers } | undefined)?.headers;
         return new Response("export const remoteValue = 1;", { status: 200 });
       },
       injectContextImpl: (headers) => {
@@ -170,6 +170,43 @@ describe("modules/react-loader/ssr-module-loader/cross-project-import-loader", (
     assertEquals(cached?.contentHash, "1234abcd");
     assertEquals(debugLogs.includes("[SSR-MODULE-LOADER] Fetching cross-project import"), true);
     assertEquals(debugLogs.includes("[SSR-MODULE-LOADER] Cross-project import transformed"), true);
+  });
+
+  it("rejects source bodies whose UTF-8 byte size exceeds the fallback limit", async () => {
+    globalCrossProjectCache.clear();
+
+    let transformed = false;
+    const oversizedUtf8Source = "é".repeat(3_000_000);
+
+    await assertRejects(
+      () =>
+        transformCrossProjectImportFlow({
+          crossProjectImport,
+          options: {
+            projectId: "project-a",
+            projectDir: "/project",
+            dev: true,
+            apiBaseUrl: "https://registry.example.com/api",
+            adapter: denoAdapter,
+          },
+          cache: {
+            hashContentAsync: async () => "unused",
+            getTempPath: async () => "/tmp/unused.mjs",
+            getFs: () => createMockCacheFs(),
+          },
+          withTransformCapacity: async (_syntheticFilePath, operation) => await operation(),
+          fetchImpl: async () => new Response(oversizedUtf8Source, { status: 200 }),
+          transformToESMImpl: async () => {
+            transformed = true;
+            return "";
+          },
+          loggerImpl: { debug: () => {}, error: () => {} },
+        }),
+      Error,
+      "Cross-project source exceeds size limit",
+    );
+
+    assertEquals(transformed, false);
   });
 
   it("throws with equivalent fetch error message and logs failure context", async () => {

--- a/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.test.ts
@@ -172,7 +172,7 @@ describe("modules/react-loader/ssr-module-loader/cross-project-import-loader", (
     assertEquals(debugLogs.includes("[SSR-MODULE-LOADER] Cross-project import transformed"), true);
   });
 
-  it("rejects source bodies whose UTF-8 byte size exceeds the fallback limit", async () => {
+  it("rejects source bodies whose UTF-8 byte size exceeds the fallback limit before transform", async () => {
     globalCrossProjectCache.clear();
 
     let transformed = false;

--- a/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.ts
@@ -14,6 +14,10 @@ import type { SSRModuleLoaderOptions } from "./types.ts";
 /** Max size of a fetched cross-project module source, to bound memory use. */
 const MAX_CROSS_PROJECT_SOURCE_BYTES = 5 * 1024 * 1024; // 5MB
 
+function getSourceByteLength(source: string): number {
+  return new TextEncoder().encode(source).byteLength;
+}
+
 interface CrossProjectImportCache {
   hashContentAsync(content: string): Promise<string>;
   getTempPath(filePath: string, contentHash?: string): Promise<string>;
@@ -103,9 +107,11 @@ export async function transformCrossProjectImportFlow(
     }
 
     const sourceCode = await response.text();
-    if (sourceCode.length > MAX_CROSS_PROJECT_SOURCE_BYTES) {
+    const sourceByteLength = getSourceByteLength(sourceCode);
+    if (sourceByteLength > MAX_CROSS_PROJECT_SOURCE_BYTES) {
       throw NETWORK_ERROR.create({
-        detail: `Cross-project source exceeds size limit: ${registryUrl}`,
+        detail:
+          `Cross-project source exceeds size limit: ${registryUrl} (${sourceByteLength} bytes)`,
       });
     }
     const contentHash = await cache.hashContentAsync(sourceCode);

--- a/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.ts
@@ -11,6 +11,9 @@ import { rendererLogger as logger } from "#veryfront/utils";
 import { globalCrossProjectCache } from "./cache/index.ts";
 import type { SSRModuleLoaderOptions } from "./types.ts";
 
+/** Max size of a fetched cross-project module source, to bound memory use. */
+const MAX_CROSS_PROJECT_SOURCE_BYTES = 5 * 1024 * 1024; // 5MB
+
 interface CrossProjectImportCache {
   hashContentAsync(content: string): Promise<string>;
   getTempPath(filePath: string, contentHash?: string): Promise<string>;
@@ -89,7 +92,22 @@ export async function transformCrossProjectImportFlow(
       });
     }
 
+    // Bound the response size — registryUrl derives from the requested ref, so
+    // an oversized body would otherwise be buffered whole into memory (OOM).
+    const declaredLength = Number(response.headers.get("content-length") ?? "");
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_CROSS_PROJECT_SOURCE_BYTES) {
+      await response.body?.cancel();
+      throw NETWORK_ERROR.create({
+        detail: `Cross-project source too large: ${registryUrl} (${declaredLength} bytes)`,
+      });
+    }
+
     const sourceCode = await response.text();
+    if (sourceCode.length > MAX_CROSS_PROJECT_SOURCE_BYTES) {
+      throw NETWORK_ERROR.create({
+        detail: `Cross-project source exceeds size limit: ${registryUrl}`,
+      });
+    }
     const contentHash = await cache.hashContentAsync(sourceCode);
 
     const ext = path.match(/\.(tsx?|jsx?|mdx)$/)?.[0] ?? ".tsx";

--- a/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.ts
@@ -10,13 +10,7 @@ import { writeCacheFile } from "#veryfront/utils/cache-file-ops.ts";
 import { rendererLogger as logger } from "#veryfront/utils";
 import { globalCrossProjectCache } from "./cache/index.ts";
 import type { SSRModuleLoaderOptions } from "./types.ts";
-
-/** Max size of a fetched cross-project module source, to bound memory use. */
-const MAX_CROSS_PROJECT_SOURCE_BYTES = 5 * 1024 * 1024; // 5MB
-
-function getSourceByteLength(source: string): number {
-  return new TextEncoder().encode(source).byteLength;
-}
+import { readLimitedCrossProjectSource } from "#veryfront/modules/server/cross-project-source-limit.ts";
 
 interface CrossProjectImportCache {
   hashContentAsync(content: string): Promise<string>;
@@ -96,24 +90,7 @@ export async function transformCrossProjectImportFlow(
       });
     }
 
-    // Bound the response size — registryUrl derives from the requested ref, so
-    // an oversized body would otherwise be buffered whole into memory (OOM).
-    const declaredLength = Number(response.headers.get("content-length") ?? "");
-    if (Number.isFinite(declaredLength) && declaredLength > MAX_CROSS_PROJECT_SOURCE_BYTES) {
-      await response.body?.cancel();
-      throw NETWORK_ERROR.create({
-        detail: `Cross-project source too large: ${registryUrl} (${declaredLength} bytes)`,
-      });
-    }
-
-    const sourceCode = await response.text();
-    const sourceByteLength = getSourceByteLength(sourceCode);
-    if (sourceByteLength > MAX_CROSS_PROJECT_SOURCE_BYTES) {
-      throw NETWORK_ERROR.create({
-        detail:
-          `Cross-project source exceeds size limit: ${registryUrl} (${sourceByteLength} bytes)`,
-      });
-    }
+    const sourceCode = await readLimitedCrossProjectSource(response, registryUrl);
     const contentHash = await cache.hashContentAsync(sourceCode);
 
     const ext = path.match(/\.(tsx?|jsx?|mdx)$/)?.[0] ?? ".tsx";

--- a/src/modules/server/cross-project-source-limit.ts
+++ b/src/modules/server/cross-project-source-limit.ts
@@ -1,0 +1,55 @@
+/** Max size of a fetched cross-project module source, to bound memory use. */
+export const MAX_CROSS_PROJECT_SOURCE_BYTES = 5 * 1024 * 1024; // 5MB
+
+export class CrossProjectSourceTooLargeError extends Error {
+  constructor(registryUrl: string, maxBytes = MAX_CROSS_PROJECT_SOURCE_BYTES) {
+    super(`Cross-project source exceeds size limit: ${registryUrl} (${maxBytes} bytes)`);
+    this.name = "CrossProjectSourceTooLargeError";
+  }
+}
+
+export async function readLimitedCrossProjectSource(
+  response: Response,
+  registryUrl: string,
+  maxBytes = MAX_CROSS_PROJECT_SOURCE_BYTES,
+): Promise<string> {
+  const declaredLength = Number(response.headers.get("content-length") ?? "");
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    await response.body?.cancel();
+    throw new CrossProjectSourceTooLargeError(registryUrl, maxBytes);
+  }
+
+  if (!response.body) {
+    const text = await response.text();
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
+      throw new CrossProjectSourceTooLargeError(registryUrl, maxBytes);
+    }
+    return text;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        await reader.cancel();
+        throw new CrossProjectSourceTooLargeError(registryUrl, maxBytes);
+      }
+
+      chunks.push(decoder.decode(value, { stream: true }));
+    }
+
+    const tail = decoder.decode();
+    if (tail.length > 0) chunks.push(tail);
+    return chunks.join("");
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/src/modules/server/module-batch-handler.ts
+++ b/src/modules/server/module-batch-handler.ts
@@ -416,10 +416,9 @@ function generateBatchBundle(
  * Converts ES module syntax to work within the bundle wrapper
  */
 function transformExportsForBundle(code: string): string {
-  return code
-    .split("\n")
-    .map((line) => `  ${line}`)
-    .join("\n");
+  // Indent every line by two spaces. A single regex avoids allocating an
+  // intermediate array of lines per module on the batch hot path.
+  return code.replace(/^/gm, "  ");
 }
 
 /**

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -98,6 +98,10 @@ const CROSS_PROJECT_LATEST_PREFIX = /^\/_vf_modules\/_cross\/([a-z0-9-]+)\/\@\/(
 /** Max size of a fetched cross-project module source, to bound memory use. */
 const MAX_CROSS_PROJECT_SOURCE_BYTES = 5 * 1024 * 1024; // 5MB
 
+function getSourceByteLength(source: string): number {
+  return new TextEncoder().encode(source).byteLength;
+}
+
 export interface ModuleServerOptions {
   /** Project identifier (directory path, legacy naming) */
   projectId: string;
@@ -789,10 +793,11 @@ async function fetchCrossProjectSource(
   }
 
   const text = await response.text();
-  if (text.length > MAX_CROSS_PROJECT_SOURCE_BYTES) {
+  const sourceByteLength = getSourceByteLength(text);
+  if (sourceByteLength > MAX_CROSS_PROJECT_SOURCE_BYTES) {
     logger.warn("Cross-project source exceeds size limit", {
       registryUrl,
-      size: text.length,
+      size: sourceByteLength,
     });
     return null;
   }

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -20,6 +20,7 @@ import {
   resolveFrameworkSourcePath,
 } from "#veryfront/platform/compat/framework-source-resolver.ts";
 import { getReactUrls, REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
+import { readLimitedCrossProjectSource } from "./cross-project-source-limit.ts";
 
 const logger = serverLogger.component("module-server");
 
@@ -95,13 +96,6 @@ const SNIPPET_MODULE_PREFIX = /^\/_vf_modules\/_snippets\/([a-f0-9]+)\.js/;
 const CROSS_PROJECT_VERSIONED_PREFIX =
   /^\/_vf_modules\/_cross\/([a-z0-9-]+)@([\d^~x][\d.x^~-]*)\/\@\/(.+)$/;
 const CROSS_PROJECT_LATEST_PREFIX = /^\/_vf_modules\/_cross\/([a-z0-9-]+)\/\@\/(.+)$/;
-/** Max size of a fetched cross-project module source, to bound memory use. */
-const MAX_CROSS_PROJECT_SOURCE_BYTES = 5 * 1024 * 1024; // 5MB
-
-function getSourceByteLength(source: string): number {
-  return new TextEncoder().encode(source).byteLength;
-}
-
 export interface ModuleServerOptions {
   /** Project identifier (directory path, legacy naming) */
   projectId: string;
@@ -781,25 +775,13 @@ async function fetchCrossProjectSource(
     return null;
   }
 
-  // Bound the response size: registryUrl is derived from the request path, so
-  // a crafted cross-project ref could otherwise stream an arbitrarily large
-  // body into memory (OOM). Reject oversized responses up front via
-  // Content-Length, and guard again after reading in case it was absent.
-  const contentLength = Number(response.headers.get("content-length") ?? "");
-  if (Number.isFinite(contentLength) && contentLength > MAX_CROSS_PROJECT_SOURCE_BYTES) {
-    logger.warn("Cross-project source too large", { registryUrl, contentLength });
-    await response.body?.cancel();
-    return null;
-  }
-
-  const text = await response.text();
-  const sourceByteLength = getSourceByteLength(text);
-  if (sourceByteLength > MAX_CROSS_PROJECT_SOURCE_BYTES) {
-    logger.warn("Cross-project source exceeds size limit", {
+  try {
+    return await readLimitedCrossProjectSource(response, registryUrl);
+  } catch (error) {
+    logger.warn("Cross-project source too large", {
       registryUrl,
-      size: sourceByteLength,
+      error: error instanceof Error ? error.message : String(error),
     });
     return null;
   }
-  return text;
 }

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -95,6 +95,8 @@ const SNIPPET_MODULE_PREFIX = /^\/_vf_modules\/_snippets\/([a-f0-9]+)\.js/;
 const CROSS_PROJECT_VERSIONED_PREFIX =
   /^\/_vf_modules\/_cross\/([a-z0-9-]+)@([\d^~x][\d.x^~-]*)\/\@\/(.+)$/;
 const CROSS_PROJECT_LATEST_PREFIX = /^\/_vf_modules\/_cross\/([a-z0-9-]+)\/\@\/(.+)$/;
+/** Max size of a fetched cross-project module source, to bound memory use. */
+const MAX_CROSS_PROJECT_SOURCE_BYTES = 5 * 1024 * 1024; // 5MB
 
 export interface ModuleServerOptions {
   /** Project identifier (directory path, legacy naming) */
@@ -775,5 +777,24 @@ async function fetchCrossProjectSource(
     return null;
   }
 
-  return response.text();
+  // Bound the response size: registryUrl is derived from the request path, so
+  // a crafted cross-project ref could otherwise stream an arbitrarily large
+  // body into memory (OOM). Reject oversized responses up front via
+  // Content-Length, and guard again after reading in case it was absent.
+  const contentLength = Number(response.headers.get("content-length") ?? "");
+  if (Number.isFinite(contentLength) && contentLength > MAX_CROSS_PROJECT_SOURCE_BYTES) {
+    logger.warn("Cross-project source too large", { registryUrl, contentLength });
+    await response.body?.cancel();
+    return null;
+  }
+
+  const text = await response.text();
+  if (text.length > MAX_CROSS_PROJECT_SOURCE_BYTES) {
+    logger.warn("Cross-project source exceeds size limit", {
+      registryUrl,
+      size: text.length,
+    });
+    return null;
+  }
+  return text;
 }

--- a/src/oauth/providers/base.ts
+++ b/src/oauth/providers/base.ts
@@ -245,8 +245,9 @@ export class OAuthProvider {
       return {
         success: false,
         error: "OAuth not configured",
-        errorDescription:
-          `Missing ${this.config.clientIdEnvVar} or ${this.config.clientSecretEnvVar}`,
+        // Don't leak internal env var names to the caller; this result can
+        // propagate to HTTP responses via OAuthService.
+        errorDescription: "OAuth provider credentials are not configured",
       };
     }
 

--- a/src/provider/runtime-loader/tool-input-status.ts
+++ b/src/provider/runtime-loader/tool-input-status.ts
@@ -187,17 +187,26 @@ export async function* withToolInputStatusTransitions(
 
     if (nextDueAt !== null) {
       let timeoutId: ReturnType<typeof setTimeout> | null = null;
-      const timeoutResult = await Promise.race([
-        nextPartPromise.then((result) => ({ kind: "part" as const, result })),
-        new Promise<{ kind: "timeout" }>((resolve) => {
-          timeoutId = setTimeout(
-            () => resolve({ kind: "timeout" }),
-            Math.max(0, nextDueAt - Date.now()),
-          );
-        }),
-      ]);
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
+      // Clear the timer in finally so it is released even when the race
+      // rejects (iterator error) or the generator is abandoned mid-await
+      // (consumer break/return), not just on the happy path.
+      let timeoutResult:
+        | { kind: "part"; result: IteratorResult<unknown> }
+        | { kind: "timeout" };
+      try {
+        timeoutResult = await Promise.race([
+          nextPartPromise.then((result) => ({ kind: "part" as const, result })),
+          new Promise<{ kind: "timeout" }>((resolve) => {
+            timeoutId = setTimeout(
+              () => resolve({ kind: "timeout" }),
+              Math.max(0, nextDueAt - Date.now()),
+            );
+          }),
+        ]);
+      } finally {
+        if (timeoutId !== null) {
+          clearTimeout(timeoutId);
+        }
       }
 
       if (timeoutResult.kind === "timeout") {

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -12,6 +12,7 @@ import { getColorSchemeFromRequest } from "#veryfront/security/http/client-hints
 import {
   endRenderSession,
   hasRenderSession,
+  runInRenderSession,
   startRenderSession,
 } from "#veryfront/transforms/mdx/esm-module-loader/module-fetcher/index.ts";
 import { getErrorCollector } from "#veryfront/observability/error-collector.ts";
@@ -172,28 +173,32 @@ export class SSRService implements SSRServiceLike {
       });
 
       const renderStartTime = performance.now();
-      const result = await profilePhase(
-        "ssr.render_page",
-        () =>
-          timeAsync("render-page", () =>
-            renderer.renderPage(slug, {
-              delivery: "stream",
-              request,
-              url,
-              nonce,
-              studioEmbed,
-              projectId,
-              pageId,
-              colorScheme,
-              colorSchemeFromParam,
-              colorSchemeFromHeader,
-              environment: ctx.requestContext?.mode,
-              projectSlug: ctx.projectSlug,
-              noHmr,
-              forceProductionScripts: options.forceProductionScripts,
-              renderSessionId,
-            })),
-      );
+      // Bind the render session to this async context so modules fetched
+      // during the render are attributed to THIS render, not whichever
+      // concurrent session started first.
+      const result = await runInRenderSession(renderSessionId, () =>
+        profilePhase(
+          "ssr.render_page",
+          () =>
+            timeAsync("render-page", () =>
+              renderer.renderPage(slug, {
+                delivery: "stream",
+                request,
+                url,
+                nonce,
+                studioEmbed,
+                projectId,
+                pageId,
+                colorScheme,
+                colorSchemeFromParam,
+                colorSchemeFromHeader,
+                environment: ctx.requestContext?.mode,
+                projectSlug: ctx.projectSlug,
+                noHmr,
+                forceProductionScripts: options.forceProductionScripts,
+                renderSessionId,
+              })),
+        ));
 
       logger.debug("renderPage DONE", {
         projectSlug: ctx.projectSlug,

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
@@ -32,7 +32,12 @@ import { transformResolvedModuleSource } from "./source-transform.ts";
 
 // Re-export extracted modules for backward compatibility
 export { rewriteDntImports } from "./import-rewriter.ts";
-export { endRenderSession, hasRenderSession, startRenderSession } from "./render-sessions.ts";
+export {
+  endRenderSession,
+  hasRenderSession,
+  runInRenderSession,
+  startRenderSession,
+} from "./render-sessions.ts";
 
 /**
  * Maximum time allowed for the entire transform tree (recursive module resolution).

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/render-sessions.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/render-sessions.ts
@@ -6,6 +6,7 @@
  * @module transforms/mdx/esm-module-loader/module-fetcher/render-sessions
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import { rendererLogger as globalLogger } from "#veryfront/utils";
 import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 import { recordSSRModules } from "#veryfront/modules/manifest/route-module-manifest.ts";
@@ -24,6 +25,21 @@ interface RenderSession {
  * Key: renderSessionId, Value: RenderSession
  */
 const renderSessions = new Map<string, RenderSession>();
+
+/**
+ * The render session id active on the current async execution context.
+ * Set via {@link runInRenderSession} so concurrent SSR renders each resolve
+ * their own session instead of sharing whichever one started first.
+ */
+const currentSessionIdStorage = new AsyncLocalStorage<string>();
+
+/**
+ * Run `fn` with `sessionId` bound as the active render session for all async
+ * work it spawns. Modules fetched inside are attributed to this session.
+ */
+export function runInRenderSession<T>(sessionId: string, fn: () => T): T {
+  return currentSessionIdStorage.run(sessionId, fn);
+}
 
 /**
  * Start a render session to track module loading.
@@ -85,8 +101,20 @@ export function hasRenderSession(sessionId: string): boolean {
  * Used to record modules during fetch and for per-session in-flight deduplication.
  */
 function getCurrentSession(): RenderSession | null {
-  const firstSession = renderSessions.values().next();
-  return firstSession.done ? null : firstSession.value;
+  const activeId = currentSessionIdStorage.getStore();
+  if (activeId !== undefined) {
+    return renderSessions.get(activeId) ?? null;
+  }
+
+  // No session bound on the async context (caller not wrapped in
+  // runInRenderSession). Fall back to the single-session heuristic only when
+  // it is unambiguous; with multiple concurrent sessions, decline rather than
+  // mis-attribute modules to the wrong render.
+  if (renderSessions.size === 1) {
+    const firstSession = renderSessions.values().next();
+    return firstSession.done ? null : firstSession.value;
+  }
+  return null;
 }
 
 export function recordModuleToSession(normalizedPath: string): void {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.739";
+export const VERSION = "0.1.740";

--- a/src/workflow/worker/workflow-worker.ts
+++ b/src/workflow/worker/workflow-worker.ts
@@ -20,6 +20,9 @@ const DEFAULT_POLL_INTERVAL_MS = 5_000;
 /** Default threshold after which a run is considered stalled */
 const DEFAULT_STALLED_THRESHOLD_MS = 60_000;
 
+/** Maximum time stop() waits for in-flight resumes before abandoning them */
+const WORKER_STOP_TIMEOUT_MS = 30_000;
+
 /**
  * Configuration for the workflow worker
  */
@@ -173,8 +176,16 @@ export class WorkflowWorker {
       this.pollTimeout = undefined;
     }
 
-    // Wait for active resumes to complete
+    // Wait for active resumes to complete, but bound the wait: a hung
+    // resumeFn (e.g. an unreachable backend) must not block shutdown forever.
+    const stopDeadline = Date.now() + WORKER_STOP_TIMEOUT_MS;
     while (this.activeResumes.size > 0) {
+      if (Date.now() >= stopDeadline) {
+        logger.warn(
+          `[WorkflowWorker] Stop timed out with ${this.activeResumes.size} active resume(s); abandoning wait`,
+        );
+        break;
+      }
       if (this.config.debug) {
         logger.debug(
           `[WorkflowWorker] Waiting for ${this.activeResumes.size} active resumes to complete`,


### PR DESCRIPTION
Second batch from the deep code review — the medium-severity items that aren't in #2244. Rebases onto current main and prepares release 0.1.740. Each commit is scoped to one issue or review tightening. Local pre-push passed formatting, lint, typecheck, and the full unit suite.

## Bugs
- **#2239** Workflow worker `stop()` now bounds its wait (30s) instead of hanging forever on a stuck `resumeFn`.
- **#2240** `withToolInputStatusTransitions` clears its pending timeout in `finally` (covers race rejection and generator abandonment).
- **#2237** Render session bound to the async context via `AsyncLocalStorage`, so concurrent SSR renders record modules to their own session instead of whichever started first. Safe single-session fallback for unwrapped callers.

## Security hardening (#2241, subset)
- CORS preflight no longer echoes a rejected origin (was falling back to the configured `*`).
- OAuth token-exchange error no longer names internal client id/secret env vars.
- Cross-project module fetch is size-bounded (5MB, Content-Length + byte-accurate post-read UTF-8 guard) in both fetch paths — prevents an OOM via a crafted ref.

## Memory bounds (#2235)
- MCP `SessionManager` gains a 30-min inactivity TTL with lazy pruning (orphan sessions from unclean disconnects no longer leak). Tests added.
- `route-module-manifest` stores (`manifestStore`, `pendingCollections`) bounded with `LRUCache` — they grew per project:route / leaked on render errors.

## Performance (#2242, subset)
- Batch module indentation uses one `replace(/^/gm, "  ")` instead of per-line split/map/join.

## Release
- Bumps `deno.json` and `VERSION` to `0.1.740`.

## Verification
- `deno task verify:quick`
- `deno test --frozen --allow-all src/modules/react-loader/ssr-module-loader/cross-project-import-loader.test.ts src/mcp/session.test.ts src/provider/runtime-loader.test.ts`
- `deno check --frozen` on the focused touched module set
- pre-push hook: formatting, lint, typecheck, and unit suite (2024 passed, 0 failed)

## Deliberately NOT changed (with rationale)
- **#2241 rate-limiter "unknown" bucket:** changing it broke tests that rely on header-less requests sharing a bucket — it's a real deployment/product trade-off (block vs. allow-unlimited vs. share), not a clear bug. Left for a product decision.
- **#2241 env-config cached secrets:** removing the fields is a broad, risky refactor touching many readers; deferred.
- **#2241 http-validator regex / proxy hosted redirect:** the esbuild onLoad check is the real import allow-list enforcement, and the hosted redirect intentionally uses the full URL for cross-origin sign-in return (suffix check + auth-gated subdomains mitigate). Left as-is.
- **#2234 findSourceFile negative cache & #2242 transform-cache LRU:** hot-path resolver changes with dev-HMR correctness implications (a cached miss can mask a newly-created file). Worth doing carefully with benchmarks; deferred rather than risk a subtle regression.
- **#2235 SSR transform caches (`veryfrontTransformCache`/`frameworkFileCache`):** keyed by framework file path, so already bounded by the fixed framework file count — not actually unbounded.
- **#2243 dev error-overlay innerHTML:** already escaped via `escapeHtml(...)`; not vulnerable. Other #2243 lows remain backlog.