### PR TITLE
Bound extension setup with a configurable timeout

### DIFF
--- a/src/config/environment-config.ts
+++ b/src/config/environment-config.ts
@@ -43,6 +43,7 @@ export interface EnvironmentConfig {
   port: number;
   requestTimeoutMs: number | undefined;
   httpFetchTimeoutMs: number | undefined;
+  extensionSetupTimeoutMs: number | undefined;
   ssrMaxConcurrentTransforms: number;
 
   otelEnabled: boolean;
@@ -103,6 +104,7 @@ function readEnvSnapshot(): EnvironmentConfig {
 
   const requestTimeoutRaw = getEnv("REQUEST_TIMEOUT_MS");
   const httpFetchTimeoutRaw = getEnv("VF_HTTP_FETCH_TIMEOUT");
+  const extensionSetupTimeoutRaw = getEnv("VF_EXTENSION_SETUP_TIMEOUT_MS");
   const v8MaxOldSpaceSizeRaw = getEnv("V8_MAX_OLD_SPACE_SIZE");
 
   const apiUrl = getEnv("VERYFRONT_API_URL") || undefined;
@@ -152,6 +154,9 @@ function readEnvSnapshot(): EnvironmentConfig {
       : undefined,
     httpFetchTimeoutMs: httpFetchTimeoutRaw
       ? parseNumber(httpFetchTimeoutRaw, DEFAULT_HTTP_FETCH_TIMEOUT_MS)
+      : undefined,
+    extensionSetupTimeoutMs: extensionSetupTimeoutRaw
+      ? parseNumber(extensionSetupTimeoutRaw, 30_000)
       : undefined,
     ssrMaxConcurrentTransforms: parseNumber(
       getEnv("SSR_MAX_CONCURRENT_TRANSFORMS"),

--- a/src/extensions/errors.ts
+++ b/src/extensions/errors.ts
@@ -41,3 +41,13 @@ export const EXTENSION_CONFLICT_ERROR = defineError({
   title: "Conflicting extensions detected",
   suggestion: "Remove or disable one of the conflicting extensions in your configuration",
 });
+
+/** Shared extension setup timeout error value. */
+export const EXTENSION_SETUP_TIMEOUT_ERROR = defineError({
+  slug: "extension-setup-timeout",
+  category: "RUNTIME",
+  status: 500,
+  title: "Extension setup timed out",
+  suggestion:
+    "Check the extension's setup() for blocking operations, or increase VF_EXTENSION_SETUP_TIMEOUT_MS",
+});

--- a/src/extensions/loader.test.ts
+++ b/src/extensions/loader.test.ts
@@ -201,6 +201,80 @@ describe("ExtensionLoader", () => {
     });
   });
 
+  describe("setupAll() — setup timeout", () => {
+    it("should throw a timeout error when setup() never resolves within the configured timeout", async () => {
+      const hanging = makeExt("hanging", {
+        setup: () => new Promise<void>(() => {}), // never resolves
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      const err = await assertRejects(
+        () => loader.setupAll([makeResolved(hanging)], {}, { setupTimeoutMs: 50 }),
+        Error,
+        "hanging",
+      );
+      assertEquals((err as { slug?: string }).slug, "extension-setup-timeout");
+    });
+
+    it("should include the timeout value in the error message", async () => {
+      const hanging = makeExt("slow-ext", {
+        setup: () => new Promise<void>(() => {}),
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      const err = await assertRejects(
+        () => loader.setupAll([makeResolved(hanging)], {}, { setupTimeoutMs: 75 }),
+        Error,
+      );
+      assertEquals((err as Error).message.includes("75ms"), true);
+    });
+
+    it("should rollback already-loaded extensions on timeout of a later one", async () => {
+      const order: string[] = [];
+      const a = makeExt("ext-a", {
+        setup: () => {
+          order.push("a-setup");
+        },
+        teardown: () => {
+          order.push("a-teardown");
+        },
+      });
+      const hanging = makeExt("hanging", {
+        setup: () => new Promise<void>(() => {}),
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      await assertRejects(
+        () => loader.setupAll([makeResolved(a), makeResolved(hanging)], {}, { setupTimeoutMs: 50 }),
+        Error,
+        "hanging",
+      );
+      assertEquals(order, ["a-setup", "a-teardown"]);
+    });
+
+    it("should not time out when setup() completes within the limit", async () => {
+      const fast = makeExt("fast", {
+        setup: () => Promise.resolve(),
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      // Should not throw
+      await loader.setupAll([makeResolved(fast)], {}, { setupTimeoutMs: 5_000 });
+    });
+
+    it("should disable timeout when setupTimeoutMs is 0", async () => {
+      // A setup that takes longer than a tight timeout would catch,
+      // but we call with 0 (disabled) so it must not throw.
+      const slow = makeExt("slow", {
+        setup: () => new Promise<void>((resolve) => setTimeout(resolve, 20)),
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      // With a 5 ms timeout this would fail; with 0 (disabled) it must succeed.
+      await loader.setupAll([makeResolved(slow)], {}, { setupTimeoutMs: 0 });
+    });
+  });
+
   describe("teardownAll()", () => {
     it("should call teardown() in reverse order", async () => {
       const order: string[] = [];

--- a/src/extensions/loader.test.ts
+++ b/src/extensions/loader.test.ts
@@ -229,6 +229,28 @@ describe("ExtensionLoader", () => {
       assertEquals((err as Error).message.includes("75ms"), true);
     });
 
+    it("should ignore provide() from a timed-out setup that resumes later", async () => {
+      let capturedProvide: ((contract: string, impl: unknown) => void) | undefined;
+      const hanging = makeExt("late-provider", {
+        setup: (ctx) => {
+          capturedProvide = ctx.provide;
+          return new Promise<void>(() => {}); // never resolves
+        },
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      await assertRejects(
+        () => loader.setupAll([makeResolved(hanging)], {}, { setupTimeoutMs: 50 }),
+        Error,
+        "late-provider",
+      );
+
+      // Simulate the losing setup promise resuming after rollback and trying
+      // to mutate the contract registry through its stale context.
+      capturedProvide?.("LateContract", { id: "poisoned" });
+      assertEquals(tryResolve("LateContract"), undefined);
+    });
+
     it("should rollback already-loaded extensions on timeout of a later one", async () => {
       const order: string[] = [];
       const a = makeExt("ext-a", {

--- a/src/extensions/loader.ts
+++ b/src/extensions/loader.ts
@@ -7,12 +7,25 @@
 import {
   CIRCULAR_DEPENDENCY_ERROR,
   EXTENSION_CONFLICT_ERROR,
+  EXTENSION_SETUP_TIMEOUT_ERROR,
   EXTENSION_VALIDATION_ERROR,
 } from "./errors.ts";
 import { register, reset, resolve as resolveContract, tryResolve } from "./contracts.ts";
 import { auditCapabilities } from "./capabilities.ts";
 import { detectConflicts, selectContractProviders, validateExtension } from "./validation.ts";
 import type { Extension, ExtensionContext, ExtensionLogger, ResolvedExtension } from "./types.ts";
+
+const DEFAULT_SETUP_TIMEOUT_MS = 30_000;
+const SETUP_TIMEOUT_SENTINEL = Symbol("extension-setup-timeout");
+
+/** Options for {@link ExtensionLoader.setupAll}. */
+export interface SetupAllOptions {
+  /**
+   * Per-extension setup() timeout in milliseconds.
+   * Defaults to 30 000 ms. Pass `0` to disable.
+   */
+  setupTimeoutMs?: number;
+}
 
 /** Implement extension loader. */
 export class ExtensionLoader {
@@ -156,7 +169,11 @@ export class ExtensionLoader {
   async setupAll(
     extensions: ResolvedExtension[],
     projectConfig: Record<string, unknown>,
+    options?: SetupAllOptions,
   ): Promise<void> {
+    const timeoutMs = options?.setupTimeoutMs === 0
+      ? 0
+      : (options?.setupTimeoutMs ?? DEFAULT_SETUP_TIMEOUT_MS);
     // Idempotent: teardownAll clears setupOrder and resets the contract
     // registry even when nothing is loaded yet.
     await this.teardownAll();
@@ -218,8 +235,26 @@ export class ExtensionLoader {
           logger: this.logger,
         };
         try {
-          await ext.setup(ctx);
+          if (timeoutMs > 0) {
+            let timerId: ReturnType<typeof setTimeout> | undefined;
+            const timeoutPromise = new Promise<never>((_, reject) => {
+              timerId = setTimeout(() => reject(SETUP_TIMEOUT_SENTINEL), timeoutMs);
+            });
+            try {
+              await Promise.race([ext.setup(ctx), timeoutPromise]);
+            } finally {
+              clearTimeout(timerId);
+            }
+          } else {
+            await ext.setup(ctx);
+          }
         } catch (err) {
+          const normalized = err === SETUP_TIMEOUT_SENTINEL
+            ? EXTENSION_SETUP_TIMEOUT_ERROR.create({
+              message: `Extension "${ext.name}" setup() timed out after ${timeoutMs}ms`,
+              detail: `Extension "${ext.name}" setup() did not complete within ${timeoutMs}ms`,
+            })
+            : err;
           // Best-effort teardown of the partially-initialized extension so
           // any resources it opened before throwing get a chance to close.
           if (ext.teardown) {
@@ -234,7 +269,7 @@ export class ExtensionLoader {
           }
           // Roll back everything loaded so far and clear the registry.
           await this.teardownAll();
-          throw err;
+          throw normalized;
         }
       }
 

--- a/src/extensions/loader.ts
+++ b/src/extensions/loader.ts
@@ -222,10 +222,20 @@ export class ExtensionLoader {
       }
 
       if (ext.setup) {
+        // Once setup fails (notably on timeout, where the losing promise may
+        // resume later), the context must stop mutating the contract registry,
+        // or a late provide() would poison state after teardownAll() rollback.
+        let ctxRevoked = false;
         const ctx: ExtensionContext = {
           get: <T>(contract: string) => tryResolve<T>(contract),
           require: <T>(contract: string) => resolveContract<T>(contract),
           provide: <T>(contract: string, impl: T) => {
+            if (ctxRevoked) {
+              this.logger.warn(
+                `Ignoring provide("${contract}") from "${ext.name}": its setup() already failed or timed out`,
+              );
+              return;
+            }
             const winner = contractWinner.get(contract);
             if (!winner || winner === resolved) {
               register(contract, impl);
@@ -249,6 +259,7 @@ export class ExtensionLoader {
             await ext.setup(ctx);
           }
         } catch (err) {
+          ctxRevoked = true;
           const normalized = err === SETUP_TIMEOUT_SENTINEL
             ? EXTENSION_SETUP_TIMEOUT_ERROR.create({
               message: `Extension "${ext.name}" setup() timed out after ${timeoutMs}ms`,

--- a/src/extensions/orchestrate.ts
+++ b/src/extensions/orchestrate.ts
@@ -36,6 +36,9 @@ export interface OrchestrateOptions {
    *  project, package, or config extension with the same name overrides them.
    *  Users can disable them via `{ name: "ext-llm-anthropic", enabled: false }`. */
   builtinExtensions?: ResolvedExtension[];
+  /** Per-extension setup() timeout in milliseconds. Defaults to 30 000 ms.
+   *  Pass `0` to disable. */
+  setupTimeoutMs?: number;
   /** @internal Override discovery functions in tests. */
   discovery?: {
     discoverPackageExtensions: typeof defaultDiscovery.discoverPackageExtensions;
@@ -177,7 +180,9 @@ export async function orchestrateExtensions(
   if (options.primeContracts) {
     loader.primeContracts(options.primeContracts);
   }
-  await loader.setupAll(merged, config as Record<string, unknown>);
+  await loader.setupAll(merged, config as Record<string, unknown>, {
+    setupTimeoutMs: options.setupTimeoutMs,
+  });
   return loader;
 }
 

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -296,6 +296,7 @@ export async function bootstrap(
         logger: bootstrapLog,
         primeContracts: { [LLMProviderRegistryName]: createLLMProviderRegistry() },
         builtinExtensions: createBuiltinExtensions(),
+        setupTimeoutMs: getEnvironmentConfig().extensionSetupTimeoutMs,
       });
       wireTracingShim();
       assertRequiredContracts();
@@ -347,6 +348,7 @@ export async function bootstrap(
         logger: bootstrapLog,
         primeContracts: { [LLMProviderRegistryName]: createLLMProviderRegistry() },
         builtinExtensions: createBuiltinExtensions(),
+        setupTimeoutMs: getEnvironmentConfig().extensionSetupTimeoutMs,
       });
       wireTracingShim();
       assertRequiredContracts();
@@ -420,6 +422,7 @@ export async function bootstrap(
           logger: bootstrapLog,
           primeContracts: { [LLMProviderRegistryName]: createLLMProviderRegistry() },
           builtinExtensions: createBuiltinExtensions(),
+          setupTimeoutMs: getEnvironmentConfig().extensionSetupTimeoutMs,
         }),
       fsDispose,
     );


### PR DESCRIPTION
## Summary
- `ExtensionLoader.setupAll` previously awaited each `ext.setup(ctx)` unbounded — a misbehaving extension could hang server bootstrap indefinitely with no diagnostic.
- Each setup call is now raced against a per-extension timeout (default 30 s). On timeout the loader throws a `VeryfrontError` (slug `extension-setup-timeout`, registered in `src/extensions/errors.ts`) naming the extension and the deadline.
- The timeout path reuses the existing failure semantics: best-effort `teardown()` of the hanging extension, then `teardownAll()` rollback of everything loaded so far.
- Configurable via `setupTimeoutMs` on `setupAll()` / `orchestrateExtensions()` (`0` disables), or the `VF_EXTENSION_SETUP_TIMEOUT_MS` env var, read in `environment-config.ts` and wired through all three bootstrap orchestration call sites.
- Timers are cleared in `finally`, so the Deno test sanitizers stay green.

Found during an architecture review of the extension loader.

## Test plan
- New loader tests: hung `setup()` with a short timeout throws the timeout error naming the extension; previously-loaded extensions are torn down; normal extensions unaffected; `setupTimeoutMs: 0` disables the bound.
- `deno test src/extensions/loader.test.ts src/extensions/orchestrate.test.ts` with repo flags: 3 passed (50 steps), 0 failed.
- `deno check` on `loader.ts`, `orchestrate.ts`, `bootstrap.ts` passes.