### PR TITLE
Validate persisted cache and RAG shapes

### DIFF
--- a/src/cache/backends/disk.test.ts
+++ b/src/cache/backends/disk.test.ts
@@ -68,6 +68,29 @@ Deno.test("DiskCacheBackend", async (t) => {
     assertEquals(await backend.get("hello"), "world");
   });
 
+  await t.step("get returns null for invalid cache envelope fields", async () => {
+    const isolatedDir = join(Deno.makeTempDirSync(), "invalid-envelope-get");
+    const backend = new DiskCacheBackend(isolatedDir);
+    const key = "invalid-envelope";
+    await backend.set(key, "value");
+
+    const cacheDir = join(isolatedDir, "veryfront-files");
+    let wroteInvalidEnvelope = false;
+    for await (const file of Deno.readDir(cacheDir)) {
+      if (file.isFile && file.name.endsWith(".json")) {
+        await Deno.writeTextFile(
+          join(cacheDir, file.name),
+          JSON.stringify({ key, value: { nested: true } }),
+        );
+        wroteInvalidEnvelope = true;
+        break;
+      }
+    }
+
+    assertEquals(wroteInvalidEnvelope, true);
+    assertEquals(await backend.get(key), null);
+  });
+
   await t.step("del removes a key", async () => {
     const backend = makeBackend();
     await backend.set("to-delete", "value");
@@ -160,6 +183,33 @@ Deno.test("DiskCacheBackend", async (t) => {
     assertEquals(await backend.get("user:1:name"), null);
     assertEquals(await backend.get("user:2:name"), null);
     assertEquals(await backend.get("other:key"), "value");
+  });
+
+  await t.step("delByPattern skips invalid cache envelope fields", async () => {
+    const isolatedDir = join(Deno.makeTempDirSync(), "invalid-envelope-delbypattern");
+    const backend = new DiskCacheBackend(isolatedDir);
+    await backend.set("user:valid", "value");
+    await backend.set("user:invalid", "value");
+
+    const cacheDir = join(isolatedDir, "veryfront-files");
+    for await (const file of Deno.readDir(cacheDir)) {
+      if (!file.isFile || !file.name.endsWith(".json")) continue;
+      const filePath = join(cacheDir, file.name);
+      const raw = await Deno.readTextFile(filePath);
+      const parsed = JSON.parse(raw) as { key?: string };
+      if (parsed.key === "user:invalid") {
+        await Deno.writeTextFile(
+          filePath,
+          JSON.stringify({ key: "user:invalid", value: { nested: true } }),
+        );
+        break;
+      }
+    }
+
+    const deleted = await backend.delByPattern("user:*");
+    assertEquals(deleted, 1);
+    assertEquals(await backend.get("user:valid"), null);
+    assertEquals(await backend.get("user:invalid"), null);
   });
 
   await t.step("overwrite existing key", async () => {

--- a/src/cache/backends/disk.ts
+++ b/src/cache/backends/disk.ts
@@ -14,6 +14,27 @@ interface DiskCacheEnvelope {
   expiresAt?: number;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseDiskCacheEnvelope(value: unknown): DiskCacheEnvelope | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.key !== "string") return null;
+  if (typeof value.value !== "string") return null;
+  if (
+    value.expiresAt !== undefined &&
+    (typeof value.expiresAt !== "number" || !Number.isFinite(value.expiresAt))
+  ) {
+    return null;
+  }
+  return {
+    key: value.key,
+    value: value.value,
+    expiresAt: value.expiresAt,
+  };
+}
+
 function hashKey(input: string): string {
   const seeds = [0x811c9dc5, 0x6c62272e, 0x2e726c6f, 0x636f6465];
   return seeds
@@ -51,7 +72,8 @@ export class DiskCacheBackend implements CacheBackend {
     try {
       const { readFile } = await fsPromises;
       const raw = await readFile(this.filePath(key), "utf-8");
-      const envelope: DiskCacheEnvelope = JSON.parse(raw);
+      const envelope = parseDiskCacheEnvelope(JSON.parse(raw));
+      if (!envelope) return null;
       if (envelope.key !== key) return null;
       if (envelope.expiresAt != null && Date.now() > envelope.expiresAt) {
         this.del(key).catch((cleanupError) => {
@@ -138,7 +160,11 @@ export class DiskCacheBackend implements CacheBackend {
         try {
           const filePath = join(this.dir, file);
           const raw = await readFile(filePath, "utf-8");
-          const envelope: DiskCacheEnvelope = JSON.parse(raw);
+          const envelope = parseDiskCacheEnvelope(JSON.parse(raw));
+          if (!envelope) {
+            logger.error("[DiskCache] Skip invalid cache file", { file });
+            continue;
+          }
           if (glob.test(envelope.key)) {
             await unlink(filePath);
             deleted++;

--- a/src/embedding/rag-store.test.ts
+++ b/src/embedding/rag-store.test.ts
@@ -154,6 +154,66 @@ describe("ragStore", () => {
     });
   });
 
+  it("resets local store when document entries fail validation", async () => {
+    await withTempDir(async (tempDir) => {
+      const storagePath = join(tempDir, "data", "index.json");
+      await Deno.mkdir(join(tempDir, "data"), { recursive: true });
+      await Deno.writeTextFile(
+        storagePath,
+        JSON.stringify({
+          documents: [{
+            id: 123,
+            title: "Invalid Doc",
+            source: "upload:invalid.txt",
+            type: "txt",
+            createdAt: 1,
+          }],
+          chunks: [],
+        }),
+      );
+
+      const store = ragStore({
+        model: "local/test-model",
+        storagePath,
+      });
+
+      assertEquals(await store.listDocuments(), []);
+    });
+  });
+
+  it("resets local store when chunk entries fail validation", async () => {
+    await withTempDir(async (tempDir) => {
+      const storagePath = join(tempDir, "data", "index.json");
+      await Deno.mkdir(join(tempDir, "data"), { recursive: true });
+      await Deno.writeTextFile(
+        storagePath,
+        JSON.stringify({
+          documents: [{
+            id: "doc-1",
+            title: "Valid Doc",
+            source: "upload:valid.txt",
+            type: "txt",
+            createdAt: 1,
+          }],
+          chunks: [{
+            id: "chunk-1",
+            documentId: "doc-1",
+            text: "content",
+            embedding: ["not-a-number"],
+            index: 0,
+          }],
+        }),
+      );
+
+      const store = ragStore({
+        model: "local/test-model",
+        storagePath,
+      });
+
+      assertEquals(await store.listDocuments(), []);
+    });
+  });
+
   it("auto-upgrades to the veryfront-cloud backend when cloud bootstrap is present", async () => {
     setEnv("VERYFRONT_API_TOKEN", "vf_test_cloud");
     setEnv("VERYFRONT_PROJECT_SLUG", "cloud-project");

--- a/src/embedding/rag-store.ts
+++ b/src/embedding/rag-store.ts
@@ -45,6 +45,58 @@ type ResolvedRagStoreConfig = RagStoreConfig & { model: string };
 /** Default number of top results returned by similarity search. */
 const DEFAULT_TOP_K = 5;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isNumberArray(value: unknown): value is number[] {
+  return Array.isArray(value) && value.every(isFiniteNumber);
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isInteger(value) && Number(value) >= 0;
+}
+
+function isRagDocumentMeta(value: unknown): value is RagDocumentMeta {
+  if (!isRecord(value)) return false;
+  return typeof value.id === "string" &&
+    typeof value.title === "string" &&
+    typeof value.source === "string" &&
+    typeof value.type === "string" &&
+    isFiniteNumber(value.createdAt) &&
+    (value.url === undefined || typeof value.url === "string");
+}
+
+function isRagChunk(value: unknown): value is RagChunk {
+  if (!isRecord(value)) return false;
+  return typeof value.id === "string" &&
+    typeof value.documentId === "string" &&
+    typeof value.text === "string" &&
+    isNumberArray(value.embedding) &&
+    isNonNegativeInteger(value.index);
+}
+
+function isRagStoreData(value: unknown): value is RagStoreData {
+  if (!isRecord(value)) return false;
+  return Array.isArray(value.documents) &&
+    value.documents.every(isRagDocumentMeta) &&
+    Array.isArray(value.chunks) &&
+    value.chunks.every(isRagChunk);
+}
+
+function isLegacyStoredChunk(value: unknown): value is LegacyStoredChunk {
+  if (!isRecord(value)) return false;
+  return typeof value.id === "string" &&
+    typeof value.uploadId === "string" &&
+    typeof value.text === "string" &&
+    isNumberArray(value.embedding) &&
+    isNonNegativeInteger(value.index);
+}
+
 /**
  * Creates a persistent RAG store with lazy embedding and similarity search.
  *
@@ -182,7 +234,10 @@ function createLocalJsonRagStore(config: ResolvedRagStoreConfig): RagStore {
   function isLegacyUploadStoreData(value: unknown): value is LegacyUploadStoreData {
     if (!value || typeof value !== "object") return false;
     const data = value as { uploads?: unknown; chunks?: unknown };
-    return Array.isArray(data.uploads) && Array.isArray(data.chunks);
+    return Array.isArray(data.uploads) &&
+      data.uploads.every(isRagDocumentMeta) &&
+      Array.isArray(data.chunks) &&
+      data.chunks.every(isLegacyStoredChunk);
   }
 
   function migrateLegacyUploadStoreData(data: LegacyUploadStoreData): RagStoreData {
@@ -205,11 +260,11 @@ function createLocalJsonRagStore(config: ResolvedRagStoreConfig): RagStore {
       if (isLegacyUploadStoreData(parsed)) {
         return migrateLegacyUploadStoreData(parsed);
       }
-      if (!parsed || !Array.isArray(parsed.documents) || !Array.isArray(parsed.chunks)) {
+      if (!isRagStoreData(parsed)) {
         serverLogger.warn("[rag-store] Corrupted store file, resetting", { storagePath });
         return { documents: [], chunks: [] };
       }
-      return parsed as RagStoreData;
+      return parsed;
     } catch (err) {
       // File not found is expected on first run; anything else is worth logging
       if (isNotFoundError(err)) {


### PR DESCRIPTION
## Summary
- Validate disk cache JSON envelopes before returning values or pattern-deleting by persisted key.
- Validate local RAG store documents, chunks, and legacy upload-store migration entries before trusting parsed JSON.
- Reset malformed local RAG store data through the existing corrupted-store path.

## Issue
Part of #2258: cache/RAG deserialization validation.

## Verification
- deno test --no-check --allow-all src/cache/backends/disk.test.ts
- deno test --no-check --allow-all src/embedding/rag-store.test.ts
- deno fmt --check src/cache/backends/disk.ts src/cache/backends/disk.test.ts src/embedding/rag-store.ts src/embedding/rag-store.test.ts
- deno lint src/cache/backends/disk.ts src/cache/backends/disk.test.ts src/embedding/rag-store.ts src/embedding/rag-store.test.ts
- deno check src/cache/backends/disk.ts src/cache/backends/disk.test.ts src/embedding/rag-store.ts src/embedding/rag-store.test.ts
- git diff --check
- Pre-push hook: format, lint, typecheck, generated assets, unit tests (2045 passed)