### PR TITLE
Emit eval runtime metrics

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.909",
+  "version": "0.1.910",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/eval/runner.test.ts
+++ b/src/eval/runner.test.ts
@@ -5,13 +5,17 @@ import { datasets, evalAgent, metrics, runEval } from "veryfront/eval";
 import { createEvalReportExporterRegistry } from "veryfront/extensions/eval";
 import {
   _resetShimForTests,
+  type MetricsAPI,
   setGlobalActiveSpanAccessor,
+  setGlobalMetricsAPI,
   type Span,
 } from "../observability/tracing/api-shim.ts";
+import { metrics as runtimeMetrics } from "#veryfront/metrics";
 
 describe("eval/runner", () => {
   afterEach(() => {
     _resetShimForTests();
+    runtimeMetrics.__resetForTests();
   });
 
   it("runs an agent eval and summarizes metric results", async () => {
@@ -98,6 +102,80 @@ describe("eval/runner", () => {
     assertEquals(report.summary.passRate, 0);
     assertEquals(report.records[0]?.completed, false);
     assertEquals(report.records[0]?.error, "AG-UI request failed");
+  });
+
+  it("emits eval result and duration metrics through the runtime metrics API", async () => {
+    const counterCalls: unknown[] = [];
+    const histogramCalls: unknown[] = [];
+
+    setGlobalMetricsAPI({
+      getMeter() {
+        return {
+          createCounter(name: string) {
+            return {
+              add(value: number, attributes?: Record<string, unknown>) {
+                counterCalls.push({ name, value, attributes });
+              },
+            };
+          },
+          createHistogram(name: string) {
+            return {
+              record(value: number, attributes?: Record<string, unknown>) {
+                histogramCalls.push({ name, value, attributes });
+              },
+            };
+          },
+          createUpDownCounter() {
+            return { add() {} };
+          },
+          createObservableGauge() {
+            return { addCallback() {} };
+          },
+        };
+      },
+    } as MetricsAPI);
+
+    const definition = evalAgent({
+      id: "metrics-smoke-runtime",
+      target: "agent:researcher",
+      dataset: datasets.inline([
+        { id: "q1", input: "France capital?", reference: "Paris" },
+      ]),
+      metrics: [metrics.answer.contains({ text: "Paris" }).gate()],
+    });
+
+    await runEval(definition, {
+      adapters: {
+        agent: async () => ({ text: "Paris", durationMs: 1558 }),
+      },
+    });
+
+    assertEquals(counterCalls, [
+      {
+        name: "vf_eval_result_total",
+        value: 1,
+        attributes: {
+          eval_id: "metrics-smoke-runtime",
+          target_kind: "agent",
+          metric: "answer.contains",
+          family: "answer",
+          severity: "gate",
+          outcome: "pass",
+        },
+      },
+    ]);
+    assertEquals(histogramCalls, [
+      {
+        name: "vf_eval_duration_ms",
+        value: 1558,
+        attributes: {
+          eval_id: "metrics-smoke-runtime",
+          target_kind: "agent",
+          metric: "duration",
+          outcome: "pass",
+        },
+      },
+    ]);
   });
 
   it("exports completed reports through selected eval report exporters", async () => {

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -1,5 +1,6 @@
 import { createEvalCheckContext } from "./expect.ts";
 import { createEvalReport } from "./report.ts";
+import { metrics as runtimeMetrics } from "#veryfront/metrics";
 import {
   createEvalReportExporterRegistry,
   type EvalReportExportContext,
@@ -52,6 +53,74 @@ function isBlockingFailure(record: EvalRecord): boolean {
     !result.skipped && result.pass === false &&
     (result.severity === "gate" || result.severity === "budget")
   );
+}
+
+function recordPassed(record: EvalRecord): boolean {
+  if (!record.completed || record.error) return false;
+  return !isBlockingFailure(record);
+}
+
+function emitEvalRuntimeMetrics(report: ReturnType<typeof createEvalReport>): void {
+  const baseAttributes = {
+    eval_id: report.definitionId,
+    target_kind: report.targetKind,
+  };
+
+  for (const metric of report.summary.metrics) {
+    const common = {
+      ...baseAttributes,
+      metric: metric.name,
+      family: metric.family,
+      severity: metric.severity,
+    };
+    if (metric.passed > 0) {
+      runtimeMetrics.counter("vf_eval_result_total", metric.passed, {
+        ...common,
+        outcome: "pass",
+      });
+    }
+    if (metric.failed > 0) {
+      runtimeMetrics.counter("vf_eval_result_total", metric.failed, {
+        ...common,
+        outcome: "fail",
+      });
+    }
+    if (metric.skipped > 0) {
+      runtimeMetrics.counter("vf_eval_result_total", metric.skipped, {
+        ...common,
+        outcome: "skipped",
+      });
+    }
+  }
+
+  if (report.summary.metrics.length === 0) {
+    if (report.summary.passed > 0) {
+      runtimeMetrics.counter("vf_eval_result_total", report.summary.passed, {
+        ...baseAttributes,
+        metric: "record",
+        family: "record",
+        severity: "gate",
+        outcome: "pass",
+      });
+    }
+    if (report.summary.failed > 0) {
+      runtimeMetrics.counter("vf_eval_result_total", report.summary.failed, {
+        ...baseAttributes,
+        metric: "record",
+        family: "record",
+        severity: "gate",
+        outcome: "fail",
+      });
+    }
+  }
+
+  for (const record of report.records) {
+    runtimeMetrics.histogram("vf_eval_duration_ms", record.durationMs, {
+      ...baseAttributes,
+      metric: "duration",
+      outcome: recordPassed(record) ? "pass" : "fail",
+    });
+  }
 }
 
 function createMissingRegistryResults(exporterIds: string[]): EvalReportExportResult[] {
@@ -234,6 +303,7 @@ export async function runEval(
     startedAt,
     endedAt,
   });
+  emitEvalRuntimeMetrics(report);
   const exports = await exportEvalReport(report, options.export);
   return exports === undefined ? report : { ...report, exports };
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.909";
+export const VERSION = "0.1.910";


### PR DESCRIPTION
## Summary
- emit eval result counters and duration histograms from the eval runner
- add a regression test for the runtime metrics API calls
- bump package version to 0.1.910 so the main release can publish

## Test plan
- deno fmt --check deno.json src/eval/runner.ts src/eval/runner.test.ts src/utils/version-constant.ts
- deno lint src/eval/runner.ts src/eval/runner.test.ts src/utils/version-constant.ts
- deno test --no-check --allow-all src/eval/runner.test.ts
- deno task typecheck
- deno task lint
- git push pre-push checks: formatting, linting, typecheck, 2203 unit tests