### PR TITLE
Preserve starter policy across reloads

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.774",
+  "version": "0.1.775",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/load-skill-tool.test.ts
+++ b/src/agent/runtime/load-skill-tool.test.ts
@@ -143,7 +143,7 @@ Deno.test("createRuntimeLoadSkillTool makes same-skill reloads concise and idemp
     builtinStore: createBuiltinStore({
       skills: new Map([
         [
-          "plan",
+          "write",
           `---
 allowed-tools:
   - read_file
@@ -155,27 +155,27 @@ max-steps: 8
 Use form_input once, then produce the plan.`,
         ],
       ]),
-      referenceLists: new Map([["plan", ["references/plan.md"]]]),
+      referenceLists: new Map([["write", ["references/write.md"]]]),
     }),
   });
 
-  const firstResult = expectLoadedSkillResponse(await tool.execute({ skillId: "plan" }));
-  const secondResult = expectLoadedSkillResponse(await tool.execute({ skillId: "plan" }));
+  const firstResult = expectLoadedSkillResponse(await tool.execute({ skillId: "write" }));
+  const secondResult = expectLoadedSkillResponse(await tool.execute({ skillId: "write" }));
 
   assertStringIncludes(firstResult.instructions, "Use form_input once");
-  assertStringIncludes(secondResult.instructions, 'Skill "plan" is already loaded');
+  assertStringIncludes(secondResult.instructions, 'Skill "write" is already loaded');
   assertStringIncludes(secondResult.instructions, "Do not call load_skill");
   assertStringIncludes(secondResult.instructions, "do not call form_input again");
   assertEquals(secondResult.allowedTools, ["read_file"]);
   assertEquals(secondResult.delegationTools, ["read_file", "write_file"]);
   assertEquals(secondResult.unavailableCurrentRunTools, ["write_file"]);
   assertEquals(secondResult.maxSteps, 8);
-  assertEquals(secondResult.references, ["references/plan.md"]);
+  assertEquals(secondResult.references, ["references/write.md"]);
 });
 
 Deno.test("createRuntimeLoadSkillTool removes form_input from same-skill reload policy", async () => {
   const context = createProjectContext({
-    availableToolNames: ["form_input", "studio_suggestions", "create_file"],
+    availableToolNames: ["form_input", "studio_suggestions", "list_files", "create_file"],
   });
   const tool = createRuntimeLoadSkillTool({
     context,
@@ -189,6 +189,7 @@ Deno.test("createRuntimeLoadSkillTool removes form_input from same-skill reload 
 allowed-tools:
   - form_input
   - studio_suggestions
+  - list_files
   - create_file
 ---
 # Plan
@@ -202,11 +203,17 @@ Use one form, then write the plan.`,
   const firstResult = expectLoadedSkillResponse(await tool.execute({ skillId: "plan" }));
   const secondResult = expectLoadedSkillResponse(await tool.execute({ skillId: "plan" }));
 
-  assertEquals(firstResult.allowedTools, ["form_input", "studio_suggestions", "create_file"]);
+  assertEquals(firstResult.allowedTools, [
+    "form_input",
+    "studio_suggestions",
+    "list_files",
+    "create_file",
+  ]);
   assertEquals(secondResult.allowedTools, ["studio_suggestions", "create_file"]);
   assertEquals(secondResult.delegationTools, [
     "form_input",
     "studio_suggestions",
+    "list_files",
     "create_file",
   ]);
 });

--- a/src/agent/runtime/load-skill-tool.ts
+++ b/src/agent/runtime/load-skill-tool.ts
@@ -27,6 +27,7 @@ import {
   type RuntimeLoadedSkillResponseMessages,
   type RuntimeSkillMetadataLogger,
 } from "./skill-metadata.ts";
+import { narrowPolicyAfterSubmittedForm } from "./skill-policy-enforcement.ts";
 
 /** Shared runtime load skill continuation note value. */
 export const RUNTIME_LOAD_SKILL_CONTINUATION_NOTE =
@@ -162,7 +163,7 @@ function buildAlreadyLoadedSkillResponse(
   skillId: string,
   response: RuntimeLoadedSkillResponse,
 ): RuntimeLoadedSkillResponse {
-  const finishAllowedTools = response.allowedTools?.filter((toolName) => toolName !== "form_input");
+  const finishAllowedTools = narrowPolicyAfterSubmittedForm(skillId, response.allowedTools);
 
   return {
     ...response,

--- a/src/agent/runtime/skill-policy-enforcement.ts
+++ b/src/agent/runtime/skill-policy-enforcement.ts
@@ -94,6 +94,15 @@ export function removeFormInputAfterSubmission(
     return activeSkillPolicy;
   }
 
+  return narrowPolicyAfterSubmittedForm(activeSkillId, activeSkillPolicy);
+}
+
+export function narrowPolicyAfterSubmittedForm(
+  activeSkillId: string | undefined,
+  activeSkillPolicy: string[] | undefined,
+): string[] | undefined {
+  if (!activeSkillPolicy) return activeSkillPolicy;
+
   if (activeSkillId === "research") {
     return activeSkillPolicy.filter((allowedToolName) =>
       [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.774";
+export const VERSION = "0.1.775";


### PR DESCRIPTION
## Summary\n- Reuse the submitted-form policy narrowing when a skill is reloaded in the same turn.\n- Prevent starter same-skill reloads from reintroducing inspection tools after intake.\n- Bump veryfront to 0.1.775 for deployable runtime verification.\n\n## Staging evidence\nAfter veryfront@0.1.774 and veryfront-agent artifact 20260613054330-9167daf1a566, Create a plan still reloaded plan repeatedly after a submitted form. Debug evidence:\n- /tmp/vf-plan-after-0774-reload-loop.json\n- /tmp/vf-plan-after-0774-reload-loop.png\n\nDebug summary showed one submitted Plan brief, five load_skill(plan) calls, and a second blocked form_input whose policy had been reset to include list_files/get_file/search_files.\n\n## Local evidence\n- deno test --no-check --allow-all src/agent/runtime/skill-policy.test.ts src/agent/runtime/load-skill-tool.test.ts src/agent/hosted/form-input-tool.test.ts src/utils/version.test.ts src/utils/logger/logger.test.ts\n- deno fmt --check src/agent/runtime/load-skill-tool.ts src/agent/runtime/skill-policy-enforcement.ts src/agent/runtime/load-skill-tool.test.ts src/agent/runtime/skill-policy.test.ts deno.json src/utils/version-constant.ts\n- deno task verify:quick\n\n## Follow-up\nAfter publish and agent deploy, rerun all four staging suggestions and inspect debug JSON for submitted forms and tool calls.