### PR TITLE
Publish runtime skill-reload guard

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.770",
+  "version": "0.1.771",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.770";
+export const VERSION = "0.1.771";


### PR DESCRIPTION
## Summary
- bump veryfront package version to 0.1.771
- keep src/utils/version-constant.ts synchronized with deno.json

## Evidence
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts
- deno task verify:quick

## Follow-up validation
- wait for main release to publish veryfront@0.1.771
- bump veryfront-agent and deploy staging
- rerun starter suggestion flows with agent-browser