### PR TITLE
Extract agent skill policy enforcement

### DIFF
--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -63,10 +63,15 @@ import {
   getToolResultError,
   isRecoverablePlaceholderToolCall,
   isStreamedToolCallIncomplete,
-  isToolResultPart,
   materializeStreamedToolCall,
   shouldContinueAfterStreamStep,
 } from "./tool-result-continuation.ts";
+import {
+  enforceSkillPolicy,
+  extractSkillPolicy,
+  hydrateActiveSkillStateFromMessages,
+  LOAD_SKILL_TOOL_ID,
+} from "./skill-policy-enforcement.ts";
 
 // Re-export from submodules
 export { closeSSEStream, generateMessageId, sendSSE } from "./sse-utils.ts";
@@ -123,27 +128,26 @@ export {
   shouldContinueAfterStreamStep,
   type StreamedToolCallMaterialization,
 } from "./tool-result-continuation.ts";
+export {
+  enforceSkillPolicy,
+  extractSkillPolicy,
+  type SkillPolicyResult,
+} from "./skill-policy-enforcement.ts";
 
 import { DEFAULT_MAX_TOKENS, DEFAULT_TEMPERATURE, getModelMaxOutputTokens } from "./constants.ts";
 import { closeSSEStream, generateMessageId, sendSSE } from "./sse-utils.ts";
 import { executeConfiguredTool, getAvailableTools, isDynamicTool } from "./tool-helpers.ts";
 import { accumulateUsage, getMaxSteps, normalizeInput } from "./input-utils.ts";
-import {
-  filterToolsForSkill,
-  isToolAllowedBySkill,
-  validateAllowedToolPatterns,
-} from "#veryfront/skill/allowed-tools.ts";
+import { filterToolsForSkill } from "#veryfront/skill/allowed-tools.ts";
 import { resolveConfiguredAgentModel, resolveRuntimeModel } from "./model-resolution.ts";
 import type { RuntimeGenerateToolResult } from "./runtime-tool-types.ts";
 import { stringifyToolError, throwIfAborted } from "./error-utils.ts";
 import {
   applySkillDelegationOverridesToToolInput,
   extractSkillDelegationOverrides,
-  type SkillDelegationOverrides,
 } from "./skill-delegation-overrides.ts";
 
 const logger = serverLogger.component("agent");
-const LOAD_SKILL_TOOL_ID = "load_skill";
 
 type RuntimeToolFilterConfig = AgentConfig & {
   __vfForwardedIntegrationToolDefs?: Array<
@@ -159,11 +163,6 @@ function isAbortError(error: unknown, abortSignal?: AbortSignal): boolean {
   return error instanceof DOMException && error.name === "AbortError";
 }
 
-function getSkillActivationRequiredError(toolName: string): string {
-  return `Tool "${toolName}" cannot run before load_skill succeeds in the same step. ` +
-    `Call "${LOAD_SKILL_TOOL_ID}" first to establish the active skill context.`;
-}
-
 function warnLocalToolSkipping(agentId: string, modelId: string): void {
   logger.warn(
     `Agent "${agentId}" has tools configured but is using local model "${modelId}". ` +
@@ -171,94 +170,6 @@ function warnLocalToolSkipping(agentId: string, modelId: string): void {
       "Set VERYFRONT_API_TOKEN and VERYFRONT_PROJECT_SLUG, or configure " +
       "OPENAI_API_KEY, ANTHROPIC_API_KEY, or GOOGLE_API_KEY for full tool support.",
   );
-}
-
-function hydrateActiveSkillStateFromMessages(
-  messages: readonly Message[],
-): {
-  activeSkillPolicy: string[] | undefined;
-  activeSkillDelegationOverrides: SkillDelegationOverrides | undefined;
-} {
-  let activeSkillPolicy: string[] | undefined;
-  let activeSkillDelegationOverrides: SkillDelegationOverrides | undefined;
-
-  for (const message of messages) {
-    for (const part of message.parts) {
-      if (!isToolResultPart(part) || part.toolName !== LOAD_SKILL_TOOL_ID) continue;
-      activeSkillPolicy = extractSkillPolicy(part.result);
-      activeSkillDelegationOverrides = extractSkillDelegationOverrides(part.result);
-    }
-  }
-
-  return { activeSkillPolicy, activeSkillDelegationOverrides };
-}
-
-/**
- * Extract and validate the skill policy from a load_skill tool result.
- * Returns `[]` (no tools allowed) for invalid/missing policies instead of
- * `undefined` (no restrictions), preventing accidental policy bypass.
- */
-export function extractSkillPolicy(result: unknown): string[] | undefined {
-  if (!result || typeof result !== "object") return undefined;
-  const skillResult = result as { allowedTools?: unknown };
-
-  // No allowedTools key means the skill has no restrictions
-  if (!("allowedTools" in skillResult) || skillResult.allowedTools === undefined) {
-    return undefined;
-  }
-
-  // Validate the shape: must be a string array
-  const raw = skillResult.allowedTools;
-  if (!Array.isArray(raw) || !raw.every((v) => typeof v === "string")) {
-    // Invalid shape — fail closed (empty policy = no tools allowed)
-    logger.warn(
-      "load_skill returned invalid allowedTools; falling back to empty policy (no tools)",
-    );
-    return [];
-  }
-
-  // Validate each pattern against the regex
-  try {
-    return validateAllowedToolPatterns(raw);
-  } catch (error) {
-    logger.warn(
-      "load_skill returned invalid tool patterns; falling back to empty policy (no tools)",
-      { error },
-    );
-    return [];
-  }
-}
-
-/** Result of skill policy enforcement for a single tool call */
-type SkillPolicyResult =
-  | { allowed: true }
-  | { allowed: false; error: string };
-
-/**
- * Enforce skill policy on a single tool call.
- * Shared between generate() and stream() paths.
- */
-export function enforceSkillPolicy(
-  toolName: string,
-  activeSkillPolicy: string[] | undefined,
-  mustLoadSkillFirst: boolean,
-): SkillPolicyResult {
-  // Must load skill before other tools
-  if (mustLoadSkillFirst && toolName !== LOAD_SKILL_TOOL_ID) {
-    return { allowed: false, error: getSkillActivationRequiredError(toolName) };
-  }
-
-  // Check tool allowed by active skill policy (Layer 2: execution-time)
-  if (activeSkillPolicy && !isToolAllowedBySkill(toolName, activeSkillPolicy)) {
-    return {
-      allowed: false,
-      error: `Tool "${toolName}" is not allowed by the active skill policy. Allowed: ${
-        activeSkillPolicy.join(", ")
-      }`,
-    };
-  }
-
-  return { allowed: true };
 }
 
 function getRuntimeAllowedRemoteTools(config: AgentConfig): string[] | undefined {

--- a/src/agent/runtime/skill-policy-enforcement.ts
+++ b/src/agent/runtime/skill-policy-enforcement.ts
@@ -1,0 +1,92 @@
+import type { Message } from "../types.ts";
+import { serverLogger } from "#veryfront/utils";
+import {
+  isToolAllowedBySkill,
+  validateAllowedToolPatterns,
+} from "#veryfront/skill/allowed-tools.ts";
+import { isToolResultPart } from "./tool-result-continuation.ts";
+import {
+  extractSkillDelegationOverrides,
+  type SkillDelegationOverrides,
+} from "./skill-delegation-overrides.ts";
+
+const logger = serverLogger.component("agent");
+
+export const LOAD_SKILL_TOOL_ID = "load_skill";
+
+function getSkillActivationRequiredError(toolName: string): string {
+  return `Tool "${toolName}" cannot run before load_skill succeeds in the same step. ` +
+    `Call "${LOAD_SKILL_TOOL_ID}" first to establish the active skill context.`;
+}
+
+export function hydrateActiveSkillStateFromMessages(
+  messages: readonly Message[],
+): {
+  activeSkillPolicy: string[] | undefined;
+  activeSkillDelegationOverrides: SkillDelegationOverrides | undefined;
+} {
+  let activeSkillPolicy: string[] | undefined;
+  let activeSkillDelegationOverrides: SkillDelegationOverrides | undefined;
+
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (!isToolResultPart(part) || part.toolName !== LOAD_SKILL_TOOL_ID) continue;
+      activeSkillPolicy = extractSkillPolicy(part.result);
+      activeSkillDelegationOverrides = extractSkillDelegationOverrides(part.result);
+    }
+  }
+
+  return { activeSkillPolicy, activeSkillDelegationOverrides };
+}
+
+export function extractSkillPolicy(result: unknown): string[] | undefined {
+  if (!result || typeof result !== "object") return undefined;
+  const skillResult = result as { allowedTools?: unknown };
+
+  if (!("allowedTools" in skillResult) || skillResult.allowedTools === undefined) {
+    return undefined;
+  }
+
+  const raw = skillResult.allowedTools;
+  if (!Array.isArray(raw) || !raw.every((v) => typeof v === "string")) {
+    logger.warn(
+      "load_skill returned invalid allowedTools; falling back to empty policy (no tools)",
+    );
+    return [];
+  }
+
+  try {
+    return validateAllowedToolPatterns(raw);
+  } catch (error) {
+    logger.warn(
+      "load_skill returned invalid tool patterns; falling back to empty policy (no tools)",
+      { error },
+    );
+    return [];
+  }
+}
+
+export type SkillPolicyResult =
+  | { allowed: true }
+  | { allowed: false; error: string };
+
+export function enforceSkillPolicy(
+  toolName: string,
+  activeSkillPolicy: string[] | undefined,
+  mustLoadSkillFirst: boolean,
+): SkillPolicyResult {
+  if (mustLoadSkillFirst && toolName !== LOAD_SKILL_TOOL_ID) {
+    return { allowed: false, error: getSkillActivationRequiredError(toolName) };
+  }
+
+  if (activeSkillPolicy && !isToolAllowedBySkill(toolName, activeSkillPolicy)) {
+    return {
+      allowed: false,
+      error: `Tool "${toolName}" is not allowed by the active skill policy. Allowed: ${
+        activeSkillPolicy.join(", ")
+      }`,
+    };
+  }
+
+  return { allowed: true };
+}

--- a/src/agent/runtime/skill-policy.test.ts
+++ b/src/agent/runtime/skill-policy.test.ts
@@ -1,7 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { enforceSkillPolicy, extractSkillPolicy } from "./index.ts";
+import {
+  enforceSkillPolicy,
+  extractSkillPolicy,
+  hydrateActiveSkillStateFromMessages,
+} from "./skill-policy-enforcement.ts";
+import type { Message } from "../types.ts";
 
 describe("src/agent/runtime skill policy helpers", () => {
   describe("extractSkillPolicy", () => {
@@ -129,6 +134,62 @@ describe("src/agent/runtime skill policy helpers", () => {
       assertEquals(enforceSkillPolicy("Read", undefined, false), { allowed: true });
       assertEquals(enforceSkillPolicy("Write", undefined, false), { allowed: true });
       assertEquals(enforceSkillPolicy("Bash", undefined, false), { allowed: true });
+    });
+  });
+
+  describe("hydrateActiveSkillStateFromMessages", () => {
+    it("hydrates the latest load_skill policy and delegation overrides from tool history", () => {
+      const messages: Message[] = [
+        {
+          id: "tool_load_skill_old",
+          role: "tool",
+          parts: [{
+            type: "tool-result",
+            toolCallId: "load_skill_old",
+            toolName: "load_skill",
+            result: {
+              allowedTools: ["Read"],
+              model: "anthropic/claude-sonnet-4-5",
+              thinking: true,
+              maxSteps: 4,
+            },
+          }],
+        },
+        {
+          id: "tool_other",
+          role: "tool",
+          parts: [{
+            type: "tool-result",
+            toolCallId: "other_tool",
+            toolName: "read_file",
+            result: { allowedTools: ["Bash"] },
+          }],
+        },
+        {
+          id: "tool_load_skill_new",
+          role: "tool",
+          parts: [{
+            type: "tool-result",
+            toolCallId: "load_skill_new",
+            toolName: "load_skill",
+            result: {
+              allowedTools: ["Write"],
+              model: "openai/gpt-5.1",
+              thinking: false,
+              maxSteps: 8,
+            },
+          }],
+        },
+      ];
+
+      const hydrated = hydrateActiveSkillStateFromMessages(messages);
+
+      assertEquals(hydrated.activeSkillPolicy, ["Write"]);
+      assertEquals(hydrated.activeSkillDelegationOverrides, {
+        model: "openai/gpt-5.1",
+        thinking: false,
+        maxSteps: 8,
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- Extract skill policy parsing, enforcement, and active-skill hydration from `src/agent/runtime/index.ts` into `src/agent/runtime/skill-policy-enforcement.ts`.
- Keep the existing runtime index exports stable for `enforceSkillPolicy`, `extractSkillPolicy`, and `SkillPolicyResult`.
- Add regression coverage for loading the latest `load_skill` policy and delegation overrides from tool history.

## Behavior notes
- This is a #2216 decomposition slice. No runtime behavior change is intended.
- The new hydration helper intentionally does not add a role filter because the old inline helper scanned all message objects for matching tool results.

## Verification
- `deno test --no-check --allow-all src/agent/runtime/skill-policy.test.ts`
- `deno test --no-check --allow-all src/agent/runtime/skill-policy.test.ts src/agent/runtime/refresh.test.ts src/agent/runtime/load-skill-tool.test.ts`
- `deno test --no-check --allow-all src/agent/runtime`
- `deno fmt --check src/agent/runtime/index.ts src/agent/runtime/skill-policy-enforcement.ts src/agent/runtime/skill-policy.test.ts`
- `deno lint src/agent/runtime/index.ts src/agent/runtime/skill-policy-enforcement.ts src/agent/runtime/skill-policy.test.ts`
- `deno check --frozen src/agent/runtime/index.ts src/agent/runtime/skill-policy-enforcement.ts src/agent/runtime/skill-policy.test.ts`
- `deno task verify:quick`
- Pre-push hook: format, lint, typecheck, unit suite (`2051 passed`, `0 failed`)

Part of #2216.
