### PR TITLE
Cache production hydration runtime with a versioned URL

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.826",
+  "version": "0.1.827",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/build/production-build/build/output-generator.test.ts
+++ b/src/build/production-build/build/output-generator.test.ts
@@ -1,7 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { generateClientScripts, generateRedirectsFile } from "./output-generator.ts";
+import { getProdHydrationModulePath } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
 
 describe("build/production-build/build/output-generator", () => {
   describe("generateClientScripts", () => {
@@ -50,6 +51,17 @@ describe("build/production-build/build/output-generator", () => {
         ),
         true,
       );
+      assertEquals(
+        writes.some((write) => write.path.endsWith(getProdHydrationModulePath().slice(1))),
+        true,
+      );
+      assertEquals(
+        writes.some((write) =>
+          write.path.endsWith(getProdHydrationModulePath().slice(1)) &&
+          write.content.includes("RouterProvider")
+        ),
+        true,
+      );
     });
   });
 
@@ -84,8 +96,10 @@ describe("build/production-build/build/output-generator", () => {
       // deno-lint-ignore no-explicit-any
       await generateRedirectsFile(adapter as any, "/output", false);
       assertEquals(writes.length, 1);
-      assertEquals(writes[0].path.includes("_redirects"), true);
-      assertEquals(writes[0].content.includes("/*"), true);
+      const write = writes[0];
+      assertExists(write);
+      assertEquals(write.path.includes("_redirects"), true);
+      assertEquals(write.content.includes("/*"), true);
     });
   });
 });

--- a/src/build/production-build/build/output-generator.ts
+++ b/src/build/production-build/build/output-generator.ts
@@ -15,7 +15,10 @@ import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { ChunkManifest } from "#veryfront/build/bundler/index.ts";
 import type { AppRouteInfo, BuildStats, RouteInfo } from "#veryfront/server/build-types.ts";
 import { generateServiceWorker } from "#veryfront/server/build-service-worker.ts";
-import { generateProdHydrationModule } from "../../../html/hydration-script-builder/prod-scripts.ts";
+import {
+  generateProdHydrationModule,
+  getProdHydrationModulePath,
+} from "../../../html/hydration-script-builder/prod-scripts.ts";
 import { copyStaticAssets } from "../asset-generation.ts";
 import {
   generateAppModule,
@@ -64,9 +67,14 @@ export async function generateClientScripts(
     join(outputDir, "_veryfront/prefetch.js"),
     await generatePrefetchScript(adapter),
   );
+  const hydrationRuntime = generateProdHydrationModule();
   await adapter.fs.writeFile(
     join(outputDir, "_veryfront/hydration-runtime.js"),
-    generateProdHydrationModule(),
+    hydrationRuntime,
+  );
+  await adapter.fs.writeFile(
+    join(outputDir, getProdHydrationModulePath().slice(1)),
+    hydrationRuntime,
   );
 }
 

--- a/src/html/html-shell-generator.test.ts
+++ b/src/html/html-shell-generator.test.ts
@@ -9,6 +9,7 @@ import {
 import { wrapInHTMLShell } from "./html-shell-generator.ts";
 import type { RenderMetadata } from "#veryfront/types";
 import type { HTMLGenerationOptions } from "./types.ts";
+import { getProdHydrationModulePath } from "./hydration-script-builder/prod-scripts.ts";
 
 describe("html-generation/html-shell-generator", () => {
   const mockConfig = {
@@ -302,9 +303,10 @@ describe("html-generation/html-shell-generator", () => {
         createMeta(),
         createOptions({ mode: "production", isLocalProject: false }),
       );
+      const runtimePath = getProdHydrationModulePath();
 
-      assertStringIncludes(result, "/_veryfront/hydration-runtime.js");
-      assertStringIncludes(result, 'rel="modulepreload" href="/_veryfront/hydration-runtime.js"');
+      assertStringIncludes(result, runtimePath);
+      assertStringIncludes(result, `rel="modulepreload" href="${runtimePath}"`);
       assert(!result.includes("Client-side error logger"));
     });
 
@@ -320,7 +322,7 @@ describe("html-generation/html-shell-generator", () => {
         }),
       );
 
-      assertStringIncludes(result, "/_veryfront/hydration-runtime.js");
+      assertStringIncludes(result, getProdHydrationModulePath());
       assert(!result.includes("Client-side error logger"));
       assert(!result.includes("veryfront-error-overlay"));
     });

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -20,8 +20,8 @@ import { buildNonceAttribute, escapeHTML } from "./html-escape.ts";
 import {
   generateHydrationData,
   getDevScripts,
+  getProdHydrationModulePath,
   getProdScripts,
-  PROD_HYDRATION_MODULE_PATH,
 } from "./hydration-script-builder/index.ts";
 import { getPreviewStylesheetLink, getStudioScripts } from "./dev-scripts.ts";
 import { processMetadata } from "./metadata-builder.ts";
@@ -282,7 +282,7 @@ async function generateHTMLShellPartsImpl(
     : "";
   const prodHydrationModulePreload = useDevScripts
     ? ""
-    : `<link rel="modulepreload" href="${PROD_HYDRATION_MODULE_PATH}">`;
+    : `<link rel="modulepreload" href="${getProdHydrationModulePath()}">`;
 
   const nonceAttr = buildNonceAttribute(nonce);
 

--- a/src/html/hydration-script-builder/index.ts
+++ b/src/html/hydration-script-builder/index.ts
@@ -15,7 +15,10 @@ export { generateDevClientRendererScript } from "./dev-client-renderer.ts";
 
 export {
   generateProdHydrationModule,
+  getProdHydrationModulePath,
   getProdScripts,
+  isVersionedProdHydrationModulePath,
   PROD_HYDRATION_MODULE_PATH,
+  PROD_HYDRATION_MODULE_VERSIONED_PATH_PATTERN,
 } from "./prod-scripts.ts";
 export { generateProdHydrationScript } from "./prod-hydration.ts";

--- a/src/html/hydration-script-builder/prod-scripts.test.ts
+++ b/src/html/hydration-script-builder/prod-scripts.test.ts
@@ -3,20 +3,34 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   generateProdHydrationModule,
+  getProdHydrationModulePath,
   getProdScripts,
   PROD_HYDRATION_MODULE_PATH,
 } from "./prod-scripts.ts";
 
 describe("hydration-script-builder/prod-scripts", () => {
   describe("getProdScripts", () => {
-    it("should return an external module script tag", () => {
+    it("should return an external module script tag with the versioned runtime path", () => {
       const result = getProdScripts("my-page");
+      const runtimePath = getProdHydrationModulePath();
       assertEquals(
-        result.includes(`<script type="module" src="${PROD_HYDRATION_MODULE_PATH}"`),
+        result.includes(`<script type="module" src="${runtimePath}"`),
         true,
       );
+      assertEquals(result.includes(PROD_HYDRATION_MODULE_PATH), false);
       assertEquals(result.includes("</script>"), true);
       assertEquals(result.includes("renderPage"), false);
+    });
+
+    it("should derive a stable content-addressed runtime path", () => {
+      const runtimePath = getProdHydrationModulePath();
+
+      assertEquals(
+        /^\/_veryfront\/hydration-runtime\.[0-9a-f]+\.js$/.test(runtimePath),
+        true,
+      );
+      assertEquals(getProdHydrationModulePath(), runtimePath);
+      assertEquals(runtimePath === PROD_HYDRATION_MODULE_PATH, false);
     });
 
     it("should include nonce attribute when provided", () => {

--- a/src/html/hydration-script-builder/prod-scripts.ts
+++ b/src/html/hydration-script-builder/prod-scripts.ts
@@ -1,7 +1,12 @@
 import { getLoaderScript, getRendererScript, getRouterScript } from "./templates/index.ts";
 import { buildNonceAttribute } from "../html-escape.ts";
+import { fnv1aHash } from "#veryfront/utils/hash-utils.ts";
 
 export const PROD_HYDRATION_MODULE_PATH = "/_veryfront/hydration-runtime.js";
+export const PROD_HYDRATION_MODULE_VERSIONED_PATH_PATTERN =
+  /^\/_veryfront\/hydration-runtime\.[0-9a-f]{8}\.js$/;
+
+let cachedProdHydrationModulePath: string | null = null;
 
 export function generateProdHydrationModule(): string {
   return [
@@ -15,6 +20,18 @@ export function generateProdHydrationModule(): string {
   ].join("\n\n");
 }
 
+export function getProdHydrationModulePath(): string {
+  if (cachedProdHydrationModulePath) return cachedProdHydrationModulePath;
+
+  const hash = fnv1aHash(generateProdHydrationModule()).padStart(8, "0");
+  cachedProdHydrationModulePath = `/_veryfront/hydration-runtime.${hash}.js`;
+  return cachedProdHydrationModulePath;
+}
+
+export function isVersionedProdHydrationModulePath(pathname: string): boolean {
+  return PROD_HYDRATION_MODULE_VERSIONED_PATH_PATTERN.test(pathname);
+}
+
 export function getProdScripts(
   _slug: string,
   _params?: Record<string, string | string[]>,
@@ -22,5 +39,5 @@ export function getProdScripts(
   nonce?: string,
 ): string {
   const nonceAttr = buildNonceAttribute(nonce);
-  return `\n  <script type="module" src="${PROD_HYDRATION_MODULE_PATH}"${nonceAttr}></script>`;
+  return `\n  <script type="module" src="${getProdHydrationModulePath()}"${nonceAttr}></script>`;
 }

--- a/src/server/build-app-route-renderer.test.ts
+++ b/src/server/build-app-route-renderer.test.ts
@@ -6,6 +6,7 @@ import { renderAppRouteToHTML } from "./build-app-route-renderer.ts";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import { RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
+import { getProdHydrationModulePath } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
 
 async function makeProject(): Promise<{ projectDir: string; pageFile: string }> {
   const projectDir = await Deno.makeTempDir({ prefix: "vf-app-route-renderer-" });
@@ -95,7 +96,7 @@ Deno.test({
       assertStringIncludes(html, "Open uploads");
       assertStringIncludes(html, 'data-testid="app-layout"');
       assertStringIncludes(html, 'id="veryfront-hydration-data"');
-      assertStringIncludes(html, "/_veryfront/hydration-runtime.js");
+      assertStringIncludes(html, getProdHydrationModulePath());
       assertEquals(html.includes("/_veryfront/app.js"), false);
 
       const hydrationData = extractHydrationData(html);

--- a/src/server/handlers/request/prod-hydration-module.handler.test.ts
+++ b/src/server/handlers/request/prod-hydration-module.handler.test.ts
@@ -4,7 +4,13 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { ProdHydrationModuleHandler } from "./prod-hydration-module.handler.ts";
 import type { HandlerContext } from "../types.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
-import { PROD_HYDRATION_MODULE_PATH } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
+import {
+  getProdHydrationModulePath,
+  PROD_HYDRATION_MODULE_PATH,
+} from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
+
+const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+const NO_CACHE_CONTROL = "no-cache, no-store, must-revalidate";
 
 function createMockAdapter(): RuntimeAdapter {
   return {
@@ -49,10 +55,10 @@ function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
 }
 
 describe("server/handlers/request/prod-hydration-module.handler", () => {
-  it("serves the production hydration runtime module", async () => {
+  it("serves the versioned production hydration runtime module with immutable caching", async () => {
     const handler = new ProdHydrationModuleHandler();
     const result = await handler.handle(
-      new Request(`http://localhost${PROD_HYDRATION_MODULE_PATH}`),
+      new Request(`http://localhost${getProdHydrationModulePath()}`),
       makeCtx(),
     );
 
@@ -63,28 +69,48 @@ describe("server/handlers/request/prod-hydration-module.handler", () => {
       result.response.headers.get("content-type"),
       "application/javascript; charset=utf-8",
     );
+    assertEquals(result.response.headers.get("cache-control"), IMMUTABLE_CACHE_CONTROL);
+    assertEquals(result.response.headers.get("pragma"), null);
+    assertEquals(result.response.headers.get("expires"), null);
 
     const body = await result.response.text();
     assertStringIncludes(body, "MODULE_SERVER_URL");
     assertStringIncludes(body, "renderPage");
   });
 
-  it("returns not modified when ETag matches", async () => {
+  it("keeps the legacy production hydration runtime path revalidated", async () => {
     const handler = new ProdHydrationModuleHandler();
-    const first = await handler.handle(
+    const result = await handler.handle(
       new Request(`http://localhost${PROD_HYDRATION_MODULE_PATH}`),
+      makeCtx(),
+    );
+
+    assertEquals(result.response?.status, 200);
+    assertEquals(result.response?.headers.get("cache-control"), NO_CACHE_CONTROL);
+    assertEquals(result.response?.headers.get("pragma"), "no-cache");
+    assertEquals(result.response?.headers.get("expires"), "0");
+  });
+
+  it("returns not modified with immutable caching when the versioned ETag matches", async () => {
+    const handler = new ProdHydrationModuleHandler();
+    const runtimePath = getProdHydrationModulePath();
+    const first = await handler.handle(
+      new Request(`http://localhost${runtimePath}`),
       makeCtx(),
     );
     const etag = first.response?.headers.get("etag");
     assertExists(etag);
 
     const second = await handler.handle(
-      new Request(`http://localhost${PROD_HYDRATION_MODULE_PATH}`, {
+      new Request(`http://localhost${runtimePath}`, {
         headers: { "if-none-match": etag },
       }),
       makeCtx(),
     );
 
     assertEquals(second.response?.status, 304);
+    assertEquals(second.response?.headers.get("cache-control"), IMMUTABLE_CACHE_CONTROL);
+    assertEquals(second.response?.headers.get("pragma"), null);
+    assertEquals(second.response?.headers.get("expires"), null);
   });
 });

--- a/src/server/handlers/request/prod-hydration-module.handler.ts
+++ b/src/server/handlers/request/prod-hydration-module.handler.ts
@@ -2,7 +2,9 @@ import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import {
   generateProdHydrationModule,
+  isVersionedProdHydrationModulePath,
   PROD_HYDRATION_MODULE_PATH,
+  PROD_HYDRATION_MODULE_VERSIONED_PATH_PATTERN,
 } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
 import { computeStrongEtag, hasMatchingEtag } from "../utils/etag.ts";
 import { HTTP_OK, PRIORITY_HIGH_DEV } from "#veryfront/utils/constants/index.ts";
@@ -27,6 +29,8 @@ export class ProdHydrationModuleHandler extends BaseHandler {
     patterns: [
       { pattern: PROD_HYDRATION_MODULE_PATH, exact: true, method: "GET" },
       { pattern: PROD_HYDRATION_MODULE_PATH, exact: true, method: "HEAD" },
+      { pattern: PROD_HYDRATION_MODULE_VERSIONED_PATH_PATTERN, method: "GET" },
+      { pattern: PROD_HYDRATION_MODULE_VERSIONED_PATH_PATTERN, method: "HEAD" },
     ],
   };
 
@@ -36,19 +40,24 @@ export class ProdHydrationModuleHandler extends BaseHandler {
     }
 
     const method = req.method.toUpperCase();
+    const pathname = new URL(req.url).pathname;
+    const cacheStrategy = isVersionedProdHydrationModulePath(pathname) ? "immutable" : "no-cache";
     const { js, etag } = getProdHydrationModuleBundle();
     const builder = this.createResponseBuilder(ctx).withCORS(req, ctx.securityConfig?.cors);
 
     if (hasMatchingEtag(req, etag)) {
       return this.respond(
-        builder.withSecurity(ctx.securityConfig ?? undefined, req).notModified(etag),
+        builder
+          .withSecurity(ctx.securityConfig ?? undefined, req)
+          .withCache(cacheStrategy)
+          .notModified(etag),
       );
     }
 
     return this.respond(
       builder
         .withSecurity(ctx.securityConfig ?? undefined, req)
-        .withCache("no-cache")
+        .withCache(cacheStrategy)
         .withETag(etag)
         .withContentType(
           "application/javascript; charset=utf-8",

--- a/src/server/handlers/request/static.handler.ts
+++ b/src/server/handlers/request/static.handler.ts
@@ -21,6 +21,7 @@ import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { StaticFileService } from "../../services/static/index.ts";
 import { addNonceToHtmlTags } from "#veryfront/html/nonce-injection.ts";
 import { computeEtag } from "../utils/etag.ts";
+import { isVersionedProdHydrationModulePath } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
 
 function isHtmlResponse(contentType: string): boolean {
   return /\btext\/html\b/i.test(contentType);
@@ -32,6 +33,7 @@ function isProductionBuildAssetPath(pathname: string): boolean {
     pathname === "/_veryfront/router.js" ||
     pathname === "/_veryfront/prefetch.js" ||
     pathname === "/_veryfront/hydration-runtime.js" ||
+    isVersionedProdHydrationModulePath(pathname) ||
     pathname === "/_veryfront/manifest.json" ||
     pathname.startsWith("/_veryfront/chunks/") ||
     pathname.startsWith("/_veryfront/pages/") ||

--- a/src/server/runtime-handler/request-utils.test.ts
+++ b/src/server/runtime-handler/request-utils.test.ts
@@ -12,6 +12,7 @@ import {
   shouldSkipEnrichedContext,
   TIMEOUT_SENTINEL,
 } from "./request-utils.ts";
+import { getProdHydrationModulePath } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
 
 describe("request-utils", () => {
   describe("constants", () => {
@@ -34,7 +35,7 @@ describe("request-utils", () => {
       assertEquals(LIGHTWEIGHT_PATH_PREFIXES.includes("/_vf_modules/"), true);
       assertEquals(LIGHTWEIGHT_PATH_PREFIXES.includes("/_vf_styles/"), true);
       assertEquals(LIGHTWEIGHT_PATH_PREFIXES.includes("/_veryfront/modules/"), true);
-      assertEquals(LIGHTWEIGHT_PATH_PREFIXES.includes("/_veryfront/hydration-runtime.js"), true);
+      assertEquals(LIGHTWEIGHT_PATH_PREFIXES.includes("/_veryfront/hydration-runtime"), true);
     });
   });
 
@@ -100,6 +101,7 @@ describe("request-utils", () => {
       assertEquals(isLightweightPath("/_vf_modules/react.js"), true);
       assertEquals(isLightweightPath("/_veryfront/modules/client.js"), true);
       assertEquals(isLightweightPath("/_veryfront/hydration-runtime.js"), true);
+      assertEquals(isLightweightPath(getProdHydrationModulePath()), true);
       assertEquals(isLightweightPath("/_veryfront/preview-hmr.js"), true);
       assertEquals(isLightweightPath("/_veryfront/studio-bridge.js"), true);
     });

--- a/src/server/runtime-handler/request-utils.ts
+++ b/src/server/runtime-handler/request-utils.ts
@@ -60,7 +60,7 @@ export const LIGHTWEIGHT_PATH_PREFIXES = [
   "/_vf_modules/",
   "/_vf_styles/",
   "/_veryfront/modules/",
-  "/_veryfront/hydration-runtime.js",
+  "/_veryfront/hydration-runtime",
   "/_veryfront/preview-hmr.js",
   "/_veryfront/studio-bridge.js",
   "/_vf/css/",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.826";
+export const VERSION = "0.1.827";


### PR DESCRIPTION
## Summary

- Add a content-addressed production hydration runtime URL and use it in production script and modulepreload HTML.
- Serve the versioned hydration runtime with immutable cache headers while keeping the legacy unversioned URL on no-cache for compatibility.
- Emit the hashed hydration runtime file in production build output alongside the legacy file.
- Bump Veryfront Code to 0.1.827 for release automation.

## Verification

- deno test --allow-all src/html/hydration-script-builder/prod-scripts.test.ts src/server/handlers/request/prod-hydration-module.handler.test.ts src/html/html-shell-generator.test.ts src/server/runtime-handler/request-utils.test.ts src/build/production-build/build/output-generator.test.ts src/server/build-app-route-renderer.test.ts src/server/handlers/request/static.handler.test.ts src/server/services/static/static-file.service.test.ts
- deno test --quiet --no-check --allow-all --unstable-worker-options --unstable-net --parallel '--ignore=tests,src/workflow/__tests__,cli/commands/*.integration.test.ts'
- deno lint touched files
- deno fmt --check touched files
- git diff --check
- pre-push hook: formatting, lint, type check, generation, and unit tests passed (2169 tests)
