### PR TITLE
Read release asset manifest flag from host env

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.765",
+  "version": "0.1.766",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": "P2D",

--- a/src/release-assets/manifest-cache.ts
+++ b/src/release-assets/manifest-cache.ts
@@ -26,7 +26,7 @@
 import { serverLogger } from "#veryfront/utils";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { registerLRUCache } from "#veryfront/cache";
-import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { RELEASE_ASSET_MANIFEST_ENV_FLAG } from "./constants.ts";
 import { parseReleaseAssetManifest, type ReleaseAssetManifest } from "./manifest-schema.ts";
 
@@ -113,7 +113,10 @@ function resolveFetcher(
 
 /** True when production manifest consumption is enabled via env flag. */
 export function isReleaseAssetManifestEnabled(): boolean {
-  return getEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG) === "1";
+  // Deployment-level flag: read HOST env explicitly. `getEnv` consults the
+  // per-request project env overlay and refuses host fallthrough during remote
+  // project renders, which left this flag permanently off in production.
+  return getHostEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG) === "1";
 }
 
 /** Build the cache key from releaseId + the latest known manifestVersion. */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.765";
+export const VERSION = "0.1.766";


### PR DESCRIPTION
getEnv consults the per-request project env overlay and refuses host fallthrough during remote project renders, leaving the deployment-level VERYFRONT_RELEASE_ASSET_MANIFEST flag permanently off in production. Found during staging E2E verification: manifest built and served correctly, but HTML never consumed it. Reads via getHostEnv instead. Bumps 0.1.766.