### PR TITLE
Release eval runtime context forwarding

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.903",
+  "version": "0.1.904",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.903";
+export const VERSION = "0.1.904";


### PR DESCRIPTION
## Summary
- Bump veryfront to 0.1.904 and keep the exported runtime version constant in sync.
- Publish the current mainline typed eval AG-UI runtime context forwarding fix so downstream runtimes can consume managed preview AG-UI routing.

## Verification
- deno fmt --check deno.json src/eval/agent-service.ts src/eval/agent-service.test.ts src/server/handlers/request/project-run-execute.handler.ts src/server/handlers/request/project-run-execute.handler.test.ts
- deno check src/eval/agent-service.test.ts src/server/handlers/request/project-run-execute.handler.test.ts
- deno test --no-check --allow-all src/eval/agent-service.test.ts src/server/handlers/request/project-run-execute.handler.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- pre-push hook: format, lint, type check, generated manifests/prebundles, unit suite: 2201 passed