### PR TITLE
Rewrite release asset project imports

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.784",
+  "version": "0.1.785",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -168,6 +168,126 @@ describe("release asset build executor", () => {
     assert(!pageUpload.text.includes("/_vf_modules/components/Header.js"));
   });
 
+  it("rewrites transformed relative project imports to immutable asset URLs", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "pages/index.tsx",
+        content: 'import Hero from "../components/sections/HeroSection.tsx"; export default Hero;',
+      },
+      {
+        path: "components/sections/HeroSection.tsx",
+        content: 'import Button from "../elements/Button.tsx"; export default Button;',
+      },
+      {
+        path: "components/elements/Button.tsx",
+        content: "export default function Button() { return null; }",
+      },
+    ];
+    const client = makeClient(files, rec);
+    const transform = (_source: string, sourceFile: string) => {
+      if (sourceFile.endsWith("pages/index.tsx")) {
+        return Promise.resolve(
+          'import Hero from "/_vf_modules/components/sections/HeroSection.js"; export default Hero;',
+        );
+      }
+      if (sourceFile.endsWith("components/sections/HeroSection.tsx")) {
+        return Promise.resolve(
+          'import Button from "../../components/elements/Button.js"; export default Button;',
+        );
+      }
+      return Promise.resolve("export default function Button() { return null; }");
+    };
+
+    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    const buttonHash = manifest.modules["components/elements/Button.tsx"]?.contentHash;
+    assertExists(buttonHash);
+    const heroHash = manifest.modules["components/sections/HeroSection.tsx"]?.contentHash;
+    assertExists(heroHash);
+    const pageHash = manifest.modules["pages/index.tsx"]?.contentHash;
+    assertExists(pageHash);
+
+    const heroUpload = rec.uploads.find((u) => u.hash === heroHash);
+    assertExists(heroUpload);
+    assert(heroUpload.text.includes(`"/_vf/assets/${buttonHash}.js"`));
+    assert(!heroUpload.text.includes("../../components/elements/Button.js"));
+
+    const pageUpload = rec.uploads.find((u) => u.hash === pageHash);
+    assertExists(pageUpload);
+    assert(pageUpload.text.includes(`"/_vf/assets/${heroHash}.js"`));
+    assert(!pageUpload.text.includes("/_vf_modules/components/sections/HeroSection.js"));
+  });
+
+  it("rewrites transformed root project imports to immutable asset URLs", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      { path: "pages/index.tsx", content: 'import Button from "../components/Button.tsx";' },
+      { path: "components/Button.tsx", content: "export const Button = () => null;" },
+    ];
+    const client = makeClient(files, rec);
+    const transform = (_source: string, sourceFile: string) => {
+      if (sourceFile.endsWith("pages/index.tsx")) {
+        return Promise.resolve('import { Button } from "/components/Button.js"; Button();');
+      }
+      return Promise.resolve("export const Button = () => null;");
+    };
+
+    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    const buttonHash = manifest.modules["components/Button.tsx"]?.contentHash;
+    assertExists(buttonHash);
+    const pageHash = manifest.modules["pages/index.tsx"]?.contentHash;
+    assertExists(pageHash);
+
+    const pageUpload = rec.uploads.find((u) => u.hash === pageHash);
+    assertExists(pageUpload);
+    assert(pageUpload.text.includes(`"/_vf/assets/${buttonHash}.js"`));
+    assert(!pageUpload.text.includes("/components/Button.js"));
+  });
+
+  it("does not rewrite import-like strings or comments in transformed modules", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      { path: "pages/index.tsx", content: "export default function Page() { return null; }" },
+      { path: "components/Button.tsx", content: "export const Button = () => null;" },
+    ];
+    const client = makeClient(files, rec);
+    const transform = (_source: string, sourceFile: string) => {
+      if (sourceFile.endsWith("pages/index.tsx")) {
+        return Promise.resolve([
+          "const sample = 'import { Button } from \"/components/Button.js\"';",
+          '// import { Button } from "/components/Button.js"',
+          "export default function Page() { return sample; }",
+        ].join("\n"));
+      }
+      return Promise.resolve("export const Button = () => null;");
+    };
+
+    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    const buttonHash = manifest.modules["components/Button.tsx"]?.contentHash;
+    assertExists(buttonHash);
+    const pageHash = manifest.modules["pages/index.tsx"]?.contentHash;
+    assertExists(pageHash);
+
+    const pageUpload = rec.uploads.find((u) => u.hash === pageHash);
+    assertExists(pageUpload);
+    assert(
+      pageUpload.text.includes(
+        "const sample = 'import { Button } from \"/components/Button.js\"';",
+      ),
+    );
+    assert(pageUpload.text.includes('// import { Button } from "/components/Button.js"'));
+    assert(!pageUpload.text.includes(`/_vf/assets/${buttonHash}.js`));
+  });
+
   it("keeps framework module imports on the module-server path", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -21,6 +21,7 @@ import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { dirname, join } from "#veryfront/compat/path/index.ts";
 import { resolveFrameworkSourcePath } from "#veryfront/platform/compat/framework-source-resolver.ts";
 import { transformToESM } from "#veryfront/transforms/esm-transform.ts";
+import { parseImports, replaceSpecifiers } from "#veryfront/transforms/esm/lexer.ts";
 import { PLATFORM_UTILITIES } from "#veryfront/html/utils.ts";
 import { extractCandidatesFromFiles } from "#veryfront/html/styles-builder/candidate-extractor.ts";
 import { sha256HexBytes } from "./hash.ts";
@@ -248,10 +249,12 @@ function resolveStaticImports(
 }
 
 function resolveKnownModulePath(path: string, knownPaths: Set<string>): string | null {
-  const normalized = path
-    .replace(/^\/?_vf_modules\//, "")
-    .replace(/^\/+/, "")
-    .replace(/[?#].*$/, "");
+  const normalized = normalizeLogicalPath(
+    path
+      .replace(/^\/?_vf_modules\//, "")
+      .replace(/^\/+/, "")
+      .replace(/[?#].*$/, ""),
+  );
 
   if (normalized.startsWith("_veryfront/")) return null;
   if (knownPaths.has(normalized)) return normalized;
@@ -265,39 +268,95 @@ function resolveKnownModulePath(path: string, knownPaths: Set<string>): string |
   return null;
 }
 
-function collectVfModuleImports(
-  code: string,
-  knownPaths: Set<string>,
-): Map<string, string> {
-  const imports = new Map<string, string>();
-  const re = /(["'])(\/_vf_modules\/[^"']+)\1/g;
-  let match: RegExpExecArray | null;
+function normalizeLogicalPath(path: string): string {
+  const parts: string[] = [];
+  for (const part of path.split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") {
+      parts.pop();
+      continue;
+    }
+    parts.push(part);
+  }
+  return parts.join("/");
+}
 
-  while ((match = re.exec(code)) !== null) {
-    const specifier = match[2]!;
-    const logicalPath = resolveKnownModulePath(specifier, knownPaths);
-    if (logicalPath) imports.set(specifier, logicalPath);
+function normalizeProjectSpecifier(specifier: string, logicalPath: string): string | null {
+  if (
+    specifier.startsWith("http://") ||
+    specifier.startsWith("https://") ||
+    specifier.startsWith("data:") ||
+    specifier.startsWith("blob:") ||
+    specifier.startsWith("#")
+  ) {
+    return null;
+  }
+
+  if (specifier.startsWith("/_vf_modules/_veryfront/")) return null;
+  if (specifier.startsWith("/_vf_modules/")) return specifier;
+  if (specifier.startsWith("_veryfront/")) return null;
+
+  if (specifier.startsWith("./") || specifier.startsWith("../")) {
+    const dir = logicalPath.includes("/")
+      ? logicalPath.slice(0, logicalPath.lastIndexOf("/"))
+      : ".";
+    return `${dir}/${specifier}`;
+  }
+
+  if (specifier.startsWith("/")) return specifier;
+
+  if (BROWSER_MODULE_DIRS.some((dir) => specifier.startsWith(dir))) return specifier;
+
+  return null;
+}
+
+function resolveProjectModuleSpecifier(
+  specifier: string,
+  logicalPath: string,
+  knownPaths: Set<string>,
+): string | null {
+  const normalized = normalizeProjectSpecifier(specifier, logicalPath);
+  if (!normalized) return null;
+  return resolveKnownModulePath(normalized, knownPaths);
+}
+
+async function collectProjectModuleImports(
+  code: string,
+  logicalPath: string,
+  knownPaths: Set<string>,
+): Promise<Map<string, string>> {
+  const imports = new Map<string, string>();
+
+  for (const imp of await parseImports(code)) {
+    if (!imp.n) continue;
+
+    const specifier = imp.n;
+    const importedPath = resolveProjectModuleSpecifier(specifier, logicalPath, knownPaths);
+    if (importedPath) imports.set(specifier, importedPath);
   }
 
   return imports;
 }
 
-function rewriteVfModuleImports(
+async function rewriteProjectModuleImports(
   code: string,
+  logicalPath: string,
   moduleAssets: Map<string, PreparedAsset>,
   knownPaths: Set<string>,
   dependencyUrls: Map<string, string>,
-): string {
-  return code.replace(/(["'])(\/_vf_modules\/[^"']+)\1/g, (full, quote, specifier) => {
-    const dependencyUrl = dependencyUrls.get(specifier.replace(/[?#].*$/, ""));
-    if (dependencyUrl) return `${quote}${dependencyUrl}${quote}`;
+): Promise<string> {
+  function rewriteSpecifier(specifier: string): string | null {
+    if (specifier.startsWith("/_vf_modules/")) {
+      const dependencyUrl = dependencyUrls.get(specifier.replace(/[?#].*$/, ""));
+      if (dependencyUrl) return dependencyUrl;
+    }
 
-    const logicalPath = resolveKnownModulePath(specifier, knownPaths);
-    const asset = logicalPath ? moduleAssets.get(logicalPath) : undefined;
-    if (!asset) return full;
+    const importedPath = resolveProjectModuleSpecifier(specifier, logicalPath, knownPaths);
+    const asset = importedPath ? moduleAssets.get(importedPath) : undefined;
+    return asset ? releaseAssetUrl(asset.contentHash, "js") : null;
+  }
 
-    return `${quote}${releaseAssetUrl(asset.contentHash, "js")}${quote}`;
-  });
+  return await replaceSpecifiers(code, (specifier) => rewriteSpecifier(specifier));
 }
 
 function buildDependencyUrlMap(_dependencies: Record<string, PreparedAsset>): Map<string, string> {
@@ -317,7 +376,7 @@ async function finalizeProjectModules(
 ): Promise<{ modules: Record<string, PreparedAsset>; skippedModules: Set<string> }> {
   const finalized = new Map<string, PreparedAsset>();
   const unresolvedCycles = new Set<string>();
-  const cyclicModules = collectCyclicProjectModules(transformedModules, knownPaths, gaps);
+  const cyclicModules = await collectCyclicProjectModules(transformedModules, knownPaths, gaps);
   const skippedModules = new Set(cyclicModules);
 
   async function finalize(logicalPath: string, stack: string[]): Promise<PreparedAsset | null> {
@@ -339,13 +398,14 @@ async function finalizeProjectModules(
     if (!transformed) return null;
 
     const nextStack = [...stack, logicalPath];
-    const imports = collectVfModuleImports(transformed.code, knownPaths);
+    const imports = await collectProjectModuleImports(transformed.code, logicalPath, knownPaths);
     for (const importedPath of imports.values()) {
       await finalize(importedPath, nextStack);
     }
 
-    const rewritten = rewriteVfModuleImports(
+    const rewritten = await rewriteProjectModuleImports(
       transformed.code,
+      logicalPath,
       finalized,
       knownPaths,
       dependencyUrls,
@@ -376,18 +436,18 @@ async function finalizeProjectModules(
   return { modules: Object.fromEntries(finalized), skippedModules };
 }
 
-function collectCyclicProjectModules(
+async function collectCyclicProjectModules(
   transformedModules: Map<string, TransformedProjectModule>,
   knownPaths: Set<string>,
   gaps: string[],
-): Set<string> {
+): Promise<Set<string>> {
   const cyclic = new Set<string>();
   const visiting = new Set<string>();
   const visited = new Set<string>();
   const stack: string[] = [];
   const recordedCycles = new Set<string>();
 
-  function visit(logicalPath: string): void {
+  async function visit(logicalPath: string): Promise<void> {
     if (visited.has(logicalPath)) return;
 
     if (visiting.has(logicalPath)) {
@@ -411,9 +471,9 @@ function collectCyclicProjectModules(
     visiting.add(logicalPath);
     stack.push(logicalPath);
 
-    const imports = collectVfModuleImports(transformed.code, knownPaths);
+    const imports = await collectProjectModuleImports(transformed.code, logicalPath, knownPaths);
     for (const importedPath of imports.values()) {
-      if (transformedModules.has(importedPath)) visit(importedPath);
+      if (transformedModules.has(importedPath)) await visit(importedPath);
     }
 
     stack.pop();
@@ -421,7 +481,7 @@ function collectCyclicProjectModules(
     visited.add(logicalPath);
   }
 
-  for (const logicalPath of transformedModules.keys()) visit(logicalPath);
+  for (const logicalPath of transformedModules.keys()) await visit(logicalPath);
   return cyclic;
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.784";
+export const VERSION = "0.1.785";


### PR DESCRIPTION
## Summary
- rewrite release-asset project imports that were left as relative or root specifiers after transform
- keep framework _veryfront imports on the existing fallback path
- bump veryfront-code to 0.1.785 so server can consume a new package release

## Root cause
Release asset modules could still contain imports like ../../components/Button.js or /components/Button.js. When those modules are served from /_vf/assets/{hash}.js, the browser resolves them against the public origin, gets /components/... 404s, and hydration falls back to /_vf_modules JIT. That is why codersociety.com still showed project module fallback after v0.1.784.

## Validation
- deno test --no-check --allow-all src/release-assets/build-executor.test.ts src/utils/version.test.ts src/utils/logger/logger.test.ts
- deno check src/release-assets/build-executor.ts src/utils/version.ts src/utils/version-constant.ts
- deno fmt --check src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts src/utils/version-constant.ts deno.json
- pre-push hook: deno fmt check, deno lint, deno check src/index.ts, and unit suite with 2136 passed / 0 failed

## Rollout note
Existing manifests contain already-built bad asset bytes. After this release reaches production, affected production releases need a new release-asset manifest build before browser verification will drop the fallback.