### PR TITLE
Prevent hover prefetch from duplicating page-data navigation

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.846",
+  "version": "0.1.847",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/html/hydration-script-builder/templates/router.test.ts
+++ b/src/html/hydration-script-builder/templates/router.test.ts
@@ -135,6 +135,18 @@ describe("hydration-script-builder/templates/router", () => {
       assertIncludes(result, "timingSource: 'network'");
     });
 
+    it("should cancel hover prefetch before click navigation", () => {
+      const result = getRouterScript();
+      assertIncludes(result, "function cancelScheduledPrefetch()");
+      assertIncludes(result, "cancelScheduledPrefetch();\n      void navigateSPA(href, true);");
+    });
+
+    it("should skip page-data prefetches while navigation is active", () => {
+      const result = getRouterScript();
+      assertIncludes(result, "let isNavigating = false;");
+      assertIncludes(result, "function prefetchPage(href) {\n      if (isNavigating) return;");
+    });
+
     it("should emit route transition timing events", () => {
       const result = getRouterScript();
       assertIncludes(result, "function emitRouteTiming(phase, path, startedAt, detail = {})");

--- a/src/html/hydration-script-builder/templates/router.ts
+++ b/src/html/hydration-script-builder/templates/router.ts
@@ -628,8 +628,18 @@ export const getRouterScript = () => `
     // Prefetching on hover
     // ============================================
     let prefetchTimeout = null;
+    let currentHoverLink = null;
     const prefetchedPaths = new Set();
     const inFlightPrefetches = new Set();
+
+    function cancelScheduledPrefetch() {
+      if (prefetchTimeout) {
+        clearTimeout(prefetchTimeout);
+        prefetchTimeout = null;
+      }
+
+      currentHoverLink = null;
+    }
 
     function getPageDataModulePaths(pageData) {
       const layoutPaths = (pageData.layouts || []).map((l) => l.path).filter(Boolean);
@@ -660,6 +670,7 @@ export const getRouterScript = () => `
     }
 
     function prefetchPage(href) {
+      if (isNavigating) return;
       if (prefetchedPaths.has(href) || inFlightPrefetches.has(href)) return;
 
       const cachedPageData = getCachedPageData(href);
@@ -780,10 +791,9 @@ export const getRouterScript = () => `
       }
 
       e.preventDefault();
+      cancelScheduledPrefetch();
       void navigateSPA(href, true);
     });
-
-    let currentHoverLink = null;
 
     document.addEventListener(
       'mouseenter',
@@ -819,11 +829,7 @@ export const getRouterScript = () => `
         const relatedTarget = e.relatedTarget;
         if (currentHoverLink && relatedTarget && currentHoverLink.contains(relatedTarget)) return;
 
-        if (prefetchTimeout) {
-          clearTimeout(prefetchTimeout);
-          prefetchTimeout = null;
-        }
-        currentHoverLink = null;
+        cancelScheduledPrefetch();
       },
       true
     );

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.846";
+export const VERSION = "0.1.847";


### PR DESCRIPTION
## Summary
- cancel delayed hover prefetch when a link click starts SPA navigation
- skip page-data prefetch while navigation is active
- bump Veryfront runtime version to 0.1.847 for a fresh release

## Why
Browser verification on codersociety.com showed a route click could issue two `/_veryfront/page-data/*.json` GETs: the click navigation fetch and a delayed hover prefetch firing around the same time. This keeps route transitions slower than needed and adds duplicate backend/cache pressure.

## Tests
- `deno test --no-check --allow-all src/html/hydration-script-builder/templates/router.test.ts src/utils/version.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts src/html/hydration-script-builder/templates/router.ts src/html/hydration-script-builder/templates/router.test.ts`
- `git diff --check`
- `deno lint src/html/hydration-script-builder/templates/router.ts src/html/hydration-script-builder/templates/router.test.ts src/utils/version-constant.ts src/utils/version.test.ts`
- `deno check src/html/hydration-script-builder/templates/router.ts src/html/hydration-script-builder/templates/router.test.ts src/utils/version-constant.ts src/utils/version.test.ts`
- `deno test --no-check --allow-all src/html/hydration-script-builder/prod-scripts.test.ts src/build/production-build/build/output-generator.test.ts`
- pre-push hook: format, lint, typecheck, generated-code check, full no-check test suite