### PR TITLE
Clear request cache after preview source refresh

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.819",
+  "version": "0.1.820",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
@@ -3,6 +3,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  clearRequestScopedFileCache,
   getCurrentRequestContext,
   getRequestScopedFile,
   isMultiProjectAdapter,
@@ -124,13 +125,15 @@ describe("MultiProjectFSAdapter", () => {
       await withAdapterAsync((adapter) => adapter.initialize());
     });
 
-    it("refreshSourceSnapshot should delegate to the request-scoped adapter", async () => {
+    it("refreshSourceSnapshot should delegate and clear request-scoped file cache", async () => {
       await withAdapterAsync(async (adapter) => {
         const originalManager = (adapter as any).manager;
         let refreshedReason: string | undefined;
         let capturedProjectSlug: string | undefined;
         let capturedProjectId: string | undefined;
         let capturedBranch: string | null | undefined;
+        let cachedBeforeRefresh: string | undefined;
+        let cachedAfterRefresh: string | undefined;
 
         (adapter as any).manager = {
           getAdapter(
@@ -160,7 +163,12 @@ describe("MultiProjectFSAdapter", () => {
           await adapter.runWithContext(
             "project-a",
             "test-token",
-            () => adapter.refreshSourceSnapshot("review-comment"),
+            async () => {
+              setRequestScopedFile("file:pages/index.mdx", "stale-content");
+              cachedBeforeRefresh = getRequestScopedFile("file:pages/index.mdx");
+              await adapter.refreshSourceSnapshot("review-comment");
+              cachedAfterRefresh = getRequestScopedFile("file:pages/index.mdx");
+            },
             "project-id-a",
             { branch: "main" },
           );
@@ -172,6 +180,8 @@ describe("MultiProjectFSAdapter", () => {
         assertEquals(capturedProjectSlug, "project-a");
         assertEquals(capturedProjectId, "project-id-a");
         assertEquals(capturedBranch, "main");
+        assertEquals(cachedBeforeRefresh, "stale-content");
+        assertEquals(cachedAfterRefresh, undefined);
       });
     });
   });
@@ -334,6 +344,24 @@ describe("getRequestScopedFile / setRequestScopedFile", () => {
       },
     );
   });
+
+  it("should clear all files in the current context", async () => {
+    await runWithRequestContext(
+      { projectSlug: "proj", token: "tok" },
+      async () => {
+        setRequestScopedFile("file:a.ts", "a");
+        setRequestScopedFile("file:b.ts", "b");
+
+        assertEquals(clearRequestScopedFileCache(), 2);
+        assertEquals(getRequestScopedFile("file:a.ts"), undefined);
+        assertEquals(getRequestScopedFile("file:b.ts"), undefined);
+      },
+    );
+  });
+
+  it("should return zero when no context is active", () => {
+    assertEquals(clearRequestScopedFileCache(), 0);
+  });
 });
 
 describe("wrapWithCurrentContext", () => {
@@ -376,5 +404,12 @@ describe("globalThis.__vf_multi_project_adapter", () => {
 
   it("should have setRequestScopedFile function", () => {
     assertEquals(typeof globalThis.__vf_multi_project_adapter!.setRequestScopedFile, "function");
+  });
+
+  it("should have clearRequestScopedFileCache function", () => {
+    assertEquals(
+      typeof globalThis.__vf_multi_project_adapter!.clearRequestScopedFileCache,
+      "function",
+    );
   });
 });

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
@@ -5,8 +5,13 @@ import type { FileInfo, ResolveFileOptions } from "../../base.ts";
 import { ProxyFSAdapterManager } from "./proxy-manager.ts";
 import type { VeryfrontFSAdapter } from "./adapter.ts";
 import { runWithCacheBatching } from "#veryfront/cache/request-cache-batcher.ts";
-import { asyncLocalStorage, type RequestContext } from "./request-context.ts";
+import {
+  asyncLocalStorage,
+  clearRequestScopedFileCache,
+  type RequestContext,
+} from "./request-context.ts";
 export {
+  clearRequestScopedFileCache,
   getCurrentRequestContext,
   getRequestScopedFile,
   runWithRequestContext,
@@ -211,6 +216,13 @@ export class MultiProjectFSAdapter implements FSAdapter {
   async refreshSourceSnapshot(reason?: string): Promise<void> {
     const adapter = await this.getAdapter();
     await adapter.refreshSourceSnapshot(reason);
+    const cleared = clearRequestScopedFileCache();
+    if (cleared > 0) {
+      logger.debug("Cleared request-scoped file cache after source snapshot refresh", {
+        reason,
+        cleared,
+      });
+    }
   }
 
   dispose(): void {

--- a/src/platform/adapters/fs/veryfront/request-context.ts
+++ b/src/platform/adapters/fs/veryfront/request-context.ts
@@ -51,6 +51,13 @@ export function setRequestScopedFile(cacheKey: string, content: string): void {
   asyncLocalStorage.getStore()?.fileCache?.set(cacheKey, content);
 }
 
+export function clearRequestScopedFileCache(): number {
+  const fileCache = asyncLocalStorage.getStore()?.fileCache;
+  const cleared = fileCache?.size ?? 0;
+  fileCache?.clear();
+  return cleared;
+}
+
 /**
  * Run a function within a request context.
  * Standalone version that doesn't require an adapter instance.
@@ -91,6 +98,7 @@ interface VfMultiProjectAdapterGlobal {
   getCurrentRequestContext: () => RequestContext | null;
   getRequestScopedFile: (cacheKey: string) => string | undefined;
   setRequestScopedFile: (cacheKey: string, content: string) => void;
+  clearRequestScopedFileCache: () => number;
 }
 
 declare global {
@@ -102,4 +110,5 @@ globalThis.__vf_multi_project_adapter = {
   getCurrentRequestContext,
   getRequestScopedFile,
   setRequestScopedFile,
+  clearRequestScopedFileCache,
 };

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.819";
+export const VERSION = "0.1.820";


### PR DESCRIPTION
## Summary
- Clear the request-scoped file cache after preview source snapshot refresh.
- Keep stale MDX retry from reusing content read during the failed attempt.
- Bump the package/runtime version to `0.1.820`.

## Context
Follow-up to #2475. The preview retry runs inside the same `runWithContext`, so the request-scoped file cache must be cleared after refresh before the retry resolves page/dependency content.

## Test Plan
- `deno fmt --check src/platform/adapters/fs/veryfront/request-context.ts src/platform/adapters/fs/veryfront/multi-project-adapter.ts src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts deno.json src/utils/version-constant.ts`
- `git diff --check HEAD~1 HEAD`
- `deno check src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts src/platform/adapters/fs/wrapper.test.ts src/rendering/page-rendering.test.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version.test.ts`
- `deno test --no-check --allow-all src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts src/platform/adapters/fs/wrapper.test.ts src/rendering/page-rendering.test.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version.test.ts`