### PR TITLE
Bump version to 0.1.795

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.794",
+  "version": "0.1.795",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.794";
+export const VERSION = "0.1.795";


### PR DESCRIPTION
## Summary
- Bump deno.json version to 0.1.795
- Keep src/utils/version-constant.ts in sync

## Verification
- deno fmt --check deno.json src/utils/version-constant.ts
- git diff --check
- pre-push checks: format, lint, typecheck, generation, unit suite (2137 passed, 0 failed)
