### PR TITLE
Keep safe release modules immutable without manifests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.837",
+  "version": "0.1.838",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -394,7 +394,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
       await Deno.mkdir(`${projectDir}/components`, { recursive: true });
       await Deno.writeTextFile(
         `${projectDir}/components/App.ts`,
-        `export const value = 1;\n`,
+        `export const value = "https://example.com/docs";\n`,
       );
 
       const response = await runWithRequestProfiling(
@@ -547,6 +547,77 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
       assertEquals(first.status, 200);
       assertEquals(second.status, 200);
       assertEquals(second.body, first.body);
+      assertEquals(Boolean(first.record.phases["module.source_lookup"]), true);
+      assertEquals(Boolean(first.record.phases["module.transform"]), true);
+      assertEquals(second.record.phases["module.response_cache_hit"], 0);
+      assertEquals("module.source_lookup" in second.record.phases, false);
+      assertEquals("module.transform" in second.record.phases, false);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("caches release-versioned modules when the dependency manifest is absent but unused", async () => {
+    setEnv("VERYFRONT_ENABLE_SERVER_TIMING", "1");
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-release-module-null-manifest-" });
+    const releaseId = `rel-null-manifest-${crypto.randomUUID()}`;
+    const request = new Request(
+      `http://localhost:3000/_vf_modules/components/App.js?vf_release=${releaseId}&vf_runtime=${VERSION}`,
+    );
+
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({ state: "building", manifest: null })
+    );
+
+    async function serveWithProfile(): Promise<{
+      body: string;
+      cacheControl: string | null;
+      record: NonNullable<ReturnType<typeof finalizeRequestProfiling>>;
+      status: number;
+    }> {
+      let record: ReturnType<typeof finalizeRequestProfiling> = null;
+      let profiledResponse: Response | undefined;
+      const response = await runWithRequestProfiling(
+        {
+          category: "module",
+          method: "GET",
+          pathname: "/_vf_modules/components/App.js",
+        },
+        async () => {
+          try {
+            profiledResponse = await serveProductionModule(request, projectDir, releaseId);
+            return profiledResponse;
+          } finally {
+            record = finalizeRequestProfiling(profiledResponse?.status);
+          }
+        },
+      );
+
+      return {
+        body: await response.text(),
+        cacheControl: response.headers.get("cache-control"),
+        record: record!,
+        status: response.status,
+      };
+    }
+
+    try {
+      await Deno.mkdir(`${projectDir}/components`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/components/App.ts`,
+        `export const value = 1;\n`,
+      );
+
+      const first = await serveWithProfile();
+      const second = await serveWithProfile();
+
+      assertEquals(first.status, 200);
+      assertEquals(second.status, 200);
+      assertEquals(first.body, second.body);
+      assertEquals(first.cacheControl, "public, max-age=31536000, immutable");
+      assertEquals(second.cacheControl, "public, max-age=31536000, immutable");
       assertEquals(Boolean(first.record.phases["module.source_lookup"]), true);
       assertEquals(Boolean(first.record.phases["module.transform"]), true);
       assertEquals(second.record.phases["module.response_cache_hit"], 0);
@@ -769,6 +840,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
 
     async function serveWithProfile(): Promise<{
       body: string;
+      cacheControl: string | null;
       record: NonNullable<ReturnType<typeof finalizeRequestProfiling>>;
       status: number;
     }> {
@@ -795,6 +867,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
 
       return {
         body: await response.text(),
+        cacheControl: response.headers.get("cache-control"),
         record: record!,
         status: response.status,
       };
@@ -837,9 +910,13 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
       assertEquals(first.status, 200);
       assertEquals(second.status, 200);
       assertEquals(third.status, 200);
+      assertEquals(first.cacheControl, "no-cache");
+      assertEquals(second.cacheControl, "public, max-age=31536000, immutable");
+      assertEquals(third.cacheControl, "public, max-age=31536000, immutable");
       assertEquals(first.body.includes(`"/_vf/assets/${hash}.js"`), false);
       assertEquals(second.body.includes(`"/_vf/assets/${hash}.js"`), true);
       assertEquals(third.body, second.body);
+      assertEquals("module.response_cache_store" in first.record.phases, false);
       assertEquals(Boolean(second.record.phases["module.source_lookup"]), true);
       assertEquals("module.response_cache_hit" in second.record.phases, false);
       assertEquals(third.record.phases["module.response_cache_hit"], 0);

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -35,6 +35,7 @@ import { readLimitedCrossProjectSource } from "./cross-project-source-limit.ts";
 import { sha256Short } from "#veryfront/cache/hash.ts";
 import {
   getReleaseDependencyRewriteManifestState,
+  hasReleaseDependencyImportSpecifiers,
   rewriteReleaseDependencyImportsForModule,
 } from "#veryfront/release-assets/module-consumption.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
@@ -477,17 +478,16 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
         shouldCacheReleaseVersionedModule(url, options, isSSR);
       let releaseDependencyManifest: ReleaseAssetManifest | null = null;
       let releaseDependencyManifestVersion: number | null = null;
-      let releaseDependencyManifestReady = true;
+      let releaseDependencyManifestRequired = false;
       if (canCacheReleaseVersionedModule) {
         const manifestState = await getReleaseDependencyRewriteManifestState(options.releaseId);
         if (manifestState.enabled) {
           releaseDependencyManifest = manifestState.manifest;
           releaseDependencyManifestVersion = manifestState.manifest?.manifestVersion ?? null;
-          releaseDependencyManifestReady = manifestState.manifest !== null;
+          releaseDependencyManifestRequired = manifestState.manifest === null;
         }
       }
-      const releaseModuleResponseCacheKey = canCacheReleaseVersionedModule &&
-          releaseDependencyManifestReady
+      const releaseModuleResponseCacheKey = canCacheReleaseVersionedModule
         ? buildReleaseModuleResponseCacheKey({
           projectIdentity: effectiveProjectId,
           projectDir,
@@ -504,16 +504,21 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
       if (releaseModuleResponseCacheKey) {
         const cachedResponse = await getReleaseModuleResponse(releaseModuleResponseCacheKey);
         if (cachedResponse?.entry) {
-          markRequestProfilePhase("module.response_cache_hit");
-          if (cachedResponse.source === "distributed") {
-            markRequestProfilePhase("module.response_cache_distributed_hit");
+          const canUseCachedResponse = !releaseDependencyManifestRequired ||
+            !(await hasReleaseDependencyImportSpecifiers(cachedResponse.entry.body));
+          if (canUseCachedResponse) {
+            markRequestProfilePhase("module.response_cache_hit");
+            if (cachedResponse.source === "distributed") {
+              markRequestProfilePhase("module.response_cache_distributed_hit");
+            }
+            return createModuleResponse(
+              method,
+              cachedResponse.entry.body,
+              cachedResponse.entry.status,
+              Object.fromEntries(cachedResponse.entry.headers),
+            );
           }
-          return createModuleResponse(
-            method,
-            cachedResponse.entry.body,
-            cachedResponse.entry.status,
-            Object.fromEntries(cachedResponse.entry.headers),
-          );
+          markRequestProfilePhase("module.response_cache_manifest_blocked");
         }
         markRequestProfilePhase("module.response_cache_miss");
       }
@@ -635,15 +640,18 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
           }
         }
 
+        const canCacheModuleResponse = releaseModuleResponseCacheKey !== null &&
+          (!releaseDependencyManifestRequired ||
+            !(await hasReleaseDependencyImportSpecifiers(code)));
         const headers = getModuleHeaders(modulePath, {
-          cacheable: releaseModuleResponseCacheKey !== null,
+          cacheable: canCacheModuleResponse,
         });
         logger.debug("Request complete", {
           path: modulePath,
           durationMs: (performance.now() - startTime).toFixed(1),
         });
 
-        if (releaseModuleResponseCacheKey && method === "GET") {
+        if (canCacheModuleResponse && method === "GET") {
           void rememberReleaseModuleResponse(releaseModuleResponseCacheKey, {
             body: code,
             status: HTTP_OK,

--- a/src/release-assets/module-consumption.ts
+++ b/src/release-assets/module-consumption.ts
@@ -32,6 +32,26 @@ export function isReleaseDependencyImportMapRewriteEnabled(): boolean {
   return getHostEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG) === "1";
 }
 
+function isHttpImportSpecifier(specifier: string): boolean {
+  try {
+    const url = new URL(specifier);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export async function hasReleaseDependencyImportSpecifiers(code: string): Promise<boolean> {
+  if (!code.includes("http") && !code.includes("veryfront-http-bundle")) return false;
+
+  for (const imp of await parseImports(code)) {
+    if (!imp.n) continue;
+    if (isHttpImportSpecifier(imp.n) || localHttpBundlePath(imp.n)) return true;
+  }
+
+  return false;
+}
+
 export async function getReleaseDependencyRewriteManifestState(
   releaseId: string | null | undefined,
 ): Promise<ReleaseDependencyRewriteManifestState> {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.837";
+export const VERSION = "0.1.838";


### PR DESCRIPTION
## Summary
- allow release-versioned module responses to use immutable cache headers when the dependency manifest is absent but the transformed module has no dependency import specifiers that a future manifest could rewrite
- reject cached no-manifest module bodies if dependency imports are present, preserving the existing readiness gate for dependency-bearing modules
- bump runtime version to 0.1.838 for a new release

## Verification
- deno fmt --check deno.json src/utils/version-constant.ts src/release-assets/module-consumption.ts src/modules/server/module-server.ts src/modules/server/module-server.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/modules/server/module-server.test.ts src/release-assets/module-consumption.test.ts
- pre-push gate: format, lint, typecheck, generated assets, and unit suite passed (2172 tests)
