### PR TITLE
Preserve transform fallback entry-only capacity

### DIFF
--- a/src/transforms/esm/transform-cache.test.ts
+++ b/src/transforms/esm/transform-cache.test.ts
@@ -91,6 +91,77 @@ describe("transforms/esm/transform-cache", () => {
       assertEquals(typeof result?.timestamp, "number");
       assertEquals(result!.timestamp > 0, true);
     });
+
+    it("does not materialize and sort fallback entries during eviction", () => {
+      __injectCachesForTests(null);
+      __injectCachesForTests({ cacheBackend: null });
+      destroyTransformCache();
+
+      const originalArrayFrom = Array.from;
+      let arrayFromCalls = 0;
+
+      Object.defineProperty(Array, "from", {
+        configurable: true,
+        writable: true,
+        value: function (...args: unknown[]) {
+          arrayFromCalls++;
+          return Reflect.apply(originalArrayFrom, Array, args);
+        },
+      });
+
+      try {
+        for (let i = 0; i < 501; i++) {
+          setCachedTransform(`key-${i}`, `const value = ${i};`, `hash-${i}`);
+        }
+
+        assertEquals(arrayFromCalls, 0);
+      } finally {
+        Object.defineProperty(Array, "from", {
+          configurable: true,
+          writable: true,
+          value: originalArrayFrom,
+        });
+        destroyTransformCache();
+      }
+    });
+
+    it("evicts the least recently used fallback entry", () => {
+      __injectCachesForTests(null);
+      __injectCachesForTests({ cacheBackend: null });
+      destroyTransformCache();
+
+      try {
+        for (let i = 0; i < 500; i++) {
+          setCachedTransform(`key-${i}`, `const value = ${i};`, `hash-${i}`);
+        }
+
+        assertEquals(getCachedTransform("key-0")?.hash, "hash-0");
+        setCachedTransform("key-500", "const value = 500;", "hash-500");
+
+        assertEquals(getCachedTransform("key-0")?.hash, "hash-0");
+        assertEquals(getCachedTransform("key-1"), undefined);
+        assertEquals(getCachedTransform("key-500")?.hash, "hash-500");
+      } finally {
+        destroyTransformCache();
+      }
+    });
+
+    it("retains fallback entries larger than the default LRU byte limit", () => {
+      __injectCachesForTests(null);
+      __injectCachesForTests({ cacheBackend: null });
+      destroyTransformCache();
+
+      try {
+        const largeTransform = "x".repeat(26 * 1024 * 1024);
+        setCachedTransform("large-key", largeTransform, "large-hash");
+
+        const result = getCachedTransform("large-key");
+        assertEquals(result?.code.length, largeTransform.length);
+        assertEquals(result?.hash, "large-hash");
+      } finally {
+        destroyTransformCache();
+      }
+    });
   });
 
   describe("default local fallback eviction", () => {

--- a/src/transforms/esm/transform-cache.ts
+++ b/src/transforms/esm/transform-cache.ts
@@ -1,7 +1,6 @@
 import { registerCache } from "#veryfront/utils/memory/index.ts";
 import { logger as baseLogger } from "#veryfront/utils/logger/logger.ts";
 import { buildTransformCacheKey } from "#veryfront/cache/keys.ts";
-import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import {
   type CacheBackend,
   CacheBackends,
@@ -38,19 +37,64 @@ let cacheGateway: TokenizingCacheGateway | null = null;
 let cacheInitialized = false;
 let cacheInitPromise: Promise<void> | null = null;
 
-const defaultLocalFallback = new LRUCache<string, TransformCacheEntry>({
-  maxEntries: FALLBACK_MAX_ENTRIES,
-});
-
 interface LocalFallbackLike<K, V> {
   get(key: K): V | undefined;
-  set(key: K, value: V): void | this;
+  set(key: K, value: V): unknown;
   delete(key: K): boolean;
   has(key: K): boolean;
   clear(): void;
   readonly size: number;
   entries(): IterableIterator<[K, V]>;
 }
+
+class EntryBoundedFallback<K, V> implements LocalFallbackLike<K, V> {
+  private readonly store = new Map<K, V>();
+
+  constructor(private readonly maxEntries: number) {}
+
+  get(key: K): V | undefined {
+    const value = this.store.get(key);
+    if (value === undefined) return undefined;
+    this.store.delete(key);
+    this.store.set(key, value);
+    return value;
+  }
+
+  set(key: K, value: V): void {
+    this.store.delete(key);
+    this.store.set(key, value);
+
+    while (this.store.size > this.maxEntries) {
+      const oldestKey = this.store.keys().next();
+      if (oldestKey.done) break;
+      this.store.delete(oldestKey.value);
+    }
+  }
+
+  delete(key: K): boolean {
+    return this.store.delete(key);
+  }
+
+  has(key: K): boolean {
+    return this.store.has(key);
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  get size(): number {
+    return this.store.size;
+  }
+
+  entries(): IterableIterator<[K, V]> {
+    return this.store.entries();
+  }
+}
+
+const defaultLocalFallback = new EntryBoundedFallback<string, TransformCacheEntry>(
+  FALLBACK_MAX_ENTRIES,
+);
 
 /** Injected caches for testing */
 let injectedLocalFallback: LocalFallbackLike<string, TransformCacheEntry> | null = null;
@@ -251,20 +295,6 @@ function normalizeTtl(ttlSeconds: number): number {
 function setLocalFallback(key: string, entry: TransformCacheEntry): void {
   const fallback = getLocalFallback();
   fallback.set(key, entry);
-  if (fallback === defaultLocalFallback) return;
-  if (fallback.size > FALLBACK_MAX_ENTRIES) pruneLocalFallback();
-}
-
-function pruneLocalFallback(): void {
-  const fallback = getLocalFallback();
-  const excess = fallback.size - FALLBACK_MAX_ENTRIES;
-  if (excess <= 0) return;
-
-  const entries = Array.from(fallback.entries()).sort(([, a], [, b]) => a.timestamp - b.timestamp);
-  for (let i = 0; i < excess; i++) {
-    const [key] = entries[i]!;
-    fallback.delete(key);
-  }
 }
 
 export function destroyTransformCache(): void {


### PR DESCRIPTION
## Summary
- replace the transform fallback's shared LRU wrapper with a local entry-bounded LRU map
- preserve the previous 500-entry capacity contract without the wrapper's byte-size ceiling
- add regression coverage for large transform retention and read-refresh LRU eviction

Part of #2242. This follows up #2299, which removed the sort-based eviction path but accidentally introduced the shared wrapper's byte-size cap.

## Tests
- RED: deno test --no-check --allow-all src/transforms/esm/transform-cache.test.ts failed because a 26 MiB transform was evicted under the wrapper byte limit
- deno test --no-check --allow-all src/transforms/esm/transform-cache.test.ts
- deno fmt --check src/transforms/esm/transform-cache.ts src/transforms/esm/transform-cache.test.ts
- deno lint src/transforms/esm/transform-cache.ts src/transforms/esm/transform-cache.test.ts
- deno check src/transforms/esm/transform-cache.test.ts
- pre-push: format, lint, typecheck, unit tests (2045 tests, 18239 steps)