### PR TITLE
docs: tighten README getting started flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ npx veryfront init my-app --template minimal
 npx veryfront init my-workflow --template agentic-workflow
 ```
 
-Install the binary for the CLI and TUI:
+Install the binary when you want to run `veryfront` directly for local
+development commands and the TUI:
 
 ```bash
 curl -fsSL https://veryfront.com/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -14,6 +14,49 @@ It gives you agents, tools, workflows, and a complete React rendering stack in a
   <img src="./assets/banner.svg" alt="Veryfront" width="100%">
 </p>
 
+## Get started
+
+Create a new Veryfront Code app with the interactive wizard:
+
+```bash
+npm create veryfront
+```
+
+Use a template flag when you already know which starting point you need:
+
+```bash
+# Agent app with a chat UI, tool, and AG-UI route
+npx veryfront init support-agent --template ai-agent
+
+# Blank full-stack app with pages and routing
+npx veryfront init my-app --template minimal
+
+# Durable multi-step AI pipeline
+npx veryfront init my-workflow --template agentic-workflow
+```
+
+<details>
+<summary>pnpm, yarn, bun, deno</summary>
+
+```bash
+pnpm create veryfront
+yarn create veryfront
+bun create veryfront
+deno init --npm veryfront
+```
+
+Install the binary for the CLI and TUI:
+
+```bash
+curl -fsSL https://veryfront.com/install.sh | sh
+# or
+brew install veryfront/tap/veryfront
+```
+
+</details>
+
+Follow the [Quickstart guide](https://veryfront.com/docs/code/getting-started/quickstart) to build the agent app end-to-end. Use [Create a project](https://veryfront.com/docs/code/getting-started/create-a-project) for project setup options and template details. For the full documentation, visit [veryfront.com/docs/code](https://veryfront.com/docs/code).
+
 ## Why Veryfront Code?
 
 Purpose-built for TypeScript and React, Veryfront Code gives you everything you need to build agentic full-stack applications out-of-the-box.
@@ -49,50 +92,6 @@ Purpose-built for TypeScript and React, Veryfront Code gives you everything you 
 - [**Data Fetching & API Routes**](https://veryfront.com/docs/code/guides/data-fetching) - Load server data, define API handlers, and add [middleware](https://veryfront.com/docs/code/guides/middleware) with built-in [OAuth](https://veryfront.com/docs/code/guides/oauth).
 
 - [**Extensions**](https://veryfront.com/docs/code/guides/extensions) - Extend Veryfront Code with contract-based packages for LLM providers, bundling, CSS, tracing, caching, and more.
-
-## Get Started
-
-Use the interactive project wizard when you want to compare templates:
-
-```bash
-npm create veryfront
-```
-
-Choose a starting point directly with `npx` when you already know what you want
-to build:
-
-```bash
-# Agent app with a chat UI, tool, and AG-UI route
-npx veryfront init support-agent --template ai-agent
-
-# Blank full-stack app with pages and routing
-npx veryfront init my-app --template minimal
-
-# Durable multi-step AI pipeline
-npx veryfront init my-workflow --template agentic-workflow
-```
-
-<details>
-<summary>pnpm, yarn, bun, deno</summary>
-
-```bash
-pnpm create veryfront
-yarn create veryfront
-bun create veryfront
-deno init --npm veryfront
-```
-
-Binary install (recommended for the CLI/TUI):
-
-```bash
-curl -fsSL https://veryfront.com/install.sh | sh
-# or
-brew install veryfront/tap/veryfront
-```
-
-</details>
-
-Follow the [Quickstart guide](https://veryfront.com/docs/code/getting-started/quickstart) to build the agent app end-to-end, or use [Create a project](https://veryfront.com/docs/code/getting-started/create-a-project) to compare templates before you scaffold. For the full documentation, visit [veryfront.com/docs/code](https://veryfront.com/docs/code).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ Create a new Veryfront Code app with the interactive wizard:
 npm create veryfront
 ```
 
+<details>
+<summary>pnpm, yarn, bun, deno</summary>
+
+```bash
+pnpm create veryfront
+yarn create veryfront
+bun create veryfront
+deno init --npm veryfront
+```
+
+</details>
+
 Use a template flag when you already know which starting point you need:
 
 ```bash
@@ -35,16 +47,6 @@ npx veryfront init my-app --template minimal
 npx veryfront init my-workflow --template agentic-workflow
 ```
 
-<details>
-<summary>pnpm, yarn, bun, deno</summary>
-
-```bash
-pnpm create veryfront
-yarn create veryfront
-bun create veryfront
-deno init --npm veryfront
-```
-
 Install the binary for the CLI and TUI:
 
 ```bash
@@ -52,8 +54,6 @@ curl -fsSL https://veryfront.com/install.sh | sh
 # or
 brew install veryfront/tap/veryfront
 ```
-
-</details>
 
 Follow the [Quickstart guide](https://veryfront.com/docs/code/getting-started/quickstart) to build the agent app end-to-end. Use [Create a project](https://veryfront.com/docs/code/getting-started/create-a-project) for project setup options and template details. For the full documentation, visit [veryfront.com/docs/code](https://veryfront.com/docs/code).
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ It gives you agents, tools, workflows, and a complete React rendering stack in a
 
 ## Get started
 
-Create a new Veryfront Code app with the interactive wizard:
+Create a new Veryfront Code app:
 
 ```bash
 npm create veryfront
 ```
 
 <details>
-<summary>pnpm, yarn, bun, deno</summary>
+<summary>Use another package manager</summary>
 
 ```bash
 pnpm create veryfront
@@ -40,10 +40,9 @@ Start from a template directly:
 npx veryfront init <PROJECT_NAME> --template <TEMPLATE>
 ```
 
-Available starters include `ai-agent`, `minimal`, and `agentic-workflow`.
+Available starters: `ai-agent`, `minimal`, `agentic-workflow`.
 
-Install the binary when you want to run `veryfront` directly for local
-development commands and the TUI:
+Install the `veryfront` binary for local development commands and the TUI:
 
 ```bash
 curl -fsSL https://veryfront.com/install.sh | sh
@@ -51,7 +50,7 @@ curl -fsSL https://veryfront.com/install.sh | sh
 brew install veryfront/tap/veryfront
 ```
 
-Follow the [Quickstart guide](https://veryfront.com/docs/code/getting-started/quickstart) to build the agent app end-to-end. Use [Create a project](https://veryfront.com/docs/code/getting-started/create-a-project) for project setup options and template details. For the full documentation, visit [veryfront.com/docs/code](https://veryfront.com/docs/code).
+Follow the [Quickstart guide](https://veryfront.com/docs/code/getting-started/quickstart) to build your first app. For project setup options and template details, see [Create a project](https://veryfront.com/docs/code/getting-started/create-a-project). For the full documentation, visit [veryfront.com/docs/code](https://veryfront.com/docs/code).
 
 ## Why Veryfront Code?
 

--- a/README.md
+++ b/README.md
@@ -34,18 +34,13 @@ deno init --npm veryfront
 
 </details>
 
-Use a template flag when you already know which starting point you need:
+Start from a template directly:
 
 ```bash
-# Agent app with a chat UI, tool, and AG-UI route
-npx veryfront init support-agent --template ai-agent
-
-# Blank full-stack app with pages and routing
-npx veryfront init my-app --template minimal
-
-# Durable multi-step AI pipeline
-npx veryfront init my-workflow --template agentic-workflow
+npx veryfront init <PROJECT_NAME> --template <TEMPLATE>
 ```
+
+Available starters include `ai-agent`, `minimal`, and `agentic-workflow`.
 
 Install the binary when you want to run `veryfront` directly for local
 development commands and the TUI:

--- a/README.md
+++ b/README.md
@@ -94,54 +94,11 @@ brew install veryfront/tap/veryfront
 
 Follow the [Quickstart guide](https://veryfront.com/docs/code/getting-started/quickstart) to build the agent app end-to-end, or use [Create a project](https://veryfront.com/docs/code/getting-started/create-a-project) to compare templates before you scaffold. For the full documentation, visit [veryfront.com/docs/code](https://veryfront.com/docs/code).
 
-## Project Structure
-
-```
-veryfront/
-├── src/                  # Framework core modules
-│   ├── agent/           # Agent runtime, AG-UI, hosted execution
-│   ├── tool/            # Tool definitions and registry
-│   ├── workflow/        # Durable DAG workflows with crash recovery
-│   ├── mcp/             # Model Context Protocol server
-│   ├── skill/           # Agent skills system (SKILL.md)
-│   ├── chat/            # Chat UI components and streaming
-│   ├── discovery/       # Auto-discovery of tools, agents, workflows
-│   ├── sandbox/         # Ephemeral compute environments
-│   ├── runs/            # Durable runs client
-│   ├── task/            # Task definitions and runner
-│   ├── channels/        # Control-plane agent routing
-│   ├── integrations/    # Third-party connector metadata
-│   ├── provider/        # AI model provider adapters
-│   ├── rendering/       # SSR/RSC engine
-│   ├── server/          # HTTP servers (dev + production)
-│   ├── routing/         # File-based routing
-│   ├── security/        # Rate limiting, CORS, CSP, validation
-│   └── ...              # See src/README.md for full list
-├── cli/                  # CLI and TUI dashboard
-├── extensions/           # First-party extension packages
-├── docs/                 # Architecture diagrams and guides
-├── tests/                # Integration and E2E tests
-└── scripts/              # Development and build scripts
-```
-
-## Examples
-
-You can find standalone, runnable examples in the [veryfront-examples](https://github.com/veryfront/veryfront-examples) repo.
-
 ## Contributing
 
 Looking to contribute? All types of help are appreciated, from coding to testing and feature specification. Read [CONTRIBUTING.md](./CONTRIBUTING.md) for more details on how to get involved.
 
 If you are a developer and would like to contribute with code, please open an issue to discuss before opening a Pull Request.
-
-## Supply-Chain Hardening
-
-Veryfront Code treats dependency changes as reviewed code changes.
-
-- Workspace Deno dependencies use exact versions and are resolved through the checked-in `deno.lock`.
-- `deno.json` sets `minimumDependencyAge` to delay freshly published dependency versions during Deno resolution.
-- `.npmrc` sets `save-exact=true` so npm-compatible tooling records exact versions.
-- The npm package generator pins automatic `dependencies`, `optionalDependencies`, and `devDependencies`; peer ranges remain available only for opt-in compatibility constraints.
 
 ## Support
 


### PR DESCRIPTION
## Summary
- Move Get started above the feature overview so setup is the first action path.
- Tighten the Get started copy and remove the out-of-context template comparison phrasing.
- Remove internal project structure details, the examples section, and the supply-chain hardening section from README.md.

## Verification
- git diff --check
- rg -n "^## |Project Structure|## Examples|Supply-Chain Hardening|compare templates|Get Started|Get started" README.md
- Pre-push checks: formatting, lint, type check, generation, and unit tests passed