### PR TITLE
Reduce cache fragmentation from noisy query params

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.841",
+  "version": "0.1.842",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/architecture/02-request-pipeline.md
+++ b/docs/architecture/02-request-pipeline.md
@@ -90,9 +90,11 @@ Default routing cache controls:
 
 Release-backed production page-data requests use a fresh cache window plus a
 bounded stale-while-revalidate window. The cache key includes the project,
-environment, release content source, slug, and sorted query. Requests with
-cache-sensitive state are not cached. Preview branch page data keeps the fresh
-TTL cache but does not serve stale responses after expiry.
+environment, release content source, slug, and canonical query. The canonical
+query uses the same `config.cache.queryParams` policy as HTML rendering, so
+default tracking and cache-busting parameters do not fragment the cache.
+Requests with cache-sensitive state are not cached. Preview branch page data
+keeps the fresh TTL cache but does not serve stale responses after expiry.
 
 Default page-data cache controls:
 

--- a/src/cache/keys.test.ts
+++ b/src/cache/keys.test.ts
@@ -293,6 +293,14 @@ describe("cache/keys", () => {
       const result = filterQueryParams(params, { policy: "exclude-list" });
       assertEquals(result, [["page", "1"]]);
     });
+
+    it("should exclude tracking and cache-busting params case-insensitively", () => {
+      const params = new URLSearchParams(
+        "page=1&UTM_SOURCE=google&GAD_SOURCE=ad&CACHEBUST=123&_=456",
+      );
+      const result = filterQueryParams(params);
+      assertEquals(result, [["page", "1"]]);
+    });
   });
 
   describe("sanitizeQueryParamsForCacheKey", () => {
@@ -308,12 +316,16 @@ describe("cache/keys", () => {
       assertEquals(result, "baz-qux_foo-bar");
     });
 
-    it("should sanitize values with special characters", () => {
+    it("should encode values with special characters without collisions", () => {
       const url = new URL("https://example.com/page?url=https://example.com");
       const result = sanitizeQueryParamsForCacheKey(url);
-      // Special chars in values should be replaced with underscores
-      // Note: dots (.) are allowed, so example.com stays as-is
-      assertEquals(result, "url-https___example.com");
+      assertEquals(result, "url-https*3A*2F*2Fexample.com");
+    });
+
+    it("should keep distinct query values with different special characters", () => {
+      const left = sanitizeQueryParamsForCacheKey(new URL("https://example.com/page?q=a/b"));
+      const right = sanitizeQueryParamsForCacheKey(new URL("https://example.com/page?q=a:b"));
+      assertNotEquals(left, right);
     });
 
     it("should respect ignore-all policy", () => {
@@ -326,6 +338,12 @@ describe("cache/keys", () => {
       const url = new URL("https://example.com/page?page=1&utm_source=google");
       const result = sanitizeQueryParamsForCacheKey(url, { policy: "exclude-list" });
       assertEquals(result, "page-1");
+    });
+
+    it("should sort duplicate query keys by value", () => {
+      const url = new URL("https://example.com/page?tag=b&tag=a&page=2");
+      const result = sanitizeQueryParamsForCacheKey(url);
+      assertEquals(result, "page-2_tag-a_tag-b");
     });
   });
 
@@ -358,6 +376,12 @@ describe("cache/keys", () => {
 
     it("should return just slug when all params are tracking params", () => {
       const url = new URL("https://example.com/blog?utm_source=google&utm_campaign=test");
+      const result = buildQueryAwareCacheKey("/blog", url);
+      assertEquals(result, "/blog");
+    });
+
+    it("should return just slug when all params are cache-busting params", () => {
+      const url = new URL("https://example.com/blog?cb=123&cacheBust=456&cache_buster=789");
       const result = buildQueryAwareCacheKey("/blog", url);
       assertEquals(result, "/blog");
     });

--- a/src/cache/keys/prefixes.ts
+++ b/src/cache/keys/prefixes.ts
@@ -56,14 +56,14 @@ export type FileSourceType = "branch" | "release" | "environment";
  * Query parameter handling policy for cache keys.
  *
  * - "ignore-all": Ignore all query params (best for marketing UTM params)
- * - "include-all": Include all query params in cache key (default behavior)
+ * - "include-all": Include all query params in cache key
  * - "include-list": Only include specified params
- * - "exclude-list": Include all except specified params
+ * - "exclude-list": Include all except specified params (default behavior)
  */
 export type QueryParamPolicy = "ignore-all" | "include-all" | "include-list" | "exclude-list";
 
 export interface QueryParamCacheOptions {
-  /** How to handle query params. Default: "include-all" */
+  /** How to handle query params. Default: "exclude-list" */
   policy?: QueryParamPolicy;
   /** List of param names for include-list or exclude-list policies */
   params?: string[];
@@ -108,20 +108,34 @@ export const DEFAULT_EXCLUDED_QUERY_PARAMS = [
   "dclid",
   "_ga",
   "_gl",
+  "gad_source",
+  "gbraid",
+  "wbraid",
   // Facebook
   "fbclid",
   "fb_action_ids",
   "fb_action_types",
+  // LinkedIn
+  "li_fat_id",
   // Microsoft / Bing
   "msclkid",
   // Mailchimp
   "mc_cid",
   "mc_eid",
+  // Cache-busting probes
+  "_",
+  "cb",
+  "cacheBust",
+  "cache_bust",
+  "cachebuster",
+  "cache_buster",
   // Other tracking
   "ref",
   "referrer",
   "source",
   "_openstat",
+  "igshid",
+  "twclid",
   "yclid",
   "zanpid",
 ];

--- a/src/cache/keys/utils.ts
+++ b/src/cache/keys/utils.ts
@@ -15,6 +15,8 @@ import { cacheRegistry } from "../registry.ts";
 
 import { DEFAULT_EXCLUDED_QUERY_PARAMS, type QueryParamCacheOptions } from "./prefixes.ts";
 
+const querySegmentEncoder = new TextEncoder();
+
 export function parseRenderCacheKey(cacheKey: string): {
   projectId: string;
   environment: string;
@@ -115,15 +117,20 @@ export function filterQueryParams(
       return entries.filter(([key]) => paramList.includes(key));
 
     case "exclude-list": {
-      // Merge user-provided list with defaults
-      const excludeSet = new Set([...DEFAULT_EXCLUDED_QUERY_PARAMS, ...paramList]);
-      return entries.filter(([key]) => !excludeSet.has(key));
+      const excludeSet = new Set(
+        [...DEFAULT_EXCLUDED_QUERY_PARAMS, ...paramList].map(normalizeQueryParamName),
+      );
+      return entries.filter(([key]) => !excludeSet.has(normalizeQueryParamName(key)));
     }
 
     case "include-all":
     default:
       return entries;
   }
+}
+
+function normalizeQueryParamName(param: string): string {
+  return param.toLowerCase();
 }
 
 /**
@@ -146,23 +153,35 @@ export function sanitizeQueryParamsForCacheKey(
   const filtered = filterQueryParams(params, options);
   if (filtered.length === 0) return "";
 
-  // Sort for consistent ordering
-  const sorted = filtered.sort(([a], [b]) => a.localeCompare(b));
+  // Sort for consistent ordering, including duplicate keys.
+  const sorted = filtered.sort(([leftKey, leftValue], [rightKey, rightValue]) =>
+    leftKey === rightKey ? leftValue.localeCompare(rightValue) : leftKey.localeCompare(rightKey)
+  );
 
   // Build sanitized string using allowed characters:
   // - Use hyphen (-) instead of equals (=)
   // - Use underscore (_) instead of ampersand (&)
-  // - URL-encode values that contain special characters
+  // - Percent-encode special characters using * as the escape marker
   const sanitized = sorted
     .map(([key, value]) => {
-      // Sanitize key and value to only contain allowed chars
-      const safeKey = key.replace(/[^a-zA-Z0-9_.-]/g, "_");
-      const safeValue = value.replace(/[^a-zA-Z0-9_.-]/g, "_");
+      const safeKey = encodeCacheKeySegment(key);
+      const safeValue = encodeCacheKeySegment(value);
       return `${safeKey}-${safeValue}`;
     })
     .join("_");
 
   return sanitized;
+}
+
+function encodeCacheKeySegment(value: string): string {
+  return Array.from(value, (char) => {
+    if (/^[a-zA-Z0-9_.-]$/.test(char)) return char;
+
+    return Array.from(
+      querySegmentEncoder.encode(char),
+      (byte) => `*${byte.toString(16).toUpperCase().padStart(2, "0")}`,
+    ).join("");
+  }).join("");
 }
 
 export function createCacheKeyFilter(options: {

--- a/src/config/schemas/config.schema.ts
+++ b/src/config/schemas/config.schema.ts
@@ -112,9 +112,9 @@ export const getVeryfrontConfigSchema = defineSchema((v) =>
            *
            * Policies:
            * - "ignore-all": Ignore all query params (pages with ?utm_campaign=x share cache with /)
-           * - "include-all": Include all query params (default, each unique query = separate cache)
+           * - "include-all": Include all query params (each unique query = separate cache)
            * - "include-list": Only include specified params in cache key
-           * - "exclude-list": Exclude specified params (+ common tracking params like utm_*)
+           * - "exclude-list": Exclude specified params (+ common tracking params like utm_*) (default)
            *
            * @example
            * // Ignore all marketing/tracking params (recommended for most sites)

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -311,9 +311,9 @@ export class Renderer {
    *
    * Query param handling is configurable via `config.cache.queryParams`:
    * - "ignore-all": Ignore all query params (pages share cache regardless of URL params)
-   * - "include-all": Include all query params (default, each unique query = separate cache)
+   * - "include-all": Include all query params (each unique query = separate cache)
    * - "include-list": Only include specified params
-   * - "exclude-list": Exclude common tracking params (utm_*, gclid, fbclid, etc.)
+   * - "exclude-list": Exclude common tracking/cache-busting params (default)
    */
   private buildCacheKey(
     slug: string,

--- a/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
@@ -212,6 +212,53 @@ describe("server/handlers/request/module/page-data-endpoint-handler", () => {
     assertEquals(await first.text(), await second.text());
   });
 
+  it("shares page-data cache entries across tracking and cache-busting query params", async () => {
+    let calls = 0;
+    setRendererInitializer(
+      createInitializer((slug) => Promise.resolve(createPageData(slug, ++calls))),
+    );
+
+    const ctx = makeCtx();
+    const first = await callPageDataEndpoint(
+      new Request("http://localhost/_veryfront/page-data/index.json?page=1"),
+      ctx,
+    );
+    const second = await callPageDataEndpoint(
+      new Request(
+        "http://localhost/_veryfront/page-data/index.json?page=1&utm_source=google&cb=abc",
+      ),
+      ctx,
+    );
+
+    assertEquals(first.status, 200);
+    assertEquals(second.status, 200);
+    assertEquals(calls, 1);
+    assertEquals(await first.text(), await second.text());
+  });
+
+  it("keeps distinct page-data cache entries for meaningful query params", async () => {
+    let calls = 0;
+    setRendererInitializer(
+      createInitializer((slug) => Promise.resolve(createPageData(slug, ++calls))),
+    );
+
+    const ctx = makeCtx();
+    const first = await callPageDataEndpoint(
+      new Request("http://localhost/_veryfront/page-data/index.json?page=1"),
+      ctx,
+    );
+    const second = await callPageDataEndpoint(
+      new Request("http://localhost/_veryfront/page-data/index.json?page=2"),
+      ctx,
+    );
+
+    assertEquals(first.status, 200);
+    assertEquals(second.status, 200);
+    assertEquals(calls, 2);
+    assertEquals(JSON.parse(await first.text()).frontmatter.sequence, 1);
+    assertEquals(JSON.parse(await second.text()).frontmatter.sequence, 2);
+  });
+
   it("uses cached etags to answer 304 without resolving page data again", async () => {
     let calls = 0;
     setRendererInitializer(

--- a/src/server/handlers/request/module/page-data-endpoint-handler.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.ts
@@ -9,6 +9,10 @@ import { HTTP_GATEWAY_TIMEOUT } from "#veryfront/utils/constants/http.ts";
 import { serverLogger } from "#veryfront/utils";
 import { Singleflight } from "#veryfront/utils/singleflight.ts";
 import { requestHasCacheSensitiveState } from "#veryfront/cache/request-cacheability.ts";
+import {
+  type QueryParamCacheOptions,
+  sanitizeQueryParamsForCacheKey,
+} from "#veryfront/cache/keys.ts";
 import type { PageDataResponse } from "#veryfront/rendering/orchestrator/types.ts";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
 
@@ -321,7 +325,8 @@ function buildPageDataCacheKey(ctx: HandlerContext, slug: string, url: URL): str
     (environment === "production"
       ? ctx.releaseId ?? "release"
       : ctx.requestContext?.branch ?? "main");
-  const query = buildSortedQueryKey(url);
+  const queryParamOptions = ctx.config?.cache?.queryParams as QueryParamCacheOptions | undefined;
+  const query = sanitizeQueryParamsForCacheKey(url, queryParamOptions);
 
   return [
     projectKey,
@@ -330,16 +335,4 @@ function buildPageDataCacheKey(ctx: HandlerContext, slug: string, url: URL): str
     slug || "index",
     query,
   ].join("|");
-}
-
-function buildSortedQueryKey(url: URL): string {
-  const entries = Array.from(url.searchParams.entries());
-  if (entries.length === 0) return "";
-
-  return entries
-    .sort(([leftKey, leftValue], [rightKey, rightValue]) =>
-      leftKey === rightKey ? leftValue.localeCompare(rightValue) : leftKey.localeCompare(rightKey)
-    )
-    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
-    .join("&");
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.841";
+export const VERSION = "0.1.842";


### PR DESCRIPTION
## Summary
- align page-data cache keys with the HTML render query canonicalizer
- exclude additional common tracking and cache-busting params by default while preserving meaningful unknown params
- make query cache-key encoding collision-resistant and deterministic for duplicate query keys
- bump `deno.json` and `src/utils/version-constant.ts` to `0.1.842` for a new release

## Expected performance effect
- Avoids first-hit work for page-data and HTML render requests that differ only by standard analytics or cache-busting query params.
- Keeps query-driven pages safe because unknown params such as `page`, `sort`, or feature-specific params still vary the cache key.

## Tests
- `deno test --no-check --allow-all src/cache/keys.test.ts src/server/handlers/request/module/page-data-endpoint-handler.test.ts src/utils/version.test.ts`
- `deno fmt --check src/cache/keys/prefixes.ts src/cache/keys/utils.ts src/config/schemas/config.schema.ts src/rendering/renderer.ts src/server/handlers/request/module/page-data-endpoint-handler.ts src/cache/keys.test.ts src/server/handlers/request/module/page-data-endpoint-handler.test.ts docs/architecture/02-request-pipeline.md src/utils/version-constant.ts deno.json`
- `git diff --check`
- pre-push hook: format, lint, type check, generated manifests, and unit suite (`2172 passed`)
