### PR TITLE
Move fork runtime step progress out of stream orchestration

### DIFF
--- a/src/agent/streaming/fork-runtime-step-progress.test.ts
+++ b/src/agent/streaming/fork-runtime-step-progress.test.ts
@@ -1,0 +1,98 @@
+import { assertEquals } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
+import type { AgentResponse } from "../types.ts";
+import {
+  buildForkRuntimeStepFromResponse,
+  commitForkRuntimeStep,
+  createForkRuntimeProgress,
+  getForkRuntimeProgressUsage,
+  shouldContinueForkRuntimeStep,
+} from "./fork-runtime-step-progress.ts";
+
+describe("agent/fork-runtime-step-progress", () => {
+  it("builds fork runtime steps from agent responses", () => {
+    const response: AgentResponse = {
+      text: "Saved.",
+      messages: [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          parts: [{
+            type: "tool-create_file",
+            toolCallId: "tool-1",
+            toolName: "create_file",
+            args: { path: "plans/a.md" },
+          }],
+        },
+      ],
+      toolCalls: [
+        {
+          id: "tool-1",
+          name: "create_file",
+          args: { path: "plans/a.md" },
+          status: "completed",
+          result: { path: "plans/a.md", success: true },
+        },
+      ],
+      status: "completed",
+      metadata: { finishReason: "tool-calls" },
+    };
+
+    const step = buildForkRuntimeStepFromResponse(response);
+
+    assertEquals(step, {
+      text: "Saved.",
+      messages: response.messages,
+      toolCalls: [{ toolCallId: "tool-1", toolName: "create_file", input: { path: "plans/a.md" } }],
+      toolResults: [{
+        toolCallId: "tool-1",
+        toolName: "create_file",
+        input: { path: "plans/a.md" },
+        output: { path: "plans/a.md", success: true },
+      }],
+      finishReason: "tool-calls",
+    });
+    assertEquals(shouldContinueForkRuntimeStep(step, response), true);
+  });
+
+  it("commits steps and accumulates usage for the fork runtime loop", () => {
+    const initialMessages = [{
+      id: "user-1",
+      role: "user" as const,
+      parts: [{ type: "text" as const, text: "Start" }],
+    }];
+    const progress = createForkRuntimeProgress(initialMessages);
+    const firstResponse: AgentResponse = {
+      text: "First.",
+      messages: [{
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "First." }],
+      }],
+      toolCalls: [],
+      status: "completed",
+      usage: { promptTokens: 2, completionTokens: 3, totalTokens: 5 },
+    };
+    const secondResponse: AgentResponse = {
+      text: "Second.",
+      messages: [{
+        id: "assistant-2",
+        role: "assistant",
+        parts: [{ type: "text", text: "Second." }],
+      }],
+      toolCalls: [],
+      status: "completed",
+      usage: { promptTokens: 5, completionTokens: 7, totalTokens: 12 },
+    };
+
+    const firstStep = commitForkRuntimeStep(progress, firstResponse);
+    const secondStep = commitForkRuntimeStep(progress, secondResponse);
+
+    assertEquals(progress.steps, [firstStep, secondStep]);
+    assertEquals(progress.currentMessages, secondResponse.messages);
+    assertEquals(getForkRuntimeProgressUsage(progress), {
+      inputTokens: 7,
+      outputTokens: 10,
+    });
+  });
+});

--- a/src/agent/streaming/fork-runtime-step-progress.ts
+++ b/src/agent/streaming/fork-runtime-step-progress.ts
@@ -1,0 +1,80 @@
+import type { AgentResponse, Message as AgentMessage } from "../schemas/index.ts";
+import type { ForkRuntimeStep } from "./fork-runtime-stream.ts";
+
+export interface ForkRuntimeProgress {
+  steps: ForkRuntimeStep[];
+  currentMessages: AgentMessage[];
+  accumulatedInputTokens: number;
+  accumulatedOutputTokens: number;
+}
+
+/** Build a fork runtime step from an agent response. */
+export function buildForkRuntimeStepFromResponse(response: AgentResponse): ForkRuntimeStep {
+  const toolCalls = response.toolCalls.map((toolCall) => ({
+    toolCallId: toolCall.id,
+    toolName: toolCall.name,
+    input: toolCall.args,
+  }));
+  const toolResults = response.toolCalls.flatMap((toolCall) =>
+    toolCall.status === "completed"
+      ? [
+        {
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+          input: toolCall.args,
+          output: toolCall.result,
+        },
+      ]
+      : []
+  );
+  const finishReasonValue = response.metadata?.finishReason;
+
+  return {
+    text: response.text,
+    messages: structuredClone(response.messages),
+    toolCalls,
+    toolResults,
+    finishReason: typeof finishReasonValue === "string" ? finishReasonValue : null,
+  };
+}
+
+/** Should continue fork runtime step helper. */
+export function shouldContinueForkRuntimeStep(
+  step: ForkRuntimeStep,
+  response: AgentResponse,
+): boolean {
+  return step.finishReason === "tool-calls" &&
+    response.toolCalls.some((toolCall) => toolCall.status !== "error");
+}
+
+export function createForkRuntimeProgress(
+  currentMessages: AgentMessage[],
+): ForkRuntimeProgress {
+  return {
+    steps: [],
+    currentMessages,
+    accumulatedInputTokens: 0,
+    accumulatedOutputTokens: 0,
+  };
+}
+
+export function commitForkRuntimeStep(
+  progress: ForkRuntimeProgress,
+  response: AgentResponse,
+): ForkRuntimeStep {
+  const step = buildForkRuntimeStepFromResponse(response);
+  progress.steps.push(step);
+  progress.accumulatedInputTokens += response.usage?.promptTokens ?? 0;
+  progress.accumulatedOutputTokens += response.usage?.completionTokens ?? 0;
+  progress.currentMessages = response.messages;
+  return step;
+}
+
+export function getForkRuntimeProgressUsage(
+  progress: ForkRuntimeProgress,
+): { inputTokens: number; outputTokens: number } {
+  return {
+    inputTokens: progress.accumulatedInputTokens,
+    outputTokens: progress.accumulatedOutputTokens,
+  };
+}

--- a/src/agent/streaming/fork-runtime-stream.ts
+++ b/src/agent/streaming/fork-runtime-stream.ts
@@ -25,6 +25,12 @@ import {
 } from "../runtime/provider-native-tool-inventory.ts";
 import { AgentRuntime } from "../runtime/index.ts";
 import type { AgentResponse, Message as AgentMessage } from "../schemas/index.ts";
+import {
+  commitForkRuntimeStep,
+  createForkRuntimeProgress,
+  getForkRuntimeProgressUsage,
+  shouldContinueForkRuntimeStep,
+} from "./fork-runtime-step-progress.ts";
 
 export {
   buildRecoveredStepParts,
@@ -45,6 +51,10 @@ export type {
   RecoveredToolObservation,
 } from "./fork-runtime-part-mapper.ts";
 export type { StreamedStepState } from "./fork-runtime-step-state.ts";
+export {
+  buildForkRuntimeStepFromResponse,
+  shouldContinueForkRuntimeStep,
+} from "./fork-runtime-step-progress.ts";
 
 interface ForkStreamPart {
   type: "reasoning-delta" | "text-delta";
@@ -410,45 +420,6 @@ export type ForkRuntimeContinuationPromptResolver = (input: {
   stepIndex: number;
 }) => Promise<string | null> | string | null;
 
-/** Response payload for build fork runtime step from. */
-export function buildForkRuntimeStepFromResponse(response: AgentResponse): ForkRuntimeStep {
-  const toolCalls = response.toolCalls.map((toolCall) => ({
-    toolCallId: toolCall.id,
-    toolName: toolCall.name,
-    input: toolCall.args,
-  }));
-  const toolResults = response.toolCalls.flatMap((toolCall) =>
-    toolCall.status === "completed"
-      ? [
-        {
-          toolCallId: toolCall.id,
-          toolName: toolCall.name,
-          input: toolCall.args,
-          output: toolCall.result,
-        },
-      ]
-      : []
-  );
-  const finishReasonValue = response.metadata?.finishReason;
-
-  return {
-    text: response.text,
-    messages: structuredClone(response.messages),
-    toolCalls,
-    toolResults,
-    finishReason: typeof finishReasonValue === "string" ? finishReasonValue : null,
-  };
-}
-
-/** Should continue fork runtime step helper. */
-export function shouldContinueForkRuntimeStep(
-  step: ForkRuntimeStep,
-  response: AgentResponse,
-): boolean {
-  return step.finishReason === "tool-calls" &&
-    response.toolCalls.some((toolCall) => toolCall.status !== "error");
-}
-
 /** Message shape for create fork runtime user. */
 export function createForkRuntimeUserMessage(input: {
   text: string;
@@ -527,9 +498,6 @@ export function startAgentRuntimeFork(input: StartAgentRuntimeForkInput): ForkRu
     }
     | undefined
   >();
-  const steps: ForkRuntimeStep[] = [];
-  let accumulatedInputTokens = 0;
-  let accumulatedOutputTokens = 0;
   const runStep = input.runStep ?? runAgentRuntimeForkStep;
 
   return {
@@ -540,17 +508,17 @@ export function startAgentRuntimeFork(input: StartAgentRuntimeForkInput): ForkRu
         );
       }
 
-      let currentMessages = createInitialForkRuntimeMessages({
+      const progress = createForkRuntimeProgress(createInitialForkRuntimeMessages({
         initialMessages: input.initialMessages,
         prompt: input.prompt,
-      });
+      }));
       let continuationStepsRemaining = input.maxContinuationSteps ?? 0;
 
       try {
-        while (steps.length < getMaxForkRuntimeStepCount(input)) {
+        while (progress.steps.length < getMaxForkRuntimeStepCount(input)) {
           const prepared = await prepareForkRuntimeStep({
             prepareStep: input.prepareStep,
-            messages: currentMessages,
+            messages: progress.currentMessages,
             buildInstructions: input.buildInstructions,
             forkToolNames: input.forkToolNames,
           });
@@ -582,40 +550,33 @@ export function startAgentRuntimeFork(input: StartAgentRuntimeForkInput): ForkRu
             responsePromise,
             responseTimeoutMs: input.responseTimeoutMs ?? DEFAULT_FORK_RESPONSE_PROMISE_TIMEOUT_MS,
             ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
-            currentMessages,
+            currentMessages: progress.currentMessages,
             streamedStepState,
           });
-          const step = buildForkRuntimeStepFromResponse(response);
+          const step = commitForkRuntimeStep(progress, response);
           for (const recoveredPart of buildRecoveredStepParts(step, state)) {
             yield recoveredPart;
           }
-          steps.push(step);
-          accumulatedInputTokens += response.usage?.promptTokens ?? 0;
-          accumulatedOutputTokens += response.usage?.completionTokens ?? 0;
-          currentMessages = response.messages;
 
           if (!shouldContinueForkRuntimeStep(step, response)) {
             const followUpState = await resolveForkRuntimeContinuationState({
               continuationStepsRemaining,
               onBeforeStop: input.onBeforeStop,
               step,
-              currentMessages,
-              stepIndex: steps.length - 1,
+              currentMessages: progress.currentMessages,
+              stepIndex: progress.steps.length - 1,
             });
             if (followUpState) {
               continuationStepsRemaining = followUpState.continuationStepsRemaining;
-              currentMessages = followUpState.currentMessages;
+              progress.currentMessages = followUpState.currentMessages;
               continue;
             }
             break;
           }
         }
 
-        stepsDeferred.resolve(steps);
-        totalUsageDeferred.resolve({
-          inputTokens: accumulatedInputTokens,
-          outputTokens: accumulatedOutputTokens,
-        });
+        stepsDeferred.resolve(progress.steps);
+        totalUsageDeferred.resolve(getForkRuntimeProgressUsage(progress));
       } catch (error) {
         stepsDeferred.reject(error);
         totalUsageDeferred.reject(error);


### PR DESCRIPTION
## Summary
- add a focused fork runtime step progress helper for step construction, continuation decision, message advancement, and usage accumulation
- keep `fork-runtime-stream.ts` public exports stable while thinning the main stream loop
- add focused tests for step building and accumulated progress, with existing fork-stream tests covering ordering and continuation

## Verification
- red-first: `deno test --no-check --allow-all src/agent/streaming/fork-runtime-step-progress.test.ts` failed while the helper module was missing
- `deno test --no-check --allow-all src/agent/streaming/fork-runtime-step-progress.test.ts src/agent/streaming/fork-runtime-stream.test.ts`
- `deno test --no-check --allow-all src/agent/streaming`
- `deno check src/agent/streaming/fork-runtime-stream.ts src/agent/streaming/fork-runtime-step-progress.ts src/agent/streaming/fork-runtime-step-progress.test.ts src/agent/streaming/fork-runtime-stream.test.ts`
- `deno lint src/agent/streaming/fork-runtime-stream.ts src/agent/streaming/fork-runtime-step-progress.ts src/agent/streaming/fork-runtime-step-progress.test.ts src/agent/streaming/fork-runtime-stream.test.ts`
- `deno fmt --check src/agent/streaming/fork-runtime-stream.ts src/agent/streaming/fork-runtime-step-progress.ts src/agent/streaming/fork-runtime-step-progress.test.ts src/agent/streaming/fork-runtime-stream.test.ts`
- `git diff --check`
- pre-push hook passed: format, lint, typecheck, unit suite (`2164 passed`, `0 failed`)

Refs #2216.
