### PR TITLE
Bump veryfront to 0.1.858

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.857",
+  "version": "0.1.858",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.857";
+export const VERSION = "0.1.858";


### PR DESCRIPTION
## Summary

Follow-up to #2529. The main release failed because npm already has veryfront@0.1.857 for a different gitHead, so this bumps the source-of-truth version files to 0.1.858.

## Verification

- deno check src/utils/version-constant.ts cli/main.ts
- deno.json/version constant sync check
- git diff --check
- pre-push format, lint, typecheck, and unit tests: 2177 passed