### PR TITLE
Make capability visibility owner-aware across all resolution surfaces

### DIFF
--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -55,6 +55,54 @@ The file path provides the agent id. For example, `agents/support.md` registers
 `support` and can be invoked through the same project runtime and control-plane
 surfaces as `agents/support.ts`.
 
+## Per-agent skills and tools
+
+A markdown agent can own its skills and tools by using a directory instead of a
+single file. Put the agent definition in `AGENT.md` and colocate its
+capabilities beside it:
+
+```
+agents/
+  researcher/
+    AGENT.md            # the agent definition (frontmatter + instructions)
+    SKILL.md            # the agent's own skill, loaded as load_skill("researcher")
+    skills/
+      cite/SKILL.md     # an extra skill, loaded as load_skill("researcher--cite")
+    tools/
+      fetch-paper.ts    # a colocated tool, registered as "researcher--fetch-paper"
+```
+
+The directory name is the agent id. The flat `agents/{id}.md` form still works
+for agents that do not own skills or tools, and both layouts can coexist.
+
+Colocated capabilities are registered with owner metadata and namespaced
+`{agentId}--{name}`. Ownership controls visibility everywhere: an agent only
+ever sees unowned (project-global) capabilities plus its own — never another
+agent's. This one rule applies to `skills:` and `tools:` for every agent kind
+(TypeScript, flat markdown, and directory markdown):
+
+```md
+---
+name: Researcher
+model: anthropic/claude-sonnet-4-6
+skills: true # all skills visible to this agent (global + own)
+tools: [fetch-paper] # own short names resolve first, then global tool ids
+---
+
+Research the question and cite every claim.
+```
+
+- `skills: true` / `tools: true` — every capability visible to the agent.
+- `skills: [..]` / `tools: [..]` — each entry resolves as the agent's own
+  short name first, then as a global id. A colocated short name that shadows a
+  global id is reported at discovery so the reference stays unambiguous.
+- Duplicate agent ids (flat file + directory) and agent ids whose sanitized
+  namespaces collide are reported as discovery errors.
+
+> Note: colocated capabilities currently resolve in the local runtime; hosted
+> runtime catalog support is tracked separately and lands before this layout
+> is documented as stable.
+
 ## Add tools
 
 Agents call tools to take actions or fetch data. Reference tools by name: the

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -99,6 +99,29 @@ const researcher = getAgent("researcher");
 const researchTool = agentAsTool(researcher, "Research a topic using web search");
 ```
 
+## Declarative delegation with `delegates`
+
+A markdown agent can opt into orchestration by listing the specialists it may
+call in its `delegates` frontmatter. The runtime gives the agent one
+`agent_{id}` tool per delegate; each delegate runs with its own settings,
+skills, and tools — capability ownership does not cross the delegation
+boundary in either direction.
+
+```md
+---
+name: Lead
+description: Plans the work and routes to specialists
+delegates: [researcher, writer]
+---
+
+Break the task down. Use agent_researcher to gather facts, then agent_writer to
+produce the final copy.
+```
+
+With several agents and no `delegates`, the agents are independent: a caller
+selects one by id. Self-delegation and delegate ids that cannot form a valid
+provider tool name are rejected at discovery with explicit diagnostics.
+
 ## Workflow-based composition
 
 For deterministic multi-agent pipelines, use [workflows](./workflows.md):

--- a/scripts/lint/check-sanitizer-baseline.ts
+++ b/scripts/lint/check-sanitizer-baseline.ts
@@ -22,7 +22,7 @@ const SCAN_ROOTS = [
 
 // Lower this when you remove sanitizer opt-outs. Never raise it without a very
 // good reason — a new opt-out means a leak is being suppressed rather than fixed.
-export const SANITIZER_OPT_OUT_BASELINE = 420;
+export const SANITIZER_OPT_OUT_BASELINE = 422;
 
 const OPT_OUT_PATTERN = /sanitize(?:Resources|Ops|Exit)\s*:\s*false/g;
 

--- a/scripts/lint/check-sanitizer-baseline.ts
+++ b/scripts/lint/check-sanitizer-baseline.ts
@@ -22,6 +22,10 @@ const SCAN_ROOTS = [
 
 // Lower this when you remove sanitizer opt-outs. Never raise it without a very
 // good reason — a new opt-out means a leak is being suppressed rather than fixed.
+// 422 = 420 (historical) + 2 for the colocated tool-loading discovery test
+// (src/discovery/agent-scoped-capabilities.test.ts): importModule transpiles
+// via esbuild, whose warm child process trips the op/resource sanitizers —
+// same rationale as src/discovery/transpiler.test.ts.
 export const SANITIZER_OPT_OUT_BASELINE = 422;
 
 const OPT_OUT_PATTERN = /sanitize(?:Resources|Ops|Exit)\s*:\s*false/g;

--- a/src/agent/ag-ui/tool-shared.test.ts
+++ b/src/agent/ag-ui/tool-shared.test.ts
@@ -78,3 +78,39 @@ describe("buildMergedAgUiTools", () => {
     assertEquals(mergedTools["number-generator"], true);
   });
 });
+
+// ── Owner-aware tools: true expansion (review round 3) ────────────────────
+
+import { clearMCPRegistry, registerTool } from "#veryfront/mcp";
+
+function makeRegistryTool(id: string, ownerAgentId?: string): Tool {
+  return {
+    id,
+    type: "function",
+    description: `${id} test tool`,
+    inputSchema: defineSchema((v) => v.object({}))(),
+    execute: () => Promise.resolve({ ok: true }),
+    ...(ownerAgentId === undefined ? {} : { ownerAgentId }),
+  };
+}
+
+describe("buildMergedAgUiTools owner scope", () => {
+  it("tools: true excludes other agents' owned tools and includes the owner's", () => {
+    clearMCPRegistry();
+    try {
+      registerTool("global-echo", makeRegistryTool("global-echo"));
+      registerTool("researcher--fetch", makeRegistryTool("researcher--fetch", "researcher"));
+
+      const writer = { id: "writer", config: { tools: true } } as unknown as Agent;
+      const writerTools = buildMergedAgUiTools(writer, "run_w", []);
+      assertEquals(Object.keys(writerTools ?? {}).includes("global-echo"), true);
+      assertEquals(Object.keys(writerTools ?? {}).includes("researcher--fetch"), false);
+
+      const researcher = { id: "researcher", config: { tools: true } } as unknown as Agent;
+      const researcherTools = buildMergedAgUiTools(researcher, "run_r", []);
+      assertEquals(Object.keys(researcherTools ?? {}).includes("researcher--fetch"), true);
+    } finally {
+      clearMCPRegistry();
+    }
+  });
+});

--- a/src/agent/ag-ui/tool-shared.ts
+++ b/src/agent/ag-ui/tool-shared.ts
@@ -2,6 +2,7 @@ import { defineSchema } from "#veryfront/schemas/index.ts";
 import type { Schema } from "#veryfront/extensions/schema/index.ts";
 import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
 import { toolRegistry } from "#veryfront/tool/registry.ts";
+import { isToolVisibleTo } from "#veryfront/tool/executor.ts";
 import type { Tool } from "#veryfront/tool/types.ts";
 import type { RunResumeSessionManager } from "../runtime/index.ts";
 import type { Agent } from "../types.ts";
@@ -73,8 +74,13 @@ export function buildMergedAgUiTools(
 
   if (agent.config.tools === true) {
     const merged: Record<string, Tool | boolean> = {};
-    for (const [toolId] of toolRegistry.getAll()) {
+    for (const [toolId, registryTool] of toolRegistry.getAll()) {
       if (!agent.config.skills && SKILL_TOOL_IDS.has(toolId)) {
+        continue;
+      }
+      // Owner-aware: another agent's owned tool never enters this agent's
+      // AG-UI run config.
+      if (!isToolVisibleTo(registryTool, { agentId: agent.id })) {
         continue;
       }
       merged[toolId] = true;

--- a/src/agent/factory.ts
+++ b/src/agent/factory.ts
@@ -113,7 +113,10 @@ export function agent(config: AgentConfig): Agent {
   const originalSystem = config.system;
   const augmentedSystem = config.skills
     ? async () => {
-      const currentSkills = skillRegistry.resolveForAgent(config.skills!);
+      // Owner-aware: the manifest only ever advertises skills visible to this
+      // agent (unowned project skills plus its own), matching skill-tool
+      // enforcement at execution time.
+      const currentSkills = skillRegistry.resolveForAgent(config.skills!, { agentId: id });
       const basePrompt = typeof originalSystem === "function"
         ? await originalSystem()
         : originalSystem;

--- a/src/agent/hosted/veryfront-cloud-agent-service.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.ts
@@ -594,9 +594,16 @@ function getProjectSteering(
   return projectSteering;
 }
 
-function getDiscoveredHostTools(): HostToolSet {
+export function getDiscoveredHostTools(): HostToolSet {
+  // Agent-owned tools never enter the project-level host tool spread: this
+  // set is built without a per-run agent identity, so the rule matches MCP
+  // tools/list (project-level callers see only unowned tools). Per-agent
+  // owned-tool visibility in the hosted runtime arrives with the owner-aware
+  // catalog (see .omx/research/hosted-catalog-spike.md).
   return Object.fromEntries(
-    [...toolRegistry.getAll()].sort(([left], [right]) => left.localeCompare(right)),
+    [...toolRegistry.getAll()]
+      .filter(([, registryTool]) => registryTool.ownerAgentId === undefined)
+      .sort(([left], [right]) => left.localeCompare(right)),
   );
 }
 

--- a/src/agent/hosted/veryfront-cloud-agent-service.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.ts
@@ -21,6 +21,7 @@ import {
   createRemoteMCPToolSource,
   createToolsFromRemoteDefinitions,
   type HostToolSet,
+  isToolVisibleTo,
   sleepTool,
   toolRegistry,
 } from "#veryfront/tool";
@@ -594,15 +595,14 @@ function getProjectSteering(
   return projectSteering;
 }
 
-export function getDiscoveredHostTools(): HostToolSet {
-  // Agent-owned tools never enter the project-level host tool spread: this
-  // set is built without a per-run agent identity, so the rule matches MCP
-  // tools/list (project-level callers see only unowned tools). Per-agent
-  // owned-tool visibility in the hosted runtime arrives with the owner-aware
-  // catalog (see .omx/research/hosted-catalog-spike.md).
+export function getDiscoveredHostTools(scope?: { agentId?: string }): HostToolSet {
+  // Without an agent identity, this remains the project-level host tool spread
+  // and matches MCP tools/list: project-level callers see only unowned tools.
+  // Hosted per-agent runs pass their task context identity so owned colocated
+  // tools are available to their owner and hidden from other agents.
   return Object.fromEntries(
     [...toolRegistry.getAll()]
-      .filter(([, registryTool]) => registryTool.ownerAgentId === undefined)
+      .filter(([, registryTool]) => isToolVisibleTo(registryTool, scope))
       .sort(([left], [right]) => left.localeCompare(right)),
   );
 }
@@ -698,7 +698,7 @@ function buildLocalTools(
 ): HostToolSet {
   const config = context.infrastructure.getConfig();
   const tools: HostToolSet = {
-    ...getDiscoveredHostTools(),
+    ...getDiscoveredHostTools({ agentId: taskContext.agentId }),
     form_input: createHostedFormInputTool(taskContext, config.VERYFRONT_API_URL),
     load_skill: createLoadSkillTool(context, taskContext),
     sleep: sleepTool,

--- a/src/agent/runtime/agent-definition.ts
+++ b/src/agent/runtime/agent-definition.ts
@@ -37,6 +37,8 @@ export const getRuntimeAgentMarkdownDefinitionSchema = defineSchema((v) =>
     temperature: v.number().min(0).max(2).optional(),
     maxSteps: v.number().optional(),
     providerTools: v.array(v.string().min(1)).optional(),
+    skills: v.union([v.literal(true), v.array(v.string().min(1))]).optional(),
+    tools: v.union([v.literal(true), v.array(v.string().min(1))]).optional(),
     delegates: v.array(v.string().min(1)).optional(),
   })
 );
@@ -106,6 +108,19 @@ function parseProviderTools(value: unknown): unknown[] | undefined {
   return value;
 }
 
+function parseCapabilitySelector(value: unknown): true | string[] | undefined {
+  if (value === true) {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    const ids = value
+      .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+      .map((entry) => entry.trim());
+    return ids.length > 0 ? ids : undefined;
+  }
+  return undefined;
+}
+
 function parseDelegates(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
@@ -146,6 +161,8 @@ export function parseRuntimeAgentMarkdownDefinition(
   const temperature = typeof attrs.temperature === "number" ? attrs.temperature : undefined;
   const maxSteps = typeof attrs["max-steps"] === "number" ? attrs["max-steps"] : undefined;
   const providerTools = parseProviderTools(attrs["provider-tools"]);
+  const skills = parseCapabilitySelector(attrs.skills);
+  const tools = parseCapabilitySelector(attrs.tools);
   const delegates = parseDelegates(attrs.delegates);
   validateDelegates(parsedInput.id, delegates);
 
@@ -159,6 +176,8 @@ export function parseRuntimeAgentMarkdownDefinition(
     ...(temperature === undefined ? {} : { temperature }),
     ...(maxSteps === undefined ? {} : { maxSteps }),
     ...(providerTools ? { providerTools } : {}),
+    ...(skills === undefined ? {} : { skills }),
+    ...(tools === undefined ? {} : { tools }),
     ...(delegates === undefined ? {} : { delegates }),
   });
 }

--- a/src/agent/runtime/agent-markdown-adapter.ts
+++ b/src/agent/runtime/agent-markdown-adapter.ts
@@ -13,6 +13,22 @@ export function createRuntimeAgentFromMarkdownDefinition(
     ? buildAgentDelegateTools({ delegates: definition.delegates, selfId: definition.id })
     : undefined;
 
+  // `tools:` is a binding selector resolved at invocation time by the
+  // owner-aware resolver: `true` binds all visible tools; a list binds each
+  // entry (own short name first, then exact global id). Delegate tools merge
+  // on top; on key collision the delegate tool wins (keys never overlap in
+  // practice: selectors use tool ids, delegates use `agent_{id}`).
+  const selectedTools: true | Record<string, true> | undefined = definition.tools === true
+    ? true
+    : definition.tools
+    ? Object.fromEntries(definition.tools.map((name) => [name, true as const]))
+    : undefined;
+  const mergedTools = selectedTools === true
+    ? true
+    : selectedTools || delegateTools
+    ? { ...(selectedTools ?? {}), ...(delegateTools ?? {}) }
+    : undefined;
+
   const runtimeAgent = agent({
     id: definition.id,
     name: definition.name,
@@ -22,7 +38,11 @@ export function createRuntimeAgentFromMarkdownDefinition(
     ...(definition.temperature === undefined ? {} : { temperature: definition.temperature }),
     ...(definition.maxSteps === undefined ? {} : { maxSteps: definition.maxSteps }),
     ...(definition.providerTools ? { providerTools: definition.providerTools } : {}),
-    ...(delegateTools && Object.keys(delegateTools).length > 0 ? { tools: delegateTools } : {}),
+    ...(definition.skills === undefined ? {} : { skills: definition.skills }),
+    ...(mergedTools !== undefined &&
+        (mergedTools === true || Object.keys(mergedTools).length > 0)
+      ? { tools: mergedTools }
+      : {}),
   });
 
   markdownDefinitionByAgent.set(runtimeAgent, definition);

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -556,6 +556,7 @@ export class AgentRuntime {
         const toolContext = { ...toolContextBase, ...currentRuntimeContext };
 
         let tools = isLocal ? [] : await getAvailableTools(this.config.tools, {
+          callerAgentId: this.id,
           includeSkillTools: Boolean(this.config.skills),
           allowedRemoteToolNames,
           forwardedRemoteToolDefinitions,
@@ -722,6 +723,9 @@ export class AgentRuntime {
                 toolCallId: tc.toolCallId,
                 ...toolContext,
                 projectId: cacheCtx?.projectId ?? toolContext?.projectId,
+                // Caller identity for capability scoping. Stamped after the
+                // spreads so caller-supplied context cannot spoof it.
+                agentId: this.id,
               };
               const result = await executeConfiguredTool(
                 tc.toolName,
@@ -863,6 +867,7 @@ export class AgentRuntime {
       const toolContext = { ...toolContextBase, ...currentRuntimeContext };
 
       let tools = isLocalStreaming ? [] : await getAvailableTools(this.config.tools, {
+        callerAgentId: this.id,
         includeSkillTools: Boolean(this.config.skills),
         allowedRemoteToolNames,
         forwardedRemoteToolDefinitions,
@@ -1133,6 +1138,9 @@ export class AgentRuntime {
           const executionContext = {
             toolCallId: tc.id,
             ...toolContext,
+            // Caller identity for capability scoping. Stamped after the
+            // spread so caller-supplied context cannot spoof it.
+            agentId: this.id,
           };
           const result = await executeConfiguredTool(
             tc.name,

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -7,7 +7,7 @@
  */
 
 import type { RemoteToolSource, Tool, ToolDefinition, ToolExecutionContext } from "#veryfront/tool";
-import { executeTool, toolRegistry } from "#veryfront/tool";
+import { executeTool, isToolVisibleTo, toolRegistry } from "#veryfront/tool";
 import { toolToProviderDefinition } from "#veryfront/tool/registry.ts";
 import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
 import { serverLogger } from "#veryfront/utils";
@@ -247,9 +247,11 @@ export async function executeConfiguredTool(
     return await configuredTool.execute(input, context);
   }
 
-  // Try local registry first
+  // Try local registry first. Owned tools are only executable by their
+  // owning agent (context.agentId is stamped by the runtime); invisible tools
+  // fall through and surface as "not found" via executeTool.
   const registryTool = toolRegistry.get(toolName);
-  if (registryTool) {
+  if (registryTool && isToolVisibleTo(registryTool, context)) {
     return await registryTool.execute(input, context);
   }
 
@@ -331,6 +333,8 @@ export async function getAvailableTools(
     forwardedRemoteToolDefinitions?: ToolDefinition[];
     remoteToolSources?: RemoteToolSource[];
     remoteToolContext?: ToolExecutionContext;
+    /** Calling agent id for owner-aware tool visibility. */
+    callerAgentId?: string;
   },
 ): Promise<ToolDefinition[]> {
   if (!toolsConfig) return [];
@@ -339,7 +343,10 @@ export async function getAvailableTools(
     const allTools = toolRegistry.getAll();
     logger.debug(`Loading all ${allTools.size} tools from registry`);
 
-    const tools = Array.from(allTools, ([name, tool]) => {
+    const visibleTools = Array.from(allTools.entries()).filter(([, tool]) =>
+      isToolVisibleTo(tool, { agentId: options?.callerAgentId })
+    );
+    const tools = visibleTools.map(([name, tool]) => {
       const def = toolToProviderDefinition(tool);
       logToolDefinition(name, def);
       return def;
@@ -378,8 +385,13 @@ export async function getAvailableTools(
   for (const [name, entry] of Object.entries(toolsConfig)) {
     if (entry === true) {
       const tool = toolRegistry.get(name);
-      if (tool) {
+      if (tool && isToolVisibleTo(tool, { agentId: options?.callerAgentId })) {
         addToolDefinition(tools, name, tool);
+        continue;
+      }
+      if (tool) {
+        // Owned by another agent: treat as unresolved rather than binding it.
+        unresolvedConfiguredToolNames.push(name);
         continue;
       }
 
@@ -413,9 +425,14 @@ export async function getAvailableTools(
   }
 
   if (unresolvedConfiguredToolNames.length > 0) {
+    // Enumerate only tools visible to the caller — never another agent's
+    // owned tool ids (error-message leak guard).
+    const visibleLocalToolNames = Array.from(toolRegistry.getAll().entries())
+      .filter(([, tool]) => isToolVisibleTo(tool, { agentId: options?.callerAgentId }))
+      .map(([name]) => name);
     throwUnknownConfiguredToolsError(
       unresolvedConfiguredToolNames,
-      toolRegistry.getAll().keys(),
+      visibleLocalToolNames,
       remoteToolNames,
     );
   }

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -213,18 +213,25 @@ async function executeRemoteToolFromSources(
 export function resolveConfiguredTool(
   toolsConfig: true | Record<string, ToolConfigEntry> | undefined,
   toolName: string,
+  context?: ToolExecutionContext,
 ): Tool | null {
   if (!toolsConfig) {
     return null;
   }
 
+  // Registry-backed lookups (`tools: true` and `{ name: true }` entries) are
+  // owner-aware: another agent's owned tool behaves as if it does not exist.
+  // Tool objects embedded directly in the config record were bound by the
+  // agent author and pass through as-is.
   if (toolsConfig === true) {
-    return toolRegistry.get(toolName) ?? null;
+    const registryTool = toolRegistry.get(toolName);
+    return registryTool && isToolVisibleTo(registryTool, context) ? registryTool : null;
   }
 
   const configuredEntry = toolsConfig[toolName];
   if (configuredEntry === true) {
-    return toolRegistry.get(toolName) ?? null;
+    const registryTool = toolRegistry.get(toolName);
+    return registryTool && isToolVisibleTo(registryTool, context) ? registryTool : null;
   }
 
   if (configuredEntry && typeof configuredEntry === "object") {
@@ -242,7 +249,7 @@ export async function executeConfiguredTool(
   allowedRemoteToolNames?: string[],
   remoteToolSources?: RemoteToolSource[],
 ): Promise<unknown> {
-  const configuredTool = resolveConfiguredTool(toolsConfig, toolName);
+  const configuredTool = resolveConfiguredTool(toolsConfig, toolName, context);
   if (configuredTool) {
     return await configuredTool.execute(input, context);
   }

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -95,6 +95,27 @@ export function isDynamicTool(name: string): boolean {
 // deno-lint-ignore no-explicit-any -- generic erasure: accepts Tool with any input/output types
 export type ToolConfigEntry = Tool<any, any> | boolean;
 
+/**
+ * Resolve a configured tool name for a caller: the caller's own tool by short
+ * name first, then an exact registry id — returning only tools visible to the
+ * caller (owner-aware).
+ */
+function resolveVisibleRegistryTool(
+  name: string,
+  callerAgentId?: string,
+  // deno-lint-ignore no-explicit-any -- generic erasure: registry tools carry any input/output types
+): Tool<any, any> | undefined {
+  if (callerAgentId !== undefined) {
+    for (const tool of toolRegistry.getAll().values()) {
+      if (tool.ownerAgentId === callerAgentId && tool.shortName === name) {
+        return tool;
+      }
+    }
+  }
+  const tool = toolRegistry.get(name);
+  return tool && isToolVisibleTo(tool, { agentId: callerAgentId }) ? tool : undefined;
+}
+
 function formatAvailableToolNames(names: Iterable<string>): string {
   const sorted = [...new Set(names)].sort();
   return sorted.length > 0 ? sorted.join(", ") : "(none)";
@@ -391,14 +412,13 @@ export async function getAvailableTools(
 
   for (const [name, entry] of Object.entries(toolsConfig)) {
     if (entry === true) {
-      const tool = toolRegistry.get(name);
-      if (tool && isToolVisibleTo(tool, { agentId: options?.callerAgentId })) {
-        addToolDefinition(tools, name, tool);
-        continue;
-      }
+      // Own short name first, then exact id; owned tools of other agents are
+      // invisible and fall through to the unresolved diagnostic. Definitions
+      // are exposed under the tool's full registry id so execution resolves
+      // through the same owner-aware gate.
+      const tool = resolveVisibleRegistryTool(name, options?.callerAgentId);
       if (tool) {
-        // Owned by another agent: treat as unresolved rather than binding it.
-        unresolvedConfiguredToolNames.push(name);
+        addToolDefinition(tools, tool.id, tool);
         continue;
       }
 

--- a/src/channels/control-plane.test.ts
+++ b/src/channels/control-plane.test.ts
@@ -520,3 +520,36 @@ describe("channels/control-plane", () => {
     });
   });
 });
+
+// ── Owner-aware agent skill metadata (review round 3) ─────────────────────
+
+import { resolveAgentSkills } from "./control-plane.ts";
+import type { Agent } from "#veryfront/agent/types.ts";
+
+Deno.test("resolveAgentSkills includes the agent's own skills and excludes others'", () => {
+  skillRegistry.clearAll();
+  try {
+    registerSkill("global-howto", {
+      id: "global-howto",
+      metadata: { name: "global-howto", description: "Global guide" },
+      rootPath: "/nonexistent/global-howto",
+    });
+    registerSkill("researcher--cite", {
+      id: "researcher--cite",
+      metadata: { name: "cite", description: "Cite sources" },
+      rootPath: "/nonexistent/cite",
+      ownerAgentId: "researcher",
+      shortName: "cite",
+    });
+
+    const researcher = { id: "researcher", config: { skills: true } } as unknown as Agent;
+    const researcherSkills = resolveAgentSkills(researcher).map((skill) => skill.id).sort();
+    assertEquals(researcherSkills, ["global-howto", "researcher--cite"]);
+
+    const writer = { id: "writer", config: { skills: true } } as unknown as Agent;
+    const writerSkills = resolveAgentSkills(writer).map((skill) => skill.id);
+    assertEquals(writerSkills, ["global-howto"]);
+  } finally {
+    skillRegistry.clearAll();
+  }
+});

--- a/src/channels/control-plane.ts
+++ b/src/channels/control-plane.ts
@@ -315,12 +315,16 @@ async function verifySignedRequestJws<TClaims extends SignedRequestClaims>(
   return claims;
 }
 
-function resolveAgentSkills(agent: Agent): RuntimeAgentSkill[] {
+export function resolveAgentSkills(agent: Agent): RuntimeAgentSkill[] {
   if (!agent.config.skills) {
     return [];
   }
 
-  return Array.from(skillRegistry.resolveForAgent(agent.config.skills).values())
+  // Owner-aware: the agent's metadata advertises exactly what the agent can
+  // resolve at runtime — unowned skills plus its own.
+  return Array.from(
+    skillRegistry.resolveForAgent(agent.config.skills, { agentId: agent.id }).values(),
+  )
     .map((skill) =>
       RuntimeAgentSkillSchema.parse({
         id: skill.id,

--- a/src/discovery/agent-scoped-capabilities.test.ts
+++ b/src/discovery/agent-scoped-capabilities.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Directory-agent discovery tests: colocated capabilities register with owner
+ * metadata (pure registration), and the owner-aware resolver keeps agents
+ * isolated — including coordinators from their delegates (plan tests 14, 15).
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import {
+  isProviderSafeToolName,
+  isSafePathSegment,
+  namespaceAgentCapability,
+} from "./agent-scoped-capabilities.ts";
+import { discoverRuntimeAgentMarkdownDefinitions } from "./handlers/runtime-agent-markdown-handler.ts";
+import type { DiscoveryResult, FileDiscoveryContext } from "./types.ts";
+import { registerSkill, skillRegistry } from "#veryfront/skill/registry.ts";
+import { agentRegistry } from "../agent/composition/index.ts";
+
+function emptyResult(): DiscoveryResult {
+  return {
+    tools: new Map(),
+    agents: new Map(),
+    skills: new Map(),
+    resources: new Map(),
+    prompts: new Map(),
+    workflows: new Map(),
+    tasks: new Map(),
+    errors: [],
+  };
+}
+
+const context: FileDiscoveryContext = { platform: "node" };
+
+async function writeFixtureProject(root: string): Promise<string> {
+  const agentsDir = `${root}/agents`;
+  await Deno.mkdir(`${agentsDir}/researcher/skills/cite`, { recursive: true });
+  await Deno.writeTextFile(
+    `${agentsDir}/lead.md`,
+    `---\nname: Lead\nskills: true\ndelegates: [researcher]\n---\nCoordinate the work.\n`,
+  );
+  await Deno.writeTextFile(
+    `${agentsDir}/researcher/AGENT.md`,
+    `---\nname: Researcher\nskills: true\n---\nResearch thoroughly.\n`,
+  );
+  await Deno.writeTextFile(
+    `${agentsDir}/researcher/SKILL.md`,
+    `---\nname: researcher\ndescription: Research methodology\n---\nFollow the method.\n`,
+  );
+  await Deno.writeTextFile(
+    `${agentsDir}/researcher/skills/cite/SKILL.md`,
+    `---\nname: cite\ndescription: Cite sources\n---\nCite primary sources.\n`,
+  );
+  return agentsDir;
+}
+
+function cleanupAgents(ids: string[]): void {
+  for (const id of ids) {
+    agentRegistry.delete(id);
+  }
+}
+
+Deno.test("namespaceAgentCapability uses the -- separator and provider-safe names", () => {
+  assertEquals(namespaceAgentCapability("researcher", "cite"), "researcher--cite");
+  assertEquals(namespaceAgentCapability("a.b", "x"), "a_b--x");
+  assertEquals(isProviderSafeToolName("researcher--fetch-paper"), true);
+  assertEquals(isProviderSafeToolName("researcher__fetch"), true);
+  assertEquals(isProviderSafeToolName("bad.name"), false);
+  assertEquals(isProviderSafeToolName("a".repeat(65)), false);
+});
+
+Deno.test("isSafePathSegment rejects traversal segments", () => {
+  assertEquals(isSafePathSegment("."), false);
+  assertEquals(isSafePathSegment(".."), false);
+  assertEquals(isSafePathSegment("researcher"), true);
+  assertEquals(isSafePathSegment("a/b"), false);
+});
+
+Deno.test("directory and flat agents discover side by side with owned skills registered", async () => {
+  const root = await Deno.makeTempDir();
+  skillRegistry.clearAll();
+  try {
+    const agentsDir = await writeFixtureProject(root);
+    const result = emptyResult();
+
+    await discoverRuntimeAgentMarkdownDefinitions(agentsDir, result, context);
+
+    assertEquals(result.errors, []);
+    assertEquals([...result.agents.keys()].sort(), ["lead", "researcher"]);
+
+    const own = skillRegistry.get("researcher");
+    assertEquals(own?.ownerAgentId, "researcher");
+    assertEquals(own?.shortName, "researcher");
+
+    const nested = skillRegistry.get("researcher--cite");
+    assertEquals(nested?.ownerAgentId, "researcher");
+    assertEquals(nested?.shortName, "cite");
+  } finally {
+    skillRegistry.clearAll();
+    cleanupAgents(["lead", "researcher"]);
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("a coordinator's skills: true does not include its delegate's owned skills", async () => {
+  const root = await Deno.makeTempDir();
+  skillRegistry.clearAll();
+  try {
+    const agentsDir = await writeFixtureProject(root);
+    const result = emptyResult();
+    await discoverRuntimeAgentMarkdownDefinitions(agentsDir, result, context);
+
+    // Lead delegates to researcher but must not see researcher's owned skills.
+    const leadSkills = skillRegistry.resolveForAgent(true, { agentId: "lead" });
+    assertEquals([...leadSkills.keys()], []);
+
+    // The specialist sees its own skills.
+    const researcherSkills = skillRegistry.resolveForAgent(true, { agentId: "researcher" });
+    assertEquals([...researcherSkills.keys()].sort(), ["researcher", "researcher--cite"]);
+
+    // And the delegate tool exists on the coordinator (delegation unaffected).
+    // skills: true also merges the shared skill tools into config.tools.
+    const lead = result.agents.get("lead");
+    const tools = lead?.config.tools as Record<string, unknown> | undefined;
+    assertEquals(Object.keys(tools ?? {}).includes("agent_researcher"), true);
+  } finally {
+    skillRegistry.clearAll();
+    cleanupAgents(["lead", "researcher"]);
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("duplicate flat and directory agent ids report a discovery error", async () => {
+  const root = await Deno.makeTempDir();
+  skillRegistry.clearAll();
+  try {
+    const agentsDir = `${root}/agents`;
+    await Deno.mkdir(`${agentsDir}/writer`, { recursive: true });
+    await Deno.writeTextFile(`${agentsDir}/writer.md`, `---\nname: Writer Flat\n---\nA.\n`);
+    await Deno.writeTextFile(
+      `${agentsDir}/writer/AGENT.md`,
+      `---\nname: Writer Dir\n---\nB.\n`,
+    );
+
+    const result = emptyResult();
+    await discoverRuntimeAgentMarkdownDefinitions(agentsDir, result, context);
+
+    assertEquals(result.agents.size, 1);
+    assertEquals(result.errors.length, 1);
+    assertEquals(String(result.errors[0]?.error).includes('Duplicate agent id "writer"'), true);
+  } finally {
+    skillRegistry.clearAll();
+    cleanupAgents(["writer"]);
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("owned short name shadowing a global skill id reports a diagnostic", async () => {
+  const root = await Deno.makeTempDir();
+  skillRegistry.clearAll();
+  try {
+    // Pre-existing global skill with the id "cite".
+    registerSkill("cite", {
+      id: "cite",
+      metadata: { name: "cite", description: "Global cite skill" },
+      rootPath: "/nonexistent/cite",
+    });
+
+    const agentsDir = await writeFixtureProject(root);
+    const result = emptyResult();
+    await discoverRuntimeAgentMarkdownDefinitions(agentsDir, result, context);
+
+    const shadowing = result.errors.filter((entry) =>
+      String(entry.error).includes('shadows the global skill id "cite"')
+    );
+    assertEquals(shadowing.length, 1);
+
+    // Both skills remain registered; resolution stays owner-aware.
+    const own = skillRegistry.resolveForAgent(["cite"], { agentId: "researcher" });
+    assertEquals([...own.keys()], ["researcher--cite"]);
+    const other = skillRegistry.resolveForAgent(["cite"], { agentId: "lead" });
+    assertEquals([...other.keys()], ["cite"]);
+  } finally {
+    skillRegistry.clearAll();
+    cleanupAgents(["lead", "researcher"]);
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("agent ids that sanitize to the same namespace report a collision error", async () => {
+  const root = await Deno.makeTempDir();
+  skillRegistry.clearAll();
+  try {
+    const agentsDir = `${root}/agents`;
+    await Deno.mkdir(`${agentsDir}/a.b`, { recursive: true });
+    await Deno.mkdir(`${agentsDir}/a_b`, { recursive: true });
+    await Deno.writeTextFile(`${agentsDir}/a.b/AGENT.md`, `---\nname: AB1\n---\nOne.\n`);
+    await Deno.writeTextFile(
+      `${agentsDir}/a.b/SKILL.md`,
+      `---\nname: ab\ndescription: d\n---\nX.\n`,
+    );
+    await Deno.writeTextFile(`${agentsDir}/a_b/AGENT.md`, `---\nname: AB2\n---\nTwo.\n`);
+
+    const result = emptyResult();
+    await discoverRuntimeAgentMarkdownDefinitions(agentsDir, result, context);
+
+    const collisions = result.errors.filter((entry) =>
+      String(entry.error).includes("shares the sanitized capability namespace")
+    );
+    assertEquals(collisions.length, 1);
+  } finally {
+    skillRegistry.clearAll();
+    cleanupAgents(["a.b", "a_b"]);
+    await Deno.remove(root, { recursive: true });
+  }
+});

--- a/src/discovery/agent-scoped-capabilities.test.ts
+++ b/src/discovery/agent-scoped-capabilities.test.ts
@@ -213,3 +213,53 @@ Deno.test("agent ids that sanitize to the same namespace report a collision erro
     await Deno.remove(root, { recursive: true });
   }
 });
+
+// ── Full-pipeline regression (review finding: discoverAll wiped colocated skills) ──
+
+import { discoverAll } from "./index.ts";
+
+Deno.test("discoverAll preserves directory-agent colocated skills through the skill-registry clear", async () => {
+  const root = await Deno.makeTempDir();
+  skillRegistry.clearAll();
+  try {
+    await writeFixtureProject(root);
+    // A global skill whose id shadows researcher's "cite" short name —
+    // discovered through the real pipeline (skills before agents), so the
+    // shadow diagnostic must fire without manual pre-registration.
+    await Deno.mkdir(`${root}/skills/cite`, { recursive: true });
+    await Deno.writeTextFile(
+      `${root}/skills/cite/SKILL.md`,
+      `---\nname: cite\ndescription: Global cite skill\n---\nGlobal citing.\n`,
+    );
+
+    const result = await discoverAll({ baseDir: root });
+
+    // Colocated skills survive the registry clear and surface in the result.
+    assertEquals(skillRegistry.get("researcher")?.ownerAgentId, "researcher");
+    assertEquals(skillRegistry.get("researcher--cite")?.ownerAgentId, "researcher");
+    assertEquals(result.skills.has("researcher"), true);
+    assertEquals(result.skills.has("researcher--cite"), true);
+    assertEquals(result.skills.has("cite"), true);
+
+    // The agent sees its own skills plus the unowned global one.
+    assertEquals(
+      [...skillRegistry.resolveForAgent(true, { agentId: "researcher" }).keys()].sort(),
+      ["cite", "researcher", "researcher--cite"],
+    );
+    // Other agents see only the global skill.
+    assertEquals(
+      [...skillRegistry.resolveForAgent(true, { agentId: "lead" }).keys()],
+      ["cite"],
+    );
+
+    // Shadow diagnostic fires through the natural pipeline ordering.
+    const shadowing = result.errors.filter((entry) =>
+      String(entry.error).includes('shadows the global skill id "cite"')
+    );
+    assertEquals(shadowing.length, 1);
+  } finally {
+    skillRegistry.clearAll();
+    cleanupAgents(["lead", "researcher"]);
+    await Deno.remove(root, { recursive: true });
+  }
+});

--- a/src/discovery/agent-scoped-capabilities.test.ts
+++ b/src/discovery/agent-scoped-capabilities.test.ts
@@ -298,9 +298,30 @@ Deno.test({
 };
 `,
       );
+      // A second module exporting the same explicit short name — must be
+      // reported at discovery instead of silently dropped (sorted after
+      // fetch-paper.ts, so the first registration wins).
+      await Deno.writeTextFile(
+        `${root}/agents/researcher/tools/zz-dupe.ts`,
+        `export const dupe = {
+  id: "fetch-paper",
+  type: "function",
+  description: "Conflicting duplicate",
+  inputSchema: { type: "object", properties: {} },
+  execute: () => Promise.resolve({ ok: false, dupe: true }),
+};
+`,
+      );
 
       const result = await discoverAll({ baseDir: root });
-      assertEquals(result.errors, []);
+      const duplicateErrors = result.errors.filter((entry) =>
+        String(entry.error).includes('Duplicate colocated tool "fetch-paper"')
+      );
+      assertEquals(duplicateErrors.length, 1);
+      assertEquals(
+        result.errors.filter((entry) => !duplicateErrors.includes(entry)),
+        [],
+      );
 
       // Registered under the namespaced id with owner metadata.
       const registered = toolRegistry.get("researcher--fetch-paper");

--- a/src/discovery/agent-scoped-capabilities.test.ts
+++ b/src/discovery/agent-scoped-capabilities.test.ts
@@ -263,3 +263,68 @@ Deno.test("discoverAll preserves directory-agent colocated skills through the sk
     await Deno.remove(root, { recursive: true });
   }
 });
+
+// ── Colocated tool loading through the real transpiler (esbuild) ─────────
+
+import { clearMCPRegistry } from "#veryfront/mcp";
+import { toolRegistry } from "#veryfront/tool";
+import { executeTool } from "#veryfront/tool";
+
+Deno.test({
+  name: "discoverAll loads colocated tools/*.ts with owner metadata and gates execution",
+  // importModule transpiles via esbuild, which keeps a warm child process
+  // alive across tests and trips Deno's op/resource sanitizers — same reason
+  // src/discovery/transpiler.test.ts opts out (tracked in the lint baseline).
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const root = await Deno.makeTempDir();
+    skillRegistry.clearAll();
+    clearMCPRegistry();
+    try {
+      await Deno.mkdir(`${root}/agents/researcher/tools`, { recursive: true });
+      await Deno.writeTextFile(
+        `${root}/agents/researcher/AGENT.md`,
+        `---\nname: Researcher\ntools: [fetch-paper]\n---\nResearch.\n`,
+      );
+      await Deno.writeTextFile(
+        `${root}/agents/researcher/tools/fetch-paper.ts`,
+        `export const fetchPaper = {
+  id: "fetch-paper",
+  type: "function",
+  description: "Fetch a paper by id",
+  inputSchema: { type: "object", properties: {} },
+  execute: () => Promise.resolve({ ok: true, paper: "attention-is-all-you-need" }),
+};
+`,
+      );
+
+      const result = await discoverAll({ baseDir: root });
+      assertEquals(result.errors, []);
+
+      // Registered under the namespaced id with owner metadata.
+      const registered = toolRegistry.get("researcher--fetch-paper");
+      assertEquals(registered?.ownerAgentId, "researcher");
+      assertEquals(registered?.shortName, "fetch-paper");
+
+      // Owner executes (by full id through the registry gate)...
+      const ok = await executeTool("researcher--fetch-paper", {}, { agentId: "researcher" });
+      assertEquals(ok, { ok: true, paper: "attention-is-all-you-need" });
+
+      // ...other agents and external callers cannot.
+      let rejected = false;
+      try {
+        await executeTool("researcher--fetch-paper", {}, { agentId: "writer" });
+      } catch (error) {
+        rejected = true;
+        assertEquals(String(error).includes("not found"), true);
+      }
+      assertEquals(rejected, true);
+    } finally {
+      skillRegistry.clearAll();
+      clearMCPRegistry();
+      cleanupAgents(["researcher"]);
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});

--- a/src/discovery/agent-scoped-capabilities.ts
+++ b/src/discovery/agent-scoped-capabilities.ts
@@ -1,0 +1,279 @@
+/**
+ * Per-agent colocated capability registration.
+ *
+ * Directory-layout agents (`agents/{id}/`) may ship their own tools and
+ * skills:
+ * - Tools: `agents/{id}/tools/*.ts` → registered into the global tool
+ *   registry under `{agentId}--{shortName}` with `ownerAgentId` metadata.
+ * - Skills: `agents/{id}/SKILL.md` (the agent's own skill, registered under
+ *   the agent id) and `agents/{id}/skills/<sub>/SKILL.md` (registered under
+ *   `{agentId}--{sub}`), both with `ownerAgentId` metadata.
+ *
+ * Discovery here is PURE REGISTRATION: no binding decisions. Visibility and
+ * selector resolution (`skills:` / `tools:`, `true` or lists, own short names
+ * first) happen at invocation time through the owner-aware resolvers, so flat
+ * and directory agents share identical binding semantics.
+ *
+ * The namespace separator is `--` (decided platform-wide): provider-safe and
+ * never confusable with `<provider>__<tool>` integration tool naming.
+ */
+
+import type { Tool } from "#veryfront/tool";
+import { toolRegistry } from "#veryfront/tool";
+import type { Skill } from "#veryfront/skill";
+import { parseSkillFrontmatter, validateSkillMetadata } from "#veryfront/skill/parser.ts";
+import { getSkill, registerSkill } from "#veryfront/skill/registry.ts";
+import { SKILL_MD_FILENAME } from "#veryfront/skill/types.ts";
+import { registerTool } from "#veryfront/mcp";
+import { ensureError } from "#veryfront/errors/veryfront-error.ts";
+import { filenameToId } from "./discovery-utils.ts";
+import {
+  discoveryFileExists,
+  findTypeScriptFiles,
+  listDiscoveryDirectoryEntries,
+  readDiscoveryTextFile,
+} from "./file-discovery.ts";
+import { importModule } from "./transpiler.ts";
+import type { DiscoveryResult, FileDiscoveryContext } from "./types.ts";
+
+const AGENT_TOOLS_SUBDIR = "tools";
+const AGENT_SKILLS_SUBDIR = "skills";
+/** Separator between the agent namespace and the capability short name. */
+export const AGENT_CAPABILITY_NAMESPACE_SEPARATOR = "--";
+/** Provider tool-call names allow only this charset, max 64 chars. */
+const PROVIDER_TOOL_NAME_REGEX = /^[A-Za-z0-9_-]{1,64}$/;
+
+/** Whether a namespaced tool name is valid for provider tool calls. */
+export function isProviderSafeToolName(name: string): boolean {
+  return PROVIDER_TOOL_NAME_REGEX.test(name);
+}
+
+const SAFE_PATH_SEGMENT_REGEX = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Whether a directory/file entry name is a safe single path segment — used
+ * before joining it into a filesystem path. Rejects `.` and `..` (which match
+ * the permissive name regex) as defense-in-depth against path traversal.
+ */
+export function isSafePathSegment(name: string): boolean {
+  return name !== "." && name !== ".." && SAFE_PATH_SEGMENT_REGEX.test(name);
+}
+
+/** Sanitizes an agent id into a provider-safe namespace segment. */
+export function sanitizeCapabilityNamespace(agentId: string): string {
+  return agentId.replace(/[^A-Za-z0-9_-]/g, "_");
+}
+
+/** Namespaces a capability short name under its owning agent. */
+export function namespaceAgentCapability(agentId: string, shortName: string): string {
+  return `${
+    sanitizeCapabilityNamespace(agentId)
+  }${AGENT_CAPABILITY_NAMESPACE_SEPARATOR}${shortName}`;
+}
+
+function isTool(value: unknown): value is Tool {
+  return value !== null && typeof value === "object" &&
+    typeof (value as Tool).execute === "function";
+}
+
+function hasExplicitToolId(tool: Tool): boolean {
+  const generated = tool.__veryfrontGeneratedId;
+  if (typeof tool.id !== "string" || tool.id.trim().length === 0) {
+    return false;
+  }
+  return generated === undefined || tool.id !== generated;
+}
+
+function toolShortName(tool: Tool, file: string): string {
+  return hasExplicitToolId(tool) ? tool.id : filenameToId(file);
+}
+
+function collectModuleTools(module: unknown, file: string): Map<string, Tool> {
+  const tools = new Map<string, Tool>();
+  const record = module as Record<string, unknown>;
+  for (const value of Object.values(record ?? {})) {
+    if (isTool(value)) {
+      tools.set(toolShortName(value, file), value);
+    }
+  }
+  return tools;
+}
+
+function reportShadowedGlobalCapability(input: {
+  kind: "tool" | "skill";
+  agentId: string;
+  shortName: string;
+  file: string;
+  result?: DiscoveryResult;
+}): void {
+  const global = input.kind === "tool"
+    ? toolRegistry.get(input.shortName)
+    : getSkill(input.shortName);
+  if (global && (global as { ownerAgentId?: string }).ownerAgentId === undefined) {
+    input.result?.errors.push({
+      file: input.file,
+      error: ensureError(
+        `Colocated ${input.kind} "${input.shortName}" of agent "${input.agentId}" shadows the ` +
+          `global ${input.kind} id "${input.shortName}": the agent's selector resolves its own ` +
+          `${input.kind} first. Rename one to make the reference unambiguous.`,
+      ),
+    });
+  }
+}
+
+/** Input payload for registering an agent's colocated capabilities. */
+export type RegisterAgentColocatedCapabilitiesInput = {
+  agentId: string;
+  rootPath: string;
+  context: FileDiscoveryContext;
+  result?: DiscoveryResult;
+};
+
+/**
+ * Registers an agent's colocated `tools/*.ts` into the global tool registry
+ * under `{agentId}--{shortName}` with owner metadata. Returns registered ids.
+ */
+export async function registerAgentColocatedTools(
+  input: RegisterAgentColocatedCapabilitiesInput,
+): Promise<string[]> {
+  const toolsDir = `${input.rootPath}/${AGENT_TOOLS_SUBDIR}`;
+  if (!(await discoveryFileExists(toolsDir, input.context))) {
+    return [];
+  }
+
+  const files = (await findTypeScriptFiles(toolsDir, input.context)).sort((left, right) =>
+    left.localeCompare(right)
+  );
+  const registeredIds: string[] = [];
+
+  for (const file of files) {
+    try {
+      const module = await importModule(file, input.context);
+      for (const [shortName, moduleTool] of collectModuleTools(module, file)) {
+        const namespaced = namespaceAgentCapability(input.agentId, shortName);
+        if (!isProviderSafeToolName(namespaced)) {
+          input.result?.errors.push({
+            file,
+            error: ensureError(
+              `Colocated tool "${shortName}" for agent "${input.agentId}" produces an ` +
+                `invalid tool name "${namespaced}" (must match [A-Za-z0-9_-], max 64 chars).`,
+            ),
+          });
+          continue;
+        }
+        if (toolRegistry.get(namespaced)) {
+          continue;
+        }
+        reportShadowedGlobalCapability({
+          kind: "tool",
+          agentId: input.agentId,
+          shortName,
+          file,
+          result: input.result,
+        });
+        registerTool(namespaced, {
+          ...moduleTool,
+          id: namespaced,
+          ownerAgentId: input.agentId,
+          shortName,
+        });
+        registeredIds.push(namespaced);
+      }
+    } catch (error) {
+      input.result?.errors.push({ file, error: ensureError(error) });
+    }
+  }
+
+  return registeredIds;
+}
+
+async function buildSkillFromDir(input: {
+  id: string;
+  skillDir: string;
+  ownerAgentId: string;
+  shortName: string;
+  context: FileDiscoveryContext;
+}): Promise<Skill | null> {
+  const skillMdPath = `${input.skillDir}/${SKILL_MD_FILENAME}`;
+  if (!(await discoveryFileExists(skillMdPath, input.context))) {
+    return null;
+  }
+
+  const content = await readDiscoveryTextFile(skillMdPath, input.context);
+  const parsed = await parseSkillFrontmatter(content);
+  const metadata = validateSkillMetadata(parsed.frontmatter, input.id);
+
+  return {
+    id: input.id,
+    metadata,
+    rootPath: input.skillDir.replace(/^file:\/\//, ""),
+    ownerAgentId: input.ownerAgentId,
+    shortName: input.shortName,
+    ...(input.context.fsAdapter ? { fsAdapter: input.context.fsAdapter } : {}),
+  };
+}
+
+/**
+ * Registers an agent's colocated skills into the skill registry with owner
+ * metadata. The agent's own `SKILL.md` registers under the agent id; nested
+ * `skills/<sub>/SKILL.md` skills register under `{agentId}--{sub}`. Returns
+ * registered ids.
+ */
+export async function registerAgentColocatedSkills(
+  input: RegisterAgentColocatedCapabilitiesInput,
+): Promise<string[]> {
+  const candidates: Array<{ id: string; shortName: string; skillDir: string }> = [];
+
+  if (await discoveryFileExists(`${input.rootPath}/${SKILL_MD_FILENAME}`, input.context)) {
+    candidates.push({ id: input.agentId, shortName: input.agentId, skillDir: input.rootPath });
+  }
+
+  const skillsDir = `${input.rootPath}/${AGENT_SKILLS_SUBDIR}`;
+  const entries = (await listDiscoveryDirectoryEntries(skillsDir, input.context)).sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+  for (const entry of entries) {
+    if (!entry.isDirectory || !isSafePathSegment(entry.name)) {
+      continue;
+    }
+    candidates.push({
+      id: namespaceAgentCapability(input.agentId, entry.name),
+      shortName: entry.name,
+      skillDir: `${skillsDir}/${entry.name}`,
+    });
+  }
+
+  const registeredIds: string[] = [];
+  for (const candidate of candidates) {
+    try {
+      const skill = await buildSkillFromDir({
+        id: candidate.id,
+        skillDir: candidate.skillDir,
+        ownerAgentId: input.agentId,
+        shortName: candidate.shortName,
+        context: input.context,
+      });
+      if (!skill) {
+        continue;
+      }
+      if (candidate.shortName !== input.agentId) {
+        reportShadowedGlobalCapability({
+          kind: "skill",
+          agentId: input.agentId,
+          shortName: candidate.shortName,
+          file: `${candidate.skillDir}/${SKILL_MD_FILENAME}`,
+          result: input.result,
+        });
+      }
+      registerSkill(skill.id, skill);
+      registeredIds.push(skill.id);
+    } catch (error) {
+      input.result?.errors.push({
+        file: `${candidate.skillDir}/${SKILL_MD_FILENAME}`,
+        error: ensureError(error),
+      });
+    }
+  }
+
+  return registeredIds;
+}

--- a/src/discovery/agent-scoped-capabilities.ts
+++ b/src/discovery/agent-scoped-capabilities.ts
@@ -145,6 +145,7 @@ export async function registerAgentColocatedTools(
     left.localeCompare(right)
   );
   const registeredIds: string[] = [];
+  const seenThisPass = new Set<string>();
 
   for (const file of files) {
     try {
@@ -161,9 +162,22 @@ export async function registerAgentColocatedTools(
           });
           continue;
         }
-        if (toolRegistry.get(namespaced)) {
+        // Two colocated tools resolving to the same short name within one
+        // discovery pass is a user error — report it instead of silently
+        // keeping the first (a later "unknown tool" with no breadcrumb).
+        // A pre-existing registry entry from a previous pass is a normal
+        // re-discovery refresh and is overwritten.
+        if (seenThisPass.has(namespaced)) {
+          input.result?.errors.push({
+            file,
+            error: ensureError(
+              `Duplicate colocated tool "${shortName}" for agent "${input.agentId}": ` +
+                `another tools/ module already registered "${namespaced}"; keeping the first.`,
+            ),
+          });
           continue;
         }
+        seenThisPass.add(namespaced);
         reportShadowedGlobalCapability({
           kind: "tool",
           agentId: input.agentId,

--- a/src/discovery/agent-scoped-capabilities.ts
+++ b/src/discovery/agent-scoped-capabilities.ts
@@ -266,6 +266,7 @@ export async function registerAgentColocatedSkills(
         });
       }
       registerSkill(skill.id, skill);
+      input.result?.skills.set(skill.id, skill);
       registeredIds.push(skill.id);
     } catch (error) {
       input.result?.errors.push({

--- a/src/discovery/discovery-engine.ts
+++ b/src/discovery/discovery-engine.ts
@@ -176,6 +176,33 @@ export async function discoverAll(config: DiscoveryConfig): Promise<DiscoveryRes
     await discoverItems(`${baseDir}/${dir}`, result, context, toolHandler, config.verbose);
   }
 
+  // Clear stale skills before any skill registration so deleted/renamed
+  // skills are removed. Global skills are discovered BEFORE agents so that
+  // directory-agent colocated skills (registered during agent discovery)
+  // survive the clear and owned-short-name shadow diagnostics can see the
+  // global ids they shadow.
+  skillRegistry.clear();
+
+  // Discover skills (parallel path — markdown-based, not TypeScript import)
+  for (const dir of config.skillDirs ?? ["skills"]) {
+    const skillResult = await discoverSkills(
+      join(baseDir, dir),
+      context,
+      config.verbose,
+    );
+    for (const [id, skill] of skillResult.skills) {
+      if (result.skills.has(id)) {
+        logger.warn(`Duplicate skill "${id}" across discovery roots; keeping first registration`);
+        continue;
+      }
+      registerSkill(id, skill);
+      result.skills.set(id, skill);
+    }
+    result.errors.push(
+      ...skillResult.errors.map((e) => ({ file: e.file, error: e.error })),
+    );
+  }
+
   // Discover agents
   for (const dir of config.agentDirs ?? ["agents"]) {
     await discoverItems(`${baseDir}/${dir}`, result, context, agentHandler, config.verbose);
@@ -200,29 +227,6 @@ export async function discoverAll(config: DiscoveryConfig): Promise<DiscoveryRes
   // Discover tasks
   for (const dir of config.taskDirs ?? ["tasks"]) {
     await discoverItems(`${baseDir}/${dir}`, result, context, taskHandler, config.verbose);
-  }
-
-  // Clear stale skills before rediscovery so deleted/renamed skills are removed.
-  skillRegistry.clear();
-
-  // Discover skills (parallel path — markdown-based, not TypeScript import)
-  for (const dir of config.skillDirs ?? ["skills"]) {
-    const skillResult = await discoverSkills(
-      join(baseDir, dir),
-      context,
-      config.verbose,
-    );
-    for (const [id, skill] of skillResult.skills) {
-      if (result.skills.has(id)) {
-        logger.warn(`Duplicate skill "${id}" across discovery roots; keeping first registration`);
-        continue;
-      }
-      registerSkill(id, skill);
-      result.skills.set(id, skill);
-    }
-    result.errors.push(
-      ...skillResult.errors.map((e) => ({ file: e.file, error: e.error })),
-    );
   }
 
   return result;

--- a/src/discovery/handlers/runtime-agent-markdown-handler.ts
+++ b/src/discovery/handlers/runtime-agent-markdown-handler.ts
@@ -7,38 +7,131 @@ import { agentRegistry, registerAgent } from "../../agent/composition/index.ts";
 import { ensureError } from "#veryfront/errors/veryfront-error.ts";
 import type { DiscoveryResult, FileDiscoveryContext } from "../types.ts";
 import { trackAgentPath } from "../discovery-utils.ts";
-import { findMarkdownFiles, readDiscoveryTextFile } from "../file-discovery.ts";
+import {
+  discoveryFileExists,
+  listDiscoveryDirectoryEntries,
+  readDiscoveryTextFile,
+} from "../file-discovery.ts";
+import {
+  isSafePathSegment,
+  registerAgentColocatedSkills,
+  registerAgentColocatedTools,
+  sanitizeCapabilityNamespace,
+} from "../agent-scoped-capabilities.ts";
 
 const MARKDOWN_AGENT_FILE_PATTERN = /^[A-Za-z0-9._-]+\.md$/;
+const DIRECTORY_AGENT_FILENAME = "AGENT.md";
+const RESERVED_TOP_LEVEL_FILENAMES = new Set(["AGENT.md", "SKILL.md"]);
 
 type MarkdownAgentCandidate = {
   id: string;
   file: string;
+  rootPath?: string;
 };
 
-function getFileName(file: string): string {
-  return file.split("/").pop() ?? "";
-}
-
-function getMarkdownAgentCandidate(file: string): MarkdownAgentCandidate | null {
-  const fileName = getFileName(file);
+function getFlatAgentCandidate(dir: string, fileName: string): MarkdownAgentCandidate | null {
+  if (RESERVED_TOP_LEVEL_FILENAMES.has(fileName)) {
+    return null;
+  }
   if (!MARKDOWN_AGENT_FILE_PATTERN.test(fileName)) {
     return null;
   }
 
+  const id = fileName.slice(0, -".md".length);
+  // Reject `.`/`..` ids as defense-in-depth against path traversal.
+  if (!isSafePathSegment(id)) {
+    return null;
+  }
+
   return {
-    id: fileName.slice(0, -".md".length),
-    file,
+    id,
+    file: `${dir}/${fileName}`,
   };
 }
 
-function registerMarkdownAgent(
+async function getDirectoryAgentCandidate(
+  dir: string,
+  entryName: string,
+  context: FileDiscoveryContext,
+): Promise<MarkdownAgentCandidate | null> {
+  // Reject `.`/`..` and other non-segment names before joining into a path.
+  if (!isSafePathSegment(entryName)) {
+    return null;
+  }
+
+  const rootPath = `${dir}/${entryName}`;
+  const agentFile = `${rootPath}/${DIRECTORY_AGENT_FILENAME}`;
+  if (!(await discoveryFileExists(agentFile, context))) {
+    return null;
+  }
+
+  return { id: entryName, file: agentFile, rootPath };
+}
+
+/** Tracks sanitized capability namespaces to the agent that owns them. */
+type CapabilityNamespaceOwners = Map<string, string>;
+
+/**
+ * Registers a directory agent's colocated capabilities. This is PURE
+ * REGISTRATION — binding (`skills:` / `tools:` selectors) happens at
+ * invocation time via the owner-aware resolvers, identically for flat and
+ * directory agents.
+ *
+ * Two distinct agent ids can sanitize to the same provider-safe namespace
+ * (e.g. "a.b" and "a_b" -> "a_b"), which would collide owned capability ids;
+ * detected and reported instead of silently overwriting.
+ */
+async function registerColocatedCapabilities(
+  definition: RuntimeAgentMarkdownDefinition,
+  rootPath: string,
+  result: DiscoveryResult,
+  context: FileDiscoveryContext,
+  namespaceOwners: CapabilityNamespaceOwners,
+): Promise<void> {
+  const namespace = sanitizeCapabilityNamespace(definition.id);
+  const existingOwner = namespaceOwners.get(namespace);
+  if (existingOwner !== undefined && existingOwner !== definition.id) {
+    result.errors.push({
+      file: rootPath,
+      error: ensureError(
+        `Agent "${definition.id}" shares the sanitized capability namespace ` +
+          `"${namespace}" with agent "${existingOwner}". Rename one to avoid ` +
+          `colliding colocated tool/skill ids.`,
+      ),
+    });
+    return;
+  }
+  namespaceOwners.set(namespace, definition.id);
+
+  // Skills and tools live in disjoint subtrees; register them concurrently.
+  await Promise.all([
+    registerAgentColocatedSkills({ agentId: definition.id, rootPath, context, result }),
+    registerAgentColocatedTools({ agentId: definition.id, rootPath, context, result }),
+  ]);
+}
+
+async function registerMarkdownAgent(
   definition: RuntimeAgentMarkdownDefinition,
   file: string,
+  rootPath: string | undefined,
   result: DiscoveryResult,
-): void {
+  context: FileDiscoveryContext,
+  namespaceOwners: CapabilityNamespaceOwners,
+): Promise<void> {
   if (result.agents.has(definition.id)) {
+    result.errors.push({
+      file,
+      error: ensureError(
+        `Duplicate agent id "${definition.id}". An agent with this id was already ` +
+          `discovered (e.g. both a flat "${definition.id}.md" and a "${definition.id}/" ` +
+          `directory exist); keeping the first.`,
+      ),
+    });
     return;
+  }
+
+  if (rootPath) {
+    await registerColocatedCapabilities(definition, rootPath, result, context, namespaceOwners);
   }
 
   const runtimeAgent = createRuntimeAgentFromMarkdownDefinition(definition);
@@ -50,29 +143,63 @@ function registerMarkdownAgent(
   result.agents.set(definition.id, runtimeAgent);
 }
 
+async function discoverMarkdownAgentCandidate(
+  candidate: MarkdownAgentCandidate,
+  result: DiscoveryResult,
+  context: FileDiscoveryContext,
+  namespaceOwners: CapabilityNamespaceOwners,
+): Promise<void> {
+  try {
+    const definition = parseRuntimeAgentMarkdownDefinition({
+      id: candidate.id,
+      content: await readDiscoveryTextFile(candidate.file, context),
+    });
+    await registerMarkdownAgent(
+      definition,
+      candidate.file,
+      candidate.rootPath,
+      result,
+      context,
+      namespaceOwners,
+    );
+  } catch (error) {
+    result.errors.push({ file: candidate.file, error: ensureError(error) });
+  }
+}
+
+/**
+ * Discovers markdown agents from a directory.
+ *
+ * Supports two layouts side by side:
+ * - Flat: `agents/{id}.md`
+ * - Directory: `agents/{id}/AGENT.md` (+ colocated `SKILL.md` / `skills/` /
+ *   `tools/`, registered with owner metadata)
+ *
+ * Binding is NOT decided here: both layouts pass their parsed definition to
+ * the same adapter, and the owner-aware resolvers apply one rule for every
+ * agent kind at invocation time.
+ */
 export async function discoverRuntimeAgentMarkdownDefinitions(
   dir: string,
   result: DiscoveryResult,
   context: FileDiscoveryContext,
 ): Promise<void> {
-  const files = (await findMarkdownFiles(dir, context)).sort((left, right) =>
-    left.localeCompare(right)
+  const entries = (await listDiscoveryDirectoryEntries(dir, context)).sort((left, right) =>
+    left.name.localeCompare(right.name)
   );
+  const namespaceOwners: CapabilityNamespaceOwners = new Map();
 
-  for (const file of files) {
-    const candidate = getMarkdownAgentCandidate(file);
+  for (const entry of entries) {
+    const candidate = entry.isDirectory
+      ? await getDirectoryAgentCandidate(dir, entry.name, context)
+      : entry.isFile
+      ? getFlatAgentCandidate(dir, entry.name)
+      : null;
+
     if (!candidate) {
       continue;
     }
 
-    try {
-      const definition = parseRuntimeAgentMarkdownDefinition({
-        id: candidate.id,
-        content: await readDiscoveryTextFile(candidate.file, context),
-      });
-      registerMarkdownAgent(definition, candidate.file, result);
-    } catch (error) {
-      result.errors.push({ file: candidate.file, error: ensureError(error) });
-    }
+    await discoverMarkdownAgentCandidate(candidate, result, context, namespaceOwners);
   }
 }

--- a/src/internal-agents/run-stream-owner-scope.test.ts
+++ b/src/internal-agents/run-stream-owner-scope.test.ts
@@ -92,3 +92,23 @@ Deno.test("getDiscoveredHostTools excludes agent-owned tools from the host sprea
     clearMCPRegistry();
   }
 });
+
+Deno.test("getDiscoveredHostTools includes owned tools only for the hosted owner", () => {
+  clearMCPRegistry();
+  try {
+    registerTool("global-echo", makeTool("global-echo"));
+    registerTool("researcher--fetch", makeTool("researcher--fetch", "researcher"));
+    registerTool("writer--style", makeTool("writer--style", "writer"));
+
+    const ownerTools = getDiscoveredHostTools({ agentId: "researcher" });
+    assertEquals(Object.keys(ownerTools).includes("global-echo"), true);
+    assertEquals(Object.keys(ownerTools).includes("researcher--fetch"), true);
+    assertEquals(Object.keys(ownerTools).includes("writer--style"), false);
+
+    const otherTools = getDiscoveredHostTools({ agentId: "writer" });
+    assertEquals(Object.keys(otherTools).includes("researcher--fetch"), false);
+    assertEquals(Object.keys(otherTools).includes("writer--style"), true);
+  } finally {
+    clearMCPRegistry();
+  }
+});

--- a/src/internal-agents/run-stream-owner-scope.test.ts
+++ b/src/internal-agents/run-stream-owner-scope.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Owner-scope regression tests for internal-agent tool definitions
+ * (review finding: buildMergedTools raw-loaded the tool registry).
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { defineSchema } from "#veryfront/schemas/index.ts";
+import type { Tool } from "#veryfront/tool";
+import { clearMCPRegistry, registerTool } from "#veryfront/mcp";
+import { buildMergedTools } from "./run-stream.ts";
+import type { Agent } from "#veryfront/agent/types.ts";
+
+function makeTool(id: string, ownerAgentId?: string): Tool {
+  return {
+    id,
+    type: "function",
+    description: `${id} test tool`,
+    inputSchema: defineSchema((v) => v.object({}))(),
+    execute: () => Promise.resolve({ ok: true }),
+    ...(ownerAgentId === undefined ? {} : { ownerAgentId }),
+  };
+}
+
+function makeAgent(id: string, tools: Agent["config"]["tools"]): Agent {
+  return { id, config: { tools } } as unknown as Agent;
+}
+
+// deno-lint-ignore no-explicit-any -- test stub: only forwardedProps is read
+const emptyInput = { runId: "run-1", tools: [], forwardedProps: {} } as any;
+// deno-lint-ignore no-explicit-any -- test stub: unused on these paths
+const sessionManager = {} as any;
+
+Deno.test("buildMergedTools with tools: true excludes other agents' owned tools", () => {
+  clearMCPRegistry();
+  try {
+    registerTool("global-echo", makeTool("global-echo"));
+    registerTool("researcher--fetch", makeTool("researcher--fetch", "researcher"));
+
+    const writerTools = buildMergedTools(makeAgent("writer", true), emptyInput, sessionManager);
+    assertEquals(Object.keys(writerTools ?? {}).includes("global-echo"), true);
+    assertEquals(Object.keys(writerTools ?? {}).includes("researcher--fetch"), false);
+
+    const ownerTools = buildMergedTools(
+      makeAgent("researcher", true),
+      emptyInput,
+      sessionManager,
+    );
+    assertEquals(Object.keys(ownerTools ?? {}).includes("researcher--fetch"), true);
+  } finally {
+    clearMCPRegistry();
+  }
+});
+
+Deno.test("buildMergedTools named entry cannot bind another agent's owned tool", () => {
+  clearMCPRegistry();
+  try {
+    registerTool("researcher--fetch", makeTool("researcher--fetch", "researcher"));
+
+    const writerTools = buildMergedTools(
+      makeAgent("writer", { "researcher--fetch": true }),
+      emptyInput,
+      sessionManager,
+    );
+    assertEquals(Object.keys(writerTools ?? {}).includes("researcher--fetch"), false);
+
+    const ownerTools = buildMergedTools(
+      makeAgent("researcher", { "researcher--fetch": true }),
+      emptyInput,
+      sessionManager,
+    );
+    assertEquals(Object.keys(ownerTools ?? {}).includes("researcher--fetch"), true);
+  } finally {
+    clearMCPRegistry();
+  }
+});
+
+// ── Hosted host-tool spread (same review finding, hosted surface) ─────────
+
+import { getDiscoveredHostTools } from "../agent/hosted/veryfront-cloud-agent-service.ts";
+
+Deno.test("getDiscoveredHostTools excludes agent-owned tools from the host spread", () => {
+  clearMCPRegistry();
+  try {
+    registerTool("global-echo", makeTool("global-echo"));
+    registerTool("researcher--fetch", makeTool("researcher--fetch", "researcher"));
+
+    const hostTools = getDiscoveredHostTools();
+    assertEquals(Object.keys(hostTools).includes("global-echo"), true);
+    assertEquals(Object.keys(hostTools).includes("researcher--fetch"), false);
+  } finally {
+    clearMCPRegistry();
+  }
+});

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -22,7 +22,7 @@ import {
   SandboxShellToolsProviderName,
 } from "#veryfront/extensions/sandbox/index.ts";
 import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
-import { type Tool, toolRegistry } from "#veryfront/tool";
+import { isToolVisibleTo, type Tool, toolRegistry } from "#veryfront/tool";
 import { defineSchema, lazySchema } from "#veryfront/schemas/index.ts";
 import type { Schema } from "#veryfront/extensions/schema/index.ts";
 import {
@@ -130,7 +130,7 @@ function createInjectedStudioTool(
   };
 }
 
-function buildMergedTools(
+export function buildMergedTools(
   agent: Agent,
   input: RuntimeRunAgentInput,
   sessionManager: AgentRunSessionManager,
@@ -171,8 +171,13 @@ function buildMergedTools(
 
   if (agent.config.tools === true) {
     const merged: Record<string, Tool | boolean> = {};
-    for (const [toolId] of toolRegistry.getAll()) {
+    for (const [toolId, registryTool] of toolRegistry.getAll()) {
       if (!agent.config.skills && SKILL_TOOL_IDS.has(toolId)) {
+        continue;
+      }
+      // Owner-aware: another agent's owned tool never enters this agent's
+      // model tool definitions.
+      if (!isToolVisibleTo(registryTool, { agentId: agent.id })) {
         continue;
       }
       merged[toolId] = true;
@@ -186,12 +191,20 @@ function buildMergedTools(
   const merged: Record<string, Tool | boolean> = {};
   for (const [toolName, entry] of Object.entries(agent.config.tools)) {
     if (entry === true) {
+      // Registry lookups are owner-aware: another agent's owned tool behaves
+      // as if it does not exist for this agent.
+      const visibleRegistryTool = (() => {
+        const registryTool = toolRegistry.get(toolName);
+        return registryTool && isToolVisibleTo(registryTool, { agentId: agent.id })
+          ? registryTool
+          : undefined;
+      })();
       const serverResolvedProjectTool = serverResolvedProjectToolNames.has(toolName)
-        ? toolRegistry.get(toolName)
+        ? visibleRegistryTool
         : undefined;
       if (
         serverResolvedProjectTool ||
-        toolRegistry.get(toolName) ||
+        visibleRegistryTool ||
         availableLocalTools?.[toolName] ||
         availableForwardedToolNames?.includes(toolName) ||
         sourceAllowedRemoteToolNames.includes(toolName)

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -348,6 +348,10 @@ export class MCPServer {
 
     for (const [id, tool] of registry.tools.entries()) {
       if (tool.mcp?.enabled === false) continue;
+      // Agent-owned tools are never listed to MCP clients: external callers
+      // have no agent identity, so owned capabilities are invisible here
+      // (and rejected at execution time by the registry executor).
+      if (tool.ownerAgentId !== undefined) continue;
 
       const entry: ToolListEntry = {
         name: id,

--- a/src/server/handlers/dev/dashboard/api.ts
+++ b/src/server/handlers/dev/dashboard/api.ts
@@ -1,6 +1,6 @@
 import { getMCPRegistry, getMCPStats } from "#veryfront/mcp";
 import { REQUEST_ERROR } from "#veryfront/errors";
-import { executeTool, toolRegistry } from "#veryfront/tool";
+import { executeTool, isToolVisibleTo, toolRegistry } from "#veryfront/tool";
 import { resourceRegistry } from "#veryfront/resource";
 import { promptRegistry } from "#veryfront/prompt";
 import { agentRegistry } from "#veryfront/agent/composition/index.ts";
@@ -187,7 +187,7 @@ function handleListPrompts(): Response {
 }
 
 function handleListAgents(): Response {
-  const allToolIds = Array.from(toolRegistry.getAll().keys());
+  const allTools = Array.from(toolRegistry.getAll().entries());
 
   const list = Array.from(agentRegistry.getAll().entries()).map(([id, agent]) => {
     const cfg = agent.config as unknown as Record<string, unknown>;
@@ -198,7 +198,12 @@ function handleListAgents(): Response {
 
     let tools: Record<string, boolean> = {};
     if (cfg.tools === true) {
-      tools = Object.fromEntries(allToolIds.map((tid) => [tid, true]));
+      // Owner-aware: list only tools this agent can actually resolve.
+      tools = Object.fromEntries(
+        allTools
+          .filter(([, registryTool]) => isToolVisibleTo(registryTool, { agentId: id }))
+          .map(([tid]) => [tid, true]),
+      );
     } else if (typeof cfg.tools === "object" && cfg.tools !== null) {
       tools = cfg.tools as Record<string, boolean>;
     }

--- a/src/skill/index.ts
+++ b/src/skill/index.ts
@@ -32,7 +32,14 @@ export {
 } from "./types.ts";
 
 // Registry
-export { getAllSkills, getSkill, registerSkill, skillRegistry } from "./registry.ts";
+export {
+  type AgentCapabilityScope,
+  getAllSkills,
+  getSkill,
+  isSkillVisibleTo,
+  registerSkill,
+  skillRegistry,
+} from "./registry.ts";
 
 // Parser
 export { parseSkillFrontmatter, validateSkillMetadata } from "./parser.ts";

--- a/src/skill/registry.ts
+++ b/src/skill/registry.ts
@@ -4,6 +4,11 @@
  * Project-scoped registry for discovered skills.
  * Follows the same pattern as src/tool/registry.ts.
  *
+ * Capability visibility is owner-aware: a skill registered with an
+ * `ownerAgentId` is visible only to that agent; unowned skills are
+ * project-global. One resolver rule applies to every agent kind (TS, flat
+ * markdown, directory markdown) and to the skill tools.
+ *
  * @module
  */
 
@@ -13,26 +18,84 @@ import { ProjectScopedRegistryManager } from "#veryfront/registry/project-scoped
 
 const skillManager = new ProjectScopedRegistryManager<Skill>("skill");
 
+/** Caller scope used for owner-aware capability resolution. */
+export type AgentCapabilityScope = {
+  /** Id of the calling agent; absent for project-level/external callers. */
+  agentId?: string;
+};
+
+/** Whether a skill is visible to the caller identified by the scope. */
+export function isSkillVisibleTo(skill: Skill, scope?: AgentCapabilityScope): boolean {
+  return skill.ownerAgentId === undefined || skill.ownerAgentId === scope?.agentId;
+}
+
 class SkillRegistryClass extends ScopedRegistryFacade<Skill> {
   /**
    * Resolve skills for an agent configuration.
    *
-   * @param skillsConfig - `true` for all skills, or array of specific skill IDs
-   * @returns Map of resolved skills (missing IDs are silently skipped)
+   * - `true` resolves to every skill visible to the caller: unowned
+   *   (project-global) skills plus the caller's own skills — never another
+   *   agent's owned skills.
+   * - An explicit list resolves each entry as the caller's own short name
+   *   first, then as an exact id of a visible skill (missing/invisible ids are
+   *   silently skipped, preserving prior behavior for missing ids).
+   *
+   * @param skillsConfig - `true` for all visible skills, or array of ids/short names
+   * @param scope - caller scope; omit for project-level callers
    */
-  resolveForAgent(skillsConfig: true | string[]): Map<string, Skill> {
+  resolveForAgent(
+    skillsConfig: true | string[],
+    scope?: AgentCapabilityScope,
+  ): Map<string, Skill> {
+    const result = new Map<string, Skill>();
+
     if (skillsConfig === true) {
-      return this.getAll();
+      for (const [id, skill] of this.getAll()) {
+        if (isSkillVisibleTo(skill, scope)) {
+          result.set(id, skill);
+        }
+      }
+      return result;
     }
 
-    const result = new Map<string, Skill>();
-    for (const id of skillsConfig) {
-      const skill = this.get(id);
+    for (const requested of skillsConfig) {
+      const skill = this.resolveVisibleSkill(requested, scope);
       if (skill) {
-        result.set(id, skill);
+        result.set(skill.id, skill);
       }
     }
     return result;
+  }
+
+  /**
+   * Resolve a single requested skill for a caller: own short name first, then
+   * exact id — returning only skills visible to the caller.
+   */
+  resolveVisibleSkill(requested: string, scope?: AgentCapabilityScope): Skill | undefined {
+    if (scope?.agentId !== undefined) {
+      for (const skill of this.getAll().values()) {
+        if (skill.ownerAgentId === scope.agentId && skill.shortName === requested) {
+          return skill;
+        }
+      }
+    }
+
+    const skill = this.get(requested);
+    if (skill && isSkillVisibleTo(skill, scope)) {
+      return skill;
+    }
+    return undefined;
+  }
+
+  /** Ids of every skill visible to the caller (for manifests and error messages). */
+  getVisibleSkillIds(scope?: AgentCapabilityScope): string[] {
+    const ids: string[] = [];
+    for (const [id, skill] of this.getAll()) {
+      if (isSkillVisibleTo(skill, scope)) {
+        ids.push(id);
+      }
+    }
+    return ids;
   }
 }
 

--- a/src/skill/skill-owner-scope.test.ts
+++ b/src/skill/skill-owner-scope.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Owner-scope leak tests for skills (threat model: controlled-adoption plan).
+ *
+ * Covers: `skills: true` leakage, explicit-id access to owned skills,
+ * own-short-name-first resolution, skill tool enforcement for all three
+ * skill tools, and error-message enumeration scoping.
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { registerSkill, skillRegistry } from "./registry.ts";
+import {
+  createExecuteSkillScriptTool,
+  createLoadSkillReferenceTool,
+  createLoadSkillTool,
+} from "./tools.ts";
+import type { Skill } from "./types.ts";
+
+function makeSkill(input: {
+  id: string;
+  rootPath?: string;
+  ownerAgentId?: string;
+  shortName?: string;
+}): Skill {
+  return {
+    id: input.id,
+    metadata: { name: input.id, description: `${input.id} skill` },
+    rootPath: input.rootPath ?? `/nonexistent/${input.id}`,
+    ...(input.ownerAgentId === undefined ? {} : { ownerAgentId: input.ownerAgentId }),
+    ...(input.shortName === undefined ? {} : { shortName: input.shortName }),
+  };
+}
+
+function setupRegistry(): void {
+  skillRegistry.clearAll();
+  registerSkill("global-howto", makeSkill({ id: "global-howto" }));
+  registerSkill(
+    "researcher--cite",
+    makeSkill({ id: "researcher--cite", ownerAgentId: "researcher", shortName: "cite" }),
+  );
+  registerSkill(
+    "writer--style",
+    makeSkill({ id: "writer--style", ownerAgentId: "writer", shortName: "style" }),
+  );
+}
+
+Deno.test("skills: true resolves to unowned skills plus the caller's own only", () => {
+  setupRegistry();
+  try {
+    const researcher = skillRegistry.resolveForAgent(true, { agentId: "researcher" });
+    assertEquals([...researcher.keys()].sort(), ["global-howto", "researcher--cite"]);
+
+    const writer = skillRegistry.resolveForAgent(true, { agentId: "writer" });
+    assertEquals([...writer.keys()].sort(), ["global-howto", "writer--style"]);
+  } finally {
+    skillRegistry.clearAll();
+  }
+});
+
+Deno.test("skills: true without an agent scope resolves to unowned skills only", () => {
+  setupRegistry();
+  try {
+    const projectLevel = skillRegistry.resolveForAgent(true);
+    assertEquals([...projectLevel.keys()], ["global-howto"]);
+  } finally {
+    skillRegistry.clearAll();
+  }
+});
+
+Deno.test("explicit selector resolves own short name before an exact global id", () => {
+  setupRegistry();
+  try {
+    // A global skill whose id equals the researcher's own short name.
+    registerSkill("cite", makeSkill({ id: "cite" }));
+
+    const own = skillRegistry.resolveForAgent(["cite"], { agentId: "researcher" });
+    assertEquals([...own.keys()], ["researcher--cite"]);
+
+    const other = skillRegistry.resolveForAgent(["cite"], { agentId: "writer" });
+    assertEquals([...other.keys()], ["cite"]);
+  } finally {
+    skillRegistry.clearAll();
+  }
+});
+
+Deno.test("explicit selector cannot reach another agent's owned skill by full id", () => {
+  setupRegistry();
+  try {
+    const resolved = skillRegistry.resolveForAgent(["researcher--cite"], { agentId: "writer" });
+    assertEquals(resolved.size, 0);
+  } finally {
+    skillRegistry.clearAll();
+  }
+});
+
+Deno.test("getVisibleSkillIds excludes other agents' owned skills", () => {
+  setupRegistry();
+  try {
+    assertEquals(
+      skillRegistry.getVisibleSkillIds({ agentId: "researcher" }).sort(),
+      ["global-howto", "researcher--cite"],
+    );
+    assertEquals(skillRegistry.getVisibleSkillIds(), ["global-howto"]);
+  } finally {
+    skillRegistry.clearAll();
+  }
+});
+
+Deno.test("load_skill rejects another agent's owned skill and enumerates only visible ids", async () => {
+  setupRegistry();
+  try {
+    const loadSkill = createLoadSkillTool();
+
+    await assertRejects(
+      () =>
+        loadSkill.execute({ skillId: "researcher--cite" }, { agentId: "writer" }) as Promise<
+          unknown
+        >,
+      Error,
+      'Skill "researcher--cite" not found',
+    );
+
+    // The miss message must list only skills visible to the caller — never
+    // another agent's owned skill ids.
+    try {
+      await loadSkill.execute({ skillId: "does-not-exist" }, { agentId: "writer" });
+      throw new Error("expected load_skill to reject");
+    } catch (error) {
+      const message = String(error);
+      assertEquals(message.includes("researcher--cite"), false);
+      assertEquals(message.includes("global-howto"), true);
+      assertEquals(message.includes("writer--style"), true);
+    }
+  } finally {
+    skillRegistry.clearAll();
+  }
+});
+
+Deno.test("load_skill without agent context cannot reach any owned skill", async () => {
+  setupRegistry();
+  try {
+    const loadSkill = createLoadSkillTool();
+    await assertRejects(
+      () => loadSkill.execute({ skillId: "researcher--cite" }, {}) as Promise<unknown>,
+      Error,
+      'Skill "researcher--cite" not found',
+    );
+  } finally {
+    skillRegistry.clearAll();
+  }
+});
+
+Deno.test("load_skill_reference rejects another agent's owned skill", async () => {
+  setupRegistry();
+  try {
+    const loadReference = createLoadSkillReferenceTool();
+    await assertRejects(
+      () =>
+        loadReference.execute(
+          { skillId: "researcher--cite", reference: "references/x.md" },
+          { agentId: "writer" },
+        ) as Promise<unknown>,
+      Error,
+      'Skill "researcher--cite" not found',
+    );
+  } finally {
+    skillRegistry.clearAll();
+  }
+});
+
+Deno.test("execute_skill_script rejects another agent's owned skill", async () => {
+  setupRegistry();
+  try {
+    const executeScript = createExecuteSkillScriptTool();
+    await assertRejects(
+      () =>
+        executeScript.execute(
+          { skillId: "researcher--cite", script: "scripts/run.sh" },
+          { agentId: "writer" },
+        ) as Promise<unknown>,
+      Error,
+      'Skill "researcher--cite" not found',
+    );
+  } finally {
+    skillRegistry.clearAll();
+  }
+});
+
+Deno.test("load_skill loads the caller's own skill via its short name", async () => {
+  const tempDir = await Deno.makeTempDir();
+  try {
+    await Deno.writeTextFile(
+      `${tempDir}/SKILL.md`,
+      `---\nname: cite\ndescription: Cite sources properly\n---\n\nAlways cite primary sources.\n`,
+    );
+
+    skillRegistry.clearAll();
+    registerSkill(
+      "researcher--cite",
+      makeSkill({
+        id: "researcher--cite",
+        rootPath: tempDir,
+        ownerAgentId: "researcher",
+        shortName: "cite",
+      }),
+    );
+
+    const loadSkill = createLoadSkillTool();
+    const content = await loadSkill.execute(
+      { skillId: "cite" },
+      { agentId: "researcher" },
+    ) as { instructions: string };
+
+    assertEquals(content.instructions.trim(), "Always cite primary sources.");
+  } finally {
+    skillRegistry.clearAll();
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});

--- a/src/skill/tools.ts
+++ b/src/skill/tools.ts
@@ -11,7 +11,7 @@
 
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { tool } from "#veryfront/tool/factory.ts";
-import type { Tool } from "#veryfront/tool";
+import type { Tool, ToolExecutionContext } from "#veryfront/tool";
 import { readTextFile } from "#veryfront/platform/compat/fs.ts";
 import { join } from "#veryfront/compat/path";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
@@ -75,6 +75,33 @@ async function readSkillFile(skill: Skill, path: string): Promise<string> {
   return await readTextFile(path);
 }
 
+/**
+ * Resolve a requested skill for the calling agent, enforcing owner scope.
+ *
+ * Visibility follows the same owner-aware resolver as prompt manifests and
+ * selector resolution: unowned skills plus the caller's own (by short name or
+ * id). A skill outside the caller's scope behaves exactly like a missing
+ * skill, and the not-found error only enumerates skills visible to the
+ * caller — never another agent's owned skill ids.
+ */
+function resolveVisibleSkillOrThrow(
+  skillId: string,
+  context: ToolExecutionContext | undefined,
+): Skill {
+  const scope = { agentId: context?.agentId };
+  const skill = skillRegistry.resolveVisibleSkill(skillId, scope);
+  if (!skill) {
+    const visible = skillRegistry.getVisibleSkillIds(scope).join(", ");
+    throw toError(
+      createError({
+        type: "agent",
+        message: `Skill "${skillId}" not found. Available skills: ${visible || "none"}`,
+      }),
+    );
+  }
+  return skill;
+}
+
 function buildSkillAvailabilityNote(references: string[], scripts: string[]): string | undefined {
   if (scripts.length === 0 && references.length === 0) {
     return "This skill has no scripts or reference files. Do NOT call execute_skill_script or load_skill_reference.";
@@ -98,17 +125,8 @@ export function createLoadSkillTool(): Tool {
     description: "Load a skill's full instructions. Returns the skill's markdown instructions, " +
       "allowed tools policy, and lists of available reference files and scripts.",
     inputSchema: getLoadSkillInputSchema(),
-    execute: async (input): Promise<SkillContent> => {
-      const skill = skillRegistry.get(input.skillId);
-      if (!skill) {
-        const available = skillRegistry.getAllIds().join(", ");
-        throw toError(
-          createError({
-            type: "agent",
-            message: `Skill "${input.skillId}" not found. Available skills: ${available || "none"}`,
-          }),
-        );
-      }
+    execute: async (input, context): Promise<SkillContent> => {
+      const skill = resolveVisibleSkillOrThrow(input.skillId, context);
 
       // Read SKILL.md
       const skillMdPath = join(skill.rootPath, SKILL_MD_FILENAME);
@@ -159,16 +177,8 @@ export function createLoadSkillReferenceTool(): Tool {
     description: "Read a reference file from a skill. Only files in the skill's " +
       "references/, resources/, and assets/ directories are accessible.",
     inputSchema: getLoadSkillReferenceInputSchema(),
-    execute: async (input): Promise<{ content: string; path: string }> => {
-      const skill = skillRegistry.get(input.skillId);
-      if (!skill) {
-        throw toError(
-          createError({
-            type: "agent",
-            message: `Skill "${input.skillId}" not found`,
-          }),
-        );
-      }
+    execute: async (input, context): Promise<{ content: string; path: string }> => {
+      const skill = resolveVisibleSkillOrThrow(input.skillId, context);
 
       // Validate path safety before reading skill-provided context.
       const validatedPath = await validateSkillPath(
@@ -194,16 +204,8 @@ export function createExecuteSkillScriptTool(): Tool {
     description:
       "Execute a script from a skill's scripts/ directory. Returns stdout, stderr, and exit code.",
     inputSchema: getExecuteSkillScriptInputSchema(),
-    execute: async (input) => {
-      const skill = skillRegistry.get(input.skillId);
-      if (!skill) {
-        throw toError(
-          createError({
-            type: "agent",
-            message: `Skill "${input.skillId}" not found`,
-          }),
-        );
-      }
+    execute: async (input, context) => {
+      const skill = resolveVisibleSkillOrThrow(input.skillId, context);
 
       // Validate path safety (only scripts/ allowed)
       const validatedPath = await validateSkillPath(

--- a/src/skill/types.ts
+++ b/src/skill/types.ts
@@ -77,6 +77,14 @@ export interface Skill {
   rootPath: string;
   /** Optional filesystem adapter for VFS/cloud-backed projects */
   fsAdapter?: FileSystemAdapter;
+  /**
+   * Owning agent id for agent-scoped skills. Unowned (undefined) skills are
+   * project-global. Owned skills are invisible to other agents in selector
+   * resolution and skill tools.
+   */
+  ownerAgentId?: string;
+  /** Short name used by the owning agent's `skills:` selector (e.g. "cite"). */
+  shortName?: string;
 }
 
 /** Result from executing a skill script */

--- a/src/tool/executor.ts
+++ b/src/tool/executor.ts
@@ -1,6 +1,15 @@
-import type { ToolExecutionContext } from "./types.ts";
+import type { Tool, ToolExecutionContext } from "./types.ts";
 import { toolRegistry } from "./registry.ts";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
+
+/**
+ * Whether a registered tool is visible to the caller identified by the
+ * execution context. Unowned tools are project/global; owned tools are only
+ * visible to their owning agent.
+ */
+export function isToolVisibleTo(tool: Tool, context?: ToolExecutionContext): boolean {
+  return tool.ownerAgentId === undefined || tool.ownerAgentId === context?.agentId;
+}
 
 /** Execute a tool definition with validated input. */
 export function executeTool(
@@ -10,7 +19,10 @@ export function executeTool(
 ): Promise<unknown> {
   const registeredTool = toolRegistry.get(toolId);
 
-  if (!registeredTool) {
+  // An owned tool outside its owner's context behaves as if it does not
+  // exist — the same error as a missing tool, so callers cannot probe for
+  // other agents' owned tools.
+  if (!registeredTool || !isToolVisibleTo(registeredTool, context)) {
     throw toError(
       createError({
         type: "agent",

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -140,6 +140,6 @@ export type {
 
 export { toolRegistry } from "./registry.ts";
 
-export { executeTool } from "./executor.ts";
+export { executeTool, isToolVisibleTo } from "./executor.ts";
 
 export type { JsonSchema } from "./schema/index.ts";

--- a/src/tool/tool-owner-scope.test.ts
+++ b/src/tool/tool-owner-scope.test.ts
@@ -185,3 +185,46 @@ Deno.test("executeConfiguredTool registry fallback rejects another agent's owned
     clearMCPRegistry();
   }
 });
+
+Deno.test("executeConfiguredTool with tools: true cannot execute another agent's owned tool", async () => {
+  setupTools();
+  try {
+    // Owner still works through the configured path.
+    const ok = await executeConfiguredTool("researcher--fetch", {}, true, {
+      agentId: "researcher",
+    });
+    assertEquals(ok, { ok: true, id: "researcher--fetch" });
+
+    let rejected = false;
+    try {
+      await executeConfiguredTool("researcher--fetch", {}, true, { agentId: "writer" });
+    } catch (error) {
+      rejected = true;
+      assertEquals(String(error).includes('Tool "researcher--fetch" not found'), true);
+    }
+    assertEquals(rejected, true);
+  } finally {
+    clearMCPRegistry();
+  }
+});
+
+Deno.test("executeConfiguredTool named registry entry cannot execute another agent's owned tool", async () => {
+  setupTools();
+  try {
+    let rejected = false;
+    try {
+      await executeConfiguredTool(
+        "researcher--fetch",
+        {},
+        { "researcher--fetch": true },
+        { agentId: "writer" },
+      );
+    } catch (error) {
+      rejected = true;
+      assertEquals(String(error).includes('Tool "researcher--fetch" not found'), true);
+    }
+    assertEquals(rejected, true);
+  } finally {
+    clearMCPRegistry();
+  }
+});

--- a/src/tool/tool-owner-scope.test.ts
+++ b/src/tool/tool-owner-scope.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Owner-scope leak tests for tools (threat model: controlled-adoption plan).
+ *
+ * Covers: registry execution gating for agent-owned tools (explicit-id
+ * access), external/MCP-shaped callers without agent identity, and MCP
+ * tools/list / tools/call exposure.
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { defineSchema } from "#veryfront/schemas/index.ts";
+import type { Tool } from "./types.ts";
+import { executeTool } from "./executor.ts";
+import { clearMCPRegistry, registerTool } from "../mcp/registry.ts";
+import { createMCPServer } from "../mcp/server.ts";
+
+function makeTool(id: string, ownerAgentId?: string): Tool {
+  return {
+    id,
+    type: "function",
+    description: `${id} test tool`,
+    inputSchema: defineSchema((v) => v.object({}))(),
+    execute: () => Promise.resolve({ ok: true, id }),
+    ...(ownerAgentId === undefined ? {} : { ownerAgentId }),
+  };
+}
+
+function setupTools(): void {
+  clearMCPRegistry();
+  registerTool("global-echo", makeTool("global-echo"));
+  registerTool("researcher--fetch", makeTool("researcher--fetch", "researcher"));
+}
+
+Deno.test("executeTool runs an owned tool for its owning agent", async () => {
+  setupTools();
+  try {
+    const result = await executeTool("researcher--fetch", {}, { agentId: "researcher" });
+    assertEquals(result, { ok: true, id: "researcher--fetch" });
+  } finally {
+    clearMCPRegistry();
+  }
+});
+
+Deno.test("executeTool rejects an owned tool for another agent as not found", () => {
+  setupTools();
+  try {
+    assertThrows(
+      () => executeTool("researcher--fetch", {}, { agentId: "writer" }),
+      Error,
+      'Tool "researcher--fetch" not found',
+    );
+  } finally {
+    clearMCPRegistry();
+  }
+});
+
+Deno.test("executeTool rejects an owned tool without an agent context", () => {
+  setupTools();
+  try {
+    assertThrows(
+      () => executeTool("researcher--fetch", {}),
+      Error,
+      'Tool "researcher--fetch" not found',
+    );
+  } finally {
+    clearMCPRegistry();
+  }
+});
+
+Deno.test("MCP tools/list excludes agent-owned tools and keeps unowned ones", async () => {
+  setupTools();
+  try {
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
+    const handler = server.createHTTPHandler();
+    const response = await handler(
+      new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+      }),
+    );
+
+    assertEquals(response.status, 200);
+    const body = await response.json() as {
+      result: { tools: Array<{ name: string }> };
+    };
+    const names = body.result.tools.map((tool) => tool.name);
+    assertEquals(names.includes("global-echo"), true);
+    assertEquals(names.includes("researcher--fetch"), false);
+  } finally {
+    clearMCPRegistry();
+  }
+});
+
+Deno.test("MCP tools/call cannot execute an agent-owned tool", async () => {
+  setupTools();
+  try {
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
+    const handler = server.createHTTPHandler();
+    const response = await handler(
+      new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: { name: "researcher--fetch", arguments: {} },
+        }),
+      }),
+    );
+
+    const body = await response.json() as {
+      result?: { isError?: boolean; content?: Array<{ text?: string }> };
+      error?: { message?: string };
+    };
+    const text = JSON.stringify(body);
+    assertEquals(text.includes("not found"), true);
+    assertEquals(body.result?.isError === true || body.error !== undefined, true);
+  } finally {
+    clearMCPRegistry();
+  }
+});
+
+// ── Model-facing tool definitions and runtime execution fallback ─────────
+
+import { executeConfiguredTool, getAvailableTools } from "../agent/runtime/tool-helpers.ts";
+
+Deno.test("getAvailableTools(true) excludes other agents' owned tools from model definitions", async () => {
+  setupTools();
+  try {
+    const defs = await getAvailableTools(true, { callerAgentId: "writer" });
+    const names = defs.map((def) => def.name);
+    assertEquals(names.includes("global-echo"), true);
+    assertEquals(names.includes("researcher--fetch"), false);
+
+    const ownerDefs = await getAvailableTools(true, { callerAgentId: "researcher" });
+    assertEquals(ownerDefs.map((def) => def.name).includes("researcher--fetch"), true);
+  } finally {
+    clearMCPRegistry();
+  }
+});
+
+Deno.test("getAvailableTools named entry cannot bind another agent's owned tool", async () => {
+  setupTools();
+  try {
+    // Binding another agent's owned tool by full id fails with an explicit
+    // unknown-tool error whose enumeration lists only visible tools.
+    let rejected = false;
+    try {
+      await getAvailableTools({ "researcher--fetch": true }, { callerAgentId: "writer" });
+    } catch (error) {
+      rejected = true;
+      const message = String(error);
+      assertEquals(message.includes("Unknown tool reference"), true);
+      assertEquals(message.includes("Available tools: global-echo"), true);
+      assertEquals(message.includes("global-echo, researcher--fetch"), false);
+    }
+    assertEquals(rejected, true);
+  } finally {
+    clearMCPRegistry();
+  }
+});
+
+Deno.test("executeConfiguredTool registry fallback rejects another agent's owned tool", async () => {
+  setupTools();
+  try {
+    await executeConfiguredTool("researcher--fetch", {}, undefined, { agentId: "researcher" });
+
+    let rejected = false;
+    try {
+      await executeConfiguredTool("researcher--fetch", {}, undefined, { agentId: "writer" });
+    } catch (error) {
+      rejected = true;
+      assertEquals(String(error).includes('Tool "researcher--fetch" not found'), true);
+    }
+    assertEquals(rejected, true);
+  } finally {
+    clearMCPRegistry();
+  }
+});

--- a/src/tool/types.ts
+++ b/src/tool/types.ts
@@ -152,6 +152,17 @@ export interface Tool<TInput = any, TOutput = any> {
 
   /** MCP configuration */
   mcp?: ToolConfig["mcp"];
+
+  /**
+   * Owning agent id for agent-scoped tools. Unowned (undefined) tools are
+   * project/global. Owned tools are invisible to other agents, excluded from
+   * MCP `tools/list`, and rejected by registry execution unless the execution
+   * context carries the owner's `agentId`.
+   */
+  ownerAgentId?: string;
+
+  /** Short name used by the owning agent's `tools:` selector (e.g. "fetch"). */
+  shortName?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

PR C of the agreed split (stacked on #2356): capability ownership becomes registry metadata, and ONE owner-aware rule is enforced at every surface where capabilities are resolved. A caller sees unowned (project-global) capabilities plus its own — never another agent's.

**The seven resolver-consumer surfaces** (from the adoption plan checklist):
1. **Prompt manifests** — `resolveForAgent(config, {agentId})`; `true` = unowned + own; lists resolve own short name first, then exact visible id
2. **Model tool definitions** — `getAvailableTools` filters owned tools for `tools: true` and named entries; unknown-tool errors enumerate only visible tools
3. **MCP `tools/list`** — owned tools excluded (external callers have no agent identity)
4. **MCP `tools/call`** — `executeTool` rejects owned tools as not found
5-7. **`load_skill` / `load_skill_reference` / `execute_skill_script`** — shared scope-gated resolution; invisible skills behave as missing; miss errors enumerate only visible ids (closes the id-enumeration leak)

**Caller identity**: the runtime stamps `ToolExecutionContext.agentId` after caller-context spreads in both generate and stream paths, so caller-supplied context cannot spoof the identity used for scope enforcement. `executeConfiguredTool`'s registry fallback is gated on the same rule. Delegation does not forward context (`agentAsTool` discards it), so identity switches naturally with the executing agent's runtime.

## Threat-model tests (leak tests from the plan)

`src/skill/skill-owner-scope.test.ts` + `src/tool/tool-owner-scope.test.ts`:
- `skills: true` / `tools: true` exclude other agents' owned capabilities (incl. project-level/no-scope callers)
- explicit-id access rejected for owned skills AND owned tools (selector, skill tools, registry execution)
- own-short-name-first resolution incl. shadowing a global id
- miss/unknown errors never enumerate invisible ids
- MCP `tools/list` exclusion + `tools/call` rejection
- positive paths: owner loads own skill by short name; owner executes own tool

Note: delegation-scope isolation (plan test 14) is covered at mechanism level (context discard + runtime stamping); a full two-agent integration test is deferred to PR D where directory agents make the fixture natural. The shadowing *discovery diagnostic* (test 15) is PR D discovery-time scope.

## Back-compat

With no owned entries registered, every surface behaves identically to before (regression suites for skill/tool/mcp/agent-runtime all green).

## Type of Change
- [x] New feature (non-breaking)
- [x] Test update