### PR TITLE
Restore Studio AG-UI SDK package exports

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.872",
+  "version": "0.1.873",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {
@@ -72,6 +72,8 @@
     "./context": "./src/react/context/index.tsx",
     "./fonts": "./src/react/fonts/index.ts",
     "./chat": "./src/chat/index.ts",
+    "./chat/ag-ui": "./src/chat/ag-ui.ts",
+    "./chat/protocol": "./src/chat/protocol.ts",
     "./chat/types": "./src/chat/types.ts",
     "./markdown": "./src/markdown/index.ts",
     "./mdx": "./src/mdx/index.ts",

--- a/scripts/build/browser-safe-exports.mjs
+++ b/scripts/build/browser-safe-exports.mjs
@@ -4,6 +4,8 @@ export const BROWSER_SAFE_EXPORTS = [
   "./context",
   "./fonts",
   "./chat",
+  "./chat/ag-ui",
+  "./chat/protocol",
   "./chat/types",
   "./chat/message-prep",
   "./markdown",
@@ -20,8 +22,6 @@ export const BROWSER_SAFE_DNT_TIMER_MODULES = [
 export const BROWSER_SAFE_CLIENT_MODULES = [
   // Demoted from public exports in #2350 but still browser-consumed via the
   // ./chat barrel, so they keep the polyfill-stripping treatment by path.
-  "src/chat/ag-ui.js",
-  "src/chat/protocol.js",
   "src/chat/conversation.js",
   "src/chat/provider-errors.js",
   "src/agent/react/use-voice-input.js",

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -138,6 +138,14 @@ describe("normalizeNpmPackageMetadata", () => {
 });
 
 describe("npm supply-chain policy", () => {
+	it("exports Studio AG-UI package entrypoints", async () => {
+		const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
+		const exports = denoConfig.exports as Record<string, string>;
+
+		assertEquals(exports["./chat/ag-ui"], "./src/chat/ag-ui.ts");
+		assertEquals(exports["./chat/protocol"], "./src/chat/protocol.ts");
+	});
+
 	it("keeps browser-safe export patches aligned to public exports", async () => {
 		const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
 		const exports = denoConfig.exports as Record<string, string>;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.872";
+export const VERSION = "0.1.873";


### PR DESCRIPTION
## Summary
- expose veryfront/chat/ag-ui and veryfront/chat/protocol as public npm exports
- keep both entries in the browser-safe npm patch list
- bump the SDK release version to 0.1.873

## Verification
- deno test --config=scripts/test.deno.json --no-check --allow-read scripts/build/browser-safe-exports.test.ts scripts/build/npm-package-metadata.test.ts
- deno fmt --check deno.json scripts/build/browser-safe-exports.mjs scripts/build/npm-package-metadata.test.ts src/utils/version-constant.ts
- git diff --check
- deno task build:npm, then inspected npm/package.json exports for ./chat/ag-ui and ./chat/protocol
- pre-push hook: formatting, lint, typecheck, and deno task test:unit (2188 passed, 0 failed)

Constraint: Studio currently imports the narrow AG-UI entrypoint and has a package-surface test for it.
