### PR TITLE
Guard Bun runtime against unsandboxed code execution

### DIFF
--- a/src/security/sandbox/deno-sandbox.test.ts
+++ b/src/security/sandbox/deno-sandbox.test.ts
@@ -3,6 +3,8 @@ import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { isDeno } from "#veryfront/platform/compat/runtime.ts";
 import {
+  BUN_SANDBOX_ALLOW_UNSAFE_ENV,
+  isBunSandboxAllowedUnsafe,
   isNodeSandboxAllowedUnsafe,
   NODE_SANDBOX_ALLOW_UNSAFE_ENV,
   runInWorker,
@@ -80,6 +82,40 @@ describe("deno-sandbox Node opt-in guard (SEC-008)", () => {
 
   it("allows execution only on the literal string '1'", () => {
     assertEquals(isNodeSandboxAllowedUnsafe("1"), true);
+  });
+});
+
+// SEC-008: Bun Workers have no permission isolation. The opt-in decision helper
+// must be strict — only the literal "1" enables unsafe mode. Unit-testing the
+// pure helper means coverage works under any runtime.
+describe("deno-sandbox Bun opt-in guard (SEC-008)", () => {
+  it("exposes the documented env var name", () => {
+    assertEquals(BUN_SANDBOX_ALLOW_UNSAFE_ENV, "VERYFRONT_BUN_SANDBOX_ALLOW_UNSAFE");
+  });
+
+  it("blocks when env var is undefined", () => {
+    assertEquals(isBunSandboxAllowedUnsafe(undefined), false);
+  });
+
+  it("blocks when env var is empty", () => {
+    assertEquals(isBunSandboxAllowedUnsafe(""), false);
+  });
+
+  it("blocks when env var is '0'", () => {
+    assertEquals(isBunSandboxAllowedUnsafe("0"), false);
+  });
+
+  it("blocks when env var is loose truthy (rejects 'true', 'yes', etc.)", () => {
+    assertEquals(isBunSandboxAllowedUnsafe("true"), false);
+    assertEquals(isBunSandboxAllowedUnsafe("TRUE"), false);
+    assertEquals(isBunSandboxAllowedUnsafe("yes"), false);
+    assertEquals(isBunSandboxAllowedUnsafe("on"), false);
+    assertEquals(isBunSandboxAllowedUnsafe("1 "), false);
+    assertEquals(isBunSandboxAllowedUnsafe(" 1"), false);
+  });
+
+  it("allows execution only on the literal string '1'", () => {
+    assertEquals(isBunSandboxAllowedUnsafe("1"), true);
   });
 });
 

--- a/src/security/sandbox/deno-sandbox.ts
+++ b/src/security/sandbox/deno-sandbox.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_SANDBOX_TIMEOUT_MS, MAX_SANDBOX_CODE_SIZE } from "./constants.ts";
 import { isCompiledBinary, serverLogger } from "#veryfront/utils";
-import { isDeno, isNode } from "#veryfront/platform/compat/runtime.ts";
+import { isBun, isDeno, isNode } from "#veryfront/platform/compat/runtime.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process/env.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { INVALID_ARGUMENT, NOT_SUPPORTED, TIMEOUT_ERROR, UNKNOWN_ERROR } from "#veryfront/errors";
@@ -45,6 +45,30 @@ export function isNodeSandboxAllowedUnsafe(envValue: string | undefined): boolea
 }
 
 /**
+ * Operator opt-in env var that allows {@link runInWorker} to execute on Bun
+ * despite the lack of permission isolation. Read via {@link getHostEnv} so that
+ * a per-request project env overlay cannot enable unsafe execution from inside
+ * a tenant context.
+ *
+ * @internal Exported for testing.
+ */
+export const BUN_SANDBOX_ALLOW_UNSAFE_ENV = "VERYFRONT_BUN_SANDBOX_ALLOW_UNSAFE";
+
+/**
+ * Pure decision helper for the Bun sandbox guard. Given the raw env-var
+ * value, decide whether to block execution on Bun.
+ *
+ * Returns `true` only when the value is the literal string `"1"`. Any other
+ * value (including `"true"`, `"yes"`, whitespace, or empty string) keeps the
+ * guard active. Strict equality is intentional for a security opt-in.
+ *
+ * @internal Exported for testing only.
+ */
+export function isBunSandboxAllowedUnsafe(envValue: string | undefined): boolean {
+  return envValue === "1";
+}
+
+/**
  * Run untrusted JavaScript in an isolated Worker.
  *
  * ## Isolation model
@@ -58,14 +82,16 @@ export function isNodeSandboxAllowedUnsafe(envValue: string | undefined): boolea
  *   path is **disabled by default** and throws {@link NOT_SUPPORTED}.
  *   Operators who deliberately trust their input may set the env var
  *   `VERYFRONT_NODE_SANDBOX_ALLOW_UNSAFE=1` to bypass the guard.
- * - **Bun and other runtimes:** Bun Workers have the same lack of permission
- *   isolation as Node. This guard does not currently cover Bun; treat Bun as
- *   "no sandbox" for untrusted code until explicit support is added.
+ * - **Bun:** Bun Workers have the same lack of permission isolation as Node.js.
+ *   The Bun path is **disabled by default** and throws {@link NOT_SUPPORTED}.
+ *   Operators who deliberately trust their input may set the env var
+ *   `VERYFRONT_BUN_SANDBOX_ALLOW_UNSAFE=1` to bypass the guard.
  *
- * Callers SHOULD NOT pass untrusted code to this function on Node.js unless
- * they have audited every caller and operator and accept the risk.
+ * Callers SHOULD NOT pass untrusted code to this function on Node.js or Bun
+ * unless they have audited every caller and operator and accept the risk.
  *
  * @throws NOT_SUPPORTED — on Node.js without the explicit opt-in env var.
+ * @throws NOT_SUPPORTED — on Bun without the explicit opt-in env var.
  */
 export function runInWorker<T = unknown>(code: string, options: SandboxOptions = {}): Promise<T> {
   if (typeof code !== "string") {
@@ -89,6 +115,18 @@ export function runInWorker<T = unknown>(code: string, options: SandboxOptions =
       detail: "Sandbox execution is not safely supported on Node.js. The current " +
         "implementation provides only memory limits, not permission isolation. " +
         "Set VERYFRONT_NODE_SANDBOX_ALLOW_UNSAFE=1 to enable execution at your " +
+        "own risk, or run under Deno for full isolation.",
+    }));
+  }
+
+  // SEC-008: Bun Workers have no permission isolation (same risk as Node.js).
+  // Refuse execution unless the operator has explicitly opted in via host env
+  // var. Use getHostEnv so a tenant project env overlay cannot enable this.
+  if (isBun && !isBunSandboxAllowedUnsafe(getHostEnv(BUN_SANDBOX_ALLOW_UNSAFE_ENV))) {
+    return Promise.reject(NOT_SUPPORTED.create({
+      detail: "Sandbox execution is not safely supported on Bun. The current " +
+        "implementation provides no permission isolation. " +
+        "Set VERYFRONT_BUN_SANDBOX_ALLOW_UNSAFE=1 to enable execution at your " +
         "own risk, or run under Deno for full isolation.",
     }));
   }

--- a/src/security/sandbox/deno-sandbox.ts
+++ b/src/security/sandbox/deno-sandbox.ts
@@ -90,8 +90,8 @@ export function isBunSandboxAllowedUnsafe(envValue: string | undefined): boolean
  * Callers SHOULD NOT pass untrusted code to this function on Node.js or Bun
  * unless they have audited every caller and operator and accept the risk.
  *
- * @throws NOT_SUPPORTED — on Node.js without the explicit opt-in env var.
- * @throws NOT_SUPPORTED — on Bun without the explicit opt-in env var.
+ * @throws NOT_SUPPORTED on Node.js without the explicit opt-in env var.
+ * @throws NOT_SUPPORTED on Bun without the explicit opt-in env var.
  */
 export function runInWorker<T = unknown>(code: string, options: SandboxOptions = {}): Promise<T> {
   if (typeof code !== "string") {


### PR DESCRIPTION
## Summary
- Mirror the Node.js SEC-008 guard for Bun in `runInWorker`: Bun Workers have no permission isolation, so sandbox execution on Bun now refuses to run by default and throws `NOT_SUPPORTED`.
- Operators who deliberately trust their input can opt in via `VERYFRONT_BUN_SANDBOX_ALLOW_UNSAFE=1`. The value is read through `getHostEnv`, so a per-request tenant project env overlay cannot enable unsafe execution.
- Strict opt-in semantics: only the literal string `"1"` bypasses the guard (`true`/`yes`/whitespace keep it active), matching the Node guard.

Found during an architecture review: Deno had full `permissions: "none"` isolation and Node had the SEC-008 opt-in guard, but Bun was documented as "no sandbox" with no guard at all, so untrusted code could execute unisolated.

## Test plan
- New `deno-sandbox Bun opt-in guard (SEC-008)` test group mirroring the Node guard tests (blocks on undefined/empty/`0`/loose-truthy values, allows only literal `"1"`).
- `deno test src/security/sandbox/deno-sandbox.test.ts` with repo flags: 4 passed (19 steps), 0 failed.
- `deno check` on both changed files passes.