### PR TITLE
Cache release-scoped module fallbacks

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.831",
+  "version": "0.1.832",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -9,13 +9,21 @@ import {
   generateModulePreloadHintsFromManifest,
   getRouteManifest,
 } from "#veryfront/modules/manifest/route-module-manifest.ts";
-import { getReadyManifestForRenderAsync } from "#veryfront/release-assets/manifest-cache.ts";
+import {
+  getReadyManifestForRenderAsync,
+  isReleaseAssetManifestEnabled,
+} from "#veryfront/release-assets/manifest-cache.ts";
+import {
+  RELEASE_MODULE_RUNTIME_VERSION_PARAM,
+  RELEASE_MODULE_VERSION_PARAM,
+} from "#veryfront/release-assets/constants.ts";
 import {
   resolveManifestModuleUrl,
   resolveManifestRoutePreloadUrls,
 } from "#veryfront/release-assets/html-consumption.ts";
 import { routeForPage } from "#veryfront/release-assets/route-path.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
+import { VERSION } from "#veryfront/utils/version.ts";
 import { buildNonceAttribute, escapeHTML } from "./html-escape.ts";
 import {
   generateHydrationData,
@@ -37,6 +45,7 @@ function pathToModuleUrl(
   path: string,
   studioEmbed?: boolean,
   manifest?: ReleaseAssetManifest | null,
+  fallbackReleaseId?: string,
 ): string {
   if (!path) return "";
 
@@ -52,7 +61,17 @@ function pathToModuleUrl(
     ? `/_vf_modules/${path}.js`
     : `/_vf_modules/${withExtReplaced}`;
 
-  return studioEmbed ? `${urlBase}?studio_embed=true` : urlBase;
+  if (studioEmbed) return `${urlBase}?studio_embed=true`;
+  return fallbackReleaseId ? appendReleaseModuleVersion(urlBase, fallbackReleaseId) : urlBase;
+}
+
+function appendReleaseModuleVersion(url: string, releaseId: string): string {
+  const separator = url.includes("?") ? "&" : "?";
+  const params = new URLSearchParams({
+    [RELEASE_MODULE_VERSION_PARAM]: releaseId,
+    [RELEASE_MODULE_RUNTIME_VERSION_PARAM]: VERSION,
+  });
+  return `${url}${separator}${params.toString()}`;
 }
 
 function getRelativePagePath(
@@ -84,6 +103,10 @@ function generateModulePreloadHints(
   const addedUrls = new Set<string>();
   const projectDir = options.projectDir ?? "";
   const studioEmbed = options.studioEmbed;
+  const fallbackReleaseId = !studioEmbed && !releaseManifest && options.releaseId &&
+      isReleaseAssetManifestEnabled()
+    ? options.releaseId
+    : undefined;
 
   function addHint(moduleUrl: string): void {
     if (!moduleUrl || addedUrls.has(moduleUrl)) return;
@@ -93,7 +116,7 @@ function generateModulePreloadHints(
 
   if (options.pagePath) {
     const relativePath = getRelativePagePath(options.pagePath, projectDir);
-    addHint(pathToModuleUrl(relativePath, studioEmbed, releaseManifest));
+    addHint(pathToModuleUrl(relativePath, studioEmbed, releaseManifest, fallbackReleaseId));
   }
 
   for (const layout of options.nestedLayouts ?? []) {
@@ -101,7 +124,7 @@ function generateModulePreloadHints(
     if (!layoutPath) continue;
 
     const relativePath = getRelativePagePath(layoutPath, projectDir);
-    addHint(pathToModuleUrl(relativePath, studioEmbed, releaseManifest));
+    addHint(pathToModuleUrl(relativePath, studioEmbed, releaseManifest, fallbackReleaseId));
   }
 
   // Skip manifest-based preloads in preview/studio-embed mode:
@@ -140,10 +163,13 @@ function generateModulePreloadHints(
       50,
     )
   ) {
-    const href = hint.match(/href="([^"]+)"/)?.[1];
+    const rawHref = hint.match(/href="([^"]+)"/)?.[1];
+    const href = rawHref && fallbackReleaseId && rawHref.startsWith("/_vf_modules/")
+      ? appendReleaseModuleVersion(rawHref, fallbackReleaseId)
+      : rawHref;
     if (!href || addedUrls.has(href)) continue;
 
-    hints.push(hint);
+    hints.push(href === rawHref ? hint : hint.replace(/href="([^"]+)"/, `href="${href}"`));
     addedUrls.add(href);
   }
 

--- a/src/html/html-shell-manifest.test.ts
+++ b/src/html/html-shell-manifest.test.ts
@@ -96,6 +96,16 @@ describe("html shell release asset manifest consumption", () => {
     assertStringIncludes(result.start, `/_vf/assets/${PAGE_HASH}.js`);
   });
 
+  it("version-stamps fallback module URLs when manifest lookup is enabled but unavailable", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    configureReleaseAssetManifestFetcher(undefined);
+
+    const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
+
+    assertStringIncludes(result.start, "/_vf_modules/pages/index.js?vf_release=rel-1");
+    assert(!result.start.includes("/_vf/assets/"));
+  });
+
   it("uses manifest route closure preloads for index routes", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     configureReleaseAssetManifestFetcher(() =>

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -96,6 +96,21 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     });
   }
 
+  async function serveProductionModule(
+    req: Request,
+    projectDir: string,
+    releaseId = "rel-1",
+  ): Promise<Response> {
+    const { serveModule } = await import("./module-server.ts");
+    return await serveModule(req, {
+      projectId: "test",
+      projectDir,
+      adapter: denoAdapter,
+      dev: false,
+      releaseId,
+    });
+  }
+
   function extractChildVersion(code: string): string {
     const match = code.match(/\.\/child\.js\?ssr=true&v=([^"']+)/);
     return match?.[1] ?? "";
@@ -403,6 +418,52 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
       const header = buildServerTimingHeader(record!);
       assertEquals(header.includes("module.source_lookup"), true);
       assertEquals(header.includes("module.transform"), true);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("sets immutable cache headers for release-versioned production modules", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-release-module-cache-" });
+
+    try {
+      await Deno.mkdir(`${projectDir}/components`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/components/App.ts`,
+        `export const value = 1;\n`,
+      );
+
+      const response = await serveProductionModule(
+        new Request(
+          `http://localhost:3000/_vf_modules/components/App.js?vf_release=rel-1&vf_runtime=${VERSION}`,
+        ),
+        projectDir,
+      );
+
+      assertEquals(response.status, 200);
+      assertEquals(response.headers.get("cache-control"), "public, max-age=31536000, immutable");
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("keeps unversioned production modules on no-cache headers", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-unversioned-module-cache-" });
+
+    try {
+      await Deno.mkdir(`${projectDir}/components`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/components/App.ts`,
+        `export const value = 1;\n`,
+      );
+
+      const response = await serveProductionModule(
+        new Request("http://localhost:3000/_vf_modules/components/App.js"),
+        projectDir,
+      );
+
+      assertEquals(response.status, 200);
+      assertEquals(response.headers.get("cache-control"), "no-cache");
     } finally {
       await Deno.remove(projectDir, { recursive: true });
     }

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -22,6 +22,7 @@ import {
   stripSSRModuleJsExtension,
 } from "./ssr-import-rewriter.ts";
 import { addHMRTimestamps } from "#veryfront/transforms/esm/import-rewriter.ts";
+import { replaceSpecifiers } from "#veryfront/transforms/esm/lexer.ts";
 import {
   FRAMEWORK_ROOT,
   resolveFrameworkSourcePath,
@@ -30,6 +31,11 @@ import { getReactUrls, REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/
 import { readLimitedCrossProjectSource } from "./cross-project-source-limit.ts";
 import { sha256Short } from "#veryfront/cache/hash.ts";
 import { rewriteReleaseDependencyImportsForModule } from "#veryfront/release-assets/module-consumption.ts";
+import {
+  RELEASE_ASSET_IMMUTABLE_MAX_AGE_SECONDS,
+  RELEASE_MODULE_RUNTIME_VERSION_PARAM,
+  RELEASE_MODULE_VERSION_PARAM,
+} from "#veryfront/release-assets/constants.ts";
 import {
   buildSourceMissCacheKey,
   hasSourceMiss,
@@ -114,6 +120,49 @@ const SNIPPET_MODULE_PREFIX = /^\/_vf_modules\/_snippets\/([a-f0-9]+)\.js/;
 const CROSS_PROJECT_VERSIONED_PREFIX =
   /^\/_vf_modules\/_cross\/([a-z0-9-]+)@([\d^~x][\d.x^~-]*)\/\@\/(.+)$/;
 const CROSS_PROJECT_LATEST_PREFIX = /^\/_vf_modules\/_cross\/([a-z0-9-]+)\/\@\/(.+)$/;
+
+function appendReleaseModuleVersion(url: string, releaseId: string): string {
+  if (
+    url.includes(`${RELEASE_MODULE_VERSION_PARAM}=`) ||
+    url.includes(`${RELEASE_MODULE_RUNTIME_VERSION_PARAM}=`)
+  ) {
+    return url;
+  }
+
+  const separator = url.includes("?") ? "&" : "?";
+  const params = new URLSearchParams({
+    [RELEASE_MODULE_VERSION_PARAM]: releaseId,
+    [RELEASE_MODULE_RUNTIME_VERSION_PARAM]: VERSION,
+  });
+  return `${url}${separator}${params.toString()}`;
+}
+
+function shouldCacheReleaseVersionedModule(
+  url: URL,
+  options: ModuleServerOptions,
+  isSSR: boolean,
+): boolean {
+  if (options.dev || isSSR || !options.releaseId) return false;
+  return url.searchParams.get(RELEASE_MODULE_VERSION_PARAM) === options.releaseId &&
+    url.searchParams.get(RELEASE_MODULE_RUNTIME_VERSION_PARAM) === VERSION;
+}
+
+function isSSRModuleRequest(req: Request, url: URL): boolean {
+  const userAgent = req.headers.get("user-agent") ?? "";
+  return url.searchParams.get("ssr") === "true" || userAgent.startsWith("Deno/");
+}
+
+async function addReleaseVersionToFallbackImports(
+  code: string,
+  releaseId: string | null | undefined,
+): Promise<string> {
+  if (!releaseId || !code.includes("/_vf_modules/")) return code;
+
+  return await replaceSpecifiers(code, (specifier) => {
+    if (!specifier.startsWith("/_vf_modules/")) return null;
+    return appendReleaseModuleVersion(specifier, releaseId);
+  });
+}
 
 interface SourceLookupContext {
   projectId?: string;
@@ -229,8 +278,7 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
 
         const { slug: snippetProjectSlug, branch: snippetBranch } = parseProjectDomain(url.host);
 
-        const userAgent = req.headers.get("user-agent") ?? "";
-        const isSSR = url.searchParams.get("ssr") === "true" || userAgent.startsWith("Deno/");
+        const isSSR = isSSRModuleRequest(req, url);
 
         logger.debug("Transforming snippet", {
           hash,
@@ -336,8 +384,7 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
             );
           }
 
-          const userAgent = req.headers.get("user-agent") ?? "";
-          const isSSR = url.searchParams.get("ssr") === "true" || userAgent.startsWith("Deno/");
+          const isSSR = isSSRModuleRequest(req, url);
 
           let code = await profileModuleTransform(() =>
             transformToESM(source, crossPath, projectDir, adapter, {
@@ -449,7 +496,7 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
           }
 
           const userAgent = req.headers.get("user-agent") ?? "";
-          const isSSR = url.searchParams.get("ssr") === "true" || userAgent.startsWith("Deno/");
+          const isSSR = isSSRModuleRequest(req, url);
 
           const studioEmbed = url.searchParams.get("studio_embed") === "true";
           const shouldInjectPositions = dev || options.mode === "preview";
@@ -512,10 +559,13 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
               releaseId: options.releaseId,
               readDependencySource: (path) => platformFs.readTextFile(path),
             });
+            code = await addReleaseVersionToFallbackImports(code, options.releaseId);
           }
         }
 
-        const headers = getDevModuleHeaders(modulePath);
+        const headers = getModuleHeaders(modulePath, {
+          cacheable: shouldCacheReleaseVersionedModule(url, options, isSSRModuleRequest(req, url)),
+        });
         logger.debug("Request complete", {
           path: modulePath,
           durationMs: (performance.now() - startTime).toFixed(1),
@@ -526,7 +576,7 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
         const errorMsg = getErrorMessage(error);
         logger.error("Module transform error", { modulePath, error: errorMsg });
 
-        const headers = getDevModuleHeaders(modulePath);
+        const headers = getModuleHeaders(modulePath);
         const errorBody = createDevModuleErrorBody(modulePath, errorMsg);
 
         return createModuleResponse(method, errorBody, HTTP_SERVER_ERROR, headers);
@@ -905,10 +955,15 @@ export function isModuleRequest(req: Request): boolean {
   return DEV_MODULE_PREFIX.test(url.pathname);
 }
 
-function getDevModuleHeaders(modulePath: string): Record<string, string> {
+function getModuleHeaders(
+  modulePath: string,
+  options: { cacheable?: boolean } = {},
+): Record<string, string> {
   return {
     "Content-Type": getDevModuleContentType(modulePath),
-    "Cache-Control": "no-cache",
+    "Cache-Control": options.cacheable
+      ? `public, max-age=${RELEASE_ASSET_IMMUTABLE_MAX_AGE_SECONDS}, immutable`
+      : "no-cache",
   };
 }
 

--- a/src/release-assets/constants.ts
+++ b/src/release-assets/constants.ts
@@ -31,6 +31,12 @@ export const RELEASE_ASSET_MAX_SIZE_BYTES = 10 * 1024 * 1024;
 /** Immutable cache max-age in seconds (1 year). */
 export const RELEASE_ASSET_IMMUTABLE_MAX_AGE_SECONDS = 31_536_000;
 
+/** Query param that scopes fallback module URLs to an immutable release. */
+export const RELEASE_MODULE_VERSION_PARAM = "vf_release" as const;
+
+/** Query param that scopes fallback module URLs to the Veryfront runtime build. */
+export const RELEASE_MODULE_RUNTIME_VERSION_PARAM = "vf_runtime" as const;
+
 /** Bounded upload concurrency when posting assets during a build. */
 export const RELEASE_ASSET_UPLOAD_CONCURRENCY = 8;
 

--- a/src/release-assets/html-consumption.test.ts
+++ b/src/release-assets/html-consumption.test.ts
@@ -4,6 +4,11 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import {
+  finalizeRequestProfiling,
+  resetRequestProfiles,
+  runWithRequestProfiling,
+} from "#veryfront/observability/request-profiler.ts";
+import {
   normalizeManifestModuleKey,
   resolveManifestModuleUrl,
   resolveManifestRoutePreloadUrls,
@@ -93,8 +98,10 @@ describe("manifest cache gating", () => {
 
   afterEach(() => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, originalFlag ?? "");
+    Deno.env.delete("VERYFRONT_ENABLE_SERVER_TIMING");
     configureReleaseAssetManifestFetcher(undefined);
     clearReleaseAssetManifestCache();
+    resetRequestProfiles();
   });
 
   it("returns null when the flag is off (byte-identical fallback)", () => {
@@ -109,6 +116,56 @@ describe("manifest cache gating", () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     configureReleaseAssetManifestFetcher(undefined);
     assertEquals(getReadyManifestForRender("r"), null);
+  });
+
+  it("marks the no-fetcher fallback reason during profiled async reads", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
+    configureReleaseAssetManifestFetcher(undefined);
+
+    const record = await runWithRequestProfiling(
+      { category: "html", method: "GET", pathname: "/" },
+      async () => {
+        assertEquals(await getReadyManifestForRenderAsync("r"), null);
+        return finalizeRequestProfiling(200);
+      },
+    );
+
+    assertEquals(record?.phases["release_manifest.no_fetcher"], 0);
+  });
+
+  it("marks ready manifest fetches during profiled async reads", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({ state: "ready", manifest: manifest() })
+    );
+
+    const record = await runWithRequestProfiling(
+      { category: "html", method: "GET", pathname: "/" },
+      async () => {
+        assertEquals((await getReadyManifestForRenderAsync("r"))?.manifestVersion, 3);
+        return finalizeRequestProfiling(200);
+      },
+    );
+
+    assertEquals(record?.phases["release_manifest.fetch_ready"], 0);
+  });
+
+  it("marks manifest fetch failures during profiled async reads", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
+    configureReleaseAssetManifestFetcher(() => Promise.reject(new Error("boom")));
+
+    const record = await runWithRequestProfiling(
+      { category: "html", method: "GET", pathname: "/" },
+      async () => {
+        assertEquals(await getReadyManifestForRenderAsync("r"), null);
+        return finalizeRequestProfiling(200);
+      },
+    );
+
+    assertEquals(record?.phases["release_manifest.fetch_failed"], 0);
   });
 
   it("caches a ready manifest after a background fetch", async () => {

--- a/src/release-assets/manifest-cache.ts
+++ b/src/release-assets/manifest-cache.ts
@@ -27,6 +27,10 @@ import { serverLogger } from "#veryfront/utils";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { registerLRUCache } from "#veryfront/cache";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
+import {
+  markRequestProfilePhase,
+  profilePhase,
+} from "#veryfront/observability/request-profiler.ts";
 import { RELEASE_ASSET_MANIFEST_ENV_FLAG } from "./constants.ts";
 import { parseReleaseAssetManifest, type ReleaseAssetManifest } from "./manifest-schema.ts";
 
@@ -136,6 +140,10 @@ function cacheKey(releaseId: string, manifestVersion?: number): string {
   return manifestVersion !== undefined ? `${releaseId}:${manifestVersion}` : releaseId;
 }
 
+function markManifestDecision(decision: string): void {
+  markRequestProfilePhase(`release_manifest.${decision}`);
+}
+
 function findCachedReadyEntry(releaseId: string): CacheEntry | null {
   let best: CacheEntry | null = null;
   for (const [k, v] of manifestCache.entries()) {
@@ -168,12 +176,22 @@ function maybeScheduleReadyRefresh(releaseId: string, entry: CacheEntry): void {
 export function getReadyManifestForRender(
   releaseId: string | null | undefined,
 ): ReleaseAssetManifest | null {
-  if (!releaseId) return null;
-  if (!isReleaseAssetManifestEnabled()) return null;
-  if (!resolveFetcher(releaseId)) return null;
+  if (!releaseId) {
+    markManifestDecision("no_release_id");
+    return null;
+  }
+  if (!isReleaseAssetManifestEnabled()) {
+    markManifestDecision("disabled");
+    return null;
+  }
+  if (!resolveFetcher(releaseId)) {
+    markManifestDecision("no_fetcher");
+    return null;
+  }
 
   const best = findCachedReadyEntry(releaseId);
   if (best) {
+    markManifestDecision("cached_ready");
     maybeScheduleReadyRefresh(releaseId, best);
     return best.manifest;
   }
@@ -182,9 +200,11 @@ export function getReadyManifestForRender(
   const plain = manifestCache.get(releaseId);
   if (plain && plain.expiresAt > Date.now()) {
     // Non-ready entry still warm — return null without scheduling another fetch.
+    markManifestDecision("cached_null");
     return null;
   }
 
+  markManifestDecision("cache_miss");
   scheduleFetch(releaseId);
   return null;
 }
@@ -200,18 +220,31 @@ export function getReadyManifestForRender(
 export async function getReadyManifestForRenderAsync(
   releaseId: string | null | undefined,
 ): Promise<ReleaseAssetManifest | null> {
-  if (!releaseId) return null;
-  if (!isReleaseAssetManifestEnabled()) return null;
-  if (!resolveFetcher(releaseId)) return null;
+  if (!releaseId) {
+    markManifestDecision("no_release_id");
+    return null;
+  }
+  if (!isReleaseAssetManifestEnabled()) {
+    markManifestDecision("disabled");
+    return null;
+  }
+  if (!resolveFetcher(releaseId)) {
+    markManifestDecision("no_fetcher");
+    return null;
+  }
 
   const best = findCachedReadyEntry(releaseId);
   if (best) {
+    markManifestDecision("cached_ready");
     maybeScheduleReadyRefresh(releaseId, best);
     return best.manifest;
   }
 
   const plain = manifestCache.get(releaseId);
-  if (plain && plain.expiresAt > Date.now()) return null;
+  if (plain && plain.expiresAt > Date.now()) {
+    markManifestDecision("cached_null");
+    return null;
+  }
 
   return await fetchManifest(releaseId);
 }
@@ -222,18 +255,25 @@ function scheduleFetch(releaseId: string): void {
 
 function fetchManifest(releaseId: string): Promise<ReleaseAssetManifest | null> {
   const existing = inFlight.get(releaseId);
-  if (existing) return existing.promise;
+  if (existing) {
+    markManifestDecision("await_inflight");
+    return existing.promise;
+  }
   const active = resolveFetcher(releaseId);
-  if (!active) return Promise.resolve(null);
+  if (!active) {
+    markManifestDecision("no_fetcher");
+    return Promise.resolve(null);
+  }
   const fetchGeneration = cacheGeneration;
   const token = Symbol(releaseId);
 
-  const promise = Promise.resolve().then(async () => {
+  const promise = profilePhase("release_manifest.fetch", async () => {
     try {
       const result = await active(releaseId);
       if (fetchGeneration !== cacheGeneration) return null;
 
       if (!result) {
+        markManifestDecision("fetch_missing");
         manifestCache.set(releaseId, { manifest: null, expiresAt: Date.now() + NON_READY_TTL_MS });
         return null;
       }
@@ -243,6 +283,7 @@ function fetchManifest(releaseId: string): Promise<ReleaseAssetManifest | null> 
         : null;
 
       if (manifest) {
+        markManifestDecision("fetch_ready");
         const key = cacheKey(releaseId, manifest.manifestVersion);
         manifestCache.set(key, {
           manifest,
@@ -257,6 +298,7 @@ function fetchManifest(releaseId: string): Promise<ReleaseAssetManifest | null> 
         });
         return manifest;
       } else {
+        markManifestDecision("fetch_not_ready");
         manifestCache.set(releaseId, {
           manifest: null,
           expiresAt: Date.now() + NON_READY_TTL_MS,
@@ -269,6 +311,7 @@ function fetchManifest(releaseId: string): Promise<ReleaseAssetManifest | null> 
         error: error instanceof Error ? error.message : String(error),
       });
       if (fetchGeneration !== cacheGeneration) return null;
+      markManifestDecision("fetch_failed");
       manifestCache.set(releaseId, { manifest: null, expiresAt: Date.now() + NON_READY_TTL_MS });
       return null;
     } finally {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.831";
+export const VERSION = "0.1.832";


### PR DESCRIPTION
## Summary
- add `vf_release` + `vf_runtime` query params to release-backed fallback `_vf_modules` preload and import URLs when the release asset manifest is enabled but unavailable
- serve only matching release/runtime module URLs with immutable cache headers; keep unversioned module URLs on `no-cache`
- add request-profiler phases for release manifest fallback/fetch decisions so production Server-Timing can show why HTML fell back
- bump `deno.json` and `src/utils/version-constant.ts` to `0.1.832` so this produces a new release

## Why
The current production deployment can still fall back to `_vf_modules` for page modules when the release asset manifest is not ready. Those fallback URLs were uncacheable, which keeps client navigation slow even after gateway static asset caching is fixed. This scopes fallback module URLs to the project release and Veryfront runtime version instead of making unversioned module URLs immutable.

## Verification
- `deno check src/release-assets/manifest-cache.ts src/html/html-shell-generator.ts src/modules/server/module-server.ts`
- `deno test --no-check --allow-all src/release-assets/html-consumption.test.ts src/html/html-shell-manifest.test.ts src/modules/server/module-server.test.ts src/modules/server/module-batch-handler.test.ts src/rendering/renderer.test.ts src/release-assets/module-consumption.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --parallel --reporter=dot '--ignore=tests,src/workflow/__tests__,cli/commands/*.integration.test.ts'`
- pre-push hook: format, lint, type check, generate, and `deno task test:unit` passed
