### PR TITLE
fix(env): getHostEnv returns undefined instead of throwing under env allowlist (#2318)

### DIFF
--- a/src/platform/compat/process.test.ts
+++ b/src/platform/compat/process.test.ts
@@ -157,6 +157,23 @@ describe("Process Compat", () => {
         assertEquals(getHostEnv(testKey), "host-value");
       });
     });
+
+    it("returns undefined instead of throwing when an env read is denied", () => {
+      // Under a tightened env permission allowlist (project isolation workers),
+      // Deno.env.get throws NotCapable for a non-allowlisted key. getHostEnv must
+      // degrade to undefined rather than propagating the throw and crashing the
+      // request. Simulate the denial by stubbing Deno.env.get.
+      if (typeof Deno === "undefined") return;
+      const original = Deno.env.get;
+      try {
+        Deno.env.get = () => {
+          throw new Error("Requires env access, run again with the --allow-env flag");
+        };
+        assertEquals(getHostEnv("__DENIED_BY_ALLOWLIST__"), undefined);
+      } finally {
+        Deno.env.get = original;
+      }
+    });
   });
 
   describe("getEnvString", () => {

--- a/src/platform/compat/process/env.ts
+++ b/src/platform/compat/process/env.ts
@@ -60,7 +60,18 @@ export function getHostEnv(key: string): string | undefined {
     return overlayResult.value;
   }
 
-  if (IS_DENO) return Deno.env.get(key);
+  if (IS_DENO) {
+    try {
+      return Deno.env.get(key);
+    } catch {
+      // Under a tightened env permission allowlist (project isolation workers),
+      // reading a non-allowlisted variable throws NotCapable. Treat it as absent
+      // to match the prior `env: true` behavior where reads never threw, so
+      // optional-variable lookups degrade to undefined instead of crashing the
+      // request.
+      return undefined;
+    }
+  }
   if (runtimeProcess) return runtimeProcess.env[key];
   return undefined;
 }


### PR DESCRIPTION
## Description

Follow-up to the merged worker env allowlist (PR #2322 / #2318). That change
correctly constrains the worker `env` permission to
`FRAMEWORK_WORKER_ENV_ALLOWLIST` plus the project's configured keys, which
closes the host-secret read. It leaves one runtime-crash side effect.

Under a constrained env permission, `Deno.env.get(key)` throws `NotCapable` for
any key not on the allowlist. `getHostEnv` returned the result directly with no
guard, and `getEnv` falls through to it:

```ts
// src/platform/compat/process/env.ts (before)
if (IS_DENO) return Deno.env.get(key);
```

With `env: true` (the old behavior) these reads never threw; an unset variable
returned `undefined`. After the allowlist, a project route/data handler running
inside an isolated worker that reads an optional, unset, non-allowlisted
variable (e.g. `getEnv("MY_OPTIONAL_FLAG")`) throws `NotCapable` and crashes the
request.

This wraps the read and returns `undefined` on denial, restoring the prior
semantics:

```ts
if (IS_DENO) {
  try {
    return Deno.env.get(key);
  } catch {
    return undefined;
  }
}
```

The bug is latent today (it only manifests when worker isolation is enabled),
but it should be fixed before that flag is turned on, since it would otherwise
break example projects and any handler that probes optional env.

## Related Issue(s)

Follow-up to #2318 (see
https://github.com/veryfront/veryfront-code/issues/2318#issuecomment-4669734028)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

Test: `getHostEnv` returns `undefined` when `Deno.env.get` throws (stubbed to
simulate the allowlist denial). Red/green verified (the test fails without the
guard). `deno fmt`/`deno lint` clean.

Note: the local pre-push `deno check src/index.ts` fails in the sandbox on
pre-existing, environment-specific React (`esm.sh @types/react`) type resolution
that also fails on a no-op push of `main`; this PR adds zero new type errors. CI
runs the authoritative checks.
