### PR TITLE
Harden agent final response tool guard

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.886",
+  "version": "0.1.887",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -157,6 +157,10 @@ import { resolveAgentModelTransport, type ResolvedModelTransport } from "./model
 
 const logger = serverLogger.component("agent");
 
+function shouldDisableToolsForFinalResponseAfterToolSuccess(toolName: string): boolean {
+  return toolName === "create_agent" || toolName === "update_agent";
+}
+
 function parseToolResultJson(result: string): unknown {
   try {
     return JSON.parse(result);
@@ -1104,9 +1108,6 @@ export class AgentRuntime {
 
         if (matchingResult) {
           await persistToolResult(matchingResult);
-          if (tc.name === "create_agent") {
-            toolsDisabledForFinalResponse = true;
-          }
           toolCall.status = matchingResult.error === undefined ? "completed" : "error";
           toolCall.result = matchingResult.output;
           toolCall.error = matchingResult.error === undefined
@@ -1115,6 +1116,9 @@ export class AgentRuntime {
           toolCalls.push(toolCall);
 
           if (matchingResult.error === undefined) {
+            if (shouldDisableToolsForFinalResponseAfterToolSuccess(tc.name)) {
+              toolsDisabledForFinalResponse = true;
+            }
             if (tc.name === LOAD_SKILL_TOOL_ID) {
               activeSkillId = extractSkillId(matchingResult.output);
               activeSkillPolicy = extractSkillPolicy(matchingResult.output);
@@ -1139,14 +1143,14 @@ export class AgentRuntime {
 
         if (persistedResult) {
           const persistedError = getToolResultError(persistedResult.result);
-          if (tc.name === "create_agent") {
-            toolsDisabledForFinalResponse = true;
-          }
           toolCall.status = persistedError === undefined ? "completed" : "error";
           toolCall.result = persistedResult.result;
           toolCall.error = persistedError;
           toolCalls.push(toolCall);
           if (persistedError === undefined) {
+            if (shouldDisableToolsForFinalResponseAfterToolSuccess(tc.name)) {
+              toolsDisabledForFinalResponse = true;
+            }
             if (tc.name === LOAD_SKILL_TOOL_ID) {
               activeSkillId = extractSkillId(persistedResult.result);
               activeSkillPolicy = extractSkillPolicy(persistedResult.result);
@@ -1278,7 +1282,7 @@ export class AgentRuntime {
             hasSubmittedFormInputInLoop = true;
             currentRuntimeContext = markSubmittedFormInputRuntimeContext(currentRuntimeContext);
           }
-          if (tc.name === "create_agent") {
+          if (shouldDisableToolsForFinalResponseAfterToolSuccess(tc.name)) {
             toolsDisabledForFinalResponse = true;
           }
 
@@ -1306,9 +1310,6 @@ export class AgentRuntime {
             currentMessages,
             toolCalls,
           );
-          if (tc.name === "create_agent") {
-            toolsDisabledForFinalResponse = true;
-          }
         }
       }
 

--- a/src/agent/runtime/refresh.test.ts
+++ b/src/agent/runtime/refresh.test.ts
@@ -294,6 +294,178 @@ describe("agent runtime refresh hooks", () => {
     assertEquals(toolNamesByStep[1], []);
   });
 
+  it("keeps tools available after a failed create_agent attempt", async () => {
+    const toolNamesByStep: string[][] = [];
+    let callCount = 0;
+    const model: ModelRuntime = {
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "unused" }],
+          finishReason: "stop",
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        };
+      },
+      async doStream(options) {
+        const rawTools = (options as { tools?: unknown }).tools;
+        const toolNames = Array.isArray(rawTools)
+          ? rawTools.map((entry) =>
+            (entry as { name?: string; id?: string }).name ??
+              (entry as { name?: string; id?: string }).id ?? ""
+          )
+          : Object.keys((rawTools as Record<string, unknown> | undefined) ?? {});
+        toolNamesByStep.push(toolNames);
+        callCount++;
+
+        if (callCount === 1) {
+          return {
+            stream: createRuntimeStream([
+              {
+                type: "tool-call",
+                toolCallId: "create-agent-1",
+                toolName: "create_agent",
+                input: '{"id":"gmail-assistant-e2e"}',
+              },
+              {
+                type: "finish",
+                finishReason: "tool-calls",
+                usage: { inputTokens: 1, outputTokens: 1 },
+              },
+            ]),
+          };
+        }
+
+        return {
+          stream: createRuntimeStream([
+            { type: "text-delta", text: "I can retry with corrected agent input." },
+            {
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 1, outputTokens: 1 },
+            },
+          ]),
+        };
+      },
+    };
+
+    const createAgent = tool({
+      id: "create_agent",
+      description: "Create a Studio project agent",
+      inputSchema: defineSchema((v) => v.object({ id: v.string() }))(),
+      execute: () => {
+        throw new Error("Agent already exists");
+      },
+    });
+
+    const assistant = agent({
+      model: "anthropic/claude-sonnet-4-6",
+      system: "Create agents and recover from failed tool calls.",
+      tools: { create_agent: createAgent },
+      providerTools: ["web_search", "web_fetch"],
+      maxSteps: 3,
+      resolveModelTransport: async () => ({ model }),
+    });
+
+    const response = (await assistant.stream({
+      input: "Create a Gmail agent",
+    })).toDataStreamResponse();
+
+    await response.text();
+    assertEquals(toolNamesByStep.length, 2);
+    assertEquals(toolNamesByStep[0]?.includes("create_agent"), true);
+    assertEquals(toolNamesByStep[1]?.includes("create_agent"), true);
+    assertEquals(toolNamesByStep[1]?.includes("web_search"), true);
+    assertEquals(toolNamesByStep[1]?.includes("web_fetch"), true);
+  });
+
+  it("removes provider-native tools from the forced final response after update_agent", async () => {
+    const toolNamesByStep: string[][] = [];
+    let callCount = 0;
+    const model: ModelRuntime = {
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "unused" }],
+          finishReason: "stop",
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        };
+      },
+      async doStream(options) {
+        const rawTools = (options as { tools?: unknown }).tools;
+        const toolNames = Array.isArray(rawTools)
+          ? rawTools.map((entry) =>
+            (entry as { name?: string; id?: string }).name ??
+              (entry as { name?: string; id?: string }).id ?? ""
+          )
+          : Object.keys((rawTools as Record<string, unknown> | undefined) ?? {});
+        toolNamesByStep.push(toolNames);
+        callCount++;
+
+        if (callCount === 1) {
+          return {
+            stream: createRuntimeStream([
+              {
+                type: "tool-call",
+                toolCallId: "update-agent-1",
+                toolName: "update_agent",
+                input: '{"id":"gmail-assistant-e2e"}',
+              },
+              {
+                type: "finish",
+                finishReason: "tool-calls",
+                usage: { inputTokens: 1, outputTokens: 1 },
+              },
+            ]),
+          };
+        }
+
+        return {
+          stream: createRuntimeStream([
+            { type: "text-delta", text: "Updated Gmail Assistant." },
+            {
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 1, outputTokens: 1 },
+            },
+          ]),
+        };
+      },
+    };
+
+    const updateAgent = tool({
+      id: "update_agent",
+      description: "Update a Studio project agent",
+      inputSchema: defineSchema((v) => v.object({ id: v.string() }))(),
+      execute: async ({ id }) => ({
+        id,
+        name: "Gmail Assistant",
+        source_path: `agents/${id}.ts`,
+      }),
+    });
+
+    const assistant = agent({
+      model: "anthropic/claude-sonnet-4-6",
+      system: "Update agents and summarize successful tool results.",
+      tools: { update_agent: updateAgent },
+      providerTools: ["web_search", "web_fetch"],
+      maxSteps: 3,
+      resolveModelTransport: async () => ({ model }),
+    });
+
+    const response = (await assistant.stream({
+      input: "Update my Gmail agent",
+    })).toDataStreamResponse();
+
+    await response.text();
+    assertEquals(toolNamesByStep.length, 2);
+    assertEquals(toolNamesByStep[0]?.includes("update_agent"), true);
+    assertEquals(toolNamesByStep[0]?.includes("web_search"), true);
+    assertEquals(toolNamesByStep[0]?.includes("web_fetch"), true);
+    assertEquals(toolNamesByStep[1], []);
+  });
+
   it("notifies configured hooks after stream() executes a tool", async () => {
     const toolResults: ToolExecutionResultRequest[] = [];
     let callCount = 0;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.886";
+export const VERSION = "0.1.887";


### PR DESCRIPTION
## What
- Disables local/provider tools for the forced final response only after successful `create_agent` or `update_agent` tool results.
- Keeps tools available after failed `create_agent` attempts so the model can repair/diagnose instead of being forced into a tool-less final step.
- Extends the final-response guard to successful `update_agent`, matching canonical create-or-update agent flows.
- Bumps package version to `0.1.887` so the fix can publish.

## Why
Review feedback on veryfront-studio#5081 noted that the previous guard flipped even for failed `create_agent` attempts, making failed creation harder to repair or diagnose.

## Verification
- `deno fmt --check deno.json src/utils/version-constant.ts src/agent/runtime/index.ts src/agent/runtime/refresh.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/agent/runtime/refresh.test.ts`

## Notes
- Full pre-push test suite reached `2194 passed` before failing in unrelated `observability/metrics/config` defaults (`otlp` vs `console`); targeted runtime guard tests pass.
