### PR TITLE
Recover stale preview MDX cache automatically

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.817",
+  "version": "0.1.818",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/platform/adapters/base.ts
+++ b/src/platform/adapters/base.ts
@@ -152,6 +152,8 @@ export interface FileSystemAdapter {
   watch(paths: string | string[], options?: WatchOptions): FileWatcher;
   /** Resolve a file path with extension fallback (e.g., pages/test → pages/test.mdx) */
   resolveFile?(basePath: string, options?: ResolveFileOptions): Promise<string | null>;
+  /** Refresh remote source snapshots when a preview render detects stale cached content. */
+  refreshSourceSnapshot?(reason?: string): Promise<void>;
 }
 
 export interface ResolveFileOptions {

--- a/src/platform/adapters/fs/cache/file-cache.test.ts
+++ b/src/platform/adapters/fs/cache/file-cache.test.ts
@@ -295,6 +295,13 @@ describe("FileCache", () => {
       assertEquals(cache.get("key1"), "value1");
     });
 
+    it("deleteAsync() should delete an exact key", async () => {
+      cache.set("key1", "value1");
+      assertEquals(await cache.deleteAsync("key1"), true);
+      assertEquals(cache.get("key1"), undefined);
+      assertEquals(await cache.deleteAsync("missing"), false);
+    });
+
     it("deleteByPrefixAsync() should delete matching entries", async () => {
       cache.set("p:key1", "v1");
       cache.set("p:key2", "v2");

--- a/src/platform/adapters/fs/cache/file-cache.ts
+++ b/src/platform/adapters/fs/cache/file-cache.ts
@@ -283,6 +283,21 @@ export class FileCache {
     return this.fallbackCache.delete(key);
   }
 
+  deleteAsync(key: string): Promise<boolean> {
+    return withSpan(
+      "platform.fs.cache.deleteAsync",
+      async () => {
+        const deletedFromFallback = this.delete(key);
+        const backend = this.getBackend();
+        if (backend) {
+          await backend.del(key);
+        }
+        return deletedFromFallback;
+      },
+      { "cache.key": key },
+    );
+  }
+
   deleteByPrefix(prefix: string): number {
     let count = 0;
 

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -98,6 +98,7 @@ describe("VeryfrontFSAdapter", () => {
       "getFilePathByEntityId",
       "getPokeMetrics",
       "getClient",
+      "refreshSourceSnapshot",
     ] as const;
 
     for (const method of methods) {

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -519,6 +519,51 @@ export class VeryfrontFSAdapter implements FSAdapter {
     this.readOps.setFileListReadyPromise(warmupPromise);
   }
 
+  async refreshSourceSnapshot(reason = "manual-refresh"): Promise<void> {
+    await this.ensureInitialized();
+
+    if (!this.contentContext) {
+      logger.debug("Skipping source snapshot refresh without content context", {
+        reason,
+        projectSlug: this.projectSlug,
+      });
+      return;
+    }
+
+    const cacheKey = buildFileListCacheKey(this.contentContext);
+    const refreshContext = this.contentContext;
+
+    this.fileListWarmupPromise = null;
+    this.fileListWarmupKey = null;
+    this.readOps.clearFileListIndex();
+    this.statOps.clearIndex();
+    this.dirOps.clearTree();
+
+    await this.cache.deleteAsync(cacheKey);
+
+    const files = await fetchFileListForContext(this.client, refreshContext);
+    await this.cache.setAsync(cacheKey, files);
+    const fileSummary = summarizeFileList(files);
+
+    if (fileSummary.sourceFilesWithContent > 0 && this.shouldBackgroundPregenerateStyles()) {
+      this.triggerCSSPregeneration(files).catch(() => {
+        // Error already logged in triggerCSSPregeneration
+      });
+    }
+
+    logger.info("Refreshed source snapshot", {
+      reason,
+      cacheKey,
+      projectSlug: this.projectSlug,
+      sourceType: refreshContext.sourceType,
+      branch: refreshContext.branch,
+      environmentName: refreshContext.environmentName,
+      releaseId: refreshContext.releaseId,
+      totalFiles: fileSummary.totalFiles,
+      filesWithContent: fileSummary.filesWithContent,
+    });
+  }
+
   getPokeMetrics(): {
     received: number;
     invalidationsTriggered: number;

--- a/src/platform/adapters/fs/veryfront/types.ts
+++ b/src/platform/adapters/fs/veryfront/types.ts
@@ -28,6 +28,7 @@ export interface FSAdapter {
   shutdown?(): Promise<void>;
 
   resolveFile?(basePath: string, options?: ResolveFileOptions): Promise<string | null>;
+  refreshSourceSnapshot?(reason?: string): Promise<void>;
 }
 
 export interface ContextualFSAdapter extends FSAdapter {

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -148,6 +148,50 @@ describe("RenderPipeline behavior", () => {
     assertEquals(persists, [{ slug: "", cacheKey: "index" }]);
   });
 
+  it("renderPage refreshes preview caches and retries stale MDX ESM export mismatches", async () => {
+    const slug = "/behavior-stale-mdx";
+    let renderAttempts = 0;
+    let sourceRefreshes = 0;
+    const pipeline = createPipeline("/project/pages/behavior-stale-mdx.mdx", {
+      adapter: {
+        env: { get: () => undefined },
+        fs: {
+          exists: async () => false,
+          refreshSourceSnapshot: () => {
+            sourceRefreshes++;
+            return Promise.resolve();
+          },
+        },
+      } as any,
+      pageRenderer: {
+        preparePageBundles: async () => {
+          renderAttempts++;
+          if (renderAttempts === 1) {
+            throw new Error(
+              "The requested module 'file:///cache/vfmod.mjs' does not provide an export named 'default'",
+            );
+          }
+
+          return {
+            pageElement: {},
+            pageBundle: {},
+          };
+        },
+      } as any,
+    } as Partial<RenderPipelineConfig>);
+
+    const result = await pipeline.renderPage(slug, {
+      delivery: "string",
+      projectId: "project-1",
+      projectSlug: "project-slug",
+      contentSourceId: "preview-main",
+    });
+
+    assertEquals(result.html, "<!doctype html><html><body>ok</body></html>");
+    assertEquals(renderAttempts, 2);
+    assertEquals(sourceRefreshes, 1);
+  });
+
   it("resolvePageData surfaces notFound from data hooks", async () => {
     const slug = "/behavior-not-found";
     const projectId = "proj-not-found";

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -64,6 +64,7 @@ import {
   runWithCSSCollector,
 } from "#veryfront/modules/react-loader/css-import-collector.ts";
 import { assembleRenderResult } from "./render-result-assembly.ts";
+import { isMdxEsmExportMismatchError, recoverStaleMdxEsmPreviewCaches } from "../page-rendering.ts";
 
 // Extracted modules
 import { EMPTY_LAYOUT_RESULT, isDotPath } from "./path-helpers.ts";
@@ -415,210 +416,239 @@ export class RenderPipeline {
       clearSSRModuleCacheForProject(projectId);
     }
 
-    return withSpan(
-      "render.page",
-      async () => {
-        const { result } = await runWithCSSCollector(async () => {
-          const pageResolveStart = performance.now();
-          const pageInfo = await withSpan(
-            "render.resolve_page",
-            () => this.config.pageResolver.resolvePage(slug),
-            { "render.slug": slug },
-          );
-          timing.pageResolve = Math.round(performance.now() - pageResolveStart);
-
-          const sourceFile = extractRelativePathShared(
-            pageInfo.entity.path,
-            this.config.projectDir,
-          );
-
-          try {
-            const skipLayouts = isDotPath(slug, pageInfo.entity.path);
-
-            const layoutCollectStart = performance.now();
-            const layoutResult = skipLayouts ? EMPTY_LAYOUT_RESULT : await withSpan(
-              "render.collect_layouts",
-              () => this.config.layoutOrchestrator.collectLayouts(pageInfo),
+    const renderOnce = () =>
+      withSpan(
+        "render.page",
+        async () => {
+          const { result } = await runWithCSSCollector(async () => {
+            const pageResolveStart = performance.now();
+            const pageInfo = await withSpan(
+              "render.resolve_page",
+              () => this.config.pageResolver.resolvePage(slug),
               { "render.slug": slug },
             );
-            timing.layoutCollect = Math.round(performance.now() - layoutCollectStart);
+            timing.pageResolve = Math.round(performance.now() - pageResolveStart);
 
-            const layoutPreloadPromise = !skipLayouts && layoutResult.nestedLayouts.length > 0
-              ? this.config.layoutOrchestrator.preloadLayoutModules(layoutResult.nestedLayouts)
-              : Promise.resolve();
+            const sourceFile = extractRelativePathShared(
+              pageInfo.entity.path,
+              this.config.projectDir,
+            );
 
-            let dataFetchingProps: Record<string, unknown> | undefined;
-            let resolvedParams: Record<string, string | string[]> = options?.params
-              ? { ...options.params }
-              : {};
-            let layoutDataMap = new Map<string, Record<string, unknown>>();
+            try {
+              const skipLayouts = isDotPath(slug, pageInfo.entity.path);
 
-            const dataFetchStart = performance.now();
-            if (options?.request && options?.url) {
-              await withSpan(
-                "render.data_fetching",
-                async () => {
-                  try {
-                    const dataResolution = await this.resolveDataFetching(
-                      slug,
-                      pageInfo.entity.path,
-                      layoutResult.nestedLayouts,
-                      options,
-                    );
-                    resolvedParams = dataResolution.params;
-                    dataFetchingProps = Object.keys(dataResolution.pageProps).length > 0
-                      ? dataResolution.pageProps
-                      : undefined;
-                    layoutDataMap = dataResolution.layoutProps;
-                  } catch (error) {
-                    if (error instanceof VeryfrontError) throw error;
-
-                    renderPageLog.error("Data fetching error", {
-                      slug,
-                      error: error instanceof Error ? error.message : String(error),
-                    });
-                    throw error;
-                  }
-                },
+              const layoutCollectStart = performance.now();
+              const layoutResult = skipLayouts ? EMPTY_LAYOUT_RESULT : await withSpan(
+                "render.collect_layouts",
+                () => this.config.layoutOrchestrator.collectLayouts(pageInfo),
                 { "render.slug": slug },
               );
-            }
-            timing.dataFetch = Math.round(performance.now() - dataFetchStart);
+              timing.layoutCollect = Math.round(performance.now() - layoutCollectStart);
 
-            const hasResolvedParams = Object.keys(resolvedParams).length > 0;
-            const mergedOptions = (dataFetchingProps || hasResolvedParams)
-              ? {
-                ...options,
-                ...(hasResolvedParams ? { params: resolvedParams } : {}),
-                ...(dataFetchingProps
-                  ? { props: { ...options?.props, ...dataFetchingProps } }
-                  : {}),
+              const layoutPreloadPromise = !skipLayouts && layoutResult.nestedLayouts.length > 0
+                ? this.config.layoutOrchestrator.preloadLayoutModules(layoutResult.nestedLayouts)
+                : Promise.resolve();
+
+              let dataFetchingProps: Record<string, unknown> | undefined;
+              let resolvedParams: Record<string, string | string[]> = options?.params
+                ? { ...options.params }
+                : {};
+              let layoutDataMap = new Map<string, Record<string, unknown>>();
+
+              const dataFetchStart = performance.now();
+              if (options?.request && options?.url) {
+                await withSpan(
+                  "render.data_fetching",
+                  async () => {
+                    try {
+                      const dataResolution = await this.resolveDataFetching(
+                        slug,
+                        pageInfo.entity.path,
+                        layoutResult.nestedLayouts,
+                        options,
+                      );
+                      resolvedParams = dataResolution.params;
+                      dataFetchingProps = Object.keys(dataResolution.pageProps).length > 0
+                        ? dataResolution.pageProps
+                        : undefined;
+                      layoutDataMap = dataResolution.layoutProps;
+                    } catch (error) {
+                      if (error instanceof VeryfrontError) throw error;
+
+                      renderPageLog.error("Data fetching error", {
+                        slug,
+                        error: error instanceof Error ? error.message : String(error),
+                      });
+                      throw error;
+                    }
+                  },
+                  { "render.slug": slug },
+                );
               }
-              : options;
+              timing.dataFetch = Math.round(performance.now() - dataFetchStart);
 
-            const bundlePrepStart = performance.now();
-            const pageBundleResult = await withSpan(
-              "render.prepare_bundles",
-              () =>
-                this.config.pageRenderer.preparePageBundles(
-                  pageInfo,
-                  slug,
-                  cacheResult?.cachedModule,
-                  mergedOptions,
-                ),
-              { "render.slug": slug },
-            );
-            timing.bundlePrep = Math.round(performance.now() - bundlePrepStart);
+              const hasResolvedParams = Object.keys(resolvedParams).length > 0;
+              const mergedOptions = (dataFetchingProps || hasResolvedParams)
+                ? {
+                  ...options,
+                  ...(hasResolvedParams ? { params: resolvedParams } : {}),
+                  ...(dataFetchingProps
+                    ? { props: { ...options?.props, ...dataFetchingProps } }
+                    : {}),
+                }
+                : options;
 
-            if (pageBundleResult.scriptResult) return pageBundleResult.scriptResult;
-
-            if (!pageBundleResult.pageElement || !pageBundleResult.pageBundle) {
-              throw RENDER_ERROR.create({
-                detail: "Failed to prepare page bundle",
-                context: { slug },
-              });
-            }
-
-            const { pageElement, pageBundle } = pageBundleResult;
-
-            const mergedFrontmatter = {
-              ...pageInfo.entity.frontmatter,
-              ...(pageBundle as MdxBundle).frontmatter,
-            };
-
-            const headings = (pageBundle as PageBundle).headings || [];
-
-            await layoutPreloadPromise;
-
-            const layoutApplyStart = performance.now();
-            const wrappedElement = await withSpan(
-              "render.apply_layouts",
-              () =>
-                this.config.layoutOrchestrator.applyLayoutsAndWrappers(
-                  pageElement,
-                  pageInfo,
-                  layoutResult.layoutBundle,
-                  layoutResult.nestedLayouts,
-                  layoutDataMap,
-                  options?.url,
-                  resolvedParams,
-                  mergedFrontmatter,
-                  headings,
-                  options?.projectSlug,
-                ),
-              { "render.slug": slug, "render.layout_count": layoutResult.nestedLayouts.length },
-            );
-            timing.layoutApply = Math.round(performance.now() - layoutApplyStart);
-
-            // Snapshot CSS imports collected during module loading (before SSR rendering).
-            // These are passed to the HTML generator to be included in the output.
-            const collectedCSSImports = getCSSImports();
-
-            const ssrStart = performance.now();
-            const ssrResult = await withSpan(
-              "render.ssr",
-              () =>
-                withTimeoutThrow(
-                  this.config.ssrOrchestrator.performSSRRendering(
-                    wrappedElement,
-                    {
-                      pageInfo,
-                      pageBundle,
-                      layoutBundle: layoutResult.layoutBundle,
-                      nestedLayouts: layoutResult.nestedLayouts,
-                      collectedMetadata: pageBundleResult.collectedMetadata,
-                      slug,
-                      cssImports: collectedCSSImports,
-                    },
+              const bundlePrepStart = performance.now();
+              const pageBundleResult = await withSpan(
+                "render.prepare_bundles",
+                () =>
+                  this.config.pageRenderer.preparePageBundles(
+                    pageInfo,
+                    slug,
+                    cacheResult?.cachedModule,
                     mergedOptions,
                   ),
-                  SSR_RENDER_TIMEOUT_MS,
-                  `SSR rendering for ${slug}`,
-                ),
-              { "render.slug": slug, "render.delivery": mergedOptions?.delivery || "full" },
-            );
-            timing.ssr = Math.round(performance.now() - ssrStart);
+                { "render.slug": slug },
+              );
+              timing.bundlePrep = Math.round(performance.now() - bundlePrepStart);
 
-            if (collectedCSSImports.length > 0) {
-              renderPipelineLog.debug("CSS imports collected for HTML generation", {
+              if (pageBundleResult.scriptResult) return pageBundleResult.scriptResult;
+
+              if (!pageBundleResult.pageElement || !pageBundleResult.pageBundle) {
+                throw RENDER_ERROR.create({
+                  detail: "Failed to prepare page bundle",
+                  context: { slug },
+                });
+              }
+
+              const { pageElement, pageBundle } = pageBundleResult;
+
+              const mergedFrontmatter = {
+                ...pageInfo.entity.frontmatter,
+                ...(pageBundle as MdxBundle).frontmatter,
+              };
+
+              const headings = (pageBundle as PageBundle).headings || [];
+
+              await layoutPreloadPromise;
+
+              const layoutApplyStart = performance.now();
+              const wrappedElement = await withSpan(
+                "render.apply_layouts",
+                () =>
+                  this.config.layoutOrchestrator.applyLayoutsAndWrappers(
+                    pageElement,
+                    pageInfo,
+                    layoutResult.layoutBundle,
+                    layoutResult.nestedLayouts,
+                    layoutDataMap,
+                    options?.url,
+                    resolvedParams,
+                    mergedFrontmatter,
+                    headings,
+                    options?.projectSlug,
+                  ),
+                { "render.slug": slug, "render.layout_count": layoutResult.nestedLayouts.length },
+              );
+              timing.layoutApply = Math.round(performance.now() - layoutApplyStart);
+
+              // Snapshot CSS imports collected during module loading (before SSR rendering).
+              // These are passed to the HTML generator to be included in the output.
+              const collectedCSSImports = getCSSImports();
+
+              const ssrStart = performance.now();
+              const ssrResult = await withSpan(
+                "render.ssr",
+                () =>
+                  withTimeoutThrow(
+                    this.config.ssrOrchestrator.performSSRRendering(
+                      wrappedElement,
+                      {
+                        pageInfo,
+                        pageBundle,
+                        layoutBundle: layoutResult.layoutBundle,
+                        nestedLayouts: layoutResult.nestedLayouts,
+                        collectedMetadata: pageBundleResult.collectedMetadata,
+                        slug,
+                        cssImports: collectedCSSImports,
+                      },
+                      mergedOptions,
+                    ),
+                    SSR_RENDER_TIMEOUT_MS,
+                    `SSR rendering for ${slug}`,
+                  ),
+                { "render.slug": slug, "render.delivery": mergedOptions?.delivery || "full" },
+              );
+              timing.ssr = Math.round(performance.now() - ssrStart);
+
+              if (collectedCSSImports.length > 0) {
+                renderPipelineLog.debug("CSS imports collected for HTML generation", {
+                  slug,
+                  count: collectedCSSImports.length,
+                  paths: collectedCSSImports.map((p) => p.split("/").pop()),
+                });
+              }
+
+              const result = assembleRenderResult({
                 slug,
-                count: collectedCSSImports.length,
-                paths: collectedCSSImports.map((p) => p.split("/").pop()),
+                cacheKey,
+                ssrResult,
+                pageBundle: pageBundleResult.pageBundle,
+                clientModuleCode: pageBundleResult.clientModuleCode,
+                pageModuleType: pageBundleResult.pageModuleType,
+                shouldCache,
+                skipCachePersist: options?.skipCachePersist,
+                cacheCoordinator: this.config.cacheCoordinator,
+                logger: renderPipelineLog,
               });
+
+              timing.total = Math.round(performance.now() - pipelineStartTime);
+              renderPipelineLog.debug("Complete", { slug, timing });
+
+              return result;
+            } catch (error) {
+              if (error instanceof Error) {
+                (error as Error & { sourceFile?: string }).sourceFile = sourceFile;
+              }
+              throw error;
             }
+          });
+          return result;
+        },
+        {
+          "render.slug": slug,
+          "render.project_id": options?.projectId || this.config.projectDir,
+          "render.mode": this.config.mode,
+        },
+      );
 
-            const result = assembleRenderResult({
-              slug,
-              cacheKey,
-              ssrResult,
-              pageBundle: pageBundleResult.pageBundle,
-              clientModuleCode: pageBundleResult.clientModuleCode,
-              pageModuleType: pageBundleResult.pageModuleType,
-              shouldCache,
-              skipCachePersist: options?.skipCachePersist,
-              cacheCoordinator: this.config.cacheCoordinator,
-              logger: renderPipelineLog,
-            });
-
-            timing.total = Math.round(performance.now() - pipelineStartTime);
-            renderPipelineLog.debug("Complete", { slug, timing });
-
-            return result;
-          } catch (error) {
-            if (error instanceof Error) {
-              (error as Error & { sourceFile?: string }).sourceFile = sourceFile;
-            }
-            throw error;
-          }
+    try {
+      return await renderOnce();
+    } catch (error) {
+      if (isMdxEsmExportMismatchError(error)) {
+        const recovered = await recoverStaleMdxEsmPreviewCaches({
+          adapter: this.config.adapter,
+          projectId,
+          projectSlug,
+          contentSourceId: options?.contentSourceId,
+          slug,
+          pagePath: slug,
         });
-        return result;
-      },
-      {
-        "render.slug": slug,
-        "render.project_id": options?.projectId || this.config.projectDir,
-        "render.mode": this.config.mode,
-      },
-    );
+
+        if (recovered) {
+          cacheResult = null;
+          renderPipelineLog.warn("Retrying page render after stale MDX ESM cache recovery", {
+            slug,
+            projectId,
+            projectSlug,
+            contentSourceId: options?.contentSourceId,
+          });
+          return await renderOnce();
+        }
+      }
+
+      throw error;
+    }
   }
 
   /** Resolve page data for SPA client-side navigation without rendering HTML. */

--- a/src/rendering/page-rendering.test.ts
+++ b/src/rendering/page-rendering.test.ts
@@ -2,8 +2,10 @@ import "#veryfront/schemas/_test-setup.ts";
 import "../transforms/mdx/compiler/__tests__/content-processor-setup.ts";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { mdxRenderer } from "#veryfront/transforms/mdx/index.ts";
 import type { EntityInfo } from "#veryfront/types";
-import { prepareMDXPageBundles } from "./page-rendering.ts";
+import { handleMDXPage, prepareMDXPageBundles } from "./page-rendering.ts";
 
 function createMDXPageInfo(content: string): EntityInfo {
   return {
@@ -62,5 +64,76 @@ describe("rendering/page-rendering", () => {
     assertEquals(pageBundle.clientModuleCode, precompiledModule);
     assert(serverModuleCode.includes("file:///project/components/Marker.tsx"));
     assertEquals(serverModuleCode.includes("/_veryfront/fs/"), false);
+  });
+
+  it("refreshes preview caches and retries once when MDX ESM imports have stale exports", async () => {
+    const pageInfo = createMDXPageInfo("# MDX Probe");
+    const originalLoadModuleESM = mdxRenderer.loadModuleESM;
+    let loadAttempts = 0;
+    let sourceRefreshes = 0;
+
+    const adapter = {
+      id: "deno",
+      name: "test",
+      capabilities: {
+        typescript: true,
+        jsx: true,
+        http2: false,
+        websocket: false,
+        workers: false,
+        fileWatching: false,
+        shell: false,
+        kvStore: false,
+        writableFs: true,
+      },
+      fs: {
+        refreshSourceSnapshot: () => {
+          sourceRefreshes++;
+          return Promise.resolve();
+        },
+      },
+      env: {},
+      server: {},
+      serve: () => Promise.reject(new Error("not used")),
+    } as unknown as RuntimeAdapter;
+
+    const mutableRenderer = mdxRenderer as unknown as {
+      loadModuleESM: typeof mdxRenderer.loadModuleESM;
+    };
+
+    mutableRenderer.loadModuleESM = () => {
+      loadAttempts++;
+      if (loadAttempts === 1) {
+        throw new Error(
+          "The requested module 'file:///cache/vfmod.mjs' does not provide an export named 'default'",
+        );
+      }
+
+      return Promise.resolve({
+        default: () => null,
+      });
+    };
+
+    try {
+      await handleMDXPage(
+        pageInfo,
+        "probe",
+        "/project",
+        {},
+        async () => ({ compiledCode: "", frontmatter: {}, headings: [] }),
+        adapter,
+        {
+          projectId: "project-1",
+          projectSlug: "project-slug",
+          contentSourceId: "preview-main",
+          studioEmbed: true,
+        },
+      );
+
+      assertEquals(loadAttempts, 2);
+      assertEquals(sourceRefreshes, 1);
+    } finally {
+      mutableRenderer.loadModuleESM = originalLoadModuleESM;
+    }
   });
 });

--- a/src/rendering/page-rendering.ts
+++ b/src/rendering/page-rendering.ts
@@ -4,6 +4,7 @@ import type * as BundledReact from "react";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { EntityInfo, MdxBundle, MDXComponents, MDXModule, PageBundle } from "#veryfront/types";
 import { mdxRenderer } from "#veryfront/transforms/mdx/index.ts";
+import { clearMdxEsmCacheNamespace } from "#veryfront/transforms/mdx/esm-module-loader/index.ts";
 import { getProjectReact } from "#veryfront/react";
 import { compileContent } from "#veryfront/transforms/mdx/compiler/index.ts";
 import { ensureError, getErrorMessage } from "#veryfront/errors/veryfront-error.ts";
@@ -18,6 +19,50 @@ interface MDXPageResult {
 interface PreparedMDXPageBundles {
   pageBundle: PageBundle;
   serverModuleCode: string;
+}
+
+interface StaleMdxEsmRecoveryOptions {
+  adapter: RuntimeAdapter;
+  projectId?: string;
+  projectSlug?: string;
+  contentSourceId?: string;
+  slug: string;
+  pagePath: string;
+}
+
+export function isMdxEsmExportMismatchError(error: unknown): boolean {
+  const message = getErrorMessage(error);
+  return /does not provide an export named/i.test(message) &&
+    /requested module|import/i.test(message);
+}
+
+export async function recoverStaleMdxEsmPreviewCaches(
+  options: StaleMdxEsmRecoveryOptions,
+): Promise<boolean> {
+  let recovered = false;
+  const refreshSourceSnapshot = options.adapter.fs.refreshSourceSnapshot;
+
+  if (typeof refreshSourceSnapshot === "function") {
+    await refreshSourceSnapshot.call(options.adapter.fs, "mdx-esm-export-mismatch");
+    recovered = true;
+  }
+
+  if (options.projectId && options.contentSourceId) {
+    await clearMdxEsmCacheNamespace(options.projectId, options.contentSourceId);
+    recovered = true;
+  }
+
+  if (recovered) {
+    logger.warn("Recovered stale MDX ESM preview caches, retrying render", {
+      slug: options.slug,
+      pagePath: options.pagePath,
+      projectId: options.projectId,
+      projectSlug: options.projectSlug,
+      contentSourceId: options.contentSourceId,
+    });
+  }
+
+  return recovered;
 }
 
 export async function prepareMDXPageBundles(
@@ -106,9 +151,10 @@ export function handleMDXPage(
         precompiledModule: options?.precompiledModule,
         studioEmbed: options?.studioEmbed,
       });
-      let collectedMetadata: Record<string, unknown> = {};
 
-      try {
+      const loadPageElement = async (): Promise<MDXPageResult> => {
+        let collectedMetadata: Record<string, unknown> = {};
+
         const mod = (await mdxRenderer.loadModuleESM(
           serverModuleCode,
           adapter,
@@ -170,7 +216,45 @@ export function handleMDXPage(
         ) as BundledReact.ReactElement;
 
         return { pageElement, pageBundle, collectedMetadata };
+      };
+
+      try {
+        return await loadPageElement();
       } catch (error) {
+        if (isMdxEsmExportMismatchError(error)) {
+          let recovered = false;
+
+          try {
+            recovered = await recoverStaleMdxEsmPreviewCaches({
+              adapter,
+              projectId: options?.projectId,
+              projectSlug: options?.projectSlug,
+              contentSourceId: options?.contentSourceId,
+              slug,
+              pagePath: path,
+            });
+          } catch (recoveryError) {
+            logger.warn("Failed to recover stale MDX ESM preview caches", {
+              slug,
+              path,
+              error: getErrorMessage(recoveryError),
+            });
+          }
+
+          if (recovered) {
+            try {
+              return await loadPageElement();
+            } catch (retryError) {
+              throw RENDER_ERROR.create({
+                detail: `Failed to import MDX page via ESM after cache refresh: ${
+                  getErrorMessage(retryError)
+                }`,
+                context: { slug, error: retryError, recoveredFrom: error },
+              });
+            }
+          }
+        }
+
         throw RENDER_ERROR.create({
           detail: `Failed to import MDX page via ESM: ${getErrorMessage(error)}`,
           context: { slug, error },

--- a/src/transforms/mdx/esm-module-loader/cache/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.test.ts
@@ -3,6 +3,7 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path";
 import {
+  clearMdxEsmCacheNamespace,
   clearModulePathCache,
   getLocalFs,
   getModulePathCache,
@@ -15,12 +16,50 @@ import {
 } from "./index.ts";
 import { makeTempDir } from "#veryfront/testing/deno-compat.ts";
 import { exists, remove, writeTextFile } from "#veryfront/compat/fs.ts";
+import { runWithCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { cacheModule } from "../module-fetcher/module-cache.ts";
 import { rendererLogger as log } from "#veryfront/utils";
 import { buildMdxEsmModuleFileName, buildMdxEsmPathCacheKey } from "../cache-format.ts";
 import { getCacheStats } from "#veryfront/utils/memory/index.ts";
 
 describe("MDX module path cache", () => {
+  it("clears a project/content-source namespace from disk and memory", async () => {
+    clearModulePathCache();
+
+    const cacheBase = await makeTempDir({ prefix: "vf-mdx-namespace-clear-" });
+    const projectId = "project/with spaces";
+    const contentSourceId = "preview-main";
+    const cacheDir = join(
+      cacheBase,
+      "veryfront-mdx-esm",
+      encodeURIComponent(projectId),
+      encodeURIComponent(contentSourceId),
+    );
+    const cacheKey = buildMdxEsmPathCacheKey("_vf_modules/pages/index.js", "19.1.1");
+    const cachedPath = join(cacheDir, "stale.mjs");
+
+    try {
+      await runWithCacheDir(cacheBase, async () => {
+        await getLocalFs().mkdir(cacheDir, { recursive: true });
+        await writeTextFile(cachedPath, "export default function Stale() {}");
+
+        const cache = await getModulePathCache(cacheDir);
+        cache.set(cacheKey, cachedPath);
+        verifiedModuleDeps.set(`${cachedPath}:${cacheKey}`, true);
+
+        await clearMdxEsmCacheNamespace(projectId, contentSourceId);
+
+        assertEquals(await exists(cachedPath), false);
+        assertEquals((await getModulePathCache(cacheDir)).get(cacheKey), undefined);
+        assertEquals(verifiedModuleDeps.get(`${cachedPath}:${cacheKey}`), undefined);
+        assertEquals(await exists(cacheDir), true);
+      });
+    } finally {
+      await remove(cacheBase, { recursive: true });
+      clearModulePathCache();
+    }
+  });
+
   it("isolates per cache dir", async () => {
     clearModulePathCache();
 

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -397,6 +397,51 @@ export async function clearESMDiskCache(): Promise<void> {
   }
 }
 
+export async function clearMdxEsmCacheNamespace(
+  projectId: string,
+  contentSourceId: string,
+): Promise<void> {
+  const cacheDir = join(
+    getMdxEsmCacheDir(),
+    encodeURIComponent(projectId),
+    encodeURIComponent(contentSourceId),
+  );
+
+  modulePathCaches.delete(cacheDir);
+  modulePathCacheLoaded.delete(cacheDir);
+
+  for (const key of Array.from(verifiedModuleDeps.keys())) {
+    if (String(key).startsWith(cacheDir)) {
+      verifiedModuleDeps.delete(key);
+    }
+  }
+
+  try {
+    await getLocalFs().remove(cacheDir, { recursive: true });
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to remove MDX-ESM cache namespace`, {
+        cacheDir,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  try {
+    await getLocalFs().mkdir(cacheDir, { recursive: true });
+    logger.debug(`${LOG_PREFIX_MDX_LOADER} Cleared MDX-ESM cache namespace`, {
+      projectId,
+      contentSourceId,
+      cacheDir,
+    });
+  } catch (error) {
+    logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to recreate MDX-ESM cache namespace`, {
+      cacheDir,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 export async function clearHttpBundleCache(): Promise<void> {
   const cacheDir = getHttpBundleCacheDir();
   const fs = getLocalFs();

--- a/src/transforms/mdx/esm-module-loader/index.ts
+++ b/src/transforms/mdx/esm-module-loader/index.ts
@@ -5,7 +5,12 @@
  */
 
 // Cache exports
-export { clearESMDiskCache, clearModulePathCache, invalidateModulePaths } from "./cache/index.ts";
+export {
+  clearESMDiskCache,
+  clearMdxEsmCacheNamespace,
+  clearModulePathCache,
+  invalidateModulePaths,
+} from "./cache/index.ts";
 
 // Constants exports
 export { IS_TRUE_NODE, LOG_PREFIX_MDX_LOADER, LOG_PREFIX_MDX_RENDERER } from "./constants.ts";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.817";
+export const VERSION = "0.1.818";


### PR DESCRIPTION
## Summary
- Detect MDX ESM export-mismatch failures from stale preview caches and recover automatically.
- Refresh the Veryfront source snapshot, clear the scoped MDX ESM cache namespace, and retry the MDX/page render once.
- Bump the package/runtime version to `0.1.818`.

## Test Plan
- `deno fmt --check` on touched files
- `deno test --no-check --allow-all src/rendering/page-rendering.test.ts src/transforms/mdx/esm-module-loader/cache/index.test.ts src/platform/adapters/fs/cache/file-cache.test.ts src/platform/adapters/fs/veryfront/adapter.test.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version.test.ts`
- `deno check src/rendering/page-rendering.test.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/transforms/mdx/esm-module-loader/cache/index.test.ts src/platform/adapters/fs/cache/file-cache.test.ts src/platform/adapters/fs/veryfront/adapter.test.ts src/utils/version.test.ts`
- Local `tomcode` Studio-shaped preview request returned HTTP 200 with the expected title
- Pre-push hook passed: format, lint, type check, and unit tests (`2167 passed`, `0 failed`)