### PR TITLE
Hydrate skill state from hosted tool history

### DIFF
--- a/src/agent/runtime/skill-policy-enforcement.ts
+++ b/src/agent/runtime/skill-policy-enforcement.ts
@@ -15,6 +15,35 @@ const logger = serverLogger.component("agent");
 export const LOAD_SKILL_TOOL_ID = "load_skill";
 export const FORM_INPUT_TOOL_ID = "form_input";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function getStringField(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const field = value[key];
+  return typeof field === "string" && field.length > 0 ? field : undefined;
+}
+
+function getToolCallId(part: unknown): string | undefined {
+  return getStringField(part, "toolCallId") ??
+    getStringField(part, "tool_call_id") ??
+    getStringField(part, "id");
+}
+
+function getToolName(part: unknown): string | undefined {
+  return getStringField(part, "toolName") ??
+    getStringField(part, "tool_name") ??
+    getStringField(part, "name");
+}
+
+function getToolResultPayload(part: unknown): unknown {
+  if (!isRecord(part)) return undefined;
+  if (Object.hasOwn(part, "result")) return part.result;
+  if (Object.hasOwn(part, "output")) return part.output;
+  return undefined;
+}
+
 function getSkillActivationRequiredError(toolName: string): string {
   return `Tool "${toolName}" cannot run before load_skill succeeds in the same step. ` +
     `Call "${LOAD_SKILL_TOOL_ID}" first to establish the active skill context.`;
@@ -30,13 +59,28 @@ export function hydrateActiveSkillStateFromMessages(
   let activeSkillId: string | undefined;
   let activeSkillPolicy: string[] | undefined;
   let activeSkillDelegationOverrides: SkillDelegationOverrides | undefined;
+  const toolNamesById = new Map<string, string>();
 
   for (const message of messages) {
     for (const part of message.parts) {
-      if (!isToolResultPart(part) || part.toolName !== LOAD_SKILL_TOOL_ID) continue;
-      activeSkillId = extractSkillId(part.result);
-      activeSkillPolicy = extractSkillPolicy(part.result);
-      activeSkillDelegationOverrides = extractSkillDelegationOverrides(part.result);
+      const toolCallId = getToolCallId(part);
+      const toolName = getToolName(part);
+      if (toolCallId && toolName) {
+        toolNamesById.set(toolCallId, toolName);
+      }
+
+      const isToolResult = isToolResultPart(part) ||
+        (isRecord(part) && part.type === "tool_result");
+      if (!isToolResult) continue;
+
+      const resultToolName = toolName ??
+        (toolCallId ? toolNamesById.get(toolCallId) : undefined);
+      if (resultToolName !== LOAD_SKILL_TOOL_ID) continue;
+
+      const result = getToolResultPayload(part);
+      activeSkillId = extractSkillId(result);
+      activeSkillPolicy = extractSkillPolicy(result);
+      activeSkillDelegationOverrides = extractSkillDelegationOverrides(result);
     }
   }
 

--- a/src/agent/runtime/skill-policy.test.ts
+++ b/src/agent/runtime/skill-policy.test.ts
@@ -393,5 +393,43 @@ describe("src/agent/runtime skill policy helpers", () => {
         maxSteps: 8,
       });
     });
+
+    it("hydrates load_skill state from hosted inline snake_case tool history", () => {
+      const messages = [
+        {
+          id: "assistant_inline_tools",
+          role: "assistant",
+          parts: [
+            { type: "text", text: "Loading the skill." },
+            {
+              type: "tool_call",
+              id: "toolu_load_skill",
+              name: "load_skill",
+              input: { skillId: "review-timesheets" },
+              state: "completed",
+            },
+            {
+              type: "tool_result",
+              tool_call_id: "toolu_load_skill",
+              output: {
+                skillId: "review-timesheets",
+                allowedTools: ["get-current-date", "harvest__list_users"],
+                model: "anthropic/claude-opus-4-6",
+                maxSteps: 100,
+              },
+            },
+          ],
+        },
+      ] as unknown as Message[];
+
+      const hydrated = hydrateActiveSkillStateFromMessages(messages);
+
+      assertEquals(hydrated.activeSkillId, "review-timesheets");
+      assertEquals(hydrated.activeSkillPolicy, ["get-current-date", "harvest__list_users"]);
+      assertEquals(hydrated.activeSkillDelegationOverrides, {
+        model: "anthropic/claude-opus-4-6",
+        maxSteps: 100,
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Hydrate active skill state from hosted inline `tool_call` / `tool_result` history.
- Resolve snake_case tool results back to their tool names via prior tool-call IDs.
- Add regression coverage for the production message shape from veryfront-studio#4925.

## Evidence
- Staging DB run `99c588fd-4712-41c7-8801-60ccb4a53f18` persisted all 55 tool results (`0` unmatched starts), but stored them inline with snake_case parts.
- The failing run looped: `load_skill_reference=19`, `load_skill=15`, `harvest__list_time_entries=9`, `get-current-date=7`, `harvest__list_users=5`.
- The persisted `tool_result` parts have `tool_call_id` + `output`, while the tool name lives on the preceding `tool_call` part, so replay hydration missed `load_skill` state before this fix.

## Tests
- `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/agent/runtime/skill-policy.test.ts` (red before fix, green after)
- `deno task test src/agent/runtime/skill-policy.test.ts src/agent/runtime/text-generation-runtime-message-converter.test.ts src/agent/runtime/message-adapter.test.ts src/agent/runtime/load-skill-tool.test.ts`

## Pre-push
- Full pre-push formatting/lint/typecheck passed.
- Full unit pre-push hit unrelated existing failures:
  - `src/observability/metrics/config.test.ts`: expected exporter `console`, actual `otlp`
  - `src/server/build-app-route-renderer.test.ts`: expected `data-testid="app-layout"` in rendered HTML