### PR TITLE
Bump veryfront to 0.1.859

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.858",
+  "version": "0.1.859",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.858";
+export const VERSION = "0.1.859";


### PR DESCRIPTION
## Summary
- Bump the stable veryfront package version from 0.1.858 to 0.1.859 after 0.1.858 was already published from another main commit.
- Keep src/utils/version-constant.ts in sync with deno.json.

## Test Plan
- deno fmt --check deno.json src/utils/version-constant.ts
- git diff --check
- npm view veryfront@0.1.859 version --json (expected 404 before release)