### PR TITLE
Fix renderer project mutex handoff race

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.741",
+  "version": "0.1.742",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/rendering/renderer-concurrency.test.ts
+++ b/src/rendering/renderer-concurrency.test.ts
@@ -114,3 +114,51 @@ describe("Mutex", () => {
     assertEquals(counter, 20);
   });
 });
+
+describe("project render slots", () => {
+  it("does not delete a held project mutex while waiters are queued", async () => {
+    const previousLimit = Deno.env.get("RENDER_PER_PROJECT_LIMIT");
+    Deno.env.set("RENDER_PER_PROJECT_LIMIT", "1");
+    const originalDelete = Map.prototype.delete;
+    try {
+      const concurrency = await import(
+        `./renderer-concurrency.ts?queued-slot-race=${crypto.randomUUID()}`
+      );
+      const projectId = `project-${crypto.randomUUID()}`;
+      let projectDeleteCount = 0;
+      let competingAcquire: Promise<boolean> | undefined;
+
+      Map.prototype.delete = function patchedDelete<K, V>(
+        this: Map<K, V>,
+        key: K,
+      ): boolean {
+        const result = originalDelete.call(this, key);
+        if (key === projectId) {
+          projectDeleteCount++;
+          if (projectDeleteCount === 2) {
+            competingAcquire = concurrency.acquireProjectSlot(projectId);
+          }
+        }
+        return result;
+      };
+
+      assertEquals(await concurrency.acquireProjectSlot(projectId), true);
+
+      const releasing = concurrency.releaseProjectSlot(projectId);
+      const queuedAcquire = concurrency.acquireProjectSlot(projectId);
+
+      await releasing;
+      competingAcquire ??= concurrency.acquireProjectSlot(projectId);
+
+      assertEquals(await queuedAcquire, true);
+      assertEquals(await competingAcquire, false);
+    } finally {
+      Map.prototype.delete = originalDelete;
+      if (previousLimit === undefined) {
+        Deno.env.delete("RENDER_PER_PROJECT_LIMIT");
+      } else {
+        Deno.env.set("RENDER_PER_PROJECT_LIMIT", previousLimit);
+      }
+    }
+  });
+});

--- a/src/rendering/renderer-concurrency.ts
+++ b/src/rendering/renderer-concurrency.ts
@@ -178,16 +178,25 @@ export async function releaseProjectSlot(
 ): Promise<void> {
   if (RENDER_PER_PROJECT_LIMIT <= 0) return;
 
-  const release = await acquireProjectLock(projectId);
+  const mutex = getProjectMutex(projectId);
+  const release = await mutex.acquire(LOCK_TIMEOUT_MS);
+  let deleteIdleMutex = false;
   try {
     const current = projectRenderCounts.get(projectId) ?? 0;
     if (current <= 1) {
       projectRenderCounts.delete(projectId);
-      projectMutexes.delete(projectId);
+      deleteIdleMutex = mutex.waiting === 0;
       return;
     }
     projectRenderCounts.set(projectId, current - 1);
   } finally {
     release();
+    if (
+      deleteIdleMutex &&
+      !projectRenderCounts.has(projectId) &&
+      projectMutexes.get(projectId) === mutex
+    ) {
+      projectMutexes.delete(projectId);
+    }
   }
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.741";
+export const VERSION = "0.1.742";


### PR DESCRIPTION
## Summary
- Keep a project mutex mapped while it has queued waiters during last-slot release.
- Delete only idle mutexes after release when no render count was recreated and the map still points at the same mutex.
- Add a regression that proves a queued acquire cannot be bypassed by a newer acquire at per-project limit 1.
- Bump release version to 0.1.742.

Closes #2250

## Verification
- deno test --frozen --allow-all src/rendering/renderer-concurrency.test.ts
- deno task verify:quick
- git diff --check
- pre-push hook: format, lint, typecheck, unit suite (2028 passed, 0 failed)