### PR TITLE
Version SSR import URLs by target content

### DIFF
--- a/src/modules/server/module-batch-handler.test.ts
+++ b/src/modules/server/module-batch-handler.test.ts
@@ -57,6 +57,11 @@ describe(
         };
       }
 
+      function extractChildVersion(code: string): string {
+        const match = code.match(/\.\/child\.js\?ssr=true&project=test&v=([^"']+)/);
+        return match?.[1] ?? "";
+      }
+
       it("should return 400 when paths parameter is missing", async () => {
         const response = await handleModuleBatch(createBatchRequest(), createOptions());
         assertEquals(response.status, 400);
@@ -166,6 +171,45 @@ describe(
 
         assertEquals(response.status, 200);
         assertEquals(response.headers.get("Cache-Control")?.includes("immutable"), true);
+      });
+
+      it("uses child source content for SSR import cache busters", async () => {
+        const adapter = createMockAdapter();
+        adapter.fs.files.set(
+          "/test-project/page.ts",
+          `import { child } from "./child.js";\nexport const page = child;\n`,
+        );
+        adapter.fs.files.set("/test-project/child.ts", `export const child = "one";\n`);
+
+        const firstResponse = await handleModuleBatch(
+          createBatchRequest("page.js", "ssr=true"),
+          {
+            projectDir: "/test-project",
+            adapter,
+            projectSlug: "test",
+            dev: true,
+          },
+        );
+        assertEquals(firstResponse.status, 200);
+        const firstVersion = extractChildVersion(await firstResponse.text());
+
+        adapter.fs.files.set("/test-project/child.ts", `export const child = "two";\n`);
+
+        const secondResponse = await handleModuleBatch(
+          createBatchRequest("page.js", "ssr=true"),
+          {
+            projectDir: "/test-project",
+            adapter,
+            projectSlug: "test",
+            dev: true,
+          },
+        );
+        assertEquals(secondResponse.status, 200);
+        const secondVersion = extractChildVersion(await secondResponse.text());
+
+        assertEquals(firstVersion.length > 0, true);
+        assertEquals(secondVersion.length > 0, true);
+        assertEquals(firstVersion !== secondVersion, true);
       });
     });
   },

--- a/src/modules/server/module-batch-handler.ts
+++ b/src/modules/server/module-batch-handler.ts
@@ -28,12 +28,18 @@ import { createSecureFs } from "#veryfront/security";
 import { transformToESM } from "#veryfront/transforms/esm-transform.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { join } from "#veryfront/compat/path/index.ts";
-import { applySSRImportRewrites } from "./ssr-import-rewriter.ts";
+import {
+  applySSRImportRewritesAsync,
+  resolveSSRImportTargetModulePath,
+  type SSRImportRewriteTarget,
+  stripSSRModuleJsExtension,
+} from "./ssr-import-rewriter.ts";
 import { buildModuleTransformCacheKey } from "#veryfront/cache/keys.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { getFrameworkRootFromMeta } from "#veryfront/platform/compat/vfs-paths.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { registerLRUCache } from "#veryfront/cache";
+import { sha256Short } from "#veryfront/cache/hash.ts";
 
 const logger = serverLogger.component("module-batch");
 
@@ -294,7 +300,7 @@ async function loadAndTransformModule(
       if (!stat.isFile) continue;
 
       const source = await secureFs.readFile(fullPath);
-      return transformModule(source, fullPath, projectDir, adapter, options);
+      return transformModule(source, fullPath, modulePath, projectDir, adapter, secureFs, options);
     } catch (_) {
       /* expected: file may not exist at this extension */
     }
@@ -317,7 +323,15 @@ async function loadAndTransformModule(
         if (!stat.isFile) continue;
 
         const source = await platformFs.readTextFile(frameworkPath);
-        return transformModule(source, frameworkPath, projectDir, adapter, options);
+        return transformModule(
+          source,
+          frameworkPath,
+          modulePath,
+          projectDir,
+          adapter,
+          secureFs,
+          options,
+        );
       } catch (_) {
         /* expected: framework file may not exist at this extension */
       }
@@ -330,8 +344,10 @@ async function loadAndTransformModule(
 async function transformModule(
   source: string,
   sourceFile: string,
+  modulePath: string,
   projectDir: string,
   adapter: RuntimeAdapter,
+  secureFs: ReturnType<typeof createSecureFs>,
   options: {
     dev: boolean;
     ssr: boolean;
@@ -349,13 +365,90 @@ async function transformModule(
   });
 
   if (options.ssr) {
-    code = applySSRImportRewrites(code, {
+    code = await applySSRImportRewritesAsync(code, {
       projectSlug: options.projectSlug,
       branch: options.branch,
+      resolveCacheBuster: createBatchSSRTargetCacheBusterResolver({
+        projectDir,
+        secureFs,
+        currentModulePath: modulePath,
+      }),
     });
   }
 
   return code;
+}
+
+async function readBatchTargetSource(
+  projectDir: string,
+  secureFs: ReturnType<typeof createSecureFs>,
+  modulePath: string,
+): Promise<{ path: string; source: string } | null> {
+  const basePath = stripSSRModuleJsExtension(modulePath);
+
+  for (const ext of EXTENSIONS) {
+    const fullPath = join(projectDir, basePath + ext);
+    try {
+      const stat = await secureFs.stat(fullPath);
+      if (!stat.isFile) continue;
+
+      return {
+        path: fullPath,
+        source: await secureFs.readFile(fullPath),
+      };
+    } catch (_) {
+      /* expected: file may not exist at this extension */
+    }
+  }
+
+  if (!basePath.startsWith("lib/")) return null;
+
+  const frameworkLookupDirs = [EMBEDDED_SRC_DIR, join(FRAMEWORK_ROOT, "src")];
+  const platformFs = createFileSystem();
+  for (const lookupDir of frameworkLookupDirs) {
+    for (const ext of FRAMEWORK_EXTENSIONS) {
+      const frameworkPath = join(lookupDir, basePath + ext);
+      try {
+        const stat = await platformFs.stat(frameworkPath);
+        if (!stat.isFile) continue;
+
+        return {
+          path: frameworkPath,
+          source: await platformFs.readTextFile(frameworkPath),
+        };
+      } catch (_) {
+        /* expected: framework file may not exist at this extension */
+      }
+    }
+  }
+
+  return null;
+}
+
+function createBatchSSRTargetCacheBusterResolver(options: {
+  projectDir: string;
+  secureFs: ReturnType<typeof createSecureFs>;
+  currentModulePath: string;
+}): (target: SSRImportRewriteTarget) => Promise<string | undefined> {
+  const versions = new Map<string, Promise<string | undefined>>();
+
+  return (target) => {
+    const targetPath = resolveSSRImportTargetModulePath(target, options.currentModulePath);
+    let promise = versions.get(targetPath);
+    if (!promise) {
+      promise = (async () => {
+        const resolved = await readBatchTargetSource(
+          options.projectDir,
+          options.secureFs,
+          targetPath,
+        );
+        if (!resolved) return undefined;
+        return await sha256Short(`${resolved.path}\0${resolved.source}`);
+      })();
+      versions.set(targetPath, promise);
+    }
+    return promise;
+  };
 }
 
 /**

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -68,6 +68,11 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     });
   }
 
+  function extractChildVersion(code: string): string {
+    const match = code.match(/\.\/child\.js\?ssr=true&v=([^"']+)/);
+    return match?.[1] ?? "";
+  }
+
   it("should return 404 for non-module path prefix", async () => {
     const response = await serve(new Request("http://localhost:3000/not-a-module"));
 
@@ -206,5 +211,38 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     assertEquals(response.status, 200);
     const contentType = response.headers.get("content-type") ?? "";
     assertEquals(contentType.includes("javascript"), true);
+  });
+
+  it("uses child source content for SSR import cache busters", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-ssr-cache-buster-" });
+    try {
+      await Deno.writeTextFile(
+        `${projectDir}/page.ts`,
+        `import { child } from "./child.js";\nexport const page = child;\n`,
+      );
+      await Deno.writeTextFile(`${projectDir}/child.ts`, `export const child = "one";\n`);
+
+      const firstResponse = await serve(
+        new Request("http://localhost:3000/_vf_modules/page.js?ssr=true"),
+        projectDir,
+      );
+      assertEquals(firstResponse.status, 200);
+      const firstVersion = extractChildVersion(await firstResponse.text());
+
+      await Deno.writeTextFile(`${projectDir}/child.ts`, `export const child = "two";\n`);
+
+      const secondResponse = await serve(
+        new Request("http://localhost:3000/_vf_modules/page.js?ssr=true"),
+        projectDir,
+      );
+      assertEquals(secondResponse.status, 200);
+      const secondVersion = extractChildVersion(await secondResponse.text());
+
+      assertEquals(firstVersion.length > 0, true);
+      assertEquals(secondVersion.length > 0, true);
+      assertEquals(firstVersion !== secondVersion, true);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
   });
 });

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -13,7 +13,12 @@ import { getApiBaseUrlEnv } from "#veryfront/config/env.ts";
 import { injectContext, withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { injectNodePositions } from "#veryfront/transforms/plugins/babel-node-positions.ts";
 import { parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
-import { applySSRImportRewrites } from "./ssr-import-rewriter.ts";
+import {
+  applySSRImportRewritesAsync,
+  resolveSSRImportTargetModulePath,
+  type SSRImportRewriteTarget,
+  stripSSRModuleJsExtension,
+} from "./ssr-import-rewriter.ts";
 import { addHMRTimestamps } from "#veryfront/transforms/esm/import-rewriter.ts";
 import {
   FRAMEWORK_ROOT,
@@ -21,6 +26,7 @@ import {
 } from "#veryfront/platform/compat/framework-source-resolver.ts";
 import { getReactUrls, REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import { readLimitedCrossProjectSource } from "./cross-project-source-limit.ts";
+import { sha256Short } from "#veryfront/cache/hash.ts";
 
 const logger = serverLogger.component("module-server");
 
@@ -221,9 +227,15 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
           );
 
           if (isSSR) {
-            transformedCode = applySSRImportRewrites(transformedCode, {
+            transformedCode = await applySSRImportRewritesAsync(transformedCode, {
               projectSlug: snippetProjectSlug,
               branch: snippetBranch,
+              resolveCacheBuster: createSSRTargetCacheBusterResolver({
+                secureFs,
+                projectDir,
+                currentModulePath: `_snippets/${hash}.js`,
+                reactVersion,
+              }),
             });
           }
 
@@ -303,7 +315,16 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
           });
 
           if (isSSR) {
-            code = applySSRImportRewrites(code, { crossProjectRef: projectRef });
+            code = await applySSRImportRewritesAsync(code, {
+              crossProjectRef: projectRef,
+              resolveCacheBuster: createSSRTargetCacheBusterResolver({
+                secureFs,
+                projectDir,
+                currentModulePath: crossPath,
+                crossProjectRef: projectRef,
+                reactVersion,
+              }),
+            });
           }
 
           return createModuleResponse(method, code, HTTP_OK, {
@@ -407,7 +428,16 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
           code = await transformToESM(source, sourceFile, projectDir, adapter, transformOpts);
 
           if (isSSR) {
-            code = applySSRImportRewrites(code, { projectSlug, branch });
+            code = await applySSRImportRewritesAsync(code, {
+              projectSlug,
+              branch,
+              resolveCacheBuster: createSSRTargetCacheBusterResolver({
+                secureFs,
+                projectDir,
+                currentModulePath: modulePath,
+                reactVersion,
+              }),
+            });
           }
 
           const hmrTimestamp = url.searchParams.get("t");
@@ -446,6 +476,55 @@ interface FindSourceFileResult {
   isFrameworkFile: boolean;
   /** Embedded content for compiled binaries (no filesystem access needed) */
   embeddedContent?: string;
+}
+
+async function readSourceFileForVersion(
+  secureFs: ReturnType<typeof createSecureFs>,
+  findResult: FindSourceFileResult,
+): Promise<string> {
+  if (findResult.embeddedContent !== undefined) return findResult.embeddedContent;
+
+  const platformFs = createFileSystem();
+  return findResult.isFrameworkFile
+    ? await platformFs.readTextFile(findResult.path)
+    : await secureFs.readFile(findResult.path);
+}
+
+function createSSRTargetCacheBusterResolver(options: {
+  secureFs: ReturnType<typeof createSecureFs>;
+  projectDir: string;
+  currentModulePath: string;
+  crossProjectRef?: string;
+  reactVersion?: string;
+}): (target: SSRImportRewriteTarget) => Promise<string | undefined> {
+  const versions = new Map<string, Promise<string | undefined>>();
+
+  return (target) => {
+    const targetPath = resolveSSRImportTargetModulePath(target, options.currentModulePath);
+    const key = `${options.crossProjectRef ?? "local"}\0${targetPath}`;
+    let promise = versions.get(key);
+    if (!promise) {
+      promise = (async () => {
+        if (options.crossProjectRef) {
+          const source = await fetchCrossProjectSource(options.crossProjectRef, targetPath);
+          return source === null ? undefined : await sha256Short(`${targetPath}\0${source}`);
+        }
+
+        const findResult = await findSourceFile(
+          options.secureFs,
+          options.projectDir,
+          stripSSRModuleJsExtension(targetPath),
+          options.reactVersion,
+        );
+        if (!findResult) return undefined;
+
+        const source = await readSourceFileForVersion(options.secureFs, findResult);
+        return await sha256Short(`${findResult.path}\0${source}`);
+      })();
+      versions.set(key, promise);
+    }
+    return promise;
+  };
 }
 
 const REACT_PACKAGE_ASSET_SPECIFIERS: Record<string, string> = {

--- a/src/modules/server/ssr-import-rewriter.test.ts
+++ b/src/modules/server/ssr-import-rewriter.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { applySSRImportRewrites } from "./ssr-import-rewriter.ts";
+import { applySSRImportRewrites, applySSRImportRewritesAsync } from "./ssr-import-rewriter.ts";
 
 describe("modules/server/ssr-import-rewriter", () => {
   describe("applySSRImportRewrites - path aliases (@/)", () => {
@@ -130,6 +130,63 @@ describe("modules/server/ssr-import-rewriter", () => {
       const result = applySSRImportRewrites(code, { cacheBuster: 9999 });
       assertEquals(result.includes("/_vf_modules/components/A.js?ssr=true"), true);
       assertEquals(result.includes("./local.js?ssr=true"), true);
+    });
+
+    it("uses deterministic default versions for the same target", () => {
+      const originalNow = Date.now;
+      try {
+        Date.now = () => 1;
+        const first = applySSRImportRewrites([
+          `import { A } from "@/components/A";`,
+          `import { helper } from "./local.js";`,
+        ].join("\n"));
+
+        Date.now = () => 2;
+        const second = applySSRImportRewrites([
+          `import { A } from "@/components/A";`,
+          `import { helper } from "./local.js";`,
+        ].join("\n"));
+
+        assertEquals(second, first);
+      } finally {
+        Date.now = originalNow;
+      }
+    });
+
+    it("versions each rewritten target independently", () => {
+      const result = applySSRImportRewrites([
+        `import { A } from "@/components/A";`,
+        `import { B } from "@/components/B";`,
+        `import { helper } from "./local.js";`,
+      ].join("\n"));
+
+      const versions = Array.from(result.matchAll(/[?&]v=([^"']+)/g), (match) => match[1]);
+
+      assertEquals(versions.length, 3);
+      assertEquals(new Set(versions).size, 3);
+    });
+
+    it("uses async per-target version resolver when provided", async () => {
+      const code = [
+        `import { A } from "@/components/A";`,
+        `import { B } from "./local.js";`,
+      ].join("\n");
+
+      const result = await applySSRImportRewritesAsync(code, {
+        resolveCacheBuster: (target) => {
+          if (target.modulePath === "components/A.js") return "hash-a";
+          if (target.specifier === "./local.js") return "hash-local";
+          return "fallback";
+        },
+      });
+
+      assertEquals(
+        result,
+        [
+          `import { A } from "/_vf_modules/components/A.js?ssr=true&v=hash-a";`,
+          `import { B } from "./local.js?ssr=true&v=hash-local";`,
+        ].join("\n"),
+      );
     });
   });
 

--- a/src/modules/server/ssr-import-rewriter.ts
+++ b/src/modules/server/ssr-import-rewriter.ts
@@ -4,14 +4,57 @@ import {
 } from "#veryfront/transforms/esm/package-registry.ts";
 import { isDeno, isNode } from "#veryfront/platform/compat/runtime.ts";
 import { getLocalReactPaths } from "#veryfront/platform/compat/react-paths.ts";
+import { hashString } from "#veryfront/cache/hash.ts";
+
+type CacheBuster = number | string;
+
+export interface SSRImportRewriteTarget {
+  specifier: string;
+  kind: "alias" | "relative";
+  modulePath: string;
+  rewrittenPath: string;
+}
+
+export function stripSSRModuleJsExtension(path: string): string {
+  return path.replace(/\.(?:mjs|js)$/i, "");
+}
+
+function normalizeSSRModulePath(path: string): string {
+  let normalized = path.replace(/^\/+/, "");
+  if (normalized.startsWith("_vf_modules/")) {
+    normalized = normalized.slice("_vf_modules/".length);
+  }
+  if (normalized.startsWith("@/")) normalized = normalized.slice(2);
+  return normalized;
+}
+
+export function resolveSSRImportTargetModulePath(
+  target: SSRImportRewriteTarget,
+  currentModulePath: string,
+): string {
+  if (target.kind === "alias") return normalizeSSRModulePath(target.modulePath);
+
+  const currentPath = normalizeSSRModulePath(currentModulePath);
+  if (target.specifier.startsWith("/")) {
+    return normalizeSSRModulePath(target.specifier);
+  }
+
+  const basePath = currentPath.startsWith("/") ? currentPath : `/${currentPath}`;
+  const resolved = new URL(target.specifier, `http://veryfront.local${basePath}`).pathname;
+  return normalizeSSRModulePath(resolved);
+}
 
 interface SSRRewriteOptions {
   /** Project slug for multi-project routing */
   projectSlug?: string | null;
   /** Branch name for branch-aware routing */
   branch?: string | null;
-  /** Cache buster timestamp */
-  cacheBuster?: number;
+  /** Cache buster token. When omitted, each rewritten target gets a stable token. */
+  cacheBuster?: CacheBuster;
+  /** Resolve a cache buster token for each rewritten target. */
+  resolveCacheBuster?: (
+    target: SSRImportRewriteTarget,
+  ) => CacheBuster | null | undefined | Promise<CacheBuster | null | undefined>;
   /** Cross-project reference (e.g., "demo@0.0") for @/ path rewrites */
   crossProjectRef?: string;
   /** React version to use for import rewrites */
@@ -82,29 +125,105 @@ function rewriteBareImports(code: string, version?: string): string {
   });
 }
 
+function getDefaultCacheBuster(target: SSRImportRewriteTarget, options: SSRRewriteOptions): string {
+  return hashString([
+    target.kind,
+    target.modulePath,
+    target.rewrittenPath,
+    options.projectSlug ?? "",
+    options.branch ?? "",
+    options.crossProjectRef ?? "",
+    options.reactVersion ?? "",
+  ].join("\0"));
+}
+
+function getCacheBusterSync(
+  target: SSRImportRewriteTarget,
+  options: SSRRewriteOptions,
+): string {
+  if (options.cacheBuster !== undefined) return String(options.cacheBuster);
+  return getDefaultCacheBuster(target, options);
+}
+
+async function getCacheBusterAsync(
+  target: SSRImportRewriteTarget,
+  options: SSRRewriteOptions,
+): Promise<string> {
+  if (options.cacheBuster !== undefined) return String(options.cacheBuster);
+  const resolved = await options.resolveCacheBuster?.(target);
+  if (resolved !== undefined && resolved !== null) return String(resolved);
+  return getDefaultCacheBuster(target, options);
+}
+
+function buildAliasRewrite(
+  specifierPath: string,
+  options: SSRRewriteOptions,
+): { target: SSRImportRewriteTarget; prefix: string } {
+  const { crossProjectRef } = options;
+  const jsPath = specifierPath.endsWith(".js") ? specifierPath : `${specifierPath}.js`;
+
+  if (crossProjectRef) {
+    const rewrittenPath = `/_vf_modules/_cross/${crossProjectRef}/@/${jsPath}`;
+    return {
+      target: {
+        specifier: `@/${specifierPath}`,
+        kind: "alias",
+        modulePath: jsPath,
+        rewrittenPath,
+      },
+      prefix: `${rewrittenPath}?ssr=true`,
+    };
+  }
+
+  const rewrittenPath = `/_vf_modules/${jsPath}`;
+  return {
+    target: {
+      specifier: `@/${specifierPath}`,
+      kind: "alias",
+      modulePath: jsPath,
+      rewrittenPath,
+    },
+    prefix: `${rewrittenPath}?ssr=true`,
+  };
+}
+
+function buildRelativeRewrite(
+  specifier: string,
+): { target: SSRImportRewriteTarget; prefix: string } {
+  return {
+    target: {
+      specifier,
+      kind: "relative",
+      modulePath: specifier,
+      rewrittenPath: specifier,
+    },
+    prefix: `${specifier}?ssr=true`,
+  };
+}
+
+function buildScopedParams(options: SSRRewriteOptions): string {
+  const projectParam = options.projectSlug ? `&project=${options.projectSlug}` : "";
+  const branchParam = options.branch ? `&branch=${options.branch}` : "";
+  return `${projectParam}${branchParam}`;
+}
+
 function rewritePathAliases(code: string, options: SSRRewriteOptions): string {
-  const { projectSlug, branch, cacheBuster = Date.now(), crossProjectRef } = options;
-  const projectParam = projectSlug ? `&project=${projectSlug}` : "";
-  const branchParam = branch ? `&branch=${branch}` : "";
+  const scopedParams = buildScopedParams(options);
 
   return code.replace(/from\s+["']@\/([^"']+)["']/g, (_match, path: string) => {
-    const jsPath = path.endsWith(".js") ? path : `${path}.js`;
-
-    if (crossProjectRef) {
-      return `from "/_vf_modules/_cross/${crossProjectRef}/@/${jsPath}?ssr=true&v=${cacheBuster}"`;
-    }
-
-    return `from "/_vf_modules/${jsPath}?ssr=true${projectParam}${branchParam}&v=${cacheBuster}"`;
+    const { target, prefix } = buildAliasRewrite(path, options);
+    const cacheBuster = getCacheBusterSync(target, options);
+    return `from "${prefix}${scopedParams}&v=${cacheBuster}"`;
   });
 }
 
 function rewriteRelativeImports(code: string, options: SSRRewriteOptions): string {
-  const { projectSlug, branch, cacheBuster = Date.now() } = options;
-  const projectParam = projectSlug ? `&project=${projectSlug}` : "";
-  const branchParam = branch ? `&branch=${branch}` : "";
+  const scopedParams = buildScopedParams(options);
 
   return code.replace(/from\s+["']((?:\.\.?\/|\/)[^"']+\.js)["']/g, (_match, path: string) => {
-    return `from "${path}?ssr=true${projectParam}${branchParam}&v=${cacheBuster}"`;
+    const { target, prefix } = buildRelativeRewrite(path);
+    const cacheBuster = getCacheBusterSync(target, options);
+    return `from "${prefix}${scopedParams}&v=${cacheBuster}"`;
   });
 }
 
@@ -112,5 +231,60 @@ export function applySSRImportRewrites(code: string, options: SSRRewriteOptions 
   let result = rewriteBareImports(code, options.reactVersion);
   result = rewritePathAliases(result, options);
   result = rewriteRelativeImports(result, options);
+  return result;
+}
+
+async function replaceAsync(
+  code: string,
+  pattern: RegExp,
+  replacer: (match: RegExpExecArray) => Promise<string>,
+): Promise<string> {
+  const chunks: string[] = [];
+  let lastIndex = 0;
+  pattern.lastIndex = 0;
+
+  for (let match = pattern.exec(code); match; match = pattern.exec(code)) {
+    chunks.push(code.slice(lastIndex, match.index));
+    chunks.push(await replacer(match));
+    lastIndex = match.index + match[0].length;
+  }
+
+  chunks.push(code.slice(lastIndex));
+  return chunks.join("");
+}
+
+async function rewritePathAliasesAsync(
+  code: string,
+  options: SSRRewriteOptions,
+): Promise<string> {
+  const scopedParams = buildScopedParams(options);
+  return await replaceAsync(code, /from\s+["']@\/([^"']+)["']/g, async (match) => {
+    const path = match[1] ?? "";
+    const { target, prefix } = buildAliasRewrite(path, options);
+    const cacheBuster = await getCacheBusterAsync(target, options);
+    return `from "${prefix}${scopedParams}&v=${cacheBuster}"`;
+  });
+}
+
+async function rewriteRelativeImportsAsync(
+  code: string,
+  options: SSRRewriteOptions,
+): Promise<string> {
+  const scopedParams = buildScopedParams(options);
+  return await replaceAsync(code, /from\s+["']((?:\.\.?\/|\/)[^"']+\.js)["']/g, async (match) => {
+    const path = match[1] ?? "";
+    const { target, prefix } = buildRelativeRewrite(path);
+    const cacheBuster = await getCacheBusterAsync(target, options);
+    return `from "${prefix}${scopedParams}&v=${cacheBuster}"`;
+  });
+}
+
+export async function applySSRImportRewritesAsync(
+  code: string,
+  options: SSRRewriteOptions = {},
+): Promise<string> {
+  let result = rewriteBareImports(code, options.reactVersion);
+  result = await rewritePathAliasesAsync(result, options);
+  result = await rewriteRelativeImportsAsync(result, options);
   return result;
 }


### PR DESCRIPTION
Closes #2233.

## Summary
- Replaces the default Date.now SSR import cache-buster with deterministic per-target tokens.
- Adds an async per-target resolver so module server and batch SSR responses hash the rewritten child target source instead of the parent module.
- Covers normal module serving, batch serving, embedded/framework paths, and cross-project targets when source is available.

## Verification
- deno fmt --check src/modules/server/ssr-import-rewriter.ts src/modules/server/ssr-import-rewriter.test.ts src/modules/server/module-server.ts src/modules/server/module-server.test.ts src/modules/server/module-batch-handler.ts src/modules/server/module-batch-handler.test.ts
- deno check src/modules/server/ssr-import-rewriter.ts src/modules/server/ssr-import-rewriter.test.ts src/modules/server/module-server.ts src/modules/server/module-server.test.ts src/modules/server/module-batch-handler.ts src/modules/server/module-batch-handler.test.ts
- deno lint src/modules/server/ssr-import-rewriter.ts src/modules/server/ssr-import-rewriter.test.ts src/modules/server/module-server.ts src/modules/server/module-server.test.ts src/modules/server/module-batch-handler.ts src/modules/server/module-batch-handler.test.ts
- deno test --no-check --allow-all src/modules/server
- pre-push hook: format, lint, typecheck, generation, unit suite: 2029 passed, 18178 steps