### PR TITLE
Reuse submitted form input after continuation

### DIFF
--- a/src/agent/hosted/chat-preparation.ts
+++ b/src/agent/hosted/chat-preparation.ts
@@ -33,6 +33,7 @@ import {
   type ContextBudgetManagerOptions,
   ContextCompactionError,
 } from "./context-budget-manager.ts";
+import { findSubmittedFormInputResult } from "./form-input-tool.ts";
 
 /** Request payload for normalized hosted chat. */
 export type NormalizedHostedChatRequest = {
@@ -399,6 +400,7 @@ export async function prepareHostedChatExecution<
     fetchSteering: input.fetchSteering,
     buildInstructions: input.buildInstructions,
   });
+  const submittedFormInputResult = findSubmittedFormInputResult(normalized.effectiveMessages);
   const finalMessages = await prepareHostedChatRuntimeMessages(
     normalized.effectiveMessages,
     {
@@ -431,7 +433,10 @@ export async function prepareHostedChatExecution<
       ...budgetedContext.diagnostics,
     });
   }
-  const runtime = await input.createRuntime(runtimePreparation.creationOptions);
+  const runtime = await input.createRuntime({
+    ...runtimePreparation.creationOptions,
+    ...(submittedFormInputResult ? { submittedFormInputResult } : {}),
+  });
 
   return {
     ...normalized,

--- a/src/agent/hosted/chat-runtime-contract.ts
+++ b/src/agent/hosted/chat-runtime-contract.ts
@@ -89,6 +89,12 @@ export type HostedChatRuntimeProjectSteering<TRuntimeAgentDefinition> = {
   initialSkills?: RuntimeSkillDefinition[];
 };
 
+/** Submitted form_input result carried across hosted runtime continuations. */
+export type HostedSubmittedFormInputResult = {
+  values: Record<string, unknown>;
+  inputRequestId: string;
+};
+
 /** Options accepted by hosted chat runtime creation. */
 export type HostedChatRuntimeCreationOptions<TRuntimeAgentDefinition, TThinkingConfig> = {
   projectId: string | null;
@@ -112,4 +118,5 @@ export type HostedChatRuntimeCreationOptions<TRuntimeAgentDefinition, TThinkingC
   publishParentRunEvents?: (events: ConversationRunEvent[]) => Promise<void>;
   clientProfile?: RuntimeClientProfile | null;
   liveProjectSteering?: HostedChatRuntimeProjectSteering<TRuntimeAgentDefinition>;
+  submittedFormInputResult?: HostedSubmittedFormInputResult;
 };

--- a/src/agent/hosted/default-chat-runtime.test.ts
+++ b/src/agent/hosted/default-chat-runtime.test.ts
@@ -43,6 +43,10 @@ Deno.test("createDefaultHostedChatRuntime builds a cloud-backed hosted runtime",
       userId: "user-1",
       parentRunId: "run-1",
       parentMessageId: "message-1",
+      submittedFormInputResult: {
+        values: { topic: "Support FAQ assistant" },
+        inputRequestId: "input-request-1",
+      },
     },
     config: {
       apiUrl: "https://api.example.com",
@@ -64,5 +68,9 @@ Deno.test("createDefaultHostedChatRuntime builds a cloud-backed hosted runtime",
   assertEquals(capturedContext.branchId, "branch-1");
   assertEquals(capturedContext.model, "anthropic/claude-sonnet-4-6");
   assertEquals(capturedContext.userId, "user-1");
+  assertEquals(capturedContext.submittedFormInputResult, {
+    values: { topic: "Support FAQ assistant" },
+    inputRequestId: "input-request-1",
+  });
   assertEquals(capturedContext.availableToolNames, ["sleep"]);
 });

--- a/src/agent/hosted/default-chat-runtime.ts
+++ b/src/agent/hosted/default-chat-runtime.ts
@@ -83,6 +83,7 @@ export type DefaultHostedChatRuntimeTaskContext = HostedRuntimeStateResolverCont
   skillSourcePaths?: Readonly<Record<string, string>>;
   publishParentRunEvents?: DefaultHostedChatRuntimeCreationOptions["publishParentRunEvents"];
   availableToolNames?: string[];
+  submittedFormInputResult?: DefaultHostedChatRuntimeCreationOptions["submittedFormInputResult"];
 };
 
 /** Input payload for create default hosted chat runtime context. */
@@ -153,6 +154,7 @@ function createDefaultTaskContext(
     availableSkillIds: input.options.availableSkillIds,
     skillSourcePaths: input.options.skillSourcePaths,
     publishParentRunEvents: input.options.publishParentRunEvents,
+    submittedFormInputResult: input.options.submittedFormInputResult,
   };
 }
 

--- a/src/agent/hosted/form-input-tool.test.ts
+++ b/src/agent/hosted/form-input-tool.test.ts
@@ -2,7 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { ToolExecutionContext } from "#veryfront/tool";
-import { createHostedFormInputTool } from "../index.ts";
+import { createHostedFormInputTool, findSubmittedFormInputResult } from "../index.ts";
 
 const API_URL = "https://api.example.com";
 const AUTH_TOKEN = "token-123";
@@ -183,6 +183,32 @@ describe("agent/hosted-form-input-tool", () => {
       reason: "A submitted form_input result already exists for this run.",
     });
     assertEquals(calls.length, 2);
+  });
+
+  it("finds a submitted form_input result from persisted UI tool parts", () => {
+    const result = findSubmittedFormInputResult([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{
+          type: "dynamic-tool",
+          toolCallId: TOOL_CALL_ID,
+          toolName: "form_input",
+          state: "output-available",
+          input: { title: "Plan intake" },
+          output: {
+            submitted: true,
+            values: { idea: "Build a support assistant" },
+            inputRequestId: INPUT_REQUEST_ID,
+          },
+        }],
+      },
+    ]);
+
+    assertEquals(result, {
+      values: { idea: "Build a support assistant" },
+      inputRequestId: INPUT_REQUEST_ID,
+    });
   });
 
   it("publishes a lifecycle data event for the created durable input request", async () => {

--- a/src/agent/hosted/form-input-tool.ts
+++ b/src/agent/hosted/form-input-tool.ts
@@ -1,5 +1,7 @@
 import { tool, type ToolExecutionContext } from "#veryfront/tool";
 import { containsExactArtifactPathValue } from "../artifacts/slash-command-artifact-policy.ts";
+import type { ChatUiMessage, ChatUiMessagePart } from "../../chat/types.ts";
+import type { HostedSubmittedFormInputResult } from "./chat-runtime-contract.ts";
 import {
   buildInputRequestLifecycleDataEvent,
   createInputRequest,
@@ -13,16 +15,18 @@ import { executeDurableHumanInputFlow, type HumanInputResult } from "../input/hu
 const INPUT_REQUEST_TIMEOUT_MS = 5 * 60_000;
 const INPUT_REQUEST_POLL_INTERVAL_MS = 500;
 
+type PersistedFormInputToolPart = ChatUiMessagePart & {
+  toolCallId: string;
+  output: unknown;
+};
+
 /** Context for hosted form input tool. */
 export interface HostedFormInputToolContext {
   authToken: string;
   conversationId?: string;
   parentRunId?: string;
   slashCommandArtifactPathSeen?: boolean;
-  submittedFormInputResult?: {
-    values: Record<string, unknown>;
-    inputRequestId: string;
-  };
+  submittedFormInputResult?: HostedSubmittedFormInputResult;
 }
 
 /** Create hosted form input tool. */
@@ -144,4 +148,57 @@ function resolveDurableInputRequestResult(
   }
 
   return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isFormInputToolPart(part: ChatUiMessagePart): part is PersistedFormInputToolPart {
+  if (!isRecord(part)) {
+    return false;
+  }
+  const record = part as Record<string, unknown>;
+  if (typeof record.toolCallId !== "string" || !("output" in record)) {
+    return false;
+  }
+  const toolName = typeof record.toolName === "string" ? record.toolName : undefined;
+
+  return toolName === "form_input" || part.type === "tool-form_input";
+}
+
+function extractSubmittedFormInputResult(
+  part: ChatUiMessagePart,
+): HostedSubmittedFormInputResult | undefined {
+  if (!isFormInputToolPart(part) || !isRecord(part.output)) {
+    return undefined;
+  }
+  if (part.output.submitted !== true || !isRecord(part.output.values)) {
+    return undefined;
+  }
+
+  const inputRequestId = typeof part.output.inputRequestId === "string" &&
+      part.output.inputRequestId.length > 0
+    ? part.output.inputRequestId
+    : part.toolCallId;
+
+  return {
+    values: part.output.values,
+    inputRequestId,
+  };
+}
+
+/** Find the latest submitted form_input result persisted in UI messages. */
+export function findSubmittedFormInputResult(
+  messages: readonly ChatUiMessage[],
+): HostedSubmittedFormInputResult | undefined {
+  let result: HostedSubmittedFormInputResult | undefined;
+
+  for (const message of messages) {
+    for (const part of message.parts) {
+      result = extractSubmittedFormInputResult(part) ?? result;
+    }
+  }
+
+  return result;
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1716,6 +1716,7 @@ export {
 export {
   createHostedFormInputTool,
   createHostedFormInputTool as createAgentServiceFormInputTool,
+  findSubmittedFormInputResult,
   type HostedFormInputToolContext,
   type HostedFormInputToolContext as AgentServiceFormInputToolContext,
 } from "./hosted/form-input-tool.ts";


### PR DESCRIPTION
## Summary
- Hydrate hosted form_input from the latest submitted persisted UI tool result when a run continues.
- Keep duplicate-form prevention at the hosted tool boundary instead of adding more skill prompt rules.
- Export and test the submitted-form scanner.

## Evidence
- Staging artifact 20260613003055-e82e55e014f7 still reproduced the issue: Create a plan showed one submitted intake followed by a second active plan form.
- Targeted hosted/runtime tests passed: 21 tests, 33 steps.
- Focused deno check passed for form-input-tool, chat-preparation, default-chat-runtime, and agent index.
- deno task verify:quick passed locally and in pre-commit.

## Follow-up after merge
- Publish the new veryfront package, bump veryfront-agent, deploy staging, and rerun all four starter suggestions with browser evidence.