### PR TITLE
Release v0.1.887

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.886",
+  "version": "0.1.887",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.886";
+export const VERSION = "0.1.887";


### PR DESCRIPTION
## Summary
- release the durable hosted bootstrap finalization fix as `veryfront@0.1.887`
- required for veryfront-agent issue veryfront/veryfront-agent#1606

## Verification
- `deno task verify:quick`

Depends on veryfront-code#2584.