### PR TITLE
Stop SPA navigation from bypassing shared caches

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.833",
+  "version": "0.1.834",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/html/hydration-script-builder/hydration-data-generator.test.ts
+++ b/src/html/hydration-script-builder/hydration-data-generator.test.ts
@@ -162,6 +162,24 @@ describe("hydration-data-generator", () => {
       );
     });
 
+    it("includes release id for production fallback module versioning", () => {
+      const parsed = parseHydrationData(
+        "page",
+        {},
+        {},
+        {
+          ...baseOptions,
+          mode: "production",
+          environment: "production",
+          releaseId: "rel-1",
+        },
+      ) as {
+        releaseId?: string;
+      };
+
+      assertEquals(parsed.releaseId, "rel-1");
+    });
+
     it("should include pageType from options", () => {
       const options: HTMLGenerationOptions = {
         ...baseOptions,

--- a/src/html/hydration-script-builder/hydration-data-generator.ts
+++ b/src/html/hydration-script-builder/hydration-data-generator.ts
@@ -82,6 +82,7 @@ export function generateHydrationData(
       isLocalProject: options.isLocalProject,
       environment: options.environment as HydrationEnvironment | undefined,
     }),
+    releaseId: options.releaseId,
     releaseAssetModules: buildReleaseAssetModules(options.releaseAssetManifest),
     frontmatter: options.frontmatter,
     layoutProps: options.layoutProps,

--- a/src/html/hydration-script-builder/templates/loader.test.ts
+++ b/src/html/hydration-script-builder/templates/loader.test.ts
@@ -1,9 +1,54 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { VERSION } from "#veryfront/utils/version.ts";
 import { getLoaderScript } from "./loader.ts";
 
 describe("hydration-script-builder/templates/loader", () => {
+  type MutableTestGlobal = Record<string, unknown> & {
+    __veryfrontReleaseId?: string | null;
+    __veryfrontReleaseAssetModules?: Record<string, string> | null;
+  };
+
+  function runGeneratedPathToModuleUrl(
+    path: string,
+    setup = "",
+    studioEmbed = false,
+  ): string {
+    const globalRecord = globalThis as MutableTestGlobal;
+    const previousWindow = globalRecord.window;
+    const previousReleaseId = globalRecord.__veryfrontReleaseId;
+    const previousReleaseAssetModules = globalRecord.__veryfrontReleaseAssetModules;
+
+    globalRecord.window = globalThis;
+
+    try {
+      return new Function(
+        "path",
+        "studioEmbed",
+        `const MODULE_SERVER_URL = '/_vf_modules';\n${getLoaderScript()}\n${setup}\nreturn pathToModuleUrl(path, studioEmbed);`,
+      )(path, studioEmbed) as string;
+    } finally {
+      if (previousWindow === undefined) {
+        delete globalRecord.window;
+      } else {
+        globalRecord.window = previousWindow;
+      }
+
+      if (previousReleaseId === undefined) {
+        delete globalRecord.__veryfrontReleaseId;
+      } else {
+        globalRecord.__veryfrontReleaseId = previousReleaseId;
+      }
+
+      if (previousReleaseAssetModules === undefined) {
+        delete globalRecord.__veryfrontReleaseAssetModules;
+      } else {
+        globalRecord.__veryfrontReleaseAssetModules = previousReleaseAssetModules;
+      }
+    }
+  }
+
   describe("getLoaderScript", () => {
     function getResult(): string {
       return getLoaderScript();
@@ -52,6 +97,13 @@ describe("hydration-script-builder/templates/loader", () => {
         true,
       );
       assertEquals(result.includes("resolveReleaseAssetModuleUrl(path)"), true);
+    });
+
+    it("should expose release id support for immutable fallback module URLs", () => {
+      const result = getResult();
+      assertEquals(result.includes("window.__veryfrontSetReleaseId = setReleaseId"), true);
+      assertEquals(result.includes("appendReleaseModuleVersion(url)"), true);
+      assertEquals(result.includes("VERYFRONT_RUNTIME_VERSION"), true);
     });
 
     it("should handle known source file extensions in pathToModuleUrl", () => {
@@ -106,6 +158,47 @@ describe("hydration-script-builder/templates/loader", () => {
     it("should handle MODULE_SERVER_URL in pathToModuleUrl", () => {
       const result = getResult();
       assertEquals(result.includes("MODULE_SERVER_URL"), true);
+    });
+
+    it("version-stamps fallback module URLs when release id is configured", () => {
+      const result = runGeneratedPathToModuleUrl(
+        "pages/blog.mdx",
+        "window.__veryfrontSetReleaseId('rel-1');",
+      );
+
+      assertEquals(
+        result,
+        `/_vf_modules/pages/blog.js?vf_release=rel-1&vf_runtime=${VERSION}`,
+      );
+    });
+
+    it("does not version-stamp studio embed fallback module URLs", () => {
+      const result = runGeneratedPathToModuleUrl(
+        "pages/blog.mdx",
+        "window.__veryfrontSetReleaseId('rel-1');",
+        true,
+      );
+
+      assertEquals(result, "/_vf_modules/pages/blog.js?studio_embed=true");
+    });
+
+    it("does not version-stamp HMR fallback module URLs", () => {
+      const result = runGeneratedPathToModuleUrl(
+        "pages/blog.mdx",
+        "window.__veryfrontSetReleaseId('rel-1'); window.__veryfrontSetHMRRefreshTimestamp('123');",
+      );
+
+      assertEquals(result, "/_vf_modules/pages/blog.js?t=123");
+    });
+
+    it("keeps release asset module URLs ahead of fallback release stamping", () => {
+      const assetUrl = "/_vf/assets/" + "a".repeat(64) + ".js";
+      const result = runGeneratedPathToModuleUrl(
+        "pages/blog.mdx",
+        `window.__veryfrontSetReleaseId('rel-1'); window.__veryfrontSetReleaseAssetModules({ 'pages/blog.mdx': '${assetUrl}' });`,
+      );
+
+      assertEquals(result, assetUrl);
     });
   });
 });

--- a/src/html/hydration-script-builder/templates/loader.ts
+++ b/src/html/hydration-script-builder/templates/loader.ts
@@ -1,6 +1,9 @@
+import { VERSION } from "#veryfront/utils/version.ts";
+
 export const getLoaderScript = (): string => `
     // Note: DEBUG, log, logError are defined in router.ts which loads first
 
+    const VERYFRONT_RUNTIME_VERSION = '${VERSION}';
     const componentCache = new Map();
     const loadingPromises = new Map();
 
@@ -20,6 +23,20 @@ export const getLoaderScript = (): string => `
 
     function appendQueryParam(url, key, value) {
       return url + (url.includes('?') ? '&' : '?') + key + '=' + value;
+    }
+
+    let __releaseId = null;
+    function setReleaseId(value) {
+      __releaseId = typeof value === 'string' && value ? value : null;
+      window.__veryfrontReleaseId = __releaseId;
+    }
+    window.__veryfrontSetReleaseId = setReleaseId;
+
+    function appendReleaseModuleVersion(url) {
+      if (!__releaseId || url.includes('vf_release=')) return url;
+      let versionedUrl = appendQueryParam(url, 'vf_release', encodeURIComponent(__releaseId));
+      versionedUrl = appendQueryParam(versionedUrl, 'vf_runtime', encodeURIComponent(VERYFRONT_RUNTIME_VERSION));
+      return versionedUrl;
     }
 
     let __releaseAssetModules = null;
@@ -76,6 +93,7 @@ export const getLoaderScript = (): string => `
 
       if (studioEmbed) url = appendQueryParam(url, 'studio_embed', 'true');
       if (__hmrRefreshTimestamp) url = appendQueryParam(url, 't', __hmrRefreshTimestamp);
+      if (!studioEmbed && !__hmrRefreshTimestamp) url = appendReleaseModuleVersion(url);
 
       return url;
     }

--- a/src/html/hydration-script-builder/templates/renderer.test.ts
+++ b/src/html/hydration-script-builder/templates/renderer.test.ts
@@ -39,6 +39,12 @@ describe("hydration-script-builder/templates/renderer", () => {
       assertIncludes(result, "__veryfrontSetReleaseAssetModules");
     });
 
+    it("should install release id from hydration data", () => {
+      const result = getRendererScript();
+      assertIncludes(result, "data.releaseId");
+      assertIncludes(result, "__veryfrontSetReleaseId");
+    });
+
     it("should use the RSC module endpoint only for app router RSC client pages", () => {
       const result = getRendererScript();
       assertIncludes(result, "data.clientModuleStrategy === 'rsc-module'");

--- a/src/html/hydration-script-builder/templates/renderer.ts
+++ b/src/html/hydration-script-builder/templates/renderer.ts
@@ -33,6 +33,9 @@ export const getRendererScript = () => `
       if (data.studioEmbed && window.__veryfrontSetStudioEmbed) {
         window.__veryfrontSetStudioEmbed(true);
       }
+      if (window.__veryfrontSetReleaseId) {
+        window.__veryfrontSetReleaseId(data.releaseId || null);
+      }
       if (data.releaseAssetModules && window.__veryfrontSetReleaseAssetModules) {
         window.__veryfrontSetReleaseAssetModules(data.releaseAssetModules);
       }

--- a/src/html/hydration-script-builder/templates/router.test.ts
+++ b/src/html/hydration-script-builder/templates/router.test.ts
@@ -174,6 +174,12 @@ describe("hydration-script-builder/templates/router", () => {
       assertIncludes(result, "__veryfrontSetReleaseAssetModules");
     });
 
+    it("should install release id from SPA page data before loading components", () => {
+      const result = getRouterScript();
+      assertIncludes(result, "pageData.releaseId");
+      assertIncludes(result, "__veryfrontSetReleaseId");
+    });
+
     it("should clear release asset modules when SPA page data has no map", () => {
       assertIncludes(
         getRouterScript(),

--- a/src/html/hydration-script-builder/templates/router.ts
+++ b/src/html/hydration-script-builder/templates/router.ts
@@ -502,6 +502,9 @@ export const getRouterScript = () => `
     // Render page from page data
     // ============================================
     async function renderPageFromData(pageData, targetPath) {
+      if (window.__veryfrontSetReleaseId) {
+        window.__veryfrontSetReleaseId(pageData.releaseId || null);
+      }
       if (window.__veryfrontSetReleaseAssetModules) {
         window.__veryfrontSetReleaseAssetModules(pageData.releaseAssetModules || null);
       }
@@ -633,6 +636,9 @@ export const getRouterScript = () => `
 
     async function preloadModulesForPageData(pageData, path) {
       if (!pageData) return;
+      if (pageData.releaseId && window.__veryfrontSetReleaseId) {
+        window.__veryfrontSetReleaseId(pageData.releaseId);
+      }
       if (pageData.releaseAssetModules && window.__veryfrontSetReleaseAssetModules) {
         window.__veryfrontSetReleaseAssetModules(pageData.releaseAssetModules);
       }

--- a/src/html/hydration-script-builder/templates/spa-renderer.test.ts
+++ b/src/html/hydration-script-builder/templates/spa-renderer.test.ts
@@ -50,6 +50,12 @@ describe("hydration-script-builder/templates/spa-renderer", () => {
       assertIncludes(result, "__veryfrontSetReleaseAssetModules");
     });
 
+    it("should install release id from initial data", () => {
+      const result = getSpaRendererScript();
+      assertIncludes(result, "initialData.releaseId");
+      assertIncludes(result, "__veryfrontSetReleaseId");
+    });
+
     it("should load page component", () => {
       assertIncludes(getSpaRendererScript(), "loadComponent(initialData.pagePath)");
     });

--- a/src/html/hydration-script-builder/templates/spa-renderer.ts
+++ b/src/html/hydration-script-builder/templates/spa-renderer.ts
@@ -22,6 +22,9 @@ export const getSpaRendererScript = (): string => `
       if (initialData.releaseAssetModules && window.__veryfrontSetReleaseAssetModules) {
         window.__veryfrontSetReleaseAssetModules(initialData.releaseAssetModules);
       }
+      if (window.__veryfrontSetReleaseId) {
+        window.__veryfrontSetReleaseId(initialData.releaseId || null);
+      }
 
       try {
         const pageComponent = await loadComponent(initialData.pagePath);

--- a/src/html/hydration-script-builder/types.ts
+++ b/src/html/hydration-script-builder/types.ts
@@ -14,6 +14,8 @@ export interface HydrationDataStructure {
   pagePath?: string;
   pageType?: "mdx" | "md" | "tsx" | "jsx" | "ts" | "js";
   clientModuleStrategy?: ClientModuleStrategy;
+  /** Production release id used to version fallback module URLs. */
+  releaseId?: string;
   /** Production release asset URLs keyed by logical source path. */
   releaseAssetModules?: Record<string, string>;
   frontmatter?: Record<string, unknown>;

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -414,6 +414,22 @@ describe("RenderPipeline behavior", () => {
     );
   });
 
+  it("resolvePageData includes release id for fallback module versioning", async () => {
+    const slug = "/behavior-release-id";
+    const projectId = "proj-release-id";
+    const pipeline = createPipeline("/project/pages/behavior-release-id.mdx");
+    primeCssCache(slug, projectId);
+
+    const pageData = await pipeline.resolvePageData(slug, {
+      projectId,
+      request: new Request(`http://localhost${slug}`),
+      url: new URL(`http://localhost${slug}`),
+      releaseId: "rel-1",
+    });
+
+    assertEquals(pageData.releaseId, "rel-1");
+  });
+
   it("resolvePageData includes projectUpdated in buildVersion when available", async () => {
     const slug = "/behavior-build-version";
     const projectId = "proj-build-version";

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -782,6 +782,7 @@ export class RenderPipeline {
       layoutProps,
       buildVersion: createBuildVersion(projectUpdatedAt),
       appPath,
+      releaseId: options?.releaseId,
       releaseAssetModules: buildReleaseAssetModules(options?.releaseAssetManifest),
       headings,
       css,

--- a/src/rendering/orchestrator/types.ts
+++ b/src/rendering/orchestrator/types.ts
@@ -83,6 +83,8 @@ export interface PageDataResponse {
   layoutProps: Record<string, Record<string, unknown>>;
   buildVersion: BuildVersion;
   appPath?: string;
+  /** Production release id used to version fallback module URLs. */
+  releaseId?: string;
   /** Production release asset URLs keyed by logical source path. */
   releaseAssetModules?: Record<string, string>;
   /** Headings extracted from MDX for sidebar/TOC navigation */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.833";
+export const VERSION = "0.1.834";


### PR DESCRIPTION
## Summary
- carry `releaseId` through hydration and page-data responses
- install the release id before initial and SPA route module loading
- append `vf_release` and `vf_runtime=0.1.834` only to fallback `_vf_modules` URLs so they get immutable/cacheable production handling
- keep release asset URLs, studio embed, and HMR cache busters ahead of fallback version stamping

## Production evidence before this change
- `/_veryfront/page-data/blog.json` is cacheable and has no `Set-Cookie`, but does not expose `releaseId`
- SPA navigation still loads bare `_vf_modules/pages/blog.js` with `Cache-Control: no-cache`, `Set-Cookie: lb=...`, and `cf-cache-status: BYPASS`
- manually versioned module URLs already return `Cache-Control: public, max-age=31536000, immutable` with no `Set-Cookie` and warm TTFB around 80 ms from Stockholm

## Verification
- `deno fmt deno.json ...`
- `deno check src/html/hydration-script-builder/templates/loader.test.ts src/html/hydration-script-builder/hydration-data-generator.test.ts src/html/hydration-script-builder/templates/renderer.test.ts src/html/hydration-script-builder/templates/router.test.ts src/html/hydration-script-builder/templates/spa-renderer.test.ts src/rendering/orchestrator/pipeline.behavior.test.ts`
- `deno test --no-check --allow-all src/html/hydration-script-builder/templates/loader.test.ts src/html/hydration-script-builder/hydration-data-generator.test.ts src/html/hydration-script-builder/templates/renderer.test.ts src/html/hydration-script-builder/templates/router.test.ts src/html/hydration-script-builder/templates/spa-renderer.test.ts`
- `deno test --no-check --allow-all src/modules/server/module-server.test.ts src/rendering/orchestrator/pipeline.behavior.test.ts`
- `git diff --check`
- pre-push hook: format, lint, typecheck, generate, and broad unit suite: `2171 passed`, `0 failed`

## Release
- bumps `deno.json` and `src/utils/version-constant.ts` to `0.1.834` to force a new Veryfront release