### PR TITLE
Normalize React release asset dependency lookup

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.803",
+  "version": "0.1.804",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { normalizeHttpUrl } from "#veryfront/transforms/esm/http-cache.ts";
 import { RELEASE_ASSET_MAX_SIZE_BYTES } from "./constants.ts";
 import {
   type ReleaseAssetBuildClient,
@@ -95,6 +96,17 @@ function fakeVendorHttpImports(code: string): Promise<ReleaseAssetVendorResult> 
   return Promise.resolve({ code: rewritten, dependencies });
 }
 
+async function fakeNormalizedVendorHttpImports(code: string): Promise<ReleaseAssetVendorResult> {
+  const result = await fakeVendorHttpImports(code);
+  return {
+    code: result.code,
+    dependencies: result.dependencies.map((dependency) => ({
+      ...dependency,
+      manifestKey: normalizeHttpUrl(dependency.manifestKey),
+    })),
+  };
+}
+
 function withFakeReactVendor(
   vendor: ReleaseAssetHttpDependencyVendor,
 ): ReleaseAssetHttpDependencyVendor {
@@ -180,6 +192,29 @@ describe("release asset build executor", () => {
       manifest.dependencies["veryfront/head"]?.contentHash,
       manifest.dependencies["veryfront/react/head"]?.contentHash,
     );
+  });
+
+  it("matches React import-map dependencies by normalized HTTP manifest key", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [{ path: "pages/index.tsx", content: "export default () => null;" }];
+    const client = makeClient(files, rec);
+    const transform = (source: string) => Promise.resolve(source);
+
+    const result = await runReleaseAssetBuild(
+      {
+        ...baseInput(client, transform),
+        vendorHttpImports: fakeNormalizedVendorHttpImports,
+      },
+      await tmp(),
+    );
+
+    assertEquals(result.success, true);
+
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertExists(manifest.dependencies.react);
+    assertExists(manifest.dependencies["react-dom/client"]);
+    assertExists(manifest.dependencies["react/jsx-runtime"]);
   });
 
   it("fails when React import-map dependencies cannot be vendored", async () => {

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -21,7 +21,7 @@ import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { dirname, join, normalize } from "#veryfront/compat/path/index.ts";
 import { resolveFrameworkSourcePath } from "#veryfront/platform/compat/framework-source-resolver.ts";
 import { transformToESM } from "#veryfront/transforms/esm-transform.ts";
-import { cacheHttpImportsToLocal } from "#veryfront/transforms/esm/http-cache.ts";
+import { cacheHttpImportsToLocal, normalizeHttpUrl } from "#veryfront/transforms/esm/http-cache.ts";
 import { extractSourceUrl } from "#veryfront/transforms/esm/source-url-embed.ts";
 import { parseImports, replaceSpecifiers } from "#veryfront/transforms/esm/lexer.ts";
 import { getReactUrls } from "#veryfront/transforms/esm/package-registry.ts";
@@ -505,20 +505,35 @@ function normalizeDependencySpecifier(specifier: string): string {
   return specifier.replace(/[?#].*$/, "");
 }
 
+function dependencyLookupKeys(specifier: string): Set<string> {
+  const keys = new Set<string>([specifier, normalizeDependencySpecifier(specifier)]);
+  if (specifier.startsWith("http://") || specifier.startsWith("https://")) {
+    const normalizedHttp = normalizeHttpUrl(specifier);
+    keys.add(normalizedHttp);
+    keys.add(normalizeDependencySpecifier(normalizedHttp));
+  }
+  return keys;
+}
+
 function findDependencyModuleBySpecifier(
   dependencies: Map<string, DependencyModule>,
   specifier: string,
 ): DependencyModule | null {
-  const normalized = normalizeDependencySpecifier(specifier);
-  const direct = dependencies.get(specifier) ?? dependencies.get(normalized);
-  if (direct) return direct;
+  const lookupKeys = dependencyLookupKeys(specifier);
+  for (const key of lookupKeys) {
+    const direct = dependencies.get(key);
+    if (direct) return direct;
+  }
 
   for (const dependency of dependencies.values()) {
-    if (dependency.manifestKey === specifier || dependency.manifestKey === normalized) {
+    if (lookupKeys.has(dependency.manifestKey)) {
       return dependency;
     }
     for (const dependencySpecifier of dependency.specifiers) {
-      if (normalizeDependencySpecifier(dependencySpecifier) === normalized) {
+      for (const key of dependencyLookupKeys(dependencySpecifier)) {
+        if (lookupKeys.has(key)) return dependency;
+      }
+      if (lookupKeys.has(normalizeDependencySpecifier(dependencySpecifier))) {
         return dependency;
       }
     }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.803";
+export const VERSION = "0.1.804";


### PR DESCRIPTION
## Summary
- reuse the HTTP cache URL normalizer when matching vendored React import-map dependencies
- add a regression where the vendor returns normalized HTTP manifest keys while React registry URLs are raw
- bump package version to `0.1.803` for the follow-up release

## Why
PR #2430 fixed the duplicate-React production path, but the review correctly pointed out that the default HTTP vendor stores normalized manifest keys. Without this follow-up, fresh release asset builds can fail closed with `React import-map dependency missing` even though the dependency was vendored correctly.

## Testing
- `deno fmt --check deno.json src/utils/version-constant.ts src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts`
- `deno check --allow-import src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts`
- `deno lint src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts`
- `deno test --no-check --allow-all src/html/utils.test.ts src/html/html-shell-manifest.test.ts src/release-assets/build-executor.test.ts`
- pre-push suite: `2143 passed (18533 steps), 0 failed`

Addresses the normalized-key review finding from #2430.