### PR TITLE
Let dynamic Veryfront routes survive static misses

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.807",
+  "version": "0.1.808",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/handlers/request/static.handler.test.ts
+++ b/src/server/handlers/request/static.handler.test.ts
@@ -114,6 +114,48 @@ describe("server/handlers/request/static.handler", () => {
     assertEquals(await result.response.text(), "export const react = true;");
   });
 
+  it("lets missing generated page modules fall through to ModuleHandler", async () => {
+    const handler = new StaticHandler();
+    let resolvedPath = "";
+    (handler as any).staticService = {
+      resolveFile: async (pathname: string) => {
+        resolvedPath = pathname;
+        return null;
+      },
+      isAssetRequest: () => true,
+    };
+
+    const result = await handler.handle(
+      new Request("http://localhost/_veryfront/pages/index.js"),
+      makeCtx(),
+    );
+
+    assertEquals(resolvedPath, "/_veryfront/pages/index.js");
+    assertEquals(result.continue, true);
+    assertEquals(result.response, undefined);
+  });
+
+  it("lets missing generated data endpoints fall through to ModuleHandler", async () => {
+    const handler = new StaticHandler();
+    let resolvedPath = "";
+    (handler as any).staticService = {
+      resolveFile: async (pathname: string) => {
+        resolvedPath = pathname;
+        return null;
+      },
+      isAssetRequest: () => true,
+    };
+
+    const result = await handler.handle(
+      new Request("http://localhost/_veryfront/data/index.json"),
+      makeCtx(),
+    );
+
+    assertEquals(resolvedPath, "/_veryfront/data/index.json");
+    assertEquals(result.continue, true);
+    assertEquals(result.response, undefined);
+  });
+
   it("adds matching nonces to static HTML responses before applying CSP", async () => {
     const handler = new StaticHandler();
     (handler as any).staticService = {

--- a/src/server/handlers/request/static.handler.ts
+++ b/src/server/handlers/request/static.handler.ts
@@ -39,6 +39,11 @@ function isProductionBuildAssetPath(pathname: string): boolean {
     pathname.startsWith("/_vf/assets/");
 }
 
+function isDynamicBuildFallbackPath(pathname: string): boolean {
+  return pathname.startsWith("/_veryfront/pages/") ||
+    pathname.startsWith("/_veryfront/data/");
+}
+
 export class StaticHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "StaticHandler",
@@ -89,6 +94,7 @@ export class StaticHandler extends BaseHandler {
         });
 
         if (!result) {
+          if (isDynamicBuildFallbackPath(pathname)) return null;
           if (!this.staticService.isAssetRequest(pathname)) return null;
 
           return builder

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.807";
+export const VERSION = "0.1.808";


### PR DESCRIPTION
## Summary
- Let missing `/_veryfront/pages/*` and `/_veryfront/data/*` requests fall through to `ModuleHandler` instead of becoming static 404s.
- Keep generated SSG page/data artifacts served by the static handler when files exist.
- Bump the package version to `0.1.808`.

## Verification
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/server/handlers/request/static.handler.test.ts`
- `deno fmt --check src/server/handlers/request/static.handler.ts src/server/handlers/request/static.handler.test.ts deno.json src/utils/version-constant.ts`
- `deno check --no-lock src/server/handlers/request/static.handler.ts src/server/handlers/request/static.handler.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net tests/integration/server/module-handler-cache.test.ts tests/integration/server/production/data-endpoint.test.ts`
- Pre-push hook: format, lint, typecheck, and unit suite passed (`2149 passed`, `0 failed`).

## Coder Society deployment note
The live `react.production.js` `useEffect` null-dispatcher error still points to stale or mixed build artifacts from before the release-asset dependency import-map fix. This static fallthrough patch is separate. Coder Society still needs a fresh build artifact and deployment using the patched Veryfront version and the release asset env flags enabled.