### PR TITLE
Preserve repeated query order in render cache keys

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.842",
+  "version": "0.1.843",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/cache/keys.test.ts
+++ b/src/cache/keys.test.ts
@@ -340,10 +340,20 @@ describe("cache/keys", () => {
       assertEquals(result, "page-1");
     });
 
-    it("should sort duplicate query keys by value", () => {
+    it("should preserve repeated query param value order while sorting keys", () => {
       const url = new URL("https://example.com/page?tag=b&tag=a&page=2");
       const result = sanitizeQueryParamsForCacheKey(url);
-      assertEquals(result, "page-2_tag-a_tag-b");
+      assertEquals(result, "page-2_tag-b_tag-a");
+    });
+
+    it("should keep different repeated query param orders distinct", () => {
+      const left = sanitizeQueryParamsForCacheKey(
+        new URL("https://example.com/page?sort=price&sort=rating"),
+      );
+      const right = sanitizeQueryParamsForCacheKey(
+        new URL("https://example.com/page?sort=rating&sort=price"),
+      );
+      assertNotEquals(left, right);
     });
   });
 

--- a/src/cache/keys/utils.ts
+++ b/src/cache/keys/utils.ts
@@ -153,10 +153,7 @@ export function sanitizeQueryParamsForCacheKey(
   const filtered = filterQueryParams(params, options);
   if (filtered.length === 0) return "";
 
-  // Sort for consistent ordering, including duplicate keys.
-  const sorted = filtered.sort(([leftKey, leftValue], [rightKey, rightValue]) =>
-    leftKey === rightKey ? leftValue.localeCompare(rightValue) : leftKey.localeCompare(rightKey)
-  );
+  const sorted = sortQueryParamsForCacheKey(filtered);
 
   // Build sanitized string using allowed characters:
   // - Use hyphen (-) instead of equals (=)
@@ -171,6 +168,24 @@ export function sanitizeQueryParamsForCacheKey(
     .join("_");
 
   return sanitized;
+}
+
+function sortQueryParamsForCacheKey(entries: Array<[string, string]>): Array<[string, string]> {
+  const grouped = new Map<string, Array<[string, string]>>();
+
+  for (const entry of entries) {
+    const [key] = entry;
+    const group = grouped.get(key);
+    if (group) {
+      group.push(entry);
+    } else {
+      grouped.set(key, [entry]);
+    }
+  }
+
+  return [...grouped.keys()]
+    .sort((leftKey, rightKey) => leftKey.localeCompare(rightKey))
+    .flatMap((key) => grouped.get(key)!);
 }
 
 function encodeCacheKeySegment(value: string): string {

--- a/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.test.ts
@@ -259,6 +259,29 @@ describe("server/handlers/request/module/page-data-endpoint-handler", () => {
     assertEquals(JSON.parse(await second.text()).frontmatter.sequence, 2);
   });
 
+  it("keeps distinct page-data cache entries for repeated query params in different orders", async () => {
+    let calls = 0;
+    setRendererInitializer(
+      createInitializer((slug) => Promise.resolve(createPageData(slug, ++calls))),
+    );
+
+    const ctx = makeCtx();
+    const first = await callPageDataEndpoint(
+      new Request("http://localhost/_veryfront/page-data/index.json?sort=price&sort=rating"),
+      ctx,
+    );
+    const second = await callPageDataEndpoint(
+      new Request("http://localhost/_veryfront/page-data/index.json?sort=rating&sort=price"),
+      ctx,
+    );
+
+    assertEquals(first.status, 200);
+    assertEquals(second.status, 200);
+    assertEquals(calls, 2);
+    assertEquals(JSON.parse(await first.text()).frontmatter.sequence, 1);
+    assertEquals(JSON.parse(await second.text()).frontmatter.sequence, 2);
+  });
+
   it("uses cached etags to answer 304 without resolving page data again", async () => {
     let calls = 0;
     setRendererInitializer(

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.842";
+export const VERSION = "0.1.843";


### PR DESCRIPTION
## Summary
- preserve URL order for repeated query params inside render/page-data cache keys
- keep distinct query param names sorted so ordinary key order changes remain canonical
- add cache-key and page-data regression coverage for order-sensitive repeated params
- bump `deno.json` and `src/utils/version-constant.ts` to `0.1.843`

## Why
Addresses the review comment on #2503: pages can use `URLSearchParams.getAll()`, so repeated params with different value order must not share a cache key.

## Tests
- `deno test --no-check --allow-all src/cache/keys.test.ts src/server/handlers/request/module/page-data-endpoint-handler.test.ts src/utils/version.test.ts`
- `deno fmt --check src/cache/keys/utils.ts src/cache/keys.test.ts src/server/handlers/request/module/page-data-endpoint-handler.test.ts deno.json src/utils/version-constant.ts`
- `git diff --check`
- pre-push hook: format, lint, typecheck, generated manifests, and unit suite (`2172 passed`)
