### PR TITLE
Prevent dependency hash cache cycle deadlocks

### DIFF
--- a/src/cache/dependency-graph.ts
+++ b/src/cache/dependency-graph.ts
@@ -123,6 +123,7 @@ export interface DependencyHashCache {
   contentHashes: Map<string, string>;
   completedModules: Set<string>;
   inProgressModules: Map<string, Promise<void>>;
+  buildQueue: Promise<void>;
 }
 
 export function createDependencyHashCache(): DependencyHashCache {
@@ -131,6 +132,7 @@ export function createDependencyHashCache(): DependencyHashCache {
     contentHashes: new Map<string, string>(),
     completedModules: new Set<string>(),
     inProgressModules: new Map<string, Promise<void>>(),
+    buildQueue: Promise.resolve(),
   };
 }
 
@@ -193,12 +195,13 @@ export async function computeDepsHash(
   projectDir: string,
   cache: DependencyHashCache = createDependencyHashCache(),
 ): Promise<string> {
-  await buildDependencyGraph(
-    filePath,
-    cache,
-    getContent,
-    projectDir,
-  );
+  await enqueueDependencyGraphBuild(cache, () =>
+    buildDependencyGraph(
+      filePath,
+      cache,
+      getContent,
+      projectDir,
+    ));
 
   const deps = [filePath, ...cache.graph.getTransitiveDependencies(filePath)].sort();
   const combinedHash = deps
@@ -207,6 +210,15 @@ export async function computeDepsHash(
     .join(":");
 
   return computeHash(combinedHash);
+}
+
+async function enqueueDependencyGraphBuild(
+  cache: DependencyHashCache,
+  build: () => Promise<void>,
+): Promise<void> {
+  const queuedBuild = cache.buildQueue.then(build);
+  cache.buildQueue = queuedBuild.catch(() => {});
+  await queuedBuild;
 }
 
 async function buildDependencyGraph(

--- a/src/cache/dependency-tracking.test.ts
+++ b/src/cache/dependency-tracking.test.ts
@@ -126,6 +126,43 @@ describe("Dependency tracking cache invalidation", () => {
 
       expect(reads.get("/project/components/shared.js")).toBe(1);
     });
+
+    it("does not deadlock concurrent roots with circular local imports in one cache", async () => {
+      const files = new Map<string, string>([
+        ["/project/pages/a.js", `import { b } from "./b.ts"; export const a = b;`],
+        ["/project/pages/b.js", `import { a } from "./a.ts"; export const b = a;`],
+      ]);
+      const reads = new Map<string, number>();
+      const cache = createDependencyHashCache();
+
+      const getContent = async (path: string): Promise<string> => {
+        reads.set(path, (reads.get(path) ?? 0) + 1);
+        await Promise.resolve();
+        const content = files.get(path);
+        if (content == null) throw new Error(`not found: ${path}`);
+        return content;
+      };
+
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const hashes = await Promise.race([
+        Promise.all([
+          computeDepsHash("/project/pages/a.js", getContent, "/project", cache),
+          computeDepsHash("/project/pages/b.js", getContent, "/project", cache),
+        ]),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("timed out waiting for dependency hashes")),
+            100,
+          );
+        }),
+      ]).finally(() => {
+        if (timeout !== undefined) clearTimeout(timeout);
+      });
+
+      expect(hashes[0]).toBe(hashes[1]);
+      expect(reads.get("/project/pages/a.js")).toBe(1);
+      expect(reads.get("/project/pages/b.js")).toBe(1);
+    });
   });
 
   describe("computeConfigHash", () => {


### PR DESCRIPTION
## Summary
- add a per-cache build queue to the render-scoped dependency hash cache from #2302
- prevent concurrent root dependency hash computations from cross-awaiting each other on circular local imports
- add a regression for concurrent A <-> B roots sharing one dependency hash cache

Part of #2242.

## Tests
- RED: `deno test --no-check --allow-all src/cache/dependency-tracking.test.ts` failed with timeout for concurrent circular roots
- `deno test --no-check --allow-all src/cache/dependency-tracking.test.ts`
- `deno fmt --check src/cache/dependency-graph.ts src/cache/dependency-tracking.test.ts src/transforms/pipeline/types.ts src/transforms/pipeline/index.ts src/transforms/esm/types.ts src/modules/react-loader/ssr-module-loader/loader.ts src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts`
- `deno lint src/cache/dependency-graph.ts src/cache/dependency-tracking.test.ts src/transforms/pipeline/types.ts src/transforms/pipeline/index.ts src/transforms/esm/types.ts src/modules/react-loader/ssr-module-loader/loader.ts src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts`
- `deno check src/cache/dependency-tracking.test.ts src/transforms/pipeline/index.ts src/modules/react-loader/ssr-module-loader/loader.ts src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts`
- `deno test --no-check --allow-all src/cache/dependency-graph.test.ts src/cache/dependency-tracking.test.ts src/transforms/pipeline/index.test.ts src/modules/react-loader/ssr-module-loader/loader.test.ts`
- pre-push: format, lint, typecheck, generated assets, and unit suite passed: 2045 tests, 18242 steps