### PR TITLE
Bump framework version to 0.1.866

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.865",
+  "version": "0.1.866",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.865";
+export const VERSION = "0.1.866";


### PR DESCRIPTION
## Summary
- bumps root framework version from 0.1.865 to 0.1.866
- keeps src/utils/version-constant.ts in sync with deno.json

## Context
Follow-up to #2551 so the Anthropic replay fix has a new package version.

## Verification
- `deno fmt --check deno.json src/utils/version-constant.ts` -> `Checked 2 files`
- `git diff --check` -> clean
- `deno task verify:quick` -> blocked at pre-existing `lint:cli-boundary` violations outside this PR after manifest, format, lint, and style passed