### PR TITLE
Close form input after submitted intake

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.772",
+  "version": "0.1.773",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -67,6 +67,7 @@ import {
   extractSkillPolicy,
   hydrateActiveSkillStateFromMessages,
   LOAD_SKILL_TOOL_ID,
+  removeFormInputAfterSubmission,
 } from "./skill-policy-enforcement.ts";
 import {
   getRuntimeAllowedRemoteTools,
@@ -754,6 +755,11 @@ export class AgentRuntime {
                 activeSkillDelegationOverrides = extractSkillDelegationOverrides(result);
                 mustLoadSkillFirst = false;
               }
+              activeSkillPolicy = removeFormInputAfterSubmission(
+                tc.toolName,
+                result,
+                activeSkillPolicy,
+              );
 
               const toolResultMessage = createToolResultMessage(
                 tc.toolCallId,
@@ -1171,6 +1177,11 @@ export class AgentRuntime {
             activeSkillDelegationOverrides = extractSkillDelegationOverrides(result);
             mustLoadSkillFirst = false;
           }
+          activeSkillPolicy = removeFormInputAfterSubmission(
+            tc.name,
+            result,
+            activeSkillPolicy,
+          );
 
           const dynamic = isDynamicTool(tc.name);
           sendSSE(controller, encoder, {

--- a/src/agent/runtime/skill-policy-enforcement.ts
+++ b/src/agent/runtime/skill-policy-enforcement.ts
@@ -13,6 +13,7 @@ import {
 const logger = serverLogger.component("agent");
 
 export const LOAD_SKILL_TOOL_ID = "load_skill";
+export const FORM_INPUT_TOOL_ID = "form_input";
 
 function getSkillActivationRequiredError(toolName: string): string {
   return `Tool "${toolName}" cannot run before load_skill succeeds in the same step. ` +
@@ -64,6 +65,26 @@ export function extractSkillPolicy(result: unknown): string[] | undefined {
     );
     return [];
   }
+}
+
+function isSubmittedFormInputResult(result: unknown): boolean {
+  return Boolean(result) && typeof result === "object" &&
+    (result as { submitted?: unknown }).submitted === true;
+}
+
+export function removeFormInputAfterSubmission(
+  toolName: string,
+  result: unknown,
+  activeSkillPolicy: string[] | undefined,
+): string[] | undefined {
+  if (
+    toolName !== FORM_INPUT_TOOL_ID || !isSubmittedFormInputResult(result) ||
+    activeSkillPolicy === undefined
+  ) {
+    return activeSkillPolicy;
+  }
+
+  return activeSkillPolicy.filter((allowedToolName) => allowedToolName !== FORM_INPUT_TOOL_ID);
 }
 
 export type SkillPolicyResult =

--- a/src/agent/runtime/skill-policy.test.ts
+++ b/src/agent/runtime/skill-policy.test.ts
@@ -5,6 +5,7 @@ import {
   enforceSkillPolicy,
   extractSkillPolicy,
   hydrateActiveSkillStateFromMessages,
+  removeFormInputAfterSubmission,
 } from "./skill-policy-enforcement.ts";
 import type { Message } from "../types.ts";
 
@@ -134,6 +135,36 @@ describe("src/agent/runtime skill policy helpers", () => {
       assertEquals(enforceSkillPolicy("Read", undefined, false), { allowed: true });
       assertEquals(enforceSkillPolicy("Write", undefined, false), { allowed: true });
       assertEquals(enforceSkillPolicy("Bash", undefined, false), { allowed: true });
+    });
+  });
+
+  describe("removeFormInputAfterSubmission", () => {
+    it("removes form_input from the active policy after a submitted form result", () => {
+      assertEquals(
+        removeFormInputAfterSubmission("form_input", { submitted: true }, [
+          "form_input",
+          "studio_suggestions",
+          "create_file",
+        ]),
+        ["studio_suggestions", "create_file"],
+      );
+    });
+
+    it("keeps form_input available for non-submitted or non-form tool results", () => {
+      assertEquals(
+        removeFormInputAfterSubmission("form_input", { submitted: false }, [
+          "form_input",
+          "studio_suggestions",
+        ]),
+        ["form_input", "studio_suggestions"],
+      );
+      assertEquals(
+        removeFormInputAfterSubmission("web_search", { submitted: true }, [
+          "form_input",
+          "web_search",
+        ]),
+        ["form_input", "web_search"],
+      );
     });
   });
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.772";
+export const VERSION = "0.1.773";


### PR DESCRIPTION
## Summary
- Remove form_input from the active skill policy immediately after a submitted form result.
- Keep the existing repeated-load guard, but prevent the next model step from seeing form_input at all after intake is complete.
- Bump veryfront to 0.1.773 for release.

## Staging evidence motivating this
- Research starter on 0.1.772 produced an output but then planned a second invalid form_input in the same run.
- Debug artifact: /tmp/vf-research-after-0772.json showed one submitted Research brief form plus a second output-error form; conversation status ready with generic error.

## Verification
- deno test --no-check --allow-all src/agent/runtime/skill-policy.test.ts src/agent/runtime/load-skill-tool.test.ts src/agent/hosted/form-input-tool.test.ts src/utils/version.test.ts src/utils/logger/logger.test.ts
- deno fmt --check src/agent/runtime/index.ts src/agent/runtime/skill-policy-enforcement.ts src/agent/runtime/skill-policy.test.ts deno.json src/utils/version-constant.ts
- deno task verify:quick
