### PR TITLE
Register resolved release contexts for manifest consumption

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.791",
+  "version": "0.1.792",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -213,6 +213,100 @@ describe("VeryfrontFSAdapter", () => {
       assertEquals(fetchCount, 1);
     });
 
+    it("should register a release asset manifest fetcher when initialize resolves the release id", async () => {
+      setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+      const releaseId = "release-env-initialize";
+      const contentHash = "c".repeat(64);
+      const files = [{
+        path: "pages/index.tsx",
+        content: "export default function Page() { return null }",
+      }];
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          contentSource: { type: "environment", name: "production" },
+          cache: { enabled: false },
+        },
+      });
+      let fetchCount = 0;
+
+      const client = adapter.getClient() as unknown as {
+        initialize: () => Promise<void>;
+        getProjectSlug: () => string;
+        getProjectId: () => string;
+        getCachedProject: () => { provider: string; layout: string };
+        listEnvironmentFiles: (environmentName: string) => Promise<{
+          files: Array<{ path: string; content?: string }>;
+          page_info: { has_more: boolean; next: null };
+          release_id: string;
+        }>;
+        listAllEnvironmentFiles: (
+          environmentName: string,
+        ) => Promise<Array<{ path: string; content?: string }>>;
+        getReleaseAssetManifest: (releaseId: string) => Promise<{
+          state: string;
+          manifest: unknown;
+        }>;
+      };
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+      client.listEnvironmentFiles = (environmentName) => {
+        assertEquals(environmentName, "production");
+        return Promise.resolve({
+          files,
+          page_info: { has_more: false, next: null },
+          release_id: releaseId,
+        });
+      };
+      client.listAllEnvironmentFiles = (environmentName) => {
+        assertEquals(environmentName, "production");
+        return Promise.resolve(files);
+      };
+      client.getReleaseAssetManifest = async (requestedReleaseId) => {
+        fetchCount++;
+        assertEquals(requestedReleaseId, releaseId);
+        return {
+          state: "ready",
+          manifest: {
+            schemaVersion: 1,
+            projectId: "project-123",
+            releaseId,
+            releaseVersion: 1,
+            manifestVersion: 3,
+            builderVersion: "0.1.792",
+            sourceContentHash: "",
+            createdAt: "2026-06-12T00:00:00.000Z",
+            assetBasePath: "/_vf/assets",
+            modules: {
+              "pages/index.tsx": {
+                contentHash,
+                size: 1,
+                contentType: "text/javascript",
+              },
+            },
+            css: [],
+            routes: { "/": { modules: ["pages/index.tsx"], css: [] } },
+            dependencies: {},
+            fallback: { mode: "jit", gaps: [] },
+          },
+        };
+      };
+
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      await adapter.initialize();
+
+      assertEquals(adapter.getContentContext()?.releaseId, releaseId);
+      assertEquals(getReadyManifestForRender(releaseId), null);
+      await waitFor(async () => getReadyManifestForRender(releaseId)?.manifestVersion === 3);
+      assertEquals(fetchCount, 1);
+    });
+
     it("should clear cached release asset manifests on poke without unregistering the fetcher", async () => {
       setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
       const releaseId = "release-env-poke";

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -663,6 +663,59 @@ describe("VeryfrontFSAdapter", () => {
       }
     });
 
+    it("preserves request branch while initializing branch content context", async () => {
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          contentSource: { type: "branch", branch: "main" },
+          cache: { enabled: false },
+        },
+      });
+
+      const client = (adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          getContext: () => { type: string; name?: string; version?: string };
+          listAllFiles: () => Promise<Array<{ path: string; content?: string }>>;
+        };
+      }).client;
+
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+
+      let observedContext: ReturnType<typeof client.getContext> | null = null;
+      client.listAllFiles = () => {
+        observedContext = client.getContext();
+        assertEquals(observedContext, { type: "branch", name: "draft" });
+        return Promise.resolve([{
+          path: "pages/index.tsx",
+          content: "export default function Page() { return null }",
+        }]);
+      };
+
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      adapter.setRequestBranch("draft");
+
+      await adapter.initialize();
+
+      assertEquals(adapter.getRequestBranch(), "draft");
+      assertEquals(observedContext, { type: "branch", name: "draft" });
+      assertEquals(adapter.getContentContext(), {
+        sourceType: "branch",
+        projectSlug: "test-project",
+        branch: "main",
+      });
+    });
+
     it("should rehydrate a missing file list cache in the background", async () => {
       const adapter = createAdapter({
         veryfront: {

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -102,6 +102,20 @@ export class VeryfrontFSAdapter implements FSAdapter {
     return this.contentContext ? buildFileListCacheKey(this.contentContext) : undefined;
   }
 
+  private syncClientContext(): void {
+    this.client.clearRequestBranch();
+
+    if (this.contentContext) {
+      this.client.setContext(toClientContext(this.contentContext));
+    } else {
+      this.client.clearContext();
+    }
+
+    if (this.requestBranch) {
+      this.client.setRequestBranch(this.requestBranch);
+    }
+  }
+
   private getCachedFileListSync<T extends { path: string; id?: string }>(): T[] | undefined {
     const cacheKey = this.getCurrentFileListCacheKey();
     if (!cacheKey) return undefined;
@@ -663,7 +677,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
   setRequestBranch(branch: string | null): void {
     this.requestBranch = branch;
-    this.client.setRequestBranch(branch);
+    this.syncClientContext();
   }
 
   getRequestBranch(): string | null {
@@ -672,7 +686,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
   clearRequestBranch(): void {
     this.requestBranch = null;
-    this.client.clearRequestBranch();
+    this.syncClientContext();
   }
 
   setContentContext(context: ResolvedContentContext): void {
@@ -709,7 +723,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
     }
 
     this.contentContext = context;
-    this.client.setContext(toClientContext(context));
+    this.syncClientContext();
 
     if (contextChanged) {
       this.statOps.clearIndex();

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -315,14 +315,15 @@ export class VeryfrontFSAdapter implements FSAdapter {
     if (!this.contentContext) {
       logger.debug("Step 3: resolveContentSource START", { projectSlug });
       const step3Start = performance.now();
-      this.contentContext = await resolveContentContext(
+      const resolvedContext = await resolveContentContext(
         this.client,
         this.contentSource,
         this.projectSlug,
       );
+      this.setContentContext(resolvedContext);
       logger.debug("Step 3: resolveContentSource DONE", {
         projectSlug,
-        sourceType: this.contentContext.sourceType,
+        sourceType: resolvedContext.sourceType,
         duration: `${(performance.now() - step3Start).toFixed(2)}ms`,
       });
     } else {
@@ -332,19 +333,29 @@ export class VeryfrontFSAdapter implements FSAdapter {
       });
     }
 
+    const contentContext = this.contentContext;
+    if (!contentContext) {
+      throw toError(
+        createError({
+          type: "config",
+          message: "Veryfront adapter content context resolution failed",
+        }),
+      );
+    }
+
     logger.debug("Content context resolved", {
-      sourceType: this.contentContext.sourceType,
-      projectSlug: this.contentContext.projectSlug,
-      branch: this.contentContext.branch,
-      environmentName: this.contentContext.environmentName,
-      releaseId: this.contentContext.releaseId,
+      sourceType: contentContext.sourceType,
+      projectSlug: contentContext.projectSlug,
+      branch: contentContext.branch,
+      environmentName: contentContext.environmentName,
+      releaseId: contentContext.releaseId,
     });
 
-    const cacheKey = buildFileListCacheKey(this.contentContext);
+    const cacheKey = buildFileListCacheKey(contentContext);
     logger.debug("Step 4: fetchFileList START", { projectSlug, cacheKey });
 
     try {
-      const files = await fetchFileListForContext(this.client, this.contentContext);
+      const files = await fetchFileListForContext(this.client, contentContext);
       const fileSummary = summarizeFileList(files);
 
       await this.cache.setAsync(cacheKey, files);
@@ -377,11 +388,11 @@ export class VeryfrontFSAdapter implements FSAdapter {
         totalDuration: `${(performance.now() - initStartTime).toFixed(2)}ms`,
       });
 
-      if (this.contentContext.sourceType === "branch") {
+      if (contentContext.sourceType === "branch") {
         logger.debug("Initialized (branch mode)", {
           projectId: this.client.getProjectId(),
           files: files.length,
-          branch: this.contentContext.branch,
+          branch: contentContext.branch,
           proxyMode: this.proxyMode,
         });
         this.wsManager.connect(projectId);
@@ -391,14 +402,14 @@ export class VeryfrontFSAdapter implements FSAdapter {
       logger.debug("Initialized (published mode)", {
         projectId: this.client.getProjectId(),
         files: files.length,
-        sourceType: this.contentContext.sourceType,
-        environmentName: this.contentContext.environmentName,
-        releaseId: this.contentContext.releaseId,
+        sourceType: contentContext.sourceType,
+        environmentName: contentContext.environmentName,
+        releaseId: contentContext.releaseId,
       });
 
       // Keep a WebSocket connection in environment mode to receive deployment pokes.
       // Release mode is immutable, so no need to keep a live connection.
-      if (this.contentContext.sourceType === "environment") {
+      if (contentContext.sourceType === "environment") {
         this.wsManager.connect(projectId);
       }
     } catch (error) {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.791";
+export const VERSION = "0.1.792";


### PR DESCRIPTION
## Summary
- Route auto-resolved VeryfrontFSAdapter content contexts through setContentContext() so production environment/domain initialization registers the release asset manifest fetcher.
- Add a regression test for initialize() resolving a release id and then consuming a ready release asset manifest.
- Bump veryfront package version to 0.1.792 for a new release.

## Root cause
The release asset manifest was ready in the API, but renderer pods that resolved the production environment during initialize() assigned contentContext directly. That bypassed setContentContext(), so no per-release manifest fetcher was registered and HTML kept falling back to /_vf_modules. Rebuilding the manifest alone would not fix that path.

## Verification
- deno fmt --check deno.json src/platform/adapters/fs/veryfront/adapter.ts src/platform/adapters/fs/veryfront/adapter.test.ts src/utils/version-constant.ts
- deno check --allow-import src/platform/adapters/fs/veryfront/adapter.ts src/platform/adapters/fs/veryfront/adapter.test.ts
- deno test --no-check --allow-all src/platform/adapters/fs/veryfront/adapter.test.ts src/html/html-shell-manifest.test.ts src/release-assets/html-consumption.test.ts
