### PR TITLE
Use release assets during hydration

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.783",
+  "version": "0.1.784",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/client/spa/path-utils.test.ts
+++ b/src/client/spa/path-utils.test.ts
@@ -6,6 +6,7 @@ import { getModuleServerUrl, pathToModuleUrl } from "./path-utils.ts";
 function withWindow<T>(fn: () => T): T {
   const globalRecord = globalThis as typeof globalThis & {
     MODULE_SERVER_URL?: string;
+    __veryfrontReleaseAssetModules?: Record<string, string> | null;
     window?: typeof globalThis;
   };
   const previousWindow = globalRecord.window;
@@ -63,5 +64,28 @@ describe("client/spa/path-utils", () => {
         assertEquals(pathToModuleUrl(input, baseUrl), expected);
       });
     }
+
+    it("uses release asset modules when available", () => {
+      const globalRecord = globalThis as typeof globalThis & {
+        __veryfrontReleaseAssetModules?: Record<string, string> | null;
+      };
+      const previousMap = globalRecord.__veryfrontReleaseAssetModules;
+      globalRecord.__veryfrontReleaseAssetModules = {
+        "pages/index.mdx": "/_vf/assets/" + "a".repeat(64) + ".js",
+      };
+
+      try {
+        assertEquals(
+          pathToModuleUrl("pages/index.mdx"),
+          "/_vf/assets/" + "a".repeat(64) + ".js",
+        );
+      } finally {
+        if (previousMap === undefined) {
+          delete globalRecord.__veryfrontReleaseAssetModules;
+        } else {
+          globalRecord.__veryfrontReleaseAssetModules = previousMap;
+        }
+      }
+    });
   });
 });

--- a/src/client/spa/path-utils.ts
+++ b/src/client/spa/path-utils.ts
@@ -23,12 +23,51 @@ const ABSOLUTE_SOURCE_PATH_PATTERN = new RegExp(`/${SOURCE_PATH_PATTERN.source}`
 /** Precomputed regex for relative paths starting with a source directory */
 const RELATIVE_SOURCE_PATH_PATTERN = new RegExp(`^${SOURCE_PATH_PATTERN.source}`);
 
+type ReleaseAssetGlobal = typeof globalThis & {
+  __veryfrontReleaseAssetModules?: Record<string, string> | null;
+  __veryfrontStudioEmbed?: boolean;
+  __veryfrontHMRRefreshTimestamp?: string | null;
+};
+
+function normalizeReleaseAssetModulePath(path: string): string {
+  return String(path || "")
+    .replace(/^\/?_vf_modules\//, "")
+    .replace(/^\/+/, "")
+    .replace(/[?#].*$/, "");
+}
+
+function resolveReleaseAssetModuleUrl(path: string): string | null {
+  const globalRecord = globalThis as ReleaseAssetGlobal;
+  const releaseAssetModules = globalRecord.__veryfrontReleaseAssetModules;
+  if (
+    !releaseAssetModules || globalRecord.__veryfrontStudioEmbed ||
+    globalRecord.__veryfrontHMRRefreshTimestamp
+  ) {
+    return null;
+  }
+
+  const key = normalizeReleaseAssetModulePath(path);
+  if (releaseAssetModules[key]) return releaseAssetModules[key];
+
+  const withoutExt = key.replace(/\.(tsx|ts|jsx|mdx|js|mjs)$/, "");
+  for (const ext of [".tsx", ".ts", ".jsx", ".mdx", ".js"]) {
+    const candidate = withoutExt + ext;
+    if (releaseAssetModules[candidate]) return releaseAssetModules[candidate];
+  }
+
+  return null;
+}
+
 export function getModuleServerUrl(): string {
   if (typeof window === "undefined") return "/_vf_modules";
-  return globalThis.MODULE_SERVER_URL ?? "/_vf_modules";
+  return (globalThis as typeof globalThis & { MODULE_SERVER_URL?: string }).MODULE_SERVER_URL ??
+    "/_vf_modules";
 }
 
 export function pathToModuleUrl(path: string, baseUrl?: string): string {
+  const releaseAssetUrl = resolveReleaseAssetModuleUrl(path);
+  if (releaseAssetUrl) return releaseAssetUrl;
+
   const base = baseUrl ?? getModuleServerUrl();
 
   const match = path.match(ABSOLUTE_SOURCE_PATH_PATTERN) ??
@@ -47,7 +86,42 @@ export function pathToModuleUrl(path: string, baseUrl?: string): string {
 
 export function getPathToModuleUrlScript(): string {
   return `
+    function setReleaseAssetModules(value) {
+      window.__veryfrontReleaseAssetModules =
+        value && typeof value === 'object' && !Array.isArray(value) ? value : null;
+    }
+    window.__veryfrontSetReleaseAssetModules = setReleaseAssetModules;
+
+    function normalizeReleaseAssetModulePath(path) {
+      return String(path || '')
+        .replace(/^\\/?_vf_modules\\//, '')
+        .replace(/^\\/+/, '')
+        .replace(/[?#].*$/, '');
+    }
+
+    function resolveReleaseAssetModuleUrl(path) {
+      const releaseAssetModules = window.__veryfrontReleaseAssetModules;
+      if (!releaseAssetModules || window.__veryfrontStudioEmbed || window.__veryfrontHMRRefreshTimestamp) {
+        return null;
+      }
+
+      const key = normalizeReleaseAssetModulePath(path);
+      if (releaseAssetModules[key]) return releaseAssetModules[key];
+
+      const withoutExt = key.replace(/\\.(tsx|ts|jsx|mdx|js|mjs)$/, '');
+      const extensions = ['.tsx', '.ts', '.jsx', '.mdx', '.js'];
+      for (const ext of extensions) {
+        const candidate = withoutExt + ext;
+        if (releaseAssetModules[candidate]) return releaseAssetModules[candidate];
+      }
+
+      return null;
+    }
+
     function pathToModuleUrl(path, baseUrl) {
+      const releaseAssetUrl = resolveReleaseAssetModuleUrl(path);
+      if (releaseAssetUrl) return releaseAssetUrl;
+
       const base = baseUrl || MODULE_SERVER_URL;
       const pattern = /(pages|components|app|lib|layouts|shared|features)\\/(.+)\\.(tsx|ts|jsx|mdx)$/;
 

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -238,7 +238,7 @@ async function generateHTMLShellPartsImpl(
     meta.slug || "",
     params ?? {},
     props ?? {},
-    options,
+    { ...options, releaseAssetManifest: releaseManifest },
     { pretty: useDevScripts },
   );
 

--- a/src/html/hydration-script-builder/hydration-data-generator.test.ts
+++ b/src/html/hydration-script-builder/hydration-data-generator.test.ts
@@ -3,6 +3,7 @@ import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { generateHydrationData } from "./hydration-data-generator.ts";
 import type { HTMLGenerationOptions } from "../types.ts";
+import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 
 function parseHydrationData(
   slug: string,
@@ -105,6 +106,60 @@ describe("hydration-data-generator", () => {
         pagePath?: unknown;
       };
       assertEquals(typeof parsed.pagePath, "string");
+    });
+
+    it("includes release asset module URLs for hydration when a manifest is provided", () => {
+      const manifest: ReleaseAssetManifest = {
+        schemaVersion: 1,
+        projectId: "project-id",
+        releaseId: "release-id",
+        releaseVersion: 1,
+        manifestVersion: 5,
+        builderVersion: "0.1.784",
+        sourceContentHash: "",
+        createdAt: "2026-06-13T00:00:00.000Z",
+        assetBasePath: "/_vf/assets",
+        modules: {
+          "pages/index.mdx": {
+            contentHash: "a".repeat(64),
+            size: 100,
+            contentType: "text/javascript",
+          },
+          "components/layouts/DefaultLayout.mdx": {
+            contentHash: "b".repeat(64),
+            size: 100,
+            contentType: "text/javascript",
+          },
+        },
+        css: [],
+        routes: {},
+        dependencies: {},
+        fallback: { mode: "jit", gaps: [] },
+      };
+      const parsed = parseHydrationData(
+        "page",
+        {},
+        {},
+        {
+          ...baseOptions,
+          mode: "production",
+          pagePath: "/project/pages/index.mdx",
+          nestedLayouts: [{ kind: "mdx", path: "/project/components/layouts/DefaultLayout.mdx" }],
+          projectDir: "/project",
+          releaseAssetManifest: manifest,
+        } as HTMLGenerationOptions & { releaseAssetManifest: ReleaseAssetManifest },
+      ) as {
+        releaseAssetModules?: Record<string, string>;
+      };
+
+      assertEquals(
+        parsed.releaseAssetModules?.["pages/index.mdx"],
+        `/_vf/assets/${"a".repeat(64)}.js`,
+      );
+      assertEquals(
+        parsed.releaseAssetModules?.["components/layouts/DefaultLayout.mdx"],
+        `/_vf/assets/${"b".repeat(64)}.js`,
+      );
     });
 
     it("should include pageType from options", () => {

--- a/src/html/hydration-script-builder/hydration-data-generator.ts
+++ b/src/html/hydration-script-builder/hydration-data-generator.ts
@@ -3,6 +3,8 @@ import { resolveRelativePath } from "#veryfront/modules/react-loader/path-resolv
 import { getExtensionName } from "#veryfront/utils/path-utils.ts";
 import { determineClientModuleStrategy } from "#veryfront/rendering/rsc/client-module-strategy.ts";
 import { jsonForInlineScript } from "#veryfront/security/client/html-sanitizer.ts";
+import { releaseAssetUrl } from "#veryfront/release-assets/constants.ts";
+import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import type { HTMLGenerationOptions } from "../types.ts";
 import type { HydrationDataStructure } from "./types.ts";
 
@@ -33,11 +35,27 @@ function inferPageType(pagePath?: string): PageType | undefined {
   return PAGE_TYPE_EXTENSIONS.has(ext as PageType) ? (ext as PageType) : undefined;
 }
 
+type HydrationOptions = HTMLGenerationOptions & {
+  releaseAssetManifest?: ReleaseAssetManifest | null;
+};
+
+function buildReleaseAssetModules(
+  manifest?: ReleaseAssetManifest | null,
+): Record<string, string> | undefined {
+  if (!manifest) return undefined;
+
+  const modules: Record<string, string> = {};
+  for (const [path, entry] of Object.entries(manifest.modules)) {
+    modules[path] = releaseAssetUrl(entry.contentHash, "js");
+  }
+  return Object.keys(modules).length > 0 ? modules : undefined;
+}
+
 export function generateHydrationData(
   slug: string,
   params: Record<string, string | string[]>,
   props: ComponentProps,
-  options: HTMLGenerationOptions,
+  options: HydrationOptions,
   serializeOptions?: { pretty?: boolean },
 ): string {
   const layouts = (options.nestedLayouts ?? [])
@@ -76,6 +94,7 @@ export function generateHydrationData(
       isLocalProject: options.isLocalProject,
       environment: options.environment as HydrationEnvironment | undefined,
     }),
+    releaseAssetModules: buildReleaseAssetModules(options.releaseAssetManifest),
     frontmatter: options.frontmatter,
     layoutProps: options.layoutProps,
     // In dev mode, client uses createRoot instead of hydrateRoot to avoid

--- a/src/html/hydration-script-builder/templates/loader.test.ts
+++ b/src/html/hydration-script-builder/templates/loader.test.ts
@@ -44,6 +44,16 @@ describe("hydration-script-builder/templates/loader", () => {
       assertEquals(result.includes("function pathToModuleUrl(path, studioEmbed)"), true);
     });
 
+    it("should expose release asset module map support", () => {
+      const result = getResult();
+      assertEquals(result.includes("let __releaseAssetModules = null"), true);
+      assertEquals(
+        result.includes("window.__veryfrontSetReleaseAssetModules = setReleaseAssetModules"),
+        true,
+      );
+      assertEquals(result.includes("resolveReleaseAssetModuleUrl(path)"), true);
+    });
+
     it("should handle known source file extensions in pathToModuleUrl", () => {
       const result = getResult();
       assertEquals(result.includes("pages|components|app|lib|layouts|shared|features"), true);

--- a/src/html/hydration-script-builder/templates/loader.ts
+++ b/src/html/hydration-script-builder/templates/loader.ts
@@ -22,7 +22,41 @@ export const getLoaderScript = (): string => `
       return url + (url.includes('?') ? '&' : '?') + key + '=' + value;
     }
 
+    let __releaseAssetModules = null;
+    function setReleaseAssetModules(value) {
+      __releaseAssetModules =
+        value && typeof value === 'object' && !Array.isArray(value) ? value : null;
+      window.__veryfrontReleaseAssetModules = __releaseAssetModules;
+    }
+    window.__veryfrontSetReleaseAssetModules = setReleaseAssetModules;
+
+    function normalizeReleaseAssetModulePath(path) {
+      return String(path || '')
+        .replace(/^\\/?_vf_modules\\//, '')
+        .replace(/^\\/+/, '')
+        .replace(/[?#].*$/, '');
+    }
+
+    function resolveReleaseAssetModuleUrl(path) {
+      if (!__releaseAssetModules || __studioEmbed || __hmrRefreshTimestamp) return null;
+
+      const key = normalizeReleaseAssetModulePath(path);
+      if (__releaseAssetModules[key]) return __releaseAssetModules[key];
+
+      const withoutExt = key.replace(/\\.(tsx|ts|jsx|mdx|js|mjs)$/, '');
+      const extensions = ['.tsx', '.ts', '.jsx', '.mdx', '.js'];
+      for (const ext of extensions) {
+        const candidate = withoutExt + ext;
+        if (__releaseAssetModules[candidate]) return __releaseAssetModules[candidate];
+      }
+
+      return null;
+    }
+
     function pathToModuleUrl(path, studioEmbed) {
+      const releaseAssetUrl = resolveReleaseAssetModuleUrl(path);
+      if (releaseAssetUrl) return releaseAssetUrl;
+
       const pattern = /(pages|components|app|lib|layouts|shared|features)\\/(.+)\\.(tsx|ts|jsx|mdx)$/;
 
       const match =
@@ -49,12 +83,14 @@ export const getLoaderScript = (): string => `
     let __studioEmbed = false;
     function setStudioEmbed(value) {
       __studioEmbed = value;
+      window.__veryfrontStudioEmbed = value;
     }
     window.__veryfrontSetStudioEmbed = setStudioEmbed;
 
     let __hmrRefreshTimestamp = null;
     function setHMRRefreshTimestamp(timestamp) {
       __hmrRefreshTimestamp = timestamp;
+      window.__veryfrontHMRRefreshTimestamp = timestamp;
     }
     window.__veryfrontSetHMRRefreshTimestamp = setHMRRefreshTimestamp;
 

--- a/src/html/hydration-script-builder/templates/renderer.test.ts
+++ b/src/html/hydration-script-builder/templates/renderer.test.ts
@@ -33,6 +33,12 @@ describe("hydration-script-builder/templates/renderer", () => {
       assertIncludes(result, "__veryfrontSetStudioEmbed");
     });
 
+    it("should install release asset modules from hydration data", () => {
+      const result = getRendererScript();
+      assertIncludes(result, "data.releaseAssetModules");
+      assertIncludes(result, "__veryfrontSetReleaseAssetModules");
+    });
+
     it("should use the RSC module endpoint only for app router RSC client pages", () => {
       const result = getRendererScript();
       assertIncludes(result, "data.clientModuleStrategy === 'rsc-module'");

--- a/src/html/hydration-script-builder/templates/renderer.ts
+++ b/src/html/hydration-script-builder/templates/renderer.ts
@@ -33,6 +33,9 @@ export const getRendererScript = () => `
       if (data.studioEmbed && window.__veryfrontSetStudioEmbed) {
         window.__veryfrontSetStudioEmbed(true);
       }
+      if (data.releaseAssetModules && window.__veryfrontSetReleaseAssetModules) {
+        window.__veryfrontSetReleaseAssetModules(data.releaseAssetModules);
+      }
 
       try {
         let pageModule;

--- a/src/html/hydration-script-builder/templates/router.test.ts
+++ b/src/html/hydration-script-builder/templates/router.test.ts
@@ -133,6 +133,12 @@ describe("hydration-script-builder/templates/router", () => {
       assertIncludes(getRouterScript(), "async function renderPageFromData(pageData, targetPath)");
     });
 
+    it("should install release asset modules from SPA page data before loading components", () => {
+      const result = getRouterScript();
+      assertIncludes(result, "pageData.releaseAssetModules");
+      assertIncludes(result, "__veryfrontSetReleaseAssetModules");
+    });
+
     it("should define prefetching on hover", () => {
       const result = getRouterScript();
       assertIncludes(result, "function prefetchPage(href)");

--- a/src/html/hydration-script-builder/templates/router.ts
+++ b/src/html/hydration-script-builder/templates/router.ts
@@ -401,6 +401,10 @@ export const getRouterScript = () => `
     // Render page from page data
     // ============================================
     async function renderPageFromData(pageData, targetPath) {
+      if (pageData.releaseAssetModules && window.__veryfrontSetReleaseAssetModules) {
+        window.__veryfrontSetReleaseAssetModules(pageData.releaseAssetModules);
+      }
+
       perfStart('render:loadAll');
       const layoutPaths = (pageData.layouts || []).map((l) => l.path);
       const allPaths = [pageData.pagePath, ...layoutPaths];

--- a/src/html/hydration-script-builder/templates/spa-renderer.test.ts
+++ b/src/html/hydration-script-builder/templates/spa-renderer.test.ts
@@ -44,6 +44,12 @@ describe("hydration-script-builder/templates/spa-renderer", () => {
       assertIncludes(result, "__veryfrontSetStudioEmbed");
     });
 
+    it("should install release asset modules from initial data", () => {
+      const result = getSpaRendererScript();
+      assertIncludes(result, "initialData.releaseAssetModules");
+      assertIncludes(result, "__veryfrontSetReleaseAssetModules");
+    });
+
     it("should load page component", () => {
       assertIncludes(getSpaRendererScript(), "loadComponent(initialData.pagePath)");
     });

--- a/src/html/hydration-script-builder/templates/spa-renderer.ts
+++ b/src/html/hydration-script-builder/templates/spa-renderer.ts
@@ -19,6 +19,9 @@ export const getSpaRendererScript = (): string => `
       if (initialData.studioEmbed && window.__veryfrontSetStudioEmbed) {
         window.__veryfrontSetStudioEmbed(true);
       }
+      if (initialData.releaseAssetModules && window.__veryfrontSetReleaseAssetModules) {
+        window.__veryfrontSetReleaseAssetModules(initialData.releaseAssetModules);
+      }
 
       try {
         const pageComponent = await loadComponent(initialData.pagePath);

--- a/src/html/hydration-script-builder/types.ts
+++ b/src/html/hydration-script-builder/types.ts
@@ -14,6 +14,8 @@ export interface HydrationDataStructure {
   pagePath?: string;
   pageType?: "mdx" | "md" | "tsx" | "jsx" | "ts" | "js";
   clientModuleStrategy?: ClientModuleStrategy;
+  /** Production release asset URLs keyed by logical source path. */
+  releaseAssetModules?: Record<string, string>;
   frontmatter?: Record<string, unknown>;
   layoutProps?: Record<string, Record<string, unknown>>;
   /**

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.783";
+export const VERSION = "0.1.784";


### PR DESCRIPTION
## Summary
- Pass the ready release asset manifest into hydration data as a source-path to hashed-asset URL map.
- Install that map before initial hydration imports and SPA navigation imports so page/layout/app loads do not fall back to `/_vf_modules` when covered by the manifest.
- Keep Studio embed and HMR on dynamic module-server URLs, and bump the package/runtime version to `0.1.784`.

## Verification
- `deno test --no-check --allow-all src/html/html-shell-manifest.test.ts src/release-assets/html-consumption.test.ts src/html/hydration-script-builder/hydration-data-generator.test.ts src/html/hydration-script-builder/templates/loader.test.ts src/html/hydration-script-builder/templates/renderer.test.ts src/html/hydration-script-builder/templates/router.test.ts src/html/hydration-script-builder/templates/spa-renderer.test.ts src/client/spa/path-utils.test.ts src/client/spa/component-loader.test.ts src/client/spa/ClientApp.test.tsx src/utils/version.test.ts src/utils/logger/logger.test.ts`
- `deno check src/html/hydration-script-builder/hydration-data-generator.ts src/html/html-shell-generator.ts src/html/hydration-script-builder/templates/loader.ts src/html/hydration-script-builder/templates/renderer.ts src/html/hydration-script-builder/templates/router.ts src/html/hydration-script-builder/templates/spa-renderer.ts src/client/spa/path-utils.ts src/utils/version.ts src/utils/version-constant.ts`
- Pre-push hook: format, lint, type check, unit suite: 2136 passed, 0 failed

## Notes
- This targets the remaining browser waterfall observed on codersociety.com after release assets were built and served.
- External package requests to esm.sh are separate from this project-module hydration fallback and remain a later dependency-vendoring workstream.
