### PR TITLE
Fix submitted form_input run scoping

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.852",
+  "version": "0.1.853",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/hosted/chat-preparation.test.ts
+++ b/src/agent/hosted/chat-preparation.test.ts
@@ -308,6 +308,90 @@ Deno.test("prepareHostedChatExecution prepares root run, runtime, and final mess
   ]);
 });
 
+Deno.test("prepareHostedChatExecution does not carry old submitted form input into a new user turn", async () => {
+  const messages: ChatUiMessage[] = [
+    {
+      id: "user-old",
+      role: "user",
+      parts: [{ type: "text", text: "Help me build an agent" }],
+    },
+    {
+      id: "assistant-old",
+      role: "assistant",
+      parts: [{
+        type: "dynamic-tool",
+        toolCallId: "old-form-call",
+        toolName: "form_input",
+        state: "output-available",
+        input: { title: "Create Agent" },
+        output: {
+          submitted: true,
+          values: { brief: "old gmail agent" },
+          inputRequestId: "old-input-request",
+        },
+      }],
+    },
+    {
+      id: "user-new",
+      role: "user",
+      parts: [{ type: "text", text: "Now help me plan something else" }],
+    },
+  ];
+  let runtimeOptions:
+    | { submittedFormInputResult?: unknown }
+    | undefined;
+
+  await prepareHostedChatExecution({
+    request: createParsedHostedChatRequest({
+      messages,
+      conversationId: "conversation-1",
+      projectId: "project-1",
+      durableRootRun: {
+        runId: "run-new",
+        messageId: "message-new",
+        latestEventId: 3,
+        latestExternalEventSequence: 2,
+      },
+    }),
+    agentConfig: {
+      id: "agent-1",
+      model: "configured-model",
+      maxSteps: 25,
+    },
+    apiUrl: "https://api.example.com",
+    abortSignal: new AbortController().signal,
+    resolveModelId: (modelId) => modelId ? `resolved:${modelId}` : undefined,
+    fetchSteering: () =>
+      Promise.resolve({
+        instructions: "Project instructions",
+        skills: [],
+      }),
+    buildInstructions: (input) => [
+      {
+        role: "system",
+        content: `${input.agentConfig.id}:${input.instructions}`,
+      },
+    ],
+    createRuntime: (options) => {
+      runtimeOptions = options;
+      return Promise.resolve({
+        runtimeKind: "framework",
+        modelId: options.model ?? "resolved:configured-model",
+        cleanup: () => Promise.resolve(),
+        agent: {
+          stream: () =>
+            Promise.resolve({
+              steps: Promise.resolve([]),
+              toUIMessageStream: async function* () {},
+            }),
+        },
+      });
+    },
+  });
+
+  assertEquals(runtimeOptions?.submittedFormInputResult, undefined);
+});
+
 Deno.test("prepareHostedChatExecution preserves allowed remote tool history", async () => {
   const messages: ChatUiMessage[] = [
     {

--- a/src/agent/hosted/chat-runtime-tool-assembly.test.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.test.ts
@@ -83,7 +83,7 @@ Deno.test("prepareHostedChatRuntimeToolAssembly preserves runtime-essential skil
   assertEquals(taskContext.availableToolNames, ["invoke_agent", "load_skill", "sleep"]);
 });
 
-Deno.test("prepareHostedChatRuntimeToolAssembly hides intake tools after submitted form input", async () => {
+Deno.test("prepareHostedChatRuntimeToolAssembly hides intake tools but keeps delegation after submitted form input", async () => {
   const taskContext: HostedChatRuntimeToolAssemblyContext = {
     authToken: "token",
     projectId: "project-1",
@@ -111,8 +111,8 @@ Deno.test("prepareHostedChatRuntimeToolAssembly hides intake tools after submitt
     preloadLatestConversationUserText: false,
   });
 
-  assertEquals(toolAssembly.localToolNames, ["sleep"]);
-  assertEquals(taskContext.availableToolNames, ["sleep"]);
+  assertEquals(toolAssembly.localToolNames, ["invoke_agent", "sleep"]);
+  assertEquals(taskContext.availableToolNames, ["invoke_agent", "sleep"]);
 });
 
 Deno.test("prepareHostedChatRuntimeToolAssembly keeps empty allowed tools as explicit deny-all", async () => {

--- a/src/agent/hosted/chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.ts
@@ -112,7 +112,7 @@ function filterPostFormInputLocalTools(
     return tools;
   }
 
-  const blockedToolNames = new Set(["form_input", "load_skill", "invoke_agent"]);
+  const blockedToolNames = new Set(["form_input", "load_skill"]);
   return Object.fromEntries(
     Object.entries(tools).filter(([toolName]) => !blockedToolNames.has(toolName)),
   );

--- a/src/agent/hosted/form-input-tool.ts
+++ b/src/agent/hosted/form-input-tool.ts
@@ -189,13 +189,24 @@ function extractSubmittedFormInputResult(
   };
 }
 
-/** Find the latest submitted form_input result persisted in UI messages. */
+function latestUserMessageIndex(messages: readonly ChatUiMessage[]): number {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index]?.role === "user") {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+/** Find the latest submitted form_input result persisted after the latest user message. */
 export function findSubmittedFormInputResult(
   messages: readonly ChatUiMessage[],
 ): HostedSubmittedFormInputResult | undefined {
   let result: HostedSubmittedFormInputResult | undefined;
+  const startIndex = latestUserMessageIndex(messages) + 1;
 
-  for (const message of messages) {
+  for (const message of messages.slice(startIndex)) {
     for (const part of message.parts) {
       result = extractSubmittedFormInputResult(part) ?? result;
     }

--- a/src/agent/runtime/agent-runtime-step.test.ts
+++ b/src/agent/runtime/agent-runtime-step.test.ts
@@ -122,7 +122,7 @@ describe("agent/runtime-step", () => {
     assertEquals(prepared.toolContext, {});
   });
 
-  it("hides intake and delegation tools after submitted form input", async () => {
+  it("hides intake tools but keeps delegation tools after submitted form input", async () => {
     const messages: Message[] = [{
       id: "tool_result_1",
       role: "tool",
@@ -160,12 +160,13 @@ describe("agent/runtime-step", () => {
     });
 
     assertEquals(prepared.tools.map((tool) => tool.name), [
+      "invoke_agent",
       "list_integrations",
       "create_agent",
     ]);
   });
 
-  it("hides intake and delegation tools when hosted context records submitted form input", async () => {
+  it("hides intake tools but keeps delegation tools when hosted context records submitted form input", async () => {
     const prepared = await prepareAgentRuntimeStep({
       agentId: "agent_1",
       activeSkillPolicy: undefined,
@@ -194,8 +195,60 @@ describe("agent/runtime-step", () => {
     });
 
     assertEquals(prepared.tools.map((tool) => tool.name), [
+      "invoke_agent",
       "list_integrations",
       "create_agent",
+    ]);
+  });
+
+  it("does not treat submitted form input before the latest user message as active intake state", async () => {
+    const messages: Message[] = [
+      {
+        id: "tool_result_old_form",
+        role: "tool",
+        parts: [{
+          type: "tool-result",
+          toolCallId: "old_form_call",
+          toolName: "form_input",
+          result: { submitted: true, values: { brief: "old brief" } },
+        }],
+        timestamp: 1,
+      },
+      {
+        id: "user_new_turn",
+        role: "user",
+        parts: [{ type: "text", text: "Start a new request" }],
+        timestamp: 2,
+      },
+    ];
+
+    const prepared = await prepareAgentRuntimeStep({
+      agentId: "agent_1",
+      activeSkillPolicy: undefined,
+      allowedRemoteToolNames: undefined,
+      config: { model: "auto", system: "Base", tools: true, skills: true } as AgentConfig,
+      forwardedRemoteToolDefinitions: undefined,
+      isLocalModel: false,
+      messages,
+      mode: "stream",
+      remoteToolSources: [],
+      runtimeContext: undefined,
+      step: 1,
+      systemPrompt: "Base",
+      toolContextBase: undefined,
+      getAvailableTools: async () => [
+        toolDefinition("form_input"),
+        toolDefinition("load_skill"),
+        toolDefinition("invoke_agent"),
+      ],
+      resolveRuntimeState: async () => ({ systemPrompt: "Base", context: undefined }),
+    });
+
+    assertEquals(prepared.runtimeContext, undefined);
+    assertEquals(prepared.tools.map((tool) => tool.name), [
+      "form_input",
+      "load_skill",
+      "invoke_agent",
     ]);
   });
 });

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -553,7 +553,7 @@ export class AgentRuntime {
       let activeSkillId = hydratedSkillState.activeSkillId;
       let activeSkillPolicy = hydratedSkillState.activeSkillPolicy;
       let activeSkillDelegationOverrides = hydratedSkillState.activeSkillDelegationOverrides;
-      const hasSubmittedFormInputInLoop = hasSubmittedFormInputResult(currentMessages) ||
+      let hasSubmittedFormInputInLoop = hasSubmittedFormInputResult(currentMessages) ||
         runtimeContext?.[SUBMITTED_FORM_INPUT_CONTEXT_KEY] === true;
       const allowedRemoteToolNames = getRuntimeAllowedRemoteTools(this.config);
       const providerTools = getRuntimeProviderTools(this.config);
@@ -791,6 +791,10 @@ export class AgentRuntime {
                 activeSkillId,
                 activeSkillPolicy,
               );
+              if (isSubmittedFormInputExecutionResult(tc.toolName, result)) {
+                hasSubmittedFormInputInLoop = true;
+                currentRuntimeContext = markSubmittedFormInputRuntimeContext(currentRuntimeContext);
+              }
 
               const toolResultMessage = createToolResultMessage(
                 tc.toolCallId,

--- a/src/agent/runtime/skill-policy-enforcement.ts
+++ b/src/agent/runtime/skill-policy-enforcement.ts
@@ -21,7 +21,6 @@ export const SUBMITTED_FORM_INPUT_CONTEXT_KEY = "hasSubmittedFormInputResult";
 const POST_SUBMITTED_FORM_INPUT_BLOCKED_TOOL_IDS = new Set([
   FORM_INPUT_TOOL_ID,
   LOAD_SKILL_TOOL_ID,
-  INVOKE_AGENT_TOOL_ID,
 ]);
 
 function getSkillActivationRequiredError(toolName: string): string {
@@ -110,8 +109,20 @@ function isSubmittedFormInputResult(result: unknown): boolean {
   return containsSubmittedFormInputResult(result);
 }
 
+function latestUserMessageIndex(messages: readonly Message[]): number {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index]?.role === "user") {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
 export function hasSubmittedFormInputResult(messages: readonly Message[]): boolean {
-  return messages.some((message) =>
+  const startIndex = latestUserMessageIndex(messages) + 1;
+
+  return messages.slice(startIndex).some((message) =>
     message.parts.some((part) =>
       isToolResultPart(part) &&
       part.toolName === FORM_INPUT_TOOL_ID &&

--- a/src/agent/runtime/skill-policy.test.ts
+++ b/src/agent/runtime/skill-policy.test.ts
@@ -100,17 +100,23 @@ describe("src/agent/runtime skill policy helpers", () => {
       assertEquals(result.allowed, false);
     });
 
-    it("blocks intake and skill reload tools after a submitted form", () => {
+    it("blocks intake and skill reload tools after a submitted form without blocking delegation", () => {
       assertEquals(
         enforceSkillPolicy("form_input", ["studio_suggestions"], false).allowed,
         false,
       );
-      for (const toolName of ["form_input", "load_skill", "invoke_agent"]) {
+      for (const toolName of ["form_input", "load_skill"]) {
         const result = enforceSkillPolicy(toolName, [toolName], false, {
           hasSubmittedFormInput: true,
         });
         assertEquals(result.allowed, false);
       }
+      assertEquals(
+        enforceSkillPolicy("invoke_agent", ["invoke_agent"], false, {
+          hasSubmittedFormInput: true,
+        }),
+        { allowed: true },
+      );
       assertEquals(
         enforceSkillPolicy("create_agent", ["create_agent"], false, {
           hasSubmittedFormInput: true,
@@ -365,6 +371,26 @@ describe("src/agent/runtime skill policy helpers", () => {
             result: { submitted: false, values: {} },
           }],
         }]),
+        false,
+      );
+      assertEquals(
+        hasSubmittedFormInputResult([
+          {
+            id: "tool_form_input_old",
+            role: "tool",
+            parts: [{
+              type: "tool-result",
+              toolCallId: "form_input_old",
+              toolName: "form_input",
+              result: { submitted: true, values: { topic: "old topic" } },
+            }],
+          },
+          {
+            id: "user_new_turn",
+            role: "user",
+            parts: [{ type: "text", text: "Start something new" }],
+          },
+        ]),
         false,
       );
     });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.852";
+export const VERSION = "0.1.853";


### PR DESCRIPTION
## Summary
- Scope submitted `form_input` detection to the current assistant run/turn instead of the full conversation history.
- After a submitted form, hide only intake tools (`form_input`, `load_skill`) while keeping `invoke_agent` available when policy/runtime allows it.
- Mark submitted form state in the generate loop as well as streaming.
- Bump `veryfront` package version to `0.1.853` so veryfront-agent can consume the patched runtime after release.

## Verification
- `deno test -A src/utils/version.test.ts src/agent/hosted/chat-runtime-tool-assembly.test.ts src/agent/runtime/agent-runtime-step.test.ts src/agent/runtime/skill-policy.test.ts src/agent/hosted/chat-preparation.test.ts` → `ok | 24 passed (58 steps) | 0 failed`
- `deno lint src/agent/runtime/skill-policy-enforcement.ts src/agent/hosted/form-input-tool.ts src/agent/hosted/chat-runtime-tool-assembly.ts src/agent/runtime/index.ts src/agent/hosted/chat-preparation.test.ts src/agent/hosted/chat-runtime-tool-assembly.test.ts src/agent/runtime/agent-runtime-step.test.ts src/agent/runtime/skill-policy.test.ts src/utils/version-constant.ts src/utils/version.test.ts` → `Checked 10 files`
- `env -u OTEL_METRICS_EXPORTER -u OTEL_LOGS_EXPORTER -u OTEL_TRACES_EXPORTER -u OTEL_EXPORTER_OTLP_ENDPOINT -u OTEL_EXPORTER_OTLP_HEADERS -u OTEL_EXPORTER_OTLP_PROTOCOL deno test -A src/observability/metrics/config.test.ts` → passed

Note: the local pre-push full `test:unit` run reached `2173 passed` and failed only `src/observability/metrics/config.test.ts` because this shell had OTEL exporter variables set, changing the expected default metrics exporter. The same test passes with OTEL variables unset as above.

Fixes the runtime side of veryfront/veryfront-studio#5090.
