### PR TITLE
Keep release asset builds usable after partial module failures

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.839",
+  "version": "0.1.840",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -235,6 +235,88 @@ describe("release asset build executor", () => {
     assert(!pageUpload.text.includes("/_vf/assets/"));
   });
 
+  it("keeps the manifest ready when one module transform fails", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      { path: "pages/index.tsx", content: "export default () => null;" },
+      { path: "pages/broken.tsx", content: "export default () => null;" },
+    ];
+    const client = makeClient(files, rec);
+    const transform = (_source: string, sourceFile: string) => {
+      if (sourceFile.endsWith("pages/broken.tsx")) {
+        return Promise.reject(new Error("Invalid left-hand side in prefix operation. (1:2)"));
+      }
+      return Promise.resolve("export default () => null;");
+    };
+
+    const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    assertEquals(result.success, true);
+    assertEquals(result.state, "ready");
+    assertEquals(rec.states, []);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertExists(manifest.modules["pages/index.tsx"]);
+    assertEquals(manifest.modules["pages/broken.tsx"], undefined);
+    assert(manifest.fallback.gaps.includes("module-transform-failed:pages/broken.tsx"));
+  });
+
+  it("falls back to unvendored module code when HTTP dependency vendoring fails", async () => {
+    enableDependencyImportMap();
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [{ path: "pages/index.tsx", content: "export default () => null;" }];
+    const client = makeClient(files, rec);
+    const reactUrl = "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3";
+    const transform = () =>
+      Promise.resolve(`import React from "${reactUrl}"; export default React;`);
+    const input = {
+      ...baseInput(client, transform),
+      vendorHttpImports: () =>
+        Promise.reject(new Error("Invalid left-hand side in prefix operation. (1:2)")),
+    };
+
+    const result = await runReleaseAssetBuild(input, await tmp());
+
+    assertEquals(result.success, true);
+    assertEquals(result.state, "ready");
+    assertEquals(rec.states, []);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertExists(manifest.modules["pages/index.tsx"]);
+    assert(manifest.fallback.gaps.includes("module-dependency-vendor-failed:pages/index.tsx"));
+    assert(manifest.fallback.gaps.includes("dependency-vendor-failed:react-import-map"));
+
+    const pageHash = manifest.modules["pages/index.tsx"]?.contentHash;
+    assertExists(pageHash);
+    const pageUpload = rec.uploads.find((u) => u.hash === pageHash);
+    assertExists(pageUpload);
+    assert(pageUpload.text.includes(reactUrl));
+    assert(!pageUpload.text.includes("file://"));
+  });
+
+  it("keeps project modules ready when React import-map dependency vendoring fails", async () => {
+    enableDependencyImportMap();
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [{ path: "pages/index.tsx", content: "export default () => null;" }];
+    const client = makeClient(files, rec);
+    const transform = (source: string) => Promise.resolve(source);
+    const input = {
+      ...baseInput(client, transform),
+      vendorHttpImports: () =>
+        Promise.reject(new Error("Invalid left-hand side in prefix operation. (1:2)")),
+    };
+
+    const result = await runReleaseAssetBuild(input, await tmp());
+
+    assertEquals(result.success, true);
+    assertEquals(result.state, "ready");
+    assertEquals(rec.states, []);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertExists(manifest.modules["pages/index.tsx"]);
+    assert(manifest.fallback.gaps.includes("dependency-vendor-failed:react-import-map"));
+  });
+
   it("records framework import-map modules as manifest dependencies when dependency vendoring is enabled", async () => {
     enableDependencyImportMap();
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
@@ -381,7 +463,7 @@ describe("release asset build executor", () => {
     assertExists(manifest.dependencies["react/jsx-runtime"]);
   });
 
-  it("fails when React import-map dependencies cannot be vendored", async () => {
+  it("records a gap when React import-map dependencies cannot be vendored", async () => {
     enableDependencyImportMap();
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [{ path: "pages/index.tsx", content: "export default () => null;" }];
@@ -394,11 +476,13 @@ describe("release asset build executor", () => {
 
     const result = await runReleaseAssetBuild(input, await tmp());
 
-    assertEquals(result.success, false);
-    assertEquals(result.state, "failed");
-    assertEquals(rec.manifest, null);
-    assertEquals(rec.states.at(-1)?.state, "failed");
-    assert(rec.states.at(-1)?.error?.includes("React import-map dependency missing"));
+    assertEquals(result.success, true);
+    assertEquals(result.state, "ready");
+    assertEquals(rec.states, []);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertExists(manifest.modules["pages/index.tsx"]);
+    assert(manifest.fallback.gaps.includes("dependency-vendor-failed:react-import-map"));
   });
 
   it("rewrites covered project module imports to immutable asset URLs", async () => {
@@ -678,7 +762,7 @@ describe("release asset build executor", () => {
     assertEquals(rec.states.find((state) => state.state === "failed"), undefined);
   });
 
-  it("fails the manifest when a vendored dependency keeps an unresolved file import", async () => {
+  it("falls back to source URLs when a vendored dependency keeps an unresolved file import", async () => {
     enableDependencyImportMap();
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
@@ -712,14 +796,22 @@ describe("release asset build executor", () => {
 
     const result = await runReleaseAssetBuild(input, await tmp());
 
-    assertEquals(result.success, false);
-    assertEquals(result.state, "failed");
-    assert(result.error?.includes("Unresolved vendored file dependency"));
-    assertEquals(rec.states.at(-1)?.state, "failed");
-    assertEquals(rec.manifest, null);
+    assertEquals(result.success, true);
+    assertEquals(result.state, "ready");
+    assertEquals(rec.states, []);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertExists(manifest.modules["pages/index.tsx"]);
+    assert(manifest.fallback.gaps.includes("dependency-finalize-failed"));
+    const pageHash = manifest.modules["pages/index.tsx"]?.contentHash;
+    assertExists(pageHash);
+    const pageUpload = rec.uploads.find((u) => u.hash === pageHash);
+    assertExists(pageUpload);
+    assert(pageUpload.text.includes("https://esm.sh/parent@1"));
+    assert(!pageUpload.text.includes("file://"));
   });
 
-  it("fails the manifest when a vendored dependency asset exceeds the size limit", async () => {
+  it("falls back to source URLs when a vendored dependency asset exceeds the size limit", async () => {
     enableDependencyImportMap();
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
@@ -753,12 +845,19 @@ describe("release asset build executor", () => {
 
     const result = await runReleaseAssetBuild(input, await tmp());
 
-    assertEquals(result.success, false);
-    assertEquals(result.state, "failed");
-    assert(result.error?.includes("exceeds release asset size limit"));
-    assertEquals(rec.states.at(-1)?.state, "failed");
-    assertEquals(rec.manifest, null);
-    assertEquals(rec.uploads.length, 0);
+    assertEquals(result.success, true);
+    assertEquals(result.state, "ready");
+    assertEquals(rec.states, []);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertExists(manifest.modules["pages/index.tsx"]);
+    assert(manifest.fallback.gaps.includes("dependency-finalize-failed"));
+    const pageHash = manifest.modules["pages/index.tsx"]?.contentHash;
+    assertExists(pageHash);
+    const pageUpload = rec.uploads.find((u) => u.hash === pageHash);
+    assertExists(pageUpload);
+    assert(pageUpload.text.includes("https://esm.sh/parent@1"));
+    assert(!pageUpload.text.includes("file://"));
   });
 
   it("rewrites transformed relative project imports to immutable asset URLs", async () => {
@@ -1117,7 +1216,7 @@ describe("release asset build executor", () => {
     assertEquals(manifest.routes["/a"], undefined);
   });
 
-  it("reports failed and does not PUT on a transform error", async () => {
+  it("records a gap and still PUTs when a project module transform fails", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [{ path: "pages/index.tsx", content: "boom" }];
     const client = makeClient(files, rec);
@@ -1125,13 +1224,13 @@ describe("release asset build executor", () => {
 
     const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
 
-    assertEquals(result.success, false);
-    assertEquals(result.state, "failed");
-    assertEquals(rec.manifest, null);
-    assertEquals(rec.states.length, 1);
-    assertEquals(rec.states[0]?.state, "failed");
-    // Error is sanitized — no raw filesystem path leaks.
-    assert(!(rec.states[0]?.error ?? "").includes("/secret/path.tsx"));
+    assertEquals(result.success, true);
+    assertEquals(result.state, "ready");
+    assertEquals(rec.states, []);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.modules["pages/index.tsx"], undefined);
+    assert(manifest.fallback.gaps.includes("module-transform-failed:pages/index.tsx"));
   });
 
   it("dedupes identical transformed bytes into a single upload", async () => {

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -203,6 +203,7 @@ export interface PreparedReleaseAsset extends PreparedAsset {
 interface TransformedProjectModule {
   logicalPath: string;
   code: string;
+  unvendoredCode: string;
 }
 
 interface DependencyModule {
@@ -581,6 +582,10 @@ function addDependencyModule(
 
 function normalizeDependencySpecifier(specifier: string): string {
   return specifier.replace(/[?#].*$/, "");
+}
+
+function pushGap(gaps: string[], gap: string): void {
+  if (!gaps.includes(gap)) gaps.push(gap);
 }
 
 function dependencyLookupKeys(specifier: string): Set<string> {
@@ -1066,7 +1071,17 @@ async function finalizeProjectModules(
     if (!transformed) return null;
 
     const nextStack = [...stack, logicalPath];
-    const imports = await collectProjectModuleImports(transformed.code, logicalPath, knownPaths);
+    let imports: Map<string, string>;
+    try {
+      imports = await collectProjectModuleImports(transformed.code, logicalPath, knownPaths);
+    } catch (error) {
+      pushGap(gaps, `module-import-parse-failed:${logicalPath}`);
+      logger.warn("Module import parse failed during release asset finalization", {
+        path: logicalPath,
+        error: sanitizeError(error),
+      });
+      return null;
+    }
     for (const importedPath of imports.values()) {
       await finalize(importedPath, nextStack);
     }
@@ -1139,7 +1154,21 @@ async function collectCyclicProjectModules(
     visiting.add(logicalPath);
     stack.push(logicalPath);
 
-    const imports = await collectProjectModuleImports(transformed.code, logicalPath, knownPaths);
+    let imports: Map<string, string>;
+    try {
+      imports = await collectProjectModuleImports(transformed.code, logicalPath, knownPaths);
+    } catch (error) {
+      cyclic.add(logicalPath);
+      pushGap(gaps, `module-import-parse-failed:${logicalPath}`);
+      logger.warn("Module import parse failed during release asset cycle collection", {
+        path: logicalPath,
+        error: sanitizeError(error),
+      });
+      stack.pop();
+      visiting.delete(logicalPath);
+      visited.add(logicalPath);
+      return;
+    }
     for (const importedPath of imports.values()) {
       if (transformedModules.has(importedPath)) await visit(importedPath);
     }
@@ -1518,28 +1547,16 @@ async function runBuildInner(
           reactVersion: input.reactVersion,
         });
       } catch (error) {
-        // Hard requirement: any module transform failure -> report failed, stop.
         const sanitized = sanitizeError(error);
+        pushGap(gaps, `module-transform-failed:${logicalPath}`);
         logger.warn("Module transform failed during release asset build", {
           path: logicalPath,
           error: sanitized,
         });
-        await client.reportReleaseAssetManifestState(
-          input.releaseVersionRef,
-          "failed",
-          sanitized,
-        );
-        return {
-          success: false,
-          state: "failed",
-          moduleCount: 0,
-          cssCount: 0,
-          routeCount: 0,
-          gaps,
-          error: sanitized,
-        };
+        return null;
       }
 
+      const unvendoredCode = code;
       if (vendorDependencies) {
         try {
           const vendored = await vendorHttpImports(code, {
@@ -1552,30 +1569,29 @@ async function runBuildInner(
           }
         } catch (error) {
           const sanitized = sanitizeError(error);
+          pushGap(gaps, `module-dependency-vendor-failed:${logicalPath}`);
           logger.warn("HTTP dependency vendoring failed during release asset build", {
             path: logicalPath,
             error: sanitized,
           });
-          await client.reportReleaseAssetManifestState(
-            input.releaseVersionRef,
-            "failed",
-            sanitized,
-          );
-          return {
-            success: false,
-            state: "failed",
-            moduleCount: 0,
-            cssCount: 0,
-            routeCount: 0,
-            gaps,
-            error: sanitized,
-          };
+          code = unvendoredCode;
         }
       }
 
-      transformedModules.set(logicalPath, { logicalPath, code });
+      let imports: Map<string, string>;
+      try {
+        imports = await collectProjectModuleImports(code, logicalPath, knownPaths);
+      } catch (error) {
+        const sanitized = sanitizeError(error);
+        pushGap(gaps, `module-import-parse-failed:${logicalPath}`);
+        logger.warn("Module import parse failed during release asset build", {
+          path: logicalPath,
+          error: sanitized,
+        });
+        return null;
+      }
 
-      const imports = await collectProjectModuleImports(code, logicalPath, knownPaths);
+      transformedModules.set(logicalPath, { logicalPath, code, unvendoredCode });
       for (const importedPath of imports.values()) {
         const failure = await transformProjectModule(importedPath);
         if (failure) return failure;
@@ -1604,23 +1620,10 @@ async function runBuildInner(
       );
     } catch (error) {
       const sanitized = sanitizeError(error);
+      pushGap(gaps, "dependency-vendor-failed:react-import-map");
       logger.warn("React import-map dependency vendoring failed during release asset build", {
         error: sanitized,
       });
-      await client.reportReleaseAssetManifestState(
-        input.releaseVersionRef,
-        "failed",
-        sanitized,
-      );
-      return {
-        success: false,
-        state: "failed",
-        moduleCount: 0,
-        cssCount: 0,
-        routeCount: 0,
-        gaps,
-        error: sanitized,
-      };
     }
   }
 
@@ -1637,23 +1640,16 @@ async function runBuildInner(
     httpDependencyFallbackUrls = finalizedHttpDependencies.fallbackUrls;
   } catch (error) {
     const sanitized = sanitizeError(error);
+    pushGap(gaps, "dependency-finalize-failed");
     logger.warn("HTTP dependency finalization failed during release asset build", {
       error: sanitized,
     });
-    await client.reportReleaseAssetManifestState(
-      input.releaseVersionRef,
-      "failed",
-      sanitized,
-    );
-    return {
-      success: false,
-      state: "failed",
-      moduleCount: 0,
-      cssCount: 0,
-      routeCount: 0,
-      gaps,
-      error: sanitized,
-    };
+    for (const transformed of transformedModules.values()) {
+      transformed.code = transformed.unvendoredCode;
+    }
+    dependencyModules.clear();
+    httpDependencies = {};
+    httpDependencyFallbackUrls = new Map();
   }
   httpDependencies = exposeDependencySpecifierAliases(httpDependencies, dependencyModules);
   const dependencyUrls = buildDependencyUrlMap(httpDependencies, dependencyModules);

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.839";
+export const VERSION = "0.1.840";


### PR DESCRIPTION
## Summary
- keep release asset manifest builds `ready` when an individual project module transform, module import parse, or dependency vendoring/finalization step fails
- record explicit fallback gaps for those partial failures and keep source HTTP imports when dependency asset generation cannot be completed safely
- keep global build/list/upload/manifest PUT failures as hard failures
- bump `deno.json` and `src/utils/version-constant.ts` to `0.1.840` so a new package release is cut

## Why
The production release for `codersociety.com` had no ready release asset manifest because a single parser/vendor failure failed the whole manifest. That left versioned module requests on repeated JIT transforms and no-cache responses. This lets the builder publish cacheable assets for covered modules while preserving fallback behavior for uncovered modules.

## Tests
- `deno test --no-check --allow-all src/release-assets/build-executor.test.ts src/release-assets/html-consumption.test.ts src/release-assets/module-consumption.test.ts src/release-assets/css-compile.test.ts src/release-assets/manifest-schema.test.ts`
- `deno test --no-check --allow-all src/modules/server/module-response-cache.test.ts src/modules/server/module-server.test.ts`
- `deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts`
- `deno check src/release-assets/build-executor.ts src/release-assets/build-executor.test.ts`
- `git diff --check`
- pre-push hook: format, lint, typecheck, generate, and unit test task (`2172 passed`)
