### PR TITLE
Prevent OAuth refresh token races

### DIFF
--- a/src/oauth/providers/base.test.ts
+++ b/src/oauth/providers/base.test.ts
@@ -197,6 +197,75 @@ async function withTokenFetch(
 }
 
 Deno.test(
+  "OAuthService.getAccessToken: concurrent expired-token reads share one refresh",
+  async () => {
+    let storedTokens: OAuthTokens = {
+      accessToken: "expired-access-token",
+      refreshToken: "rotating-refresh-token",
+      tokenType: "Bearer",
+      scope: "read",
+      expiresAt: Date.now() - 60_000,
+    };
+    let setTokenCalls = 0;
+    const tokenStore: TokenStore = {
+      getTokens(): Promise<OAuthTokens | null> {
+        return Promise.resolve(storedTokens);
+      },
+      setTokens(_serviceId: string, _userId: string, tokens: OAuthTokens): Promise<void> {
+        setTokenCalls++;
+        storedTokens = tokens;
+        return Promise.resolve();
+      },
+      clearTokens(): Promise<void> {
+        return Promise.resolve();
+      },
+      setState(): Promise<void> {
+        return Promise.resolve();
+      },
+      consumeState(): Promise<StoredOAuthState | null> {
+        return Promise.resolve(null);
+      },
+    };
+    const service = new OAuthService(TEST_CONFIG, tokenStore, (k) => ENV[k]);
+    const original = globalThis.fetch;
+    let refreshCalls = 0;
+    globalThis.fetch = ((): Promise<Response> => {
+      refreshCalls++;
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: "fresh-access-token",
+            refresh_token: "rotated-refresh-token",
+            token_type: "Bearer",
+            scope: "read",
+            expires_in: 3600,
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+    }) as typeof fetch;
+
+    try {
+      const [first, second] = await Promise.all([
+        service.getAccessToken("user-1"),
+        service.getAccessToken("user-1"),
+      ]);
+
+      assertEquals(first, "fresh-access-token");
+      assertEquals(second, "fresh-access-token");
+      assertEquals(refreshCalls, 1);
+      assertEquals(setTokenCalls, 1);
+      assertEquals(storedTokens.refreshToken, "rotated-refresh-token");
+    } finally {
+      globalThis.fetch = original;
+    }
+  },
+);
+
+Deno.test(
   "OAuthService.exchangeCode: 200 with no access_token is treated as failure (H11)",
   async () => {
     const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);

--- a/src/oauth/providers/base.ts
+++ b/src/oauth/providers/base.ts
@@ -316,6 +316,7 @@ export class OAuthProvider {
 export class OAuthService extends OAuthProvider {
   protected serviceConfig: OAuthServiceConfig;
   protected tokenStore?: TokenStore;
+  private refreshPromises = new Map<string, Promise<string | null>>();
 
   constructor(config: OAuthServiceConfig, tokenStore?: TokenStore, envReader?: EnvReader) {
     super(config, envReader);
@@ -329,6 +330,10 @@ export class OAuthService extends OAuthProvider {
 
   get apiBaseUrl(): string {
     return this.serviceConfig.apiBaseUrl;
+  }
+
+  private refreshKey(userId: string): string {
+    return JSON.stringify([this.serviceId, userId]);
   }
 
   override createAuthorizationUrl(
@@ -356,7 +361,27 @@ export class OAuthService extends OAuthProvider {
 
     if (!tokens.refreshToken) return null;
 
-    const result = await this.refreshTokens(tokens.refreshToken);
+    const key = this.refreshKey(userId);
+    const existingRefresh = this.refreshPromises.get(key);
+    if (existingRefresh) return existingRefresh;
+
+    const refreshPromise = this.refreshAndStoreAccessToken(userId, tokens.refreshToken);
+    this.refreshPromises.set(key, refreshPromise);
+
+    try {
+      return await refreshPromise;
+    } finally {
+      if (this.refreshPromises.get(key) === refreshPromise) {
+        this.refreshPromises.delete(key);
+      }
+    }
+  }
+
+  private async refreshAndStoreAccessToken(
+    userId: string,
+    refreshToken: string,
+  ): Promise<string | null> {
+    const result = await this.refreshTokens(refreshToken);
     if (!result.success || !result.tokens) return null;
 
     if (!this.tokenStore) {


### PR DESCRIPTION
## Summary
- add per-service/user singleflight for expired OAuth token refreshes
- keep refresh-token writes scoped to one in-flight refresh per user slot
- add a concurrent getAccessToken regression that fails without the dedupe

Closes #2249

## Verification
- deno test --no-check --allow-all src/oauth/providers/base.test.ts
- deno check src/oauth/providers/base.ts src/oauth/providers/base.test.ts
- deno test --no-check --allow-all src/oauth/providers/base.test.ts src/oauth/token-store/memory.test.ts src/oauth/handlers/init-handler.test.ts src/oauth/handlers/callback-handler.test.ts
- pre-push hook: format, lint, type check, generation, unit suite: 2027 passed, 18167 steps