### PR TITLE
Review sweep 2: performance — OTLP config cache, Redis MGET, hot-path cleanups

### DIFF
--- a/src/cache/paths.ts
+++ b/src/cache/paths.ts
@@ -51,6 +51,10 @@ const HARDCODED_PATH_PATTERNS = [
  * Check if code contains hardcoded cache paths that should be tokenized.
  */
 export function hasHardcodedCachePaths(code: string): boolean {
+  // Fast reject: every pattern requires a "file://" prefix, so if the code
+  // contains no file:// URL at all we skip the 12 full-string regex scans.
+  // This runs on every cache write over whole (often 50-200KB) modules.
+  if (!code.includes("file://")) return false;
   return HARDCODED_PATH_PATTERNS.some((pattern) => pattern.test(code));
 }
 

--- a/src/cache/portability.test.ts
+++ b/src/cache/portability.test.ts
@@ -94,6 +94,11 @@ describe("Cache Portability", () => {
       const code = `import x from "file:///usr/local/lib/node_modules/react/index.js"`;
       assertEquals(hasHardcodedCachePaths(code), false);
     });
+
+    it("does not detect cache marker text without file URLs", () => {
+      const code = `const cacheDir = "veryfront-http-bundle/http-123.mjs";`;
+      assertEquals(hasHardcodedCachePaths(code), false);
+    });
   });
 
   describe("Tokenization", () => {

--- a/src/observability/file-log-subscriber.ts
+++ b/src/observability/file-log-subscriber.ts
@@ -60,6 +60,7 @@ export class FileLogSubscriber {
   private closed = false;
   private permissionFailed = false;
   private config: FileLogConfig;
+  private readonly encoder = new TextEncoder();
 
   constructor(config: FileLogConfig) {
     this.config = config;
@@ -90,7 +91,7 @@ export class FileLogSubscriber {
       if (!this.file) await this.openFile();
 
       const line = this.formatter(entry) + "\n";
-      const bytes = new TextEncoder().encode(line);
+      const bytes = this.encoder.encode(line);
 
       if (this.currentSize + bytes.length > this.maxSizeBytes) {
         await this.rotate();


### PR DESCRIPTION
Rebased version of the review-sweep performance PR. The original OTLP config-cache and Redis MGET commits are now superseded by newer focused PRs already on `main`; this PR keeps only the remaining non-overlapping hot-path cleanup.

## Fixes
- **#2262 (subset)** `hasHardcodedCachePaths` now short-circuits when code contains no `file://` URL, avoiding the full hardcoded-path regex set for ordinary module strings.
- **#2262 (subset)** `FileLogSubscriber` reuses one `TextEncoder` per subscriber instead of allocating a new encoder for every written log line.

## Superseded on main
- **#2259** OTLP tracing hot-path config work is covered by the newer tracing runtime cache on `main`.
- **#2260** Redis `getBatch` is covered by the newer MGET implementation with fallback on `main`.

## Verification
- `deno test --no-check --allow-all src/cache/portability.test.ts src/observability/file-log-subscriber.test.ts`
- `deno fmt --check src/cache/paths.ts src/cache/portability.test.ts src/observability/file-log-subscriber.ts src/observability/file-log-subscriber.test.ts`
- `deno lint src/cache/paths.ts src/cache/portability.test.ts src/observability/file-log-subscriber.ts src/observability/file-log-subscriber.test.ts`
- `deno check src/cache/paths.ts src/cache/portability.test.ts src/observability/file-log-subscriber.ts src/observability/file-log-subscriber.test.ts`
- `git diff --check`
- Pre-push hook: format, lint, typecheck, generated assets, unit tests (`2041 passed`)

## Deferred
- Remaining #2262 items stay tracked in #2262: embedding batch parallelization, RAG store re-parse caching, and log-buffer double-redaction.