### PR TITLE
Delegate preview source refresh through adapters

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.818",
+  "version": "0.1.819",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
@@ -103,6 +103,10 @@ describe("MultiProjectFSAdapter", () => {
       withAdapter((adapter) => assertMethod(adapter, "runWithContext"));
     });
 
+    it("should have refreshSourceSnapshot method", () => {
+      withAdapter((adapter) => assertMethod(adapter, "refreshSourceSnapshot"));
+    });
+
     it("should have getManagerStats method", () => {
       withAdapter((adapter) => assertMethod(adapter, "getManagerStats"));
     });
@@ -118,6 +122,57 @@ describe("MultiProjectFSAdapter", () => {
 
     it("initialize should resolve immediately", async () => {
       await withAdapterAsync((adapter) => adapter.initialize());
+    });
+
+    it("refreshSourceSnapshot should delegate to the request-scoped adapter", async () => {
+      await withAdapterAsync(async (adapter) => {
+        const originalManager = (adapter as any).manager;
+        let refreshedReason: string | undefined;
+        let capturedProjectSlug: string | undefined;
+        let capturedProjectId: string | undefined;
+        let capturedBranch: string | null | undefined;
+
+        (adapter as any).manager = {
+          getAdapter(
+            projectSlug: string,
+            _token: string,
+            projectId?: string,
+            _productionMode?: boolean,
+            _releaseId?: string | null,
+            _environmentName?: string | null,
+            branch?: string | null,
+          ) {
+            capturedProjectSlug = projectSlug;
+            capturedProjectId = projectId;
+            capturedBranch = branch;
+            return Promise.resolve({
+              refreshSourceSnapshot(reason?: string) {
+                refreshedReason = reason;
+                return Promise.resolve();
+              },
+            });
+          },
+          getStats: () => ({ adapters: 0, stats: [] }),
+          dispose: () => {},
+        };
+
+        try {
+          await adapter.runWithContext(
+            "project-a",
+            "test-token",
+            () => adapter.refreshSourceSnapshot("review-comment"),
+            "project-id-a",
+            { branch: "main" },
+          );
+        } finally {
+          (adapter as any).manager = originalManager;
+        }
+
+        assertEquals(refreshedReason, "review-comment");
+        assertEquals(capturedProjectSlug, "project-a");
+        assertEquals(capturedProjectId, "project-id-a");
+        assertEquals(capturedBranch, "main");
+      });
     });
   });
 });
@@ -289,19 +344,17 @@ describe("wrapWithCurrentContext", () => {
   });
 
   it("should preserve context in wrapped function", async () => {
-    let wrappedFn: (() => string | null) | null = null;
-
-    await runWithRequestContext(
+    const projectSlug = await runWithRequestContext(
       { projectSlug: "proj", token: "tok" },
       async () => {
-        wrappedFn = wrapWithCurrentContext(() => {
+        const wrappedFn = wrapWithCurrentContext(() => {
           return getCurrentRequestContext()?.projectSlug ?? null;
         });
+        return wrappedFn();
       },
     );
 
-    assertExists(wrappedFn);
-    assertEquals(wrappedFn!(), "proj");
+    assertEquals(projectSlug, "proj");
   });
 });
 

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
@@ -208,6 +208,11 @@ export class MultiProjectFSAdapter implements FSAdapter {
     return adapter.resolveFile(basePath, options);
   }
 
+  async refreshSourceSnapshot(reason?: string): Promise<void> {
+    const adapter = await this.getAdapter();
+    await adapter.refreshSourceSnapshot(reason);
+  }
+
   dispose(): void {
     this.manager.dispose();
     this.defaultAdapter?.dispose();

--- a/src/platform/adapters/fs/wrapper.test.ts
+++ b/src/platform/adapters/fs/wrapper.test.ts
@@ -185,6 +185,29 @@ describe("FSAdapterWrapper", () => {
     });
   });
 
+  describe("refreshSourceSnapshot", () => {
+    it("should not expose refreshSourceSnapshot when the wrapped adapter does not support it", () => {
+      const wrapper = new FSAdapterWrapper(createMockFSAdapter());
+
+      assertEquals(wrapper.refreshSourceSnapshot, undefined);
+    });
+
+    it("should delegate refreshSourceSnapshot to the wrapped adapter", async () => {
+      let refreshedReason: string | undefined;
+      const fsAdapter = createMockFSAdapter({
+        refreshSourceSnapshot(reason?: string) {
+          refreshedReason = reason;
+          return Promise.resolve();
+        },
+      });
+      const wrapper = new FSAdapterWrapper(fsAdapter);
+
+      await wrapper.refreshSourceSnapshot?.("review-comment");
+
+      assertEquals(refreshedReason, "review-comment");
+    });
+  });
+
   describe("readFile", () => {
     it("should read file using readTextFile if available", async () => {
       const fsAdapter = createMockFSAdapter({

--- a/src/platform/adapters/fs/wrapper.ts
+++ b/src/platform/adapters/fs/wrapper.ts
@@ -79,9 +79,14 @@ function isContextualAdapter(adapter: FSAdapter): adapter is ContextualFSAdapter
 
 export class FSAdapterWrapper implements ExtendedFileSystemAdapter {
   private readonly _fsAdapter: FSAdapter;
+  readonly refreshSourceSnapshot?: (reason?: string) => Promise<void>;
 
   constructor(fsAdapter: FSAdapter) {
     this._fsAdapter = fsAdapter;
+    if (typeof fsAdapter.refreshSourceSnapshot === "function") {
+      this.refreshSourceSnapshot = (reason?: string) =>
+        fsAdapter.refreshSourceSnapshot!.call(fsAdapter, reason);
+    }
   }
 
   getUnderlyingAdapter(): FSAdapter {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.818";
+export const VERSION = "0.1.819";


### PR DESCRIPTION
## Summary
- Expose `refreshSourceSnapshot` through `FSAdapterWrapper` only when the wrapped adapter supports it.
- Delegate `MultiProjectFSAdapter.refreshSourceSnapshot()` to the active request-scoped Veryfront adapter.
- Bump the package/runtime version to `0.1.819`.

## Context
Follow-up to #2474. The stale MDX recovery path needs the wrapped preview runtime adapter to refresh the source snapshot, not only clear the scoped MDX ESM cache.

## Test Plan
- `deno fmt --check` on touched files
- `deno test --no-check --allow-all src/platform/adapters/fs/wrapper.test.ts src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts src/rendering/page-rendering.test.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version.test.ts`
- `deno check src/platform/adapters/fs/wrapper.test.ts src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts src/rendering/page-rendering.test.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version.test.ts`
- Pre-push hook passed: format, lint, type check, and unit tests (`2167 passed`, `0 failed`)