### PR TITLE
Bind contextual adapter methods for release rendering

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.830",
+  "version": "0.1.831",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/platform/adapters/fs/wrapper.test.ts
+++ b/src/platform/adapters/fs/wrapper.test.ts
@@ -7,6 +7,7 @@ import {
   NotSupportedError,
   wrapFSAdapter,
 } from "./wrapper.ts";
+import { MultiProjectFSAdapter } from "./veryfront/multi-project-adapter.ts";
 import type { ContextualFSAdapter, FSAdapter } from "./veryfront/types.ts";
 
 function createMockFSAdapter(overrides: Partial<FSAdapter> = {}): FSAdapter {
@@ -586,6 +587,53 @@ describe("FSAdapterWrapper", () => {
       );
       assertEquals(captured, { slug: "my-slug", token: "my-token" });
       assertEquals(result, "result");
+    });
+
+    it("runWithContext should preserve adapter binding for production release materialization", async () => {
+      const adapter = new MultiProjectFSAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          cache: { enabled: false },
+        },
+      });
+      const wrapper = new FSAdapterWrapper(adapter);
+      const originalManager = (adapter as any).manager;
+      let getAdapterCalled = false;
+      let callbackSawMaterializedAdapter = false;
+
+      (adapter as any).manager = {
+        getAdapter() {
+          getAdapterCalled = true;
+          return Promise.resolve(createMockFSAdapter());
+        },
+        getStats: () => ({ adapters: 0, stats: [] }),
+        dispose: () => {},
+      };
+
+      try {
+        const result = await wrapper.runWithContext(
+          "project-release",
+          "test-token",
+          async () => {
+            callbackSawMaterializedAdapter = getAdapterCalled;
+            return "result";
+          },
+          "project-id-release",
+          {
+            productionMode: true,
+            releaseId: "rel-first-hit",
+            environmentName: "production",
+          },
+        );
+
+        assertEquals(result, "result");
+        assertEquals(callbackSawMaterializedAdapter, true);
+      } finally {
+        (adapter as any).manager = originalManager;
+        adapter.dispose();
+      }
     });
   });
 });

--- a/src/platform/adapters/fs/wrapper.ts
+++ b/src/platform/adapters/fs/wrapper.ts
@@ -120,7 +120,9 @@ export class FSAdapterWrapper implements ExtendedFileSystemAdapter {
     const adapter = this.contextual;
     const method = adapter[key];
     if (!method) throw new NotSupportedError(operation, this.adapterType);
-    return method as NonNullable<ContextualFSAdapter[K]>;
+    return (typeof method === "function" ? method.bind(adapter) : method) as NonNullable<
+      ContextualFSAdapter[K]
+    >;
   }
 
   setRequestToken(token: string): void {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.830";
+export const VERSION = "0.1.831";


### PR DESCRIPTION
## Summary
- bind delegated contextual adapter methods in FSAdapterWrapper so MultiProjectFSAdapter.runWithContext keeps its receiver
- add a production release materialization regression through FSAdapterWrapper
- bump framework version to 0.1.831 for a new release

## Verification
- deno test --no-check --allow-all src/platform/adapters/fs/wrapper.test.ts src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts src/server/handlers/request/module/page-data-endpoint-handler.test.ts src/utils/version.test.ts
- deno check src/platform/adapters/fs/wrapper.ts src/platform/adapters/fs/wrapper.test.ts src/platform/adapters/fs/veryfront/multi-project-adapter.ts src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts src/platform/adapters/fs/wrapper.ts src/platform/adapters/fs/wrapper.test.ts
- git diff --check
- pre-push hook: formatting, lint, type check, generation, unit tests (2170 passed)