### PR TITLE
Make SPA navigation reuse production render work

### DIFF
--- a/src/cache/keys.test.ts
+++ b/src/cache/keys.test.ts
@@ -334,6 +334,11 @@ describe("cache/keys", () => {
       assertEquals(buildQueryAwareCacheKey("/blog"), "/blog");
     });
 
+    it("should normalize the root slug to a non-empty key", () => {
+      assertEquals(buildQueryAwareCacheKey(""), "index");
+      assertEquals(buildQueryAwareCacheKey("", new URL("https://example.com/")), "index");
+    });
+
     it("should return slug when URL has no query params", () => {
       const url = new URL("https://example.com/blog");
       assertEquals(buildQueryAwareCacheKey("/blog", url), "/blog");

--- a/src/cache/keys/builders/render.ts
+++ b/src/cache/keys/builders/render.ts
@@ -126,8 +126,9 @@ export function buildQueryAwareCacheKey(
   url?: URL,
   options?: QueryParamCacheOptions,
 ): string {
-  if (!url) return slug;
+  const normalizedSlug = slug || "index";
+  if (!url) return normalizedSlug;
 
   const queryPart = sanitizeQueryParamsForCacheKey(url, options);
-  return queryPart ? `${slug}:q:${queryPart}` : slug;
+  return queryPart ? `${normalizedSlug}:q:${queryPart}` : normalizedSlug;
 }

--- a/src/cache/request-cacheability.test.ts
+++ b/src/cache/request-cacheability.test.ts
@@ -1,0 +1,40 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { isCacheNeutralCookieName, requestHasCacheSensitiveState } from "./request-cacheability.ts";
+
+describe("cache/request-cacheability", () => {
+  it("treats requests without auth state as cacheable", () => {
+    const req = new Request("https://example.com/");
+    assertEquals(requestHasCacheSensitiveState(req), false);
+  });
+
+  it("treats authorization and API keys as cache-sensitive", () => {
+    const withAuthorization = new Request("https://example.com/", {
+      headers: { authorization: "Bearer test" },
+    });
+    const withApiKey = new Request("https://example.com/", {
+      headers: { "x-api-key": "test" },
+    });
+
+    assertEquals(requestHasCacheSensitiveState(withAuthorization), true);
+    assertEquals(requestHasCacheSensitiveState(withApiKey), true);
+  });
+
+  it("does not treat the load-balancer cookie as personalized state", () => {
+    const req = new Request("https://example.com/", {
+      headers: { cookie: "lb=server-a" },
+    });
+
+    assertEquals(isCacheNeutralCookieName("lb"), true);
+    assertEquals(requestHasCacheSensitiveState(req), false);
+  });
+
+  it("treats unknown cookies as cache-sensitive", () => {
+    const req = new Request("https://example.com/", {
+      headers: { cookie: "lb=server-a; session=abc123" },
+    });
+
+    assertEquals(requestHasCacheSensitiveState(req), true);
+  });
+});

--- a/src/cache/request-cacheability.ts
+++ b/src/cache/request-cacheability.ts
@@ -1,0 +1,30 @@
+const CACHE_NEUTRAL_COOKIES = new Set([
+  "lb",
+]);
+
+export function requestHasCacheSensitiveState(req: Request): boolean {
+  if (req.headers.has("authorization") || req.headers.has("x-api-key")) {
+    return true;
+  }
+
+  const cookieHeader = req.headers.get("cookie");
+  if (!cookieHeader) return false;
+
+  return parseCookieNames(cookieHeader).some((name) => !isCacheNeutralCookieName(name));
+}
+
+export function isCacheNeutralCookieName(name: string): boolean {
+  return CACHE_NEUTRAL_COOKIES.has(name.trim().toLowerCase());
+}
+
+function parseCookieNames(cookieHeader: string): string[] {
+  return cookieHeader
+    .split(";")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => {
+      const separatorIndex = part.indexOf("=");
+      return separatorIndex === -1 ? part : part.slice(0, separatorIndex).trim();
+    })
+    .filter(Boolean);
+}

--- a/src/html/hydration-script-builder/hydration-data-generator.ts
+++ b/src/html/hydration-script-builder/hydration-data-generator.ts
@@ -3,7 +3,7 @@ import { resolveRelativePath } from "#veryfront/modules/react-loader/path-resolv
 import { getExtensionName } from "#veryfront/utils/path-utils.ts";
 import { determineClientModuleStrategy } from "#veryfront/rendering/rsc/client-module-strategy.ts";
 import { jsonForInlineScript } from "#veryfront/security/client/html-sanitizer.ts";
-import { releaseAssetUrl } from "#veryfront/release-assets/constants.ts";
+import { buildReleaseAssetModules } from "#veryfront/release-assets/client-module-map.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import type { HTMLGenerationOptions } from "../types.ts";
 import type { HydrationDataStructure } from "./types.ts";
@@ -38,18 +38,6 @@ function inferPageType(pagePath?: string): PageType | undefined {
 type HydrationOptions = HTMLGenerationOptions & {
   releaseAssetManifest?: ReleaseAssetManifest | null;
 };
-
-function buildReleaseAssetModules(
-  manifest?: ReleaseAssetManifest | null,
-): Record<string, string> | undefined {
-  if (!manifest) return undefined;
-
-  const modules: Record<string, string> = {};
-  for (const [path, entry] of Object.entries(manifest.modules)) {
-    modules[path] = releaseAssetUrl(entry.contentHash, "js");
-  }
-  return Object.keys(modules).length > 0 ? modules : undefined;
-}
 
 export function generateHydrationData(
   slug: string,

--- a/src/html/hydration-script-builder/templates/router.test.ts
+++ b/src/html/hydration-script-builder/templates/router.test.ts
@@ -149,6 +149,8 @@ describe("hydration-script-builder/templates/router", () => {
     it("should define prefetching on hover", () => {
       const result = getRouterScript();
       assertIncludes(result, "function prefetchPage(href)");
+      assertIncludes(result, "function preloadModulesForPageData(pageData, path)");
+      assertIncludes(result, "loadComponent(modulePath)");
       assertIncludes(result, "PREFETCH_DELAY_MS");
       assertIncludes(result, "MAX_PREFETCH_PATHS = 100");
     });

--- a/src/html/hydration-script-builder/templates/router.ts
+++ b/src/html/hydration-script-builder/templates/router.ts
@@ -306,9 +306,11 @@ export const getRouterScript = () => `
 
     async function fetchPageDataForPrefetch(path) {
       if (getCachedPageData(path)) return;
-      return fetchPageDataFresh(path, null).catch((error) => {
-        logBackgroundFetchFailure('Page data prefetch', path, error);
-      });
+      return fetchPageDataFresh(path, null)
+        .then((data) => preloadModulesForPageData(data, path))
+        .catch((error) => {
+          logBackgroundFetchFailure('Page data prefetch', path, error);
+        });
     }
 
     // ============================================
@@ -406,11 +408,7 @@ export const getRouterScript = () => `
       }
 
       perfStart('render:loadAll');
-      const layoutPaths = (pageData.layouts || []).map((l) => l.path);
-      const allPaths = [pageData.pagePath, ...layoutPaths];
-
-      if (pageData.appPath) allPaths.push(pageData.appPath);
-
+      const allPaths = getPageDataModulePaths(pageData);
       const components = await Promise.all(allPaths.map((path) => loadComponent(path)));
       perfEnd('render:loadAll');
 
@@ -517,14 +515,47 @@ export const getRouterScript = () => `
     }
 
     // ============================================
-    // Prefetching on hover (page data only, no module preloading)
+    // Prefetching on hover
     // ============================================
     let prefetchTimeout = null;
     const prefetchedPaths = new Set();
     const inFlightPrefetches = new Set();
 
+    function getPageDataModulePaths(pageData) {
+      const layoutPaths = (pageData.layouts || []).map((l) => l.path).filter(Boolean);
+      const allPaths = [pageData.pagePath, ...layoutPaths].filter(Boolean);
+
+      if (pageData.appPath) allPaths.push(pageData.appPath);
+
+      return allPaths;
+    }
+
+    async function preloadModulesForPageData(pageData, path) {
+      if (!pageData) return;
+      if (pageData.releaseAssetModules && window.__veryfrontSetReleaseAssetModules) {
+        window.__veryfrontSetReleaseAssetModules(pageData.releaseAssetModules);
+      }
+
+      const modulePaths = getPageDataModulePaths(pageData);
+      if (modulePaths.length === 0) return;
+
+      try {
+        await Promise.all(modulePaths.map((modulePath) => loadComponent(modulePath)));
+      } catch (error) {
+        logBackgroundFetchFailure('Module prefetch', path, error);
+      }
+    }
+
     function prefetchPage(href) {
-      if (prefetchedPaths.has(href) || getCachedPageData(href) || inFlightPrefetches.has(href)) return;
+      if (prefetchedPaths.has(href) || inFlightPrefetches.has(href)) return;
+
+      const cachedPageData = getCachedPageData(href);
+      if (cachedPageData) {
+        preloadModulesForPageData(cachedPageData, href).catch((error) => {
+          logBackgroundFetchFailure('Module prefetch', href, error);
+        });
+        return;
+      }
 
       if (prefetchedPaths.size >= MAX_PREFETCH_PATHS) {
         const oldest = prefetchedPaths.values().next().value;

--- a/src/observability/request-profiler.test.ts
+++ b/src/observability/request-profiler.test.ts
@@ -57,6 +57,12 @@ describe("request profiler", () => {
     assertEquals(result.phases["render.cache_hit"], 0);
   });
 
+  it("profiles page-data requests when Server-Timing diagnostics are enabled", () => {
+    Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
+
+    assertEquals(isRequestProfilingEnabled("/_veryfront/page-data/blog.json"), true);
+  });
+
   it("formats a Server-Timing header from total and phase durations", () => {
     const header = buildServerTimingHeader({
       sequence: 1,

--- a/src/observability/request-profiler.ts
+++ b/src/observability/request-profiler.ts
@@ -57,6 +57,7 @@ function shouldProfilePath(pathname: string): boolean {
     pathname.startsWith("/api/bench/") ||
     pathname.startsWith("/_vf_styles/") ||
     pathname.startsWith("/_vf_modules/") ||
+    (shouldEnableServerTiming() && pathname.startsWith("/_veryfront/page-data/")) ||
     (shouldEnableServerTiming() && isHtmlPath(pathname));
 }
 

--- a/src/release-assets/client-module-map.ts
+++ b/src/release-assets/client-module-map.ts
@@ -1,0 +1,15 @@
+import { releaseAssetUrl } from "./constants.ts";
+import type { ReleaseAssetManifest } from "./manifest-schema.ts";
+
+export function buildReleaseAssetModules(
+  manifest?: ReleaseAssetManifest | null,
+): Record<string, string> | undefined {
+  if (!manifest) return undefined;
+
+  const modules: Record<string, string> = {};
+  for (const [path, entry] of Object.entries(manifest.modules)) {
+    modules[path] = releaseAssetUrl(entry.contentHash, "js");
+  }
+
+  return Object.keys(modules).length > 0 ? modules : undefined;
+}

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -15,7 +15,10 @@ import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 
 const RELEASE_CSS_HASH = "c".repeat(64);
 
-function createPipeline(pagePath: string): RenderPipeline {
+function createPipeline(
+  pagePath: string,
+  overrides: Partial<RenderPipelineConfig> = {},
+): RenderPipeline {
   const config: RenderPipelineConfig = {
     pageResolver: {
       resolvePage: async () =>
@@ -32,6 +35,7 @@ function createPipeline(pagePath: string): RenderPipeline {
     } as any,
     pageRenderer: {
       preparePageBundles: async () => ({
+        pageElement: {},
         pageBundle: {},
       }),
     } as any,
@@ -65,6 +69,7 @@ function createPipeline(pagePath: string): RenderPipeline {
     } as any,
     mode: "production",
     projectDir: "/project",
+    ...overrides,
   };
 
   return new RenderPipeline(config);
@@ -115,6 +120,32 @@ describe("RenderPipeline behavior", () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, originalManifestFlag ?? "");
     configureReleaseAssetManifestFetcher(undefined);
     clearReleaseAssetManifestCache();
+  });
+
+  it("renderPage uses a non-empty cache key for the root slug", async () => {
+    const checks: Array<{ slug: string; cacheKey?: string }> = [];
+    const persists: Array<{ slug: string; cacheKey?: string }> = [];
+    const pipeline = createPipeline("/project/pages/index.mdx", {
+      cacheCoordinator: {
+        checkCache: async (slug, cacheKey) => {
+          checks.push({ slug, cacheKey });
+          return {
+            depAwareSlug: slug,
+            moduleCacheKey: cacheKey ?? slug,
+            cacheStatus: "miss",
+            lookupDurationMs: 0,
+          };
+        },
+        persistResult: async (_result, slug, cacheKey) => {
+          persists.push({ slug, cacheKey });
+        },
+      },
+    } as Partial<RenderPipelineConfig>);
+
+    await pipeline.renderPage("", { delivery: "string" });
+
+    assertEquals(checks, [{ slug: "", cacheKey: "index" }]);
+    assertEquals(persists, [{ slug: "", cacheKey: "index" }]);
   });
 
   it("resolvePageData surfaces notFound from data hooks", async () => {
@@ -229,6 +260,34 @@ describe("RenderPipeline behavior", () => {
     });
 
     assertEquals(pageData.appPath, "components/app.tsx");
+  });
+
+  it("resolvePageData includes release asset modules when a manifest is provided", async () => {
+    const slug = "/behavior-release-modules";
+    const projectId = "proj-release-modules";
+    const pipeline = createPipeline("/project/pages/behavior-release-modules.mdx");
+    primeCssCache(slug, projectId);
+
+    const manifest = releaseManifestWithCss();
+    manifest.modules = {
+      "pages/behavior-release-modules.mdx": {
+        contentHash: "a".repeat(64),
+        size: 100,
+        contentType: "application/javascript",
+      },
+    };
+
+    const pageData = await pipeline.resolvePageData(slug, {
+      projectId,
+      request: new Request(`http://localhost${slug}`),
+      url: new URL(`http://localhost${slug}`),
+      releaseAssetManifest: manifest,
+    });
+
+    assertEquals(
+      pageData.releaseAssetModules?.["pages/behavior-release-modules.mdx"],
+      `/_vf/assets/${"a".repeat(64)}.js`,
+    );
   });
 
   it("resolvePageData includes projectUpdated in buildVersion when available", async () => {

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -22,6 +22,7 @@ import { SpanNames } from "#veryfront/observability/tracing/span-names.ts";
 import { VeryfrontError } from "#veryfront/errors/index.ts";
 import { FILE_NOT_FOUND, RENDER_ERROR } from "#veryfront/errors/error-registry.ts";
 import { buildQueryAwareCacheKey } from "#veryfront/cache/keys.ts";
+import { requestHasCacheSensitiveState } from "#veryfront/cache/request-cacheability.ts";
 import {
   extractRelativePath as extractRelativePathShared,
   extractRouteParams as extractRouteParamsShared,
@@ -50,6 +51,7 @@ import { LAYOUT_EXTENSIONS } from "../layouts/types.ts";
 import type { LayoutItem } from "#veryfront/types";
 import { withTimeout, withTimeoutThrow } from "../utils/stream-utils.ts";
 import { extractCandidates, generateTailwindCSS } from "#veryfront/html/styles-builder/index.ts";
+import { buildReleaseAssetModules } from "#veryfront/release-assets/client-module-map.ts";
 import {
   getCSSByHashAsync,
   regenerateCSSByHash,
@@ -391,7 +393,7 @@ export class RenderPipeline {
     let cacheResult: Awaited<ReturnType<typeof this.config.cacheCoordinator.checkCache>> | null =
       null;
 
-    const shouldCache = !!cacheKey && options?.delivery !== "stream";
+    const shouldCache = cacheKey !== null && options?.delivery !== "stream";
 
     if (shouldCache && !options?.skipCacheCheck) {
       const cacheCheckStart = performance.now();
@@ -698,6 +700,7 @@ export class RenderPipeline {
       layoutProps,
       buildVersion: createBuildVersion(projectUpdatedAt),
       appPath,
+      releaseAssetModules: buildReleaseAssetModules(options?.releaseAssetManifest),
       headings,
       css,
       cssAction,
@@ -851,7 +854,9 @@ export class RenderPipeline {
 
   private hasReadyReleaseCss(options: RenderOptions | undefined): boolean {
     if (options?.environment !== "production") return false;
-    const releaseManifest = getReadyManifestForRender(options?.releaseId);
+    const releaseManifest = options.releaseAssetManifest !== undefined
+      ? options.releaseAssetManifest
+      : getReadyManifestForRender(options?.releaseId);
     return (releaseManifest?.css?.length ?? 0) > 0;
   }
 
@@ -885,15 +890,9 @@ export class RenderPipeline {
     if (options?.cacheKey) return options.cacheKey;
     const req = options?.request;
     if (req) {
-      const hasAuth = req.headers.has("authorization") ||
-        req.headers.has("cookie") ||
-        req.headers.has("x-api-key");
-      if (hasAuth) return null;
+      if (requestHasCacheSensitiveState(req)) return null;
     }
 
-    const url = options?.url;
-    if (!url) return slug;
-
-    return buildQueryAwareCacheKey(slug, url, this.config.queryParamOptions);
+    return buildQueryAwareCacheKey(slug, options?.url, this.config.queryParamOptions);
   }
 }

--- a/src/rendering/orchestrator/types.ts
+++ b/src/rendering/orchestrator/types.ts
@@ -83,6 +83,8 @@ export interface PageDataResponse {
   layoutProps: Record<string, Record<string, unknown>>;
   buildVersion: BuildVersion;
   appPath?: string;
+  /** Production release asset URLs keyed by logical source path. */
+  releaseAssetModules?: Record<string, string>;
   /** Headings extracted from MDX for sidebar/TOC navigation */
   headings?: Array<{ id: string; text: string; level: number }>;
   /** JIT-compiled Tailwind CSS for this page (for SPA navigation in prod mode) */

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -39,6 +39,7 @@ import {
   buildRenderCachePrefix,
   type QueryParamCacheOptions,
 } from "#veryfront/cache/keys.ts";
+import { requestHasCacheSensitiveState } from "#veryfront/cache/request-cacheability.ts";
 import { getEnvNumber } from "#veryfront/compat/process.ts";
 import { getReadyManifestForRenderAsync } from "#veryfront/release-assets/manifest-cache.ts";
 import {
@@ -200,7 +201,7 @@ export class Renderer {
           releaseAssetManifest: releaseManifest,
         };
         const cacheKey = this.buildCacheKey(slug, effectiveCtx, effectiveOptions);
-        const cacheResult = cacheKey
+        const cacheResult = cacheKey !== null
           ? await this.cache.checkCache(slug, effectiveCtx, effectiveOptions?.colorScheme, cacheKey)
           : { hit: false, cacheKey: "", status: "miss" as const, lookupDurationMs: 0 };
         if (cacheResult.hit && cacheResult.cachedResult) {
@@ -323,19 +324,13 @@ export class Renderer {
 
     const req = options?.request;
     if (req) {
-      const hasAuth = req.headers.has("authorization") ||
-        req.headers.has("cookie") ||
-        req.headers.has("x-api-key");
-      if (hasAuth) return null;
+      if (requestHasCacheSensitiveState(req)) return null;
     }
-
-    const url = options?.url;
-    if (!url) return slug;
 
     // Get query param handling options from config
     const queryParamOptions = ctx.config?.cache?.queryParams as QueryParamCacheOptions | undefined;
 
-    return buildQueryAwareCacheKey(slug, url, queryParamOptions);
+    return buildQueryAwareCacheKey(slug, options?.url, queryParamOptions);
   }
 
   private async doRenderPage(
@@ -347,7 +342,7 @@ export class Renderer {
   ): Promise<RenderResult> {
     const effectiveKey = cacheKey ?? crypto.randomUUID();
     const flightKey = this.getSingleflightKey(effectiveKey, ctx, options?.colorScheme);
-    const isFollower = cacheKey ? this.renderFlight.has(flightKey) : false;
+    const isFollower = cacheKey !== null ? this.renderFlight.has(flightKey) : false;
 
     const runRender = async () => {
       const services = this.createServicesForContext(ctx, options?.colorScheme);
@@ -379,7 +374,7 @@ export class Renderer {
         throw error;
       }
 
-      if (cacheKey) {
+      if (cacheKey !== null) {
         await this.cache.persistResult(result, slug, ctx, options?.colorScheme, cacheKey);
       }
 
@@ -399,7 +394,7 @@ export class Renderer {
       };
     };
 
-    const cachedData = cacheKey
+    const cachedData = cacheKey !== null
       ? await this.renderFlight.do(flightKey, runRender)
       : await runRender();
 
@@ -433,14 +428,24 @@ export class Renderer {
       });
     }
 
-    const services = this.createServicesForContext(ctx);
+    return withSpan("renderer.resolvePageData", async () => {
+      const releaseManifest = await this.resolveReleaseAssetManifest(ctx, options);
+      const effectiveCtx = this.withManifestCachePrefix(ctx, releaseManifest);
+      const services = this.createServicesForContext(effectiveCtx);
 
-    return services.pipeline.resolvePageData(slug, {
-      ...options,
-      projectId: ctx.projectId,
-      projectSlug: ctx.projectSlug,
-      environment: ctx.environment,
-      contentSourceId: ctx.contentSourceId,
+      return services.pipeline.resolvePageData(slug, {
+        ...options,
+        projectId: effectiveCtx.projectId,
+        projectSlug: effectiveCtx.projectSlug,
+        environment: effectiveCtx.environment,
+        contentSourceId: effectiveCtx.contentSourceId,
+        releaseId: effectiveCtx.releaseId,
+        releaseAssetManifest: releaseManifest,
+      });
+    }, {
+      "renderer.slug": slug,
+      "renderer.projectId": ctx.projectId,
+      "renderer.environment": ctx.environment,
     });
   }
 

--- a/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
@@ -1,0 +1,185 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { ResponseBuilder } from "#veryfront/security/index.ts";
+import type { HandlerContext, HandlerResult } from "../../types.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { PageDataResponse } from "#veryfront/rendering/orchestrator/types.ts";
+import type { Renderer } from "#veryfront/rendering/renderer.ts";
+import {
+  destroyRendererAdapter,
+  type RendererInitializer,
+  setRendererInitializer,
+} from "../../../shared/renderer/index.ts";
+import {
+  __clearPageDataEndpointCacheForTests,
+  handlePageDataEndpoint,
+} from "./page-data-endpoint-handler.ts";
+
+function createMockAdapter(): RuntimeAdapter {
+  return {
+    id: "memory",
+    name: "mock",
+    capabilities: {
+      typescript: true,
+      jsx: true,
+      fileWatcher: false,
+      shell: false,
+      kvStore: false,
+      workers: false,
+    },
+    fs: {
+      exists: () => Promise.resolve(false),
+      readFile: () => Promise.resolve(""),
+      writeFile: () => Promise.resolve(),
+      readDir: () => Promise.resolve([]),
+      mkdir: () => Promise.resolve(),
+      remove: () => Promise.resolve(),
+      stat: () => Promise.resolve({ isFile: false, isDirectory: false, size: 0, mtime: null }),
+    },
+    env: {
+      get: () => undefined,
+      set: () => {},
+      delete: () => {},
+      toObject: () => ({}),
+    },
+    server: { createHandler: () => () => new Response() },
+    serve: () => Promise.resolve({ close: () => Promise.resolve() } as any),
+  } as unknown as RuntimeAdapter;
+}
+
+function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    projectDir: "/tmp/test-project",
+    projectSlug: "test-project",
+    projectId: "proj-page-data",
+    releaseId: "rel-page-data",
+    resolvedEnvironment: "production",
+    requestContext: { mode: "production", branch: null } as HandlerContext["requestContext"],
+    config: {} as HandlerContext["config"],
+    adapter: createMockAdapter(),
+    securityConfig: null,
+    cspUserHeader: null,
+    ...overrides,
+  };
+}
+
+function createPageData(slug: string, sequence: number): PageDataResponse {
+  return {
+    slug,
+    pagePath: "pages/index.mdx",
+    pageType: "mdx",
+    layouts: [],
+    providers: [],
+    frontmatter: { sequence },
+    props: {},
+    params: {},
+    layoutProps: {},
+    buildVersion: { framework: "test", serverStart: 1 },
+  };
+}
+
+function createInitializer(resolvePageData: Renderer["resolvePageData"]): RendererInitializer {
+  const renderer = {
+    resolvePageData,
+  } as Partial<Renderer>;
+
+  return {
+    initialize: () => Promise.resolve(renderer as Renderer),
+    isInitialized: () => true,
+    get: () => renderer as Renderer,
+    destroy: () => Promise.resolve(),
+  };
+}
+
+async function callPageDataEndpoint(
+  req: Request,
+  ctx: HandlerContext,
+): Promise<Response> {
+  const result = await handlePageDataEndpoint(
+    req,
+    new URL(req.url).pathname,
+    ctx,
+    () => new ResponseBuilder(),
+    (response): HandlerResult => ({ response, continue: false }),
+    (error) => error instanceof Error ? error.message : String(error),
+  );
+
+  return result.response!;
+}
+
+describe("server/handlers/request/module/page-data-endpoint-handler", () => {
+  afterEach(async () => {
+    __clearPageDataEndpointCacheForTests();
+    await destroyRendererAdapter();
+    setRendererInitializer(undefined);
+  });
+
+  it("caches anonymous page-data responses by project, release, slug, and query", async () => {
+    let calls = 0;
+    setRendererInitializer(
+      createInitializer((slug) => Promise.resolve(createPageData(slug, ++calls))),
+    );
+
+    const ctx = makeCtx();
+    const req = new Request("http://localhost/_veryfront/page-data/index.json?b=2&a=1");
+
+    const first = await callPageDataEndpoint(req, ctx);
+    const second = await callPageDataEndpoint(
+      new Request("http://localhost/_veryfront/page-data/index.json?a=1&b=2"),
+      ctx,
+    );
+
+    assertEquals(first.status, 200);
+    assertEquals(second.status, 200);
+    assertEquals(calls, 1);
+    assertEquals(await first.text(), await second.text());
+  });
+
+  it("uses cached etags to answer 304 without resolving page data again", async () => {
+    let calls = 0;
+    setRendererInitializer(
+      createInitializer((slug) => Promise.resolve(createPageData(slug, ++calls))),
+    );
+
+    const ctx = makeCtx();
+    const first = await callPageDataEndpoint(
+      new Request("http://localhost/_veryfront/page-data/index.json"),
+      ctx,
+    );
+    const etag = first.headers.get("etag");
+
+    const second = await callPageDataEndpoint(
+      new Request("http://localhost/_veryfront/page-data/index.json", {
+        headers: etag ? { "if-none-match": etag } : undefined,
+      }),
+      ctx,
+    );
+
+    assertEquals(first.status, 200);
+    assertEquals(second.status, 304);
+    assertEquals(calls, 1);
+  });
+
+  it("does not cache requests with sensitive cookies", async () => {
+    let calls = 0;
+    setRendererInitializer(
+      createInitializer((slug) => Promise.resolve(createPageData(slug, ++calls))),
+    );
+
+    const ctx = makeCtx();
+    const init = { headers: { cookie: "session=abc123" } };
+
+    const first = await callPageDataEndpoint(
+      new Request("http://localhost/_veryfront/page-data/index.json", init),
+      ctx,
+    );
+    await callPageDataEndpoint(
+      new Request("http://localhost/_veryfront/page-data/index.json", init),
+      ctx,
+    );
+
+    assertEquals(calls, 2);
+    assertEquals(first.headers.get("cache-control"), "no-cache, no-store, must-revalidate");
+  });
+});

--- a/src/server/handlers/request/module/page-data-endpoint-handler.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.ts
@@ -4,10 +4,29 @@ import { ResponseBuilder } from "#veryfront/security/index.ts";
 import { getRendererForProject } from "../../../shared/renderer-factory.ts";
 import { TimeoutError, withTimeoutThrow } from "#veryfront/rendering/utils/stream-utils.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { markRequestProfilePhase } from "#veryfront/observability/request-profiler.ts";
 import { HTTP_GATEWAY_TIMEOUT } from "#veryfront/utils/constants/http.ts";
 import { serverLogger } from "#veryfront/utils";
+import { Singleflight } from "#veryfront/utils/singleflight.ts";
+import { requestHasCacheSensitiveState } from "#veryfront/cache/request-cacheability.ts";
+import type { PageDataResponse } from "#veryfront/rendering/orchestrator/types.ts";
 
 const PAGE_DATA_TIMEOUT_MS = 25_000;
+const PAGE_DATA_CACHE_TTL_MS = 60_000;
+const PAGE_DATA_CACHE_MAX_ENTRIES = 500;
+
+interface PageDataCacheEntry {
+  body: string;
+  etag: string;
+  expiresAt: number;
+}
+
+const pageDataCache = new Map<string, PageDataCacheEntry>();
+const pageDataFlight = new Singleflight<PageDataCacheEntry>();
+
+export function __clearPageDataEndpointCacheForTests(): void {
+  pageDataCache.clear();
+}
 
 export function handlePageDataEndpoint(
   req: Request,
@@ -27,31 +46,42 @@ export function handlePageDataEndpoint(
 
         const url = new URL(req.url);
         const renderer = await getRendererForProject(ctx);
+        const cacheKey = requestHasCacheSensitiveState(req)
+          ? null
+          : buildPageDataCacheKey(ctx, slug, url);
 
-        const pageData = await withTimeoutThrow(
-          renderer.resolvePageData(slug, { request: req, url }),
-          PAGE_DATA_TIMEOUT_MS,
-          `resolvePageData for ${slug}`,
-        );
-
-        const body = JSON.stringify(pageData);
-        const etag = computeEtag(body);
+        const payload = cacheKey
+          ? await resolveCachedPageData(cacheKey, () =>
+            withTimeoutThrow(
+              renderer.resolvePageData(slug, { request: req, url }),
+              PAGE_DATA_TIMEOUT_MS,
+              `resolvePageData for ${slug}`,
+            ))
+          : await resolveUncachedPageData(() =>
+            withTimeoutThrow(
+              renderer.resolvePageData(slug, { request: req, url }),
+              PAGE_DATA_TIMEOUT_MS,
+              `resolvePageData for ${slug}`,
+            )
+          );
+        const cacheStrategy = cacheKey ? { maxAge: 60, public: true } : "no-cache";
 
         const builder = createResponseBuilder(ctx).withCORS(
           req,
           ctx.securityConfig?.cors,
         );
 
-        if (hasMatchingEtag(req, etag)) {
-          return respond(builder.notModified(etag));
+        if (hasMatchingEtag(req, payload.etag)) {
+          return respond(builder.notModified(payload.etag));
         }
 
         return respond(
           builder
             .withSecurity(ctx.securityConfig ?? undefined, req)
-            .withCache({ maxAge: 60, public: true })
-            .withETag(etag)
-            .json(pageData, 200),
+            .withCache(cacheStrategy)
+            .withETag(payload.etag)
+            .withHeaders({ "content-type": "application/json" })
+            .build(payload.body, 200),
         );
       } catch (e) {
         if (e instanceof TimeoutError) {
@@ -105,4 +135,97 @@ export function handlePageDataEndpoint(
       "module.pageData.projectSlug": ctx.projectSlug || "unknown",
     },
   );
+}
+
+async function resolveCachedPageData(
+  cacheKey: string,
+  resolve: () => Promise<PageDataResponse>,
+): Promise<PageDataCacheEntry> {
+  const cached = getCachedPageData(cacheKey);
+  if (cached) {
+    markRequestProfilePhase("page_data.cache_hit");
+    return cached;
+  }
+
+  markRequestProfilePhase("page_data.cache_miss");
+  return await pageDataFlight.do(cacheKey, async () => {
+    const concurrentCached = getCachedPageData(cacheKey);
+    if (concurrentCached) {
+      markRequestProfilePhase("page_data.cache_hit_after_wait");
+      return concurrentCached;
+    }
+
+    const payload = await resolveUncachedPageData(resolve);
+    setCachedPageData(cacheKey, payload);
+    return payload;
+  });
+}
+
+async function resolveUncachedPageData(
+  resolve: () => Promise<PageDataResponse>,
+): Promise<PageDataCacheEntry> {
+  const startedAt = performance.now();
+  const pageData = await resolve();
+  markRequestProfilePhase("page_data.resolve", performance.now() - startedAt);
+
+  const bodyStart = performance.now();
+  const body = JSON.stringify(pageData);
+  const etag = computeEtag(body);
+  markRequestProfilePhase("page_data.serialize", performance.now() - bodyStart);
+
+  return {
+    body,
+    etag,
+    expiresAt: Date.now() + PAGE_DATA_CACHE_TTL_MS,
+  };
+}
+
+function getCachedPageData(cacheKey: string): PageDataCacheEntry | null {
+  const entry = pageDataCache.get(cacheKey);
+  if (!entry) return null;
+
+  if (Date.now() <= entry.expiresAt) return entry;
+
+  pageDataCache.delete(cacheKey);
+  markRequestProfilePhase("page_data.cache_expired");
+  return null;
+}
+
+function setCachedPageData(cacheKey: string, entry: PageDataCacheEntry): void {
+  if (pageDataCache.size >= PAGE_DATA_CACHE_MAX_ENTRIES && !pageDataCache.has(cacheKey)) {
+    const oldestKey = pageDataCache.keys().next().value;
+    if (oldestKey) pageDataCache.delete(oldestKey);
+  }
+
+  pageDataCache.set(cacheKey, entry);
+}
+
+function buildPageDataCacheKey(ctx: HandlerContext, slug: string, url: URL): string {
+  const projectKey = ctx.projectId ?? ctx.projectSlug ?? ctx.projectDir;
+  const environment = ctx.resolvedEnvironment ?? ctx.requestContext?.mode ?? "preview";
+  const contentSource = ctx.enriched?.contentSourceId ??
+    (environment === "production"
+      ? ctx.releaseId ?? "release"
+      : ctx.requestContext?.branch ?? "main");
+  const query = buildSortedQueryKey(url);
+
+  return [
+    projectKey,
+    environment,
+    contentSource,
+    slug || "index",
+    query,
+  ].join("|");
+}
+
+function buildSortedQueryKey(url: URL): string {
+  const entries = Array.from(url.searchParams.entries());
+  if (entries.length === 0) return "";
+
+  return entries
+    .sort(([leftKey, leftValue], [rightKey, rightValue]) =>
+      leftKey === rightKey ? leftValue.localeCompare(rightValue) : leftKey.localeCompare(rightKey)
+    )
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join("&");
 }


### PR DESCRIPTION
## Summary
- Normalize root render cache keys and keep infrastructure `lb` cookies from disabling anonymous render cache.
- Add a short server-side page-data cache with singleflight and Server-Timing phases for page-data endpoints.
- Preserve release asset module maps in SPA page data and warm page/layout/app modules during router prefetch.

## Why
Production hard navigations can be fast on cached HTML, but SPA navigation was still paying slow page-data resolution and dynamic module imports. Live checks on codersociety.com showed cached HTML hits in single-digit server ms while `/_veryfront/page-data/...json` took about 1.9s TTFB.

## Verification
- `deno test --no-check --allow-all src/cache/request-cacheability.test.ts src/cache/keys.test.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/html/hydration-script-builder/templates/router.test.ts src/observability/request-profiler.test.ts src/server/handlers/request/module/page-data-endpoint-handler.test.ts`
- `deno check src/server/handlers/request/module/page-data-endpoint-handler.ts src/server/handlers/request/module/page-data-endpoint-handler.test.ts src/rendering/renderer.ts src/rendering/orchestrator/pipeline.ts src/html/hydration-script-builder/templates/router.ts src/observability/request-profiler.ts src/cache/request-cacheability.ts src/release-assets/client-module-map.ts`
- `deno test --no-check --allow-all src/html/hydration-script-builder/hydration-data-generator.test.ts src/server/handlers/request/module/module.handler.test.ts`
- `deno check src/html/hydration-script-builder/hydration-data-generator.ts src/html/hydration-script-builder/hydration-data-generator.test.ts src/server/handlers/request/module/module.handler.test.ts src/server/handlers/request/module/page-data-endpoint-handler.ts`
