### PR TITLE
Suppress recovered rapid heap growth warnings

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.817",
+  "version": "0.1.818",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/memory/profiler.test.ts
+++ b/src/utils/memory/profiler.test.ts
@@ -7,8 +7,10 @@ import {
   forceGC,
   getCacheStats,
   getHeapStats,
+  getInitialRapidHeapGrowthState,
   getMemoryMonitoringLogContext,
   getMemorySnapshot,
+  getRapidHeapGrowthEvaluation,
   registerCache,
   setHeapWarningThreshold,
   startMemoryMonitoring,
@@ -133,6 +135,63 @@ describe("memory/profiler", () => {
   describe("forceGC", () => {
     it("should return a boolean", async () => {
       assertEquals(typeof (await forceGC()), "boolean");
+    });
+  });
+
+  describe("getRapidHeapGrowthEvaluation", () => {
+    it("seeds restart baselines from current heap so stable warm heaps do not warn", () => {
+      const initialState = getInitialRapidHeapGrowthState(153.01);
+
+      const flatSample = getRapidHeapGrowthEvaluation({
+        previousHeapUsedMB: initialState.lastHeapUsedMB,
+        currentHeapUsedMB: 153.01,
+        pending: initialState.pending,
+        thresholdMB: 100,
+      });
+
+      assertEquals(flatSample.shouldWarn, false);
+      assertEquals(flatSample.pending, undefined);
+    });
+
+    it("does not warn when a one-interval spike is reclaimed on the next sample", () => {
+      const first = getRapidHeapGrowthEvaluation({
+        previousHeapUsedMB: 99.16,
+        currentHeapUsedMB: 212.69,
+        pending: undefined,
+        thresholdMB: 100,
+      });
+
+      assertEquals(first.shouldWarn, false);
+      assertEquals(first.pending?.baselineHeapUsedMB, 99.16);
+
+      const settled = getRapidHeapGrowthEvaluation({
+        previousHeapUsedMB: 212.69,
+        currentHeapUsedMB: 153.01,
+        pending: first.pending,
+        thresholdMB: 100,
+      });
+
+      assertEquals(settled.shouldWarn, false);
+      assertEquals(settled.pending, undefined);
+    });
+
+    it("warns when rapid heap growth remains sustained after the next sample", () => {
+      const first = getRapidHeapGrowthEvaluation({
+        previousHeapUsedMB: 100,
+        currentHeapUsedMB: 225,
+        pending: undefined,
+        thresholdMB: 100,
+      });
+      const sustained = getRapidHeapGrowthEvaluation({
+        previousHeapUsedMB: 225,
+        currentHeapUsedMB: 235,
+        pending: first.pending,
+        thresholdMB: 100,
+      });
+
+      assertEquals(sustained.shouldWarn, true);
+      assertEquals(sustained.growthMB, 135);
+      assertEquals(sustained.pending, undefined);
     });
   });
 

--- a/src/utils/memory/profiler.ts
+++ b/src/utils/memory/profiler.ts
@@ -89,6 +89,31 @@ let memoryCheckInterval: ReturnType<typeof setInterval> | undefined;
 let memoryCheckIntervalMs: number | undefined;
 let lastHeapUsed = 0;
 let heapGrowthWarningThreshold = 0.8;
+let pendingRapidHeapGrowth: PendingRapidHeapGrowth | undefined;
+
+export interface PendingRapidHeapGrowth {
+  baselineHeapUsedMB: number;
+  observedGrowthMB: number;
+}
+
+export interface RapidHeapGrowthEvaluationInput {
+  previousHeapUsedMB: number;
+  currentHeapUsedMB: number;
+  pending: PendingRapidHeapGrowth | undefined;
+  thresholdMB: number;
+}
+
+export interface RapidHeapGrowthEvaluation {
+  shouldWarn: boolean;
+  growthMB?: number;
+  observedGrowthMB?: number;
+  pending?: PendingRapidHeapGrowth;
+}
+
+export interface RapidHeapGrowthState {
+  lastHeapUsedMB: number;
+  pending: PendingRapidHeapGrowth | undefined;
+}
 
 export function registerCache(name: string, getStats: () => CacheStats): void {
   cacheRegistry.set(name, getStats);
@@ -213,6 +238,49 @@ export function getMemoryMonitoringConfig(env: MemoryMonitoringEnv): MemoryMonit
   return { enabled, intervalMs };
 }
 
+function roundMemoryMB(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+export function getInitialRapidHeapGrowthState(initialHeapUsedMB: number): RapidHeapGrowthState {
+  return {
+    lastHeapUsedMB: initialHeapUsedMB,
+    pending: undefined,
+  };
+}
+
+export function getRapidHeapGrowthEvaluation(
+  input: RapidHeapGrowthEvaluationInput,
+): RapidHeapGrowthEvaluation {
+  const intervalGrowthMB = roundMemoryMB(input.currentHeapUsedMB - input.previousHeapUsedMB);
+
+  if (input.pending) {
+    const sustainedGrowthMB = roundMemoryMB(
+      input.currentHeapUsedMB - input.pending.baselineHeapUsedMB,
+    );
+    if (sustainedGrowthMB > input.thresholdMB) {
+      return {
+        shouldWarn: true,
+        growthMB: sustainedGrowthMB,
+        observedGrowthMB: input.pending.observedGrowthMB,
+      };
+    }
+    return { shouldWarn: false };
+  }
+
+  if (intervalGrowthMB > input.thresholdMB) {
+    return {
+      shouldWarn: false,
+      pending: {
+        baselineHeapUsedMB: input.previousHeapUsedMB,
+        observedGrowthMB: intervalGrowthMB,
+      },
+    };
+  }
+
+  return { shouldWarn: false };
+}
+
 export function getMemoryMonitoringState(): MemoryMonitoringState {
   return {
     active: memoryCheckInterval !== undefined,
@@ -237,6 +305,9 @@ export function startMemoryMonitoring(intervalMs = DEFAULT_MEMORY_MONITORING_INT
 
   logger.info(`Starting memory monitoring (interval: ${intervalMs}ms)`);
   memoryCheckIntervalMs = intervalMs;
+  const rapidGrowthState = getInitialRapidHeapGrowthState(getHeapStats().usedHeapSizeMB);
+  lastHeapUsed = rapidGrowthState.lastHeapUsedMB;
+  pendingRapidHeapGrowth = rapidGrowthState.pending;
 
   memoryCheckInterval = setInterval(() => {
     const snapshot = getMemorySnapshot();
@@ -255,10 +326,17 @@ export function startMemoryMonitoring(intervalMs = DEFAULT_MEMORY_MONITORING_INT
       });
     }
 
-    const heapGrowthMB = heap.usedHeapSizeMB - lastHeapUsed;
-    if (heapGrowthMB > HEAP_RAPID_GROWTH_THRESHOLD_MB) {
+    const rapidGrowthEvaluation = getRapidHeapGrowthEvaluation({
+      previousHeapUsedMB: lastHeapUsed,
+      currentHeapUsedMB: heap.usedHeapSizeMB,
+      pending: pendingRapidHeapGrowth,
+      thresholdMB: HEAP_RAPID_GROWTH_THRESHOLD_MB,
+    });
+    pendingRapidHeapGrowth = rapidGrowthEvaluation.pending;
+    if (rapidGrowthEvaluation.shouldWarn) {
       logger.warn("Rapid heap growth detected", {
-        growthMB: heapGrowthMB,
+        growthMB: rapidGrowthEvaluation.growthMB,
+        observedGrowthMB: rapidGrowthEvaluation.observedGrowthMB,
         intervalMs,
         topCaches: monitoringContext.topCaches,
       });
@@ -291,6 +369,7 @@ export function stopMemoryMonitoring(): void {
   clearInterval(memoryCheckInterval);
   memoryCheckInterval = undefined;
   memoryCheckIntervalMs = undefined;
+  pendingRapidHeapGrowth = undefined;
   logger.info("Memory monitoring stopped");
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.817";
+export const VERSION = "0.1.818";


### PR DESCRIPTION
## Summary
- Delay `Rapid heap growth detected` by one memory-monitoring interval and only warn if heap remains more than 100MB above the pre-spike baseline.
- Preserve the existing warning message for sustained growth, while adding `observedGrowthMB` to distinguish the original spike from the sustained delta.
- Bump `deno.json` and `src/utils/version-constant.ts` from `0.1.817` to `0.1.818`.

## Runtime evidence addressed
The production sample from #3200 showed a cold render/cache warmup spike from 99.16MB to 212.69MB, then recovery to 153.01MB on the next sample. This change suppresses that recovered one-interval spike but still alerts when the next sample remains over the 100MB sustained-growth threshold.

## Test plan
- Red/green regression: `deno test --no-check --allow-all src/utils/memory/profiler.test.ts`
- `deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/utils/memory/profiler.test.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/utils/memory/profiler.ts src/utils/memory/profiler.test.ts`
- `deno check src/utils/memory/profiler.ts src/utils/memory/profiler.test.ts`
- `deno task typecheck`
- `deno task test:unit` passed: 2167 tests, 18661 steps.
- `git push` pre-push checks passed: formatting, lint, typecheck, unit tests.

## Known repo gate
- `deno task verify:quick` currently stops at pre-existing `lint:cli-boundary` violations in `cli/shared/server-startup.ts`, unrelated to this diff.