### PR TITLE
Fix eval AG-UI request body shape

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.901",
+  "version": "0.1.902",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/eval/agent-service.test.ts
+++ b/src/eval/agent-service.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { AgUiRequestSchema } from "veryfront/agent";
 import { datasets, evalAgent, metrics, runEval } from "veryfront/eval";
 import {
   buildAgentServiceEvalRequestBody,
@@ -83,9 +84,11 @@ describe("eval/agent-service", () => {
       {
         id: body.messages[0]?.id,
         role: "user",
-        content: "List files",
+        parts: [{ type: "text", text: "List files" }],
       },
     ]);
+    const parsedAgUiRequest = AgUiRequestSchema.parse(body);
+    assertEquals(parsedAgUiRequest.messages[0]?.parts, [{ type: "text", text: "List files" }]);
     assertEquals(body.forwardedProps, {
       veryfront: {
         agentId: "researcher",

--- a/src/eval/agent-service.ts
+++ b/src/eval/agent-service.ts
@@ -81,7 +81,10 @@ export interface AgentServiceEvalRequestBody {
   messages: Array<{
     id: string;
     role: "user";
-    content: string;
+    parts: Array<{
+      type: "text";
+      text: string;
+    }>;
   }>;
 }
 
@@ -356,7 +359,7 @@ export function buildAgentServiceEvalRequestBody(
       {
         id: crypto.randomUUID(),
         role: "user",
-        content: stringifyPromptInput(input.input),
+        parts: [{ type: "text", text: stringifyPromptInput(input.input) }],
       },
     ],
   };

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.901";
+export const VERSION = "0.1.902";


### PR DESCRIPTION
## Summary

Fixes the eval runtime adapter so AG-UI requests sent to project `createAgUiHandler` endpoints use the exported public request schema.

The staging eval reached the project runtime but `/api/ag-ui` returned `404` with no AG-UI events. A direct agent run in the same environment completed with `Paris`, which narrowed the failure to the eval adapter's public AG-UI payload. The adapter now sends user messages as `parts: [{ type: "text", text }]` instead of legacy `content` fields.

## Verification

- `deno test --no-check --allow-all src/eval/agent-service.test.ts`
- `deno test --no-check --allow-all src/server/handlers/request/project-run-execute.handler.test.ts`
- `deno fmt --check deno.json src/eval/agent-service.ts src/eval/agent-service.test.ts src/utils/version-constant.ts`
- `deno check src/eval/agent-service.ts src/eval/agent-service.test.ts`
- `git diff --check`
- Pre-push hook: format, lint, type check, generated assets, unit suite: `2201 passed (18866 steps)`

## Release

Bumps `veryfront` to `0.1.902` for downstream staging rollout.
