### PR TITLE
Short-circuit dependency cycle checks

### DIFF
--- a/src/cache/dependency-graph.test.ts
+++ b/src/cache/dependency-graph.test.ts
@@ -80,6 +80,27 @@ describe("DependencyGraph", () => {
       expect(graph.wouldCreateCycle("/c.ts", "/a.ts")).toBe(true);
       expect(graph.wouldCreateCycle("/d.ts", "/a.ts")).toBe(false);
     });
+
+    it("short-circuits once the target dependency is found", () => {
+      class ThrowingDependencySet extends Set<string> {
+        override [Symbol.iterator](): SetIterator<string> {
+          throw new Error("unvisited dependency branch should not be traversed");
+        }
+      }
+
+      const graph = new DependencyGraph();
+      graph.addModule("/entry.ts", ["/target.ts", "/unvisited.ts"]);
+
+      const internals = graph as unknown as {
+        dependencies: Map<string, Set<string>>;
+      };
+      internals.dependencies.set(
+        "/unvisited.ts",
+        new ThrowingDependencySet(["/too-late.ts"]),
+      );
+
+      expect(graph.wouldCreateCycle("/target.ts", "/entry.ts")).toBe(true);
+    });
   });
 });
 

--- a/src/cache/dependency-graph.ts
+++ b/src/cache/dependency-graph.ts
@@ -49,7 +49,7 @@ export class DependencyGraph {
   }
 
   wouldCreateCycle(from: string, to: string): boolean {
-    return this.getTransitiveDependencies(to).includes(from);
+    return this.hasTransitiveDependency(to, from, new Set(), new Set());
   }
 
   clear(): void {
@@ -76,6 +76,28 @@ export class DependencyGraph {
     }
 
     path.delete(filePath);
+  }
+
+  private hasTransitiveDependency(
+    filePath: string,
+    target: string,
+    visited: Set<string>,
+    path: Set<string>,
+  ): boolean {
+    if (path.has(filePath) || visited.has(filePath)) return false;
+
+    visited.add(filePath);
+    path.add(filePath);
+
+    for (const dep of this.dependencies.get(filePath) ?? []) {
+      if (dep === target || this.hasTransitiveDependency(dep, target, visited, path)) {
+        path.delete(filePath);
+        return true;
+      }
+    }
+
+    path.delete(filePath);
+    return false;
   }
 
   private collectDependents(


### PR DESCRIPTION
## Summary
- change `DependencyGraph.wouldCreateCycle()` to use an early-exit boolean DFS
- preserve `getTransitiveDependencies()` behavior for callers that still need the complete dependency closure
- add a regression that fails if `wouldCreateCycle()` traverses branches after finding the target

## Test plan
- deno test --no-check --allow-all src/cache/dependency-graph.test.ts src/cache/dependency-tracking.test.ts
- deno fmt --check src/cache/dependency-graph.ts src/cache/dependency-graph.test.ts src/cache/dependency-tracking.test.ts
- deno lint src/cache/dependency-graph.ts src/cache/dependency-graph.test.ts src/cache/dependency-tracking.test.ts
- deno check src/cache/dependency-graph.ts src/cache/dependency-graph.test.ts src/cache/dependency-tracking.test.ts
- git diff --check
- pre-push hook: format, lint, typecheck, generation, unit suite (2035 passed)

Refs #2242