### PR TITLE
Preserve preview eval AG-UI endpoints

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.898",
+  "version": "0.1.899",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -256,7 +256,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     });
   });
 
-  it("runs a discovered eval with the canonical run id and local AG-UI adapter endpoint", async () => {
+  it("runs a discovered eval with the canonical run id and external preview AG-UI adapter endpoint", async () => {
     const report: EvalReport = {
       kind: "eval-report",
       runId: "run_eval_1",
@@ -323,10 +323,47 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     });
     assertEquals(receivedRunId, "run_eval_1");
     assertEquals(receivedBaseDir, "/project");
-    assertEquals(receivedEndpoint, "http://127.0.0.1:4311/api/ag-ui");
+    assertEquals(receivedEndpoint, "https://demo-project.preview.veryfront.org/api/ag-ui");
     assertEquals(receivedAuthToken, "runtime-token");
     assertEquals(receivedAgentId, "researcher");
     assertEquals(receivedProjectSlug, "demo-project");
+  });
+
+  it("uses the local AG-UI adapter endpoint when the runtime endpoint is local", async () => {
+    let receivedEndpoint: string | undefined;
+    const handler = new ProjectRunExecuteHandler(createDeps({
+      createEvalAgentAdapter: (config) => {
+        receivedEndpoint = config.endpoint;
+        return async () => ({ text: "Paris" });
+      },
+    }));
+    const body = {
+      runId: "run_eval_local_endpoint",
+      kind: "eval",
+      target: "eval:deep-research",
+      projectId: "proj-1",
+      runtimeAgUiEndpoint: "http://localhost:4311/api/ag-ui",
+    };
+    const { request, publicKeyPem } = await signedRequest(
+      "/api/control-plane/runs/run_eval_local_endpoint/execute",
+      body,
+      {
+        "x-token": "runtime-token",
+        "x-forwarded-host": "localhost:4311",
+        "x-forwarded-proto": "http",
+      },
+      "http://localhost:4311",
+    );
+
+    const result = await withEnvValue(
+      "PORT",
+      "4311",
+      () => handler.handle(request, createCtx(publicKeyPem)),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(receivedEndpoint, "http://127.0.0.1:4311/api/ag-ui");
   });
 
   it("preserves non-sibling eval AG-UI endpoints", async () => {

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -447,6 +447,14 @@ function isLocalHostname(hostname: string): boolean {
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
 }
 
+function isLocalAgUiEndpoint(endpoint: string): boolean {
+  try {
+    return isLocalHostname(new URL(endpoint).hostname);
+  } catch {
+    return false;
+  }
+}
+
 function getRuntimeLocalPort(req: Request): number {
   const url = new URL(req.url);
   const requestPort = isLocalHostname(url.hostname) ? url.port : "";
@@ -463,7 +471,10 @@ function getLocalAgUiEndpoint(req: Request): string {
 }
 
 function resolveEvalAgUiEndpoint(req: Request, endpoint?: string): string {
-  if (endpoint && !isRequestSiblingAgUiEndpoint(endpoint, req)) {
+  if (!endpoint) {
+    return getLocalAgUiEndpoint(req);
+  }
+  if (!isRequestSiblingAgUiEndpoint(endpoint, req) || !isLocalAgUiEndpoint(endpoint)) {
     return endpoint;
   }
   return getLocalAgUiEndpoint(req);

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.898";
+export const VERSION = "0.1.899";


### PR DESCRIPTION
## Summary
- Preserve external preview AG-UI endpoints for eval runs instead of rewriting them to loopback.
- Keep loopback normalization for local sibling AG-UI endpoints.
- Bump veryfront to 0.1.899 for release.

## Why
Staging eval runs still reached the runtime through http://127.0.0.1:<port>/api/ag-ui and received the generic Veryfront 404 page. The preview endpoint carries the host context needed for project route resolution.

## Verification
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/server/handlers/request/project-run-execute.handler.test.ts
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/server/handlers/request/project-run-execute.handler.test.ts src/eval/agent-service.test.ts src/server/handlers/request/api/pages-api-handler.test.ts
- deno task fmt:check
- deno task lint
- deno task typecheck
- pre-push checks: format, lint, typecheck, unit tests: 2201 passed, 18864 steps, 0 failed