### PR TITLE
Separate durable append error classification

### DIFF
--- a/src/agent/conversation/durable-append-errors.test.ts
+++ b/src/agent/conversation/durable-append-errors.test.ts
@@ -1,0 +1,54 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  AppendConversationRunEventsError,
+  isCursorMismatchConversationRunAppendError,
+  isIgnorableConversationRunAppendError,
+  parseAppendConversationRunEventsErrorBody,
+} from "./durable-append-errors.ts";
+
+describe("agent/durable-append-errors", () => {
+  it("parses structured and plaintext append errors", () => {
+    assertEquals(
+      parseAppendConversationRunEventsErrorBody(
+        JSON.stringify({ detail: "Cannot append external events to a terminal run" }),
+      ),
+      "Cannot append external events to a terminal run",
+    );
+    assertEquals(
+      parseAppendConversationRunEventsErrorBody(JSON.stringify({ error: "append failed" })),
+      "append failed",
+    );
+    assertEquals(parseAppendConversationRunEventsErrorBody("plain text"), "plain text");
+    assertEquals(parseAppendConversationRunEventsErrorBody(""), null);
+  });
+
+  it("classifies ignorable and cursor-mismatch append failures", () => {
+    const terminal = new AppendConversationRunEventsError({
+      status: 400,
+      detail: "Cannot append external events to a terminal run",
+    });
+    const waitingForTool = new AppendConversationRunEventsError({
+      status: 400,
+      detail: "Cannot append external events while the run is waiting for a tool result",
+    });
+    const missingRun = new AppendConversationRunEventsError({ status: 404 });
+    const cursorMismatch = new AppendConversationRunEventsError({
+      status: 400,
+      detail: "External run event cursor mismatch",
+    });
+    const upstreamFailure = new AppendConversationRunEventsError({
+      status: 500,
+      detail: "internal failure",
+    });
+
+    assertEquals(isIgnorableConversationRunAppendError(terminal), true);
+    assertEquals(isIgnorableConversationRunAppendError(waitingForTool), true);
+    assertEquals(isIgnorableConversationRunAppendError(missingRun), true);
+    assertEquals(isIgnorableConversationRunAppendError(cursorMismatch), false);
+    assertEquals(isIgnorableConversationRunAppendError(upstreamFailure), false);
+    assertEquals(isCursorMismatchConversationRunAppendError(cursorMismatch), true);
+    assertEquals(isCursorMismatchConversationRunAppendError(terminal), false);
+  });
+});

--- a/src/agent/conversation/durable-append-errors.ts
+++ b/src/agent/conversation/durable-append-errors.ts
@@ -1,0 +1,70 @@
+import { getConversationRunErrorSchema } from "./durable-contracts.ts";
+
+/** Error shape for append conversation run events. */
+export class AppendConversationRunEventsError extends Error {
+  readonly status: number;
+  readonly detail: string | null;
+
+  constructor(input: {
+    status: number;
+    detail?: string | null;
+    statusText?: string;
+  }) {
+    const detail = input.detail?.trim() || input.statusText || `HTTP ${input.status}`;
+    super(`Append conversation run events failed (${input.status}): ${detail}`);
+    this.name = "AppendConversationRunEventsError";
+    this.status = input.status;
+    this.detail = input.detail?.trim() || null;
+  }
+}
+
+/** Parses append conversation run events error body. */
+export function parseAppendConversationRunEventsErrorBody(bodyText: string): string | null {
+  if (!bodyText) {
+    return null;
+  }
+
+  try {
+    const parsed = getConversationRunErrorSchema().safeParse(JSON.parse(bodyText));
+    if (parsed.success) {
+      return parsed.data.detail ?? parsed.data.error ?? null;
+    }
+  } catch {
+    return bodyText;
+  }
+
+  return bodyText;
+}
+
+/** Error shape for is ignorable conversation run append. */
+export function isIgnorableConversationRunAppendError(
+  error: unknown,
+): error is AppendConversationRunEventsError {
+  if (!(error instanceof AppendConversationRunEventsError)) {
+    return false;
+  }
+
+  if (error.status === 404) {
+    return true;
+  }
+
+  if (error.status !== 400) {
+    return false;
+  }
+
+  return (
+    error.detail === "Cannot append external events to a terminal run" ||
+    error.detail === "Cannot append external events while the run is waiting for a tool result"
+  );
+}
+
+/** Error shape for is cursor mismatch conversation run append. */
+export function isCursorMismatchConversationRunAppendError(
+  error: unknown,
+): error is AppendConversationRunEventsError {
+  return (
+    error instanceof AppendConversationRunEventsError &&
+    error.status === 400 &&
+    error.detail === "External run event cursor mismatch"
+  );
+}

--- a/src/agent/conversation/durable.ts
+++ b/src/agent/conversation/durable.ts
@@ -4,7 +4,6 @@ import {
   CompleteConversationRunResponseSchema,
   ConversationRunProjectionSchema,
   CreateConversationRunAcceptedSchema,
-  getConversationRunErrorSchema,
   resolveConversationRunTargets,
 } from "./durable-contracts.ts";
 import type {
@@ -19,6 +18,12 @@ import type {
   FinalizeConversationAgentRunInput,
   TerminalConversationRunStatus,
 } from "./durable-contracts.ts";
+import {
+  AppendConversationRunEventsError,
+  isCursorMismatchConversationRunAppendError,
+  isIgnorableConversationRunAppendError,
+  parseAppendConversationRunEventsErrorBody,
+} from "./durable-append-errors.ts";
 
 export {
   AppendConversationRunEventsResponseSchema,
@@ -35,6 +40,12 @@ export {
   getCreateConversationRunAcceptedSchema,
   resolveConversationRunTargets,
 } from "./durable-contracts.ts";
+export {
+  AppendConversationRunEventsError,
+  isCursorMismatchConversationRunAppendError,
+  isIgnorableConversationRunAppendError,
+  parseAppendConversationRunEventsErrorBody,
+} from "./durable-append-errors.ts";
 export type {
   ActiveConversationRunStatus,
   AppendConversationRunEventsResponse,
@@ -96,75 +107,6 @@ export class ConversationRunTerminalStateError extends Error {
     this.status = status;
     this.run = run;
   }
-}
-
-/** Error shape for append conversation run events. */
-export class AppendConversationRunEventsError extends Error {
-  readonly status: number;
-  readonly detail: string | null;
-
-  constructor(input: {
-    status: number;
-    detail?: string | null;
-    statusText?: string;
-  }) {
-    const detail = input.detail?.trim() || input.statusText || `HTTP ${input.status}`;
-    super(`Append conversation run events failed (${input.status}): ${detail}`);
-    this.name = "AppendConversationRunEventsError";
-    this.status = input.status;
-    this.detail = input.detail?.trim() || null;
-  }
-}
-
-/** Parses append conversation run events error body. */
-export function parseAppendConversationRunEventsErrorBody(bodyText: string): string | null {
-  if (!bodyText) {
-    return null;
-  }
-
-  try {
-    const parsed = getConversationRunErrorSchema().safeParse(JSON.parse(bodyText));
-    if (parsed.success) {
-      return parsed.data.detail ?? parsed.data.error ?? null;
-    }
-  } catch {
-    return bodyText;
-  }
-
-  return bodyText;
-}
-
-/** Error shape for is ignorable conversation run append. */
-export function isIgnorableConversationRunAppendError(
-  error: unknown,
-): error is AppendConversationRunEventsError {
-  if (!(error instanceof AppendConversationRunEventsError)) {
-    return false;
-  }
-
-  if (error.status === 404) {
-    return true;
-  }
-
-  if (error.status !== 400) {
-    return false;
-  }
-
-  return (
-    error.detail === "Cannot append external events to a terminal run" ||
-    error.detail === "Cannot append external events while the run is waiting for a tool result"
-  );
-}
-
-/** Error shape for is cursor mismatch conversation run append. */
-export function isCursorMismatchConversationRunAppendError(
-  error: unknown,
-): error is AppendConversationRunEventsError {
-  return (
-    error instanceof AppendConversationRunEventsError &&
-    error.status === 400 &&
-    error.detail === "External run event cursor mismatch"
-  );
 }
 
 /** Check whether a conversation run status is active. */


### PR DESCRIPTION
## Summary
- add `durable-append-errors.ts` for append error parsing and classification
- keep `durable.ts` public exports stable by re-exporting the moved helpers
- add focused tests for structured/plaintext append errors, ignorable append rejections, and cursor mismatch classification

## Verification
- red-first: `deno test --no-check --allow-all src/agent/conversation/durable-append-errors.test.ts` failed while the helper module was missing
- `deno test --no-check --allow-all src/agent/conversation/durable-append-errors.test.ts src/agent/conversation/durable.test.ts`
- `deno test --no-check --allow-all src/agent/conversation`
- `deno check src/agent/conversation/durable.ts src/agent/conversation/durable-append-errors.ts src/agent/conversation/durable-append-errors.test.ts src/agent/index.ts`
- `deno lint src/agent/conversation/durable.ts src/agent/conversation/durable-append-errors.ts src/agent/conversation/durable-append-errors.test.ts`
- `deno fmt --check src/agent/conversation/durable.ts src/agent/conversation/durable-append-errors.ts src/agent/conversation/durable-append-errors.test.ts`
- `git diff --check`
- pre-push hook passed: format, lint, typecheck, unit suite (`2166 passed`, `0 failed`)

Refs #2216.
