### PR TITLE
Include browser-reachable custom folders in release assets

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.825",
+  "version": "0.1.826",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -840,6 +840,55 @@ describe("release asset build executor", () => {
     assert(!pageUpload.text.includes("/components/Button.js"));
   });
 
+  it("rewrites browser-reachable imports from arbitrary project folders", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "pages/index.tsx",
+        content: 'import Header from "../components/Header.tsx"; export default Header;',
+      },
+      {
+        path: "components/Header.tsx",
+        content: 'import { BreakpointsProvider } from "../custom-client/BreakpointsProvider.tsx";',
+      },
+      {
+        path: "custom-client/BreakpointsProvider.tsx",
+        content: "export const BreakpointsProvider = ({ children }) => children;",
+      },
+    ];
+    const client = makeClient(files, rec);
+    const transform = (_source: string, sourceFile: string) => {
+      if (sourceFile.endsWith("pages/index.tsx")) {
+        return Promise.resolve(
+          'import Header from "/_vf_modules/components/Header.js"; export default Header;',
+        );
+      }
+      if (sourceFile.endsWith("components/Header.tsx")) {
+        return Promise.resolve(
+          'import { BreakpointsProvider } from "../../custom-client/BreakpointsProvider.js"; export { BreakpointsProvider };',
+        );
+      }
+      return Promise.resolve("export const BreakpointsProvider = ({ children }) => children;");
+    };
+
+    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    const providerHash = manifest.modules["custom-client/BreakpointsProvider.tsx"]?.contentHash;
+    assertExists(providerHash);
+    const headerHash = manifest.modules["components/Header.tsx"]?.contentHash;
+    assertExists(headerHash);
+
+    const headerUpload = rec.uploads.find((u) => u.hash === headerHash);
+    assertExists(headerUpload);
+    assert(headerUpload.text.includes(`"/_vf/assets/${providerHash}.js"`));
+    assert(!headerUpload.text.includes("../../custom-client/BreakpointsProvider.js"));
+
+    const routeModules = manifest.routes["/"]?.modules ?? [];
+    assert(routeModules.includes("custom-client/BreakpointsProvider.tsx"));
+  });
+
   it("does not rewrite import-like strings or comments in transformed modules", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -55,7 +55,7 @@ const logger = serverLogger.component("release-asset-build");
 
 /** Browser module source extensions eligible for transform. */
 const BROWSER_MODULE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js", ".mdx"];
-/** Directories whose modules are part of the browser closure. */
+/** Directories used as browser graph entry seeds. Imports may reach any project directory. */
 const BROWSER_MODULE_DIRS = ["pages/", "components/", "layouts/", "lib/", "src/"];
 const FRAMEWORK_MODULE_URL_PREFIX = "/_vf_modules/_veryfront/";
 const REACT_IMPORT_MAP_DEPENDENCIES = [
@@ -245,9 +245,15 @@ function sanitizeError(error: unknown): string {
 }
 
 /** True when a logical path is an eligible browser module. */
-function isBrowserModule(path: string): boolean {
+function isTransformableBrowserModule(path: string): boolean {
   if (!BROWSER_MODULE_EXTENSIONS.some((ext) => path.endsWith(ext))) return false;
   if (path.endsWith(".d.ts")) return false;
+  return true;
+}
+
+/** True when a logical path should seed the browser module graph. */
+function isBrowserModule(path: string): boolean {
+  if (!isTransformableBrowserModule(path)) return false;
   return BROWSER_MODULE_DIRS.some((dir) => path.startsWith(dir));
 }
 
@@ -1489,57 +1495,35 @@ async function runBuildInner(
   const knownPaths = new Set(sourceByPath.keys());
   const vendorHttpImports = input.vendorHttpImports ?? vendorHttpImportsWithCache;
   const vendorDependencies = isDependencyImportMapEnabled();
+  const transformingModules = new Set<string>();
 
-  for (const [logicalPath, source] of sourceByPath) {
-    if (!isBrowserModule(logicalPath)) continue;
+  async function transformProjectModule(
+    logicalPath: string,
+  ): Promise<ReleaseAssetBuildResult | null> {
+    if (transformedModules.has(logicalPath) || transformingModules.has(logicalPath)) return null;
+    if (!isTransformableBrowserModule(logicalPath)) return null;
 
-    // M2: enforce client-side size limit before transform (source is a proxy;
-    // transformed output is checked after encoding below).
-    const sourceFile = join(tempDir, logicalPath);
-    let code: string;
+    const source = sourceByPath.get(logicalPath);
+    if (typeof source !== "string") return null;
+
+    transformingModules.add(logicalPath);
+
     try {
-      code = await transform(source, sourceFile, tempDir, input.adapter, {
-        projectId: input.projectId,
-        dev: false,
-        ssr: false,
-        reactVersion: input.reactVersion,
-      });
-    } catch (error) {
-      // Hard requirement: any module transform failure → report failed, stop.
-      const sanitized = sanitizeError(error);
-      logger.warn("Module transform failed during release asset build", {
-        path: logicalPath,
-        error: sanitized,
-      });
-      await client.reportReleaseAssetManifestState(
-        input.releaseVersionRef,
-        "failed",
-        sanitized,
-      );
-      return {
-        success: false,
-        state: "failed",
-        moduleCount: 0,
-        cssCount: 0,
-        routeCount: 0,
-        gaps,
-        error: sanitized,
-      };
-    }
-
-    if (vendorDependencies) {
+      // M2: enforce client-side size limit before transform (source is a proxy;
+      // transformed output is checked after encoding below).
+      const sourceFile = join(tempDir, logicalPath);
+      let code: string;
       try {
-        const vendored = await vendorHttpImports(code, {
-          tempDir,
+        code = await transform(source, sourceFile, tempDir, input.adapter, {
+          projectId: input.projectId,
+          dev: false,
+          ssr: false,
           reactVersion: input.reactVersion,
         });
-        code = vendored.code;
-        for (const dependency of vendored.dependencies) {
-          addDependencyModule(dependencyModules, dependency);
-        }
       } catch (error) {
+        // Hard requirement: any module transform failure -> report failed, stop.
         const sanitized = sanitizeError(error);
-        logger.warn("HTTP dependency vendoring failed during release asset build", {
+        logger.warn("Module transform failed during release asset build", {
           path: logicalPath,
           error: sanitized,
         });
@@ -1558,9 +1542,59 @@ async function runBuildInner(
           error: sanitized,
         };
       }
+
+      if (vendorDependencies) {
+        try {
+          const vendored = await vendorHttpImports(code, {
+            tempDir,
+            reactVersion: input.reactVersion,
+          });
+          code = vendored.code;
+          for (const dependency of vendored.dependencies) {
+            addDependencyModule(dependencyModules, dependency);
+          }
+        } catch (error) {
+          const sanitized = sanitizeError(error);
+          logger.warn("HTTP dependency vendoring failed during release asset build", {
+            path: logicalPath,
+            error: sanitized,
+          });
+          await client.reportReleaseAssetManifestState(
+            input.releaseVersionRef,
+            "failed",
+            sanitized,
+          );
+          return {
+            success: false,
+            state: "failed",
+            moduleCount: 0,
+            cssCount: 0,
+            routeCount: 0,
+            gaps,
+            error: sanitized,
+          };
+        }
+      }
+
+      transformedModules.set(logicalPath, { logicalPath, code });
+
+      const imports = await collectProjectModuleImports(code, logicalPath, knownPaths);
+      for (const importedPath of imports.values()) {
+        const failure = await transformProjectModule(importedPath);
+        if (failure) return failure;
+      }
+    } finally {
+      transformingModules.delete(logicalPath);
     }
 
-    transformedModules.set(logicalPath, { logicalPath, code });
+    return null;
+  }
+
+  for (const logicalPath of sourceByPath.keys()) {
+    if (!isBrowserModule(logicalPath)) continue;
+
+    const failure = await transformProjectModule(logicalPath);
+    if (failure) return failure;
   }
 
   if (vendorDependencies) {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.825";
+export const VERSION = "0.1.826";


### PR DESCRIPTION
## Summary
- Recursively transforms project modules reached from parsed browser imports instead of relying only on fixed top-level browser directories.
- Keeps the existing directory list as browser graph entry seeds, so unrelated files are not published as independent browser entries.
- Adds a regression for an arbitrary user folder imported by a hydrated component, matching the failure mode where a production chunk requested a root-relative provider module.
- Bumps Veryfront to 0.1.826 for release automation.

## Why
Production loaded a release asset for the header component that still contained a relative import to a project-level provider file. The browser resolved that to a public /providers/... URL, which returned 404. The provider file existed in the release file set, but it was outside the fixed browser module directory seeds, so no immutable /_vf/assets URL was available for the rewrite.

## Verification
- deno test --allow-all src/release-assets/build-executor.test.ts
- deno test --no-check --allow-all src/release-assets
- deno fmt --check deno.json src/utils/version-constant.ts src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts
- Pre-push hook: formatting, lint, typecheck, generated files, and unit tests: 2169 passed, 18683 steps, 0 failed

## Notes
This is the preferred long-term shape over adding providers/ to the allowlist. The release builder now follows the browser graph using parsed import specifiers and supports user-named folders when they are browser-reachable.