### PR TITLE
Model WebSocket upgrades without fake DOM responses

### DIFF
--- a/src/modules/server/rate-limiter.ts
+++ b/src/modules/server/rate-limiter.ts
@@ -1,12 +1,16 @@
 import { HMR_RATE_LIMIT_WINDOW_MS } from "#veryfront/utils";
+import type { WebSocketConnection } from "#veryfront/platform/adapters/base.ts";
 
 export class RateLimiter {
-  private readonly messageCounts = new Map<WebSocket, { count: number; resetTime: number }>();
+  private readonly messageCounts = new Map<
+    WebSocketConnection,
+    { count: number; resetTime: number }
+  >();
   private readonly windowMs = HMR_RATE_LIMIT_WINDOW_MS;
 
   constructor(private readonly maxMessages: number) {}
 
-  check(socket: WebSocket): boolean {
+  check(socket: WebSocketConnection): boolean {
     const now = Date.now();
     const record = this.messageCounts.get(socket);
 
@@ -20,7 +24,7 @@ export class RateLimiter {
     return true;
   }
 
-  cleanup(socket: WebSocket): void {
+  cleanup(socket: WebSocketConnection): void {
     this.messageCounts.delete(socket);
   }
 }

--- a/src/platform/adapters/base.test.ts
+++ b/src/platform/adapters/base.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createWebSocketUpgradeResponse, isWebSocketUpgradeResponse } from "./base.ts";
 import type {
   DirEntry,
   EnvironmentAdapter,
@@ -18,6 +19,22 @@ import type {
 } from "./base.ts";
 
 describe("base.ts type exports", () => {
+  describe("WebSocketUpgradeResponse", () => {
+    it("models upgrade responses without constructing a DOM Response", () => {
+      const response = createWebSocketUpgradeResponse({
+        headers: { upgrade: "websocket" },
+      });
+
+      assertEquals(response.status, 101);
+      assertEquals(response.statusText, "Switching Protocols");
+      assertEquals(response.body, null);
+      assertEquals(response.headers.get("upgrade"), "websocket");
+      assertEquals(response instanceof Response, false);
+      assertEquals(isWebSocketUpgradeResponse(response), true);
+      assertEquals(isWebSocketUpgradeResponse(new Response()), false);
+    });
+  });
+
   describe("RuntimeId", () => {
     it("should accept valid runtime identifiers", () => {
       const ids: RuntimeId[] = ["deno", "node", "bun", "cloudflare", "memory"];

--- a/src/platform/adapters/base.ts
+++ b/src/platform/adapters/base.ts
@@ -85,9 +85,45 @@ export interface ServerAdapter {
   upgradeWebSocket(request: Request): WebSocketUpgrade;
 }
 
+export interface WebSocketConnection {
+  readonly readyState: number;
+  send(data: string | ArrayBuffer): void;
+  close(code?: number, reason?: string): void;
+  addEventListener(type: string, listener: EventListener, options?: AddEventListenerOptions): void;
+  removeEventListener(type: string, listener: EventListener): void;
+}
+
+const WEBSOCKET_UPGRADE_RESPONSE_KIND = "websocket-upgrade";
+
+export interface WebSocketUpgradeResponse {
+  readonly kind: typeof WEBSOCKET_UPGRADE_RESPONSE_KIND;
+  readonly status: 101;
+  readonly statusText: string;
+  readonly headers: Headers;
+  readonly body: null;
+}
+
 export interface WebSocketUpgrade {
-  socket: WebSocket;
-  response: Response;
+  socket: WebSocketConnection;
+  response: Response | WebSocketUpgradeResponse;
+}
+
+export function createWebSocketUpgradeResponse(
+  input: { headers?: HeadersInit; statusText?: string } = {},
+): WebSocketUpgradeResponse {
+  return {
+    kind: WEBSOCKET_UPGRADE_RESPONSE_KIND,
+    status: 101,
+    statusText: input.statusText ?? "Switching Protocols",
+    headers: new Headers(input.headers),
+    body: null,
+  };
+}
+
+export function isWebSocketUpgradeResponse(value: unknown): value is WebSocketUpgradeResponse {
+  return typeof value === "object" && value !== null &&
+    (value as { kind?: unknown }).kind === WEBSOCKET_UPGRADE_RESPONSE_KIND &&
+    (value as { status?: unknown }).status === 101;
 }
 
 export interface ServeOptions {

--- a/src/platform/adapters/index.ts
+++ b/src/platform/adapters/index.ts
@@ -23,8 +23,11 @@ export type {
   ServerAdapter,
   ShellAdapter,
   WatchOptions,
+  WebSocketConnection,
   WebSocketUpgrade,
+  WebSocketUpgradeResponse,
 } from "./base.ts";
+export { createWebSocketUpgradeResponse, isWebSocketUpgradeResponse } from "./base.ts";
 
 // Detection & registry
 export { getAdapter } from "./detect.ts";

--- a/src/platform/adapters/runtime/bun/websocket-adapter.ts
+++ b/src/platform/adapters/runtime/bun/websocket-adapter.ts
@@ -15,7 +15,7 @@ export class BunServerAdapter implements ServerAdapter {
     const socket = new BunWebSocket();
     const response = new Response(null, { status: 101, statusText: "Switching Protocols" });
 
-    return { socket: socket as unknown as WebSocket, response };
+    return { socket, response };
   }
 }
 
@@ -43,5 +43,39 @@ export class BunWebSocket {
 
   close(_code?: number, _reason?: string): void {
     this.readyState = BunWebSocket.CLOSED;
+  }
+
+  addEventListener(type: string, listener: EventListener): void {
+    switch (type) {
+      case "open":
+        this.onopen = listener as (event: Event) => void;
+        return;
+      case "close":
+        this.onclose = listener as (event: Event) => void;
+        return;
+      case "error":
+        this.onerror = listener as (event: Event) => void;
+        return;
+      case "message":
+        this.onmessage = listener as (event: MessageEvent) => void;
+        return;
+    }
+  }
+
+  removeEventListener(type: string, _listener: EventListener): void {
+    switch (type) {
+      case "open":
+        this.onopen = null;
+        return;
+      case "close":
+        this.onclose = null;
+        return;
+      case "error":
+        this.onerror = null;
+        return;
+      case "message":
+        this.onmessage = null;
+        return;
+    }
   }
 }

--- a/src/platform/adapters/runtime/cloudflare/server.ts
+++ b/src/platform/adapters/runtime/cloudflare/server.ts
@@ -21,7 +21,7 @@ export class CloudflareServerAdapter implements ServerAdapter {
     };
 
     return {
-      socket: server as unknown as WebSocket,
+      socket: server,
       response: new Response(null, responseInit),
     };
   }

--- a/src/platform/adapters/runtime/node/websocket-adapter.test.ts
+++ b/src/platform/adapters/runtime/node/websocket-adapter.test.ts
@@ -1,9 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { isWebSocketUpgradeResponse } from "../../base.ts";
 import { EventEmitter } from "node:events";
 import { Buffer } from "node:buffer";
-import { NodeWebSocket } from "./websocket-adapter.ts";
+import { resolveWebSocketUpgrade } from "./http-server.ts";
+import { NodeServerAdapter, NodeWebSocket } from "./websocket-adapter.ts";
 import type { WSWebSocket } from "./types.ts";
 
 /**
@@ -29,6 +31,31 @@ function attach(): { socket: NodeWebSocket; ws: WSWebSocket & EventEmitter } {
   socket._attachRealSocket(ws);
   return { socket, ws };
 }
+
+describe("NodeServerAdapter WebSocket upgrade", () => {
+  it("returns an explicit non-DOM upgrade response signal", () => {
+    const requestId = "dGhlIHNhbXBsZSBub25jZQ==";
+    const adapter = new NodeServerAdapter();
+
+    const { response } = adapter.upgradeWebSocket(
+      new Request("http://localhost/_ws", {
+        headers: {
+          connection: "Upgrade",
+          upgrade: "websocket",
+          "sec-websocket-key": requestId,
+        },
+      }),
+    );
+
+    assertEquals(isWebSocketUpgradeResponse(response), true);
+    assertEquals(response.status, 101);
+    assertEquals(response.statusText, "Switching Protocols");
+    assertEquals(response.headers.get("upgrade"), "websocket");
+    assertEquals(response instanceof Response, false);
+
+    assertEquals(resolveWebSocketUpgrade(requestId, createMockWs()), true);
+  });
+});
 
 describe("NodeWebSocket close handling", () => {
   it("invokes onclose with a CloseEvent-shaped object on a clean close", () => {

--- a/src/platform/adapters/runtime/node/websocket-adapter.ts
+++ b/src/platform/adapters/runtime/node/websocket-adapter.ts
@@ -1,4 +1,8 @@
-import type { ServerAdapter, WebSocketUpgrade } from "../../base.ts";
+import {
+  createWebSocketUpgradeResponse,
+  type ServerAdapter,
+  type WebSocketUpgrade,
+} from "../../base.ts";
 import type { WSMessageData, WSWebSocket } from "./types.ts";
 import { createError, toError } from "#veryfront/errors";
 import { serverLogger } from "#veryfront/utils";
@@ -63,17 +67,9 @@ export class NodeServerAdapter implements ServerAdapter {
       ...(protocol ? { "Sec-WebSocket-Protocol": protocol } : {}),
     };
 
-    // Node.js (undici) doesn't allow status 101 in Response constructor.
-    // Create a minimal signal object — only checked for status === 101 upstream.
-    const response = {
-      status: 101,
-      statusText: "Switching Protocols",
-      headers: new Headers(headers),
-      body: null,
-      ok: false,
-    } as unknown as Response;
+    const response = createWebSocketUpgradeResponse({ headers });
 
-    return { socket: socket as unknown as WebSocket, response };
+    return { socket, response };
   }
 
   private generateAcceptKey(key: string): string {

--- a/src/security/http/base-handler.ts
+++ b/src/security/http/base-handler.ts
@@ -7,12 +7,16 @@ import type {
 } from "#veryfront/types";
 import { runWithCacheBatching } from "#veryfront/cache/request-cache-batcher.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
+import type { WebSocketUpgradeResponse } from "#veryfront/platform/adapters/base.ts";
 import { serverLogger } from "#veryfront/utils";
 import { ResponseBuilder } from "./response/index.ts";
 
 export interface HandlerHelpers {
   createResponseBuilder: (ctx: HandlerContext, nonce?: string) => ResponseBuilder;
-  respond: (response: Response, metadata?: Record<string, unknown>) => HandlerResult;
+  respond: (
+    response: Response | WebSocketUpgradeResponse,
+    metadata?: Record<string, unknown>,
+  ) => HandlerResult;
   logDebug: (message: string, extra?: Record<string, unknown>, ctx?: HandlerContext) => void;
   getErrorMessage: (error: unknown) => string;
   continue: () => HandlerResult;
@@ -99,8 +103,11 @@ export abstract class BaseHandler implements Handler {
     return { continue: true };
   }
 
-  protected respond(response: Response, metadata?: Record<string, unknown>): HandlerResult {
-    return { response, continue: false, metadata };
+  protected respond(
+    response: Response | WebSocketUpgradeResponse,
+    metadata?: Record<string, unknown>,
+  ): HandlerResult {
+    return { response: response as Response, continue: false, metadata };
   }
 
   protected withProxyContext<T>(

--- a/src/server/handlers/preview/hmr-client-manager.ts
+++ b/src/server/handlers/preview/hmr-client-manager.ts
@@ -1,11 +1,12 @@
 import { serverLogger } from "#veryfront/utils";
+import type { WebSocketConnection } from "#veryfront/platform/adapters/base.ts";
 
 const logger = serverLogger.component("hmr-handler");
 
 /** Client metadata for observability */
 export interface HMRClientInfo {
   id: string;
-  socket: WebSocket;
+  socket: WebSocketConnection;
   connectedAt: number;
   projectSlug?: string;
   userAgent?: string;
@@ -69,8 +70,8 @@ export function getClientDetails(): HMRClientDetail[] {
  * Get all open WebSocket connections, optionally filtered by projectSlug.
  * This replaces the old exported `clientSockets` Set that drifted out of sync.
  */
-export function getOpenSockets(projectSlug?: string): WebSocket[] {
-  const sockets: WebSocket[] = [];
+export function getOpenSockets(projectSlug?: string): WebSocketConnection[] {
+  const sockets: WebSocketConnection[] = [];
   for (const client of clientsMap.values()) {
     if (client.socket.readyState !== WebSocket.OPEN) continue;
     if (projectSlug && client.projectSlug !== projectSlug) continue;

--- a/src/server/handlers/preview/hmr-message-router.test.ts
+++ b/src/server/handlers/preview/hmr-message-router.test.ts
@@ -15,6 +15,10 @@ class MockSocket {
   close(): void {
     this.readyState = WebSocket.CLOSED;
   }
+
+  addEventListener(): void {}
+
+  removeEventListener(): void {}
 }
 
 describe("server/handlers/preview/hmr-message-router", () => {
@@ -27,7 +31,7 @@ describe("server/handlers/preview/hmr-message-router", () => {
     const socket = new MockSocket();
     addClient({
       id: "client-1",
-      socket: socket as unknown as WebSocket,
+      socket,
       connectedAt: Date.now(),
       lastActivity: Date.now(),
       projectSlug: "demo-project",

--- a/src/server/handlers/preview/hmr.handler.test.ts
+++ b/src/server/handlers/preview/hmr.handler.test.ts
@@ -4,7 +4,11 @@ import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { NOT_SUPPORTED } from "#veryfront/errors";
 import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
 import type { HandlerContext } from "../types.ts";
-import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import {
+  createWebSocketUpgradeResponse,
+  type RuntimeAdapter,
+  type WebSocketConnection,
+} from "#veryfront/platform/adapters/base.ts";
 import { HMRHandler } from "./hmr.handler.ts";
 
 const encoder = new TextEncoder();
@@ -86,6 +90,44 @@ function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
     cspUserHeader: null,
     ...overrides,
   } as unknown as HandlerContext;
+}
+
+function createMockSocket(): {
+  socket: WebSocketConnection;
+  sentMessages: string[];
+  emit(type: string, event: unknown): void;
+} {
+  const listeners = new Map<string, Set<EventListener>>();
+  const sentMessages: string[] = [];
+
+  const socket: WebSocketConnection = {
+    readyState: WebSocket.OPEN,
+    send: (message) => {
+      sentMessages.push(String(message));
+    },
+    close: () => {},
+    addEventListener: (type, listener) => {
+      let typeListeners = listeners.get(type);
+      if (!typeListeners) {
+        typeListeners = new Set();
+        listeners.set(type, typeListeners);
+      }
+      typeListeners.add(listener);
+    },
+    removeEventListener: (type, listener) => {
+      listeners.get(type)?.delete(listener);
+    },
+  };
+
+  return {
+    socket,
+    sentMessages,
+    emit: (type, event) => {
+      for (const listener of listeners.get(type) ?? []) {
+        listener(event as Event);
+      }
+    },
+  };
 }
 
 describe("server/handlers/preview/hmr.handler", () => {
@@ -381,6 +423,56 @@ describe("server/handlers/preview/hmr.handler", () => {
   });
 
   describe("handle - websocket upgrade", () => {
+    it("returns an explicit WebSocket upgrade signal from adapter upgrades", async () => {
+      const handler = new HMRHandler();
+      const mock = createMockSocket();
+      const req = new Request("http://localhost/_ws", {
+        headers: { upgrade: "websocket" },
+      });
+      const upgradeResponse = createWebSocketUpgradeResponse();
+      const ctx = makeCtx({
+        isLocalProject: true,
+        adapter: createMockAdapter({
+          upgradeWebSocket: () => ({
+            socket: mock.socket,
+            response: upgradeResponse,
+          }),
+        }),
+      });
+
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.continue, false);
+      assertEquals(Object.is(result.response, upgradeResponse), true);
+      assertEquals(result.response instanceof Response, false);
+      assertEquals(result.response!.status, 101);
+    });
+
+    it("preserves data from structurally compatible message events", async () => {
+      const handler = new HMRHandler();
+      const mock = createMockSocket();
+      const req = new Request("http://localhost/_ws", {
+        headers: { upgrade: "websocket" },
+      });
+      const ctx = makeCtx({
+        isLocalProject: true,
+        adapter: createMockAdapter({
+          upgradeWebSocket: () => ({
+            socket: mock.socket,
+            response: createWebSocketUpgradeResponse(),
+          }),
+        }),
+      });
+
+      await handler.handle(req, ctx);
+      mock.emit("message", { data: JSON.stringify({ type: "ping" }) });
+
+      assertEquals(mock.sentMessages, [
+        JSON.stringify({ type: "connected" }),
+        JSON.stringify({ type: "pong" }),
+      ]);
+    });
+
     it("returns 501 when adapter.server is missing", async () => {
       const handler = new HMRHandler();
       const req = new Request("http://localhost/_ws", {

--- a/src/server/handlers/preview/hmr.handler.ts
+++ b/src/server/handlers/preview/hmr.handler.ts
@@ -35,6 +35,10 @@ export type { HMRClientInfo } from "./hmr-client-manager.ts";
 // Priority between auth (0) and high (100)
 const PRIORITY_HMR: HandlerPriority = HandlerPriority.EARLY;
 
+function getMessageEventData(event: Event): unknown {
+  return "data" in event ? (event as { data: unknown }).data : undefined;
+}
+
 export class HMRHandler extends BaseHandler {
   private static rateLimiter = new RateLimiter(HMR_MAX_MESSAGES_PER_MINUTE);
   private static reloadUnsubscribe: (() => void) | null = null;
@@ -189,7 +193,7 @@ export class HMRHandler extends BaseHandler {
       socket.addEventListener("message", (event) => {
         handleHmrClientMessage({
           socket,
-          data: event.data,
+          data: getMessageEventData(event),
           rateLimiter: HMRHandler.rateLimiter,
           onActivity: () => {
             const client = getClient(clientId);


### PR DESCRIPTION
## Summary

- Adds an explicit `WebSocketUpgradeResponse` signal and `WebSocketConnection` contract for runtime adapter upgrades.
- Switches the Node adapter away from casting a fake 101 object to `Response`, and removes socket casts from Node/Bun/Cloudflare upgrade paths.
- Narrows HMR client storage and rate limiting to the WebSocket operations they actually use.
- Adds focused adapter and HMR tests for the non-DOM upgrade signal.

## Verification

- `deno test --frozen --no-check --allow-all src/platform/adapters/base.test.ts src/platform/adapters/runtime/node/websocket-adapter.test.ts src/server/handlers/preview/hmr.handler.test.ts src/server/handlers/preview/hmr-message-router.test.ts src/server/handlers/preview/hmr-client-message.test.ts`
- `deno fmt --check` on focused touched files
- `deno lint` on focused touched files
- `deno check --frozen` on focused touched files
- `git diff --check`
- `deno task verify:quick`
- pre-push hook: format, lint, typecheck, unit suite (`2050 passed`, `0 failed`)

## Notes

- Native Bun and Cloudflare runtime handshakes remain covered by types/unit boundaries, not live runtime e2e in this local run.

Related: #2218
