### PR TITLE
Carry owner metadata through the hosted skill catalog and scope runs by agent

### DIFF
--- a/src/agent/hosted/chat-preparation.test.ts
+++ b/src/agent/hosted/chat-preparation.test.ts
@@ -690,6 +690,9 @@ Deno.test("prepareHostedChatRuntimeCreationOptions filters skills to the run age
   // the returned steering all carry the same owner-scoped set.
   assertEquals(seenByInstructions, [expected]);
   assertEquals(result.creationOptions.availableSkillIds, expected);
+  assertEquals(result.creationOptions.skillSourcePaths, {
+    "researcher--cite": "agents/researcher/skills/cite/SKILL.md",
+  });
   assertEquals(
     (result.creationOptions.liveProjectSteering?.initialSkills ?? []).map((
       skill: { id: string },

--- a/src/agent/hosted/chat-preparation.test.ts
+++ b/src/agent/hosted/chat-preparation.test.ts
@@ -635,3 +635,66 @@ Deno.test("prepareHostedChatRuntimeMessages omits provider-owned remote tool his
     text: "Unlimited tax liability is based on Chapter 3 of the Income Tax Act.",
   }]);
 });
+
+Deno.test("prepareHostedChatRuntimeCreationOptions filters skills to the run agent's owner scope", async () => {
+  const skills = [
+    {
+      id: "global-howto",
+      name: "Global Howto",
+      description: "Project-global guide",
+      instructions: "Follow the guide.",
+      allowedTools: [],
+    },
+    {
+      id: "researcher--cite",
+      name: "cite",
+      description: "Cite sources",
+      instructions: "Cite primary sources.",
+      allowedTools: [],
+      ownerAgentId: "researcher",
+      shortName: "cite",
+      sourcePath: "agents/researcher/skills/cite/SKILL.md",
+    },
+    {
+      id: "writer--style",
+      name: "style",
+      description: "House style",
+      instructions: "Use the house style.",
+      allowedTools: [],
+      ownerAgentId: "writer",
+      shortName: "style",
+    },
+  ];
+  const seenByInstructions: string[][] = [];
+
+  const result = await prepareHostedChatRuntimeCreationOptions({
+    request: createParsedHostedChatRequest({}),
+    agentConfig: { id: "researcher", model: "configured-model" },
+    projectId: "project-1",
+    authToken: "token-1",
+    resolveModelId: (modelId) => modelId,
+    resolveModelThinking: () => undefined,
+    fetchSteering: () =>
+      Promise.resolve({
+        instructions: "Project instructions",
+        skills,
+      }),
+    buildInstructions: (input) => {
+      seenByInstructions.push(input.skills.map((entry) => entry.id));
+      return [{ role: "system", content: "x" }];
+    },
+  });
+
+  const expected = ["global-howto", "researcher--cite"];
+  // Prompt-manifest input, per-run load_skill gate, live steering payload, and
+  // the returned steering all carry the same owner-scoped set.
+  assertEquals(seenByInstructions, [expected]);
+  assertEquals(result.creationOptions.availableSkillIds, expected);
+  assertEquals(
+    (result.creationOptions.liveProjectSteering?.initialSkills ?? []).map((
+      skill: { id: string },
+    ) => skill.id),
+    expected,
+  );
+  assertEquals(result.steering.skills.map((skill) => skill.id), expected);
+});

--- a/src/agent/hosted/chat-preparation.ts
+++ b/src/agent/hosted/chat-preparation.ts
@@ -320,6 +320,15 @@ export async function prepareHostedChatRuntimeCreationOptions<
         ? { parentMessageId: input.rootRunContext.effectiveParentMessageId }
         : {}),
       availableSkillIds: visibleSkills.map((skill) => skill.id),
+      ...(visibleSkills.some((skill) => skill.sourcePath)
+        ? {
+          skillSourcePaths: Object.fromEntries(
+            visibleSkills
+              .filter((skill) => skill.sourcePath)
+              .map((skill) => [skill.id, skill.sourcePath as string]),
+          ),
+        }
+        : {}),
       ...(input.rootRunContext?.publishParentRunEvents
         ? { publishParentRunEvents: input.rootRunContext.publishParentRunEvents }
         : {}),

--- a/src/agent/hosted/chat-preparation.ts
+++ b/src/agent/hosted/chat-preparation.ts
@@ -26,7 +26,7 @@ import {
   resolveHostedRuntimeRequestConfig,
 } from "./runtime-request-config.ts";
 import { getRuntimeUploadUrl } from "../runtime/upload-url-client.ts";
-import type { RuntimeSkillDefinition } from "../runtime/skill-metadata.ts";
+import { isRuntimeSkillVisibleTo, type RuntimeSkillDefinition } from "../runtime/skill-metadata.ts";
 import {
   applyContextBudget,
   type ContextBudgetDiagnostics,
@@ -266,13 +266,20 @@ export async function prepareHostedChatRuntimeCreationOptions<
     authToken: input.authToken,
     branchId: input.branchId,
   });
+  // Owner-aware: the run only ever sees skills visible to its agent (unowned
+  // plus the agent's own). Filtering here scopes the prompt manifest, the
+  // per-run availableSkillIds gate used by hosted load_skill, its not-found
+  // enumeration, and the live steering payload in one place.
+  const visibleSkills = steering.skills.filter((skill) =>
+    isRuntimeSkillVisibleTo(skill, { agentId: input.agentConfig.id })
+  );
   const agentInstructions = input.buildInstructions({
     agentConfig: input.agentConfig,
     projectId: input.projectId,
     branchId: input.branchId,
     environmentContext: input.environmentContext,
     instructions: steering.instructions,
-    skills: steering.skills,
+    skills: visibleSkills,
   });
   const runtimeConfig = resolveHostedRuntimeRequestConfig({
     request: input.request,
@@ -312,7 +319,7 @@ export async function prepareHostedChatRuntimeCreationOptions<
       ...(input.rootRunContext?.effectiveParentMessageId
         ? { parentMessageId: input.rootRunContext.effectiveParentMessageId }
         : {}),
-      availableSkillIds: steering.skills.map((skill) => skill.id),
+      availableSkillIds: visibleSkills.map((skill) => skill.id),
       ...(input.rootRunContext?.publishParentRunEvents
         ? { publishParentRunEvents: input.rootRunContext.publishParentRunEvents }
         : {}),
@@ -321,11 +328,12 @@ export async function prepareHostedChatRuntimeCreationOptions<
         agentConfig: input.agentConfig,
         environmentContext: input.environmentContext,
         instructions: steering.instructions,
-        skills: steering.skills,
+        skills: visibleSkills,
       }),
     },
     steering: {
       ...steering,
+      skills: visibleSkills,
       agentInstructions,
     },
     runtimeConfig,

--- a/src/agent/hosted/chat-runtime-contract.ts
+++ b/src/agent/hosted/chat-runtime-contract.ts
@@ -107,6 +107,8 @@ export type HostedChatRuntimeCreationOptions<TRuntimeAgentDefinition, TThinkingC
   parentRunId?: string;
   parentMessageId?: string;
   availableSkillIds?: string[];
+  /** Per-run skill id -> discovered SKILL.md source path (owner-aware catalog). */
+  skillSourcePaths?: Readonly<Record<string, string>>;
   publishParentRunEvents?: (events: ConversationRunEvent[]) => Promise<void>;
   clientProfile?: RuntimeClientProfile | null;
   liveProjectSteering?: HostedChatRuntimeProjectSteering<TRuntimeAgentDefinition>;

--- a/src/agent/hosted/default-chat-runtime.ts
+++ b/src/agent/hosted/default-chat-runtime.ts
@@ -79,6 +79,8 @@ export type DefaultHostedChatRuntimeTaskContext = HostedRuntimeStateResolverCont
   parentRunId?: string;
   parentMessageId?: string;
   availableSkillIds?: string[];
+  /** Per-run skill id -> discovered SKILL.md source path (owner-aware catalog). */
+  skillSourcePaths?: Readonly<Record<string, string>>;
   publishParentRunEvents?: DefaultHostedChatRuntimeCreationOptions["publishParentRunEvents"];
   availableToolNames?: string[];
 };
@@ -149,6 +151,7 @@ function createDefaultTaskContext(
     parentRunId: input.options.parentRunId,
     parentMessageId: input.options.parentMessageId,
     availableSkillIds: input.options.availableSkillIds,
+    skillSourcePaths: input.options.skillSourcePaths,
     publishParentRunEvents: input.options.publishParentRunEvents,
   };
 }

--- a/src/agent/hosted/default-project-steering-refresh.test.ts
+++ b/src/agent/hosted/default-project-steering-refresh.test.ts
@@ -146,6 +146,30 @@ describe("agent/default-hosted-project-steering-refresh", () => {
     assertEquals(system.includes("Current run tool inventory:"), true);
   });
 
+  it("keeps an empty visible skill set restrictive during refresh", async () => {
+    const refresh = createDefaultHostedProjectSteeringRefresh({
+      fetchProjectInstructions: () => Promise.resolve("Fresh instructions"),
+      fetchSkills: () => Promise.resolve([createSkill("other-agent--private")]),
+      buildInstructions: (input) =>
+        `${input.instructions}:${input.skills.map((skill) => skill.id).join(",")}`,
+    });
+
+    const system = await refresh(
+      createRefreshInput({
+        taskContext: {
+          authToken: "auth-token",
+          projectId: "project-1",
+          branchId: "branch-1",
+          model: "openai/gpt-test",
+          availableSkillIds: [],
+        },
+      }),
+    );
+
+    assertEquals(system.includes("Fresh instructions:other-agent--private"), false);
+    assertEquals(system.includes("Fresh instructions:"), true);
+  });
+
   it("keeps provider-native tools in refreshed runtime inventory", async () => {
     const refresh = createDefaultHostedProjectSteeringRefresh({
       fetchProjectInstructions: () => Promise.resolve("Fresh instructions"),

--- a/src/agent/hosted/default-project-steering-refresh.ts
+++ b/src/agent/hosted/default-project-steering-refresh.ts
@@ -165,7 +165,7 @@ function filterVisibleSkills(input: {
   skills: RuntimeSkillDefinition[];
   allowedSkillIds?: string[];
 }): RuntimeSkillDefinition[] {
-  if (!input.allowedSkillIds || input.allowedSkillIds.length === 0) {
+  if (!input.allowedSkillIds) {
     return input.skills;
   }
 

--- a/src/agent/hosted/project-steering-adapter.test.ts
+++ b/src/agent/hosted/project-steering-adapter.test.ts
@@ -183,3 +183,60 @@ Deno.test("hosted project steering adapter accepts a custom builtin skill store"
     assertEquals(referenceCalls, [{ skillsDir, skillId: "custom" }]);
   });
 });
+
+Deno.test("refreshProjectSkillIds keeps the caller's owner scope and source paths", async () => {
+  await withSkillsDir(async (skillsDir) => {
+    const skillMd = (name: string) =>
+      `---
+name: ${name}
+description: ${name} skill
+---
+Body.`;
+    const adapter = createHostedProjectSteeringAdapter({
+      apiUrl: "https://api.example.test",
+      skillsDir,
+      projectFilesClient: createProjectFilesClient({
+        getProjectFile: async ({ path }) =>
+          path === "skills/global/SKILL.md" ||
+            path === "agents/researcher/skills/cite/SKILL.md" ||
+            path === "agents/writer/skills/style/SKILL.md"
+            ? { path, content: skillMd(path) }
+            : null,
+        getProjectFiles: async () => [
+          { path: "skills/global/SKILL.md" },
+          { path: "agents/researcher/skills/cite/SKILL.md" },
+          { path: "agents/writer/skills/style/SKILL.md" },
+        ],
+      }),
+    });
+
+    // With an agent scope: unowned + own, never another agent's owned skill;
+    // the source-path map refreshes alongside.
+    const researcherContext = {
+      projectId: "project-1",
+      authToken: "token-1",
+      branchId: null,
+      agentId: "researcher",
+      availableSkillIds: ["stale-id"],
+      skillSourcePaths: { "stale-id": "skills/stale/SKILL.md" } as Readonly<
+        Record<string, string>
+      >,
+    };
+    await adapter.refreshProjectSkillIds(researcherContext);
+    assertEquals(researcherContext.availableSkillIds, ["builtin", "global", "researcher--cite"]);
+    assertEquals(researcherContext.skillSourcePaths, {
+      global: "skills/global/SKILL.md",
+      "researcher--cite": "agents/researcher/skills/cite/SKILL.md",
+    });
+
+    // Without an agent scope: conservative project-level rule (unowned only).
+    const projectContext = {
+      projectId: "project-1",
+      authToken: "token-1",
+      branchId: null,
+      availableSkillIds: [],
+    };
+    await adapter.refreshProjectSkillIds(projectContext);
+    assertEquals(projectContext.availableSkillIds, ["builtin", "global"]);
+  });
+});

--- a/src/agent/hosted/project-steering-adapter.ts
+++ b/src/agent/hosted/project-steering-adapter.ts
@@ -37,6 +37,7 @@ import type {
   RuntimeSkillDefinition,
   RuntimeSkillMetadataLogger,
 } from "../runtime/skill-metadata.ts";
+import { isRuntimeSkillVisibleTo } from "../runtime/skill-metadata.ts";
 
 /** Public API contract for hosted project steering logger. */
 export type HostedProjectSteeringLogger =
@@ -59,6 +60,13 @@ export type HostedProjectSteeringAdapterOptions = {
 /** Context for hosted project skill IDs. */
 export type HostedProjectSkillIdsContext = MutableAgentProjectContext & {
   authToken: string;
+  /**
+   * Id of the agent this run executes as. Refreshes scope the rewritten
+   * skill set to this agent (unowned + own); when absent, the conservative
+   * project-level rule applies (unowned only) — a refresh can never widen
+   * visibility beyond the caller's scope.
+   */
+  agentId?: string;
 };
 
 /** Public API contract for hosted project steering adapter. */
@@ -183,7 +191,21 @@ export function createHostedProjectSteeringAdapter(
         branchId: context.branchId,
       });
 
-      context.availableSkillIds = skills.map((skill) => skill.id);
+      // Owner-aware: the refreshed per-run skill set keeps the caller's
+      // scope — never another agent's owned skills — and the source-path
+      // map stays in sync so colocated skills do not go stale.
+      const visibleSkills = skills.filter((skill) =>
+        isRuntimeSkillVisibleTo(skill, { agentId: context.agentId })
+      );
+      context.availableSkillIds = visibleSkills.map((skill) => skill.id);
+      const skillSourcePaths = Object.fromEntries(
+        visibleSkills
+          .filter((skill) => skill.sourcePath)
+          .map((skill) => [skill.id, skill.sourcePath as string]),
+      );
+      context.skillSourcePaths = Object.keys(skillSourcePaths).length > 0
+        ? skillSourcePaths
+        : undefined;
     },
   };
 }

--- a/src/agent/hosted/veryfront-cloud-agent-service.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.ts
@@ -742,10 +742,9 @@ function createAgentRuntime(
     refreshSystem,
     onSteeringMutation: async ({ mutation, taskContext }) => {
       if (mutation.skillsChanged) {
-        await refreshProjectSkillIds(context, {
-          ...taskContext,
-          authToken: taskContext.authToken,
-        });
+        // Pass the live task context (not a spread copy) so the refreshed
+        // owner-scoped skill ids and source paths actually land on the run.
+        await refreshProjectSkillIds(context, taskContext);
       }
     },
     onStudioProjectSwitch: async ({ projectId, taskContext }) => {
@@ -753,10 +752,7 @@ function createAgentRuntime(
         return false;
       }
 
-      await refreshProjectSkillIds(context, {
-        ...taskContext,
-        authToken: taskContext.authToken,
-      });
+      await refreshProjectSkillIds(context, taskContext);
       return true;
     },
     projectScopedRemoteToolOptions: {

--- a/src/agent/project/context.test.ts
+++ b/src/agent/project/context.test.ts
@@ -11,6 +11,7 @@ Deno.test("applyAgentProjectContextChange updates project and resets branch and 
     projectId: "project-1",
     branchId: "branch-1",
     availableSkillIds: ["skill-a"],
+    skillSourcePaths: { "skill-a": "skills/skill-a/SKILL.md" },
     steeringRevision: 3,
   };
 
@@ -21,6 +22,7 @@ Deno.test("applyAgentProjectContextChange updates project and resets branch and 
     projectId: "project-2",
     branchId: null,
     availableSkillIds: undefined,
+    skillSourcePaths: undefined,
     steeringRevision: 3,
   });
 });

--- a/src/agent/project/context.ts
+++ b/src/agent/project/context.ts
@@ -3,6 +3,8 @@ export interface MutableAgentProjectContext {
   projectId: string;
   branchId?: string | null;
   availableSkillIds?: string[];
+  /** Per-run skill id -> discovered SKILL.md source path (owner-aware catalog). */
+  skillSourcePaths?: Readonly<Record<string, string>>;
 }
 
 /** Apply agent project context change helper. */
@@ -17,6 +19,7 @@ export function applyAgentProjectContextChange(
   context.projectId = projectId;
   context.branchId = null;
   context.availableSkillIds = undefined;
+  context.skillSourcePaths = undefined;
   return true;
 }
 

--- a/src/agent/project/steering-mutation.test.ts
+++ b/src/agent/project/steering-mutation.test.ts
@@ -64,6 +64,36 @@ Deno.test("getProjectSteeringMutation detects legacy hidden skill directory move
   );
 });
 
+Deno.test("getProjectSteeringMutation detects colocated skill writes", () => {
+  assertEquals(
+    getProjectSteeringMutation({
+      toolName: "update_file",
+      toolInput: {
+        project_reference: "project-1",
+        branch_id: "branch-1",
+        path: "agents/researcher/SKILL.md",
+      },
+      activeProjectId: "project-1",
+      activeBranchId: "branch-1",
+    }),
+    { instructionsChanged: false, skillsChanged: true },
+  );
+
+  assertEquals(
+    getProjectSteeringMutation({
+      toolName: "update_file",
+      toolInput: {
+        project_reference: "project-1",
+        branch_id: "branch-1",
+        path: "agents/researcher/skills/cite/references/style.md",
+      },
+      activeProjectId: "project-1",
+      activeBranchId: "branch-1",
+    }),
+    { instructionsChanged: false, skillsChanged: true },
+  );
+});
+
 Deno.test("getProjectSteeringMutation ignores mutations for other projects", () => {
   assertEquals(
     getProjectSteeringMutation({

--- a/src/agent/project/steering-mutation.ts
+++ b/src/agent/project/steering-mutation.ts
@@ -44,10 +44,19 @@ function getPathMutationFlags(
 ): ProjectSteeringMutationResult {
   return {
     instructionsChanged: steeringPaths.instructions.includes(path),
-    skillsChanged: steeringPaths.skills.some((prefix) =>
-      path === prefix || path.startsWith(`${prefix}/`)
-    ),
+    skillsChanged: isProjectSkillMutationPath(path, steeringPaths),
   };
+}
+
+function isProjectSkillMutationPath(
+  path: string,
+  steeringPaths: ProjectSteeringPaths,
+): boolean {
+  if (steeringPaths.skills.some((prefix) => path === prefix || path.startsWith(`${prefix}/`))) {
+    return true;
+  }
+
+  return /^agents\/[^/]+\/(?:SKILL\.md|references\/|skills\/[^/]+\/)/.test(path);
 }
 
 function mergeMutationFlags(

--- a/src/agent/runtime/project-skill-catalog.test.ts
+++ b/src/agent/runtime/project-skill-catalog.test.ts
@@ -195,3 +195,62 @@ Deno.test("getRuntimeProjectSkillCatalog still parses legacy hidden project skil
   assertEquals(skills.map((skill) => skill.id), ["legacy"]);
   assertEquals(fileCalls.map((call) => call.path), [".veryfront/skills/legacy/SKILL.md"]);
 });
+
+// ── Colocated (agent-owned) skills in the catalog (review finding) ────────
+
+const CITE_SKILL_MD = `---
+name: cite
+description: Cite sources properly
+---
+Cite primary sources.
+`;
+
+const RESEARCHER_SKILL_MD = `---
+name: researcher
+description: Research methodology
+---
+Follow the method.
+`;
+
+Deno.test("catalog includes colocated skills with owner metadata and source paths", async () => {
+  const { catalog } = createSkillCatalog({
+    paths: [
+      "agents/researcher/AGENT.md",
+      "agents/researcher/SKILL.md",
+      "agents/researcher/skills/cite/SKILL.md",
+      "agents/researcher/skills/cite/references/styles.md",
+    ],
+    contentsByPath: {
+      "agents/researcher/SKILL.md": RESEARCHER_SKILL_MD,
+      "agents/researcher/skills/cite/SKILL.md": CITE_SKILL_MD,
+    },
+  });
+
+  const skills = await catalog();
+  const ids = skills.map((skill) => skill.id).sort();
+  assertEquals(ids, ["researcher", "researcher--cite"]);
+
+  const nested = skills.find((skill) => skill.id === "researcher--cite");
+  assertEquals(nested?.ownerAgentId, "researcher");
+  assertEquals(nested?.shortName, "cite");
+  assertEquals(nested?.sourcePath, "agents/researcher/skills/cite/SKILL.md");
+  assertEquals(nested?.references, ["references/styles.md"]);
+
+  const own = skills.find((skill) => skill.id === "researcher");
+  assertEquals(own?.ownerAgentId, "researcher");
+  assertEquals(own?.sourcePath, "agents/researcher/SKILL.md");
+});
+
+Deno.test("catalog keeps global skills unowned and carries their source paths", async () => {
+  const { catalog } = createSkillCatalog({
+    paths: ["skills/gmail/SKILL.md"],
+    contentsByPath: {
+      "skills/gmail/SKILL.md": CITE_SKILL_MD,
+    },
+  });
+
+  const skills = await catalog();
+  assertEquals(skills.length, 1);
+  assertEquals(skills[0]?.ownerAgentId, undefined);
+  assertEquals(skills[0]?.sourcePath, "skills/gmail/SKILL.md");
+});

--- a/src/agent/runtime/project-skill-catalog.ts
+++ b/src/agent/runtime/project-skill-catalog.ts
@@ -194,6 +194,53 @@ export async function getRuntimeProjectSkillCatalog(
         id,
         content: file.content,
         references: getProjectSkillReferences({ allFiles, file, isFlat }),
+        sourcePath: file.path,
+        logger: input.logger,
+      });
+
+      if (definition && !projectSkillsById.has(definition.id)) {
+        projectSkillsById.set(definition.id, definition);
+      }
+    }
+  }
+
+  // Colocated (agent-owned) skills: agents/{id}/SKILL.md (the agent's own
+  // skill) and agents/{id}/skills/{sub}/SKILL.md. Registered with owner
+  // metadata so per-run filtering and the source-path loader can apply the
+  // one owner-aware rule; ids match framework/control-plane discovery.
+  const colocatedPaths = allFiles
+    .map((file) => file.path)
+    .filter((path) => getColocatedSkillIdentity(path) !== null)
+    .sort();
+
+  if (colocatedPaths.length > 0) {
+    const colocatedFiles = await Promise.all(
+      colocatedPaths.map((path) =>
+        input.getProjectFile({
+          projectId: input.projectId,
+          authToken: input.authToken,
+          branchId: input.branchId,
+          path,
+        })
+      ),
+    );
+
+    for (const file of colocatedFiles) {
+      if (!file?.content) {
+        continue;
+      }
+      const identity = getColocatedSkillIdentity(file.path);
+      if (!identity) {
+        continue;
+      }
+
+      const definition = buildRuntimeSkillDefinition({
+        id: identity.id,
+        content: file.content,
+        references: getProjectSkillReferences({ allFiles, file, isFlat: false }),
+        ownerAgentId: identity.ownerAgentId,
+        shortName: identity.shortName,
+        sourcePath: file.path,
         logger: input.logger,
       });
 
@@ -213,6 +260,49 @@ export async function getRuntimeProjectSkillCatalog(
   }
 
   return sortSkillsById(mergedSkillsById.values());
+}
+
+/**
+ * Owned-capability namespace rule. Mirrors discovery
+ * (src/discovery/agent-scoped-capabilities.ts) and the control plane's skill
+ * source derivation; duplicated locally because the runtime layer must not
+ * import from discovery.
+ */
+const AGENT_CAPABILITY_NAMESPACE_SEPARATOR = "--";
+
+function sanitizeCapabilityNamespace(agentId: string): string {
+  return agentId.replace(/[^A-Za-z0-9_-]/g, "_");
+}
+
+const COLOCATED_OWN_SKILL_REGEX = /^agents\/([^/]+)\/SKILL\.md$/;
+const COLOCATED_NESTED_SKILL_REGEX = /^agents\/([^/]+)\/skills\/([^/]+)\/SKILL\.md$/;
+
+type ColocatedSkillIdentity = {
+  id: string;
+  ownerAgentId: string;
+  shortName: string;
+};
+
+function getColocatedSkillIdentity(path: string): ColocatedSkillIdentity | null {
+  const nested = path.match(COLOCATED_NESTED_SKILL_REGEX);
+  const nestedAgentId = nested?.[1];
+  const nestedShortName = nested?.[2];
+  if (nestedAgentId && nestedShortName) {
+    return {
+      id: `${
+        sanitizeCapabilityNamespace(nestedAgentId)
+      }${AGENT_CAPABILITY_NAMESPACE_SEPARATOR}${nestedShortName}`,
+      ownerAgentId: nestedAgentId,
+      shortName: nestedShortName,
+    };
+  }
+
+  const ownAgentId = path.match(COLOCATED_OWN_SKILL_REGEX)?.[1];
+  if (ownAgentId) {
+    return { id: ownAgentId, ownerAgentId: ownAgentId, shortName: ownAgentId };
+  }
+
+  return null;
 }
 
 function getProjectSkillId(path: string, isFlat: boolean): string | null {

--- a/src/agent/runtime/project-skill-loader.test.ts
+++ b/src/agent/runtime/project-skill-loader.test.ts
@@ -205,3 +205,80 @@ Deno.test("runtime project skill loader returns null and logs when lookup is den
     },
   ]);
 });
+
+// ── Catalog sourcePath resolution (colocated/owned skills) ────────────────
+
+const COLOCATED_CONTEXT = {
+  ...PROJECT_CONTEXT,
+  skillSourcePaths: {
+    "researcher--cite": "agents/researcher/skills/cite/SKILL.md",
+  },
+};
+
+Deno.test("loadProjectSkill resolves a colocated skill at its catalog sourcePath", async () => {
+  const { loader, fileCalls } = createLoader({
+    getProjectFile: (options) =>
+      Promise.resolve(
+        options.path === "agents/researcher/skills/cite/SKILL.md"
+          ? { path: options.path, content: "Cite primary sources." }
+          : null,
+      ),
+  });
+
+  const skill = await loader.loadProjectSkill(COLOCATED_CONTEXT, "researcher--cite");
+
+  assertEquals(skill?.instructions, "Cite primary sources.");
+  // The namespaced id must never be probed as skills/{id}/SKILL.md.
+  assertEquals(
+    fileCalls.some((call) => call.path.includes("skills/researcher--cite")),
+    false,
+  );
+});
+
+Deno.test("loadProjectSkillReference reads reference files from the catalog skill dir", async () => {
+  const { loader } = createLoader({
+    getProjectFile: (options) =>
+      Promise.resolve(
+        options.path === "agents/researcher/skills/cite/references/styles.md"
+          ? { path: options.path, content: "APA or MLA." }
+          : null,
+      ),
+  });
+
+  const content = await loader.loadProjectSkillReference(
+    COLOCATED_CONTEXT,
+    "researcher--cite",
+    "references/styles.md",
+  );
+
+  assertEquals(content, "APA or MLA.");
+});
+
+Deno.test("listProjectSkillReferences lists references under the catalog skill dir", async () => {
+  const { loader } = createLoader({
+    getProjectFiles: () =>
+      Promise.resolve([
+        { path: "agents/researcher/skills/cite/references/styles.md" },
+        { path: "agents/researcher/skills/cite/references/journals.md" },
+        { path: "skills/other/references/nope.md" },
+      ] as RuntimeProjectFileListItem[]),
+  });
+
+  const references = await loader.listProjectSkillReferences(
+    COLOCATED_CONTEXT,
+    "researcher--cite",
+  );
+
+  assertEquals(references, ["references/journals.md", "references/styles.md"]);
+});
+
+Deno.test("loader falls back to steering-path probing without a catalog entry", async () => {
+  const { loader, fileCalls } = createLoader();
+
+  await loader.loadProjectSkill(PROJECT_CONTEXT, "plain-skill");
+
+  assertEquals(
+    fileCalls.some((call) => call.path.endsWith("/plain-skill/SKILL.md")),
+    true,
+  );
+});

--- a/src/agent/runtime/project-skill-loader.ts
+++ b/src/agent/runtime/project-skill-loader.ts
@@ -15,6 +15,15 @@ export type RuntimeProjectSkillContext = {
   projectId?: string | null;
   authToken: string;
   branchId?: string | null;
+  /**
+   * Per-run map of skill id to its discovered SKILL.md source path (from the
+   * owner-aware catalog). When present for an id, the loader resolves the
+   * skill and its references at that real path instead of probing
+   * `{skillsPath}/{skillId}/...` — required for colocated skills whose
+   * namespaced ids (e.g. `researcher--cite`) do not correspond to a
+   * `skills/{id}/` directory.
+   */
+  skillSourcePaths?: Readonly<Record<string, string>>;
 };
 
 /** Public API contract for runtime loaded project skill. */
@@ -69,7 +78,31 @@ function isAccessDeniedError(
 
 type ProjectSkillSource =
   | { kind: "directory"; skillsPath: string }
-  | { kind: "flat"; skillsPath: string };
+  | { kind: "flat"; skillsPath: string }
+  | { kind: "explicit"; skillDir: string };
+
+/** Directory containing the skill's files, per source kind. */
+function getSkillDir(source: ProjectSkillSource, skillId: string): string | null {
+  if (source.kind === "explicit") {
+    return source.skillDir;
+  }
+  if (source.kind === "directory") {
+    return `${source.skillsPath}/${skillId}`;
+  }
+  return null;
+}
+
+/** Resolves a skill's directory from the per-run catalog source path, if any. */
+function resolveCatalogSkillDir(
+  context: RuntimeProjectSkillContext,
+  skillId: string,
+): string | null {
+  const sourcePath = context.skillSourcePaths?.[skillId];
+  if (!sourcePath || !sourcePath.endsWith("/SKILL.md")) {
+    return null;
+  }
+  return sourcePath.slice(0, -"/SKILL.md".length);
+}
 
 async function findProjectSkillSource(input: {
   options: RuntimeProjectSkillLoaderOptions;
@@ -79,6 +112,11 @@ async function findProjectSkillSource(input: {
   const projectId = input.context.projectId;
   if (!projectId) {
     return null;
+  }
+
+  const catalogSkillDir = resolveCatalogSkillDir(input.context, input.skillId);
+  if (catalogSkillDir) {
+    return { kind: "explicit", skillDir: catalogSkillDir };
   }
 
   for (const skillsPath of getSkillPaths(input.options)) {
@@ -108,10 +146,9 @@ async function findProjectSkillSource(input: {
 
 function collectProjectSkillReferences(input: {
   allFiles: readonly RuntimeProjectFileListItem[];
-  skillsPath: string;
-  skillId: string;
+  skillDir: string;
 }): string[] {
-  const skillPrefix = `${input.skillsPath}/${input.skillId}/`;
+  const skillPrefix = `${input.skillDir}/`;
   const refsPrefix = `${skillPrefix}references/`;
   const references = new Set<string>();
 
@@ -148,7 +185,8 @@ async function listProjectSkillReferences(input: {
   const source: ProjectSkillSource | null = input.skillsPath
     ? { kind: "directory", skillsPath: input.skillsPath }
     : await findProjectSkillSource(input);
-  if (source?.kind !== "directory") {
+  const skillDir = source ? getSkillDir(source, input.skillId) : null;
+  if (!skillDir) {
     return [];
   }
 
@@ -160,8 +198,7 @@ async function listProjectSkillReferences(input: {
 
   return collectProjectSkillReferences({
     allFiles,
-    skillsPath: source.skillsPath,
-    skillId: input.skillId,
+    skillDir,
   });
 }
 
@@ -176,6 +213,22 @@ async function loadProjectSkill(input: {
   }
 
   try {
+    const catalogSkillDir = resolveCatalogSkillDir(input.context, input.skillId);
+    if (catalogSkillDir) {
+      const catalogSkill = await input.options.getProjectFile({
+        projectId,
+        authToken: input.context.authToken,
+        branchId: input.context.branchId,
+        path: `${catalogSkillDir}/SKILL.md`,
+      });
+      if (catalogSkill?.content) {
+        return {
+          instructions: catalogSkill.content,
+          references: await listProjectSkillReferences(input),
+        };
+      }
+    }
+
     for (const skillsPath of getSkillPaths(input.options)) {
       const directorySkill = await input.options.getProjectFile({
         projectId,
@@ -237,7 +290,8 @@ async function loadProjectSkillReference(input: {
 
   try {
     const source = await findProjectSkillSource(input);
-    if (source?.kind !== "directory") {
+    const skillDir = source ? getSkillDir(source, input.skillId) : null;
+    if (!skillDir) {
       return null;
     }
 
@@ -245,7 +299,7 @@ async function loadProjectSkillReference(input: {
       projectId,
       authToken: input.context.authToken,
       branchId: input.context.branchId,
-      path: `${source.skillsPath}/${input.skillId}/${input.normalizedFile}`,
+      path: `${skillDir}/${input.normalizedFile}`,
     });
     if (projectFile?.content) {
       return projectFile.content;

--- a/src/agent/runtime/skill-metadata.ts
+++ b/src/agent/runtime/skill-metadata.ts
@@ -68,7 +68,31 @@ export type RuntimeSkillDefinition = {
   thinking?: false | number;
   maxSteps?: number;
   references?: string[];
+  /**
+   * Owning agent id for agent-scoped (colocated) skills. Unowned (undefined)
+   * skills are project-global; owned skills are visible only to their owner.
+   */
+  ownerAgentId?: string;
+  /** Short name used by the owning agent's `skills:` selector (e.g. "cite"). */
+  shortName?: string;
+  /**
+   * Actual discovered source path of the skill's SKILL.md. Consumers must use
+   * this instead of reconstructing paths from (possibly namespaced) ids.
+   */
+  sourcePath?: string;
 };
+
+/**
+ * Whether a runtime skill definition is visible to the caller identified by
+ * the scope — the same owner-aware rule as the local skill registry: unowned
+ * skills plus the caller's own.
+ */
+export function isRuntimeSkillVisibleTo(
+  definition: Pick<RuntimeSkillDefinition, "ownerAgentId">,
+  scope?: { agentId?: string },
+): boolean {
+  return definition.ownerAgentId === undefined || definition.ownerAgentId === scope?.agentId;
+}
 
 /** Public API contract for runtime loaded skill response messages. */
 export type RuntimeLoadedSkillResponseMessages = {
@@ -171,6 +195,9 @@ export function buildRuntimeSkillDefinition(input: {
   id: string;
   content: string;
   references?: readonly string[];
+  ownerAgentId?: string;
+  shortName?: string;
+  sourcePath?: string;
   logger?: RuntimeSkillMetadataLogger;
 }): RuntimeSkillDefinition | null {
   const document = parseRuntimeSkillDocument(input.content, { logger: input.logger });
@@ -192,6 +219,9 @@ export function buildRuntimeSkillDefinition(input: {
     ...(input.references && input.references.length > 0
       ? { references: [...input.references] }
       : {}),
+    ...(input.ownerAgentId === undefined ? {} : { ownerAgentId: input.ownerAgentId }),
+    ...(input.shortName === undefined ? {} : { shortName: input.shortName }),
+    ...(input.sourcePath === undefined ? {} : { sourcePath: input.sourcePath }),
   };
 }
 


### PR DESCRIPTION
## Summary

Phase 6 (framework side) of the directory-agent adoption — the contract and runtime changes that let the **hosted** runtime carry and correctly scope colocated (agent-owned) skills. Follows the cross-repo spike (`.omx/research/hosted-catalog-spike.md`).

**Catalog contract** (`RuntimeSkillDefinition`, additive):
- `ownerAgentId?` / `shortName?` — owner metadata, same semantics as the local skill registry
- `sourcePath?` — the actual discovered `SKILL.md` path. Consumers must use this instead of reconstructing `skills/{id}/SKILL.md` from ids, which breaks for namespaced ids like `researcher--cite`
- `buildRuntimeSkillDefinition` threads all three; `isRuntimeSkillVisibleTo` exposes the one visibility rule for catalog definitions

**Hosted per-run scoping** (`prepareHostedChatRuntimeCreationOptions`): the run's skill set filters to *unowned + the run agent's own* at a single choke point, which scopes all four downstream consumers at once — the prompt manifest input, the per-run `availableSkillIds` gate that hosted `load_skill` enforces, its not-found enumeration, and the live steering payload. This brings hosted parity with the local resolver rule from #2357.

Hosted owned-**tool** visibility was already identity-aware via the merge-time `getDiscoveredHostTools(scope)` change; this PR completes the skill side.

## What this unblocks (control-plane follow-up)

Per the spike's ownership table, the control plane can now: discover `agents/*/SKILL.md` + `agents/*/skills/*/SKILL.md` with `--` ids and owner metadata, populate the catalog through `getSkillsConfig`, and resolve skill references via `sourcePath` in its `projectSkillLoader` (the framework's reference loading already delegates there). Because `RuntimeSkillDefinition.instructions` is inlined, hosted `load_skill` for owned skills works as soon as the catalog includes them.

## Testing

- New: `prepareHostedChatRuntimeCreationOptions` owner-scope test asserting all four consumers carry the same filtered set (owner sees global + own; another agent's owned skill excluded)
- Regression: hosted + runtime + skill suites green; back-compat preserved (no owned entries → identical behavior)

## Type of Change
- [x] New feature (non-breaking, additive contract)
- [x] Test update
