### PR TITLE
Guard suppressed logger calls from redaction work

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.747",
+  "version": "0.1.748",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/utils/logger/logger.test.ts
+++ b/src/utils/logger/logger.test.ts
@@ -155,6 +155,35 @@ describe("logger", () => {
         __resetLoggerConfigForTests();
       }
     });
+
+    it("should not format or redact arguments for suppressed log levels", () => {
+      const previousLogLevel = Deno.env.get("LOG_LEVEL");
+      const previousLogFormat = Deno.env.get("LOG_FORMAT");
+      let getterReads = 0;
+
+      try {
+        Deno.env.set("LOG_LEVEL", "ERROR");
+        Deno.env.set("LOG_FORMAT", "json");
+        __resetLoggerConfigForTests();
+
+        const context = {
+          get password() {
+            getterReads += 1;
+            throw new Error("suppressed log context was formatted");
+          },
+        };
+
+        serverLogger.debug("Suppressed debug log", context);
+
+        assertEquals(getterReads, 0);
+      } finally {
+        if (previousLogLevel === undefined) Deno.env.delete("LOG_LEVEL");
+        else Deno.env.set("LOG_LEVEL", previousLogLevel);
+        if (previousLogFormat === undefined) Deno.env.delete("LOG_FORMAT");
+        else Deno.env.set("LOG_FORMAT", previousLogFormat);
+        __resetLoggerConfigForTests();
+      }
+    });
   });
 
   describe("LogLevel enum", () => {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.747";
+export const VERSION = "0.1.748";


### PR DESCRIPTION
## Summary
- add a regression proving suppressed logger calls return before context formatting/redaction
- use a throwing credential getter so future `redactSensitive()` work before the level gate fails immediately
- bump release version to `0.1.748`

Closes #2261

## Verification
- `deno test --frozen --allow-all src/utils/logger/logger.test.ts`
- `deno task verify:quick`
