### PR TITLE
Extract streamed assistant message materialization

### DIFF
--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -76,6 +76,7 @@ import {
   getRuntimeProviderTools,
 } from "./runtime-tool-config.ts";
 import { prepareAgentRuntimeStep } from "./agent-runtime-step.ts";
+import { buildStreamedAssistantMessage } from "./streamed-assistant-message.ts";
 
 // Re-export from submodules
 export { closeSSEStream, generateMessageId, sendSSE } from "./sse-utils.ts";
@@ -896,27 +897,13 @@ export class AgentRuntime {
       throwIfAborted(abortSignal);
       finalFinishReason = state.finishReason ?? finalFinishReason;
 
-      const streamParts: MessagePart[] = [];
-      for (const reasoningPart of state.reasoningParts) {
-        if (
-          reasoningPart.text.length === 0 &&
-          !reasoningPart.signature &&
-          !reasoningPart.redactedData
-        ) {
-          continue;
-        }
-        streamParts.push({
-          type: "reasoning",
-          ...(reasoningPart.text.length > 0 ? { text: reasoningPart.text } : {}),
-          ...(reasoningPart.signature ? { signature: reasoningPart.signature } : {}),
-          ...(reasoningPart.redactedData ? { redactedData: reasoningPart.redactedData } : {}),
-        });
-      }
-      if (state.accumulatedText) streamParts.push({ type: "text", text: state.accumulatedText });
+      const assistantMessage = buildStreamedAssistantMessage(state, {
+        id: `msg_${Date.now()}_${step}`,
+        timestamp: Date.now(),
+      });
 
       for (const tc of state.toolCalls.values()) {
         const materialized = materializeStreamedToolCall(tc);
-        streamParts.push(materialized.part);
 
         if (materialized.kind === "incomplete" && isRecoverablePlaceholderToolCall(tc)) {
           // Provisional empty-object placeholder that never finalized. The
@@ -956,12 +943,6 @@ export class AgentRuntime {
         }
       }
 
-      const assistantMessage: Message = {
-        id: `msg_${Date.now()}_${step}`,
-        role: "assistant",
-        parts: streamParts,
-        timestamp: Date.now(),
-      };
       latestAssistantText = getTextFromParts(assistantMessage.parts);
       currentMessages.push(assistantMessage);
       await this.memory.add(assistantMessage);

--- a/src/agent/runtime/streamed-assistant-message.test.ts
+++ b/src/agent/runtime/streamed-assistant-message.test.ts
@@ -1,0 +1,73 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ChatStreamState } from "./chat-stream-handler.ts";
+import { buildStreamedAssistantMessage } from "./streamed-assistant-message.ts";
+
+describe("agent/streamed-assistant-message", () => {
+  it("builds an assistant message from completed stream state", () => {
+    const state: ChatStreamState = {
+      accumulatedText: "Final answer",
+      reasoningParts: [
+        { id: "reasoning_empty", text: "" },
+        { id: "reasoning_text", text: "internal note", signature: "sig_1" },
+        { id: "reasoning_redacted", text: "", redactedData: "redacted_1" },
+      ],
+      finishReason: "tool-calls",
+      toolCalls: new Map([
+        [
+          "call_1",
+          {
+            id: "call_1",
+            name: "lookup",
+            arguments: '{"query":"docs"}',
+            inputAvailable: true,
+          },
+        ],
+        [
+          "call_2",
+          {
+            id: "call_2",
+            name: "web_search",
+            arguments: '{"q":"Veryfront"}',
+            inputAvailable: true,
+            providerExecuted: true,
+          },
+        ],
+      ]),
+      toolResults: [],
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    };
+
+    const message = buildStreamedAssistantMessage(state, {
+      id: "msg_fixed",
+      timestamp: 123,
+    });
+
+    assertEquals(message, {
+      id: "msg_fixed",
+      role: "assistant",
+      timestamp: 123,
+      parts: [
+        { type: "reasoning", text: "internal note", signature: "sig_1" },
+        { type: "reasoning", redactedData: "redacted_1" },
+        { type: "text", text: "Final answer" },
+        {
+          type: "tool-lookup",
+          toolCallId: "call_1",
+          toolName: "lookup",
+          args: { query: "docs" },
+          inputText: '{"query":"docs"}',
+        },
+        {
+          type: "tool-web_search",
+          toolCallId: "call_2",
+          toolName: "web_search",
+          args: { q: "Veryfront" },
+          inputText: '{"q":"Veryfront"}',
+          providerExecuted: true,
+        },
+      ],
+    });
+  });
+});

--- a/src/agent/runtime/streamed-assistant-message.ts
+++ b/src/agent/runtime/streamed-assistant-message.ts
@@ -1,0 +1,46 @@
+import type { Message, MessagePart } from "../types.ts";
+import type { ChatStreamState } from "./chat-stream-handler.ts";
+import { materializeStreamedToolCall } from "./tool-result-continuation.ts";
+
+export interface StreamedAssistantMessageIdentity {
+  id: string;
+  timestamp: number;
+}
+
+export function buildStreamedAssistantMessage(
+  state: Pick<ChatStreamState, "accumulatedText" | "reasoningParts" | "toolCalls">,
+  identity: StreamedAssistantMessageIdentity,
+): Message {
+  const parts: MessagePart[] = [];
+
+  for (const reasoningPart of state.reasoningParts) {
+    if (
+      reasoningPart.text.length === 0 &&
+      !reasoningPart.signature &&
+      !reasoningPart.redactedData
+    ) {
+      continue;
+    }
+    parts.push({
+      type: "reasoning",
+      ...(reasoningPart.text.length > 0 ? { text: reasoningPart.text } : {}),
+      ...(reasoningPart.signature ? { signature: reasoningPart.signature } : {}),
+      ...(reasoningPart.redactedData ? { redactedData: reasoningPart.redactedData } : {}),
+    });
+  }
+
+  if (state.accumulatedText) {
+    parts.push({ type: "text", text: state.accumulatedText });
+  }
+
+  for (const toolCall of state.toolCalls.values()) {
+    parts.push(materializeStreamedToolCall(toolCall).part);
+  }
+
+  return {
+    id: identity.id,
+    role: "assistant",
+    parts,
+    timestamp: identity.timestamp,
+  };
+}


### PR DESCRIPTION
## Summary
- add a focused helper for building assistant history messages from completed stream state
- replace inline stream-loop message assembly with the helper while keeping tool error reporting side effects in the loop
- add regression coverage for reasoning filtering, text retention, local tool calls, and provider-executed tool calls

## Verification
- red-first: `deno test --no-check --allow-all src/agent/runtime/streamed-assistant-message.test.ts` failed while the helper module was missing
- `deno test --no-check --allow-all src/agent/runtime/streamed-assistant-message.test.ts src/agent/runtime/tool-result-continuation.test.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/runtime-stream-cancel.test.ts`
- `deno test --no-check --allow-all src/agent/runtime`
- `deno check src/agent/runtime/index.ts src/agent/runtime/streamed-assistant-message.ts src/agent/runtime/streamed-assistant-message.test.ts`
- `deno lint src/agent/runtime/index.ts src/agent/runtime/streamed-assistant-message.ts src/agent/runtime/streamed-assistant-message.test.ts`
- `deno fmt --check src/agent/runtime/index.ts src/agent/runtime/streamed-assistant-message.ts src/agent/runtime/streamed-assistant-message.test.ts`
- `git diff --check`
- pre-push hook passed: format, lint, typecheck, unit suite (`2165 passed`, `0 failed`)

Refs #2216.
