### PR TITLE
Include preview API route files in runtime file lists

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.903",
+  "version": "0.1.904",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/platform/adapters/veryfront-api-client/operations.test.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.test.ts
@@ -139,7 +139,41 @@ describe("VeryfrontAPIOperations", () => {
     });
   });
 
-  describe("published server function access", () => {
+  describe("runtime server function access", () => {
+    it("requests branch file lists with server functions for preview route discovery", async () => {
+      let requestedUrl = "";
+      stubJsonFetch((url) => {
+        requestedUrl = url;
+        return {
+          data: [],
+          page_info: { self: null, first: null, next: null, prev: null },
+        };
+      });
+
+      await createOps().listBranchFiles("project-slug", "main");
+
+      assertStringIncludes(requestedUrl, "include_server_functions=true");
+    });
+
+    it("requests branch file content with server functions for preview handlers", async () => {
+      let requestedUrl = "";
+      stubJsonFetch((url) => {
+        requestedUrl = url;
+        return {
+          id: "file-id",
+          path: "app/api/ag-ui/route.ts",
+          content: "export const POST = () => new Response();",
+          size: 40,
+          type: "function",
+          updated_at: "2026-04-23T00:00:00.000Z",
+        };
+      });
+
+      await createOps().getBranchFile("project-slug", "main", "app/api/ag-ui/route.ts");
+
+      assertStringIncludes(requestedUrl, "include_server_functions=true");
+    });
+
     it("requests release file lists with server functions for runtime route discovery", async () => {
       let requestedUrl = "";
       stubJsonFetch((url) => {

--- a/src/platform/adapters/veryfront-api-client/operations.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.ts
@@ -232,7 +232,7 @@ export class VeryfrontAPIOperations {
     branchRef = "main",
     options: ListFilesOptions = {},
   ): Promise<FileListResult> {
-    const params = buildListParams(options);
+    const params = addRuntimeServerFunctionAccess(buildListParams(options));
     params.set("branch", branchRef);
     const url = `/projects/${encodeURIComponent(projectRef)}/files?${params}`;
     logger.debug("listBranchFiles", { projectRef, branchRef, pattern: options.pattern });
@@ -272,7 +272,7 @@ export class VeryfrontAPIOperations {
     return withSpan(
       SpanNames.API_GET_FILE,
       async () => {
-        const params = new URLSearchParams({ branch: branchRef });
+        const params = addRuntimeServerFunctionAccess(new URLSearchParams({ branch: branchRef }));
         const url = `/projects/${encodeURIComponent(projectRef)}/files/${
           encodeURIComponent(pathOrId)
         }?${params}`;

--- a/src/server/handlers/request/api/api-handler-wrapper.test.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.test.ts
@@ -32,7 +32,7 @@ function createCtx(captured: { options?: Record<string, unknown> }): HandlerCont
     environmentName: "Staging",
     requestContext: {
       token: "vf_proxy_token",
-      branch: null,
+      branch: "feature-branch",
       mode: "production",
     },
   } as unknown as HandlerContext;
@@ -46,5 +46,17 @@ describe("ApiHandlerWrapper", () => {
     await handler.handle(new Request("http://localhost/api/test"), createCtx(captured));
 
     assertEquals(captured.options?.environmentName, "Staging");
+  });
+
+  it("forwards preview branch into multi-project request context", async () => {
+    const captured: { options?: Record<string, unknown> } = {};
+    const ctx = createCtx(captured);
+    ctx.requestContext!.mode = "preview";
+    ctx.releaseId = undefined;
+    const handler = new ApiHandlerWrapper("/tmp/project", ctx.adapter);
+
+    await handler.handle(new Request("http://localhost/api/test"), ctx);
+
+    assertEquals(captured.options?.branch, "feature-branch");
   });
 });

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -20,6 +20,7 @@ type FsWrapper = {
     options?: {
       productionMode?: boolean;
       releaseId?: string | null;
+      branch?: string | null;
       environmentName?: string | null;
     },
   ) => Promise<T>;
@@ -99,6 +100,8 @@ export class ApiHandlerWrapper extends BaseHandler {
       {
         productionMode: isProduction,
         releaseId: ctx.releaseId,
+        branch: isProduction ? null : ctx.requestContext?.branch ?? ctx.parsedDomain?.branch ??
+          null,
         environmentName: ctx.environmentName,
       },
     );

--- a/src/server/handlers/request/api/pages-api-handler.test.ts
+++ b/src/server/handlers/request/api/pages-api-handler.test.ts
@@ -76,7 +76,7 @@ function createHandlerContext(
     releaseId: input.releaseId,
     requestContext: {
       token: "test-token",
-      projectSlug: input.projectSlug ?? "test-project",
+      slug: input.projectSlug ?? "test-project",
       mode: input.mode ?? "preview",
       branch: "main",
     },

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.903";
+export const VERSION = "0.1.904";


### PR DESCRIPTION
## Summary\n- include server-function files in branch file list/content requests used by preview runtime discovery\n- forward preview branch context through API route handling\n- bump runtime package version to 0.1.904 for release\n\n## Test evidence\n- deno test --allow-all src/platform/adapters/veryfront-api-client/operations.test.ts src/server/handlers/request/api/api-handler-wrapper.test.ts src/server/handlers/request/api/pages-api-handler.test.ts\n- deno task fmt:check && deno task lint && deno task typecheck\n- deno task test:unit\n- pre-push hook passed the same repo checks\n\n## Live evidence before fix\n- staging eval run_b7f10d74-ed45-4433-9199-cc8f71ab80ce failed because runtime branch file list returned 9 files and omitted app/api/ag-ui/route.ts\n- live file endpoint with include_server_functions=true returns 10 files including app/api/ag-ui/route.ts\n