### PR TITLE
Warn on untrusted in-process route execution

### DIFF
--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -14,6 +14,7 @@ import { loadHandlerModule } from "./module-loader/loader.ts";
 import { discoverAppRoutes, discoverPagesRoutes } from "./route-discovery.ts";
 import { executeAppRoute, executePagesRoute, type ExecuteRouteOptions } from "./route-executor.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import type { HandlerContext } from "#veryfront/types";
 
 /** Max entries in the loaded-handler LRU cache */
 const HANDLER_CACHE_MAX_ENTRIES = 256;
@@ -129,7 +130,7 @@ export class APIRouteHandler {
     );
   }
 
-  handle(request: Request): Promise<Response | null> {
+  handle(request: Request, ctx?: HandlerContext): Promise<Response | null> {
     const { pathname } = new URL(request.url);
 
     return withSpan(
@@ -192,6 +193,7 @@ export class APIRouteHandler {
         const isolationOptions: ExecuteRouteOptions = {
           modulePath: match.route.page,
           projectDir: this.projectDir,
+          isLocalProject: ctx?.isLocalProject,
         };
 
         const response = isAppRoute

--- a/src/routing/api/route-executor.test.ts
+++ b/src/routing/api/route-executor.test.ts
@@ -1,10 +1,15 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
-import { executeAppRoute, executePagesRoute } from "./route-executor.ts";
+import {
+  __resetInProcessIsolationWarningForTests,
+  executeAppRoute,
+  executePagesRoute,
+} from "./route-executor.ts";
 import type { RouteMatch } from "./api-route-matcher.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { __resetPoolForTests } from "#veryfront/security/sandbox/worker-pool.ts";
+import { __resetLoggerConfigForTests } from "../../utils/logger/index.ts";
 
 function makeAdapter(mode = "development"): RuntimeAdapter {
   const envMap = new Map<string, string>([["MODE", mode]]);
@@ -66,6 +71,36 @@ function makeMatch(
   params: RouteMatch["params"] = {},
 ): RouteMatch {
   return { route: { pattern, page }, params };
+}
+
+function captureConsoleWarn(): { getOutput: () => string; restore: () => void } {
+  const originalWarn = console.warn;
+  const output: string[] = [];
+
+  console.warn = (...args: unknown[]) => {
+    output.push(args.map(String).join(" "));
+  };
+
+  return {
+    getOutput: () => output.join("\n"),
+    restore: () => {
+      console.warn = originalWarn;
+    },
+  };
+}
+
+function restoreEnv(snapshot: Map<string, string | undefined>): void {
+  for (const [key, value] of snapshot) {
+    if (value === undefined) {
+      Deno.env.delete(key);
+    } else {
+      Deno.env.set(key, value);
+    }
+  }
+}
+
+function snapshotEnv(keys: string[]): Map<string, string | undefined> {
+  return new Map(keys.map((key) => [key, Deno.env.get(key)]));
 }
 
 describe("routing/api/route-executor", () => {
@@ -469,6 +504,115 @@ describe("routing/api/route-executor", () => {
       );
 
       assertEquals(response.status, 500);
+    });
+  });
+
+  describe("untrusted in-process execution warning", () => {
+    const envKeys = [
+      "WORKER_ISOLATION_ENABLED",
+      "WORKER_ISOLATION_API",
+      "LOG_FORMAT",
+      "LOG_LEVEL",
+      "NO_COLOR",
+    ];
+
+    afterEach(() => {
+      Deno.env.delete("WORKER_ISOLATION_ENABLED");
+      Deno.env.delete("WORKER_ISOLATION_API");
+      __resetPoolForTests();
+      __resetInProcessIsolationWarningForTests();
+      __resetLoggerConfigForTests();
+    });
+
+    it("warns once when a remote app route falls back to in-process execution", async () => {
+      const envSnapshot = snapshotEnv(envKeys);
+      Deno.env.delete("WORKER_ISOLATION_ENABLED");
+      Deno.env.delete("WORKER_ISOLATION_API");
+      Deno.env.set("LOG_FORMAT", "text");
+      Deno.env.set("LOG_LEVEL", "WARN");
+      Deno.env.set("NO_COLOR", "1");
+      __resetPoolForTests();
+      __resetInProcessIsolationWarningForTests();
+      __resetLoggerConfigForTests();
+
+      const captured = captureConsoleWarn();
+      try {
+        const handler = {
+          GET: () => new Response("ok"),
+        };
+        const request = new Request("http://localhost/api/test", { method: "GET" });
+        const options = {
+          modulePath: "/tmp/test/handler.ts",
+          projectDir: "/tmp/test",
+          isLocalProject: false,
+        };
+
+        const first = await executeAppRoute(
+          handler,
+          request,
+          makeMatch(),
+          "/api/test",
+          makeAdapter(),
+          options,
+        );
+        const second = await executeAppRoute(
+          handler,
+          new Request("http://localhost/api/test", { method: "GET" }),
+          makeMatch(),
+          "/api/test",
+          makeAdapter(),
+          options,
+        );
+
+        assertEquals(first.status, 200);
+        assertEquals(second.status, 200);
+        assertEquals(await first.text(), "ok");
+        assertEquals(await second.text(), "ok");
+
+        const output = captured.getOutput();
+        assertEquals((output.match(/worker isolation disabled/g) ?? []).length, 1);
+        assert(output.includes("WORKER_ISOLATION_ENABLED"));
+        assert(output.includes("WORKER_ISOLATION_API"));
+      } finally {
+        captured.restore();
+        restoreEnv(envSnapshot);
+        __resetLoggerConfigForTests();
+      }
+    });
+
+    it("does not warn for local app route in-process execution", async () => {
+      const envSnapshot = snapshotEnv(envKeys);
+      Deno.env.delete("WORKER_ISOLATION_ENABLED");
+      Deno.env.delete("WORKER_ISOLATION_API");
+      Deno.env.set("LOG_FORMAT", "text");
+      Deno.env.set("LOG_LEVEL", "WARN");
+      Deno.env.set("NO_COLOR", "1");
+      __resetPoolForTests();
+      __resetInProcessIsolationWarningForTests();
+      __resetLoggerConfigForTests();
+
+      const captured = captureConsoleWarn();
+      try {
+        const response = await executeAppRoute(
+          { GET: () => new Response("ok") },
+          new Request("http://localhost/api/test", { method: "GET" }),
+          makeMatch(),
+          "/api/test",
+          makeAdapter(),
+          {
+            modulePath: "/tmp/test/handler.ts",
+            projectDir: "/tmp/test",
+            isLocalProject: true,
+          },
+        );
+
+        assertEquals(response.status, 200);
+        assertEquals(captured.getOutput(), "");
+      } finally {
+        captured.restore();
+        restoreEnv(envSnapshot);
+        __resetLoggerConfigForTests();
+      }
     });
   });
 

--- a/src/routing/api/route-executor.test.ts
+++ b/src/routing/api/route-executor.test.ts
@@ -505,6 +505,57 @@ describe("routing/api/route-executor", () => {
 
       assertEquals(response.status, 500);
     });
+
+    it("continues pages API route execution when isolation warning logging fails", async () => {
+      const envSnapshot = snapshotEnv([
+        "WORKER_ISOLATION_ENABLED",
+        "WORKER_ISOLATION_API",
+        "LOG_FORMAT",
+        "LOG_LEVEL",
+        "NO_COLOR",
+      ]);
+      Deno.env.delete("WORKER_ISOLATION_ENABLED");
+      Deno.env.delete("WORKER_ISOLATION_API");
+      Deno.env.set("LOG_FORMAT", "text");
+      Deno.env.set("LOG_LEVEL", "WARN");
+      Deno.env.set("NO_COLOR", "1");
+      __resetPoolForTests();
+      __resetInProcessIsolationWarningForTests();
+      __resetLoggerConfigForTests();
+      const originalWarn = console.warn;
+
+      try {
+        console.warn = () => {
+          throw new Error("warning sink unavailable");
+        };
+
+        const handler = {
+          GET: () => Response.json({ msg: "pages api" }),
+        };
+
+        const request = new Request("http://localhost/api/hello", { method: "GET" });
+        const response = await executePagesRoute(
+          handler,
+          request,
+          makeMatch("/api/hello", "/tmp/test/pages/api/hello.ts"),
+          "/api/hello",
+          makeAdapter("production"),
+          "/tmp/test",
+          {
+            modulePath: "/tmp/test/pages/api/hello.ts",
+            projectDir: "/tmp/test",
+            isLocalProject: false,
+          },
+        );
+
+        assertEquals(response.status, 200);
+        assertEquals(await response.json(), { msg: "pages api" });
+      } finally {
+        console.warn = originalWarn;
+        restoreEnv(envSnapshot);
+        __resetLoggerConfigForTests();
+      }
+    });
   });
 
   describe("untrusted in-process execution warning", () => {
@@ -772,12 +823,14 @@ describe("routing/api/route-executor", () => {
         },
       });
 
-      const request = new Request("http://localhost/api/test", {
-        method: "POST",
-        body: stream,
-        // deno-lint-ignore no-explicit-any
-        duplex: "half" as any,
-      });
+      const request = new Request(
+        "http://localhost/api/test",
+        {
+          method: "POST",
+          body: stream,
+          duplex: "half",
+        } as RequestInit & { duplex: "half" },
+      );
 
       const response = await executeAppRoute(
         handler,

--- a/src/routing/api/route-executor.ts
+++ b/src/routing/api/route-executor.ts
@@ -154,6 +154,35 @@ function checkContentLengthLimit(request: Request): void {
   }
 }
 
+let warnedUntrustedInProcessExecution = false;
+
+export function __resetInProcessIsolationWarningForTests(): void {
+  warnedUntrustedInProcessExecution = false;
+}
+
+function warnIfUntrustedInProcessExecution(
+  routeKind: "app" | "pages",
+  pathname: string,
+  options?: ExecuteRouteOptions,
+): void {
+  if (options?.isLocalProject !== false) return;
+  if (isWorkerIsolationEnabled()) return;
+  if (warnedUntrustedInProcessExecution) return;
+
+  warnedUntrustedInProcessExecution = true;
+  logger.warn(
+    "Untrusted project code is executing in-process with worker isolation disabled. Enable WORKER_ISOLATION_ENABLED=1 and WORKER_ISOLATION_API=1 to run project routes in a permission-restricted worker.",
+    {
+      modulePath: options.modulePath,
+      pathname,
+      projectDir: options.projectDir,
+      requiredEnv: ["WORKER_ISOLATION_ENABLED", "WORKER_ISOLATION_API"],
+      routeKind,
+      workerIsolationEnabled: false,
+    },
+  );
+}
+
 async function readBodyWithSizeGuard(request: Request): Promise<Uint8Array | null> {
   if (!request.body) return null;
 
@@ -343,6 +372,8 @@ export interface ExecuteRouteOptions {
   modulePath?: string;
   /** Project directory (for isolated execution scope) */
   projectDir?: string;
+  /** Whether the handler module belongs to a trusted local development project. */
+  isLocalProject?: boolean;
 }
 
 export function executeAppRoute(
@@ -370,6 +401,7 @@ export function executeAppRoute(
   }
 
   // Default path: execute in main process (existing behavior)
+  warnIfUntrustedInProcessExecution("app", pathname, options);
   const method = request.method.toUpperCase() as HTTPMethod;
 
   return withSpan(
@@ -425,6 +457,7 @@ export function executePagesRoute(
   }
 
   // Default path: execute in main process (existing behavior)
+  warnIfUntrustedInProcessExecution("pages", pathname, options);
   const method = request.method as keyof APIRoute;
 
   return withSpan(

--- a/src/routing/api/route-executor.ts
+++ b/src/routing/api/route-executor.ts
@@ -170,17 +170,21 @@ function warnIfUntrustedInProcessExecution(
   if (warnedUntrustedInProcessExecution) return;
 
   warnedUntrustedInProcessExecution = true;
-  logger.warn(
-    "Untrusted project code is executing in-process with worker isolation disabled. Enable WORKER_ISOLATION_ENABLED=1 and WORKER_ISOLATION_API=1 to run project routes in a permission-restricted worker.",
-    {
-      modulePath: options.modulePath,
-      pathname,
-      projectDir: options.projectDir,
-      requiredEnv: ["WORKER_ISOLATION_ENABLED", "WORKER_ISOLATION_API"],
-      routeKind,
-      workerIsolationEnabled: false,
-    },
-  );
+  try {
+    logger.warn(
+      "Untrusted project code is executing in-process with worker isolation disabled. Enable WORKER_ISOLATION_ENABLED=1 and WORKER_ISOLATION_API=1 to run project routes in a permission-restricted worker.",
+      {
+        modulePath: options.modulePath,
+        pathname,
+        projectDir: options.projectDir,
+        requiredEnv: ["WORKER_ISOLATION_ENABLED", "WORKER_ISOLATION_API"],
+        routeKind,
+        workerIsolationEnabled: false,
+      },
+    );
+  } catch {
+    // A diagnostic warning must not prevent the API route from running.
+  }
 }
 
 async function readBodyWithSizeGuard(request: Request): Promise<Uint8Array | null> {

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -110,7 +110,7 @@ export class ApiHandlerWrapper extends BaseHandler {
           await ensureProjectDiscovery(ctx);
 
           const api = await getApiHandler(ctx);
-          const apiRes = await api.handle(req);
+          const apiRes = await api.handle(req, ctx);
 
           if (!apiRes) {
             this.logDebug(


### PR DESCRIPTION
## Summary

Adds the Phase 1 warning for #2317 when a remote/untrusted project route would execute in-process while worker isolation is disabled.

## Changes

- Threads `isLocalProject` from `ApiHandlerWrapper` into `APIRouteHandler.handle()` and then into `ExecuteRouteOptions`.
- Emits a single process-local warning before the existing in-process fallback for untrusted app/pages route execution.
- Names the required isolation env flags in the warning: `WORKER_ISOLATION_ENABLED=1` and `WORKER_ISOLATION_API=1`.
- Covers the warning path with a unit test that verifies execution behavior remains unchanged.

## Simplifications made

- Kept the change at the existing route-executor boundary instead of introducing a new isolation policy layer.
- Preserved the current execution behavior; this PR only adds visibility for the known Phase 1 risk.

## Verification

- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all --unstable-worker-options src/routing/api/route-executor.test.ts`
- `deno fmt --check src/routing/api/route-executor.ts src/routing/api/route-executor.test.ts src/routing/api/handler.ts src/server/handlers/request/api/api-handler-wrapper.ts`
- `deno check src/routing/api/route-executor.ts src/routing/api/handler.ts src/server/handlers/request/api/api-handler-wrapper.ts`
- `deno task verify:quick`
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/server/build-app-route-renderer.test.ts`

## Remaining risks

- Phase 2 is still required to make untrusted route execution worker-gated by default.
- The full pre-push unit suite hit a parallel-only failure in `src/server/build-app-route-renderer.test.ts`; the same test passed in isolation under the same env. `deno task verify:quick` and the focused route-executor test passed.

Related: #2317
