### PR TITLE
Reject new agent work with 503 during graceful shutdown (lame-duck mode)

### DIFF
--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -77,7 +77,7 @@ for agents that do not own skills or tools, and both layouts can coexist.
 
 Colocated capabilities are registered with owner metadata and namespaced
 `{agentId}--{name}`. Ownership controls visibility everywhere: an agent only
-ever sees unowned (project-global) capabilities plus its own — never another
+ever sees unowned (project-global) capabilities plus its own - never another
 agent's. This one rule applies to `skills:` and `tools:` for every agent kind
 (TypeScript, flat markdown, and directory markdown):
 
@@ -92,8 +92,8 @@ tools: [fetch-paper] # own short names resolve first, then global tool ids
 Research the question and cite every claim.
 ```
 
-- `skills: true` / `tools: true` — every capability visible to the agent.
-- `skills: [..]` / `tools: [..]` — each entry resolves as the agent's own
+- `skills: true` / `tools: true` - every capability visible to the agent.
+- `skills: [..]` / `tools: [..]` - each entry resolves as the agent's own
   short name first, then as a global id. A colocated short name that shadows a
   global id is reported at discovery so the reference stays unambiguous.
 - Duplicate agent ids (flat file + directory) and agent ids whose sanitized

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -104,7 +104,7 @@ const researchTool = agentAsTool(researcher, "Research a topic using web search"
 A markdown agent can opt into orchestration by listing the specialists it may
 call in its `delegates` frontmatter. The runtime gives the agent one
 `agent_{id}` tool per delegate; each delegate runs with its own settings,
-skills, and tools — capability ownership does not cross the delegation
+skills, and tools - capability ownership does not cross the delegation
 boundary in either direction.
 
 ```md

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -23,6 +23,7 @@ import {
   createNoopFsAdapter,
   TrackingSessionManager,
 } from "./agent-stream.handler.test-helpers.ts";
+import { __resetServerShuttingDownForTests, markServerShuttingDown } from "../../shutdown-state.ts";
 
 function createRuntimeAgentRunInvocationBody() {
   return JSON.stringify({
@@ -1653,5 +1654,64 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(sessionManager.stats.completeCalls, 1);
     assertEquals(sessionManager.stats.cancelCalls, 0);
     assertEquals(sessionManager.stats.failCalls, 0);
+  });
+
+  it("rejects new agent stream requests with 503 while the runtime is shutting down", async () => {
+    let discoveryCalls = 0;
+    let resolveOwnerCalls = 0;
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {
+        discoveryCalls += 1;
+      },
+      getAgent: (id) => id === "assistant-1" ? createAgent("assistant-1") : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager: new AgentRunSessionManager(),
+      resolveRuntimeOwnerInvokeUrl: async () => {
+        resolveOwnerCalls += 1;
+        return "http://10.0.0.7:20000/channels/invoke";
+      },
+      createRuntime: () => ({
+        stream: async () =>
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.close();
+            },
+          }),
+      }),
+    });
+
+    const body = createAgentStreamRequestBody();
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    markServerShuttingDown();
+    try {
+      const result = await handler.handle(
+        new Request("https://example.com/api/control-plane/runs/run_1/stream", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-veryfront-control-plane-jws": jws,
+          },
+          body,
+        }),
+        createCtx(publicKeyPem),
+      );
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 503);
+      assertEquals(result.response.headers.get("connection"), "close");
+      assertEquals(
+        result.response.headers.get("x-veryfront-runtime-owner-invoke-url"),
+        null,
+      );
+      const responseBody = await result.response.json();
+      assertEquals(responseBody.code, "RUNTIME_SHUTTING_DOWN");
+      assertEquals(typeof responseBody.message, "string");
+      // Rejection must happen before discovery / runtime-owner resolution.
+      assertEquals(discoveryCalls, 0);
+      assertEquals(resolveOwnerCalls, 0);
+    } finally {
+      __resetServerShuttingDownForTests();
+    }
   });
 });

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -42,6 +42,8 @@ import {
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
+import { buildRuntimeShuttingDownResponse } from "./runtime-shutdown-response.ts";
+import { isServerShuttingDown } from "../../shutdown-state.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { serverLogger } from "#veryfront/utils";
 import {
@@ -392,6 +394,15 @@ export class AgentStreamHandler extends BaseHandler {
   async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
     if (!this.shouldHandle(req, ctx)) {
       return this.continue();
+    }
+
+    // Lame-duck: reject NEW agent streams during graceful shutdown before any
+    // control-plane verification, discovery, or runtime-owner resolution, so the
+    // API gets a clean pre-side-effect failure (without the runtime-owner header
+    // that would otherwise re-pin the run to this terminating pod) and can retry
+    // against another instance. In-flight streams are unaffected.
+    if (isServerShuttingDown()) {
+      return this.respond(buildRuntimeShuttingDownResponse(this.createResponseBuilder(ctx)));
     }
 
     return this.withProxyContext(ctx, async () => {

--- a/src/server/handlers/request/channel-invoke.handler.test.ts
+++ b/src/server/handlers/request/channel-invoke.handler.test.ts
@@ -6,6 +6,7 @@ import type { HandlerContext } from "#veryfront/types";
 import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
 import type { ChannelInvokeRequest } from "../../../channels/invoke.ts";
 import { ChannelInvokeHandler } from "./channel-invoke.handler.ts";
+import { __resetServerShuttingDownForTests, markServerShuttingDown } from "../../shutdown-state.ts";
 
 const encoder = new TextEncoder();
 
@@ -228,5 +229,50 @@ describe("server/handlers/request/channel-invoke.handler", () => {
     assertExists(result.response);
     assertEquals(result.response.status, 400);
     assertEquals(await result.response.json(), { error: "Invalid channel invoke request" });
+  });
+
+  it("rejects new invoke requests with 503 while the runtime is shutting down", async () => {
+    let discoveryCalls = 0;
+    const handler = new ChannelInvokeHandler({
+      ensureProjectDiscovery: async () => {
+        discoveryCalls += 1;
+      },
+      getAgent: () => createAgent(async () => createAgentResponse()),
+      getAllAgentIds: () => ["agent-1"],
+    });
+
+    const payload = createPayload();
+    const body = JSON.stringify(payload);
+    const { jws, publicKeyPem } = await createDispatchSignature(body);
+
+    markServerShuttingDown();
+    try {
+      const result = await handler.handle(
+        new Request("https://example.com/channels/invoke", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-veryfront-dispatch-jws": jws,
+          },
+          body,
+        }),
+        createCtx(publicKeyPem),
+      );
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 503);
+      assertEquals(result.response.headers.get("connection"), "close");
+      assertEquals(
+        result.response.headers.get("x-veryfront-runtime-owner-invoke-url"),
+        null,
+      );
+      const responseBody = await result.response.json();
+      assertEquals(responseBody.code, "RUNTIME_SHUTTING_DOWN");
+      assertEquals(typeof responseBody.message, "string");
+      // Rejection must happen before any dispatch verification / agent work.
+      assertEquals(discoveryCalls, 0);
+    } finally {
+      __resetServerShuttingDownForTests();
+    }
   });
 });

--- a/src/server/handlers/request/channel-invoke.handler.ts
+++ b/src/server/handlers/request/channel-invoke.handler.ts
@@ -8,6 +8,8 @@ import {
 } from "../../../channels/invoke.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 import { readSignedChannelDispatchRequest } from "./channel-dispatch-request.ts";
+import { buildRuntimeShuttingDownResponse } from "./runtime-shutdown-response.ts";
+import { isServerShuttingDown } from "../../shutdown-state.ts";
 
 export class ChannelInvokeHandler extends BaseHandler {
   metadata: HandlerMetadata = {
@@ -23,6 +25,13 @@ export class ChannelInvokeHandler extends BaseHandler {
   async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
     if (!this.shouldHandle(req, ctx)) {
       return this.continue();
+    }
+
+    // Lame-duck: reject NEW agent work during graceful shutdown before any
+    // dispatch verification or agent execution, so the API gets a clean
+    // pre-side-effect failure it can retry against another instance.
+    if (isServerShuttingDown()) {
+      return this.respond(buildRuntimeShuttingDownResponse(this.createResponseBuilder(ctx)));
     }
 
     return this.withProxyContext(ctx, async () => {

--- a/src/server/handlers/request/runtime-shutdown-response.ts
+++ b/src/server/handlers/request/runtime-shutdown-response.ts
@@ -1,0 +1,24 @@
+import type { ResponseBuilder } from "#veryfront/security/index.ts";
+import { HTTP_UNAVAILABLE } from "#veryfront/utils/constants/index.ts";
+
+/** Stable error code returned when the renderer is in lame-duck shutdown mode. */
+export const RUNTIME_SHUTTING_DOWN_CODE = "RUNTIME_SHUTTING_DOWN";
+
+/** Human-readable message paired with {@link RUNTIME_SHUTTING_DOWN_CODE}. */
+export const RUNTIME_SHUTTING_DOWN_MESSAGE =
+  "Runtime is shutting down; retry against another instance";
+
+/**
+ * Builds the 503 response used to reject new agent-work requests while the
+ * renderer is draining. Sends `Connection: close` so the API drops the keep-alive
+ * connection to this terminating pod, and deliberately omits the runtime-owner
+ * invoke URL header so the API does not re-pin the run to this pod's IP.
+ */
+export function buildRuntimeShuttingDownResponse(builder: ResponseBuilder): Response {
+  return builder
+    .withHeaders({ Connection: "close" })
+    .json(
+      { code: RUNTIME_SHUTTING_DOWN_CODE, message: RUNTIME_SHUTTING_DOWN_MESSAGE },
+      HTTP_UNAVAILABLE,
+    );
+}

--- a/src/server/production-server.ts
+++ b/src/server/production-server.ts
@@ -26,6 +26,7 @@ import {
 } from "#veryfront/html/styles-builder/css-pregeneration.ts";
 import { createStyleScopeProfile } from "#veryfront/html/styles-builder/style-scope-profile.ts";
 import { setServerInitialized } from "./handlers/monitoring/health.handler.ts";
+import { markServerShuttingDown } from "./shutdown-state.ts";
 import {
   enableSSRClientOnlyFetching,
   enableSSRFetchInterception,
@@ -412,7 +413,12 @@ if (import.meta.main) {
         drainTimeoutMs,
       });
 
-      // Phase 1: Mark server as not ready to stop K8s from routing new requests
+      // Phase 1: Enter lame-duck mode. markServerShuttingDown() makes the
+      // agent-work handlers reject NEW requests with 503 (before any side
+      // effects) so the API can retry against another instance, even while the
+      // pod IP is still directly reachable. setServerInitialized(false) flips
+      // /readyz to not-ready so K8s stops routing Service traffic.
+      markServerShuttingDown();
       setServerInitialized(false);
       logger.info("Server marked as not ready, waiting for in-flight requests to drain...");
 

--- a/src/server/shutdown-state.test.ts
+++ b/src/server/shutdown-state.test.ts
@@ -1,0 +1,26 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  __resetServerShuttingDownForTests,
+  isServerShuttingDown,
+  markServerShuttingDown,
+} from "./shutdown-state.ts";
+
+describe("server/shutdown-state", () => {
+  afterEach(() => {
+    __resetServerShuttingDownForTests();
+  });
+
+  it("defaults to not shutting down", () => {
+    assertEquals(isServerShuttingDown(), false);
+  });
+
+  it("reports shutting down after markServerShuttingDown()", () => {
+    markServerShuttingDown();
+    assertEquals(isServerShuttingDown(), true);
+  });
+
+  it("resets between tests via the test-only helper", () => {
+    assertEquals(isServerShuttingDown(), false);
+  });
+});

--- a/src/server/shutdown-state.ts
+++ b/src/server/shutdown-state.ts
@@ -1,0 +1,26 @@
+/**
+ * Explicit lame-duck shutdown state for the renderer.
+ *
+ * This is intentionally separate from the `serverInitialized` health flag,
+ * which is also `false` during startup. Once SIGTERM is received the renderer
+ * enters lame-duck mode: new agent-work requests are rejected with 503 so the
+ * API gets a clean pre-side-effect failure it can retry against another
+ * instance, while in-flight streams continue draining.
+ */
+
+let shuttingDown = false;
+
+/** Marks the server as entering graceful shutdown (lame-duck mode). */
+export function markServerShuttingDown(): void {
+  shuttingDown = true;
+}
+
+/** Returns true once the server has started graceful shutdown. */
+export function isServerShuttingDown(): boolean {
+  return shuttingDown;
+}
+
+/** Test-only helper to reset lame-duck state between tests. */
+export function __resetServerShuttingDownForTests(): void {
+  shuttingDown = false;
+}


### PR DESCRIPTION
## Summary

Fixes the renderer half of veryfront/veryfront-studio#4327 (interrupted agent runs during deployment rollouts).

During a rollout, a terminating renderer pod keeps accepting **new** long-lived agent streams for its entire graceful-shutdown drain window, then gets SIGKILLed mid-SSE. Because the API binds runs to the pod's direct IP (`x-veryfront-runtime-owner-invoke-url` built from `POD_IP`), Kubernetes readiness/Service endpoint removal never protects these requests — observed in staging on 2026-06-09 where a pod accepted a new child-run stream 23s after receiving `Killing`, then died mid-stream (`RUNTIME_STREAM_FAILED: terminated`) after the run's SAP tool calls had already executed.

This PR adds explicit **lame-duck mode**:

- New `src/server/shutdown-state.ts` with `markServerShuttingDown()` / `isServerShuttingDown()` — intentionally separate from the `serverInitialized` health flag (which is also false during startup).
- `production-server.ts` shutdown Phase 1 now calls `markServerShuttingDown()` in addition to flipping `/readyz`.
- `ChannelInvokeHandler` (`POST /channels/invoke`) and `AgentStreamHandler` (control-plane run streams) reject **new** requests during shutdown with:
  - HTTP 503, JSON body `{ code: "RUNTIME_SHUTTING_DOWN", message: ... }`
  - `Connection: close`
  - no `x-veryfront-runtime-owner-invoke-url` header (so the API cannot re-pin the run to the terminating pod)
  - rejection happens before dispatch verification / discovery / any side-effectful work
- In-flight streams are unaffected and continue to drain as before.

The companion API PR (veryfront-api) treats this 503 as a safely retryable pre-stream failure: it clears the stale runtime-owner binding and requeues the run against a healthy pod.

## Test plan (red-green)

- New failing-first tests:
  - `src/server/shutdown-state.test.ts` — state unit tests
  - `channel-invoke.handler.test.ts` — 503 + code + `Connection: close` while shutting down; no dispatch work performed
  - `agent-stream.handler.test.ts` — same, plus asserts no runtime-owner header and no discovery/owner resolution
- Red verified: both handler tests fail against the unpatched handlers (`FAILED (due to 1 failed step)` each)
- Green: `deno test -A` on the three files → 3 passed (29 steps), 0 failed; `deno check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Notes

- Includes a small preliminary commit fixing pre-existing `docs:validate` em-dash failures on main (`docs/guides/agents.md`, `docs/guides/multi-agent.md`) that block pre-commit verification for any commit on this branch.
- The `docs-coverage.test.ts` baseline check also fails on pristine origin/main (verified independently of this change); it is unrelated to this PR.
