### PR TITLE
Keep render prewarm focused on resolvable routes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.848",
+  "version": "0.1.849",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/architecture/02-request-pipeline.md
+++ b/docs/architecture/02-request-pipeline.md
@@ -109,11 +109,11 @@ endpoint cache.
 
 Production HTML rendering also starts a bounded background prewarm after the
 first cacheable request for a project release context. The prewarm discovers
-concrete static routes, skips dynamic route patterns, uses canonical route cache
-keys without request cookies, query strings, or nonces, and checks the shared
-render cache before rendering each route. This populates the API-backed
-distributed render cache for sibling routes without adding latency to the
-foreground response.
+concrete static routes, skips dynamic route patterns, validates each candidate
+route resolves, uses canonical route cache keys without request cookies, query
+strings, or nonces, and checks the shared render cache before rendering each
+route. This populates the API-backed distributed render cache for sibling routes
+without adding latency to the foreground response.
 
 Default render prewarm controls:
 

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -351,10 +351,15 @@ describe("Renderer release asset cache isolation", () => {
   it("prewarms sibling production routes after a cacheable render", async () => {
     const store = createInMemoryStore();
     const renderedSlugs: string[] = [];
+    const stalePages = Array.from(
+      { length: 14 },
+      (_, index) => `aa-stale-${index.toString().padStart(2, "0")}`,
+    );
     const renderer = new Renderer({ cache: { store } });
     (renderer as unknown as { initialized: boolean }).initialized = true;
     (renderer as unknown as {
       getAllPages: () => Promise<string[]>;
+      pageExists: (slug: string) => Promise<boolean>;
       createServicesForContext: () => {
         pipeline: {
           renderPage: (
@@ -368,7 +373,11 @@ describe("Renderer release asset cache isolation", () => {
           }>;
         };
       };
-    }).getAllPages = () => Promise.resolve(["/", "/blog", "/docs/[slug]", "about", "/blog"]);
+    }).getAllPages = () =>
+      Promise.resolve(["/", ...stalePages, "/docs/[slug]", "about", "/blog", "/blog"]);
+    (renderer as unknown as {
+      pageExists: (slug: string) => Promise<boolean>;
+    }).pageExists = (slug) => Promise.resolve(slug === "/about" || slug === "/blog");
     (renderer as unknown as {
       createServicesForContext: () => {
         pipeline: {
@@ -414,10 +423,13 @@ describe("Renderer release asset cache isolation", () => {
     const prefix = buildRenderCachePrefix("proj-1", "production", "rel-1");
     assertEquals(result.html, "<html>/</html>");
     assertEquals(renderedSlugs.includes("/blog"), true);
-    assertEquals(renderedSlugs.includes("about"), true);
+    assertEquals(renderedSlugs.includes("/about"), true);
+    assertEquals(renderedSlugs.includes("about"), false);
     assertEquals(renderedSlugs.includes("/docs/[slug]"), false);
+    assertEquals(renderedSlugs.some((slug) => slug.startsWith("/aa-stale-")), false);
     assertEquals(store.data.has(`${prefix}:page:/blog`), true);
-    assertEquals(store.data.has(`${prefix}:page:about`), true);
+    assertEquals(store.data.has(`${prefix}:page:/about`), true);
+    assertEquals(store.data.has(`${prefix}:page:about`), false);
   });
 
   it("does not prewarm when the request has cache-sensitive state", async () => {

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -177,13 +177,10 @@ function prewarmSlugDepth(slug: string): number {
 function selectPrewarmSlugs(
   currentSlug: string,
   pages: string[],
-  maxRoutes: number,
 ): string[] {
-  if (maxRoutes <= 0) return [];
-
   const currentComparable = normalizeComparableSlug(currentSlug);
   const seen = new Set<string>();
-  const candidates: Array<{ slug: string; comparable: string }> = [];
+  const candidates: Array<{ comparable: string }> = [];
 
   for (const page of pages) {
     if (!isConcretePrewarmSlug(page)) continue;
@@ -192,7 +189,7 @@ function selectPrewarmSlugs(
     if (comparable === currentComparable || seen.has(comparable)) continue;
 
     seen.add(comparable);
-    candidates.push({ slug: page, comparable });
+    candidates.push({ comparable });
   }
 
   candidates.sort((a, b) =>
@@ -200,7 +197,7 @@ function selectPrewarmSlugs(
     a.comparable.localeCompare(b.comparable)
   );
 
-  return candidates.slice(0, maxRoutes).map(({ slug }) => slug);
+  return candidates.map(({ comparable }) => comparable);
 }
 
 /**
@@ -512,8 +509,15 @@ export class Renderer {
     ctx: RenderContext,
     options: RenderOptions,
   ): Promise<void> {
+    if (RENDER_PREWARM_MAX_ROUTES <= 0) return;
+
     const pages = await this.getAllPages(ctx);
-    const slugs = selectPrewarmSlugs(currentSlug, pages, RENDER_PREWARM_MAX_ROUTES);
+    const candidateSlugs = selectPrewarmSlugs(currentSlug, pages);
+    const slugs = await this.filterResolvablePrewarmSlugs(
+      ctx,
+      candidateSlugs,
+      RENDER_PREWARM_MAX_ROUTES,
+    );
     if (slugs.length === 0) return;
 
     logger.debug("Production render prewarm started", {
@@ -679,6 +683,44 @@ export class Renderer {
     }
 
     return createPageResolver(ctx).getAllPages();
+  }
+
+  async pageExists(slug: string, ctx: RenderContext): Promise<boolean> {
+    if (!this.initialized) {
+      throw INITIALIZATION_ERROR.create({
+        detail: "Renderer not initialized. Call initialize() first.",
+      });
+    }
+
+    return createPageResolver(ctx).pageExists(slug);
+  }
+
+  private async filterResolvablePrewarmSlugs(
+    ctx: RenderContext,
+    slugs: string[],
+    maxRoutes: number,
+  ): Promise<string[]> {
+    if (maxRoutes <= 0) return [];
+
+    const resolvable: string[] = [];
+
+    for (const slug of slugs) {
+      try {
+        if (await this.pageExists(slug, ctx)) {
+          resolvable.push(slug);
+          if (resolvable.length >= maxRoutes) break;
+        }
+      } catch (error) {
+        logger.warn("Production render prewarm route validation failed", {
+          slug,
+          projectId: ctx.projectId,
+          releaseId: ctx.releaseId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return resolvable;
   }
 
   async clearCache(ctx: RenderContext, slug?: string): Promise<void> {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.848";
+export const VERSION = "0.1.849";


### PR DESCRIPTION
## Summary
- validate production prewarm candidates with page resolution before rendering
- apply the prewarm route cap after validation so stale page-like files cannot consume the budget
- canonicalize bare page slugs to request-path cache keys and bump Veryfront to 0.1.849

## Verification
- deno fmt src/rendering/renderer.ts src/rendering/renderer.test.ts docs/architecture/02-request-pipeline.md deno.json src/utils/version-constant.ts
- VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --unstable-net src/rendering/renderer.test.ts
- VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --unstable-net src/rendering/page-resolution/page-resolver.test.ts src/rendering/shared/context-aware-cache.test.ts
- deno check src/rendering/renderer.ts src/rendering/renderer.test.ts
- git diff --check
- pre-push hook: format, lint, typecheck, unit tests: 2173 passed, 0 failed