### PR TITLE
Bump Veryfront to 0.1.828

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.827",
+  "version": "0.1.828",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.827";
+export const VERSION = "0.1.828";


### PR DESCRIPTION
## Summary
- Bump `deno.json` and `src/utils/version-constant.ts` to `0.1.828` so the merged Studio module rewrite fix can publish as a new stable package.
- Leaves the release workflow to publish the package and dispatch the server staging build.

## Why
- `veryfront@0.1.827` was already published from the static asset cache merge. Its npm `gitHead` is `5b51112328acd6fd44e4a0b5cabd48401b803a69`, so it does not carry the #2484 merge commit `0b5369015f9dab2f74e99722266130c434e82f22`.

## Verification
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno lint src/utils/version-constant.ts src/utils/version.ts`
- `deno check src/utils/version-constant.ts src/utils/version.ts`
- `deno test --no-check --allow-all src/utils/version.test.ts`
- pre-push hook: format, lint, typecheck, unit tests (`2170 passed`, `0 failed`)

## Release follow-up
- After this merges and `veryfront@0.1.828` publishes, verify npm `gitHead`, wait for the `veryfront-server` repository dispatch build, then create the production-release PR with that artifact.