### PR TITLE
Add directory-layout agents with owner-registered colocated capabilities

### DIFF
--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -55,6 +55,54 @@ The file path provides the agent id. For example, `agents/support.md` registers
 `support` and can be invoked through the same project runtime and control-plane
 surfaces as `agents/support.ts`.
 
+## Per-agent skills and tools
+
+A markdown agent can own its skills and tools by using a directory instead of a
+single file. Put the agent definition in `AGENT.md` and colocate its
+capabilities beside it:
+
+```
+agents/
+  researcher/
+    AGENT.md            # the agent definition (frontmatter + instructions)
+    SKILL.md            # the agent's own skill, loaded as load_skill("researcher")
+    skills/
+      cite/SKILL.md     # an extra skill, loaded as load_skill("researcher--cite")
+    tools/
+      fetch-paper.ts    # a colocated tool, registered as "researcher--fetch-paper"
+```
+
+The directory name is the agent id. The flat `agents/{id}.md` form still works
+for agents that do not own skills or tools, and both layouts can coexist.
+
+Colocated capabilities are registered with owner metadata and namespaced
+`{agentId}--{name}`. Ownership controls visibility everywhere: an agent only
+ever sees unowned (project-global) capabilities plus its own — never another
+agent's. This one rule applies to `skills:` and `tools:` for every agent kind
+(TypeScript, flat markdown, and directory markdown):
+
+```md
+---
+name: Researcher
+model: anthropic/claude-sonnet-4-6
+skills: true # all skills visible to this agent (global + own)
+tools: [fetch-paper] # own short names resolve first, then global tool ids
+---
+
+Research the question and cite every claim.
+```
+
+- `skills: true` / `tools: true` — every capability visible to the agent.
+- `skills: [..]` / `tools: [..]` — each entry resolves as the agent's own
+  short name first, then as a global id. A colocated short name that shadows a
+  global id is reported at discovery so the reference stays unambiguous.
+- Duplicate agent ids (flat file + directory) and agent ids whose sanitized
+  namespaces collide are reported as discovery errors.
+
+> Note: colocated capabilities currently resolve in the local runtime; hosted
+> runtime catalog support is tracked separately and lands before this layout
+> is documented as stable.
+
 ## Add tools
 
 Agents call tools to take actions or fetch data. Reference tools by name: the

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -99,6 +99,29 @@ const researcher = getAgent("researcher");
 const researchTool = agentAsTool(researcher, "Research a topic using web search");
 ```
 
+## Declarative delegation with `delegates`
+
+A markdown agent can opt into orchestration by listing the specialists it may
+call in its `delegates` frontmatter. The runtime gives the agent one
+`agent_{id}` tool per delegate; each delegate runs with its own settings,
+skills, and tools — capability ownership does not cross the delegation
+boundary in either direction.
+
+```md
+---
+name: Lead
+description: Plans the work and routes to specialists
+delegates: [researcher, writer]
+---
+
+Break the task down. Use agent_researcher to gather facts, then agent_writer to
+produce the final copy.
+```
+
+With several agents and no `delegates`, the agents are independent: a caller
+selects one by id. Self-delegation and delegate ids that cannot form a valid
+provider tool name are rejected at discovery with explicit diagnostics.
+
 ## Workflow-based composition
 
 For deterministic multi-agent pipelines, use [workflows](./workflows.md):

--- a/scripts/lint/check-sanitizer-baseline.ts
+++ b/scripts/lint/check-sanitizer-baseline.ts
@@ -22,7 +22,7 @@ const SCAN_ROOTS = [
 
 // Lower this when you remove sanitizer opt-outs. Never raise it without a very
 // good reason — a new opt-out means a leak is being suppressed rather than fixed.
-export const SANITIZER_OPT_OUT_BASELINE = 420;
+export const SANITIZER_OPT_OUT_BASELINE = 422;
 
 const OPT_OUT_PATTERN = /sanitize(?:Resources|Ops|Exit)\s*:\s*false/g;
 

--- a/scripts/lint/check-sanitizer-baseline.ts
+++ b/scripts/lint/check-sanitizer-baseline.ts
@@ -22,6 +22,10 @@ const SCAN_ROOTS = [
 
 // Lower this when you remove sanitizer opt-outs. Never raise it without a very
 // good reason — a new opt-out means a leak is being suppressed rather than fixed.
+// 422 = 420 (historical) + 2 for the colocated tool-loading discovery test
+// (src/discovery/agent-scoped-capabilities.test.ts): importModule transpiles
+// via esbuild, whose warm child process trips the op/resource sanitizers —
+// same rationale as src/discovery/transpiler.test.ts.
 export const SANITIZER_OPT_OUT_BASELINE = 422;
 
 const OPT_OUT_PATTERN = /sanitize(?:Resources|Ops|Exit)\s*:\s*false/g;

--- a/src/agent/runtime/agent-definition.ts
+++ b/src/agent/runtime/agent-definition.ts
@@ -37,6 +37,8 @@ export const getRuntimeAgentMarkdownDefinitionSchema = defineSchema((v) =>
     temperature: v.number().min(0).max(2).optional(),
     maxSteps: v.number().optional(),
     providerTools: v.array(v.string().min(1)).optional(),
+    skills: v.union([v.literal(true), v.array(v.string().min(1))]).optional(),
+    tools: v.union([v.literal(true), v.array(v.string().min(1))]).optional(),
     delegates: v.array(v.string().min(1)).optional(),
   })
 );
@@ -106,6 +108,19 @@ function parseProviderTools(value: unknown): unknown[] | undefined {
   return value;
 }
 
+function parseCapabilitySelector(value: unknown): true | string[] | undefined {
+  if (value === true) {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    const ids = value
+      .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+      .map((entry) => entry.trim());
+    return ids.length > 0 ? ids : undefined;
+  }
+  return undefined;
+}
+
 function parseDelegates(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
@@ -146,6 +161,8 @@ export function parseRuntimeAgentMarkdownDefinition(
   const temperature = typeof attrs.temperature === "number" ? attrs.temperature : undefined;
   const maxSteps = typeof attrs["max-steps"] === "number" ? attrs["max-steps"] : undefined;
   const providerTools = parseProviderTools(attrs["provider-tools"]);
+  const skills = parseCapabilitySelector(attrs.skills);
+  const tools = parseCapabilitySelector(attrs.tools);
   const delegates = parseDelegates(attrs.delegates);
   validateDelegates(parsedInput.id, delegates);
 
@@ -159,6 +176,8 @@ export function parseRuntimeAgentMarkdownDefinition(
     ...(temperature === undefined ? {} : { temperature }),
     ...(maxSteps === undefined ? {} : { maxSteps }),
     ...(providerTools ? { providerTools } : {}),
+    ...(skills === undefined ? {} : { skills }),
+    ...(tools === undefined ? {} : { tools }),
     ...(delegates === undefined ? {} : { delegates }),
   });
 }

--- a/src/agent/runtime/agent-markdown-adapter.ts
+++ b/src/agent/runtime/agent-markdown-adapter.ts
@@ -13,6 +13,22 @@ export function createRuntimeAgentFromMarkdownDefinition(
     ? buildAgentDelegateTools({ delegates: definition.delegates, selfId: definition.id })
     : undefined;
 
+  // `tools:` is a binding selector resolved at invocation time by the
+  // owner-aware resolver: `true` binds all visible tools; a list binds each
+  // entry (own short name first, then exact global id). Delegate tools merge
+  // on top; on key collision the delegate tool wins (keys never overlap in
+  // practice: selectors use tool ids, delegates use `agent_{id}`).
+  const selectedTools: true | Record<string, true> | undefined = definition.tools === true
+    ? true
+    : definition.tools
+    ? Object.fromEntries(definition.tools.map((name) => [name, true as const]))
+    : undefined;
+  const mergedTools = selectedTools === true
+    ? true
+    : selectedTools || delegateTools
+    ? { ...(selectedTools ?? {}), ...(delegateTools ?? {}) }
+    : undefined;
+
   const runtimeAgent = agent({
     id: definition.id,
     name: definition.name,
@@ -22,7 +38,11 @@ export function createRuntimeAgentFromMarkdownDefinition(
     ...(definition.temperature === undefined ? {} : { temperature: definition.temperature }),
     ...(definition.maxSteps === undefined ? {} : { maxSteps: definition.maxSteps }),
     ...(definition.providerTools ? { providerTools: definition.providerTools } : {}),
-    ...(delegateTools && Object.keys(delegateTools).length > 0 ? { tools: delegateTools } : {}),
+    ...(definition.skills === undefined ? {} : { skills: definition.skills }),
+    ...(mergedTools !== undefined &&
+        (mergedTools === true || Object.keys(mergedTools).length > 0)
+      ? { tools: mergedTools }
+      : {}),
   });
 
   markdownDefinitionByAgent.set(runtimeAgent, definition);

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -95,6 +95,27 @@ export function isDynamicTool(name: string): boolean {
 // deno-lint-ignore no-explicit-any -- generic erasure: accepts Tool with any input/output types
 export type ToolConfigEntry = Tool<any, any> | boolean;
 
+/**
+ * Resolve a configured tool name for a caller: the caller's own tool by short
+ * name first, then an exact registry id — returning only tools visible to the
+ * caller (owner-aware).
+ */
+function resolveVisibleRegistryTool(
+  name: string,
+  callerAgentId?: string,
+  // deno-lint-ignore no-explicit-any -- generic erasure: registry tools carry any input/output types
+): Tool<any, any> | undefined {
+  if (callerAgentId !== undefined) {
+    for (const tool of toolRegistry.getAll().values()) {
+      if (tool.ownerAgentId === callerAgentId && tool.shortName === name) {
+        return tool;
+      }
+    }
+  }
+  const tool = toolRegistry.get(name);
+  return tool && isToolVisibleTo(tool, { agentId: callerAgentId }) ? tool : undefined;
+}
+
 function formatAvailableToolNames(names: Iterable<string>): string {
   const sorted = [...new Set(names)].sort();
   return sorted.length > 0 ? sorted.join(", ") : "(none)";
@@ -391,14 +412,13 @@ export async function getAvailableTools(
 
   for (const [name, entry] of Object.entries(toolsConfig)) {
     if (entry === true) {
-      const tool = toolRegistry.get(name);
-      if (tool && isToolVisibleTo(tool, { agentId: options?.callerAgentId })) {
-        addToolDefinition(tools, name, tool);
-        continue;
-      }
+      // Own short name first, then exact id; owned tools of other agents are
+      // invisible and fall through to the unresolved diagnostic. Definitions
+      // are exposed under the tool's full registry id so execution resolves
+      // through the same owner-aware gate.
+      const tool = resolveVisibleRegistryTool(name, options?.callerAgentId);
       if (tool) {
-        // Owned by another agent: treat as unresolved rather than binding it.
-        unresolvedConfiguredToolNames.push(name);
+        addToolDefinition(tools, tool.id, tool);
         continue;
       }
 

--- a/src/discovery/agent-scoped-capabilities.test.ts
+++ b/src/discovery/agent-scoped-capabilities.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Directory-agent discovery tests: colocated capabilities register with owner
+ * metadata (pure registration), and the owner-aware resolver keeps agents
+ * isolated — including coordinators from their delegates (plan tests 14, 15).
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import {
+  isProviderSafeToolName,
+  isSafePathSegment,
+  namespaceAgentCapability,
+} from "./agent-scoped-capabilities.ts";
+import { discoverRuntimeAgentMarkdownDefinitions } from "./handlers/runtime-agent-markdown-handler.ts";
+import type { DiscoveryResult, FileDiscoveryContext } from "./types.ts";
+import { registerSkill, skillRegistry } from "#veryfront/skill/registry.ts";
+import { agentRegistry } from "../agent/composition/index.ts";
+
+function emptyResult(): DiscoveryResult {
+  return {
+    tools: new Map(),
+    agents: new Map(),
+    skills: new Map(),
+    resources: new Map(),
+    prompts: new Map(),
+    workflows: new Map(),
+    tasks: new Map(),
+    errors: [],
+  };
+}
+
+const context: FileDiscoveryContext = { platform: "node" };
+
+async function writeFixtureProject(root: string): Promise<string> {
+  const agentsDir = `${root}/agents`;
+  await Deno.mkdir(`${agentsDir}/researcher/skills/cite`, { recursive: true });
+  await Deno.writeTextFile(
+    `${agentsDir}/lead.md`,
+    `---\nname: Lead\nskills: true\ndelegates: [researcher]\n---\nCoordinate the work.\n`,
+  );
+  await Deno.writeTextFile(
+    `${agentsDir}/researcher/AGENT.md`,
+    `---\nname: Researcher\nskills: true\n---\nResearch thoroughly.\n`,
+  );
+  await Deno.writeTextFile(
+    `${agentsDir}/researcher/SKILL.md`,
+    `---\nname: researcher\ndescription: Research methodology\n---\nFollow the method.\n`,
+  );
+  await Deno.writeTextFile(
+    `${agentsDir}/researcher/skills/cite/SKILL.md`,
+    `---\nname: cite\ndescription: Cite sources\n---\nCite primary sources.\n`,
+  );
+  return agentsDir;
+}
+
+function cleanupAgents(ids: string[]): void {
+  for (const id of ids) {
+    agentRegistry.delete(id);
+  }
+}
+
+Deno.test("namespaceAgentCapability uses the -- separator and provider-safe names", () => {
+  assertEquals(namespaceAgentCapability("researcher", "cite"), "researcher--cite");
+  assertEquals(namespaceAgentCapability("a.b", "x"), "a_b--x");
+  assertEquals(isProviderSafeToolName("researcher--fetch-paper"), true);
+  assertEquals(isProviderSafeToolName("researcher__fetch"), true);
+  assertEquals(isProviderSafeToolName("bad.name"), false);
+  assertEquals(isProviderSafeToolName("a".repeat(65)), false);
+});
+
+Deno.test("isSafePathSegment rejects traversal segments", () => {
+  assertEquals(isSafePathSegment("."), false);
+  assertEquals(isSafePathSegment(".."), false);
+  assertEquals(isSafePathSegment("researcher"), true);
+  assertEquals(isSafePathSegment("a/b"), false);
+});
+
+Deno.test("directory and flat agents discover side by side with owned skills registered", async () => {
+  const root = await Deno.makeTempDir();
+  skillRegistry.clearAll();
+  try {
+    const agentsDir = await writeFixtureProject(root);
+    const result = emptyResult();
+
+    await discoverRuntimeAgentMarkdownDefinitions(agentsDir, result, context);
+
+    assertEquals(result.errors, []);
+    assertEquals([...result.agents.keys()].sort(), ["lead", "researcher"]);
+
+    const own = skillRegistry.get("researcher");
+    assertEquals(own?.ownerAgentId, "researcher");
+    assertEquals(own?.shortName, "researcher");
+
+    const nested = skillRegistry.get("researcher--cite");
+    assertEquals(nested?.ownerAgentId, "researcher");
+    assertEquals(nested?.shortName, "cite");
+  } finally {
+    skillRegistry.clearAll();
+    cleanupAgents(["lead", "researcher"]);
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("a coordinator's skills: true does not include its delegate's owned skills", async () => {
+  const root = await Deno.makeTempDir();
+  skillRegistry.clearAll();
+  try {
+    const agentsDir = await writeFixtureProject(root);
+    const result = emptyResult();
+    await discoverRuntimeAgentMarkdownDefinitions(agentsDir, result, context);
+
+    // Lead delegates to researcher but must not see researcher's owned skills.
+    const leadSkills = skillRegistry.resolveForAgent(true, { agentId: "lead" });
+    assertEquals([...leadSkills.keys()], []);
+
+    // The specialist sees its own skills.
+    const researcherSkills = skillRegistry.resolveForAgent(true, { agentId: "researcher" });
+    assertEquals([...researcherSkills.keys()].sort(), ["researcher", "researcher--cite"]);
+
+    // And the delegate tool exists on the coordinator (delegation unaffected).
+    // skills: true also merges the shared skill tools into config.tools.
+    const lead = result.agents.get("lead");
+    const tools = lead?.config.tools as Record<string, unknown> | undefined;
+    assertEquals(Object.keys(tools ?? {}).includes("agent_researcher"), true);
+  } finally {
+    skillRegistry.clearAll();
+    cleanupAgents(["lead", "researcher"]);
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("duplicate flat and directory agent ids report a discovery error", async () => {
+  const root = await Deno.makeTempDir();
+  skillRegistry.clearAll();
+  try {
+    const agentsDir = `${root}/agents`;
+    await Deno.mkdir(`${agentsDir}/writer`, { recursive: true });
+    await Deno.writeTextFile(`${agentsDir}/writer.md`, `---\nname: Writer Flat\n---\nA.\n`);
+    await Deno.writeTextFile(
+      `${agentsDir}/writer/AGENT.md`,
+      `---\nname: Writer Dir\n---\nB.\n`,
+    );
+
+    const result = emptyResult();
+    await discoverRuntimeAgentMarkdownDefinitions(agentsDir, result, context);
+
+    assertEquals(result.agents.size, 1);
+    assertEquals(result.errors.length, 1);
+    assertEquals(String(result.errors[0]?.error).includes('Duplicate agent id "writer"'), true);
+  } finally {
+    skillRegistry.clearAll();
+    cleanupAgents(["writer"]);
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("owned short name shadowing a global skill id reports a diagnostic", async () => {
+  const root = await Deno.makeTempDir();
+  skillRegistry.clearAll();
+  try {
+    // Pre-existing global skill with the id "cite".
+    registerSkill("cite", {
+      id: "cite",
+      metadata: { name: "cite", description: "Global cite skill" },
+      rootPath: "/nonexistent/cite",
+    });
+
+    const agentsDir = await writeFixtureProject(root);
+    const result = emptyResult();
+    await discoverRuntimeAgentMarkdownDefinitions(agentsDir, result, context);
+
+    const shadowing = result.errors.filter((entry) =>
+      String(entry.error).includes('shadows the global skill id "cite"')
+    );
+    assertEquals(shadowing.length, 1);
+
+    // Both skills remain registered; resolution stays owner-aware.
+    const own = skillRegistry.resolveForAgent(["cite"], { agentId: "researcher" });
+    assertEquals([...own.keys()], ["researcher--cite"]);
+    const other = skillRegistry.resolveForAgent(["cite"], { agentId: "lead" });
+    assertEquals([...other.keys()], ["cite"]);
+  } finally {
+    skillRegistry.clearAll();
+    cleanupAgents(["lead", "researcher"]);
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("agent ids that sanitize to the same namespace report a collision error", async () => {
+  const root = await Deno.makeTempDir();
+  skillRegistry.clearAll();
+  try {
+    const agentsDir = `${root}/agents`;
+    await Deno.mkdir(`${agentsDir}/a.b`, { recursive: true });
+    await Deno.mkdir(`${agentsDir}/a_b`, { recursive: true });
+    await Deno.writeTextFile(`${agentsDir}/a.b/AGENT.md`, `---\nname: AB1\n---\nOne.\n`);
+    await Deno.writeTextFile(
+      `${agentsDir}/a.b/SKILL.md`,
+      `---\nname: ab\ndescription: d\n---\nX.\n`,
+    );
+    await Deno.writeTextFile(`${agentsDir}/a_b/AGENT.md`, `---\nname: AB2\n---\nTwo.\n`);
+
+    const result = emptyResult();
+    await discoverRuntimeAgentMarkdownDefinitions(agentsDir, result, context);
+
+    const collisions = result.errors.filter((entry) =>
+      String(entry.error).includes("shares the sanitized capability namespace")
+    );
+    assertEquals(collisions.length, 1);
+  } finally {
+    skillRegistry.clearAll();
+    cleanupAgents(["a.b", "a_b"]);
+    await Deno.remove(root, { recursive: true });
+  }
+});

--- a/src/discovery/agent-scoped-capabilities.test.ts
+++ b/src/discovery/agent-scoped-capabilities.test.ts
@@ -213,3 +213,53 @@ Deno.test("agent ids that sanitize to the same namespace report a collision erro
     await Deno.remove(root, { recursive: true });
   }
 });
+
+// ── Full-pipeline regression (review finding: discoverAll wiped colocated skills) ──
+
+import { discoverAll } from "./index.ts";
+
+Deno.test("discoverAll preserves directory-agent colocated skills through the skill-registry clear", async () => {
+  const root = await Deno.makeTempDir();
+  skillRegistry.clearAll();
+  try {
+    await writeFixtureProject(root);
+    // A global skill whose id shadows researcher's "cite" short name —
+    // discovered through the real pipeline (skills before agents), so the
+    // shadow diagnostic must fire without manual pre-registration.
+    await Deno.mkdir(`${root}/skills/cite`, { recursive: true });
+    await Deno.writeTextFile(
+      `${root}/skills/cite/SKILL.md`,
+      `---\nname: cite\ndescription: Global cite skill\n---\nGlobal citing.\n`,
+    );
+
+    const result = await discoverAll({ baseDir: root });
+
+    // Colocated skills survive the registry clear and surface in the result.
+    assertEquals(skillRegistry.get("researcher")?.ownerAgentId, "researcher");
+    assertEquals(skillRegistry.get("researcher--cite")?.ownerAgentId, "researcher");
+    assertEquals(result.skills.has("researcher"), true);
+    assertEquals(result.skills.has("researcher--cite"), true);
+    assertEquals(result.skills.has("cite"), true);
+
+    // The agent sees its own skills plus the unowned global one.
+    assertEquals(
+      [...skillRegistry.resolveForAgent(true, { agentId: "researcher" }).keys()].sort(),
+      ["cite", "researcher", "researcher--cite"],
+    );
+    // Other agents see only the global skill.
+    assertEquals(
+      [...skillRegistry.resolveForAgent(true, { agentId: "lead" }).keys()],
+      ["cite"],
+    );
+
+    // Shadow diagnostic fires through the natural pipeline ordering.
+    const shadowing = result.errors.filter((entry) =>
+      String(entry.error).includes('shadows the global skill id "cite"')
+    );
+    assertEquals(shadowing.length, 1);
+  } finally {
+    skillRegistry.clearAll();
+    cleanupAgents(["lead", "researcher"]);
+    await Deno.remove(root, { recursive: true });
+  }
+});

--- a/src/discovery/agent-scoped-capabilities.test.ts
+++ b/src/discovery/agent-scoped-capabilities.test.ts
@@ -298,9 +298,30 @@ Deno.test({
 };
 `,
       );
+      // A second module exporting the same explicit short name — must be
+      // reported at discovery instead of silently dropped (sorted after
+      // fetch-paper.ts, so the first registration wins).
+      await Deno.writeTextFile(
+        `${root}/agents/researcher/tools/zz-dupe.ts`,
+        `export const dupe = {
+  id: "fetch-paper",
+  type: "function",
+  description: "Conflicting duplicate",
+  inputSchema: { type: "object", properties: {} },
+  execute: () => Promise.resolve({ ok: false, dupe: true }),
+};
+`,
+      );
 
       const result = await discoverAll({ baseDir: root });
-      assertEquals(result.errors, []);
+      const duplicateErrors = result.errors.filter((entry) =>
+        String(entry.error).includes('Duplicate colocated tool "fetch-paper"')
+      );
+      assertEquals(duplicateErrors.length, 1);
+      assertEquals(
+        result.errors.filter((entry) => !duplicateErrors.includes(entry)),
+        [],
+      );
 
       // Registered under the namespaced id with owner metadata.
       const registered = toolRegistry.get("researcher--fetch-paper");

--- a/src/discovery/agent-scoped-capabilities.test.ts
+++ b/src/discovery/agent-scoped-capabilities.test.ts
@@ -263,3 +263,68 @@ Deno.test("discoverAll preserves directory-agent colocated skills through the sk
     await Deno.remove(root, { recursive: true });
   }
 });
+
+// ── Colocated tool loading through the real transpiler (esbuild) ─────────
+
+import { clearMCPRegistry } from "#veryfront/mcp";
+import { toolRegistry } from "#veryfront/tool";
+import { executeTool } from "#veryfront/tool";
+
+Deno.test({
+  name: "discoverAll loads colocated tools/*.ts with owner metadata and gates execution",
+  // importModule transpiles via esbuild, which keeps a warm child process
+  // alive across tests and trips Deno's op/resource sanitizers — same reason
+  // src/discovery/transpiler.test.ts opts out (tracked in the lint baseline).
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const root = await Deno.makeTempDir();
+    skillRegistry.clearAll();
+    clearMCPRegistry();
+    try {
+      await Deno.mkdir(`${root}/agents/researcher/tools`, { recursive: true });
+      await Deno.writeTextFile(
+        `${root}/agents/researcher/AGENT.md`,
+        `---\nname: Researcher\ntools: [fetch-paper]\n---\nResearch.\n`,
+      );
+      await Deno.writeTextFile(
+        `${root}/agents/researcher/tools/fetch-paper.ts`,
+        `export const fetchPaper = {
+  id: "fetch-paper",
+  type: "function",
+  description: "Fetch a paper by id",
+  inputSchema: { type: "object", properties: {} },
+  execute: () => Promise.resolve({ ok: true, paper: "attention-is-all-you-need" }),
+};
+`,
+      );
+
+      const result = await discoverAll({ baseDir: root });
+      assertEquals(result.errors, []);
+
+      // Registered under the namespaced id with owner metadata.
+      const registered = toolRegistry.get("researcher--fetch-paper");
+      assertEquals(registered?.ownerAgentId, "researcher");
+      assertEquals(registered?.shortName, "fetch-paper");
+
+      // Owner executes (by full id through the registry gate)...
+      const ok = await executeTool("researcher--fetch-paper", {}, { agentId: "researcher" });
+      assertEquals(ok, { ok: true, paper: "attention-is-all-you-need" });
+
+      // ...other agents and external callers cannot.
+      let rejected = false;
+      try {
+        await executeTool("researcher--fetch-paper", {}, { agentId: "writer" });
+      } catch (error) {
+        rejected = true;
+        assertEquals(String(error).includes("not found"), true);
+      }
+      assertEquals(rejected, true);
+    } finally {
+      skillRegistry.clearAll();
+      clearMCPRegistry();
+      cleanupAgents(["researcher"]);
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+});

--- a/src/discovery/agent-scoped-capabilities.ts
+++ b/src/discovery/agent-scoped-capabilities.ts
@@ -1,0 +1,279 @@
+/**
+ * Per-agent colocated capability registration.
+ *
+ * Directory-layout agents (`agents/{id}/`) may ship their own tools and
+ * skills:
+ * - Tools: `agents/{id}/tools/*.ts` → registered into the global tool
+ *   registry under `{agentId}--{shortName}` with `ownerAgentId` metadata.
+ * - Skills: `agents/{id}/SKILL.md` (the agent's own skill, registered under
+ *   the agent id) and `agents/{id}/skills/<sub>/SKILL.md` (registered under
+ *   `{agentId}--{sub}`), both with `ownerAgentId` metadata.
+ *
+ * Discovery here is PURE REGISTRATION: no binding decisions. Visibility and
+ * selector resolution (`skills:` / `tools:`, `true` or lists, own short names
+ * first) happen at invocation time through the owner-aware resolvers, so flat
+ * and directory agents share identical binding semantics.
+ *
+ * The namespace separator is `--` (decided platform-wide): provider-safe and
+ * never confusable with `<provider>__<tool>` integration tool naming.
+ */
+
+import type { Tool } from "#veryfront/tool";
+import { toolRegistry } from "#veryfront/tool";
+import type { Skill } from "#veryfront/skill";
+import { parseSkillFrontmatter, validateSkillMetadata } from "#veryfront/skill/parser.ts";
+import { getSkill, registerSkill } from "#veryfront/skill/registry.ts";
+import { SKILL_MD_FILENAME } from "#veryfront/skill/types.ts";
+import { registerTool } from "#veryfront/mcp";
+import { ensureError } from "#veryfront/errors/veryfront-error.ts";
+import { filenameToId } from "./discovery-utils.ts";
+import {
+  discoveryFileExists,
+  findTypeScriptFiles,
+  listDiscoveryDirectoryEntries,
+  readDiscoveryTextFile,
+} from "./file-discovery.ts";
+import { importModule } from "./transpiler.ts";
+import type { DiscoveryResult, FileDiscoveryContext } from "./types.ts";
+
+const AGENT_TOOLS_SUBDIR = "tools";
+const AGENT_SKILLS_SUBDIR = "skills";
+/** Separator between the agent namespace and the capability short name. */
+export const AGENT_CAPABILITY_NAMESPACE_SEPARATOR = "--";
+/** Provider tool-call names allow only this charset, max 64 chars. */
+const PROVIDER_TOOL_NAME_REGEX = /^[A-Za-z0-9_-]{1,64}$/;
+
+/** Whether a namespaced tool name is valid for provider tool calls. */
+export function isProviderSafeToolName(name: string): boolean {
+  return PROVIDER_TOOL_NAME_REGEX.test(name);
+}
+
+const SAFE_PATH_SEGMENT_REGEX = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Whether a directory/file entry name is a safe single path segment — used
+ * before joining it into a filesystem path. Rejects `.` and `..` (which match
+ * the permissive name regex) as defense-in-depth against path traversal.
+ */
+export function isSafePathSegment(name: string): boolean {
+  return name !== "." && name !== ".." && SAFE_PATH_SEGMENT_REGEX.test(name);
+}
+
+/** Sanitizes an agent id into a provider-safe namespace segment. */
+export function sanitizeCapabilityNamespace(agentId: string): string {
+  return agentId.replace(/[^A-Za-z0-9_-]/g, "_");
+}
+
+/** Namespaces a capability short name under its owning agent. */
+export function namespaceAgentCapability(agentId: string, shortName: string): string {
+  return `${
+    sanitizeCapabilityNamespace(agentId)
+  }${AGENT_CAPABILITY_NAMESPACE_SEPARATOR}${shortName}`;
+}
+
+function isTool(value: unknown): value is Tool {
+  return value !== null && typeof value === "object" &&
+    typeof (value as Tool).execute === "function";
+}
+
+function hasExplicitToolId(tool: Tool): boolean {
+  const generated = tool.__veryfrontGeneratedId;
+  if (typeof tool.id !== "string" || tool.id.trim().length === 0) {
+    return false;
+  }
+  return generated === undefined || tool.id !== generated;
+}
+
+function toolShortName(tool: Tool, file: string): string {
+  return hasExplicitToolId(tool) ? tool.id : filenameToId(file);
+}
+
+function collectModuleTools(module: unknown, file: string): Map<string, Tool> {
+  const tools = new Map<string, Tool>();
+  const record = module as Record<string, unknown>;
+  for (const value of Object.values(record ?? {})) {
+    if (isTool(value)) {
+      tools.set(toolShortName(value, file), value);
+    }
+  }
+  return tools;
+}
+
+function reportShadowedGlobalCapability(input: {
+  kind: "tool" | "skill";
+  agentId: string;
+  shortName: string;
+  file: string;
+  result?: DiscoveryResult;
+}): void {
+  const global = input.kind === "tool"
+    ? toolRegistry.get(input.shortName)
+    : getSkill(input.shortName);
+  if (global && (global as { ownerAgentId?: string }).ownerAgentId === undefined) {
+    input.result?.errors.push({
+      file: input.file,
+      error: ensureError(
+        `Colocated ${input.kind} "${input.shortName}" of agent "${input.agentId}" shadows the ` +
+          `global ${input.kind} id "${input.shortName}": the agent's selector resolves its own ` +
+          `${input.kind} first. Rename one to make the reference unambiguous.`,
+      ),
+    });
+  }
+}
+
+/** Input payload for registering an agent's colocated capabilities. */
+export type RegisterAgentColocatedCapabilitiesInput = {
+  agentId: string;
+  rootPath: string;
+  context: FileDiscoveryContext;
+  result?: DiscoveryResult;
+};
+
+/**
+ * Registers an agent's colocated `tools/*.ts` into the global tool registry
+ * under `{agentId}--{shortName}` with owner metadata. Returns registered ids.
+ */
+export async function registerAgentColocatedTools(
+  input: RegisterAgentColocatedCapabilitiesInput,
+): Promise<string[]> {
+  const toolsDir = `${input.rootPath}/${AGENT_TOOLS_SUBDIR}`;
+  if (!(await discoveryFileExists(toolsDir, input.context))) {
+    return [];
+  }
+
+  const files = (await findTypeScriptFiles(toolsDir, input.context)).sort((left, right) =>
+    left.localeCompare(right)
+  );
+  const registeredIds: string[] = [];
+
+  for (const file of files) {
+    try {
+      const module = await importModule(file, input.context);
+      for (const [shortName, moduleTool] of collectModuleTools(module, file)) {
+        const namespaced = namespaceAgentCapability(input.agentId, shortName);
+        if (!isProviderSafeToolName(namespaced)) {
+          input.result?.errors.push({
+            file,
+            error: ensureError(
+              `Colocated tool "${shortName}" for agent "${input.agentId}" produces an ` +
+                `invalid tool name "${namespaced}" (must match [A-Za-z0-9_-], max 64 chars).`,
+            ),
+          });
+          continue;
+        }
+        if (toolRegistry.get(namespaced)) {
+          continue;
+        }
+        reportShadowedGlobalCapability({
+          kind: "tool",
+          agentId: input.agentId,
+          shortName,
+          file,
+          result: input.result,
+        });
+        registerTool(namespaced, {
+          ...moduleTool,
+          id: namespaced,
+          ownerAgentId: input.agentId,
+          shortName,
+        });
+        registeredIds.push(namespaced);
+      }
+    } catch (error) {
+      input.result?.errors.push({ file, error: ensureError(error) });
+    }
+  }
+
+  return registeredIds;
+}
+
+async function buildSkillFromDir(input: {
+  id: string;
+  skillDir: string;
+  ownerAgentId: string;
+  shortName: string;
+  context: FileDiscoveryContext;
+}): Promise<Skill | null> {
+  const skillMdPath = `${input.skillDir}/${SKILL_MD_FILENAME}`;
+  if (!(await discoveryFileExists(skillMdPath, input.context))) {
+    return null;
+  }
+
+  const content = await readDiscoveryTextFile(skillMdPath, input.context);
+  const parsed = await parseSkillFrontmatter(content);
+  const metadata = validateSkillMetadata(parsed.frontmatter, input.id);
+
+  return {
+    id: input.id,
+    metadata,
+    rootPath: input.skillDir.replace(/^file:\/\//, ""),
+    ownerAgentId: input.ownerAgentId,
+    shortName: input.shortName,
+    ...(input.context.fsAdapter ? { fsAdapter: input.context.fsAdapter } : {}),
+  };
+}
+
+/**
+ * Registers an agent's colocated skills into the skill registry with owner
+ * metadata. The agent's own `SKILL.md` registers under the agent id; nested
+ * `skills/<sub>/SKILL.md` skills register under `{agentId}--{sub}`. Returns
+ * registered ids.
+ */
+export async function registerAgentColocatedSkills(
+  input: RegisterAgentColocatedCapabilitiesInput,
+): Promise<string[]> {
+  const candidates: Array<{ id: string; shortName: string; skillDir: string }> = [];
+
+  if (await discoveryFileExists(`${input.rootPath}/${SKILL_MD_FILENAME}`, input.context)) {
+    candidates.push({ id: input.agentId, shortName: input.agentId, skillDir: input.rootPath });
+  }
+
+  const skillsDir = `${input.rootPath}/${AGENT_SKILLS_SUBDIR}`;
+  const entries = (await listDiscoveryDirectoryEntries(skillsDir, input.context)).sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+  for (const entry of entries) {
+    if (!entry.isDirectory || !isSafePathSegment(entry.name)) {
+      continue;
+    }
+    candidates.push({
+      id: namespaceAgentCapability(input.agentId, entry.name),
+      shortName: entry.name,
+      skillDir: `${skillsDir}/${entry.name}`,
+    });
+  }
+
+  const registeredIds: string[] = [];
+  for (const candidate of candidates) {
+    try {
+      const skill = await buildSkillFromDir({
+        id: candidate.id,
+        skillDir: candidate.skillDir,
+        ownerAgentId: input.agentId,
+        shortName: candidate.shortName,
+        context: input.context,
+      });
+      if (!skill) {
+        continue;
+      }
+      if (candidate.shortName !== input.agentId) {
+        reportShadowedGlobalCapability({
+          kind: "skill",
+          agentId: input.agentId,
+          shortName: candidate.shortName,
+          file: `${candidate.skillDir}/${SKILL_MD_FILENAME}`,
+          result: input.result,
+        });
+      }
+      registerSkill(skill.id, skill);
+      registeredIds.push(skill.id);
+    } catch (error) {
+      input.result?.errors.push({
+        file: `${candidate.skillDir}/${SKILL_MD_FILENAME}`,
+        error: ensureError(error),
+      });
+    }
+  }
+
+  return registeredIds;
+}

--- a/src/discovery/agent-scoped-capabilities.ts
+++ b/src/discovery/agent-scoped-capabilities.ts
@@ -145,6 +145,7 @@ export async function registerAgentColocatedTools(
     left.localeCompare(right)
   );
   const registeredIds: string[] = [];
+  const seenThisPass = new Set<string>();
 
   for (const file of files) {
     try {
@@ -161,9 +162,22 @@ export async function registerAgentColocatedTools(
           });
           continue;
         }
-        if (toolRegistry.get(namespaced)) {
+        // Two colocated tools resolving to the same short name within one
+        // discovery pass is a user error — report it instead of silently
+        // keeping the first (a later "unknown tool" with no breadcrumb).
+        // A pre-existing registry entry from a previous pass is a normal
+        // re-discovery refresh and is overwritten.
+        if (seenThisPass.has(namespaced)) {
+          input.result?.errors.push({
+            file,
+            error: ensureError(
+              `Duplicate colocated tool "${shortName}" for agent "${input.agentId}": ` +
+                `another tools/ module already registered "${namespaced}"; keeping the first.`,
+            ),
+          });
           continue;
         }
+        seenThisPass.add(namespaced);
         reportShadowedGlobalCapability({
           kind: "tool",
           agentId: input.agentId,

--- a/src/discovery/agent-scoped-capabilities.ts
+++ b/src/discovery/agent-scoped-capabilities.ts
@@ -266,6 +266,7 @@ export async function registerAgentColocatedSkills(
         });
       }
       registerSkill(skill.id, skill);
+      input.result?.skills.set(skill.id, skill);
       registeredIds.push(skill.id);
     } catch (error) {
       input.result?.errors.push({

--- a/src/discovery/discovery-engine.ts
+++ b/src/discovery/discovery-engine.ts
@@ -176,6 +176,33 @@ export async function discoverAll(config: DiscoveryConfig): Promise<DiscoveryRes
     await discoverItems(`${baseDir}/${dir}`, result, context, toolHandler, config.verbose);
   }
 
+  // Clear stale skills before any skill registration so deleted/renamed
+  // skills are removed. Global skills are discovered BEFORE agents so that
+  // directory-agent colocated skills (registered during agent discovery)
+  // survive the clear and owned-short-name shadow diagnostics can see the
+  // global ids they shadow.
+  skillRegistry.clear();
+
+  // Discover skills (parallel path — markdown-based, not TypeScript import)
+  for (const dir of config.skillDirs ?? ["skills"]) {
+    const skillResult = await discoverSkills(
+      join(baseDir, dir),
+      context,
+      config.verbose,
+    );
+    for (const [id, skill] of skillResult.skills) {
+      if (result.skills.has(id)) {
+        logger.warn(`Duplicate skill "${id}" across discovery roots; keeping first registration`);
+        continue;
+      }
+      registerSkill(id, skill);
+      result.skills.set(id, skill);
+    }
+    result.errors.push(
+      ...skillResult.errors.map((e) => ({ file: e.file, error: e.error })),
+    );
+  }
+
   // Discover agents
   for (const dir of config.agentDirs ?? ["agents"]) {
     await discoverItems(`${baseDir}/${dir}`, result, context, agentHandler, config.verbose);
@@ -200,29 +227,6 @@ export async function discoverAll(config: DiscoveryConfig): Promise<DiscoveryRes
   // Discover tasks
   for (const dir of config.taskDirs ?? ["tasks"]) {
     await discoverItems(`${baseDir}/${dir}`, result, context, taskHandler, config.verbose);
-  }
-
-  // Clear stale skills before rediscovery so deleted/renamed skills are removed.
-  skillRegistry.clear();
-
-  // Discover skills (parallel path — markdown-based, not TypeScript import)
-  for (const dir of config.skillDirs ?? ["skills"]) {
-    const skillResult = await discoverSkills(
-      join(baseDir, dir),
-      context,
-      config.verbose,
-    );
-    for (const [id, skill] of skillResult.skills) {
-      if (result.skills.has(id)) {
-        logger.warn(`Duplicate skill "${id}" across discovery roots; keeping first registration`);
-        continue;
-      }
-      registerSkill(id, skill);
-      result.skills.set(id, skill);
-    }
-    result.errors.push(
-      ...skillResult.errors.map((e) => ({ file: e.file, error: e.error })),
-    );
   }
 
   return result;

--- a/src/discovery/handlers/runtime-agent-markdown-handler.ts
+++ b/src/discovery/handlers/runtime-agent-markdown-handler.ts
@@ -7,38 +7,131 @@ import { agentRegistry, registerAgent } from "../../agent/composition/index.ts";
 import { ensureError } from "#veryfront/errors/veryfront-error.ts";
 import type { DiscoveryResult, FileDiscoveryContext } from "../types.ts";
 import { trackAgentPath } from "../discovery-utils.ts";
-import { findMarkdownFiles, readDiscoveryTextFile } from "../file-discovery.ts";
+import {
+  discoveryFileExists,
+  listDiscoveryDirectoryEntries,
+  readDiscoveryTextFile,
+} from "../file-discovery.ts";
+import {
+  isSafePathSegment,
+  registerAgentColocatedSkills,
+  registerAgentColocatedTools,
+  sanitizeCapabilityNamespace,
+} from "../agent-scoped-capabilities.ts";
 
 const MARKDOWN_AGENT_FILE_PATTERN = /^[A-Za-z0-9._-]+\.md$/;
+const DIRECTORY_AGENT_FILENAME = "AGENT.md";
+const RESERVED_TOP_LEVEL_FILENAMES = new Set(["AGENT.md", "SKILL.md"]);
 
 type MarkdownAgentCandidate = {
   id: string;
   file: string;
+  rootPath?: string;
 };
 
-function getFileName(file: string): string {
-  return file.split("/").pop() ?? "";
-}
-
-function getMarkdownAgentCandidate(file: string): MarkdownAgentCandidate | null {
-  const fileName = getFileName(file);
+function getFlatAgentCandidate(dir: string, fileName: string): MarkdownAgentCandidate | null {
+  if (RESERVED_TOP_LEVEL_FILENAMES.has(fileName)) {
+    return null;
+  }
   if (!MARKDOWN_AGENT_FILE_PATTERN.test(fileName)) {
     return null;
   }
 
+  const id = fileName.slice(0, -".md".length);
+  // Reject `.`/`..` ids as defense-in-depth against path traversal.
+  if (!isSafePathSegment(id)) {
+    return null;
+  }
+
   return {
-    id: fileName.slice(0, -".md".length),
-    file,
+    id,
+    file: `${dir}/${fileName}`,
   };
 }
 
-function registerMarkdownAgent(
+async function getDirectoryAgentCandidate(
+  dir: string,
+  entryName: string,
+  context: FileDiscoveryContext,
+): Promise<MarkdownAgentCandidate | null> {
+  // Reject `.`/`..` and other non-segment names before joining into a path.
+  if (!isSafePathSegment(entryName)) {
+    return null;
+  }
+
+  const rootPath = `${dir}/${entryName}`;
+  const agentFile = `${rootPath}/${DIRECTORY_AGENT_FILENAME}`;
+  if (!(await discoveryFileExists(agentFile, context))) {
+    return null;
+  }
+
+  return { id: entryName, file: agentFile, rootPath };
+}
+
+/** Tracks sanitized capability namespaces to the agent that owns them. */
+type CapabilityNamespaceOwners = Map<string, string>;
+
+/**
+ * Registers a directory agent's colocated capabilities. This is PURE
+ * REGISTRATION — binding (`skills:` / `tools:` selectors) happens at
+ * invocation time via the owner-aware resolvers, identically for flat and
+ * directory agents.
+ *
+ * Two distinct agent ids can sanitize to the same provider-safe namespace
+ * (e.g. "a.b" and "a_b" -> "a_b"), which would collide owned capability ids;
+ * detected and reported instead of silently overwriting.
+ */
+async function registerColocatedCapabilities(
+  definition: RuntimeAgentMarkdownDefinition,
+  rootPath: string,
+  result: DiscoveryResult,
+  context: FileDiscoveryContext,
+  namespaceOwners: CapabilityNamespaceOwners,
+): Promise<void> {
+  const namespace = sanitizeCapabilityNamespace(definition.id);
+  const existingOwner = namespaceOwners.get(namespace);
+  if (existingOwner !== undefined && existingOwner !== definition.id) {
+    result.errors.push({
+      file: rootPath,
+      error: ensureError(
+        `Agent "${definition.id}" shares the sanitized capability namespace ` +
+          `"${namespace}" with agent "${existingOwner}". Rename one to avoid ` +
+          `colliding colocated tool/skill ids.`,
+      ),
+    });
+    return;
+  }
+  namespaceOwners.set(namespace, definition.id);
+
+  // Skills and tools live in disjoint subtrees; register them concurrently.
+  await Promise.all([
+    registerAgentColocatedSkills({ agentId: definition.id, rootPath, context, result }),
+    registerAgentColocatedTools({ agentId: definition.id, rootPath, context, result }),
+  ]);
+}
+
+async function registerMarkdownAgent(
   definition: RuntimeAgentMarkdownDefinition,
   file: string,
+  rootPath: string | undefined,
   result: DiscoveryResult,
-): void {
+  context: FileDiscoveryContext,
+  namespaceOwners: CapabilityNamespaceOwners,
+): Promise<void> {
   if (result.agents.has(definition.id)) {
+    result.errors.push({
+      file,
+      error: ensureError(
+        `Duplicate agent id "${definition.id}". An agent with this id was already ` +
+          `discovered (e.g. both a flat "${definition.id}.md" and a "${definition.id}/" ` +
+          `directory exist); keeping the first.`,
+      ),
+    });
     return;
+  }
+
+  if (rootPath) {
+    await registerColocatedCapabilities(definition, rootPath, result, context, namespaceOwners);
   }
 
   const runtimeAgent = createRuntimeAgentFromMarkdownDefinition(definition);
@@ -50,29 +143,63 @@ function registerMarkdownAgent(
   result.agents.set(definition.id, runtimeAgent);
 }
 
+async function discoverMarkdownAgentCandidate(
+  candidate: MarkdownAgentCandidate,
+  result: DiscoveryResult,
+  context: FileDiscoveryContext,
+  namespaceOwners: CapabilityNamespaceOwners,
+): Promise<void> {
+  try {
+    const definition = parseRuntimeAgentMarkdownDefinition({
+      id: candidate.id,
+      content: await readDiscoveryTextFile(candidate.file, context),
+    });
+    await registerMarkdownAgent(
+      definition,
+      candidate.file,
+      candidate.rootPath,
+      result,
+      context,
+      namespaceOwners,
+    );
+  } catch (error) {
+    result.errors.push({ file: candidate.file, error: ensureError(error) });
+  }
+}
+
+/**
+ * Discovers markdown agents from a directory.
+ *
+ * Supports two layouts side by side:
+ * - Flat: `agents/{id}.md`
+ * - Directory: `agents/{id}/AGENT.md` (+ colocated `SKILL.md` / `skills/` /
+ *   `tools/`, registered with owner metadata)
+ *
+ * Binding is NOT decided here: both layouts pass their parsed definition to
+ * the same adapter, and the owner-aware resolvers apply one rule for every
+ * agent kind at invocation time.
+ */
 export async function discoverRuntimeAgentMarkdownDefinitions(
   dir: string,
   result: DiscoveryResult,
   context: FileDiscoveryContext,
 ): Promise<void> {
-  const files = (await findMarkdownFiles(dir, context)).sort((left, right) =>
-    left.localeCompare(right)
+  const entries = (await listDiscoveryDirectoryEntries(dir, context)).sort((left, right) =>
+    left.name.localeCompare(right.name)
   );
+  const namespaceOwners: CapabilityNamespaceOwners = new Map();
 
-  for (const file of files) {
-    const candidate = getMarkdownAgentCandidate(file);
+  for (const entry of entries) {
+    const candidate = entry.isDirectory
+      ? await getDirectoryAgentCandidate(dir, entry.name, context)
+      : entry.isFile
+      ? getFlatAgentCandidate(dir, entry.name)
+      : null;
+
     if (!candidate) {
       continue;
     }
 
-    try {
-      const definition = parseRuntimeAgentMarkdownDefinition({
-        id: candidate.id,
-        content: await readDiscoveryTextFile(candidate.file, context),
-      });
-      registerMarkdownAgent(definition, candidate.file, result);
-    } catch (error) {
-      result.errors.push({ file: candidate.file, error: ensureError(error) });
-    }
+    await discoverMarkdownAgentCandidate(candidate, result, context, namespaceOwners);
   }
 }


### PR DESCRIPTION
## Summary

PR D of the agreed split (stacked on #2357; includes the #2355 helpers via cherry-pick until it merges). Directory-layout agents (`agents/{id}/AGENT.md`) ship their own `SKILL.md`, `skills/**`, and `tools/*.ts`.

**Discovery is pure registration** — the design change requested in the #2354 review: colocated capabilities register into the existing global registries namespaced **`{agentId}--{shortName}`** (the platform-decided separator: provider-safe, never confusable with `<provider>__<tool>` integration naming) with `ownerAgentId`/`shortName` metadata. No handler-resolved id lists, no adapter sentinel.

**Binding is uniform**: `skills:` / `tools:` (`true | [..]`) mean the same thing for TS, flat markdown, and directory markdown agents — all visible capabilities, or own-short-name-first then global id — resolved at invocation time by the owner-aware resolvers from #2357. `tools:` now actually binds for flat agents too (was a silent no-op in #2354), failing with an explicit unknown-tool diagnostic when unresolvable.

**Discovery diagnostics**: duplicate agent ids (flat + directory coexisting), sanitized-namespace collisions, owned-short-name vs global-id shadowing (plan test 15), invalid colocated tool names, `.`/`..` rejection.

**Capability isolation across delegation** (plan test 14): a coordinator's `skills: true` never includes its delegate's owned skills, and vice versa — tested on a real fixture project with `lead.md` (delegates) + `researcher/` (directory agent with own + nested skills).

## Known limitations (transparent)

- Hosted runtime: colocated skills resolve locally only until the catalog work lands (spike: framework adds owner/sourcePath to `RuntimeSkillDefinition`; control plane discovers `agents/*/SKILL.md`). The guides mark this explicitly.
- ~~Colocated `tools/*.ts` loading integration test~~ — now covered: `discoverAll()` loads a real colocated tool module through the esbuild transpiler, asserts owner-metadata registration (`researcher--fetch-paper`), owner execution, and not-found rejection for other agents (sanitizer baseline 420 → 422 for the two opt-outs).

## Testing

- `src/discovery/agent-scoped-capabilities.test.ts` — 7 tests on a real temp-dir fixture (side-by-side layouts, owner metadata, delegation isolation, duplicate-id, shadowing, namespace collision, path-segment guards)
- Full regression sweep green: `src/discovery src/skill src/tool src/mcp src/agent/runtime`

## Type of Change
- [x] New feature (non-breaking)
- [x] Documentation update
- [x] Test update
