### PR TITLE
Default preview metrics environment label

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.910",
+  "version": "0.1.911",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -148,6 +148,64 @@ describe("metrics public SDK", () => {
     ]);
   });
 
+  it("defaults preview metrics to the preview environment label", async () => {
+    const counterCalls: unknown[] = [];
+
+    setGlobalMetricsAPI({
+      getMeter() {
+        return {
+          createCounter(name: string) {
+            return {
+              add(value: number, attributes?: Record<string, unknown>) {
+                counterCalls.push({ name, value, attributes });
+              },
+            };
+          },
+          createHistogram() {
+            return { record() {} };
+          },
+          createUpDownCounter() {
+            return { add() {} };
+          },
+          createObservableGauge() {
+            return { addCallback() {} };
+          },
+        };
+      },
+    } as MetricsAPI);
+
+    await runWithRequestContext(
+      {
+        projectSlug: "demo-project",
+        projectId: "project-123",
+        token: "token",
+        productionMode: false,
+        branch: "main",
+      },
+      async () => {
+        metrics.counter("vf_eval_result_total", 1, {
+          metric: "answer.contains",
+          outcome: "pass",
+        });
+      },
+    );
+
+    assertEquals(counterCalls, [
+      {
+        name: "vf_eval_result_total",
+        value: 1,
+        attributes: {
+          project_id: "project-123",
+          project_slug: "demo-project",
+          environment: "preview",
+          branch: "main",
+          metric: "answer.contains",
+          outcome: "pass",
+        },
+      },
+    ]);
+  });
+
   it("records gauges through an observable callback", () => {
     let callback: ((result: ObservableResult) => void) | undefined;
     const observed: unknown[] = [];

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -56,8 +56,12 @@ function normalizeAttributes(attributes?: MetricAttributes): Record<string, Attr
   const context = getCurrentRequestContext();
   if (context?.projectId) normalized.project_id = context.projectId;
   if (context?.projectSlug) normalized.project_slug = context.projectSlug;
-  if (context?.environmentName) normalized.environment = context.environmentName;
-  if (context && !context.productionMode) normalized.branch = context.branch ?? "main";
+  if (context) {
+    const environmentName = context.environmentName ??
+      (!context.productionMode ? "preview" : undefined);
+    if (environmentName) normalized.environment = environmentName;
+    if (!context.productionMode) normalized.branch = context.branch ?? "main";
+  }
 
   return normalized;
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.910";
+export const VERSION = "0.1.911";


### PR DESCRIPTION
## Summary
- default runtime metrics to environment=preview when request context is preview but has no explicit environment name
- add regression coverage for preview metrics labels matching the Metrics panel filters
- bump package version to 0.1.911 for release/deploy

## Test plan
- deno test --no-check --allow-all src/metrics/index.test.ts src/eval/runner.test.ts
- deno fmt --check deno.json src/metrics/index.ts src/metrics/index.test.ts src/utils/version-constant.ts
- deno lint src/metrics/index.ts src/metrics/index.test.ts src/utils/version-constant.ts
- deno task typecheck
- deno task lint
- git push pre-push checks: formatting, linting, typecheck, 2203 unit tests