### PR TITLE
Queue SSR transform slot waiters

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.752",
+  "version": "0.1.753",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
@@ -12,6 +12,7 @@ import {
   globalModuleCache,
   globalTmpDirs,
   releaseTransformSlot,
+  tryAcquireTransformSlot,
 } from "./memory.ts";
 import { verifiedHttpBundlePaths } from "../http-bundle-helpers.ts";
 import { getTransformPerProjectLimit } from "../constants.ts";
@@ -138,6 +139,41 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
       // A bypassing release must be a no-op (no underflow / phantom entry).
       releaseTransformSlot(projectId, true);
       assertEquals(getTransformStats().activeProjects.has(projectId), false);
+    });
+
+    it("should wake queued acquisitions when a slot is released", async () => {
+      const previousLimit = Deno.env.get("SSR_TRANSFORM_PER_PROJECT_LIMIT");
+      Deno.env.set("SSR_TRANSFORM_PER_PROJECT_LIMIT", "1");
+      resetState();
+
+      const originalSetTimeout = globalThis.setTimeout;
+      try {
+        const projectId = "test-wake-queued-acquire";
+        assertEquals(acquireTransformSlot(projectId), true);
+
+        globalThis.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+          if (timeout === 50) {
+            throw new Error("queued transform slot acquisition should not poll");
+          }
+          return originalSetTimeout(handler, timeout, ...args);
+        }) as typeof globalThis.setTimeout;
+
+        const waiter = tryAcquireTransformSlot(projectId, 1_000);
+        releaseTransformSlot(projectId);
+
+        assertEquals(await waiter, true);
+        assertEquals(getTransformStats().activeProjects.get(projectId), 1);
+
+        releaseTransformSlot(projectId);
+      } finally {
+        globalThis.setTimeout = originalSetTimeout;
+        if (previousLimit === undefined) {
+          Deno.env.delete("SSR_TRANSFORM_PER_PROJECT_LIMIT");
+        } else {
+          Deno.env.set("SSR_TRANSFORM_PER_PROJECT_LIMIT", previousLimit);
+        }
+        resetState();
+      }
     });
   });
 

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.ts
@@ -65,6 +65,13 @@ export function getTransformSemaphore(): Semaphore {
  */
 const projectTransformCounts = new Map<string, number>();
 
+type ProjectTransformWaiter = {
+  resolve: (acquired: boolean) => void;
+  timeoutId: ReturnType<typeof setTimeout>;
+};
+
+const projectTransformWaiters = new Map<string, ProjectTransformWaiter[]>();
+
 /**
  * Projects that bypass per-project rate limiting.
  * - "__single__": Used for local development and tests where there's no multi-tenancy
@@ -105,8 +112,62 @@ export function acquireTransformSlot(projectId: string, bypass = false): boolean
   return true;
 }
 
-/** How long to wait between retry attempts for per-project slots */
-const PROJECT_SLOT_RETRY_INTERVAL_MS = 50;
+function removeProjectTransformWaiter(
+  projectId: string,
+  waiter: ProjectTransformWaiter,
+): void {
+  const queue = projectTransformWaiters.get(projectId);
+  if (!queue) return;
+
+  const index = queue.indexOf(waiter);
+  if (index !== -1) queue.splice(index, 1);
+  if (queue.length === 0) projectTransformWaiters.delete(projectId);
+}
+
+function settleProjectTransformWaiter(
+  projectId: string,
+  waiter: ProjectTransformWaiter,
+  acquired: boolean,
+): void {
+  removeProjectTransformWaiter(projectId, waiter);
+  clearTimeout(waiter.timeoutId);
+  waiter.resolve(acquired);
+}
+
+function wakeNextProjectTransformWaiter(projectId: string): void {
+  const limit = getTransformPerProjectLimit();
+  if (limit <= 0) return;
+
+  const queue = projectTransformWaiters.get(projectId);
+  if (!queue?.length) return;
+
+  const current = projectTransformCounts.get(projectId) ?? 0;
+  if (current >= limit) return;
+
+  const waiter = queue.shift();
+  if (queue.length === 0) projectTransformWaiters.delete(projectId);
+  if (!waiter) return;
+
+  projectTransformCounts.set(projectId, current + 1);
+  clearTimeout(waiter.timeoutId);
+  waiter.resolve(true);
+}
+
+function rejectProjectTransformWaiters(projectId: string): void {
+  const queue = projectTransformWaiters.get(projectId);
+  if (!queue?.length) return;
+
+  projectTransformWaiters.delete(projectId);
+  for (const waiter of queue) {
+    clearTimeout(waiter.timeoutId);
+    waiter.resolve(false);
+  }
+}
+
+function rejectAllProjectTransformWaiters(): void {
+  const projectIds = Array.from(projectTransformWaiters.keys());
+  for (const projectId of projectIds) rejectProjectTransformWaiters(projectId);
+}
 
 /**
  * Try to acquire a project-level transform slot with retries.
@@ -119,14 +180,24 @@ export async function tryAcquireTransformSlot(
   bypass = false,
 ): Promise<boolean> {
   if (acquireTransformSlot(projectId, bypass)) return true;
+  if (timeoutMs <= 0) return false;
 
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    await new Promise<void>((resolve) => setTimeout(resolve, PROJECT_SLOT_RETRY_INTERVAL_MS)); // no cleanup needed: one-shot
-    if (acquireTransformSlot(projectId, bypass)) return true;
-  }
+  return new Promise<boolean>((resolve) => {
+    const waiter: ProjectTransformWaiter = {
+      resolve,
+      timeoutId: setTimeout(() => {
+        settleProjectTransformWaiter(projectId, waiter, false);
+      }, timeoutMs),
+    };
 
-  return false;
+    const queue = projectTransformWaiters.get(projectId);
+    if (queue) {
+      queue.push(waiter);
+      return;
+    }
+
+    projectTransformWaiters.set(projectId, [waiter]);
+  });
 }
 
 /**
@@ -140,10 +211,12 @@ export function releaseTransformSlot(projectId: string, bypass = false): void {
   const current = projectTransformCounts.get(projectId) ?? 0;
   if (current <= 1) {
     projectTransformCounts.delete(projectId);
+    wakeNextProjectTransformWaiter(projectId);
     return;
   }
 
   projectTransformCounts.set(projectId, current - 1);
+  wakeNextProjectTransformWaiter(projectId);
 }
 
 /**
@@ -219,6 +292,7 @@ export function clearSSRModuleCache(): void {
   globalModuleCache.clear();
   failedComponents.clear();
   projectTransformCounts.clear();
+  rejectAllProjectTransformWaiters();
   verifiedHttpBundlePaths.clear();
 
   // Reset the transform semaphore and cached limits so leaked permits
@@ -273,6 +347,7 @@ export function clearSSRModuleCacheForProject(projectId: string): void {
   }
 
   projectTransformCounts.delete(projectId);
+  rejectProjectTransformWaiters(projectId);
 
   // Clear verified HTTP bundle paths — keys are tempPath:contentHash (not project-scoped),
   // so full clear is needed. This just forces re-verification on next access.

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.752";
+export const VERSION = "0.1.753";


### PR DESCRIPTION
## Summary
- replace the per-project transform slot 50 ms polling loop with queued waiters that wake on release
- settle queued waiters when project or global SSR cache state is cleared
- add a regression test that fails if queued acquisition schedules the old polling timer
- bump the package release to 0.1.753 in both deno.json and src/utils/version-constant.ts

## Issue
- Part of #2242: transform-slot polling loop

## Verification
- RED: deno test --no-check --allow-all src/modules/react-loader/ssr-module-loader/cache/memory.test.ts failed on the old 50 ms polling timer
- deno fmt --check deno.json src/utils/version-constant.ts src/modules/react-loader/ssr-module-loader/cache/memory.ts src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
- deno lint src/modules/react-loader/ssr-module-loader/cache/memory.ts src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
- deno check src/modules/react-loader/ssr-module-loader/cache/memory.ts src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
- deno test --no-check --allow-all src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
- deno task verify:quick && git diff --check
- pre-push: 2045 unit tests passed

## Remaining #2242 items
- avoid recomputing per-render dependency graph hashes when request graphs overlap
- review batch bundle streaming to avoid one large intermediate string without widening the runtime contract