### PR TITLE
Refresh load skill schema after body loads

### DIFF
--- a/src/agent/runtime/load-skill-tool.test.ts
+++ b/src/agent/runtime/load-skill-tool.test.ts
@@ -6,6 +6,7 @@ import {
   type RuntimeLoadSkillBuiltinStore,
   type RuntimeLoadSkillToolContext,
 } from "./load-skill-tool.ts";
+import { toolToProviderDefinition } from "#veryfront/tool/registry.ts";
 import type {
   RuntimeLoadedProjectSkill,
   RuntimeProjectSkillContext,
@@ -229,6 +230,66 @@ Deno.test("createRuntimeLoadSkillTool schema disallows body reloads for already-
       },
     ],
   });
+});
+
+Deno.test("createRuntimeLoadSkillTool refreshes its provider schema after a skill body load", async () => {
+  const context = createProjectContext({
+    availableSkillIds: ["veryfront"],
+  });
+  const tool = createRuntimeLoadSkillTool({
+    context,
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({
+      skills: new Map([
+        ["veryfront", {
+          skillId: "veryfront",
+          instructions: "# Veryfront",
+          references: ["references/create-agent.md"],
+        }],
+      ]),
+    }),
+    builtinStore: createBuiltinStore({}),
+  });
+
+  const beforeLoad = toolToProviderDefinition(tool).parameters;
+  assertEquals(beforeLoad, {
+    type: "object",
+    properties: {
+      skillId: {
+        type: "string",
+        enum: ["veryfront"],
+        description: "The skill ID to load. Available skill IDs: veryfront",
+      },
+      file: {
+        type: "string",
+        description:
+          "Optional reference file to load. First load the skill with only skillId, then use file only for a reference path listed by that loaded skill.",
+      },
+    },
+    required: ["skillId"],
+  });
+
+  await tool.execute({ skillId: "veryfront" });
+
+  const afterLoad = toolToProviderDefinition(tool).parameters;
+  assertEquals(afterLoad, {
+    type: "object",
+    properties: {
+      skillId: {
+        type: "string",
+        enum: ["veryfront"],
+        description:
+          "Already-loaded skill ID. Body reloads are not allowed; use this only with file for listed references. Loaded skill IDs: veryfront",
+      },
+      file: {
+        type: "string",
+        description:
+          "Required reference file to load from an already-loaded skill. Do not call load_skill again for the skill body.",
+      },
+    },
+    required: ["skillId", "file"],
+  });
+  await assertRejects(() => tool.execute({ skillId: "veryfront" }));
 });
 
 Deno.test("createRuntimeLoadSkillTool schema only permits reference loads when all known skills are loaded", async () => {

--- a/src/agent/runtime/load-skill-tool.ts
+++ b/src/agent/runtime/load-skill-tool.ts
@@ -1,7 +1,7 @@
 import { defineSchema, lazySchema } from "#veryfront/schemas/index.ts";
 import type { InferSchema } from "#veryfront/extensions/schema/index.ts";
-import { tool } from "#veryfront/tool";
 import type { Tool } from "#veryfront/tool/types.ts";
+import { zodToJsonSchema } from "#veryfront/tool/schema/zod-json-schema.ts";
 import {
   LOAD_SKILL_CONTINUE_SAME_TURN,
   LOAD_SKILL_DELEGATION_THRESHOLD,
@@ -427,47 +427,66 @@ export function createRuntimeLoadSkillTool(
 ): Tool<RuntimeLoadSkillToolInput, RuntimeLoadSkillToolOutput> {
   const builtinStore = getBuiltinStore(options);
 
-  return tool({
+  async function execute({ skillId, file }: RuntimeLoadSkillToolInput) {
+    let parsed: RuntimeLoadSkillToolInput;
+    try {
+      parsed = buildRuntimeLoadSkillInputSchema(options).parse({ skillId, file });
+    } catch (error) {
+      throw new Error(
+        `Tool "load_skill" input validation failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    skillId = parsed.skillId;
+    file = parsed.file;
+
+    if (file) {
+      return await loadRuntimeSkillReferenceFile(options, skillId, file);
+    }
+
+    const loadedSkillResponses = options.context.loadedSkillResponses ??= {};
+    const loadedSkillKey = buildRuntimeSkillCacheKey(options.context, skillId);
+    const loadedResponse = loadedSkillResponses[loadedSkillKey];
+    if (loadedResponse) {
+      return buildAlreadyLoadedSkillResponse(skillId, loadedResponse);
+    }
+
+    const projectSkill = await loadRuntimeSkillBody(options, skillId);
+    if (projectSkill) {
+      const response = buildLoadedSkillResponse({
+        options,
+        skillId,
+        instructions: projectSkill.instructions,
+        references: projectSkill.references,
+      });
+      loadedSkillResponses[loadedSkillKey] = response;
+      return response;
+    }
+
+    const localContent = builtinStore.readSkill(options.skillsDir, skillId);
+    if (localContent) {
+      const response = buildLoadedSkillResponse({
+        options,
+        skillId,
+        instructions: localContent,
+        references: builtinStore.listReferences(options.skillsDir, skillId),
+      });
+      loadedSkillResponses[loadedSkillKey] = response;
+      return response;
+    }
+
+    return buildMissingSkillError(options, skillId);
+  }
+
+  return {
     id: "load_skill",
+    type: "function",
     description: buildRuntimeLoadSkillDescription(options),
-    inputSchema: buildRuntimeLoadSkillInputSchema(options),
-    execute: async ({ skillId, file }) => {
-      if (file) {
-        return await loadRuntimeSkillReferenceFile(options, skillId, file);
-      }
-
-      const loadedSkillResponses = options.context.loadedSkillResponses ??= {};
-      const loadedSkillKey = buildRuntimeSkillCacheKey(options.context, skillId);
-      const loadedResponse = loadedSkillResponses[loadedSkillKey];
-      if (loadedResponse) {
-        return buildAlreadyLoadedSkillResponse(skillId, loadedResponse);
-      }
-
-      const projectSkill = await loadRuntimeSkillBody(options, skillId);
-      if (projectSkill) {
-        const response = buildLoadedSkillResponse({
-          options,
-          skillId,
-          instructions: projectSkill.instructions,
-          references: projectSkill.references,
-        });
-        loadedSkillResponses[loadedSkillKey] = response;
-        return response;
-      }
-
-      const localContent = builtinStore.readSkill(options.skillsDir, skillId);
-      if (localContent) {
-        const response = buildLoadedSkillResponse({
-          options,
-          skillId,
-          instructions: localContent,
-          references: builtinStore.listReferences(options.skillsDir, skillId),
-        });
-        loadedSkillResponses[loadedSkillKey] = response;
-        return response;
-      }
-
-      return buildMissingSkillError(options, skillId);
+    inputSchema: runtimeLoadSkillToolInputSchema,
+    get inputSchemaJson() {
+      return zodToJsonSchema(buildRuntimeLoadSkillInputSchema(options));
     },
-  });
+    execute,
+  };
 }


### PR DESCRIPTION
## Summary
- make the runtime load_skill provider schema refresh from live loaded-skill state instead of freezing at tool construction
- preserve existing load_skill execution behavior and validation error shape
- add a regression showing the same tool object's provider schema changes after loading a skill body and rejects stale body reload input

## Root cause
Staging still produced duplicate load_skill({skillId:"veryfront"}) calls after veryfront-code#2546 because hosted chat builds the load_skill tool object once per run. The schema narrowing was computed when the tool was created, before any skill was loaded, so later model steps still received a stale provider schema that allowed body reloads.

## Verification
- deno test --allow-all src/agent/runtime/load-skill-tool.test.ts src/agent/runtime/agent-runtime-step.test.ts src/agent/runtime/skill-policy.test.ts
- deno fmt --check src/ cli/ react/
- deno fmt --check --config=scripts/test.deno.json scripts/test/
- DENO_NO_PACKAGE_JSON=1 deno lint src/ cli/ react/
- deno lint --config=scripts/test.deno.json scripts/test/ scripts/build/npm-package-metadata.test.ts

Constraint: staging demo db2cc918-1343-4075-8bdc-dd0d0bfb9295 functionally succeeded but still showed duplicate load_skill and web_fetch calls.
Rejected: static schema narrowing at tool construction | hosted runtime creates the tool once per run, so provider schema stayed stale across model steps.
Confidence: high
Scope-risk: narrow
Directive: Keep load_skill available for advertised reference files, but do not expose already-loaded skill bodies as repeat top-level load options.
Tested: targeted runtime tests and broad format/lint checks listed above.
Not-tested: deno task verify:quick locally, blocked by unrelated pre-existing CLI boundary violations on origin/main; staging Studio chat after package release and agent dependency bump.