### PR TITLE
Move reusable agent eval helpers under eval

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.877",
+  "version": "0.1.878",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/api-reference/veryfront/eval.md
+++ b/docs/api-reference/veryfront/eval.md
@@ -61,73 +61,73 @@ const report = await runEval(definition, {
 
 ### Functions
 
-| Name                       | Description                                                             | Source                                                                                     |
-| -------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `createEvalReport`         | Create a JSON-serializable eval report from executed records.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/report.ts#L66)     |
-| `createEvalSourceDocument` | Create the normalized Eval document Studio can list, inspect, and edit. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L210)    |
-| `deriveEvalId`             | Derive the stable `eval:<path>` ID for an eval file.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L77)  |
-| `discoverEvals`            | Discover eval definitions from a project eval directory.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L152) |
-| `evalAgent`                | Define a V1 eval that targets a Veryfront agent.                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/factory.ts#L26)    |
-| `findEvalById`             | Discover and return one eval definition by ID.                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L195) |
-| `isEvalDefinition`         | Check whether a value is a normalized eval definition.                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/factory.ts#L48)    |
-| `runEval`                  | Execute an eval locally with injected target adapters.                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/runner.ts#L109)    |
-| `summarizeEvalRecords`     | Summarize eval records into pass/fail and metric aggregates.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/report.ts#L53)     |
+| Name | Description | Source |
+|------|-------------|--------|
+| `createEvalReport` | Create a JSON-serializable eval report from executed records. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/report.ts#L66) |
+| `createEvalSourceDocument` | Create the normalized Eval document Studio can list, inspect, and edit. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L210) |
+| `deriveEvalId` | Derive the stable `eval:<path>` ID for an eval file. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L77) |
+| `discoverEvals` | Discover eval definitions from a project eval directory. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L152) |
+| `evalAgent` | Define a V1 eval that targets a Veryfront agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/factory.ts#L26) |
+| `findEvalById` | Discover and return one eval definition by ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L195) |
+| `isEvalDefinition` | Check whether a value is a normalized eval definition. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/factory.ts#L48) |
+| `runEval` | Execute an eval locally with injected target adapters. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/runner.ts#L109) |
+| `summarizeEvalRecords` | Summarize eval records into pass/fail and metric aggregates. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/report.ts#L53) |
 
 ### Types
 
-| Name                              | Description                                                            | Source                                                                                    |
-| --------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `CreateEvalSourceDocumentOptions` | Options for creating a Studio source document from a discovered eval.  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L152)   |
-| `DiscoveredEval`                  | Eval definition discovered from project source.                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L22) |
-| `EvalAgentAdapter`                | Adapter used by `runEval` to execute V1 agent targets.                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L205)    |
-| `EvalAgentAdapterContext`         | Context passed to an agent adapter when `runEval` executes an example. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L186)    |
-| `EvalAgentAdapterResult`          | Agent adapter result normalized into an eval record.                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L193)    |
-| `EvalAgentInput`                  | Input accepted by `evalAgent`.                                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L172)    |
-| `EvalCheckContext`                | Context passed to an eval definition's `check` callback.               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L140)    |
-| `EvalDataset`                     | Dataset loader used by an eval definition.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L46)     |
-| `EvalDatasetLoadContext`          | Context passed to dataset loaders.                                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L41)     |
-| `EvalDefinition`                  | First-class eval definition discovered from project source.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L155)    |
-| `EvalDiscoveryOptions`            | Options for project-local eval discovery.                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L37) |
-| `EvalDiscoveryResult`             | Result returned by eval discovery.                                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L47) |
-| `EvalEditableField`               | Form-editable Eval source field name.                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L141)   |
-| `EvalExample`                     | Normalized dataset example used by eval runners and reports.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L25)     |
-| `EvalExampleInput`                | Dataset example shape accepted by eval definitions.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L33)     |
-| `EvalExpect`                      | Built-in expectation helpers available inside `check`.                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L133)    |
-| `EvalExpectation`                 | Fluent severity helpers for `check` expectations.                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L126)    |
-| `EvalMetric`                      | Metric contract used by eval definitions.                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L113)    |
-| `EvalMetricContext`               | Optional runtime context passed to metric evaluators.                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L108)    |
-| `EvalMetricFamily`                | Metric family used for grouping report summaries.                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L13)     |
-| `EvalMetricResult`                | Result emitted by a metric or check assertion.                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L95)     |
-| `EvalMetricSummary`               | Aggregate pass/fail summary for one metric.                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L220)    |
-| `EvalMetricThreshold`             | Numeric threshold attached to score-based metrics.                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L16)     |
-| `EvalRecord`                      | One executed example and repetition inside an eval report.             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L76)     |
-| `EvalReport`                      | JSON-serializable report produced by `runEval`.                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L240)    |
-| `EvalReportSummary`               | Aggregate pass/fail summary for one eval report.                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L231)    |
-| `EvalRun`                         | V2-ready Eval run projection.                                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L149)   |
-| `EvalSeverity`                    | How a metric result affects the final eval result.                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L10)     |
-| `EvalSource`                      | Source location for a discovered eval definition.                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L149)    |
-| `EvalSourceDocument`              | Studio-editable Eval source document.                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L145)   |
-| `EvalSourcePatch`                 | Eval source patch submitted by Studio forms.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L147)   |
-| `EvalSourceReference`             | Source location for an Eval definition.                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L143)   |
-| `EvalStudioCapability`            | Capability string Studio uses for Eval read and write access.          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L139)   |
-| `EvalTargetKind`                  | Primitive kind an eval can execute. V1 supports agent targets.         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L7)      |
-| `EvalToolCall`                    | Tool call metadata captured during one eval record.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L62)     |
-| `EvalTrace`                       | Trace metadata captured for one eval record.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L70)     |
-| `EvalUsage`                       | Token and cost usage captured for one eval record.                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L54)     |
-| `RunEvalOptions`                  | Options for running an eval locally.                                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L210)    |
+| Name | Description | Source |
+|------|-------------|--------|
+| `CreateEvalSourceDocumentOptions` | Options for creating a Studio source document from a discovered eval. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L152) |
+| `DiscoveredEval` | Eval definition discovered from project source. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L22) |
+| `EvalAgentAdapter` | Adapter used by `runEval` to execute V1 agent targets. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L205) |
+| `EvalAgentAdapterContext` | Context passed to an agent adapter when `runEval` executes an example. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L186) |
+| `EvalAgentAdapterResult` | Agent adapter result normalized into an eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L193) |
+| `EvalAgentInput` | Input accepted by `evalAgent`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L172) |
+| `EvalCheckContext` | Context passed to an eval definition's `check` callback. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L140) |
+| `EvalDataset` | Dataset loader used by an eval definition. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L46) |
+| `EvalDatasetLoadContext` | Context passed to dataset loaders. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L41) |
+| `EvalDefinition` | First-class eval definition discovered from project source. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L155) |
+| `EvalDiscoveryOptions` | Options for project-local eval discovery. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L37) |
+| `EvalDiscoveryResult` | Result returned by eval discovery. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L47) |
+| `EvalEditableField` | Form-editable Eval source field name. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L141) |
+| `EvalExample` | Normalized dataset example used by eval runners and reports. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L25) |
+| `EvalExampleInput` | Dataset example shape accepted by eval definitions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L33) |
+| `EvalExpect` | Built-in expectation helpers available inside `check`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L133) |
+| `EvalExpectation` | Fluent severity helpers for `check` expectations. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L126) |
+| `EvalMetric` | Metric contract used by eval definitions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L113) |
+| `EvalMetricContext` | Optional runtime context passed to metric evaluators. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L108) |
+| `EvalMetricFamily` | Metric family used for grouping report summaries. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L13) |
+| `EvalMetricResult` | Result emitted by a metric or check assertion. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L95) |
+| `EvalMetricSummary` | Aggregate pass/fail summary for one metric. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L220) |
+| `EvalMetricThreshold` | Numeric threshold attached to score-based metrics. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L16) |
+| `EvalRecord` | One executed example and repetition inside an eval report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L76) |
+| `EvalReport` | JSON-serializable report produced by `runEval`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L240) |
+| `EvalReportSummary` | Aggregate pass/fail summary for one eval report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L231) |
+| `EvalRun` | V2-ready Eval run projection. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L149) |
+| `EvalSeverity` | How a metric result affects the final eval result. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L10) |
+| `EvalSource` | Source location for a discovered eval definition. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L149) |
+| `EvalSourceDocument` | Studio-editable Eval source document. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L145) |
+| `EvalSourcePatch` | Eval source patch submitted by Studio forms. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L147) |
+| `EvalSourceReference` | Source location for an Eval definition. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L143) |
+| `EvalStudioCapability` | Capability string Studio uses for Eval read and write access. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L139) |
+| `EvalTargetKind` | Primitive kind an eval can execute. V1 supports agent targets. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L7) |
+| `EvalToolCall` | Tool call metadata captured during one eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L62) |
+| `EvalTrace` | Trace metadata captured for one eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L70) |
+| `EvalUsage` | Token and cost usage captured for one eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L54) |
+| `RunEvalOptions` | Options for running an eval locally. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L210) |
 
 ### Constants
 
-| Name                            | Description                                                                         | Source                                                                                   |
-| ------------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `datasets`                      | Dataset factories for inline, JSON, and JSONL eval examples.                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/datasets.ts#L40) |
-| `getEvalEditableFieldSchema`    | Schema for an editable Eval source field name.                                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L11)   |
-| `getEvalRunSchema`              | Schema for V2-ready Eval run projections.                                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L114)  |
-| `getEvalSourceDocumentSchema`   | Schema for a Studio-editable Eval source document.                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L74)   |
-| `getEvalSourcePatchSchema`      | Schema for a source patch submitted from an Eval editor.                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L95)   |
-| `getEvalSourceReferenceSchema`  | Schema for an Eval source reference.                                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L28)   |
-| `getEvalStudioCapabilitySchema` | Schema for Eval Studio capabilities.                                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L6)    |
-| `metrics`                       | Metric factories for deterministic answers, agent behavior, operations, and judges. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/metrics.ts#L133) |
+| Name | Description | Source |
+|------|-------------|--------|
+| `datasets` | Dataset factories for inline, JSON, and JSONL eval examples. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/datasets.ts#L40) |
+| `getEvalEditableFieldSchema` | Schema for an editable Eval source field name. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L11) |
+| `getEvalRunSchema` | Schema for V2-ready Eval run projections. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L114) |
+| `getEvalSourceDocumentSchema` | Schema for a Studio-editable Eval source document. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L74) |
+| `getEvalSourcePatchSchema` | Schema for a source patch submitted from an Eval editor. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L95) |
+| `getEvalSourceReferenceSchema` | Schema for an Eval source reference. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L28) |
+| `getEvalStudioCapabilitySchema` | Schema for Eval Studio capabilities. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L6) |
+| `metrics` | Metric factories for deterministic answers, agent behavior, operations, and judges. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/metrics.ts#L133) |
 
 ## Deep imports
 
@@ -136,36 +136,141 @@ These import paths group focused functionality under this module. Each is a sepa
 ### `veryfront/eval/agent-service`
 
 ```ts
-import {
-  buildAgentServiceEvalRequestBody,
-  createAgentServiceEvalAdapter,
-  evaluateAgentServiceEvalEnvironment,
-} from "veryfront/eval/agent-service";
+import { assertCompleted, assertNoMalformedCreateFileToolCalls, buildAgentServiceEvalRequestBody } from "veryfront/eval/agent-service";
 ```
 
 #### Components
 
-| Name                                  | Description                                               | Source                                                                                        |
-| ------------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `DEFAULT_AGENT_SERVICE_EVAL_ENDPOINT` | Default local AG-UI endpoint used by agent-service evals. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L15) |
+| Name | Description | Source |
+|------|-------------|--------|
+| `DEFAULT_AGENT_SERVICE_EVAL_ENDPOINT` | Default local AG-UI endpoint used by agent-service evals. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L19) |
+| `DEFAULT_DURABLE_RUN_CANARY_TIMEOUT_MS` | Default value for durable run canary timeout ms. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/environment.ts#L15) |
+| `DEFAULT_LIVE_EVAL_AREA_TAG_RULES` | Default value for live eval area tag rules. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/metadata.ts#L36) |
+| `DEFAULT_LIVE_EVAL_ENDPOINT` | Default value for live eval endpoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/environment.ts#L16) |
+| `DEFAULT_LIVE_EVAL_OPTIONAL_JUDGE_CASE_PREFIXES` | Default value for live eval optional judge case prefixes. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/metadata.ts#L29) |
 
 #### Functions
 
-| Name                                  | Description                                                                                  | Source                                                                                         |
-| ------------------------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `buildAgentServiceEvalRequestBody`    | Build the AG-UI request body for a single eval example.                                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L247) |
-| `createAgentServiceEvalAdapter`       | Create an `EvalAgentAdapter` that executes examples against an AG-UI agent-service endpoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L277) |
-| `evaluateAgentServiceEvalEnvironment` | Evaluate whether the required live agent-service eval environment is present.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L226) |
-| `resolveAgentServiceEvalEnvironment`  | Resolve environment values for live agent-service eval execution.                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L206) |
+| Name | Description | Source |
+|------|-------------|--------|
+| `assertCompleted` | Assert that a durable run canary completed successfully. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/validation.ts#L31) |
+| `assertNoMalformedCreateFileToolCalls` | Assert no malformed create file tool calls helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/validation.ts#L78) |
+| `buildAgentServiceEvalRequestBody` | Build the AG-UI request body for a single eval example. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L305) |
+| `buildFailureSuffix` | Builds failure suffix. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/formatting.ts#L79) |
+| `buildLiveEvalCaseMetadata` | Builds live eval case metadata. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/metadata.ts#L121) |
+| `buildLiveEvalCaseTagSummary` | Builds live eval case tag summary. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/report.ts#L40) |
+| `buildLiveEvalRequestBody` | Builds live eval request body. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/request.ts#L32) |
+| `buildLiveEvalRuntimeSummary` | Builds live eval runtime summary. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/report.ts#L136) |
+| `buildLiveEvalStatusSummary` | Builds live eval status summary. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/report.ts#L151) |
+| `buildProgressLine` | Builds progress line. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/formatting.ts#L58) |
+| `buildRuntimePerformanceSummary` | Builds runtime performance summary. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/performance.ts#L36) |
+| `cancelLiveEvalInputRequest` | Request payload for cancel live eval input. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L569) |
+| `collectAssistantText` | Collect assistant text helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/validation.ts#L70) |
+| `containsOrderedSubsequence` | Contains ordered subsequence helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/formatting.ts#L92) |
+| `containsSkillLoad` | Contains skill load helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L478) |
+| `countStepStartedEvents` | Count step started events helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L483) |
+| `createAgentServiceEvalAdapter` | Create an `EvalAgentAdapter` that executes examples against an AG-UI agent-service endpoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L335) |
+| `createDurableRunCanaryApiClient` | Create durable run canary API client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L257) |
+| `createDurableRunCanaryRunner` | Create durable run canary runner. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L503) |
+| `createFailedEvalResult` | Result returned from create failed eval. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/result.ts#L79) |
+| `createLiveEvalApiClient` | Create live eval API client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L266) |
+| `createLiveEvalCaseSupport` | Create live eval case support. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L488) |
+| `createLiveEvalConversation` | Create live eval conversation. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L282) |
+| `createLiveEvalProjectUploadFixture` | Create live eval project upload fixture. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L334) |
+| `createLiveEvalRelease` | Create live eval release. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L429) |
+| `createPassedEvalResult` | Result returned from create passed eval. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/result.ts#L97) |
+| `createPlainTextPdf` | Create plain text pdf. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/formatting.ts#L11) |
+| `createSkippedEvalResult` | Result returned from create skipped eval. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/result.ts#L61) |
+| `deleteLiveEvalConversation` | Delete live eval conversation helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L311) |
+| `deleteLiveEvalProjectFile` | Delete live eval project file helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L464) |
+| `evaluateAgentServiceEvalEnvironment` | Evaluate whether the required live agent-service eval environment is present. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L284) |
+| `evaluateRuntimeConfidenceEnv` | Evaluate runtime confidence env helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/preflight.ts#L13) |
+| `findAssistantMessage` | Message shape for find assistant. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/validation.ts#L42) |
+| `getLiveEvalProjectFile` | Return live eval project file. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L395) |
+| `hasEveryLiveEvalTag` | Check whether every live eval tag is present. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/report.ts#L26) |
+| `hasFinished` | Check whether finished is present. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L473) |
+| `listOpenLiveEvalInputRequests` | List open live eval input requests. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L490) |
+| `parseDurableRunCanaryRunSummary` | Parses durable run canary run summary. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L111) |
+| `printRuntimeConfidencePreflight` | Print runtime confidence preflight helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/preflight.ts#L39) |
+| `resolveAgentServiceEvalEnvironment` | Resolve environment values for live agent-service eval execution. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L264) |
+| `resolveDurableRunCanaryEnvironment` | Resolves durable run canary environment. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/environment.ts#L18) |
+| `resolveLiveEvalEnvironment` | Resolves live eval environment. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/environment.ts#L19) |
+| `resolveLiveEvalRequestedCaseIds` | Resolves live eval requested case IDs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/report.ts#L87) |
+| `runDurableRunCanaryCli` | Run durable run canary cli. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/cli-runner.ts#L45) |
+| `runLiveEvalCli` | Run live eval cli. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/cli-runner.ts#L85) |
+| `selectLiveEvalCases` | Select live eval cases helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/report.ts#L60) |
+| `stringifyUnknown` | Stringify unknown helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/validation.ts#L57) |
+| `submitLiveEvalInputResponse` | Response payload for submit live eval input. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L544) |
+| `waitForOpenLiveEvalInputRequest` | Request payload for wait for open live eval input. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L516) |
+| `withLiveEvalMetadata` | Applies live eval metadata. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/metadata.ts#L160) |
 
 #### Types
 
-| Name                                         | Description                                                  | Source                                                                                        |
-| -------------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| `AgentServiceEvalAdapterConfig`              | Configuration for the live agent-service eval adapter.       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L81) |
-| `AgentServiceEvalEnvironment`                | Resolved environment values for live agent-service evals.    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L21) |
-| `AgentServiceEvalEnvironmentInput`           | Environment input accepted by agent-service eval helpers.    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L18) |
-| `AgentServiceEvalEnvironmentPreflightResult` | Preflight result for a live agent-service eval environment.  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L31) |
-| `AgentServiceEvalForwardedProps`             | Veryfront forwarded props included in an AG-UI eval request. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L38) |
-| `AgentServiceEvalRequestBody`                | AG-UI request body sent to an agent-service endpoint.        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L64) |
-| `BuildAgentServiceEvalRequestBodyInput`      | Input accepted by `buildAgentServiceEvalRequestBody`.        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L50) |
+| Name | Description | Source |
+|------|-------------|--------|
+| `AgentServiceEvalAdapterConfig` | Configuration for the live agent-service eval adapter. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L85) |
+| `AgentServiceEvalEnvironment` | Resolved environment values for live agent-service evals. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L25) |
+| `AgentServiceEvalEnvironmentInput` | Environment input accepted by agent-service eval helpers. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L22) |
+| `AgentServiceEvalEnvironmentPreflightResult` | Preflight result for a live agent-service eval environment. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L35) |
+| `AgentServiceEvalForwardedProps` | Veryfront forwarded props included in an AG-UI eval request. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L42) |
+| `AgentServiceEvalRequestBody` | AG-UI request body sent to an agent-service endpoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L68) |
+| `BuildAgentServiceEvalRequestBodyInput` | Input accepted by `buildAgentServiceEvalRequestBody`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L54) |
+| `BuildLiveEvalCaseMetadataInput` | Input payload for build live eval case metadata. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/metadata.ts#L22) |
+| `BuildLiveEvalRequestBodyInput` | Input payload for build live eval request body. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/request.ts#L18) |
+| `DurableRunCanaryApiClient` | Public API contract for durable run canary API client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L246) |
+| `DurableRunCanaryApiConfig` | Configuration used by durable run canary API. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L7) |
+| `DurableRunCanaryCase` | Public API contract for durable run canary case. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L368) |
+| `DurableRunCanaryCliCaseFactoryInput` | Input payload for durable run canary cli case factory. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/cli-runner.ts#L15) |
+| `DurableRunCanaryCreateRootRunInput` | Input payload for durable run canary create root run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L18) |
+| `DurableRunCanaryEnvironment` | Public API contract for durable run canary environment. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/environment.ts#L6) |
+| `DurableRunCanaryMessage` | Message shape for durable run canary. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L47) |
+| `DurableRunCanaryPreparedCase` | Public API contract for durable run canary prepared case. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L354) |
+| `DurableRunCanaryResult` | Result returned from durable run canary. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L342) |
+| `DurableRunCanaryRunnerConfig` | Configuration used by durable run canary runner. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L375) |
+| `DurableRunCanaryRunSummary` | Public API contract for durable run canary run summary. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L52) |
+| `DurableRunCanarySendUserMessageInput` | Input payload for durable run canary send user message. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L24) |
+| `DurableRunCanaryStartRunInput` | Input payload for durable run canary start run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L30) |
+| `LiveEvalApiClient` | Public API contract for live eval API client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L120) |
+| `LiveEvalApiContext` | Context for live eval API. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L8) |
+| `LiveEvalCase` | Public API contract for live eval case. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L36) |
+| `LiveEvalCaseMetadata` | Public API contract for live eval case metadata. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/report.ts#L3) |
+| `LiveEvalCaseMetadataOptions` | Options accepted by live eval case metadata. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/metadata.ts#L15) |
+| `LiveEvalCaseSelectionInput` | Input payload for live eval case selection. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/report.ts#L14) |
+| `LiveEvalCaseSurface` | Public API contract for live eval case surface. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/metadata.ts#L4) |
+| `LiveEvalCaseTagRule` | Public API contract for live eval case tag rule. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/metadata.ts#L7) |
+| `LiveEvalCliCaseFactoryInput` | Input payload for live eval cli case factory. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/cli-runner.ts#L33) |
+| `LiveEvalCliCaseGroups` | Public API contract for live eval cli case groups. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/cli-runner.ts#L26) |
+| `LiveEvalContext` | Context for live eval. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L29) |
+| `LiveEvalConversationInput` | Input payload for live eval conversation. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L26) |
+| `LiveEvalCreateConversationInput` | Input payload for live eval create conversation. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L21) |
+| `LiveEvalCreateReleaseInput` | Input payload for live eval create release. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L46) |
+| `LiveEvalEnvironment` | Public API contract for live eval environment. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/environment.ts#L6) |
+| `LiveEvalInputRequestInput` | Input payload for live eval input request. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L70) |
+| `LiveEvalInputRequestRecord` | Record shape for live eval input request. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L115) |
+| `LiveEvalInputResponseValues` | Public API contract for live eval input response values. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L58) |
+| `LiveEvalProjectFile` | Public API contract for live eval project file. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L60) |
+| `LiveEvalProjectFileInput` | Input payload for live eval project file. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L41) |
+| `LiveEvalProjectFileReaderInput` | Input payload for live eval project file reader. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L66) |
+| `LiveEvalProjectUploadFixtureInput` | Input payload for live eval project upload fixture. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L31) |
+| `LiveEvalRequestBody` | Public API contract for live eval request body. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/request.ts#L1) |
+| `LiveEvalRequestTimeoutInput` | Input payload for live eval request timeout. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L16) |
+| `LiveEvalResultForPerformance` | Public API contract for live eval result for performance. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/performance.ts#L4) |
+| `LiveEvalResultForReport` | Public API contract for live eval result for report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/report.ts#L8) |
+| `LiveEvalResultRecord` | Record shape for live eval result. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/result.ts#L3) |
+| `LiveEvalRunnerConfig` | Configuration used by live eval runner. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L72) |
+| `LiveEvalRuntime` | Public API contract for live eval runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/performance.ts#L1) |
+| `LiveEvalSubmitInputResponseInput` | Input payload for live eval submit input response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L63) |
+| `LiveEvalWaitForOpenInputRequestInput` | Input payload for live eval wait for open input request. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L51) |
+| `PreparedLiveEvalInput` | Input payload for prepared live eval. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L20) |
+| `RunDurableRunCanaryCliInput` | Input payload for run durable run canary cli. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/cli-runner.ts#L21) |
+| `RunLiveEvalCliInput` | Input payload for run live eval cli. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/cli-runner.ts#L50) |
+| `RuntimeConfidencePreflightResult` | Result returned from runtime confidence preflight. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/preflight.ts#L6) |
+| `RuntimePerformanceSummary` | Public API contract for runtime performance summary. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/performance.ts#L10) |
+
+#### Constants
+
+| Name | Description | Source |
+|------|-------------|--------|
+| `durableRunCanaryRunnerInternals` | White-box helpers used by durable run canary tests. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L611) |
+| `getDurableRunCanaryMessageSchema` | Zod schema for get durable run canary message. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L37) |
+| `liveEvalRunnerInternals` | White-box helpers used by live eval runner tests. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L631) |

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -182,6 +182,12 @@ project-scoped API state. The adapter reads AG-UI events into
 `record.trace.events`, records tool starts as `record.trace.toolCalls`, and puts
 the parsed text at `record.output.text`.
 
+Projects with existing live AG-UI suites can also import reusable CLI, API, and
+durable canary helpers from `veryfront/eval/agent-service`. Use those helpers
+for product-specific canaries that are not yet expressed as `evalAgent`
+definitions. Do not import `veryfront/agent/testing`; that legacy testing path
+is intentionally absent.
+
 ## Discovery
 
 Eval files are discovered from `evals/`:

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -149,9 +149,12 @@ describe("npm supply-chain policy", () => {
 	it("exports agent-service evals without legacy agent testing", async () => {
 		const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
 		const exports = denoConfig.exports as Record<string, string>;
+		const imports = denoConfig.imports as Record<string, string>;
 
 		assertEquals(exports["./eval/agent-service"], "./src/eval/agent-service.ts");
+		assertEquals(imports["veryfront/eval/agent-service"], "./src/eval/agent-service.ts");
 		assertEquals(exports["./agent/testing"], undefined);
+		assertEquals(imports["veryfront/agent/testing"], undefined);
 	});
 
 	it("keeps browser-safe export patches aligned to public exports", async () => {

--- a/src/eval/agent-service.test.ts
+++ b/src/eval/agent-service.test.ts
@@ -6,7 +6,10 @@ import {
   buildAgentServiceEvalRequestBody,
   createAgentServiceEvalAdapter,
   evaluateAgentServiceEvalEnvironment,
+  evaluateRuntimeConfidenceEnv,
   resolveAgentServiceEvalEnvironment,
+  runDurableRunCanaryCli,
+  runLiveEvalCli,
 } from "veryfront/eval/agent-service";
 
 function createSseResponse(
@@ -224,6 +227,12 @@ describe("eval/agent-service", () => {
     const mod = await import("veryfront/eval/agent-service");
 
     assertEquals(typeof mod.createAgentServiceEvalAdapter, "function");
+    assertEquals(typeof mod.runLiveEvalCli, "function");
+    assertEquals(typeof mod.runDurableRunCanaryCli, "function");
+    assertEquals(typeof mod.evaluateRuntimeConfidenceEnv, "function");
+    assertEquals(typeof runLiveEvalCli, "function");
+    assertEquals(typeof runDurableRunCanaryCli, "function");
+    assertEquals(typeof evaluateRuntimeConfidenceEnv, "function");
   });
 
   it("does not revive the legacy agent testing import path", async () => {

--- a/src/eval/agent-service.ts
+++ b/src/eval/agent-service.ts
@@ -13,6 +13,9 @@ import type {
   EvalToolCall,
 } from "./types.ts";
 
+export * from "./agent-service/live-evals/index.ts";
+export * from "./agent-service/durable-run-canaries/index.ts";
+
 /** Default local AG-UI endpoint used by agent-service evals. */
 export const DEFAULT_AGENT_SERVICE_EVAL_ENDPOINT = "http://127.0.0.1:3001/api/ag-ui";
 

--- a/src/eval/agent-service/durable-run-canaries/cli-runner.ts
+++ b/src/eval/agent-service/durable-run-canaries/cli-runner.ts
@@ -1,0 +1,120 @@
+import { mkdir, writeTextFile } from "#veryfront/platform/compat/fs.ts";
+import { dirname, resolve } from "#veryfront/platform/compat/path/index.ts";
+import { cwd as getProcessCwd } from "#veryfront/platform/compat/process.ts";
+import { type LiveEvalApiContext } from "../live-evals/api-client.ts";
+import { resolveDurableRunCanaryEnvironment } from "./environment.ts";
+import {
+  createDurableRunCanaryRunner,
+  type DurableRunCanaryCase,
+  type DurableRunCanaryResult,
+  type DurableRunCanaryRunnerConfig,
+} from "./runner.ts";
+
+type EnvRecord = Record<string, string | undefined>;
+
+/** Input payload for durable run canary cli case factory. */
+export interface DurableRunCanaryCliCaseFactoryInput {
+  context: LiveEvalApiContext;
+  requestTimeoutMs: number;
+}
+
+/** Input payload for run durable run canary cli. */
+export interface RunDurableRunCanaryCliInput {
+  env: EnvRecord;
+  agentId: string;
+  createCases: (input: DurableRunCanaryCliCaseFactoryInput) => DurableRunCanaryCase[];
+  cwd?: string;
+  log?: (message: string) => void;
+  createRunner?: (
+    config: DurableRunCanaryRunnerConfig,
+  ) => ReturnType<typeof createDurableRunCanaryRunner>;
+}
+
+function createTimestampedReportPath(input: {
+  cwd: string;
+  directory: string;
+}): string {
+  return resolve(
+    input.cwd,
+    ".omx/logs",
+    input.directory,
+    `${new Date().toISOString().replaceAll(":", "-").replaceAll(".", "-")}.json`,
+  );
+}
+
+/** Run durable run canary cli. */
+export async function runDurableRunCanaryCli(
+  input: RunDurableRunCanaryCliInput,
+): Promise<number> {
+  const log = input.log ?? console.log;
+  const cwd = input.cwd ?? getProcessCwd();
+  const { apiUrl, authToken, projectId, requestTimeoutMs, keepSuccessfulEvidence } =
+    resolveDurableRunCanaryEnvironment(input.env);
+  const reportPath = input.env.DURABLE_CANARY_REPORT_PATH ??
+    createTimestampedReportPath({ cwd, directory: "durable-run-staging-canaries" });
+
+  if (!authToken) {
+    throw new Error("Missing VERYFRONT_TOKEN");
+  }
+  if (!projectId) {
+    throw new Error("Missing AG_UI_EVAL_PROJECT_ID");
+  }
+
+  const context: LiveEvalApiContext = {
+    apiUrl,
+    authToken,
+    projectId,
+  };
+  const createRunner = input.createRunner ?? createDurableRunCanaryRunner;
+  const { runCase } = createRunner({
+    apiUrl,
+    authToken,
+    agentId: input.agentId,
+    projectId,
+    requestTimeoutMs,
+    keepSuccessfulEvidence,
+  });
+  const testCases = input.createCases({
+    context,
+    requestTimeoutMs,
+  });
+
+  log(`Durable run canaries -> ${apiUrl}`);
+  log(`Project scope -> ${projectId}`);
+
+  const results: DurableRunCanaryResult[] = [];
+  for (const testCase of testCases) {
+    log(`\n[run] ${testCase.label}`);
+    const result = await runCase(testCase);
+    results.push(result);
+    log(`[${result.status}] ${result.id}: ${result.details}`);
+  }
+
+  const summary = {
+    passed: results.filter((result) => result.status === "pass").length,
+    failed: results.filter((result) => result.status === "fail").length,
+  };
+
+  await mkdir(dirname(reportPath), { recursive: true });
+  await writeTextFile(
+    reportPath,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        apiUrl,
+        projectId,
+        results,
+        summary,
+      },
+      null,
+      2,
+    ),
+  );
+
+  log("\nSummary");
+  log(`passed: ${summary.passed}`);
+  log(`failed: ${summary.failed}`);
+  log(`report: ${reportPath}`);
+
+  return summary.failed > 0 ? 1 : 0;
+}

--- a/src/eval/agent-service/durable-run-canaries/environment.ts
+++ b/src/eval/agent-service/durable-run-canaries/environment.ts
@@ -1,0 +1,33 @@
+import {
+  type AgentServiceConfigInput,
+  parseAgentServiceConfig,
+} from "../../../agent/service/config.ts";
+
+/** Public API contract for durable run canary environment. */
+export interface DurableRunCanaryEnvironment {
+  apiUrl: string;
+  authToken: string;
+  projectId: string;
+  requestTimeoutMs: number;
+  keepSuccessfulEvidence: boolean;
+}
+
+/** Default value for durable run canary timeout ms. */
+export const DEFAULT_DURABLE_RUN_CANARY_TIMEOUT_MS = 240_000;
+
+/** Resolves durable run canary environment. */
+export function resolveDurableRunCanaryEnvironment(
+  env: AgentServiceConfigInput = {},
+): DurableRunCanaryEnvironment {
+  return {
+    apiUrl: typeof env.VERYFRONT_API_URL === "string"
+      ? env.VERYFRONT_API_URL
+      : parseAgentServiceConfig(env).VERYFRONT_API_URL,
+    authToken: typeof env.VERYFRONT_TOKEN === "string" ? env.VERYFRONT_TOKEN : "",
+    projectId: typeof env.AG_UI_EVAL_PROJECT_ID === "string" ? env.AG_UI_EVAL_PROJECT_ID : "",
+    requestTimeoutMs: Number(
+      env.DURABLE_CANARY_TIMEOUT_MS ?? DEFAULT_DURABLE_RUN_CANARY_TIMEOUT_MS,
+    ),
+    keepSuccessfulEvidence: env.DURABLE_CANARY_KEEP_SUCCESS === "1",
+  };
+}

--- a/src/eval/agent-service/durable-run-canaries/index.ts
+++ b/src/eval/agent-service/durable-run-canaries/index.ts
@@ -1,0 +1,36 @@
+export {
+  type DurableRunCanaryCliCaseFactoryInput,
+  runDurableRunCanaryCli,
+  type RunDurableRunCanaryCliInput,
+} from "./cli-runner.ts";
+export {
+  DEFAULT_DURABLE_RUN_CANARY_TIMEOUT_MS,
+  type DurableRunCanaryEnvironment,
+  resolveDurableRunCanaryEnvironment,
+} from "./environment.ts";
+export {
+  createDurableRunCanaryApiClient,
+  createDurableRunCanaryRunner,
+  type DurableRunCanaryApiClient,
+  type DurableRunCanaryApiConfig,
+  type DurableRunCanaryCase,
+  type DurableRunCanaryCreateRootRunInput,
+  type DurableRunCanaryMessage,
+  type DurableRunCanaryPreparedCase,
+  type DurableRunCanaryResult,
+  type DurableRunCanaryRunnerConfig,
+  durableRunCanaryRunnerInternals,
+  type DurableRunCanaryRunSummary,
+  type DurableRunCanarySendUserMessageInput,
+  type DurableRunCanaryStartRunInput,
+  getDurableRunCanaryMessageSchema,
+  parseDurableRunCanaryRunSummary,
+} from "./runner.ts";
+
+export {
+  assertCompleted,
+  assertNoMalformedCreateFileToolCalls,
+  collectAssistantText,
+  findAssistantMessage,
+  stringifyUnknown,
+} from "./validation.ts";

--- a/src/eval/agent-service/durable-run-canaries/runner.ts
+++ b/src/eval/agent-service/durable-run-canaries/runner.ts
@@ -1,0 +1,615 @@
+import { defineSchema } from "#veryfront/schemas/index.ts";
+import { ensureBuiltinSchemaValidator } from "#veryfront/extensions/builtin-extensions.ts";
+import type { InferSchema } from "#veryfront/extensions/schema/index.ts";
+
+ensureBuiltinSchemaValidator();
+
+/** Configuration used by durable run canary API. */
+export interface DurableRunCanaryApiConfig {
+  apiUrl: string;
+  authToken: string;
+  agentId: string;
+  projectId: string | null;
+  branchId?: string | null;
+  requestTimeoutMs: number;
+  fetch?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+}
+
+/** Input payload for durable run canary create root run. */
+export interface DurableRunCanaryCreateRootRunInput {
+  conversationId: string;
+  runId: string;
+}
+
+/** Input payload for durable run canary send user message. */
+export interface DurableRunCanarySendUserMessageInput {
+  conversationId: string;
+  prompt: string;
+}
+
+/** Input payload for durable run canary start run. */
+export interface DurableRunCanaryStartRunInput extends DurableRunCanaryCreateRootRunInput {
+  messageId: string;
+  prompt: string;
+  userMessageId: string;
+}
+
+/** Zod schema for get durable run canary message. */
+export const getDurableRunCanaryMessageSchema = defineSchema((v) =>
+  v.object({
+    id: v.string(),
+    role: v.enum(["user", "assistant", "system", "tool"] as const),
+    status: v.string().optional(),
+    parts: v.array(v.object({ type: v.string() }).passthrough()).default([]),
+  }).passthrough()
+);
+
+/** Message shape for durable run canary. */
+export type DurableRunCanaryMessage = InferSchema<
+  ReturnType<typeof getDurableRunCanaryMessageSchema>
+>;
+
+/** Public API contract for durable run canary run summary. */
+export interface DurableRunCanaryRunSummary {
+  runId: string;
+  conversationId: string;
+  messageId: string;
+  agentId: string;
+  status: string;
+  latestEventId: number;
+  latestExternalEventSequence: number | null;
+  waitingToolCallId: string | null;
+  waitingToolName: string | null;
+  terminalErrorCode: string | null;
+  terminalErrorMessage: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+}
+
+const getSnakeRunSummarySchema = defineSchema((v) =>
+  v.object({
+    run_id: v.string(),
+    conversation_id: v.string().uuid(),
+    message_id: v.string().uuid(),
+    agent_id: v.string(),
+    status: v.string(),
+    latest_event_id: v.number().int().nonnegative(),
+    latest_external_event_sequence: v.number().int().nonnegative().optional(),
+    waiting_tool_call_id: v.string().nullable().optional(),
+    waiting_tool_name: v.string().nullable().optional(),
+    terminal_error_code: v.string().nullable().optional(),
+    terminal_error_message: v.string().nullable().optional(),
+    started_at: v.string().nullable().optional(),
+    finished_at: v.string().nullable().optional(),
+  }).passthrough()
+);
+
+const getCamelRunSummarySchema = defineSchema((v) =>
+  v.object({
+    runId: v.string(),
+    conversationId: v.string().uuid(),
+    messageId: v.string().uuid(),
+    agentId: v.string(),
+    status: v.string(),
+    latestEventId: v.number().int().nonnegative(),
+    latestExternalEventSequence: v.number().int().nonnegative().optional(),
+    waitingToolCallId: v.string().nullable().optional(),
+    waitingToolName: v.string().nullable().optional(),
+    terminalErrorCode: v.string().nullable().optional(),
+    terminalErrorMessage: v.string().nullable().optional(),
+    startedAt: v.string().nullable().optional(),
+    finishedAt: v.string().nullable().optional(),
+  }).passthrough()
+);
+
+const getDurableRunCanaryMessageListSchema = defineSchema((v) =>
+  v.object({
+    data: v.array(getDurableRunCanaryMessageSchema()),
+  })
+);
+
+/** Parses durable run canary run summary. */
+export function parseDurableRunCanaryRunSummary(value: unknown): DurableRunCanaryRunSummary {
+  const snake = getSnakeRunSummarySchema().safeParse(value);
+  if (snake.success) {
+    return {
+      runId: snake.data.run_id,
+      conversationId: snake.data.conversation_id,
+      messageId: snake.data.message_id,
+      agentId: snake.data.agent_id,
+      status: snake.data.status,
+      latestEventId: snake.data.latest_event_id,
+      latestExternalEventSequence: snake.data.latest_external_event_sequence ?? null,
+      waitingToolCallId: snake.data.waiting_tool_call_id ?? null,
+      waitingToolName: snake.data.waiting_tool_name ?? null,
+      terminalErrorCode: snake.data.terminal_error_code ?? null,
+      terminalErrorMessage: snake.data.terminal_error_message ?? null,
+      startedAt: snake.data.started_at ?? null,
+      finishedAt: snake.data.finished_at ?? null,
+    };
+  }
+
+  const camel = getCamelRunSummarySchema().parse(value);
+  return {
+    runId: camel.runId,
+    conversationId: camel.conversationId,
+    messageId: camel.messageId,
+    agentId: camel.agentId,
+    status: camel.status,
+    latestEventId: camel.latestEventId,
+    latestExternalEventSequence: camel.latestExternalEventSequence ?? null,
+    waitingToolCallId: camel.waitingToolCallId ?? null,
+    waitingToolName: camel.waitingToolName ?? null,
+    terminalErrorCode: camel.terminalErrorCode ?? null,
+    terminalErrorMessage: camel.terminalErrorMessage ?? null,
+    startedAt: camel.startedAt ?? null,
+    finishedAt: camel.finishedAt ?? null,
+  };
+}
+
+function createJsonHeaders(config: DurableRunCanaryApiConfig, headers?: HeadersInit): Headers {
+  const result = new Headers(headers);
+  if (!result.has("Content-Type")) {
+    result.set("Content-Type", "application/json");
+  }
+  result.set("Authorization", `Bearer ${config.authToken}`);
+  return result;
+}
+
+function createFetch(config: DurableRunCanaryApiConfig) {
+  return config.fetch ?? fetch;
+}
+
+function createApiUrl(config: DurableRunCanaryApiConfig, path: string): URL {
+  const baseHref = config.apiUrl.endsWith("/") ? config.apiUrl : `${config.apiUrl}/`;
+  const relativePath = path.startsWith("/") ? path.slice(1) : path;
+  return new URL(relativePath, baseHref);
+}
+
+function buildCreateRootRunTargetFields(config: DurableRunCanaryApiConfig) {
+  if (!config.projectId) {
+    return {};
+  }
+
+  if (config.branchId) {
+    return {
+      source_target_kind: "preview_branch",
+      runtime_target_kind: "preview_branch",
+      source_target_branch_id: config.branchId,
+      runtime_target_branch_id: config.branchId,
+    } as const;
+  }
+
+  return {
+    source_target_kind: "project",
+    runtime_target_kind: "main_branch",
+    runtime_target_branch_id: null,
+  } as const;
+}
+
+function buildCreateRootRunBody(
+  config: DurableRunCanaryApiConfig,
+  input: DurableRunCanaryCreateRootRunInput,
+) {
+  return {
+    kind: "agent",
+    owner: {
+      kind: "conversation",
+      id: input.conversationId,
+    },
+    public_id: input.runId,
+    request: {
+      mode: "agent",
+      agent_id: config.agentId,
+      initial_status: "pending",
+      ...buildCreateRootRunTargetFields(config),
+    },
+  };
+}
+
+function buildStartRunBody(
+  config: DurableRunCanaryApiConfig,
+  input: DurableRunCanaryStartRunInput,
+) {
+  return {
+    kind: "agent",
+    owner: {
+      kind: "conversation",
+      id: input.conversationId,
+    },
+    public_id: input.runId,
+    request: {
+      mode: "agent",
+      agent_id: config.agentId,
+      input: {
+        messages: [
+          {
+            id: input.userMessageId,
+            role: "user",
+            parts: [{ type: "text", text: input.prompt }],
+          },
+        ],
+        context: {
+          conversation_id: input.conversationId,
+          project_id: config.projectId,
+          branch_id: config.branchId ?? null,
+        },
+        durable_root_run: {
+          run_id: input.runId,
+          message_id: input.messageId,
+        },
+      },
+    },
+  };
+}
+
+/** Public API contract for durable run canary API client. */
+export interface DurableRunCanaryApiClient {
+  createDurableRootRun: (input: DurableRunCanaryCreateRootRunInput) => Promise<void>;
+  getRunSummary: (input: DurableRunCanaryCreateRootRunInput) => Promise<DurableRunCanaryRunSummary>;
+  listMessagesForCanary: (input: { conversationId: string }) => Promise<DurableRunCanaryMessage[]>;
+  sendUserMessageForCanary: (
+    input: DurableRunCanarySendUserMessageInput,
+  ) => Promise<DurableRunCanaryMessage>;
+  startDurableRun: (input: DurableRunCanaryStartRunInput) => Promise<void>;
+}
+
+/** Create durable run canary API client. */
+export function createDurableRunCanaryApiClient(
+  config: DurableRunCanaryApiConfig,
+): DurableRunCanaryApiClient {
+  const request = createFetch(config);
+
+  async function apiFetch<T>(
+    path: string,
+    init: RequestInit | undefined,
+    parse: (value: unknown) => T,
+  ): Promise<T>;
+  async function apiFetch(path: string, init?: RequestInit): Promise<unknown>;
+  async function apiFetch<T>(
+    path: string,
+    init?: RequestInit,
+    parse?: (value: unknown) => T,
+  ): Promise<T | unknown> {
+    const response = await request(createApiUrl(config, path), {
+      ...init,
+      headers: createJsonHeaders(config, init?.headers),
+      signal: AbortSignal.timeout(config.requestTimeoutMs),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `API ${init?.method ?? "GET"} ${path} failed: ${response.status} ${await response.text()}`,
+      );
+    }
+
+    const payload: unknown = await response.json();
+    return parse ? parse(payload) : payload;
+  }
+
+  async function sendUserMessageForCanary(input: DurableRunCanarySendUserMessageInput) {
+    return apiFetch(
+      `/conversations/${input.conversationId}/messages`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          role: "user",
+          parts: [{ type: "text", text: input.prompt }],
+        }),
+      },
+      (value) => getDurableRunCanaryMessageSchema().parse(value),
+    );
+  }
+
+  async function createDurableRootRun(input: DurableRunCanaryCreateRootRunInput): Promise<void> {
+    await apiFetch("/runs", {
+      method: "POST",
+      body: JSON.stringify(buildCreateRootRunBody(config, input)),
+    });
+  }
+
+  async function startDurableRun(input: DurableRunCanaryStartRunInput): Promise<void> {
+    await apiFetch("/runs", {
+      method: "POST",
+      body: JSON.stringify(buildStartRunBody(config, input)),
+    });
+  }
+
+  async function getRunSummary(input: DurableRunCanaryCreateRootRunInput) {
+    const response = await apiFetch(`/conversations/${input.conversationId}/runs/${input.runId}`);
+    return parseDurableRunCanaryRunSummary(response);
+  }
+
+  async function listMessagesForCanary(input: { conversationId: string }) {
+    const payload = await apiFetch(
+      `/conversations/${input.conversationId}/messages?limit=100`,
+      undefined,
+      (value) => getDurableRunCanaryMessageListSchema().parse(value),
+    );
+
+    return payload.data;
+  }
+
+  return {
+    createDurableRootRun,
+    getRunSummary,
+    listMessagesForCanary,
+    sendUserMessageForCanary,
+    startDurableRun,
+  };
+}
+
+/** Result returned from durable run canary. */
+export interface DurableRunCanaryResult {
+  id: string;
+  label: string;
+  status: "pass" | "fail";
+  details: string;
+  durationMs: number;
+  conversationId: string;
+  runId: string;
+  artifactPaths?: string[];
+}
+
+/** Public API contract for durable run canary prepared case. */
+export interface DurableRunCanaryPreparedCase {
+  artifactPaths?: string[] | ((runId: string) => string[]);
+  cleanup: (input?: { runId: string }) => Promise<void>;
+  conversationId: string;
+  prompt: string;
+  startSidecar?: () => Promise<(() => Promise<void>) | void>;
+  title: string;
+  validate: (input: {
+    messages: DurableRunCanaryMessage[];
+    run: DurableRunCanaryRunSummary;
+  }) => Promise<void> | void;
+}
+
+/** Public API contract for durable run canary case. */
+export interface DurableRunCanaryCase {
+  id: string;
+  label: string;
+  prepare: () => Promise<DurableRunCanaryPreparedCase>;
+}
+
+/** Configuration used by durable run canary runner. */
+export interface DurableRunCanaryRunnerConfig extends DurableRunCanaryApiConfig {
+  keepSuccessfulEvidence: boolean;
+}
+
+interface RunSummaryLocator {
+  conversationId: string;
+  runId: string;
+}
+
+interface WaitForRunInput extends RunSummaryLocator {
+  getRunSummary: (input: RunSummaryLocator) => Promise<DurableRunCanaryRunSummary>;
+}
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function collectChildConversationIdsFromValue(
+  value: unknown,
+  childConversationIds: Set<string>,
+  depth = 0,
+): void {
+  if (depth > 8) {
+    return;
+  }
+
+  if (typeof value === "string") {
+    try {
+      collectChildConversationIdsFromValue(JSON.parse(value), childConversationIds, depth + 1);
+    } catch {
+      return;
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectChildConversationIdsFromValue(entry, childConversationIds, depth + 1);
+    }
+    return;
+  }
+
+  if (!isRecord(value)) {
+    return;
+  }
+
+  for (const key of ["childConversationId", "child_conversation_id"]) {
+    const childConversationId = value[key];
+    if (typeof childConversationId === "string" && UUID_PATTERN.test(childConversationId)) {
+      childConversationIds.add(childConversationId);
+    }
+  }
+
+  for (const nestedValue of Object.values(value)) {
+    collectChildConversationIdsFromValue(nestedValue, childConversationIds, depth + 1);
+  }
+}
+
+function collectReferencedChildConversationIds(messages: DurableRunCanaryMessage[]): string[] {
+  const childConversationIds = new Set<string>();
+
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (!isRecord(part) || (part.type !== "tool_result" && part.type !== "tool-result")) {
+        continue;
+      }
+
+      collectChildConversationIdsFromValue(part.output, childConversationIds);
+    }
+  }
+
+  return [...childConversationIds];
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function isTerminalRunStatus(status: string): boolean {
+  return status === "completed" || status === "failed" || status === "cancelled";
+}
+
+function createDurableRunCanaryRunId(): string {
+  return `run_${crypto.randomUUID()}`;
+}
+
+async function waitForRunSummaryVisibility(
+  input: WaitForRunInput,
+): Promise<DurableRunCanaryRunSummary> {
+  const deadline = Date.now() + 30_000;
+
+  while (Date.now() < deadline) {
+    try {
+      return await input.getRunSummary(input);
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.includes(" 404 ")) {
+        throw error;
+      }
+    }
+
+    await sleep(500);
+  }
+
+  throw new Error(`Run ${input.runId} did not become visible in time`);
+}
+
+async function waitForTerminalRun(
+  input: WaitForRunInput & { requestTimeoutMs: number },
+): Promise<DurableRunCanaryRunSummary> {
+  const deadline = Date.now() + input.requestTimeoutMs;
+
+  while (Date.now() < deadline) {
+    const run = await input.getRunSummary(input);
+    if (isTerminalRunStatus(run.status)) {
+      return run;
+    }
+
+    await sleep(1_500);
+  }
+
+  throw new Error(`Timed out waiting for run ${input.runId} to reach a terminal state`);
+}
+
+/** Create durable run canary runner. */
+export function createDurableRunCanaryRunner(
+  config: DurableRunCanaryRunnerConfig,
+  apiClient: DurableRunCanaryApiClient = createDurableRunCanaryApiClient(config),
+) {
+  const getRunSummary = apiClient.getRunSummary;
+
+  async function listMessagesWithReferencedChildren(
+    conversationId: string,
+  ): Promise<DurableRunCanaryMessage[]> {
+    const messages = await apiClient.listMessagesForCanary({ conversationId });
+    const childConversationIds = collectReferencedChildConversationIds(messages);
+    const childMessages = await Promise.all(
+      childConversationIds.map((childConversationId) =>
+        apiClient.listMessagesForCanary({ conversationId: childConversationId })
+      ),
+    );
+
+    return [...messages, ...childMessages.flat()];
+  }
+
+  async function runCase(testCase: DurableRunCanaryCase): Promise<DurableRunCanaryResult> {
+    const startedAt = Date.now();
+    const prepared = await testCase.prepare();
+    let runId = "unknown";
+    const stopSidecar = await prepared.startSidecar?.();
+    const resolveArtifactPaths = (currentRunId: string): string[] | undefined =>
+      typeof prepared.artifactPaths === "function"
+        ? prepared.artifactPaths(currentRunId)
+        : prepared.artifactPaths;
+
+    try {
+      const userMessage = await apiClient.sendUserMessageForCanary({
+        conversationId: prepared.conversationId,
+        prompt: prepared.prompt,
+      });
+      runId = createDurableRunCanaryRunId();
+
+      await apiClient.createDurableRootRun({
+        conversationId: prepared.conversationId,
+        runId,
+      });
+      const visibleRun = await waitForRunSummaryVisibility({
+        conversationId: prepared.conversationId,
+        getRunSummary,
+        runId,
+      });
+
+      await apiClient.startDurableRun({
+        conversationId: prepared.conversationId,
+        messageId: visibleRun.messageId,
+        prompt: prepared.prompt,
+        runId,
+        userMessageId: userMessage.id,
+      });
+
+      const terminalRun = await waitForTerminalRun({
+        conversationId: prepared.conversationId,
+        getRunSummary,
+        requestTimeoutMs: config.requestTimeoutMs,
+        runId,
+      });
+      const messages = await listMessagesWithReferencedChildren(prepared.conversationId);
+
+      await prepared.validate({
+        messages,
+        run: terminalRun,
+      });
+
+      const artifactPaths = resolveArtifactPaths(runId);
+
+      if (!config.keepSuccessfulEvidence) {
+        await prepared.cleanup({ runId });
+      }
+
+      return {
+        id: testCase.id,
+        label: testCase.label,
+        status: "pass",
+        details: "OK",
+        durationMs: Date.now() - startedAt,
+        conversationId: prepared.conversationId,
+        runId,
+        ...(artifactPaths?.length ? { artifactPaths } : {}),
+      };
+    } catch (error) {
+      const artifactPaths = resolveArtifactPaths(runId);
+
+      return {
+        id: testCase.id,
+        label: testCase.label,
+        status: "fail",
+        details: error instanceof Error ? error.message : String(error),
+        durationMs: Date.now() - startedAt,
+        conversationId: prepared.conversationId,
+        runId,
+        ...(artifactPaths?.length ? { artifactPaths } : {}),
+      };
+    } finally {
+      await stopSidecar?.();
+    }
+  }
+
+  return {
+    runCase,
+  };
+}
+
+/** White-box helpers used by durable run canary tests. */
+export const durableRunCanaryRunnerInternals = {
+  collectReferencedChildConversationIds,
+  isTerminalRunStatus,
+};

--- a/src/eval/agent-service/durable-run-canaries/validation.ts
+++ b/src/eval/agent-service/durable-run-canaries/validation.ts
@@ -1,0 +1,91 @@
+import type { DurableRunCanaryMessage, DurableRunCanaryRunSummary } from "./runner.ts";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function getStringProperty(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" ? value : null;
+}
+
+function getToolCallName(part: Record<string, unknown>): string | null {
+  if (part.type === "tool_call") {
+    return getStringProperty(part, "name");
+  }
+
+  if (part.type === "tool-call") {
+    return getStringProperty(part, "toolName");
+  }
+
+  return null;
+}
+
+function hasCreateFileInput(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return getStringProperty(value, "path") !== null && getStringProperty(value, "content") !== null;
+}
+/** Assert that a durable run canary completed successfully. */
+export function assertCompleted(run: DurableRunCanaryRunSummary): void {
+  if (run.status !== "completed") {
+    throw new Error(
+      `Expected completed run, got ${run.status} (${run.terminalErrorCode ?? "no-code"}: ${
+        run.terminalErrorMessage ?? "no message"
+      })`,
+    );
+  }
+}
+
+/** Message shape for find assistant. */
+export function findAssistantMessage(
+  messages: DurableRunCanaryMessage[],
+  messageId: string,
+): DurableRunCanaryMessage {
+  const message = messages.find((candidate) => candidate.id === messageId);
+  if (!message) {
+    throw new Error(`Assistant message ${messageId} was not persisted`);
+  }
+  if (message.role !== "assistant") {
+    throw new Error(`Expected assistant message ${messageId}, got role ${message.role}`);
+  }
+  return message;
+}
+
+/** Stringify unknown helper. */
+export function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/** Collect assistant text helper. */
+export function collectAssistantText(message: DurableRunCanaryMessage): string {
+  return message.parts
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("\n");
+}
+
+/** Assert no malformed create file tool calls helper. */
+export function assertNoMalformedCreateFileToolCalls(messages: DurableRunCanaryMessage[]): void {
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (!isRecord(part) || getToolCallName(part) !== "create_file") {
+        continue;
+      }
+
+      if (!hasCreateFileInput(part.input)) {
+        throw new Error("Expected create_file tool_call input to include a path and content");
+      }
+    }
+  }
+}

--- a/src/eval/agent-service/live-evals/api-client.ts
+++ b/src/eval/agent-service/live-evals/api-client.ts
@@ -1,0 +1,591 @@
+import { ensureBuiltinSchemaValidator } from "#veryfront/extensions/builtin-extensions.ts";
+import type { InferSchema } from "#veryfront/extensions/schema/index.ts";
+import { defineSchema } from "#veryfront/schemas/index.ts";
+import type { LiveEvalProjectFile } from "./runner.ts";
+
+ensureBuiltinSchemaValidator();
+
+/** Context for live eval API. */
+export interface LiveEvalApiContext {
+  apiUrl: string;
+  authToken: string;
+  projectId: string | null;
+  fetch?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+}
+
+/** Input payload for live eval request timeout. */
+export interface LiveEvalRequestTimeoutInput {
+  requestTimeoutMs: number;
+}
+
+/** Input payload for live eval create conversation. */
+export interface LiveEvalCreateConversationInput extends LiveEvalRequestTimeoutInput {
+  title: string;
+}
+
+/** Input payload for live eval conversation. */
+export interface LiveEvalConversationInput extends LiveEvalRequestTimeoutInput {
+  conversationId: string;
+}
+
+/** Input payload for live eval project upload fixture. */
+export interface LiveEvalProjectUploadFixtureInput extends LiveEvalRequestTimeoutInput {
+  filePath: string;
+  contentType: string;
+  body: BodyInit | Uint8Array;
+  size?: number;
+  pollIntervalMs?: number;
+  maxAttempts?: number;
+}
+
+/** Input payload for live eval project file. */
+export interface LiveEvalProjectFileInput extends LiveEvalRequestTimeoutInput {
+  filePath: string;
+}
+
+/** Input payload for live eval create release. */
+export interface LiveEvalCreateReleaseInput extends LiveEvalRequestTimeoutInput {
+  description?: string;
+}
+
+/** Input payload for live eval wait for open input request. */
+export interface LiveEvalWaitForOpenInputRequestInput extends LiveEvalConversationInput {
+  abortSignal: AbortSignal;
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+}
+
+/** Public API contract for live eval input response values. */
+export interface LiveEvalInputResponseValues {
+  [key: string]: string | boolean | number | null;
+}
+
+/** Input payload for live eval submit input response. */
+export interface LiveEvalSubmitInputResponseInput extends LiveEvalRequestTimeoutInput {
+  conversationId: string;
+  inputRequestId: string;
+  values: LiveEvalInputResponseValues;
+}
+
+/** Input payload for live eval input request. */
+export interface LiveEvalInputRequestInput extends LiveEvalRequestTimeoutInput {
+  conversationId: string;
+  inputRequestId: string;
+}
+
+const getLiveEvalIdResponseSchema = defineSchema((v) =>
+  v.object({
+    id: v.string().optional(),
+  })
+);
+
+const getProjectUploadResponseSchema = defineSchema((v) =>
+  v.object({
+    file_upload_url: v.string().optional(),
+    required_headers: v.record(v.string(), v.string()).optional(),
+  })
+);
+
+const getProjectUploadListResponseSchema = defineSchema((v) =>
+  v.object({
+    data: v.array(v.object({ path: v.string().optional() }).passthrough()).optional(),
+  })
+);
+
+const getProjectFileResponseSchema = defineSchema((v) =>
+  v.object({
+    path: v.string().optional(),
+    content: v.string().optional(),
+  })
+);
+
+const getInputRequestRecordSchema = defineSchema((v) =>
+  v.object({
+    id: v.string(),
+    status: v.string(),
+  })
+);
+
+const getInputRequestListResponseSchema = defineSchema((v) =>
+  v.object({
+    data: v.array(v.unknown()).optional(),
+  })
+);
+
+/** Record shape for live eval input request. */
+export type LiveEvalInputRequestRecord = InferSchema<
+  ReturnType<typeof getInputRequestRecordSchema>
+>;
+
+/** Public API contract for live eval API client. */
+export interface LiveEvalApiClient {
+  createConversation(input: LiveEvalCreateConversationInput): Promise<string>;
+  deleteConversation(input: LiveEvalConversationInput): Promise<void>;
+  createProjectUploadFixture(input: LiveEvalProjectUploadFixtureInput): Promise<string>;
+  getProjectFile(input: LiveEvalProjectFileInput): Promise<LiveEvalProjectFile | null>;
+  createRelease(input: LiveEvalCreateReleaseInput): Promise<string>;
+  deleteProjectFile(input: LiveEvalProjectFileInput): Promise<void>;
+  listOpenInputRequests(input: LiveEvalConversationInput): Promise<LiveEvalInputRequestRecord[]>;
+  waitForOpenInputRequest(input: LiveEvalWaitForOpenInputRequestInput): Promise<string>;
+  submitInputResponse(input: LiveEvalSubmitInputResponseInput): Promise<void>;
+  cancelInputRequest(input: LiveEvalInputRequestInput): Promise<void>;
+}
+
+function createLiveEvalAuthHeaders(context: LiveEvalApiContext): Headers {
+  const headers = new Headers();
+  headers.set("Authorization", `Bearer ${context.authToken}`);
+  return headers;
+}
+
+function createLiveEvalJsonHeaders(context: LiveEvalApiContext): Headers {
+  const headers = createLiveEvalAuthHeaders(context);
+  headers.set("Content-Type", "application/json");
+  return headers;
+}
+
+function requireLiveEvalProjectId(projectId: string | null, errorMessage: string): string {
+  if (!projectId) {
+    throw new Error(errorMessage);
+  }
+
+  return projectId;
+}
+
+function createFetch(context: LiveEvalApiContext) {
+  return context.fetch ?? fetch;
+}
+
+function createApiUrl(context: LiveEvalApiContext, path: string): URL {
+  const baseHref = context.apiUrl.endsWith("/") ? context.apiUrl : `${context.apiUrl}/`;
+  const relativePath = path.startsWith("/") ? path.slice(1) : path;
+  return new URL(relativePath, baseHref);
+}
+
+function createProjectUploadHeaders(
+  requiredHeaders: Record<string, string> | undefined,
+  contentType: string,
+): Headers {
+  const uploadHeaders = new Headers(requiredHeaders);
+  if (!uploadHeaders.has("Content-Type")) {
+    uploadHeaders.set("Content-Type", contentType);
+  }
+
+  return uploadHeaders;
+}
+
+function getProjectUploadBodySize(
+  body: BodyInit | Uint8Array,
+  explicitSize: number | undefined,
+): number {
+  if (typeof explicitSize === "number") {
+    return explicitSize;
+  }
+  if (typeof body === "string") {
+    return new TextEncoder().encode(body).byteLength;
+  }
+  if (body instanceof Blob) {
+    return body.size;
+  }
+  if (body instanceof URLSearchParams) {
+    return new TextEncoder().encode(body.toString()).byteLength;
+  }
+  if (body instanceof ArrayBuffer) {
+    return body.byteLength;
+  }
+  if (ArrayBuffer.isView(body)) {
+    return body.byteLength;
+  }
+  throw new Error("Project upload fixtures require size when body length cannot be inferred");
+}
+
+function createProjectUploadBody(body: BodyInit | Uint8Array, contentType: string): BodyInit {
+  if (body instanceof Blob) {
+    return body;
+  }
+  if (typeof body === "string") {
+    return new Blob([body], { type: contentType });
+  }
+  if (body instanceof Uint8Array) {
+    return new Blob([body.slice()], { type: contentType });
+  }
+  return body;
+}
+
+function getResponseText(response: Response): Promise<string> {
+  return response.text();
+}
+
+async function wait(input: { ms: number }): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, input.ms);
+  });
+}
+
+async function waitForProjectUploadFixture(
+  context: LiveEvalApiContext,
+  input: {
+    projectId: string;
+    filePath: string;
+    requestTimeoutMs: number;
+    pollIntervalMs?: number;
+    maxAttempts?: number;
+  },
+): Promise<string> {
+  const listUrl = createApiUrl(context, `/projects/${input.projectId}/uploads`);
+  const requestFetch = createFetch(context);
+  const maxAttempts = input.maxAttempts ?? 12;
+  const pollIntervalMs = input.pollIntervalMs ?? 2_000;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const listResponse = await requestFetch(listUrl, {
+      headers: createLiveEvalAuthHeaders(context),
+      signal: AbortSignal.timeout(input.requestTimeoutMs),
+    });
+
+    if (!listResponse.ok) {
+      throw new Error(
+        `Failed to confirm project upload fixture: ${listResponse.status} ${await getResponseText(
+          listResponse,
+        )}`,
+      );
+    }
+
+    const payload = getProjectUploadListResponseSchema().parse(await listResponse.json());
+    if (payload.data?.some((upload) => upload.path === input.filePath)) {
+      return input.filePath;
+    }
+
+    if (attempt + 1 < maxAttempts) {
+      await wait({ ms: pollIntervalMs });
+    }
+  }
+
+  throw new Error(`Project upload fixture did not appear in time: ${input.filePath}`);
+}
+
+/** Create live eval API client. */
+export function createLiveEvalApiClient(context: LiveEvalApiContext): LiveEvalApiClient {
+  return {
+    createConversation: (input) => createLiveEvalConversation(context, input),
+    deleteConversation: (input) => deleteLiveEvalConversation(context, input),
+    createProjectUploadFixture: (input) => createLiveEvalProjectUploadFixture(context, input),
+    getProjectFile: (input) => getLiveEvalProjectFile(context, input),
+    createRelease: (input) => createLiveEvalRelease(context, input),
+    deleteProjectFile: (input) => deleteLiveEvalProjectFile(context, input),
+    listOpenInputRequests: (input) => listOpenLiveEvalInputRequests(context, input),
+    waitForOpenInputRequest: (input) => waitForOpenLiveEvalInputRequest(context, input),
+    submitInputResponse: (input) => submitLiveEvalInputResponse(context, input),
+    cancelInputRequest: (input) => cancelLiveEvalInputRequest(context, input),
+  } satisfies LiveEvalApiClient;
+}
+
+/** Create live eval conversation. */
+export async function createLiveEvalConversation(
+  context: LiveEvalApiContext,
+  input: LiveEvalCreateConversationInput,
+): Promise<string> {
+  const response = await createFetch(context)(createApiUrl(context, "/conversations"), {
+    method: "POST",
+    headers: createLiveEvalJsonHeaders(context),
+    body: JSON.stringify({
+      ...(context.projectId ? { project_id: context.projectId } : {}),
+      title: input.title,
+    }),
+    signal: AbortSignal.timeout(input.requestTimeoutMs),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to create eval conversation: ${response.status} ${await getResponseText(response)}`,
+    );
+  }
+
+  const payload = getLiveEvalIdResponseSchema().parse(await response.json());
+  if (!payload.id) {
+    throw new Error("Conversation creation response did not include id");
+  }
+
+  return payload.id;
+}
+
+/** Delete live eval conversation helper. */
+export async function deleteLiveEvalConversation(
+  context: LiveEvalApiContext,
+  input: LiveEvalConversationInput,
+): Promise<void> {
+  const response = await createFetch(context)(
+    createApiUrl(context, `/conversations/${input.conversationId}`),
+    {
+      method: "DELETE",
+      headers: createLiveEvalAuthHeaders(context),
+      signal: AbortSignal.timeout(input.requestTimeoutMs),
+    },
+  );
+
+  if (!response.ok && response.status !== 404) {
+    throw new Error(
+      `Failed to delete eval conversation ${input.conversationId}: ${response.status} ${await getResponseText(
+        response,
+      )}`,
+    );
+  }
+}
+
+/** Create live eval project upload fixture. */
+export async function createLiveEvalProjectUploadFixture(
+  context: LiveEvalApiContext,
+  input: LiveEvalProjectUploadFixtureInput,
+): Promise<string> {
+  const projectId = requireLiveEvalProjectId(
+    context.projectId,
+    "Project upload fixtures require a live-eval project id",
+  );
+
+  const createResponse = await createFetch(context)(
+    createApiUrl(context, `/projects/${projectId}/uploads`),
+    {
+      method: "POST",
+      headers: createLiveEvalJsonHeaders(context),
+      body: JSON.stringify({
+        file_path: input.filePath,
+        content_type: input.contentType,
+        size: getProjectUploadBodySize(input.body, input.size),
+      }),
+      signal: AbortSignal.timeout(input.requestTimeoutMs),
+    },
+  );
+
+  if (!createResponse.ok) {
+    throw new Error(
+      `Failed to create project upload URL: ${createResponse.status} ${await getResponseText(
+        createResponse,
+      )}`,
+    );
+  }
+
+  const createPayload = getProjectUploadResponseSchema().parse(await createResponse.json());
+  if (!createPayload.file_upload_url) {
+    throw new Error("Project upload response did not include file_upload_url");
+  }
+
+  const uploadResponse = await createFetch(context)(createPayload.file_upload_url, {
+    method: "PUT",
+    headers: createProjectUploadHeaders(createPayload.required_headers, input.contentType),
+    body: createProjectUploadBody(input.body, input.contentType),
+    signal: AbortSignal.timeout(input.requestTimeoutMs),
+  });
+
+  if (!uploadResponse.ok) {
+    throw new Error(
+      `Failed to upload project fixture: ${uploadResponse.status} ${await getResponseText(
+        uploadResponse,
+      )}`,
+    );
+  }
+
+  return waitForProjectUploadFixture(context, {
+    projectId,
+    filePath: input.filePath,
+    requestTimeoutMs: input.requestTimeoutMs,
+    pollIntervalMs: input.pollIntervalMs,
+    maxAttempts: input.maxAttempts,
+  });
+}
+
+/** Return live eval project file. */
+export async function getLiveEvalProjectFile(
+  context: LiveEvalApiContext,
+  input: LiveEvalProjectFileInput,
+): Promise<LiveEvalProjectFile | null> {
+  const projectId = requireLiveEvalProjectId(
+    context.projectId,
+    "getLiveEvalProjectFile requires a live-eval project id",
+  );
+  const response = await createFetch(context)(
+    createApiUrl(context, `/projects/${projectId}/files/${encodeURIComponent(input.filePath)}`),
+    {
+      headers: createLiveEvalAuthHeaders(context),
+      signal: AbortSignal.timeout(input.requestTimeoutMs),
+    },
+  );
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to read project file: ${response.status} ${await getResponseText(response)}`,
+    );
+  }
+
+  const payload = getProjectFileResponseSchema().parse(await response.json());
+  return {
+    path: payload.path ?? input.filePath,
+    content: payload.content ?? "",
+  };
+}
+
+/** Create live eval release. */
+export async function createLiveEvalRelease(
+  context: LiveEvalApiContext,
+  input: LiveEvalCreateReleaseInput,
+): Promise<string> {
+  const projectId = requireLiveEvalProjectId(
+    context.projectId,
+    "createLiveEvalRelease requires a live-eval project id",
+  );
+  const response = await createFetch(context)(
+    createApiUrl(context, `/projects/${projectId}/releases`),
+    {
+      method: "POST",
+      headers: createLiveEvalJsonHeaders(context),
+      body: JSON.stringify({
+        description: input.description ?? "eval platform capability release",
+      }),
+      signal: AbortSignal.timeout(input.requestTimeoutMs),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to create release: ${response.status} ${await getResponseText(response)}`,
+    );
+  }
+
+  const payload = getLiveEvalIdResponseSchema().parse(await response.json());
+  if (!payload.id) {
+    throw new Error("Release creation response did not include id");
+  }
+
+  return payload.id;
+}
+
+/** Delete live eval project file helper. */
+export async function deleteLiveEvalProjectFile(
+  context: LiveEvalApiContext,
+  input: LiveEvalProjectFileInput,
+): Promise<void> {
+  const projectId = context.projectId;
+  if (!projectId) {
+    return;
+  }
+
+  const response = await createFetch(context)(
+    createApiUrl(context, `/projects/${projectId}/files/${encodeURIComponent(input.filePath)}`),
+    {
+      method: "DELETE",
+      headers: createLiveEvalAuthHeaders(context),
+      signal: AbortSignal.timeout(input.requestTimeoutMs),
+    },
+  );
+
+  if (!response.ok && response.status !== 404) {
+    throw new Error(
+      `Failed to delete project file: ${response.status} ${await getResponseText(response)}`,
+    );
+  }
+}
+
+/** List open live eval input requests. */
+export async function listOpenLiveEvalInputRequests(
+  context: LiveEvalApiContext,
+  input: LiveEvalConversationInput,
+): Promise<LiveEvalInputRequestRecord[]> {
+  const response = await createFetch(context)(
+    createApiUrl(context, `/conversations/${input.conversationId}/input-requests?status=open`),
+    {
+      headers: createLiveEvalAuthHeaders(context),
+      signal: AbortSignal.timeout(input.requestTimeoutMs),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to list eval input requests: ${response.status} ${await getResponseText(response)}`,
+    );
+  }
+
+  const payload = getInputRequestListResponseSchema().parse(await response.json());
+  return (payload.data ?? []).flatMap((item) => {
+    const parsed = getInputRequestRecordSchema().safeParse(item);
+    return parsed.success ? [parsed.data] : [];
+  });
+}
+
+/** Request payload for wait for open live eval input. */
+export async function waitForOpenLiveEvalInputRequest(
+  context: LiveEvalApiContext,
+  input: LiveEvalWaitForOpenInputRequestInput,
+): Promise<string> {
+  const timeoutMs = input.timeoutMs ?? 30_000;
+  const pollIntervalMs = input.pollIntervalMs ?? 500;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (input.abortSignal.aborted) {
+      throw new Error("Eval sidecar aborted before an input request appeared");
+    }
+
+    const requests = await listOpenLiveEvalInputRequests(context, input);
+    const request = requests[0];
+    if (request) {
+      return request.id;
+    }
+
+    await wait({ ms: pollIntervalMs });
+  }
+
+  throw new Error(
+    `Timed out while waiting for an open input request in conversation ${input.conversationId}`,
+  );
+}
+
+/** Response payload for submit live eval input. */
+export async function submitLiveEvalInputResponse(
+  context: LiveEvalApiContext,
+  input: LiveEvalSubmitInputResponseInput,
+): Promise<void> {
+  const response = await createFetch(context)(
+    createApiUrl(
+      context,
+      `/conversations/${input.conversationId}/input-requests/${input.inputRequestId}/responses`,
+    ),
+    {
+      method: "POST",
+      headers: createLiveEvalJsonHeaders(context),
+      body: JSON.stringify({ values: input.values }),
+      signal: AbortSignal.timeout(input.requestTimeoutMs),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to submit eval input response: ${response.status} ${await getResponseText(response)}`,
+    );
+  }
+}
+
+/** Request payload for cancel live eval input. */
+export async function cancelLiveEvalInputRequest(
+  context: LiveEvalApiContext,
+  input: LiveEvalInputRequestInput,
+): Promise<void> {
+  const response = await createFetch(context)(
+    createApiUrl(
+      context,
+      `/conversations/${input.conversationId}/input-requests/${input.inputRequestId}/cancel`,
+    ),
+    {
+      method: "POST",
+      headers: createLiveEvalAuthHeaders(context),
+      signal: AbortSignal.timeout(input.requestTimeoutMs),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to cancel eval input request: ${response.status} ${await getResponseText(response)}`,
+    );
+  }
+}

--- a/src/eval/agent-service/live-evals/cli-runner.ts
+++ b/src/eval/agent-service/live-evals/cli-runner.ts
@@ -1,0 +1,238 @@
+import { mkdir, writeTextFile } from "#veryfront/platform/compat/fs.ts";
+import { dirname, resolve } from "#veryfront/platform/compat/path/index.ts";
+import { cwd as getProcessCwd } from "#veryfront/platform/compat/process.ts";
+import { buildRuntimePerformanceSummary, type LiveEvalRuntime } from "./performance.ts";
+import {
+  buildLiveEvalCaseTagSummary,
+  buildLiveEvalRuntimeSummary,
+  buildLiveEvalStatusSummary,
+  resolveLiveEvalRequestedCaseIds,
+  selectLiveEvalCases,
+} from "./report.ts";
+import {
+  containsSkillLoad,
+  countStepStartedEvents,
+  createLiveEvalCaseSupport,
+  hasFinished,
+  type LiveEvalCase,
+  type LiveEvalRunnerConfig,
+} from "./runner.ts";
+import { getLiveEvalProjectFile, type LiveEvalApiContext } from "./api-client.ts";
+import { resolveLiveEvalEnvironment } from "./environment.ts";
+import type { LiveEvalResultRecord } from "./result.ts";
+
+type EnvRecord = Record<string, string | undefined>;
+
+/** Public API contract for live eval cli case groups. */
+export interface LiveEvalCliCaseGroups {
+  readOnlyCases: LiveEvalCase[];
+  writeCases: LiveEvalCase[];
+  experimentalWriteCases: LiveEvalCase[];
+}
+
+/** Input payload for live eval cli case factory. */
+export interface LiveEvalCliCaseFactoryInput {
+  authToken: string;
+  endpoint: string;
+  projectId: string | null;
+  branchId: string | null;
+  model: string | null;
+  requestTimeoutMs: number;
+  enableLlmJudge: boolean;
+  hasFinished: typeof hasFinished;
+  containsSkillLoad: typeof containsSkillLoad;
+  countStepStartedEvents: typeof countStepStartedEvents;
+  verifyFileExists: ReturnType<typeof createLiveEvalCaseSupport>["verifyFileExists"];
+  withJudge: ReturnType<typeof createLiveEvalCaseSupport>["withJudge"];
+  judgeLlm: ReturnType<typeof createLiveEvalCaseSupport>["judgeLlm"];
+}
+
+/** Input payload for run live eval cli. */
+export interface RunLiveEvalCliInput {
+  env: EnvRecord;
+  caseSets: Record<string, readonly string[]>;
+  createCases: (input: LiveEvalCliCaseFactoryInput) => LiveEvalCliCaseGroups;
+  runtimes?: readonly LiveEvalRuntime[];
+  cwd?: string;
+  log?: (message: string) => void;
+  error?: (message: string) => void;
+  createCaseSupport?: (
+    config: LiveEvalRunnerConfig,
+  ) => ReturnType<typeof createLiveEvalCaseSupport>;
+}
+
+function splitCsvEnv(value: string | undefined): Set<string> {
+  return new Set(
+    (value ?? "")
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0),
+  );
+}
+
+function createTimestampedReportPath(input: {
+  cwd: string;
+  directory: string;
+}): string {
+  return resolve(
+    input.cwd,
+    ".omx/logs",
+    input.directory,
+    `${new Date().toISOString().replaceAll(":", "-").replaceAll(".", "-")}.json`,
+  );
+}
+
+/** Run live eval cli. */
+export async function runLiveEvalCli(input: RunLiveEvalCliInput): Promise<number> {
+  const log = input.log ?? console.log;
+  const error = input.error ?? console.error;
+  const cwd = input.cwd ?? getProcessCwd();
+  const { endpoint, authToken, apiUrl, projectId, branchId, model } = resolveLiveEvalEnvironment(
+    input.env,
+  );
+  const requestedRuntimeSelection = input.runtimes ?? ["framework"];
+  const runWriteEvals = input.env.AG_UI_EVAL_WRITE === "1";
+  const runExperimentalWriteEvals = input.env.AG_UI_EVAL_EXPERIMENTAL === "1";
+  const requestTimeoutMs = Number(input.env.AG_UI_EVAL_TIMEOUT_MS ?? "240000");
+  const progressLogIntervalMs = Number(input.env.AG_UI_EVAL_PROGRESS_MS ?? "15000");
+  const reportPath = input.env.AG_UI_EVAL_REPORT_PATH ??
+    createTimestampedReportPath({ cwd, directory: "ag-ui-live-evals" });
+  const requestedCaseIds = splitCsvEnv(input.env.AG_UI_EVAL_CASES);
+  const requestedCaseTags = splitCsvEnv(input.env.AG_UI_EVAL_TAGS);
+  const requestedCaseSetId = input.env.AG_UI_EVAL_CASE_SET?.trim() || null;
+  const enableLlmJudge = input.env.AG_UI_EVAL_LLM_JUDGE === "1";
+
+  const apiContext: LiveEvalApiContext = {
+    apiUrl,
+    authToken,
+    projectId: projectId ?? null,
+  };
+  const createCaseSupport = input.createCaseSupport ?? createLiveEvalCaseSupport;
+  const { judgeLlm, runEval, verifyFileExists, withJudge } = createCaseSupport({
+    endpoint,
+    authToken,
+    apiUrl,
+    projectId: projectId ?? null,
+    branchId: branchId ?? null,
+    model: model ?? null,
+    requestTimeoutMs,
+    progressLogIntervalMs,
+    enableLlmJudge,
+    readProjectFile: (readerInput) => getLiveEvalProjectFile(apiContext, readerInput),
+  });
+
+  const { readOnlyCases, writeCases, experimentalWriteCases } = input.createCases({
+    authToken,
+    endpoint,
+    projectId: projectId ?? null,
+    branchId: branchId ?? null,
+    model: model ?? null,
+    requestTimeoutMs,
+    enableLlmJudge,
+    hasFinished,
+    containsSkillLoad,
+    countStepStartedEvents,
+    verifyFileExists,
+    withJudge,
+    judgeLlm,
+  });
+
+  if (authToken.length === 0) {
+    error("Missing VERYFRONT_TOKEN");
+    return 1;
+  }
+
+  log(`AG-UI live evals -> ${endpoint}`);
+  log(`Veryfront API -> ${apiUrl}`);
+  log(`Project scope -> ${projectId ?? "none"}`);
+  log(`Runtime -> ${requestedRuntimeSelection.join(", ")}`);
+  log(`Write evals -> ${runWriteEvals ? "enabled" : "disabled"}`);
+  log(`Experimental evals -> ${runExperimentalWriteEvals ? "enabled" : "disabled"}`);
+  log(`Case set -> ${requestedCaseSetId ?? "none"}`);
+  log(`Case tags -> ${requestedCaseTags.size > 0 ? [...requestedCaseTags].join(", ") : "none"}`);
+
+  const allCases = [...readOnlyCases, ...writeCases, ...experimentalWriteCases];
+  const resolvedRequestedCaseIds = resolveLiveEvalRequestedCaseIds({
+    caseSets: input.caseSets,
+    requestedCaseIds,
+    requestedCaseSetId,
+  });
+  const cases = selectLiveEvalCases({
+    allCases,
+    readOnlyCases,
+    writeCases,
+    experimentalWriteCases,
+    requestedCaseIds: resolvedRequestedCaseIds,
+    requestedCaseTags,
+    runWriteEvals,
+    runExperimentalWriteEvals,
+  });
+  const selectedCaseTagSummary = buildLiveEvalCaseTagSummary(cases);
+
+  if (cases.length === 0) {
+    error("No eval cases selected.");
+    return 1;
+  }
+
+  const results: LiveEvalResultRecord[] = [];
+
+  for (const runtime of requestedRuntimeSelection) {
+    log(`\n[runtime] ${runtime}`);
+    for (const testCase of cases) {
+      log(`\n[run] ${runtime} :: ${testCase.label}`);
+      const result = await runEval(testCase, runtime);
+      results.push(result);
+      log(`[${runtime}] [${result.status}] ${result.details}`);
+    }
+  }
+
+  const summary = buildLiveEvalStatusSummary(results);
+  const runtimeSummary = buildLiveEvalRuntimeSummary(requestedRuntimeSelection, results);
+  const runtimePerformanceSummary = buildRuntimePerformanceSummary(results);
+
+  log("\nSummary");
+  log(`passed: ${summary.passed}`);
+  log(`failed: ${summary.failed}`);
+  log(`skipped: ${summary.skipped}`);
+  for (const runtime of requestedRuntimeSelection) {
+    const currentRuntimeSummary = runtimeSummary[runtime];
+    log(
+      `${runtime}: passed=${currentRuntimeSummary.passed} failed=${currentRuntimeSummary.failed} skipped=${currentRuntimeSummary.skipped}`,
+    );
+    const performance = runtimePerformanceSummary[runtime];
+    log(
+      `${runtime}: avg=${performance.avgDurationMs}ms p50=${performance.p50DurationMs}ms p95=${performance.p95DurationMs}ms min=${performance.minDurationMs}ms max=${performance.maxDurationMs}ms`,
+    );
+  }
+
+  await mkdir(dirname(reportPath), { recursive: true });
+  await writeTextFile(
+    reportPath,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        endpoint,
+        apiUrl,
+        projectId: projectId ?? null,
+        runtimes: requestedRuntimeSelection,
+        writeEvals: runWriteEvals,
+        requestedCaseIds: [...resolvedRequestedCaseIds],
+        requestedCaseTags: [...requestedCaseTags],
+        requestedCaseSetId,
+        caseMetadata: Object.fromEntries(
+          cases.map((testCase) => [testCase.id, testCase.metadata ?? { tags: [] }]),
+        ),
+        selectedCaseTagSummary,
+        results,
+        summary,
+        runtimeSummary,
+        runtimePerformanceSummary,
+      },
+      null,
+      2,
+    ),
+  );
+  log(`report: ${reportPath}`);
+
+  return summary.failed > 0 ? 1 : 0;
+}

--- a/src/eval/agent-service/live-evals/environment.ts
+++ b/src/eval/agent-service/live-evals/environment.ts
@@ -1,0 +1,37 @@
+import {
+  type AgentServiceConfigInput,
+  parseAgentServiceConfig,
+} from "../../../agent/service/config.ts";
+
+/** Public API contract for live eval environment. */
+export interface LiveEvalEnvironment {
+  endpoint: string;
+  authToken: string;
+  apiUrl: string;
+  projectId: string | undefined;
+  branchId: string | undefined;
+  model: string | undefined;
+}
+
+/** Default value for live eval endpoint. */
+export const DEFAULT_LIVE_EVAL_ENDPOINT = "http://127.0.0.1:3001/api/ag-ui";
+
+/** Resolves live eval environment. */
+export function resolveLiveEvalEnvironment(
+  env: AgentServiceConfigInput = {},
+): LiveEvalEnvironment {
+  return {
+    endpoint: typeof env.AG_UI_EVAL_ENDPOINT === "string"
+      ? env.AG_UI_EVAL_ENDPOINT
+      : DEFAULT_LIVE_EVAL_ENDPOINT,
+    authToken: typeof env.VERYFRONT_TOKEN === "string" ? env.VERYFRONT_TOKEN : "",
+    apiUrl: typeof env.VERYFRONT_API_URL === "string"
+      ? env.VERYFRONT_API_URL
+      : parseAgentServiceConfig(env).VERYFRONT_API_URL,
+    projectId: typeof env.AG_UI_EVAL_PROJECT_ID === "string"
+      ? env.AG_UI_EVAL_PROJECT_ID
+      : undefined,
+    branchId: typeof env.AG_UI_EVAL_BRANCH_ID === "string" ? env.AG_UI_EVAL_BRANCH_ID : undefined,
+    model: typeof env.AG_UI_EVAL_MODEL === "string" ? env.AG_UI_EVAL_MODEL : undefined,
+  };
+}

--- a/src/eval/agent-service/live-evals/formatting.ts
+++ b/src/eval/agent-service/live-evals/formatting.ts
@@ -1,0 +1,110 @@
+import { Buffer } from "node:buffer";
+import type { AgUiSseProgressSnapshot as EvalProgressSnapshot } from "#veryfront/agent";
+
+function escapePdfText(input: string): string {
+  return input.replaceAll("\\", "\\\\").replaceAll("(", "\\(").replaceAll(
+    ")",
+    "\\)",
+  );
+}
+
+/** Create plain text pdf. */
+export function createPlainTextPdf(lines: string[]): Buffer {
+  const contentLines = [
+    "BT",
+    "/F1 18 Tf",
+    "72 720 Td",
+    `(${escapePdfText(lines[0] ?? "Untitled")}) Tj`,
+    "/F1 12 Tf",
+    ...lines.slice(1).flatMap((
+      line,
+    ) => ["0 -20 Td", `(${escapePdfText(line)}) Tj`]),
+    "ET",
+  ];
+  const contentStream = contentLines.join("\n");
+
+  const objects = [
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
+    `<< /Length ${
+      Buffer.byteLength(contentStream, "utf8")
+    } >>\nstream\n${contentStream}\nendstream`,
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+  ];
+
+  let pdf = "%PDF-1.4\n";
+  const offsets = [0];
+
+  objects.forEach((objectBody, index) => {
+    offsets.push(Buffer.byteLength(pdf, "utf8"));
+    pdf += `${index + 1} 0 obj\n${objectBody}\nendobj\n`;
+  });
+
+  const xrefOffset = Buffer.byteLength(pdf, "utf8");
+  pdf += `xref\n0 ${objects.length + 1}\n`;
+  pdf += "0000000000 65535 f \n";
+
+  offsets.slice(1).forEach((offset) => {
+    pdf += `${offset.toString().padStart(10, "0")} 00000 n \n`;
+  });
+
+  pdf += `trailer\n<< /Root 1 0 R /Size ${
+    objects.length + 1
+  } >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+  return Buffer.from(pdf, "utf8");
+}
+
+/** Builds progress line. */
+export function buildProgressLine(input: {
+  caseId: string;
+  startedAt: number;
+  progress: EvalProgressSnapshot;
+}): string {
+  const elapsedSeconds = Math.max(
+    1,
+    Math.round((Date.now() - input.startedAt) / 1000),
+  );
+  const lastEvent = input.progress.lastEventType ?? "none";
+  const lastTool = input.progress.lastToolCallName
+    ? ` tool=${input.progress.lastToolCallName}`
+    : "";
+  const toolSummary = input.progress.toolStarts.length > 0
+    ? ` tools=${input.progress.toolStarts.join(",")}`
+    : "";
+  const textSummary = input.progress.textLength > 0 ? ` text=${input.progress.textLength}ch` : "";
+  return `[progress] ${input.caseId} ${elapsedSeconds}s events=${input.progress.eventCount} last=${lastEvent}${lastTool}${toolSummary}${textSummary}`;
+}
+
+/** Builds failure suffix. */
+export function buildFailureSuffix(progress: EvalProgressSnapshot): string {
+  const details = [
+    `events=${progress.eventCount}`,
+    `last=${progress.lastEventType ?? "none"}`,
+    progress.lastToolCallName ? `tool=${progress.lastToolCallName}` : null,
+    progress.toolStarts.length > 0 ? `tools=${progress.toolStarts.join(",")}` : null,
+    progress.textLength > 0 ? `text=${progress.textLength}ch` : null,
+  ].filter((value) => value !== null);
+
+  return details.length > 0 ? ` Progress: ${details.join(" ")}` : "";
+}
+
+/** Contains ordered subsequence helper. */
+export function containsOrderedSubsequence(
+  haystack: string[],
+  needle: string[],
+): boolean {
+  let cursor = 0;
+
+  for (const value of haystack) {
+    if (value === needle[cursor]) {
+      cursor += 1;
+    }
+
+    if (cursor === needle.length) {
+      return true;
+    }
+  }
+
+  return cursor === needle.length;
+}

--- a/src/eval/agent-service/live-evals/index.ts
+++ b/src/eval/agent-service/live-evals/index.ts
@@ -1,0 +1,99 @@
+export {
+  type LiveEvalCliCaseFactoryInput,
+  type LiveEvalCliCaseGroups,
+  runLiveEvalCli,
+  type RunLiveEvalCliInput,
+} from "./cli-runner.ts";
+export {
+  DEFAULT_LIVE_EVAL_ENDPOINT,
+  type LiveEvalEnvironment,
+  resolveLiveEvalEnvironment,
+} from "./environment.ts";
+export {
+  cancelLiveEvalInputRequest,
+  createLiveEvalApiClient,
+  createLiveEvalConversation,
+  createLiveEvalProjectUploadFixture,
+  createLiveEvalRelease,
+  deleteLiveEvalConversation,
+  deleteLiveEvalProjectFile,
+  getLiveEvalProjectFile,
+  listOpenLiveEvalInputRequests,
+  type LiveEvalApiClient,
+  type LiveEvalApiContext,
+  type LiveEvalConversationInput,
+  type LiveEvalCreateConversationInput,
+  type LiveEvalCreateReleaseInput,
+  type LiveEvalInputRequestInput,
+  type LiveEvalInputRequestRecord,
+  type LiveEvalInputResponseValues,
+  type LiveEvalProjectFileInput,
+  type LiveEvalProjectUploadFixtureInput,
+  type LiveEvalRequestTimeoutInput,
+  type LiveEvalSubmitInputResponseInput,
+  type LiveEvalWaitForOpenInputRequestInput,
+  submitLiveEvalInputResponse,
+  waitForOpenLiveEvalInputRequest,
+} from "./api-client.ts";
+export {
+  buildFailureSuffix,
+  buildProgressLine,
+  containsOrderedSubsequence,
+  createPlainTextPdf,
+} from "./formatting.ts";
+export {
+  evaluateRuntimeConfidenceEnv,
+  printRuntimeConfidencePreflight,
+  type RuntimeConfidencePreflightResult,
+} from "./preflight.ts";
+export {
+  buildRuntimePerformanceSummary,
+  type LiveEvalResultForPerformance,
+  type LiveEvalRuntime,
+  type RuntimePerformanceSummary,
+} from "./performance.ts";
+export {
+  buildLiveEvalCaseMetadata,
+  type BuildLiveEvalCaseMetadataInput,
+  DEFAULT_LIVE_EVAL_AREA_TAG_RULES,
+  DEFAULT_LIVE_EVAL_OPTIONAL_JUDGE_CASE_PREFIXES,
+  type LiveEvalCaseMetadataOptions,
+  type LiveEvalCaseSurface,
+  type LiveEvalCaseTagRule,
+  withLiveEvalMetadata,
+} from "./metadata.ts";
+export {
+  buildLiveEvalRequestBody,
+  type BuildLiveEvalRequestBodyInput,
+  type LiveEvalRequestBody,
+} from "./request.ts";
+export {
+  buildLiveEvalCaseTagSummary,
+  buildLiveEvalRuntimeSummary,
+  buildLiveEvalStatusSummary,
+  hasEveryLiveEvalTag,
+  type LiveEvalCaseMetadata,
+  type LiveEvalCaseSelectionInput,
+  type LiveEvalResultForReport,
+  resolveLiveEvalRequestedCaseIds,
+  selectLiveEvalCases,
+} from "./report.ts";
+export {
+  createFailedEvalResult,
+  createPassedEvalResult,
+  createSkippedEvalResult,
+  type LiveEvalResultRecord,
+} from "./result.ts";
+export {
+  containsSkillLoad,
+  countStepStartedEvents,
+  createLiveEvalCaseSupport,
+  hasFinished,
+  type LiveEvalCase,
+  type LiveEvalContext,
+  type LiveEvalProjectFile,
+  type LiveEvalProjectFileReaderInput,
+  type LiveEvalRunnerConfig,
+  liveEvalRunnerInternals,
+  type PreparedLiveEvalInput,
+} from "./runner.ts";

--- a/src/eval/agent-service/live-evals/metadata.ts
+++ b/src/eval/agent-service/live-evals/metadata.ts
@@ -1,0 +1,175 @@
+import type { LiveEvalCaseMetadata } from "./report.ts";
+import type { LiveEvalCase } from "./runner.ts";
+
+/** Public API contract for live eval case surface. */
+export type LiveEvalCaseSurface = "read-only" | "write" | "experimental";
+
+/** Public API contract for live eval case tag rule. */
+export interface LiveEvalCaseTagRule {
+  tag: string;
+  equals?: string | readonly string[];
+  startsWith?: string | readonly string[];
+  includes?: string | readonly string[];
+}
+
+/** Options accepted by live eval case metadata. */
+export interface LiveEvalCaseMetadataOptions {
+  releaseGateCaseIds?: readonly string[] | ReadonlySet<string>;
+  optionalJudgeCasePrefixes?: readonly string[];
+  areaTagRules?: readonly LiveEvalCaseTagRule[];
+}
+
+/** Input payload for build live eval case metadata. */
+export interface BuildLiveEvalCaseMetadataInput extends LiveEvalCaseMetadataOptions {
+  caseId: string;
+  surface: LiveEvalCaseSurface;
+  requireProject: boolean;
+}
+
+/** Default value for live eval optional judge case prefixes. */
+export const DEFAULT_LIVE_EVAL_OPTIONAL_JUDGE_CASE_PREFIXES: readonly string[] = [
+  "knowledge-",
+  "grounded-",
+  "judged-",
+];
+
+/** Default value for live eval area tag rules. */
+export const DEFAULT_LIVE_EVAL_AREA_TAG_RULES: readonly LiveEvalCaseTagRule[] = [
+  { startsWith: "starter-", tag: "area:starter-routing" },
+  { startsWith: "starter-task-", tag: "area:starter-artifact-flow" },
+  { startsWith: "starter-", tag: "behavior:conversation-first" },
+  { startsWith: "workflow-", tag: "area:workflow" },
+  { startsWith: "platform-", tag: "area:platform" },
+  { startsWith: "security-", tag: "area:security" },
+  { startsWith: ["knowledge-", "grounded-", "judged-"], tag: "area:knowledge" },
+  { startsWith: "tool-truthfulness", tag: "area:tool-truthfulness" },
+  { startsWith: "degraded-", tag: "area:resilience" },
+  { equals: "error-recovery-missing-file", tag: "area:resilience" },
+  { includes: "deploy", tag: "area:deployment" },
+  { includes: "sandbox", tag: "area:sandbox" },
+  { includes: "debug", tag: "area:debugging" },
+  { includes: "operate", tag: "area:operations" },
+  { includes: "research", tag: "area:research" },
+  { includes: "knowledge", tag: "area:knowledge-lifecycle" },
+  { includes: "agent", tag: "area:agent-authoring" },
+  { includes: "form-input", tag: "area:interactive-input" },
+  { includes: ["invoke-agent", "delegation"], tag: "area:delegation" },
+  { includes: ["create-page", "create-api-route", "create-skill"], tag: "area:file-generation" },
+];
+
+function toStringArray(value: string | readonly string[] | undefined): readonly string[] {
+  if (!value) {
+    return [];
+  }
+
+  return typeof value === "string" ? [value] : value;
+}
+
+function caseIdCollectionHas(
+  collection: readonly string[] | ReadonlySet<string> | undefined,
+  caseId: string,
+): boolean {
+  if (!collection) {
+    return false;
+  }
+
+  if ("has" in collection) {
+    return collection.has(caseId);
+  }
+
+  return collection.includes(caseId);
+}
+
+function matchesTagRule(caseId: string, rule: LiveEvalCaseTagRule): boolean {
+  for (const value of toStringArray(rule.equals)) {
+    if (caseId === value) {
+      return true;
+    }
+  }
+
+  for (const value of toStringArray(rule.startsWith)) {
+    if (caseId.startsWith(value)) {
+      return true;
+    }
+  }
+
+  for (const value of toStringArray(rule.includes)) {
+    if (caseId.includes(value)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isOptionalJudgeCase(caseId: string, prefixes: readonly string[]): boolean {
+  return prefixes.some((prefix) => caseId.startsWith(prefix));
+}
+
+function buildAreaTags(caseId: string, rules: readonly LiveEvalCaseTagRule[]): string[] {
+  const tags = new Set<string>();
+
+  for (const rule of rules) {
+    if (matchesTagRule(caseId, rule)) {
+      tags.add(rule.tag);
+    }
+  }
+
+  return [...tags];
+}
+
+/** Builds live eval case metadata. */
+export function buildLiveEvalCaseMetadata(
+  input: BuildLiveEvalCaseMetadataInput,
+): LiveEvalCaseMetadata {
+  const optionalJudgeCasePrefixes = input.optionalJudgeCasePrefixes ??
+    DEFAULT_LIVE_EVAL_OPTIONAL_JUDGE_CASE_PREFIXES;
+  const areaTagRules = input.areaTagRules ?? DEFAULT_LIVE_EVAL_AREA_TAG_RULES;
+  const gradingTag = isOptionalJudgeCase(input.caseId, optionalJudgeCasePrefixes)
+    ? "grading:deterministic-plus-optional-llm"
+    : "grading:deterministic-only";
+
+  const tags = new Set<string>([
+    `surface:${input.surface}`,
+    input.requireProject ? "project:required" : "project:optional",
+    input.surface === "experimental" ? "stability:experimental" : "stability:stable",
+    gradingTag,
+  ]);
+
+  if (input.surface !== "experimental") {
+    tags.add("gate:nightly");
+  }
+
+  if (gradingTag === "grading:deterministic-only" && input.surface !== "experimental") {
+    tags.add("gate:ci");
+  }
+
+  if (caseIdCollectionHas(input.releaseGateCaseIds, input.caseId)) {
+    tags.add("gate:release");
+  }
+
+  for (const tag of buildAreaTags(input.caseId, areaTagRules)) {
+    tags.add(tag);
+  }
+
+  return {
+    tags: [...tags].sort(),
+  };
+}
+
+/** Applies live eval metadata. */
+export function withLiveEvalMetadata<TCase extends LiveEvalCase>(
+  cases: readonly TCase[],
+  surface: LiveEvalCaseSurface,
+  options: LiveEvalCaseMetadataOptions = {},
+): Array<TCase & { metadata: LiveEvalCaseMetadata }> {
+  return cases.map((testCase) => ({
+    ...testCase,
+    metadata: buildLiveEvalCaseMetadata({
+      ...options,
+      caseId: testCase.id,
+      surface,
+      requireProject: testCase.requireProject === true,
+    }),
+  }));
+}

--- a/src/eval/agent-service/live-evals/performance.ts
+++ b/src/eval/agent-service/live-evals/performance.ts
@@ -1,0 +1,56 @@
+/** Public API contract for live eval runtime. */
+export type LiveEvalRuntime = "framework";
+
+/** Public API contract for live eval result for performance. */
+export interface LiveEvalResultForPerformance {
+  runtime: LiveEvalRuntime;
+  durationMs: number;
+}
+
+/** Public API contract for runtime performance summary. */
+export interface RuntimePerformanceSummary {
+  count: number;
+  avgDurationMs: number;
+  p50DurationMs: number;
+  p95DurationMs: number;
+  minDurationMs: number;
+  maxDurationMs: number;
+}
+
+function calculateDurationPercentile(
+  sortedDurations: number[],
+  percentile: number,
+): number {
+  if (sortedDurations.length === 0) {
+    return 0;
+  }
+
+  const index = Math.min(
+    sortedDurations.length - 1,
+    Math.max(0, Math.ceil((percentile / 100) * sortedDurations.length) - 1),
+  );
+
+  return sortedDurations[index] ?? 0;
+}
+
+/** Builds runtime performance summary. */
+export function buildRuntimePerformanceSummary(
+  results: LiveEvalResultForPerformance[],
+): Record<LiveEvalRuntime, RuntimePerformanceSummary> {
+  const durations = results.map((result) => result.durationMs).sort((
+    left,
+    right,
+  ) => left - right);
+  const totalDuration = durations.reduce((sum, value) => sum + value, 0);
+
+  return {
+    framework: {
+      count: durations.length,
+      avgDurationMs: durations.length > 0 ? Math.round(totalDuration / durations.length) : 0,
+      p50DurationMs: calculateDurationPercentile(durations, 50),
+      p95DurationMs: calculateDurationPercentile(durations, 95),
+      minDurationMs: durations[0] ?? 0,
+      maxDurationMs: durations.at(-1) ?? 0,
+    },
+  };
+}

--- a/src/eval/agent-service/live-evals/preflight.ts
+++ b/src/eval/agent-service/live-evals/preflight.ts
@@ -1,0 +1,48 @@
+import {
+  type AgentServiceConfigInput,
+  parseAgentServiceConfig,
+} from "../../../agent/service/config.ts";
+
+/** Result returned from runtime confidence preflight. */
+export interface RuntimeConfidencePreflightResult {
+  ok: boolean;
+  resolvedApiUrl: string;
+  messages: string[];
+}
+
+/** Evaluate runtime confidence env helper. */
+export function evaluateRuntimeConfidenceEnv(
+  env: AgentServiceConfigInput = {},
+  resolvedApiUrl: string = parseAgentServiceConfig(env).VERYFRONT_API_URL,
+): RuntimeConfidencePreflightResult {
+  const messages: string[] = [`Resolved VERYFRONT_API_URL: ${resolvedApiUrl}`];
+  let hasBlockers = false;
+
+  if (typeof env.VERYFRONT_TOKEN !== "string" || env.VERYFRONT_TOKEN.length === 0) {
+    hasBlockers = true;
+    messages.push("BLOCKER: VERYFRONT_TOKEN is missing");
+  }
+  if (typeof env.AG_UI_EVAL_PROJECT_ID !== "string" || env.AG_UI_EVAL_PROJECT_ID.length === 0) {
+    hasBlockers = true;
+    messages.push("BLOCKER: AG_UI_EVAL_PROJECT_ID is missing");
+  }
+
+  if (!hasBlockers) {
+    messages.push("Runtime-confidence preflight: PASS");
+    return { ok: true, resolvedApiUrl, messages };
+  }
+
+  messages.push("Runtime-confidence preflight: FAIL");
+  return { ok: false, resolvedApiUrl, messages };
+}
+
+/** Print runtime confidence preflight helper. */
+export function printRuntimeConfidencePreflight(
+  result: RuntimeConfidencePreflightResult,
+  output: Pick<Console, "error" | "log"> = console,
+): void {
+  for (const message of result.messages) {
+    const writer = result.ok ? output.log : output.error;
+    writer(message);
+  }
+}

--- a/src/eval/agent-service/live-evals/report.ts
+++ b/src/eval/agent-service/live-evals/report.ts
@@ -1,0 +1,164 @@
+import type { LiveEvalRuntime } from "./performance.ts";
+
+/** Public API contract for live eval case metadata. */
+export interface LiveEvalCaseMetadata {
+  tags: readonly string[];
+}
+
+/** Public API contract for live eval result for report. */
+export interface LiveEvalResultForReport {
+  runtime: LiveEvalRuntime;
+  status: "pass" | "fail" | "skip";
+}
+
+/** Input payload for live eval case selection. */
+export interface LiveEvalCaseSelectionInput<TCase extends { id: string }> {
+  allCases: TCase[];
+  readOnlyCases: TCase[];
+  writeCases: TCase[];
+  experimentalWriteCases: TCase[];
+  requestedCaseIds: Set<string>;
+  requestedCaseTags?: Set<string>;
+  runWriteEvals: boolean;
+  runExperimentalWriteEvals: boolean;
+}
+
+/** Check whether every live eval tag is present. */
+export function hasEveryLiveEvalTag(
+  tags: readonly string[],
+  requestedTags: Set<string>,
+): boolean {
+  for (const requestedTag of requestedTags) {
+    if (!tags.includes(requestedTag)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/** Builds live eval case tag summary. */
+export function buildLiveEvalCaseTagSummary(
+  cases: readonly {
+    metadata?: LiveEvalCaseMetadata;
+  }[],
+): Record<string, number> {
+  const counts = new Map<string, number>();
+
+  for (const testCase of cases) {
+    const caseTags = testCase.metadata?.tags ?? [];
+    for (const tag of caseTags) {
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+
+  return Object.fromEntries(
+    [...counts.entries()].sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+/** Select live eval cases helper. */
+export function selectLiveEvalCases<
+  TCase extends { id: string; metadata?: LiveEvalCaseMetadata },
+>(
+  input: LiveEvalCaseSelectionInput<TCase>,
+): TCase[] {
+  const configuredCases = input.runWriteEvals
+    ? [
+      ...input.readOnlyCases,
+      ...input.writeCases,
+      ...(input.runExperimentalWriteEvals ? input.experimentalWriteCases : []),
+    ]
+    : input.readOnlyCases;
+
+  const selectedCases = input.requestedCaseIds.size > 0
+    ? input.allCases.filter((testCase) => input.requestedCaseIds.has(testCase.id))
+    : configuredCases;
+
+  const requestedCaseTags = input.requestedCaseTags ?? new Set<string>();
+
+  return requestedCaseTags.size > 0
+    ? selectedCases.filter((testCase) =>
+      hasEveryLiveEvalTag(testCase.metadata?.tags ?? [], requestedCaseTags)
+    )
+    : selectedCases;
+}
+
+/** Resolves live eval requested case IDs. */
+export function resolveLiveEvalRequestedCaseIds(input: {
+  caseSets: Record<string, readonly string[]>;
+  requestedCaseIds: Set<string>;
+  requestedCaseSetId?: string | null;
+}): Set<string> {
+  const resolved = new Set(input.requestedCaseIds);
+  const requestedCaseSetId = input.requestedCaseSetId?.trim();
+
+  if (!requestedCaseSetId) {
+    return resolved;
+  }
+
+  const caseIds = input.caseSets[requestedCaseSetId];
+  if (!caseIds) {
+    throw new Error(
+      `Unknown AG_UI_EVAL_CASE_SET "${requestedCaseSetId}". Known sets: ${
+        Object.keys(input.caseSets).join(", ")
+      }`,
+    );
+  }
+
+  for (const caseId of caseIds) {
+    resolved.add(caseId);
+  }
+
+  return resolved;
+}
+
+interface LiveEvalRuntimeCounts {
+  passed: number;
+  failed: number;
+  skipped: number;
+}
+
+function buildRuntimeCounts(
+  results: LiveEvalResultForReport[],
+  runtime: LiveEvalRuntime,
+): LiveEvalRuntimeCounts {
+  return {
+    passed:
+      results.filter((result) => result.runtime === runtime && result.status === "pass").length,
+    failed:
+      results.filter((result) => result.runtime === runtime && result.status === "fail").length,
+    skipped:
+      results.filter((result) => result.runtime === runtime && result.status === "skip").length,
+  };
+}
+
+/** Builds live eval runtime summary. */
+export function buildLiveEvalRuntimeSummary(
+  runtimes: readonly LiveEvalRuntime[],
+  results: LiveEvalResultForReport[],
+): Record<LiveEvalRuntime, LiveEvalRuntimeCounts> {
+  const empty: LiveEvalRuntimeCounts = { passed: 0, failed: 0, skipped: 0 };
+  const summary: Record<LiveEvalRuntime, LiveEvalRuntimeCounts> = {
+    framework: empty,
+  };
+  for (const runtime of runtimes) {
+    summary[runtime] = buildRuntimeCounts(results, runtime);
+  }
+  return summary;
+}
+
+/** Builds live eval status summary. */
+export function buildLiveEvalStatusSummary(
+  results: LiveEvalResultForReport[],
+): {
+  passed: number;
+  failed: number;
+  skipped: number;
+} {
+  return {
+    passed: results.filter((result) => result.status === "pass").length,
+    failed: results.filter((result) => result.status === "fail").length,
+    skipped: results.filter((result) => result.status === "skip").length,
+  };
+}

--- a/src/eval/agent-service/live-evals/request.ts
+++ b/src/eval/agent-service/live-evals/request.ts
@@ -1,0 +1,80 @@
+/** Public API contract for live eval request body. */
+export interface LiveEvalRequestBody {
+  threadId: string;
+  runId: string;
+  state: Record<string, string>;
+  tools: unknown[];
+  context: unknown[];
+  forwardedProps?: {
+    veryfront: Record<string, unknown>;
+  };
+  messages: Array<{
+    id: string;
+    role: "user";
+    content: string;
+  }>;
+}
+
+/** Input payload for build live eval request body. */
+export interface BuildLiveEvalRequestBodyInput {
+  testCaseId: string;
+  prompt: string;
+  metadata?: Record<string, string>;
+  projectId: string | null;
+  branchId?: string;
+  model?: string;
+  conversationId?: string | null;
+  allowedTools?: string[];
+  forceRuntimeOverrides?: boolean;
+  maxSteps?: number;
+}
+
+/** Builds live eval request body. */
+export function buildLiveEvalRequestBody(
+  input: BuildLiveEvalRequestBodyInput,
+): LiveEvalRequestBody {
+  const veryfront: Record<string, unknown> = {};
+  if (input.projectId) {
+    veryfront.projectId = input.projectId;
+  }
+  if (input.conversationId) {
+    veryfront.conversationId = input.conversationId;
+  }
+  if (input.branchId) {
+    veryfront.branchId = input.branchId;
+  }
+  if (input.model) {
+    veryfront.model = input.model;
+  }
+  if (input.allowedTools || input.forceRuntimeOverrides) {
+    veryfront.runtimeOverrides = {
+      allowedTools: input.allowedTools ?? [],
+      ...(input.maxSteps ? { maxSteps: input.maxSteps } : {}),
+    };
+  }
+
+  return {
+    threadId: crypto.randomUUID(),
+    runId: `eval-run-${crypto.randomUUID()}`,
+    state: {
+      evalCase: input.testCaseId,
+      ...(input.metadata ?? {}),
+    },
+    tools: [],
+    context: [],
+    ...(Object.keys(veryfront).length > 0
+      ? {
+        forwardedProps: {
+          veryfront,
+        },
+      }
+      : {}),
+    messages: [
+      {
+        id: crypto.randomUUID(),
+        role: "user" as const,
+        content: input.prompt,
+      },
+    ],
+  };
+}

--- a/src/eval/agent-service/live-evals/result.ts
+++ b/src/eval/agent-service/live-evals/result.ts
@@ -1,0 +1,113 @@
+import type { LiveEvalRuntime } from "./performance.ts";
+
+/** Record shape for live eval result. */
+export interface LiveEvalResultRecord {
+  id: string;
+  label: string;
+  runtime: LiveEvalRuntime;
+  status: "pass" | "fail" | "skip";
+  details: string;
+  durationMs: number;
+  conversationId?: string;
+  runId?: string;
+  artifactPaths?: string[];
+  traceSignature?: string;
+  toolStarts?: string[];
+  toolArgsPreview?: string;
+  textPreview?: string;
+}
+
+type EvalResultStatus = LiveEvalResultRecord["status"];
+
+interface BaseEvalResultInput {
+  id: string;
+  label: string;
+  runtime: LiveEvalRuntime;
+  details: string;
+  startedAt: number;
+}
+
+interface EvalResultInputWithContext extends BaseEvalResultInput {
+  conversationId?: string;
+  runId?: string;
+  artifactPaths?: string[];
+  traceSignature?: string;
+  toolStarts?: string[];
+  toolArgsPreview?: string;
+  textPreview?: string;
+}
+
+function createEvalResult(
+  status: EvalResultStatus,
+  input: EvalResultInputWithContext,
+): LiveEvalResultRecord {
+  return {
+    id: input.id,
+    label: input.label,
+    runtime: input.runtime,
+    status,
+    details: input.details,
+    durationMs: Date.now() - input.startedAt,
+    ...(input.conversationId ? { conversationId: input.conversationId } : {}),
+    ...(input.runId ? { runId: input.runId } : {}),
+    ...(input.artifactPaths?.length ? { artifactPaths: input.artifactPaths } : {}),
+    ...(input.traceSignature ? { traceSignature: input.traceSignature } : {}),
+    ...(input.toolStarts ? { toolStarts: input.toolStarts } : {}),
+    ...(input.toolArgsPreview ? { toolArgsPreview: input.toolArgsPreview } : {}),
+    ...(input.textPreview ? { textPreview: input.textPreview } : {}),
+  };
+}
+
+/** Result returned from create skipped eval. */
+export function createSkippedEvalResult(input: {
+  id: string;
+  label: string;
+  runtime: LiveEvalRuntime;
+  details: string;
+  startedAt: number;
+}): LiveEvalResultRecord {
+  return {
+    id: input.id,
+    label: input.label,
+    runtime: input.runtime,
+    status: "skip",
+    details: input.details,
+    durationMs: Date.now() - input.startedAt,
+  };
+}
+
+/** Result returned from create failed eval. */
+export function createFailedEvalResult(input: {
+  id: string;
+  label: string;
+  runtime: LiveEvalRuntime;
+  details: string;
+  startedAt: number;
+  conversationId?: string;
+  runId?: string;
+  artifactPaths?: string[];
+  traceSignature?: string;
+  toolStarts?: string[];
+  toolArgsPreview?: string;
+  textPreview?: string;
+}): LiveEvalResultRecord {
+  return createEvalResult("fail", input);
+}
+
+/** Result returned from create passed eval. */
+export function createPassedEvalResult(input: {
+  id: string;
+  label: string;
+  runtime: LiveEvalRuntime;
+  details: string;
+  startedAt: number;
+  conversationId?: string;
+  runId?: string;
+  artifactPaths?: string[];
+  traceSignature?: string;
+  toolStarts?: string[];
+  toolArgsPreview?: string;
+  textPreview?: string;
+}): LiveEvalResultRecord {
+  return createEvalResult("pass", input);
+}

--- a/src/eval/agent-service/live-evals/runner.ts
+++ b/src/eval/agent-service/live-evals/runner.ts
@@ -1,0 +1,639 @@
+import {
+  agUiSseEventTypes,
+  type AgUiSseProgressSnapshot as EvalProgressSnapshot,
+  buildAgUiSseTraceSignature as buildTraceSignature,
+  getAgUiSseStringField as getStringField,
+  parseAgUiSseResponse as parseSseResponse,
+  type ParsedAgUiSseRun as ParsedRun,
+} from "#veryfront/agent";
+import { buildFailureSuffix, buildProgressLine, containsOrderedSubsequence } from "./formatting.ts";
+import { type LiveEvalRuntime } from "./performance.ts";
+import { buildLiveEvalRequestBody } from "./request.ts";
+import { type LiveEvalCaseMetadata } from "./report.ts";
+import {
+  createFailedEvalResult,
+  createPassedEvalResult,
+  createSkippedEvalResult,
+  type LiveEvalResultRecord,
+} from "./result.ts";
+
+/** Input payload for prepared live eval. */
+export interface PreparedLiveEvalInput {
+  prompt?: string;
+  metadata?: Record<string, string>;
+  verificationContext?: LiveEvalContext;
+  cleanup?: () => Promise<void>;
+  startSidecar?: () => Promise<(() => Promise<void>) | void>;
+}
+
+/** Context for live eval. */
+export interface LiveEvalContext {
+  apiUrl: string;
+  authToken: string;
+  projectId: string | null;
+}
+
+/** Public API contract for live eval case. */
+export interface LiveEvalCase {
+  readonly id: string;
+  readonly label: string;
+  readonly prompt?: string;
+  allowedTools?: string[];
+  forceRuntimeOverrides?: boolean;
+  requireProject?: boolean;
+  maxSteps?: number;
+  expectedEventSubsequence?: string[];
+  metadata?: LiveEvalCaseMetadata;
+  prepare?: (context: LiveEvalContext) => Promise<PreparedLiveEvalInput>;
+  verify: (
+    run: ParsedRun,
+    prepared: PreparedLiveEvalInput | null,
+  ) => string | null | Promise<string | null>;
+}
+
+interface FileCheckInput {
+  filePath: string;
+  requiredContent?: string[];
+  description?: string;
+}
+
+/** Public API contract for live eval project file. */
+export interface LiveEvalProjectFile {
+  path: string;
+  content: string;
+}
+
+/** Input payload for live eval project file reader. */
+export interface LiveEvalProjectFileReaderInput {
+  filePath: string;
+  requestTimeoutMs: number;
+}
+
+/** Configuration used by live eval runner. */
+export interface LiveEvalRunnerConfig {
+  endpoint: string;
+  authToken: string;
+  apiUrl: string;
+  projectId: string | null;
+  branchId: string | null;
+  model: string | null;
+  requestTimeoutMs: number;
+  progressLogIntervalMs: number;
+  enableLlmJudge: boolean;
+  fetch?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+  log?: (message: string) => void;
+  readProjectFile?: (input: LiveEvalProjectFileReaderInput) => Promise<LiveEvalProjectFile | null>;
+}
+
+interface LiveEvalJudgeInput {
+  question: string;
+  criteria: string;
+}
+
+interface LiveEvalJudgeRequest extends LiveEvalJudgeInput {
+  answer: string;
+}
+
+interface LiveEvalJudgeResult {
+  pass: boolean;
+  reason: string;
+}
+
+function resolveFetch(config: Pick<LiveEvalRunnerConfig, "fetch">) {
+  return config.fetch ?? fetch;
+}
+
+function createLiveEvalJudgeSupport(
+  config: Pick<LiveEvalRunnerConfig, "endpoint" | "authToken" | "enableLlmJudge" | "fetch">,
+): {
+  judgeLlm: (input: LiveEvalJudgeRequest) => Promise<LiveEvalJudgeResult>;
+  withJudge: (
+    structuralVerify: (run: ParsedRun) => string | null,
+    judgeInput: LiveEvalJudgeInput,
+  ) => (run: ParsedRun) => Promise<string | null>;
+} {
+  async function judgeLlm(input: LiveEvalJudgeRequest): Promise<LiveEvalJudgeResult> {
+    try {
+      const body = buildLiveEvalRequestBody({
+        testCaseId: "llm-judge",
+        prompt: `You are an eval judge. Grade the following answer.
+
+QUESTION: ${input.question}
+
+ANSWER: ${input.answer}
+
+CRITERIA: ${input.criteria}
+
+Respond with exactly one line: PASS or FAIL followed by a brief reason.
+Example: "PASS — correctly explains the pattern with accurate details"
+Example: "FAIL — mentions the wrong file convention"`,
+        projectId: null,
+        allowedTools: [],
+        forceRuntimeOverrides: true,
+        maxSteps: 2,
+      });
+
+      const response = await resolveFetch(config)(config.endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${config.authToken}`,
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(30_000),
+      });
+
+      const run = await parseSseResponse(response);
+      if (run.responseStatus !== 200) {
+        return { pass: false, reason: `judge returned HTTP ${run.responseStatus}` };
+      }
+      const line = run.text
+        .split("\n")
+        .map((value) => value.trim())
+        .find((value) => value.length > 0) ?? "";
+      if (line.toUpperCase().startsWith("PASS")) {
+        return { pass: true, reason: line };
+      }
+      return { pass: false, reason: line || "judge returned no decision" };
+    } catch (error) {
+      return {
+        pass: false,
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  function withJudge(
+    structuralVerify: (run: ParsedRun) => string | null,
+    judgeInput: LiveEvalJudgeInput,
+  ): (run: ParsedRun) => Promise<string | null> {
+    return async (run) => {
+      const structuralFailure = structuralVerify(run);
+      if (structuralFailure) {
+        return structuralFailure;
+      }
+      if (!config.enableLlmJudge) {
+        return null;
+      }
+      const judgment = await judgeLlm({
+        question: judgeInput.question,
+        answer: run.text,
+        criteria: judgeInput.criteria,
+      });
+      return judgment.pass ? null : `LLM judge: ${judgment.reason}`;
+    };
+  }
+
+  return {
+    judgeLlm,
+    withJudge,
+  };
+}
+
+interface LiveEvalProgressReporter {
+  stop: () => void;
+  update: (snapshot: EvalProgressSnapshot) => void;
+  getSnapshot: () => EvalProgressSnapshot;
+}
+
+function createInitialProgressSnapshot(): EvalProgressSnapshot {
+  return {
+    eventCount: 0,
+    lastEventType: null,
+    lastToolCallName: null,
+    toolStarts: [],
+    textLength: 0,
+  };
+}
+
+interface UnrefableTimer {
+  unref: () => void;
+}
+
+function isUnrefableTimer(value: unknown): value is UnrefableTimer {
+  return typeof value === "object" && value !== null && "unref" in value &&
+    typeof value.unref === "function";
+}
+
+function maybeUnrefTimer(timer: ReturnType<typeof setInterval>): void {
+  if (isUnrefableTimer(timer)) {
+    timer.unref();
+  }
+}
+
+function createLiveEvalProgressReporter(input: {
+  caseId: string;
+  startedAt: number;
+  intervalMs: number;
+  log: (message: string) => void;
+}): LiveEvalProgressReporter {
+  let latestProgress = createInitialProgressSnapshot();
+  const progressTimer = setInterval(() => {
+    input.log(
+      buildProgressLine({
+        caseId: input.caseId,
+        startedAt: input.startedAt,
+        progress: latestProgress,
+      }),
+    );
+  }, input.intervalMs);
+  maybeUnrefTimer(progressTimer);
+
+  return {
+    stop: () => {
+      clearInterval(progressTimer);
+    },
+    update: (snapshot) => {
+      latestProgress = snapshot;
+    },
+    getSnapshot: () => latestProgress,
+  };
+}
+
+function collectPreparedArtifactPaths(prepared: PreparedLiveEvalInput | null): string[] {
+  if (!prepared?.metadata) {
+    return [];
+  }
+
+  return [
+    ...new Set(
+      Object.entries(prepared.metadata)
+        .filter(([key, value]) => key.toLowerCase().includes("path") && value.length > 0)
+        .map(([, value]) => value),
+    ),
+  ].sort();
+}
+
+function extractPreparedConversationId(prepared: PreparedLiveEvalInput | null): string | null {
+  return typeof prepared?.metadata?.conversationId === "string" &&
+      prepared.metadata.conversationId.length > 0
+    ? prepared.metadata.conversationId
+    : null;
+}
+
+interface LiveEvalResultContext {
+  id: string;
+  label: string;
+  runtime: LiveEvalRuntime;
+  startedAt: number;
+  conversationId?: string | null;
+  artifactPaths?: string[];
+}
+
+interface LiveEvalRunArtifactsInput {
+  run: ParsedRun;
+  runId?: string;
+  traceSignature: string;
+}
+
+interface LiveEvalRunArtifacts {
+  runId?: string;
+  traceSignature: string;
+  toolStarts: string[];
+  toolArgsPreview: string;
+  textPreview: string;
+}
+
+function createLiveEvalRunArtifacts(input: LiveEvalRunArtifactsInput): LiveEvalRunArtifacts {
+  return {
+    ...(input.runId ? { runId: input.runId } : {}),
+    traceSignature: input.traceSignature,
+    toolStarts: input.run.toolStarts,
+    toolArgsPreview: input.run.toolArgs.join(" | ").slice(0, 1000),
+    textPreview: input.run.text.slice(0, 280),
+  };
+}
+
+function createFailedRunEvalResult(input: {
+  details: string;
+  context: LiveEvalResultContext;
+  runArtifacts: LiveEvalRunArtifacts;
+}): LiveEvalResultRecord {
+  return createFailedEvalResult({
+    id: input.context.id,
+    label: input.context.label,
+    runtime: input.context.runtime,
+    details: input.details,
+    startedAt: input.context.startedAt,
+    ...(input.context.conversationId ? { conversationId: input.context.conversationId } : {}),
+    ...(input.runArtifacts.runId ? { runId: input.runArtifacts.runId } : {}),
+    ...(input.context.artifactPaths?.length ? { artifactPaths: input.context.artifactPaths } : {}),
+    traceSignature: input.runArtifacts.traceSignature,
+    toolStarts: input.runArtifacts.toolStarts,
+    toolArgsPreview: input.runArtifacts.toolArgsPreview,
+    textPreview: input.runArtifacts.textPreview,
+  });
+}
+
+function createPassedRunEvalResult(input: {
+  details: string;
+  context: LiveEvalResultContext;
+  runArtifacts: LiveEvalRunArtifacts;
+}): LiveEvalResultRecord {
+  return createPassedEvalResult({
+    id: input.context.id,
+    label: input.context.label,
+    runtime: input.context.runtime,
+    details: input.details,
+    startedAt: input.context.startedAt,
+    ...(input.context.conversationId ? { conversationId: input.context.conversationId } : {}),
+    ...(input.runArtifacts.runId ? { runId: input.runArtifacts.runId } : {}),
+    ...(input.context.artifactPaths?.length ? { artifactPaths: input.context.artifactPaths } : {}),
+    traceSignature: input.runArtifacts.traceSignature,
+    toolStarts: input.runArtifacts.toolStarts,
+    toolArgsPreview: input.runArtifacts.toolArgsPreview,
+    textPreview: input.runArtifacts.textPreview,
+  });
+}
+
+function createStreamingFailureEvalResult(input: {
+  details: string;
+  context: LiveEvalResultContext;
+  progress: EvalProgressSnapshot;
+}): LiveEvalResultRecord {
+  return createFailedEvalResult({
+    id: input.context.id,
+    label: input.context.label,
+    runtime: input.context.runtime,
+    details: `${input.details}${buildFailureSuffix(input.progress)}`,
+    startedAt: input.context.startedAt,
+    ...(input.context.conversationId ? { conversationId: input.context.conversationId } : {}),
+    ...(input.context.artifactPaths?.length ? { artifactPaths: input.context.artifactPaths } : {}),
+    toolStarts: input.progress.toolStarts,
+    textPreview: input.progress.textLength > 0
+      ? `${input.progress.textLength} characters streamed`
+      : undefined,
+  });
+}
+
+function createLiveEvalResultContext(input: {
+  testCase: LiveEvalCase;
+  runtime: LiveEvalRuntime;
+  startedAt: number;
+  conversationId: string | null;
+  artifactPaths: string[];
+}): LiveEvalResultContext {
+  return {
+    id: input.testCase.id,
+    label: input.testCase.label,
+    runtime: input.runtime,
+    startedAt: input.startedAt,
+    ...(input.conversationId ? { conversationId: input.conversationId } : {}),
+    ...(input.artifactPaths.length > 0 ? { artifactPaths: input.artifactPaths } : {}),
+  };
+}
+
+function buildLiveEvalRunBody(input: {
+  config: LiveEvalRunnerConfig;
+  testCase: LiveEvalCase;
+  prepared: PreparedLiveEvalInput | null;
+  conversationId: string | null;
+}): unknown {
+  const customBody = typeof input.prepared?.metadata?.customBody === "string"
+    ? input.prepared.metadata.customBody
+    : null;
+
+  if (customBody) {
+    return JSON.parse(customBody);
+  }
+
+  return buildLiveEvalRequestBody({
+    testCaseId: input.testCase.id,
+    prompt: input.prepared?.prompt ?? input.testCase.prompt ?? "",
+    metadata: input.prepared?.metadata,
+    projectId: input.config.projectId && input.testCase.requireProject
+      ? input.config.projectId
+      : null,
+    ...(input.config.branchId ? { branchId: input.config.branchId } : {}),
+    ...(input.config.model ? { model: input.config.model } : {}),
+    ...(input.conversationId ? { conversationId: input.conversationId } : {}),
+    allowedTools: input.testCase.allowedTools,
+    forceRuntimeOverrides: input.testCase.forceRuntimeOverrides,
+    maxSteps: input.testCase.maxSteps,
+  });
+}
+
+async function resolveCompletedLiveEvalRun(input: {
+  testCase: LiveEvalCase;
+  run: ParsedRun;
+  prepared: PreparedLiveEvalInput | null;
+  context: LiveEvalResultContext;
+  runId?: string;
+}): Promise<LiveEvalResultRecord> {
+  const traceSignature = buildTraceSignature(input.run.eventTypes);
+  const runArtifacts = createLiveEvalRunArtifacts({
+    run: input.run,
+    runId: input.runId,
+    traceSignature,
+  });
+  const failure = await input.testCase.verify(input.run, input.prepared);
+
+  if (!failure && input.testCase.expectedEventSubsequence) {
+    if (
+      !containsOrderedSubsequence(input.run.eventTypes, input.testCase.expectedEventSubsequence)
+    ) {
+      return createFailedRunEvalResult({
+        context: input.context,
+        details: `Expected AG-UI event subsequence ${
+          input.testCase.expectedEventSubsequence.join(" -> ")
+        }, got ${traceSignature}`,
+        runArtifacts,
+      });
+    }
+  }
+
+  if (failure) {
+    return createFailedRunEvalResult({
+      context: input.context,
+      details: failure,
+      runArtifacts,
+    });
+  }
+
+  return createPassedRunEvalResult({
+    context: input.context,
+    details: `OK: ${input.run.toolStarts.join(", ") || "no tools"} | ${
+      input.run.text.slice(0, 140) || "no text"
+    }`,
+    runArtifacts,
+  });
+}
+
+function extractRunId(run: ParsedRun): string | null {
+  for (const event of run.events) {
+    const runId = getStringField(event, "runId") ?? getStringField(event, "run_id");
+    if (runId) {
+      return runId;
+    }
+  }
+
+  return null;
+}
+
+/** Check whether finished is present. */
+export function hasFinished(run: ParsedRun): boolean {
+  return run.eventTypes.includes(agUiSseEventTypes.runFinished) && !run.runError;
+}
+
+/** Contains skill load helper. */
+export function containsSkillLoad(run: ParsedRun, skillId: string): boolean {
+  return run.toolStarts.includes("load_skill") && run.toolArgs.join("").includes(skillId);
+}
+
+/** Count step started events helper. */
+export function countStepStartedEvents(run: ParsedRun): number {
+  return run.eventTypes.filter((eventType) => eventType === agUiSseEventTypes.stepStarted).length;
+}
+
+/** Create live eval case support. */
+export function createLiveEvalCaseSupport(config: LiveEvalRunnerConfig): {
+  runEval: (testCase: LiveEvalCase, runtime: LiveEvalRuntime) => Promise<LiveEvalResultRecord>;
+  verifyFileExists: (input: FileCheckInput) => Promise<string | null>;
+  withJudge: (
+    structuralVerify: (run: ParsedRun) => string | null,
+    judgeInput: LiveEvalJudgeInput,
+  ) => (run: ParsedRun) => Promise<string | null>;
+  judgeLlm: (input: LiveEvalJudgeRequest) => Promise<LiveEvalJudgeResult>;
+} {
+  const fetchImpl = resolveFetch(config);
+  const log = config.log ?? console.log;
+  const { judgeLlm, withJudge } = createLiveEvalJudgeSupport(config);
+
+  async function verifyFileExists(input: FileCheckInput): Promise<string | null> {
+    if (!config.projectId || !config.readProjectFile) {
+      return null;
+    }
+
+    const file = await config.readProjectFile({
+      filePath: input.filePath,
+      requestTimeoutMs: config.requestTimeoutMs,
+    });
+
+    if (!file) {
+      return `${
+        input.description ?? input.filePath
+      }: file not found in project after task completed`;
+    }
+
+    if (!file.content || file.content.trim().length === 0) {
+      return `${input.description ?? input.filePath}: file exists but is empty`;
+    }
+
+    if (input.requiredContent) {
+      const missing = input.requiredContent.filter((keyword) =>
+        !file.content.toLowerCase().includes(keyword.toLowerCase())
+      );
+      if (missing.length > 0) {
+        return `${input.description ?? input.filePath}: missing required content: ${
+          missing.join(", ")
+        }. Got: ${file.content.slice(0, 200)}`;
+      }
+    }
+
+    return null;
+  }
+
+  async function runEval(
+    testCase: LiveEvalCase,
+    runtime: LiveEvalRuntime,
+  ): Promise<LiveEvalResultRecord> {
+    const startedAt = Date.now();
+    if (testCase.requireProject && !config.projectId) {
+      return createSkippedEvalResult({
+        id: testCase.id,
+        label: testCase.label,
+        runtime,
+        details: "Skipped because AG_UI_EVAL_PROJECT_ID is not set.",
+        startedAt,
+      });
+    }
+
+    const prepared = testCase.prepare
+      ? await testCase.prepare({
+        apiUrl: config.apiUrl,
+        authToken: config.authToken,
+        projectId: config.projectId,
+      })
+      : null;
+    const preparedConversationId = extractPreparedConversationId(prepared);
+    const preparedArtifactPaths = collectPreparedArtifactPaths(prepared);
+    const resultContext = createLiveEvalResultContext({
+      testCase,
+      runtime,
+      startedAt,
+      conversationId: preparedConversationId,
+      artifactPaths: preparedArtifactPaths,
+    });
+
+    try {
+      const sidecarCleanup = prepared?.startSidecar ? await prepared.startSidecar() : undefined;
+      const progressReporter = createLiveEvalProgressReporter({
+        caseId: testCase.id,
+        startedAt,
+        intervalMs: config.progressLogIntervalMs,
+        log,
+      });
+
+      const body = buildLiveEvalRunBody({
+        config,
+        testCase,
+        prepared,
+        conversationId: preparedConversationId,
+      });
+
+      try {
+        const response = await fetchImpl(config.endpoint, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${config.authToken}`,
+          },
+          body: JSON.stringify(body),
+          signal: AbortSignal.timeout(config.requestTimeoutMs),
+        });
+
+        log(`[stream] ${runtime}:${testCase.id} HTTP ${response.status}`);
+
+        const run = await parseSseResponse(response, {
+          onProgress: progressReporter.update,
+        });
+        return resolveCompletedLiveEvalRun({
+          testCase,
+          run,
+          prepared,
+          context: resultContext,
+          runId: extractRunId(run) ?? undefined,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return createStreamingFailureEvalResult({
+          context: resultContext,
+          details: message,
+          progress: progressReporter.getSnapshot(),
+        });
+      } finally {
+        progressReporter.stop();
+        await sidecarCleanup?.();
+      }
+    } finally {
+      await prepared?.cleanup?.();
+    }
+  }
+
+  return {
+    judgeLlm,
+    runEval,
+    verifyFileExists,
+    withJudge,
+  };
+}
+
+/** White-box helpers used by live eval runner tests. */
+export const liveEvalRunnerInternals = {
+  collectPreparedArtifactPaths,
+  createFailedRunEvalResult,
+  createLiveEvalRunArtifacts,
+  createPassedRunEvalResult,
+  createStreamingFailureEvalResult,
+  extractRunId,
+};

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.877";
+export const VERSION = "0.1.878";


### PR DESCRIPTION
## Summary
- Publish reusable live AG-UI and durable canary helpers from `veryfront/eval/agent-service`.
- Keep `veryfront/agent/testing` removed and add regressions for the new eval import surface.
- Bump framework version to `0.1.878` so downstream eval suites can migrate cleanly.

## Verification
- `deno check src/eval/agent-service.ts src/eval/agent-service.test.ts`
- `deno test --no-check --allow-all src/eval/agent-service.test.ts src/eval/runner.test.ts src/eval/metrics.test.ts src/eval/factory.test.ts src/eval/discovery.test.ts src/eval/studio.test.ts`
- `deno test --config=scripts/test.deno.json --no-check --allow-read --allow-write --allow-run scripts/build/npm-package-metadata.test.ts`
- `deno task docs:validate && deno task typecheck`
- Pre-push hook passed: format, lint, typecheck, and unit suite (2193 passed / 18826 steps).

## Known gap
- `deno task verify:quick` still stops on existing CLI boundary violations in cli/shared and cli/skills before eval-specific gates run.