### PR TITLE
Fix assistant-prefill retry after final assistant text

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.866",
+  "version": "0.1.867",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -965,9 +965,10 @@ export class AgentRuntime {
 
         if (materialized.kind === "incomplete" && isRecoverablePlaceholderToolCall(tc)) {
           // Provisional empty-object placeholder that never finalized. The
-          // model never committed arguments; the loop will recover by
-          // re-calling the model. Persist the (empty) part for transparent
-          // history but surface no termination warning or error.
+          // model never committed arguments. The assistant message builder
+          // omits it when final text exists; otherwise it remains transparent
+          // history while the loop recovers by re-calling the model. Surface no
+          // termination warning or error.
           continue;
         }
 
@@ -1063,9 +1064,10 @@ export class AgentRuntime {
         throwIfAborted(abortSignal);
         if (isRecoverablePlaceholderToolCall(tc)) {
           // Provisional empty-object placeholder that never finalized. The
-          // model never committed arguments, so we neither execute it nor
-          // surface a stream-termination error, so the loop continues and the
-          // next model call recovers the real tool call.
+          // model never committed arguments. At this point the continuation
+          // gate has confirmed there is no final assistant text, so the loop
+          // can continue and let the next model call recover the real tool
+          // call without executing or surfacing a stream-termination error.
           continue;
         }
         if (isStreamedToolCallIncomplete(tc)) {

--- a/src/agent/runtime/refresh.test.ts
+++ b/src/agent/runtime/refresh.test.ts
@@ -229,6 +229,12 @@ describe("agent runtime refresh hooks", () => {
   it("does not re-call the model after final assistant text with a provisional placeholder", async () => {
     const toolResults: ToolExecutionResultRequest[] = [];
     let callCount = 0;
+    const studioSuggestions = tool({
+      id: "studio_suggestions",
+      description: "Capture Studio suggestions",
+      inputSchema: defineSchema((v) => v.object({}))(),
+      execute: async () => ({ suggestions: [] }),
+    });
     const model: ModelRuntime = {
       provider: "hosted",
       modelId: "hosted/text-placeholder-stream",
@@ -269,6 +275,7 @@ describe("agent runtime refresh hooks", () => {
       system: "Placeholder recovery regression test",
       maxSteps: 2,
       resolveModelTransport: async () => ({ model }),
+      tools: { studio_suggestions: studioSuggestions },
       onToolResult: (request) => {
         toolResults.push(request);
       },

--- a/src/agent/runtime/refresh.test.ts
+++ b/src/agent/runtime/refresh.test.ts
@@ -226,6 +226,64 @@ describe("agent runtime refresh hooks", () => {
     assertEquals(toolResults[0]?.context?.projectId, "project-stream");
   });
 
+  it("does not re-call the model after final assistant text with a provisional placeholder", async () => {
+    const toolResults: ToolExecutionResultRequest[] = [];
+    let callCount = 0;
+    const model: ModelRuntime = {
+      provider: "hosted",
+      modelId: "hosted/text-placeholder-stream",
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "unused" }],
+          finishReason: "stop",
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        };
+      },
+      async doStream() {
+        callCount++;
+        if (callCount > 1) {
+          throw new Error("unexpected second stream call");
+        }
+
+        return {
+          stream: createRuntimeStream([
+            { type: "text-delta", text: "Created the Outlook assistant." },
+            {
+              type: "tool-input-start",
+              id: "toolu_placeholder_after_text",
+              toolName: "studio_suggestions",
+            },
+            { type: "tool-input-delta", id: "toolu_placeholder_after_text", delta: "{}" },
+            {
+              type: "finish",
+              finishReason: "tool-calls",
+              usage: { inputTokens: 1, outputTokens: 1 },
+            },
+          ]),
+        };
+      },
+    };
+
+    const assistant = agent({
+      model: "hosted/text-placeholder-stream",
+      system: "Placeholder recovery regression test",
+      maxSteps: 2,
+      resolveModelTransport: async () => ({ model }),
+      onToolResult: (request) => {
+        toolResults.push(request);
+      },
+    });
+
+    const response = (await assistant.stream({
+      input: "Create an Outlook assistant",
+    })).toDataStreamResponse();
+    const body = await response.text();
+
+    assertEquals(callCount, 1);
+    assertEquals(toolResults, []);
+    assertEquals(body.includes("Created the Outlook assistant."), true);
+  });
+
   it("applies loaded skill maxSteps overrides to generate() invoke_agent calls", async () => {
     const toolResults: ToolExecutionResultRequest[] = [];
     let callCount = 0;

--- a/src/agent/runtime/streamed-assistant-message.test.ts
+++ b/src/agent/runtime/streamed-assistant-message.test.ts
@@ -35,6 +35,7 @@ describe("agent/streamed-assistant-message", () => {
           },
         ],
       ]),
+      suppressedToolCalls: [],
       toolResults: [],
       usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
     };
@@ -67,6 +68,42 @@ describe("agent/streamed-assistant-message", () => {
           inputText: '{"q":"Veryfront"}',
           providerExecuted: true,
         },
+      ],
+    });
+  });
+
+  it("omits recoverable placeholder tool parts when assistant text exists", () => {
+    const state: ChatStreamState = {
+      accumulatedText: "Created the Outlook assistant.",
+      reasoningParts: [],
+      finishReason: "tool-calls",
+      toolCalls: new Map([
+        [
+          "call_placeholder",
+          {
+            id: "call_placeholder",
+            name: "studio_suggestions",
+            arguments: "{}",
+            inputAvailable: false,
+          },
+        ],
+      ]),
+      suppressedToolCalls: [],
+      toolResults: [],
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    };
+
+    const message = buildStreamedAssistantMessage(state, {
+      id: "msg_text_only",
+      timestamp: 456,
+    });
+
+    assertEquals(message, {
+      id: "msg_text_only",
+      role: "assistant",
+      timestamp: 456,
+      parts: [
+        { type: "text", text: "Created the Outlook assistant." },
       ],
     });
   });

--- a/src/agent/runtime/streamed-assistant-message.ts
+++ b/src/agent/runtime/streamed-assistant-message.ts
@@ -1,6 +1,9 @@
 import type { Message, MessagePart } from "../types.ts";
 import type { ChatStreamState } from "./chat-stream-handler.ts";
-import { materializeStreamedToolCall } from "./tool-result-continuation.ts";
+import {
+  materializeStreamedToolCall,
+  shouldOmitRecoverablePlaceholderToolCall,
+} from "./tool-result-continuation.ts";
 
 export interface StreamedAssistantMessageIdentity {
   id: string;
@@ -34,6 +37,9 @@ export function buildStreamedAssistantMessage(
   }
 
   for (const toolCall of state.toolCalls.values()) {
+    if (shouldOmitRecoverablePlaceholderToolCall(state, toolCall)) {
+      continue;
+    }
     parts.push(materializeStreamedToolCall(toolCall).part);
   }
 

--- a/src/agent/runtime/tool-result-continuation.test.ts
+++ b/src/agent/runtime/tool-result-continuation.test.ts
@@ -23,7 +23,7 @@ function createState(
 describe("agent runtime streamed tool result collection", () => {
   it("continues after suppressing unavailable streamed tool calls", () => {
     const shouldContinue = shouldContinueAfterStreamStep({
-      accumulatedText: "I will reload the skill.",
+      accumulatedText: "",
       finishReason: "tool-calls",
       toolCalls: new Map(),
       toolResults: [],
@@ -31,6 +31,18 @@ describe("agent runtime streamed tool result collection", () => {
     });
 
     assertEquals(shouldContinue, true);
+  });
+
+  it("stops after suppressing unavailable streamed tool calls when the assistant already answered", () => {
+    const shouldContinue = shouldContinueAfterStreamStep({
+      accumulatedText: "Created the Outlook assistant.",
+      finishReason: "tool-calls",
+      toolCalls: new Map(),
+      toolResults: [],
+      suppressedToolCalls: [{ id: "tc-stale", name: "studio_suggestions" }],
+    });
+
+    assertEquals(shouldContinue, false);
   });
 
   it("continues after provider-executed tool results arrive without assistant text", () => {
@@ -413,6 +425,27 @@ describe("agent runtime streamed tool result collection", () => {
     });
 
     assertEquals(shouldContinue, true);
+  });
+
+  it("stops instead of recovering a placeholder after final assistant text", () => {
+    const shouldContinue = shouldContinueAfterStreamStep({
+      accumulatedText: "Created the Outlook assistant.",
+      finishReason: "tool-calls",
+      toolCalls: new Map([
+        [
+          "toolu_placeholder_after_text",
+          {
+            id: "toolu_placeholder_after_text",
+            name: "studio_suggestions",
+            arguments: "{}",
+            inputAvailable: false,
+          },
+        ],
+      ]),
+      toolResults: [],
+    });
+
+    assertEquals(shouldContinue, false);
   });
 
   it("does not recover provider-executed placeholders by re-calling the model", () => {

--- a/src/agent/runtime/tool-result-continuation.test.ts
+++ b/src/agent/runtime/tool-result-continuation.test.ts
@@ -33,16 +33,16 @@ describe("agent runtime streamed tool result collection", () => {
     assertEquals(shouldContinue, true);
   });
 
-  it("stops after suppressing unavailable streamed tool calls when the assistant already answered", () => {
+  it("continues after suppressing unavailable streamed tool calls with preamble text", () => {
     const shouldContinue = shouldContinueAfterStreamStep({
-      accumulatedText: "Created the Outlook assistant.",
+      accumulatedText: "I will reload the skill.",
       finishReason: "tool-calls",
       toolCalls: new Map(),
       toolResults: [],
-      suppressedToolCalls: [{ id: "tc-stale", name: "studio_suggestions" }],
+      suppressedToolCalls: [{ id: "tc-stale", name: "load_skill" }],
     });
 
-    assertEquals(shouldContinue, false);
+    assertEquals(shouldContinue, true);
   });
 
   it("continues after provider-executed tool results arrive without assistant text", () => {

--- a/src/agent/runtime/tool-result-continuation.ts
+++ b/src/agent/runtime/tool-result-continuation.ts
@@ -162,9 +162,7 @@ export function shouldContinueAfterStreamStep(
   const hasAssistantText = hasSubstantiveAssistantText(state.accumulatedText);
 
   if (!state.toolCalls.size) {
-    return state.finishReason === "tool-calls" &&
-      !hasAssistantText &&
-      Boolean(state.suppressedToolCalls?.length);
+    return state.finishReason === "tool-calls" && Boolean(state.suppressedToolCalls?.length);
   }
 
   const streamedToolCalls = Array.from(state.toolCalls.values());
@@ -197,7 +195,7 @@ export function shouldContinueAfterStreamStep(
       return false;
     }
     if (hasRecoverablePlaceholderToolCall && !hasFinalizedClientToolCall) {
-      return !hasAssistantText;
+      return true;
     }
     return !hasIncompleteToolCall && hasFinalizedClientToolCall;
   }

--- a/src/agent/runtime/tool-result-continuation.ts
+++ b/src/agent/runtime/tool-result-continuation.ts
@@ -128,13 +128,43 @@ export function collectGeneratedToolResults(
   return generatedToolResults;
 }
 
+export function hasSubstantiveAssistantText(text: string | undefined): boolean {
+  return typeof text === "string" && text.trim().length > 0;
+}
+
+export function isClientRecoverablePlaceholderToolCall(
+  toolCall: Pick<StreamingToolCall, "arguments" | "inputAvailable" | "providerExecuted">,
+): boolean {
+  return toolCall.providerExecuted !== true && isRecoverablePlaceholderToolCall(toolCall);
+}
+
+export function shouldRecoverPlaceholderToolCall(
+  state: Pick<ChatStreamState, "accumulatedText">,
+  toolCall: Pick<StreamingToolCall, "arguments" | "inputAvailable" | "providerExecuted">,
+): boolean {
+  return !hasSubstantiveAssistantText(state.accumulatedText) &&
+    isClientRecoverablePlaceholderToolCall(toolCall);
+}
+
+export function shouldOmitRecoverablePlaceholderToolCall(
+  state: Pick<ChatStreamState, "accumulatedText">,
+  toolCall: Pick<StreamingToolCall, "arguments" | "inputAvailable" | "providerExecuted">,
+): boolean {
+  return hasSubstantiveAssistantText(state.accumulatedText) &&
+    isClientRecoverablePlaceholderToolCall(toolCall);
+}
+
 export function shouldContinueAfterStreamStep(
   state:
     & Pick<ChatStreamState, "accumulatedText" | "finishReason" | "toolCalls" | "toolResults">
     & Partial<Pick<ChatStreamState, "suppressedToolCalls">>,
 ): boolean {
+  const hasAssistantText = hasSubstantiveAssistantText(state.accumulatedText);
+
   if (!state.toolCalls.size) {
-    return state.finishReason === "tool-calls" && Boolean(state.suppressedToolCalls?.length);
+    return state.finishReason === "tool-calls" &&
+      !hasAssistantText &&
+      Boolean(state.suppressedToolCalls?.length);
   }
 
   const streamedToolCalls = Array.from(state.toolCalls.values());
@@ -147,15 +177,16 @@ export function shouldContinueAfterStreamStep(
   );
   // A non-finalized call whose only accumulated arguments are a bare
   // empty-object placeholder is provisional streamed input the model never
-  // committed. The runtime can recover by re-calling the model, so it must not
-  // block continuation like a truncated partial-JSON call does.
+  // committed. The runtime can recover by re-calling the model only before the
+  // assistant has produced final text, so it must not block earlier
+  // continuation like a truncated partial-JSON call does.
   const hasIncompleteDeadToolCall = streamedToolCalls.some(
     (toolCall) =>
       isStreamedToolCallIncomplete(toolCall) &&
       !isRecoverablePlaceholderToolCall(toolCall),
   );
   const hasRecoverablePlaceholderToolCall = streamedToolCalls.some(
-    isRecoverablePlaceholderToolCall,
+    (toolCall) => shouldRecoverPlaceholderToolCall(state, toolCall),
   );
 
   if (state.finishReason === "tool-calls") {
@@ -166,7 +197,7 @@ export function shouldContinueAfterStreamStep(
       return false;
     }
     if (hasRecoverablePlaceholderToolCall && !hasFinalizedClientToolCall) {
-      return true;
+      return !hasAssistantText;
     }
     return !hasIncompleteToolCall && hasFinalizedClientToolCall;
   }
@@ -175,7 +206,7 @@ export function shouldContinueAfterStreamStep(
     return false;
   }
 
-  if (state.accumulatedText.trim().length > 0) {
+  if (hasAssistantText) {
     return false;
   }
 

--- a/src/chat/provider-errors.test.ts
+++ b/src/chat/provider-errors.test.ts
@@ -122,6 +122,82 @@ describe("chat/provider-errors", () => {
     );
   });
 
+  it("classifies provider assistant-prefill rejections", () => {
+    const expected = {
+      code: "MODEL_UNSUPPORTED_ASSISTANT_PREFILL",
+      message:
+        "The selected model does not support assistant-message prefill. Start a new user message or choose a compatible model.",
+    };
+
+    assertEquals(
+      parseProviderError({
+        responseBody: JSON.stringify({
+          type: "error",
+          error: {
+            type: "invalid_request_error",
+            message:
+              "This model does not support assistant message prefill. The conversation must end with a user message.",
+          },
+          request_id: "req_test",
+        }),
+      }),
+      expected,
+    );
+
+    assertEquals(
+      parseProviderError(
+        "veryfront-cloud request failed: " + JSON.stringify({
+          type: "error",
+          error: {
+            type: "invalid_request_error",
+            message:
+              "This model does not support assistant message prefill. The conversation must end with a user message.",
+          },
+        }),
+      ),
+      expected,
+    );
+
+    assertEquals(
+      parseProviderError({
+        lastError: {
+          responseBody: JSON.stringify({
+            type: "error",
+            error: {
+              type: "invalid_request_error",
+              message:
+                "This model does not support assistant message prefill. The conversation must end with a user message.",
+            },
+          }),
+        },
+      }),
+      expected,
+    );
+  });
+
+  it("guards cyclic nested provider error envelopes", () => {
+    const cyclicError: Record<string, unknown> = {};
+    cyclicError.error = cyclicError;
+
+    assertEquals(parseProviderError(cyclicError), {
+      code: "EXTERNAL_SERVICE_ERROR",
+      message: "LLM provider service error",
+    });
+  });
+
+  it("does not overmatch unrelated invalid request messages", () => {
+    assertEquals(
+      parseProviderError({
+        type: "invalid_request_error",
+        message: "The conversation must end with a user message before tool output.",
+      }),
+      {
+        code: "EXTERNAL_SERVICE_ERROR",
+        message: "LLM provider service error",
+      },
+    );
+  });
+
   it("walks nested lastError chains without stack overflows or cycles", () => {
     const errorA: Record<string, unknown> = { message: "outer", lastError: null };
     const errorB: Record<string, unknown> = { message: "inner", lastError: errorA };

--- a/src/chat/provider-errors.ts
+++ b/src/chat/provider-errors.ts
@@ -103,7 +103,24 @@ export function isCreditLimitMessage(normalizedMessage: string): boolean {
   );
 }
 
-function parseKnownProviderBody(body: unknown): ParsedProviderError | null {
+function isAssistantPrefillUnsupportedMessage(message: string): boolean {
+  const normalizedMessage = message.toLowerCase();
+  const mentionsAssistantPrefill = normalizedMessage.includes("assistant message prefill") ||
+    normalizedMessage.includes("assistant-message prefill") ||
+    (
+      normalizedMessage.includes("assistant") &&
+      normalizedMessage.includes("prefill")
+    );
+  const rejectsAssistantPrefill = normalizedMessage.includes("does not support") ||
+    normalizedMessage.includes("unsupported") ||
+    normalizedMessage.includes("conversation must end with a user message");
+  return mentionsAssistantPrefill && rejectsAssistantPrefill;
+}
+
+function parseKnownProviderBody(
+  body: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+): ParsedProviderError | null {
   const problemMatch = parseKnownProblemBody(body);
   if (problemMatch) {
     return problemMatch;
@@ -113,8 +130,16 @@ function parseKnownProviderBody(body: unknown): ParsedProviderError | null {
     return null;
   }
 
-  if (body.type === "error" && isErrorRecord(body.error)) {
-    return parseKnownProviderBody(body.error);
+  if (seen.has(body)) {
+    return null;
+  }
+  seen.add(body);
+
+  if (isErrorRecord(body.error)) {
+    const nestedError = parseKnownProviderBody(body.error, seen);
+    if (nestedError) {
+      return nestedError;
+    }
   }
 
   if (body.type === "overloaded_error") {
@@ -145,18 +170,13 @@ function parseKnownProviderBody(body: unknown): ParsedProviderError | null {
     };
   }
 
-  if (
-    body.type === "invalid_request_error" && typeof body.message === "string" &&
-    body.message.includes("too long")
-  ) {
-    return { code: "CONTEXT_LENGTH_EXCEEDED", message: "Conversation is too long" };
-  }
-
-  if (
-    body.type === "invalid_request_error" && typeof body.message === "string" &&
-    body.message.toLowerCase().includes("does not support assistant message prefill")
-  ) {
-    return MODEL_UNSUPPORTED_ASSISTANT_PREFILL_ERROR;
+  if (body.type === "invalid_request_error" && typeof body.message === "string") {
+    if (isAssistantPrefillUnsupportedMessage(body.message)) {
+      return MODEL_UNSUPPORTED_ASSISTANT_PREFILL_ERROR;
+    }
+    if (body.message.includes("too long")) {
+      return { code: "CONTEXT_LENGTH_EXCEEDED", message: "Conversation is too long" };
+    }
   }
 
   return null;
@@ -249,6 +269,9 @@ function parseProviderErrorInner(error: unknown, seen: WeakSet<object>): ParsedP
     }
 
     const normalizedMessage = message.toLowerCase();
+    if (isAssistantPrefillUnsupportedMessage(message)) {
+      return MODEL_UNSUPPORTED_ASSISTANT_PREFILL_ERROR;
+    }
     if (isCreditLimitMessage(normalizedMessage)) {
       return { code: "INSUFFICIENT_CREDITS", message: "Insufficient AI credits", status: 402 };
     }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.866";
+export const VERSION = "0.1.867";


### PR DESCRIPTION
## Summary
- stop runtime provider re-calls after substantive assistant text when only provisional or suppressed tool input remains
- omit ignored recoverable placeholder tool parts from persisted assistant messages
- classify assistant-prefill provider errors with narrowed, cycle-safe nested envelope parsing

## Tests
- deno test --allow-env src/agent/runtime/tool-result-continuation.test.ts src/agent/runtime/streamed-assistant-message.test.ts src/chat/provider-errors.test.ts src/agent/runtime/refresh.test.ts src/agent/runtime/chat-stream-handler.test.ts
- deno check src/agent/runtime/tool-result-continuation.ts src/agent/runtime/streamed-assistant-message.ts src/chat/provider-errors.ts
- deno fmt --check src/agent/runtime/index.ts src/agent/runtime/tool-result-continuation.ts src/agent/runtime/tool-result-continuation.test.ts src/agent/runtime/streamed-assistant-message.ts src/agent/runtime/streamed-assistant-message.test.ts src/agent/runtime/refresh.test.ts src/chat/provider-errors.ts src/chat/provider-errors.test.ts
- deno lint src/agent/runtime/index.ts src/agent/runtime/tool-result-continuation.ts src/agent/runtime/tool-result-continuation.test.ts src/agent/runtime/streamed-assistant-message.ts src/agent/runtime/streamed-assistant-message.test.ts src/agent/runtime/refresh.test.ts src/chat/provider-errors.ts src/chat/provider-errors.test.ts
- pre-push hook: format, lint, typecheck, unit tests; 2,195 passed, 0 failed

Fixes veryfront/veryfront-studio#5113