### PR TITLE
Serve framework imports from release assets

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.778",
+  "version": "0.1.779",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -224,12 +224,14 @@ async function generateHTMLShellPartsImpl(
   // Enable dev scripts for local dev OR preview mode (for HMR support in Studio),
   // unless a caller explicitly forces production client scripts for fair benchmarking.
   const useDevScripts = !options.forceProductionScripts && (isLocalProject || isPreviewMode);
+  const releaseManifest = options.studioEmbed ? null : getReadyManifestForRender(options.releaseId);
 
   const importMapPromise = buildImportMap({
     projectDir: options.projectDir,
     config: options.config,
     customImports: options.importMap,
     pretty: useDevScripts,
+    releaseAssetManifest: releaseManifest,
   });
 
   const hydrationDataJson = generateHydrationData(

--- a/src/html/html-shell-manifest.test.ts
+++ b/src/html/html-shell-manifest.test.ts
@@ -15,6 +15,7 @@ import { RELEASE_ASSET_MANIFEST_ENV_FLAG } from "#veryfront/release-assets/const
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 
 const PAGE_HASH = "a".repeat(64);
+const CHAT_HASH = "b".repeat(64);
 
 function meta(): RenderMetadata {
   return { title: "T", slug: "index", frontmatter: {} };
@@ -120,6 +121,31 @@ describe("html shell release asset manifest consumption", () => {
     assertStringIncludes(result.start, `/_vf/assets/${CSS_HASH}.css`);
     // The JIT project-CSS link is replaced, not duplicated.
     assert(!result.start.includes("/_vf/css/"));
+  });
+
+  it("rewrites covered framework import-map entries to manifest dependency assets", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({
+        state: "ready",
+        manifest: {
+          ...manifest(),
+          dependencies: {
+            "veryfront/chat": {
+              contentHash: CHAT_HASH,
+              size: 10,
+              contentType: "text/javascript",
+            },
+          },
+        },
+      })
+    );
+    await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
+    assertStringIncludes(result.start, `"veryfront/chat":"/_vf/assets/${CHAT_HASH}.js"`);
+    assertStringIncludes(result.start, `"@/":"/_vf_modules/"`);
   });
 
   it("falls back to the existing URL for an uncovered page when the flag is on", async () => {

--- a/src/html/utils.ts
+++ b/src/html/utils.ts
@@ -1,6 +1,7 @@
 import { escapeHTML } from "./html-escape.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
+import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import { VERYFRONT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import {
   DEFAULT_REACT_VERSION,
@@ -103,7 +104,7 @@ const AI_MODULE_UTILITIES: Record<string, string> = {
   "veryfront/workflow": PLATFORM_UTILITY_PATHS.workflow,
 };
 
-const PLATFORM_UTILITIES: Record<string, string> = {
+export const PLATFORM_UTILITIES: Record<string, string> = {
   ...CORE_PLATFORM_UTILITIES,
   ...AI_MODULE_UTILITIES,
 };
@@ -268,6 +269,7 @@ interface BuildImportMapOptions {
   config?: VeryfrontConfig;
   customImports?: Record<string, string>;
   pretty?: boolean;
+  releaseAssetManifest?: ReleaseAssetManifest | null;
 }
 
 function stringifyImportMap(imports: Record<string, string>, pretty = true): string {
@@ -280,12 +282,42 @@ function stableMapKey(imports?: Record<string, string>): string {
     : "";
 }
 
+function stableManifestDependencyKey(manifest?: ReleaseAssetManifest | null): string {
+  return manifest
+    ? JSON.stringify({
+      assetBasePath: manifest.assetBasePath,
+      dependencies: Object.entries(manifest.dependencies)
+        .map(([specifier, entry]) => [specifier, entry.contentHash])
+        .sort(([a], [b]) => String(a).localeCompare(String(b))),
+    })
+    : "";
+}
+
+function applyManifestDependencies(
+  imports: Record<string, string>,
+  manifest?: ReleaseAssetManifest | null,
+): Record<string, string> {
+  if (!manifest) return imports;
+
+  let rewritten: Record<string, string> | null = null;
+  for (const specifier of Object.keys(imports)) {
+    const entry = manifest.dependencies[specifier];
+    if (!entry || entry.contentType !== "text/javascript") continue;
+
+    rewritten ??= { ...imports };
+    rewritten[specifier] = `${manifest.assetBasePath}/${entry.contentHash}.js`;
+  }
+
+  return rewritten ?? imports;
+}
+
 function isImportMapOnlyOptions(
   options: BuildImportMapOptions | Record<string, string>,
 ): options is Record<string, string> {
   return !("projectDir" in options) &&
     !("config" in options) &&
     !("customImports" in options) &&
+    !("releaseAssetManifest" in options) &&
     !("pretty" in options);
 }
 
@@ -299,21 +331,22 @@ export async function buildImportMap(
     }
   }
 
-  const { projectDir, config, customImports, pretty = true } =
+  const { projectDir, config, customImports, pretty = true, releaseAssetManifest } =
     (options ?? {}) as BuildImportMapOptions;
   const mode = config?.client?.moduleResolution ?? "cdn";
   const versions = projectDir ? await resolveVersions(projectDir, config) : DEFAULT_VERSIONS;
 
   if (mode === "bundled") {
     const reactTemplates = CDN_URL_TEMPLATES["esm.sh"];
-    const imports: Record<string, string> = {
+    let imports: Record<string, string> = {
       react: reactTemplates.react(versions.react),
       "react-dom": reactTemplates.reactDom(versions.react),
       "react-dom/client": reactTemplates.reactDomClient(versions.react),
       "react/jsx-runtime": reactTemplates.jsxRuntime(versions.react),
       "react/jsx-dev-runtime": reactTemplates.jsxDevRuntime(versions.react),
-      ...customImports,
     };
+    imports = applyManifestDependencies(imports, releaseAssetManifest);
+    imports = { ...imports, ...customImports };
 
     return { imports, json: stringifyImportMap(imports, pretty) };
   }
@@ -329,6 +362,7 @@ export async function buildImportMap(
   }
 
   imports["@/"] = "/_vf_modules/";
+  imports = applyManifestDependencies(imports, releaseAssetManifest);
 
   if (customImports) {
     imports = { ...imports, ...customImports };
@@ -342,6 +376,7 @@ export async function buildImportMap(
     veryfront: versions.veryfront,
     pretty,
     customImports: stableMapKey(customImports),
+    manifestDependencies: stableManifestDependencyKey(releaseAssetManifest),
   });
   const cached = importMapJsonCache.get(cacheKey);
   if (cached) return cached;

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -107,9 +107,28 @@ describe("release asset build executor", () => {
     // No CSS pipeline injected → css empty + gap recorded.
     assertEquals(manifest.css.length, 0);
     assert(manifest.fallback.gaps.includes("css:no-pipeline"));
-    // Two distinct modules uploaded.
-    assertEquals(rec.uploads.length, 2);
+    // Project modules plus framework import-map dependencies are uploaded.
+    assert(rec.uploads.length >= 2);
     assert(rec.uploads.every((u) => u.contentType === "text/javascript"));
+  });
+
+  it("records framework import-map modules as manifest dependencies", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [{ path: "pages/index.tsx", content: "export default () => null;" }];
+    const client = makeClient(files, rec);
+    const transform = (source: string, sourceFile: string) =>
+      Promise.resolve(`/*${sourceFile}*/\n${source}`);
+
+    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertExists(manifest.dependencies["veryfront/chat"]);
+    assertExists(manifest.dependencies["veryfront/workflow"]);
+    assertEquals(
+      manifest.dependencies["veryfront/head"]?.contentHash,
+      manifest.dependencies["veryfront/react/head"]?.contentHash,
+    );
   });
 
   it("reports failed and does not PUT on a transform error", async () => {

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -19,7 +19,9 @@ import { serverLogger } from "#veryfront/utils";
 import { VERSION } from "#veryfront/utils/version.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { dirname, join } from "#veryfront/compat/path/index.ts";
+import { resolveFrameworkSourcePath } from "#veryfront/platform/compat/framework-source-resolver.ts";
 import { transformToESM } from "#veryfront/transforms/esm-transform.ts";
+import { PLATFORM_UTILITIES } from "#veryfront/html/utils.ts";
 import { sha256HexBytes } from "./hash.ts";
 import {
   RELEASE_ASSET_BASE_PATH,
@@ -40,6 +42,7 @@ const logger = serverLogger.component("release-asset-build");
 const BROWSER_MODULE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js", ".mdx"];
 /** Directories whose modules are part of the browser closure. */
 const BROWSER_MODULE_DIRS = ["pages/", "components/", "layouts/", "lib/", "src/"];
+const FRAMEWORK_MODULE_URL_PREFIX = "/_vf_modules/_veryfront/";
 
 export interface ReleaseAssetBuildInput {
   /** Project reference (slug or id) used for API calls. */
@@ -136,6 +139,13 @@ interface PreparedAsset {
   contentType: string;
 }
 
+function frameworkModuleUrlToSourceKey(moduleUrl: string): string | null {
+  if (!moduleUrl.startsWith(FRAMEWORK_MODULE_URL_PREFIX)) return null;
+  return moduleUrl
+    .slice(FRAMEWORK_MODULE_URL_PREFIX.length)
+    .replace(/\.(mjs|cjs|js|jsx|ts|tsx)$/, "");
+}
+
 /** Sanitize an error for state reporting (no internal paths / stack traces). */
 function sanitizeError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
@@ -228,6 +238,87 @@ function resolveStaticImports(
   }
 
   return results;
+}
+
+async function addPreparedJavaScriptAsset(
+  logicalPath: string,
+  code: string,
+  uploadQueue: PreparedAsset[],
+  pendingBytes: Map<string, { bytes: Uint8Array<ArrayBuffer>; contentType: string }>,
+): Promise<PreparedAsset | null> {
+  const bytes = new TextEncoder().encode(code) as Uint8Array<ArrayBuffer>;
+  if (bytes.byteLength > RELEASE_ASSET_MAX_SIZE_BYTES) return null;
+
+  const contentHash = await sha256HexBytes(bytes);
+  const entry: PreparedAsset = {
+    logicalPath,
+    contentHash,
+    size: bytes.byteLength,
+    contentType: RELEASE_ASSET_CONTENT_TYPES.js,
+  };
+  if (!pendingBytes.has(contentHash)) {
+    pendingBytes.set(contentHash, { bytes, contentType: RELEASE_ASSET_CONTENT_TYPES.js });
+    uploadQueue.push(entry);
+  }
+  return entry;
+}
+
+async function buildFrameworkDependencies(
+  input: ReleaseAssetBuildInput,
+  tempDir: string,
+  transform: ReleaseAssetTransform,
+  uploadQueue: PreparedAsset[],
+  pendingBytes: Map<string, { bytes: Uint8Array<ArrayBuffer>; contentType: string }>,
+  gaps: string[],
+): Promise<Record<string, PreparedAsset>> {
+  const fs = createFileSystem();
+  const dependencies: Record<string, PreparedAsset> = {};
+
+  for (const [specifier, moduleUrl] of Object.entries(PLATFORM_UTILITIES)) {
+    const sourceKey = frameworkModuleUrlToSourceKey(moduleUrl);
+    if (!sourceKey) continue;
+
+    const frameworkSource = await resolveFrameworkSourcePath(sourceKey, {
+      extraLookupDirs: [join(tempDir, "src")],
+    });
+    if (!frameworkSource) {
+      gaps.push(`dependency-missing:${specifier}`);
+      continue;
+    }
+
+    let code: string;
+    try {
+      const source = await fs.readTextFile(frameworkSource.path);
+      code = await transform(source, frameworkSource.path, tempDir, input.adapter, {
+        projectId: input.projectId,
+        dev: false,
+        ssr: false,
+        reactVersion: input.reactVersion,
+      });
+    } catch (error) {
+      gaps.push(`dependency-transform-failed:${specifier}`);
+      logger.warn("Framework dependency transform failed during release asset build", {
+        specifier,
+        error: sanitizeError(error),
+      });
+      continue;
+    }
+
+    const entry = await addPreparedJavaScriptAsset(
+      `__dependencies__/${specifier}`,
+      code,
+      uploadQueue,
+      pendingBytes,
+    );
+    if (!entry) {
+      gaps.push(`dependency-oversized:${specifier}`);
+      continue;
+    }
+
+    dependencies[specifier] = entry;
+  }
+
+  return dependencies;
 }
 
 /**
@@ -386,33 +477,33 @@ async function runBuildInner(
       };
     }
 
-    // L2: hash the bytes, not the string.
-    const bytes = new TextEncoder().encode(code) as Uint8Array<ArrayBuffer>;
-
+    const entry = await addPreparedJavaScriptAsset(
+      logicalPath,
+      code,
+      uploadQueue,
+      pendingBytes,
+    );
     // M2: enforce 10 MB client-side limit — skip oversized modules with a gap.
-    if (bytes.byteLength > RELEASE_ASSET_MAX_SIZE_BYTES) {
+    if (!entry) {
       gaps.push(`oversized:${logicalPath}`);
       logger.warn("Module exceeds max size, skipping", {
         path: logicalPath,
-        size: bytes.byteLength,
         limit: RELEASE_ASSET_MAX_SIZE_BYTES,
       });
       continue;
     }
 
-    const contentHash = await sha256HexBytes(bytes);
-    const entry: PreparedAsset = {
-      logicalPath,
-      contentHash,
-      size: bytes.byteLength,
-      contentType: RELEASE_ASSET_CONTENT_TYPES.js,
-    };
     modules[logicalPath] = entry;
-    if (!pendingBytes.has(contentHash)) {
-      pendingBytes.set(contentHash, { bytes, contentType: RELEASE_ASSET_CONTENT_TYPES.js });
-      uploadQueue.push(entry);
-    }
   }
+
+  const dependencies = await buildFrameworkDependencies(
+    input,
+    tempDir,
+    transform,
+    uploadQueue,
+    pendingBytes,
+    gaps,
+  );
 
   // 5b. CSS: compile project CSS where reachable, else record css:[] and note.
   const css: ReleaseAssetCssEntry[] = [];
@@ -531,7 +622,13 @@ async function runBuildInner(
     ),
     css,
     routes,
-    dependencies: {},
+    dependencies: Object.fromEntries(
+      Object.entries(dependencies).map(([specifier, entry]) => [specifier, {
+        contentHash: entry.contentHash,
+        size: entry.size,
+        contentType: entry.contentType,
+      }]),
+    ),
     fallback: { mode: "jit", gaps },
   };
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.778";
+export const VERSION = "0.1.779";

--- a/tests/e2e/regressions/rsc-proxy-hydration.test.ts
+++ b/tests/e2e/regressions/rsc-proxy-hydration.test.ts
@@ -247,6 +247,7 @@ async function withProxyBrowserPage(
         "x-veryfront-dispatch-jws": await mintTrustedDispatchJws(context.projectId),
       },
     });
+    await installEsmShCorsShim(browserContext);
 
     try {
       const page = await browserContext.newPage();
@@ -255,6 +256,7 @@ async function withProxyBrowserPage(
       assertEquals(response?.status(), 200);
       await run(page, diagnostics);
     } finally {
+      await browserContext.unrouteAll({ behavior: "ignoreErrors" });
       await browserContext.close();
     }
   } finally {
@@ -266,6 +268,50 @@ async function withProxyBrowserPage(
       Deno.env.set(DISPATCH_PUBLIC_KEY_ENV, previousDispatchPublicKey);
     }
   }
+}
+
+async function installEsmShCorsShim(
+  browserContext: import("npm:playwright").BrowserContext,
+): Promise<void> {
+  await browserContext.route("https://esm.sh/**", async (route) => {
+    const request = route.request();
+    const corsHeaders = {
+      "access-control-allow-origin": "*",
+      "access-control-allow-methods": "GET, HEAD, OPTIONS",
+      "access-control-allow-headers": request.headers()["access-control-request-headers"] ?? "*",
+    };
+
+    try {
+      if (request.method().toUpperCase() === "OPTIONS") {
+        await route.fulfill({
+          status: 204,
+          headers: corsHeaders,
+          body: "",
+        });
+        return;
+      }
+
+      const response = await route.fetch();
+      await route.fulfill({
+        response,
+        headers: {
+          ...response.headers(),
+          ...corsHeaders,
+        },
+      });
+    } catch (error) {
+      if (isClosedRouteError(error)) {
+        return;
+      }
+      throw error;
+    }
+  });
+}
+
+function isClosedRouteError(error: unknown): boolean {
+  return error instanceof Error &&
+    (error.message.includes("Target page, context or browser has been closed") ||
+      error.message.includes("Route is already handled"));
 }
 
 async function assertCounterHydration(


### PR DESCRIPTION
## Summary
- build framework import-map modules into release asset manifest dependencies
- rewrite covered production import-map entries to /_vf/assets/{hash}.js while keeping preview/studio-embed dynamic
- bump package version to 0.1.779

## Verification
- deno check src/release-assets/build-executor.ts src/html/html-shell-generator.ts src/html/utils.ts
- deno test --no-check --allow-all src/release-assets/build-executor.test.ts src/html/html-shell-manifest.test.ts src/release-assets/html-consumption.test.ts
- pre-push hook after rebase: format, lint, typecheck, unit suite (2136 passed)