### PR TITLE
Extract local proxy project resolution

### DIFF
--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -1,26 +1,12 @@
 import { TokenManager, type TokenScope } from "./token-manager.ts";
 import { type ParsedDomain, parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
 import type { TokenCache } from "./cache/types.ts";
-import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
-import { cwd, getEnv } from "#veryfront/platform/compat/process.ts";
-import { join } from "#veryfront/compat/path/index.ts";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
 import { injectContext, ProxySpanNames, withSpan } from "./tracing.ts";
 import { computeContentSourceId } from "#veryfront/cache/keys.ts";
 import { resolve as resolveContract } from "../extensions/contracts.ts";
 import type { AuthProvider } from "../extensions/auth/index.ts";
-import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
-import { registerLRUCache } from "#veryfront/cache";
-
-/**
- * Bounded cache for project paths discovered dynamically at request time
- * (slug → absolute path). Previously these were written into the per-handler
- * `localProjects` config map, which grew without bound. Using a registered
- * LRU keeps the working set capped and exposes it to cache monitoring, while
- * the static `config.localProjects` map continues to reflect *configured*
- * projects for the public `ProxyHandler.localProjects` surface.
- */
-const discoveredLocalProjects = new LRUCache<string, string>({ maxEntries: 100 });
-registerLRUCache("proxy-discovered-local-projects", discoveredLocalProjects);
+import { createLocalProjectResolver } from "./local-project-resolver.ts";
 
 /**
  * Cache the resolved AuthProvider at module scope so the proxy does not pay
@@ -337,59 +323,7 @@ function isProjectMember(
 export function createProxyHandler(options: ProxyHandlerOptions) {
   const { config, cache, logger } = options;
   const localProjects = config.localProjects ?? {};
-
-  const fs = createFileSystem();
-
-  async function findLocalProject(slug: string): Promise<string | undefined> {
-    const mapped = localProjects[slug];
-    if (mapped) return mapped;
-
-    const projectDirs = ["projects", "data/projects", "examples"];
-    const basePath = cwd();
-    // Key the discovery cache by the filesystem root as well as the slug: the
-    // cache is process-wide, so the same slug can resolve to different paths
-    // across handlers/workspaces or after a cwd change. Keying by basePath
-    // prevents a stale entry from one root being proxied for another.
-    const cacheKey = `${basePath} ${slug}`;
-
-    const cached = discoveredLocalProjects.get(cacheKey);
-    if (cached) return cached;
-
-    const candidatePaths = projectDirs.map((dir) => join(basePath, dir, slug));
-
-    const existingPaths = await Promise.all(
-      candidatePaths.map(async (projectPath) => {
-        try {
-          return (await fs.exists(projectPath)) ? projectPath : null;
-        } catch (_) {
-          /* expected: filesystem check may fail */
-          return null;
-        }
-      }),
-    );
-
-    for (const projectPath of existingPaths) {
-      if (!projectPath) continue;
-
-      try {
-        const [hasApp, hasPages, hasComponents] = await Promise.all([
-          fs.exists(join(projectPath, "app")),
-          fs.exists(join(projectPath, "pages")),
-          fs.exists(join(projectPath, "components")),
-        ]);
-
-        if (!hasApp && !hasPages && !hasComponents) continue;
-
-        discoveredLocalProjects.set(cacheKey, projectPath);
-        logger?.debug("Dynamically discovered local project", { slug, projectPath });
-        return projectPath;
-      } catch (_) {
-        // expected: filesystem check may fail
-      }
-    }
-
-    return undefined;
-  }
+  const localProjectResolver = createLocalProjectResolver({ localProjects, logger });
 
   const tokenManager = new TokenManager(
     {
@@ -652,7 +586,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
       };
     }
 
-    const localPath = projectSlug ? await findLocalProject(projectSlug) : undefined;
+    const localPath = projectSlug ? await localProjectResolver.find(projectSlug) : undefined;
     const isLocalProject = !!localPath;
 
     logger?.debug("Processing request", {

--- a/src/proxy/local-project-resolver.test.ts
+++ b/src/proxy/local-project-resolver.test.ts
@@ -1,0 +1,65 @@
+import { assertEquals } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
+import { createLocalProjectResolver } from "./local-project-resolver.ts";
+
+describe("local project resolver", () => {
+  it("uses configured local projects without filesystem discovery", async () => {
+    const existsCalls: string[] = [];
+    const resolver = createLocalProjectResolver({
+      localProjects: { storefront: "/configured/storefront" },
+      basePath: () => "/workspace",
+      fs: {
+        exists(path: string): Promise<boolean> {
+          existsCalls.push(path);
+          return Promise.resolve(false);
+        },
+      },
+    });
+
+    const path = await resolver.find("storefront");
+
+    assertEquals(path, "/configured/storefront");
+    assertEquals(existsCalls, []);
+  });
+
+  it("discovers projects with Veryfront source markers and caches per workspace", async () => {
+    const workspaceA = "/workspace-a";
+    const workspaceB = "/workspace-b";
+    const existingPaths = new Set([
+      `${workspaceA}/projects/shop`,
+      `${workspaceA}/projects/shop/app`,
+      `${workspaceB}/projects/shop`,
+    ]);
+    const existsCalls: string[] = [];
+    const fs = {
+      exists(path: string): Promise<boolean> {
+        existsCalls.push(path);
+        return Promise.resolve(existingPaths.has(path));
+      },
+    };
+
+    const resolverA = createLocalProjectResolver({
+      localProjects: {},
+      basePath: () => workspaceA,
+      fs,
+    });
+
+    const firstPath = await resolverA.find("shop");
+    existsCalls.length = 0;
+    const cachedPath = await resolverA.find("shop");
+
+    assertEquals(firstPath, `${workspaceA}/projects/shop`);
+    assertEquals(cachedPath, `${workspaceA}/projects/shop`);
+    assertEquals(existsCalls, []);
+
+    const resolverB = createLocalProjectResolver({
+      localProjects: {},
+      basePath: () => workspaceB,
+      fs,
+    });
+
+    const workspaceBPath = await resolverB.find("shop");
+
+    assertEquals(workspaceBPath, undefined);
+  });
+});

--- a/src/proxy/local-project-resolver.ts
+++ b/src/proxy/local-project-resolver.ts
@@ -1,0 +1,93 @@
+import { registerLRUCache } from "#veryfront/cache";
+import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { join } from "#veryfront/compat/path/index.ts";
+import { cwd } from "#veryfront/platform/compat/process.ts";
+import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
+
+interface LocalProjectFileSystem {
+  exists(path: string): Promise<boolean> | boolean;
+}
+
+interface LocalProjectLogger {
+  debug(message: string, extra?: Record<string, unknown>): void;
+}
+
+export interface LocalProjectResolverOptions {
+  localProjects?: Record<string, string>;
+  fs?: LocalProjectFileSystem;
+  basePath?: () => string;
+  logger?: LocalProjectLogger;
+}
+
+export interface LocalProjectResolver {
+  find(slug: string): Promise<string | undefined>;
+}
+
+/**
+ * Bounded cache for project paths discovered dynamically at request time
+ * (slug -> absolute path). Configured `localProjects` are never written here,
+ * so `ProxyHandler.localProjects` continues to expose only configured projects.
+ */
+const discoveredLocalProjects = new LRUCache<string, string>({ maxEntries: 100 });
+registerLRUCache("proxy-discovered-local-projects", discoveredLocalProjects);
+
+export function createLocalProjectResolver(
+  options: LocalProjectResolverOptions,
+): LocalProjectResolver {
+  const localProjects = options.localProjects ?? {};
+  const fs = options.fs ?? createFileSystem();
+  const getBasePath = options.basePath ?? cwd;
+  const logger = options.logger;
+
+  async function find(slug: string): Promise<string | undefined> {
+    const mapped = localProjects[slug];
+    if (mapped) return mapped;
+
+    const projectDirs = ["projects", "data/projects", "examples"];
+    const basePath = getBasePath();
+    // Key the discovery cache by the filesystem root as well as the slug: the
+    // cache is process-wide, so the same slug can resolve to different paths
+    // across handlers/workspaces or after a cwd change. Keying by basePath
+    // prevents a stale entry from one root being proxied for another.
+    const cacheKey = `${basePath}\0${slug}`;
+
+    const cached = discoveredLocalProjects.get(cacheKey);
+    if (cached) return cached;
+
+    const candidatePaths = projectDirs.map((dir) => join(basePath, dir, slug));
+
+    const existingPaths = await Promise.all(
+      candidatePaths.map(async (projectPath) => {
+        try {
+          return (await fs.exists(projectPath)) ? projectPath : null;
+        } catch (_) {
+          return null;
+        }
+      }),
+    );
+
+    for (const projectPath of existingPaths) {
+      if (!projectPath) continue;
+
+      try {
+        const [hasApp, hasPages, hasComponents] = await Promise.all([
+          fs.exists(join(projectPath, "app")),
+          fs.exists(join(projectPath, "pages")),
+          fs.exists(join(projectPath, "components")),
+        ]);
+
+        if (!hasApp && !hasPages && !hasComponents) continue;
+
+        discoveredLocalProjects.set(cacheKey, projectPath);
+        logger?.debug("Dynamically discovered local project", { slug, projectPath });
+        return projectPath;
+      } catch (_) {
+        // expected: filesystem check may fail
+      }
+    }
+
+    return undefined;
+  }
+
+  return { find };
+}


### PR DESCRIPTION
## Summary

- Extract local proxy project resolution from `createProxyHandler` into `src/proxy/local-project-resolver.ts`.
- Preserve configured `localProjects` precedence and keep dynamic discoveries in the bounded registered LRU cache.
- Add focused resolver tests for configured lookup, marker-based dynamic discovery, per-workspace cache isolation, and no filesystem work on cache hits.

## Verification

- `deno test --no-check --allow-all src/proxy/local-project-resolver.test.ts src/proxy/token-priority.test.ts src/proxy/handler.test.ts`
- `deno fmt --check src/proxy/handler.ts src/proxy/local-project-resolver.ts src/proxy/local-project-resolver.test.ts`
- `deno lint src/proxy/handler.ts src/proxy/local-project-resolver.ts src/proxy/local-project-resolver.test.ts`
- `deno check --frozen src/proxy/handler.ts src/proxy/local-project-resolver.ts src/proxy/local-project-resolver.test.ts`
- `deno test --no-check --allow-all src/proxy`
- `deno task verify:quick`
- pre-push hook: format, lint, typecheck, unit suite (`2051 passed`, `0 failed`)

## Notes

This is a narrow #2217 slice. It intentionally leaves token resolution, protected-environment access checks, and dashboard endpoint splitting for follow-up PRs.

Related: #2217
