### PR TITLE
Align optional project tool discovery before release

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.866",
+  "version": "0.1.867",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/tool/project-scoped-remote-tools.test.ts
+++ b/src/tool/project-scoped-remote-tools.test.ts
@@ -63,6 +63,26 @@ Deno.test("filterProjectScopedRemoteToolDefinitions does not infer project scope
   );
 });
 
+Deno.test("filterProjectScopedRemoteToolDefinitions hides optional project_reference tools without an active project", () => {
+  const projectTool = toolDefinition({ name: "generate_agent_avatar" });
+  projectTool.parameters = {
+    type: "object",
+    properties: {
+      project_reference: { type: "string" },
+      agent_id: { type: "string" },
+    },
+    required: ["agent_id"],
+  };
+
+  assertEquals(
+    filterProjectScopedRemoteToolDefinitions([
+      toolDefinition({ name: "list_agents" }),
+      projectTool,
+    ], null).map((tool) => tool.name),
+    ["list_agents"],
+  );
+});
+
 Deno.test("filterProjectScopedRemoteToolDefinitions allows configured navigation tools without an active project", () => {
   const tools = [
     toolDefinition({ name: "open_project", required: ["project_id"] }),

--- a/src/tool/project-scoped-remote-tools.ts
+++ b/src/tool/project-scoped-remote-tools.ts
@@ -90,9 +90,11 @@ function requiresActiveProject(
     return false;
   }
 
-  return getRequiredToolProperties(toolDefinition).some(
-    (property) => property === "project_reference" || property === "project_id",
-  );
+  if (acceptsProjectReference(toolDefinition)) {
+    return true;
+  }
+
+  return getRequiredToolProperties(toolDefinition).includes("project_id");
 }
 
 function requiresProjectReference(toolDefinition: ToolDefinition): boolean {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.866";
+export const VERSION = "0.1.867";


### PR DESCRIPTION
## Summary
- Align optional `project_reference` tool visibility with execution hydration so unscoped sessions do not advertise project-scoped tools.
- Add a regression test for optional declared `project_reference` tools without an active project.
- Bump the package version to `0.1.867`.

## Review score
- Code-reviewer lane: 94/100, approve.
- Architect re-review: CLEAR, 95/100.
- Final score: 95/100.

## Verification
- [x] `deno test src/tool/project-scoped-remote-tools.test.ts`
- [x] `deno test --allow-read src/agent/hosted/project-remote-tool-source.test.ts`
- [x] `deno fmt --check deno.json src/tool/project-scoped-remote-tools.ts src/tool/project-scoped-remote-tools.test.ts src/agent/hosted/project-remote-tool-source.test.ts`
- [x] `deno lint src/tool/project-scoped-remote-tools.ts src/tool/project-scoped-remote-tools.test.ts src/agent/hosted/project-remote-tool-source.test.ts`
- [x] `deno check src/tool/index.ts src/agent/index.ts`

## Not verified
- Full `verify:quick` is blocked by pre-existing unrelated CLI boundary violations in `cli/*`.