### PR TITLE
Add branch labels to project metrics

### DIFF
--- a/docs/guides/project-metrics.md
+++ b/docs/guides/project-metrics.md
@@ -38,8 +38,10 @@ current values. Prefer stable `vf_`-prefixed metric names so they are easy to
 discover in Studio.
 
 When code runs inside Veryfront, the SDK adds request-scoped labels for
-`project_id`, `project_slug`, and `environment`. User code should not provide
-or trust those labels for isolation; the platform-owned request context wins.
+`project_id`, `project_slug`, `environment`, and `branch` for preview requests.
+Preview requests without an explicit branch use `branch="main"`. User code
+should not provide or trust those labels for isolation; the platform-owned
+request context wins.
 
 ## Emit eval metrics
 
@@ -76,13 +78,13 @@ export default evalAgent({
 
 Metric labels become query dimensions. Keep them low-cardinality and safe:
 
-| Good labels                                                                            | Avoid                                                                                    |
-| -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `environment`, `service`, `route`, `status`, `outcome`, `model`, `provider`, `eval_id` | User IDs, email addresses, prompts, outputs, request IDs, session IDs, raw URLs, secrets |
+| Good labels                                                                                      | Avoid                                                                                    |
+| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `environment`, `branch`, `service`, `route`, `status`, `outcome`, `model`, `provider`, `eval_id` | User IDs, email addresses, prompts, outputs, request IDs, session IDs, raw URLs, secrets |
 
 Use a small allowlist per metric. Do not put tenant identity, project identity,
 credentials, or personally identifiable data into user-supplied labels.
-Project and environment labels are injected by the platform.
+Project, environment, and preview branch labels are injected by the platform.
 
 ## Relationship to OpenTelemetry
 

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -71,6 +71,7 @@ describe("metrics public SDK", () => {
           project_id: "project-123",
           project_slug: "demo-project",
           environment: "Staging",
+          branch: "main",
           provider: "openai",
         },
       },
@@ -83,7 +84,65 @@ describe("metrics public SDK", () => {
           project_id: "project-123",
           project_slug: "demo-project",
           environment: "Staging",
+          branch: "main",
           model: "gpt-5",
+        },
+      },
+    ]);
+  });
+
+  it("records preview metrics with the request-scoped branch label", async () => {
+    const counterCalls: unknown[] = [];
+
+    setGlobalMetricsAPI({
+      getMeter() {
+        return {
+          createCounter(name: string) {
+            return {
+              add(value: number, attributes?: Record<string, unknown>) {
+                counterCalls.push({ name, value, attributes });
+              },
+            };
+          },
+          createHistogram() {
+            return { record() {} };
+          },
+          createUpDownCounter() {
+            return { add() {} };
+          },
+          createObservableGauge() {
+            return { addCallback() {} };
+          },
+        };
+      },
+    } as MetricsAPI);
+
+    await runWithRequestContext(
+      {
+        projectSlug: "demo-project",
+        projectId: "project-123",
+        token: "token",
+        environmentName: "Preview",
+        branch: "feature-metrics",
+      },
+      async () => {
+        metrics.counter("vf_eval_result_total", 1, {
+          branch: "user-supplied-branch",
+          outcome: "pass",
+        });
+      },
+    );
+
+    assertEquals(counterCalls, [
+      {
+        name: "vf_eval_result_total",
+        value: 1,
+        attributes: {
+          project_id: "project-123",
+          project_slug: "demo-project",
+          environment: "Preview",
+          branch: "feature-metrics",
+          outcome: "pass",
         },
       },
     ]);

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -57,6 +57,7 @@ function normalizeAttributes(attributes?: MetricAttributes): Record<string, Attr
   if (context?.projectId) normalized.project_id = context.projectId;
   if (context?.projectSlug) normalized.project_slug = context.projectSlug;
   if (context?.environmentName) normalized.environment = context.environmentName;
+  if (context && !context.productionMode) normalized.branch = context.branch ?? "main";
 
   return normalized;
 }


### PR DESCRIPTION
## Summary
- add the request-context branch label to project metrics for non-production/runtime preview contexts
- default non-production metrics to branch=main when no branch is available
- document project/environment/branch label behavior in the SDK guide

## Verification
- deno fmt --check src/metrics/index.ts src/metrics/index.test.ts docs/guides/project-metrics.md
- deno test --no-check --allow-all src/metrics/index.test.ts
- deno lint src/metrics/index.ts src/metrics/index.test.ts
- pre-push: 2201 Deno tests passed