### PR TITLE
Keep release manifest cache identity aligned with HTML

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.798",
+  "version": "0.1.799",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -235,6 +235,9 @@ async function generateHTMLShellPartsImpl(
   const useDevScripts = !options.forceProductionScripts && (isLocalProject || isPreviewMode);
   const releaseManifest = options.studioEmbed
     ? null
+    : "releaseAssetManifest" in options
+    ? (options as HTMLGenerationOptions & { releaseAssetManifest?: ReleaseAssetManifest | null })
+      .releaseAssetManifest ?? null
     : await profilePhase("html.release_asset_manifest", () =>
       getReadyManifestForRenderAsync(options.releaseId));
 

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -226,6 +226,7 @@ export class HTMLGenerator {
       buildImportMapJson({
         projectDir: this.config.projectDir,
         config: this.config.config,
+        releaseAssetManifest: context.options?.releaseAssetManifest,
       }),
     ]);
 
@@ -480,6 +481,7 @@ export class HTMLGenerator {
       isLocalProject: this.config.mode === "development",
       noHmr: context.options?.noHmr,
       forceProductionScripts: context.options?.forceProductionScripts,
+      releaseAssetManifest: context.options?.releaseAssetManifest,
     }));
   }
 

--- a/src/rendering/orchestrator/types.ts
+++ b/src/rendering/orchestrator/types.ts
@@ -2,6 +2,7 @@ import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import type { RenderResult } from "#veryfront/types";
 import type { BuildVersion } from "#veryfront/utils/version.ts";
+import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 
 export type { RenderResult };
 
@@ -50,6 +51,8 @@ export interface RenderOptions {
   contentSourceId?: string;
   /** Release ID for production renders (drives release asset manifest consumption) */
   releaseId?: string;
+  /** Request-scoped ready release asset manifest, shared by cache keys and HTML generation. */
+  releaseAssetManifest?: ReleaseAssetManifest | null;
   /** Skip cache check in pipeline (cache already checked by Renderer) */
   skipCacheCheck?: boolean;
   /** Skip cache persistence (used for prefetch/aux renders like CSS generation) */

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -1,6 +1,16 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { buildRenderCachePrefix } from "#veryfront/cache/keys.ts";
+import { RELEASE_ASSET_MANIFEST_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
+import {
+  clearReleaseAssetManifestCache,
+  configureReleaseAssetManifestFetcher,
+} from "#veryfront/release-assets/manifest-cache.ts";
+import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
+import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import type { CachePayload, CacheStore } from "./cache/types.ts";
+import type { RenderContext } from "./context/render-context.ts";
 import { destroyRenderer, getRenderer, initializeRenderer, Renderer } from "./renderer.ts";
 
 function getEnv(name: string): string | undefined {
@@ -49,6 +59,73 @@ function createProjectSlotManager(limit: number) {
   }
 
   return { acquire, release, getCount, getCounts };
+}
+
+function createInMemoryStore(): CacheStore & { data: Map<string, CachePayload> } {
+  const data = new Map<string, CachePayload>();
+  return {
+    data,
+    get: (key: string) => Promise.resolve(data.get(key)),
+    set(key: string, value: CachePayload) {
+      data.set(key, value);
+      return Promise.resolve();
+    },
+    delete(key: string) {
+      data.delete(key);
+      return Promise.resolve();
+    },
+    deleteByPrefix(prefix: string) {
+      let deleted = 0;
+      for (const key of data.keys()) {
+        if (!key.startsWith(prefix)) continue;
+        data.delete(key);
+        deleted++;
+      }
+      return Promise.resolve(deleted);
+    },
+    clear() {
+      data.clear();
+      return Promise.resolve();
+    },
+    destroy() {
+      data.clear();
+      return Promise.resolve();
+    },
+  };
+}
+
+function makeReadyManifest(): ReleaseAssetManifest {
+  return {
+    schemaVersion: 1,
+    projectId: "proj-1",
+    releaseId: "rel-1",
+    releaseVersion: 1,
+    manifestVersion: 1,
+    builderVersion: "0.1.799",
+    sourceContentHash: "",
+    createdAt: "2026-06-14T00:00:00.000Z",
+    assetBasePath: "/_vf/assets",
+    modules: {},
+    css: [],
+    routes: {},
+    dependencies: {},
+    fallback: { mode: "jit", gaps: [] },
+  };
+}
+
+function makeRenderContext(): RenderContext {
+  return {
+    projectId: "proj-1",
+    projectSlug: "proj-1",
+    projectDir: "/project",
+    config: {} as RenderContext["config"],
+    mode: "production",
+    adapter: {} as RenderContext["adapter"],
+    cachePrefix: buildRenderCachePrefix("proj-1", "production", "rel-1"),
+    environment: "production",
+    contentSourceId: "release-rel-1",
+    releaseId: "rel-1",
+  };
 }
 
 describe("Renderer helpers", () => {
@@ -168,6 +245,100 @@ describe("Renderer helpers", () => {
     it("should parse default max concurrent as 30", () => {
       assertEquals(parseInt("30", 10), 30);
     });
+  });
+});
+
+describe("Renderer release asset cache isolation", () => {
+  const originalManifestFlag = getHostEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG);
+
+  afterEach(() => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, originalManifestFlag ?? "");
+    configureReleaseAssetManifestFetcher(undefined);
+    clearReleaseAssetManifestCache();
+  });
+
+  it("checks the manifest-versioned cache prefix after awaiting a ready manifest", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({ state: "ready", manifest: makeReadyManifest() })
+    );
+
+    const store = createInMemoryStore();
+    const manifestPrefix = buildRenderCachePrefix("proj-1", "production", "rel-1", 1);
+    store.data.set(`${manifestPrefix}:page:/cached`, {
+      result: {
+        html: "<html>manifest cache hit</html>",
+        frontmatter: {},
+        headings: [],
+        stream: null,
+        ssrHash: "cached",
+      },
+      storedAt: Date.now(),
+    });
+
+    const renderer = new Renderer({ cache: { store } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    (renderer as unknown as {
+      createServicesForContext: () => never;
+    }).createServicesForContext = () => {
+      throw new Error("renderer should hit the manifest-versioned cache");
+    };
+
+    const result = await renderer.renderPage("/cached", makeRenderContext(), {
+      environment: "production",
+      releaseId: "rel-1",
+    });
+
+    assertEquals(result.html, "<html>manifest cache hit</html>");
+  });
+
+  it("persists rendered HTML under the manifest-versioned cache prefix", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({ state: "ready", manifest: makeReadyManifest() })
+    );
+
+    const store = createInMemoryStore();
+    const renderer = new Renderer({ cache: { store } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: (
+            slug: string,
+            options?: { releaseAssetManifest?: ReleaseAssetManifest | null },
+          ) => Promise<{
+            html: string;
+            frontmatter: Record<string, unknown>;
+            headings: never[];
+            stream: null;
+          }>;
+        };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: (_slug, options) => {
+          assertEquals(options?.releaseAssetManifest?.manifestVersion, 1);
+          return Promise.resolve({
+            html: "<html>fresh manifest render</html>",
+            frontmatter: {},
+            headings: [],
+            stream: null,
+          });
+        },
+      },
+    });
+
+    const result = await renderer.renderPage("/fresh", makeRenderContext(), {
+      environment: "production",
+      releaseId: "rel-1",
+    });
+
+    const manifestPrefix = buildRenderCachePrefix("proj-1", "production", "rel-1", 1);
+    const jitPrefix = buildRenderCachePrefix("proj-1", "production", "rel-1");
+    assertEquals(result.html, "<html>fresh manifest render</html>");
+    assertEquals(store.data.has(`${manifestPrefix}:page:/fresh`), true);
+    assertEquals(store.data.has(`${jitPrefix}:page:/fresh`), false);
   });
 });
 

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -34,8 +34,13 @@ import { rendererLogger } from "#veryfront/utils";
 import { MDXCacheAdapter } from "#veryfront/transforms/mdx/index.ts";
 import { INITIALIZATION_ERROR, SERVICE_OVERLOADED } from "#veryfront/errors/error-registry.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
-import { buildQueryAwareCacheKey, type QueryParamCacheOptions } from "#veryfront/cache/keys.ts";
+import {
+  buildQueryAwareCacheKey,
+  buildRenderCachePrefix,
+  type QueryParamCacheOptions,
+} from "#veryfront/cache/keys.ts";
 import { getEnvNumber } from "#veryfront/compat/process.ts";
+import { getReadyManifestForRenderAsync } from "#veryfront/release-assets/manifest-cache.ts";
 import {
   createRenderContext,
   createRenderContextFromEnriched,
@@ -80,6 +85,7 @@ import {
   RENDER_PER_PROJECT_LIMIT,
   renderSemaphore,
 } from "./renderer-concurrency.ts";
+import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 
 const logger = rendererLogger.component("renderer");
 
@@ -129,7 +135,9 @@ interface CachedRenderData {
  * be consumed once). This prevents "body already consumed" errors while
  * still avoiding duplicate render work.
  *
- * The Singleflight key includes: projectId, environment, releaseId, slug, colorScheme
+ * The Singleflight key includes cache prefix, slug, and colorScheme. The prefix
+ * includes release and manifest version when a ready release asset manifest is
+ * consumed, so JIT and manifest-backed renders never share in-flight work.
  */
 export class Renderer {
   private cache: ContextAwareCacheCoordinator;
@@ -140,7 +148,7 @@ export class Renderer {
   /**
    * Singleflight for render deduplication. Caches HTML string results so
    * concurrent requests for the same page share the render work.
-   * Key format: {projectId}:{environment}:{releaseId}:{slug}:{colorScheme}
+   * Key format: {cachePrefix}:{slug}:{colorScheme}
    */
   private renderFlight = new Singleflight<CachedRenderData>();
 
@@ -185,25 +193,31 @@ export class Renderer {
           environment: ctx.environment,
         });
 
-        const cacheKey = this.buildCacheKey(slug, ctx, options);
+        const releaseManifest = await this.resolveReleaseAssetManifest(ctx, options);
+        const effectiveCtx = this.withManifestCachePrefix(ctx, releaseManifest);
+        const effectiveOptions = {
+          ...options,
+          releaseAssetManifest: releaseManifest,
+        };
+        const cacheKey = this.buildCacheKey(slug, effectiveCtx, effectiveOptions);
         const cacheResult = cacheKey
-          ? await this.cache.checkCache(slug, ctx, options?.colorScheme, cacheKey)
+          ? await this.cache.checkCache(slug, effectiveCtx, effectiveOptions?.colorScheme, cacheKey)
           : { hit: false, cacheKey: "" };
         if (cacheResult.hit && cacheResult.cachedResult) {
           logger.debug("Cache hit", {
             slug,
-            projectId: ctx.projectId,
-            colorScheme: options?.colorScheme,
+            projectId: effectiveCtx.projectId,
+            colorScheme: effectiveOptions?.colorScheme,
             duration: `${(performance.now() - startTime).toFixed(2)}ms`,
           });
           return cacheResult.cachedResult;
         }
 
-        if (!(await acquireProjectSlot(ctx.projectId))) {
-          const activeCount = projectRenderCounts.get(ctx.projectId) ?? 0;
+        if (!(await acquireProjectSlot(effectiveCtx.projectId))) {
+          const activeCount = projectRenderCounts.get(effectiveCtx.projectId) ?? 0;
           logger.error("Per-project render limit reached", {
             slug,
-            projectId: ctx.projectId,
+            projectId: effectiveCtx.projectId,
             activeRenders: activeCount,
             limit: RENDER_PER_PROJECT_LIMIT,
           });
@@ -221,10 +235,10 @@ export class Renderer {
 
         const acquired = await renderSemaphore.tryAcquire(RENDER_ACQUIRE_TIMEOUT_MS);
         if (!acquired) {
-          await releaseProjectSlot(ctx.projectId);
+          await releaseProjectSlot(effectiveCtx.projectId);
           logger.error("Render capacity exceeded - service overloaded", {
             slug,
-            projectId: ctx.projectId,
+            projectId: effectiveCtx.projectId,
             waiting: renderSemaphore.waiting,
             available: renderSemaphore.available,
           });
@@ -236,10 +250,10 @@ export class Renderer {
         }
 
         try {
-          return await this.doRenderPage(slug, ctx, options, startTime, cacheKey);
+          return await this.doRenderPage(slug, effectiveCtx, effectiveOptions, startTime, cacheKey);
         } finally {
           renderSemaphore.release();
-          await releaseProjectSlot(ctx.projectId);
+          await releaseProjectSlot(effectiveCtx.projectId);
         }
       },
       {
@@ -248,6 +262,34 @@ export class Renderer {
         "renderer.environment": ctx.environment,
       },
     );
+  }
+
+  private async resolveReleaseAssetManifest(
+    ctx: RenderContext,
+    options?: RenderOptions,
+  ): Promise<ReleaseAssetManifest | null> {
+    if (options && "releaseAssetManifest" in options) {
+      return options.releaseAssetManifest ?? null;
+    }
+    if (options?.studioEmbed || ctx.environment !== "production") return null;
+    return await getReadyManifestForRenderAsync(ctx.releaseId);
+  }
+
+  private withManifestCachePrefix(
+    ctx: RenderContext,
+    releaseManifest: ReleaseAssetManifest | null,
+  ): RenderContext {
+    if (!releaseManifest || ctx.environment !== "production") return ctx;
+    const releaseKey = ctx.releaseId ?? ctx.contentSourceId.replace(/^release-/, "");
+    return {
+      ...ctx,
+      cachePrefix: buildRenderCachePrefix(
+        ctx.projectId,
+        ctx.environment,
+        releaseKey,
+        releaseManifest.manifestVersion,
+      ),
+    };
   }
 
   /**
@@ -259,9 +301,7 @@ export class Renderer {
     ctx: RenderContext,
     colorScheme?: "light" | "dark",
   ): string {
-    return `${ctx.projectId}:${ctx.environment}:${ctx.contentSourceId ?? "draft"}:${slug}:${
-      colorScheme ?? "default"
-    }`;
+    return `${ctx.cachePrefix}:${slug}:${colorScheme ?? "default"}`;
   }
 
   /**

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.798";
+export const VERSION = "0.1.799";


### PR DESCRIPTION
## Summary
- resolve one ready release asset manifest snapshot before production render cache lookup
- pass that same snapshot through renderer options into full-document and shell HTML generation
- key cache lookup, cache persistence, and singleflight by the manifest-versioned cache prefix
- bump package version to 0.1.799 so release automation publishes a new veryfront-code build

## Why
PR #2423 made shell rendering await the ready manifest, but the outer renderer cache prefix could still come from a cold non-blocking lookup. That allowed manifest-backed HTML to be cached under the no-manifest prefix. This PR makes the renderer snapshot authoritative for both cache identity and emitted HTML.

## Tests
- deno fmt --check targeted files
- deno lint targeted renderer/html files
- deno test --no-check --allow-all src/rendering/renderer.test.ts src/html/html-shell-manifest.test.ts src/release-assets/html-consumption.test.ts
- deno check --allow-import targeted renderer/html files
- git diff --check
- pre-push: format, lint, typecheck, unit tests: 2140 passed, 0 failed

Related: #2423 review comment https://github.com/veryfront/veryfront-code/pull/2423#discussion_r3408895994