### PR TITLE
Release v0.1.886

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.885",
+  "version": "0.1.886",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.885";
+export const VERSION = "0.1.886";


### PR DESCRIPTION
## Summary
- bump veryfront package version to 0.1.886
- keep src/utils/version-constant.ts synchronized with deno.json
- publish the merged eval telemetry extension support for downstream consumers

## Verification
- git diff --check
- deno fmt --check deno.json src/utils/version-constant.ts
- deno test --frozen --no-check --allow-all src/utils/version.test.ts
- pre-push hook: format, lint, typecheck, unit tests
