### PR TITLE
Fix renderer init, SSG paths, and OAuth state bounds

### DIFF
--- a/src/build/production-build/static-generation.test.ts
+++ b/src/build/production-build/static-generation.test.ts
@@ -248,6 +248,28 @@ describe(
         assertEquals(stats.totalSize > 0, true);
       });
 
+      it("records generated Pages Router paths in SSG stats", async () => {
+        const stats = await buildPagesRoutes(
+          [
+            { slug: "index", path: "/", file: "pages/index.mdx" },
+            { slug: "about", path: "/about", file: "pages/about.mdx" },
+          ],
+          {
+            adapter: createMockAdapter(),
+            projectDir: "/tmp/project",
+            outputDir: "/tmp/output",
+            renderer: createMockRenderer(),
+            config: createMockConfig(),
+            enablePrefetch: false,
+            chunkManifest: null,
+            dryRun: true,
+          },
+        );
+
+        assertEquals(stats.pages, 2);
+        assertEquals(stats.ssgPaths, ["/", "/about"]);
+      });
+
       it("escapes route slug before embedding it in the client bootstrap script", async () => {
         const adapter = createMemoryAdapter();
         const slug = `bad";globalThis.__xss=1;//`;

--- a/src/build/production-build/static-generation.ts
+++ b/src/build/production-build/static-generation.ts
@@ -238,6 +238,7 @@ ${clientStyles}
       if (dryRun) {
         stats.pages++;
         stats.totalSize += getByteLength(enhancedHtml);
+        stats.ssgPaths.push(route.path);
         logger.debug(`Built page: ${route.slug}`);
         continue;
       }
@@ -246,6 +247,7 @@ ${clientStyles}
 
       stats.pages++;
       stats.totalSize += getByteLength(enhancedHtml);
+      stats.ssgPaths.push(route.path);
 
       const pageData = {
         slug: route.slug,

--- a/src/oauth/token-store/memory.test.ts
+++ b/src/oauth/token-store/memory.test.ts
@@ -59,6 +59,18 @@ Deno.test("MemoryTokenStore consumeState is one-shot and rejects expired/unknown
   assertEquals(await store.consumeState("old"), null);
 });
 
+Deno.test("MemoryTokenStore bounds OAuth states via oldest-entry eviction", async () => {
+  const store = new MemoryTokenStore("default", { maxStateEntries: 2 });
+
+  await store.setState("state-1", { userId: "u1", serviceId: "svc", createdAt: Date.now() });
+  await store.setState("state-2", { userId: "u2", serviceId: "svc", createdAt: Date.now() });
+  await store.setState("state-3", { userId: "u3", serviceId: "svc", createdAt: Date.now() });
+
+  assertEquals(await store.consumeState("state-1"), null);
+  assertEquals((await store.consumeState("state-2"))?.userId, "u2");
+  assertEquals((await store.consumeState("state-3"))?.userId, "u3");
+});
+
 Deno.test("MemoryTokenStore scopes keys by projectId", async () => {
   const a = new MemoryTokenStore("project-a");
   const b = new MemoryTokenStore("project-b");

--- a/src/oauth/token-store/memory.ts
+++ b/src/oauth/token-store/memory.ts
@@ -17,6 +17,9 @@ const STATE_EXPIRY_MS = 10 * 60 * 1_000;
  */
 const DEFAULT_MAX_TOKEN_ENTRIES = 10_000;
 
+/** Default cap on in-flight OAuth state values. */
+const DEFAULT_MAX_STATE_ENTRIES = 10_000;
+
 /** Options for {@link MemoryTokenStore}. */
 export interface MemoryTokenStoreOptions {
   /**
@@ -25,6 +28,11 @@ export interface MemoryTokenStoreOptions {
    * {@link DEFAULT_MAX_TOKEN_ENTRIES}.
    */
   maxEntries?: number;
+  /**
+   * Maximum number of in-flight OAuth state entries to retain before oldest
+   * entries are evicted. Defaults to {@link DEFAULT_MAX_STATE_ENTRIES}.
+   */
+  maxStateEntries?: number;
 }
 
 /**
@@ -43,11 +51,13 @@ export interface MemoryTokenStoreOptions {
 export class MemoryTokenStore implements TokenStore {
   private tokens: LRUCacheAdapter;
   private states = new Map<string, StoredOAuthState>();
+  private maxStateEntries: number;
   private projectId: string;
   private warnedProductionUse = false;
 
   constructor(projectId = "default", options: MemoryTokenStoreOptions = {}) {
     this.projectId = projectId;
+    this.maxStateEntries = Math.max(1, options.maxStateEntries ?? DEFAULT_MAX_STATE_ENTRIES);
     this.tokens = new LRUCacheAdapter({
       maxEntries: options.maxEntries ?? DEFAULT_MAX_TOKEN_ENTRIES,
     });
@@ -91,8 +101,9 @@ export class MemoryTokenStore implements TokenStore {
   }
 
   setState(state: string, meta: StoredOAuthState): Promise<void> {
-    this.states.set(state, meta);
     this.cleanupExpiredStates();
+    this.states.set(state, meta);
+    this.evictOldestStates();
     return Promise.resolve();
   }
 
@@ -116,6 +127,14 @@ export class MemoryTokenStore implements TokenStore {
       if (now - meta.createdAt > STATE_EXPIRY_MS) {
         this.states.delete(state);
       }
+    }
+  }
+
+  private evictOldestStates(): void {
+    while (this.states.size > this.maxStateEntries) {
+      const oldestState = this.states.keys().next().value;
+      if (oldestState === undefined) return;
+      this.states.delete(oldestState);
     }
   }
 

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { destroyRenderer, initializeRenderer, Renderer } from "./renderer.ts";
+import { destroyRenderer, getRenderer, initializeRenderer, Renderer } from "./renderer.ts";
 
 function getEnv(name: string): string | undefined {
   // deno-lint-ignore no-explicit-any
@@ -212,6 +212,47 @@ describe("rendering/renderer singleton initialization", () => {
       const [firstRenderer, secondRenderer] = await Promise.all([first, second]);
       assertEquals(firstRenderer, secondRenderer);
       assertEquals(initializeCalls, 1);
+    } finally {
+      Renderer.prototype.initialize = originalInitialize;
+      Renderer.prototype.destroy = originalDestroy;
+      await destroyRenderer();
+    }
+  });
+
+  it("does not publish a renderer after destroy runs during initialization", async () => {
+    await destroyRenderer();
+
+    const originalInitialize = Renderer.prototype.initialize;
+    const originalDestroy = Renderer.prototype.destroy;
+    let destroyCalls = 0;
+    let resolveStarted!: () => void;
+    let resolveInitialize!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const initializeDone = new Promise<void>((resolve) => {
+      resolveInitialize = resolve;
+    });
+
+    Renderer.prototype.initialize = function () {
+      resolveStarted();
+      return initializeDone;
+    };
+    Renderer.prototype.destroy = () => {
+      destroyCalls++;
+      return Promise.resolve();
+    };
+
+    try {
+      const pendingInitialize = initializeRenderer();
+      await started;
+
+      await destroyRenderer();
+      resolveInitialize();
+
+      await assertRejects(() => pendingInitialize, Error, "cancelled");
+      assertThrows(() => getRenderer());
+      assertEquals(destroyCalls, 1);
     } finally {
       Renderer.prototype.initialize = originalInitialize;
       Renderer.prototype.destroy = originalDestroy;

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { destroyRenderer, initializeRenderer, Renderer } from "./renderer.ts";
 
 function getEnv(name: string): string | undefined {
   // deno-lint-ignore no-explicit-any
@@ -167,5 +168,54 @@ describe("Renderer helpers", () => {
     it("should parse default max concurrent as 30", () => {
       assertEquals(parseInt("30", 10), 30);
     });
+  });
+});
+
+describe("rendering/renderer singleton initialization", () => {
+  it("waits for an in-flight singleton initialization", async () => {
+    await destroyRenderer();
+
+    const originalInitialize = Renderer.prototype.initialize;
+    const originalDestroy = Renderer.prototype.destroy;
+    let initializeCalls = 0;
+    let resolveStarted!: () => void;
+    let resolveInitialize!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const initializeDone = new Promise<void>((resolve) => {
+      resolveInitialize = resolve;
+    });
+
+    Renderer.prototype.initialize = function () {
+      initializeCalls++;
+      resolveStarted();
+      return initializeDone;
+    };
+    Renderer.prototype.destroy = () => Promise.resolve();
+
+    try {
+      const first = initializeRenderer();
+      await started;
+
+      let secondResolved = false;
+      const second = initializeRenderer().then((value) => {
+        secondResolved = true;
+        return value;
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      assertEquals(secondResolved, false);
+
+      resolveInitialize();
+      const [firstRenderer, secondRenderer] = await Promise.all([first, second]);
+      assertEquals(firstRenderer, secondRenderer);
+      assertEquals(initializeCalls, 1);
+    } finally {
+      Renderer.prototype.initialize = originalInitialize;
+      Renderer.prototype.destroy = originalDestroy;
+      await destroyRenderer();
+    }
   });
 });

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -164,11 +164,8 @@ export class Renderer {
       });
     })();
 
-    try {
-      await this.initializationPromise;
-    } finally {
-      this.initializationPromise = null;
-    }
+    await this.initializationPromise;
+    this.initializationPromise = null;
   }
 
   renderPage(slug: string, ctx: RenderContext, options?: RenderOptions): Promise<RenderResult> {
@@ -433,6 +430,7 @@ export class Renderer {
   async destroy(): Promise<void> {
     await this.cache.destroy();
     this.initialized = false;
+    this.initializationPromise = null;
     logger.debug("Destroyed");
   }
 
@@ -536,6 +534,7 @@ export {
 };
 
 let renderer: Renderer | null = null;
+let rendererInitializationPromise: Promise<Renderer> | null = null;
 
 export function getRenderer(): Renderer {
   if (!renderer) {
@@ -548,10 +547,19 @@ export function getRenderer(): Renderer {
 
 export async function initializeRenderer(options?: RendererOptions): Promise<Renderer> {
   if (renderer) return renderer;
+  if (rendererInitializationPromise) return rendererInitializationPromise;
 
-  renderer = new Renderer(options);
-  await renderer.initialize(options?.shared);
-  return renderer;
+  const nextRenderer = new Renderer(options);
+  rendererInitializationPromise = (async () => {
+    try {
+      await nextRenderer.initialize(options?.shared);
+      renderer = nextRenderer;
+      return nextRenderer;
+    } finally {
+      rendererInitializationPromise = null;
+    }
+  })();
+  return rendererInitializationPromise;
 }
 
 export function isRendererInitialized(): boolean {
@@ -559,6 +567,7 @@ export function isRendererInitialized(): boolean {
 }
 
 export async function destroyRenderer(): Promise<void> {
+  rendererInitializationPromise = null;
   if (!renderer) return;
 
   await renderer.destroy();

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -535,6 +535,7 @@ export {
 
 let renderer: Renderer | null = null;
 let rendererInitializationPromise: Promise<Renderer> | null = null;
+let rendererGeneration = 0;
 
 export function getRenderer(): Renderer {
   if (!renderer) {
@@ -550,9 +551,16 @@ export async function initializeRenderer(options?: RendererOptions): Promise<Ren
   if (rendererInitializationPromise) return rendererInitializationPromise;
 
   const nextRenderer = new Renderer(options);
+  const generation = rendererGeneration;
   rendererInitializationPromise = (async () => {
     try {
       await nextRenderer.initialize(options?.shared);
+      if (generation !== rendererGeneration) {
+        await nextRenderer.destroy();
+        throw INITIALIZATION_ERROR.create({
+          detail: "Renderer initialization was cancelled before it completed.",
+        });
+      }
       renderer = nextRenderer;
       return nextRenderer;
     } finally {
@@ -567,11 +575,13 @@ export function isRendererInitialized(): boolean {
 }
 
 export async function destroyRenderer(): Promise<void> {
+  rendererGeneration++;
   rendererInitializationPromise = null;
-  if (!renderer) return;
-
-  await renderer.destroy();
+  const currentRenderer = renderer;
   renderer = null;
+  if (!currentRenderer) return;
+
+  await currentRenderer.destroy();
 }
 
 export async function clearRendererCacheForProject(projectId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- share in-flight `initializeRenderer()` work and publish the singleton only after initialization completes
- record successful Pages Router SSG paths in build stats
- cap in-flight `MemoryTokenStore` OAuth states with oldest-entry eviction

Closes #2257

## Verification
- `deno fmt --check src/build/production-build/static-generation.ts src/build/production-build/static-generation.test.ts src/oauth/token-store/memory.ts src/oauth/token-store/memory.test.ts src/rendering/renderer.ts src/rendering/renderer.test.ts`
- `deno lint src/build/production-build/static-generation.ts src/build/production-build/static-generation.test.ts src/oauth/token-store/memory.ts src/oauth/token-store/memory.test.ts src/rendering/renderer.ts src/rendering/renderer.test.ts`
- `deno check src/build/production-build/static-generation.ts src/build/production-build/static-generation.test.ts src/oauth/token-store/memory.ts src/oauth/token-store/memory.test.ts src/rendering/renderer.ts src/rendering/renderer.test.ts`
- `deno test --no-check --allow-all src/build/production-build/static-generation.test.ts src/oauth/token-store/memory.test.ts src/rendering/renderer.test.ts`
- `deno test --no-check --allow-all src/build/production-build src/oauth src/rendering/renderer.test.ts`
- `git diff --check`
- pre-push hook: format, lint, typecheck, generation, unit suite (`2035 passed`)

## Risks
- `Renderer.initialize()` now retains a failed in-instance initialization promise until destroy, matching the issue request to avoid ambiguous retry state. The global `initializeRenderer()` wrapper still clears its in-flight guard on failure and does not publish a failed renderer.