### PR TITLE
Preserve creation tools after guided intake

### DIFF
--- a/src/agent/runtime/skill-policy-enforcement.ts
+++ b/src/agent/runtime/skill-policy-enforcement.ts
@@ -126,10 +126,13 @@ export function narrowPolicyAfterSubmittedForm(
   }
 
   if (
-    activeSkillId === "plan" ||
     activeSkillId === "create-agent" ||
     activeSkillId === "create-agentic-workflow"
   ) {
+    return activeSkillPolicy.filter((allowedToolName) => allowedToolName !== FORM_INPUT_TOOL_ID);
+  }
+
+  if (activeSkillId === "plan") {
     return activeSkillPolicy.filter((allowedToolName) =>
       [
         "studio_suggestions",

--- a/src/agent/runtime/skill-policy.test.ts
+++ b/src/agent/runtime/skill-policy.test.ts
@@ -218,6 +218,77 @@ describe("src/agent/runtime skill policy helpers", () => {
       );
     });
 
+    it("keeps agent design tools available after create-agent intake", () => {
+      assertEquals(
+        removeFormInputAfterSubmission("form_input", { submitted: true }, "create-agent", [
+          "form_input",
+          "studio_suggestions",
+          "create_agent",
+          "create_skill",
+          "create_tool",
+          "create_file",
+          "update_file",
+          "list_integrations",
+          "get_integration",
+          "get_user_oauth_status",
+          "list_user_oauth_integrations",
+          "web_fetch",
+        ]),
+        [
+          "studio_suggestions",
+          "create_agent",
+          "create_skill",
+          "create_tool",
+          "create_file",
+          "update_file",
+          "list_integrations",
+          "get_integration",
+          "get_user_oauth_status",
+          "list_user_oauth_integrations",
+          "web_fetch",
+        ],
+      );
+    });
+
+    it("keeps workflow primitive tools available after create-agentic-workflow intake", () => {
+      assertEquals(
+        removeFormInputAfterSubmission(
+          "form_input",
+          { submitted: true },
+          "create-agentic-workflow",
+          [
+            "form_input",
+            "studio_suggestions",
+            "create_workflow",
+            "create_agent",
+            "create_skill",
+            "create_tool",
+            "list_files",
+            "get_file",
+            "search_files",
+            "create_file",
+            "update_file",
+            "web_search",
+            "web_fetch",
+          ],
+        ),
+        [
+          "studio_suggestions",
+          "create_workflow",
+          "create_agent",
+          "create_skill",
+          "create_tool",
+          "list_files",
+          "get_file",
+          "search_files",
+          "create_file",
+          "update_file",
+          "web_search",
+          "web_fetch",
+        ],
+      );
+    });
+
     it("keeps source tools for research after submission but closes project inspection", () => {
       assertEquals(
         removeFormInputAfterSubmission("form_input", { submitted: true }, "research", [


### PR DESCRIPTION
## Summary
- Keep create-agent and create-agentic-workflow tool policies from dropping creation and integration tools after the first submitted form.
- Continue removing only form_input for those skills so intake cannot restart in the same turn.
- Add regression coverage for create-agent and create-agentic-workflow post-intake policies.

## Root cause
The first form submission was succeeding. After submission, the runtime narrowed create-agent/create-agentic-workflow to a file-only starter policy, which removed tools like create_agent, create_workflow, create_skill, create_tool, and list_integrations before the skill could use them.

## Evidence
- Red test reproduced current failure: create-agent lost create_agent/list_integrations; create-agentic-workflow lost create_workflow/create_agent/create_skill/create_tool.
- Green: deno test src/agent/runtime/skill-policy.test.ts
- Adjacent runtime checks: deno test src/agent/runtime/skill-policy.test.ts src/agent/runtime/load-skill-tool.test.ts src/agent/runtime/tool-result-continuation.test.ts
- Static/quick verification: deno task verify:quick

## Not tested
- Full deno task verify E2E binary suite.