### PR TITLE
Extract module-loader transform retry phase

### DIFF
--- a/src/rendering/orchestrator/module-loader/index.ts
+++ b/src/rendering/orchestrator/module-loader/index.ts
@@ -10,20 +10,10 @@
 import { rendererLogger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
-import { transformToESM } from "#veryfront/transforms/esm-transform.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { getProjectTmpDir } from "#veryfront/modules/react-loader/index.ts";
-import {
-  generateCacheKey as generateTransformCacheKey,
-  getOrComputeTransform,
-  initializeTransformCache,
-  setCachedTransformAsync,
-} from "#veryfront/transforms/esm/transform-cache.ts";
-import { TRANSFORM_DISTRIBUTED_TTL_SEC } from "#veryfront/utils/constants/cache.ts";
-import { validateCachedBundlesByManifestOrCode } from "#veryfront/transforms/esm/cached-bundle-validation.ts";
 import { getHttpBundleCacheDir, getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { join } from "#veryfront/compat/path/index.ts";
-import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import {
   invalidateMdxEsmModule,
   lookupMdxEsmCache,
@@ -33,15 +23,16 @@ import {
   rewriteResolvedDependencyImports,
 } from "./dependency-resolver.ts";
 import { persistTransformedModule } from "./module-persistence.ts";
+import {
+  transformModuleCodeWithCache,
+  UNRESOLVED_VF_MODULES_RE,
+} from "./module-transform-cache.ts";
 
 const logger = rendererLogger.component("module-loader");
 
 // Re-export utilities
 export { createEsmCache, createModuleCache, generateHash } from "./cache.ts";
 export { fetchEsmModule, rewriteEsmPaths } from "./esm-rewriter.ts";
-
-/** TTL for cached transforms (uses centralized config) */
-const TRANSFORM_CACHE_TTL_SECONDS = TRANSFORM_DISTRIBUTED_TTL_SEC;
 
 function getModuleCacheKey(
   filePath: string,
@@ -69,9 +60,6 @@ function decodeFileContent(fileContent: string | Uint8Array): string {
  * @param useLocalAdapter - Whether to use local adapter for reading
  * @returns Path to the transformed module file
  */
-/** Pattern to detect unresolved /_vf_modules/ imports that will fail at runtime */
-const UNRESOLVED_VF_MODULES_RE = /from\s*["']((?:file:\/\/)?\/?\/?_vf_modules\/[^"']+)["']/;
-
 export async function transformModuleWithDeps(
   filePath: string,
   tmpDir: string,
@@ -184,119 +172,16 @@ export async function transformModuleWithDeps(
     });
   }
 
-  const contentHash = hashCodeHex(fileContent);
   const effectiveProjectId = projectId ?? projectDir;
-  const scopedPath = `${effectiveProjectId}:${filePath}`;
-  const transformCacheKey = generateTransformCacheKey(scopedPath, contentHash, true);
-
-  await initializeTransformCache();
-
-  const transformResult = await getOrComputeTransform(
-    transformCacheKey,
-    () => {
-      logger.debug("Transform cache miss, transforming", { filePath });
-      return transformToESM(fileContent, filePath, projectDir, adapter, {
-        projectId: effectiveProjectId,
-        dev: mode === "development",
-        ssr: true,
-        reactVersion: config.reactVersion,
-      });
-    },
-    TRANSFORM_CACHE_TTL_SECONDS,
-  );
-
-  let transformedCode = transformResult.code;
-
-  const cacheDir = getHttpBundleCacheDir();
-  let bundlesValid = true;
-
-  if (transformResult.cacheHit) {
-    const validation = await validateCachedBundlesByManifestOrCode(
-      transformedCode,
-      transformResult.bundleManifestId,
-      cacheDir,
-    );
-    if (!validation.valid) {
-      logger.warn("Cached HTTP bundle validation failed, re-transforming", {
-        filePath,
-        manifestId: transformResult.bundleManifestId?.slice(0, 12),
-        failedHashes: validation.failedHashes,
-        reason: validation.reason,
-        source: validation.source,
-      });
-      bundlesValid = false;
-    }
-  }
-
-  if (!bundlesValid) {
-    transformedCode = await transformToESM(fileContent, filePath, projectDir, adapter, {
-      projectId: effectiveProjectId,
-      dev: mode === "development",
-      ssr: true,
-      reactVersion: config.reactVersion,
-    });
-
-    setCachedTransformAsync(
-      transformCacheKey,
-      transformedCode,
-      contentHash,
-      TRANSFORM_CACHE_TTL_SECONDS,
-    ).catch((error) => {
-      logger.debug("Failed to update transform cache after re-transform", {
-        filePath,
-        error,
-      });
-    });
-  }
-
-  // CRITICAL: Validate that no unresolved /_vf_modules/ imports remain after transform.
-  // These imports should have been resolved to file:// paths by ssrVfModulesPlugin.
-  // If they're still present, retry the transform bypassing all caches.
-  if (UNRESOLVED_VF_MODULES_RE.test(transformedCode)) {
-    const match = transformedCode.match(UNRESOLVED_VF_MODULES_RE);
-    const unresolvedImport = match?.[1] || "unknown";
-    logger.warn(
-      "[ModuleLoader] Transform has unresolved _vf_modules import, retrying without cache",
-      {
-        filePath: filePath.slice(-60),
-        unresolvedImport: unresolvedImport.slice(0, 80),
-        cacheHit: transformResult.cacheHit,
-      },
-    );
-
-    // Force a fresh transform bypassing all caches
-    // Import runPipeline directly to bypass getOrComputeTransform cache
-    const { runPipeline } = await import("#veryfront/transforms/pipeline/index.ts");
-    const pipelineResult = await runPipeline(fileContent, filePath, projectDir, {
-      projectId: effectiveProjectId,
-      dev: mode === "development",
-      ssr: true,
-      reactVersion: config.reactVersion,
-    });
-    transformedCode = pipelineResult.code;
-
-    // Check again after retry
-    if (UNRESOLVED_VF_MODULES_RE.test(transformedCode)) {
-      const retryMatch = transformedCode.match(UNRESOLVED_VF_MODULES_RE);
-      logger.error("Transform still has unresolved _vf_modules after retry", {
-        filePath: filePath.slice(-60),
-        unresolvedImport: retryMatch?.[1]?.slice(0, 80) || "unknown",
-        hint:
-          "Check that framework sources exist in dist/framework-src/ and ssrVfModulesPlugin is running",
-      });
-      // Continue anyway - let it fail at import time for better error context
-    } else {
-      // Retry succeeded - update the cache
-      setCachedTransformAsync(
-        transformCacheKey,
-        transformedCode,
-        hashCodeHex(transformedCode).slice(0, 16),
-        TRANSFORM_CACHE_TTL_SECONDS,
-      ).catch((error) => {
-        logger.debug("Failed to update cache after retry", { filePath, error });
-      });
-    }
-  }
+  const { code: transformedCode } = await transformModuleCodeWithCache({
+    fileContent,
+    filePath,
+    projectDir,
+    effectiveProjectId,
+    mode,
+    adapter,
+    reactVersion: config.reactVersion,
+  });
 
   return await persistTransformedModule({
     filePath,

--- a/src/rendering/orchestrator/module-loader/module-transform-cache.test.ts
+++ b/src/rendering/orchestrator/module-loader/module-transform-cache.test.ts
@@ -1,0 +1,134 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
+import {
+  type ModuleTransformCacheDeps,
+  transformModuleCodeWithCache,
+} from "./module-transform-cache.ts";
+
+function createDeps(
+  overrides: Partial<ModuleTransformCacheDeps>,
+): ModuleTransformCacheDeps {
+  return {
+    initializeTransformCache: () => Promise.resolve(false),
+    getOrComputeTransform: () => {
+      throw new Error("getOrComputeTransform was not configured");
+    },
+    transformToESM: () => {
+      throw new Error("transformToESM was not configured");
+    },
+    validateCachedBundlesByManifestOrCode: () => {
+      throw new Error("validateCachedBundlesByManifestOrCode was not configured");
+    },
+    getHttpBundleCacheDir: () => "/tmp/vf-http-bundles",
+    setCachedTransformAsync: () => Promise.resolve(),
+    runPipeline: () => {
+      throw new Error("runPipeline was not configured");
+    },
+    ...overrides,
+  };
+}
+
+describe("module-loader/module-transform-cache", () => {
+  it("re-transforms cached code when HTTP bundle validation fails", async () => {
+    const setCalls: Array<{ key: string; code: string; hash: string; ttl: number }> = [];
+    let transformCalls = 0;
+
+    const result = await transformModuleCodeWithCache({
+      fileContent: "export const page = 1;",
+      filePath: "/project/app/page.tsx",
+      projectDir: "/project",
+      effectiveProjectId: "project-1",
+      mode: "production",
+      adapter: {} as RuntimeAdapter,
+      ttlSeconds: 123,
+      deps: createDeps({
+        getOrComputeTransform: (_key, _compute) =>
+          Promise.resolve({
+            code: 'import x from "file:///tmp/veryfront-http-bundle/http-deadbeef.mjs";',
+            cacheHit: true,
+            bundleManifestId: "manifest-abc",
+          }),
+        validateCachedBundlesByManifestOrCode: (code, manifestId, cacheDir) => {
+          assertEquals(code.includes("deadbeef"), true);
+          assertEquals(manifestId, "manifest-abc");
+          assertEquals(cacheDir, "/tmp/vf-http-bundles");
+          return Promise.resolve({
+            valid: false,
+            failedHashes: ["deadbeef"],
+            reason: "bundle_missing",
+            source: "manifest",
+          });
+        },
+        transformToESM: () => {
+          transformCalls++;
+          return Promise.resolve("export const page = 1;");
+        },
+        setCachedTransformAsync: (key, code, hash, ttl) => {
+          setCalls.push({ key, code, hash, ttl: ttl ?? -1 });
+          return Promise.resolve();
+        },
+      }),
+    });
+
+    assertEquals(result.code, "export const page = 1;");
+    assertEquals(transformCalls, 1);
+    assertEquals(setCalls.length, 1);
+    assertEquals(setCalls[0]!.code, "export const page = 1;");
+    assertEquals(setCalls[0]!.hash, hashCodeHex("export const page = 1;"));
+    assertEquals(setCalls[0]!.ttl, 123);
+  });
+
+  it("retries through the transform pipeline when cached code has unresolved _vf_modules imports", async () => {
+    const retryCode = "export const page = 2;";
+    const setCalls: Array<{ code: string; hash: string }> = [];
+    let pipelineCalls = 0;
+
+    const result = await transformModuleCodeWithCache({
+      fileContent: "export const page = 2;",
+      filePath: "/project/app/page.tsx",
+      projectDir: "/project",
+      effectiveProjectId: "project-2",
+      mode: "development",
+      adapter: {} as RuntimeAdapter,
+      reactVersion: "19.1.1",
+      ttlSeconds: 456,
+      deps: createDeps({
+        getOrComputeTransform: () =>
+          Promise.resolve({
+            code: 'import React from "/_vf_modules/_veryfront/react.js";',
+            cacheHit: true,
+          }),
+        validateCachedBundlesByManifestOrCode: () =>
+          Promise.resolve({
+            valid: true,
+            failedHashes: [],
+            source: "code",
+          }),
+        runPipeline: (_code, filePath, projectDir, options) => {
+          pipelineCalls++;
+          assertEquals(filePath, "/project/app/page.tsx");
+          assertEquals(projectDir, "/project");
+          assertEquals(options.projectId, "project-2");
+          assertEquals(options.dev, true);
+          assertEquals(options.ssr, true);
+          assertEquals(options.reactVersion, "19.1.1");
+          return Promise.resolve({ code: retryCode });
+        },
+        setCachedTransformAsync: (_key, code, hash) => {
+          setCalls.push({ code, hash });
+          return Promise.resolve();
+        },
+      }),
+    });
+
+    assertEquals(result.code, retryCode);
+    assertEquals(pipelineCalls, 1);
+    assertEquals(setCalls, [{
+      code: retryCode,
+      hash: hashCodeHex(retryCode).slice(0, 16),
+    }]);
+  });
+});

--- a/src/rendering/orchestrator/module-loader/module-transform-cache.ts
+++ b/src/rendering/orchestrator/module-loader/module-transform-cache.ts
@@ -1,0 +1,229 @@
+/**
+ * Transform-cache and retry phase for the SSR module loader.
+ *
+ * @module rendering/orchestrator/module-loader/module-transform-cache
+ */
+
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { rendererLogger } from "#veryfront/utils";
+import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
+import { transformToESM } from "#veryfront/transforms/esm-transform.ts";
+import {
+  generateCacheKey as generateTransformCacheKey,
+  getOrComputeTransform,
+  initializeTransformCache,
+  setCachedTransformAsync,
+} from "#veryfront/transforms/esm/transform-cache.ts";
+import { validateCachedBundlesByManifestOrCode } from "#veryfront/transforms/esm/cached-bundle-validation.ts";
+import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
+import { TRANSFORM_DISTRIBUTED_TTL_SEC } from "#veryfront/utils/constants/cache.ts";
+
+const logger = rendererLogger.component("module-loader");
+
+/** Pattern to detect unresolved /_vf_modules/ imports that will fail at runtime. */
+export const UNRESOLVED_VF_MODULES_RE = /from\s*["']((?:file:\/\/)?\/?\/?_vf_modules\/[^"']+)["']/;
+
+export interface ModuleTransformCacheResult {
+  code: string;
+  cacheKey: string;
+  contentHash: string;
+}
+
+interface TransformCacheResult {
+  code: string;
+  cacheHit: boolean;
+  bundleManifestId?: string;
+}
+
+interface BundleValidationResult {
+  valid: boolean;
+  failedHashes: string[];
+  reason?: string;
+  source: string;
+}
+
+interface TransformOptions {
+  projectId: string;
+  dev: boolean;
+  ssr: boolean;
+  reactVersion?: string;
+}
+
+interface PipelineResult {
+  code: string;
+}
+
+export interface ModuleTransformCacheDeps {
+  initializeTransformCache: typeof initializeTransformCache;
+  getOrComputeTransform: (
+    key: string,
+    compute: () => Promise<string>,
+    ttlSeconds: number,
+  ) => Promise<TransformCacheResult>;
+  transformToESM: (
+    code: string,
+    filePath: string,
+    projectDir: string,
+    adapter: RuntimeAdapter,
+    options: TransformOptions,
+  ) => Promise<string>;
+  validateCachedBundlesByManifestOrCode: (
+    code: string,
+    bundleManifestId: string | undefined,
+    cacheDir: string,
+  ) => Promise<BundleValidationResult>;
+  getHttpBundleCacheDir: typeof getHttpBundleCacheDir;
+  setCachedTransformAsync: typeof setCachedTransformAsync;
+  runPipeline: (
+    code: string,
+    filePath: string,
+    projectDir: string,
+    options: TransformOptions,
+  ) => Promise<PipelineResult>;
+}
+
+const defaultDeps: ModuleTransformCacheDeps = {
+  initializeTransformCache,
+  getOrComputeTransform,
+  transformToESM,
+  validateCachedBundlesByManifestOrCode,
+  getHttpBundleCacheDir,
+  setCachedTransformAsync,
+  runPipeline: async (code, filePath, projectDir, options) => {
+    const { runPipeline } = await import("#veryfront/transforms/pipeline/index.ts");
+    return await runPipeline(code, filePath, projectDir, options);
+  },
+};
+
+export interface TransformModuleCodeWithCacheInput {
+  fileContent: string;
+  filePath: string;
+  projectDir: string;
+  effectiveProjectId: string;
+  mode: "development" | "production";
+  adapter: RuntimeAdapter;
+  reactVersion?: string;
+  ttlSeconds?: number;
+  deps?: ModuleTransformCacheDeps;
+}
+
+/** Transform module source through the shared cache and stale-cache retry checks. */
+export async function transformModuleCodeWithCache(
+  input: TransformModuleCodeWithCacheInput,
+): Promise<ModuleTransformCacheResult> {
+  const deps = input.deps ?? defaultDeps;
+  const ttlSeconds = input.ttlSeconds ?? TRANSFORM_DISTRIBUTED_TTL_SEC;
+  const contentHash = hashCodeHex(input.fileContent);
+  const scopedPath = `${input.effectiveProjectId}:${input.filePath}`;
+  const cacheKey = generateTransformCacheKey(scopedPath, contentHash, true);
+  const transformOptions = {
+    projectId: input.effectiveProjectId,
+    dev: input.mode === "development",
+    ssr: true,
+    reactVersion: input.reactVersion,
+  };
+
+  await deps.initializeTransformCache();
+
+  const transformResult = await deps.getOrComputeTransform(
+    cacheKey,
+    () => {
+      logger.debug("Transform cache miss, transforming", { filePath: input.filePath });
+      return deps.transformToESM(
+        input.fileContent,
+        input.filePath,
+        input.projectDir,
+        input.adapter,
+        transformOptions,
+      );
+    },
+    ttlSeconds,
+  );
+
+  let transformedCode = transformResult.code;
+
+  if (transformResult.cacheHit) {
+    const validation = await deps.validateCachedBundlesByManifestOrCode(
+      transformedCode,
+      transformResult.bundleManifestId,
+      deps.getHttpBundleCacheDir(),
+    );
+    if (!validation.valid) {
+      logger.warn("Cached HTTP bundle validation failed, re-transforming", {
+        filePath: input.filePath,
+        manifestId: transformResult.bundleManifestId?.slice(0, 12),
+        failedHashes: validation.failedHashes,
+        reason: validation.reason,
+        source: validation.source,
+      });
+
+      transformedCode = await deps.transformToESM(
+        input.fileContent,
+        input.filePath,
+        input.projectDir,
+        input.adapter,
+        transformOptions,
+      );
+
+      deps.setCachedTransformAsync(
+        cacheKey,
+        transformedCode,
+        contentHash,
+        ttlSeconds,
+      ).catch((error) => {
+        logger.debug("Failed to update transform cache after re-transform", {
+          filePath: input.filePath,
+          error,
+        });
+      });
+    }
+  }
+
+  // CRITICAL: Validate that no unresolved /_vf_modules/ imports remain after transform.
+  // These imports should have been resolved to file:// paths by ssrVfModulesPlugin.
+  // If they're still present, retry the transform bypassing all caches.
+  if (UNRESOLVED_VF_MODULES_RE.test(transformedCode)) {
+    const match = transformedCode.match(UNRESOLVED_VF_MODULES_RE);
+    const unresolvedImport = match?.[1] || "unknown";
+    logger.warn(
+      "[ModuleLoader] Transform has unresolved _vf_modules import, retrying without cache",
+      {
+        filePath: input.filePath.slice(-60),
+        unresolvedImport: unresolvedImport.slice(0, 80),
+        cacheHit: transformResult.cacheHit,
+      },
+    );
+
+    const pipelineResult = await deps.runPipeline(
+      input.fileContent,
+      input.filePath,
+      input.projectDir,
+      transformOptions,
+    );
+    transformedCode = pipelineResult.code;
+
+    if (UNRESOLVED_VF_MODULES_RE.test(transformedCode)) {
+      const retryMatch = transformedCode.match(UNRESOLVED_VF_MODULES_RE);
+      logger.error("Transform still has unresolved _vf_modules after retry", {
+        filePath: input.filePath.slice(-60),
+        unresolvedImport: retryMatch?.[1]?.slice(0, 80) || "unknown",
+        hint:
+          "Check that framework sources exist in dist/framework-src/ and ssrVfModulesPlugin is running",
+      });
+    } else {
+      deps.setCachedTransformAsync(
+        cacheKey,
+        transformedCode,
+        hashCodeHex(transformedCode).slice(0, 16),
+        ttlSeconds,
+      ).catch((error) => {
+        logger.debug("Failed to update cache after retry", {
+          filePath: input.filePath,
+          error,
+        });
+      });
+    }
+  }
+
+  return { code: transformedCode, cacheKey, contentHash };
+}


### PR DESCRIPTION
## Summary
- Extract the module-loader transform-cache and retry phase into `module-transform-cache.ts`.
- Keep dependency resolution and final artifact persistence in `transformModuleWithDeps`, preserving the existing orchestration behavior.
- Add focused tests for stale HTTP bundle re-transform and unresolved `_vf_modules` pipeline retry behavior.

## Verification
- Red first: `deno test --frozen --no-check --allow-all src/rendering/orchestrator/module-loader/module-transform-cache.test.ts` failed before `module-transform-cache.ts` existed.
- `deno test --frozen --no-check --allow-all src/rendering/orchestrator/module-loader/module-transform-cache.test.ts`
- `deno fmt --check src/rendering/orchestrator/module-loader/index.ts src/rendering/orchestrator/module-loader/module-transform-cache.ts src/rendering/orchestrator/module-loader/module-transform-cache.test.ts`
- `deno lint src/rendering/orchestrator/module-loader/index.ts src/rendering/orchestrator/module-loader/module-transform-cache.ts src/rendering/orchestrator/module-loader/module-transform-cache.test.ts`
- `deno check --frozen src/rendering/orchestrator/module-loader/index.ts src/rendering/orchestrator/module-loader/module-transform-cache.ts src/rendering/orchestrator/module-loader/module-transform-cache.test.ts`
- `deno test --frozen --no-check --allow-all src/rendering/orchestrator/module-loader/module-transform-cache.test.ts src/rendering/orchestrator/module-loader/module-persistence.test.ts src/rendering/orchestrator/module-loader/index.test.ts src/rendering/orchestrator/module-loader/dependency-resolver.test.ts src/rendering/orchestrator/module-loader/cache.test.ts src/rendering/orchestrator/module-loader/esm-rewriter.test.ts`
- `git diff --check`
- `deno task verify:quick`
- Pre-push hook: format/lint/typecheck/unit suite passed (`2049 passed`, `0 failed`).

Refs #2219
