### PR TITLE
Emit manifest CSS asset link in production HTML

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.768",
+  "version": "0.1.769",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -314,7 +314,15 @@ async function generateHTMLShellPartsImpl(
     : "";
 
   let tailwindCSSBlock = "";
-  if (useProductionCSS) {
+  // Manifest-consumed CSS: when a ready release asset manifest carries a
+  // compiled CSS entry, serve it from the immutable asset path (no renderer
+  // involvement). Per-entry fallback: no manifest CSS → existing JIT link.
+  const manifestForCss = options.studioEmbed ? null : getReadyManifestForRender(options.releaseId);
+  const manifestCssEntry = useProductionCSS ? manifestForCss?.css?.[0] : undefined;
+  if (manifestCssEntry) {
+    tailwindCSSBlock =
+      `<link rel="stylesheet" href="/_vf/assets/${manifestCssEntry.contentHash}.css">`;
+  } else if (useProductionCSS) {
     const projectCSS = await profilePhase("html.project_css", () => projectCSSPromise);
     const cssHash = projectCSS?.hash ?? "";
     if (cssHash) {

--- a/src/html/html-shell-manifest.test.ts
+++ b/src/html/html-shell-manifest.test.ts
@@ -95,6 +95,33 @@ describe("html shell release asset manifest consumption", () => {
     assertStringIncludes(result.start, `/_vf/assets/${PAGE_HASH}.js`);
   });
 
+  it("emits the manifest CSS asset link when the manifest carries CSS", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    const CSS_HASH = "c".repeat(64);
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({
+        state: "ready",
+        manifest: {
+          ...manifest(),
+          css: [{
+            contentHash: CSS_HASH,
+            size: 10,
+            contentType: "text/css",
+            styleProfileHash: "sp",
+          }],
+          routes: { "/": { modules: ["pages/index.tsx"], css: [CSS_HASH] } },
+        },
+      })
+    );
+    await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
+    assertStringIncludes(result.start, `/_vf/assets/${CSS_HASH}.css`);
+    // The JIT project-CSS link is replaced, not duplicated.
+    assert(!result.start.includes("/_vf/css/"));
+  });
+
   it("falls back to the existing URL for an uncovered page when the flag is on", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     await primeReadyManifest();

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.768";
+export const VERSION = "0.1.769";


### PR DESCRIPTION
When a ready release asset manifest carries compiled CSS, the HTML shell links the immutable /_vf/assets/{hash}.css instead of the JIT /_vf/css route (per-entry fallback when the manifest has no CSS; flag-off byte-identical). Completes the CSS half of the release asset pipeline — manifest CSS production shipped in #2380, this consumes it. Bumps 0.1.769.