### PR TITLE
Reuse submitted form input within a run

### DIFF
--- a/src/agent/hosted/form-input-tool.test.ts
+++ b/src/agent/hosted/form-input-tool.test.ts
@@ -146,6 +146,45 @@ describe("agent/hosted-form-input-tool", () => {
     assertEquals(calls[1]?.init?.method, "GET");
   });
 
+  it("reuses a submitted form result instead of opening another form in the same run", async () => {
+    const calls = stubFetchSequence([
+      jsonResponse(createInputRequestRecord(), 201),
+      jsonResponse(
+        createInputRequestRecord({
+          status: "submitted",
+          submitted_at: "2026-04-04T00:00:30.000Z",
+          latest_response: createLatestResponse({ topic: "Support FAQ assistant" }),
+        }),
+        200,
+      ),
+    ]);
+
+    const context = createContext();
+    const formInputTool = createHostedFormInputTool(context, API_URL);
+    const firstResult = await formInputTool.execute(
+      createExecuteInput([{ type: "textarea", name: "topic", label: "Topic" }]),
+      { toolCallId: TOOL_CALL_ID },
+    );
+    const secondResult = await formInputTool.execute(
+      createExecuteInput([{ type: "textarea", name: "topic", label: "Topic" }]),
+      { toolCallId: "tool-call-2" },
+    );
+
+    assertEquals(firstResult, {
+      submitted: true,
+      values: { topic: "Support FAQ assistant" },
+      inputRequestId: INPUT_REQUEST_ID,
+    });
+    assertEquals(secondResult, {
+      submitted: true,
+      values: { topic: "Support FAQ assistant" },
+      inputRequestId: INPUT_REQUEST_ID,
+      reused: true,
+      reason: "A submitted form_input result already exists for this run.",
+    });
+    assertEquals(calls.length, 2);
+  });
+
   it("publishes a lifecycle data event for the created durable input request", async () => {
     const publishedEvents: unknown[] = [];
     stubFetchSequence([

--- a/src/agent/hosted/form-input-tool.ts
+++ b/src/agent/hosted/form-input-tool.ts
@@ -19,6 +19,10 @@ export interface HostedFormInputToolContext {
   conversationId?: string;
   parentRunId?: string;
   slashCommandArtifactPathSeen?: boolean;
+  submittedFormInputResult?: {
+    values: Record<string, unknown>;
+    inputRequestId: string;
+  };
 }
 
 /** Create hosted form input tool. */
@@ -47,6 +51,16 @@ async function executeDurableFormInputFlow(
 
   const conversationId = context.conversationId;
   const parentRunId = context.parentRunId;
+  if (context.submittedFormInputResult) {
+    return {
+      submitted: true,
+      values: context.submittedFormInputResult.values,
+      inputRequestId: context.submittedFormInputResult.inputRequestId,
+      reused: true,
+      reason: "A submitted form_input result already exists for this run.",
+    };
+  }
+
   const toolCallId =
     typeof execContext?.toolCallId === "string" && execContext.toolCallId.length > 0
       ? execContext.toolCallId
@@ -111,6 +125,10 @@ function resolveDurableInputRequestResult(
     if (containsExactArtifactPathValue(values)) {
       context.slashCommandArtifactPathSeen = true;
     }
+    context.submittedFormInputResult = {
+      values,
+      inputRequestId: snapshot.id,
+    };
 
     return {
       submitted: true,


### PR DESCRIPTION
## Summary
- cache the first submitted hosted form_input result on the run context
- return that submitted result for later form_input calls in the same run instead of opening another durable request
- add regression coverage for repeated form_input calls after submission

## Evidence
- Staging repro before fix: `/tmp/plan-debug-after-1516.json`, conversation `cd63e99b-8e26-4d79-b03d-a626361e4ae5`, two `form_input` dynamic tools, second unsubmitted, zero suggestions
- Red: `deno test --no-check --allow-all src/agent/hosted/form-input-tool.test.ts` failed with `Unexpected fetch call` on the second form request
- Green: `deno test --no-check --allow-all src/agent/hosted/form-input-tool.test.ts` passed, 5 steps
- Broader: `deno test --no-check --allow-all src/agent/hosted/form-input-tool.test.ts src/agent/runtime/tool-result-continuation.test.ts src/agent/hosted/chat-runtime-tool-assembly.test.ts` passed, 10 tests / 32 steps
- Format: `deno fmt --check src/agent/hosted/form-input-tool.ts src/agent/hosted/form-input-tool.test.ts` passed
- Commit hook: `deno task verify:quick` passed during commit

## Notes
- Keeps starter skills simple; duplicate-form prevention lives at the hosted form_input boundary.