### PR TITLE
Bound MDX ESM path cache

### DIFF
--- a/src/transforms/mdx/esm-module-loader/cache/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.test.ts
@@ -151,6 +151,36 @@ describe("MDX module path cache", () => {
       clearModulePathCache();
     }
   });
+
+  it("bounds loaded path-cache entries and reports the aggregate limit", async () => {
+    clearModulePathCache();
+
+    const cacheDir = await makeTempDir({ prefix: "vf-mdx-cache-bound-" });
+    const index: Record<string, string> = {};
+    for (let i = 0; i < 501; i++) {
+      index[buildMdxEsmPathCacheKey(`_vf_modules/pages/${i}.js`)] = `/tmp/${i}.mjs`;
+    }
+
+    try {
+      await writeTextFile(join(cacheDir, "_index.json"), JSON.stringify(index));
+
+      const cache = await getModulePathCache(cacheDir);
+      const stats = getCacheStats();
+      const pathCacheStats = stats.find((s) => s.name === "mdx-esm-path-caches") as
+        | ({ entries: number; maxEntries?: number; cacheDirs?: number })
+        | undefined;
+
+      assertEquals(cache.size, 500);
+      assertEquals(pathCacheStats?.entries, 500);
+      assertEquals(pathCacheStats?.maxEntries, 500);
+      assertEquals(pathCacheStats?.cacheDirs, 1);
+      assertEquals(cache.get(buildMdxEsmPathCacheKey("_vf_modules/pages/0.js")), undefined);
+      assertEquals(cache.get(buildMdxEsmPathCacheKey("_vf_modules/pages/500.js")), "/tmp/500.mjs");
+    } finally {
+      await remove(cacheDir, { recursive: true }).catch(() => {});
+      clearModulePathCache();
+    }
+  });
 });
 
 describe("invalidateModulePaths — disk persistence", () => {

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -29,10 +29,28 @@ export type CacheLookupResult =
   | { status: "corrupted"; reason: string; filePath: string };
 
 const MAX_VERIFIED_MODULE_DEPS = 2_000;
+const MAX_MODULE_PATH_CACHE_ENTRIES = 500;
 
 export const verifiedModuleDeps = new LRUCache<string, true>({
   maxEntries: MAX_VERIFIED_MODULE_DEPS,
 });
+
+class BoundedModulePathCache extends Map<string, string> {
+  constructor(private readonly maxEntries: number) {
+    super();
+  }
+
+  override set(key: string, value: string): this {
+    if (!this.has(key) && this.size >= this.maxEntries) {
+      const oldestKey = this.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.delete(oldestKey);
+      }
+    }
+
+    return super.set(key, value);
+  }
+}
 
 /**
  * Check if cached code has file:// paths from a different environment.
@@ -146,6 +164,7 @@ function getModulePathCacheEntryCount(): number {
 registerCache("mdx-esm-path-caches", () => ({
   name: "mdx-esm-path-caches",
   entries: getModulePathCacheEntryCount(),
+  maxEntries: MAX_MODULE_PATH_CACHE_ENTRIES * Math.max(1, modulePathCaches.size),
   cacheDirs: modulePathCaches.size,
 }));
 
@@ -159,7 +178,7 @@ export async function getModulePathCache(cacheDir: string): Promise<Map<string, 
   const existing = modulePathCaches.get(cacheDir);
   if (existing && modulePathCacheLoaded.has(cacheDir)) return existing;
 
-  const cache = existing ?? new Map<string, string>();
+  const cache = existing ?? new BoundedModulePathCache(MAX_MODULE_PATH_CACHE_ENTRIES);
   modulePathCaches.set(cacheDir, cache);
 
   const indexPath = join(cacheDir, "_index.json");


### PR DESCRIPTION
## Summary
- Add a bounded Map for MDX ESM path-cache entries while preserving the existing cache API.
- Report aggregate `maxEntries` for `mdx-esm-path-caches` memory profiler stats.
- Add regression coverage that loads 501 cached paths and verifies the 500-entry cap.

Fixes veryfront/veryfront-api#3199.
Addresses veryfront/veryfront-api#3175 and veryfront/veryfront-api#3174 by bounding one unbounded MDX ESM cache contributor.

## Test plan
- Red: `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/transforms/mdx/esm-module-loader/cache/index.test.ts` failed with 501 entries before the fix.
- Green: `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/transforms/mdx/esm-module-loader/cache/index.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/transforms/mdx/esm-module-loader src/utils/memory/profiler.test.ts`
- `deno fmt --check src/transforms/mdx/esm-module-loader/cache/index.ts src/transforms/mdx/esm-module-loader/cache/index.test.ts`
- `deno check src/transforms/mdx/esm-module-loader/cache/index.ts src/transforms/mdx/esm-module-loader/cache/index.test.ts`
- Pre-push checks passed: format, lint, typecheck, and 2013 unit tests.
