### PR TITLE
Bump version to 0.1.760

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.759",
+  "version": "0.1.760",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.759";
+export const VERSION = "0.1.760";


### PR DESCRIPTION
Releases the graceful-shutdown lame-duck behavior (#2361, part of veryfront/veryfront-studio#4327) and the coverage-gate flaky-test fixes (#2362).

The `release` job on main currently fails with "v0.1.759 already exists on npm. Bump deno.json before releasing." — this was also the cause of the previous merge's red CI/CD run. Merging this publishes 0.1.760 via the existing release automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)