### PR TITLE
Reuse submitted forms through narrowed skill policy

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.775",
+  "version": "0.1.776",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -66,6 +66,7 @@ import {
   enforceSkillPolicy,
   extractSkillId,
   extractSkillPolicy,
+  hasSubmittedFormInputResult,
   hydrateActiveSkillStateFromMessages,
   LOAD_SKILL_TOOL_ID,
   removeFormInputAfterSubmission,
@@ -690,6 +691,9 @@ export class AgentRuntime {
               tc.toolName,
               activeSkillPolicy,
               mustLoadSkillFirst,
+              {
+                allowSubmittedFormInputReuse: hasSubmittedFormInputResult(currentMessages),
+              },
             );
             if (!policyCheck.allowed) {
               toolCall.status = "error";
@@ -1122,7 +1126,14 @@ export class AgentRuntime {
           continue;
         }
 
-        const policyCheck = enforceSkillPolicy(tc.name, activeSkillPolicy, mustLoadSkillFirst);
+        const policyCheck = enforceSkillPolicy(
+          tc.name,
+          activeSkillPolicy,
+          mustLoadSkillFirst,
+          {
+            allowSubmittedFormInputReuse: hasSubmittedFormInputResult(currentMessages),
+          },
+        );
         if (!policyCheck.allowed) {
           await this.recordToolError(
             toolCall,

--- a/src/agent/runtime/skill-policy-enforcement.ts
+++ b/src/agent/runtime/skill-policy-enforcement.ts
@@ -81,6 +81,16 @@ function isSubmittedFormInputResult(result: unknown): boolean {
     (result as { submitted?: unknown }).submitted === true;
 }
 
+export function hasSubmittedFormInputResult(messages: readonly Message[]): boolean {
+  return messages.some((message) =>
+    message.parts.some((part) =>
+      isToolResultPart(part) &&
+      part.toolName === FORM_INPUT_TOOL_ID &&
+      isSubmittedFormInputResult(part.result)
+    )
+  );
+}
+
 export function removeFormInputAfterSubmission(
   toolName: string,
   result: unknown,
@@ -132,13 +142,25 @@ export type SkillPolicyResult =
   | { allowed: true }
   | { allowed: false; error: string };
 
+export type SkillPolicyOptions = {
+  allowSubmittedFormInputReuse?: boolean;
+};
+
 export function enforceSkillPolicy(
   toolName: string,
   activeSkillPolicy: string[] | undefined,
   mustLoadSkillFirst: boolean,
+  options: SkillPolicyOptions = {},
 ): SkillPolicyResult {
   if (mustLoadSkillFirst && toolName !== LOAD_SKILL_TOOL_ID) {
     return { allowed: false, error: getSkillActivationRequiredError(toolName) };
+  }
+
+  if (
+    toolName === FORM_INPUT_TOOL_ID &&
+    options.allowSubmittedFormInputReuse === true
+  ) {
+    return { allowed: true };
   }
 
   if (activeSkillPolicy && !isToolAllowedBySkill(toolName, activeSkillPolicy)) {

--- a/src/agent/runtime/skill-policy.test.ts
+++ b/src/agent/runtime/skill-policy.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   enforceSkillPolicy,
   extractSkillPolicy,
+  hasSubmittedFormInputResult,
   hydrateActiveSkillStateFromMessages,
   removeFormInputAfterSubmission,
 } from "./skill-policy-enforcement.ts";
@@ -97,6 +98,19 @@ describe("src/agent/runtime skill policy helpers", () => {
     it("should reject tool not in active policy", () => {
       const result = enforceSkillPolicy("Bash", ["Read", "Write"], false);
       assertEquals(result.allowed, false);
+    });
+
+    it("allows form_input through a narrowed policy only to reuse a submitted form", () => {
+      assertEquals(
+        enforceSkillPolicy("form_input", ["studio_suggestions"], false).allowed,
+        false,
+      );
+      assertEquals(
+        enforceSkillPolicy("form_input", ["studio_suggestions"], false, {
+          allowSubmittedFormInputReuse: true,
+        }),
+        { allowed: true },
+      );
     });
 
     it("should always allow skill system tools regardless of policy", () => {
@@ -215,6 +229,36 @@ describe("src/agent/runtime skill policy helpers", () => {
   });
 
   describe("hydrateActiveSkillStateFromMessages", () => {
+    it("detects a submitted form_input result in message history", () => {
+      const messages: Message[] = [
+        {
+          id: "tool_form_input",
+          role: "tool",
+          parts: [{
+            type: "tool-result",
+            toolCallId: "form_input_1",
+            toolName: "form_input",
+            result: { submitted: true, values: { topic: "Support FAQ assistant" } },
+          }],
+        },
+      ];
+
+      assertEquals(hasSubmittedFormInputResult(messages), true);
+      assertEquals(
+        hasSubmittedFormInputResult([{
+          id: "tool_form_input_pending",
+          role: "tool",
+          parts: [{
+            type: "tool-result",
+            toolCallId: "form_input_2",
+            toolName: "form_input",
+            result: { submitted: false, values: {} },
+          }],
+        }]),
+        false,
+      );
+    });
+
     it("hydrates the latest load_skill policy and delegation overrides from tool history", () => {
       const messages: Message[] = [
         {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.775";
+export const VERSION = "0.1.776";


### PR DESCRIPTION
## Summary\n- allow form_input through narrowed skill policy only when a submitted form result already exists\n- preserves the existing hosted form reuse behavior instead of surfacing policy errors\n- bump framework version to 0.1.776\n\n## Evidence\n- deno test --no-check --allow-all src/agent/runtime/skill-policy.test.ts src/agent/runtime/load-skill-tool.test.ts src/agent/hosted/form-input-tool.test.ts src/utils/version.test.ts\n- deno fmt --check src/agent/runtime/index.ts src/agent/runtime/skill-policy-enforcement.ts src/agent/runtime/skill-policy.test.ts deno.json src/utils/version-constant.ts\n- deno task verify:quick\n\n## Staging failure addressed\nCreate-agent submitted its first form successfully, then repeatedly attempted new form_input calls after policy narrowed to studio_suggestions/create_file/update_file. Those calls were rejected before the form tool could reuse the submitted values. This change keeps first-time post-submit forms blocked but lets submitted-form reuse complete.