### PR TITLE
Rewrite module imports by source span

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.740",
+  "version": "0.1.741",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/rendering/orchestrator/module-loader/dependency-resolver.test.ts
+++ b/src/rendering/orchestrator/module-loader/dependency-resolver.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { dirname, join } from "#veryfront/compat/path/index.ts";
 import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
 import {
+  type ResolvedModuleDependency,
   resolveModuleDependencies,
   rewriteResolvedDependencyImports,
 } from "./dependency-resolver.ts";
@@ -25,6 +26,14 @@ async function withDependencyFixture<T>(
   } finally {
     await Deno.remove(projectDir, { recursive: true }).catch(() => undefined);
   }
+}
+
+function withSpan<T extends { full: string }>(
+  source: string,
+  dep: T,
+): T & { start: number; end: number } {
+  const start = source.indexOf(dep.full);
+  return { ...dep, start, end: start + dep.full.length };
 }
 
 describe("module-loader/dependency-resolver", () => {
@@ -66,25 +75,60 @@ describe("module-loader/dependency-resolver", () => {
     ].join("\n");
 
     const rewritten = rewriteResolvedDependencyImports(source, [
-      {
+      withSpan(source, {
         full: `from "@/Button"`,
         path: "@/Button",
         relativePath: "Button",
         depFilePath: "/project/components/Button.tsx",
         depTempPath: "/tmp/components/Button.abc.js",
         isLocalLib: false,
-      },
-      {
+      }),
+      withSpan(source, {
         full: `from "../lib/value"`,
         path: "../lib/value",
         relativePath: "../lib/value",
         depFilePath: "/project/lib/value.ts",
         depTempPath: "/tmp/lib/value.def.js",
         isLocalLib: false,
-      },
+      }),
     ]);
 
     assertStringIncludes(rewritten, `from "file:///tmp/components/Button.abc.js"`);
     assertStringIncludes(rewritten, `from "file:///tmp/lib/value.def.js"`);
+  });
+
+  it("rewrites the matched import instead of the same text in an earlier comment", async () => {
+    await withDependencyFixture(
+      {
+        "app/page.tsx": [
+          `// Previous example: from "@/Button"`,
+          `import { Button } from "@/Button";`,
+          `export const page = Button;`,
+        ].join("\n"),
+        "components/Button.tsx": `export const Button = "button";`,
+      },
+      async ({ projectDir }) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.tsx");
+        const fileContent = await Deno.readTextFile(filePath);
+
+        const deps = await resolveModuleDependencies({
+          adapter,
+          fileContent,
+          filePath,
+          projectDir,
+        });
+        const transformedDeps: Array<ResolvedModuleDependency & { depTempPath: string }> = deps
+          .map((dep) => ({ ...dep, depTempPath: "/tmp/components/Button.abc.js" }));
+
+        const rewritten = rewriteResolvedDependencyImports(fileContent, transformedDeps);
+
+        assertStringIncludes(rewritten, `// Previous example: from "@/Button"`);
+        assertStringIncludes(
+          rewritten,
+          `import { Button } from "file:///tmp/components/Button.abc.js";`,
+        );
+      },
+    );
   });
 });

--- a/src/rendering/orchestrator/module-loader/dependency-resolver.ts
+++ b/src/rendering/orchestrator/module-loader/dependency-resolver.ts
@@ -1,17 +1,24 @@
 import { dirname, join, normalize } from "#veryfront/compat/path/index.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { parallelMap, rendererLogger } from "#veryfront/utils";
+import {
+  findStaticImportFromSpans,
+  replaceSourceSpans,
+  type SourceSpanReplacement,
+} from "#veryfront/transforms/mdx/esm-module-loader/utils/source-spans.ts";
 import { findSourceFile } from "../file-resolver/index.ts";
 
 const logger = rendererLogger.component("module-loader");
 
-type AliasImport = { full: string; path: string };
-type RelativeImport = { full: string; path: string; fromDir: string };
+type AliasImport = { full: string; path: string; start: number; end: number };
+type RelativeImport = { full: string; path: string; fromDir: string; start: number; end: number };
 
 /** Resolved local module dependency discovered in a source module. */
 export type ResolvedModuleDependency = {
   full: string;
   path: string;
+  start: number;
+  end: number;
   relativePath: string;
   depFilePath: string | null;
   isLocalLib: boolean;
@@ -31,15 +38,29 @@ export interface ResolveModuleDependenciesInput {
 }
 
 function collectAliasImports(fileContent: string): AliasImport[] {
-  return [...fileContent.matchAll(/from\s+["'](@\/[^"']+)["']/g)].map((m) => ({
-    full: m[0],
-    path: m[1] ?? "",
+  return findStaticImportFromSpans(
+    fileContent,
+    (specifier) => specifier.startsWith("@/") ? specifier : null,
+  ).map(({ original, path, start, end }) => ({
+    full: original,
+    path,
+    start,
+    end,
   }));
 }
 
 function collectRelativeImports(fileContent: string, fileDir: string): RelativeImport[] {
-  return [...fileContent.matchAll(/from\s+["'](\.\.?\/[^"']+)["']/g)]
-    .map((m) => ({ full: m[0], path: m[1] ?? "", fromDir: fileDir }))
+  return findStaticImportFromSpans(
+    fileContent,
+    (specifier) => specifier.match(/^(\.\.?\/[^?]+)(?:\?.*)?$/)?.[1],
+  )
+    .map(({ original, path, start, end }) => ({
+      full: original,
+      path,
+      fromDir: fileDir,
+      start,
+      end,
+    }))
     // Ignore already-transformed file:// imports.
     .filter((imp) => !imp.path.includes("file://"));
 }
@@ -102,6 +123,8 @@ async function resolveRelativeImport(
   return {
     full: imp.full,
     path: imp.path,
+    start: imp.start,
+    end: imp.end,
     relativePath: imp.path,
     depFilePath,
     isLocalLib: false,
@@ -141,9 +164,11 @@ export function rewriteResolvedDependencyImports(
   fileContent: string,
   transformedDeps: TransformedModuleDependency[],
 ): string {
-  let rewritten = fileContent;
-  for (const dep of transformedDeps) {
-    rewritten = rewritten.replace(dep.full, `from "file://${dep.depTempPath}"`);
-  }
-  return rewritten;
+  const replacements: SourceSpanReplacement[] = transformedDeps.map((dep) => ({
+    start: dep.start,
+    end: dep.end,
+    expected: dep.full,
+    replacement: `from "file://${dep.depTempPath}"`,
+  }));
+  return replaceSourceSpans(fileContent, replacements);
 }

--- a/src/transforms/mdx/esm-module-loader/loader-helpers.ts
+++ b/src/transforms/mdx/esm-module-loader/loader-helpers.ts
@@ -18,6 +18,11 @@ import { exists as fsExists } from "#veryfront/platform/compat/fs.ts";
 import { LOG_PREFIX_MDX_LOADER } from "./constants.ts";
 import { getLocalFs } from "./cache/index.ts";
 import { createStubModule } from "./utils/stub-module.ts";
+import {
+  findStaticImportFromSpans,
+  replaceSourceSpans,
+  type SourceSpanReplacement,
+} from "./utils/source-spans.ts";
 import { createModuleFetcherContext, fetchAndCacheModule } from "./module-fetcher/index.ts";
 import { buildMissingModuleError } from "./missing-module.ts";
 import type { ESMLoaderContext } from "./types.ts";
@@ -95,17 +100,13 @@ export async function initializeCacheDir(context: ESMLoaderContext): Promise<str
 /**
  * Find /_vf_modules/ imports in code.
  */
-export function findVfModuleImports(code: string): Array<{ original: string; path: string }> {
-  const imports: Array<{ original: string; path: string }> = [];
-  const pattern = /from\s*["'](\/?)(_vf_modules\/[^"']+)["']/g;
-
-  let match: RegExpExecArray | null;
-  while ((match = pattern.exec(code)) !== null) {
-    const [original, , path] = match;
-    if (path) imports.push({ original, path });
-  }
-
-  return imports;
+export function findVfModuleImports(
+  code: string,
+): Array<{ original: string; path: string; start: number; end: number }> {
+  return findStaticImportFromSpans(
+    code,
+    (specifier) => specifier.match(/^\/?(_vf_modules\/[^?]+)(?:\?.*)?$/)?.[1],
+  );
 }
 
 /**
@@ -113,7 +114,7 @@ export function findVfModuleImports(code: string): Array<{ original: string; pat
  */
 export async function processVfModuleImports(
   code: string,
-  imports: Array<{ original: string; path: string }>,
+  imports: Array<{ original: string; path: string; start: number; end: number }>,
   context: ESMLoaderContext,
   projectDir: string,
   strictMissingModules: boolean,
@@ -165,7 +166,7 @@ export async function processVfModuleImports(
   const fetchStart = performance.now();
 
   const results = await Promise.all(
-    imports.map(async ({ original, path }, index) => {
+    imports.map(async ({ original, path, start, end }, index) => {
       return await withSpan(
         SpanNames.MDX_FETCH_MODULE,
         async () => {
@@ -182,7 +183,7 @@ export async function processVfModuleImports(
             path,
             durationMs: (performance.now() - moduleStart).toFixed(1),
           });
-          return { original, filePath, path };
+          return { original, start, end, filePath, path };
         },
         {
           "mdx.module_path": path,
@@ -199,10 +200,15 @@ export async function processVfModuleImports(
     durationMs: (performance.now() - fetchStart).toFixed(1),
   });
 
-  let result = code;
-  for (const { original, filePath, path } of results) {
+  const replacements: SourceSpanReplacement[] = [];
+  for (const { original, start, end, filePath, path } of results) {
     if (filePath) {
-      result = result.replace(original, `from "file://${filePath}"`);
+      replacements.push({
+        start,
+        end,
+        expected: original,
+        replacement: `from "file://${filePath}"`,
+      });
       continue;
     }
 
@@ -216,9 +222,16 @@ export async function processVfModuleImports(
       });
     }
 
-    const stubPath = await createStubModule(path, result, original, context.esmCacheDir!);
-    if (stubPath) result = result.replace(original, `from "file://${stubPath}"`);
+    const stubPath = await createStubModule(path, code, original, context.esmCacheDir!);
+    if (stubPath) {
+      replacements.push({
+        start,
+        end,
+        expected: original,
+        replacement: `from "file://${stubPath}"`,
+      });
+    }
   }
 
-  return result;
+  return replaceSourceSpans(code, replacements);
 }

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.test.ts
@@ -1,0 +1,50 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { Logger } from "#veryfront/utils/logger/logger.ts";
+import { fetchModuleViaHTTP } from "./http-fetcher.ts";
+
+describe("module-fetcher/http-fetcher", () => {
+  it("rewrites the matched import instead of the same text in an earlier comment", async () => {
+    const originalFetch = globalThis.fetch;
+    const logger = { debug: () => {}, warn: () => {} } as unknown as Logger;
+    const adapter = {
+      env: {
+        get(key: string) {
+          if (key === "VERYFRONT_DEV_PORT") return "3001";
+          return undefined;
+        },
+      },
+    } as RuntimeAdapter;
+
+    try {
+      globalThis.fetch = async () =>
+        new Response([
+          `// Previous example: from "./local.js"`,
+          `import local from "./local.js";`,
+          `export { local };`,
+        ].join("\n"));
+
+      const result = await fetchModuleViaHTTP(
+        "_vf_modules/pages/index.js",
+        adapter,
+        (path) => Promise.resolve(`/cache/${path.replaceAll("/", "__")}.mjs`),
+        logger,
+        "docs",
+        true,
+      );
+
+      assertEquals(
+        result,
+        [
+          `// Previous example: from "./local.js"`,
+          `import local from "file:///cache/.__local.js.mjs";`,
+          `export { local };`,
+        ].join("\n"),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.ts
@@ -14,6 +14,7 @@ import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 import { rewriteVeryfrontImports } from "./import-rewriter.ts";
 import { findNestedImports } from "./nested-imports.ts";
+import { replaceSourceSpans, type SourceSpanReplacement } from "../utils/source-spans.ts";
 
 /**
  * Fetch module via HTTP as a fallback (local development only).
@@ -60,26 +61,44 @@ export async function fetchModuleViaHTTP(
     return null;
   }
 
-  let moduleCode = rewriteVeryfrontImports(await response.text());
+  const moduleCode = rewriteVeryfrontImports(await response.text());
 
   const { vfModules, relative } = findNestedImports(moduleCode);
   const allImports = [
-    ...vfModules.map(({ original, path }) => ({ original, path, key: "nestedPath" as const })),
-    ...relative.map(({ original, path }) => ({ original, path, key: "relativePath" as const })),
+    ...vfModules.map(({ original, path, start, end }) => ({
+      original,
+      path,
+      start,
+      end,
+      key: "nestedPath" as const,
+    })),
+    ...relative.map(({ original, path, start, end }) => ({
+      original,
+      path,
+      start,
+      end,
+      key: "relativePath" as const,
+    })),
   ];
 
   const results = await Promise.all(
-    allImports.map(async ({ original, path, key }) => {
+    allImports.map(async ({ original, path, start, end, key }) => {
       const nestedFilePath = await fetchAndCacheModuleFn(path, normalizedPath);
-      return { original, nestedFilePath, [key]: path };
+      return { original, start, end, nestedFilePath, [key]: path };
     }),
   );
 
-  for (const { original, nestedFilePath } of results) {
+  const replacements: SourceSpanReplacement[] = [];
+  for (const { original, start, end, nestedFilePath } of results) {
     if (nestedFilePath) {
-      moduleCode = moduleCode.replace(original, `from "file://${nestedFilePath}"`);
+      replacements.push({
+        start,
+        end,
+        expected: original,
+        replacement: `from "file://${nestedFilePath}"`,
+      });
     }
   }
 
-  return moduleCode;
+  return replaceSourceSpans(moduleCode, replacements);
 }

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.test.ts
@@ -32,6 +32,21 @@ describe("rewriteVeryfrontImports", () => {
     const code = `import { z } from "zod";\n`;
     assertEquals(rewriteVeryfrontImports(code), code);
   });
+
+  it("rewrites veryfront imports without changing earlier comments", () => {
+    const code = [
+      `// Previous example: from "veryfront/head"`,
+      `import { Head } from "veryfront/head";`,
+    ].join("\n");
+
+    assertEquals(
+      rewriteVeryfrontImports(code),
+      [
+        `// Previous example: from "veryfront/head"`,
+        `import { Head } from "/_vf_modules/_veryfront/react/runtime/core.js?ssr=true";`,
+      ].join("\n"),
+    );
+  });
 });
 
 describe("rewriteDntImports", () => {
@@ -68,5 +83,19 @@ describe("rewriteDntImports", () => {
     assertEquals(result.includes(`from "file://`), true);
     assertEquals(result.includes(`from "./ai/csp-nonce.js"`), false);
     assertEquals(/\/ai\/csp-nonce\./.test(rewrittenSpecifier), true);
+  });
+
+  it("rewrites the matched import instead of the same text in an earlier comment", async () => {
+    const sourceDir = join(FRAMEWORK_ROOT, "dist/framework-src/react/components");
+    const code = [
+      `// Previous example: from "./ai/csp-nonce.js"`,
+      `import { getDocumentNonce } from "./ai/csp-nonce.js";`,
+    ].join("\n");
+
+    const result = await rewriteDntImports(code, `${sourceDir}/Head.tsx.src`);
+    const lines = result.split("\n");
+
+    assertEquals(lines[0], `// Previous example: from "./ai/csp-nonce.js"`);
+    assertEquals(lines[1]?.includes(`from "file://`), true);
   });
 });

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.ts
@@ -8,17 +8,33 @@ import { dirname, join, resolve } from "#veryfront/compat/path";
 import { FRAMEWORK_ROOT } from "../constants.ts";
 import { resolveVeryfrontModuleUrl } from "../../../veryfront-module-urls.ts";
 import { getLocalFs } from "../cache/index.ts";
+import {
+  findStaticImportFromSpans,
+  findStaticSideEffectImportSpans,
+  replaceSourceSpans,
+  type SourceSpanReplacement,
+} from "../utils/source-spans.ts";
 
 /**
  * Rewrite veryfront/* imports to /_vf_modules/_veryfront/ paths for MDX module loading.
  * Uses deno.json exports/imports as the source of truth and appends ?ssr=true.
  */
 export function rewriteVeryfrontImports(code: string): string {
-  return code.replace(/from\s*["'](veryfront\/[^"']+)["']/g, (_match, specifier: string) => {
-    const mapped = resolveVeryfrontModuleUrl(specifier);
-    if (!mapped) return `from "${specifier}"`;
-    return `from "${mapped}?ssr=true"`;
+  const replacements: SourceSpanReplacement[] = findStaticImportFromSpans(
+    code,
+    (specifier) => specifier.startsWith("veryfront/") ? specifier : null,
+  ).flatMap(({ original, path, start, end }) => {
+    const mapped = resolveVeryfrontModuleUrl(path);
+    if (!mapped) return [];
+    return [{
+      start,
+      end,
+      expected: original,
+      replacement: `from "${mapped}?ssr=true"`,
+    }];
   });
+
+  return replaceSourceSpans(code, replacements);
 }
 
 /**
@@ -81,27 +97,39 @@ export async function rewriteDntImports(code: string, sourceFilePath: string): P
   let rewritten = code;
   const patterns = [
     {
-      regex: /from\s*["'](\.\.?\/[^"']+)["']/g,
+      findMatches: (source: string) =>
+        findStaticImportFromSpans(
+          source,
+          (specifier) => specifier.match(/^(\.\.?\/[^?]+)(?:\?.*)?$/)?.[1],
+        ),
       buildReplacement: (path: string) => `from "file://${path}"`,
     },
     {
-      regex: /import\s*["'](\.\.?\/[^"']+)["']/g,
+      findMatches: (source: string) =>
+        findStaticSideEffectImportSpans(
+          source,
+          (specifier) => specifier.match(/^(\.\.?\/[^?]+)(?:\?.*)?$/)?.[1],
+        ),
       buildReplacement: (path: string) => `import "file://${path}"`,
     },
   ] as const;
 
-  for (const { regex, buildReplacement } of patterns) {
-    const matches = [...rewritten.matchAll(regex)];
-    for (const match of matches) {
-      const original = match[0];
-      const relativePath = match[1];
-      if (!relativePath) continue;
+  for (const { findMatches, buildReplacement } of patterns) {
+    const matches = findMatches(rewritten);
+    const replacements: SourceSpanReplacement[] = [];
+    for (const { original, path: relativePath, start, end } of matches) {
       const absolutePath = resolve(sourceDir, relativePath);
       const resolvedPath = needsFrameworkSourceFallback
         ? await findExistingFrameworkRelativeTarget(absolutePath) ?? absolutePath
         : absolutePath;
-      rewritten = rewritten.replace(original, buildReplacement(resolvedPath));
+      replacements.push({
+        start,
+        end,
+        expected: original,
+        replacement: buildReplacement(resolvedPath),
+      });
     }
+    rewritten = replaceSourceSpans(rewritten, replacements);
   }
 
   return rewritten;

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.test.ts
@@ -123,5 +123,29 @@ import { bar } from "./local.js";
         ].join("\n"),
       );
     });
+
+    it("rewrites the matched import instead of the same text in an earlier comment", async () => {
+      const result = await resolveNestedModuleImports({
+        moduleCode: [
+          `// Previous example: from "./local.js"`,
+          `import local from "./local.js";`,
+          `export { local };`,
+        ].join("\n"),
+        esmCacheDir: "/tmp/veryfront-unused",
+        normalizedPath: "_vf_modules/pages/index.js",
+        projectSlug: "docs",
+        strictMissingModules: true,
+        fetchAndCacheModule: (path) => Promise.resolve(`/cache/${path.replaceAll("/", "__")}.mjs`),
+      });
+
+      assertEquals(
+        result,
+        [
+          `// Previous example: from "./local.js"`,
+          `import local from "file:///cache/.__local.js.mjs";`,
+          `export { local };`,
+        ].join("\n"),
+      );
+    });
   });
 });

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.ts
@@ -4,14 +4,14 @@
  * @module transforms/mdx/esm-module-loader/module-fetcher/nested-imports
  */
 
-import {
-  LOG_PREFIX_MDX_LOADER,
-  RELATIVE_IMPORT_PATTERN,
-  UNRESOLVED_VF_MODULES_PATTERN,
-  VF_MODULE_IMPORT_PATTERN,
-} from "../constants.ts";
+import { LOG_PREFIX_MDX_LOADER, UNRESOLVED_VF_MODULES_PATTERN } from "../constants.ts";
 import type { NestedImportResult } from "../types.ts";
 import { createStubModule } from "../utils/stub-module.ts";
+import {
+  findStaticImportFromSpans,
+  replaceSourceSpans,
+  type SourceSpanReplacement,
+} from "../utils/source-spans.ts";
 import { buildMissingModuleError } from "../missing-module.ts";
 import type { Logger } from "#veryfront/utils/logger/logger.ts";
 
@@ -22,26 +22,39 @@ import type { Logger } from "#veryfront/utils/logger/logger.ts";
 export function findNestedImports(
   moduleCode: string,
 ): {
-  vfModules: Array<{ original: string; path: string }>;
-  relative: Array<{ original: string; path: string }>;
+  vfModules: Array<{ original: string; path: string; start: number; end: number }>;
+  relative: Array<{ original: string; path: string; start: number; end: number }>;
 } {
-  const vfModules: Array<{ original: string; path: string }> = [];
-  const relative: Array<{ original: string; path: string }> = [];
+  const vfModules: Array<{ original: string; path: string; start: number; end: number }> = [];
+  const relative: Array<{ original: string; path: string; start: number; end: number }> = [];
 
-  const vfPattern = new RegExp(VF_MODULE_IMPORT_PATTERN.source, "g");
-  let match: RegExpExecArray | null;
-  while ((match = vfPattern.exec(moduleCode)) !== null) {
-    const rawPath = match[1];
+  for (
+    const { original, path: rawPath, start, end } of findStaticImportFromSpans(
+      moduleCode,
+      (specifier) => specifier.match(/^((?:file:\/\/)?\/?\/?_vf_modules\/[^?]+)(?:\?.*)?$/)?.[1],
+    )
+  ) {
     // Strip file:// prefix and leading slashes to get clean _vf_modules/... path
-    if (rawPath) {
-      vfModules.push({ original: match[0], path: rawPath.replace(/^(?:file:\/\/)?\/+/, "") });
-    }
+    vfModules.push({
+      original,
+      path: rawPath.replace(/^(?:file:\/\/)?\/+/, ""),
+      start,
+      end,
+    });
   }
 
-  const relativePattern = new RegExp(RELATIVE_IMPORT_PATTERN.source, "g");
-  while ((match = relativePattern.exec(moduleCode)) !== null) {
-    const path = match[1];
-    if (path) relative.push({ original: match[0], path });
+  for (
+    const { original, path, start, end } of findStaticImportFromSpans(
+      moduleCode,
+      (specifier) => specifier.match(/^(\.\.?\/[^?]+)(?:\?.*)?$/)?.[1],
+    )
+  ) {
+    relative.push({
+      original,
+      path,
+      start,
+      end,
+    });
   }
 
   return { vfModules, relative };
@@ -70,11 +83,16 @@ export async function processNestedImports(
   parentModulePath?: string,
   projectSlug?: string,
 ): Promise<string> {
-  let result = moduleCode;
+  const replacements: SourceSpanReplacement[] = [];
 
-  for (const { original, nestedFilePath, nestedPath, relativePath } of results) {
+  for (const { original, start, end, nestedFilePath, nestedPath, relativePath } of results) {
     if (nestedFilePath) {
-      result = result.replace(original, `from "file://${nestedFilePath}"`);
+      replacements.push({
+        start,
+        end,
+        expected: original,
+        replacement: `from "file://${nestedFilePath}"`,
+      });
       continue;
     }
 
@@ -89,11 +107,18 @@ export async function processNestedImports(
       });
     }
 
-    const stubPath = await createStubModule(modulePath, result, original, esmCacheDir);
-    if (stubPath) result = result.replace(original, `from "file://${stubPath}"`);
+    const stubPath = await createStubModule(modulePath, moduleCode, original, esmCacheDir);
+    if (stubPath) {
+      replacements.push({
+        start,
+        end,
+        expected: original,
+        replacement: `from "file://${stubPath}"`,
+      });
+    }
   }
 
-  return result;
+  return replaceSourceSpans(moduleCode, replacements);
 }
 
 export interface ResolveNestedModuleImportsInput {
@@ -112,7 +137,7 @@ export interface ResolveNestedModuleImportsInput {
 export async function resolveNestedModuleImports(
   input: ResolveNestedModuleImportsInput,
 ): Promise<string> {
-  let moduleCode = input.moduleCode;
+  const moduleCode = input.moduleCode;
   const { vfModules, relative } = findNestedImports(moduleCode);
 
   input.log?.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] found nested imports`, {
@@ -130,11 +155,17 @@ export async function resolveNestedModuleImports(
     count: vfModules.length,
   });
   const vfStart = performance.now();
+  const allImports = [
+    ...vfModules.map((module) => ({ ...module, key: "nestedPath" as const })),
+    ...relative.map((module) => ({ ...module, key: "relativePath" as const })),
+  ];
   const nestedResults = await Promise.all(
-    vfModules.map(async ({ original, path }) => ({
+    allImports.map(async ({ original, path, start, end, key }) => ({
       original,
+      start,
+      end,
       nestedFilePath: await input.fetchAndCacheModule(path, input.normalizedPath),
-      nestedPath: path,
+      [key]: path,
     })),
   );
   input.log?.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] processing vfModules DONE`, {
@@ -142,42 +173,19 @@ export async function resolveNestedModuleImports(
     normalizedPath: input.normalizedPath,
     vfMs: (performance.now() - vfStart).toFixed(1),
   });
-  moduleCode = await processNestedImports(
-    moduleCode,
-    nestedResults,
-    input.esmCacheDir,
-    input.strictMissingModules,
-    input.normalizedPath,
-    input.projectSlug,
-  );
 
   input.log?.debug(
-    `${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] processing relative imports START`,
+    `${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] processing relative imports`,
     {
       projectSlug: input.projectSlug,
       normalizedPath: input.normalizedPath,
       count: relative.length,
     },
   );
-  const relStart = performance.now();
-  const relativeResults = await Promise.all(
-    relative.map(async ({ original, path }) => ({
-      original,
-      nestedFilePath: await input.fetchAndCacheModule(path, input.normalizedPath),
-      relativePath: path,
-    })),
-  );
-  input.log?.debug(
-    `${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] processing relative imports DONE`,
-    {
-      projectSlug: input.projectSlug,
-      normalizedPath: input.normalizedPath,
-      relMs: (performance.now() - relStart).toFixed(1),
-    },
-  );
+
   return await processNestedImports(
     moduleCode,
-    relativeResults,
+    nestedResults,
     input.esmCacheDir,
     input.strictMissingModules,
     input.normalizedPath,

--- a/src/transforms/mdx/esm-module-loader/types.ts
+++ b/src/transforms/mdx/esm-module-loader/types.ts
@@ -31,6 +31,8 @@ export interface FSAdapter {
 interface ImportMatch {
   original: string;
   path: string;
+  start: number;
+  end: number;
 }
 
 interface ModuleFetchResult {
@@ -41,6 +43,8 @@ interface ModuleFetchResult {
 
 export interface NestedImportResult {
   original: string;
+  start: number;
+  end: number;
   nestedFilePath: string | null;
   nestedPath?: string;
   relativePath?: string;

--- a/src/transforms/mdx/esm-module-loader/utils/source-spans.ts
+++ b/src/transforms/mdx/esm-module-loader/utils/source-spans.ts
@@ -1,0 +1,257 @@
+/**
+ * Source-span replacement helpers for import rewrites.
+ *
+ * @module transforms/mdx/esm-module-loader/utils/source-spans
+ */
+
+export interface SourceSpanReplacement {
+  start: number;
+  end: number;
+  replacement: string;
+  expected?: string;
+}
+
+export interface StaticImportSpan {
+  original: string;
+  path: string;
+  start: number;
+  end: number;
+}
+
+type SpecifierMatcher = (specifier: string) => string | null | undefined;
+
+export function replaceSourceSpans(
+  source: string,
+  replacements: SourceSpanReplacement[],
+): string {
+  let result = source;
+  const sorted = [...replacements].sort((left, right) => right.start - left.start);
+
+  for (const { start, end, replacement, expected } of sorted) {
+    if (start < 0 || end < start || end > source.length) {
+      throw new RangeError(`Invalid source replacement span: ${start}-${end}`);
+    }
+
+    if (expected !== undefined && source.slice(start, end) !== expected) {
+      throw new Error(`Source replacement span did not match expected text: ${expected}`);
+    }
+
+    result = result.slice(0, start) + replacement + result.slice(end);
+  }
+
+  return result;
+}
+
+function isIdentifierChar(char: string | undefined): boolean {
+  return char !== undefined && /[A-Za-z0-9_$]/.test(char);
+}
+
+function isStatementKeywordAt(
+  source: string,
+  index: number,
+  keyword: "import" | "export",
+): boolean {
+  if (!source.startsWith(keyword, index)) return false;
+  if (isIdentifierChar(source[index - 1]) || source[index - 1] === ".") return false;
+  if (isIdentifierChar(source[index + keyword.length])) return false;
+
+  const lineStart = source.lastIndexOf("\n", index - 1) + 1;
+  return /^[\t ]*$/.test(source.slice(lineStart, index));
+}
+
+function skipIgnored(source: string, index: number): number {
+  const char = source[index];
+  const next = source[index + 1];
+
+  if (char === "/" && next === "/") {
+    const newline = source.indexOf("\n", index + 2);
+    return newline === -1 ? source.length : newline + 1;
+  }
+
+  if (char === "/" && next === "*") {
+    const end = source.indexOf("*/", index + 2);
+    return end === -1 ? source.length : end + 2;
+  }
+
+  if (char === '"' || char === "'" || char === "`") {
+    let cursor = index + 1;
+    while (cursor < source.length) {
+      if (source[cursor] === "\\") {
+        cursor += 2;
+        continue;
+      }
+      if (source[cursor] === char) return cursor + 1;
+      cursor++;
+    }
+    return source.length;
+  }
+
+  return index;
+}
+
+function skipWhitespace(source: string, index: number): number {
+  let cursor = index;
+  while (/\s/.test(source[cursor] ?? "")) cursor++;
+  return cursor;
+}
+
+function nextStatementCursor(source: string, index: number): number {
+  const semicolon = source.indexOf(";", index);
+  const newline = source.indexOf("\n", index);
+  const candidates = [semicolon, newline].filter((position) => position >= 0);
+  if (candidates.length === 0) return source.length;
+  return Math.min(...candidates) + 1;
+}
+
+function readQuotedSpecifier(
+  source: string,
+  quoteIndex: number,
+): { end: number; specifier: string } | null {
+  const quote = source[quoteIndex];
+  if (quote !== '"' && quote !== "'") return null;
+
+  let cursor = quoteIndex + 1;
+  while (cursor < source.length) {
+    if (source[cursor] === "\\") {
+      cursor += 2;
+      continue;
+    }
+    if (source[cursor] === quote) {
+      return {
+        end: cursor + 1,
+        specifier: source.slice(quoteIndex + 1, cursor),
+      };
+    }
+    cursor++;
+  }
+
+  return null;
+}
+
+function findFromSpan(
+  source: string,
+  statementStart: number,
+  matcher: SpecifierMatcher,
+): StaticImportSpan | null {
+  let cursor = statementStart;
+
+  while (cursor < source.length) {
+    const skipped = skipIgnored(source, cursor);
+    if (skipped !== cursor) {
+      cursor = skipped;
+      continue;
+    }
+
+    if (source[cursor] === ";") return null;
+
+    if (
+      source.startsWith("from", cursor) &&
+      !isIdentifierChar(source[cursor - 1]) &&
+      !isIdentifierChar(source[cursor + 4])
+    ) {
+      const quoteIndex = skipWhitespace(source, cursor + 4);
+      const quoted = readQuotedSpecifier(source, quoteIndex);
+      if (!quoted) {
+        cursor++;
+        continue;
+      }
+
+      const matchedPath = matcher(quoted.specifier);
+      if (!matchedPath) return null;
+
+      return {
+        original: source.slice(cursor, quoted.end),
+        path: matchedPath,
+        start: cursor,
+        end: quoted.end,
+      };
+    }
+
+    cursor++;
+  }
+
+  return null;
+}
+
+export function findStaticImportFromSpans(
+  source: string,
+  matcher: SpecifierMatcher,
+): StaticImportSpan[] {
+  const spans: StaticImportSpan[] = [];
+  let cursor = 0;
+
+  while (cursor < source.length) {
+    const skipped = skipIgnored(source, cursor);
+    if (skipped !== cursor) {
+      cursor = skipped;
+      continue;
+    }
+
+    const isImport = isStatementKeywordAt(source, cursor, "import");
+    const isExport = isStatementKeywordAt(source, cursor, "export");
+    if (!isImport && !isExport) {
+      cursor++;
+      continue;
+    }
+
+    const keywordLength = isImport ? "import".length : "export".length;
+    const afterKeyword = skipWhitespace(source, cursor + keywordLength);
+    if (isImport && source[afterKeyword] === "(") {
+      cursor = afterKeyword + 1;
+      continue;
+    }
+
+    const span = findFromSpan(source, afterKeyword, matcher);
+    if (span) {
+      spans.push(span);
+      cursor = span.end;
+      continue;
+    }
+
+    cursor = nextStatementCursor(source, afterKeyword);
+  }
+
+  return spans;
+}
+
+export function findStaticSideEffectImportSpans(
+  source: string,
+  matcher: SpecifierMatcher,
+): StaticImportSpan[] {
+  const spans: StaticImportSpan[] = [];
+  let cursor = 0;
+
+  while (cursor < source.length) {
+    const skipped = skipIgnored(source, cursor);
+    if (skipped !== cursor) {
+      cursor = skipped;
+      continue;
+    }
+
+    if (!isStatementKeywordAt(source, cursor, "import")) {
+      cursor++;
+      continue;
+    }
+
+    const quoteIndex = skipWhitespace(source, cursor + "import".length);
+    const quoted = readQuotedSpecifier(source, quoteIndex);
+    if (!quoted) {
+      cursor = nextStatementCursor(source, quoteIndex);
+      continue;
+    }
+
+    const matchedPath = matcher(quoted.specifier);
+    if (matchedPath) {
+      spans.push({
+        original: source.slice(cursor, quoted.end),
+        path: matchedPath,
+        start: cursor,
+        end: quoted.end,
+      });
+    }
+
+    cursor = quoted.end;
+  }
+
+  return spans;
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.740";
+export const VERSION = "0.1.741";


### PR DESCRIPTION
## Summary
- carry import source spans through MDX nested imports, HTTP fallback imports, framework DNT rewrites, loader helpers, and orchestrator dependency resolution
- replace matched import spans instead of the first matching string in the full source
- add regressions for comments containing the same import text before the actual import
- bump release metadata to 0.1.741

Closes #2236

## Verification
- deno task verify:quick
- deno test --frozen --allow-all src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.test.ts src/rendering/orchestrator/module-loader/dependency-resolver.test.ts src/transforms/mdx/esm-module-loader/loader-helpers.test.ts
- deno test --frozen --allow-all src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts
- git diff --check
- pre-push checks: format, lint, typecheck, unit tests (2026 passed, 0 failed)