### PR TITLE
Encode API cache project refs and sanitize trace URLs

### DIFF
--- a/src/cache/backend.test.ts
+++ b/src/cache/backend.test.ts
@@ -10,6 +10,18 @@ import "#veryfront/schemas/_test-setup.ts";
  */
 
 import { assertEquals, assertExists } from "#std/assert";
+import {
+  _resetShimForTests,
+  type AttributeValue,
+  setGlobalTracerProvider,
+  type Span,
+  type Tracer,
+} from "#veryfront/observability/tracing/api-shim.ts";
+
+type RecordedSpan = {
+  name: string;
+  attributes: Record<string, AttributeValue>;
+};
 
 async function importBackend(): Promise<typeof import("./backend.ts")> {
   return await import("./backend.ts");
@@ -17,6 +29,47 @@ async function importBackend(): Promise<typeof import("./backend.ts")> {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function createRecordingSpan(record: RecordedSpan): Span {
+  return {
+    setAttribute(key, value) {
+      record.attributes[key] = value;
+      return this;
+    },
+    setAttributes(attrs) {
+      Object.assign(record.attributes, attrs);
+      return this;
+    },
+    setStatus() {
+      return this;
+    },
+    recordException() {},
+    addEvent() {
+      return this;
+    },
+    end() {},
+    spanContext() {
+      return {
+        traceId: "0".repeat(32),
+        spanId: "0".repeat(16),
+        traceFlags: 0,
+      };
+    },
+    updateName() {},
+  };
+}
+
+function installRecordingTracer(records: RecordedSpan[]): void {
+  const tracer = {
+    startSpan(name: string, options?: { attributes?: Record<string, AttributeValue> }) {
+      const record = { name, attributes: { ...(options?.attributes ?? {}) } };
+      records.push(record);
+      return createRecordingSpan(record);
+    },
+  } as unknown as Tracer;
+
+  setGlobalTracerProvider({ getTracer: () => tracer });
 }
 
 Deno.test({
@@ -373,6 +426,67 @@ Deno.test("ApiCacheBackend uses custom keyPrefix", async () => {
   const cache = new ApiCacheBackend({ keyPrefix: "custom-prefix" });
   assertExists(cache);
   assertEquals(cache.type, "api");
+});
+
+Deno.test("ApiCacheBackend URL-encodes project refs and omits cache keys from span URLs", async () => {
+  const { ApiCacheBackend } = await importBackend();
+  const globals = globalThis as Record<string, unknown>;
+  const originalAdapter = globals.__vf_multi_project_adapter;
+  const originalFetch = globalThis.fetch;
+  const records: RecordedSpan[] = [];
+  const projectRef = "team/../../demo?token=raw";
+  let capturedUrl = "";
+
+  installRecordingTracer(records);
+  globals.__vf_multi_project_adapter = {
+    getCurrentRequestContext: () => ({
+      token: "request-token",
+      projectSlug: projectRef,
+    }),
+  };
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    capturedUrl = String(input);
+    return Promise.resolve(
+      new Response(JSON.stringify({ value: null }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }) as typeof fetch;
+
+  try {
+    const cache = new ApiCacheBackend({
+      apiBaseUrl: "https://api.example.test",
+      keyPrefix: "prefix",
+      circuitBreakerName: "api-cache-url-encoding-test",
+    });
+
+    await cache.get("secret-cache-key");
+
+    const encodedProjectRef = encodeURIComponent(projectRef);
+    assertEquals(
+      capturedUrl,
+      `https://api.example.test/projects/${encodedProjectRef}/cache/get?key=prefix%3Asecret-cache-key`,
+    );
+
+    const span = records.find((record) => record.name === "http.client.fetch");
+    assertExists(span);
+    assertEquals(
+      span.attributes["http.url"],
+      `https://api.example.test/projects/${encodedProjectRef}/cache/get`,
+    );
+    assertEquals(span.attributes["cache.operation"], "/get");
+    assertEquals(String(span.attributes["http.url"]).includes("secret-cache-key"), false);
+    assertEquals(String(span.attributes["cache.operation"]).includes("secret-cache-key"), false);
+  } finally {
+    if (originalAdapter === undefined) {
+      delete globals.__vf_multi_project_adapter;
+    } else {
+      globals.__vf_multi_project_adapter = originalAdapter;
+    }
+    globalThis.fetch = originalFetch;
+    _resetShimForTests();
+  }
 });
 
 Deno.test("RedisCacheBackend type property", async () => {

--- a/src/cache/backends/api.ts
+++ b/src/cache/backends/api.ts
@@ -7,6 +7,7 @@ import type { CacheBackend } from "../types.ts";
 import { getEnvValue } from "./helpers.ts";
 import { buildBatchResults } from "../batch-results.ts";
 import { REQUEST_ERROR } from "#veryfront/errors";
+import { sanitizeUrlForSpan } from "#veryfront/utils/logger/redact.ts";
 
 const logger = baseLogger.component("api-cache-backend");
 
@@ -85,7 +86,10 @@ export class ApiCacheBackend implements CacheBackend {
 
     try {
       return await this.circuitBreaker.execute(async () => {
-        const url = `${this.apiBaseUrl}/projects/${projectRef}/cache${path}`;
+        const encodedProjectRef = encodeURIComponent(projectRef);
+        const url = `${this.apiBaseUrl}/projects/${encodedProjectRef}/cache${path}`;
+        const spanUrl = sanitizeUrlForSpan(url);
+        const cacheOperation = sanitizeUrlForSpan(path);
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
 
@@ -104,9 +108,9 @@ export class ApiCacheBackend implements CacheBackend {
               }),
             {
               "http.method": method,
-              "http.url": url,
+              "http.url": spanUrl,
               "http.host": new URL(this.apiBaseUrl).host,
-              "cache.operation": path,
+              "cache.operation": cacheOperation,
               "cache.project_slug": projectRef,
             },
           );
@@ -134,7 +138,7 @@ export class ApiCacheBackend implements CacheBackend {
     } catch (error) {
       if (error instanceof CircuitBreakerOpen) {
         logger.info("Circuit breaker open, failing fast", {
-          path,
+          path: sanitizeUrlForSpan(path),
           nextAttemptMs: error.nextAttemptMs,
         });
         return null;
@@ -143,7 +147,7 @@ export class ApiCacheBackend implements CacheBackend {
       const isTimeout = error instanceof Error && error.name === "AbortError";
       const errorMsg = error instanceof Error ? error.message : String(error);
       logger.info(`Request ${isTimeout ? "timeout" : "error"}`, {
-        path,
+        path: sanitizeUrlForSpan(path),
         error: errorMsg,
         isTimeout,
         tokenSource,

--- a/src/observability/auto-instrument/http-instrumentation.ts
+++ b/src/observability/auto-instrument/http-instrumentation.ts
@@ -1,4 +1,5 @@
 import { serverLogger } from "#veryfront/utils";
+import { sanitizeUrlForSpan } from "#veryfront/utils/logger/redact.ts";
 import {
   context as otContext,
   propagation,
@@ -11,7 +12,9 @@ import type { ErrorAttributes, HttpAttributes } from "./types.ts";
 
 const logger = serverLogger.component("auto-instrument");
 
-const tracer = trace.getTracer("veryfront-http");
+function getHttpTracer() {
+  return trace.getTracer("veryfront-http");
+}
 
 const headersGetter = {
   keys(carrier: Headers): string[] {
@@ -42,7 +45,7 @@ export function instrumentHttpHandler(
     const parentContext = extractParentContext(request.headers);
 
     try {
-      return await tracer.startActiveSpan(
+      return await getHttpTracer().startActiveSpan(
         "http.server.request",
         { kind: SpanKind.SERVER, attributes: httpAttrs },
         parentContext,
@@ -79,11 +82,12 @@ export function createInstrumentedFetch(
     const startTime = performance.now();
     const urlString = extractFetchUrl(input);
     const method = init?.method ?? "GET";
+    const spanUrl = sanitizeUrlForSpan(urlString);
 
     const fetchAttrs: HttpAttributes = {
       "http.method": method,
-      "http.url": urlString,
-      "http.target": urlString,
+      "http.url": spanUrl,
+      "http.target": spanUrl,
       "http.host": "",
       "http.scheme": "",
     };
@@ -98,7 +102,7 @@ export function createInstrumentedFetch(
     }
 
     try {
-      return await tracer.startActiveSpan(
+      return await getHttpTracer().startActiveSpan(
         "http.client.fetch",
         { kind: SpanKind.CLIENT, attributes: fetchAttrs },
         async (span) => {
@@ -129,7 +133,7 @@ export function createInstrumentedFetch(
 function buildHttpAttributes(request: Request, url: URL): HttpAttributes {
   return {
     "http.method": request.method,
-    "http.url": request.url,
+    "http.url": sanitizeUrlForSpan(request.url),
     "http.target": url.pathname,
     "http.host": url.host,
     "http.scheme": url.protocol.replace(":", ""),

--- a/src/utils/logger/redact.test.ts
+++ b/src/utils/logger/redact.test.ts
@@ -7,6 +7,7 @@ import {
   redactSensitive,
   sanitizeSerializedError,
   sanitizeUrlCredentials,
+  sanitizeUrlForSpan,
 } from "./redact.ts";
 
 describe("logger/redact", () => {
@@ -107,10 +108,9 @@ describe("logger/redact", () => {
         apiKey = "sk-secret";
         name = "app";
       }
-      const result = redactSensitive({ config: new ApiConfig() }) as Record<
-        string,
-        Record<string, unknown>
-      >;
+      const result = redactSensitive({ config: new ApiConfig() }) as unknown as {
+        config: Record<string, unknown>;
+      };
       assertEquals(result.config.apiKey, REDACTED);
       assertEquals(result.config.name, "app");
     });
@@ -216,6 +216,19 @@ describe("logger/redact", () => {
 
     it("leaves non-URL strings untouched", () => {
       assertEquals(sanitizeUrlCredentials("just a plain message"), "just a plain message");
+    });
+  });
+
+  describe("sanitizeUrlForSpan", () => {
+    it("removes query strings, fragments, and URL credentials", () => {
+      assertEquals(
+        sanitizeUrlForSpan("https://user:secret@example.com/path?token=secret#frag"),
+        "https://example.com/path",
+      );
+    });
+
+    it("removes query strings from relative URL-shaped values", () => {
+      assertEquals(sanitizeUrlForSpan("/cache/get?key=secret#frag"), "/cache/get");
     });
   });
 

--- a/src/utils/logger/redact.test.ts
+++ b/src/utils/logger/redact.test.ts
@@ -230,6 +230,13 @@ describe("logger/redact", () => {
     it("removes query strings from relative URL-shaped values", () => {
       assertEquals(sanitizeUrlForSpan("/cache/get?key=secret#frag"), "/cache/get");
     });
+
+    it("removes userinfo from protocol-relative URL-shaped values", () => {
+      assertEquals(
+        sanitizeUrlForSpan("//user:secret@example.com/path?key=secret"),
+        "//example.com/path",
+      );
+    });
   });
 
   describe("sanitizeSerializedError", () => {

--- a/src/utils/logger/redact.ts
+++ b/src/utils/logger/redact.ts
@@ -239,6 +239,17 @@ function firstUrlDelimiterIndex(input: string): number {
   return Math.min(queryIndex, hashIndex);
 }
 
+function sanitizeProtocolRelativeUrlForSpan(input: string): string | null {
+  if (!input.startsWith("//")) return null;
+
+  try {
+    const url = new URL(`https:${input}`);
+    return `//${url.host}${url.pathname}`;
+  } catch (_) {
+    return null;
+  }
+}
+
 /**
  * Return the URL form safe to attach to observability span attributes.
  *
@@ -260,6 +271,9 @@ export function sanitizeUrlForSpan(input: string): string {
 
   const delimiterIndex = firstUrlDelimiterIndex(input);
   const withoutQueryOrFragment = delimiterIndex === -1 ? input : input.slice(0, delimiterIndex);
+  const protocolRelativeUrl = sanitizeProtocolRelativeUrlForSpan(withoutQueryOrFragment);
+  if (protocolRelativeUrl) return protocolRelativeUrl;
+
   return sanitizeUrlCredentials(withoutQueryOrFragment);
 }
 

--- a/src/utils/logger/redact.ts
+++ b/src/utils/logger/redact.ts
@@ -231,6 +231,38 @@ export function sanitizeUrlCredentials(input: string): string {
   return out;
 }
 
+function firstUrlDelimiterIndex(input: string): number {
+  const queryIndex = input.indexOf("?");
+  const hashIndex = input.indexOf("#");
+  if (queryIndex === -1) return hashIndex;
+  if (hashIndex === -1) return queryIndex;
+  return Math.min(queryIndex, hashIndex);
+}
+
+/**
+ * Return the URL form safe to attach to observability span attributes.
+ *
+ * Span attributes bypass the logger's structured redaction pass, so `http.url`
+ * must not include query strings, fragments, or URL userinfo. This intentionally
+ * strips every query parameter instead of selectively redacting credential-like
+ * names because cache keys and callback state can be sensitive even when the
+ * parameter name is not obviously a credential.
+ */
+export function sanitizeUrlForSpan(input: string): string {
+  if (typeof input !== "string" || input.length === 0) return input;
+
+  try {
+    const url = new URL(input);
+    if (url.origin !== "null") return `${url.origin}${url.pathname}`;
+  } catch (_) {
+    // Relative or malformed URL-shaped strings are handled by the fallback.
+  }
+
+  const delimiterIndex = firstUrlDelimiterIndex(input);
+  const withoutQueryOrFragment = delimiterIndex === -1 ? input : input.slice(0, delimiterIndex);
+  return sanitizeUrlCredentials(withoutQueryOrFragment);
+}
+
 /**
  * Apply {@link sanitizeUrlCredentials} to the `message` and `stack` of a
  * serialized-error-shaped object, returning a new object. Used by the logger's

--- a/tests/integration/observability/http-tracing.test.ts
+++ b/tests/integration/observability/http-tracing.test.ts
@@ -2,16 +2,82 @@ import "../../_helpers/contract-init.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import {
+  _resetShimForTests,
+  type AttributeValue,
+  setGlobalTracerProvider,
+  type Span,
+  type Tracer,
+} from "../../../src/observability/tracing/api-shim.ts";
+import {
   createInstrumentedFetch,
   instrumentHttpHandler,
 } from "../../../src/observability/auto-instrument/http-instrumentation.ts";
 import { endSpan, startSpan, withActiveSpan } from "../../../src/observability/tracing/index.ts";
 
+type RecordedSpan = {
+  name: string;
+  attributes: Record<string, AttributeValue>;
+};
+
+function createRecordingSpan(record: RecordedSpan): Span {
+  return {
+    setAttribute(key, value) {
+      record.attributes[key] = value;
+      return this;
+    },
+    setAttributes(attrs) {
+      Object.assign(record.attributes, attrs);
+      return this;
+    },
+    setStatus() {
+      return this;
+    },
+    recordException() {},
+    addEvent() {
+      return this;
+    },
+    end() {},
+    spanContext() {
+      return {
+        traceId: "0".repeat(32),
+        spanId: "0".repeat(16),
+        traceFlags: 0,
+      };
+    },
+    updateName() {},
+  };
+}
+
+function installRecordingTracer(records: RecordedSpan[]): void {
+  const tracer = {
+    startActiveSpan(
+      name: string,
+      optionsOrFn:
+        | { attributes?: Record<string, AttributeValue> }
+        | ((span: Span) => unknown),
+      contextOrFn?: unknown,
+      fn?: (span: Span) => unknown,
+    ) {
+      const options = typeof optionsOrFn === "function" ? {} : optionsOrFn;
+      const callback = typeof optionsOrFn === "function"
+        ? optionsOrFn
+        : typeof contextOrFn === "function"
+        ? contextOrFn
+        : fn!;
+      const record = { name, attributes: { ...(options.attributes ?? {}) } };
+      records.push(record);
+      return callback(createRecordingSpan(record));
+    },
+  } as unknown as Tracer;
+
+  setGlobalTracerProvider({ getTracer: () => tracer });
+}
+
 describe("HTTP Tracing Integration", () => {
   it("should inject W3C trace context into fetch headers", async () => {
     let capturedHeaders: Headers | null = null;
 
-    const mockFetch = (input: RequestInfo | URL, init?: RequestInit) => {
+    const mockFetch = (_input: RequestInfo | URL, init?: RequestInit) => {
       capturedHeaders = new Headers(init?.headers);
       return Promise.resolve(new Response("OK"));
     };
@@ -43,5 +109,36 @@ describe("HTTP Tracing Integration", () => {
 
     const res = await instrumented(req);
     assertEquals(res.status, 200);
+  });
+
+  it("records http.url without query strings or URL credentials", async () => {
+    const records: RecordedSpan[] = [];
+    installRecordingTracer(records);
+
+    try {
+      const instrumentedFetch = createInstrumentedFetch(() => Promise.resolve(new Response("OK")));
+      await instrumentedFetch("https://user:secret@example.com/cache/get?key=cache-secret#frag");
+
+      const handler = instrumentHttpHandler(() => new Response("OK"));
+      const response = await handler(
+        new Request("https://app.example.com/callback?token=callback-secret&next=/dashboard"),
+      );
+
+      assertEquals(response.status, 200);
+
+      const fetchSpan = records.find((record) => record.name === "http.client.fetch");
+      const serverSpan = records.find((record) => record.name === "http.server.request");
+      assertExists(fetchSpan);
+      assertExists(serverSpan);
+
+      assertEquals(fetchSpan.attributes["http.url"], "https://example.com/cache/get");
+      assertEquals(fetchSpan.attributes["http.target"], "/cache/get");
+      assertEquals(String(fetchSpan.attributes["http.url"]).includes("cache-secret"), false);
+      assertEquals(serverSpan.attributes["http.url"], "https://app.example.com/callback");
+      assertEquals(serverSpan.attributes["http.target"], "/callback");
+      assertEquals(String(serverSpan.attributes["http.url"]).includes("callback-secret"), false);
+    } finally {
+      _resetShimForTests();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- URL-encode API cache project refs before constructing control-plane cache paths.
- Strip query strings, fragments, and URL userinfo from `http.url` span attributes.
- Add regression coverage for cache request URL construction, cache span attributes, HTTP fetch/server spans, and span-safe URL sanitization.

Closes #2253

## Verification
- `deno test --no-check --allow-all src/cache/backend.test.ts tests/integration/observability/http-tracing.test.ts src/utils/logger/redact.test.ts`
- `deno fmt src/cache/backend.test.ts src/cache/backends/api.ts src/observability/auto-instrument/http-instrumentation.ts src/utils/logger/redact.ts src/utils/logger/redact.test.ts tests/integration/observability/http-tracing.test.ts`
- `deno check src/cache/backend.test.ts src/cache/backends/api.ts src/observability/auto-instrument/http-instrumentation.ts src/utils/logger/redact.ts src/utils/logger/redact.test.ts tests/integration/observability/http-tracing.test.ts`
- `deno lint src/cache/backend.test.ts src/cache/backends/api.ts src/observability/auto-instrument/http-instrumentation.ts src/utils/logger/redact.ts src/utils/logger/redact.test.ts tests/integration/observability/http-tracing.test.ts`
- `deno test --no-check --allow-all src/cache src/observability tests/integration/observability src/utils/logger/redact.test.ts`
- Pre-push hook: format, lint, typecheck, generate, unit tests (2031 passed, 18194 steps, 0 failed)

## Not tested
- GitHub CI binary e2e before opening the PR.