### PR TITLE
fix(sandbox): re-check egress on every redirect hop in worker fetch guard (#2320)

### DIFF
--- a/src/security/sandbox/worker-egress-guard.test.ts
+++ b/src/security/sandbox/worker-egress-guard.test.ts
@@ -202,4 +202,60 @@ describe("worker-egress-guard guardedEgressFetch redirect handling", () => {
     assertEquals(seen[0], "Bearer secret");
     assertEquals(seen[1], "Bearer secret");
   });
+
+  it("blocks a redirect to a non-http(s) scheme (e.g. file://)", async () => {
+    let calls = 0;
+    const fetchImpl: typeof fetch = (input) => {
+      calls++;
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.startsWith("http://93.184.216.34")) {
+        return Promise.resolve(redirectTo("file:///etc/passwd"));
+      }
+      throw new Error(`fetch should not have been called for ${url}`);
+    };
+
+    await assertRejects(
+      () => guardedEgressFetch("http://93.184.216.34/start", undefined, { fetchImpl }),
+      WorkerEgressBlockedError,
+    );
+    // The file:// target must never be fetched (would be a local file read).
+    assertEquals(calls, 1);
+  });
+
+  it("preserves the abort signal across redirect hops", async () => {
+    const controller = new AbortController();
+    const seenSignals: Array<AbortSignal | null | undefined> = [];
+    const fetchImpl: typeof fetch = (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      seenSignals.push(init?.signal);
+      if (url === "http://93.184.216.34/a") {
+        return Promise.resolve(redirectTo("http://93.184.216.35/b"));
+      }
+      return Promise.resolve(new Response("ok", { status: 200 }));
+    };
+
+    await guardedEgressFetch(
+      "http://93.184.216.34/a",
+      { signal: controller.signal },
+      { fetchImpl },
+    );
+    assertEquals(seenSignals[0], controller.signal);
+    assertEquals(seenSignals[1], controller.signal);
+  });
+
+  it("preserves request options (signal) from a Request input", async () => {
+    const controller = new AbortController();
+    // A Request wraps the passed signal in its own (following) AbortSignal, so we
+    // compare against request.signal, not controller.signal.
+    const request = new Request("http://93.184.216.34/a", { signal: controller.signal });
+    let seenSignal: AbortSignal | null | undefined;
+    const fetchImpl: typeof fetch = (_input, init) => {
+      seenSignal = init?.signal;
+      return Promise.resolve(new Response("ok", { status: 200 }));
+    };
+
+    await guardedEgressFetch(request, undefined, { fetchImpl });
+    assertEquals(seenSignal instanceof AbortSignal, true);
+    assertEquals(seenSignal, request.signal);
+  });
 });

--- a/src/security/sandbox/worker-egress-guard.test.ts
+++ b/src/security/sandbox/worker-egress-guard.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   assertWorkerEgressAllowed,
   assertWorkerHostEgressAllowed,
+  guardedEgressFetch,
   isInternalEgressIp,
   isInternalEgressOverrideEnabled,
   WORKER_INTERNAL_EGRESS_OVERRIDE_ENV,
@@ -97,5 +98,108 @@ describe("worker-egress-guard", () => {
     assertEquals(isInternalEgressOverrideEnabled("on"), true);
     assertEquals(isInternalEgressOverrideEnabled("0"), false);
     assertEquals(isInternalEgressOverrideEnabled(undefined), false);
+  });
+});
+
+describe("worker-egress-guard guardedEgressFetch redirect handling", () => {
+  function redirectTo(location: string, status = 302): Response {
+    return new Response(null, { status, headers: { location } });
+  }
+
+  it("blocks a public URL that redirects to an internal address", async () => {
+    let calls = 0;
+    const fetchImpl: typeof fetch = (input) => {
+      calls++;
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.startsWith("http://93.184.216.34")) {
+        return Promise.resolve(redirectTo("http://169.254.169.254/latest/meta-data"));
+      }
+      throw new Error(`fetch should not have been called for ${url}`);
+    };
+
+    await assertRejects(
+      () => guardedEgressFetch("http://93.184.216.34/start", undefined, { fetchImpl }),
+      WorkerEgressBlockedError,
+    );
+    // The internal redirect target must never be fetched.
+    assertEquals(calls, 1);
+  });
+
+  it("follows a public -> public redirect chain and returns the final response", async () => {
+    const fetchImpl: typeof fetch = (input) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url === "http://93.184.216.34/a") {
+        return Promise.resolve(redirectTo("http://93.184.216.35/b"));
+      }
+      if (url === "http://93.184.216.35/b") {
+        return Promise.resolve(new Response("ok", { status: 200 }));
+      }
+      throw new Error(`unexpected fetch to ${url}`);
+    };
+
+    const res = await guardedEgressFetch("http://93.184.216.34/a", undefined, { fetchImpl });
+    assertEquals(res.status, 200);
+    assertEquals(await res.text(), "ok");
+  });
+
+  it("returns the redirect unfollowed when redirect mode is 'manual'", async () => {
+    const fetchImpl: typeof fetch = () => Promise.resolve(redirectTo("http://169.254.169.254/x"));
+    const res = await guardedEgressFetch(
+      "http://93.184.216.34/a",
+      { redirect: "manual" },
+      { fetchImpl },
+    );
+    assertEquals(res.status, 302);
+  });
+
+  it("throws after exceeding the maximum redirect count", async () => {
+    const fetchImpl: typeof fetch = () => Promise.resolve(redirectTo("http://93.184.216.34/loop"));
+    await assertRejects(
+      () => guardedEgressFetch("http://93.184.216.34/loop", undefined, { fetchImpl }),
+      WorkerEgressBlockedError,
+    );
+  });
+
+  it("strips Authorization and Cookie on a cross-origin redirect", async () => {
+    const seen: Array<{ auth: string | null; cookie: string | null }> = [];
+    const fetchImpl: typeof fetch = (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const headers = new Headers(init?.headers);
+      seen.push({ auth: headers.get("authorization"), cookie: headers.get("cookie") });
+      if (url === "http://93.184.216.34/start") {
+        return Promise.resolve(redirectTo("http://93.184.216.35/landing"));
+      }
+      return Promise.resolve(new Response("ok", { status: 200 }));
+    };
+
+    const res = await guardedEgressFetch(
+      "http://93.184.216.34/start",
+      { headers: { Authorization: "Bearer secret", Cookie: "sid=abc" } },
+      { fetchImpl },
+    );
+    assertEquals(res.status, 200);
+    assertEquals(seen[0].auth, "Bearer secret");
+    assertEquals(seen[1].auth, null);
+    assertEquals(seen[1].cookie, null);
+  });
+
+  it("preserves Authorization on a same-origin redirect", async () => {
+    const seen: Array<string | null> = [];
+    const fetchImpl: typeof fetch = (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      seen.push(new Headers(init?.headers).get("authorization"));
+      if (url === "http://93.184.216.34/a") {
+        return Promise.resolve(redirectTo("http://93.184.216.34/b"));
+      }
+      return Promise.resolve(new Response("ok", { status: 200 }));
+    };
+
+    await guardedEgressFetch(
+      "http://93.184.216.34/a",
+      { headers: { Authorization: "Bearer secret" } },
+      { fetchImpl },
+    );
+    assertEquals(seen[0], "Bearer secret");
+    assertEquals(seen[1], "Bearer secret");
   });
 });

--- a/src/security/sandbox/worker-egress-guard.ts
+++ b/src/security/sandbox/worker-egress-guard.ts
@@ -201,6 +201,112 @@ function getAllowInternalEgress(): boolean {
   }
 }
 
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const MAX_EGRESS_REDIRECTS = 20;
+
+/** Dependencies for {@link guardedEgressFetch} (injectable for tests). */
+export interface GuardedEgressFetchDeps {
+  /** Underlying fetch implementation (defaults to the global `fetch`). */
+  fetchImpl?: typeof fetch;
+  /** Egress options applied to the initial URL and every redirect hop. */
+  options?: WorkerEgressGuardOptions;
+}
+
+/** A request body that can be safely replayed across a body-preserving redirect. */
+function isReplayableBody(body: BodyInit | null | undefined): boolean {
+  return body == null || typeof body === "string" ||
+    body instanceof Uint8Array || body instanceof ArrayBuffer ||
+    body instanceof URLSearchParams;
+}
+
+/**
+ * Egress-checked fetch that re-validates EVERY redirect hop.
+ *
+ * The platform `fetch` follows 3xx redirects transparently, so checking only the
+ * initial URL lets a public host redirect to an internal address (loopback,
+ * RFC1918, link-local, cloud metadata) that the guard never sees. This forces
+ * `redirect: "manual"` on the underlying fetch and re-runs the egress check on
+ * each `Location` before following it. The caller's redirect intent is honored:
+ * `manual` returns the redirect unfollowed, `error` throws, `follow` (default)
+ * follows manually after re-checking. Credential headers are stripped on a
+ * cross-origin hop, matching the platform fetch the guard wraps.
+ */
+export async function guardedEgressFetch(
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+  deps: GuardedEgressFetchDeps = {},
+): Promise<Response> {
+  const doFetch = deps.fetchImpl ?? fetch;
+  const options = deps.options ?? {};
+
+  const requestedRedirect: RequestRedirect = init?.redirect ??
+    (input instanceof Request ? input.redirect : "follow");
+
+  let url = input instanceof Request
+    ? input.url
+    : input instanceof URL
+    ? input.href
+    : String(input);
+  let method = (init?.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase();
+  const headers = new Headers(
+    init?.headers ?? (input instanceof Request ? input.headers : undefined),
+  );
+  let body: BodyInit | undefined;
+  if (init?.body != null) {
+    body = init.body as BodyInit;
+  } else if (input instanceof Request && input.body) {
+    body = new Uint8Array(await input.arrayBuffer());
+  }
+
+  for (let hop = 0;; hop++) {
+    await assertWorkerEgressAllowed(url, options);
+
+    const response = await doFetch(url, { ...init, method, headers, body, redirect: "manual" });
+
+    if (!REDIRECT_STATUSES.has(response.status)) return response;
+    const location = response.headers.get("location");
+    if (!location) return response;
+    if (requestedRedirect === "manual") return response;
+    if (requestedRedirect === "error") {
+      throw new WorkerEgressBlockedError(
+        "Worker egress: unexpected redirect with redirect mode 'error'",
+      );
+    }
+    if (hop >= MAX_EGRESS_REDIRECTS) {
+      throw new WorkerEgressBlockedError(
+        "Worker network egress blocked: exceeded maximum redirect count",
+      );
+    }
+
+    const nextUrl = new URL(location, url);
+    // Cross-origin redirect: strip credential-bearing headers, matching the
+    // platform fetch this guard replaces, so a redirect target cannot receive
+    // the caller's Authorization/Cookie.
+    if (nextUrl.origin !== new URL(url).origin) {
+      headers.delete("authorization");
+      headers.delete("cookie");
+      headers.delete("proxy-authorization");
+    }
+    url = nextUrl.href;
+
+    // Standard fetch redirect method/body rules: 303, and 301/302 for a
+    // non-GET/HEAD method, downgrade to GET and drop the body; 307/308 preserve.
+    const downgrades = response.status === 303 ||
+      ((response.status === 301 || response.status === 302) &&
+        method !== "GET" && method !== "HEAD");
+    if (downgrades) {
+      method = "GET";
+      body = undefined;
+      headers.delete("content-length");
+      headers.delete("content-type");
+    } else if (!isReplayableBody(body)) {
+      throw new WorkerEgressBlockedError(
+        "Worker network egress blocked: cannot safely follow a body-preserving redirect",
+      );
+    }
+  }
+}
+
 export function installWorkerEgressGuard(options: WorkerEgressGuardOptions = {}): void {
   const globalRecord = globalThis as typeof globalThis & Record<PropertyKey, unknown>;
   if (globalRecord[guardInstalled]) return;
@@ -215,8 +321,12 @@ export function installWorkerEgressGuard(options: WorkerEgressGuardOptions = {})
     input: Parameters<typeof fetch>[0],
     init?: Parameters<typeof fetch>[1],
   ): Promise<Response> => {
-    await assertWorkerEgressAllowed(input, baseOptions);
-    return await originalFetch(input, init);
+    // guardedEgressFetch checks the initial URL and re-checks every redirect hop,
+    // so a public host cannot redirect into an internal address.
+    return await guardedEgressFetch(input, init, {
+      fetchImpl: originalFetch,
+      options: baseOptions,
+    });
   };
   Object.defineProperty(fetchWrapper, guardedFetch, { value: true });
   globalThis.fetch = fetchWrapper as typeof fetch;

--- a/src/security/sandbox/worker-egress-guard.ts
+++ b/src/security/sandbox/worker-egress-guard.ts
@@ -258,10 +258,31 @@ export async function guardedEgressFetch(
     body = new Uint8Array(await input.arrayBuffer());
   }
 
+  // Preserve request-level options (notably `signal`, so aborts keep working)
+  // that would otherwise be dropped when the caller passes a Request object
+  // rather than an init bag, and that must persist across every redirect hop.
+  const reqInput = input instanceof Request ? input : undefined;
+  const carryInit: RequestInit = {
+    signal: init?.signal ?? reqInput?.signal,
+    credentials: init?.credentials ?? reqInput?.credentials,
+    cache: init?.cache ?? reqInput?.cache,
+    mode: init?.mode ?? reqInput?.mode,
+    referrer: init?.referrer ?? reqInput?.referrer,
+    referrerPolicy: init?.referrerPolicy ?? reqInput?.referrerPolicy,
+    keepalive: init?.keepalive ?? reqInput?.keepalive,
+  };
+
   for (let hop = 0;; hop++) {
     await assertWorkerEgressAllowed(url, options);
 
-    const response = await doFetch(url, { ...init, method, headers, body, redirect: "manual" });
+    const response = await doFetch(url, {
+      ...init,
+      ...carryInit,
+      method,
+      headers,
+      body,
+      redirect: "manual",
+    });
 
     if (!REDIRECT_STATUSES.has(response.status)) return response;
     const location = response.headers.get("location");
@@ -279,6 +300,16 @@ export async function guardedEgressFetch(
     }
 
     const nextUrl = new URL(location, url);
+    // Only follow redirects to http(s). The platform fetch treats a redirect to
+    // any other scheme as a network error; following e.g. file:// here would let
+    // an attacker-controlled redirect turn a network fetch into a local file
+    // read, since assertWorkerEgressAllowed no-ops for hostless (non-network)
+    // URLs.
+    if (nextUrl.protocol !== "http:" && nextUrl.protocol !== "https:") {
+      throw new WorkerEgressBlockedError(
+        `Worker network egress blocked: redirect to non-http(s) scheme ${nextUrl.protocol}`,
+      );
+    }
     // Cross-origin redirect: strip credential-bearing headers, matching the
     // platform fetch this guard replaces, so a redirect target cannot receive
     // the caller's Authorization/Cookie.


### PR DESCRIPTION
## Description

Follow-up to the merged worker egress guard (PR #2324 / #2320). That change
blocks direct fetch/connect to internal hosts well (IP literals, post-DNS host
checks, plus `Deno.connect`/`connectTls`). The fetch path remained bypassable
through an HTTP redirect.

The fetch wrapper checked only the initial URL, then delegated to the platform
`fetch` with its default `redirect: "follow"`:

```ts
// before
const fetchWrapper = async (input, init) => {
  await assertWorkerEgressAllowed(input, baseOptions);
  return await originalFetch(input, init); // default redirect: "follow"
};
```

Only the first hop was checked. A project handler that fetches a public URL
whose host an attacker can influence (a partner API, a link shortener, an
attacker host, any endpoint that can emit a 3xx) receives e.g.
`302 Location: http://169.254.169.254/latest/meta-data/...`; the runtime follows
it and the guard never re-checks it, so cloud-metadata, loopback, and RFC1918
services become reachable again.

This adds `guardedEgressFetch`, which:

- forces `redirect: "manual"` on the underlying fetch and re-runs
  `assertWorkerEgressAllowed` on each `Location` (resolved against the current
  URL) before following it, with a redirect cap;
- honors the caller's redirect intent (`manual` returns the redirect unfollowed,
  `error` throws, `follow` follows manually after re-checking);
- strips `Authorization`/`Cookie`/`Proxy-Authorization` on a cross-origin hop,
  matching the platform `fetch` the guard wraps, so manual following cannot leak
  the caller's credentials to the redirect target.

The installed fetch wrapper now delegates to it. `Deno.connect`/`connectTls`
wrapping is unchanged.

## Related Issue(s)

Follow-up to #2320 (see
https://github.com/veryfront/veryfront-code/issues/2320#issuecomment-4669733800)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

Tests (red/green verified): public->internal redirect blocked (internal target
never fetched), public->public chain followed to the final response, `manual`
mode returns the redirect unfollowed, max-redirect cap, cross-origin redirect
strips `Authorization`/`Cookie`, same-origin redirect preserves them. Existing
egress and `project-worker` integration tests pass. `deno fmt`/`deno lint`
clean.

Note: the local pre-push `deno check src/index.ts` fails in the sandbox on
pre-existing, environment-specific React (`esm.sh @types/react`) type resolution
that also fails on a no-op push of `main`; this PR adds zero new type errors. CI
runs the authoritative checks.
