### PR TITLE
Review sweep 2: XSS/output-escaping and injection hardening

### DIFF
--- a/src/build/production-build/static-generation.ts
+++ b/src/build/production-build/static-generation.ts
@@ -361,7 +361,7 @@ function generateClientRuntime(
   <script type="module">
     import { boot } from '/_veryfront/client.js';
     if (typeof boot === 'function') {
-      boot({ slug: '${route.slug}' });
+      boot({ slug: ${JSON.stringify(route.slug)} });
     }
   </script>
 </body>`;

--- a/src/cache/backends/api.ts
+++ b/src/cache/backends/api.ts
@@ -85,7 +85,7 @@ export class ApiCacheBackend implements CacheBackend {
 
     try {
       return await this.circuitBreaker.execute(async () => {
-        const url = `${this.apiBaseUrl}/projects/${projectRef}/cache${path}`;
+        const url = `${this.apiBaseUrl}/projects/${encodeURIComponent(projectRef)}/cache${path}`;
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
 
@@ -104,7 +104,10 @@ export class ApiCacheBackend implements CacheBackend {
               }),
             {
               "http.method": method,
-              "http.url": url,
+              // Drop the query string: it carries the (encoded) cache key,
+              // and span attributes bypass log redaction on their way to the
+              // tracing backend.
+              "http.url": url.split("?")[0] ?? url,
               "http.host": new URL(this.apiBaseUrl).host,
               "cache.operation": path,
               "cache.project_slug": projectRef,

--- a/src/embedding/react/use-uploads.ts
+++ b/src/embedding/react/use-uploads.ts
@@ -90,7 +90,7 @@ export function useUploads(options: UseUploadsOptions): UseUploadsResult {
     async (id: string): Promise<void> => {
       setError(null);
       try {
-        await fetch(`${options.api}/${id}`, { method: "DELETE" });
+        await fetch(`${options.api}/${encodeURIComponent(id)}`, { method: "DELETE" });
         await refresh();
       } catch (error) {
         console.debug("useUploads: failed to delete upload", error);

--- a/src/html/html-escape.test.ts
+++ b/src/html/html-escape.test.ts
@@ -1,9 +1,48 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { buildAttributes, buildNonceAttribute, escapeHTML, escapeHtml } from "./html-escape.ts";
+import {
+  buildAttributes,
+  buildNonceAttribute,
+  escapeHTML,
+  escapeHtml,
+  jsonForInlineScript,
+  neutralizeRawTextContent,
+} from "./html-escape.ts";
 
 describe("html-escape", () => {
+  describe("jsonForInlineScript", () => {
+    it("neutralizes </script> breakout", () => {
+      const out = jsonForInlineScript({ title: "</script><script>alert(1)</script>" });
+      assertEquals(out.includes("</script>"), false);
+      assertEquals(out.includes("\\u003c/script>"), true);
+    });
+
+    it("escapes U+2028 and U+2029 line separators", () => {
+      const out = jsonForInlineScript({ t: "a\u2028b\u2029c" });
+      assertEquals(out.includes("\u2028"), false);
+      assertEquals(out.includes("\u2029"), false);
+      assertEquals(out.includes("\\u2028"), true);
+      assertEquals(out.includes("\\u2029"), true);
+    });
+
+    it("round-trips as valid JSON", () => {
+      const data = { a: 1, b: "</script>", c: ["x", "y"] };
+      assertEquals(JSON.parse(jsonForInlineScript(data)), data);
+    });
+  });
+
+  describe("neutralizeRawTextContent", () => {
+    it("neutralizes a closing script tag without escaping other content", () => {
+      const out = neutralizeRawTextContent("var a = 1; </script>", "script");
+      assertEquals(out, "var a = 1; <\\/script>");
+    });
+
+    it("neutralizes a closing style tag case-insensitively", () => {
+      assertEquals(neutralizeRawTextContent("a{} </STYLE>", "style"), "a{} <\\/STYLE>");
+    });
+  });
+
   describe("escapeHTML", () => {
     it("should escape ampersand", () => {
       assertEquals(escapeHTML("foo & bar"), "foo &amp; bar");

--- a/src/html/html-escape.ts
+++ b/src/html/html-escape.ts
@@ -18,3 +18,26 @@ export function buildAttributes(attrs: Record<string, string>): string {
 export function buildNonceAttribute(nonce?: string): string {
   return nonce ? ` nonce="${escapeHTML(nonce)}"` : "";
 }
+
+/**
+ * Neutralize the closing tag for a raw-text element (`script`/`style`) inside
+ * inline content, so the content cannot break out of its element. The content
+ * is otherwise left as-is (it is intentionally raw JS/CSS, not HTML).
+ */
+export function neutralizeRawTextContent(content: string, tag: "script" | "style"): string {
+  return content.replace(new RegExp(`</(${tag})`, "gi"), "<\\/$1");
+}
+
+/**
+ * Serialize a value to JSON safe for embedding inside an inline `<script>`.
+ *
+ * `JSON.stringify` alone does not neutralize `</script>` breakouts or the
+ * U+2028/U+2029 line separators (which are invalid in JS string literals),
+ * so any user-influenced data placed in a script tag must go through this.
+ */
+export function jsonForInlineScript(value: unknown, space?: number): string {
+  return JSON.stringify(value, null, space)
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -342,7 +342,7 @@ async function generateHTMLShellPartsImpl(
   ${modeStyles}
   ${slugForOverlay}
 </head>
-<body${bodyClass ? ` class="${bodyClass}"` : ""} suppressHydrationWarning>
+<body${bodyClass ? ` class="${escapeHTML(bodyClass)}"` : ""} suppressHydrationWarning>
   <div ${rootAttributes}>`;
 
   const relativePagePath = getRelativePagePath(options.pagePath, options.projectDir);

--- a/src/html/hydration-script-builder/hydration-data-generator.ts
+++ b/src/html/hydration-script-builder/hydration-data-generator.ts
@@ -2,6 +2,7 @@ import type { ComponentProps } from "#veryfront/types";
 import { resolveRelativePath } from "#veryfront/modules/react-loader/path-resolver.ts";
 import { getExtensionName } from "#veryfront/utils/path-utils.ts";
 import { determineClientModuleStrategy } from "#veryfront/rendering/rsc/client-module-strategy.ts";
+import { jsonForInlineScript } from "../html-escape.ts";
 import type { HTMLGenerationOptions } from "../types.ts";
 import type { HydrationDataStructure } from "./types.ts";
 
@@ -84,5 +85,7 @@ export function generateHydrationData(
     studioEmbed: options.studioEmbed,
   };
 
-  return JSON.stringify(data, null, serializeOptions?.pretty ?? true ? 2 : undefined);
+  // Escape for inline <script> embedding: JSON.stringify alone leaves
+  // </script> breakouts and U+2028/U+2029 in user-influenced frontmatter/props.
+  return jsonForInlineScript(data, serializeOptions?.pretty ?? true ? 2 : undefined);
 }

--- a/src/html/tag-generators.ts
+++ b/src/html/tag-generators.ts
@@ -1,5 +1,5 @@
 import type { HTMLMetadata } from "#veryfront/transforms/mdx/types.ts";
-import { buildAttributes, escapeHTML } from "./html-escape.ts";
+import { buildAttributes, escapeHTML, neutralizeRawTextContent } from "./html-escape.ts";
 
 function filterAttrs(
   obj: Record<string, unknown>,
@@ -91,7 +91,11 @@ export function generateScriptTags(
       filterAttrs(script, ["content", "src"]),
       nonce,
     );
-    tags.push(`<script ${buildAttributes(attrs)}>${script.content}</script>`);
+    tags.push(
+      `<script ${buildAttributes(attrs)}>${
+        neutralizeRawTextContent(script.content, "script")
+      }</script>`,
+    );
   }
 
   return tags.join("\n  ");
@@ -113,7 +117,11 @@ export function generateStyleTags(metadata: HTMLMetadata, nonce?: string): strin
       filterAttrs(style, ["content", "href"]),
       nonce,
     );
-    tags.push(`<style ${buildAttributes(attrs)}>${style.content}</style>`);
+    tags.push(
+      `<style ${buildAttributes(attrs)}>${
+        neutralizeRawTextContent(style.content, "style")
+      }</style>`,
+    );
   }
 
   return tags.join("\n  ");

--- a/src/rendering/orchestrator/html-head.ts
+++ b/src/rendering/orchestrator/html-head.ts
@@ -1,5 +1,6 @@
 import type { CollectedHead } from "#veryfront/react/head-collector.ts";
 import type { MdxBundle, MDXFrontmatter } from "#veryfront/types";
+import { escapeHTML, neutralizeRawTextContent } from "#veryfront/html/html-escape.ts";
 
 interface FrontmatterContextLike {
   pageInfo: { entity: { frontmatter?: Record<string, unknown> } };
@@ -29,9 +30,11 @@ export function buildHeadElements(head?: CollectedHead): { scripts: string; othe
       attrPairs.push(["data-vf-hash", "vf" + Math.abs(sum).toString(36)]);
     }
 
-    const attrStr = attrPairs.map(([k, v]) => `${k}="${v}"`).join(" ");
+    const attrStr = attrPairs.map(([k, v]) => `${k}="${escapeHTML(v)}"`).join(" ");
     if (content) {
-      scriptParts.push(`<script ${attrStr}>${content}</script>`);
+      scriptParts.push(
+        `<script ${attrStr}>${neutralizeRawTextContent(content, "script")}</script>`,
+      );
     } else if (attrs.src) {
       scriptParts.push(`<script ${attrStr}></script>`);
     }
@@ -41,22 +44,22 @@ export function buildHeadElements(head?: CollectedHead): { scripts: string; othe
     if (meta.name === "description") continue;
 
     const attrs: string[] = [];
-    if (meta.name) attrs.push(`name="${meta.name}"`);
-    if (meta.property) attrs.push(`property="${meta.property}"`);
-    if (meta.content) attrs.push(`content="${meta.content}"`);
+    if (meta.name) attrs.push(`name="${escapeHTML(meta.name)}"`);
+    if (meta.property) attrs.push(`property="${escapeHTML(meta.property)}"`);
+    if (meta.content) attrs.push(`content="${escapeHTML(meta.content)}"`);
     if (attrs.length) otherParts.push(`<meta ${attrs.join(" ")}>`);
   }
 
   for (const link of head.links) {
     const attrs = Object.entries(link)
       .filter(([, v]) => v != null)
-      .map(([k, v]) => `${k}="${v}"`)
+      .map(([k, v]) => `${k}="${escapeHTML(String(v))}"`)
       .join(" ");
     if (attrs) otherParts.push(`<link ${attrs}>`);
   }
 
   for (const style of head.styles) {
-    otherParts.push(`<style>${style}</style>`);
+    otherParts.push(`<style>${neutralizeRawTextContent(style, "style")}</style>`);
   }
 
   return {

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -8,6 +8,7 @@ import {
   injectHTMLContent,
   isFullHTMLDocument,
 } from "#veryfront/html";
+import { buildNonceAttribute } from "#veryfront/html/html-escape.ts";
 import type { MDXFrontmatter } from "#veryfront/types";
 import { DEFAULT_DASHBOARD_PORT, rendererLogger } from "#veryfront/utils";
 import { addNonceToHtmlTags } from "#veryfront/html/nonce-injection.ts";
@@ -81,7 +82,7 @@ function injectThemePersistenceScript(
   if (!enabled || !colorScheme || !/<\/head>/i.test(html)) return html;
   if (html.includes(`localStorage.setItem('theme','${colorScheme}')`)) return html;
 
-  const nonceAttr = nonce ? ` nonce="${nonce}"` : "";
+  const nonceAttr = buildNonceAttribute(nonce);
   const script = `<script${nonceAttr}>
 (function(){try{localStorage.setItem('theme','${colorScheme}')}catch(e){/* SILENT: localStorage may be unavailable */}})();
 </script>`;


### PR DESCRIPTION
First of three PRs from the second review sweep. Output-escaping / injection hardening. All changed files typecheck, lint, and the full unit suite passes (pre-push).

## Fixes
- **#2251 (HIGH)** Hydration data embedded in an inline `<script>` went through plain `JSON.stringify` — `</script>` and U+2028/U+2029 breakouts. Now routed through a new `jsonForInlineScript` helper.
- **#2252 (HIGH/MED)** Output-escaping gaps:
  - `bodyClass` → `escapeHTML` into the `<body class>` attribute.
  - static-gen `slug` → `JSON.stringify` into its inline `boot()` script.
  - theme-persistence nonce → `buildNonceAttribute`.
  - `html-head` meta/link attribute values → `escapeHTML`.
  - frontmatter `script.content` / `style.content` → `neutralizeRawTextContent` (guards `</script>`/`</style>` without HTML-escaping intentional raw JS/CSS).
- **#2253 (HIGH)** API cache backend: `encodeURIComponent(projectRef)` in the URL path (path-injection guard) and strip the query string from the `http.url` span attribute (span attributes bypass log redaction; the query carries the cache key).
- **#2257 (part)** `use-uploads` delete: `encodeURIComponent(id)`.

## New helpers + tests
`jsonForInlineScript` and `neutralizeRawTextContent` added to `src/html/html-escape.ts` with unit tests (breakout neutralization, U+2028/29 escaping, JSON round-trip).

## Note on trust model
These are output-escaping fixes — correct as defense-in-depth regardless of whether frontmatter/slug are treated as trusted. The hydration one (#2251) is the clearest exploitable XSS since props/frontmatter reach a `<script>` tag.

Remaining sweep-2 work in follow-up PRs: bugs/concurrency (#2249, #2250, #2254–#2256) and performance (#2259–#2262).