### PR TITLE
Expose module waterfall diagnostics before cache tuning

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.811",
+  "version": "0.1.812",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/deno.lock
+++ b/deno.lock
@@ -3,8 +3,12 @@
   "specifiers": {
     "jsr:@std/assert@1.0.19": "1.0.19",
     "jsr:@std/assert@^1.0.17": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/async@1.2.0": "1.2.0",
     "jsr:@std/cli@1.0.28": "1.0.28",
+    "jsr:@std/data-structures@^1.0.10": "1.0.11",
     "jsr:@std/dotenv@0.225.6": "0.225.6",
+    "jsr:@std/expect@1.0.18": "1.0.18",
     "jsr:@std/fmt@1.0.9": "1.0.9",
     "jsr:@std/fs@1.0.23": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.12",
@@ -68,11 +72,25 @@
         "jsr:@std/internal"
       ]
     },
+    "@std/async@1.2.0": {
+      "integrity": "c059c6f6d95ca7cc012ae8e8d7164d1697113d54b0b679e4372b354b11c2dee5"
+    },
     "@std/cli@1.0.28": {
       "integrity": "74ef9b976db59ca6b23a5283469c9072be6276853807a83ec6c7ce412135c70a"
     },
+    "@std/data-structures@1.0.11": {
+      "integrity": "53b98ed7efa61f107dfc14244bd2ec5557f7f7ee0bbaef6d449d7937facacb89"
+    },
     "@std/dotenv@0.225.6": {
       "integrity": "1d6f9db72f565bd26790fa034c26e45ecb260b5245417be76c2279e5734c421b"
+    },
+    "@std/expect@1.0.18": {
+      "integrity": "8566eab35200466f8609eb7e7aed062ed0db314e9a258d5d201b1b8997ce801a",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.19",
+        "jsr:@std/internal",
+        "jsr:@std/path@^1.1.4"
+      ]
     },
     "@std/fmt@1.0.9": {
       "integrity": "2487343e8899fb2be5d0e3d35013e54477ada198854e52dd05ed0422eddcabe0"
@@ -97,6 +115,7 @@
       "integrity": "87bdc2700fa98249d48a17cd72413352d3d3680dcfbdb64947fd0982d6bbf681",
       "dependencies": [
         "jsr:@std/assert@^1.0.17",
+        "jsr:@std/data-structures",
         "jsr:@std/internal"
       ]
     },

--- a/src/modules/manifest/route-module-manifest.test.ts
+++ b/src/modules/manifest/route-module-manifest.test.ts
@@ -7,6 +7,7 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { resetMetrics, state } from "#veryfront/observability/simple-metrics/index.ts";
 import {
   clearAllManifests,
   clearProjectManifests,
@@ -97,6 +98,18 @@ describe("Route Module Manifest", () => {
   it("handles undefined projectSlug gracefully", () => {
     recordSSRModules(undefined, "home", ["pages/home.js"]);
     assertEquals(getRouteModulePaths(undefined, "home"), ["pages/home.js"]);
+  });
+
+  it("records route manifest LRU hit and miss totals", () => {
+    clearAllManifests();
+    resetMetrics();
+
+    assertEquals(getRouteManifest("test-project", "missing"), null);
+    recordSSRModules("test-project", "index", ["_vf_modules/pages/index.js"]);
+    assertExists(getRouteManifest("test-project", "index"));
+
+    assertEquals(state.routeManifestLruMisses, 1);
+    assertEquals(state.routeManifestLruHits, 1);
   });
 
   clearAllManifests();

--- a/src/modules/manifest/route-module-manifest.ts
+++ b/src/modules/manifest/route-module-manifest.ts
@@ -12,6 +12,7 @@
 
 import { serverLogger } from "#veryfront/utils";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
+import { metrics } from "#veryfront/observability/simple-metrics/index.ts";
 
 const logger = serverLogger.component("route-module-manifest");
 
@@ -124,6 +125,7 @@ export function getRouteManifest(
 ): RouteManifest | null {
   const key = buildKey(projectSlug, route);
   const manifest = manifestStore.get(key);
+  metrics.recordRouteManifestLookup(!!manifest);
 
   logger.debug("Get manifest", {
     key,

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -11,6 +11,12 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  buildServerTimingHeader,
+  finalizeRequestProfiling,
+  resetRequestProfiles,
+  runWithRequestProfiling,
+} from "#veryfront/observability/request-profiler.ts";
 import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { VERSION } from "#veryfront/utils/version.ts";
@@ -75,8 +81,10 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
   afterEach(() => {
     deleteEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG);
     deleteEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG);
+    deleteEnv("VERYFRONT_ENABLE_SERVER_TIMING");
     configureReleaseAssetManifestFetcher(undefined);
     clearReleaseAssetManifestCache();
+    resetRequestProfiles();
   });
 
   async function serve(req: Request, projectDir = "/tmp/test"): Promise<Response> {
@@ -357,6 +365,47 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     assertEquals(response.status, 200);
     const contentType = response.headers.get("content-type") ?? "";
     assertEquals(contentType.includes("javascript"), true);
+  });
+
+  it("marks source lookup and transform phases for module Server-Timing", async () => {
+    setEnv("VERYFRONT_ENABLE_SERVER_TIMING", "1");
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-module-timing-" });
+    let record: ReturnType<typeof finalizeRequestProfiling> = null;
+
+    try {
+      await Deno.mkdir(`${projectDir}/components`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/components/App.ts`,
+        `export const value = 1;\n`,
+      );
+
+      const response = await runWithRequestProfiling(
+        {
+          category: "module",
+          method: "GET",
+          pathname: "/_vf_modules/components/App.js",
+        },
+        async () => {
+          let profiledResponse: Response | undefined;
+          try {
+            profiledResponse = await serve(
+              new Request("http://localhost:3000/_vf_modules/components/App.js"),
+              projectDir,
+            );
+            return profiledResponse;
+          } finally {
+            record = finalizeRequestProfiling(profiledResponse?.status);
+          }
+        },
+      );
+
+      assertEquals(response.status, 200);
+      const header = buildServerTimingHeader(record!);
+      assertEquals(header.includes("module.source_lookup"), true);
+      assertEquals(header.includes("module.transform"), true);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
   });
 
   it("rewrites browser module HTTP bundle imports through the release manifest", async () => {

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -10,6 +10,8 @@ import { getContentTypeForPath } from "#veryfront/server/handlers/utils/content-
 import { createSecureFs } from "#veryfront/security";
 import { getErrorMessage } from "#veryfront/errors/veryfront-error.ts";
 import { getApiBaseUrlEnv } from "#veryfront/config/env.ts";
+import { profilePhase } from "#veryfront/observability/request-profiler.ts";
+import { metrics, type ModuleServeStatus } from "#veryfront/observability/simple-metrics/index.ts";
 import { injectContext, withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { injectNodePositions } from "#veryfront/transforms/plugins/babel-node-positions.ts";
 import { parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
@@ -237,12 +239,14 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
         });
 
         try {
-          let transformedCode = await transformToESM(
-            snippetCode,
-            `_snippets/${hash}.tsx`,
-            projectDir,
-            adapter,
-            { projectId: effectiveProjectId, dev, ssr: isSSR, reactVersion },
+          let transformedCode = await profileModuleTransform(() =>
+            transformToESM(
+              snippetCode,
+              `_snippets/${hash}.tsx`,
+              projectDir,
+              adapter,
+              { projectId: effectiveProjectId, dev, ssr: isSSR, reactVersion },
+            )
           );
 
           if (isSSR) {
@@ -334,13 +338,15 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
           const userAgent = req.headers.get("user-agent") ?? "";
           const isSSR = url.searchParams.get("ssr") === "true" || userAgent.startsWith("Deno/");
 
-          let code = await transformToESM(source, crossPath, projectDir, adapter, {
-            projectId: effectiveProjectId,
-            dev,
-            ssr: isSSR,
-            moduleServerUrl: `http://${url.host}`,
-            reactVersion,
-          });
+          let code = await profileModuleTransform(() =>
+            transformToESM(source, crossPath, projectDir, adapter, {
+              projectId: effectiveProjectId,
+              dev,
+              ssr: isSSR,
+              moduleServerUrl: `http://${url.host}`,
+              reactVersion,
+            })
+          );
 
           if (isSSR) {
             code = await applySSRImportRewritesAsync(code, {
@@ -393,18 +399,22 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
       }
 
       try {
-        const findResult = await findSourceFile(
-          secureFs,
-          projectDir,
-          filePathWithoutExt,
-          {
-            projectId: effectiveProjectId,
-            projectSlug,
-            branch,
-            releaseId: options.releaseId,
-            reactVersion,
-          },
-          modulePath,
+        const findResult = await profilePhase(
+          "module.source_lookup",
+          () =>
+            findSourceFile(
+              secureFs,
+              projectDir,
+              filePathWithoutExt,
+              {
+                projectId: effectiveProjectId,
+                projectSlug,
+                branch,
+                releaseId: options.releaseId,
+                reactVersion,
+              },
+              modulePath,
+            ),
         );
         if (!findResult) {
           logger.warn("Module not found", {
@@ -413,9 +423,8 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
             projectSlug,
             projectDir,
           });
-          return new Response("Module not found", {
-            status: HTTP_NOT_FOUND,
-            headers: { "Content-Type": "text/plain" },
+          return createModuleResponse(method, "Module not found", HTTP_NOT_FOUND, {
+            "Content-Type": "text/plain",
           });
         }
 
@@ -466,7 +475,9 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
             reactVersion,
           };
 
-          code = await transformToESM(source, sourceFile, projectDir, adapter, transformOpts);
+          code = await profileModuleTransform(() =>
+            transformToESM(source, sourceFile, projectDir, adapter, transformOpts)
+          );
 
           if (isSSR) {
             code = await applySSRImportRewritesAsync(code, {
@@ -933,12 +944,28 @@ function createDevModuleErrorBody(modulePath: string, errorMessage: string): str
   return `// Transform Error\nthrow new Error(${JSON.stringify(errorMessage)});`;
 }
 
+async function profileModuleTransform<T>(fn: () => Promise<T>): Promise<T> {
+  const startedAt = performance.now();
+  try {
+    return await profilePhase("module.transform", fn);
+  } finally {
+    metrics.recordModuleTransform(performance.now() - startedAt);
+  }
+}
+
+function classifyModuleServeStatus(status: number): ModuleServeStatus {
+  if (status >= 200 && status < 300) return "ok";
+  if (status === HTTP_NOT_FOUND) return "not_found";
+  return "error";
+}
+
 function createModuleResponse(
   method: string,
   body: string,
   status: number,
   headers: Record<string, string>,
 ): Response {
+  metrics.recordModuleServe(classifyModuleServeStatus(status));
   return new Response(method === "HEAD" ? null : body, { status, headers });
 }
 

--- a/src/observability/simple-metrics/index.ts
+++ b/src/observability/simple-metrics/index.ts
@@ -41,13 +41,16 @@ export {
   recordContentNetworkFetch,
   recordCorsRejection,
   recordHttp,
+  recordModuleServe,
+  recordModuleTransform,
+  recordRouteManifestLookup,
   recordRSC,
   recordRSCStreamDuration,
   recordSecurityHeaders,
   recordSSR,
 } from "./metrics-recorder.ts";
 
-export type { ContentCacheLayer } from "./metrics-recorder.ts";
+export type { ContentCacheLayer, ModuleServeStatus } from "./metrics-recorder.ts";
 
 import {
   incRequest,
@@ -60,6 +63,9 @@ import {
   recordContentNetworkFetch,
   recordCorsRejection,
   recordHttp,
+  recordModuleServe,
+  recordModuleTransform,
+  recordRouteManifestLookup,
   recordRSC,
   recordRSCStreamDuration,
   recordSecurityHeaders,
@@ -82,6 +88,9 @@ export const metrics = {
   recordApiRetry,
   recordContentCacheHit,
   recordContentNetworkFetch,
+  recordModuleServe,
+  recordModuleTransform,
+  recordRouteManifestLookup,
   snapshot: createSnapshot,
   reset: resetMetrics,
   getRequestCount,

--- a/src/observability/simple-metrics/metrics-recorder.test.ts
+++ b/src/observability/simple-metrics/metrics-recorder.test.ts
@@ -10,6 +10,9 @@ import {
   recordCacheSet,
   recordCorsRejection,
   recordHttp,
+  recordModuleServe,
+  recordModuleTransform,
+  recordRouteManifestLookup,
   recordRSC,
   recordSecurityHeaders,
   recordSSR,
@@ -49,6 +52,39 @@ describe("observability/simple-metrics/metrics-recorder", () => {
       resetMetrics();
       recordCacheSet();
       assertEquals(state.cacheSets, 1);
+    });
+  });
+
+  describe("module performance metrics", () => {
+    it("records module serve status totals", () => {
+      resetMetrics();
+      recordModuleServe("ok");
+      recordModuleServe("not_found");
+      recordModuleServe("error");
+
+      assertEquals(state.moduleServeTotal, 3);
+      assertEquals(state.moduleServeOk, 1);
+      assertEquals(state.moduleServeNotFound, 1);
+      assertEquals(state.moduleServeError, 1);
+    });
+
+    it("records module transform count and total duration", () => {
+      resetMetrics();
+      recordModuleTransform(12.8);
+      recordModuleTransform(-5);
+
+      assertEquals(state.moduleTransformTotal, 2);
+      assertEquals(state.moduleTransformDurationMsTotal, 12);
+    });
+
+    it("records route manifest LRU hits and misses", () => {
+      resetMetrics();
+      recordRouteManifestLookup(true);
+      recordRouteManifestLookup(false);
+      recordRouteManifestLookup(false);
+
+      assertEquals(state.routeManifestLruHits, 1);
+      assertEquals(state.routeManifestLruMisses, 2);
     });
   });
 

--- a/src/observability/simple-metrics/metrics-recorder.ts
+++ b/src/observability/simple-metrics/metrics-recorder.ts
@@ -129,6 +129,53 @@ export function recordCacheInvalidate(n: number): void {
   );
 }
 
+export type ModuleServeStatus = "ok" | "not_found" | "error";
+
+export function recordModuleServe(status: ModuleServeStatus): void {
+  state.moduleServeTotal++;
+
+  switch (status) {
+    case "ok":
+      state.moduleServeOk++;
+      break;
+    case "not_found":
+      state.moduleServeNotFound++;
+      break;
+    case "error":
+      state.moduleServeError++;
+      break;
+  }
+
+  const otel = getOtelInstruments();
+  void safeOtelOperation(
+    () => otel.moduleServeCounter?.add(1, { status }),
+    "module serve counter add failed",
+  );
+}
+
+export function recordModuleTransform(durationMs: number): void {
+  const duration = Math.max(0, Math.floor(durationMs));
+  state.moduleTransformTotal++;
+  state.moduleTransformDurationMsTotal += duration;
+
+  const otel = getOtelInstruments();
+  void safeOtelOperation(() => {
+    otel.moduleTransformCounter?.add(1);
+    otel.moduleTransformDurationHistogram?.record(duration);
+  }, "module transform metrics record failed");
+}
+
+export function recordRouteManifestLookup(hit: boolean): void {
+  if (hit) state.routeManifestLruHits++;
+  else state.routeManifestLruMisses++;
+
+  const otel = getOtelInstruments();
+  void safeOtelOperation(
+    () => otel.routeManifestLookupCounter?.add(1, { hit: hit ? "true" : "false" }),
+    "route manifest lookup counter add failed",
+  );
+}
+
 /**
  * Record SSR render duration
  *

--- a/src/observability/simple-metrics/metrics-state.test.ts
+++ b/src/observability/simple-metrics/metrics-state.test.ts
@@ -44,6 +44,9 @@ describe("observability/simple-metrics/metrics-state", () => {
       assertEquals(typeof snap.cacheGets, "number");
       assertEquals(typeof snap.cacheHits, "number");
       assertEquals(typeof snap.cacheMisses, "number");
+      assertEquals(typeof snap.moduleServeTotal, "number");
+      assertEquals(typeof snap.moduleTransformTotal, "number");
+      assertEquals(typeof snap.routeManifestLruHits, "number");
       assertEquals(typeof snap.corsRejections, "number");
     });
 
@@ -69,10 +72,14 @@ describe("observability/simple-metrics/metrics-state", () => {
     it("should reset all counters to zero", () => {
       state.requests = 100;
       state.cacheHits = 50;
+      state.moduleServeTotal = 12;
+      state.routeManifestLruMisses = 4;
       state.corsRejections = 5;
       resetMetrics();
       assertEquals(state.requests, 0);
       assertEquals(state.cacheHits, 0);
+      assertEquals(state.moduleServeTotal, 0);
+      assertEquals(state.routeManifestLruMisses, 0);
       assertEquals(state.corsRejections, 0);
     });
 

--- a/src/observability/simple-metrics/metrics-state.ts
+++ b/src/observability/simple-metrics/metrics-state.ts
@@ -19,6 +19,14 @@ export const state: MetricsState = {
   cacheMisses: 0,
   cacheSets: 0,
   cacheInvalidations: 0,
+  moduleServeTotal: 0,
+  moduleServeOk: 0,
+  moduleServeNotFound: 0,
+  moduleServeError: 0,
+  moduleTransformTotal: 0,
+  moduleTransformDurationMsTotal: 0,
+  routeManifestLruHits: 0,
+  routeManifestLruMisses: 0,
   ssrHistogram: undefined,
   rscStreamHistogram: undefined,
   corsRejections: 0,
@@ -64,6 +72,14 @@ export function createSnapshot(): VeryfrontMetrics {
     cacheMisses: state.cacheMisses,
     cacheSets: state.cacheSets,
     cacheInvalidations: state.cacheInvalidations,
+    moduleServeTotal: state.moduleServeTotal,
+    moduleServeOk: state.moduleServeOk,
+    moduleServeNotFound: state.moduleServeNotFound,
+    moduleServeError: state.moduleServeError,
+    moduleTransformTotal: state.moduleTransformTotal,
+    moduleTransformDurationMsTotal: state.moduleTransformDurationMsTotal,
+    routeManifestLruHits: state.routeManifestLruHits,
+    routeManifestLruMisses: state.routeManifestLruMisses,
     corsRejections: state.corsRejections,
     securityHeadersApplied: state.securityHeadersApplied,
     apiRequests2xx: state.apiRequests2xx,
@@ -110,6 +126,14 @@ export function resetMetrics(): void {
   state.cacheMisses = 0;
   state.cacheSets = 0;
   state.cacheInvalidations = 0;
+  state.moduleServeTotal = 0;
+  state.moduleServeOk = 0;
+  state.moduleServeNotFound = 0;
+  state.moduleServeError = 0;
+  state.moduleTransformTotal = 0;
+  state.moduleTransformDurationMsTotal = 0;
+  state.routeManifestLruHits = 0;
+  state.routeManifestLruMisses = 0;
   state.corsRejections = 0;
   state.securityHeadersApplied = 0;
   state.apiRequests2xx = 0;

--- a/src/observability/simple-metrics/otel-instruments.ts
+++ b/src/observability/simple-metrics/otel-instruments.ts
@@ -63,6 +63,22 @@ export async function ensureOtelInstruments(): Promise<void> {
     otel.cacheInvalidateCounter = meter.createCounter("veryfront.cache.invalidations", {
       description: "Cache invalidations",
     });
+    otel.moduleServeCounter = meter.createCounter("veryfront.module.serve.total", {
+      description: "Module server responses by status",
+    });
+    otel.moduleTransformCounter = meter.createCounter("veryfront.module.transform.total", {
+      description: "Module transforms",
+    });
+    otel.moduleTransformDurationHistogram = meter.createHistogram(
+      "veryfront.module.transform.duration",
+      {
+        description: "Module transform duration (ms)",
+        unit: "ms",
+      },
+    );
+    otel.routeManifestLookupCounter = meter.createCounter("veryfront.route_manifest.lookup.total", {
+      description: "Route module manifest LRU lookups by hit status",
+    });
   } catch (e) {
     safeLogWarn("[metrics] OpenTelemetry init failed", e);
   }

--- a/src/observability/simple-metrics/types.ts
+++ b/src/observability/simple-metrics/types.ts
@@ -42,6 +42,14 @@ export interface VeryfrontMetrics {
   cacheMisses: number;
   cacheSets: number;
   cacheInvalidations: number;
+  moduleServeTotal: number;
+  moduleServeOk: number;
+  moduleServeNotFound: number;
+  moduleServeError: number;
+  moduleTransformTotal: number;
+  moduleTransformDurationMsTotal: number;
+  routeManifestLruHits: number;
+  routeManifestLruMisses: number;
   ssrHistogram?: { boundaries: number[]; counts: number[] };
   corsRejections: number;
   securityHeadersApplied: number;
@@ -78,4 +86,8 @@ export interface OtelInstruments {
   cacheMissCounter?: Counter;
   cacheSetCounter?: Counter;
   cacheInvalidateCounter?: Counter;
+  moduleServeCounter?: Counter;
+  moduleTransformCounter?: Counter;
+  moduleTransformDurationHistogram?: Histogram;
+  routeManifestLookupCounter?: Counter;
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.811";
+export const VERSION = "0.1.812";


### PR DESCRIPTION
## Summary
- Add low-cardinality module serve, module transform, and route-manifest lookup counters to simple metrics and OTel instruments.
- Add module Server-Timing phases for source lookup and transform work so production sampling can separate module waterfall cost from render-cache and HTML TTFB cost.
- Bump Veryfront to 0.1.812 for the main-branch release workflow and refresh deno.lock metadata from the repo pre-push gate.

## Validation
- deno fmt --check deno.json src/utils/version-constant.ts src/modules/manifest/route-module-manifest.test.ts src/modules/manifest/route-module-manifest.ts src/modules/server/module-server.test.ts src/modules/server/module-server.ts src/observability/simple-metrics/index.ts src/observability/simple-metrics/metrics-recorder.test.ts src/observability/simple-metrics/metrics-recorder.ts src/observability/simple-metrics/metrics-state.test.ts src/observability/simple-metrics/metrics-state.ts src/observability/simple-metrics/otel-instruments.ts src/observability/simple-metrics/types.ts
- deno check src/utils/version-constant.ts src/utils/version.ts src/observability/simple-metrics/types.ts src/observability/simple-metrics/metrics-state.ts src/observability/simple-metrics/metrics-recorder.ts src/observability/simple-metrics/index.ts src/observability/simple-metrics/otel-instruments.ts src/modules/manifest/route-module-manifest.ts src/modules/server/module-server.ts src/modules/server/module-server.test.ts
- deno test --no-check --allow-all src/observability/simple-metrics/metrics-recorder.test.ts src/observability/simple-metrics/metrics-state.test.ts src/modules/manifest/route-module-manifest.test.ts src/modules/server/module-server.test.ts src/observability/request-profiler.test.ts src/server/handlers/monitoring/metrics.handler.test.ts src/observability/simple-metrics/otel-instruments.test.ts
- git diff --check origin/main..HEAD
- pre-push hook passed formatting, lint, type check, generated assets, and unit tests: 2155 passed, 18610 steps, 0 failed
- npm view veryfront@0.1.812 version returned 404, so the release version is available

## Rollout
- Merge to main runs .github/workflows/cicd.yml. The version check should detect 0.1.812 and publish the stable release.
- After release, sample the target app with VERYFRONT_ENABLE_SERVER_TIMING=1 and inspect module.source_lookup, module.transform, module serve counters, transform duration, and route-manifest hit/miss counters.

## Remaining risk
- Live production sampling is still needed to decide whether the next performance change should tune route-manifest caching, transform caching, module caching headers, or render/HTML caching.
