### PR TITLE
Avoid static node:path import in shared watcher

### DIFF
--- a/src/platform/adapters/runtime/shared/shared-watcher.test.ts
+++ b/src/platform/adapters/runtime/shared/shared-watcher.test.ts
@@ -14,6 +14,13 @@ describe("shared-watcher", () => {
       assertExists(setupNodeFsWatcher);
       assertEquals(typeof setupNodeFsWatcher, "function");
     });
+
+    it("keeps node:path out of the shared module top level", async () => {
+      const source = await Deno.readTextFile(new URL("./shared-watcher.ts", import.meta.url));
+
+      assertEquals(source.includes(`from "node:path"`), false);
+      assertEquals(source.includes(`from 'node:path'`), false);
+    });
   });
 
   describe("createWatcherIterator", () => {

--- a/src/platform/adapters/runtime/shared/shared-watcher.ts
+++ b/src/platform/adapters/runtime/shared/shared-watcher.ts
@@ -1,5 +1,4 @@
 import type { FileChangeEvent, FileChangeKind } from "../../base.ts";
-import { join } from "node:path";
 import { createFileWatcher, createWatcherIterator, enqueueWatchEvent } from "./watcher-queue.ts";
 
 export { createFileWatcher, createWatcherIterator, enqueueWatchEvent };
@@ -20,6 +19,7 @@ export async function setupNodeFsWatcher(
   try {
     const fs = await import("node:fs");
     const fsPromises = await import("node:fs/promises");
+    const { join } = await import("node:path");
 
     let exists: boolean;
     try {


### PR DESCRIPTION
## Summary
- move shared watcher node:path loading behind setupNodeFsWatcher dynamic imports
- add a boundary regression that prevents node:path from returning as a top-level shared-module import
- keep Node/Bun watcher behavior unchanged

Refs #2218

## Verification
- red first: deno test --no-check --allow-all src/platform/adapters/runtime/shared/shared-watcher.test.ts failed on the static node:path import
- deno test --no-check --allow-all src/platform/adapters/runtime/shared/shared-watcher.test.ts
- deno check src/platform/adapters/runtime/shared/shared-watcher.ts src/platform/adapters/runtime/shared/shared-watcher.test.ts src/platform/adapters/runtime/node/filesystem-adapter.ts src/platform/adapters/runtime/bun/filesystem-adapter.ts
- git diff --check
- pre-push hook: formatting, lint, typecheck, generated manifests, unit suite (2151 passed, 18588 steps)