### PR TITLE
Harden module resolution for arbitrary project folders

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.826",
+  "version": "0.1.827",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/client/spa/path-utils.test.ts
+++ b/src/client/spa/path-utils.test.ts
@@ -1,14 +1,16 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { getModuleServerUrl, pathToModuleUrl } from "./path-utils.ts";
+import { getModuleServerUrl, getPathToModuleUrlScript, pathToModuleUrl } from "./path-utils.ts";
+
+type MutableTestGlobal = {
+  MODULE_SERVER_URL?: string;
+  __veryfrontReleaseAssetModules?: Record<string, string> | null;
+  window?: unknown;
+};
 
 function withWindow<T>(fn: () => T): T {
-  const globalRecord = globalThis as typeof globalThis & {
-    MODULE_SERVER_URL?: string;
-    __veryfrontReleaseAssetModules?: Record<string, string> | null;
-    window?: typeof globalThis;
-  };
+  const globalRecord = globalThis as unknown as MutableTestGlobal;
   const previousWindow = globalRecord.window;
 
   globalRecord.window = globalThis;
@@ -24,20 +26,50 @@ function withWindow<T>(fn: () => T): T {
   }
 }
 
+function runGeneratedPathToModuleUrl(path: string, baseUrl?: string): string {
+  const globalRecord = globalThis as unknown as MutableTestGlobal;
+  const previousWindow = globalRecord.window;
+  const previousModuleServerUrl = globalRecord.MODULE_SERVER_URL;
+
+  globalRecord.window = globalThis;
+  globalRecord.MODULE_SERVER_URL = "/_vf_modules";
+
+  try {
+    return new Function(
+      "path",
+      "baseUrl",
+      `${getPathToModuleUrlScript()}\nreturn pathToModuleUrl(path, baseUrl);`,
+    )(path, baseUrl) as string;
+  } finally {
+    if (previousWindow === undefined) {
+      delete globalRecord.window;
+    } else {
+      globalRecord.window = previousWindow;
+    }
+
+    if (previousModuleServerUrl === undefined) {
+      delete globalRecord.MODULE_SERVER_URL;
+    } else {
+      globalRecord.MODULE_SERVER_URL = previousModuleServerUrl;
+    }
+  }
+}
+
 describe("client/spa/path-utils", () => {
   describe("getModuleServerUrl", () => {
     it("uses the browser-configured module server url when available", () => {
-      const previousModuleServerUrl = globalThis.MODULE_SERVER_URL;
-      globalThis.MODULE_SERVER_URL = "https://cdn.example.com/modules";
+      const globalRecord = globalThis as unknown as MutableTestGlobal;
+      const previousModuleServerUrl = globalRecord.MODULE_SERVER_URL;
+      globalRecord.MODULE_SERVER_URL = "https://cdn.example.com/modules";
 
       try {
         const moduleServerUrl = withWindow(() => getModuleServerUrl());
         assertEquals(moduleServerUrl, "https://cdn.example.com/modules");
       } finally {
         if (previousModuleServerUrl === undefined) {
-          delete globalThis.MODULE_SERVER_URL;
+          delete globalRecord.MODULE_SERVER_URL;
         } else {
-          globalThis.MODULE_SERVER_URL = previousModuleServerUrl;
+          globalRecord.MODULE_SERVER_URL = previousModuleServerUrl;
         }
       }
     });
@@ -53,8 +85,23 @@ describe("client/spa/path-utils", () => {
       ["components/Card.jsx", "/_vf_modules", "/_vf_modules/components/Card.js"],
       ["pages/about.mdx", "/_vf_modules", "/_vf_modules/pages/about.js"],
       ["utils/helper.ts", "/_vf_modules", "/_vf_modules/utils/helper.js"],
+      [
+        "providers/BreakpointsProvider.tsx",
+        "/_vf_modules",
+        "/_vf_modules/providers/BreakpointsProvider.js",
+      ],
       ["some/module", "/_vf_modules", "/_vf_modules/some/module.js"],
       ["utils/helper.js", "/_vf_modules", "/_vf_modules/utils/helper.js"],
+      [
+        "/_vf_modules/providers/BreakpointsProvider.js",
+        "/_vf_modules",
+        "/_vf_modules/providers/BreakpointsProvider.js",
+      ],
+      [
+        "/_vf_modules/custom-client/BreakpointsProvider.js?studio_embed=true",
+        "/_vf_modules",
+        "/_vf_modules/custom-client/BreakpointsProvider.js?studio_embed=true",
+      ],
       ["/project/pages/index.tsx", "/_vf_modules", "/_vf_modules/pages/index.js"],
       ["pages/home.tsx", "/custom", "/custom/pages/home.js"],
     ];
@@ -86,6 +133,13 @@ describe("client/spa/path-utils", () => {
           globalRecord.__veryfrontReleaseAssetModules = previousMap;
         }
       }
+    });
+
+    it("keeps existing arbitrary-folder module URLs unchanged in the generated browser helper", () => {
+      assertEquals(
+        runGeneratedPathToModuleUrl("/_vf_modules/providers/BreakpointsProvider.js"),
+        "/_vf_modules/providers/BreakpointsProvider.js",
+      );
     });
   });
 });

--- a/src/client/spa/path-utils.ts
+++ b/src/client/spa/path-utils.ts
@@ -11,11 +11,12 @@ const SOURCE_EXTENSIONS = ["tsx", "ts", "jsx", "mdx"] as const;
 
 /** Regex pattern for matching source paths */
 const SOURCE_PATH_PATTERN = new RegExp(
-  `(${SOURCE_DIRS.join("|")})/(.+)\\.(${SOURCE_EXTENSIONS.join("|")})$`,
+  `(${SOURCE_DIRS.join("|")})/(.+)\\.(${SOURCE_EXTENSIONS.join("|")})([?#].*)?$`,
 );
 
-const KNOWN_EXT_PATTERN = /\.(tsx|ts|jsx|mdx|js|mjs)$/;
-const SOURCE_EXT_REPLACE_PATTERN = /\.(tsx|ts|jsx|mdx)$/;
+const MODULE_SERVER_PATH_PATTERN = /^\/?_vf_modules\//;
+const KNOWN_EXT_PATTERN = /\.(tsx|ts|jsx|mdx|js|mjs)([?#].*)?$/;
+const SOURCE_EXT_REPLACE_PATTERN = /\.(tsx|ts|jsx|mdx)([?#].*)?$/;
 
 /** Precomputed regex for absolute paths containing a source directory */
 const ABSOLUTE_SOURCE_PATH_PATTERN = new RegExp(`/${SOURCE_PATH_PATTERN.source}`);
@@ -58,6 +59,22 @@ function resolveReleaseAssetModuleUrl(path: string): string | null {
   return null;
 }
 
+function normalizeModuleRequestPath(path: string): string {
+  const key = String(path || "")
+    .replace(MODULE_SERVER_PATH_PATTERN, "")
+    .replace(/^\/+/, "");
+
+  if (SOURCE_EXT_REPLACE_PATTERN.test(key)) {
+    return key.replace(SOURCE_EXT_REPLACE_PATTERN, ".js$2");
+  }
+
+  if (KNOWN_EXT_PATTERN.test(key)) {
+    return key;
+  }
+
+  return `${key}.js`;
+}
+
 export function getModuleServerUrl(): string {
   if (typeof window === "undefined") return "/_vf_modules";
   return (globalThis as typeof globalThis & { MODULE_SERVER_URL?: string }).MODULE_SERVER_URL ??
@@ -70,18 +87,18 @@ export function pathToModuleUrl(path: string, baseUrl?: string): string {
 
   const base = baseUrl ?? getModuleServerUrl();
 
+  if (MODULE_SERVER_PATH_PATTERN.test(path)) {
+    return `${base}/${normalizeModuleRequestPath(path)}`;
+  }
+
   const match = path.match(ABSOLUTE_SOURCE_PATH_PATTERN) ??
     path.match(RELATIVE_SOURCE_PATH_PATTERN);
 
   if (match) {
-    return `${base}/${match[1]}/${match[2]}.js`;
+    return `${base}/${match[1]}/${match[2]}.js${match[4] ?? ""}`;
   }
 
-  if (KNOWN_EXT_PATTERN.test(path)) {
-    return `${base}/${path.replace(SOURCE_EXT_REPLACE_PATTERN, ".js")}`;
-  }
-
-  return `${base}/${path}.js`;
+  return `${base}/${normalizeModuleRequestPath(path)}`;
 }
 
 export function getPathToModuleUrlScript(): string {
@@ -118,25 +135,41 @@ export function getPathToModuleUrlScript(): string {
       return null;
     }
 
+    function normalizeModuleRequestPath(path) {
+      const key = String(path || '')
+        .replace(/^\\/?_vf_modules\\//, '')
+        .replace(/^\\/+/, '');
+
+      if (/\\.(tsx|ts|jsx|mdx)([?#].*)?$/.test(key)) {
+        return key.replace(/\\.(tsx|ts|jsx|mdx)([?#].*)?$/, '.js$2');
+      }
+
+      if (/\\.(tsx|ts|jsx|mdx|js|mjs)([?#].*)?$/.test(key)) {
+        return key;
+      }
+
+      return key + '.js';
+    }
+
     function pathToModuleUrl(path, baseUrl) {
       const releaseAssetUrl = resolveReleaseAssetModuleUrl(path);
       if (releaseAssetUrl) return releaseAssetUrl;
 
       const base = baseUrl || MODULE_SERVER_URL;
-      const pattern = /(pages|components|app|lib|layouts|shared|features)\\/(.+)\\.(tsx|ts|jsx|mdx)$/;
+      if (/^\\/?_vf_modules\\//.test(path)) {
+        return base + '/' + normalizeModuleRequestPath(path);
+      }
+
+      const pattern = /(pages|components|app|lib|layouts|shared|features)\\/(.+)\\.(tsx|ts|jsx|mdx)([?#].*)?$/;
 
       let match = path.match(new RegExp('/' + pattern.source));
       match = match || path.match(new RegExp('^' + pattern.source));
 
-      if (!match) {
-        const hasKnownExt = /\\.(tsx|ts|jsx|mdx|js|mjs)$/.test(path);
-        if (hasKnownExt) {
-          return base + '/' + path.replace(/\\.(tsx|ts|jsx|mdx)$/, '.js');
-        }
-        return base + '/' + path + '.js';
+      if (match) {
+        return base + '/' + match[1] + '/' + match[2] + '.js' + (match[4] || '');
       }
 
-      return base + '/' + match[1] + '/' + match[2] + '.js';
+      return base + '/' + normalizeModuleRequestPath(path);
     }
   `.trim();
 }

--- a/src/modules/react-loader/ssr-module-loader/import-rewriter.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/import-rewriter.test.ts
@@ -4,9 +4,9 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { rewriteCrossProjectImport, rewriteLocalImports } from "./import-rewriter.ts";
 
 describe("rewriteCrossProjectImport", () => {
-  it("rewrites .tsx specifier to file:// path", () => {
+  it("rewrites .tsx specifier to file:// path", async () => {
     const code = `import { Foo } from "@acme/ui@1.0.0/@/components/Button.tsx";`;
-    const result = rewriteCrossProjectImport(
+    const result = await rewriteCrossProjectImport(
       code,
       "@acme/ui@1.0.0/@/components/Button.tsx",
       "/tmp/cache/cross-project/Button.js",
@@ -14,9 +14,9 @@ describe("rewriteCrossProjectImport", () => {
     assertEquals(result, `import { Foo } from "file:///tmp/cache/cross-project/Button.js";`);
   });
 
-  it("rewrites .js version of .tsx specifier", () => {
+  it("rewrites .js version of .tsx specifier", async () => {
     const code = `import { Foo } from "@acme/ui@1.0.0/@/components/Button.js";`;
-    const result = rewriteCrossProjectImport(
+    const result = await rewriteCrossProjectImport(
       code,
       "@acme/ui@1.0.0/@/components/Button.tsx",
       "/tmp/cache/cross-project/Button.js",
@@ -24,30 +24,30 @@ describe("rewriteCrossProjectImport", () => {
     assertEquals(result, `import { Foo } from "file:///tmp/cache/cross-project/Button.js";`);
   });
 
-  it("rewrites multiple occurrences", () => {
+  it("rewrites multiple occurrences", async () => {
     const code = [
       `import { A } from "@acme/ui@1.0.0/@/A.tsx";`,
       `import { B } from "@acme/ui@1.0.0/@/A.tsx";`,
     ].join("\n");
-    const result = rewriteCrossProjectImport(code, "@acme/ui@1.0.0/@/A.tsx", "/tmp/A.js");
+    const result = await rewriteCrossProjectImport(code, "@acme/ui@1.0.0/@/A.tsx", "/tmp/A.js");
     assertEquals(result.match(/file:\/\//g)?.length, 2);
   });
 
-  it("handles specifiers with special regex characters", () => {
+  it("handles specifiers with special characters", async () => {
     const code = `import { X } from "pkg+foo(bar)";`;
-    const result = rewriteCrossProjectImport(code, "pkg+foo(bar)", "/tmp/pkg.js");
+    const result = await rewriteCrossProjectImport(code, "pkg+foo(bar)", "/tmp/pkg.js");
     assertEquals(result, `import { X } from "file:///tmp/pkg.js";`);
   });
 
-  it("handles single-quoted imports", () => {
+  it("handles single-quoted imports", async () => {
     const code = `import { Foo } from 'my-pkg';`;
-    const result = rewriteCrossProjectImport(code, "my-pkg", "/tmp/my-pkg.js");
-    assertEquals(result, `import { Foo } from "file:///tmp/my-pkg.js";`);
+    const result = await rewriteCrossProjectImport(code, "my-pkg", "/tmp/my-pkg.js");
+    assertEquals(result, `import { Foo } from 'file:///tmp/my-pkg.js';`);
   });
 
-  it("leaves unrelated imports untouched", () => {
+  it("leaves unrelated imports untouched", async () => {
     const code = `import { Foo } from "react";\nimport { Bar } from "other";`;
-    const result = rewriteCrossProjectImport(code, "react", "/tmp/react.js");
+    const result = await rewriteCrossProjectImport(code, "react", "/tmp/react.js");
     assertEquals(result.includes(`from "other"`), true);
   });
 });
@@ -55,118 +55,106 @@ describe("rewriteCrossProjectImport", () => {
 describe("rewriteLocalImports", () => {
   const projectDir = "/project";
 
-  it("returns unchanged code when map is empty", () => {
+  it("returns unchanged code when map is empty", async () => {
     const code = `import { A } from "./A.js";`;
-    const result = rewriteLocalImports(code, new Map(), "/project/pages/index.tsx", projectDir);
+    const result = await rewriteLocalImports(
+      code,
+      new Map(),
+      "/project/pages/index.tsx",
+      projectDir,
+    );
     assertEquals(result, code);
   });
 
-  it("rewrites @/ alias import from depth-1 directory", () => {
+  it("rewrites @/ alias import from depth-1 directory", async () => {
     const map = new Map([["@/components/Button", "/tmp/Button.js"]]);
     const code = `import { Button } from "../components/Button.js";`;
-    const result = rewriteLocalImports(code, map, "/project/pages/index.tsx", projectDir);
+    const result = await rewriteLocalImports(code, map, "/project/pages/index.tsx", projectDir);
     assertEquals(result, `import { Button } from "file:///tmp/Button.js";`);
   });
 
-  it("rewrites @/ alias import from root-level file", () => {
+  it("rewrites @/ alias import from root-level file", async () => {
     const map = new Map([["@/components/Button", "/tmp/Button.js"]]);
     const code = `import { Button } from "./components/Button.js";`;
-    const result = rewriteLocalImports(code, map, "/project/index.tsx", projectDir);
+    const result = await rewriteLocalImports(code, map, "/project/index.tsx", projectDir);
     assertEquals(result, `import { Button } from "file:///tmp/Button.js";`);
   });
 
-  it("rewrites @/ alias import from nested directory", () => {
+  it("rewrites @/ alias import from nested directory", async () => {
     const map = new Map([["@/utils/helpers", "/tmp/helpers.js"]]);
     const code = `import { h } from "../../utils/helpers.js";`;
-    const result = rewriteLocalImports(code, map, "/project/pages/blog/post.tsx", projectDir);
+    const result = await rewriteLocalImports(code, map, "/project/pages/blog/post.tsx", projectDir);
     assertEquals(result, `import { h } from "file:///tmp/helpers.js";`);
   });
 
-  it("rewrites relative import (./)", () => {
+  it("rewrites relative import (./)", async () => {
     const map = new Map([["./sibling", "/tmp/sibling.js"]]);
     const code = `import { S } from "./sibling.js";`;
-    const result = rewriteLocalImports(code, map, "/project/components/parent.tsx", projectDir);
+    const result = await rewriteLocalImports(
+      code,
+      map,
+      "/project/components/parent.tsx",
+      projectDir,
+    );
     assertEquals(result, `import { S } from "file:///tmp/sibling.js";`);
   });
 
-  it("rewrites relative import (../)", () => {
+  it("rewrites relative import (../)", async () => {
     const map = new Map([["../utils/log", "/tmp/log.js"]]);
     const code = `import { log } from "../utils/log.js";`;
-    const result = rewriteLocalImports(code, map, "/project/components/Button.tsx", projectDir);
+    const result = await rewriteLocalImports(
+      code,
+      map,
+      "/project/components/Button.tsx",
+      projectDir,
+    );
     assertEquals(result, `import { log } from "file:///tmp/log.js";`);
   });
 
-  it("rewrites absolute path starting with projectDir", () => {
+  it("rewrites absolute path starting with projectDir", async () => {
     const map = new Map([["/project/lib/api.ts", "/tmp/api.js"]]);
     const code = `import { fetch } from "../lib/api.js";`;
-    const result = rewriteLocalImports(code, map, "/project/pages/index.tsx", projectDir);
+    const result = await rewriteLocalImports(code, map, "/project/pages/index.tsx", projectDir);
     assertEquals(result, `import { fetch } from "file:///tmp/api.js";`);
   });
 
-  it("strips trailing slash from projectDir", () => {
+  it("strips trailing slash from projectDir", async () => {
     const map = new Map([["@/utils/log", "/tmp/log.js"]]);
     const code = `import { log } from "../utils/log.js";`;
-    const result = rewriteLocalImports(code, map, "/project/pages/index.tsx", "/project/");
+    const result = await rewriteLocalImports(code, map, "/project/pages/index.tsx", "/project/");
     assertEquals(result, `import { log } from "file:///tmp/log.js";`);
   });
 
-  it("rewrites .tsx extensions to .js in alias patterns", () => {
+  it("rewrites .tsx extensions to .js in alias patterns", async () => {
     const map = new Map([["@/components/Card.tsx", "/tmp/Card.js"]]);
     const code = `import { Card } from "../components/Card.js";`;
-    const result = rewriteLocalImports(code, map, "/project/pages/index.tsx", projectDir);
+    const result = await rewriteLocalImports(code, map, "/project/pages/index.tsx", projectDir);
     assertEquals(result, `import { Card } from "file:///tmp/Card.js";`);
   });
 
-  it("handles multiple imports in the same code", () => {
+  it("handles multiple imports in the same code", async () => {
     const map = new Map([
       ["./A", "/tmp/A.js"],
       ["./B", "/tmp/B.js"],
     ]);
     const code = `import { A } from "./A.js";\nimport { B } from "./B.js";`;
-    const result = rewriteLocalImports(code, map, "/project/src/index.tsx", projectDir);
+    const result = await rewriteLocalImports(code, map, "/project/src/index.tsx", projectDir);
     assertEquals(result.includes("file:///tmp/A.js"), true);
     assertEquals(result.includes("file:///tmp/B.js"), true);
   });
 
-  it("uses one replacement regex for local imports", () => {
-    const originalRegExp = globalThis.RegExp;
-    const constructedPatterns: string[] = [];
+  it("does not rewrite import-looking text in strings or comments", async () => {
+    const map = new Map([["./A", "/tmp/A.js"]]);
+    const code = [
+      `const text = 'from "./A.js"';`,
+      `// import { A } from "./A.js";`,
+      `import { A } from "./A.js";`,
+    ].join("\n");
 
-    class CountingRegExp extends originalRegExp {
-      constructor(pattern: string | RegExp, flags?: string) {
-        constructedPatterns.push(String(pattern));
-        super(pattern, flags);
-      }
-    }
+    const result = await rewriteLocalImports(code, map, "/project/src/index.tsx", projectDir);
 
-    Object.defineProperty(globalThis, "RegExp", {
-      configurable: true,
-      value: CountingRegExp,
-    });
-
-    try {
-      const map = new Map([
-        ["./A", "/tmp/A.js"],
-        ["./B", "/tmp/B.js"],
-        ["./C", "/tmp/C.js"],
-      ]);
-      const code = [
-        `import { A } from "./A.js";`,
-        `import { B } from "./B.js";`,
-        `import { C } from "./C.js";`,
-      ].join("\n");
-
-      const result = rewriteLocalImports(code, map, "/project/src/index.tsx", projectDir);
-
-      assertEquals(result.includes("file:///tmp/A.js"), true);
-      assertEquals(result.includes("file:///tmp/B.js"), true);
-      assertEquals(result.includes("file:///tmp/C.js"), true);
-      assertEquals(constructedPatterns.length, 1);
-    } finally {
-      Object.defineProperty(globalThis, "RegExp", {
-        configurable: true,
-        value: originalRegExp,
-      });
-    }
+    assertEquals(result.includes(`const text = 'from "./A.js"';`), true);
+    assertEquals(result.includes(`// import { A } from "./A.js";`), true);
+    assertEquals(result.includes(`import { A } from "file:///tmp/A.js";`), true);
   });
 });

--- a/src/modules/react-loader/ssr-module-loader/import-rewriter.ts
+++ b/src/modules/react-loader/ssr-module-loader/import-rewriter.ts
@@ -7,43 +7,39 @@
  * @module module-system/react-loader/ssr-module-loader/import-rewriter
  */
 
-const IMPORT_FROM_PREFIX = "from\\s*[\"']";
-const IMPORT_FROM_SUFFIX = "[\"']";
-const REGEX_ESCAPE = /[.*+?^${}()|[\]\\]/g;
-
-function escapeRegExp(value: string): string {
-  return value.replace(REGEX_ESCAPE, "\\$&");
-}
+import { replaceSpecifiers } from "#veryfront/transforms/esm/lexer.ts";
 
 /**
  * Rewrite a cross-project import specifier to use a local temp path.
  */
-export function rewriteCrossProjectImport(
+export async function rewriteCrossProjectImport(
   transformed: string,
   specifier: string,
   tempPath: string,
-): string {
+): Promise<string> {
   const jsSpecifier = toJsExtension(specifier);
-  const escapedSpecifier = escapeRegExp(specifier);
-  const escapedJsSpecifier = escapeRegExp(jsSpecifier);
-  const pattern = new RegExp(
-    `${IMPORT_FROM_PREFIX}(${escapedSpecifier}|${escapedJsSpecifier})${IMPORT_FROM_SUFFIX}`,
-    "g",
-  );
+  const replacement = `file://${tempPath}`;
+  const replacements = new Map<string, string>([
+    [specifier, replacement],
+    [jsSpecifier, replacement],
+  ]);
 
-  return transformed.replace(pattern, `from "file://${tempPath}"`);
+  return await replaceSpecifiers(
+    transformed,
+    (importSpecifier) => replacements.get(importSpecifier) ?? null,
+  );
 }
 
 /**
  * Rewrite local imports to use hashed temp paths.
  * This ensures each content version uses its own cached module file.
  */
-export function rewriteLocalImports(
+export async function rewriteLocalImports(
   transformed: string,
   localImportPaths: Map<string, string>,
   fromFilePath: string,
   projectDir: string,
-): string {
+): Promise<string> {
   if (localImportPaths.size === 0) return transformed;
 
   const normalizedProjectDir = projectDir.replace(/\/$/, "");
@@ -52,27 +48,24 @@ export function rewriteLocalImports(
     ? fromFileDir.substring(normalizedProjectDir.length + 1)
     : fromFileDir;
 
-  const replacementByPattern = new Map<string, string>();
+  const replacements = new Map<string, string>();
 
   for (const [specifierOrPath, tempPath] of localImportPaths) {
     const patterns = buildImportPatterns(specifierOrPath, fromRelativeDir, normalizedProjectDir);
 
     for (const pattern of patterns) {
-      if (!replacementByPattern.has(pattern)) {
-        replacementByPattern.set(pattern, tempPath);
+      if (!replacements.has(pattern)) {
+        replacements.set(pattern, `file://${tempPath}`);
       }
     }
   }
 
-  if (replacementByPattern.size === 0) return transformed;
+  if (replacements.size === 0) return transformed;
 
-  const importPattern = Array.from(replacementByPattern.keys()).map(escapeRegExp).join("|");
-  const regex = new RegExp(`${IMPORT_FROM_PREFIX}(${importPattern})${IMPORT_FROM_SUFFIX}`, "g");
-
-  return transformed.replace(regex, (match, specifier: string) => {
-    const tempPath = replacementByPattern.get(specifier);
-    return tempPath === undefined ? match : `from "file://${tempPath}"`;
-  });
+  return await replaceSpecifiers(
+    transformed,
+    (importSpecifier) => replacements.get(importSpecifier) ?? null,
+  );
 }
 
 /**

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -616,10 +616,10 @@ export class SSRModuleLoader {
         );
 
         for (const [specifier, tempPath] of crossProjectPaths.entries()) {
-          transformed = rewriteCrossProjectImport(transformed, specifier, tempPath);
+          transformed = await rewriteCrossProjectImport(transformed, specifier, tempPath);
         }
 
-        transformed = rewriteLocalImports(
+        transformed = await rewriteLocalImports(
           transformed,
           localImportPaths,
           filePath,

--- a/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.test.ts
@@ -164,4 +164,50 @@ describe("SSRCacheManager", { sanitizeResources: false, sanitizeOps: false }, ()
       await remove(projectDir, { recursive: true });
     }
   });
+
+  it("rejects only real unresolved _vf_modules imports", async () => {
+    const projectDir = await makeTempDir({ prefix: "vf-ssr-cache-manager-" });
+    const cacheManager = new SSRCacheManager({
+      projectDir,
+      projectId: `project-${crypto.randomUUID()}`,
+      contentSourceId: `preview-${crypto.randomUUID()}`,
+      adapter: denoAdapter,
+      dev: true,
+    });
+
+    try {
+      const importLookingTextIsValid = await cacheManager.validateCachedCode(
+        [
+          `const text = 'from "/_vf_modules/react@18.3.1/some-module.js"';`,
+          `// import x from "/_vf_modules/commented.js";`,
+          `export default text;`,
+        ].join("\n"),
+        join(projectDir, "pages", "index.tsx"),
+        "redis-cache",
+        {
+          checkLocalPaths: false,
+          checkInvalidEsmShPath: true,
+        },
+      );
+
+      assertEquals(importLookingTextIsValid, true);
+
+      const realImportIsInvalid = await cacheManager.validateCachedCode(
+        [
+          `import x from "/_vf_modules/react@18.3.1/some-module.js";`,
+          `export default x;`,
+        ].join("\n"),
+        join(projectDir, "pages", "index.tsx"),
+        "redis-cache",
+        {
+          checkLocalPaths: false,
+          checkInvalidEsmShPath: true,
+        },
+      );
+
+      assertEquals(realImportIsInvalid, false);
+    } finally {
+      await remove(projectDir, { recursive: true });
+    }
+  });
 });

--- a/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.ts
@@ -15,6 +15,7 @@ import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { rendererLogger } from "#veryfront/utils";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import { ensureHttpBundlesExist } from "#veryfront/transforms/esm/http-cache.ts";
+import { parseImports } from "#veryfront/transforms/esm/lexer.ts";
 import { getHttpBundleCacheDir, getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { globalModuleCache, globalTmpDirs } from "./cache/index.ts";
 import {
@@ -30,9 +31,6 @@ const logger = rendererLogger.component("ssr-module-loader");
 
 /** Content length threshold: below this, use fast sync hash; above, use async SHA-256 */
 const SYNC_HASH_THRESHOLD = 10_000;
-
-const UNRESOLVED_VF_MODULE_IMPORT_PATTERN =
-  /from\s*["']((?:file:\/\/)?\/?\/?_vf_modules\/[^"']+)["']/;
 
 /**
  * Manages caching concerns for SSR module loading:
@@ -143,7 +141,7 @@ export class SSRCacheManager {
       return false;
     }
 
-    if (this.hasUnresolvedVfModuleImports(code)) {
+    if (await this.hasUnresolvedVfModuleImports(code)) {
       logger.warn(
         source === "memory-cache"
           ? "[SSR-MODULE-LOADER] Memory cache has unresolved _vf_modules imports, invalidating"
@@ -208,8 +206,15 @@ export class SSRCacheManager {
     return this.fs;
   }
 
-  private hasUnresolvedVfModuleImports(code: string): boolean {
-    return UNRESOLVED_VF_MODULE_IMPORT_PATTERN.test(code);
+  private async hasUnresolvedVfModuleImports(code: string): Promise<boolean> {
+    const imports = await parseImports(code);
+    return imports.some((importSpecifier) => {
+      const rawPath = importSpecifier.n;
+      if (!rawPath) return false;
+
+      const path = rawPath.replace(/^(?:file:\/\/)?\/+/, "");
+      return path.startsWith("_vf_modules/");
+    });
   }
 
   private async hasMissingHttpBundles(

--- a/src/modules/react-loader/ssr-module-loader/vf-module-resolver.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/vf-module-resolver.test.ts
@@ -5,27 +5,45 @@ import { findVfModuleImports } from "./vf-module-resolver.ts";
 
 describe("modules/react-loader/ssr-module-loader/vf-module-resolver", () => {
   describe("findVfModuleImports", () => {
-    it("finds /_vf_modules imports and normalizes paths", () => {
+    it("finds /_vf_modules imports and normalizes paths", async () => {
       const code = [
         `import a from "/_vf_modules/react@18/index.js";`,
         `import b from "file:///_vf_modules/lodash@4/chunk.js";`,
       ].join("\n");
 
-      assertEquals(findVfModuleImports(code), [
+      assertEquals(await findVfModuleImports(code), [
         {
-          original: `from "/_vf_modules/react@18/index.js"`,
+          specifier: "/_vf_modules/react@18/index.js",
           path: "_vf_modules/react@18/index.js",
         },
         {
-          original: `from "file:///_vf_modules/lodash@4/chunk.js"`,
+          specifier: "file:///_vf_modules/lodash@4/chunk.js",
           path: "_vf_modules/lodash@4/chunk.js",
         },
       ]);
     });
 
-    it("returns empty array when code has no /_vf_modules imports", () => {
+    it("strips query params from normalized paths", async () => {
+      const code = `import a from "/_vf_modules/react@18/index.js?ssr=true";`;
+      assertEquals(await findVfModuleImports(code), [
+        {
+          specifier: "/_vf_modules/react@18/index.js?ssr=true",
+          path: "_vf_modules/react@18/index.js",
+        },
+      ]);
+    });
+
+    it("does not match import-looking text in strings or comments", async () => {
+      const code = `
+        const text = 'from "/_vf_modules/react@18/index.js"';
+        // import a from "/_vf_modules/commented.js";
+      `;
+      assertEquals(await findVfModuleImports(code), []);
+    });
+
+    it("returns empty array when code has no /_vf_modules imports", async () => {
       const code = `import x from "./local.js";`;
-      assertEquals(findVfModuleImports(code), []);
+      assertEquals(await findVfModuleImports(code), []);
     });
   });
 });

--- a/src/modules/react-loader/ssr-module-loader/vf-module-resolver.ts
+++ b/src/modules/react-loader/ssr-module-loader/vf-module-resolver.ts
@@ -9,16 +9,16 @@ import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { rendererLogger } from "#veryfront/utils";
 import { getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
+import { parseImports, replaceSpecifiers } from "#veryfront/transforms/esm/lexer.ts";
 import {
   createModuleFetcherContext,
   fetchAndCacheModule,
 } from "#veryfront/transforms/mdx/esm-module-loader/module-fetcher/index.ts";
-import { VF_MODULE_IMPORT_PATTERN } from "#veryfront/transforms/mdx/esm-module-loader/constants.ts";
 
 const logger = rendererLogger.component("ssr-module-loader");
 
 interface VfModuleImport {
-  original: string;
+  specifier: string;
   path: string;
 }
 
@@ -35,18 +35,23 @@ interface ResolveVfModuleImportsOptions {
  * Find /_vf_modules/ imports in transformed code.
  * Matches both /_vf_modules/... and file:///_vf_modules/... forms.
  */
-export function findVfModuleImports(code: string): VfModuleImport[] {
+export async function findVfModuleImports(code: string): Promise<VfModuleImport[]> {
   const imports: VfModuleImport[] = [];
-  const pattern = new RegExp(VF_MODULE_IMPORT_PATTERN.source, "g");
+  const parsedImports = await parseImports(code);
 
-  let match: RegExpExecArray | null;
-  while ((match = pattern.exec(code)) !== null) {
-    const rawPath = match[1];
+  for (const importSpecifier of parsedImports) {
+    const rawPath = importSpecifier.n;
     if (!rawPath) continue;
 
     // Normalize "file:///_vf_modules/..." and "/_vf_modules/..." to "_vf_modules/..."
     const path = rawPath.replace(/^(?:file:\/\/)?\/+/, "");
-    imports.push({ original: match[0], path });
+    if (!path.startsWith("_vf_modules/")) continue;
+
+    const queryStart = path.indexOf("?");
+    imports.push({
+      specifier: rawPath,
+      path: queryStart === -1 ? path : path.slice(0, queryStart),
+    });
   }
 
   return imports;
@@ -59,7 +64,7 @@ export async function resolveVfModuleImports(
   code: string,
   options: ResolveVfModuleImportsOptions,
 ): Promise<string> {
-  const imports = findVfModuleImports(code);
+  const imports = await findVfModuleImports(code);
   if (imports.length === 0) return code;
 
   logger.debug("Processing _vf_modules imports", {
@@ -86,25 +91,25 @@ export async function resolveVfModuleImports(
   );
 
   const results = await Promise.all(
-    imports.map(async ({ original, path }) => {
+    imports.map(async ({ specifier, path }) => {
       try {
         const cachedFilePath = await fetchAndCacheModule(path, fetcherContext);
-        return { original, path, cachedFilePath };
+        return { specifier, path, cachedFilePath };
       } catch (error) {
         logger.warn("Failed to fetch _vf_modules import", {
           file: options.filePath.slice(-40),
           path,
           error: error instanceof Error ? error.message : String(error),
         });
-        return { original, path, cachedFilePath: null };
+        return { specifier, path, cachedFilePath: null };
       }
     }),
   );
 
-  let transformed = code;
-  for (const { original, path, cachedFilePath } of results) {
+  const replacements = new Map<string, string>();
+  for (const { specifier, path, cachedFilePath } of results) {
     if (cachedFilePath) {
-      transformed = transformed.replace(original, `from "file://${cachedFilePath}"`);
+      replacements.set(specifier, `file://${cachedFilePath}`);
     } else {
       logger.warn("Failed to resolve _vf_modules import", {
         file: options.filePath.slice(-40),
@@ -113,5 +118,6 @@ export async function resolveVfModuleImports(
     }
   }
 
-  return transformed;
+  if (replacements.size === 0) return code;
+  return await replaceSpecifiers(code, (specifier) => replacements.get(specifier) ?? null);
 }

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -1,7 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
+import "../transforms/plugins/__tests__/code-parser-setup.ts";
 
 import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import type { CodeParser } from "#veryfront/extensions/parser/index.ts";
+import { register, tryResolve, unregister } from "#veryfront/extensions/contracts.ts";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import { normalizeHttpUrl } from "#veryfront/transforms/esm/http-cache.ts";
 import { parseImports } from "#veryfront/transforms/esm/lexer.ts";
@@ -887,6 +890,132 @@ describe("release asset build executor", () => {
 
     const routeModules = manifest.routes["/"]?.modules ?? [];
     assert(routeModules.includes("custom-client/BreakpointsProvider.tsx"));
+  });
+
+  it("does not preload type-only imports from arbitrary project folders", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "pages/index.tsx",
+        content: [
+          'import Header from "../components/Header.tsx";',
+          'import type { BreakpointName } from "../providers/BreakpointsProvider.ts";',
+          "export default Header;",
+        ].join("\n"),
+      },
+      {
+        path: "components/Header.tsx",
+        content: "export default function Header() { return null; }",
+      },
+      {
+        path: "providers/BreakpointsProvider.ts",
+        content: "export type BreakpointName = 'mobile' | 'desktop';",
+      },
+    ];
+    const client = makeClient(files, rec);
+    const transform = (_source: string, sourceFile: string) => {
+      if (sourceFile.endsWith("pages/index.tsx")) {
+        return Promise.resolve(
+          'import Header from "/_vf_modules/components/Header.js"; export default Header;',
+        );
+      }
+      return Promise.resolve("export default function Header() { return null; }");
+    };
+
+    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.modules["providers/BreakpointsProvider.ts"], undefined);
+    assertEquals(manifest.routes["/"]?.modules.includes("providers/BreakpointsProvider.ts"), false);
+    assertEquals(
+      manifest.fallback.gaps.some((gap) => gap.includes("providers/BreakpointsProvider.ts")),
+      false,
+    );
+  });
+
+  it("does not preload inline type-only import or export specifiers", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "pages/index.tsx",
+        content: [
+          'import Header from "../components/Header.tsx";',
+          'import { type BreakpointName } from "../providers/BreakpointsProvider.ts";',
+          'export { type BreakpointToken } from "../providers/BreakpointTokens.ts";',
+          "export default Header;",
+        ].join("\n"),
+      },
+      {
+        path: "components/Header.tsx",
+        content: "export default function Header() { return null; }",
+      },
+      {
+        path: "providers/BreakpointsProvider.ts",
+        content: "export type BreakpointName = 'mobile' | 'desktop';",
+      },
+      {
+        path: "providers/BreakpointTokens.ts",
+        content: "export type BreakpointToken = 'sm' | 'lg';",
+      },
+    ];
+    const client = makeClient(files, rec);
+    const transform = (_source: string, sourceFile: string) => {
+      if (sourceFile.endsWith("pages/index.tsx")) {
+        return Promise.resolve(
+          'import Header from "/_vf_modules/components/Header.js"; export default Header;',
+        );
+      }
+      return Promise.resolve("export default function Header() { return null; }");
+    };
+
+    await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.modules["providers/BreakpointsProvider.ts"], undefined);
+    assertEquals(manifest.modules["providers/BreakpointTokens.ts"], undefined);
+    assertEquals(
+      manifest.fallback.gaps.some((gap) => gap.includes("providers/BreakpointsProvider.ts")),
+      false,
+    );
+    assertEquals(
+      manifest.fallback.gaps.some((gap) => gap.includes("providers/BreakpointTokens.ts")),
+      false,
+    );
+  });
+
+  it("fails the release asset build when the AST parser contract is unavailable", async () => {
+    const parser = tryResolve<CodeParser>("CodeParser");
+    assertExists(parser);
+    unregister("CodeParser");
+
+    try {
+      const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+      const files = [
+        {
+          path: "pages/index.tsx",
+          content: 'import Header from "../components/Header.tsx"; export default Header;',
+        },
+        {
+          path: "components/Header.tsx",
+          content: "export default function Header() { return null; }",
+        },
+      ];
+      const client = makeClient(files, rec);
+      const transform = (s: string) => Promise.resolve(s);
+
+      const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+      assertEquals(result.success, false);
+      assertEquals(result.state, "failed");
+      assertEquals(rec.manifest, null);
+      assertEquals(rec.states.length, 1);
+      assertEquals(rec.states[0]?.state, "failed");
+      assert((rec.states[0]?.error ?? "").includes('contract "CodeParser"'));
+    } finally {
+      register("CodeParser", parser);
+    }
   });
 
   it("does not rewrite import-like strings or comments in transformed modules", async () => {

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -17,6 +17,8 @@
 
 import { serverLogger } from "#veryfront/utils";
 import { VERSION } from "#veryfront/utils/version.ts";
+import { resolve } from "#veryfront/extensions/contracts.ts";
+import type { CodeParser, NodePath } from "#veryfront/extensions/parser/index.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { dirname, join, normalize } from "#veryfront/compat/path/index.ts";
@@ -215,6 +217,18 @@ interface FinalizedDependencyModules {
   fallbackUrls: Map<string, string>;
 }
 
+interface ModuleSpecifierNode {
+  importKind?: string;
+  exportKind?: string;
+}
+
+interface ModuleSourceNode {
+  source?: { value?: unknown };
+  importKind?: string;
+  exportKind?: string;
+  specifiers?: ModuleSpecifierNode[];
+}
+
 function frameworkModuleUrlToSourceKey(moduleUrl: string): string | null {
   if (!moduleUrl.startsWith(FRAMEWORK_MODULE_URL_PREFIX)) return null;
   return moduleUrl
@@ -258,75 +272,57 @@ function isBrowserModule(path: string): boolean {
 }
 
 /**
- * Statically resolve relative imports in a source file to logical paths.
- *
- * Parses `import/export ... from "..."` and bare `import "..."` statements.
- * Only relative specifiers (`./` or `../`) are resolved; package imports and
- * absolute URLs are skipped. Extension-less specifiers try each browser module
- * extension in order.
+ * Statically resolve runtime imports in a TS/JSX source file to logical paths.
+ * Uses the CodeParser AST contract so type-only imports do not enter route
+ * preload closure.
  */
-function resolveStaticImports(
+async function collectStaticProjectModuleImports(
   source: string,
   moduleLogicalPath: string,
   knownPaths: Set<string>,
-): string[] {
-  const importRe = /(?:^|;|\n)\s*(?:import|export)\s+(?:[^'"]+\s+from\s+)?['"]([^'"]+)['"]/gm;
-  const results: string[] = [];
-  let m: RegExpExecArray | null;
+): Promise<string[]> {
+  return await collectAstStaticProjectModuleImports(source, moduleLogicalPath, knownPaths);
+}
 
-  while ((m = importRe.exec(source)) !== null) {
-    const specifier = m[1]!;
-    const isAlias = specifier.startsWith("@/");
-    if (!isAlias && !specifier.startsWith("./") && !specifier.startsWith("../")) continue;
+function readModuleSource(node: ModuleSourceNode): string | null {
+  return typeof node.source?.value === "string" ? node.source.value : null;
+}
 
-    const dir = moduleLogicalPath.includes("/")
-      ? moduleLogicalPath.slice(0, moduleLogicalPath.lastIndexOf("/"))
-      : ".";
+function isTypeOnlyModuleDeclaration(node: ModuleSourceNode): boolean {
+  if (node.importKind === "type" || node.exportKind === "type") return true;
+  if (!node.specifiers?.length) return false;
+  return node.specifiers.every((specifier) =>
+    specifier.importKind === "type" || specifier.exportKind === "type"
+  );
+}
 
-    // `@/x` is a project-root alias (mirrors transforms/esm/path-resolver.ts).
-    // Resolve the path segments manually (no path library needed for simple cases).
-    const segments = (isAlias ? specifier.substring(2) : `${dir}/${specifier}`)
-      .split("/").filter((s) => s !== "");
-    const resolved: string[] = [];
-    for (const seg of segments) {
-      if (seg === "..") {
-        resolved.pop();
-      } else if (seg !== ".") {
-        resolved.push(seg);
-      }
-    }
-    const candidate = resolved.join("/");
+async function collectAstStaticProjectModuleImports(
+  source: string,
+  moduleLogicalPath: string,
+  knownPaths: Set<string>,
+): Promise<string[]> {
+  const parser = resolve<CodeParser>("CodeParser");
+  const ast = await parser.parse({ code: source, filePath: moduleLogicalPath });
+  const results = new Set<string>();
 
-    // If the specifier already has a known extension and exists, use it.
-    if (knownPaths.has(candidate)) {
-      results.push(candidate);
-      continue;
-    }
+  const visit = (path: NodePath) => {
+    const node = path.node as ModuleSourceNode;
+    if (isTypeOnlyModuleDeclaration(node)) return;
 
-    // Try appending each browser module extension.
-    let found = false;
-    for (const ext of BROWSER_MODULE_EXTENSIONS) {
-      const withExt = `${candidate}${ext}`;
-      if (knownPaths.has(withExt)) {
-        results.push(withExt);
-        found = true;
-        break;
-      }
-    }
+    const specifier = readModuleSource(node);
+    if (!specifier) return;
 
-    // Also try /index variants for directory imports.
-    if (!found) {
-      for (const ext of BROWSER_MODULE_EXTENSIONS) {
-        const indexPath = `${candidate}/index${ext}`;
-        if (knownPaths.has(indexPath)) {
-          results.push(indexPath);
-          break;
-        }
-      }
-    }
-  }
+    const importedPath = resolveProjectModuleSpecifier(specifier, moduleLogicalPath, knownPaths);
+    if (importedPath) results.add(importedPath);
+  };
 
-  return results;
+  parser.traverse(ast, {
+    ImportDeclaration: visit,
+    ExportNamedDeclaration: visit,
+    ExportAllDeclaration: visit,
+  });
+
+  return [...results];
 }
 
 function resolveKnownModulePath(path: string, knownPaths: Set<string>): string | null {
@@ -376,6 +372,7 @@ function normalizeProjectSpecifier(specifier: string, logicalPath: string): stri
   if (specifier.startsWith("/_vf_modules/_veryfront/")) return null;
   if (specifier.startsWith("/_vf_modules/")) return specifier;
   if (specifier.startsWith("_veryfront/")) return null;
+  if (specifier.startsWith("@/")) return specifier.slice(2);
 
   if (specifier.startsWith("./") || specifier.startsWith("../")) {
     const dir = logicalPath.includes("/")
@@ -1379,11 +1376,11 @@ function addFrameworkDependencyUrlAliases(
  * Returns all reachable logical paths (entries included).
  * Modules not in `sourceByPath` are recorded as closure gaps.
  */
-function collectClosure(
+async function collectClosure(
   entrypoints: string[],
   sourceByPath: Map<string, string>,
   knownPaths: Set<string>,
-): { modules: string[]; gaps: string[] } {
+): Promise<{ modules: string[]; gaps: string[] }> {
   const visited = new Set<string>();
   const queue = [...entrypoints];
   const gaps: string[] = [];
@@ -1400,7 +1397,7 @@ function collectClosure(
       continue;
     }
 
-    const imports = resolveStaticImports(source, current, knownPaths);
+    const imports = await collectStaticProjectModuleImports(source, current, knownPaths);
     for (const imp of imports) {
       if (!visited.has(imp)) queue.push(imp);
     }
@@ -1762,7 +1759,7 @@ async function runBuildInner(
     const route = routeForPage(logicalPath);
     if (!route) continue;
 
-    const { modules: closureModules, gaps: closureGaps } = collectClosure(
+    const { modules: closureModules, gaps: closureGaps } = await collectClosure(
       [logicalPath],
       sourceByPath,
       knownPaths,

--- a/src/release-assets/html-consumption.test.ts
+++ b/src/release-assets/html-consumption.test.ts
@@ -57,6 +57,22 @@ describe("html consumption helpers", () => {
     assertEquals(url, `/_vf/assets/${MOD_HASH}.js`);
   });
 
+  it("matches arbitrary-folder module URLs with query parameters", () => {
+    const customManifest = manifest();
+    customManifest.modules["providers/BreakpointsProvider.tsx"] = {
+      contentHash: MOD_HASH,
+      size: 1,
+      contentType: "text/javascript",
+    };
+
+    const url = resolveManifestModuleUrl(
+      customManifest,
+      "/_vf_modules/providers/BreakpointsProvider.js?studio_embed=true",
+    );
+
+    assertEquals(url, `/_vf/assets/${MOD_HASH}.js`);
+  });
+
   it("returns null (fallback) for an uncovered module", () => {
     assertEquals(resolveManifestModuleUrl(manifest(), "pages/missing.tsx"), null);
   });

--- a/src/release-assets/html-consumption.ts
+++ b/src/release-assets/html-consumption.ts
@@ -21,11 +21,13 @@ const logger = serverLogger.component("release-asset-consume");
  * The HTML shell works with relative source paths like `pages/index.tsx` and
  * `/_vf_modules/pages/index.js` URLs. Manifest module keys use the logical
  * source path (e.g. `pages/index.tsx`). This strips a leading `/_vf_modules/`
- * and any `.js` URL extension so both forms resolve.
+ * prefix and URL query/hash data before the resolver compares source
+ * extensions.
  */
 export function normalizeManifestModuleKey(path: string): string {
-  let key = path.replace(/^\/?_vf_modules\//, "");
+  let key = String(path || "").replace(/^\/?_vf_modules\//, "");
   key = key.replace(/^\/+/, "");
+  key = key.replace(/[?#].*$/, "");
   return key;
 }
 

--- a/src/rendering/rsc/component-analyzer.test.ts
+++ b/src/rendering/rsc/component-analyzer.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import "#veryfront/transforms/plugins/__tests__/code-parser-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";

--- a/src/rendering/rsc/component-analyzer.ts
+++ b/src/rendering/rsc/component-analyzer.ts
@@ -20,11 +20,12 @@ export async function analyzeComponent(
 
   // Determine component type: directive takes precedence over file naming convention
   const type: ComponentType = hasUseClient || filePath.includes(".client.") ? "client" : "server";
+  const exports = await extractExportNames(content, filePath);
 
   return {
     type,
     filePath,
-    exports: extractExportNames(content),
+    exports,
     id: generateComponentId(filePath),
     hasUseClient,
     hasUseServer,

--- a/src/rendering/rsc/export-extractor.test.ts
+++ b/src/rendering/rsc/export-extractor.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import "#veryfront/transforms/plugins/__tests__/code-parser-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { extractExportNames } from "./export-extractor.ts";
@@ -9,26 +10,26 @@ describe("rendering/rsc/export-extractor", () => {
       assertEquals(names.includes(name), true);
     }
 
-    it("should extract default export", () => {
-      const names = extractExportNames(`export default function App() {}`);
+    it("should extract default export", async () => {
+      const names = await extractExportNames(`export default function App() {}`);
       assertIncludes(names, "default");
     });
 
-    it("should extract named function exports", () => {
-      const names = extractExportNames(
+    it("should extract named function exports", async () => {
+      const names = await extractExportNames(
         `export function greet() {}\nexport function farewell() {}`,
       );
       assertIncludes(names, "greet");
       assertIncludes(names, "farewell");
     });
 
-    it("should extract named class exports", () => {
-      const names = extractExportNames(`export class MyComponent {}`);
+    it("should extract named class exports", async () => {
+      const names = await extractExportNames(`export class MyComponent {}`);
       assertIncludes(names, "MyComponent");
     });
 
-    it("should extract const/let/var exports", () => {
-      const names = extractExportNames(
+    it("should extract const/let/var exports", async () => {
+      const names = await extractExportNames(
         `export const FOO = 1;\nexport let bar = 2;\nexport var baz = 3;`,
       );
       assertIncludes(names, "FOO");
@@ -36,40 +37,67 @@ describe("rendering/rsc/export-extractor", () => {
       assertIncludes(names, "baz");
     });
 
-    it("should extract named exports from braces", () => {
-      const names = extractExportNames(`const a = 1; const b = 2;\nexport { a, b };`);
+    it("should extract named exports from braces", async () => {
+      const names = await extractExportNames(`const a = 1; const b = 2;\nexport { a, b };`);
       assertIncludes(names, "a");
       assertIncludes(names, "b");
     });
 
-    it("should handle 'as' aliases in export braces", () => {
-      const names = extractExportNames(`const foo = 1;\nexport { foo as bar };`);
+    it("should handle 'as' aliases in export braces", async () => {
+      const names = await extractExportNames(`const foo = 1;\nexport { foo as bar };`);
       assertIncludes(names, "bar");
     });
 
-    it("should return empty array for no exports", () => {
-      const names = extractExportNames(`const x = 1;`);
+    it("should return empty array for no exports", async () => {
+      const names = await extractExportNames(`const x = 1;`);
       assertEquals(names.length, 0);
     });
 
-    it("should handle mixed exports", () => {
+    it("should handle mixed exports", async () => {
       const source = `
         export default function App() {}
         export function helper() {}
         export const VALUE = 42;
         export class Widget {}
       `;
-      const names = extractExportNames(source);
+      const names = await extractExportNames(source);
       assertIncludes(names, "default");
       assertIncludes(names, "helper");
       assertIncludes(names, "VALUE");
       assertIncludes(names, "Widget");
     });
 
-    it("should not duplicate names", () => {
-      const names = extractExportNames(`export default function App() {}\nexport { App };`);
+    it("should not duplicate names", async () => {
+      const names = await extractExportNames(`export default function App() {}\nexport { App };`);
       const defaultCount = names.filter((n) => n === "default").length;
       assertEquals(defaultCount, 1);
+    });
+
+    it("should extract async functions and all variable declaration exports", async () => {
+      const names = await extractExportNames(
+        `export async function load() {}\nexport const one = 1, two = 2;`,
+      );
+      assertIncludes(names, "load");
+      assertIncludes(names, "one");
+      assertIncludes(names, "two");
+    });
+
+    it("should not extract export-looking text from strings or comments", async () => {
+      const names = await extractExportNames(`
+        const text = "export function fake() {}";
+        // export const hidden = 1;
+        /* export class Hidden {} */
+      `);
+      assertEquals(names, []);
+    });
+
+    it("should skip type-only exports", async () => {
+      const names = await extractExportNames(`
+        export type Props = { name: string };
+        export interface State { count: number }
+        export { type Props as PublicProps };
+      `);
+      assertEquals(names, []);
     });
   });
 });

--- a/src/rendering/rsc/export-extractor.ts
+++ b/src/rendering/rsc/export-extractor.ts
@@ -1,44 +1,99 @@
+import { resolve } from "#veryfront/extensions/contracts.ts";
+import type { CodeParser, NodePath } from "#veryfront/extensions/parser/index.ts";
+
+interface IdentifierLike {
+  name?: unknown;
+  value?: unknown;
+}
+
+interface ExportSpecifierNode {
+  exported?: IdentifierLike;
+  local?: IdentifierLike;
+  exportKind?: string;
+}
+
+interface VariableDeclaratorNode {
+  id?: IdentifierLike;
+}
+
+interface ExportDeclarationNode {
+  type?: string;
+  id?: IdentifierLike;
+  declarations?: VariableDeclaratorNode[];
+  declare?: boolean;
+}
+
+interface ExportNamedDeclarationNode {
+  declaration?: ExportDeclarationNode;
+  specifiers?: ExportSpecifierNode[];
+  exportKind?: string;
+}
+
+function readName(node: IdentifierLike | undefined): string | null {
+  if (typeof node?.name === "string") return node.name;
+  if (typeof node?.value === "string") return node.value;
+  return null;
+}
+
+function isTypeOnlyDeclaration(declaration: ExportDeclarationNode | undefined): boolean {
+  if (!declaration) return false;
+  if (declaration.declare === true) return true;
+  return declaration.type === "TSInterfaceDeclaration" ||
+    declaration.type === "TSTypeAliasDeclaration";
+}
+
+function addDeclarationNames(names: Set<string>, declaration: ExportDeclarationNode | undefined) {
+  if (!declaration || isTypeOnlyDeclaration(declaration)) return;
+
+  if (
+    declaration.type === "FunctionDeclaration" ||
+    declaration.type === "ClassDeclaration" ||
+    declaration.type === "TSEnumDeclaration"
+  ) {
+    const name = readName(declaration.id);
+    if (name) names.add(name);
+    return;
+  }
+
+  if (declaration.type !== "VariableDeclaration") return;
+
+  for (const declarator of declaration.declarations ?? []) {
+    const name = readName(declarator.id);
+    if (name) names.add(name);
+  }
+}
+
 /**
- * Extract all export names from source code.
- * Handles export function/class/const, named exports, and default exports.
+ * Extract runtime export names from source code.
+ *
+ * Uses the CodeParser AST contract so export-looking strings, comments, and
+ * type-only exports do not enter RSC manifests.
  */
-export function extractExportNames(source: string): string[] {
+export async function extractExportNames(
+  source: string,
+  filePath = "component.tsx",
+): Promise<string[]> {
+  const parser = resolve<CodeParser>("CodeParser");
+  const ast = await parser.parse({ code: source, filePath });
   const names = new Set<string>();
 
-  if (/export\s+default\s+/m.test(source)) {
-    names.add("default");
-  }
+  parser.traverse(ast, {
+    ExportDefaultDeclaration() {
+      names.add("default");
+    },
+    ExportNamedDeclaration(path: NodePath) {
+      const node = path.node as ExportNamedDeclarationNode;
+      if (node.exportKind === "type") return;
 
-  for (const match of source.matchAll(/export\s+function\s+([A-Za-z0-9_]+)/g)) {
-    if (match[1]) names.add(match[1]);
-  }
+      addDeclarationNames(names, node.declaration);
 
-  for (const match of source.matchAll(/export\s+class\s+([A-Za-z0-9_]+)/g)) {
-    if (match[1]) names.add(match[1]);
-  }
-
-  for (const match of source.matchAll(/export\s+(?:const|let|var)\s+([A-Za-z0-9_]+)/g)) {
-    if (match[1]) names.add(match[1]);
-  }
-
-  for (const match of source.matchAll(/export\s*\{([^}]+)\}/g)) {
-    const innerRaw = match[1];
-    if (!innerRaw) continue;
-    const inner = innerRaw.split(",");
-    for (const seg of inner) {
-      const part = seg.trim();
-      if (!part) continue;
-
-      const asMatch = part.match(/([A-Za-z0-9_]+)\s+as\s+([A-Za-z0-9_]+)/i);
-      if (asMatch?.[2]) {
-        names.add(asMatch[2]);
-        continue;
+      for (const specifier of node.specifiers ?? []) {
+        if (specifier.exportKind === "type") continue;
+        const name = readName(specifier.exported) ?? readName(specifier.local);
+        if (name) names.add(name);
       }
-
-      const plain = part.match(/^([A-Za-z0-9_]+)/);
-      if (plain?.[1]) names.add(plain[1]);
-    }
-  }
+    },
+  });
 
   return [...names];
 }

--- a/src/rendering/rsc/manifest.ts
+++ b/src/rendering/rsc/manifest.ts
@@ -34,8 +34,8 @@ export async function buildRscModules(
 
       try {
         const text = await adapter.fs.readFile(e.path);
-        const names = extractExportNames(text);
-        if (names.length > 0) exportsList = ["default", ...names];
+        const names = await extractExportNames(text, e.path);
+        if (names.length > 0) exportsList = [...new Set(["default", ...names])];
       } catch (_) {
         /* expected: file may not be readable, use default exports only */
       }

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -20,6 +20,7 @@ import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { registerCache } from "#veryfront/utils/memory/index.ts";
 import { buildMdxEsmPathCacheKey, MDX_ESM_ALL_FILE_URL_PATTERN_SOURCE } from "../cache-format.ts";
 import { ensureMdxModuleDependencies } from "../module-fetcher/dependency-recovery.ts";
+import { findStaticImportFromSpans } from "../utils/source-spans.ts";
 export { getLocalFs } from "./local-fs.ts";
 import { getLocalFs } from "./local-fs.ts";
 
@@ -124,15 +125,9 @@ async function findMissingFileDependencies(code: string): Promise<string[]> {
   return missing;
 }
 
-/**
- * Pattern to match unresolved /_vf_modules/ imports that weren't converted to proper file:// paths.
- * Matches both:
- * - `from "/_vf_modules/..."` or `from "_vf_modules/..."` (unresolved)
- * - `from "file:///_vf_modules/..."` (malformed - points to non-existent root /_vf_modules/)
- * Note: Uses \s* instead of \s+ because minified code may have no space after `from`.
- * These imports will fail at runtime because they can't be resolved by Deno's dynamic import.
- */
-const UNRESOLVED_VF_MODULES_PATTERN = /from\s*["']((?:file:\/\/)?\/?\/?_vf_modules\/[^"']+)["']/g;
+function matchUnresolvedVfModuleSpecifier(specifier: string): string | null {
+  return specifier.match(/^((?:file:\/\/)?\/?\/?_vf_modules\/[^?]+)(?:\?.*)?$/)?.[1] ?? null;
+}
 
 /**
  * Check if cached code has unresolved or malformed /_vf_modules/ imports.
@@ -140,12 +135,11 @@ const UNRESOLVED_VF_MODULES_PATTERN = /from\s*["']((?:file:\/\/)?\/?\/?_vf_modul
  * Returns true if any unresolved or malformed imports are found.
  */
 function hasUnresolvedVfModules(code: string): boolean {
-  const pattern = new RegExp(UNRESOLVED_VF_MODULES_PATTERN.source, "g");
-  let match;
-  while ((match = pattern.exec(code)) !== null) {
-    const importPath = match[1] as string;
+  const matches = findStaticImportFromSpans(code, matchUnresolvedVfModuleSpecifier);
+  const first = matches[0];
+  if (first) {
     logger.debug(`${LOG_PREFIX_MDX_LOADER} Cached module has unresolved _vf_modules import`, {
-      importPath,
+      importPath: first.path,
     });
     return true;
   }

--- a/src/transforms/mdx/esm-module-loader/import-transformer.test.ts
+++ b/src/transforms/mdx/esm-module-loader/import-transformer.test.ts
@@ -4,44 +4,55 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { rewriteProjectAliasImports, transformImports } from "./import-transformer.ts";
 
 describe("rewriteProjectAliasImports", () => {
-  it("rewrites @/ alias to /_vf_modules/ path", () => {
+  it("rewrites @/ alias to /_vf_modules/ path", async () => {
     const code = `import { Foo } from "@/components/Foo";\n`;
-    const result = rewriteProjectAliasImports(code);
+    const result = await rewriteProjectAliasImports(code);
     assertEquals(result.includes("/_vf_modules/components/Foo.js"), true);
   });
 
-  it("adds .js extension if missing", () => {
+  it("adds .js extension if missing", async () => {
     const code = `import { Foo } from "@/components/Foo";\n`;
-    const result = rewriteProjectAliasImports(code);
+    const result = await rewriteProjectAliasImports(code);
     assertEquals(result.includes(".js"), true);
   });
 
-  it("does not double-add .js extension", () => {
+  it("does not double-add .js extension", async () => {
     const code = `import { Foo } from "@/components/Foo.js";\n`;
-    const result = rewriteProjectAliasImports(code);
+    const result = await rewriteProjectAliasImports(code);
     assertEquals(result.includes(".js.js"), false);
     assertEquals(result.includes("/_vf_modules/components/Foo.js"), true);
   });
 
-  it("returns code unchanged when no @/ imports", () => {
+  it("returns code unchanged when no @/ imports", async () => {
     const code = `import { useState } from "react";\n`;
-    assertEquals(rewriteProjectAliasImports(code), code);
+    assertEquals(await rewriteProjectAliasImports(code), code);
   });
 
-  it("handles deeply nested paths", () => {
+  it("handles deeply nested paths", async () => {
     const code = `import { x } from "@/lib/utils/helpers";\n`;
-    const result = rewriteProjectAliasImports(code);
+    const result = await rewriteProjectAliasImports(code);
     assertEquals(result.includes("/_vf_modules/lib/utils/helpers.js"), true);
   });
 
-  it("rewrites multiple @/ imports", () => {
+  it("rewrites multiple @/ imports", async () => {
     const code = [
       `import { A } from "@/a";`,
       `import { B } from "@/b";`,
     ].join("\n");
-    const result = rewriteProjectAliasImports(code);
+    const result = await rewriteProjectAliasImports(code);
     assertEquals(result.includes("/_vf_modules/a.js"), true);
     assertEquals(result.includes("/_vf_modules/b.js"), true);
+  });
+
+  it("rewrites dynamic @/ imports", async () => {
+    const code = `const mod = await import("@/components/Foo");`;
+    const result = await rewriteProjectAliasImports(code);
+    assertEquals(result.includes(`import("/_vf_modules/components/Foo.js")`), true);
+  });
+
+  it("does not rewrite import-looking text inside strings", async () => {
+    const code = `const text = 'from "@/components/Foo"';`;
+    assertEquals(await rewriteProjectAliasImports(code), code);
   });
 });
 

--- a/src/transforms/mdx/esm-module-loader/import-transformer.ts
+++ b/src/transforms/mdx/esm-module-loader/import-transformer.ts
@@ -11,15 +11,13 @@ import { join } from "#veryfront/compat/path";
 import { rendererLogger as logger } from "#veryfront/utils";
 import { transformImportsWithMap } from "#veryfront/modules/import-map/index.ts";
 import type { ImportMapConfig } from "#veryfront/modules/import-map/index.ts";
-import { replaceSpecifiers } from "../../esm/lexer.ts";
+import { parseImports, replaceSpecifiers } from "../../esm/lexer.ts";
 import { getLocalReactPaths, isReactSpecifier } from "#veryfront/platform/compat/react-paths.ts";
 import {
   ESBUILD_JSX_FACTORY,
   ESBUILD_JSX_FRAGMENT,
   FRAMEWORK_ROOT,
-  JSX_IMPORT_PATTERN,
   LOG_PREFIX_MDX_LOADER,
-  REACT_IMPORT_PATTERN,
 } from "./constants.ts";
 import { getLocalFs } from "./cache/index.ts";
 import { buildMdxJsxCacheFileName } from "./cache-format.ts";
@@ -30,10 +28,12 @@ import type { ESMLoaderContext } from "./types.ts";
 /**
  * Rewrite @/ aliased imports to /_vf_modules/ paths.
  */
-export function rewriteProjectAliasImports(code: string): string {
-  return code.replace(/from\s*["']@\/([^"']+)["']/g, (_match, path) => {
+export async function rewriteProjectAliasImports(code: string): Promise<string> {
+  return await replaceSpecifiers(code, (specifier) => {
+    if (!specifier.startsWith("@/")) return null;
+    const path = specifier.slice(2);
     const jsPath = path.endsWith(".js") ? path : `${path}.js`;
-    return `from "/_vf_modules/${jsPath}"`;
+    return `/_vf_modules/${jsPath}`;
   });
 }
 
@@ -82,6 +82,11 @@ export function transformImports(code: string, importMap: ImportMapConfig): stri
   });
 }
 
+async function hasReactImport(code: string): Promise<boolean> {
+  const imports = await parseImports(code);
+  return imports.some((importSpecifier) => importSpecifier.n === "react");
+}
+
 /**
  * Transform JSX/TSX imports using esbuild.
  * Optimized to process all imports in parallel batches for better performance.
@@ -94,27 +99,21 @@ export async function transformJsxImports(
   const { transform } = await import("veryfront/extensions/bundler");
 
   const importsToProcess: Array<{
-    fullMatch: string;
-    importClause: string;
+    specifier: string;
     filePath: string;
     ext: string;
   }> = [];
 
-  let jsxMatch: RegExpExecArray | null;
-  while ((jsxMatch = JSX_IMPORT_PATTERN.exec(code)) !== null) {
-    const [fullMatch, importClause, filePath, ext] = jsxMatch;
+  const imports = await parseImports(code);
+  for (const importSpecifier of imports) {
+    const specifier = importSpecifier.n;
+    if (!specifier?.startsWith("file://")) continue;
 
-    if (!filePath || !importClause || !ext) {
-      logger.warn(`${LOG_PREFIX_MDX_LOADER} Skipping JSX import with undefined fields`, {
-        fullMatch,
-        hasFilePath: !!filePath,
-        hasImportClause: !!importClause,
-        hasExt: !!ext,
-      });
-      continue;
-    }
+    const filePath = specifier.slice("file://".length);
+    const ext = filePath.match(/\.(tsx?|jsx?)$/)?.[1];
+    if (!ext) continue;
 
-    importsToProcess.push({ fullMatch, importClause, filePath, ext });
+    importsToProcess.push({ specifier, filePath, ext });
   }
 
   if (importsToProcess.length === 0) return code;
@@ -125,7 +124,7 @@ export async function transformJsxImports(
   );
 
   const transformResults = await Promise.all(
-    importsToProcess.map(async ({ fullMatch, importClause, filePath, ext }) => {
+    importsToProcess.map(async ({ specifier, filePath, ext }) => {
       try {
         const isFrameworkFile = filePath.startsWith(FRAMEWORK_ROOT);
         let jsxCode: string | Uint8Array;
@@ -152,8 +151,8 @@ export async function transformJsxImports(
             const useCached = await ensureCachedJsxModulePatched(transformedPath, filePath);
             if (useCached) {
               return {
-                original: fullMatch,
-                transformed: `import ${importClause} from "file://${transformedPath}";`,
+                specifier,
+                replacement: `file://${transformedPath}`,
                 cached: true,
               };
             }
@@ -179,7 +178,7 @@ export async function transformJsxImports(
         });
 
         let transformed = result.code;
-        if (!REACT_IMPORT_PATTERN.test(transformed)) {
+        if (!(await hasReactImport(transformed))) {
           transformed = `import React from 'react';\n${transformed}`;
         }
 
@@ -191,8 +190,8 @@ export async function transformJsxImports(
         await getLocalFs().writeTextFile(transformedPath, transformed);
 
         return {
-          original: fullMatch,
-          transformed: `import ${importClause} from "file://${transformedPath}";`,
+          specifier,
+          replacement: `file://${transformedPath}`,
           cached: false,
         };
       } catch (error) {
@@ -209,10 +208,11 @@ export async function transformJsxImports(
     durationMs: (performance.now() - transformStart).toFixed(1),
   });
 
-  let result = code;
+  const replacements = new Map<string, string>();
   for (const t of transformResults) {
-    if (t) result = result.replace(t.original, t.transformed);
+    if (t) replacements.set(t.specifier, t.replacement);
   }
 
-  return result;
+  if (replacements.size === 0) return code;
+  return await replaceSpecifiers(code, (specifier) => replacements.get(specifier) ?? null);
 }

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.test.ts
@@ -89,6 +89,16 @@ import { bar } from "./local.js";
       const result = hasUnresolvedImports("");
       assertEquals(result.count, 0);
     });
+
+    it("does not count import-looking text in strings or comments", () => {
+      const code = [
+        `const text = 'from "/_vf_modules/_veryfront/lib.js"';`,
+        `// import { foo } from "/_vf_modules/_veryfront/commented.js";`,
+      ].join("\n");
+      const result = hasUnresolvedImports(code);
+      assertEquals(result.count, 0);
+      assertEquals(result.paths, []);
+    });
   });
 
   describe("resolveNestedModuleImports", () => {

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/nested-imports.ts
@@ -4,7 +4,7 @@
  * @module transforms/mdx/esm-module-loader/module-fetcher/nested-imports
  */
 
-import { LOG_PREFIX_MDX_LOADER, UNRESOLVED_VF_MODULES_PATTERN } from "../constants.ts";
+import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 import type { NestedImportResult } from "../types.ts";
 import { createStubModule } from "../utils/stub-module.ts";
 import {
@@ -14,6 +14,10 @@ import {
 } from "../utils/source-spans.ts";
 import { buildMissingModuleError } from "../missing-module.ts";
 import type { Logger } from "#veryfront/utils/logger/logger.ts";
+
+function matchUnresolvedVfModuleSpecifier(specifier: string): string | null {
+  return specifier.match(/^((?:file:\/\/)?\/?\/?_vf_modules\/[^?]+)(?:\?.*)?$/)?.[1] ?? null;
+}
 
 /**
  * Find nested module imports in code.
@@ -31,7 +35,7 @@ export function findNestedImports(
   for (
     const { original, path: rawPath, start, end } of findStaticImportFromSpans(
       moduleCode,
-      (specifier) => specifier.match(/^((?:file:\/\/)?\/?\/?_vf_modules\/[^?]+)(?:\?.*)?$/)?.[1],
+      matchUnresolvedVfModuleSpecifier,
     )
   ) {
     // Strip file:// prefix and leading slashes to get clean _vf_modules/... path
@@ -64,11 +68,10 @@ export function findNestedImports(
  * Check for unresolved /_vf_modules/ imports.
  */
 export function hasUnresolvedImports(moduleCode: string): { count: number; paths: string[] } {
-  const pattern = new RegExp(UNRESOLVED_VF_MODULES_PATTERN.source, "g");
-  const matches = [...moduleCode.matchAll(pattern)];
+  const matches = findStaticImportFromSpans(moduleCode, matchUnresolvedVfModuleSpecifier);
   return {
     count: matches.length,
-    paths: matches.map((m) => m[1]).filter((p): p is string => p !== undefined).slice(0, 5),
+    paths: matches.map((match) => match.path).slice(0, 5),
   };
 }
 

--- a/src/transforms/mdx/esm-module-loader/module-writer.ts
+++ b/src/transforms/mdx/esm-module-loader/module-writer.ts
@@ -34,11 +34,7 @@ import { setupSSRGlobals } from "#veryfront/rendering/ssr-globals.ts";
 import type { MDXFrontmatter, MDXModule } from "../types.ts";
 import type { ESMLoaderContext } from "./types.ts";
 import type { ImportMapConfig } from "#veryfront/modules/import-map/index.ts";
-import {
-  LOG_PREFIX_MDX_LOADER,
-  LOG_PREFIX_MDX_RENDERER,
-  UNRESOLVED_VF_MODULES_PATTERN,
-} from "./constants.ts";
+import { LOG_PREFIX_MDX_LOADER, LOG_PREFIX_MDX_RENDERER } from "./constants.ts";
 import { getLocalFs } from "./cache/index.ts";
 import { hashString } from "./utils/hash.ts";
 import { ssrVfModulesPlugin } from "../../pipeline/stages/ssr-vf-modules.ts";
@@ -57,6 +53,7 @@ import {
   processVfModuleImports,
   resolveProjectDir,
 } from "./loader-helpers.ts";
+import { hasUnresolvedImports } from "./module-fetcher/nested-imports.ts";
 
 /** Singleflight for MDX module file writes to prevent race conditions */
 const mdxWriteFlight = new Singleflight<void>();
@@ -103,7 +100,7 @@ export async function doLoadModuleESM(
     const esmCacheDir = await initializeCacheDir(context);
     logger.debug(`${LOG_PREFIX_MDX_LOADER} Step: initializeCacheDir DONE`, { projectSlug });
 
-    let rewritten = rewriteProjectAliasImports(compiledProgramCode);
+    let rewritten = await rewriteProjectAliasImports(compiledProgramCode);
 
     const projectDir = resolveProjectDir(context);
     logger.debug(`${LOG_PREFIX_MDX_LOADER} Step: loadImportMap START`, { projectSlug });
@@ -172,13 +169,12 @@ export async function doLoadModuleESM(
     }
     logger.debug(`${LOG_PREFIX_MDX_LOADER} Module cache miss`, { projectSlug, compositeKey });
 
-    const unresolvedMatches = [
-      ...rewritten.matchAll(new RegExp(UNRESOLVED_VF_MODULES_PATTERN.source, "g")),
-    ];
-    if (unresolvedMatches.length > 0) {
-      const unresolvedPaths = unresolvedMatches.map((m) => m[1]).slice(0, 5);
-      const errorMsg = `MDX has ${unresolvedMatches.length} unresolved module imports: ${
-        unresolvedPaths.join(", ")
+    const unresolved = hasUnresolvedImports(rewritten);
+    if (unresolved.count > 0) {
+      const errorMsg = `MDX has ${unresolved.count} unresolved module imports: ${
+        unresolved.paths
+          .slice(0, 5)
+          .join(", ")
       }`;
       logger.error(`${LOG_PREFIX_MDX_RENDERER} ${errorMsg}`);
       throw IMPORT_RESOLUTION_ERROR.create({ detail: errorMsg });

--- a/src/transforms/mdx/esm-module-loader/transforms/alias-imports.test.ts
+++ b/src/transforms/mdx/esm-module-loader/transforms/alias-imports.test.ts
@@ -1,0 +1,76 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { FSAdapter } from "../types.ts";
+import { transformModuleServerImports, transformProjectAliasImports } from "./alias-imports.ts";
+
+class MemoryFs implements FSAdapter {
+  readonly files = new Map<string, string>();
+
+  constructor(files: Record<string, string>) {
+    for (const [path, content] of Object.entries(files)) {
+      this.files.set(path, content);
+    }
+  }
+
+  readFile(path: string): Promise<string> {
+    const content = this.files.get(path);
+    if (content === undefined) throw new Error(`Missing file: ${path}`);
+    return Promise.resolve(content);
+  }
+
+  mkdir(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  writeFile(path: string, content: string | Uint8Array): Promise<void> {
+    this.files.set(path, typeof content === "string" ? content : new TextDecoder().decode(content));
+    return Promise.resolve();
+  }
+
+  stat(path: string): Promise<{ isFile?: boolean } | null> {
+    return Promise.resolve(this.files.has(path) ? { isFile: true } : null);
+  }
+
+  makeTempDir(prefix: string): Promise<string> {
+    return Promise.resolve(`${prefix}-tmp`);
+  }
+}
+
+describe("alias import transforms", () => {
+  it("rewrites only real project alias imports", async () => {
+    const fs = new MemoryFs({
+      "components/Foo.js": `export default function Foo() { return null; }`,
+    });
+    const code = [
+      `const text = 'from "@/components/Foo"';`,
+      `// import Foo from "@/components/Commented";`,
+      `import Foo from "@/components/Foo";`,
+    ].join("\n");
+
+    const result = await transformProjectAliasImports(code, fs, "/cache");
+
+    assertStringIncludes(result, `const text = 'from "@/components/Foo"';`);
+    assertStringIncludes(result, `// import Foo from "@/components/Commented";`);
+    assertStringIncludes(result, `import Foo from "file:///cache/alias-`);
+    assertEquals(fs.files.has("components/Commented.js"), false);
+  });
+
+  it("rewrites only real _vf_modules imports", async () => {
+    const fs = new MemoryFs({
+      "components/Foo.js": `export default function Foo() { return null; }`,
+    });
+    const code = [
+      `const text = 'from "/_vf_modules/components/Foo.js"';`,
+      `// import Foo from "/_vf_modules/components/Commented.js";`,
+      `import Foo from "/_vf_modules/components/Foo.js?ssr=true";`,
+    ].join("\n");
+
+    const result = await transformModuleServerImports(code, fs, "/cache");
+
+    assertStringIncludes(result, `const text = 'from "/_vf_modules/components/Foo.js"';`);
+    assertStringIncludes(result, `// import Foo from "/_vf_modules/components/Commented.js";`);
+    assertStringIncludes(result, `import Foo from "file:///cache/vfmod-`);
+    assertEquals(fs.files.has("components/Commented.js"), false);
+  });
+});

--- a/src/transforms/mdx/esm-module-loader/transforms/alias-imports.ts
+++ b/src/transforms/mdx/esm-module-loader/transforms/alias-imports.ts
@@ -10,46 +10,46 @@
 
 import { join } from "#veryfront/compat/path";
 import { rendererLogger as logger } from "#veryfront/utils";
-import {
-  ESBUILD_JSX_FACTORY,
-  ESBUILD_JSX_FRAGMENT,
-  LOG_PREFIX_MDX_LOADER,
-  MODULE_SERVER_IMPORT_PATTERN,
-  PROJECT_ALIAS_IMPORT_PATTERN,
-  REACT_IMPORT_PATTERN,
-} from "../constants.ts";
+import { ESBUILD_JSX_FACTORY, ESBUILD_JSX_FRAGMENT, LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 import type { FSAdapter } from "../types.ts";
 import { hashString } from "../utils/hash.ts";
 import { resolveFileWithExtension } from "../resolution/file-finder.ts";
+import { parseImports, replaceSpecifiers } from "../../../esm/lexer.ts";
 
 type ImportType = "project-alias" | "vf-modules";
 
 interface AliasImport {
-  original: string;
-  importClause?: string;
+  specifier: string;
   relativePath: string;
   type: ImportType;
 }
 
-function findAliasImports(code: string): AliasImport[] {
+async function findAliasImports(code: string): Promise<AliasImport[]> {
   const imports: AliasImport[] = [];
+  const parsedImports = await parseImports(code);
 
-  const projectAliasPattern = new RegExp(PROJECT_ALIAS_IMPORT_PATTERN.source, "g");
-  let match: RegExpExecArray | null;
+  for (const importSpecifier of parsedImports) {
+    const specifier = importSpecifier.n;
+    if (!specifier) continue;
 
-  while ((match = projectAliasPattern.exec(code)) !== null) {
-    const [original, importClause, relativePath] = match;
-    if (!relativePath || !importClause) continue;
-    imports.push({ original, importClause, relativePath, type: "project-alias" });
-  }
+    if (specifier.startsWith("@/")) {
+      imports.push({
+        specifier,
+        relativePath: specifier.slice(2),
+        type: "project-alias",
+      });
+      continue;
+    }
 
-  const moduleServerPattern = new RegExp(MODULE_SERVER_IMPORT_PATTERN.source, "g");
-  while ((match = moduleServerPattern.exec(code)) !== null) {
-    const [original, modulePath] = match;
-    if (!modulePath) continue;
+    const normalized = specifier.replace(/^(?:file:\/\/)?\/+/, "");
+    if (!normalized.startsWith("_vf_modules/")) continue;
+
+    const modulePath = normalized.slice("_vf_modules/".length);
+    const queryStart = modulePath.indexOf("?");
+    const relativePath = queryStart === -1 ? modulePath : modulePath.slice(0, queryStart);
     imports.push({
-      original,
-      relativePath: modulePath.replace(/\.js$/, ""),
+      specifier,
+      relativePath: relativePath.replace(/\.js$/, ""),
       type: "vf-modules",
     });
   }
@@ -84,12 +84,17 @@ function getEsbuildLoader(extension: string): "tsx" | "jsx" | "ts" | null {
   return null;
 }
 
+async function hasReactImport(code: string): Promise<boolean> {
+  const imports = await parseImports(code);
+  return imports.some((importSpecifier) => importSpecifier.n === "react");
+}
+
 async function transformImport(
   imp: AliasImport,
   fs: FSAdapter,
   esmCacheDir: string,
   transform: typeof import("veryfront/extensions/bundler").transform,
-): Promise<{ original: string; replacement: string } | null> {
+): Promise<{ specifier: string; replacement: string } | null> {
   const readFile = createFileReader(fs);
   const resolved = await resolveFileWithExtension(imp.relativePath, readFile);
 
@@ -116,7 +121,7 @@ async function transformImport(
       transformed = esbuildResult.code;
 
       if (
-        (extension === ".tsx" || extension === ".jsx") && !REACT_IMPORT_PATTERN.test(transformed)
+        (extension === ".tsx" || extension === ".jsx") && !(await hasReactImport(transformed))
       ) {
         transformed = `import React from 'react';\n${transformed}`;
       }
@@ -127,13 +132,9 @@ async function transformImport(
     const transformedPath = join(esmCacheDir, transformedFileName);
     await fs.writeFile(transformedPath, transformed);
 
-    const replacement = imp.type === "project-alias" && imp.importClause
-      ? `import ${imp.importClause} from "file://${transformedPath}";`
-      : `from "file://${transformedPath}"`;
-
     logger.debug(`${LOG_PREFIX_MDX_LOADER} Transformed ${getPathDesc(imp)} -> ${transformedPath}`);
 
-    return { original: imp.original, replacement };
+    return { specifier: imp.specifier, replacement: `file://${transformedPath}` };
   } catch (error) {
     logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to transform ${getPathDesc(imp)}`, error);
     return null;
@@ -146,22 +147,23 @@ async function transformAliasImports(
   esmCacheDir: string,
   type: ImportType,
 ): Promise<string> {
-  const imports = findAliasImports(code).filter((imp) => imp.type === type);
+  const imports = (await findAliasImports(code)).filter((imp) => imp.type === type);
   if (imports.length === 0) return code;
 
   const label = type === "project-alias" ? "@/ imports" : "/_vf_modules/ imports";
   logger.debug(`${LOG_PREFIX_MDX_LOADER} Found ${imports.length} ${label} to transform`);
 
   const { transform } = await import("veryfront/extensions/bundler");
-  let result = code;
+  const replacements = new Map<string, string>();
 
   for (const imp of imports) {
     const transformed = await transformImport(imp, fs, esmCacheDir, transform);
     if (!transformed) continue;
-    result = result.replace(transformed.original, transformed.replacement);
+    replacements.set(transformed.specifier, transformed.replacement);
   }
 
-  return result;
+  if (replacements.size === 0) return code;
+  return await replaceSpecifiers(code, (specifier) => replacements.get(specifier) ?? null);
 }
 
 type AliasImportTransformer = (code: string, fs: FSAdapter, esmCacheDir: string) => Promise<string>;

--- a/src/transforms/pipeline/stages/ssr-vf-modules.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules.test.ts
@@ -35,20 +35,20 @@ const { findVfModuleImports, findRelativeImports, FRAMEWORK_ROOT, EMBEDDED_SRC_D
 
 describe("ssr-vf-modules", { sanitizeOps: false, sanitizeResources: false }, () => {
   describe("findVfModuleImports", () => {
-    it("finds single /_vf_modules/ import", () => {
+    it("finds single /_vf_modules/ import", async () => {
       const code =
         `import { Head } from "/_vf_modules/_veryfront/react/components/Head.js?ssr=true";`;
-      const imports = findVfModuleImports(code);
+      const imports = await findVfModuleImports(code);
       assertEquals(imports, ["/_vf_modules/_veryfront/react/components/Head.js?ssr=true"]);
     });
 
-    it("finds multiple /_vf_modules/ imports", () => {
+    it("finds multiple /_vf_modules/ imports", async () => {
       const code = `
         import { Head } from "/_vf_modules/_veryfront/react/components/Head.js?ssr=true";
         import { Router } from "/_vf_modules/_veryfront/react/router/index.js?ssr=true";
         import { something } from "other-package";
       `;
-      const imports = findVfModuleImports(code);
+      const imports = await findVfModuleImports(code);
       assertEquals(imports.length, 2);
       assertEquals(
         imports.includes("/_vf_modules/_veryfront/react/components/Head.js?ssr=true"),
@@ -60,103 +60,103 @@ describe("ssr-vf-modules", { sanitizeOps: false, sanitizeResources: false }, () 
       );
     });
 
-    it("deduplicates repeated imports", () => {
+    it("deduplicates repeated imports", async () => {
       const code = `
         import { Head } from "/_vf_modules/_veryfront/react/components/Head.js";
         import { Head as H2 } from "/_vf_modules/_veryfront/react/components/Head.js";
       `;
-      const imports = findVfModuleImports(code);
+      const imports = await findVfModuleImports(code);
       assertEquals(imports.length, 1);
     });
 
-    it("returns empty array for code without /_vf_modules/ imports", () => {
+    it("returns empty array for code without /_vf_modules/ imports", async () => {
       const code = `
         import React from "react";
         import { something } from "./local";
       `;
-      const imports = findVfModuleImports(code);
+      const imports = await findVfModuleImports(code);
       assertEquals(imports, []);
     });
 
-    it("handles single quotes", () => {
+    it("handles single quotes", async () => {
       const code = `import { Head } from '/_vf_modules/_veryfront/react/components/Head.js';`;
-      const imports = findVfModuleImports(code);
+      const imports = await findVfModuleImports(code);
       assertEquals(imports.length, 1);
     });
 
-    it("finds file:///_vf_modules imports", () => {
+    it("finds file:///_vf_modules imports", async () => {
       const code =
         `import { usePageContext } from "file:///_vf_modules/_veryfront/react/runtime/core.js?ssr=true";`;
-      const imports = findVfModuleImports(code);
+      const imports = await findVfModuleImports(code);
       assertEquals(imports, ["file:///_vf_modules/_veryfront/react/runtime/core.js?ssr=true"]);
     });
 
-    it("ignores string literals without from keyword", () => {
+    it("ignores string literals without from keyword", async () => {
       const code = `const path = "/_vf_modules/something";`;
-      const imports = findVfModuleImports(code);
+      const imports = await findVfModuleImports(code);
       assertEquals(imports, []);
     });
   });
 
   describe("findRelativeImports", () => {
-    it("finds from-style relative imports", () => {
+    it("finds from-style relative imports", async () => {
       const code = `
         import { foo } from "./foo.js";
         import { bar } from "../bar.js";
       `;
-      const imports = findRelativeImports(code);
+      const imports = await findRelativeImports(code);
       assertEquals(imports.length, 2);
       assertEquals(imports.includes("./foo.js"), true);
       assertEquals(imports.includes("../bar.js"), true);
     });
 
-    it("finds side-effect relative imports (no from keyword)", () => {
+    it("finds side-effect relative imports (no from keyword)", async () => {
       const code = `import "./polyfills.js";`;
-      const imports = findRelativeImports(code);
+      const imports = await findRelativeImports(code);
       assertEquals(imports, ["./polyfills.js"]);
     });
 
-    it("finds deeply nested side-effect imports like dnt polyfills", () => {
+    it("finds deeply nested side-effect imports like dnt polyfills", async () => {
       const code = `import "../../../_dnt.polyfills.js";`;
-      const imports = findRelativeImports(code);
+      const imports = await findRelativeImports(code);
       assertEquals(imports, ["../../../_dnt.polyfills.js"]);
     });
 
-    it("finds both from and side-effect imports in the same code", () => {
+    it("finds both from and side-effect imports in the same code", async () => {
       const code = `
         import "../../../_dnt.polyfills.js";
         import { shims } from "./_dnt.shims.js";
         import "./setup.js";
       `;
-      const imports = findRelativeImports(code);
+      const imports = await findRelativeImports(code);
       assertEquals(imports.length, 3);
       assertEquals(imports.includes("../../../_dnt.polyfills.js"), true);
       assertEquals(imports.includes("./_dnt.shims.js"), true);
       assertEquals(imports.includes("./setup.js"), true);
     });
 
-    it("deduplicates across from and side-effect patterns", () => {
+    it("deduplicates across from and side-effect patterns", async () => {
       const code = `
         import "./shared.js";
         import { x } from "./shared.js";
       `;
-      const imports = findRelativeImports(code);
+      const imports = await findRelativeImports(code);
       assertEquals(imports.length, 1);
       assertEquals(imports[0], "./shared.js");
     });
 
-    it("ignores non-relative side-effect imports", () => {
+    it("ignores non-relative side-effect imports", async () => {
       const code = `
         import "some-bare-module";
         import "@scope/package";
       `;
-      const imports = findRelativeImports(code);
+      const imports = await findRelativeImports(code);
       assertEquals(imports, []);
     });
 
-    it("handles single quotes in side-effect imports", () => {
+    it("handles single quotes in side-effect imports", async () => {
       const code = `import '../polyfills.js';`;
-      const imports = findRelativeImports(code);
+      const imports = await findRelativeImports(code);
       assertEquals(imports, ["../polyfills.js"]);
     });
   });
@@ -386,7 +386,7 @@ describe("ssr-vf-modules relative import resolution", {
     assertStringIncludes(resolved!, "Head.tsx");
   });
 
-  it("finds relative imports in transformed code", () => {
+  it("finds relative imports in transformed code", async () => {
     // Test the findRelativeImports function
     const { findRelativeImports } = _testExports;
 
@@ -396,7 +396,7 @@ describe("ssr-vf-modules relative import resolution", {
       import React from "react";
     `;
 
-    const imports = findRelativeImports(code);
+    const imports = await findRelativeImports(code);
     assertEquals(imports.length, 2);
     assertEquals(imports.includes("./Head.js"), true);
     assertEquals(imports.includes("../components/Link.js"), true);

--- a/src/transforms/pipeline/stages/ssr-vf-modules/import-finder.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/import-finder.test.ts
@@ -4,82 +4,98 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { findRelativeImports, findVfModuleImports } from "./import-finder.ts";
 
 describe("findVfModuleImports", () => {
-  it("finds veryfront module imports", () => {
+  it("finds veryfront module imports", async () => {
     const code = `import { foo } from "/_vf_modules/_veryfront/utils.js";`;
-    assertEquals(findVfModuleImports(code), ["/_vf_modules/_veryfront/utils.js"]);
+    assertEquals(await findVfModuleImports(code), ["/_vf_modules/_veryfront/utils.js"]);
   });
 
-  it("returns empty array when no vf imports", () => {
-    assertEquals(findVfModuleImports(`import { x } from "./local.ts";`), []);
+  it("returns empty array when no vf imports", async () => {
+    assertEquals(await findVfModuleImports(`import { x } from "./local.ts";`), []);
   });
 
-  it("deduplicates repeated imports", () => {
+  it("deduplicates repeated imports", async () => {
     const code = [
       `import { a } from "/_vf_modules/_veryfront/utils.js";`,
       `import { b } from "/_vf_modules/_veryfront/utils.js";`,
     ].join("\n");
-    assertEquals(findVfModuleImports(code), ["/_vf_modules/_veryfront/utils.js"]);
+    assertEquals(await findVfModuleImports(code), ["/_vf_modules/_veryfront/utils.js"]);
   });
 
-  it("finds multiple distinct vf imports", () => {
+  it("finds multiple distinct vf imports", async () => {
     const code = [
       `import { a } from "/_vf_modules/_veryfront/utils.js";`,
       `import { b } from "/_vf_modules/_veryfront/errors.js";`,
     ].join("\n");
-    assertEquals(findVfModuleImports(code).length, 2);
+    assertEquals((await findVfModuleImports(code)).length, 2);
   });
 
-  it("does not match user project vf_modules paths", () => {
+  it("does not match user project vf_modules paths", async () => {
     const code = `import { x } from "/_vf_modules/components/Foo.js";`;
-    assertEquals(findVfModuleImports(code), []);
+    assertEquals(await findVfModuleImports(code), []);
   });
 
-  it("handles minified code without spaces after from", () => {
+  it("handles minified code without spaces after from", async () => {
     const code = `import{foo}from"/_vf_modules/_veryfront/utils.js";`;
-    assertEquals(findVfModuleImports(code), ["/_vf_modules/_veryfront/utils.js"]);
+    assertEquals(await findVfModuleImports(code), ["/_vf_modules/_veryfront/utils.js"]);
   });
 
-  it("handles single-quoted imports", () => {
+  it("handles single-quoted imports", async () => {
     const code = `import { foo } from '/_vf_modules/_veryfront/utils.js';`;
-    assertEquals(findVfModuleImports(code), ["/_vf_modules/_veryfront/utils.js"]);
+    assertEquals(await findVfModuleImports(code), ["/_vf_modules/_veryfront/utils.js"]);
+  });
+
+  it("does not match import-looking text in strings or comments", async () => {
+    const code = `
+      const text = 'from "/_vf_modules/_veryfront/utils.js"';
+      // import { foo } from "/_vf_modules/_veryfront/commented.js";
+    `;
+    assertEquals(await findVfModuleImports(code), []);
   });
 });
 
 describe("findRelativeImports", () => {
-  it("finds relative imports with ./", () => {
+  it("finds relative imports with ./", async () => {
     const code = `import { foo } from "./bar.ts";`;
-    assertEquals(findRelativeImports(code), ["./bar.ts"]);
+    assertEquals(await findRelativeImports(code), ["./bar.ts"]);
   });
 
-  it("finds relative imports with ../", () => {
+  it("finds relative imports with ../", async () => {
     const code = `import { foo } from "../bar.ts";`;
-    assertEquals(findRelativeImports(code), ["../bar.ts"]);
+    assertEquals(await findRelativeImports(code), ["../bar.ts"]);
   });
 
-  it("finds side-effect imports", () => {
+  it("finds side-effect imports", async () => {
     const code = `import "./styles.css";`;
-    assertEquals(findRelativeImports(code), ["./styles.css"]);
+    assertEquals(await findRelativeImports(code), ["./styles.css"]);
   });
 
-  it("ignores non-relative imports", () => {
-    assertEquals(findRelativeImports(`import { x } from "react";`), []);
+  it("ignores non-relative imports", async () => {
+    assertEquals(await findRelativeImports(`import { x } from "react";`), []);
   });
 
-  it("deduplicates", () => {
+  it("deduplicates", async () => {
     const code = `import { a } from "./x.ts";\nimport { b } from "./x.ts";`;
-    assertEquals(findRelativeImports(code), ["./x.ts"]);
+    assertEquals(await findRelativeImports(code), ["./x.ts"]);
   });
 
-  it("finds both from and side-effect imports", () => {
+  it("finds both from and side-effect imports", async () => {
     const code = [
       `import { a } from "./utils.ts";`,
       `import "./styles.css";`,
     ].join("\n");
-    assertEquals(findRelativeImports(code).length, 2);
+    assertEquals((await findRelativeImports(code)).length, 2);
   });
 
-  it("handles single-quoted imports", () => {
+  it("handles single-quoted imports", async () => {
     const code = `import { foo } from '../bar.ts';`;
-    assertEquals(findRelativeImports(code), ["../bar.ts"]);
+    assertEquals(await findRelativeImports(code), ["../bar.ts"]);
+  });
+
+  it("does not match import-looking text in strings or comments", async () => {
+    const code = `
+      const text = 'from "./fake.js"';
+      // import "./commented.js";
+    `;
+    assertEquals(await findRelativeImports(code), []);
   });
 });

--- a/src/transforms/pipeline/stages/ssr-vf-modules/import-finder.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/import-finder.ts
@@ -2,45 +2,40 @@
  * Import discovery functions for the SSR VF Modules stage.
  */
 
+import { parseImports } from "../../../esm/lexer.ts";
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
 /**
  * Find all /_vf_modules/_veryfront/ imports in the code.
  * Only matches framework modules, not user project files.
  */
-export function findVfModuleImports(code: string): string[] {
-  const imports: string[] = [];
-  // Note: \s* allows zero whitespace (minified code: from"..." has no space)
-  // Only match _veryfront/ framework modules, not user project files.
-  // Handle both raw "/_vf_modules/..." specifiers and malformed
-  // "file:///_vf_modules/..." variants that can leak out of stale caches.
-  const pattern = /from\s*["']((?:file:\/\/)?\/_vf_modules\/_veryfront\/[^"']+)["']/g;
-
-  let match: RegExpExecArray | null;
-  while ((match = pattern.exec(code)) !== null) {
-    imports.push(match[1]!);
-  }
-
-  return [...new Set(imports)];
+export async function findVfModuleImports(code: string): Promise<string[]> {
+  const imports = await parseImports(code);
+  return unique(
+    imports
+      .map((imp) => imp.n)
+      .filter((specifier): specifier is string =>
+        specifier?.startsWith("/_vf_modules/_veryfront/") === true ||
+        specifier?.startsWith("file:///_vf_modules/_veryfront/") === true
+      ),
+  );
 }
 
 /**
  * Find all relative imports (./foo, ../bar) in the code.
  * Returns array of specifiers.
  */
-export function findRelativeImports(code: string): string[] {
-  const imports: string[] = [];
-
-  // Match: from "./foo" or from "../bar"
-  const fromPattern = /from\s*["'](\.\.?\/[^"']+)["']/g;
-  // Match side-effect imports: import "./foo" or import "../bar" (no `from`)
-  const sideEffectPattern = /import\s*["'](\.\.?\/[^"']+)["']/g;
-
-  let match: RegExpExecArray | null;
-  while ((match = fromPattern.exec(code)) !== null) {
-    imports.push(match[1]!);
-  }
-  while ((match = sideEffectPattern.exec(code)) !== null) {
-    imports.push(match[1]!);
-  }
-
-  return [...new Set(imports)];
+export async function findRelativeImports(code: string): Promise<string[]> {
+  const imports = await parseImports(code);
+  return unique(
+    imports
+      .map((imp) => imp.n)
+      .filter((specifier): specifier is string =>
+        specifier?.startsWith("./") === true ||
+        specifier?.startsWith("../") === true
+      ),
+  );
 }

--- a/src/transforms/pipeline/stages/ssr-vf-modules/index.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/index.ts
@@ -99,7 +99,7 @@ export const ssrVfModulesPlugin: TransformPlugin = {
   async transform(ctx) {
     logInitOnce();
 
-    const vfModuleImports = findVfModuleImports(ctx.code);
+    const vfModuleImports = await findVfModuleImports(ctx.code);
     logger.debug(`${LOG_PREFIX} Transform called`, {
       file: ctx.filePath?.slice(-60) ?? "<unknown>",
       count: vfModuleImports.length,

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
@@ -10,7 +10,7 @@ import { join } from "#veryfront/compat/path/index.ts";
 import denoConfig from "#deno-config" with { type: "json" };
 import { rendererLogger as logger } from "#veryfront/utils";
 import { IMPORT_RESOLUTION_ERROR } from "#veryfront/errors";
-import { replaceSpecifiers } from "../../../esm/lexer.ts";
+import { parseImports, replaceSpecifiers } from "../../../esm/lexer.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { getHttpBundleCacheDir, getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
@@ -240,7 +240,7 @@ async function rewriteFallbackRelativeImports(
 
   // Note: we do not early-return when there are no relative imports, because
   // react/react-dom specifiers still need rewriting below.
-  const relativeImports = findRelativeImports(code);
+  const relativeImports = await findRelativeImports(code);
 
   // Built once and reused for both the relative-import loop (React re-export
   // rewriting) and the final specifier pass below.
@@ -383,8 +383,10 @@ export async function transformFrameworkCode(
 
     // Collect and recursively resolve all #veryfront/ imports
     const veryfrontReplacements = new Map<string, string>();
-    for (const match of transformed.matchAll(/from\s+["'](#veryfront\/[^"']+)["']/g)) {
-      const specifier = match[1]!;
+    const transformedImports = await parseImports(transformed);
+    for (const importSpecifier of transformedImports) {
+      const specifier = importSpecifier.n;
+      if (!specifier?.startsWith("#veryfront/")) continue;
       if (veryfrontReplacements.has(specifier)) continue;
 
       const resolved = await resolveAndTransformVeryfrontImport(specifier, ctx);
@@ -421,7 +423,7 @@ export async function transformFrameworkCode(
     const embeddedSrcDirPrefix = EMBEDDED_SRC_DIR + "/";
 
     {
-      const relativeImports = findRelativeImports(transformed);
+      const relativeImports = await findRelativeImports(transformed);
 
       for (const specifier of relativeImports) {
         // Skip non-code imports (like deno.json, package.json, etc.)

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.826";
+export const VERSION = "0.1.827";


### PR DESCRIPTION
## Summary
- Make client module URL normalization folder-agnostic for arbitrary project folders and already-resolved /_vf_modules URLs, including query-bearing module URLs.
- Normalize release manifest module keys by stripping query/hash before extension matching.
- Replace release route closure's regex source import collector with a required CodeParser/Babel AST pass that skips declaration-level and inline type-only import/export specifiers. If CodeParser is unavailable, the release asset build now fails instead of silently falling back to regex behavior.
- Bump the runtime package version to 0.1.827.

## Testing
- deno fmt --check deno.json src/utils/version-constant.ts src/client/spa/path-utils.ts src/client/spa/path-utils.test.ts src/release-assets/html-consumption.ts src/release-assets/html-consumption.test.ts src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts
- deno lint src/utils/version-constant.ts src/client/spa/path-utils.ts src/client/spa/path-utils.test.ts src/release-assets/html-consumption.ts src/release-assets/html-consumption.test.ts src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts
- deno check src/utils/version-constant.ts src/utils/version.test.ts src/client/spa/path-utils.ts src/client/spa/path-utils.test.ts src/release-assets/html-consumption.ts src/release-assets/html-consumption.test.ts src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- deno test --no-check --allow-all src/client/spa/path-utils.test.ts src/release-assets/html-consumption.test.ts src/release-assets/module-consumption.test.ts src/release-assets/build-executor.test.ts src/transforms/import-rewriter/__tests__/hydration-parity.test.ts src/transforms/import-rewriter/strategies/relative-strategy.test.ts src/transforms/import-rewriter/strategies/alias-strategy.test.ts
- git push pre-push hook: format, lint, type check, generated assets, and unit tests passed (2169 passed, 0 failed).
