### PR TITLE
Preserve preview AG-UI endpoints for eval runs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.897",
+  "version": "0.1.898",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -357,7 +357,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     assertEquals(receivedEndpoint, "https://agent-service.example.com/api/ag-ui");
   });
 
-  it("rewrites preview AG-UI endpoints when control-plane requests use an internal runtime host", async () => {
+  it("preserves external preview AG-UI endpoints when control-plane requests use an internal runtime host", async () => {
     let receivedEndpoint: string | undefined;
     const handler = new ProjectRunExecuteHandler(createDeps({
       createEvalAgentAdapter: (config) => {
@@ -387,7 +387,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
 
     assertExists(result.response);
     assertEquals(result.response.status, 200);
-    assertEquals(receivedEndpoint, "http://127.0.0.1:4311/api/ag-ui");
+    assertEquals(receivedEndpoint, "https://demo-project.preview.veryfront.org/api/ag-ui");
   });
 
   it("marks eval execution unsuccessful when records contain adapter failures", async () => {

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -447,26 +447,6 @@ function isLocalHostname(hostname: string): boolean {
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
 }
 
-function isInternalRuntimeHostname(hostname: string): boolean {
-  const normalized = hostname.toLowerCase();
-  return isLocalHostname(normalized) ||
-    normalized === "veryfront-server" ||
-    normalized.endsWith(".svc") ||
-    normalized.endsWith(".svc.cluster.local");
-}
-
-function isAgUiEndpoint(endpoint: string): boolean {
-  try {
-    return new URL(endpoint).pathname === "/api/ag-ui";
-  } catch {
-    return false;
-  }
-}
-
-function requestUsesInternalRuntimeHost(req: Request): boolean {
-  return isInternalRuntimeHostname(new URL(req.url).hostname);
-}
-
 function getRuntimeLocalPort(req: Request): number {
   const url = new URL(req.url);
   const requestPort = isLocalHostname(url.hostname) ? url.port : "";
@@ -483,11 +463,7 @@ function getLocalAgUiEndpoint(req: Request): string {
 }
 
 function resolveEvalAgUiEndpoint(req: Request, endpoint?: string): string {
-  if (
-    endpoint &&
-    !isRequestSiblingAgUiEndpoint(endpoint, req) &&
-    !(isAgUiEndpoint(endpoint) && requestUsesInternalRuntimeHost(req))
-  ) {
+  if (endpoint && !isRequestSiblingAgUiEndpoint(endpoint, req)) {
     return endpoint;
   }
   return getLocalAgUiEndpoint(req);

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.897";
+export const VERSION = "0.1.898";


### PR DESCRIPTION
## Summary
- preserve externally supplied preview AG-UI endpoints during eval execution
- keep localhost fallback only for missing or same-origin/sibling AG-UI endpoints
- bump package version to 0.1.898 for the next release

## Verification
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/server/handlers/request/project-run-execute.handler.test.ts src/eval/agent-service.test.ts src/server/handlers/request/api/pages-api-handler.test.ts
- git diff --check
- deno task fmt:check
- deno task lint
- deno task typecheck
- pre-push hook: generation, formatting, lint, typecheck, unit tests: 2201 passed, 0 failed