### PR TITLE
Prefetch route assets before client navigation

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.851",
+  "version": "0.1.852",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/guides/pages-and-routing.md
+++ b/docs/guides/pages-and-routing.md
@@ -179,6 +179,9 @@ export default function Nav() {
 }
 ```
 
+Veryfront can prefetch eligible internal links before navigation. Use
+`prefetch={false}` when a link must not prefetch.
+
 Programmatic navigation:
 
 ```tsx

--- a/src/html/hydration-script-builder/templates/router.test.ts
+++ b/src/html/hydration-script-builder/templates/router.test.ts
@@ -266,6 +266,35 @@ describe("hydration-script-builder/templates/router", () => {
       assertIncludes(result, "MAX_PREFETCH_PATHS = 100");
     });
 
+    it("should schedule capped idle and viewport prefetch for eligible internal links", () => {
+      const result = getRouterScript();
+      assertIncludes(result, "IDLE_PREFETCH_DELAY_MS = 1200");
+      assertIncludes(result, "IDLE_PREFETCH_MAX_LINKS = 4");
+      assertIncludes(result, "VIEWPORT_PREFETCH_MAX_LINKS = 8");
+      assertIncludes(result, "VIEWPORT_PREFETCH_ROOT_MARGIN = '200px'");
+      assertIncludes(result, "link.getAttribute('data-prefetch') === 'false'");
+      assertIncludes(result, "document.querySelectorAll('a[href]')");
+      assertIncludes(result, "function getInternalRouteHrefFromLink(link)");
+      assertIncludes(result, "function getEligiblePrefetchLinks(limit)");
+      assertIncludes(result, "function prefetchEligibleRouteLinks(limit)");
+      assertIncludes(result, "function observeViewportPrefetchLinks()");
+      assertIncludes(result, "IntersectionObserver");
+      assertIncludes(result, "requestIdleCallback(runRoutePrefetchRefresh");
+    });
+
+    it("should refresh eligible prefetch links after load and SPA renders", () => {
+      const result = getRouterScript();
+      assertIncludes(result, "scheduleRoutePrefetchRefresh();\n        return;");
+      assertIncludes(
+        result,
+        "document.addEventListener('DOMContentLoaded', scheduleRoutePrefetchRefresh",
+      );
+      assertIncludes(
+        result,
+        "scheduleRoutePrefetchRefresh();\n    }\n\n    // ============================================",
+      );
+    });
+
     it("should define router object with standard methods", () => {
       const result = getRouterScript();
       for (

--- a/src/html/hydration-script-builder/templates/router.ts
+++ b/src/html/hydration-script-builder/templates/router.ts
@@ -36,6 +36,10 @@ export const getRouterScript = () => `
     const BACKGROUND_REFRESH_INTERVAL_MS = 30 * 1000;
     const PREFETCH_DELAY_MS = 100;
     const MAX_PREFETCH_PATHS = 100;
+    const IDLE_PREFETCH_DELAY_MS = 1200;
+    const IDLE_PREFETCH_MAX_LINKS = 4;
+    const VIEWPORT_PREFETCH_MAX_LINKS = 8;
+    const VIEWPORT_PREFETCH_ROOT_MARGIN = '200px';
     const MAX_ROUTE_TIMINGS = 100;
     const MAX_SERVER_TIMING_LENGTH = 1024;
 
@@ -758,6 +762,7 @@ export const getRouterScript = () => `
         container.__reactRoot.render(tree);
         perfEnd('render:reactRender');
         log('Page re-rendered via SPA');
+        scheduleRoutePrefetchRefresh();
         return;
       }
 
@@ -773,6 +778,9 @@ export const getRouterScript = () => `
     // ============================================
     let prefetchTimeout = null;
     let currentHoverLink = null;
+    let routePrefetchRefreshPending = false;
+    let viewportPrefetchObserver = null;
+    const observedPrefetchLinks = new WeakSet();
     const prefetchedPaths = new Set();
     const inFlightPrefetches = new Set();
 
@@ -792,6 +800,51 @@ export const getRouterScript = () => `
       if (pageData.appPath) allPaths.push(pageData.appPath);
 
       return allPaths;
+    }
+
+    function getCurrentRouteHref() {
+      return window.location.pathname + window.location.search;
+    }
+
+    function getInternalRouteHrefFromLink(link) {
+      if (
+        !link ||
+        link.target === '_blank' ||
+        link.hasAttribute('download') ||
+        link.getAttribute('data-prefetch') === 'false'
+      ) {
+        return null;
+      }
+
+      const href = link.getAttribute('href');
+      if (!href || href.startsWith('#') || href.startsWith('//') || !href.startsWith('/')) return null;
+
+      try {
+        const url = new URL(href, window.location.origin);
+        if (url.origin !== window.location.origin) return null;
+
+        const routeHref = url.pathname + url.search;
+        return routeHref === getCurrentRouteHref() ? null : routeHref;
+      } catch (_) {
+        return null;
+      }
+    }
+
+    function getEligiblePrefetchLinks(limit) {
+      const links = [];
+      const seenHrefs = new Set();
+
+      for (const link of document.querySelectorAll('a[href]')) {
+        const href = getInternalRouteHrefFromLink(link);
+        if (!href || seenHrefs.has(href)) continue;
+
+        seenHrefs.add(href);
+        links.push({ link, href });
+
+        if (links.length >= limit) break;
+      }
+
+      return links;
     }
 
     async function preloadModulesForPageData(pageData, path) {
@@ -840,6 +893,62 @@ export const getRouterScript = () => `
         .finally(() => {
           inFlightPrefetches.delete(href);
         });
+    }
+
+    function prefetchEligibleRouteLinks(limit) {
+      for (const { href } of getEligiblePrefetchLinks(limit)) {
+        prefetchPage(href);
+      }
+    }
+
+    function ensureViewportPrefetchObserver() {
+      if (viewportPrefetchObserver || typeof IntersectionObserver !== 'function') {
+        return viewportPrefetchObserver;
+      }
+
+      viewportPrefetchObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+
+          viewportPrefetchObserver?.unobserve(entry.target);
+          const href = getInternalRouteHrefFromLink(entry.target);
+          if (href) prefetchPage(href);
+        }
+      }, { rootMargin: VIEWPORT_PREFETCH_ROOT_MARGIN });
+
+      return viewportPrefetchObserver;
+    }
+
+    function observeViewportPrefetchLinks() {
+      const observer = ensureViewportPrefetchObserver();
+      if (!observer) return;
+
+      for (const { link } of getEligiblePrefetchLinks(VIEWPORT_PREFETCH_MAX_LINKS)) {
+        if (observedPrefetchLinks.has(link)) continue;
+
+        observedPrefetchLinks.add(link);
+        observer.observe(link);
+      }
+    }
+
+    function runRoutePrefetchRefresh() {
+      routePrefetchRefreshPending = false;
+      prefetchEligibleRouteLinks(IDLE_PREFETCH_MAX_LINKS);
+      observeViewportPrefetchLinks();
+    }
+
+    function scheduleRoutePrefetchRefresh() {
+      if (routePrefetchRefreshPending) return;
+
+      routePrefetchRefreshPending = true;
+      setTimeout(() => {
+        if (typeof requestIdleCallback === 'function') {
+          requestIdleCallback(runRoutePrefetchRefresh, { timeout: IDLE_PREFETCH_DELAY_MS });
+          return;
+        }
+
+        runRoutePrefetchRefresh();
+      }, IDLE_PREFETCH_DELAY_MS);
     }
 
     // ============================================
@@ -946,8 +1055,8 @@ export const getRouterScript = () => `
         const link = e.target.closest('a[href]');
         if (!link) return;
 
-        const href = link.getAttribute('href');
-        if (!href?.startsWith('/') || href.startsWith('//')) return;
+        const href = getInternalRouteHrefFromLink(link);
+        if (!href) return;
 
         if (currentHoverLink === link) return;
 
@@ -977,6 +1086,12 @@ export const getRouterScript = () => `
       },
       true
     );
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', scheduleRoutePrefetchRefresh, { once: true });
+    } else {
+      scheduleRoutePrefetchRefresh();
+    }
 
     // ============================================
     // Router hooks

--- a/src/react/runtime/core.ts
+++ b/src/react/runtime/core.ts
@@ -176,7 +176,7 @@ export function Link({
 }: LinkProps): React.ReactElement {
   return React.createElement(
     "a",
-    { ...rest, "data-prefetch": prefetch ? "true" : undefined },
+    { ...rest, "data-prefetch": prefetch ? "true" : "false" },
     children,
   );
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.851";
+export const VERSION = "0.1.852";

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -543,6 +543,12 @@ describe("Guide: pages-and-routing.md", () => {
 
     assertEquals(link.type, Link);
     assertEquals(router.type, RouterProvider);
+
+    const prefetchLink = Link({ href: "/about", children: "About" });
+    const noPrefetchLink = Link({ href: "/about", prefetch: false, children: "About" });
+
+    assertEquals(prefetchLink.props["data-prefetch"], "true");
+    assertEquals(noPrefetchLink.props["data-prefetch"], "false");
   });
 });
 


### PR DESCRIPTION
## Summary
- add bounded idle and viewport prefetch for eligible internal route links
- reuse the existing page-data and module prefetch path so warm navigation can use browser/module cache
- make `Link prefetch={false}` emit `data-prefetch="false"` so hover and background prefetch share the same opt-out rule
- bump Veryfront to `0.1.852` for a new release

## Motivation
Production timing showed warm server work around 22 ms, but fresh client navigation still spent about 190 ms on page-data transfer and about 220 ms on route modules. Repeat navigation from browser cache was about 2.6 ms, so moving the existing prefetch path earlier is the next proper client-side optimization.

## Safety
- background prefetch is capped to 4 idle links and 8 viewport-observed links
- prefetch skips the current route, external URLs, hash-only links, downloads, new-tab links, and `data-prefetch="false"`
- no new dependency or server cache layer

## Verification
- `deno fmt src/html/hydration-script-builder/templates/router.ts src/html/hydration-script-builder/templates/router.test.ts src/react/runtime/core.ts tests/docs/guide-code-examples.test.ts docs/guides/pages-and-routing.md src/utils/version-constant.ts deno.json`
- `deno lint src/html/hydration-script-builder/templates/router.ts src/html/hydration-script-builder/templates/router.test.ts src/react/runtime/core.ts tests/docs/guide-code-examples.test.ts`
- `deno test --no-check --allow-all src/html/hydration-script-builder/templates/router.test.ts tests/docs/guide-code-examples.test.ts`
- `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/server/build-app-route-renderer.test.ts`
- pre-push hook: format, lint, typecheck, generation, and unit tests passed (`2173 passed`)
- `git diff --check`