### PR TITLE
Enable builtin OpenTelemetry extension for runtime metrics

### DIFF
--- a/src/extensions/builtin-extensions.test.ts
+++ b/src/extensions/builtin-extensions.test.ts
@@ -90,4 +90,16 @@ describe("createBuiltinExtensions", () => {
 
     assertEquals(authExtension?.extension.provides?.AuthProvider !== undefined, true);
   });
+
+  it("includes the OpenTelemetry observability extension for runtime metrics", () => {
+    const otelExtension = createBuiltinExtensions().find((entry) =>
+      entry.extension.name === "ext-observability-opentelemetry"
+    );
+
+    assertEquals(otelExtension?.extension.contracts?.provides?.includes("TracingExporter"), true);
+    assertEquals(
+      otelExtension?.extension.contracts?.provides?.includes("NodeTelemetryProvider"),
+      true,
+    );
+  });
 });

--- a/src/extensions/builtin-extensions.ts
+++ b/src/extensions/builtin-extensions.ts
@@ -14,6 +14,7 @@ import extMdx from "../../extensions/ext-content-mdx/src/index.ts";
 import extTailwind from "../../extensions/ext-css-tailwind/src/index.ts";
 import extDocumentKreuzberg from "../../extensions/ext-document-kreuzberg/src/index.ts";
 import extDbSqlite from "../../extensions/ext-db-sqlite/src/index.ts";
+import extOpenTelemetry from "../../extensions/ext-observability-opentelemetry/src/index.ts";
 import extSandboxShellTools from "../../extensions/ext-sandbox-shell-tools/src/index.ts";
 import extZod from "../../extensions/ext-schema-zod/src/index.ts";
 import { createZodAdapter } from "../../extensions/ext-schema-zod/src/adapter.ts";
@@ -131,6 +132,11 @@ export function createBuiltinExtensions(): ResolvedExtension[] {
       source: "builtin",
       origin: "veryfront/ext-auth-jwt",
       extension: extJwt(),
+    },
+    {
+      source: "builtin",
+      origin: "veryfront/ext-observability-opentelemetry",
+      extension: extOpenTelemetry(),
     },
     {
       source: "builtin",


### PR DESCRIPTION
## Summary
- register ext-observability-opentelemetry as a builtin extension so hosted runtimes install the TracingExporter/metrics API bridge
- add a regression test proving the builtin list includes the observability extension and its contracts

## Verification
- deno test --no-check --allow-all src/extensions/builtin-extensions.test.ts
- deno task fmt:check
- deno task lint
- deno task lint:extension-capabilities
- deno task typecheck