### PR TITLE
Keep cacheable responses free of sticky cookies and expose render timing

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.832",
+  "version": "0.1.833",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -58,6 +58,7 @@ import {
   profileProxyServerTimingPhase,
   withProxyServerTimingHeader,
 } from "./server-timing.ts";
+import { removeStickyCookieFromPublicCacheableResponse } from "./response-headers.ts";
 
 function getLocalProjects(): Record<string, string> {
   const raw = getEnv("LOCAL_PROJECTS");
@@ -432,11 +433,13 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
               }
 
               return withProxyTiming(
-                new Response(response.body, {
-                  status: response.status,
-                  statusText: response.statusText,
-                  headers: response.headers,
-                }),
+                removeStickyCookieFromPublicCacheableResponse(
+                  new Response(response.body, {
+                    status: response.status,
+                    statusText: response.statusText,
+                    headers: response.headers,
+                  }),
+                ),
               );
             } catch (error) {
               clearTimeout(timeoutId);

--- a/src/proxy/response-headers.test.ts
+++ b/src/proxy/response-headers.test.ts
@@ -1,0 +1,63 @@
+import "#veryfront/schemas/_test-setup.ts";
+
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { removeStickyCookieFromPublicCacheableResponse } from "./response-headers.ts";
+
+function getSetCookies(headers: Headers): string[] {
+  const getSetCookie = headers.getSetCookie;
+  if (typeof getSetCookie === "function") {
+    return getSetCookie.call(headers);
+  }
+
+  const values: string[] = [];
+  for (const [key, value] of headers) {
+    if (key.toLowerCase() === "set-cookie") values.push(value);
+  }
+  return values;
+}
+
+describe("proxy response headers", () => {
+  it("removes the load-balancer cookie from public page-data responses", async () => {
+    const headers = new Headers({
+      "Cache-Control": "public, max-age=60, stale-while-revalidate=1800",
+      "Content-Type": "application/json",
+    });
+    headers.append("Set-Cookie", "lb=server-a; Path=/; HttpOnly; SameSite=Lax");
+
+    const response = removeStickyCookieFromPublicCacheableResponse(
+      new Response('{"ok":true}', { headers }),
+    );
+
+    assertEquals(getSetCookies(response.headers), []);
+    assertEquals(await response.text(), '{"ok":true}');
+  });
+
+  it("preserves application cookies while removing lb on public cacheable responses", () => {
+    const headers = new Headers({
+      "Cache-Control": "public, max-age=31536000, immutable",
+      "Content-Type": "text/javascript",
+    });
+    headers.append("Set-Cookie", "lb=server-a; Path=/; HttpOnly");
+    headers.append("Set-Cookie", "session=keep; Path=/; HttpOnly");
+
+    const response = removeStickyCookieFromPublicCacheableResponse(
+      new Response("export const ok = true;", { headers }),
+    );
+
+    assertEquals(getSetCookies(response.headers), ["session=keep; Path=/; HttpOnly"]);
+  });
+
+  it("leaves non-cacheable sticky-cookie responses untouched", () => {
+    const headers = new Headers({
+      "Cache-Control": "private, no-store",
+      "Set-Cookie": "lb=server-a; Path=/; HttpOnly",
+    });
+
+    const response = removeStickyCookieFromPublicCacheableResponse(
+      new Response("html", { headers }),
+    );
+
+    assertEquals(getSetCookies(response.headers), ["lb=server-a; Path=/; HttpOnly"]);
+  });
+});

--- a/src/proxy/response-headers.ts
+++ b/src/proxy/response-headers.ts
@@ -1,0 +1,82 @@
+const STICKY_COOKIE_NAME = "lb";
+
+function parseCacheControl(cacheControl: string | null): Map<string, string | true> {
+  const directives = new Map<string, string | true>();
+  if (!cacheControl) return directives;
+
+  for (const part of cacheControl.split(",")) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const [rawName, rawValue] = trimmed.split("=", 2);
+    const name = rawName?.trim().toLowerCase();
+    if (!name) continue;
+    directives.set(name, rawValue === undefined ? true : rawValue.trim().replace(/^"|"$/g, ""));
+  }
+
+  return directives;
+}
+
+function readPositiveDirectiveSeconds(
+  directives: Map<string, string | true>,
+  name: string,
+): number {
+  const value = directives.get(name);
+  if (typeof value !== "string") return 0;
+  const seconds = Number(value);
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : 0;
+}
+
+function isPublicCacheable(headers: Headers): boolean {
+  const directives = parseCacheControl(headers.get("cache-control"));
+  if (!directives.has("public")) return false;
+  if (directives.has("private") || directives.has("no-store") || directives.has("no-cache")) {
+    return false;
+  }
+
+  return directives.has("immutable") ||
+    readPositiveDirectiveSeconds(directives, "s-maxage") > 0 ||
+    readPositiveDirectiveSeconds(directives, "max-age") > 0;
+}
+
+function readSetCookies(headers: Headers): string[] {
+  const getSetCookie = headers.getSetCookie;
+  if (typeof getSetCookie === "function") {
+    const values = getSetCookie.call(headers);
+    if (values.length > 0) return values;
+  }
+
+  const values: string[] = [];
+  for (const [key, value] of headers) {
+    if (key.toLowerCase() === "set-cookie") values.push(value);
+  }
+
+  const directValue = headers.get("set-cookie");
+  if (values.length === 0 && directValue) values.push(directValue);
+
+  return values;
+}
+
+function isStickyCookie(setCookie: string): boolean {
+  const [name] = setCookie.split("=", 1);
+  return name?.trim().toLowerCase() === STICKY_COOKIE_NAME;
+}
+
+export function removeStickyCookieFromPublicCacheableResponse(response: Response): Response {
+  if (!isPublicCacheable(response.headers)) return response;
+
+  const setCookies = readSetCookies(response.headers);
+  if (setCookies.length === 0 || !setCookies.some(isStickyCookie)) return response;
+
+  const headers = new Headers(response.headers);
+  headers.delete("set-cookie");
+
+  for (const setCookie of setCookies) {
+    if (!isStickyCookie(setCookie)) headers.append("Set-Cookie", setCookie);
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { RenderPipeline, type RenderPipelineConfig } from "./pipeline.ts";
 import { cachePageCss, getPageCssCacheKey } from "./css-cache.ts";
@@ -12,6 +12,11 @@ import {
 } from "#veryfront/release-assets/manifest-cache.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import {
+  finalizeRequestProfiling,
+  resetRequestProfiles,
+  runWithRequestProfiling,
+} from "#veryfront/observability/request-profiler.ts";
 
 const RELEASE_CSS_HASH = "c".repeat(64);
 
@@ -118,6 +123,8 @@ describe("RenderPipeline behavior", () => {
 
   afterEach(() => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, originalManifestFlag ?? "");
+    Deno.env.delete("VERYFRONT_ENABLE_SERVER_TIMING");
+    resetRequestProfiles();
     configureReleaseAssetManifestFetcher(undefined);
     clearReleaseAssetManifestCache();
   });
@@ -192,6 +199,41 @@ describe("RenderPipeline behavior", () => {
     assertEquals(sourceRefreshes, 1);
   });
 
+  it("renderPage emits request-profiler timings for pipeline stages", async () => {
+    Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
+    const slug = "/behavior-profile-render";
+    const pipeline = createPipeline("/project/pages/behavior-profile-render.mdx");
+
+    const record = await runWithRequestProfiling(
+      {
+        category: "html",
+        method: "GET",
+        pathname: slug,
+      },
+      async () => {
+        await pipeline.renderPage(slug, {
+          delivery: "string",
+          request: new Request(`http://localhost${slug}`),
+          url: new URL(`http://localhost${slug}`),
+        });
+        return finalizeRequestProfiling(200);
+      },
+    );
+
+    assert(record);
+    for (
+      const phase of [
+        "render.resolve_page",
+        "render.collect_layouts",
+        "render.prepare_bundles",
+        "render.apply_layouts",
+        "render.ssr",
+      ]
+    ) {
+      assert(phase in record.phases, `missing ${phase}`);
+    }
+  });
+
   it("resolvePageData surfaces notFound from data hooks", async () => {
     const slug = "/behavior-not-found";
     const projectId = "proj-not-found";
@@ -213,6 +255,44 @@ describe("RenderPipeline behavior", () => {
       Error,
       "Page/Layout returned notFound",
     );
+  });
+
+  it("resolvePageData emits request-profiler timings for first-hit stages", async () => {
+    Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
+    const slug = "/behavior-profile-page-data";
+    const projectId = "proj-profile-page-data";
+    const pipeline = createPipeline("/project/pages/behavior-profile-page-data.mdx");
+    primeCssCache(slug, projectId);
+
+    const record = await runWithRequestProfiling(
+      {
+        category: "page-data",
+        method: "GET",
+        pathname: `/_veryfront/page-data${slug}.json`,
+      },
+      async () => {
+        await pipeline.resolvePageData(slug, {
+          projectId,
+          request: new Request(`http://localhost${slug}`),
+          url: new URL(`http://localhost${slug}`),
+        });
+        return finalizeRequestProfiling(200);
+      },
+    );
+
+    assert(record);
+    for (
+      const phase of [
+        "page_data.resolve_page",
+        "page_data.collect_layouts",
+        "page_data.resolve_data",
+        "page_data.extract_mdx_metadata",
+        "page_data.resolve_app_path",
+        "page_data.resolve_css",
+      ]
+    ) {
+      assert(phase in record.phases, `missing ${phase}`);
+    }
   });
 
   it("resolvePageData surfaces redirect from data hooks", async () => {

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -18,6 +18,7 @@ import { rendererLogger as logger } from "#veryfront/utils";
 import { getExtensionName } from "#veryfront/utils/path-utils.ts";
 import { createBuildVersion } from "#veryfront/utils/version.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { profilePhase } from "#veryfront/observability/request-profiler.ts";
 import { SpanNames } from "#veryfront/observability/tracing/span-names.ts";
 import { VeryfrontError } from "#veryfront/errors/index.ts";
 import { FILE_NOT_FOUND, RENDER_ERROR } from "#veryfront/errors/error-registry.ts";
@@ -303,15 +304,19 @@ export class RenderPipeline {
       return { params, pageProps, layoutProps };
     }
 
-    const loadedModules = await withSpan(
-      SpanNames.RENDER_LOAD_MODULES,
+    const loadedModules = await profilePhase(
+      "render.load_modules",
       () =>
-        withTimeoutThrow(
-          this.loadModulesInParallel(modulesToLoad),
-          MODULE_LOAD_TIMEOUT_MS,
-          `Module loading for ${slug}`,
+        withSpan(
+          SpanNames.RENDER_LOAD_MODULES,
+          () =>
+            withTimeoutThrow(
+              this.loadModulesInParallel(modulesToLoad),
+              MODULE_LOAD_TIMEOUT_MS,
+              `Module loading for ${slug}`,
+            ),
+          { "render.module_count": modulesToLoad.length },
         ),
-      { "render.module_count": modulesToLoad.length },
     );
 
     const dataJobs = loadedModules.filter((m) => hasDataFetchingFunction(m.mod));
@@ -319,30 +324,39 @@ export class RenderPipeline {
       return { params, pageProps, layoutProps };
     }
 
-    const dataResults = await withSpan(
-      SpanNames.RENDER_FETCH_DATA,
+    const dataResults = await profilePhase(
+      "render.fetch_data",
       () =>
-        withTimeoutThrow(
-          Promise.all(
-            dataJobs.map(async (job) => {
-              try {
-                const jobPath = (job as LoadedModule & { path?: string }).path;
-                const fetchOptions: FetchDataOptions = {
-                  modulePath: jobPath,
-                  projectDir: this.config.projectDir,
-                };
-                const result = await this.dataFetcher
-                  .fetchData(job.mod as PageWithData, dataContext, this.config.mode, fetchOptions);
-                return { ...job, result, error: null as Error | null };
-              } catch (error) {
-                return { ...job, result: null, error: error as Error };
-              }
-            }),
-          ),
-          DATA_FETCH_TIMEOUT_MS,
-          `Data fetch for ${slug}`,
+        withSpan(
+          SpanNames.RENDER_FETCH_DATA,
+          () =>
+            withTimeoutThrow(
+              Promise.all(
+                dataJobs.map(async (job) => {
+                  try {
+                    const jobPath = (job as LoadedModule & { path?: string }).path;
+                    const fetchOptions: FetchDataOptions = {
+                      modulePath: jobPath,
+                      projectDir: this.config.projectDir,
+                    };
+                    const result = await this.dataFetcher
+                      .fetchData(
+                        job.mod as PageWithData,
+                        dataContext,
+                        this.config.mode,
+                        fetchOptions,
+                      );
+                    return { ...job, result, error: null as Error | null };
+                  } catch (error) {
+                    return { ...job, result: null, error: error as Error };
+                  }
+                }),
+              ),
+              DATA_FETCH_TIMEOUT_MS,
+              `Data fetch for ${slug}`,
+            ),
+          { "render.data_job_count": dataJobs.length },
         ),
-      { "render.data_job_count": dataJobs.length },
     );
 
     this.applyFetchedDataResults(slug, dataResults, pageProps, layoutProps);
@@ -422,10 +436,14 @@ export class RenderPipeline {
         async () => {
           const { result } = await runWithCSSCollector(async () => {
             const pageResolveStart = performance.now();
-            const pageInfo = await withSpan(
+            const pageInfo = await profilePhase(
               "render.resolve_page",
-              () => this.config.pageResolver.resolvePage(slug),
-              { "render.slug": slug },
+              () =>
+                withSpan(
+                  "render.resolve_page",
+                  () => this.config.pageResolver.resolvePage(slug),
+                  { "render.slug": slug },
+                ),
             );
             timing.pageResolve = Math.round(performance.now() - pageResolveStart);
 
@@ -438,10 +456,14 @@ export class RenderPipeline {
               const skipLayouts = isDotPath(slug, pageInfo.entity.path);
 
               const layoutCollectStart = performance.now();
-              const layoutResult = skipLayouts ? EMPTY_LAYOUT_RESULT : await withSpan(
+              const layoutResult = skipLayouts ? EMPTY_LAYOUT_RESULT : await profilePhase(
                 "render.collect_layouts",
-                () => this.config.layoutOrchestrator.collectLayouts(pageInfo),
-                { "render.slug": slug },
+                () =>
+                  withSpan(
+                    "render.collect_layouts",
+                    () => this.config.layoutOrchestrator.collectLayouts(pageInfo),
+                    { "render.slug": slug },
+                  ),
               );
               timing.layoutCollect = Math.round(performance.now() - layoutCollectStart);
 
@@ -457,32 +479,36 @@ export class RenderPipeline {
 
               const dataFetchStart = performance.now();
               if (options?.request && options?.url) {
-                await withSpan(
+                await profilePhase(
                   "render.data_fetching",
-                  async () => {
-                    try {
-                      const dataResolution = await this.resolveDataFetching(
-                        slug,
-                        pageInfo.entity.path,
-                        layoutResult.nestedLayouts,
-                        options,
-                      );
-                      resolvedParams = dataResolution.params;
-                      dataFetchingProps = Object.keys(dataResolution.pageProps).length > 0
-                        ? dataResolution.pageProps
-                        : undefined;
-                      layoutDataMap = dataResolution.layoutProps;
-                    } catch (error) {
-                      if (error instanceof VeryfrontError) throw error;
+                  () =>
+                    withSpan(
+                      "render.data_fetching",
+                      async () => {
+                        try {
+                          const dataResolution = await this.resolveDataFetching(
+                            slug,
+                            pageInfo.entity.path,
+                            layoutResult.nestedLayouts,
+                            options,
+                          );
+                          resolvedParams = dataResolution.params;
+                          dataFetchingProps = Object.keys(dataResolution.pageProps).length > 0
+                            ? dataResolution.pageProps
+                            : undefined;
+                          layoutDataMap = dataResolution.layoutProps;
+                        } catch (error) {
+                          if (error instanceof VeryfrontError) throw error;
 
-                      renderPageLog.error("Data fetching error", {
-                        slug,
-                        error: error instanceof Error ? error.message : String(error),
-                      });
-                      throw error;
-                    }
-                  },
-                  { "render.slug": slug },
+                          renderPageLog.error("Data fetching error", {
+                            slug,
+                            error: error instanceof Error ? error.message : String(error),
+                          });
+                          throw error;
+                        }
+                      },
+                      { "render.slug": slug },
+                    ),
                 );
               }
               timing.dataFetch = Math.round(performance.now() - dataFetchStart);
@@ -499,16 +525,20 @@ export class RenderPipeline {
                 : options;
 
               const bundlePrepStart = performance.now();
-              const pageBundleResult = await withSpan(
+              const pageBundleResult = await profilePhase(
                 "render.prepare_bundles",
                 () =>
-                  this.config.pageRenderer.preparePageBundles(
-                    pageInfo,
-                    slug,
-                    cacheResult?.cachedModule,
-                    mergedOptions,
+                  withSpan(
+                    "render.prepare_bundles",
+                    () =>
+                      this.config.pageRenderer.preparePageBundles(
+                        pageInfo,
+                        slug,
+                        cacheResult?.cachedModule,
+                        mergedOptions,
+                      ),
+                    { "render.slug": slug },
                   ),
-                { "render.slug": slug },
               );
               timing.bundlePrep = Math.round(performance.now() - bundlePrepStart);
 
@@ -533,22 +563,29 @@ export class RenderPipeline {
               await layoutPreloadPromise;
 
               const layoutApplyStart = performance.now();
-              const wrappedElement = await withSpan(
+              const wrappedElement = await profilePhase(
                 "render.apply_layouts",
                 () =>
-                  this.config.layoutOrchestrator.applyLayoutsAndWrappers(
-                    pageElement,
-                    pageInfo,
-                    layoutResult.layoutBundle,
-                    layoutResult.nestedLayouts,
-                    layoutDataMap,
-                    options?.url,
-                    resolvedParams,
-                    mergedFrontmatter,
-                    headings,
-                    options?.projectSlug,
+                  withSpan(
+                    "render.apply_layouts",
+                    () =>
+                      this.config.layoutOrchestrator.applyLayoutsAndWrappers(
+                        pageElement,
+                        pageInfo,
+                        layoutResult.layoutBundle,
+                        layoutResult.nestedLayouts,
+                        layoutDataMap,
+                        options?.url,
+                        resolvedParams,
+                        mergedFrontmatter,
+                        headings,
+                        options?.projectSlug,
+                      ),
+                    {
+                      "render.slug": slug,
+                      "render.layout_count": layoutResult.nestedLayouts.length,
+                    },
                   ),
-                { "render.slug": slug, "render.layout_count": layoutResult.nestedLayouts.length },
               );
               timing.layoutApply = Math.round(performance.now() - layoutApplyStart);
 
@@ -557,27 +594,31 @@ export class RenderPipeline {
               const collectedCSSImports = getCSSImports();
 
               const ssrStart = performance.now();
-              const ssrResult = await withSpan(
+              const ssrResult = await profilePhase(
                 "render.ssr",
                 () =>
-                  withTimeoutThrow(
-                    this.config.ssrOrchestrator.performSSRRendering(
-                      wrappedElement,
-                      {
-                        pageInfo,
-                        pageBundle,
-                        layoutBundle: layoutResult.layoutBundle,
-                        nestedLayouts: layoutResult.nestedLayouts,
-                        collectedMetadata: pageBundleResult.collectedMetadata,
-                        slug,
-                        cssImports: collectedCSSImports,
-                      },
-                      mergedOptions,
-                    ),
-                    SSR_RENDER_TIMEOUT_MS,
-                    `SSR rendering for ${slug}`,
+                  withSpan(
+                    "render.ssr",
+                    () =>
+                      withTimeoutThrow(
+                        this.config.ssrOrchestrator.performSSRRendering(
+                          wrappedElement,
+                          {
+                            pageInfo,
+                            pageBundle,
+                            layoutBundle: layoutResult.layoutBundle,
+                            nestedLayouts: layoutResult.nestedLayouts,
+                            collectedMetadata: pageBundleResult.collectedMetadata,
+                            slug,
+                            cssImports: collectedCSSImports,
+                          },
+                          mergedOptions,
+                        ),
+                        SSR_RENDER_TIMEOUT_MS,
+                        `SSR rendering for ${slug}`,
+                      ),
+                    { "render.slug": slug, "render.delivery": mergedOptions?.delivery || "full" },
                   ),
-                { "render.slug": slug, "render.delivery": mergedOptions?.delivery || "full" },
               );
               timing.ssr = Math.round(performance.now() - ssrStart);
 
@@ -663,33 +704,45 @@ export class RenderPipeline {
       clearSSRModuleCacheForProject(projectId);
     }
 
-    const pageInfo = await this.config.pageResolver.resolvePage(slug);
+    const pageInfo = await profilePhase(
+      "page_data.resolve_page",
+      () => this.config.pageResolver.resolvePage(slug),
+    );
 
     const skipLayouts = isDotPath(slug, pageInfo.entity.path);
-    const layoutResult = skipLayouts
-      ? EMPTY_LAYOUT_RESULT
-      : await this.config.layoutOrchestrator.collectLayouts(pageInfo);
+    const layoutResult = skipLayouts ? EMPTY_LAYOUT_RESULT : await profilePhase(
+      "page_data.collect_layouts",
+      () => this.config.layoutOrchestrator.collectLayouts(pageInfo),
+    );
 
     const pagePath = extractRelativePathShared(pageInfo.entity.path, this.config.projectDir);
     const fileExtension = getExtensionName(pageInfo.entity.path);
     const pageType = fileExtension as PageDataResponse["pageType"];
-    const dataResolution = await this.resolveDataFetching(
-      slug,
-      pageInfo.entity.path,
-      layoutResult.nestedLayouts,
-      options,
+    const dataResolution = await profilePhase(
+      "page_data.resolve_data",
+      () =>
+        this.resolveDataFetching(
+          slug,
+          pageInfo.entity.path,
+          layoutResult.nestedLayouts,
+          options,
+        ),
     );
 
     const pageProps: Record<string, unknown> = dataResolution.pageProps;
     const params = dataResolution.params;
     const layoutProps = serializeLayoutProps(dataResolution.layoutProps);
 
-    const { frontmatter, headings } = await this.extractMdxMetadata(
-      pageType,
-      pageInfo,
-      slug,
-      options,
-      params,
+    const { frontmatter, headings } = await profilePhase(
+      "page_data.extract_mdx_metadata",
+      () =>
+        this.extractMdxMetadata(
+          pageType,
+          pageInfo,
+          slug,
+          options,
+          params,
+        ),
     );
 
     const layouts = serializeLayouts(layoutResult.nestedLayouts, this.config.projectDir);
@@ -698,12 +751,11 @@ export class RenderPipeline {
 
     const projectUpdatedAt = this.resolveProjectUpdatedAt();
 
-    const appPath = await this.resolveAppPath();
+    const appPath = await profilePhase("page_data.resolve_app_path", () => this.resolveAppPath());
 
-    const { css, cssAction, cssError } = await this.resolvePageDataCss(
-      slug,
-      options,
-      projectUpdatedAt,
+    const { css, cssAction, cssError } = await profilePhase(
+      "page_data.resolve_css",
+      () => this.resolvePageDataCss(slug, options, projectUpdatedAt),
     );
 
     resolvePageDataLog.debug("Resolved page data", {
@@ -827,15 +879,19 @@ export class RenderPipeline {
     }
 
     try {
-      const renderResult = await withTimeout(
-        this.renderPage(slug, {
-          ...options,
-          delivery: "string",
-          skipCacheCheck: true,
-          skipCachePersist: true,
-        }),
-        CSS_SSR_TIMEOUT_MS,
-        `CSS SSR for ${slug}`,
+      const renderResult = await profilePhase(
+        "page_data.css.render_html",
+        () =>
+          withTimeout(
+            this.renderPage(slug, {
+              ...options,
+              delivery: "string",
+              skipCacheCheck: true,
+              skipCachePersist: true,
+            }),
+            CSS_SSR_TIMEOUT_MS,
+            `CSS SSR for ${slug}`,
+          ),
       );
 
       if (!renderResult?.html) {
@@ -843,9 +899,13 @@ export class RenderPipeline {
       }
 
       let cssAction: PageDataResponse["cssAction"] | undefined;
-      let css = await this.resolveCssFromRenderedHtml(
-        renderResult.html,
-        options?.projectSlug ?? options?.projectId,
+      let css = await profilePhase(
+        "page_data.css.extract_from_html",
+        () =>
+          this.resolveCssFromRenderedHtml(
+            renderResult.html,
+            options?.projectSlug ?? options?.projectId,
+          ),
       );
 
       if (css) {
@@ -860,7 +920,10 @@ export class RenderPipeline {
           slug,
         });
       } else {
-        css = await this.generatePageCssFromHtml(slug, renderResult.html, options);
+        css = await profilePhase(
+          "page_data.css.generate_from_html",
+          () => this.generatePageCssFromHtml(slug, renderResult.html, options),
+        );
       }
 
       if (css) cachePageCss(cssCacheKey, css);

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.832";
+export const VERSION = "0.1.833";


### PR DESCRIPTION
## Summary
- remove only the proxy `lb` sticky cookie from public cacheable responses so page-data and immutable assets stay shared-cache friendly
- add request-profiler spans inside `RenderPipeline.renderPage()` and `resolvePageData()` to break down first-hit SSR/page-data latency
- bump `deno.json` and `src/utils/version-constant.ts` to `0.1.833` for a new release

## Verification
- `deno check src/proxy/response-headers.ts src/proxy/main.ts src/rendering/orchestrator/pipeline.ts`
- `deno test --no-check --allow-all src/proxy/response-headers.test.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/server/handlers/request/module/page-data-endpoint-handler.test.ts src/server/handlers/request/module/module.handler.test.ts src/modules/server/module-server.test.ts`
- pre-push hook: formatting, lint, type check, full unit suite: `2171 passed (18727 steps), 0 failed`

## Deployment note
After merge and the `0.1.833` release, update `veryfront-server` to the released package/image, deploy production, then retest browser-to-proxy-to-pod timings with `Server-Timing` enabled.