### PR TITLE
Fit Mistral Large chat within current quota

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.857",
+  "version": "0.1.858",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/constants.test.ts
+++ b/src/agent/runtime/constants.test.ts
@@ -23,8 +23,8 @@ describe("getModelMaxOutputTokens", () => {
   });
 
   it("returns known limits for Mistral models", () => {
-    assertEquals(getModelMaxOutputTokens("mistral/mistral-large-2512"), 4_096);
-    assertEquals(getModelMaxOutputTokens("veryfront-cloud/mistral/mistral-large-2512"), 4_096);
+    assertEquals(getModelMaxOutputTokens("mistral/mistral-large-2512"), 1_024);
+    assertEquals(getModelMaxOutputTokens("veryfront-cloud/mistral/mistral-large-2512"), 1_024);
   });
 
   it("returns undefined for unknown models", () => {

--- a/src/agent/runtime/constants.ts
+++ b/src/agent/runtime/constants.ts
@@ -19,7 +19,7 @@ const MODEL_MAX_OUTPUT_TOKENS: Record<string, number> = {
   "google-ai-studio/gemini-3.1-flash-lite": 65_536,
   "google-ai-studio/gemini-2.5-pro": 65_536,
   "google-ai-studio/gemini-2.5-flash": 65_536,
-  "mistral/mistral-large-2512": 4_096,
+  "mistral/mistral-large-2512": 1_024,
 };
 
 const MODEL_MAX_OUTPUT_TOKEN_ALIASES: Record<string, string> = {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.857";
+export const VERSION = "0.1.858";


### PR DESCRIPTION
## Summary

- lower the hosted Mistral Large output reservation from 4096 to 1024 tokens
- bump the framework version to `0.1.858`
- keep the public model ID unchanged: `mistral/mistral-large-2512`

## Evidence

Staging after `veryfront@0.1.857` rollout still reached the Mistral Large deployment but failed with provider `RateLimitReached` under the current 20k TPM quota. The deployed image did contain the 4096 cap, so this follow-up tightens the operational cap to leave room for default-chat system/tool context until the quota increase lands.

## Verification

- `deno task test src/agent/runtime/constants.test.ts` passed
- `deno task test:unit src/utils/logger/logger.test.ts` passed; this expanded to the full unit suite: `2177 passed`, `0 failed`

## Known Gap

- `git commit` pre-commit `verify:quick` still fails on existing CLI boundary violations in unrelated files (`cli/shared/server-startup.ts`, `cli/commands/skills/validate.ts`, `cli/commands/serve/split-mode.ts`, `cli/skills/*`). This PR does not touch those files.
- Full staging success must be retested after this version is published and `veryfront-agent` is bumped/rolled out.
