### PR TITLE
Recover immutable module caching for partial manifests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.838",
+  "version": "0.1.839",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -138,6 +138,42 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     };
   }
 
+  async function serveProductionModuleWithProfile(
+    request: Request,
+    projectDir: string,
+    releaseId: string,
+  ): Promise<{
+    body: string;
+    cacheControl: string | null;
+    record: NonNullable<ReturnType<typeof finalizeRequestProfiling>>;
+    status: number;
+  }> {
+    let record: ReturnType<typeof finalizeRequestProfiling> = null;
+    let profiledResponse: Response | undefined;
+    const response = await runWithRequestProfiling(
+      {
+        category: "module",
+        method: "GET",
+        pathname: "/_vf_modules/components/App.js",
+      },
+      async () => {
+        try {
+          profiledResponse = await serveProductionModule(request, projectDir, releaseId);
+          return profiledResponse;
+        } finally {
+          record = finalizeRequestProfiling(profiledResponse?.status);
+        }
+      },
+    );
+
+    return {
+      body: await response.text(),
+      cacheControl: response.headers.get("cache-control"),
+      record: record!,
+      status: response.status,
+    };
+  }
+
   it("should return 404 for non-module path prefix", async () => {
     const response = await serve(new Request("http://localhost:3000/not-a-module"));
 
@@ -786,6 +822,111 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
       const text = await response.text();
       assertEquals(text.includes(`"/_vf/assets/${hash}.js"`), true);
       assertEquals(text.includes("file://"), false);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(cacheDir, { recursive: true });
+    }
+  });
+
+  it("caches dependency-bearing release modules with partial manifest bodies", async () => {
+    setEnv("VERYFRONT_ENABLE_SERVER_TIMING", "1");
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-module-partial-manifest-" });
+    const cacheDir = await Deno.makeTempDir({ prefix: "vf-module-partial-cache-" });
+    const dependencyDir = `${cacheDir}/veryfront-http-bundle`;
+    const dependencyPath = `${dependencyDir}/http-123abc.mjs`;
+    const sourceUrl = "https://esm.sh/react@19.2.4?deps=csstype%403.2.3&target=es2022";
+    const hash = "c".repeat(64);
+    const releaseId = `release-partial-${crypto.randomUUID()}`;
+    const request = new Request(
+      `http://localhost:3000/_vf_modules/components/App.js?vf_release=${releaseId}&vf_runtime=${VERSION}`,
+    );
+
+    try {
+      await Deno.mkdir(dependencyDir, { recursive: true });
+      await Deno.writeTextFile(
+        dependencyPath,
+        `/*! @vf-source: ${sourceUrl} */\nexport default {};`,
+      );
+      await Deno.mkdir(`${projectDir}/components`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/components/App.tsx`,
+        `import React from ${JSON.stringify(`file://${dependencyPath}`)};\nexport default React;\n`,
+      );
+      configureReleaseAssetManifestFetcher(() =>
+        Promise.resolve({
+          state: "partial",
+          manifest: manifest({
+            [sourceUrl]: {
+              contentHash: hash,
+              size: 100,
+              contentType: "text/javascript",
+            },
+          }),
+        })
+      );
+
+      const first = await serveProductionModuleWithProfile(request, projectDir, releaseId);
+      const second = await serveProductionModuleWithProfile(request, projectDir, releaseId);
+
+      assertEquals(first.status, 200);
+      assertEquals(second.status, 200);
+      assertEquals(first.cacheControl, "public, max-age=31536000, immutable");
+      assertEquals(second.cacheControl, "public, max-age=31536000, immutable");
+      assertStringIncludes(first.body, `"/_vf/assets/${hash}.js"`);
+      assertEquals(first.body.includes("file://"), false);
+      assertEquals(second.body, first.body);
+      assertEquals(first.record.phases["release_manifest.fetch_partial"], 0);
+      assertEquals(second.record.phases["module.response_cache_hit"], 0);
+      assertEquals("module.source_lookup" in second.record.phases, false);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(cacheDir, { recursive: true });
+    }
+  });
+
+  it("keeps dependency-bearing release modules uncached when manifest rewrites miss", async () => {
+    setEnv("VERYFRONT_ENABLE_SERVER_TIMING", "1");
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-module-manifest-miss-" });
+    const cacheDir = await Deno.makeTempDir({ prefix: "vf-module-manifest-miss-cache-" });
+    const dependencyDir = `${cacheDir}/veryfront-http-bundle`;
+    const dependencyPath = `${dependencyDir}/http-123abc.mjs`;
+    const sourceUrl = "https://esm.sh/react@19.2.4?deps=csstype%403.2.3&target=es2022";
+    const releaseId = `release-manifest-miss-${crypto.randomUUID()}`;
+    const request = new Request(
+      `http://localhost:3000/_vf_modules/components/App.js?vf_release=${releaseId}&vf_runtime=${VERSION}`,
+    );
+
+    try {
+      await Deno.mkdir(dependencyDir, { recursive: true });
+      await Deno.writeTextFile(
+        dependencyPath,
+        `/*! @vf-source: ${sourceUrl} */\nexport default {};`,
+      );
+      await Deno.mkdir(`${projectDir}/components`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/components/App.tsx`,
+        `import React from ${JSON.stringify(`file://${dependencyPath}`)};\nexport default React;\n`,
+      );
+      configureReleaseAssetManifestFetcher(() =>
+        Promise.resolve({ state: "ready", manifest: manifest({}) })
+      );
+
+      const first = await serveProductionModuleWithProfile(request, projectDir, releaseId);
+      const second = await serveProductionModuleWithProfile(request, projectDir, releaseId);
+
+      assertEquals(first.status, 200);
+      assertEquals(second.status, 200);
+      assertEquals(first.cacheControl, "no-cache");
+      assertEquals(second.cacheControl, "no-cache");
+      assertEquals(first.body.includes(`"/_vf/assets/`), false);
+      assertEquals("module.response_cache_store" in first.record.phases, false);
+      assertEquals(first.record.phases["module.response_cache_dependency_blocked"], 0);
+      assertEquals("module.response_cache_hit" in second.record.phases, false);
+      assertEquals(Boolean(second.record.phases["module.source_lookup"]), true);
     } finally {
       await Deno.remove(projectDir, { recursive: true });
       await Deno.remove(cacheDir, { recursive: true });

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -478,13 +478,15 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
         shouldCacheReleaseVersionedModule(url, options, isSSR);
       let releaseDependencyManifest: ReleaseAssetManifest | null = null;
       let releaseDependencyManifestVersion: number | null = null;
-      let releaseDependencyManifestRequired = false;
+      let releaseDependencyRewriteEnabled = false;
       if (canCacheReleaseVersionedModule) {
-        const manifestState = await getReleaseDependencyRewriteManifestState(options.releaseId);
+        const manifestState = await getReleaseDependencyRewriteManifestState(options.releaseId, {
+          refreshCachedNull: true,
+        });
         if (manifestState.enabled) {
+          releaseDependencyRewriteEnabled = true;
           releaseDependencyManifest = manifestState.manifest;
           releaseDependencyManifestVersion = manifestState.manifest?.manifestVersion ?? null;
-          releaseDependencyManifestRequired = manifestState.manifest === null;
         }
       }
       const releaseModuleResponseCacheKey = canCacheReleaseVersionedModule
@@ -504,7 +506,7 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
       if (releaseModuleResponseCacheKey) {
         const cachedResponse = await getReleaseModuleResponse(releaseModuleResponseCacheKey);
         if (cachedResponse?.entry) {
-          const canUseCachedResponse = !releaseDependencyManifestRequired ||
+          const canUseCachedResponse = !releaseDependencyRewriteEnabled ||
             !(await hasReleaseDependencyImportSpecifiers(cachedResponse.entry.body));
           if (canUseCachedResponse) {
             markRequestProfilePhase("module.response_cache_hit");
@@ -518,7 +520,7 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
               Object.fromEntries(cachedResponse.entry.headers),
             );
           }
-          markRequestProfilePhase("module.response_cache_manifest_blocked");
+          markRequestProfilePhase("module.response_cache_dependency_blocked");
         }
         markRequestProfilePhase("module.response_cache_miss");
       }
@@ -633,16 +635,21 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
           if (!isSSR) {
             code = await rewriteReleaseDependencyImportsForModule(code, {
               releaseId: options.releaseId,
-              manifest: releaseDependencyManifest ?? undefined,
+              manifest: releaseDependencyRewriteEnabled ? releaseDependencyManifest : undefined,
+              manifestReadOptions: { refreshCachedNull: true },
               readDependencySource: (path) => platformFs.readTextFile(path),
             });
             code = await addReleaseVersionToFallbackImports(code, modulePath, options.releaseId);
           }
         }
 
+        const hasUnrewrittenReleaseDependencyImports = releaseDependencyRewriteEnabled &&
+          await hasReleaseDependencyImportSpecifiers(code);
         const canCacheModuleResponse = releaseModuleResponseCacheKey !== null &&
-          (!releaseDependencyManifestRequired ||
-            !(await hasReleaseDependencyImportSpecifiers(code)));
+          !hasUnrewrittenReleaseDependencyImports;
+        if (hasUnrewrittenReleaseDependencyImports) {
+          markRequestProfilePhase("module.response_cache_dependency_blocked");
+        }
         const headers = getModuleHeaders(modulePath, {
           cacheable: canCacheModuleResponse,
         });

--- a/src/release-assets/html-consumption.test.ts
+++ b/src/release-assets/html-consumption.test.ts
@@ -152,6 +152,25 @@ describe("manifest cache gating", () => {
     assertEquals(record?.phases["release_manifest.fetch_ready"], 0);
   });
 
+  it("uses partial manifests that include a manifest body", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
+    configureReleaseAssetManifestFetcher(() =>
+      Promise.resolve({ state: "partial", manifest: manifest() })
+    );
+
+    const record = await runWithRequestProfiling(
+      { category: "html", method: "GET", pathname: "/" },
+      async () => {
+        assertEquals((await getReadyManifestForRenderAsync("r"))?.manifestVersion, 3);
+        return finalizeRequestProfiling(200);
+      },
+    );
+
+    assertEquals(record?.phases["release_manifest.fetch_partial"], 0);
+    assertEquals(getReadyManifestForRender("r")?.manifestVersion, 3);
+  });
+
   it("marks manifest fetch failures during profiled async reads", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
@@ -221,6 +240,40 @@ describe("manifest cache gating", () => {
     assertEquals(firstReady?.manifestVersion, 3);
     assertEquals(secondReady?.manifestVersion, 3);
     assertEquals(fetchCount, 1);
+  });
+
+  it("revalidates cached non-ready entries on awaited refresh reads", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    let now = 1_000;
+    const originalDateNow = Date.now;
+    Date.now = () => now;
+
+    try {
+      let fetchCount = 0;
+      configureReleaseAssetManifestFetcher(async () => {
+        fetchCount++;
+        return fetchCount === 1
+          ? { state: "building", manifest: null }
+          : { state: "ready", manifest: manifest() };
+      });
+
+      assertEquals(await getReadyManifestForRenderAsync("r"), null);
+      assertEquals(fetchCount, 1);
+
+      now += 1_000;
+      assertEquals(await getReadyManifestForRenderAsync("r", { refreshCachedNull: true }), null);
+      assertEquals(fetchCount, 1);
+
+      now += 5_000;
+      assertEquals(
+        (await getReadyManifestForRenderAsync("r", { refreshCachedNull: true }))
+          ?.manifestVersion,
+        3,
+      );
+      assertEquals(fetchCount, 2);
+    } finally {
+      Date.now = originalDateNow;
+    }
   });
 
   it("ignores stale in-flight manifest fetches after the cache is cleared", async () => {

--- a/src/release-assets/manifest-cache.ts
+++ b/src/release-assets/manifest-cache.ts
@@ -40,6 +40,8 @@ const logger = serverLogger.component("release-asset-manifest");
 const MAX_CACHED_MANIFESTS = 500;
 /** Short TTL for non-ready / missing results (ms). */
 const NON_READY_TTL_MS = 30_000;
+/** Minimum delay before an awaited consumer can retry a cached non-ready result. */
+const NON_READY_REVALIDATE_MS = 5_000;
 /** TTL for ready manifests — long but finite so superseded entries are picked up (15 min). */
 const READY_TTL_MS = 15 * 60 * 1000;
 /** Background revalidation interval for ready manifests (1 min). */
@@ -60,6 +62,15 @@ interface InFlightFetch {
   generation: number;
   token: symbol;
   promise: Promise<ReleaseAssetManifest | null>;
+}
+
+export interface ReadyManifestReadOptions {
+  /**
+   * Retry a cached non-ready result after a short throttle instead of waiting
+   * for the full null TTL. Used by module responses that cannot be cached
+   * safely until dependency imports can be rewritten through the manifest.
+   */
+  refreshCachedNull?: boolean;
 }
 
 /** In-flight fetches, deduped per releaseId. */
@@ -219,6 +230,7 @@ export function getReadyManifestForRender(
  */
 export async function getReadyManifestForRenderAsync(
   releaseId: string | null | undefined,
+  options: ReadyManifestReadOptions = {},
 ): Promise<ReleaseAssetManifest | null> {
   if (!releaseId) {
     markManifestDecision("no_release_id");
@@ -240,8 +252,14 @@ export async function getReadyManifestForRenderAsync(
     return best.manifest;
   }
 
+  const now = Date.now();
   const plain = manifestCache.get(releaseId);
-  if (plain && plain.expiresAt > Date.now()) {
+  if (plain && plain.expiresAt > now) {
+    if (options.refreshCachedNull && (plain.refreshAfter ?? plain.expiresAt) <= now) {
+      markManifestDecision("cached_null_refresh");
+      return await fetchManifest(releaseId);
+    }
+
     markManifestDecision("cached_null");
     return null;
   }
@@ -274,16 +292,17 @@ function fetchManifest(releaseId: string): Promise<ReleaseAssetManifest | null> 
 
       if (!result) {
         markManifestDecision("fetch_missing");
-        manifestCache.set(releaseId, { manifest: null, expiresAt: Date.now() + NON_READY_TTL_MS });
+        cacheNonReadyManifest(releaseId);
         return null;
       }
 
-      const manifest = result.state === "ready" && result.manifest
+      const manifestState = normalizeManifestState(result.state);
+      const manifest = isUsableManifestState(result.state) && result.manifest
         ? parseReleaseAssetManifest(result.manifest)
         : null;
 
       if (manifest) {
-        markManifestDecision("fetch_ready");
+        markManifestDecision(manifestState === "partial" ? "fetch_partial" : "fetch_ready");
         const key = cacheKey(releaseId, manifest.manifestVersion);
         manifestCache.set(key, {
           manifest,
@@ -293,16 +312,15 @@ function fetchManifest(releaseId: string): Promise<ReleaseAssetManifest | null> 
         logger.debug("Cached ready manifest", {
           releaseId,
           manifestVersion: manifest.manifestVersion,
+          state: result.state,
           ttlMs: READY_TTL_MS,
           refreshMs: READY_REVALIDATE_MS,
         });
         return manifest;
       } else {
+        markManifestDecision(`fetch_${manifestState}`);
         markManifestDecision("fetch_not_ready");
-        manifestCache.set(releaseId, {
-          manifest: null,
-          expiresAt: Date.now() + NON_READY_TTL_MS,
-        });
+        cacheNonReadyManifest(releaseId);
         return null;
       }
     } catch (error) {
@@ -312,7 +330,7 @@ function fetchManifest(releaseId: string): Promise<ReleaseAssetManifest | null> 
       });
       if (fetchGeneration !== cacheGeneration) return null;
       markManifestDecision("fetch_failed");
-      manifestCache.set(releaseId, { manifest: null, expiresAt: Date.now() + NON_READY_TTL_MS });
+      cacheNonReadyManifest(releaseId);
       return null;
     } finally {
       const current = inFlight.get(releaseId);
@@ -324,6 +342,23 @@ function fetchManifest(releaseId: string): Promise<ReleaseAssetManifest | null> 
 
   inFlight.set(releaseId, { generation: fetchGeneration, token, promise });
   return promise;
+}
+
+function isUsableManifestState(state: string): boolean {
+  return state === "ready" || state === "partial";
+}
+
+function normalizeManifestState(state: string): string {
+  return state.toLowerCase().replace(/[^a-z0-9_]/g, "_").slice(0, 32) || "unknown";
+}
+
+function cacheNonReadyManifest(releaseId: string): void {
+  const now = Date.now();
+  manifestCache.set(releaseId, {
+    manifest: null,
+    expiresAt: now + NON_READY_TTL_MS,
+    refreshAfter: now + NON_READY_REVALIDATE_MS,
+  });
 }
 
 /** Clear cached manifest bodies while keeping registered fetchers intact. */

--- a/src/release-assets/module-consumption.ts
+++ b/src/release-assets/module-consumption.ts
@@ -14,13 +14,14 @@ import { normalizeHttpUrl } from "#veryfront/transforms/esm/http-cache.ts";
 import { parseImports, replaceSpecifiers } from "#veryfront/transforms/esm/lexer.ts";
 import { extractSourceUrl } from "#veryfront/transforms/esm/source-url-embed.ts";
 import { RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, releaseAssetUrl } from "./constants.ts";
-import { getReadyManifestForRenderAsync } from "./manifest-cache.ts";
+import { getReadyManifestForRenderAsync, type ReadyManifestReadOptions } from "./manifest-cache.ts";
 import type { ReleaseAssetManifest } from "./manifest-schema.ts";
 
 export interface RewriteReleaseDependencyImportsOptions {
   releaseId?: string | null;
   readDependencySource: (path: string) => Promise<string>;
   manifest?: ReleaseAssetManifest | null;
+  manifestReadOptions?: ReadyManifestReadOptions;
 }
 
 export interface ReleaseDependencyRewriteManifestState {
@@ -54,6 +55,7 @@ export async function hasReleaseDependencyImportSpecifiers(code: string): Promis
 
 export async function getReleaseDependencyRewriteManifestState(
   releaseId: string | null | undefined,
+  options: ReadyManifestReadOptions = {},
 ): Promise<ReleaseDependencyRewriteManifestState> {
   if (!releaseId || !isReleaseDependencyImportMapRewriteEnabled()) {
     return { enabled: false, manifest: null };
@@ -61,7 +63,7 @@ export async function getReleaseDependencyRewriteManifestState(
 
   return {
     enabled: true,
-    manifest: await getReadyManifestForRenderAsync(releaseId),
+    manifest: await getReadyManifestForRenderAsync(releaseId, options),
   };
 }
 
@@ -124,7 +126,7 @@ export async function rewriteReleaseDependencyImportsForModule(
 
   const manifest = options.manifest !== undefined
     ? options.manifest
-    : await getReadyManifestForRenderAsync(options.releaseId);
+    : await getReadyManifestForRenderAsync(options.releaseId, options.manifestReadOptions);
   if (!manifest || Object.keys(manifest.dependencies).length === 0) return code;
 
   const replacements = new Map<string, string>();

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.838";
+export const VERSION = "0.1.839";


### PR DESCRIPTION
## Summary
- Treat release asset manifests in `partial` state as usable when the API returns a valid manifest body, so dependency import rewrites can recover on releases with fallback gaps.
- Add a short throttled async revalidation path for cached non-ready manifest reads used by module serving.
- Block immutable release module response caching whenever dependency imports remain after rewrite.
- Bump Veryfront to `0.1.839` for a fresh release.

## Production context
Live `codersociety.com/_vf_modules/pages/blog.js?vf_release=...&vf_runtime=0.1.838` is still served as `cache-control: no-cache` with `release_manifest.cached_null`, so source lookup and transform run on repeated requests.

## Verification
- `deno fmt --check deno.json src/utils/version-constant.ts src/release-assets/manifest-cache.ts src/release-assets/module-consumption.ts src/release-assets/html-consumption.test.ts src/modules/server/module-server.ts src/modules/server/module-server.test.ts`
- `deno lint src/release-assets/manifest-cache.ts src/release-assets/module-consumption.ts src/release-assets/html-consumption.test.ts src/modules/server/module-server.ts src/modules/server/module-server.test.ts src/utils/version-constant.ts`
- `deno check src/release-assets/manifest-cache.ts src/release-assets/module-consumption.ts src/modules/server/module-server.ts`
- `deno test --no-check --allow-all src/utils/version.test.ts src/release-assets/html-consumption.test.ts src/release-assets/module-consumption.test.ts src/modules/server/module-server.test.ts`
- Pre-push hook: format, lint, type check, unit tests: `2172 passed`
