### PR TITLE
Release framework runtime fix package

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.862",
+  "version": "0.1.863",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.862";
+export const VERSION = "0.1.863";


### PR DESCRIPTION
## Summary
- bump veryfront package version from 0.1.862 to 0.1.863
- keep VERSION in sync with deno.json
- enables publishing the dynamic load_skill schema fix from veryfront-code#2547 for veryfront-agent consumption

## Verification
- deno fmt --check deno.json src/utils/version-constant.ts
- DENO_NO_PACKAGE_JSON=1 deno lint src/utils/version-constant.ts
- deno task generate:manifests:check
- npm view veryfront version => 0.1.862, so 0.1.863 is unpublished

Constraint: veryfront-code#2547 merged the runtime fix but main still advertised the already-published 0.1.862 version.
Rejected: reuse 0.1.862 | npm cannot publish an already-used package version.
Confidence: high
Scope-risk: narrow
Directive: Publish 0.1.863 before bumping veryfront-agent.
Tested: targeted checks listed above.
Not-tested: full verify locally, same unrelated CLI-boundary baseline blocks verify:quick.