### PR TITLE
Memoize repeated sensitive key redaction checks

### DIFF
--- a/src/utils/logger/redact.test.ts
+++ b/src/utils/logger/redact.test.ts
@@ -68,6 +68,15 @@ describe("logger/redact", () => {
       // masked even though it is not itself a secret.
       assertEquals(isSensitiveKey("tokenCount"), true);
     });
+
+    it("keeps results stable after the sensitive-key cache evicts old entries", () => {
+      for (let i = 0; i < 600; i++) {
+        assertEquals(isSensitiveKey(`requestId${i}`), false);
+      }
+
+      assertEquals(isSensitiveKey("token"), true);
+      assertEquals(isSensitiveKey("requestId0"), false);
+    });
   });
 
   describe("redactSensitive", () => {

--- a/src/utils/logger/redact.ts
+++ b/src/utils/logger/redact.ts
@@ -60,6 +60,9 @@ const SENSITIVE_KEY_PATTERNS = [
   "csrf",
 ] as const;
 
+const SENSITIVE_KEY_CACHE_MAX_SIZE = 512;
+const sensitiveKeyCache = new Map<string, boolean>();
+
 /** Stop traversing past this depth to keep the pass cheap and stack-safe. */
 const MAX_DEPTH = 16;
 
@@ -72,8 +75,19 @@ const MAX_DEPTH = 16;
  * normalizes to `author`, which contains none of the patterns.
  */
 export function isSensitiveKey(key: string): boolean {
+  const cached = sensitiveKeyCache.get(key);
+  if (cached !== undefined) return cached;
+
   const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "");
-  return SENSITIVE_KEY_PATTERNS.some((pattern) => normalized.includes(pattern));
+  const sensitive = SENSITIVE_KEY_PATTERNS.some((pattern) => normalized.includes(pattern));
+
+  if (sensitiveKeyCache.size >= SENSITIVE_KEY_CACHE_MAX_SIZE) {
+    const oldestKey = sensitiveKeyCache.keys().next().value as string | undefined;
+    if (oldestKey !== undefined) sensitiveKeyCache.delete(oldestKey);
+  }
+  sensitiveKeyCache.set(key, sensitive);
+
+  return sensitive;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add a bounded exact-key cache to `isSensitiveKey()` so repeated log field names skip repeated normalization and sensitive-pattern scans.
- Keep the current conservative over-redaction behavior and cap the cache at 512 entries.
- Add a regression-style stability test that exceeds the cache bound and verifies sensitive and non-sensitive results still hold after eviction.

Part of #2262.

## Verification
- `deno test --no-check --allow-all src/utils/logger/redact.test.ts`
- `deno fmt --check src/utils/logger/redact.ts src/utils/logger/redact.test.ts`
- `deno lint src/utils/logger/redact.ts src/utils/logger/redact.test.ts`
- `deno check src/utils/logger/redact.ts src/utils/logger/redact.test.ts`
- `git diff --check`
- pre-push hook: format, lint, typecheck, generated assets, unit tests (`2038 passed`)