### PR TITLE
Reduce origin latency for release-backed navigation

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.815",
+  "version": "0.1.816",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/architecture/02-request-pipeline.md
+++ b/docs/architecture/02-request-pipeline.md
@@ -71,6 +71,40 @@ flowchart TD
 5. Protocol and control-plane paths enter their dedicated handlers.
 6. Response helpers normalize headers, CORS, errors, and not-found behavior.
 
+## Runtime caches
+
+The split proxy caches successful project metadata lookups for service and
+static-token requests. The cache is per proxy handler, bounded, and short lived.
+It does not cache lookup misses, preview user-token lookups, signed internal
+request lookups, or protected-access decisions. Protected environments still run
+their access check on every request.
+
+Default proxy lookup cache controls:
+
+| Environment variable                               | Default |
+| -------------------------------------------------- | ------- |
+| `VERYFRONT_PROXY_PROJECT_LOOKUP_CACHE_TTL_MS`      | `30000` |
+| `VERYFRONT_PROXY_PROJECT_LOOKUP_CACHE_MAX_ENTRIES` | `1000`  |
+
+Set either value to `0` to disable the proxy project lookup cache.
+
+Release-backed production page-data requests use a fresh cache window plus a
+bounded stale-while-revalidate window. The cache key includes the project,
+environment, release content source, slug, and sorted query. Requests with
+cache-sensitive state are not cached. Preview branch page data keeps the fresh
+TTL cache but does not serve stale responses after expiry.
+
+Default page-data cache controls:
+
+| Environment variable                    | Default   |
+| --------------------------------------- | --------- |
+| `VERYFRONT_PAGE_DATA_CACHE_TTL_MS`      | `60000`   |
+| `VERYFRONT_PAGE_DATA_CACHE_STALE_MS`    | `1800000` |
+| `VERYFRONT_PAGE_DATA_CACHE_MAX_ENTRIES` | `500`     |
+
+Set `VERYFRONT_PAGE_DATA_CACHE_MAX_ENTRIES` to `0` to disable the page-data
+endpoint cache.
+
 ## Boundaries
 
 - Rendering details belong in [rendering runtime](./03-rendering-runtime.md).

--- a/docs/architecture/13-observability.md
+++ b/docs/architecture/13-observability.md
@@ -34,6 +34,9 @@ proxy also appends proxy-prefixed phases:
 
 - `proxy.total`: time from proxy request receipt to response header return.
 - `proxy.resolve_request`: project, token, domain, and access resolution.
+- `proxy.project_lookup`: project metadata lookup fetch time.
+- `proxy.project_lookup_cache_hit`: project metadata cache hit marker.
+- `proxy.project_lookup_pending`: project metadata lookup singleflight marker.
 - `proxy.resolve_server`: dedicated renderer server lookup.
 - `proxy.retry_delay`: retry backoff time.
 - `proxy.upstream`: fetch time from proxy to renderer response headers.

--- a/src/html/hydration-script-builder/templates/router.test.ts
+++ b/src/html/hydration-script-builder/templates/router.test.ts
@@ -101,6 +101,15 @@ describe("hydration-script-builder/templates/router", () => {
       assertIncludes(result, "function setCachedPageData(path, data)");
     });
 
+    it("should dedupe and throttle background page-data refreshes", () => {
+      const result = getRouterScript();
+      assertIncludes(result, "BACKGROUND_REFRESH_INTERVAL_MS = 30 * 1000");
+      assertIncludes(result, "const pendingPageDataFetches = new Map()");
+      assertIncludes(result, "function refreshPageDataInBackground(path)");
+      assertIncludes(result, "pendingPageDataFetches.set(path, refreshPromise)");
+      assertIncludes(result, "refreshPageDataInBackground(path)");
+    });
+
     it("should define scroll position memory", () => {
       const result = getRouterScript();
       assertIncludes(result, "function saveScrollPosition(path)");

--- a/src/html/hydration-script-builder/templates/router.ts
+++ b/src/html/hydration-script-builder/templates/router.ts
@@ -33,6 +33,7 @@ export const getRouterScript = () => `
     const MAX_RETRIES = 2;
     const MAX_CACHE_SIZE = 50;
     const CACHE_TTL_MS = 5 * 60 * 1000;
+    const BACKGROUND_REFRESH_INTERVAL_MS = 30 * 1000;
     const PREFETCH_DELAY_MS = 100;
     const MAX_PREFETCH_PATHS = 100;
 
@@ -126,6 +127,8 @@ export const getRouterScript = () => `
     // LRU Cache with TTL (single Map to prevent sync issues)
     // ============================================
     const pageDataCache = new Map();
+    const pendingPageDataFetches = new Map();
+    const backgroundRefreshTimestamps = new Map();
 
     function getCachedPageData(path) {
       const entry = pageDataCache.get(path);
@@ -134,13 +137,17 @@ export const getRouterScript = () => `
       if (Date.now() - entry.timestamp < CACHE_TTL_MS) return entry.data;
 
       pageDataCache.delete(path);
+      backgroundRefreshTimestamps.delete(path);
       return null;
     }
 
     function setCachedPageData(path, data) {
       if (pageDataCache.size >= MAX_CACHE_SIZE) {
         const oldest = pageDataCache.keys().next().value;
-        if (oldest) pageDataCache.delete(oldest);
+        if (oldest) {
+          pageDataCache.delete(oldest);
+          backgroundRefreshTimestamps.delete(oldest);
+        }
       }
 
       pageDataCache.set(path, { data, timestamp: Date.now() });
@@ -291,13 +298,33 @@ export const getRouterScript = () => `
       return data;
     }
 
+    function fetchPageDataDeduped(path) {
+      const pending = pendingPageDataFetches.get(path);
+      if (pending) return pending;
+
+      const refreshPromise = fetchPageDataFresh(path, null).finally(() => {
+        pendingPageDataFetches.delete(path);
+      });
+      pendingPageDataFetches.set(path, refreshPromise);
+      return refreshPromise;
+    }
+
+    function refreshPageDataInBackground(path) {
+      const lastRefreshAt = backgroundRefreshTimestamps.get(path) || 0;
+      const now = Date.now();
+      if (now - lastRefreshAt < BACKGROUND_REFRESH_INTERVAL_MS) return;
+
+      backgroundRefreshTimestamps.set(path, now);
+      fetchPageDataDeduped(path).catch((error) => {
+        logBackgroundFetchFailure('Stale page data refresh', path, error);
+      });
+    }
+
     async function fetchPageDataForNavigation(path, signal) {
       const cached = getCachedPageData(path);
       if (cached) {
         log('Using cached page data:', path);
-        fetchPageDataFresh(path, null).catch((error) => {
-          logBackgroundFetchFailure('Stale page data refresh', path, error);
-        });
+        refreshPageDataInBackground(path);
         return cached;
       }
 
@@ -306,7 +333,7 @@ export const getRouterScript = () => `
 
     async function fetchPageDataForPrefetch(path) {
       if (getCachedPageData(path)) return;
-      return fetchPageDataFresh(path, null)
+      return fetchPageDataDeduped(path)
         .then((data) => preloadModulesForPageData(data, path))
         .catch((error) => {
           logBackgroundFetchFailure('Page data prefetch', path, error);

--- a/src/proxy/cache/tracing-cache.test.ts
+++ b/src/proxy/cache/tracing-cache.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert";
+import { assertEquals, assertExists } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import { TracingTokenCache } from "./tracing-cache.ts";
 import type { CacheStats, TokenCache, TokenCacheEntry } from "./types.ts";
@@ -73,9 +73,11 @@ describe("TracingTokenCache", () => {
     await traced.set("k2", entry);
 
     assertEquals(fake.calls.length, 1);
-    assertEquals(fake.calls[0].method, "set");
-    assertEquals(fake.calls[0].args[0], "k2");
-    assertEquals(fake.calls[0].args[1], entry);
+    const call = fake.calls[0];
+    assertExists(call);
+    assertEquals(call.method, "set");
+    assertEquals(call.args[0], "k2");
+    assertEquals(call.args[1], entry);
   });
 
   it("delegates delete()", async () => {

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -302,6 +302,53 @@ describe("Proxy Handler", () => {
       }
     });
 
+    it("reuses successful custom domain project lookups across requests", async () => {
+      let projectLookups = 0;
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") return createTokenResponse();
+
+        if (pathname.startsWith("/projects/")) {
+          projectLookups++;
+          return Response.json({
+            id: "proj-123",
+            slug: "my-project",
+            name: "My Project",
+            environments: [{
+              id: "env-1",
+              name: "production",
+              domains: ["example.com"],
+              active_release_id: "rel-123",
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+        const req = () =>
+          new Request("http://example.com/page", {
+            headers: { host: "example.com" },
+          });
+
+        const first = await handler.processRequest(req());
+        const second = await handler.processRequest(req());
+
+        assertEquals(first.error, undefined);
+        assertEquals(second.error, undefined);
+        assertEquals(first.projectSlug, "my-project");
+        assertEquals(second.projectSlug, "my-project");
+        assertEquals(projectLookups, 1);
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
     it("returns 404 error when custom domain not found", async () => {
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);
@@ -755,6 +802,62 @@ describe("Proxy Handler", () => {
         assertEquals(ctx.error, undefined);
         assertEquals(ctx.projectSlug, "protected-project");
         assertEquals(ctx.releaseId, "rel-123");
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
+    it("rechecks protected custom domain access when project metadata is cached", async () => {
+      const memberToken = await signTestJwt({ userId: "user-123", sub: "user-123" });
+      let projectLookups = 0;
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") return createTokenResponse();
+
+        if (pathname.startsWith("/projects/")) {
+          projectLookups++;
+          return Response.json({
+            id: "proj-123",
+            slug: "protected-project",
+            name: "Protected Project",
+            users: [{ id: "user-123" }],
+            environments: [{
+              id: "env-1",
+              name: "production",
+              domains: ["protected.example.com"],
+              active_release_id: "rel-123",
+              protected: true,
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+
+        const allowed = await handler.processRequest(
+          new Request("http://protected.example.com/page", {
+            headers: {
+              host: "protected.example.com",
+              cookie: `authToken=${memberToken}`,
+            },
+          }),
+        );
+        const redirected = await handler.processRequest(
+          new Request("http://protected.example.com/page", {
+            headers: { host: "protected.example.com" },
+          }),
+        );
+
+        assertEquals(allowed.error, undefined);
+        assertEquals(redirected.error?.status, 302);
+        assertEquals(redirected.error?.message, "Authentication required");
+        assertEquals(projectLookups, 1);
 
         await handler.close();
       } finally {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -7,6 +7,7 @@ import { checkProtectedProxyAccess } from "./proxy-access-control.ts";
 import { createLocalProjectResolver } from "./local-project-resolver.ts";
 import {
   isMissingCustomDomainProjectError,
+  type ResolvedProxyRequestToken,
   resolveProxyRequestToken,
 } from "./proxy-token-resolution.ts";
 import {
@@ -14,6 +15,12 @@ import {
   createProxyErrorContext,
   createReleaseNotFoundProxyContext,
 } from "./proxy-error-context.ts";
+import {
+  markProxyServerTimingPhase,
+  profileProxyServerTimingPhase,
+  type ProxyServerTiming,
+} from "./server-timing.ts";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 export { __resetCachedAuthProviderForTests } from "./proxy-access-control.ts";
 
@@ -35,6 +42,9 @@ const INTERNAL_CONTROL_PLANE_SIGNATURE_HEADERS = [
   "x-veryfront-control-plane-jws",
   "x-veryfront-dispatch-jws",
 ] as const;
+
+const DEFAULT_PROJECT_LOOKUP_CACHE_TTL_MS = 30_000;
+const DEFAULT_PROJECT_LOOKUP_CACHE_MAX_ENTRIES = 1_000;
 
 function isInternalControlPlanePath(pathname: string): boolean {
   return pathname === "/channels/invoke" ||
@@ -181,6 +191,12 @@ export interface ProxyHandlerOptions {
 
 export interface ProxyRequestOptions {
   url?: URL;
+  timing?: ProxyServerTiming;
+}
+
+interface ProjectLookupCacheEntry {
+  value: DomainLookupResult;
+  expiresAt: number;
 }
 
 function getRequestHost(req: Request, url: URL): string {
@@ -197,10 +213,33 @@ function parseStatusFromError(error: unknown): number | null {
   return match ? Number(match[1]) : null;
 }
 
+function readPositiveIntegerEnv(name: string, fallback: number): number {
+  const raw = getEnv(name);
+  if (!raw) return fallback;
+
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0) return fallback;
+  return Math.floor(value);
+}
+
+function normalizeProjectLookupCacheKey(lookupKey: string): string {
+  return lookupKey.toLowerCase().replace(/:\d+$/, "");
+}
+
 export function createProxyHandler(options: ProxyHandlerOptions) {
   const { config, cache, logger } = options;
   const localProjects = config.localProjects ?? {};
   const localProjectResolver = createLocalProjectResolver({ localProjects, logger });
+  const projectLookupCacheTtlMs = readPositiveIntegerEnv(
+    "VERYFRONT_PROXY_PROJECT_LOOKUP_CACHE_TTL_MS",
+    DEFAULT_PROJECT_LOOKUP_CACHE_TTL_MS,
+  );
+  const projectLookupCacheMaxEntries = readPositiveIntegerEnv(
+    "VERYFRONT_PROXY_PROJECT_LOOKUP_CACHE_MAX_ENTRIES",
+    DEFAULT_PROJECT_LOOKUP_CACHE_MAX_ENTRIES,
+  );
+  const projectLookupCache = new Map<string, ProjectLookupCacheEntry>();
+  const pendingProjectLookups = new Map<string, Promise<DomainLookupResult | null>>();
 
   const tokenManager = new TokenManager(
     {
@@ -212,6 +251,79 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     },
     { cache },
   );
+
+  function canCacheProjectLookup(tokenSource: ResolvedProxyRequestToken["tokenSource"]): boolean {
+    return projectLookupCacheTtlMs > 0 &&
+      projectLookupCacheMaxEntries > 0 &&
+      (tokenSource === "service" || tokenSource === "static");
+  }
+
+  function getCachedProjectLookup(cacheKey: string): DomainLookupResult | null {
+    const entry = projectLookupCache.get(cacheKey);
+    if (!entry) return null;
+
+    if (Date.now() > entry.expiresAt) {
+      projectLookupCache.delete(cacheKey);
+      return null;
+    }
+
+    projectLookupCache.delete(cacheKey);
+    projectLookupCache.set(cacheKey, entry);
+    return entry.value;
+  }
+
+  function setCachedProjectLookup(cacheKey: string, value: DomainLookupResult): void {
+    if (
+      projectLookupCache.size >= projectLookupCacheMaxEntries && !projectLookupCache.has(cacheKey)
+    ) {
+      const oldestKey = projectLookupCache.keys().next().value;
+      if (oldestKey !== undefined) projectLookupCache.delete(oldestKey);
+    }
+
+    projectLookupCache.set(cacheKey, {
+      value,
+      expiresAt: Date.now() + projectLookupCacheTtlMs,
+    });
+  }
+
+  async function resolveProjectLookup(
+    lookupKey: string,
+    token: string,
+    cacheable: boolean,
+    timing?: ProxyServerTiming,
+  ): Promise<DomainLookupResult | null> {
+    const cacheKey = normalizeProjectLookupCacheKey(lookupKey);
+    if (cacheable) {
+      const cached = getCachedProjectLookup(cacheKey);
+      if (cached) {
+        if (timing) markProxyServerTimingPhase(timing, "proxy.project_lookup_cache_hit");
+        return cached;
+      }
+
+      const pending = pendingProjectLookups.get(cacheKey);
+      if (pending) {
+        if (timing) markProxyServerTimingPhase(timing, "proxy.project_lookup_pending");
+        return await pending;
+      }
+    }
+
+    const lookupPromise = profileProxyServerTimingPhase(
+      timing ?? { enabled: false, startedAt: 0, phases: new Map() },
+      "proxy.project_lookup",
+      () => lookupProjectByDomain(lookupKey, config.apiBaseUrl, token, logger),
+    );
+
+    if (!cacheable) return await lookupPromise;
+
+    pendingProjectLookups.set(cacheKey, lookupPromise);
+    try {
+      const result = await lookupPromise;
+      if (result) setCachedProjectLookup(cacheKey, result);
+      return result;
+    } finally {
+      pendingProjectLookups.delete(cacheKey);
+    }
+  }
 
   function validateConfig(): string[] {
     const missing: string[] = [];
@@ -227,12 +339,14 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     userToken: string | undefined,
     lookupKey: string,
     envMatcher: (env: NonNullable<DomainLookupResult["environments"]>[number]) => boolean,
+    cacheableLookup: boolean,
+    timing: ProxyServerTiming | undefined,
     logContext: Record<string, unknown>,
   ): Promise<
     | { projectId?: string; releaseId?: string; environmentId?: string }
     | { error: { status: number; message: string; redirectUrl?: string } }
   > {
-    const lookupResult = await lookupProjectByDomain(lookupKey, config.apiBaseUrl, token, logger);
+    const lookupResult = await resolveProjectLookup(lookupKey, token, cacheableLookup, timing);
     if (!lookupResult) return { projectId: undefined, releaseId: undefined };
 
     const matchingEnv = lookupResult.environments?.find(envMatcher);
@@ -302,12 +416,13 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
     let userToken: string | undefined;
     let token: string | undefined;
+    let tokenSource: ResolvedProxyRequestToken["tokenSource"];
     let tokenFetchError: unknown;
 
     if (isLocalProject) {
       logger?.debug("Local project, skipping token fetch", { localPath });
     } else {
-      ({ token, userToken, tokenFetchError } = await resolveProxyRequestToken(
+      ({ token, tokenSource, userToken, tokenFetchError } = await resolveProxyRequestToken(
         {
           req,
           url,
@@ -322,6 +437,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
           tokenFetchErrorMessage: "Token fetch failed",
         },
       ));
+      const cacheableProjectLookup = canCacheProjectLookup(tokenSource);
 
       if (projectSlug && !token) {
         const status = parseStatusFromError(tokenFetchError);
@@ -369,7 +485,12 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
           });
         }
 
-        const lookupResult = await lookupProjectByDomain(host, config.apiBaseUrl, token, logger);
+        const lookupResult = await resolveProjectLookup(
+          host,
+          token,
+          cacheableProjectLookup,
+          options.timing,
+        );
         if (!lookupResult) {
           logger?.info("Custom domain not found", { domain: host });
           return createProxyErrorContext(base, {
@@ -427,6 +548,8 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
           userToken,
           projectSlug,
           (env) => env.name.toLowerCase() === targetEnv,
+          cacheableProjectLookup,
+          options.timing,
           { projectSlug },
         );
 
@@ -470,6 +593,8 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
           userToken,
           projectSlug,
           (env) => env.name.toLowerCase() === "preview",
+          cacheableProjectLookup,
+          options.timing,
           { projectSlug },
         );
 

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -303,7 +303,7 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
       const ctx = await profileProxyServerTimingPhase(
         proxyTiming,
         "proxy.resolve_request",
-        () => proxyHandler.processRequest(req, { url }),
+        () => proxyHandler.processRequest(req, { url, timing: proxyTiming }),
       );
 
       return runWithProxyRequestContext(

--- a/src/proxy/proxy-token-resolution.ts
+++ b/src/proxy/proxy-token-resolution.ts
@@ -37,6 +37,7 @@ export interface ResolveProxyRequestTokenOptions {
 
 export interface ResolvedProxyRequestToken {
   token?: string;
+  tokenSource?: "signed-internal" | "user" | "service" | "static";
   userToken?: string;
   tokenFetchError?: unknown;
 }
@@ -72,16 +73,19 @@ export async function resolveProxyRequestToken(
     options.signedInternalControlPlaneRequest;
 
   let token: string | undefined;
+  let tokenSource: ResolvedProxyRequestToken["tokenSource"];
   let tokenFetchError: unknown;
 
   if (useSignedInternalControlPlaneToken) {
     token = req.headers.get("x-token") ?? undefined;
+    if (token) tokenSource = "signed-internal";
     logger?.debug("Using signed control-plane token for internal request", {
       pathname: url.pathname,
       scope,
     });
   } else if (scope === "preview" && userToken) {
     token = userToken;
+    tokenSource = "user";
     logger?.debug("Using user auth token for preview");
   }
 
@@ -90,6 +94,7 @@ export async function resolveProxyRequestToken(
     if (projectSlug || customDomain) {
       try {
         token = await tokenManager.getToken(scope, projectSlug, customDomain);
+        tokenSource = "service";
       } catch (error) {
         tokenFetchError = error;
         if (!(customDomain && isMissingCustomDomainProjectError(error))) {
@@ -104,8 +109,9 @@ export async function resolveProxyRequestToken(
 
   if (!token && config.apiToken) {
     token = config.apiToken;
+    tokenSource = "static";
     logger?.debug("Using static API token fallback");
   }
 
-  return { token, userToken, tokenFetchError };
+  return { token, tokenSource, userToken, tokenFetchError };
 }

--- a/src/security/http/response/cache-handler.test.ts
+++ b/src/security/http/response/cache-handler.test.ts
@@ -85,6 +85,13 @@ describe("security/http/response/cache-handler", () => {
         );
       });
 
+      it("should include stale-while-revalidate when configured", () => {
+        assertEquals(
+          buildCacheControl({ maxAge: 60, staleWhileRevalidate: 1800 }),
+          "public, max-age=60, stale-while-revalidate=1800",
+        );
+      });
+
       it("should combine all flags", () => {
         const result = buildCacheControl({
           maxAge: 3600,

--- a/src/security/http/response/cache-handler.ts
+++ b/src/security/http/response/cache-handler.ts
@@ -30,5 +30,9 @@ export function buildCacheControl(strategy: CacheStrategy): string {
     parts.push("must-revalidate");
   }
 
+  if (typeof strategy.staleWhileRevalidate === "number") {
+    parts.push(`stale-while-revalidate=${strategy.staleWhileRevalidate}`);
+  }
+
   return parts.join(", ");
 }

--- a/src/security/http/response/types.ts
+++ b/src/security/http/response/types.ts
@@ -21,6 +21,7 @@ export type CacheStrategy =
     public?: boolean;
     immutable?: boolean;
     mustRevalidate?: boolean;
+    staleWhileRevalidate?: number;
   };
 
 export interface ResponseBuilderConfig {

--- a/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
@@ -16,6 +16,8 @@ import {
   handlePageDataEndpoint,
 } from "./page-data-endpoint-handler.ts";
 
+type PageDataEndpointHandler = typeof handlePageDataEndpoint;
+
 function createMockAdapter(): RuntimeAdapter {
   return {
     id: "memory",
@@ -92,11 +94,31 @@ function createInitializer(resolvePageData: Renderer["resolvePageData"]): Render
   };
 }
 
+async function withMockedNow<T>(
+  initialNow: number,
+  fn: (clock: { advance: (ms: number) => void }) => Promise<T>,
+): Promise<T> {
+  const originalNow = Date.now;
+  let now = initialNow;
+  Date.now = () => now;
+
+  try {
+    return await fn({
+      advance(ms: number) {
+        now += ms;
+      },
+    });
+  } finally {
+    Date.now = originalNow;
+  }
+}
+
 async function callPageDataEndpoint(
   req: Request,
   ctx: HandlerContext,
+  handler: PageDataEndpointHandler = handlePageDataEndpoint,
 ): Promise<Response> {
-  const result = await handlePageDataEndpoint(
+  const result = await handler(
     req,
     new URL(req.url).pathname,
     ctx,
@@ -106,6 +128,14 @@ async function callPageDataEndpoint(
   );
 
   return result.response!;
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    Deno.env.delete(name);
+  } else {
+    Deno.env.set(name, value);
+  }
 }
 
 describe("server/handlers/request/module/page-data-endpoint-handler", () => {
@@ -181,5 +211,88 @@ describe("server/handlers/request/module/page-data-endpoint-handler", () => {
 
     assertEquals(calls, 2);
     assertEquals(first.headers.get("cache-control"), "no-cache, no-store, must-revalidate");
+  });
+
+  it("can disable the page-data cache with max entries set to zero", async () => {
+    const envName = "VERYFRONT_PAGE_DATA_CACHE_MAX_ENTRIES";
+    const originalMaxEntries = Deno.env.get(envName);
+    Deno.env.set(envName, "0");
+
+    try {
+      const module = await import(
+        `./page-data-endpoint-handler.ts?cache-disabled=${Date.now()}`
+      );
+
+      let calls = 0;
+      setRendererInitializer(
+        createInitializer((slug) => Promise.resolve(createPageData(slug, ++calls))),
+      );
+
+      const ctx = makeCtx();
+      const req = () => new Request("http://localhost/_veryfront/page-data/index.json");
+
+      const first = await callPageDataEndpoint(req(), ctx, module.handlePageDataEndpoint);
+      const second = await callPageDataEndpoint(req(), ctx, module.handlePageDataEndpoint);
+
+      assertEquals(first.status, 200);
+      assertEquals(second.status, 200);
+      assertEquals(calls, 2);
+      assertEquals(first.headers.get("cache-control"), "no-cache, no-store, must-revalidate");
+      module.__clearPageDataEndpointCacheForTests();
+    } finally {
+      restoreEnv(envName, originalMaxEntries);
+    }
+  });
+
+  it("serves stale anonymous page data while refreshing the cache", async () => {
+    let calls = 0;
+    setRendererInitializer(
+      createInitializer((slug) => Promise.resolve(createPageData(slug, ++calls))),
+    );
+
+    await withMockedNow(1_000_000, async (clock) => {
+      const ctx = makeCtx();
+      const req = () => new Request("http://localhost/_veryfront/page-data/index.json");
+
+      const first = await callPageDataEndpoint(req(), ctx);
+      clock.advance(60_001);
+      const second = await callPageDataEndpoint(req(), ctx);
+      await Promise.resolve();
+      const third = await callPageDataEndpoint(req(), ctx);
+
+      assertEquals(JSON.parse(await first.text()).frontmatter.sequence, 1);
+      assertEquals(JSON.parse(await second.text()).frontmatter.sequence, 1);
+      assertEquals(JSON.parse(await third.text()).frontmatter.sequence, 2);
+      assertEquals(calls, 2);
+      assertEquals(
+        first.headers.get("cache-control"),
+        "public, max-age=60, stale-while-revalidate=1800",
+      );
+    });
+  });
+
+  it("does not serve stale page data for preview branch content", async () => {
+    let calls = 0;
+    setRendererInitializer(
+      createInitializer((slug) => Promise.resolve(createPageData(slug, ++calls))),
+    );
+
+    await withMockedNow(1_000_000, async (clock) => {
+      const ctx = makeCtx({
+        releaseId: undefined,
+        resolvedEnvironment: "preview",
+        requestContext: { mode: "preview", branch: "main" } as HandlerContext["requestContext"],
+      });
+      const req = () => new Request("http://localhost/_veryfront/page-data/index.json");
+
+      const first = await callPageDataEndpoint(req(), ctx);
+      clock.advance(60_001);
+      const second = await callPageDataEndpoint(req(), ctx);
+
+      assertEquals(JSON.parse(await first.text()).frontmatter.sequence, 1);
+      assertEquals(JSON.parse(await second.text()).frontmatter.sequence, 2);
+      assertEquals(calls, 2);
+      assertEquals(first.headers.get("cache-control"), "public, max-age=60");
+    });
   });
 });

--- a/src/server/handlers/request/module/page-data-endpoint-handler.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.ts
@@ -10,19 +10,69 @@ import { serverLogger } from "#veryfront/utils";
 import { Singleflight } from "#veryfront/utils/singleflight.ts";
 import { requestHasCacheSensitiveState } from "#veryfront/cache/request-cacheability.ts";
 import type { PageDataResponse } from "#veryfront/rendering/orchestrator/types.ts";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 const PAGE_DATA_TIMEOUT_MS = 25_000;
-const PAGE_DATA_CACHE_TTL_MS = 60_000;
-const PAGE_DATA_CACHE_MAX_ENTRIES = 500;
+const PAGE_DATA_CACHE_TTL_MS = readPositiveIntegerEnv("VERYFRONT_PAGE_DATA_CACHE_TTL_MS", 60_000);
+const PAGE_DATA_CACHE_STALE_MS = readPositiveIntegerEnv(
+  "VERYFRONT_PAGE_DATA_CACHE_STALE_MS",
+  30 * 60_000,
+);
+const PAGE_DATA_CACHE_MAX_ENTRIES = readPositiveIntegerEnv(
+  "VERYFRONT_PAGE_DATA_CACHE_MAX_ENTRIES",
+  500,
+);
+const PAGE_DATA_CACHE_MAX_AGE_SECONDS = Math.max(0, Math.floor(PAGE_DATA_CACHE_TTL_MS / 1000));
+const PAGE_DATA_CACHE_STALE_SECONDS = Math.max(0, Math.floor(PAGE_DATA_CACHE_STALE_MS / 1000));
+
+interface PageDataCachePolicy {
+  ttlMs: number;
+  staleMs: number;
+  maxAgeSeconds: number;
+  staleSeconds: number;
+}
 
 interface PageDataCacheEntry {
   body: string;
   etag: string;
   expiresAt: number;
+  staleUntil: number;
 }
 
 const pageDataCache = new Map<string, PageDataCacheEntry>();
 const pageDataFlight = new Singleflight<PageDataCacheEntry>();
+
+const RELEASE_PAGE_DATA_CACHE_POLICY: PageDataCachePolicy = {
+  ttlMs: PAGE_DATA_CACHE_TTL_MS,
+  staleMs: PAGE_DATA_CACHE_STALE_MS,
+  maxAgeSeconds: PAGE_DATA_CACHE_MAX_AGE_SECONDS,
+  staleSeconds: PAGE_DATA_CACHE_STALE_SECONDS,
+};
+
+function readPositiveIntegerEnv(name: string, fallback: number): number {
+  const raw = getEnv(name);
+  if (!raw) return fallback;
+
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0) return fallback;
+  return Math.floor(value);
+}
+
+function getPageDataCachePolicy(ctx: HandlerContext): PageDataCachePolicy {
+  const environment = ctx.resolvedEnvironment ?? ctx.requestContext?.mode ?? "preview";
+  const isReleaseBackedProduction = environment === "production" && !!ctx.releaseId;
+  if (isReleaseBackedProduction) return RELEASE_PAGE_DATA_CACHE_POLICY;
+
+  return {
+    ...RELEASE_PAGE_DATA_CACHE_POLICY,
+    staleMs: 0,
+    staleSeconds: 0,
+  };
+}
+
+function isPageDataCacheEnabled(): boolean {
+  return PAGE_DATA_CACHE_MAX_ENTRIES > 0;
+}
 
 export function __clearPageDataEndpointCacheForTests(): void {
   pageDataCache.clear();
@@ -46,9 +96,10 @@ export function handlePageDataEndpoint(
 
         const url = new URL(req.url);
         const renderer = await getRendererForProject(ctx);
-        const cacheKey = requestHasCacheSensitiveState(req)
+        const cacheKey = !isPageDataCacheEnabled() || requestHasCacheSensitiveState(req)
           ? null
           : buildPageDataCacheKey(ctx, slug, url);
+        const cachePolicy = cacheKey ? getPageDataCachePolicy(ctx) : null;
 
         const payload = cacheKey
           ? await resolveCachedPageData(cacheKey, () =>
@@ -56,7 +107,7 @@ export function handlePageDataEndpoint(
               renderer.resolvePageData(slug, { request: req, url }),
               PAGE_DATA_TIMEOUT_MS,
               `resolvePageData for ${slug}`,
-            ))
+            ), cachePolicy!)
           : await resolveUncachedPageData(() =>
             withTimeoutThrow(
               renderer.resolvePageData(slug, { request: req, url }),
@@ -64,7 +115,15 @@ export function handlePageDataEndpoint(
               `resolvePageData for ${slug}`,
             )
           );
-        const cacheStrategy = cacheKey ? { maxAge: 60, public: true } : "no-cache";
+        const cacheStrategy = cacheKey
+          ? {
+            maxAge: cachePolicy!.maxAgeSeconds,
+            public: true,
+            ...(cachePolicy!.staleSeconds > 0
+              ? { staleWhileRevalidate: cachePolicy!.staleSeconds }
+              : {}),
+          }
+          : "no-cache";
 
         const builder = createResponseBuilder(ctx).withCORS(
           req,
@@ -140,22 +199,35 @@ export function handlePageDataEndpoint(
 async function resolveCachedPageData(
   cacheKey: string,
   resolve: () => Promise<PageDataResponse>,
+  cachePolicy: PageDataCachePolicy,
 ): Promise<PageDataCacheEntry> {
   const cached = getCachedPageData(cacheKey);
-  if (cached) {
+  if (cached?.state === "fresh") {
     markRequestProfilePhase("page_data.cache_hit");
-    return cached;
+    return cached.entry;
+  }
+
+  if (cached?.state === "stale") {
+    markRequestProfilePhase("page_data.cache_stale");
+    refreshStalePageData(cacheKey, resolve, cachePolicy);
+    return cached.entry;
   }
 
   markRequestProfilePhase("page_data.cache_miss");
   return await pageDataFlight.do(cacheKey, async () => {
     const concurrentCached = getCachedPageData(cacheKey);
-    if (concurrentCached) {
+    if (concurrentCached?.state === "fresh") {
       markRequestProfilePhase("page_data.cache_hit_after_wait");
-      return concurrentCached;
+      return concurrentCached.entry;
     }
 
-    const payload = await resolveUncachedPageData(resolve);
+    if (concurrentCached?.state === "stale") {
+      markRequestProfilePhase("page_data.cache_stale_after_wait");
+      refreshStalePageData(cacheKey, resolve, cachePolicy);
+      return concurrentCached.entry;
+    }
+
+    const payload = await resolveUncachedPageData(resolve, cachePolicy);
     setCachedPageData(cacheKey, payload);
     return payload;
   });
@@ -163,6 +235,7 @@ async function resolveCachedPageData(
 
 async function resolveUncachedPageData(
   resolve: () => Promise<PageDataResponse>,
+  cachePolicy = RELEASE_PAGE_DATA_CACHE_POLICY,
 ): Promise<PageDataCacheEntry> {
   const startedAt = performance.now();
   const pageData = await resolve();
@@ -176,15 +249,29 @@ async function resolveUncachedPageData(
   return {
     body,
     etag,
-    expiresAt: Date.now() + PAGE_DATA_CACHE_TTL_MS,
+    expiresAt: Date.now() + cachePolicy.ttlMs,
+    staleUntil: Date.now() + cachePolicy.ttlMs + cachePolicy.staleMs,
   };
 }
 
-function getCachedPageData(cacheKey: string): PageDataCacheEntry | null {
+function getCachedPageData(
+  cacheKey: string,
+): { entry: PageDataCacheEntry; state: "fresh" | "stale" } | null {
   const entry = pageDataCache.get(cacheKey);
   if (!entry) return null;
 
-  if (Date.now() <= entry.expiresAt) return entry;
+  const now = Date.now();
+  if (now <= entry.expiresAt) {
+    pageDataCache.delete(cacheKey);
+    pageDataCache.set(cacheKey, entry);
+    return { entry, state: "fresh" };
+  }
+
+  if (now <= entry.staleUntil) {
+    pageDataCache.delete(cacheKey);
+    pageDataCache.set(cacheKey, entry);
+    return { entry, state: "stale" };
+  }
 
   pageDataCache.delete(cacheKey);
   markRequestProfilePhase("page_data.cache_expired");
@@ -192,12 +279,39 @@ function getCachedPageData(cacheKey: string): PageDataCacheEntry | null {
 }
 
 function setCachedPageData(cacheKey: string, entry: PageDataCacheEntry): void {
+  if (!isPageDataCacheEnabled()) return;
+
   if (pageDataCache.size >= PAGE_DATA_CACHE_MAX_ENTRIES && !pageDataCache.has(cacheKey)) {
     const oldestKey = pageDataCache.keys().next().value;
     if (oldestKey) pageDataCache.delete(oldestKey);
   }
 
   pageDataCache.set(cacheKey, entry);
+}
+
+function refreshStalePageData(
+  cacheKey: string,
+  resolve: () => Promise<PageDataResponse>,
+  cachePolicy: PageDataCachePolicy,
+): void {
+  void pageDataFlight.do(cacheKey, async () => {
+    const payload = await resolveUncachedPageData(resolve, cachePolicy);
+    setCachedPageData(cacheKey, payload);
+    return payload;
+  }).then(
+    () => {
+      markRequestProfilePhase("page_data.refresh_background");
+    },
+    (error) => {
+      serverLogger.warn("[page-data] Background refresh failed", {
+        detail: error instanceof Error ? error.message : String(error),
+      });
+      const stale = pageDataCache.get(cacheKey);
+      if (stale && Date.now() > stale.staleUntil) {
+        pageDataCache.delete(cacheKey);
+      }
+    },
+  );
 }
 
 function buildPageDataCacheKey(ctx: HandlerContext, slug: string, url: URL): string {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.815";
+export const VERSION = "0.1.816";


### PR DESCRIPTION
## Summary
- Cache service/static-token project metadata lookups briefly in the proxy, with per-handler bounds, singleflight, server-timing phases, and no cached protected-access decisions.
- Serve release-backed production page data stale while refreshing, keep preview branch page data fresh-only, and add a deterministic cache-disable path.
- Deduplicate and throttle client router page-data refreshes so cached navigation does not start a fetch on every click.
- Bump the framework release version to `0.1.816` so the merged change can publish a new veryfront-code release.

## Validation
- [x] `deno test --allow-all src/proxy`
- [x] `deno test --allow-all src/proxy/handler.test.ts src/server/handlers/request/module/page-data-endpoint-handler.test.ts src/html/hydration-script-builder/templates/router.test.ts src/security/http/response/cache-handler.test.ts src/proxy/cache/tracing-cache.test.ts`
- [x] `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --parallel --unstable-worker-options '--ignore=tests,src/workflow/__tests__,cli/commands/*.integration.test.ts'`\n- [x] `deno test --allow-all src/utils/version.test.ts`\n- [x] pre-push hook: full format, lint, typecheck, generation, and unit tests (`2167 passed`, `0 failed`)\n- [x] `git diff --check`\n\n## Release checks\n- [x] `0.1.816` has no source repo tag.\n- [x] `0.1.816` has no GitHub release in `veryfront/veryfront-code` or `veryfront/veryfront`.\n- [x] `npm view veryfront@0.1.816 version` returns 404, so the npm version is unpublished.\n\n## Rollout notes\n- After merge, follow the `veryfront-code` release for `0.1.816`.\n- Then update/deploy `veryfront-server`, keep the cache env knobs in Helm values, and compare Server-Timing between pod/internal and browser paths.