### PR TITLE
Fix eval AG-UI endpoint context forwarding

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.900",
+  "version": "0.1.901",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/eval/agent-service.test.ts
+++ b/src/eval/agent-service.test.ts
@@ -127,6 +127,7 @@ describe("eval/agent-service", () => {
       agentId: "veryfront",
       projectId: "project_123",
       projectSlug: "demo-project",
+      contentSourceId: "preview-main",
       branchId: "branch_123",
       branchName: "main",
       environment: "preview",
@@ -178,6 +179,10 @@ describe("eval/agent-service", () => {
     assertEquals(
       (requests[0]?.init.headers as Record<string, string>)["x-project-id"],
       "project_123",
+    );
+    assertEquals(
+      (requests[0]?.init.headers as Record<string, string>)["x-content-source-id"],
+      "preview-main",
     );
     assertEquals(
       (requests[0]?.init.headers as Record<string, string>)["x-branch-id"],

--- a/src/eval/agent-service.ts
+++ b/src/eval/agent-service.ts
@@ -94,6 +94,7 @@ export interface AgentServiceEvalAdapterConfig {
   projectSlug?: string | null;
   conversationId?: string | null;
   releaseId?: string | null;
+  contentSourceId?: string | null;
   branchId?: string | null;
   branchName?: string | null;
   environment?: string | null;
@@ -190,6 +191,7 @@ function createHeaders(config: AgentServiceEvalAdapterConfig): Record<string, st
     ...(config.projectId ? { "x-project-id": config.projectId } : {}),
     ...(config.projectSlug ? { "x-project-slug": config.projectSlug } : {}),
     ...(config.releaseId ? { "x-release-id": config.releaseId } : {}),
+    ...(config.contentSourceId ? { "x-content-source-id": config.contentSourceId } : {}),
     ...(config.branchId ? { "x-branch-id": config.branchId } : {}),
     ...(config.branchName ? { "x-branch-name": config.branchName } : {}),
     ...(config.environment ? { "x-environment": config.environment } : {}),

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -387,6 +387,52 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     assertEquals(receivedEndpoint, "http://127.0.0.1:4311/api/ag-ui");
   });
 
+  it("forwards managed AG-UI endpoint host context when localizing from a generic control-plane host", async () => {
+    let receivedEndpoint: string | undefined;
+    let receivedForwardedHost: unknown;
+    let receivedForwardedProto: unknown;
+    let receivedEnvironment: unknown;
+    const handler = new ProjectRunExecuteHandler(createDeps({
+      createEvalAgentAdapter: (config) => {
+        receivedEndpoint = config.endpoint;
+        receivedForwardedHost = config.forwardedHost;
+        receivedForwardedProto = config.forwardedProto;
+        receivedEnvironment = config.environment;
+        return async () => ({ text: "Paris" });
+      },
+    }));
+    const body = {
+      runId: "run_eval_generic_control_host",
+      kind: "eval",
+      target: "eval:deep-research",
+      projectId: "proj-1",
+      runtimeAgUiEndpoint: "https://demo-project.preview.veryfront.org/api/ag-ui",
+    };
+    const { request, publicKeyPem } = await signedRequest(
+      "/api/control-plane/runs/run_eval_generic_control_host/execute",
+      body,
+      {
+        "x-token": "runtime-token",
+        "x-forwarded-host": "veryfront.org",
+        "x-forwarded-proto": "https",
+      },
+      "https://veryfront.org",
+    );
+
+    const result = await withEnvValue(
+      "PORT",
+      "4311",
+      () => handler.handle(request, createCtx(publicKeyPem)),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(receivedEndpoint, "http://127.0.0.1:4311/api/ag-ui");
+    assertEquals(receivedForwardedHost, "demo-project.preview.veryfront.org");
+    assertEquals(receivedForwardedProto, "https");
+    assertEquals(receivedEnvironment, "preview");
+  });
+
   it("preserves non-sibling eval AG-UI endpoints", async () => {
     let receivedEndpoint: string | undefined;
     const handler = new ProjectRunExecuteHandler(createDeps({

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -456,15 +456,29 @@ function isLocalAgUiEndpoint(endpoint: string): boolean {
   }
 }
 
-function isManagedProjectAgUiEndpoint(endpoint: string, projectSlug?: string): boolean {
-  if (!projectSlug) return false;
+interface ManagedProjectAgUiEndpointContext {
+  forwardedHost: string;
+  forwardedProto: string;
+  environment: "preview" | "production";
+}
+
+function getManagedProjectAgUiEndpointContext(
+  endpoint?: string,
+  projectSlug?: string,
+): ManagedProjectAgUiEndpointContext | null {
+  if (!endpoint || !projectSlug) return null;
   try {
     const endpointUrl = new URL(endpoint);
-    if (endpointUrl.pathname !== "/api/ag-ui") return false;
+    if (endpointUrl.pathname !== "/api/ag-ui") return null;
     const parsed = parseProjectDomain(endpointUrl.host);
-    return parsed.isVeryfrontDomain && parsed.slug === projectSlug;
+    if (!parsed.isVeryfrontDomain || parsed.slug !== projectSlug) return null;
+    return {
+      forwardedHost: endpointUrl.host,
+      forwardedProto: endpointUrl.protocol.replace(/:$/, ""),
+      environment: parsed.environment === "preview" ? "preview" : "production",
+    };
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -492,7 +506,7 @@ function resolveEvalAgUiEndpoint(
     return getLocalAgUiEndpoint(req);
   }
   const shouldUseLocalEndpoint = isRequestSiblingAgUiEndpoint(endpoint, req) ||
-    isManagedProjectAgUiEndpoint(endpoint, projectSlug) ||
+    !!getManagedProjectAgUiEndpointContext(endpoint, projectSlug) ||
     isLocalAgUiEndpoint(endpoint);
   if (!shouldUseLocalEndpoint) {
     return endpoint;
@@ -834,6 +848,10 @@ function createEvalAdapterConfig(input: {
   if (!authToken) {
     throw new Error("Missing project runtime API token");
   }
+  const managedEndpointContext = getManagedProjectAgUiEndpointContext(
+    input.request.runtimeAgUiEndpoint,
+    input.ctx.projectSlug,
+  );
 
   return {
     endpoint: resolveEvalAgUiEndpoint(
@@ -846,15 +864,19 @@ function createEvalAdapterConfig(input: {
     projectId: input.request.projectId,
     projectSlug: input.ctx.projectSlug,
     releaseId: input.req.headers.get("x-release-id") ?? input.ctx.releaseId,
+    contentSourceId: input.req.headers.get("x-content-source-id"),
     branchId: getStringConfig(config, ["branch_id", "branchId"]) ??
       getStringConfig(runInput, ["branch_id", "branchId"]) ??
       input.req.headers.get("x-branch-id"),
     branchName: input.req.headers.get("x-branch-name"),
-    environment: input.req.headers.get("x-environment") ?? input.ctx.resolvedEnvironment,
+    environment: managedEndpointContext?.environment ?? input.req.headers.get("x-environment") ??
+      input.ctx.resolvedEnvironment,
     environmentId: input.req.headers.get("x-environment-id") ?? input.ctx.environmentId,
-    forwardedHost: getHeaderFirstValue(input.req.headers.get("x-forwarded-host")) ??
+    forwardedHost: managedEndpointContext?.forwardedHost ??
+      getHeaderFirstValue(input.req.headers.get("x-forwarded-host")) ??
       getEndpointHost(input.request.runtimeAgUiEndpoint),
-    forwardedProto: getHeaderFirstValue(input.req.headers.get("x-forwarded-proto")) ??
+    forwardedProto: managedEndpointContext?.forwardedProto ??
+      getHeaderFirstValue(input.req.headers.get("x-forwarded-proto")) ??
       getEndpointProtocol(input.request.runtimeAgUiEndpoint),
     model: getStringConfig(config, ["model"]),
     allowedTools: getStringArrayConfig(config, ["allowed_tools", "allowedTools"]),

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.900";
+export const VERSION = "0.1.901";


### PR DESCRIPTION
## Summary
- Route localized managed eval AG-UI calls with the target endpoint host, protocol, and proxy environment instead of the inbound control-plane host.
- Forward `x-content-source-id` through the eval agent-service adapter so runtime project source resolution keeps the same source context.
- Bump the package version to `0.1.901` for release.

## Verification
- `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/server/handlers/request/project-run-execute.handler.test.ts src/eval/agent-service.test.ts`
- `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/server/handlers/request/project-run-execute.handler.test.ts src/eval/agent-service.test.ts src/utils/version.test.ts`
- `deno check src/server/handlers/request/project-run-execute.handler.ts src/server/handlers/request/project-run-execute.handler.test.ts src/eval/agent-service.ts src/eval/agent-service.test.ts src/utils/version-constant.ts`
- `deno task fmt:check`
- `git diff --check`
- `deno task lint`
- `deno task typecheck`
- Pre-push hook: full unit suite, `2201 passed`, `0 failed`
