### PR TITLE
Extract module-loader persistence phase

### DIFF
--- a/src/rendering/orchestrator/module-loader/index.ts
+++ b/src/rendering/orchestrator/module-loader/index.ts
@@ -25,16 +25,14 @@ import { getHttpBundleCacheDir, getMdxEsmCacheDir } from "#veryfront/utils/cache
 import { join } from "#veryfront/compat/path/index.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import {
-  getModulePathCache,
   invalidateMdxEsmModule,
   lookupMdxEsmCache,
-  saveModulePathCache,
 } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
-import { buildMdxEsmPathCacheKey } from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
 import {
   resolveModuleDependencies,
   rewriteResolvedDependencyImports,
 } from "./dependency-resolver.ts";
+import { persistTransformedModule } from "./module-persistence.ts";
 
 const logger = rendererLogger.component("module-loader");
 
@@ -42,28 +40,8 @@ const logger = rendererLogger.component("module-loader");
 export { createEsmCache, createModuleCache, generateHash } from "./cache.ts";
 export { fetchEsmModule, rewriteEsmPaths } from "./esm-rewriter.ts";
 
-/** Maximum number of directories to track to prevent memory leaks */
-const MAX_CREATED_DIRS = 5_000;
-
-/** Cache for created directories to avoid repeated mkdir calls (LRU-style) */
-const createdDirs = new Set<string>();
-
 /** TTL for cached transforms (uses centralized config) */
 const TRANSFORM_CACHE_TTL_SECONDS = TRANSFORM_DISTRIBUTED_TTL_SEC;
-
-/** Prune oldest entries when cache exceeds limit */
-function pruneCreatedDirs(): void {
-  if (createdDirs.size <= MAX_CREATED_DIRS) return;
-
-  const toDelete = createdDirs.size - MAX_CREATED_DIRS;
-  let deleted = 0;
-
-  for (const dir of createdDirs) {
-    if (deleted >= toDelete) break;
-    createdDirs.delete(dir);
-    deleted++;
-  }
-}
 
 function getModuleCacheKey(
   filePath: string,
@@ -79,19 +57,6 @@ function getModuleCacheKey(
 function decodeFileContent(fileContent: string | Uint8Array): string {
   if (typeof fileContent === "string") return fileContent;
   return new TextDecoder().decode(fileContent);
-}
-
-async function ensureDir(adapter: RuntimeAdapter, dir: string): Promise<void> {
-  if (createdDirs.has(dir)) return;
-
-  try {
-    await adapter.fs.mkdir(dir, { recursive: true });
-  } catch (_) {
-    /* expected: directory might already exist */
-  } finally {
-    createdDirs.add(dir);
-    pruneCreatedDirs();
-  }
 }
 
 /**
@@ -333,48 +298,17 @@ export async function transformModuleWithDeps(
     }
   }
 
-  const transformedHash = hashCodeHex(transformedCode).slice(0, 8);
-
-  const relativePath = filePath.startsWith(projectDir)
-    ? filePath.slice(projectDir.length).replace(/^\/+/, "")
-    : filePath.replace(/^\/+/, "");
-
-  const jsPath = relativePath.replace(/\.(tsx?|jsx|mdx)$/, `.${transformedHash}.js`);
-  const tempFilePath = join(tmpDir, jsPath);
-
-  const tempDir = tempFilePath.substring(0, tempFilePath.lastIndexOf("/"));
-  await ensureDir(localAdapter, tempDir);
-
-  try {
-    await localAdapter.fs.writeFile(tempFilePath, transformedCode);
-  } catch (error) {
-    logger.error("Failed to write module:", {
-      filePath,
-      tempFilePath,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    throw error;
-  }
-
-  if (contentSourceId) {
-    const normalizedPath = `_vf_modules/${relativePath.replace(/\.(tsx?|jsx|mdx)$/, ".js")}`;
-    const mdxCacheKey = buildMdxEsmPathCacheKey(normalizedPath, config.reactVersion);
-    const cache = await getModulePathCache(tmpDir);
-    cache.set(mdxCacheKey, tempFilePath);
-
-    saveModulePathCache(tmpDir).catch((err) => {
-      logger.debug("Failed to save module cache", { error: String(err) });
-    });
-
-    logger.debug("Registered module in MDX-ESM cache", {
-      file: filePath.slice(-40),
-      mdxCacheKey,
-      tempFilePath: tempFilePath.slice(-60),
-    });
-  }
-
-  moduleCache.set(cacheKey, tempFilePath);
-  return tempFilePath;
+  return await persistTransformedModule({
+    filePath,
+    projectDir,
+    tmpDir,
+    transformedCode,
+    localAdapter,
+    moduleCache,
+    cacheKey,
+    contentSourceId,
+    reactVersion: config.reactVersion,
+  });
 }
 
 export interface ModuleLoaderConfig {

--- a/src/rendering/orchestrator/module-loader/module-persistence.test.ts
+++ b/src/rendering/orchestrator/module-loader/module-persistence.test.ts
@@ -1,0 +1,50 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { dirname, join } from "#veryfront/compat/path/index.ts";
+import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
+import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
+import { getModulePathCache } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
+import { buildMdxEsmPathCacheKey } from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
+import { persistTransformedModule } from "./module-persistence.ts";
+
+describe("module-loader/module-persistence", () => {
+  it("writes transformed code, registers MDX path-cache, and updates module cache", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-module-persist-project-" });
+    const tmpDir = await Deno.makeTempDir({ prefix: "vf-module-persist-out-" });
+    const localAdapter = await getLocalAdapter();
+    const filePath = join(projectDir, "app/page.tsx");
+    const transformedCode = "export const page = 1;";
+    const moduleCache = new Map<string, string>();
+    const cacheKey = "project:preview:page";
+
+    try {
+      await Deno.mkdir(dirname(filePath), { recursive: true });
+      await Deno.writeTextFile(filePath, "export const page = 1;");
+
+      const result = await persistTransformedModule({
+        filePath,
+        projectDir,
+        tmpDir,
+        transformedCode,
+        localAdapter,
+        moduleCache,
+        cacheKey,
+        contentSourceId: "preview-main",
+        reactVersion: "19.1.1",
+      });
+
+      const expectedHash = hashCodeHex(transformedCode).slice(0, 8);
+      assertEquals(result, join(tmpDir, `app/page.${expectedHash}.js`));
+      assertEquals(await Deno.readTextFile(result), transformedCode);
+      assertEquals(moduleCache.get(cacheKey), result);
+
+      const pathCache = await getModulePathCache(tmpDir);
+      const mdxCacheKey = buildMdxEsmPathCacheKey("_vf_modules/app/page.js", "19.1.1");
+      assertEquals(pathCache.get(mdxCacheKey), result);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true }).catch(() => undefined);
+      await Deno.remove(tmpDir, { recursive: true }).catch(() => undefined);
+    }
+  });
+});

--- a/src/rendering/orchestrator/module-loader/module-persistence.ts
+++ b/src/rendering/orchestrator/module-loader/module-persistence.ts
@@ -1,0 +1,110 @@
+/**
+ * Final module-loader persistence phase.
+ *
+ * @module rendering/orchestrator/module-loader/module-persistence
+ */
+
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { join } from "#veryfront/compat/path/index.ts";
+import { rendererLogger } from "#veryfront/utils";
+import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
+import {
+  getModulePathCache,
+  saveModulePathCache,
+} from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
+import { buildMdxEsmPathCacheKey } from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
+
+const logger = rendererLogger.component("module-loader");
+
+/** Maximum number of directories to track to prevent memory leaks. */
+const MAX_CREATED_DIRS = 5_000;
+
+/** Cache for created directories to avoid repeated mkdir calls (LRU-style). */
+const createdDirs = new Set<string>();
+
+/** Prune oldest entries when cache exceeds limit. */
+function pruneCreatedDirs(): void {
+  if (createdDirs.size <= MAX_CREATED_DIRS) return;
+
+  const toDelete = createdDirs.size - MAX_CREATED_DIRS;
+  let deleted = 0;
+
+  for (const dir of createdDirs) {
+    if (deleted >= toDelete) break;
+    createdDirs.delete(dir);
+    deleted++;
+  }
+}
+
+async function ensureDir(adapter: RuntimeAdapter, dir: string): Promise<void> {
+  if (createdDirs.has(dir)) return;
+
+  try {
+    await adapter.fs.mkdir(dir, { recursive: true });
+  } catch (_) {
+    /* expected: directory might already exist */
+  } finally {
+    createdDirs.add(dir);
+    pruneCreatedDirs();
+  }
+}
+
+export interface PersistTransformedModuleInput {
+  filePath: string;
+  projectDir: string;
+  tmpDir: string;
+  transformedCode: string;
+  localAdapter: RuntimeAdapter;
+  moduleCache: Map<string, string>;
+  cacheKey: string;
+  contentSourceId?: string;
+  reactVersion?: string;
+}
+
+/** Write a transformed module artifact and register cache pointers. */
+export async function persistTransformedModule(
+  input: PersistTransformedModuleInput,
+): Promise<string> {
+  const transformedHash = hashCodeHex(input.transformedCode).slice(0, 8);
+
+  const relativePath = input.filePath.startsWith(input.projectDir)
+    ? input.filePath.slice(input.projectDir.length).replace(/^\/+/, "")
+    : input.filePath.replace(/^\/+/, "");
+
+  const jsPath = relativePath.replace(/\.(tsx?|jsx|mdx)$/, `.${transformedHash}.js`);
+  const tempFilePath = join(input.tmpDir, jsPath);
+
+  const tempDir = tempFilePath.substring(0, tempFilePath.lastIndexOf("/"));
+  await ensureDir(input.localAdapter, tempDir);
+
+  try {
+    await input.localAdapter.fs.writeFile(tempFilePath, input.transformedCode);
+  } catch (error) {
+    logger.error("Failed to write module:", {
+      filePath: input.filePath,
+      tempFilePath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+
+  if (input.contentSourceId) {
+    const normalizedPath = `_vf_modules/${relativePath.replace(/\.(tsx?|jsx|mdx)$/, ".js")}`;
+    const mdxCacheKey = buildMdxEsmPathCacheKey(normalizedPath, input.reactVersion);
+    const cache = await getModulePathCache(input.tmpDir);
+    cache.set(mdxCacheKey, tempFilePath);
+
+    saveModulePathCache(input.tmpDir).catch((err) => {
+      logger.debug("Failed to save module cache", { error: String(err) });
+    });
+
+    logger.debug("Registered module in MDX-ESM cache", {
+      file: input.filePath.slice(-40),
+      mdxCacheKey,
+      tempFilePath: tempFilePath.slice(-60),
+    });
+  }
+
+  input.moduleCache.set(input.cacheKey, tempFilePath);
+  return tempFilePath;
+}


### PR DESCRIPTION
## Summary
- Extract final module-loader artifact persistence into `module-persistence.ts`.
- Keep `transformModuleWithDeps` behavior unchanged while removing inline temp-file write, MDX path-cache registration, and module-cache update logic.
- Add focused coverage for transformed file writes, MDX path-cache registration, and in-memory module cache updates.

## Verification
- Red first: `deno test --frozen --no-check --allow-all src/rendering/orchestrator/module-loader/module-persistence.test.ts` failed before `module-persistence.ts` existed.
- Focused helper test passed.
- `deno fmt --check src/rendering/orchestrator/module-loader/index.ts src/rendering/orchestrator/module-loader/module-persistence.ts src/rendering/orchestrator/module-loader/module-persistence.test.ts`
- `deno lint src/rendering/orchestrator/module-loader/index.ts src/rendering/orchestrator/module-loader/module-persistence.ts src/rendering/orchestrator/module-loader/module-persistence.test.ts`
- `deno check --frozen src/rendering/orchestrator/module-loader/index.ts src/rendering/orchestrator/module-loader/module-persistence.ts src/rendering/orchestrator/module-loader/module-persistence.test.ts`
- `deno test --frozen --no-check --allow-all src/rendering/orchestrator/module-loader/module-persistence.test.ts src/rendering/orchestrator/module-loader/index.test.ts src/rendering/orchestrator/module-loader/dependency-resolver.test.ts src/rendering/orchestrator/module-loader/cache.test.ts src/rendering/orchestrator/module-loader/esm-rewriter.test.ts`
- `git diff --check`
- `deno task verify:quick`
- Pre-push hook: format/lint/typecheck/unit suite passed (`2048 passed`, `0 failed`).

Refs #2219
