### PR TITLE
Close proxy WebSocket peers on upstream EOF

### DIFF
--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -23,6 +23,7 @@
 import { createProxyHandler, INTERNAL_PROXY_HEADERS, type ProxyConfig } from "./handler.ts";
 import { createCacheFromEnv } from "./cache/index.ts";
 import { isRetryableConnectionError } from "./retry.ts";
+import { closeBridgePeer, getServerWebSocketErrorLogLevel } from "./websocket-bridge.ts";
 import { register } from "../extensions/contracts.ts";
 import { createAuthProvider } from "../../extensions/ext-auth-jwt/src/index.ts";
 import {
@@ -242,12 +243,16 @@ function handleWebSocketUpgrade(req: Request, url: URL): Response {
 
     serverSocket.onerror = (event) => {
       clearConnectTimeout();
-      proxyLogger.error("[WebSocket] Server connection error", {
+      const error = event instanceof ErrorEvent ? event.message : "Unknown error";
+      const logLevel = getServerWebSocketErrorLogLevel(error);
+      proxyLogger[logLevel]("[WebSocket] Server connection error", {
         projectSlug,
         environment: scope,
         targetUrl: targetUrl.toString(),
-        error: event instanceof ErrorEvent ? event.message : "Unknown error",
+        error,
       });
+      closeBridgePeer(clientSocket, 1011, "Server connection error");
+      closeBridgePeer(serverSocket, 1011, "Server connection error");
     };
 
     serverSocket.onclose = (event) => {

--- a/src/proxy/websocket-bridge.ts
+++ b/src/proxy/websocket-bridge.ts
@@ -1,0 +1,22 @@
+type BridgePeer = Pick<WebSocket, "close" | "readyState">;
+
+export type ServerWebSocketErrorLogLevel = "warn" | "error";
+
+const TRANSIENT_SERVER_ERROR_PATTERNS = [
+  /unexpected eof/i,
+  /connection reset/i,
+  /connection closed/i,
+  /socket closed/i,
+];
+
+export function getServerWebSocketErrorLogLevel(message: string): ServerWebSocketErrorLogLevel {
+  return TRANSIENT_SERVER_ERROR_PATTERNS.some((pattern) => pattern.test(message))
+    ? "warn"
+    : "error";
+}
+
+export function closeBridgePeer(peer: BridgePeer | null, code: number, reason: string): void {
+  if (!peer) return;
+  if (peer.readyState !== WebSocket.OPEN && peer.readyState !== WebSocket.CONNECTING) return;
+  peer.close(code, reason);
+}

--- a/src/proxy/websocket-proxy.test.ts
+++ b/src/proxy/websocket-proxy.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import { parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
+import { closeBridgePeer, getServerWebSocketErrorLogLevel } from "./websocket-bridge.ts";
 
 function isWebSocketUpgrade(req: Request): boolean {
   return req.headers.get("upgrade")?.toLowerCase() === "websocket";
@@ -143,6 +144,26 @@ describe("Proxy WebSocket Handler Tests", () => {
       assertEquals(WebSocket.OPEN, 1);
       assertEquals(WebSocket.CLOSING, 2);
       assertEquals(WebSocket.CLOSED, 3);
+    });
+  });
+
+  describe("Server WebSocket error handling", () => {
+    it("treats upstream EOF as a transient warning", () => {
+      assertEquals(getServerWebSocketErrorLogLevel("Unexpected EOF"), "warn");
+    });
+
+    it("closes the accepted client socket when the upstream bridge fails", () => {
+      const calls: Array<{ code?: number; reason?: string }> = [];
+      const socket = {
+        readyState: WebSocket.OPEN,
+        close(code?: number, reason?: string) {
+          calls.push({ code, reason });
+        },
+      };
+
+      closeBridgePeer(socket, 1011, "Server connection error");
+
+      assertEquals(calls, [{ code: 1011, reason: "Server connection error" }]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Close the accepted client socket when the upstream server WebSocket emits an error.
- Close the upstream peer as part of bridge cleanup.
- Treat transient upstream EOF-style failures as `warn` instead of `error` so one-off disconnects do not create error-class incidents.

## Root cause
- veryfront-api#3589 captured `veryfront-proxy` logging `[WebSocket] Server connection error` with `Unexpected EOF` for `ws://veryfront-server/_ws`.
- The exact log line is emitted from `src/proxy/main.ts`, so the owning code is in `veryfront-code`, not `veryfront-api`.
- The existing `serverSocket.onerror` handler only logged and cleared the connection timeout. It did not close the browser WebSocket accepted by the proxy, so an upstream EOF before a normal close event could leave the client side open without a server bridge.

## Evidence
- Red: `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/proxy/websocket-proxy.test.ts` failed before implementation because `src/proxy/websocket-bridge.ts` did not exist.
- Green: targeted websocket proxy test passes after implementation.
- Full proxy slice passes after implementation.
- Touched files typecheck, format, and lint.

## Test plan
- [x] `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/proxy/websocket-proxy.test.ts`
- [x] `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/proxy`
- [x] `deno check src/proxy/main.ts src/proxy/websocket-bridge.ts src/proxy/websocket-proxy.test.ts`
- [x] `deno fmt --check src/proxy/main.ts src/proxy/websocket-bridge.ts src/proxy/websocket-proxy.test.ts`
- [x] `deno lint src/proxy/main.ts src/proxy/websocket-bridge.ts src/proxy/websocket-proxy.test.ts`

## Notes
- Local pre-commit `verify:quick` still fails on pre-existing CLI boundary violations in files outside this change, for example `cli/shared/server-startup.ts` and `cli/commands/serve/split-mode.ts`.
- Direct historical Loki lookup could not run because the documented Grafana 1Password vault was unavailable in this session.

Refs veryfront/veryfront-api#3589