### PR TITLE
Refresh cached ready release manifests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.789",
+  "version": "0.1.790",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/release-assets/html-consumption.test.ts
+++ b/src/release-assets/html-consumption.test.ts
@@ -19,13 +19,13 @@ import type { ReleaseAssetManifest } from "./manifest-schema.ts";
 
 const MOD_HASH = "a".repeat(64);
 
-function manifest(contentHash = MOD_HASH): ReleaseAssetManifest {
+function manifest(contentHash = MOD_HASH, manifestVersion = 3): ReleaseAssetManifest {
   return {
     schemaVersion: 1,
     projectId: "p",
     releaseId: "r",
     releaseVersion: 1,
-    manifestVersion: 3,
+    manifestVersion,
     builderVersion: "0.1.765",
     sourceContentHash: "",
     createdAt: "2026-06-12T00:00:00.000Z",
@@ -156,5 +156,38 @@ describe("manifest cache gating", () => {
       getReadyManifestForRender("r")?.modules["pages/index.tsx"]?.contentHash,
       secondHash,
     );
+  });
+
+  it("refreshes cached ready manifests so same-release rebuilds are discovered", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    const firstHash = "a".repeat(64);
+    const secondHash = "b".repeat(64);
+    let now = 1_000;
+    const originalDateNow = Date.now;
+    Date.now = () => now;
+
+    try {
+      let fetchCount = 0;
+      configureReleaseAssetManifestFetcher(async () => {
+        fetchCount++;
+        return fetchCount === 1
+          ? { state: "ready", manifest: manifest(firstHash, 3) }
+          : { state: "ready", manifest: manifest(secondHash, 4) };
+      });
+
+      assertEquals(getReadyManifestForRender("r"), null);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      assertEquals(getReadyManifestForRender("r")?.manifestVersion, 3);
+
+      now += 61_000;
+      assertEquals(getReadyManifestForRender("r")?.manifestVersion, 3);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const refreshed = getReadyManifestForRender("r");
+      assertEquals(refreshed?.manifestVersion, 4);
+      assertEquals(refreshed?.modules["pages/index.tsx"]?.contentHash, secondHash);
+    } finally {
+      Date.now = originalDateNow;
+    }
   });
 });

--- a/src/release-assets/manifest-cache.ts
+++ b/src/release-assets/manifest-cache.ts
@@ -38,11 +38,15 @@ const MAX_CACHED_MANIFESTS = 500;
 const NON_READY_TTL_MS = 30_000;
 /** TTL for ready manifests — long but finite so superseded entries are picked up (15 min). */
 const READY_TTL_MS = 15 * 60 * 1000;
+/** Background revalidation interval for ready manifests (1 min). */
+const READY_REVALIDATE_MS = 60_000;
 
 interface CacheEntry {
   manifest: ReleaseAssetManifest | null;
   /** Absolute expiry timestamp. */
   expiresAt: number;
+  /** Absolute timestamp after which ready entries should refresh in the background. */
+  refreshAfter?: number;
 }
 
 const manifestCache = new LRUCache<string, CacheEntry>({ maxEntries: MAX_CACHED_MANIFESTS });
@@ -160,7 +164,12 @@ export function getReadyManifestForRender(
     }
   }
 
-  if (best) return best.manifest;
+  if (best) {
+    if ((best.refreshAfter ?? best.expiresAt) <= Date.now()) {
+      scheduleFetch(releaseId);
+    }
+    return best.manifest;
+  }
 
   // Also check the plain releaseId slot (non-ready / null entry).
   const plain = manifestCache.get(releaseId);
@@ -197,11 +206,16 @@ function scheduleFetch(releaseId: string): void {
 
       if (manifest) {
         const key = cacheKey(releaseId, manifest.manifestVersion);
-        manifestCache.set(key, { manifest, expiresAt: Date.now() + READY_TTL_MS });
+        manifestCache.set(key, {
+          manifest,
+          expiresAt: Date.now() + READY_TTL_MS,
+          refreshAfter: Date.now() + READY_REVALIDATE_MS,
+        });
         logger.debug("Cached ready manifest", {
           releaseId,
           manifestVersion: manifest.manifestVersion,
           ttlMs: READY_TTL_MS,
+          refreshMs: READY_REVALIDATE_MS,
         });
       } else {
         manifestCache.set(releaseId, {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.789";
+export const VERSION = "0.1.790";


### PR DESCRIPTION
## Summary

- Refresh ready release asset manifest cache entries in the background after 60 seconds.
- Keep production render non-blocking: stale ready manifests are returned immediately while the newer manifest is fetched asynchronously.
- Add a regression test for same-release manifest rebuilds advancing from one manifest version to the next.
- Bump `veryfront` to `0.1.790` so the server can consume a new package release.

## Root cause

Coder Society's production API release manifest had been rebuilt successfully, but renderer pods could keep serving an older ready manifest body from the in-process cache until the 15 minute TTL or a reliable deployment poke. That older manifest referenced hashed assets whose module bodies still imported `/components/...`, producing client-side 404s and broken navigation/layout.

This PR keeps the fast path but adds stale-while-revalidate behavior for ready manifests, so same-release rebuilds are discovered without blocking HTML render and without relying on manual cache purge operations.

## Verification

- `deno test --no-check --allow-all src/release-assets/html-consumption.test.ts src/platform/adapters/fs/veryfront/adapter.test.ts src/cache/keys.test.ts`
- `deno check src/release-assets/manifest-cache.ts src/release-assets/html-consumption.test.ts`
- pre-push hook: formatting, lint, type check, generation, and unit suite (`2137 passed`, `0 failed`)
