### PR TITLE
Hydrate optional project-scoped tool references

### DIFF
--- a/src/agent/hosted/project-remote-tool-source.test.ts
+++ b/src/agent/hosted/project-remote-tool-source.test.ts
@@ -25,6 +25,22 @@ function projectFileTool(name: string): ToolDefinition {
   };
 }
 
+function optionalProjectReferenceTool(name: string): ToolDefinition {
+  return {
+    name,
+    description: `${name} description`,
+    parameters: {
+      type: "object",
+      properties: {
+        project_reference: { type: "string" },
+        agent_id: { type: "string" },
+        config: { type: "object" },
+      },
+      required: ["agent_id"],
+    },
+  };
+}
+
 function navigationTool(name: string): ToolDefinition {
   return {
     name,
@@ -122,6 +138,38 @@ Deno.test("createHostedProjectRemoteToolSource scopes tool listings and hydrates
     {
       toolName: "update_file",
       args: { path: "AGENTS.md", project_reference: "project-1" },
+      context: { projectId: "project-1" },
+    },
+  ]);
+});
+
+Deno.test("createHostedProjectRemoteToolSource hydrates optional declared project references", async () => {
+  const executeCalls: Array<{ toolName: string; args: unknown; context?: ToolExecutionContext }> =
+    [];
+  const source = createHostedProjectRemoteToolSource({
+    source: createRemoteSource({
+      tools: [optionalProjectReferenceTool("generate_agent_avatar")],
+      execute: (toolName, args, context) => {
+        executeCalls.push({ toolName, args, context });
+        return { avatar_url: "https://api.example/avatar.svg" };
+      },
+    }),
+    defaultProjectId: () => "project-1",
+  });
+
+  await source.executeTool("generate_agent_avatar", {
+    agent_id: "harvest-assistant",
+    config: { seed: "harvest-assistant" },
+  });
+
+  assertEquals(executeCalls, [
+    {
+      toolName: "generate_agent_avatar",
+      args: {
+        agent_id: "harvest-assistant",
+        config: { seed: "harvest-assistant" },
+        project_reference: "project-1",
+      },
       context: { projectId: "project-1" },
     },
   ]);

--- a/src/tool/project-scoped-remote-tools.test.ts
+++ b/src/tool/project-scoped-remote-tools.test.ts
@@ -102,6 +102,32 @@ Deno.test("hydrateProjectScopedRemoteToolInput injects project_reference when re
   );
 });
 
+Deno.test("hydrateProjectScopedRemoteToolInput injects project_reference when optional but declared", () => {
+  const definition = toolDefinition({ name: "generate_agent_avatar" });
+  definition.parameters = {
+    type: "object",
+    properties: {
+      project_reference: { type: "string" },
+      agent_id: { type: "string" },
+      config: { type: "object" },
+    },
+    required: ["agent_id"],
+  };
+
+  assertEquals(
+    hydrateProjectScopedRemoteToolInput({
+      toolDefinition: definition,
+      activeProjectId: "project-1",
+      toolInput: { agent_id: "harvest-assistant", config: { seed: "harvest-assistant" } },
+    }),
+    {
+      agent_id: "harvest-assistant",
+      config: { seed: "harvest-assistant" },
+      project_reference: "project-1",
+    },
+  );
+});
+
 Deno.test("hydrateProjectScopedRemoteToolInput preserves explicit project_reference", () => {
   const toolInput = { project_reference: "explicit-project", pattern: "src" };
 

--- a/src/tool/project-scoped-remote-tools.ts
+++ b/src/tool/project-scoped-remote-tools.ts
@@ -99,6 +99,21 @@ function requiresProjectReference(toolDefinition: ToolDefinition): boolean {
   return getRequiredToolProperties(toolDefinition).includes("project_reference");
 }
 
+function hasToolProperty(toolDefinition: ToolDefinition, property: string): boolean {
+  if (typeof toolDefinition.parameters !== "object" || toolDefinition.parameters === null) {
+    return false;
+  }
+
+  const properties = Reflect.get(toolDefinition.parameters, "properties");
+  return typeof properties === "object" && properties !== null &&
+    Object.prototype.hasOwnProperty.call(properties, property);
+}
+
+function acceptsProjectReference(toolDefinition: ToolDefinition): boolean {
+  return requiresProjectReference(toolDefinition) ||
+    hasToolProperty(toolDefinition, "project_reference");
+}
+
 function isMissingRequiredToolInput(value: unknown): boolean {
   return value === undefined || value === null ||
     (typeof value === "string" && value.trim().length === 0);
@@ -167,7 +182,7 @@ export function hydrateProjectScopedRemoteToolInput(input: {
 }): Record<string, unknown> {
   if (
     !input.toolDefinition || !input.activeProjectId ||
-    !requiresProjectReference(input.toolDefinition)
+    !acceptsProjectReference(input.toolDefinition)
   ) {
     return input.toolInput;
   }


### PR DESCRIPTION
## Root Cause

Conversation `3ed0f016-01d4-45da-90f7-7fabc9d51c63` was project-scoped in staging, but the `generate_agent_avatar` call reached the API MCP endpoint without `project_reference`. The API MCP `projectTool` registration intentionally advertises `project_reference` as optional in `tools/list`, so project-scoped endpoints can omit it. Hosted agent runs call the unscoped API MCP endpoint and rely on `veryfront-code` to hydrate project context into tool args. That hydration only checked `required`, so optional-but-declared project tools like `generate_agent_avatar` were not hydrated and the API returned:

```
project_reference is required: pass it explicitly or connect through a project-scoped endpoint (/projects/{project}/mcp)
```

## Fix

Hydrate `project_reference` when the remote tool schema declares a `project_reference` property, even if it is not listed as required. Explicit `project_reference` values are still preserved.

## Verification

- Red/green: `deno test src/tool/project-scoped-remote-tools.test.ts --filter "optional but declared"` failed before the fix and passes after.
- `deno test src/tool/project-scoped-remote-tools.test.ts`
- `deno test --allow-read src/agent/hosted/project-remote-tool-source.test.ts`
- `deno fmt --check src/tool/project-scoped-remote-tools.ts src/tool/project-scoped-remote-tools.test.ts src/agent/hosted/project-remote-tool-source.test.ts`
- `deno lint src/tool/project-scoped-remote-tools.ts src/tool/project-scoped-remote-tools.test.ts src/agent/hosted/project-remote-tool-source.test.ts`
- `deno check src/tool/index.ts src/agent/index.ts`

## Not Verified

Full `deno task verify` / pre-commit `verify:quick` currently fails on unrelated existing CLI boundary violations in `cli/*` on current `origin/main`; this PR does not touch those files. Live staging replay requires package release/deploy after merge.