### PR TITLE
Release the Video.js CSP fix

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.763",
+  "version": "0.1.764",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.763";
+export const VERSION = "0.1.764";


### PR DESCRIPTION
## Summary
- bump Veryfront from 0.1.763 to 0.1.764
- force a fresh published package and downstream server image containing the already-merged Video.js CSP fix

## Why
The CSP code fix merged in #2375, but 0.1.763 had already been published by an earlier main merge. Production artifact 20260612094302-7cee2ddc9def still served the old CSP.

## Verification
- deno test --no-check --allow-all src/security/http/response/security-handler.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts src/security/http/response/security-handler.ts src/security/http/response/security-handler.test.ts
- git diff --check
- pre-push checks: fmt, lint, typecheck, unit tests (2125 passed)