### PR TITLE
Preserve expired render cache diagnostics

### DIFF
--- a/src/rendering/cache/cache-coordinator.test.ts
+++ b/src/rendering/cache/cache-coordinator.test.ts
@@ -17,6 +17,31 @@ function makeResult(html: string): RenderResult {
   };
 }
 
+async function withStoreTtlEnabled(fn: () => Promise<void>): Promise<void> {
+  const globalState = globalThis as Record<string, unknown>;
+  const previousGlobal = globalState.__vfDisableLruInterval;
+  const previousEnv = Deno.env.get("VF_DISABLE_LRU_INTERVAL");
+
+  globalState.__vfDisableLruInterval = false;
+  Deno.env.delete("VF_DISABLE_LRU_INTERVAL");
+
+  try {
+    await fn();
+  } finally {
+    if (previousGlobal === undefined) {
+      delete globalState.__vfDisableLruInterval;
+    } else {
+      globalState.__vfDisableLruInterval = previousGlobal;
+    }
+
+    if (previousEnv === undefined) {
+      Deno.env.delete("VF_DISABLE_LRU_INTERVAL");
+    } else {
+      Deno.env.set("VF_DISABLE_LRU_INTERVAL", previousEnv);
+    }
+  }
+}
+
 describe("CacheCoordinator", () => {
   it("returns cached result on second lookup", async () => {
     const coordinator = new CacheCoordinator({ ttlMs: 10_000 });
@@ -50,6 +75,22 @@ describe("CacheCoordinator", () => {
     assertEquals(typeof lookup.lookupDurationMs, "number");
 
     await coordinator.destroy();
+  });
+
+  it("reports expired when the memory store TTL path is enabled", async () => {
+    await withStoreTtlEnabled(async () => {
+      const coordinator = new CacheCoordinator({ ttlMs: scaleMs(20) });
+      const slug = "store-ttl-test";
+
+      await coordinator.persistResult(makeResult("first"), slug);
+      await delay(40);
+
+      const lookup = await coordinator.checkCache(slug);
+      assertEquals(lookup.cachedResult, undefined);
+      assertEquals(lookup.cacheStatus, "expired");
+
+      await coordinator.destroy();
+    });
   });
 
   it("isolates cache entries by projectId", async () => {

--- a/src/rendering/cache/cache-coordinator.ts
+++ b/src/rendering/cache/cache-coordinator.ts
@@ -73,6 +73,7 @@ export class CacheCoordinator {
       new MemoryCacheStore({
         maxEntries: options.memory?.maxEntries,
         ttlMs: options.memory?.ttlMs ?? this.ttlMs,
+        enforceStoreTtl: false,
       });
   }
 

--- a/src/rendering/cache/stores/api-store.test.ts
+++ b/src/rendering/cache/stores/api-store.test.ts
@@ -3,6 +3,30 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { APICacheStore } from "./api-store.ts";
 
+async function withStoreTtlEnabled(fn: () => Promise<void>): Promise<void> {
+  const previousGlobal = (globalThis as Record<string, unknown>).__vfDisableLruInterval;
+  const previousEnv = Deno.env.get("VF_DISABLE_LRU_INTERVAL");
+
+  (globalThis as Record<string, unknown>).__vfDisableLruInterval = false;
+  Deno.env.delete("VF_DISABLE_LRU_INTERVAL");
+
+  try {
+    await fn();
+  } finally {
+    if (previousGlobal === undefined) {
+      delete (globalThis as Record<string, unknown>).__vfDisableLruInterval;
+    } else {
+      (globalThis as Record<string, unknown>).__vfDisableLruInterval = previousGlobal;
+    }
+
+    if (previousEnv === undefined) {
+      Deno.env.delete("VF_DISABLE_LRU_INTERVAL");
+    } else {
+      Deno.env.set("VF_DISABLE_LRU_INTERVAL", previousEnv);
+    }
+  }
+}
+
 describe("rendering/cache/stores/api-store", () => {
   describe("APICacheStore constructor", () => {
     it("should create with default options", () => {
@@ -238,6 +262,31 @@ describe("rendering/cache/stores/api-store", () => {
       await store.set("no-local", payload);
       const result = await store.get("no-local");
       assertEquals(result, undefined);
+    });
+
+    it("expires local entries without payload expiresAt using store TTL", async () => {
+      await withStoreTtlEnabled(async () => {
+        const store = new APICacheStore({ enableLocalCache: true, ttlSeconds: 1 });
+        try {
+          const payload = {
+            result: {
+              html: "<p>ttl</p>",
+              frontmatter: {},
+              headings: [],
+              stream: null,
+            },
+            storedAt: Date.now(),
+          } as any;
+
+          await store.set("ttl-key", payload);
+          await new Promise((resolve) => setTimeout(resolve, 1_100));
+
+          const result = await store.get("ttl-key");
+          assertEquals(result, undefined);
+        } finally {
+          await store.destroy();
+        }
+      });
     });
   });
 });

--- a/src/rendering/cache/stores/memory-store.ts
+++ b/src/rendering/cache/stores/memory-store.ts
@@ -25,6 +25,8 @@ interface CacheLike<K, V> {
 export interface MemoryCacheStoreOptions {
   maxEntries?: number;
   ttlMs?: number;
+  /** Disable store-level TTL when callers classify payload expiration themselves. */
+  enforceStoreTtl?: boolean;
   /** Optional cache implementation for testing */
   cache?: CacheLike<string, CachePayload>;
 }
@@ -39,9 +41,10 @@ export class MemoryCacheStore implements CacheStore {
     }
 
     const disableIntervals = isLruIntervalDisabled();
+    const enforceStoreTtl = options.enforceStoreTtl ?? true;
     this.cache = new LRUCache<string, CachePayload>({
       maxEntries: options.maxEntries ?? DEFAULT_MAX_ENTRIES,
-      ttlMs: disableIntervals ? undefined : options.ttlMs,
+      ttlMs: disableIntervals || !enforceStoreTtl ? undefined : options.ttlMs,
     });
   }
 

--- a/src/rendering/cache/stores/redis-store.test.ts
+++ b/src/rendering/cache/stores/redis-store.test.ts
@@ -1,7 +1,31 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { expect } from "#std/expect.ts";
 import { RedisCacheStore } from "./redis-store.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+
+async function withStoreTtlEnabled(fn: () => Promise<void>): Promise<void> {
+  const previousGlobal = (globalThis as Record<string, unknown>).__vfDisableLruInterval;
+  const previousEnv = Deno.env.get("VF_DISABLE_LRU_INTERVAL");
+
+  (globalThis as Record<string, unknown>).__vfDisableLruInterval = false;
+  Deno.env.delete("VF_DISABLE_LRU_INTERVAL");
+
+  try {
+    await fn();
+  } finally {
+    if (previousGlobal === undefined) {
+      delete (globalThis as Record<string, unknown>).__vfDisableLruInterval;
+    } else {
+      (globalThis as Record<string, unknown>).__vfDisableLruInterval = previousGlobal;
+    }
+
+    if (previousEnv === undefined) {
+      Deno.env.delete("VF_DISABLE_LRU_INTERVAL");
+    } else {
+      Deno.env.set("VF_DISABLE_LRU_INTERVAL", previousEnv);
+    }
+  }
+}
 
 function createStore(options?: ConstructorParameters<typeof RedisCacheStore>[0]): RedisCacheStore {
   return new RedisCacheStore(options);
@@ -10,44 +34,46 @@ function createStore(options?: ConstructorParameters<typeof RedisCacheStore>[0])
 describe("RedisCacheStore", () => {
   describe("constructor", () => {
     it("should create store with default options", () => {
-      expect(createStore()).toBeDefined();
+      assertEquals(createStore() instanceof RedisCacheStore, true);
     });
 
     it("should create store with custom key prefix", () => {
-      expect(createStore({ keyPrefix: "custom:" })).toBeDefined();
+      assertEquals(createStore({ keyPrefix: "custom:" }) instanceof RedisCacheStore, true);
     });
 
     it("should create store with fallback disabled", () => {
-      expect(createStore({ enableFallback: false })).toBeDefined();
+      assertEquals(createStore({ enableFallback: false }) instanceof RedisCacheStore, true);
     });
 
     it("should create store with custom URL", () => {
-      expect(createStore({ url: "redis://localhost:6379" })).toBeDefined();
+      assertEquals(createStore({ url: "redis://localhost:6379" }) instanceof RedisCacheStore, true);
     });
 
     it("should create store with all options", () => {
-      expect(
+      assertEquals(
         createStore({
           url: "redis://localhost:6379",
           keyPrefix: "test:",
           enableFallback: true,
-        }),
-      ).toBeDefined();
+        }) instanceof RedisCacheStore,
+        true,
+      );
     });
 
     it("should accept custom TTL seconds", () => {
-      expect(createStore({ ttlSeconds: 7200 })).toBeDefined();
+      assertEquals(createStore({ ttlSeconds: 7200 }) instanceof RedisCacheStore, true);
     });
 
     it("should accept combined options", () => {
-      expect(
+      assertEquals(
         createStore({
           url: "redis://localhost:6379",
           keyPrefix: "custom:",
           enableFallback: true,
           ttlSeconds: 1800,
-        }),
-      ).toBeDefined();
+        }) instanceof RedisCacheStore,
+        true,
+      );
     });
   });
 
@@ -60,6 +86,34 @@ describe("RedisCacheStore", () => {
       const store = createStore();
       await store.destroy();
       await store.destroy();
+    });
+  });
+
+  describe("fallback cache", () => {
+    it("expires fallback entries without payload expiresAt using store TTL", async () => {
+      await withStoreTtlEnabled(async () => {
+        const store = createStore({ enableFallback: true, ttlSeconds: 1 });
+        try {
+          (store as any).redisUnavailable = true;
+
+          await store.set("fallback-ttl", {
+            result: {
+              html: "<p>fallback</p>",
+              frontmatter: {},
+              headings: [],
+              stream: null,
+            },
+            storedAt: Date.now(),
+          } as any);
+
+          await new Promise((resolve) => setTimeout(resolve, 1_100));
+
+          const result = await store.get("fallback-ttl");
+          assertEquals(result, undefined);
+        } finally {
+          await store.destroy();
+        }
+      });
     });
   });
 });

--- a/src/rendering/orchestrator/lifecycle.ts
+++ b/src/rendering/orchestrator/lifecycle.ts
@@ -136,6 +136,7 @@ export class RendererLifecycle {
           maxEntries: renderCacheConfig.maxEntries ??
             (debugMode ? DEBUG_MODE_MAX_ENTRIES : PRODUCTION_MAX_ENTRIES),
           ttlMs: renderCacheConfig.ttl,
+          enforceStoreTtl: false,
         });
         break;
     }

--- a/src/rendering/shared/context-aware-cache.test.ts
+++ b/src/rendering/shared/context-aware-cache.test.ts
@@ -58,6 +58,31 @@ function makeMockCtx(overrides: Partial<RenderContext> = {}): RenderContext {
   };
 }
 
+async function withStoreTtlEnabled(fn: () => Promise<void>): Promise<void> {
+  const globalState = globalThis as Record<string, unknown>;
+  const previousGlobal = globalState.__vfDisableLruInterval;
+  const previousEnv = Deno.env.get("VF_DISABLE_LRU_INTERVAL");
+
+  globalState.__vfDisableLruInterval = false;
+  Deno.env.delete("VF_DISABLE_LRU_INTERVAL");
+
+  try {
+    await fn();
+  } finally {
+    if (previousGlobal === undefined) {
+      delete globalState.__vfDisableLruInterval;
+    } else {
+      globalState.__vfDisableLruInterval = previousGlobal;
+    }
+
+    if (previousEnv === undefined) {
+      Deno.env.delete("VF_DISABLE_LRU_INTERVAL");
+    } else {
+      Deno.env.set("VF_DISABLE_LRU_INTERVAL", previousEnv);
+    }
+  }
+}
+
 describe("rendering/shared/context-aware-cache", () => {
   describe("ContextAwareCacheCoordinator", () => {
     it("should create with default options", () => {
@@ -158,6 +183,30 @@ describe("rendering/shared/context-aware-cache", () => {
       assertEquals(lookup.hit, false);
       assertEquals(lookup.status, "expired");
       assertEquals(typeof lookup.lookupDurationMs, "number");
+    });
+
+    it("should report expired when the memory store TTL path is enabled", async () => {
+      await withStoreTtlEnabled(async () => {
+        const cache = new ContextAwareCacheCoordinator({ ttlMs: 1 });
+        const ctx = makeMockCtx();
+
+        const renderResult = {
+          html: "<h1>Expired</h1>",
+          frontmatter: {},
+          headings: [],
+          stream: null,
+          ssrHash: "exp",
+        };
+
+        await cache.persistResult(renderResult as any, "store-ttl-page", ctx);
+        await new Promise((r) => setTimeout(r, 10));
+
+        const lookup = await cache.checkCache("store-ttl-page", ctx);
+        assertEquals(lookup.hit, false);
+        assertEquals(lookup.status, "expired");
+
+        await cache.destroy();
+      });
     });
 
     it("should use color scheme in cache key", async () => {

--- a/src/rendering/shared/context-aware-cache.ts
+++ b/src/rendering/shared/context-aware-cache.ts
@@ -50,6 +50,7 @@ export class ContextAwareCacheCoordinator {
       new MemoryCacheStore({
         maxEntries: options.memory?.maxEntries ?? DEFAULT_MAX_ENTRIES,
         ttlMs: options.memory?.ttlMs ?? this.ttlMs,
+        enforceStoreTtl: false,
       });
   }
 


### PR DESCRIPTION
## Summary
- keep render cache memory stores from evicting payload-expired entries before coordinators can classify them
- preserve generic MemoryCacheStore TTL behavior by making render cache opt out explicitly
- add regressions for the LRU TTL path so expired entries report `expired`, not `miss`

Addresses the automated review follow-up from #2441. This keeps per-replica render-cache timing diagnostics accurate in horizontally scaled Kubernetes deployments: each replica can report whether its local lookup was a hit, miss, or expired entry without store-level TTL hiding the expiry state.

## Verification
- `deno test --no-check --allow-all src/rendering/cache/cache-coordinator.test.ts src/rendering/shared/context-aware-cache.test.ts src/rendering/cache/stores/memory-store.test.ts`
- `deno check src/rendering/cache/stores/memory-store.ts src/rendering/cache/stores/api-store.ts src/rendering/cache/stores/redis-store.ts src/rendering/orchestrator/lifecycle.ts src/rendering/cache/cache-coordinator.ts src/rendering/shared/context-aware-cache.ts src/rendering/renderer.ts`
- `deno test --no-check --allow-all src/observability/request-profiler.test.ts src/rendering/cache/cache-coordinator.test.ts src/rendering/shared/context-aware-cache.test.ts src/rendering/orchestrator/pipeline.test.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/rendering/orchestrator/lifecycle.test.ts src/rendering/renderer.test.ts src/rendering/renderer-concurrency.test.ts src/utils/version.test.ts src/utils/logger/logger.test.ts`