### PR TITLE
Preserve snake_case tool-role replay results

### DIFF
--- a/src/agent/runtime/text-generation-runtime-message-converter.test.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.test.ts
@@ -212,6 +212,33 @@ describe("text-generation-runtime-message-converter", () => {
       });
     });
 
+    it("converts a stored snake_case tool result message", () => {
+      const msg = {
+        id: "t-snake",
+        role: "tool",
+        parts: [
+          {
+            type: "tool_result",
+            tool_call_id: "tc-snake",
+            tool_name: "harvest__list_users",
+            output: { users: [{ id: 1, name: "Ada" }] },
+          },
+        ],
+      } as unknown as Message;
+
+      const result = convertToTextGenerationRuntimeMessage(msg);
+
+      assertEquals(result.role, "tool");
+      assertEquals((result as TextGenerationRuntimeToolMessage).content, [
+        {
+          type: "tool-result",
+          toolCallId: "tc-snake",
+          toolName: "harvest__list_users",
+          output: { type: "json", value: { users: [{ id: 1, name: "Ada" }] } },
+        },
+      ]);
+    });
+
     it("handles tool result with missing toolName", () => {
       const msg: Message = {
         id: "t2",

--- a/src/agent/runtime/text-generation-runtime-message-converter.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.ts
@@ -17,13 +17,7 @@ import type {
   TextGenerationRuntimeToolResultPart,
 } from "./text-generation-runtime-message-types.ts";
 import { buildDataFileAnnotation } from "#veryfront/chat/types.ts";
-import {
-  getTextFromParts,
-  getToolArguments,
-  type Message,
-  type ToolCallPart,
-  type ToolResultPart,
-} from "../types.ts";
+import { getTextFromParts, getToolArguments, type Message, type ToolCallPart } from "../types.ts";
 
 function getStringPartField(part: unknown, key: string): string | undefined {
   if (!part || typeof part !== "object" || Array.isArray(part)) return undefined;
@@ -297,22 +291,19 @@ export function convertToTextGenerationRuntimeMessage(
 
     case "tool": {
       const content: TextGenerationRuntimeToolMessage["content"] = [];
+      const toolNamesById = new Map<string, string>();
 
       for (const part of msg.parts) {
-        if (part.type !== "tool-result") continue;
-
-        const resultPart = part as ToolResultPart;
         if (
-          shouldSkipProviderExecutedToolResult(resultPart, providerExecutedToolCallIds)
+          shouldSkipProviderExecutedToolResult(part, providerExecutedToolCallIds)
         ) {
           continue;
         }
-        content.push({
-          type: "tool-result",
-          toolCallId: resultPart.toolCallId,
-          toolName: resultPart.toolName ?? "unknown",
-          output: { type: "json", value: resultPart.result },
-        });
+
+        const toolResultPart = getTextGenerationToolResultPart(part, toolNamesById);
+        if (toolResultPart) {
+          content.push(toolResultPart);
+        }
       }
 
       const toolMessage: TextGenerationRuntimeToolMessage = { role: "tool", content };


### PR DESCRIPTION
## Summary
- Preserve stored snake_case `tool_result` parts when they are already split into `role: "tool"` replay messages.
- Reuse the existing tool-result normalizer so both `result` and `output`, camelCase and snake_case fields, reach the text-generation runtime.
- Add a regression test for API-style `role: "tool"` + `type: "tool_result"` + `output` history.

## Root cause
API replay normalization can split persisted assistant inline tool results into separate tool-role messages with snake_case parts. `convertToTextGenerationRuntimeMessage()` only handled hyphen-case `tool-result` parts in the `role: "tool"` branch, so these nearby tool results were converted to empty content and then dropped before the next model call.

## Verification
- `deno test src/agent/runtime/text-generation-runtime-message-converter.test.ts src/agent/runtime/message-adapter.test.ts`
- `deno test --allow-env src/agent/runtime/agent-invocation-contract.test.ts`
- pre-push hook: format, lint, type check, full unit tests (`2141 passed`)
