### PR TITLE
Extract proxy token resolution from handler

### DIFF
--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -7,6 +7,10 @@ import { computeContentSourceId } from "#veryfront/cache/keys.ts";
 import { resolve as resolveContract } from "../extensions/contracts.ts";
 import type { AuthProvider } from "../extensions/auth/index.ts";
 import { createLocalProjectResolver } from "./local-project-resolver.ts";
+import {
+  isMissingCustomDomainProjectError,
+  resolveProxyRequestToken,
+} from "./proxy-token-resolution.ts";
 
 /**
  * Cache the resolved AuthProvider at module scope so the proxy does not pay
@@ -234,24 +238,10 @@ function getScope(environment: string | null): TokenScope {
   return environment === "preview" ? "preview" : "production";
 }
 
-function extractUserToken(cookieHeader: string): string | undefined {
-  const match = cookieHeader.match(/(?:^|;\s*)authToken=([^;]+)/);
-  return match?.[1] ? decodeURIComponent(match[1]) : undefined;
-}
-
 function parseStatusFromError(error: unknown): number | null {
   const message = error instanceof Error ? error.message : String(error);
   const match = message.match(/failed: (\d+)/);
   return match ? Number(match[1]) : null;
-}
-
-// Brittle on purpose: we string-match the API's OAuth error body. Source of truth is
-// veryfront-api/src/api/http/rest/auth/routes.ts — `oauthError(c, 'Project not found
-// for domain', ...)`. If that string is renamed, this regex silently regresses to 502.
-// Durable fix is a typed error code from the token-mint helper; tracked separately.
-function isMissingCustomDomainProjectError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return /project not found for domain/i.test(message);
 }
 
 async function extractUserIdFromToken(
@@ -408,60 +398,6 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     );
   }
 
-  async function resolveRequestToken(
-    req: Request,
-    url: URL,
-    scope: TokenScope,
-    host: string,
-    projectSlug: string | undefined,
-    options: {
-      allowSignedInternalControlPlaneToken?: boolean;
-      tokenFetchErrorMessage: string;
-    },
-  ): Promise<{ token?: string; userToken?: string; tokenFetchError?: unknown }> {
-    const userToken = extractUserToken(req.headers.get("cookie") ?? "");
-    const useSignedInternalControlPlaneToken = options.allowSignedInternalControlPlaneToken &&
-      isSignedInternalControlPlaneRequest(req, url);
-
-    let token: string | undefined;
-    let tokenFetchError: unknown;
-
-    if (useSignedInternalControlPlaneToken) {
-      token = req.headers.get("x-token") ?? undefined;
-      logger?.debug("Using signed control-plane token for internal request", {
-        pathname: url.pathname,
-        scope,
-      });
-    } else if (scope === "preview" && userToken) {
-      token = userToken;
-      logger?.debug("Using user auth token for preview");
-    }
-
-    if (!token && config.apiClientId && config.apiClientSecret) {
-      const customDomain = projectSlug ? undefined : host;
-      if (projectSlug || customDomain) {
-        try {
-          token = await tokenManager.getToken(scope, projectSlug, customDomain);
-        } catch (error) {
-          tokenFetchError = error;
-          if (!(customDomain && isMissingCustomDomainProjectError(error))) {
-            logger?.error(options.tokenFetchErrorMessage, error as Error, {
-              projectSlug,
-              customDomain,
-            });
-          }
-        }
-      }
-    }
-
-    if (!token && config.apiToken) {
-      token = config.apiToken;
-      logger?.debug("Using static API token fallback");
-    }
-
-    return { token, userToken, tokenFetchError };
-  }
-
   async function checkProtectedAccess(
     req: Request,
     url: URL,
@@ -604,14 +540,18 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     if (isLocalProject) {
       logger?.debug("Local project, skipping token fetch", { localPath });
     } else {
-      ({ token, userToken, tokenFetchError } = await resolveRequestToken(
-        req,
-        url,
-        scope,
-        host,
-        projectSlug,
+      ({ token, userToken, tokenFetchError } = await resolveProxyRequestToken(
         {
+          req,
+          url,
+          scope,
+          host,
+          projectSlug,
+          config,
+          tokenManager,
+          logger,
           allowSignedInternalControlPlaneToken: true,
+          signedInternalControlPlaneRequest: isSignedInternalControlPlaneRequest(req, url),
           tokenFetchErrorMessage: "Token fetch failed",
         },
       ));
@@ -831,16 +771,18 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     const parsedDomain = parseProjectDomain(host);
     const scope = getScope(parsedDomain.environment);
     const projectSlug = parsedDomain.slug ?? undefined;
-    const { token } = await resolveRequestToken(
+    const { token } = await resolveProxyRequestToken({
       req,
       url,
       scope,
       host,
       projectSlug,
-      {
-        tokenFetchErrorMessage: "Token fetch failed for API",
-      },
-    );
+      config,
+      tokenManager,
+      logger,
+      signedInternalControlPlaneRequest: isSignedInternalControlPlaneRequest(req, url),
+      tokenFetchErrorMessage: "Token fetch failed for API",
+    });
     return token;
   }
 

--- a/src/proxy/proxy-token-resolution.test.ts
+++ b/src/proxy/proxy-token-resolution.test.ts
@@ -1,0 +1,81 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  isMissingCustomDomainProjectError,
+  resolveProxyRequestToken,
+} from "./proxy-token-resolution.ts";
+
+describe("proxy/proxy-token-resolution", () => {
+  it("prefers signed internal control-plane tokens over preview user cookies", async () => {
+    const tokenManagerCalls: unknown[] = [];
+    const result = await resolveProxyRequestToken({
+      req: new Request("https://example.com/channels/invoke", {
+        headers: {
+          cookie: "authToken=user-cookie-token",
+          "x-token": "signed-control-plane-token",
+        },
+      }),
+      url: new URL("https://example.com/channels/invoke"),
+      scope: "preview",
+      host: "example.com",
+      projectSlug: "my-project",
+      config: {
+        apiClientId: "client",
+        apiClientSecret: "secret",
+        apiToken: "static-token",
+      },
+      tokenManager: {
+        getToken(...args) {
+          tokenManagerCalls.push(args);
+          return Promise.resolve("oauth-token");
+        },
+      },
+      signedInternalControlPlaneRequest: true,
+      allowSignedInternalControlPlaneToken: true,
+      tokenFetchErrorMessage: "Token fetch failed",
+    });
+
+    assertEquals(result.token, "signed-control-plane-token");
+    assertEquals(result.userToken, "user-cookie-token");
+    assertEquals(result.tokenFetchError, undefined);
+    assertEquals(tokenManagerCalls, []);
+  });
+
+  it("returns custom-domain token fetch errors without logging expected misses as errors", async () => {
+    const loggedErrors: string[] = [];
+    const notFoundError = new Error(
+      "OAuth token request failed: 400 - Project not found for domain",
+    );
+
+    const result = await resolveProxyRequestToken({
+      req: new Request("https://custom.example/page"),
+      url: new URL("https://custom.example/page"),
+      scope: "production",
+      host: "custom.example",
+      projectSlug: undefined,
+      config: {
+        apiClientId: "client",
+        apiClientSecret: "secret",
+        apiToken: undefined,
+      },
+      tokenManager: {
+        getToken() {
+          return Promise.reject(notFoundError);
+        },
+      },
+      logger: {
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: (message) => loggedErrors.push(message),
+      },
+      tokenFetchErrorMessage: "Token fetch failed",
+    });
+
+    assertEquals(result.token, undefined);
+    assertEquals(result.tokenFetchError, notFoundError);
+    assertEquals(isMissingCustomDomainProjectError(result.tokenFetchError), true);
+    assertEquals(loggedErrors, []);
+  });
+});

--- a/src/proxy/proxy-token-resolution.ts
+++ b/src/proxy/proxy-token-resolution.ts
@@ -1,0 +1,111 @@
+import type { TokenScope } from "./token-manager.ts";
+
+export interface ProxyTokenResolutionConfig {
+  apiClientId: string;
+  apiClientSecret: string;
+  apiToken?: string;
+}
+
+export interface ProxyTokenManager {
+  getToken(
+    scope: TokenScope,
+    projectSlug?: string,
+    customDomain?: string,
+  ): Promise<string>;
+}
+
+export interface ProxyTokenResolutionLogger {
+  debug: (msg: string, extra?: Record<string, unknown>) => void;
+  info: (msg: string, extra?: Record<string, unknown>) => void;
+  warn: (msg: string, extra?: Record<string, unknown>) => void;
+  error: (msg: string, error?: Error, extra?: Record<string, unknown>) => void;
+}
+
+export interface ResolveProxyRequestTokenOptions {
+  req: Request;
+  url: URL;
+  scope: TokenScope;
+  host: string;
+  projectSlug: string | undefined;
+  config: ProxyTokenResolutionConfig;
+  tokenManager: ProxyTokenManager;
+  logger?: ProxyTokenResolutionLogger;
+  allowSignedInternalControlPlaneToken?: boolean;
+  signedInternalControlPlaneRequest?: boolean;
+  tokenFetchErrorMessage: string;
+}
+
+export interface ResolvedProxyRequestToken {
+  token?: string;
+  userToken?: string;
+  tokenFetchError?: unknown;
+}
+
+export function extractUserToken(cookieHeader: string): string | undefined {
+  const match = cookieHeader.match(/(?:^|;\s*)authToken=([^;]+)/);
+  return match?.[1] ? decodeURIComponent(match[1]) : undefined;
+}
+
+// Brittle on purpose: the API currently returns this text when token minting
+// cannot map a custom domain. Tracked in #2217 until a typed error code exists.
+export function isMissingCustomDomainProjectError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /project not found for domain/i.test(message);
+}
+
+export async function resolveProxyRequestToken(
+  options: ResolveProxyRequestTokenOptions,
+): Promise<ResolvedProxyRequestToken> {
+  const {
+    config,
+    host,
+    logger,
+    projectSlug,
+    req,
+    scope,
+    tokenFetchErrorMessage,
+    tokenManager,
+    url,
+  } = options;
+  const userToken = extractUserToken(req.headers.get("cookie") ?? "");
+  const useSignedInternalControlPlaneToken = options.allowSignedInternalControlPlaneToken &&
+    options.signedInternalControlPlaneRequest;
+
+  let token: string | undefined;
+  let tokenFetchError: unknown;
+
+  if (useSignedInternalControlPlaneToken) {
+    token = req.headers.get("x-token") ?? undefined;
+    logger?.debug("Using signed control-plane token for internal request", {
+      pathname: url.pathname,
+      scope,
+    });
+  } else if (scope === "preview" && userToken) {
+    token = userToken;
+    logger?.debug("Using user auth token for preview");
+  }
+
+  if (!token && config.apiClientId && config.apiClientSecret) {
+    const customDomain = projectSlug ? undefined : host;
+    if (projectSlug || customDomain) {
+      try {
+        token = await tokenManager.getToken(scope, projectSlug, customDomain);
+      } catch (error) {
+        tokenFetchError = error;
+        if (!(customDomain && isMissingCustomDomainProjectError(error))) {
+          logger?.error(tokenFetchErrorMessage, error as Error, {
+            projectSlug,
+            customDomain,
+          });
+        }
+      }
+    }
+  }
+
+  if (!token && config.apiToken) {
+    token = config.apiToken;
+    logger?.debug("Using static API token fallback");
+  }
+
+  return { token, userToken, tokenFetchError };
+}


### PR DESCRIPTION
## Summary

Moves the proxy request token cascade out of `src/proxy/handler.ts` into `src/proxy/proxy-token-resolution.ts` as the next focused slice for #2217.

This keeps the existing behavior intact:
- signed internal control-plane token precedence
- preview user cookie token precedence
- OAuth token minting by project slug or custom domain
- expected custom-domain token-mint miss handling
- static API token fallback

## Verification

- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/proxy/proxy-token-resolution.test.ts src/proxy/token-priority.test.ts src/proxy/handler.test.ts`
- `deno check src/proxy/handler.ts src/proxy/proxy-token-resolution.ts src/proxy/proxy-token-resolution.test.ts`
- `deno fmt --check src/proxy/handler.ts src/proxy/proxy-token-resolution.ts src/proxy/proxy-token-resolution.test.ts`
- `deno task verify:quick`
- Pre-push hook ran format, lint, typecheck, and the full unit suite, then failed on the known unrelated parallel-suite `src/server/build-app-route-renderer.test.ts` assertion. That test passed immediately in isolation with the production-like test env:
  `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/server/build-app-route-renderer.test.ts`

## Remaining risk

This is intentionally not the full #2217 roadmap. Auth/member extraction, lifecycle wrapping, dashboard route splitting, and typed proxy error codes remain for follow-up slices.

Refs #2217
