### PR TITLE
Harden generated HTML output escaping

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.745",
+  "version": "0.1.746",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/build/production-build/static-generation.test.ts
+++ b/src/build/production-build/static-generation.test.ts
@@ -248,6 +248,43 @@ describe(
         assertEquals(stats.totalSize > 0, true);
       });
 
+      it("escapes route slug before embedding it in the client bootstrap script", async () => {
+        const adapter = createMemoryAdapter();
+        const slug = `bad";globalThis.__xss=1;//`;
+        const renderer = {
+          renderPage: () =>
+            Promise.resolve({
+              html: "<html><head></head><body><div>content</div></body></html>",
+              frontmatter: { description: "</script><script>alert(1)</script>" },
+              headings: [],
+            }),
+          destroy: () => Promise.resolve(),
+        } as unknown as VeryfrontRenderer;
+
+        await buildPagesRoutes(
+          [{ slug, path: "/bad", file: "pages/bad.mdx" }],
+          {
+            adapter,
+            projectDir: "/tmp/project",
+            outputDir: "/tmp/output",
+            renderer,
+            config: createMockConfig(),
+            enablePrefetch: false,
+            chunkManifest: null,
+            dryRun: false,
+          },
+        );
+
+        const html =
+          [...adapter.fs.files.values()].find((value) =>
+            value.includes("Client runtime bootstrap")
+          ) ?? "";
+        assertStringIncludes(html, `boot({ slug: ${JSON.stringify(slug)} });`);
+        assertEquals(html.includes(`boot({ slug: '${slug}' });`), false);
+        assertEquals(html.includes("</script><script>alert(1)</script>"), false);
+        assertStringIncludes(html, "\\u003c/script\\u003e");
+      });
+
       it("should handle renderer errors gracefully", async () => {
         const errorRenderer = {
           renderPage: () => Promise.reject(new Error("render failed")),

--- a/src/build/production-build/static-generation.ts
+++ b/src/build/production-build/static-generation.ts
@@ -21,6 +21,7 @@ import {
 } from "#veryfront/html/styles-builder/index.ts";
 import { DEFAULT_STYLESHEET } from "#veryfront/html/styles-builder/css-hash-cache.ts";
 import { FRAMEWORK_CANDIDATES } from "#veryfront/server/handlers/dev/framework-candidates.generated.ts";
+import { jsonForInlineScript } from "#veryfront/security/client/html-sanitizer.ts";
 
 export interface PageRenderResult {
   html: string;
@@ -354,14 +355,14 @@ function generateClientRuntime(
   return `
   <!-- Page data for hydration -->
   <script data-veryfront-page type="application/json">
-    ${JSON.stringify(pageData)}
+    ${jsonForInlineScript(pageData)}
   </script>
 
   <!-- Client runtime bootstrap -->
   <script type="module">
     import { boot } from '/_veryfront/client.js';
     if (typeof boot === 'function') {
-      boot({ slug: '${route.slug}' });
+      boot({ slug: ${jsonForInlineScript(route.slug)} });
     }
   </script>
 </body>`;

--- a/src/html/html-escape.test.ts
+++ b/src/html/html-escape.test.ts
@@ -1,7 +1,14 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { buildAttributes, buildNonceAttribute, escapeHTML, escapeHtml } from "./html-escape.ts";
+import {
+  buildAttributes,
+  buildNonceAttribute,
+  escapeHTML,
+  escapeHtml,
+  escapeInlineScriptContent,
+  escapeInlineStyleContent,
+} from "./html-escape.ts";
 
 describe("html-escape", () => {
   describe("escapeHTML", () => {
@@ -109,6 +116,22 @@ describe("html-escape", () => {
 
     it("should omit the attribute when nonce is missing", () => {
       assertEquals(buildNonceAttribute(undefined), "");
+    });
+  });
+
+  describe("raw text element content escaping", () => {
+    it("neutralizes closing script tags without escaping ordinary script text", () => {
+      assertEquals(
+        escapeInlineScriptContent(`globalThis.value="</script><script>alert(1)</script>"`),
+        `globalThis.value="<\\/script><script>alert(1)<\\/script>"`,
+      );
+    });
+
+    it("neutralizes closing style tags without escaping ordinary style text", () => {
+      assertEquals(
+        escapeInlineStyleContent(`body:after{content:"</style><style>body{color:red}</style>"}`),
+        `body:after{content:"<\\/style><style>body{color:red}<\\/style>"}`,
+      );
     });
   });
 });

--- a/src/html/html-escape.ts
+++ b/src/html/html-escape.ts
@@ -18,3 +18,11 @@ export function buildAttributes(attrs: Record<string, string>): string {
 export function buildNonceAttribute(nonce?: string): string {
   return nonce ? ` nonce="${escapeHTML(nonce)}"` : "";
 }
+
+export function escapeInlineScriptContent(content: string): string {
+  return String(content ?? "").replace(/<\/script/gi, "<\\/script");
+}
+
+export function escapeInlineStyleContent(content: string): string {
+  return String(content ?? "").replace(/<\/style/gi, "<\\/style");
+}

--- a/src/html/html-shell-generator.test.ts
+++ b/src/html/html-shell-generator.test.ts
@@ -397,6 +397,20 @@ describe("html-generation/html-shell-generator", () => {
       );
     });
 
+    it("escapes body class values from frontmatter", async () => {
+      const result = await wrapInHTMLShell(
+        "<div>Content</div>",
+        createMeta({ frontmatter: { bodyClass: `theme" onclick="alert(1)` } }),
+        createOptions(),
+      );
+
+      assertStringIncludes(
+        result,
+        '<body class="theme&quot; onclick=&quot;alert(1)" suppressHydrationWarning>',
+      );
+      assert(!result.includes('class="theme" onclick="alert(1)"'));
+    });
+
     it("should include veryfront-portals div", async () => {
       const result = await wrapInHTMLShell(
         "<div>Content</div>",

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -342,7 +342,7 @@ async function generateHTMLShellPartsImpl(
   ${modeStyles}
   ${slugForOverlay}
 </head>
-<body${bodyClass ? ` class="${bodyClass}"` : ""} suppressHydrationWarning>
+<body${bodyClass ? ` class="${escapeHTML(bodyClass)}"` : ""} suppressHydrationWarning>
   <div ${rootAttributes}>`;
 
   const relativePagePath = getRelativePagePath(options.pagePath, options.projectDir);

--- a/src/html/tag-generators.test.ts
+++ b/src/html/tag-generators.test.ts
@@ -147,6 +147,16 @@ describe("tag-generators", () => {
       assertStringIncludes(result, "</script>");
     });
 
+    it("neutralizes closing script tags in inline script content", () => {
+      const result = generateScriptTags({
+        scripts: [{ content: `globalThis.value="</script><script>alert(1)</script>"` }],
+      });
+
+      assertEquals(result.includes("</script><script>alert(1)</script>"), false);
+      assertStringIncludes(result, `<\\/script><script>alert(1)<\\/script>`);
+      assertStringIncludes(result, "</script>");
+    });
+
     it("should add nonce to inline scripts", () => {
       assertStringIncludes(
         generateScriptTags({ scripts: [{ content: "alert(1);" }] }, "abc123"),
@@ -190,6 +200,16 @@ describe("tag-generators", () => {
         styles: [{ content: "body { color: red; }" }],
       });
       assertStringIncludes(result, "body { color: red; }");
+      assertStringIncludes(result, "</style>");
+    });
+
+    it("neutralizes closing style tags in inline style content", () => {
+      const result = generateStyleTags({
+        styles: [{ content: `body:after{content:"</style><style>body{color:red}</style>"}` }],
+      });
+
+      assertEquals(result.includes("</style><style>body{color:red}</style>"), false);
+      assertStringIncludes(result, `<\\/style><style>body{color:red}<\\/style>`);
       assertStringIncludes(result, "</style>");
     });
 

--- a/src/html/tag-generators.ts
+++ b/src/html/tag-generators.ts
@@ -1,5 +1,10 @@
 import type { HTMLMetadata } from "#veryfront/transforms/mdx/types.ts";
-import { buildAttributes, escapeHTML } from "./html-escape.ts";
+import {
+  buildAttributes,
+  escapeHTML,
+  escapeInlineScriptContent,
+  escapeInlineStyleContent,
+} from "./html-escape.ts";
 
 function filterAttrs(
   obj: Record<string, unknown>,
@@ -91,7 +96,9 @@ export function generateScriptTags(
       filterAttrs(script, ["content", "src"]),
       nonce,
     );
-    tags.push(`<script ${buildAttributes(attrs)}>${script.content}</script>`);
+    tags.push(
+      `<script ${buildAttributes(attrs)}>${escapeInlineScriptContent(script.content)}</script>`,
+    );
   }
 
   return tags.join("\n  ");
@@ -113,7 +120,9 @@ export function generateStyleTags(metadata: HTMLMetadata, nonce?: string): strin
       filterAttrs(style, ["content", "href"]),
       nonce,
     );
-    tags.push(`<style ${buildAttributes(attrs)}>${style.content}</style>`);
+    tags.push(
+      `<style ${buildAttributes(attrs)}>${escapeInlineStyleContent(style.content)}</style>`,
+    );
   }
 
   return tags.join("\n  ");

--- a/src/react/components/chat/color-mode.test.tsx
+++ b/src/react/components/chat/color-mode.test.tsx
@@ -2,9 +2,9 @@ import * as React from "react";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import { JSDOM } from "npm:jsdom@28.0.0";
-import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { ColorModeProvider, useColorMode } from "./color-mode.tsx";
+import { ColorModeProvider, ColorModeScript, useColorMode } from "./color-mode.tsx";
 
 function installDomGlobals(dom: JSDOM): () => void {
   const window = dom.window;
@@ -67,6 +67,18 @@ function ToggleFixture(): React.ReactElement {
 }
 
 describe("react/components/chat/color-mode", () => {
+  it("escapes storage keys before embedding them in the inline color-mode script", () => {
+    const storageKey = `vf";</script><script>alert(1)</script>//`;
+    const element = ColorModeScript({ defaultMode: "dark", storageKey }) as React.ReactElement<{
+      dangerouslySetInnerHTML: { __html: string };
+    }>;
+    const script = element.props.dangerouslySetInnerHTML.__html;
+
+    assertEquals(script.includes(`</script><script>alert(1)</script>`), false);
+    assertStringIncludes(script, `\\u003c/script\\u003e`);
+    assertStringIncludes(script, `localStorage.getItem("vf\\";\\u003c/script`);
+  });
+
   it("updates the html color-scheme inline style when toggling color mode", async () => {
     const dom = new JSDOM(
       '<!doctype html><html style="color-scheme: dark;"><body><div id="root"></div></body></html>',

--- a/src/react/components/chat/color-mode.tsx
+++ b/src/react/components/chat/color-mode.tsx
@@ -8,6 +8,7 @@
 
 import * as React from "react";
 import { COMPONENT_ERROR } from "#veryfront/errors/error-registry.ts";
+import { jsonForInlineScript } from "#veryfront/security/client/html-sanitizer.ts";
 
 type ColorMode = "light" | "dark" | "system";
 type ResolvedColorMode = "light" | "dark";
@@ -132,8 +133,9 @@ export function ColorModeScript({
   const applyAttribute = attribute === "class"
     ? 'd.classList.add(r);d.classList.remove(r==="dark"?"light":"dark")'
     : 'd.setAttribute("data-theme",r)';
-  const script =
-    `(function(){try{var m=localStorage.getItem("${storageKey}")||"${defaultMode}";var r=m==="system"?globalThis.matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light":m;var d=document.documentElement;${applyAttribute};d.style.colorScheme=r}catch(e){}})()`;
+  const script = `(function(){try{var m=localStorage.getItem(${jsonForInlineScript(storageKey)})||${
+    jsonForInlineScript(defaultMode)
+  };var r=m==="system"?globalThis.matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light":m;var d=document.documentElement;${applyAttribute};d.style.colorScheme=r}catch(e){}})()`;
   return <script dangerouslySetInnerHTML={{ __html: script }} />;
 }
 ColorModeScript.displayName = "ColorModeScript";

--- a/src/rendering/orchestrator/html-head.ts
+++ b/src/rendering/orchestrator/html-head.ts
@@ -1,5 +1,10 @@
 import type { CollectedHead } from "#veryfront/react/head-collector.ts";
 import type { MdxBundle, MDXFrontmatter } from "#veryfront/types";
+import {
+  buildAttributes,
+  escapeInlineScriptContent,
+  escapeInlineStyleContent,
+} from "#veryfront/html/html-escape.ts";
 
 interface FrontmatterContextLike {
   pageInfo: { entity: { frontmatter?: Record<string, unknown> } };
@@ -29,9 +34,9 @@ export function buildHeadElements(head?: CollectedHead): { scripts: string; othe
       attrPairs.push(["data-vf-hash", "vf" + Math.abs(sum).toString(36)]);
     }
 
-    const attrStr = attrPairs.map(([k, v]) => `${k}="${v}"`).join(" ");
+    const attrStr = buildAttributes(Object.fromEntries(attrPairs));
     if (content) {
-      scriptParts.push(`<script ${attrStr}>${content}</script>`);
+      scriptParts.push(`<script ${attrStr}>${escapeInlineScriptContent(content)}</script>`);
     } else if (attrs.src) {
       scriptParts.push(`<script ${attrStr}></script>`);
     }
@@ -40,23 +45,25 @@ export function buildHeadElements(head?: CollectedHead): { scripts: string; othe
   for (const meta of head.metas) {
     if (meta.name === "description") continue;
 
-    const attrs: string[] = [];
-    if (meta.name) attrs.push(`name="${meta.name}"`);
-    if (meta.property) attrs.push(`property="${meta.property}"`);
-    if (meta.content) attrs.push(`content="${meta.content}"`);
-    if (attrs.length) otherParts.push(`<meta ${attrs.join(" ")}>`);
+    const attrs: [string, string][] = [];
+    if (meta.name) attrs.push(["name", meta.name]);
+    if (meta.property) attrs.push(["property", meta.property]);
+    if (meta.content) attrs.push(["content", meta.content]);
+    if (attrs.length) otherParts.push(`<meta ${buildAttributes(Object.fromEntries(attrs))}>`);
   }
 
   for (const link of head.links) {
-    const attrs = Object.entries(link)
-      .filter(([, v]) => v != null)
-      .map(([k, v]) => `${k}="${v}"`)
-      .join(" ");
-    if (attrs) otherParts.push(`<link ${attrs}>`);
+    const attrs = Object.fromEntries(
+      Object.entries(link)
+        .filter(([, v]) => v != null)
+        .map(([k, v]) => [k, String(v)]),
+    );
+    const attrStr = buildAttributes(attrs);
+    if (attrStr) otherParts.push(`<link ${attrStr}>`);
   }
 
   for (const style of head.styles) {
-    otherParts.push(`<style>${style}</style>`);
+    otherParts.push(`<style>${escapeInlineStyleContent(style)}</style>`);
   }
 
   return {

--- a/src/rendering/orchestrator/html.test.ts
+++ b/src/rendering/orchestrator/html.test.ts
@@ -74,6 +74,48 @@ describe("HTMLGenerator helpers", () => {
       assertEquals(result.includes("integrity"), false);
     });
 
+    it("escapes collected head attributes and neutralizes raw text closing tags", () => {
+      const result = buildHeadElements({
+        metas: [
+          {
+            name: `viewport" onmouseover="alert(1)`,
+            content: `" < > &`,
+          },
+        ],
+        links: [
+          {
+            rel: `stylesheet" onload="alert(1)`,
+            href: `/style.css?x="<&`,
+          },
+        ],
+        styles: [`body:after{content:"</style><style>body{color:red}</style>"}`],
+        scripts: [
+          {
+            id: `head" onload="alert(1)`,
+            content: `globalThis.value="</script><script>alert(1)</script>"`,
+          },
+        ],
+      } as any);
+
+      assertEquals(result.other.includes('name="viewport" onmouseover="alert(1)"'), false);
+      assertEquals(result.other.includes('rel="stylesheet" onload="alert(1)"'), false);
+      assertEquals(result.scripts.includes('id="head" onload="alert(1)"'), false);
+      assertEquals(result.scripts.includes("</script><script>alert(1)</script>"), false);
+      assertEquals(result.other.includes("</style><style>body{color:red}</style>"), false);
+      assertEquals(result.other.includes('content="&quot; &lt; &gt; &amp;"'), true);
+      assertEquals(
+        result.other.includes('name="viewport&quot; onmouseover=&quot;alert(1)"'),
+        true,
+      );
+      assertEquals(
+        result.other.includes('rel="stylesheet&quot; onload=&quot;alert(1)"'),
+        true,
+      );
+      assertEquals(result.scripts.includes('id="head&quot; onload=&quot;alert(1)"'), true);
+      assertEquals(result.scripts.includes("<\\/script><script>alert(1)<\\/script>"), true);
+      assertEquals(result.other.includes("<\\/style><style>body{color:red}<\\/style>"), true);
+    });
+
     it("should render style tags", () => {
       const head: Head = {
         metas: [],
@@ -259,6 +301,39 @@ describe("HTMLGenerator helpers", () => {
       );
       assertEquals(html.includes('data-theme="dark"'), true);
       assertEquals(html.includes("color-scheme: dark;"), true);
+      assertEquals(html.includes(`localStorage.setItem('theme','dark')`), true);
+    });
+
+    it("escapes nonce values before injecting theme persistence scripts", async () => {
+      const mockAdapter = createMockAdapter(async () => `'use client';`);
+
+      const generator = createHTMLGenerator({
+        readFile: mockAdapter.fs.readFile,
+      });
+
+      const html = await generator.generateFullHTML({
+        html: "<!DOCTYPE html><html><head></head><body><main>Hello</main></body></html>",
+        pageInfo: {
+          entity: {
+            path: "/project/app/page.tsx",
+            frontmatter: {},
+          },
+        } as any,
+        pageBundle: {} as any,
+        layoutBundle: undefined,
+        nestedLayouts: [],
+        collectedMetadata: {},
+        slug: "test-page",
+        ssrHash: "hash123",
+        options: {
+          nonce: `nonce-"<&'`,
+          colorScheme: "dark",
+          colorSchemeFromParam: true,
+        },
+      });
+
+      assertEquals(html.includes('nonce="nonce-&quot;&lt;&amp;&#39;"'), true);
+      assertEquals(html.includes(`nonce="nonce-"<&'"`), false);
       assertEquals(html.includes(`localStorage.setItem('theme','dark')`), true);
     });
 

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -8,6 +8,7 @@ import {
   injectHTMLContent,
   isFullHTMLDocument,
 } from "#veryfront/html";
+import { buildNonceAttribute } from "#veryfront/html/html-escape.ts";
 import type { MDXFrontmatter } from "#veryfront/types";
 import { DEFAULT_DASHBOARD_PORT, rendererLogger } from "#veryfront/utils";
 import { addNonceToHtmlTags } from "#veryfront/html/nonce-injection.ts";
@@ -81,7 +82,7 @@ function injectThemePersistenceScript(
   if (!enabled || !colorScheme || !/<\/head>/i.test(html)) return html;
   if (html.includes(`localStorage.setItem('theme','${colorScheme}')`)) return html;
 
-  const nonceAttr = nonce ? ` nonce="${nonce}"` : "";
+  const nonceAttr = buildNonceAttribute(nonce);
   const script = `<script${nonceAttr}>
 (function(){try{localStorage.setItem('theme','${colorScheme}')}catch(e){/* SILENT: localStorage may be unavailable */}})();
 </script>`;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.745";
+export const VERSION = "0.1.746";


### PR DESCRIPTION
## Summary
- escape body class and nonce values before injecting generated HTML attributes
- route static-generation slugs and page data through inline-script-safe JSON serialization
- harden generated meta/link/script/style tags and the color-mode inline script against raw closing tags
- bump release version to `0.1.746`

Closes #2252

## Verification
- `deno check src/html/html-escape.ts src/html/tag-generators.ts src/html/html-shell-generator.ts src/build/production-build/static-generation.ts src/rendering/orchestrator/html.ts src/rendering/orchestrator/html-head.ts src/react/components/chat/color-mode.tsx`
- `deno test --frozen --allow-all src/html/html-escape.test.ts src/html/tag-generators.test.ts src/html/html-shell-generator.test.ts src/build/production-build/static-generation.test.ts src/rendering/orchestrator/html.test.ts src/react/components/chat/color-mode.test.tsx`
- `deno test --frozen --allow-all cli/auth/login.test.ts`
- `deno task verify:quick` from platform-adjacent checkout `<local-path>`
- `git diff --check`

Note: the local pre-push hook was interrupted after the full parallel unit suite hung on `Login Module / User info from token / invalid JWT`; the same `cli/auth/login.test.ts` file passes independently in 473ms. Hosted CI is the source of truth for the full suite.
