### PR TITLE
Review sweep 2: critical concurrency + correctness fixes

### DIFF
--- a/src/oauth/providers/base.test.ts
+++ b/src/oauth/providers/base.test.ts
@@ -367,3 +367,121 @@ Deno.test(
     );
   },
 );
+
+Deno.test(
+  "OAuthService.getAccessToken: separate service instances share refresh by token store",
+  async () => {
+    const expired: OAuthTokens = {
+      accessToken: "old-token",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+      scope: "read",
+      idToken: undefined,
+      expiresAt: Date.now() - 1_000,
+    };
+    let setCount = 0;
+    const store: TokenStore = {
+      getTokens: () => Promise.resolve(expired),
+      setTokens: () => {
+        setCount++;
+        return Promise.resolve();
+      },
+      clearTokens: () => Promise.resolve(),
+      setState: () => Promise.resolve(),
+      consumeState: () => Promise.resolve(null),
+    };
+    const firstService = new OAuthService(TEST_CONFIG, store, (k) => ENV[k]);
+    const secondService = new OAuthService(TEST_CONFIG, store, (k) => ENV[k]);
+
+    const original = globalThis.fetch;
+    let tokenCalls = 0;
+    globalThis.fetch = ((input: string | URL | Request): Promise<Response> => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+      if (url === TEST_CONFIG.tokenUrl) tokenCalls++;
+      return Promise.resolve(
+        new Response(JSON.stringify({ access_token: "new-token", token_type: "Bearer" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }) as typeof fetch;
+
+    try {
+      const [first, second] = await Promise.all([
+        firstService.getAccessToken("user-concurrent"),
+        secondService.getAccessToken("user-concurrent"),
+      ]);
+      assertEquals(first, "new-token");
+      assertEquals(second, "new-token");
+      assertEquals(tokenCalls, 1);
+      assertEquals(setCount, 1);
+    } finally {
+      globalThis.fetch = original;
+    }
+  },
+);
+
+Deno.test(
+  "OAuthService.getAccessToken: separate token stores do not share refresh promises",
+  async () => {
+    function makeExpiredStore(refreshToken: string): TokenStore {
+      const expired: OAuthTokens = {
+        accessToken: `old-${refreshToken}`,
+        refreshToken,
+        tokenType: "Bearer",
+        scope: "read",
+        idToken: undefined,
+        expiresAt: Date.now() - 1_000,
+      };
+      return {
+        getTokens: () => Promise.resolve(expired),
+        setTokens: () => Promise.resolve(),
+        clearTokens: () => Promise.resolve(),
+        setState: () => Promise.resolve(),
+        consumeState: () => Promise.resolve(null),
+      };
+    }
+
+    const firstService = new OAuthService(
+      TEST_CONFIG,
+      makeExpiredStore("refresh-a"),
+      (k) => ENV[k],
+    );
+    const secondService = new OAuthService(
+      TEST_CONFIG,
+      makeExpiredStore("refresh-b"),
+      (k) => ENV[k],
+    );
+
+    const original = globalThis.fetch;
+    const refreshBodies: string[] = [];
+    globalThis.fetch = ((
+      _input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      refreshBodies.push(String(init?.body ?? ""));
+      return Promise.resolve(
+        new Response(JSON.stringify({ access_token: "new-token", token_type: "Bearer" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }) as typeof fetch;
+
+    try {
+      await Promise.all([
+        firstService.getAccessToken("same-user"),
+        secondService.getAccessToken("same-user"),
+      ]);
+      assertEquals(refreshBodies.length, 2);
+      assertEquals(refreshBodies.some((body) => body.includes("refresh-a")), true);
+      assertEquals(refreshBodies.some((body) => body.includes("refresh-b")), true);
+    } finally {
+      globalThis.fetch = original;
+    }
+  },
+);

--- a/src/oauth/providers/base.ts
+++ b/src/oauth/providers/base.ts
@@ -312,11 +312,51 @@ export class OAuthProvider {
   }
 }
 
+/**
+ * Module-level singleflight for token refreshes, scoped by TokenStore instance
+ * and then `(serviceId, userId)`. This dedupes separate OAuthService instances
+ * that share the same scoped store without making different project stores
+ * share refresh promises.
+ */
+const refreshInFlightByStore = new WeakMap<TokenStore, Map<string, Promise<string | null>>>();
+
+function getRefreshInFlight(
+  tokenStore: TokenStore,
+  key: string,
+): Promise<string | null> | undefined {
+  return refreshInFlightByStore.get(tokenStore)?.get(key);
+}
+
+function setRefreshInFlight(
+  tokenStore: TokenStore,
+  key: string,
+  promise: Promise<string | null>,
+): void {
+  let storeInflight = refreshInFlightByStore.get(tokenStore);
+  if (!storeInflight) {
+    storeInflight = new Map();
+    refreshInFlightByStore.set(tokenStore, storeInflight);
+  }
+  storeInflight.set(key, promise);
+}
+
+function clearRefreshInFlight(
+  tokenStore: TokenStore,
+  key: string,
+  promise: Promise<string | null>,
+): void {
+  const storeInflight = refreshInFlightByStore.get(tokenStore);
+  if (!storeInflight || storeInflight.get(key) !== promise) return;
+  storeInflight.delete(key);
+  if (storeInflight.size === 0) {
+    refreshInFlightByStore.delete(tokenStore);
+  }
+}
+
 /** Implement oauth service. */
 export class OAuthService extends OAuthProvider {
   protected serviceConfig: OAuthServiceConfig;
   protected tokenStore?: TokenStore;
-  private refreshPromises = new Map<string, Promise<string | null>>();
 
   constructor(config: OAuthServiceConfig, tokenStore?: TokenStore, envReader?: EnvReader) {
     super(config, envReader);
@@ -330,10 +370,6 @@ export class OAuthService extends OAuthProvider {
 
   get apiBaseUrl(): string {
     return this.serviceConfig.apiBaseUrl;
-  }
-
-  private refreshKey(userId: string): string {
-    return JSON.stringify([this.serviceId, userId]);
   }
 
   override createAuthorizationUrl(
@@ -361,19 +397,22 @@ export class OAuthService extends OAuthProvider {
 
     if (!tokens.refreshToken) return null;
 
-    const key = this.refreshKey(userId);
-    const existingRefresh = this.refreshPromises.get(key);
+    if (!this.tokenStore) {
+      throw new Error("TokenStore not configured");
+    }
+
+    const key = JSON.stringify([this.serviceId, userId]);
+    const existingRefresh = getRefreshInFlight(this.tokenStore, key);
     if (existingRefresh) return existingRefresh;
 
+    const tokenStore = this.tokenStore;
     const refreshPromise = this.refreshAndStoreAccessToken(userId, tokens.refreshToken);
-    this.refreshPromises.set(key, refreshPromise);
+    setRefreshInFlight(tokenStore, key, refreshPromise);
 
     try {
       return await refreshPromise;
     } finally {
-      if (this.refreshPromises.get(key) === refreshPromise) {
-        this.refreshPromises.delete(key);
-      }
+      clearRefreshInFlight(tokenStore, key, refreshPromise);
     }
   }
 


### PR DESCRIPTION
Second of three PRs from the second review sweep — concurrency and correctness bugs. All changed files typecheck, lint, and the full unit suite passes (pre-push).

## Critical
- **#2249** OAuth token-refresh race — `getAccessToken` was check-then-refresh-then-write with no lock; concurrent callers for the same user+service both refreshed with the same refresh token (corrupting the store with providers that rotate refresh tokens). Added a module-level singleflight keyed by `serviceId:userId`, with a concurrency regression test.
- **#2250** Renderer per-project mutex deleted while held — `releaseProjectSlot` deleted the mutex inside its own critical section, letting a concurrent acquire create a fresh unlocked mutex and defeat the per-project limit. Keep the (lightweight) mutex.

## High
- **#2254** `getReleaseKey` coerced a missing production `releaseId` to the string `"undefined"`, sharing one cache bucket across releases. Throw instead (consistent with the file's other required-context checks).
- **#2255** Skill executor timeout left the pending command promise uncaught → unhandled rejection (Deno exits non-zero). Attach a no-op catch.
- **#2256** Redis rate-limit reused a cached client after disconnect. Reset it on `error`/`end` so the next call reconnects. (The immortal-key window is already self-healed by the existing `pttl===-1` recheck.)

## Note
`api.ts` `getBatch` is already batched on main — the N+1 finding was the **Redis** backend (`redis.ts`), addressed in the performance PR (follow-up). Mediums (#2257: renderer init races, ssgPaths, MemoryTokenStore states) and the data-validation items (#2258) remain follow-ups.