### PR TITLE
Cache tracing runtime for span helpers

### DIFF
--- a/src/observability/tracing/api-shim.ts
+++ b/src/observability/tracing/api-shim.ts
@@ -249,6 +249,7 @@ function createNoopProvider(): TracerProvider {
 // ---------------------------------------------------------------------------
 
 let _provider: TracerProvider = createNoopProvider();
+let _providerRevision = 0;
 let _activeContext: Context = NOOP_CONTEXT;
 let _propagator: TextMapPropagator | null = null;
 
@@ -279,10 +280,15 @@ export function setGlobalActiveSpanAccessor(
  */
 export function setGlobalTracerProvider(p: TracerProvider): void {
   _provider = p;
+  _providerRevision++;
 }
 
 export function getGlobalTracerProvider(): TracerProvider {
   return _provider;
+}
+
+export function getTracerProviderRevision(): number {
+  return _providerRevision;
 }
 
 /**
@@ -325,6 +331,7 @@ export const trace = {
   },
   setGlobalTracerProvider(p: TracerProvider): void {
     _provider = p;
+    _providerRevision++;
   },
   getGlobalTracerProvider(): TracerProvider {
     return _provider;
@@ -402,6 +409,7 @@ export function getGlobalMetricsAPI(): MetricsAPI | null {
 
 export function _resetShimForTests(): void {
   _provider = createNoopProvider();
+  _providerRevision++;
   _activeContext = NOOP_CONTEXT;
   _propagator = null;
   _metricsApi = null;

--- a/src/observability/tracing/otlp-setup.test.ts
+++ b/src/observability/tracing/otlp-setup.test.ts
@@ -1,8 +1,19 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  _resetShimForTests,
+  setGlobalTracerProvider,
+  type Span,
+  type SpanContext,
+  type Tracer,
+} from "./api-shim.ts";
 
 describe("observability/tracing/otlp-setup", () => {
+  afterEach(() => {
+    _resetShimForTests();
+  });
+
   it("withSpan should execute the callback when OTLP is unavailable", async () => {
     const { withSpan } = await import("./otlp-setup.ts");
 
@@ -48,5 +59,81 @@ describe("observability/tracing/otlp-setup", () => {
     const { getTraceContext } = await import("./otlp-setup.ts");
 
     assertEquals(getTraceContext(), {});
+  });
+
+  it("span helpers reuse the resolved tracer until the provider changes", async () => {
+    const { startServerSpan, withSpan, withSpanSync } = await import("./otlp-setup.ts");
+
+    let getTracerCalls = 0;
+    const spanContext: SpanContext = {
+      traceId: "00000000000000000000000000000001",
+      spanId: "0000000000000001",
+      traceFlags: 1,
+    };
+    const span: Span = {
+      setAttribute() {
+        return span;
+      },
+      setAttributes() {
+        return span;
+      },
+      setStatus() {
+        return span;
+      },
+      recordException() {},
+      addEvent() {
+        return span;
+      },
+      end() {},
+      spanContext() {
+        return spanContext;
+      },
+      updateName() {},
+    };
+    const tracer: Tracer = {
+      startSpan() {
+        return span;
+      },
+      startActiveSpan<T>(
+        _name: string,
+        optionsOrFn:
+          | { kind?: number; attributes?: Record<string, string | number | boolean | undefined> }
+          | ((span: Span) => T),
+        contextOrFn?: unknown,
+        fn?: (span: Span) => T,
+      ): T {
+        const callback = typeof optionsOrFn === "function"
+          ? optionsOrFn
+          : typeof contextOrFn === "function"
+          ? contextOrFn as (span: Span) => T
+          : fn!;
+        return callback(span);
+      },
+    };
+
+    setGlobalTracerProvider({
+      getTracer() {
+        getTracerCalls++;
+        return tracer;
+      },
+    });
+
+    await withSpan("test.async", async () => "ok");
+    withSpanSync("test.sync", () => "ok");
+    const serverSpan = startServerSpan("GET", "/cache");
+
+    assertExists(serverSpan);
+    assertEquals(getTracerCalls, 1);
+
+    setGlobalTracerProvider({
+      getTracer() {
+        getTracerCalls++;
+        return tracer;
+      },
+    });
+
+    await withSpan("test.after-provider-swap", async () => "ok");
+
+    assertEquals(getTracerCalls, 2);
   });
 });

--- a/src/observability/tracing/otlp-setup.ts
+++ b/src/observability/tracing/otlp-setup.ts
@@ -21,11 +21,13 @@ import {
   defaultTextMapGetter,
   defaultTextMapSetter,
   getTracer,
+  getTracerProviderRevision,
   propagation as shimPropagation,
   type Span,
   SpanKind,
   SpanStatusCode,
   trace as shimTrace,
+  type Tracer,
 } from "./api-shim.ts";
 
 const logger = serverLogger.component("otel");
@@ -67,6 +69,28 @@ function getConfig(): OTLPConfig {
     endpoint: getEnv("OTEL_EXPORTER_OTLP_ENDPOINT") || "",
     headers: parseHeaders(getEnv("OTEL_EXPORTER_OTLP_HEADERS")),
   };
+}
+
+let cachedTracingRuntime:
+  | {
+    providerRevision: number;
+    config: OTLPConfig;
+    tracer: Tracer;
+  }
+  | undefined;
+
+function getTracingRuntime(): { config: OTLPConfig; tracer: Tracer } {
+  const providerRevision = getTracerProviderRevision();
+  if (!cachedTracingRuntime || cachedTracingRuntime.providerRevision !== providerRevision) {
+    const config = getConfig();
+    cachedTracingRuntime = {
+      providerRevision,
+      config,
+      tracer: getTracer(config.serviceName),
+    };
+  }
+
+  return cachedTracingRuntime;
 }
 
 // ---------------------------------------------------------------------------
@@ -121,8 +145,7 @@ export async function withSpan<T>(
   fn: () => Promise<T>,
   attributes?: Record<string, string | number | boolean>,
 ): Promise<T> {
-  const config = getConfig();
-  const tracer = getTracer(config.serviceName);
+  const { tracer } = getTracingRuntime();
   const parentContext = shimContext.active();
 
   const span = tracer.startSpan(
@@ -151,8 +174,7 @@ export function withSpanSync<T>(
   fn: () => T,
   attributes?: Record<string, string | number | boolean>,
 ): T {
-  const config = getConfig();
-  const tracer = getTracer(config.serviceName);
+  const { tracer } = getTracingRuntime();
   const parentContext = shimContext.active();
 
   const span = tracer.startSpan(
@@ -194,8 +216,7 @@ export function startServerSpan(
   path: string,
   parentContext?: unknown,
 ): { span: Span; context: Context } | null {
-  const config = getConfig();
-  const tracer = getTracer(config.serviceName);
+  const { tracer } = getTracingRuntime();
   const ctx = (parentContext || shimContext.active()) as Context;
 
   const span = tracer.startSpan(`${method} ${path}`, { kind: SpanKind.SERVER }, ctx);


### PR DESCRIPTION
## Summary
- Cache OTLP config and tracer resolution lazily for span helpers.
- Track shim provider revisions so bootstrap or tests can swap providers without keeping a stale no-op tracer.
- Add a regression test proving withSpan, withSpanSync, and startServerSpan reuse one tracer resolution until the provider changes.

Closes #2259

## Verification
- Red: `deno test --no-check --allow-all src/observability/tracing/otlp-setup.test.ts` failed with 3 tracer lookups before implementation.
- `deno test --no-check --allow-all src/observability/tracing/otlp-setup.test.ts`
- `deno test --no-check --allow-all src/observability/tracing/api-shim.test.ts src/observability/tracing/otlp-setup.test.ts`
- `deno test --no-check --allow-all src/observability/tracing`
- `deno fmt --check src/observability/tracing/otlp-setup.test.ts src/observability/tracing/otlp-setup.ts src/observability/tracing/api-shim.ts`
- `deno lint src/observability/tracing/otlp-setup.test.ts src/observability/tracing/otlp-setup.ts src/observability/tracing/api-shim.ts`
- `deno check src/observability/tracing/otlp-setup.test.ts src/observability/tracing/otlp-setup.ts src/observability/tracing/api-shim.ts`
- Pre-push hook: format, lint, typecheck, generate, unit tests (2033 passed, 18199 steps, 0 failed)