### PR TITLE
Ignore stale release manifest fetches after clears

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.787",
+  "version": "0.1.788",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/release-assets/html-consumption.test.ts
+++ b/src/release-assets/html-consumption.test.ts
@@ -9,6 +9,7 @@ import {
   resolveManifestRoutePreloadUrls,
 } from "./html-consumption.ts";
 import {
+  clearCachedReleaseAssetManifests,
   clearReleaseAssetManifestCache,
   configureReleaseAssetManifestFetcher,
   getReadyManifestForRender,
@@ -18,7 +19,7 @@ import type { ReleaseAssetManifest } from "./manifest-schema.ts";
 
 const MOD_HASH = "a".repeat(64);
 
-function manifest(): ReleaseAssetManifest {
+function manifest(contentHash = MOD_HASH): ReleaseAssetManifest {
   return {
     schemaVersion: 1,
     projectId: "p",
@@ -30,7 +31,7 @@ function manifest(): ReleaseAssetManifest {
     createdAt: "2026-06-12T00:00:00.000Z",
     assetBasePath: "/_vf/assets",
     modules: {
-      "pages/index.tsx": { contentHash: MOD_HASH, size: 1, contentType: "text/javascript" },
+      "pages/index.tsx": { contentHash, size: 1, contentType: "text/javascript" },
     },
     css: [],
     routes: { "/": { modules: ["pages/index.tsx"], css: [] } },
@@ -110,5 +111,50 @@ describe("manifest cache gating", () => {
 
     const cached = getReadyManifestForRender("r");
     assertEquals(cached?.manifestVersion, 3);
+  });
+
+  it("ignores stale in-flight manifest fetches after the cache is cleared", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    const firstHash = "a".repeat(64);
+    const secondHash = "b".repeat(64);
+    let resolveFirst: () => void = () => {};
+    let resolveSecond: () => void = () => {};
+    const firstGate = new Promise<void>((resolve) => (resolveFirst = resolve));
+    const secondGate = new Promise<void>((resolve) => (resolveSecond = resolve));
+    let fetchCount = 0;
+
+    configureReleaseAssetManifestFetcher(async () => {
+      fetchCount++;
+      if (fetchCount === 1) {
+        await firstGate;
+        return { state: "ready", manifest: manifest(firstHash) };
+      }
+
+      await secondGate;
+      return { state: "ready", manifest: manifest(secondHash) };
+    });
+
+    assertEquals(getReadyManifestForRender("r"), null);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assertEquals(fetchCount, 1);
+
+    clearCachedReleaseAssetManifests();
+    assertEquals(getReadyManifestForRender("r"), null);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assertEquals(fetchCount, 2);
+
+    resolveSecond();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assertEquals(
+      getReadyManifestForRender("r")?.modules["pages/index.tsx"]?.contentHash,
+      secondHash,
+    );
+
+    resolveFirst();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assertEquals(
+      getReadyManifestForRender("r")?.modules["pages/index.tsx"]?.contentHash,
+      secondHash,
+    );
   });
 });

--- a/src/release-assets/manifest-cache.ts
+++ b/src/release-assets/manifest-cache.ts
@@ -48,8 +48,15 @@ interface CacheEntry {
 const manifestCache = new LRUCache<string, CacheEntry>({ maxEntries: MAX_CACHED_MANIFESTS });
 registerLRUCache("release-asset-manifest-cache", manifestCache);
 
+interface InFlightFetch {
+  generation: number;
+  token: symbol;
+}
+
 /** In-flight fetches, deduped per releaseId. */
-const inFlight = new Map<string, Promise<void>>();
+const inFlight = new Map<string, InFlightFetch>();
+/** Monotonic guard that invalidates pending fetch writers after cache clears. */
+let cacheGeneration = 0;
 
 /**
  * Fetcher used to retrieve a manifest for a release. Registered per-releaseId
@@ -170,10 +177,15 @@ function scheduleFetch(releaseId: string): void {
   if (inFlight.has(releaseId)) return;
   const active = resolveFetcher(releaseId);
   if (!active) return;
+  const fetchGeneration = cacheGeneration;
+  const token = Symbol(releaseId);
+  inFlight.set(releaseId, { generation: fetchGeneration, token });
 
-  const promise = (async () => {
+  void Promise.resolve().then(async () => {
     try {
       const result = await active(releaseId);
+      if (fetchGeneration !== cacheGeneration) return;
+
       if (!result) {
         manifestCache.set(releaseId, { manifest: null, expiresAt: Date.now() + NON_READY_TTL_MS });
         return;
@@ -202,17 +214,20 @@ function scheduleFetch(releaseId: string): void {
         releaseId,
         error: error instanceof Error ? error.message : String(error),
       });
+      if (fetchGeneration !== cacheGeneration) return;
       manifestCache.set(releaseId, { manifest: null, expiresAt: Date.now() + NON_READY_TTL_MS });
     } finally {
-      inFlight.delete(releaseId);
+      const current = inFlight.get(releaseId);
+      if (current?.token === token && current.generation === fetchGeneration) {
+        inFlight.delete(releaseId);
+      }
     }
-  })();
-
-  inFlight.set(releaseId, promise);
+  });
 }
 
 /** Clear cached manifest bodies while keeping registered fetchers intact. */
 export function clearCachedReleaseAssetManifests(): void {
+  cacheGeneration++;
   manifestCache.clear();
   inFlight.clear();
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.787";
+export const VERSION = "0.1.788";


### PR DESCRIPTION
## Summary
- add a generation guard for release asset manifest cache clears
- keep in-flight fetch dedupe, but prevent fetches started before a clear from writing stale manifest bodies afterward
- add a regression for the exact stale-writer race raised on #2405
- bump package version to 0.1.788

## Why
PR #2405 correctly clears cached manifest bodies on deploy/publish pokes, but the review identified a remaining race: a manifest fetch that began before the clear could resolve after the clear and repopulate the cache with a stale same-version manifest body.

This keeps the design simple: cache clears advance a monotonic generation, fetches capture their start generation, and only same-generation fetches can write cache entries or clear their in-flight ownership.

## Verification
- deno fmt src/release-assets/manifest-cache.ts src/release-assets/html-consumption.test.ts deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all src/release-assets/html-consumption.test.ts src/platform/adapters/fs/veryfront/adapter.test.ts src/cache/keys.test.ts
- deno check src/release-assets/manifest-cache.ts src/release-assets/html-consumption.test.ts src/platform/adapters/fs/veryfront/adapter.ts
- git diff --check
- pre-push hook: formatting, lint, typecheck, unit tests: 2136 passed, 0 failed

## Related
- Follow-up to review comment on #2405: stale in-flight manifest fetches could recache after clear.