### PR TITLE
Centralize proxy request lifecycle finalization

### DIFF
--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -45,6 +45,7 @@ import { exit, getEnv, onSignal } from "#veryfront/platform/compat/process.ts";
 import { createHttpServer, upgradeWebSocket } from "#veryfront/platform/compat/http/index.ts";
 import { createProxyErrorResponse, jsonErrorResponse } from "./error-response.ts";
 import { handleReleaseAssetRequest, isReleaseAssetPath } from "./asset-handler.ts";
+import { type ProxyRequestLifecycle, runProxyRequestLifecycle } from "./request-lifecycle.ts";
 
 function getLocalProjects(): Record<string, string> {
   const raw = getEnv("LOCAL_PROJECTS");
@@ -282,10 +283,7 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
   const requestId = crypto.randomUUID();
   const host = req.headers.get("host") || "";
 
-  const parentContext = extractContext(req.headers);
-  const spanInfo = startServerSpan(req.method, url.pathname, parentContext);
-
-  const execute = async (): Promise<Response> => {
+  const execute = async (lifecycle: ProxyRequestLifecycle): Promise<Response> => {
     try {
       const ctx = await proxyHandler.processRequest(req, { url });
 
@@ -305,7 +303,7 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
             const ms = Math.round(performance.now() - startTime);
             const logLevel = getProxyFailureLogLevel(ctx.error.status, req.method, url.pathname);
             proxyLogger[logLevel](`${ctx.error.status} ${req.method} ${url.pathname}`, { ms });
-            endSpan(spanInfo?.span, ctx.error.status);
+            lifecycle.end(ctx.error.status);
             return createProxyErrorResponse(ctx.error);
           }
 
@@ -401,8 +399,6 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
                 reqLogger.info(`${response.status} ${req.method} ${url.pathname}`, { ms });
               }
 
-              endSpan(spanInfo?.span, response.status);
-
               return new Response(response.body, {
                 status: response.status,
                 statusText: response.statusText,
@@ -418,7 +414,7 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
                   ms,
                   timeoutMs: VERYFRONT_SERVER_REQUEST_TIMEOUT_MS,
                 });
-                endSpan(spanInfo?.span, 504, error);
+                lifecycle.end(504, error);
                 return jsonErrorResponse(504, {
                   error: "Gateway Timeout",
                   message:
@@ -460,7 +456,7 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
           const ms = Math.round(performance.now() - startTime);
           const logLevel = getProxyFailureLogLevel(502, req.method, url.pathname);
           proxyLogger[logLevel](`502 ${req.method} ${url.pathname}`, { ms }, lastError as Error);
-          endSpan(spanInfo?.span, 502, lastError as Error);
+          lifecycle.end(502, lastError as Error);
           return jsonErrorResponse(502, {
             error: "Proxy Error",
             message: lastError instanceof Error ? lastError.message : "Unknown error",
@@ -470,7 +466,7 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
     } catch (error) {
       const ms = Math.round(performance.now() - startTime);
       proxyLogger.error(`500 ${req.method} ${url.pathname}`, { ms }, error as Error);
-      endSpan(spanInfo?.span, 500, error as Error);
+      lifecycle.end(500, error as Error);
       return jsonErrorResponse(500, {
         error: "Internal Proxy Error",
         message: error instanceof Error ? error.message : "Unknown error",
@@ -478,7 +474,15 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
     }
   };
 
-  return spanInfo?.context ? withContext(spanInfo.context, execute) : execute();
+  return runProxyRequestLifecycle({
+    req,
+    url,
+    startServerSpan,
+    endSpan,
+    extractContext,
+    withContext,
+    handle: execute,
+  });
 }
 
 /**

--- a/src/proxy/request-lifecycle.test.ts
+++ b/src/proxy/request-lifecycle.test.ts
@@ -1,0 +1,96 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { Context, Span } from "#veryfront/observability/tracing/api-shim.ts";
+import { runProxyRequestLifecycle } from "./request-lifecycle.ts";
+
+describe("proxy request lifecycle", () => {
+  it("starts a server span, runs inside the extracted context, and ends with response status", async () => {
+    const req = new Request("https://example.com/docs", {
+      method: "POST",
+      headers: { traceparent: "00-test" },
+    });
+    const url = new URL(req.url);
+    const parentContext = {} as Context;
+    const span = {} as Span;
+    const calls: string[] = [];
+
+    const response = await runProxyRequestLifecycle({
+      req,
+      url,
+      extractContext(headers) {
+        calls.push(`extract:${headers.get("traceparent")}`);
+        return parentContext;
+      },
+      startServerSpan(method, path, receivedParentContext) {
+        calls.push(`start:${method}:${path}:${receivedParentContext === parentContext}`);
+        return { span, context: "span-context" as unknown as Context };
+      },
+      withContext(spanContext, fn) {
+        calls.push(`context:${spanContext === ("span-context" as unknown as Context)}`);
+        return fn();
+      },
+      endSpan(receivedSpan, statusCode, error) {
+        calls.push(`end:${receivedSpan === span}:${statusCode}:${error?.message ?? ""}`);
+      },
+      handle: async () => new Response("created", { status: 201 }),
+    });
+
+    assertEquals(response.status, 201);
+    assertEquals(calls, [
+      "extract:00-test",
+      "start:POST:/docs:true",
+      "context:true",
+      "end:true:201:",
+    ]);
+  });
+
+  it("honors an explicit lifecycle end and does not end the span twice", async () => {
+    const req = new Request("https://example.com/protected");
+    const span = {} as Span;
+    const ended: string[] = [];
+
+    const response = await runProxyRequestLifecycle({
+      req,
+      url: new URL(req.url),
+      extractContext: () => undefined,
+      startServerSpan: () => ({ span, context: {} as Context }),
+      withContext: (_context, fn) => fn(),
+      endSpan(_span, statusCode, error) {
+        ended.push(`${statusCode}:${error?.message ?? ""}`);
+      },
+      handle: async (lifecycle) => {
+        lifecycle.end(403);
+        return new Response(null, { status: 302 });
+      },
+    });
+
+    assertEquals(response.status, 302);
+    assertEquals(ended, ["403:"]);
+  });
+
+  it("ends the span once with the thrown error before rethrowing", async () => {
+    const req = new Request("https://example.com/fail");
+    const span = {} as Span;
+    const ended: string[] = [];
+
+    try {
+      await runProxyRequestLifecycle({
+        req,
+        url: new URL(req.url),
+        extractContext: () => undefined,
+        startServerSpan: () => ({ span, context: {} as Context }),
+        withContext: (_context, fn) => fn(),
+        endSpan(_span, statusCode, error) {
+          ended.push(`${statusCode}:${error?.message ?? ""}`);
+        },
+        handle: () => {
+          throw new Error("boom");
+        },
+      });
+    } catch (error) {
+      assertEquals(error instanceof Error ? error.message : String(error), "boom");
+    }
+
+    assertEquals(ended, ["500:boom"]);
+  });
+});

--- a/src/proxy/request-lifecycle.ts
+++ b/src/proxy/request-lifecycle.ts
@@ -1,0 +1,50 @@
+import type { Context, Span } from "#veryfront/observability/tracing/api-shim.ts";
+
+export interface ProxyRequestLifecycle {
+  end(statusCode: number, error?: Error): void;
+}
+
+export interface RunProxyRequestLifecycleOptions {
+  req: Request;
+  url: URL;
+  extractContext(headers: Headers): Context | undefined;
+  startServerSpan(
+    method: string,
+    path: string,
+    parentContext?: Context,
+  ): { span: Span; context: Context } | null;
+  withContext<T>(spanContext: Context, fn: () => Promise<T>): Promise<T>;
+  endSpan(span: Span | undefined, statusCode: number, error?: Error): void;
+  handle(lifecycle: ProxyRequestLifecycle): Promise<Response>;
+}
+
+/** Run a proxied HTTP request with tracing context and exactly-once span finalization. */
+export async function runProxyRequestLifecycle(
+  options: RunProxyRequestLifecycleOptions,
+): Promise<Response> {
+  const parentContext = options.extractContext(options.req.headers);
+  const spanInfo = options.startServerSpan(options.req.method, options.url.pathname, parentContext);
+  let ended = false;
+
+  const lifecycle: ProxyRequestLifecycle = {
+    end(statusCode, error) {
+      if (ended) return;
+      ended = true;
+      options.endSpan(spanInfo?.span, statusCode, error);
+    },
+  };
+
+  const execute = async (): Promise<Response> => {
+    try {
+      const response = await options.handle(lifecycle);
+      lifecycle.end(response.status);
+      return response;
+    } catch (error) {
+      const spanError = error instanceof Error ? error : new Error(String(error));
+      lifecycle.end(500, spanError);
+      throw error;
+    }
+  };
+
+  return spanInfo?.context ? options.withContext(spanInfo.context, execute) : execute();
+}


### PR DESCRIPTION
## Summary
- add a proxy request lifecycle helper that owns trace context propagation and exactly-once span finalization
- route `forwardToServer` through the helper while preserving routing, retry, timeout, and error response behavior
- cover context propagation, explicit early lifecycle end, and thrown-error finalization

## Verification
- red-first: `deno test --no-check --allow-all src/proxy/request-lifecycle.test.ts` failed while the helper module was missing
- `deno test --no-check --allow-all src/proxy/request-lifecycle.test.ts src/proxy/main.test.ts src/proxy/error-response.test.ts`
- `deno check src/proxy/request-lifecycle.ts src/proxy/request-lifecycle.test.ts src/proxy/main.ts`
- `deno lint src/proxy/request-lifecycle.ts src/proxy/request-lifecycle.test.ts src/proxy/main.ts`
- `git diff --check`
- `deno test --no-check --allow-all src/proxy`

Closes part of #2217.