### PR TITLE
Deduplicate first-hit page-data navigation fetches

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.843",
+  "version": "0.1.844",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/html/hydration-script-builder/templates/router.test.ts
+++ b/src/html/hydration-script-builder/templates/router.test.ts
@@ -105,8 +105,9 @@ describe("hydration-script-builder/templates/router", () => {
       const result = getRouterScript();
       assertIncludes(result, "BACKGROUND_REFRESH_INTERVAL_MS = 30 * 1000");
       assertIncludes(result, "const pendingPageDataFetches = new Map()");
+      assertIncludes(result, "function startPageDataFetch(path, signal, options = {})");
       assertIncludes(result, "function refreshPageDataInBackground(path)");
-      assertIncludes(result, "pendingPageDataFetches.set(path, refreshPromise)");
+      assertIncludes(result, "pendingPageDataFetches.set(path, request)");
       assertIncludes(result, "refreshPageDataInBackground(path)");
     });
 
@@ -124,8 +125,14 @@ describe("hydration-script-builder/templates/router", () => {
       const result = getRouterScript();
       assertIncludes(result, "recordRouteTiming = false");
       assertIncludes(result, "if (recordRouteTiming) {");
-      assertIncludes(result, "fetchPageDataFresh(path, null).finally");
+      assertIncludes(result, "startPageDataFetch(path, null)");
       assertIncludes(result, "recordRouteTiming: true");
+    });
+
+    it("should register first-hit navigation page-data fetches for prefetch dedupe", () => {
+      const result = getRouterScript();
+      assertIncludes(result, "return startPageDataFetch(path, signal, {");
+      assertIncludes(result, "timingSource: 'network'");
     });
 
     it("should emit route transition timing events", () => {

--- a/src/html/hydration-script-builder/templates/router.ts
+++ b/src/html/hydration-script-builder/templates/router.ts
@@ -354,15 +354,21 @@ export const getRouterScript = () => `
       return data;
     }
 
+    function startPageDataFetch(path, signal, options = {}) {
+      const request = fetchPageDataFresh(path, signal, options).finally(() => {
+        if (pendingPageDataFetches.get(path) === request) {
+          pendingPageDataFetches.delete(path);
+        }
+      });
+      pendingPageDataFetches.set(path, request);
+      return request;
+    }
+
     function fetchPageDataDeduped(path) {
       const pending = pendingPageDataFetches.get(path);
       if (pending) return pending;
 
-      const refreshPromise = fetchPageDataFresh(path, null).finally(() => {
-        pendingPageDataFetches.delete(path);
-      });
-      pendingPageDataFetches.set(path, refreshPromise);
-      return refreshPromise;
+      return startPageDataFetch(path, null);
     }
 
     function refreshPageDataInBackground(path) {
@@ -394,7 +400,7 @@ export const getRouterScript = () => `
         return handlePageDataVersionMismatch(path, data);
       }
 
-      return fetchPageDataFresh(path, signal, {
+      return startPageDataFetch(path, signal, {
         triggerReloadOnVersionMismatch: true,
         recordRouteTiming: true,
         timingSource: 'network'

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.843";
+export const VERSION = "0.1.844";


### PR DESCRIPTION
## Summary
- route cold SPA navigation page-data fetches through the shared pending request map
- preserve route timing metadata and abort signaling for navigation fetches
- bump veryfront-code to 0.1.844 for a new release

## Why
Browser testing on codersociety.com showed first uncached client navigation could request `/_veryfront/page-data/accelerators.json` twice when hover prefetch fired during the same click window. The navigation path was not registered in `pendingPageDataFetches`, so prefetch could not dedupe against it.

## Tests
- `deno test --no-check --allow-all src/html/hydration-script-builder/templates/router.test.ts src/routing/client/page-loader.test.ts src/utils/version.test.ts`
- `deno lint src/html/hydration-script-builder/templates/router.ts src/html/hydration-script-builder/templates/router.test.ts src/utils/version-constant.ts src/utils/version.test.ts src/routing/client/page-loader.test.ts`
- `deno fmt --check src/html/hydration-script-builder/templates/router.ts src/html/hydration-script-builder/templates/router.test.ts deno.json src/utils/version-constant.ts`
- `git diff --check`
- pre-push: format, lint, typecheck, generated bundles, full unit suite (`2172 passed`)
