### PR TITLE
Release veryfront 0.1.857

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.856",
+  "version": "0.1.857",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.856";
+export const VERSION = "0.1.857";


### PR DESCRIPTION
Publishes a new veryfront package version that includes the merged Anthropic assistant-prefill runtime fix from #2528.

Why this is needed:
- veryfront@0.1.856 is already published from an older gitHead.
- npm package versions are immutable, so staging cannot consume the #2528 fix via 0.1.856.
- veryfront-agent needs a published package version containing the fix before the staging retest is meaningful.

Local verification:
- deno fmt --check deno.json src/utils/version-constant.ts
- deno check src/utils/version-constant.ts src/utils/version.ts
- npm view veryfront@0.1.857 version gitHead --json returned 404 before publishing
- pre-push hook passed, including deno task test:unit with OTEL env unset