### PR TITLE
Harden preview provider module default exports

### DIFF
--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -435,6 +435,35 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     }
   });
 
+  it("adds a default export for preview provider modules outside components", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-provider-default-module-" });
+
+    try {
+      await Deno.mkdir(`${projectDir}/providers`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/providers/BreakpointsProvider.tsx`,
+        `export const BreakpointsProvider = ({ children }) => children;\n`,
+      );
+
+      const response = await serve(
+        new Request(
+          "http://localhost:3000/_vf_modules/providers/BreakpointsProvider.js?studio_embed=true",
+        ),
+        projectDir,
+      );
+
+      assertEquals(response.status, 200);
+      const text = await response.text();
+      assertStringIncludes(text, "export { BreakpointsProvider as default };");
+      assertEquals(
+        /export \{ BreakpointsProvider as default \};\n\/\/# sourceMappingURL=/.test(text),
+        true,
+      );
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
   it("adds a default export for filename-matched browser barrel modules", async () => {
     const projectDir = await Deno.makeTempDir({ prefix: "vf-client-barrel-default-module-" });
 


### PR DESCRIPTION
## Description

Adds a focused module-server regression test for the Tomcode failure shape: a preview request for `/_vf_modules/providers/BreakpointsProvider.js?studio_embed=true` where the source file exports a filename-matched named component but no default export. The test asserts that the served browser module gets `export { BreakpointsProvider as default };` before the source map.

This is test-only hardening for behavior already fixed in the runtime path.

## Related Issue(s)

Tomcode preview/module-resolution follow-up.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Verification

- `deno test --no-check --allow-all src/modules/server/module-server.test.ts`
- `deno fmt --check src/modules/server/module-server.test.ts`
- `git diff --check`
- Pre-push hook: format, lint, typecheck, and unit tests (`2170 passed`, `0 failed`)
