### PR TITLE
Refresh preview source before API route discovery

### DIFF
--- a/src/server/handlers/request/api/pages-api-handler.test.ts
+++ b/src/server/handlers/request/api/pages-api-handler.test.ts
@@ -166,6 +166,13 @@ describe("server/handlers/request/api/pages-api-handler", () => {
   describe("getApiHandler", () => {
     it("should not reuse stale preview route maps after source changes", async () => {
       const adapter = createMockAdapter();
+      let refreshCalls = 0;
+      (adapter.fs as unknown as { refreshSourceSnapshot?: (reason?: string) => Promise<void> })
+        .refreshSourceSnapshot = (reason?: string) => {
+          refreshCalls++;
+          assertEquals(reason, "preview-api-route-discovery");
+          return Promise.resolve();
+        };
       const ctx = createHandlerContext({
         adapter,
         projectSlug: "my-project",
@@ -202,11 +209,18 @@ describe("server/handlers/request/api/pages-api-handler", () => {
       assertExists(updatedResponse);
       assertEquals(updatedResponse.status, 200);
       assertEquals(await updatedResponse.json(), { ok: true });
+      assertEquals(refreshCalls, 2);
     });
 
     it("should cache production route handlers by release context", async () => {
       const cache = createMockCache();
       const adapter = createMockAdapter();
+      let refreshCalls = 0;
+      (adapter.fs as unknown as { refreshSourceSnapshot?: (reason?: string) => Promise<void> })
+        .refreshSourceSnapshot = () => {
+          refreshCalls++;
+          return Promise.resolve();
+        };
       __injectCacheForTests(cache as any);
 
       await getApiHandler(
@@ -242,6 +256,7 @@ describe("server/handlers/request/api/pages-api-handler", () => {
           "/project-dir:my-project:production:release-2",
         ],
       );
+      assertEquals(refreshCalls, 0);
     });
   });
 });

--- a/src/server/handlers/request/api/pages-api-handler.ts
+++ b/src/server/handlers/request/api/pages-api-handler.ts
@@ -56,7 +56,16 @@ function shouldCacheApiHandler(ctx: HandlerContext): boolean {
   return getApiHandlerCacheContext(ctx).mode === "production";
 }
 
+async function refreshPreviewSourceSnapshot(ctx: HandlerContext): Promise<void> {
+  if (!ctx.projectSlug) return;
+  if (getApiHandlerCacheContext(ctx).mode === "production") return;
+
+  await ctx.adapter.fs.refreshSourceSnapshot?.("preview-api-route-discovery");
+}
+
 async function createApiHandler(ctx: HandlerContext): Promise<APIRouteHandler> {
+  await refreshPreviewSourceSnapshot(ctx);
+
   const handler = new APIRouteHandler(ctx.projectDir, ctx.adapter);
   await handler.initialize();
   return handler;


### PR DESCRIPTION
## Summary
- refresh preview source snapshots before API route discovery
- keep production API route handler caching release-scoped
- add regression assertions for preview refresh vs production no-refresh

## Test plan
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/server/handlers/request/project-run-execute.handler.test.ts src/eval/agent-service.test.ts src/server/handlers/request/api/pages-api-handler.test.ts
- deno task fmt:check
- pre-push: fmt, lint, typecheck, unit tests (2201 passed)