### PR TITLE
Escape hydration JSON for inline script use

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.744",
+  "version": "0.1.745",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/html/hydration-script-builder/hydration-data-generator.test.ts
+++ b/src/html/hydration-script-builder/hydration-data-generator.test.ts
@@ -221,5 +221,40 @@ describe("hydration-data-generator", () => {
       const result = generateHydrationData("page", {}, {}, baseOptions, { pretty: false });
       assertEquals(result.includes("\n"), false);
     });
+
+    it("escapes JSON for inline script contexts", () => {
+      const scriptBreakout = "</script><script>alert(1)</script>";
+      const lineSeparators = "\u2028\u2029";
+      const result = generateHydrationData(
+        "page",
+        {},
+        { title: scriptBreakout, lineSeparators },
+        {
+          ...baseOptions,
+          frontmatter: { description: scriptBreakout },
+          layoutProps: {
+            "layouts/main.tsx": { lineSeparators },
+          },
+        },
+      );
+
+      assertEquals(result.includes("</script>"), false);
+      assertEquals(result.includes("<script>"), false);
+      assertEquals(result.includes("\u2028"), false);
+      assertEquals(result.includes("\u2029"), false);
+      assertStringIncludes(result, "\\u003c/script\\u003e");
+      assertStringIncludes(result, "\\u2028");
+      assertStringIncludes(result, "\\u2029");
+
+      const parsed = JSON.parse(result) as {
+        props: { title: string; lineSeparators: string };
+        frontmatter: { description: string };
+        layoutProps: Record<string, { lineSeparators: string }>;
+      };
+      assertEquals(parsed.props.title, scriptBreakout);
+      assertEquals(parsed.props.lineSeparators, lineSeparators);
+      assertEquals(parsed.frontmatter.description, scriptBreakout);
+      assertEquals(parsed.layoutProps["layouts/main.tsx"]?.lineSeparators, lineSeparators);
+    });
   });
 });

--- a/src/html/hydration-script-builder/hydration-data-generator.ts
+++ b/src/html/hydration-script-builder/hydration-data-generator.ts
@@ -2,6 +2,7 @@ import type { ComponentProps } from "#veryfront/types";
 import { resolveRelativePath } from "#veryfront/modules/react-loader/path-resolver.ts";
 import { getExtensionName } from "#veryfront/utils/path-utils.ts";
 import { determineClientModuleStrategy } from "#veryfront/rendering/rsc/client-module-strategy.ts";
+import { jsonForInlineScript } from "#veryfront/security/client/html-sanitizer.ts";
 import type { HTMLGenerationOptions } from "../types.ts";
 import type { HydrationDataStructure } from "./types.ts";
 
@@ -84,5 +85,6 @@ export function generateHydrationData(
     studioEmbed: options.studioEmbed,
   };
 
-  return JSON.stringify(data, null, serializeOptions?.pretty ?? true ? 2 : undefined);
+  const pretty = serializeOptions?.pretty ?? true;
+  return jsonForInlineScript(data, pretty ? 2 : undefined);
 }

--- a/src/security/client/html-sanitizer.test.ts
+++ b/src/security/client/html-sanitizer.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { validateTrustedHtml } from "./html-sanitizer.ts";
+import { jsonForInlineScript, validateTrustedHtml } from "./html-sanitizer.ts";
 
 describe("validateTrustedHtml", () => {
   describe("allows safe HTML", () => {
@@ -85,5 +85,27 @@ describe("validateTrustedHtml", () => {
         "data: HTML URL",
       );
     });
+  });
+});
+
+describe("jsonForInlineScript", () => {
+  it("escapes script-breaking and JavaScript separator characters", () => {
+    const value = {
+      script: "</script><script>alert(1)</script>",
+      separators: "\u2028\u2029",
+      ampersand: "a&b",
+    };
+
+    const result = jsonForInlineScript(value);
+
+    assertEquals(result.includes("</script>"), false);
+    assertEquals(result.includes("<script>"), false);
+    assertEquals(result.includes("\u2028"), false);
+    assertEquals(result.includes("\u2029"), false);
+    assertStringIncludes(result, "\\u003c/script\\u003e");
+    assertStringIncludes(result, "\\u2028");
+    assertStringIncludes(result, "\\u2029");
+    assertStringIncludes(result, "\\u0026");
+    assertEquals(JSON.parse(result), value);
   });
 });

--- a/src/security/client/html-sanitizer.ts
+++ b/src/security/client/html-sanitizer.ts
@@ -30,8 +30,8 @@ function createSuspiciousPatterns(): Array<{ pattern: RegExp; name: string }> {
   }));
 }
 
-function jsonForInlineScript(value: unknown): string {
-  return JSON.stringify(value)
+export function jsonForInlineScript(value: unknown, space?: string | number): string {
+  return JSON.stringify(value, null, space)
     .replace(/</g, "\\u003c")
     .replace(/>/g, "\\u003e")
     .replace(/&/g, "\\u0026")

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.744";
+export const VERSION = "0.1.745";


### PR DESCRIPTION
## Summary
- Reuse `jsonForInlineScript` for hydration data embedded in the `application/json` script tag.
- Preserve existing pretty and compact hydration JSON output modes.
- Add a regression test for script terminators and U+2028/U+2029 in props, frontmatter, and layout props.

Closes #2251

## Verification
- `deno test --no-check --allow-all src/html/hydration-script-builder/hydration-data-generator.test.ts`
- `deno test --no-check --allow-all src/security/client/html-sanitizer.test.ts`
- `deno fmt --check src/html/hydration-script-builder/hydration-data-generator.ts src/html/hydration-script-builder/hydration-data-generator.test.ts src/security/client/html-sanitizer.ts src/security/client/html-sanitizer.test.ts`
- `deno check src/html/hydration-script-builder/hydration-data-generator.ts src/html/hydration-script-builder/hydration-data-generator.test.ts src/security/client/html-sanitizer.ts src/security/client/html-sanitizer.test.ts`
- `deno lint src/html/hydration-script-builder/hydration-data-generator.ts src/html/hydration-script-builder/hydration-data-generator.test.ts src/security/client/html-sanitizer.ts src/security/client/html-sanitizer.test.ts`
- `deno test --no-check --allow-all src/html/hydration-script-builder src/security/client`
- `git diff --check`
- Pre-push hook: format, lint, type check, generation, and unit tests: 2029 passed, 18180 steps
