### PR TITLE
Preserve release CSS during SPA navigation

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.792",
+  "version": "0.1.793",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/html/hydration-script-builder/templates/router.test.ts
+++ b/src/html/hydration-script-builder/templates/router.test.ts
@@ -223,6 +223,13 @@ describe("hydration-script-builder/templates/router", () => {
       assertIncludes(result, "styleEl.setAttribute('nonce', nonce)");
     });
 
+    it("should clear stale SPA CSS when page data marks release CSS authoritative", () => {
+      const result = getRouterScript();
+      assertIncludes(result, "pageData.cssAction === 'clear'");
+      assertIncludes(result, "existingStyle.remove()");
+      assertIncludes(result, "Cleared SPA CSS for release stylesheet navigation");
+    });
+
     it("should update document title during SPA navigation", () => {
       assertIncludes(getRouterScript(), "document.title = pageData.frontmatter.title");
     });

--- a/src/html/hydration-script-builder/templates/router.ts
+++ b/src/html/hydration-script-builder/templates/router.ts
@@ -444,6 +444,12 @@ export const getRouterScript = () => `
           document.head.appendChild(styleEl);
         }
         log('Injected CSS for SPA navigation', { cssLength: pageData.css.length });
+      } else if (pageData.cssAction === 'clear') {
+        const existingStyle = document.getElementById('veryfront-spa-css');
+        if (existingStyle) {
+          existingStyle.remove();
+          log('Cleared SPA CSS for release stylesheet navigation');
+        }
       }
 
       let tree = React.createElement(PageComponent, {

--- a/src/rendering/orchestrator/pipeline-helpers.ts
+++ b/src/rendering/orchestrator/pipeline-helpers.ts
@@ -2,9 +2,14 @@ import type { LayoutItem } from "#veryfront/types";
 import { extractRelativePath as extractRelativePathShared } from "#veryfront/utils/route-path-utils.ts";
 
 const RENDERED_CSS_HASH_RE = /href="\/_vf\/css\/([a-z0-9-]{1,16})\.css"/i;
+const RENDERED_RELEASE_ASSET_CSS_RE = /href="\/_vf\/assets\/([a-f0-9]{64})\.css"/i;
 
 export function extractRenderedCssHash(html: string): string | undefined {
   return html.match(RENDERED_CSS_HASH_RE)?.[1];
+}
+
+export function hasRenderedReleaseAssetCss(html: string): boolean {
+  return RENDERED_RELEASE_ASSET_CSS_RE.test(html);
 }
 
 export function serializeLayouts(

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -1,9 +1,19 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { RenderPipeline, type RenderPipelineConfig } from "./pipeline.ts";
 import { cachePageCss, getPageCssCacheKey } from "./css-cache.ts";
 import { cacheCSSAsync } from "#veryfront/html/styles-builder/index.ts";
+import { RELEASE_ASSET_MANIFEST_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
+import {
+  clearReleaseAssetManifestCache,
+  configureReleaseAssetManifestFetcher,
+  getReadyManifestForRender,
+} from "#veryfront/release-assets/manifest-cache.ts";
+import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
+import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+
+const RELEASE_CSS_HASH = "c".repeat(64);
 
 function createPipeline(pagePath: string): RenderPipeline {
   const config: RenderPipelineConfig = {
@@ -65,7 +75,48 @@ function primeCssCache(slug: string, projectId: string): void {
   cachePageCss(cssKey, "/* cached css */");
 }
 
+function releaseManifestWithCss(): ReleaseAssetManifest {
+  return {
+    schemaVersion: 1,
+    projectId: "p",
+    releaseId: "rel-css",
+    releaseVersion: 1,
+    manifestVersion: 1,
+    builderVersion: "0.1.793",
+    sourceContentHash: "",
+    createdAt: "2026-06-12T00:00:00.000Z",
+    assetBasePath: "/_vf/assets",
+    modules: {},
+    css: [{
+      contentHash: RELEASE_CSS_HASH,
+      size: 10,
+      contentType: "text/css",
+      styleProfileHash: "style-profile",
+    }],
+    routes: { "/behavior-release-css": { modules: [], css: [RELEASE_CSS_HASH] } },
+    dependencies: {},
+    fallback: { mode: "jit", gaps: [] },
+  };
+}
+
+async function primeReadyReleaseCssManifest(): Promise<void> {
+  configureReleaseAssetManifestFetcher(() =>
+    Promise.resolve({ state: "ready", manifest: releaseManifestWithCss() })
+  );
+  setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+  getReadyManifestForRender("rel-css");
+  await new Promise((r) => setTimeout(r, 0));
+}
+
 describe("RenderPipeline behavior", () => {
+  const originalManifestFlag = getHostEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG);
+
+  afterEach(() => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, originalManifestFlag ?? "");
+    configureReleaseAssetManifestFetcher(undefined);
+    clearReleaseAssetManifestCache();
+  });
+
   it("resolvePageData surfaces notFound from data hooks", async () => {
     const slug = "/behavior-not-found";
     const projectId = "proj-not-found";
@@ -294,6 +345,56 @@ describe("RenderPipeline behavior", () => {
     });
 
     assertEquals(pageData.css, expectedCss);
+    assertEquals(pageData.cssError, undefined);
+  });
+
+  it("resolvePageData skips SPA CSS fallback when SSR uses a release CSS asset", async () => {
+    const slug = "/behavior-release-css";
+    const projectId = "proj-release-css";
+    const pipeline = createPipeline("/project/pages/behavior-release-css.tsx");
+
+    (pipeline as any).loadModule = async () => ({});
+    (pipeline as any).renderPage = async () => ({
+      html:
+        `<!DOCTYPE html><html><head><link rel="stylesheet" href="/_vf/assets/${RELEASE_CSS_HASH}.css"></head><body><button class="hidden dark:block">theme</button></body></html>`,
+    });
+
+    const pageData = await pipeline.resolvePageData(slug, {
+      projectId,
+      request: new Request(`http://localhost${slug}`),
+      url: new URL(`http://localhost${slug}`),
+      environment: "production",
+    });
+
+    assertEquals(pageData.css, undefined);
+    assertEquals(pageData.cssAction, "clear");
+    assertEquals(pageData.cssError, undefined);
+  });
+
+  it("resolvePageData ignores stale cached SPA CSS when ready release CSS is authoritative", async () => {
+    const slug = "/behavior-release-css";
+    const projectId = "proj-release-css";
+    const pipeline = createPipeline("/project/pages/behavior-release-css.tsx");
+    const cssKey = getPageCssCacheKey(projectId, "production", slug, undefined);
+    cachePageCss(cssKey, '.dark\\:block{&:is(.dark,[data-theme="dark"])*{display:block}}');
+
+    await primeReadyReleaseCssManifest();
+
+    (pipeline as any).loadModule = async () => ({});
+    (pipeline as any).renderPage = async () => {
+      throw new Error("renderPage should not run when ready release CSS is cached");
+    };
+
+    const pageData = await pipeline.resolvePageData(slug, {
+      projectId,
+      releaseId: "rel-css",
+      request: new Request(`http://localhost${slug}`),
+      url: new URL(`http://localhost${slug}`),
+      environment: "production",
+    });
+
+    assertEquals(pageData.css, undefined);
+    assertEquals(pageData.cssAction, "clear");
     assertEquals(pageData.cssError, undefined);
   });
 

--- a/src/rendering/orchestrator/pipeline.test.ts
+++ b/src/rendering/orchestrator/pipeline.test.ts
@@ -7,6 +7,7 @@ import { getPageCssCacheKey } from "./css-cache.ts";
 import { collectModulesToLoad, hasDataFetchingFunction } from "./module-collection.ts";
 import {
   extractRenderedCssHash,
+  hasRenderedReleaseAssetCss,
   serializeLayoutProps,
   serializeLayouts,
 } from "./pipeline-helpers.ts";
@@ -32,6 +33,19 @@ describe("RenderPipeline helpers", () => {
       assertEquals(
         extractRenderedCssHash('<link rel="stylesheet" href="/_vf/css/abc123.css">'),
         "abc123",
+      );
+    });
+
+    it("hasRenderedReleaseAssetCss recognizes immutable release CSS links", () => {
+      assertEquals(
+        hasRenderedReleaseAssetCss(
+          `<link rel="stylesheet" href="/_vf/assets/${"c".repeat(64)}.css">`,
+        ),
+        true,
+      );
+      assertEquals(
+        hasRenderedReleaseAssetCss('<link rel="stylesheet" href="/_vf/css/abc123.css">'),
+        false,
       );
     });
 

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -28,6 +28,7 @@ import {
 } from "#veryfront/utils/route-path-utils.ts";
 import {
   extractRenderedCssHash,
+  hasRenderedReleaseAssetCss,
   serializeLayoutProps,
   serializeLayouts,
 } from "./pipeline-helpers.ts";
@@ -53,6 +54,7 @@ import {
   getCSSByHashAsync,
   regenerateCSSByHash,
 } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
+import { getReadyManifestForRender } from "#veryfront/release-assets/manifest-cache.ts";
 import { createEsmCache, createModuleCache, loadModule } from "./module-loader/index.ts";
 import type { ModuleLoaderConfig } from "./module-loader/index.ts";
 import {
@@ -121,6 +123,7 @@ interface MdxMetadataResult {
 
 interface PageCssResult {
   css: string | undefined;
+  cssAction: PageDataResponse["cssAction"] | undefined;
   cssError: string | undefined;
 }
 
@@ -681,7 +684,11 @@ export class RenderPipeline {
 
     const appPath = await this.resolveAppPath();
 
-    const { css, cssError } = await this.resolvePageDataCss(slug, options, projectUpdatedAt);
+    const { css, cssAction, cssError } = await this.resolvePageDataCss(
+      slug,
+      options,
+      projectUpdatedAt,
+    );
 
     resolvePageDataLog.debug("Resolved page data", {
       slug,
@@ -691,6 +698,7 @@ export class RenderPipeline {
       appPath,
       headingsCount: headings.length,
       hasCss: !!css,
+      cssAction,
       hasCssError: !!cssError,
     });
 
@@ -708,6 +716,7 @@ export class RenderPipeline {
       appPath,
       headings,
       css,
+      cssAction,
       cssError,
     };
   }
@@ -783,6 +792,10 @@ export class RenderPipeline {
     options: RenderOptions | undefined,
     projectUpdatedAt: string | undefined,
   ): Promise<PageCssResult> {
+    if (this.hasReadyReleaseCss(options)) {
+      return { css: undefined, cssAction: "clear", cssError: undefined };
+    }
+
     const cssCacheKey = getPageCssCacheKey(
       options?.projectId,
       options?.environment,
@@ -793,7 +806,7 @@ export class RenderPipeline {
     const cachedCss = getCachedPageCss(cssCacheKey);
     if (cachedCss) {
       resolvePageDataLog.debug("CSS cache hit", { slug, cssLength: cachedCss.length });
-      return { css: cachedCss, cssError: undefined };
+      return { css: cachedCss, cssAction: undefined, cssError: undefined };
     }
 
     try {
@@ -809,9 +822,10 @@ export class RenderPipeline {
       );
 
       if (!renderResult?.html) {
-        return { css: undefined, cssError: undefined };
+        return { css: undefined, cssAction: undefined, cssError: undefined };
       }
 
+      let cssAction: PageDataResponse["cssAction"] | undefined;
       let css = await this.resolveCssFromRenderedHtml(
         renderResult.html,
         options?.projectSlug ?? options?.projectId,
@@ -823,12 +837,17 @@ export class RenderPipeline {
           cssLength: css.length,
           source: "rendered-html-hash",
         });
+      } else if (hasRenderedReleaseAssetCss(renderResult.html)) {
+        cssAction = "clear";
+        resolvePageDataLog.debug("Skipped SPA CSS fallback; rendered HTML uses release CSS asset", {
+          slug,
+        });
       } else {
         css = await this.generatePageCssFromHtml(slug, renderResult.html, options);
       }
 
       if (css) cachePageCss(cssCacheKey, css);
-      return { css, cssError: undefined };
+      return { css, cssAction, cssError: undefined };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       // Surface CSS generation failures instead of silently swallowing them.
@@ -840,9 +859,16 @@ export class RenderPipeline {
       });
       return {
         css: undefined,
+        cssAction: undefined,
         cssError: `CSS generation failed: ${errorMessage}`,
       };
     }
+  }
+
+  private hasReadyReleaseCss(options: RenderOptions | undefined): boolean {
+    if (options?.environment !== "production") return false;
+    const releaseManifest = getReadyManifestForRender(options?.releaseId);
+    return (releaseManifest?.css?.length ?? 0) > 0;
   }
 
   private async generatePageCssFromHtml(

--- a/src/rendering/orchestrator/types.ts
+++ b/src/rendering/orchestrator/types.ts
@@ -84,6 +84,8 @@ export interface PageDataResponse {
   headings?: Array<{ id: string; text: string; level: number }>;
   /** JIT-compiled Tailwind CSS for this page (for SPA navigation in prod mode) */
   css?: string;
+  /** Client action for the SPA CSS tag when no route CSS payload is sent. */
+  cssAction?: "clear";
   /**
    * Error message if CSS generation failed.
    * When set, the css field will be undefined and clients should fall back

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.792";
+export const VERSION = "0.1.793";


### PR DESCRIPTION
## Summary

Fixes a production SPA navigation regression where release-backed pages could inject fallback route CSS compiled with the default Tailwind profile after client navigation.

When SSR HTML uses the immutable release CSS asset (`/_vf/assets/{hash}.css`), `resolvePageData` now treats CSS as already present and skips fallback route CSS generation. The existing JIT CSS reuse path for `/_vf/css/{hash}.css` remains unchanged.

## Root cause

`resolvePageData` only recognized SSR CSS links in the legacy JIT form (`/_vf/css/{hash}.css`). Release manifest CSS is emitted as `/_vf/assets/{contentHash}.css`, so route data fell through to candidate-based fallback CSS generation. That fallback uses the default Tailwind stylesheet profile, which can conflict with a project's custom `@variant dark` selector and override the loaded release stylesheet during SPA navigation.

## Changes

- Add `hasRenderedReleaseAssetCss()` to recognize immutable release CSS links.
- Skip SPA CSS fallback when rendered HTML already references release CSS.
- Add helper and behavior regression tests.
- Bump package version to `0.1.793`.

## Verification

- `deno test --no-check --allow-all src/rendering/orchestrator/pipeline.test.ts src/rendering/orchestrator/pipeline.behavior.test.ts`
- `deno fmt --check src/rendering/orchestrator/pipeline.ts src/rendering/orchestrator/pipeline-helpers.ts src/rendering/orchestrator/pipeline.test.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version-constant.ts deno.json`
- `deno check --allow-import src/rendering/orchestrator/pipeline.ts src/rendering/orchestrator/pipeline-helpers.ts`
- Pre-push hook: format, lint, typecheck, and unit tests: `2137 passed`, `0 failed`.

## Notes

This does not remove the longer-term need to put CSS fully under the release manifest contract and retire production JIT fallback after the manifest hit-rate gate. It prevents the current release CSS path from being undermined by route fallback CSS.
