### PR TITLE
Bump framework release to 0.1.814

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.813",
+  "version": "0.1.814",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.813";
+export const VERSION = "0.1.814";


### PR DESCRIPTION
## Summary
- bump the framework version from 0.1.813 to 0.1.814
- keep the shared runtime version constant in sync
- unblock a new stable release that includes the proxy Server-Timing instrumentation from #2465

## Verification
- npm view veryfront@0.1.814 version: not published
- gh release view v0.1.814 --repo veryfront/veryfront: not found
- deno fmt --check deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- pre-push hook: format, lint, typecheck, unit suite (2167 passed, 18650 steps, 0 failed)