### PR TITLE
Keep unsafe release asset imports on module paths

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.782",
+  "version": "0.1.783",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/html/html-shell-manifest.test.ts
+++ b/src/html/html-shell-manifest.test.ts
@@ -123,7 +123,7 @@ describe("html shell release asset manifest consumption", () => {
     assert(!result.start.includes("/_vf/css/"));
   });
 
-  it("rewrites covered framework import-map entries to manifest dependency assets", async () => {
+  it("keeps covered framework import-map entries on the module-server path", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     configureReleaseAssetManifestFetcher(() =>
       Promise.resolve({
@@ -144,7 +144,8 @@ describe("html shell release asset manifest consumption", () => {
     await new Promise((r) => setTimeout(r, 0));
 
     const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
-    assertStringIncludes(result.start, `"veryfront/chat":"/_vf/assets/${CHAT_HASH}.js"`);
+    assert(!result.start.includes(`/_vf/assets/${CHAT_HASH}.js`));
+    assertStringIncludes(result.start, `"veryfront/chat":"/_vf_modules/_veryfront/chat/index.js"`);
     assertStringIncludes(result.start, `"@/":"/_vf_modules/"`);
   });
 

--- a/src/html/utils.ts
+++ b/src/html/utils.ts
@@ -295,20 +295,12 @@ function stableManifestDependencyKey(manifest?: ReleaseAssetManifest | null): st
 
 function applyManifestDependencies(
   imports: Record<string, string>,
-  manifest?: ReleaseAssetManifest | null,
+  _manifest?: ReleaseAssetManifest | null,
 ): Record<string, string> {
-  if (!manifest) return imports;
-
-  let rewritten: Record<string, string> | null = null;
-  for (const specifier of Object.keys(imports)) {
-    const entry = manifest.dependencies[specifier];
-    if (!entry || entry.contentType !== "text/javascript") continue;
-
-    rewritten ??= { ...imports };
-    rewritten[specifier] = `${manifest.assetBasePath}/${entry.contentHash}.js`;
-  }
-
-  return rewritten ?? imports;
+  // Framework dependency assets are recorded for future S7 vendoring, but they
+  // are not browser-safe until their own relative import closures are rewritten
+  // and uploaded. Keep import-map entries on their existing module URLs.
+  return imports;
 }
 
 function isImportMapOnlyOptions(

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -168,6 +168,43 @@ describe("release asset build executor", () => {
     assert(!pageUpload.text.includes("/_vf_modules/components/Header.js"));
   });
 
+  it("keeps framework module imports on the module-server path", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "pages/index.tsx",
+        content: 'import { useWorkflow } from "veryfront/workflow"; export default useWorkflow;',
+      },
+    ];
+    const client = makeClient(files, rec);
+    const frameworkUrl = "/_vf_modules/_veryfront/workflow/react/index.js";
+    const transform = (_source: string, sourceFile: string) => {
+      if (sourceFile.endsWith("pages/index.tsx")) {
+        return Promise.resolve(
+          `import { useWorkflow } from "${frameworkUrl}"; export default useWorkflow;`,
+        );
+      }
+      return Promise.resolve("export const useWorkflow = () => null;");
+    };
+
+    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertExists(manifest.dependencies["veryfront/workflow"]);
+    const pageHash = manifest.modules["pages/index.tsx"]?.contentHash;
+    assertExists(pageHash);
+
+    const pageUpload = rec.uploads.find((u) => u.hash === pageHash);
+    assertExists(pageUpload);
+    assert(pageUpload.text.includes(`"${frameworkUrl}"`));
+    assert(
+      !pageUpload.text.includes(
+        `"/_vf/assets/${manifest.dependencies["veryfront/workflow"]?.contentHash}.js"`,
+      ),
+    );
+  });
+
   it("keeps cyclic project imports on the JIT fallback path", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
@@ -187,11 +224,9 @@ describe("release asset build executor", () => {
     assert(result.gaps.includes("cycle:pages/a.tsx->components/B.tsx->pages/a.tsx"));
     const manifest = parseReleaseAssetManifest(rec.manifest);
     assertExists(manifest);
-    const bHash = manifest.modules["components/B.tsx"]?.contentHash;
-    assertExists(bHash);
-    const bUpload = rec.uploads.find((u) => u.hash === bHash);
-    assertExists(bUpload);
-    assert(bUpload.text.includes("/_vf_modules/pages/a.js"));
+    assertEquals(manifest.modules["pages/a.tsx"], undefined);
+    assertEquals(manifest.modules["components/B.tsx"], undefined);
+    assertEquals(manifest.routes["/a"], undefined);
   });
 
   it("reports failed and does not PUT on a transform error", async () => {

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -300,16 +300,11 @@ function rewriteVfModuleImports(
   });
 }
 
-function buildDependencyUrlMap(dependencies: Record<string, PreparedAsset>): Map<string, string> {
-  const urls = new Map<string, string>();
-
-  for (const [specifier, moduleUrl] of Object.entries(PLATFORM_UTILITIES)) {
-    const entry = dependencies[specifier];
-    if (!entry) continue;
-    urls.set(moduleUrl, releaseAssetUrl(entry.contentHash, "js"));
-  }
-
-  return urls;
+function buildDependencyUrlMap(_dependencies: Record<string, PreparedAsset>): Map<string, string> {
+  // Framework barrels can contain their own relative import closure. Keep those
+  // URLs on the module server until the builder rewrites and uploads the full
+  // framework closure, otherwise the browser resolves relatives under /_vf/assets.
+  return new Map<string, string>();
 }
 
 async function finalizeProjectModules(
@@ -319,13 +314,16 @@ async function finalizeProjectModules(
   uploadQueue: PreparedAsset[],
   pendingBytes: Map<string, { bytes: Uint8Array<ArrayBuffer>; contentType: string }>,
   gaps: string[],
-): Promise<Record<string, PreparedAsset>> {
+): Promise<{ modules: Record<string, PreparedAsset>; skippedModules: Set<string> }> {
   const finalized = new Map<string, PreparedAsset>();
   const unresolvedCycles = new Set<string>();
+  const cyclicModules = collectCyclicProjectModules(transformedModules, knownPaths, gaps);
+  const skippedModules = new Set(cyclicModules);
 
   async function finalize(logicalPath: string, stack: string[]): Promise<PreparedAsset | null> {
     const existing = finalized.get(logicalPath);
     if (existing) return existing;
+    if (cyclicModules.has(logicalPath)) return null;
 
     if (stack.includes(logicalPath)) {
       const cycle = [...stack.slice(stack.indexOf(logicalPath)), logicalPath].join("->");
@@ -365,14 +363,66 @@ async function finalizeProjectModules(
   }
 
   for (const logicalPath of transformedModules.keys()) {
+    if (cyclicModules.has(logicalPath)) continue;
+
     const entry = await finalize(logicalPath, []);
     if (!entry) {
+      skippedModules.add(logicalPath);
       const gap = `oversized:${logicalPath}`;
       if (!gaps.includes(gap)) gaps.push(gap);
     }
   }
 
-  return Object.fromEntries(finalized);
+  return { modules: Object.fromEntries(finalized), skippedModules };
+}
+
+function collectCyclicProjectModules(
+  transformedModules: Map<string, TransformedProjectModule>,
+  knownPaths: Set<string>,
+  gaps: string[],
+): Set<string> {
+  const cyclic = new Set<string>();
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const stack: string[] = [];
+  const recordedCycles = new Set<string>();
+
+  function visit(logicalPath: string): void {
+    if (visited.has(logicalPath)) return;
+
+    if (visiting.has(logicalPath)) {
+      const index = stack.indexOf(logicalPath);
+      if (index < 0) return;
+
+      const cycleMembers = stack.slice(index);
+      for (const member of cycleMembers) cyclic.add(member);
+
+      const gap = `cycle:${[...cycleMembers, logicalPath].join("->")}`;
+      if (!recordedCycles.has(gap)) {
+        recordedCycles.add(gap);
+        gaps.push(gap);
+      }
+      return;
+    }
+
+    const transformed = transformedModules.get(logicalPath);
+    if (!transformed) return;
+
+    visiting.add(logicalPath);
+    stack.push(logicalPath);
+
+    const imports = collectVfModuleImports(transformed.code, knownPaths);
+    for (const importedPath of imports.values()) {
+      if (transformedModules.has(importedPath)) visit(importedPath);
+    }
+
+    stack.pop();
+    visiting.delete(logicalPath);
+    visited.add(logicalPath);
+  }
+
+  for (const logicalPath of transformedModules.keys()) visit(logicalPath);
+  return cyclic;
 }
 
 async function addPreparedJavaScriptAsset(
@@ -625,7 +675,7 @@ async function runBuildInner(
   );
   const dependencyUrls = buildDependencyUrlMap(dependencies);
 
-  const modules = await finalizeProjectModules(
+  const { modules, skippedModules } = await finalizeProjectModules(
     transformedModules,
     knownPaths,
     dependencyUrls,
@@ -636,6 +686,8 @@ async function runBuildInner(
 
   for (const logicalPath of transformedModules.keys()) {
     if (modules[logicalPath]) continue;
+    if (skippedModules.has(logicalPath)) continue;
+
     logger.warn("Module exceeds max size, skipping", {
       path: logicalPath,
       limit: RELEASE_ASSET_MAX_SIZE_BYTES,

--- a/src/release-assets/manifest-schema.ts
+++ b/src/release-assets/manifest-schema.ts
@@ -61,8 +61,9 @@ export const getReleaseAssetManifestSchema = defineSchema((v) =>
     modules: v.record(v.string(), v.object(assetEntryShape(v))),
     css: v.array(v.object(cssEntryShape(v))),
     routes: v.record(v.string(), v.object(routeEntryShape(v))),
-    // `dependencies` is reserved for S7 vendoring — always {} in v1, but the
-    // validator accepts entries shaped like `modules` values keyed by specifier.
+    // `dependencies` records framework dependency artifacts for future S7
+    // vendoring. HTML keeps import-map entries on module URLs until those
+    // artifacts include their own rewritten import closures.
     dependencies: v.record(v.string(), v.object(assetEntryShape(v))),
     fallback: v.object(fallbackShape(v)),
   })

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.782";
+export const VERSION = "0.1.783";


### PR DESCRIPTION
## Summary\n- keep framework dependency import-map entries and transformed framework URLs on existing module-server paths until dependency closure vendoring is safe\n- exclude every member of a detected project import cycle from release asset output so cycles use one JIT graph\n- bump veryfront to 0.1.783 for server rollout\n\n## Review comments addressed\n- Follow-up to #2400 comments: do not assetize framework barrels without their closures; keep cyclic modules on one module path.\n\n## Verification\n- deno test --no-check --allow-all src/release-assets/build-executor.test.ts src/release-assets/html-consumption.test.ts src/release-assets/manifest-schema.test.ts src/html/html-shell-manifest.test.ts\n- deno check --unstable-worker-options src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts src/html/utils.ts src/html/html-shell-manifest.test.ts src/release-assets/manifest-schema.ts\n- deno lint src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts src/html/utils.ts src/html/html-shell-manifest.test.ts src/release-assets/manifest-schema.ts\n- git diff --check\n- pre-push hook: format, lint, typecheck, unit suite (2136 passed, 18477 steps)