### PR TITLE
fix(agent): make memory stateless by default to isolate concurrent runs (#2336)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.757",
+  "version": "0.1.758",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/docs/guides/memory-and-streaming.md
+++ b/docs/guides/memory-and-streaming.md
@@ -4,9 +4,12 @@ description: "Conversation memory strategies and streaming responses."
 order: 21
 ---
 
-Agents are stateless by default: each request gets the messages the client
-sends, and nothing else. Configure `memory` on the agent to persist history
-across requests, and use `createAgUiHandler` to stream the response back.
+Agents are stateless by default: each `stream()` / `generate()` call gets the
+messages the client sends, and nothing else. Because nothing is shared between
+calls, you can safely reuse one agent instance across concurrent runs — fanning
+out per-item reviews or classifications over a shared instance keeps every run
+isolated. Configure `memory` on the agent to persist history across calls, and
+use `createAgUiHandler` to stream the response back.
 
 Memory configuration is independent of model selection, so these examples omit
 `model` and follow the runtime default.
@@ -21,7 +24,19 @@ Memory configuration is independent of model selection, so these examples omit
 
 ## Choose a memory mode
 
-Configure memory on your agent to persist messages across requests:
+Configure memory on your agent to persist messages across requests. A configured
+agent accumulates **one shared conversation** on the instance, so reuse it
+sequentially (a single chat thread) rather than across concurrent independent
+runs — for per-item fan-out, create a fresh agent per run instead. To keep the
+stateless default explicitly (for a single-shot agent that should never persist
+history), set `enabled: false`:
+
+```ts
+export default agent({
+  system: "You are a one-shot classifier.",
+  memory: { type: "conversation", enabled: false }, // never persists across calls
+});
+```
 
 ### Buffer memory
 

--- a/docs/guides/memory-and-streaming.md
+++ b/docs/guides/memory-and-streaming.md
@@ -6,7 +6,7 @@ order: 21
 
 Agents are stateless by default: each `stream()` / `generate()` call gets the
 messages the client sends, and nothing else. Because nothing is shared between
-calls, you can safely reuse one agent instance across concurrent runs — fanning
+calls, you can safely reuse one agent instance across concurrent runs. Fanning
 out per-item reviews or classifications over a shared instance keeps every run
 isolated. Configure `memory` on the agent to persist history across calls, and
 use `createAgUiHandler` to stream the response back.
@@ -27,7 +27,7 @@ Memory configuration is independent of model selection, so these examples omit
 Configure memory on your agent to persist messages across requests. A configured
 agent accumulates **one shared conversation** on the instance, so reuse it
 sequentially (a single chat thread) rather than across concurrent independent
-runs — for per-item fan-out, create a fresh agent per run instead. To keep the
+runs. For per-item fan-out, create a fresh agent per run instead. To keep the
 stateless default explicitly (for a single-shot agent that should never persist
 history), set `enabled: false`:
 

--- a/src/agent/debug/inspector.test.ts
+++ b/src/agent/debug/inspector.test.ts
@@ -1,0 +1,65 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { type ModelRuntime } from "#veryfront/provider";
+import { agent } from "../index.ts";
+import type { MemoryConfig } from "../schemas/index.ts";
+import { inspectAgent } from "./inspector.ts";
+
+function stubModel(modelId: string): ModelRuntime {
+  return {
+    provider: "hosted",
+    modelId,
+    doGenerate() {
+      return Promise.resolve({
+        content: [{ type: "text", text: "ok" }],
+        finishReason: "stop",
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      });
+    },
+    doStream() {
+      return Promise.resolve({
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "finish", finishReason: "stop" });
+            controller.close();
+          },
+        }),
+      });
+    },
+  } as ModelRuntime;
+}
+
+function inspectableAgent(id: string, memory?: MemoryConfig) {
+  return agent({
+    id,
+    model: `hosted/${id}`,
+    system: "test",
+    maxSteps: 1,
+    ...(memory ? { memory } : {}),
+    resolveModelTransport: () => Promise.resolve({ model: stubModel(`hosted/${id}`) }),
+  });
+}
+
+describe("inspectAgent memoryType reporting", () => {
+  it("reports 'none' for a stateless (unconfigured) agent", async () => {
+    const report = await inspectAgent(inspectableAgent("inspect-stateless"), "hi");
+    assertEquals(report.agent.memoryType, "none");
+  });
+
+  it("reports 'none' when memory is explicitly disabled", async () => {
+    const report = await inspectAgent(
+      inspectableAgent("inspect-disabled", { type: "conversation", enabled: false }),
+      "hi",
+    );
+    assertEquals(report.agent.memoryType, "none");
+  });
+
+  it("reports the configured store type for a stateful agent", async () => {
+    const report = await inspectAgent(
+      inspectableAgent("inspect-buffer", { type: "buffer", maxMessages: 10 }),
+      "hi",
+    );
+    assertEquals(report.agent.memoryType, "buffer");
+  });
+});

--- a/src/agent/debug/inspector.ts
+++ b/src/agent/debug/inspector.ts
@@ -66,7 +66,7 @@ export async function inspectAgent(
       model: agent.config.model,
       maxSteps: agent.config.maxSteps ?? 20,
       // Report the resolved runtime memory type ("none" when the agent is
-      // stateless), not a guess from config — an unconfigured agent now has no
+      // stateless), not a guess from config. An unconfigured agent now has no
       // persisted memory rather than the implicit "conversation" store.
       memoryType: memoryStatsAfter.type,
     },

--- a/src/agent/debug/inspector.ts
+++ b/src/agent/debug/inspector.ts
@@ -65,7 +65,10 @@ export async function inspectAgent(
       id: agent.id,
       model: agent.config.model,
       maxSteps: agent.config.maxSteps ?? 20,
-      memoryType: agent.config.memory?.type ?? "conversation",
+      // Report the resolved runtime memory type ("none" when the agent is
+      // stateless), not a guess from config — an unconfigured agent now has no
+      // persisted memory rather than the implicit "conversation" store.
+      memoryType: memoryStatsAfter.type,
     },
     execution: {
       input,

--- a/src/agent/memory/index.ts
+++ b/src/agent/memory/index.ts
@@ -12,7 +12,14 @@ export {
   type MemoryStats,
   type MinimalMessage,
 } from "./memory-interface.ts";
-export { BufferMemory, ConversationMemory, createMemory, SummaryMemory } from "./memory.ts";
+export {
+  BufferMemory,
+  ConversationMemory,
+  createAgentMemory,
+  createMemory,
+  NoMemory,
+  SummaryMemory,
+} from "./memory.ts";
 export {
   createRedisMemory,
   type RedisClient,

--- a/src/agent/memory/memory-interface.ts
+++ b/src/agent/memory/memory-interface.ts
@@ -16,7 +16,7 @@ export interface MemoryConfigBase {
   /**
    * Persist conversation history across `stream()` / `generate()` calls on the
    * agent instance. Defaults to `true` when a memory config is provided. Set to
-   * `false` to run every call in isolation (no shared history) — the same
+   * `false` to run every call in isolation (no shared history), the same
    * effect as omitting `memory` entirely.
    */
   enabled?: boolean;

--- a/src/agent/memory/memory-interface.ts
+++ b/src/agent/memory/memory-interface.ts
@@ -13,6 +13,13 @@ export interface MemoryConfigBase {
   type: string;
   maxTokens?: number;
   maxMessages?: number;
+  /**
+   * Persist conversation history across `stream()` / `generate()` calls on the
+   * agent instance. Defaults to `true` when a memory config is provided. Set to
+   * `false` to run every call in isolation (no shared history) — the same
+   * effect as omitting `memory` entirely.
+   */
+  enabled?: boolean;
 }
 
 /** Public API contract for memory stats. */

--- a/src/agent/memory/memory.test.ts
+++ b/src/agent/memory/memory.test.ts
@@ -1,0 +1,68 @@
+import { assertEquals, assertInstanceOf } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  BufferMemory,
+  ConversationMemory,
+  createAgentMemory,
+  createMemory,
+  NoMemory,
+  SummaryMemory,
+} from "./memory.ts";
+import type { MinimalMessage } from "./memory-interface.ts";
+
+function userMessage(id: string, text: string): MinimalMessage {
+  return { id, role: "user", parts: [{ type: "text", text } as { type: string }] };
+}
+
+describe("NoMemory", () => {
+  it("never persists added messages", async () => {
+    const memory = new NoMemory();
+    await memory.add(userMessage("1", "hello"));
+    await memory.add(userMessage("2", "world"));
+    assertEquals(await memory.getMessages(), []);
+  });
+
+  it("reports empty stats with type 'none'", async () => {
+    const memory = new NoMemory();
+    await memory.add(userMessage("1", "hello"));
+    assertEquals(await memory.getStats(), {
+      totalMessages: 0,
+      estimatedTokens: 0,
+      type: "none",
+    });
+  });
+
+  it("clear is a no-op", async () => {
+    const memory = new NoMemory();
+    await memory.clear();
+    assertEquals(await memory.getMessages(), []);
+  });
+});
+
+describe("createAgentMemory", () => {
+  it("returns NoMemory when no config is provided (stateless default)", () => {
+    assertInstanceOf(createAgentMemory(), NoMemory);
+  });
+
+  it("returns NoMemory when memory is disabled", () => {
+    assertInstanceOf(
+      createAgentMemory({ type: "conversation", enabled: false }),
+      NoMemory,
+    );
+  });
+
+  it("builds the configured store when memory is enabled", () => {
+    assertInstanceOf(createAgentMemory({ type: "conversation" }), ConversationMemory);
+    assertInstanceOf(createAgentMemory({ type: "buffer" }), BufferMemory);
+    assertInstanceOf(createAgentMemory({ type: "summary" }), SummaryMemory);
+    // enabled: true is the implicit default and stays stateful.
+    assertInstanceOf(
+      createAgentMemory({ type: "conversation", enabled: true }),
+      ConversationMemory,
+    );
+  });
+
+  it("createMemory still builds a stateful store directly", () => {
+    assertInstanceOf(createMemory({ type: "conversation" }), ConversationMemory);
+  });
+});

--- a/src/agent/memory/memory.ts
+++ b/src/agent/memory/memory.ts
@@ -251,6 +251,35 @@ export class SummaryMemory<M extends MinimalMessage = MinimalMessage> implements
   }
 }
 
+/**
+ * No-op memory.
+ *
+ * Holds nothing and never persists. Used when an agent has no `memory` config
+ * (the documented stateless default) or when `memory.enabled === false`. Every
+ * `stream()` / `generate()` call then runs in isolation on just its own input,
+ * which is what makes concurrent fan-out on a shared agent instance safe — runs
+ * cannot interleave into a shared conversation. Multi-step tool loops are
+ * unaffected: in-run continuity is driven by the loop's local message array,
+ * not by this store.
+ */
+export class NoMemory<M extends MinimalMessage = MinimalMessage> implements Memory<M> {
+  add(_message: M): Promise<void> {
+    return Promise.resolve();
+  }
+
+  getMessages(): Promise<M[]> {
+    return Promise.resolve([]);
+  }
+
+  clear(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  getStats(): Promise<MemoryStats> {
+    return Promise.resolve({ totalMessages: 0, estimatedTokens: 0, type: "none" });
+  }
+}
+
 /** Create memory. */
 export function createMemory<M extends MinimalMessage = MinimalMessage>(
   config: MemoryConfigBase,
@@ -264,4 +293,20 @@ export function createMemory<M extends MinimalMessage = MinimalMessage>(
     default:
       return new ConversationMemory<M>(config);
   }
+}
+
+/**
+ * Resolve the memory store for an agent runtime.
+ *
+ * Agents are stateless by default: with no `memory` config (or `enabled: false`)
+ * the runtime gets a {@link NoMemory} store so calls never share conversation
+ * history. A provided config opts in to cross-call persistence.
+ */
+export function createAgentMemory<M extends MinimalMessage = MinimalMessage>(
+  config?: MemoryConfigBase,
+): Memory<M> {
+  if (!config || config.enabled === false) {
+    return new NoMemory<M>();
+  }
+  return createMemory<M>(config);
 }

--- a/src/agent/memory/memory.ts
+++ b/src/agent/memory/memory.ts
@@ -257,7 +257,7 @@ export class SummaryMemory<M extends MinimalMessage = MinimalMessage> implements
  * Holds nothing and never persists. Used when an agent has no `memory` config
  * (the documented stateless default) or when `memory.enabled === false`. Every
  * `stream()` / `generate()` call then runs in isolation on just its own input,
- * which is what makes concurrent fan-out on a shared agent instance safe — runs
+ * which is what makes concurrent fan-out on a shared agent instance safe: runs
  * cannot interleave into a shared conversation. Multi-step tool loops are
  * unaffected: in-run continuity is driven by the loop's local message array,
  * not by this store.

--- a/src/agent/runtime/defaults.ts
+++ b/src/agent/runtime/defaults.ts
@@ -2,8 +2,6 @@ export const AGENT_DEFAULTS = {
   maxTokens: 4_096,
   temperature: 0,
   maxSteps: 20,
-  memoryType: "conversation",
-  memoryMaxTokens: 4_000,
 } as const;
 
 export const STREAMING_DEFAULTS = {

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1279,7 +1279,13 @@ export class AgentRuntime {
       return Math.floor(maxOutputTokensOverride);
     }
 
-    return this.config.memory?.maxTokens ??
+    // A disabled memory config contributes nothing, exactly like omitting
+    // `memory`, so its maxTokens (a conversation-window size) must not cap
+    // model output.
+    const memoryMaxTokens = this.config.memory?.enabled === false
+      ? undefined
+      : this.config.memory?.maxTokens;
+    return memoryMaxTokens ??
       (modelString ? getModelMaxOutputTokens(modelString) : undefined) ??
       DEFAULT_MAX_TOKENS;
   }

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -27,7 +27,7 @@ import {
 import { ensureModelReady, type ModelRuntime, resolveModel } from "#veryfront/provider";
 import { generateId } from "#veryfront/utils/id.ts";
 import { detectPlatform, getPlatformCapabilities } from "#veryfront/platform/core-platform.ts";
-import { createMemory, type Memory } from "../memory/index.ts";
+import { createAgentMemory, type Memory } from "../memory/index.ts";
 import { serverLogger } from "#veryfront/utils";
 import {
   addSpanEvent,
@@ -45,7 +45,6 @@ import {
 } from "./chat-stream-handler.ts";
 import { repairToolCall } from "./repair-tool-call.ts";
 import { MiddlewareChain } from "../middleware/chain.ts";
-import { AGENT_DEFAULTS } from "./defaults.ts";
 import { tryGetCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
 import type { ToolExecutionContext } from "#veryfront/tool";
 import { isLocalModelRuntime } from "#veryfront/provider/runtime-inspection.ts";
@@ -193,9 +192,11 @@ export class AgentRuntime {
     this.id = id;
     this.config = config;
 
-    const memoryConfig = config.memory ||
-      { type: "conversation", maxTokens: AGENT_DEFAULTS.memoryMaxTokens };
-    this.memory = createMemory<Message>(memoryConfig);
+    // Agents are stateless by default (see docs/guides/memory-and-streaming.md):
+    // with no `memory` config, calls never share conversation history, so
+    // concurrent stream()/generate() on a shared instance stay isolated.
+    // Providing `memory` opts in to cross-call persistence.
+    this.memory = createAgentMemory<Message>(config.memory);
   }
 
   private async resolveModelTransport(
@@ -282,8 +283,13 @@ export class AgentRuntime {
 
       const inputMessages = normalizeInput(input);
       for (const msg of inputMessages) await this.memory.add(msg);
+      // Configured memory returns the full persisted conversation (this turn +
+      // history). The stateless default persists nothing, so fall back to this
+      // turn's input — each call then runs in isolation, keeping concurrent
+      // calls on a shared instance from mixing into one conversation.
+      const persisted = await this.memory.getMessages();
+      const messages = persisted.length > 0 ? persisted : inputMessages;
 
-      const messages = await this.memory.getMessages();
       const systemPrompt = await this.resolveSystemPrompt();
 
       const agentContext: AgentContext = {
@@ -343,8 +349,13 @@ export class AgentRuntime {
     }
 
     for (const msg of messages) await this.memory.add(msg);
+    // Configured memory returns the full persisted conversation (this turn +
+    // history). The stateless default persists nothing, so fall back to this
+    // turn's input — concurrent streams on a shared instance then stay isolated
+    // instead of interleaving into one conversation.
+    const persisted = await this.memory.getMessages();
+    const memoryMessages = persisted.length > 0 ? persisted : messages;
 
-    const memoryMessages = await this.memory.getMessages();
     const systemPrompt = await this.resolveSystemPrompt();
 
     const encoder = new TextEncoder();

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -199,6 +199,20 @@ export class AgentRuntime {
     this.memory = createAgentMemory<Message>(config.memory);
   }
 
+  /**
+   * Persist this turn's input, then resolve the messages to run on. Configured
+   * memory returns the full persisted conversation (this turn + history); the
+   * stateless default persists nothing and returns empty, so we fall back to
+   * this turn's input. That fallback is what keeps concurrent stream()/
+   * generate() calls on a shared instance isolated instead of interleaving into
+   * one conversation.
+   */
+  private async prepareTurnMessages(inputMessages: Message[]): Promise<Message[]> {
+    for (const msg of inputMessages) await this.memory.add(msg);
+    const persisted = await this.memory.getMessages();
+    return persisted.length > 0 ? persisted : inputMessages;
+  }
+
   private async resolveModelTransport(
     context: Record<string, unknown> | undefined,
     modelOverride: string | undefined,
@@ -282,13 +296,7 @@ export class AgentRuntime {
       });
 
       const inputMessages = normalizeInput(input);
-      for (const msg of inputMessages) await this.memory.add(msg);
-      // Configured memory returns the full persisted conversation (this turn +
-      // history). The stateless default persists nothing, so fall back to this
-      // turn's input — each call then runs in isolation, keeping concurrent
-      // calls on a shared instance from mixing into one conversation.
-      const persisted = await this.memory.getMessages();
-      const messages = persisted.length > 0 ? persisted : inputMessages;
+      const messages = await this.prepareTurnMessages(inputMessages);
 
       const systemPrompt = await this.resolveSystemPrompt();
 
@@ -348,13 +356,7 @@ export class AgentRuntime {
       );
     }
 
-    for (const msg of messages) await this.memory.add(msg);
-    // Configured memory returns the full persisted conversation (this turn +
-    // history). The stateless default persists nothing, so fall back to this
-    // turn's input — concurrent streams on a shared instance then stay isolated
-    // instead of interleaving into one conversation.
-    const persisted = await this.memory.getMessages();
-    const memoryMessages = persisted.length > 0 ? persisted : messages;
+    const memoryMessages = await this.prepareTurnMessages(messages);
 
     const systemPrompt = await this.resolveSystemPrompt();
 

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -162,7 +162,7 @@ function isAbortError(error: unknown, abortSignal?: AbortSignal): boolean {
 function warnLocalToolSkipping(agentId: string, modelId: string): void {
   logger.warn(
     `Agent "${agentId}" has tools configured but is using local model "${modelId}". ` +
-      "Local models don't support tool calling — tools will be skipped. " +
+      "Local models don't support tool calling. Tools will be skipped. " +
       "Set VERYFRONT_API_TOKEN and VERYFRONT_PROJECT_SLUG, or configure " +
       "OPENAI_API_KEY, ANTHROPIC_API_KEY, or GOOGLE_API_KEY for full tool support.",
   );
@@ -382,7 +382,7 @@ export class AgentRuntime {
     };
     const textPartId = generateId("text");
 
-    // Resolve model BEFORE creating the ReadableStream — if this throws
+    // Resolve model BEFORE creating the ReadableStream. If this throws
     // (e.g., no_ai_available), the error propagates to the caller who can
     // return a proper error response (503) instead of a 200 with an error event.
     const languageModel = transport.languageModel;
@@ -411,7 +411,7 @@ export class AgentRuntime {
     // no-op rejection handler. When the client cancels, we abort the shared
     // signal; the loop (model fetch / tool execution) then rejects with an
     // AbortError. The `start` body awaits it, but cancellation can land after
-    // that await settles, leaving the rejection without a consumer — fatal as
+    // that await settles, leaving the rejection without a consumer, fatal as
     // an unhandled rejection under Deno (#2334).
     let inFlight: Promise<AgentResponse> | undefined;
 
@@ -423,7 +423,7 @@ export class AgentRuntime {
 
           const messageId = generateMessageId();
           sendSSE(controller, encoder, { type: "message-start", messageId });
-          // Report the effective model — when resolveModel falls back from
+          // Report the effective model. When resolveModel falls back from
           // cloud to local (e.g. missing API key), use the resolved object's
           // modelId so the client avatar matches the actual provider.
           const effectiveModel = isLocal && !resolvedModelString.startsWith("local/")
@@ -523,7 +523,7 @@ export class AgentRuntime {
       const currentMessages = [...messages];
       const totalUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
 
-      // Local models can't reliably do function calling — skip tools gracefully.
+      // Local models can't reliably do function calling, so skip tools gracefully.
       const isLocal = isLocalModelRuntime(languageModel);
       if (isLocal && this.config.tools) {
         warnLocalToolSkipping(this.id, effectiveModel);
@@ -827,7 +827,7 @@ export class AgentRuntime {
     const currentMessages = [...messages];
     const totalUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
 
-    // Local models can't reliably do function calling — skip tools gracefully.
+    // Local models can't reliably do function calling, so skip tools gracefully.
     const isLocalStreaming = isLocalModelRuntime(languageModel);
     if (isLocalStreaming && this.config.tools) {
       warnLocalToolSkipping(this.id, effectiveModel);
@@ -1015,13 +1015,13 @@ export class AgentRuntime {
         if (isRecoverablePlaceholderToolCall(tc)) {
           // Provisional empty-object placeholder that never finalized. The
           // model never committed arguments, so we neither execute it nor
-          // surface a stream-termination error — the loop continues and the
+          // surface a stream-termination error, so the loop continues and the
           // next model call recovers the real tool call.
           continue;
         }
         if (isStreamedToolCallIncomplete(tc)) {
           // Stream ended before the provider finalized this tool call. We
-          // cannot execute it — record a distinct stream-termination error
+          // cannot execute it, so record a distinct stream-termination error
           // (not a tool-argument parse error) so the parent step and any
           // upstream orchestrator (e.g. the child-fork watchdog) see a
           // completed step with a clearly-labelled failure and can recover.

--- a/src/agent/runtime/memory-isolation.test.ts
+++ b/src/agent/runtime/memory-isolation.test.ts
@@ -1,0 +1,145 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { type ModelRuntime } from "#veryfront/provider";
+import { agent } from "../index.ts";
+
+function createRuntimeStream(parts: unknown[]) {
+  return new ReadableStream<unknown>({
+    start(controller) {
+      for (const part of parts) controller.enqueue(part);
+      controller.close();
+    },
+  });
+}
+
+/**
+ * Read the most recent user-turn text from the model-runtime prompt. The stub
+ * model echoes this back, so a contaminated (shared) conversation would surface
+ * another concurrent run's input here instead of this call's own input.
+ */
+function lastUserText(options: unknown): string {
+  const prompt = (options as { prompt?: Array<{ role?: string; content?: unknown }> }).prompt;
+  if (!Array.isArray(prompt)) return "";
+  for (let i = prompt.length - 1; i >= 0; i--) {
+    const entry = prompt[i];
+    if (entry?.role !== "user") continue;
+    const content = entry.content;
+    if (typeof content === "string") return content;
+    if (Array.isArray(content)) {
+      return content
+        .map((p) =>
+          p && typeof p === "object" && "text" in p
+            ? String((p as { text?: unknown }).text ?? "")
+            : ""
+        )
+        .join("");
+    }
+    return "";
+  }
+  return "";
+}
+
+/** A model that echoes the latest user message verbatim. */
+function echoModel(modelId: string): ModelRuntime {
+  return {
+    provider: "hosted",
+    modelId,
+    doGenerate(options: unknown) {
+      return Promise.resolve({
+        content: [{ type: "text", text: lastUserText(options) }],
+        finishReason: "stop",
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      });
+    },
+    doStream(options: unknown) {
+      return Promise.resolve({
+        stream: createRuntimeStream([
+          { type: "text-delta", text: lastUserText(options) },
+          { type: "finish", finishReason: "stop", usage: { inputTokens: 1, outputTokens: 1 } },
+        ]),
+      });
+    },
+  } as ModelRuntime;
+}
+
+const WORDS = ["APPLE", "BANANA", "CHERRY"];
+const prompt = (word: string) => `The secret word is ${word}.`;
+
+describe("agent memory isolation (issue 2336)", () => {
+  it("isolates concurrent generate() calls on a shared default instance", async () => {
+    const shared = agent({
+      id: "echo-generate-concurrent",
+      model: "hosted/echo-generate-concurrent",
+      system: "Echo the secret word.",
+      maxSteps: 1,
+      resolveModelTransport: () => Promise.resolve({ model: echoModel("hosted/echo") }),
+    });
+
+    const results = await Promise.all(WORDS.map((w) => shared.generate({ input: prompt(w) })));
+
+    assertEquals(results.map((r) => r.text), WORDS.map(prompt));
+    // Stateless by default: nothing accumulates, so concurrent runs can't mix.
+    assertEquals((await shared.getMemoryStats()).totalMessages, 0);
+  });
+
+  it("isolates concurrent stream() calls on a shared default instance", async () => {
+    const shared = agent({
+      id: "echo-stream-concurrent",
+      model: "hosted/echo-stream-concurrent",
+      system: "Echo the secret word.",
+      maxSteps: 1,
+      resolveModelTransport: () => Promise.resolve({ model: echoModel("hosted/echo") }),
+    });
+
+    const texts = await Promise.all(WORDS.map(async (w) => {
+      let captured = "";
+      const result = await shared.stream({
+        input: prompt(w),
+        maxOutputTokens: 20,
+        onFinish: (r) => (captured = r.text),
+      });
+      await result.toDataStreamResponse().text();
+      return captured;
+    }));
+
+    assertEquals(texts, WORDS.map(prompt));
+    assertEquals((await shared.getMemoryStats()).totalMessages, 0);
+  });
+
+  it("memory.enabled === false keeps every call isolated and stateless", async () => {
+    const isolated = agent({
+      id: "echo-disabled-memory",
+      model: "hosted/echo-disabled-memory",
+      system: "Echo.",
+      maxSteps: 1,
+      memory: { type: "conversation", enabled: false },
+      resolveModelTransport: () => Promise.resolve({ model: echoModel("hosted/echo") }),
+    });
+
+    await isolated.generate({ input: "first" });
+    await isolated.generate({ input: "second" });
+
+    const stats = await isolated.getMemoryStats();
+    assertEquals(stats.totalMessages, 0);
+    assertEquals(stats.type, "none");
+  });
+
+  it("configured memory still persists conversation across sequential calls", async () => {
+    const stateful = agent({
+      id: "echo-stateful-memory",
+      model: "hosted/echo-stateful-memory",
+      system: "Echo.",
+      maxSteps: 1,
+      memory: { type: "conversation" },
+      resolveModelTransport: () => Promise.resolve({ model: echoModel("hosted/echo") }),
+    });
+
+    await stateful.generate({ input: "first" });
+    // One single-step turn persists the user message and the assistant reply.
+    assertEquals((await stateful.getMemoryStats()).totalMessages, 2);
+
+    await stateful.generate({ input: "second" });
+    assertEquals((await stateful.getMemoryStats()).totalMessages, 4);
+  });
+});

--- a/src/agent/runtime/memory-isolation.test.ts
+++ b/src/agent/runtime/memory-isolation.test.ts
@@ -63,6 +63,27 @@ function echoModel(modelId: string): ModelRuntime {
   } as ModelRuntime;
 }
 
+/** A model that records the maxOutputTokens the runtime resolved for the call. */
+function capturingModel(modelId: string, captured: { maxOutputTokens?: number }): ModelRuntime {
+  return {
+    provider: "hosted",
+    modelId,
+    doGenerate(options: unknown) {
+      captured.maxOutputTokens = (options as { maxOutputTokens?: number }).maxOutputTokens;
+      return Promise.resolve({
+        content: [{ type: "text", text: "ok" }],
+        finishReason: "stop",
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      });
+    },
+    doStream() {
+      return Promise.resolve({
+        stream: createRuntimeStream([{ type: "finish", finishReason: "stop" }]),
+      });
+    },
+  } as ModelRuntime;
+}
+
 const WORDS = ["APPLE", "BANANA", "CHERRY"];
 const prompt = (word: string) => `The secret word is ${word}.`;
 
@@ -141,5 +162,36 @@ describe("agent memory isolation (issue 2336)", () => {
 
     await stateful.generate({ input: "second" });
     assertEquals((await stateful.getMemoryStats()).totalMessages, 4);
+  });
+
+  it("memory.enabled === false ignores leftover maxTokens for the output limit", async () => {
+    // A disabled memory config must behave exactly like omitting `memory`: its
+    // maxTokens (a conversation-window size) must not cap model output.
+    const disabledCapture: { maxOutputTokens?: number } = {};
+    const disabled = agent({
+      id: "echo-disabled-maxtokens",
+      model: "hosted/echo-disabled-maxtokens",
+      system: "x",
+      maxSteps: 1,
+      memory: { type: "conversation", enabled: false, maxTokens: 100 },
+      resolveModelTransport: () =>
+        Promise.resolve({ model: capturingModel("hosted/cap-disabled", disabledCapture) }),
+    });
+
+    const omittedCapture: { maxOutputTokens?: number } = {};
+    const omitted = agent({
+      id: "echo-omitted-memory",
+      model: "hosted/echo-omitted-memory",
+      system: "x",
+      maxSteps: 1,
+      resolveModelTransport: () =>
+        Promise.resolve({ model: capturingModel("hosted/cap-omitted", omittedCapture) }),
+    });
+
+    await disabled.generate({ input: "hi" });
+    await omitted.generate({ input: "hi" });
+
+    assertEquals(disabledCapture.maxOutputTokens, omittedCapture.maxOutputTokens);
+    assertEquals(disabledCapture.maxOutputTokens === 100, false);
   });
 });

--- a/src/agent/schemas/agent.schema.ts
+++ b/src/agent/schemas/agent.schema.ts
@@ -23,6 +23,9 @@ export const getMemoryConfigSchema = defineSchema((v) =>
     type: v.enum(["conversation", "buffer", "summary", "redis"] as const),
     maxTokens: v.number().int().positive().optional(),
     maxMessages: v.number().int().positive().optional(),
+    // Persist history across calls on the agent instance. Defaults to true when
+    // a memory config is provided; set false to keep every call isolated.
+    enabled: v.boolean().optional(),
   })
 );
 

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -167,7 +167,7 @@ export interface AgentConfig {
    * Conversation memory persisted across `stream()` / `generate()` calls on this
    * instance. Omit for the stateless default: every call runs in isolation,
    * which keeps concurrent fan-out on a shared instance correct. When set, the
-   * instance accumulates one shared conversation — reuse it sequentially, not
+   * instance accumulates one shared conversation, so reuse it sequentially, not
    * across concurrent independent runs (use a separate instance per run for
    * that). Set `enabled: false` to force the stateless behavior explicitly.
    */

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -163,6 +163,14 @@ export interface AgentConfig {
   /** Sampling temperature for model generation. Defaults to 0. */
   temperature?: number;
   streaming?: boolean;
+  /**
+   * Conversation memory persisted across `stream()` / `generate()` calls on this
+   * instance. Omit for the stateless default: every call runs in isolation,
+   * which keeps concurrent fan-out on a shared instance correct. When set, the
+   * instance accumulates one shared conversation — reuse it sequentially, not
+   * across concurrent independent runs (use a separate instance per run for
+   * that). Set `enabled: false` to force the stateless behavior explicitly.
+   */
   memory?: MemoryConfig;
   middleware?: AgentMiddleware[];
   edge?: EdgeConfig;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.757";
+export const VERSION = "0.1.758";


### PR DESCRIPTION
## Description

A single `agent(...)` instance forced a shared `conversation` memory **even when no `memory` was configured**, contradicting the documented *"Agents are stateless by default"* contract. Because the instance is reused, concurrent `stream()` / `generate()` calls interleaved their turns into that one store and cross-contaminated each other (e.g. per-item fan-out reviewers returning each other's results — the original repro in #2336).

Memory is now genuinely **opt-in**:

- No `memory` config (or `memory: { enabled: false }`) → a no-op `NoMemory` store. Each call runs in isolation on just its own input, so concurrent fan-out on a shared instance is correct.
- A provided `memory` config keeps its **exact prior behavior** — one persisted conversation across sequential calls.

Multi-step tool loops are unaffected: in-run continuity is driven by the loop's local message array, not the shared store (verified). Server paths (AG-UI handlers, `respond()`, channel invoke) already passed full history per request and only used `clearMemory()` defensively, so this change preserves their behavior and removes a latent cross-request/cross-tenant accumulation path.

### Changes
- Add `NoMemory` store and `createAgentMemory()` (returns `NoMemory` when unconfigured or `enabled: false`, else delegates to `createMemory`).
- Add `enabled?: boolean` to `MemoryConfig` (type + schema).
- Wire the runtime to stateless-by-default via a shared `prepareTurnMessages()`; the stateful path is byte-for-byte unchanged.
- `inspectAgent()` now reports the **resolved** memory type (`"none"` for stateless) instead of guessing `"conversation"` from config.
- Remove the now-dead `AGENT_DEFAULTS.memoryType` / `memoryMaxTokens`.
- Docs: clarify the isolation guarantee, document `enabled: false`, and warn that a memory-configured instance reused across concurrent runs shares one conversation (use a fresh instance per run for fan-out).

### Tests
- `memory-isolation.test.ts`: concurrent `generate()` and `stream()` on a shared default instance stay isolated; `enabled: false` is stateless; configured memory still persists across sequential calls.
- `memory.test.ts`: `NoMemory` + `createAgentMemory` units.
- `inspector.test.ts`: memoryType reporting for stateless / disabled / configured agents.

All of `src/agent/` passes: 522 passed (1122 steps), 0 failed. Reviewed via the three-pass deep-review chain (simplify → code-review → security).

## Related Issue(s)

Fixes #2336

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Code refactoring
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
