### PR TITLE
Fix default research workspace artifact canonicalization

### DIFF
--- a/src/agent/artifacts/default-research-artifact-support.test.ts
+++ b/src/agent/artifacts/default-research-artifact-support.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  applyDefaultResearchArtifactPath,
   createDefaultResearchRunArtifactMirrorHandler,
   type DefaultResearchArtifactContext,
   extractLatestUserText,
@@ -45,6 +46,25 @@ describe("default research artifact support", () => {
     assertEquals(
       taskContext.defaultResearchArtifacts?.currentReportPath,
       "/research/ai-coding-agents/report.md",
+    );
+  });
+
+  it("canonicalizes default research topic-root markdown files to the current report path", () => {
+    assertEquals(
+      applyDefaultResearchArtifactPath(
+        "create_file",
+        {
+          path: "research/ai-coding-agents.md",
+          content: "# report",
+        },
+        {
+          defaultResearchArtifacts: defaultArtifacts(),
+        },
+      ),
+      {
+        path: "research/ai-coding-agents/report.md",
+        content: "# report",
+      },
     );
   });
 

--- a/src/agent/artifacts/default-research-artifact-support.ts
+++ b/src/agent/artifacts/default-research-artifact-support.ts
@@ -234,12 +234,20 @@ export function applyDefaultResearchArtifactPath(
   const canonicalRunPath = defaultArtifacts.runReportPath.replace(/^\/+/, "");
   const canonicalFindingsPath = defaultArtifacts.findingsPath.replace(/^\/+/, "");
   const canonicalSourcesPath = defaultArtifacts.sourcesPath.replace(/^\/+/, "");
+  const canonicalTopicRootPath = canonicalCurrentPath.replace(/\/report\.md$/, "");
 
   if (
     path === canonicalCurrentPath || path === canonicalRunPath || path === canonicalFindingsPath ||
     path === canonicalSourcesPath
   ) {
     return toolInput;
+  }
+
+  if (path === `${canonicalTopicRootPath}.md`) {
+    return {
+      ...toolInput,
+      path: canonicalCurrentPath,
+    };
   }
 
   if (!path.endsWith("/report.md") && path !== "report.md") {


### PR DESCRIPTION
## Summary
- canonicalize default research topic-root markdown writes like `research/<topic>.md` to `research/<topic>/report.md`
- preserve the existing run-scoped mirror path so durable research canaries get both the current report and `runs/<run>.report.md`
- add regression coverage for the staging path shape observed while investigating veryfront-agent#403

## Root cause
The durable staging canary was not seeing malformed empty `create_file` input anymore. The failed default-workspace research run made one valid `create_file` call with a topic-root markdown path. Because `applyDefaultResearchArtifactPath` only canonicalized `report.md` or `*/report.md`, the file was written outside the default research workspace contract and the mirror hook never produced the run-scoped report.

## Test Plan
- RED: `deno test src/agent/artifacts/default-research-artifact-support.test.ts` failed on the new topic-root markdown canonicalization regression test
- GREEN: `deno test src/agent/artifacts/default-research-artifact-support.test.ts`
- `deno test src/agent/artifacts/default-research-artifact-policy.test.ts src/agent/artifacts/default-research-artifact-support.test.ts src/agent/hosted/chat-runtime-tool-assembly.test.ts`
- `deno task verify:quick`
- pre-commit `deno task verify:quick`

No auth tokens, project IDs, or raw staging report payloads are included.