### PR TITLE
Prefer markdown for hosted web_fetch

### DIFF
--- a/src/agent/hosted/web-fetch-tool.test.ts
+++ b/src/agent/hosted/web-fetch-tool.test.ts
@@ -4,10 +4,13 @@ import { createHostedWebFetchTool } from "./web-fetch-tool.ts";
 
 Deno.test("createHostedWebFetchTool fetches an explicit HTTPS URL without prior search", async () => {
   const requestedUrls: string[] = [];
+  const acceptHeaders: string[] = [];
   const tool = createHostedWebFetchTool({
     fetch: (input, init) => {
+      const requestInit = init as globalThis.RequestInit | undefined;
       requestedUrls.push(String(input));
-      assertEquals(init?.redirect, "follow");
+      assertEquals(requestInit?.redirect, "follow");
+      acceptHeaders.push(new Headers(requestInit?.headers).get("accept") ?? "");
       return Promise.resolve(
         new Response("Create agent docs", {
           status: 200,
@@ -22,6 +25,10 @@ Deno.test("createHostedWebFetchTool fetches an explicit HTTPS URL without prior 
   });
 
   assertEquals(requestedUrls, ["https://api.veryfront.com/docs/mcp?tool=create_agent"]);
+  assertEquals(
+    acceptHeaders,
+    ["text/markdown,text/plain,text/html,application/xhtml+xml,application/xml,*/*;q=0.8"],
+  );
   assertEquals((result as { type?: unknown }).type, "web_fetch_result");
   assertEquals(
     (result as { url?: unknown }).url,

--- a/src/agent/hosted/web-fetch-tool.ts
+++ b/src/agent/hosted/web-fetch-tool.ts
@@ -66,7 +66,7 @@ async function executeHostedWebFetch(
     redirect: "follow",
     signal: context?.abortSignal,
     headers: {
-      accept: "text/html,application/xhtml+xml,application/xml,text/markdown,text/plain,*/*;q=0.8",
+      accept: "text/markdown,text/plain,text/html,application/xhtml+xml,application/xml,*/*;q=0.8",
       "user-agent": "Veryfront web_fetch",
     },
   });


### PR DESCRIPTION
## Summary
- Make hosted web_fetch send markdown-preferred Accept headers so canonical docs page URLs can return compact markdown representations when the site supports them.
- Add a regression assertion for the hosted web_fetch Accept header.

## Validation
- deno test --allow-all src/agent/hosted/web-fetch-tool.test.ts
- deno fmt --check src/agent/hosted/web-fetch-tool.ts src/agent/hosted/web-fetch-tool.test.ts
- DENO_NO_PACKAGE_JSON=1 deno lint src/agent/hosted/web-fetch-tool.ts src/agent/hosted/web-fetch-tool.test.ts

## Note
- Full deno task verify:quick is still blocked by unrelated existing CLI boundary violations in cli/shared/server-startup.ts, cli/commands/skills/validate.ts, cli/commands/serve/split-mode.ts, cli/skills/loader.ts, and cli/skills/types.ts.