### PR TITLE
Require skill body before reference file loads

### DIFF
--- a/src/agent/runtime/load-skill-tool.test.ts
+++ b/src/agent/runtime/load-skill-tool.test.ts
@@ -94,7 +94,8 @@ Deno.test("createRuntimeLoadSkillTool loads project skills before builtin skills
     instructions: "# Project plan",
     nextStep: RUNTIME_LOAD_SKILL_CONTINUATION_NOTE,
     references: ["references/project.md"],
-    referenceNote: "Use load_skill with the `file` parameter to load any of these reference files.",
+    referenceNote:
+      "After this skill is loaded, use load_skill with the `file` parameter only for one of these listed reference files.",
   });
 });
 
@@ -250,27 +251,107 @@ Use one form, then write the plan.`,
   ]);
 });
 
-Deno.test("createRuntimeLoadSkillTool loads project and builtin reference files", async () => {
+Deno.test("createRuntimeLoadSkillTool rejects reference files before the skill body is loaded", async () => {
   const tool = createRuntimeLoadSkillTool({
     context: createProjectContext(),
     skillsDir: "/skills",
     projectSkillLoader: createProjectSkillLoader({
+      skills: new Map([
+        ["veryfront", { instructions: "# Veryfront", references: ["references/ROUTES.md"] }],
+      ]),
+      references: new Map([
+        ["veryfront/references/ROUTES.md", "routes reference"],
+      ]),
+    }),
+    builtinStore: createBuiltinStore({}),
+  });
+
+  assertEquals(await tool.execute({ skillId: "veryfront", file: "references/ROUTES.md" }), {
+    error:
+      'Skill "veryfront" must be loaded before reference file "references/ROUTES.md". Call load_skill with only {"skillId":"veryfront"} first, then request one of the listed reference files.',
+  });
+  assertEquals(await tool.execute({ skillId: "veryfront", file: "references/does-not-exist.md" }), {
+    error:
+      'Skill "veryfront" must be loaded before reference file "references/does-not-exist.md". Call load_skill with only {"skillId":"veryfront"} first, then request one of the listed reference files.',
+  });
+});
+
+Deno.test("createRuntimeLoadSkillTool loads project and builtin reference files after body load", async () => {
+  const tool = createRuntimeLoadSkillTool({
+    context: createProjectContext(),
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({
+      skills: new Map([
+        ["plan", { instructions: "# Plan", references: ["references/project.md"] }],
+      ]),
       references: new Map([["plan/references/project.md", "project reference"]]),
     }),
     builtinStore: createBuiltinStore({
-      references: new Map([["plan/references/builtin.md", "builtin reference"]]),
+      skills: new Map([["build", "# Build"]]),
+      references: new Map([["build/references/builtin.md", "builtin reference"]]),
+      referenceLists: new Map([["build", ["references/builtin.md"]]]),
     }),
   });
 
+  await tool.execute({ skillId: "plan" });
   assertEquals(await tool.execute({ skillId: "plan", file: "references/project.md" }), {
     skillId: "plan",
     file: "references/project.md",
     content: "project reference",
   });
-  assertEquals(await tool.execute({ skillId: "plan", file: "references/builtin.md" }), {
-    skillId: "plan",
+  await tool.execute({ skillId: "build" });
+  assertEquals(await tool.execute({ skillId: "build", file: "references/builtin.md" }), {
+    skillId: "build",
     file: "references/builtin.md",
     content: "builtin reference",
+  });
+});
+
+Deno.test("createRuntimeLoadSkillTool rejects unadvertised references after body load", async () => {
+  const tool = createRuntimeLoadSkillTool({
+    context: createProjectContext(),
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({
+      skills: new Map([
+        ["veryfront", { instructions: "# Veryfront", references: ["references/ROUTES.md"] }],
+      ]),
+      references: new Map([
+        ["veryfront/references/ROUTES.md", "routes reference"],
+        ["veryfront/references/does-not-exist.md", "hidden reference"],
+      ]),
+    }),
+    builtinStore: createBuiltinStore({}),
+  });
+
+  await tool.execute({ skillId: "veryfront" });
+
+  assertEquals(await tool.execute({ skillId: "veryfront", file: "references/does-not-exist.md" }), {
+    error:
+      'Reference file not advertised by loaded skill "veryfront": references/does-not-exist.md. Available references: references/ROUTES.md',
+  });
+});
+
+Deno.test("createRuntimeLoadSkillTool preserves advertised quickstart references", async () => {
+  const tool = createRuntimeLoadSkillTool({
+    context: createProjectContext(),
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({
+      skills: new Map([
+        ["veryfront", { instructions: "# Veryfront", references: ["references/quickstart.md"] }],
+      ]),
+      references: new Map([
+        ["veryfront/references/quickstart.md", "quickstart reference"],
+      ]),
+    }),
+    builtinStore: createBuiltinStore({}),
+  });
+
+  await tool.execute({ skillId: "veryfront" });
+
+  assertEquals(await tool.execute({ skillId: "veryfront", file: "references/quickstart.md" }), {
+    skillId: "veryfront",
+    file: "references/quickstart.md",
+    content: "quickstart reference",
   });
 });
 
@@ -281,7 +362,11 @@ Deno.test("createRuntimeLoadSkillTool makes same-reference reloads concise and i
     skillsDir: "/skills",
     projectSkillLoader: {
       listProjectSkillReferences: () => Promise.resolve([]),
-      loadProjectSkill: () => Promise.resolve(null),
+      loadProjectSkill: () =>
+        Promise.resolve({
+          instructions: "# Plan",
+          references: ["references/project.md"],
+        }),
       loadProjectSkillReference: (_context, skillId, normalizedFile) => {
         projectReferenceReads++;
         return Promise.resolve(`${skillId}/${normalizedFile} content`);
@@ -290,6 +375,7 @@ Deno.test("createRuntimeLoadSkillTool makes same-reference reloads concise and i
     builtinStore: createBuiltinStore({}),
   });
 
+  await tool.execute({ skillId: "plan" });
   const firstResult = await tool.execute({ skillId: "plan", file: "references/project.md" });
   const secondResult = await tool.execute({ skillId: "plan", file: "references/project.md" });
 
@@ -315,7 +401,11 @@ Deno.test("createRuntimeLoadSkillTool reloads same reference after project conte
     skillsDir: "/skills",
     projectSkillLoader: {
       listProjectSkillReferences: () => Promise.resolve([]),
-      loadProjectSkill: () => Promise.resolve(null),
+      loadProjectSkill: (activeContext, skillId) =>
+        Promise.resolve({
+          instructions: `# ${activeContext.projectId} ${skillId}`,
+          references: ["references/project.md"],
+        }),
       loadProjectSkillReference: (activeContext, skillId, normalizedFile) => {
         projectReferenceReads++;
         return Promise.resolve(`${activeContext.projectId}/${skillId}/${normalizedFile}`);
@@ -324,10 +414,12 @@ Deno.test("createRuntimeLoadSkillTool reloads same reference after project conte
     builtinStore: createBuiltinStore({}),
   });
 
+  await tool.execute({ skillId: "plan" });
   const firstResult = await tool.execute({ skillId: "plan", file: "references/project.md" });
   context.projectId = "project-2";
   context.branchId = null;
   context.skillSourcePaths = { plan: "agents/planner/skills/plan/SKILL.md" };
+  await tool.execute({ skillId: "plan" });
   const secondResult = await tool.execute({ skillId: "plan", file: "references/project.md" });
 
   assertEquals(projectReferenceReads, 2);

--- a/src/agent/runtime/load-skill-tool.ts
+++ b/src/agent/runtime/load-skill-tool.ts
@@ -35,7 +35,7 @@ export const RUNTIME_LOAD_SKILL_CONTINUATION_NOTE =
 
 /** Shared runtime load skill description value. */
 export const RUNTIME_LOAD_SKILL_DESCRIPTION =
-  `Load the full instructions for a skill. Use this when you need detailed guidance for a specific task type. If the skill specifies allowed-tools, you MUST only use those tools while following this skill. load_skill does not perform the task by itself. ${LOAD_SKILL_CONTINUE_SAME_TURN} ${LOAD_SKILL_ROOT_OWNERSHIP} ${LOAD_SKILL_USE_ALLOWED_TOOLS} ${LOAD_SKILL_DELEGATION_THRESHOLD} Use the optional \`file\` parameter to load a specific reference file from the skill.`;
+  `Load the full instructions for a skill. Use this when you need detailed guidance for a specific task type. If the skill specifies allowed-tools, you MUST only use those tools while following this skill. load_skill does not perform the task by itself. ${LOAD_SKILL_CONTINUE_SAME_TURN} ${LOAD_SKILL_ROOT_OWNERSHIP} ${LOAD_SKILL_USE_ALLOWED_TOOLS} ${LOAD_SKILL_DELEGATION_THRESHOLD} First call load_skill with only skillId. Use the optional \`file\` parameter only after the skill is loaded and only for a reference file listed by that loaded skill.`;
 
 const DEFAULT_RUNTIME_LOAD_SKILL_RESPONSE_MESSAGES: RuntimeLoadedSkillResponseMessages = {
   allowedToolsNote:
@@ -45,7 +45,8 @@ const DEFAULT_RUNTIME_LOAD_SKILL_RESPONSE_MESSAGES: RuntimeLoadedSkillResponseMe
   unavailableCurrentRunToolsDelegationNote:
     "IMPORTANT: Some tools required by this skill are not available in the current run. Use invoke_agent for the isolated work and pass delegationTools as the child tools allowlist.",
   overrideNote: LOAD_SKILL_OVERRIDE_FORWARDING,
-  referenceNote: "Use load_skill with the `file` parameter to load any of these reference files.",
+  referenceNote:
+    "After this skill is loaded, use load_skill with the `file` parameter only for one of these listed reference files.",
 };
 
 /** Context for runtime load skill tool. */
@@ -85,7 +86,7 @@ export const getRuntimeLoadSkillToolInputSchema = defineSchema((v) =>
       .regex(/^[a-zA-Z0-9_-]+$/, 'skillId must contain only letters, numbers, "_" or "-"')
       .describe('The skill ID to load (e.g., "react-components", "api-design")'),
     file: v.string().optional().describe(
-      'Optional reference file to load (e.g. "references/quickstart.md")',
+      "Optional reference file to load. First load the skill with only skillId, then use file only for a reference path listed by that loaded skill.",
     ),
   })
 );
@@ -281,7 +282,7 @@ function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) 
         `The skill ID to load. Available skill IDs: ${knownIds.join(", ")}`,
       ),
       file: v.string().optional().describe(
-        'Optional reference file to load (e.g. "references/quickstart.md")',
+        "Optional reference file to load. First load the skill with only skillId, then use file only for a reference path listed by that loaded skill.",
       ),
     })
   )();
@@ -295,6 +296,26 @@ async function loadRuntimeSkillReferenceFile(
   const normalizedFile = normalizeRuntimeSkillReferencePath(file);
   if (!normalizedFile) {
     return { error: `Invalid reference file path: ${file}` };
+  }
+
+  const loadedSkillKey = buildRuntimeSkillCacheKey(options.context, skillId);
+  const loadedSkillResponse = options.context.loadedSkillResponses?.[loadedSkillKey];
+  if (!loadedSkillResponse) {
+    return {
+      error: `Skill "${skillId}" must be loaded before reference file "${normalizedFile}". ` +
+        `Call load_skill with only {"skillId":"${skillId}"} first, then request one of the listed reference files.`,
+    };
+  }
+
+  const advertisedReferences = loadedSkillResponse.references ?? [];
+  if (!advertisedReferences.includes(normalizedFile)) {
+    const availableReferences = advertisedReferences.length > 0
+      ? advertisedReferences.join(", ")
+      : "none";
+    return {
+      error: `Reference file not advertised by loaded skill "${skillId}": ${normalizedFile}. ` +
+        `Available references: ${availableReferences}`,
+    };
   }
 
   const loadedSkillReferenceResponses = options.context.loadedSkillReferenceResponses ??= {};


### PR DESCRIPTION
## Summary
- Require `load_skill` body load before any `file` reference load.
- Limit reference file loads to paths advertised by the loaded skill.
- Remove generic quickstart-style guidance from the runtime schema/description.

## Verification
- `deno test --no-check --allow-all src/agent/runtime/load-skill-tool.test.ts`
- `deno task build`
- Pre-commit `verify:quick` passed during commit.