### PR TITLE
Use Redis MGET for cache batch reads

### DIFF
--- a/src/cache/backend.test.ts
+++ b/src/cache/backend.test.ts
@@ -17,6 +17,7 @@ import {
   type Span,
   type Tracer,
 } from "#veryfront/observability/tracing/api-shim.ts";
+import type { RedisClient } from "#veryfront/utils/redis-client.ts";
 
 type RecordedSpan = {
   name: string;
@@ -539,6 +540,39 @@ Deno.test("RedisCacheBackend getBatch returns empty map for empty keys", async (
   const cache = new RedisCacheBackend();
   const results = await cache.getBatch([]);
   assertEquals(results.size, 0);
+});
+
+Deno.test("RedisCacheBackend getBatch uses one MGET call for prefixed keys", async () => {
+  const { RedisCacheBackend } = await importBackend();
+  const cache = new RedisCacheBackend("vf:test:");
+  const getCalls: string[] = [];
+  const mGetCalls: string[][] = [];
+  const client = {
+    connect: () => Promise.resolve(),
+    disconnect: () => Promise.resolve(),
+    get: (key: string) => {
+      getCalls.push(key);
+      return Promise.resolve(`single:${key}`);
+    },
+    mGet: (keys: string[]) => {
+      mGetCalls.push([...keys]);
+      return Promise.resolve(["value-a", null, "value-c"]);
+    },
+    set: () => Promise.resolve(null),
+    del: () => Promise.resolve(0),
+    scan: () => Promise.resolve({ cursor: 0, keys: [] }),
+    expire: () => Promise.resolve(0),
+  } satisfies RedisClient;
+
+  (cache as unknown as { client: RedisClient }).client = client;
+
+  const results = await cache.getBatch(["a", "b", "c"]);
+
+  assertEquals(mGetCalls, [["vf:test:a", "vf:test:b", "vf:test:c"]]);
+  assertEquals(getCalls, []);
+  assertEquals(results.get("a"), "value-a");
+  assertEquals(results.get("b"), null);
+  assertEquals(results.get("c"), "value-c");
 });
 
 Deno.test("RedisCacheBackend setBatch is no-op without client", async () => {

--- a/src/cache/backend.test.ts
+++ b/src/cache/backend.test.ts
@@ -575,6 +575,39 @@ Deno.test("RedisCacheBackend getBatch uses one MGET call for prefixed keys", asy
   assertEquals(results.get("c"), "value-c");
 });
 
+Deno.test("RedisCacheBackend getBatch falls back to GET when MGET fails", async () => {
+  const { RedisCacheBackend } = await importBackend();
+  const cache = new RedisCacheBackend("vf:test:");
+  const getCalls: string[] = [];
+  const client = {
+    connect: () => Promise.resolve(),
+    disconnect: () => Promise.resolve(),
+    get: (key: string) => {
+      getCalls.push(key);
+      const values = new Map<string, string | null>([
+        ["vf:test:a", "value-a"],
+        ["vf:test:b", null],
+        ["vf:test:c", "value-c"],
+      ]);
+      return Promise.resolve(values.get(key) ?? null);
+    },
+    mGet: () => Promise.reject(new Error("CROSSSLOT Keys in request do not hash to the same slot")),
+    set: () => Promise.resolve(null),
+    del: () => Promise.resolve(0),
+    scan: () => Promise.resolve({ cursor: 0, keys: [] }),
+    expire: () => Promise.resolve(0),
+  } satisfies RedisClient;
+
+  (cache as unknown as { client: RedisClient }).client = client;
+
+  const results = await cache.getBatch(["a", "b", "c"]);
+
+  assertEquals(getCalls, ["vf:test:a", "vf:test:b", "vf:test:c"]);
+  assertEquals(results.get("a"), "value-a");
+  assertEquals(results.get("b"), null);
+  assertEquals(results.get("c"), "value-c");
+});
+
 Deno.test("RedisCacheBackend setBatch is no-op without client", async () => {
   const { RedisCacheBackend } = await importBackend();
 

--- a/src/cache/backends/redis.ts
+++ b/src/cache/backends/redis.ts
@@ -68,7 +68,17 @@ export class RedisCacheBackend implements CacheBackend {
 
     try {
       const prefixedKeys = keys.map((key) => this.prefixKey(key));
-      const fetched = await this.client.mGet(prefixedKeys);
+      let fetched: Array<string | null>;
+      try {
+        fetched = await this.client.mGet(prefixedKeys);
+      } catch (error) {
+        logger.debug("GetBatch MGET failed, falling back to GET", { keyCount: keys.length, error });
+        const fallbackFetched = await Promise.all(
+          keys.map(async (key) => [key, await this.get(key)] as const),
+        );
+        const fallbackValues = new Map(fallbackFetched);
+        return buildBatchResults(keys, (key) => fallbackValues.get(key) ?? null);
+      }
       const values = new Map(
         keys.map((key, index) => [key, fetched[index] ?? null] as const),
       );

--- a/src/cache/backends/redis.ts
+++ b/src/cache/backends/redis.ts
@@ -67,10 +67,11 @@ export class RedisCacheBackend implements CacheBackend {
     }
 
     try {
-      const fetched = await Promise.all(
-        keys.map(async (key) => [key, await this.get(key)] as const),
+      const prefixedKeys = keys.map((key) => this.prefixKey(key));
+      const fetched = await this.client.mGet(prefixedKeys);
+      const values = new Map(
+        keys.map((key, index) => [key, fetched[index] ?? null] as const),
       );
-      const values = new Map(fetched);
       return buildBatchResults(keys, (key) => values.get(key) ?? null);
     } catch (error) {
       logger.debug("GetBatch failed", { keyCount: keys.length, error });

--- a/src/utils/redis-client.ts
+++ b/src/utils/redis-client.ts
@@ -8,6 +8,7 @@ export interface RedisClient {
   connect(): Promise<void>;
   disconnect(): Promise<void>;
   get(key: string): Promise<string | null>;
+  mGet(keys: string[]): Promise<Array<string | null>>;
   set(key: string, value: string, options?: { EX?: number }): Promise<string | null>;
   del(key: string | string[]): Promise<number>;
   scan(


### PR DESCRIPTION
## Summary
- use Redis MGET for RedisCacheBackend.getBatch instead of per-key GET fan-out
- map MGET results back to requested keys and preserve null misses
- add a regression test that asserts one prefixed MGET call and no individual GET calls

Closes #2260

## Verification
- deno test --no-check --allow-all src/cache/backend.test.ts
- deno test --no-check --allow-all src/cache
- deno fmt --check src/cache/backend.test.ts src/cache/backends/redis.ts src/utils/redis-client.ts
- deno check src/cache/backend.test.ts src/cache/backends/redis.ts src/utils/redis-client.ts
- deno lint src/cache/backend.test.ts src/cache/backends/redis.ts src/utils/redis-client.ts
- pre-push: format, lint, typecheck, generate, unit tests (2032 passed, 18198 steps, 0 failed)