### PR TITLE
Keep eval preview routes from going stale

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.896",
+  "version": "0.1.897",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/handlers/request/api/pages-api-handler.test.ts
+++ b/src/server/handlers/request/api/pages-api-handler.test.ts
@@ -1,8 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { __injectDepsForTests as __injectApiRouteDepsForTests } from "#veryfront/routing/api/handler.ts";
 import {
   __injectCacheForTests,
+  getApiHandler,
   type HandlerCache,
   resetApiHandler,
   resetApiHandlerForProject,
@@ -46,9 +50,38 @@ function createMockHandler(): MockHandler {
   };
 }
 
-afterEach(() => {
+afterEach(async () => {
+  await resetApiHandler();
   __injectCacheForTests(null);
+  __injectApiRouteDepsForTests(null);
 });
+
+function createHandlerContext(
+  input: {
+    adapter: ReturnType<typeof createMockAdapter>;
+    projectDir?: string;
+    projectSlug?: string;
+    mode?: "preview" | "production";
+    releaseId?: string;
+  },
+): HandlerContext {
+  return {
+    projectDir: input.projectDir ?? "/project-dir",
+    adapter: input.adapter,
+    securityConfig: null,
+    cspUserHeader: null,
+    projectSlug: input.projectSlug,
+    projectId: input.projectSlug ? `${input.projectSlug}-id` : undefined,
+    resolvedEnvironment: input.mode ?? "preview",
+    releaseId: input.releaseId,
+    requestContext: {
+      token: "test-token",
+      projectSlug: input.projectSlug ?? "test-project",
+      mode: input.mode ?? "preview",
+      branch: "main",
+    },
+  };
+}
 
 describe("server/handlers/request/api/pages-api-handler", () => {
   describe("resetApiHandler", () => {
@@ -93,9 +126,11 @@ describe("server/handlers/request/api/pages-api-handler", () => {
       const h1 = createMockHandler();
       const h2 = createMockHandler();
       const h3 = createMockHandler();
+      const h4 = createMockHandler();
       cache.set("/dir:my-project", Promise.resolve(h1));
       cache.set("/other:my-project", Promise.resolve(h2));
       cache.set("/dir:other-project", Promise.resolve(h3));
+      cache.set("/dir:my-project:production:release-1", Promise.resolve(h4));
       __injectCacheForTests(cache as any);
 
       await resetApiHandlerForProject("my-project");
@@ -104,6 +139,7 @@ describe("server/handlers/request/api/pages-api-handler", () => {
       assertEquals(h1.destroyed, true);
       assertEquals(h2.destroyed, true);
       assertEquals(h3.destroyed, false);
+      assertEquals(h4.destroyed, true);
     });
 
     it("should match exact slug key", async () => {
@@ -124,6 +160,88 @@ describe("server/handlers/request/api/pages-api-handler", () => {
 
       await resetApiHandlerForProject("nonexistent");
       assertEquals(cache.store.size, 1);
+    });
+  });
+
+  describe("getApiHandler", () => {
+    it("should not reuse stale preview route maps after source changes", async () => {
+      const adapter = createMockAdapter();
+      const ctx = createHandlerContext({
+        adapter,
+        projectSlug: "my-project",
+        mode: "preview",
+      });
+
+      __injectApiRouteDepsForTests({
+        loadHandlerModule: () =>
+          Promise.resolve({
+            POST: () => Response.json({ ok: true }),
+          }),
+      });
+
+      const missingHandler = await getApiHandler(ctx);
+      const missingResponse = await missingHandler.handle(
+        new Request("http://localhost/api/ag-ui", { method: "POST" }),
+        ctx,
+      );
+
+      assertExists(missingResponse);
+      assertEquals(missingResponse.status, 404);
+
+      adapter.fs.files.set(
+        "/project-dir/pages/api/ag-ui.ts",
+        "export function POST() { return Response.json({ ok: true }); }",
+      );
+
+      const updatedHandler = await getApiHandler(ctx);
+      const updatedResponse = await updatedHandler.handle(
+        new Request("http://localhost/api/ag-ui", { method: "POST" }),
+        ctx,
+      );
+
+      assertExists(updatedResponse);
+      assertEquals(updatedResponse.status, 200);
+      assertEquals(await updatedResponse.json(), { ok: true });
+    });
+
+    it("should cache production route handlers by release context", async () => {
+      const cache = createMockCache();
+      const adapter = createMockAdapter();
+      __injectCacheForTests(cache as any);
+
+      await getApiHandler(
+        createHandlerContext({
+          adapter,
+          projectSlug: "my-project",
+          mode: "production",
+          releaseId: "release-1",
+        }),
+      );
+      await getApiHandler(
+        createHandlerContext({
+          adapter,
+          projectSlug: "my-project",
+          mode: "production",
+          releaseId: "release-1",
+        }),
+      );
+      await getApiHandler(
+        createHandlerContext({
+          adapter,
+          projectSlug: "my-project",
+          mode: "production",
+          releaseId: "release-2",
+        }),
+      );
+
+      assertEquals(cache.store.size, 2);
+      assertEquals(
+        [...cache.store.keys()].sort(),
+        [
+          "/project-dir:my-project:production:release-1",
+          "/project-dir:my-project:production:release-2",
+        ],
+      );
     });
   });
 });

--- a/src/server/handlers/request/api/pages-api-handler.ts
+++ b/src/server/handlers/request/api/pages-api-handler.ts
@@ -9,6 +9,10 @@
 
 import { APIRouteHandler } from "#veryfront/routing";
 import { serverLogger } from "#veryfront/utils";
+import {
+  extractCacheKeyContext,
+  tryGetCacheKeyContext,
+} from "#veryfront/cache/cache-key-builder.ts";
 import type { HandlerContext } from "../../types.ts";
 
 const logger = serverLogger.component("reset-api-handler");
@@ -35,8 +39,27 @@ export function __injectCacheForTests(
   injectedCache = cache;
 }
 
+function getApiHandlerCacheContext(ctx: HandlerContext) {
+  return tryGetCacheKeyContext() ?? extractCacheKeyContext(ctx);
+}
+
 function getCacheKey(ctx: HandlerContext): string {
-  return ctx.projectSlug ? `${ctx.projectDir}:${ctx.projectSlug}` : ctx.projectDir;
+  if (!ctx.projectSlug) return ctx.projectDir;
+
+  const cacheContext = getApiHandlerCacheContext(ctx);
+  return `${ctx.projectDir}:${ctx.projectSlug}:${cacheContext.mode}:${cacheContext.versionId}`;
+}
+
+function shouldCacheApiHandler(ctx: HandlerContext): boolean {
+  if (!ctx.projectSlug) return true;
+
+  return getApiHandlerCacheContext(ctx).mode === "production";
+}
+
+async function createApiHandler(ctx: HandlerContext): Promise<APIRouteHandler> {
+  const handler = new APIRouteHandler(ctx.projectDir, ctx.adapter);
+  await handler.initialize();
+  return handler;
 }
 
 async function destroyHandler(promise?: Promise<APIRouteHandler>): Promise<void> {
@@ -55,16 +78,14 @@ async function destroyHandler(promise?: Promise<APIRouteHandler>): Promise<void>
 }
 
 export async function getApiHandler(ctx: HandlerContext): Promise<APIRouteHandler> {
+  if (!shouldCacheApiHandler(ctx)) return createApiHandler(ctx);
+
   const cache = getCache();
   const key = getCacheKey(ctx);
 
   let promise = cache.get(key);
   if (!promise) {
-    promise = (async () => {
-      const handler = new APIRouteHandler(ctx.projectDir, ctx.adapter);
-      await handler.initialize();
-      return handler;
-    })();
+    promise = createApiHandler(ctx);
     cache.set(key, promise);
   }
 
@@ -89,19 +110,20 @@ export async function resetApiHandler(projectDir?: string): Promise<void> {
 /**
  * Reset cached API handlers for a specific project slug.
  *
- * In proxy/production mode the cache key is `"${projectDir}:${projectSlug}"`,
- * so we can't reuse `resetApiHandler(projectDir)`. Instead we iterate all
- * entries and destroy those whose key ends with `:${projectSlug}`.
+ * In proxy/production mode the cache key includes the project slug and release
+ * context, so we can't reuse `resetApiHandler(projectDir)`. Instead we iterate
+ * all entries and destroy those scoped to the project slug.
  */
 export async function resetApiHandlerForProject(
   projectSlug: string,
 ): Promise<void> {
   const cache = getCache();
-  const suffix = `:${projectSlug}`;
   const toDestroy: Promise<APIRouteHandler>[] = [];
 
   for (const [key, promise] of cache.entries()) {
-    if (key.endsWith(suffix) || key === projectSlug) {
+    if (
+      key === projectSlug || key.endsWith(`:${projectSlug}`) || key.includes(`:${projectSlug}:`)
+    ) {
       cache.delete(key);
       toDestroy.push(promise);
     }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.896";
+export const VERSION = "0.1.897";


### PR DESCRIPTION
## Summary
- bypass project-scoped Pages API handler caching for preview contexts so same-branch source edits can add routes immediately
- keep production API handler caching, but key it by release context
- add regression coverage for stale preview route maps and release-isolated production cache keys
- bump veryfront to 0.1.897

## Root cause
The staging eval run used veryfront@0.1.896 and failed with a generic 404 for /api/ag-ui. Logs showed no /api/ag-ui route request and the runtime reused a cached preview adapter for the same project/branch. The Pages API handler cache was keyed only by project directory plus project slug, so a handler initialized before pages/api/ag-ui.ts existed could keep returning a generic 404 after Studio added the route on the same branch.

## Verification
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/server/handlers/request/project-run-execute.handler.test.ts src/eval/agent-service.test.ts src/server/handlers/request/api/pages-api-handler.test.ts
- deno task fmt:check
- deno task lint
- deno task typecheck
- git diff --check
- pre-push full unit suite: 2201 passed, 0 failed