### PR TITLE
Encode upload IDs for delete requests

### DIFF
--- a/src/embedding/react/use-uploads.test.ts
+++ b/src/embedding/react/use-uploads.test.ts
@@ -1,0 +1,12 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { buildUploadResourceUrl } from "./use-uploads.ts";
+
+describe("buildUploadResourceUrl", () => {
+  it("encodes upload IDs before appending them to the API path", () => {
+    assertEquals(
+      buildUploadResourceUrl("/api/uploads", "folder/a b.json?x=1"),
+      "/api/uploads/folder%2Fa%20b.json%3Fx%3D1",
+    );
+  });
+});

--- a/src/embedding/react/use-uploads.ts
+++ b/src/embedding/react/use-uploads.ts
@@ -31,6 +31,10 @@ export interface UseUploadsResult {
   refresh: () => Promise<void>;
 }
 
+export function buildUploadResourceUrl(api: string, id: string): string {
+  return `${api}/${encodeURIComponent(id)}`;
+}
+
 /**
  * useUploads hook for managing RAG upload lifecycle.
  */
@@ -90,7 +94,7 @@ export function useUploads(options: UseUploadsOptions): UseUploadsResult {
     async (id: string): Promise<void> => {
       setError(null);
       try {
-        await fetch(`${options.api}/${id}`, { method: "DELETE" });
+        await fetch(buildUploadResourceUrl(options.api, id), { method: "DELETE" });
         await refresh();
       } catch (error) {
         console.debug("useUploads: failed to delete upload", error);


### PR DESCRIPTION
## Summary
- Add a small URL builder for upload resource paths that encodes upload IDs before path interpolation.
- Route `useUploads().remove()` through that encoded URL builder.
- Add a regression test for IDs containing `/`, spaces, query characters, and `=`.

## Test Plan
- [x] `deno test --no-check --allow-all src/embedding/react/use-uploads.test.ts`
- [x] `deno fmt --check src/embedding/react/use-uploads.ts src/embedding/react/use-uploads.test.ts`
- [x] `deno lint src/embedding/react/use-uploads.ts src/embedding/react/use-uploads.test.ts`
- [x] `deno check src/embedding/react/use-uploads.ts src/embedding/react/use-uploads.test.ts`
- [x] Pre-push hook: format, lint, typecheck, generation, unit suite (`2036 passed`)

Refs #2258