### PR TITLE
Reuse dependency graph hashes during SSR renders

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.753",
+  "version": "0.1.754",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/cache/dependency-graph.ts
+++ b/src/cache/dependency-graph.ts
@@ -118,6 +118,22 @@ export class DependencyGraph {
   }
 }
 
+export interface DependencyHashCache {
+  graph: DependencyGraph;
+  contentHashes: Map<string, string>;
+  completedModules: Set<string>;
+  inProgressModules: Map<string, Promise<void>>;
+}
+
+export function createDependencyHashCache(): DependencyHashCache {
+  return {
+    graph: new DependencyGraph(),
+    contentHashes: new Map<string, string>(),
+    completedModules: new Set<string>(),
+    inProgressModules: new Map<string, Promise<void>>(),
+  };
+}
+
 export async function extractImports(code: string): Promise<string[]> {
   const parsed = await parseAllImports(code);
   return parsed.imports.map((imp) => imp.specifier);
@@ -175,21 +191,18 @@ export async function computeDepsHash(
   filePath: string,
   getContent: (path: string) => Promise<string>,
   projectDir: string,
+  cache: DependencyHashCache = createDependencyHashCache(),
 ): Promise<string> {
-  const graph = new DependencyGraph();
-  const contentHashes = new Map<string, string>();
-
   await buildDependencyGraph(
     filePath,
-    graph,
-    contentHashes,
+    cache,
     getContent,
     projectDir,
   );
 
-  const deps = [filePath, ...graph.getTransitiveDependencies(filePath)].sort();
+  const deps = [filePath, ...cache.graph.getTransitiveDependencies(filePath)].sort();
   const combinedHash = deps
-    .map((dep) => contentHashes.get(dep) ?? "")
+    .map((dep) => cache.contentHashes.get(dep) ?? "")
     .filter(Boolean)
     .join(":");
 
@@ -198,33 +211,64 @@ export async function computeDepsHash(
 
 async function buildDependencyGraph(
   filePath: string,
-  graph: DependencyGraph,
-  contentHashes: Map<string, string>,
+  cache: DependencyHashCache,
   getContent: (path: string) => Promise<string>,
   projectDir: string,
   visited: Set<string> = new Set<string>(),
 ): Promise<void> {
+  if (cache.completedModules.has(filePath)) return;
   if (visited.has(filePath)) return;
   visited.add(filePath);
 
+  const inProgress = cache.inProgressModules.get(filePath);
+  if (inProgress) {
+    await inProgress;
+    return;
+  }
+
+  const buildPromise = buildDependencyGraphFresh(
+    filePath,
+    cache,
+    getContent,
+    projectDir,
+    visited,
+  );
+  cache.inProgressModules.set(filePath, buildPromise);
+
+  try {
+    await buildPromise;
+  } finally {
+    cache.inProgressModules.delete(filePath);
+  }
+}
+
+async function buildDependencyGraphFresh(
+  filePath: string,
+  cache: DependencyHashCache,
+  getContent: (path: string) => Promise<string>,
+  projectDir: string,
+  visited: Set<string>,
+): Promise<void> {
   try {
     const content = await getContent(filePath);
-    contentHashes.set(filePath, await computeHash(content));
+    cache.contentHashes.set(filePath, await computeHash(content));
 
     const allImports = await extractImports(content);
     const normalizedDeps = filterLocalImports(allImports).map((spec) =>
       normalizeSpecifierToPath(spec, filePath, projectDir)
     );
 
-    graph.addModule(filePath, normalizedDeps);
+    cache.graph.addModule(filePath, normalizedDeps);
 
     await Promise.all(
       normalizedDeps.map((dep) =>
-        buildDependencyGraph(dep, graph, contentHashes, getContent, projectDir, visited)
+        buildDependencyGraph(dep, cache, getContent, projectDir, visited)
       ),
     );
   } catch (_) {
     // expected: file may not exist or imports may fail to parse
-    graph.addModule(filePath, []);
+    cache.graph.addModule(filePath, []);
+  } finally {
+    cache.completedModules.add(filePath);
   }
 }

--- a/src/cache/dependency-tracking.test.ts
+++ b/src/cache/dependency-tracking.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { expect } from "#std/expect.ts";
-import { computeDepsHash } from "./dependency-graph.ts";
+import { computeDepsHash, createDependencyHashCache } from "./dependency-graph.ts";
 import { computeConfigHash } from "./config-hash.ts";
 import { buildTransformCacheKey } from "./keys.ts";
 
@@ -97,6 +97,34 @@ describe("Dependency tracking cache invalidation", () => {
       );
 
       expect(hash1).not.toBe(hash2);
+    });
+
+    it("should reuse cached content for overlapping dependency graphs", async () => {
+      const files = new Map<string, string>([
+        [
+          "/project/pages/a.js",
+          `import { shared } from "../components/shared.ts";\nexport const a = shared;\n`,
+        ],
+        [
+          "/project/pages/b.js",
+          `import { shared } from "../components/shared.ts";\nexport const b = shared;\n`,
+        ],
+        ["/project/components/shared.js", "export const shared = 1;\n"],
+      ]);
+      const reads = new Map<string, number>();
+      const cache = createDependencyHashCache();
+
+      const getContent = async (path: string): Promise<string> => {
+        reads.set(path, (reads.get(path) ?? 0) + 1);
+        const content = files.get(path);
+        if (content == null) throw new Error(`not found: ${path}`);
+        return content;
+      };
+
+      await computeDepsHash("/project/pages/a.js", getContent, "/project", cache);
+      await computeDepsHash("/project/pages/b.js", getContent, "/project", cache);
+
+      expect(reads.get("/project/components/shared.js")).toBe(1);
     });
   });
 

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -60,6 +60,10 @@ import { resolveVfModuleImports } from "./vf-module-resolver.ts";
 import { registerCSSImport } from "../css-import-collector.ts";
 import { injectNodePositions } from "#veryfront/transforms/plugins/babel-node-positions.ts";
 import { ensureMdxModuleDependencies } from "#veryfront/transforms/mdx/esm-module-loader/module-fetcher/dependency-recovery.ts";
+import {
+  createDependencyHashCache,
+  type DependencyHashCache,
+} from "#veryfront/cache/dependency-graph.ts";
 
 const logger = rendererLogger.component("ssr-module-loader");
 
@@ -78,7 +82,8 @@ export class SSRModuleLoader {
     this.cache = new SSRCacheManager(options);
     this.depValidator = new SSRDependencyValidator(
       (filePath) => this.cache.getCacheKey(filePath),
-      (filePath, source, depth) => this.transformWithDependencies(filePath, source, depth),
+      (filePath, source, depth, dependencyHashCache) =>
+        this.transformWithDependencies(filePath, source, depth, dependencyHashCache),
       (crossImport) => this.transformCrossProjectImport(crossImport),
       options.adapter,
       options.projectDir,
@@ -268,7 +273,8 @@ export class SSRModuleLoader {
         this.depValidator.reset();
 
         try {
-          await this.transformWithDependencies(filePath, source);
+          const dependencyHashCache = createDependencyHashCache();
+          await this.transformWithDependencies(filePath, source, 0, dependencyHashCache);
 
           if (this.depValidator.missingDependencies.length > 0) {
             this.depValidator.throwMissingDependencies(filePath);
@@ -327,12 +333,13 @@ export class SSRModuleLoader {
     filePath: string,
     source?: string,
     depth: number = 0,
+    dependencyHashCache: DependencyHashCache = createDependencyHashCache(),
   ): Promise<void> {
     const fileName = filePath.split("/").pop() || filePath;
 
     return withSpan(
       SpanNames.SSR_TRANSFORM_DEPENDENCIES,
-      () => this.doTransformWithDependencies(filePath, source, depth),
+      () => this.doTransformWithDependencies(filePath, source, depth, dependencyHashCache),
       {
         "ssr.file": fileName,
         "ssr.depth": depth,
@@ -344,6 +351,7 @@ export class SSRModuleLoader {
     filePath: string,
     source?: string,
     depth: number = 0,
+    dependencyHashCache: DependencyHashCache = createDependencyHashCache(),
   ): Promise<void> {
     if (depth > MAX_TRANSFORM_DEPTH) {
       logger.warn("Max transform depth exceeded", {
@@ -559,6 +567,7 @@ export class SSRModuleLoader {
         filePath,
         depth,
         localFs,
+        dependencyHashCache,
       );
 
       for (let i = 0; i < parseResult.crossProjectImports.length; i += TRANSFORM_BATCH_SIZE) {
@@ -590,6 +599,7 @@ export class SSRModuleLoader {
           ssr: true,
           apiBaseUrl: this.options.apiBaseUrl,
           reactVersion: this.options.reactVersion,
+          dependencyHashCache,
         };
 
         let transformed = await withSpan(

--- a/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
@@ -16,6 +16,10 @@ import { rendererLogger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { MAX_TRANSFORM_DEPTH, TRANSFORM_BATCH_SIZE } from "./constants.ts";
 import { globalModuleCache } from "./cache/index.ts";
+import {
+  createDependencyHashCache,
+  type DependencyHashCache,
+} from "#veryfront/cache/dependency-graph.ts";
 
 const logger = rendererLogger.component("ssr-module-loader");
 
@@ -35,6 +39,7 @@ export class SSRDependencyValidator {
       filePath: string,
       source: string | undefined,
       depth: number,
+      dependencyHashCache: DependencyHashCache,
     ) => Promise<void>,
     private transformCrossProjectImport: (
       crossProjectImport: CrossProjectImport,
@@ -103,7 +108,13 @@ export class SSRDependencyValidator {
     }
 
     const localFs = createFileSystem();
-    await this.processLocalImports(parseResult.imports, filePath, depth, localFs);
+    await this.processLocalImports(
+      parseResult.imports,
+      filePath,
+      depth,
+      localFs,
+      createDependencyHashCache(),
+    );
 
     for (let i = 0; i < parseResult.crossProjectImports.length; i += TRANSFORM_BATCH_SIZE) {
       const batch = parseResult.crossProjectImports.slice(i, i + TRANSFORM_BATCH_SIZE);
@@ -134,6 +145,7 @@ export class SSRDependencyValidator {
     fromFilePath: string,
     depth: number,
     localFs: ReturnType<typeof createFileSystem>,
+    dependencyHashCache: DependencyHashCache,
   ): Promise<Map<string, string>> {
     const importPathMap = new Map<string, string>();
 
@@ -146,7 +158,12 @@ export class SSRDependencyValidator {
               ? await localFs.readTextFile(imp.absolutePath)
               : await this.adapter.fs.readFile(imp.absolutePath);
 
-            await this.transformWithDependencies(imp.absolutePath, depSource, depth + 1);
+            await this.transformWithDependencies(
+              imp.absolutePath,
+              depSource,
+              depth + 1,
+              dependencyHashCache,
+            );
 
             const depCacheKey = this.getCacheKey(imp.absolutePath);
             const depEntry = globalModuleCache.get(depCacheKey);

--- a/src/transforms/esm/types.ts
+++ b/src/transforms/esm/types.ts
@@ -1,4 +1,5 @@
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { DependencyHashCache } from "#veryfront/cache/dependency-graph.ts";
 
 export interface TransformOptions {
   dev?: boolean;
@@ -11,6 +12,8 @@ export interface TransformOptions {
   studioEmbed?: boolean;
   /** React version for transforms (from project config, defaults to DEFAULT_REACT_VERSION) */
   reactVersion?: string;
+  /** Internal per-render dependency hash cache. */
+  dependencyHashCache?: DependencyHashCache;
 }
 
 export interface TransformContext {

--- a/src/transforms/pipeline/index.ts
+++ b/src/transforms/pipeline/index.ts
@@ -165,7 +165,12 @@ export function runPipeline(
         dev: ctx.dev,
       });
 
-      const depsHash = await computeDepsHashSafe(filePath, projectDir, options.readFile);
+      const depsHash = await computeDepsHashSafe(
+        filePath,
+        projectDir,
+        options.readFile,
+        options.dependencyHashCache,
+      );
 
       const cacheKey = generateCacheKey(
         filePath,
@@ -285,11 +290,12 @@ async function computeDepsHashSafe(
   filePath: string,
   projectDir: string,
   readFile?: (path: string) => Promise<string>,
+  dependencyHashCache?: TransformOptions["dependencyHashCache"],
 ): Promise<string | undefined> {
   if (!readFile) return undefined;
 
   try {
-    return await computeDepsHash(filePath, readFile, projectDir);
+    return await computeDepsHash(filePath, readFile, projectDir, dependencyHashCache);
   } catch (err) {
     logger.debug("depsHash computation failed, skipping", {
       file: filePath.slice(-60),

--- a/src/transforms/pipeline/types.ts
+++ b/src/transforms/pipeline/types.ts
@@ -5,6 +5,8 @@
  * Each stage handles one concern, making the pipeline testable and maintainable.
  */
 
+import type { DependencyHashCache } from "#veryfront/cache/dependency-graph.ts";
+
 /**
  * Transform stages in execution order.
  * Each stage runs after the previous completes.
@@ -57,6 +59,8 @@ export interface TransformOptions {
   reactVersion?: string;
   /** File reader for dependency hash computation. When provided, enables dependency-aware cache invalidation. */
   readFile?: (path: string) => Promise<string>;
+  /** Internal per-render dependency hash cache. */
+  dependencyHashCache?: DependencyHashCache;
 }
 
 /**

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.753";
+export const VERSION = "0.1.754";


### PR DESCRIPTION
## Summary
- add an explicit dependency hash cache that reuses graph/content hashes across overlapping transform dependency graphs
- thread one cache through a top-level SSR load and recursive local dependency transforms, without persisting it across separate loads
- bump release version to 0.1.754 in deno.json and src/utils/version-constant.ts

## Issue
Part of #2242. This addresses the per-transform DependencyGraph rebuild item.

## Verification
- deno test --no-check --allow-all src/cache/dependency-tracking.test.ts src/cache/dependency-graph.test.ts
- deno test --no-check --allow-all src/modules/react-loader/ssr-module-loader/loader.test.ts
- deno task verify:quick && git diff --check
- pre-push checks: format, lint, typecheck, unit tests (2045 passed)