### PR TITLE
Route dev dashboard API through a dispatch table

### DIFF
--- a/src/server/handlers/dev/dashboard/api.test.ts
+++ b/src/server/handlers/dev/dashboard/api.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { handleDashboardAPI } from "./api.ts";
+import { getDashboardApiRoutePaths, handleDashboardAPI } from "./api.ts";
 import type { HandlerContext } from "../../types.ts";
 
 // Minimal mock adapter with fs that tracks readDir/readFile calls
@@ -39,6 +39,38 @@ describe("Dashboard API - auth", () => {
     const req = new Request("http://localhost/_dev/api/stats");
     const res = await handleDashboardAPI(req, ctx);
     assertEquals(res?.status, 401);
+  });
+});
+
+describe("Dashboard API - route table", () => {
+  it("registers the expected GET and POST API routes", () => {
+    assertEquals(getDashboardApiRoutePaths("GET"), [
+      "/_dev/api/agents",
+      "/_dev/api/build",
+      "/_dev/api/config",
+      "/_dev/api/errors",
+      "/_dev/api/file-content",
+      "/_dev/api/files",
+      "/_dev/api/handlers",
+      "/_dev/api/infrastructure",
+      "/_dev/api/live-errors",
+      "/_dev/api/live-logs",
+      "/_dev/api/memory",
+      "/_dev/api/metrics",
+      "/_dev/api/prompts",
+      "/_dev/api/resources",
+      "/_dev/api/stats",
+      "/_dev/api/tools",
+      "/_dev/api/workflows",
+    ]);
+
+    assertEquals(getDashboardApiRoutePaths("POST"), [
+      "/_dev/api/execute-tool",
+      "/_dev/api/hmr-trigger",
+      "/_dev/api/read-resource",
+      "/_dev/api/render-prompt",
+      "/_dev/api/start-workflow",
+    ]);
   });
 });
 

--- a/src/server/handlers/dev/dashboard/api.ts
+++ b/src/server/handlers/dev/dashboard/api.ts
@@ -69,6 +69,54 @@ const TEXT_EXTENSIONS = new Set([
   "dockerignore",
 ]);
 
+type DashboardApiMethod = "GET" | "POST";
+type DashboardApiRouteHandler = (
+  req: Request,
+  ctx: HandlerContext,
+) => Promise<Response> | Response;
+
+const GET_DASHBOARD_API_ROUTES: Record<string, DashboardApiRouteHandler> = {
+  "/_dev/api/stats": () => handleStats(),
+  "/_dev/api/tools": () => handleListTools(),
+  "/_dev/api/resources": () => handleListResources(),
+  "/_dev/api/prompts": () => handleListPrompts(),
+  "/_dev/api/agents": () => handleListAgents(),
+  "/_dev/api/workflows": () => handleListWorkflows(),
+  "/_dev/api/handlers": (_req, ctx) => handleListHandlers(ctx),
+  "/_dev/api/metrics": () => handleGetMetrics(),
+  "/_dev/api/files": (req, ctx) => handleListFiles(req, ctx),
+  "/_dev/api/file-content": (req, ctx) => handleReadFileContent(req, ctx),
+  "/_dev/api/infrastructure": () => handleGetInfrastructure(),
+  "/_dev/api/memory": () => handleGetMemory(),
+  "/_dev/api/build": () => handleGetBuild(),
+  "/_dev/api/errors": () => handleGetErrors(),
+  "/_dev/api/config": (_req, ctx) => handleGetConfig(ctx),
+  "/_dev/api/live-errors": (req) => handleLiveErrors(req),
+  "/_dev/api/live-logs": (req) => handleLiveLogs(req),
+};
+
+const POST_DASHBOARD_API_ROUTES: Record<string, DashboardApiRouteHandler> = {
+  "/_dev/api/hmr-trigger": (req) => handleHmrTrigger(req),
+  "/_dev/api/execute-tool": (req) => handleExecuteTool(req),
+  "/_dev/api/read-resource": (req) => handleReadResource(req),
+  "/_dev/api/render-prompt": (req) => handleRenderPrompt(req),
+  "/_dev/api/start-workflow": (req) => handleStartWorkflow(req),
+};
+
+function getDashboardRouteHandler(
+  method: string,
+  pathname: string,
+): DashboardApiRouteHandler | undefined {
+  if (method === "GET") return GET_DASHBOARD_API_ROUTES[pathname];
+  if (method === "POST") return POST_DASHBOARD_API_ROUTES[pathname];
+  return undefined;
+}
+
+export function getDashboardApiRoutePaths(method: DashboardApiMethod): string[] {
+  const routes = method === "GET" ? GET_DASHBOARD_API_ROUTES : POST_DASHBOARD_API_ROUTES;
+  return Object.keys(routes).sort();
+}
+
 export function handleDashboardAPI(
   req: Request,
   ctx: HandlerContext,
@@ -76,66 +124,10 @@ export function handleDashboardAPI(
   if (!ctx.isLocalProject) return errorResponse("Unauthorized", 401);
 
   const { pathname } = new URL(req.url);
+  const handler = getDashboardRouteHandler(req.method, pathname);
+  if (!handler) return null;
 
-  if (req.method === "GET") {
-    switch (pathname) {
-      case "/_dev/api/stats":
-        return handleStats();
-      case "/_dev/api/tools":
-        return handleListTools();
-      case "/_dev/api/resources":
-        return handleListResources();
-      case "/_dev/api/prompts":
-        return handleListPrompts();
-      case "/_dev/api/agents":
-        return handleListAgents();
-      case "/_dev/api/workflows":
-        return handleListWorkflows();
-      case "/_dev/api/handlers":
-        return handleListHandlers(ctx);
-      case "/_dev/api/metrics":
-        return handleGetMetrics();
-      case "/_dev/api/files":
-        return handleListFiles(req, ctx);
-      case "/_dev/api/file-content":
-        return handleReadFileContent(req, ctx);
-      case "/_dev/api/infrastructure":
-        return handleGetInfrastructure();
-      case "/_dev/api/memory":
-        return handleGetMemory();
-      case "/_dev/api/build":
-        return handleGetBuild();
-      case "/_dev/api/errors":
-        return handleGetErrors();
-      case "/_dev/api/config":
-        return handleGetConfig(ctx);
-      case "/_dev/api/live-errors":
-        return handleLiveErrors(req);
-      case "/_dev/api/live-logs":
-        return handleLiveLogs(req);
-      default:
-        return null;
-    }
-  }
-
-  if (req.method === "POST") {
-    switch (pathname) {
-      case "/_dev/api/hmr-trigger":
-        return handleHmrTrigger(req);
-      case "/_dev/api/execute-tool":
-        return handleExecuteTool(req);
-      case "/_dev/api/read-resource":
-        return handleReadResource(req);
-      case "/_dev/api/render-prompt":
-        return handleRenderPrompt(req);
-      case "/_dev/api/start-workflow":
-        return handleStartWorkflow(req);
-      default:
-        return null;
-    }
-  }
-
-  return null;
+  return handler(req, ctx);
 }
 
 function handleStats(): Response {


### PR DESCRIPTION
## Summary
- replace the dashboard API method switches with explicit GET/POST dispatch tables
- add route inventory coverage so future feature-module splits cannot silently drop endpoints
- preserve existing authorization and endpoint handler behavior

Refs #2217

## Verification
- red first: deno test --no-check --allow-all src/server/handlers/dev/dashboard/api.test.ts failed because getDashboardApiRoutePaths was not exported
- deno test --no-check --allow-all src/server/handlers/dev/dashboard/api.test.ts
- deno check src/server/handlers/dev/dashboard/api.ts src/server/handlers/dev/dashboard/api.test.ts
- git diff --check
- pre-push hook: formatting, lint, typecheck, generated manifests, unit suite (2152 passed, 18588 steps)