### PR TITLE
Release veryfront 0.1.908

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.907",
+  "version": "0.1.908",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.907";
+export const VERSION = "0.1.908";


### PR DESCRIPTION
## Summary\n- bump veryfront framework version to 0.1.908\n- keep the runtime VERSION constant in sync with deno.json\n\n## Verification\n- deno test --lock=deno.lock --frozen --no-check --allow-all src/utils/version.test.ts\n- deno task --lock=deno.lock --frozen typecheck\n- git diff --check\n- pre-push gate: format, lint, typecheck, generated manifests, unit tests (2203 passed, 18878 steps)\n- npm view veryfront@0.1.908 version returns 404 before release\n\n## Release purpose\nThis publishes the merged eval V2 report and baseline work so veryfront-api, veryfront-studio, and veryfront-agent can consume a stable package version.