### PR TITLE
Remove Tailwind extension dependency on esm.sh

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.768",
+  "version": "0.1.769",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/deno.lock
+++ b/deno.lock
@@ -66,6 +66,7 @@
     "npm:remark-gfm@4.0.1": "4.0.1",
     "npm:remark-parse@11.0.0": "11.0.0",
     "npm:remark-rehype@11.1.2": "11.1.2",
+    "npm:tailwindcss@4.2.2": "4.2.2",
     "npm:unified@11.0.5": "11.0.5",
     "npm:unist-util-visit@5.1.0": "5.1.0",
     "npm:vfile@6.0.3": "6.0.3",
@@ -3846,6 +3847,9 @@
     "symbol-tree@3.2.4": {
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
+    "tailwindcss@4.2.2": {
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="
+    },
     "tar-fs@2.1.4": {
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "dependencies": [
@@ -4846,7 +4850,8 @@
       "extensions/ext-css-tailwind": {
         "dependencies": [
           "jsr:@std/assert@1.0.19",
-          "jsr:@std/testing@1.0.17"
+          "jsr:@std/testing@1.0.17",
+          "npm:tailwindcss@4.2.2"
         ]
       },
       "extensions/ext-db-sqlite": {

--- a/extensions/ext-css-tailwind/deno.json
+++ b/extensions/ext-css-tailwind/deno.json
@@ -12,10 +12,10 @@
     ]
   },
   "imports": {
-    "tailwindcss": "https://esm.sh/tailwindcss@4.2.2",
-    "tailwindcss/plugin": "https://esm.sh/tailwindcss@4.2.2/plugin",
-    "tailwindcss/defaultTheme": "https://esm.sh/tailwindcss@4.2.2/defaultTheme",
-    "tailwindcss/colors": "https://esm.sh/tailwindcss@4.2.2/colors",
+    "tailwindcss": "npm:tailwindcss@4.2.2",
+    "tailwindcss/plugin": "npm:tailwindcss@4.2.2/plugin",
+    "tailwindcss/defaultTheme": "npm:tailwindcss@4.2.2/defaultTheme",
+    "tailwindcss/colors": "npm:tailwindcss@4.2.2/colors",
     "@std/assert": "jsr:@std/assert@1.0.19",
     "@std/testing/bdd": "jsr:@std/testing@1.0.17/bdd",
     "veryfront/extensions": "../../src/extensions/index.ts",

--- a/scripts/build/generate-sbom.test.ts
+++ b/scripts/build/generate-sbom.test.ts
@@ -131,20 +131,22 @@ describe("componentsFromLock", () => {
     );
   });
 
-  it("can emit lock and esm.sh components for one workspace manifest boundary", () => {
+  it("can emit lock and import-map components for one workspace manifest boundary", () => {
     const lock = JSON.stringify({
       version: "5",
       specifiers: {
         "npm:bash-tool@1.3.16": "1.3.16",
+        "npm:tailwindcss@4.2.2": "4.2.2",
       },
       npm: {
         "bash-tool@1.3.16": { integrity: "sha512-shell", dependencies: [] },
+        "tailwindcss@4.2.2": { integrity: "sha512-tailwind", dependencies: [] },
       },
       workspace: {
         dependencies: [],
         members: {
           "extensions/ext-css-tailwind": {
-            dependencies: ["npm:bash-tool@1.3.16"],
+            dependencies: ["npm:bash-tool@1.3.16", "npm:tailwindcss@4.2.2"],
           },
         },
       },
@@ -156,7 +158,7 @@ describe("componentsFromLock", () => {
       {
         manifestImportsByPath: {
           "extensions/ext-css-tailwind/deno.json": {
-            tailwindcss: "https://esm.sh/tailwindcss@4.2.2",
+            tailwindcss: "npm:tailwindcss@4.2.2",
           },
         },
       },
@@ -216,15 +218,17 @@ describe("componentsFromLock", () => {
       version: "5",
       specifiers: {
         "npm:bash-tool@1.3.16": "1.3.16",
+        "npm:tailwindcss@4.2.2": "4.2.2",
       },
       npm: {
         "bash-tool@1.3.16": { integrity: "sha512-shell", dependencies: [] },
+        "tailwindcss@4.2.2": { integrity: "sha512-tailwind", dependencies: [] },
       },
       workspace: {
         dependencies: [],
         members: {
           "extensions/ext-css-tailwind": {
-            dependencies: [],
+            dependencies: ["npm:tailwindcss@4.2.2"],
           },
           "extensions/ext-sandbox-shell-tools": {
             dependencies: ["npm:bash-tool@1.3.16"],
@@ -250,8 +254,8 @@ describe("componentsFromLock", () => {
             "https://esm.sh/react@19.2.4/jsx-runtime?deps=csstype@3.2.3&external=react&target=es2022",
         },
         "extensions/ext-css-tailwind/deno.json": {
-          tailwindcss: "https://esm.sh/tailwindcss@4.2.2",
-          "tailwindcss/plugin": "https://esm.sh/tailwindcss@4.2.2/plugin",
+          tailwindcss: "npm:tailwindcss@4.2.2",
+          "tailwindcss/plugin": "npm:tailwindcss@4.2.2/plugin",
         },
       },
     });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.768";
+export const VERSION = "0.1.769";


### PR DESCRIPTION
## Summary

- Replace the Tailwind extension's `esm.sh` Tailwind imports with pinned `npm:tailwindcss@4.2.2` imports.
- Keep `deno.lock` to the minimal Tailwind npm additions needed for frozen cache resolution.
- Bump the veryfront-code package version to `0.1.769` so this follow-up can produce a fresh release after #2380.
- Update SBOM tests to model Tailwind as an npm workspace dependency.

## Why

PR #2380 fixed the Security Audit failure, but the RSC browser e2e job then failed before test execution because CI could not import `https://esm.sh/tailwindcss@4.2.2` and received a 522. This removes that CDN dependency from the Tailwind extension path while preserving the same Tailwind version.

## Verification

- `deno cache --lock=deno.lock --frozen=true extensions/ext-css-tailwind/src/index.ts`
- `deno task audit && deno task lint:deps && deno task lint:core-deps`
- `deno test --no-check --allow-all src/utils/version.test.ts extensions/ext-css-tailwind/src/index.test.ts`
- `deno test --config=scripts/test.deno.json --no-check --allow-all scripts/build/generate-sbom.test.ts scripts/build/npm-dependency-sources.test.ts`
- `deno task test:e2e:rsc-browser --no-lock --no-run`
- `deno fmt --check deno.json src/utils/version-constant.ts extensions/ext-css-tailwind/deno.json`
- `deno fmt --check --config=scripts/test.deno.json scripts/build/generate-sbom.test.ts`
- `git diff --check`
- Pre-push hook: format, lint, typecheck, and `2133 passed (18456 steps) | 0 failed`

## Notes

A full local browser e2e run reached Playwright after the Tailwind import fix, but local macOS Chromium launch timed out. CI Linux is the target environment for full browser execution.