### PR TITLE
Rewrite release asset imports away from module server

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.781",
+  "version": "0.1.782",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -12,7 +12,7 @@ import { parseReleaseAssetManifest } from "./manifest-schema.ts";
 
 interface Recorded {
   began: boolean;
-  uploads: Array<{ hash: string; contentType: string }>;
+  uploads: Array<{ hash: string; contentType: string; text: string }>;
   manifest: unknown;
   states: Array<{ state: string; error?: string }>;
 }
@@ -28,8 +28,8 @@ function makeClient(
       return Promise.resolve({ id: "b1", manifest_version: 7, state: "building" });
     },
     listAllReleaseFiles: () => Promise.resolve(files),
-    uploadReleaseAsset: (_v, hash, contentType) => {
-      rec.uploads.push({ hash, contentType });
+    uploadReleaseAsset: (_v, hash, contentType, bytes) => {
+      rec.uploads.push({ hash, contentType, text: new TextDecoder().decode(bytes) });
       return Promise.resolve({ stored: true, existed: false });
     },
     putReleaseAssetManifest: (_v, manifest) => {
@@ -129,6 +129,69 @@ describe("release asset build executor", () => {
       manifest.dependencies["veryfront/head"]?.contentHash,
       manifest.dependencies["veryfront/react/head"]?.contentHash,
     );
+  });
+
+  it("rewrites covered project module imports to immutable asset URLs", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "pages/index.tsx",
+        content: 'import Header from "../components/Header.tsx"; export default Header;',
+      },
+      {
+        path: "components/Header.tsx",
+        content: "export default function Header() { return null; }",
+      },
+    ];
+    const client = makeClient(files, rec);
+    const transform = (_source: string, sourceFile: string) => {
+      if (sourceFile.endsWith("pages/index.tsx")) {
+        return Promise.resolve(
+          'import Header from "/_vf_modules/components/Header.js"; export default Header;',
+        );
+      }
+      return Promise.resolve("export default function Header() { return null; }");
+    };
+
+    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    const headerHash = manifest.modules["components/Header.tsx"]?.contentHash;
+    assertExists(headerHash);
+    const pageHash = manifest.modules["pages/index.tsx"]?.contentHash;
+    assertExists(pageHash);
+
+    const pageUpload = rec.uploads.find((u) => u.hash === pageHash);
+    assertExists(pageUpload);
+    assert(pageUpload.text.includes(`"/_vf/assets/${headerHash}.js"`));
+    assert(!pageUpload.text.includes("/_vf_modules/components/Header.js"));
+  });
+
+  it("keeps cyclic project imports on the JIT fallback path", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      { path: "pages/a.tsx", content: 'import B from "../components/B.tsx"; export default B;' },
+      { path: "components/B.tsx", content: 'import A from "../pages/a.tsx"; export default A;' },
+    ];
+    const client = makeClient(files, rec);
+    const transform = (_source: string, sourceFile: string) => {
+      if (sourceFile.endsWith("pages/a.tsx")) {
+        return Promise.resolve('import B from "/_vf_modules/components/B.js"; export default B;');
+      }
+      return Promise.resolve('import A from "/_vf_modules/pages/a.js"; export default A;');
+    };
+
+    const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    assert(result.gaps.includes("cycle:pages/a.tsx->components/B.tsx->pages/a.tsx"));
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    const bHash = manifest.modules["components/B.tsx"]?.contentHash;
+    assertExists(bHash);
+    const bUpload = rec.uploads.find((u) => u.hash === bHash);
+    assertExists(bUpload);
+    assert(bUpload.text.includes("/_vf_modules/pages/a.js"));
   });
 
   it("reports failed and does not PUT on a transform error", async () => {
@@ -262,9 +325,10 @@ describe("release asset build executor", () => {
     await runReleaseAssetBuild(baseInput(client, transform), await tmp());
 
     assertExists(seenCandidates);
-    assert(seenCandidates.has("h-16"));
-    assert(seenCandidates.has("md:h-[4.5rem]"));
-    assert(seenCandidates.has("lg:h-[5rem]"));
+    const candidates = seenCandidates as Set<string>;
+    assert(candidates.has("h-16"));
+    assert(candidates.has("md:h-[4.5rem]"));
+    assert(candidates.has("lg:h-[5rem]"));
   });
 
   // B2: route closure includes transitive imports, not just page entrypoint.

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -30,6 +30,7 @@ import {
   RELEASE_ASSET_MANIFEST_SCHEMA_VERSION,
   RELEASE_ASSET_MAX_SIZE_BYTES,
   RELEASE_ASSET_UPLOAD_CONCURRENCY,
+  releaseAssetUrl,
 } from "./constants.ts";
 import type {
   ReleaseAssetCssEntry,
@@ -140,6 +141,11 @@ interface PreparedAsset {
   contentType: string;
 }
 
+interface TransformedProjectModule {
+  logicalPath: string;
+  code: string;
+}
+
 function frameworkModuleUrlToSourceKey(moduleUrl: string): string | null {
   if (!moduleUrl.startsWith(FRAMEWORK_MODULE_URL_PREFIX)) return null;
   return moduleUrl
@@ -239,6 +245,134 @@ function resolveStaticImports(
   }
 
   return results;
+}
+
+function resolveKnownModulePath(path: string, knownPaths: Set<string>): string | null {
+  const normalized = path
+    .replace(/^\/?_vf_modules\//, "")
+    .replace(/^\/+/, "")
+    .replace(/[?#].*$/, "");
+
+  if (normalized.startsWith("_veryfront/")) return null;
+  if (knownPaths.has(normalized)) return normalized;
+
+  const withoutExt = normalized.replace(/\.(tsx|ts|jsx|mdx|js)$/, "");
+  for (const ext of BROWSER_MODULE_EXTENSIONS) {
+    const candidate = `${withoutExt}${ext}`;
+    if (knownPaths.has(candidate)) return candidate;
+  }
+
+  return null;
+}
+
+function collectVfModuleImports(
+  code: string,
+  knownPaths: Set<string>,
+): Map<string, string> {
+  const imports = new Map<string, string>();
+  const re = /(["'])(\/_vf_modules\/[^"']+)\1/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = re.exec(code)) !== null) {
+    const specifier = match[2]!;
+    const logicalPath = resolveKnownModulePath(specifier, knownPaths);
+    if (logicalPath) imports.set(specifier, logicalPath);
+  }
+
+  return imports;
+}
+
+function rewriteVfModuleImports(
+  code: string,
+  moduleAssets: Map<string, PreparedAsset>,
+  knownPaths: Set<string>,
+  dependencyUrls: Map<string, string>,
+): string {
+  return code.replace(/(["'])(\/_vf_modules\/[^"']+)\1/g, (full, quote, specifier) => {
+    const dependencyUrl = dependencyUrls.get(specifier.replace(/[?#].*$/, ""));
+    if (dependencyUrl) return `${quote}${dependencyUrl}${quote}`;
+
+    const logicalPath = resolveKnownModulePath(specifier, knownPaths);
+    const asset = logicalPath ? moduleAssets.get(logicalPath) : undefined;
+    if (!asset) return full;
+
+    return `${quote}${releaseAssetUrl(asset.contentHash, "js")}${quote}`;
+  });
+}
+
+function buildDependencyUrlMap(dependencies: Record<string, PreparedAsset>): Map<string, string> {
+  const urls = new Map<string, string>();
+
+  for (const [specifier, moduleUrl] of Object.entries(PLATFORM_UTILITIES)) {
+    const entry = dependencies[specifier];
+    if (!entry) continue;
+    urls.set(moduleUrl, releaseAssetUrl(entry.contentHash, "js"));
+  }
+
+  return urls;
+}
+
+async function finalizeProjectModules(
+  transformedModules: Map<string, TransformedProjectModule>,
+  knownPaths: Set<string>,
+  dependencyUrls: Map<string, string>,
+  uploadQueue: PreparedAsset[],
+  pendingBytes: Map<string, { bytes: Uint8Array<ArrayBuffer>; contentType: string }>,
+  gaps: string[],
+): Promise<Record<string, PreparedAsset>> {
+  const finalized = new Map<string, PreparedAsset>();
+  const unresolvedCycles = new Set<string>();
+
+  async function finalize(logicalPath: string, stack: string[]): Promise<PreparedAsset | null> {
+    const existing = finalized.get(logicalPath);
+    if (existing) return existing;
+
+    if (stack.includes(logicalPath)) {
+      const cycle = [...stack.slice(stack.indexOf(logicalPath)), logicalPath].join("->");
+      const gap = `cycle:${cycle}`;
+      if (!unresolvedCycles.has(gap)) {
+        unresolvedCycles.add(gap);
+        gaps.push(gap);
+      }
+      return null;
+    }
+
+    const transformed = transformedModules.get(logicalPath);
+    if (!transformed) return null;
+
+    const nextStack = [...stack, logicalPath];
+    const imports = collectVfModuleImports(transformed.code, knownPaths);
+    for (const importedPath of imports.values()) {
+      await finalize(importedPath, nextStack);
+    }
+
+    const rewritten = rewriteVfModuleImports(
+      transformed.code,
+      finalized,
+      knownPaths,
+      dependencyUrls,
+    );
+    const entry = await addPreparedJavaScriptAsset(
+      logicalPath,
+      rewritten,
+      uploadQueue,
+      pendingBytes,
+    );
+
+    if (!entry) return null;
+    finalized.set(logicalPath, entry);
+    return entry;
+  }
+
+  for (const logicalPath of transformedModules.keys()) {
+    const entry = await finalize(logicalPath, []);
+    if (!entry) {
+      const gap = `oversized:${logicalPath}`;
+      if (!gaps.includes(gap)) gaps.push(gap);
+    }
+  }
+
+  return Object.fromEntries(finalized);
 }
 
 async function addPreparedJavaScriptAsset(
@@ -434,7 +568,7 @@ async function runBuildInner(
 
   // 3 + 4. Collect the browser module closure and transform each module
   // through the SAME pipeline serveModule uses (browser, non-SSR).
-  const modules: Record<string, PreparedAsset> = {};
+  const transformedModules = new Map<string, TransformedProjectModule>();
   const gaps: string[] = [];
   const uploadQueue: PreparedAsset[] = [];
   // Bytes are held per-hash only until uploaded, then dropped (M3).
@@ -478,23 +612,7 @@ async function runBuildInner(
       };
     }
 
-    const entry = await addPreparedJavaScriptAsset(
-      logicalPath,
-      code,
-      uploadQueue,
-      pendingBytes,
-    );
-    // M2: enforce 10 MB client-side limit — skip oversized modules with a gap.
-    if (!entry) {
-      gaps.push(`oversized:${logicalPath}`);
-      logger.warn("Module exceeds max size, skipping", {
-        path: logicalPath,
-        limit: RELEASE_ASSET_MAX_SIZE_BYTES,
-      });
-      continue;
-    }
-
-    modules[logicalPath] = entry;
+    transformedModules.set(logicalPath, { logicalPath, code });
   }
 
   const dependencies = await buildFrameworkDependencies(
@@ -505,6 +623,24 @@ async function runBuildInner(
     pendingBytes,
     gaps,
   );
+  const dependencyUrls = buildDependencyUrlMap(dependencies);
+
+  const modules = await finalizeProjectModules(
+    transformedModules,
+    knownPaths,
+    dependencyUrls,
+    uploadQueue,
+    pendingBytes,
+    gaps,
+  );
+
+  for (const logicalPath of transformedModules.keys()) {
+    if (modules[logicalPath]) continue;
+    logger.warn("Module exceeds max size, skipping", {
+      path: logicalPath,
+      limit: RELEASE_ASSET_MAX_SIZE_BYTES,
+    });
+  }
 
   // 5b. CSS: compile project CSS where reachable, else record css:[] and note.
   const css: ReleaseAssetCssEntry[] = [];

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.781";
+export const VERSION = "0.1.782";


### PR DESCRIPTION
## Summary\n- rewrite covered project module imports inside release assets to content-addressed /_vf/assets URLs\n- keep cyclic project imports on the existing JIT fallback path\n- bump veryfront to 0.1.782 so a new package release can be published\n\n## Root cause\nCoder Society was serving hashed release assets, but those JS files still imported transitive dependencies from /_vf_modules. The browser therefore preloaded immutable assets and then fell back into the renderer-backed module server during hydration and SPA navigation.\n\n## Verification\n- deno test --no-check --allow-all src/release-assets/build-executor.test.ts src/release-assets/html-consumption.test.ts src/html/html-shell-manifest.test.ts src/html/hydration-script-builder/templates/loader.test.ts src/html/hydration-script-builder/templates/spa-renderer.test.ts\n- deno check --unstable-worker-options src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts\n- deno lint src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts\n- git diff --check\n\n## Remaining rollout\nAfter merge/publish, rebuild the Coder Society release asset manifest and verify route navigation no longer requests project modules from /_vf_modules. React/esm.sh vendoring remains a separate optimization step.