### PR TITLE
Vendor release asset HTTP dependencies

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.793",
+  "version": "0.1.794",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { RELEASE_ASSET_MAX_SIZE_BYTES } from "./constants.ts";
 import {
   type ReleaseAssetBuildClient,
   type ReleaseAssetBuildInput,
@@ -166,6 +167,306 @@ describe("release asset build executor", () => {
     assertExists(pageUpload);
     assert(pageUpload.text.includes(`"/_vf/assets/${headerHash}.js"`));
     assert(!pageUpload.text.includes("/_vf_modules/components/Header.js"));
+  });
+
+  it("vendors transformed HTTP imports into immutable dependency assets", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "pages/index.tsx",
+        content: 'import motion from "framer-motion"; export default motion;',
+      },
+    ];
+    const client = makeClient(files, rec);
+    const transform = () =>
+      Promise.resolve(
+        'import motion from "https://esm.sh/framer-motion@11"; export default motion;',
+      );
+    const input = {
+      ...baseInput(client, transform),
+      vendorHttpImports: (code: string) =>
+        Promise.resolve({
+          code: code.replace(
+            "https://esm.sh/framer-motion@11",
+            "file:///tmp/veryfront-http-bundle/http-123.mjs",
+          ),
+          dependencies: [{
+            specifier: "file:///tmp/veryfront-http-bundle/http-123.mjs",
+            manifestKey: "https://esm.sh/framer-motion@11",
+            code: "export default function motion() {}",
+          }],
+        }),
+    };
+
+    await runReleaseAssetBuild(input, await tmp());
+
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    const dependencyHash = manifest.dependencies["https://esm.sh/framer-motion@11"]?.contentHash;
+    assertExists(dependencyHash);
+    const pageHash = manifest.modules["pages/index.tsx"]?.contentHash;
+    assertExists(pageHash);
+
+    const dependencyUpload = rec.uploads.find((u) => u.hash === dependencyHash);
+    assertExists(dependencyUpload);
+    assertEquals(dependencyUpload.text, "export default function motion() {}");
+
+    const pageUpload = rec.uploads.find((u) => u.hash === pageHash);
+    assertExists(pageUpload);
+    assert(pageUpload.text.includes(`"/_vf/assets/${dependencyHash}.js"`));
+    assert(!pageUpload.text.includes("https://esm.sh/framer-motion"));
+    assert(!pageUpload.text.includes("file:///tmp/veryfront-http-bundle"));
+  });
+
+  it("rewrites nested vendored HTTP dependency imports to immutable assets", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "pages/index.tsx",
+        content: 'import parent from "remote-parent"; export default parent;',
+      },
+    ];
+    const client = makeClient(files, rec);
+    const transform = () =>
+      Promise.resolve(
+        'import parent from "https://esm.sh/parent@1"; export default parent;',
+      );
+    const input = {
+      ...baseInput(client, transform),
+      vendorHttpImports: (code: string) =>
+        Promise.resolve({
+          code: code.replace(
+            "https://esm.sh/parent@1",
+            "file:///tmp/veryfront-http-bundle/http-aaa.mjs",
+          ),
+          dependencies: [
+            {
+              specifier: "file:///tmp/veryfront-http-bundle/http-aaa.mjs",
+              manifestKey: "https://esm.sh/parent@1",
+              sourcePath: "/tmp/veryfront-http-bundle/http-aaa.mjs",
+              code: 'import child from "./http-bbb.mjs"; export default child;',
+            },
+            {
+              specifier: "file:///tmp/veryfront-http-bundle/http-bbb.mjs",
+              manifestKey: "https://esm.sh/child@1",
+              sourcePath: "/tmp/veryfront-http-bundle/http-bbb.mjs",
+              code: "export default function child() {}",
+            },
+          ],
+        }),
+    };
+
+    await runReleaseAssetBuild(input, await tmp());
+
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    const parentHash = manifest.dependencies["https://esm.sh/parent@1"]?.contentHash;
+    const childHash = manifest.dependencies["https://esm.sh/child@1"]?.contentHash;
+    assertExists(parentHash);
+    assertExists(childHash);
+
+    const parentUpload = rec.uploads.find((u) => u.hash === parentHash);
+    assertExists(parentUpload);
+    assert(parentUpload.text.includes(`"/_vf/assets/${childHash}.js"`));
+    assert(!parentUpload.text.includes("./http-bbb.mjs"));
+  });
+
+  it("resolves vendored dependency relatives from their source file path", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "pages/index.tsx",
+        content: 'import a from "remote-a"; import b from "remote-b"; export default [a, b];',
+      },
+    ];
+    const client = makeClient(files, rec);
+    const transform = () =>
+      Promise.resolve(
+        'import a from "https://esm.sh/a@1"; import b from "https://esm.sh/b@1"; export default [a, b];',
+      );
+    const input = {
+      ...baseInput(client, transform),
+      vendorHttpImports: (code: string) =>
+        Promise.resolve({
+          code: code
+            .replace("https://esm.sh/a@1", "file:///tmp/vf-http/a/parent.mjs")
+            .replace("https://esm.sh/b@1", "file:///tmp/vf-http/b/parent.mjs"),
+          dependencies: [
+            {
+              specifier: "file:///tmp/vf-http/a/parent.mjs",
+              manifestKey: "https://esm.sh/a@1",
+              sourcePath: "/tmp/vf-http/a/parent.mjs",
+              code: 'import shared from "./shared.mjs"; export default shared;',
+            },
+            {
+              specifier: "file:///tmp/vf-http/a/shared.mjs",
+              manifestKey: "https://esm.sh/a-shared@1",
+              sourcePath: "/tmp/vf-http/a/shared.mjs",
+              code: 'export default "a";',
+            },
+            {
+              specifier: "file:///tmp/vf-http/b/parent.mjs",
+              manifestKey: "https://esm.sh/b@1",
+              sourcePath: "/tmp/vf-http/b/parent.mjs",
+              code: 'import shared from "./shared.mjs"; export default shared;',
+            },
+            {
+              specifier: "file:///tmp/vf-http/b/shared.mjs",
+              manifestKey: "https://esm.sh/b-shared@1",
+              sourcePath: "/tmp/vf-http/b/shared.mjs",
+              code: 'export default "b";',
+            },
+          ],
+        }),
+    };
+
+    await runReleaseAssetBuild(input, await tmp());
+
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    const aParentHash = manifest.dependencies["https://esm.sh/a@1"]?.contentHash;
+    const aSharedHash = manifest.dependencies["https://esm.sh/a-shared@1"]?.contentHash;
+    const bParentHash = manifest.dependencies["https://esm.sh/b@1"]?.contentHash;
+    const bSharedHash = manifest.dependencies["https://esm.sh/b-shared@1"]?.contentHash;
+    assertExists(aParentHash);
+    assertExists(aSharedHash);
+    assertExists(bParentHash);
+    assertExists(bSharedHash);
+
+    const aParentUpload = rec.uploads.find((u) => u.hash === aParentHash);
+    const bParentUpload = rec.uploads.find((u) => u.hash === bParentHash);
+    assertExists(aParentUpload);
+    assertExists(bParentUpload);
+    assert(aParentUpload.text.includes(`"/_vf/assets/${aSharedHash}.js"`));
+    assert(!aParentUpload.text.includes(`"/_vf/assets/${bSharedHash}.js"`));
+    assert(bParentUpload.text.includes(`"/_vf/assets/${bSharedHash}.js"`));
+    assert(!bParentUpload.text.includes(`"/_vf/assets/${aSharedHash}.js"`));
+  });
+
+  it("fails the manifest when vendored dependency assets contain a cycle", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "pages/index.tsx",
+        content: 'import parent from "remote-parent"; export default parent;',
+      },
+    ];
+    const client = makeClient(files, rec);
+    const transform = () =>
+      Promise.resolve(
+        'import parent from "https://esm.sh/parent@1"; export default parent;',
+      );
+    const input = {
+      ...baseInput(client, transform),
+      vendorHttpImports: (code: string) =>
+        Promise.resolve({
+          code: code.replace(
+            "https://esm.sh/parent@1",
+            "file:///tmp/veryfront-http-bundle/http-aaa.mjs",
+          ),
+          dependencies: [
+            {
+              specifier: "file:///tmp/veryfront-http-bundle/http-aaa.mjs",
+              manifestKey: "https://esm.sh/parent@1",
+              sourcePath: "/tmp/veryfront-http-bundle/http-aaa.mjs",
+              code: 'import child from "./http-bbb.mjs"; export default child;',
+            },
+            {
+              specifier: "file:///tmp/veryfront-http-bundle/http-bbb.mjs",
+              manifestKey: "https://esm.sh/child@1",
+              sourcePath: "/tmp/veryfront-http-bundle/http-bbb.mjs",
+              code: 'import parent from "./http-aaa.mjs"; export default parent;',
+            },
+          ],
+        }),
+    };
+
+    const result = await runReleaseAssetBuild(input, await tmp());
+
+    assertEquals(result.success, false);
+    assertEquals(result.state, "failed");
+    assert(result.error?.includes("Circular release asset dependency graph"));
+    assertEquals(rec.states.at(-1)?.state, "failed");
+    assertEquals(rec.manifest, null);
+  });
+
+  it("fails the manifest when a vendored dependency keeps an unresolved file import", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "pages/index.tsx",
+        content: 'import parent from "remote-parent"; export default parent;',
+      },
+    ];
+    const client = makeClient(files, rec);
+    const transform = () =>
+      Promise.resolve(
+        'import parent from "https://esm.sh/parent@1"; export default parent;',
+      );
+    const input = {
+      ...baseInput(client, transform),
+      vendorHttpImports: (code: string) =>
+        Promise.resolve({
+          code: code.replace(
+            "https://esm.sh/parent@1",
+            "file:///tmp/veryfront-http-bundle/http-aaa.mjs",
+          ),
+          dependencies: [{
+            specifier: "file:///tmp/veryfront-http-bundle/http-aaa.mjs",
+            manifestKey: "https://esm.sh/parent@1",
+            sourcePath: "/tmp/veryfront-http-bundle/http-aaa.mjs",
+            code: 'import secret from "file:///tmp/outside-secret.mjs"; export default secret;',
+          }],
+        }),
+    };
+
+    const result = await runReleaseAssetBuild(input, await tmp());
+
+    assertEquals(result.success, false);
+    assertEquals(result.state, "failed");
+    assert(result.error?.includes("Unresolved vendored file dependency"));
+    assertEquals(rec.states.at(-1)?.state, "failed");
+    assertEquals(rec.manifest, null);
+  });
+
+  it("fails the manifest when a vendored dependency asset exceeds the size limit", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "pages/index.tsx",
+        content: 'import parent from "remote-parent"; export default parent;',
+      },
+    ];
+    const client = makeClient(files, rec);
+    const transform = () =>
+      Promise.resolve(
+        'import parent from "https://esm.sh/parent@1"; export default parent;',
+      );
+    const input = {
+      ...baseInput(client, transform),
+      vendorHttpImports: (code: string) =>
+        Promise.resolve({
+          code: code.replace(
+            "https://esm.sh/parent@1",
+            "file:///tmp/veryfront-http-bundle/http-aaa.mjs",
+          ),
+          dependencies: [{
+            specifier: "file:///tmp/veryfront-http-bundle/http-aaa.mjs",
+            manifestKey: "https://esm.sh/parent@1",
+            sourcePath: "/tmp/veryfront-http-bundle/http-aaa.mjs",
+            code: "x".repeat(RELEASE_ASSET_MAX_SIZE_BYTES + 1),
+          }],
+        }),
+    };
+
+    const result = await runReleaseAssetBuild(input, await tmp());
+
+    assertEquals(result.success, false);
+    assertEquals(result.state, "failed");
+    assert(result.error?.includes("exceeds release asset size limit"));
+    assertEquals(rec.states.at(-1)?.state, "failed");
+    assertEquals(rec.manifest, null);
+    assertEquals(rec.uploads.length, 0);
   });
 
   it("rewrites transformed relative project imports to immutable asset URLs", async () => {

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -18,9 +18,11 @@
 import { serverLogger } from "#veryfront/utils";
 import { VERSION } from "#veryfront/utils/version.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
-import { dirname, join } from "#veryfront/compat/path/index.ts";
+import { dirname, join, normalize } from "#veryfront/compat/path/index.ts";
 import { resolveFrameworkSourcePath } from "#veryfront/platform/compat/framework-source-resolver.ts";
 import { transformToESM } from "#veryfront/transforms/esm-transform.ts";
+import { cacheHttpImportsToLocal } from "#veryfront/transforms/esm/http-cache.ts";
+import { extractSourceUrl } from "#veryfront/transforms/esm/source-url-embed.ts";
 import { parseImports, replaceSpecifiers } from "#veryfront/transforms/esm/lexer.ts";
 import { PLATFORM_UTILITIES } from "#veryfront/html/utils.ts";
 import { extractCandidatesFromFiles } from "#veryfront/html/styles-builder/candidate-extractor.ts";
@@ -79,6 +81,11 @@ export interface ReleaseAssetBuildInput {
    * Injectable for tests.
    */
   transform?: ReleaseAssetTransform;
+  /**
+   * Optional HTTP dependency vendor. Defaults to the existing HTTP module cache
+   * and is injectable so tests do not depend on live package CDN behavior.
+   */
+  vendorHttpImports?: ReleaseAssetHttpDependencyVendor;
 }
 
 export type ReleaseAssetTransform = (
@@ -89,6 +96,30 @@ export type ReleaseAssetTransform = (
   adapter: any,
   options: { projectId: string; dev: boolean; ssr: boolean; reactVersion?: string },
 ) => Promise<string>;
+
+export interface ReleaseAssetVendorDependency {
+  /** Specifier currently used by transformed code after vendoring. */
+  specifier: string;
+  /** Stable manifest key, normally the original HTTP source URL. */
+  manifestKey: string;
+  /** Absolute local cache path when the dependency came from disk. */
+  sourcePath?: string;
+  /** Browser ESM source for this dependency. */
+  code: string;
+}
+
+export interface ReleaseAssetVendorResult {
+  code: string;
+  dependencies: ReleaseAssetVendorDependency[];
+}
+
+export type ReleaseAssetHttpDependencyVendor = (
+  code: string,
+  options: {
+    tempDir: string;
+    reactVersion?: string;
+  },
+) => Promise<ReleaseAssetVendorResult>;
 
 /** Subset of the API client used by the builder (eases testing). */
 export interface ReleaseAssetBuildClient {
@@ -146,6 +177,13 @@ interface PreparedAsset {
 
 interface TransformedProjectModule {
   logicalPath: string;
+  code: string;
+}
+
+interface DependencyModule {
+  manifestKey: string;
+  specifiers: Set<string>;
+  sourcePath?: string;
   code: string;
 }
 
@@ -339,6 +377,9 @@ async function rewriteProjectModuleImports(
   dependencyUrls: Map<string, string>,
 ): Promise<string> {
   function rewriteSpecifier(specifier: string): string | null {
+    const dependencyUrl = dependencyUrls.get(specifier.replace(/[?#].*$/, ""));
+    if (dependencyUrl) return dependencyUrl;
+
     if (specifier.startsWith("/_vf_modules/")) {
       const dependencyUrl = dependencyUrls.get(specifier.replace(/[?#].*$/, ""));
       if (dependencyUrl) return dependencyUrl;
@@ -352,11 +393,254 @@ async function rewriteProjectModuleImports(
   return await replaceSpecifiers(code, (specifier) => rewriteSpecifier(specifier));
 }
 
-function buildDependencyUrlMap(_dependencies: Record<string, PreparedAsset>): Map<string, string> {
-  // Framework barrels can contain their own relative import closure. Keep those
-  // URLs on the module server until the builder rewrites and uploads the full
-  // framework closure, otherwise the browser resolves relatives under /_vf/assets.
-  return new Map<string, string>();
+function buildDependencyUrlMap(
+  dependencies: Record<string, PreparedAsset>,
+  dependencyModules?: Map<string, DependencyModule>,
+): Map<string, string> {
+  const urls = new Map<string, string>();
+  for (const [manifestKey, entry] of Object.entries(dependencies)) {
+    const dependency = dependencyModules?.get(manifestKey);
+    if (!dependency) continue;
+
+    const url = releaseAssetUrl(entry.contentHash, "js");
+    urls.set(manifestKey, url);
+    urls.set(entry.logicalPath, url);
+    for (const specifier of dependency.specifiers) {
+      urls.set(normalizeDependencySpecifier(specifier), url);
+    }
+  }
+  return urls;
+}
+
+function addDependencyModule(
+  dependencies: Map<string, DependencyModule>,
+  dependency: ReleaseAssetVendorDependency,
+): void {
+  const sourcePath = dependency.sourcePath ?? resolveLocalDependencyPath(dependency.specifier) ??
+    undefined;
+  const existing = dependencies.get(dependency.manifestKey);
+  if (existing) {
+    existing.specifiers.add(dependency.specifier);
+    existing.sourcePath ??= sourcePath;
+    return;
+  }
+
+  dependencies.set(dependency.manifestKey, {
+    manifestKey: dependency.manifestKey,
+    specifiers: new Set([dependency.specifier]),
+    sourcePath,
+    code: dependency.code,
+  });
+}
+
+function normalizeDependencySpecifier(specifier: string): string {
+  return specifier.replace(/[?#].*$/, "");
+}
+
+function resolveLocalDependencyPath(specifier: string, parentFilePath?: string): string | null {
+  const normalized = normalizeDependencySpecifier(specifier);
+
+  if (normalized.startsWith("file://")) {
+    try {
+      return normalize(decodeURIComponent(new URL(normalized).pathname));
+    } catch (_) {
+      return null;
+    }
+  }
+
+  if (!parentFilePath || (!normalized.startsWith("./") && !normalized.startsWith("../"))) {
+    return null;
+  }
+
+  return normalize(join(dirname(parentFilePath), normalized));
+}
+
+function isPathInsideRoot(filePath: string, rootPath: string): boolean {
+  const file = normalize(filePath);
+  const root = normalize(rootPath);
+  return file === root || file.startsWith(`${root}/`) || file.startsWith(`${root}\\`);
+}
+
+async function collectLocalHttpDependencyModules(
+  code: string,
+  dependencies: Map<string, DependencyModule>,
+  cacheDir: string,
+): Promise<void> {
+  const fs = createFileSystem();
+  const cacheRoot = normalize(cacheDir);
+  const seen = new Set<string>();
+  const queue: Array<{ specifier: string; parentFilePath?: string }> = [];
+
+  for (const imp of await parseImports(code)) {
+    if (imp.n) queue.push({ specifier: imp.n });
+  }
+
+  while (queue.length > 0) {
+    const { specifier, parentFilePath } = queue.shift()!;
+    const filePath = resolveLocalDependencyPath(specifier, parentFilePath);
+    if (!filePath || seen.has(filePath)) continue;
+    if (!isPathInsideRoot(filePath, cacheRoot)) {
+      throw new Error(`Vendored HTTP dependency resolved outside cache root: ${specifier}`);
+    }
+    seen.add(filePath);
+
+    const depCode = await fs.readTextFile(filePath);
+    const manifestKey = extractSourceUrl(depCode) ?? `file://${filePath}`;
+    const depSpecifiers = new Set<string>([
+      normalizeDependencySpecifier(specifier),
+      `file://${filePath}`,
+    ]);
+
+    const existing = dependencies.get(manifestKey);
+    if (existing) {
+      for (const depSpecifier of depSpecifiers) existing.specifiers.add(depSpecifier);
+      existing.sourcePath ??= filePath;
+    } else {
+      dependencies.set(manifestKey, {
+        manifestKey,
+        specifiers: depSpecifiers,
+        sourcePath: filePath,
+        code: depCode,
+      });
+    }
+
+    for (const imp of await parseImports(depCode)) {
+      if (imp.n) queue.push({ specifier: imp.n, parentFilePath: filePath });
+    }
+  }
+}
+
+async function vendorHttpImportsWithCache(
+  code: string,
+  options: { tempDir: string; reactVersion?: string },
+): Promise<ReleaseAssetVendorResult> {
+  const imports = await parseImports(code);
+  if (
+    !imports.some((imp) =>
+      imp.n &&
+      (imp.n.startsWith("http://") || imp.n.startsWith("https://") || imp.n.startsWith("npm:"))
+    )
+  ) {
+    return { code, dependencies: [] };
+  }
+
+  const cacheDir = join(options.tempDir, ".veryfront-http-bundle");
+  const result = await cacheHttpImportsToLocal(code, {
+    cacheDir,
+    importMap: { imports: {}, scopes: {} },
+    reactVersion: options.reactVersion,
+  });
+
+  const dependencies = new Map<string, DependencyModule>();
+  await collectLocalHttpDependencyModules(result.code, dependencies, cacheDir);
+
+  return {
+    code: result.code,
+    dependencies: [...dependencies.values()].flatMap((dependency) =>
+      [...dependency.specifiers].map((specifier) => ({
+        specifier,
+        manifestKey: dependency.manifestKey,
+        sourcePath: dependency.sourcePath,
+        code: dependency.code,
+      }))
+    ),
+  };
+}
+
+async function finalizeDependencyModules(
+  dependencyModules: Map<string, DependencyModule>,
+  uploadQueue: PreparedAsset[],
+  pendingBytes: Map<string, { bytes: Uint8Array<ArrayBuffer>; contentType: string }>,
+): Promise<Record<string, PreparedAsset>> {
+  const bySpecifier = new Map<string, DependencyModule>();
+  const byFilePath = new Map<string, DependencyModule>();
+  for (const dependency of dependencyModules.values()) {
+    for (const specifier of dependency.specifiers) {
+      bySpecifier.set(normalizeDependencySpecifier(specifier), dependency);
+      const filePath = resolveLocalDependencyPath(specifier);
+      if (filePath) byFilePath.set(filePath, dependency);
+    }
+    if (dependency.sourcePath) byFilePath.set(dependency.sourcePath, dependency);
+  }
+
+  const finalized = new Map<string, PreparedAsset>();
+  const visiting: string[] = [];
+
+  function resolveDependencyImport(
+    specifier: string,
+    parent: DependencyModule,
+  ): DependencyModule | null {
+    const filePath = resolveLocalDependencyPath(specifier, parent.sourcePath);
+    if (filePath) {
+      const localDependency = byFilePath.get(filePath);
+      if (localDependency) return localDependency;
+    }
+
+    return bySpecifier.get(normalizeDependencySpecifier(specifier)) ?? null;
+  }
+
+  async function finalize(manifestKey: string): Promise<PreparedAsset | null> {
+    const existing = finalized.get(manifestKey);
+    if (existing) return existing;
+    if (visiting.includes(manifestKey)) {
+      const cycle = [...visiting.slice(visiting.indexOf(manifestKey)), manifestKey].join(" -> ");
+      throw new Error(`Circular release asset dependency graph: ${cycle}`);
+    }
+
+    const dependency = dependencyModules.get(manifestKey);
+    if (!dependency) return null;
+
+    visiting.push(manifestKey);
+    try {
+      const imports = await parseImports(dependency.code);
+      for (const imp of imports) {
+        if (!imp.n) continue;
+        const filePath = resolveLocalDependencyPath(imp.n, dependency.sourcePath);
+        if (filePath && !byFilePath.has(filePath)) {
+          throw new Error(`Unresolved vendored file dependency: ${imp.n}`);
+        }
+        const child = resolveDependencyImport(imp.n, dependency);
+        if (!child) continue;
+        if (child.manifestKey === manifestKey) {
+          throw new Error(
+            `Circular release asset dependency graph: ${manifestKey} -> ${manifestKey}`,
+          );
+        }
+        await finalize(child.manifestKey);
+      }
+
+      const rewritten = await replaceSpecifiers(dependency.code, (specifier) => {
+        const child = resolveDependencyImport(specifier, dependency);
+        if (!child) return null;
+        const asset = finalized.get(child.manifestKey);
+        return asset ? releaseAssetUrl(asset.contentHash, "js") : null;
+      });
+
+      const entry = await addPreparedJavaScriptAsset(
+        `__dependencies__/${manifestKey}`,
+        rewritten,
+        uploadQueue,
+        pendingBytes,
+      );
+      if (!entry) {
+        throw new Error(`Vendored dependency exceeds release asset size limit: ${manifestKey}`);
+      }
+      for (const specifier of dependency.specifiers) {
+        bySpecifier.set(normalizeDependencySpecifier(specifier), dependency);
+      }
+      finalized.set(manifestKey, entry);
+      return entry;
+    } finally {
+      visiting.pop();
+    }
+  }
+
+  try {
+    for (const manifestKey of dependencyModules.keys()) await finalize(manifestKey);
+  } finally {
+    visiting.length = 0;
+  }
+  return Object.fromEntries(finalized);
 }
 
 async function finalizeProjectModules(
@@ -672,11 +956,13 @@ async function runBuildInner(
   // 3 + 4. Collect the browser module closure and transform each module
   // through the SAME pipeline serveModule uses (browser, non-SSR).
   const transformedModules = new Map<string, TransformedProjectModule>();
+  const dependencyModules = new Map<string, DependencyModule>();
   const gaps: string[] = [];
   const uploadQueue: PreparedAsset[] = [];
   // Bytes are held per-hash only until uploaded, then dropped (M3).
   const pendingBytes = new Map<string, { bytes: Uint8Array<ArrayBuffer>; contentType: string }>();
   const knownPaths = new Set(sourceByPath.keys());
+  const vendorHttpImports = input.vendorHttpImports ?? vendorHttpImportsWithCache;
 
   for (const [logicalPath, source] of sourceByPath) {
     if (!isBrowserModule(logicalPath)) continue;
@@ -715,10 +1001,41 @@ async function runBuildInner(
       };
     }
 
+    try {
+      const vendored = await vendorHttpImports(code, {
+        tempDir,
+        reactVersion: input.reactVersion,
+      });
+      code = vendored.code;
+      for (const dependency of vendored.dependencies) {
+        addDependencyModule(dependencyModules, dependency);
+      }
+    } catch (error) {
+      const sanitized = sanitizeError(error);
+      logger.warn("HTTP dependency vendoring failed during release asset build", {
+        path: logicalPath,
+        error: sanitized,
+      });
+      await client.reportReleaseAssetManifestState(
+        input.releaseVersionRef,
+        "failed",
+        sanitized,
+      );
+      return {
+        success: false,
+        state: "failed",
+        moduleCount: 0,
+        cssCount: 0,
+        routeCount: 0,
+        gaps,
+        error: sanitized,
+      };
+    }
+
     transformedModules.set(logicalPath, { logicalPath, code });
   }
 
-  const dependencies = await buildFrameworkDependencies(
+  const frameworkDependencies = await buildFrameworkDependencies(
     input,
     tempDir,
     transform,
@@ -726,7 +1043,35 @@ async function runBuildInner(
     pendingBytes,
     gaps,
   );
-  const dependencyUrls = buildDependencyUrlMap(dependencies);
+  let httpDependencies: Record<string, PreparedAsset>;
+  try {
+    httpDependencies = await finalizeDependencyModules(
+      dependencyModules,
+      uploadQueue,
+      pendingBytes,
+    );
+  } catch (error) {
+    const sanitized = sanitizeError(error);
+    logger.warn("HTTP dependency finalization failed during release asset build", {
+      error: sanitized,
+    });
+    await client.reportReleaseAssetManifestState(
+      input.releaseVersionRef,
+      "failed",
+      sanitized,
+    );
+    return {
+      success: false,
+      state: "failed",
+      moduleCount: 0,
+      cssCount: 0,
+      routeCount: 0,
+      gaps,
+      error: sanitized,
+    };
+  }
+  const dependencies = { ...frameworkDependencies, ...httpDependencies };
+  const dependencyUrls = buildDependencyUrlMap(dependencies, dependencyModules);
 
   const { modules, skippedModules } = await finalizeProjectModules(
     transformedModules,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.793";
+export const VERSION = "0.1.794";


### PR DESCRIPTION
## Summary
- vendor transformed HTTP/npm browser imports during release asset builds using the existing HTTP module cache
- upload the dependency closure as immutable release assets and rewrite project/nested dependency imports to `/_vf/assets/{hash}.js`
- keep framework dependency fallback behavior unchanged and fail the manifest cleanly for unsupported dependency cycles
- bump `veryfront` to `0.1.794`

## Why
Coder Society production release assets are served from `/_vf/assets`, but transformed project modules can still import `esm.sh` at runtime. This keeps third-party module fetches on the critical navigation path. This PR moves that dependency work into the release asset build so production runtime fetches local immutable assets instead.

## Verification
- `deno fmt --check deno.json src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts src/utils/version-constant.ts`
- `deno check --allow-import src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts`
- `git diff --check`
- `deno test --no-check --allow-all src/release-assets`
- pre-push hook: format, lint, typecheck, unit tests (`2137 passed (18508 steps), 0 failed`)

## Rollout note
After merge and package release, Coder Society needs a new release asset manifest rebuild/republish on the deployed server version before runtime `esm.sh` requests disappear from production navigation.