### PR TITLE
Confine native HTTP globals behind typed accessors

### DIFF
--- a/src/platform/compat/http/native-response.test.ts
+++ b/src/platform/compat/http/native-response.test.ts
@@ -1,12 +1,24 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assert, assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { getNativeDeno, getNativeResponse, toNativeResponse } from "./native-response.ts";
+import {
+  getNativeDeno,
+  getNativeDenoFromHost,
+  getNativeResponse,
+  getNativeResponseFromHost,
+  toNativeResponse,
+} from "./native-response.ts";
 
 describe("getNativeResponse", () => {
   it("returns the native Response constructor", () => {
     const NativeResponse = getNativeResponse();
     // In Deno, `self` equals `globalThis`, so this is the real Response.
+    assertStrictEquals(NativeResponse, Response);
+  });
+
+  it("reads Response through the typed host accessor", () => {
+    const NativeResponse = getNativeResponseFromHost({ Response });
+
     assertStrictEquals(NativeResponse, Response);
   });
 
@@ -22,6 +34,14 @@ describe("getNativeDeno", () => {
   it("returns the native Deno namespace in the Deno runtime", () => {
     const nativeDeno = getNativeDeno();
     assertStrictEquals(nativeDeno, Deno);
+  });
+
+  it("returns undefined when the typed host has no native Deno namespace", () => {
+    assertEquals(getNativeDenoFromHost({}), undefined);
+  });
+
+  it("ignores non-object Deno values on the typed host", () => {
+    assertEquals(getNativeDenoFromHost({ Deno: "not-deno" }), undefined);
   });
 
   it("exposes native APIs absent from the dnt shim", () => {

--- a/src/platform/compat/http/native-response.ts
+++ b/src/platform/compat/http/native-response.ts
@@ -13,12 +13,38 @@
  * @module platform/compat/http/native-response
  */
 
+type NativeResponseHost = {
+  Response: typeof Response;
+};
+
+type NativeDenoHost = {
+  Deno?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isNativeDeno(value: unknown): value is typeof Deno {
+  if (!isRecord(value)) return false;
+  return typeof value.serve === "function" && typeof value.upgradeWebSocket === "function";
+}
+
+export function getNativeResponseFromHost(host: NativeResponseHost): typeof Response {
+  return host.Response;
+}
+
+export function getNativeDenoFromHost(host: NativeDenoHost): typeof Deno | undefined {
+  if (!isNativeDeno(host.Deno)) return undefined;
+  return host.Deno;
+}
+
 /**
  * The native `Response` constructor, accessed via `self` to bypass the dnt
  * shim transform (dnt rewrites bare `Response` to undici's polyfill).
  */
 export function getNativeResponse(): typeof Response {
-  return (self as unknown as { Response: typeof Response }).Response;
+  return getNativeResponseFromHost(self);
 }
 
 /**
@@ -35,7 +61,7 @@ export function getNativeResponse(): typeof Response {
  * Deno runtime can use a non-null assertion on the result.
  */
 export function getNativeDeno(): typeof Deno | undefined {
-  return (self as unknown as Record<string, typeof Deno | undefined>)["Deno"];
+  return getNativeDenoFromHost(self);
 }
 
 /**


### PR DESCRIPTION
## Summary
- add typed host helpers for the native HTTP Response and Deno globals
- route getNativeResponse and getNativeDeno through that single boundary
- cover absent and invalid Deno host values in native-response tests

Refs #2218

## Tests
- deno test --no-check --allow-all src/platform/compat/http/native-response.test.ts
- deno check src/platform/compat/http/native-response.ts src/platform/compat/http/native-response.test.ts
- deno test --no-check --allow-all src/platform/compat/http/native-response.test.ts src/platform/compat/http/deno-server.test.ts src/platform/compat/http/factory.test.ts src/platform/compat/http/index.test.ts
- git diff --check
- pre-push hook: format, lint, typecheck, unit suite (2152 passed, 18596 steps)