### PR TITLE
Expose eval run capability to Studio runtime clients

### DIFF
--- a/src/agent/hosted/runtime-request-config.test.ts
+++ b/src/agent/hosted/runtime-request-config.test.ts
@@ -118,6 +118,7 @@ Deno.test("resolveHostedRuntimeRequestConfig resolves overrides, thinking, max s
       "project_switching",
       "project.evals.read",
       "project.evals.write",
+      "project.evals.run",
     ],
   });
 });

--- a/src/agent/runtime/client-profile.test.ts
+++ b/src/agent/runtime/client-profile.test.ts
@@ -25,6 +25,7 @@ Deno.test("resolveRuntimeClientProfile normalizes nested Veryfront client metada
         "project_switching",
         "project.evals.read",
         "project.evals.write",
+        "project.evals.run",
       ],
     },
   );
@@ -78,6 +79,7 @@ Deno.test("clientAllowsStudioMcp allows trusted studio-capable clients", () => {
       "project_switching",
       "project.evals.read",
       "project.evals.write",
+      "project.evals.run",
     ],
   });
   assertEquals(clientAllowsStudioMcp(profile), true);

--- a/src/agent/runtime/client-profile.ts
+++ b/src/agent/runtime/client-profile.ts
@@ -15,6 +15,7 @@ export const getRuntimeClientCapabilitySchema = defineSchema((v) =>
     "project_switching",
     "project.evals.read",
     "project.evals.write",
+    "project.evals.run",
   ])
 );
 
@@ -85,6 +86,7 @@ const FIRST_PARTY_CLIENTS: Readonly<Record<string, FirstPartyClientProfile>> = {
       "project_switching",
       "project.evals.read",
       "project.evals.write",
+      "project.evals.run",
     ],
   },
   "veryfront-cli": {

--- a/src/eval/studio.test.ts
+++ b/src/eval/studio.test.ts
@@ -6,6 +6,7 @@ import {
   datasets,
   type DiscoveredEval,
   evalAgent,
+  type EvalRun,
   getEvalRunSchema,
   getEvalSourceDocumentSchema,
   metrics,
@@ -77,7 +78,7 @@ describe("eval/studio", () => {
   });
 
   it("validates V2-ready EvalRun projections", () => {
-    const run = {
+    const run: EvalRun = {
       kind: "eval-run",
       runId: "evalrun_123",
       evalId: "eval:deep-research",


### PR DESCRIPTION
## Summary
- add project.evals.run to the runtime client capability schema
- include project.evals.run in the first-party veryfront-studio runtime profile
- lock hosted runtime request config and client profile tests to the separate eval run capability
- type the EvalRun schema fixture so deno check catches schema/type drift

## Verification
- deno test --no-check --allow-all src/agent/runtime/client-profile.test.ts src/agent/hosted/runtime-request-config.test.ts src/eval/studio.test.ts
- deno check src/agent/runtime/client-profile.ts src/agent/runtime/client-profile.test.ts src/agent/hosted/runtime-request-config.test.ts src/eval/studio.test.ts
- deno fmt --check src/agent/runtime/client-profile.ts src/agent/runtime/client-profile.test.ts src/agent/hosted/runtime-request-config.test.ts src/eval/studio.test.ts && git diff --check
- deno task --lock=deno.lock --frozen test:unit
- pre-push hook: format, lint, typecheck, and unit tests passed