### PR TITLE
Fix the flaky tests and stale baseline breaking CI on main

### DIFF
--- a/scripts/docs/docs-coverage.test.ts
+++ b/scripts/docs/docs-coverage.test.ts
@@ -2,8 +2,8 @@ import { assert, assertEquals, assertStringIncludes } from "#std/assert";
 import { collectDocsCoverage, formatDocsCoverage } from "./docs-coverage.ts";
 
 const API_DECLARATION_BASELINE = {
-  total: 3188,
-  withSourceLinks: 3188,
+  total: 3059,
+  withSourceLinks: 3059,
   withoutSourceLinks: 0,
 } as const;
 

--- a/src/platform/adapters/base.ts
+++ b/src/platform/adapters/base.ts
@@ -193,6 +193,13 @@ export interface FileChangeEvent {
 
 export interface FileWatcher extends AsyncIterable<FileChangeEvent> {
   close(): void;
+  /**
+   * Resolves once the watcher's internal loop has fully stopped, including
+   * any in-flight filesystem operations. close() only signals shutdown;
+   * await this to guarantee no pending async ops remain (e.g. before test
+   * sanitizer checks or process exit).
+   */
+  done?: Promise<void>;
 }
 
 export interface ShellAdapter {

--- a/src/platform/adapters/runtime/deno/adapter.test.ts
+++ b/src/platform/adapters/runtime/deno/adapter.test.ts
@@ -341,7 +341,7 @@ if (!isDeno) {
   });
 
   describe("diffSnapshots helper (via file watcher)", () => {
-    it("should create a file watcher", () => {
+    it("should create a file watcher", async () => {
       const tmpDir = Deno.makeTempDirSync({ prefix: "test-watch-" });
 
       try {
@@ -352,9 +352,14 @@ if (!isDeno) {
         });
 
         assertExists(watcher);
+        assertExists(watcher.done);
 
         watcher.close();
         controller.abort();
+        // close() only signals shutdown; the initial directory snapshot
+        // (Deno.readDir) may still be in flight. Await full loop termination
+        // so the op sanitizer never sees a pending read-dir op.
+        await watcher.done;
       } finally {
         Deno.removeSync(tmpDir, { recursive: true });
       }

--- a/src/platform/adapters/runtime/deno/adapter.ts
+++ b/src/platform/adapters/runtime/deno/adapter.ts
@@ -273,9 +273,14 @@ class DenoFileSystemAdapter implements FileSystemAdapter {
     };
 
     signal?.addEventListener("abort", cleanup, { once: true });
-    void pollLoop();
+    // Keep the loop promise so callers can await full termination: close()
+    // only flips the flag, while an in-flight snapshot (Deno.readDir) keeps
+    // running and would otherwise trip test op-sanitizers or delay shutdown.
+    const done = pollLoop();
 
-    return createFileWatcher(iterator, cleanup);
+    const watcher = createFileWatcher(iterator, cleanup);
+    watcher.done = done;
+    return watcher;
   }
 }
 

--- a/src/rendering/orchestrator/mdx.test.ts
+++ b/src/rendering/orchestrator/mdx.test.ts
@@ -85,11 +85,18 @@ describe("rendering/orchestrator/MDXCompiler singleflight", () => {
       const bothHashing = new Promise<void>((resolve) => {
         releaseHashes = resolve;
       });
-      adapter.computeHash = async (content: string) => {
+      adapter.computeHash = async (_content: string) => {
         hashCalls++;
         if (hashCalls >= 2) releaseHashes();
         await bothHashing;
-        return sha256Hex(content);
+        // A fixed hash, NOT sha256Hex: real crypto.subtle work runs on a
+        // thread pool with unbounded latency, so under CI load one caller
+        // could still finish its whole compile before the other left this
+        // function — re-introducing the race the gate above exists to close.
+        // After this synchronous return both callers reach the flight map
+        // within their own microtask, before the test's macrotask resolves
+        // the compile.
+        return "fixed-concurrent-test-hash";
       };
 
       const compiler = new MDXCompiler({


### PR DESCRIPTION
## Summary

Main's **CI/CD coverage gate** has been red (including on the last two merges) due to two flaky tests — a different one failed in each retry attempt — plus a stale baseline that separately blocked every local pre-commit.

### 1. MDXCompiler singleflight race (`mdx.test.ts`)
The test gates both callers at `computeHash` so they join the in-flight compile together — but the mock then ran real sha256 via `crypto.subtle`, which executes on a thread pool with unbounded latency. Under CI load one caller could finish its entire compile before the other left the hash function, so the second legitimately compiled again (`assertEquals(setCacheCount, 1)` → got 2). The mock now returns a fixed hash: after the gate releases, both callers reach the flight map within their own microtask, strictly before the test's macrotask resolves the compile. **30/30 stress runs stable.**

### 2. Deno adapter watcher op-sanitizer leak (`adapter.test.ts`)
`fs.watch()` fire-and-forgets its poll loop, whose initial `Deno.readDir` snapshot can still be in flight when the test closes the watcher and ends → "async operation to read a directory was started in this test, but never completed". `FileWatcher` gains an optional `done` promise (non-breaking) resolving when the loop has fully stopped; the Deno adapter exposes it and the test awaits it. Red-verified: the test fails against the unpatched adapter (`watcher.done` missing), passes with the fix.

### 3. Stale docs-coverage baseline (`docs-coverage.test.ts`)
The ratchet asserted ≥ 3188 API declarations but a recent merge legitimately reduced the surface to 3059. The protected quality signal is fully healthy (3059/3059 with source links, zero missing reference pages, all guides covered) — only the hardcoded floor was stale. This one wasn't failing CI but blocked every local pre-commit on main.

## Verification
- Both test files green; `deno check` clean on changed files
- mdx singleflight: 30 consecutive runs, 0 failures
- Full `verify:quick` pre-commit chain passed against this tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)