### PR TITLE
chore: bump veryfront for coverage ci release

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.861",
+  "version": "0.1.862",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.861";
+export const VERSION = "0.1.862";


### PR DESCRIPTION
## Summary
- Bump veryfront package version to 0.1.862 after the coverage CI task changes modified deno.json metadata
- Keep src/utils/version-constant.ts in sync with deno.json

## Verification
- deno fmt --check deno.json src/utils/version-constant.ts
- env -u OTEL_METRICS_EXPORTER -u OTEL_EXPORTER_OTLP_ENDPOINT -u OTEL_EXPORTER_OTLP_METRICS_ENDPOINT -u OTEL_METRICS_ENABLED -u VERYFRONT_OTEL deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/observability/metrics/config.test.ts
- pre-push hook: format, lint, typecheck, unit tests passed (2,192 tests)
- npm view veryfront@0.1.862 version returned no published version
