### PR TITLE
Route eval runs to the resolved runtime AG-UI endpoint

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.893",
+  "version": "0.1.894",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -277,6 +277,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
       kind: "eval",
       target: "eval:deep-research",
       projectId: "proj-1",
+      runtimeAgUiEndpoint: "https://demo-project.preview.veryfront.org/api/ag-ui",
       input: { dataset: "smoke" },
       config: { repetitions: 2 },
     };
@@ -298,7 +299,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     });
     assertEquals(receivedRunId, "run_eval_1");
     assertEquals(receivedBaseDir, "/project");
-    assertEquals(receivedEndpoint, "https://example.com/api/ag-ui");
+    assertEquals(receivedEndpoint, "https://demo-project.preview.veryfront.org/api/ag-ui");
     assertEquals(receivedAuthToken, "runtime-token");
     assertEquals(receivedAgentId, "researcher");
     assertEquals(receivedProjectSlug, "demo-project");

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -50,6 +50,7 @@ export interface ProjectRunExecuteRequest {
   kind: "task" | "workflow" | "eval";
   target: string;
   projectId: string;
+  runtimeAgUiEndpoint?: string;
   config?: Record<string, unknown>;
   input?: Record<string, unknown>;
 }
@@ -145,6 +146,21 @@ function parseRecord(value: unknown): Record<string, unknown> | undefined {
   return value;
 }
 
+function parseOptionalUrl(value: unknown, fieldName: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || value.length === 0) throw new Error(`Invalid ${fieldName}`);
+
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new Error(`Invalid ${fieldName}`);
+    }
+    return url.toString();
+  } catch {
+    throw new Error(`Invalid ${fieldName}`);
+  }
+}
+
 function parseExecuteRequest(value: unknown, pathRunId: string): ProjectRunExecuteRequest {
   if (!isRecord(value)) throw new Error("Expected object");
 
@@ -171,6 +187,7 @@ function parseExecuteRequest(value: unknown, pathRunId: string): ProjectRunExecu
     kind,
     target,
     projectId,
+    runtimeAgUiEndpoint: parseOptionalUrl(value.runtimeAgUiEndpoint, "runtimeAgUiEndpoint"),
     config: parseRecord(value.config),
     input: parseRecord(value.input),
   };
@@ -711,7 +728,7 @@ function createEvalAdapterConfig(input: {
   }
 
   return {
-    endpoint: getSameOriginAgUiEndpoint(input.req),
+    endpoint: input.request.runtimeAgUiEndpoint ?? getSameOriginAgUiEndpoint(input.req),
     authToken,
     agentId: getEvalTargetAgentId(input.definition),
     projectId: input.request.projectId,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.893";
+export const VERSION = "0.1.894";


### PR DESCRIPTION
## Summary
- Add a signed `runtimeAgUiEndpoint` field to project-run execution payloads and use it for eval AG-UI adapter calls.
- Preserve the previous same-origin fallback for older/local callers.
- Bump the framework package version to `0.1.894` so the fix can release through the normal main-branch publish workflow.

## Why
Staging eval source discovery, create/edit, and run creation work, but eval execution currently derives `/api/ag-ui` from the control-plane request origin. In hosted staging that points at Studio and returns a 404 HTML page instead of AG-UI events.

## Verification
- `deno test --no-check --allow-all src/eval/agent-service.test.ts src/eval/runner.test.ts src/eval/metrics.test.ts cli/commands/eval/command.test.ts src/eval/studio.test.ts src/server/handlers/request/project-run-execute.handler.test.ts`
- `deno test --no-check --allow-all src/utils/version.test.ts src/server/handlers/request/project-run-execute.handler.test.ts`
- `deno check src/server/handlers/request/project-run-execute.handler.ts src/utils/version.ts`
- `git diff --check`
- Pre-push hook: formatting, lint, typecheck, and unit suite, 2200 tests passed.