### PR TITLE
Extract runtime tool config helpers

### DIFF
--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -37,10 +37,7 @@ import {
 import { convertToTextGenerationRuntimeMessages } from "./text-generation-runtime-message-converter.ts";
 import { convertToolsToRuntimeTools } from "./model-tool-converter.ts";
 import { resolveProviderOptionsWithDefaults } from "./default-provider-options.ts";
-import {
-  getRuntimeRemoteToolSources,
-  type RuntimeRemoteToolConfig,
-} from "./mcp-server-tool-sources.ts";
+import { getRuntimeRemoteToolSources } from "./mcp-server-tool-sources.ts";
 import {
   createStreamState,
   processStream,
@@ -50,7 +47,7 @@ import { repairToolCall } from "./repair-tool-call.ts";
 import { MiddlewareChain } from "../middleware/chain.ts";
 import { AGENT_DEFAULTS } from "./defaults.ts";
 import { tryGetCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
-import type { ToolDefinition, ToolExecutionContext } from "#veryfront/tool";
+import type { ToolExecutionContext } from "#veryfront/tool";
 import { isLocalModelRuntime } from "#veryfront/provider/runtime-inspection.ts";
 import { generateText, streamText } from "#veryfront/runtime/runtime-bridge.ts";
 import {
@@ -72,6 +69,11 @@ import {
   hydrateActiveSkillStateFromMessages,
   LOAD_SKILL_TOOL_ID,
 } from "./skill-policy-enforcement.ts";
+import {
+  getRuntimeAllowedRemoteTools,
+  getRuntimeForwardedIntegrationToolDefs,
+  getRuntimeProviderTools,
+} from "./runtime-tool-config.ts";
 
 // Re-export from submodules
 export { closeSSEStream, generateMessageId, sendSSE } from "./sse-utils.ts";
@@ -149,12 +151,6 @@ import {
 
 const logger = serverLogger.component("agent");
 
-type RuntimeToolFilterConfig = AgentConfig & {
-  __vfForwardedIntegrationToolDefs?: Array<
-    { name: string; description: string; parameters: Record<string, unknown> }
-  >;
-} & RuntimeRemoteToolConfig;
-
 function isAbortError(error: unknown, abortSignal?: AbortSignal): boolean {
   if (abortSignal?.aborted && error === abortSignal.reason) {
     return true;
@@ -170,50 +166,6 @@ function warnLocalToolSkipping(agentId: string, modelId: string): void {
       "Set VERYFRONT_API_TOKEN and VERYFRONT_PROJECT_SLUG, or configure " +
       "OPENAI_API_KEY, ANTHROPIC_API_KEY, or GOOGLE_API_KEY for full tool support.",
   );
-}
-
-function getRuntimeAllowedRemoteTools(config: AgentConfig): string[] | undefined {
-  const configWithRuntimeFilters = config as RuntimeToolFilterConfig;
-  if (!Object.hasOwn(configWithRuntimeFilters, "__vfAllowedRemoteTools")) {
-    return undefined;
-  }
-  const raw = configWithRuntimeFilters.__vfAllowedRemoteTools;
-  if (!Array.isArray(raw)) {
-    return [];
-  }
-  return raw.every((toolName) => typeof toolName === "string") ? raw : [];
-}
-
-function getRuntimeProviderTools(config: AgentConfig): string[] {
-  const raw = config.providerTools;
-  if (!Array.isArray(raw)) {
-    return [];
-  }
-  return raw.every((toolName) => typeof toolName === "string") ? raw : [];
-}
-
-function getRuntimeForwardedIntegrationToolDefs(
-  config: AgentConfig,
-): ToolDefinition[] | undefined {
-  const configWithFilters = config as RuntimeToolFilterConfig;
-  const raw = configWithFilters.__vfForwardedIntegrationToolDefs;
-  if (!Array.isArray(raw) || raw.length === 0) return undefined;
-  return raw
-    .filter(
-      (def): def is { name: string; description: string; parameters: Record<string, unknown> } =>
-        typeof def === "object" &&
-        def !== null &&
-        typeof def.name === "string" &&
-        typeof def.description === "string",
-    )
-    .map((def) => ({
-      name: def.name,
-      description: def.description,
-      parameters: typeof def.parameters === "object" && def.parameters !== null &&
-          !Array.isArray(def.parameters)
-        ? def.parameters
-        : { type: "object", properties: {} },
-    }));
 }
 
 type ResolvedModelTransport = {

--- a/src/agent/runtime/runtime-tool-config.test.ts
+++ b/src/agent/runtime/runtime-tool-config.test.ts
@@ -1,0 +1,112 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { AgentConfig } from "../types.ts";
+import {
+  getRuntimeAllowedRemoteTools,
+  getRuntimeForwardedIntegrationToolDefs,
+  getRuntimeProviderTools,
+} from "./runtime-tool-config.ts";
+
+function runtimeConfig(extra: Record<string, unknown> = {}): AgentConfig {
+  return {
+    model: "auto",
+    system: "Test runtime tool config.",
+    ...extra,
+  } as AgentConfig;
+}
+
+describe("agent/runtime-tool-config", () => {
+  describe("getRuntimeAllowedRemoteTools", () => {
+    it("distinguishes absent allow-lists from invalid configured allow-lists", () => {
+      assertEquals(getRuntimeAllowedRemoteTools(runtimeConfig()), undefined);
+      assertEquals(
+        getRuntimeAllowedRemoteTools(runtimeConfig({
+          __vfAllowedRemoteTools: "search",
+        })),
+        [],
+      );
+    });
+
+    it("preserves valid remote tool allow-lists and fails closed for mixed arrays", () => {
+      assertEquals(
+        getRuntimeAllowedRemoteTools(runtimeConfig({
+          __vfAllowedRemoteTools: ["search_docs", "read_file"],
+        })),
+        ["search_docs", "read_file"],
+      );
+      assertEquals(
+        getRuntimeAllowedRemoteTools(runtimeConfig({
+          __vfAllowedRemoteTools: ["search_docs", 42],
+        })),
+        [],
+      );
+    });
+  });
+
+  describe("getRuntimeProviderTools", () => {
+    it("returns provider-native tool names only when the whole list is valid", () => {
+      assertEquals(getRuntimeProviderTools(runtimeConfig()), []);
+      assertEquals(
+        getRuntimeProviderTools(runtimeConfig({
+          providerTools: ["web_search", "web_fetch"],
+        })),
+        ["web_search", "web_fetch"],
+      );
+      assertEquals(
+        getRuntimeProviderTools(runtimeConfig({
+          providerTools: ["web_search", 42],
+        })),
+        [],
+      );
+    });
+  });
+
+  describe("getRuntimeForwardedIntegrationToolDefs", () => {
+    it("normalizes forwarded integration definitions and filters malformed entries", () => {
+      assertEquals(
+        getRuntimeForwardedIntegrationToolDefs(runtimeConfig({
+          __vfForwardedIntegrationToolDefs: [
+            {
+              name: "search_docs",
+              description: "Search docs",
+              parameters: { type: "object", properties: { query: { type: "string" } } },
+            },
+            {
+              name: "bad_params",
+              description: "Bad params",
+              parameters: ["not", "an", "object"],
+            },
+            {
+              name: 42,
+              description: "Bad name",
+              parameters: { type: "object" },
+            },
+          ],
+        })),
+        [
+          {
+            name: "search_docs",
+            description: "Search docs",
+            parameters: { type: "object", properties: { query: { type: "string" } } },
+          },
+          {
+            name: "bad_params",
+            description: "Bad params",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      );
+    });
+
+    it("returns undefined when no forwarded definitions are present", () => {
+      assertEquals(getRuntimeForwardedIntegrationToolDefs(runtimeConfig()), undefined);
+      assertEquals(
+        getRuntimeForwardedIntegrationToolDefs(runtimeConfig({
+          __vfForwardedIntegrationToolDefs: [],
+        })),
+        undefined,
+      );
+    });
+  });
+});

--- a/src/agent/runtime/runtime-tool-config.ts
+++ b/src/agent/runtime/runtime-tool-config.ts
@@ -1,0 +1,53 @@
+import type { ToolDefinition } from "#veryfront/tool";
+import type { AgentConfig } from "../types.ts";
+import type { RuntimeRemoteToolConfig } from "./mcp-server-tool-sources.ts";
+
+export type RuntimeToolFilterConfig = AgentConfig & {
+  __vfForwardedIntegrationToolDefs?: Array<
+    { name: string; description: string; parameters: Record<string, unknown> }
+  >;
+} & RuntimeRemoteToolConfig;
+
+export function getRuntimeAllowedRemoteTools(config: AgentConfig): string[] | undefined {
+  const configWithRuntimeFilters = config as RuntimeToolFilterConfig;
+  if (!Object.hasOwn(configWithRuntimeFilters, "__vfAllowedRemoteTools")) {
+    return undefined;
+  }
+  const raw = configWithRuntimeFilters.__vfAllowedRemoteTools;
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw.every((toolName) => typeof toolName === "string") ? raw : [];
+}
+
+export function getRuntimeProviderTools(config: AgentConfig): string[] {
+  const raw = config.providerTools;
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw.every((toolName) => typeof toolName === "string") ? raw : [];
+}
+
+export function getRuntimeForwardedIntegrationToolDefs(
+  config: AgentConfig,
+): ToolDefinition[] | undefined {
+  const configWithFilters = config as RuntimeToolFilterConfig;
+  const raw = configWithFilters.__vfForwardedIntegrationToolDefs;
+  if (!Array.isArray(raw) || raw.length === 0) return undefined;
+  return raw
+    .filter(
+      (def): def is { name: string; description: string; parameters: Record<string, unknown> } =>
+        typeof def === "object" &&
+        def !== null &&
+        typeof def.name === "string" &&
+        typeof def.description === "string",
+    )
+    .map((def) => ({
+      name: def.name,
+      description: def.description,
+      parameters: typeof def.parameters === "object" && def.parameters !== null &&
+          !Array.isArray(def.parameters)
+        ? def.parameters
+        : { type: "object", properties: {} },
+    }));
+}


### PR DESCRIPTION
## Summary

Part of #2216.

This extracts runtime tool configuration normalization out of `src/agent/runtime/index.ts` into `src/agent/runtime/runtime-tool-config.ts`:

- remote tool allow-list parsing
- provider-native tool name parsing
- forwarded integration tool definition normalization

The extraction preserves the existing fail-closed behavior for malformed configured arrays while keeping an absent remote allow-list distinct from an invalid configured allow-list.

## Verification

- `deno test --no-check --allow-all src/agent/runtime/runtime-tool-config.test.ts`
- `deno test --no-check --allow-all src/agent/runtime/tool-helpers.test.ts src/agent/runtime/model-tool-converter.test.ts`
- `deno fmt src/agent/runtime/index.ts src/agent/runtime/runtime-tool-config.ts src/agent/runtime/runtime-tool-config.test.ts`
- `deno fmt --check src/agent/runtime/index.ts src/agent/runtime/runtime-tool-config.ts src/agent/runtime/runtime-tool-config.test.ts`
- `deno check --frozen src/agent/runtime/index.ts src/agent/runtime/runtime-tool-config.ts src/agent/runtime/runtime-tool-config.test.ts`
- `deno lint src/agent/runtime/index.ts src/agent/runtime/runtime-tool-config.ts src/agent/runtime/runtime-tool-config.test.ts`
- `deno test --no-check --allow-all src/agent/runtime`
- `deno task verify:quick`
- `git diff --check`
- `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net cli/router.test.ts`

Note: the local pre-push hook was interrupted after the full parallel unit suite stopped producing output for several minutes while reporting `cli/router helpers` as running. The isolated `cli/router.test.ts` command passes in 774ms, and hosted CI should be treated as the full-suite authority for this branch.
