### PR TITLE
Isolate agent runtime step preparation

### DIFF
--- a/src/agent/runtime/agent-runtime-step.test.ts
+++ b/src/agent/runtime/agent-runtime-step.test.ts
@@ -1,0 +1,124 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { RemoteToolSource, ToolDefinition, ToolExecutionContext } from "#veryfront/tool";
+import type { AgentConfig, Message } from "../types.ts";
+import type { AgentRuntimeStepState } from "./agent-runtime-step.ts";
+import { prepareAgentRuntimeStep } from "./agent-runtime-step.ts";
+
+function toolDefinition(name: string): ToolDefinition {
+  return {
+    name,
+    description: `${name} tool`,
+    parameters: { type: "object", properties: {} },
+  };
+}
+
+function remoteToolSource(id: string): RemoteToolSource {
+  return {
+    id,
+    listTools: () => Promise.resolve([]),
+    executeTool: () => Promise.resolve(undefined),
+  };
+}
+
+describe("agent/runtime-step", () => {
+  it("resolves runtime state, merges tool context, and applies active skill policy", async () => {
+    const messages: Message[] = [{
+      id: "msg_1",
+      role: "user",
+      parts: [{ type: "text", text: "Run it" }],
+      timestamp: 1,
+    }];
+    const config = {
+      model: "auto",
+      system: "Base system",
+      tools: true,
+      skills: true,
+    } as AgentConfig;
+    const capturedContexts: ToolExecutionContext[] = [];
+    const remoteSource = remoteToolSource("remote_source");
+
+    const prepared = await prepareAgentRuntimeStep({
+      agentId: "agent_1",
+      activeSkillPolicy: ["allowed_tool"],
+      allowedRemoteToolNames: ["remote_allowed"],
+      config,
+      forwardedRemoteToolDefinitions: [toolDefinition("forwarded_remote")],
+      isLocalModel: false,
+      messages,
+      mode: "generate",
+      remoteToolSources: [remoteSource],
+      runtimeContext: { projectId: "old_project", keep: true },
+      step: 2,
+      systemPrompt: "Base system",
+      toolContextBase: { projectId: "base_project", userId: "user_1" },
+      getAvailableTools: async (_toolsConfig, options) => {
+        capturedContexts.push(options?.remoteToolContext ?? {});
+        assertEquals(options?.callerAgentId, "agent_1");
+        assertEquals(options?.includeSkillTools, true);
+        assertEquals(options?.allowedRemoteToolNames, ["remote_allowed"]);
+        assertEquals(options?.forwardedRemoteToolDefinitions, [toolDefinition("forwarded_remote")]);
+        assertEquals(options?.remoteToolSources, [remoteSource]);
+        return [toolDefinition("allowed_tool"), toolDefinition("blocked_tool")];
+      },
+      resolveRuntimeState: async (
+        receivedMessages,
+        receivedContext,
+        receivedMode,
+        receivedStep,
+        receivedSystemPrompt,
+      ): Promise<AgentRuntimeStepState> => {
+        assertEquals(receivedMessages, messages);
+        assertEquals(receivedContext, { projectId: "old_project", keep: true });
+        assertEquals(receivedMode, "generate");
+        assertEquals(receivedStep, 2);
+        assertEquals(receivedSystemPrompt, "Base system");
+        return {
+          systemPrompt: "Updated system",
+          context: { projectId: "runtime_project", keep: true, traceId: "trace_1" },
+        };
+      },
+    });
+
+    assertEquals(prepared.systemPrompt, "Updated system");
+    assertEquals(prepared.runtimeContext, {
+      projectId: "runtime_project",
+      keep: true,
+      traceId: "trace_1",
+    });
+    assertEquals(prepared.toolContext, {
+      projectId: "runtime_project",
+      userId: "user_1",
+      keep: true,
+      traceId: "trace_1",
+    });
+    assertEquals(capturedContexts, [prepared.toolContext]);
+    assertEquals(prepared.tools.map((tool) => tool.name), ["allowed_tool"]);
+  });
+
+  it("skips tool loading for local models", async () => {
+    const prepared = await prepareAgentRuntimeStep({
+      agentId: "agent_1",
+      activeSkillPolicy: undefined,
+      allowedRemoteToolNames: undefined,
+      config: { model: "local/test", system: "Local", tools: true } as AgentConfig,
+      forwardedRemoteToolDefinitions: undefined,
+      isLocalModel: true,
+      messages: [],
+      mode: "stream",
+      remoteToolSources: [],
+      runtimeContext: undefined,
+      step: 0,
+      systemPrompt: "Local",
+      toolContextBase: undefined,
+      getAvailableTools: async () => {
+        throw new Error("local model should not load tools");
+      },
+      resolveRuntimeState: async () => ({ systemPrompt: "Local", context: undefined }),
+    });
+
+    assertEquals(prepared.tools, []);
+    assertEquals(prepared.toolContext, {});
+  });
+});

--- a/src/agent/runtime/agent-runtime-step.ts
+++ b/src/agent/runtime/agent-runtime-step.ts
@@ -1,0 +1,91 @@
+import type { RemoteToolSource, ToolDefinition, ToolExecutionContext } from "#veryfront/tool";
+import type { AgentConfig, Message } from "../types.ts";
+import { filterToolsForSkill } from "#veryfront/skill/allowed-tools.ts";
+import type { ToolConfigEntry } from "./tool-helpers.ts";
+
+export type AgentRuntimeStepMode = "generate" | "stream";
+
+export type RuntimeStepToolLoader = (
+  toolsConfig: true | Record<string, ToolConfigEntry> | undefined,
+  options?: {
+    includeSkillTools?: boolean;
+    includeIntegrationTools?: boolean;
+    allowedRemoteToolNames?: string[];
+    forwardedRemoteToolDefinitions?: ToolDefinition[];
+    remoteToolSources?: RemoteToolSource[];
+    remoteToolContext?: ToolExecutionContext;
+    callerAgentId?: string;
+  },
+) => Promise<ToolDefinition[]>;
+
+export interface AgentRuntimeStepState {
+  systemPrompt: string;
+  context?: Record<string, unknown>;
+}
+
+export type RuntimeStepStateResolver = (
+  messages: Message[],
+  runtimeContext: Record<string, unknown> | undefined,
+  mode: AgentRuntimeStepMode,
+  step: number,
+  systemPrompt: string,
+) => Promise<AgentRuntimeStepState>;
+
+export interface PrepareAgentRuntimeStepInput {
+  agentId: string;
+  activeSkillPolicy: string[] | undefined;
+  allowedRemoteToolNames: string[] | undefined;
+  config: AgentConfig;
+  forwardedRemoteToolDefinitions: ToolDefinition[] | undefined;
+  getAvailableTools: RuntimeStepToolLoader;
+  isLocalModel: boolean;
+  messages: Message[];
+  mode: AgentRuntimeStepMode;
+  remoteToolSources: RemoteToolSource[] | undefined;
+  resolveRuntimeState: RuntimeStepStateResolver;
+  runtimeContext: Record<string, unknown> | undefined;
+  step: number;
+  systemPrompt: string;
+  toolContextBase: ToolExecutionContext | undefined;
+}
+
+export interface PreparedAgentRuntimeStep {
+  runtimeContext: Record<string, unknown> | undefined;
+  systemPrompt: string;
+  toolContext: ToolExecutionContext;
+  tools: ToolDefinition[];
+}
+
+/** Resolve per-step runtime state and the tools visible for that step. */
+export async function prepareAgentRuntimeStep(
+  input: PrepareAgentRuntimeStepInput,
+): Promise<PreparedAgentRuntimeStep> {
+  const runtimeState = await input.resolveRuntimeState(
+    input.messages,
+    input.runtimeContext,
+    input.mode,
+    input.step,
+    input.systemPrompt,
+  );
+  const toolContext = { ...input.toolContextBase, ...runtimeState.context };
+
+  let tools = input.isLocalModel ? [] : await input.getAvailableTools(input.config.tools, {
+    callerAgentId: input.agentId,
+    includeSkillTools: Boolean(input.config.skills),
+    allowedRemoteToolNames: input.allowedRemoteToolNames,
+    forwardedRemoteToolDefinitions: input.forwardedRemoteToolDefinitions,
+    remoteToolSources: input.remoteToolSources,
+    remoteToolContext: toolContext,
+  });
+
+  if (input.activeSkillPolicy) {
+    tools = filterToolsForSkill(tools, input.activeSkillPolicy);
+  }
+
+  return {
+    runtimeContext: runtimeState.context,
+    systemPrompt: runtimeState.systemPrompt,
+    toolContext,
+    tools,
+  };
+}

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -75,6 +75,7 @@ import {
   getRuntimeForwardedIntegrationToolDefs,
   getRuntimeProviderTools,
 } from "./runtime-tool-config.ts";
+import { prepareAgentRuntimeStep } from "./agent-runtime-step.ts";
 
 // Re-export from submodules
 export { closeSSEStream, generateMessageId, sendSSE } from "./sse-utils.ts";
@@ -141,7 +142,6 @@ import { DEFAULT_MAX_TOKENS, DEFAULT_TEMPERATURE, getModelMaxOutputTokens } from
 import { closeSSEStream, generateMessageId, sendSSE } from "./sse-utils.ts";
 import { executeConfiguredTool, getAvailableTools, isDynamicTool } from "./tool-helpers.ts";
 import { accumulateUsage, getMaxSteps, normalizeInput } from "./input-utils.ts";
-import { filterToolsForSkill } from "#veryfront/skill/allowed-tools.ts";
 import { resolveRuntimeModel } from "./model-resolution.ts";
 import type { RuntimeGenerateToolResult } from "./runtime-tool-types.ts";
 import { stringifyToolError, throwIfAborted } from "./error-utils.ts";
@@ -527,30 +527,27 @@ export class AgentRuntime {
         this.status = "thinking";
         addSpanEvent(loopSpan, "step_start", { step });
 
-        const runtimeState = await this.resolveRuntimeState(
-          currentMessages,
-          currentRuntimeContext,
-          "generate",
-          step,
-          currentSystemPrompt,
-        );
-        currentSystemPrompt = runtimeState.systemPrompt;
-        currentRuntimeContext = runtimeState.context;
-        const toolContext = { ...toolContextBase, ...currentRuntimeContext };
-
-        let tools = isLocal ? [] : await getAvailableTools(this.config.tools, {
-          callerAgentId: this.id,
-          includeSkillTools: Boolean(this.config.skills),
+        const preparedStep = await prepareAgentRuntimeStep({
+          agentId: this.id,
+          activeSkillPolicy,
           allowedRemoteToolNames,
+          config: this.config,
           forwardedRemoteToolDefinitions,
+          getAvailableTools,
+          isLocalModel: isLocal,
+          messages: currentMessages,
+          mode: "generate",
           remoteToolSources,
-          remoteToolContext: toolContext,
+          resolveRuntimeState: this.resolveRuntimeState.bind(this),
+          runtimeContext: currentRuntimeContext,
+          step,
+          systemPrompt: currentSystemPrompt,
+          toolContextBase,
         });
-
-        // Layer 1: Filter tools based on active skill policy (planning-time)
-        if (activeSkillPolicy) {
-          tools = filterToolsForSkill(tools, activeSkillPolicy);
-        }
+        currentSystemPrompt = preparedStep.systemPrompt;
+        currentRuntimeContext = preparedStep.runtimeContext;
+        const toolContext = preparedStep.toolContext;
+        const tools = preparedStep.tools;
 
         const temperature = this.resolveTemperature(temperatureModelString ?? effectiveModel);
         const response = await withSpan("agent.generate_text", async (span) => {
@@ -849,30 +846,27 @@ export class AgentRuntime {
       sendSSE(controller, encoder, { type: "step-start" });
       const currentStepToolResults = new Map<string, ToolResultPart>();
 
-      const runtimeState = await this.resolveRuntimeState(
-        currentMessages,
-        currentRuntimeContext,
-        "stream",
-        step,
-        currentSystemPrompt,
-      );
-      currentSystemPrompt = runtimeState.systemPrompt;
-      currentRuntimeContext = runtimeState.context;
-      const toolContext = { ...toolContextBase, ...currentRuntimeContext };
-
-      let tools = isLocalStreaming ? [] : await getAvailableTools(this.config.tools, {
-        callerAgentId: this.id,
-        includeSkillTools: Boolean(this.config.skills),
+      const preparedStep = await prepareAgentRuntimeStep({
+        agentId: this.id,
+        activeSkillPolicy,
         allowedRemoteToolNames,
+        config: this.config,
         forwardedRemoteToolDefinitions,
+        getAvailableTools,
+        isLocalModel: isLocalStreaming,
+        messages: currentMessages,
+        mode: "stream",
         remoteToolSources,
-        remoteToolContext: toolContext,
+        resolveRuntimeState: this.resolveRuntimeState.bind(this),
+        runtimeContext: currentRuntimeContext,
+        step,
+        systemPrompt: currentSystemPrompt,
+        toolContextBase,
       });
-
-      // Layer 1: Filter tools based on active skill policy (planning-time)
-      if (activeSkillPolicy) {
-        tools = filterToolsForSkill(tools, activeSkillPolicy);
-      }
+      currentSystemPrompt = preparedStep.systemPrompt;
+      currentRuntimeContext = preparedStep.runtimeContext;
+      const toolContext = preparedStep.toolContext;
+      const tools = preparedStep.tools;
 
       const runtimeTools = convertToolsToRuntimeTools(tools, {
         model: effectiveModel,


### PR DESCRIPTION
Refs #2216.

## Summary
- Extract per-step runtime state/tool preparation from the generate and stream loops into `src/agent/runtime/agent-runtime-step.ts`.
- Add focused helper coverage for runtime-state refresh, merged tool context propagation, active skill policy filtering, and local-model tool skipping.
- Preserve model execution, stream processing, and tool execution behavior in `AgentRuntime`.

## Verification
- Red-first: `deno test --no-check --allow-all src/agent/runtime/agent-runtime-step.test.ts` failed with missing helper module before implementation.
- `deno test --no-check --allow-all src/agent/runtime/agent-runtime-step.test.ts src/agent/runtime/refresh.test.ts src/agent/runtime/runtime-stream-cancel.test.ts`
- `deno test --no-check --allow-all src/agent/runtime`
- `deno check src/agent/runtime/agent-runtime-step.ts src/agent/runtime/agent-runtime-step.test.ts src/agent/runtime/index.ts`
- `deno lint src/agent/runtime/agent-runtime-step.ts src/agent/runtime/agent-runtime-step.test.ts src/agent/runtime/index.ts`
- `deno fmt src/agent/runtime/agent-runtime-step.ts src/agent/runtime/agent-runtime-step.test.ts src/agent/runtime/index.ts`
- `git diff --check`
- Pre-push hook passed: format, lint, typecheck, unit suite (`2161 passed`, `0 failed`).

## Note
`deno task verify:quick` currently stops on baseline CLI boundary violations in `cli/shared/server-startup.ts`, outside this branch. The pre-push hook uses the repo push gate and passed.