### PR TITLE
Preserve release manifest fallback for undefined snapshots

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.799",
+  "version": "0.1.800",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -233,11 +233,13 @@ async function generateHTMLShellPartsImpl(
   // Enable dev scripts for local dev OR preview mode (for HMR support in Studio),
   // unless a caller explicitly forces production client scripts for fair benchmarking.
   const useDevScripts = !options.forceProductionScripts && (isLocalProject || isPreviewMode);
+  const explicitReleaseManifest =
+    (options as HTMLGenerationOptions & { releaseAssetManifest?: ReleaseAssetManifest | null })
+      .releaseAssetManifest;
   const releaseManifest = options.studioEmbed
     ? null
-    : "releaseAssetManifest" in options
-    ? (options as HTMLGenerationOptions & { releaseAssetManifest?: ReleaseAssetManifest | null })
-      .releaseAssetManifest ?? null
+    : explicitReleaseManifest !== undefined
+    ? explicitReleaseManifest
     : await profilePhase("html.release_asset_manifest", () =>
       getReadyManifestForRenderAsync(options.releaseId));
 

--- a/src/html/html-shell-manifest.test.ts
+++ b/src/html/html-shell-manifest.test.ts
@@ -194,6 +194,25 @@ describe("html shell release asset manifest consumption", () => {
     assertStringIncludes(result.start, `"react":"/_vf/assets/${REACT_HASH}.js"`);
   });
 
+  it("treats an undefined manifest option as absent and fetches the ready manifest", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({ state: "ready", manifest: manifest() })
+    );
+
+    const result = await generateHTMLShellParts(
+      meta(),
+      prodOptions(
+        {
+          releaseId: "rel-1",
+          releaseAssetManifest: undefined,
+        } as Partial<HTMLGenerationOptions> & { releaseAssetManifest?: ReleaseAssetManifest },
+      ),
+    );
+
+    assertStringIncludes(result.start, `/_vf/assets/${PAGE_HASH}.js`);
+  });
+
   it("keeps covered framework import-map entries on the module-server path", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     configureReleaseAssetManifestFetcher(() =>

--- a/src/rendering/orchestrator/html.test.ts
+++ b/src/rendering/orchestrator/html.test.ts
@@ -1,7 +1,14 @@
 import "#veryfront/schemas/_test-setup.ts";
 import "../../html/styles-builder/__tests__/css-processor-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import { RELEASE_ASSET_MANIFEST_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
+import {
+  clearReleaseAssetManifestCache,
+  configureReleaseAssetManifestFetcher,
+} from "#veryfront/release-assets/manifest-cache.ts";
+import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import { type HTMLGeneratorConfig } from "./html.ts";
 import { buildHeadElements, mergeFrontmatter } from "./html-head.ts";
 import { mergeImportedCSS } from "./html-imported-css.ts";
@@ -18,7 +25,43 @@ type Head = {
   styles: string[];
 };
 
+const REACT_HASH = "e".repeat(64);
+const REACT_CDN_URL = "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3";
+
+function releaseManifest(): ReleaseAssetManifest {
+  return {
+    schemaVersion: 1,
+    projectId: "p",
+    releaseId: "rel-1",
+    releaseVersion: 1,
+    manifestVersion: 1,
+    builderVersion: "0.1.800",
+    sourceContentHash: "",
+    createdAt: "2026-06-12T00:00:00.000Z",
+    assetBasePath: "/_vf/assets",
+    modules: {},
+    css: [],
+    routes: {},
+    dependencies: {
+      [REACT_CDN_URL]: {
+        contentHash: REACT_HASH,
+        size: 1,
+        contentType: "text/javascript",
+      },
+    },
+    fallback: { mode: "jit", gaps: [] },
+  };
+}
+
 describe("HTMLGenerator helpers", () => {
+  const originalManifestFlag = getHostEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG);
+
+  afterEach(() => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, originalManifestFlag ?? "");
+    configureReleaseAssetManifestFetcher(undefined);
+    clearReleaseAssetManifestCache();
+  });
+
   describe("buildHeadElements", () => {
     it("should return empty string for undefined head", () => {
       assertEquals(buildHeadElements(undefined), { scripts: "", other: "" });
@@ -225,6 +268,26 @@ describe("HTMLGenerator helpers", () => {
       }));
 
       assertEquals(html.includes('<script type="importmap" nonce="nonce-123">'), true);
+    });
+
+    it("treats an undefined manifest option as absent for full HTML import maps", async () => {
+      setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+      configureReleaseAssetManifestFetcher(() =>
+        Promise.resolve({ state: "ready", manifest: releaseManifest() })
+      );
+      const generator = createHTMLGenerator({
+        readFile: async (path: string) => path.endsWith("/app/page.tsx") ? `'use client';` : "",
+      });
+
+      const html = await generator.generateFullHTML(createHTMLContext({
+        options: {
+          environment: "production",
+          releaseId: "rel-1",
+          releaseAssetManifest: undefined,
+        },
+      }));
+
+      assertStringIncludes(html, `/_vf/assets/${REACT_HASH}.js`);
     });
 
     it("injects preview utility CSS into full HTML documents for preview rendering", async () => {

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -15,6 +15,8 @@ import { addNonceToHtmlTags } from "#veryfront/html/nonce-injection.ts";
 import { injectElementSelectors } from "#veryfront/studio/element-selector-injector.ts";
 import { computeSourceHash } from "#veryfront/studio/hash-utils.ts";
 import { extractRelativePath } from "#veryfront/utils/route-path-utils.ts";
+import { getReadyManifestForRenderAsync } from "#veryfront/release-assets/manifest-cache.ts";
+import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import { resolveAppComponentPath } from "../layouts/utils/app-resolver.ts";
 import { StreamTimeoutError, streamToString } from "../utils/stream-utils.ts";
 import { profilePhase, profileSyncPhase } from "#veryfront/observability/request-profiler.ts";
@@ -48,6 +50,25 @@ function resolveReleaseId(
   const source = options?.contentSourceId;
   if (source && source.startsWith("release-")) return source.slice("release-".length);
   return undefined;
+}
+
+type OptionsWithReleaseAssetManifest = {
+  studioEmbed?: boolean;
+  releaseId?: string;
+  contentSourceId?: string;
+  releaseAssetManifest?: ReleaseAssetManifest | null;
+};
+
+async function resolveReleaseAssetManifestForHTML(
+  options: OptionsWithReleaseAssetManifest | undefined,
+): Promise<ReleaseAssetManifest | null> {
+  if (options?.studioEmbed) return null;
+  if (options?.releaseAssetManifest !== undefined) return options.releaseAssetManifest;
+
+  return await profilePhase(
+    "html.release_asset_manifest",
+    () => getReadyManifestForRenderAsync(resolveReleaseId(options)),
+  );
 }
 
 function applyExplicitThemeToDocument(
@@ -221,14 +242,15 @@ export class HTMLGenerator {
     );
 
     const pagePath = context.pageInfo.entity.path;
-    const [isClientPage, importMapJson] = await Promise.all([
+    const [isClientPage, releaseAssetManifest] = await Promise.all([
       this.detectUseClientDirective(pagePath),
-      buildImportMapJson({
-        projectDir: this.config.projectDir,
-        config: this.config.config,
-        releaseAssetManifest: context.options?.releaseAssetManifest,
-      }),
+      resolveReleaseAssetManifestForHTML(context.options),
     ]);
+    const importMapJson = await buildImportMapJson({
+      projectDir: this.config.projectDir,
+      config: this.config.config,
+      releaseAssetManifest,
+    });
 
     const themedHtml = injectThemePersistenceScript(
       applyExplicitThemeToDocument(
@@ -481,7 +503,9 @@ export class HTMLGenerator {
       isLocalProject: this.config.mode === "development",
       noHmr: context.options?.noHmr,
       forceProductionScripts: context.options?.forceProductionScripts,
-      releaseAssetManifest: context.options?.releaseAssetManifest,
+      ...(context.options?.releaseAssetManifest !== undefined
+        ? { releaseAssetManifest: context.options.releaseAssetManifest }
+        : {}),
     }));
   }
 

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -268,8 +268,8 @@ export class Renderer {
     ctx: RenderContext,
     options?: RenderOptions,
   ): Promise<ReleaseAssetManifest | null> {
-    if (options && "releaseAssetManifest" in options) {
-      return options.releaseAssetManifest ?? null;
+    if (options?.releaseAssetManifest !== undefined) {
+      return options.releaseAssetManifest;
     }
     if (options?.studioEmbed || ctx.environment !== "production") return null;
     return await getReadyManifestForRenderAsync(ctx.releaseId);

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.799";
+export const VERSION = "0.1.800";


### PR DESCRIPTION
## Summary
- treat releaseAssetManifest: undefined as absent instead of explicit null
- only pass releaseAssetManifest from HTMLGenerator when it is explicitly set
- preserve async ready-manifest fallback for RenderPipeline/VeryfrontRenderer paths with a releaseId
- bump veryfront-code to 0.1.800 for a new release

## Why
PR #2424 merged before its review follow-up could land. The review was correct: optional chaining could add releaseAssetManifest: undefined, which suppressed getReadyManifestForRenderAsync() and fell back to JIT/CDN assets. This PR keeps explicit null as the opt-out state and lets undefined use the normal fallback.

## Tests
- deno fmt --check targeted files
- deno lint targeted renderer/html files
- deno test --no-check --allow-all src/rendering/renderer.test.ts src/html/html-shell-manifest.test.ts src/release-assets/html-consumption.test.ts
- deno check --allow-import targeted renderer/html files
- git diff --check

Related: #2424 review comment https://github.com/veryfront/veryfront-code/pull/2424#discussion_r3408910333