### PR TITLE
Propagate environment labels for project metrics

### DIFF
--- a/src/security/http/base-handler.test.ts
+++ b/src/security/http/base-handler.test.ts
@@ -2,6 +2,13 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { deleteEnv, setEnv } from "#veryfront/compat/process.ts";
+import {
+  _resetShimForTests,
+  type MetricsAPI,
+  setGlobalMetricsAPI,
+} from "#veryfront/observability/tracing/api-shim.ts";
+import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
+import { metrics } from "#veryfront/metrics";
 import { BaseHandler } from "./base-handler.ts";
 import type {
   HandlerContext,
@@ -50,6 +57,8 @@ describe("BaseHandler.withProxyContext", () => {
     } catch {
       // expected
     }
+    _resetShimForTests();
+    metrics.__resetForTests();
   });
 
   it("runs fn() in local dev mode (no projectSlug)", async () => {
@@ -155,5 +164,89 @@ describe("BaseHandler.withProxyContext", () => {
     );
 
     assertEquals(called, true, "fn should run with proxyToken");
+  });
+
+  it("emits metrics with project and environment labels in multi-project request context", async () => {
+    const handler = new TestHandler();
+    const counterCalls: unknown[] = [];
+
+    setGlobalMetricsAPI({
+      getMeter() {
+        return {
+          createCounter(name: string) {
+            return {
+              add(value: number, attributes?: Record<string, unknown>) {
+                counterCalls.push({ name, value, attributes });
+              },
+            };
+          },
+          createHistogram() {
+            return { record() {} };
+          },
+          createUpDownCounter() {
+            return { add() {} };
+          },
+          createObservableGauge() {
+            return { addCallback() {} };
+          },
+        };
+      },
+    } as MetricsAPI);
+
+    const ctx = createMinimalCtx({
+      projectSlug: "my-project",
+      projectId: "project-123",
+      proxyToken: "vf_proxy_token",
+      releaseId: "release-123",
+      resolvedEnvironment: "production",
+      environmentName: "Staging",
+      adapter: {
+        fs: {
+          setRequestBranch() {},
+          isMultiProjectMode: () => true,
+          runWithContext: async (
+            _slug: string,
+            _token: string,
+            fn: () => Promise<unknown>,
+            _projectId?: string,
+            options?: Record<string, unknown>,
+          ) => {
+            return await runWithRequestContext(
+              {
+                projectSlug: "my-project",
+                token: "vf_proxy_token",
+                projectId: "project-123",
+                productionMode: options?.productionMode === true,
+                releaseId: options?.releaseId as string | undefined,
+                branch: options?.branch as string | undefined,
+                environmentName: options?.environmentName as string | undefined,
+              },
+              fn,
+            );
+          },
+        },
+      } as unknown as HandlerContext["adapter"],
+    });
+
+    await handler.testWithProxyContext(ctx, async () => {
+      metrics.counter("vf_proxy_context_total", 1, {
+        project_id: "spoofed-project",
+        source: "test",
+      });
+      return { continue: true };
+    });
+
+    assertEquals(counterCalls, [
+      {
+        name: "vf_proxy_context_total",
+        value: 1,
+        attributes: {
+          project_id: "project-123",
+          project_slug: "my-project",
+          environment: "Staging",
+          source: "test",
+        },
+      },
+    ]);
   });
 });

--- a/src/security/http/base-handler.ts
+++ b/src/security/http/base-handler.ts
@@ -127,7 +127,12 @@ export abstract class BaseHandler implements Handler {
         token: string,
         fn: () => Promise<R>,
         projectId?: string,
-        options?: { productionMode?: boolean; releaseId?: string | null; branch?: string | null },
+        options?: {
+          productionMode?: boolean;
+          releaseId?: string | null;
+          branch?: string | null;
+          environmentName?: string | null;
+        },
       ) => Promise<R>;
     };
 
@@ -177,7 +182,12 @@ export abstract class BaseHandler implements Handler {
         effectiveToken,
         fn,
         ctx.projectId,
-        { productionMode: isProduction, releaseId: ctx.releaseId, branch },
+        {
+          productionMode: isProduction,
+          releaseId: ctx.releaseId,
+          branch,
+          environmentName: ctx.environmentName,
+        },
       );
     }
 

--- a/src/server/handlers/request/api/api-handler-wrapper.test.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.test.ts
@@ -1,0 +1,50 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { ApiHandlerWrapper } from "./api-handler-wrapper.ts";
+
+function createCtx(captured: { options?: Record<string, unknown> }): HandlerContext {
+  return {
+    projectDir: "/tmp/project",
+    adapter: {
+      fs: {
+        isMultiProjectMode: () => true,
+        runWithContext: async (
+          _slug: string,
+          _token: string,
+          _fn: () => Promise<unknown>,
+          _projectId?: string,
+          options?: Record<string, unknown>,
+        ) => {
+          captured.options = options;
+          return { continue: true };
+        },
+      },
+      env: { get: () => undefined },
+    },
+    securityConfig: null,
+    cspUserHeader: null,
+    projectSlug: "my-project",
+    projectId: "project-123",
+    proxyToken: "vf_proxy_token",
+    releaseId: "release-123",
+    environmentName: "Staging",
+    requestContext: {
+      token: "vf_proxy_token",
+      branch: null,
+      mode: "production",
+    },
+  } as unknown as HandlerContext;
+}
+
+describe("ApiHandlerWrapper", () => {
+  it("forwards environmentName into multi-project request context", async () => {
+    const captured: { options?: Record<string, unknown> } = {};
+    const handler = new ApiHandlerWrapper("/tmp/project", createCtx(captured).adapter);
+
+    await handler.handle(new Request("http://localhost/api/test"), createCtx(captured));
+
+    assertEquals(captured.options?.environmentName, "Staging");
+  });
+});

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -17,7 +17,11 @@ type FsWrapper = {
     token: string,
     fn: () => Promise<T>,
     projectId?: string,
-    options?: { productionMode?: boolean; releaseId?: string | null },
+    options?: {
+      productionMode?: boolean;
+      releaseId?: string | null;
+      environmentName?: string | null;
+    },
   ) => Promise<T>;
 };
 
@@ -92,7 +96,11 @@ export class ApiHandlerWrapper extends BaseHandler {
       ctx.proxyToken ?? "",
       () => this.handleWithContext(req, ctx, pathname),
       ctx.projectId,
-      { productionMode: isProduction, releaseId: ctx.releaseId },
+      {
+        productionMode: isProduction,
+        releaseId: ctx.releaseId,
+        environmentName: ctx.environmentName,
+      },
     );
   }
 


### PR DESCRIPTION
## Summary
- pass environmentName through shared proxy multi-project context
- pass environmentName through API handler multi-project context
- add regressions for project metric labels under proxy context and API wrapper environment forwarding

## Verification
- deno test --allow-all src/security/http/base-handler.test.ts src/server/handlers/request/api/api-handler-wrapper.test.ts
- deno test --allow-all src/metrics/index.test.ts src/observability/tracing/api-shim.test.ts extensions/ext-observability-opentelemetry/src/index.test.ts src/security/http/base-handler.test.ts src/server/handlers/request/api/api-handler-wrapper.test.ts src/server/handlers/request/ssr/ssr.handler.test.ts
- DENO_NO_PACKAGE_JSON=1 deno lint src/security/http/base-handler.ts src/security/http/base-handler.test.ts src/server/handlers/request/api/api-handler-wrapper.ts src/server/handlers/request/api/api-handler-wrapper.test.ts
- pre-push hook: fmt, lint, typecheck, test:unit (2201 passed, 0 failed)