### PR TITLE
Allow hosted agents to fetch explicit docs URLs

### DIFF
--- a/src/agent/hosted/chat-runtime-tool-assembly.test.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.test.ts
@@ -260,6 +260,7 @@ Deno.test("prepareHostedChatRuntimeToolAssembly includes source provider tools o
     instructions: "Base instructions",
     localTools: {
       sleep: localTool("Sleep"),
+      web_fetch: localTool("Fetch a URL"),
     },
     apiUrl: "https://api.example.com",
     apiMcpUrl: "https://api.example.com/mcp",
@@ -269,9 +270,10 @@ Deno.test("prepareHostedChatRuntimeToolAssembly includes source provider tools o
     preloadLatestConversationUserText: false,
   });
 
-  assertEquals(toolAssembly.localToolNames, ["sleep"]);
-  assertEquals(toolAssembly.providerToolNames, ["web_fetch", "web_search"]);
+  assertEquals(toolAssembly.localToolNames, ["sleep", "web_fetch"]);
+  assertEquals(toolAssembly.providerToolNames, ["web_search"]);
   assertEquals(taskContext.availableToolNames, ["sleep", "web_fetch", "web_search"]);
+  assertExists(toolAssembly.runtimeTools.web_fetch);
   assertStringIncludes(toolAssembly.systemInstructions, "- web_fetch");
   assertStringIncludes(toolAssembly.systemInstructions, "- web_search");
 });

--- a/src/agent/hosted/chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted/chat-runtime-tool-assembly.ts
@@ -36,6 +36,8 @@ import {
 } from "./runtime-essential-tools.ts";
 import type { HostedSubmittedFormInputResult } from "./chat-runtime-contract.ts";
 
+const HOSTED_LOCAL_PROVIDER_TOOL_NAMES = new Set(["web_fetch"]);
+
 /** Context for hosted chat runtime tool assembly. */
 export type HostedChatRuntimeToolAssemblyContext = DefaultResearchArtifactContext & {
   authToken: string;
@@ -122,10 +124,15 @@ function filterPostFormInputLocalTools(
 export function filterHostedChatRuntimeLocalTools(input: {
   tools: HostToolSet;
   allowedToolNames?: HostedChatRuntimeAllowedToolNames;
+  sourceProviderToolNames?: readonly string[];
 }): HostToolSet {
   const allowedToolNames = normalizeHostedRuntimeAllowedToolNames(input.allowedToolNames);
+  const sourceProviderToolNames = new Set(input.sourceProviderToolNames ?? []);
   const entries = Object.entries(input.tools).filter(([toolName]) =>
-    allowedToolNames ? allowedToolNames.has(toolName) : true
+    allowedToolNames
+      ? allowedToolNames.has(toolName) ||
+        (HOSTED_LOCAL_PROVIDER_TOOL_NAMES.has(toolName) && sourceProviderToolNames.has(toolName))
+      : true
   );
 
   return Object.fromEntries(entries.sort(([left], [right]) => left.localeCompare(right)));
@@ -145,6 +152,7 @@ export async function prepareHostedChatRuntimeToolAssembly<
   const sortedLocalTools = filterHostedChatRuntimeLocalTools({
     tools: filterPostFormInputLocalTools(input.localTools, input.taskContext),
     allowedToolNames,
+    sourceProviderToolNames: input.sourceProviderToolNames,
   });
   const localHostTools = input.traceLocalTools
     ? traceHostTools(sortedLocalTools, input.traceLocalTools)
@@ -173,10 +181,16 @@ export async function prepareHostedChatRuntimeToolAssembly<
     projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions,
   });
   const sourceProviderToolNames = new Set(input.sourceProviderToolNames ?? []);
+  const localProviderToolNames = new Set(
+    Object.keys(sortedLocalTools).filter((toolName) =>
+      HOSTED_LOCAL_PROVIDER_TOOL_NAMES.has(toolName)
+    ),
+  );
   const providerToolNames = getProviderNativeToolNames({ model: input.taskContext.model }).filter(
     (toolName) =>
-      sourceProviderToolNames.has(toolName) ||
-      (allowedToolNames ? allowedToolNames.has(toolName) : false),
+      !localProviderToolNames.has(toolName) &&
+      (sourceProviderToolNames.has(toolName) ||
+        (allowedToolNames ? allowedToolNames.has(toolName) : false)),
   );
   const localToolNames = Object.keys(localHostTools);
   const availableToolNames = selectProviderCompatibleToolNames(

--- a/src/agent/hosted/veryfront-cloud-agent-service.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.ts
@@ -48,6 +48,7 @@ import {
 } from "../service/bootstrap.ts";
 import { loadAgentServiceEnvFiles } from "../service/env-files.ts";
 import { createHostedFormInputTool } from "./form-input-tool.ts";
+import { createHostedWebFetchTool } from "./web-fetch-tool.ts";
 import {
   createHostedAgentProjectSteering,
   type HostedAgentProjectSteering,
@@ -709,6 +710,7 @@ function buildLocalTools(
     form_input: createHostedFormInputTool(taskContext, config.VERYFRONT_API_URL),
     load_skill: createLoadSkillTool(context, taskContext),
     sleep: sleepTool,
+    web_fetch: createHostedWebFetchTool(),
   };
 
   if (options.allowDelegation !== false) {

--- a/src/agent/hosted/web-fetch-tool.test.ts
+++ b/src/agent/hosted/web-fetch-tool.test.ts
@@ -1,0 +1,53 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { createHostedWebFetchTool } from "./web-fetch-tool.ts";
+
+Deno.test("createHostedWebFetchTool fetches an explicit HTTPS URL without prior search", async () => {
+  const requestedUrls: string[] = [];
+  const tool = createHostedWebFetchTool({
+    fetch: (input, init) => {
+      requestedUrls.push(String(input));
+      assertEquals(init?.redirect, "follow");
+      return Promise.resolve(
+        new Response("Create agent docs", {
+          status: 200,
+          headers: { "content-type": "text/markdown; charset=utf-8" },
+        }),
+      );
+    },
+  });
+
+  const result = await tool.execute?.({
+    url: "https://api.veryfront.com/docs/mcp?tool=create_agent",
+  });
+
+  assertEquals(requestedUrls, ["https://api.veryfront.com/docs/mcp?tool=create_agent"]);
+  assertEquals((result as { type?: unknown }).type, "web_fetch_result");
+  assertEquals(
+    (result as { url?: unknown }).url,
+    "https://api.veryfront.com/docs/mcp?tool=create_agent",
+  );
+  assertEquals(
+    (result as { content?: { source?: { data?: unknown; mediaType?: unknown } } }).content
+      ?.source?.mediaType,
+    "text/markdown; charset=utf-8",
+  );
+  assertStringIncludes(
+    String((result as { content?: { source?: { data?: unknown } } }).content?.source?.data),
+    "Create agent docs",
+  );
+});
+
+Deno.test("createHostedWebFetchTool rejects non-http URLs", async () => {
+  const tool = createHostedWebFetchTool({
+    fetch: () => {
+      throw new Error("fetch should not be called");
+    },
+  });
+
+  await assertRejects(
+    () => tool.execute?.({ url: "file:///etc/passwd" }) as Promise<unknown>,
+    Error,
+    "web_fetch only supports http and https URLs",
+  );
+});

--- a/src/agent/hosted/web-fetch-tool.ts
+++ b/src/agent/hosted/web-fetch-tool.ts
@@ -1,0 +1,113 @@
+import { defineSchema } from "#veryfront/schemas/index.ts";
+import { tool, type ToolExecutionContext } from "#veryfront/tool";
+
+const DEFAULT_MAX_CONTENT_CHARS = 500_000;
+
+/** Input payload for hosted web_fetch. */
+export type HostedWebFetchToolInput = {
+  url: string;
+};
+
+/** Output payload matching provider-native web_fetch result shape. */
+export type HostedWebFetchToolOutput = {
+  type: "web_fetch_result";
+  url: string;
+  content: {
+    type: "document";
+    source: {
+      type: "text";
+      mediaType: string;
+      data: string;
+    };
+  };
+  retrievedAt: string;
+  status: number;
+  truncated?: boolean;
+};
+
+/** Options accepted by hosted web_fetch. */
+export type HostedWebFetchToolOptions = {
+  fetch?: typeof fetch;
+  maxContentChars?: number;
+};
+
+const getHostedWebFetchInputSchema = defineSchema((v) =>
+  v.object({
+    url: v.string().min(1),
+  })
+);
+
+function parseFetchUrl(value: string): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("web_fetch requires an absolute URL");
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("web_fetch only supports http and https URLs");
+  }
+  if (url.username || url.password) {
+    throw new Error("web_fetch does not support credentials in URLs");
+  }
+
+  return url;
+}
+
+async function executeHostedWebFetch(
+  input: HostedWebFetchToolInput,
+  options: Required<HostedWebFetchToolOptions>,
+  context?: ToolExecutionContext,
+): Promise<HostedWebFetchToolOutput> {
+  const url = parseFetchUrl(input.url);
+  const response = await options.fetch(url.toString(), {
+    method: "GET",
+    redirect: "follow",
+    signal: context?.abortSignal,
+    headers: {
+      accept: "text/html,application/xhtml+xml,application/xml,text/markdown,text/plain,*/*;q=0.8",
+      "user-agent": "Veryfront web_fetch",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`web_fetch failed with HTTP ${response.status}`);
+  }
+
+  const mediaType = response.headers.get("content-type") ?? "text/plain";
+  const text = await response.text();
+  const truncated = text.length > options.maxContentChars;
+
+  return {
+    type: "web_fetch_result",
+    url: response.url || url.toString(),
+    content: {
+      type: "document",
+      source: {
+        type: "text",
+        mediaType,
+        data: truncated ? text.slice(0, options.maxContentChars) : text,
+      },
+    },
+    retrievedAt: new Date().toISOString(),
+    status: response.status,
+    ...(truncated ? { truncated } : {}),
+  };
+}
+
+/** Create hosted web_fetch tool that allows direct explicit URL fetches. */
+export function createHostedWebFetchTool(options: HostedWebFetchToolOptions = {}) {
+  const resolvedOptions: Required<HostedWebFetchToolOptions> = {
+    fetch: options.fetch ?? globalThis.fetch,
+    maxContentChars: options.maxContentChars ?? DEFAULT_MAX_CONTENT_CHARS,
+  };
+
+  return tool<HostedWebFetchToolInput, HostedWebFetchToolOutput>({
+    id: "web_fetch",
+    description:
+      "Fetch the content of an explicit http or https URL directly. Use this for canonical documentation or pages named in the task or available context; no prior web_search is required.",
+    inputSchema: getHostedWebFetchInputSchema(),
+    execute: (input, context) => executeHostedWebFetch(input, resolvedOptions, context),
+  });
+}


### PR DESCRIPTION
## Summary
- add a hosted local `web_fetch` tool that fetches explicit http/https URLs directly
- route hosted `web_fetch` to the local tool when an agent config requests it, while keeping provider-native `web_search`
- cover the direct docs URL path and hosted tool assembly behavior with tests

## Verification
- `deno test --no-check --allow-all src/agent/hosted/chat-runtime-tool-assembly.test.ts src/agent/hosted/web-fetch-tool.test.ts`
- `deno task typecheck`

## Verification gap
- `deno task verify:quick` currently fails on pre-existing CLI boundary violations in `cli/shared/server-startup.ts`, `cli/commands/skills/validate.ts`, `cli/commands/serve/split-mode.ts`, `cli/skills/loader.ts`, and `cli/skills/types.ts`; these files are outside this PR.

## Outcome
Hosted Veryfront agents can call `web_fetch` on canonical docs URLs directly without requiring a prior `web_search` result.