### PR TITLE
Require release ids for production cache keys

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.742",
+  "version": "0.1.743",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/rendering/context/render-context.ts
+++ b/src/rendering/context/render-context.ts
@@ -93,7 +93,14 @@ function getReleaseKey(
   releaseId?: string,
 ): string {
   if (isLocal) return branch ?? "main";
-  if (environment === "production") return releaseId!;
+  if (environment === "production") {
+    if (!releaseId) {
+      throw INVALID_ARGUMENT.create({
+        detail: "Production requires releaseId for cache isolation",
+      });
+    }
+    return releaseId;
+  }
   return branch ?? "main";
 }
 

--- a/src/server/context/enriched-context.test.ts
+++ b/src/server/context/enriched-context.test.ts
@@ -38,6 +38,7 @@ function makeOptions(
     branch: null,
     isLocalProject: false,
     contentSourceId: "release-abc123",
+    releaseId: "rel_abc123",
     parsedDomain: stubParsedDomain,
     adapter: stubAdapter,
     config: stubConfig,
@@ -119,11 +120,13 @@ describe("enriched-context", () => {
       assertEquals(ctx.cachePrefix.startsWith("proj_1:production:rel_99:"), true);
     });
 
-    it("should fallback to 'unknown' when releaseId is undefined in production", () => {
-      const ctx = buildEnrichedContext(
-        makeOptions({ environment: "production", releaseId: undefined }),
+    it("should throw when releaseId is undefined in production", () => {
+      assertThrows(
+        () =>
+          buildEnrichedContext(makeOptions({ environment: "production", releaseId: undefined })),
+        Error,
+        "Production requires releaseId for cache isolation",
       );
-      assertEquals(ctx.cachePrefix.startsWith("proj_1:production:unknown:"), true);
     });
 
     it("should use branch as releaseKey in preview environment", () => {
@@ -154,7 +157,13 @@ describe("enriched-context", () => {
     });
 
     it("should leave optional fields undefined when not provided", () => {
-      const ctx = buildEnrichedContext(makeOptions());
+      const ctx = buildEnrichedContext(
+        makeOptions({
+          contentSourceId: "preview-main",
+          environment: "preview",
+          releaseId: undefined,
+        }),
+      );
       assertEquals(ctx.moduleServerUrl, undefined);
       assertEquals(ctx.nonce, undefined);
       assertEquals(ctx.debug, undefined);

--- a/src/server/context/enriched-context.ts
+++ b/src/server/context/enriched-context.ts
@@ -13,9 +13,19 @@ export function buildEnrichedContext(options: BuildEnrichedContextOptions): Enri
     throw INVALID_ARGUMENT.create({ detail: `Missing contentSourceId for ${options.projectSlug}` });
   }
 
-  const releaseKey = options.environment === "production"
-    ? (options.releaseId ?? "unknown")
-    : (options.branch ?? "main");
+  let releaseKey: string;
+  if (options.isLocalProject) {
+    releaseKey = options.branch ?? "main";
+  } else if (options.environment === "production") {
+    if (!options.releaseId) {
+      throw INVALID_ARGUMENT.create({
+        detail: "Production requires releaseId for cache isolation",
+      });
+    }
+    releaseKey = options.releaseId;
+  } else {
+    releaseKey = options.branch ?? "main";
+  }
 
   return {
     projectId: options.projectId,

--- a/src/server/handlers/request/api/project-discovery.test.ts
+++ b/src/server/handlers/request/api/project-discovery.test.ts
@@ -111,6 +111,32 @@ describe(
       assertEquals(cachedAgent.config.system, "FIRST");
     });
 
+    it("does not cache completed production discovery without a release id", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+
+      const ctx = createHandlerContext(
+        "/production-missing-release-project",
+        "production-missing-release-project",
+        "production",
+      );
+      const agentId = "production-missing-release-agent";
+
+      await writeAgentFile(ctx, agentId, "FIRST");
+      await ensureProjectDiscovery(ctx);
+
+      const firstAgent = getAgent(agentId);
+      assertExists(firstAgent);
+      assertEquals(firstAgent.config.system, "FIRST");
+
+      await writeAgentFile(ctx, agentId, "SECOND");
+      await ensureProjectDiscovery(ctx);
+
+      const updatedAgent = getAgent(agentId);
+      assertExists(updatedAgent);
+      assertEquals(updatedAgent.config.system, "SECOND");
+    });
+
     it("uses cache-key context to isolate production discovery by release", async () => {
       agentRegistry.clearAll();
       toolRegistry.clearAll();

--- a/src/server/handlers/request/api/project-discovery.ts
+++ b/src/server/handlers/request/api/project-discovery.ts
@@ -32,7 +32,7 @@ function discoveryKey(ctx: HandlerContext): string {
     (ctx.releaseId ? "production" : "preview");
 
   if (environment === "production") {
-    return `${slug}:release:${ctx.releaseId ?? "unknown"}`;
+    return ctx.releaseId ? `${slug}:release:${ctx.releaseId}` : `${slug}:production:unreleased`;
   }
 
   const branch = ctx.requestContext?.branch ?? ctx.enriched?.branch ?? ctx.parsedDomain?.branch ??
@@ -48,7 +48,7 @@ function shouldCacheCompletedDiscovery(ctx: HandlerContext): boolean {
 
   const environment = ctx.enriched?.environment ?? ctx.resolvedEnvironment ??
     (ctx.releaseId ? "production" : "preview");
-  return environment === "production";
+  return environment === "production" && !!ctx.releaseId;
 }
 
 /**

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.742";
+export const VERSION = "0.1.743";


### PR DESCRIPTION
## Summary
- Reject non-local production render/enriched contexts when `releaseId` is missing so cache prefixes cannot use a shared undefined or unknown bucket.
- Preserve local project branch-based cache keys.
- Prevent request-time project discovery from retaining completed production discovery when no release id is available.
- Bump release version to 0.1.743.

Closes #2254

## Verification
- deno test --frozen --allow-all src/server/context/enriched-context.test.ts tests/rendering/render-context.test.ts src/server/handlers/request/api/project-discovery.test.ts
- deno task verify:quick
- git diff --check
- pre-push hook: format, lint, typecheck, unit suite (2029 passed, 0 failed)