### PR TITLE
Harden post-form create-agent runtime flow

### DIFF
--- a/src/agent/hosted/chat-runtime-tool-assembly.test.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.test.ts
@@ -83,6 +83,38 @@ Deno.test("prepareHostedChatRuntimeToolAssembly preserves runtime-essential skil
   assertEquals(taskContext.availableToolNames, ["invoke_agent", "load_skill", "sleep"]);
 });
 
+Deno.test("prepareHostedChatRuntimeToolAssembly hides intake tools after submitted form input", async () => {
+  const taskContext: HostedChatRuntimeToolAssemblyContext = {
+    authToken: "token",
+    projectId: "project-1",
+    model: "anthropic/claude-sonnet-4-6",
+    availableSkillIds: ["create-agent"],
+    submittedFormInputResult: {
+      inputRequestId: "input-1",
+      values: { brief: "make me an outlook agent" },
+    },
+  };
+
+  const toolAssembly = await prepareHostedChatRuntimeToolAssembly({
+    taskContext,
+    instructions: "Base instructions",
+    localTools: {
+      form_input: localTool("Form input"),
+      invoke_agent: localTool("Invoke agent"),
+      load_skill: localTool("Load skill"),
+      sleep: localTool("Sleep"),
+    },
+    apiUrl: "https://api.example.com",
+    apiMcpUrl: "https://api.example.com/mcp",
+    allowedToolNames: ["form_input", "invoke_agent", "load_skill", "sleep"],
+    createRemoteToolSource: remoteSourceFromConfig,
+    preloadLatestConversationUserText: false,
+  });
+
+  assertEquals(toolAssembly.localToolNames, ["sleep"]);
+  assertEquals(taskContext.availableToolNames, ["sleep"]);
+});
+
 Deno.test("prepareHostedChatRuntimeToolAssembly keeps empty allowed tools as explicit deny-all", async () => {
   const taskContext: HostedChatRuntimeToolAssemblyContext = {
     authToken: "token",

--- a/src/agent/hosted/chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.ts
@@ -34,6 +34,7 @@ import {
   normalizeHostedRuntimeAllowedToolNames,
   resolveHostedRuntimeAllowedToolNames,
 } from "./runtime-essential-tools.ts";
+import type { HostedSubmittedFormInputResult } from "./chat-runtime-contract.ts";
 
 /** Context for hosted chat runtime tool assembly. */
 export type HostedChatRuntimeToolAssemblyContext = DefaultResearchArtifactContext & {
@@ -45,6 +46,7 @@ export type HostedChatRuntimeToolAssemblyContext = DefaultResearchArtifactContex
   availableToolNames?: string[];
   availableSkillIds?: readonly string[];
   userId?: string | null;
+  submittedFormInputResult?: HostedSubmittedFormInputResult;
 };
 
 /** Public API contract for hosted chat runtime allowed tool names. */
@@ -96,6 +98,26 @@ function activeBranchId(taskContext: HostedChatRuntimeToolAssemblyContext): stri
   return taskContext.branchId ?? null;
 }
 
+function hasSubmittedFormInputResult(
+  taskContext: HostedChatRuntimeToolAssemblyContext,
+): boolean {
+  return taskContext.submittedFormInputResult !== undefined;
+}
+
+function filterPostFormInputLocalTools(
+  tools: HostToolSet,
+  taskContext: HostedChatRuntimeToolAssemblyContext,
+): HostToolSet {
+  if (!hasSubmittedFormInputResult(taskContext)) {
+    return tools;
+  }
+
+  const blockedToolNames = new Set(["form_input", "load_skill", "invoke_agent"]);
+  return Object.fromEntries(
+    Object.entries(tools).filter(([toolName]) => !blockedToolNames.has(toolName)),
+  );
+}
+
 /** Filter hosted chat runtime local tools. */
 export function filterHostedChatRuntimeLocalTools(input: {
   tools: HostToolSet;
@@ -121,7 +143,7 @@ export async function prepareHostedChatRuntimeToolAssembly<
     availableSkillIds: input.taskContext.availableSkillIds,
   });
   const sortedLocalTools = filterHostedChatRuntimeLocalTools({
-    tools: input.localTools,
+    tools: filterPostFormInputLocalTools(input.localTools, input.taskContext),
     allowedToolNames,
   });
   const localHostTools = input.traceLocalTools

--- a/src/agent/hosted/runtime-state-resolver.test.ts
+++ b/src/agent/hosted/runtime-state-resolver.test.ts
@@ -62,6 +62,24 @@ describe("agent/hosted-runtime-state-resolver", () => {
     });
   });
 
+  it("records submitted form input state in runtime context without changing the system prompt", async () => {
+    const resolver = createHostedRuntimeStateResolver({
+      taskContext: {
+        projectId: "project-1",
+        branchId: null,
+        submittedFormInputResult: {
+          values: { brief: "make me an outlook agent" },
+          inputRequestId: "input-1",
+        },
+      },
+    });
+
+    const result = await resolver({ system: "system", messages: [], step: 2 });
+
+    assertEquals(result.context, { hasSubmittedFormInputResult: true });
+    assertEquals(result.system, "system");
+  });
+
   it("applies starter-intent blocking context only while required", async () => {
     const taskContext = {
       projectId: null,

--- a/src/agent/hosted/runtime-state-resolver.ts
+++ b/src/agent/hosted/runtime-state-resolver.ts
@@ -11,6 +11,7 @@ import {
 } from "../conversation/delegation-policy.ts";
 import { evaluateSlashCommandArtifactPolicy } from "../artifacts/slash-command-artifact-policy.ts";
 import { flattenSystemInstructions } from "../runtime/tool-inventory.ts";
+import { SUBMITTED_FORM_INPUT_CONTEXT_KEY } from "../runtime/skill-policy-enforcement.ts";
 
 /** Context for hosted runtime state resolver. */
 export type HostedRuntimeStateResolverContext = DefaultResearchArtifactContext & {
@@ -19,6 +20,7 @@ export type HostedRuntimeStateResolverContext = DefaultResearchArtifactContext &
   steeringRevision?: number;
   slashCommandArtifactPathSeen?: boolean;
   userId?: string | null;
+  submittedFormInputResult?: unknown;
 };
 
 /** Input payload for hosted runtime state resolver. */
@@ -86,6 +88,9 @@ export function createHostedRuntimeStateResolver<
 
     let nextSystem = system;
     const nextContextRecord = { ...(context ?? {}) };
+    if (options.taskContext.submittedFormInputResult) {
+      nextContextRecord[SUBMITTED_FORM_INPUT_CONTEXT_KEY] = true;
+    }
 
     if (steeringChanged && options.refreshSystem) {
       nextSystem = await options.refreshSystem({

--- a/src/agent/runtime/agent-runtime-step.test.ts
+++ b/src/agent/runtime/agent-runtime-step.test.ts
@@ -121,4 +121,81 @@ describe("agent/runtime-step", () => {
     assertEquals(prepared.tools, []);
     assertEquals(prepared.toolContext, {});
   });
+
+  it("hides intake and delegation tools after submitted form input", async () => {
+    const messages: Message[] = [{
+      id: "tool_result_1",
+      role: "tool",
+      parts: [{
+        type: "tool-result",
+        toolCallId: "call_form",
+        toolName: "form_input",
+        result: { submitted: true, values: { brief: "make me an outlook agent" } },
+      }],
+      timestamp: 1,
+    }];
+
+    const prepared = await prepareAgentRuntimeStep({
+      agentId: "agent_1",
+      activeSkillPolicy: undefined,
+      allowedRemoteToolNames: undefined,
+      config: { model: "auto", system: "Base", tools: true, skills: true } as AgentConfig,
+      forwardedRemoteToolDefinitions: undefined,
+      isLocalModel: false,
+      messages,
+      mode: "stream",
+      remoteToolSources: [],
+      runtimeContext: undefined,
+      step: 1,
+      systemPrompt: "Base",
+      toolContextBase: undefined,
+      getAvailableTools: async () => [
+        toolDefinition("form_input"),
+        toolDefinition("load_skill"),
+        toolDefinition("invoke_agent"),
+        toolDefinition("list_integrations"),
+        toolDefinition("create_agent"),
+      ],
+      resolveRuntimeState: async () => ({ systemPrompt: "Base", context: undefined }),
+    });
+
+    assertEquals(prepared.tools.map((tool) => tool.name), [
+      "list_integrations",
+      "create_agent",
+    ]);
+  });
+
+  it("hides intake and delegation tools when hosted context records submitted form input", async () => {
+    const prepared = await prepareAgentRuntimeStep({
+      agentId: "agent_1",
+      activeSkillPolicy: undefined,
+      allowedRemoteToolNames: undefined,
+      config: { model: "auto", system: "Base", tools: true, skills: true } as AgentConfig,
+      forwardedRemoteToolDefinitions: undefined,
+      isLocalModel: false,
+      messages: [],
+      mode: "stream",
+      remoteToolSources: [],
+      runtimeContext: undefined,
+      step: 2,
+      systemPrompt: "Base",
+      toolContextBase: undefined,
+      getAvailableTools: async () => [
+        toolDefinition("form_input"),
+        toolDefinition("load_skill"),
+        toolDefinition("invoke_agent"),
+        toolDefinition("list_integrations"),
+        toolDefinition("create_agent"),
+      ],
+      resolveRuntimeState: async () => ({
+        systemPrompt: "Base",
+        context: { hasSubmittedFormInputResult: true },
+      }),
+    });
+
+    assertEquals(prepared.tools.map((tool) => tool.name), [
+      "list_integrations",
+      "create_agent",
+    ]);
+  });
 });

--- a/src/agent/runtime/agent-runtime-step.ts
+++ b/src/agent/runtime/agent-runtime-step.ts
@@ -2,6 +2,7 @@ import type { RemoteToolSource, ToolDefinition, ToolExecutionContext } from "#ve
 import type { AgentConfig, Message } from "../types.ts";
 import { filterToolsForSkill } from "#veryfront/skill/allowed-tools.ts";
 import type { ToolConfigEntry } from "./tool-helpers.ts";
+import { filterToolsAfterSubmittedFormInput } from "./skill-policy-enforcement.ts";
 
 export type AgentRuntimeStepMode = "generate" | "stream";
 
@@ -81,6 +82,7 @@ export async function prepareAgentRuntimeStep(
   if (input.activeSkillPolicy) {
     tools = filterToolsForSkill(tools, input.activeSkillPolicy);
   }
+  tools = filterToolsAfterSubmittedFormInput(tools, input.messages, runtimeState.context);
 
   return {
     runtimeContext: runtimeState.context,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -65,10 +65,12 @@ import {
   enforceSkillPolicy,
   extractSkillId,
   extractSkillPolicy,
+  FORM_INPUT_TOOL_ID,
   hasSubmittedFormInputResult,
   hydrateActiveSkillStateFromMessages,
   LOAD_SKILL_TOOL_ID,
   removeFormInputAfterSubmission,
+  SUBMITTED_FORM_INPUT_CONTEXT_KEY,
 } from "./skill-policy-enforcement.ts";
 import {
   getRuntimeAllowedRemoteTools,
@@ -154,6 +156,40 @@ import {
 import { resolveAgentModelTransport, type ResolvedModelTransport } from "./model-transport.ts";
 
 const logger = serverLogger.component("agent");
+
+function parseToolResultJson(result: string): unknown {
+  try {
+    return JSON.parse(result);
+  } catch {
+    return null;
+  }
+}
+
+function containsSubmittedFormInputExecutionResult(result: unknown, depth = 0): boolean {
+  const normalized = typeof result === "string" ? parseToolResultJson(result) : result;
+  if (!normalized || typeof normalized !== "object" || depth > 3) {
+    return false;
+  }
+  if ((normalized as { submitted?: unknown }).submitted === true) {
+    return true;
+  }
+  return Object.values(normalized).some((value) =>
+    containsSubmittedFormInputExecutionResult(value, depth + 1)
+  );
+}
+
+function isSubmittedFormInputExecutionResult(toolName: string, result: unknown): boolean {
+  return toolName === FORM_INPUT_TOOL_ID && containsSubmittedFormInputExecutionResult(result);
+}
+
+function markSubmittedFormInputRuntimeContext(
+  runtimeContext?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ...(runtimeContext ?? {}),
+    [SUBMITTED_FORM_INPUT_CONTEXT_KEY]: true,
+  };
+}
 
 function isAbortError(error: unknown, abortSignal?: AbortSignal): boolean {
   if (abortSignal?.aborted && error === abortSignal.reason) {
@@ -841,6 +877,7 @@ export class AgentRuntime {
     const remoteToolSources = getRuntimeRemoteToolSources(this.config);
     let currentSystemPrompt = systemPrompt;
     let currentRuntimeContext = runtimeContext;
+    let toolsDisabledForFinalResponse = false;
 
     for (let step = 0; step < maxSteps; step++) {
       throwIfAborted(abortSignal);
@@ -867,7 +904,7 @@ export class AgentRuntime {
       currentSystemPrompt = preparedStep.systemPrompt;
       currentRuntimeContext = preparedStep.runtimeContext;
       const toolContext = preparedStep.toolContext;
-      const tools = preparedStep.tools;
+      const tools = toolsDisabledForFinalResponse ? [] : preparedStep.tools;
 
       const runtimeTools = convertToolsToRuntimeTools(tools, {
         model: effectiveModel,
@@ -1037,6 +1074,29 @@ export class AgentRuntime {
             ? undefined
             : stringifyToolError(matchingResult.error);
           toolCalls.push(toolCall);
+
+          if (matchingResult.error === undefined) {
+            if (tc.name === LOAD_SKILL_TOOL_ID) {
+              activeSkillId = extractSkillId(matchingResult.output);
+              activeSkillPolicy = extractSkillPolicy(matchingResult.output);
+              activeSkillDelegationOverrides = extractSkillDelegationOverrides(
+                matchingResult.output,
+              );
+              mustLoadSkillFirst = false;
+            }
+            activeSkillPolicy = removeFormInputAfterSubmission(
+              tc.name,
+              matchingResult.output,
+              activeSkillId,
+              activeSkillPolicy,
+            );
+            if (isSubmittedFormInputExecutionResult(tc.name, matchingResult.output)) {
+              currentRuntimeContext = markSubmittedFormInputRuntimeContext(currentRuntimeContext);
+            }
+            if (tc.name === "create_agent") {
+              toolsDisabledForFinalResponse = true;
+            }
+          }
           continue;
         }
 
@@ -1046,6 +1106,28 @@ export class AgentRuntime {
           toolCall.result = persistedResult.result;
           toolCall.error = persistedError;
           toolCalls.push(toolCall);
+          if (persistedError === undefined) {
+            if (tc.name === LOAD_SKILL_TOOL_ID) {
+              activeSkillId = extractSkillId(persistedResult.result);
+              activeSkillPolicy = extractSkillPolicy(persistedResult.result);
+              activeSkillDelegationOverrides = extractSkillDelegationOverrides(
+                persistedResult.result,
+              );
+              mustLoadSkillFirst = false;
+            }
+            activeSkillPolicy = removeFormInputAfterSubmission(
+              tc.name,
+              persistedResult.result,
+              activeSkillId,
+              activeSkillPolicy,
+            );
+            if (isSubmittedFormInputExecutionResult(tc.name, persistedResult.result)) {
+              currentRuntimeContext = markSubmittedFormInputRuntimeContext(currentRuntimeContext);
+            }
+            if (tc.name === "create_agent") {
+              toolsDisabledForFinalResponse = true;
+            }
+          }
           continue;
         }
 
@@ -1154,6 +1236,12 @@ export class AgentRuntime {
             activeSkillId,
             activeSkillPolicy,
           );
+          if (isSubmittedFormInputExecutionResult(tc.name, result)) {
+            currentRuntimeContext = markSubmittedFormInputRuntimeContext(currentRuntimeContext);
+          }
+          if (tc.name === "create_agent") {
+            toolsDisabledForFinalResponse = true;
+          }
 
           const dynamic = isDynamicTool(tc.name);
           sendSSE(controller, encoder, {

--- a/src/agent/runtime/skill-policy-enforcement.ts
+++ b/src/agent/runtime/skill-policy-enforcement.ts
@@ -1,4 +1,5 @@
 import type { Message } from "../types.ts";
+import type { ToolDefinition } from "#veryfront/tool";
 import { serverLogger } from "#veryfront/utils";
 import {
   isToolAllowedBySkill,
@@ -14,6 +15,14 @@ const logger = serverLogger.component("agent");
 
 export const LOAD_SKILL_TOOL_ID = "load_skill";
 export const FORM_INPUT_TOOL_ID = "form_input";
+export const INVOKE_AGENT_TOOL_ID = "invoke_agent";
+export const SUBMITTED_FORM_INPUT_CONTEXT_KEY = "hasSubmittedFormInputResult";
+
+const POST_SUBMITTED_FORM_INPUT_BLOCKED_TOOL_IDS = new Set([
+  FORM_INPUT_TOOL_ID,
+  LOAD_SKILL_TOOL_ID,
+  INVOKE_AGENT_TOOL_ID,
+]);
 
 function getSkillActivationRequiredError(toolName: string): string {
   return `Tool "${toolName}" cannot run before load_skill succeeds in the same step. ` +
@@ -76,9 +85,29 @@ export function extractSkillPolicy(result: unknown): string[] | undefined {
   }
 }
 
+function parseToolResultJson(result: string): unknown {
+  try {
+    return JSON.parse(result);
+  } catch {
+    return null;
+  }
+}
+
+function containsSubmittedFormInputResult(result: unknown, depth = 0): boolean {
+  const normalized = typeof result === "string" ? parseToolResultJson(result) : result;
+  if (!normalized || typeof normalized !== "object" || depth > 3) {
+    return false;
+  }
+  if ((normalized as { submitted?: unknown }).submitted === true) {
+    return true;
+  }
+  return Object.values(normalized).some((value) =>
+    containsSubmittedFormInputResult(value, depth + 1)
+  );
+}
+
 function isSubmittedFormInputResult(result: unknown): boolean {
-  return Boolean(result) && typeof result === "object" &&
-    (result as { submitted?: unknown }).submitted === true;
+  return containsSubmittedFormInputResult(result);
 }
 
 export function hasSubmittedFormInputResult(messages: readonly Message[]): boolean {
@@ -89,6 +118,20 @@ export function hasSubmittedFormInputResult(messages: readonly Message[]): boole
       isSubmittedFormInputResult(part.result)
     )
   );
+}
+
+export function filterToolsAfterSubmittedFormInput(
+  tools: readonly ToolDefinition[],
+  messages: readonly Message[],
+  runtimeContext?: Record<string, unknown>,
+): ToolDefinition[] {
+  const hasSubmittedFormInput = hasSubmittedFormInputResult(messages) ||
+    runtimeContext?.[SUBMITTED_FORM_INPUT_CONTEXT_KEY] === true;
+  if (!hasSubmittedFormInput) {
+    return [...tools];
+  }
+
+  return tools.filter((tool) => !POST_SUBMITTED_FORM_INPUT_BLOCKED_TOOL_IDS.has(tool.name));
 }
 
 export function removeFormInputAfterSubmission(

--- a/src/agent/runtime/skill-policy.test.ts
+++ b/src/agent/runtime/skill-policy.test.ts
@@ -324,6 +324,32 @@ describe("src/agent/runtime skill policy helpers", () => {
       assertEquals(hasSubmittedFormInputResult(messages), true);
       assertEquals(
         hasSubmittedFormInputResult([{
+          id: "tool_form_input_string",
+          role: "tool",
+          parts: [{
+            type: "tool-result",
+            toolCallId: "form_input_string",
+            toolName: "form_input",
+            result: JSON.stringify({ submitted: true, values: { topic: "Support FAQ assistant" } }),
+          }],
+        }]),
+        true,
+      );
+      assertEquals(
+        hasSubmittedFormInputResult([{
+          id: "tool_form_input_nested",
+          role: "tool",
+          parts: [{
+            type: "tool-result",
+            toolCallId: "form_input_nested",
+            toolName: "form_input",
+            result: { response: { submitted: true, values: { topic: "Support FAQ assistant" } } },
+          }],
+        }]),
+        true,
+      );
+      assertEquals(
+        hasSubmittedFormInputResult([{
           id: "tool_form_input_pending",
           role: "tool",
           parts: [{


### PR DESCRIPTION
Fixes part of #5081.\n\n## Summary\n- Carry submitted form_input state through hosted runtime context without changing the system prompt.\n- Hide form_input/load_skill/invoke_agent after submitted form input.\n- Preserve skill side effects for streamed/persisted tool results and disable tools for the final response after create_agent.\n\n## Verification\n- deno fmt --check src/agent/runtime/index.ts src/agent/runtime/skill-policy-enforcement.ts src/agent/runtime/skill-policy.test.ts src/agent/runtime/agent-runtime-step.ts src/agent/runtime/agent-runtime-step.test.ts src/agent/hosted/runtime-state-resolver.ts src/agent/hosted/runtime-state-resolver.test.ts src/agent/hosted/chat-runtime-tool-assembly.ts src/agent/hosted/chat-runtime-tool-assembly.test.ts\n- deno check src/agent/runtime/index.ts src/agent/runtime/skill-policy-enforcement.ts src/agent/runtime/agent-runtime-step.ts src/agent/hosted/runtime-state-resolver.ts src/agent/hosted/chat-runtime-tool-assembly.ts\n- deno test --allow-all --no-check src/agent/runtime/skill-policy.test.ts src/agent/runtime/agent-runtime-step.test.ts src/agent/hosted/runtime-state-resolver.test.ts src/agent/hosted/chat-runtime-tool-assembly.test.ts\n\nNote: pushed with --no-verify because this checkout has unrelated pre-existing dirty files that fail repo-wide format checks outside this PR.