### PR TITLE
Fix provider web tool finalization

### DIFF
--- a/src/agent/hosted/chat-execution-runtime.test.ts
+++ b/src/agent/hosted/chat-execution-runtime.test.ts
@@ -747,6 +747,57 @@ describe("agent/hosted-chat-execution-runtime", () => {
     assertEquals(terminalStates, [{ status: "completed" }]);
   });
 
+  it("completes response finalization with provider-native web tool input still open", async () => {
+    let streamOptions: HostedChatRuntimeToUiMessageStreamOptions | undefined;
+    const terminalStates: HostedLifecycleTerminalState[] = [];
+    const runtime = createHostedChatExecutionRuntime({
+      agentId: "agent-1",
+      modelId: "anthropic/claude-sonnet-4-5-20250929",
+      originalMessages: [],
+      runContext: { withContext: (fn) => fn() },
+      abortSignal: new AbortController().signal,
+      bootstrap: {
+        cleanup: async () => {},
+        lifecycleAdapter: createLifecycleAdapter({ terminalStates }),
+        rootStreamWatchdog: createRootStreamWatchdog(),
+        streamResult: createStreamResult({
+          finalStep: {},
+          captureOptions: (options) => {
+            streamOptions = options;
+          },
+        }),
+        streamingMessageId: "stream-message-1",
+        capturedMessageId: "stream-message-1",
+        capturedConversationId: "conversation-1",
+        mirroredToolChunkState: createMirroredToolChunkState(),
+      },
+    });
+    if (!streamOptions) {
+      throw new Error("stream options were not captured");
+    }
+
+    await streamOptions.onFinish?.({
+      messages: [],
+      isContinuation: false,
+      responseMessage: createResponseMessage({
+        parts: [
+          { type: "text", text: "done" },
+          {
+            type: "tool-web_fetch",
+            toolCallId: "srvtoolu-fetch",
+            input: { url: "https://veryfront.com/docs/agent/create-agent" },
+            state: "input-available",
+          },
+        ],
+      }),
+      isAborted: false,
+      finishReason: "stop",
+    });
+    await runtime.waitForFinish();
+
+    assertEquals(terminalStates, [{ status: "completed" }]);
+  });
+
   it("records stream errors before detached finalization fallback", async () => {
     let streamOptions: HostedChatRuntimeToUiMessageStreamOptions | undefined;
     const terminalStates: HostedLifecycleTerminalState[] = [];

--- a/src/agent/hosted/finalized-message.test.ts
+++ b/src/agent/hosted/finalized-message.test.ts
@@ -59,6 +59,38 @@ Deno.test("buildFinalizedMessageState does not fail provider-owned input-availab
   ]);
 });
 
+Deno.test("buildFinalizedMessageState does not fail provider-native web tools when providerExecuted is omitted", () => {
+  const result = buildFinalizedMessageState({
+    responseMessage: {
+      id: "assistant-1",
+      role: "assistant",
+      parts: [
+        { type: "text", text: "Done" },
+        {
+          type: "tool-web_fetch",
+          toolCallId: "srvtoolu-fetch",
+          input: { url: "https://veryfront.com/docs/agent/create-agent" },
+          state: "input-available",
+        },
+      ],
+    },
+    isAborted: false,
+    finalStep: { text: "Done" },
+    incompleteToolCallsPartErrorText: "tool error",
+  });
+
+  assertEquals(result.hasIncompleteFinalizedToolParts, false);
+  assertEquals(result.sanitizedFinalizedMessage.parts, [
+    { type: "text", text: "Done" },
+    {
+      type: "tool-web_fetch",
+      toolCallId: "srvtoolu-fetch",
+      input: { url: "https://veryfront.com/docs/agent/create-agent" },
+      state: "input-available",
+    },
+  ]);
+});
+
 Deno.test("buildDetachedFallbackMessageState uses the captured message id for detached fallback messages", () => {
   const result = buildDetachedFallbackMessageState({
     capturedMessageId: "captured-1",

--- a/src/chat/conversation.test.ts
+++ b/src/chat/conversation.test.ts
@@ -191,6 +191,41 @@ describe("chat/conversation helpers", () => {
     ]);
   });
 
+  it("treats provider-native web tools as complete when the AI SDK omits providerExecuted", () => {
+    const message: ChatUiMessage = {
+      id: "assistant-provider-native-tool",
+      role: "assistant",
+      parts: [
+        { type: "text", text: "I can answer with the fetched context." },
+        {
+          type: "tool-web_fetch",
+          toolCallId: "srvtoolu-fetch",
+          input: { url: "https://veryfront.com/docs/agent/create-agent" },
+          state: "input-available",
+        },
+      ],
+    };
+
+    assertEquals(hasIncompleteToolParts(message), false);
+    assertEquals(markIncompleteToolPartsAsErrored(message, "Tool call did not complete"), message);
+    assertEquals(toConversationPartsFromUiMessage(message), [
+      { type: "text", text: "I can answer with the fetched context." },
+      {
+        type: "tool_call",
+        id: "srvtoolu-fetch",
+        name: "web_fetch",
+        input: { url: "https://veryfront.com/docs/agent/create-agent" },
+        state: "completed",
+      },
+      {
+        type: "tool_result",
+        tool_call_id: "srvtoolu-fetch",
+        output: null,
+        is_error: false,
+      },
+    ]);
+  });
+
   it("maps UI messages into persistable conversation parts", () => {
     const message: ChatUiMessage = {
       id: "assistant-2",

--- a/src/chat/conversation.ts
+++ b/src/chat/conversation.ts
@@ -197,6 +197,8 @@ export interface ReasoningPartLike {
 type ToolUiPart = Extract<ChatUiMessagePart, { toolCallId: string; state: string }>;
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
 
+const PROVIDER_NATIVE_WEB_TOOL_NAMES = new Set(["web_fetch", "web_search"]);
+
 /** Shared UUID pattern value. */
 export const UUID_PATTERN =
   /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/i;
@@ -301,6 +303,19 @@ export function getUiToolName(part: ToolUiPart): string | undefined {
   return part.type.startsWith("tool-") ? part.type.replace(/^tool-/, "") : undefined;
 }
 
+function isProviderOwnedInputAvailableTool(input: {
+  toolName?: string;
+  state: string;
+  providerExecuted?: unknown;
+}): boolean {
+  if (input.state !== "input-available") {
+    return false;
+  }
+
+  return input.providerExecuted === true ||
+    (typeof input.toolName === "string" && PROVIDER_NATIVE_WEB_TOOL_NAMES.has(input.toolName));
+}
+
 /** Push tool parts. */
 export function pushToolParts(
   parts: MessagePart[],
@@ -316,7 +331,11 @@ export function pushToolParts(
 ): void {
   const input = toRecord(part.input);
   const isErroredState = state === "output-error" || state === "error" || state === "output-denied";
-  const isProviderOwnedAvailable = part.providerExecuted === true && state === "input-available";
+  const isProviderOwnedAvailable = isProviderOwnedInputAvailableTool({
+    toolName,
+    state,
+    providerExecuted: part.providerExecuted,
+  });
   const hasResultState = state === "output-available" || state === "completed" ||
     isErroredState || isProviderOwnedAvailable;
 
@@ -451,7 +470,13 @@ export function toConversationPartsFromUiMessage(message: ChatUiMessage): Messag
 }
 
 function isToolComplete(part: ToolUiPart): boolean {
-  if (part.providerExecuted === true && part.state === "input-available") {
+  if (
+    isProviderOwnedInputAvailableTool({
+      toolName: getUiToolName(part),
+      state: part.state,
+      providerExecuted: part.providerExecuted,
+    })
+  ) {
     return true;
   }
 


### PR DESCRIPTION
## Summary

Fix hosted chat finalization for Anthropic provider-native web tools when the AI SDK emits a final `tool-web_fetch` / `tool-web_search` part as `input-available` without `providerExecuted: true`.

This addresses the staging retest failure tracked from veryfront-studio#5081 where `create_agent` succeeded, the created-agent card rendered, but the assistant message/run was marked failed with `INCOMPLETE_TOOL_CALLS` because an earlier `web_fetch` part was treated as an incomplete local tool.

## Changes

- Treat provider-native web tools (`web_fetch`, `web_search`) as provider-owned while `input-available`, even when `providerExecuted` is omitted.
- Add regression coverage for:
  - conversation part conversion
  - finalized message sanitization
  - hosted chat terminal state finalization

## Verification

Clean worktree from `origin/main`:

```text
deno fmt --check src/chat/conversation.ts src/chat/conversation.test.ts src/agent/hosted/finalized-message.test.ts src/agent/hosted/chat-execution-runtime.test.ts
# PASS

deno check src/chat/conversation.ts src/agent/hosted/finalized-message.ts src/agent/hosted/chat-execution-runtime.ts
# PASS

deno test --no-check --allow-all src/chat/conversation.test.ts src/agent/hosted/finalized-message.test.ts src/agent/hosted/chat-execution-runtime.test.ts
# PASS: 10 passed (32 steps), 0 failed
```

Pre-push hook evidence:

```text
fmt: PASS
lint: PASS
typecheck: PASS
test:unit: FAIL in unrelated observability/metrics/config tests
  expected exporter default `console`, got `otlp`
```

The failed pre-push tests are unrelated to this diff and occur outside touched files.

## Tracking

- veryfront-studio issue: https://github.com/veryfront/veryfront-studio/issues/5081
- Staging retest conversation: `ee76a89e-554f-4207-8bbc-fe72ab2c7012`
- Failed run before this fix: `run_d6aa4f98-cf23-48de-acbe-9ecc0aac2438`
