### PR TITLE
Release veryfront 0.1.891

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.890",
+  "version": "0.1.891",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.890";
+export const VERSION = "0.1.891";


### PR DESCRIPTION
## Summary

- bump the Veryfront package version to 0.1.891
- include the merged eval CLI artifact behavior in the next framework patch

## Verification

- deno fmt --check deno.json src/utils/version-constant.ts
- deno check src/utils/version.ts
- git diff --check