### PR TITLE
Mount Studio MCP for project-agent streams

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.804",
+  "version": "0.1.805",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/hosted/project-remote-tool-source.test.ts
+++ b/src/agent/hosted/project-remote-tool-source.test.ts
@@ -269,7 +269,7 @@ Deno.test("createHostedProjectRemoteToolSource skips mutation callbacks for fail
   assertEquals(mutationCount, 0);
 });
 
-Deno.test("createHostedProjectRemoteToolSources defaults to the Veryfront API MCP server", async () => {
+Deno.test("createHostedProjectRemoteToolSources defaults to first-party MCP servers for trusted Studio clients", async () => {
   const configs: RemoteMCPToolSourceConfig[] = [];
   const sources = createHostedProjectRemoteToolSources({
     authToken: "token-1",
@@ -288,8 +288,11 @@ Deno.test("createHostedProjectRemoteToolSources defaults to the Veryfront API MC
     },
   });
 
-  assertEquals(sources.map((source) => source.id), ["veryfront-mcp"]);
-  assertEquals(configs.map((config) => config.endpoint), ["https://api.example/mcp"]);
+  assertEquals(sources.map((source) => source.id), ["veryfront-mcp", "studio-mcp"]);
+  assertEquals(configs.map((config) => config.endpoint), [
+    "https://api.example/mcp",
+    "https://studio.example/mcp",
+  ]);
 });
 
 Deno.test("createHostedProjectRemoteToolSources filters Veryfront API MCP tools with the tool access profile", async () => {

--- a/src/agent/hosted/veryfront-cloud-agent-service.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.ts
@@ -73,7 +73,10 @@ import {
   fetchDefaultHostedProjectSteering,
 } from "./default-project-steering-refresh.ts";
 import { type HostedProjectSkillIdsContext } from "./project-steering-adapter.ts";
-import type { AgentServiceMcpServerConfig } from "../service/mcp-server-config.ts";
+import {
+  type AgentServiceMcpServerConfig,
+  defaultAgentServiceMcpServers,
+} from "../service/mcp-server-config.ts";
 import type { AgentVeryfrontMcpServerConfig } from "../types.ts";
 import type { RuntimeLoadSkillToolContext } from "../runtime/load-skill-tool.ts";
 import type { RuntimeProjectSteeringLookup } from "../runtime/project-skill-catalog.ts";
@@ -350,7 +353,7 @@ function resolveDefaultProcessTarget(): NodeVeryfrontCloudAgentServiceProcessTar
 function resolveMcpServers(
   options: Pick<NodeVeryfrontCloudAgentServiceOptions, "mcpServers">,
 ): readonly NodeVeryfrontCloudAgentServiceMcpServer[] {
-  return options.mcpServers ?? [veryfrontApiMcpServer()];
+  return options.mcpServers ?? defaultAgentServiceMcpServers();
 }
 
 async function loadDefaultCreateBashTool(): Promise<

--- a/src/agent/service/mcp-server-config.test.ts
+++ b/src/agent/service/mcp-server-config.test.ts
@@ -4,8 +4,11 @@ import {
   defaultAgentServiceMcpServers,
 } from "./mcp-server-config.ts";
 
-Deno.test("defaultAgentServiceMcpServers enables the Veryfront API MCP server", () => {
-  assertEquals(defaultAgentServiceMcpServers(), [{ kind: "veryfront-api" }]);
+Deno.test("defaultAgentServiceMcpServers enables first-party MCP servers", () => {
+  assertEquals(defaultAgentServiceMcpServers(), [
+    { kind: "veryfront-api" },
+    { kind: "veryfront-studio" },
+  ]);
 });
 
 Deno.test("createAgentServiceRemoteMcpConfig builds Veryfront API MCP config", async () => {

--- a/src/agent/service/mcp-server-config.ts
+++ b/src/agent/service/mcp-server-config.ts
@@ -43,7 +43,7 @@ export type CreateAgentServiceRemoteMcpConfigInput = {
 };
 
 export function defaultAgentServiceMcpServers(): AgentServiceMcpServerConfig[] {
-  return [{ kind: "veryfront-api" }];
+  return [{ kind: "veryfront-api" }, { kind: "veryfront-studio" }];
 }
 
 function createGenericRemoteMcpConfig(

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -593,6 +593,122 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(capturedAllowedTools, ["gmail:list-emails", "gmail:get-email"]);
   });
 
+  it("auto-exposes Studio MCP tools for trusted Studio project-agent requests", async () => {
+    let capturedAllowedRemoteTools: string[] | undefined;
+    let capturedRemoteToolNames: string[] = [];
+    const originalFetch = globalThis.fetch;
+    const originalStudioMcpUrl = Deno.env.get("VERYFRONT_STUDIO_MCP_URL");
+
+    Deno.env.set("VERYFRONT_STUDIO_MCP_URL", "https://studio.veryfront.org/mcp");
+    globalThis.fetch = ((url, init) => {
+      assertEquals(String(url), "https://studio.veryfront.org/mcp");
+      const headers = new Headers(init?.headers);
+      assertEquals(headers.get("authorization"), "Bearer request-scoped-user-token");
+      assertEquals(headers.get("x-project-id"), "proj-1");
+      assertEquals(headers.get("x-conversation-id"), "10000000-1000-4000-8000-100000000001");
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: "veryfront-studio-mcp:tools:list",
+            result: {
+              tools: [
+                {
+                  name: "studio_todo_write",
+                  description: "Write the assistant task list",
+                  inputSchema: { type: "object", properties: {} },
+                },
+                {
+                  name: "studio_panel_control",
+                  description: "Control Studio panels",
+                  inputSchema: { type: "object", properties: {} },
+                },
+              ],
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+      );
+    }) as typeof fetch;
+
+    try {
+      const handler = new AgentStreamHandler({
+        ensureProjectDiscovery: async () => {},
+        getAgent: (id) => id === "assistant-1" ? createAgent("assistant-1") : undefined,
+        getAllAgentIds: () => ["assistant-1"],
+        sessionManager: new AgentRunSessionManager(),
+        createRuntime: (runtimeAgent) => ({
+          stream: async (_messages, _context, callbacks) => {
+            const runtimeConfig = runtimeAgent.config as
+              & typeof runtimeAgent.config
+              & RuntimeRemoteToolConfig;
+            capturedAllowedRemoteTools = runtimeConfig.__vfAllowedRemoteTools;
+            capturedRemoteToolNames = (await runtimeConfig.__vfRemoteToolSources?.[0]?.listTools({
+              projectId: "proj-1",
+            }))?.map((tool) => tool.name) ?? [];
+            callbacks?.onFinish?.({
+              text: "ok",
+              messages: [],
+              toolCalls: [],
+              status: "completed",
+              usage: {
+                promptTokens: 1,
+                completionTokens: 1,
+                totalTokens: 2,
+              },
+            });
+
+            return new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.close();
+              },
+            });
+          },
+        }),
+      });
+
+      const body = createAgentStreamRequestBody({
+        credentials: { authToken: "request-scoped-user-token" },
+        forwardedProps: {
+          clientId: "veryfront-studio",
+          veryfront: {
+            client: {
+              id: "veryfront-studio",
+              type: "web",
+              platform: "browser",
+            },
+          },
+          runtimeOverrides: {
+            allowedTools: ["studio_todo_write"],
+          },
+        },
+      });
+      const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+      const result = await handler.handle(
+        new Request("https://example.com/api/control-plane/runs/run_1/stream", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-veryfront-control-plane-jws": jws,
+          },
+          body,
+        }),
+        createCtx(publicKeyPem),
+      );
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 200);
+      assertEquals(capturedAllowedRemoteTools, ["studio_todo_write"]);
+      assertEquals(capturedRemoteToolNames, ["studio_todo_write", "studio_panel_control"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalStudioMcpUrl === undefined) Deno.env.delete("VERYFRONT_STUDIO_MCP_URL");
+      else Deno.env.set("VERYFRONT_STUDIO_MCP_URL", originalStudioMcpUrl);
+    }
+  });
+
   it("fails closed for malformed runtime integration tool allowlists from forwarded props", async () => {
     let capturedAllowedTools: string[] | undefined;
 

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -12,6 +12,11 @@ import {
   type RuntimeAgentStreamExecutionDeps,
 } from "#veryfront/internal-agents/run-stream.ts";
 import type { RuntimeRemoteToolConfig } from "#veryfront/agent/runtime/mcp-server-tool-sources.ts";
+import { buildStudioMcpHeaders } from "#veryfront/agent/project/live-studio-mcp-tools.ts";
+import {
+  clientAllowsStudioMcp,
+  resolveRuntimeClientProfile,
+} from "#veryfront/agent/runtime/client-profile.ts";
 import {
   resolveRuntimeOwnerInvokeUrl,
   RUNTIME_OWNER_INVOKE_URL_HEADER,
@@ -65,6 +70,17 @@ const defaultDeps: AgentStreamHandlerDeps = {
 const logger = serverLogger.component("agent-stream-handler");
 const RUN_STREAM_PATH_REGEX = /^\/api\/control-plane\/runs\/([^/]+)\/stream$/;
 const VERYFRONT_PLATFORM_REMOTE_TOOL_SOURCE_ID = "veryfront-platform-mcp";
+const VERYFRONT_STUDIO_REMOTE_TOOL_SOURCE_ID = "veryfront-studio-mcp";
+const STUDIO_RUNTIME_REMOTE_TOOL_NAMES = new Set<string>(
+  [
+    "studio_suggestions",
+    "studio_todo_write",
+    "studio_panel_control",
+    "studio_open_project",
+    "studio_display_media",
+    "studio_capture_screenshot",
+  ] as const,
+);
 const LOCAL_RUNTIME_BOOLEAN_TOOL_NAMES = new Set(["bash"]);
 
 // Per-environment env var cache shared across all agent stream requests (60s TTL)
@@ -140,6 +156,36 @@ function mergeAllowedRemoteTools(
   return [...allowed].sort();
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getForwardedAllowedRemoteToolNames(
+  forwardedProps: Record<string, unknown> | undefined,
+): string[] {
+  const runtimeOverrides = isRecord(forwardedProps?.runtimeOverrides)
+    ? forwardedProps.runtimeOverrides
+    : null;
+  const allowedTools = runtimeOverrides?.allowedTools;
+  return Array.isArray(allowedTools) &&
+      allowedTools.every((toolName) => typeof toolName === "string")
+    ? allowedTools
+    : [];
+}
+
+function getRequestedStudioToolNames(input: {
+  forwardedProps?: Record<string, unknown>;
+  availableToolNames?: string[];
+}): string[] {
+  const requestedToolNames = new Set([
+    ...getForwardedAllowedRemoteToolNames(input.forwardedProps),
+    ...(input.availableToolNames ?? []),
+  ]);
+  return [...requestedToolNames]
+    .filter((toolName) => STUDIO_RUNTIME_REMOTE_TOOL_NAMES.has(toolName))
+    .sort();
+}
+
 function getVeryfrontApiMcpPolicy(agent: Agent): {
   allowAll: boolean;
   requestedToolNames: string[];
@@ -172,6 +218,13 @@ function hasVeryfrontPlatformRemoteToolSource(
   remoteTools: RemoteToolSource[] | undefined,
 ): boolean {
   return remoteTools?.some((source) => source.id === VERYFRONT_PLATFORM_REMOTE_TOOL_SOURCE_ID) ??
+    false;
+}
+
+function hasVeryfrontStudioRemoteToolSource(
+  remoteTools: RemoteToolSource[] | undefined,
+): boolean {
+  return remoteTools?.some((source) => source.id === VERYFRONT_STUDIO_REMOTE_TOOL_SOURCE_ID) ??
     false;
 }
 
@@ -246,6 +299,59 @@ async function withVeryfrontPlatformRemoteTools(input: {
       requestedPlatformToolNames,
     ),
     __vfRemoteToolSources: [...remoteTools, ...platformRemoteToolSources],
+  };
+
+  return {
+    ...input.agent,
+    config: runtimeConfig,
+  };
+}
+
+function withVeryfrontStudioRemoteTools(input: {
+  agent: Agent;
+  token?: string | null;
+  projectId?: string | null;
+  forwardedProps?: Record<string, unknown>;
+  availableToolNames?: string[];
+  conversationId?: string;
+}): Agent {
+  const studioMcpUrl = getHostEnv("VERYFRONT_STUDIO_MCP_URL")?.trim();
+  const clientProfile = resolveRuntimeClientProfile(input.forwardedProps);
+  const requestedStudioToolNames = getRequestedStudioToolNames({
+    forwardedProps: input.forwardedProps,
+    availableToolNames: input.availableToolNames,
+  });
+  if (
+    !input.token ||
+    !studioMcpUrl ||
+    !clientAllowsStudioMcp(clientProfile) ||
+    requestedStudioToolNames.length === 0
+  ) {
+    return input.agent;
+  }
+
+  const runtimeRemoteToolConfig = input.agent.config as Agent["config"] & RuntimeRemoteToolConfig;
+  const remoteTools = runtimeRemoteToolConfig.__vfRemoteToolSources ?? [];
+  const studioRemoteToolSources = hasVeryfrontStudioRemoteToolSource(remoteTools) ? [] : [
+    createRemoteMCPToolSource({
+      id: VERYFRONT_STUDIO_REMOTE_TOOL_SOURCE_ID,
+      endpoint: studioMcpUrl,
+      headers: () =>
+        buildStudioMcpHeaders(
+          input.token ?? "",
+          input.projectId ?? null,
+          input.conversationId,
+        ),
+    }),
+  ];
+
+  const runtimeConfig: Agent["config"] & RuntimeRemoteToolConfig = {
+    ...input.agent.config,
+    __vfAllowedRemoteTools: mergeAllowedRemoteTools(
+      runtimeRemoteToolConfig.__vfAllowedRemoteTools,
+      requestedStudioToolNames,
+    ),
+    __vfRemoteToolSources: [...remoteTools, ...studioRemoteToolSources],
   };
 
   return {
@@ -455,11 +561,19 @@ export class AgentStreamHandler extends BaseHandler {
             const runtimeInput = toRuntimeRunAgentInput(payload);
             const apiAuthToken = payload.credentials?.authToken || ctx.proxyToken ||
               getHostEnv("VERYFRONT_API_TOKEN") || "";
-            const runtimeAgent = await withVeryfrontPlatformRemoteTools({
+            const platformRuntimeAgent = await withVeryfrontPlatformRemoteTools({
               agent: agent as Agent,
               token: apiAuthToken || null,
               projectId: ctx.projectId ?? null,
               availableToolNames: runtimeInput.tools.map((tool) => tool.name),
+            });
+            const runtimeAgent = withVeryfrontStudioRemoteTools({
+              agent: platformRuntimeAgent,
+              token: apiAuthToken || null,
+              projectId: ctx.projectId ?? null,
+              forwardedProps: runtimeInput.forwardedProps,
+              availableToolNames: runtimeInput.tools.map((tool) => tool.name),
+              conversationId: runtimeInput.threadId,
             });
 
             // Load project env vars so source-defined MCP tool headers resolve

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.804";
+export const VERSION = "0.1.805";


### PR DESCRIPTION
## Summary
- add Studio MCP to the default hosted agent-service MCP server set
- mount the Studio MCP source for trusted Studio project-agent stream requests
- keep the runtime allowlist narrow by intersecting requested Studio tool names with forwarded allowed tools and available runtime tools
- bump the package version to 0.1.805 so downstream services can consume a new release

## Verification
- deno fmt src/agent/service/mcp-server-config.ts src/agent/service/mcp-server-config.test.ts src/agent/hosted/veryfront-cloud-agent-service.ts src/agent/hosted/project-remote-tool-source.test.ts src/server/handlers/request/agent-stream.handler.ts src/server/handlers/request/agent-stream.handler.test.ts deno.json src/utils/version-constant.ts
- VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --unstable-net src/agent/service/mcp-server-config.test.ts src/agent/hosted/veryfront-cloud-agent-service.test.ts src/agent/hosted/project-remote-tool-source.test.ts src/server/handlers/request/agent-stream.handler.test.ts
- deno check src/agent/service/mcp-server-config.ts src/agent/hosted/veryfront-cloud-agent-service.ts src/server/handlers/request/agent-stream.handler.ts
- git pre-push hook: formatting, lint, typecheck, and full Deno unit suite passed

## Notes
- Runtime still requires trusted Studio client profile and explicit forwarded allowlist; this does not expose arbitrary Studio tools.
- API companion PR follows to auto-forward studio_todo_write for first-party Studio runs.