### PR TITLE
Bump veryfront version to 0.1.857

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.856",
+  "version": "0.1.857",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.856";
+export const VERSION = "0.1.857";


### PR DESCRIPTION
## Summary

Bump `veryfront` from `0.1.856` to `0.1.857` so the release job can publish the already-merged provider web tool finalization fix.

The previous main CI/CD release job failed because `veryfront@0.1.856` already exists on npm for commit `f1fc5fc985fc9b8486c7d6339a6eb0aed611f1e3`.

## Verification

```text
deno fmt --check deno.json src/utils/version-constant.ts
# PASS
```

## Tracking

- Unblocks release for https://github.com/veryfront/veryfront-code/pull/2527
- Tracks staging issue https://github.com/veryfront/veryfront-studio/issues/5081
