### PR TITLE
Route Mistral through Veryfront Cloud

### DIFF
--- a/cli/templates/integrations/mistral/connector.json
+++ b/cli/templates/integrations/mistral/connector.json
@@ -61,7 +61,7 @@
           "model": {
             "type": "string",
             "in": "path",
-            "description": "Model ID, e.g. mistral-large-latest or mistral-small-latest",
+            "description": "Model ID, e.g. mistral-large-2512 or mistral-small-2603",
             "required": true
           }
         }
@@ -78,7 +78,7 @@
         "body": {
           "model": {
             "type": "string",
-            "description": "Model ID to use, e.g. mistral-large-latest",
+            "description": "Model ID to use, e.g. mistral-large-2512",
             "required": true
           },
           "messages": {

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -65,6 +65,7 @@ Set only the variables for the provider you use:
 - `OPENAI_API_KEY` for OpenAI.
 - `ANTHROPIC_API_KEY` for Anthropic.
 - `GOOGLE_API_KEY` for Google.
+- `MISTRAL_API_KEY` for Mistral when requests route through Veryfront Cloud AI Gateway.
 - `OPENAI_BASE_URL` for OpenAI-compatible services.
 
 Explicit provider env vars still work when you want to pin a provider directly:
@@ -76,6 +77,7 @@ export default agent({
   model: "openai/gpt-5.5", // OpenAI
   // model: "anthropic/claude-sonnet-4-6", // Anthropic
   // model: "google/gemini-3.5-flash",     // Google
+  // model: "veryfront-cloud/mistral/mistral-large-latest", // Mistral through AI Gateway
   system: "You are a helpful assistant.",
 });
 ```
@@ -117,6 +119,7 @@ Agents reference models as `"provider/model"`. The framework splits on the first
 ```ts
 // Veryfront Cloud explicit override
 agent({ model: "veryfront-cloud/openai/gpt-5.5" });
+agent({ model: "veryfront-cloud/mistral/mistral-large-latest" });
 
 // Direct provider override
 agent({ model: "openai/gpt-5.5" });

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -65,7 +65,7 @@ Set only the variables for the provider you use:
 - `OPENAI_API_KEY` for OpenAI.
 - `ANTHROPIC_API_KEY` for Anthropic.
 - `GOOGLE_API_KEY` for Google.
-- `MISTRAL_API_KEY` for Mistral when requests route through Veryfront Cloud AI Gateway.
+- `MISTRAL_API_KEY` for direct Mistral requests. Without this key, hosted Mistral models route through Veryfront Cloud when cloud bootstrap is available.
 - `OPENAI_BASE_URL` for OpenAI-compatible services.
 
 Explicit provider env vars still work when you want to pin a provider directly:
@@ -77,7 +77,7 @@ export default agent({
   model: "openai/gpt-5.5", // OpenAI
   // model: "anthropic/claude-sonnet-4-6", // Anthropic
   // model: "google/gemini-3.5-flash",     // Google
-  // model: "veryfront-cloud/mistral/mistral-large-latest", // Mistral through AI Gateway
+  // model: "veryfront-cloud/mistral/mistral-large-2512", // Mistral through AI Gateway
   system: "You are a helpful assistant.",
 });
 ```
@@ -119,7 +119,7 @@ Agents reference models as `"provider/model"`. The framework splits on the first
 ```ts
 // Veryfront Cloud explicit override
 agent({ model: "veryfront-cloud/openai/gpt-5.5" });
-agent({ model: "veryfront-cloud/mistral/mistral-large-latest" });
+agent({ model: "veryfront-cloud/mistral/mistral-large-2512" });
 
 // Direct provider override
 agent({ model: "openai/gpt-5.5" });

--- a/src/agent/runtime/constants.test.ts
+++ b/src/agent/runtime/constants.test.ts
@@ -23,8 +23,8 @@ describe("getModelMaxOutputTokens", () => {
   });
 
   it("returns known limits for Mistral models", () => {
-    assertEquals(getModelMaxOutputTokens("mistral/mistral-large-latest"), 131_072);
-    assertEquals(getModelMaxOutputTokens("veryfront-cloud/mistral/codestral-latest"), 256_000);
+    assertEquals(getModelMaxOutputTokens("mistral/mistral-large-2512"), 131_072);
+    assertEquals(getModelMaxOutputTokens("veryfront-cloud/mistral/mistral-medium-3-5"), 131_072);
   });
 
   it("returns undefined for unknown models", () => {

--- a/src/agent/runtime/constants.test.ts
+++ b/src/agent/runtime/constants.test.ts
@@ -22,6 +22,11 @@ describe("getModelMaxOutputTokens", () => {
     assertEquals(getModelMaxOutputTokens("google/gemini-3.5-flash"), 65_536);
   });
 
+  it("returns known limits for Mistral models", () => {
+    assertEquals(getModelMaxOutputTokens("mistral/mistral-large-latest"), 131_072);
+    assertEquals(getModelMaxOutputTokens("veryfront-cloud/mistral/codestral-latest"), 256_000);
+  });
+
   it("returns undefined for unknown models", () => {
     assertEquals(getModelMaxOutputTokens("unknown/model"), undefined);
   });

--- a/src/agent/runtime/constants.ts
+++ b/src/agent/runtime/constants.ts
@@ -19,10 +19,9 @@ const MODEL_MAX_OUTPUT_TOKENS: Record<string, number> = {
   "google-ai-studio/gemini-3.1-flash-lite": 65_536,
   "google-ai-studio/gemini-2.5-pro": 65_536,
   "google-ai-studio/gemini-2.5-flash": 65_536,
-  "mistral/mistral-large-latest": 131_072,
-  "mistral/mistral-medium-latest": 131_072,
-  "mistral/mistral-small-latest": 131_072,
-  "mistral/codestral-latest": 256_000,
+  "mistral/mistral-large-2512": 131_072,
+  "mistral/mistral-medium-3-5": 131_072,
+  "mistral/mistral-small-2603": 131_072,
 };
 
 const MODEL_MAX_OUTPUT_TOKEN_ALIASES: Record<string, string> = {

--- a/src/agent/runtime/constants.ts
+++ b/src/agent/runtime/constants.ts
@@ -19,6 +19,10 @@ const MODEL_MAX_OUTPUT_TOKENS: Record<string, number> = {
   "google-ai-studio/gemini-3.1-flash-lite": 65_536,
   "google-ai-studio/gemini-2.5-pro": 65_536,
   "google-ai-studio/gemini-2.5-flash": 65_536,
+  "mistral/mistral-large-latest": 131_072,
+  "mistral/mistral-medium-latest": 131_072,
+  "mistral/mistral-small-latest": 131_072,
+  "mistral/codestral-latest": 256_000,
 };
 
 const MODEL_MAX_OUTPUT_TOKEN_ALIASES: Record<string, string> = {

--- a/src/agent/runtime/model-resolution.test.ts
+++ b/src/agent/runtime/model-resolution.test.ts
@@ -88,6 +88,10 @@ describe("agent/runtime/model-resolution", () => {
       resolveConfiguredAgentModel("kimi-k2.6"),
       "moonshotai/kimi-k2.6",
     );
+    assertEquals(
+      resolveConfiguredAgentModel("mistral-large"),
+      "mistral/mistral-large-latest",
+    );
   });
 
   it("upgrades auto/local models to the default Veryfront cloud model when bootstrap is present", () => {
@@ -125,6 +129,10 @@ describe("agent/runtime/model-resolution", () => {
     assertEquals(
       resolveRuntimeModel("kimi-k2.6"),
       "veryfront-cloud/moonshotai/kimi-k2.6",
+    );
+    assertEquals(
+      resolveRuntimeModel("mistral-large"),
+      "veryfront-cloud/mistral/mistral-large-latest",
     );
   });
 

--- a/src/agent/runtime/model-resolution.test.ts
+++ b/src/agent/runtime/model-resolution.test.ts
@@ -13,6 +13,7 @@ const MODEL_ENV_KEYS = [
   "ANTHROPIC_API_KEY",
   "GOOGLE_API_KEY",
   "GOOGLE_GENERATIVE_AI_API_KEY",
+  "MISTRAL_API_KEY",
   "OPENAI_API_KEY",
   "VERYFRONT_API_TOKEN",
   "VERYFRONT_DEFAULT_MODEL",
@@ -90,7 +91,7 @@ describe("agent/runtime/model-resolution", () => {
     );
     assertEquals(
       resolveConfiguredAgentModel("mistral-large"),
-      "mistral/mistral-large-latest",
+      "mistral/mistral-large-2512",
     );
   });
 
@@ -132,7 +133,18 @@ describe("agent/runtime/model-resolution", () => {
     );
     assertEquals(
       resolveRuntimeModel("mistral-large"),
-      "veryfront-cloud/mistral/mistral-large-latest",
+      "veryfront-cloud/mistral/mistral-large-2512",
+    );
+  });
+
+  it("routes explicit Mistral models through the direct provider when native credentials are configured", () => {
+    setEnv("VERYFRONT_API_TOKEN", "vf_test_runtime");
+    setEnv("VERYFRONT_PROJECT_SLUG", "demo-project");
+    setEnv("MISTRAL_API_KEY", "mistral-test");
+
+    assertEquals(
+      resolveRuntimeModel("mistral-large"),
+      "mistral/mistral-large-2512",
     );
   });
 

--- a/src/agent/runtime/model-resolution.ts
+++ b/src/agent/runtime/model-resolution.ts
@@ -13,6 +13,7 @@ const HOSTED_PROVIDER_NAMES = new Set([
   "anthropic",
   "google",
   "google-ai-studio",
+  "mistral",
   "moonshotai",
   "openai",
 ]);
@@ -46,6 +47,14 @@ const LEGACY_MODEL_ALIASES: Record<string, string> = {
   "gemini-2.5-flash": "google-ai-studio/gemini-2.5-flash",
   "kimi-k2.6": "moonshotai/kimi-k2.6",
   "kimi-k2.5": "moonshotai/kimi-k2.5",
+  "mistral-large": "mistral/mistral-large-latest",
+  "mistral-large-latest": "mistral/mistral-large-latest",
+  "mistral-medium": "mistral/mistral-medium-latest",
+  "mistral-medium-latest": "mistral/mistral-medium-latest",
+  "mistral-small": "mistral/mistral-small-latest",
+  "mistral-small-latest": "mistral/mistral-small-latest",
+  codestral: "mistral/codestral-latest",
+  "codestral-latest": "mistral/codestral-latest",
 };
 
 export function normalizeAgentModelConfig(model?: string): string {

--- a/src/agent/runtime/model-resolution.ts
+++ b/src/agent/runtime/model-resolution.ts
@@ -1,6 +1,7 @@
 import {
   getAnthropicEnvConfig,
   getGoogleGenAIEnvConfig,
+  getMistralEnvConfig,
   getOpenAIEnvConfig,
 } from "#veryfront/config/env.ts";
 import { findAvailableCloudModel } from "#veryfront/provider";
@@ -47,14 +48,12 @@ const LEGACY_MODEL_ALIASES: Record<string, string> = {
   "gemini-2.5-flash": "google-ai-studio/gemini-2.5-flash",
   "kimi-k2.6": "moonshotai/kimi-k2.6",
   "kimi-k2.5": "moonshotai/kimi-k2.5",
-  "mistral-large": "mistral/mistral-large-latest",
-  "mistral-large-latest": "mistral/mistral-large-latest",
-  "mistral-medium": "mistral/mistral-medium-latest",
-  "mistral-medium-latest": "mistral/mistral-medium-latest",
-  "mistral-small": "mistral/mistral-small-latest",
-  "mistral-small-latest": "mistral/mistral-small-latest",
-  codestral: "mistral/codestral-latest",
-  "codestral-latest": "mistral/codestral-latest",
+  "mistral-large": "mistral/mistral-large-2512",
+  "mistral-large-2512": "mistral/mistral-large-2512",
+  "mistral-medium": "mistral/mistral-medium-3-5",
+  "mistral-medium-3-5": "mistral/mistral-medium-3-5",
+  "mistral-small": "mistral/mistral-small-2603",
+  "mistral-small-2603": "mistral/mistral-small-2603",
 };
 
 export function normalizeAgentModelConfig(model?: string): string {
@@ -81,6 +80,8 @@ function hasDirectProviderCredentials(provider: string): boolean {
       return Boolean(getAnthropicEnvConfig().apiKey);
     case "google":
       return Boolean(getGoogleGenAIEnvConfig().apiKey);
+    case "mistral":
+      return Boolean(getMistralEnvConfig().apiKey);
     case "openai":
       return Boolean(getOpenAIEnvConfig().apiKey);
     default:

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -113,6 +113,16 @@ export function getGoogleGenAIEnvConfig(): {
   return { apiKey: getEnv("GOOGLE_API_KEY") || getEnv("GOOGLE_GENERATIVE_AI_API_KEY") };
 }
 
+export function getMistralEnvConfig(): {
+  apiKey?: string;
+  baseURL?: string;
+} {
+  return {
+    apiKey: getEnv("MISTRAL_API_KEY"),
+    baseURL: getEnv("MISTRAL_BASE_URL") || "https://api.mistral.ai/v1",
+  };
+}
+
 export function isDebugEnvEnabled(env: EnvironmentConfig = getEnvironmentConfig()): boolean {
   return env.debug;
 }

--- a/src/integrations/_data.ts
+++ b/src/integrations/_data.ts
@@ -33861,7 +33861,7 @@ export const connectors: IntegrationConfig[] = [
           "model": {
             "type": "string",
             "in": "path",
-            "description": "Model ID, e.g. mistral-large-latest or mistral-small-latest",
+            "description": "Model ID, e.g. mistral-large-2512 or mistral-small-2603",
             "required": true,
           },
         },
@@ -33877,7 +33877,7 @@ export const connectors: IntegrationConfig[] = [
         "body": {
           "model": {
             "type": "string",
-            "description": "Model ID to use, e.g. mistral-large-latest",
+            "description": "Model ID to use, e.g. mistral-large-2512",
             "required": true,
           },
           "messages": {

--- a/src/provider/model-registry.ts
+++ b/src/provider/model-registry.ts
@@ -17,6 +17,7 @@ import { createError, fromError, toError } from "#veryfront/errors/veryfront-err
 import {
   getAnthropicEnvConfig,
   getGoogleGenAIEnvConfig,
+  getMistralEnvConfig,
   getOpenAIEnvConfig,
 } from "#veryfront/config/env.ts";
 import { ensureBuiltinLLMProviders } from "#veryfront/extensions/builtin-extensions.ts";
@@ -162,6 +163,34 @@ function autoInitializeFromEnv(): void {
             "Google provider not installed. Add @veryfront/ext-llm-google to use google/* models.",
         }),
       );
+    });
+  }
+
+  if (!manager.has("mistral")) {
+    manager.registerShared("mistral", (id) => {
+      const config = getMistralEnvConfig();
+      if (!config.apiKey) {
+        throw toError(
+          createError({
+            type: "config",
+            message:
+              "MISTRAL_API_KEY not set. Set the environment variable or register a custom provider with registerModelProvider().",
+          }),
+        );
+      }
+      const registry = ensureBuiltinLLMProviders();
+      const provider = registry.get("openai");
+      if (provider) {
+        return provider.createModel(id, {
+          credential: config.apiKey,
+          baseURL: config.baseURL,
+        });
+      }
+      throw toError(createError({
+        type: "config",
+        message:
+          "OpenAI-compatible provider not installed. Add @veryfront/ext-llm-openai to use mistral/* models.",
+      }));
     });
   }
 

--- a/src/provider/veryfront-cloud/model-catalog.test.ts
+++ b/src/provider/veryfront-cloud/model-catalog.test.ts
@@ -25,6 +25,7 @@ describe("provider/veryfront-cloud/model-catalog", () => {
     assertEquals(findVeryfrontCloudModel("gemini-3.1-pro-preview")?.provider, "google");
     assertEquals(findVeryfrontCloudModel("gemini-3.5-flash")?.provider, "google");
     assertEquals(findVeryfrontCloudModel("kimi-k2.6")?.provider, "moonshotai");
+    assertEquals(findVeryfrontCloudModel("mistral-large")?.provider, "mistral");
     assertEquals(findVeryfrontCloudModel("nonexistent"), undefined);
   });
 
@@ -36,6 +37,7 @@ describe("provider/veryfront-cloud/model-catalog", () => {
       "google",
     );
     assertEquals(getVeryfrontCloudProviderFromModelId("moonshotai/kimi-k2.6"), "moonshotai");
+    assertEquals(getVeryfrontCloudProviderFromModelId("mistral/mistral-large-latest"), "mistral");
     assertThrows(
       () => getVeryfrontCloudProviderFromModelId("unknown/model"),
       Error,
@@ -67,6 +69,7 @@ describe("provider/veryfront-cloud/model-catalog", () => {
       "openai",
       "google",
       "moonshotai",
+      "mistral",
     ]);
     assertEquals(groups[0]?.label, "Anthropic");
     assertEquals(groups[1]?.label, "OpenAI");
@@ -78,6 +81,7 @@ describe("provider/veryfront-cloud/model-catalog", () => {
   it("resolves aliases and preserves direct model ids", () => {
     assertEquals(resolveVeryfrontCloudModelId("opus"), "anthropic/claude-opus-4-8");
     assertEquals(resolveVeryfrontCloudModelId("gpt-5.5"), "openai/gpt-5.5");
+    assertEquals(resolveVeryfrontCloudModelId("mistral-large"), "mistral/mistral-large-latest");
     assertEquals(resolveVeryfrontCloudModelId("openai/gpt-5.5"), "openai/gpt-5.5");
     assertThrows(
       () => resolveVeryfrontCloudModelId("not-a-real-model"),
@@ -118,6 +122,10 @@ describe("provider/veryfront-cloud/model-catalog", () => {
     assertEquals(
       resolveHostedVeryfrontCloudModelId("openai/gpt-5.5"),
       "veryfront-cloud/openai/gpt-5.5",
+    );
+    assertEquals(
+      resolveHostedVeryfrontCloudModelId("mistral/mistral-large-latest"),
+      "veryfront-cloud/mistral/mistral-large-latest",
     );
   });
 

--- a/src/provider/veryfront-cloud/model-catalog.test.ts
+++ b/src/provider/veryfront-cloud/model-catalog.test.ts
@@ -37,7 +37,7 @@ describe("provider/veryfront-cloud/model-catalog", () => {
       "google",
     );
     assertEquals(getVeryfrontCloudProviderFromModelId("moonshotai/kimi-k2.6"), "moonshotai");
-    assertEquals(getVeryfrontCloudProviderFromModelId("mistral/mistral-large-latest"), "mistral");
+    assertEquals(getVeryfrontCloudProviderFromModelId("mistral/mistral-large-2512"), "mistral");
     assertThrows(
       () => getVeryfrontCloudProviderFromModelId("unknown/model"),
       Error,
@@ -81,7 +81,7 @@ describe("provider/veryfront-cloud/model-catalog", () => {
   it("resolves aliases and preserves direct model ids", () => {
     assertEquals(resolveVeryfrontCloudModelId("opus"), "anthropic/claude-opus-4-8");
     assertEquals(resolveVeryfrontCloudModelId("gpt-5.5"), "openai/gpt-5.5");
-    assertEquals(resolveVeryfrontCloudModelId("mistral-large"), "mistral/mistral-large-latest");
+    assertEquals(resolveVeryfrontCloudModelId("mistral-large"), "mistral/mistral-large-2512");
     assertEquals(resolveVeryfrontCloudModelId("openai/gpt-5.5"), "openai/gpt-5.5");
     assertThrows(
       () => resolveVeryfrontCloudModelId("not-a-real-model"),
@@ -124,8 +124,8 @@ describe("provider/veryfront-cloud/model-catalog", () => {
       "veryfront-cloud/openai/gpt-5.5",
     );
     assertEquals(
-      resolveHostedVeryfrontCloudModelId("mistral/mistral-large-latest"),
-      "veryfront-cloud/mistral/mistral-large-latest",
+      resolveHostedVeryfrontCloudModelId("mistral/mistral-large-2512"),
+      "veryfront-cloud/mistral/mistral-large-2512",
     );
   });
 

--- a/src/provider/veryfront-cloud/model-catalog.ts
+++ b/src/provider/veryfront-cloud/model-catalog.ts
@@ -85,31 +85,24 @@ export const VERYFRONT_CLOUD_CHAT_MODELS: VeryfrontCloudChatModel[] = [
   },
   {
     id: "mistral-large",
-    modelId: "mistral/mistral-large-latest",
+    modelId: "mistral/mistral-large-2512",
     provider: "mistral",
-    name: "Mistral Large",
-    description: "Most capable Mistral model",
+    name: "Mistral Large 3",
+    description: "Flagship multimodal Mistral model",
   },
   {
     id: "mistral-medium",
-    modelId: "mistral/mistral-medium-latest",
+    modelId: "mistral/mistral-medium-3-5",
     provider: "mistral",
-    name: "Mistral Medium",
+    name: "Mistral Medium 3.5",
     description: "Balanced Mistral model for agentic and coding tasks",
   },
   {
     id: "mistral-small",
-    modelId: "mistral/mistral-small-latest",
+    modelId: "mistral/mistral-small-2603",
     provider: "mistral",
-    name: "Mistral Small",
+    name: "Mistral Small 4",
     description: "Fast Mistral model for lightweight tasks",
-  },
-  {
-    id: "codestral",
-    modelId: "mistral/codestral-latest",
-    provider: "mistral",
-    name: "Codestral",
-    description: "Mistral code generation model",
   },
 ];
 

--- a/src/provider/veryfront-cloud/model-catalog.ts
+++ b/src/provider/veryfront-cloud/model-catalog.ts
@@ -27,6 +27,7 @@ const VERYFRONT_CLOUD_GATEWAY_MODEL_PROVIDER_PREFIXES = [
   "google/",
   "google-ai-studio/",
   "moonshotai/",
+  "mistral/",
 ];
 
 /** Shared Veryfront Cloud chat models value. */
@@ -82,6 +83,34 @@ export const VERYFRONT_CLOUD_CHAT_MODELS: VeryfrontCloudChatModel[] = [
     name: "Kimi K2.6",
     description: "Deep thinking and multimodal",
   },
+  {
+    id: "mistral-large",
+    modelId: "mistral/mistral-large-latest",
+    provider: "mistral",
+    name: "Mistral Large",
+    description: "Most capable Mistral model",
+  },
+  {
+    id: "mistral-medium",
+    modelId: "mistral/mistral-medium-latest",
+    provider: "mistral",
+    name: "Mistral Medium",
+    description: "Balanced Mistral model for agentic and coding tasks",
+  },
+  {
+    id: "mistral-small",
+    modelId: "mistral/mistral-small-latest",
+    provider: "mistral",
+    name: "Mistral Small",
+    description: "Fast Mistral model for lightweight tasks",
+  },
+  {
+    id: "codestral",
+    modelId: "mistral/codestral-latest",
+    provider: "mistral",
+    name: "Codestral",
+    description: "Mistral code generation model",
+  },
 ];
 
 /** Find Veryfront Cloud model. */
@@ -111,7 +140,12 @@ export function getVeryfrontCloudProviderFromModelId(
   const normalizedModelId = normalizeVeryfrontCloudModelId(modelId);
   const prefix = normalizedModelId.split("/")[0];
   if (prefix === "google-ai-studio") return "google";
-  if (prefix === "openai" || prefix === "anthropic" || prefix === "moonshotai") return prefix;
+  if (
+    prefix === "openai" ||
+    prefix === "anthropic" ||
+    prefix === "moonshotai" ||
+    prefix === "mistral"
+  ) return prefix;
 
   throw new Error(`Unknown model provider prefix "${prefix}" in model ID "${modelId}"`);
 }
@@ -218,9 +252,16 @@ const PROVIDER_LABELS: Record<VeryfrontCloudProviderId, string> = {
   openai: "OpenAI",
   google: "Google",
   moonshotai: "Kimi",
+  mistral: "Mistral",
 };
 
-const PROVIDER_ORDER: VeryfrontCloudProviderId[] = ["anthropic", "openai", "google", "moonshotai"];
+const PROVIDER_ORDER: VeryfrontCloudProviderId[] = [
+  "anthropic",
+  "openai",
+  "google",
+  "moonshotai",
+  "mistral",
+];
 
 /** Group Veryfront Cloud models by provider. */
 export function groupVeryfrontCloudModelsByProvider(): Array<{

--- a/src/provider/veryfront-cloud/provider.test.ts
+++ b/src/provider/veryfront-cloud/provider.test.ts
@@ -54,6 +54,18 @@ describe("provider/veryfront-cloud", () => {
     assertEquals(typeof model.doStream, "function");
   });
 
+  it("resolves veryfront-cloud mistral models without a project-specific Mistral extension", () => {
+    setCloudBootstrap();
+
+    const model = resolveModel("veryfront-cloud/mistral/mistral-large-latest") as Record<
+      string,
+      unknown
+    >;
+
+    assertEquals(typeof model.doGenerate, "function");
+    assertEquals(typeof model.doStream, "function");
+  });
+
   it("resolves veryfront-cloud anthropic models without project ext-llm-anthropic installed", () => {
     setCloudBootstrap();
 

--- a/src/provider/veryfront-cloud/provider.test.ts
+++ b/src/provider/veryfront-cloud/provider.test.ts
@@ -12,6 +12,7 @@ const CLOUD_ENV_KEYS = [
   "VERYFRONT_SERVICE_LAYER",
   "ANTHROPIC_API_KEY",
   "GOOGLE_API_KEY",
+  "MISTRAL_API_KEY",
 ] as const;
 
 function clearCloudEnv(): void {
@@ -57,7 +58,7 @@ describe("provider/veryfront-cloud", () => {
   it("resolves veryfront-cloud mistral models without a project-specific Mistral extension", () => {
     setCloudBootstrap();
 
-    const model = resolveModel("veryfront-cloud/mistral/mistral-large-latest") as Record<
+    const model = resolveModel("veryfront-cloud/mistral/mistral-large-2512") as Record<
       string,
       unknown
     >;
@@ -103,6 +104,15 @@ describe("provider/veryfront-cloud", () => {
     setEnv("GOOGLE_API_KEY", "google_test_provider");
 
     const model = resolveModel("google/gemini-2.5-flash") as Record<string, unknown>;
+
+    assertEquals(typeof model.doGenerate, "function");
+    assertEquals(typeof model.doStream, "function");
+  });
+
+  it("resolves direct Mistral models through the OpenAI-compatible built-in provider", () => {
+    setEnv("MISTRAL_API_KEY", "mistral_test_provider");
+
+    const model = resolveModel("mistral/mistral-large-2512") as Record<string, unknown>;
 
     assertEquals(typeof model.doGenerate, "function");
     assertEquals(typeof model.doStream, "function");

--- a/src/provider/veryfront-cloud/provider.ts
+++ b/src/provider/veryfront-cloud/provider.ts
@@ -45,7 +45,8 @@ export function createVeryfrontCloudModel(modelId: string): ModelRuntime {
     }
 
     case "openai":
-    case "moonshotai": {
+    case "moonshotai":
+    case "mistral": {
       const openai = registry.get("openai");
       if (openai) {
         return openai.createModel(upstreamModelId, {

--- a/src/provider/veryfront-cloud/shared.test.ts
+++ b/src/provider/veryfront-cloud/shared.test.ts
@@ -37,6 +37,10 @@ describe("provider/veryfront-cloud/shared", () => {
       getVeryfrontCloudGatewayBaseUrl("https://api.veryfront.com/", "google"),
       "https://api.veryfront.com/ai/gateway/google/v1beta",
     );
+    assertEquals(
+      getVeryfrontCloudGatewayBaseUrl("https://api.veryfront.com/", "mistral"),
+      "https://api.veryfront.com/ai/gateway/mistral/v1",
+    );
   });
 
   it("rewrites auth headers for the gateway fetch wrapper", async () => {

--- a/src/provider/veryfront-cloud/shared.ts
+++ b/src/provider/veryfront-cloud/shared.ts
@@ -6,7 +6,8 @@ export type VeryfrontCloudProviderId =
   | "anthropic"
   | "openai"
   | "google"
-  | "moonshotai";
+  | "moonshotai"
+  | "mistral";
 
 interface ParsedVeryfrontCloudModelId {
   provider: VeryfrontCloudProviderId;
@@ -19,6 +20,7 @@ const PROVIDER_ALIASES: Record<string, VeryfrontCloudProviderId> = {
   google: "google",
   "google-ai-studio": "google",
   moonshotai: "moonshotai",
+  mistral: "mistral",
 };
 
 const GATEWAY_PATHS: Record<VeryfrontCloudProviderId, string> = {
@@ -26,6 +28,7 @@ const GATEWAY_PATHS: Record<VeryfrontCloudProviderId, string> = {
   openai: "ai/gateway/openai/v1",
   google: "ai/gateway/google/v1beta",
   moonshotai: "ai/gateway/moonshotai/v1",
+  mistral: "ai/gateway/mistral/v1",
 };
 
 function joinUrl(base: string, path: string): string {


### PR DESCRIPTION
## Summary
- Add Mistral to the Veryfront Cloud hosted provider set and gateway path map.
- Add hosted Mistral model catalog entries, legacy aliases, provider grouping, and runtime auto-upgrade behavior.
- Document Mistral model strings and `MISTRAL_API_KEY` for Veryfront Cloud AI Gateway routing.

## Verification
- `deno fmt --check` on touched files
- `deno lint` on touched TypeScript files
- `deno check src/provider/veryfront-cloud/model-catalog.ts src/provider/veryfront-cloud/shared.ts src/provider/veryfront-cloud/provider.ts src/agent/runtime/model-resolution.ts src/agent/runtime/constants.ts`
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/provider/veryfront-cloud/model-catalog.test.ts src/provider/veryfront-cloud/shared.test.ts src/provider/veryfront-cloud/provider.test.ts src/agent/runtime/model-resolution.test.ts src/agent/runtime/constants.test.ts`

Note: the repository pre-commit `verify:quick` currently reports pre-existing CLI-boundary violations in `cli/shared/server-startup.ts`, which this PR does not touch.

Refs veryfront/veryfront-studio#5075.
