### PR TITLE
Avoid repeated proxy request URL parsing

### DIFF
--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -88,8 +88,8 @@ function createMockAuthProvider(options: MockAuthOptions = {}): AuthProvider {
     async verify(token: string, opts): Promise<TokenPayload> {
       const parts = token.split(".");
       if (parts.length !== 3) throw new Error("Malformed token");
-      const header = JSON.parse(base64urlDecode(parts[0])) as { alg?: string };
-      const body = JSON.parse(base64urlDecode(parts[1])) as TokenPayload;
+      const header = JSON.parse(base64urlDecode(parts[0]!)) as { alg?: string };
+      const body = JSON.parse(base64urlDecode(parts[1]!)) as TokenPayload;
       const alg = header.alg ?? "";
       const allowed = opts?.algorithms ?? ["HS256"];
       if (!allowed.includes(alg)) throw new Error(`Unexpected alg: ${alg}`);
@@ -124,7 +124,7 @@ function createMockAuthProvider(options: MockAuthOptions = {}): AuthProvider {
       const parts = token.split(".");
       if (parts.length !== 3) return undefined;
       try {
-        return JSON.parse(base64urlDecode(parts[0])) as TokenHeader;
+        return JSON.parse(base64urlDecode(parts[0]!)) as TokenHeader;
       } catch {
         return undefined;
       }
@@ -220,6 +220,45 @@ afterEach(() => {
 });
 
 describe("Proxy Handler", () => {
+  it("uses a pre-parsed request URL when provided", async () => {
+    const handler = createProxyHandler({
+      config: {
+        apiBaseUrl: "http://127.0.0.1:9",
+        apiClientId: "",
+        apiClientSecret: "",
+        previewApiClientId: "",
+        previewApiClientSecret: "",
+      },
+    });
+    const req = new Request("http://test-project.preview.veryfront.com/blog", {
+      headers: { host: "test-project.preview.veryfront.com" },
+    });
+    const url = new URL(req.url);
+    const originalUrl = globalThis.URL;
+
+    try {
+      Object.defineProperty(globalThis, "URL", {
+        configurable: true,
+        value: class URLShouldNotBeCalled {
+          constructor() {
+            throw new Error("processRequest reparsed req.url");
+          }
+        },
+      });
+
+      const ctx = await handler.processRequest(req, { url });
+
+      assertEquals(ctx.host, "test-project.preview.veryfront.com");
+      assertEquals(ctx.error?.status, 502);
+    } finally {
+      Object.defineProperty(globalThis, "URL", {
+        configurable: true,
+        value: originalUrl,
+      });
+      await handler.close();
+    }
+  });
+
   describe("processRequest with custom domains", () => {
     it("resolves project slug for custom domain via domain lookup", async () => {
       const { server, port } = createMockServer((req: Request) => {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -88,8 +88,8 @@ function isInternalControlPlanePath(pathname: string): boolean {
     pathname.startsWith("/internal/workflows/");
 }
 
-function isSignedInternalControlPlaneRequest(req: Request): boolean {
-  const pathname = new URL(req.url).pathname;
+function isSignedInternalControlPlaneRequest(req: Request, url: URL): boolean {
+  const pathname = url.pathname;
   if (!isInternalControlPlanePath(pathname)) {
     return false;
   }
@@ -236,8 +236,12 @@ export interface ProxyHandlerOptions {
   logger?: ProxyLogger;
 }
 
-function getRequestHost(req: Request): string {
-  return req.headers.get("host") ?? new URL(req.url).host;
+export interface ProxyRequestOptions {
+  url?: URL;
+}
+
+function getRequestHost(req: Request, url: URL): string {
+  return req.headers.get("host") ?? url.host;
 }
 
 function getScope(environment: string | null): TokenScope {
@@ -431,8 +435,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     };
   }
 
-  function makeAuthRedirectUrl(req: Request): string {
-    const url = new URL(req.url);
+  function makeAuthRedirectUrl(url: URL): string {
     // Collapse leading slashes to prevent protocol-relative open redirects (e.g. "//evil.com/path")
     const safePath = url.pathname.replace(/^\/\/+/, "/");
     let returnPath = safePath + url.search;
@@ -473,6 +476,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
   async function resolveRequestToken(
     req: Request,
+    url: URL,
     scope: TokenScope,
     host: string,
     projectSlug: string | undefined,
@@ -483,7 +487,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
   ): Promise<{ token?: string; userToken?: string; tokenFetchError?: unknown }> {
     const userToken = extractUserToken(req.headers.get("cookie") ?? "");
     const useSignedInternalControlPlaneToken = options.allowSignedInternalControlPlaneToken &&
-      isSignedInternalControlPlaneRequest(req);
+      isSignedInternalControlPlaneRequest(req, url);
 
     let token: string | undefined;
     let tokenFetchError: unknown;
@@ -491,7 +495,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     if (useSignedInternalControlPlaneToken) {
       token = req.headers.get("x-token") ?? undefined;
       logger?.debug("Using signed control-plane token for internal request", {
-        pathname: new URL(req.url).pathname,
+        pathname: url.pathname,
         scope,
       });
     } else if (scope === "preview" && userToken) {
@@ -526,6 +530,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
   async function checkProtectedAccess(
     req: Request,
+    url: URL,
     matchingEnv: NonNullable<DomainLookupResult["environments"]>[number] | undefined,
     userToken: string | undefined,
     users: DomainLookupResult["users"],
@@ -533,20 +538,20 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
   ): Promise<{ status: number; message: string; redirectUrl?: string } | null> {
     if (!matchingEnv?.protected) return null;
 
-    if (isSignedInternalControlPlaneRequest(req)) {
+    if (isSignedInternalControlPlaneRequest(req, url)) {
       logger?.debug(
         "Allowing signed internal control-plane request through protected environment",
         {
           ...logContext,
           environmentName: matchingEnv.name,
-          pathname: new URL(req.url).pathname,
+          pathname: url.pathname,
         },
       );
       return null;
     }
 
     if (!userToken) {
-      const redirectUrl = makeAuthRedirectUrl(req);
+      const redirectUrl = makeAuthRedirectUrl(url);
       logger?.info("Protected environment requires authentication", {
         ...logContext,
         environmentName: matchingEnv.name,
@@ -561,7 +566,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
       logger,
     );
     if (!userId) {
-      const redirectUrl = makeAuthRedirectUrl(req);
+      const redirectUrl = makeAuthRedirectUrl(url);
       logger?.info("Could not extract userId from token", {
         ...logContext,
         environmentName: matchingEnv.name,
@@ -583,6 +588,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
   async function resolveReleaseAndProtection(
     req: Request,
+    url: URL,
     token: string,
     userToken: string | undefined,
     lookupKey: string,
@@ -599,6 +605,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
     const protectionError = await checkProtectedAccess(
       req,
+      url,
       matchingEnv,
       userToken,
       lookupResult.users,
@@ -613,8 +620,12 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     };
   }
 
-  async function processRequest(req: Request): Promise<ProxyContext> {
-    const rawHost = getRequestHost(req);
+  async function processRequest(
+    req: Request,
+    options: ProxyRequestOptions = {},
+  ): Promise<ProxyContext> {
+    const url = options.url ?? new URL(req.url);
+    const rawHost = getRequestHost(req, url);
     const host = rawHost.replace(/:\d+$/, "");
     const parsedDomain = parseProjectDomain(host);
     const scope = getScope(parsedDomain.environment);
@@ -661,6 +672,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     } else {
       ({ token, userToken, tokenFetchError } = await resolveRequestToken(
         req,
+        url,
         scope,
         host,
         projectSlug,
@@ -728,6 +740,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
         const protectionError = await checkProtectedAccess(
           req,
+          url,
           matchingEnv,
           userToken,
           lookupResult.users,
@@ -755,6 +768,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
         const resolved = await resolveReleaseAndProtection(
           req,
+          url,
           token,
           userToken,
           projectSlug,
@@ -798,6 +812,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
         // still enforce the environment's `protected` flag like other scopes.
         const resolved = await resolveReleaseAndProtection(
           req,
+          url,
           token,
           userToken,
           projectSlug,
@@ -872,15 +887,26 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     };
   }
 
-  async function getTokenForApi(req: Request): Promise<string | undefined> {
-    const rawHost = getRequestHost(req);
+  async function getTokenForApi(
+    req: Request,
+    options: ProxyRequestOptions = {},
+  ): Promise<string | undefined> {
+    const url = options.url ?? new URL(req.url);
+    const rawHost = getRequestHost(req, url);
     const host = rawHost.replace(/:\d+$/, "");
     const parsedDomain = parseProjectDomain(host);
     const scope = getScope(parsedDomain.environment);
     const projectSlug = parsedDomain.slug ?? undefined;
-    const { token } = await resolveRequestToken(req, scope, host, projectSlug, {
-      tokenFetchErrorMessage: "Token fetch failed for API",
-    });
+    const { token } = await resolveRequestToken(
+      req,
+      url,
+      scope,
+      host,
+      projectSlug,
+      {
+        tokenFetchErrorMessage: "Token fetch failed for API",
+      },
+    );
     return token;
   }
 

--- a/src/proxy/main.test.ts
+++ b/src/proxy/main.test.ts
@@ -1,0 +1,11 @@
+import { assertEquals } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
+
+describe("proxy main request URL parsing", () => {
+  it("parses the incoming request URL once in the router", async () => {
+    const source = await Deno.readTextFile(new URL("./main.ts", import.meta.url));
+    const requestUrlParses = source.match(/new URL\(req\.url\)/g) ?? [];
+
+    assertEquals(requestUrlParses.length, 1);
+  });
+});

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -145,8 +145,7 @@ if (Object.keys(proxyHandler.localProjects).length > 0) {
  * Handle WebSocket upgrade requests.
  * Bridges browser WebSocket to server HMR WebSocket endpoint.
  */
-function handleWebSocketUpgrade(req: Request): Response {
-  const url = new URL(req.url);
+function handleWebSocketUpgrade(req: Request, url: URL): Response {
   const host = req.headers.get("host") || "";
 
   const parsed = parseProjectDomain(host);
@@ -277,9 +276,8 @@ function handleWebSocketUpgrade(req: Request): Response {
   return response;
 }
 
-function forwardToServer(req: Request): Promise<Response> {
+function forwardToServer(req: Request, url: URL): Promise<Response> {
   const startTime = performance.now();
-  const url = new URL(req.url);
   const requestId = crypto.randomUUID();
   const host = req.headers.get("host") || "";
 
@@ -288,7 +286,7 @@ function forwardToServer(req: Request): Promise<Response> {
 
   const execute = async (): Promise<Response> => {
     try {
-      const ctx = await proxyHandler.processRequest(req);
+      const ctx = await proxyHandler.processRequest(req, { url });
 
       return runWithProxyRequestContext(
         {
@@ -496,10 +494,8 @@ async function handleStats(): Promise<Response> {
  * Proxy API requests directly to Veryfront API (BFF pattern).
  * Routes: /_vf/api/* -> api.veryfront.com/*
  */
-async function handleApiProxy(req: Request): Promise<Response> {
-  const url = new URL(req.url);
-
-  const token = await proxyHandler.getTokenForApi(req);
+async function handleApiProxy(req: Request, url: URL): Promise<Response> {
+  const token = await proxyHandler.getTokenForApi(req, { url });
   if (!token) return jsonErrorResponse(401, { error: "No authentication token" });
 
   const apiPath = url.pathname.replace(/^\/_vf\/api/, "");
@@ -551,7 +547,7 @@ function router(req: Request): Promise<Response> {
   const url = new URL(req.url);
 
   if (req.headers.get("upgrade")?.toLowerCase() === "websocket") {
-    return Promise.resolve(handleWebSocketUpgrade(req));
+    return Promise.resolve(handleWebSocketUpgrade(req, url));
   }
 
   switch (url.pathname) {
@@ -566,9 +562,9 @@ function router(req: Request): Promise<Response> {
       );
   }
 
-  if (url.pathname.startsWith("/_vf/api/")) return handleApiProxy(req);
+  if (url.pathname.startsWith("/_vf/api/")) return handleApiProxy(req, url);
 
-  return forwardToServer(req);
+  return forwardToServer(req, url);
 }
 
 // Create server before signal registration so early SIGTERM/SIGINT can close it safely.


### PR DESCRIPTION
## Summary
- Parse split-proxy request URLs once in `router()` and pass the parsed URL into WebSocket, API, and server-forward handlers.
- Add a `ProxyRequestOptions.url` path so `ProxyHandler` can reuse the parsed URL while preserving the existing `processRequest(req)` and `getTokenForApi(req)` fallbacks.
- Add regressions for single router parse count and pre-parsed `ProxyHandler` URL reuse.

## Verification
- `deno fmt --check src/proxy/main.ts src/proxy/handler.ts src/proxy/main.test.ts src/proxy/handler.test.ts`
- `deno lint src/proxy/main.ts src/proxy/handler.ts src/proxy/main.test.ts src/proxy/handler.test.ts`
- `deno test --no-check --allow-all src/proxy/main.test.ts src/proxy/handler.test.ts`
- `deno check src/proxy/main.ts src/proxy/handler.ts src/proxy/main.test.ts src/proxy/handler.test.ts`
- `git diff --check`
- pre-push hook: format, lint, typecheck, generated assets, unit tests (`2038 passed`, `18217 steps`)

Partially addresses #2262.