### PR TITLE
Cache release module responses across pods

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.834",
+  "version": "0.1.835",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/architecture/13-observability.md
+++ b/docs/architecture/13-observability.md
@@ -42,6 +42,19 @@ proxy also appends proxy-prefixed phases:
 - `proxy.resolve_server`: dedicated renderer server lookup.
 - `proxy.retry_delay`: retry backoff time.
 - `proxy.upstream`: fetch time from proxy to renderer response headers.
+- `module.response_cache_hit`: release-scoped module response served from the
+  runtime module response cache.
+- `module.response_cache_distributed_hit`: release-scoped module response
+  recovered from a configured shared cache before source lookup or transform.
+- `module.response_cache_miss`: release-scoped module response was not cached
+  and source lookup plus transform ran for the request.
+- `module.response_cache_store`: release-scoped module response was stored for
+  later cache hits.
+
+The release module response cache uses a bounded in-process LRU for local pod
+hits. Shared reuse across horizontally scaled pods is limited to API or Redis
+cache backends. Disk and memory cache backends are not used as shared response
+stores, which avoids container disk growth for immutable module responses.
 
 Use client timing such as `curl -w '%{time_pretransfer} %{time_starttransfer}'`
 with `proxy.total` to estimate edge, ingress, and network time before the proxy

--- a/src/modules/server/module-response-cache.test.ts
+++ b/src/modules/server/module-response-cache.test.ts
@@ -1,0 +1,81 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import type { CacheBackend } from "#veryfront/cache/types.ts";
+import {
+  __setReleaseModuleResponseDistributedCacheForTests,
+  clearReleaseModuleResponseCache,
+  getReleaseModuleResponse,
+  type ReleaseModuleResponseCacheEntry,
+  rememberReleaseModuleResponse,
+} from "./module-response-cache.ts";
+
+class FakeDistributedCache implements CacheBackend {
+  readonly type = "redis" as const;
+  readonly values = new Map<string, string>();
+  readonly ttlSeconds = new Map<string, number | undefined>();
+
+  get(key: string): Promise<string | null> {
+    return Promise.resolve(this.values.get(key) ?? null);
+  }
+
+  set(key: string, value: string, ttlSeconds?: number): Promise<void> {
+    this.values.set(key, value);
+    this.ttlSeconds.set(key, ttlSeconds);
+    return Promise.resolve();
+  }
+
+  del(key: string): Promise<void> {
+    this.values.delete(key);
+    this.ttlSeconds.delete(key);
+    return Promise.resolve();
+  }
+}
+
+describe("release module response cache", () => {
+  afterEach(() => {
+    __setReleaseModuleResponseDistributedCacheForTests(undefined);
+    clearReleaseModuleResponseCache();
+  });
+
+  it("recovers release module responses from distributed cache when local cache is empty", async () => {
+    const distributedCache = new FakeDistributedCache();
+    __setReleaseModuleResponseDistributedCacheForTests(distributedCache);
+
+    const cacheKey = "release-module-response:test";
+    const entry: ReleaseModuleResponseCacheEntry = {
+      body: "export const value = 1;\n",
+      status: 200,
+      headers: [["cache-control", "public, max-age=31536000, immutable"]],
+    };
+
+    await rememberReleaseModuleResponse(cacheKey, entry);
+    clearReleaseModuleResponseCache();
+
+    const recovered = await getReleaseModuleResponse(cacheKey);
+
+    assertEquals(recovered?.source, "distributed");
+    assertEquals(recovered?.entry, entry);
+    assertEquals(typeof distributedCache.ttlSeconds.get(cacheKey), "number");
+  });
+
+  it("does not use disk cache backends for release module responses", async () => {
+    const diskCache = new FakeDistributedCache();
+    Object.defineProperty(diskCache, "type", { value: "disk" });
+    __setReleaseModuleResponseDistributedCacheForTests(diskCache);
+
+    const cacheKey = "release-module-response:disk";
+    const entry: ReleaseModuleResponseCacheEntry = {
+      body: "export const value = 1;\n",
+      status: 200,
+      headers: [["cache-control", "public, max-age=31536000, immutable"]],
+    };
+
+    await rememberReleaseModuleResponse(cacheKey, entry);
+    clearReleaseModuleResponseCache();
+
+    const recovered = await getReleaseModuleResponse(cacheKey);
+
+    assertEquals(recovered, undefined);
+    assertEquals(diskCache.values.size, 0);
+  });
+});

--- a/src/modules/server/module-response-cache.ts
+++ b/src/modules/server/module-response-cache.ts
@@ -1,0 +1,158 @@
+import { registerLRUCache } from "#veryfront/cache";
+import { CacheBackends, createDistributedCacheAccessor } from "#veryfront/cache/backend.ts";
+import { hashString } from "#veryfront/cache/hash.ts";
+import type { CacheBackend } from "#veryfront/cache/types.ts";
+import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
+import { TRANSFORM_DISTRIBUTED_TTL_SEC } from "#veryfront/utils/constants/cache.ts";
+
+const RELEASE_MODULE_RESPONSE_CACHE_MAX_ENTRIES = 10_000;
+const RELEASE_MODULE_RESPONSE_CACHE_MAX_BYTES = 64 * 1024 * 1024;
+const RELEASE_MODULE_RESPONSE_DISTRIBUTED_TTL_SEC = TRANSFORM_DISTRIBUTED_TTL_SEC;
+
+export interface ReleaseModuleResponseCacheEntry {
+  body: string;
+  status: number;
+  headers: Array<[string, string]>;
+}
+
+export interface ReleaseModuleResponseCacheKeyOptions {
+  projectIdentity: string;
+  projectDir: string;
+  projectSlug?: string | null;
+  branch?: string | null;
+  releaseId: string;
+  runtimeVersion: string;
+  reactVersion?: string;
+  releaseDependencyManifestVersion?: number | null;
+  modulePath: string;
+}
+
+export interface ReleaseModuleResponseCacheHit {
+  entry: ReleaseModuleResponseCacheEntry;
+  source: "memory" | "distributed";
+}
+
+const releaseModuleResponseCache = new LRUCache<string, ReleaseModuleResponseCacheEntry>({
+  maxEntries: RELEASE_MODULE_RESPONSE_CACHE_MAX_ENTRIES,
+  maxSizeBytes: RELEASE_MODULE_RESPONSE_CACHE_MAX_BYTES,
+});
+
+registerLRUCache("module-server-release-response-cache", releaseModuleResponseCache);
+
+const getDistributedModuleResponseCache = createDistributedCacheAccessor(
+  () => CacheBackends.module(),
+  "MODULE-RESPONSE-CACHE",
+);
+
+let injectedDistributedCache: CacheBackend | null | undefined;
+
+function parseDistributedEntry(raw: string): ReleaseModuleResponseCacheEntry | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<ReleaseModuleResponseCacheEntry>;
+    if (typeof parsed.body !== "string") return null;
+    if (typeof parsed.status !== "number") return null;
+    if (
+      !Array.isArray(parsed.headers) ||
+      !parsed.headers.every((entry) =>
+        Array.isArray(entry) &&
+        entry.length === 2 &&
+        typeof entry[0] === "string" &&
+        typeof entry[1] === "string"
+      )
+    ) return null;
+
+    return {
+      body: parsed.body,
+      status: parsed.status,
+      headers: parsed.headers as Array<[string, string]>,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function getDistributedCache(): Promise<CacheBackend | null> {
+  const cache = injectedDistributedCache !== undefined
+    ? injectedDistributedCache
+    : await getDistributedModuleResponseCache();
+  if (!cache) return null;
+  return cache.type === "api" || cache.type === "redis" ? cache : null;
+}
+
+export function buildReleaseModuleResponseCacheKey(
+  options: ReleaseModuleResponseCacheKeyOptions,
+): string {
+  const projectScope = [
+    options.projectIdentity,
+    options.projectDir,
+    options.projectSlug ?? "",
+    options.branch ?? "",
+  ].join("\0");
+
+  return [
+    "module-server-release-response",
+    hashString(projectScope),
+    options.releaseId,
+    options.runtimeVersion,
+    options.reactVersion ?? "",
+    options.releaseDependencyManifestVersion == null
+      ? ""
+      : `release-dependency-manifest:${options.releaseDependencyManifestVersion}`,
+    options.modulePath,
+  ].join("\0");
+}
+
+export async function getReleaseModuleResponse(
+  cacheKey: string,
+): Promise<ReleaseModuleResponseCacheHit | undefined> {
+  const localEntry = releaseModuleResponseCache.get(cacheKey);
+  if (localEntry) {
+    return { entry: localEntry, source: "memory" };
+  }
+
+  const distributedCache = await getDistributedCache();
+  if (!distributedCache) return undefined;
+
+  try {
+    const raw = await distributedCache.get(cacheKey);
+    if (!raw) return undefined;
+
+    const entry = parseDistributedEntry(raw);
+    if (!entry) return undefined;
+
+    releaseModuleResponseCache.set(cacheKey, entry);
+    return { entry, source: "distributed" };
+  } catch {
+    return undefined;
+  }
+}
+
+export async function rememberReleaseModuleResponse(
+  cacheKey: string,
+  entry: ReleaseModuleResponseCacheEntry,
+): Promise<void> {
+  releaseModuleResponseCache.set(cacheKey, entry);
+
+  const distributedCache = await getDistributedCache();
+  if (!distributedCache) return;
+
+  try {
+    await distributedCache.set(
+      cacheKey,
+      JSON.stringify(entry),
+      RELEASE_MODULE_RESPONSE_DISTRIBUTED_TTL_SEC,
+    );
+  } catch {
+    /* best-effort shared cache */
+  }
+}
+
+export function clearReleaseModuleResponseCache(): void {
+  releaseModuleResponseCache.clear();
+}
+
+export function __setReleaseModuleResponseDistributedCacheForTests(
+  cache: CacheBackend | null | undefined,
+): void {
+  injectedDistributedCache = cache;
+}

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -21,6 +21,7 @@ import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts"
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { VERSION } from "#veryfront/utils/version.ts";
 import { isModuleRequest } from "./module-server.ts";
+import { clearReleaseModuleResponseCache } from "./module-response-cache.ts";
 import { clearSourceMissCache } from "./module-source-resolution-cache.ts";
 import { deleteEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import {
@@ -29,6 +30,7 @@ import {
   RELEASE_ASSET_MANIFEST_SCHEMA_VERSION,
 } from "#veryfront/release-assets/constants.ts";
 import {
+  clearCachedReleaseAssetManifests,
   clearReleaseAssetManifestCache,
   configureReleaseAssetManifestFetcher,
 } from "#veryfront/release-assets/manifest-cache.ts";
@@ -84,6 +86,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     deleteEnv("VERYFRONT_ENABLE_SERVER_TIMING");
     configureReleaseAssetManifestFetcher(undefined);
     clearReleaseAssetManifestCache();
+    clearReleaseModuleResponseCache();
     resetRequestProfiles();
   });
 
@@ -447,6 +450,67 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     }
   });
 
+  it("reuses transformed responses for release-versioned production modules", async () => {
+    setEnv("VERYFRONT_ENABLE_SERVER_TIMING", "1");
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-release-module-response-cache-" });
+    const releaseId = `rel-cache-${crypto.randomUUID()}`;
+    const request = new Request(
+      `http://localhost:3000/_vf_modules/components/App.js?vf_release=${releaseId}&vf_runtime=${VERSION}`,
+    );
+
+    async function serveWithProfile(): Promise<{
+      body: string;
+      record: NonNullable<ReturnType<typeof finalizeRequestProfiling>>;
+      status: number;
+    }> {
+      let record: ReturnType<typeof finalizeRequestProfiling> = null;
+      let profiledResponse: Response | undefined;
+      const response = await runWithRequestProfiling(
+        {
+          category: "module",
+          method: "GET",
+          pathname: "/_vf_modules/components/App.js",
+        },
+        async () => {
+          try {
+            profiledResponse = await serveProductionModule(request, projectDir, releaseId);
+            return profiledResponse;
+          } finally {
+            record = finalizeRequestProfiling(profiledResponse?.status);
+          }
+        },
+      );
+
+      return {
+        body: await response.text(),
+        record: record!,
+        status: response.status,
+      };
+    }
+
+    try {
+      await Deno.mkdir(`${projectDir}/components`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/components/App.ts`,
+        `export const value = 1;\n`,
+      );
+
+      const first = await serveWithProfile();
+      const second = await serveWithProfile();
+
+      assertEquals(first.status, 200);
+      assertEquals(second.status, 200);
+      assertEquals(second.body, first.body);
+      assertEquals(Boolean(first.record.phases["module.source_lookup"]), true);
+      assertEquals(Boolean(first.record.phases["module.transform"]), true);
+      assertEquals(second.record.phases["module.response_cache_hit"], 0);
+      assertEquals("module.source_lookup" in second.record.phases, false);
+      assertEquals("module.transform" in second.record.phases, false);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
   it("keeps unversioned production modules on no-cache headers", async () => {
     const projectDir = await Deno.makeTempDir({ prefix: "vf-unversioned-module-cache-" });
 
@@ -641,6 +705,102 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
       assertEquals(firstVersion !== secondVersion, true);
     } finally {
       await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("does not cache release module responses before dependency manifest readiness", async () => {
+    setEnv("VERYFRONT_ENABLE_SERVER_TIMING", "1");
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-module-release-cache-gate-" });
+    const cacheDir = await Deno.makeTempDir({ prefix: "vf-module-cache-gate-" });
+    const dependencyDir = `${cacheDir}/veryfront-http-bundle`;
+    const dependencyPath = `${dependencyDir}/http-123abc.mjs`;
+    const sourceUrl = "https://esm.sh/react@19.2.4?deps=csstype%403.2.3&target=es2022";
+    const hash = "b".repeat(64);
+    const releaseId = `release-cache-gate-${crypto.randomUUID()}`;
+    let ready = false;
+
+    async function serveWithProfile(): Promise<{
+      body: string;
+      record: NonNullable<ReturnType<typeof finalizeRequestProfiling>>;
+      status: number;
+    }> {
+      const request = new Request(
+        `http://localhost:3000/_vf_modules/components/App.js?vf_release=${releaseId}&vf_runtime=${VERSION}`,
+      );
+      let record: ReturnType<typeof finalizeRequestProfiling> = null;
+      let profiledResponse: Response | undefined;
+      const response = await runWithRequestProfiling(
+        {
+          category: "module",
+          method: "GET",
+          pathname: "/_vf_modules/components/App.js",
+        },
+        async () => {
+          try {
+            profiledResponse = await serveProductionModule(request, projectDir, releaseId);
+            return profiledResponse;
+          } finally {
+            record = finalizeRequestProfiling(profiledResponse?.status);
+          }
+        },
+      );
+
+      return {
+        body: await response.text(),
+        record: record!,
+        status: response.status,
+      };
+    }
+
+    try {
+      await Deno.mkdir(dependencyDir, { recursive: true });
+      await Deno.writeTextFile(
+        dependencyPath,
+        `/*! @vf-source: ${sourceUrl} */\nexport default {};`,
+      );
+      await Deno.mkdir(`${projectDir}/components`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/components/App.tsx`,
+        `import React from ${JSON.stringify(`file://${dependencyPath}`)};\nexport default React;\n`,
+      );
+      configureReleaseAssetManifestFetcher(() =>
+        Promise.resolve(
+          ready
+            ? {
+              state: "ready",
+              manifest: manifest({
+                [sourceUrl]: {
+                  contentHash: hash,
+                  size: 100,
+                  contentType: "text/javascript",
+                },
+              }),
+            }
+            : { state: "building", manifest: null },
+        )
+      );
+
+      const first = await serveWithProfile();
+      ready = true;
+      clearCachedReleaseAssetManifests();
+      const second = await serveWithProfile();
+      const third = await serveWithProfile();
+
+      assertEquals(first.status, 200);
+      assertEquals(second.status, 200);
+      assertEquals(third.status, 200);
+      assertEquals(first.body.includes(`"/_vf/assets/${hash}.js"`), false);
+      assertEquals(second.body.includes(`"/_vf/assets/${hash}.js"`), true);
+      assertEquals(third.body, second.body);
+      assertEquals(Boolean(second.record.phases["module.source_lookup"]), true);
+      assertEquals("module.response_cache_hit" in second.record.phases, false);
+      assertEquals(third.record.phases["module.response_cache_hit"], 0);
+      assertEquals("module.source_lookup" in third.record.phases, false);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(cacheDir, { recursive: true });
     }
   });
 });

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -10,7 +10,10 @@ import { getContentTypeForPath } from "#veryfront/server/handlers/utils/content-
 import { createSecureFs } from "#veryfront/security";
 import { getErrorMessage } from "#veryfront/errors/veryfront-error.ts";
 import { getApiBaseUrlEnv } from "#veryfront/config/env.ts";
-import { profilePhase } from "#veryfront/observability/request-profiler.ts";
+import {
+  markRequestProfilePhase,
+  profilePhase,
+} from "#veryfront/observability/request-profiler.ts";
 import { metrics, type ModuleServeStatus } from "#veryfront/observability/simple-metrics/index.ts";
 import { injectContext, withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { injectNodePositions } from "#veryfront/transforms/plugins/babel-node-positions.ts";
@@ -30,7 +33,11 @@ import {
 import { getReactUrls, REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import { readLimitedCrossProjectSource } from "./cross-project-source-limit.ts";
 import { sha256Short } from "#veryfront/cache/hash.ts";
-import { rewriteReleaseDependencyImportsForModule } from "#veryfront/release-assets/module-consumption.ts";
+import {
+  getReleaseDependencyRewriteManifestState,
+  rewriteReleaseDependencyImportsForModule,
+} from "#veryfront/release-assets/module-consumption.ts";
+import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 import {
   RELEASE_ASSET_IMMUTABLE_MAX_AGE_SECONDS,
   RELEASE_MODULE_RUNTIME_VERSION_PARAM,
@@ -41,6 +48,11 @@ import {
   hasSourceMiss,
   rememberSourceMiss,
 } from "./module-source-resolution-cache.ts";
+import {
+  buildReleaseModuleResponseCacheKey,
+  getReleaseModuleResponse,
+  rememberReleaseModuleResponse,
+} from "./module-response-cache.ts";
 import { ensureFilenameDefaultExport } from "#veryfront/modules/loader-shared/filename-default-export.ts";
 
 const logger = serverLogger.component("module-server");
@@ -142,7 +154,8 @@ function shouldCacheReleaseVersionedModule(
   options: ModuleServerOptions,
   isSSR: boolean,
 ): boolean {
-  if (options.dev || isSSR || !options.releaseId) return false;
+  if (options.dev || options.mode === "preview" || isSSR || !options.releaseId) return false;
+  if (url.searchParams.get("studio_embed") === "true" || url.searchParams.has("t")) return false;
   return url.searchParams.get(RELEASE_MODULE_VERSION_PARAM) === options.releaseId &&
     url.searchParams.get(RELEASE_MODULE_RUNTIME_VERSION_PARAM) === VERSION;
 }
@@ -446,6 +459,53 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
         branch ??= parsedHost.branch;
       }
 
+      const isSSR = isSSRModuleRequest(req, url);
+      const canUseReleaseModuleResponseCache = method === "GET" || method === "HEAD";
+      const canCacheReleaseVersionedModule = canUseReleaseModuleResponseCache &&
+        shouldCacheReleaseVersionedModule(url, options, isSSR);
+      let releaseDependencyManifest: ReleaseAssetManifest | null = null;
+      let releaseDependencyManifestVersion: number | null = null;
+      let releaseDependencyManifestReady = true;
+      if (canCacheReleaseVersionedModule) {
+        const manifestState = await getReleaseDependencyRewriteManifestState(options.releaseId);
+        if (manifestState.enabled) {
+          releaseDependencyManifest = manifestState.manifest;
+          releaseDependencyManifestVersion = manifestState.manifest?.manifestVersion ?? null;
+          releaseDependencyManifestReady = manifestState.manifest !== null;
+        }
+      }
+      const releaseModuleResponseCacheKey = canCacheReleaseVersionedModule &&
+          releaseDependencyManifestReady
+        ? buildReleaseModuleResponseCacheKey({
+          projectIdentity: effectiveProjectId,
+          projectDir,
+          projectSlug,
+          branch,
+          releaseId: options.releaseId!,
+          runtimeVersion: VERSION,
+          reactVersion,
+          releaseDependencyManifestVersion,
+          modulePath,
+        })
+        : null;
+
+      if (releaseModuleResponseCacheKey) {
+        const cachedResponse = await getReleaseModuleResponse(releaseModuleResponseCacheKey);
+        if (cachedResponse?.entry) {
+          markRequestProfilePhase("module.response_cache_hit");
+          if (cachedResponse.source === "distributed") {
+            markRequestProfilePhase("module.response_cache_distributed_hit");
+          }
+          return createModuleResponse(
+            method,
+            cachedResponse.entry.body,
+            cachedResponse.entry.status,
+            Object.fromEntries(cachedResponse.entry.headers),
+          );
+        }
+        markRequestProfilePhase("module.response_cache_miss");
+      }
+
       try {
         const findResult = await profilePhase(
           "module.source_lookup",
@@ -496,7 +556,6 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
           }
 
           const userAgent = req.headers.get("user-agent") ?? "";
-          const isSSR = isSSRModuleRequest(req, url);
 
           const studioEmbed = url.searchParams.get("studio_embed") === "true";
           const shouldInjectPositions = dev || options.mode === "preview";
@@ -557,6 +616,7 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
           if (!isSSR) {
             code = await rewriteReleaseDependencyImportsForModule(code, {
               releaseId: options.releaseId,
+              manifest: releaseDependencyManifest ?? undefined,
               readDependencySource: (path) => platformFs.readTextFile(path),
             });
             code = await addReleaseVersionToFallbackImports(code, options.releaseId);
@@ -564,12 +624,21 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
         }
 
         const headers = getModuleHeaders(modulePath, {
-          cacheable: shouldCacheReleaseVersionedModule(url, options, isSSRModuleRequest(req, url)),
+          cacheable: releaseModuleResponseCacheKey !== null,
         });
         logger.debug("Request complete", {
           path: modulePath,
           durationMs: (performance.now() - startTime).toFixed(1),
         });
+
+        if (releaseModuleResponseCacheKey && method === "GET") {
+          void rememberReleaseModuleResponse(releaseModuleResponseCacheKey, {
+            body: code,
+            status: HTTP_OK,
+            headers: Object.entries(headers),
+          });
+          markRequestProfilePhase("module.response_cache_store");
+        }
 
         return createModuleResponse(method, code, HTTP_OK, headers);
       } catch (error) {

--- a/src/release-assets/module-consumption.ts
+++ b/src/release-assets/module-consumption.ts
@@ -20,6 +20,29 @@ import type { ReleaseAssetManifest } from "./manifest-schema.ts";
 export interface RewriteReleaseDependencyImportsOptions {
   releaseId?: string | null;
   readDependencySource: (path: string) => Promise<string>;
+  manifest?: ReleaseAssetManifest | null;
+}
+
+export interface ReleaseDependencyRewriteManifestState {
+  enabled: boolean;
+  manifest: ReleaseAssetManifest | null;
+}
+
+export function isReleaseDependencyImportMapRewriteEnabled(): boolean {
+  return getHostEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG) === "1";
+}
+
+export async function getReleaseDependencyRewriteManifestState(
+  releaseId: string | null | undefined,
+): Promise<ReleaseDependencyRewriteManifestState> {
+  if (!releaseId || !isReleaseDependencyImportMapRewriteEnabled()) {
+    return { enabled: false, manifest: null };
+  }
+
+  return {
+    enabled: true,
+    manifest: await getReadyManifestForRenderAsync(releaseId),
+  };
 }
 
 function dependencyAssetUrl(
@@ -76,10 +99,12 @@ export async function rewriteReleaseDependencyImportsForModule(
   options: RewriteReleaseDependencyImportsOptions,
 ): Promise<string> {
   if (!options.releaseId) return code;
-  if (getHostEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG) !== "1") return code;
+  if (!isReleaseDependencyImportMapRewriteEnabled()) return code;
   if (!code.includes("http") && !code.includes("veryfront-http-bundle")) return code;
 
-  const manifest = await getReadyManifestForRenderAsync(options.releaseId);
+  const manifest = options.manifest !== undefined
+    ? options.manifest
+    : await getReadyManifestForRenderAsync(options.releaseId);
   if (!manifest || Object.keys(manifest.dependencies).length === 0) return code;
 
   const replacements = new Map<string, string>();

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.834";
+export const VERSION = "0.1.835";


### PR DESCRIPTION
## Summary

This PR caches immutable release-scoped `_vf_modules` responses before the runtime repeats source lookup and ESM transform work.

The change targets the production bottleneck measured after `v0.1.834`: versioned module URLs were browser/CDN-cacheable, but direct pod hits still spent roughly 100ms in module source lookup and transform work. Enterprise deployments cannot assume Cloudflare, so the runtime needs to avoid repeating that work inside the cluster.

## Horizontal scaling behavior

- Uses a bounded in-pod LRU for fast repeated hits on the same pod: `10_000` entries and `64 MiB` estimated value size.
- Uses the existing module API or Redis cache backend when configured, so another pod can reuse the transformed response after the first pod stores it.
- Does not use memory-only or disk cache backends as shared response stores. This avoids container disk growth and avoids treating pod-local disk as a cross-pod cache.
- Does not require Redis/shared cache to boot; clusters without a shared backend still get per-pod warm cache behavior.
- The cache key includes project scope, release id, runtime version, React version, dependency manifest version when applicable, and module path to keep multi-project and multi-release serving isolated.

## Safety boundaries

Only immutable release module responses are admitted:

- `GET` and `HEAD`
- production only
- non-preview
- non-SSR
- no `studio_embed=true`
- no HMR `t` query
- `vf_release` must match the active release id
- `vf_runtime` must match the package version

When release dependency import-map rewrites are enabled, response caching also waits for a ready dependency manifest. Pre-manifest responses stay uncached and non-immutable, and ready-manifest responses include the manifest version in the response-cache key.

Dev, preview, SSR, HMR, studio embed, unversioned module responses, and pre-manifest dependency rewrite responses continue through the existing path.

## Observability

Adds Server-Timing markers:

- `module.response_cache_hit`
- `module.response_cache_distributed_hit`
- `module.response_cache_miss`
- `module.response_cache_store`

## Release

Bumps `deno.json` and `src/utils/version-constant.ts` to `0.1.835` so merge creates a new package release.

## Verification

- `deno fmt src/modules/server/module-response-cache.ts src/modules/server/module-response-cache.test.ts src/modules/server/module-server.ts src/modules/server/module-server.test.ts src/release-assets/module-consumption.ts src/release-assets/module-consumption.test.ts docs/architecture/13-observability.md`
- `deno check src/modules/server/module-response-cache.ts src/modules/server/module-response-cache.test.ts src/modules/server/module-server.ts src/modules/server/module-server.test.ts src/release-assets/module-consumption.ts src/release-assets/module-consumption.test.ts`
- `deno test --no-check --allow-all src/modules/server/module-response-cache.test.ts src/modules/server/module-server.test.ts src/release-assets/module-consumption.test.ts`
- `git diff --check`
- pre-push hook: format, lint, typecheck, unit tests (`2172 passed`)
