### PR TITLE
Prevent immortal Redis rate-limit keys

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.746",
+  "version": "0.1.747",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/middleware/builtin/security/redis-rate-limit.test.ts
+++ b/src/middleware/builtin/security/redis-rate-limit.test.ts
@@ -6,25 +6,50 @@ import { RedisRateLimitStore } from "./redis-rate-limit.ts";
 function createMockRedisClient(): {
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
+  eval: (
+    script: string,
+    options: { keys: string[]; arguments: string[] },
+  ) => Promise<[number, number]>;
   incr: (key: string) => Promise<number>;
   pExpire: (key: string, ms: number) => Promise<boolean>;
   pTTL: (key: string) => Promise<number>;
   del: (key: string) => Promise<number>;
-  on: () => void;
+  on: (event: string, listener: (...args: unknown[]) => void) => void;
+  _emit: (event: string, ...args: unknown[]) => void;
+  _evalCalls: number;
+  _incrCalls: number;
+  _pExpireCalls: number;
   _store: Map<string, { count: number; ttl: number }>;
 } {
   const store = new Map<string, { count: number; ttl: number }>();
+  const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+  let evalCalls = 0;
+  let incrCalls = 0;
+  let pExpireCalls = 0;
 
   return {
     connect: () => Promise.resolve(),
     disconnect: () => Promise.resolve(),
+    eval: (_script: string, options: { keys: string[]; arguments: string[] }) => {
+      evalCalls += 1;
+      const key = options.keys[0];
+      if (!key) throw new Error("Expected eval key");
+      const windowMs = Number(options.arguments[0]);
+      const entry = store.get(key) ?? { count: 0, ttl: -1 };
+      entry.count += 1;
+      if (entry.ttl < 0) entry.ttl = windowMs;
+      store.set(key, entry);
+      return Promise.resolve([entry.count, entry.ttl]);
+    },
     incr: (key: string) => {
+      incrCalls += 1;
       const entry = store.get(key) ?? { count: 0, ttl: -1 };
       entry.count += 1;
       store.set(key, entry);
       return Promise.resolve(entry.count);
     },
     pExpire: (key: string, ms: number) => {
+      pExpireCalls += 1;
       const entry = store.get(key);
       if (entry) entry.ttl = ms;
       return Promise.resolve(true);
@@ -38,7 +63,23 @@ function createMockRedisClient(): {
       store.delete(key);
       return Promise.resolve(deleted);
     },
-    on: () => {},
+    on: (event: string, listener: (...args: unknown[]) => void) => {
+      const eventListeners = listeners.get(event) ?? [];
+      eventListeners.push(listener);
+      listeners.set(event, eventListeners);
+    },
+    _emit: (event: string, ...args: unknown[]) => {
+      for (const listener of listeners.get(event) ?? []) listener(...args);
+    },
+    get _evalCalls() {
+      return evalCalls;
+    },
+    get _incrCalls() {
+      return incrCalls;
+    },
+    get _pExpireCalls() {
+      return pExpireCalls;
+    },
     _store: store,
   };
 }
@@ -91,6 +132,17 @@ describe("middleware/builtin/security/redis-rate-limit", () => {
         await rateStore.increment("key1", 60000);
         const storedEntry = mockClient._store.get("veryfront:ratelimit:key1");
         assertEquals(storedEntry?.ttl, 60000);
+      });
+
+      it("should increment and set missing TTL in one Redis eval", async () => {
+        const { rateStore, mockClient } = createStoreWithMock();
+
+        const entry = await rateStore.increment("key1", 60000);
+
+        assertEquals(entry.count, 1);
+        assertEquals(mockClient._evalCalls, 1);
+        assertEquals(mockClient._incrCalls, 0);
+        assertEquals(mockClient._pExpireCalls, 0);
       });
 
       it("should increment count for existing key", async () => {
@@ -176,6 +228,32 @@ describe("middleware/builtin/security/redis-rate-limit", () => {
         await rateStore.increment("a", 1000);
         // deno-lint-ignore no-explicit-any
         assertEquals((rateStore as any).client, mockClient);
+      });
+
+      it("should clear cached clients when redis emits error or end", () => {
+        const { rateStore, mockClient } = createStoreWithMock();
+
+        // deno-lint-ignore no-explicit-any
+        (rateStore as any).attachClientLifecycleHandlers(mockClient);
+        // deno-lint-ignore no-explicit-any
+        (rateStore as any).clientPromise = Promise.resolve(mockClient);
+
+        mockClient._emit("error", new Error("network partition"));
+        // deno-lint-ignore no-explicit-any
+        assertEquals((rateStore as any).client, null);
+        // deno-lint-ignore no-explicit-any
+        assertEquals((rateStore as any).clientPromise, null);
+
+        // deno-lint-ignore no-explicit-any
+        (rateStore as any).client = mockClient;
+        // deno-lint-ignore no-explicit-any
+        (rateStore as any).clientPromise = Promise.resolve(mockClient);
+
+        mockClient._emit("end");
+        // deno-lint-ignore no-explicit-any
+        assertEquals((rateStore as any).client, null);
+        // deno-lint-ignore no-explicit-any
+        assertEquals((rateStore as any).clientPromise, null);
       });
     });
   });

--- a/src/middleware/builtin/security/redis-rate-limit.ts
+++ b/src/middleware/builtin/security/redis-rate-limit.ts
@@ -7,12 +7,26 @@ const logger = serverLogger.component("redis-ratelimit");
 interface RedisClient {
   connect(): Promise<void>;
   disconnect(): Promise<void>;
+  eval(
+    script: string,
+    options: { keys: string[]; arguments: string[] },
+  ): Promise<unknown>;
   incr(key: string): Promise<number>;
   pExpire(key: string, milliseconds: number): Promise<boolean>;
   pTTL(key: string): Promise<number>;
   del(key: string): Promise<number>;
   on?(event: string, listener: (...args: unknown[]) => void): void;
 }
+
+const INCREMENT_WITH_TTL_SCRIPT = `
+local count = redis.call("INCR", KEYS[1])
+local ttl = redis.call("PTTL", KEYS[1])
+if ttl < 0 then
+  redis.call("PEXPIRE", KEYS[1], ARGV[1])
+  ttl = tonumber(ARGV[1])
+end
+return { count, ttl }
+`;
 
 /** Options accepted by redis rate limit. */
 export interface RedisRateLimitOptions {
@@ -38,6 +52,22 @@ export class RedisRateLimitStore implements RateLimitStore {
     return this.clientPromise;
   }
 
+  private clearCachedClient(): void {
+    this.client = null;
+    this.clientPromise = null;
+  }
+
+  private attachClientLifecycleHandlers(client: RedisClient): void {
+    client.on?.("error", (err: unknown) => {
+      logger.error("client error", err);
+      this.clearCachedClient();
+    });
+
+    client.on?.("end", () => {
+      this.clearCachedClient();
+    });
+  }
+
   private async connectClient(): Promise<RedisClient> {
     let createClient: (options: { url?: string }) => RedisClient;
 
@@ -59,13 +89,11 @@ export class RedisRateLimitStore implements RateLimitStore {
 
     try {
       const client = createClient({ url: this.url });
-
-      client.on?.("error", (err: unknown) => {
-        logger.error("client error", err);
-      });
+      this.attachClientLifecycleHandlers(client);
 
       await client.connect();
       this.client = client;
+      this.clientPromise = null;
       return client;
     } catch (error) {
       this.clientPromise = null;
@@ -81,19 +109,12 @@ export class RedisRateLimitStore implements RateLimitStore {
     const client = await this.ensureClient();
     const redisKey = this.storageKey(key);
 
-    const count = await client.incr(redisKey);
-
-    if (count === 1) {
-      await client.pExpire(redisKey, windowMs);
-    }
-
-    const pttl = await client.pTTL(redisKey);
-
-    if (pttl === -1) {
-      await client.pExpire(redisKey, windowMs);
-      return { count, resetAt: Date.now() + windowMs };
-    }
-
+    const [count, pttl] = parseIncrementResult(
+      await client.eval(INCREMENT_WITH_TTL_SCRIPT, {
+        keys: [redisKey],
+        arguments: [String(windowMs)],
+      }),
+    );
     const ttl = pttl > 0 ? pttl : windowMs;
     return { count, resetAt: Date.now() + ttl };
   }
@@ -106,6 +127,31 @@ export class RedisRateLimitStore implements RateLimitStore {
   async destroy(): Promise<void> {
     if (!this.client) return;
     await this.client.disconnect();
-    this.client = null;
+    this.clearCachedClient();
   }
+}
+
+function parseIncrementResult(result: unknown): [number, number] {
+  if (!Array.isArray(result) || result.length < 2) {
+    throw toError(
+      createError({
+        type: "config",
+        message: "Redis rate limit eval returned an invalid result.",
+      }),
+    );
+  }
+
+  const count = Number(result[0]);
+  const ttl = Number(result[1]);
+
+  if (!Number.isFinite(count) || !Number.isFinite(ttl)) {
+    throw toError(
+      createError({
+        type: "config",
+        message: "Redis rate limit eval returned non-numeric values.",
+      }),
+    );
+  }
+
+  return [count, ttl];
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.746";
+export const VERSION = "0.1.747";


### PR DESCRIPTION
## Summary
- replace split `INCR` / `PEXPIRE` rate-limit updates with one Redis Lua `EVAL` that increments, checks TTL, and applies missing expiry atomically
- clear cached Redis clients and pending client promises on `error` / `end` events so future requests reconnect instead of reusing stale handles
- bump release version to `0.1.747`

Closes #2256

## Verification
- `deno test --frozen --allow-all src/middleware/builtin/security/redis-rate-limit.test.ts`
- `deno check src/middleware/builtin/security/redis-rate-limit.ts src/middleware/builtin/security/redis-rate-limit.test.ts`
- `deno test --frozen --allow-all src/middleware/builtin/security/rate-limit.test.ts src/security/rate-limit/middleware.test.ts src/security/rate-limit/strategies.test.ts src/security/rate-limit/memory-store.test.ts`
- `deno task verify:quick`
