### PR TITLE
Route MDX veryfront imports through unified strategy

### DIFF
--- a/src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.test.ts
@@ -47,6 +47,15 @@ describe("rewriteVeryfrontImports", () => {
       ].join("\n"),
     );
   });
+
+  it("uses the unified veryfront strategy for SSR-only module overrides", () => {
+    const code = `import { useWorkflow } from "veryfront/workflow";\n`;
+
+    assertEquals(
+      rewriteVeryfrontImports(code),
+      `import { useWorkflow } from "/_vf_modules/_veryfront/workflow/react/index.js?ssr=true";\n`,
+    );
+  });
 });
 
 describe("rewriteDntImports", () => {

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.ts
@@ -6,7 +6,12 @@
 
 import { dirname, join, resolve } from "#veryfront/compat/path";
 import { FRAMEWORK_ROOT } from "../constants.ts";
-import { resolveVeryfrontModuleUrl } from "../../../veryfront-module-urls.ts";
+import {
+  DEFAULT_REACT_VERSION,
+  type ImportSpecifierInfo,
+  type RewriteContext,
+  veryfrontStrategy,
+} from "../../../import-rewriter/index.ts";
 import { getLocalFs } from "../cache/index.ts";
 import {
   findStaticImportFromSpans,
@@ -14,6 +19,31 @@ import {
   replaceSourceSpans,
   type SourceSpanReplacement,
 } from "../utils/source-spans.ts";
+
+const MODULE_FETCHER_VERYFRONT_CONTEXT: RewriteContext = {
+  filePath: "",
+  projectDir: "",
+  projectId: "",
+  target: "ssr",
+  dev: false,
+  reactVersion: DEFAULT_REACT_VERSION,
+};
+
+function rewriteVeryfrontModuleSpecifier(specifier: string): string | null {
+  const result = veryfrontStrategy.rewrite(
+    {
+      specifier,
+      isDynamic: false,
+      start: 0,
+      end: specifier.length,
+      statementStart: 0,
+      statementEnd: 0,
+      raw: {} as ImportSpecifierInfo["raw"],
+    },
+    MODULE_FETCHER_VERYFRONT_CONTEXT,
+  );
+  return result.specifier;
+}
 
 /**
  * Rewrite veryfront/* imports to /_vf_modules/_veryfront/ paths for MDX module loading.
@@ -24,13 +54,13 @@ export function rewriteVeryfrontImports(code: string): string {
     code,
     (specifier) => specifier.startsWith("veryfront/") ? specifier : null,
   ).flatMap(({ original, path, start, end }) => {
-    const mapped = resolveVeryfrontModuleUrl(path);
+    const mapped = rewriteVeryfrontModuleSpecifier(path);
     if (!mapped) return [];
     return [{
       start,
       end,
       expected: original,
-      replacement: `from "${mapped}?ssr=true"`,
+      replacement: `from "${mapped}"`,
     }];
   });
 


### PR DESCRIPTION
## Summary

Migrates the MDX module-fetcher `veryfront/*` rewrite decision onto the shared `veryfrontStrategy` as another focused #2220 import-rewriter unification slice.

What changed:
- `rewriteVeryfrontImports` still uses source-span replacements so comments and earlier matching text are not modified.
- The actual `veryfront/*` specifier mapping now comes from `veryfrontStrategy` instead of a local `resolveVeryfrontModuleUrl` lookup.
- MDX SSR module loading now picks up the shared `veryfront/workflow` React-only override: `/_vf_modules/_veryfront/workflow/react/index.js?ssr=true`.
- `rewriteDntImports` stays separate in this slice because it depends on source-file location and async filesystem probing.

## Verification

- Red-first: `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.test.ts` failed before implementation on the old `workflow/index.js` target.
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.test.ts src/transforms/import-rewriter/strategies/veryfront-strategy.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/http-fetcher.test.ts`
- `deno check src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.ts src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.test.ts`
- `deno task verify:quick`

## Remaining risk

This is not the full #2220 roadmap. The DNT relative import rewriter remains intentionally separate until a broader async/filesystem-aware strategy boundary is designed.

Refs #2220
