### PR TITLE
Keep Veryfront SSR imports local under npm import maps

### DIFF
--- a/src/modules/import-map/loader.test.ts
+++ b/src/modules/import-map/loader.test.ts
@@ -133,6 +133,35 @@ describe("modules/import-map/loader", () => {
       assert("valid-lib" in imports, "https:// path should be kept");
     });
 
+    it("should keep veryfront framework mappings local when deno.json uses npm overrides", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/project-with-npm-overrides/deno.json",
+        JSON.stringify({
+          imports: {
+            "veryfront": "npm:veryfront@0.1.759",
+            "veryfront/chat": "npm:veryfront@0.1.759/chat",
+            "veryfront/router": "npm:veryfront@0.1.759/router",
+            "react": "npm:react@19.1.1",
+          },
+        }),
+      );
+
+      const { imports } = await loadImportMap("/project-with-npm-overrides", adapter);
+
+      assertExists(imports);
+      assertEquals(
+        imports["veryfront/chat"]?.startsWith("/_vf_modules/_veryfront/chat/"),
+        true,
+      );
+      assertEquals(
+        imports["veryfront/router"]?.startsWith("/_vf_modules/_veryfront/react/runtime/core.js"),
+        true,
+      );
+      assertEquals(imports["veryfront/chat"]?.includes("esm.sh"), false);
+      assertEquals(imports["veryfront/router"]?.includes("esm.sh"), false);
+    });
+
     it("should filter out relative paths from deno.json scopes", async () => {
       const adapter = createMockAdapter();
       adapter.fs.files.set(

--- a/src/modules/import-map/loader.ts
+++ b/src/modules/import-map/loader.ts
@@ -37,9 +37,14 @@ function normalizeImportMapForRuntime(importMap: ImportMapConfig): ImportMapConf
   // Override React mappings AFTER all other processing to ensure single instance.
   // Remove any "react/" prefix match since we have explicit mappings.
   if (imports) {
+    const veryfrontSsrMap = Object.fromEntries(
+      Object.entries(getDefaultImportMap().imports ?? {}).filter(([key]) =>
+        key.startsWith("veryfront/")
+      ),
+    );
     const reactMap = getReactImportMap();
     delete imports["react/"];
-    imports = { ...imports, ...reactMap };
+    imports = { ...imports, ...veryfrontSsrMap, ...reactMap };
   }
 
   return { imports, scopes };

--- a/src/transforms/esm/specifier-resolver.test.ts
+++ b/src/transforms/esm/specifier-resolver.test.ts
@@ -53,6 +53,35 @@ describe("transforms/esm/specifier-resolver", () => {
       assertEquals(result.get("https://esm.sh/lodash@4"), "file:///tmp/cache/http-99999.mjs");
     });
 
+    it("rewrites mapped esm.sh veryfront URLs to local framework modules without caching", async () => {
+      const specifier = "https://esm.sh/veryfront@0.1.759/chat";
+      const code = `import { Chat } from "${specifier}";`;
+      const cacheCalls: string[] = [];
+
+      const result = await buildReplacements(
+        code,
+        undefined,
+        {
+          ...defaultOptions,
+          importMap: {
+            imports: {
+              "veryfront/chat": "/_vf_modules/_veryfront/chat/index.js?ssr=true",
+            },
+          },
+        },
+        async (url) => {
+          cacheCalls.push(url);
+          return "/tmp/cache/http-veryfront.mjs";
+        },
+      );
+
+      assertEquals(
+        result.get(specifier),
+        "/_vf_modules/_veryfront/chat/index.js?ssr=true",
+      );
+      assertEquals(cacheCalls, []);
+    });
+
     it("uses relative path when parent is an HTTP module", async () => {
       const code = `import lodash from "https://esm.sh/lodash@4";`;
       const mockCache: CacheHttpModuleFn = async () => "/tmp/cache/http-99999.mjs";

--- a/src/transforms/esm/specifier-resolver.ts
+++ b/src/transforms/esm/specifier-resolver.ts
@@ -8,6 +8,7 @@
  */
 
 import { basename } from "#veryfront/compat/path/index.ts";
+import { resolveImport } from "#veryfront/modules/import-map/resolver.ts";
 import { parseImports, replaceSpecifiers } from "./lexer.ts";
 import {
   type CacheOptions,
@@ -21,6 +22,12 @@ import {
 
 /** Function signature for caching an HTTP module and returning its local path. */
 export type CacheHttpModuleFn = (url: string, options: CacheOptions) => Promise<string | null>;
+
+function isLocalMappedSpecifier(specifier: string): boolean {
+  return specifier.startsWith("/_vf_modules/") ||
+    specifier.startsWith("_vf_modules/") ||
+    specifier.startsWith("file://");
+}
 
 /**
  * Resolve a single import specifier to a local cached path.
@@ -48,6 +55,12 @@ async function resolveSpecifier(
   }
 
   if (isHttpUrl(specifier)) {
+    const mapped = resolveImport(specifier, options.importMap);
+    if (mapped !== specifier) {
+      if (isLocalMappedSpecifier(mapped)) return mapped;
+      return resolveSpecifier(mapped, baseUrl, options, cacheHttpModule);
+    }
+
     const cached = await cacheHttpModule(specifier, options);
     if (!cached) return null;
 
@@ -71,6 +84,7 @@ async function resolveSpecifier(
 
   const mapped = resolveBareSpecifier(specifier, options.importMap, options.reactVersion);
   if (mapped === specifier) return null;
+  if (isLocalMappedSpecifier(mapped)) return mapped;
 
   return resolveSpecifier(mapped, baseUrl, options, cacheHttpModule);
 }


### PR DESCRIPTION
## Summary
- reassert known Veryfront SSR framework mappings after deno.json/config import-map overrides
- map already-rewritten esm.sh Veryfront URLs back to local /_vf_modules targets before HTTP caching
- add regressions for Node/pnpm-style npm:veryfront import-map overrides and the downstream resolver fetch path

Closes #2351.

## Verification
- deno test --no-check --allow-all src/modules/import-map/loader.test.ts src/transforms/esm/specifier-resolver.test.ts
- deno test --no-check --allow-all src/modules/import-map/loader.test.ts src/modules/import-map/resolver.test.ts src/modules/import-map/default-import-map.test.ts src/transforms/esm/specifier-resolver.test.ts src/transforms/esm/http-cache-helpers.test.ts
- deno test --no-check --allow-all src/transforms/pipeline/__fixtures__/fixture-runner.test.ts
- deno check src/modules/import-map/loader.ts src/modules/import-map/loader.test.ts src/transforms/esm/specifier-resolver.ts src/transforms/esm/specifier-resolver.test.ts
- git diff --check
- pre-push hook: deno fmt, lint, type check, generated manifests, unit suite (2151 passed, 18589 steps)