### PR TITLE
Bump release version for preview route refresh

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.902",
+  "version": "0.1.903",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.902";
+export const VERSION = "0.1.903";


### PR DESCRIPTION
## Summary
- bump veryfront release version to 0.1.903 so the merged preview API route refresh can publish a new server image
- keep the hard-coded runtime VERSION constant in sync with deno.json

## Verification
- deno fmt --check deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/utils/version.test.ts src/utils/logger/logger.test.ts
- pre-push hook: format, lint, typecheck, unit tests