### PR TITLE
Keep release asset builds ready when vendored dependencies cycle

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.795",
+  "version": "0.1.796",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -343,7 +343,7 @@ describe("release asset build executor", () => {
     assert(!bParentUpload.text.includes(`"/_vf/assets/${aSharedHash}.js"`));
   });
 
-  it("fails the manifest when vendored dependency assets contain a cycle", async () => {
+  it("falls back to source URLs when vendored dependency assets contain a cycle", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
       {
@@ -383,11 +383,22 @@ describe("release asset build executor", () => {
 
     const result = await runReleaseAssetBuild(input, await tmp());
 
-    assertEquals(result.success, false);
-    assertEquals(result.state, "failed");
-    assert(result.error?.includes("Circular release asset dependency graph"));
-    assertEquals(rec.states.at(-1)?.state, "failed");
-    assertEquals(rec.manifest, null);
+    assertEquals(result.success, true);
+    assertEquals(result.state, "ready");
+    assert(result.gaps.some((gap) => gap.startsWith("dependency-cycle:")));
+
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.dependencies["https://esm.sh/parent@1"], undefined);
+    assertEquals(manifest.dependencies["https://esm.sh/child@1"], undefined);
+
+    const pageHash = manifest.modules["pages/index.tsx"]?.contentHash;
+    assertExists(pageHash);
+    const pageUpload = rec.uploads.find((u) => u.hash === pageHash);
+    assertExists(pageUpload);
+    assert(pageUpload.text.includes('"https://esm.sh/parent@1"'));
+    assert(!pageUpload.text.includes("file:///tmp/veryfront-http-bundle"));
+    assertEquals(rec.states.find((state) => state.state === "failed"), undefined);
   });
 
   it("fails the manifest when a vendored dependency keeps an unresolved file import", async () => {

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -187,6 +187,11 @@ interface DependencyModule {
   code: string;
 }
 
+interface FinalizedDependencyModules {
+  assets: Record<string, PreparedAsset>;
+  fallbackUrls: Map<string, string>;
+}
+
 function frameworkModuleUrlToSourceKey(moduleUrl: string): string | null {
   if (!moduleUrl.startsWith(FRAMEWORK_MODULE_URL_PREFIX)) return null;
   return moduleUrl
@@ -412,6 +417,35 @@ function buildDependencyUrlMap(
   return urls;
 }
 
+function dependencyFallbackUrl(dependency: DependencyModule): string | null {
+  if (
+    dependency.manifestKey.startsWith("http://") ||
+    dependency.manifestKey.startsWith("https://")
+  ) {
+    return dependency.manifestKey;
+  }
+
+  for (const specifier of dependency.specifiers) {
+    if (specifier.startsWith("http://") || specifier.startsWith("https://")) {
+      return specifier;
+    }
+  }
+
+  return null;
+}
+
+function addDependencyUrlAliases(
+  urls: Map<string, string>,
+  dependency: DependencyModule,
+  url: string,
+): void {
+  urls.set(dependency.manifestKey, url);
+  if (dependency.sourcePath) urls.set(`file://${dependency.sourcePath}`, url);
+  for (const specifier of dependency.specifiers) {
+    urls.set(normalizeDependencySpecifier(specifier), url);
+  }
+}
+
 function addDependencyModule(
   dependencies: Map<string, DependencyModule>,
   dependency: ReleaseAssetVendorDependency,
@@ -551,7 +585,8 @@ async function finalizeDependencyModules(
   dependencyModules: Map<string, DependencyModule>,
   uploadQueue: PreparedAsset[],
   pendingBytes: Map<string, { bytes: Uint8Array<ArrayBuffer>; contentType: string }>,
-): Promise<Record<string, PreparedAsset>> {
+  gaps: string[],
+): Promise<FinalizedDependencyModules> {
   const bySpecifier = new Map<string, DependencyModule>();
   const byFilePath = new Map<string, DependencyModule>();
   for (const dependency of dependencyModules.values()) {
@@ -564,6 +599,9 @@ async function finalizeDependencyModules(
   }
 
   const finalized = new Map<string, PreparedAsset>();
+  const fallbackUrls = new Map<string, string>();
+  const skippedCycles = new Set<string>();
+  const recordedCycleGaps = new Set<string>();
   const visiting: string[] = [];
 
   function resolveDependencyImport(
@@ -579,13 +617,31 @@ async function finalizeDependencyModules(
     return bySpecifier.get(normalizeDependencySpecifier(specifier)) ?? null;
   }
 
+  function recordDependencyCycle(cycleKeys: string[]): void {
+    // Separate content-hashed ESM files cannot represent cyclic imports without
+    // release-scoped aliases or bundling, so keep only that component on source URL fallback.
+    for (const key of cycleKeys) skippedCycles.add(key);
+
+    const gap = `dependency-cycle:${cycleKeys.join("->")}`;
+    if (!recordedCycleGaps.has(gap)) {
+      recordedCycleGaps.add(gap);
+      gaps.push(gap);
+    }
+  }
+
+  function cycleFallbackFor(dependency: DependencyModule): string | null {
+    if (!skippedCycles.has(dependency.manifestKey)) return null;
+    return dependencyFallbackUrl(dependency);
+  }
+
   async function finalize(manifestKey: string): Promise<PreparedAsset | null> {
     const existing = finalized.get(manifestKey);
     if (existing) return existing;
     if (visiting.includes(manifestKey)) {
-      const cycle = [...visiting.slice(visiting.indexOf(manifestKey)), manifestKey].join(" -> ");
-      throw new Error(`Circular release asset dependency graph: ${cycle}`);
+      recordDependencyCycle([...visiting.slice(visiting.indexOf(manifestKey)), manifestKey]);
+      return null;
     }
+    if (skippedCycles.has(manifestKey)) return null;
 
     const dependency = dependencyModules.get(manifestKey);
     if (!dependency) return null;
@@ -602,18 +658,20 @@ async function finalizeDependencyModules(
         const child = resolveDependencyImport(imp.n, dependency);
         if (!child) continue;
         if (child.manifestKey === manifestKey) {
-          throw new Error(
-            `Circular release asset dependency graph: ${manifestKey} -> ${manifestKey}`,
-          );
+          recordDependencyCycle([manifestKey, manifestKey]);
+          continue;
         }
         await finalize(child.manifestKey);
       }
+
+      if (skippedCycles.has(manifestKey)) return null;
 
       const rewritten = await replaceSpecifiers(dependency.code, (specifier) => {
         const child = resolveDependencyImport(specifier, dependency);
         if (!child) return null;
         const asset = finalized.get(child.manifestKey);
-        return asset ? releaseAssetUrl(asset.contentHash, "js") : null;
+        if (asset) return releaseAssetUrl(asset.contentHash, "js");
+        return cycleFallbackFor(child);
       });
 
       const entry = await addPreparedJavaScriptAsset(
@@ -640,7 +698,20 @@ async function finalizeDependencyModules(
   } finally {
     visiting.length = 0;
   }
-  return Object.fromEntries(finalized);
+
+  for (const manifestKey of skippedCycles) {
+    const dependency = dependencyModules.get(manifestKey);
+    if (!dependency) continue;
+
+    const fallbackUrl = dependencyFallbackUrl(dependency);
+    if (!fallbackUrl) {
+      throw new Error(`Unrepresentable vendored dependency cycle: ${manifestKey}`);
+    }
+
+    addDependencyUrlAliases(fallbackUrls, dependency, fallbackUrl);
+  }
+
+  return { assets: Object.fromEntries(finalized), fallbackUrls };
 }
 
 async function finalizeProjectModules(
@@ -1044,12 +1115,16 @@ async function runBuildInner(
     gaps,
   );
   let httpDependencies: Record<string, PreparedAsset>;
+  let httpDependencyFallbackUrls = new Map<string, string>();
   try {
-    httpDependencies = await finalizeDependencyModules(
+    const finalizedHttpDependencies = await finalizeDependencyModules(
       dependencyModules,
       uploadQueue,
       pendingBytes,
+      gaps,
     );
+    httpDependencies = finalizedHttpDependencies.assets;
+    httpDependencyFallbackUrls = finalizedHttpDependencies.fallbackUrls;
   } catch (error) {
     const sanitized = sanitizeError(error);
     logger.warn("HTTP dependency finalization failed during release asset build", {
@@ -1072,6 +1147,9 @@ async function runBuildInner(
   }
   const dependencies = { ...frameworkDependencies, ...httpDependencies };
   const dependencyUrls = buildDependencyUrlMap(dependencies, dependencyModules);
+  for (const [specifier, url] of httpDependencyFallbackUrls) {
+    dependencyUrls.set(specifier, url);
+  }
 
   const { modules, skippedModules } = await finalizeProjectModules(
     transformedModules,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.795";
+export const VERSION = "0.1.796";


### PR DESCRIPTION
## Summary
- Stops cyclic vendored third-party dependency graphs from failing the whole release asset manifest build.
- Records a `dependency-cycle:*` gap and rewrites only the cyclic component back to its source HTTPS URL, while acyclic vendored dependencies still become immutable `/_vf/assets/{hash}.js` assets.
- Bumps `veryfront` to `0.1.796` for release automation.

## Why
Coder Society production manifest rebuild failed on the new `0.1.795` renderer with:

```
Circular release asset dependency graph: https:<path> -> https:<path> -> https:<path>
```

Separate content-hashed ESM files cannot represent cyclic imports without either SCC bundling or release-scoped aliases. This keeps the release build ready and browser-valid without pretending cyclic components are content-addressed.

## Verification
- `deno fmt --check deno.json src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts src/utils/version-constant.ts`
- `deno test --no-check --allow-all src/release-assets`
- `deno check --allow-import src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts`
- Pre-push hook: formatting, lint, type check, unit tests: `2137 passed`, `0 failed`.