### PR TITLE
Release veryfront 0.1.879

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.878",
+  "version": "0.1.879",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.878";
+export const VERSION = "0.1.879";


### PR DESCRIPTION
## Summary
- bump the framework package version to `0.1.879`
- keep `src/utils/version-constant.ts` in sync with `deno.json`
- prepare a patch release that includes the merged eval primitive/exporter work

## Verification
- `deno task fmt:check`
- `deno task typecheck`
- `git diff --check`
- pre-push gate passed before branch push: formatting, lint, typecheck, generation, and unit tests (`2195 passed`, `18831 steps`, `0 failed`)

## Notes
- Direct push to `main` was rejected by repository rules, so this release goes through PR as required.
- `0.1.879` was not present on npm or in GitHub releases before this bump.