### PR TITLE
Bump package version for proxy EOF fix

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.860",
+  "version": "0.1.861",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.860";
+export const VERSION = "0.1.861";


### PR DESCRIPTION
## Summary
- Bump `deno.json` from `0.1.860` to `0.1.861`.
- Keep `src/utils/version-constant.ts` synchronized.

## Why
- veryfront-code#2540 merged the proxy WebSocket EOF fix.
- The post-merge release failed because `veryfront@0.1.860` already exists on npm for commit `8c706e47c8feede0c933166f6ef3f3de4fe15fe2`.
- This lets the merged fix publish and trigger downstream deploys.

## Test plan
- [x] `deno test --no-check --allow-all src/utils/version.test.ts`
- [x] `deno fmt --check deno.json src/utils/version-constant.ts`
- [x] `deno check src/utils/version-constant.ts`

Refs veryfront/veryfront-api#3589