### PR TITLE
Fix default imports for preview vf modules

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.823",
+  "version": "0.1.824",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.test.ts
@@ -1,0 +1,122 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  makeTempDir,
+  readTextFile,
+  remove,
+  writeTextFile,
+} from "#veryfront/testing/deno-compat.ts";
+import { join, toFileUrl } from "#veryfront/compat/path/index.ts";
+import { cacheModule } from "./module-cache.ts";
+
+const noopLog = {
+  debug: () => {},
+  warn: () => {},
+} as never;
+
+describe("module-cache", () => {
+  it("adds a default export for filename-matched named component exports", async () => {
+    const esmCacheDir = await makeTempDir({ prefix: "vf-module-cache-default-" });
+    const projectDir = await makeTempDir({ prefix: "vf-module-cache-entry-" });
+    const entryPath = join(projectDir, "entry.mjs");
+    const sourceMap = "//# sourceMappingURL=data:application/json;base64,e30=";
+
+    try {
+      const cachedPath = await cacheModule(
+        "_vf_modules/components/PlatformOverview.js",
+        [
+          `const PlatformOverview = () => "ok";`,
+          `export {`,
+          `  PlatformOverview,`,
+          `};`,
+          sourceMap,
+        ].join("\n"),
+        esmCacheDir,
+        new Map(),
+        noopLog,
+      );
+      if (!cachedPath) throw new Error("Expected module to be cached");
+
+      const cachedCode = await readTextFile(cachedPath);
+      assertEquals(cachedCode.includes("export { PlatformOverview as default };"), true);
+      assertEquals(cachedCode.trimEnd().endsWith(sourceMap), true);
+
+      await writeTextFile(
+        entryPath,
+        [
+          `import PlatformOverview from ${JSON.stringify(toFileUrl(cachedPath).href)};`,
+          `export const value = PlatformOverview();`,
+        ].join("\n"),
+      );
+
+      const imported = await import(`${toFileUrl(entryPath).href}?v=${Date.now()}`);
+      assertEquals(imported.value, "ok");
+    } finally {
+      await remove(esmCacheDir, { recursive: true }).catch(() => {});
+      await remove(projectDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("adds a default re-export for filename-matched barrel exports", async () => {
+    const esmCacheDir = await makeTempDir({ prefix: "vf-module-cache-barrel-" });
+    const projectDir = await makeTempDir({ prefix: "vf-module-cache-barrel-entry-" });
+    const namedImplPath = join(projectDir, "named-impl.mjs");
+    const defaultImplPath = join(projectDir, "default-impl.mjs");
+
+    try {
+      await writeTextFile(namedImplPath, `export const PlatformOverview = () => "named";`);
+      await writeTextFile(defaultImplPath, `export default () => "default";`);
+
+      const cases = [
+        {
+          code: `export { PlatformOverview } from ${
+            JSON.stringify(toFileUrl(namedImplPath).href)
+          };`,
+          expectedExport: `export { PlatformOverview as default } from ${
+            JSON.stringify(toFileUrl(namedImplPath).href)
+          };`,
+          expectedValue: "named",
+        },
+        {
+          code: `export { default as PlatformOverview } from ${
+            JSON.stringify(toFileUrl(defaultImplPath).href)
+          };`,
+          expectedExport: `export { default as default } from ${
+            JSON.stringify(toFileUrl(defaultImplPath).href)
+          };`,
+          expectedValue: "default",
+        },
+      ];
+
+      for (const [index, barrel] of cases.entries()) {
+        const cachedPath = await cacheModule(
+          "_vf_modules/components/PlatformOverview.js",
+          barrel.code,
+          esmCacheDir,
+          new Map(),
+          noopLog,
+        );
+        if (!cachedPath) throw new Error("Expected module to be cached");
+
+        const cachedCode = await readTextFile(cachedPath);
+        assertEquals(cachedCode.includes(barrel.expectedExport), true);
+
+        const entryPath = join(projectDir, `barrel-entry-${index}.mjs`);
+        await writeTextFile(
+          entryPath,
+          [
+            `import PlatformOverview from ${JSON.stringify(toFileUrl(cachedPath).href)};`,
+            `export const value = PlatformOverview();`,
+          ].join("\n"),
+        );
+
+        const imported = await import(`${toFileUrl(entryPath).href}?v=${Date.now()}-${index}`);
+        assertEquals(imported.value, barrel.expectedValue);
+      }
+    } finally {
+      await remove(esmCacheDir, { recursive: true }).catch(() => {});
+      await remove(projectDir, { recursive: true }).catch(() => {});
+    }
+  });
+});

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.ts
@@ -18,6 +18,78 @@ import { buildMdxEsmModuleFileName, buildMdxEsmPathCacheKey } from "../cache-for
 import { hasUnresolvedImports } from "./nested-imports.ts";
 import { recordModuleToSession } from "./render-sessions.ts";
 
+const IDENTIFIER_PATTERN = /^[A-Za-z_$][\w$]*$/;
+const DEFAULT_EXPORT_PATTERN = /\bexport\s+default\b|\bexport\s*\{[^}]*\bas\s+default\b[^}]*\}/;
+
+interface ExportMatch {
+  localName: string;
+  sourceClause: string;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function getModuleIdentifier(normalizedPath: string): string | null {
+  const fileName = normalizedPath.replace(/\?.*$/, "").split("/").pop();
+  const identifier = fileName?.replace(/\.(?:[cm]?[jt]sx?|mdx)$/i, "");
+  if (!identifier || !IDENTIFIER_PATTERN.test(identifier)) return null;
+  return identifier;
+}
+
+function findExportMatch(moduleCode: string, exportName: string): ExportMatch | null {
+  const declarationPattern = new RegExp(
+    `\\bexport\\s+(?:const|let|var|function|class)\\s+${escapeRegex(exportName)}\\b`,
+  );
+  if (declarationPattern.test(moduleCode)) return { localName: exportName, sourceClause: "" };
+
+  const exportListPattern = /\bexport\s*\{([^}]*)\}\s*(from\s*["'][^"']+["'])?\s*(?:;|$)/gm;
+  let match: RegExpExecArray | null;
+  while ((match = exportListPattern.exec(moduleCode)) !== null) {
+    const specifiers = match[1]?.split(",") ?? [];
+    const sourceClause = match[2] ? ` ${match[2]}` : "";
+    for (const rawSpecifier of specifiers) {
+      const specifier = rawSpecifier.trim();
+      if (specifier === exportName) return { localName: exportName, sourceClause };
+
+      const alias = specifier.match(/^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/);
+      if (alias?.[2] === exportName && alias[1]) {
+        return { localName: alias[1], sourceClause };
+      }
+    }
+  }
+
+  return null;
+}
+
+function appendExportBeforeSourceMap(moduleCode: string, exportStatement: string): string {
+  const sourceMapMatch = moduleCode.match(/\n\/\/# sourceMappingURL=.*$/);
+  if (sourceMapMatch?.index === undefined) {
+    return `${moduleCode.trimEnd()}\n${exportStatement}\n`;
+  }
+
+  const beforeSourceMap = moduleCode.slice(0, sourceMapMatch.index).trimEnd();
+  const sourceMap = moduleCode.slice(sourceMapMatch.index);
+  return `${beforeSourceMap}\n${exportStatement}${
+    sourceMap.endsWith("\n") ? sourceMap : `${sourceMap}\n`
+  }`;
+}
+
+export function ensureFilenameDefaultExport(normalizedPath: string, moduleCode: string): string {
+  if (DEFAULT_EXPORT_PATTERN.test(moduleCode)) return moduleCode;
+
+  const exportName = getModuleIdentifier(normalizedPath);
+  if (!exportName) return moduleCode;
+
+  const exportMatch = findExportMatch(moduleCode, exportName);
+  if (!exportMatch) return moduleCode;
+
+  return appendExportBeforeSourceMap(
+    moduleCode,
+    `export { ${exportMatch.localName} as default }${exportMatch.sourceClause};`,
+  );
+}
+
 /**
  * Normalize a module path, resolving relative paths if a parent is provided.
  */
@@ -51,6 +123,8 @@ export async function cacheModule(
   log: Logger,
   reactVersion = REACT_DEFAULT_VERSION,
 ): Promise<string | null> {
+  moduleCode = ensureFilenameDefaultExport(normalizedPath, moduleCode);
+
   const unresolved = hasUnresolvedImports(moduleCode);
   if (unresolved.count > 0) {
     log.warn(

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/persistence.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/persistence.ts
@@ -6,7 +6,7 @@
 
 import type { Logger } from "#veryfront/utils/logger/logger.ts";
 import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
-import { cacheModule } from "./module-cache.ts";
+import { cacheModule, ensureFilenameDefaultExport } from "./module-cache.ts";
 import { writeDistributedCache } from "./distributed-cache.ts";
 
 type CacheLocalModuleFn = typeof cacheModule;
@@ -39,6 +39,7 @@ export async function persistResolvedModule(
 ): Promise<string | null> {
   const writeToDistributedCache = input.writeToDistributedCache ?? writeDistributedCache;
   const cacheLocalModule = input.cacheLocalModule ?? cacheModule;
+  const moduleCode = ensureFilenameDefaultExport(input.normalizedPath, input.moduleCode);
 
   if (input.distributedCacheWrite) {
     writeToDistributedCache(
@@ -46,7 +47,7 @@ export async function persistResolvedModule(
       input.distributedCacheWrite.transformCacheKey,
       input.distributedCacheWrite.projectId,
       input.distributedCacheWrite.contentSourceId,
-      input.moduleCode,
+      moduleCode,
       input.normalizedPath,
       input.log,
     );
@@ -59,7 +60,7 @@ export async function persistResolvedModule(
   const cacheStart = performance.now();
   const finalCachedPath = await cacheLocalModule(
     input.normalizedPath,
-    input.moduleCode,
+    moduleCode,
     input.esmCacheDir,
     input.pathCache,
     input.log,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.823";
+export const VERSION = "0.1.824";


### PR DESCRIPTION
## Summary
- Reproduces the preview failure locally by executing a cached vf module that is default-imported while its transformed body originally only named-exported the matching component.
- Adds filename-matched default export synthesis for cached vf modules that do not already expose a default export.
- Persists the normalized module shape to distributed and local caches.
- Bumps Veryfront Code to 0.1.824.

## Verification
- deno test --no-check --allow-all src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.test.ts src/transforms/mdx/esm-module-loader/loader-helpers.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts src/transforms/mdx/esm-module-loader/cache/index.test.ts
- deno check src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.ts src/transforms/mdx/esm-module-loader/module-fetcher/persistence.ts
- deno lint src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.ts src/transforms/mdx/esm-module-loader/module-fetcher/persistence.ts src/transforms/mdx/esm-module-loader/loader-helpers.test.ts src/utils/version-constant.ts
- deno run --allow-read scripts/lint/check-sanitizer-baseline.ts
- git diff --check
- pre-push hook: format, lint, type check, generate, unit tests (2169 passed)