### PR TITLE
Fix release asset manifest consumption for environment contexts

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.765",
+  "version": "0.1.766",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -1,10 +1,16 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import { VeryfrontFSAdapter } from "./adapter.ts";
 import { buildFileListCacheKey } from "./cache-keys.ts";
 import { createAdapter, seedCachedFiles, waitFor } from "./adapter.test-helpers.ts";
 import type { ResolvedContentContext } from "./types.ts";
+import {
+  clearReleaseAssetManifestCache,
+  getReadyManifestForRender,
+} from "#veryfront/release-assets/manifest-cache.ts";
+import { RELEASE_ASSET_MANIFEST_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
 
 describe("VeryfrontFSAdapter", () => {
   describe("class", () => {
@@ -102,6 +108,13 @@ describe("VeryfrontFSAdapter", () => {
   });
 
   describe("content context", () => {
+    const originalManifestFlag = getHostEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG);
+
+    afterEach(() => {
+      setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, originalManifestFlag ?? "");
+      clearReleaseAssetManifestCache();
+    });
+
     it("should default to null before initialize", () => {
       assertEquals(createAdapter().getContentContext(), null);
     });
@@ -144,6 +157,60 @@ describe("VeryfrontFSAdapter", () => {
       const ctx = adapter.getContentContext();
       assertEquals(ctx?.sourceType, "release");
       assertEquals(ctx?.releaseId, "release-123");
+    });
+
+    it("should register a release asset manifest fetcher for environment contexts with release ids", async () => {
+      setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+      const releaseId = "release-env-123";
+      const contentHash = "a".repeat(64);
+      const adapter = createAdapter();
+      let fetchCount = 0;
+
+      (adapter.getClient() as unknown as {
+        getReleaseAssetManifest: (releaseId: string) => Promise<{
+          state: string;
+          manifest: unknown;
+        }>;
+      }).getReleaseAssetManifest = async (requestedReleaseId: string) => {
+        fetchCount++;
+        assertEquals(requestedReleaseId, releaseId);
+        return {
+          state: "ready",
+          manifest: {
+            schemaVersion: 1,
+            projectId: "project-123",
+            releaseId,
+            releaseVersion: 1,
+            manifestVersion: 2,
+            builderVersion: "0.1.765",
+            sourceContentHash: "",
+            createdAt: "2026-06-12T00:00:00.000Z",
+            assetBasePath: "/_vf/assets",
+            modules: {
+              "pages/index.tsx": {
+                contentHash,
+                size: 1,
+                contentType: "text/javascript",
+              },
+            },
+            css: [],
+            routes: { "/": { modules: ["pages/index.tsx"], css: [] } },
+            dependencies: {},
+            fallback: { mode: "jit", gaps: [] },
+          },
+        };
+      };
+
+      adapter.setContentContext({
+        sourceType: "environment",
+        projectSlug: "test-project",
+        environmentName: "production",
+        releaseId,
+      });
+
+      assertEquals(getReadyManifestForRender(releaseId), null);
+      await waitFor(async () => getReadyManifestForRender(releaseId)?.manifestVersion === 2);
+      assertEquals(fetchCount, 1);
     });
 
     it("should preserve context set before initialize", () => {

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -678,17 +678,21 @@ export class VeryfrontFSAdapter implements FSAdapter {
       contextWillChange: contextChanged,
     });
 
+    const oldReleaseId = oldContext?.releaseId;
+    const nextReleaseId = context.releaseId;
+
     // Unregister the manifest fetcher for the previous release (if any).
-    if (oldContext?.sourceType === "release" && oldContext.releaseId) {
-      unregisterManifestFetcherForRelease(oldContext.releaseId);
+    // Environment/domain contexts can also carry a deployed releaseId.
+    if (oldReleaseId && oldReleaseId !== nextReleaseId) {
+      unregisterManifestFetcherForRelease(oldReleaseId);
     }
 
     // Register a per-releaseId manifest fetcher so production HTML can
     // consult ready manifests when the feature flag is on. Using the per-
     // releaseId registry ensures the correct project-scoped token is always
     // used, even under multi-tenant / proxy-manager operation.
-    if (context.sourceType === "release" && context.releaseId) {
-      registerManifestFetcherForRelease(context.releaseId, buildManifestFetcher(this.client));
+    if (nextReleaseId) {
+      registerManifestFetcherForRelease(nextReleaseId, buildManifestFetcher(this.client));
     }
 
     this.contentContext = context;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.765";
+export const VERSION = "0.1.766";


### PR DESCRIPTION
## Summary
- register release asset manifest fetchers for any content context carrying a releaseId, including production environment/domain contexts
- add a regression proving environment contexts with release ids can fetch/cache ready manifests
- bump Veryfront Code package metadata from 0.1.765 to 0.1.766 so this ships as a new release

## Why
Staging proved manifest build and hashed asset serving were healthy, but authenticated production HTML still emitted /_vf_modules URLs. The missing link was renderer-side consumption: environment-derived contexts can carry the deployed releaseId but were not registering the per-release manifest fetcher.

## Verification
- deno test --no-check --allow-all src/platform/adapters/fs/veryfront/adapter.test.ts
- deno test --no-check --allow-all src/release-assets/html-consumption.test.ts
- deno test --no-check --allow-all src/release-assets
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts
- pre-push format/lint/typecheck/full unit suite was attempted after the version bump; version failures were fixed, then the rerun hung in unrelated Login Module full-suite execution. Isolated cli/auth/login.test.ts passed in 713ms.

## Downstream
- veryfront-api should bump its pinned veryfront dependency from 0.1.764 to 0.1.766 after this package version is published.
- veryfront-studio does not need a bump for this fix; its only direct veryfront usage found was Vite stubbing for bundled internals, not the renderer/task runtime path.