### PR TITLE
Prewarm sibling routes after production renders

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.847",
+  "version": "0.1.848",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/architecture/02-request-pipeline.md
+++ b/docs/architecture/02-request-pipeline.md
@@ -107,6 +107,24 @@ Default page-data cache controls:
 Set `VERYFRONT_PAGE_DATA_CACHE_MAX_ENTRIES` to `0` to disable the page-data
 endpoint cache.
 
+Production HTML rendering also starts a bounded background prewarm after the
+first cacheable request for a project release context. The prewarm discovers
+concrete static routes, skips dynamic route patterns, uses canonical route cache
+keys without request cookies, query strings, or nonces, and checks the shared
+render cache before rendering each route. This populates the API-backed
+distributed render cache for sibling routes without adding latency to the
+foreground response.
+
+Default render prewarm controls:
+
+| Environment variable                   | Default |
+| -------------------------------------- | ------- |
+| `VERYFRONT_RENDER_PREWARM_MAX_ROUTES`  | `12`    |
+| `VERYFRONT_RENDER_PREWARM_CONCURRENCY` | `1`     |
+
+Set `VERYFRONT_RENDER_PREWARM_MAX_ROUTES` to `0` to disable production render
+prewarm.
+
 ## Boundaries
 
 - Rendering details belong in [rendering runtime](./03-rendering-runtime.md).

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -94,6 +94,13 @@ function createInMemoryStore(): CacheStore & { data: Map<string, CachePayload> }
   };
 }
 
+async function waitForProductionPrewarm(renderer: Renderer): Promise<void> {
+  const contexts = (renderer as unknown as {
+    productionPrewarmContexts: Map<string, Promise<void>>;
+  }).productionPrewarmContexts;
+  await Promise.all([...contexts.values()]);
+}
+
 function makeReadyManifest(): ReleaseAssetManifest {
   return {
     schemaVersion: 1,
@@ -306,7 +313,7 @@ describe("Renderer release asset cache isolation", () => {
         pipeline: {
           renderPage: (
             slug: string,
-            options?: { releaseAssetManifest?: ReleaseAssetManifest | null },
+            options?: { nonce?: string; releaseAssetManifest?: ReleaseAssetManifest | null },
           ) => Promise<{
             html: string;
             frontmatter: Record<string, unknown>;
@@ -339,6 +346,144 @@ describe("Renderer release asset cache isolation", () => {
     assertEquals(result.html, "<html>fresh manifest render</html>");
     assertEquals(store.data.has(`${manifestPrefix}:page:/fresh`), true);
     assertEquals(store.data.has(`${jitPrefix}:page:/fresh`), false);
+  });
+
+  it("prewarms sibling production routes after a cacheable render", async () => {
+    const store = createInMemoryStore();
+    const renderedSlugs: string[] = [];
+    const renderer = new Renderer({ cache: { store } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    (renderer as unknown as {
+      getAllPages: () => Promise<string[]>;
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: (
+            slug: string,
+            options?: { nonce?: string; releaseAssetManifest?: ReleaseAssetManifest | null },
+          ) => Promise<{
+            html: string;
+            frontmatter: Record<string, unknown>;
+            headings: never[];
+            stream: null;
+          }>;
+        };
+      };
+    }).getAllPages = () => Promise.resolve(["/", "/blog", "/docs/[slug]", "about", "/blog"]);
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: (
+            slug: string,
+            options?: { nonce?: string; releaseAssetManifest?: ReleaseAssetManifest | null },
+          ) => Promise<{
+            html: string;
+            frontmatter: Record<string, unknown>;
+            headings: never[];
+            stream: null;
+          }>;
+        };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: (slug, options) => {
+          assertEquals(options?.releaseAssetManifest, null);
+          assertEquals(options?.nonce, slug === "/" ? "nonce-123" : undefined);
+          renderedSlugs.push(slug);
+          return Promise.resolve({
+            html: `<html>${slug}</html>`,
+            frontmatter: {},
+            headings: [],
+            stream: null,
+          });
+        },
+      },
+    });
+
+    const ctx = {
+      ...makeRenderContext(),
+      adapter: { fs: {} } as RenderContext["adapter"],
+    };
+    const result = await renderer.renderPage("/", ctx, {
+      environment: "production",
+      releaseId: "rel-1",
+      releaseAssetManifest: null,
+      nonce: "nonce-123",
+    });
+    await waitForProductionPrewarm(renderer);
+
+    const prefix = buildRenderCachePrefix("proj-1", "production", "rel-1");
+    assertEquals(result.html, "<html>/</html>");
+    assertEquals(renderedSlugs.includes("/blog"), true);
+    assertEquals(renderedSlugs.includes("about"), true);
+    assertEquals(renderedSlugs.includes("/docs/[slug]"), false);
+    assertEquals(store.data.has(`${prefix}:page:/blog`), true);
+    assertEquals(store.data.has(`${prefix}:page:about`), true);
+  });
+
+  it("does not prewarm when the request has cache-sensitive state", async () => {
+    const store = createInMemoryStore();
+    const renderedSlugs: string[] = [];
+    let getAllPagesCalls = 0;
+    const renderer = new Renderer({ cache: { store } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    (renderer as unknown as {
+      getAllPages: () => Promise<string[]>;
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: (slug: string) => Promise<{
+            html: string;
+            frontmatter: Record<string, unknown>;
+            headings: never[];
+            stream: null;
+          }>;
+        };
+      };
+    }).getAllPages = () => {
+      getAllPagesCalls++;
+      return Promise.resolve(["/blog"]);
+    };
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: (slug: string) => Promise<{
+            html: string;
+            frontmatter: Record<string, unknown>;
+            headings: never[];
+            stream: null;
+          }>;
+        };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: (slug) => {
+          renderedSlugs.push(slug);
+          return Promise.resolve({
+            html: `<html>${slug}</html>`,
+            frontmatter: {},
+            headings: [],
+            stream: null,
+          });
+        },
+      },
+    });
+
+    const ctx = {
+      ...makeRenderContext(),
+      adapter: { fs: {} } as RenderContext["adapter"],
+    };
+    const url = new URL("https://example.com/");
+    await renderer.renderPage("/", ctx, {
+      environment: "production",
+      releaseId: "rel-1",
+      releaseAssetManifest: null,
+      request: new Request(url, { headers: { cookie: "session=abc" } }),
+      url,
+    });
+    await waitForProductionPrewarm(renderer);
+
+    assertEquals(renderedSlugs, ["/"]);
+    assertEquals(getAllPagesCalls, 0);
+    assertEquals(store.data.size, 0);
   });
 });
 

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -99,6 +99,26 @@ const DEFAULT_RENDER_PIPELINE_TIMEOUT_MS = 60_000;
 const RENDER_PIPELINE_TIMEOUT_MS = getEnvNumber("RENDER_TIMEOUT_MS") ??
   DEFAULT_RENDER_PIPELINE_TIMEOUT_MS;
 
+/** Default number of sibling production routes to warm after the first cacheable request. */
+const DEFAULT_RENDER_PREWARM_MAX_ROUTES = 12;
+/** Default low-impact background concurrency for production route prewarm. */
+const DEFAULT_RENDER_PREWARM_CONCURRENCY = 1;
+/** Bound remembered release contexts so multi-tenant processes cannot grow without limit. */
+const RENDER_PREWARM_CONTEXT_MAX_ENTRIES = 500;
+
+const RENDER_PREWARM_MAX_ROUTES = getBoundedEnvNumber(
+  "VERYFRONT_RENDER_PREWARM_MAX_ROUTES",
+  DEFAULT_RENDER_PREWARM_MAX_ROUTES,
+  0,
+  100,
+);
+const RENDER_PREWARM_CONCURRENCY = getBoundedEnvNumber(
+  "VERYFRONT_RENDER_PREWARM_CONCURRENCY",
+  DEFAULT_RENDER_PREWARM_CONCURRENCY,
+  1,
+  8,
+);
+
 /**
  * Options for initializing the Renderer
  */
@@ -120,6 +140,67 @@ interface CachedRenderData {
   headings?: RenderResult["headings"];
   ssrHash?: string;
   pageModule?: RenderResult["pageModule"];
+}
+
+function getBoundedEnvNumber(
+  name: string,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  const value = getEnvNumber(name);
+  if (value === undefined || Number.isNaN(value)) return fallback;
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizeComparableSlug(slug: string): string {
+  const trimmed = slug.trim();
+  if (!trimmed || trimmed === "index" || trimmed === "/index") return "/";
+  const withoutTrailingSlash = trimmed.replace(/\/+$/, "");
+  const normalized = withoutTrailingSlash.startsWith("/")
+    ? withoutTrailingSlash
+    : `/${withoutTrailingSlash}`;
+  return normalized || "/";
+}
+
+function isConcretePrewarmSlug(slug: string): boolean {
+  const comparable = normalizeComparableSlug(slug);
+  return !comparable.includes("[") && !comparable.includes("]") && !comparable.includes("*");
+}
+
+function prewarmSlugDepth(slug: string): number {
+  const comparable = normalizeComparableSlug(slug);
+  if (comparable === "/") return 0;
+  return comparable.split("/").filter(Boolean).length;
+}
+
+function selectPrewarmSlugs(
+  currentSlug: string,
+  pages: string[],
+  maxRoutes: number,
+): string[] {
+  if (maxRoutes <= 0) return [];
+
+  const currentComparable = normalizeComparableSlug(currentSlug);
+  const seen = new Set<string>();
+  const candidates: Array<{ slug: string; comparable: string }> = [];
+
+  for (const page of pages) {
+    if (!isConcretePrewarmSlug(page)) continue;
+
+    const comparable = normalizeComparableSlug(page);
+    if (comparable === currentComparable || seen.has(comparable)) continue;
+
+    seen.add(comparable);
+    candidates.push({ slug: page, comparable });
+  }
+
+  candidates.sort((a, b) =>
+    prewarmSlugDepth(a.comparable) - prewarmSlugDepth(b.comparable) ||
+    a.comparable.localeCompare(b.comparable)
+  );
+
+  return candidates.slice(0, maxRoutes).map(({ slug }) => slug);
 }
 
 /**
@@ -152,6 +233,7 @@ export class Renderer {
    * Key format: {cachePrefix}:{slug}:{colorScheme}
    */
   private renderFlight = new Singleflight<CachedRenderData>();
+  private productionPrewarmContexts = new Map<string, Promise<void>>();
 
   constructor(options: RendererOptions = {}) {
     this.cache = new ContextAwareCacheCoordinator(options.cache);
@@ -211,6 +293,7 @@ export class Renderer {
             colorScheme: effectiveOptions?.colorScheme,
             duration: `${(performance.now() - startTime).toFixed(2)}ms`,
           });
+          this.scheduleProductionRenderPrewarm(slug, effectiveCtx, effectiveOptions, cacheKey);
           return cacheResult.cachedResult;
         }
 
@@ -250,11 +333,23 @@ export class Renderer {
           });
         }
 
+        let renderedSuccessfully = false;
         try {
-          return await this.doRenderPage(slug, effectiveCtx, effectiveOptions, startTime, cacheKey);
+          const result = await this.doRenderPage(
+            slug,
+            effectiveCtx,
+            effectiveOptions,
+            startTime,
+            cacheKey,
+          );
+          renderedSuccessfully = true;
+          return result;
         } finally {
           renderSemaphore.release();
           await releaseProjectSlot(effectiveCtx.projectId);
+          if (renderedSuccessfully) {
+            this.scheduleProductionRenderPrewarm(slug, effectiveCtx, effectiveOptions, cacheKey);
+          }
         }
       },
       {
@@ -331,6 +426,133 @@ export class Renderer {
     const queryParamOptions = ctx.config?.cache?.queryParams as QueryParamCacheOptions | undefined;
 
     return buildQueryAwareCacheKey(slug, options?.url, queryParamOptions);
+  }
+
+  private scheduleProductionRenderPrewarm(
+    currentSlug: string,
+    ctx: RenderContext,
+    options: RenderOptions | undefined,
+    cacheKey: string | null,
+  ): void {
+    if (!this.shouldScheduleProductionPrewarm(ctx, options, cacheKey)) return;
+
+    const prewarmKey = this.getProductionPrewarmKey(ctx);
+    if (this.productionPrewarmContexts.has(prewarmKey)) return;
+
+    const prewarmOptions = this.buildCanonicalPrewarmOptions(ctx, options);
+    let resolvePromise!: () => void;
+    let rejectPromise!: (error: unknown) => void;
+    const promise = new Promise<void>((resolve, reject) => {
+      resolvePromise = resolve;
+      rejectPromise = reject;
+    });
+
+    this.rememberProductionPrewarm(prewarmKey, promise);
+
+    queueMicrotask(() => {
+      void this.runProductionRenderPrewarm(currentSlug, ctx, prewarmOptions)
+        .then(resolvePromise, rejectPromise);
+    });
+
+    promise.catch((error) => {
+      this.productionPrewarmContexts.delete(prewarmKey);
+      logger.warn("Production render prewarm failed", {
+        projectId: ctx.projectId,
+        releaseId: ctx.releaseId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }
+
+  private shouldScheduleProductionPrewarm(
+    ctx: RenderContext,
+    options: RenderOptions | undefined,
+    cacheKey: string | null,
+  ): boolean {
+    if (RENDER_PREWARM_MAX_ROUTES <= 0) return false;
+    if (cacheKey === null) return false;
+    if (ctx.environment !== "production" || ctx.mode !== "production") return false;
+    if (!ctx.adapter?.fs) return false;
+    if (options?.studioEmbed) return false;
+    if (options?.params || options?.props) return false;
+    return true;
+  }
+
+  private getProductionPrewarmKey(ctx: RenderContext): string {
+    return `${ctx.cachePrefix}:canonical`;
+  }
+
+  private rememberProductionPrewarm(key: string, promise: Promise<void>): void {
+    while (this.productionPrewarmContexts.size >= RENDER_PREWARM_CONTEXT_MAX_ENTRIES) {
+      const oldest = this.productionPrewarmContexts.keys().next().value;
+      if (oldest === undefined) break;
+      this.productionPrewarmContexts.delete(oldest);
+    }
+    this.productionPrewarmContexts.set(key, promise);
+  }
+
+  private buildCanonicalPrewarmOptions(
+    ctx: RenderContext,
+    options?: RenderOptions,
+  ): RenderOptions {
+    return {
+      environment: ctx.environment,
+      projectId: ctx.projectId,
+      projectSlug: ctx.projectSlug,
+      contentSourceId: ctx.contentSourceId,
+      releaseId: ctx.releaseId,
+      releaseAssetManifest: options?.releaseAssetManifest ?? null,
+      noHmr: options?.noHmr,
+      forceProductionScripts: options?.forceProductionScripts,
+    };
+  }
+
+  private async runProductionRenderPrewarm(
+    currentSlug: string,
+    ctx: RenderContext,
+    options: RenderOptions,
+  ): Promise<void> {
+    const pages = await this.getAllPages(ctx);
+    const slugs = selectPrewarmSlugs(currentSlug, pages, RENDER_PREWARM_MAX_ROUTES);
+    if (slugs.length === 0) return;
+
+    logger.debug("Production render prewarm started", {
+      projectId: ctx.projectId,
+      releaseId: ctx.releaseId,
+      currentSlug,
+      routeCount: slugs.length,
+      concurrency: RENDER_PREWARM_CONCURRENCY,
+    });
+
+    let nextIndex = 0;
+    const workerCount = Math.min(RENDER_PREWARM_CONCURRENCY, slugs.length);
+
+    const runWorker = async () => {
+      while (true) {
+        const index = nextIndex++;
+        if (index >= slugs.length) return;
+
+        const slug = slugs[index]!;
+        try {
+          await this.renderPage(slug, ctx, options);
+        } catch (error) {
+          logger.warn("Production render prewarm route failed", {
+            slug,
+            projectId: ctx.projectId,
+            releaseId: ctx.releaseId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    };
+
+    await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+
+    logger.debug("Production render prewarm finished", {
+      projectId: ctx.projectId,
+      releaseId: ctx.releaseId,
+      routeCount: slugs.length,
+    });
   }
 
   private async doRenderPage(
@@ -474,6 +696,7 @@ export class Renderer {
 
   async destroy(): Promise<void> {
     await this.cache.destroy();
+    this.productionPrewarmContexts.clear();
     this.initialized = false;
     this.initializationPromise = null;
     logger.debug("Destroyed");

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.847";
+export const VERSION = "0.1.848";


### PR DESCRIPTION
## Summary
- Start bounded background render prewarm after the first cacheable production request for a release context.
- Use canonical route cache keys without request cookies, query strings, props, params, or nonces, and skip dynamic route patterns.
- Keep prewarm low-impact with max routes/concurrency env knobs and bounded in-process context tracking.
- Bump Veryfront to 0.1.848 for a new release.

## Validation
- VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --unstable-net src/rendering/renderer.test.ts
- VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --unstable-net src/rendering/shared/context-aware-cache.test.ts src/cache/request-cacheability.test.ts src/cache/keys.test.ts src/rendering/page-resolution/page-resolver.test.ts
- VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --unstable-net src/server/services/rendering/ssr.service.test.ts
- deno check --allow-import src/rendering/renderer.ts src/rendering/renderer.test.ts
- git diff --check
- pre-push hook: formatting, lint, type check, generation, and unit tests passed (2172 passed)