### PR TITLE
Infer AG-UI tool result names

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.800",
+  "version": "0.1.801",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/ag-ui/host-support.test.ts
+++ b/src/agent/ag-ui/host-support.test.ts
@@ -183,6 +183,190 @@ describe("agent/ag-ui-host-support", () => {
     ]);
   });
 
+  it("infers stored snake_case tool-result names from preceding tool calls", () => {
+    const messages = normalizeAgUiMessages([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool_call",
+            id: "tool-1",
+            name: "harvest__list_users",
+            input: { accountId: "2029314" },
+            state: "completed",
+          },
+          {
+            type: "tool_result",
+            tool_call_id: "tool-1",
+            output: { users: [{ id: 1, name: "Ada" }] },
+          },
+        ],
+      },
+    ]);
+
+    assertEquals(messages, [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-call",
+            toolCallId: "tool-1",
+            toolName: "harvest__list_users",
+            args: { accountId: "2029314" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tool-1",
+            toolName: "harvest__list_users",
+            result: { users: [{ id: 1, name: "Ada" }] },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("infers camelCase tool-result names from preceding tool calls", () => {
+    const messages = normalizeAgUiMessages([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-call",
+            toolCallId: "tool-1",
+            toolName: "search_docs",
+            args: { query: "docs" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tool-1",
+            result: { matches: 2 },
+          },
+        ],
+      },
+    ]);
+
+    assertEquals(messages[0]?.parts, [
+      {
+        type: "tool-call",
+        toolCallId: "tool-1",
+        toolName: "search_docs",
+        args: { query: "docs" },
+      },
+      {
+        type: "tool-result",
+        toolCallId: "tool-1",
+        toolName: "search_docs",
+        result: { matches: 2 },
+      },
+    ]);
+  });
+
+  it("infers tool-result names across assistant and tool messages", () => {
+    const messages = normalizeAgUiMessages([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{
+          type: "tool_call",
+          id: "tool-1",
+          name: "harvest__list_users",
+          input: { accountId: "2029314" },
+        }],
+      },
+      {
+        id: "tool-1-result",
+        role: "tool",
+        parts: [{
+          type: "tool_result",
+          tool_call_id: "tool-1",
+          output: { users: [{ id: 1, name: "Ada" }] },
+        }],
+      },
+    ]);
+
+    assertEquals(messages[1]?.parts, [{
+      type: "tool-result",
+      toolCallId: "tool-1",
+      toolName: "harvest__list_users",
+      result: { users: [{ id: 1, name: "Ada" }] },
+    }]);
+  });
+
+  it("keeps unknown for tool results without a preceding call", () => {
+    const messages = normalizeAgUiMessages([
+      {
+        id: "tool-1-result",
+        role: "tool",
+        parts: [{ type: "tool_result", tool_call_id: "tool-1", output: { ok: true } }],
+      },
+    ]);
+
+    assertEquals(messages[0]?.parts, [{
+      type: "tool-result",
+      toolCallId: "tool-1",
+      toolName: "unknown",
+      result: { ok: true },
+    }]);
+  });
+
+  it("does not infer tool-result names across user boundaries", () => {
+    const messages = normalizeAgUiMessages([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{
+          type: "tool_call",
+          id: "tool-1",
+          name: "search_docs",
+          input: { query: "docs" },
+        }],
+      },
+      { id: "user-2", role: "user", parts: [{ type: "text", text: "new turn" }] },
+      {
+        id: "tool-1-result",
+        role: "tool",
+        parts: [{ type: "tool_result", tool_call_id: "tool-1", output: { matches: 2 } }],
+      },
+    ]);
+
+    assertEquals(messages[2]?.parts, [{
+      type: "tool-result",
+      toolCallId: "tool-1",
+      toolName: "unknown",
+      result: { matches: 2 },
+    }]);
+  });
+
+  it("infers tool-result names from preceding tool-prefixed call parts", () => {
+    const messages = normalizeAgUiMessages([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{
+          type: "tool-search_docs",
+          toolCallId: "tool-1",
+          toolName: "search_docs",
+          input: { query: "docs" },
+        }],
+      },
+      {
+        id: "tool-1-result",
+        role: "tool",
+        parts: [{ type: "tool_result", tool_call_id: "tool-1", output: { matches: 2 } }],
+      },
+    ]);
+
+    assertEquals(messages[1]?.parts, [{
+      type: "tool-result",
+      toolCallId: "tool-1",
+      toolName: "search_docs",
+      result: { matches: 2 },
+    }]);
+  });
+
   it("preserves tool outputs stored on assistant tool parts as tool messages", () => {
     const messages = normalizeAgUiMessages([
       {

--- a/src/agent/ag-ui/host-support.ts
+++ b/src/agent/ag-ui/host-support.ts
@@ -205,7 +205,10 @@ function shouldKeepProviderVisibleToolPart(
   return false;
 }
 
-function normalizeMessagePart(part: Record<string, unknown>): Message["parts"][number] | null {
+function normalizeMessagePart(
+  part: Record<string, unknown>,
+  toolNamesById: ReadonlyMap<string, string> = new Map(),
+): Message["parts"][number] | null {
   if (
     part.type === "text" && typeof part.text === "string" &&
     part.text.length <= MAX_TEXT_PART_LENGTH
@@ -254,7 +257,9 @@ function normalizeMessagePart(part: Record<string, unknown>): Message["parts"][n
     return {
       type: "tool-result",
       toolCallId: part.tool_call_id,
-      toolName: typeof part.tool_name === "string" ? part.tool_name : "unknown",
+      toolName: typeof part.tool_name === "string"
+        ? part.tool_name
+        : toolNamesById.get(part.tool_call_id) ?? "unknown",
       result: "output" in part ? part.output : undefined,
     };
   }
@@ -263,7 +268,9 @@ function normalizeMessagePart(part: Record<string, unknown>): Message["parts"][n
     return {
       type: "tool-result",
       toolCallId: part.toolCallId,
-      toolName: typeof part.toolName === "string" ? part.toolName : "unknown",
+      toolName: typeof part.toolName === "string"
+        ? part.toolName
+        : toolNamesById.get(part.toolCallId) ?? "unknown",
       result: "result" in part ? part.result : undefined,
     };
   }
@@ -284,6 +291,7 @@ function normalizeAssistantMessage(
   message: AgUiMessage,
   providerOwnedToolNames: ReadonlySet<string>,
   providerOwnedToolCallIds: Set<string>,
+  toolNamesById: Map<string, string>,
 ): Message[] {
   const messages: Message[] = [];
   const metadataFields = buildMessageMetadataFields(message);
@@ -303,8 +311,11 @@ function normalizeAssistantMessage(
   };
 
   for (const part of message.parts) {
-    const normalizedPart = normalizeMessagePart(part);
+    const normalizedPart = normalizeMessagePart(part, toolNamesById);
     if (!normalizedPart) continue;
+    if (normalizedPart.type !== "tool-result" && "toolCallId" in normalizedPart) {
+      toolNamesById.set(normalizedPart.toolCallId, normalizedPart.toolName);
+    }
 
     if (
       !shouldKeepProviderVisibleToolPart(
@@ -361,10 +372,12 @@ export function normalizeAgUiMessages(
 ): Message[] {
   const providerOwnedToolNames = new Set(options.providerOwnedToolNames ?? []);
   const providerOwnedToolCallIds = new Set<string>();
+  const toolNamesById = new Map<string, string>();
 
   return messages.flatMap((message) => {
     if (message.role === "user" || message.role === "system") {
       providerOwnedToolCallIds.clear();
+      toolNamesById.clear();
     }
 
     if (message.role === "assistant") {
@@ -372,6 +385,7 @@ export function normalizeAgUiMessages(
         message,
         providerOwnedToolNames,
         providerOwnedToolCallIds,
+        toolNamesById,
       );
     }
 
@@ -379,7 +393,7 @@ export function normalizeAgUiMessages(
       id: message.id,
       role: message.role,
       parts: message.parts
-        .map((part) => normalizeMessagePart(part))
+        .map((part) => normalizeMessagePart(part, toolNamesById))
         .filter((part): part is Message["parts"][number] => part !== null)
         .filter((part) =>
           shouldKeepProviderVisibleToolPart(

--- a/src/agent/ag-ui/runtime-support.test.ts
+++ b/src/agent/ag-ui/runtime-support.test.ts
@@ -1,0 +1,53 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { normalizeAgUiRuntimeMessages } from "./runtime-support.ts";
+
+describe("agent/ag-ui-runtime-support", () => {
+  it("infers tool message names from preceding assistant runtime tool calls", () => {
+    const messages = normalizeAgUiRuntimeMessages([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: "",
+        toolCalls: [{
+          id: "tool-1",
+          type: "function",
+          function: {
+            name: "harvest__list_users",
+            arguments: '{"accountId":"2029314"}',
+          },
+        }],
+      },
+      {
+        id: "tool-1-result",
+        role: "tool",
+        toolCallId: "tool-1",
+        content: '{"users":[{"id":1,"name":"Ada"}]}',
+      },
+    ]);
+
+    assertEquals(messages, [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{
+          type: "tool-call",
+          toolCallId: "tool-1",
+          toolName: "harvest__list_users",
+          args: { accountId: "2029314" },
+        }],
+      },
+      {
+        id: "tool-1-result",
+        role: "tool",
+        parts: [{
+          type: "tool-result",
+          toolCallId: "tool-1",
+          toolName: "harvest__list_users",
+          result: '{"users":[{"id":1,"name":"Ada"}]}',
+        }],
+      },
+    ]);
+  });
+});

--- a/src/agent/ag-ui/runtime-support.ts
+++ b/src/agent/ag-ui/runtime-support.ts
@@ -18,12 +18,15 @@ function parseToolArguments(serializedArguments: string): Record<string, unknown
 export function normalizeAgUiRuntimeMessages(
   messages: AgUiRuntimeRequest["messages"],
 ): Message[] {
+  const toolNamesById = new Map<string, string>();
+
   return messages.map((message) => {
     const parts: Message["parts"] = [];
 
     switch (message.role) {
       case "system":
       case "user":
+        toolNamesById.clear();
         parts.push({ type: "text", text: message.content });
         break;
       case "assistant":
@@ -37,13 +40,14 @@ export function normalizeAgUiRuntimeMessages(
             toolName: toolCall.function.name,
             args: parseToolArguments(toolCall.function.arguments),
           });
+          toolNamesById.set(toolCall.id, toolCall.function.name);
         }
         break;
       case "tool":
         parts.push({
           type: "tool-result",
           toolCallId: message.toolCallId,
-          toolName: "unknown",
+          toolName: toolNamesById.get(message.toolCallId) ?? "unknown",
           result: message.error
             ? {
               content: message.content,

--- a/src/channels/invoke.test.ts
+++ b/src/channels/invoke.test.ts
@@ -286,6 +286,34 @@ describe("channels/invoke", () => {
         timestamp: Date.parse("2026-03-13T10:00:00.000Z"),
       }]);
     });
+
+    it("infers tool result names from preceding persisted tool calls", () => {
+      const normalized = normalizeConversationHistoryForRuntime([
+        {
+          id: "msg-1",
+          role: "assistant",
+          parts: [
+            { type: "tool_call", id: "tool-1", name: "search", input: { query: "docs" } },
+            { type: "tool_result", tool_call_id: "tool-1", output: { answer: 42 } },
+          ],
+        },
+      ]);
+
+      assertEquals(normalized[0]?.parts, [
+        {
+          type: "tool-search",
+          toolCallId: "tool-1",
+          toolName: "search",
+          args: { query: "docs" },
+        },
+        {
+          type: "tool-result",
+          toolCallId: "tool-1",
+          toolName: "search",
+          result: { answer: 42 },
+        },
+      ]);
+    });
   });
 
   describe("listChannelAssistants", () => {

--- a/src/channels/invoke.ts
+++ b/src/channels/invoke.ts
@@ -222,6 +222,7 @@ export { verifyDispatchJws, verifyDispatchJwsSignature } from "./control-plane.t
 
 function normalizeConversationPart(
   part: InferSchema<ReturnType<typeof getRawHistoryPartSchema>>,
+  toolNamesById: ReadonlyMap<string, string> = new Map(),
 ): Message["parts"][number] | null {
   if (part.type === "text" && typeof part.text === "string") {
     return { type: "text", text: part.text };
@@ -247,7 +248,9 @@ function normalizeConversationPart(
     return {
       type: "tool-result",
       toolCallId: part.tool_call_id,
-      toolName: typeof part.tool_name === "string" ? part.tool_name : "unknown",
+      toolName: typeof part.tool_name === "string"
+        ? part.tool_name
+        : toolNamesById.get(part.tool_call_id) ?? "unknown",
       result: "output" in part ? part.output : undefined,
     };
   }
@@ -259,15 +262,33 @@ function normalizeConversationPart(
 export function normalizeConversationHistoryForRuntime(
   messages: ChannelInvokeRequest["conversationHistory"],
 ): Message[] {
-  return messages.map((message): Message => ({
-    id: message.id,
-    role: message.role,
-    parts: message.parts
-      .map((part) => normalizeConversationPart(part))
-      .filter((part): part is NonNullable<typeof part> => part !== null),
-    ...(message.createdAt ? { timestamp: Date.parse(message.createdAt) || undefined } : {}),
-    ...(message.metadata ? { metadata: message.metadata } : {}),
-  }));
+  const toolNamesById = new Map<string, string>();
+
+  return messages.map((message): Message => {
+    if (message.role === "user" || message.role === "system") {
+      toolNamesById.clear();
+    }
+
+    const parts = message.parts
+      .map((part) => {
+        const normalizedPart = normalizeConversationPart(part, toolNamesById);
+        if (
+          normalizedPart?.type !== "tool-result" && normalizedPart && "toolCallId" in normalizedPart
+        ) {
+          toolNamesById.set(normalizedPart.toolCallId, normalizedPart.toolName);
+        }
+        return normalizedPart;
+      })
+      .filter((part): part is NonNullable<typeof part> => part !== null);
+
+    return {
+      id: message.id,
+      role: message.role,
+      parts,
+      ...(message.createdAt ? { timestamp: Date.parse(message.createdAt) || undefined } : {}),
+      ...(message.metadata ? { metadata: message.metadata } : {}),
+    };
+  });
 }
 
 /** Resolves channel invoke agent. */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.800";
+export const VERSION = "0.1.801";


### PR DESCRIPTION
## Summary
- infer AG-UI replay tool-result names from preceding tool calls when stored results only carry call ids
- apply the same inference to AG-UI runtime role:tool messages and channel conversation-history replay
- record names from accepted AG-UI tool-prefixed call parts so later result-only records can resolve by call id
- bump veryfront release version to 0.1.801

## Test Plan
- deno test --no-check --allow-all src/agent/ag-ui/host-support.test.ts
- deno test --no-check --allow-all src/agent/ag-ui/host-support.test.ts src/agent/ag-ui/runtime-support.test.ts src/channels/invoke.test.ts src/agent/runtime/text-generation-runtime-message-converter.test.ts src/agent/runtime/message-adapter.test.ts src/agent/hosted/chat-preparation.test.ts src/agent/runtime/agent-invocation-contract.test.ts
- deno fmt --check src/agent/ag-ui/host-support.ts src/agent/ag-ui/host-support.test.ts src/agent/ag-ui/runtime-support.ts src/agent/ag-ui/runtime-support.test.ts src/channels/invoke.ts src/channels/invoke.test.ts deno.json src/utils/version-constant.ts
- deno check src/index.ts
- deno test --no-check --allow-all cli/auth/callback-server.test.ts after one unrelated pre-push flake
- git push pre-push hook: format, lint, typecheck, full unit tests: 2142 passed (18529 steps), 0 failed
