### PR TITLE
Extract MDX HTTP fallback phase

### DIFF
--- a/src/transforms/mdx/esm-module-loader/module-fetcher/http-fallback.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/http-fallback.test.ts
@@ -1,0 +1,122 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { Logger } from "#veryfront/utils/logger/logger.ts";
+import { resolveUnresolvedModuleViaHttpFallback } from "./http-fallback.ts";
+
+const noopLog: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  time: (_label, fn) => fn(),
+  child: () => noopLog,
+  component: () => noopLog,
+};
+
+const adapter = {
+  env: { get: (_key: string) => undefined },
+} as RuntimeAdapter;
+
+describe("module-fetcher/http-fallback", () => {
+  it("caches HTTP fallback module code and returns the cached path", async () => {
+    const pathCache = new Map<string, string>();
+
+    const result = await resolveUnresolvedModuleViaHttpFallback({
+      normalizedPath: "_vf_modules/app/page.js",
+      parentModulePath: "_vf_modules/root.js",
+      adapter,
+      fetchAndCacheModule: (path, parent) => {
+        assertEquals(path, "_vf_modules/nested.js");
+        assertEquals(parent, "_vf_modules/app/page.js");
+        return Promise.resolve("/cache/nested.mjs");
+      },
+      log: noopLog,
+      projectSlug: "docs",
+      isLocalProject: true,
+      strictMissingModules: true,
+      esmCacheDir: "/cache",
+      pathCache,
+      reactVersion: "19.1.1",
+      fetchViaHttp: (
+        normalizedPath,
+        receivedAdapter,
+        fetchAndCacheModule,
+        receivedLog,
+        projectSlug,
+        isLocalProject,
+      ) => {
+        assertEquals(normalizedPath, "_vf_modules/app/page.js");
+        assertEquals(receivedAdapter, adapter);
+        assertEquals(receivedLog, noopLog);
+        assertEquals(projectSlug, "docs");
+        assertEquals(isLocalProject, true);
+        return fetchAndCacheModule("_vf_modules/nested.js", normalizedPath).then(() =>
+          "export default 1;"
+        );
+      },
+      cacheLocalModule: (
+        normalizedPath,
+        moduleCode,
+        esmCacheDir,
+        receivedPathCache,
+        _log,
+        reactVersion,
+      ) => {
+        assertEquals(normalizedPath, "_vf_modules/app/page.js");
+        assertEquals(moduleCode, "export default 1;");
+        assertEquals(esmCacheDir, "/cache");
+        assertEquals(receivedPathCache, pathCache);
+        assertEquals(reactVersion, "19.1.1");
+        return Promise.resolve("/cache/app-page.mjs");
+      },
+    });
+
+    assertEquals(result, "/cache/app-page.mjs");
+  });
+
+  it("returns null for a missing fallback module when strict mode is disabled", async () => {
+    const result = await resolveUnresolvedModuleViaHttpFallback({
+      normalizedPath: "_vf_modules/missing.js",
+      adapter,
+      fetchAndCacheModule: () => Promise.resolve(null),
+      log: noopLog,
+      projectSlug: "docs",
+      isLocalProject: false,
+      strictMissingModules: false,
+      esmCacheDir: "/cache",
+      pathCache: new Map(),
+      fetchViaHttp: () => Promise.resolve(null),
+      cacheLocalModule: () => {
+        throw new Error("cacheLocalModule should not run without HTTP fallback code");
+      },
+    });
+
+    assertEquals(result, null);
+  });
+
+  it("throws a missing-module error for a missing fallback module in strict mode", async () => {
+    await assertRejects(
+      () =>
+        resolveUnresolvedModuleViaHttpFallback({
+          normalizedPath: "_vf_modules/missing.js",
+          parentModulePath: "_vf_modules/root.js",
+          adapter,
+          fetchAndCacheModule: () => Promise.resolve(null),
+          log: noopLog,
+          projectSlug: "docs",
+          isLocalProject: false,
+          strictMissingModules: true,
+          esmCacheDir: "/cache",
+          pathCache: new Map(),
+          fetchViaHttp: () => Promise.resolve(null),
+          cacheLocalModule: () => {
+            throw new Error("cacheLocalModule should not run without HTTP fallback code");
+          },
+        }),
+      Error,
+      "Missing module",
+    );
+  });
+});

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/http-fallback.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/http-fallback.ts
@@ -1,0 +1,70 @@
+/**
+ * Unresolved module HTTP fallback phase for the MDX ESM module fetcher.
+ *
+ * @module transforms/mdx/esm-module-loader/module-fetcher/http-fallback
+ */
+
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { Logger } from "#veryfront/utils/logger/logger.ts";
+import { buildMissingModuleError } from "../missing-module.ts";
+import { fetchModuleViaHTTP } from "./http-fetcher.ts";
+import { cacheModule } from "./module-cache.ts";
+
+type FetchModuleViaHttpFn = typeof fetchModuleViaHTTP;
+type CacheLocalModuleFn = typeof cacheModule;
+
+export interface ResolveUnresolvedModuleViaHttpFallbackInput {
+  normalizedPath: string;
+  parentModulePath?: string;
+  adapter: RuntimeAdapter;
+  fetchAndCacheModule: (path: string, parent?: string) => Promise<string | null>;
+  log: Logger;
+  projectSlug: string;
+  isLocalProject?: boolean;
+  strictMissingModules?: boolean;
+  esmCacheDir: string;
+  pathCache: Map<string, string>;
+  reactVersion?: string;
+  fetchViaHttp?: FetchModuleViaHttpFn;
+  cacheLocalModule?: CacheLocalModuleFn;
+}
+
+/**
+ * Resolve an unresolved filesystem module through the local HTTP fallback.
+ */
+export async function resolveUnresolvedModuleViaHttpFallback(
+  input: ResolveUnresolvedModuleViaHttpFallbackInput,
+): Promise<string | null> {
+  const fetchViaHttp = input.fetchViaHttp ?? fetchModuleViaHTTP;
+  const cacheLocalModule = input.cacheLocalModule ?? cacheModule;
+
+  const moduleCode = await fetchViaHttp(
+    input.normalizedPath,
+    input.adapter,
+    input.fetchAndCacheModule,
+    input.log,
+    input.projectSlug,
+    input.isLocalProject,
+  );
+
+  if (moduleCode) {
+    return await cacheLocalModule(
+      input.normalizedPath,
+      moduleCode,
+      input.esmCacheDir,
+      input.pathCache,
+      input.log,
+      input.reactVersion,
+    );
+  }
+
+  if (input.strictMissingModules ?? true) {
+    throw buildMissingModuleError({
+      modulePath: input.normalizedPath,
+      importer: input.parentModulePath,
+      projectSlug: input.projectSlug,
+    });
+  }
+
+  return null;
+}

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
@@ -21,12 +21,11 @@ import type { ModuleFetcherContext } from "../types.ts";
 import { getModulePathCache } from "../cache/index.ts";
 import { hashString } from "../utils/hash.ts";
 import { resolveModuleFile } from "../resolution/file-finder.ts";
-import { buildMissingModuleError } from "../missing-module.ts";
 import { getTransformCacheKey, getVersionedPathCacheKey } from "./cache-keys.ts";
 import { resolveNestedModuleImports } from "./nested-imports.ts";
 import { readDistributedCache } from "./distributed-cache.ts";
-import { fetchModuleViaHTTP } from "./http-fetcher.ts";
-import { cacheModule, normalizePath } from "./module-cache.ts";
+import { resolveUnresolvedModuleViaHttpFallback } from "./http-fallback.ts";
+import { normalizePath } from "./module-cache.ts";
 import { readValidCachedModulePath } from "./path-cache-lookup.ts";
 import { persistResolvedModule } from "./persistence.ts";
 import { transformResolvedModuleSource } from "./source-transform.ts";
@@ -215,35 +214,19 @@ async function doFetchAndCacheModule(
     const resolved = await resolveModuleFile(normalizedPath, adapter, projectDir);
 
     if (!resolved) {
-      const moduleCode = await fetchModuleViaHTTP(
+      return await resolveUnresolvedModuleViaHttpFallback({
         normalizedPath,
         adapter,
-        fetchAndCacheModuleFn,
+        fetchAndCacheModule: fetchAndCacheModuleFn,
         log,
         projectSlug,
-        context.isLocalProject,
-      );
-
-      if (moduleCode) {
-        return await cacheModule(
-          normalizedPath,
-          moduleCode,
-          esmCacheDir,
-          pathCache,
-          log,
-          effectiveReactVersion,
-        );
-      }
-
-      if (context.strictMissingModules ?? true) {
-        throw buildMissingModuleError({
-          modulePath: normalizedPath,
-          importer: parentModulePath,
-          projectSlug,
-        });
-      }
-
-      return null;
+        isLocalProject: context.isLocalProject,
+        strictMissingModules: context.strictMissingModules ?? true,
+        esmCacheDir,
+        pathCache,
+        reactVersion: effectiveReactVersion,
+        parentModulePath,
+      });
     }
 
     const { sourceCode, actualFilePath } = resolved;


### PR DESCRIPTION
## Summary
- Extract unresolved MDX module HTTP fallback, local cache write, and missing-module handling into `http-fallback.ts`.
- Keep `doFetchAndCacheModule` behavior unchanged while removing the inline unresolved-file branch.
- Add focused coverage for HTTP fallback caching, non-strict null return, and strict missing-module errors.

## Verification
- Red first: `deno test --frozen --no-check --allow-all src/transforms/mdx/esm-module-loader/module-fetcher/http-fallback.test.ts` failed before `http-fallback.ts` existed.
- Focused helper test passed.
- `deno fmt --check src/transforms/mdx/esm-module-loader/module-fetcher/index.ts src/transforms/mdx/esm-module-loader/module-fetcher/http-fallback.ts src/transforms/mdx/esm-module-loader/module-fetcher/http-fallback.test.ts`
- `deno lint src/transforms/mdx/esm-module-loader/module-fetcher/index.ts src/transforms/mdx/esm-module-loader/module-fetcher/http-fallback.ts src/transforms/mdx/esm-module-loader/module-fetcher/http-fallback.test.ts`
- `deno check --frozen src/transforms/mdx/esm-module-loader/module-fetcher/index.ts src/transforms/mdx/esm-module-loader/module-fetcher/http-fallback.ts src/transforms/mdx/esm-module-loader/module-fetcher/http-fallback.test.ts`
- `deno test --frozen --no-check --allow-all src/transforms/mdx/esm-module-loader/module-fetcher/http-fallback.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/persistence.test.ts`
- `git diff --check`
- `deno task verify:quick`
- Pre-push hook: format/lint/typecheck/unit suite passed (`2047 passed`, `0 failed`).

Refs #2220
