### PR TITLE
Keep release module imports versioned through relative children

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -124,7 +124,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 2
           retry_wait_seconds: 10
-          command: deno task test:e2e:rsc-browser --no-lock
+          command: deno task test:e2e:rsc-browser
 
   # ============================================
   # CI: Compiled Binary E2E Tests
@@ -171,7 +171,7 @@ jobs:
           max_attempts: 2
           retry_wait_seconds: 30
           command: |
-            VERYFRONT_BINARY_FRESH=1 deno task test:e2e:binary --no-lock
+            VERYFRONT_BINARY_FRESH=1 deno task test:e2e:binary
 
   # ============================================
   # CI: Split Mode Test

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.835",
+  "version": "0.1.836",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -450,6 +450,52 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     }
   });
 
+  it("adds release query params to relative imports in release-versioned modules", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-release-relative-imports-" });
+    const releaseId = `rel-relative-${crypto.randomUUID()}`;
+
+    try {
+      await Deno.mkdir(`${projectDir}/components/blog`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/components/blog/BlogList.ts`,
+        [
+          `import { BlogTeaser } from "../../components/blog/BlogTeaser.js";`,
+          `import { useArticles } from "./useArticles.js";`,
+          `export const value = [BlogTeaser, useArticles];`,
+        ].join("\n"),
+      );
+      await Deno.writeTextFile(
+        `${projectDir}/components/blog/BlogTeaser.ts`,
+        `export const BlogTeaser = "teaser";\n`,
+      );
+      await Deno.writeTextFile(
+        `${projectDir}/components/blog/useArticles.ts`,
+        `export const useArticles = "articles";\n`,
+      );
+
+      const response = await serveProductionModule(
+        new Request(
+          `http://localhost:3000/_vf_modules/components/blog/BlogList.js?vf_release=${releaseId}&vf_runtime=${VERSION}`,
+        ),
+        projectDir,
+        releaseId,
+      );
+
+      assertEquals(response.status, 200);
+      const text = await response.text();
+      assertStringIncludes(
+        text,
+        `"/_vf_modules/components/blog/BlogTeaser.js?vf_release=${releaseId}&vf_runtime=${VERSION}"`,
+      );
+      assertStringIncludes(
+        text,
+        `"/_vf_modules/components/blog/useArticles.js?vf_release=${releaseId}&vf_runtime=${VERSION}"`,
+      );
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
   it("reuses transformed responses for release-versioned production modules", async () => {
     setEnv("VERYFRONT_ENABLE_SERVER_TIMING", "1");
     const projectDir = await Deno.makeTempDir({ prefix: "vf-release-module-response-cache-" });

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -167,13 +167,25 @@ function isSSRModuleRequest(req: Request, url: URL): boolean {
 
 async function addReleaseVersionToFallbackImports(
   code: string,
+  modulePath: string,
   releaseId: string | null | undefined,
 ): Promise<string> {
-  if (!releaseId || !code.includes("/_vf_modules/")) return code;
+  if (!releaseId) return code;
+  const moduleBaseUrl = `https://veryfront.local/_vf_modules/${modulePath}`;
 
   return await replaceSpecifiers(code, (specifier) => {
-    if (!specifier.startsWith("/_vf_modules/")) return null;
-    return appendReleaseModuleVersion(specifier, releaseId);
+    if (specifier.startsWith("/_vf_modules/")) {
+      return appendReleaseModuleVersion(specifier, releaseId);
+    }
+    if (!specifier.startsWith("./") && !specifier.startsWith("../")) return null;
+
+    const resolved = new URL(specifier, moduleBaseUrl);
+    if (resolved.origin !== "https://veryfront.local") return null;
+    if (!resolved.pathname.startsWith("/_vf_modules/")) return null;
+    return appendReleaseModuleVersion(
+      `${resolved.pathname}${resolved.search}${resolved.hash}`,
+      releaseId,
+    );
   });
 }
 
@@ -619,7 +631,7 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
               manifest: releaseDependencyManifest ?? undefined,
               readDependencySource: (path) => platformFs.readTextFile(path),
             });
-            code = await addReleaseVersionToFallbackImports(code, options.releaseId);
+            code = await addReleaseVersionToFallbackImports(code, modulePath, options.releaseId);
           }
         }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.835";
+export const VERSION = "0.1.836";


### PR DESCRIPTION
## Summary

Production verification of `0.1.835` showed fresh route loads still issuing bare follow-on `/_vf_modules/...` requests after the entry module was release-versioned. The entry module emitted versioned absolute imports, but child modules with relative `./` or `../` imports preserved those relative specifiers, so the browser resolved them to unversioned module URLs.

This updates release fallback import rewriting to resolve relative child imports against the current module path and emit release/runtime-versioned `/_vf_modules/...` URLs. It preserves existing query and hash values and keeps the existing manifest-readiness guard behavior unchanged.

This also bumps the runtime to `0.1.836` so the fix produces a new release.

The first CI run exposed an unrelated browser e2e stability issue: Chromium install used the lockfile, but the browser test jobs appended `--no-lock`, allowing Playwright package drift after the install step. The browser e2e jobs now use the lock consistently.

## Verification

- `deno fmt deno.json src/utils/version-constant.ts src/modules/server/module-server.ts src/modules/server/module-server.test.ts`
- `deno check src/modules/server/module-server.ts src/modules/server/module-server.test.ts`
- `deno test --no-check --allow-all src/modules/server/module-server.test.ts`
- `git diff --check`
- Pre-push gate: format, lint, typecheck, full unit run: `2172 passed`, `0 failed`

## Notes

This fixes graph-wide version propagation for modules loaded from release-versioned URLs. Response caching is still intentionally gated by release dependency manifest readiness for the current site release.
