### PR TITLE
Keep release render paths in project context

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.829",
+  "version": "0.1.830",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
@@ -184,6 +184,65 @@ describe("MultiProjectFSAdapter", () => {
         assertEquals(cachedAfterRefresh, undefined);
       });
     });
+
+    it("materializes production release adapters before running the context callback", async () => {
+      await withAdapterAsync(async (adapter) => {
+        const originalManager = (adapter as any).manager;
+        let getAdapterCalled = false;
+        let callbackSawMaterializedAdapter = false;
+        let capturedProjectSlug: string | undefined;
+        let capturedProjectId: string | undefined;
+        let capturedProductionMode: boolean | undefined;
+        let capturedReleaseId: string | null | undefined;
+        let capturedEnvironmentName: string | null | undefined;
+
+        (adapter as any).manager = {
+          getAdapter(
+            projectSlug: string,
+            _token: string,
+            projectId?: string,
+            productionMode?: boolean,
+            releaseId?: string | null,
+            environmentName?: string | null,
+          ) {
+            getAdapterCalled = true;
+            capturedProjectSlug = projectSlug;
+            capturedProjectId = projectId;
+            capturedProductionMode = productionMode;
+            capturedReleaseId = releaseId;
+            capturedEnvironmentName = environmentName;
+            return Promise.resolve({});
+          },
+          getStats: () => ({ adapters: 0, stats: [] }),
+          dispose: () => {},
+        };
+
+        try {
+          await adapter.runWithContext(
+            "project-release",
+            "test-token",
+            async () => {
+              callbackSawMaterializedAdapter = getAdapterCalled;
+            },
+            "project-id-release",
+            {
+              productionMode: true,
+              releaseId: "rel-first-hit",
+              environmentName: "production",
+            },
+          );
+        } finally {
+          (adapter as any).manager = originalManager;
+        }
+
+        assertEquals(callbackSawMaterializedAdapter, true);
+        assertEquals(capturedProjectSlug, "project-release");
+        assertEquals(capturedProjectId, "project-id-release");
+        assertEquals(capturedProductionMode, true);
+        assertEquals(capturedReleaseId, "rel-first-hit");
+        assertEquals(capturedEnvironmentName, "production");
+      });
+    });
   });
 });
 

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
@@ -89,6 +89,12 @@ export class MultiProjectFSAdapter implements FSAdapter {
         duration: `${(performance.now() - startTime).toFixed(2)}ms`,
       });
 
+      // Release asset manifest fetchers are registered by the concrete adapter.
+      // Materialize it before renderers can ask for the manifest on a first hit.
+      if (productionMode && releaseId) {
+        await this.getAdapter();
+      }
+
       const result = await runWithCacheBatching(fn);
 
       logger.debug("runWithContext callback complete", {

--- a/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
@@ -50,6 +50,52 @@ function createMockAdapter(): RuntimeAdapter {
   } as unknown as RuntimeAdapter;
 }
 
+function createMultiProjectMockAdapter(
+  onRunWithContext: (
+    projectSlug: string,
+    token: string,
+    projectId: string | undefined,
+    options: {
+      productionMode?: boolean;
+      releaseId?: string | null;
+      branch?: string | null;
+      environmentName?: string | null;
+    } | undefined,
+  ) => void,
+): RuntimeAdapter {
+  const adapter = createMockAdapter() as RuntimeAdapter & {
+    fs: RuntimeAdapter["fs"] & {
+      getUnderlyingAdapter: () => RuntimeAdapter["fs"];
+      isVeryfrontAdapter: () => boolean;
+      isMultiProjectMode: () => boolean;
+      isContextualMode: () => boolean;
+      runWithContext: <T>(
+        projectSlug: string,
+        token: string,
+        fn: () => Promise<T>,
+        projectId?: string,
+        options?: {
+          productionMode?: boolean;
+          releaseId?: string | null;
+          branch?: string | null;
+          environmentName?: string | null;
+        },
+      ) => Promise<T>;
+    };
+  };
+
+  adapter.fs.getUnderlyingAdapter = () => adapter.fs;
+  adapter.fs.isVeryfrontAdapter = () => true;
+  adapter.fs.isMultiProjectMode = () => true;
+  adapter.fs.isContextualMode = () => true;
+  adapter.fs.runWithContext = async (projectSlug, token, fn, projectId, options) => {
+    onRunWithContext(projectSlug, token, projectId, options);
+    return await fn();
+  };
+
+  return adapter;
+}
+
 function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
   return {
     projectDir: "/tmp/test-project",
@@ -293,6 +339,65 @@ describe("server/handlers/request/module/page-data-endpoint-handler", () => {
       assertEquals(JSON.parse(await second.text()).frontmatter.sequence, 2);
       assertEquals(calls, 2);
       assertEquals(first.headers.get("cache-control"), "public, max-age=60");
+    });
+  });
+
+  it("resolves page data inside the multi-project production release context", async () => {
+    let insideContext = false;
+    const calls: Array<{
+      projectSlug: string;
+      token: string;
+      projectId: string | undefined;
+      productionMode?: boolean;
+      releaseId?: string | null;
+      branch?: string | null;
+      environmentName?: string | null;
+    }> = [];
+
+    const adapter = createMultiProjectMockAdapter(
+      (projectSlug, token, projectId, options) => {
+        calls.push({
+          projectSlug,
+          token,
+          projectId,
+          productionMode: options?.productionMode,
+          releaseId: options?.releaseId,
+          branch: options?.branch,
+          environmentName: options?.environmentName,
+        });
+        insideContext = true;
+      },
+    );
+
+    setRendererInitializer(
+      createInitializer((slug) => {
+        assertEquals(insideContext, true);
+        insideContext = false;
+        return Promise.resolve(createPageData(slug, 1));
+      }),
+    );
+
+    const ctx = makeCtx({
+      adapter,
+      proxyToken: "tok-page-data",
+      environmentName: "production",
+    });
+
+    const response = await callPageDataEndpoint(
+      new Request("http://localhost/_veryfront/page-data/index.json"),
+      ctx,
+    );
+
+    assertEquals(response.status, 200);
+    assertEquals(calls.length > 0, true);
+    assertEquals(calls.at(-1), {
+      projectSlug: "test-project",
+      token: "tok-page-data",
+      projectId: "proj-page-data",
+      productionMode: true,
+      releaseId: "rel-page-data",
+      branch: null,
+      environmentName: "production",
     });
   });
 });

--- a/src/server/shared/renderer/adapter.ts
+++ b/src/server/shared/renderer/adapter.ts
@@ -31,6 +31,8 @@ import type {
 import type { MdxBundle } from "#veryfront/types";
 import { APICacheStore } from "#veryfront/rendering/cache/stores/api-store.ts";
 import { computeContentSourceId } from "#veryfront/cache/keys.ts";
+import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 const logger = rendererLogger.component("renderer-adapter");
 
@@ -289,22 +291,63 @@ async function createContextFromHandler(ctx: HandlerContext): Promise<RenderCont
   return renderContext;
 }
 
+function shouldUseMultiProjectContext(ctx: HandlerContext): boolean {
+  if (!ctx.projectSlug) return false;
+  const fs = ctx.adapter?.fs;
+  if (!fs) return false;
+  return isExtendedFSAdapter(fs) && fs.isMultiProjectMode();
+}
+
+function resolveContextBranch(ctx: HandlerContext): string | null {
+  return ctx.requestContext?.branch ?? ctx.parsedDomain?.branch ?? null;
+}
+
+function runWithProjectContext<T>(ctx: HandlerContext, fn: () => Promise<T>): Promise<T> {
+  if (!shouldUseMultiProjectContext(ctx)) return fn();
+
+  const fs = ctx.adapter?.fs;
+  if (!fs || !isExtendedFSAdapter(fs)) return fn();
+
+  const environment = resolveEnvironment(ctx);
+  const token = ctx.proxyToken || getHostEnv("VERYFRONT_API_TOKEN") || "";
+
+  return fs.runWithContext(
+    ctx.projectSlug!,
+    token,
+    fn,
+    ctx.projectId,
+    {
+      productionMode: environment === "production",
+      releaseId: ctx.releaseId,
+      branch: resolveContextBranch(ctx),
+      environmentName: ctx.environmentName,
+    },
+  );
+}
+
 class RendererAdapterImpl implements RendererAdapter {
   constructor(
     private renderer: Renderer,
     private ctx: RenderContext,
+    private handlerCtx: HandlerContext,
   ) {}
 
   renderPage(slug: string, options?: RenderOptions): Promise<RenderResult> {
-    return this.renderer.renderPage(slug, this.ctx, options);
+    return runWithProjectContext(
+      this.handlerCtx,
+      () => this.renderer.renderPage(slug, this.ctx, options),
+    );
   }
 
   resolvePageData(slug: string, options?: RenderOptions): Promise<PageDataResponse> {
-    return this.renderer.resolvePageData(slug, this.ctx, options);
+    return runWithProjectContext(
+      this.handlerCtx,
+      () => this.renderer.resolvePageData(slug, this.ctx, options),
+    );
   }
 
   getAllPages(): Promise<string[]> {
-    return this.renderer.getAllPages(this.ctx);
+    return runWithProjectContext(this.handlerCtx, () => this.renderer.getAllPages(this.ctx));
   }
 
   clearCache(slug?: string): void {
@@ -341,21 +384,23 @@ class RendererAdapterImpl implements RendererAdapter {
     frontmatter?: Record<string, unknown>,
     filePath?: string,
   ): Promise<MdxBundle> {
-    const { MDXCompiler } = await import("../../../rendering/orchestrator/mdx.ts");
-    const { MDXCacheAdapter } = await import("#veryfront/transforms/mdx/index.ts");
+    return await runWithProjectContext(this.handlerCtx, async () => {
+      const { MDXCompiler } = await import("../../../rendering/orchestrator/mdx.ts");
+      const { MDXCacheAdapter } = await import("#veryfront/transforms/mdx/index.ts");
 
-    const mdxCacheAdapter = new MDXCacheAdapter({
-      config: this.ctx.config,
-      mode: this.ctx.mode,
+      const mdxCacheAdapter = new MDXCacheAdapter({
+        config: this.ctx.config,
+        mode: this.ctx.mode,
+      });
+
+      const compiler = new MDXCompiler({
+        projectDir: this.ctx.projectDir,
+        mode: this.ctx.mode,
+        mdxCacheAdapter,
+      });
+
+      return compiler.compileMDX(content, frontmatter, filePath);
     });
-
-    const compiler = new MDXCompiler({
-      projectDir: this.ctx.projectDir,
-      mode: this.ctx.mode,
-      mdxCacheAdapter,
-    });
-
-    return compiler.compileMDX(content, frontmatter, filePath);
   }
 
   async destroy(): Promise<void> {}
@@ -381,7 +426,7 @@ export async function getRendererForProject(ctx: HandlerContext): Promise<Render
 
   const contextStartTime = performance.now();
   logger.debug("createContextFromHandler START", { projectSlug });
-  const renderCtx = await createContextFromHandler(ctx);
+  const renderCtx = await runWithProjectContext(ctx, () => createContextFromHandler(ctx));
   logger.debug("createContextFromHandler DONE", {
     projectSlug,
     duration: `${(performance.now() - contextStartTime).toFixed(2)}ms`,
@@ -393,7 +438,7 @@ export async function getRendererForProject(ctx: HandlerContext): Promise<Render
     duration: `${(performance.now() - startTime).toFixed(2)}ms`,
   });
 
-  return new RendererAdapterImpl(renderer, renderCtx);
+  return new RendererAdapterImpl(renderer, renderCtx, ctx);
 }
 
 export async function destroyRendererAdapter(): Promise<void> {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.829";
+export const VERSION = "0.1.830";


### PR DESCRIPTION
## Summary
- Preserve multi-project production context across renderer operations, including page-data resolution.
- Materialize production release adapters before callbacks so release asset manifest fetchers exist on first hit.
- Bump the package release version to 0.1.830 and keep the runtime version constant in sync.

## Test Plan
- deno fmt --check deno.json src/utils/version-constant.ts src/platform/adapters/fs/veryfront/multi-project-adapter.ts src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts src/server/shared/renderer/adapter.ts src/server/handlers/request/module/page-data-endpoint-handler.test.ts && git diff --check
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- deno test --no-check --allow-all src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts src/server/shared/renderer/adapter.test.ts src/server/handlers/request/module/page-data-endpoint-handler.test.ts
- deno test --no-check --allow-all src/platform/adapters/fs/veryfront/adapter.test.ts
- deno test --no-check --allow-all src/server/handlers/request/ssr/ssr.handler.test.ts
- deno check src/server/shared/renderer/adapter.ts src/platform/adapters/fs/veryfront/multi-project-adapter.ts src/server/handlers/request/module/page-data-endpoint-handler.test.ts src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
- pre-push hook: fmt, lint, typecheck, and unit tests passed (2170 passed, 0 failed)
