### PR TITLE
Prevent stale JSX module reuse in preview

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.820",
+  "version": "0.1.821",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/transforms/mdx/esm-module-loader/cache-format.test.ts
+++ b/src/transforms/mdx/esm-module-loader/cache-format.test.ts
@@ -103,16 +103,21 @@ describe("transforms/mdx/esm-module-loader/cache-format", () => {
 
   describe("buildMdxJsxCacheFileName", () => {
     it("produces a jsx-<namespace>-<hash>.mjs filename", () => {
-      const name = buildMdxJsxCacheFileName("fixtures/project/Button.tsx");
+      const name = buildMdxJsxCacheFileName(
+        "fixtures/project/Button.tsx",
+        "export default function Button() {}",
+      );
       assertEquals(name.startsWith(`jsx-${MDX_ESM_CACHE_NAMESPACE}-`), true);
       assertEquals(name.endsWith(".mjs"), true);
     });
 
-    it("derives distinct names from distinct paths but is path-deterministic", () => {
-      const a = buildMdxJsxCacheFileName("fixtures/a/Button.tsx");
-      const b = buildMdxJsxCacheFileName("fixtures/b/Button.tsx");
+    it("derives distinct names from distinct paths and source contents", () => {
+      const a = buildMdxJsxCacheFileName("fixtures/a/Button.tsx", "export const A = 1;");
+      const b = buildMdxJsxCacheFileName("fixtures/b/Button.tsx", "export const A = 1;");
+      const changed = buildMdxJsxCacheFileName("fixtures/a/Button.tsx", "export default 1;");
       assertEquals(a !== b, true);
-      assertEquals(a, buildMdxJsxCacheFileName("fixtures/a/Button.tsx"));
+      assertEquals(a !== changed, true);
+      assertEquals(a, buildMdxJsxCacheFileName("fixtures/a/Button.tsx", "export const A = 1;"));
     });
   });
 

--- a/src/transforms/mdx/esm-module-loader/cache-format.ts
+++ b/src/transforms/mdx/esm-module-loader/cache-format.ts
@@ -64,8 +64,12 @@ function formatMdxEsmModuleRecoveryCacheKey(
   return `${namespace}:${projectId}:${contentSourceId}:${fileName}:vfmod`;
 }
 
-function formatMdxJsxCacheFileName(namespace: string, filePath: string): string {
-  return `jsx-${namespace}-${hashString(filePath)}.mjs`;
+function formatMdxJsxCacheFileName(
+  namespace: string,
+  filePath: string,
+  sourceCode: string,
+): string {
+  return `jsx-${namespace}-${hashString(`${filePath}\0${sourceCode}`)}.mjs`;
 }
 
 function formatFrameworkVfModuleCacheFileName(
@@ -99,13 +103,17 @@ function buildMdxEsmCacheSchemaSample() {
       "preview-main",
       formatMdxEsmModuleFileName(CACHE_NAMESPACE_SENTINEL, "deadbeef"),
     ),
-    jsxFile: formatMdxJsxCacheFileName(CACHE_NAMESPACE_SENTINEL, "/tmp/project/Button.tsx"),
+    jsxFile: formatMdxJsxCacheFileName(
+      CACHE_NAMESPACE_SENTINEL,
+      "/tmp/project/Button.tsx",
+      "export default function Button() {}",
+    ),
     unresolvedVfModulesPattern: UNRESOLVED_VF_MODULES_PATTERN.source,
     allFileUrlPattern: ALL_FILE_URL_PATTERN_SOURCE,
     mjsFileUrlPattern: MJS_FILE_URL_PATTERN_SOURCE,
     sourceHashing: [
       hashString("_vf_modules/pages/index.jsexport default 1;"),
-      hashString("/tmp/project/Button.tsx"),
+      hashString("/tmp/project/Button.tsx\0export default function Button() {}"),
     ],
     publicRuntimeAliases: buildPublicRuntimeAliasSchema({
       "veryfront/head": "./src/react/runtime/core.ts",
@@ -186,8 +194,8 @@ export function buildMdxEsmModuleRecoveryCacheKey(
   );
 }
 
-export function buildMdxJsxCacheFileName(filePath: string): string {
-  return formatMdxJsxCacheFileName(MDX_ESM_CACHE_NAMESPACE, filePath);
+export function buildMdxJsxCacheFileName(filePath: string, sourceCode: string): string {
+  return formatMdxJsxCacheFileName(MDX_ESM_CACHE_NAMESPACE, filePath, sourceCode);
 }
 
 export function buildFrameworkVfModuleCacheFileName(

--- a/src/transforms/mdx/esm-module-loader/import-transformer.ts
+++ b/src/transforms/mdx/esm-module-loader/import-transformer.ts
@@ -127,7 +127,23 @@ export async function transformJsxImports(
   const transformResults = await Promise.all(
     importsToProcess.map(async ({ fullMatch, importClause, filePath, ext }) => {
       try {
-        const transformedFileName = buildMdxJsxCacheFileName(filePath);
+        const isFrameworkFile = filePath.startsWith(FRAMEWORK_ROOT);
+        let jsxCode: string | Uint8Array;
+        if (isFrameworkFile) {
+          jsxCode = await getLocalFs().readTextFile(filePath);
+        } else if (adapter) {
+          jsxCode = await adapter.fs.readFile(filePath);
+        } else {
+          logger.warn(
+            `${LOG_PREFIX_MDX_LOADER} No adapter available to read JSX file: ${filePath}`,
+          );
+          return null;
+        }
+
+        const sourceCode = typeof jsxCode === "string"
+          ? jsxCode
+          : new TextDecoder().decode(jsxCode);
+        const transformedFileName = buildMdxJsxCacheFileName(filePath, sourceCode);
         const transformedPath = join(esmCacheDir, transformedFileName);
 
         try {
@@ -146,19 +162,6 @@ export async function transformJsxImports(
           /* expected: cached JSX module may not exist yet */
         }
 
-        const isFrameworkFile = filePath.startsWith(FRAMEWORK_ROOT);
-        let jsxCode: string | Uint8Array;
-        if (isFrameworkFile) {
-          jsxCode = await getLocalFs().readTextFile(filePath);
-        } else if (adapter) {
-          jsxCode = await adapter.fs.readFile(filePath);
-        } else {
-          logger.warn(
-            `${LOG_PREFIX_MDX_LOADER} No adapter available to read JSX file: ${filePath}`,
-          );
-          return null;
-        }
-
         const loaderMap: Record<string, "js" | "jsx" | "ts" | "tsx"> = {
           tsx: "tsx",
           ts: "ts",
@@ -167,7 +170,7 @@ export async function transformJsxImports(
         };
         const loader = loaderMap[ext] ?? "tsx";
 
-        const result = await transform(jsxCode as string, {
+        const result = await transform(sourceCode, {
           loader,
           jsx: "transform",
           jsxFactory: ESBUILD_JSX_FACTORY,

--- a/src/transforms/mdx/esm-module-loader/jsx-cache.test.ts
+++ b/src/transforms/mdx/esm-module-loader/jsx-cache.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 /** @module transforms/mdx/esm-module-loader/jsx-cache.test */
 
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   makeTempDir,
@@ -10,20 +10,28 @@ import {
   writeTextFile,
 } from "#veryfront/testing/deno-compat.ts";
 import { join } from "#veryfront/compat/path";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { FRAMEWORK_ROOT } from "./constants.ts";
 import { buildMdxJsxCacheFileName } from "./cache-format.ts";
+import { transformJsxImports } from "./import-transformer.ts";
 import { ensureCachedJsxModulePatched } from "./jsx-cache.ts";
+
+function extractCachedJsxPath(code: string): string {
+  const match = code.match(/file:\/\/([^"']+jsx-[^"']+\.mjs)/);
+  assertExists(match?.[1]);
+  return match[1];
+}
 
 describe("ensureCachedJsxModulePatched", () => {
   it("rewrites relative _dnt imports inside cached JSX modules", async () => {
     const tempDir = await makeTempDir({ prefix: "vf-jsx-cache-test-" });
 
     try {
-      const cachedPath = join(tempDir, buildMdxJsxCacheFileName("/tmp/source/Head.tsx"));
       const badCode = [
         `import "../../../_dnt.polyfills.js";`,
         `export const value = 1;`,
       ].join("\n");
+      const cachedPath = join(tempDir, buildMdxJsxCacheFileName("/tmp/source/Head.tsx", badCode));
       await writeTextFile(cachedPath, badCode);
 
       const sourceFilePath = join(
@@ -43,6 +51,51 @@ describe("ensureCachedJsxModulePatched", () => {
         rewritten.includes(`file://${join(FRAMEWORK_ROOT, "_dnt.polyfills.js")}`),
         true,
       );
+    } finally {
+      await remove(tempDir, { recursive: true });
+    }
+  });
+});
+
+describe("transformJsxImports", () => {
+  it("uses a distinct cached JSX module when source content changes at the same path", async () => {
+    const tempDir = await makeTempDir({ prefix: "vf-jsx-content-cache-test-" });
+    const sourcePath = "/tmp/source/PlatformOverview.tsx";
+    const firstSource = "export const PlatformOverview = () => <svg />;";
+    const secondSource = "export default function PlatformOverview() { return <svg />; }";
+    const files = new Map<string, string>([
+      [
+        sourcePath,
+        firstSource,
+      ],
+    ]);
+    const adapter = {
+      fs: {
+        readFile: (path: string) => {
+          const source = files.get(path);
+          if (source === undefined) throw new Error(`unexpected read: ${path}`);
+          return Promise.resolve(source);
+        },
+      },
+    } as unknown as RuntimeAdapter;
+    const mdxImportCode = `import PlatformOverview from "file://${sourcePath}";`;
+
+    try {
+      const firstCachedPath = join(tempDir, buildMdxJsxCacheFileName(sourcePath, firstSource));
+      const secondCachedPath = join(tempDir, buildMdxJsxCacheFileName(sourcePath, secondSource));
+      await writeTextFile(firstCachedPath, "export const PlatformOverview = () => null;");
+      await writeTextFile(secondCachedPath, "export default function PlatformOverview() {}");
+
+      const first = await transformJsxImports(mdxImportCode, adapter, tempDir);
+      const firstPath = extractCachedJsxPath(first);
+
+      files.set(sourcePath, secondSource);
+      const second = await transformJsxImports(mdxImportCode, adapter, tempDir);
+      const secondPath = extractCachedJsxPath(second);
+
+      assertEquals(firstPath, firstCachedPath);
+      assertEquals(secondPath, secondCachedPath);
+      assertEquals((await readTextFile(secondPath)).includes("default"), true);
     } finally {
       await remove(tempDir, { recursive: true });
     }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.820";
+export const VERSION = "0.1.821";


### PR DESCRIPTION
## Summary
- key transformed JSX cache files by source path plus source content
- add a regression for same-path JSX source changing from named export to default export
- bump Veryfront version to 0.1.821 in deno.json and version-constant.ts

## Why
The live tomcode preview request hit the newly deployed 0.1.820 server path, but cache recovery regenerated a page wrapper that imported `PlatformOverview` as a default export while the cached JSX module still exposed only a named `PlatformOverview` export. The JSX cache was keyed only by source path, so a same-path edit could keep serving stale transformed code after a source snapshot refresh.

## Verification
- `deno test --allow-all src/transforms/mdx/esm-module-loader/cache-format.test.ts src/transforms/mdx/esm-module-loader/jsx-cache.test.ts`
- `deno test --no-check --allow-all src/transforms/mdx/esm-module-loader/loader.test.ts src/rendering/page-rendering.test.ts src/rendering/orchestrator/pipeline.behavior.test.ts`
- `deno test --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts`
- `git diff --check`
- pre-push checks: format, lint, type check, generate, 2168 unit tests passed

## Not tested
- live tomcode Studio preview on a production build of 0.1.821