### PR TITLE
Release veryfront 0.1.860

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.859",
+  "version": "0.1.860",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.859";
+export const VERSION = "0.1.860";


### PR DESCRIPTION
## Summary
- bump `veryfront` package metadata to `0.1.860`
- publishes the merged hosted direct `web_fetch` runtime so `veryfront-agent` can consume it

## Verification
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno task typecheck`

## Context
`veryfront@0.1.859` was published from gitHead `0982256e`, before the direct hosted `web_fetch` fix. This release bump is needed for the agent dependency update.