### PR TITLE
Surface MCP tool errors in agent runtime

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.869",
+  "version": "0.1.870",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -114,6 +114,69 @@ describe("chat-stream-handler", () => {
       });
     });
 
+    it("renders MCP tool_error outputs as visible tool output errors", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        {
+          type: "tool-call",
+          toolCallId: "tc-create-agent",
+          toolName: "create_agent",
+          input: {
+            project_reference: "outlook-agent-zxywv0",
+            id: "harvest-timesheet-agent",
+          },
+          providerExecuted: true,
+        },
+        {
+          type: "tool-result",
+          toolCallId: "tc-create-agent",
+          toolName: "create_agent",
+          output: {
+            error: "tool_error",
+            message: "Unknown tool references: harvest__list_accounts",
+          },
+          providerExecuted: true,
+        },
+        { type: "finish", finishReason: "stop", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "text-1", undefined);
+
+      assertEquals(state.toolResults, [
+        {
+          toolCallId: "tc-create-agent",
+          toolName: "create_agent",
+          error: "Unknown tool references: harvest__list_accounts",
+          providerExecuted: true,
+        },
+      ]);
+      assertEquals(events, [
+        {
+          type: "tool-input-start",
+          toolCallId: "tc-create-agent",
+          toolName: "create_agent",
+        },
+        {
+          type: "tool-input-available",
+          toolCallId: "tc-create-agent",
+          toolName: "create_agent",
+          input: {
+            project_reference: "outlook-agent-zxywv0",
+            id: "harvest-timesheet-agent",
+          },
+          providerExecuted: true,
+        },
+        {
+          type: "tool-output-error",
+          toolCallId: "tc-create-agent",
+          errorText: "Unknown tool references: harvest__list_accounts",
+          providerExecuted: true,
+        },
+      ]);
+    });
+
     it("accumulates streamed reasoning text with Anthropic signatures", async () => {
       const { events, controller, encoder } = createSSECollector();
       const state = createStreamState();

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -151,6 +151,22 @@ function resolveToolResultOutput(part: RuntimeStreamPart): unknown {
   return undefined;
 }
 
+function getMcpToolErrorMessage(value: unknown): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  if (typeof value.error !== "string" || value.error.length === 0) {
+    return undefined;
+  }
+
+  if (typeof value.message === "string" && value.message.trim().length > 0) {
+    return value.message;
+  }
+
+  return value.error;
+}
+
 function logProviderToolPart(
   partType: "tool-result" | "tool-error",
   part: {
@@ -860,7 +876,12 @@ export function processStream(
             dynamic: typedPart.dynamic,
           });
           const toolResultOutput = resolveToolResultOutput(typedPart);
-          const isError = typedPart.isError === true;
+          const mcpToolErrorMessage = getMcpToolErrorMessage(toolResultOutput);
+          const isExplicitError = typedPart.isError === true;
+          const isError = isExplicitError || mcpToolErrorMessage !== undefined;
+          const toolResultError = isExplicitError
+            ? toolResultOutput
+            : mcpToolErrorMessage ?? toolResultOutput;
           logProviderToolPart("tool-result", {
             toolCallId: typedPart.toolCallId,
             toolName: typedPart.toolName,
@@ -875,14 +896,14 @@ export function processStream(
             state.toolResults.push({
               toolCallId: typedPart.toolCallId,
               toolName: typedPart.toolName,
-              error: toolResultOutput,
+              error: toolResultError,
               ...(providerExecuted !== undefined ? { providerExecuted } : {}),
               ...(typedPart.dynamic ? { dynamic: true } : {}),
             });
             sendSSE(controller, encoder, {
               type: "tool-output-error",
               toolCallId: typedPart.toolCallId,
-              errorText: stringifyToolError(toolResultOutput),
+              errorText: stringifyToolError(toolResultError),
               ...(providerExecuted !== undefined ? { providerExecuted } : {}),
               ...(typedPart.dynamic ? { dynamic: true } : {}),
             });

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1103,6 +1103,9 @@ export class AgentRuntime {
 
         if (matchingResult) {
           await persistToolResult(matchingResult);
+          if (tc.name === "create_agent") {
+            toolsDisabledForFinalResponse = true;
+          }
           toolCall.status = matchingResult.error === undefined ? "completed" : "error";
           toolCall.result = matchingResult.output;
           toolCall.error = matchingResult.error === undefined
@@ -1129,15 +1132,15 @@ export class AgentRuntime {
               hasSubmittedFormInputInLoop = true;
               currentRuntimeContext = markSubmittedFormInputRuntimeContext(currentRuntimeContext);
             }
-            if (tc.name === "create_agent") {
-              toolsDisabledForFinalResponse = true;
-            }
           }
           continue;
         }
 
         if (persistedResult) {
           const persistedError = getToolResultError(persistedResult.result);
+          if (tc.name === "create_agent") {
+            toolsDisabledForFinalResponse = true;
+          }
           toolCall.status = persistedError === undefined ? "completed" : "error";
           toolCall.result = persistedResult.result;
           toolCall.error = persistedError;
@@ -1160,9 +1163,6 @@ export class AgentRuntime {
             if (isSubmittedFormInputExecutionResult(tc.name, persistedResult.result)) {
               hasSubmittedFormInputInLoop = true;
               currentRuntimeContext = markSubmittedFormInputRuntimeContext(currentRuntimeContext);
-            }
-            if (tc.name === "create_agent") {
-              toolsDisabledForFinalResponse = true;
             }
           }
           continue;
@@ -1305,6 +1305,9 @@ export class AgentRuntime {
             currentMessages,
             toolCalls,
           );
+          if (tc.name === "create_agent") {
+            toolsDisabledForFinalResponse = true;
+          }
         }
       }
 

--- a/src/agent/runtime/tool-result-continuation.test.ts
+++ b/src/agent/runtime/tool-result-continuation.test.ts
@@ -6,6 +6,7 @@ import {
   collectFinalStreamToolResults,
   collectGeneratedToolResults,
   collectPersistedToolResults,
+  getToolResultError,
   isRecoverablePlaceholderToolCall,
   isStreamedToolCallIncomplete,
   materializeStreamedToolCall,
@@ -308,6 +309,16 @@ describe("agent runtime streamed tool result collection", () => {
 
     assertEquals(persistedToolResults.size, 1);
     assertEquals(persistedToolResults.get("tool-3")?.result, { submitted: true });
+  });
+
+  it("extracts MCP tool_error messages from persisted tool results", () => {
+    assertEquals(
+      getToolResultError({
+        error: "tool_error",
+        message: "Unknown tool references: harvest__list_accounts",
+      }),
+      "Unknown tool references: harvest__list_accounts",
+    );
   });
 
   it("collects the latest generated tool result from direct model output", () => {

--- a/src/agent/runtime/tool-result-continuation.ts
+++ b/src/agent/runtime/tool-result-continuation.ts
@@ -9,9 +9,31 @@ import { parseToolArgs } from "./tool-helpers.ts";
 import { stringifyToolError } from "./error-utils.ts";
 import type { RuntimeGenerateToolResult, RuntimeToolSet } from "./runtime-tool-types.ts";
 
+function getMcpToolErrorMessage(result: unknown): string | undefined {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return undefined;
+  }
+
+  const record = result as Record<string, unknown>;
+  if (typeof record.error !== "string" || record.error.length === 0) {
+    return undefined;
+  }
+
+  if (typeof record.message === "string" && record.message.trim().length > 0) {
+    return record.message;
+  }
+
+  return record.error;
+}
+
 export function getToolResultError(result: unknown): string | undefined {
   if (!result || typeof result !== "object" || !("error" in result)) {
     return undefined;
+  }
+
+  const mcpToolErrorMessage = getMcpToolErrorMessage(result);
+  if (mcpToolErrorMessage !== undefined) {
+    return mcpToolErrorMessage;
   }
 
   return stringifyToolError(result.error);

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.869";
+export const VERSION = "0.1.870";


### PR DESCRIPTION
## Summary
- Render MCP-shaped `{ error, message }` tool results as visible `tool-output-error` events even when the stream part lacks `isError`.
- Extract persisted MCP `tool_error` messages for continuation state.
- Disable further tools after `create_agent` results, including error results, so the run can produce a final response instead of looping/hanging.

## Test Plan
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/tool-result-continuation.test.ts`
- `deno check --unstable-worker-options src/agent/runtime/chat-stream-handler.ts src/agent/runtime/tool-result-continuation.ts src/agent/runtime/index.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/tool-result-continuation.test.ts`
- `deno fmt --check src/agent/runtime/chat-stream-handler.ts src/agent/runtime/tool-result-continuation.ts src/agent/runtime/index.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/tool-result-continuation.test.ts`
- Pre-push hook passed with OTEL metrics env removed for the unrelated metrics default tests: formatting, linter, typecheck, and unit tests (`2199` passed).
