### PR TITLE
Pass parent run context to child agents

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.788",
+  "version": "0.1.789",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/hosted/child-fork-execution-runner.test.ts
+++ b/src/agent/hosted/child-fork-execution-runner.test.ts
@@ -272,10 +272,13 @@ Deno.test("executeHostedChildForkToolInput resolves runtime config and prepares 
     authToken: "token",
     apiUrl: "https://api.example.com",
     projectId: "project-1",
+    conversationId: "conversation-parent-1",
+    parentRunId: "run-parent-1",
     kind: "invoke_agent",
     forkInput: {
       description: "Review checkout",
       prompt: "Review the checkout flow.",
+      context: {},
       project_id: "project-2",
       tools: ["noop"],
       model: "sonnet",
@@ -306,6 +309,18 @@ Deno.test("executeHostedChildForkToolInput resolves runtime config and prepares 
       assertEquals(runtimeConfig.maxSteps, 120);
       assertEquals(runtimeConfig.thinkingConfig, { enabled: true, budgetTokens: 256 });
       assertEquals(runtimeConfig.effectivePrompt.includes("Review the checkout flow."), true);
+      assertEquals(
+        runtimeConfig.effectivePrompt.includes('"parent_conversation_id":"conversation-parent-1"'),
+        true,
+      );
+      assertEquals(
+        runtimeConfig.effectivePrompt.includes('"parent_run_id":"run-parent-1"'),
+        true,
+      );
+      assertEquals(
+        runtimeConfig.effectivePrompt.includes('"tool_call_id":"tool-call-1"'),
+        true,
+      );
       return {
         ok: true,
         forkTools: {},

--- a/src/agent/hosted/child-fork-execution-runner.test.ts
+++ b/src/agent/hosted/child-fork-execution-runner.test.ts
@@ -314,7 +314,15 @@ Deno.test("executeHostedChildForkToolInput resolves runtime config and prepares 
         true,
       );
       assertEquals(
+        runtimeConfig.effectivePrompt.includes('"root_conversation_id":"conversation-parent-1"'),
+        true,
+      );
+      assertEquals(
         runtimeConfig.effectivePrompt.includes('"parent_run_id":"run-parent-1"'),
+        true,
+      );
+      assertEquals(
+        runtimeConfig.effectivePrompt.includes('"root_run_id":"run-parent-1"'),
         true,
       );
       assertEquals(
@@ -369,6 +377,81 @@ Deno.test("executeHostedChildForkToolInput resolves runtime config and prepares 
   if (result.success) {
     assertEquals(result.summary.text, "Resolved.");
   }
+});
+
+Deno.test("executeHostedChildForkToolInput preserves root invocation context for nested child forks", async () => {
+  await executeHostedChildForkToolInput({
+    authToken: "token",
+    apiUrl: "https://api.example.com",
+    projectId: "project-1",
+    conversationId: "conversation-parent-2",
+    parentRunId: "run-parent-2",
+    kind: "invoke_agent",
+    forkInput: {
+      description: "Review nested handoff",
+      prompt: "Review the nested handoff.",
+      context: {
+        veryfront_invocation_context: {
+          root_conversation_id: "conversation-root-1",
+          parent_conversation_id: "conversation-parent-1",
+          root_run_id: "run-root-1",
+          parent_run_id: "run-parent-1",
+          tool_call_id: "tool-call-parent",
+        },
+      },
+    },
+    toolCallId: "tool-call-2",
+    defaultModel: "haiku",
+    defaultMaxSteps: 80,
+    resolveModelId: (modelId) => modelId,
+    resolveProvider: () => "anthropic",
+    prepareToolAssembly: ({ runtimeConfig }) => {
+      assertEquals(
+        runtimeConfig.effectivePrompt.includes('"root_conversation_id":"conversation-root-1"'),
+        true,
+      );
+      assertEquals(
+        runtimeConfig.effectivePrompt.includes('"parent_conversation_id":"conversation-parent-2"'),
+        true,
+      );
+      assertEquals(
+        runtimeConfig.effectivePrompt.includes('"root_run_id":"run-root-1"'),
+        true,
+      );
+      assertEquals(
+        runtimeConfig.effectivePrompt.includes('"parent_run_id":"run-parent-2"'),
+        true,
+      );
+      assertEquals(runtimeConfig.effectivePrompt.includes('"tool_call_id":"tool-call-2"'), true);
+      assertEquals(runtimeConfig.effectivePrompt.includes('"tool-call-parent"'), false);
+      return {
+        ok: true,
+        forkTools: {},
+        availableToolNames: [],
+      };
+    },
+    startRuntime: () => ({
+      forkStreamAbortController: new AbortController(),
+      childRunMonitorAbortController: null,
+      childRunMonitorPromise: Promise.resolve(),
+      forkToolNames: [],
+      streamResult: {
+        fullStream: (async function* () {
+          yield { type: "text-delta", text: "Resolved." } as const;
+        })(),
+        steps: Promise.resolve([
+          {
+            text: "Resolved.",
+            finishReason: "stop",
+            messages: [],
+            toolCalls: [],
+            toolResults: [],
+          },
+        ]),
+        totalUsage: Promise.resolve(undefined),
+      },
+    }),
+  });
 });
 
 Deno.test("executeHostedChildForkWithPreparedTools exports stable default timeout constants", () => {

--- a/src/agent/hosted/child-fork-execution-runner.ts
+++ b/src/agent/hosted/child-fork-execution-runner.ts
@@ -49,6 +49,7 @@ import {
   type HostedChildForkToolInput,
   resolveHostedChildForkRuntimeConfig,
   type ResolveHostedChildForkRuntimeConfigInput,
+  withHostedChildInvocationContext,
 } from "./child-tool-input.ts";
 
 /** Default value for hosted child fork stream idle timeout ms. */
@@ -221,45 +222,6 @@ export type ExecuteHostedChildForkToolInputOptions<
     ) => Record<string, unknown> | undefined;
     onRuntimeConfig?: (runtimeConfig: HostedChildForkRuntimeConfig) => void | Promise<void>;
   };
-
-function buildHostedChildInvocationContext(input: {
-  conversationId?: string;
-  parentRunId?: string;
-  toolCallId: string;
-}): Record<string, string> {
-  return {
-    ...(input.conversationId
-      ? {
-        root_conversation_id: input.conversationId,
-        parent_conversation_id: input.conversationId,
-      }
-      : {}),
-    ...(input.parentRunId
-      ? {
-        root_run_id: input.parentRunId,
-        parent_run_id: input.parentRunId,
-      }
-      : {}),
-    tool_call_id: input.toolCallId,
-  };
-}
-
-function withHostedChildInvocationContext(
-  forkInput: HostedChildForkToolInput,
-  input: {
-    conversationId?: string;
-    parentRunId?: string;
-    toolCallId: string;
-  },
-): HostedChildForkToolInput {
-  return {
-    ...forkInput,
-    context: {
-      ...(forkInput.context ?? {}),
-      veryfront_invocation_context: buildHostedChildInvocationContext(input),
-    },
-  };
-}
 
 /** Input payload for execute hosted child fork tool. */
 export async function executeHostedChildForkToolInput<

--- a/src/agent/hosted/child-fork-execution-runner.ts
+++ b/src/agent/hosted/child-fork-execution-runner.ts
@@ -222,6 +222,45 @@ export type ExecuteHostedChildForkToolInputOptions<
     onRuntimeConfig?: (runtimeConfig: HostedChildForkRuntimeConfig) => void | Promise<void>;
   };
 
+function buildHostedChildInvocationContext(input: {
+  conversationId?: string;
+  parentRunId?: string;
+  toolCallId: string;
+}): Record<string, string> {
+  return {
+    ...(input.conversationId
+      ? {
+        root_conversation_id: input.conversationId,
+        parent_conversation_id: input.conversationId,
+      }
+      : {}),
+    ...(input.parentRunId
+      ? {
+        root_run_id: input.parentRunId,
+        parent_run_id: input.parentRunId,
+      }
+      : {}),
+    tool_call_id: input.toolCallId,
+  };
+}
+
+function withHostedChildInvocationContext(
+  forkInput: HostedChildForkToolInput,
+  input: {
+    conversationId?: string;
+    parentRunId?: string;
+    toolCallId: string;
+  },
+): HostedChildForkToolInput {
+  return {
+    ...forkInput,
+    context: {
+      ...(forkInput.context ?? {}),
+      veryfront_invocation_context: buildHostedChildInvocationContext(input),
+    },
+  };
+}
+
 /** Input payload for execute hosted child fork tool. */
 export async function executeHostedChildForkToolInput<
   TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
@@ -232,8 +271,13 @@ export async function executeHostedChildForkToolInput<
     await input.onRequestedProjectId?.(input.forkInput.project_id);
   }
 
+  const forkInput = withHostedChildInvocationContext(input.forkInput, {
+    conversationId: input.conversationId,
+    parentRunId: input.parentRunId,
+    toolCallId: input.toolCallId,
+  });
   const runtimeConfig = resolveHostedChildForkRuntimeConfig({
-    forkInput: input.forkInput,
+    forkInput,
     contextModel: input.contextModel,
     defaultModel: input.defaultModel,
     defaultMaxSteps: input.defaultMaxSteps,

--- a/src/agent/hosted/child-tool-input.ts
+++ b/src/agent/hosted/child-tool-input.ts
@@ -52,6 +52,77 @@ export type HostedChildForkRuntimeConfig = {
   thinkingConfig: RuntimeAgentThinkingConfig | undefined;
 };
 
+function getStringRecord(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  const record: Record<string, string> = {};
+  for (const [key, property] of Object.entries(value)) {
+    if (typeof property === "string") {
+      record[key] = property;
+    }
+  }
+
+  return record;
+}
+
+function buildHostedChildInvocationContext(
+  forkInput: HostedChildForkToolInput,
+  input: {
+    conversationId?: string;
+    parentRunId?: string;
+    toolCallId: string;
+  },
+): Record<string, string> {
+  const existing = getStringRecord(forkInput.context?.veryfront_invocation_context);
+  const rootConversationId = existing.root_conversation_id || input.conversationId;
+  const rootRunId = existing.root_run_id || input.parentRunId;
+
+  return {
+    ...existing,
+    ...(rootConversationId
+      ? {
+        root_conversation_id: rootConversationId,
+      }
+      : {}),
+    ...(input.conversationId
+      ? {
+        parent_conversation_id: input.conversationId,
+      }
+      : {}),
+    ...(rootRunId
+      ? {
+        root_run_id: rootRunId,
+      }
+      : {}),
+    ...(input.parentRunId
+      ? {
+        parent_run_id: input.parentRunId,
+      }
+      : {}),
+    tool_call_id: input.toolCallId,
+  };
+}
+
+/** Adds Veryfront invocation metadata to hosted child fork input. */
+export function withHostedChildInvocationContext(
+  forkInput: HostedChildForkToolInput,
+  input: {
+    conversationId?: string;
+    parentRunId?: string;
+    toolCallId: string;
+  },
+): HostedChildForkToolInput {
+  return {
+    ...forkInput,
+    context: {
+      ...(forkInput.context ?? {}),
+      veryfront_invocation_context: buildHostedChildInvocationContext(forkInput, input),
+    },
+  };
+}
+
 /** Input payload for resolve hosted child fork runtime config. */
 export type ResolveHostedChildForkRuntimeConfigInput = {
   forkInput: Pick<
@@ -96,6 +167,22 @@ function appendStructuredContextToPrompt(
   }\n</structured_context>\nTreat structured_context as the authoritative data payload for the child task. If prose conflicts with structured_context, use structured_context and say what conflicted.`;
 }
 
+/** Builds the effective hosted child fork prompt. */
+export function buildHostedChildForkEffectivePrompt(input: {
+  description: string;
+  prompt: string;
+  context: HostedChildForkToolInput["context"];
+  runId: string;
+}): string {
+  const promptWithArtifactPath = withDefaultResearchArtifactPath({
+    description: input.description,
+    prompt: input.prompt,
+    runId: input.runId,
+  });
+
+  return appendStructuredContextToPrompt(promptWithArtifactPath, input.context);
+}
+
 /** Configuration used by resolve hosted child fork runtime. */
 export function resolveHostedChildForkRuntimeConfig(
   input: ResolveHostedChildForkRuntimeConfigInput,
@@ -103,15 +190,15 @@ export function resolveHostedChildForkRuntimeConfig(
   const { description, prompt, context, tools, model, thinking, max_steps } = input.forkInput;
   const forkModel = input.resolveModelId(model || input.contextModel || input.defaultModel);
   const requestedMaxSteps = typeof max_steps === "number" ? max_steps : undefined;
-  const promptWithArtifactPath = withDefaultResearchArtifactPath({
-    description,
-    prompt,
-    runId: input.runId,
-  });
 
   return {
     description,
-    effectivePrompt: appendStructuredContextToPrompt(promptWithArtifactPath, context),
+    effectivePrompt: buildHostedChildForkEffectivePrompt({
+      description,
+      prompt,
+      context,
+      runId: input.runId,
+    }),
     requestedTools: tools,
     forkModel,
     provider: input.resolveProvider(forkModel),

--- a/src/agent/hosted/default-invoke-agent-tool.ts
+++ b/src/agent/hosted/default-invoke-agent-tool.ts
@@ -51,6 +51,7 @@ import {
   getHostedChildForkToolInputSchema,
   type HostedChildForkRuntimeConfig,
   type HostedChildForkToolInput,
+  withHostedChildInvocationContext,
 } from "./child-tool-input.ts";
 import type {
   DefaultHostedChildForkToolAssemblyResult,
@@ -329,7 +330,7 @@ function buildInstrumentation<TContext extends DefaultHostedInvokeAgentContext>(
 
 async function executeForkTask<TContext extends DefaultHostedInvokeAgentContext>(
   options: DefaultHostedInvokeAgentToolOptions<TContext>,
-  input: DefaultHostedInvokeAgentInput,
+  input: HostedChildForkToolInput,
   execution: {
     toolCallId: string;
     abortSignal?: AbortSignal;
@@ -416,6 +417,11 @@ export async function executeDefaultHostedInvokeAgentTool<
   const config = options.getConfig();
   const toolCallId = getToolCallId(executionContext);
   const abortSignal = getAbortSignal(executionContext);
+  const forkInput = withHostedChildInvocationContext(input, {
+    conversationId: options.context.conversationId,
+    parentRunId: options.context.parentRunId,
+    toolCallId,
+  });
   const durableInvokeRecorder = createHostedDurableChildInvokeTraceRecorder({
     traceBase: {
       conversationId: options.context.conversationId,
@@ -431,7 +437,7 @@ export async function executeDefaultHostedInvokeAgentTool<
   const executeLocalInvoke = (runtimeOptions: HostedDurableChildExecutionOptions = {}) =>
     executeForkTask(
       options,
-      input,
+      forkInput,
       {
         toolCallId,
         abortSignal,
@@ -448,7 +454,7 @@ export async function executeDefaultHostedInvokeAgentTool<
 
   if (!config.enableDurableInvokeAgent) {
     return executeHostedLocalChildInvoke({
-      forkInput: input,
+      forkInput,
       abortSignal,
       traceRecorder: durableInvokeRecorder,
       execute: executeLocalInvoke,
@@ -464,7 +470,7 @@ export async function executeDefaultHostedInvokeAgentTool<
     >({
       authToken: options.context.authToken,
       apiUrl: config.apiUrl,
-      forkInput: input,
+      forkInput,
       executionOptions: {
         toolCallId,
         abortSignal,

--- a/src/agent/hosted/durable-child-fork-execution.test.ts
+++ b/src/agent/hosted/durable-child-fork-execution.test.ts
@@ -582,6 +582,12 @@ describe("agent/hosted-durable-child-fork-execution", () => {
           description: "Inspect logs",
           prompt: "Find logs",
           project_id: "77777777-7777-4777-8777-777777777777",
+          context: {
+            veryfront_invocation_context: {
+              root_conversation_id: "root-conversation-1",
+              root_run_id: "run_root_1",
+            },
+          },
         },
         executionOptions: { toolCallId: "tool-call-1" },
         childAgentId: "invoke-agent-child",
@@ -649,6 +655,17 @@ describe("agent/hosted-durable-child-fork-execution", () => {
       targetBranchId: BRANCH_ID,
     });
     assertEquals(result.success.snapshot.success, true);
+    const handoffMessageBody = getRecordedRequest(requests, 2).body;
+    assertEquals(handoffMessageBody, {
+      role: "user",
+      parts: [
+        {
+          type: "text",
+          text:
+            'Find logs\n\n<structured_context>\n{"veryfront_invocation_context":{"root_conversation_id":"root-conversation-1","root_run_id":"run_root_1","parent_conversation_id":"11111111-1111-4111-a111-111111111111","parent_run_id":"run_parent_1","tool_call_id":"tool-call-1"}}\n</structured_context>\nTreat structured_context as the authoritative data payload for the child task. If prose conflicts with structured_context, use structured_context and say what conflicted.',
+        },
+      ],
+    });
     const createRunBody = getRecordedRequest(requests, 3).body;
     assertEquals(createRunBody, {
       kind: "agent",

--- a/src/agent/hosted/durable-child-fork-execution.ts
+++ b/src/agent/hosted/durable-child-fork-execution.ts
@@ -21,7 +21,11 @@ import {
   HostedChildTerminalStateError,
   type HostedChildTerminalStatus,
 } from "./child-status.ts";
-import type { HostedChildForkToolInput } from "./child-tool-input.ts";
+import {
+  buildHostedChildForkEffectivePrompt,
+  type HostedChildForkToolInput,
+  withHostedChildInvocationContext,
+} from "./child-tool-input.ts";
 import { isChildRunAbortError, throwIfChildRunAborted } from "../child-run/execution-support.ts";
 
 /** Options accepted by hosted durable child execution. */
@@ -481,6 +485,11 @@ async function bootstrapHostedDurableChildFork<
 
   return runBootstrap(async () => {
     await input.bootstrap?.onBootstrapStart?.(input.bootstrapContext);
+    const forkInput = withHostedChildInvocationContext(input.forkInput, {
+      conversationId: input.bootstrapContext.parentConversationId,
+      parentRunId: input.bootstrapContext.parentRunId,
+      toolCallId: input.executionOptions.toolCallId,
+    });
 
     const bootstrapChildRun = input.runtime?.bootstrapChildRun ?? bootstrapHostedChildRun;
     const run = await bootstrapChildRun({
@@ -492,8 +501,13 @@ async function bootstrapHostedDurableChildFork<
       parentRunId: input.bootstrapContext.parentRunId,
       parentMessageId: input.bootstrapContext.parentMessageId,
       spawnedFromToolCallId: input.executionOptions.toolCallId,
-      description: input.forkInput.description,
-      prompt: input.forkInput.prompt,
+      description: forkInput.description,
+      prompt: buildHostedChildForkEffectivePrompt({
+        description: forkInput.description,
+        prompt: forkInput.prompt,
+        context: forkInput.context,
+        runId: input.executionOptions.toolCallId,
+      }),
       agentId: input.childAgentId,
       branchId: getBranchId(input),
     });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.788";
+export const VERSION = "0.1.789";


### PR DESCRIPTION
## Summary\n- add a reserved veryfront_invocation_context payload to invoke_agent child structured context\n- include root/parent conversation ID, root/parent run ID, and tool call ID when available\n- cover the effective prompt contract with a hosted child fork test\n\n## Verification\n- deno test -A src/agent/hosted/default-invoke-agent-tool.test.ts src/agent/hosted/child-tool-input.test.ts src/agent/hosted/child-fork-execution-runner.test.ts\n\n## Note\n- normal git push pre-push ran the broad unit suite and failed in unrelated observability metrics config tests: expected exporter console, actual otlp. This PR only changes hosted child fork context files.