### PR TITLE
Make API render cache fills visible across pods

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.849",
+  "version": "0.1.850",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/architecture/02-request-pipeline.md
+++ b/docs/architecture/02-request-pipeline.md
@@ -113,7 +113,9 @@ concrete static routes, skips dynamic route patterns, validates each candidate
 route resolves, uses canonical route cache keys without request cookies, query
 strings, or nonces, and checks the shared render cache before rendering each
 route. This populates the API-backed distributed render cache for sibling routes
-without adding latency to the foreground response.
+without adding latency to the foreground response. API-backed render cache
+writes complete before `CacheStore.set()` resolves so a render or prewarm fill
+is visible to other pods before the cache fill is treated as done.
 
 Default render prewarm controls:
 

--- a/src/rendering/cache/stores/api-store.test.ts
+++ b/src/rendering/cache/stores/api-store.test.ts
@@ -264,6 +264,90 @@ describe("rendering/cache/stores/api-store", () => {
       assertEquals(result, undefined);
     });
 
+    it("waits for distributed writes when local cache is disabled", async () => {
+      const previousApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
+      const previousApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+      const globals = globalThis as Record<string, unknown>;
+      const originalAdapter = globals.__vf_multi_project_adapter;
+
+      let releaseSet: () => void = () => {};
+      let setStarted = false;
+      let setCompleted = false;
+      const server = Deno.serve(
+        { hostname: "127.0.0.1", port: 0, onListen: () => {} },
+        async (request) => {
+          const url = new URL(request.url);
+          if (
+            request.method !== "POST" ||
+            url.pathname !== "/projects/api-store-test-project/cache/set"
+          ) {
+            return Response.json({ error: "not found" }, { status: 404 });
+          }
+
+          setStarted = true;
+          await new Promise<void>((resolve) => {
+            releaseSet = resolve;
+          });
+          setCompleted = true;
+          return Response.json({ success: true });
+        },
+      );
+      const addr = server.addr as Deno.NetAddr;
+      Deno.env.set("VERYFRONT_API_BASE_URL", `http://${addr.hostname}:${addr.port}`);
+      Deno.env.set("VERYFRONT_API_TOKEN", "test-token");
+      globals.__vf_multi_project_adapter = {
+        getCurrentRequestContext: () => ({
+          token: "request-token",
+          projectSlug: "api-store-test-project",
+          productionMode: true,
+        }),
+      };
+      const store = new APICacheStore({ enableLocalCache: false });
+      const payload = {
+        result: { html: "<p>x</p>", frontmatter: {}, headings: [], stream: null },
+        storedAt: Date.now(),
+      } as any;
+
+      try {
+        let setResolved = false;
+        const setPromise = store.set("distributed-key", payload).then(() => {
+          setResolved = true;
+        });
+
+        for (let attempts = 0; attempts < 50 && !setStarted; attempts++) {
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+        assertEquals(setStarted, true);
+        assertEquals(setResolved, false);
+        assertEquals(setCompleted, false);
+
+        releaseSet();
+        await setPromise;
+
+        assertEquals(setCompleted, true);
+        assertEquals(setResolved, true);
+      } finally {
+        releaseSet();
+        await store.destroy();
+        await server.shutdown();
+        if (previousApiBaseUrl === undefined) {
+          Deno.env.delete("VERYFRONT_API_BASE_URL");
+        } else {
+          Deno.env.set("VERYFRONT_API_BASE_URL", previousApiBaseUrl);
+        }
+        if (previousApiToken === undefined) {
+          Deno.env.delete("VERYFRONT_API_TOKEN");
+        } else {
+          Deno.env.set("VERYFRONT_API_TOKEN", previousApiToken);
+        }
+        if (originalAdapter === undefined) {
+          delete globals.__vf_multi_project_adapter;
+        } else {
+          globals.__vf_multi_project_adapter = originalAdapter;
+        }
+      }
+    });
+
     it("expires local entries without payload expiresAt using store TTL", async () => {
       await withStoreTtlEnabled(async () => {
         const store = new APICacheStore({ enableLocalCache: true, ttlSeconds: 1 });

--- a/src/rendering/cache/stores/api-store.ts
+++ b/src/rendering/cache/stores/api-store.ts
@@ -159,17 +159,15 @@ export class APICacheStore implements CacheStore {
 
     await this.localCache?.set(key, value);
 
-    void (async () => {
-      try {
-        const backend = await this.getBackend();
-        await backend.set(key, this.serialize(value), this.ttlSeconds);
-      } catch (error) {
-        logger.debug(
-          "[APICacheStore] Failed to store in distributed cache (no fallback)",
-          { key, error },
-        );
-      }
-    })();
+    try {
+      const backend = await this.getBackend();
+      await backend.set(key, this.serialize(value), this.ttlSeconds);
+    } catch (error) {
+      logger.debug(
+        "[APICacheStore] Failed to store in distributed cache (no fallback)",
+        { key, error },
+      );
+    }
   }
 
   async delete(key: string): Promise<void> {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.849";
+export const VERSION = "0.1.850";


### PR DESCRIPTION
## Summary
- await API-backed render cache writes before `CacheStore.set()` resolves
- add a focused regression test for local-cache-disabled distributed writes
- document the multi-pod cache visibility contract
- bump `deno.json` and `src/utils/version-constant.ts` to `0.1.850` for a new release

## Why
Production testing after `0.1.849` showed warm app/proxy paths were fast, but horizontally scaled pods could still hit recurring cold render misses. The API-backed render cache was firing distributed writes in the background, so prewarm or a cold fill could be considered complete before the shared backend was readable by another pod.

## Verification
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --unstable-net src/rendering/cache/stores/api-store.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --unstable-net src/rendering/cache/stores/api-store.test.ts src/rendering/shared/context-aware-cache.test.ts src/rendering/renderer.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --unstable-net src/server/shared/renderer/adapter.test.ts`
- `deno check src/rendering/cache/stores/api-store.ts src/rendering/cache/stores/api-store.test.ts src/server/shared/renderer/adapter.ts`
- `git diff --check`
- pre-push hook: format, lint, type check, unit tests (`2173 passed`)
