### PR TITLE
Extract MDX module persistence phase

### DIFF
--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
@@ -24,10 +24,11 @@ import { resolveModuleFile } from "../resolution/file-finder.ts";
 import { buildMissingModuleError } from "../missing-module.ts";
 import { getTransformCacheKey, getVersionedPathCacheKey } from "./cache-keys.ts";
 import { resolveNestedModuleImports } from "./nested-imports.ts";
-import { readDistributedCache, writeDistributedCache } from "./distributed-cache.ts";
+import { readDistributedCache } from "./distributed-cache.ts";
 import { fetchModuleViaHTTP } from "./http-fetcher.ts";
 import { cacheModule, normalizePath } from "./module-cache.ts";
 import { readValidCachedModulePath } from "./path-cache-lookup.ts";
+import { persistResolvedModule } from "./persistence.ts";
 import { transformResolvedModuleSource } from "./source-transform.ts";
 
 // Re-export extracted modules for backward compatibility
@@ -308,40 +309,25 @@ async function doFetchAndCacheModule(
       log,
     });
 
-    // Write to distributed cache AFTER nested imports are resolved.
-    // This ensures other pods get fully-resolved code without /_vf_modules/ paths.
-    if (needsDistributedCacheWrite && distResult?.distributedCache && transformCacheKey) {
-      writeDistributedCache(
-        distResult.distributedCache,
-        transformCacheKey,
-        projectId,
-        contentSourceId!,
-        moduleCode,
-        normalizedPath,
-        log,
-      );
-    }
-
-    log.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] cacheModule START`, {
-      projectSlug,
-      normalizedPath,
-    });
-    const cacheStart = performance.now();
-    const finalCachedPath = await cacheModule(
+    return await persistResolvedModule({
       normalizedPath,
       moduleCode,
       esmCacheDir,
       pathCache,
       log,
-      effectiveReactVersion,
-    );
-    log.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] cacheModule DONE`, {
       projectSlug,
-      normalizedPath,
-      cacheMs: (performance.now() - cacheStart).toFixed(1),
+      reactVersion: effectiveReactVersion,
+      distributedCacheWrite:
+        needsDistributedCacheWrite && distResult?.distributedCache && transformCacheKey &&
+          contentSourceId
+          ? {
+            distributedCache: distResult.distributedCache,
+            transformCacheKey,
+            projectId,
+            contentSourceId,
+          }
+          : undefined,
     });
-
-    return finalCachedPath;
   } catch (error) {
     log.warn(`${LOG_PREFIX_MDX_LOADER} Failed to process ${normalizedPath}`, error);
     if ((context.strictMissingModules ?? true) || isFatalModuleFetchError(error)) {

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/persistence.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/persistence.test.ts
@@ -1,0 +1,80 @@
+import "#veryfront/schemas/_test-setup.ts";
+import type { CacheBackend } from "#veryfront/cache/backend.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { Logger } from "#veryfront/utils/logger/logger.ts";
+import { persistResolvedModule } from "./persistence.ts";
+
+const noopLog: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  time: (_label, fn) => fn(),
+  child: () => noopLog,
+  component: () => noopLog,
+};
+
+describe("module-fetcher/persistence", () => {
+  it("writes distributed cache before local cache and returns the local cache path", async () => {
+    const calls: string[] = [];
+    const pathCache = new Map<string, string>();
+    const distributedCache: CacheBackend = {
+      type: "memory",
+      get: () => Promise.resolve(null),
+      set: () => Promise.resolve(),
+      del: () => Promise.resolve(),
+    };
+
+    const result = await persistResolvedModule({
+      normalizedPath: "_vf_modules/app/page.js",
+      moduleCode: "export default 1;",
+      esmCacheDir: "/cache",
+      pathCache,
+      log: noopLog,
+      projectSlug: "docs",
+      reactVersion: "19.1.1",
+      distributedCacheWrite: {
+        distributedCache,
+        transformCacheKey: "transform-key",
+        projectId: "project-1",
+        contentSourceId: "preview-main",
+      },
+      writeToDistributedCache: (
+        receivedCache,
+        transformCacheKey,
+        projectId,
+        contentSourceId,
+        moduleCode,
+        normalizedPath,
+      ) => {
+        calls.push("distributed");
+        assertEquals(receivedCache, distributedCache);
+        assertEquals(transformCacheKey, "transform-key");
+        assertEquals(projectId, "project-1");
+        assertEquals(contentSourceId, "preview-main");
+        assertEquals(moduleCode, "export default 1;");
+        assertEquals(normalizedPath, "_vf_modules/app/page.js");
+      },
+      cacheLocalModule: (
+        normalizedPath,
+        moduleCode,
+        esmCacheDir,
+        receivedPathCache,
+        _log,
+        reactVersion,
+      ) => {
+        calls.push("local");
+        assertEquals(normalizedPath, "_vf_modules/app/page.js");
+        assertEquals(moduleCode, "export default 1;");
+        assertEquals(esmCacheDir, "/cache");
+        assertEquals(receivedPathCache, pathCache);
+        assertEquals(reactVersion, "19.1.1");
+        return Promise.resolve("/cache/page.mjs");
+      },
+    });
+
+    assertEquals(calls, ["distributed", "local"]);
+    assertEquals(result, "/cache/page.mjs");
+  });
+});

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/persistence.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/persistence.ts
@@ -1,0 +1,75 @@
+/**
+ * Final persistence phase for the MDX ESM module fetcher.
+ *
+ * @module transforms/mdx/esm-module-loader/module-fetcher/persistence
+ */
+
+import type { Logger } from "#veryfront/utils/logger/logger.ts";
+import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
+import { cacheModule } from "./module-cache.ts";
+import { writeDistributedCache } from "./distributed-cache.ts";
+
+type CacheLocalModuleFn = typeof cacheModule;
+type WriteDistributedCacheFn = typeof writeDistributedCache;
+type DistributedCache = Parameters<WriteDistributedCacheFn>[0];
+
+export interface PersistResolvedModuleInput {
+  normalizedPath: string;
+  moduleCode: string;
+  esmCacheDir: string;
+  pathCache: Map<string, string>;
+  log: Logger;
+  projectSlug: string;
+  reactVersion?: string;
+  distributedCacheWrite?: {
+    distributedCache: DistributedCache;
+    transformCacheKey: string;
+    projectId: string;
+    contentSourceId: string;
+  };
+  cacheLocalModule?: CacheLocalModuleFn;
+  writeToDistributedCache?: WriteDistributedCacheFn;
+}
+
+/**
+ * Persist fully resolved module code to distributed and local caches.
+ */
+export async function persistResolvedModule(
+  input: PersistResolvedModuleInput,
+): Promise<string | null> {
+  const writeToDistributedCache = input.writeToDistributedCache ?? writeDistributedCache;
+  const cacheLocalModule = input.cacheLocalModule ?? cacheModule;
+
+  if (input.distributedCacheWrite) {
+    writeToDistributedCache(
+      input.distributedCacheWrite.distributedCache,
+      input.distributedCacheWrite.transformCacheKey,
+      input.distributedCacheWrite.projectId,
+      input.distributedCacheWrite.contentSourceId,
+      input.moduleCode,
+      input.normalizedPath,
+      input.log,
+    );
+  }
+
+  input.log.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] cacheModule START`, {
+    projectSlug: input.projectSlug,
+    normalizedPath: input.normalizedPath,
+  });
+  const cacheStart = performance.now();
+  const finalCachedPath = await cacheLocalModule(
+    input.normalizedPath,
+    input.moduleCode,
+    input.esmCacheDir,
+    input.pathCache,
+    input.log,
+    input.reactVersion,
+  );
+  input.log.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] cacheModule DONE`, {
+    projectSlug: input.projectSlug,
+    normalizedPath: input.normalizedPath,
+    cacheMs: (performance.now() - cacheStart).toFixed(1),
+  });
+
+  return finalCachedPath;
+}


### PR DESCRIPTION
## Summary

- Extract the final MDX module-fetcher persistence phase into `persistence.ts`.
- Keep distributed cache writes after nested import resolution and before local path-cache persistence.
- Add focused helper coverage for distributed-write ordering and local cache return behavior.

## Issue

Partial progress on #2220.

## Verification

- RED: `deno test --frozen --no-check --allow-all src/transforms/mdx/esm-module-loader/module-fetcher/persistence.test.ts` failed before implementation because `persistence.ts` did not exist.
- `deno test --frozen --no-check --allow-all src/transforms/mdx/esm-module-loader/module-fetcher/persistence.test.ts`
- `deno fmt --check src/transforms/mdx/esm-module-loader/module-fetcher/index.ts src/transforms/mdx/esm-module-loader/module-fetcher/persistence.ts src/transforms/mdx/esm-module-loader/module-fetcher/persistence.test.ts`
- `deno lint src/transforms/mdx/esm-module-loader/module-fetcher/index.ts src/transforms/mdx/esm-module-loader/module-fetcher/persistence.ts src/transforms/mdx/esm-module-loader/module-fetcher/persistence.test.ts`
- `deno check --frozen src/transforms/mdx/esm-module-loader/module-fetcher/index.ts src/transforms/mdx/esm-module-loader/module-fetcher/persistence.ts src/transforms/mdx/esm-module-loader/module-fetcher/persistence.test.ts`
- `deno test --frozen --no-check --allow-all src/transforms/mdx/esm-module-loader/module-fetcher/persistence.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/dependency-recovery.test.ts`
- `git diff --check`
- `deno task verify:quick`
- pre-push hook: format, lint, typecheck, generated assets, unit suite (`2046 passed`, `0 failed`)

## Remaining #2220 work

- HTTP fallback phase extraction if a useful boundary remains.
- Import-rewriter unification where practical.
- Broader module-fetcher phase tests for any additional extracted boundaries.