### PR TITLE
Bound Deno download time in release setup

### DIFF
--- a/.github/actions/setup-deno/action.yml
+++ b/.github/actions/setup-deno/action.yml
@@ -48,6 +48,7 @@ runs:
           mkdir -p "${deno_dir}"
           zip_path="${deno_dir}/deno.zip"
           if curl --fail --location --show-error --retry 5 --retry-delay 2 \
+            --connect-timeout 20 --max-time 120 \
             "https://github.com/denoland/deno/releases/download/v${version}/deno-${arch_target}-${os_target}.zip" \
             --output "${zip_path}"; then
             unzip -oq "${zip_path}" -d "${deno_dir}"


### PR DESCRIPTION
## Summary
- Add connect and total timeouts to the pinned Deno release download in the shared setup action.
- Preserve the existing npm fallback when the direct GitHub release download fails.

## Why
The stable 0.1.762 release run is blocked in the macOS arm64 binary lane inside setup-deno. GitHub does not expose logs until the job completes, and the current curl path has retries but no timeout, so a stalled transfer can block publish and downstream deploy dispatch.

## Verification
- git diff --check
- deno fmt --check .github/actions/setup-deno/action.yml
- pre-push hook: format, lint, typecheck, generated assets, unit tests: 2125 passed, 0 failed
