### PR TITLE
Refresh release manifest caches on deploy pokes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.786",
+  "version": "0.1.787",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -213,6 +213,75 @@ describe("VeryfrontFSAdapter", () => {
       assertEquals(fetchCount, 1);
     });
 
+    it("should clear cached release asset manifests on poke without unregistering the fetcher", async () => {
+      setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+      const releaseId = "release-env-poke";
+      let contentHash = "a".repeat(64);
+      const adapter = createAdapter();
+      let fetchCount = 0;
+
+      (adapter.getClient() as unknown as {
+        getReleaseAssetManifest: (releaseId: string) => Promise<{
+          state: string;
+          manifest: unknown;
+        }>;
+      }).getReleaseAssetManifest = async (requestedReleaseId: string) => {
+        fetchCount++;
+        assertEquals(requestedReleaseId, releaseId);
+        return {
+          state: "ready",
+          manifest: {
+            schemaVersion: 1,
+            projectId: "project-123",
+            releaseId,
+            releaseVersion: 1,
+            manifestVersion: 1,
+            builderVersion: "0.1.765",
+            sourceContentHash: "",
+            createdAt: "2026-06-12T00:00:00.000Z",
+            assetBasePath: "/_vf/assets",
+            modules: {
+              "pages/index.tsx": {
+                contentHash,
+                size: 1,
+                contentType: "text/javascript",
+              },
+            },
+            css: [],
+            routes: { "/": { modules: ["pages/index.tsx"], css: [] } },
+            dependencies: {},
+            fallback: { mode: "jit", gaps: [] },
+          },
+        };
+      };
+
+      adapter.setContentContext({
+        sourceType: "environment",
+        projectSlug: "test-project",
+        environmentName: "production",
+        releaseId,
+      });
+
+      assertEquals(getReadyManifestForRender(releaseId), null);
+      await waitFor(async () =>
+        getReadyManifestForRender(releaseId)?.modules["pages/index.tsx"]?.contentHash ===
+          "a".repeat(64)
+      );
+      assertEquals(fetchCount, 1);
+
+      contentHash = "b".repeat(64);
+      (adapter as unknown as {
+        wsManager: { deps: { clearMemoryCaches: () => void } };
+      }).wsManager.deps.clearMemoryCaches();
+
+      assertEquals(getReadyManifestForRender(releaseId), null);
+      await waitFor(async () =>
+        getReadyManifestForRender(releaseId)?.modules["pages/index.tsx"]?.contentHash ===
+          "b".repeat(64)
+      );
+      assertEquals(fetchCount, 2);
+    });
+
     it("should preserve context set before initialize", () => {
       const adapter = createAdapter();
       adapter.setContentContext({

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -36,6 +36,7 @@ import {
 } from "./adapter-helpers.ts";
 
 import {
+  clearCachedReleaseAssetManifests,
   registerManifestFetcherForRelease,
   unregisterManifestFetcherForRelease,
 } from "#veryfront/release-assets/manifest-cache.ts";
@@ -247,6 +248,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
       getContentSource: () => this.contentSource,
       getProjectDir: () => this.normalizer.getProjectDir(),
       clearMemoryCaches: () => {
+        clearCachedReleaseAssetManifests();
         this.readOps.clearFileListIndex();
         this.statOps.clearIndex();
         this.dirOps.clearTree();

--- a/src/release-assets/manifest-cache.ts
+++ b/src/release-assets/manifest-cache.ts
@@ -211,9 +211,14 @@ function scheduleFetch(releaseId: string): void {
   inFlight.set(releaseId, promise);
 }
 
-/** Clear the cache (deployment / memory pressure / tests). */
-export function clearReleaseAssetManifestCache(): void {
+/** Clear cached manifest bodies while keeping registered fetchers intact. */
+export function clearCachedReleaseAssetManifests(): void {
   manifestCache.clear();
   inFlight.clear();
+}
+
+/** Clear the cache and fetcher registry (tests / adapter teardown). */
+export function clearReleaseAssetManifestCache(): void {
+  clearCachedReleaseAssetManifests();
   fetcherRegistry.clear();
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.786";
+export const VERSION = "0.1.787";


### PR DESCRIPTION
## Summary
- clear cached release asset manifest bodies when the Veryfront adapter handles a memory-cache invalidation poke
- keep registered manifest fetchers intact so the next production render refetches the current manifest
- bump package version to 0.1.787

## Why
A same-release asset manifest rebuild can replace the durable manifest body while keeping the same manifestVersion. The deployed renderer already clears render/module/file caches on deployment pokes, but it did not clear the in-process release manifest body cache. That lets fresh HTML keep pointing at stale hashed assets until the 15 minute manifest TTL expires.

## Verification
- deno fmt src/release-assets/manifest-cache.ts src/platform/adapters/fs/veryfront/adapter.ts src/platform/adapters/fs/veryfront/adapter.test.ts deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all src/platform/adapters/fs/veryfront/adapter.test.ts src/release-assets/html-consumption.test.ts src/cache/keys.test.ts
- deno test --no-check --allow-all src/platform/adapters/fs/veryfront/websocket-manager.test.ts
- deno check src/release-assets/manifest-cache.ts src/platform/adapters/fs/veryfront/adapter.ts src/platform/adapters/fs/veryfront/adapter.test.ts
- git diff --check
- pre-push hook: formatting, lint, typecheck, unit tests: 2136 passed, 0 failed

## Production follow-up
After this release is deployed to the renderer image, rebuild/poke the Coder Society release manifest again and verify the public HTML no longer emits stale hashed modules that import /components/* directly.