### PR TITLE
Preserve eval project context across AG-UI calls

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.888",
+  "version": "0.1.889",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -160,6 +160,7 @@ const environment = resolveAgentServiceEvalEnvironment({
   AG_UI_EVAL_ENDPOINT: "http://127.0.0.1:3001/api/ag-ui",
   VERYFRONT_TOKEN: "<TOKEN>",
   AG_UI_EVAL_PROJECT_ID: "<PROJECT_ID>",
+  AG_UI_EVAL_PROJECT_SLUG: "<PROJECT_SLUG>",
 });
 
 const definition = evalAgent({
@@ -178,7 +179,9 @@ const report = await runEval(definition, {
 ```
 
 Set `AG_UI_EVAL_PROJECT_ID` when cases need project files, releases, or other
-project-scoped API state. The adapter reads AG-UI events into
+project-scoped API state. Set `AG_UI_EVAL_PROJECT_SLUG` or
+`VERYFRONT_PROJECT_SLUG` when the AG-UI endpoint runs behind the project runtime
+proxy. The adapter reads AG-UI events into
 `record.trace.events`, records tool starts as `record.trace.toolCalls`, and puts
 the parsed text at `record.output.text`.
 

--- a/src/eval/agent-service.test.ts
+++ b/src/eval/agent-service.test.ts
@@ -33,6 +33,7 @@ describe("eval/agent-service", () => {
       VERYFRONT_TOKEN: "token",
       VERYFRONT_API_URL: "https://api.example.test",
       AG_UI_EVAL_PROJECT_ID: "project_123",
+      AG_UI_EVAL_PROJECT_SLUG: "demo-project",
       AG_UI_EVAL_BRANCH_ID: "branch_123",
       AG_UI_EVAL_MODEL: "provider/model",
     });
@@ -42,6 +43,7 @@ describe("eval/agent-service", () => {
       authToken: "token",
       apiUrl: "https://api.example.test",
       projectId: "project_123",
+      projectSlug: "demo-project",
       branchId: "branch_123",
       model: "provider/model",
     });
@@ -124,6 +126,7 @@ describe("eval/agent-service", () => {
       authToken: "token",
       agentId: "veryfront",
       projectId: "project_123",
+      projectSlug: "demo-project",
       branchId: "branch_123",
       fetch: async (input, init) => {
         requests.push({
@@ -158,6 +161,10 @@ describe("eval/agent-service", () => {
     assertEquals(
       (requests[0]?.init.headers as Record<string, string>).Authorization,
       "Bearer token",
+    );
+    assertEquals(
+      (requests[0]?.init.headers as Record<string, string>)["x-project-slug"],
+      "demo-project",
     );
     assertEquals(requests[0]?.body.forwardedProps, {
       veryfront: {

--- a/src/eval/agent-service.ts
+++ b/src/eval/agent-service.ts
@@ -28,6 +28,7 @@ export interface AgentServiceEvalEnvironment {
   authToken: string;
   apiUrl: string;
   projectId?: string;
+  projectSlug?: string;
   branchId?: string;
   model?: string;
 }
@@ -90,6 +91,7 @@ export interface AgentServiceEvalAdapterConfig {
   authToken: string;
   agentId?: string | null;
   projectId?: string | null;
+  projectSlug?: string | null;
   conversationId?: string | null;
   branchId?: string | null;
   model?: string | null;
@@ -174,10 +176,13 @@ function createVeryfrontForwardedProps(
   return Object.keys(veryfront).length > 0 ? veryfront : null;
 }
 
-function createHeaders(authToken: string): Record<string, string> {
+function createHeaders(
+  config: Pick<AgentServiceEvalAdapterConfig, "authToken" | "projectSlug">,
+): Record<string, string> {
   return {
     "Content-Type": "application/json",
-    Authorization: `Bearer ${authToken}`,
+    Authorization: `Bearer ${config.authToken}`,
+    ...(config.projectSlug ? { "x-project-slug": config.projectSlug } : {}),
   };
 }
 
@@ -260,7 +265,7 @@ function createRequestInit(
 ): RequestInit {
   return {
     method: "POST",
-    headers: createHeaders(config.authToken),
+    headers: createHeaders(config),
     body: JSON.stringify(body),
     ...(config.requestTimeoutMs ? { signal: AbortSignal.timeout(config.requestTimeoutMs) } : {}),
   };
@@ -280,6 +285,11 @@ export function resolveAgentServiceEvalEnvironment(
       : parseAgentServiceConfig(env).VERYFRONT_API_URL,
     ...(typeof env.AG_UI_EVAL_PROJECT_ID === "string"
       ? { projectId: env.AG_UI_EVAL_PROJECT_ID }
+      : {}),
+    ...(typeof env.AG_UI_EVAL_PROJECT_SLUG === "string"
+      ? { projectSlug: env.AG_UI_EVAL_PROJECT_SLUG }
+      : typeof env.VERYFRONT_PROJECT_SLUG === "string"
+      ? { projectSlug: env.VERYFRONT_PROJECT_SLUG }
       : {}),
     ...(typeof env.AG_UI_EVAL_BRANCH_ID === "string" ? { branchId: env.AG_UI_EVAL_BRANCH_ID } : {}),
     ...(typeof env.AG_UI_EVAL_MODEL === "string" ? { model: env.AG_UI_EVAL_MODEL } : {}),

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -256,7 +256,8 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     let receivedBaseDir: string | undefined;
     let receivedEndpoint: string | undefined;
     let receivedAuthToken: string | undefined;
-    let receivedAgentId: string | undefined;
+    let receivedAgentId: string | null | undefined;
+    let receivedProjectSlug: string | null | undefined;
     const handler = new ProjectRunExecuteHandler(createDeps({
       runEval: async (_definition, options) => {
         receivedRunId = options.runId;
@@ -267,6 +268,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
         receivedEndpoint = config.endpoint;
         receivedAuthToken = config.authToken;
         receivedAgentId = config.agentId;
+        receivedProjectSlug = (config as { projectSlug?: string | null }).projectSlug;
         return async () => ({ text: "Paris" });
       },
     }));
@@ -299,6 +301,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     assertEquals(receivedEndpoint, "https://example.com/api/ag-ui");
     assertEquals(receivedAuthToken, "runtime-token");
     assertEquals(receivedAgentId, "researcher");
+    assertEquals(receivedProjectSlug, "demo-project");
   });
 
   it("marks eval execution unsuccessful when records contain adapter failures", async () => {

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -715,6 +715,7 @@ function createEvalAdapterConfig(input: {
     authToken,
     agentId: getEvalTargetAgentId(input.definition),
     projectId: input.request.projectId,
+    projectSlug: input.ctx.projectSlug,
     branchId: getStringConfig(config, ["branch_id", "branchId"]) ??
       getStringConfig(runInput, ["branch_id", "branchId"]),
     model: getStringConfig(config, ["model"]),

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.888";
+export const VERSION = "0.1.889";


### PR DESCRIPTION
## Summary
- Pass projectSlug from canonical eval run execution into the AG-UI eval adapter
- Send x-project-slug on live agent-service eval requests while keeping projectId in forwardedProps
- Document AG_UI_EVAL_PROJECT_SLUG / VERYFRONT_PROJECT_SLUG for proxy-backed live evals
- Bump veryfront to 0.1.889

## Verification
- deno test --no-check --allow-all src/server/handlers/request/project-run-execute.handler.test.ts src/eval/agent-service.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/server/handlers/request/project-run-execute.handler.test.ts src/eval/agent-service.test.ts
- deno task docs:validate
- deno task typecheck
- deno task lint
- deno fmt --check deno.json deno.lock src/eval/agent-service.ts src/eval/agent-service.test.ts src/server/handlers/request/project-run-execute.handler.ts src/server/handlers/request/project-run-execute.handler.test.ts docs/guides/evals.md
- git diff --check
- Pre-push: format, lint, typecheck, generated manifests, and deno task test:unit: 2196 passed, 18843 steps, 0 failed

## Staging follow-up
After merge and release, rerun the Studio eval smoke against staging to confirm agent-targeted eval records no longer fail with missing project context.