### PR TITLE
Keep CLI OAuth state across hosted redirects

### DIFF
--- a/cli/auth/login.test.ts
+++ b/cli/auth/login.test.ts
@@ -120,10 +120,12 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
         "expected-state",
       );
       const parsed = new URL(authUrl);
+      const redirectUri = parsed.searchParams.get("redirect_uri");
 
       assertEquals(parsed.pathname, "/auth/github");
-      assertEquals(parsed.searchParams.get("redirect_uri"), "http://localhost:3456/callback");
+      assertEquals(redirectUri, "http://localhost:3456/callback?state=expected-state");
       assertEquals(parsed.searchParams.get("state"), "expected-state");
+      assertEquals(new URL(redirectUri!).searchParams.get("state"), "expected-state");
     });
   });
 

--- a/cli/auth/login.ts
+++ b/cli/auth/login.ts
@@ -35,9 +35,11 @@ export function createOAuthAuthorizationUrl(
   callbackUrl: string,
   state: string,
 ): string {
-  // The hosted auth endpoint must echo `state` back to the loopback callback.
+  const stateBoundCallbackUrl = new URL(callbackUrl);
+  stateBoundCallbackUrl.searchParams.set("state", state);
+
   const authUrl = new URL(`${getApiUrl().replace(/\/$/, "")}/auth/${provider}`);
-  authUrl.searchParams.set("redirect_uri", callbackUrl);
+  authUrl.searchParams.set("redirect_uri", stateBoundCallbackUrl.toString());
   authUrl.searchParams.set("state", state);
   return authUrl.toString();
 }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.864",
+  "version": "0.1.865",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.864";
+export const VERSION = "0.1.865";


### PR DESCRIPTION
## Summary
- Bind the CLI OAuth state into the loopback redirect_uri sent to hosted auth.
- Keep the top-level hosted auth state parameter unchanged.
- Bump the package version to 0.1.865 for the next CLI release.

## Root cause
The staged API can echo the CLI callback state, but production has not received that API change yet. The released CLI expects the callback to include state, while production hosted auth redirects back with only the token when the callback state is only sent as top-level OAuth state.

This change makes the CLI compatible with current production by placing state directly on the callback URL that production already preserves. It remains compatible with the staged API behavior.

## Testing
- VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all cli/auth/ src/utils/version.test.ts
- deno check --no-lock cli/auth/login.ts cli/auth/login.test.ts src/utils/version.ts src/utils/version-constant.ts
- deno fmt --check deno.json src/utils/version-constant.ts cli/auth/login.ts cli/auth/login.test.ts
- git diff --check
- pre-push hook: format, lint, type check, generation, and unit tests passed: 2196 test files, 18806 steps
