### PR TITLE
Preserve unsupported assistant-prefill provider errors

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.857",
+  "version": "0.1.858",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/hosted/stream-terminal-error.test.ts
+++ b/src/agent/hosted/stream-terminal-error.test.ts
@@ -59,6 +59,21 @@ Deno.test("getEmptyHostedFinalizedMessageTerminalError returns stream timeout wh
   );
 });
 
+Deno.test("getEmptyHostedFinalizedMessageTerminalError preserves unsupported assistant prefill provider errors", () => {
+  assertEquals(
+    getEmptyHostedFinalizedMessageTerminalError({
+      finalStep: null,
+      streamError:
+        'veryfront-cloud request failed: {"type":"error","error":{"type":"invalid_request_error","message":"This model does not support assistant message prefill. The conversation must end with a user message."}}',
+    }),
+    {
+      code: "MODEL_UNSUPPORTED_ASSISTANT_PREFILL",
+      message:
+        "The selected model does not support assistant-message prefill. Start a new user message or choose a compatible model.",
+    },
+  );
+});
+
 Deno.test("getEmptyHostedFinalizedMessageTerminalError returns credit error from stream error", () => {
   const result = getEmptyHostedFinalizedMessageTerminalError({
     finalStep: null,

--- a/src/chat/provider-errors.test.ts
+++ b/src/chat/provider-errors.test.ts
@@ -51,6 +51,33 @@ describe("chat/provider-errors", () => {
     });
   });
 
+  it("classifies unsupported assistant prefill provider rejections as model capability errors", () => {
+    const expected = {
+      code: "MODEL_UNSUPPORTED_ASSISTANT_PREFILL",
+      message:
+        "The selected model does not support assistant-message prefill. Start a new user message or choose a compatible model.",
+    };
+
+    assertEquals(
+      parseProviderError({
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          message:
+            "This model does not support assistant message prefill. The conversation must end with a user message.",
+        },
+      }),
+      expected,
+    );
+
+    assertEquals(
+      parseProviderError(
+        'veryfront-cloud request failed: {"type":"error","error":{"type":"invalid_request_error","message":"This model does not support assistant message prefill. The conversation must end with a user message."}}',
+      ),
+      expected,
+    );
+  });
+
   it("classifies invalid Veryfront schema errors as project code validation failures", () => {
     const expected = {
       code: "PROJECT_SCHEMA_ERROR",

--- a/src/chat/provider-errors.ts
+++ b/src/chat/provider-errors.ts
@@ -16,6 +16,12 @@ const PROJECT_SCHEMA_ERROR = {
     "Project code has an invalid Veryfront schema. Update the schema to use defineSchema(), then run the agent again.",
 } as const;
 
+const MODEL_UNSUPPORTED_ASSISTANT_PREFILL_ERROR = {
+  code: "MODEL_UNSUPPORTED_ASSISTANT_PREFILL",
+  message:
+    "The selected model does not support assistant-message prefill. Start a new user message or choose a compatible model.",
+} as const;
+
 function isErrorRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -95,6 +101,10 @@ function parseKnownProviderBody(body: unknown): ParsedProviderError | null {
     return null;
   }
 
+  if (body.type === "error" && isErrorRecord(body.error)) {
+    return parseKnownProviderBody(body.error);
+  }
+
   if (body.type === "overloaded_error") {
     return {
       code: "OVERLOADED_ERROR",
@@ -128,6 +138,13 @@ function parseKnownProviderBody(body: unknown): ParsedProviderError | null {
     body.message.includes("too long")
   ) {
     return { code: "CONTEXT_LENGTH_EXCEEDED", message: "Conversation is too long" };
+  }
+
+  if (
+    body.type === "invalid_request_error" && typeof body.message === "string" &&
+    body.message.toLowerCase().includes("does not support assistant message prefill")
+  ) {
+    return MODEL_UNSUPPORTED_ASSISTANT_PREFILL_ERROR;
   }
 
   return null;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.857";
+export const VERSION = "0.1.858";


### PR DESCRIPTION
## Summary

Fixes the runtime side of veryfront/veryfront-studio#5113.

The Sentry event showed an upstream provider `invalid_request_error` for a model that does not support assistant-message prefill. The runtime parser did not unwrap provider envelopes shaped like `{ "type": "error", "error": { ... } }`, so this fell through to generic provider failure handling and reached AG-UI as `STREAM_ERROR`.

This PR:
- unwraps provider `type:error` envelopes before classification
- maps unsupported assistant-message prefill rejections to `MODEL_UNSUPPORTED_ASSISTANT_PREFILL`
- verifies hosted terminal errors preserve the specific code instead of collapsing to `STREAM_ERROR`

## Red / green evidence

RED observed before implementation:
- `deno test src/chat/provider-errors.test.ts src/agent/hosted/stream-terminal-error.test.ts` failed with parser returning `EXTERNAL_SERVICE_ERROR` and terminal error returning `STREAM_ERROR`.

GREEN after implementation:
- `deno test src/chat/provider-errors.test.ts src/agent/hosted/stream-terminal-error.test.ts`
- Result: 18 passed, 0 failed.

## Verification

- `git diff --check`
- `deno test src/chat/provider-errors.test.ts src/agent/hosted/stream-terminal-error.test.ts`

## Not tested

- Full Deno suite.
- `verify:quick` hook currently fails on unrelated existing CLI boundary violations in `cli/shared/server-startup.ts`, `cli/commands/skills/validate.ts`, `cli/commands/serve/split-mode.ts`, `cli/skills/loader.ts`, and `cli/skills/types.ts`. The commit is path-scoped to `src/chat` and `src/agent/hosted`.

## Follow-up

Studio needs the paired mapping PR so the new runtime terminal code renders as a non-retryable actionable chat error.
