### PR TITLE
Narrow starter form policy after intake

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.773",
+  "version": "0.1.774",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -64,6 +64,7 @@ import {
 } from "./tool-result-continuation.ts";
 import {
   enforceSkillPolicy,
+  extractSkillId,
   extractSkillPolicy,
   hydrateActiveSkillStateFromMessages,
   LOAD_SKILL_TOOL_ID,
@@ -532,6 +533,7 @@ export class AgentRuntime {
 
       // Request-scoped skill policy (not class-level mutable state)
       const hydratedSkillState = hydrateActiveSkillStateFromMessages(currentMessages);
+      let activeSkillId = hydratedSkillState.activeSkillId;
       let activeSkillPolicy = hydratedSkillState.activeSkillPolicy;
       let activeSkillDelegationOverrides = hydratedSkillState.activeSkillDelegationOverrides;
       const allowedRemoteToolNames = getRuntimeAllowedRemoteTools(this.config);
@@ -751,6 +753,7 @@ export class AgentRuntime {
 
               // Track skill policy from load_skill results
               if (tc.toolName === LOAD_SKILL_TOOL_ID) {
+                activeSkillId = extractSkillId(result);
                 activeSkillPolicy = extractSkillPolicy(result);
                 activeSkillDelegationOverrides = extractSkillDelegationOverrides(result);
                 mustLoadSkillFirst = false;
@@ -758,6 +761,7 @@ export class AgentRuntime {
               activeSkillPolicy = removeFormInputAfterSubmission(
                 tc.toolName,
                 result,
+                activeSkillId,
                 activeSkillPolicy,
               );
 
@@ -845,6 +849,7 @@ export class AgentRuntime {
 
     // Request-scoped skill policy (not class-level mutable state)
     const hydratedSkillState = hydrateActiveSkillStateFromMessages(currentMessages);
+    let activeSkillId = hydratedSkillState.activeSkillId;
     let activeSkillPolicy = hydratedSkillState.activeSkillPolicy;
     let activeSkillDelegationOverrides = hydratedSkillState.activeSkillDelegationOverrides;
     let finalFinishReason: string | undefined;
@@ -1173,6 +1178,7 @@ export class AgentRuntime {
 
           // Track skill policy from load_skill results
           if (tc.name === LOAD_SKILL_TOOL_ID) {
+            activeSkillId = extractSkillId(result);
             activeSkillPolicy = extractSkillPolicy(result);
             activeSkillDelegationOverrides = extractSkillDelegationOverrides(result);
             mustLoadSkillFirst = false;
@@ -1180,6 +1186,7 @@ export class AgentRuntime {
           activeSkillPolicy = removeFormInputAfterSubmission(
             tc.name,
             result,
+            activeSkillId,
             activeSkillPolicy,
           );
 

--- a/src/agent/runtime/skill-policy-enforcement.ts
+++ b/src/agent/runtime/skill-policy-enforcement.ts
@@ -23,21 +23,30 @@ function getSkillActivationRequiredError(toolName: string): string {
 export function hydrateActiveSkillStateFromMessages(
   messages: readonly Message[],
 ): {
+  activeSkillId: string | undefined;
   activeSkillPolicy: string[] | undefined;
   activeSkillDelegationOverrides: SkillDelegationOverrides | undefined;
 } {
+  let activeSkillId: string | undefined;
   let activeSkillPolicy: string[] | undefined;
   let activeSkillDelegationOverrides: SkillDelegationOverrides | undefined;
 
   for (const message of messages) {
     for (const part of message.parts) {
       if (!isToolResultPart(part) || part.toolName !== LOAD_SKILL_TOOL_ID) continue;
+      activeSkillId = extractSkillId(part.result);
       activeSkillPolicy = extractSkillPolicy(part.result);
       activeSkillDelegationOverrides = extractSkillDelegationOverrides(part.result);
     }
   }
 
-  return { activeSkillPolicy, activeSkillDelegationOverrides };
+  return { activeSkillId, activeSkillPolicy, activeSkillDelegationOverrides };
+}
+
+export function extractSkillId(result: unknown): string | undefined {
+  if (!result || typeof result !== "object") return undefined;
+  const skillResult = result as { skillId?: unknown };
+  return typeof skillResult.skillId === "string" ? skillResult.skillId : undefined;
 }
 
 export function extractSkillPolicy(result: unknown): string[] | undefined {
@@ -75,6 +84,7 @@ function isSubmittedFormInputResult(result: unknown): boolean {
 export function removeFormInputAfterSubmission(
   toolName: string,
   result: unknown,
+  activeSkillId: string | undefined,
   activeSkillPolicy: string[] | undefined,
 ): string[] | undefined {
   if (
@@ -82,6 +92,28 @@ export function removeFormInputAfterSubmission(
     activeSkillPolicy === undefined
   ) {
     return activeSkillPolicy;
+  }
+
+  if (activeSkillId === "research") {
+    return activeSkillPolicy.filter((allowedToolName) =>
+      [
+        "studio_suggestions",
+        "web_search",
+        "web_fetch",
+        "create_file",
+        "update_file",
+      ].includes(allowedToolName)
+    );
+  }
+
+  if (
+    activeSkillId === "plan" ||
+    activeSkillId === "create-agent" ||
+    activeSkillId === "create-agentic-workflow"
+  ) {
+    return activeSkillPolicy.filter((allowedToolName) =>
+      ["studio_suggestions", "create_file", "update_file"].includes(allowedToolName)
+    );
   }
 
   return activeSkillPolicy.filter((allowedToolName) => allowedToolName !== FORM_INPUT_TOOL_ID);

--- a/src/agent/runtime/skill-policy.test.ts
+++ b/src/agent/runtime/skill-policy.test.ts
@@ -141,7 +141,7 @@ describe("src/agent/runtime skill policy helpers", () => {
   describe("removeFormInputAfterSubmission", () => {
     it("removes form_input from the active policy after a submitted form result", () => {
       assertEquals(
-        removeFormInputAfterSubmission("form_input", { submitted: true }, [
+        removeFormInputAfterSubmission("form_input", { submitted: true }, undefined, [
           "form_input",
           "studio_suggestions",
           "create_file",
@@ -152,18 +152,64 @@ describe("src/agent/runtime skill policy helpers", () => {
 
     it("keeps form_input available for non-submitted or non-form tool results", () => {
       assertEquals(
-        removeFormInputAfterSubmission("form_input", { submitted: false }, [
+        removeFormInputAfterSubmission("form_input", { submitted: false }, "plan", [
           "form_input",
           "studio_suggestions",
         ]),
         ["form_input", "studio_suggestions"],
       );
       assertEquals(
-        removeFormInputAfterSubmission("web_search", { submitted: true }, [
+        removeFormInputAfterSubmission("web_search", { submitted: true }, "plan", [
           "form_input",
           "web_search",
         ]),
         ["form_input", "web_search"],
+      );
+    });
+
+    it("narrows terminal starter skills to write and suggestion tools after submission", () => {
+      assertEquals(
+        removeFormInputAfterSubmission("form_input", { submitted: true }, "plan", [
+          "form_input",
+          "studio_suggestions",
+          "list_files",
+          "get_file",
+          "search_files",
+          "create_file",
+          "update_file",
+          "web_search",
+        ]),
+        ["studio_suggestions", "create_file", "update_file"],
+      );
+      assertEquals(
+        removeFormInputAfterSubmission(
+          "form_input",
+          { submitted: true },
+          "create-agentic-workflow",
+          [
+            "form_input",
+            "studio_suggestions",
+            "list_files",
+            "create_file",
+          ],
+        ),
+        ["studio_suggestions", "create_file"],
+      );
+    });
+
+    it("keeps source tools for research after submission but closes project inspection", () => {
+      assertEquals(
+        removeFormInputAfterSubmission("form_input", { submitted: true }, "research", [
+          "form_input",
+          "studio_suggestions",
+          "web_search",
+          "web_fetch",
+          "list_files",
+          "get_file",
+          "create_file",
+          "update_file",
+        ]),
+        ["studio_suggestions", "web_search", "web_fetch", "create_file", "update_file"],
       );
     });
   });
@@ -179,6 +225,7 @@ describe("src/agent/runtime skill policy helpers", () => {
             toolCallId: "load_skill_old",
             toolName: "load_skill",
             result: {
+              skillId: "old",
               allowedTools: ["Read"],
               model: "anthropic/claude-sonnet-4-5",
               thinking: true,
@@ -204,6 +251,7 @@ describe("src/agent/runtime skill policy helpers", () => {
             toolCallId: "load_skill_new",
             toolName: "load_skill",
             result: {
+              skillId: "new",
               allowedTools: ["Write"],
               model: "openai/gpt-5.1",
               thinking: false,
@@ -215,6 +263,7 @@ describe("src/agent/runtime skill policy helpers", () => {
 
       const hydrated = hydrateActiveSkillStateFromMessages(messages);
 
+      assertEquals(hydrated.activeSkillId, "new");
       assertEquals(hydrated.activeSkillPolicy, ["Write"]);
       assertEquals(hydrated.activeSkillDelegationOverrides, {
         model: "openai/gpt-5.1",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.773";
+export const VERSION = "0.1.774";


### PR DESCRIPTION
## Summary\n- Track the active skill id alongside the active skill policy.\n- After a submitted starter form, narrow the active policy to the tools needed to finish the current artifact.\n- Keep research source tools available after intake while closing extra forms and project inspection.\n\n## Evidence\n- Staging evidence before this runtime fix: plan still looped after submitted intake with repeated skill loads and project inspection in /tmp/vf-plan-after-0773-loop.json and /tmp/vf-plan-after-0773-final.png.\n- Local: deno test --no-check --allow-all src/agent/runtime/skill-policy.test.ts src/agent/runtime/load-skill-tool.test.ts src/agent/hosted/form-input-tool.test.ts src/utils/version.test.ts src/utils/logger/logger.test.ts\n- Local: deno fmt --check src/agent/runtime/index.ts src/agent/runtime/skill-policy-enforcement.ts src/agent/runtime/skill-policy.test.ts deno.json src/utils/version-constant.ts\n- Local: deno task verify:quick\n\n## Notes\nStaging browser validation will run after this publishes as veryfront@0.1.774 and veryfront-agent deploys the bumped runtime.