### PR TITLE
Keep hosted eval AG-UI calls inside internal runtimes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.895",
+  "version": "0.1.896",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -96,6 +96,7 @@ async function signedRequest(
   path: string,
   body: Record<string, unknown>,
   headers: Record<string, string> = {},
+  origin = "https://example.com",
 ): Promise<{ request: Request; publicKeyPem: string }> {
   const rawBody = JSON.stringify(body);
   const { jws, publicKeyPem } = await createControlPlaneSignature(rawBody, {
@@ -105,7 +106,7 @@ async function signedRequest(
 
   return {
     publicKeyPem,
-    request: new Request(`https://example.com${path}`, {
+    request: new Request(`${origin}${path}`, {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -354,6 +355,39 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     assertExists(result.response);
     assertEquals(result.response.status, 200);
     assertEquals(receivedEndpoint, "https://agent-service.example.com/api/ag-ui");
+  });
+
+  it("rewrites preview AG-UI endpoints when control-plane requests use an internal runtime host", async () => {
+    let receivedEndpoint: string | undefined;
+    const handler = new ProjectRunExecuteHandler(createDeps({
+      createEvalAgentAdapter: (config) => {
+        receivedEndpoint = config.endpoint;
+        return async () => ({ text: "Paris" });
+      },
+    }));
+    const body = {
+      runId: "run_eval_internal_host",
+      kind: "eval",
+      target: "eval:deep-research",
+      projectId: "proj-1",
+      runtimeAgUiEndpoint: "https://demo-project.preview.veryfront.org/api/ag-ui",
+    };
+    const { request, publicKeyPem } = await signedRequest(
+      "/api/control-plane/runs/run_eval_internal_host/execute",
+      body,
+      { "x-token": "runtime-token" },
+      "http://veryfront-server",
+    );
+
+    const result = await withEnvValue(
+      "PORT",
+      "4311",
+      () => handler.handle(request, createCtx(publicKeyPem)),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(receivedEndpoint, "http://127.0.0.1:4311/api/ag-ui");
   });
 
   it("marks eval execution unsuccessful when records contain adapter failures", async () => {

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -447,6 +447,26 @@ function isLocalHostname(hostname: string): boolean {
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
 }
 
+function isInternalRuntimeHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return isLocalHostname(normalized) ||
+    normalized === "veryfront-server" ||
+    normalized.endsWith(".svc") ||
+    normalized.endsWith(".svc.cluster.local");
+}
+
+function isAgUiEndpoint(endpoint: string): boolean {
+  try {
+    return new URL(endpoint).pathname === "/api/ag-ui";
+  } catch {
+    return false;
+  }
+}
+
+function requestUsesInternalRuntimeHost(req: Request): boolean {
+  return isInternalRuntimeHostname(new URL(req.url).hostname);
+}
+
 function getRuntimeLocalPort(req: Request): number {
   const url = new URL(req.url);
   const requestPort = isLocalHostname(url.hostname) ? url.port : "";
@@ -463,7 +483,11 @@ function getLocalAgUiEndpoint(req: Request): string {
 }
 
 function resolveEvalAgUiEndpoint(req: Request, endpoint?: string): string {
-  if (endpoint && !isRequestSiblingAgUiEndpoint(endpoint, req)) {
+  if (
+    endpoint &&
+    !isRequestSiblingAgUiEndpoint(endpoint, req) &&
+    !(isAgUiEndpoint(endpoint) && requestUsesInternalRuntimeHost(req))
+  ) {
     return endpoint;
   }
   return getLocalAgUiEndpoint(req);

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.895";
+export const VERSION = "0.1.896";


### PR DESCRIPTION
## Summary
- Rewrite trusted eval AG-UI endpoints to loopback when control-plane execution reaches the runtime on an internal service host.
- Add a regression test for the staging shape: request URL host is veryfront-server, while the API-provided AG-UI endpoint uses the public preview origin.
- Bump the framework version to 0.1.896 for release rollout.

## Evidence
- Staging logs for the failed eval run showed control-plane execution on http://veryfront-server/... and no project-runtime /api/ag-ui request.
- The deployed release contained pages/api/ag-ui.ts, so this fixes runtime endpoint resolution rather than project source.

## Verification
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/eval/agent-service.test.ts src/server/handlers/request/project-run-execute.handler.test.ts
- deno task fmt:check
- deno task lint
- deno task typecheck
- Pre-push hook: full unit suite passed (2200 passed, 0 failed)
