### PR TITLE
Route Veryfront Cloud generate calls through streaming

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.902",
+  "version": "0.1.903",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/provider/types.ts
+++ b/src/provider/types.ts
@@ -20,6 +20,7 @@ export interface ModelRuntimeStreamResult {
 /** Public API contract for model runtime. */
 export interface ModelRuntime extends RuntimeMetadata {
   readonly _isVfLocalModel?: boolean;
+  readonly _generateViaStream?: boolean;
   doGenerate(options: unknown): PromiseLike<ModelRuntimeGenerateResult>;
   doStream(options: unknown): PromiseLike<ModelRuntimeStreamResult>;
 }

--- a/src/provider/veryfront-cloud/provider.test.ts
+++ b/src/provider/veryfront-cloud/provider.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { agent } from "#veryfront/agent";
 import { deleteEnv, setEnv } from "#veryfront/compat/process.ts";
 import { clearEmbeddingProviders, resolveEmbeddingModel } from "#veryfront/embedding/index.ts";
 import { clearModelProviders, resolveModel } from "#veryfront/provider";
@@ -31,7 +32,10 @@ function setCloudBootstrap(): void {
 }
 
 describe("provider/veryfront-cloud", () => {
+  const originalFetch = globalThis.fetch;
+
   afterEach(() => {
+    globalThis.fetch = originalFetch;
     clearCloudEnv();
     clearModelProviders();
     clearEmbeddingProviders();
@@ -44,6 +48,60 @@ describe("provider/veryfront-cloud", () => {
 
     assertEquals(typeof model.doGenerate, "function");
     assertEquals(typeof model.doStream, "function");
+    assertEquals(model._generateViaStream, true);
+  });
+
+  it("routes agent.generate through the streaming Veryfront Cloud gateway path", async () => {
+    setCloudBootstrap();
+    const encoder = new TextEncoder();
+    let capturedRequest: Request | undefined;
+    let capturedBody: Record<string, unknown> | undefined;
+
+    globalThis.fetch = (async (input: URL | Request | string, init?: RequestInit) => {
+      const request = new Request(input, init);
+      capturedRequest = request;
+      capturedBody = JSON.parse(await request.text()) as Record<string, unknown>;
+
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              encoder.encode('data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n'),
+            );
+            controller.enqueue(
+              encoder.encode(
+                'data: {"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}\n\n',
+              ),
+            );
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            controller.close();
+          },
+        }),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      );
+    }) as typeof fetch;
+
+    const assistant = agent({
+      model: "veryfront-cloud/openai/gpt-test",
+      system: "You are concise.",
+    });
+
+    const result = await assistant.generate({ input: "Hi" });
+
+    assertEquals(
+      capturedRequest?.url,
+      "https://api.veryfront.com/ai/gateway/openai/v1/chat/completions",
+    );
+    assertEquals(capturedRequest?.headers.get("Authorization"), "Bearer vf_test_provider");
+    assertEquals(capturedRequest?.headers.get("x-veryfront-project-slug"), "provider-test-project");
+    assertEquals(capturedBody?.stream, true);
+    assertEquals(capturedBody?.stream_options, { include_usage: true });
+    assertEquals(result.text, "Hello");
+    assertEquals(result.usage, {
+      promptTokens: 2,
+      completionTokens: 1,
+      totalTokens: 3,
+    });
   });
 
   it("resolves veryfront-cloud moonshotai models without project ext-llm-openai installed", () => {
@@ -53,6 +111,7 @@ describe("provider/veryfront-cloud", () => {
 
     assertEquals(typeof model.doGenerate, "function");
     assertEquals(typeof model.doStream, "function");
+    assertEquals(model._generateViaStream, true);
   });
 
   it("resolves veryfront-cloud mistral models without project ext-llm-openai installed", () => {
@@ -65,6 +124,7 @@ describe("provider/veryfront-cloud", () => {
 
     assertEquals(typeof model.doGenerate, "function");
     assertEquals(typeof model.doStream, "function");
+    assertEquals(model._generateViaStream, true);
   });
 
   it("rejects unsupported pre-prefixed veryfront-cloud Mistral models", () => {
@@ -92,6 +152,7 @@ describe("provider/veryfront-cloud", () => {
 
     assertEquals(typeof model.doGenerate, "function");
     assertEquals(typeof model.doStream, "function");
+    assertEquals(model._generateViaStream, true);
   });
 
   it("resolves veryfront-cloud google models without project ext-llm-google installed", () => {
@@ -104,6 +165,7 @@ describe("provider/veryfront-cloud", () => {
 
     assertEquals(typeof model.doGenerate, "function");
     assertEquals(typeof model.doStream, "function");
+    assertEquals(model._generateViaStream, true);
   });
 
   it("resolves direct anthropic models through the built-in provider", () => {

--- a/src/provider/veryfront-cloud/provider.ts
+++ b/src/provider/veryfront-cloud/provider.ts
@@ -9,6 +9,10 @@ import {
 } from "./shared.ts";
 import { createVeryfrontCloudOpenAIModel } from "./openai.ts";
 
+function preferStreamedGenerate(model: ModelRuntime): ModelRuntime {
+  return Object.assign(model, { _generateViaStream: true as const });
+}
+
 export function createVeryfrontCloudModel(modelId: string): ModelRuntime {
   const { provider, modelId: upstreamModelId } = parseVeryfrontCloudModelId(modelId, "language");
   const { apiBaseUrl, apiToken, projectSlug } = requireVeryfrontCloudBootstrap();
@@ -20,13 +24,13 @@ export function createVeryfrontCloudModel(modelId: string): ModelRuntime {
     case "anthropic": {
       const anthropic = registry.get("anthropic");
       if (anthropic) {
-        return anthropic.createModel(upstreamModelId, {
+        return preferStreamedGenerate(anthropic.createModel(upstreamModelId, {
           credential: apiToken,
           authToken: apiToken,
           baseURL,
           name: "veryfront-cloud",
           fetch,
-        });
+        }));
       }
       break;
     }
@@ -34,12 +38,12 @@ export function createVeryfrontCloudModel(modelId: string): ModelRuntime {
     case "google": {
       const google = registry.get("google");
       if (google) {
-        return google.createModel(upstreamModelId, {
+        return preferStreamedGenerate(google.createModel(upstreamModelId, {
           credential: apiToken,
           baseURL,
           name: "veryfront-cloud",
           fetch,
-        });
+        }));
       }
       break;
     }
@@ -49,18 +53,18 @@ export function createVeryfrontCloudModel(modelId: string): ModelRuntime {
     case "moonshotai": {
       const openai = registry.get("openai");
       if (openai) {
-        return openai.createModel(upstreamModelId, {
+        return preferStreamedGenerate(openai.createModel(upstreamModelId, {
           credential: apiToken,
           baseURL,
           name: "veryfront-cloud",
           fetch,
-        });
+        }));
       }
-      return createVeryfrontCloudOpenAIModel(upstreamModelId, {
+      return preferStreamedGenerate(createVeryfrontCloudOpenAIModel(upstreamModelId, {
         apiToken,
         baseURL,
         fetch,
-      });
+      }));
     }
 
     default: {

--- a/src/runtime/runtime-bridge.test.ts
+++ b/src/runtime/runtime-bridge.test.ts
@@ -44,6 +44,93 @@ describe("runtime-bridge", () => {
     });
   });
 
+  it("buffers the stream path for models that prefer streamed generate", async () => {
+    let called = false;
+
+    const model = {
+      ...createStreamModel(
+        "veryfront-cloud",
+        "veryfront-cloud/openai/gpt-test",
+        async (options) => {
+          called = true;
+          assertEquals(options.prompt, [{
+            role: "user",
+            content: [{ type: "text", text: "Hello" }],
+          }]);
+          return {
+            stream: ReadableStream.from([
+              { type: "text-delta", delta: "Hel" },
+              { type: "text-delta", delta: "lo" },
+              {
+                type: "finish",
+                finishReason: { unified: "stop", raw: "stop" },
+                usage: {
+                  inputTokens: { total: 2 },
+                  outputTokens: { total: 5 },
+                },
+              },
+            ]),
+          };
+        },
+      ),
+      _generateViaStream: true,
+    };
+
+    const result = await generateText({
+      model,
+      messages: [{ role: "user", content: "Hello" }],
+      temperature: 0,
+    });
+
+    assertEquals(called, true);
+    assertEquals(result.text, "Hello");
+    assertEquals(result.finishReason, "stop");
+    assertEquals(result.usage, {
+      inputTokens: 2,
+      outputTokens: 5,
+      totalTokens: 7,
+    });
+  });
+
+  it("buffers streamed tool calls for models that prefer streamed generate", async () => {
+    const model = {
+      ...createStreamModel("veryfront-cloud", "veryfront-cloud/anthropic/claude-test", async () => {
+        return {
+          stream: ReadableStream.from([
+            { type: "tool-input-start", id: "tool-1", toolName: "search" },
+            { type: "tool-input-delta", id: "tool-1", delta: '{"query":' },
+            { type: "tool-input-delta", id: "tool-1", delta: '"webgpu"}' },
+            { type: "tool-input-end", id: "tool-1" },
+            {
+              type: "finish",
+              finishReason: "tool-calls",
+              usage: { inputTokens: 4, outputTokens: 3 },
+            },
+          ]),
+        };
+      }),
+      _generateViaStream: true,
+    };
+
+    const result = await generateText({
+      model,
+      messages: [{ role: "user", content: "Search" }],
+      temperature: 0,
+    });
+
+    assertEquals(result.finishReason, "tool-calls");
+    assertEquals(result.toolCalls, [{
+      toolCallId: "tool-1",
+      toolName: "search",
+      input: { query: "webgpu" },
+    }]);
+    assertEquals(result.usage, {
+      inputTokens: 4,
+      outputTokens: 3,
+      totalTokens: 7,
+    });
+  });
+
   it("uses the direct stream path for models without tools", async () => {
     const model = createStreamModel("test", "test/direct-stream", async (options) => {
       assertEquals(options.prompt, [{

--- a/src/runtime/runtime-bridge.ts
+++ b/src/runtime/runtime-bridge.ts
@@ -8,6 +8,7 @@
 import type { TextGenerationRuntimeMessage } from "#veryfront/agent/runtime/text-generation-runtime-message-types.ts";
 import type {
   RuntimeGenerateTextResult,
+  RuntimeStreamPart,
   RuntimeStreamResult,
   RuntimeToolCallRepairFunction,
   RuntimeToolSet,
@@ -146,6 +147,8 @@ type DirectToolDefinition =
     id: `${string}.${string}`;
     args: Record<string, unknown>;
   };
+
+type DirectTextOptions = GenerateTextOptions | StreamTextOptions;
 
 function normalizeSystemPrompt(system: GenerateTextOptions["system"]): string | undefined {
   if (typeof system === "string") {
@@ -321,6 +324,10 @@ function normalizeFinishReason(finishReason: unknown): string | null {
   return null;
 }
 
+function shouldGenerateViaStream(model: ModelRuntime): boolean {
+  return model._generateViaStream === true;
+}
+
 function parseToolCallInput(input: unknown): unknown {
   if (typeof input !== "string") {
     return input;
@@ -406,6 +413,36 @@ async function resolveDirectTools(
   return resolvedTools.length > 0 ? resolvedTools : undefined;
 }
 
+function buildDirectModelOptions(
+  options: DirectTextOptions,
+  tools: DirectToolDefinition[] | undefined,
+): Record<string, unknown> {
+  return {
+    prompt: toRuntimePrompt(
+      normalizeSystemPrompt(options.system),
+      getProviderRequestMessages(options.messages),
+    ),
+    maxOutputTokens: options.maxOutputTokens,
+    ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
+    topP: options.topP,
+    topK: options.topK,
+    stopSequences: options.stopSequences,
+    ...(tools ? { tools } : {}),
+    ...(options.toolChoice ? { toolChoice: options.toolChoice } : {}),
+    ...(options.seed !== undefined ? { seed: options.seed } : {}),
+    ...(options.presencePenalty !== undefined ? { presencePenalty: options.presencePenalty } : {}),
+    ...(options.frequencyPenalty !== undefined
+      ? { frequencyPenalty: options.frequencyPenalty }
+      : {}),
+    ...(options.headers ? { headers: options.headers } : {}),
+    ...(options.providerOptions ? { providerOptions: options.providerOptions } : {}),
+    ...("includeRawChunks" in options && options.includeRawChunks !== undefined
+      ? { includeRawChunks: options.includeRawChunks }
+      : {}),
+    abortSignal: options.abortSignal,
+  };
+}
+
 function isDirectToolCallPart(
   part: unknown,
 ): part is { type: "tool-call"; toolCallId: string; toolName: string; input: unknown } {
@@ -488,6 +525,149 @@ function buildDirectGenerateResult(
   };
 }
 
+function streamUsageToGenerateUsage(
+  totalUsage: Extract<RuntimeStreamPart, { type: "finish" }>["totalUsage"],
+): RuntimeGenerateTextResult["usage"] {
+  if (!totalUsage) {
+    return undefined;
+  }
+
+  const inputTokens = totalUsage.inputTokens;
+  const outputTokens = totalUsage.outputTokens;
+  const totalTokens = totalUsage.totalTokens ??
+    (inputTokens !== undefined || outputTokens !== undefined
+      ? (inputTokens ?? 0) + (outputTokens ?? 0)
+      : undefined);
+
+  return {
+    inputTokens,
+    outputTokens,
+    ...(totalTokens !== undefined ? { totalTokens } : {}),
+    ...(totalUsage.cacheCreationInputTokens !== undefined
+      ? { cacheCreationInputTokens: totalUsage.cacheCreationInputTokens }
+      : {}),
+    ...(totalUsage.cacheReadInputTokens !== undefined
+      ? { cacheReadInputTokens: totalUsage.cacheReadInputTokens }
+      : {}),
+    ...(totalUsage.cachedInputTokens !== undefined
+      ? { cachedInputTokens: totalUsage.cachedInputTokens }
+      : {}),
+    ...(totalUsage.reasoningTokens !== undefined
+      ? { reasoningTokens: totalUsage.reasoningTokens }
+      : {}),
+  };
+}
+
+async function buildGenerateResultFromStream(
+  stream: ReadableStream<unknown>,
+): Promise<RuntimeGenerateTextResult> {
+  let text = "";
+  let usage: RuntimeGenerateTextResult["usage"];
+  let finishReason: string | null = null;
+  const toolCalls = new Map<string, NonNullable<RuntimeGenerateTextResult["toolCalls"]>[number]>();
+  const toolInputs = new Map<string, { toolCallId: string; toolName: string; input: string }>();
+  const toolResults: NonNullable<RuntimeGenerateTextResult["toolResults"]> = [];
+
+  for await (const rawPart of mapReadableStream(stream)) {
+    if (!rawPart || typeof rawPart !== "object" || !("type" in rawPart)) {
+      continue;
+    }
+
+    const part = rawPart as RuntimeStreamPart;
+
+    switch (part.type) {
+      case "text-delta":
+        text += part.text;
+        break;
+
+      case "tool-input-start":
+        toolInputs.set(part.id, {
+          toolCallId: part.id,
+          toolName: part.toolName,
+          input: "",
+        });
+        break;
+
+      case "tool-input-delta": {
+        const input = toolInputs.get(part.id);
+        if (input) {
+          input.input += part.delta;
+        }
+        break;
+      }
+
+      case "tool-input-end": {
+        const input = toolInputs.get(part.id);
+        if (input) {
+          toolCalls.set(input.toolCallId, {
+            toolCallId: input.toolCallId,
+            toolName: input.toolName,
+            input: parseToolCallInput(input.input),
+          });
+        }
+        break;
+      }
+
+      case "tool-input-available": {
+        const toolCallId = part.toolCallId ?? part.id;
+        if (toolCallId) {
+          toolCalls.set(toolCallId, {
+            toolCallId,
+            toolName: part.toolName,
+            input: parseToolCallInput(part.input),
+          });
+        }
+        break;
+      }
+
+      case "tool-call":
+        toolCalls.set(part.toolCallId, {
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          input: parseToolCallInput(part.input),
+        });
+        break;
+
+      case "tool-result": {
+        const result = part.result ?? part.output ?? part.error;
+        toolResults.push({
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          result,
+          ...(part.isError === true || part.error !== undefined ? { isError: true } : {}),
+          ...(part.providerExecuted === true ? { providerExecuted: true } : {}),
+        });
+        break;
+      }
+
+      case "tool-error":
+        toolResults.push({
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          result: part.error,
+          isError: true,
+          ...(part.providerExecuted === true ? { providerExecuted: true } : {}),
+        });
+        break;
+
+      case "finish":
+        finishReason = part.finishReason ?? null;
+        usage = streamUsageToGenerateUsage(part.totalUsage);
+        break;
+    }
+  }
+
+  const finalToolCalls = [...toolCalls.values()];
+
+  return {
+    text,
+    ...(finalToolCalls.length > 0 ? { toolCalls: finalToolCalls } : {}),
+    ...(toolResults.length > 0 ? { toolResults } : {}),
+    usage,
+    finishReason,
+  };
+}
+
 function normalizeStreamPart(part: unknown): unknown {
   if (!part || typeof part !== "object" || !("type" in part)) {
     return part;
@@ -511,9 +691,10 @@ function normalizeStreamPart(part: unknown): unknown {
   const finishPart = part as {
     type: "finish";
     usage?: unknown;
+    totalUsage?: unknown;
     finishReason?: unknown;
   };
-  const usage = normalizeUsage(finishPart.usage);
+  const usage = normalizeUsage(finishPart.usage) ?? normalizeUsage(finishPart.totalUsage);
   const recomputedTotal = usage ? (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0) : undefined;
 
   return {
@@ -569,61 +750,21 @@ async function* textDeltasFromStream(stream: ReadableStream<unknown>): AsyncIter
 }
 
 export function generateText(options: GenerateTextOptions): PromiseLike<RuntimeGenerateTextResult> {
-  return resolveDirectTools(options.tools).then((tools) =>
-    options.model.doGenerate({
-      prompt: toRuntimePrompt(
-        normalizeSystemPrompt(options.system),
-        getProviderRequestMessages(options.messages),
-      ),
-      maxOutputTokens: options.maxOutputTokens,
-      ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
-      topP: options.topP,
-      topK: options.topK,
-      stopSequences: options.stopSequences,
-      ...(tools ? { tools } : {}),
-      ...(options.toolChoice ? { toolChoice: options.toolChoice } : {}),
-      ...(options.seed !== undefined ? { seed: options.seed } : {}),
-      ...(options.presencePenalty !== undefined
-        ? { presencePenalty: options.presencePenalty }
-        : {}),
-      ...(options.frequencyPenalty !== undefined
-        ? { frequencyPenalty: options.frequencyPenalty }
-        : {}),
-      ...(options.headers ? { headers: options.headers } : {}),
-      ...(options.providerOptions ? { providerOptions: options.providerOptions } : {}),
-      abortSignal: options.abortSignal,
-    }).then(buildDirectGenerateResult)
-  );
+  return resolveDirectTools(options.tools).then((tools) => {
+    const directOptions = buildDirectModelOptions(options, tools);
+    if (shouldGenerateViaStream(options.model)) {
+      return options.model.doStream(directOptions).then(({ stream }) =>
+        buildGenerateResultFromStream(stream)
+      );
+    }
+
+    return options.model.doGenerate(directOptions).then(buildDirectGenerateResult);
+  });
 }
 
 export function streamText(options: StreamTextOptions): RuntimeStreamResult {
   const directResultPromise = resolveDirectTools(options.tools).then((tools) =>
-    options.model.doStream({
-      prompt: toRuntimePrompt(
-        normalizeSystemPrompt(options.system),
-        getProviderRequestMessages(options.messages),
-      ),
-      maxOutputTokens: options.maxOutputTokens,
-      ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
-      topP: options.topP,
-      topK: options.topK,
-      stopSequences: options.stopSequences,
-      ...(tools ? { tools } : {}),
-      ...(options.toolChoice ? { toolChoice: options.toolChoice } : {}),
-      ...(options.seed !== undefined ? { seed: options.seed } : {}),
-      ...(options.presencePenalty !== undefined
-        ? { presencePenalty: options.presencePenalty }
-        : {}),
-      ...(options.frequencyPenalty !== undefined
-        ? { frequencyPenalty: options.frequencyPenalty }
-        : {}),
-      ...(options.headers ? { headers: options.headers } : {}),
-      ...(options.providerOptions ? { providerOptions: options.providerOptions } : {}),
-      ...(options.includeRawChunks !== undefined
-        ? { includeRawChunks: options.includeRawChunks }
-        : {}),
-      abortSignal: options.abortSignal,
-    })
+    options.model.doStream(buildDirectModelOptions(options, tools))
   );
   const branchedStreamsPromise = directResultPromise.then(({ stream }) => stream.tee());
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.902";
+export const VERSION = "0.1.903";


### PR DESCRIPTION
## Summary
- Route Veryfront Cloud language-model `agent.generate()` calls through the streaming gateway path, then buffer SSE parts back into the existing generate result shape.
- Preserve text, usage, finish reason, streamed tool calls, and streamed tool results for generate callers.
- Bump Veryfront version metadata to `0.1.903` in both `deno.json` and `src/utils/version-constant.ts`.

## Test Plan
- `deno fmt --check deno.json src/provider/types.ts src/provider/veryfront-cloud/provider.test.ts src/provider/veryfront-cloud/provider.ts src/runtime/runtime-bridge.test.ts src/runtime/runtime-bridge.ts`
- `deno check src/runtime/runtime-bridge.ts src/provider/veryfront-cloud/provider.ts src/provider/types.ts src/runtime/runtime-bridge.test.ts src/provider/veryfront-cloud/provider.test.ts`
- `deno test --no-check --allow-all src/agent/runtime/provider-transport.test.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/tool-result-continuation.test.ts src/runtime/runtime-bridge.test.ts src/provider/veryfront-cloud/provider.test.ts src/provider/veryfront-cloud/shared.test.ts`
- `deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts`
- `deno task build:npm`
- pre-push hook: format, lint, type check, unit tests: `2201 passed (18869 steps), 0 failed`

## Notes
- Not run: full long-running live DeepResearch benchmark through Cloudflare.
