### PR TITLE
Fix hosted runtime load_skill registration collision

### DIFF
--- a/src/agent/hosted/default-chat-runtime.test.ts
+++ b/src/agent/hosted/default-chat-runtime.test.ts
@@ -5,6 +5,7 @@ import type {
   RemoteToolSource,
   ToolExecutionContext,
 } from "#veryfront/tool";
+import { toolRegistry } from "#veryfront/tool";
 import { defineSchema } from "../../schemas/define.ts";
 import {
   createDefaultHostedChatRuntime,
@@ -73,4 +74,37 @@ Deno.test("createDefaultHostedChatRuntime builds a cloud-backed hosted runtime",
     inputRequestId: "input-request-1",
   });
   assertEquals(capturedContext.availableToolNames, ["sleep"]);
+});
+
+Deno.test("createDefaultHostedChatRuntime keeps per-run host tools out of the global registry", async () => {
+  try {
+    const createRuntime = (description: string) =>
+      createDefaultHostedChatRuntime({
+        options: {
+          projectId: "project-1",
+          branchId: "branch-1",
+          authToken: "token-1",
+          instructions: "Base instructions",
+          model: "sonnet",
+          allowedTools: ["load_skill"],
+          conversationId: "conversation-1",
+          userId: "user-1",
+        },
+        config: {
+          apiUrl: "https://api.example.com",
+          apiMcpUrl: "https://api.example.com/mcp",
+          studioMcpUrl: "https://studio.example.com/mcp",
+        },
+        buildLocalTools: () => ({ load_skill: localTool(description) }),
+        createRemoteToolSource: emptyRemoteSource,
+        preloadLatestConversationUserText: false,
+      });
+
+    await createRuntime("Load first skill catalog");
+    await createRuntime("Load updated skill catalog");
+
+    assertEquals(toolRegistry.getOwn("load_skill"), undefined);
+  } finally {
+    toolRegistry.clearAll();
+  }
 });

--- a/src/agent/hosted/default-chat-runtime.ts
+++ b/src/agent/hosted/default-chat-runtime.ts
@@ -14,6 +14,7 @@ import {
   type VeryfrontCloudContext,
 } from "#veryfront/provider/veryfront-cloud/context.ts";
 import { agent } from "../factory.ts";
+import { markRuntimeLocalTool } from "../runtime/local-tool.ts";
 import {
   applyDefaultResearchArtifactPath,
   createDefaultResearchRunArtifactMirrorHandler,
@@ -227,11 +228,18 @@ function createRuntimeAgentConfig(input: {
       })
     : undefined;
 
+  const runtimeTools = Object.fromEntries(
+    Object.entries(input.toolAssembly.runtimeTools).map(([toolName, runtimeTool]) => [
+      toolName,
+      markRuntimeLocalTool(runtimeTool),
+    ]),
+  );
+
   const runtimeConfig: AgentConfig & RuntimeRemoteToolConfig = {
     id: "veryfront-hosted-runtime",
     model: input.modelId,
     system: input.toolAssembly.systemInstructions,
-    tools: input.toolAssembly.runtimeTools,
+    tools: runtimeTools,
     providerTools: input.toolAssembly.providerToolNames,
     __vfRemoteToolSources: input.toolAssembly.remoteToolSources,
     __vfAllowedRemoteTools: input.toolAssembly.compatibleRemoteToolNames,


### PR DESCRIPTION
## Summary
Fix hosted chat setup failures caused by per-run host tools polluting the process-wide tool registry.

`createDefaultHostedChatRuntime` materializes per-run local tools such as `load_skill` into framework tool objects before calling `agent()`. Without marking them runtime-local, `agent()` registers them globally. A later run with the same tool ID but a different generated description/schema can then fail setup with:

> Tool "load_skill" is already registered with a different definition.

## Fix
Mark hosted runtime tools with `markRuntimeLocalTool(...)` before passing them to `agent()`, so they remain per-run and are not registered in the project/global registry.

## Reproduction / verification
- Red check against pre-fix implementation with the new test failed with the exact error above.
- Green check after fix:
  - `deno fmt --check src/agent/hosted/default-chat-runtime.ts src/agent/hosted/default-chat-runtime.test.ts`
  - `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/agent/hosted/default-chat-runtime.test.ts`
  - `deno check src/agent/index.ts`
- Broader local pre-push gate reached unit tests and failed on unrelated `observability/metrics/config` default exporter (`otlp` vs `console`), after 2174 tests passed.
