### PR TITLE
Harden the default CSRF cookie scope

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.749",
+  "version": "0.1.750",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/config/schemas/config.schema.ts
+++ b/src/config/schemas/config.schema.ts
@@ -176,7 +176,7 @@ export const getVeryfrontConfigSchema = defineSchema((v) =>
            * Set `true` for defaults, or pass an object to customize.
            *
            * When enabled, POST/PUT/PATCH/DELETE requests must include
-           * an `x-csrf-token` header matching the `vf_csrf` cookie.
+           * an `x-csrf-token` header matching the `__Host-vf_csrf` cookie.
            * The cookie is set automatically on HTML document responses.
            *
            * Server Actions (`/_veryfront/rsc/action`) are CSRF-protected;

--- a/src/rendering/rsc/actions/helpers.test.ts
+++ b/src/rendering/rsc/actions/helpers.test.ts
@@ -11,7 +11,7 @@ describe("rendering/rsc/actions/helpers", () => {
       const { token, setCookie } = generateCsrfToken();
       assertEquals(typeof token, "string");
       assertEquals(token.length > 0, true);
-      assertEquals(setCookie.includes("vf_csrf="), true);
+      assertEquals(setCookie.startsWith("__Host-vf_csrf="), true);
       assertEquals(setCookie.includes("HttpOnly"), true);
       assertEquals(setCookie.includes("SameSite=Lax"), true);
     });
@@ -44,7 +44,7 @@ describe("rendering/rsc/actions/helpers", () => {
     it("should return false when cookie and header differ", () => {
       const req = new Request("http://localhost/", {
         headers: {
-          cookie: "vf_csrf=token1",
+          cookie: "__Host-vf_csrf=token1",
           "x-csrf-token": "token2",
         },
       });
@@ -54,7 +54,7 @@ describe("rendering/rsc/actions/helpers", () => {
     it("should return true when cookie and header match", () => {
       const req = new Request("http://localhost/", {
         headers: {
-          cookie: "vf_csrf=matching_token",
+          cookie: "__Host-vf_csrf=matching_token",
           "x-csrf-token": "matching_token",
         },
       });

--- a/src/security/csrf/helpers.test.ts
+++ b/src/security/csrf/helpers.test.ts
@@ -9,7 +9,7 @@ describe("security/csrf/helpers", () => {
       const result = generateCsrfToken();
       assertEquals(typeof result.token, "string");
       assertEquals(result.token.length > 0, true);
-      assertEquals(result.setCookie.includes("vf_csrf="), true);
+      assertEquals(result.setCookie.startsWith("__Host-vf_csrf="), true);
       assertEquals(result.setCookie.includes("HttpOnly"), true);
       assertEquals(result.setCookie.includes("Secure"), true);
       assertEquals(result.setCookie.includes("SameSite=Lax"), true);
@@ -22,8 +22,14 @@ describe("security/csrf/helpers", () => {
       assertEquals(result.setCookie.includes("SameSite=Lax"), true);
     });
 
-    it("should omit Secure when secure is false", () => {
+    it("should keep Secure for the default __Host- cookie when secure is false", () => {
       const result = generateCsrfToken({ secure: false });
+      assertEquals(result.setCookie.startsWith("__Host-vf_csrf="), true);
+      assertEquals(result.setCookie.includes("Secure"), true);
+    });
+
+    it("should omit Secure for custom non-__Host cookies when secure is false", () => {
+      const result = generateCsrfToken({ cookieName: "my_csrf", secure: false });
       assertEquals(result.setCookie.includes("Secure"), false);
     });
 
@@ -50,7 +56,7 @@ describe("security/csrf/helpers", () => {
       const req = new Request("http://localhost/submit", {
         method: "POST",
         headers: {
-          cookie: `vf_csrf=${token}`,
+          cookie: `__Host-vf_csrf=${token}`,
           "x-csrf-token": token,
         },
       });
@@ -61,7 +67,7 @@ describe("security/csrf/helpers", () => {
       const { token } = generateCsrfToken({ secure: false });
       const req = new Request("http://localhost/submit", {
         method: "POST",
-        headers: { cookie: `vf_csrf=${token}` },
+        headers: { cookie: `__Host-vf_csrf=${token}` },
       });
       assertEquals(validateCsrf(req), false);
     });
@@ -78,7 +84,7 @@ describe("security/csrf/helpers", () => {
       const req = new Request("http://localhost/submit", {
         method: "POST",
         headers: {
-          cookie: "vf_csrf=token-a",
+          cookie: "__Host-vf_csrf=token-a",
           "x-csrf-token": "token-b",
         },
       });
@@ -101,7 +107,7 @@ describe("security/csrf/helpers", () => {
       const req = new Request("http://localhost/submit", {
         method: "POST",
         headers: {
-          cookie: "vf_csrf=some-token",
+          cookie: "__Host-vf_csrf=some-token",
           "x-csrf-token": "",
         },
       });
@@ -112,7 +118,7 @@ describe("security/csrf/helpers", () => {
       const req = new Request("http://localhost/submit", {
         method: "POST",
         headers: {
-          cookie: "vf_csrf=%ZZbadvalue",
+          cookie: "__Host-vf_csrf=%ZZbadvalue",
           "x-csrf-token": "anything",
         },
       });
@@ -130,7 +136,7 @@ describe("security/csrf/helpers", () => {
 
       const setCookie = headers.get("set-cookie");
       assertNotEquals(setCookie, null);
-      assertEquals(setCookie!.includes("vf_csrf="), true);
+      assertEquals(setCookie!.startsWith("__Host-vf_csrf="), true);
     });
 
     it("should set cookie on GET with text/html accept", () => {
@@ -142,9 +148,9 @@ describe("security/csrf/helpers", () => {
 
       const setCookie = headers.get("set-cookie");
       assertNotEquals(setCookie, null);
-      assertEquals(setCookie!.includes("vf_csrf="), true);
+      assertEquals(setCookie!.startsWith("__Host-vf_csrf="), true);
       assertEquals(setCookie!.includes("HttpOnly"), false); // double-submit needs JS access
-      assertEquals(setCookie!.includes("Secure"), false); // http:// request
+      assertEquals(setCookie!.includes("Secure"), true); // __Host- cookies require Secure
     });
 
     it("should set Secure flag on HTTPS requests", () => {
@@ -184,7 +190,7 @@ describe("security/csrf/helpers", () => {
 
     it("should skip when cookie already present in request", () => {
       const req = new Request("http://localhost/", {
-        headers: { cookie: "vf_csrf=existing-token" },
+        headers: { cookie: "__Host-vf_csrf=existing-token" },
       });
       const headers = new Headers();
       applyCsrfCookie(req, headers, true);
@@ -289,14 +295,14 @@ describe("security/csrf/helpers", () => {
 
     it("should issue fresh token on malformed cookie instead of throwing", () => {
       const req = new Request("http://localhost/", {
-        headers: { cookie: "vf_csrf=%ZZbadvalue", accept: "text/html" },
+        headers: { cookie: "__Host-vf_csrf=%ZZbadvalue", accept: "text/html" },
       });
       const headers = new Headers();
       applyCsrfCookie(req, headers, true);
 
       const setCookie = headers.get("set-cookie");
       assertNotEquals(setCookie, null);
-      assertEquals(setCookie!.includes("vf_csrf="), true);
+      assertEquals(setCookie!.startsWith("__Host-vf_csrf="), true);
     });
   });
 });

--- a/src/security/csrf/helpers.ts
+++ b/src/security/csrf/helpers.ts
@@ -12,6 +12,7 @@ import { parseCookiesFromHeaders } from "#veryfront/utils/cookie-utils.ts";
 
 /** Default CSRF token TTL: 24 hours (longer than session action TTL to avoid stale-form 403s). */
 const CSRF_DEFAULT_TTL_SEC = 86_400;
+const DEFAULT_CSRF_COOKIE_NAME = "__Host-vf_csrf";
 
 export interface CsrfConfig {
   cookieName?: string;
@@ -34,10 +35,10 @@ export function generateCsrfToken(options?: CsrfTokenOptions): {
   token: string;
   setCookie: string;
 } {
-  const cookieName = options?.cookieName ?? "vf_csrf";
+  const cookieName = options?.cookieName ?? DEFAULT_CSRF_COOKIE_NAME;
   const maxAge = options?.ttlSec ?? CSRF_DEFAULT_TTL_SEC;
   const httpOnly = options?.httpOnly ?? true;
-  const secure = options?.secure ?? true;
+  const secure = cookieName.startsWith("__Host-") ? true : options?.secure ?? true;
 
   const bytes = new Uint8Array(32);
   crypto.getRandomValues(bytes);
@@ -72,7 +73,7 @@ export function validateCsrf(
   req: Request,
   options?: { cookieName?: string; headerName?: string },
 ): boolean {
-  const cookieName = options?.cookieName ?? "vf_csrf";
+  const cookieName = options?.cookieName ?? DEFAULT_CSRF_COOKIE_NAME;
   const headerName = options?.headerName ?? "x-csrf-token";
 
   let cookieToken: string | undefined;
@@ -115,7 +116,7 @@ export function applyCsrfCookie(
   }
 
   const config = typeof csrfConfig === "boolean" ? {} : csrfConfig;
-  const cookieName = config.cookieName ?? "vf_csrf";
+  const cookieName = config.cookieName ?? DEFAULT_CSRF_COOKIE_NAME;
 
   // Skip if cookie already present in request
   let cookies: Record<string, string>;
@@ -128,7 +129,8 @@ export function applyCsrfCookie(
   if (cookies[cookieName]) return;
 
   // Detect HTTPS from request URL or forwarded proto
-  const isSecure = req.url.startsWith("https://") ||
+  const isSecure = cookieName.startsWith("__Host-") ||
+    req.url.startsWith("https://") ||
     req.headers.get("x-forwarded-proto") === "https";
 
   const { setCookie } = generateCsrfToken({

--- a/src/security/http/csrf/csrf-handler.test.ts
+++ b/src/security/http/csrf/csrf-handler.test.ts
@@ -129,7 +129,7 @@ describe("security/http/csrf/csrf-handler", () => {
       const req = new Request("http://localhost/submit", {
         method: "POST",
         headers: {
-          cookie: `vf_csrf=${token}`,
+          cookie: `__Host-vf_csrf=${token}`,
           "x-csrf-token": token,
         },
       });
@@ -143,7 +143,7 @@ describe("security/http/csrf/csrf-handler", () => {
       const req = new Request("http://localhost/submit", {
         method: "POST",
         headers: {
-          cookie: `vf_csrf=${token}`,
+          cookie: `__Host-vf_csrf=${token}`,
           "x-csrf-token": "wrong-token",
         },
       });
@@ -173,7 +173,7 @@ describe("security/http/csrf/csrf-handler", () => {
       const req = new Request("http://localhost/submit", {
         method: "POST",
         headers: {
-          cookie: `vf_csrf=${token}`,
+          cookie: `__Host-vf_csrf=${token}`,
           "x-csrf-token": token,
         },
       });

--- a/src/security/http/csrf/csrf-handler.ts
+++ b/src/security/http/csrf/csrf-handler.ts
@@ -10,7 +10,7 @@
  * are **not** exempt and require a valid CSRF token. Client-side code that calls
  * Server Actions must:
  *
- * 1. Read the `vf_csrf` cookie (set automatically on HTML responses)
+ * 1. Read the `__Host-vf_csrf` cookie (set automatically on HTML responses)
  * 2. Include it as the `x-csrf-token` request header on every POST
  *
  * Example (client-side fetch wrapper):
@@ -21,7 +21,7 @@
  *
  * const res = await fetch("/_veryfront/rsc/action", {
  *   method: "POST",
- *   headers: { "x-csrf-token": getCookie("vf_csrf") ?? "" },
+ *   headers: { "x-csrf-token": getCookie("__Host-vf_csrf") ?? "" },
  *   body: actionPayload,
  * });
  * ```

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.749";
+export const VERSION = "0.1.750";


### PR DESCRIPTION
## Summary

- Change the default CSRF double-submit cookie from vf_csrf to __Host-vf_csrf.
- Force Secure for __Host- CSRF cookies so browsers accept the prefix contract.
- Keep custom cookieName behavior intact for apps that override the default.
- Update CSRF helper, HTTP handler, RSC helper tests, and config comments.
- Bump release metadata to 0.1.750.

Addresses the CSRF __Host- prefix item in #2243. This intentionally does not close #2243 because that issue tracks multiple backlog items.

## Verification

- deno test --frozen --allow-all src/security/csrf/helpers.test.ts src/security/http/csrf/csrf-handler.test.ts
- deno test --frozen --allow-all src/security/csrf/helpers.test.ts src/security/http/csrf/csrf-handler.test.ts src/rendering/rsc/actions/helpers.test.ts
- deno check src/security/csrf/helpers.ts src/security/csrf/helpers.test.ts src/security/http/csrf/csrf-handler.ts src/security/http/csrf/csrf-handler.test.ts src/config/schemas/config.schema.ts
- deno check src/rendering/rsc/actions/helpers.test.ts
- deno task verify:quick
- local pre-push hook: format/lint/typecheck passed; unit suite found one stale RSC helper expectation, fixed before push