### PR TITLE
Release v0.1.884

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.883",
+  "version": "0.1.884",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.883";
+export const VERSION = "0.1.884";


### PR DESCRIPTION
## What

Bump `veryfront` to `0.1.884` so the merged create-agent final-step runtime fix can publish and deploy.

## Why

The prior main release attempt for veryfront/veryfront-code#2579 failed because `deno.json` still pointed at already-published `0.1.883`.

## Verification

This is a version-only release PR. The runtime fix PR checks passed before merge, including unit/integration/e2e/coverage.
