### PR TITLE
Document hosted parity for directory-agent skills

### DIFF
--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -98,10 +98,10 @@ Research the question and cite every claim.
   global id is reported at discovery so the reference stays unambiguous.
 - Duplicate agent ids (flat file + directory) and agent ids whose sanitized
   namespaces collide are reported as discovery errors.
-
-> Note: colocated capabilities currently resolve in the local runtime; hosted
-> runtime catalog support is tracked separately and lands before this layout
-> is documented as stable.
+The same catalog metadata is used by local and hosted runtime paths. Hosted
+skill loading uses the catalog `sourcePath`, not a path reconstructed from the
+namespaced id, so `load_skill("researcher--cite")` resolves to the actual
+colocated `SKILL.md`.
 
 ## Add tools
 


### PR DESCRIPTION
## Summary
- Remove the obsolete local-runtime caveat from the agent guide.
- Document that hosted skill loading uses catalog sourcePath metadata for colocated directory-agent skills.

## Verification
- git diff --check
- stale-doc grep for the old local-runtime caveat and agent allowed-tools wording
- VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all src/discovery/agent-scoped-capabilities.test.ts src/skill/skill-owner-scope.test.ts src/tool/tool-owner-scope.test.ts src/internal-agents/run-stream-owner-scope.test.ts src/agent/runtime/project-skill-catalog.test.ts src/agent/runtime/project-skill-loader.test.ts src/agent/hosted/chat-preparation.test.ts src/agent/hosted/project-steering-adapter.test.ts src/agent/hosted/default-project-steering-refresh.test.ts
- VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all tests/docs/guide-contracts.test.ts scripts/docs/docs-coverage.test.ts
- pre-push hook: formatting, lint, typecheck, unit tests (2125 passed, 0 failed)