### PR TITLE
fix(runtime): drop trailing assistant prefill before provider requests

### DIFF
--- a/src/runtime/runtime-bridge.test.ts
+++ b/src/runtime/runtime-bridge.test.ts
@@ -708,4 +708,60 @@ describe("runtime-bridge", () => {
       },
     }]);
   });
+
+  it("drops trailing assistant prefill messages before direct stream requests", async () => {
+    const model = createStreamModel(
+      "anthropic",
+      "anthropic/test-drop-prefill-stream",
+      async (options) => {
+        assertEquals(options.prompt, [{
+          role: "user",
+          content: [{ type: "text", text: "Continue after the tool result." }],
+        }]);
+        return {
+          stream: ReadableStream.from([
+            { type: "text-delta", delta: "Continuing" },
+            { type: "finish", finishReason: { unified: "stop", raw: "stop" } },
+          ]),
+        };
+      },
+    );
+
+    const result = streamText({
+      model,
+      messages: [
+        { role: "user", content: "Continue after the tool result." },
+        { role: "assistant", content: [{ type: "text", text: "Draft prefill" }] },
+      ],
+    });
+
+    assertEquals(await collectAsync(result.textStream), ["Continuing"]);
+  });
+
+  it("drops trailing assistant prefill messages before direct generate requests", async () => {
+    const model = createGenerateModel(
+      "anthropic",
+      "anthropic/test-drop-prefill-generate",
+      async (options) => {
+        assertEquals(options.prompt, [{
+          role: "user",
+          content: [{ type: "text", text: "Continue after the tool result." }],
+        }]);
+        return {
+          content: [{ type: "text", text: "Continuing" }],
+          finishReason: { unified: "stop", raw: "stop" },
+        };
+      },
+    );
+
+    const result = await generateText({
+      model,
+      messages: [
+        { role: "user", content: "Continue after the tool result." },
+        { role: "assistant", content: [{ type: "text", text: "Draft prefill" }] },
+      ],
+    });
+
+    assertEquals(result.text, "Continuing");
+  });
 });

--- a/src/runtime/runtime-bridge.ts
+++ b/src/runtime/runtime-bridge.ts
@@ -173,6 +173,18 @@ function normalizeSystemPrompt(system: GenerateTextOptions["system"]): string | 
   return undefined;
 }
 
+function getProviderRequestMessages(
+  messages: TextGenerationRuntimeMessage[],
+): TextGenerationRuntimeMessage[] {
+  const requestMessages = [...messages];
+
+  while (requestMessages.at(-1)?.role === "assistant") {
+    requestMessages.pop();
+  }
+
+  return requestMessages;
+}
+
 function toRuntimePrompt(
   system: string | undefined,
   messages: TextGenerationRuntimeMessage[],
@@ -559,7 +571,10 @@ async function* textDeltasFromStream(stream: ReadableStream<unknown>): AsyncIter
 export function generateText(options: GenerateTextOptions): PromiseLike<RuntimeGenerateTextResult> {
   return resolveDirectTools(options.tools).then((tools) =>
     options.model.doGenerate({
-      prompt: toRuntimePrompt(normalizeSystemPrompt(options.system), options.messages),
+      prompt: toRuntimePrompt(
+        normalizeSystemPrompt(options.system),
+        getProviderRequestMessages(options.messages),
+      ),
       maxOutputTokens: options.maxOutputTokens,
       ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
       topP: options.topP,
@@ -584,7 +599,10 @@ export function generateText(options: GenerateTextOptions): PromiseLike<RuntimeG
 export function streamText(options: StreamTextOptions): RuntimeStreamResult {
   const directResultPromise = resolveDirectTools(options.tools).then((tools) =>
     options.model.doStream({
-      prompt: toRuntimePrompt(normalizeSystemPrompt(options.system), options.messages),
+      prompt: toRuntimePrompt(
+        normalizeSystemPrompt(options.system),
+        getProviderRequestMessages(options.messages),
+      ),
       maxOutputTokens: options.maxOutputTokens,
       ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
       topP: options.topP,


### PR DESCRIPTION
## Summary
- Adds provider-boundary trimming in `runtime-bridge` so direct `generateText` / `streamText` calls never forward trailing assistant prefill messages.
- Covers both direct stream and generate paths with regression tests.

## Root cause
Staging conversation `dafc0e60-c344-4b08-b3ee-b9cd9cf28d68` failed with Anthropic/Veryfront Cloud rejecting a request whose conversation ended in an assistant message (`MODEL_UNSUPPORTED_ASSISTANT_PREFILL`). Agent runtime had a higher-level trimmer, but the actual provider bridge could still forward trailing assistant messages for direct runtime callers. This makes the bridge itself enforce the provider request invariant.

## Verification
- ✅ `deno test --config deno.json src/runtime/runtime-bridge.test.ts`
- ✅ `deno test --config deno.json src/agent/runtime/text-generation-runtime-message-converter.test.ts extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts src/runtime/runtime-bridge.test.ts`
- ✅ `deno check --config deno.json src/runtime/runtime-bridge.ts src/runtime/runtime-bridge.test.ts`
- ✅ `deno fmt --check src/runtime/runtime-bridge.ts src/runtime/runtime-bridge.test.ts`
- ✅ `deno lint src/runtime/runtime-bridge.ts src/runtime/runtime-bridge.test.ts`

Pre-push `deno task test:unit` was also attempted and failed on unrelated existing tests:
- `cli/commands/serve/split-mode.test.ts`: `BadResource: Listener has been closed`
- `src/observability/metrics/config.test.ts`: expected `console`, got env-driven `otlp`

Related Studio issue: veryfront/veryfront-studio#5127
