### PR TITLE
Fix provider requests with trailing assistant messages

### DIFF
--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -34,7 +34,7 @@ import {
   setSpanAttributes,
   withSpan,
 } from "#veryfront/observability/tracing/index.ts";
-import { convertToTextGenerationRuntimeMessages } from "./text-generation-runtime-message-converter.ts";
+import { convertToTextGenerationRuntimeRequestMessages } from "./text-generation-runtime-message-converter.ts";
 import { convertToolsToRuntimeTools } from "./model-tool-converter.ts";
 import { getRuntimeRemoteToolSources } from "./mcp-server-tool-sources.ts";
 import {
@@ -600,7 +600,7 @@ export class AgentRuntime {
           return generateText({
             model: languageModel,
             system: currentSystemPrompt,
-            messages: convertToTextGenerationRuntimeMessages(currentMessages),
+            messages: convertToTextGenerationRuntimeRequestMessages(currentMessages),
             tools: convertToolsToRuntimeTools(tools, {
               model: effectiveModel,
               providerTools,
@@ -935,7 +935,7 @@ export class AgentRuntime {
       const result = streamText({
         model: languageModel,
         system: currentSystemPrompt,
-        messages: convertToTextGenerationRuntimeMessages(currentMessages),
+        messages: convertToTextGenerationRuntimeRequestMessages(currentMessages),
         tools: runtimeTools,
         experimental_repairToolCall: repairToolCall,
         maxOutputTokens: this.resolveMaxOutputTokens(effectiveModel, maxOutputTokensOverride),

--- a/src/agent/runtime/text-generation-runtime-message-converter.test.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   convertToTextGenerationRuntimeMessage,
   convertToTextGenerationRuntimeMessages,
+  convertToTextGenerationRuntimeRequestMessages,
 } from "./text-generation-runtime-message-converter.ts";
 import type {
   TextGenerationRuntimeAssistantMessage,
@@ -787,6 +788,98 @@ describe("text-generation-runtime-message-converter", () => {
           output: { type: "json", value: { files: ["new.ts"] } },
         }],
       });
+    });
+  });
+
+  describe("convertToTextGenerationRuntimeRequestMessages", () => {
+    it("drops trailing assistant-only continuation text before provider requests", () => {
+      const messages: Message[] = [
+        {
+          id: "user_1",
+          role: "user",
+          parts: [{ type: "text", text: "Help me build an agent." }],
+        },
+        {
+          id: "assistant_form",
+          role: "assistant",
+          parts: [
+            {
+              type: "text",
+              text: "I'll ask one setup question.",
+            },
+            {
+              type: "tool-form_input",
+              toolCallId: "tool_form",
+              toolName: "form_input",
+              args: { title: "Agent brief" },
+            },
+          ],
+        },
+        {
+          id: "tool_form",
+          role: "tool",
+          parts: [{
+            type: "tool-result",
+            toolCallId: "tool_form",
+            toolName: "form_input",
+            result: { submitted: true, values: { brief: "gmail agent doing morning brief" } },
+          }],
+        },
+        {
+          id: "assistant_tools",
+          role: "assistant",
+          parts: [
+            { type: "text", text: "Let me check the Gmail integration." },
+            {
+              type: "tool-get_integration",
+              toolCallId: "tool_integration",
+              toolName: "get_integration",
+              args: { name: "gmail" },
+            },
+            {
+              type: "tool-list_agents",
+              toolCallId: "tool_agents",
+              toolName: "list_agents",
+              args: { project_reference: "test-661633ea" },
+            },
+          ],
+        },
+        {
+          id: "tool_integration",
+          role: "tool",
+          parts: [{
+            type: "tool-result",
+            toolCallId: "tool_integration",
+            toolName: "get_integration",
+            result: { name: "gmail", auth: "oauth" },
+          }],
+        },
+        {
+          id: "tool_agents",
+          role: "tool",
+          parts: [{
+            type: "tool-result",
+            toolCallId: "tool_agents",
+            toolName: "list_agents",
+            result: { agents: [] },
+          }],
+        },
+        {
+          id: "assistant_prefill",
+          role: "assistant",
+          parts: [{
+            type: "text",
+            text: "Let me get the one detail I need to build the right agent for you.",
+          }],
+        },
+      ];
+
+      const historyMessages = convertToTextGenerationRuntimeMessages(messages);
+      assertEquals(historyMessages.at(-1)?.role, "assistant");
+
+      const requestMessages = convertToTextGenerationRuntimeRequestMessages(messages);
+      assertEquals(requestMessages.at(-1)?.role, "tool");
+      assertEquals(requestMessages.length, historyMessages.length - 1);
     });
   });
 });

--- a/src/agent/runtime/text-generation-runtime-message-converter.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.ts
@@ -482,3 +482,23 @@ export function convertToTextGenerationRuntimeMessages(
 
   return textGenerationRuntimeMessages;
 }
+
+/**
+ * Convert messages for a provider request.
+ *
+ * Some providers reject assistant-prefill transcripts and require the prompt to
+ * end at user/tool input. Persisted runtime history may temporarily end with an
+ * assistant-only continuation message between streamed tool steps, so trim that
+ * replay-only tail at the provider boundary without changing stored history.
+ */
+export function convertToTextGenerationRuntimeRequestMessages(
+  messages: Message[],
+): TextGenerationRuntimeMessage[] {
+  const requestMessages = convertToTextGenerationRuntimeMessages(messages);
+
+  while (requestMessages.at(-1)?.role === "assistant") {
+    requestMessages.pop();
+  }
+
+  return requestMessages;
+}


### PR DESCRIPTION
## Summary
- add a provider-request message conversion helper that trims trailing assistant replay messages
- use the stricter provider-request conversion for agent generate and streaming model calls
- add a regression test mirroring the staging form/tool continuation that ended with assistant text before the next provider call

## Root cause
The staging run for conversation d48d9e86-a3f8-4c3e-8d9c-b6db20dbd83f failed because the streamed agent loop persisted assistant-only continuation text after tool results, then sent the next Anthropic request with a transcript ending in an assistant message. Anthropic rejects that shape as assistant prefill: "The conversation must end with a user message."

## Verification
- deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/agent/runtime/text-generation-runtime-message-converter.test.ts src/agent/runtime/tool-result-continuation.test.ts
- deno task lint
- deno task typecheck
- env -u OTEL_METRICS_EXPORTER -u OTEL_METRICS_ENABLED -u VERYFRONT_OTEL -u OTEL_EXPORTER_OTLP_ENDPOINT -u OTEL_EXPORTER_OTLP_METRICS_ENDPOINT deno task test:unit
- pre-push hook passed with the same OTEL metrics env unset