### PR TITLE
Constrain project worker env access to configured keys

### DIFF
--- a/src/security/sandbox/project-worker.test.ts
+++ b/src/security/sandbox/project-worker.test.ts
@@ -3,6 +3,7 @@ import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { isDeno } from "#veryfront/platform/compat/runtime.ts";
 import { ProjectWorker } from "./project-worker.ts";
+import { buildWorkerPermissions } from "./worker-permissions.ts";
 import type { WorkerPermissions } from "./worker-permissions.ts";
 
 const testSuite = isDeno ? describe : describe.skip;
@@ -21,7 +22,7 @@ const REAL_WORKER_PERMISSIONS: WorkerPermissions = {
   read: true,
   write: false,
   net: false,
-  env: true,
+  env: [],
   run: false,
   ffi: false,
   sys: false,
@@ -222,7 +223,9 @@ testSuite("ProjectWorker - real worker request isolation", () => {
 
     const worker = new ProjectWorker({
       projectId: "test-env-overlay-scope",
-      permissions: REAL_WORKER_PERMISSIONS,
+      permissions: buildWorkerPermissions([projectDir], {
+        projectEnvKeys: ["VERYFRONT_TEST_TENANT_SECRET"],
+      }),
       requestTimeoutMs: 10_000,
     });
 
@@ -278,6 +281,91 @@ testSuite("ProjectWorker - real worker request isolation", () => {
     }
   });
 
+  it("denies host env secrets while allowing project env keys", async () => {
+    const projectDir = await Deno.makeTempDir();
+    const modulePath = await Deno.makeTempFile({ dir: projectDir, suffix: ".mjs" });
+    const hostKey = "VERYFRONT_TEST_HOST_ONLY_SECRET";
+    const projectKey = "VERYFRONT_TEST_PROJECT_ALLOWED_SECRET";
+    const previousHostSecret = Deno.env.get(hostKey);
+
+    await Deno.writeTextFile(
+      modulePath,
+      `
+        export function GET() {
+          let hostValue = null;
+          let hostDenied = false;
+          try {
+            hostValue = Deno.env.get(${JSON.stringify(hostKey)}) ?? null;
+          } catch {
+            hostDenied = true;
+          }
+
+          let objectHostValue = null;
+          let objectDenied = false;
+          try {
+            objectHostValue = Deno.env.toObject()[${JSON.stringify(hostKey)}] ?? null;
+          } catch {
+            objectDenied = true;
+          }
+
+          return Response.json({
+            hostValue,
+            hostDenied,
+            objectHostValue,
+            objectDenied,
+            projectValue: Deno.env.get(${JSON.stringify(projectKey)}) ?? null,
+          });
+        }
+      `,
+    );
+
+    Deno.env.set(hostKey, "host-secret");
+
+    const worker = new ProjectWorker({
+      projectId: "test-env-allowlist",
+      permissions: buildWorkerPermissions([projectDir], {
+        projectEnvKeys: [projectKey],
+      }),
+      requestTimeoutMs: 10_000,
+    });
+
+    worker.start();
+    try {
+      const response = await worker.execute({
+        type: "execute-app-route",
+        id: "env-allowlist",
+        modulePath,
+        method: "GET",
+        request: {
+          url: "http://localhost/api/env",
+          method: "GET",
+          headers: [],
+          body: null,
+        },
+        params: {},
+        projectDir,
+        projectEnv: { [projectKey]: "project-secret" },
+      });
+
+      assertEquals(response.type, "result");
+      if (response.type !== "result") throw new Error("expected result response");
+
+      const body = JSON.parse(new TextDecoder().decode(response.response.body ?? new Uint8Array()));
+      assertEquals(body.hostValue, null);
+      assertEquals(body.hostDenied, true);
+      assertEquals(body.objectHostValue, null);
+      assertEquals(body.projectValue, "project-secret");
+    } finally {
+      worker.terminate();
+      if (previousHostSecret === undefined) {
+        Deno.env.delete(hostKey);
+      } else {
+        Deno.env.set(hostKey, previousHostSecret);
+      }
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
   it("rejects direct Deno file reads outside scoped worker read permissions", async () => {
     const projectDir = await Deno.makeTempDir();
     const outsideDir = await Deno.makeTempDir();
@@ -297,7 +385,7 @@ testSuite("ProjectWorker - real worker request isolation", () => {
 
     const worker = new ProjectWorker({
       projectId: "test-direct-deno-read-denied",
-      permissions: { ...REAL_WORKER_PERMISSIONS, read: [projectDir] },
+      permissions: buildWorkerPermissions([projectDir]),
       requestTimeoutMs: 10_000,
     });
 

--- a/src/security/sandbox/worker-permissions.test.ts
+++ b/src/security/sandbox/worker-permissions.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { buildWorkerPermissions } from "./worker-permissions.ts";
+import { buildWorkerPermissions, FRAMEWORK_WORKER_ENV_ALLOWLIST } from "./worker-permissions.ts";
 
 describe("worker-permissions", () => {
   it("builds permissions with read paths", () => {
@@ -9,10 +9,26 @@ describe("worker-permissions", () => {
     assertEquals(perms.read, ["/tmp/project-a", "/cache"]);
     assertEquals(perms.write, false);
     assertEquals(perms.net, true);
-    assertEquals(perms.env, true);
+    assertEquals(perms.env, [...FRAMEWORK_WORKER_ENV_ALLOWLIST]);
     assertEquals(perms.run, false);
     assertEquals(perms.ffi, false);
     assertEquals(perms.sys, false);
+  });
+
+  it("allows only framework and project env keys", () => {
+    const perms = buildWorkerPermissions(["/tmp/project-a"], {
+      projectEnvKeys: [
+        "VERYFRONT_TEST_PROJECT_SECRET",
+        "NODE_ENV",
+        "",
+        "  VERYFRONT_TEST_PROJECT_SECRET  ",
+      ],
+    });
+
+    assertEquals(perms.env, [
+      ...FRAMEWORK_WORKER_ENV_ALLOWLIST,
+      "VERYFRONT_TEST_PROJECT_SECRET",
+    ]);
   });
 
   it("builds permissions with empty read paths", () => {
@@ -35,7 +51,7 @@ describe("worker-permissions", () => {
     assertEquals(perms.run, false);
     assertEquals(perms.ffi, false);
     assertEquals(perms.sys, false);
-    assertEquals(perms.env, true);
+    assertEquals(perms.env, [...FRAMEWORK_WORKER_ENV_ALLOWLIST]);
   });
 
   it("always allows net for data fetchers", () => {

--- a/src/security/sandbox/worker-permissions.ts
+++ b/src/security/sandbox/worker-permissions.ts
@@ -23,7 +23,7 @@ export interface WorkerPermissions {
   read: string[] | boolean;
   write: boolean;
   net: boolean;
-  env: boolean;
+  env: string[] | boolean;
   run: boolean;
   ffi: boolean;
   sys: boolean;
@@ -34,7 +34,20 @@ interface WorkerPermissionOptions {
   isCompiledBinary?: boolean;
   /** Override for tests that need deterministic compiled-binary support paths. */
   compiledReadPaths?: string[];
+  /** Project-configured env keys that route code may read inside the worker. */
+  projectEnvKeys?: Iterable<string | undefined>;
 }
+
+export const FRAMEWORK_WORKER_ENV_ALLOWLIST = [
+  "NODE_ENV",
+  "DENO_ENV",
+  "VERYFRONT_ENV",
+  "LOG_LEVEL",
+  "LOG_FORMAT",
+  "NO_COLOR",
+  "FORCE_COLOR",
+  "CI",
+] as const;
 
 // Cache compiled binary check — Deno.execPath() is a syscall that never changes at runtime
 const _isCompiledBinary = (() => {
@@ -59,6 +72,26 @@ function normalizeReadPaths(paths: Array<string | undefined>): string[] {
   return [...unique];
 }
 
+function normalizeEnvKeys(keys: Iterable<string | undefined>): string[] {
+  const unique = new Set<string>();
+  for (const key of keys) {
+    if (!key) continue;
+    const trimmed = key.trim();
+    if (!trimmed) continue;
+    unique.add(trimmed);
+  }
+  return [...unique];
+}
+
+export function buildWorkerEnvAllowlist(
+  projectEnvKeys: Iterable<string | undefined> = [],
+): string[] {
+  return normalizeEnvKeys([
+    ...FRAMEWORK_WORKER_ENV_ALLOWLIST,
+    ...projectEnvKeys,
+  ]);
+}
+
 function getDefaultCompiledReadPaths(): string[] {
   return normalizeReadPaths([
     getFrameworkRootFromMeta(import.meta.url),
@@ -75,7 +108,7 @@ function getDefaultCompiledReadPaths(): string[] {
  * - read: restricted to the project temp dir (transformed modules) and cache dirs
  * - write: denied (workers produce output via postMessage, not filesystem)
  * - net: allowed (data fetchers and API routes may call external APIs)
- * - env: allowed (user code reads API keys and config from environment)
+ * - env: restricted to framework keys and the project's configured env keys
  * - run: denied (no subprocess spawning from user code)
  * - ffi: denied (no native code from user code)
  * - sys: denied (no system info access from user code)
@@ -86,6 +119,7 @@ export function buildWorkerPermissions(
 ): WorkerPermissions {
   const isCompiledBinary = options.isCompiledBinary ?? _isCompiledBinary;
   const normalizedReadPaths = normalizeReadPaths(readPaths);
+  const env = buildWorkerEnvAllowlist(options.projectEnvKeys);
 
   if (isCompiledBinary) {
     const compiledReadPaths = options.compiledReadPaths ?? getDefaultCompiledReadPaths();
@@ -94,7 +128,7 @@ export function buildWorkerPermissions(
       read: scopedReadPaths.length > 0 ? scopedReadPaths : false,
       write: false,
       net: true,
-      env: true,
+      env,
       run: false,
       ffi: false,
       sys: false,
@@ -105,7 +139,7 @@ export function buildWorkerPermissions(
     read: normalizedReadPaths.length > 0 ? normalizedReadPaths : false,
     write: false,
     net: true,
-    env: true,
+    env,
     run: false,
     ffi: false,
     sys: false,

--- a/src/security/sandbox/worker-pool.test.ts
+++ b/src/security/sandbox/worker-pool.test.ts
@@ -50,6 +50,16 @@ testSuite("WorkerPool", () => {
     assertEquals(stats.poolSize, 1);
   });
 
+  it("recreates a worker when the project env key set changes", () => {
+    const w1 = pool.getOrCreateWorker("project-a", [], ["PROJECT_SECRET_A"]);
+    const w2 = pool.getOrCreateWorker("project-a", [], ["PROJECT_SECRET_A"]);
+    const w3 = pool.getOrCreateWorker("project-a", [], ["PROJECT_SECRET_B"]);
+
+    assertEquals(w1, w2);
+    assert(w1 !== w3, "worker permissions must be rebuilt for changed env keys");
+    assertEquals(pool.getStats().poolSize, 1);
+  });
+
   it("creates separate workers for different projects", () => {
     pool.getOrCreateWorker("project-a", []);
     pool.getOrCreateWorker("project-b", []);
@@ -117,6 +127,7 @@ testSuite("WorkerPool", () => {
           method: "GET",
           request: { url: "http://localhost/api/test", method: "GET", headers: [], body: null },
           params: {},
+          projectDir: "/allowed/path",
         }),
       VeryfrontError,
       "outside allowed read paths",

--- a/src/security/sandbox/worker-pool.ts
+++ b/src/security/sandbox/worker-pool.ts
@@ -13,7 +13,7 @@ import { getEnvBoolean, getEnvNumber, unrefTimer } from "#veryfront/platform/com
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { SECURITY_VIOLATION } from "#veryfront/errors";
 import { ProjectWorker } from "./project-worker.ts";
-import { buildWorkerPermissions } from "./worker-permissions.ts";
+import { buildWorkerEnvAllowlist, buildWorkerPermissions } from "./worker-permissions.ts";
 import type { WorkerPoolConfig, WorkerRequest, WorkerResponse } from "./worker-types.ts";
 import { DEFAULT_WORKER_POOL_CONFIG } from "./worker-types.ts";
 
@@ -23,6 +23,23 @@ interface PoolEntry {
   worker: ProjectWorker;
   lastAccessedAt: number;
   createdAt: number;
+  projectEnvKeys: string[];
+}
+
+function extractProjectEnvKeys(request: WorkerRequest): string[] {
+  if (!("projectEnv" in request) || !request.projectEnv) return [];
+  return Object.keys(request.projectEnv);
+}
+
+function normalizeProjectEnvKeys(keys: Iterable<string | undefined>): string[] {
+  const frameworkEnvKeyCount = buildWorkerEnvAllowlist([]).length;
+  return buildWorkerEnvAllowlist(keys).slice(frameworkEnvKeyCount);
+}
+
+function sameEnvKeySet(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false;
+  const rightSet = new Set(right);
+  return left.every((key) => rightSet.has(key));
 }
 
 export class WorkerPool {
@@ -42,17 +59,27 @@ export class WorkerPool {
   /**
    * Get or create a worker for the given project.
    */
-  getOrCreateWorker(projectId: string, readPaths: string[]): ProjectWorker {
+  getOrCreateWorker(
+    projectId: string,
+    readPaths: string[],
+    projectEnvKeys: Iterable<string | undefined> = [],
+  ): ProjectWorker {
+    const normalizedProjectEnvKeys = normalizeProjectEnvKeys(projectEnvKeys);
     const existing = this.pool.get(projectId);
     if (
       existing && existing.worker.status !== "crashed" && existing.worker.status !== "terminated"
     ) {
-      existing.lastAccessedAt = Date.now();
-      return existing.worker;
+      if (!sameEnvKeySet(existing.projectEnvKeys, normalizedProjectEnvKeys)) {
+        existing.worker.terminate();
+        this.pool.delete(projectId);
+      } else {
+        existing.lastAccessedAt = Date.now();
+        return existing.worker;
+      }
     }
 
     // If an existing entry is crashed/terminated, clean it up
-    if (existing) {
+    if (existing && this.pool.has(projectId)) {
       existing.worker.terminate();
       this.pool.delete(projectId);
     }
@@ -60,7 +87,9 @@ export class WorkerPool {
     // Evict LRU if at capacity
     this.evictIfNeeded();
 
-    const permissions = buildWorkerPermissions(readPaths);
+    const permissions = buildWorkerPermissions(readPaths, {
+      projectEnvKeys: normalizedProjectEnvKeys,
+    });
     const worker = new ProjectWorker({
       projectId,
       permissions,
@@ -74,6 +103,7 @@ export class WorkerPool {
       worker,
       lastAccessedAt: now,
       createdAt: now,
+      projectEnvKeys: normalizedProjectEnvKeys,
     });
 
     logger.debug("Worker created", {
@@ -110,7 +140,8 @@ export class WorkerPool {
     return withSpan(
       "workerPool.execute",
       async () => {
-        const worker = this.getOrCreateWorker(projectId, readPaths);
+        const projectEnvKeys = extractProjectEnvKeys(request);
+        const worker = this.getOrCreateWorker(projectId, readPaths, projectEnvKeys);
 
         // Check if worker should be recycled (request count or age)
         const entry = this.pool.get(projectId);
@@ -138,12 +169,12 @@ export class WorkerPool {
           void result.then(
             () => {
               this.evictWorker(projectId);
-              this.getOrCreateWorker(projectId, readPaths);
+              this.getOrCreateWorker(projectId, readPaths, projectEnvKeys);
               this.recycling.delete(projectId);
             },
             () => {
               this.evictWorker(projectId);
-              this.getOrCreateWorker(projectId, readPaths);
+              this.getOrCreateWorker(projectId, readPaths, projectEnvKeys);
               this.recycling.delete(projectId);
             },
           );


### PR DESCRIPTION
## Summary

Fixes #2318.

- replace project worker `env: true` permissions with an explicit allowlist
- allow only framework-essential env keys plus the project env snapshot keys
- rebuild pooled workers when the project env key set changes, because Deno worker permissions are fixed at construction time
- add real worker regression coverage for `Deno.env.get` and `Deno.env.toObject` host-secret denial while preserving project env reads

## Verification

- `deno task verify:quick`
- `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/security/sandbox/worker-permissions.test.ts src/security/sandbox/project-worker.test.ts src/security/sandbox/worker-pool.test.ts src/routing/api/route-executor.test.ts`
- pre-push hook: full unit test suite passed (`2052 passed`, `0 failed`)

## Not tested

- compiled-binary e2e locally; hosted CI must validate binary packaging behavior
