### PR TITLE
Fix client hydration for filename-matched modules

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.824",
+  "version": "0.1.825",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/modules/loader-shared/filename-default-export.ts
+++ b/src/modules/loader-shared/filename-default-export.ts
@@ -1,0 +1,76 @@
+const IDENTIFIER_PATTERN = /^[A-Za-z_$][\w$]*$/;
+const DEFAULT_EXPORT_PATTERN = /\bexport\s+default\b|\bexport\s*\{[^}]*\bas\s+default\b[^}]*\}/;
+
+interface ExportMatch {
+  localName: string;
+  sourceClause: string;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function getModuleIdentifier(normalizedPath: string): string | null {
+  const fileName = normalizedPath.replace(/\?.*$/, "").split("/").pop();
+  const identifier = fileName?.replace(/\.(?:[cm]?[jt]sx?|mdx)$/i, "");
+  if (!identifier || !IDENTIFIER_PATTERN.test(identifier)) return null;
+  return identifier;
+}
+
+function findExportMatch(moduleCode: string, exportName: string): ExportMatch | null {
+  const declarationPattern = new RegExp(
+    `\\bexport\\s+(?:const|let|var|function|class)\\s+${escapeRegex(exportName)}\\b`,
+  );
+  if (declarationPattern.test(moduleCode)) return { localName: exportName, sourceClause: "" };
+
+  const exportListPattern = /\bexport\s*\{([^}]*)\}\s*(from\s*["'][^"']+["'])?\s*(?:;|$)/gm;
+  let match: RegExpExecArray | null;
+  while ((match = exportListPattern.exec(moduleCode)) !== null) {
+    const specifiers = match[1]?.split(",") ?? [];
+    const sourceClause = match[2] ? ` ${match[2]}` : "";
+    for (const rawSpecifier of specifiers) {
+      const specifier = rawSpecifier.trim();
+      if (specifier === exportName) return { localName: exportName, sourceClause };
+
+      const alias = specifier.match(/^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/);
+      if (alias?.[2] === exportName && alias[1]) {
+        return { localName: alias[1], sourceClause };
+      }
+    }
+  }
+
+  return null;
+}
+
+function appendExportBeforeSourceMap(moduleCode: string, exportStatement: string): string {
+  const sourceMapMarker = "//# sourceMappingURL=";
+  let sourceMapIndex = moduleCode.lastIndexOf(`\n${sourceMapMarker}`);
+  if (sourceMapIndex < 0 && moduleCode.startsWith(sourceMapMarker)) {
+    sourceMapIndex = 0;
+  }
+
+  if (sourceMapIndex < 0) {
+    return `${moduleCode.trimEnd()}\n${exportStatement}\n`;
+  }
+
+  const beforeSourceMap = moduleCode.slice(0, sourceMapIndex).trimEnd();
+  const sourceMap = moduleCode.slice(sourceMapIndex);
+  return `${beforeSourceMap}\n${exportStatement}${
+    sourceMap.endsWith("\n") ? sourceMap : `${sourceMap}\n`
+  }`;
+}
+
+export function ensureFilenameDefaultExport(normalizedPath: string, moduleCode: string): string {
+  if (DEFAULT_EXPORT_PATTERN.test(moduleCode)) return moduleCode;
+
+  const exportName = getModuleIdentifier(normalizedPath);
+  if (!exportName) return moduleCode;
+
+  const exportMatch = findExportMatch(moduleCode, exportName);
+  if (!exportMatch) return moduleCode;
+
+  return appendExportBeforeSourceMap(
+    moduleCode,
+    `export { ${exportMatch.localName} as default }${exportMatch.sourceClause};`,
+  );
+}

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -9,7 +9,7 @@ import "#veryfront/schemas/_test-setup.ts";
  * @module modules/server/module-server.test
  */
 
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   buildServerTimingHeader,
@@ -403,6 +403,64 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
       const header = buildServerTimingHeader(record!);
       assertEquals(header.includes("module.source_lookup"), true);
       assertEquals(header.includes("module.transform"), true);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("adds a default export for filename-matched browser modules", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-client-default-module-" });
+
+    try {
+      await Deno.mkdir(`${projectDir}/components`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/components/PlatformOverview.ts`,
+        `export const PlatformOverview = () => "ok";\n`,
+      );
+
+      const response = await serve(
+        new Request("http://localhost:3000/_vf_modules/components/PlatformOverview.js"),
+        projectDir,
+      );
+
+      assertEquals(response.status, 200);
+      const text = await response.text();
+      assertStringIncludes(text, "export { PlatformOverview as default };");
+      assertEquals(
+        /export \{ PlatformOverview as default \};\n\/\/# sourceMappingURL=/.test(text),
+        true,
+      );
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("adds a default export for filename-matched browser barrel modules", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-client-barrel-default-module-" });
+
+    try {
+      await Deno.mkdir(`${projectDir}/components`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/components/impl.ts`,
+        `export const PlatformOverview = () => "ok";\n`,
+      );
+      await Deno.writeTextFile(
+        `${projectDir}/components/PlatformOverview.ts`,
+        `export { PlatformOverview } from "./impl.ts";\n`,
+      );
+
+      const response = await serve(
+        new Request("http://localhost:3000/_vf_modules/components/PlatformOverview.js"),
+        projectDir,
+      );
+
+      assertEquals(response.status, 200);
+      const text = await response.text();
+      assertStringIncludes(text, "export { PlatformOverview as default };");
+      assertEquals(
+        /export \{ PlatformOverview as default \};\n\/\/# sourceMappingURL=/.test(text),
+        true,
+      );
     } finally {
       await Deno.remove(projectDir, { recursive: true });
     }

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -35,6 +35,7 @@ import {
   hasSourceMiss,
   rememberSourceMiss,
 } from "./module-source-resolution-cache.ts";
+import { ensureFilenameDefaultExport } from "#veryfront/modules/loader-shared/filename-default-export.ts";
 
 const logger = serverLogger.component("module-server");
 const PROJECT_FALLBACK_EMBEDDED_POLYFILLS = new Set(["deno"]);
@@ -478,6 +479,7 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
           code = await profileModuleTransform(() =>
             transformToESM(source, sourceFile, projectDir, adapter, transformOpts)
           );
+          code = ensureFilenameDefaultExport(modulePath, code);
 
           if (isSSR) {
             code = await applySSRImportRewritesAsync(code, {

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.ts
@@ -17,78 +17,7 @@ import { hashString } from "../utils/hash.ts";
 import { buildMdxEsmModuleFileName, buildMdxEsmPathCacheKey } from "../cache-format.ts";
 import { hasUnresolvedImports } from "./nested-imports.ts";
 import { recordModuleToSession } from "./render-sessions.ts";
-
-const IDENTIFIER_PATTERN = /^[A-Za-z_$][\w$]*$/;
-const DEFAULT_EXPORT_PATTERN = /\bexport\s+default\b|\bexport\s*\{[^}]*\bas\s+default\b[^}]*\}/;
-
-interface ExportMatch {
-  localName: string;
-  sourceClause: string;
-}
-
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function getModuleIdentifier(normalizedPath: string): string | null {
-  const fileName = normalizedPath.replace(/\?.*$/, "").split("/").pop();
-  const identifier = fileName?.replace(/\.(?:[cm]?[jt]sx?|mdx)$/i, "");
-  if (!identifier || !IDENTIFIER_PATTERN.test(identifier)) return null;
-  return identifier;
-}
-
-function findExportMatch(moduleCode: string, exportName: string): ExportMatch | null {
-  const declarationPattern = new RegExp(
-    `\\bexport\\s+(?:const|let|var|function|class)\\s+${escapeRegex(exportName)}\\b`,
-  );
-  if (declarationPattern.test(moduleCode)) return { localName: exportName, sourceClause: "" };
-
-  const exportListPattern = /\bexport\s*\{([^}]*)\}\s*(from\s*["'][^"']+["'])?\s*(?:;|$)/gm;
-  let match: RegExpExecArray | null;
-  while ((match = exportListPattern.exec(moduleCode)) !== null) {
-    const specifiers = match[1]?.split(",") ?? [];
-    const sourceClause = match[2] ? ` ${match[2]}` : "";
-    for (const rawSpecifier of specifiers) {
-      const specifier = rawSpecifier.trim();
-      if (specifier === exportName) return { localName: exportName, sourceClause };
-
-      const alias = specifier.match(/^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/);
-      if (alias?.[2] === exportName && alias[1]) {
-        return { localName: alias[1], sourceClause };
-      }
-    }
-  }
-
-  return null;
-}
-
-function appendExportBeforeSourceMap(moduleCode: string, exportStatement: string): string {
-  const sourceMapMatch = moduleCode.match(/\n\/\/# sourceMappingURL=.*$/);
-  if (sourceMapMatch?.index === undefined) {
-    return `${moduleCode.trimEnd()}\n${exportStatement}\n`;
-  }
-
-  const beforeSourceMap = moduleCode.slice(0, sourceMapMatch.index).trimEnd();
-  const sourceMap = moduleCode.slice(sourceMapMatch.index);
-  return `${beforeSourceMap}\n${exportStatement}${
-    sourceMap.endsWith("\n") ? sourceMap : `${sourceMap}\n`
-  }`;
-}
-
-export function ensureFilenameDefaultExport(normalizedPath: string, moduleCode: string): string {
-  if (DEFAULT_EXPORT_PATTERN.test(moduleCode)) return moduleCode;
-
-  const exportName = getModuleIdentifier(normalizedPath);
-  if (!exportName) return moduleCode;
-
-  const exportMatch = findExportMatch(moduleCode, exportName);
-  if (!exportMatch) return moduleCode;
-
-  return appendExportBeforeSourceMap(
-    moduleCode,
-    `export { ${exportMatch.localName} as default }${exportMatch.sourceClause};`,
-  );
-}
+import { ensureFilenameDefaultExport } from "#veryfront/modules/loader-shared/filename-default-export.ts";
 
 /**
  * Normalize a module path, resolving relative paths if a parent is provided.

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/persistence.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/persistence.ts
@@ -6,7 +6,8 @@
 
 import type { Logger } from "#veryfront/utils/logger/logger.ts";
 import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
-import { cacheModule, ensureFilenameDefaultExport } from "./module-cache.ts";
+import { ensureFilenameDefaultExport } from "#veryfront/modules/loader-shared/filename-default-export.ts";
+import { cacheModule } from "./module-cache.ts";
 import { writeDistributedCache } from "./distributed-cache.ts";
 
 type CacheLocalModuleFn = typeof cacheModule;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.824";
+export const VERSION = "0.1.825";


### PR DESCRIPTION
## Summary
- Share filename-based default export synthesis between MDX ESM cache and browser module server
- Apply it to /_vf_modules project module responses after transformToESM
- Bump veryfront-code version to 0.1.825

## Why
TOMcode no longer fails SSR after 0.1.824, but browser hydration still imports /_vf_modules/components/PlatformOverview.js as a default export. That route bypassed the cache path fixed in #2481, so it could still serve only a named PlatformOverview export and abort hydration. This also explains the footer color toggle not working: hydration stops before event handlers attach.

## Verification
- deno test --no-check --allow-all src/modules/server/module-server.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.test.ts
- deno check src/modules/server/module-server.test.ts src/modules/server/module-server.ts src/modules/loader-shared/filename-default-export.ts src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.ts src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.test.ts
- deno lint src/modules/server/module-server.test.ts src/modules/server/module-server.ts src/modules/loader-shared/filename-default-export.ts src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.ts src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.test.ts deno.json src/utils/version-constant.ts
- git diff --check