### PR TITLE
Use LRU eviction for transform fallback cache

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.751",
+  "version": "0.1.752",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/transforms/esm/transform-cache.test.ts
+++ b/src/transforms/esm/transform-cache.test.ts
@@ -93,6 +93,35 @@ describe("transforms/esm/transform-cache", () => {
     });
   });
 
+  describe("default local fallback eviction", () => {
+    beforeEach(() => {
+      __injectCachesForTests(null);
+      destroyTransformCache();
+    });
+
+    afterEach(() => {
+      Array.prototype.sort = originalArraySort;
+      destroyTransformCache();
+      __injectCachesForTests(null);
+    });
+
+    const originalArraySort = Array.prototype.sort;
+
+    it("evicts without sorting all fallback entries", () => {
+      Array.prototype.sort = function sortShouldNotRun() {
+        throw new Error("fallback eviction should not sort entries");
+      } as typeof Array.prototype.sort;
+
+      for (let index = 0; index <= 500; index++) {
+        setCachedTransform(`key-${index}`, `const value = ${index};`, `hash-${index}`);
+      }
+
+      assertEquals(getCachedTransform("key-0"), undefined);
+      assertEquals(getCachedTransform("key-1")?.code, "const value = 1;");
+      assertEquals(getCachedTransform("key-500")?.code, "const value = 500;");
+    });
+  });
+
   describe("getCachedTransformAsync / setCachedTransformAsync", () => {
     beforeEach(() => {
       const testMap = new Map<string, { code: string; hash: string; timestamp: number }>();

--- a/src/transforms/esm/transform-cache.ts
+++ b/src/transforms/esm/transform-cache.ts
@@ -1,6 +1,7 @@
 import { registerCache } from "#veryfront/utils/memory/index.ts";
 import { logger as baseLogger } from "#veryfront/utils/logger/logger.ts";
 import { buildTransformCacheKey } from "#veryfront/cache/keys.ts";
+import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import {
   type CacheBackend,
   CacheBackends,
@@ -37,11 +38,13 @@ let cacheGateway: TokenizingCacheGateway | null = null;
 let cacheInitialized = false;
 let cacheInitPromise: Promise<void> | null = null;
 
-const defaultLocalFallback = new Map<string, TransformCacheEntry>();
+const defaultLocalFallback = new LRUCache<string, TransformCacheEntry>({
+  maxEntries: FALLBACK_MAX_ENTRIES,
+});
 
 interface LocalFallbackLike<K, V> {
   get(key: K): V | undefined;
-  set(key: K, value: V): this;
+  set(key: K, value: V): void | this;
   delete(key: K): boolean;
   has(key: K): boolean;
   clear(): void;
@@ -248,6 +251,7 @@ function normalizeTtl(ttlSeconds: number): number {
 function setLocalFallback(key: string, entry: TransformCacheEntry): void {
   const fallback = getLocalFallback();
   fallback.set(key, entry);
+  if (fallback === defaultLocalFallback) return;
   if (fallback.size > FALLBACK_MAX_ENTRIES) pruneLocalFallback();
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.751";
+export const VERSION = "0.1.752";


### PR DESCRIPTION
## Description

Replaces the default local transform fallback `Map` with the existing `LRUCache` wrapper so overflow eviction no longer sorts the full fallback map on every set after the cap.

The map-like fallback injection used by focused tests remains supported; only the production default fallback now uses the shared LRU eviction path.

Also bumps release metadata to `0.1.752`.

## Related Issue(s)

Part of #2242: addresses the transform-cache eviction sort item.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Verification

- RED: `deno test --no-check --allow-all src/transforms/esm/transform-cache.test.ts` failed before the implementation with `fallback eviction should not sort entries` from `pruneLocalFallback()`.
- `deno fmt --check deno.json src/utils/version-constant.ts src/transforms/esm/transform-cache.ts src/transforms/esm/transform-cache.test.ts`
- `deno check src/transforms/esm/transform-cache.ts src/transforms/esm/transform-cache.test.ts`
- `deno lint src/transforms/esm/transform-cache.ts src/transforms/esm/transform-cache.test.ts`
- `deno test --no-check --allow-all src/transforms/esm/transform-cache.test.ts`
- `deno task verify:quick`
- `git diff --check`

## Remaining #2242 work

- Transform-slot polling loop
- Per-render dependency graph caching
- Batch bundle streaming
