### PR TITLE
Fix hosted skill tool replay loop

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.802",
+  "version": "0.1.803",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/hosted/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.test.ts
@@ -5,10 +5,13 @@ import { pathToFileURL } from "node:url";
 import type { CreateSandboxBashTool } from "#veryfront/sandbox";
 import { register, unregister } from "#veryfront/extensions/contracts.ts";
 import { SandboxShellToolsProviderName } from "#veryfront/extensions/sandbox/index.ts";
-import { toolRegistry } from "#veryfront/tool";
+import { tool, toolRegistry } from "#veryfront/tool";
+import { defineSchema } from "#veryfront/schemas/index.ts";
+import { createLoadSkillReferenceTool } from "#veryfront/skill/tools.ts";
 import { agentRegistry } from "../composition/index.ts";
 import {
   createNodeVeryfrontCloudAgentServiceRuntime,
+  getDiscoveredHostTools,
   startNodeVeryfrontCloudAgentService,
   veryfrontApiMcpServer,
   veryfrontStudioMcpServer,
@@ -105,6 +108,28 @@ function getRuntimeAgent(
   assert(runtimeAgent);
   return runtimeAgent;
 }
+
+Deno.test("getDiscoveredHostTools excludes shared skill infrastructure tools", () => {
+  try {
+    toolRegistry.registerShared("load_skill_reference", createLoadSkillReferenceTool());
+    toolRegistry.registerShared(
+      "shared_echo",
+      tool({
+        id: "shared_echo",
+        description: "Echo shared input",
+        inputSchema: defineSchema((v) => v.object({}))(),
+        execute: () => ({ ok: true }),
+      }),
+    );
+
+    const tools = getDiscoveredHostTools();
+
+    assertEquals("shared_echo" in tools, true);
+    assertEquals("load_skill_reference" in tools, false);
+  } finally {
+    toolRegistry.clearAll();
+  }
+});
 
 Deno.test("createNodeVeryfrontCloudAgentServiceRuntime loads the markdown agent and binds service routes", async () => {
   await withTempDir(async (rootDir) => {

--- a/src/agent/hosted/veryfront-cloud-agent-service.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.ts
@@ -25,6 +25,7 @@ import {
   sleepTool,
   toolRegistry,
 } from "#veryfront/tool";
+import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
 import { parseProviderError } from "../../chat/provider-errors.ts";
 import { DEFAULT_PROJECT_DISCOVERY_DIRS } from "../../discovery/index.ts";
 import type { DiscoveryResult } from "../../discovery/types.ts";
@@ -602,7 +603,9 @@ export function getDiscoveredHostTools(scope?: { agentId?: string }): HostToolSe
   // tools are available to their owner and hidden from other agents.
   return Object.fromEntries(
     [...toolRegistry.getAll()]
-      .filter(([, registryTool]) => isToolVisibleTo(registryTool, scope))
+      .filter(([toolId, registryTool]) =>
+        !SKILL_TOOL_IDS.has(toolId) && isToolVisibleTo(registryTool, scope)
+      )
       .sort(([left], [right]) => left.localeCompare(right)),
   );
 }

--- a/src/agent/runtime/load-skill-tool.test.ts
+++ b/src/agent/runtime/load-skill-tool.test.ts
@@ -242,6 +242,39 @@ Deno.test("createRuntimeLoadSkillTool loads project and builtin reference files"
   });
 });
 
+Deno.test("createRuntimeLoadSkillTool makes same-reference reloads concise and idempotent", async () => {
+  let projectReferenceReads = 0;
+  const tool = createRuntimeLoadSkillTool({
+    context: createProjectContext(),
+    skillsDir: "/skills",
+    projectSkillLoader: {
+      listProjectSkillReferences: () => Promise.resolve([]),
+      loadProjectSkill: () => Promise.resolve(null),
+      loadProjectSkillReference: (_context, skillId, normalizedFile) => {
+        projectReferenceReads++;
+        return Promise.resolve(`${skillId}/${normalizedFile} content`);
+      },
+    },
+    builtinStore: createBuiltinStore({}),
+  });
+
+  const firstResult = await tool.execute({ skillId: "plan", file: "references/project.md" });
+  const secondResult = await tool.execute({ skillId: "plan", file: "references/project.md" });
+
+  assertEquals(projectReferenceReads, 1);
+  assertEquals(firstResult, {
+    skillId: "plan",
+    file: "references/project.md",
+    content: "plan/references/project.md content",
+  });
+  assertEquals(secondResult, {
+    skillId: "plan",
+    file: "references/project.md",
+    content:
+      'Reference file "plan/references/project.md" is already loaded in this turn. Do not call load_skill for this file again. Continue from the existing reference content and produce the next useful response now.',
+  });
+});
+
 Deno.test("createRuntimeLoadSkillTool rejects unsafe and unknown manifest skill inputs", async () => {
   const tool = createRuntimeLoadSkillTool({
     context: createProjectContext({

--- a/src/agent/runtime/load-skill-tool.test.ts
+++ b/src/agent/runtime/load-skill-tool.test.ts
@@ -173,6 +173,38 @@ Use form_input once, then produce the plan.`,
   assertEquals(secondResult.references, ["references/write.md"]);
 });
 
+Deno.test("createRuntimeLoadSkillTool reloads same skill after project context changes", async () => {
+  const context = createProjectContext();
+  let projectSkillReads = 0;
+  const tool = createRuntimeLoadSkillTool({
+    context,
+    skillsDir: "/skills",
+    projectSkillLoader: {
+      listProjectSkillReferences: () => Promise.resolve([]),
+      loadProjectSkill: (activeContext, skillId) => {
+        projectSkillReads++;
+        return Promise.resolve({
+          instructions: `# ${activeContext.projectId} ${skillId}`,
+          references: [`references/${activeContext.projectId}.md`],
+        });
+      },
+      loadProjectSkillReference: () => Promise.resolve(null),
+    },
+    builtinStore: createBuiltinStore({}),
+  });
+
+  const firstResult = expectLoadedSkillResponse(await tool.execute({ skillId: "plan" }));
+  context.projectId = "project-2";
+  context.branchId = null;
+  context.skillSourcePaths = { plan: "agents/planner/skills/plan/SKILL.md" };
+  const secondResult = expectLoadedSkillResponse(await tool.execute({ skillId: "plan" }));
+
+  assertEquals(projectSkillReads, 2);
+  assertEquals(firstResult.instructions, "# project-1 plan");
+  assertEquals(secondResult.instructions, "# project-2 plan");
+  assertEquals(secondResult.references, ["references/project-2.md"]);
+});
+
 Deno.test("createRuntimeLoadSkillTool removes form_input from same-skill reload policy", async () => {
   const context = createProjectContext({
     availableToolNames: ["form_input", "studio_suggestions", "list_files", "create_file"],
@@ -272,6 +304,42 @@ Deno.test("createRuntimeLoadSkillTool makes same-reference reloads concise and i
     file: "references/project.md",
     content:
       'Reference file "plan/references/project.md" is already loaded in this turn. Do not call load_skill for this file again. Continue from the existing reference content and produce the next useful response now.',
+  });
+});
+
+Deno.test("createRuntimeLoadSkillTool reloads same reference after project context changes", async () => {
+  const context = createProjectContext();
+  let projectReferenceReads = 0;
+  const tool = createRuntimeLoadSkillTool({
+    context,
+    skillsDir: "/skills",
+    projectSkillLoader: {
+      listProjectSkillReferences: () => Promise.resolve([]),
+      loadProjectSkill: () => Promise.resolve(null),
+      loadProjectSkillReference: (activeContext, skillId, normalizedFile) => {
+        projectReferenceReads++;
+        return Promise.resolve(`${activeContext.projectId}/${skillId}/${normalizedFile}`);
+      },
+    },
+    builtinStore: createBuiltinStore({}),
+  });
+
+  const firstResult = await tool.execute({ skillId: "plan", file: "references/project.md" });
+  context.projectId = "project-2";
+  context.branchId = null;
+  context.skillSourcePaths = { plan: "agents/planner/skills/plan/SKILL.md" };
+  const secondResult = await tool.execute({ skillId: "plan", file: "references/project.md" });
+
+  assertEquals(projectReferenceReads, 2);
+  assertEquals(firstResult, {
+    skillId: "plan",
+    file: "references/project.md",
+    content: "project-1/plan/references/project.md",
+  });
+  assertEquals(secondResult, {
+    skillId: "plan",
+    file: "references/project.md",
+    content: "project-2/plan/references/project.md",
   });
 });
 

--- a/src/agent/runtime/load-skill-tool.ts
+++ b/src/agent/runtime/load-skill-tool.ts
@@ -213,6 +213,29 @@ function buildAlreadyLoadedSkillReferenceResponse(
   };
 }
 
+function buildRuntimeSkillCacheKey(
+  context: RuntimeLoadSkillToolContext,
+  skillId: string,
+): string {
+  return JSON.stringify([
+    skillId,
+    context.projectId ?? null,
+    context.branchId ?? null,
+    context.skillSourcePaths?.[skillId] ?? null,
+  ]);
+}
+
+function buildRuntimeSkillReferenceCacheKey(
+  context: RuntimeLoadSkillToolContext,
+  skillId: string,
+  normalizedFile: string,
+): string {
+  return JSON.stringify([
+    buildRuntimeSkillCacheKey(context, skillId),
+    normalizedFile,
+  ]);
+}
+
 function buildRuntimeLoadSkillDescription(options: RuntimeLoadSkillToolOptions): string {
   if (options.description) {
     return options.description;
@@ -275,7 +298,11 @@ async function loadRuntimeSkillReferenceFile(
   }
 
   const loadedSkillReferenceResponses = options.context.loadedSkillReferenceResponses ??= {};
-  const referenceKey = `${skillId}/${normalizedFile}`;
+  const referenceKey = buildRuntimeSkillReferenceCacheKey(
+    options.context,
+    skillId,
+    normalizedFile,
+  );
   if (loadedSkillReferenceResponses[referenceKey]) {
     return buildAlreadyLoadedSkillReferenceResponse(skillId, normalizedFile);
   }
@@ -328,7 +355,8 @@ export function createRuntimeLoadSkillTool(
       }
 
       const loadedSkillResponses = options.context.loadedSkillResponses ??= {};
-      const loadedResponse = loadedSkillResponses[skillId];
+      const loadedSkillKey = buildRuntimeSkillCacheKey(options.context, skillId);
+      const loadedResponse = loadedSkillResponses[loadedSkillKey];
       if (loadedResponse) {
         return buildAlreadyLoadedSkillResponse(skillId, loadedResponse);
       }
@@ -341,7 +369,7 @@ export function createRuntimeLoadSkillTool(
           instructions: projectSkill.instructions,
           references: projectSkill.references,
         });
-        loadedSkillResponses[skillId] = response;
+        loadedSkillResponses[loadedSkillKey] = response;
         return response;
       }
 
@@ -353,7 +381,7 @@ export function createRuntimeLoadSkillTool(
           instructions: localContent,
           references: builtinStore.listReferences(options.skillsDir, skillId),
         });
-        loadedSkillResponses[skillId] = response;
+        loadedSkillResponses[loadedSkillKey] = response;
         return response;
       }
 

--- a/src/agent/runtime/load-skill-tool.ts
+++ b/src/agent/runtime/load-skill-tool.ts
@@ -53,6 +53,7 @@ export type RuntimeLoadSkillToolContext = RuntimeProjectSkillContext & {
   availableSkillIds?: readonly string[];
   availableToolNames?: readonly string[];
   loadedSkillResponses?: Record<string, RuntimeLoadedSkillResponse>;
+  loadedSkillReferenceResponses?: Record<string, RuntimeLoadSkillReferenceFileOutput>;
 };
 
 /** Public API contract for runtime load skill builtin store. */
@@ -199,6 +200,19 @@ function buildMissingSkillError(
   };
 }
 
+function buildAlreadyLoadedSkillReferenceResponse(
+  skillId: string,
+  file: string,
+): RuntimeLoadSkillReferenceFileOutput {
+  return {
+    skillId,
+    file,
+    content:
+      `Reference file "${skillId}/${file}" is already loaded in this turn. Do not call load_skill for this file again. ` +
+      "Continue from the existing reference content and produce the next useful response now.",
+  };
+}
+
 function buildRuntimeLoadSkillDescription(options: RuntimeLoadSkillToolOptions): string {
   if (options.description) {
     return options.description;
@@ -260,13 +274,21 @@ async function loadRuntimeSkillReferenceFile(
     return { error: `Invalid reference file path: ${file}` };
   }
 
+  const loadedSkillReferenceResponses = options.context.loadedSkillReferenceResponses ??= {};
+  const referenceKey = `${skillId}/${normalizedFile}`;
+  if (loadedSkillReferenceResponses[referenceKey]) {
+    return buildAlreadyLoadedSkillReferenceResponse(skillId, normalizedFile);
+  }
+
   const projectFileContent = await options.projectSkillLoader.loadProjectSkillReference(
     options.context,
     skillId,
     normalizedFile,
   );
   if (projectFileContent) {
-    return { skillId, file: normalizedFile, content: projectFileContent };
+    const response = { skillId, file: normalizedFile, content: projectFileContent };
+    loadedSkillReferenceResponses[referenceKey] = response;
+    return response;
   }
 
   const localContent = getBuiltinStore(options).readReferenceFile(
@@ -275,7 +297,9 @@ async function loadRuntimeSkillReferenceFile(
     normalizedFile,
   );
   if (localContent) {
-    return { skillId, file: normalizedFile, content: localContent };
+    const response = { skillId, file: normalizedFile, content: localContent };
+    loadedSkillReferenceResponses[referenceKey] = response;
+    return response;
   }
 
   return { error: `Reference file not found: ${skillId}/${normalizedFile}` };

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.802";
+export const VERSION = "0.1.803";


### PR DESCRIPTION
## Summary
- prevent hosted runtime from leaking shared framework skill tools such as `load_skill_reference` from the global tool registry
- keep hosted project-aware `load_skill` as the only skill loader exposed by the service tool spread
- make repeated `load_skill({ skillId, file })` reference loads idempotent within a run
- bump framework version to `0.1.803`

## Root cause
The hosted service explicitly injects a project-aware runtime `load_skill`, but it also spread `getDiscoveredHostTools()` from the global tool registry. If shared framework skill tools had been registered globally, hosted runs could expose generic `load_skill_reference` alongside runtime `load_skill`. That bypassed the hosted project-aware skill loader/state and let the model repeatedly reload the same reference files.

## Verification
- `deno test --allow-env --allow-read src/agent/runtime/load-skill-tool.test.ts`
- `deno test --allow-env --allow-read --allow-write --allow-net --allow-run --allow-sys=uid src/agent/hosted/veryfront-cloud-agent-service.test.ts`
- `deno test --allow-env --allow-read --allow-net src/agent/hosted/chat-runtime-tool-assembly.test.ts src/agent/hosted/default-chat-runtime.test.ts`
- `deno task typecheck`
- `deno task test:unit`
- pre-push hook passed: fmt, lint, typecheck, unit tests