### PR TITLE
Stream module batch bundle responses

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.754",
+  "version": "0.1.755",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/modules/server/module-batch-handler.test.ts
+++ b/src/modules/server/module-batch-handler.test.ts
@@ -184,6 +184,43 @@ describe(
         assertEquals(code.includes("getModule"), true);
       });
 
+      it("streams cached batch bundles without joining the full response", async () => {
+        clearBatchCache();
+        const adapter = createMockAdapter();
+        adapter.fs.files.set("/test-project/streamed.tsx", "export const streamed = true;");
+        const options = {
+          projectDir: "/test-project",
+          adapter,
+          projectSlug: "test",
+          dev: false,
+        };
+
+        const firstResponse = await handleModuleBatch(createBatchRequest("streamed.js"), options);
+        assertEquals(firstResponse.status, 200);
+        await firstResponse.text();
+
+        const originalJoin = Array.prototype.join;
+        Array.prototype.join = function patchedJoin(this: unknown[], separator?: string) {
+          if (this[0] === "// Veryfront Module Batch Bundle") {
+            throw new Error("full bundle join should not be used");
+          }
+          return originalJoin.call(this, separator);
+        };
+
+        try {
+          const secondResponse = await handleModuleBatch(
+            createBatchRequest("streamed.js"),
+            options,
+          );
+          assertEquals(secondResponse.status, 200);
+          const code = await secondResponse.text();
+          assertEquals(code.includes("__vf_batch_modules"), true);
+          assertEquals(code.includes("streamed.js"), true);
+        } finally {
+          Array.prototype.join = originalJoin;
+        }
+      });
+
       it("should include batch metadata headers", async () => {
         const adapter = createMockAdapter();
         adapter.fs.files.set("/test-project/page.tsx", "export default () => null;");

--- a/src/modules/server/module-batch-handler.ts
+++ b/src/modules/server/module-batch-handler.ts
@@ -268,7 +268,7 @@ export function handleModuleBatch(req: Request, options: BatchHandlerOptions): P
         });
       }
 
-      const bundleCode = generateBatchBundle(successes, failures);
+      const bundleStream = createBatchBundleStream(successes, failures);
 
       const duration = performance.now() - startTime;
       const isSlow = duration > SLOW_REQUEST_THRESHOLD_MS;
@@ -297,7 +297,7 @@ export function handleModuleBatch(req: Request, options: BatchHandlerOptions): P
         });
       }
 
-      return new Response(bundleCode, {
+      return new Response(bundleStream, {
         status: HTTP_OK,
         headers: {
           "Content-Type": "application/javascript; charset=utf-8",
@@ -500,22 +500,41 @@ function createBatchSSRTargetCacheBusterResolver(options: {
   };
 }
 
-/**
- * Generate the batch bundle code
- * Creates a module that exports all loaded modules by path
- */
-function generateBatchBundle(
+function createBatchBundleStream(
   successes: Array<{ path: string; code: string; cached: boolean }>,
   failures: Array<{ path: string; error: string }>,
-): string {
-  const parts: string[] = [
-    "// Veryfront Module Batch Bundle",
-    "// Generated: " + new Date().toISOString(),
-    `// Modules: ${successes.length} loaded, ${failures.length} failed`,
-    "",
-    "const __vf_batch_modules = new Map();",
-    "",
-  ];
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      let isFirstChunk = true;
+
+      for (const chunk of generateBatchBundleChunks(successes, failures)) {
+        if (!isFirstChunk) controller.enqueue(encoder.encode("\n"));
+        controller.enqueue(encoder.encode(chunk));
+        isFirstChunk = false;
+      }
+
+      controller.close();
+    },
+  });
+}
+
+/**
+ * Generate the batch bundle code chunks.
+ * Creates a module that exports all loaded modules by path.
+ */
+function* generateBatchBundleChunks(
+  successes: Array<{ path: string; code: string; cached: boolean }>,
+  failures: Array<{ path: string; error: string }>,
+): IterableIterator<string> {
+  yield "// Veryfront Module Batch Bundle";
+  yield "// Generated: " + new Date().toISOString();
+  yield `// Modules: ${successes.length} loaded, ${failures.length} failed`;
+  yield "";
+  yield "const __vf_batch_modules = new Map();";
+  yield "";
 
   for (let i = 0; i < successes.length; i++) {
     const item = successes[i];
@@ -523,34 +542,32 @@ function generateBatchBundle(
     const { path, code } = item;
     const varName = `__mod_${i}`;
 
-    parts.push(`// Module: ${path}`);
-    parts.push(`const ${varName} = await (async () => {`);
-    parts.push("  const exports = {};");
-    parts.push("  const module = { exports };");
-    parts.push("  // --- Module code start ---");
-    parts.push(transformExportsForBundle(code));
-    parts.push("  // --- Module code end ---");
-    parts.push("  return exports;");
-    parts.push("})();");
-    parts.push(`__vf_batch_modules.set("${path}", ${varName});`);
-    parts.push("");
+    yield `// Module: ${path}`;
+    yield `const ${varName} = await (async () => {`;
+    yield "  const exports = {};";
+    yield "  const module = { exports };";
+    yield "  // --- Module code start ---";
+    yield transformExportsForBundle(code);
+    yield "  // --- Module code end ---";
+    yield "  return exports;";
+    yield "})();";
+    yield `__vf_batch_modules.set("${path}", ${varName});`;
+    yield "";
   }
 
   for (const { path, error } of failures) {
-    parts.push(`// Failed: ${path} - ${error}`);
-    parts.push(`__vf_batch_modules.set("${path}", { __vf_error: "${error}" });`);
+    yield `// Failed: ${path} - ${error}`;
+    yield `__vf_batch_modules.set("${path}", { __vf_error: "${error}" });`;
   }
 
-  parts.push("");
-  parts.push("export const batchModules = __vf_batch_modules;");
-  parts.push("");
-  parts.push("export function getModule(path) {");
-  parts.push("  return __vf_batch_modules.get(path);");
-  parts.push("}");
-  parts.push("");
-  parts.push("export default { batchModules, getModule };");
-
-  return parts.join("\n");
+  yield "";
+  yield "export const batchModules = __vf_batch_modules;";
+  yield "";
+  yield "export function getModule(path) {";
+  yield "  return __vf_batch_modules.get(path);";
+  yield "}";
+  yield "";
+  yield "export default { batchModules, getModule };";
 }
 
 /**

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.754";
+export const VERSION = "0.1.755";


### PR DESCRIPTION
## Summary
- stream generated module batch bundle chunks into the Response body instead of accumulating and joining one full bundle string
- preserve stable module ordering and existing JavaScript output shape
- add regression coverage that fails if the cached batch response uses the old full-bundle join path
- bump release version to 0.1.755 in deno.json and src/utils/version-constant.ts

## Issue
Part of #2242. This addresses the remaining batch bundle buffering item.

## Verification
- deno test --no-check --allow-all src/modules/server/module-batch-handler.test.ts
- deno check src/modules/server/module-batch-handler.ts src/modules/server/module-batch-handler.test.ts
- deno lint src/modules/server/module-batch-handler.ts src/modules/server/module-batch-handler.test.ts
- deno task verify:quick && git diff --check
- pre-push checks: format, lint, typecheck, unit tests (2045 passed)