### PR TITLE
Bump version to 0.1.758

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.757",
+  "version": "0.1.758",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.757";
+export const VERSION = "0.1.758";


### PR DESCRIPTION
## Summary\n- Bump package version from 0.1.757 to 0.1.758\n- Keep shared VERSION constant in sync\n\n## Verification\n- deno fmt --check deno.json src/utils/version-constant.ts\n- deno check src/utils/version-constant.ts\n- git diff --check\n- pre-push hook: fmt, lint, typecheck, test:unit (2057 passed, 0 failed)\n\nNote: the first push attempt failed because this shell had OTEL_* exporter environment variables set, which changed metrics config test defaults. Reran the failing test and push with those env vars unset.