### PR TITLE
Add durable eval execution to the framework

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.879",
+  "version": "0.1.880",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/deno.lock
+++ b/deno.lock
@@ -3,8 +3,12 @@
   "specifiers": {
     "jsr:@std/assert@1.0.19": "1.0.19",
     "jsr:@std/assert@^1.0.17": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/async@1.2.0": "1.2.0",
     "jsr:@std/cli@1.0.28": "1.0.28",
+    "jsr:@std/data-structures@^1.0.10": "1.0.11",
     "jsr:@std/dotenv@0.225.6": "0.225.6",
+    "jsr:@std/expect@1.0.18": "1.0.18",
     "jsr:@std/fmt@1.0.9": "1.0.9",
     "jsr:@std/fs@1.0.23": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.14",
@@ -68,11 +72,25 @@
         "jsr:@std/internal"
       ]
     },
+    "@std/async@1.2.0": {
+      "integrity": "c059c6f6d95ca7cc012ae8e8d7164d1697113d54b0b679e4372b354b11c2dee5"
+    },
     "@std/cli@1.0.28": {
       "integrity": "74ef9b976db59ca6b23a5283469c9072be6276853807a83ec6c7ce412135c70a"
     },
+    "@std/data-structures@1.0.11": {
+      "integrity": "53b98ed7efa61f107dfc14244bd2ec5557f7f7ee0bbaef6d449d7937facacb89"
+    },
     "@std/dotenv@0.225.6": {
       "integrity": "1d6f9db72f565bd26790fa034c26e45ecb260b5245417be76c2279e5734c421b"
+    },
+    "@std/expect@1.0.18": {
+      "integrity": "8566eab35200466f8609eb7e7aed062ed0db314e9a258d5d201b1b8997ce801a",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.19",
+        "jsr:@std/internal",
+        "jsr:@std/path@^1.1.4"
+      ]
     },
     "@std/fmt@1.0.9": {
       "integrity": "2487343e8899fb2be5d0e3d35013e54477ada198854e52dd05ed0422eddcabe0"
@@ -97,6 +115,7 @@
       "integrity": "87bdc2700fa98249d48a17cd72413352d3d3680dcfbdb64947fd0982d6bbf681",
       "dependencies": [
         "jsr:@std/assert@^1.0.17",
+        "jsr:@std/data-structures",
         "jsr:@std/internal"
       ]
     },

--- a/docs/api-reference/veryfront/runs.md
+++ b/docs/api-reference/veryfront/runs.md
@@ -8,9 +8,9 @@ order: 23
 
 ```ts
 import {
-  createRunsClient,
   CancelRunResponseSchema,
   CreateRunResponseSchema,
+  createRunsClient,
   RunEventListSchema,
   RunEventSchema,
   RunListSchema,
@@ -40,49 +40,50 @@ const events = await runs.events(accepted.run.run_id);
 
 ### Components
 
-| Name | Description | Source |
-|------|-------------|--------|
-| `CancelRunResponseSchema` | Zod schema for a cancel-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L124) |
-| `CreateRunResponseSchema` | Zod schema for a create-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L122) |
-| `RunEventListSchema` | Zod schema for a paginated run-event response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L128) |
-| `RunEventSchema` | Zod schema for a run event. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L126) |
-| `RunListSchema` | Zod schema for a paginated project-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L130) |
-| `RunSchema` | Zod schema for a canonical durable run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L120) |
+| Name                      | Description                                      | Source                                                                                   |
+| ------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `CancelRunResponseSchema` | Zod schema for a cancel-run response.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L124) |
+| `CreateRunResponseSchema` | Zod schema for a create-run response.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L122) |
+| `RunEventListSchema`      | Zod schema for a paginated run-event response.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L128) |
+| `RunEventSchema`          | Zod schema for a run event.                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L126) |
+| `RunListSchema`           | Zod schema for a paginated project-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L130) |
+| `RunSchema`               | Zod schema for a canonical durable run.          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L120) |
 
 ### Functions
 
-| Name | Description | Source |
-|------|-------------|--------|
-| `createRunsClient` | Create a runs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L350) |
+| Name               | Description           | Source                                                                                       |
+| ------------------ | --------------------- | -------------------------------------------------------------------------------------------- |
+| `createRunsClient` | Create a runs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L388) |
 
 ### Classes
 
-| Name | Description | Source |
-|------|-------------|--------|
-| `VeryfrontRunsClient` | Public client for canonical durable runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L124) |
+| Name                  | Description                               | Source                                                                                       |
+| --------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `VeryfrontRunsClient` | Public client for canonical durable runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L132) |
 
 ### Types
 
-| Name | Description | Source |
-|------|-------------|--------|
-| `CancelRunResponse` | Response returned when a run is cancelled. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L149) |
-| `CreateRunResponse` | Response returned when a run is accepted. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L147) |
-| `CreateTaskRunInput` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L54) |
-| `CreateWorkflowRunInput` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L63) |
-| `KnowledgeIngestByUploadIdsInput` | Input payload for knowledge ingest by upload IDs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L71) |
-| `KnowledgeIngestByUploadPathsInput` | Input payload for knowledge ingest by upload paths. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L77) |
-| `KnowledgeIngestByUploadPrefixInput` | Input payload for knowledge ingest by upload prefix. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L83) |
-| `ListRunEventsOptions` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L93) |
-| `ListRunsOptions` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L88) |
-| `ProjectScopedOptions` | Options accepted by project-scoped run requests. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L34) |
-| `Run` | Canonical durable run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L145) |
-| `RunEvent` | Event emitted by a run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L151) |
-| `RunExecutionError` | Error payload recorded for failed task and workflow runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L143) |
-| `RunKind` | Canonical durable run kind. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L133) |
-| `RunList` | Paginated project run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L155) |
-| `RunOwner` | Canonical durable run owner. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L137) |
-| `RunRuntimeTargetKind` | Runtime target for a task or workflow run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L39) |
-| `RunRuntimeTargetOptions` | Runtime target fields accepted by run creation APIs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L42) |
-| `RunStatus` | Canonical durable run status. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L135) |
-| `RunTriggerKind` | Trigger kind recorded on scheduled or externally-started runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L141) |
-| `VeryfrontRunsClientConfig` | Configuration used by the Veryfront runs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L26) |
+| Name                                 | Description                                                    | Source                                                                                       |
+| ------------------------------------ | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `CancelRunResponse`                  | Response returned when a run is cancelled.                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L149)     |
+| `CreateEvalRunInput`                 | Input payload for creating an eval run.                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L71)  |
+| `CreateRunResponse`                  | Response returned when a run is accepted.                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L147)     |
+| `CreateTaskRunInput`                 |                                                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L54)  |
+| `CreateWorkflowRunInput`             |                                                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L63)  |
+| `KnowledgeIngestByUploadIdsInput`    | Input payload for knowledge ingest by upload IDs.              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L79)  |
+| `KnowledgeIngestByUploadPathsInput`  | Input payload for knowledge ingest by upload paths.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L85)  |
+| `KnowledgeIngestByUploadPrefixInput` | Input payload for knowledge ingest by upload prefix.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L91)  |
+| `ListRunEventsOptions`               |                                                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L101) |
+| `ListRunsOptions`                    |                                                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L96)  |
+| `ProjectScopedOptions`               | Options accepted by project-scoped run requests.               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L34)  |
+| `Run`                                | Canonical durable run.                                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L145)     |
+| `RunEvent`                           | Event emitted by a run.                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L151)     |
+| `RunExecutionError`                  | Error payload recorded for failed task and workflow runs.      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L143)     |
+| `RunKind`                            | Canonical durable run kind.                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L133)     |
+| `RunList`                            | Paginated project run response.                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L155)     |
+| `RunOwner`                           | Canonical durable run owner.                                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L137)     |
+| `RunRuntimeTargetKind`               | Runtime target for a task, workflow, or eval run.              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L39)  |
+| `RunRuntimeTargetOptions`            | Runtime target fields accepted by run creation APIs.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L42)  |
+| `RunStatus`                          | Canonical durable run status.                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L135)     |
+| `RunTriggerKind`                     | Trigger kind recorded on scheduled or externally-started runs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L141)     |
+| `VeryfrontRunsClientConfig`          | Configuration used by the Veryfront runs client.               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L26)  |

--- a/docs/guides/runs.md
+++ b/docs/guides/runs.md
@@ -28,8 +28,7 @@ evals are definitions. A run is what executes one of those definitions.
 
 ## Setup
 
-Use the runs SDK for one-off task and workflow execution. Eval runs share the
-same durable run record shape when the eval execution API is used:
+Use the runs SDK for one-off task, workflow, and eval execution:
 
 ```ts
 import { createRunsClient } from "veryfront/runs";
@@ -65,6 +64,18 @@ await runs.createWorkflowRun({
   workflowId: "content-pipeline",
   target: "workflow:content-pipeline",
   input: { topic: "AI agents" },
+});
+```
+
+## Create an eval run
+
+```ts
+await runs.createEvalRun({
+  projectId: "22222222-2222-4222-8222-222222222222",
+  target: "eval:deep-research",
+  input: { dataset: "smoke" },
+  config: { repetitions: 2 },
+  startMode: "manual",
 });
 ```
 

--- a/src/README.md
+++ b/src/README.md
@@ -595,7 +595,7 @@ See [`transforms/import-rewriter/README.md`](./transforms/import-rewriter/README
 
 **Exports**: `veryfront/runs`
 
-- `VeryfrontRunsClient` for task and workflow run management
+- `VeryfrontRunsClient` for task, workflow, and eval run management
 - Canonical run creation and event reading
 - Runtime environment helpers
 

--- a/src/eval/report.ts
+++ b/src/eval/report.ts
@@ -13,6 +13,7 @@ function isBlockingFailure(result: EvalMetricResult): boolean {
 }
 
 function recordPassed(record: EvalRecord): boolean {
+  if (!record.completed || record.error) return false;
   const results = [...(record.metrics ?? []), ...(record.checks ?? [])];
   return results.every((result) => !isBlockingFailure(result));
 }

--- a/src/eval/runner.test.ts
+++ b/src/eval/runner.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { datasets, evalAgent, metrics, runEval } from "veryfront/eval";
 
@@ -58,10 +58,35 @@ describe("eval/runner", () => {
       },
     });
 
-    assertEquals(report.records[0]?.checks.map((check) => check.name), [
+    const record = report.records[0];
+    assertExists(record);
+    assertEquals(record.checks?.map((check) => check.name), [
       "expect.completed",
       "expect.outputContains",
     ]);
     assertEquals(report.summary.passed, 1);
+  });
+
+  it("counts adapter errors as failed records even without metrics", async () => {
+    const definition = evalAgent({
+      id: "eval:adapter-error",
+      target: "agent:researcher",
+      dataset: datasets.inline([{ id: "q1", input: "France capital?" }]),
+    });
+
+    const report = await runEval(definition, {
+      adapters: {
+        agent: async () => {
+          throw new Error("AG-UI request failed");
+        },
+      },
+    });
+
+    assertEquals(report.summary.records, 1);
+    assertEquals(report.summary.passed, 0);
+    assertEquals(report.summary.failed, 1);
+    assertEquals(report.summary.passRate, 0);
+    assertEquals(report.records[0]?.completed, false);
+    assertEquals(report.records[0]?.error, "AG-UI request failed");
   });
 });

--- a/src/runs/index.ts
+++ b/src/runs/index.ts
@@ -23,6 +23,7 @@
  */
 
 export {
+  type CreateEvalRunInput,
   createRunsClient,
   type CreateTaskRunInput,
   type CreateWorkflowRunInput,

--- a/src/runs/runs-client.test.ts
+++ b/src/runs/runs-client.test.ts
@@ -208,6 +208,49 @@ describe("VeryfrontRunsClient", () => {
     });
   });
 
+  it("creates eval runs through canonical /runs", async () => {
+    mockFetch([
+      jsonResponse({
+        accepted: true,
+        run: makeRun({
+          kind: "eval",
+          target: "eval:capital-basic-eval",
+          input: { dataset: "smoke" },
+          config: { repetitions: 2 },
+        }),
+      }, 202),
+    ]);
+
+    const client = new VeryfrontRunsClient({
+      apiUrl: "https://api.test.com",
+      authToken: "test-token",
+      projectReference: "dreamy-haven",
+    });
+
+    await client.createEvalRun({
+      projectId,
+      target: "eval:capital-basic-eval",
+      input: { dataset: "smoke" },
+      config: { repetitions: 2 },
+      startMode: "manual",
+      runtimeTargetKind: "environment",
+      runtimeTargetEnvironmentId: "44444444-4444-4444-8444-444444444444",
+    });
+
+    assertEquals(jsonBody(0), {
+      kind: "eval",
+      owner: { kind: "project", id: projectId },
+      request: {
+        target: "eval:capital-basic-eval",
+        runtime_target_kind: "environment",
+        runtime_target_environment_id: "44444444-4444-4444-8444-444444444444",
+        input: { dataset: "smoke" },
+        config: { repetitions: 2 },
+        start_mode: "manual",
+      },
+    });
+  });
+
   it("creates knowledge ingest task runs", async () => {
     mockFetch([jsonResponse({ accepted: true, run: makeRun() }, 202)]);
 

--- a/src/runs/runs-client.ts
+++ b/src/runs/runs-client.ts
@@ -36,7 +36,7 @@ export interface ProjectScopedOptions {
   projectReference?: string;
 }
 
-/** Runtime target for a task or workflow run. */
+/** Runtime target for a task, workflow, or eval run. */
 export type RunRuntimeTargetKind = "main_branch" | "environment" | "preview_branch";
 
 /** Runtime target fields accepted by run creation APIs. */
@@ -65,6 +65,14 @@ export interface CreateWorkflowRunInput extends RunCreateBaseInput, RunRuntimeTa
   workflowId: string;
   target: `workflow:${string}`;
   input?: Record<string, unknown>;
+  startMode?: string;
+}
+
+/** Input payload for creating an eval run. */
+export interface CreateEvalRunInput extends RunCreateBaseInput, RunRuntimeTargetOptions {
+  target: `eval:${string}`;
+  input?: Record<string, unknown>;
+  config?: Record<string, unknown>;
   startMode?: string;
 }
 
@@ -221,6 +229,36 @@ export class VeryfrontRunsClient {
           target,
           ...runtimeTargetBody(runtimeTarget),
           input: workflowInput,
+          start_mode: startMode,
+        },
+      },
+    });
+  }
+
+  createEvalRun(input: CreateEvalRunInput): Promise<CreateRunResponse> {
+    const {
+      projectId,
+      publicId,
+      parentRunId,
+      target,
+      input: evalInput,
+      config,
+      startMode,
+      ...runtimeTarget
+    } = input;
+
+    return this.requestJson("/runs", CreateRunResponseSchema, {
+      method: "POST",
+      body: {
+        kind: "eval",
+        owner: { kind: "project", id: projectId },
+        public_id: publicId,
+        parent_run_id: parentRunId,
+        request: {
+          target,
+          ...runtimeTargetBody(runtimeTarget),
+          input: evalInput,
+          config,
           start_mode: startMode,
         },
       },

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -298,6 +298,61 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     assertEquals(receivedAuthToken, "runtime-token");
   });
 
+  it("marks eval execution unsuccessful when records contain adapter failures", async () => {
+    const report: EvalReport = {
+      kind: "eval-report",
+      runId: "run_eval_failed_adapter",
+      definitionId: "eval:deep-research",
+      targetKind: "agent",
+      target: "agent:researcher",
+      startedAt: "2026-06-20T10:00:00.000Z",
+      endedAt: "2026-06-20T10:00:01.000Z",
+      summary: { records: 1, passed: 1, failed: 0, passRate: 1, metrics: [] },
+      records: [{
+        id: "q1:1",
+        evalId: "eval:deep-research",
+        exampleId: "q1",
+        repetition: 1,
+        input: "France capital?",
+        output: { text: "" },
+        metadata: {},
+        trace: { events: [], toolCalls: [] },
+        usage: {},
+        durationMs: 10,
+        completed: false,
+        error: "AG-UI request failed",
+        metrics: [],
+        checks: [],
+      }],
+    };
+    const handler = new ProjectRunExecuteHandler(createDeps({
+      runEval: async () => report,
+    }));
+    const body = {
+      runId: "run_eval_failed_adapter",
+      kind: "eval",
+      target: "eval:deep-research",
+      projectId: "proj-1",
+    };
+    const { request, publicKeyPem } = await signedRequest(
+      "/api/control-plane/runs/run_eval_failed_adapter/execute",
+      body,
+      { "x-token": "runtime-token" },
+    );
+
+    const result = await handler.handle(request, createCtx(publicKeyPem));
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(await result.response.json(), {
+      success: false,
+      result: report,
+      error: "1 eval record failed",
+      logs: null,
+      duration_ms: 0,
+    });
+  });
+
   it("discovers project agents and tools before starting workflow agent steps", async () => {
     const order: string[] = [];
     let hasAgentRegistry = false;

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { datasets, evalAgent, type EvalReport } from "veryfront/eval";
 import {
   ProjectRunExecuteHandler,
   type ProjectRunExecuteHandlerDeps,
@@ -35,6 +36,20 @@ function createDeps(
           definition: { id: "publish", steps: [] },
         }
         : null,
+    findEvalById: async (target) =>
+      target === "eval:deep-research"
+        ? {
+          id: "eval:deep-research",
+          name: "Deep research quality",
+          filePath: "evals/deep-research.eval.ts",
+          exportName: "default",
+          definition: evalAgent({
+            id: "eval:deep-research",
+            target: "agent:researcher",
+            dataset: datasets.inline([{ id: "q1", input: "France capital?" }]),
+          }),
+        }
+        : null,
     createWorkflowClient: () => ({
       register: () => {},
       start: async (_workflowId: string, _input: unknown, options?: { runId?: string }) => ({
@@ -46,6 +61,18 @@ function createDeps(
       }),
       destroy: async () => {},
     }),
+    runEval: async (definition, options) => ({
+      kind: "eval-report",
+      runId: options.runId ?? "eval-run",
+      definitionId: definition.id,
+      targetKind: definition.targetKind,
+      target: definition.target,
+      startedAt: "2026-06-20T10:00:00.000Z",
+      endedAt: "2026-06-20T10:00:01.000Z",
+      summary: { records: 1, passed: 1, failed: 0, passRate: 1, metrics: [] },
+      records: [],
+    }),
+    createEvalAgentAdapter: () => async () => ({ text: "Paris" }),
     executeKnowledgeIngest: async () => ({
       success: true,
       result: { kind: "knowledge_ingest", summary: { ingested_count: 1 } },
@@ -68,6 +95,7 @@ function createDeps(
 async function signedRequest(
   path: string,
   body: Record<string, unknown>,
+  headers: Record<string, string> = {},
 ): Promise<{ request: Request; publicKeyPem: string }> {
   const rawBody = JSON.stringify(body);
   const { jws, publicKeyPem } = await createControlPlaneSignature(rawBody, {
@@ -82,6 +110,7 @@ async function signedRequest(
       headers: {
         "content-type": "application/json",
         "x-veryfront-control-plane-jws": jws,
+        ...headers,
       },
       body: rawBody,
     }),
@@ -209,6 +238,64 @@ describe("server/handlers/request/project-run-execute.handler", () => {
       input: { release: "v1" },
       options: { runId: "run_workflow_1" },
     });
+  });
+
+  it("runs a discovered eval with the canonical run id and AG-UI adapter", async () => {
+    const report: EvalReport = {
+      kind: "eval-report",
+      runId: "run_eval_1",
+      definitionId: "eval:deep-research",
+      targetKind: "agent",
+      target: "agent:researcher",
+      startedAt: "2026-06-20T10:00:00.000Z",
+      endedAt: "2026-06-20T10:00:01.000Z",
+      summary: { records: 1, passed: 1, failed: 0, passRate: 1, metrics: [] },
+      records: [],
+    };
+    let receivedRunId: string | undefined;
+    let receivedBaseDir: string | undefined;
+    let receivedEndpoint: string | undefined;
+    let receivedAuthToken: string | undefined;
+    const handler = new ProjectRunExecuteHandler(createDeps({
+      runEval: async (_definition, options) => {
+        receivedRunId = options.runId;
+        receivedBaseDir = options.baseDir;
+        return report;
+      },
+      createEvalAgentAdapter: (config) => {
+        receivedEndpoint = config.endpoint;
+        receivedAuthToken = config.authToken;
+        return async () => ({ text: "Paris" });
+      },
+    }));
+    const body = {
+      runId: "run_eval_1",
+      kind: "eval",
+      target: "eval:deep-research",
+      projectId: "proj-1",
+      input: { dataset: "smoke" },
+      config: { repetitions: 2 },
+    };
+    const { request, publicKeyPem } = await signedRequest(
+      "/api/control-plane/runs/run_eval_1/execute",
+      body,
+      { "x-token": "runtime-token" },
+    );
+
+    const result = await handler.handle(request, createCtx(publicKeyPem));
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(await result.response.json(), {
+      success: true,
+      result: report,
+      duration_ms: 0,
+      logs: null,
+    });
+    assertEquals(receivedRunId, "run_eval_1");
+    assertEquals(receivedBaseDir, "/project");
+    assertEquals(receivedEndpoint, "https://example.com/api/ag-ui");
+    assertEquals(receivedAuthToken, "runtime-token");
   });
 
   it("discovers project agents and tools before starting workflow agent steps", async () => {

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -14,6 +14,18 @@ import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { type DiscoveredTask, findTaskById } from "#veryfront/task/discovery.ts";
 import { runTask, type RunTaskOptions, type TaskRunResult } from "#veryfront/task/runner.ts";
+import { type DiscoveredEval, findEvalById } from "#veryfront/eval/discovery.ts";
+import { runEval } from "#veryfront/eval/runner.ts";
+import {
+  createAgentServiceEvalAdapter,
+  type AgentServiceEvalAdapterConfig,
+} from "#veryfront/eval/agent-service.ts";
+import type {
+  EvalAgentAdapter,
+  EvalDefinition,
+  EvalReport,
+  RunEvalOptions,
+} from "#veryfront/eval/types.ts";
 import type { Logger } from "#veryfront/utils";
 import { agentRegistry } from "#veryfront/agent/composition/index.ts";
 import { type DiscoveredWorkflow, findWorkflowById } from "#veryfront/workflow/discovery";
@@ -33,7 +45,7 @@ const WORKFLOW_PERSISTENCE_REQUIRED_ERROR =
 
 export interface ProjectRunExecuteRequest {
   runId: string;
-  kind: "task" | "workflow";
+  kind: "task" | "workflow" | "eval";
   target: string;
   projectId: string;
   config?: Record<string, unknown>;
@@ -92,9 +104,20 @@ export interface ProjectRunExecuteHandlerDeps {
       debug?: boolean;
     },
   ): Promise<DiscoveredWorkflow | null>;
+  findEvalById(
+    evalId: string,
+    options: {
+      projectDir: string;
+      adapter: RuntimeAdapter;
+      config?: VeryfrontConfig;
+      debug?: boolean;
+    },
+  ): Promise<DiscoveredEval | null>;
   createWorkflowClient(
     config?: WorkflowClientConfig,
   ): WorkflowClientView | Promise<WorkflowClientView>;
+  runEval(definition: EvalDefinition, options: RunEvalOptions): Promise<EvalReport>;
+  createEvalAgentAdapter(config: AgentServiceEvalAdapterConfig): EvalAgentAdapter;
   ensureProjectDiscovery(ctx: HandlerContext): Promise<void>;
   executeKnowledgeIngest(input: {
     request: ProjectRunExecuteRequest;
@@ -130,13 +153,16 @@ function parseExecuteRequest(value: unknown, pathRunId: string): ProjectRunExecu
 
   if (typeof runId !== "string" || !runId) throw new Error("Invalid runId");
   if (runId !== pathRunId) throw new Error("Run id does not match request path");
-  if (kind !== "task" && kind !== "workflow") throw new Error("Invalid run kind");
+  if (kind !== "task" && kind !== "workflow" && kind !== "eval") {
+    throw new Error("Invalid run kind");
+  }
   if (typeof target !== "string" || !target) throw new Error("Invalid target");
   if (typeof projectId !== "string" || !projectId) throw new Error("Invalid projectId");
   if (kind === "task" && !target.startsWith("task:")) throw new Error("Invalid task target");
   if (kind === "workflow" && !target.startsWith("workflow:")) {
     throw new Error("Invalid workflow target");
   }
+  if (kind === "eval" && !target.startsWith("eval:")) throw new Error("Invalid eval target");
 
   return {
     runId,
@@ -353,9 +379,21 @@ interface RuntimeApiClient {
   delete<T>(path: string): Promise<T>;
 }
 
+function getRuntimeApiToken(req: Request, ctx: HandlerContext): string {
+  return req.headers.get("x-token") ?? ctx.proxyToken ?? ctx.requestContext?.token ?? "";
+}
+
+function getSameOriginAgUiEndpoint(req: Request): string {
+  const url = new URL(req.url);
+  url.pathname = "/api/ag-ui";
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
 function createRuntimeApiClient(req: Request, ctx: HandlerContext): RuntimeApiClient {
   const apiUrl = getEnvironmentConfig().apiBaseUrl;
-  const token = req.headers.get("x-token") ?? ctx.proxyToken ?? ctx.requestContext?.token ?? "";
+  const token = getRuntimeApiToken(req, ctx);
   if (!token) {
     throw new Error("Missing project runtime API token");
   }
@@ -610,6 +648,98 @@ function getNumberConfig(
   return undefined;
 }
 
+function getPositiveIntConfig(
+  config: Record<string, unknown>,
+  keys: readonly string[],
+): number | undefined {
+  const value = getNumberConfig(config, keys);
+  if (value === undefined) return undefined;
+  const normalized = Math.trunc(value);
+  return normalized > 0 ? normalized : undefined;
+}
+
+function withEvalRunConfig(
+  definition: EvalDefinition,
+  config: Record<string, unknown>,
+): EvalDefinition {
+  const repetitions = getPositiveIntConfig(config, ["repetitions", "repeat", "repetitionCount"]);
+  if (repetitions === undefined || repetitions === definition.repetitions) {
+    return definition;
+  }
+
+  return {
+    ...definition,
+    repetitions,
+  };
+}
+
+function createEvalAdapterConfig(input: {
+  request: ProjectRunExecuteRequest;
+  req: Request;
+  ctx: HandlerContext;
+}): AgentServiceEvalAdapterConfig {
+  const config = input.request.config ?? {};
+  const runInput = input.request.input ?? {};
+  const authToken = getRuntimeApiToken(input.req, input.ctx);
+  if (!authToken) {
+    throw new Error("Missing project runtime API token");
+  }
+
+  return {
+    endpoint: getSameOriginAgUiEndpoint(input.req),
+    authToken,
+    projectId: input.request.projectId,
+    branchId: getStringConfig(config, ["branch_id", "branchId"]) ??
+      getStringConfig(runInput, ["branch_id", "branchId"]),
+    model: getStringConfig(config, ["model"]),
+    allowedTools: getStringArrayConfig(config, ["allowed_tools", "allowedTools"]),
+    maxSteps: getPositiveIntConfig(config, ["max_steps", "maxSteps"]),
+  };
+}
+
+async function executeEvalRun(
+  request: ProjectRunExecuteRequest,
+  ctx: HandlerContext,
+  req: Request,
+  deps: ProjectRunExecuteHandlerDeps,
+): Promise<ProjectRunExecuteResponse> {
+  const startedAt = deps.now();
+  await deps.ensureProjectDiscovery(ctx);
+  const evalItem = await deps.findEvalById(request.target, {
+    projectDir: ctx.projectDir,
+    adapter: ctx.adapter,
+    config: ctx.config,
+    debug: ctx.debug,
+  });
+
+  if (!evalItem) {
+    return {
+      success: false,
+      error: `Eval not found: ${request.target}`,
+      logs: null,
+      duration_ms: 0,
+    };
+  }
+
+  const config = request.config ?? {};
+  const report = await deps.runEval(withEvalRunConfig(evalItem.definition, config), {
+    adapters: {
+      agent: deps.createEvalAgentAdapter(createEvalAdapterConfig({ request, req, ctx })),
+    },
+    baseDir: ctx.projectDir,
+    runId: request.runId,
+  });
+  const failed = report.summary.failed;
+
+  return {
+    success: failed === 0,
+    result: report,
+    ...(failed > 0 ? { error: `${failed} eval record${failed === 1 ? "" : "s"} failed` } : {}),
+    logs: null,
+    duration_ms: Math.max(0, deps.now() - startedAt),
+  };
+}
+
 async function executeReleaseAssetBuildRun(input: {
   request: ProjectRunExecuteRequest;
   ctx: HandlerContext;
@@ -713,7 +843,10 @@ const defaultDeps: ProjectRunExecuteHandlerDeps = {
   findTaskById,
   runTask,
   findWorkflowById,
+  findEvalById,
   createWorkflowClient: createRuntimeWorkflowClient,
+  runEval,
+  createEvalAgentAdapter: createAgentServiceEvalAdapter,
   ensureProjectDiscovery,
   executeKnowledgeIngest: executeKnowledgeIngestRun,
   executeReleaseAssetBuild: executeReleaseAssetBuildRun,
@@ -775,6 +908,8 @@ export class ProjectRunExecuteHandler extends BaseHandler {
             ? await this.deps.executeReleaseAssetBuild({ request, ctx, req })
             : request.kind === "task"
             ? await executeTaskRun(request, ctx, this.deps)
+            : request.kind === "eval"
+            ? await executeEvalRun(request, ctx, req, this.deps)
             : await executeWorkflowRun(request, ctx, this.deps);
           return this.respond(builder.json(response, 200));
         } catch (error) {

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -23,6 +23,8 @@ import {
 import type {
   EvalAgentAdapter,
   EvalDefinition,
+  EvalMetricResult,
+  EvalRecord,
   EvalReport,
   RunEvalOptions,
 } from "#veryfront/eval/types.ts";
@@ -658,6 +660,20 @@ function getPositiveIntConfig(
   return normalized > 0 ? normalized : undefined;
 }
 
+function isBlockingEvalResult(result: EvalMetricResult): boolean {
+  return !result.skipped && result.pass === false &&
+    (result.severity === "gate" || result.severity === "budget");
+}
+
+function evalRecordFailed(record: EvalRecord): boolean {
+  if (!record.completed || record.error) return true;
+  return [...(record.metrics ?? []), ...(record.checks ?? [])].some(isBlockingEvalResult);
+}
+
+function countFailedEvalRecords(report: EvalReport): number {
+  return report.records.filter(evalRecordFailed).length;
+}
+
 function withEvalRunConfig(
   definition: EvalDefinition,
   config: Record<string, unknown>,
@@ -729,7 +745,7 @@ async function executeEvalRun(
     baseDir: ctx.projectDir,
     runId: request.runId,
   });
-  const failed = report.summary.failed;
+  const failed = Math.max(report.summary.failed, countFailedEvalRecords(report));
 
   return {
     success: failed === 0,

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -17,8 +17,8 @@ import { runTask, type RunTaskOptions, type TaskRunResult } from "#veryfront/tas
 import { type DiscoveredEval, findEvalById } from "#veryfront/eval/discovery.ts";
 import { runEval } from "#veryfront/eval/runner.ts";
 import {
-  createAgentServiceEvalAdapter,
   type AgentServiceEvalAdapterConfig,
+  createAgentServiceEvalAdapter,
 } from "#veryfront/eval/agent-service.ts";
 import type {
   EvalAgentAdapter,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.879";
+export const VERSION = "0.1.880";


### PR DESCRIPTION
## Summary
- Adds durable eval run creation to the public runs SDK.
- Lets project runtimes execute canonical eval runs through eval discovery and the AG-UI eval adapter.
- Bumps the framework package to 0.1.880 and refreshes the lockfile for release checks.

## Test Plan
- deno test --lock=deno.lock --frozen --no-check --allow-all src/server/handlers/request/project-run-execute.handler.test.ts
- deno check --lock=deno.lock --frozen src/server/handlers/request/project-run-execute.handler.ts src/server/handlers/request/project-run-execute.handler.test.ts
- deno task typecheck
- deno task lint:style
- pre-push hook: formatting, lint, type check, unit tests: 2195 passed, 18833 steps

## Rollout
- Merge and release this as veryfront 0.1.880 before bumping downstream package consumers for runtime eval execution.