### PR TITLE
Bump release version for OTEL metrics

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.908",
+  "version": "0.1.909",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.908";
+export const VERSION = "0.1.909";


### PR DESCRIPTION
## Summary
- bump veryfront-code release version to 0.1.909 after 0.1.908 was already published
- keep src/utils/version-constant.ts in sync with deno.json

## Verification
- deno task fmt:check
- deno task lint
- pre-push checks: format, lint, typecheck, unit tests (2203 passed)