### PR TITLE
Keep release import maps on vendored React

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.796",
+  "version": "0.1.797",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/html/html-shell-manifest.test.ts
+++ b/src/html/html-shell-manifest.test.ts
@@ -17,6 +17,7 @@ import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-sc
 const PAGE_HASH = "a".repeat(64);
 const CHAT_HASH = "b".repeat(64);
 const COMPONENT_HASH = "d".repeat(64);
+const REACT_HASH = "e".repeat(64);
 
 function meta(): RenderMetadata {
   return { title: "T", slug: "index", frontmatter: {} };
@@ -152,6 +153,31 @@ describe("html shell release asset manifest consumption", () => {
     assertStringIncludes(result.start, `/_vf/assets/${CSS_HASH}.css`);
     // The JIT project-CSS link is replaced, not duplicated.
     assert(!result.start.includes("/_vf/css/"));
+  });
+
+  it("rewrites covered HTTP import-map dependencies to immutable asset URLs", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({
+        state: "ready",
+        manifest: {
+          ...manifest(),
+          dependencies: {
+            "https://esm.sh/react@19.2.4?deps=csstype%403.2.3&target=es2022": {
+              contentHash: REACT_HASH,
+              size: 10,
+              contentType: "text/javascript",
+            },
+          },
+        },
+      })
+    );
+    await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
+    assertStringIncludes(result.start, `"react":"/_vf/assets/${REACT_HASH}.js"`);
+    assertStringIncludes(result.start, `"react-dom/client":"https://esm.sh/react-dom@19.2.4`);
   });
 
   it("keeps covered framework import-map entries on the module-server path", async () => {

--- a/src/html/utils.ts
+++ b/src/html/utils.ts
@@ -1,6 +1,7 @@
 import { escapeHTML } from "./html-escape.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
+import { releaseAssetUrl } from "#veryfront/release-assets/constants.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import { VERYFRONT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import {
@@ -293,14 +294,50 @@ function stableManifestDependencyKey(manifest?: ReleaseAssetManifest | null): st
     : "";
 }
 
+function canonicalDependencyUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return value;
+
+    const sortedParams = [...url.searchParams.entries()].sort(([leftKey, leftValue], [
+      rightKey,
+      rightValue,
+    ]) => leftKey.localeCompare(rightKey) || leftValue.localeCompare(rightValue));
+    url.search = "";
+    for (const [key, paramValue] of sortedParams) {
+      url.searchParams.append(key, paramValue);
+    }
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
+
 function applyManifestDependencies(
   imports: Record<string, string>,
-  _manifest?: ReleaseAssetManifest | null,
+  manifest?: ReleaseAssetManifest | null,
 ): Record<string, string> {
-  // Framework dependency assets are recorded for future S7 vendoring, but they
-  // are not browser-safe until their own relative import closures are rewritten
-  // and uploaded. Keep import-map entries on their existing module URLs.
-  return imports;
+  if (!manifest) return imports;
+
+  const dependencyAssets = new Map<string, string>();
+  for (const [specifier, entry] of Object.entries(manifest.dependencies)) {
+    const assetUrl = releaseAssetUrl(entry.contentHash, "js");
+    dependencyAssets.set(specifier, assetUrl);
+    dependencyAssets.set(canonicalDependencyUrl(specifier), assetUrl);
+  }
+
+  return Object.fromEntries(
+    Object.entries(imports).map(([specifier, url]) => {
+      if (!url.startsWith("http://") && !url.startsWith("https://")) {
+        return [specifier, url];
+      }
+
+      return [
+        specifier,
+        dependencyAssets.get(url) ?? dependencyAssets.get(canonicalDependencyUrl(url)) ?? url,
+      ];
+    }),
+  );
 }
 
 function isImportMapOnlyOptions(

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -1115,7 +1115,7 @@ async function runBuildInner(
     gaps,
   );
   let httpDependencies: Record<string, PreparedAsset>;
-  let httpDependencyFallbackUrls = new Map<string, string>();
+  let httpDependencyFallbackUrls: Map<string, string>;
   try {
     const finalizedHttpDependencies = await finalizeDependencyModules(
       dependencyModules,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.796";
+export const VERSION = "0.1.797";


### PR DESCRIPTION
## Summary
- rewrites covered HTTP import-map dependencies to immutable release asset URLs when a ready manifest is present
- keeps local /_vf_modules platform utilities on the module-server path until their framework closure is proven asset-safe
- removes the unused fallback Map initialization flagged by CodeQL
- bumps Veryfront to 0.1.797 so the fix publishes as a fresh release

## Production bug fixed
Coder Society was loading project/dependency assets from /_vf/assets, but the HTML import map still pointed React at esm.sh. Dependencies such as next-themes imported vendored React from the manifest, while react-dom/client resolved React from the CDN import map path. That split React into two module instances and caused hooks to fail during hydration:

- Cannot read properties of null (reading 'useContext')

The fix only rewrites HTTP(S) import-map values when the ready manifest has a matching dependency asset. It canonicalizes URL query params, so equivalent esm.sh URLs match even when parameter order or @ encoding differs.

## Verification
- deno fmt --check deno.json src/html/utils.ts src/html/html-shell-manifest.test.ts src/release-assets/build-executor.ts src/utils/version-constant.ts
- deno test --no-check --allow-all src/html/html-shell-manifest.test.ts src/html/utils.test.ts src/release-assets
- deno check --allow-import src/html/utils.ts src/html/html-shell-manifest.test.ts src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts
- git diff --check
- pre-push hook: formatting, lint, type check, generated assets, unit tests (2137 passed, 0 failed)