### PR TITLE
Release veryfront 0.1.882

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.881",
+  "version": "0.1.882",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.881";
+export const VERSION = "0.1.882";


### PR DESCRIPTION
## Summary
- Bumps `veryfront` from `0.1.881` to `0.1.882` so the merged hosted runtime allowedTools fix can be published and consumed by downstream services.
- Keeps `deno.json` and the generated version constant in sync.

## Verification
- `deno fmt --check deno.json src/utils/version-constant.ts src/utils/version.ts cli/commands/init/config-generator.ts`
- `deno check src/utils/version.ts cli/commands/init/config-generator.ts`
- pre-commit `deno task verify:quick`
- `npm view veryfront@0.1.882` returned not found before the bump PR

Refs veryfront-agent#1598.