### PR TITLE
Release skill helper package export

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.892",
+  "version": "0.1.893",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {
@@ -95,6 +95,7 @@
     "./prompt": "./src/prompt/index.ts",
     "./resource": "./src/resource/index.ts",
     "./runs": "./src/runs/index.ts",
+    "./skill": "./src/skill/index.ts",
     "./mcp": "./src/mcp/index.ts",
     "./middleware": "./src/middleware/index.ts",
     "./observability": "./src/observability/index.ts",

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -35,6 +35,7 @@ order: 1
 | [`veryfront/sandbox`](./veryfront/sandbox.md) | Isolated execution. |
 | [`veryfront/schemas`](./veryfront/schemas.md) | Validation schemas. |
 | [`veryfront/server`](./veryfront/server.md) | Server runtime helpers. |
+| [`veryfront/skill`](./veryfront/skill.md) | Agent skills. Public API for the agent skills system. Skills are project-level capabilities defined as SKILL.md files following the agentskills.io specification. |
 | [`veryfront/testing`](./veryfront/testing.md) | Test utilities. |
 | [`veryfront/tool`](./veryfront/tool.md) | Tool definitions and execution. |
 | [`veryfront/utils`](./veryfront/utils.md) | Runtime utilities. |

--- a/docs/api-reference/veryfront/skill.md
+++ b/docs/api-reference/veryfront/skill.md
@@ -1,0 +1,83 @@
+---
+title: "veryfront/skill"
+description: "Agent skills. Public API for the agent skills system. Skills are project-level capabilities defined as SKILL.md files following the agentskills.io specification."
+order: 27
+---
+
+## Import
+
+```ts
+import {
+  buildSkillManifestPrompt,
+  createExecuteSkillScriptTool,
+  createLoadSkillReferenceTool,
+  createLoadSkillTool,
+  filterToolsForSkill,
+  getAllSkills,
+} from "veryfront/skill";
+```
+
+## Examples
+
+```ts
+import { parseSkillFrontmatter, validateSkillMetadata } from "veryfront/skill";
+
+const parsed = await parseSkillFrontmatter("---\nname: review\ndescription: Review code\n---\n");
+validateSkillMetadata(parsed.frontmatter, "review");
+```
+
+## Exports
+
+### Components
+
+| Name | Description | Source |
+|------|-------------|--------|
+| `SKILL_ALLOWED_TOOL_PATTERN_REGEX` | Valid allowed-tool pattern: exact ID or prefix wildcard (e.g. "api:*") | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L17) |
+| `SKILL_ASSETS_DIR` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L37) |
+| `SKILL_DESCRIPTION_MAX_LENGTH` | Maximum description length in characters | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L21) |
+| `SKILL_MD_FILENAME` | Standard SKILL.md filename per agentskills.io spec | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L24) |
+| `SKILL_NAME_REGEX` | Valid skill name: lowercase alphanumeric + hyphens, 1-64 chars | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L14) |
+| `SKILL_REFERENCES_DIR` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L35) |
+| `SKILL_RESOURCES_DIR` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L36) |
+| `SKILL_SCRIPTS_DIR` | Conventional subdirectory names | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L34) |
+| `SKILL_TOOL_IDS` | Tool IDs that belong to the skill system (single source of truth) | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L27) |
+
+### Functions
+
+| Name | Description | Source |
+|------|-------------|--------|
+| `buildSkillManifestPrompt` | Build the skill manifest prompt section for an agent's system prompt. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/prompt-augmentation.ts#L19) |
+| `createExecuteSkillScriptTool` | Create the execute_skill_script tool. Executes a script from a skill's scripts/ directory. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/tools.ts#L200) |
+| `createLoadSkillReferenceTool` | Create the load_skill_reference tool. Reads a reference file from a skill's references/, resources/, or assets/ directory. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/tools.ts#L173) |
+| `createLoadSkillTool` | Create the load_skill tool. Loads a skill's full instructions, available references, and scripts. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/tools.ts#L121) |
+| `filterToolsForSkill` | Layer 1: Filter tool definitions before sending to model. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/allowed-tools.ts#L46) |
+| `getAllSkills` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/registry.ts#L111) |
+| `getSkill` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/registry.ts#L107) |
+| `getSkillScriptExecutor` | Get the appropriate script executor. Checks cloud auth availability on every call so request-scoped credentials and environment overrides are respected. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/executor.ts#L211) |
+| `isSkillVisibleTo` | Whether a skill is visible to the caller identified by the scope. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/registry.ts#L27) |
+| `isToolAllowedBySkill` | Layer 2: Check if a specific tool call is allowed at execution time. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/allowed-tools.ts#L67) |
+| `listSkillSubdir` | List files in a skill subdirectory. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/path-safety.ts#L187) |
+| `parseSkillFrontmatter` | Parse SKILL.md content into frontmatter + body. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/parser.ts#L26) |
+| `registerSkill` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/registry.ts#L103) |
+| `validateAllowedToolPatterns` | Validate allowed-tool patterns at parse time. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/allowed-tools.ts#L86) |
+| `validateSkillMetadata` | Validate and normalize parsed frontmatter into SkillMetadata. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/parser.ts#L75) |
+| `validateSkillPath` | Validate that a requested path is safe within a skill's root directory. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/path-safety.ts#L105) |
+
+### Types
+
+| Name | Description | Source |
+|------|-------------|--------|
+| `ActiveSkillContext` | Active skill context for runtime policy tracking | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L112) |
+| `AgentCapabilityScope` | Caller scope used for owner-aware capability resolution. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/registry.ts#L21) |
+| `Skill` | Registered skill instance | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L70) |
+| `SkillContent` | Full skill content returned by load_skill tool | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L58) |
+| `SkillMetadata` | Parsed frontmatter metadata from SKILL.md | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L42) |
+| `SkillScriptExecutor` | Script executor interface | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L107) |
+| `SkillScriptExecutorInput` | Input for the script executor | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L97) |
+| `SkillScriptResult` | Result from executing a skill script | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/types.ts#L90) |
+
+### Constants
+
+| Name | Description | Source |
+|------|-------------|--------|
+| `skillRegistry` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/skill/registry.ts#L101) |

--- a/docs/architecture/05-agent-runtime.md
+++ b/docs/architecture/05-agent-runtime.md
@@ -157,8 +157,8 @@ flowchart TD
 
 Skills provide instruction packs and tool policy. They are not workflows,
 runs, or local tool definitions. Skills are configured through project
-discovery and `agent({ skills })`; there is no top-level `veryfront/skill`
-import path in the current public export map.
+discovery and `agent({ skills })`; parser, registry, tool, and policy helpers
+are available from the public `veryfront/skill` package subpath.
 
 ## Boundaries
 

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -5,6 +5,8 @@ order: 29
 ---
 
 A skill is a directory under `skills/` containing a `SKILL.md` file. It bundles structured agent instructions, an `allowed_tools` policy, optional resource and reference files, static assets, and executable scripts. The format follows the [agentskills.io](https://agentskills.io) specification.
+Use [veryfront/skill](../api-reference/veryfront/skill.md) for parser,
+registry, tool, and policy helpers in framework code.
 
 ## Prerequisites
 

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -6,6 +6,15 @@ import {
 } from "./browser-safe-exports.mjs";
 import { normalizeNpmPackageMetadata } from "./npm-package-metadata.ts";
 
+Deno.test("exports agent skill helpers as a public package subpath", async () => {
+	const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
+	const exports = denoConfig.exports as Record<string, string>;
+	const imports = denoConfig.imports as Record<string, string>;
+
+	assertEquals(exports["./skill"], "./src/skill/index.ts");
+	assertEquals(imports["veryfront/skill"], "./src/skill/index.ts");
+});
+
 describe("normalizeNpmPackageMetadata", () => {
 	it("removes source files from the published npm file list", () => {
 		const pkg = normalizeNpmPackageMetadata({

--- a/src/skill/index.ts
+++ b/src/skill/index.ts
@@ -1,11 +1,19 @@
 /**
- * Agent Skills
+ * Agent skills.
  *
  * Public API for the agent skills system.
  * Skills are project-level capabilities defined as SKILL.md files
  * following the agentskills.io specification.
  *
  * @module
+ *
+ * @example
+ * ```ts
+ * import { parseSkillFrontmatter, validateSkillMetadata } from "veryfront/skill";
+ *
+ * const parsed = await parseSkillFrontmatter("---\nname: review\ndescription: Review code\n---\n");
+ * validateSkillMetadata(parsed.frontmatter, "review");
+ * ```
  */
 
 // Types

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.892";
+export const VERSION = "0.1.893";

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -612,7 +612,10 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     snippets: ["Sandbox.create", "executeCommand", "sandbox.close"],
   },
   "guides/skills.md": {
-    references: ["../api-reference/veryfront/agent.md"],
+    references: [
+      "../api-reference/veryfront/agent.md",
+      "../api-reference/veryfront/skill.md",
+    ],
     snippets: ["SKILL.md", "allowed_tools", "veryfront skills validate"],
   },
   "guides/tasks.md": {


### PR DESCRIPTION
## Summary
- Bump Veryfront Code to `0.1.893`.
- Export the existing skill helper surface at `veryfront/skill` for published package consumers.
- Add generated API reference coverage plus a package export regression test.
- Keep the shared `VERSION` constant in sync with `deno.json`.

## Verification
- `deno test --config=scripts/test.deno.json --no-check --allow-read --filter 'exports agent skill helpers as a public package subpath' scripts/build/npm-package-metadata.test.ts`
- `deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts`
- `deno task docs:validate`
- `deno task verify:quick`
- Pre-push hook: format, lint, typecheck, generate, and unit tests passed: 2198 tests, 18852 steps.

## Notes
- No dependency changes.
- No lockfile changes.
