### PR TITLE
Centralize upstream proxy failure responses

### DIFF
--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -46,6 +46,12 @@ import { createHttpServer, upgradeWebSocket } from "#veryfront/platform/compat/h
 import { createProxyErrorResponse, jsonErrorResponse } from "./error-response.ts";
 import { handleReleaseAssetRequest, isReleaseAssetPath } from "./asset-handler.ts";
 import { type ProxyRequestLifecycle, runProxyRequestLifecycle } from "./request-lifecycle.ts";
+import {
+  createUpstreamFailureResponse,
+  createUpstreamTimeoutResponse,
+  UPSTREAM_FAILURE_STATUS,
+  UPSTREAM_TIMEOUT_STATUS,
+} from "./upstream-error-response.ts";
 
 function getLocalProjects(): Record<string, string> {
   const raw = getEnv("LOCAL_PROJECTS");
@@ -410,16 +416,12 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
 
               if (error instanceof Error && error.name === "AbortError") {
                 const ms = Math.round(performance.now() - startTime);
-                proxyLogger.error(`504 ${req.method} ${url.pathname}`, {
+                proxyLogger.error(`${UPSTREAM_TIMEOUT_STATUS} ${req.method} ${url.pathname}`, {
                   ms,
                   timeoutMs: VERYFRONT_SERVER_REQUEST_TIMEOUT_MS,
                 });
-                lifecycle.end(504, error);
-                return jsonErrorResponse(504, {
-                  error: "Gateway Timeout",
-                  message:
-                    `Server request timed out after ${VERYFRONT_SERVER_REQUEST_TIMEOUT_MS}ms`,
-                });
+                lifecycle.end(UPSTREAM_TIMEOUT_STATUS, error);
+                return createUpstreamTimeoutResponse(VERYFRONT_SERVER_REQUEST_TIMEOUT_MS);
               }
 
               // Check if this is a retryable error and we have retries left
@@ -454,13 +456,18 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
 
           // All retries exhausted or non-retryable error
           const ms = Math.round(performance.now() - startTime);
-          const logLevel = getProxyFailureLogLevel(502, req.method, url.pathname);
-          proxyLogger[logLevel](`502 ${req.method} ${url.pathname}`, { ms }, lastError as Error);
-          lifecycle.end(502, lastError as Error);
-          return jsonErrorResponse(502, {
-            error: "Proxy Error",
-            message: lastError instanceof Error ? lastError.message : "Unknown error",
-          });
+          const logLevel = getProxyFailureLogLevel(
+            UPSTREAM_FAILURE_STATUS,
+            req.method,
+            url.pathname,
+          );
+          proxyLogger[logLevel](
+            `${UPSTREAM_FAILURE_STATUS} ${req.method} ${url.pathname}`,
+            { ms },
+            lastError as Error,
+          );
+          lifecycle.end(UPSTREAM_FAILURE_STATUS, lastError as Error);
+          return createUpstreamFailureResponse(lastError);
         },
       );
     } catch (error) {

--- a/src/proxy/upstream-error-response.test.ts
+++ b/src/proxy/upstream-error-response.test.ts
@@ -1,0 +1,40 @@
+import { assertEquals } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
+import {
+  createUpstreamFailureResponse,
+  createUpstreamTimeoutResponse,
+} from "./upstream-error-response.ts";
+
+describe("proxy upstream error responses", () => {
+  it("creates a gateway timeout response with the configured timeout", async () => {
+    const response = createUpstreamTimeoutResponse(12_345);
+
+    assertEquals(response.status, 504);
+    assertEquals(response.headers.get("Content-Type"), "application/json");
+    assertEquals(await response.json(), {
+      error: "Gateway Timeout",
+      message: "Server request timed out after 12345ms",
+    });
+  });
+
+  it("creates a proxy failure response from an upstream error", async () => {
+    const response = createUpstreamFailureResponse(new Error("connection refused"));
+
+    assertEquals(response.status, 502);
+    assertEquals(response.headers.get("Content-Type"), "application/json");
+    assertEquals(await response.json(), {
+      error: "Proxy Error",
+      message: "connection refused",
+    });
+  });
+
+  it("uses a stable fallback message for non-Error upstream failures", async () => {
+    const response = createUpstreamFailureResponse("bad failure");
+
+    assertEquals(response.status, 502);
+    assertEquals(await response.json(), {
+      error: "Proxy Error",
+      message: "Unknown error",
+    });
+  });
+});

--- a/src/proxy/upstream-error-response.ts
+++ b/src/proxy/upstream-error-response.ts
@@ -1,0 +1,18 @@
+import { jsonErrorResponse } from "./error-response.ts";
+
+export const UPSTREAM_TIMEOUT_STATUS = 504;
+export const UPSTREAM_FAILURE_STATUS = 502;
+
+export function createUpstreamTimeoutResponse(timeoutMs: number): Response {
+  return jsonErrorResponse(UPSTREAM_TIMEOUT_STATUS, {
+    error: "Gateway Timeout",
+    message: `Server request timed out after ${timeoutMs}ms`,
+  });
+}
+
+export function createUpstreamFailureResponse(error: unknown): Response {
+  return jsonErrorResponse(UPSTREAM_FAILURE_STATUS, {
+    error: "Proxy Error",
+    message: error instanceof Error ? error.message : "Unknown error",
+  });
+}


### PR DESCRIPTION
## Summary
- add typed helpers for split-proxy upstream timeout and generic upstream failure responses
- replace inline 504/502 response construction in `forwardToServer` with those helpers
- lock the existing response bodies and fallback message behavior with focused tests

## Verification
- red-first: `deno test --no-check --allow-all src/proxy/upstream-error-response.test.ts` failed while the helper module was missing
- `deno test --no-check --allow-all src/proxy/upstream-error-response.test.ts src/proxy/main.test.ts src/proxy/error-response.test.ts src/proxy/request-lifecycle.test.ts`
- `deno test --no-check --allow-all src/proxy`
- `deno check src/proxy/main.ts src/proxy/upstream-error-response.ts src/proxy/upstream-error-response.test.ts`
- `deno lint src/proxy/main.ts src/proxy/upstream-error-response.ts src/proxy/upstream-error-response.test.ts`
- `deno fmt --check src/proxy/main.ts src/proxy/upstream-error-response.ts src/proxy/upstream-error-response.test.ts`
- `git diff --check`
- pre-push hook passed: format, lint, typecheck, unit suite (`2163 passed`, `0 failed`)

Refs #2217.