### PR TITLE
Fix replay of same-message tool results

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.796",
+  "version": "0.1.797",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/hosted/child-fork-step-message-preparation.test.ts
+++ b/src/agent/hosted/child-fork-step-message-preparation.test.ts
@@ -64,6 +64,68 @@ Deno.test("prepareHostedChildForkRuntimeStepMessages compacts messages and resol
   ]);
 });
 
+Deno.test("prepareHostedChildForkRuntimeStepMessages preserves same-message assistant tool results", () => {
+  const messages: AgentRuntimeMessage[] = [
+    {
+      id: "assistant-message-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-call",
+          toolCallId: "tool-call-1",
+          toolName: "read_file",
+          args: { path: "README.md" },
+        },
+        {
+          type: "tool-result",
+          toolCallId: "tool-call-1",
+          toolName: "read_file",
+          result: { content: "hello" },
+        },
+      ],
+      timestamp: 1,
+    },
+  ];
+
+  const prepared = prepareHostedChildForkRuntimeStepMessages({
+    messages,
+    buildInstructions: () => "Base instructions",
+    forkToolNames: ["read_file"],
+  });
+
+  assertEquals(prepared.messages, [
+    {
+      id: "agent-runtime-assistant-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-read_file",
+          toolCallId: "tool-call-1",
+          toolName: "read_file",
+          args: { path: "README.md" },
+        },
+      ],
+      timestamp: 0,
+    },
+    {
+      id: "agent-runtime-tool-2",
+      role: "tool",
+      parts: [
+        {
+          type: "tool-result",
+          toolCallId: "tool-call-1",
+          toolName: "read_file",
+          result: {
+            type: "json",
+            value: { content: "hello" },
+          },
+        },
+      ],
+      timestamp: 1,
+    },
+  ]);
+});
+
 Deno.test("prepareHostedChildForkRuntimeStepMessages falls back to current instructions", () => {
   const prepared = prepareHostedChildForkRuntimeStepMessages({
     messages: [],

--- a/src/agent/runtime/message-adapter.test.ts
+++ b/src/agent/runtime/message-adapter.test.ts
@@ -339,6 +339,82 @@ describe("agent runtime message adapter", () => {
     ]);
   });
 
+  it("replays same-message stored tool results after their matching assistant tool call", () => {
+    const providerMessages = convertAgentRuntimeMessagesToProviderMessages([
+      {
+        role: "assistant",
+        parts: [
+          {
+            type: "tool_call",
+            id: TOOL_CALL_ID,
+            name: TOOL_NAME,
+            input: { query: "rollout" },
+          },
+          {
+            type: "tool_result",
+            tool_call_id: TOOL_CALL_ID,
+            output: { matches: 2 },
+          },
+        ],
+      },
+    ]);
+
+    assertEquals(providerMessages, [
+      {
+        role: "assistant",
+        content: [providerToolCallPart({ query: "rollout" })],
+      },
+      {
+        role: "tool",
+        content: [
+          providerToolResultPart(jsonOutput({ matches: 2 })),
+        ],
+      },
+    ]);
+  });
+
+  it("keeps assistant text after same-message tool results in a later assistant message", () => {
+    const providerMessages = convertAgentRuntimeMessagesToProviderMessages([
+      {
+        role: "assistant",
+        parts: [
+          {
+            type: "tool_call",
+            id: TOOL_CALL_ID,
+            name: TOOL_NAME,
+            input: { query: "rollout" },
+          },
+          {
+            type: "tool_result",
+            tool_call_id: TOOL_CALL_ID,
+            output: { matches: 2 },
+          },
+          {
+            type: "text",
+            text: "Found two matches.",
+          },
+        ],
+      },
+    ]);
+
+    assertEquals(providerMessages, [
+      {
+        role: "assistant",
+        content: [providerToolCallPart({ query: "rollout" })],
+      },
+      {
+        role: "tool",
+        content: [
+          providerToolResultPart(jsonOutput({ matches: 2 })),
+        ],
+      },
+      {
+        role: "assistant",
+        content: [providerTextPart("Found two matches.")],
+      },
+    ]);
+  });
+
   it("preserves reasoning replay metadata when replaying agent runtime messages", () => {
     const providerMessages = convertAgentRuntimeMessagesToProviderMessages([
       agentRuntimeMessage(

--- a/src/agent/runtime/message-adapter.ts
+++ b/src/agent/runtime/message-adapter.ts
@@ -367,6 +367,7 @@ export function getAgentRuntimeToolCallPart(
 /** Return a runtime tool-result part when the value carries a tool result. */
 export function getAgentRuntimeToolResultPart(
   part: unknown,
+  toolNameFallback?: string,
 ): { toolCallId: string; toolName: string; output: unknown } | null {
   if (!isRecord(part) || part.type !== "tool-result" && part.type !== "tool_result") {
     return null;
@@ -375,7 +376,8 @@ export function getAgentRuntimeToolResultPart(
   const toolCallId = getOptionalStringField(part, "toolCallId") ??
     getOptionalStringField(part, "tool_call_id");
   const toolName = getOptionalStringField(part, "toolName") ??
-    getOptionalStringField(part, "tool_name");
+    getOptionalStringField(part, "tool_name") ??
+    toolNameFallback;
   if (!toolCallId || !toolName) {
     return null;
   }
@@ -389,6 +391,15 @@ export function getAgentRuntimeToolResultPart(
       ? part.output
       : null,
   };
+}
+
+function getAgentRuntimeToolResultCallId(part: unknown): string | undefined {
+  if (!isRecord(part) || part.type !== "tool-result" && part.type !== "tool_result") {
+    return undefined;
+  }
+
+  return getOptionalStringField(part, "toolCallId") ??
+    getOptionalStringField(part, "tool_call_id");
 }
 
 /** Create a chat tool-result part. */
@@ -417,6 +428,7 @@ function collectAgentRuntimeProviderContentParts(
   const toolCallParts: ProviderToolCallPart[] = [];
   const toolResultParts: ChatToolResultPart[] = [];
   const fileParts: ChatModelFilePart[] = [];
+  const toolNamesById = new Map<string, string>();
 
   for (const part of parts) {
     const textPart = getAgentRuntimeTextPart(part);
@@ -439,7 +451,11 @@ function collectAgentRuntimeProviderContentParts(
       }
     }
 
-    const toolResultPart = getAgentRuntimeToolResultPart(part);
+    const toolResultCallId = getAgentRuntimeToolResultCallId(part);
+    const toolResultPart = getAgentRuntimeToolResultPart(
+      part,
+      toolResultCallId ? toolNamesById.get(toolResultCallId) : undefined,
+    );
     if (toolResultPart) {
       toolResultParts.push(createToolResultPart(toolResultPart));
       continue;
@@ -447,6 +463,7 @@ function collectAgentRuntimeProviderContentParts(
 
     const toolCallPart = getAgentRuntimeToolCallPart(part);
     if (toolCallPart) {
+      toolNamesById.set(toolCallPart.toolCallId, toolCallPart.toolName);
       toolCallParts.push({
         type: "tool-call",
         toolCallId: toolCallPart.toolCallId,
@@ -459,63 +476,167 @@ function collectAgentRuntimeProviderContentParts(
   return { textParts, reasoningParts, toolCallParts, toolResultParts, fileParts };
 }
 
-function createProviderMessageFromAgentRuntimeMessage(
+function convertAssistantAgentRuntimePartsToProviderMessages(
+  parts: ReadonlyArray<AgentRuntimeMessageLikePart>,
+): ProviderModelMessage[] {
+  const assistantContent: Array<ProviderReasoningPart | ProviderTextPart | ProviderToolCallPart> =
+    [];
+  const deferredAssistantContent: Array<
+    ProviderReasoningPart | ProviderTextPart | ProviderToolCallPart
+  > = [];
+  const toolResults: ChatToolResultPart[] = [];
+  const pendingToolCallIds = new Set<string>();
+  const toolNamesById = new Map<string, string>();
+  const providerMessages: ProviderModelMessage[] = [];
+
+  const flushAssistantMessage = (
+    content: Array<ProviderReasoningPart | ProviderTextPart | ProviderToolCallPart>,
+  ) => {
+    if (content.length === 0) {
+      return;
+    }
+
+    providerMessages.push({ role: "assistant", content: [...content] });
+    content.length = 0;
+  };
+
+  const flushToolMessage = () => {
+    if (toolResults.length === 0) {
+      return;
+    }
+
+    providerMessages.push({ role: "tool", content: [...toolResults] });
+    toolResults.length = 0;
+  };
+
+  const pushAssistantPart = (
+    part: ProviderReasoningPart | ProviderTextPart | ProviderToolCallPart,
+  ) => {
+    if (part.type === "tool-call") {
+      if (deferredAssistantContent.length > 0) {
+        flushAssistantMessage(assistantContent);
+        flushToolMessage();
+        flushAssistantMessage(deferredAssistantContent);
+      }
+
+      assistantContent.push(part);
+      pendingToolCallIds.add(part.toolCallId);
+      toolNamesById.set(part.toolCallId, part.toolName);
+      return;
+    }
+
+    if (pendingToolCallIds.size > 0) {
+      deferredAssistantContent.push(part);
+      return;
+    }
+
+    if (toolResults.length > 0) {
+      flushAssistantMessage(assistantContent);
+      flushToolMessage();
+      flushAssistantMessage(deferredAssistantContent);
+    }
+
+    assistantContent.push(part);
+  };
+
+  const pushToolResult = (part: ChatToolResultPart) => {
+    toolResults.push(part);
+    pendingToolCallIds.delete(part.toolCallId);
+  };
+
+  for (const part of parts) {
+    const textPart = getAgentRuntimeTextPart(part);
+    if (textPart) {
+      pushAssistantPart(textPart);
+      continue;
+    }
+
+    const reasoningPart = getAgentRuntimeReasoningPart(part);
+    if (reasoningPart) {
+      pushAssistantPart(reasoningPart);
+      continue;
+    }
+
+    const toolResultCallId = getAgentRuntimeToolResultCallId(part);
+    const toolResultPart = getAgentRuntimeToolResultPart(
+      part,
+      toolResultCallId ? toolNamesById.get(toolResultCallId) : undefined,
+    );
+    if (toolResultPart) {
+      pushToolResult(createToolResultPart(toolResultPart));
+      continue;
+    }
+
+    const toolCallPart = getAgentRuntimeToolCallPart(part);
+    if (toolCallPart) {
+      pushAssistantPart({
+        type: "tool-call",
+        toolCallId: toolCallPart.toolCallId,
+        toolName: toolCallPart.toolName,
+        input: toolCallPart.input,
+      });
+    }
+  }
+
+  flushAssistantMessage(assistantContent);
+  flushToolMessage();
+  flushAssistantMessage(deferredAssistantContent);
+
+  return providerMessages;
+}
+
+function createProviderMessagesFromAgentRuntimeMessage(
   message: Pick<AgentRuntimeMessage, "role"> & {
     parts: ReadonlyArray<AgentRuntimeMessageLikePart>;
   },
-): ProviderModelMessage | null {
-  const { textParts, reasoningParts, toolCallParts, toolResultParts, fileParts } =
-    collectAgentRuntimeProviderContentParts(message.parts);
+): ProviderModelMessage[] {
+  if (message.role === "assistant") {
+    return convertAssistantAgentRuntimePartsToProviderMessages(message.parts);
+  }
+
+  const { textParts, toolResultParts, fileParts } = collectAgentRuntimeProviderContentParts(
+    message.parts,
+  );
 
   switch (message.role) {
-    case "assistant":
-      if (reasoningParts.length === 0 && textParts.length === 0 && toolCallParts.length === 0) {
-        return null;
-      }
-
-      return {
-        role: "assistant",
-        content: [...reasoningParts, ...textParts, ...toolCallParts],
-      };
-
     case "tool":
       if (toolResultParts.length === 0) {
-        return null;
+        return [];
       }
 
-      return {
+      return [{
         role: "tool",
         content: toolResultParts,
-      };
+      }];
 
     case "user": {
       if (textParts.length === 0 && fileParts.length === 0) {
-        return null;
+        return [];
       }
 
       if (fileParts.length === 0) {
-        return {
+        return [{
           role: "user",
           content: joinTextParts(textParts),
-        };
+        }];
       }
 
       const content: ChatUserContentPart[] = [...textParts, ...fileParts];
-      return {
+      return [{
         role: "user",
         content,
-      };
+      }];
     }
 
     case "system": {
       if (textParts.length === 0) {
-        return null;
+        return [];
       }
 
-      return {
+      return [{
         role: "system",
         content: joinTextParts(textParts),
-      };
+      }];
     }
 
     default: {
@@ -550,10 +671,7 @@ export function convertAgentRuntimeMessagesToProviderMessages(
   const converted: ProviderModelMessage[] = [];
 
   for (const message of messages) {
-    const convertedMessage = createProviderMessageFromAgentRuntimeMessage(message);
-    if (convertedMessage) {
-      converted.push(convertedMessage);
-    }
+    converted.push(...createProviderMessagesFromAgentRuntimeMessage(message));
   }
 
   return converted;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.796";
+export const VERSION = "0.1.797";


### PR DESCRIPTION
## Summary
- Preserve tool results stored in the same assistant message as their matching tool call by replaying them as adjacent provider `tool` messages.
- Infer missing tool result names from the matching tool call during adapter replay.
- Bump Veryfront package version from `0.1.796` to `0.1.797`.

## Tests
- `deno fmt --check deno.json src/utils/version-constant.ts src/agent/runtime/message-adapter.ts src/agent/runtime/message-adapter.test.ts src/agent/hosted/child-fork-step-message-preparation.test.ts`
- `deno lint src/utils/version-constant.ts src/agent/runtime/message-adapter.ts src/agent/runtime/message-adapter.test.ts src/agent/hosted/child-fork-step-message-preparation.test.ts`
- `deno check src/agent/runtime/message-adapter.test.ts src/agent/hosted/child-fork-step-message-preparation.test.ts src/utils/version-constant.ts`
- `deno test --no-check --allow-all src/agent/runtime/message-adapter.test.ts src/agent/hosted/child-fork-step-message-preparation.test.ts src/agent/runtime/message-preparation.test.ts src/agent/hosted/chat-preparation.test.ts src/agent/runtime/text-generation-runtime-message-converter.test.ts`
- Pre-push hook: formatting, lint, type check, generation, and unit tests (`2138 passed`, `0 failed`).
