### PR TITLE
Release runtime tool preservation fix

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.805",
+  "version": "0.1.806",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.805";
+export const VERSION = "0.1.806";


### PR DESCRIPTION
## Summary\n- bump veryfront package version to 0.1.806 so the merged runtime tool-preservation fix can release\n\n## Validation\n- deno fmt --check deno.json\n- npm view veryfront@0.1.806 confirms unpublished\n- origin has no v0.1.806 tag\n- source repo has no v0.1.806 release\n- pre-commit verify:quick passed