### PR TITLE
Preserve release CSS layout utilities

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.780",
+  "version": "0.1.781",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -233,6 +233,40 @@ describe("release asset build executor", () => {
     assertEquals(seenStylesheet, '@import "tailwindcss"; /* custom */');
   });
 
+  it("passes helper-composed Tailwind candidates to compileProjectCss", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "components/Header.tsx",
+        content: `
+          const navClass = "h-16 md:h-[4.5rem] lg:h-[5rem]";
+          export function Header() {
+            return <header className={navClass} />;
+          }
+        `,
+      },
+      {
+        path: "pages/index.tsx",
+        content: 'import { Header } from "../components/Header.tsx"; export default Header;',
+      },
+    ];
+    let seenCandidates: Set<string> | null = null;
+    const client = makeClient(files, rec, {
+      compileProjectCss: (candidates) => {
+        seenCandidates = new Set(candidates);
+        return Promise.resolve({ css: ".h-16{height:4rem}", styleProfileHash: "sp-1" });
+      },
+    });
+    const transform = (s: string) => Promise.resolve(s);
+
+    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    assertExists(seenCandidates);
+    assert(seenCandidates.has("h-16"));
+    assert(seenCandidates.has("md:h-[4.5rem]"));
+    assert(seenCandidates.has("lg:h-[5rem]"));
+  });
+
   // B2: route closure includes transitive imports, not just page entrypoint.
   it("includes transitive imports in route closure (B2)", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -22,6 +22,7 @@ import { dirname, join } from "#veryfront/compat/path/index.ts";
 import { resolveFrameworkSourcePath } from "#veryfront/platform/compat/framework-source-resolver.ts";
 import { transformToESM } from "#veryfront/transforms/esm-transform.ts";
 import { PLATFORM_UTILITIES } from "#veryfront/html/utils.ts";
+import { extractCandidatesFromFiles } from "#veryfront/html/styles-builder/candidate-extractor.ts";
 import { sha256HexBytes } from "./hash.ts";
 import {
   RELEASE_ASSET_BASE_PATH,
@@ -671,19 +672,11 @@ function resolveProjectStylesheet(
   return undefined;
 }
 
-/** Extract Tailwind class candidates from materialized source (best-effort). */
+/** Extract Tailwind class candidates from materialized source. */
 function collectClassCandidates(sourceByPath: Map<string, string>): Set<string> {
-  const candidates = new Set<string>();
-  const re = /class(?:Name)?\s*=\s*["'`]([^"'`]+)["'`]/g;
-  for (const source of sourceByPath.values()) {
-    let m: RegExpExecArray | null;
-    while ((m = re.exec(source)) !== null) {
-      for (const cls of m[1]!.split(/\s+/)) {
-        if (cls) candidates.add(cls);
-      }
-    }
-  }
-  return candidates;
+  return extractCandidatesFromFiles(
+    [...sourceByPath.entries()].map(([path, content]) => ({ path, content })),
+  );
 }
 
 /** Run an async task over items with a fixed concurrency limit. */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.780";
+export const VERSION = "0.1.781";


### PR DESCRIPTION
## Summary
- Reuse the existing source-file Tailwind candidate extractor for release asset CSS builds
- Add a regression test for helper-composed classes such as header height utilities
- Bump veryfront to 0.1.781 so the fix gets a new package release

## Why
Coder Society production CSS was served from the release asset manifest, but the immutable CSS artifact missed classes stored in helper variables. That broke layout even though the CSS asset was loading.

## Verification
- deno test --no-check --allow-all src/release-assets/build-executor.test.ts src/html/html-shell-manifest.test.ts src/release-assets/css-compile.test.ts
- deno fmt --check src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts src/utils/version-constant.ts deno.json
- git diff --check