### PR TITLE
Cache negative module source lookups

### DIFF
--- a/src/modules/server/module-batch-handler.test.ts
+++ b/src/modules/server/module-batch-handler.test.ts
@@ -123,6 +123,41 @@ describe(
         assertEquals(statCalls, afterFirstMiss);
       });
 
+      it("scopes missing module lookups by project identity", async () => {
+        clearBatchCache();
+
+        const missingAdapter = createMockAdapter();
+        const firstResponse = await handleModuleBatch(
+          createBatchRequest("components/Missing.js"),
+          {
+            projectDir: "/shared-project-dir",
+            adapter: missingAdapter,
+            projectId: "project-a",
+            projectSlug: "project-a",
+            dev: true,
+          },
+        );
+        assertEquals(firstResponse.status, 404);
+
+        const presentAdapter = createMockAdapter();
+        presentAdapter.fs.files.set(
+          "/shared-project-dir/components/Missing.tsx",
+          "export const value = 1;",
+        );
+        const secondResponse = await handleModuleBatch(
+          createBatchRequest("components/Missing.js"),
+          {
+            projectDir: "/shared-project-dir",
+            adapter: presentAdapter,
+            projectId: "project-b",
+            projectSlug: "project-b",
+            dev: true,
+          },
+        );
+
+        assertEquals(secondResponse.status, 200);
+      });
+
       it("should successfully batch existing modules", async () => {
         const adapter = createMockAdapter();
         adapter.fs.files.set(

--- a/src/modules/server/module-batch-handler.test.ts
+++ b/src/modules/server/module-batch-handler.test.ts
@@ -96,6 +96,33 @@ describe(
         assertEquals(await response.text(), "No modules could be loaded");
       });
 
+      it("caches missing module lookups", async () => {
+        clearBatchCache();
+        const adapter = createMockAdapter();
+        const originalStat = adapter.fs.stat;
+        let statCalls = 0;
+        adapter.fs.stat = (path: string) => {
+          statCalls++;
+          return originalStat(path);
+        };
+        const options = createOptions({ adapter });
+
+        const firstResponse = await handleModuleBatch(
+          createBatchRequest("components/Missing.js"),
+          options,
+        );
+        assertEquals(firstResponse.status, 404);
+        const afterFirstMiss = statCalls;
+        assertEquals(afterFirstMiss > 0, true);
+
+        const secondResponse = await handleModuleBatch(
+          createBatchRequest("components/Missing.js"),
+          options,
+        );
+        assertEquals(secondResponse.status, 404);
+        assertEquals(statCalls, afterFirstMiss);
+      });
+
       it("should successfully batch existing modules", async () => {
         const adapter = createMockAdapter();
         adapter.fs.files.set(

--- a/src/modules/server/module-batch-handler.ts
+++ b/src/modules/server/module-batch-handler.ts
@@ -126,6 +126,7 @@ export interface BatchHandlerOptions {
   projectSlug?: string;
   projectId?: string;
   branch?: string | null;
+  releaseId?: string | null;
   dev?: boolean;
   /**
    * Restrict module imports to specific directories (opt-in security).
@@ -180,6 +181,7 @@ export function handleModuleBatch(req: Request, options: BatchHandlerOptions): P
         projectSlug,
         projectId,
         branch,
+        releaseId,
         dev = false,
         allowedImportDirs,
         reactVersion,
@@ -228,6 +230,7 @@ export function handleModuleBatch(req: Request, options: BatchHandlerOptions): P
               projectSlug,
               branch,
               projectId,
+              releaseId,
               reactVersion,
             });
 
@@ -326,6 +329,7 @@ async function loadAndTransformModule(
     projectSlug?: string;
     branch?: string | null;
     projectId?: string;
+    releaseId?: string | null;
     reactVersion?: string;
   },
 ): Promise<string | null> {
@@ -333,6 +337,10 @@ async function loadAndTransformModule(
   const missCacheKey = buildSourceMissCacheKey({
     resolver: "module-batch",
     projectDir,
+    projectId: options.projectId,
+    projectSlug: options.projectSlug,
+    branch: options.branch,
+    releaseId: options.releaseId,
     basePath,
     reactVersion: options.reactVersion,
   });

--- a/src/modules/server/module-batch-handler.ts
+++ b/src/modules/server/module-batch-handler.ts
@@ -40,6 +40,12 @@ import { getFrameworkRootFromMeta } from "#veryfront/platform/compat/vfs-paths.t
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { registerLRUCache } from "#veryfront/cache";
 import { sha256Short } from "#veryfront/cache/hash.ts";
+import {
+  buildSourceMissCacheKey,
+  clearSourceMissCache,
+  hasSourceMiss,
+  rememberSourceMiss,
+} from "./module-source-resolution-cache.ts";
 
 const logger = serverLogger.component("module-batch");
 
@@ -81,6 +87,38 @@ const FRAMEWORK_EXTENSIONS = [
   ".jsx",
   ".js", // Regular sources for dev mode
 ] as const;
+
+async function findFirstSecureFile(
+  secureFs: ReturnType<typeof createSecureFs>,
+  paths: string[],
+): Promise<string | null> {
+  const results = await Promise.all(paths.map(async (path) => {
+    try {
+      const stat = await secureFs.stat(path);
+      return stat.isFile ? path : null;
+    } catch {
+      return null;
+    }
+  }));
+
+  return results.find((path): path is string => path !== null) ?? null;
+}
+
+async function findFirstPlatformFile(
+  platformFs: ReturnType<typeof createFileSystem>,
+  paths: string[],
+): Promise<string | null> {
+  const results = await Promise.all(paths.map(async (path) => {
+    try {
+      const stat = await platformFs.stat(path);
+      return stat.isFile ? path : null;
+    } catch {
+      return null;
+    }
+  }));
+
+  return results.find((path): path is string => path !== null) ?? null;
+}
 
 export interface BatchHandlerOptions {
   projectDir: string;
@@ -292,21 +330,27 @@ async function loadAndTransformModule(
   },
 ): Promise<string | null> {
   const basePath = modulePath.replace(/\.js$/, "");
+  const missCacheKey = buildSourceMissCacheKey({
+    resolver: "module-batch",
+    projectDir,
+    basePath,
+    reactVersion: options.reactVersion,
+  });
+  if (hasSourceMiss(missCacheKey)) return null;
 
-  for (const ext of EXTENSIONS) {
-    const fullPath = join(projectDir, basePath + ext);
-    try {
-      const stat = await secureFs.stat(fullPath);
-      if (!stat.isFile) continue;
-
-      const source = await secureFs.readFile(fullPath);
-      return transformModule(source, fullPath, modulePath, projectDir, adapter, secureFs, options);
-    } catch (_) {
-      /* expected: file may not exist at this extension */
-    }
+  const sourcePath = await findFirstSecureFile(
+    secureFs,
+    EXTENSIONS.map((ext) => join(projectDir, basePath + ext)),
+  );
+  if (sourcePath) {
+    const source = await secureFs.readFile(sourcePath);
+    return transformModule(source, sourcePath, modulePath, projectDir, adapter, secureFs, options);
   }
 
-  if (!basePath.startsWith("lib/")) return null;
+  if (!basePath.startsWith("lib/")) {
+    rememberSourceMiss(missCacheKey);
+    return null;
+  }
 
   // Framework lookup directories in priority order
   const frameworkLookupDirs = [
@@ -316,28 +360,25 @@ async function loadAndTransformModule(
 
   const platformFs = createFileSystem();
   for (const lookupDir of frameworkLookupDirs) {
-    for (const ext of FRAMEWORK_EXTENSIONS) {
-      const frameworkPath = join(lookupDir, basePath + ext);
-      try {
-        const stat = await platformFs.stat(frameworkPath);
-        if (!stat.isFile) continue;
-
-        const source = await platformFs.readTextFile(frameworkPath);
-        return transformModule(
-          source,
-          frameworkPath,
-          modulePath,
-          projectDir,
-          adapter,
-          secureFs,
-          options,
-        );
-      } catch (_) {
-        /* expected: framework file may not exist at this extension */
-      }
+    const frameworkPath = await findFirstPlatformFile(
+      platformFs,
+      FRAMEWORK_EXTENSIONS.map((ext) => join(lookupDir, basePath + ext)),
+    );
+    if (frameworkPath) {
+      const source = await platformFs.readTextFile(frameworkPath);
+      return transformModule(
+        source,
+        frameworkPath,
+        modulePath,
+        projectDir,
+        adapter,
+        secureFs,
+        options,
+      );
     }
   }
 
+  rememberSourceMiss(missCacheKey);
   return null;
 }
 
@@ -518,6 +559,8 @@ function transformExportsForBundle(code: string): string {
  * Clear the transform cache (on deployment or memory pressure)
  */
 export function clearBatchCache(projectSlug?: string): void {
+  clearSourceMissCache("module-batch");
+
   if (!projectSlug) {
     transformCache.clear();
     logger.debug("Cleared all cache");

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -12,8 +12,10 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
+import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { VERSION } from "#veryfront/utils/version.ts";
 import { isModuleRequest } from "./module-server.ts";
+import { clearSourceMissCache } from "./module-source-resolution-cache.ts";
 
 describe("isModuleRequest", () => {
   it("should return true for /_vf_modules/ path", () => {
@@ -201,6 +203,34 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     // esbuild may transform `export default {...}` into other export forms
     assertEquals(text.includes(VERSION), true);
     assertEquals(text.includes("version"), true);
+  });
+
+  it("caches missing project module lookups", async () => {
+    clearSourceMissCache("module-server");
+    const adapter = createMockAdapter();
+    const originalStat = adapter.fs.stat;
+    let statCalls = 0;
+    adapter.fs.stat = (path: string) => {
+      statCalls++;
+      return originalStat(path);
+    };
+
+    const { serveModule } = await import("./module-server.ts");
+    const request = new Request("http://localhost:3000/_vf_modules/components/Missing.js");
+    const options = {
+      projectId: "test",
+      projectDir: "/test-project",
+      adapter,
+    };
+
+    const firstResponse = await serveModule(request, options);
+    assertEquals(firstResponse.status, 404);
+    const afterFirstMiss = statCalls;
+    assertEquals(afterFirstMiss > 0, true);
+
+    const secondResponse = await serveModule(request, options);
+    assertEquals(secondResponse.status, 404);
+    assertEquals(statCalls, afterFirstMiss);
   });
 
   it("should serve dnt shims as JavaScript content type", async () => {

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -233,6 +233,37 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     assertEquals(statCalls, afterFirstMiss);
   });
 
+  it("scopes missing project module lookups by project identity", async () => {
+    clearSourceMissCache("module-server");
+    const { serveModule } = await import("./module-server.ts");
+    const request = new Request("http://localhost:3000/_vf_modules/components/Missing.js");
+
+    const missingAdapter = createMockAdapter();
+    const firstResponse = await serveModule(request, {
+      projectId: "fallback-project",
+      projectUUID: "project-a",
+      projectSlug: "project-a",
+      projectDir: "/shared-project-dir",
+      adapter: missingAdapter,
+    });
+    assertEquals(firstResponse.status, 404);
+
+    const presentAdapter = createMockAdapter();
+    presentAdapter.fs.files.set(
+      "/shared-project-dir/components/Missing.tsx",
+      "export const value = 1;",
+    );
+    const secondResponse = await serveModule(request, {
+      projectId: "fallback-project",
+      projectUUID: "project-b",
+      projectSlug: "project-b",
+      projectDir: "/shared-project-dir",
+      adapter: presentAdapter,
+    });
+
+    assertEquals(secondResponse.status, 200);
+  });
+
   it("should serve dnt shims as JavaScript content type", async () => {
     const response = await serve(
       new Request("http://localhost:3000/_vf_modules/_veryfront/_dnt.shims.js"),

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -27,6 +27,11 @@ import {
 import { getReactUrls, REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import { readLimitedCrossProjectSource } from "./cross-project-source-limit.ts";
 import { sha256Short } from "#veryfront/cache/hash.ts";
+import {
+  buildSourceMissCacheKey,
+  hasSourceMiss,
+  rememberSourceMiss,
+} from "./module-source-resolution-cache.ts";
 
 const logger = serverLogger.component("module-server");
 
@@ -567,17 +572,42 @@ async function findFrameworkPackageAssetFile(
 ): Promise<string | null> {
   if (hasUnsafePackageAssetPath(basePathWithoutExt)) return null;
 
-  for (const ext of extensions) {
-    const candidatePath = join(FRAMEWORK_ROOT, basePathWithoutExt + ext);
-    try {
-      const stat = await fs.stat(candidatePath);
-      if (stat.isFile) return candidatePath;
-    } catch {
-      /* expected: package asset may not exist in source checkouts */
-    }
-  }
+  return await findFirstPlatformFile(
+    fs,
+    extensions.map((ext) => join(FRAMEWORK_ROOT, basePathWithoutExt + ext)),
+  );
+}
 
-  return null;
+async function findFirstPlatformFile(
+  fs: ReturnType<typeof createFileSystem>,
+  paths: string[],
+): Promise<string | null> {
+  const results = await Promise.all(paths.map(async (path) => {
+    try {
+      const stat = await fs.stat(path);
+      return stat.isFile ? path : null;
+    } catch {
+      return null;
+    }
+  }));
+
+  return results.find((path): path is string => path !== null) ?? null;
+}
+
+async function findFirstSecureFile(
+  secureFs: ReturnType<typeof createSecureFs>,
+  paths: string[],
+): Promise<string | null> {
+  const results = await Promise.all(paths.map(async (path) => {
+    try {
+      const stat = await secureFs.stat(path);
+      return stat.isFile ? path : null;
+    } catch {
+      return null;
+    }
+  }));
+
+  return results.find((path): path is string => path !== null) ?? null;
 }
 
 async function findSourceFile(
@@ -617,6 +647,12 @@ async function findSourceFile(
   const isFrameworkPath = basePathWithoutExt.startsWith("_veryfront/");
   const isFrameworkPackageAssetPath = basePathWithoutExt.startsWith("react/") ||
     basePathWithoutExt.startsWith("deps/");
+  const missCacheKey = buildSourceMissCacheKey({
+    resolver: "module-server",
+    projectDir,
+    basePath: basePathWithoutExt,
+    reactVersion,
+  });
 
   // Check embedded polyfills first (no filesystem access needed).
   // These cover both compiled-binary polyfills (node:async_hooks etc.)
@@ -636,6 +672,8 @@ async function findSourceFile(
       embeddedContent,
     };
   }
+
+  if (hasSourceMiss(missCacheKey)) return null;
 
   if (isFrameworkPackageAssetPath) {
     const browserReactShim = createBrowserReactPackageShim(basePathWithoutExt, reactVersion);
@@ -698,17 +736,13 @@ async function findSourceFile(
   }
 
   // Project file lookups (using secureFs which may go through FSAdapter in proxy mode)
-  for (const ext of extensions) {
-    const fullPath = join(projectDir, basePathWithoutExt + ext);
-    try {
-      const stat = await secureFs.stat(fullPath);
-      if (stat.isFile) {
-        logger.debug("Found file", { basePath, resolvedPath: fullPath });
-        return { path: fullPath, isFrameworkFile: false };
-      }
-    } catch (_) {
-      /* expected: file may not exist at this extension */
-    }
+  const projectFilePath = await findFirstSecureFile(
+    secureFs,
+    extensions.map((ext) => join(projectDir, basePathWithoutExt + ext)),
+  );
+  if (projectFilePath) {
+    logger.debug("Found file", { basePath, resolvedPath: projectFilePath });
+    return { path: projectFilePath, isFrameworkFile: false };
   }
 
   const prefixesToStrip = ["components/", "pages/", "lib/", "app/", "src/"];
@@ -716,60 +750,49 @@ async function findSourceFile(
     if (!basePathWithoutExt.startsWith(prefix)) continue;
 
     const strippedPath = basePathWithoutExt.slice(prefix.length);
-    for (const ext of extensions) {
-      const fullPath = join(projectDir, strippedPath + ext);
-      try {
-        const stat = await secureFs.stat(fullPath);
-        if (stat.isFile) {
-          logger.debug("Found file after stripping prefix", {
-            originalPath: basePathWithoutExt,
-            strippedPath,
-            resolvedPath: fullPath,
-          });
-          return { path: fullPath, isFrameworkFile: false };
-        }
-      } catch (_) {
-        /* expected: file may not exist after stripping prefix */
-      }
+    const strippedFilePath = await findFirstSecureFile(
+      secureFs,
+      extensions.map((ext) => join(projectDir, strippedPath + ext)),
+    );
+    if (strippedFilePath) {
+      logger.debug("Found file after stripping prefix", {
+        originalPath: basePathWithoutExt,
+        strippedPath,
+        resolvedPath: strippedFilePath,
+      });
+      return { path: strippedFilePath, isFrameworkFile: false };
     }
   }
 
-  for (const ext of extensions) {
-    const fullPath = join(projectDir, basePathWithoutExt, `index${ext}`);
-    try {
-      const stat = await secureFs.stat(fullPath);
-      if (stat.isFile) {
-        logger.debug("Found index file", {
-          basePath: basePathWithoutExt,
-          resolvedPath: fullPath,
-        });
-        return { path: fullPath, isFrameworkFile: false };
-      }
-    } catch (_) {
-      /* expected: index file may not exist at this extension */
-    }
+  const indexFilePath = await findFirstSecureFile(
+    secureFs,
+    extensions.map((ext) => join(projectDir, basePathWithoutExt, `index${ext}`)),
+  );
+  if (indexFilePath) {
+    logger.debug("Found index file", {
+      basePath: basePathWithoutExt,
+      resolvedPath: indexFilePath,
+    });
+    return { path: indexFilePath, isFrameworkFile: false };
   }
 
   // Try looking in common project directories
   const commonDirs = ["components", "app", "pages", "lib", "src"];
   for (const dir of commonDirs) {
-    for (const ext of extensions) {
-      const fullPath = join(projectDir, dir, basePathWithoutExt + ext);
-      try {
-        const stat = await secureFs.stat(fullPath);
-        if (stat.isFile) {
-          logger.debug("Found file in common directory", {
-            basePath,
-            resolvedPath: fullPath,
-          });
-          return { path: fullPath, isFrameworkFile: false };
-        }
-      } catch (_) {
-        /* expected: file may not exist in common directory */
-      }
+    const commonDirFilePath = await findFirstSecureFile(
+      secureFs,
+      extensions.map((ext) => join(projectDir, dir, basePathWithoutExt + ext)),
+    );
+    if (commonDirFilePath) {
+      logger.debug("Found file in common directory", {
+        basePath,
+        resolvedPath: commonDirFilePath,
+      });
+      return { path: commonDirFilePath, isFrameworkFile: false };
     }
   }
 
+  rememberSourceMiss(missCacheKey);
   return null;
 }
 

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -107,6 +107,15 @@ const SNIPPET_MODULE_PREFIX = /^\/_vf_modules\/_snippets\/([a-f0-9]+)\.js/;
 const CROSS_PROJECT_VERSIONED_PREFIX =
   /^\/_vf_modules\/_cross\/([a-z0-9-]+)@([\d^~x][\d.x^~-]*)\/\@\/(.+)$/;
 const CROSS_PROJECT_LATEST_PREFIX = /^\/_vf_modules\/_cross\/([a-z0-9-]+)\/\@\/(.+)$/;
+
+interface SourceLookupContext {
+  projectId?: string;
+  projectSlug?: string | null;
+  branch?: string | null;
+  releaseId?: string | null;
+  reactVersion?: string;
+}
+
 export interface ModuleServerOptions {
   /** Project identifier (directory path, legacy naming) */
   projectId: string;
@@ -239,6 +248,10 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
                 secureFs,
                 projectDir,
                 currentModulePath: `_snippets/${hash}.js`,
+                projectId: effectiveProjectId,
+                projectSlug: snippetProjectSlug,
+                branch: snippetBranch,
+                releaseId: options.releaseId,
                 reactVersion,
               }),
             });
@@ -327,6 +340,8 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
                 projectDir,
                 currentModulePath: crossPath,
                 crossProjectRef: projectRef,
+                projectId: effectiveProjectId,
+                releaseId: options.releaseId,
                 reactVersion,
               }),
             });
@@ -367,7 +382,13 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
           secureFs,
           projectDir,
           filePathWithoutExt,
-          reactVersion,
+          {
+            projectId: effectiveProjectId,
+            projectSlug,
+            branch,
+            releaseId: options.releaseId,
+            reactVersion,
+          },
         );
         if (!findResult) {
           logger.warn("Module not found", {
@@ -440,6 +461,10 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
                 secureFs,
                 projectDir,
                 currentModulePath: modulePath,
+                projectId: effectiveProjectId,
+                projectSlug,
+                branch,
+                releaseId: options.releaseId,
                 reactVersion,
               }),
             });
@@ -500,6 +525,10 @@ function createSSRTargetCacheBusterResolver(options: {
   projectDir: string;
   currentModulePath: string;
   crossProjectRef?: string;
+  projectId?: string;
+  projectSlug?: string | null;
+  branch?: string | null;
+  releaseId?: string | null;
   reactVersion?: string;
 }): (target: SSRImportRewriteTarget) => Promise<string | undefined> {
   const versions = new Map<string, Promise<string | undefined>>();
@@ -519,7 +548,13 @@ function createSSRTargetCacheBusterResolver(options: {
           options.secureFs,
           options.projectDir,
           stripSSRModuleJsExtension(targetPath),
-          options.reactVersion,
+          {
+            projectId: options.projectId,
+            projectSlug: options.projectSlug,
+            branch: options.branch,
+            releaseId: options.releaseId,
+            reactVersion: options.reactVersion,
+          },
         );
         if (!findResult) return undefined;
 
@@ -614,8 +649,9 @@ async function findSourceFile(
   secureFs: ReturnType<typeof createSecureFs>,
   projectDir: string,
   basePath: string,
-  reactVersion?: string,
+  context: SourceLookupContext,
 ): Promise<FindSourceFileResult | null> {
+  const { reactVersion } = context;
   // Extensions including .src for compiled binary embedded sources
   const extensions = [
     ".json",
@@ -650,6 +686,10 @@ async function findSourceFile(
   const missCacheKey = buildSourceMissCacheKey({
     resolver: "module-server",
     projectDir,
+    projectId: context.projectId,
+    projectSlug: context.projectSlug,
+    branch: context.branch,
+    releaseId: context.releaseId,
     basePath: basePathWithoutExt,
     reactVersion,
   });

--- a/src/modules/server/module-source-resolution-cache.ts
+++ b/src/modules/server/module-source-resolution-cache.ts
@@ -1,0 +1,54 @@
+import { registerLRUCache } from "#veryfront/cache";
+import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
+
+type ModuleSourceResolver = "module-server" | "module-batch";
+
+const SOURCE_MISS_CACHE_MAX_ENTRIES = 5_000;
+
+const sourceMissCaches: Record<ModuleSourceResolver, LRUCache<string, true>> = {
+  "module-server": new LRUCache<string, true>({
+    maxEntries: SOURCE_MISS_CACHE_MAX_ENTRIES,
+  }),
+  "module-batch": new LRUCache<string, true>({
+    maxEntries: SOURCE_MISS_CACHE_MAX_ENTRIES,
+  }),
+};
+
+registerLRUCache("module-server-source-miss-cache", sourceMissCaches["module-server"]);
+registerLRUCache("module-batch-source-miss-cache", sourceMissCaches["module-batch"]);
+
+export function buildSourceMissCacheKey(options: {
+  resolver: ModuleSourceResolver;
+  projectDir: string;
+  basePath: string;
+  reactVersion?: string;
+}): string {
+  return [
+    options.resolver,
+    options.projectDir,
+    options.reactVersion ?? "",
+    options.basePath,
+  ].join("\0");
+}
+
+export function hasSourceMiss(cacheKey: string): boolean {
+  return sourceMissCaches[getResolverFromCacheKey(cacheKey)].has(cacheKey);
+}
+
+export function rememberSourceMiss(cacheKey: string): void {
+  sourceMissCaches[getResolverFromCacheKey(cacheKey)].set(cacheKey, true);
+}
+
+export function clearSourceMissCache(resolver?: ModuleSourceResolver): void {
+  if (resolver) {
+    sourceMissCaches[resolver].clear();
+    return;
+  }
+
+  for (const cache of Object.values(sourceMissCaches)) cache.clear();
+}
+
+function getResolverFromCacheKey(cacheKey: string): ModuleSourceResolver {
+  const resolver = cacheKey.split("\0", 1)[0];
+  return resolver === "module-batch" ? "module-batch" : "module-server";
+}

--- a/src/modules/server/module-source-resolution-cache.ts
+++ b/src/modules/server/module-source-resolution-cache.ts
@@ -20,12 +20,20 @@ registerLRUCache("module-batch-source-miss-cache", sourceMissCaches["module-batc
 export function buildSourceMissCacheKey(options: {
   resolver: ModuleSourceResolver;
   projectDir: string;
+  projectId?: string;
+  projectSlug?: string | null;
+  branch?: string | null;
+  releaseId?: string | null;
   basePath: string;
   reactVersion?: string;
 }): string {
   return [
     options.resolver,
     options.projectDir,
+    options.projectId ?? "",
+    options.projectSlug ?? "",
+    options.branch ?? "",
+    options.releaseId ?? "",
     options.reactVersion ?? "",
     options.basePath,
   ].join("\0");

--- a/src/server/context/cache-invalidation.ts
+++ b/src/server/context/cache-invalidation.ts
@@ -16,6 +16,7 @@ import {
 } from "#veryfront/rendering/router-detection.ts";
 import { clearSnippetCacheForProject } from "#veryfront/rendering/snippet-renderer.ts";
 import { resetApiHandlerForProject } from "#veryfront/server/handlers/request/api/pages-api-handler.ts";
+import { clearSourceMissCache } from "#veryfront/modules/server/module-source-resolution-cache.ts";
 
 const logger = serverLogger.component("cache-invalidation");
 
@@ -59,6 +60,7 @@ export async function invalidateProjectCaches(
     logger.debug("Clearing module path cache (full)", { projectSlug });
     clearModulePathCache();
   }
+  clearSourceMissCache();
 
   logger.debug("Clearing SSR module cache", {
     projectSlug,

--- a/src/server/handlers/request/module/batch-module-handler.ts
+++ b/src/server/handlers/request/module/batch-module-handler.ts
@@ -25,7 +25,8 @@ export function handleBatchModuleEndpoint(
         adapter: ctx.adapter,
         projectSlug: ctx.projectSlug,
         projectId: ctx.projectId,
-        branch: ctx.parsedDomain?.branch ?? null,
+        branch: ctx.requestContext?.branch ?? ctx.parsedDomain?.branch ?? null,
+        releaseId: ctx.releaseId ?? null,
         dev: !!ctx.isLocalProject,
         allowedImportDirs: ctx.config?.security?.allowedImportDirs,
       });

--- a/tests/server/context/cache-invalidation.test.ts
+++ b/tests/server/context/cache-invalidation.test.ts
@@ -1,5 +1,11 @@
 import "../../_helpers/contract-init.ts";
+import { assertEquals } from "#std/assert";
 import { describe, it } from "#std/testing/bdd";
+import {
+  buildSourceMissCacheKey,
+  hasSourceMiss,
+  rememberSourceMiss,
+} from "../../../src/modules/server/module-source-resolution-cache.ts";
 import { invalidateProjectCaches } from "../../../src/server/context/cache-invalidation.ts";
 
 describe("cache-invalidation", () => {
@@ -17,6 +23,20 @@ describe("cache-invalidation", () => {
 
     it("clears all caches when no paths provided", () => {
       invalidateProjectCaches("test-project");
+    });
+
+    it("clears source miss caches", async () => {
+      const cacheKey = buildSourceMissCacheKey({
+        resolver: "module-server",
+        projectDir: "/test-project",
+        basePath: "components/Missing",
+      });
+      rememberSourceMiss(cacheKey);
+      assertEquals(hasSourceMiss(cacheKey), true);
+
+      await invalidateProjectCaches("test-project");
+
+      assertEquals(hasSourceMiss(cacheKey), false);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add registered negative LRU caches for module-server and module-batch source misses
- parallelize extension probes within each lookup strategy while preserving extension priority
- clear source miss caches during project cache invalidation and batch cache clears

## Tests
- deno fmt --check src/modules/server/module-source-resolution-cache.ts src/modules/server/module-server.ts src/modules/server/module-batch-handler.ts src/modules/server/module-server.test.ts src/modules/server/module-batch-handler.test.ts src/server/context/cache-invalidation.ts tests/server/context/cache-invalidation.test.ts
- deno lint src/modules/server/module-source-resolution-cache.ts src/modules/server/module-server.ts src/modules/server/module-batch-handler.ts src/modules/server/module-server.test.ts src/modules/server/module-batch-handler.test.ts src/server/context/cache-invalidation.ts tests/server/context/cache-invalidation.test.ts
- deno check src/modules/server/module-source-resolution-cache.ts src/modules/server/module-server.ts src/modules/server/module-batch-handler.ts src/modules/server/module-server.test.ts src/modules/server/module-batch-handler.test.ts src/server/context/cache-invalidation.ts tests/server/context/cache-invalidation.test.ts
- deno test --no-check --allow-all src/modules/server/module-server.test.ts src/modules/server/module-batch-handler.test.ts tests/server/context/cache-invalidation.test.ts
- deno test --no-check --allow-all src/modules/server
- pre-push hook: format, lint, typecheck, generate, unit tests (2033 passed, 18201 steps)

Closes #2234