### PR TITLE
Keep project render mutexes stable

### DIFF
--- a/src/rendering/renderer-concurrency.test.ts
+++ b/src/rendering/renderer-concurrency.test.ts
@@ -1,7 +1,14 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { Mutex } from "./renderer-concurrency.ts";
+import {
+  __getProjectMutexForTests,
+  __resetProjectConcurrencyForTests,
+  acquireProjectSlot,
+  Mutex,
+  projectRenderCounts,
+  releaseProjectSlot,
+} from "./renderer-concurrency.ts";
 
 describe("Mutex", () => {
   it("acquires immediately when unlocked", async () => {
@@ -112,5 +119,27 @@ describe("Mutex", () => {
 
     await Promise.all(tasks);
     assertEquals(counter, 20);
+  });
+});
+
+describe("project render slots", () => {
+  it("keeps the project mutex stable after releasing the final slot", async () => {
+    const projectId = `project-${crypto.randomUUID()}`;
+    __resetProjectConcurrencyForTests();
+    try {
+      assertEquals(await acquireProjectSlot(projectId), true);
+      const mutex = __getProjectMutexForTests(projectId);
+
+      await releaseProjectSlot(projectId);
+
+      assertEquals(projectRenderCounts.has(projectId), false);
+      assertEquals(__getProjectMutexForTests(projectId), mutex);
+
+      assertEquals(await acquireProjectSlot(projectId), true);
+      assertEquals(__getProjectMutexForTests(projectId), mutex);
+    } finally {
+      await releaseProjectSlot(projectId);
+      __resetProjectConcurrencyForTests();
+    }
   });
 });

--- a/src/rendering/renderer-concurrency.ts
+++ b/src/rendering/renderer-concurrency.ts
@@ -136,6 +136,15 @@ function getProjectMutex(projectId: string): Mutex {
   return mutex;
 }
 
+export function __getProjectMutexForTests(projectId: string): Mutex | undefined {
+  return projectMutexes.get(projectId);
+}
+
+export function __resetProjectConcurrencyForTests(): void {
+  projectRenderCounts.clear();
+  projectMutexes.clear();
+}
+
 // ---------------------------------------------------------------------------
 // Slot Functions
 // ---------------------------------------------------------------------------
@@ -183,7 +192,6 @@ export async function releaseProjectSlot(
     const current = projectRenderCounts.get(projectId) ?? 0;
     if (current <= 1) {
       projectRenderCounts.delete(projectId);
-      projectMutexes.delete(projectId);
       return;
     }
     projectRenderCounts.set(projectId, current - 1);


### PR DESCRIPTION
## Summary
- stop deleting a per-project render mutex during final slot release
- add regression coverage for mutex identity across release/reacquire
- add test helpers to reset and inspect project concurrency state

Closes #2250

## Verification
- deno test --no-check --allow-all src/rendering/renderer-concurrency.test.ts
- deno check src/rendering/renderer-concurrency.ts src/rendering/renderer-concurrency.test.ts
- pre-push hook: format, lint, type check, generation, unit suite: 2029 passed, 18173 steps