### PR TITLE
Resolve Mistral through Veryfront Cloud catalog

### DIFF
--- a/src/agent/runtime/model-resolution.test.ts
+++ b/src/agent/runtime/model-resolution.test.ts
@@ -86,6 +86,10 @@ describe("agent/runtime/model-resolution", () => {
       "google-ai-studio/gemini-3.5-flash",
     );
     assertEquals(
+      resolveConfiguredAgentModel("mistral-small"),
+      "mistral/mistral-small-2603",
+    );
+    assertEquals(
       resolveConfiguredAgentModel("kimi-k2.6"),
       "moonshotai/kimi-k2.6",
     );
@@ -115,7 +119,7 @@ describe("agent/runtime/model-resolution", () => {
     );
   });
 
-  it("routes catalog Gemini and Kimi models through veryfront-cloud when only hosted bootstrap is available", () => {
+  it("routes catalog Gemini, Mistral, and Kimi models through veryfront-cloud when only hosted bootstrap is available", () => {
     setEnv("VERYFRONT_API_TOKEN", "vf_test_runtime");
     setEnv("VERYFRONT_PROJECT_SLUG", "demo-project");
 
@@ -126,6 +130,14 @@ describe("agent/runtime/model-resolution", () => {
     assertEquals(
       resolveRuntimeModel("moonshotai/kimi-k2.6"),
       "veryfront-cloud/moonshotai/kimi-k2.6",
+    );
+    assertEquals(
+      resolveRuntimeModel("mistral/mistral-small-2603"),
+      "veryfront-cloud/mistral/mistral-small-2603",
+    );
+    assertEquals(
+      resolveRuntimeModel("mistral-small"),
+      "veryfront-cloud/mistral/mistral-small-2603",
     );
     assertEquals(
       resolveRuntimeModel("kimi-k2.6"),

--- a/src/agent/runtime/model-resolution.ts
+++ b/src/agent/runtime/model-resolution.ts
@@ -46,14 +46,14 @@ const LEGACY_MODEL_ALIASES: Record<string, string> = {
   "gemini-3.1-flash-lite": "google-ai-studio/gemini-3.1-flash-lite",
   "gemini-2.5-pro": "google-ai-studio/gemini-2.5-pro",
   "gemini-2.5-flash": "google-ai-studio/gemini-2.5-flash",
-  "kimi-k2.6": "moonshotai/kimi-k2.6",
-  "kimi-k2.5": "moonshotai/kimi-k2.5",
-  "mistral-large": "mistral/mistral-large-2512",
-  "mistral-large-2512": "mistral/mistral-large-2512",
-  "mistral-medium": "mistral/mistral-medium-3-5",
-  "mistral-medium-3-5": "mistral/mistral-medium-3-5",
   "mistral-small": "mistral/mistral-small-2603",
   "mistral-small-2603": "mistral/mistral-small-2603",
+  "mistral-medium": "mistral/mistral-medium-3-5",
+  "mistral-medium-3-5": "mistral/mistral-medium-3-5",
+  "mistral-large": "mistral/mistral-large-2512",
+  "mistral-large-2512": "mistral/mistral-large-2512",
+  "kimi-k2.6": "moonshotai/kimi-k2.6",
+  "kimi-k2.5": "moonshotai/kimi-k2.5",
 };
 
 export function normalizeAgentModelConfig(model?: string): string {

--- a/src/provider/veryfront-cloud/model-catalog.test.ts
+++ b/src/provider/veryfront-cloud/model-catalog.test.ts
@@ -24,8 +24,8 @@ describe("provider/veryfront-cloud/model-catalog", () => {
     assertEquals(findVeryfrontCloudModel("gpt-5.5")?.provider, "openai");
     assertEquals(findVeryfrontCloudModel("gemini-3.1-pro-preview")?.provider, "google");
     assertEquals(findVeryfrontCloudModel("gemini-3.5-flash")?.provider, "google");
+    assertEquals(findVeryfrontCloudModel("mistral-small-2603")?.provider, "mistral");
     assertEquals(findVeryfrontCloudModel("kimi-k2.6")?.provider, "moonshotai");
-    assertEquals(findVeryfrontCloudModel("mistral-large")?.provider, "mistral");
     assertEquals(findVeryfrontCloudModel("nonexistent"), undefined);
   });
 
@@ -36,8 +36,8 @@ describe("provider/veryfront-cloud/model-catalog", () => {
       getVeryfrontCloudProviderFromModelId("google-ai-studio/gemini-3.1-pro-preview"),
       "google",
     );
+    assertEquals(getVeryfrontCloudProviderFromModelId("mistral/mistral-small-2603"), "mistral");
     assertEquals(getVeryfrontCloudProviderFromModelId("moonshotai/kimi-k2.6"), "moonshotai");
-    assertEquals(getVeryfrontCloudProviderFromModelId("mistral/mistral-large-2512"), "mistral");
     assertThrows(
       () => getVeryfrontCloudProviderFromModelId("unknown/model"),
       Error,
@@ -68,8 +68,8 @@ describe("provider/veryfront-cloud/model-catalog", () => {
       "anthropic",
       "openai",
       "google",
-      "moonshotai",
       "mistral",
+      "moonshotai",
     ]);
     assertEquals(groups[0]?.label, "Anthropic");
     assertEquals(groups[1]?.label, "OpenAI");
@@ -81,7 +81,7 @@ describe("provider/veryfront-cloud/model-catalog", () => {
   it("resolves aliases and preserves direct model ids", () => {
     assertEquals(resolveVeryfrontCloudModelId("opus"), "anthropic/claude-opus-4-8");
     assertEquals(resolveVeryfrontCloudModelId("gpt-5.5"), "openai/gpt-5.5");
-    assertEquals(resolveVeryfrontCloudModelId("mistral-large"), "mistral/mistral-large-2512");
+    assertEquals(resolveVeryfrontCloudModelId("mistral-small-2603"), "mistral/mistral-small-2603");
     assertEquals(resolveVeryfrontCloudModelId("openai/gpt-5.5"), "openai/gpt-5.5");
     assertThrows(
       () => resolveVeryfrontCloudModelId("not-a-real-model"),
@@ -112,6 +112,10 @@ describe("provider/veryfront-cloud/model-catalog", () => {
     assertEquals(
       resolveVeryfrontCloudGatewayModelId("google-ai-studio/gemini-3.5-flash"),
       "veryfront-cloud/google-ai-studio/gemini-3.5-flash",
+    );
+    assertEquals(
+      resolveVeryfrontCloudGatewayModelId("mistral/mistral-small-2603"),
+      "veryfront-cloud/mistral/mistral-small-2603",
     );
     assertEquals(
       resolveVeryfrontCloudGatewayModelId("veryfront-cloud/openai/gpt-5.5"),

--- a/src/provider/veryfront-cloud/model-catalog.ts
+++ b/src/provider/veryfront-cloud/model-catalog.ts
@@ -26,8 +26,8 @@ const VERYFRONT_CLOUD_GATEWAY_MODEL_PROVIDER_PREFIXES = [
   "openai/",
   "google/",
   "google-ai-studio/",
-  "moonshotai/",
   "mistral/",
+  "moonshotai/",
 ];
 
 /** Shared Veryfront Cloud chat models value. */
@@ -77,32 +77,32 @@ export const VERYFRONT_CLOUD_CHAT_MODELS: VeryfrontCloudChatModel[] = [
     description: "Fast and cost-efficient",
   },
   {
+    id: "mistral-small-2603",
+    modelId: "mistral/mistral-small-2603",
+    provider: "mistral",
+    name: "Mistral Small 2603",
+    description: "Fast Mistral model for everyday tasks",
+  },
+  {
+    id: "mistral-medium-3-5",
+    modelId: "mistral/mistral-medium-3-5",
+    provider: "mistral",
+    name: "Mistral Medium 3.5",
+    description: "Balanced Mistral model for multi-step work",
+  },
+  {
+    id: "mistral-large-2512",
+    modelId: "mistral/mistral-large-2512",
+    provider: "mistral",
+    name: "Mistral Large 3",
+    description: "Most capable Mistral model",
+  },
+  {
     id: "kimi-k2.6",
     modelId: "moonshotai/kimi-k2.6",
     provider: "moonshotai",
     name: "Kimi K2.6",
     description: "Deep thinking and multimodal",
-  },
-  {
-    id: "mistral-large",
-    modelId: "mistral/mistral-large-2512",
-    provider: "mistral",
-    name: "Mistral Large 3",
-    description: "Flagship multimodal Mistral model",
-  },
-  {
-    id: "mistral-medium",
-    modelId: "mistral/mistral-medium-3-5",
-    provider: "mistral",
-    name: "Mistral Medium 3.5",
-    description: "Balanced Mistral model for agentic and coding tasks",
-  },
-  {
-    id: "mistral-small",
-    modelId: "mistral/mistral-small-2603",
-    provider: "mistral",
-    name: "Mistral Small 4",
-    description: "Fast Mistral model for lightweight tasks",
   },
 ];
 
@@ -132,13 +132,16 @@ export function getVeryfrontCloudProviderFromModelId(
 ): VeryfrontCloudProviderId {
   const normalizedModelId = normalizeVeryfrontCloudModelId(modelId);
   const prefix = normalizedModelId.split("/")[0];
-  if (prefix === "google-ai-studio") return "google";
-  if (
-    prefix === "openai" ||
-    prefix === "anthropic" ||
-    prefix === "moonshotai" ||
-    prefix === "mistral"
-  ) return prefix;
+
+  switch (prefix) {
+    case "google-ai-studio":
+      return "google";
+    case "openai":
+    case "anthropic":
+    case "mistral":
+    case "moonshotai":
+      return prefix;
+  }
 
   throw new Error(`Unknown model provider prefix "${prefix}" in model ID "${modelId}"`);
 }
@@ -252,8 +255,8 @@ const PROVIDER_ORDER: VeryfrontCloudProviderId[] = [
   "anthropic",
   "openai",
   "google",
-  "moonshotai",
   "mistral",
+  "moonshotai",
 ];
 
 /** Group Veryfront Cloud models by provider. */

--- a/src/provider/veryfront-cloud/provider.test.ts
+++ b/src/provider/veryfront-cloud/provider.test.ts
@@ -55,10 +55,10 @@ describe("provider/veryfront-cloud", () => {
     assertEquals(typeof model.doStream, "function");
   });
 
-  it("resolves veryfront-cloud mistral models without a project-specific Mistral extension", () => {
+  it("resolves veryfront-cloud mistral models without project ext-llm-openai installed", () => {
     setCloudBootstrap();
 
-    const model = resolveModel("veryfront-cloud/mistral/mistral-large-2512") as Record<
+    const model = resolveModel("veryfront-cloud/mistral/mistral-small-2603") as Record<
       string,
       unknown
     >;

--- a/src/provider/veryfront-cloud/provider.ts
+++ b/src/provider/veryfront-cloud/provider.ts
@@ -45,8 +45,8 @@ export function createVeryfrontCloudModel(modelId: string): ModelRuntime {
     }
 
     case "openai":
-    case "moonshotai":
-    case "mistral": {
+    case "mistral":
+    case "moonshotai": {
       const openai = registry.get("openai");
       if (openai) {
         return openai.createModel(upstreamModelId, {

--- a/src/provider/veryfront-cloud/shared.test.ts
+++ b/src/provider/veryfront-cloud/shared.test.ts
@@ -22,6 +22,10 @@ describe("provider/veryfront-cloud/shared", () => {
         modelId: "gemini-2.0-flash",
       },
     );
+    assertEquals(parseVeryfrontCloudModelId("mistral/mistral-small-2603", "language"), {
+      provider: "mistral",
+      modelId: "mistral-small-2603",
+    });
   });
 
   it("rejects malformed model IDs", () => {

--- a/src/provider/veryfront-cloud/shared.ts
+++ b/src/provider/veryfront-cloud/shared.ts
@@ -6,8 +6,8 @@ export type VeryfrontCloudProviderId =
   | "anthropic"
   | "openai"
   | "google"
-  | "moonshotai"
-  | "mistral";
+  | "mistral"
+  | "moonshotai";
 
 interface ParsedVeryfrontCloudModelId {
   provider: VeryfrontCloudProviderId;
@@ -19,16 +19,16 @@ const PROVIDER_ALIASES: Record<string, VeryfrontCloudProviderId> = {
   openai: "openai",
   google: "google",
   "google-ai-studio": "google",
-  moonshotai: "moonshotai",
   mistral: "mistral",
+  moonshotai: "moonshotai",
 };
 
 const GATEWAY_PATHS: Record<VeryfrontCloudProviderId, string> = {
   anthropic: "ai/gateway/anthropic/v1",
   openai: "ai/gateway/openai/v1",
   google: "ai/gateway/google/v1beta",
-  moonshotai: "ai/gateway/moonshotai/v1",
   mistral: "ai/gateway/mistral/v1",
+  moonshotai: "ai/gateway/moonshotai/v1",
 };
 
 function joinUrl(base: string, path: string): string {


### PR DESCRIPTION
## Summary
- Add Mistral to the Veryfront Cloud runtime catalog and provider resolution path.
- Normalize Mistral aliases to documented public model IDs for runtime agent configuration.
- Preserve hosted and direct provider model ID handling through the existing Veryfront Cloud abstraction.

Refs veryfront/veryfront-studio#5093.

## Test Plan
- [x] deno test --allow-env src/provider/veryfront-cloud/model-catalog.test.ts src/provider/veryfront-cloud/shared.test.ts src/provider/veryfront-cloud/provider.test.ts src/agent/runtime/model-resolution.test.ts
- [x] deno fmt --check on changed runtime files
- [x] deno check on changed runtime test files

## Review Gate
- Critical post-fix review is still pending; merge only after score is >=90.