### PR TITLE
Expose render cache status in request timing

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.810",
+  "version": "0.1.811",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/observability/request-profiler.test.ts
+++ b/src/observability/request-profiler.test.ts
@@ -4,6 +4,7 @@ import {
   buildServerTimingHeader,
   finalizeRequestProfiling,
   isRequestProfilingEnabled,
+  markRequestProfilePhase,
   profilePhase,
   resetRequestProfiles,
   runWithRequestProfiling,
@@ -43,6 +44,7 @@ describe("request profiler", () => {
       async () => {
         updateRequestProfileContext({ projectSlug: "site", requestMode: "production" });
         await profilePhase("runtime.resolve_project", () => Promise.resolve());
+        markRequestProfilePhase("render.cache_hit");
         return finalizeRequestProfiling(200);
       },
     );
@@ -52,6 +54,7 @@ describe("request profiler", () => {
     assertEquals(result.requestMode, "production");
     assertEquals(result.status, 200);
     assert("runtime.resolve_project" in result.phases);
+    assertEquals(result.phases["render.cache_hit"], 0);
   });
 
   it("formats a Server-Timing header from total and phase durations", () => {

--- a/src/observability/request-profiler.ts
+++ b/src/observability/request-profiler.ts
@@ -102,6 +102,13 @@ export async function profilePhase<T>(name: string, fn: () => Promise<T>): Promi
   }
 }
 
+export function markRequestProfilePhase(name: string, durationMs = 0): void {
+  const session = storage.getStore();
+  if (!session) return;
+
+  session.phases.set(name, roundMs((session.phases.get(name) ?? 0) + durationMs));
+}
+
 export function profileSyncPhase<T>(name: string, fn: () => T): T {
   const session = storage.getStore();
   if (!session) return fn();

--- a/src/rendering/cache/cache-coordinator.test.ts
+++ b/src/rendering/cache/cache-coordinator.test.ts
@@ -24,11 +24,15 @@ describe("CacheCoordinator", () => {
 
     const lookupMiss = await coordinator.checkCache(slug);
     assertEquals(lookupMiss.cachedResult, undefined);
+    assertEquals(lookupMiss.cacheStatus, "miss");
+    assertEquals(typeof lookupMiss.lookupDurationMs, "number");
 
     await coordinator.persistResult(makeResult("<html>hello</html>"), slug);
 
     const lookupHit = await coordinator.checkCache(slug);
     assertObjectMatch(lookupHit.cachedResult ?? {}, { html: "<html>hello</html>" });
+    assertEquals(lookupHit.cacheStatus, "hit");
+    assertEquals(typeof lookupHit.lookupDurationMs, "number");
 
     await coordinator.destroy();
   });
@@ -42,6 +46,8 @@ describe("CacheCoordinator", () => {
 
     const lookup = await coordinator.checkCache(slug);
     assertEquals(lookup.cachedResult, undefined);
+    assertEquals(lookup.cacheStatus, "expired");
+    assertEquals(typeof lookup.lookupDurationMs, "number");
 
     await coordinator.destroy();
   });

--- a/src/rendering/cache/cache-coordinator.ts
+++ b/src/rendering/cache/cache-coordinator.ts
@@ -3,6 +3,8 @@ import type { RenderResult } from "../orchestrator/types.ts";
 import type { CachePayload, CacheStore } from "./types.ts";
 import { MemoryCacheStore, type MemoryCacheStoreOptions } from "./stores/index.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { markRequestProfilePhase } from "#veryfront/observability/request-profiler.ts";
+import { metrics } from "#veryfront/observability/simple-metrics/index.ts";
 
 /** Default TTL for cache entries (5 minutes) */
 const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1_000;
@@ -30,11 +32,15 @@ export interface CacheCoordinatorOptions {
   contentSourceId?: string;
 }
 
+export type CacheLookupStatus = "hit" | "miss" | "expired";
+
 export interface CacheLookupResult {
   cachedResult?: RenderResult;
   depAwareSlug: string;
   moduleCacheKey: string;
   cachedModule?: RenderResult["pageModule"];
+  cacheStatus: CacheLookupStatus;
+  lookupDurationMs: number;
 }
 
 export class CacheCoordinator {
@@ -86,22 +92,36 @@ export class CacheCoordinator {
     return withSpan(
       "cache.checkCache",
       async () => {
+        const lookupStart = performance.now();
         const cached = await this.store.get(key);
 
         if (!cached) {
-          return { depAwareSlug: slug, moduleCacheKey: key };
+          const lookupDurationMs = roundDurationMs(performance.now() - lookupStart);
+          recordCacheLookup("miss", lookupDurationMs);
+          return { depAwareSlug: slug, moduleCacheKey: key, cacheStatus: "miss", lookupDurationMs };
         }
 
         if (this.isExpired(cached)) {
           await this.store.delete(key);
-          return { depAwareSlug: slug, moduleCacheKey: key };
+          const lookupDurationMs = roundDurationMs(performance.now() - lookupStart);
+          recordCacheLookup("expired", lookupDurationMs);
+          return {
+            depAwareSlug: slug,
+            moduleCacheKey: key,
+            cacheStatus: "expired",
+            lookupDurationMs,
+          };
         }
 
+        const lookupDurationMs = roundDurationMs(performance.now() - lookupStart);
+        recordCacheLookup("hit", lookupDurationMs);
         return {
           cachedResult: this.hydrateResult(cached),
           depAwareSlug: slug,
           moduleCacheKey: key,
           cachedModule: cached.result.pageModule,
+          cacheStatus: "hit",
+          lookupDurationMs,
         };
       },
       { "cache.slug": slug, "cache.key": key, "cache.projectId": this.projectId ?? "unknown" },
@@ -192,4 +212,14 @@ export class CacheCoordinator {
       stream: null,
     };
   }
+}
+
+function roundDurationMs(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function recordCacheLookup(status: CacheLookupStatus, durationMs: number): void {
+  markRequestProfilePhase("render.cache_lookup", durationMs);
+  markRequestProfilePhase(`render.cache_${status}`);
+  metrics.recordCacheGet(status === "hit");
 }

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -202,7 +202,7 @@ export class Renderer {
         const cacheKey = this.buildCacheKey(slug, effectiveCtx, effectiveOptions);
         const cacheResult = cacheKey
           ? await this.cache.checkCache(slug, effectiveCtx, effectiveOptions?.colorScheme, cacheKey)
-          : { hit: false, cacheKey: "" };
+          : { hit: false, cacheKey: "", status: "miss" as const, lookupDurationMs: 0 };
         if (cacheResult.hit && cacheResult.cachedResult) {
           logger.debug("Cache hit", {
             slug,
@@ -540,6 +540,8 @@ export class Renderer {
           depAwareSlug: slug,
           moduleCacheKey: cacheKey ?? slug,
           cachedModule: result.cachedResult?.pageModule,
+          cacheStatus: result.status,
+          lookupDurationMs: result.lookupDurationMs,
         };
       },
       persistResult: async (result: RenderResult, slug: string, cacheKey?: string) => {

--- a/src/rendering/shared/context-aware-cache.test.ts
+++ b/src/rendering/shared/context-aware-cache.test.ts
@@ -78,6 +78,8 @@ describe("rendering/shared/context-aware-cache", () => {
 
       const result = await cache.checkCache("index", ctx);
       assertEquals(result.hit, false);
+      assertEquals(result.status, "miss");
+      assertEquals(typeof result.lookupDurationMs, "number");
       assertEquals(result.cachedResult, undefined);
       assertEquals(typeof result.cacheKey, "string");
     });
@@ -99,6 +101,8 @@ describe("rendering/shared/context-aware-cache", () => {
 
       const lookup = await cache.checkCache("index", ctx);
       assertEquals(lookup.hit, true);
+      assertEquals(lookup.status, "hit");
+      assertEquals(typeof lookup.lookupDurationMs, "number");
       assertEquals(lookup.cachedResult?.html, "<h1>Hello</h1>");
       assertEquals(lookup.cachedResult?.ssrHash, "abc123");
     });
@@ -152,6 +156,8 @@ describe("rendering/shared/context-aware-cache", () => {
 
       const lookup = await cache.checkCache("ttl-page", ctx);
       assertEquals(lookup.hit, false);
+      assertEquals(lookup.status, "expired");
+      assertEquals(typeof lookup.lookupDurationMs, "number");
     });
 
     it("should use color scheme in cache key", async () => {

--- a/src/rendering/shared/context-aware-cache.ts
+++ b/src/rendering/shared/context-aware-cache.ts
@@ -1,8 +1,11 @@
 import { rendererLogger } from "#veryfront/utils";
+import { markRequestProfilePhase } from "#veryfront/observability/request-profiler.ts";
+import { metrics } from "#veryfront/observability/simple-metrics/index.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { SpanNames } from "#veryfront/observability/tracing/span-names.ts";
 import type { RenderResult } from "../orchestrator/types.ts";
 import type { CacheStore } from "../cache/types.ts";
+import type { CacheLookupStatus } from "../cache/cache-coordinator.ts";
 import { MemoryCacheStore, type MemoryCacheStoreOptions } from "../cache/stores/index.ts";
 import type { RenderContext } from "../context/render-context.ts";
 import { createCacheKey } from "../context/render-context.ts";
@@ -32,6 +35,8 @@ export interface ContextAwareCacheLookupResult {
   cachedResult?: RenderResult;
   cacheKey: string;
   hit: boolean;
+  status: CacheLookupStatus;
+  lookupDurationMs: number;
 }
 
 export class ContextAwareCacheCoordinator {
@@ -59,41 +64,53 @@ export class ContextAwareCacheCoordinator {
     return withSpan(
       SpanNames.CACHE_CHECK_SPECULATIVE,
       async () => {
+        const lookupStart = performance.now();
         const cached = (await this.store.get(cacheKey)) as CachePayload | undefined;
 
         if (!cached) {
+          const lookupDurationMs = roundDurationMs(performance.now() - lookupStart);
+          recordCacheLookup("miss", lookupDurationMs);
           logger.debug("Cache miss", {
             slug,
             cacheKey,
             projectId: ctx.projectId,
             environment: ctx.environment,
+            lookupDurationMs,
           });
-          return { cacheKey, hit: false };
+          return { cacheKey, hit: false, status: "miss", lookupDurationMs };
         }
 
         if (this.isExpired(cached)) {
           await this.store.delete(cacheKey);
 
+          const lookupDurationMs = roundDurationMs(performance.now() - lookupStart);
+          recordCacheLookup("expired", lookupDurationMs);
           logger.debug("Cache expired", {
             slug,
             cacheKey,
             projectId: ctx.projectId,
             environment: ctx.environment,
+            lookupDurationMs,
           });
 
-          return { cacheKey, hit: false };
+          return { cacheKey, hit: false, status: "expired", lookupDurationMs };
         }
 
+        const lookupDurationMs = roundDurationMs(performance.now() - lookupStart);
+        recordCacheLookup("hit", lookupDurationMs);
         logger.debug("Cache hit", {
           slug,
           projectId: ctx.projectId,
           environment: ctx.environment,
+          lookupDurationMs,
         });
 
         return {
           cachedResult: this.cloneResult(cached.result, cached.nodeMapEntries),
           cacheKey,
           hit: true,
+          status: "hit",
+          lookupDurationMs,
         };
       },
       {
@@ -276,4 +293,14 @@ export class ContextAwareCacheCoordinator {
 
     return cloned;
   }
+}
+
+function roundDurationMs(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function recordCacheLookup(status: CacheLookupStatus, durationMs: number): void {
+  markRequestProfilePhase("render.cache_lookup", durationMs);
+  markRequestProfilePhase(`render.cache_${status}`);
+  metrics.recordCacheGet(status === "hit");
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.810";
+export const VERSION = "0.1.811";


### PR DESCRIPTION
## Summary
- add render cache lookup status (`hit`, `miss`, `expired`) and lookup duration to both cache coordinators
- record `render.cache_lookup` and `render.cache_<status>` request-profile phases so `Server-Timing` can diagnose the actual response path under multi-replica Kubernetes routing
- propagate status through the renderer pipeline adapter and bump package version to `0.1.811`

## Why
TTFB work needs to know whether slow HTML requests are render-cache misses, expired entries, or genuine SSR work before tuning HTML cache or edge caching. Process-local counters are not enough with horizontal replicas, so this PR adds per-request evidence first.

## Verification
- `deno test --no-check --allow-all src/observability/request-profiler.test.ts src/rendering/cache/cache-coordinator.test.ts src/rendering/shared/context-aware-cache.test.ts`
- `deno test --no-check --allow-all src/rendering/orchestrator/pipeline.test.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/rendering/orchestrator/lifecycle.test.ts src/rendering/renderer.test.ts src/rendering/renderer-concurrency.test.ts`
- `deno check src/observability/request-profiler.ts src/rendering/cache/cache-coordinator.ts src/rendering/shared/context-aware-cache.ts src/rendering/renderer.ts src/rendering/orchestrator/pipeline.test.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/rendering/orchestrator/lifecycle.test.ts`
- pre-push hook: format, lint, type check, generate, unit suite (`2149 passed`, `0 failed`)


