### PR TITLE
Bump framework release to 0.1.815

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.814",
+  "version": "0.1.815",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.814";
+export const VERSION = "0.1.815";


### PR DESCRIPTION
## Summary
- Bump the framework version from 0.1.814 to 0.1.815.
- Keep the shared runtime version constant (`src/utils/version-constant.ts`) in sync.
- Unblocks `main` CI: the `release` job was hard-failing because deno.json still pointed at 0.1.814, which is already published to npm (`v0.1.814 already exists on npm. Bump deno.json before releasing.`). All other CI jobs (lint, typecheck, tests, build-binaries) were green; only `release` was red, triggered by the docs-only push in #2468 landing on main without a version bump.

## Verification
- `npm view veryfront@0.1.815 version` → not published
- `git ls-remote --tags origin | grep v0.1.815` → not found
- `gh release view v0.1.815 --repo veryfront/veryfront` → not found
- `deno fmt --check deno.json src/utils/version-constant.ts` → passes
- `deno task verify:quick` chain passes through fmt/lint/lint:style/typecheck on the changed files (pre-existing, CI-ungated `lint:cli-boundary` violation in `cli/shared/server-startup.ts` exists on untouched main and is unrelated to this bump)

## Note
There is a separate pre-existing local-only pre-commit breakage: `deno task lint:cli-boundary` fails on `cli/shared/server-startup.ts` (direct `#veryfront/*` imports). CI does not run this check, so it does not block this release, but it's worth a follow-up fix.