### PR TITLE
Let production SSR use the render cache

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.785",
+  "version": "0.1.786",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/handlers/request/ssr/ssr-response-builder.test.ts
+++ b/src/server/handlers/request/ssr/ssr-response-builder.test.ts
@@ -175,6 +175,28 @@ describe("server/handlers/request/ssr/ssr-response-builder", () => {
       assertEquals(body, "<p>Streamed</p>");
     });
 
+    it("uses the render result cache strategy for streaming responses", async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("<p>Streamed</p>"));
+          controller.close();
+        },
+      });
+      const req = new Request("http://localhost/");
+      const ctx = makeCtx();
+      const result = makeResult({
+        cacheStrategy: "short",
+        isStreaming: true,
+        stream,
+        html: undefined,
+      });
+      const builder = new ResponseBuilder();
+
+      const response = await buildSSRResponse(req, ctx, result, builder);
+
+      assertEquals(response.headers.get("cache-control"), "public, max-age=0");
+    });
+
     it("preserves streaming while adding nonces to inline tags", async () => {
       let releaseSecondChunk: (() => void) | undefined;
       const secondChunkReady = new Promise<void>((resolve) => {

--- a/src/server/handlers/request/ssr/ssr-response-builder.ts
+++ b/src/server/handlers/request/ssr/ssr-response-builder.ts
@@ -49,7 +49,7 @@ export async function buildSSRResponse(
       .withCORS(req, ctx.securityConfig?.cors)
       .withSecurity(ctx.securityConfig ?? undefined, req)
       .withClientHints()
-      .withCache("no-cache")
+      .withCache(result.cacheStrategy)
       .withContentType(
         getContentType(".html"),
         addNonceToHtmlStream(result.stream, builder.nonce),

--- a/src/server/services/rendering/ssr.service.test.ts
+++ b/src/server/services/rendering/ssr.service.test.ts
@@ -271,6 +271,55 @@ describe("server/services/rendering/ssr.service", () => {
         assertEquals(result.cacheStrategy, "short");
       });
 
+      it("requests buffered delivery when the response is cacheable", async () => {
+        let delivery: unknown;
+        const adapter = createMockRendererAdapter({
+          renderPage: (_slug, options) => {
+            delivery = options?.delivery;
+            return Promise.resolve({
+              html: "<html>rendered</html>",
+              stream: undefined,
+              ssrHash: "hash123",
+              frontmatter: {},
+            });
+          },
+        });
+        const service = new SSRService({
+          rendererProvider: createMockRendererProvider(adapter),
+        });
+
+        await service.renderPage(makeCtx(), makeRenderOptions({ useNoCache: false }));
+
+        assertEquals(delivery, "string");
+      });
+
+      it("keeps streaming delivery for no-cache responses", async () => {
+        let delivery: unknown;
+        const adapter = createMockRendererAdapter({
+          renderPage: (_slug, options) => {
+            delivery = options?.delivery;
+            return Promise.resolve({
+              html: "",
+              stream: new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.enqueue(new TextEncoder().encode("<html>stream</html>"));
+                  controller.close();
+                },
+              }),
+              ssrHash: undefined,
+              frontmatter: {},
+            });
+          },
+        });
+        const service = new SSRService({
+          rendererProvider: createMockRendererProvider(adapter),
+        });
+
+        await service.renderPage(makeCtx(), makeRenderOptions({ useNoCache: true }));
+
+        assertEquals(delivery, "stream");
+      });
+
       it("uses no-cache strategy when useNoCache is true", async () => {
         const adapter = createMockRendererAdapter();
         const service = new SSRService({

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -176,13 +176,14 @@ export class SSRService implements SSRServiceLike {
       // Bind the render session to this async context so modules fetched
       // during the render are attributed to THIS render, not whichever
       // concurrent session started first.
+      const delivery = useNoCache ? "stream" : "string";
       const result = await runInRenderSession(renderSessionId, () =>
         profilePhase(
           "ssr.render_page",
           () =>
             timeAsync("render-page", () =>
               renderer.renderPage(slug, {
-                delivery: "stream",
+                delivery,
                 request,
                 url,
                 nonce,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.785";
+export const VERSION = "0.1.786";


### PR DESCRIPTION
## Summary
- Use buffered SSR delivery for cacheable production responses so existing render-cache persistence can store HTML payloads.
- Keep no-cache responses (preview/local/error paths) on streaming delivery.
- Make streaming SSR responses honor the selected cache strategy instead of always forcing no-cache.
- Bump Veryfront package version to `0.1.786`.

## Root cause
Production SSR hard navigations requested `delivery: "stream"`. That path returns a stream and the cache store intentionally skips stream payloads, so production pages were bypassing the render cache even though the adapter configured a distributed render cache. The response builder also forced streaming responses to `no-cache`, ignoring the service-level cache strategy.

## Validation
- `deno test --no-check --allow-all src/server/services/rendering/ssr.service.test.ts src/server/handlers/request/ssr/ssr-response-builder.test.ts`
- `deno check src/server/services/rendering/ssr.service.ts src/server/handlers/request/ssr/ssr-response-builder.ts`
- Pre-push: format, lint, typecheck, unit tests (`2136 passed`, `18489 steps`)

## Notes
This intentionally does not raise public HTML `max-age`; publish invalidation and rollback retention need a separate HTML cache policy decision. This patch unlocks the existing server-side render cache for production without changing preview freshness.
