### PR TITLE
Add directory-entry listing and existence helpers to file discovery

### DIFF
--- a/src/discovery/file-discovery.test.ts
+++ b/src/discovery/file-discovery.test.ts
@@ -45,6 +45,26 @@ Deno.test("listDiscoveryDirectoryEntries returns empty for a missing dir via fsA
   assertEquals(await listDiscoveryDirectoryEntries("/missing", context), []);
 });
 
+Deno.test("listDiscoveryDirectoryEntries reads top-level entries through the Node fallback", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await Deno.writeTextFile(`${root}/lead.md`, "Lead");
+    await Deno.mkdir(`${root}/writer`);
+    await Deno.writeTextFile(`${root}/writer/AGENT.md`, "Writer");
+    const context: FileDiscoveryContext = { platform: "node" };
+
+    const entries = (await listDiscoveryDirectoryEntries(root, context))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    assertEquals(entries, [
+      { name: "lead.md", isFile: true, isDirectory: false },
+      { name: "writer", isFile: false, isDirectory: true },
+    ]);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
 Deno.test("discoveryFileExists resolves through an fsAdapter", async () => {
   const fsAdapter = fakeFsAdapter({}, new Set(["/agents/writer/AGENT.md"]));
   const context: FileDiscoveryContext = { platform: "node", fsAdapter };

--- a/src/discovery/file-discovery.test.ts
+++ b/src/discovery/file-discovery.test.ts
@@ -1,0 +1,54 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { discoveryFileExists, listDiscoveryDirectoryEntries } from "./file-discovery.ts";
+import type { FileDiscoveryContext } from "./types.ts";
+import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
+
+type FakeEntry = { name: string; isFile: boolean; isDirectory: boolean };
+
+function fakeFsAdapter(tree: Record<string, FakeEntry[]>, files: Set<string>): FileSystemAdapter {
+  return {
+    exists: (path: string) => Promise.resolve(path in tree || files.has(path)),
+    readDir: async function* (path: string) {
+      for (const entry of tree[path] ?? []) {
+        yield entry;
+      }
+    },
+    readFile: (path: string) => Promise.resolve(`content:${path}`),
+  } as unknown as FileSystemAdapter;
+}
+
+Deno.test("listDiscoveryDirectoryEntries reads top-level entries through an fsAdapter", async () => {
+  const fsAdapter = fakeFsAdapter(
+    {
+      "/agents": [
+        { name: "lead.md", isFile: true, isDirectory: false },
+        { name: "writer", isFile: false, isDirectory: true },
+      ],
+    },
+    new Set(),
+  );
+  const context: FileDiscoveryContext = { platform: "node", fsAdapter };
+
+  const entries = await listDiscoveryDirectoryEntries("/agents", context);
+
+  assertEquals(entries, [
+    { name: "lead.md", isFile: true, isDirectory: false },
+    { name: "writer", isFile: false, isDirectory: true },
+  ]);
+});
+
+Deno.test("listDiscoveryDirectoryEntries returns empty for a missing dir via fsAdapter", async () => {
+  const fsAdapter = fakeFsAdapter({}, new Set());
+  const context: FileDiscoveryContext = { platform: "node", fsAdapter };
+
+  assertEquals(await listDiscoveryDirectoryEntries("/missing", context), []);
+});
+
+Deno.test("discoveryFileExists resolves through an fsAdapter", async () => {
+  const fsAdapter = fakeFsAdapter({}, new Set(["/agents/writer/AGENT.md"]));
+  const context: FileDiscoveryContext = { platform: "node", fsAdapter };
+
+  assertEquals(await discoveryFileExists("/agents/writer/AGENT.md", context), true);
+  assertEquals(await discoveryFileExists("/agents/writer/SKILL.md", context), false);
+});

--- a/src/discovery/file-discovery.ts
+++ b/src/discovery/file-discovery.ts
@@ -107,3 +107,66 @@ export async function readDiscoveryTextFile(
   const { fs } = await getNodeDeps(context);
   return fs.readFileSync(path, "utf-8");
 }
+
+/** A single top-level entry inside a discovery directory. */
+export type DiscoveryDirectoryEntry = {
+  name: string;
+  isFile: boolean;
+  isDirectory: boolean;
+};
+
+/** Lists the immediate (non-recursive) entries of a discovery directory. */
+export async function listDiscoveryDirectoryEntries(
+  dir: string,
+  context: FileDiscoveryContext,
+): Promise<DiscoveryDirectoryEntry[]> {
+  const entries: DiscoveryDirectoryEntry[] = [];
+
+  try {
+    if (context.fsAdapter) {
+      if (!(await context.fsAdapter.exists(dir))) return entries;
+
+      for await (const entry of context.fsAdapter.readDir(dir)) {
+        entries.push({
+          name: entry.name,
+          isFile: Boolean(entry.isFile),
+          isDirectory: Boolean(entry.isDirectory),
+        });
+      }
+
+      return entries;
+    }
+
+    const { fs } = await getNodeDeps(context);
+    if (!fs.existsSync(dir)) return entries;
+
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      entries.push({
+        name: entry.name,
+        isFile: entry.isFile(),
+        isDirectory: entry.isDirectory(),
+      });
+    }
+  } catch (_) {
+    /* expected: directory may not exist or be unreadable */
+    return entries;
+  }
+
+  return entries;
+}
+
+/** Returns true when a discovery file exists (fsAdapter-aware). */
+export async function discoveryFileExists(
+  path: string,
+  context: FileDiscoveryContext,
+): Promise<boolean> {
+  try {
+    if (context.fsAdapter) {
+      return await context.fsAdapter.exists(path);
+    }
+    const { fs } = await getNodeDeps(context);
+    return fs.existsSync(path);
+  } catch (_) {
+    return false;
+  }
+}

--- a/src/discovery/file-discovery.ts
+++ b/src/discovery/file-discovery.ts
@@ -129,8 +129,8 @@ export async function listDiscoveryDirectoryEntries(
       for await (const entry of context.fsAdapter.readDir(dir)) {
         entries.push({
           name: entry.name,
-          isFile: Boolean(entry.isFile),
-          isDirectory: Boolean(entry.isDirectory),
+          isFile: entry.isFile,
+          isDirectory: entry.isDirectory,
         });
       }
 


### PR DESCRIPTION
## Summary

Extracts the standalone file-discovery infrastructure from the multi-agent staging branch (#2354), per the agreed split (PR A): `listDiscoveryDirectoryEntries` (immediate, non-recursive directory listing) and `discoveryFileExists` (path existence), both fsAdapter-aware with Node fallback.

Purely additive — no behavior changes to existing discovery. First of the extraction series; `delegates:` support (PR B) follows separately.

## Testing

- `deno test --no-check --allow-all src/discovery/file-discovery.test.ts` — 3/3 pass
- `deno test --no-check --allow-all src/discovery` — full suite green

## Type of Change
- [x] New feature (non-breaking, additive infrastructure)
- [x] Test update