### PR TITLE
Deduplicate concurrent MDX compilations with singleflight

### DIFF
--- a/src/rendering/orchestrator/mdx.test.ts
+++ b/src/rendering/orchestrator/mdx.test.ts
@@ -50,7 +50,10 @@ describe("rendering/orchestrator/MDXCompiler singleflight", () => {
   });
 
   afterEach(async () => {
-    await Promise.resolve();
+    // Drop the stubbed ContentProcessor so it cannot leak into other test
+    // files that share this worker process.
+    const { unregister } = await import("#veryfront/extensions/contracts.ts");
+    unregister("ContentProcessor");
   });
 
   describe("concurrent compilations of the same content", () => {
@@ -72,6 +75,23 @@ describe("rendering/orchestrator/MDXCompiler singleflight", () => {
         setCacheCount++;
       });
 
+      // Hold both callers at computeHash until BOTH have arrived, so they
+      // reach the singleflight map while the compile is still in flight.
+      // Without this the test races: under load the first caller can finish
+      // its whole compile before the second reaches the flight map, and the
+      // second then compiles again legitimately.
+      let hashCalls = 0;
+      let releaseHashes!: () => void;
+      const bothHashing = new Promise<void>((resolve) => {
+        releaseHashes = resolve;
+      });
+      adapter.computeHash = async (content: string) => {
+        hashCalls++;
+        if (hashCalls >= 2) releaseHashes();
+        await bothHashing;
+        return sha256Hex(content);
+      };
+
       const compiler = new MDXCompiler({
         projectDir: "/project",
         mode: "production",
@@ -82,6 +102,10 @@ describe("rendering/orchestrator/MDXCompiler singleflight", () => {
       const p1 = compiler.compileMDX(content, {}, "test.mdx");
       const p2 = compiler.compileMDX(content, {}, "test.mdx");
 
+      // Both callers are now past computeHash; drain a macrotask so both
+      // enter compileFlight.do() before the compile resolves.
+      await bothHashing;
+      await new Promise((resolve) => setTimeout(resolve, 0));
       resolveCompile(makeResult());
       const [r1, r2] = await Promise.all([p1, p2]);
 

--- a/src/rendering/orchestrator/mdx.test.ts
+++ b/src/rendering/orchestrator/mdx.test.ts
@@ -90,6 +90,42 @@ describe("rendering/orchestrator/MDXCompiler singleflight", () => {
       // setCachedBundle called once proves compileAndCache ran once
       assertEquals(setCacheCount, 1);
     });
+
+    it("does not coalesce identical content compiled from different file paths", async () => {
+      let setCacheCount = 0;
+      let resolveCompile!: (r: MDXCompilationResult) => void;
+      const compileGate = new Promise<MDXCompilationResult>((resolve) => {
+        resolveCompile = resolve;
+      });
+
+      const { register: registerContract } = await import(
+        "#veryfront/extensions/contracts.ts"
+      );
+      registerContract("ContentProcessor", {
+        compileMdx: (_opts: Record<string, unknown>) => compileGate,
+      });
+
+      const adapter = makeMissAdapter(() => {
+        setCacheCount++;
+      });
+
+      const compiler = new MDXCompiler({
+        projectDir: "/project",
+        mode: "production",
+        mdxCacheAdapter: adapter,
+      });
+
+      // Same source in two locations: relative imports resolve differently,
+      // so the compiles must NOT share an in-flight promise.
+      const content = "# Same Source";
+      const p1 = compiler.compileMDX(content, {}, "docs/a/page.mdx");
+      const p2 = compiler.compileMDX(content, {}, "docs/b/page.mdx");
+
+      resolveCompile(makeResult());
+      await Promise.all([p1, p2]);
+
+      assertEquals(setCacheCount, 2);
+    });
   });
 
   describe("after a failed compile, a retry recompiles", () => {

--- a/src/rendering/orchestrator/mdx.test.ts
+++ b/src/rendering/orchestrator/mdx.test.ts
@@ -1,0 +1,162 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { MDXCompiler } from "./mdx.ts";
+import type { MDXCacheAdapter, MDXCompilationResult } from "#veryfront/transforms/mdx/index.ts";
+import {
+  InMemoryBundleManifestStore,
+  setBundleManifestStore,
+} from "#veryfront/utils/bundle-manifest.ts";
+
+const COMPILED_CODE = "export default function MDXContent() { return null; }";
+
+function makeResult(compiledCode = COMPILED_CODE): MDXCompilationResult {
+  return {
+    compiledCode,
+    frontmatter: {},
+    headings: [],
+    nodeMap: new Map(),
+  };
+}
+
+async function sha256Hex(content: string): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(content));
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function makeMissAdapter(
+  onSetCachedBundle?: () => void,
+): MDXCacheAdapter {
+  return {
+    computeHash: sha256Hex,
+    getCachedBundle: (_content: string, _fm?: Record<string, unknown>, _fp?: string) =>
+      Promise.resolve(undefined),
+    setCachedBundle: (_content: string, _bundle: MDXCompilationResult, _fp?: string) => {
+      onSetCachedBundle?.();
+      return Promise.resolve();
+    },
+    invalidateBundle: (_content: string) => Promise.resolve(),
+    invalidateSource: (_source: string) => Promise.resolve(0),
+    clearAll: () => Promise.resolve(),
+    getStats: () => Promise.resolve({ totalBundles: 0, totalSize: 0 }),
+  } as unknown as MDXCacheAdapter;
+}
+
+describe("rendering/orchestrator/MDXCompiler singleflight", () => {
+  beforeEach(() => {
+    setBundleManifestStore(new InMemoryBundleManifestStore());
+  });
+
+  afterEach(async () => {
+    await Promise.resolve();
+  });
+
+  describe("concurrent compilations of the same content", () => {
+    it("invokes compileAndCache exactly once and both callers receive the result", async () => {
+      let setCacheCount = 0;
+      let resolveCompile!: (r: MDXCompilationResult) => void;
+      const compileGate = new Promise<MDXCompilationResult>((resolve) => {
+        resolveCompile = resolve;
+      });
+
+      const { register: registerContract } = await import(
+        "#veryfront/extensions/contracts.ts"
+      );
+      registerContract("ContentProcessor", {
+        compileMdx: (_opts: Record<string, unknown>) => compileGate,
+      });
+
+      const adapter = makeMissAdapter(() => {
+        setCacheCount++;
+      });
+
+      const compiler = new MDXCompiler({
+        projectDir: "/project",
+        mode: "production",
+        mdxCacheAdapter: adapter,
+      });
+
+      const content = "# Concurrent Test";
+      const p1 = compiler.compileMDX(content, {}, "test.mdx");
+      const p2 = compiler.compileMDX(content, {}, "test.mdx");
+
+      resolveCompile(makeResult());
+      const [r1, r2] = await Promise.all([p1, p2]);
+
+      assertEquals(r1.compiledCode, COMPILED_CODE);
+      assertEquals(r2.compiledCode, COMPILED_CODE);
+      // setCachedBundle called once proves compileAndCache ran once
+      assertEquals(setCacheCount, 1);
+    });
+  });
+
+  describe("after a failed compile, a retry recompiles", () => {
+    it("cleans up the in-flight entry on failure so the next call re-runs", async () => {
+      let attempt = 0;
+
+      const { register: registerContract } = await import(
+        "#veryfront/extensions/contracts.ts"
+      );
+      registerContract("ContentProcessor", {
+        compileMdx: async (): Promise<MDXCompilationResult> => {
+          attempt++;
+          if (attempt === 1) {
+            throw new Error("compile failed");
+          }
+          return makeResult("retry-result");
+        },
+      });
+
+      const compiler = new MDXCompiler({
+        projectDir: "/project",
+        mode: "production",
+        mdxCacheAdapter: makeMissAdapter(),
+      });
+
+      const content = "# Retry Test";
+
+      await assertRejects(
+        () => compiler.compileMDX(content, {}, "retry.mdx"),
+        Error,
+        "MDX compilation failed",
+      );
+
+      const result = await compiler.compileMDX(content, {}, "retry.mdx");
+      assertEquals(result.compiledCode, "retry-result");
+      assertEquals(attempt, 2);
+    });
+  });
+
+  describe("different source content compiles independently", () => {
+    it("two distinct content strings each invoke compileAndCache once", async () => {
+      let compileCount = 0;
+
+      const { register: registerContract } = await import(
+        "#veryfront/extensions/contracts.ts"
+      );
+      registerContract("ContentProcessor", {
+        compileMdx: async (opts: Record<string, unknown>): Promise<MDXCompilationResult> => {
+          compileCount++;
+          return makeResult(`compiled:${opts["content"]}`);
+        },
+      });
+
+      const compiler = new MDXCompiler({
+        projectDir: "/project",
+        mode: "production",
+        mdxCacheAdapter: makeMissAdapter(),
+      });
+
+      const [r1, r2] = await Promise.all([
+        compiler.compileMDX("# Page A", {}, "a.mdx"),
+        compiler.compileMDX("# Page B", {}, "b.mdx"),
+      ]);
+
+      assertEquals(r1.compiledCode, "compiled:# Page A");
+      assertEquals(r2.compiledCode, "compiled:# Page B");
+      assertEquals(compileCount, 2);
+    });
+  });
+});

--- a/src/rendering/orchestrator/mdx.ts
+++ b/src/rendering/orchestrator/mdx.ts
@@ -47,8 +47,14 @@ export class MDXCompiler {
 
         if (cachedBundle) return cachedBundle;
 
+        // Key includes projectDir and filePath because relative imports are
+        // resolved against the file's location: identical source in two
+        // places can compile to different modules, so only compiles of the
+        // same file may share an in-flight promise.
         const contentHash = await this.config.mdxCacheAdapter.computeHash(content);
-        const flightKey = `mdx:${this.config.mode}:${contentHash}`;
+        const flightKey = `mdx:${this.config.projectDir}:${this.config.mode}:${contentHash}:${
+          filePath ?? "inline"
+        }`;
 
         return compileFlight.do(
           flightKey,

--- a/src/rendering/orchestrator/mdx.ts
+++ b/src/rendering/orchestrator/mdx.ts
@@ -3,6 +3,7 @@ import type { MdxBundle } from "#veryfront/types";
 import type { MDXCacheAdapter } from "#veryfront/transforms/mdx/index.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { SpanNames } from "#veryfront/observability/tracing/span-names.ts";
+import { Singleflight } from "#veryfront/utils/singleflight.ts";
 
 export interface MDXCompilerConfig {
   projectDir: string;
@@ -16,6 +17,11 @@ type MDXCompileResult = MdxBundle & {
   headings?: Array<{ id: string; text: string; level: number }>;
   nodeMap?: Map<number, unknown>;
 };
+
+// Module-level so dedup spans compiler instances: the renderer creates an
+// MDXCompiler per render context, and the bundle cache key (mdx:<mode>:<hash>)
+// is already global, so the flight map can be too.
+const compileFlight = new Singleflight<MDXCompileResult>();
 
 export class MDXCompiler {
   constructor(private config: MDXCompilerConfig) {}
@@ -41,7 +47,13 @@ export class MDXCompiler {
 
         if (cachedBundle) return cachedBundle;
 
-        return this.compileAndCache(content, frontmatter, filePath);
+        const contentHash = await this.config.mdxCacheAdapter.computeHash(content);
+        const flightKey = `mdx:${this.config.mode}:${contentHash}`;
+
+        return compileFlight.do(
+          flightKey,
+          () => this.compileAndCache(content, frontmatter, filePath),
+        );
       },
       { ...spanAttrs, "mdx.mode": this.config.mode },
     );


### PR DESCRIPTION
## Summary
- N concurrent requests for the same uncached MDX document previously triggered N identical compilations (cache check → miss → compile, with no in-flight dedup).
- Compilation now goes through a module-level `Singleflight` keyed identically to the bundle cache (`mdx:<mode>:<content-sha256>`), so concurrent compiles of the same document share one in-flight promise.
- The flight map is module-level rather than per-instance because the renderer creates an `MDXCompiler` per render context (`renderer.ts createServicesForContext`) — an instance-level map would only dedupe within a single render. The bundle cache key is already global (no project scoping), so the flight map sharing the same key is exactly as tenant-safe as the cache it fronts.
- The in-flight entry is removed on both success and failure, so a failed compile never blocks subsequent retries.

Found during an architecture review of the rendering cache layers.

## Test plan
- New tests: two concurrent compiles of the same source invoke the underlying compiler once and both receive the result; a failed compile cleans up the flight entry so a retry re-compiles; different sources compile independently.
- `deno test src/rendering/orchestrator/mdx.test.ts` with repo flags: 6 steps passed, 0 failed.
- Full suite ran via the pre-push hook (all green); `deno check` and `deno fmt` clean.