### PR TITLE
Bump version to 0.1.761

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.760",
+  "version": "0.1.761",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.760";
+export const VERSION = "0.1.761";


### PR DESCRIPTION
## Summary
- Bump the framework package version from 0.1.760 to 0.1.761 in deno.json.
- Keep the shared runtime VERSION constant synchronized with the package version.

## Verification
- jq -e '.version == "0.1.761"' deno.json
- rg -n '0\.1\.761|0\.1\.760' deno.json src/utils/version-constant.ts
- git diff --check
- pre-push hook: format, lint, typecheck, generation, and unit suite: 2125 passed, 0 failed