### PR TITLE
Avoid import map reparse during HTML shell generation

### DIFF
--- a/src/html/html-shell-generator.test.ts
+++ b/src/html/html-shell-generator.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import "./styles-builder/__tests__/css-processor-setup.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { assert, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import {
   clearAllManifests,
   recordSSRModules,
@@ -132,6 +132,33 @@ describe("html-generation/html-shell-generator", () => {
         preloadIndex < bodyIndex,
         "jsx-runtime preload should be in <head>, before <body>",
       );
+    });
+
+    it("does not re-parse generated import map JSON for jsx-runtime preload", async () => {
+      const originalParse = JSON.parse;
+      let importMapParseCalls = 0;
+
+      JSON.parse = ((text: string, reviver?: Parameters<typeof JSON.parse>[1]) => {
+        if (typeof text === "string" && text.includes('"react/jsx-runtime"')) {
+          importMapParseCalls++;
+          throw new Error("import map JSON should not be parsed by shell generation");
+        }
+
+        return originalParse(text, reviver);
+      }) as typeof JSON.parse;
+
+      try {
+        const result = await wrapInHTMLShell(
+          "<div>Content</div>",
+          createMeta(),
+          createOptions(),
+        );
+
+        assertStringIncludes(result, "jsx-runtime");
+        assertEquals(importMapParseCalls, 0);
+      } finally {
+        JSON.parse = originalParse;
+      }
     });
 
     it("should use projectSlug for manifest-based module preloads", async () => {

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -24,7 +24,7 @@ import {
   getProjectCSS,
 } from "./styles-builder/index.ts";
 import type { HTMLGenerationOptions } from "./types.ts";
-import { buildImportMapJson, buildRootAttributes, shouldDisableLayout } from "./utils.ts";
+import { buildImportMap, buildRootAttributes, shouldDisableLayout } from "./utils.ts";
 
 function pathToModuleUrl(path: string, studioEmbed?: boolean): string {
   if (!path) return "";
@@ -195,7 +195,7 @@ async function generateHTMLShellPartsImpl(
   // unless a caller explicitly forces production client scripts for fair benchmarking.
   const useDevScripts = !options.forceProductionScripts && (isLocalProject || isPreviewMode);
 
-  const importMapJsonPromise = buildImportMapJson({
+  const importMapPromise = buildImportMap({
     projectDir: options.projectDir,
     config: options.config,
     customImports: options.importMap,
@@ -222,12 +222,12 @@ async function generateHTMLShellPartsImpl(
   const modeStyles = useDevScripts ? getErrorOverlayStyles(nonce) : "";
 
   const modulePreloadHints = generateModulePreloadHints(options);
-  const importMapJson = await profilePhase("html.import_map", () => importMapJsonPromise);
+  const importMap = await profilePhase("html.import_map", () => importMapPromise);
+  const importMapJson = importMap.json;
 
   // Preload critical React dependencies to avoid waterfall delays.
   // jsx-runtime is discovered late (only when modules execute), adding ~500ms latency.
-  const importMapData = JSON.parse(importMapJson) as { imports?: Record<string, string> };
-  const jsxRuntimeUrl = importMapData.imports?.["react/jsx-runtime"];
+  const jsxRuntimeUrl = importMap.imports["react/jsx-runtime"];
   const criticalDepsPreload = jsxRuntimeUrl
     ? `<link rel="modulepreload" href="${jsxRuntimeUrl}">`
     : "";

--- a/src/html/utils.test.ts
+++ b/src/html/utils.test.ts
@@ -189,8 +189,8 @@ describe("html-generation/utils", () => {
         ) as {
           imports: Record<string, string>;
         };
-        assertStringIncludes(first.imports.react, "18.3.1");
-        assertStringIncludes(first.imports["veryfront/chat"], "0.1.10");
+        assertStringIncludes(first.imports.react!, "18.3.1");
+        assertStringIncludes(first.imports["veryfront/chat"]!, "0.1.10");
 
         await new Promise((resolve) => setTimeout(resolve, 5));
         await Deno.writeTextFile(
@@ -207,8 +207,8 @@ describe("html-generation/utils", () => {
         ) as {
           imports: Record<string, string>;
         };
-        assertStringIncludes(second.imports.react, "19.0.0");
-        assertStringIncludes(second.imports["veryfront/chat"], "0.2.0");
+        assertStringIncludes(second.imports.react!, "19.0.0");
+        assertStringIncludes(second.imports["veryfront/chat"]!, "0.2.0");
       } finally {
         await Deno.remove(dir, { recursive: true });
       }

--- a/src/html/utils.ts
+++ b/src/html/utils.ts
@@ -36,6 +36,12 @@ interface DetectedVersions {
 
 interface CachedImportMapEntry {
   cacheKey: string;
+  imports: Record<string, string>;
+  json: string;
+}
+
+export interface BuiltImportMap {
+  imports: Record<string, string>;
   json: string;
 }
 
@@ -264,6 +270,16 @@ interface BuildImportMapOptions {
   pretty?: boolean;
 }
 
+function stringifyImportMap(imports: Record<string, string>, pretty = true): string {
+  return JSON.stringify({ imports }, null, pretty ? 2 : undefined);
+}
+
+function stableMapKey(imports?: Record<string, string>): string {
+  return imports
+    ? JSON.stringify(Object.entries(imports).sort(([a], [b]) => a.localeCompare(b)))
+    : "";
+}
+
 function isImportMapOnlyOptions(
   options: BuildImportMapOptions | Record<string, string>,
 ): options is Record<string, string> {
@@ -273,18 +289,13 @@ function isImportMapOnlyOptions(
     !("pretty" in options);
 }
 
-export async function buildImportMapJson(
+export async function buildImportMap(
   options?: BuildImportMapOptions | Record<string, string>,
-): Promise<string> {
-  const stringifyImportMap = (imports: Record<string, string>, pretty = true) =>
-    JSON.stringify({ imports }, null, pretty ? 2 : undefined);
-  const stableMapKey = (imports?: Record<string, string>) =>
-    imports ? JSON.stringify(Object.entries(imports).sort(([a], [b]) => a.localeCompare(b))) : "";
-
+): Promise<BuiltImportMap> {
   if (options && isImportMapOnlyOptions(options)) {
-    const imports = options;
+    const imports = { ...options };
     if (Object.keys(imports).length > 0) {
-      return stringifyImportMap(imports);
+      return { imports, json: stringifyImportMap(imports) };
     }
   }
 
@@ -304,7 +315,7 @@ export async function buildImportMapJson(
       ...customImports,
     };
 
-    return stringifyImportMap(imports, pretty);
+    return { imports, json: stringifyImportMap(imports, pretty) };
   }
 
   let imports: Record<string, string>;
@@ -333,11 +344,18 @@ export async function buildImportMapJson(
     customImports: stableMapKey(customImports),
   });
   const cached = importMapJsonCache.get(cacheKey);
-  if (cached) return cached.json;
+  if (cached) return cached;
 
   const json = stringifyImportMap(imports, pretty);
-  importMapJsonCache.set(cacheKey, { cacheKey, json });
-  return json;
+  const built = { cacheKey, imports, json };
+  importMapJsonCache.set(cacheKey, built);
+  return built;
+}
+
+export async function buildImportMapJson(
+  options?: BuildImportMapOptions | Record<string, string>,
+): Promise<string> {
+  return (await buildImportMap(options)).json;
 }
 
 export function clearImportMapCache(): void {


### PR DESCRIPTION
## Summary
- add `buildImportMap()` so import map generation returns both the JSON and imports object
- use the built imports directly for the jsx-runtime preload instead of parsing the generated JSON
- add a regression test that fails if shell generation re-parses its generated import map

## Test plan
- deno test --no-check --allow-all src/html/html-shell-generator.test.ts src/html/utils.test.ts
- deno fmt --check src/html/html-shell-generator.ts src/html/html-shell-generator.test.ts src/html/utils.ts src/html/utils.test.ts
- deno lint src/html/html-shell-generator.ts src/html/html-shell-generator.test.ts src/html/utils.ts src/html/utils.test.ts
- deno check src/html/html-shell-generator.ts src/html/html-shell-generator.test.ts src/html/utils.ts src/html/utils.test.ts
- git diff --check
- pre-push hook: format, lint, typecheck, generation, unit suite (2033 passed)

Refs #2262