### PR TITLE
Release v0.1.822

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.821",
+  "version": "0.1.822",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.821";
+export const VERSION = "0.1.822";


### PR DESCRIPTION
## Summary
- Bump veryfront from 0.1.821 to 0.1.822 so the runtime stream detach fix merged in #2477 is released.

## Test Plan
- deno fmt --check deno.json src/utils/version-constant.ts
- deno check src/utils/version-constant.ts