### PR TITLE
Prevent Opus runs from sending rejected sampling parameters

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.755",
+  "version": "0.1.756",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
@@ -123,7 +123,7 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
 
     assertEquals(parts, [
       { type: "reasoning-start", id: "thinking-0" },
-      { type: "reasoning-end", id: "thinking-0" },
+      { type: "reasoning-end", id: "thinking-0", redactedData: "encrypted" },
       { type: "finish", finishReason: null },
     ]);
   });

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -144,6 +144,7 @@ import { filterToolsForSkill } from "#veryfront/skill/allowed-tools.ts";
 import { resolveConfiguredAgentModel, resolveRuntimeModel } from "./model-resolution.ts";
 import type { RuntimeGenerateToolResult } from "./runtime-tool-types.ts";
 import { stringifyToolError, throwIfAborted } from "./error-utils.ts";
+import { supportsTemperatureParameter } from "./model-capabilities.ts";
 import {
   applySkillDelegationOverridesToToolInput,
   extractSkillDelegationOverrides,
@@ -310,6 +311,7 @@ export class AgentRuntime {
             transport.headers,
             transport.providerOptions,
             maxOutputTokensOverride,
+            requestedModel,
           ),
       );
     });
@@ -431,6 +433,7 @@ export class AgentRuntime {
                 transport.providerOptions,
                 maxOutputTokensOverride,
                 streamAbortSignal,
+                requestedModel,
               ),
           );
           throwIfAborted(streamAbortSignal);
@@ -475,6 +478,7 @@ export class AgentRuntime {
     headers?: HeadersInit,
     providerOptions?: Record<string, unknown>,
     maxOutputTokensOverride?: number,
+    temperatureModelString?: string,
   ): Promise<AgentResponse> {
     return withSpan("agent.execution_loop", async (loopSpan) => {
       const { maxAgentSteps } = getPlatformCapabilities();
@@ -531,6 +535,7 @@ export class AgentRuntime {
           tools = filterToolsForSkill(tools, activeSkillPolicy);
         }
 
+        const temperature = this.resolveTemperature(temperatureModelString ?? effectiveModel);
         const response = await withSpan("agent.generate_text", async (span) => {
           setSpanAttributes(span, {
             "model.id": effectiveModel,
@@ -546,7 +551,7 @@ export class AgentRuntime {
             }),
             experimental_repairToolCall: repairToolCall,
             maxOutputTokens: this.resolveMaxOutputTokens(effectiveModel, maxOutputTokensOverride),
-            temperature: this.resolveTemperature(),
+            ...(temperature === undefined ? {} : { temperature }),
             ...(headers ? { headers } : {}),
             ...(providerOptions ? { providerOptions } : {}),
           });
@@ -778,6 +783,7 @@ export class AgentRuntime {
     providerOptions?: Record<string, unknown>,
     maxOutputTokensOverride?: number,
     abortSignal?: AbortSignal,
+    temperatureModelString?: string,
   ): Promise<AgentResponse> {
     const { maxAgentSteps } = getPlatformCapabilities();
     const maxSteps = this.computeMaxSteps(maxAgentSteps);
@@ -841,6 +847,7 @@ export class AgentRuntime {
         providerTools,
       });
 
+      const temperature = this.resolveTemperature(temperatureModelString ?? effectiveModel);
       const result = streamText({
         model: languageModel,
         system: currentSystemPrompt,
@@ -848,7 +855,7 @@ export class AgentRuntime {
         tools: runtimeTools,
         experimental_repairToolCall: repairToolCall,
         maxOutputTokens: this.resolveMaxOutputTokens(effectiveModel, maxOutputTokensOverride),
-        temperature: this.resolveTemperature(),
+        ...(temperature === undefined ? {} : { temperature }),
         ...(headers ? { headers } : {}),
         ...(providerOptions ? { providerOptions } : {}),
         abortSignal,
@@ -1223,7 +1230,10 @@ export class AgentRuntime {
     return getMaxSteps(this.config.maxSteps, edgeMaxSteps, platformLimit);
   }
 
-  private resolveTemperature(): number {
+  private resolveTemperature(modelString?: string): number | undefined {
+    if (!supportsTemperatureParameter(modelString)) {
+      return undefined;
+    }
     return this.config.temperature ?? DEFAULT_TEMPERATURE;
   }
 

--- a/src/agent/runtime/model-capabilities.test.ts
+++ b/src/agent/runtime/model-capabilities.test.ts
@@ -1,0 +1,34 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { normalizeModelCapabilityId, supportsTemperatureParameter } from "./model-capabilities.ts";
+
+describe("runtime model capabilities", () => {
+  it("normalizes Veryfront Cloud model aliases", () => {
+    assertEquals(
+      normalizeModelCapabilityId("veryfront-cloud/anthropic/claude-opus-4-8"),
+      "anthropic/claude-opus-4-8",
+    );
+    assertEquals(
+      normalizeModelCapabilityId("anthropic/claude-opus-4-8"),
+      "anthropic/claude-opus-4-8",
+    );
+  });
+
+  it("omits temperature for Anthropic Opus models that reject sampling parameters", () => {
+    assertEquals(supportsTemperatureParameter("anthropic/claude-opus-4-7"), false);
+    assertEquals(supportsTemperatureParameter("anthropic/claude-opus-4-8"), false);
+    assertEquals(
+      supportsTemperatureParameter("veryfront-cloud/anthropic/claude-opus-4-8"),
+      false,
+    );
+  });
+
+  it("keeps temperature for other current hosted models", () => {
+    assertEquals(supportsTemperatureParameter("anthropic/claude-opus-4-6"), true);
+    assertEquals(supportsTemperatureParameter("anthropic/claude-sonnet-4-6"), true);
+    assertEquals(supportsTemperatureParameter("anthropic/claude-haiku-4-5-20251001"), true);
+    assertEquals(supportsTemperatureParameter("openai/gpt-5.5"), true);
+    assertEquals(supportsTemperatureParameter("google-ai-studio/gemini-3.1-pro-preview"), true);
+    assertEquals(supportsTemperatureParameter(undefined), true);
+  });
+});

--- a/src/agent/runtime/model-capabilities.ts
+++ b/src/agent/runtime/model-capabilities.ts
@@ -1,0 +1,19 @@
+const VERYFRONT_CLOUD_MODEL_PREFIX = "veryfront-cloud/";
+
+const MODELS_WITHOUT_TEMPERATURE_PARAMETER = new Set([
+  "anthropic/claude-opus-4-7",
+  "anthropic/claude-opus-4-8",
+]);
+
+export function normalizeModelCapabilityId(modelString?: string): string | undefined {
+  if (!modelString) return undefined;
+  return modelString.startsWith(VERYFRONT_CLOUD_MODEL_PREFIX)
+    ? modelString.slice(VERYFRONT_CLOUD_MODEL_PREFIX.length)
+    : modelString;
+}
+
+export function supportsTemperatureParameter(modelString?: string): boolean {
+  const normalizedModel = normalizeModelCapabilityId(modelString);
+  if (!normalizedModel) return true;
+  return !MODELS_WITHOUT_TEMPERATURE_PARAMETER.has(normalizedModel);
+}

--- a/src/agent/runtime/provider-transport.test.ts
+++ b/src/agent/runtime/provider-transport.test.ts
@@ -115,6 +115,157 @@ describe("agent provider transport hooks", () => {
     assertEquals(captured.generateOptions.temperature, 0.2);
   });
 
+  it("omits temperature for Claude Opus 4.8 generate requests", async () => {
+    const captured: {
+      generateOptions?: Record<string, unknown>;
+    } = {};
+
+    const transportModel: ModelRuntime = {
+      provider: "hosted",
+      modelId: "hosted/gateway-model",
+      async doGenerate(options: unknown) {
+        captured.generateOptions = options as Record<string, unknown>;
+        return {
+          content: [{ type: "text", text: "opus generate" }],
+          finishReason: "stop",
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        };
+      },
+      async doStream() {
+        return { stream: createTextStream([{ type: "finish" }]) };
+      },
+    };
+
+    const assistant = agent({
+      model: "anthropic/claude-opus-4-8",
+      system: "You are a helpful assistant.",
+      temperature: 0,
+      resolveModelTransport: () => ({ model: transportModel }),
+    });
+
+    await assistant.generate({ input: "Hello" });
+
+    assertExists(captured.generateOptions);
+    assertEquals("temperature" in captured.generateOptions, false);
+  });
+
+  it("omits temperature for Claude Opus 4.8 stream requests", async () => {
+    const captured: {
+      streamOptions?: Record<string, unknown>;
+    } = {};
+
+    const transportModel: ModelRuntime = {
+      provider: "hosted",
+      modelId: "hosted/gateway-model",
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "unused" }],
+          finishReason: "stop",
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        };
+      },
+      async doStream(options: unknown) {
+        captured.streamOptions = options as Record<string, unknown>;
+        return {
+          stream: createTextStream([
+            { type: "text-delta", text: "opus stream" },
+            { type: "finish" },
+          ]),
+        };
+      },
+    };
+
+    const assistant = agent({
+      model: "anthropic/claude-opus-4-8",
+      system: "You are a helpful assistant.",
+      temperature: 0,
+      resolveModelTransport: () => ({ model: transportModel }),
+    });
+
+    const response = (await assistant.stream({ input: "Hello" })).toDataStreamResponse();
+    const body = await response.text();
+
+    assertStringIncludes(body, "opus stream");
+    assertExists(captured.streamOptions);
+    assertEquals("temperature" in captured.streamOptions, false);
+  });
+
+  it("omits temperature for Veryfront Cloud Claude Opus 4.8 generate requests", async () => {
+    const captured: {
+      generateOptions?: Record<string, unknown>;
+    } = {};
+
+    const transportModel: ModelRuntime = {
+      provider: "hosted",
+      modelId: "hosted/gateway-model",
+      async doGenerate(options: unknown) {
+        captured.generateOptions = options as Record<string, unknown>;
+        return {
+          content: [{ type: "text", text: "cloud opus generate" }],
+          finishReason: "stop",
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        };
+      },
+      async doStream() {
+        return { stream: createTextStream([{ type: "finish" }]) };
+      },
+    };
+
+    const assistant = agent({
+      model: "veryfront-cloud/anthropic/claude-opus-4-8",
+      system: "You are a helpful assistant.",
+      temperature: 0,
+      resolveModelTransport: () => ({ model: transportModel }),
+    });
+
+    await assistant.generate({ input: "Hello" });
+
+    assertExists(captured.generateOptions);
+    assertEquals("temperature" in captured.generateOptions, false);
+  });
+
+  it("preserves temperature for other hosted models", async () => {
+    const cases = [
+      { model: "anthropic/claude-sonnet-4-6", temperature: 0 },
+      { model: "openai/gpt-5.5", temperature: 0.2 },
+      { model: "google-ai-studio/gemini-3.1-pro-preview", temperature: 0.7 },
+    ];
+
+    for (const testCase of cases) {
+      const captured: {
+        generateOptions?: Record<string, unknown>;
+      } = {};
+
+      const transportModel: ModelRuntime = {
+        provider: "hosted",
+        modelId: "hosted/gateway-model",
+        async doGenerate(options: unknown) {
+          captured.generateOptions = options as Record<string, unknown>;
+          return {
+            content: [{ type: "text", text: "other model generate" }],
+            finishReason: "stop",
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          };
+        },
+        async doStream() {
+          return { stream: createTextStream([{ type: "finish" }]) };
+        },
+      };
+
+      const assistant = agent({
+        model: testCase.model,
+        system: "You are a helpful assistant.",
+        temperature: testCase.temperature,
+        resolveModelTransport: () => ({ model: transportModel }),
+      });
+
+      await assistant.generate({ input: "Hello" });
+
+      assertExists(captured.generateOptions);
+      assertEquals(captured.generateOptions.temperature, testCase.temperature);
+    }
+  });
+
   it("lets hosts attach request-aware transport options while still using the registered provider runtime for stream()", async () => {
     const captured: {
       request?: ModelTransportRequest;

--- a/src/runtime/runtime-bridge.ts
+++ b/src/runtime/runtime-bridge.ts
@@ -504,7 +504,7 @@ export function generateText(options: GenerateTextOptions): PromiseLike<RuntimeG
     options.model.doGenerate({
       prompt: toRuntimePrompt(normalizeSystemPrompt(options.system), options.messages),
       maxOutputTokens: options.maxOutputTokens,
-      temperature: options.temperature,
+      ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
       topP: options.topP,
       topK: options.topK,
       stopSequences: options.stopSequences,
@@ -529,7 +529,7 @@ export function streamText(options: StreamTextOptions): RuntimeStreamResult {
     options.model.doStream({
       prompt: toRuntimePrompt(normalizeSystemPrompt(options.system), options.messages),
       maxOutputTokens: options.maxOutputTokens,
-      temperature: options.temperature,
+      ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
       topP: options.topP,
       topK: options.topK,
       stopSequences: options.stopSequences,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.755";
+export const VERSION = "0.1.756";


### PR DESCRIPTION
## Summary
- Add a model capability helper for sampling-parameter support.
- Omit `temperature` for Anthropic Claude Opus 4.7 and 4.8, including Veryfront Cloud model IDs.
- Preserve temperature for Sonnet, OpenAI, Gemini, and other hosted models.
- Bump `deno.json` and `VERSION` to `0.1.756`.

## Verification
- `deno test --no-check --allow-all src/agent/runtime/model-capabilities.test.ts src/agent/runtime/provider-transport.test.ts src/agent/runtime/default-provider-options.test.ts src/provider/veryfront-cloud/model-catalog.test.ts` passed.
- `deno test --no-check --allow-all --unstable-worker-options src/utils/version.test.ts src/utils/logger/logger.test.ts extensions/ext-llm-anthropic/src/anthropic-stream.test.ts` passed.
- Broad sweep passed: `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --quiet --no-check --allow-all --unstable-worker-options --parallel --ignore=tests,src/workflow/__tests__,cli/commands/*.integration.test.ts`, 2162 passed / 0 failed.
- Pre-push hook passed: format, lint, type check, and unit tests, 2055 passed / 0 failed.

## Risk
- Moderate: shared runtime/provider request construction changed, but behavior is gated by explicit model capability tests and transport regressions.