### PR TITLE
Preserve code agent tool declarations for runtime

### DIFF
--- a/src/agent/project/agent-runtime.test.ts
+++ b/src/agent/project/agent-runtime.test.ts
@@ -35,6 +35,11 @@ Deno.test("project agent runtime resolves code and markdown agent candidates", a
     model: "openai/gpt-5.4",
     maxSteps: 7,
     system: () => "Help from code.",
+    tools: {
+      get_active_agent_run: true,
+      get_agent_run_events: true,
+    },
+    providerTools: ["web_search"],
   });
   const markdownAgent = createRuntimeAgentFromMarkdownDefinition({
     id: "writer",
@@ -80,6 +85,8 @@ Deno.test("project agent runtime resolves code and markdown agent candidates", a
     instructions: "Help from code.",
     model: "openai/gpt-5.4",
     maxSteps: 7,
+    providerTools: ["web_search"],
+    tools: ["get_active_agent_run", "get_agent_run_events"],
   });
   assertEquals(await createRuntimeAgentDefinitionFromAgent(markdownAgent), {
     id: "writer",

--- a/src/agent/project/agent-runtime.ts
+++ b/src/agent/project/agent-runtime.ts
@@ -37,6 +37,23 @@ function resolveAgentSystem(system: AgentConfig["system"]): Promise<string> | st
   return typeof system === "function" ? system() : system;
 }
 
+function resolveAgentToolNames(tools: AgentConfig["tools"]): true | string[] | undefined {
+  if (tools === true) {
+    return true;
+  }
+
+  if (!tools) {
+    return undefined;
+  }
+
+  const names = Object.entries(tools)
+    .filter(([, value]) => value === true)
+    .map(([name]) => name)
+    .sort();
+
+  return names.length > 0 ? names : undefined;
+}
+
 /** Clear project agent runtime registries. */
 export function clearProjectAgentRuntimeRegistries(): void {
   clearTrackedAgents();
@@ -83,6 +100,7 @@ export async function createRuntimeAgentDefinitionFromAgent(
   if (markdownDefinition) {
     return markdownDefinition;
   }
+  const toolNames = resolveAgentToolNames(runtimeAgent.config.tools);
 
   return {
     id: runtimeAgent.id,
@@ -94,6 +112,11 @@ export async function createRuntimeAgentDefinitionFromAgent(
       ? {}
       : { temperature: runtimeAgent.config.temperature }),
     maxSteps: runtimeAgent.config.maxSteps,
+    ...(runtimeAgent.config.providerTools
+      ? { providerTools: runtimeAgent.config.providerTools }
+      : {}),
+    ...(runtimeAgent.config.skills === undefined ? {} : { skills: runtimeAgent.config.skills }),
+    ...(toolNames === undefined ? {} : { tools: toolNames }),
   };
 }
 


### PR DESCRIPTION
## Summary\n- Preserve tools, providerTools, and skills when converting code agents to runtime definitions\n- Keeps platform-owned tool declarations visible to hosted runtime preparation\n\n## Validation\n- deno test --allow-env --allow-read --allow-write --allow-run --allow-net --allow-sys=uid src/agent/project/agent-runtime.test.ts\n- pre-commit verify:quick