### PR TITLE
Correlate page-data route timing with browser metrics

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.850",
+  "version": "0.1.851",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/html/hydration-script-builder/templates/router.test.ts
+++ b/src/html/hydration-script-builder/templates/router.test.ts
@@ -15,6 +15,10 @@ describe("hydration-script-builder/templates/router", () => {
       assertEquals(result.length > 0, true);
     });
 
+    it("should generate parseable browser JavaScript", () => {
+      new Function(getRouterScript());
+    });
+
     it("should define MODULE_SERVER_URL from window origin", () => {
       assertIncludes(getRouterScript(), "window.location.origin + '/_vf_modules'");
     });
@@ -153,6 +157,53 @@ describe("hydration-script-builder/templates/router", () => {
       assertIncludes(result, "window.__veryfrontRouteTimings");
       assertIncludes(result, "veryfront:route-timing");
       assertIncludes(result, "emitRouteTiming('total', targetPath, navigationStartedAt");
+    });
+
+    it("should capture bounded Server-Timing details for page-data network timing", () => {
+      const result = getRouterScript();
+      assertIncludes(result, "MAX_SERVER_TIMING_LENGTH = 1024");
+      assertIncludes(result, "function sanitizeServerTimingHeader(value)");
+      assertIncludes(result, "replace(/[^\\x20-\\x7E]/g, ' ')");
+      assertIncludes(result, "sanitized.slice(0, MAX_SERVER_TIMING_LENGTH)");
+      assertIncludes(result, "response.headers?.get('server-timing')");
+      assertIncludes(result, "function parseServerTimingMetrics(value)");
+      assertIncludes(result, "segment.split('=')");
+      assertIncludes(result, "if (!Number.isFinite(duration) || duration < 0) continue;");
+      assertIncludes(result, "metrics.push(name + ';dur='");
+      assertIncludes(result, "detail.serverTiming = serverTiming");
+      assertIncludes(result, "detail.serverTimingMetrics = serverTimingMetrics");
+    });
+
+    it("should capture best-effort browser resource timing for page-data network timing", () => {
+      const result = getRouterScript();
+      assertIncludes(result, "function getPageDataResourceTiming(endpoint, fetchStartedAt)");
+      assertIncludes(result, "performance.getEntriesByName(href, 'resource')");
+      assertIncludes(result, "function extractResourceTiming(entry)");
+      assertIncludes(result, "'responseStart'");
+      assertIncludes(result, "'responseEnd'");
+      assertIncludes(result, "'transferSize'");
+      assertIncludes(result, "value >= 0");
+      assertIncludes(result, "Number.isFinite(entry.responseEnd)");
+      assertIncludes(result, "entry.responseEnd + 1 >= fetchStartedAt");
+      assertIncludes(result, "return null;");
+      assertIncludes(result, "detail.resourceTiming = resourceTiming");
+    });
+
+    it("should enrich only page-data network timing records", () => {
+      const result = getRouterScript();
+      assertIncludes(
+        result,
+        "function buildPageDataTimingDetail(response, endpoint, fetchStartedAt, source)",
+      );
+      assertIncludes(
+        result,
+        "buildPageDataTimingDetail(response, endpoint, startedAt, timingSource)",
+      );
+      assertIncludes(result, "emitRouteTiming('page-data', path, startedAt, { source: 'cache' });");
+      assertIncludes(
+        result,
+        "emitRouteTiming('page-data', path, startedAt, { source: 'deduped' });",
+      );
     });
 
     it("should define scroll position memory", () => {

--- a/src/html/hydration-script-builder/templates/router.ts
+++ b/src/html/hydration-script-builder/templates/router.ts
@@ -37,6 +37,7 @@ export const getRouterScript = () => `
     const PREFETCH_DELAY_MS = 100;
     const MAX_PREFETCH_PATHS = 100;
     const MAX_ROUTE_TIMINGS = 100;
+    const MAX_SERVER_TIMING_LENGTH = 1024;
 
     // ============================================
     // Debug logging (production-safe)
@@ -157,6 +158,139 @@ export const getRouterScript = () => `
 
       log('Route timing:', entry);
       return entry;
+    }
+
+    function sanitizeServerTimingHeader(value) {
+      if (!value) return null;
+
+      const metrics = [];
+      const printable = String(value).replace(/[^\\x20-\\x7E]/g, ' ').trim();
+      if (!printable) return null;
+
+      for (const item of printable.split(',')) {
+        const segments = item.split(';').map((segment) => segment.trim()).filter(Boolean);
+        const name = sanitizeServerTimingMetricName(segments[0]);
+        if (!name) continue;
+
+        for (const segment of segments.slice(1)) {
+          const [key, rawValue = ''] = segment.split('=');
+          if (key.trim().toLowerCase() !== 'dur') continue;
+
+          const duration = Number(rawValue.trim().replace(/^"|"$/g, ''));
+          if (!Number.isFinite(duration) || duration < 0) continue;
+
+          metrics.push(name + ';dur=' + (Math.round(duration * 100) / 100).toFixed(2));
+          break;
+        }
+      }
+
+      const sanitized = metrics.join(', ');
+      return sanitized ? sanitized.slice(0, MAX_SERVER_TIMING_LENGTH) : null;
+    }
+
+    function sanitizeServerTimingMetricName(name) {
+      return String(name || '').trim().replace(/[^A-Za-z0-9_.-]/g, '_').slice(0, 128);
+    }
+
+    function parseServerTimingMetrics(value) {
+      const header = sanitizeServerTimingHeader(value);
+      if (!header) return null;
+
+      const metrics = {};
+      for (const item of header.split(',')) {
+        const segments = item.split(';').map((segment) => segment.trim()).filter(Boolean);
+        const name = sanitizeServerTimingMetricName(segments[0]);
+        if (!name) continue;
+
+        for (const segment of segments.slice(1)) {
+          const [key, rawValue = ''] = segment.split('=');
+          if (key.trim().toLowerCase() !== 'dur') continue;
+
+          const duration = Number(rawValue.trim().replace(/^"|"$/g, ''));
+          if (Number.isFinite(duration) && duration >= 0) {
+            metrics[name] = Math.round(duration * 100) / 100;
+          }
+        }
+      }
+
+      return Object.keys(metrics).length ? metrics : null;
+    }
+
+    function readResponseServerTiming(response) {
+      try {
+        return sanitizeServerTimingHeader(response.headers?.get('server-timing'));
+      } catch (_) {
+        return null;
+      }
+    }
+
+    function roundRouteTimingValue(value) {
+      return Math.round(value * 100) / 100;
+    }
+
+    function extractResourceTiming(entry) {
+      const fields = [
+        'startTime',
+        'requestStart',
+        'responseStart',
+        'responseEnd',
+        'duration',
+        'transferSize',
+        'encodedBodySize',
+        'decodedBodySize'
+      ];
+      const timing = {};
+
+      for (const field of fields) {
+        const value = entry?.[field];
+        if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+          timing[field] = roundRouteTimingValue(value);
+        }
+      }
+
+      return Object.keys(timing).length ? timing : null;
+    }
+
+    function getPageDataResourceTiming(endpoint, fetchStartedAt) {
+      try {
+        if (typeof performance === 'undefined' || typeof performance.getEntriesByName !== 'function') {
+          return null;
+        }
+
+        const href = new URL(endpoint, window.location.href).href;
+        const entries = performance.getEntriesByName(href, 'resource');
+        if (!entries.length) return null;
+
+        for (let index = entries.length - 1; index >= 0; index--) {
+          const entry = entries[index];
+          if (
+            typeof entry?.responseEnd === 'number' &&
+            Number.isFinite(entry.responseEnd) &&
+            entry.responseEnd + 1 >= fetchStartedAt
+          ) {
+            return extractResourceTiming(entry);
+          }
+        }
+
+        return null;
+      } catch (_) {
+        return null;
+      }
+    }
+
+    function buildPageDataTimingDetail(response, endpoint, fetchStartedAt, source) {
+      const detail = { source, status: response.status };
+      const serverTiming = readResponseServerTiming(response);
+      if (serverTiming) {
+        detail.serverTiming = serverTiming;
+        const serverTimingMetrics = parseServerTimingMetrics(serverTiming);
+        if (serverTimingMetrics) detail.serverTimingMetrics = serverTimingMetrics;
+      }
+
+      const resourceTiming = getPageDataResourceTiming(response.url || endpoint, fetchStartedAt);
+      if (resourceTiming) detail.resourceTiming = resourceTiming;
+
+      return detail;
     }
 
     // ============================================
@@ -320,7 +454,12 @@ export const getRouterScript = () => `
       if (!response.ok) {
         perfEnd('fetch:' + path);
         if (recordRouteTiming) {
-          emitRouteTiming('page-data', path, startedAt, { source: timingSource, status: response.status });
+          emitRouteTiming(
+            'page-data',
+            path,
+            startedAt,
+            buildPageDataTimingDetail(response, endpoint, startedAt, timingSource)
+          );
         }
         const error = new Error('Failed to fetch page data: ' + response.status);
         error.status = response.status;
@@ -332,7 +471,12 @@ export const getRouterScript = () => `
       perfEnd('parse:' + path);
       perfEnd('fetch:' + path);
       if (recordRouteTiming) {
-        emitRouteTiming('page-data', path, startedAt, { source: timingSource, status: response.status });
+        emitRouteTiming(
+          'page-data',
+          path,
+          startedAt,
+          buildPageDataTimingDetail(response, endpoint, startedAt, timingSource)
+        );
       }
 
       if (triggerReloadOnVersionMismatch) {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.850";
+export const VERSION = "0.1.851";


### PR DESCRIPTION
## Summary
- add metrics-only Server-Timing enrichment to page-data network route timing
- add whitelisted browser Resource Timing fields for the matching page-data fetch
- keep cache hits, deduped loads, prefetches, and navigation behavior unchanged
- bump package version to 0.1.851 for release creation

## Why
This gives production measurements enough browser-to-pod correlation to explain time outside the pod before changing cache semantics. It is diagnostic-only and avoids preserving arbitrary header text, URLs, request details, cookies, or tokens.

## Tests
- deno test --no-check --allow-all src/html/hydration-script-builder/templates/router.test.ts
- deno test --no-check --allow-all src/observability/request-profiler.test.ts src/proxy/server-timing.test.ts src/server/handlers/request/module/page-data-endpoint-handler.test.ts src/routing/client/page-loader.test.ts
- deno eval --no-check generated router parse check
- deno lint src/html/hydration-script-builder/templates/router.ts src/html/hydration-script-builder/templates/router.test.ts
- git diff --check
- pre-push hook: format, lint, typecheck, generation, and src+cli unit tests: 2173 passed