### PR TITLE
Release eval runtime context fixes as 0.1.905

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.904",
+  "version": "0.1.905",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.904";
+export const VERSION = "0.1.905";


### PR DESCRIPTION
## Summary\n- Bump the veryfront package version to 0.1.905 so downstream services can consume the current mainline eval runtime context fixes.\n- Keep the hard-coded VERSION constant in sync with deno.json.\n\n## Why\n- npm veryfront@0.1.904 was published from 74069be11 before the later eval AG-UI context forwarding and preview route file list fixes reached main.\n- npm package versions are immutable, so staging needs a fresh package version that includes those fixes.\n\n## Verification\n- deno fmt --check deno.json src/utils/version-constant.ts\n- git diff --check\n- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts\n- pre-push gate: formatting, lint, typecheck, generation, unit tests: 2201 passed, 18872 steps, 0 failed\n