### PR TITLE
Expose proxy boundary timing

### DIFF
--- a/docs/architecture/13-observability.md
+++ b/docs/architecture/13-observability.md
@@ -26,6 +26,23 @@ Primary source areas:
 4. Log subscribers and buffers expose recent runtime output.
 5. Request profiling records route-level timing and resource use.
 
+## Server timing
+
+When `VERYFRONT_ENABLE_SERVER_TIMING=1`, HTML and page-data responses include
+renderer request phases in the `Server-Timing` header. In split proxy mode, the
+proxy also appends proxy-prefixed phases:
+
+- `proxy.total`: time from proxy request receipt to response header return.
+- `proxy.resolve_request`: project, token, domain, and access resolution.
+- `proxy.resolve_server`: dedicated renderer server lookup.
+- `proxy.retry_delay`: retry backoff time.
+- `proxy.upstream`: fetch time from proxy to renderer response headers.
+
+Use client timing such as `curl -w '%{time_pretransfer} %{time_starttransfer}'`
+with `proxy.total` to estimate edge, ingress, and network time before the proxy
+pod receives the request. Use `proxy.upstream` minus the renderer `total` metric
+to estimate proxy-to-renderer network and response header overhead.
+
 ## Boundaries
 
 - Observability records behavior. It does not own business logic.

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -52,6 +52,12 @@ import {
   UPSTREAM_FAILURE_STATUS,
   UPSTREAM_TIMEOUT_STATUS,
 } from "./upstream-error-response.ts";
+import {
+  createProxyServerTiming,
+  markProxyServerTimingPhase,
+  profileProxyServerTimingPhase,
+  withProxyServerTimingHeader,
+} from "./server-timing.ts";
 
 function getLocalProjects(): Record<string, string> {
   const raw = getEnv("LOCAL_PROJECTS");
@@ -286,12 +292,19 @@ function handleWebSocketUpgrade(req: Request, url: URL): Response {
 
 function forwardToServer(req: Request, url: URL): Promise<Response> {
   const startTime = performance.now();
+  const proxyTiming = createProxyServerTiming();
+  const withProxyTiming = (response: Response): Response =>
+    withProxyServerTimingHeader(response, proxyTiming, performance.now() - startTime);
   const requestId = crypto.randomUUID();
   const host = req.headers.get("host") || "";
 
   const execute = async (lifecycle: ProxyRequestLifecycle): Promise<Response> => {
     try {
-      const ctx = await proxyHandler.processRequest(req, { url });
+      const ctx = await profileProxyServerTimingPhase(
+        proxyTiming,
+        "proxy.resolve_request",
+        () => proxyHandler.processRequest(req, { url }),
+      );
 
       return runWithProxyRequestContext(
         {
@@ -310,7 +323,7 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
             const logLevel = getProxyFailureLogLevel(ctx.error.status, req.method, url.pathname);
             proxyLogger[logLevel](`${ctx.error.status} ${req.method} ${url.pathname}`, { ms });
             lifecycle.end(ctx.error.status);
-            return createProxyErrorResponse(ctx.error);
+            return withProxyTiming(createProxyErrorResponse(ctx.error));
           }
 
           const reqLogger = proxyLogger.child({
@@ -343,9 +356,11 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
 
           for (let attempt = 0; attempt <= maxRetries; attempt++) {
             // Resolve dedicated server per attempt so retries can fall back to shared pool
-            const dedicatedServerUrl = skipDedicated
-              ? null
-              : await serverResolver.resolve(ctx.environmentId);
+            const dedicatedServerUrl = skipDedicated ? null : await profileProxyServerTimingPhase(
+              proxyTiming,
+              "proxy.resolve_server",
+              () => serverResolver.resolve(ctx.environmentId),
+            );
             const baseUrl = dedicatedServerUrl ??
               rendererRouter?.resolve(ctx.projectSlug) ??
               PRODUCTION_SERVER_URL;
@@ -363,7 +378,13 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
                   method: req.method,
                 },
               );
+              const retryDelayStartedAt = performance.now();
               await new Promise((resolve) => setTimeout(resolve, VERYFRONT_SERVER_RETRY_DELAY_MS)); // no cleanup needed: one-shot
+              markProxyServerTimingPhase(
+                proxyTiming,
+                "proxy.retry_delay",
+                performance.now() - retryDelayStartedAt,
+              );
             }
 
             const abortController = new AbortController();
@@ -372,25 +393,30 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
             }, VERYFRONT_SERVER_REQUEST_TIMEOUT_MS);
 
             try {
-              const response = await withSpan(
-                ProxySpanNames.HTTP_CLIENT_FETCH,
+              const response = await profileProxyServerTimingPhase(
+                proxyTiming,
+                "proxy.upstream",
                 () =>
-                  fetch(serverUrl.toString(), {
-                    method: req.method,
-                    headers: newHeaders,
-                    body: req.body,
-                    redirect: "manual",
-                    signal: abortController.signal,
-                  }),
-                {
-                  "http.method": req.method,
-                  "http.url": serverUrl.toString(),
-                  "http.host": serverUrl.host,
-                  "proxy.target": "server",
-                  "proxy.project_slug": ctx.projectSlug || "",
-                  "proxy.timeout_ms": VERYFRONT_SERVER_REQUEST_TIMEOUT_MS,
-                  "proxy.retry_attempt": attempt,
-                },
+                  withSpan(
+                    ProxySpanNames.HTTP_CLIENT_FETCH,
+                    () =>
+                      fetch(serverUrl.toString(), {
+                        method: req.method,
+                        headers: newHeaders,
+                        body: req.body,
+                        redirect: "manual",
+                        signal: abortController.signal,
+                      }),
+                    {
+                      "http.method": req.method,
+                      "http.url": serverUrl.toString(),
+                      "http.host": serverUrl.host,
+                      "proxy.target": "server",
+                      "proxy.project_slug": ctx.projectSlug || "",
+                      "proxy.timeout_ms": VERYFRONT_SERVER_REQUEST_TIMEOUT_MS,
+                      "proxy.retry_attempt": attempt,
+                    },
+                  ),
               );
 
               clearTimeout(timeoutId);
@@ -405,11 +431,13 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
                 reqLogger.info(`${response.status} ${req.method} ${url.pathname}`, { ms });
               }
 
-              return new Response(response.body, {
-                status: response.status,
-                statusText: response.statusText,
-                headers: response.headers,
-              });
+              return withProxyTiming(
+                new Response(response.body, {
+                  status: response.status,
+                  statusText: response.statusText,
+                  headers: response.headers,
+                }),
+              );
             } catch (error) {
               clearTimeout(timeoutId);
               lastError = error as Error;
@@ -421,7 +449,9 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
                   timeoutMs: VERYFRONT_SERVER_REQUEST_TIMEOUT_MS,
                 });
                 lifecycle.end(UPSTREAM_TIMEOUT_STATUS, error);
-                return createUpstreamTimeoutResponse(VERYFRONT_SERVER_REQUEST_TIMEOUT_MS);
+                return withProxyTiming(
+                  createUpstreamTimeoutResponse(VERYFRONT_SERVER_REQUEST_TIMEOUT_MS),
+                );
               }
 
               // Check if this is a retryable error and we have retries left
@@ -467,17 +497,19 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
             lastError as Error,
           );
           lifecycle.end(UPSTREAM_FAILURE_STATUS, lastError as Error);
-          return createUpstreamFailureResponse(lastError);
+          return withProxyTiming(createUpstreamFailureResponse(lastError));
         },
       );
     } catch (error) {
       const ms = Math.round(performance.now() - startTime);
       proxyLogger.error(`500 ${req.method} ${url.pathname}`, { ms }, error as Error);
       lifecycle.end(500, error as Error);
-      return jsonErrorResponse(500, {
-        error: "Internal Proxy Error",
-        message: error instanceof Error ? error.message : "Unknown error",
-      });
+      return withProxyTiming(
+        jsonErrorResponse(500, {
+          error: "Internal Proxy Error",
+          message: error instanceof Error ? error.message : "Unknown error",
+        }),
+      );
     }
   };
 

--- a/src/proxy/server-timing.test.ts
+++ b/src/proxy/server-timing.test.ts
@@ -1,0 +1,59 @@
+import "#veryfront/schemas/_test-setup.ts";
+
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  createProxyServerTiming,
+  markProxyServerTimingPhase,
+  shouldEnableProxyServerTiming,
+  withProxyServerTimingHeader,
+} from "./server-timing.ts";
+
+describe("proxy server timing", () => {
+  afterEach(() => {
+    Deno.env.delete("VERYFRONT_ENABLE_PROXY_SERVER_TIMING");
+    Deno.env.delete("VERYFRONT_ENABLE_SERVER_TIMING");
+  });
+
+  it("uses the proxy-specific flag or shared server timing flag", () => {
+    assertEquals(shouldEnableProxyServerTiming(), false);
+
+    Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
+    assertEquals(shouldEnableProxyServerTiming(), true);
+
+    Deno.env.delete("VERYFRONT_ENABLE_SERVER_TIMING");
+    Deno.env.set("VERYFRONT_ENABLE_PROXY_SERVER_TIMING", "1");
+    assertEquals(shouldEnableProxyServerTiming(), true);
+  });
+
+  it("appends proxy metrics to an existing renderer Server-Timing header", () => {
+    const timing = createProxyServerTiming(true);
+    markProxyServerTimingPhase(timing, "proxy.resolve_request", 2.345);
+    markProxyServerTimingPhase(timing, "proxy.upstream", 10);
+
+    const response = withProxyServerTimingHeader(
+      new Response("ok", {
+        headers: { "Server-Timing": "total;dur=4.00, render.cache_hit;dur=0.00" },
+      }),
+      timing,
+      15.556,
+    );
+
+    const header = response.headers.get("Server-Timing") ?? "";
+    assertStringIncludes(header, "total;dur=4.00");
+    assertStringIncludes(header, "render.cache_hit;dur=0.00");
+    assertStringIncludes(header, "proxy.total;dur=15.56");
+    assertStringIncludes(header, "proxy.resolve_request;dur=2.35");
+    assertStringIncludes(header, "proxy.upstream;dur=10.00");
+  });
+
+  it("leaves responses untouched when timing is disabled", () => {
+    const response = withProxyServerTimingHeader(
+      new Response("ok"),
+      createProxyServerTiming(false),
+      12,
+    );
+
+    assertEquals(response.headers.get("Server-Timing"), null);
+  });
+});

--- a/src/proxy/server-timing.ts
+++ b/src/proxy/server-timing.ts
@@ -1,0 +1,88 @@
+import { getEnv } from "#veryfront/platform/compat/process.ts";
+
+export interface ProxyServerTiming {
+  enabled: boolean;
+  startedAt: number;
+  phases: Map<string, number>;
+}
+
+function roundMs(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function formatDuration(value: number): string {
+  return Math.max(0, roundMs(value)).toFixed(2);
+}
+
+function sanitizeMetricName(name: string): string {
+  return name.replace(/[^A-Za-z0-9!#$%&'*+\-.^_`|~]/g, "_");
+}
+
+export function shouldEnableProxyServerTiming(): boolean {
+  return getEnv("VERYFRONT_ENABLE_PROXY_SERVER_TIMING") === "1" ||
+    getEnv("VERYFRONT_ENABLE_SERVER_TIMING") === "1";
+}
+
+export function createProxyServerTiming(
+  enabled = shouldEnableProxyServerTiming(),
+): ProxyServerTiming {
+  return {
+    enabled,
+    startedAt: performance.now(),
+    phases: new Map(),
+  };
+}
+
+export function markProxyServerTimingPhase(
+  timing: ProxyServerTiming,
+  name: string,
+  durationMs = 0,
+): void {
+  if (!timing.enabled) return;
+  timing.phases.set(name, roundMs((timing.phases.get(name) ?? 0) + durationMs));
+}
+
+export async function profileProxyServerTimingPhase<T>(
+  timing: ProxyServerTiming,
+  name: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!timing.enabled) return await fn();
+
+  const startedAt = performance.now();
+  try {
+    return await fn();
+  } finally {
+    markProxyServerTimingPhase(timing, name, performance.now() - startedAt);
+  }
+}
+
+export function withProxyServerTimingHeader(
+  response: Response,
+  timing: ProxyServerTiming,
+  totalMs = performance.now() - timing.startedAt,
+): Response {
+  if (!timing.enabled) return response;
+
+  const metrics = [`proxy.total;dur=${formatDuration(totalMs)}`];
+  for (const [name, duration] of timing.phases.entries()) {
+    metrics.push(`${sanitizeMetricName(name)};dur=${formatDuration(duration)}`);
+  }
+
+  const value = metrics.join(", ");
+
+  try {
+    const existing = response.headers.get("Server-Timing");
+    response.headers.set("Server-Timing", existing ? `${existing}, ${value}` : value);
+    return response;
+  } catch {
+    const headers = new Headers(response.headers);
+    const existing = headers.get("Server-Timing");
+    headers.set("Server-Timing", existing ? `${existing}, ${value}` : value);
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- append proxy-prefixed Server-Timing phases in split proxy mode
- measure request resolution, dedicated server lookup, retry delay, and proxy-to-renderer fetch time
- document how to subtract proxy and renderer timings from client timing to isolate edge/ingress overhead

## Verification
- deno test --no-check --allow-all src/proxy/server-timing.test.ts src/proxy/main.test.ts src/proxy/request-lifecycle.test.ts src/proxy/upstream-error-response.test.ts
- deno test --no-check --allow-all --parallel src/proxy/*.test.ts
- deno fmt --check src/proxy/main.ts src/proxy/server-timing.ts src/proxy/server-timing.test.ts docs/architecture/13-observability.md
- deno check src/proxy/main.ts src/proxy/server-timing.ts src/proxy/server-timing.test.ts
- pre-push hook: formatting, lint, typecheck, unit suite: 2167 passed, 0 failed

## Notes
This is the runtime half. After merge and release, deploy the matching veryfront-server image with proxy Server-Timing enabled to see proxy.total and proxy.upstream in production responses.