### PR TITLE
Block internal egress from project workers

### DIFF
--- a/src/security/sandbox/project-worker.test.ts
+++ b/src/security/sandbox/project-worker.test.ts
@@ -5,6 +5,7 @@ import { isDeno } from "#veryfront/platform/compat/runtime.ts";
 import { ProjectWorker } from "./project-worker.ts";
 import { buildWorkerPermissions } from "./worker-permissions.ts";
 import type { WorkerPermissions } from "./worker-permissions.ts";
+import { WORKER_INTERNAL_EGRESS_OVERRIDE_ENV } from "./worker-egress-guard.ts";
 
 const testSuite = isDeno ? describe : describe.skip;
 
@@ -507,6 +508,184 @@ testSuite("ProjectWorker - real worker request isolation", () => {
       worker.terminate();
       await Deno.remove(projectDir, { recursive: true });
       await Deno.remove(outsideDir, { recursive: true });
+    }
+  });
+
+  it("blocks project fetches to loopback network targets", async () => {
+    const projectDir = await Deno.makeTempDir();
+    const modulePath = await Deno.makeTempFile({ dir: projectDir, suffix: ".mjs" });
+    const loopbackServer = Deno.serve(
+      { hostname: "127.0.0.1", port: 0, onListen: () => {} },
+      () => Response.json({ leaked: true }),
+    );
+    const loopbackUrl = `http://127.0.0.1:${loopbackServer.addr.port}/secret`;
+
+    await Deno.writeTextFile(
+      modulePath,
+      `
+        export async function GET() {
+          const response = await fetch(${JSON.stringify(loopbackUrl)});
+          return Response.json({ leaked: response.ok });
+        }
+      `,
+    );
+
+    const worker = new ProjectWorker({
+      projectId: "test-worker-egress-loopback-denied",
+      permissions: buildWorkerPermissions([projectDir]),
+      requestTimeoutMs: 10_000,
+    });
+
+    worker.start();
+    try {
+      const response = await worker.execute({
+        type: "execute-app-route",
+        id: "loopback-fetch",
+        modulePath,
+        method: "GET",
+        request: {
+          url: "http://localhost/api/fetch-loopback",
+          method: "GET",
+          headers: [],
+          body: null,
+        },
+        params: {},
+        projectDir,
+      });
+
+      assertEquals(response.type, "error");
+      if (response.type !== "error") throw new Error("expected error response");
+      assert(
+        response.error.message.includes("Worker network egress blocked"),
+        `expected egress denial, got: ${response.error.message}`,
+      );
+    } finally {
+      worker.terminate();
+      await loopbackServer.shutdown();
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("blocks project TCP connections to loopback network targets", async () => {
+    const projectDir = await Deno.makeTempDir();
+    const modulePath = await Deno.makeTempFile({ dir: projectDir, suffix: ".mjs" });
+    const listener = Deno.listen({ hostname: "127.0.0.1", port: 0 });
+    const accept = (async () => {
+      const conn = await listener.accept();
+      conn.close();
+    })();
+
+    await Deno.writeTextFile(
+      modulePath,
+      `
+        export async function GET() {
+          const conn = await Deno.connect({
+            hostname: "127.0.0.1",
+            port: ${listener.addr.port},
+          });
+          conn.close();
+          return Response.json({ connected: true });
+        }
+      `,
+    );
+
+    const worker = new ProjectWorker({
+      projectId: "test-worker-egress-loopback-connect-denied",
+      permissions: buildWorkerPermissions([projectDir]),
+      requestTimeoutMs: 10_000,
+    });
+
+    worker.start();
+    try {
+      const response = await worker.execute({
+        type: "execute-app-route",
+        id: "loopback-connect",
+        modulePath,
+        method: "GET",
+        request: {
+          url: "http://localhost/api/connect-loopback",
+          method: "GET",
+          headers: [],
+          body: null,
+        },
+        params: {},
+        projectDir,
+      });
+
+      assertEquals(response.type, "error");
+      if (response.type !== "error") throw new Error("expected error response");
+      assert(
+        response.error.message.includes("Worker network egress blocked"),
+        `expected egress denial, got: ${response.error.message}`,
+      );
+    } finally {
+      worker.terminate();
+      listener.close();
+      await accept.catch(() => {});
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("allows project loopback fetches when internal egress override is enabled", async () => {
+    const projectDir = await Deno.makeTempDir();
+    const modulePath = await Deno.makeTempFile({ dir: projectDir, suffix: ".mjs" });
+    const previousOverride = Deno.env.get(WORKER_INTERNAL_EGRESS_OVERRIDE_ENV);
+    const loopbackServer = Deno.serve(
+      { hostname: "127.0.0.1", port: 0, onListen: () => {} },
+      () => Response.json({ reachable: true }),
+    );
+    const loopbackUrl = `http://127.0.0.1:${loopbackServer.addr.port}/internal`;
+
+    await Deno.writeTextFile(
+      modulePath,
+      `
+        export async function GET() {
+          const response = await fetch(${JSON.stringify(loopbackUrl)});
+          return Response.json(await response.json());
+        }
+      `,
+    );
+
+    Deno.env.set(WORKER_INTERNAL_EGRESS_OVERRIDE_ENV, "1");
+
+    const worker = new ProjectWorker({
+      projectId: "test-worker-egress-loopback-override",
+      permissions: buildWorkerPermissions([projectDir]),
+      requestTimeoutMs: 10_000,
+    });
+
+    worker.start();
+    try {
+      const response = await worker.execute({
+        type: "execute-app-route",
+        id: "loopback-fetch-override",
+        modulePath,
+        method: "GET",
+        request: {
+          url: "http://localhost/api/fetch-loopback",
+          method: "GET",
+          headers: [],
+          body: null,
+        },
+        params: {},
+        projectDir,
+      });
+
+      assertEquals(response.type, "result");
+      if (response.type !== "result") throw new Error("expected result response");
+      assertEquals(
+        JSON.parse(new TextDecoder().decode(response.response.body ?? new Uint8Array())),
+        { reachable: true },
+      );
+    } finally {
+      worker.terminate();
+      await loopbackServer.shutdown();
+      if (previousOverride === undefined) {
+        Deno.env.delete(WORKER_INTERNAL_EGRESS_OVERRIDE_ENV);
+      } else {
+        Deno.env.set(WORKER_INTERNAL_EGRESS_OVERRIDE_ENV, previousOverride);
+      }
+      await Deno.remove(projectDir, { recursive: true });
     }
   });
 });

--- a/src/security/sandbox/project-worker.ts
+++ b/src/security/sandbox/project-worker.ts
@@ -12,6 +12,11 @@ import { serverLogger } from "#veryfront/utils";
 import { isCompiledBinary } from "#veryfront/utils";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { TIMEOUT_ERROR, UNKNOWN_ERROR } from "#veryfront/errors";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
+import {
+  isInternalEgressOverrideEnabled,
+  WORKER_INTERNAL_EGRESS_OVERRIDE_ENV,
+} from "./worker-egress-guard.ts";
 import type { WorkerPermissions } from "./worker-permissions.ts";
 import type {
   WorkerRequest,
@@ -22,6 +27,7 @@ import type {
 
 const logger = serverLogger.component("project-worker");
 const textEncoder = new TextEncoder();
+const WORKER_ALLOW_INTERNAL_EGRESS_PARAM = "allowInternalEgress";
 
 // Intersection with the DOM `WorkerOptions` so the value is assignable to the
 // `Worker` constructor without suppression — Deno reads the extra `deno` field
@@ -347,7 +353,21 @@ export class ProjectWorker {
 
     // Use import.meta.resolve to get the absolute URL of the worker script.
     // This works in both `deno run` and `deno compile` contexts.
-    return import.meta.resolve("./worker-script.ts");
+    return this.withEgressPolicy(import.meta.resolve("./worker-script.ts"));
+  }
+
+  private withEgressPolicy(workerScriptUrl: string): string {
+    if (!isInternalEgressOverrideEnabled(getHostEnv(WORKER_INTERNAL_EGRESS_OVERRIDE_ENV))) {
+      return workerScriptUrl;
+    }
+
+    try {
+      const url = new URL(workerScriptUrl);
+      url.searchParams.set(WORKER_ALLOW_INTERNAL_EGRESS_PARAM, "1");
+      return url.toString();
+    } catch {
+      return workerScriptUrl;
+    }
   }
 
   private handleMessage(

--- a/src/security/sandbox/worker-egress-guard.test.ts
+++ b/src/security/sandbox/worker-egress-guard.test.ts
@@ -1,0 +1,101 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  assertWorkerEgressAllowed,
+  assertWorkerHostEgressAllowed,
+  isInternalEgressIp,
+  isInternalEgressOverrideEnabled,
+  WORKER_INTERNAL_EGRESS_OVERRIDE_ENV,
+  WorkerEgressBlockedError,
+} from "./worker-egress-guard.ts";
+
+describe("worker-egress-guard", () => {
+  it("identifies loopback, metadata, private, and link-local addresses", () => {
+    assertEquals(isInternalEgressIp("127.0.0.1"), true);
+    assertEquals(isInternalEgressIp("169.254.169.254"), true);
+    assertEquals(isInternalEgressIp("169.254.1.2"), true);
+    assertEquals(isInternalEgressIp("10.1.2.3"), true);
+    assertEquals(isInternalEgressIp("172.16.0.1"), true);
+    assertEquals(isInternalEgressIp("172.31.255.255"), true);
+    assertEquals(isInternalEgressIp("192.168.1.10"), true);
+    assertEquals(isInternalEgressIp("::1"), true);
+    assertEquals(isInternalEgressIp("fe80::1"), true);
+    assertEquals(isInternalEgressIp("fd00::1"), true);
+    assertEquals(isInternalEgressIp("93.184.216.34"), false);
+    assertEquals(isInternalEgressIp("2606:2800:220:1:248:1893:25c8:1946"), false);
+  });
+
+  it("blocks direct metadata, private, link-local, and localhost targets", async () => {
+    await assertRejects(
+      () => assertWorkerEgressAllowed("http://169.254.169.254/latest/meta-data/"),
+      WorkerEgressBlockedError,
+      "Worker network egress blocked",
+    );
+    await assertRejects(
+      () => assertWorkerEgressAllowed("http://10.0.0.5/private"),
+      WorkerEgressBlockedError,
+      "Worker network egress blocked",
+    );
+    await assertRejects(
+      () => assertWorkerEgressAllowed("http://[fe80::1]/"),
+      WorkerEgressBlockedError,
+      "Worker network egress blocked",
+    );
+    await assertRejects(
+      () => assertWorkerEgressAllowed("http://localhost/internal"),
+      WorkerEgressBlockedError,
+      "Worker network egress blocked",
+    );
+  });
+
+  it("allows public direct IP targets", async () => {
+    await assertWorkerEgressAllowed("https://93.184.216.34/");
+    await assertWorkerEgressAllowed("https://[2606:2800:220:1:248:1893:25c8:1946]/");
+  });
+
+  it("blocks hostnames that resolve to private addresses", async () => {
+    await assertRejects(
+      () =>
+        assertWorkerHostEgressAllowed("tenant.example", {
+          resolveHost: () => Promise.resolve(["10.1.2.3"]),
+        }),
+      WorkerEgressBlockedError,
+      "resolved to internal address",
+    );
+  });
+
+  it("allows hostnames that resolve only to public addresses", async () => {
+    await assertWorkerHostEgressAllowed("api.example.com", {
+      resolveHost: () => Promise.resolve(["93.184.216.34"]),
+    });
+  });
+
+  it("requires hostname resolution by default", async () => {
+    await assertRejects(
+      () =>
+        assertWorkerHostEgressAllowed("api.example.com", {
+          resolveHost: () => Promise.resolve([]),
+        }),
+      WorkerEgressBlockedError,
+      "unable to resolve host",
+    );
+  });
+
+  it("allows internal targets only when the self-hosted override is enabled", async () => {
+    await assertWorkerEgressAllowed("http://127.0.0.1:3000/internal", {
+      allowInternalEgress: true,
+      resolveHost: () => Promise.resolve(["127.0.0.1"]),
+    });
+  });
+
+  it("parses the explicit internal egress override env value", () => {
+    assertEquals(WORKER_INTERNAL_EGRESS_OVERRIDE_ENV, "VERYFRONT_WORKER_ALLOW_INTERNAL_EGRESS");
+    assertEquals(isInternalEgressOverrideEnabled("1"), true);
+    assertEquals(isInternalEgressOverrideEnabled("true"), true);
+    assertEquals(isInternalEgressOverrideEnabled("yes"), true);
+    assertEquals(isInternalEgressOverrideEnabled("on"), true);
+    assertEquals(isInternalEgressOverrideEnabled("0"), false);
+    assertEquals(isInternalEgressOverrideEnabled(undefined), false);
+  });
+});

--- a/src/security/sandbox/worker-egress-guard.ts
+++ b/src/security/sandbox/worker-egress-guard.ts
@@ -1,0 +1,251 @@
+/**
+ * Worker network egress guard.
+ *
+ * Project workers need outbound network access for public API calls, but user
+ * code must not reach host-internal networks or cloud metadata endpoints.
+ *
+ * @module security/sandbox/worker-egress-guard
+ */
+
+export const WORKER_INTERNAL_EGRESS_OVERRIDE_ENV = "VERYFRONT_WORKER_ALLOW_INTERNAL_EGRESS";
+
+export class WorkerEgressBlockedError extends Error {
+  override name = "WorkerEgressBlockedError";
+}
+
+export type ResolveWorkerHost = (hostname: string) => Promise<string[]>;
+
+export interface WorkerEgressGuardOptions {
+  allowInternalEgress?: boolean;
+  resolveHost?: ResolveWorkerHost;
+}
+
+const guardInstalled = Symbol.for("veryfront.workerEgressGuardInstalled");
+const guardedFetch = Symbol.for("veryfront.workerEgressGuard.fetch");
+const guardedConnect = Symbol.for("veryfront.workerEgressGuard.connect");
+const guardedConnectTls = Symbol.for("veryfront.workerEgressGuard.connectTls");
+
+function isObject(value: unknown): value is Record<PropertyKey, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function isInternalEgressOverrideEnabled(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  switch (value.trim().toLowerCase()) {
+    case "1":
+    case "true":
+    case "yes":
+    case "on":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function stripIpv6Brackets(value: string): string {
+  return value.startsWith("[") && value.endsWith("]") ? value.slice(1, -1) : value;
+}
+
+function stripIpv6Zone(value: string): string {
+  const zoneIndex = value.indexOf("%");
+  return zoneIndex === -1 ? value : value.slice(0, zoneIndex);
+}
+
+function parseIpv4(value: string): number[] | null {
+  const parts = value.split(".");
+  if (parts.length !== 4) return null;
+
+  const octets: number[] = [];
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const octet = Number(part);
+    if (!Number.isInteger(octet) || octet < 0 || octet > 255) return null;
+    octets.push(octet);
+  }
+  return octets;
+}
+
+function isPrivateIpv4(octets: number[]): boolean {
+  const [a = -1, b = -1] = octets;
+  return (
+    a === 10 ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    a === 0
+  );
+}
+
+function isInternalIpv6(value: string): boolean {
+  const normalized = stripIpv6Zone(stripIpv6Brackets(value)).toLowerCase();
+  if (normalized === "::" || normalized === "::1") return true;
+
+  const mappedIpv4 = normalized.match(/(?:::ffff:)(\d{1,3}(?:\.\d{1,3}){3})$/);
+  if (mappedIpv4?.[1]) {
+    const octets = parseIpv4(mappedIpv4[1]);
+    return octets !== null && isPrivateIpv4(octets);
+  }
+
+  const firstHextetText = normalized.split(":", 1)[0] ?? "";
+  if (!/^[0-9a-f]{1,4}$/.test(firstHextetText)) return false;
+  const firstHextet = Number.parseInt(firstHextetText, 16);
+
+  // fe80::/10 link-local, fc00::/7 unique local.
+  return (firstHextet & 0xffc0) === 0xfe80 || (firstHextet & 0xfe00) === 0xfc00;
+}
+
+export function isInternalEgressIp(address: string): boolean {
+  const host = stripIpv6Zone(stripIpv6Brackets(address.trim().toLowerCase()));
+  const ipv4 = parseIpv4(host);
+  if (ipv4) return isPrivateIpv4(ipv4);
+  return host.includes(":") && isInternalIpv6(host);
+}
+
+function isIpLiteral(address: string): boolean {
+  const host = stripIpv6Zone(stripIpv6Brackets(address.trim().toLowerCase()));
+  return parseIpv4(host) !== null || host.includes(":");
+}
+
+function isLocalhostName(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  return normalized === "localhost" || normalized.endsWith(".localhost");
+}
+
+async function defaultResolveHost(hostname: string): Promise<string[]> {
+  const results: string[] = [];
+  const resolver = Deno.resolveDns;
+
+  for (const recordType of ["A", "AAAA"] as const) {
+    try {
+      results.push(...await resolver(hostname, recordType));
+    } catch {
+      // A host may legitimately have only one address family.
+    }
+  }
+
+  return results;
+}
+
+function getUrlHostname(input: string | URL | Request): string | null {
+  const url = input instanceof URL
+    ? input
+    : input instanceof Request
+    ? new URL(input.url)
+    : new URL(String(input));
+
+  if (
+    url.protocol !== "http:" && url.protocol !== "https:" && url.protocol !== "ws:" &&
+    url.protocol !== "wss:"
+  ) {
+    return null;
+  }
+
+  return stripIpv6Brackets(url.hostname);
+}
+
+export async function assertWorkerEgressAllowed(
+  target: string | URL | Request,
+  options: WorkerEgressGuardOptions = {},
+): Promise<void> {
+  if (options.allowInternalEgress) return;
+
+  const hostname = getUrlHostname(target);
+  if (!hostname) return;
+
+  await assertWorkerHostEgressAllowed(hostname, options);
+}
+
+export async function assertWorkerHostEgressAllowed(
+  hostname: string,
+  options: WorkerEgressGuardOptions = {},
+): Promise<void> {
+  if (options.allowInternalEgress) return;
+
+  const host = stripIpv6Brackets(hostname.trim().toLowerCase());
+  if (isLocalhostName(host) || isInternalEgressIp(host)) {
+    throw new WorkerEgressBlockedError(
+      `Worker network egress blocked for internal host: ${hostname}`,
+    );
+  }
+  if (isIpLiteral(host)) return;
+
+  const resolveHost = options.resolveHost ?? defaultResolveHost;
+  const addresses = await resolveHost(host);
+  if (addresses.length === 0) {
+    throw new WorkerEgressBlockedError(
+      `Worker network egress blocked: unable to resolve host ${hostname}`,
+    );
+  }
+
+  for (const address of addresses) {
+    if (isInternalEgressIp(address)) {
+      throw new WorkerEgressBlockedError(
+        `Worker network egress blocked for host ${hostname} resolved to internal address ${address}`,
+      );
+    }
+  }
+}
+
+function getConnectHostname(options: unknown): string | null {
+  if (!isObject(options)) return null;
+  const hostname = options.hostname;
+  return typeof hostname === "string" ? hostname : null;
+}
+
+function getAllowInternalEgress(): boolean {
+  try {
+    return isInternalEgressOverrideEnabled(Deno.env.get(WORKER_INTERNAL_EGRESS_OVERRIDE_ENV));
+  } catch {
+    return false;
+  }
+}
+
+export function installWorkerEgressGuard(options: WorkerEgressGuardOptions = {}): void {
+  const globalRecord = globalThis as typeof globalThis & Record<PropertyKey, unknown>;
+  if (globalRecord[guardInstalled]) return;
+
+  const baseOptions = {
+    ...options,
+    allowInternalEgress: options.allowInternalEgress ?? getAllowInternalEgress(),
+  };
+
+  const originalFetch = globalThis.fetch.bind(globalThis);
+  const fetchWrapper = async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ): Promise<Response> => {
+    await assertWorkerEgressAllowed(input, baseOptions);
+    return await originalFetch(input, init);
+  };
+  Object.defineProperty(fetchWrapper, guardedFetch, { value: true });
+  globalThis.fetch = fetchWrapper as typeof fetch;
+
+  if (typeof Deno.connect === "function") {
+    const originalConnect = Deno.connect.bind(Deno);
+    const connectWrapper = async (
+      options: Parameters<typeof Deno.connect>[0],
+    ): ReturnType<typeof Deno.connect> => {
+      const hostname = getConnectHostname(options);
+      if (hostname) await assertWorkerHostEgressAllowed(hostname, baseOptions);
+      return await originalConnect(options);
+    };
+    Object.defineProperty(connectWrapper, guardedConnect, { value: true });
+    Deno.connect = connectWrapper as typeof Deno.connect;
+  }
+
+  if (typeof Deno.connectTls === "function") {
+    const originalConnectTls = Deno.connectTls.bind(Deno);
+    const connectTlsWrapper = async (
+      options: Parameters<typeof Deno.connectTls>[0],
+    ): ReturnType<typeof Deno.connectTls> => {
+      const hostname = getConnectHostname(options);
+      if (hostname) await assertWorkerHostEgressAllowed(hostname, baseOptions);
+      return await originalConnectTls(options);
+    };
+    Object.defineProperty(connectTlsWrapper, guardedConnectTls, { value: true });
+    Deno.connectTls = connectTlsWrapper as typeof Deno.connectTls;
+  }
+
+  globalRecord[guardInstalled] = true;
+}

--- a/src/security/sandbox/worker-permissions.ts
+++ b/src/security/sandbox/worker-permissions.ts
@@ -14,6 +14,7 @@ import {
   getHttpBundleCacheDir,
   getMdxEsmCacheDir,
 } from "#veryfront/utils/cache-dir.ts";
+import { WORKER_INTERNAL_EGRESS_OVERRIDE_ENV } from "./worker-egress-guard.ts";
 
 /**
  * Deno Worker permission object.
@@ -47,6 +48,7 @@ export const FRAMEWORK_WORKER_ENV_ALLOWLIST = [
   "NO_COLOR",
   "FORCE_COLOR",
   "CI",
+  WORKER_INTERNAL_EGRESS_OVERRIDE_ENV,
 ] as const;
 
 // Cache compiled binary check — Deno.execPath() is a syscall that never changes at runtime

--- a/src/security/sandbox/worker-script.ts
+++ b/src/security/sandbox/worker-script.ts
@@ -29,10 +29,18 @@ import type {
   WorkerStreamChunk,
   WorkerStreamEnd,
 } from "./worker-types.ts";
+import { installWorkerEgressGuard } from "./worker-egress-guard.ts";
 import { isAbsolute, relative, resolve as resolvePath, sep as PATH_SEP } from "node:path";
 
 // Module-level singletons to avoid per-call allocation churn
 const encoder = new TextEncoder();
+const allowInternalEgress = (() => {
+  try {
+    return new URL(import.meta.url).searchParams.get("allowInternalEgress") === "1";
+  } catch {
+    return false;
+  }
+})();
 
 /** True when `child` is the same as, or nested under, `root`. Cross-platform. */
 function isContained(root: string, child: string): boolean {
@@ -517,6 +525,8 @@ async function handleRenderSSR(
 
 async function processWorkerRequest(request: WorkerRequest): Promise<void> {
   try {
+    installWorkerEgressGuard({ allowInternalEgress });
+
     // Data fetcher returns a different response shape than HTTP handlers
     if (request.type === "fetch-data") {
       const dataResult = await handleFetchData(request);


### PR DESCRIPTION
Fixes #2320.

Summary:
- add a worker-local egress guard for project-code `fetch`, `Deno.connect`, and `Deno.connectTls`
- block loopback, RFC1918 private ranges, link-local/metadata addresses, and hostnames that resolve to blocked addresses by default
- keep public direct IPs and public DNS targets allowed
- add `VERYFRONT_WORKER_ALLOW_INTERNAL_EGRESS=1` as an explicit self-hosted override
- add worker-level regressions for loopback fetch/TCP denial and override behavior

Verification:
- `deno task verify:quick`
- `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/security/sandbox/worker-egress-guard.test.ts src/security/sandbox/project-worker.test.ts src/security/sandbox/worker-permissions.test.ts src/security/sandbox/worker-pool.test.ts src/routing/api/route-executor.test.ts`
- pre-push hook: format, lint, typecheck, unit tests (`2053 passed`, `0 failed`)

Not tested:
- hosted binary e2e locally; CI must validate packaging/runtime.
