### PR TITLE
Preserve integration tool history in model replay

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.797",
+  "version": "0.1.798",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/hosted/chat-preparation.test.ts
+++ b/src/agent/hosted/chat-preparation.test.ts
@@ -308,6 +308,115 @@ Deno.test("prepareHostedChatExecution prepares root run, runtime, and final mess
   ]);
 });
 
+Deno.test("prepareHostedChatExecution preserves allowed remote tool history", async () => {
+  const messages: ChatUiMessage[] = [
+    {
+      id: "user-1",
+      role: "user",
+      parts: [{ type: "text", text: "Check my Harvest account." }],
+    },
+    {
+      id: "assistant-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "harvest__list_accounts",
+          toolCallId: "toolu_harvest_accounts",
+          input: {},
+          state: "output-available",
+          output: {
+            accounts: [{ id: "acct-1", name: "Test Account", product: "harvest" }],
+            summary: { count: 1 },
+          },
+        },
+      ],
+    },
+    {
+      id: "tool-1",
+      role: "tool",
+      parts: [
+        {
+          type: "tool-harvest__list_accounts",
+          toolCallId: "toolu_harvest_accounts",
+          toolName: "harvest__list_accounts",
+          input: {},
+          state: "output-available",
+          output: {
+            accounts: [{ id: "acct-1", name: "Test Account", product: "harvest" }],
+            summary: { count: 1 },
+          },
+        },
+      ],
+    },
+    {
+      id: "user-2",
+      role: "user",
+      parts: [{ type: "text", text: "Use that account." }],
+    },
+  ];
+
+  const result = await prepareHostedChatExecution({
+    request: createParsedHostedChatRequest({
+      messages,
+      conversationId: "conversation-1",
+      projectId: "project-1",
+      durableRootRun: {
+        runId: "run-1",
+        messageId: "message-1",
+        latestEventId: 3,
+        latestExternalEventSequence: 2,
+      },
+    }),
+    agentConfig: {
+      id: "agent-1",
+      model: "configured-model",
+      allowedRemoteTools: ["harvest__list_accounts"],
+    },
+    apiUrl: "https://api.example.com",
+    abortSignal: new AbortController().signal,
+    resolveModelId: (modelId) => modelId,
+    fetchSteering: () =>
+      Promise.resolve({
+        instructions: "Project instructions",
+        skills: [],
+      }),
+    buildInstructions: (input) => input.instructions,
+    createRuntime: (options) =>
+      Promise.resolve({
+        runtimeKind: "framework",
+        modelId: options.model ?? "configured-model",
+        cleanup: () => Promise.resolve(),
+        agent: {
+          stream: () =>
+            Promise.resolve({
+              steps: Promise.resolve([]),
+              toUIMessageStream: async function* () {},
+            }),
+        },
+      }),
+  });
+
+  assertEquals(
+    result.finalMessages.some((message) =>
+      message.parts.some((part) =>
+        part.type === "tool-result" &&
+        part.toolName === "harvest__list_accounts" &&
+        "result" in part &&
+        typeof part.result === "object" &&
+        part.result !== null &&
+        "type" in part.result &&
+        part.result.type === "json" &&
+        "value" in part.result &&
+        typeof part.result.value === "object" &&
+        part.result.value !== null &&
+        "accounts" in part.result.value
+      )
+    ),
+    true,
+  );
+});
+
 Deno.test("prepareHostedChatExecution compacts oversized context and appends a durable event", async () => {
   const originalFetch = globalThis.fetch;
   const appendedBodies: unknown[] = [];

--- a/src/agent/hosted/chat-preparation.ts
+++ b/src/agent/hosted/chat-preparation.ts
@@ -87,6 +87,7 @@ export type HostedChatRuntimeCreationPreparationInput<TRuntimeAgentDefinition> =
     thinking?: RuntimeAgentThinkingConfig;
     maxSteps?: number;
     allowedRemoteTools?: unknown;
+    providerTools?: unknown;
   };
   projectId: string | null;
   authToken: string;
@@ -120,9 +121,9 @@ export type HostedChatRuntimeCreationPreparationResult<TRuntimeAgentDefinition> 
   runtimeConfig: ResolvedHostedRuntimeRequestConfig;
 };
 
-function getAllowedRemoteToolNames(agentConfig: { allowedRemoteTools?: unknown }): string[] {
-  return Array.isArray(agentConfig.allowedRemoteTools)
-    ? agentConfig.allowedRemoteTools.filter((toolName): toolName is string =>
+function getProviderToolNames(agentConfig: { providerTools?: unknown }): string[] {
+  return Array.isArray(agentConfig.providerTools)
+    ? agentConfig.providerTools.filter((toolName): toolName is string =>
       typeof toolName === "string" && toolName.length > 0
     )
     : [];
@@ -177,6 +178,7 @@ export type HostedChatExecutionPreparationInput<
     thinking?: RuntimeAgentThinkingConfig;
     maxSteps?: number;
     allowedRemoteTools?: unknown;
+    providerTools?: unknown;
   },
   TRuntimeResult extends HostedChatRuntimeCreationResult,
 > = {
@@ -358,6 +360,7 @@ export async function prepareHostedChatExecution<
     thinking?: RuntimeAgentThinkingConfig;
     maxSteps?: number;
     allowedRemoteTools?: unknown;
+    providerTools?: unknown;
   },
   TRuntimeResult extends HostedChatRuntimeCreationResult,
 >(
@@ -407,7 +410,7 @@ export async function prepareHostedChatExecution<
       authToken: input.request.authToken,
       apiUrl: input.apiUrl,
       projectId: input.request.projectId,
-      providerOwnedToolNames: getAllowedRemoteToolNames(input.agentConfig),
+      providerOwnedToolNames: getProviderToolNames(input.agentConfig),
     },
   );
   let budgetedContext: Awaited<ReturnType<typeof applyContextBudget>> | undefined;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.797";
+export const VERSION = "0.1.798";


### PR DESCRIPTION
## Summary
- keep provider-owned tool elision scoped to configured providerTools instead of allowed remote integration tools
- preserve Harvest-style remote integration tool results in hosted chat replay
- replay same-message stored tool results as adjacent provider tool messages

## Validation
- deno check src/agent/hosted/chat-preparation.ts src/agent/hosted/chat-preparation.test.ts src/agent/runtime/message-adapter.ts src/agent/runtime/message-adapter.test.ts
- deno test --no-check --allow-all src/agent/hosted/chat-preparation.test.ts src/agent/runtime/message-adapter.test.ts src/agent/runtime/message-preparation.test.ts src/agent/runtime/text-generation-runtime-message-converter.test.ts src/agent/hosted/child-fork-step-message-preparation.test.ts
- deno fmt --check src/agent/hosted/chat-preparation.ts src/agent/hosted/chat-preparation.test.ts src/agent/runtime/message-adapter.ts src/agent/runtime/message-adapter.test.ts
- deno lint src/agent/hosted/chat-preparation.ts
- pre-commit verify:quick passed