### PR TITLE
Bump release version to 0.1.906

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.905",
+  "version": "0.1.906",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.905";
+export const VERSION = "0.1.906";


### PR DESCRIPTION
## Summary\n- bump veryfront runtime version to 0.1.906 so the current main commit can publish after 0.1.905 was used by #2618\n\n## Test evidence\n- deno fmt --check deno.json src/utils/version-constant.ts\n- deno check src/utils/version-constant.ts\n- npm view veryfront@0.1.906 returns not published\n