### PR TITLE
Keep framework runtime imports on release React assets

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.809",
+  "version": "0.1.810",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/build/production-build/build/build-executor.ts
+++ b/src/build/production-build/build/build-executor.ts
@@ -5,6 +5,7 @@ import type { VeryfrontConfig } from "#veryfront/config";
 import type { VeryfrontRenderer } from "#veryfront/rendering/index.ts";
 import type { AppRouteInfo, RouteInfo } from "#veryfront/server/build-types.ts";
 import type { ChunkManifest } from "#veryfront/build/bundler/index.ts";
+import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 
 const logger = serverLogger.component("build");
 
@@ -18,6 +19,7 @@ export interface BuildExecutorOptions {
   chunkManifest: ChunkManifest | null;
   baseUrl: string;
   dryRun: boolean;
+  releaseAssetManifest?: ReleaseAssetManifest | null;
 }
 
 export interface BuildResult {

--- a/src/build/production-build/build/build-orchestrator.ts
+++ b/src/build/production-build/build/build-orchestrator.ts
@@ -15,6 +15,7 @@ import { runCodeSplitting } from "./code-splitter-orchestrator.ts";
 import { generateAllOutputs } from "./output-generator.ts";
 import { collectAllRoutes } from "./route-collector.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { generateLocalReleaseAssetManifest } from "../local-release-assets.ts";
 
 export function buildProduction(options: BuildOptions): Promise<BuildStats> {
   return withSpan(
@@ -58,6 +59,18 @@ export function buildProduction(options: BuildOptions): Promise<BuildStats> {
         {},
       );
 
+      const releaseAssetManifest = await withSpan(
+        "build.localReleaseAssets",
+        () =>
+          generateLocalReleaseAssetManifest({
+            adapter: context.adapter,
+            projectDir: normalizedOptions.projectDir,
+            outputDir,
+            dryRun,
+          }),
+        {},
+      );
+
       const routes = await withSpan(
         "build.collectRoutes",
         () =>
@@ -98,6 +111,7 @@ export function buildProduction(options: BuildOptions): Promise<BuildStats> {
             chunkManifest: splitResult.manifest,
             baseUrl: "",
             dryRun,
+            releaseAssetManifest,
           }),
         {},
       );
@@ -120,6 +134,7 @@ export function buildProduction(options: BuildOptions): Promise<BuildStats> {
             enableCompression,
             chunkManifest: splitResult.manifest,
             dryRun,
+            releaseAssetManifest,
           }),
         {},
       );

--- a/src/build/production-build/build/output-generator.ts
+++ b/src/build/production-build/build/output-generator.ts
@@ -25,6 +25,7 @@ import {
 } from "../client-runtime.ts";
 import { generateLocalReleaseAssetManifest } from "../local-release-assets.ts";
 import { generateManifest, generateRedirects } from "../manifest.ts";
+import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 
 export interface OutputGeneratorOptions {
   adapter: RuntimeAdapter;
@@ -38,6 +39,7 @@ export interface OutputGeneratorOptions {
   enableCompression: boolean;
   chunkManifest: ChunkManifest | null;
   dryRun: boolean;
+  releaseAssetManifest?: ReleaseAssetManifest | null;
 }
 
 /**
@@ -135,15 +137,17 @@ export function copyAssets(
  * Generate all output files
  */
 export async function generateAllOutputs(options: OutputGeneratorOptions): Promise<void> {
-  const { adapter, projectDir, outputDir, dryRun, stats } = options;
+  const { adapter, projectDir, outputDir, dryRun, stats, releaseAssetManifest } = options;
 
   await generateClientScripts(adapter, outputDir, dryRun);
-  await generateLocalReleaseAssetManifest({
-    adapter,
-    projectDir,
-    outputDir,
-    dryRun,
-  });
+  if (releaseAssetManifest === undefined) {
+    await generateLocalReleaseAssetManifest({
+      adapter,
+      projectDir,
+      outputDir,
+      dryRun,
+    });
+  }
 
   const assetStats = await copyAssets(adapter, projectDir, outputDir, dryRun);
   stats.assets = assetStats.assets;

--- a/src/build/production-build/local-release-assets.test.ts
+++ b/src/build/production-build/local-release-assets.test.ts
@@ -1,11 +1,17 @@
 import "#veryfront/schemas/_test-setup.ts";
 
-import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import { RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
 import { parseReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import type { ReleaseAssetHttpDependencyVendor } from "#veryfront/release-assets/build-executor.ts";
+import { parseImports } from "#veryfront/transforms/esm/lexer.ts";
 import { generateLocalReleaseAssetManifest } from "./local-release-assets.ts";
 import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
 
@@ -72,6 +78,24 @@ const fakeVendorHttpImports: ReleaseAssetHttpDependencyVendor = (code) => {
   });
 };
 
+async function hasEsmShReactImport(code: string): Promise<boolean> {
+  for (const imp of await parseImports(code)) {
+    if (!imp.n) continue;
+    try {
+      const url = new URL(imp.n);
+      if (url.hostname === "esm.sh" && url.pathname.startsWith("/react")) return true;
+    } catch {
+      // Not an absolute URL import.
+    }
+  }
+  return false;
+}
+
+const fakeFrameworkTransform = () =>
+  Promise.resolve(
+    'import React from "react"; export const Head = () => React.createElement("title");',
+  );
+
 describe("build/production-build/local-release-assets", () => {
   const originalFlag = getHostEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG);
 
@@ -109,6 +133,7 @@ describe("build/production-build/local-release-assets", () => {
       projectId: "local-project",
       releaseId: "standalone-dev",
       vendorHttpImports: fakeVendorHttpImports,
+      frameworkTransform: fakeFrameworkTransform,
     });
 
     assertExists(manifest);
@@ -119,12 +144,26 @@ describe("build/production-build/local-release-assets", () => {
     assertExists(manifestText);
     const parsed = parseReleaseAssetManifest(JSON.parse(manifestText));
     assertExists(parsed);
+    assertExists(parsed.dependencies.react);
     assertEquals(parsed.dependencies.react.contentHash, manifest.dependencies.react.contentHash);
 
     const reactAssetPath = `/project/dist/_vf/assets/${manifest.dependencies.react.contentHash}.js`;
     const reactAsset = writes.get(reactAssetPath);
     assertExists(reactAsset);
     assertEquals(reactAsset.includes("sourceUrl"), true);
+    assertExists(manifest.dependencies["veryfront/head"]);
+    assertExists(manifest.dependencies["veryfront/react/head"]);
+
+    const headAssetPath = `/project/dist/_vf/assets/${
+      manifest.dependencies["veryfront/head"].contentHash
+    }.js`;
+    const headAsset = writes.get(headAssetPath);
+    assertExists(headAsset);
+    assertStringIncludes(
+      headAsset,
+      `/_vf/assets/${manifest.dependencies.react.contentHash}.js`,
+    );
+    assertEquals(await hasEsmShReactImport(headAsset), false);
     assertEquals(removed.includes("/tmp/vf-local-release-assets-test"), true);
   });
 
@@ -149,6 +188,7 @@ describe("build/production-build/local-release-assets", () => {
         projectId: "local-project",
         releaseId: "standalone-dev",
         vendorHttpImports: fakeVendorHttpImports,
+        frameworkTransform: fakeFrameworkTransform,
       });
 
       assertExists(manifest);

--- a/src/build/production-build/local-release-assets.ts
+++ b/src/build/production-build/local-release-assets.ts
@@ -8,9 +8,12 @@ import {
 } from "#veryfront/release-assets/constants.ts";
 import {
   buildCachedHttpDependencyAssets,
+  buildFrameworkDependencyAssets,
   buildReactImportMapDependencyAssets,
+  buildReleaseAssetDependencyUrlMap,
   type PreparedReleaseAsset,
   type ReleaseAssetHttpDependencyVendor,
+  type ReleaseAssetTransform,
 } from "#veryfront/release-assets/build-executor.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import { sha256HexBytes } from "#veryfront/release-assets/hash.ts";
@@ -27,6 +30,7 @@ export interface LocalReleaseAssetOptions {
   projectId?: string;
   releaseId?: string;
   vendorHttpImports?: ReleaseAssetHttpDependencyVendor;
+  frameworkTransform?: ReleaseAssetTransform;
 }
 
 function shouldBuildLocalDependencyAssets(): boolean {
@@ -65,12 +69,22 @@ export async function generateLocalReleaseAssetManifest(
       const cached = await buildCachedHttpDependencyAssets({
         cacheDir: join(options.projectDir, ".cache", "veryfront-http-bundle"),
       });
-      const dependencies = { ...cached.dependencies, ...built.dependencies };
+      let dependencies = { ...cached.dependencies, ...built.dependencies };
+      const dependencyUrls = buildReleaseAssetDependencyUrlMap(dependencies);
+      const framework = await buildFrameworkDependencyAssets({
+        tempDir,
+        adapter: options.adapter,
+        reactVersion,
+        projectId: options.projectId ?? "local",
+        transform: options.frameworkTransform,
+        dependencyUrls,
+      });
+      dependencies = { ...dependencies, ...framework.dependencies };
       const assetsByHash = new Map<string, PreparedReleaseAsset>();
-      for (const asset of [...cached.assets, ...built.assets]) {
+      for (const asset of [...cached.assets, ...built.assets, ...framework.assets]) {
         assetsByHash.set(asset.contentHash, asset);
       }
-      const gaps = [...cached.gaps, ...built.gaps];
+      const gaps = [...cached.gaps, ...built.gaps, ...framework.gaps];
       const sourceContentHash = await sha256HexBytes(
         new TextEncoder().encode(
           [

--- a/src/build/production-build/static-generation.test.ts
+++ b/src/build/production-build/static-generation.test.ts
@@ -1,12 +1,15 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { buildAppRoutes, buildPagesRoutes } from "./static-generation.ts";
 import { clearCSSCache, getCSSByHash } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { VeryfrontRenderer } from "#veryfront/rendering/orchestrator/ssr.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { createMockAdapter as createMemoryAdapter } from "#veryfront/platform/adapters/mock.ts";
+import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import { RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
+import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 
 function createMockAdapter(): RuntimeAdapter {
   const files = new Map<string, string>();
@@ -50,10 +53,34 @@ function createMockConfig(): VeryfrontConfig {
   return {} as VeryfrontConfig;
 }
 
+function extractImportMapImports(html: string): Record<string, string> {
+  const match = html.match(/<script type="importmap">([\s\S]*?)<\/script>/);
+  assertExists(match?.[1], "expected import map script");
+  return JSON.parse(match[1]).imports ?? {};
+}
+
+function hasEsmShReactImportMapValue(imports: Record<string, string>): boolean {
+  for (const value of Object.values(imports)) {
+    try {
+      const url = new URL(value);
+      if (url.hostname === "esm.sh" && url.pathname.startsWith("/react")) return true;
+    } catch {
+      // Not an absolute URL import-map value.
+    }
+  }
+  return false;
+}
+
 describe(
   "build/production-build/static-generation",
   { sanitizeOps: false, sanitizeResources: false },
   () => {
+    const originalFlag = getHostEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG);
+
+    afterEach(() => {
+      setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, originalFlag ?? "");
+    });
+
     describe("buildAppRoutes", () => {
       it("should return empty stats for empty routes", async () => {
         const stats = await buildAppRoutes([], {
@@ -281,6 +308,144 @@ describe(
         assertEquals(pageData.html, "<main><div>Page content</div></main>");
         assertEquals(pageData.html.includes("<script"), false);
         assertEquals(pageData.html.includes("<!DOCTYPE html>"), false);
+      });
+
+      it("does not inject a second import map when the renderer already emitted one", async () => {
+        const adapter = createMemoryAdapter();
+        const renderer = {
+          renderPage: () =>
+            Promise.resolve({
+              html:
+                '<html><head><script type="importmap">{"imports":{"react":"/react.js"}}</script></head><body><div>content</div></body></html>',
+              frontmatter: {},
+              headings: [],
+            }),
+          destroy: () => Promise.resolve(),
+        } as unknown as VeryfrontRenderer;
+
+        await buildPagesRoutes(
+          [{ slug: "blog", path: "/blog", file: "pages/blog.mdx" }],
+          {
+            adapter,
+            projectDir: "/tmp/project",
+            outputDir: "/tmp/output",
+            renderer,
+            config: createMockConfig(),
+            enablePrefetch: false,
+            chunkManifest: null,
+            dryRun: false,
+          },
+        );
+
+        const html = adapter.fs.files.get("/tmp/output/blog/index.html") ?? "";
+        const importMapCount = html.match(/<script type="importmap">/g)?.length ?? 0;
+        assertEquals(importMapCount, 1);
+        assertStringIncludes(html, "Basic styles");
+      });
+
+      it("uses the release asset manifest for rendered and injected import maps", async () => {
+        setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
+        const adapter = createMemoryAdapter();
+        const reactHash = "1".repeat(64);
+        const reactDomHash = "2".repeat(64);
+        const reactDomClientHash = "3".repeat(64);
+        const jsxRuntimeHash = "4".repeat(64);
+        const jsxDevRuntimeHash = "5".repeat(64);
+        const headHash = "6".repeat(64);
+        const manifest: ReleaseAssetManifest = {
+          schemaVersion: 1,
+          projectId: "local-project",
+          releaseId: "standalone-dev",
+          releaseVersion: 0,
+          manifestVersion: 1,
+          builderVersion: "0.1.810",
+          sourceContentHash: "source",
+          createdAt: "2026-06-15T00:00:00.000Z",
+          assetBasePath: "/_vf/assets",
+          modules: {},
+          css: [],
+          routes: {},
+          dependencies: {
+            react: {
+              contentHash: reactHash,
+              size: 10,
+              contentType: "text/javascript",
+            },
+            "react-dom": {
+              contentHash: reactDomHash,
+              size: 10,
+              contentType: "text/javascript",
+            },
+            "react-dom/client": {
+              contentHash: reactDomClientHash,
+              size: 10,
+              contentType: "text/javascript",
+            },
+            "react/jsx-runtime": {
+              contentHash: jsxRuntimeHash,
+              size: 10,
+              contentType: "text/javascript",
+            },
+            "react/jsx-dev-runtime": {
+              contentHash: jsxDevRuntimeHash,
+              size: 10,
+              contentType: "text/javascript",
+            },
+            "veryfront/head": {
+              contentHash: headHash,
+              size: 10,
+              contentType: "text/javascript",
+            },
+            "veryfront/react/head": {
+              contentHash: headHash,
+              size: 10,
+              contentType: "text/javascript",
+            },
+          },
+          fallback: { mode: "jit", gaps: [] },
+        };
+        const renderer = {
+          renderPage: (
+            _slug: string,
+            options?: { releaseAssetManifest?: ReleaseAssetManifest | null },
+          ) => {
+            assertEquals(options?.releaseAssetManifest, manifest);
+            return Promise.resolve({
+              html: "<html><head></head><body><div>content</div></body></html>",
+              frontmatter: {},
+              headings: [],
+            });
+          },
+          destroy: () => Promise.resolve(),
+        } as unknown as VeryfrontRenderer;
+
+        await buildPagesRoutes(
+          [{ slug: "blog", path: "/blog", file: "pages/blog.mdx" }],
+          {
+            adapter,
+            projectDir: "/tmp/project",
+            outputDir: "/tmp/output",
+            renderer,
+            config: createMockConfig(),
+            enablePrefetch: false,
+            chunkManifest: null,
+            dryRun: false,
+            releaseAssetManifest: manifest,
+          },
+        );
+
+        const html = adapter.fs.files.get("/tmp/output/blog/index.html") ?? "";
+        assertStringIncludes(html, `"/_vf/assets/${reactHash}.js"`);
+        assertStringIncludes(html, `"/_vf/assets/${headHash}.js"`);
+        assertEquals(hasEsmShReactImportMapValue(extractImportMapImports(html)), false);
+        assertEquals(
+          html.includes('"veryfront/head": "/_vf_modules/_veryfront/react/runtime/core.js"'),
+          false,
+        );
+        assertEquals(
+          html.includes('"veryfront/react/head": "/_vf_modules/_veryfront/react/runtime/core.js"'),
+          false,
+        );
       });
 
       it("records generated Pages Router paths in SSG stats", async () => {

--- a/src/build/production-build/static-generation.ts
+++ b/src/build/production-build/static-generation.ts
@@ -12,7 +12,8 @@ import type { ChunkManifest } from "#veryfront/build/bundler/index.ts";
 import { renderAppRouteToHTML } from "#veryfront/server/build-app-route-renderer.ts";
 import type { AppRouteInfo, RouteInfo } from "#veryfront/server/build-types.ts";
 import { loadClientStyles } from "./asset-generation.ts";
-import { generateImportMap } from "./client-runtime.ts";
+import { buildImportMap } from "#veryfront/html/utils.ts";
+import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import {
   cacheCSSAsync,
   extractCandidatesFromFiles,
@@ -56,6 +57,7 @@ export interface SSGOptions {
   traceStep?: <T>(name: string, fn: () => Promise<T>) => Promise<T>;
   /** React version for import map generation */
   reactVersion?: string;
+  releaseAssetManifest?: ReleaseAssetManifest | null;
 }
 
 function getOutputPath(outputDir: string, slug: string): string {
@@ -74,6 +76,10 @@ function defaultTraceStep<T>(_: string, fn: () => Promise<T>): Promise<T> {
 
 function getByteLength(text: string): number {
   return new TextEncoder().encode(text).length;
+}
+
+function hasImportMapScript(html: string): boolean {
+  return /<script\b[^>]*\btype=(["'])importmap\1/i.test(html);
 }
 
 function extractClientNavigationHtml(html: string): string {
@@ -211,7 +217,11 @@ export async function buildPagesRoutes(
     try {
       const result = await traceStep(
         `page:${route.slug}`,
-        () => renderer.renderPage(route.slug, { contentSourceId }),
+        () =>
+          renderer.renderPage(route.slug, {
+            contentSourceId,
+            releaseAssetManifest: options.releaseAssetManifest,
+          }),
       );
 
       let enhancedHtml = result.html;
@@ -228,18 +238,37 @@ export async function buildPagesRoutes(
         enhancedHtml = enhancedHtml.replace("</head>", `${preloadLinks}\n</head>`);
       }
 
-      const importMap = await generateImportMap();
-      enhancedHtml = enhancedHtml.replace(
-        "</head>",
-        `
-${importMap}
+      if (!hasImportMapScript(enhancedHtml)) {
+        const importMap = await buildImportMap({
+          projectDir: options.projectDir,
+          config: options.config,
+          releaseAssetManifest: options.releaseAssetManifest,
+        });
+        enhancedHtml = enhancedHtml.replace(
+          "</head>",
+          `
+  <!-- Import map for React dependencies -->
+  <script type="importmap">
+  ${importMap.json}
+  </script>
 
   <!-- Basic styles -->
   <style>
 ${clientStyles}
   </style>
 </head>`,
-      );
+        );
+      } else {
+        enhancedHtml = enhancedHtml.replace(
+          "</head>",
+          `
+  <!-- Basic styles -->
+  <style>
+${clientStyles}
+  </style>
+</head>`,
+        );
+      }
 
       enhancedHtml = enhancedHtml.replace(
         "</body>",
@@ -327,6 +356,7 @@ export async function buildAppRoutes(
           pageFile: route.pageFile,
           contentSourceId,
           reactVersion,
+          releaseAssetManifest: options.releaseAssetManifest,
           stylesheetHref,
           includePreviewStylesheet: false,
         }));

--- a/src/html/utils.test.ts
+++ b/src/html/utils.test.ts
@@ -271,6 +271,54 @@ describe("html-generation/utils", () => {
       assertEquals(imports["react/jsx-dev-runtime"], `/_vf/assets/${"5".repeat(64)}.js`);
     });
 
+    it("rewrites local Veryfront import-map aliases from manifest dependency keys", async () => {
+      setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
+      const headHash = "a".repeat(64);
+      const workflowHash = "b".repeat(64);
+      const manifest: ReleaseAssetManifest = {
+        schemaVersion: 1,
+        projectId: "project-id",
+        releaseId: "release-id",
+        releaseVersion: 1,
+        manifestVersion: 1,
+        builderVersion: "0.1.810",
+        sourceContentHash: "source",
+        createdAt: "2026-06-15T00:00:00.000Z",
+        assetBasePath: "/_vf/assets",
+        modules: {},
+        css: [],
+        routes: {},
+        dependencies: {
+          "veryfront/head": {
+            contentHash: headHash,
+            size: 10,
+            contentType: "text/javascript",
+          },
+          "veryfront/react/head": {
+            contentHash: headHash,
+            size: 10,
+            contentType: "text/javascript",
+          },
+          "veryfront/workflow": {
+            contentHash: workflowHash,
+            size: 10,
+            contentType: "text/javascript",
+          },
+        },
+        fallback: { mode: "jit", gaps: [] },
+      };
+
+      const result = await buildImportMapJson({
+        pretty: false,
+        releaseAssetManifest: manifest,
+      });
+      const imports = JSON.parse(result).imports as Record<string, string>;
+
+      assertEquals(imports["veryfront/head"], `/_vf/assets/${headHash}.js`);
+      assertEquals(imports["veryfront/react/head"], `/_vf/assets/${headHash}.js`);
+      assertEquals(imports["veryfront/workflow"], `/_vf/assets/${workflowHash}.js`);
+    });
+
     it("refreshes cached import maps when project package versions change", async () => {
       const dir = await Deno.makeTempDir({ prefix: "vf-import-map-cache-" });
 

--- a/src/html/utils.ts
+++ b/src/html/utils.ts
@@ -333,15 +333,14 @@ function applyManifestDependencies(
 
   return Object.fromEntries(
     Object.entries(imports).map(([specifier, url]) => {
-      if (!url.startsWith("http://") && !url.startsWith("https://")) {
-        return [specifier, url];
-      }
+      const directAsset = dependencyAssets.get(specifier);
+      if (directAsset) return [specifier, directAsset];
 
-      return [
-        specifier,
-        dependencyAssets.get(specifier) ?? dependencyAssets.get(url) ??
-          dependencyAssets.get(canonicalDependencyUrl(url)) ?? url,
-      ];
+      const urlAsset = dependencyAssets.get(url) ??
+        dependencyAssets.get(canonicalDependencyUrl(url));
+      if (urlAsset) return [specifier, urlAsset];
+
+      return [specifier, url];
     }),
   );
 }

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -4,6 +4,7 @@ import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import { normalizeHttpUrl } from "#veryfront/transforms/esm/http-cache.ts";
+import { parseImports } from "#veryfront/transforms/esm/lexer.ts";
 import {
   RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG,
   RELEASE_ASSET_MAX_SIZE_BYTES,
@@ -75,6 +76,19 @@ function fakeHttpCachePath(url: string): string {
     .join("")
     .slice(0, 32);
   return `/tmp/veryfront-http-bundle/http-${hash}.mjs`;
+}
+
+async function hasEsmShReactImport(code: string): Promise<boolean> {
+  for (const imp of await parseImports(code)) {
+    if (!imp.n) continue;
+    try {
+      const url = new URL(imp.n);
+      if (url.hostname === "esm.sh" && url.pathname.startsWith("/react")) return true;
+    } catch {
+      // Not an absolute URL import.
+    }
+  }
+  return false;
 }
 
 function fakeVendorHttpImports(code: string): Promise<ReleaseAssetVendorResult> {
@@ -235,6 +249,103 @@ describe("release asset build executor", () => {
       manifest.dependencies["veryfront/head"]?.contentHash,
       manifest.dependencies["veryfront/react/head"]?.contentHash,
     );
+  });
+
+  it("keeps framework dependency assets on the vendored React instance", async () => {
+    enableDependencyImportMap();
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const frameworkUrl = "/_vf_modules/_veryfront/react/runtime/core.js";
+    const files = [{
+      path: "pages/blog.mdx",
+      content: 'import { Head } from "veryfront/head"; export default Head;',
+    }];
+    const client = makeClient(files, rec);
+    const transform = (_source: string, sourceFile: string) => {
+      if (sourceFile.endsWith("pages/blog.mdx")) {
+        return Promise.resolve(`import { Head } from "${frameworkUrl}"; export default Head;`);
+      }
+      if (sourceFile.endsWith("src/react/runtime/core.ts")) {
+        return Promise.resolve(
+          'import React, { useEffect } from "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3"; export function Head() { useEffect(() => {}, []); return React.createElement("div"); }',
+        );
+      }
+      return Promise.resolve("export const value = true;");
+    };
+
+    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    const reactHash = manifest.dependencies.react?.contentHash;
+    const headHash = manifest.dependencies["veryfront/head"]?.contentHash;
+    const pageHash = manifest.modules["pages/blog.mdx"]?.contentHash;
+    assertExists(reactHash);
+    assertExists(headHash);
+    assertExists(pageHash);
+
+    const headUpload = rec.uploads.find((u) => u.hash === headHash);
+    assertExists(headUpload);
+    assert(headUpload.text.includes(`"/_vf/assets/${reactHash}.js"`));
+    assertEquals(await hasEsmShReactImport(headUpload.text), false);
+
+    const pageUpload = rec.uploads.find((u) => u.hash === pageHash);
+    assertExists(pageUpload);
+    assert(pageUpload.text.includes(`"/_vf/assets/${headHash}.js"`));
+    assert(!pageUpload.text.includes(frameworkUrl));
+  });
+
+  it("rewrites transitive framework dependency imports to immutable assets", async () => {
+    enableDependencyImportMap();
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const fontsUrl = "/_vf_modules/_veryfront/react/fonts/index.js";
+    const files = [{
+      path: "pages/fonts.mdx",
+      content: 'import { FontHead } from "veryfront/fonts"; export default FontHead;',
+    }];
+    const client = makeClient(files, rec);
+    const transform = (_source: string, sourceFile: string) => {
+      if (sourceFile.endsWith("pages/fonts.mdx")) {
+        return Promise.resolve(`import { FontHead } from "${fontsUrl}"; export default FontHead;`);
+      }
+      if (sourceFile.endsWith("src/react/fonts/index.ts")) {
+        return Promise.resolve(
+          'import { InternalHead } from "../components/Head.js"; export const FontHead = InternalHead;',
+        );
+      }
+      if (sourceFile.endsWith("src/react/components/Head.tsx")) {
+        return Promise.resolve(
+          'import React from "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3"; export function InternalHead() { return React.createElement("title"); }',
+        );
+      }
+      return Promise.resolve("export const value = true;");
+    };
+
+    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    const reactHash = manifest.dependencies.react?.contentHash;
+    const fontsHash = manifest.dependencies["veryfront/fonts"]?.contentHash;
+    const pageHash = manifest.modules["pages/fonts.mdx"]?.contentHash;
+    assertExists(reactHash);
+    assertExists(fontsHash);
+    assertExists(pageHash);
+
+    const fontsUpload = rec.uploads.find((u) => u.hash === fontsHash);
+    assertExists(fontsUpload);
+    assert(!fontsUpload.text.includes("../components/Head"));
+    const internalHeadMatch = fontsUpload.text.match(/"\/_vf\/assets\/([a-f0-9]{64})\.js"/);
+    assertExists(internalHeadMatch?.[1]);
+
+    const internalHeadUpload = rec.uploads.find((u) => u.hash === internalHeadMatch[1]);
+    assertExists(internalHeadUpload);
+    assert(internalHeadUpload.text.includes(`"/_vf/assets/${reactHash}.js"`));
+    assertEquals(await hasEsmShReactImport(internalHeadUpload.text), false);
+
+    const pageUpload = rec.uploads.find((u) => u.hash === pageHash);
+    assertExists(pageUpload);
+    assert(pageUpload.text.includes(`"/_vf/assets/${fontsHash}.js"`));
+    assert(!pageUpload.text.includes(fontsUrl));
   });
 
   it("matches React import-map dependencies by normalized HTTP manifest key", async () => {

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -20,7 +20,12 @@ import { VERSION } from "#veryfront/utils/version.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { dirname, join, normalize } from "#veryfront/compat/path/index.ts";
-import { resolveFrameworkSourcePath } from "#veryfront/platform/compat/framework-source-resolver.ts";
+import {
+  FRAMEWORK_EMBEDDED_SRC_DIR,
+  FRAMEWORK_SRC_DIR,
+  resolveFrameworkSourcePath,
+  resolveRelativeFrameworkSourceImport,
+} from "#veryfront/platform/compat/framework-source-resolver.ts";
 import { transformToESM } from "#veryfront/transforms/esm-transform.ts";
 import { cacheHttpImportsToLocal, normalizeHttpUrl } from "#veryfront/transforms/esm/http-cache.ts";
 import { extractSourceUrl } from "#veryfront/transforms/esm/source-url-embed.ts";
@@ -217,6 +222,22 @@ function frameworkModuleUrlToSourceKey(moduleUrl: string): string | null {
     .replace(/\.(mjs|cjs|js|jsx|ts|tsx)$/, "");
 }
 
+function frameworkSourceKeyToModuleUrl(sourceKey: string): string {
+  return `${FRAMEWORK_MODULE_URL_PREFIX}${sourceKey}.js`;
+}
+
+function frameworkSourcePathToSourceKey(sourcePath: string, lookupDirs: string[]): string | null {
+  for (const lookupDir of lookupDirs) {
+    if (!sourcePath.startsWith(`${lookupDir}/`)) continue;
+    const relativePath = sourcePath.slice(lookupDir.length + 1)
+      .replace(/\.src$/, "")
+      .replace(/\.(tsx?|jsx?|mjs|mdx?|js)$/, "");
+    return normalizeLogicalPath(relativePath);
+  }
+
+  return null;
+}
+
 /** Sanitize an error for state reporting (no internal paths / stack traces). */
 function sanitizeError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
@@ -400,11 +421,11 @@ async function rewriteProjectModuleImports(
   dependencyUrls: Map<string, string>,
 ): Promise<string> {
   function rewriteSpecifier(specifier: string): string | null {
-    const dependencyUrl = dependencyUrls.get(specifier.replace(/[?#].*$/, ""));
+    const dependencyUrl = dependencyUrlForSpecifier(dependencyUrls, specifier);
     if (dependencyUrl) return dependencyUrl;
 
     if (specifier.startsWith("/_vf_modules/")) {
-      const dependencyUrl = dependencyUrls.get(specifier.replace(/[?#].*$/, ""));
+      const dependencyUrl = dependencyUrlForSpecifier(dependencyUrls, specifier);
       if (dependencyUrl) return dependencyUrl;
     }
 
@@ -416,6 +437,30 @@ async function rewriteProjectModuleImports(
   return await replaceSpecifiers(code, (specifier) => rewriteSpecifier(specifier));
 }
 
+function dependencyUrlForSpecifier(
+  dependencyUrls: Map<string, string>,
+  specifier: string,
+): string | null {
+  const direct = dependencyUrls.get(specifier) ??
+    dependencyUrls.get(normalizeDependencySpecifier(specifier));
+  if (direct) return direct;
+
+  if (specifier.startsWith("http://") || specifier.startsWith("https://")) {
+    const normalized = normalizeHttpUrl(specifier);
+    return dependencyUrls.get(normalized) ??
+      dependencyUrls.get(normalizeDependencySpecifier(normalized)) ?? null;
+  }
+
+  return null;
+}
+
+export function releaseAssetDependencyUrlForSpecifier(
+  dependencyUrls: Map<string, string>,
+  specifier: string,
+): string | null {
+  return dependencyUrlForSpecifier(dependencyUrls, specifier);
+}
+
 function buildDependencyUrlMap(
   dependencies: Record<string, PreparedAsset>,
   dependencyModules?: Map<string, DependencyModule>,
@@ -423,16 +468,36 @@ function buildDependencyUrlMap(
   const urls = new Map<string, string>();
   for (const [manifestKey, entry] of Object.entries(dependencies)) {
     const dependency = dependencyModules?.get(manifestKey);
+    const url = releaseAssetUrl(entry.contentHash, "js");
+
+    urls.set(manifestKey, url);
+    urls.set(normalizeDependencySpecifier(manifestKey), url);
+    if (manifestKey.startsWith("http://") || manifestKey.startsWith("https://")) {
+      const normalized = normalizeHttpUrl(manifestKey);
+      urls.set(normalized, url);
+      urls.set(normalizeDependencySpecifier(normalized), url);
+    }
+
     if (!dependency) continue;
 
-    const url = releaseAssetUrl(entry.contentHash, "js");
-    urls.set(manifestKey, url);
     urls.set(entry.logicalPath, url);
     for (const specifier of dependency.specifiers) {
+      urls.set(specifier, url);
       urls.set(normalizeDependencySpecifier(specifier), url);
+      if (specifier.startsWith("http://") || specifier.startsWith("https://")) {
+        const normalized = normalizeHttpUrl(specifier);
+        urls.set(normalized, url);
+        urls.set(normalizeDependencySpecifier(normalized), url);
+      }
     }
   }
   return urls;
+}
+
+export function buildReleaseAssetDependencyUrlMap(
+  dependencies: Record<string, PreparedAsset>,
+): Map<string, string> {
+  return buildDependencyUrlMap(dependencies);
 }
 
 function exposeDependencySpecifierAliases(
@@ -1112,25 +1177,54 @@ async function buildFrameworkDependencies(
   input: ReleaseAssetBuildInput,
   tempDir: string,
   transform: ReleaseAssetTransform,
+  dependencyUrls: Map<string, string>,
   uploadQueue: PreparedAsset[],
   pendingBytes: Map<string, { bytes: Uint8Array<ArrayBuffer>; contentType: string }>,
   gaps: string[],
 ): Promise<Record<string, PreparedAsset>> {
   const fs = createFileSystem();
   const dependencies: Record<string, PreparedAsset> = {};
+  const lookupDirs = [FRAMEWORK_SRC_DIR, FRAMEWORK_EMBEDDED_SRC_DIR, join(tempDir, "src")];
+  const moduleAssets = new Map<string, PreparedAsset>();
+  const visiting = new Set<string>();
 
-  for (const [specifier, moduleUrl] of Object.entries(PLATFORM_UTILITIES)) {
-    const sourceKey = frameworkModuleUrlToSourceKey(moduleUrl);
-    if (!sourceKey) continue;
+  async function resolveFrameworkImport(
+    specifier: string,
+    fromSourcePath: string,
+  ): Promise<string | null> {
+    if (specifier.startsWith("./") || specifier.startsWith("../")) {
+      const resolvedPath = await resolveRelativeFrameworkSourceImport(specifier, fromSourcePath);
+      return resolvedPath ? frameworkSourcePathToSourceKey(resolvedPath, lookupDirs) : null;
+    }
+
+    if (specifier.startsWith(FRAMEWORK_MODULE_URL_PREFIX)) {
+      return frameworkModuleUrlToSourceKey(specifier);
+    }
+
+    return null;
+  }
+
+  async function processFrameworkModule(
+    sourceKey: string,
+    publicSpecifier: string,
+  ): Promise<PreparedAsset | null> {
+    const existing = moduleAssets.get(sourceKey);
+    if (existing) return existing;
+
+    if (visiting.has(sourceKey)) {
+      gaps.push(`dependency-cycle:${publicSpecifier}:${sourceKey}`);
+      return null;
+    }
 
     const frameworkSource = await resolveFrameworkSourcePath(sourceKey, {
       extraLookupDirs: [join(tempDir, "src")],
     });
     if (!frameworkSource) {
-      gaps.push(`dependency-missing:${specifier}`);
-      continue;
+      gaps.push(`dependency-missing:${publicSpecifier}:${sourceKey}`);
+      return null;
     }
 
+    visiting.add(sourceKey);
     let code: string;
     try {
       const source = await fs.readTextFile(frameworkSource.path);
@@ -1140,23 +1234,67 @@ async function buildFrameworkDependencies(
         ssr: false,
         reactVersion: input.reactVersion,
       });
+
+      const frameworkImportUrls = new Map<string, string>();
+      let hasUnresolvedFrameworkImport = false;
+      for (const imp of await parseImports(code)) {
+        if (!imp.n) continue;
+
+        const importedSourceKey = await resolveFrameworkImport(imp.n, frameworkSource.path);
+        if (!importedSourceKey) continue;
+
+        const importedAsset = await processFrameworkModule(importedSourceKey, publicSpecifier);
+        if (!importedAsset) {
+          hasUnresolvedFrameworkImport = true;
+          break;
+        }
+        frameworkImportUrls.set(imp.n, releaseAssetUrl(importedAsset.contentHash, "js"));
+      }
+      if (hasUnresolvedFrameworkImport) {
+        visiting.delete(sourceKey);
+        return null;
+      }
+
+      code = await replaceSpecifiers(
+        code,
+        (specifier) =>
+          frameworkImportUrls.get(specifier) ??
+            dependencyUrlForSpecifier(dependencyUrls, specifier),
+      );
     } catch (error) {
-      gaps.push(`dependency-transform-failed:${specifier}`);
+      gaps.push(`dependency-transform-failed:${publicSpecifier}:${sourceKey}`);
       logger.warn("Framework dependency transform failed during release asset build", {
-        specifier,
+        specifier: publicSpecifier,
+        sourceKey,
         error: sanitizeError(error),
       });
-      continue;
+      visiting.delete(sourceKey);
+      return null;
     }
 
+    visiting.delete(sourceKey);
+
     const entry = await addPreparedJavaScriptAsset(
-      `__dependencies__/${specifier}`,
+      `__dependencies__/${frameworkSourceKeyToModuleUrl(sourceKey)}`,
       code,
       uploadQueue,
       pendingBytes,
     );
     if (!entry) {
-      gaps.push(`dependency-oversized:${specifier}`);
+      gaps.push(`dependency-oversized:${publicSpecifier}:${sourceKey}`);
+      return null;
+    }
+
+    moduleAssets.set(sourceKey, entry);
+    return entry;
+  }
+
+  for (const [specifier, moduleUrl] of Object.entries(PLATFORM_UTILITIES)) {
+    const sourceKey = frameworkModuleUrlToSourceKey(moduleUrl);
+    if (!sourceKey) continue;
+
+    const entry = await processFrameworkModule(sourceKey, specifier);
+    if (!entry) {
       continue;
     }
 
@@ -1164,6 +1302,70 @@ async function buildFrameworkDependencies(
   }
 
   return dependencies;
+}
+
+export async function buildFrameworkDependencyAssets(options: {
+  tempDir: string;
+  // deno-lint-ignore no-explicit-any -- adapter is passed through to transformToESM
+  adapter: any;
+  reactVersion?: string;
+  projectId?: string;
+  transform?: ReleaseAssetTransform;
+  dependencyUrls: Map<string, string>;
+}): Promise<{
+  dependencies: Record<string, PreparedAsset>;
+  assets: PreparedReleaseAsset[];
+  gaps: string[];
+}> {
+  const uploadQueue: PreparedAsset[] = [];
+  const pendingBytes = new Map<string, { bytes: Uint8Array<ArrayBuffer>; contentType: string }>();
+  const gaps: string[] = [];
+  const transform = options.transform ?? transformToESM;
+  const dependencies = await buildFrameworkDependencies(
+    {
+      projectReference: options.projectId ?? "local",
+      projectId: options.projectId ?? "local",
+      releaseId: "local",
+      releaseVersion: 0,
+      releaseVersionRef: "local",
+      reactVersion: options.reactVersion,
+      client: undefined as unknown as ReleaseAssetBuildClient,
+      adapter: options.adapter,
+      transform,
+    },
+    options.tempDir,
+    transform,
+    options.dependencyUrls,
+    uploadQueue,
+    pendingBytes,
+    gaps,
+  );
+
+  return {
+    dependencies,
+    assets: uploadQueue.flatMap((asset) => {
+      const stored = pendingBytes.get(asset.contentHash);
+      if (!stored) return [];
+      return [{
+        ...asset,
+        bytes: stored.bytes,
+      }];
+    }),
+    gaps,
+  };
+}
+
+function addFrameworkDependencyUrlAliases(
+  urls: Map<string, string>,
+  dependencies: Record<string, PreparedAsset>,
+): void {
+  for (const [specifier, entry] of Object.entries(dependencies)) {
+    const url = releaseAssetUrl(entry.contentHash, "js");
+    urls.set(specifier, url);
+
+    const moduleUrl = PLATFORM_UTILITIES[specifier];
+    if (moduleUrl) urls.set(moduleUrl, url);
+  }
 }
 
 /**
@@ -1391,14 +1593,6 @@ async function runBuildInner(
     }
   }
 
-  const frameworkDependencies = await buildFrameworkDependencies(
-    input,
-    tempDir,
-    transform,
-    uploadQueue,
-    pendingBytes,
-    gaps,
-  );
   let httpDependencies: Record<string, PreparedAsset>;
   let httpDependencyFallbackUrls: Map<string, string>;
   try {
@@ -1431,11 +1625,21 @@ async function runBuildInner(
     };
   }
   httpDependencies = exposeDependencySpecifierAliases(httpDependencies, dependencyModules);
-  const dependencies = { ...frameworkDependencies, ...httpDependencies };
-  const dependencyUrls = buildDependencyUrlMap(dependencies, dependencyModules);
+  const dependencyUrls = buildDependencyUrlMap(httpDependencies, dependencyModules);
   for (const [specifier, url] of httpDependencyFallbackUrls) {
     dependencyUrls.set(specifier, url);
   }
+  const frameworkDependencies = await buildFrameworkDependencies(
+    input,
+    tempDir,
+    transform,
+    dependencyUrls,
+    uploadQueue,
+    pendingBytes,
+    gaps,
+  );
+  if (vendorDependencies) addFrameworkDependencyUrlAliases(dependencyUrls, frameworkDependencies);
+  const dependencies = { ...frameworkDependencies, ...httpDependencies };
 
   const { modules, skippedModules } = await finalizeProjectModules(
     transformedModules,

--- a/src/server/build-app-route-renderer.test.ts
+++ b/src/server/build-app-route-renderer.test.ts
@@ -3,6 +3,9 @@ import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/tes
 import { denoAdapter } from "#veryfront/platform/adapters/deno.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { renderAppRouteToHTML } from "./build-app-route-renderer.ts";
+import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import { RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
+import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 
 async function makeProject(): Promise<{ projectDir: string; pageFile: string }> {
   const projectDir = await Deno.makeTempDir({ prefix: "vf-app-route-renderer-" });
@@ -64,12 +67,19 @@ function extractHydrationData(html: string): Record<string, unknown> {
   return JSON.parse(match[1]);
 }
 
+function extractImportMapImports(html: string): Record<string, string> {
+  const match = html.match(/<script type="importmap">([\s\S]*?)<\/script>/);
+  assertExists(match?.[1], "expected import map script");
+  return JSON.parse(match[1]).imports ?? {};
+}
+
 Deno.test({
   name:
     "server/build-app-route-renderer renders App Router HTML with Veryfront hydration data and runtime",
   sanitizeOps: false,
   sanitizeResources: false,
   async fn() {
+    const originalFlag = getHostEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG);
     const { projectDir, pageFile } = await makeProject();
 
     try {
@@ -93,7 +103,68 @@ Deno.test({
       assertEquals(hydrationData.slug, "");
       assertEquals(hydrationData.clientModuleStrategy, "rsc-module");
       assertEquals(hydrationData.layouts, [{ kind: "tsx", path: "app/layout.tsx" }]);
+
+      setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
+      const reactHash = "1".repeat(64);
+      const reactDomHash = "2".repeat(64);
+      const reactDomClientHash = "3".repeat(64);
+      const jsxRuntimeHash = "4".repeat(64);
+      const jsxDevRuntimeHash = "5".repeat(64);
+      const manifest: ReleaseAssetManifest = {
+        schemaVersion: 1,
+        projectId: "local-project",
+        releaseId: "standalone-dev",
+        releaseVersion: 0,
+        manifestVersion: 1,
+        builderVersion: "0.1.810",
+        sourceContentHash: "source",
+        createdAt: "2026-06-15T00:00:00.000Z",
+        assetBasePath: "/_vf/assets",
+        modules: {},
+        css: [],
+        routes: {},
+        dependencies: {
+          react: {
+            contentHash: reactHash,
+            size: 10,
+            contentType: "text/javascript",
+          },
+          "react-dom": {
+            contentHash: reactDomHash,
+            size: 10,
+            contentType: "text/javascript",
+          },
+          "react-dom/client": {
+            contentHash: reactDomClientHash,
+            size: 10,
+            contentType: "text/javascript",
+          },
+          "react/jsx-runtime": {
+            contentHash: jsxRuntimeHash,
+            size: 10,
+            contentType: "text/javascript",
+          },
+          "react/jsx-dev-runtime": {
+            contentHash: jsxDevRuntimeHash,
+            size: 10,
+            contentType: "text/javascript",
+          },
+        },
+        fallback: { mode: "jit", gaps: [] },
+      };
+      const releaseHtml = await renderAppRouteToHTML({
+        adapter: denoAdapter,
+        projectDir,
+        routePath: "/",
+        pageFile,
+        contentSourceId: "test-content-source",
+        releaseAssetManifest: manifest,
+      });
+
+      assertStringIncludes(releaseHtml, `"/_vf/assets/${reactHash}.js"`);
+      assertEquals(extractImportMapImports(releaseHtml).react, `/_vf/assets/${reactHash}.js`);
     } finally {
+      setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, originalFlag ?? "");
       await Deno.remove(projectDir, { recursive: true }).catch(() => undefined);
     }
   },

--- a/src/server/build-app-route-renderer.ts
+++ b/src/server/build-app-route-renderer.ts
@@ -10,6 +10,7 @@ import { loadComponentFromSource } from "#veryfront/modules/react-loader/index.t
 import { COMPILATION_ERROR } from "#veryfront/errors/index.ts";
 import { generateHydrationData, getProdScripts } from "#veryfront/html";
 import { buildImportMapJson } from "#veryfront/html/utils.ts";
+import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import { getPreviewStylesheetLink } from "#veryfront/html/dev-scripts.ts";
 import {
   shouldUnwrapAppRouterDocumentLayout,
@@ -79,6 +80,7 @@ export async function renderAppRouteToHTML(args: {
   pageFile: string;
   contentSourceId: string;
   reactVersion?: string;
+  releaseAssetManifest?: ReleaseAssetManifest | null;
   stylesheetHref?: string;
   includePreviewStylesheet?: boolean;
 }): Promise<string> {
@@ -88,6 +90,7 @@ export async function renderAppRouteToHTML(args: {
     routePath,
     pageFile,
     contentSourceId,
+    releaseAssetManifest,
     stylesheetHref,
     includePreviewStylesheet,
   } = args;
@@ -143,7 +146,7 @@ export async function renderAppRouteToHTML(args: {
   const htmlInner = await renderToStringAdapter(element);
   const title = "Veryfront App";
   const slug = routePathToSlug(routePath);
-  const importMapJson = await buildImportMapJson({ projectDir });
+  const importMapJson = await buildImportMapJson({ projectDir, releaseAssetManifest });
   const hydrationData = hasUseClientDirective(pageSource)
     ? generateHydrationData(
       slug,
@@ -155,6 +158,7 @@ export async function renderAppRouteToHTML(args: {
         projectDir,
         pagePath: pageFile,
         pageType: "tsx",
+        releaseAssetManifest,
         isLocalProject: false,
         forceProductionScripts: true,
         nestedLayouts: layouts.map((layoutPath) => ({ kind: "tsx", path: layoutPath })),

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.809";
+export const VERSION = "0.1.810";


### PR DESCRIPTION
## Summary
- generate the local release asset manifest before route HTML rendering so build-time import maps can consume it
- include Veryfront framework import-map aliases in release dependency assets
- rewrite framework runtime imports such as `veryfront/head` to the same vendored React asset used by app bundles
- recursively rewrite transitive framework-relative imports, such as `veryfront/fonts -> ../components/Head.js`, to immutable release assets before publishing aliases
- bump package version to `0.1.810`

