### PR TITLE
Fix suppressed tool recovery assistant-prefill retry

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.867",
+  "version": "0.1.868",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1012,7 +1012,7 @@ export class AgentRuntime {
         ];
         currentMessages.push({
           id: `runtime_note_${Date.now()}_${step}`,
-          role: "system",
+          role: "user",
           parts: [{
             type: "text",
             text: `Runtime recovery: ignored unavailable tool call(s): ${

--- a/src/agent/runtime/refresh.test.ts
+++ b/src/agent/runtime/refresh.test.ts
@@ -77,6 +77,72 @@ function supplierInvoiceEvidenceMessages(): Message[] {
 }
 
 describe("agent runtime refresh hooks", () => {
+  it("continues suppressed unavailable tool calls with a user recovery turn after assistant text", async () => {
+    const observedPrompts: Array<Array<{ role?: string; content?: unknown }>> = [];
+    let callCount = 0;
+    const model: ModelRuntime = {
+      provider: "hosted",
+      modelId: "hosted/suppressed-tool-recovery",
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "unused" }],
+          finishReason: "stop",
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        };
+      },
+      async doStream(options: unknown) {
+        callCount++;
+        observedPrompts.push(
+          (options as { prompt?: Array<{ role?: string; content?: unknown }> }).prompt ?? [],
+        );
+
+        if (callCount === 1) {
+          return {
+            stream: createRuntimeStream([
+              { type: "text-delta", text: "I will reload the skill." },
+              { type: "tool-input-start", id: "tc-stale", toolName: "load_skill" },
+              { type: "tool-input-delta", id: "tc-stale", delta: '{"skillId":"create-agent"}' },
+              { type: "tool-input-end", id: "tc-stale" },
+              {
+                type: "tool-call",
+                toolCallId: "tc-stale",
+                toolName: "load_skill",
+                input: { skillId: "create-agent" },
+              },
+              { type: "finish", finishReason: "tool-calls" },
+            ]),
+          };
+        }
+
+        return {
+          stream: createRuntimeStream([
+            { type: "text-delta", text: "Recovered." },
+            { type: "finish", finishReason: "stop" },
+          ]),
+        };
+      },
+    };
+
+    const assistant = agent({
+      model: "hosted/suppressed-tool-recovery",
+      system: "Recover from stale tools.",
+      maxSteps: 2,
+      resolveModelTransport: async () => ({ model }),
+    });
+
+    await (await assistant.stream({ input: "Build an agent" })).toDataStreamResponse().text();
+
+    assertEquals(callCount, 2);
+    const retryPrompt = observedPrompts[1] ?? [];
+    assertEquals(retryPrompt.at(-1)?.role, "user");
+    assertEquals(
+      JSON.stringify(retryPrompt.at(-1)?.content).includes(
+        "ignored unavailable tool call(s): load_skill",
+      ),
+      true,
+    );
+  });
+
   it("notifies configured hooks after generate() executes a tool", async () => {
     const toolResults: ToolExecutionResultRequest[] = [];
     const model: ModelRuntime = {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.867";
+export const VERSION = "0.1.868";


### PR DESCRIPTION
## Summary
- Fix the residual assistant-message-prefill failure for suppressed unavailable tool calls that follow assistant text.
- Keep the suppressed-tool continuation behavior, but append the runtime recovery note as a user turn so retry prompts end with user input.
- Bump veryfront to 0.1.868 for agent consumption.

## Root Cause
The agent deployment was active and running veryfront@0.1.867, but conversation a4e18cbd-57e0-4400-bf41-b16a58d65aa9 hit a second path: an assistant text preamble plus suppressed unavailable tool call. The runtime continued, then appended the recovery note as a system message. Provider prompt preparation left the retry effectively assistant-ended, triggering Anthropic request req_011CcCXJKi7E4r4VsTizfwgQ: "This model does not support assistant message prefill. The conversation must end with a user message."

## Verification
- Red regression first: `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/agent/runtime/refresh.test.ts` failed with last retry role `system`, expected `user`.
- Targeted runtime tests passed: `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/agent/runtime/refresh.test.ts src/agent/runtime/tool-result-continuation.test.ts`.
- `git diff --check` passed.
- `deno task fmt:check` passed.
- `deno task typecheck` passed.
- `deno task lint` passed.
- Pre-push full unit suite passed with local OTEL test env sanitized: `2199 passed (18814 steps), 0 failed`.

## Related
- Follow-up to veryfront-code#2555 and veryfront-agent#1589.
- Production/staging evidence saved under `<local-path>`.
- Tracks veryfront-studio#5113.