### PR TITLE
Bump release version for preview route file-list fix

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.904",
+  "version": "0.1.905",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.904";
+export const VERSION = "0.1.905";


### PR DESCRIPTION
## Summary\n- bump veryfront runtime version to 0.1.905 so the already-merged preview route file-list fix can publish after 0.1.904 was used by #2614\n\n## Test evidence\n- deno fmt --check deno.json src/utils/version-constant.ts\n- deno check src/utils/version-constant.ts\n