### PR TITLE
Keep eval AG-UI calls inside routed runtimes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.899",
+  "version": "0.1.900",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/eval/agent-service.test.ts
+++ b/src/eval/agent-service.test.ts
@@ -128,6 +128,11 @@ describe("eval/agent-service", () => {
       projectId: "project_123",
       projectSlug: "demo-project",
       branchId: "branch_123",
+      branchName: "main",
+      environment: "preview",
+      environmentId: "env_123",
+      forwardedHost: "demo-project.preview.veryfront.org",
+      forwardedProto: "https",
       fetch: async (input, init) => {
         requests.push({
           url: String(input),
@@ -169,6 +174,34 @@ describe("eval/agent-service", () => {
     assertEquals(
       (requests[0]?.init.headers as Record<string, string>)["x-project-slug"],
       "demo-project",
+    );
+    assertEquals(
+      (requests[0]?.init.headers as Record<string, string>)["x-project-id"],
+      "project_123",
+    );
+    assertEquals(
+      (requests[0]?.init.headers as Record<string, string>)["x-branch-id"],
+      "branch_123",
+    );
+    assertEquals(
+      (requests[0]?.init.headers as Record<string, string>)["x-branch-name"],
+      "main",
+    );
+    assertEquals(
+      (requests[0]?.init.headers as Record<string, string>)["x-environment"],
+      "preview",
+    );
+    assertEquals(
+      (requests[0]?.init.headers as Record<string, string>)["x-environment-id"],
+      "env_123",
+    );
+    assertEquals(
+      (requests[0]?.init.headers as Record<string, string>)["x-forwarded-host"],
+      "demo-project.preview.veryfront.org",
+    );
+    assertEquals(
+      (requests[0]?.init.headers as Record<string, string>)["x-forwarded-proto"],
+      "https",
     );
     assertEquals(requests[0]?.body.forwardedProps, {
       veryfront: {

--- a/src/eval/agent-service.ts
+++ b/src/eval/agent-service.ts
@@ -93,7 +93,13 @@ export interface AgentServiceEvalAdapterConfig {
   projectId?: string | null;
   projectSlug?: string | null;
   conversationId?: string | null;
+  releaseId?: string | null;
   branchId?: string | null;
+  branchName?: string | null;
+  environment?: string | null;
+  environmentId?: string | null;
+  forwardedHost?: string | null;
+  forwardedProto?: string | null;
   model?: string | null;
   allowedTools?: string[];
   forceRuntimeOverrides?: boolean;
@@ -176,14 +182,20 @@ function createVeryfrontForwardedProps(
   return Object.keys(veryfront).length > 0 ? veryfront : null;
 }
 
-function createHeaders(
-  config: Pick<AgentServiceEvalAdapterConfig, "authToken" | "projectSlug">,
-): Record<string, string> {
+function createHeaders(config: AgentServiceEvalAdapterConfig): Record<string, string> {
   return {
     "Content-Type": "application/json",
     Authorization: `Bearer ${config.authToken}`,
     "x-token": config.authToken,
+    ...(config.projectId ? { "x-project-id": config.projectId } : {}),
     ...(config.projectSlug ? { "x-project-slug": config.projectSlug } : {}),
+    ...(config.releaseId ? { "x-release-id": config.releaseId } : {}),
+    ...(config.branchId ? { "x-branch-id": config.branchId } : {}),
+    ...(config.branchName ? { "x-branch-name": config.branchName } : {}),
+    ...(config.environment ? { "x-environment": config.environment } : {}),
+    ...(config.environmentId ? { "x-environment-id": config.environmentId } : {}),
+    ...(config.forwardedHost ? { "x-forwarded-host": config.forwardedHost } : {}),
+    ...(config.forwardedProto ? { "x-forwarded-proto": config.forwardedProto } : {}),
   };
 }
 

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -256,7 +256,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     });
   });
 
-  it("runs a discovered eval with the canonical run id and external preview AG-UI adapter endpoint", async () => {
+  it("runs a discovered eval with the canonical run id and local routed AG-UI adapter endpoint", async () => {
     const report: EvalReport = {
       kind: "eval-report",
       runId: "run_eval_1",
@@ -274,6 +274,12 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     let receivedAuthToken: string | undefined;
     let receivedAgentId: string | null | undefined;
     let receivedProjectSlug: string | null | undefined;
+    let receivedForwardedHost: unknown;
+    let receivedForwardedProto: unknown;
+    let receivedEnvironment: unknown;
+    let receivedEnvironmentId: unknown;
+    let receivedProjectIdHeader: unknown;
+    let receivedBranchName: unknown;
     const handler = new ProjectRunExecuteHandler(createDeps({
       runEval: async (_definition, options) => {
         receivedRunId = options.runId;
@@ -285,6 +291,12 @@ describe("server/handlers/request/project-run-execute.handler", () => {
         receivedAuthToken = config.authToken;
         receivedAgentId = config.agentId;
         receivedProjectSlug = (config as { projectSlug?: string | null }).projectSlug;
+        receivedForwardedHost = config.forwardedHost;
+        receivedForwardedProto = config.forwardedProto;
+        receivedEnvironment = config.environment;
+        receivedEnvironmentId = config.environmentId;
+        receivedProjectIdHeader = config.projectId;
+        receivedBranchName = config.branchName;
         return async () => ({ text: "Paris" });
       },
     }));
@@ -304,6 +316,9 @@ describe("server/handlers/request/project-run-execute.handler", () => {
         "x-token": "runtime-token",
         "x-forwarded-host": "demo-project.preview.veryfront.org",
         "x-forwarded-proto": "https",
+        "x-environment": "preview",
+        "x-environment-id": "env-1",
+        "x-branch-name": "main",
       },
     );
 
@@ -323,10 +338,16 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     });
     assertEquals(receivedRunId, "run_eval_1");
     assertEquals(receivedBaseDir, "/project");
-    assertEquals(receivedEndpoint, "https://demo-project.preview.veryfront.org/api/ag-ui");
+    assertEquals(receivedEndpoint, "http://127.0.0.1:4311/api/ag-ui");
     assertEquals(receivedAuthToken, "runtime-token");
     assertEquals(receivedAgentId, "researcher");
     assertEquals(receivedProjectSlug, "demo-project");
+    assertEquals(receivedForwardedHost, "demo-project.preview.veryfront.org");
+    assertEquals(receivedForwardedProto, "https");
+    assertEquals(receivedEnvironment, "preview");
+    assertEquals(receivedEnvironmentId, "env-1");
+    assertEquals(receivedProjectIdHeader, "proj-1");
+    assertEquals(receivedBranchName, "main");
   });
 
   it("uses the local AG-UI adapter endpoint when the runtime endpoint is local", async () => {
@@ -394,7 +415,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     assertEquals(receivedEndpoint, "https://agent-service.example.com/api/ag-ui");
   });
 
-  it("preserves external preview AG-UI endpoints when control-plane requests use an internal runtime host", async () => {
+  it("uses local AG-UI endpoints for managed preview URLs when control-plane requests use an internal runtime host", async () => {
     let receivedEndpoint: string | undefined;
     const handler = new ProjectRunExecuteHandler(createDeps({
       createEvalAgentAdapter: (config) => {
@@ -424,7 +445,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
 
     assertExists(result.response);
     assertEquals(result.response.status, 200);
-    assertEquals(receivedEndpoint, "https://demo-project.preview.veryfront.org/api/ag-ui");
+    assertEquals(receivedEndpoint, "http://127.0.0.1:4311/api/ag-ui");
   });
 
   it("marks eval execution unsuccessful when records contain adapter failures", async () => {

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -38,6 +38,7 @@ import { ensureProjectDiscovery } from "./api/project-discovery.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { BaseHandler } from "../response/base.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
+import { parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
 
 const EXECUTE_PATH_REGEX = /^\/api\/control-plane\/runs\/([^/]+)\/execute$/;
 const DEFAULT_WORKFLOW_STATUS_POLL_INTERVAL_MS = 100;
@@ -455,6 +456,18 @@ function isLocalAgUiEndpoint(endpoint: string): boolean {
   }
 }
 
+function isManagedProjectAgUiEndpoint(endpoint: string, projectSlug?: string): boolean {
+  if (!projectSlug) return false;
+  try {
+    const endpointUrl = new URL(endpoint);
+    if (endpointUrl.pathname !== "/api/ag-ui") return false;
+    const parsed = parseProjectDomain(endpointUrl.host);
+    return parsed.isVeryfrontDomain && parsed.slug === projectSlug;
+  } catch {
+    return false;
+  }
+}
+
 function getRuntimeLocalPort(req: Request): number {
   const url = new URL(req.url);
   const requestPort = isLocalHostname(url.hostname) ? url.port : "";
@@ -470,14 +483,39 @@ function getLocalAgUiEndpoint(req: Request): string {
   return `http://127.0.0.1:${getRuntimeLocalPort(req)}/api/ag-ui`;
 }
 
-function resolveEvalAgUiEndpoint(req: Request, endpoint?: string): string {
+function resolveEvalAgUiEndpoint(
+  req: Request,
+  endpoint?: string,
+  projectSlug?: string,
+): string {
   if (!endpoint) {
     return getLocalAgUiEndpoint(req);
   }
-  if (!isRequestSiblingAgUiEndpoint(endpoint, req) || !isLocalAgUiEndpoint(endpoint)) {
+  const shouldUseLocalEndpoint = isRequestSiblingAgUiEndpoint(endpoint, req) ||
+    isManagedProjectAgUiEndpoint(endpoint, projectSlug) ||
+    isLocalAgUiEndpoint(endpoint);
+  if (!shouldUseLocalEndpoint) {
     return endpoint;
   }
   return getLocalAgUiEndpoint(req);
+}
+
+function getEndpointHost(endpoint?: string): string | undefined {
+  if (!endpoint) return undefined;
+  try {
+    return new URL(endpoint).host;
+  } catch {
+    return undefined;
+  }
+}
+
+function getEndpointProtocol(endpoint?: string): string | undefined {
+  if (!endpoint) return undefined;
+  try {
+    return new URL(endpoint).protocol.replace(/:$/, "");
+  } catch {
+    return undefined;
+  }
 }
 
 function createRuntimeApiClient(req: Request, ctx: HandlerContext): RuntimeApiClient {
@@ -798,13 +836,26 @@ function createEvalAdapterConfig(input: {
   }
 
   return {
-    endpoint: resolveEvalAgUiEndpoint(input.req, input.request.runtimeAgUiEndpoint),
+    endpoint: resolveEvalAgUiEndpoint(
+      input.req,
+      input.request.runtimeAgUiEndpoint,
+      input.ctx.projectSlug,
+    ),
     authToken,
     agentId: getEvalTargetAgentId(input.definition),
     projectId: input.request.projectId,
     projectSlug: input.ctx.projectSlug,
+    releaseId: input.req.headers.get("x-release-id") ?? input.ctx.releaseId,
     branchId: getStringConfig(config, ["branch_id", "branchId"]) ??
-      getStringConfig(runInput, ["branch_id", "branchId"]),
+      getStringConfig(runInput, ["branch_id", "branchId"]) ??
+      input.req.headers.get("x-branch-id"),
+    branchName: input.req.headers.get("x-branch-name"),
+    environment: input.req.headers.get("x-environment") ?? input.ctx.resolvedEnvironment,
+    environmentId: input.req.headers.get("x-environment-id") ?? input.ctx.environmentId,
+    forwardedHost: getHeaderFirstValue(input.req.headers.get("x-forwarded-host")) ??
+      getEndpointHost(input.request.runtimeAgUiEndpoint),
+    forwardedProto: getHeaderFirstValue(input.req.headers.get("x-forwarded-proto")) ??
+      getEndpointProtocol(input.request.runtimeAgUiEndpoint),
     model: getStringConfig(config, ["model"]),
     allowedTools: getStringArrayConfig(config, ["allowed_tools", "allowedTools"]),
     maxSteps: getPositiveIntConfig(config, ["max_steps", "maxSteps"]),

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.899";
+export const VERSION = "0.1.900";


### PR DESCRIPTION
## Summary
- route managed same-project eval AG-UI endpoints through the runtime-local listener instead of the protected public preview URL
- forward project routing headers on eval AG-UI requests so local loopback calls still resolve preview project source and environment context
- bump veryfront to 0.1.900 for release rollout

## Verification
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/eval/agent-service.test.ts src/server/handlers/request/project-run-execute.handler.test.ts
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/server/handlers/request/project-run-execute.handler.test.ts src/eval/agent-service.test.ts src/server/handlers/request/api/pages-api-handler.test.ts
- deno task fmt:check
- deno task lint
- deno task typecheck
- git diff --check
- pre-push hook: formatting, lint, typecheck, unit tests: 2201 passed, 0 failed

## Notes
- A broad ad hoc script-inclusive unit command still reports existing docs/generated-npm artifact gaps outside this patch: extra docs reference page `metrics` and absent generated `npm/esm` files in the worktree.