### PR TITLE
Reject disallowed CORS preflights

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.748",
+  "version": "0.1.749",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/middleware/builtin/security/cors-simple.test.ts
+++ b/src/middleware/builtin/security/cors-simple.test.ts
@@ -43,6 +43,21 @@ describe("corsSimple", () => {
 
       assertEquals(response?.headers.get("Access-Control-Allow-Origin"), "*");
     });
+
+    it("should reject preflight requests from disallowed origins", async () => {
+      const middleware = corsSimple("https://allowed.com");
+      const ctx = createContext("OPTIONS", "https://evil.com");
+      let calledNext = false;
+
+      const response = await middleware(ctx, () => {
+        calledNext = true;
+        return Promise.resolve(new Response("OK"));
+      });
+
+      assertEquals(response?.status, 403);
+      assertEquals(response?.headers.get("Access-Control-Allow-Origin"), null);
+      assertEquals(calledNext, false);
+    });
   });
 
   describe("actual requests", () => {

--- a/src/middleware/builtin/security/cors-simple.ts
+++ b/src/middleware/builtin/security/cors-simple.ts
@@ -2,7 +2,7 @@ import type { Middleware } from "../types.ts";
 import { getRequest } from "../types.ts";
 import type { CORSOptions } from "./types.ts";
 import { validateOriginSync } from "#veryfront/security/http/cors/validators.ts";
-import { HTTP_NO_CONTENT } from "#veryfront/utils/constants/http.ts";
+import { HTTP_FORBIDDEN, HTTP_NO_CONTENT } from "#veryfront/utils/constants/http.ts";
 
 export function corsSimple(options: CORSOptions | string = "*"): Middleware {
   const origin = typeof options === "string" ? options : options.origin ?? "*";
@@ -12,6 +12,10 @@ export function corsSimple(options: CORSOptions | string = "*"): Middleware {
     const validation = validateOriginSync(req.headers.get("origin"), { origin });
 
     if (req.method === "OPTIONS") {
+      if (!validation.allowedOrigin) {
+        return new Response(null, { status: HTTP_FORBIDDEN });
+      }
+
       // Only echo Access-Control-Allow-Origin when the origin actually passed
       // validation. Falling back to the configured origin (e.g. "*") here would
       // grant a permissive preflight to an origin we just rejected.

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.748";
+export const VERSION = "0.1.749";


### PR DESCRIPTION
## Summary

- Return 403 for CORS preflight requests whose origin fails validation.
- Keep allowed preflight behavior unchanged.
- Add a regression test that verifies rejected preflights do not echo Access-Control-Allow-Origin or call downstream middleware.
- Bump release metadata to 0.1.749.

Addresses the CORS preflight item in #2241. This intentionally does not close #2241 because that issue tracks multiple hardening items.

## Verification

- deno test --frozen --allow-all src/middleware/builtin/security/cors-simple.test.ts
- deno check src/middleware/builtin/security/cors-simple.ts src/middleware/builtin/security/cors-simple.test.ts
- deno task verify:quick
- pre-push hook: formatting, lint, type check, unit tests (2045 passed)