### PR TITLE
Release veryfront 0.1.883

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.882",
+  "version": "0.1.883",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.882";
+export const VERSION = "0.1.883";


### PR DESCRIPTION
## Summary\n- bump framework package version to 0.1.883\n- publish the default research workspace artifact fix from #2577 for veryfront-agent staging verification\n\n## Test plan\n- deno task verify:quick\n- pre-commit deno task verify:quick\n\nNo sensitive values included.