### PR TITLE
Extract module loader cache lookup stage

### DIFF
--- a/src/rendering/orchestrator/module-loader/index.ts
+++ b/src/rendering/orchestrator/module-loader/index.ts
@@ -10,40 +10,23 @@
 import { rendererLogger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
-import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { getProjectTmpDir } from "#veryfront/modules/react-loader/index.ts";
 import { getHttpBundleCacheDir, getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { join } from "#veryfront/compat/path/index.ts";
-import {
-  invalidateMdxEsmModule,
-  lookupMdxEsmCache,
-} from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
+import { invalidateMdxEsmModule } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
 import {
   resolveModuleDependencies,
   rewriteResolvedDependencyImports,
 } from "./dependency-resolver.ts";
 import { persistTransformedModule } from "./module-persistence.ts";
-import {
-  transformModuleCodeWithCache,
-  UNRESOLVED_VF_MODULES_RE,
-} from "./module-transform-cache.ts";
+import { transformModuleCodeWithCache } from "./module-transform-cache.ts";
+import { getModuleCacheKey, resolveCachedModulePath } from "./module-cache-lookup.ts";
 
 const logger = rendererLogger.component("module-loader");
 
 // Re-export utilities
 export { createEsmCache, createModuleCache, generateHash } from "./cache.ts";
 export { fetchEsmModule, rewriteEsmPaths } from "./esm-rewriter.ts";
-
-function getModuleCacheKey(
-  filePath: string,
-  projectId?: string,
-  projectDir?: string,
-  contentSourceId?: string,
-): string {
-  const base = projectId ?? projectDir ?? "default";
-  const source = contentSourceId ?? "default";
-  return `${base}:${source}:${filePath}`;
-}
 
 function decodeFileContent(fileContent: string | Uint8Array): string {
   if (typeof fileContent === "string") return fileContent;
@@ -70,59 +53,17 @@ export async function transformModuleWithDeps(
   const { moduleCache, projectDir, projectId, contentSourceId, adapter, mode } = config;
   const cacheKey = getModuleCacheKey(filePath, projectId, projectDir, contentSourceId);
 
-  const cachedPath = moduleCache.get(cacheKey);
+  const cachedPath = await resolveCachedModulePath({
+    cacheKey,
+    filePath,
+    projectDir,
+    projectId,
+    contentSourceId,
+    moduleCache,
+    reactVersion: config.reactVersion,
+  });
   if (cachedPath) {
-    // Validate cached file doesn't contain unresolved /_vf_modules/ imports
-    // These would fail at runtime and indicate stale cache from before framework import fix
-    try {
-      const cachedCode = await createFileSystem().readTextFile(cachedPath);
-      if (UNRESOLVED_VF_MODULES_RE.test(cachedCode)) {
-        logger.warn(
-          "[ModuleLoader] In-memory cache contains unresolved _vf_modules, invalidating",
-          {
-            filePath: filePath.slice(-60),
-            cachedPath: cachedPath.slice(-60),
-          },
-        );
-        moduleCache.delete(cacheKey);
-        // Don't return - fall through to re-transform
-      } else {
-        return cachedPath;
-      }
-    } catch (_) {
-      /* expected: cached file may no longer exist on disk */
-      moduleCache.delete(cacheKey);
-    }
-  }
-
-  if (projectId && contentSourceId) {
-    const baseCacheDir = getMdxEsmCacheDir();
-    const projectKey = encodeURIComponent(projectId);
-    const sourceKey = encodeURIComponent(contentSourceId);
-    const mdxCacheDir = join(baseCacheDir, projectKey, sourceKey);
-
-    const mdxCacheResult = await lookupMdxEsmCache(
-      filePath,
-      mdxCacheDir,
-      projectDir,
-      undefined,
-      {
-        projectId,
-        contentSourceId,
-      },
-      config.reactVersion,
-    );
-    if (mdxCacheResult.status === "hit") {
-      moduleCache.set(cacheKey, mdxCacheResult.path);
-      return mdxCacheResult.path;
-    }
-
-    if (mdxCacheResult.status === "corrupted") {
-      logger.warn("MDX-ESM cache corrupted, will re-transform", {
-        filePath,
-        reason: mdxCacheResult.reason,
-      });
-    }
+    return cachedPath;
   }
 
   const readAdapter = useLocalAdapter ? localAdapter : adapter;

--- a/src/rendering/orchestrator/module-loader/module-cache-lookup.test.ts
+++ b/src/rendering/orchestrator/module-loader/module-cache-lookup.test.ts
@@ -51,6 +51,29 @@ describe("module-loader/module-cache-lookup", () => {
     });
   });
 
+  it("keeps the fallback filesystem reader bound to its receiver", async () => {
+    const moduleCache = new Map([["cache-key", "module.js"]]);
+
+    const fileSystem = {
+      prefix: "export",
+      readTextFile(path: string): Promise<string> {
+        return Promise.resolve(`${this.prefix} const path = ${JSON.stringify(path)};`);
+      },
+    };
+
+    assertEquals(
+      await resolveCachedModulePath({
+        cacheKey: "cache-key",
+        filePath: "/project/app/page.tsx",
+        projectDir: "/project",
+        moduleCache,
+        fileSystem,
+      }),
+      "module.js",
+    );
+    assertEquals(moduleCache.get("cache-key"), "module.js");
+  });
+
   it("invalidates in-memory cached modules that still contain unresolved vf imports", async () => {
     await withCachedFile(`import x from "/_vf_modules/react.js";`, async (cachedPath) => {
       const moduleCache = new Map([["cache-key", cachedPath]]);

--- a/src/rendering/orchestrator/module-loader/module-cache-lookup.test.ts
+++ b/src/rendering/orchestrator/module-loader/module-cache-lookup.test.ts
@@ -1,0 +1,95 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { join } from "#veryfront/compat/path/index.ts";
+import { getModuleCacheKey, resolveCachedModulePath } from "./module-cache-lookup.ts";
+
+async function withCachedFile<T>(
+  content: string,
+  test: (path: string) => Promise<T>,
+): Promise<T> {
+  const dir = await Deno.makeTempDir({ prefix: "vf-module-cache-lookup-" });
+  const path = join(dir, "module.js");
+  await Deno.writeTextFile(path, content);
+
+  try {
+    return await test(path);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => undefined);
+  }
+}
+
+describe("module-loader/module-cache-lookup", () => {
+  it("builds a stable cache key scoped by project, source, and file path", () => {
+    assertEquals(
+      getModuleCacheKey("/project/app/page.tsx", "project-id", "/project", "source-id"),
+      "project-id:source-id:/project/app/page.tsx",
+    );
+  });
+
+  it("uses projectDir and default source when IDs are unavailable", () => {
+    assertEquals(
+      getModuleCacheKey("/project/app/page.tsx", undefined, "/project", undefined),
+      "/project:default:/project/app/page.tsx",
+    );
+  });
+
+  it("returns a valid in-memory cached module path", async () => {
+    await withCachedFile("export const ok = true;", async (cachedPath) => {
+      const moduleCache = new Map([["cache-key", cachedPath]]);
+
+      assertEquals(
+        await resolveCachedModulePath({
+          cacheKey: "cache-key",
+          filePath: "/project/app/page.tsx",
+          projectDir: "/project",
+          moduleCache,
+        }),
+        cachedPath,
+      );
+      assertEquals(moduleCache.get("cache-key"), cachedPath);
+    });
+  });
+
+  it("invalidates in-memory cached modules that still contain unresolved vf imports", async () => {
+    await withCachedFile(`import x from "/_vf_modules/react.js";`, async (cachedPath) => {
+      const moduleCache = new Map([["cache-key", cachedPath]]);
+
+      assertEquals(
+        await resolveCachedModulePath({
+          cacheKey: "cache-key",
+          filePath: "/project/app/page.tsx",
+          projectDir: "/project",
+          moduleCache,
+        }),
+        undefined,
+      );
+      assertEquals(moduleCache.has("cache-key"), false);
+    });
+  });
+
+  it("promotes an MDX-ESM cache hit into the in-memory cache", async () => {
+    const moduleCache = new Map<string, string>();
+
+    const cachedPath = await resolveCachedModulePath({
+      cacheKey: "cache-key",
+      filePath: "/project/app/page.tsx",
+      projectDir: "/project",
+      projectId: "project-id",
+      contentSourceId: "source-id",
+      reactVersion: "19.1.0",
+      moduleCache,
+      lookupMdxCache: (path, cacheDir, projectDir, _unused, options, reactVersion) => {
+        assertEquals(path, "/project/app/page.tsx");
+        assertEquals(cacheDir.endsWith("/project-id/source-id"), true);
+        assertEquals(projectDir, "/project");
+        assertEquals(options, { projectId: "project-id", contentSourceId: "source-id" });
+        assertEquals(reactVersion, "19.1.0");
+        return Promise.resolve({ status: "hit", path: "/cache/page.js" });
+      },
+    });
+
+    assertEquals(cachedPath, "/cache/page.js");
+    assertEquals(moduleCache.get("cache-key"), "/cache/page.js");
+  });
+});

--- a/src/rendering/orchestrator/module-loader/module-cache-lookup.ts
+++ b/src/rendering/orchestrator/module-loader/module-cache-lookup.ts
@@ -1,0 +1,118 @@
+/**
+ * Cache lookup phase for the SSR module loader.
+ *
+ * @module rendering/orchestrator/module-loader/module-cache-lookup
+ */
+
+import { join } from "#veryfront/compat/path/index.ts";
+import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import {
+  type CacheLookupResult,
+  lookupMdxEsmCache,
+} from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
+import { getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
+import { rendererLogger } from "#veryfront/utils";
+import { UNRESOLVED_VF_MODULES_RE } from "./module-transform-cache.ts";
+
+const logger = rendererLogger.component("module-loader");
+
+export function getModuleCacheKey(
+  filePath: string,
+  projectId?: string,
+  projectDir?: string,
+  contentSourceId?: string,
+): string {
+  const base = projectId ?? projectDir ?? "default";
+  const source = contentSourceId ?? "default";
+  return `${base}:${source}:${filePath}`;
+}
+
+type LookupMdxCache = typeof lookupMdxEsmCache;
+
+export interface ResolveCachedModulePathInput {
+  cacheKey: string;
+  filePath: string;
+  projectDir: string;
+  projectId?: string;
+  contentSourceId?: string;
+  reactVersion?: string;
+  moduleCache: Map<string, string>;
+  readTextFile?: (path: string) => Promise<string>;
+  lookupMdxCache?: LookupMdxCache;
+}
+
+async function resolveInMemoryCachedPath(
+  input: Pick<
+    ResolveCachedModulePathInput,
+    "cacheKey" | "filePath" | "moduleCache" | "readTextFile"
+  >,
+): Promise<string | undefined> {
+  const cachedPath = input.moduleCache.get(input.cacheKey);
+  if (!cachedPath) return undefined;
+
+  try {
+    const readTextFile = input.readTextFile ?? createFileSystem().readTextFile;
+    const cachedCode = await readTextFile(cachedPath);
+    if (!UNRESOLVED_VF_MODULES_RE.test(cachedCode)) return cachedPath;
+
+    logger.warn(
+      "[ModuleLoader] In-memory cache contains unresolved _vf_modules, invalidating",
+      {
+        filePath: input.filePath.slice(-60),
+        cachedPath: cachedPath.slice(-60),
+      },
+    );
+  } catch (_) {
+    /* expected: cached file may no longer exist on disk */
+  }
+
+  input.moduleCache.delete(input.cacheKey);
+  return undefined;
+}
+
+async function resolveMdxEsmCachedPath(
+  input: ResolveCachedModulePathInput,
+): Promise<string | undefined> {
+  if (!input.projectId || !input.contentSourceId) return undefined;
+
+  const baseCacheDir = getMdxEsmCacheDir();
+  const projectKey = encodeURIComponent(input.projectId);
+  const sourceKey = encodeURIComponent(input.contentSourceId);
+  const mdxCacheDir = join(baseCacheDir, projectKey, sourceKey);
+  const lookup = input.lookupMdxCache ?? lookupMdxEsmCache;
+
+  const mdxCacheResult: CacheLookupResult = await lookup(
+    input.filePath,
+    mdxCacheDir,
+    input.projectDir,
+    undefined,
+    {
+      projectId: input.projectId,
+      contentSourceId: input.contentSourceId,
+    },
+    input.reactVersion,
+  );
+
+  if (mdxCacheResult.status === "hit") {
+    input.moduleCache.set(input.cacheKey, mdxCacheResult.path);
+    return mdxCacheResult.path;
+  }
+
+  if (mdxCacheResult.status === "corrupted") {
+    logger.warn("MDX-ESM cache corrupted, will re-transform", {
+      filePath: input.filePath,
+      reason: mdxCacheResult.reason,
+    });
+  }
+
+  return undefined;
+}
+
+export async function resolveCachedModulePath(
+  input: ResolveCachedModulePathInput,
+): Promise<string | undefined> {
+  const inMemoryPath = await resolveInMemoryCachedPath(input);
+  if (inMemoryPath) return inMemoryPath;
+
+  return await resolveMdxEsmCachedPath(input);
+}

--- a/src/rendering/orchestrator/module-loader/module-cache-lookup.ts
+++ b/src/rendering/orchestrator/module-loader/module-cache-lookup.ts
@@ -28,6 +28,7 @@ export function getModuleCacheKey(
 }
 
 type LookupMdxCache = typeof lookupMdxEsmCache;
+type FileSystemReader = Pick<ReturnType<typeof createFileSystem>, "readTextFile">;
 
 export interface ResolveCachedModulePathInput {
   cacheKey: string;
@@ -38,20 +39,23 @@ export interface ResolveCachedModulePathInput {
   reactVersion?: string;
   moduleCache: Map<string, string>;
   readTextFile?: (path: string) => Promise<string>;
+  fileSystem?: FileSystemReader;
   lookupMdxCache?: LookupMdxCache;
 }
 
 async function resolveInMemoryCachedPath(
   input: Pick<
     ResolveCachedModulePathInput,
-    "cacheKey" | "filePath" | "moduleCache" | "readTextFile"
+    "cacheKey" | "filePath" | "moduleCache" | "readTextFile" | "fileSystem"
   >,
 ): Promise<string | undefined> {
   const cachedPath = input.moduleCache.get(input.cacheKey);
   if (!cachedPath) return undefined;
 
   try {
-    const readTextFile = input.readTextFile ?? createFileSystem().readTextFile;
+    const fileSystem = input.fileSystem ?? createFileSystem();
+    const readTextFile = input.readTextFile ??
+      ((path: string) => fileSystem.readTextFile(path));
     const cachedCode = await readTextFile(cachedPath);
     if (!UNRESOLVED_VF_MODULES_RE.test(cachedCode)) return cachedPath;
 


### PR DESCRIPTION
## Summary
- extract transformModuleWithDeps cache lookup into module-cache-lookup.ts
- preserve in-memory stale artifact invalidation and MDX-ESM cache-hit promotion
- add direct tests for cache key scoping, unresolved _vf_modules invalidation, and MDX cache lookup wiring

Refs #2219

## Tests
- deno test --no-check --allow-all src/rendering/orchestrator/module-loader/module-cache-lookup.test.ts src/rendering/orchestrator/module-loader/index.test.ts
- deno check src/rendering/orchestrator/module-loader/module-cache-lookup.ts src/rendering/orchestrator/module-loader/module-cache-lookup.test.ts src/rendering/orchestrator/module-loader/index.ts src/rendering/orchestrator/module-loader/index.test.ts
- git diff --check
- pre-push hook: format, lint, typecheck, unit suite (2153 passed, 18598 steps)