### PR TITLE
Cancel active agent runtime on client detach

### DIFF
--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -697,6 +697,61 @@ describe("internal-agents/run-stream", () => {
     await reader.cancel();
   });
 
+  it("cancels an active runtime stream when the client disconnects before a tool wait", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    const agent = {
+      id: "disconnect-agent",
+      config: {
+        id: "disconnect-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "disconnect-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_disconnect",
+      messages: [],
+      tools: [],
+      context: [],
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    let runtimeCancelCalls = 0;
+    const response = await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        createRuntime: () => ({
+          stream: async () =>
+            new ReadableStream<Uint8Array>({
+              cancel() {
+                runtimeCancelCalls++;
+              },
+            }),
+        }),
+      },
+    );
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error("Expected a runtime response body");
+    }
+
+    const decoder = new TextDecoder();
+    const started = await reader.read();
+    assertStringIncludes(decoder.decode(started.value), "event: RunStarted");
+
+    await reader.cancel();
+    for (let attempt = 0; attempt < 20 && runtimeCancelCalls === 0; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    assertEquals(runtimeCancelCalls, 1);
+    assertEquals(sessionManager.getRunStatus(input.runId), null);
+  });
+
   it("debug logs runtime reader cancellation failures during abort cleanup", async () => {
     const logs = captureConsoleJsonLogs();
     try {

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -687,10 +687,17 @@ export async function createRuntimeAgentStreamResponse(
       clientAttached = false;
       stopHeartbeat?.();
       stopHeartbeat = undefined;
+      const status = deps.sessionManager.getRunStatus(input.runId);
+      const shouldCancelActiveRun = status !== null && status !== "waiting";
+      if (shouldCancelActiveRun) {
+        deps.sessionManager.cancelRun(input.runId);
+      }
       logger.info("Internal agent runtime client detached", {
         runId: input.runId,
         threadId: input.threadId,
         agentId: agent.id,
+        status,
+        cancelledActiveRun: shouldCancelActiveRun,
       });
       return Promise.resolve();
     },


### PR DESCRIPTION
## Summary
- cancel the underlying active runtime session when the control-plane stream client disconnects before a tool wait
- preserve the existing waiting-for-tool detach behavior so Studio-injected tool waits remain resumable
- add a regression test for active runtime cancellation on client detach

## Production evidence
- Tracks veryfront/veryfront-studio#4996
- Production run `f34f89d8-d692-407f-ba34-543dc8847e16` was persisted as `RUNTIME_STREAM_INTERRUPTED` at `2026-06-16 13:57:44 UTC` after the API client detached.
- Runtime owner pod `veryfront-server-848b96b495-mmhrx` at `10.192.14.252` logged `Internal agent runtime client detached` at `13:57:44.273Z`, then continued and logged `Internal agent runtime stream finalized` at `13:57:55.445Z` with `sawVisibleOutput=true`, `sawTerminalError=false`, `finishReason=stop`.
- Root cause: `createRuntimeAgentStreamResponse` only set `clientAttached=false` on response cancel, so active runtime execution could continue after the API had already lost the SSE stream and marked the run interrupted.

## Verification
- Red: new `src/internal-agents/run-stream.test.ts` case failed with `runtimeCancelCalls` actual `0`, expected `1`.
- Green: `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/internal-agents/run-stream.test.ts src/server/handlers/request/agent-stream.handler.test.ts` passed: 2 files, 34 steps.
- Type check: `deno check src/internal-agents/run-stream.ts src/internal-agents/run-stream.test.ts` passed.
- Broader `deno task test:unit` and pre-push hook remain blocked by unrelated `src/observability/metrics/config.test.ts` expectations (`console` expected, `otlp` actual) in two assertions; 2166 tests passed before that failure.
