### PR TITLE
Pass runtime auth context to API MCP tools

### DIFF
--- a/src/agent/hosted/chat-runtime-agent-adapter.test.ts
+++ b/src/agent/hosted/chat-runtime-agent-adapter.test.ts
@@ -72,6 +72,7 @@ describe("createHostedChatRuntimeAgentAdapter", () => {
       runtimeAgent,
       agentId: "agent-1",
       runId: "run-1",
+      authToken: "run-token-1",
       runStream: async (operation) => {
         runnerCalled = true;
         return await operation();
@@ -98,7 +99,8 @@ describe("createHostedChatRuntimeAgentAdapter", () => {
     assertEquals(capturedInput?.context?.abortSignal, abortController.signal);
     assertEquals(capturedInput?.context?.agentId, "agent-1");
     assertEquals(capturedInput?.context?.runId, "run-1");
-    assertEquals(chunks, [
+    assertEquals(capturedInput?.context?.authToken, "run-token-1");
+    const expectedChunks = [
       { type: "start", messageId: "assistant-message" },
       { type: "start-step" },
       { type: "text-start", id: "assistant-message", contentId: "text-1" },
@@ -111,7 +113,8 @@ describe("createHostedChatRuntimeAgentAdapter", () => {
       { type: "finish-step" },
       { type: "text-end", id: "assistant-message", contentId: "text-1" },
       { type: "finish", finishReason: "stop" },
-    ]);
+    ] as unknown as ChatUiMessageChunk[];
+    assertEquals(chunks, expectedChunks);
   });
 
   it("bridges host-published tool data events into the UI message stream", async () => {

--- a/src/agent/hosted/chat-runtime-agent-adapter.ts
+++ b/src/agent/hosted/chat-runtime-agent-adapter.ts
@@ -23,6 +23,7 @@ export type HostedChatRuntimeAgentAdapterInput = {
   runtimeAgent: Pick<Agent, "stream">;
   runId?: string;
   agentId?: string;
+  authToken?: string;
   runStream?: HostedChatRuntimeAgentAdapterRunner;
   warnOrphanedToolInput?: (
     message: string,
@@ -49,6 +50,7 @@ export function createHostedChatRuntimeAgentAdapter(
           context: {
             ...(input.runId ? { runId: input.runId } : {}),
             ...(input.agentId ? { agentId: input.agentId } : {}),
+            ...(input.authToken ? { authToken: input.authToken } : {}),
             abortSignal: streamInput.abortSignal,
             publishDataEvent: (event: ToolExecutionDataEvent) => publishDataEvent(event),
           },

--- a/src/agent/hosted/default-chat-runtime.ts
+++ b/src/agent/hosted/default-chat-runtime.ts
@@ -331,6 +331,7 @@ export async function createDefaultHostedChatRuntime(
         runtimeAgent,
         runId: taskContext.runId,
         agentId: taskContext.agentId,
+        authToken: taskContext.authToken,
         runStream: (operation) =>
           runWithDefaultHostedRequestContext({
             taskContext,

--- a/src/agent/hosted/project-remote-tool-source.test.ts
+++ b/src/agent/hosted/project-remote-tool-source.test.ts
@@ -66,8 +66,9 @@ function createRemoteSource(input: {
 
 async function resolveTestHeaders(
   headers: RemoteMCPToolSourceConfig["headers"],
+  context?: ToolExecutionContext,
 ): Promise<HeadersInit | undefined> {
-  return typeof headers === "function" ? await headers() : headers;
+  return typeof headers === "function" ? await headers(context) : headers;
 }
 
 Deno.test("hosted remote tool sources do not carry legacy end-user identity plumbing", async () => {
@@ -406,7 +407,12 @@ Deno.test("createHostedProjectRemoteToolSources builds API and explicit gated St
     "https://api.example/mcp",
     "https://studio.example/mcp",
   ]);
-  assertEquals(configs[0]?.headers, { Authorization: "Bearer token-1" });
+  assertEquals(await resolveTestHeaders(configs[0]?.headers), {
+    Authorization: "Bearer token-1",
+  });
+  assertEquals(await resolveTestHeaders(configs[0]?.headers, { authToken: "run-token-1" }), {
+    Authorization: "Bearer run-token-1",
+  });
 
   activeProjectId = "project-2";
   assertEquals(await resolveTestHeaders(configs[1]?.headers), {
@@ -470,7 +476,12 @@ Deno.test("createHostedProjectRemoteToolSources builds explicit MCP server lists
     "https://studio.example/mcp",
     "https://linear.example/mcp",
   ]);
-  assertEquals(configs[0]?.headers, { Authorization: "Bearer token-1" });
+  assertEquals(await resolveTestHeaders(configs[0]?.headers), {
+    Authorization: "Bearer token-1",
+  });
+  assertEquals(await resolveTestHeaders(configs[0]?.headers, { authToken: "run-token-1" }), {
+    Authorization: "Bearer run-token-1",
+  });
   assertEquals(configs[2]?.headers, { Authorization: "Bearer linear-token" });
 
   activeProjectId = "project-2";

--- a/src/agent/service/mcp-server-config.test.ts
+++ b/src/agent/service/mcp-server-config.test.ts
@@ -8,19 +8,26 @@ Deno.test("defaultAgentServiceMcpServers enables the Veryfront API MCP server", 
   assertEquals(defaultAgentServiceMcpServers(), [{ kind: "veryfront-api" }]);
 });
 
-Deno.test("createAgentServiceRemoteMcpConfig builds Veryfront API MCP config", () => {
+Deno.test("createAgentServiceRemoteMcpConfig builds Veryfront API MCP config", async () => {
+  const config = createAgentServiceRemoteMcpConfig({
+    server: { kind: "veryfront-api" },
+    authToken: "token-1",
+    apiMcpUrl: "https://api.example/mcp",
+  });
+  assertEquals(config?.id, "veryfront-mcp");
+  assertEquals(config?.endpoint, "https://api.example/mcp");
   assertEquals(
-    createAgentServiceRemoteMcpConfig({
-      server: { kind: "veryfront-api" },
-      authToken: "token-1",
-      apiMcpUrl: "https://api.example/mcp",
-    }),
+    typeof config?.headers === "function" ? await config.headers() : config?.headers,
     {
-      id: "veryfront-mcp",
-      endpoint: "https://api.example/mcp",
-      headers: {
-        Authorization: "Bearer token-1",
-      },
+      Authorization: "Bearer token-1",
+    },
+  );
+  assertEquals(
+    typeof config?.headers === "function"
+      ? await config.headers({ authToken: "run-token-1" })
+      : config?.headers,
+    {
+      Authorization: "Bearer run-token-1",
     },
   );
 

--- a/src/agent/service/mcp-server-config.ts
+++ b/src/agent/service/mcp-server-config.ts
@@ -72,8 +72,11 @@ function createVeryfrontApiRemoteMcpConfig(
   return {
     id: server.id ?? input.defaultSourceId ?? "veryfront-mcp",
     endpoint: input.apiMcpUrl,
-    headers: {
-      Authorization: `Bearer ${input.authToken}`,
+    headers: (context) => {
+      const authToken = typeof context?.authToken === "string" && context.authToken.length > 0
+        ? context.authToken
+        : input.authToken;
+      return { Authorization: `Bearer ${authToken}` };
     },
   };
 }


### PR DESCRIPTION
## Summary
- pass the hosted runtime auth token into framework agent execution context
- let Veryfront API MCP headers prefer the per-tool execution auth token, falling back to the configured token
- update remote MCP tests to verify fallback and run-context token behavior

## Evidence
- `deno test src/agent/hosted/chat-runtime-agent-adapter.test.ts src/agent/service/mcp-server-config.test.ts`
- `deno test --allow-read --no-check src/agent/hosted/chat-runtime-agent-adapter.test.ts src/agent/service/mcp-server-config.test.ts src/agent/hosted/chat-runtime-tool-assembly.test.ts src/agent/hosted/project-remote-tool-source.test.ts`
- `deno fmt --check src/agent/hosted/chat-runtime-agent-adapter.ts src/agent/hosted/default-chat-runtime.ts src/agent/service/mcp-server-config.ts src/agent/hosted/chat-runtime-agent-adapter.test.ts src/agent/service/mcp-server-config.test.ts src/agent/hosted/project-remote-tool-source.test.ts`

## Note
Local pre-push full test hook was blocked by unrelated observability metrics config expectations (`otlp` vs `console`). Focused and related tests for this change pass.
