### PR TITLE
fix: API client retry and client version header

### DIFF
--- a/cli/shared/config.test.ts
+++ b/cli/shared/config.test.ts
@@ -6,7 +6,8 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { resolveConfig, resolveConfigWithAuth } from "./config.ts";
+import { createApiClient, resolveConfig, resolveConfigWithAuth } from "./config.ts";
+import type { ResolvedConfig } from "./config.ts";
 import type { EnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import { join } from "veryfront/platform/path";
 
@@ -198,5 +199,213 @@ describe("resolveConfigWithAuth", () => {
         Deno.env.set("TENANT_PROJECT_ID", previousTenantProjectId);
       }
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createApiClient tests
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
+  return {
+    apiUrl: "https://api.veryfront.com",
+    apiToken: "test-token",
+    projectSlug: "test-project",
+    ...overrides,
+  };
+}
+
+describe("createApiClient", () => {
+  describe("x-veryfront-client-version header", () => {
+    it("sends x-veryfront-client-version on GET requests", async () => {
+      let capturedHeaders: Headers | undefined;
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = ((_input: unknown, init?: RequestInit) => {
+        capturedHeaders = new Headers(init?.headers as HeadersInit);
+        return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+      }) as typeof fetch;
+
+      try {
+        const client = createApiClient(makeConfig());
+        await client.get("/test");
+        const version = capturedHeaders?.get("x-veryfront-client-version");
+        assertEquals(typeof version, "string");
+        assertEquals(version!.length > 0, true);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("sends x-veryfront-client-version on POST requests", async () => {
+      let capturedHeaders: Headers | undefined;
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = ((_input: unknown, init?: RequestInit) => {
+        capturedHeaders = new Headers(init?.headers as HeadersInit);
+        return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+      }) as typeof fetch;
+
+      try {
+        const client = createApiClient(makeConfig());
+        await client.post("/test", { foo: "bar" });
+        const version = capturedHeaders?.get("x-veryfront-client-version");
+        assertEquals(typeof version, "string");
+        assertEquals(version!.length > 0, true);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  });
+
+  describe("retry on transient failures for idempotent requests", () => {
+    it("retries GET on 502 and succeeds on second attempt", async () => {
+      let callCount = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = ((_input: unknown, _init?: RequestInit) => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve(new Response("bad gateway", { status: 502 }));
+        }
+        return Promise.resolve(new Response(JSON.stringify({ data: "ok" }), { status: 200 }));
+      }) as typeof fetch;
+
+      try {
+        const client = createApiClient(makeConfig());
+        const result = await client.get<{ data: string }>("/test");
+        assertEquals(result.data, "ok");
+        assertEquals(callCount, 2);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("retries GET on 503 and succeeds on second attempt", async () => {
+      let callCount = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = ((_input: unknown, _init?: RequestInit) => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve(new Response("service unavailable", { status: 503 }));
+        }
+        return Promise.resolve(new Response(JSON.stringify({ data: "ok" }), { status: 200 }));
+      }) as typeof fetch;
+
+      try {
+        const client = createApiClient(makeConfig());
+        const result = await client.get<{ data: string }>("/test");
+        assertEquals(result.data, "ok");
+        assertEquals(callCount, 2);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("retries GET on connection error and succeeds on second attempt", async () => {
+      let callCount = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = ((_input: unknown, _init?: RequestInit) => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.reject(new Error("connection reset by peer"));
+        }
+        return Promise.resolve(new Response(JSON.stringify({ data: "ok" }), { status: 200 }));
+      }) as typeof fetch;
+
+      try {
+        const client = createApiClient(makeConfig());
+        const result = await client.get<{ data: string }>("/test");
+        assertEquals(result.data, "ok");
+        assertEquals(callCount, 2);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("exhausts retries and throws after 3 consecutive 502 responses", async () => {
+      let callCount = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = ((_input: unknown, _init?: RequestInit) => {
+        callCount++;
+        return Promise.resolve(new Response("bad gateway", { status: 502 }));
+      }) as typeof fetch;
+
+      try {
+        const client = createApiClient(makeConfig());
+        await assertRejects(
+          () => client.get("/test"),
+          Error,
+          "502",
+        );
+        assertEquals(callCount, 3);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  });
+
+  describe("retry behavior for non-idempotent requests", () => {
+    it("does NOT retry POST on 502", async () => {
+      let callCount = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = ((_input: unknown, _init?: RequestInit) => {
+        callCount++;
+        return Promise.resolve(new Response("bad gateway", { status: 502 }));
+      }) as typeof fetch;
+
+      try {
+        const client = createApiClient(makeConfig());
+        await assertRejects(
+          () => client.post("/test", {}),
+          Error,
+          "502",
+        );
+        assertEquals(callCount, 1);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("retries POST on connection-refused error (request never reached server)", async () => {
+      let callCount = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = ((_input: unknown, _init?: RequestInit) => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.reject(new Error("connection refused (os error 111)"));
+        }
+        return Promise.resolve(new Response(JSON.stringify({ created: true }), { status: 200 }));
+      }) as typeof fetch;
+
+      try {
+        const client = createApiClient(makeConfig());
+        const result = await client.post<{ created: boolean }>("/test", {});
+        assertEquals(result.created, true);
+        assertEquals(callCount, 2);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("does NOT retry POST on connection-reset (request may have reached server)", async () => {
+      let callCount = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = ((_input: unknown, _init?: RequestInit) => {
+        callCount++;
+        return Promise.reject(new Error("connection reset by peer"));
+      }) as typeof fetch;
+
+      try {
+        const client = createApiClient(makeConfig());
+        await assertRejects(
+          () => client.post("/test", {}),
+          Error,
+          "connection reset",
+        );
+        assertEquals(callCount, 1);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
   });
 });

--- a/cli/shared/config.ts
+++ b/cli/shared/config.ts
@@ -10,10 +10,33 @@ import type { InferSchema } from "veryfront/extensions/schema";
 import { join } from "veryfront/platform/path";
 import { createFileSystem, cwd, getEnv } from "veryfront/platform";
 import { type EnvironmentConfig, getEnvironmentConfig } from "veryfront/config";
-import { cliLogger } from "#cli/utils";
+import { cliLogger, VERSION } from "#cli/utils";
 import { readToken } from "../auth/token-store.ts";
 import { ensureAuthenticated } from "../auth/login.ts";
 import { DEFAULT_API_URL } from "./constants.ts";
+import { isRetryableConnectionError } from "../../src/proxy/retry.ts";
+
+// Delays for exponential backoff with jitter: attempt 1 = ~300ms, 2 = ~1s, 3 = ~3s
+const API_RETRY_DELAYS_MS = [300, 1000, 3000] as const;
+const API_MAX_RETRIES = 3;
+
+/** Returns true for HTTP status codes that indicate a transient gateway failure. */
+function isTransientStatus(status: number): boolean {
+  return status === 502 || status === 503 || status === 504;
+}
+
+/** Returns true when the connection error is a refused connection (request never reached server). */
+function isConnectionRefused(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const msg = error.message.toLowerCase();
+  return msg.includes("connection refused") || msg.includes("os error 111");
+}
+
+/** Sleep for `ms` milliseconds plus a random jitter up to 20% of `ms`. */
+function sleepWithJitter(ms: number): Promise<void> {
+  const jitter = Math.floor(ms * 0.2 * Math.random());
+  return new Promise<void>((resolve) => setTimeout(resolve, ms + jitter));
+}
 
 export const getVeryfrontConfigSchema = defineSchema((v) =>
   v.object({
@@ -196,24 +219,18 @@ export type ApiError = InferSchema<ReturnType<typeof getApiErrorSchema>>;
 export function createApiClient(config: ResolvedConfig): ApiClient {
   const { apiUrl, apiToken } = config;
 
-  async function request<T>(
+  async function requestOnce<T>(
     method: string,
-    path: string,
+    url: string,
     body?: unknown,
-    params?: Record<string, string>,
   ): Promise<T> {
-    const url = new URL(`${apiUrl}${path}`);
-
-    for (const [key, value] of Object.entries(params ?? {})) {
-      url.searchParams.set(key, value);
-    }
-
-    const response = await fetch(url.toString(), {
+    const response = await fetch(url, {
       method,
       headers: {
         Authorization: `Bearer ${apiToken}`,
         "Content-Type": "application/json",
         Accept: "application/json",
+        "x-veryfront-client-version": VERSION,
       },
       body: body ? JSON.stringify(body) : undefined,
     });
@@ -230,12 +247,67 @@ export function createApiClient(config: ResolvedConfig): ApiClient {
         // Keep default error message if JSON parsing fails
       }
 
-      throw new Error(errorMessage);
+      const err = new Error(errorMessage) as Error & { status: number };
+      err.status = response.status;
+      throw err;
     }
 
     if (response.status === 204) return undefined as T;
 
     return response.json() as Promise<T>;
+  }
+
+  /** Returns true for request methods that are safe to retry on any transient failure. */
+  function isIdempotent(method: string): boolean {
+    return method === "GET" || method === "HEAD";
+  }
+
+  async function request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    params?: Record<string, string>,
+  ): Promise<T> {
+    const url = new URL(`${apiUrl}${path}`);
+
+    for (const [key, value] of Object.entries(params ?? {})) {
+      url.searchParams.set(key, value);
+    }
+
+    const urlStr = url.toString();
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < API_MAX_RETRIES; attempt++) {
+      try {
+        return await requestOnce<T>(method, urlStr, body);
+      } catch (error) {
+        lastError = error;
+
+        const status = (error as { status?: number }).status;
+        const isTransient = status !== undefined
+          ? isTransientStatus(status)
+          : isRetryableConnectionError(error);
+        const isRefused = isConnectionRefused(error);
+
+        // Idempotent: retry on transient HTTP status or any retryable connection error.
+        // Non-idempotent: retry only on connection-refused (request never reached server).
+        const shouldRetry = isIdempotent(method)
+          ? (isTransient || isRetryableConnectionError(error))
+          : isRefused;
+
+        if (!shouldRetry || attempt >= API_MAX_RETRIES - 1) {
+          throw error;
+        }
+
+        await sleepWithJitter(API_RETRY_DELAYS_MS[attempt as 0 | 1 | 2]);
+        cliLogger.debug(
+          `API request ${method} ${path} failed (attempt ${attempt + 1}), retrying...`,
+          error,
+        );
+      }
+    }
+
+    throw lastError;
   }
 
   return {


### PR DESCRIPTION
## Summary
CLI/API-client resilience during deployments (from the June 2026 platform HA audit):
- **Transient-failure retry** in the central API client: GET/HEAD retried up to 3× (300ms/1s/3s + 20% jitter) on 502/503/504 and retryable connection errors; mutations retried only on connection-refused (request never reached the server), fail-fast otherwise.
- **Client version header**: every request now sends `x-veryfront-client-version` so the API can detect/act on version skew (enforcement is api-side follow-up).

## Verification
- `deno check` ✅; new BDD tests: 3 suites / 22 steps pass; proxy retry tests pass.
