### PR TITLE
Bind CLI OAuth callbacks to login state

### DIFF
--- a/cli/auth/callback-server.test.ts
+++ b/cli/auth/callback-server.test.ts
@@ -87,6 +87,85 @@ describe(
         assertEquals(result.error, undefined);
       });
 
+      it("should receive token when callback state matches", async () => {
+        server = await startCallbackServer(9876, { expectedState: "expected-state" });
+        const callbackUrl = getCallbackUrl(server.port);
+
+        const callbackPromise = server.waitForCallback(scaleMs(5000));
+
+        setTimeout(() => {
+          void fetchAndCancel(`${callbackUrl}?token=test-oauth-token&state=expected-state`);
+        }, scaleMs(100));
+
+        const result = await callbackPromise;
+        assertEquals(result.token, "test-oauth-token");
+        assertEquals(result.error, undefined);
+      });
+
+      it("should reject callback token when state is missing", async () => {
+        server = await startCallbackServer(9876, { expectedState: "expected-state" });
+        const callbackUrl = getCallbackUrl(server.port);
+
+        const callbackPromise = server.waitForCallback(scaleMs(5000));
+
+        setTimeout(() => {
+          void fetchAndCancel(`${callbackUrl}?token=test-oauth-token`);
+        }, scaleMs(100));
+
+        const result = await callbackPromise;
+        assertEquals(result.token, "");
+        assertEquals(result.error, "Invalid OAuth state");
+      });
+
+      it("should reject callback token when state is mismatched", async () => {
+        server = await startCallbackServer(9876, { expectedState: "expected-state" });
+        const callbackUrl = getCallbackUrl(server.port);
+
+        const callbackPromise = server.waitForCallback(scaleMs(5000));
+
+        setTimeout(() => {
+          void fetchAndCancel(`${callbackUrl}?token=test-oauth-token&state=wrong-state`);
+        }, scaleMs(100));
+
+        const result = await callbackPromise;
+        assertEquals(result.token, "");
+        assertEquals(result.error, "Invalid OAuth state");
+      });
+
+      it("should reject callback token from cross-origin requests", async () => {
+        server = await startCallbackServer(9876, { expectedState: "expected-state" });
+        const callbackUrl = getCallbackUrl(server.port);
+
+        const callbackPromise = server.waitForCallback(scaleMs(5000));
+
+        setTimeout(() => {
+          void fetch(callbackUrl + "?token=test-oauth-token&state=expected-state", {
+            headers: { Origin: "https://evil.example" },
+          }).then((resp) => resp.body?.cancel());
+        }, scaleMs(100));
+
+        const result = await callbackPromise;
+        assertEquals(result.token, "");
+        assertEquals(result.error, "Invalid callback origin");
+      });
+
+      it("should reject callback token with cross-origin referer", async () => {
+        server = await startCallbackServer(9876, { expectedState: "expected-state" });
+        const callbackUrl = getCallbackUrl(server.port);
+
+        const callbackPromise = server.waitForCallback(scaleMs(5000));
+
+        setTimeout(() => {
+          void fetch(callbackUrl + "?token=test-oauth-token&state=expected-state", {
+            headers: { Referer: "https://evil.example/login" },
+          }).then((resp) => resp.body?.cancel());
+        }, scaleMs(100));
+
+        const result = await callbackPromise;
+        assertEquals(result.token, "");
+        assertEquals(result.error, "Invalid callback origin");
+      });
+
       it("should handle error from callback", async () => {
         server = await startCallbackServer(9876);
         const callbackUrl = getCallbackUrl(server.port);

--- a/cli/auth/callback-server.ts
+++ b/cli/auth/callback-server.ts
@@ -17,6 +17,10 @@ export interface CallbackServer {
   stop(): Promise<void>;
 }
 
+export interface CallbackServerOptions {
+  expectedState?: string;
+}
+
 function renderSuccessPage(): string {
   return `<!DOCTYPE html>
 <html>
@@ -168,18 +172,50 @@ function isAddrInUseError(error: unknown): boolean {
   return false;
 }
 
-function handleCallback(url: URL): { result: CallbackResult; html: string } {
+function callbackError(message: string): { result: CallbackResult; html: string } {
+  return { result: { token: "", error: message }, html: renderErrorPage(message) };
+}
+
+function headerOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+function hasCrossOriginHeader(headers: Headers, url: URL): boolean {
+  const expectedOrigin = url.origin;
+  const origin = headers.get("origin");
+  if (origin && headerOrigin(origin) !== expectedOrigin) return true;
+
+  const referer = headers.get("referer");
+  if (referer && headerOrigin(referer) !== expectedOrigin) return true;
+
+  return false;
+}
+
+function handleCallback(
+  url: URL,
+  headers: Headers,
+  options: CallbackServerOptions = {},
+): { result: CallbackResult; html: string } {
+  if (hasCrossOriginHeader(headers, url)) return callbackError("Invalid callback origin");
+
+  if (options.expectedState && url.searchParams.get("state") !== options.expectedState) {
+    return callbackError("Invalid OAuth state");
+  }
+
   const token = url.searchParams.get("token");
   const error = url.searchParams.get("error");
 
   if (error) return { result: { token: "", error }, html: renderErrorPage(error) };
   if (token) return { result: { token }, html: renderSuccessPage() };
 
-  const message = "No token received";
-  return { result: { token: "", error: message }, html: renderErrorPage(message) };
+  return callbackError("No token received");
 }
 
-function tryStartDenoServer(port: number): CallbackServer {
+function tryStartDenoServer(port: number, options: CallbackServerOptions = {}): CallbackServer {
   let resolveCallback: (result: CallbackResult) => void = () => {};
   const callbackPromise = new Promise<CallbackResult>((resolve) => {
     resolveCallback = resolve;
@@ -196,7 +232,7 @@ function tryStartDenoServer(port: number): CallbackServer {
         return new Response("Not Found", { status: 404, headers: { Connection: "close" } });
       }
 
-      const { result, html } = handleCallback(url);
+      const { result, html } = handleCallback(url, request.headers, options);
       resolveCallback(result);
 
       // Close connection immediately to allow clean server shutdown
@@ -215,10 +251,10 @@ function tryStartDenoServer(port: number): CallbackServer {
   };
 }
 
-function startDenoServer(startPort: number): CallbackServer {
+function startDenoServer(startPort: number, options: CallbackServerOptions = {}): CallbackServer {
   for (let port = startPort, i = 0; i < MAX_PORT_ATTEMPTS; i++, port++) {
     try {
-      return tryStartDenoServer(port);
+      return tryStartDenoServer(port, options);
     } catch (error) {
       if (!isAddrInUseError(error) || i === MAX_PORT_ATTEMPTS - 1) {
         throw error;
@@ -229,7 +265,23 @@ function startDenoServer(startPort: number): CallbackServer {
   throw new Error("Could not find an available port");
 }
 
-async function tryStartNodeServer(port: number): Promise<CallbackServer> {
+function nodeHeadersToHeaders(headers: Record<string, string | string[] | undefined>): Headers {
+  const result = new Headers();
+  for (const [name, value] of Object.entries(headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) result.append(name, item);
+      continue;
+    }
+    result.set(name, value);
+  }
+  return result;
+}
+
+async function tryStartNodeServer(
+  port: number,
+  options: CallbackServerOptions = {},
+): Promise<CallbackServer> {
   const http = await import("node:http");
 
   let resolveCallback: (result: CallbackResult) => void = () => {};
@@ -246,7 +298,11 @@ async function tryStartNodeServer(port: number): Promise<CallbackServer> {
       return;
     }
 
-    const { result, html } = handleCallback(url);
+    const { result, html } = handleCallback(
+      url,
+      nodeHeadersToHeaders(req.headers),
+      options,
+    );
     resolveCallback(result);
 
     res.setHeader("Content-Type", "text/html; charset=utf-8");
@@ -270,10 +326,13 @@ async function tryStartNodeServer(port: number): Promise<CallbackServer> {
   };
 }
 
-async function startNodeServer(startPort: number): Promise<CallbackServer> {
+async function startNodeServer(
+  startPort: number,
+  options: CallbackServerOptions = {},
+): Promise<CallbackServer> {
   for (let port = startPort, i = 0; i < MAX_PORT_ATTEMPTS; i++, port++) {
     try {
-      return await tryStartNodeServer(port);
+      return await tryStartNodeServer(port, options);
     } catch (error) {
       if (!isAddrInUseError(error) || i === MAX_PORT_ATTEMPTS - 1) {
         throw error;
@@ -286,9 +345,10 @@ async function startNodeServer(startPort: number): Promise<CallbackServer> {
 
 export async function startCallbackServer(
   preferredPort: number = DEFAULT_CALLBACK_PORT,
+  options: CallbackServerOptions = {},
 ): Promise<CallbackServer> {
   // Server functions handle port retry internally to avoid race conditions
-  return isDeno ? startDenoServer(preferredPort) : startNodeServer(preferredPort);
+  return isDeno ? startDenoServer(preferredPort, options) : startNodeServer(preferredPort, options);
 }
 
 export function getCallbackUrl(port: number): string {

--- a/cli/auth/index.ts
+++ b/cli/auth/index.ts
@@ -1,5 +1,7 @@
 export {
   type AuthMethod,
+  createOAuthAuthorizationUrl,
+  createOAuthState,
   deleteToken,
   ensureAuthenticated,
   hasToken,

--- a/cli/auth/login.test.ts
+++ b/cli/auth/login.test.ts
@@ -87,6 +87,46 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
     });
   });
 
+  describe("OAuth state", () => {
+    it("should generate distinct OAuth state values", async () => {
+      const loginModule = await import("./login.ts") as typeof import("./login.ts") & {
+        createOAuthState?: () => string;
+      };
+
+      assertEquals(typeof loginModule.createOAuthState, "function");
+
+      const first = loginModule.createOAuthState!();
+      const second = loginModule.createOAuthState!();
+
+      assertEquals(first.length >= 32, true);
+      assertEquals(second.length >= 32, true);
+      assertEquals(first !== second, true);
+    });
+
+    it("should include state in the OAuth authorization URL", async () => {
+      const loginModule = await import("./login.ts") as typeof import("./login.ts") & {
+        createOAuthAuthorizationUrl?: (
+          provider: "google" | "github" | "microsoft",
+          callbackUrl: string,
+          state: string,
+        ) => string;
+      };
+
+      assertEquals(typeof loginModule.createOAuthAuthorizationUrl, "function");
+
+      const authUrl = loginModule.createOAuthAuthorizationUrl!(
+        "github",
+        "http://localhost:3456/callback",
+        "expected-state",
+      );
+      const parsed = new URL(authUrl);
+
+      assertEquals(parsed.pathname, "/auth/github");
+      assertEquals(parsed.searchParams.get("redirect_uri"), "http://localhost:3456/callback");
+      assertEquals(parsed.searchParams.get("state"), "expected-state");
+    });
+  });
+
   describe("logout", { sanitizeOps: false, sanitizeResources: false }, () => {
     it("should clear stored token", async () => {
       await saveToken("test-token");

--- a/cli/auth/login.ts
+++ b/cli/auth/login.ts
@@ -6,7 +6,7 @@ import { getCallbackUrl, startCallbackServer } from "./callback-server.ts";
 import { canOpenBrowser, openBrowser } from "./browser.ts";
 import { isTTY, promptUser } from "../utils/index.ts";
 import { brand, dim, error, muted, success, warning } from "../ui/colors.ts";
-import { DEFAULT_LOGIN_TIMEOUT_MS, getApiUrl } from "../shared/constants.ts";
+import { DEFAULT_CALLBACK_PORT, DEFAULT_LOGIN_TIMEOUT_MS, getApiUrl } from "../shared/constants.ts";
 import { createSuccessEnvelope, isJsonMode, outputJson } from "../shared/json-output.ts";
 
 export type AuthMethod = "google" | "github" | "microsoft" | "token";
@@ -23,6 +23,24 @@ const AUTH_OPTIONS: { id: AuthMethod; label: string }[] = [
   { id: "microsoft", label: "Microsoft" },
   { id: "token", label: "API Token" },
 ];
+
+export function createOAuthState(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export function createOAuthAuthorizationUrl(
+  provider: "google" | "github" | "microsoft",
+  callbackUrl: string,
+  state: string,
+): string {
+  // The hosted auth endpoint must echo `state` back to the loopback callback.
+  const authUrl = new URL(`${getApiUrl().replace(/\/$/, "")}/auth/${provider}`);
+  authUrl.searchParams.set("redirect_uri", callbackUrl);
+  authUrl.searchParams.set("state", state);
+  return authUrl.toString();
+}
 
 export async function validateToken(token: string): Promise<UserInfo | null> {
   try {
@@ -116,27 +134,26 @@ async function loginWithOAuth(provider: "google" | "github" | "microsoft"): Prom
 
   console.log("  " + dim("Starting authentication server..."));
 
+  const state = createOAuthState();
   let server: Awaited<ReturnType<typeof startCallbackServer>>;
   try {
-    server = await startCallbackServer();
+    server = await startCallbackServer(DEFAULT_CALLBACK_PORT, { expectedState: state });
   } catch (e) {
     console.log("  " + error(`Failed to start server: ${e}`));
     return null;
   }
 
   const callbackUrl = getCallbackUrl(server.port);
-  const authUrl = `${getApiUrl()}/auth/${provider}?redirect_uri=${encodeURIComponent(callbackUrl)}`;
+  const authUrl = createOAuthAuthorizationUrl(provider, callbackUrl, state);
 
   console.log("  " + brand("Opening browser to log in..."));
-  console.log();
-  console.log("  " + dim("If the browser doesn't open, visit:"));
-  console.log("  " + dim(authUrl));
   console.log();
 
   try {
     await openBrowser(authUrl);
   } catch {
     console.log("  " + dim("Could not open browser automatically."));
+    console.log("  " + dim("Please use the API token option instead."));
   }
 
   console.log("  " + muted("Waiting for login..."));

--- a/cli/commands/demo/demo.ts
+++ b/cli/commands/demo/demo.ts
@@ -23,10 +23,16 @@ import {
   typeLine,
 } from "#cli/ui";
 import { exitProcess, isTTY } from "#cli/utils";
-import { readToken, saveToken, validateToken } from "../../auth/index.ts";
+import {
+  createOAuthAuthorizationUrl,
+  createOAuthState,
+  readToken,
+  saveToken,
+  validateToken,
+} from "../../auth/index.ts";
 import { canOpenBrowser, openBrowser } from "../../auth/browser.ts";
 import { getCallbackUrl, startCallbackServer } from "../../auth/callback-server.ts";
-import { DEFAULT_LOGIN_TIMEOUT_MS, getApiUrl } from "#cli/shared/constants";
+import { DEFAULT_CALLBACK_PORT, DEFAULT_LOGIN_TIMEOUT_MS } from "#cli/shared/constants";
 import { initCommand } from "../init/index.ts";
 import { writeProjectSlug } from "#cli/shared/config";
 import { randomSuffix } from "#cli/shared/slug";
@@ -183,27 +189,26 @@ async function demoLogin(preselectedMethod?: AuthMethod): Promise<boolean> {
 
   console.log(`  ${dim("Starting authentication server...")}`);
 
+  const state = createOAuthState();
   let server: Awaited<ReturnType<typeof startCallbackServer>>;
   try {
-    server = await startCallbackServer();
+    server = await startCallbackServer(DEFAULT_CALLBACK_PORT, { expectedState: state });
   } catch (e) {
     console.log(`  ${error(`Failed to start server: ${e}`)}`);
     return false;
   }
 
   const callbackUrl = getCallbackUrl(server.port);
-  const authUrl = `${getApiUrl()}/auth/${method}?redirect_uri=${encodeURIComponent(callbackUrl)}`;
+  const authUrl = createOAuthAuthorizationUrl(method, callbackUrl, state);
 
   console.log(`  ${brand("Opening browser to log in...")}`);
-  console.log();
-  console.log(`  ${dim("If the browser doesn't open, visit:")}`);
-  console.log(`  ${dim(authUrl)}`);
   console.log();
 
   try {
     await openBrowser(authUrl);
   } catch {
     console.log(`  ${dim("Could not open browser automatically.")}`);
+    console.log(`  ${dim("Please use the API token option instead.")}`);
   }
 
   console.log(`  ${muted("Waiting for login...")}`);


### PR DESCRIPTION
Fixes #2321.

Summary:
- generate a per-flow CSPRNG OAuth `state` for CLI browser login and include it in the hosted auth URL
- require the loopback callback to return the expected `state` before accepting a token
- reject callback requests carrying cross-origin `Origin` or `Referer` headers
- stop printing the state-bearing auth URL to terminal output
- apply the same state-bound login flow to `veryfront demo`

Hosted auth contract:
- the hosted `/auth/{provider}` endpoint must echo the `state` query parameter back to the loopback redirect; the CLI now rejects callbacks when that state is missing or different

Verification:
- red callback/login regressions failed before implementation
- `deno fmt --check cli/auth/login.ts`
- `deno check cli/auth/login.ts cli/commands/demo/demo.ts`
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all cli/auth/callback-server.test.ts cli/auth/login.test.ts cli/commands/demo/demo.test.ts cli/commands/demo/steps.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all cli/auth cli/commands/demo/demo.test.ts cli/commands/demo/steps.test.ts`
- `deno task verify:quick`
- pre-push hook: format, lint, typecheck, unit tests (`2053 passed`, `0 failed`)

Not tested:
- live hosted OAuth provider redirect in a real browser.
