### PR TITLE
Stop repeated skill intake after submitted forms

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.771",
+  "version": "0.1.772",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/hosted/form-input-tool.test.ts
+++ b/src/agent/hosted/form-input-tool.test.ts
@@ -180,7 +180,8 @@ describe("agent/hosted-form-input-tool", () => {
       values: { topic: "Support FAQ assistant" },
       inputRequestId: INPUT_REQUEST_ID,
       reused: true,
-      reason: "A submitted form_input result already exists for this run.",
+      reason:
+        "A submitted form_input result already exists for this run. Use these values as final input, do not call form_input again, and continue to the requested output.",
     });
     assertEquals(calls.length, 2);
   });

--- a/src/agent/hosted/form-input-tool.ts
+++ b/src/agent/hosted/form-input-tool.ts
@@ -61,7 +61,8 @@ async function executeDurableFormInputFlow(
       values: context.submittedFormInputResult.values,
       inputRequestId: context.submittedFormInputResult.inputRequestId,
       reused: true,
-      reason: "A submitted form_input result already exists for this run.",
+      reason:
+        "A submitted form_input result already exists for this run. Use these values as final input, do not call form_input again, and continue to the requested output.",
     };
   }
 

--- a/src/agent/runtime/load-skill-tool.test.ts
+++ b/src/agent/runtime/load-skill-tool.test.ts
@@ -165,11 +165,50 @@ Use form_input once, then produce the plan.`,
   assertStringIncludes(firstResult.instructions, "Use form_input once");
   assertStringIncludes(secondResult.instructions, 'Skill "plan" is already loaded');
   assertStringIncludes(secondResult.instructions, "Do not call load_skill");
+  assertStringIncludes(secondResult.instructions, "do not call form_input again");
   assertEquals(secondResult.allowedTools, ["read_file"]);
   assertEquals(secondResult.delegationTools, ["read_file", "write_file"]);
   assertEquals(secondResult.unavailableCurrentRunTools, ["write_file"]);
   assertEquals(secondResult.maxSteps, 8);
   assertEquals(secondResult.references, ["references/plan.md"]);
+});
+
+Deno.test("createRuntimeLoadSkillTool removes form_input from same-skill reload policy", async () => {
+  const context = createProjectContext({
+    availableToolNames: ["form_input", "studio_suggestions", "create_file"],
+  });
+  const tool = createRuntimeLoadSkillTool({
+    context,
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({}),
+    builtinStore: createBuiltinStore({
+      skills: new Map([
+        [
+          "plan",
+          `---
+allowed-tools:
+  - form_input
+  - studio_suggestions
+  - create_file
+---
+# Plan
+
+Use one form, then write the plan.`,
+        ],
+      ]),
+    }),
+  });
+
+  const firstResult = expectLoadedSkillResponse(await tool.execute({ skillId: "plan" }));
+  const secondResult = expectLoadedSkillResponse(await tool.execute({ skillId: "plan" }));
+
+  assertEquals(firstResult.allowedTools, ["form_input", "studio_suggestions", "create_file"]);
+  assertEquals(secondResult.allowedTools, ["studio_suggestions", "create_file"]);
+  assertEquals(secondResult.delegationTools, [
+    "form_input",
+    "studio_suggestions",
+    "create_file",
+  ]);
 });
 
 Deno.test("createRuntimeLoadSkillTool loads project and builtin reference files", async () => {

--- a/src/agent/runtime/load-skill-tool.ts
+++ b/src/agent/runtime/load-skill-tool.ts
@@ -162,13 +162,24 @@ function buildAlreadyLoadedSkillResponse(
   skillId: string,
   response: RuntimeLoadedSkillResponse,
 ): RuntimeLoadedSkillResponse {
+  const finishAllowedTools = response.allowedTools?.filter((toolName) => toolName !== "form_input");
+
   return {
     ...response,
     instructions:
       `Skill "${skillId}" is already loaded in this turn. Do not call load_skill for "${skillId}" again. ` +
-      "Continue from the existing user request and any submitted tool results, then produce the next useful response now.",
+      "Continue from the existing user request and any submitted tool results, then produce the next useful response now. " +
+      "If a form_input result already exists, treat it as final for this turn and do not call form_input again.",
     nextStep:
       "Continue now. Do not reload this skill or restart intake; use the existing context and finish the current turn.",
+    ...(finishAllowedTools
+      ? {
+        allowedTools: finishAllowedTools,
+        note: finishAllowedTools.length > 0
+          ? response.note
+          : "IMPORTANT: Intake is complete for this turn. Do not call form_input again; finish with the existing context.",
+      }
+      : {}),
     references: response.references,
   };
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.771";
+export const VERSION = "0.1.772";


### PR DESCRIPTION
## Summary\n- Makes repeated same-skill `load_skill` responses remove `form_input` from the active same-turn allowed-tool policy.\n- Makes reused `form_input` output explicitly tell the model to use the submitted values as final input and continue.\n- Bumps `veryfront` to `0.1.772` for publishing.\n\n## Browser evidence before fix\nStaging artifact `20260613030644-abd417024a60` still looped on a fresh `Create a plan` starter flow after submitting the form. Downloaded debug JSON: `/tmp/vf-plan-after-0771-loop.json`.\n\nObserved from debug JSON:\n- status: `streaming`\n- `tool-load_skill`: 6 calls, all `plan`\n- forms: 1 real submitted `Plan intake`, then 6 reused submitted forms\n- repeated form titles included `Plan details`, `Plan scope`, and `What should this plan cover?`\n\nRoot cause from tool output: repeated `load_skill` responses were concise, but still carried original `allowedTools` including `form_input`, so the next step could keep reopening/reusing intake.\n\n## Verification\n- `deno test --no-check --allow-all src/agent/runtime/load-skill-tool.test.ts src/agent/hosted/form-input-tool.test.ts src/agent/runtime/skill-policy.test.ts src/utils/version.test.ts src/utils/logger/logger.test.ts` -> 13 files/tests groups passed, 105 steps, 0 failed\n- `deno fmt --check src/agent/runtime/load-skill-tool.ts src/agent/runtime/load-skill-tool.test.ts src/agent/hosted/form-input-tool.ts src/agent/hosted/form-input-tool.test.ts deno.json src/utils/version-constant.ts` -> checked 6 files\n- `deno task verify:quick` -> passed\n- Pre-commit `deno task verify:quick` -> passed\n\n## Staging validation plan\nAfter merge and publish of `veryfront@0.1.772`, bump `veryfront-agent` to consume it, deploy staging, then rerun all four starter suggestions with agent-browser and inspect screenshots/debug JSON for loop-free form completion.\n