### PR TITLE
Distinguish provider spend caps from user credits

### DIFF
--- a/src/chat/provider-errors.test.ts
+++ b/src/chat/provider-errors.test.ts
@@ -51,6 +51,33 @@ describe("chat/provider-errors", () => {
     });
   });
 
+  it("classifies provider spend limits separately from user credit balance", () => {
+    const expected = {
+      code: "AI_PROVIDER_SPEND_LIMIT_EXCEEDED",
+      message:
+        "The AI provider spend limit has been reached. Try again later or ask an administrator to raise the AI provider spend limit.",
+      status: 402,
+    };
+
+    assertEquals(
+      parseProviderError({
+        slug: "insufficient-credits",
+        error: "AI provider spend limit exceeded for the daily window.",
+        suggestion: "Try again later or ask an administrator to raise the AI provider spend limit.",
+        balance: 1,
+        required: 2,
+      }),
+      expected,
+    );
+
+    assertEquals(
+      parseProviderError(
+        'veryfront-cloud request failed: {"slug":"insufficient-credits","error":"AI provider spend limit exceeded for the daily window.","suggestion":"Try again later or ask an administrator to raise the AI provider spend limit.","balance":1,"required":2}',
+      ),
+      expected,
+    );
+  });
+
   it("classifies unsupported assistant prefill provider rejections as model capability errors", () => {
     const expected = {
       code: "MODEL_UNSUPPORTED_ASSISTANT_PREFILL",

--- a/src/chat/provider-errors.ts
+++ b/src/chat/provider-errors.ts
@@ -22,6 +22,13 @@ const MODEL_UNSUPPORTED_ASSISTANT_PREFILL_ERROR = {
     "The selected model does not support assistant-message prefill. Start a new user message or choose a compatible model.",
 } as const;
 
+const AI_PROVIDER_SPEND_LIMIT_ERROR = {
+  code: "AI_PROVIDER_SPEND_LIMIT_EXCEEDED",
+  message:
+    "The AI provider spend limit has been reached. Try again later or ask an administrator to raise the AI provider spend limit.",
+  status: 402,
+} as const;
+
 function isErrorRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -61,6 +68,11 @@ export function parseKnownProblemBody(body: unknown): ParsedProviderError | null
   const slug = typeof body.slug === "string" ? body.slug : null;
   const error = typeof body.error === "string" ? body.error : null;
   const suggestion = typeof body.suggestion === "string" ? body.suggestion : null;
+  const normalizedProblemText = `${error ?? ""} ${suggestion ?? ""}`.toLowerCase();
+
+  if (normalizedProblemText.includes("ai provider spend limit")) {
+    return AI_PROVIDER_SPEND_LIMIT_ERROR;
+  }
 
   if (slug === "insufficient-credits" || error === "AI credit limit exceeded") {
     return {


### PR DESCRIPTION
## Summary

Follow-up for veryfront/veryfront-studio#5113.

The runtime can receive provider spend-limit failures as problem JSON with `slug: "insufficient-credits"`, even when the body explicitly says `AI provider spend limit exceeded`. Because `parseKnownProblemBody()` trusted the slug first, Studio showed the wrong user-credit failure even when the user still had extra credits.

This PR:
- classifies explicit AI provider spend-limit text before the generic `insufficient-credits` slug
- emits `AI_PROVIDER_SPEND_LIMIT_EXCEEDED`
- keeps the message actionable for an administrator/provider-budget limit, not a user balance issue
- adds regression coverage for the direct problem body and embedded `veryfront-cloud request failed: {...}` text

## Red / green evidence

RED observed:
- `deno test src/chat/provider-errors.test.ts` failed because the new case returned `INSUFFICIENT_CREDITS`.

GREEN after implementation:
- `deno test src/chat/provider-errors.test.ts`
- Result: 1 file passed, 6 test steps passed, 0 failed.

## Verification

- `git diff --check`
- `deno test src/chat/provider-errors.test.ts`

## Not tested

- Full Deno suite.
- `verify:quick` hook is blocked by unrelated existing CLI boundary violations in `cli/shared/server-startup.ts`, `cli/commands/skills/validate.ts`, `cli/commands/serve/split-mode.ts`, `cli/skills/loader.ts`, and `cli/skills/types.ts`.

## Studio follow-up

Paired Studio PR maps the new terminal code to user-facing copy.
