### PR TITLE
Disable provider tools for create_agent final step

### DIFF
--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -919,10 +919,11 @@ export class AgentRuntime {
       currentRuntimeContext = preparedStep.runtimeContext;
       const toolContext = preparedStep.toolContext;
       const tools = toolsDisabledForFinalResponse ? [] : preparedStep.tools;
+      const stepProviderTools = toolsDisabledForFinalResponse ? [] : providerTools;
 
       const runtimeTools = convertToolsToRuntimeTools(tools, {
         model: effectiveModel,
-        providerTools,
+        providerTools: stepProviderTools,
       });
       const runtimeToolNames = Object.keys(runtimeTools ?? {});
 

--- a/src/agent/runtime/refresh.test.ts
+++ b/src/agent/runtime/refresh.test.ts
@@ -207,6 +207,93 @@ describe("agent runtime refresh hooks", () => {
     assertEquals(toolResults[0]?.context?.projectId, "project-generate");
   });
 
+  it("removes provider-native tools from the forced final response after create_agent", async () => {
+    const toolNamesByStep: string[][] = [];
+    let callCount = 0;
+    const model: ModelRuntime = {
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "unused" }],
+          finishReason: "stop",
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        };
+      },
+      async doStream(options) {
+        const rawTools = (options as { tools?: unknown }).tools;
+        const toolNames = Array.isArray(rawTools)
+          ? rawTools.map((entry) =>
+            (entry as { name?: string; id?: string }).name ??
+              (entry as { name?: string; id?: string }).id ?? ""
+          )
+          : Object.keys((rawTools as Record<string, unknown> | undefined) ?? {});
+        toolNamesByStep.push(toolNames);
+        callCount++;
+
+        if (callCount === 1) {
+          return {
+            stream: createRuntimeStream([
+              {
+                type: "tool-call",
+                toolCallId: "create-agent-1",
+                toolName: "create_agent",
+                input: '{"id":"gmail-assistant-e2e"}',
+              },
+              {
+                type: "finish",
+                finishReason: "tool-calls",
+                usage: { inputTokens: 1, outputTokens: 1 },
+              },
+            ]),
+          };
+        }
+
+        return {
+          stream: createRuntimeStream([
+            { type: "text-delta", text: "Created Gmail Assistant." },
+            {
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 1, outputTokens: 1 },
+            },
+          ]),
+        };
+      },
+    };
+
+    const createAgent = tool({
+      id: "create_agent",
+      description: "Create a Studio project agent",
+      inputSchema: defineSchema((v) => v.object({ id: v.string() }))(),
+      execute: async ({ id }) => ({
+        id,
+        name: "Gmail Assistant",
+        source_path: `agents/${id}.ts`,
+      }),
+    });
+
+    const assistant = agent({
+      model: "anthropic/claude-sonnet-4-6",
+      system: "Create agents and summarize successful tool results.",
+      tools: { create_agent: createAgent },
+      providerTools: ["web_search", "web_fetch"],
+      maxSteps: 3,
+      resolveModelTransport: async () => ({ model }),
+    });
+
+    const response = (await assistant.stream({
+      input: "Create a Gmail agent",
+    })).toDataStreamResponse();
+
+    await response.text();
+    assertEquals(toolNamesByStep.length, 2);
+    assertEquals(toolNamesByStep[0]?.includes("create_agent"), true);
+    assertEquals(toolNamesByStep[0]?.includes("web_search"), true);
+    assertEquals(toolNamesByStep[0]?.includes("web_fetch"), true);
+    assertEquals(toolNamesByStep[1], []);
+  });
+
   it("notifies configured hooks after stream() executes a tool", async () => {
     const toolResults: ToolExecutionResultRequest[] = [];
     let callCount = 0;


### PR DESCRIPTION
## What

Disable provider-native tools during the forced final response step after `create_agent` has executed in the streaming runtime.

## Why

Staging canonical starter-prompt verification showed the model successfully called `create_agent`, but the framework then forced a final response with local/project tools disabled while provider-native tools (`web_search`/`web_fetch`) were still exposed. That made the final step see only web tools and recant the successful agent creation.

Blocks veryfront/veryfront-studio#5081 and fixes veryfront/veryfront-agent#1602.

## How

When `toolsDisabledForFinalResponse` is active, pass an empty provider tool list to `convertToolsToRuntimeTools`, so the final summarization step has no tools at all and must summarize persisted tool results.

## Verification

- `deno fmt src/agent/runtime/index.ts src/agent/runtime/refresh.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/agent/runtime/refresh.test.ts`

Note: pre-push full `deno task test:unit` was attempted and failed on pre-existing/unrelated `observability/metrics/config` env default expectations (`otlp` vs `console`).
