### PR TITLE
Render dev overlay errors without innerHTML

### DIFF
--- a/src/server/handlers/dev/scripts/error-overlay.test.ts
+++ b/src/server/handlers/dev/scripts/error-overlay.test.ts
@@ -1,0 +1,13 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { getErrorOverlay } from "./error-overlay.ts";
+
+describe("server/handlers/dev/scripts/error-overlay", () => {
+  it("does not render error-controlled content through overlay innerHTML", () => {
+    const script = getErrorOverlay();
+
+    assertEquals(script.includes("overlayElement.innerHTML"), false);
+    assertEquals(script.includes("textContent = String(error.message"), true);
+    assertEquals(script.includes("textContent = String(error.stack"), true);
+  });
+});

--- a/src/server/handlers/dev/scripts/error-overlay.ts
+++ b/src/server/handlers/dev/scripts/error-overlay.ts
@@ -12,6 +12,7 @@ export function getErrorOverlay(): string {
 // Veryfront Error Overlay
 (function() {
   let overlayElement = null;
+  let entriesElement = null;
 
   window.addEventListener('error', (event) => {
     showError({
@@ -35,18 +36,35 @@ export function getErrorOverlay(): string {
       createOverlay();
     }
 
-    const errorHtml = \`
-      <div style="margin-bottom: 20px;">
-        <div style="color: #ff5555; font-size: 18px; font-weight: bold; margin-bottom: 10px;">
-          \${escapeHtml(error.message)}
-        </div>
-        \${error.filename ? \`<div style="color: #8b8b8b; margin-bottom: 5px;">\${escapeHtml(error.filename)}:\${error.lineno}:\${error.colno}</div>\` : ''}
-        \${error.stack ? \`<pre style="color: #cccccc; font-size: 12px; overflow-x: auto;">\${escapeHtml(error.stack)}</pre>\` : ''}
-      </div>
-    \`;
-
-    overlayElement.innerHTML = errorHtml + overlayElement.innerHTML;
+    const errorEntry = createErrorEntry(error);
+    entriesElement.insertBefore(errorEntry, entriesElement.firstChild);
     overlayElement.style.display = 'block';
+  }
+
+  function createErrorEntry(error) {
+    const entry = document.createElement('div');
+    entry.style.cssText = 'margin-bottom: 20px;';
+
+    const message = document.createElement('div');
+    message.style.cssText = 'color: #ff5555; font-size: 18px; font-weight: bold; margin-bottom: 10px;';
+    message.textContent = String(error.message || 'Unknown error');
+    entry.appendChild(message);
+
+    if (error.filename) {
+      const location = document.createElement('div');
+      location.style.cssText = 'color: #8b8b8b; margin-bottom: 5px;';
+      location.textContent = String(error.filename) + ':' + error.lineno + ':' + error.colno;
+      entry.appendChild(location);
+    }
+
+    if (error.stack) {
+      const stack = document.createElement('pre');
+      stack.style.cssText = 'color: #cccccc; font-size: 12px; overflow-x: auto;';
+      stack.textContent = String(error.stack);
+      entry.appendChild(stack);
+    }
+
+    return entry;
   }
 
   function createOverlay() {
@@ -83,17 +101,13 @@ export function getErrorOverlay(): string {
     \`;
     closeButton.onclick = () => {
       overlayElement.style.display = 'none';
-      overlayElement.innerHTML = '';
+      entriesElement.replaceChildren();
     };
 
+    entriesElement = document.createElement('div');
     overlayElement.appendChild(closeButton);
+    overlayElement.appendChild(entriesElement);
     document.body.appendChild(overlayElement);
-  }
-
-  function escapeHtml(text) {
-    const div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
   }
 })();
     `.trim();


### PR DESCRIPTION
## Summary
- Replace the dev error overlay string-built error entry with DOM nodes.
- Assign error message, location, and stack through `textContent` instead of reparsing strings through `innerHTML`.
- Add a regression test that forbids the generated overlay from using `overlayElement.innerHTML` for error-controlled content.

## Test Plan
- [x] `deno test --no-check --allow-all src/server/handlers/dev/scripts/error-overlay.test.ts`
- [x] `deno fmt --check src/server/handlers/dev/scripts/error-overlay.ts src/server/handlers/dev/scripts/error-overlay.test.ts`
- [x] `deno lint src/server/handlers/dev/scripts/error-overlay.ts src/server/handlers/dev/scripts/error-overlay.test.ts`
- [x] `deno check src/server/handlers/dev/scripts/error-overlay.ts src/server/handlers/dev/scripts/error-overlay.test.ts`
- [x] Pre-push hook: format, lint, typecheck, generation, unit suite (`2036 passed`)

Refs #2243