### PR TITLE
Bump release version for Cloud streaming generate

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.903",
+  "version": "0.1.904",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.903";
+export const VERSION = "0.1.904";


### PR DESCRIPTION
## Summary
- Bump Veryfront from 0.1.903 to 0.1.904 so the already-merged Cloud streaming generate fix can publish.
- Keep this PR version-only; PR #2613 contains the behavior change.

## Why
- npm `veryfront@0.1.903` was published at 2026-06-22T14:08:50Z before PR #2613 merged at 2026-06-22T14:30:49Z.
- The post-merge release for #2613 failed because `v0.1.903` already exists on npm for `cf5bbd5`.

## Verification
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno test --no-check --allow-all src/utils/version.test.ts`
- `deno task build:npm`
- Built npm package smoke confirmed Veryfront Cloud `agent.generate()` sends `stream: true`, includes `stream_options.include_usage: true`, and buffers SSE text/usage back into the generate result.
- Pre-push hook: format, lint, typecheck, and unit tests passed (`2201 passed`, `0 failed`).