### PR TITLE
Avoid repeated nonce stream lowercasing

### DIFF
--- a/src/html/nonce-injection.test.ts
+++ b/src/html/nonce-injection.test.ts
@@ -133,4 +133,71 @@ describe("html/nonce-injection", () => {
         '<style nonce="nonce-123">.chat{color:red}</style>',
     );
   });
+
+  it("keeps streamed lowercase tracking aligned after expanding lowercase characters", async () => {
+    const encoder = new TextEncoder();
+    const chunks = [
+      "İ<div></div>",
+      "<script>x</script><style>y</style>",
+    ];
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(chunk));
+        }
+        controller.close();
+      },
+    });
+
+    const html = await readUtf8Stream(addNonceToHtmlStream(stream, "nonce-123"));
+
+    assertEquals(
+      html,
+      'İ<div></div><script nonce="nonce-123">x</script><style nonce="nonce-123">y</style>',
+    );
+  });
+
+  it("lowercases only newly received stream text while a tag is incomplete", async () => {
+    const originalToLowerCase = String.prototype.toLowerCase;
+    let lowercasedChars = 0;
+
+    Object.defineProperty(String.prototype, "toLowerCase", {
+      configurable: true,
+      value: function toLowerCaseSpy(this: string): string {
+        lowercasedChars += String(this).length;
+        return originalToLowerCase.call(this);
+      },
+    });
+
+    try {
+      const encoder = new TextEncoder();
+      const chunks = [
+        "<script",
+        " ".repeat(1_000),
+        " ".repeat(1_000),
+        " ".repeat(1_000),
+        " ".repeat(1_000),
+        " ".repeat(1_000),
+        ">x</script>",
+      ];
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const chunk of chunks) {
+            controller.enqueue(encoder.encode(chunk));
+          }
+          controller.close();
+        },
+      });
+
+      const html = await readUtf8Stream(addNonceToHtmlStream(stream, "nonce-123"));
+
+      assertEquals(html, `<script${" ".repeat(5_000)} nonce="nonce-123">x</script>`);
+      assertEquals(lowercasedChars < 10_000, true);
+    } finally {
+      Object.defineProperty(String.prototype, "toLowerCase", {
+        configurable: true,
+        value: originalToLowerCase,
+      });
+    }
+  });
 });

--- a/src/html/nonce-injection.ts
+++ b/src/html/nonce-injection.ts
@@ -197,12 +197,12 @@ export function addNonceToHtmlStream(
   const decoder = new TextDecoder();
   const encoder = new TextEncoder();
   let buffer = "";
+  let lowerBuffer = "";
   let rawTextTag: "script" | "style" | null = null;
 
   function transformBuffer(flush: boolean): string {
     let result = "";
     let index = 0;
-    const lowerBuffer = buffer.toLowerCase();
 
     while (index < buffer.length) {
       if (rawTextTag) {
@@ -277,7 +277,10 @@ export function addNonceToHtmlStream(
       }
     }
 
-    buffer = buffer.slice(index);
+    if (index > 0) {
+      buffer = buffer.slice(index);
+      lowerBuffer = buffer.toLowerCase();
+    }
     return result;
   }
 
@@ -297,7 +300,9 @@ export function addNonceToHtmlStream(
           const { done, value } = await reader.read();
 
           if (done) {
-            buffer += decoder.decode();
+            const decoded = decoder.decode();
+            buffer += decoded;
+            lowerBuffer += decoded.toLowerCase();
             const transformed = transformBuffer(true);
             if (transformed) controller.enqueue(encoder.encode(transformed));
             controller.close();
@@ -305,7 +310,9 @@ export function addNonceToHtmlStream(
             return;
           }
 
-          buffer += decoder.decode(value, { stream: true });
+          const decoded = decoder.decode(value, { stream: true });
+          buffer += decoded;
+          lowerBuffer += decoded.toLowerCase();
           const transformed = transformBuffer(false);
           if (transformed) {
             controller.enqueue(encoder.encode(transformed));


### PR DESCRIPTION
## Summary
- Keep a lowercase companion buffer for streamed nonce injection.
- Lowercase only newly decoded stream chunks instead of the retained cumulative buffer.
- Add a regression for long incomplete tags split across chunks.

## Test Plan
- [x] `deno test --no-check --allow-all src/html/nonce-injection.test.ts`
- [x] `deno fmt --check src/html/nonce-injection.ts src/html/nonce-injection.test.ts`
- [x] `deno lint src/html/nonce-injection.ts src/html/nonce-injection.test.ts`
- [x] `deno check src/html/nonce-injection.ts src/html/nonce-injection.test.ts`
- [x] `git diff --check`
- [x] Pre-push hook: format, lint, typecheck, generation, unit suite (`2037 passed`)

Refs #2262