### PR TITLE
Release veryfront 0.1.892

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.891",
+  "version": "0.1.892",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.891";
+export const VERSION = "0.1.892";


### PR DESCRIPTION
## Summary
- bump veryfront to 0.1.892 for the merged eval capability support
- keep the release diff limited to deno.json and the shared version constant

## Verification
- deno fmt --check deno.json src/utils/version-constant.ts
- deno check src/utils/version-constant.ts
- git diff --check
- deno task --lock=deno.lock --frozen test:unit
- pre-push: format, lint, typecheck, test:unit