### PR TITLE
Block intake tools after submitted form input

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.849",
+  "version": "0.1.850",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -553,6 +553,8 @@ export class AgentRuntime {
       let activeSkillId = hydratedSkillState.activeSkillId;
       let activeSkillPolicy = hydratedSkillState.activeSkillPolicy;
       let activeSkillDelegationOverrides = hydratedSkillState.activeSkillDelegationOverrides;
+      const hasSubmittedFormInputInLoop = hasSubmittedFormInputResult(currentMessages) ||
+        runtimeContext?.[SUBMITTED_FORM_INPUT_CONTEXT_KEY] === true;
       const allowedRemoteToolNames = getRuntimeAllowedRemoteTools(this.config);
       const providerTools = getRuntimeProviderTools(this.config);
       const forwardedRemoteToolDefinitions = getRuntimeForwardedIntegrationToolDefs(this.config);
@@ -563,6 +565,9 @@ export class AgentRuntime {
       for (let step = 0; step < maxSteps; step++) {
         this.status = "thinking";
         addSpanEvent(loopSpan, "step_start", { step });
+        const stepRuntimeContext = hasSubmittedFormInputInLoop
+          ? markSubmittedFormInputRuntimeContext(currentRuntimeContext)
+          : currentRuntimeContext;
 
         const preparedStep = await prepareAgentRuntimeStep({
           agentId: this.id,
@@ -576,7 +581,7 @@ export class AgentRuntime {
           mode: "generate",
           remoteToolSources,
           resolveRuntimeState: this.resolveRuntimeState.bind(this),
-          runtimeContext: currentRuntimeContext,
+          runtimeContext: stepRuntimeContext,
           step,
           systemPrompt: currentSystemPrompt,
           toolContextBase,
@@ -710,7 +715,7 @@ export class AgentRuntime {
               activeSkillPolicy,
               mustLoadSkillFirst,
               {
-                allowSubmittedFormInputReuse: hasSubmittedFormInputResult(currentMessages),
+                hasSubmittedFormInput: hasSubmittedFormInputInLoop,
               },
             );
             if (!policyCheck.allowed) {
@@ -874,6 +879,8 @@ export class AgentRuntime {
     let activeSkillId = hydratedSkillState.activeSkillId;
     let activeSkillPolicy = hydratedSkillState.activeSkillPolicy;
     let activeSkillDelegationOverrides = hydratedSkillState.activeSkillDelegationOverrides;
+    let hasSubmittedFormInputInLoop = hasSubmittedFormInputResult(currentMessages) ||
+      runtimeContext?.[SUBMITTED_FORM_INPUT_CONTEXT_KEY] === true;
     let finalFinishReason: string | undefined;
     let latestAssistantText = "";
     const allowedRemoteToolNames = getRuntimeAllowedRemoteTools(this.config);
@@ -888,6 +895,9 @@ export class AgentRuntime {
       throwIfAborted(abortSignal);
       sendSSE(controller, encoder, { type: "step-start" });
       const currentStepToolResults = new Map<string, ToolResultPart>();
+      const stepRuntimeContext = hasSubmittedFormInputInLoop
+        ? markSubmittedFormInputRuntimeContext(currentRuntimeContext)
+        : currentRuntimeContext;
 
       const preparedStep = await prepareAgentRuntimeStep({
         agentId: this.id,
@@ -901,7 +911,7 @@ export class AgentRuntime {
         mode: "stream",
         remoteToolSources,
         resolveRuntimeState: this.resolveRuntimeState.bind(this),
-        runtimeContext: currentRuntimeContext,
+        runtimeContext: stepRuntimeContext,
         step,
         systemPrompt: currentSystemPrompt,
         toolContextBase,
@@ -1115,6 +1125,7 @@ export class AgentRuntime {
               activeSkillPolicy,
             );
             if (isSubmittedFormInputExecutionResult(tc.name, matchingResult.output)) {
+              hasSubmittedFormInputInLoop = true;
               currentRuntimeContext = markSubmittedFormInputRuntimeContext(currentRuntimeContext);
             }
             if (tc.name === "create_agent") {
@@ -1146,6 +1157,7 @@ export class AgentRuntime {
               activeSkillPolicy,
             );
             if (isSubmittedFormInputExecutionResult(tc.name, persistedResult.result)) {
+              hasSubmittedFormInputInLoop = true;
               currentRuntimeContext = markSubmittedFormInputRuntimeContext(currentRuntimeContext);
             }
             if (tc.name === "create_agent") {
@@ -1191,7 +1203,7 @@ export class AgentRuntime {
           activeSkillPolicy,
           mustLoadSkillFirst,
           {
-            allowSubmittedFormInputReuse: hasSubmittedFormInputResult(currentMessages),
+            hasSubmittedFormInput: hasSubmittedFormInputInLoop,
           },
         );
         if (!policyCheck.allowed) {
@@ -1261,6 +1273,7 @@ export class AgentRuntime {
             activeSkillPolicy,
           );
           if (isSubmittedFormInputExecutionResult(tc.name, result)) {
+            hasSubmittedFormInputInLoop = true;
             currentRuntimeContext = markSubmittedFormInputRuntimeContext(currentRuntimeContext);
           }
           if (tc.name === "create_agent") {

--- a/src/agent/runtime/skill-policy-enforcement.ts
+++ b/src/agent/runtime/skill-policy-enforcement.ts
@@ -196,7 +196,7 @@ export type SkillPolicyResult =
   | { allowed: false; error: string };
 
 export type SkillPolicyOptions = {
-  allowSubmittedFormInputReuse?: boolean;
+  hasSubmittedFormInput?: boolean;
 };
 
 export function enforceSkillPolicy(
@@ -210,10 +210,14 @@ export function enforceSkillPolicy(
   }
 
   if (
-    toolName === FORM_INPUT_TOOL_ID &&
-    options.allowSubmittedFormInputReuse === true
+    options.hasSubmittedFormInput === true &&
+    POST_SUBMITTED_FORM_INPUT_BLOCKED_TOOL_IDS.has(toolName)
   ) {
-    return { allowed: true };
+    return {
+      allowed: false,
+      error:
+        `Tool "${toolName}" cannot run after a submitted form_input result exists. Continue with the submitted values.`,
+    };
   }
 
   if (activeSkillPolicy && !isToolAllowedBySkill(toolName, activeSkillPolicy)) {

--- a/src/agent/runtime/skill-policy.test.ts
+++ b/src/agent/runtime/skill-policy.test.ts
@@ -100,14 +100,20 @@ describe("src/agent/runtime skill policy helpers", () => {
       assertEquals(result.allowed, false);
     });
 
-    it("allows form_input through a narrowed policy only to reuse a submitted form", () => {
+    it("blocks intake and skill reload tools after a submitted form", () => {
       assertEquals(
         enforceSkillPolicy("form_input", ["studio_suggestions"], false).allowed,
         false,
       );
+      for (const toolName of ["form_input", "load_skill", "invoke_agent"]) {
+        const result = enforceSkillPolicy(toolName, [toolName], false, {
+          hasSubmittedFormInput: true,
+        });
+        assertEquals(result.allowed, false);
+      }
       assertEquals(
-        enforceSkillPolicy("form_input", ["studio_suggestions"], false, {
-          allowSubmittedFormInputReuse: true,
+        enforceSkillPolicy("create_agent", ["create_agent"], false, {
+          hasSubmittedFormInput: true,
         }),
         { allowed: true },
       );

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.849";
+export const VERSION = "0.1.850";


### PR DESCRIPTION
## Summary\n- carry submitted form state inside the runtime loop across steps\n- hide/block form_input, load_skill, and invoke_agent after a submitted form result\n- update skill policy regression coverage\n\n## Verification\n- deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/agent/runtime/skill-policy.test.ts src/agent/runtime/agent-runtime-step.test.ts\n- deno check src/agent/index.ts\n- pre-push lint/typecheck passed; full unit pre-push hit existing observability metrics default mismatch (expected console, got otlp) unrelated to changed files