### PR TITLE
Publish runtime continuation fix as 0.1.770

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.769",
+  "version": "0.1.770",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.769";
+export const VERSION = "0.1.770";


### PR DESCRIPTION
## Summary
- bump veryfront-code package version from 0.1.769 to 0.1.770
- unblock publishing the runtime continuation fix merged in #2384

## Why
The main release for #2384 failed at `Ensure stable version is unpublished` because `veryfront@0.1.769` was already published. veryfront-agent cannot consume the continuation form-input fix until a new package version exists.

## Verification
- `deno fmt --check deno.json`
- `deno task verify:quick`
- confirmed `npm view veryfront@0.1.770 version` returns 404 before publish, so the release guard should pass

## Notes
- One-file version-only PR. Runtime behavior was reviewed in #2384.