### PR TITLE
Keep agent registry bridges idempotent

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.869",
+  "version": "0.1.870",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/composition/composition.test.ts
+++ b/src/agent/composition/composition.test.ts
@@ -14,11 +14,30 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { Agent, AgentResponse, AgentStreamResult } from "../types.ts";
 
 // Side-effect import: registers the globalThis bridges
-import { agentAsTool } from "./composition.ts";
+import { agentAsTool, agentRegistry, registerAgent } from "./composition.ts";
 
 const BRIDGE_KEYS = ["__vfGetAgent", "__vfRegisterAgent", "__vfGetAllAgentIds"] as const;
 
 describe("globalThis agent registry bridges", () => {
+  it("should tolerate repeated module evaluation", async () => {
+    await import("./composition.ts?duplicate-agent-bridge-test");
+  });
+
+  it("should delegate duplicate module registry reads to the existing bridge", async () => {
+    const id = "duplicate-bridge-agent";
+    const agent = createMinimalAgent(id);
+
+    registerAgent(id, agent);
+    try {
+      const duplicate = await import("./composition.ts?duplicate-agent-bridge-delegation-test");
+
+      assertEquals(duplicate.getAgent(id), agent);
+      assertEquals(duplicate.getAllAgentIds().includes(id), true);
+    } finally {
+      agentRegistry.delete(id);
+    }
+  });
+
   for (const key of BRIDGE_KEYS) {
     describe(key, () => {
       it("should be defined on globalThis", () => {
@@ -78,6 +97,45 @@ describe("globalThis agent registry bridges", () => {
     });
   }
 });
+
+function createMinimalAgent(id: string): Agent {
+  const response: AgentResponse = {
+    text: "ok",
+    messages: [],
+    toolCalls: [],
+    status: "completed",
+  };
+
+  return {
+    id,
+    config: {
+      model: "anthropic/claude-sonnet-4-6",
+      system: "Test agent",
+    },
+    generate: () => Promise.resolve(response),
+    async stream(input): Promise<AgentStreamResult> {
+      input.onFinish?.(response);
+      return {
+        toDataStreamResponse() {
+          return new Response("data: {}\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      };
+    },
+    respond: () => Promise.resolve(new Response(null)),
+    getMemory() {
+      throw new Error("not used");
+    },
+    getMemoryStats: () =>
+      Promise.resolve({
+        totalMessages: 0,
+        estimatedTokens: 0,
+        type: "test",
+      }),
+    clearMemory: () => Promise.resolve(),
+  };
+}
 
 describe("agentAsTool", () => {
   it("executes child agents through the streaming path", async () => {

--- a/src/agent/composition/composition.ts
+++ b/src/agent/composition/composition.ts
@@ -155,18 +155,49 @@ export const agentRegistry = new AgentRegistryClass(agentManager);
 
 export { AgentRegistryClass };
 
+const GET_AGENT_BRIDGE_KEY = "__vfGetAgent";
+const REGISTER_AGENT_BRIDGE_KEY = "__vfRegisterAgent";
+const GET_ALL_AGENT_IDS_BRIDGE_KEY = "__vfGetAllAgentIds";
+
+function getExistingGlobalAgentBridge(key: string, localValue: unknown): unknown | undefined {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, key);
+  if (!descriptor) return undefined;
+  if (typeof descriptor.value !== "function") {
+    throw new TypeError(`Global agent bridge ${key} already exists and is not callable.`);
+  }
+  return descriptor.value === localValue ? undefined : descriptor.value;
+}
+
 /** Registers agent. */
 export function registerAgent(id: string, agent: Agent): void {
+  const register = getExistingGlobalAgentBridge(REGISTER_AGENT_BRIDGE_KEY, registerAgent) as
+    | ((id: string, agent: Agent) => void)
+    | undefined;
+  if (register) {
+    register(id, agent);
+    return;
+  }
+
   agentRegistry.register(id, agent);
 }
 
 /** Return agent. */
 export function getAgent(id: string): Agent | undefined {
+  const get = getExistingGlobalAgentBridge(GET_AGENT_BRIDGE_KEY, getAgent) as
+    | ((id: string) => Agent | undefined)
+    | undefined;
+  if (get) return get(id);
+
   return agentRegistry.get(id);
 }
 
 /** Return all agent IDs. */
 export function getAllAgentIds(): string[] {
+  const getAllIds = getExistingGlobalAgentBridge(GET_ALL_AGENT_IDS_BRIDGE_KEY, getAllAgentIds) as
+    | (() => string[])
+    | undefined;
+  if (getAllIds) return getAllIds();
+
   return agentRegistry.getAllIds();
 }
 
@@ -174,13 +205,13 @@ export function getAllAgentIds(): string[] {
 // real registry. External temp-file modules can't import from the embedded
 // binary FS, so they use globalThis bridges instead.
 // Use Object.defineProperty to prevent accidental overwriting or enumeration.
-for (
-  const [key, value] of Object.entries({
-    __vfGetAgent: getAgent,
-    __vfRegisterAgent: registerAgent,
-    __vfGetAllAgentIds: getAllAgentIds,
-  })
-) {
+function defineGlobalAgentBridge(key: string, value: unknown): void {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, key);
+  if (descriptor) {
+    if (typeof descriptor.value === "function") return;
+    throw new TypeError(`Global agent bridge ${key} already exists and is not callable.`);
+  }
+
   Object.defineProperty(globalThis, key, {
     value,
     writable: false,
@@ -189,11 +220,23 @@ for (
   });
 }
 
+for (
+  const [key, value] of Object.entries({
+    [GET_AGENT_BRIDGE_KEY]: getAgent,
+    [REGISTER_AGENT_BRIDGE_KEY]: registerAgent,
+    [GET_ALL_AGENT_IDS_BRIDGE_KEY]: getAllAgentIds,
+  })
+) {
+  defineGlobalAgentBridge(key, value);
+}
+
 /** Return agents as tools. */
 export function getAgentsAsTools(descriptions?: Record<string, string>): Record<string, Tool> {
   const tools: Record<string, Tool> = {};
 
-  for (const [id, agent] of agentRegistry.getAll()) {
+  for (const id of getAllAgentIds()) {
+    const agent = getAgent(id);
+    if (!agent) continue;
     tools[id] = agentAsTool(agent, descriptions?.[id] ?? `Call ${id} agent`);
   }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.869";
+export const VERSION = "0.1.870";


### PR DESCRIPTION
## Summary

- Make agent registry global bridge registration idempotent when multiple Veryfront runtime copies are evaluated in one process.
- Preserve first-install bridge hardening: non-writable, non-enumerable, and non-configurable.
- Add a regression test for repeated `composition.ts` module evaluation.
- Bump release metadata from `0.1.869` to `0.1.870`.

## Why

AG-UI route loading can evaluate the server runtime copy and a project-installed `veryfront` package copy in the same process. The first copy registers non-configurable global bridge properties. The second copy previously tried to redefine those properties and failed during dynamic import:

```text
TypeError: 'defineProperty' on proxy: trap returned truish for adding property '__vfGetAgent' that is incompatible with the existing property in the proxy target
```

## Verification

- `deno test --no-check --allow-all src/agent/composition/composition.test.ts`
- `deno eval 'await import("./src/agent/composition/composition.ts"); await import("./src/agent/composition/composition.ts?duplicate-bridge-eval"); console.log("duplicate import ok")'`
- `deno fmt --check deno.json src/agent/composition/composition.ts src/agent/composition/composition.test.ts src/utils/version-constant.ts`
- `git diff --check`
- `deno task build:npm`
- `node --input-type=module -e 'await import("./npm/esm/src/agent/composition/composition.js"); await import("./npm/esm/src/agent/composition/composition.js?duplicate-node-import"); console.log("node duplicate import ok")'`
- `deno task lint`
- `deno task typecheck`
- Pre-push hook: format, lint, typecheck, and unit tests, 2199 passed
