### PR TITLE
Infer Studio MCP for allowed Studio tools

### DIFF
--- a/src/agent/hosted/project-remote-tool-source.test.ts
+++ b/src/agent/hosted/project-remote-tool-source.test.ts
@@ -440,6 +440,44 @@ Deno.test("createHostedProjectRemoteToolSources builds API and explicit gated St
   assertEquals(blockedSources.map((source) => source.id), ["veryfront-mcp"]);
 });
 
+Deno.test("createHostedProjectRemoteToolSources infers Studio MCP from allowed Studio tools", async () => {
+  const configs: RemoteMCPToolSourceConfig[] = [];
+  const sources = createHostedProjectRemoteToolSources({
+    authToken: "token-1",
+    apiMcpUrl: "https://api.example/mcp",
+    studioMcpUrl: "https://studio.example/mcp",
+    mcpServers: [{ kind: "veryfront-api" }],
+    clientProfile: {
+      id: "veryfront-studio",
+      type: "web",
+      trusted: true,
+      capabilities: ["ui_panels"],
+    },
+    getProjectId: () => "project-1",
+    conversationId: "conversation-1",
+    allowedToolNames: new Set(["invoke_agent", "studio_todo_write"]),
+    createRemoteToolSource: (config) => {
+      configs.push(config);
+      return createRemoteSource({
+        id: config.id,
+        tools: config.id === "studio-mcp"
+          ? [simpleTool("studio_todo_write")]
+          : [projectFileTool("update_file")],
+      });
+    },
+  });
+
+  assertEquals(sources.map((source) => source.id), ["veryfront-mcp", "studio-mcp"]);
+  assertEquals(configs.map((config) => config.endpoint), [
+    "https://api.example/mcp",
+    "https://studio.example/mcp",
+  ]);
+  assertEquals(
+    (await sources[1]?.listTools({ projectId: "project-1" }))?.map((tool) => tool.name),
+    ["studio_todo_write"],
+  );
+});
+
 Deno.test("createHostedProjectRemoteToolSources builds explicit MCP server lists", async () => {
   const configs: RemoteMCPToolSourceConfig[] = [];
   let activeProjectId = "project-1";

--- a/src/agent/hosted/project-remote-tool-source.ts
+++ b/src/agent/hosted/project-remote-tool-source.ts
@@ -212,6 +212,28 @@ export type CreateHostedProjectRemoteToolSourcesInput =
     onStudioProjectSwitch?: HostedProjectRemoteToolSourceProjectSwitchHandler;
   };
 
+function needsStudioMcpSource(input: CreateHostedProjectRemoteToolSourcesInput): boolean {
+  const allowedToolNames = input.allowedToolNames;
+  if (!allowedToolNames) {
+    return false;
+  }
+
+  return Array.from(allowedToolNames).some((toolName) => toolName.startsWith("studio_"));
+}
+
+function resolveHostedProjectMcpServers(
+  input: CreateHostedProjectRemoteToolSourcesInput,
+): readonly AgentServiceMcpServerConfig[] {
+  const servers = [...(input.mcpServers ?? defaultAgentServiceMcpServers())];
+  if (
+    needsStudioMcpSource(input) &&
+    !servers.some((server) => server.kind === "veryfront-studio")
+  ) {
+    servers.push({ kind: "veryfront-studio" });
+  }
+  return servers;
+}
+
 function createHostedProjectRemoteToolSourceFromConfig(
   input: CreateHostedProjectRemoteToolSourcesInput,
   server: AgentServiceMcpServerConfig,
@@ -296,7 +318,7 @@ export function createHostedProjectRemoteToolSources(
 ): RemoteToolSource[] {
   const createRemoteToolSource = input.createRemoteToolSource ?? createRemoteMCPToolSource;
   const sources: RemoteToolSource[] = [];
-  const mcpServers = input.mcpServers ?? defaultAgentServiceMcpServers();
+  const mcpServers = resolveHostedProjectMcpServers(input);
 
   for (const server of mcpServers) {
     const remoteConfig = createAgentServiceRemoteMcpConfig({


### PR DESCRIPTION
## Summary\n- infer the hosted Studio MCP source when runtime allowed tools include a studio_* tool\n- preserves clean project source with tools like studio_todo_write and invoke_agent, without explicit mcpServers\n\n## Verification\n- deno test --allow-all src/agent/hosted/project-remote-tool-source.test.ts