### PR TITLE
Let eval telemetry flow through extension-owned HTTP sinks

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -50,6 +50,7 @@
     "./extensions/ext-parser-babel",
     "./extensions/ext-sandbox-shell-tools",
     "./extensions/ext-observability-opentelemetry",
+    "./extensions/ext-eval-report-http",
     "./extensions/ext-content-mdx",
     "./extensions/ext-schema-zod"
   ],

--- a/deno.lock
+++ b/deno.lock
@@ -5026,6 +5026,12 @@
           "npm:@kreuzberg/wasm@4.5.2"
         ]
       },
+      "extensions/ext-eval-report-http": {
+        "dependencies": [
+          "jsr:@std/assert@1.0.19",
+          "jsr:@std/testing@1.0.17"
+        ]
+      },
       "extensions/ext-llm-anthropic": {
         "dependencies": [
           "jsr:@std/assert@1.0.19",

--- a/docs/concepts/framework-extensions.md
+++ b/docs/concepts/framework-extensions.md
@@ -40,9 +40,13 @@ For implementation steps, see [Extensions](../guides/extensions.md) and
 Eval report export and runtime observability are separate extension surfaces.
 Use `veryfront/extensions/eval` when a project needs to send completed
 `EvalReport` payloads to an eval platform such as Braintrust, Langfuse, or
-LangSmith. Use `veryfront/extensions/observability` for runtime tracing,
-OpenTelemetry SDK setup, spans, and monitoring.
+LangSmith. Use `@veryfront/ext-eval-report-http` for a generic HTTP transport
+when a project wants one gateway endpoint instead of vendor SDKs. Use
+`veryfront/extensions/observability` for runtime tracing, OpenTelemetry SDK
+setup, spans, and monitoring.
 
 Eval exporters receive redacted reports by default. Projects must explicitly
 allow inputs, outputs, references, traces, metric evidence, metric explanations,
-or record metadata before those fields leave the process.
+or record metadata before those fields leave the process. When OpenTelemetry is
+active, `runEval` attaches the active `traceId` and `spanId` to export context
+unless the caller passes an explicit trace context.

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -258,7 +258,31 @@ The registry redacts inputs, outputs, references, traces, metric evidence,
 metric explanations, and metadata unless the export context explicitly allows
 each field. Runtime monitoring remains separate: use
 `veryfront/extensions/observability` and the OpenTelemetry extension for spans,
-traces, metrics, and service monitoring.
+traces, metrics, and service monitoring. When OpenTelemetry is active, `runEval`
+adds the active `traceId` and `spanId` to export context unless you pass
+`context.trace` explicitly.
+
+Use `@veryfront/ext-eval-report-http` when an eval gateway endpoint should
+receive reports without adding a vendor SDK:
+
+```ts
+import extEvalReportHttp from "@veryfront/ext-eval-report-http";
+import { defineConfig } from "veryfront";
+
+export default defineConfig({
+  extensions: [
+    extEvalReportHttp({
+      exporters: [
+        {
+          id: "eval-gateway",
+          url: "https://evals.example.com/reports",
+          token: "<TOKEN>",
+        },
+      ],
+    }),
+  ],
+});
+```
 
 From the CLI, pass comma-separated exporter ids. Export failures are reported in
 the JSON report and do not prevent local report or JUnit files from being

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -52,6 +52,12 @@ Extension availability is separate from contract requirement:
 | --------------------------------------------------------------- | ------------------- | ------------------------ |
 | [`@veryfront/ext-document-kreuzberg`](./ext-document-kreuzberg) | `DocumentExtractor` | Document text extraction |
 
+### Eval export
+
+| Package                                                     | Contract                     | Description                                             |
+| ----------------------------------------------------------- | ---------------------------- | ------------------------------------------------------- |
+| [`@veryfront/ext-eval-report-http`](./ext-eval-report-http) | `EvalReportExporterRegistry` | Generic HTTP transport for redacted eval report exports |
+
 ### Schema
 
 | Package                                         | Contract          | Description                         |
@@ -114,6 +120,7 @@ level.
 | `LLMProvider:*`             | A matching model provider is selected           | Auto-enabled core extension           |
 | `AuthProvider`              | Auth signing or verification is configured      | User-installed extension              |
 | `TokenCacheStore`           | Redis-backed token cache is configured          | User-installed extension              |
+| `EvalReportExporterRegistry` | Eval report exporters are registered            | Auto-enabled core extension           |
 | `TracingExporter`           | OTLP tracing export is configured               | User-installed extension              |
 | `NodeTelemetryProvider`     | Node agent service telemetry is enabled         | Auto-enabled agent service extension  |
 
@@ -233,6 +240,7 @@ check for drift and to enforce the sensitive capability policies below.
 | `ext-db-sqlite`                        | `fs:read`, `fs:write`                                          | Opens native SQLite databases               |
 | `ext-document-kreuzberg`               | `fs:read`                                                      | Parses uploaded or user-provided documents  |
 | `ext-observability-opentelemetry`      | `net:outbound`, `env:read` for `OTEL_*`                        | Exports telemetry and reads collector config |
+| `ext-eval-report-http`                 | `net:outbound`, `env:read` for `VERYFRONT_EVAL_HTTP_*`         | Exports eval reports to an external endpoint |
 
 Use `veryfront.contracts` for contract ownership and dependency ordering. Use
 `veryfront.capabilities` only for runtime resource access and audit metadata.

--- a/extensions/ext-eval-report-http/README.md
+++ b/extensions/ext-eval-report-http/README.md
@@ -1,0 +1,94 @@
+# @veryfront/ext-eval-report-http
+
+> **Category:** Eval export | **Requires:** `EvalReportExporterRegistry` | **Optional**
+
+Registers HTTP-backed eval report exporters. Use this extension when a project
+needs to send redacted `EvalReport` payloads to an internal endpoint, Braintrust,
+Langfuse, LangSmith, or another eval platform through a gateway.
+
+The extension does not own runtime tracing. Use
+`@veryfront/ext-observability-opentelemetry` for OpenTelemetry spans, metrics,
+and service monitoring.
+
+## Installation
+
+Add the extension to your project's `veryfront.config.ts`:
+
+```ts
+import extEvalReportHttp from "@veryfront/ext-eval-report-http";
+
+export default defineConfig({
+  extensions: [
+    extEvalReportHttp({
+      exporters: [
+        {
+          id: "braintrust-proxy",
+          url: "https://evals.example.com/reports",
+          token: "<TOKEN>",
+          headers: { "x-workspace": "default" },
+        },
+      ],
+    }),
+  ],
+});
+```
+
+Then run an eval with a matching exporter id:
+
+```bash
+veryfront eval deep-research --export braintrust-proxy
+```
+
+## Environment variables
+
+Without factory configuration, the extension registers one exporter from env
+configuration.
+
+| Variable                               | Required | Description                                       |
+| -------------------------------------- | -------- | ------------------------------------------------- |
+| `VERYFRONT_EVAL_HTTP_EXPORTER_URL`     | Yes      | HTTP endpoint that receives `{ report, context }` |
+| `VERYFRONT_EVAL_HTTP_EXPORTER_ID`      | No       | Exporter id. Defaults to `http`                   |
+| `VERYFRONT_EVAL_HTTP_EXPORTER_TOKEN`   | No       | Bearer token for the `authorization` header       |
+| `VERYFRONT_EVAL_HTTP_EXPORTER_HEADERS` | No       | JSON object or comma-separated `key=value` pairs  |
+
+## Factory configuration
+
+```ts
+extEvalReportHttp({
+  exporters: [
+    {
+      id: "langfuse-proxy",
+      url: "https://evals.example.com/langfuse",
+      token: "<TOKEN>",
+      headers: { "x-project": "docs-agent" },
+      method: "POST",
+    },
+  ],
+});
+```
+
+Each exporter sends:
+
+```json
+{
+  "report": {},
+  "context": {}
+}
+```
+
+`runEval` enriches export context with the active runtime `traceId` and `spanId`
+when OpenTelemetry is active and the caller did not pass an explicit
+`context.trace`.
+
+## Required contract
+
+`EvalReportExporterRegistry` is seeded by Veryfront bootstrap. The extension
+requires that registry during setup and registers one `EvalReportExporter` per
+configured endpoint. Teardown unregisters only the exporter ids that this
+extension registered.
+
+## Capabilities
+
+- **net `*`:** sends eval reports to the configured endpoint.
+- **env:** reads the four `VERYFRONT_EVAL_HTTP_EXPORTER_*` variables listed
+  above when explicit factory configuration is not set.

--- a/extensions/ext-eval-report-http/deno.json
+++ b/extensions/ext-eval-report-http/deno.json
@@ -1,0 +1,32 @@
+{
+  "name": "@veryfront/ext-eval-report-http",
+  "version": "0.1.0",
+  "exports": "./src/index.ts",
+  "veryfront": {
+    "extension": true,
+    "contracts": {
+      "requires": ["EvalReportExporterRegistry"]
+    },
+    "capabilities": [
+      { "type": "net:outbound", "hosts": ["*"] },
+      {
+        "type": "env:read",
+        "keys": [
+          "VERYFRONT_EVAL_HTTP_EXPORTER_HEADERS",
+          "VERYFRONT_EVAL_HTTP_EXPORTER_ID",
+          "VERYFRONT_EVAL_HTTP_EXPORTER_TOKEN",
+          "VERYFRONT_EVAL_HTTP_EXPORTER_URL"
+        ]
+      }
+    ]
+  },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@1.0.19",
+    "@std/testing/bdd": "jsr:@std/testing@1.0.17/bdd",
+    "veryfront/extensions": "../../src/extensions/index.ts",
+    "veryfront/extensions/eval": "../../src/extensions/eval/index.ts"
+  },
+  "tasks": {
+    "test": "deno test --no-check --allow-all src/"
+  }
+}

--- a/extensions/ext-eval-report-http/src/index.test.ts
+++ b/extensions/ext-eval-report-http/src/index.test.ts
@@ -1,0 +1,177 @@
+/**
+ * ext-eval-report-http extension tests.
+ *
+ * @module extensions/ext-eval-report-http/test
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import type { ExtensionContext } from "veryfront/extensions";
+import {
+  createEvalReportExporterRegistry,
+  type EvalReportExporterRegistry,
+  EvalReportExporterRegistryName,
+} from "veryfront/extensions/eval";
+import factory from "./index.ts";
+
+const noopLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+} satisfies ExtensionContext["logger"];
+
+function createContext(registry: EvalReportExporterRegistry): ExtensionContext {
+  return {
+    config: {},
+    logger: noopLogger,
+    provide() {},
+    get: <T>(name: string) => name === EvalReportExporterRegistryName ? registry as T : undefined,
+    require: <T>(name: string) => {
+      if (name === EvalReportExporterRegistryName) return registry as T;
+      throw new Error(`missing ${name}`);
+    },
+  };
+}
+
+describe("ext-eval-report-http", () => {
+  it("declares the eval report exporter registry dependency", () => {
+    const extension = factory();
+
+    assertEquals(extension.name, "ext-eval-report-http");
+    assertEquals(extension.version, "0.1.0");
+    assertEquals(extension.contracts?.requires, [EvalReportExporterRegistryName]);
+    assertEquals(extension.capabilities, [
+      { type: "net:outbound", hosts: ["*"] },
+      {
+        type: "env:read",
+        keys: [
+          "VERYFRONT_EVAL_HTTP_EXPORTER_HEADERS",
+          "VERYFRONT_EVAL_HTTP_EXPORTER_ID",
+          "VERYFRONT_EVAL_HTTP_EXPORTER_TOKEN",
+          "VERYFRONT_EVAL_HTTP_EXPORTER_URL",
+        ],
+      },
+    ]);
+  });
+
+  it("registers configured HTTP eval report exporters during setup", async () => {
+    const registry = createEvalReportExporterRegistry();
+    const requests: Array<{ url: string; init: RequestInit }> = [];
+
+    const extension = factory({
+      exporters: [
+        {
+          id: "braintrust-proxy",
+          url: "https://evals.example.test/reports",
+          token: "test-token",
+          headers: { "x-workspace": "docs" },
+        },
+      ],
+      fetch: (input: string | URL | Request, init?: RequestInit) => {
+        requests.push({ url: String(input), init: init ?? {} });
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              externalRunId: "run-123",
+              url: "https://evals.example.test/runs/run-123",
+              metadata: { provider: "proxy" },
+            }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          ),
+        );
+      },
+    });
+
+    await extension.setup?.(createContext(registry));
+
+    const exporter = registry.get("braintrust-proxy");
+    assertExists(exporter);
+
+    const receipt = await exporter.export(
+      {
+        kind: "eval-report",
+        definitionId: "eval:smoke",
+        targetKind: "agent",
+        target: "agent:researcher",
+        runId: "evalrun_1",
+        startedAt: "2026-06-21T00:00:00.000Z",
+        endedAt: "2026-06-21T00:00:01.000Z",
+        records: [],
+        summary: {
+          records: 0,
+          passed: 0,
+          failed: 0,
+          passRate: 1,
+          metrics: [],
+        },
+      },
+      {
+        projectReference: "docs-agent",
+        trace: { traceId: "trace-1", spanId: "span-1" },
+      },
+    );
+
+    assertEquals(receipt, {
+      externalRunId: "run-123",
+      url: "https://evals.example.test/runs/run-123",
+      metadata: { provider: "proxy" },
+    });
+    assertEquals(requests.length, 1);
+    assertEquals(requests[0]?.url, "https://evals.example.test/reports");
+    assertEquals(requests[0]?.init.method, "POST");
+    assertEquals(requests[0]?.init.headers, {
+      "authorization": "Bearer test-token",
+      "content-type": "application/json",
+      "x-workspace": "docs",
+    });
+    assertEquals(JSON.parse(String(requests[0]?.init.body)), {
+      report: {
+        kind: "eval-report",
+        definitionId: "eval:smoke",
+        targetKind: "agent",
+        target: "agent:researcher",
+        runId: "evalrun_1",
+        startedAt: "2026-06-21T00:00:00.000Z",
+        endedAt: "2026-06-21T00:00:01.000Z",
+        records: [],
+        summary: {
+          records: 0,
+          passed: 0,
+          failed: 0,
+          passRate: 1,
+          metrics: [],
+        },
+      },
+      context: {
+        projectReference: "docs-agent",
+        trace: { traceId: "trace-1", spanId: "span-1" },
+      },
+    });
+  });
+
+  it("unregisters exporters during teardown", async () => {
+    const registry = createEvalReportExporterRegistry();
+    const extension = factory({
+      exporters: [{ id: "generic-http", url: "https://evals.example.test/reports" }],
+    });
+
+    await extension.setup?.(createContext(registry));
+    assertEquals(registry.has("generic-http"), true);
+
+    await extension.teardown?.();
+    assertEquals(registry.has("generic-http"), false);
+  });
+
+  it("does not register an exporter when no URL is configured", async () => {
+    const registry = createEvalReportExporterRegistry();
+    const extension = factory({ exporters: [{ id: "missing-url" }] });
+
+    await extension.setup?.(createContext(registry));
+
+    assertEquals(registry.list(), []);
+  });
+});

--- a/extensions/ext-eval-report-http/src/index.ts
+++ b/extensions/ext-eval-report-http/src/index.ts
@@ -1,0 +1,288 @@
+/**
+ * ext-eval-report-http: generic HTTP transport for eval report exports.
+ *
+ * The extension resolves the core `EvalReportExporterRegistry` contract during
+ * setup and registers one or more HTTP-backed `EvalReportExporter`
+ * implementations. It intentionally depends only on `fetch`; vendor-specific
+ * mapping belongs in the receiving endpoint or a narrower vendor extension.
+ *
+ * @module extensions/ext-eval-report-http
+ */
+
+import type { ExtensionFactory } from "veryfront/extensions";
+import {
+  type EvalReportExportContext,
+  type EvalReportExporter,
+  type EvalReportExporterRegistry,
+  EvalReportExporterRegistryName,
+  type EvalReportExportReceipt,
+} from "veryfront/extensions/eval";
+
+const ENV_EXPORTER_ID = "VERYFRONT_EVAL_HTTP_EXPORTER_ID";
+const ENV_EXPORTER_URL = "VERYFRONT_EVAL_HTTP_EXPORTER_URL";
+const ENV_EXPORTER_TOKEN = "VERYFRONT_EVAL_HTTP_EXPORTER_TOKEN";
+const ENV_EXPORTER_HEADERS = "VERYFRONT_EVAL_HTTP_EXPORTER_HEADERS";
+
+type EvalReportHttpFetch = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export interface EvalReportHttpExporterDefinition {
+  id: string;
+  url?: string;
+  token?: string;
+  headers?: Record<string, string>;
+  method?: "POST" | "PUT";
+}
+
+export interface EvalReportHttpExtensionConfig {
+  exporters?: EvalReportHttpExporterDefinition[];
+  fetch?: EvalReportHttpFetch;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readEnv(name: string): string | undefined {
+  try {
+    const value = Deno.env.get(name);
+    return value && value.length > 0 ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseHeaders(input: string | undefined): Record<string, string> {
+  if (!input) return {};
+
+  const trimmed = input.trim();
+  if (trimmed.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (isRecord(parsed)) {
+        return Object.fromEntries(
+          Object.entries(parsed).filter((entry): entry is [string, string] =>
+            typeof entry[1] === "string"
+          ),
+        );
+      }
+    } catch {
+      return {};
+    }
+  }
+
+  const headers: Record<string, string> = {};
+  for (const part of input.split(",")) {
+    const [key, ...valueParts] = part.split("=");
+    if (!key || valueParts.length === 0) continue;
+    headers[key.trim()] = valueParts.join("=").trim();
+  }
+  return headers;
+}
+
+function normalizeHeaders(value: unknown): Record<string, string> {
+  if (!isRecord(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, string] =>
+      typeof entry[1] === "string"
+    ),
+  );
+}
+
+function normalizeExporterDefinition(value: unknown): EvalReportHttpExporterDefinition | undefined {
+  if (!isRecord(value) || typeof value.id !== "string" || value.id.length === 0) {
+    return undefined;
+  }
+  return {
+    id: value.id,
+    ...(typeof value.url === "string" ? { url: value.url } : {}),
+    ...(typeof value.token === "string" ? { token: value.token } : {}),
+    ...(isRecord(value.headers) ? { headers: normalizeHeaders(value.headers) } : {}),
+    ...(value.method === "PUT" ? { method: "PUT" } : {}),
+  };
+}
+
+function normalizeConfig(config: unknown): EvalReportHttpExtensionConfig {
+  if (!isRecord(config)) return {};
+  const exporters = Array.isArray(config.exporters)
+    ? config.exporters
+      .map(normalizeExporterDefinition)
+      .filter((entry): entry is EvalReportHttpExporterDefinition => entry !== undefined)
+    : undefined;
+  return {
+    ...(exporters ? { exporters } : {}),
+    ...(typeof config.fetch === "function" ? { fetch: config.fetch as EvalReportHttpFetch } : {}),
+  };
+}
+
+function resolveExporterDefinitions(
+  config: EvalReportHttpExtensionConfig,
+): EvalReportHttpExporterDefinition[] {
+  if (config.exporters && config.exporters.length > 0) return config.exporters;
+
+  return [
+    {
+      id: readEnv(ENV_EXPORTER_ID) ?? "http",
+      url: readEnv(ENV_EXPORTER_URL),
+      token: readEnv(ENV_EXPORTER_TOKEN),
+      headers: parseHeaders(readEnv(ENV_EXPORTER_HEADERS)),
+    },
+  ];
+}
+
+function createRequestHeaders(
+  definition: EvalReportHttpExporterDefinition,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    ...(definition.headers ?? {}),
+  };
+  if (definition.token) {
+    headers.authorization = `Bearer ${definition.token}`;
+  }
+  return headers;
+}
+
+async function readErrorBody(response: Response): Promise<string> {
+  try {
+    return (await response.text()).trim().slice(0, 1000);
+  } catch {
+    return "";
+  }
+}
+
+function readStringField(record: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+async function parseReceipt(response: Response): Promise<EvalReportExportReceipt | void> {
+  if (response.status === 204) return undefined;
+
+  const text = (await response.text()).trim();
+  if (text.length === 0) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+
+  if (!isRecord(parsed)) return undefined;
+
+  const receipt: EvalReportExportReceipt = {};
+  const externalRunId = readStringField(parsed, "externalRunId", "runId", "id");
+  const url = readStringField(parsed, "url", "runUrl");
+  if (externalRunId) receipt.externalRunId = externalRunId;
+  if (url) receipt.url = url;
+  if (isRecord(parsed.metadata)) receipt.metadata = parsed.metadata;
+
+  return Object.keys(receipt).length > 0 ? receipt : undefined;
+}
+
+export class EvalReportHttpExporter implements EvalReportExporter {
+  readonly id: string;
+  private readonly definition: EvalReportHttpExporterDefinition & { url: string };
+  private readonly fetchImpl: EvalReportHttpFetch;
+
+  constructor(
+    definition: EvalReportHttpExporterDefinition & { url: string },
+    fetchImpl: EvalReportHttpFetch = fetch,
+  ) {
+    this.id = definition.id;
+    this.definition = definition;
+    this.fetchImpl = fetchImpl;
+  }
+
+  async export(
+    report: Parameters<EvalReportExporter["export"]>[0],
+    context: EvalReportExportContext,
+  ): Promise<EvalReportExportReceipt | void> {
+    const response = await this.fetchImpl(this.definition.url, {
+      method: this.definition.method ?? "POST",
+      headers: createRequestHeaders(this.definition),
+      body: JSON.stringify({ report, context }),
+    });
+
+    if (!response.ok) {
+      const body = await readErrorBody(response);
+      throw new Error(
+        `Eval report HTTP exporter "${this.id}" failed with HTTP ${response.status}${
+          body ? `: ${body}` : ""
+        }`,
+      );
+    }
+
+    return await parseReceipt(response);
+  }
+}
+
+export function createEvalReportHttpExporter(
+  definition: EvalReportHttpExporterDefinition & { url: string },
+  fetchImpl?: EvalReportHttpFetch,
+): EvalReportHttpExporter {
+  return new EvalReportHttpExporter(definition, fetchImpl);
+}
+
+const extEvalReportHttp: ExtensionFactory = (config?: unknown) => {
+  const factoryConfig = normalizeConfig(config);
+  let registry: EvalReportExporterRegistry | undefined;
+  const registeredIds = new Set<string>();
+
+  return {
+    name: "ext-eval-report-http",
+    version: "0.1.0",
+    contracts: {
+      requires: ["EvalReportExporterRegistry"],
+    },
+    capabilities: [
+      { type: "net:outbound", hosts: ["*"] },
+      {
+        type: "env:read",
+        keys: [
+          "VERYFRONT_EVAL_HTTP_EXPORTER_HEADERS",
+          "VERYFRONT_EVAL_HTTP_EXPORTER_ID",
+          "VERYFRONT_EVAL_HTTP_EXPORTER_TOKEN",
+          "VERYFRONT_EVAL_HTTP_EXPORTER_URL",
+        ],
+      },
+    ],
+    setup(ctx) {
+      registry = ctx.require<EvalReportExporterRegistry>(EvalReportExporterRegistryName);
+
+      for (const definition of resolveExporterDefinitions(factoryConfig)) {
+        if (!definition.url) {
+          ctx.logger.info(
+            `[ext-eval-report-http] Skipping EvalReportExporter "${definition.id}": no URL configured`,
+          );
+          continue;
+        }
+
+        registry.register(
+          new EvalReportHttpExporter(
+            { ...definition, url: definition.url },
+            factoryConfig.fetch,
+          ),
+        );
+        registeredIds.add(definition.id);
+        ctx.logger.info(`[ext-eval-report-http] EvalReportExporter "${definition.id}" registered`);
+      }
+    },
+    teardown() {
+      if (!registry) return;
+      for (const id of registeredIds) {
+        registry.unregister(id);
+      }
+      registeredIds.clear();
+      registry = undefined;
+    },
+  };
+};
+
+export default extEvalReportHttp;

--- a/scripts/lint/audit-extension-capabilities.ts
+++ b/scripts/lint/audit-extension-capabilities.ts
@@ -67,6 +67,22 @@ export const SENSITIVE_EXTENSION_CAPABILITY_POLICIES:
         },
       ],
     },
+    {
+      label: "eval report HTTP export",
+      manifestPath: "extensions/ext-eval-report-http/deno.json",
+      requiredCapabilities: [
+        { type: "net:outbound", hosts: ["*"] },
+        {
+          type: "env:read",
+          keys: [
+            "VERYFRONT_EVAL_HTTP_EXPORTER_HEADERS",
+            "VERYFRONT_EVAL_HTTP_EXPORTER_ID",
+            "VERYFRONT_EVAL_HTTP_EXPORTER_TOKEN",
+            "VERYFRONT_EVAL_HTTP_EXPORTER_URL",
+          ],
+        },
+      ],
+    },
   ];
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/eval/runner.test.ts
+++ b/src/eval/runner.test.ts
@@ -1,10 +1,19 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { datasets, evalAgent, metrics, runEval } from "veryfront/eval";
 import { createEvalReportExporterRegistry } from "veryfront/extensions/eval";
+import {
+  _resetShimForTests,
+  setGlobalActiveSpanAccessor,
+  type Span,
+} from "../observability/tracing/api-shim.ts";
 
 describe("eval/runner", () => {
+  afterEach(() => {
+    _resetShimForTests();
+  });
+
   it("runs an agent eval and summarizes metric results", async () => {
     const definition = evalAgent({
       id: "eval:capital-answer",
@@ -163,5 +172,115 @@ describe("eval/runner", () => {
       sourcePath: "evals/export.eval.ts",
       redaction: { metadataAllowlist: ["dataset"] },
     });
+  });
+
+  it("adds the active runtime trace context to eval report exports", async () => {
+    const registry = createEvalReportExporterRegistry();
+    const exportedContexts: unknown[] = [];
+
+    registry.register({
+      id: "capture",
+      export(_report, context) {
+        exportedContexts.push(context);
+      },
+    });
+
+    setGlobalActiveSpanAccessor({
+      getActiveSpan: () => ({
+        spanContext: () => ({
+          traceId: "trace-1234567890abcdef1234567890abcdef",
+          spanId: "span-1234567890",
+          traceFlags: 1,
+        }),
+      } as Span),
+      getSpan: () => undefined,
+    });
+
+    const definition = evalAgent({
+      id: "eval:trace-export",
+      target: "agent:researcher",
+      dataset: datasets.inline([{ id: "q1", input: "France capital?", reference: "Paris" }]),
+      metrics: [metrics.answer.exactMatch().gate()],
+    });
+
+    await runEval(definition, {
+      adapters: {
+        agent: async () => ({ text: "Paris" }),
+      },
+      export: {
+        registry,
+        exporterIds: ["capture"],
+        context: {
+          projectReference: "docs-agent",
+        },
+      },
+    });
+
+    assertEquals(exportedContexts, [
+      {
+        projectReference: "docs-agent",
+        trace: {
+          traceId: "trace-1234567890abcdef1234567890abcdef",
+          spanId: "span-1234567890",
+        },
+      },
+    ]);
+  });
+
+  it("preserves explicit eval report export trace context", async () => {
+    const registry = createEvalReportExporterRegistry();
+    const exportedContexts: unknown[] = [];
+
+    registry.register({
+      id: "capture",
+      export(_report, context) {
+        exportedContexts.push(context);
+      },
+    });
+
+    setGlobalActiveSpanAccessor({
+      getActiveSpan: () => ({
+        spanContext: () => ({
+          traceId: "active-trace",
+          spanId: "active-span",
+          traceFlags: 1,
+        }),
+      } as Span),
+      getSpan: () => undefined,
+    });
+
+    const definition = evalAgent({
+      id: "eval:explicit-trace-export",
+      target: "agent:researcher",
+      dataset: datasets.inline([{ id: "q1", input: "France capital?", reference: "Paris" }]),
+      metrics: [metrics.answer.exactMatch().gate()],
+    });
+
+    await runEval(definition, {
+      adapters: {
+        agent: async () => ({ text: "Paris" }),
+      },
+      export: {
+        registry,
+        exporterIds: ["capture"],
+        context: {
+          trace: {
+            traceId: "explicit-trace",
+            spanId: "explicit-span",
+            parentSpanId: "explicit-parent",
+          },
+        },
+      },
+    });
+
+    assertEquals(exportedContexts, [
+      {
+        trace: {
+          traceId: "explicit-trace",
+          spanId: "explicit-span",
+          parentSpanId: "explicit-parent",
+        },
+      },
+    ]);
   });
 });

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -2,10 +2,13 @@ import { createEvalCheckContext } from "./expect.ts";
 import { createEvalReport } from "./report.ts";
 import {
   createEvalReportExporterRegistry,
+  type EvalReportExportContext,
   type EvalReportExporterRegistry,
   EvalReportExporterRegistryName,
   type EvalReportExportResult,
+  type EvalReportExportTraceContext,
 } from "#veryfront/extensions/eval";
+import { trace } from "../observability/tracing/api-shim.ts";
 import { tryResolve } from "../extensions/contracts.ts";
 import type {
   EvalAgentAdapterResult,
@@ -74,6 +77,36 @@ function resolveExporterRegistry(
     tryResolve<EvalReportExporterRegistry>(EvalReportExporterRegistryName);
 }
 
+function isEmptyTraceId(value: string | undefined): boolean {
+  return value === undefined || /^0+$/.test(value);
+}
+
+function getActiveEvalExportTraceContext(): EvalReportExportTraceContext | undefined {
+  const spanContext = trace.getActiveSpan()?.spanContext();
+  if (!spanContext) return undefined;
+  if (isEmptyTraceId(spanContext.traceId) || isEmptyTraceId(spanContext.spanId)) {
+    return undefined;
+  }
+  return {
+    traceId: spanContext.traceId,
+    spanId: spanContext.spanId,
+  };
+}
+
+function withActiveTraceContext(
+  context?: EvalReportExportContext,
+): EvalReportExportContext | undefined {
+  if (context?.trace) return context;
+
+  const activeTrace = getActiveEvalExportTraceContext();
+  if (!activeTrace) return context;
+
+  return {
+    ...(context ?? {}),
+    trace: activeTrace,
+  };
+}
+
 async function exportWithSelectedExporter(
   registry: EvalReportExporterRegistry,
   report: ReturnType<typeof createEvalReport>,
@@ -85,7 +118,7 @@ async function exportWithSelectedExporter(
 
   const selectedRegistry = createEvalReportExporterRegistry();
   selectedRegistry.register(exporter);
-  const [result] = await selectedRegistry.export(report, config.context);
+  const [result] = await selectedRegistry.export(report, withActiveTraceContext(config.context));
   return result ?? {
     exporterId,
     ok: false,
@@ -104,7 +137,7 @@ async function exportEvalReport(
   if (!registry) return createMissingRegistryResults(exporterIds);
 
   if (exporterIds.length === 0) {
-    return registry.export(report, config.context);
+    return registry.export(report, withActiveTraceContext(config.context));
   }
 
   const results: EvalReportExportResult[] = [];


### PR DESCRIPTION
## Summary
- add active runtime trace correlation to eval report export contexts unless callers pass an explicit trace
- add @veryfront/ext-eval-report-http as a generic EvalReportExporter transport with env/factory config, receipts, teardown cleanup, and no vendor SDK dependency
- document eval export vs OTEL observability separation and register the extension capability policy/workspace metadata

## Verification
- deno task verify:quick
- deno test --frozen --no-check --allow-all src/ (from extensions/ext-eval-report-http)
