### PR TITLE
Preserve eval target agents during durable eval runs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.887",
+  "version": "0.1.888",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/hosted/ag-ui-chat-request.ts
+++ b/src/agent/hosted/ag-ui-chat-request.ts
@@ -20,6 +20,7 @@ import type {
 
 export const getHostedAgUiChatForwardedConfigSchema = defineSchema((v) =>
   v.object({
+    agentId: v.string().min(1).max(128).optional(),
     projectId: v.string().nullable().optional(),
     branchId: v.string().nullable().optional(),
     conversationId: v.string().optional(),
@@ -47,6 +48,7 @@ export type HostedAgUiChatForwardedConfig = InferSchema<
 /** Context for derived hosted AG-UI chat. */
 export type DerivedHostedAgUiChatContext = {
   validatedContext: ChatRequestContext;
+  agentId?: string;
   projectId: string | null;
   conversationId: string | undefined;
   model: string | undefined;
@@ -123,6 +125,8 @@ export function deriveHostedAgUiChatContext(
     parseAgUiContextString(contextMap.get(`${contextNamespace}.environmentContext`));
   const conversationId = forwardedConfig?.conversationId ??
     parseAgUiContextString(contextMap.get(`${contextNamespace}.conversationId`));
+  const agentId = forwardedConfig?.agentId ??
+    parseAgUiContextString(contextMap.get(`${contextNamespace}.agentId`));
 
   const validatedContext: ChatRequestContext = {
     projectId,
@@ -133,6 +137,7 @@ export function deriveHostedAgUiChatContext(
 
   return {
     validatedContext,
+    ...(agentId ? { agentId } : {}),
     projectId,
     conversationId,
     model: forwardedConfig?.model ??
@@ -187,7 +192,7 @@ export async function buildParsedHostedAgUiRequest(
   }
 
   return {
-    agentId: undefined,
+    agentId: chatContext.agentId,
     agUiInput: input.agUiInput,
     userId: input.userId,
     authToken: input.authToken,

--- a/src/agent/service/routes.test.ts
+++ b/src/agent/service/routes.test.ts
@@ -125,6 +125,26 @@ Deno.test("agent service routes stream prepared AG-UI execution", async () => {
   assertEquals(streamInputs, [{ executionId: "exec-1", agUiRunId: "run-1" }]);
 });
 
+Deno.test("agent service routes preserve forwarded AG-UI target agent ids", async () => {
+  const { routeSet, preparedRequests } = createRouteSet();
+  const response = await routeSet.handleAgUiRequest(
+    createAuthenticatedRequest("/api/ag-ui", {
+      ...createAgUiBody(),
+      forwardedProps: {
+        veryfront: {
+          agentId: "researcher",
+          projectId: "project_123",
+        },
+      },
+    }),
+  );
+
+  assertEquals(response.status, 200);
+  assertEquals(preparedRequests.length, 1);
+  assertEquals(preparedRequests[0]?.agentId, "researcher");
+  assertEquals(preparedRequests[0]?.projectId, "project_123");
+});
+
 Deno.test("agent service routes preserve control-plane target agent ids", async () => {
   const { routeSet, preparedRequests } = createRouteSet();
   const response = await routeSet.handleRuntimeAgentRunInvocationExecuteRequest({

--- a/src/eval/agent-service.test.ts
+++ b/src/eval/agent-service.test.ts
@@ -64,6 +64,7 @@ describe("eval/agent-service", () => {
     const body = buildAgentServiceEvalRequestBody({
       exampleId: "smoke",
       input: { prompt: "List files", metadata: { area: "files" } },
+      agentId: "researcher",
       projectId: "project_123",
       branchId: "branch_123",
       model: "provider/model",
@@ -85,6 +86,7 @@ describe("eval/agent-service", () => {
     ]);
     assertEquals(body.forwardedProps, {
       veryfront: {
+        agentId: "researcher",
         projectId: "project_123",
         branchId: "branch_123",
         conversationId: "conversation_123",
@@ -120,6 +122,7 @@ describe("eval/agent-service", () => {
     const adapter = createAgentServiceEvalAdapter({
       endpoint: "http://127.0.0.1:4311/api/ag-ui",
       authToken: "token",
+      agentId: "veryfront",
       projectId: "project_123",
       branchId: "branch_123",
       fetch: async (input, init) => {
@@ -158,6 +161,7 @@ describe("eval/agent-service", () => {
     );
     assertEquals(requests[0]?.body.forwardedProps, {
       veryfront: {
+        agentId: "veryfront",
         projectId: "project_123",
         branchId: "branch_123",
       },

--- a/src/eval/agent-service.ts
+++ b/src/eval/agent-service.ts
@@ -41,6 +41,7 @@ export interface AgentServiceEvalEnvironmentPreflightResult {
 
 /** Veryfront forwarded props included in an AG-UI eval request. */
 export interface AgentServiceEvalForwardedProps {
+  agentId?: string;
   projectId?: string;
   conversationId?: string;
   branchId?: string;
@@ -56,6 +57,7 @@ export interface BuildAgentServiceEvalRequestBodyInput {
   exampleId: string;
   input: unknown;
   metadata?: Record<string, unknown>;
+  agentId?: string | null;
   projectId?: string | null;
   conversationId?: string | null;
   branchId?: string | null;
@@ -86,6 +88,7 @@ export interface AgentServiceEvalRequestBody {
 export interface AgentServiceEvalAdapterConfig {
   endpoint?: string;
   authToken: string;
+  agentId?: string | null;
   projectId?: string | null;
   conversationId?: string | null;
   branchId?: string | null;
@@ -135,6 +138,7 @@ function getInputMetadata(input: unknown): Record<string, unknown> {
 function getRequestOverrides(input: BuildAgentServiceEvalRequestBodyInput) {
   const record = isRecord(input.input) ? input.input : {};
   return {
+    agentId: input.agentId ?? null,
     projectId: input.projectId ?? readString(record.projectId) ?? null,
     conversationId: input.conversationId ?? readString(record.conversationId) ?? null,
     branchId: input.branchId ?? readString(record.branchId) ?? null,
@@ -151,6 +155,7 @@ function createVeryfrontForwardedProps(
   const overrides = getRequestOverrides(input);
   const veryfront: AgentServiceEvalForwardedProps = {};
 
+  if (overrides.agentId) veryfront.agentId = overrides.agentId;
   if (overrides.projectId) veryfront.projectId = overrides.projectId;
   if (overrides.conversationId) veryfront.conversationId = overrides.conversationId;
   if (overrides.branchId) veryfront.branchId = overrides.branchId;
@@ -345,6 +350,7 @@ export function createAgentServiceEvalAdapter(
       exampleId: context.example.id,
       input: context.example.input,
       metadata: context.example.metadata,
+      agentId: config.agentId,
       projectId: config.projectId,
       conversationId: config.conversationId,
       branchId: config.branchId,

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -256,6 +256,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     let receivedBaseDir: string | undefined;
     let receivedEndpoint: string | undefined;
     let receivedAuthToken: string | undefined;
+    let receivedAgentId: string | undefined;
     const handler = new ProjectRunExecuteHandler(createDeps({
       runEval: async (_definition, options) => {
         receivedRunId = options.runId;
@@ -265,6 +266,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
       createEvalAgentAdapter: (config) => {
         receivedEndpoint = config.endpoint;
         receivedAuthToken = config.authToken;
+        receivedAgentId = config.agentId;
         return async () => ({ text: "Paris" });
       },
     }));
@@ -296,6 +298,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     assertEquals(receivedBaseDir, "/project");
     assertEquals(receivedEndpoint, "https://example.com/api/ag-ui");
     assertEquals(receivedAuthToken, "runtime-token");
+    assertEquals(receivedAgentId, "researcher");
   });
 
   it("marks eval execution unsuccessful when records contain adapter failures", async () => {

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -689,8 +689,17 @@ function withEvalRunConfig(
   };
 }
 
+function getEvalTargetAgentId(definition: EvalDefinition): string | undefined {
+  if (definition.targetKind !== "agent") return undefined;
+  const target = definition.target.startsWith("agent:")
+    ? definition.target.slice("agent:".length)
+    : definition.target;
+  return target.length > 0 ? target : undefined;
+}
+
 function createEvalAdapterConfig(input: {
   request: ProjectRunExecuteRequest;
+  definition: EvalDefinition;
   req: Request;
   ctx: HandlerContext;
 }): AgentServiceEvalAdapterConfig {
@@ -704,6 +713,7 @@ function createEvalAdapterConfig(input: {
   return {
     endpoint: getSameOriginAgUiEndpoint(input.req),
     authToken,
+    agentId: getEvalTargetAgentId(input.definition),
     projectId: input.request.projectId,
     branchId: getStringConfig(config, ["branch_id", "branchId"]) ??
       getStringConfig(runInput, ["branch_id", "branchId"]),
@@ -740,7 +750,9 @@ async function executeEvalRun(
   const config = request.config ?? {};
   const report = await deps.runEval(withEvalRunConfig(evalItem.definition, config), {
     adapters: {
-      agent: deps.createEvalAgentAdapter(createEvalAdapterConfig({ request, req, ctx })),
+      agent: deps.createEvalAgentAdapter(
+        createEvalAdapterConfig({ request, definition: evalItem.definition, req, ctx }),
+      ),
     },
     baseDir: ctx.projectDir,
     runId: request.runId,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.887";
+export const VERSION = "0.1.888";


### PR DESCRIPTION
## Summary
- preserve eval target agent ids when durable eval runs execute through the agent service adapter
- forward `agentId` through eval request bodies, AG-UI forwarded props, and hosted AG-UI parsing
- bump `veryfront` to `0.1.888` and sync the runtime version constant

## Verification
- `deno test --no-check --allow-all src/eval/agent-service.test.ts src/agent/service/routes.test.ts src/server/handlers/request/project-run-execute.handler.test.ts`
- `deno test --no-check --allow-all src/agent/hosted/ag-ui-chat-request.test.ts src/task/discovery.test.ts src/utils/logger/logger.test.ts src/utils/version.test.ts`
- `deno check src/agent/hosted/ag-ui-chat-request.ts src/utils/version.ts src/utils/version-constant.ts`
- `deno fmt --check src/utils/version-constant.ts src/agent/hosted/ag-ui-chat-request.ts`
- pre-push: format, lint, typecheck, generation, and unit tests passed (`2196 passed`, `18843 steps`)
