### PR TITLE
Release veryfront 0.1.864

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.863",
+  "version": "0.1.864",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.863";
+export const VERSION = "0.1.864";


### PR DESCRIPTION
## Summary
- Bump Veryfront package metadata from 0.1.863 to 0.1.864.
- Keep the runtime VERSION constant synchronized with deno.json.

## Verification
- VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts
- deno eval JSON.parse deno.json and assert version 0.1.864 matches runtime VERSION
- git diff --check
- pre-push hook: format, lint, typecheck, generate, unit tests (2196 passed)