### PR TITLE
Release v0.1.830

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.829",
+  "version": "0.1.830",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.829";
+export const VERSION = "0.1.830";


### PR DESCRIPTION
## Summary
- bump `deno.json` from 0.1.829 to 0.1.830
- update the synced `src/utils/version-constant.ts` runtime version

## Why
- release job 81776610328 failed because npm already has `veryfront@0.1.829` and the source repo already has tag `v0.1.829`
- `0.1.830` is currently unpublished on npm and has no source/public GitHub release or source tag

## Verification
- RED: `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/utils/version.test.ts` failed after only bumping `deno.json` because `VERSION` was still 0.1.829
- GREEN: `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/utils/version.test.ts` passed after updating the constant
- `deno task fmt:check` passed
- `npm view veryfront@0.1.830 version` returns E404
- `git ls-remote --tags origin 'v0.1.830'` returns no tag
- `gh release view v0.1.830 --repo veryfront/veryfront` returns release not found
- `gh release view v0.1.830 --repo veryfront/veryfront-code` returns release not found
- pre-push hook passed: formatting, lint, typecheck, and `deno task test:unit` with 2170 passed / 0 failed

## Notes
The first local pre-push attempt failed because this shell exports `OTEL_METRICS_EXPORTER=otlp` and `OTEL_EXPORTER_OTLP_ENDPOINT`, which changes metrics config defaults in the local test process. Re-running the same hook with those local OTEL vars unset passed.
