### PR TITLE
Expose opt-in Server-Timing for TTFB diagnosis

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.776",
+  "version": "0.1.777",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/observability/request-profiler.test.ts
+++ b/src/observability/request-profiler.test.ts
@@ -1,0 +1,99 @@
+import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  buildServerTimingHeader,
+  finalizeRequestProfiling,
+  isRequestProfilingEnabled,
+  profilePhase,
+  resetRequestProfiles,
+  runWithRequestProfiling,
+  snapshotRequestProfiles,
+  updateRequestProfileContext,
+  withServerTimingHeader,
+} from "./request-profiler.ts";
+
+const ENV_KEYS = ["VERYFRONT_ENABLE_PERF_PROFILING", "VERYFRONT_ENABLE_SERVER_TIMING"] as const;
+
+function clearProfilerEnv(): void {
+  for (const key of ENV_KEYS) Deno.env.delete(key);
+}
+
+describe("request profiler", () => {
+  afterEach(() => {
+    clearProfilerEnv();
+    resetRequestProfiles();
+  });
+
+  it("keeps normal HTML requests unprofiled by default", () => {
+    assertEquals(isRequestProfilingEnabled("/"), false);
+    assertEquals(snapshotRequestProfiles().enabled, false);
+  });
+
+  it("profiles HTML requests when Server-Timing diagnostics are enabled", async () => {
+    Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
+
+    assertEquals(isRequestProfilingEnabled("/"), true);
+
+    const result = await runWithRequestProfiling(
+      {
+        category: "html",
+        method: "GET",
+        pathname: "/",
+      },
+      async () => {
+        updateRequestProfileContext({ projectSlug: "site", requestMode: "production" });
+        await profilePhase("runtime.resolve_project", () => Promise.resolve());
+        return finalizeRequestProfiling(200);
+      },
+    );
+
+    assertExists(result);
+    assertEquals(result.projectSlug, "site");
+    assertEquals(result.requestMode, "production");
+    assertEquals(result.status, 200);
+    assert("runtime.resolve_project" in result.phases);
+  });
+
+  it("formats a Server-Timing header from total and phase durations", () => {
+    const header = buildServerTimingHeader({
+      sequence: 1,
+      category: "html",
+      method: "GET",
+      pathname: "/",
+      status: 200,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      completedAt: "2026-01-01T00:00:00.010Z",
+      totalMs: 12.345,
+      phases: {
+        "runtime.resolve project": 3.456,
+        "handler.execute": 8,
+      },
+    });
+
+    assertEquals(
+      header,
+      "total;dur=12.35, runtime.resolve_project;dur=3.46, handler.execute;dur=8.00",
+    );
+  });
+
+  it("adds Server-Timing only when the diagnostic flag is enabled", () => {
+    const record = {
+      sequence: 1,
+      category: "html",
+      method: "GET",
+      pathname: "/",
+      status: 200,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      completedAt: "2026-01-01T00:00:00.010Z",
+      totalMs: 10,
+      phases: {},
+    };
+
+    const withoutFlag = withServerTimingHeader(new Response("ok"), record);
+    assertEquals(withoutFlag.headers.get("Server-Timing"), null);
+
+    Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
+    const withFlag = withServerTimingHeader(new Response("ok"), record);
+    assertEquals(withFlag.headers.get("Server-Timing"), "total;dur=10.00");
+  });
+});

--- a/src/observability/request-profiler.ts
+++ b/src/observability/request-profiler.ts
@@ -15,6 +15,11 @@ export interface RequestProfileRecord {
   phases: Record<string, number>;
 }
 
+export interface RequestProfileContextUpdate {
+  projectSlug?: string;
+  requestMode?: string;
+}
+
 interface RequestProfileSession {
   category: string;
   method: string;
@@ -38,15 +43,25 @@ function shouldEnableProfiling(): boolean {
   return getEnv("VERYFRONT_ENABLE_PERF_PROFILING") === "1";
 }
 
+function shouldEnableServerTiming(): boolean {
+  return getEnv("VERYFRONT_ENABLE_SERVER_TIMING") === "1";
+}
+
+function isHtmlPath(pathname: string): boolean {
+  return !pathname.startsWith("/_") && !pathname.startsWith("/api/") &&
+    !/\.[a-zA-Z0-9]+$/.test(pathname);
+}
+
 function shouldProfilePath(pathname: string): boolean {
   return pathname.startsWith("/bench/") ||
     pathname.startsWith("/api/bench/") ||
     pathname.startsWith("/_vf_styles/") ||
-    pathname.startsWith("/_vf_modules/");
+    pathname.startsWith("/_vf_modules/") ||
+    (shouldEnableServerTiming() && isHtmlPath(pathname));
 }
 
 export function isRequestProfilingEnabled(pathname?: string): boolean {
-  if (!shouldEnableProfiling()) return false;
+  if (!shouldEnableProfiling() && !shouldEnableServerTiming()) return false;
   if (!pathname) return true;
   return shouldProfilePath(pathname);
 }
@@ -100,9 +115,17 @@ export function profileSyncPhase<T>(name: string, fn: () => T): T {
   }
 }
 
-export function finalizeRequestProfiling(status?: number): void {
+export function updateRequestProfileContext(update: RequestProfileContextUpdate): void {
   const session = storage.getStore();
   if (!session) return;
+
+  if (update.projectSlug !== undefined) session.projectSlug = update.projectSlug;
+  if (update.requestMode !== undefined) session.requestMode = update.requestMode;
+}
+
+export function finalizeRequestProfiling(status?: number): RequestProfileRecord | null {
+  const session = storage.getStore();
+  if (!session) return null;
 
   const record: RequestProfileRecord = {
     sequence: ++sequence,
@@ -120,6 +143,48 @@ export function finalizeRequestProfiling(status?: number): void {
 
   records.push(record);
   while (records.length > MAX_RECORDS) records.shift();
+
+  return record;
+}
+
+function sanitizeMetricName(name: string): string {
+  return name.replace(/[^A-Za-z0-9!#$%&'*+\-.^_`|~]/g, "_");
+}
+
+function formatDuration(value: number): string {
+  return Math.max(0, roundMs(value)).toFixed(2);
+}
+
+export function buildServerTimingHeader(record: RequestProfileRecord): string {
+  const metrics = [`total;dur=${formatDuration(record.totalMs)}`];
+
+  for (const [name, duration] of Object.entries(record.phases).slice(0, 20)) {
+    metrics.push(`${sanitizeMetricName(name)};dur=${formatDuration(duration)}`);
+  }
+
+  return metrics.join(", ");
+}
+
+export function withServerTimingHeader(
+  response: Response,
+  record: RequestProfileRecord | null,
+): Response {
+  if (!record || !shouldEnableServerTiming()) return response;
+
+  const value = buildServerTimingHeader(record);
+
+  try {
+    response.headers.set("Server-Timing", value);
+    return response;
+  } catch {
+    const headers = new Headers(response.headers);
+    headers.set("Server-Timing", value);
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
 }
 
 export function snapshotRequestProfiles(): {
@@ -128,7 +193,7 @@ export function snapshotRequestProfiles(): {
   records: RequestProfileRecord[];
 } {
   return {
-    enabled: shouldEnableProfiling(),
+    enabled: shouldEnableProfiling() || shouldEnableServerTiming(),
     last_sequence: sequence,
     records: [...records],
   };

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -35,7 +35,10 @@ import { HealthHandler } from "../handlers/monitoring/health.handler.ts";
 import { MetricsHandler } from "../handlers/monitoring/metrics.handler.ts";
 import {
   finalizeRequestProfiling,
+  profilePhase,
   runWithRequestProfiling,
+  updateRequestProfileContext,
+  withServerTimingHeader,
 } from "#veryfront/observability/request-profiler.ts";
 import { ClientLogHandler } from "../handlers/monitoring/client-log.handler.ts";
 import { MemoryDebugHandler } from "../handlers/monitoring/memory.handler.ts";
@@ -488,35 +491,51 @@ export function createVeryfrontHandler(
           }
         }
 
+        const profileCategory = url.pathname.startsWith("/_vf_styles/")
+          ? "css"
+          : url.pathname.startsWith("/_vf_modules/")
+          ? "module"
+          : url.pathname.startsWith("/api/")
+          ? "api"
+          : "html";
+        let requestProfileRecord: ReturnType<typeof finalizeRequestProfiling> = null;
+
         const executeHandler = async (): Promise<Response> => {
           // Fast rejection of vulnerability scanner probes before any async work
           if (SCANNER_PATH_PATTERN.test(url.pathname)) {
             return new Response("Not Found", { status: 404 });
           }
 
-          await readyPromise;
+          await profilePhase("runtime.ready", () => readyPromise);
 
-          await timeAsync("security:load", async () => {
-            if (isProxyMode) return;
-            await securityLoader.ensureLoaded();
-          });
+          await timeAsync("security:load", () =>
+            profilePhase("runtime.security_load", async () => {
+              if (isProxyMode) return;
+              await securityLoader.ensureLoaded();
+            }));
 
-          await timeAsync("config:load", async () => {
-            await configPromise;
-          });
+          await timeAsync("config:load", () =>
+            profilePhase("runtime.config_load", async () => {
+              await configPromise;
+            }));
 
           const reqCtx = createRequestContext(req);
 
           const wsSlugOverride = url.searchParams.get("x-project-slug") || undefined;
 
           // Resolve project from various sources
-          const projectRes = await resolveProject(req, url, headers, {
-            config,
-            reqCtx,
-            defaultProjectSlug: opts.defaultProjectSlug,
-            defaultProjectId: opts.defaultProjectId,
-            wsSlugOverride,
-          });
+          const projectRes = await profilePhase(
+            "runtime.resolve_project",
+            () =>
+              resolveProject(req, url, headers, {
+                config,
+                reqCtx,
+                defaultProjectSlug: opts.defaultProjectSlug,
+                defaultProjectId: opts.defaultProjectId,
+                wsSlugOverride,
+              }),
+          );
+          updateRequestProfileContext({ projectSlug: projectRes.projectSlug });
 
           setProjectAttributes(spanInfo.span, projectRes.projectSlug, projectRes.proxyEnv);
 
@@ -543,21 +562,22 @@ export function createVeryfrontHandler(
           // Note: `x-project-path` is NOT forwarded via `headers.projectPath` anymore;
           // `resolveAdapter` reads it directly from `req` and only honours it when the
           // request is proxy-trusted (see isProxyTrusted).
-          const adapterRes = await resolveAdapter({
-            req,
-            projectDir,
-            adapter,
-            config,
-            projectSlug: projectRes.projectSlug,
-            projectId: projectRes.projectId,
-            proxyToken: reqCtx.token,
-            releaseId: projectRes.releaseId,
-            proxyEnv: projectRes.proxyEnv,
-            branch: reqCtx.branch,
-            environmentName: projectRes.environmentName,
-            parsedDomain: projectRes.parsedDomain,
-            isProxyMode,
-          });
+          const adapterRes = await profilePhase("runtime.resolve_adapter", () =>
+            resolveAdapter({
+              req,
+              projectDir,
+              adapter,
+              config,
+              projectSlug: projectRes.projectSlug,
+              projectId: projectRes.projectId,
+              proxyToken: reqCtx.token,
+              releaseId: projectRes.releaseId,
+              proxyEnv: projectRes.proxyEnv,
+              branch: reqCtx.branch,
+              environmentName: projectRes.environmentName,
+              parsedDomain: projectRes.parsedDomain,
+              isProxyMode,
+            }));
 
           // Resolve environment and validate
           const host = req.headers.get("x-forwarded-host") || req.headers.get("host") || url.host;
@@ -578,6 +598,7 @@ export function createVeryfrontHandler(
           if (envRes.errorResponse) {
             return envRes.errorResponse;
           }
+          updateRequestProfileContext({ requestMode: envRes.resolvedEnvironment });
 
           const skipRenderEnrichedContext = shouldSkipEnrichedContext(url.pathname);
 
@@ -612,15 +633,21 @@ export function createVeryfrontHandler(
             reqCtx.token &&
             projectRes.projectSlug
           ) {
-            envVarsForRequest = await envVarCache.get(
-              headers.environmentId,
-              reqCtx.token,
-              projectRes.projectSlug,
+            const environmentId = headers.environmentId;
+            const projectSlug = projectRes.projectSlug;
+            envVarsForRequest = await profilePhase(
+              "runtime.load_env_vars",
+              () =>
+                envVarCache.get(
+                  environmentId,
+                  reqCtx.token,
+                  projectSlug,
+                ),
             );
 
             logDebug("[runtime-handler] Project env vars fetched", {
-              projectSlug: projectRes.projectSlug,
-              environmentId: headers.environmentId,
+              projectSlug,
+              environmentId,
               count: Object.keys(envVarsForRequest).length,
             });
           }
@@ -632,41 +659,19 @@ export function createVeryfrontHandler(
           // reqCtx.token indicates the request came through the proxy with auth.
           // Without it (standalone / test), host env must remain accessible.
           const shouldIsolateEnv = !adapterRes.isLocalProject && !!reqCtx.token;
-          const response = await runWithRequestProfiling(
+          const response = await withSpan(
+            SpanNames.HANDLER_EXECUTE,
+            () =>
+              profilePhase("handler.execute", () => {
+                if (shouldIsolateEnv) {
+                  return runWithProjectEnv(envVarsForRequest, executeRoute);
+                }
+                return executeRoute();
+              }),
             {
-              category: url.pathname.startsWith("/_vf_styles/")
-                ? "css"
-                : url.pathname.startsWith("/_vf_modules/")
-                ? "module"
-                : url.pathname.startsWith("/api/")
-                ? "api"
-                : "html",
-              method: req.method,
-              pathname: url.pathname,
-              projectSlug: projectRes.projectSlug,
-              requestMode: envRes.resolvedEnvironment,
-            },
-            async () => {
-              let routedResponse: Response | null | undefined;
-              try {
-                routedResponse = await withSpan(
-                  SpanNames.HANDLER_EXECUTE,
-                  () => {
-                    if (shouldIsolateEnv) {
-                      return runWithProjectEnv(envVarsForRequest, executeRoute);
-                    }
-                    return executeRoute();
-                  },
-                  {
-                    "handler.project_slug": projectRes.projectSlug || "unknown",
-                    "handler.path": url.pathname,
-                    "handler.method": req.method,
-                  },
-                );
-                return routedResponse;
-              } finally {
-                finalizeRequestProfiling(routedResponse?.status);
-              }
+              "handler.project_slug": projectRes.projectSlug || "unknown",
+              "handler.path": url.pathname,
+              "handler.method": req.method,
             },
           );
 
@@ -684,7 +689,25 @@ export function createVeryfrontHandler(
         };
 
         const { response, error } = await withRequestTimeout(
-          () => executeWithTracingContext(spanInfo, executeHandler),
+          () =>
+            runWithRequestProfiling(
+              {
+                category: profileCategory,
+                method: req.method,
+                pathname: url.pathname,
+                projectSlug: headers.projectSlug,
+                requestMode: headers.environment,
+              },
+              async () => {
+                let profiledResponse: Response | undefined;
+                try {
+                  profiledResponse = await executeWithTracingContext(spanInfo, executeHandler);
+                  return profiledResponse;
+                } finally {
+                  requestProfileRecord = finalizeRequestProfiling(profiledResponse?.status);
+                }
+              },
+            ),
           url.pathname,
           req.method,
         );
@@ -701,7 +724,7 @@ export function createVeryfrontHandler(
         completeRequestTracking(lifecycle.requestId, response.status, isTimeout);
         completeIsolatedRequest(headers.projectSlug, lifecycle.shouldCheckIsolation, isTimeout);
 
-        return response;
+        return withServerTimingHeader(response, requestProfileRecord);
       } finally {
         endRequestLifecycle(lifecycle);
       }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.776";
+export const VERSION = "0.1.777";


### PR DESCRIPTION
## Summary
- add opt-in `VERYFRONT_ENABLE_SERVER_TIMING=1` support for HTML request Server-Timing diagnostics
- expand request profiling around runtime readiness, security/config load, project/adapter resolution, env-var loading, and handler execution
- keep public response headers disabled unless the diagnostic flag is set
- bump package version to `0.1.777` and sync the exported version constant

## Why
`codersociety.com` is still slow after the CSP fix. Current production checks show dynamic HTML TTFB around 1.0s to 3.5s, with one light-mode request at 6.9s TTFB, plus `0` `/_vf/assets` refs and about `30` `/_vf_modules` refs. Release asset manifests address the module waterfall, but they do not explain TTFB. This PR gives the renderer a safe diagnostic path to split request time by runtime phase before changing cache or render policy.

## Verification
- `deno fmt --check deno.json src/observability/request-profiler.ts src/observability/request-profiler.test.ts src/server/runtime-handler/index.ts`
- `deno check src/observability/request-profiler.ts src/server/runtime-handler/index.ts`
- `deno test --no-check --allow-all src/observability/request-profiler.test.ts src/server/runtime-handler/index.test.ts`
- `deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts`
- `git diff --check`
- pre-push hook: formatting, lint, typecheck, and unit suite passed: `2136 passed (18470 steps) | 0 failed | 0 ignored (2 steps)`
