### PR TITLE
Update Work docs for expectations

### DIFF
--- a/docs/api-reference/veryfront/work.md
+++ b/docs/api-reference/veryfront/work.md
@@ -19,7 +19,7 @@ export default work({
   id: "supplier-invoice-processing",
   name: "Supplier invoice processing",
   outcome: "Resolve all open supplier invoices.",
-  acceptanceCriteria: [
+  expectations: [
     {
       id: "invoices_discovered",
       description: "Open supplier invoices have been discovered.",
@@ -34,46 +34,48 @@ export default work({
 
 Create a typed Work definition.
 
-| Property | Type | Description | Source |
-|----------|------|-------------|--------|
-| `id` | `string` | Stable project-local Work identifier. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L14) |
-| `name?` | `string` | Human-readable display name. Defaults to the id when omitted. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L16) |
-| `outcome` | `string` | Business outcome the execution layer should make true. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L18) |
-| `acceptanceCriteria` | `WorkAcceptanceCriterion[]` | Outcome criteria tracked as business process state. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L20) |
+| Property              | Type                | Description                                                   | Source                                                                                |
+| --------------------- | ------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `id`                  | `string`            | Stable project-local Work identifier.                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L21) |
+| `name?`               | `string`            | Human-readable display name. Defaults to the id when omitted. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L23) |
+| `outcome`             | `string`            | Business outcome the execution layer should make true.        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L25) |
+| `expectations?`       | `WorkExpectation[]` | Expectations tracked as business process state.               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L27) |
+| `acceptanceCriteria?` | `WorkExpectation[]` | Deprecated alias for expectations                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L29) |
 
 **Returns:** `WorkDefinition`
 
 ## Type Reference
 
-### `WorkAcceptanceCriterion`
+### `WorkExpectation`
 
-One measurable outcome condition for a Work definition.
+One measurable expectation for a Work definition.
 
-| Property | Type | Description | Source |
-|----------|------|-------------|--------|
-| `id` | `string` | Stable identifier used by execution state and cloud persistence. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L4) |
+| Property      | Type     | Description                                                      | Source                                                                               |
+| ------------- | -------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `id`          | `string` | Stable identifier used by execution state and cloud persistence. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L4) |
 | `description` | `string` | Human-readable condition that must be satisfied unless optional. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L6) |
-| `optional?` | `true` | Optional criteria do not block Work execution completion. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L8) |
+| `optional?`   | `true`   | Optional expectations do not block Work execution completion.    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L8) |
 
 ## Exports
 
 ### Functions
 
-| Name | Description | Source |
-|------|-------------|--------|
+| Name   | Description                     | Source                                                                                 |
+| ------ | ------------------------------- | -------------------------------------------------------------------------------------- |
 | `work` | Create a typed Work definition. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/factory.ts#L5) |
 
 ### Types
 
-| Name | Description | Source |
-|------|-------------|--------|
-| `WorkAcceptanceCriterion` | One measurable outcome condition for a Work definition. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L2) |
-| `WorkConfig` | Configuration used by work(). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L12) |
-| `WorkDefinition` | Public API contract for Work definitions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L24) |
-| `WorkReference` | Agent-level reference to source-declared Work. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L32) |
+| Name                      | Description                                       | Source                                                                                |
+| ------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `WorkAcceptanceCriterion` | Deprecated alias for WorkExpectation.             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L16) |
+| `WorkConfig`              | Configuration used by work().                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L19) |
+| `WorkDefinition`          | Public API contract for Work definitions.         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L33) |
+| `WorkExpectation`         | One measurable expectation for a Work definition. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L2)  |
+| `WorkReference`           | Agent-level reference to source-declared Work.    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/types.ts#L43) |
 
 ### Constants
 
-| Name | Description | Source |
-|------|-------------|--------|
+| Name           | Description                 | Source                                                                                   |
+| -------------- | --------------------------- | ---------------------------------------------------------------------------------------- |
 | `workRegistry` | Shared Work registry value. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/work/registry.ts#L30) |

--- a/docs/concepts/work.md
+++ b/docs/concepts/work.md
@@ -1,49 +1,93 @@
 ---
 title: "Work"
-description: "How Work defines business process outcomes and acceptance criteria."
+description: "How Work defines business process outcomes and expectations."
 order: 33
 ---
 
-Work owns business process state. A Work definition names the outcome that
-should become true and the acceptance criteria used to observe whether a run of
-that work is complete.
+Work owns business process state. It gives agents, operators, and business users
+a shared view of what should happen, what is currently running, and what evidence
+has been recorded.
 
-Work exists because business users and operators need to see process state even
-when the automation path is dynamic. An agent, task, or workflow can decide how
-to pursue the outcome. The Work definition stays focused on what done means.
+Use Work when the outcome matters independently of the automation path. An
+agent, task, or workflow can decide how to pursue the outcome. The Work model
+keeps the observable process state separate from that control flow.
 
-## Characteristics
+## Work definition
+
+A Work definition is the source-backed declaration of the business process.
+Definitions live in `work/` and are discovered at startup.
 
 - `id` is stable and project-local.
+- `name` is the human-readable display name.
 - `outcome` describes the desired business result.
-- `acceptanceCriteria` are stable objects with IDs and descriptions.
-- Criteria are required by default. Set `optional: true` only when the criterion
-  should not block completion.
-- Work definitions live in `work/` and are discovered at startup.
+- `expectations` are stable objects with IDs and descriptions.
+- Expectations are required by default. Set `optional: true` only when the
+  expectation should not block completion.
 
-## Example
+In `work/supplier-invoice-processing.ts`, export a definition with
+`work({ id, name, outcome, expectations })`:
 
-In `work/supplier-invoice-processing.ts`, export `work({ id, name, outcome,
-acceptanceCriteria })`. Each acceptance criterion is an object such as
-`{ id: "invoices_discovered", description: "Open supplier invoices have been discovered." }`.
-Use `optional: true` only for criteria that should not block completion.
+```ts
+import { work } from "veryfront/work";
+
+export default work({
+  id: "supplier-invoice-processing",
+  name: "Supplier invoice processing",
+  outcome: "Resolve all open supplier invoices.",
+  expectations: [
+    {
+      id: "invoices_discovered",
+      description: "Open supplier invoices have been discovered.",
+    },
+    {
+      id: "approved_invoices_scheduled",
+      description: "Payment scheduling has been resolved for every payment-ready invoice.",
+    },
+    {
+      id: "notify_finance_team",
+      description: "Finance team has been notified when notification is required.",
+      optional: true,
+    },
+  ],
+});
+```
+
+## Work execution
+
+A Work execution is a durable run of a Work definition. It records the current
+status, input, state, summary, and per-expectation progress for one attempt to
+make the outcome true.
+
+Executions let agents update process state as work unfolds. For example, an
+invoice-processing run can mark discovered invoices, record that a blocked
+invoice is waiting on an owner, mark scheduled payments, and attach evidence to
+each expectation.
+
+## Work events
+
+Work events are the timeline for a Work execution. Use events to record
+observable process changes such as execution creation, process transitions,
+specialist handoffs, expectation updates, evidence discrepancies, and final
+summaries.
+
+Events make the process auditable without forcing the Work definition to encode
+every branch, retry, or tool call.
 
 ## Boundary
 
 Work is not a workflow. A workflow owns automation logic such as sequence,
-parallelism, retries, and branching. Work owns process observability: outcome,
-criteria, execution status, evidence, and history.
+parallelism, retries, and branching. Work owns process observability: the
+definition, execution status, expectations, evidence, and events.
 
-For example, an invoice-processing agent can ingest invoices, call matching and
-payment tools, skip criteria that are not applicable, and record events. The
-Work definition should not prescribe that control flow.
+The Work definition should not prescribe control flow. It should describe what
+done means and which expectations prove that outcome.
 
 ## Agents
 
 Agents can reference Work by ID with `agent({ work: "supplier-invoice-processing", ... })`.
 
 The Work context is added to the agent system prompt so the agent understands
-the outcome and criteria. Persistence of executions happens through Work tools
-or APIs, not through the source definition itself.
+the outcome and expectations. Persistence of executions and events happens
+through Work tools or APIs, not through the source definition itself.
 
 For API details, see [veryfront/work](../api-reference/veryfront/work.md).

--- a/scripts/docs/generate-api-reference.ts
+++ b/scripts/docs/generate-api-reference.ts
@@ -593,7 +593,8 @@ const DESCRIPTIONS: Record<string, Record<string, string>> = {
     workRegistry: "Project-scoped Work registry",
     WorkDefinition: "`work()` return type",
     WorkConfig: "`work()` config",
-    WorkAcceptanceCriterion: "Outcome acceptance criterion",
+    WorkExpectation: "Outcome expectation",
+    WorkAcceptanceCriterion: "Deprecated alias for WorkExpectation",
     WorkReference: "Agent Work reference",
   },
 
@@ -1666,7 +1667,7 @@ const API_DOCS: Record<string, APIDocs> = {
   },
   "veryfront/work": {
     functions: { work: { configType: "WorkConfig" } },
-    expandTypes: ["WorkConfig", "WorkAcceptanceCriterion"],
+    expandTypes: ["WorkConfig", "WorkExpectation", "WorkAcceptanceCriterion"],
   },
   "veryfront/middleware": {
     methods: { MiddlewarePipeline: "Composable middleware chain" },
@@ -2032,12 +2033,18 @@ const PROPERTY_DESCRIPTIONS: Record<string, Record<string, string>> = {
     id: "Unique Work identifier",
     name: "Human-readable Work name",
     outcome: "Business outcome to make true",
-    acceptanceCriteria: "Outcome criteria tracked by executions",
+    expectations: "Expectations tracked by executions",
+    acceptanceCriteria: "Deprecated alias for expectations",
+  },
+  WorkExpectation: {
+    id: "Stable expectation identifier",
+    description: "Measurable condition to satisfy",
+    optional: "Whether completion can ignore this expectation",
   },
   WorkAcceptanceCriterion: {
-    id: "Stable criterion identifier",
+    id: "Stable expectation identifier",
     description: "Measurable condition to satisfy",
-    optional: "Whether completion can ignore this criterion",
+    optional: "Whether completion can ignore this expectation",
   },
   ResourceConfig: {
     uri: "Resource URI pattern",

--- a/src/discovery/__fixtures__/autodiscovery/work/supplier-invoice-processing.ts
+++ b/src/discovery/__fixtures__/autodiscovery/work/supplier-invoice-processing.ts
@@ -4,7 +4,7 @@ export default work({
   id: "supplier-invoice-processing",
   name: "Supplier invoice processing",
   outcome: "Resolve all open supplier invoices.",
-  acceptanceCriteria: [
+  expectations: [
     {
       id: "invoices_discovered",
       description: "Open supplier invoices have been discovered.",

--- a/src/discovery/handlers/work-handler.ts
+++ b/src/discovery/handlers/work-handler.ts
@@ -13,10 +13,17 @@ export const workHandler: DiscoveryHandler<WorkDefinition> = {
     typeof item === "object" &&
     typeof (item as WorkDefinition).id === "string" &&
     typeof (item as WorkDefinition).outcome === "string" &&
-    Array.isArray((item as WorkDefinition).acceptanceCriteria),
+    (Array.isArray((item as WorkDefinition).expectations) ||
+      Array.isArray((item as WorkDefinition).acceptanceCriteria)),
   getId: (definition) => definition.id,
   register: (id, definition) => {
-    const definitionWithId = definition.id === id ? definition : { ...definition, id };
+    const expectations = definition.expectations ?? definition.acceptanceCriteria;
+    const definitionWithId = {
+      ...definition,
+      id,
+      expectations,
+      acceptanceCriteria: expectations,
+    };
     workRegistry.register(id, definitionWithId);
     return definitionWithId;
   },

--- a/src/work/factory.test.ts
+++ b/src/work/factory.test.ts
@@ -10,7 +10,7 @@ describe("work factory", () => {
         id: "supplier-invoice-processing",
         name: "Supplier invoice processing",
         outcome: "Resolve all open supplier invoices.",
-        acceptanceCriteria: [
+        expectations: [
           {
             id: "invoices_discovered",
             description: "Open supplier invoices have been discovered.",
@@ -27,6 +27,17 @@ describe("work factory", () => {
         id: "supplier-invoice-processing",
         name: "Supplier invoice processing",
         outcome: "Resolve all open supplier invoices.",
+        expectations: [
+          {
+            id: "invoices_discovered",
+            description: "Open supplier invoices have been discovered.",
+          },
+          {
+            id: "notify_finance_team",
+            description: "Finance team has been notified.",
+            optional: true,
+          },
+        ],
         acceptanceCriteria: [
           {
             id: "invoices_discovered",
@@ -41,11 +52,33 @@ describe("work factory", () => {
       });
     });
 
+    it("accepts legacy acceptanceCriteria as an alias", () => {
+      const definition = work({
+        id: "supplier-invoice-processing",
+        name: "Supplier invoice processing",
+        outcome: "Resolve all open supplier invoices.",
+        acceptanceCriteria: [
+          {
+            id: "invoices_discovered",
+            description: "Open supplier invoices have been discovered.",
+          },
+        ],
+      });
+
+      assertEquals(definition.expectations, [
+        {
+          id: "invoices_discovered",
+          description: "Open supplier invoices have been discovered.",
+        },
+      ]);
+      assertEquals(definition.acceptanceCriteria, definition.expectations);
+    });
+
     it("defaults the display name to the id", () => {
       const definition = work({
         id: "clean-email",
         outcome: "Keep the inbox clean.",
-        acceptanceCriteria: [
+        expectations: [
           {
             id: "spam_archived",
             description: "Spam messages are archived.",
@@ -56,16 +89,16 @@ describe("work factory", () => {
       assertEquals(definition.name, "clean-email");
     });
 
-    it("rejects missing acceptance criteria", () => {
+    it("rejects missing expectations", () => {
       assertThrows(
         () =>
           work({
             id: "empty-work",
             outcome: "Do something measurable.",
-            acceptanceCriteria: [],
+            expectations: [],
           }),
         Error,
-        'Work "empty-work" must define at least one acceptance criterion.',
+        'Work "empty-work" must define at least one expectation.',
       );
     });
 
@@ -75,7 +108,7 @@ describe("work factory", () => {
           work({
             id: "finance/invoices",
             outcome: "Process invoices.",
-            acceptanceCriteria: [
+            expectations: [
               {
                 id: "done",
                 description: "Done.",
@@ -87,13 +120,13 @@ describe("work factory", () => {
       );
     });
 
-    it("rejects duplicate acceptance criterion ids", () => {
+    it("rejects duplicate expectation ids", () => {
       assertThrows(
         () =>
           work({
             id: "duplicate-criteria",
             outcome: "Resolve duplicate criteria.",
-            acceptanceCriteria: [
+            expectations: [
               {
                 id: "done",
                 description: "Done once.",
@@ -105,7 +138,7 @@ describe("work factory", () => {
             ],
           }),
         Error,
-        'Work "duplicate-criteria" has duplicate acceptance criterion id "done".',
+        'Work "duplicate-criteria" has duplicate expectation id "done".',
       );
     });
   });

--- a/src/work/factory.ts
+++ b/src/work/factory.ts
@@ -5,27 +5,28 @@ import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 export function work(config: WorkConfig): WorkDefinition {
   const id = assertWorkId(config.id);
   const outcome = assertNonEmptyString(config.outcome, `Work "${id}" outcome`);
+  const rawExpectations = config.expectations ?? config.acceptanceCriteria;
 
-  if (!Array.isArray(config.acceptanceCriteria) || config.acceptanceCriteria.length === 0) {
-    throwWorkConfigError(`Work "${id}" must define at least one acceptance criterion.`);
+  if (!Array.isArray(rawExpectations) || rawExpectations.length === 0) {
+    throwWorkConfigError(`Work "${id}" must define at least one expectation.`);
   }
 
   const seenCriterionIds = new Set<string>();
-  const acceptanceCriteria = config.acceptanceCriteria.map((criterion, index) => {
+  const expectations = rawExpectations.map((criterion, index) => {
     const criterionId = assertNonEmptyString(
       criterion.id,
-      `Work "${id}" acceptance criterion at index ${index} id`,
+      `Work "${id}" expectation at index ${index} id`,
     );
     if (seenCriterionIds.has(criterionId)) {
       throwWorkConfigError(
-        `Work "${id}" has duplicate acceptance criterion id "${criterionId}".`,
+        `Work "${id}" has duplicate expectation id "${criterionId}".`,
       );
     }
     seenCriterionIds.add(criterionId);
 
     const description = assertNonEmptyString(
       criterion.description,
-      `Work "${id}" acceptance criterion "${criterionId}" description`,
+      `Work "${id}" expectation "${criterionId}" description`,
     );
 
     const normalizedCriterion: WorkAcceptanceCriterion = {
@@ -42,7 +43,8 @@ export function work(config: WorkConfig): WorkDefinition {
     id,
     name: config.name?.trim() || id,
     outcome,
-    acceptanceCriteria,
+    expectations,
+    acceptanceCriteria: expectations,
   };
 }
 

--- a/src/work/index.ts
+++ b/src/work/index.ts
@@ -11,7 +11,7 @@
  *   id: "supplier-invoice-processing",
  *   name: "Supplier invoice processing",
  *   outcome: "Resolve all open supplier invoices.",
- *   acceptanceCriteria: [
+ *   expectations: [
  *     {
  *       id: "invoices_discovered",
  *       description: "Open supplier invoices have been discovered.",
@@ -25,6 +25,7 @@ export type {
   WorkAcceptanceCriterion,
   WorkConfig,
   WorkDefinition,
+  WorkExpectation,
   WorkReference,
 } from "./types.ts";
 export { work } from "./factory.ts";

--- a/src/work/prompt-augmentation.test.ts
+++ b/src/work/prompt-augmentation.test.ts
@@ -11,7 +11,7 @@ describe("work prompt augmentation", () => {
       id: "supplier-invoice-processing",
       name: "Supplier invoice processing",
       outcome: "Resolve all open supplier invoices.",
-      acceptanceCriteria: [
+      expectations: [
         {
           id: "invoices_discovered",
           description: "Open supplier invoices have been discovered.",
@@ -28,6 +28,7 @@ describe("work prompt augmentation", () => {
 
     assertStringIncludes(prompt, "Work is business/process state");
     assertStringIncludes(prompt, "Outcome: Resolve all open supplier invoices.");
+    assertStringIncludes(prompt, "Expectations:");
     assertStringIncludes(
       prompt,
       "- notify_finance_team (optional): Finance team has been notified.",
@@ -39,7 +40,7 @@ describe("work prompt augmentation", () => {
     const definition = work({
       id: "clean-email",
       outcome: "Keep the inbox clean.",
-      acceptanceCriteria: [
+      expectations: [
         {
           id: "spam_archived",
           description: "Spam messages are archived.",

--- a/src/work/prompt-augmentation.ts
+++ b/src/work/prompt-augmentation.ts
@@ -15,7 +15,7 @@ export function buildWorkManifestPrompt(works: Iterable<WorkDefinition>): string
   if (workDefinitions.length === 0) return "";
 
   const sections = workDefinitions.map((definition) => {
-    const criteria = definition.acceptanceCriteria.map((criterion) => {
+    const expectations = definition.expectations.map((criterion) => {
       const optionalLabel = criterion.optional ? " (optional)" : "";
       return `- ${criterion.id}${optionalLabel}: ${criterion.description}`;
     }).join("\n");
@@ -23,8 +23,8 @@ export function buildWorkManifestPrompt(works: Iterable<WorkDefinition>): string
     return [
       `### ${definition.name} (${definition.id})`,
       `Outcome: ${definition.outcome}`,
-      "Acceptance criteria:",
-      criteria,
+      "Expectations:",
+      expectations,
     ].join("\n");
   }).join("\n\n");
 

--- a/src/work/types.ts
+++ b/src/work/types.ts
@@ -1,12 +1,19 @@
-/** One measurable outcome condition for a Work definition. */
-export interface WorkAcceptanceCriterion {
+/** One measurable expectation for a Work definition. */
+export interface WorkExpectation {
   /** Stable identifier used by execution state and cloud persistence. */
   id: string;
   /** Human-readable condition that must be satisfied unless optional. */
   description: string;
-  /** Optional criteria do not block Work execution completion. */
+  /** Optional expectations do not block Work execution completion. */
   optional?: true;
 }
+
+/**
+ * Deprecated alias for WorkExpectation.
+ *
+ * @deprecated Use WorkExpectation.
+ */
+export type WorkAcceptanceCriterion = WorkExpectation;
 
 /** Configuration used by work(). */
 export interface WorkConfig {
@@ -16,8 +23,10 @@ export interface WorkConfig {
   name?: string;
   /** Business outcome the execution layer should make true. */
   outcome: string;
-  /** Outcome criteria tracked as business process state. */
-  acceptanceCriteria: WorkAcceptanceCriterion[];
+  /** Expectations tracked as business process state. */
+  expectations?: WorkExpectation[];
+  /** @deprecated Use expectations. */
+  acceptanceCriteria?: WorkExpectation[];
 }
 
 /** Public API contract for Work definitions. */
@@ -25,7 +34,9 @@ export interface WorkDefinition {
   id: string;
   name: string;
   outcome: string;
-  acceptanceCriteria: WorkAcceptanceCriterion[];
+  expectations: WorkExpectation[];
+  /** @deprecated Use expectations. */
+  acceptanceCriteria: WorkExpectation[];
 }
 
 /** Agent-level reference to source-declared Work. */

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -92,6 +92,7 @@ const THIS_GUIDE_EXAMPLE_SUITE = [
   "sandbox.md",
   "skills.md",
   "tasks.md",
+  "work.md",
   "workflows-advanced.md",
 ] as const;
 
@@ -107,7 +108,7 @@ const noopLogger = {
   error: () => {},
 };
 
-const GUIDE_DIRS = ["docs/getting-started", "docs/guides"] as const;
+const GUIDE_DIRS = ["docs/getting-started", "docs/guides", "docs/concepts"] as const;
 
 async function readGuide(filename: string): Promise<string> {
   for (const dir of GUIDE_DIRS) {
@@ -198,28 +199,37 @@ describe("Guide: chat-ui.md", () => {
     assertEquals(typeof useChat, "function");
     assertEquals(typeof createAgUiHandler, "function");
     assertExists(Chat);
-    assertEquals(typeof (Chat as Record<string, unknown>).render, "function");
-    assertExists((Chat as Record<string, unknown>).Root);
-    assertExists((Chat as Record<string, unknown>).MessageList);
-    assertExists((Chat as Record<string, unknown>).Composer);
-    assertExists((Message as Record<string, unknown>).Root);
+    const chatRecord = Chat as unknown as Record<string, unknown>;
+    const messageRecord = Message as unknown as Record<string, unknown>;
+    assertEquals(typeof chatRecord.render, "function");
+    assertExists(chatRecord.Root);
+    assertExists(chatRecord.MessageList);
+    assertExists(chatRecord.Composer);
+    assertExists(messageRecord.Root);
     assertExists(ChatWithSidebar);
     assertExists(ChatContextProvider);
     assertExists(ComposerContextProvider);
     assertExists(MessageContextProvider);
     assertEquals(typeof useChatContextOptional, "function");
 
+    const chatComponents = Chat as unknown as Record<
+      string,
+      React.ComponentType<Record<string, unknown>>
+    >;
+    const ChatRoot = chatComponents.Root;
+    const ChatEmpty = chatComponents.Empty;
+    assertExists(ChatRoot);
+    assertExists(ChatEmpty);
+
     const element = React.createElement(
-      (Chat as Record<string, React.ComponentType<Record<string, unknown>>>)
-        .Root,
+      ChatRoot,
       { messages: [], input: "" },
       React.createElement(
-        (Chat as Record<string, React.ComponentType<Record<string, unknown>>>)
-          .Empty,
+        ChatEmpty,
         { title: "Ask me anything" },
       ),
     );
-    assertEquals(element.type, (Chat as Record<string, unknown>).Root);
+    assertEquals(element.type, ChatRoot);
   });
 });
 
@@ -407,7 +417,9 @@ describe("Guide: extension-authoring.md", () => {
       version: "1.0.0",
       capabilities: [],
       provides: { CacheStore: cache },
-      teardown: () => events.push("provider:teardown"),
+      teardown: () => {
+        events.push("provider:teardown");
+      },
     };
     const consumer = {
       name: "cache-consumer",
@@ -419,7 +431,9 @@ describe("Guide: extension-authoring.md", () => {
           ctx.get("CacheStore") === cache ? "consumer:setup" : "missing",
         );
       },
-      teardown: () => events.push("consumer:teardown"),
+      teardown: () => {
+        events.push("consumer:teardown");
+      },
     };
 
     await loader.setupAll(
@@ -441,7 +455,7 @@ describe("Guide: extension-authoring.md", () => {
   it("verifies a factory and resolves a CacheStore through the loader", async () => {
     const values = new Map<string, unknown>();
     const cache: CacheStore = {
-      get: (key) => Promise.resolve(values.get(key)),
+      get: <T = unknown>(key: string) => Promise.resolve(values.get(key) as T | undefined),
       set: (key, value) => {
         values.set(key, value);
         return Promise.resolve();
@@ -568,8 +582,10 @@ describe("Guide: pages-and-routing.md", () => {
     const prefetchLink = Link({ href: "/about", children: "About" });
     const noPrefetchLink = Link({ href: "/about", prefetch: false, children: "About" });
 
-    assertEquals(prefetchLink.props["data-prefetch"], "true");
-    assertEquals(noPrefetchLink.props["data-prefetch"], "false");
+    const prefetchProps = prefetchLink.props as Record<string, unknown>;
+    const noPrefetchProps = noPrefetchLink.props as Record<string, unknown>;
+    assertEquals(prefetchProps["data-prefetch"], "true");
+    assertEquals(noPrefetchProps["data-prefetch"], "false");
   });
 });
 

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -386,7 +386,10 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     references: ["../api-reference/veryfront/work.md"],
     snippets: [
       "business process state",
-      "acceptanceCriteria",
+      "Work definition",
+      "Work execution",
+      "Work events",
+      "expectations",
       "Work is not a workflow",
       "agent({ work:",
     ],


### PR DESCRIPTION
## Summary
- Update the Work concept page around Work definitions, Work executions, and Work events.
- Promote `expectations` as the current Work definition field while keeping `acceptanceCriteria` as a deprecated compatibility alias.
- Regenerate the `veryfront/work` reference and update docs coverage checks for the new Work example.

## Test Plan
- `deno check src/work/factory.test.ts src/work/prompt-augmentation.test.ts src/discovery/auto-discovery.integration.test.ts tests/docs/guide-code-examples.test.ts`
- `deno test --no-check --allow-all src/work/factory.test.ts src/work/prompt-augmentation.test.ts src/discovery/auto-discovery.integration.test.ts`
- `deno task docs:validate`
- Pre-push hook with OTEL/Grafana env cleared: `deno fmt --check`, `deno lint`, `deno check src/index.ts`, `deno task test:unit` (2199 passed, 0 failed)
