### PR TITLE
Use full-project candidates for production page CSS

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.762",
+  "version": "0.1.763",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/rendering/orchestrator/html-project-css.test.ts
+++ b/src/rendering/orchestrator/html-project-css.test.ts
@@ -107,7 +107,8 @@ describe("rendering/orchestrator/html-project-css", () => {
                     },
                     {
                       path: "/project/components/header.tsx",
-                      content: `export const Header = () => <header className="h-16 md:pr-8">Nav</header>;`,
+                      content:
+                        `export const Header = () => <header className="h-16 md:pr-8">Nav</header>;`,
                     },
                   ]),
               }),

--- a/src/rendering/orchestrator/html-project-css.test.ts
+++ b/src/rendering/orchestrator/html-project-css.test.ts
@@ -28,6 +28,7 @@ describe("rendering/orchestrator/html-project-css", () => {
   describe("getProjectContentVersion", () => {
     it("prefers the adapter content context version", () => {
       const version = getProjectContentVersion({
+        mode: "production",
         adapter: {
           fs: {
             getUnderlyingAdapter: () => ({
@@ -47,6 +48,7 @@ describe("rendering/orchestrator/html-project-css", () => {
 
     it("falls back to project updated_at when no content context is available", () => {
       const version = getProjectContentVersion({
+        mode: "production",
         adapter: {
           fs: {
             getUnderlyingAdapter: () => ({
@@ -90,7 +92,50 @@ describe("rendering/orchestrator/html-project-css", () => {
   });
 
   describe("extractProjectClassesForRoute", () => {
-    it("delegates route metadata and returns the candidate set", async () => {
+    it("includes candidates from component files outside the route module graph", async () => {
+      const classes = await extractProjectClassesForRoute(
+        {
+          projectDir: "/project",
+          adapter: {
+            fs: {
+              getUnderlyingAdapter: () => ({
+                getAllSourceFiles: () =>
+                  Promise.resolve([
+                    {
+                      path: "/project/pages/docs.tsx",
+                      content: `export default () => <div className="text-sm">Docs</div>;`,
+                    },
+                    {
+                      path: "/project/components/header.tsx",
+                      content: `export const Header = () => <header className="h-16 md:pr-8">Nav</header>;`,
+                    },
+                  ]),
+              }),
+            },
+          } as any,
+          config: {} as any,
+          mode: "production",
+        },
+        {
+          slug: "docs",
+          pageInfo: { entity: { path: "/project/pages/docs.tsx" } },
+          nestedLayouts: [],
+          options: { projectSlug: "route-scope-regression" },
+        } as any,
+        undefined,
+        {
+          getProjectContentVersion: () => "v1",
+        },
+      );
+
+      assertEquals(classes.has("text-sm"), true);
+      // Classes from shared components must be present even when the route
+      // module manifest has never observed them (cold pod, first render).
+      assertEquals(classes.has("h-16"), true);
+      assertEquals(classes.has("md:pr-8"), true);
+    });
+
+    it("delegates project metadata and returns the candidate set", async () => {
       const calls: Array<Record<string, unknown>> = [];
 
       const classes = await extractProjectClassesForRoute(
@@ -117,8 +162,8 @@ describe("rendering/orchestrator/html-project-css", () => {
         } as any,
         "/project/app.tsx",
         {
-          getRouteCandidates: (input) => {
-            calls.push(input as Record<string, unknown>);
+          getProjectCandidates: (input) => {
+            calls.push(input as unknown as Record<string, unknown>);
             return new Set(["prose", "docs-page"]);
           },
           createStyleScopeProfile: () => ({ mode: "test" }) as any,
@@ -128,13 +173,10 @@ describe("rendering/orchestrator/html-project-css", () => {
 
       assertEquals([...classes], ["prose", "docs-page"]);
       assertEquals(calls.length, 1);
-      assertEquals(calls[0]?.routeKey, "docs");
       assertEquals(calls[0]?.projectScope, "demo-project");
       assertEquals(calls[0]?.projectVersion, "version-123");
-      assertEquals(
-        calls[0]?.routeFilePaths,
-        ["/project/pages/docs.tsx", "/project/layouts/docs.tsx", "/project/app.tsx"],
-      );
+      assertEquals(calls[0]?.projectDir, "/project");
+      assertEquals(calls[0]?.developmentMode, false);
     });
   });
 });

--- a/src/rendering/orchestrator/html-project-css.ts
+++ b/src/rendering/orchestrator/html-project-css.ts
@@ -11,7 +11,7 @@ import type {
 } from "#veryfront/platform/adapters/fs/veryfront/types.ts";
 import { rendererLogger } from "#veryfront/utils";
 import { extractRelativePath } from "#veryfront/utils/route-path-utils.ts";
-import { getRouteCandidates } from "./css-candidate-manifest.ts";
+import { getProjectCandidates } from "./css-candidate-manifest.ts";
 import type { HTMLGenerationContext } from "./html-types.ts";
 
 const logger = rendererLogger.component("html-project-css");
@@ -31,7 +31,7 @@ interface ProjectCssDeps {
   getProjectContentVersion?: (
     config: Pick<ProjectCssConfig, "adapter" | "mode">,
   ) => string | undefined;
-  getRouteCandidates?: typeof getRouteCandidates;
+  getProjectCandidates?: typeof getProjectCandidates;
   resolveStyleContentVersion?: typeof resolveStyleContentVersion;
   warmPreparedCSSArtifactFromFiles?: typeof warmPreparedCSSArtifactFromFiles;
 }
@@ -156,10 +156,10 @@ export function startPreparedCSSWarmup(
 export async function extractProjectClassesForRoute(
   config: ProjectCssConfig,
   context: HTMLGenerationContext,
-  appComponentPath?: string,
+  _appComponentPath?: string,
   deps: Pick<
     ProjectCssDeps,
-    "createStyleScopeProfile" | "getProjectContentVersion" | "getRouteCandidates"
+    "createStyleScopeProfile" | "getProjectContentVersion" | "getProjectCandidates"
   > = {},
 ): Promise<Set<string>> {
   const classes = new Set<string>();
@@ -175,35 +175,26 @@ export async function extractProjectClassesForRoute(
   const resolveProjectContentVersion = deps.getProjectContentVersion ?? getProjectContentVersion;
   const projectVersion = resolveProjectContentVersion(config) ??
     (config.mode === "development" ? "dev" : "unknown");
-  const routeKey = buildRouteManifestKey(context.pageInfo.entity.path, config.projectDir);
-  const routeLayoutPaths = context.nestedLayouts
-    .map((layout) => layout.componentPath || layout.path)
-    .filter((path): path is string => Boolean(path));
-  const routeFilePaths = [
-    context.pageInfo.entity.path,
-    ...routeLayoutPaths,
-    ...(appComponentPath ? [appComponentPath] : []),
-  ];
 
   const createStyleProfile = deps.createStyleScopeProfile ?? createStyleScopeProfile;
-  const getRouteCssCandidates = deps.getRouteCandidates ?? getRouteCandidates;
-  const routeCandidates = getRouteCssCandidates({
+  const getProjectCssCandidates = deps.getProjectCandidates ?? getProjectCandidates;
+  // Candidates must come from the full source scan, not the route-module
+  // manifest: the manifest is populated per pod from request history, so
+  // route-scoped candidates omit shared components the pod has not yet
+  // observed and produce divergent CSS across replicas for the same page.
+  const projectCandidates = getProjectCssCandidates({
     projectScope,
     projectVersion,
     projectDir: config.projectDir,
     styleProfile: createStyleProfile(config.config),
-    routeKey,
-    routeFilePaths,
     files,
     developmentMode: config.mode === "development",
   });
 
-  for (const cls of routeCandidates) classes.add(cls);
+  for (const cls of projectCandidates) classes.add(cls);
 
   logger.debug("extractProjectClasses", {
     filesProcessed: files.length,
-    routeKey,
-    routeFileCount: routeFilePaths.length,
     totalClasses: classes.size,
   });
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.762";
+export const VERSION = "0.1.763";


### PR DESCRIPTION
Fixes #2373

## Problem

Production page CSS candidates were resolved route-scoped from the runtime route-module manifest — an LRU populated per replica from request history. Cold replicas compiled CSS without shared-component classes (header, nav, buttons), cached the incomplete result per route, and never recovered. Replicas served divergent stylesheets for the same page (four distinct bundles observed, 26KB–38KB); pages rendered with missing layout rules depending on which replica answered.

## Change

`extractProjectClassesForRoute` now derives candidates from the deterministic full-project source scan (`getProjectCandidates`), matching dev mode and CSS pregeneration. CSS becomes a pure function of project source + version: same hash, identical styling on every replica.

- `src/rendering/orchestrator/html-project-css.ts`: swap `getRouteCandidates` → `getProjectCandidates`; drop route-key plumbing from the candidate call.
- `src/rendering/orchestrator/html-project-css.test.ts`: regression test — classes from a component file outside the route module graph must be present (fails on main); update delegation test; fix two pre-existing `deno check` errors.
- Version bump 0.1.762 → 0.1.763.

## Trade-off

Page CSS now includes all project classes rather than a route-scoped subset — standard Tailwind semantics (one stylesheet per project). The route-scoped optimization can return later behind a static import graph, which would be deterministic.

## Tested

- `deno test --no-check --allow-all src/rendering/orchestrator/` — 22 passed (279 steps)
- `deno test --no-check --allow-all src/html/styles-builder/` — all passing
- `deno check src/rendering/orchestrator/html-project-css.ts src/rendering/orchestrator/html-project-css.test.ts` — clean