### PR TITLE
Preserve 404s for missing page modules

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.808",
+  "version": "0.1.809",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/handlers/request/module/module.handler.test.ts
+++ b/src/server/handlers/request/module/module.handler.test.ts
@@ -1,9 +1,16 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { ModuleHandler } from "./module.handler.ts";
 import type { HandlerContext } from "../../types.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { FILE_NOT_FOUND } from "#veryfront/errors/error-registry.ts";
+import type { Renderer } from "#veryfront/rendering/renderer.ts";
+import {
+  destroyRendererAdapter,
+  type RendererInitializer,
+  setRendererInitializer,
+} from "../../../shared/renderer/index.ts";
 
 function createMockAdapter(): RuntimeAdapter {
   return {
@@ -47,7 +54,21 @@ function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
   };
 }
 
+function createInitializer(renderer: Partial<Renderer>): RendererInitializer {
+  return {
+    initialize: () => Promise.resolve(renderer as Renderer),
+    isInitialized: () => true,
+    get: () => renderer as Renderer,
+    destroy: () => Promise.resolve(),
+  };
+}
+
 describe("server/handlers/request/module/module.handler", () => {
+  afterEach(async () => {
+    await destroyRendererAdapter();
+    setRendererInitializer(undefined);
+  });
+
   describe("ModuleHandler metadata", () => {
     it("has correct name", () => {
       const handler = new ModuleHandler();
@@ -119,6 +140,27 @@ describe("server/handlers/request/module/module.handler", () => {
       const ctx = makeCtx();
       const result = await handler.handle(req, ctx);
       assertEquals(result.continue, true);
+    });
+  });
+
+  describe("handle - page modules", () => {
+    it("returns 404 when a missing page module falls through from static handling", async () => {
+      setRendererInitializer(createInitializer({
+        renderPage: () => {
+          throw FILE_NOT_FOUND.create({
+            detail: "Page not found: no-such",
+            context: { slug: "no-such" },
+          });
+        },
+      }));
+
+      const handler = new ModuleHandler();
+      const req = new Request("http://localhost/_veryfront/pages/no-such.js");
+      const ctx = makeCtx();
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.continue, false);
+      assertEquals(result.response?.status, 404);
     });
   });
 });

--- a/src/server/handlers/request/module/page-module-handler.ts
+++ b/src/server/handlers/request/module/page-module-handler.ts
@@ -5,6 +5,12 @@ import { getRendererForProject } from "../../../shared/renderer-factory.ts";
 import { shouldUseNoCacheHeadersFromHandler } from "../../../context/enriched-context.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { serverLogger } from "#veryfront/utils";
+import { VeryfrontError } from "#veryfront/errors";
+
+function isPageModuleNotFound(error: unknown): boolean {
+  return error instanceof VeryfrontError &&
+    (error.status === 404 || error.slug === "file-not-found" || error.slug === "page-not-found");
+}
 
 export function handlePageModule(
   req: Request,
@@ -55,6 +61,15 @@ export function handlePageModule(
           builder.withCache(cacheMode).withETag(etag).javascript(code, 200),
         );
       } catch (error) {
+        if (isPageModuleNotFound(error)) {
+          return respond(
+            ResponseBuilder.error(404, "Module not found", req, {
+              securityConfig: ctx.securityConfig,
+              corsConfig: ctx.securityConfig?.cors,
+            }),
+          );
+        }
+
         // Log the full error server-side but return a generic message
         // to avoid leaking internal details (Babel/TS errors, file paths, etc.)
         serverLogger.error("[page-module] Failed to generate module", {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.808";
+export const VERSION = "0.1.809";


### PR DESCRIPTION
## Summary
- Map renderer `file-not-found` / `page-not-found` errors from `/_veryfront/pages/*` module requests to HTTP 404.
- Keep the dynamic page-module fallthrough from #2437 intact for SSR routes.
- Bump the package version to `0.1.809`.

## Review context
Addresses the Codex inline review on #2437: stale imports or probes such as `/_veryfront/pages/no-such.js` should not regress from 404 to 500 after static misses fall through to `ModuleHandler`.

## Verification
- Red test before fix: `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/server/handlers/request/module/module.handler.test.ts` failed with actual `500`, expected `404`.
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/server/handlers/request/module/module.handler.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/server/handlers/request/static.handler.test.ts src/server/handlers/request/module/module.handler.test.ts`
- `deno fmt --check src/server/handlers/request/module/page-module-handler.ts src/server/handlers/request/module/module.handler.test.ts deno.json src/utils/version-constant.ts`
- `deno check --no-lock src/server/handlers/request/module/page-module-handler.ts src/server/handlers/request/module/module.handler.test.ts`
- `git diff --check`
- Pre-push hook: format, lint, typecheck, and unit suite passed (`2149 passed`, `0 failed`).