### PR TITLE
Ignore stale release manifest fetches

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.787",
+  "version": "0.1.788",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/release-assets/html-consumption.test.ts
+++ b/src/release-assets/html-consumption.test.ts
@@ -9,6 +9,7 @@ import {
   resolveManifestRoutePreloadUrls,
 } from "./html-consumption.ts";
 import {
+  clearCachedReleaseAssetManifests,
   clearReleaseAssetManifestCache,
   configureReleaseAssetManifestFetcher,
   getReadyManifestForRender,
@@ -18,7 +19,7 @@ import type { ReleaseAssetManifest } from "./manifest-schema.ts";
 
 const MOD_HASH = "a".repeat(64);
 
-function manifest(): ReleaseAssetManifest {
+function manifest(contentHash = MOD_HASH): ReleaseAssetManifest {
   return {
     schemaVersion: 1,
     projectId: "p",
@@ -30,7 +31,7 @@ function manifest(): ReleaseAssetManifest {
     createdAt: "2026-06-12T00:00:00.000Z",
     assetBasePath: "/_vf/assets",
     modules: {
-      "pages/index.tsx": { contentHash: MOD_HASH, size: 1, contentType: "text/javascript" },
+      "pages/index.tsx": { contentHash, size: 1, contentType: "text/javascript" },
     },
     css: [],
     routes: { "/": { modules: ["pages/index.tsx"], css: [] } },
@@ -110,5 +111,31 @@ describe("manifest cache gating", () => {
 
     const cached = getReadyManifestForRender("r");
     assertEquals(cached?.manifestVersion, 3);
+  });
+
+  it("ignores in-flight manifest fetches that resolve after the cache is cleared", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    const resolvers: Array<(value: { state: string; manifest: ReleaseAssetManifest }) => void> = [];
+    configureReleaseAssetManifestFetcher(() =>
+      new Promise((resolve) => {
+        resolvers.push(resolve);
+      })
+    );
+
+    assertEquals(getReadyManifestForRender("r"), null);
+    await Promise.resolve();
+    assertEquals(resolvers.length, 1);
+    clearCachedReleaseAssetManifests();
+    assertEquals(getReadyManifestForRender("r"), null);
+    await Promise.resolve();
+    assertEquals(resolvers.length, 2);
+
+    resolvers[1]!({ state: "ready", manifest: manifest("b".repeat(64)) });
+    await new Promise((r) => setTimeout(r, 0));
+    resolvers[0]!({ state: "ready", manifest: manifest("a".repeat(64)) });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const cached = getReadyManifestForRender("r");
+    assertEquals(cached?.modules["pages/index.tsx"]?.contentHash, "b".repeat(64));
   });
 });

--- a/src/release-assets/manifest-cache.ts
+++ b/src/release-assets/manifest-cache.ts
@@ -50,6 +50,7 @@ registerLRUCache("release-asset-manifest-cache", manifestCache);
 
 /** In-flight fetches, deduped per releaseId. */
 const inFlight = new Map<string, Promise<void>>();
+let cacheGeneration = 0;
 
 /**
  * Fetcher used to retrieve a manifest for a release. Registered per-releaseId
@@ -171,9 +172,12 @@ function scheduleFetch(releaseId: string): void {
   const active = resolveFetcher(releaseId);
   if (!active) return;
 
-  const promise = (async () => {
+  const generation = cacheGeneration;
+  const promise = Promise.resolve().then(async () => {
     try {
       const result = await active(releaseId);
+      if (generation !== cacheGeneration) return;
+
       if (!result) {
         manifestCache.set(releaseId, { manifest: null, expiresAt: Date.now() + NON_READY_TTL_MS });
         return;
@@ -202,17 +206,21 @@ function scheduleFetch(releaseId: string): void {
         releaseId,
         error: error instanceof Error ? error.message : String(error),
       });
+      if (generation !== cacheGeneration) return;
       manifestCache.set(releaseId, { manifest: null, expiresAt: Date.now() + NON_READY_TTL_MS });
     } finally {
-      inFlight.delete(releaseId);
+      if (inFlight.get(releaseId) === promise) {
+        inFlight.delete(releaseId);
+      }
     }
-  })();
+  });
 
   inFlight.set(releaseId, promise);
 }
 
 /** Clear cached manifest bodies while keeping registered fetchers intact. */
 export function clearCachedReleaseAssetManifests(): void {
+  cacheGeneration++;
   manifestCache.clear();
   inFlight.clear();
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.787";
+export const VERSION = "0.1.788";


### PR DESCRIPTION
## Summary
- Add a cache generation guard so manifest fetches started before a deploy-poke cache clear cannot write stale same-version manifest bodies afterward.
- Preserve newer in-flight fetch entries when older promises settle late.
- Add a regression test for stale fetch A resolving after fresh fetch B, and bump Veryfront to 0.1.788.

## Test Plan
- [x] VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all src/release-assets/build-executor.test.ts src/platform/adapters/fs/veryfront/adapter.test.ts src/release-assets/html-consumption.test.ts src/cache/keys.test.ts src/server/services/rendering/ssr.service.test.ts src/server/handlers/request/ssr/ssr-response-builder.test.ts
- [x] deno check src/release-assets/manifest-cache.ts src/release-assets/html-consumption.test.ts
- [x] git diff --check
- [x] pre-push hook: formatting, lint, typecheck, unit tests: 2136 passed, 0 failed
