### PR TITLE
Document project metrics SDK usage

### DIFF
--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -280,6 +280,11 @@ such as `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_METRICS_ENABLED`, and
 `OTEL_TRACES_ENABLED` do not route eval reports to those vendors; they only
 control runtime trace and metric export.
 
+Use [project metrics](./project-metrics.md) when an eval should also emit
+aggregate dashboard signals such as `vf_eval_result_total` or
+`vf_eval_duration_ms`. Keep report exports for rich per-case eval data, and keep
+project metrics to low-cardinality counters, histograms, and gauges.
+
 Use `@veryfront/ext-eval-report-http` when an eval gateway endpoint should
 receive reports without adding a vendor SDK:
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -37,6 +37,7 @@ details, see [API reference](../api-reference/index.md).
 | Choose model providers and runtime defaults | [Providers](./providers.md)                       |
 | Give an agent a typed capability            | [Tools](./tools.md)                               |
 | Measure agent behavior with evals           | [Evals](./evals.md)                               |
+| Emit app and eval dashboard metrics         | [Project metrics](./project-metrics.md)           |
 | Add memory or streamed responses            | [Memory and streaming](./memory-and-streaming.md) |
 | Build document Q&A with RAG                 | [Build a RAG app](./build-a-rag-app.md)           |
 | Coordinate more than one agent              | [Multi-agent](./multi-agent.md)                   |

--- a/docs/guides/project-metrics.md
+++ b/docs/guides/project-metrics.md
@@ -1,0 +1,130 @@
+---
+title: "Project metrics"
+description: "Emit project-scoped counters, histograms, and gauges from app and eval code."
+order: 41
+---
+
+Project metrics are custom application and eval measurements that show up in
+the Veryfront Metrics panel. They are separate from runtime traces and logs:
+the runtime installs the OpenTelemetry meter provider, while project code emits
+named instruments through `veryfront/metrics`.
+
+For runtime observability APIs and OTLP setup, see
+[veryfront/observability](../api-reference/veryfront/observability.md).
+
+## Emit metrics
+
+Use the SDK hook from app, agent, tool, task, workflow, and eval code:
+
+```ts
+import { metrics } from "veryfront/metrics";
+
+metrics.counter("vf_signup_total", 1, {
+  plan: "pro",
+  source: "checkout",
+});
+
+metrics.histogram("vf_checkout_duration_seconds", 1.24, {
+  step: "payment",
+});
+
+metrics.gauge("vf_queue_depth", 42, {
+  queue: "email",
+});
+```
+
+Use counters for totals, histograms for durations and sizes, and gauges for
+current values. Prefer stable `vf_`-prefixed metric names so they are easy to
+discover in Studio.
+
+When code runs inside Veryfront, the SDK adds request-scoped labels for
+`project_id`, `project_slug`, and `environment`. User code should not provide
+or trust those labels for isolation; the platform-owned request context wins.
+
+## Emit eval metrics
+
+Eval definitions still use `veryfront/eval` metrics for pass/fail, scores, and
+reports. Add project metrics when you also want aggregate dashboards:
+
+```ts
+import { datasets, evalAgent, metrics as evalMetrics } from "veryfront/eval";
+import { metrics } from "veryfront/metrics";
+
+export default evalAgent({
+  target: "agent:support",
+  dataset: datasets.inline([
+    { id: "q1", input: "Capital of France?", reference: "Paris" },
+  ]),
+  metrics: [evalMetrics.answer.exactMatch().gate()],
+  async check(ctx) {
+    const passed = ctx.record.output.text?.includes("Paris") === true;
+
+    metrics.counter("vf_eval_result_total", 1, {
+      eval_id: "support",
+      metric: "answer.exactMatch",
+      outcome: passed ? "pass" : "fail",
+    });
+
+    metrics.histogram("vf_eval_duration_ms", ctx.record.durationMs, {
+      eval_id: "support",
+    });
+  },
+});
+```
+
+## Label policy
+
+Metric labels become query dimensions. Keep them low-cardinality and safe:
+
+| Good labels                                                                            | Avoid                                                                                    |
+| -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `environment`, `service`, `route`, `status`, `outcome`, `model`, `provider`, `eval_id` | User IDs, email addresses, prompts, outputs, request IDs, session IDs, raw URLs, secrets |
+
+Use a small allowlist per metric. Do not put tenant identity, project identity,
+credentials, or personally identifiable data into user-supplied labels.
+Project and environment labels are injected by the platform.
+
+## Relationship to OpenTelemetry
+
+`veryfront/metrics` writes to the active OpenTelemetry metrics API. Export
+routing is owned by the runtime process:
+
+- Shared Veryfront runtimes use platform-owned OTel env vars and filter
+  project-supplied telemetry routing keys.
+- Dedicated project runtimes may use deployment environment variables because
+  they run in their own process boundary.
+- Local or customer-cloud deployments can use any Prometheus-compatible backend
+  that the runtime config points at; Studio should treat the backend as an
+  implementation detail.
+
+Regular OpenTelemetry traces and metrics describe runtime behavior. Project
+metrics describe product, app, and eval behavior inside one project.
+
+## Relationship to eval exporters
+
+Langfuse, LangSmith, Braintrust, and similar systems should use explicit eval
+report exporters from `veryfront/extensions/eval`. Those exporters receive the
+completed, redacted `EvalReport` only when an eval run selects them.
+
+Project metrics are aggregate signals for dashboards and alerts. They are not
+the report transport and should not include eval inputs, outputs, traces, or
+judge evidence.
+
+## MCP posture
+
+Do not expose arbitrary raw metric writes over MCP. Agents that need to create
+metrics should call project code or a typed project tool that uses
+`veryfront/metrics`; that keeps project scoping, label policy, rate limits, and
+redaction in one framework path.
+
+## Verify it worked
+
+Deploy or run the code path that emits the metric, then open the project
+Metrics panel in Studio and query the metric name, for example
+`vf_eval_result_total`.
+
+If no series appears, check that metrics export is enabled for the runtime
+environment and that the selected time range includes the emitted sample. In
+shared Veryfront runtimes, platform telemetry env vars control export. In
+dedicated runtimes, check the deployment environment variables for the project
+runtime process.

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -29,6 +29,7 @@ import {
 import { createUploadHandler, ragStore, useUploads } from "../../src/embedding/index.ts";
 import { defineConfig } from "../../src/config/index.ts";
 import { datasets, evalAgent, metrics, runEval } from "../../src/eval/index.ts";
+import { metrics as projectMetrics } from "../../src/metrics/index.ts";
 import {
   type ExtensionFactory,
   ExtensionLoader,
@@ -90,6 +91,7 @@ const THIS_GUIDE_EXAMPLE_SUITE = [
   "integrations.md",
   "pages-and-routing.md",
   "project-structure.md",
+  "project-metrics.md",
   "quickstart.md",
   "sandbox.md",
   "skills.md",
@@ -194,6 +196,17 @@ describe("Guide: index.md", () => {
     ) {
       assertStringIncludes(guide, snippet);
     }
+  });
+});
+
+describe("Guide: project-metrics.md", () => {
+  it("uses the public project metrics SDK hook", async () => {
+    const guide = await readGuide("project-metrics.md");
+
+    assertEquals(typeof projectMetrics.counter, "function");
+    assertEquals(typeof projectMetrics.histogram, "function");
+    assertEquals(typeof projectMetrics.gauge, "function");
+    assertStringIncludes(guide, 'import { metrics } from "veryfront/metrics"');
   });
 });
 

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -523,6 +523,21 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
     references: ["../api-reference/veryfront/index.md"],
     snippets: ["app/", "agents/", "tools/"],
   },
+  "guides/project-metrics.md": {
+    references: ["../api-reference/veryfront/observability.md"],
+    snippets: [
+      "veryfront/metrics",
+      "metrics.counter",
+      "metrics.histogram",
+      "metrics.gauge",
+      "vf_eval_result_total",
+      "project_id",
+      "Langfuse",
+      "LangSmith",
+      "Braintrust",
+      "Do not expose arbitrary raw metric writes over MCP",
+    ],
+  },
   "getting-started/installation.md": {
     references: [],
     snippets: [


### PR DESCRIPTION
## Summary
- add a project metrics guide for metrics.counter, metrics.histogram, and metrics.gauge
- explain label policy, eval metric usage, OpenTelemetry boundaries, eval exporters, and MCP posture
- link the guide from evals and guide index docs

## Verification
- deno run --allow-read scripts/docs/validate-guides.ts
- deno test --no-check --allow-read tests/docs/guide-contracts.test.ts tests/docs/guide-content.test.ts
- deno test --no-check --allow-all tests/docs/guide-code-examples.test.ts
- pre-push checks: 2,200 tests passed