### PR TITLE
Finalize durable runs on hosted bootstrap failure

### DIFF
--- a/src/agent/hosted/chat-execution-runtime.test.ts
+++ b/src/agent/hosted/chat-execution-runtime.test.ts
@@ -450,6 +450,95 @@ describe("agent/hosted-chat-execution-runtime", () => {
     });
   });
 
+  it("finalizes durable root runs when bootstrapping hosted chat execution fails", async () => {
+    const tracer = createTracer();
+    const terminalStates: HostedLifecycleTerminalState[] = [];
+    const agent: HostedChatRuntimeAgent = {
+      stream: async () => {
+        throw new Error("stream startup failed");
+      },
+    };
+
+    await assertRejects(
+      async () => {
+        await createBootstrappedHostedChatExecutionRuntime({
+          authToken: "token",
+          apiUrl: "https://api.example.test",
+          agent,
+          agentId: "agent-1",
+          modelId: "openai/gpt-5.4",
+          cleanup: async () => {},
+          messages: [],
+          finalMessages: [],
+          conversationId: "conversation-1",
+          projectId: "project-1",
+          userId: "user-1",
+          rootRunContext: {
+            durableRootRun: {
+              runId: "root-run-1",
+              conversationId: "conversation-1",
+              messageId: "stream-message-1",
+              latestEventId: 0,
+              latestExternalEventSequence: 0,
+            },
+            durableRunMirror: null,
+          },
+          abortSignal: new AbortController().signal,
+          tracer: tracer.tracer,
+          resolveProvider: () => "openai",
+          createTerminalAdapter: (input) => ({
+            toTerminalState: (state) => ({
+              status: state.status,
+              metadata: state.metadata ?? { modelId: input.fallbackModelId },
+              ...(state.terminalErrorCode !== undefined
+                ? { terminalErrorCode: state.terminalErrorCode }
+                : {}),
+              ...(state.terminalErrorMessage !== undefined
+                ? { terminalErrorMessage: state.terminalErrorMessage }
+                : {}),
+            }),
+            finalizeRun: async (state) => {
+              terminalStates.push(state);
+            },
+            cancelRun: async (state) => {
+              terminalStates.push(state);
+            },
+            onTerminalState: async (state) => {
+              await input.onTerminalState?.(state);
+            },
+            dispatch: async (state) => {
+              const terminalState = {
+                status: state.status,
+                metadata: state.metadata ?? { modelId: input.fallbackModelId },
+                ...(state.terminalErrorCode !== undefined
+                  ? { terminalErrorCode: state.terminalErrorCode }
+                  : {}),
+                ...(state.terminalErrorMessage !== undefined
+                  ? { terminalErrorMessage: state.terminalErrorMessage }
+                  : {}),
+              };
+              terminalStates.push(terminalState);
+              await input.onTerminalState?.(terminalState);
+              return terminalState;
+            },
+          }),
+        });
+      },
+      Error,
+      "stream startup failed",
+    );
+
+    assertEquals(terminalStates, [
+      {
+        status: "failed",
+        metadata: { modelId: "openai/gpt-5.4" },
+        terminalErrorCode: "STREAM_ERROR",
+        terminalErrorMessage: "stream startup failed",
+      },
+    ]);
+    assertEquals(tracer.finishCount, 1);
+  });
+
   it("appends fallback chunks and flushes through the mirror", async () => {
     const chunks: ChatUiMessageChunk<MessageMetadata>[] = [];
     const flushes: string[] = [];

--- a/src/agent/hosted/chat-execution-runtime.ts
+++ b/src/agent/hosted/chat-execution-runtime.ts
@@ -274,18 +274,34 @@ async function createBootstrappedHostedChatRuntime(
     resolveProvider: input.resolveProvider,
     ...(input.createTerminalAdapter ? { createTerminalAdapter: input.createTerminalAdapter } : {}),
   });
-  const bootstrap = await createHostedChatExecutionRuntimeBootstrap({
-    agent: input.agent,
-    cleanup: input.cleanup,
-    lifecycleAdapter,
-    finalMessages: input.finalMessages,
-    conversationId: input.conversationId,
-    abortSignal: input.abortSignal,
-    traceStream: input.traceStream,
-    ...(input.createRootStreamWatchdog
-      ? { createRootStreamWatchdog: input.createRootStreamWatchdog }
-      : {}),
-  });
+  let bootstrap: HostedChatExecutionRuntimeBootstrap;
+  try {
+    bootstrap = await createHostedChatExecutionRuntimeBootstrap({
+      agent: input.agent,
+      cleanup: input.cleanup,
+      lifecycleAdapter,
+      finalMessages: input.finalMessages,
+      conversationId: input.conversationId,
+      abortSignal: input.abortSignal,
+      traceStream: input.traceStream,
+      ...(input.createRootStreamWatchdog
+        ? { createRootStreamWatchdog: input.createRootStreamWatchdog }
+        : {}),
+    });
+  } catch (error) {
+    await dispatchConversationHostedStreamErrorState(lifecycleAdapter, error).catch(
+      (terminalError) => {
+        input.logger?.error("Durable chat bootstrap failure finalization failed", {
+          error: terminalError instanceof Error ? terminalError.message : String(terminalError),
+        });
+      },
+    );
+    await cleanupAfterHostedChatExecutionFinalization({
+      cleanup: input.cleanup,
+      logger: input.logger,
+    });
+    throw error;
+  }
 
   return createHostedChatExecutionRuntime({
     agentId: input.agentId,


### PR DESCRIPTION
## Summary
- finalize durable root runs through the hosted terminal adapter when stream bootstrap fails before a runtime execution object exists
- keep cleanup and original error propagation intact
- add a regression test for accepted durable runs that fail during hosted stream startup

## Root cause
An accepted detached durable run could fail while creating the hosted stream, before `runPreparedHostedChatExecutionDetached` had an `execution` object and before `execution.fail(error)` was available. The detached AG-UI handler then only marked the local session as failed and logged via `onError`; it did not drive the conversation terminal adapter, so the API-side assistant message could remain `streaming` with zero parts until stale cleanup.

## Red/green proof
- RED: new regression initially failed with no durable terminal state dispatched for `stream startup failed`
- GREEN: `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/agent/hosted/chat-execution-runtime.test.ts`
- GREEN: `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/agent/hosted/durable-chat-run-start.test.ts src/agent/hosted/chat-execution-runtime.test.ts`
- GREEN: `deno task verify:quick`

Fixes veryfront/veryfront-agent#1606