### PR TITLE
Keep Mistral chat within available quota

### DIFF
--- a/src/agent/runtime/constants.test.ts
+++ b/src/agent/runtime/constants.test.ts
@@ -23,8 +23,8 @@ describe("getModelMaxOutputTokens", () => {
   });
 
   it("returns known limits for Mistral models", () => {
-    assertEquals(getModelMaxOutputTokens("mistral/mistral-large-2512"), 131_072);
-    assertEquals(getModelMaxOutputTokens("veryfront-cloud/mistral/mistral-large-2512"), 131_072);
+    assertEquals(getModelMaxOutputTokens("mistral/mistral-large-2512"), 4_096);
+    assertEquals(getModelMaxOutputTokens("veryfront-cloud/mistral/mistral-large-2512"), 4_096);
   });
 
   it("returns undefined for unknown models", () => {

--- a/src/agent/runtime/constants.ts
+++ b/src/agent/runtime/constants.ts
@@ -19,7 +19,7 @@ const MODEL_MAX_OUTPUT_TOKENS: Record<string, number> = {
   "google-ai-studio/gemini-3.1-flash-lite": 65_536,
   "google-ai-studio/gemini-2.5-pro": 65_536,
   "google-ai-studio/gemini-2.5-flash": 65_536,
-  "mistral/mistral-large-2512": 131_072,
+  "mistral/mistral-large-2512": 4_096,
 };
 
 const MODEL_MAX_OUTPUT_TOKEN_ALIASES: Record<string, string> = {


### PR DESCRIPTION
## Summary
- cap Mistral Large default output reservation at 4096 tokens
- keep hosted/direct Mistral model resolution unchanged

## Why
Staging Mistral runs are currently failing with provider rate limits because the deployed quota is 20k TPM and the runtime reserved the full Mistral output window.

## Validation
- `deno task test src/agent/runtime/constants.test.ts`
- `deno task test src/agent/runtime/model-resolution.test.ts src/provider/veryfront-cloud/model-catalog.test.ts src/provider/veryfront-cloud/provider.test.ts`

## Notes
- Full pre-commit `verify:quick` is blocked by existing CLI boundary lint violations outside this patch.
