### PR TITLE
ci: keep coverage gate active after shard failures

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -99,6 +99,7 @@ jobs:
     timeout-minutes: 5
     name: coverage gate
     needs: [coverage-shards]
+    if: ${{ always() }}
     steps:
       - name: Require coverage shards
         env:

--- a/src/config/cicd-coverage-workflow.test.ts
+++ b/src/config/cicd-coverage-workflow.test.ts
@@ -24,6 +24,7 @@ Deno.test("CI keeps the required coverage gate as a fast merge job", () => {
   assertStringIncludes(workflow, "coverage:");
   assertStringIncludes(workflow, "name: coverage gate");
   assertStringIncludes(workflow, "needs: [coverage-shards]");
+  assertStringIncludes(workflow, "if: ${{ always() }}");
   assertStringIncludes(workflow, "timeout-minutes: 5");
   assertStringIncludes(workflow, "actions/download-artifact");
   assertStringIncludes(workflow, "Download unit coverage lcov files");


### PR DESCRIPTION
## Summary
- Address Codex review feedback from #2543 by forcing the required `coverage gate` job to run with `if: ${{ always() }}` even when a coverage shard fails or is cancelled.
- Add a workflow contract assertion so the guard stays in place.

## Test Plan
- [x] `deno test --no-check --allow-read src/config/cicd-coverage-workflow.test.ts`
- [x] `deno task fmt:check`
- [x] `deno task lint`
