### PR TITLE
Constrain compiled worker filesystem reads

### DIFF
--- a/src/security/sandbox/project-worker.test.ts
+++ b/src/security/sandbox/project-worker.test.ts
@@ -277,6 +277,59 @@ testSuite("ProjectWorker - real worker request isolation", () => {
       await Deno.remove(projectDir, { recursive: true });
     }
   });
+
+  it("rejects direct Deno file reads outside scoped worker read permissions", async () => {
+    const projectDir = await Deno.makeTempDir();
+    const outsideDir = await Deno.makeTempDir();
+    const outsidePath = await Deno.makeTempFile({ dir: outsideDir, suffix: ".txt" });
+    const modulePath = await Deno.makeTempFile({ dir: projectDir, suffix: ".mjs" });
+
+    await Deno.writeTextFile(outsidePath, "outside secret");
+    await Deno.writeTextFile(
+      modulePath,
+      `
+        export async function GET() {
+          await Deno.readTextFile(${JSON.stringify(outsidePath)});
+          return Response.json({ leaked: true });
+        }
+      `,
+    );
+
+    const worker = new ProjectWorker({
+      projectId: "test-direct-deno-read-denied",
+      permissions: { ...REAL_WORKER_PERMISSIONS, read: [projectDir] },
+      requestTimeoutMs: 10_000,
+    });
+
+    worker.start();
+    try {
+      const response = await worker.execute({
+        type: "execute-app-route",
+        id: "direct-read",
+        modulePath,
+        method: "GET",
+        request: {
+          url: "http://localhost/api/read",
+          method: "GET",
+          headers: [],
+          body: null,
+        },
+        params: {},
+        projectDir,
+      });
+
+      assertEquals(response.type, "error");
+      if (response.type !== "error") throw new Error("expected error response");
+      assert(
+        response.error.message.includes("Requires read access"),
+        `expected permission denial, got: ${response.error.message}`,
+      );
+    } finally {
+      worker.terminate();
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(outsideDir, { recursive: true });
+    }
+  });
 });
 
 testSuite("ProjectWorker - executeStream", () => {

--- a/src/security/sandbox/worker-permissions.test.ts
+++ b/src/security/sandbox/worker-permissions.test.ts
@@ -20,6 +20,15 @@ describe("worker-permissions", () => {
     assertEquals(perms.read, false);
   });
 
+  it("keeps compiled-binary read permissions scoped to explicit paths", () => {
+    const perms = buildWorkerPermissions(["/tmp/project-a"], {
+      isCompiledBinary: true,
+      compiledReadPaths: ["/tmp/deno-compile-abc/dist/framework-src"],
+    });
+
+    assertEquals(perms.read, ["/tmp/project-a", "/tmp/deno-compile-abc/dist/framework-src"]);
+  });
+
   it("always denies write, run, ffi, sys", () => {
     const perms = buildWorkerPermissions(["/anything"]);
     assertEquals(perms.write, false);

--- a/src/security/sandbox/worker-permissions.ts
+++ b/src/security/sandbox/worker-permissions.ts
@@ -7,6 +7,14 @@
  * @module security/sandbox/worker-permissions
  */
 
+import { getFrameworkRootFromMeta } from "#veryfront/platform/compat/vfs-paths.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
+import {
+  getCacheBaseDir,
+  getHttpBundleCacheDir,
+  getMdxEsmCacheDir,
+} from "#veryfront/utils/cache-dir.ts";
+
 /**
  * Deno Worker permission object.
  * See: https://docs.deno.com/runtime/fundamentals/permissions/
@@ -21,6 +29,13 @@ export interface WorkerPermissions {
   sys: boolean;
 }
 
+interface WorkerPermissionOptions {
+  /** Override for tests that need to exercise compiled-binary behavior. */
+  isCompiledBinary?: boolean;
+  /** Override for tests that need deterministic compiled-binary support paths. */
+  compiledReadPaths?: string[];
+}
+
 // Cache compiled binary check — Deno.execPath() is a syscall that never changes at runtime
 const _isCompiledBinary = (() => {
   try {
@@ -32,6 +47,27 @@ const _isCompiledBinary = (() => {
     return false;
   }
 })();
+
+function normalizeReadPaths(paths: Array<string | undefined>): string[] {
+  const unique = new Set<string>();
+  for (const path of paths) {
+    if (!path) continue;
+    const trimmed = path.trim();
+    if (!trimmed) continue;
+    unique.add(trimmed);
+  }
+  return [...unique];
+}
+
+function getDefaultCompiledReadPaths(): string[] {
+  return normalizeReadPaths([
+    getFrameworkRootFromMeta(import.meta.url),
+    getCacheBaseDir(),
+    getMdxEsmCacheDir(),
+    getHttpBundleCacheDir(),
+    getHostEnv("DENO_DIR"),
+  ]);
+}
 
 /**
  * Build scoped permissions for a project worker.
@@ -46,20 +82,16 @@ const _isCompiledBinary = (() => {
  */
 export function buildWorkerPermissions(
   readPaths: string[],
+  options: WorkerPermissionOptions = {},
 ): WorkerPermissions {
-  // In compiled binaries, user modules import from the VFS temp dir which
-  // is outside the project directory. Rather than trying to enumerate all
-  // read paths, grant full read access — the security boundary is enforced
-  // by denying write/run/ffi/sys, not by restricting reads.
-  //
-  // SECURITY (residual, tracked in #2245): with read:true a user route
-  // handler can call Deno.readTextFile directly to read any host file,
-  // bypassing the project-scoped ctx.fs adapter. Narrowing this to a
-  // binary-validated allow-list (or removing direct Deno fs from user module
-  // scope) is blocking work for the next security batch.
-  if (_isCompiledBinary) {
+  const isCompiledBinary = options.isCompiledBinary ?? _isCompiledBinary;
+  const normalizedReadPaths = normalizeReadPaths(readPaths);
+
+  if (isCompiledBinary) {
+    const compiledReadPaths = options.compiledReadPaths ?? getDefaultCompiledReadPaths();
+    const scopedReadPaths = normalizeReadPaths([...normalizedReadPaths, ...compiledReadPaths]);
     return {
-      read: true,
+      read: scopedReadPaths.length > 0 ? scopedReadPaths : false,
       write: false,
       net: true,
       env: true,
@@ -70,7 +102,7 @@ export function buildWorkerPermissions(
   }
 
   return {
-    read: readPaths.length > 0 ? readPaths : false,
+    read: normalizedReadPaths.length > 0 ? normalizedReadPaths : false,
     write: false,
     net: true,
     env: true,

--- a/src/security/sandbox/worker-script.ts
+++ b/src/security/sandbox/worker-script.ts
@@ -52,9 +52,9 @@ async function tryRealPath(path: string): Promise<string | null> {
 /**
  * Build a path guard that confines filesystem access to `projectDir`.
  *
- * In compiled-binary mode the worker has full read permission, so this
- * read-only `ctx.fs` adapter is a key barrier against user route handlers
- * reading arbitrary host files. The guard is both:
+ * Worker permissions restrict direct Deno filesystem reads to an explicit
+ * allow-list, and this read-only `ctx.fs` adapter further confines framework
+ * filesystem access to the project directory. The guard is both:
  *  - cross-platform (uses `relative()`, not a hard-coded `/` separator), and
  *  - symlink-safe (canonicalizes via `Deno.realPath` so a symlink inside the
  *    project that points outside it is rejected, not followed).


### PR DESCRIPTION
## Summary
- replace compiled-binary worker read:true with an explicit allow-list
- include project read paths plus compiled framework/cache support paths
- add regressions for compiled permission construction and direct Deno reads outside the project scope

Closes #2245

## Verification
- deno test --no-check --allow-all src/security/sandbox/worker-permissions.test.ts
- deno test --no-check --allow-all --unstable-worker-options src/security/sandbox/worker-script.test.ts src/security/sandbox/worker-pool.test.ts src/security/sandbox/project-worker.test.ts
- deno check src/security/sandbox/worker-permissions.ts src/security/sandbox/worker-permissions.test.ts src/security/sandbox/project-worker.test.ts src/security/sandbox/worker-script.ts
- pre-push hook: format, lint, type check, generation, unit suite: 2025 passed, 18167 steps

## Risk
Hosted tests (binary e2e) are the final validation for compiled-binary module loading.