### PR TITLE
Expose eval run capability to Studio

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.880",
+  "version": "0.1.881",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/api-reference/veryfront/eval.md
+++ b/docs/api-reference/veryfront/eval.md
@@ -109,7 +109,7 @@ const report = await runEval(definition, {
 | `EvalSourceDocument` | Studio-editable Eval source document. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L145) |
 | `EvalSourcePatch` | Eval source patch submitted by Studio forms. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L147) |
 | `EvalSourceReference` | Source location for an Eval definition. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L143) |
-| `EvalStudioCapability` | Capability string Studio uses for Eval read and write access. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L139) |
+| `EvalStudioCapability` | Capability string Studio uses for Eval source and run actions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L139) |
 | `EvalTargetKind` | Primitive kind an eval can execute. V1 supports agent targets. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L7) |
 | `EvalToolCall` | Tool call metadata captured during one eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L62) |
 | `EvalTrace` | Trace metadata captured for one eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L70) |

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -277,8 +277,9 @@ for Studio panels. The document exposes `editableFields`, `dynamicFields`,
 the eval capabilities required by the panel.
 
 Use `project.evals.read` for listing reports and definitions. Use
-`project.evals.write` for editing eval source definitions. Triggering an eval run
-also records a canonical run with kind `eval` when the durable run API is used.
+`project.evals.write` for editing eval source definitions. Source documents that
+can start durable runs also include `project.evals.run`. Triggering an eval run
+records a canonical run with kind `eval` when the durable run API is used.
 
 ## Verify it worked
 

--- a/src/eval/studio.test.ts
+++ b/src/eval/studio.test.ts
@@ -54,7 +54,11 @@ describe("eval/studio", () => {
       exportName: "default",
       content: "export default evalAgent({})",
     });
-    assertEquals(document.capabilities, ["project.evals.read", "project.evals.write"]);
+    assertEquals(document.capabilities, [
+      "project.evals.read",
+      "project.evals.write",
+      "project.evals.run",
+    ]);
     assertEquals(document.editableFields.includes("dataset"), true);
     assertEquals(document.dataset.kind, "inline");
     assertEquals(document.dataset.examples?.[0]?.reference, "Paris");

--- a/src/eval/studio.ts
+++ b/src/eval/studio.ts
@@ -5,7 +5,7 @@ import type { EvalDefinition, EvalExample } from "./types.ts";
 
 /** Schema for Eval Studio capabilities. */
 export const getEvalStudioCapabilitySchema = defineSchema((v) =>
-  v.enum(["project.evals.read", "project.evals.write"] as const)
+  v.enum(["project.evals.read", "project.evals.write", "project.evals.run"] as const)
 );
 
 /** Schema for an editable Eval source field name. */
@@ -136,7 +136,7 @@ export const getEvalRunSchema = defineSchema((v) =>
   })
 );
 
-/** Capability string Studio uses for Eval read and write access. */
+/** Capability string Studio uses for Eval source and run actions. */
 export type EvalStudioCapability = InferSchema<ReturnType<typeof getEvalStudioCapabilitySchema>>;
 /** Form-editable Eval source field name. */
 export type EvalEditableField = InferSchema<ReturnType<typeof getEvalEditableFieldSchema>>;
@@ -158,6 +158,7 @@ export interface CreateEvalSourceDocumentOptions {
 const DEFAULT_EVAL_STUDIO_CAPABILITIES: EvalStudioCapability[] = [
   "project.evals.read",
   "project.evals.write",
+  "project.evals.run",
 ];
 
 const BASE_EDITABLE_FIELDS: EvalEditableField[] = [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.880";
+export const VERSION = "0.1.881";

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -252,6 +252,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "--junit",
       "project.evals.read",
       "project.evals.write",
+      "project.evals.run",
     ],
   },
   "guides/head-and-seo.md": {


### PR DESCRIPTION
## Summary
- add project.evals.run to the public eval Studio capability schema
- advertise read/write/run by default for eval source documents so Studio can show run actions
- bump the framework package version to 0.1.881 and keep VERSION in sync
- update eval guide and API reference text for runnable source docs

## Verification
- deno test --no-check --allow-all src/eval/studio.test.ts tests/docs/guide-contracts.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- deno fmt --check src/utils/version-constant.ts deno.json src/eval/studio.ts src/eval/studio.test.ts tests/docs/guide-contracts.test.ts docs/guides/evals.md
- pre-push broad Deno gate was run before the version-constant fix and only failed on VERSION/deno.json mismatch; targeted version/logger tests pass after the fix