### PR TITLE
Wait for npm gitHead metadata before stable release verification

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -440,9 +440,25 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           TAG="v${VERSION}"
-          if npm view veryfront@"${VERSION}" version 2>/dev/null; then
+          wait_for_existing_npm_git_head() {
+            for attempt in $(seq 1 24); do
+              PUBLISHED_GIT_HEAD="$(npm view veryfront@"${VERSION}" gitHead 2>/dev/null || true)"
+              if [ "${PUBLISHED_GIT_HEAD}" = "${GITHUB_SHA}" ]; then
+                return 0
+              fi
+              if [ -n "${PUBLISHED_GIT_HEAD}" ]; then
+                return 1
+              fi
+              echo "Waiting for npm registry metadata for veryfront@${VERSION} (attempt ${attempt}/24)."
+              sleep 5
+            done
+
             PUBLISHED_GIT_HEAD="$(npm view veryfront@"${VERSION}" gitHead 2>/dev/null || true)"
-            if [ "${PUBLISHED_GIT_HEAD}" != "${GITHUB_SHA}" ]; then
+            [ "${PUBLISHED_GIT_HEAD}" = "${GITHUB_SHA}" ]
+          }
+
+          if npm view veryfront@"${VERSION}" version 2>/dev/null; then
+            if ! wait_for_existing_npm_git_head; then
               echo "::error::v${VERSION} already exists on npm for ${PUBLISHED_GIT_HEAD}. Bump deno.json before releasing."
               exit 1
             fi
@@ -476,6 +492,23 @@ jobs:
           deno task build:npm
           cd npm
 
+          wait_for_npm_git_head() {
+            for attempt in $(seq 1 24); do
+              PUBLISHED_GIT_HEAD="$(npm view veryfront@"${VERSION}" gitHead 2>/dev/null || true)"
+              if [ "${PUBLISHED_GIT_HEAD}" = "${GITHUB_SHA}" ]; then
+                return 0
+              fi
+              if [ -n "${PUBLISHED_GIT_HEAD}" ]; then
+                return 1
+              fi
+              echo "Waiting for npm registry metadata for veryfront@${VERSION} (attempt ${attempt}/24)."
+              sleep 5
+            done
+
+            PUBLISHED_GIT_HEAD="$(npm view veryfront@"${VERSION}" gitHead 2>/dev/null || true)"
+            [ "${PUBLISHED_GIT_HEAD}" = "${GITHUB_SHA}" ]
+          }
+
           PUBLISHED_GIT_HEAD="$(npm view veryfront@"${VERSION}" gitHead 2>/dev/null || true)"
           if [ "${PUBLISHED_GIT_HEAD}" = "${GITHUB_SHA}" ]; then
             echo "veryfront@${VERSION} is already published for this commit; skipping npm publish."
@@ -487,9 +520,8 @@ jobs:
             printf '%s\n' "${PUBLISH_OUTPUT}"
 
             if [ "${PUBLISH_STATUS}" -ne 0 ]; then
-              PUBLISHED_GIT_HEAD="$(npm view veryfront@"${VERSION}" gitHead 2>/dev/null || true)"
               if printf '%s\n' "${PUBLISH_OUTPUT}" | grep -Fq "previously published versions: ${VERSION}" \
-                && [ "${PUBLISHED_GIT_HEAD}" = "${GITHUB_SHA}" ]; then
+                && wait_for_npm_git_head; then
                 echo "npm reports veryfront@${VERSION} already exists, and gitHead matches this commit; continuing."
               else
                 exit "${PUBLISH_STATUS}"
@@ -497,8 +529,7 @@ jobs:
             fi
           fi
 
-          PUBLISHED_GIT_HEAD="$(npm view veryfront@"${VERSION}" gitHead 2>/dev/null || true)"
-          if [ "${PUBLISHED_GIT_HEAD}" != "${GITHUB_SHA}" ]; then
+          if ! wait_for_npm_git_head; then
             echo "::error::Published veryfront@${VERSION} gitHead is ${PUBLISHED_GIT_HEAD}, expected ${GITHUB_SHA}."
             exit 1
           fi

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.845",
+  "version": "0.1.846",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.845";
+export const VERSION = "0.1.846";


### PR DESCRIPTION
## Summary
- wait for npm registry gitHead metadata in stable release preflight and post-publish verification
- bump Veryfront to 0.1.846 so the next merge produces a fresh stable release

## Context
The 0.1.845 npm publish succeeded, but the release job queried gitHead before npm metadata propagated and failed before GitHub release creation or server dispatch.

## Verification
- deno test --no-check --allow-all src/utils/version.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts
- deno lint src/utils/version-constant.ts src/utils/version.test.ts
- ruby YAML parse for .github/workflows/cicd.yml
- actionlint .github/workflows/cicd.yml
- git diff --check
- pre-push full gate: format, lint, typecheck, generated assets, unit suite (2172 passed)

## Release
After merge, follow the main CI/CD release for 0.1.846 and verify npm, GitHub releases, and server repository dispatch.