### PR TITLE
Make release manifest shell rendering atomic

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.797",
+  "version": "0.1.798",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -9,7 +9,7 @@ import {
   generateModulePreloadHintsFromManifest,
   getRouteManifest,
 } from "#veryfront/modules/manifest/route-module-manifest.ts";
-import { getReadyManifestForRender } from "#veryfront/release-assets/manifest-cache.ts";
+import { getReadyManifestForRenderAsync } from "#veryfront/release-assets/manifest-cache.ts";
 import {
   resolveManifestModuleUrl,
   resolveManifestRoutePreloadUrls,
@@ -76,16 +76,14 @@ function resolveProjectCSSScope(
   return options.projectSlug || options.projectId || metaSlug || "default";
 }
 
-function generateModulePreloadHints(options: HTMLGenerationOptions): string {
+function generateModulePreloadHints(
+  options: HTMLGenerationOptions,
+  releaseManifest: ReleaseAssetManifest | null,
+): string {
   const hints: string[] = [];
   const addedUrls = new Set<string>();
   const projectDir = options.projectDir ?? "";
   const studioEmbed = options.studioEmbed;
-
-  // Release asset manifest (production only, env-gated, ready manifests only).
-  // Never consulted in studio-embed; returns null when the flag is off so the
-  // emitted HTML is byte-identical to today.
-  const releaseManifest = studioEmbed ? null : getReadyManifestForRender(options.releaseId);
 
   function addHint(moduleUrl: string): void {
     if (!moduleUrl || addedUrls.has(moduleUrl)) return;
@@ -235,7 +233,10 @@ async function generateHTMLShellPartsImpl(
   // Enable dev scripts for local dev OR preview mode (for HMR support in Studio),
   // unless a caller explicitly forces production client scripts for fair benchmarking.
   const useDevScripts = !options.forceProductionScripts && (isLocalProject || isPreviewMode);
-  const releaseManifest = options.studioEmbed ? null : getReadyManifestForRender(options.releaseId);
+  const releaseManifest = options.studioEmbed
+    ? null
+    : await profilePhase("html.release_asset_manifest", () =>
+      getReadyManifestForRenderAsync(options.releaseId));
 
   const importMapPromise = buildImportMap({
     projectDir: options.projectDir,
@@ -264,7 +265,7 @@ async function generateHTMLShellPartsImpl(
 
   const modeStyles = useDevScripts ? getErrorOverlayStyles(nonce) : "";
 
-  const modulePreloadHints = generateModulePreloadHints(options);
+  const modulePreloadHints = generateModulePreloadHints(options, releaseManifest);
   const importMap = await profilePhase("html.import_map", () => importMapPromise);
   const importMapJson = importMap.json;
 
@@ -330,8 +331,7 @@ async function generateHTMLShellPartsImpl(
   // Manifest-consumed CSS: when a ready release asset manifest carries a
   // compiled CSS entry, serve it from the immutable asset path (no renderer
   // involvement). Per-entry fallback: no manifest CSS → existing JIT link.
-  const manifestForCss = options.studioEmbed ? null : getReadyManifestForRender(options.releaseId);
-  const manifestCssEntry = useProductionCSS ? manifestForCss?.css?.[0] : undefined;
+  const manifestCssEntry = useProductionCSS ? releaseManifest?.css?.[0] : undefined;
   if (manifestCssEntry) {
     tailwindCSSBlock =
       `<link rel="stylesheet" href="/_vf/assets/${manifestCssEntry.contentHash}.css">`;

--- a/src/html/html-shell-manifest.test.ts
+++ b/src/html/html-shell-manifest.test.ts
@@ -56,15 +56,6 @@ function manifest(): ReleaseAssetManifest {
   };
 }
 
-async function primeReadyManifest(): Promise<void> {
-  configureReleaseAssetManifestFetcher(() =>
-    Promise.resolve({ state: "ready", manifest: manifest() })
-  );
-  // Render once to schedule + settle the background fetch, then clear nothing.
-  await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
-  await new Promise((r) => setTimeout(r, 0));
-}
-
 describe("html shell release asset manifest consumption", () => {
   const originalFlag = getHostEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG);
 
@@ -92,7 +83,9 @@ describe("html shell release asset manifest consumption", () => {
 
   it("emits a hashed asset URL for a covered page when the flag is on", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
-    await primeReadyManifest();
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({ state: "ready", manifest: manifest() })
+    );
 
     const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
     assertStringIncludes(result.start, `/_vf/assets/${PAGE_HASH}.js`);
@@ -121,9 +114,6 @@ describe("html shell release asset manifest consumption", () => {
         },
       })
     );
-    await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
-    await new Promise((r) => setTimeout(r, 0));
-
     const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
     assertStringIncludes(result.start, `/_vf/assets/${COMPONENT_HASH}.js`);
   });
@@ -146,9 +136,6 @@ describe("html shell release asset manifest consumption", () => {
         },
       })
     );
-    await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
-    await new Promise((r) => setTimeout(r, 0));
-
     const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
     assertStringIncludes(result.start, `/_vf/assets/${CSS_HASH}.css`);
     // The JIT project-CSS link is replaced, not duplicated.
@@ -172,12 +159,39 @@ describe("html shell release asset manifest consumption", () => {
         },
       })
     );
-    await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
-    await new Promise((r) => setTimeout(r, 0));
-
     const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
     assertStringIncludes(result.start, `"react":"/_vf/assets/${REACT_HASH}.js"`);
     assertStringIncludes(result.start, `"react-dom/client":"https://esm.sh/react-dom@19.2.4`);
+  });
+
+  it("uses one ready manifest snapshot on a cold first render", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({
+        state: "ready",
+        manifest: {
+          ...manifest(),
+          css: [{
+            contentHash: "f".repeat(64),
+            size: 10,
+            contentType: "text/css",
+            styleProfileHash: "sp",
+          }],
+          dependencies: {
+            "https://esm.sh/react@19.2.4?deps=csstype%403.2.3&target=es2022": {
+              contentHash: REACT_HASH,
+              size: 10,
+              contentType: "text/javascript",
+            },
+          },
+        },
+      })
+    );
+
+    const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
+    assertStringIncludes(result.start, `/_vf/assets/${PAGE_HASH}.js`);
+    assertStringIncludes(result.start, `/_vf/assets/${"f".repeat(64)}.css`);
+    assertStringIncludes(result.start, `"react":"/_vf/assets/${REACT_HASH}.js"`);
   });
 
   it("keeps covered framework import-map entries on the module-server path", async () => {
@@ -197,9 +211,6 @@ describe("html shell release asset manifest consumption", () => {
         },
       })
     );
-    await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
-    await new Promise((r) => setTimeout(r, 0));
-
     const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
     assert(!result.start.includes(`/_vf/assets/${CHAT_HASH}.js`));
     assertStringIncludes(result.start, `"veryfront/chat":"/_vf_modules/_veryfront/chat/index.js"`);
@@ -208,7 +219,9 @@ describe("html shell release asset manifest consumption", () => {
 
   it("falls back to the existing URL for an uncovered page when the flag is on", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
-    await primeReadyManifest();
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({ state: "ready", manifest: manifest() })
+    );
 
     const result = await generateHTMLShellParts(
       meta(),

--- a/src/release-assets/html-consumption.test.ts
+++ b/src/release-assets/html-consumption.test.ts
@@ -13,6 +13,7 @@ import {
   clearReleaseAssetManifestCache,
   configureReleaseAssetManifestFetcher,
   getReadyManifestForRender,
+  getReadyManifestForRenderAsync,
 } from "./manifest-cache.ts";
 import { RELEASE_ASSET_MANIFEST_ENV_FLAG } from "./constants.ts";
 import type { ReleaseAssetManifest } from "./manifest-schema.ts";
@@ -111,6 +112,42 @@ describe("manifest cache gating", () => {
 
     const cached = getReadyManifestForRender("r");
     assertEquals(cached?.manifestVersion, 3);
+  });
+
+  it("awaits a ready manifest on the first async read", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({ state: "ready", manifest: manifest() })
+    );
+
+    const ready = await getReadyManifestForRenderAsync("r");
+
+    assertEquals(ready?.manifestVersion, 3);
+    assertEquals(getReadyManifestForRender("r")?.manifestVersion, 3);
+  });
+
+  it("dedupes concurrent async ready-manifest reads", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    let resolveFetch: () => void = () => {};
+    const gate = new Promise<void>((resolve) => (resolveFetch = resolve));
+    let fetchCount = 0;
+
+    configureReleaseAssetManifestFetcher(async () => {
+      fetchCount++;
+      await gate;
+      return { state: "ready", manifest: manifest() };
+    });
+
+    const first = getReadyManifestForRenderAsync("r");
+    const second = getReadyManifestForRenderAsync("r");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assertEquals(fetchCount, 1);
+
+    resolveFetch();
+    const [firstReady, secondReady] = await Promise.all([first, second]);
+    assertEquals(firstReady?.manifestVersion, 3);
+    assertEquals(secondReady?.manifestVersion, 3);
+    assertEquals(fetchCount, 1);
   });
 
   it("ignores stale in-flight manifest fetches after the cache is cleared", async () => {

--- a/src/release-assets/manifest-cache.ts
+++ b/src/release-assets/manifest-cache.ts
@@ -11,9 +11,9 @@
  * When the flag is off, `getReadyManifestForRender` always returns null so the
  * HTML output is byte-identical to today.
  *
- * The HTML shell is synchronous, so reads are non-blocking: a cache miss kicks
- * off a background fetch and returns null for the current render. Subsequent
- * renders for the same release pick up the cached result.
+ * Most callers use the non-blocking read so fallback stays cheap. HTML shell
+ * generation uses the awaited read so import maps, preload hints, CSS, and
+ * hydration data are generated from one manifest snapshot.
  *
  * Multi-tenancy: each releaseId is served by the fetcher registered for that
  * specific releaseId (the adapter that owns it). There is no cross-project
@@ -55,6 +55,7 @@ registerLRUCache("release-asset-manifest-cache", manifestCache);
 interface InFlightFetch {
   generation: number;
   token: symbol;
+  promise: Promise<ReleaseAssetManifest | null>;
 }
 
 /** In-flight fetches, deduped per releaseId. */
@@ -135,6 +136,28 @@ function cacheKey(releaseId: string, manifestVersion?: number): string {
   return manifestVersion !== undefined ? `${releaseId}:${manifestVersion}` : releaseId;
 }
 
+function findCachedReadyEntry(releaseId: string): CacheEntry | null {
+  let best: CacheEntry | null = null;
+  for (const [k, v] of manifestCache.entries()) {
+    if (k !== releaseId && !k.startsWith(`${releaseId}:`)) continue;
+    if (v.expiresAt > Date.now() && v.manifest) {
+      const existingVersion = best?.manifest?.manifestVersion ?? -1;
+      if ((v.manifest.manifestVersion ?? 0) > existingVersion) {
+        best = v;
+      }
+    }
+  }
+  return best;
+}
+
+function maybeScheduleReadyRefresh(releaseId: string, entry: CacheEntry): void {
+  const now = Date.now();
+  if ((entry.refreshAfter ?? entry.expiresAt) <= now) {
+    entry.refreshAfter = now + READY_REVALIDATE_MS;
+    scheduleFetch(releaseId);
+  }
+}
+
 /**
  * Return a ready manifest for `releaseId` if one is cached, else null.
  *
@@ -149,27 +172,9 @@ export function getReadyManifestForRender(
   if (!isReleaseAssetManifestEnabled()) return null;
   if (!resolveFetcher(releaseId)) return null;
 
-  // Look up the most recent cached entry for this release. We do a prefix scan
-  // of the LRU to find any `releaseId:*` entry; if we find a live ready one we
-  // return it without scheduling another fetch.
-  let best: CacheEntry | null = null;
-  for (const [k, v] of manifestCache.entries()) {
-    if (k !== releaseId && !k.startsWith(`${releaseId}:`)) continue;
-    if (v.expiresAt > Date.now() && v.manifest) {
-      // Prefer the entry with the highest manifest version.
-      const existingVersion = best?.manifest?.manifestVersion ?? -1;
-      if ((v.manifest.manifestVersion ?? 0) > existingVersion) {
-        best = v;
-      }
-    }
-  }
-
+  const best = findCachedReadyEntry(releaseId);
   if (best) {
-    const now = Date.now();
-    if ((best.refreshAfter ?? best.expiresAt) <= now) {
-      best.refreshAfter = now + READY_REVALIDATE_MS;
-      scheduleFetch(releaseId);
-    }
+    maybeScheduleReadyRefresh(releaseId, best);
     return best.manifest;
   }
 
@@ -184,22 +189,53 @@ export function getReadyManifestForRender(
   return null;
 }
 
+/**
+ * Await a ready manifest for `releaseId`.
+ *
+ * HTML generation uses this path so a cold process cannot emit a mixed shell
+ * where preload hints see the manifest but the import map does not. It still
+ * falls back to null when the flag is off, no fetcher is registered, the
+ * manifest is unavailable, or the fetch fails.
+ */
+export async function getReadyManifestForRenderAsync(
+  releaseId: string | null | undefined,
+): Promise<ReleaseAssetManifest | null> {
+  if (!releaseId) return null;
+  if (!isReleaseAssetManifestEnabled()) return null;
+  if (!resolveFetcher(releaseId)) return null;
+
+  const best = findCachedReadyEntry(releaseId);
+  if (best) {
+    maybeScheduleReadyRefresh(releaseId, best);
+    return best.manifest;
+  }
+
+  const plain = manifestCache.get(releaseId);
+  if (plain && plain.expiresAt > Date.now()) return null;
+
+  return await fetchManifest(releaseId);
+}
+
 function scheduleFetch(releaseId: string): void {
-  if (inFlight.has(releaseId)) return;
+  void fetchManifest(releaseId);
+}
+
+function fetchManifest(releaseId: string): Promise<ReleaseAssetManifest | null> {
+  const existing = inFlight.get(releaseId);
+  if (existing) return existing.promise;
   const active = resolveFetcher(releaseId);
-  if (!active) return;
+  if (!active) return Promise.resolve(null);
   const fetchGeneration = cacheGeneration;
   const token = Symbol(releaseId);
-  inFlight.set(releaseId, { generation: fetchGeneration, token });
 
-  void Promise.resolve().then(async () => {
+  const promise = Promise.resolve().then(async () => {
     try {
       const result = await active(releaseId);
-      if (fetchGeneration !== cacheGeneration) return;
+      if (fetchGeneration !== cacheGeneration) return null;
 
       if (!result) {
         manifestCache.set(releaseId, { manifest: null, expiresAt: Date.now() + NON_READY_TTL_MS });
-        return;
+        return null;
       }
 
       const manifest = result.state === "ready" && result.manifest
@@ -219,19 +255,22 @@ function scheduleFetch(releaseId: string): void {
           ttlMs: READY_TTL_MS,
           refreshMs: READY_REVALIDATE_MS,
         });
+        return manifest;
       } else {
         manifestCache.set(releaseId, {
           manifest: null,
           expiresAt: Date.now() + NON_READY_TTL_MS,
         });
+        return null;
       }
     } catch (error) {
       logger.debug("Manifest fetch failed", {
         releaseId,
         error: error instanceof Error ? error.message : String(error),
       });
-      if (fetchGeneration !== cacheGeneration) return;
+      if (fetchGeneration !== cacheGeneration) return null;
       manifestCache.set(releaseId, { manifest: null, expiresAt: Date.now() + NON_READY_TTL_MS });
+      return null;
     } finally {
       const current = inFlight.get(releaseId);
       if (current?.token === token && current.generation === fetchGeneration) {
@@ -239,6 +278,9 @@ function scheduleFetch(releaseId: string): void {
       }
     }
   });
+
+  inFlight.set(releaseId, { generation: fetchGeneration, token, promise });
+  return promise;
 }
 
 /** Clear cached manifest bodies while keeping registered fetchers intact. */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.797";
+export const VERSION = "0.1.798";


### PR DESCRIPTION
## Summary
- await one ready release manifest snapshot during HTML shell generation
- use that same snapshot for import-map rewriting, hydration data, preload hints, and release CSS
- add cold first-render and concurrent async manifest cache regressions
- bump veryfront-code to 0.1.798

## Root cause
Cold renderer pods could build a mixed production shell. The import map read the release manifest before the async cache fetch completed, while module preloads or CSS could read it later in the same render. That mixed CDN React with manifest-backed assets and can split React identity during hydration, producing `useContext` / `useEffect` null crashes.

## Verification
- `deno fmt --check deno.json src/release-assets/manifest-cache.ts src/html/html-shell-generator.ts src/html/html-shell-manifest.test.ts src/release-assets/html-consumption.test.ts src/utils/version-constant.ts`
- `deno test --no-check --allow-all src/html/html-shell-manifest.test.ts src/html/utils.test.ts src/release-assets`
- `deno check --allow-import src/release-assets/manifest-cache.ts src/html/html-shell-generator.ts src/html/html-shell-manifest.test.ts src/release-assets/html-consumption.test.ts`
- `git diff --check`
- pre-push hook: format, lint, typecheck, unit tests (`2138 passed`, `0 failed`)
