### PR TITLE
Document DNT import rewrite boundary

### DIFF
--- a/src/transforms/import-rewriter/README.md
+++ b/src/transforms/import-rewriter/README.md
@@ -47,6 +47,29 @@ Strategies are applied in priority order (lower number = higher priority):
 | 6        | `BareStrategy`         | NPM packages (`lodash`, `@org/pkg`) |
 | 7        | `URLStrategy`          | `https://`, `http://` URLs          |
 
+## Intentional non-strategy rewrites
+
+`rewriteDntImports` in
+`src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.ts`
+intentionally remains outside this strategy pipeline.
+
+The unified import-rewriter strategies are synchronous specifier transforms. They
+decide a replacement from the parsed import specifier and the transform context.
+DNT rewriting is a later MDX/framework module relocation step:
+
+- It only applies to Veryfront framework files from `FRAMEWORK_ROOT`,
+  embedded framework source, or `node_modules`.
+- It resolves relative imports from the actual source file directory.
+- It probes the local filesystem for generated `.src`, TypeScript, TSX, JSX,
+  JavaScript, and MJS fallback targets before choosing the replacement.
+- It rewrites both `from` imports and side-effect imports to absolute `file://`
+  URLs so cached framework modules do not resolve relative imports from the
+  cache directory.
+
+Do not move this path into the synchronous strategy pipeline unless the strategy
+contract gains an async filesystem-aware phase and the MDX framework relocation
+tests move with it.
+
 ## Framework Imports
 
 User-facing imports map to internal framework paths via `deno.json`:


### PR DESCRIPTION
## Summary
- document why rewriteDntImports remains outside the unified import-rewriter strategy pipeline
- record the async filesystem-aware conditions that make it a separate MDX/framework relocation phase
- mark the remaining #2220 import-rewriter decision as resolved with existing DNT coverage

Closes #2220.

## Verification
- deno fmt src/transforms/import-rewriter/README.md
- deno test --no-check --allow-all src/transforms/mdx/esm-module-loader/module-fetcher/import-rewriter.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts src/transforms/import-rewriter/strategies/veryfront-strategy.test.ts
- git diff --check
- pre-push hook: deno fmt, lint, type check, generated manifests, unit suite (2151 passed, 18587 steps)