### PR TITLE
Release navigation cache fix as 0.1.813

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.812",
+  "version": "0.1.813",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.812";
+export const VERSION = "0.1.813";


### PR DESCRIPTION
## Summary
- Bump the root package version from `0.1.812` to `0.1.813`.
- Keep `src/utils/version-constant.ts` in sync so logger/version tests reflect the release version.

## Why
Main release failed because `0.1.812` already exists on npm. The release gate requires `deno.json` to point at an unpublished stable version before publishing and triggering downstream deployments.

## Verification
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `git diff --check`
- `deno eval 'const cfg=JSON.parse(await Deno.readTextFile("deno.json")); if (cfg.version !== "0.1.813") throw new Error(String(cfg.version)); console.log(cfg.version)'`
- `npm view veryfront@0.1.813 version 2>/dev/null || true` returned no published version
- `deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts`
- Pre-push hook: format, lint, typecheck, unit suite (`2160 passed`, `0 failed`)
