### PR TITLE
Suppress unavailable streamed tool calls

### DIFF
--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -68,6 +68,7 @@ describe("chat-stream-handler", () => {
       assertEquals(state.finishReason, null);
       assertEquals(state.toolCalls.size, 0);
       assertEquals(state.toolResults.length, 0);
+      assertEquals(state.suppressedToolCalls, []);
       assertEquals(state.usage, { promptTokens: 0, completionTokens: 0, totalTokens: 0 });
     });
   });
@@ -185,6 +186,38 @@ describe("chat-stream-handler", () => {
         },
         { type: "text-start", id: "text-1" },
         { type: "text-delta", id: "text-1", delta: " After tool." },
+        { type: "text-end", id: "text-1" },
+      ]);
+    });
+
+    it("suppresses streamed tool calls that are not available in the current step", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        { type: "text-delta", text: "I will reload the skill." },
+        { type: "tool-input-start", id: "tc-stale", toolName: "load_skill" },
+        { type: "tool-input-delta", id: "tc-stale", delta: '{"id":"create-agent"}' },
+        { type: "tool-input-end", id: "tc-stale" },
+        {
+          type: "tool-call",
+          toolCallId: "tc-stale",
+          toolName: "load_skill",
+          input: { id: "create-agent" },
+        },
+        { type: "finish", finishReason: "tool-calls", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "text-1", {
+        availableToolNames: ["create_agent", "list_integrations", "get_integration"],
+      });
+
+      assertEquals(state.toolCalls.size, 0);
+      assertEquals(state.toolResults, []);
+      assertEquals(state.suppressedToolCalls, [{ id: "tc-stale", name: "load_skill" }]);
+      assertEquals(events, [
+        { type: "text-start", id: "text-1" },
+        { type: "text-delta", id: "text-1", delta: "I will reload the skill." },
         { type: "text-end", id: "text-1" },
       ]);
     });

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -68,6 +68,7 @@ export interface ChatStreamState {
   finishReason: string | null;
   toolCalls: Map<string, StreamingToolCall>;
   toolResults: StreamingToolResult[];
+  suppressedToolCalls: { id: string; name: string }[];
   usage: {
     promptTokens: number;
     completionTokens: number;
@@ -91,6 +92,7 @@ export interface ChatStreamCallbacks {
     reasoningTokens?: number;
   }) => void;
   providerExecutedToolNames?: readonly string[];
+  availableToolNames?: readonly string[];
   localToolInputIdleTimeoutMs?: number;
   streamIdleTimeoutMs?: number;
 }
@@ -301,6 +303,7 @@ export function createStreamState(): ChatStreamState {
     finishReason: null,
     toolCalls: new Map(),
     toolResults: [],
+    suppressedToolCalls: [],
     usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
   };
 }
@@ -332,6 +335,21 @@ export function processStream(
     let shouldStopForCommittedLocalToolCall = false;
     let hasActiveLocalToolInput = false;
     const providerExecutedToolNames = new Set(callbacks?.providerExecutedToolNames ?? []);
+    const availableToolNames = callbacks?.availableToolNames
+      ? new Set(callbacks.availableToolNames)
+      : null;
+    const suppressedToolCallIds = new Set<string>();
+
+    const isUnavailableTool = (toolName: string) =>
+      availableToolNames !== null && !availableToolNames.has(toolName);
+
+    const suppressToolCall = (toolCallId: string | undefined, toolName: string) => {
+      if (!toolCallId || suppressedToolCallIds.has(toolCallId)) {
+        return;
+      }
+      suppressedToolCallIds.add(toolCallId);
+      state.suppressedToolCalls.push({ id: toolCallId, name: toolName });
+    };
 
     const resolveProviderExecuted = (toolName: string, providerExecuted?: boolean) =>
       providerExecuted ?? (providerExecutedToolNames.has(toolName) ? true : undefined);
@@ -653,6 +671,11 @@ export function processStream(
           closeReasoningSegment();
           shouldStopForCommittedLocalToolCall = false;
           const toolId = typedPart.id;
+          if (isUnavailableTool(typedPart.toolName)) {
+            suppressToolCall(toolId, typedPart.toolName);
+            hasActiveLocalToolInput = false;
+            break;
+          }
           const providerExecuted = resolveProviderExecuted(
             typedPart.toolName,
             typedPart.providerExecuted,
@@ -674,6 +697,7 @@ export function processStream(
         case "tool-input-delta": {
           closeReasoningSegment();
           const toolId = typedPart.id;
+          if (suppressedToolCallIds.has(toolId)) break;
           const tc = state.toolCalls.get(toolId);
           if (!tc) break;
 
@@ -687,6 +711,10 @@ export function processStream(
           closeTextSegment();
           closeReasoningSegment();
           const toolId = typedPart.id;
+          if (suppressedToolCallIds.has(toolId)) {
+            hasActiveLocalToolInput = false;
+            break;
+          }
           const tc = state.toolCalls.get(toolId);
           if (!tc) break;
 
@@ -716,6 +744,11 @@ export function processStream(
           closeReasoningSegment();
           const toolId = typedPart.toolCallId ?? typedPart.id;
           if (!toolId) {
+            break;
+          }
+          if (isUnavailableTool(typedPart.toolName)) {
+            suppressToolCall(toolId, typedPart.toolName);
+            hasActiveLocalToolInput = false;
             break;
           }
           const providerExecuted = resolveProviderExecuted(
@@ -759,6 +792,11 @@ export function processStream(
           closeReasoningSegment();
           // tool-call fires when the full tool call is available
           const toolId = typedPart.toolCallId;
+          if (isUnavailableTool(typedPart.toolName)) {
+            suppressToolCall(toolId, typedPart.toolName);
+            hasActiveLocalToolInput = false;
+            break;
+          }
           const providerExecuted = resolveProviderExecuted(
             typedPart.toolName,
             typedPart.providerExecuted,
@@ -803,6 +841,13 @@ export function processStream(
         case "tool-result": {
           closeTextSegment();
           closeReasoningSegment();
+          if (
+            suppressedToolCallIds.has(typedPart.toolCallId) ||
+            isUnavailableTool(typedPart.toolName)
+          ) {
+            suppressToolCall(typedPart.toolCallId, typedPart.toolName);
+            break;
+          }
           const providerExecuted = resolveProviderExecuted(
             typedPart.toolName,
             typedPart.providerExecuted,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -915,6 +915,7 @@ export class AgentRuntime {
         model: effectiveModel,
         providerTools,
       });
+      const runtimeToolNames = Object.keys(runtimeTools ?? {});
 
       const temperature = this.resolveTemperature(temperatureModelString ?? effectiveModel);
       const result = streamText({
@@ -935,6 +936,7 @@ export class AgentRuntime {
         onChunk: callbacks?.onChunk,
         onUsage: (usage) => accumulateUsage(totalUsage, usage),
         providerExecutedToolNames: getProviderExecutedToolNames(runtimeTools),
+        availableToolNames: runtimeToolNames,
       }, abortSignal);
       throwIfAborted(abortSignal);
       finalFinishReason = state.finishReason ?? finalFinishReason;
@@ -988,6 +990,23 @@ export class AgentRuntime {
       latestAssistantText = getTextFromParts(assistantMessage.parts);
       currentMessages.push(assistantMessage);
       await this.memory.add(assistantMessage);
+
+      if (state.suppressedToolCalls.length > 0) {
+        const unavailableNames = [
+          ...new Set(state.suppressedToolCalls.map((toolCall) => toolCall.name)),
+        ];
+        currentMessages.push({
+          id: `runtime_note_${Date.now()}_${step}`,
+          role: "system",
+          parts: [{
+            type: "text",
+            text: `Runtime recovery: ignored unavailable tool call(s): ${
+              unavailableNames.join(", ")
+            }. Continue using only currently available tools: ${runtimeToolNames.join(", ")}.`,
+          }],
+          timestamp: Date.now(),
+        });
+      }
 
       const finalToolResults = collectFinalStreamToolResults(state);
 

--- a/src/agent/runtime/tool-result-continuation.test.ts
+++ b/src/agent/runtime/tool-result-continuation.test.ts
@@ -21,6 +21,18 @@ function createState(
 }
 
 describe("agent runtime streamed tool result collection", () => {
+  it("continues after suppressing unavailable streamed tool calls", () => {
+    const shouldContinue = shouldContinueAfterStreamStep({
+      accumulatedText: "I will reload the skill.",
+      finishReason: "tool-calls",
+      toolCalls: new Map(),
+      toolResults: [],
+      suppressedToolCalls: [{ id: "tc-stale", name: "load_skill" }],
+    });
+
+    assertEquals(shouldContinue, true);
+  });
+
   it("continues after provider-executed tool results arrive without assistant text", () => {
     const shouldContinue = shouldContinueAfterStreamStep({
       accumulatedText: "",

--- a/src/agent/runtime/tool-result-continuation.ts
+++ b/src/agent/runtime/tool-result-continuation.ts
@@ -129,10 +129,12 @@ export function collectGeneratedToolResults(
 }
 
 export function shouldContinueAfterStreamStep(
-  state: Pick<ChatStreamState, "accumulatedText" | "finishReason" | "toolCalls" | "toolResults">,
+  state:
+    & Pick<ChatStreamState, "accumulatedText" | "finishReason" | "toolCalls" | "toolResults">
+    & Partial<Pick<ChatStreamState, "suppressedToolCalls">>,
 ): boolean {
   if (!state.toolCalls.size) {
-    return false;
+    return state.finishReason === "tool-calls" && Boolean(state.suppressedToolCalls?.length);
   }
 
   const streamedToolCalls = Array.from(state.toolCalls.values());


### PR DESCRIPTION
## Summary\n- suppress stale streamed tool calls that are no longer in the current runtime tool set\n- continue the agent loop with an internal recovery note instead of emitting failed tool-call events\n- add regression coverage for unavailable streamed tool suppression\n\n## Verification\n- deno task test src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/tool-result-continuation.test.ts\n- deno task typecheck\n- pre-push unit suite was attempted and hit pre-existing observability/metrics/config expectations: expected console, actual otlp\n