### PR TITLE
Keep hosted eval runs inside the runtime boundary

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.894",
+  "version": "0.1.895",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -117,6 +117,21 @@ async function signedRequest(
   };
 }
 
+async function withEnvValue<T>(
+  key: string,
+  value: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const original = Deno.env.get(key);
+  Deno.env.set(key, value);
+  try {
+    return await fn();
+  } finally {
+    if (original === undefined) Deno.env.delete(key);
+    else Deno.env.set(key, original);
+  }
+}
+
 describe("server/handlers/request/project-run-execute.handler", () => {
   it("runs a discovered task and returns canonical runtime execution output", async () => {
     let receivedConfig: Record<string, unknown> | undefined;
@@ -240,7 +255,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     });
   });
 
-  it("runs a discovered eval with the canonical run id and AG-UI adapter", async () => {
+  it("runs a discovered eval with the canonical run id and local AG-UI adapter endpoint", async () => {
     const report: EvalReport = {
       kind: "eval-report",
       runId: "run_eval_1",
@@ -284,10 +299,18 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     const { request, publicKeyPem } = await signedRequest(
       "/api/control-plane/runs/run_eval_1/execute",
       body,
-      { "x-token": "runtime-token" },
+      {
+        "x-token": "runtime-token",
+        "x-forwarded-host": "demo-project.preview.veryfront.org",
+        "x-forwarded-proto": "https",
+      },
     );
 
-    const result = await handler.handle(request, createCtx(publicKeyPem));
+    const result = await withEnvValue(
+      "PORT",
+      "4311",
+      () => handler.handle(request, createCtx(publicKeyPem)),
+    );
 
     assertExists(result.response);
     assertEquals(result.response.status, 200);
@@ -299,10 +322,38 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     });
     assertEquals(receivedRunId, "run_eval_1");
     assertEquals(receivedBaseDir, "/project");
-    assertEquals(receivedEndpoint, "https://demo-project.preview.veryfront.org/api/ag-ui");
+    assertEquals(receivedEndpoint, "http://127.0.0.1:4311/api/ag-ui");
     assertEquals(receivedAuthToken, "runtime-token");
     assertEquals(receivedAgentId, "researcher");
     assertEquals(receivedProjectSlug, "demo-project");
+  });
+
+  it("preserves non-sibling eval AG-UI endpoints", async () => {
+    let receivedEndpoint: string | undefined;
+    const handler = new ProjectRunExecuteHandler(createDeps({
+      createEvalAgentAdapter: (config) => {
+        receivedEndpoint = config.endpoint;
+        return async () => ({ text: "Paris" });
+      },
+    }));
+    const body = {
+      runId: "run_eval_custom_endpoint",
+      kind: "eval",
+      target: "eval:deep-research",
+      projectId: "proj-1",
+      runtimeAgUiEndpoint: "https://agent-service.example.com/api/ag-ui",
+    };
+    const { request, publicKeyPem } = await signedRequest(
+      "/api/control-plane/runs/run_eval_custom_endpoint/execute",
+      body,
+      { "x-token": "runtime-token" },
+    );
+
+    const result = await handler.handle(request, createCtx(publicKeyPem));
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(receivedEndpoint, "https://agent-service.example.com/api/ag-ui");
   });
 
   it("marks eval execution unsuccessful when records contain adapter failures", async () => {

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -42,6 +42,7 @@ import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 const EXECUTE_PATH_REGEX = /^\/api\/control-plane\/runs\/([^/]+)\/execute$/;
 const DEFAULT_WORKFLOW_STATUS_POLL_INTERVAL_MS = 100;
 const DEFAULT_WORKFLOW_STATUS_TIMEOUT_MS = 15 * 60 * 1_000;
+const DEFAULT_LOCAL_AG_UI_PORT = 3001;
 const WORKFLOW_PERSISTENCE_REQUIRED_ERROR =
   "Workflow paused but runtime workflow persistence is not configured";
 
@@ -402,12 +403,70 @@ function getRuntimeApiToken(req: Request, ctx: HandlerContext): string {
   return req.headers.get("x-token") ?? ctx.proxyToken ?? ctx.requestContext?.token ?? "";
 }
 
-function getSameOriginAgUiEndpoint(req: Request): string {
+function getHeaderFirstValue(value: string | null): string | undefined {
+  return value?.split(",")[0]?.trim() || undefined;
+}
+
+function getForwardedProtocol(req: Request): "http:" | "https:" | undefined {
+  const value = getHeaderFirstValue(req.headers.get("x-forwarded-proto"))?.replace(/:$/, "");
+  return value === "http" || value === "https" ? `${value}:` : undefined;
+}
+
+function getRequestOriginCandidates(req: Request): Set<string> {
   const url = new URL(req.url);
-  url.pathname = "/api/ag-ui";
-  url.search = "";
-  url.hash = "";
-  return url.toString();
+  const protocols = new Set([url.protocol]);
+  const forwardedProtocol = getForwardedProtocol(req);
+  if (forwardedProtocol) protocols.add(forwardedProtocol);
+
+  const hosts = new Set([url.host]);
+  const hostHeader = getHeaderFirstValue(req.headers.get("host"));
+  const forwardedHost = getHeaderFirstValue(req.headers.get("x-forwarded-host"));
+  if (hostHeader) hosts.add(hostHeader);
+  if (forwardedHost) hosts.add(forwardedHost);
+
+  const origins = new Set<string>();
+  for (const protocol of protocols) {
+    for (const host of hosts) {
+      origins.add(`${protocol}//${host}`);
+    }
+  }
+  return origins;
+}
+
+function isRequestSiblingAgUiEndpoint(endpoint: string, req: Request): boolean {
+  try {
+    const endpointUrl = new URL(endpoint);
+    if (endpointUrl.pathname !== "/api/ag-ui") return false;
+    return getRequestOriginCandidates(req).has(endpointUrl.origin);
+  } catch {
+    return false;
+  }
+}
+
+function isLocalHostname(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+function getRuntimeLocalPort(req: Request): number {
+  const url = new URL(req.url);
+  const requestPort = isLocalHostname(url.hostname) ? url.port : "";
+  for (const value of [getHostEnv("PORT"), getHostEnv("VERYFRONT_PORT"), requestPort]) {
+    if (!value) continue;
+    const port = Number.parseInt(value, 10);
+    if (Number.isInteger(port) && port > 0 && port <= 65_535) return port;
+  }
+  return DEFAULT_LOCAL_AG_UI_PORT;
+}
+
+function getLocalAgUiEndpoint(req: Request): string {
+  return `http://127.0.0.1:${getRuntimeLocalPort(req)}/api/ag-ui`;
+}
+
+function resolveEvalAgUiEndpoint(req: Request, endpoint?: string): string {
+  if (endpoint && !isRequestSiblingAgUiEndpoint(endpoint, req)) {
+    return endpoint;
+  }
+  return getLocalAgUiEndpoint(req);
 }
 
 function createRuntimeApiClient(req: Request, ctx: HandlerContext): RuntimeApiClient {
@@ -728,7 +787,7 @@ function createEvalAdapterConfig(input: {
   }
 
   return {
-    endpoint: input.request.runtimeAgUiEndpoint ?? getSameOriginAgUiEndpoint(input.req),
+    endpoint: resolveEvalAgUiEndpoint(input.req, input.request.runtimeAgUiEndpoint),
     authToken,
     agentId: getEvalTargetAgentId(input.definition),
     projectId: input.request.projectId,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.894";
+export const VERSION = "0.1.895";


### PR DESCRIPTION
## Summary
- resolve API-generated sibling eval AG-UI endpoints to a runtime-local loopback endpoint
- preserve custom non-sibling eval AG-UI endpoints
- bump veryfront to 0.1.895 for release

## Verification
- deno test --no-check --allow-all src/server/handlers/request/project-run-execute.handler.test.ts
- deno check src/server/handlers/request/project-run-execute.handler.ts src/server/handlers/request/project-run-execute.handler.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts src/server/handlers/request/project-run-execute.handler.ts src/server/handlers/request/project-run-execute.handler.test.ts
- git diff --check