### PR TITLE
Fix CLI OAuth callback origin handling

### DIFF
--- a/cli/auth/callback-server.test.ts
+++ b/cli/auth/callback-server.test.ts
@@ -149,7 +149,7 @@ describe(
         assertEquals(result.error, "Invalid callback origin");
       });
 
-      it("should reject callback token with cross-origin referer", async () => {
+      it("should accept state-protected callback token with hosted auth referer", async () => {
         server = await startCallbackServer(9876, { expectedState: "expected-state" });
         const callbackUrl = getCallbackUrl(server.port);
 
@@ -157,6 +157,23 @@ describe(
 
         setTimeout(() => {
           void fetch(callbackUrl + "?token=test-oauth-token&state=expected-state", {
+            headers: { Referer: "https://api.veryfront.com/auth/google" },
+          }).then((resp) => resp.body?.cancel());
+        }, scaleMs(100));
+
+        const result = await callbackPromise;
+        assertEquals(result.token, "test-oauth-token");
+        assertEquals(result.error, undefined);
+      });
+
+      it("should reject callback token with cross-origin referer when state is not required", async () => {
+        server = await startCallbackServer(9876);
+        const callbackUrl = getCallbackUrl(server.port);
+
+        const callbackPromise = server.waitForCallback(scaleMs(5000));
+
+        setTimeout(() => {
+          void fetch(callbackUrl + "?token=test-oauth-token", {
             headers: { Referer: "https://evil.example/login" },
           }).then((resp) => resp.body?.cancel());
         }, scaleMs(100));

--- a/cli/auth/callback-server.ts
+++ b/cli/auth/callback-server.ts
@@ -184,11 +184,16 @@ function headerOrigin(value: string): string | null {
   }
 }
 
-function hasCrossOriginHeader(headers: Headers, url: URL): boolean {
+function hasCrossOriginOriginHeader(headers: Headers, url: URL): boolean {
   const expectedOrigin = url.origin;
   const origin = headers.get("origin");
   if (origin && headerOrigin(origin) !== expectedOrigin) return true;
 
+  return false;
+}
+
+function hasCrossOriginRefererHeader(headers: Headers, url: URL): boolean {
+  const expectedOrigin = url.origin;
   const referer = headers.get("referer");
   if (referer && headerOrigin(referer) !== expectedOrigin) return true;
 
@@ -200,7 +205,11 @@ function handleCallback(
   headers: Headers,
   options: CallbackServerOptions = {},
 ): { result: CallbackResult; html: string } {
-  if (hasCrossOriginHeader(headers, url)) return callbackError("Invalid callback origin");
+  if (hasCrossOriginOriginHeader(headers, url)) return callbackError("Invalid callback origin");
+
+  if (!options.expectedState && hasCrossOriginRefererHeader(headers, url)) {
+    return callbackError("Invalid callback origin");
+  }
 
   if (options.expectedState && url.searchParams.get("state") !== options.expectedState) {
     return callbackError("Invalid OAuth state");


### PR DESCRIPTION
## Summary
- Allow state-protected loopback callbacks to accept hosted auth referers.
- Keep cross-origin Origin rejection and no-state referer rejection.
- Add regression coverage for hosted auth callback behavior.

## Test Plan
- [x] VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all cli/auth/callback-server.test.ts
- [x] deno fmt --check cli/auth/callback-server.ts cli/auth/callback-server.test.ts
- [x] deno check --no-lock cli/auth/callback-server.ts cli/auth/callback-server.test.ts
- [x] git diff --check
- [x] pre-push hook: format, lint, typecheck, generated manifests/bundles, Deno unit suite (2196 passed, 0 failed)

## Notes
- Live hosted OAuth login still needs validation after the API-side fix is deployed.