### PR TITLE
Sync browser-safe exports list with deno.json after chat export demotion

### DIFF
--- a/scripts/build/browser-safe-exports.mjs
+++ b/scripts/build/browser-safe-exports.mjs
@@ -4,13 +4,8 @@ export const BROWSER_SAFE_EXPORTS = [
   "./context",
   "./fonts",
   "./chat",
-  "./chat/ag-ui",
-  "./chat/protocol",
   "./chat/types",
-  "./chat/conversation",
   "./chat/message-prep",
-  "./chat/final-step-fallback",
-  "./chat/provider-errors",
   "./markdown",
   "./mdx",
   "./agent/identity",
@@ -23,6 +18,12 @@ export const BROWSER_SAFE_DNT_TIMER_MODULES = [
 ];
 
 export const BROWSER_SAFE_CLIENT_MODULES = [
+  // Demoted from public exports in #2350 but still browser-consumed via the
+  // ./chat barrel, so they keep the polyfill-stripping treatment by path.
+  "src/chat/ag-ui.js",
+  "src/chat/protocol.js",
+  "src/chat/conversation.js",
+  "src/chat/provider-errors.js",
   "src/agent/react/use-voice-input.js",
   "src/react/components/chat/chat/components/code-block.js",
   "src/react/components/chat/chat/components/inline-citation.js",

--- a/scripts/build/browser-safe-exports.test.ts
+++ b/scripts/build/browser-safe-exports.test.ts
@@ -1,0 +1,41 @@
+import { assert } from "#std/assert";
+import {
+	BROWSER_SAFE_CLIENT_MODULES,
+	BROWSER_SAFE_DNT_TIMER_MODULES,
+	BROWSER_SAFE_EXPORTS,
+} from "./browser-safe-exports.mjs";
+
+// build-npm-dnt.ts postBuild throws "Missing browser-safe export source" when
+// an entry here no longer exists in deno.json exports — but only at release
+// time. This test surfaces the drift in PR CI instead (broke release 0.1.761
+// after #2350 demoted six chat exports without updating this list).
+Deno.test("every BROWSER_SAFE_EXPORTS entry is a deno.json export", async () => {
+	const denoJson = JSON.parse(await Deno.readTextFile("./deno.json"));
+	const exports = denoJson.exports as Record<string, string>;
+
+	const stale = BROWSER_SAFE_EXPORTS.filter((entry: string) => !exports[entry]);
+	assert(
+		stale.length === 0,
+		`Stale BROWSER_SAFE_EXPORTS entries with no matching deno.json export: ${stale.join(", ")}`,
+	);
+});
+
+Deno.test("every browser-safe module path points at an existing source file", async () => {
+	const missing: string[] = [];
+	for (const builtPath of [...BROWSER_SAFE_CLIENT_MODULES, ...BROWSER_SAFE_DNT_TIMER_MODULES]) {
+		const sourcePath = (builtPath as string).replace(/\.js$/, ".ts");
+		try {
+			await Deno.stat(sourcePath);
+		} catch {
+			try {
+				await Deno.stat(`${sourcePath}x`); // .tsx
+			} catch {
+				missing.push(builtPath as string);
+			}
+		}
+	}
+	assert(
+		missing.length === 0,
+		`Browser-safe module paths with no matching source file: ${missing.join(", ")}`,
+	);
+});


### PR DESCRIPTION
## Summary

Fixes the npm release build, which failed for 0.1.761 with:

```
Error: Missing browser-safe export source for ./chat/ag-ui
  at Object.postBuild (scripts/build/build-npm-dnt.ts:254)
```

#2350 demoted five chat exports (`./chat/ag-ui`, `./chat/protocol`, `./chat/conversation`, `./chat/final-step-fallback`, `./chat/provider-errors`) from `deno.json` but left them in `BROWSER_SAFE_EXPORTS`, and the drift only surfaces in dnt's postBuild — i.e. at release time, which is why every test job was green while the release kept failing.

- Remove the five demoted entries from `BROWSER_SAFE_EXPORTS`.
- Preserve the polyfill-stripping behavior for those still-browser-consumed modules by adding their built paths to `BROWSER_SAFE_CLIENT_MODULES` (`final-step-fallback` was already covered via the timer-modules list).
- Add `browser-safe-exports.test.ts`: every `BROWSER_SAFE_EXPORTS` entry must be a real `deno.json` export, and every module path must have a source file — so future drift fails in PR CI instead of breaking the release.

## Test plan (red-green)

- New sync test fails against the stale list (`Stale BROWSER_SAFE_EXPORTS entries: ./chat/ag-ui, ...`), passes after the fix.
- `npm-package-metadata.test.ts` (existing consumer of the list) still green.
- Full `deno task build` (dnt) completes past postBuild locally — the exact step that failed in the release job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)