### PR TITLE
Preserve proxy auth for nested eval agent calls

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.889",
+  "version": "0.1.890",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/eval/agent-service.test.ts
+++ b/src/eval/agent-service.test.ts
@@ -163,6 +163,10 @@ describe("eval/agent-service", () => {
       "Bearer token",
     );
     assertEquals(
+      (requests[0]?.init.headers as Record<string, string>)["x-token"],
+      "token",
+    );
+    assertEquals(
       (requests[0]?.init.headers as Record<string, string>)["x-project-slug"],
       "demo-project",
     );

--- a/src/eval/agent-service.ts
+++ b/src/eval/agent-service.ts
@@ -182,6 +182,7 @@ function createHeaders(
   return {
     "Content-Type": "application/json",
     Authorization: `Bearer ${config.authToken}`,
+    "x-token": config.authToken,
     ...(config.projectSlug ? { "x-project-slug": config.projectSlug } : {}),
   };
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.889";
+export const VERSION = "0.1.890";


### PR DESCRIPTION
## Summary
- Send the resolved eval runtime token as both Authorization and x-token for AG-UI agent-service calls.
- Keep x-project-slug propagation from the previous rollout intact while satisfying proxy-mode auth context requirements.
- Bump the package version to 0.1.890 and keep the runtime VERSION constant synced with deno.json.

## Staging evidence
- Staging evals on veryfront@0.1.889 no longer failed on missing x-project-slug.
- The next failure was inside the nested AG-UI call: missing authentication context because proxy mode required x-token.

## Verification
- deno fmt --check deno.json src/utils/version-constant.ts src/eval/agent-service.ts src/eval/agent-service.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/eval/agent-service.test.ts src/server/handlers/request/project-run-execute.handler.test.ts
- pre-push hook: format, lint, typecheck, generate, and unit tests (2196 passed, 0 failed)
