### PR TITLE
fix: suppress low-pressure rapid heap warnings

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.822",
+  "version": "0.1.823",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/memory/profiler.test.ts
+++ b/src/utils/memory/profiler.test.ts
@@ -193,6 +193,30 @@ describe("memory/profiler", () => {
       assertEquals(sustained.growthMB, 135);
       assertEquals(sustained.pending, undefined);
     });
+
+    it("defers sustained rapid heap growth warnings while heap pressure is low", () => {
+      const first = getRapidHeapGrowthEvaluation({
+        previousHeapUsedMB: 99.16,
+        currentHeapUsedMB: 212.69,
+        pending: undefined,
+        thresholdMB: 100,
+        currentHeapUsedPercent: 4.15,
+        memoryPressureWarningThresholdPercent: 75,
+      });
+
+      const sustainedLowPressure = getRapidHeapGrowthEvaluation({
+        previousHeapUsedMB: 212.69,
+        currentHeapUsedMB: 235.59,
+        pending: first.pending,
+        thresholdMB: 100,
+        currentHeapUsedPercent: 4.6,
+        memoryPressureWarningThresholdPercent: 75,
+      });
+
+      assertEquals(sustainedLowPressure.shouldWarn, false);
+      assertEquals(sustainedLowPressure.pending?.baselineHeapUsedMB, 99.16);
+      assertEquals(sustainedLowPressure.pending?.observedGrowthMB, 113.53);
+    });
   });
 
   describe("checkMemoryPressure", () => {

--- a/src/utils/memory/profiler.ts
+++ b/src/utils/memory/profiler.ts
@@ -99,8 +99,10 @@ export interface PendingRapidHeapGrowth {
 export interface RapidHeapGrowthEvaluationInput {
   previousHeapUsedMB: number;
   currentHeapUsedMB: number;
+  currentHeapUsedPercent?: number;
   pending: PendingRapidHeapGrowth | undefined;
   thresholdMB: number;
+  memoryPressureWarningThresholdPercent?: number;
 }
 
 export interface RapidHeapGrowthEvaluation {
@@ -259,6 +261,17 @@ export function getRapidHeapGrowthEvaluation(
       input.currentHeapUsedMB - input.pending.baselineHeapUsedMB,
     );
     if (sustainedGrowthMB > input.thresholdMB) {
+      if (
+        input.currentHeapUsedPercent !== undefined &&
+        input.memoryPressureWarningThresholdPercent !== undefined &&
+        input.currentHeapUsedPercent <= input.memoryPressureWarningThresholdPercent
+      ) {
+        return {
+          shouldWarn: false,
+          pending: input.pending,
+        };
+      }
+
       return {
         shouldWarn: true,
         growthMB: sustainedGrowthMB,
@@ -329,8 +342,10 @@ export function startMemoryMonitoring(intervalMs = DEFAULT_MEMORY_MONITORING_INT
     const rapidGrowthEvaluation = getRapidHeapGrowthEvaluation({
       previousHeapUsedMB: lastHeapUsed,
       currentHeapUsedMB: heap.usedHeapSizeMB,
+      currentHeapUsedPercent: heap.heapUsedPercent,
       pending: pendingRapidHeapGrowth,
       thresholdMB: HEAP_RAPID_GROWTH_THRESHOLD_MB,
+      memoryPressureWarningThresholdPercent: thresholdPercent,
     });
     pendingRapidHeapGrowth = rapidGrowthEvaluation.pending;
     if (rapidGrowthEvaluation.shouldWarn) {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.822";
+export const VERSION = "0.1.823";


### PR DESCRIPTION
## Summary
- defer rapid heap-growth warnings while heap usage remains below the configured memory warning threshold
- keep the rapid-growth candidate pending so it can still warn if heap pressure later becomes real
- bump veryfront release metadata from 0.1.822 to 0.1.823

Addresses https://github.com/veryfront/veryfront-api/issues/3200

## Verification
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/utils/memory/profiler.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/utils/version.test.ts`
- `deno fmt --check src/utils/memory/profiler.ts src/utils/memory/profiler.test.ts src/utils/version-constant.ts deno.json`
- `deno check src/utils/memory/profiler.ts src/utils/memory/profiler.test.ts src/utils/version.test.ts`
- pre-push: formatting, linter, type check, and `deno task test:unit` passed (`2168` test files, `18678` steps)