### PR TITLE
Keep submitted starter forms inspectable

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.776",
+  "version": "0.1.777",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/load-skill-tool.test.ts
+++ b/src/agent/runtime/load-skill-tool.test.ts
@@ -209,7 +209,7 @@ Use one form, then write the plan.`,
     "list_files",
     "create_file",
   ]);
-  assertEquals(secondResult.allowedTools, ["studio_suggestions", "create_file"]);
+  assertEquals(secondResult.allowedTools, ["studio_suggestions", "list_files", "create_file"]);
   assertEquals(secondResult.delegationTools, [
     "form_input",
     "studio_suggestions",

--- a/src/agent/runtime/skill-policy-enforcement.ts
+++ b/src/agent/runtime/skill-policy-enforcement.ts
@@ -131,7 +131,14 @@ export function narrowPolicyAfterSubmittedForm(
     activeSkillId === "create-agentic-workflow"
   ) {
     return activeSkillPolicy.filter((allowedToolName) =>
-      ["studio_suggestions", "create_file", "update_file"].includes(allowedToolName)
+      [
+        "studio_suggestions",
+        "list_files",
+        "get_file",
+        "search_files",
+        "create_file",
+        "update_file",
+      ].includes(allowedToolName)
     );
   }
 

--- a/src/agent/runtime/skill-policy.test.ts
+++ b/src/agent/runtime/skill-policy.test.ts
@@ -181,7 +181,7 @@ describe("src/agent/runtime skill policy helpers", () => {
       );
     });
 
-    it("narrows terminal starter skills to write and suggestion tools after submission", () => {
+    it("narrows terminal starter skills to read, write, and suggestion tools after submission", () => {
       assertEquals(
         removeFormInputAfterSubmission("form_input", { submitted: true }, "plan", [
           "form_input",
@@ -193,7 +193,14 @@ describe("src/agent/runtime skill policy helpers", () => {
           "update_file",
           "web_search",
         ]),
-        ["studio_suggestions", "create_file", "update_file"],
+        [
+          "studio_suggestions",
+          "list_files",
+          "get_file",
+          "search_files",
+          "create_file",
+          "update_file",
+        ],
       );
       assertEquals(
         removeFormInputAfterSubmission(
@@ -207,7 +214,7 @@ describe("src/agent/runtime skill policy helpers", () => {
             "create_file",
           ],
         ),
-        ["studio_suggestions", "create_file"],
+        ["studio_suggestions", "list_files", "create_file"],
       );
     });
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.776";
+export const VERSION = "0.1.777";


### PR DESCRIPTION
## Summary
- allow terminal starter skills to keep read-only project inspection tools after submitted form intake
- keep form/web intake closed and write scope limited to existing create/update tools
- bump veryfront to 0.1.777 for agent runtime consumption

## Verification
- deno test --allow-all src/agent/runtime/skill-policy.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts src/agent/runtime/skill-policy-enforcement.ts src/agent/runtime/skill-policy.test.ts
- deno task verify:quick

## Staging evidence
- Staging runtime 0.1.776 still surfaced a post-form policy error in create-agent: `Tool "list_files" is not allowed by the active skill policy`.
- This change keeps that post-form inspection read-only and policy-allowed instead of broadening write/destructive access.