### PR TITLE
Release veryfront 0.1.897

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.896",
+  "version": "0.1.897",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.896";
+export const VERSION = "0.1.897";


### PR DESCRIPTION
## Summary
- Bump `deno.json` from `0.1.896` to `0.1.897` so the merged project metrics environment-context fix can publish.
- Keep `src/utils/version-constant.ts` in sync with the package version.

## Why
`main` currently contains the metrics fix from #2602, but the CI/CD release job failed because `veryfront@0.1.896` is already published from commit `41535b1975fcfe8068a1c047f835e1d8f40fcd11`. Publishing a new stable version is required for the downstream `veryfront-code-released` dispatch and staging rollout.

## Verification
- `npm view veryfront@0.1.897 version gitHead --json` returns 404 / unpublished.
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/utils/version-constant.ts`
- `deno check src/utils/version-constant.ts`
- `deno test --allow-read --allow-env src/utils/version.test.ts`
- `git diff --check`
- pre-push hook: format, lint, typecheck, full `test:unit` (`2201 passed`, `0 failed`)
