### PR TITLE
Keep React client imports on release assets

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.801",
+  "version": "0.1.802",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/html/utils.test.ts
+++ b/src/html/utils.test.ts
@@ -8,6 +8,7 @@ import {
   shouldDisableLayout,
 } from "./utils.ts";
 import { getDefaultImportMap } from "#veryfront/modules/import-map/default-import-map.ts";
+import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 
 describe("html-generation/utils", () => {
   afterEach(() => {
@@ -168,6 +169,53 @@ describe("html-generation/utils", () => {
       const result = await buildImportMapJson({ pretty: false });
 
       assertEquals(result.includes("\n"), false);
+    });
+
+    it("rewrites React import-map aliases from manifest dependency keys", async () => {
+      const dependencies = Object.fromEntries(
+        [
+          "react",
+          "react-dom",
+          "react-dom/client",
+          "react/jsx-runtime",
+          "react/jsx-dev-runtime",
+        ].map((specifier, index) => [
+          specifier,
+          {
+            contentHash: `${index + 1}`.repeat(64),
+            size: 10,
+            contentType: "text/javascript",
+          },
+        ]),
+      );
+      const manifest: ReleaseAssetManifest = {
+        schemaVersion: 1,
+        projectId: "project-id",
+        releaseId: "release-id",
+        releaseVersion: 1,
+        manifestVersion: 1,
+        builderVersion: "0.1.802",
+        sourceContentHash: "source",
+        createdAt: "2026-06-14T00:00:00.000Z",
+        assetBasePath: "/_vf/assets",
+        modules: {},
+        css: [],
+        routes: {},
+        dependencies,
+        fallback: { mode: "jit", gaps: [] },
+      };
+
+      const result = await buildImportMapJson({
+        pretty: false,
+        releaseAssetManifest: manifest,
+      });
+      const imports = JSON.parse(result).imports as Record<string, string>;
+
+      assertEquals(imports.react, `/_vf/assets/${"1".repeat(64)}.js`);
+      assertEquals(imports["react-dom"], `/_vf/assets/${"2".repeat(64)}.js`);
+      assertEquals(imports["react-dom/client"], `/_vf/assets/${"3".repeat(64)}.js`);
+      assertEquals(imports["react/jsx-runtime"], `/_vf/assets/${"4".repeat(64)}.js`);
+      assertEquals(imports["react/jsx-dev-runtime"], `/_vf/assets/${"5".repeat(64)}.js`);
     });
 
     it("refreshes cached import maps when project package versions change", async () => {

--- a/src/html/utils.ts
+++ b/src/html/utils.ts
@@ -334,7 +334,8 @@ function applyManifestDependencies(
 
       return [
         specifier,
-        dependencyAssets.get(url) ?? dependencyAssets.get(canonicalDependencyUrl(url)) ?? url,
+        dependencyAssets.get(specifier) ?? dependencyAssets.get(url) ??
+          dependencyAssets.get(canonicalDependencyUrl(url)) ?? url,
       ];
     }),
   );

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -6,6 +6,8 @@ import { RELEASE_ASSET_MAX_SIZE_BYTES } from "./constants.ts";
 import {
   type ReleaseAssetBuildClient,
   type ReleaseAssetBuildInput,
+  type ReleaseAssetHttpDependencyVendor,
+  type ReleaseAssetVendorResult,
   routeForPage,
   runReleaseAssetBuild,
 } from "./build-executor.ts";
@@ -58,6 +60,49 @@ function baseInput(
     adapter: {},
     client,
     transform,
+    vendorHttpImports: fakeVendorHttpImports,
+  };
+}
+
+function fakeHttpCachePath(url: string): string {
+  const hash = Array.from(new TextEncoder().encode(url))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 32);
+  return `/tmp/veryfront-http-bundle/http-${hash}.mjs`;
+}
+
+function fakeVendorHttpImports(code: string): Promise<ReleaseAssetVendorResult> {
+  const urls = [
+    ...new Set(
+      [...code.matchAll(/["'](https?:\/\/[^"']+)["']/g)]
+        .map((match) => match[1])
+        .filter((url): url is string => typeof url === "string"),
+    ),
+  ];
+  let rewritten = code;
+  const dependencies = urls.map((url) => {
+    const sourcePath = fakeHttpCachePath(url);
+    rewritten = rewritten.replaceAll(url, `file://${sourcePath}`);
+    return {
+      specifier: `file://${sourcePath}`,
+      manifestKey: url,
+      sourcePath,
+      code: `export const sourceUrl = ${JSON.stringify(url)};`,
+    };
+  });
+
+  return Promise.resolve({ code: rewritten, dependencies });
+}
+
+function withFakeReactVendor(
+  vendor: ReleaseAssetHttpDependencyVendor,
+): ReleaseAssetHttpDependencyVendor {
+  return (code, options) => {
+    if (code.includes("https://esm.sh/react@") || code.includes("https://esm.sh/react-dom@")) {
+      return fakeVendorHttpImports(code);
+    }
+    return vendor(code, options);
   };
 }
 
@@ -124,12 +169,36 @@ describe("release asset build executor", () => {
 
     const manifest = parseReleaseAssetManifest(rec.manifest);
     assertExists(manifest);
+    assertExists(manifest.dependencies.react);
+    assertExists(manifest.dependencies["react-dom"]);
+    assertExists(manifest.dependencies["react-dom/client"]);
+    assertExists(manifest.dependencies["react/jsx-runtime"]);
+    assertExists(manifest.dependencies["react/jsx-dev-runtime"]);
     assertExists(manifest.dependencies["veryfront/chat"]);
     assertExists(manifest.dependencies["veryfront/workflow"]);
     assertEquals(
       manifest.dependencies["veryfront/head"]?.contentHash,
       manifest.dependencies["veryfront/react/head"]?.contentHash,
     );
+  });
+
+  it("fails when React import-map dependencies cannot be vendored", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [{ path: "pages/index.tsx", content: "export default () => null;" }];
+    const client = makeClient(files, rec);
+    const transform = (source: string) => Promise.resolve(source);
+    const input = {
+      ...baseInput(client, transform),
+      vendorHttpImports: (code: string) => Promise.resolve({ code, dependencies: [] }),
+    };
+
+    const result = await runReleaseAssetBuild(input, await tmp());
+
+    assertEquals(result.success, false);
+    assertEquals(result.state, "failed");
+    assertEquals(rec.manifest, null);
+    assertEquals(rec.states.at(-1)?.state, "failed");
+    assert(rec.states.at(-1)?.error?.includes("React import-map dependency missing"));
   });
 
   it("rewrites covered project module imports to immutable asset URLs", async () => {
@@ -184,7 +253,7 @@ describe("release asset build executor", () => {
       );
     const input = {
       ...baseInput(client, transform),
-      vendorHttpImports: (code: string) =>
+      vendorHttpImports: withFakeReactVendor((code: string) =>
         Promise.resolve({
           code: code.replace(
             "https://esm.sh/framer-motion@11",
@@ -195,7 +264,8 @@ describe("release asset build executor", () => {
             manifestKey: "https://esm.sh/framer-motion@11",
             code: "export default function motion() {}",
           }],
-        }),
+        })
+      ),
     };
 
     await runReleaseAssetBuild(input, await tmp());
@@ -233,7 +303,7 @@ describe("release asset build executor", () => {
       );
     const input = {
       ...baseInput(client, transform),
-      vendorHttpImports: (code: string) =>
+      vendorHttpImports: withFakeReactVendor((code: string) =>
         Promise.resolve({
           code: code.replace(
             "https://esm.sh/parent@1",
@@ -253,7 +323,8 @@ describe("release asset build executor", () => {
               code: "export default function child() {}",
             },
           ],
-        }),
+        })
+      ),
     };
 
     await runReleaseAssetBuild(input, await tmp());
@@ -286,7 +357,7 @@ describe("release asset build executor", () => {
       );
     const input = {
       ...baseInput(client, transform),
-      vendorHttpImports: (code: string) =>
+      vendorHttpImports: withFakeReactVendor((code: string) =>
         Promise.resolve({
           code: code
             .replace("https://esm.sh/a@1", "file:///tmp/vf-http/a/parent.mjs")
@@ -317,7 +388,8 @@ describe("release asset build executor", () => {
               code: 'export default "b";',
             },
           ],
-        }),
+        })
+      ),
     };
 
     await runReleaseAssetBuild(input, await tmp());
@@ -358,7 +430,7 @@ describe("release asset build executor", () => {
       );
     const input = {
       ...baseInput(client, transform),
-      vendorHttpImports: (code: string) =>
+      vendorHttpImports: withFakeReactVendor((code: string) =>
         Promise.resolve({
           code: code.replace(
             "https://esm.sh/parent@1",
@@ -378,7 +450,8 @@ describe("release asset build executor", () => {
               code: 'import parent from "./http-aaa.mjs"; export default parent;',
             },
           ],
-        }),
+        })
+      ),
     };
 
     const result = await runReleaseAssetBuild(input, await tmp());
@@ -416,7 +489,7 @@ describe("release asset build executor", () => {
       );
     const input = {
       ...baseInput(client, transform),
-      vendorHttpImports: (code: string) =>
+      vendorHttpImports: withFakeReactVendor((code: string) =>
         Promise.resolve({
           code: code.replace(
             "https://esm.sh/parent@1",
@@ -428,7 +501,8 @@ describe("release asset build executor", () => {
             sourcePath: "/tmp/veryfront-http-bundle/http-aaa.mjs",
             code: 'import secret from "file:///tmp/outside-secret.mjs"; export default secret;',
           }],
-        }),
+        })
+      ),
     };
 
     const result = await runReleaseAssetBuild(input, await tmp());
@@ -455,7 +529,7 @@ describe("release asset build executor", () => {
       );
     const input = {
       ...baseInput(client, transform),
-      vendorHttpImports: (code: string) =>
+      vendorHttpImports: withFakeReactVendor((code: string) =>
         Promise.resolve({
           code: code.replace(
             "https://esm.sh/parent@1",
@@ -467,7 +541,8 @@ describe("release asset build executor", () => {
             sourcePath: "/tmp/veryfront-http-bundle/http-aaa.mjs",
             code: "x".repeat(RELEASE_ASSET_MAX_SIZE_BYTES + 1),
           }],
-        }),
+        })
+      ),
     };
 
     const result = await runReleaseAssetBuild(input, await tmp());
@@ -691,7 +766,10 @@ describe("release asset build executor", () => {
 
     assertEquals(result.moduleCount, 2);
     // Same bytes → same hash → one upload.
-    assertEquals(rec.uploads.length, 1);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    const moduleHashes = new Set(Object.values(manifest.modules).map((entry) => entry.contentHash));
+    assertEquals(rec.uploads.filter((upload) => moduleHashes.has(upload.hash)).length, 1);
   });
 
   it("includes compiled CSS when a css pipeline is provided", async () => {
@@ -929,10 +1007,9 @@ describe("release asset build executor", () => {
 
     const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
 
-    // Module is skipped — not uploaded, not in manifest modules.
-    assertEquals(rec.uploads.length, 0);
     const manifest = parseReleaseAssetManifest(rec.manifest);
     assertExists(manifest);
+    // Module is skipped — not uploaded as a page asset, not in manifest modules.
     assertEquals(Object.keys(manifest.modules).length, 0);
     // Gap is recorded.
     assert(result.gaps.some((g) => g.startsWith("oversized:")));

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -24,6 +24,7 @@ import { transformToESM } from "#veryfront/transforms/esm-transform.ts";
 import { cacheHttpImportsToLocal } from "#veryfront/transforms/esm/http-cache.ts";
 import { extractSourceUrl } from "#veryfront/transforms/esm/source-url-embed.ts";
 import { parseImports, replaceSpecifiers } from "#veryfront/transforms/esm/lexer.ts";
+import { getReactUrls } from "#veryfront/transforms/esm/package-registry.ts";
 import { PLATFORM_UTILITIES } from "#veryfront/html/utils.ts";
 import { extractCandidatesFromFiles } from "#veryfront/html/styles-builder/candidate-extractor.ts";
 import { sha256HexBytes } from "./hash.ts";
@@ -50,6 +51,13 @@ const BROWSER_MODULE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js", ".mdx"];
 /** Directories whose modules are part of the browser closure. */
 const BROWSER_MODULE_DIRS = ["pages/", "components/", "layouts/", "lib/", "src/"];
 const FRAMEWORK_MODULE_URL_PREFIX = "/_vf_modules/_veryfront/";
+const REACT_IMPORT_MAP_DEPENDENCIES = [
+  "react",
+  "react-dom",
+  "react-dom/client",
+  "react/jsx-runtime",
+  "react/jsx-dev-runtime",
+] as const;
 
 export interface ReleaseAssetBuildInput {
   /** Project reference (slug or id) used for API calls. */
@@ -417,6 +425,32 @@ function buildDependencyUrlMap(
   return urls;
 }
 
+function exposeDependencySpecifierAliases(
+  assets: Record<string, PreparedAsset>,
+  dependencyModules: Map<string, DependencyModule>,
+): Record<string, PreparedAsset> {
+  const aliased = { ...assets };
+  for (const dependency of dependencyModules.values()) {
+    const asset = assets[dependency.manifestKey];
+    if (!asset) continue;
+
+    for (const specifier of dependency.specifiers) {
+      const normalized = normalizeDependencySpecifier(specifier);
+      if (
+        normalized.startsWith("http://") ||
+        normalized.startsWith("https://") ||
+        normalized.startsWith("file://") ||
+        normalized.startsWith("./") ||
+        normalized.startsWith("../")
+      ) {
+        continue;
+      }
+      aliased[normalized] = asset;
+    }
+  }
+  return aliased;
+}
+
 function dependencyFallbackUrl(dependency: DependencyModule): string | null {
   if (
     dependency.manifestKey.startsWith("http://") ||
@@ -469,6 +503,61 @@ function addDependencyModule(
 
 function normalizeDependencySpecifier(specifier: string): string {
   return specifier.replace(/[?#].*$/, "");
+}
+
+function findDependencyModuleBySpecifier(
+  dependencies: Map<string, DependencyModule>,
+  specifier: string,
+): DependencyModule | null {
+  const normalized = normalizeDependencySpecifier(specifier);
+  const direct = dependencies.get(specifier) ?? dependencies.get(normalized);
+  if (direct) return direct;
+
+  for (const dependency of dependencies.values()) {
+    if (dependency.manifestKey === specifier || dependency.manifestKey === normalized) {
+      return dependency;
+    }
+    for (const dependencySpecifier of dependency.specifiers) {
+      if (normalizeDependencySpecifier(dependencySpecifier) === normalized) {
+        return dependency;
+      }
+    }
+  }
+
+  return null;
+}
+
+async function collectReactImportMapDependencyModules(
+  input: ReleaseAssetBuildInput,
+  tempDir: string,
+  vendorHttpImports: ReleaseAssetHttpDependencyVendor,
+  dependencies: Map<string, DependencyModule>,
+): Promise<void> {
+  const reactUrls = getReactUrls(input.reactVersion);
+  const entries: Array<readonly [string, string]> = [];
+  for (const specifier of REACT_IMPORT_MAP_DEPENDENCIES) {
+    const url = reactUrls[specifier];
+    if (url) entries.push([specifier, url] as const);
+  }
+
+  const source = entries.map(([, url]) => `import ${JSON.stringify(url)};`).join("\n");
+  if (!source) return;
+
+  const vendored = await vendorHttpImports(source, {
+    tempDir,
+    reactVersion: input.reactVersion,
+  });
+  for (const dependency of vendored.dependencies) {
+    addDependencyModule(dependencies, dependency);
+  }
+
+  for (const [specifier, url] of entries) {
+    const dependency = findDependencyModuleBySpecifier(dependencies, url);
+    if (!dependency) {
+      throw new Error(`React import-map dependency missing: ${specifier}`);
+    }
+    dependency.specifiers.add(specifier);
+  }
 }
 
 function resolveLocalDependencyPath(specifier: string, parentFilePath?: string): string | null {
@@ -1106,6 +1195,34 @@ async function runBuildInner(
     transformedModules.set(logicalPath, { logicalPath, code });
   }
 
+  try {
+    await collectReactImportMapDependencyModules(
+      input,
+      tempDir,
+      vendorHttpImports,
+      dependencyModules,
+    );
+  } catch (error) {
+    const sanitized = sanitizeError(error);
+    logger.warn("React import-map dependency vendoring failed during release asset build", {
+      error: sanitized,
+    });
+    await client.reportReleaseAssetManifestState(
+      input.releaseVersionRef,
+      "failed",
+      sanitized,
+    );
+    return {
+      success: false,
+      state: "failed",
+      moduleCount: 0,
+      cssCount: 0,
+      routeCount: 0,
+      gaps,
+      error: sanitized,
+    };
+  }
+
   const frameworkDependencies = await buildFrameworkDependencies(
     input,
     tempDir,
@@ -1145,6 +1262,7 @@ async function runBuildInner(
       error: sanitized,
     };
   }
+  httpDependencies = exposeDependencySpecifierAliases(httpDependencies, dependencyModules);
   const dependencies = { ...frameworkDependencies, ...httpDependencies };
   const dependencyUrls = buildDependencyUrlMap(dependencies, dependencyModules);
   for (const [specifier, url] of httpDependencyFallbackUrls) {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.801";
+export const VERSION = "0.1.802";


### PR DESCRIPTION
## Summary
- vendor the core React import-map aliases (`react`, `react-dom`, `react-dom/client`, JSX runtimes) into release asset manifests
- rewrite manifest dependencies by import-map specifier before URL matching so `react-dom/client` cannot stay on `esm.sh` while React is content-addressed
- fail release asset builds when required React aliases cannot be vendored, rather than publishing a half-ready manifest
- bump package version to `0.1.802` for a new release

## Why
Production pages could mix content-addressed React assets with an `esm.sh` `react-dom/client` subgraph. That creates multiple React instances in the browser and causes hook dispatcher crashes like `Cannot read properties of null (reading useEffect)`.

## Testing
- `deno fmt --check deno.json src/utils/version-constant.ts src/html/utils.ts src/html/utils.test.ts src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts`
- `deno check --allow-import src/html/utils.ts src/html/utils.test.ts src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts`
- `deno lint src/html/utils.ts src/html/utils.test.ts src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts`
- `deno test --no-check --allow-all src/html/utils.test.ts src/html/html-shell-manifest.test.ts src/release-assets/build-executor.test.ts`
- pre-push suite: `2142 passed (18531 steps), 0 failed`

## Rollout note
After merge and package release, server production still needs to promote a renderer build that consumes `veryfront-code@0.1.802`, then affected production releases such as Coder Society need their release asset manifest rebuilt.