### PR TITLE
Release Server-Timing package under 0.1.778

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.777",
+  "version": "0.1.778",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.777";
+export const VERSION = "0.1.778";


### PR DESCRIPTION
## Summary

- Bump `veryfront` from `0.1.777` to `0.1.778` in `deno.json` and `src/utils/version-constant.ts`.
- This unblocks the already-merged Server-Timing release, because the main release job found `0.1.777` already exists on npm.

## Verification

- `git diff --check`
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno eval` version sync check
- npm/GitHub release/tag checks show `0.1.778` is unused
- Pre-push checks completed: format, lint, typecheck, and unit tests (`2136 passed`, `0 failed`)

## Notes

No runtime code changes. This only moves the package metadata to an unpublished version so the stable release workflow can publish.
