### PR TITLE
Preserve active Anthropic tool results across same-turn steps

### DIFF
--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
@@ -344,6 +344,183 @@ describe("ext-llm-anthropic/anthropic-request-builder", () => {
     ]);
   });
 
+  it("keeps same-turn tool results when later assistant steps continue without a user turn", () => {
+    const prompt: RuntimePromptMessage[] = [
+      { role: "user", content: [{ type: "text", text: "Create an integration agent." }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I will load the platform skill." },
+          {
+            type: "tool-call",
+            toolCallId: "toolu_load_skill",
+            toolName: "load_skill",
+            input: { skillId: "veryfront" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [{
+          type: "tool-result",
+          toolCallId: "toolu_load_skill",
+          toolName: "load_skill",
+          output: {
+            type: "json",
+            value: {
+              skillId: "veryfront",
+              instructions: "Create agents with create_agent after gathering context.",
+            },
+          },
+        }],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Now I will inspect the integration." },
+          {
+            type: "tool-call",
+            toolCallId: "toolu_get_integration",
+            toolName: "get_integration",
+            input: { integration: "harvest" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [{
+          type: "tool-result",
+          toolCallId: "toolu_get_integration",
+          toolName: "get_integration",
+          output: {
+            type: "json",
+            value: { slug: "harvest", name: "Harvest" },
+          },
+        }],
+      },
+    ];
+    const warnings = createWarningCollector();
+
+    const body = buildAnthropicMessagesRequest(
+      "claude-sonnet-4-6",
+      "anthropic",
+      { prompt },
+      false,
+      warnings,
+    );
+
+    assertEquals(body.messages, [
+      { role: "user", content: [{ type: "text", text: "Create an integration agent." }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I will load the platform skill." },
+          {
+            type: "tool_use",
+            id: "toolu_load_skill",
+            name: "load_skill",
+            input: { skillId: "veryfront" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [{
+          type: "tool_result",
+          tool_use_id: "toolu_load_skill",
+          content:
+            '{"skillId":"veryfront","instructions":"Create agents with create_agent after gathering context."}',
+        }],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Now I will inspect the integration." },
+          {
+            type: "tool_use",
+            id: "toolu_get_integration",
+            name: "get_integration",
+            input: { integration: "harvest" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [{
+          type: "tool_result",
+          tool_use_id: "toolu_get_integration",
+          content: '{"slug":"harvest","name":"Harvest"}',
+        }],
+      },
+    ]);
+  });
+
+  it("keeps historical tool-only rounds when active same-turn assistant text follows the latest user", () => {
+    const prompt: RuntimePromptMessage[] = [
+      { role: "user", content: [{ type: "text", text: "Start with account context." }] },
+      {
+        role: "assistant",
+        content: [{
+          type: "tool-call",
+          toolCallId: "toolu_account",
+          toolName: "account__lookup",
+          input: { id: "acct-1" },
+        }],
+      },
+      {
+        role: "tool",
+        content: [{
+          type: "tool-result",
+          toolCallId: "toolu_account",
+          toolName: "account__lookup",
+          output: { type: "json", value: { plan: "pro" } },
+        }],
+      },
+      { role: "user", content: [{ type: "text", text: "retry with more detail" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "I will continue from the account context." }],
+      },
+    ];
+    const warnings = createWarningCollector();
+
+    const body = buildAnthropicMessagesRequest(
+      "claude-sonnet-4-6",
+      "anthropic",
+      { prompt },
+      false,
+      warnings,
+    );
+
+    assertEquals(body.messages, [
+      { role: "user", content: [{ type: "text", text: "Start with account context." }] },
+      {
+        role: "assistant",
+        content: [{
+          type: "tool_use",
+          id: "toolu_account",
+          name: "account__lookup",
+          input: { id: "acct-1" },
+        }],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_account",
+            content: '{"plan":"pro"}',
+          },
+          { type: "text", text: "retry with more detail" },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "I will continue from the account context." }],
+      },
+    ]);
+  });
+
   it("drops orphaned tool results when their tool use was not emitted", () => {
     const prompt: RuntimePromptMessage[] = [
       {

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
@@ -209,7 +209,9 @@ function toAnthropicMessages(
 } {
   const systemParts: string[] = [];
   const messages: AnthropicCompatibleMessage[] = [];
-  const lastAssistantTextIndex = prompt.findLastIndex((message) =>
+  const lastUserIndex = prompt.findLastIndex((message) => message.role === "user");
+  const lastHistoricalAssistantTextIndex = prompt.findLastIndex((message, index) =>
+    index < lastUserIndex &&
     message.role === "assistant" &&
     message.content.some((part) => part.type === "text" && part.text.length > 0)
   );
@@ -232,7 +234,7 @@ function toAnthropicMessages(
         break;
       case "assistant": {
         skippingHistoricalToolResults = false;
-        const shouldCompactCompletedToolRound = index < lastAssistantTextIndex &&
+        const shouldCompactCompletedToolRound = index < lastHistoricalAssistantTextIndex &&
           message.content.some((part) => part.type === "tool-call");
         const assistantContent = shouldCompactCompletedToolRound
           ? message.content.filter((part) => part.type === "text" && part.text.length > 0)


### PR DESCRIPTION
## Summary
- fixes Anthropic replay compaction so active same-user-turn assistant/tool steps retain their `tool_use` / `tool_result` pairs
- keeps historical compaction for completed tool rounds once a later assistant answer exists before a user retry
- adds a regression covering `load_skill` -> result -> `get_integration` -> result in one hosted turn

## Root cause
Staging `veryfront-agent` was not missing durable `TOOL_CALL_RESULT` events. The stored transcript had contiguous tool-call result events, but Anthropic request replay compacted earlier same-turn tool rounds whenever later assistant text existed.

That assumption is valid for historical completed turns, but hosted streaming can produce several assistant/tool steps before the next user message. In that active same-user turn, compaction hid prior setup/discovery results from Claude, so the model saw incomplete context and repeated `load_skill`, `web_fetch`, and integration lookup work.

This is the root fix rather than a duplicate-call cache: it preserves the model input that should have been replayed.

Fixes veryfront/veryfront-studio#5137.

## Verification
- RED: `deno test extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts` failed the new same-turn replay regression before the fix because the first tool round was dropped.
- GREEN: `deno test extensions/ext-llm-anthropic/src/anthropic-provider.test.ts extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts` -> `ok | 2 passed (78 steps) | 0 failed`
- `deno fmt --check extensions/ext-llm-anthropic/src/anthropic-request-builder.ts extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts` -> `Checked 2 files`
- `git diff --check` -> clean

## Not run
- Full pre-commit `verify:quick` is currently blocked by pre-existing CLI boundary violations outside this PR.
