### PR TITLE
Prevent pooled workers from overlapping env overlays

### DIFF
--- a/src/security/sandbox/project-worker.test.ts
+++ b/src/security/sandbox/project-worker.test.ts
@@ -281,6 +281,97 @@ testSuite("ProjectWorker - real worker request isolation", () => {
     }
   });
 
+  it("does not leak overlapping projectEnv overlays between concurrent requests", async () => {
+    const projectDir = await Deno.makeTempDir();
+    const modulePath = await Deno.makeTempFile({ dir: projectDir, suffix: ".mjs" });
+    const requestAKey = "VERYFRONT_TEST_REQUEST_A_SECRET";
+    const requestBKey = "VERYFRONT_TEST_REQUEST_B_SECRET";
+
+    await Deno.writeTextFile(
+      modulePath,
+      `
+        const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+        export async function GET(request) {
+          const url = new URL(request.url);
+          if (url.searchParams.get("request") === "a") {
+            await sleep(100);
+          }
+
+          return Response.json({
+            request: url.searchParams.get("request"),
+            requestA: Deno.env.get(${JSON.stringify(requestAKey)}) ?? null,
+            requestB: Deno.env.get(${JSON.stringify(requestBKey)}) ?? null,
+          });
+        }
+      `,
+    );
+
+    const worker = new ProjectWorker({
+      projectId: "test-concurrent-env-overlay-scope",
+      permissions: buildWorkerPermissions([projectDir], {
+        projectEnvKeys: [requestAKey, requestBKey],
+      }),
+      requestTimeoutMs: 10_000,
+    });
+
+    worker.start();
+    try {
+      const first = worker.execute({
+        type: "execute-app-route",
+        id: "request-a",
+        modulePath,
+        method: "GET",
+        request: {
+          url: "http://localhost/api/env?request=a",
+          method: "GET",
+          headers: [],
+          body: null,
+        },
+        params: {},
+        projectDir,
+        projectEnv: { [requestAKey]: "tenant-a" },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      const second = await worker.execute({
+        type: "execute-app-route",
+        id: "request-b",
+        modulePath,
+        method: "GET",
+        request: {
+          url: "http://localhost/api/env?request=b",
+          method: "GET",
+          headers: [],
+          body: null,
+        },
+        params: {},
+        projectDir,
+        projectEnv: { [requestBKey]: "tenant-b" },
+      });
+
+      const firstResponse = await first;
+
+      assertEquals(second.type, "result");
+      if (second.type !== "result") throw new Error("expected result response");
+      assertEquals(
+        JSON.parse(new TextDecoder().decode(second.response.body ?? new Uint8Array())),
+        { request: "b", requestA: null, requestB: "tenant-b" },
+      );
+
+      assertEquals(firstResponse.type, "result");
+      if (firstResponse.type !== "result") throw new Error("expected result response");
+      assertEquals(
+        JSON.parse(new TextDecoder().decode(firstResponse.response.body ?? new Uint8Array())),
+        { request: "a", requestA: "tenant-a", requestB: null },
+      );
+    } finally {
+      worker.terminate();
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
   it("denies host env secrets while allowing project env keys", async () => {
     const projectDir = await Deno.makeTempDir();
     const modulePath = await Deno.makeTempFile({ dir: projectDir, suffix: ".mjs" });

--- a/src/security/sandbox/worker-script.ts
+++ b/src/security/sandbox/worker-script.ts
@@ -515,25 +515,7 @@ async function handleRenderSSR(
 // Message Handler
 // ---------------------------------------------------------------------------
 
-self.onmessage = async (
-  event: MessageEvent<WorkerRequest | { type: "ping"; id: string } | { type: "clear-cache" }>,
-) => {
-  const msg = event.data;
-
-  // Health check
-  if (msg.type === "ping") {
-    self.postMessage({ type: "pong", id: (msg as { id: string }).id });
-    return;
-  }
-
-  // Module cache invalidation (for dev mode hot reload)
-  if (msg.type === "clear-cache") {
-    clearModuleCache();
-    return;
-  }
-
-  const request = msg as WorkerRequest;
-
+async function processWorkerRequest(request: WorkerRequest): Promise<void> {
   try {
     // Data fetcher returns a different response shape than HTTP handlers
     if (request.type === "fetch-data") {
@@ -590,4 +572,33 @@ self.onmessage = async (
     };
     self.postMessage(errorResponse);
   }
+}
+
+let requestQueue: Promise<void> = Promise.resolve();
+
+self.onmessage = (
+  event: MessageEvent<WorkerRequest | { type: "ping"; id: string } | { type: "clear-cache" }>,
+) => {
+  const msg = event.data;
+
+  // Health check
+  if (msg.type === "ping") {
+    self.postMessage({ type: "pong", id: (msg as { id: string }).id });
+    return;
+  }
+
+  // Module cache invalidation (for dev mode hot reload)
+  if (msg.type === "clear-cache") {
+    clearModuleCache();
+    return;
+  }
+
+  const request = msg as WorkerRequest;
+  // User code runs in the worker process and may read process-global state such
+  // as Deno.env. Keep requests non-overlapping so per-request env overlays
+  // cannot bleed across async handlers in the same pooled worker.
+  requestQueue = requestQueue.then(
+    () => processWorkerRequest(request),
+    () => processWorkerRequest(request),
+  );
 };


### PR DESCRIPTION
Fixes #2319.

Summary:
- serialize worker request execution inside each project worker so process-global `Deno.env` overlays cannot overlap across async handlers
- keep health pings immediate
- add regression coverage for two concurrent requests with different `projectEnv` overlays on the same worker

Verification:
- `deno task verify:quick`
- `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/security/sandbox/project-worker.test.ts src/security/sandbox/worker-pool.test.ts src/routing/api/route-executor.test.ts`
- pre-push hook: format, lint, typecheck, and unit tests (`2052 passed`, `0 failed`)

Not tested:
- hosted binary e2e locally; CI must validate packaging/runtime.
