### PR TITLE
fix(cli): bind loopback OAuth login with state and Origin checks (#2321)

### DIFF
--- a/cli/auth/callback-server.test.ts
+++ b/cli/auth/callback-server.test.ts
@@ -6,10 +6,15 @@ import "#veryfront/schemas/_test-setup.ts";
  * and are skipped on Node.js and Bun.
  */
 
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertNotEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { isDeno, scaleMs } from "#veryfront/testing";
-import { type CallbackServer, getCallbackUrl, startCallbackServer } from "./callback-server.ts";
+import {
+  type CallbackServer,
+  generateCallbackState,
+  getCallbackUrl,
+  startCallbackServer,
+} from "./callback-server.ts";
 
 describe(
   "Callback Server",
@@ -124,5 +129,183 @@ describe(
         await response.body?.cancel();
       });
     });
+
+    describe("state binding (CSRF)", { sanitizeOps: false, sanitizeResources: false }, () => {
+      const expectedState = "expected-state-nonce-abc123";
+
+      async function fetchTextAndCancel(url: string, init?: RequestInit): Promise<string> {
+        const resp = await fetch(url, init);
+        const text = await resp.text();
+        return text;
+      }
+
+      it("should accept token when state matches (happy path)", async () => {
+        server = await startCallbackServer(9876, { expectedState });
+        const callbackUrl = getCallbackUrl(server.port);
+
+        const callbackPromise = server.waitForCallback(scaleMs(5000));
+
+        let pageHtml = "";
+        setTimeout(() => {
+          void fetchTextAndCancel(
+            `${callbackUrl}?token=test-oauth-token&state=${encodeURIComponent(expectedState)}`,
+          ).then((html) => {
+            pageHtml = html;
+          });
+        }, scaleMs(100));
+
+        const result = await callbackPromise;
+        assertEquals(result.token, "test-oauth-token");
+        assertEquals(result.error, undefined);
+        // Confirm the served page is the success page once the body resolves.
+        await new Promise((r) => setTimeout(r, scaleMs(100)));
+        assertEquals(pageHtml.includes("Logged in"), true);
+      });
+
+      it("should reject token when state is missing", async () => {
+        server = await startCallbackServer(9876, { expectedState });
+        const callbackUrl = getCallbackUrl(server.port);
+
+        const callbackPromise = server.waitForCallback(scaleMs(5000));
+
+        setTimeout(() => {
+          // Token present but no state param: must be rejected.
+          void fetchTextAndCancel(`${callbackUrl}?token=attacker-token`);
+        }, scaleMs(100));
+
+        const result = await callbackPromise;
+        assertEquals(result.token, "");
+        assertEquals(result.error, "Missing state parameter");
+      });
+
+      it("should reject token when state does not match", async () => {
+        server = await startCallbackServer(9876, { expectedState });
+        const callbackUrl = getCallbackUrl(server.port);
+
+        const callbackPromise = server.waitForCallback(scaleMs(5000));
+
+        setTimeout(() => {
+          void fetchTextAndCancel(`${callbackUrl}?token=attacker-token&state=wrong-state`);
+        }, scaleMs(100));
+
+        const result = await callbackPromise;
+        assertEquals(result.token, "");
+        assertEquals(result.error, "Invalid state parameter");
+      });
+
+      it("should not echo the expected state in the rejection page", async () => {
+        server = await startCallbackServer(9876, { expectedState });
+        const callbackUrl = getCallbackUrl(server.port);
+
+        const callbackPromise = server.waitForCallback(scaleMs(5000));
+
+        let pageHtml = "";
+        setTimeout(() => {
+          void fetchTextAndCancel(`${callbackUrl}?token=attacker-token&state=wrong-state`)
+            .then((html) => {
+              pageHtml = html;
+            });
+        }, scaleMs(100));
+
+        await callbackPromise;
+        await new Promise((r) => setTimeout(r, scaleMs(100)));
+        // The secret state value must never be reflected back to the browser.
+        assertEquals(pageHtml.includes(expectedState), false);
+      });
+    });
+
+    describe("cross-origin rejection", { sanitizeOps: false, sanitizeResources: false }, () => {
+      async function fetchAndDrop(url: string, init?: RequestInit): Promise<void> {
+        const resp = await fetch(url, init);
+        await resp.body?.cancel();
+      }
+
+      it("should reject a request carrying a cross-origin Origin header", async () => {
+        server = await startCallbackServer(9876, { expectedState: "s" });
+        const callbackUrl = getCallbackUrl(server.port);
+
+        const callbackPromise = server.waitForCallback(scaleMs(5000));
+
+        setTimeout(() => {
+          void fetchAndDrop(`${callbackUrl}?token=attacker-token&state=s`, {
+            headers: { Origin: "https://evil.example.com" },
+          });
+        }, scaleMs(100));
+
+        const result = await callbackPromise;
+        assertEquals(result.token, "");
+        assertEquals(result.error, "Rejected cross-origin callback request");
+      });
+
+      it("allows a cross-origin Referer (state is the CSRF gate, not Referer)", async () => {
+        // A legitimate provider redirect over the https->http(loopback) downgrade
+        // may carry a cross-site Referer depending on the server's Referrer-Policy.
+        // Referer is deliberately not a rejection trigger; the single-use state
+        // nonce is. With a matching state the request must be accepted.
+        server = await startCallbackServer(9876, { expectedState: "s" });
+        const callbackUrl = getCallbackUrl(server.port);
+
+        const callbackPromise = server.waitForCallback(scaleMs(5000));
+
+        setTimeout(() => {
+          void fetchAndDrop(`${callbackUrl}?token=ok-token&state=s`, {
+            headers: { Referer: "https://accounts.google.com/o/oauth2/auth" },
+          });
+        }, scaleMs(100));
+
+        const result = await callbackPromise;
+        assertEquals(result.token, "ok-token");
+        assertEquals(result.error, undefined);
+      });
+
+      it("should allow a same-loopback Referer header", async () => {
+        server = await startCallbackServer(9876, { expectedState: "s" });
+        const callbackUrl = getCallbackUrl(server.port);
+
+        const callbackPromise = server.waitForCallback(scaleMs(5000));
+
+        setTimeout(() => {
+          void fetchAndDrop(`${callbackUrl}?token=ok-token&state=s`, {
+            headers: { Referer: `http://localhost:${server!.port}/` },
+          });
+        }, scaleMs(100));
+
+        const result = await callbackPromise;
+        assertEquals(result.token, "ok-token");
+        assertEquals(result.error, undefined);
+      });
+    });
   },
 );
+
+describe("generateCallbackState", { sanitizeOps: false, sanitizeResources: false }, () => {
+  it("should produce a long hex string (CSPRNG, 256-bit)", () => {
+    const state = generateCallbackState();
+    // 32 bytes -> 64 hex chars.
+    assertEquals(state.length, 64);
+    assertEquals(/^[0-9a-f]+$/.test(state), true);
+  });
+
+  it("should produce unique values across calls", () => {
+    const values = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      values.add(generateCallbackState());
+    }
+    // CSPRNG output must not collide across 100 draws.
+    assertEquals(values.size, 100);
+  });
+
+  it("should not be derived from Math.random", () => {
+    // Force Math.random to a constant; a CSPRNG-based generator must ignore it
+    // and still produce varying output.
+    const original = Math.random;
+    try {
+      Math.random = () => 0.5;
+      const a = generateCallbackState();
+      const b = generateCallbackState();
+      assertNotEquals(a, b);
+    } finally {
+      Math.random = original;
+    }
+  });
+});

--- a/cli/auth/callback-server.ts
+++ b/cli/auth/callback-server.ts
@@ -1,4 +1,5 @@
 import { isDeno } from "veryfront/platform";
+import { constantTimeEqual } from "veryfront/security";
 import { escapeHtml } from "veryfront/utils/html-escape";
 import {
   DEFAULT_CALLBACK_PORT,
@@ -15,6 +16,79 @@ export interface CallbackServer {
   port: number;
   waitForCallback(timeoutMs?: number): Promise<CallbackResult>;
   stop(): Promise<void>;
+}
+
+/** Options for the loopback OAuth callback server. */
+export interface StartCallbackServerOptions {
+  /**
+   * Expected `state` nonce for this login flow (CSRF / session-fixation
+   * binding). When set, the callback accepts a token ONLY when the request
+   * carries a `?state=` that matches this value. Missing or mismatched state
+   * is rejected. Generate this with a CSPRNG (see `generateCallbackState`).
+   * When omitted, state is not enforced (kept for callers that do not pass a
+   * state through the authorization URL).
+   */
+  expectedState?: string;
+}
+
+/**
+ * Generate a cryptographically random `state` nonce for the loopback OAuth
+ * flow. Uses the platform CSPRNG (`crypto.getRandomValues`), never
+ * `Math.random`. Mirrors the server-side web flow in `src/oauth/providers`.
+ */
+export function generateCallbackState(): string {
+  // 32 random bytes rendered as hex (256 bits of entropy).
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Reject callback requests that carry a cross-origin `Origin` header.
+ *
+ * The real CSRF defense for the loopback flow is the single-use `state` nonce
+ * (validated in `handleCallback`); this is a cheap secondary check. A legitimate
+ * top-level browser redirect from the authorization server to
+ * `http://127.0.0.1:<port>/callback` is a GET navigation that carries no
+ * `Origin` header, so a present cross-site `Origin` indicates a programmatic
+ * cross-origin request (login CSRF) and is rejected.
+ *
+ * `Referer` is deliberately NOT used as a rejection trigger: on the https->http
+ * (loopback) downgrade browsers strip or vary it by `Referrer-Policy`, so
+ * rejecting on a cross-site `Referer` would break legitimate logins for no
+ * security gain beyond the `state` nonce.
+ *
+ * Returns `true` when the request must be rejected.
+ */
+function isCrossOriginRequest(headers: { origin: string | null }): boolean {
+  return isForeignHeader(headers.origin);
+}
+
+function isForeignHeader(value: string | null): boolean {
+  // Absent header is the normal case for a top-level redirect: allow it.
+  if (!value) return false;
+  // Some browsers send the opaque "null" origin (e.g. sandboxed/privacy
+  // contexts) for a legitimate top-level navigation. Treat it as not foreign.
+  if (value === "null") return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    // An unparseable Origin/Referer is not a trusted same-origin value.
+    return true;
+  }
+  return !isLoopbackHost(parsed.hostname);
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]" ||
+    hostname === "::1";
+}
+
+/** Normalize a Node.js header value (`string | string[] | undefined`) to `string | null`. */
+function headerValue(value: string | string[] | undefined): string | null {
+  if (value === undefined) return null;
+  return Array.isArray(value) ? (value[0] ?? null) : value;
 }
 
 function renderSuccessPage(): string {
@@ -168,18 +242,50 @@ function isAddrInUseError(error: unknown): boolean {
   return false;
 }
 
-function handleCallback(url: URL): { result: CallbackResult; html: string } {
-  const token = url.searchParams.get("token");
-  const error = url.searchParams.get("error");
+interface CallbackRequest {
+  url: URL;
+  origin: string | null;
+}
+
+function handleCallback(
+  request: CallbackRequest,
+  expectedState?: string,
+): { result: CallbackResult; html: string } {
+  // Reject browser-initiated cross-origin requests (login CSRF). A legitimate
+  // top-level redirect does not carry a cross-site Origin header.
+  if (isCrossOriginRequest(request)) {
+    const message = "Rejected cross-origin callback request";
+    return { result: { token: "", error: message }, html: renderErrorPage(message) };
+  }
+
+  const token = request.url.searchParams.get("token");
+  const error = request.url.searchParams.get("error");
+  const state = request.url.searchParams.get("state");
 
   if (error) return { result: { token: "", error }, html: renderErrorPage(error) };
+
+  // When a state nonce was generated for this flow, the callback MUST carry a
+  // matching state before any token is accepted. Missing or mismatched state
+  // is a CSRF / session-fixation attempt and is rejected. The state value is
+  // never included in the error message or logged.
+  if (expectedState !== undefined) {
+    if (!state) {
+      const message = "Missing state parameter";
+      return { result: { token: "", error: message }, html: renderErrorPage(message) };
+    }
+    if (!constantTimeEqual(state, expectedState)) {
+      const message = "Invalid state parameter";
+      return { result: { token: "", error: message }, html: renderErrorPage(message) };
+    }
+  }
+
   if (token) return { result: { token }, html: renderSuccessPage() };
 
   const message = "No token received";
   return { result: { token: "", error: message }, html: renderErrorPage(message) };
 }
 
-function tryStartDenoServer(port: number): CallbackServer {
+function tryStartDenoServer(port: number, expectedState?: string): CallbackServer {
   let resolveCallback: (result: CallbackResult) => void = () => {};
   const callbackPromise = new Promise<CallbackResult>((resolve) => {
     resolveCallback = resolve;
@@ -196,7 +302,10 @@ function tryStartDenoServer(port: number): CallbackServer {
         return new Response("Not Found", { status: 404, headers: { Connection: "close" } });
       }
 
-      const { result, html } = handleCallback(url);
+      const { result, html } = handleCallback({
+        url,
+        origin: request.headers.get("origin"),
+      }, expectedState);
       resolveCallback(result);
 
       // Close connection immediately to allow clean server shutdown
@@ -215,10 +324,10 @@ function tryStartDenoServer(port: number): CallbackServer {
   };
 }
 
-function startDenoServer(startPort: number): CallbackServer {
+function startDenoServer(startPort: number, expectedState?: string): CallbackServer {
   for (let port = startPort, i = 0; i < MAX_PORT_ATTEMPTS; i++, port++) {
     try {
-      return tryStartDenoServer(port);
+      return tryStartDenoServer(port, expectedState);
     } catch (error) {
       if (!isAddrInUseError(error) || i === MAX_PORT_ATTEMPTS - 1) {
         throw error;
@@ -229,7 +338,7 @@ function startDenoServer(startPort: number): CallbackServer {
   throw new Error("Could not find an available port");
 }
 
-async function tryStartNodeServer(port: number): Promise<CallbackServer> {
+async function tryStartNodeServer(port: number, expectedState?: string): Promise<CallbackServer> {
   const http = await import("node:http");
 
   let resolveCallback: (result: CallbackResult) => void = () => {};
@@ -246,7 +355,10 @@ async function tryStartNodeServer(port: number): Promise<CallbackServer> {
       return;
     }
 
-    const { result, html } = handleCallback(url);
+    const { result, html } = handleCallback({
+      url,
+      origin: headerValue(req.headers.origin),
+    }, expectedState);
     resolveCallback(result);
 
     res.setHeader("Content-Type", "text/html; charset=utf-8");
@@ -270,10 +382,10 @@ async function tryStartNodeServer(port: number): Promise<CallbackServer> {
   };
 }
 
-async function startNodeServer(startPort: number): Promise<CallbackServer> {
+async function startNodeServer(startPort: number, expectedState?: string): Promise<CallbackServer> {
   for (let port = startPort, i = 0; i < MAX_PORT_ATTEMPTS; i++, port++) {
     try {
-      return await tryStartNodeServer(port);
+      return await tryStartNodeServer(port, expectedState);
     } catch (error) {
       if (!isAddrInUseError(error) || i === MAX_PORT_ATTEMPTS - 1) {
         throw error;
@@ -286,9 +398,13 @@ async function startNodeServer(startPort: number): Promise<CallbackServer> {
 
 export async function startCallbackServer(
   preferredPort: number = DEFAULT_CALLBACK_PORT,
+  options: StartCallbackServerOptions = {},
 ): Promise<CallbackServer> {
+  const { expectedState } = options;
   // Server functions handle port retry internally to avoid race conditions
-  return isDeno ? startDenoServer(preferredPort) : startNodeServer(preferredPort);
+  return isDeno
+    ? startDenoServer(preferredPort, expectedState)
+    : startNodeServer(preferredPort, expectedState);
 }
 
 export function getCallbackUrl(port: number): string {

--- a/cli/auth/login.test.ts
+++ b/cli/auth/login.test.ts
@@ -113,4 +113,59 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
       assertEquals(typeof userInfo.email, "string");
     });
   });
+
+  describe("buildOAuthAuthUrl (state binding)", {
+    sanitizeOps: false,
+    sanitizeResources: false,
+  }, () => {
+    const callbackUrl = "http://localhost:9876/callback";
+
+    it("should include a URL-encoded state query parameter", async () => {
+      const { buildOAuthAuthUrl } = await import("./login.ts");
+      const state = "abc123statevalue";
+      const url = buildOAuthAuthUrl("google", callbackUrl, state);
+
+      const parsed = new URL(url);
+      assertEquals(parsed.pathname, "/auth/google");
+      assertEquals(parsed.searchParams.get("state"), state);
+      assertEquals(parsed.searchParams.get("redirect_uri"), callbackUrl);
+    });
+
+    it("should percent-encode special characters in state", async () => {
+      const { buildOAuthAuthUrl } = await import("./login.ts");
+      // A state containing reserved characters must not break out of the query.
+      const state = "a b&c=d#e";
+      const url = buildOAuthAuthUrl("github", callbackUrl, state);
+
+      // Raw reserved characters must be encoded in the URL string.
+      assertEquals(url.includes(" "), false);
+      assertEquals(url.includes("state=a b"), false);
+      // Decoding the query yields the original value back, intact.
+      const parsed = new URL(url);
+      assertEquals(parsed.searchParams.get("state"), state);
+    });
+
+    it("should bind the same state value into the callback server contract", async () => {
+      // The state generated for the flow is the value the loopback server
+      // enforces. generateCallbackState is the CSPRNG source used by login.
+      const { buildOAuthAuthUrl } = await import("./login.ts");
+      const { generateCallbackState } = await import("./callback-server.ts");
+
+      const state = generateCallbackState();
+      const url = buildOAuthAuthUrl("microsoft", callbackUrl, state);
+      const parsed = new URL(url);
+      assertEquals(parsed.searchParams.get("state"), state);
+      assertEquals(state.length, 64);
+    });
+  });
+
+  describe("API token login path", { sanitizeOps: false, sanitizeResources: false }, () => {
+    it("should keep validateToken usable for the non-OAuth path", async () => {
+      // The API-token login path must remain intact alongside the OAuth
+      // state-binding changes. An empty token is rejected without a network
+      // call returning a token.
+      const { validateToken } = await import("./login.ts");
+      assertEquals(await validateToken(""), null);
+    });
+  });
 });

--- a/cli/auth/login.ts
+++ b/cli/auth/login.ts
@@ -2,7 +2,7 @@ import { cliLogger } from "#cli/utils";
 import { getStdinReader, setRawMode, writeStdout } from "veryfront/platform";
 import { type EnvironmentConfig, getEnvironmentConfig } from "veryfront/config";
 import { deleteToken, getTokenLocation, hasToken, readToken, saveToken } from "./token-store.ts";
-import { getCallbackUrl, startCallbackServer } from "./callback-server.ts";
+import { generateCallbackState, getCallbackUrl, startCallbackServer } from "./callback-server.ts";
 import { canOpenBrowser, openBrowser } from "./browser.ts";
 import { isTTY, promptUser } from "../utils/index.ts";
 import { brand, dim, error, muted, success, warning } from "../ui/colors.ts";
@@ -105,6 +105,23 @@ async function promptAuthMethod(): Promise<AuthMethod> {
   }
 }
 
+/**
+ * Build the provider authorization URL for the loopback login flow.
+ *
+ * The `state` nonce binds the browser flow to this CLI process (CSRF /
+ * session-fixation protection) and is URL-encoded. The auth server must echo
+ * `state` back to `redirect_uri` so the callback can verify it.
+ */
+export function buildOAuthAuthUrl(
+  provider: "google" | "github" | "microsoft",
+  callbackUrl: string,
+  state: string,
+): string {
+  return `${getApiUrl()}/auth/${provider}?redirect_uri=${encodeURIComponent(callbackUrl)}&state=${
+    encodeURIComponent(state)
+  }`;
+}
+
 async function loginWithOAuth(provider: "google" | "github" | "microsoft"): Promise<string | null> {
   console.log();
 
@@ -116,16 +133,22 @@ async function loginWithOAuth(provider: "google" | "github" | "microsoft"): Prom
 
   console.log("  " + dim("Starting authentication server..."));
 
+  // CSRF / session-fixation binding: generate a single-use CSPRNG state nonce,
+  // bind the loopback callback to it, and send it on the authorization URL.
+  // The callback accepts a token only when the returned state matches. The
+  // state value must never be logged.
+  const state = generateCallbackState();
+
   let server: Awaited<ReturnType<typeof startCallbackServer>>;
   try {
-    server = await startCallbackServer();
+    server = await startCallbackServer(undefined, { expectedState: state });
   } catch (e) {
     console.log("  " + error(`Failed to start server: ${e}`));
     return null;
   }
 
   const callbackUrl = getCallbackUrl(server.port);
-  const authUrl = `${getApiUrl()}/auth/${provider}?redirect_uri=${encodeURIComponent(callbackUrl)}`;
+  const authUrl = buildOAuthAuthUrl(provider, callbackUrl, state);
 
   console.log("  " + brand("Opening browser to log in..."));
   console.log();

--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -8,6 +8,8 @@
 export { BaseHandler } from "./http/base-handler.ts";
 export type { HandlerHelpers } from "./http/base-handler.ts";
 
+export { constantTimeEqual } from "./utils/constant-time.ts";
+
 export {
   CommonSchemas,
   createValidatedHandler,


### PR DESCRIPTION
## Description

Binds the CLI loopback OAuth login flow with a single-use `state` nonce and an
`Origin` check, closing a login CSRF / session-fixation gap.

Before this change, `loginWithOAuth` started a loopback HTTP server and opened
the OAuth URL with only `redirect_uri`. No `state` was generated, sent, or
verified, and the loopback `/callback` accepted any `?token=` with no `Origin`
check. During the login window, a local web page or co-located process could
deliver an attacker-chosen token to the callback, silently binding the user's
CLI to the attacker's account.

Changes (client side, `cli/auth` only):

- Generate a single-use CSPRNG `state` (256-bit) per login flow and include it
  URL-encoded in the authorization URL.
- Bind the loopback callback to the expected `state`: accept a token only when
  the returned `state` matches (constant-time compare via the shared
  `constantTimeEqual`); reject missing or mismatched `state`. `state` is never
  logged or echoed back to the browser.
- Reject callback requests carrying a cross-origin `Origin` header. `Referer` is
  intentionally **not** used as a gate: the `https`→`http(loopback)` downgrade
  strips it by policy, so it would break real logins; the `state` nonce is the
  real defense.
- Extract `buildOAuthAuthUrl` so the state-in-URL contract is unit-testable.

State enforcement is opt-in (`startCallbackServer(port, { expectedState })`), so
the demo callback and the API-token login path are unaffected.

**Server dependency:** the hosted `/auth/{provider}` endpoint must echo the
`state` query param back to `redirect_uri`. The full client side is implemented
here and fails closed on missing `state`, so that server change must be
coordinated before OAuth login is re-enabled end to end.

## Related Issue(s)

Fixes #2321

Context: this came out of the 2026-06-10 security audit that also filed
#2317–#2320. #2318, #2319, and #2320 were already fixed upstream (PRs #2322,
#2323, #2324), so they are intentionally not in this PR. #2317 (mandatory
isolation) is architectural and remains open. Two residual gaps in the
already-merged fixes are flagged in comments on #2320 and #2318.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

Tests: happy path (matching `state` accepted), missing `state` rejected,
mismatched `state` rejected, cross-origin `Origin` rejected, `state` not echoed
in the error page, CSPRNG generation (length/uniqueness, not `Math.random`). The
demo callback and API-token paths keep their existing tests.
`deno fmt`/`deno lint` clean; `cli/auth` suite green (10 files, 84 steps).

Note: the local pre-push `deno check src/index.ts` fails in the sandbox on
pre-existing, environment-specific React (`esm.sh @types/react`) type resolution
that also fails on a no-op push of `main`; this PR adds zero new type errors. CI
will run the authoritative checks.
