### PR TITLE
Sanitize client log parse-error previews

### DIFF
--- a/src/server/handlers/monitoring/client-log.handler.ts
+++ b/src/server/handlers/monitoring/client-log.handler.ts
@@ -17,6 +17,33 @@ const CLIENT_LOG_MESSAGE_MAX_LENGTH = 5_000;
 /** Max chars of raw body shown in parse-error diagnostics */
 const CLIENT_LOG_BODY_PREVIEW_LENGTH = 500;
 
+function escapeControlCharacter(char: string): string {
+  switch (char) {
+    case "\n":
+      return "\\n";
+    case "\r":
+      return "\\r";
+    case "\t":
+      return "\\t";
+    default:
+      return `\\u${char.charCodeAt(0).toString(16).padStart(4, "0")}`;
+  }
+}
+
+export function sanitizeClientLogPreview(
+  value: string,
+  maxLength = CLIENT_LOG_BODY_PREVIEW_LENGTH,
+): string {
+  let sanitized = "";
+  for (const char of value.slice(0, maxLength)) {
+    const code = char.charCodeAt(0);
+    sanitized += code <= 0x1f || (code >= 0x7f && code <= 0x9f)
+      ? escapeControlCharacter(char)
+      : char;
+  }
+  return sanitized;
+}
+
 export class ClientLogHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "ClientLogHandler",
@@ -92,15 +119,14 @@ export class ClientLogHandler extends BaseHandler {
   }
 
   private handleParseError(e: unknown, body: string): void {
-    serverLogger.error(
-      "[ClientLogHandler] Failed to parse client log. Error:",
-      getErrorMessage(e),
-    );
-    serverLogger.error(
-      `[ClientLogHandler] Raw body received (first ${CLIENT_LOG_BODY_PREVIEW_LENGTH} chars):`,
-      body.slice(0, CLIENT_LOG_BODY_PREVIEW_LENGTH),
-    );
-    logger.error("Body length:", body.length);
+    serverLogger.error("[ClientLogHandler] Failed to parse client log", {
+      parse_error_message: getErrorMessage(e),
+    });
+    serverLogger.error("[ClientLogHandler] Sanitized body preview", {
+      body_length: body.length,
+      body_preview: sanitizeClientLogPreview(body),
+      preview_length: CLIENT_LOG_BODY_PREVIEW_LENGTH,
+    });
 
     // Try to identify the problematic character for SyntaxError
     if (!(e instanceof SyntaxError) || !e.message.includes("position")) {
@@ -116,12 +142,14 @@ export class ClientLogHandler extends BaseHandler {
     const start = Math.max(0, pos - 20);
     const end = Math.min(body.length, pos + 20);
 
-    logger.error("Context around error position:", body.slice(start, end));
-    serverLogger.error(
-      "[ClientLogHandler] Character at position:",
-      body.charCodeAt(pos),
-      "which is:",
-      body.charAt(pos),
-    );
+    logger.error("Context around error position", {
+      body_context: sanitizeClientLogPreview(body.slice(start, end)),
+      error_position: pos,
+    });
+    serverLogger.error("[ClientLogHandler] Character at error position", {
+      char_code: body.charCodeAt(pos),
+      char_preview: sanitizeClientLogPreview(body.charAt(pos), 1),
+      error_position: pos,
+    });
   }
 }

--- a/src/server/handlers/monitoring/client-log.test.ts
+++ b/src/server/handlers/monitoring/client-log.test.ts
@@ -1,7 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { ClientLogHandler } from "./client-log.handler.ts";
+import { __resetLoggerConfigForTests } from "#veryfront/utils/logger/logger.ts";
+import { ClientLogHandler, sanitizeClientLogPreview } from "./client-log.handler.ts";
 
 function createHandler(): ClientLogHandler {
   return new ClientLogHandler();
@@ -22,6 +23,19 @@ async function assertOkResponse(result: { response?: Response }): Promise<void> 
 }
 
 describe("server/handlers/monitoring/client-log", () => {
+  describe("sanitizeClientLogPreview", () => {
+    it("escapes control characters before logging body previews", () => {
+      assertEquals(
+        sanitizeClientLogPreview("line\nnext\r\t\u001b[31m\u0000tail", 30),
+        "line\\nnext\\r\\t\\u001b[31m\\u0000tail",
+      );
+    });
+
+    it("truncates before escaping the preview", () => {
+      assertEquals(sanitizeClientLogPreview("abcdef\n", 3), "abc");
+    });
+  });
+
   describe("ClientLogHandler metadata", () => {
     it("should have correct handler name", () => {
       const handler = createHandler();
@@ -102,6 +116,45 @@ describe("server/handlers/monitoring/client-log", () => {
       await assertOkResponse(result);
       const body = await (result.response as Response).json();
       assertEquals(body.ok, true);
+    });
+
+    it("logs sanitized invalid-JSON previews in emitted context", async () => {
+      const originalError = console.error;
+      const originalLogFormat = Deno.env.get("LOG_FORMAT");
+      const originalLogLevel = Deno.env.get("LOG_LEVEL");
+      const originalNoColor = Deno.env.get("NO_COLOR");
+      const output: string[] = [];
+
+      console.error = (message: unknown) => {
+        output.push(String(message));
+      };
+      Deno.env.set("LOG_FORMAT", "text");
+      Deno.env.set("LOG_LEVEL", "ERROR");
+      Deno.env.set("NO_COLOR", "1");
+      __resetLoggerConfigForTests();
+
+      try {
+        const handler = createHandler();
+        const req = new Request("http://localhost/_veryfront/log", {
+          method: "POST",
+          body: '{"message":"line\n\u001b[31m"}',
+        });
+
+        await handler.handle(req, localCtx);
+      } finally {
+        console.error = originalError;
+        if (originalLogFormat === undefined) Deno.env.delete("LOG_FORMAT");
+        else Deno.env.set("LOG_FORMAT", originalLogFormat);
+        if (originalLogLevel === undefined) Deno.env.delete("LOG_LEVEL");
+        else Deno.env.set("LOG_LEVEL", originalLogLevel);
+        if (originalNoColor === undefined) Deno.env.delete("NO_COLOR");
+        else Deno.env.set("NO_COLOR", originalNoColor);
+        __resetLoggerConfigForTests();
+      }
+
+      const combinedOutput = output.join("\n");
+      assertEquals(combinedOutput.includes("body_preview="), true);
+      assertEquals(combinedOutput.includes("line\\n\\u001b[31m"), true);
     });
 
     it("should return ok:true for log data with details", async () => {


### PR DESCRIPTION
## Summary
- Escape control characters before logging client-log parse-failure body previews.
- Sanitize syntax-error context and single-character diagnostics before logging.
- Add regression coverage for newline, carriage return, tab, terminal escape, and NUL bytes.

## Test Plan
- [x] `deno test --no-check --allow-all src/server/handlers/monitoring/client-log.test.ts`
- [x] `deno fmt --check src/server/handlers/monitoring/client-log.handler.ts src/server/handlers/monitoring/client-log.test.ts`
- [x] `deno lint src/server/handlers/monitoring/client-log.handler.ts src/server/handlers/monitoring/client-log.test.ts`
- [x] `deno check src/server/handlers/monitoring/client-log.handler.ts src/server/handlers/monitoring/client-log.test.ts`
- [x] `git diff --check`
- [x] Pre-push hook: format, lint, typecheck, generation, unit suite (`2037 passed`)

Refs #2243