### PR TITLE
Constrain loaded skill body reloads

### DIFF
--- a/src/agent/runtime/load-skill-tool.test.ts
+++ b/src/agent/runtime/load-skill-tool.test.ts
@@ -174,6 +174,136 @@ Use form_input once, then produce the plan.`,
   assertEquals(secondResult.references, ["references/write.md"]);
 });
 
+Deno.test("createRuntimeLoadSkillTool schema disallows body reloads for already-loaded skills", async () => {
+  const context = createProjectContext({
+    availableSkillIds: ["plan", "veryfront"],
+    loadedSkillResponses: {
+      "veryfront-key": {
+        skillId: "veryfront",
+        instructions: "# Veryfront",
+        nextStep: "Continue.",
+      },
+    },
+  });
+  const tool = createRuntimeLoadSkillTool({
+    context,
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({}),
+    builtinStore: createBuiltinStore({}),
+  });
+
+  assertEquals(tool.inputSchemaJson, {
+    anyOf: [
+      {
+        type: "object",
+        properties: {
+          skillId: {
+            type: "string",
+            enum: ["plan"],
+            description: "Unloaded skill ID to load. Available unloaded skill IDs: plan",
+          },
+          file: {
+            type: "string",
+            description:
+              "Optional reference file to load. First load the skill with only skillId, then use file only for a reference path listed by that loaded skill.",
+          },
+        },
+        required: ["skillId"],
+      },
+      {
+        type: "object",
+        properties: {
+          skillId: {
+            type: "string",
+            enum: ["veryfront"],
+            description:
+              "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: veryfront",
+          },
+          file: {
+            type: "string",
+            description:
+              "Required reference file to load from an already-loaded skill. Do not call load_skill again for the skill body.",
+          },
+        },
+        required: ["skillId", "file"],
+      },
+    ],
+  });
+});
+
+Deno.test("createRuntimeLoadSkillTool schema only permits reference loads when all known skills are loaded", async () => {
+  const context = createProjectContext({
+    availableSkillIds: ["veryfront"],
+    loadedSkillResponses: {
+      "veryfront-key": {
+        skillId: "veryfront",
+        instructions: "# Veryfront",
+        nextStep: "Continue.",
+      },
+    },
+  });
+  const tool = createRuntimeLoadSkillTool({
+    context,
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({}),
+    builtinStore: createBuiltinStore({}),
+  });
+
+  assertEquals(tool.inputSchemaJson, {
+    type: "object",
+    properties: {
+      skillId: {
+        type: "string",
+        enum: ["veryfront"],
+        description:
+          "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: veryfront",
+      },
+      file: {
+        type: "string",
+        description:
+          "Required reference file to load from an already-loaded skill. Do not call load_skill again for the skill body.",
+      },
+    },
+    required: ["skillId", "file"],
+  });
+});
+
+Deno.test("createRuntimeLoadSkillTool schema ignores stale loaded skills outside the current manifest", async () => {
+  const context = createProjectContext({
+    availableSkillIds: ["veryfront"],
+    loadedSkillResponses: {
+      "old-plan-key": {
+        skillId: "plan",
+        instructions: "# Old plan",
+        nextStep: "Continue.",
+      },
+    },
+  });
+  const tool = createRuntimeLoadSkillTool({
+    context,
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({}),
+    builtinStore: createBuiltinStore({}),
+  });
+
+  assertEquals(tool.inputSchemaJson, {
+    type: "object",
+    properties: {
+      skillId: {
+        type: "string",
+        enum: ["veryfront"],
+        description: "The skill ID to load. Available skill IDs: veryfront",
+      },
+      file: {
+        type: "string",
+        description:
+          "Optional reference file to load. First load the skill with only skillId, then use file only for a reference path listed by that loaded skill.",
+      },
+    },
+    required: ["skillId"],
+  });
+});
+
 Deno.test("createRuntimeLoadSkillTool reloads same skill after project context changes", async () => {
   const context = createProjectContext();
   let projectSkillReads = 0;

--- a/src/agent/runtime/load-skill-tool.ts
+++ b/src/agent/runtime/load-skill-tool.ts
@@ -268,10 +268,71 @@ function getKnownRuntimeSkillIds(options: RuntimeLoadSkillToolOptions): string[]
   ].sort();
 }
 
+function getLoadedRuntimeSkillIds(options: RuntimeLoadSkillToolOptions): string[] {
+  return [
+    ...new Set(
+      Object.values(options.context.loadedSkillResponses ?? {})
+        .map((response) => response.skillId)
+        .filter((skillId): skillId is string => typeof skillId === "string" && skillId.length > 0),
+    ),
+  ].sort();
+}
+
 function buildRuntimeLoadSkillInputSchema(options: RuntimeLoadSkillToolOptions) {
   const knownIds = getKnownRuntimeSkillIds(options);
   if (!knownIds || knownIds.length === 0) {
     return runtimeLoadSkillToolInputSchema;
+  }
+
+  const knownIdSet = new Set(knownIds);
+  const loadedIds = getLoadedRuntimeSkillIds(options).filter((skillId) => knownIdSet.has(skillId));
+  const loadedIdSet = new Set(loadedIds);
+  const unloadedIds = knownIds.filter((skillId) => !loadedIdSet.has(skillId));
+
+  if (loadedIds.length > 0 && unloadedIds.length === 0) {
+    const [firstLoaded, ...restLoaded] = loadedIds as [string, ...string[]];
+    const loadedEnumValues = [firstLoaded, ...restLoaded] as [string, ...string[]];
+    return defineSchema((v) =>
+      v.object({
+        skillId: v.enum(loadedEnumValues).describe(
+          `Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: ${
+            loadedIds.join(", ")
+          }`,
+        ),
+        file: v.string().describe(
+          "Required reference file to load from an already-loaded skill. Do not call load_skill again for the skill body.",
+        ),
+      })
+    )();
+  }
+
+  if (loadedIds.length > 0) {
+    const [firstUnloaded, ...restUnloaded] = unloadedIds as [string, ...string[]];
+    const unloadedEnumValues = [firstUnloaded, ...restUnloaded] as [string, ...string[]];
+    const [firstLoaded, ...restLoaded] = loadedIds as [string, ...string[]];
+    const loadedEnumValues = [firstLoaded, ...restLoaded] as [string, ...string[]];
+    return defineSchema((v) =>
+      v.union([
+        v.object({
+          skillId: v.enum(unloadedEnumValues).describe(
+            `Unloaded skill ID to load. Available unloaded skill IDs: ${unloadedIds.join(", ")}`,
+          ),
+          file: v.string().optional().describe(
+            "Optional reference file to load. First load the skill with only skillId, then use file only for a reference path listed by that loaded skill.",
+          ),
+        }),
+        v.object({
+          skillId: v.enum(loadedEnumValues).describe(
+            `Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: ${
+              loadedIds.join(", ")
+            }`,
+          ),
+          file: v.string().describe(
+            "Required reference file to load from an already-loaded skill. Do not call load_skill again for the skill body.",
+          ),
+        }),
+      ])
+    )();
   }
 
   const [first, ...rest] = knownIds as [string, ...string[]];


### PR DESCRIPTION
## Summary
- Narrow the runtime `load_skill` schema after a skill body has already loaded.
- Already-loaded skills remain callable only with `file` for listed references; unloaded skills can still be loaded normally.
- Add regression tests for mixed loaded/unloaded manifests, all-loaded manifests, and stale loaded skill cache entries.

## Why
The Veryfront agent staging demo still emitted a second `load_skill(veryfront)` after integration/OAuth checks. The existing tool result was idempotent, but the duplicate call still appeared in Studio transcripts. This moves the guard into the per-step tool schema instead of relying on prompt reminders.

## Verification
- `deno fmt --check src/ cli/ react/ && deno fmt --check --config=scripts/test.deno.json scripts/test/`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/ cli/ react/ && deno lint --config=scripts/test.deno.json scripts/test/ scripts/build/npm-package-metadata.test.ts`
- `deno test --allow-all src/agent/runtime/load-skill-tool.test.ts src/agent/runtime/agent-runtime-step.test.ts src/agent/runtime/skill-policy.test.ts`

## Gap
- `deno task verify:quick` is blocked on current `origin/main` by existing CLI-boundary lint violations in `cli/*` imports, unrelated to these files.
