### PR TITLE
Extract agent model transport helper

### DIFF
--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -36,7 +36,6 @@ import {
 } from "#veryfront/observability/tracing/index.ts";
 import { convertToTextGenerationRuntimeMessages } from "./text-generation-runtime-message-converter.ts";
 import { convertToolsToRuntimeTools } from "./model-tool-converter.ts";
-import { resolveProviderOptionsWithDefaults } from "./default-provider-options.ts";
 import { getRuntimeRemoteToolSources } from "./mcp-server-tool-sources.ts";
 import {
   createStreamState,
@@ -143,7 +142,7 @@ import { closeSSEStream, generateMessageId, sendSSE } from "./sse-utils.ts";
 import { executeConfiguredTool, getAvailableTools, isDynamicTool } from "./tool-helpers.ts";
 import { accumulateUsage, getMaxSteps, normalizeInput } from "./input-utils.ts";
 import { filterToolsForSkill } from "#veryfront/skill/allowed-tools.ts";
-import { resolveConfiguredAgentModel, resolveRuntimeModel } from "./model-resolution.ts";
+import { resolveRuntimeModel } from "./model-resolution.ts";
 import type { RuntimeGenerateToolResult } from "./runtime-tool-types.ts";
 import { stringifyToolError, throwIfAborted } from "./error-utils.ts";
 import { supportsTemperatureParameter } from "./model-capabilities.ts";
@@ -151,6 +150,7 @@ import {
   applySkillDelegationOverridesToToolInput,
   extractSkillDelegationOverrides,
 } from "./skill-delegation-overrides.ts";
+import { resolveAgentModelTransport, type ResolvedModelTransport } from "./model-transport.ts";
 
 const logger = serverLogger.component("agent");
 
@@ -170,14 +170,6 @@ function warnLocalToolSkipping(agentId: string, modelId: string): void {
       "OPENAI_API_KEY, ANTHROPIC_API_KEY, or GOOGLE_API_KEY for full tool support.",
   );
 }
-
-type ResolvedModelTransport = {
-  requestedModel: string;
-  resolvedModelString: string;
-  languageModel: ModelRuntime;
-  headers?: HeadersInit;
-  providerOptions?: Record<string, unknown>;
-};
 
 type RuntimeStepState = {
   systemPrompt: string;
@@ -221,26 +213,13 @@ export class AgentRuntime {
     modelOverride: string | undefined,
     mode: "generate" | "stream",
   ): Promise<ResolvedModelTransport> {
-    const requestedModel = resolveConfiguredAgentModel(modelOverride || this.config.model);
-    const resolvedModelString = resolveRuntimeModel(modelOverride || this.config.model);
-    const transport = await this.config.resolveModelTransport?.({
+    return await resolveAgentModelTransport({
       agentId: this.id,
-      requestedModel,
-      resolvedModel: resolvedModelString,
+      config: this.config,
       context,
+      modelOverride,
       mode,
     });
-
-    return {
-      requestedModel,
-      resolvedModelString,
-      languageModel: transport?.model ?? resolveModel(resolvedModelString),
-      headers: transport?.headers,
-      providerOptions: resolveProviderOptionsWithDefaults(
-        resolvedModelString,
-        transport?.providerOptions,
-      ),
-    };
   }
 
   private async resolveRuntimeState(

--- a/src/agent/runtime/model-transport.test.ts
+++ b/src/agent/runtime/model-transport.test.ts
@@ -1,0 +1,80 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ModelRuntime } from "#veryfront/provider";
+import type { AgentConfig, ModelTransportRequest } from "../types.ts";
+import { resolveAgentModelTransport } from "./model-transport.ts";
+
+function createModel(modelId: string): ModelRuntime {
+  return {
+    provider: "test",
+    modelId,
+    async doGenerate() {
+      return {
+        content: [],
+        finishReason: "stop",
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      };
+    },
+    async doStream() {
+      return { stream: new ReadableStream<unknown>() };
+    },
+  };
+}
+
+describe("resolveAgentModelTransport", () => {
+  it("resolves the configured runtime model when no host transport hook is present", async () => {
+    const config = {
+      model: "local/smollm2-135m",
+      system: "You are a helpful assistant.",
+    } as AgentConfig;
+
+    const transport = await resolveAgentModelTransport({
+      agentId: "agent-1",
+      config,
+      context: undefined,
+      mode: "generate",
+      modelOverride: undefined,
+    });
+
+    assertEquals(transport.requestedModel, "local/smollm2-135m");
+    assertEquals(transport.resolvedModelString, "local/smollm2-135m");
+    assertEquals(transport.languageModel.modelId, "local/smollm2-135m");
+  });
+
+  it("lets the host override model runtime, headers, and provider options", async () => {
+    const hostModel = createModel("hosted/gateway-model");
+    let capturedRequest: ModelTransportRequest | undefined;
+    const config = {
+      model: "host/default-model",
+      system: "You are a helpful assistant.",
+      resolveModelTransport: (request: ModelTransportRequest) => {
+        capturedRequest = request;
+        return {
+          model: hostModel,
+          headers: { Authorization: "Bearer vf_test" },
+          providerOptions: { veryfront: { projectSlug: request.context?.projectSlug } },
+        };
+      },
+    } as AgentConfig;
+
+    const transport = await resolveAgentModelTransport({
+      agentId: "agent-1",
+      config,
+      context: { projectSlug: "demo-project" },
+      mode: "stream",
+      modelOverride: "host/override-model",
+    });
+
+    assertEquals(capturedRequest, {
+      agentId: "agent-1",
+      requestedModel: "host/override-model",
+      resolvedModel: "host/override-model",
+      context: { projectSlug: "demo-project" },
+      mode: "stream",
+    });
+    assertStrictEquals(transport.languageModel, hostModel);
+    assertEquals(new Headers(transport.headers).get("Authorization"), "Bearer vf_test");
+    assertEquals(transport.providerOptions, { veryfront: { projectSlug: "demo-project" } });
+  });
+});

--- a/src/agent/runtime/model-transport.ts
+++ b/src/agent/runtime/model-transport.ts
@@ -1,0 +1,51 @@
+/**
+ * Model transport resolution for the agent runtime.
+ *
+ * @module agent/runtime/model-transport
+ */
+
+import { type AgentConfig } from "../types.ts";
+import { type ModelRuntime, resolveModel } from "#veryfront/provider";
+import { resolveProviderOptionsWithDefaults } from "./default-provider-options.ts";
+import { resolveConfiguredAgentModel, resolveRuntimeModel } from "./model-resolution.ts";
+
+export type ResolvedModelTransport = {
+  requestedModel: string;
+  resolvedModelString: string;
+  languageModel: ModelRuntime;
+  headers?: HeadersInit;
+  providerOptions?: Record<string, unknown>;
+};
+
+export interface ResolveAgentModelTransportInput {
+  agentId: string;
+  config: AgentConfig;
+  context: Record<string, unknown> | undefined;
+  modelOverride: string | undefined;
+  mode: "generate" | "stream";
+}
+
+export async function resolveAgentModelTransport(
+  input: ResolveAgentModelTransportInput,
+): Promise<ResolvedModelTransport> {
+  const requestedModel = resolveConfiguredAgentModel(input.modelOverride || input.config.model);
+  const resolvedModelString = resolveRuntimeModel(input.modelOverride || input.config.model);
+  const transport = await input.config.resolveModelTransport?.({
+    agentId: input.agentId,
+    requestedModel,
+    resolvedModel: resolvedModelString,
+    context: input.context,
+    mode: input.mode,
+  });
+
+  return {
+    requestedModel,
+    resolvedModelString,
+    languageModel: transport?.model ?? resolveModel(resolvedModelString),
+    headers: transport?.headers,
+    providerOptions: resolveProviderOptionsWithDefaults(
+      resolvedModelString,
+      transport?.providerOptions,
+    ),
+  };
+}


### PR DESCRIPTION
## Summary
- move AgentRuntime model transport resolution into model-transport.ts
- keep resolveModelTransport hook request shape, model fallback, headers, and provider option defaulting unchanged
- add direct helper tests alongside existing provider transport runtime coverage

Refs #2216

## Tests
- deno test --no-check --allow-all src/agent/runtime/model-transport.test.ts src/agent/runtime/provider-transport.test.ts
- deno check src/agent/runtime/model-transport.ts src/agent/runtime/model-transport.test.ts src/agent/runtime/index.ts src/agent/runtime/provider-transport.test.ts
- git diff --check
- pre-push hook: format, lint, typecheck, unit suite (2154 passed, 18599 steps)