### PR TITLE
Bump version to 0.1.759

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.758",
+  "version": "0.1.759",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.758";
+export const VERSION = "0.1.759";


### PR DESCRIPTION
Release 0.1.759 — includes veryfront/veryfront-studio#2341 (full Drive + legacy Docs OAuth scopes for Google connectors), needed for the OAuth verification of project veryfront (see veryfront/veryfront-issue-inbox#279).