### PR TITLE
Release memory isolation fix as 0.1.759

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.758",
+  "version": "0.1.759",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.758";
+export const VERSION = "0.1.759";


### PR DESCRIPTION
## Summary
- Bump the Veryfront package version from 0.1.758 to 0.1.759 so the already-merged memory isolation fix can publish.
- Keep deno.json and src/utils/version-constant.ts in sync.

## Context
The main release for 0.1.758 stopped before publishing because npm already contains veryfront@0.1.758. The release guard failed at the unpublished-version check, before build/publish/tag/deploy dispatch steps.

## Verification
- npm view veryfront@0.1.759 version returns npm E404, confirming the target version is unpublished.
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- git diff --check
- pre-push checks: format, lint, typecheck, generated assets, unit tests: 2061 passed / 18339 steps

Related: #2338, #2336