### PR TITLE
Release veryfront 0.1.854

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.853",
+  "version": "0.1.854",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.853";
+export const VERSION = "0.1.854";


### PR DESCRIPTION
## Summary
Bump `veryfront` to `0.1.854` so the merged hosted-runtime `load_skill` collision fix can publish as a new package.

The prior main release attempted to publish `0.1.853`, which already exists for commit `0bae9a78713e`, so release failed before publishing the fix from `42b2a4308eb8`.

## Verification
- `deno fmt --check deno.json src/utils/version-constant.ts`
