### PR TITLE
Version release import-map module aliases

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.836",
+  "version": "0.1.837",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/html/html-shell-manifest.test.ts
+++ b/src/html/html-shell-manifest.test.ts
@@ -16,6 +16,7 @@ import {
   RELEASE_ASSET_MANIFEST_ENV_FLAG,
 } from "#veryfront/release-assets/constants.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
+import { VERYFRONT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 
 const PAGE_HASH = "a".repeat(64);
 const CHAT_HASH = "b".repeat(64);
@@ -271,7 +272,10 @@ describe("html shell release asset manifest consumption", () => {
     );
     const result = await generateHTMLShellParts(meta(), prodOptions({ releaseId: "rel-1" }));
     assert(!result.start.includes(`/_vf/assets/${CHAT_HASH}.js`));
-    assertStringIncludes(result.start, `"veryfront/chat":"/_vf_modules/_veryfront/chat/index.js"`);
+    assertStringIncludes(
+      result.start,
+      `"veryfront/chat":"/_vf_modules/_veryfront/chat/index.js?vf_release=rel-1&vf_runtime=${VERYFRONT_VERSION}"`,
+    );
     assertStringIncludes(result.start, `"@/":"/_vf_modules/"`);
   });
 

--- a/src/html/utils.test.ts
+++ b/src/html/utils.test.ts
@@ -10,6 +10,7 @@ import {
 import { getDefaultImportMap } from "#veryfront/modules/import-map/default-import-map.ts";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import { RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
+import { VERYFRONT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 
 describe("html-generation/utils", () => {
@@ -216,11 +217,11 @@ describe("html-generation/utils", () => {
       });
       const imports = JSON.parse(result).imports as Record<string, string>;
 
-      assertStringIncludes(imports.react, "https://esm.sh/react@");
-      assertStringIncludes(imports["react-dom"], "https://esm.sh/react-dom@");
-      assertStringIncludes(imports["react-dom/client"], "https://esm.sh/react-dom@");
-      assertStringIncludes(imports["react/jsx-runtime"], "https://esm.sh/react@");
-      assertStringIncludes(imports["react/jsx-dev-runtime"], "https://esm.sh/react@");
+      assertStringIncludes(imports.react!, "https://esm.sh/react@");
+      assertStringIncludes(imports["react-dom"]!, "https://esm.sh/react-dom@");
+      assertStringIncludes(imports["react-dom/client"]!, "https://esm.sh/react-dom@");
+      assertStringIncludes(imports["react/jsx-runtime"]!, "https://esm.sh/react@");
+      assertStringIncludes(imports["react/jsx-dev-runtime"]!, "https://esm.sh/react@");
     });
 
     it("rewrites React import-map aliases from manifest dependency keys when explicitly enabled", async () => {
@@ -317,6 +318,37 @@ describe("html-generation/utils", () => {
       assertEquals(imports["veryfront/head"], `/_vf/assets/${headHash}.js`);
       assertEquals(imports["veryfront/react/head"], `/_vf/assets/${headHash}.js`);
       assertEquals(imports["veryfront/workflow"], `/_vf/assets/${workflowHash}.js`);
+    });
+
+    it("versions local module-server import-map aliases in release manifest context", async () => {
+      const manifest: ReleaseAssetManifest = {
+        schemaVersion: 1,
+        projectId: "project-id",
+        releaseId: "release-id",
+        releaseVersion: 1,
+        manifestVersion: 1,
+        builderVersion: "0.1.810",
+        sourceContentHash: "source",
+        createdAt: "2026-06-15T00:00:00.000Z",
+        assetBasePath: "/_vf/assets",
+        modules: {},
+        css: [],
+        routes: {},
+        dependencies: {},
+        fallback: { mode: "jit", gaps: [] },
+      };
+
+      const result = await buildImportMapJson({
+        pretty: false,
+        releaseAssetManifest: manifest,
+      });
+      const imports = JSON.parse(result).imports as Record<string, string>;
+
+      assertEquals(
+        imports["veryfront/router"],
+        `/_vf_modules/_veryfront/react/runtime/core.js?vf_release=release-id&vf_runtime=${VERYFRONT_VERSION}`,
+      );
+      assertEquals(imports["@/"], "/_vf_modules/");
     });
 
     it("refreshes cached import maps when project package versions change", async () => {

--- a/src/html/utils.ts
+++ b/src/html/utils.ts
@@ -3,6 +3,8 @@ import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import {
   RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG,
+  RELEASE_MODULE_RUNTIME_VERSION_PARAM,
+  RELEASE_MODULE_VERSION_PARAM,
   releaseAssetUrl,
 } from "#veryfront/release-assets/constants.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
@@ -291,6 +293,8 @@ function stableManifestDependencyKey(manifest?: ReleaseAssetManifest | null): st
   return manifest
     ? JSON.stringify({
       assetBasePath: manifest.assetBasePath,
+      releaseId: manifest.releaseId,
+      manifestVersion: manifest.manifestVersion,
       dependencies: Object.entries(manifest.dependencies)
         .map(([specifier, entry]) => [specifier, entry.contentHash])
         .sort(([a], [b]) => String(a).localeCompare(String(b))),
@@ -345,6 +349,35 @@ function applyManifestDependencies(
   );
 }
 
+function shouldVersionReleaseModuleImportMapUrl(value: string): boolean {
+  if (!value.startsWith("/_vf_modules/")) return false;
+  const pathname = value.split(/[?#]/, 1)[0] ?? "";
+  return pathname.endsWith(".js") || pathname.endsWith(".mjs");
+}
+
+function appendReleaseModuleVersion(value: string, releaseId: string): string {
+  if (!shouldVersionReleaseModuleImportMapUrl(value)) return value;
+
+  const url = new URL(value, "https://veryfront.local");
+  url.searchParams.set(RELEASE_MODULE_VERSION_PARAM, releaseId);
+  url.searchParams.set(RELEASE_MODULE_RUNTIME_VERSION_PARAM, VERYFRONT_VERSION);
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+function applyReleaseModuleVersions(
+  imports: Record<string, string>,
+  manifest?: ReleaseAssetManifest | null,
+): Record<string, string> {
+  if (!manifest?.releaseId) return imports;
+
+  return Object.fromEntries(
+    Object.entries(imports).map(([specifier, url]) => [
+      specifier,
+      appendReleaseModuleVersion(url, manifest.releaseId),
+    ]),
+  );
+}
+
 function isImportMapOnlyOptions(
   options: BuildImportMapOptions | Record<string, string>,
 ): options is Record<string, string> {
@@ -380,6 +413,7 @@ export async function buildImportMap(
       "react/jsx-dev-runtime": reactTemplates.jsxDevRuntime(versions.react),
     };
     imports = applyManifestDependencies(imports, releaseAssetManifest);
+    imports = applyReleaseModuleVersions(imports, releaseAssetManifest);
     imports = { ...imports, ...customImports };
 
     return { imports, json: stringifyImportMap(imports, pretty) };
@@ -397,6 +431,7 @@ export async function buildImportMap(
 
   imports["@/"] = "/_vf_modules/";
   imports = applyManifestDependencies(imports, releaseAssetManifest);
+  imports = applyReleaseModuleVersions(imports, releaseAssetManifest);
 
   if (customImports) {
     imports = { ...imports, ...customImports };

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.836";
+export const VERSION = "0.1.837";


### PR DESCRIPTION
## Summary
- append release/runtime query params to local module-server import-map aliases when release manifest context is available
- keep prefix import-map entries such as `@/` unchanged
- bump `deno.json` and version constant to `0.1.837` so merge produces a new release

## Why
Production HTML still emits bare `/_vf_modules/_veryfront/...` import-map aliases beside versioned route modules. Browser probes show this causes the runtime core to be fetched both with and without release params, and the bare path stays on no-cache/module-server behavior.

## Verification
- `deno fmt deno.json src/html/utils.ts src/html/utils.test.ts src/html/html-shell-manifest.test.ts src/utils/version-constant.ts`
- `git diff --check`
- `deno check src/html/utils.ts src/html/utils.test.ts src/html/html-shell-manifest.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/html/html-shell-manifest.test.ts src/html/utils.test.ts src/routing/client/page-loader.test.ts`
- pre-push hook: formatting, lint, type check, generation, unit suite, 2172 passed / 0 failed

## Production observation before this PR
- `veryfront-code#2496` released as `veryfront@0.1.836` and production server reports `Veryfront CLI v0.1.836`
- no-cache `/blog` probe: HTML TTFB about 2.1s, server-timing total about 1.7s
- browser initial page shows both versioned and bare `/_vf_modules/_veryfront/react/runtime/core.js` fetches
- versioned `/_vf_modules/pages/blog.js` still returned `cache-control: no-cache` and `set-cookie: lb`, which remains a separate gateway/server header follow-up if this PR does not resolve it
