### PR TITLE
Publish Mistral quota fix as a new framework version

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.856",
+  "version": "0.1.857",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.856";
+export const VERSION = "0.1.857";


### PR DESCRIPTION
## Summary\n- bump veryfront-code package version from 0.1.856 to 0.1.857\n- unblock publishing the already-merged Mistral output-cap fix from #2525\n\n## Root cause\n- #2525 merged after v0.1.856 had already been published from the previous main commit\n- npm veryfront@0.1.856 still contains the old Mistral output cap, so downstream agent images cannot consume the fix under that version\n\n## Verification\n- jq -r '.version' deno.json -> 0.1.857\n- local full pre-commit hook is blocked by pre-existing CLI boundary lint violations unrelated to this one-line version bump