### PR TITLE
Reduce SSR import rewrite scans

### DIFF
--- a/src/modules/react-loader/ssr-module-loader/import-rewriter.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/import-rewriter.test.ts
@@ -127,4 +127,46 @@ describe("rewriteLocalImports", () => {
     assertEquals(result.includes("file:///tmp/A.js"), true);
     assertEquals(result.includes("file:///tmp/B.js"), true);
   });
+
+  it("uses one replacement regex for local imports", () => {
+    const originalRegExp = globalThis.RegExp;
+    const constructedPatterns: string[] = [];
+
+    class CountingRegExp extends originalRegExp {
+      constructor(pattern: string | RegExp, flags?: string) {
+        constructedPatterns.push(String(pattern));
+        super(pattern, flags);
+      }
+    }
+
+    Object.defineProperty(globalThis, "RegExp", {
+      configurable: true,
+      value: CountingRegExp,
+    });
+
+    try {
+      const map = new Map([
+        ["./A", "/tmp/A.js"],
+        ["./B", "/tmp/B.js"],
+        ["./C", "/tmp/C.js"],
+      ]);
+      const code = [
+        `import { A } from "./A.js";`,
+        `import { B } from "./B.js";`,
+        `import { C } from "./C.js";`,
+      ].join("\n");
+
+      const result = rewriteLocalImports(code, map, "/project/src/index.tsx", projectDir);
+
+      assertEquals(result.includes("file:///tmp/A.js"), true);
+      assertEquals(result.includes("file:///tmp/B.js"), true);
+      assertEquals(result.includes("file:///tmp/C.js"), true);
+      assertEquals(constructedPatterns.length, 1);
+    } finally {
+      Object.defineProperty(globalThis, "RegExp", {
+        configurable: true,
+        value: originalRegExp,
+      });
+    }
+  });
 });

--- a/src/modules/react-loader/ssr-module-loader/import-rewriter.ts
+++ b/src/modules/react-loader/ssr-module-loader/import-rewriter.ts
@@ -52,22 +52,27 @@ export function rewriteLocalImports(
     ? fromFileDir.substring(normalizedProjectDir.length + 1)
     : fromFileDir;
 
-  let result = transformed;
+  const replacementByPattern = new Map<string, string>();
 
   for (const [specifierOrPath, tempPath] of localImportPaths) {
     const patterns = buildImportPatterns(specifierOrPath, fromRelativeDir, normalizedProjectDir);
 
     for (const pattern of patterns) {
-      const escapedPattern = escapeRegExp(pattern);
-      const regex = new RegExp(
-        `${IMPORT_FROM_PREFIX}(${escapedPattern})${IMPORT_FROM_SUFFIX}`,
-        "g",
-      );
-      result = result.replace(regex, `from "file://${tempPath}"`);
+      if (!replacementByPattern.has(pattern)) {
+        replacementByPattern.set(pattern, tempPath);
+      }
     }
   }
 
-  return result;
+  if (replacementByPattern.size === 0) return transformed;
+
+  const importPattern = Array.from(replacementByPattern.keys()).map(escapeRegExp).join("|");
+  const regex = new RegExp(`${IMPORT_FROM_PREFIX}(${importPattern})${IMPORT_FROM_SUFFIX}`, "g");
+
+  return transformed.replace(regex, (match, specifier: string) => {
+    const tempPath = replacementByPattern.get(specifier);
+    return tempPath === undefined ? match : `from "file://${tempPath}"`;
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace per-pattern local import replacement scans with one combined regex pass.
- Preserve first-match behavior for duplicate generated patterns.
- Add a regression that fails when local import rewriting constructs more than one replacement regex per call.

## Test Plan
- [x] `deno test --no-check --allow-all src/modules/react-loader/ssr-module-loader/import-rewriter.test.ts`
- [x] `deno fmt --check src/modules/react-loader/ssr-module-loader/import-rewriter.ts src/modules/react-loader/ssr-module-loader/import-rewriter.test.ts`
- [x] `deno lint src/modules/react-loader/ssr-module-loader/import-rewriter.ts src/modules/react-loader/ssr-module-loader/import-rewriter.test.ts`
- [x] `deno check src/modules/react-loader/ssr-module-loader/import-rewriter.ts src/modules/react-loader/ssr-module-loader/import-rewriter.test.ts`
- [x] `git diff --check`
- [x] Pre-push hook: format, lint, typecheck, generation, unit suite (`2037 passed`)

Refs #2242