### PR TITLE
Keep protected proxy metadata fresh

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.816",
+  "version": "0.1.817",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/architecture/02-request-pipeline.md
+++ b/docs/architecture/02-request-pipeline.md
@@ -73,20 +73,11 @@ flowchart TD
 
 ## Runtime caches
 
-The split proxy caches successful project metadata lookups for service and
-static-token requests. The cache is per proxy handler, bounded, and short lived.
-It does not cache lookup misses, preview user-token lookups, signed internal
-request lookups, or protected-access decisions. Protected environments still run
-their access check on every request.
-
-Default proxy lookup cache controls:
-
-| Environment variable                               | Default |
-| -------------------------------------------------- | ------- |
-| `VERYFRONT_PROXY_PROJECT_LOOKUP_CACHE_TTL_MS`      | `30000` |
-| `VERYFRONT_PROXY_PROJECT_LOOKUP_CACHE_MAX_ENTRIES` | `1000`  |
-
-Set either value to `0` to disable the proxy project lookup cache.
+Project metadata lookups are not cached in the proxy. The current lookup
+response carries both routing data and access-control state (`protected`
+environment flags and project members), so caching it can authorize with stale
+metadata after protection or membership changes. Add a routing-only control
+plane contract before introducing a proxy lookup cache.
 
 Release-backed production page-data requests use a fresh cache window plus a
 bounded stale-while-revalidate window. The cache key includes the project,

--- a/docs/architecture/13-observability.md
+++ b/docs/architecture/13-observability.md
@@ -35,8 +35,6 @@ proxy also appends proxy-prefixed phases:
 - `proxy.total`: time from proxy request receipt to response header return.
 - `proxy.resolve_request`: project, token, domain, and access resolution.
 - `proxy.project_lookup`: project metadata lookup fetch time.
-- `proxy.project_lookup_cache_hit`: project metadata cache hit marker.
-- `proxy.project_lookup_pending`: project metadata lookup singleflight marker.
 - `proxy.resolve_server`: dedicated renderer server lookup.
 - `proxy.retry_delay`: retry backoff time.
 - `proxy.upstream`: fetch time from proxy to renderer response headers.

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -302,7 +302,7 @@ describe("Proxy Handler", () => {
       }
     });
 
-    it("reuses successful custom domain project lookups across requests", async () => {
+    it("fetches custom domain project metadata on each request", async () => {
       let projectLookups = 0;
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);
@@ -341,7 +341,7 @@ describe("Proxy Handler", () => {
         assertEquals(second.error, undefined);
         assertEquals(first.projectSlug, "my-project");
         assertEquals(second.projectSlug, "my-project");
-        assertEquals(projectLookups, 1);
+        assertEquals(projectLookups, 2);
 
         await handler.close();
       } finally {
@@ -809,7 +809,54 @@ describe("Proxy Handler", () => {
       }
     });
 
-    it("rechecks protected custom domain access when project metadata is cached", async () => {
+    it("uses fresh custom domain protection metadata on each request", async () => {
+      let projectLookups = 0;
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") return createTokenResponse();
+
+        if (pathname.startsWith("/projects/")) {
+          projectLookups++;
+          return Response.json({
+            id: "proj-123",
+            slug: "protected-project",
+            name: "Protected Project",
+            environments: [{
+              id: "env-1",
+              name: "production",
+              domains: ["protected.example.com"],
+              active_release_id: "rel-123",
+              protected: projectLookups >= 2,
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+        const req = () =>
+          new Request("http://protected.example.com/page", {
+            headers: { host: "protected.example.com" },
+          });
+
+        const publicAccess = await handler.processRequest(req());
+        const protectedAccess = await handler.processRequest(req());
+
+        assertEquals(publicAccess.error, undefined);
+        assertEquals(protectedAccess.error?.status, 302);
+        assertEquals(protectedAccess.error?.message, "Authentication required");
+        assertEquals(projectLookups, 2);
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
+    it("uses fresh custom domain project membership on each request", async () => {
       const memberToken = await signTestJwt({ userId: "user-123", sub: "user-123" });
       let projectLookups = 0;
       const { server, port } = createMockServer((req: Request) => {
@@ -823,7 +870,7 @@ describe("Proxy Handler", () => {
             id: "proj-123",
             slug: "protected-project",
             name: "Protected Project",
-            users: [{ id: "user-123" }],
+            users: projectLookups === 1 ? [{ id: "user-123" }] : [],
             environments: [{
               id: "env-1",
               name: "production",
@@ -848,16 +895,19 @@ describe("Proxy Handler", () => {
             },
           }),
         );
-        const redirected = await handler.processRequest(
+        const rejected = await handler.processRequest(
           new Request("http://protected.example.com/page", {
-            headers: { host: "protected.example.com" },
+            headers: {
+              host: "protected.example.com",
+              cookie: `authToken=${memberToken}`,
+            },
           }),
         );
 
         assertEquals(allowed.error, undefined);
-        assertEquals(redirected.error?.status, 302);
-        assertEquals(redirected.error?.message, "Authentication required");
-        assertEquals(projectLookups, 1);
+        assertEquals(rejected.error?.status, 403);
+        assertEquals(rejected.error?.message, "Access denied");
+        assertEquals(projectLookups, 2);
 
         await handler.close();
       } finally {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -7,7 +7,6 @@ import { checkProtectedProxyAccess } from "./proxy-access-control.ts";
 import { createLocalProjectResolver } from "./local-project-resolver.ts";
 import {
   isMissingCustomDomainProjectError,
-  type ResolvedProxyRequestToken,
   resolveProxyRequestToken,
 } from "./proxy-token-resolution.ts";
 import {
@@ -15,12 +14,7 @@ import {
   createProxyErrorContext,
   createReleaseNotFoundProxyContext,
 } from "./proxy-error-context.ts";
-import {
-  markProxyServerTimingPhase,
-  profileProxyServerTimingPhase,
-  type ProxyServerTiming,
-} from "./server-timing.ts";
-import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { profileProxyServerTimingPhase, type ProxyServerTiming } from "./server-timing.ts";
 
 export { __resetCachedAuthProviderForTests } from "./proxy-access-control.ts";
 
@@ -42,9 +36,6 @@ const INTERNAL_CONTROL_PLANE_SIGNATURE_HEADERS = [
   "x-veryfront-control-plane-jws",
   "x-veryfront-dispatch-jws",
 ] as const;
-
-const DEFAULT_PROJECT_LOOKUP_CACHE_TTL_MS = 30_000;
-const DEFAULT_PROJECT_LOOKUP_CACHE_MAX_ENTRIES = 1_000;
 
 function isInternalControlPlanePath(pathname: string): boolean {
   return pathname === "/channels/invoke" ||
@@ -194,11 +185,6 @@ export interface ProxyRequestOptions {
   timing?: ProxyServerTiming;
 }
 
-interface ProjectLookupCacheEntry {
-  value: DomainLookupResult;
-  expiresAt: number;
-}
-
 function getRequestHost(req: Request, url: URL): string {
   return req.headers.get("host") ?? url.host;
 }
@@ -213,33 +199,10 @@ function parseStatusFromError(error: unknown): number | null {
   return match ? Number(match[1]) : null;
 }
 
-function readPositiveIntegerEnv(name: string, fallback: number): number {
-  const raw = getEnv(name);
-  if (!raw) return fallback;
-
-  const value = Number(raw);
-  if (!Number.isFinite(value) || value < 0) return fallback;
-  return Math.floor(value);
-}
-
-function normalizeProjectLookupCacheKey(lookupKey: string): string {
-  return lookupKey.toLowerCase().replace(/:\d+$/, "");
-}
-
 export function createProxyHandler(options: ProxyHandlerOptions) {
   const { config, cache, logger } = options;
   const localProjects = config.localProjects ?? {};
   const localProjectResolver = createLocalProjectResolver({ localProjects, logger });
-  const projectLookupCacheTtlMs = readPositiveIntegerEnv(
-    "VERYFRONT_PROXY_PROJECT_LOOKUP_CACHE_TTL_MS",
-    DEFAULT_PROJECT_LOOKUP_CACHE_TTL_MS,
-  );
-  const projectLookupCacheMaxEntries = readPositiveIntegerEnv(
-    "VERYFRONT_PROXY_PROJECT_LOOKUP_CACHE_MAX_ENTRIES",
-    DEFAULT_PROJECT_LOOKUP_CACHE_MAX_ENTRIES,
-  );
-  const projectLookupCache = new Map<string, ProjectLookupCacheEntry>();
-  const pendingProjectLookups = new Map<string, Promise<DomainLookupResult | null>>();
 
   const tokenManager = new TokenManager(
     {
@@ -252,77 +215,16 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     { cache },
   );
 
-  function canCacheProjectLookup(tokenSource: ResolvedProxyRequestToken["tokenSource"]): boolean {
-    return projectLookupCacheTtlMs > 0 &&
-      projectLookupCacheMaxEntries > 0 &&
-      (tokenSource === "service" || tokenSource === "static");
-  }
-
-  function getCachedProjectLookup(cacheKey: string): DomainLookupResult | null {
-    const entry = projectLookupCache.get(cacheKey);
-    if (!entry) return null;
-
-    if (Date.now() > entry.expiresAt) {
-      projectLookupCache.delete(cacheKey);
-      return null;
-    }
-
-    projectLookupCache.delete(cacheKey);
-    projectLookupCache.set(cacheKey, entry);
-    return entry.value;
-  }
-
-  function setCachedProjectLookup(cacheKey: string, value: DomainLookupResult): void {
-    if (
-      projectLookupCache.size >= projectLookupCacheMaxEntries && !projectLookupCache.has(cacheKey)
-    ) {
-      const oldestKey = projectLookupCache.keys().next().value;
-      if (oldestKey !== undefined) projectLookupCache.delete(oldestKey);
-    }
-
-    projectLookupCache.set(cacheKey, {
-      value,
-      expiresAt: Date.now() + projectLookupCacheTtlMs,
-    });
-  }
-
   async function resolveProjectLookup(
     lookupKey: string,
     token: string,
-    cacheable: boolean,
     timing?: ProxyServerTiming,
   ): Promise<DomainLookupResult | null> {
-    const cacheKey = normalizeProjectLookupCacheKey(lookupKey);
-    if (cacheable) {
-      const cached = getCachedProjectLookup(cacheKey);
-      if (cached) {
-        if (timing) markProxyServerTimingPhase(timing, "proxy.project_lookup_cache_hit");
-        return cached;
-      }
-
-      const pending = pendingProjectLookups.get(cacheKey);
-      if (pending) {
-        if (timing) markProxyServerTimingPhase(timing, "proxy.project_lookup_pending");
-        return await pending;
-      }
-    }
-
-    const lookupPromise = profileProxyServerTimingPhase(
+    return await profileProxyServerTimingPhase(
       timing ?? { enabled: false, startedAt: 0, phases: new Map() },
       "proxy.project_lookup",
       () => lookupProjectByDomain(lookupKey, config.apiBaseUrl, token, logger),
     );
-
-    if (!cacheable) return await lookupPromise;
-
-    pendingProjectLookups.set(cacheKey, lookupPromise);
-    try {
-      const result = await lookupPromise;
-      if (result) setCachedProjectLookup(cacheKey, result);
-      return result;
-    } finally {
-      pendingProjectLookups.delete(cacheKey);
-    }
   }
 
   function validateConfig(): string[] {
@@ -339,14 +241,13 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     userToken: string | undefined,
     lookupKey: string,
     envMatcher: (env: NonNullable<DomainLookupResult["environments"]>[number]) => boolean,
-    cacheableLookup: boolean,
     timing: ProxyServerTiming | undefined,
     logContext: Record<string, unknown>,
   ): Promise<
     | { projectId?: string; releaseId?: string; environmentId?: string }
     | { error: { status: number; message: string; redirectUrl?: string } }
   > {
-    const lookupResult = await resolveProjectLookup(lookupKey, token, cacheableLookup, timing);
+    const lookupResult = await resolveProjectLookup(lookupKey, token, timing);
     if (!lookupResult) return { projectId: undefined, releaseId: undefined };
 
     const matchingEnv = lookupResult.environments?.find(envMatcher);
@@ -416,13 +317,12 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
     let userToken: string | undefined;
     let token: string | undefined;
-    let tokenSource: ResolvedProxyRequestToken["tokenSource"];
     let tokenFetchError: unknown;
 
     if (isLocalProject) {
       logger?.debug("Local project, skipping token fetch", { localPath });
     } else {
-      ({ token, tokenSource, userToken, tokenFetchError } = await resolveProxyRequestToken(
+      ({ token, userToken, tokenFetchError } = await resolveProxyRequestToken(
         {
           req,
           url,
@@ -437,7 +337,6 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
           tokenFetchErrorMessage: "Token fetch failed",
         },
       ));
-      const cacheableProjectLookup = canCacheProjectLookup(tokenSource);
 
       if (projectSlug && !token) {
         const status = parseStatusFromError(tokenFetchError);
@@ -488,7 +387,6 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
         const lookupResult = await resolveProjectLookup(
           host,
           token,
-          cacheableProjectLookup,
           options.timing,
         );
         if (!lookupResult) {
@@ -548,7 +446,6 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
           userToken,
           projectSlug,
           (env) => env.name.toLowerCase() === targetEnv,
-          cacheableProjectLookup,
           options.timing,
           { projectSlug },
         );
@@ -593,7 +490,6 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
           userToken,
           projectSlug,
           (env) => env.name.toLowerCase() === "preview",
-          cacheableProjectLookup,
           options.timing,
           { projectSlug },
         );

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.816";
+export const VERSION = "0.1.817";


### PR DESCRIPTION
## Summary

- removes the proxy project lookup cache because the current lookup response carries routing metadata together with protected environment flags and project members
- adds regressions for protection toggles and membership revocation across repeated custom-domain requests
- updates architecture and observability docs to remove the unsafe lookup-cache knobs and timing phases
- bumps `deno.json` and `src/utils/version-constant.ts` to `0.1.817`

Addresses https://github.com/veryfront/veryfront-code/pull/2470#discussion_r3419549108.

## Rationale

The cache added in #2470 reused `DomainLookupResult` for service/static-token proxy requests. That result currently includes access-control metadata, so caching it can authorize with stale state after an environment becomes protected or after a project member is removed. The stable fix is to keep this lookup fresh until the control plane exposes a routing-only contract that can be cached independently.

## Validation

- `deno test --allow-all src/proxy/handler.test.ts`
- `deno test --allow-all src/proxy src/utils/version.test.ts`
- `deno check src/proxy/handler.ts src/proxy/handler.test.ts src/utils/version.test.ts`
- `deno lint src/proxy/handler.ts src/proxy/handler.test.ts src/utils/version-constant.ts`
- `deno fmt --check deno.json src/proxy/handler.ts src/proxy/handler.test.ts src/utils/version-constant.ts docs/architecture/02-request-pipeline.md docs/architecture/13-observability.md`
- `git diff --check`
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --parallel --unstable-worker-options '--ignore=tests,src/workflow/__tests__,cli/commands/*.integration.test.ts'` (`2276 passed`, `0 failed`)
- pre-push hook: format, lint, typecheck, generation, unit tests (`2167 passed`, `0 failed`)
- verified `0.1.817` was not already present as a git tag, GitHub release, or npm package version

## Rollout

After merge, follow the `veryfront-code` release for `0.1.817`, then update and deploy `veryfront-server`. The previous page-data cache environment settings can still be kept where useful. The proxy project lookup cache environment settings from #2470 should not be configured because this PR removes that cache path.
