### PR TITLE
Fix DATEV upload at connector.json source (regen-safe), release 0.1.780

### DIFF
--- a/cli/templates/integrations/datev/connector.json
+++ b/cli/templates/integrations/datev/connector.json
@@ -9,7 +9,9 @@
     "provider": "datev",
     "authorizationUrl": "https://login.datev.de/openid/authorize",
     "tokenUrl": "https://api.datev.de/token",
-    "scopes": ["openid"],
+    "scopes": [
+      "openid"
+    ],
     "callbackPath": "/oauth/callback/datev",
     "tokenAuthMethod": "basic",
     "pkce": true,
@@ -87,14 +89,22 @@
         "body": {
           "file": {
             "type": "string",
-            "description": "Binary content of the document to upload (e.g. a PDF invoice), sent as the multipart 'file' part",
+            "description": "Base64-encoded content of the document (e.g. a PDF invoice), sent decoded as the binary multipart 'file' part",
+            "required": true,
+            "encoding": "base64",
+            "partFilenameField": "file_name"
+          },
+          "file_name": {
+            "type": "string",
+            "description": "Filename for the uploaded document, e.g. invoice.pdf",
             "required": true
           },
           "metadata": {
             "type": "object",
             "description": "Optional JSON metadata part, e.g. { \"document_type\": \"Rechnungseingang\", \"note\": \"...\" }. Use List Document Types to find valid document types."
           }
-        }
+        },
+        "bodyMode": "form-data"
       }
     }
   ],
@@ -114,7 +124,11 @@
       "icon": "users"
     }
   ],
-  "suggestedWith": ["gmail", "drive", "slack"],
+  "suggestedWith": [
+    "gmail",
+    "drive",
+    "slack"
+  ],
   "SETUP_GUIDE": {
     "title": "DATEV setup",
     "steps": [

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.779",
+  "version": "0.1.780",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/integrations/_data.ts
+++ b/src/integrations/_data.ts
@@ -10005,20 +10005,20 @@ export const connectors: IntegrationConfig[] = [
       "keyName": "CHECKLY_API_KEY",
       "headerPrefix": "Bearer",
       "additionalHeaders": { "X-Checkly-Account": "CHECKLY_ACCOUNT_ID" },
-      "docsUrl": "https://developers.checklyhq.com/reference/authentication",
+      "docsUrl": "https://www.checklyhq.com/docs/api-reference/overview/",
     },
     "envVars": [{
       "name": "CHECKLY_API_KEY",
       "description": "Checkly user API key",
       "required": true,
       "sensitive": true,
-      "docsUrl": "https://developers.checklyhq.com/reference/authentication",
+      "docsUrl": "https://www.checklyhq.com/docs/api-reference/overview/",
     }, {
       "name": "CHECKLY_ACCOUNT_ID",
       "description": "Checkly account ID (sent as the X-Checkly-Account header)",
       "required": true,
       "sensitive": false,
-      "docsUrl": "https://developers.checklyhq.com/reference/authentication",
+      "docsUrl": "https://www.checklyhq.com/docs/api-reference/overview/",
     }],
     "tools": [{
       "id": "list_checks",
@@ -10182,7 +10182,7 @@ export const connectors: IntegrationConfig[] = [
         "Raw check results are kept for 30 days, and a results query window (from/to) may span at most 6 hours",
         "Check results use the newer /v2 path; checks and statuses use /v1",
       ],
-      "documentation": "https://developers.checklyhq.com/reference",
+      "documentation": "https://www.checklyhq.com/docs/api-reference/overview/",
     },
   },
   {
@@ -29799,7 +29799,7 @@ export const connectors: IntegrationConfig[] = [
         "Permissions are configured on the app in the Developer Hub; the authorize URL carries no scope parameter",
         "Requests default to the API version pinned on your app; you can override per-request with the Intercom-Version header",
       ],
-      "documentation": "https://developers.intercom.com/docs/references/rest-api/",
+      "documentation": "https://developers.intercom.com/docs/references/introduction",
     },
   },
   {
@@ -31139,7 +31139,7 @@ export const connectors: IntegrationConfig[] = [
       "description": "Klaviyo private API key (starts with pk_)",
       "required": true,
       "sensitive": true,
-      "docsUrl": "https://developers.klaviyo.com/en/docs/retrieve_api_credentials",
+      "docsUrl": "https://developers.klaviyo.com/en/docs/authenticate_",
     }],
     "tools": [{
       "id": "list_profiles",
@@ -33995,7 +33995,7 @@ export const connectors: IntegrationConfig[] = [
       "description": "Mixpanel Project Token for event tracking",
       "required": false,
       "sensitive": true,
-      "docsUrl": "https://docs.mixpanel.com/docs/tracking-methods/id-management/authentication",
+      "docsUrl": "https://docs.mixpanel.com/docs/tracking/how-tos/api-credentials",
     }, {
       "name": "MIXPANEL_API_SECRET",
       "description":
@@ -34599,7 +34599,7 @@ export const connectors: IntegrationConfig[] = [
       "tokenAuthMethod": "request_body",
       "requiredApis": [{
         "name": "monday.com Developer Center",
-        "enableUrl": "https://monday.com/developers/apps",
+        "enableUrl": "https://developer.monday.com/apps/docs/the-developer-center",
       }],
       "docsUrl": "https://developer.monday.com/apps/docs/oauth",
     },
@@ -34800,7 +34800,7 @@ export const connectors: IntegrationConfig[] = [
         "step": 1,
         "title": "Create a monday.com app",
         "description":
-          "Sign in to monday.com (a free trial account works) and open the Developer Center via your avatar → Developers, or https://monday.com/developers/apps. Click Create App.",
+          "Sign in to monday.com (a free trial account works) and open the Developer Center via your avatar → Developers, or https://developer.monday.com/apps/docs/the-developer-center. Click Create App.",
       }, {
         "step": 2,
         "title": "Configure OAuth scopes and redirect URI",
@@ -51416,7 +51416,7 @@ export const connectors: IntegrationConfig[] = [
       "description": "Default schema to use for queries (defaults to PUBLIC)",
       "required": false,
       "sensitive": false,
-      "docsUrl": "https://docs.snowflake.com/en/user-guide/schemas",
+      "docsUrl": "https://docs.snowflake.com/en/user-guide/databases",
     }],
     "tools": [{
       "id": "run_query",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.779";
+export const VERSION = "0.1.780";


### PR DESCRIPTION
## Why a second fix
#2396 edited the **generated** `src/integrations/_data.ts` but not its source `cli/templates/integrations/datev/connector.json` (`_data.ts` is `// Auto-generated — do not edit`). The npm build runs `generate-integrations-module.ts`, which regenerated `_data.ts` from the unchanged `connector.json` and **dropped the fix** — verified by unpacking published `veryfront@0.1.779`: the DATEV upload block has no `bodyMode`.

## This PR
Applies the multipart fix to the generator **source** (`connector.json`): `bodyMode: "form-data"`, `file` with `encoding: "base64"` + `partFilenameField: "file_name"`, required `file_name`; regenerates `_data.ts`; bumps to **0.1.780** (0.1.779 is already on npm) so the release republishes with the fix actually present in the built package.

## Verified
- `deno test src/integrations/_data.test.ts` (33 steps) green
- Regenerated `_data.ts` carries `bodyMode`/`encoding:base64`/`file_name`
- Fix behavior already proven through the real `endpoint-executor` (multipart boundary + binary file part + metadata)

After publish, bump `veryfront-api` to `0.1.780` + deploy.