### PR TITLE
Export project metrics directly via OTLP

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.911",
+  "version": "0.1.912",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -248,4 +248,82 @@ describe("metrics public SDK", () => {
     metrics.histogram("vf_missing_provider_ms", 1);
     metrics.gauge("vf_missing_provider_gauge", 1);
   });
+
+  it("exports project metrics directly to OTLP when configured", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+
+    Deno.env.set("OTEL_METRICS_ENABLED", "true");
+    Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.example/otlp");
+    Deno.env.set("OTEL_EXPORTER_OTLP_HEADERS", "Authorization=Basic secret");
+    Deno.env.set("OTEL_SERVICE_NAME", "veryfront-server");
+
+    globalThis.fetch = ((url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init });
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as typeof fetch;
+
+    try {
+      metrics.counter("vf_eval_result_total", 1, {
+        project_id: "project-123",
+        environment: "preview",
+        branch: "main",
+        metric: "answer.contains",
+        outcome: "pass",
+      });
+      await (metrics as unknown as { __flushForTests(): Promise<void> }).__flushForTests();
+    } finally {
+      globalThis.fetch = originalFetch;
+      Deno.env.delete("OTEL_METRICS_ENABLED");
+      Deno.env.delete("OTEL_EXPORTER_OTLP_ENDPOINT");
+      Deno.env.delete("OTEL_EXPORTER_OTLP_HEADERS");
+      Deno.env.delete("OTEL_SERVICE_NAME");
+    }
+
+    assertEquals(requests.length, 1);
+    assertEquals(requests[0]?.url, "https://collector.example/otlp/v1/metrics");
+    assertEquals(
+      (requests[0]?.init?.headers as Record<string, string>).Authorization,
+      "Basic secret",
+    );
+
+    const body = JSON.parse(String(requests[0]?.init?.body));
+    const metric = body.resourceMetrics[0].scopeMetrics[0].metrics[0];
+    assertEquals(metric.name, "vf_eval_result_total");
+    assertEquals(metric.sum.isMonotonic, true);
+    assertEquals(metric.sum.dataPoints[0].asDouble, 1);
+    assertEquals(
+      metric.sum.dataPoints[0].attributes.find((attr: { key: string }) => attr.key === "project_id")
+        .value.stringValue,
+      "project-123",
+    );
+  });
+
+  it("exports gauges directly even when no SDK meter is installed", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+
+    Deno.env.set("OTEL_METRICS_ENABLED", "true");
+    Deno.env.set("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "https://collector.example/v1/metrics");
+
+    globalThis.fetch = ((url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init });
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as typeof fetch;
+
+    try {
+      metrics.gauge("vf_queue_depth", 3, { project_id: "project-123" });
+      await (metrics as unknown as { __flushForTests(): Promise<void> }).__flushForTests();
+    } finally {
+      globalThis.fetch = originalFetch;
+      Deno.env.delete("OTEL_METRICS_ENABLED");
+      Deno.env.delete("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
+    }
+
+    assertEquals(requests.length, 1);
+    const body = JSON.parse(String(requests[0]?.init?.body));
+    const metric = body.resourceMetrics[0].scopeMetrics[0].metrics[0];
+    assertEquals(metric.name, "vf_queue_depth");
+    assertEquals(metric.gauge.dataPoints[0].asDouble, 3);
+  });
 });

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -35,12 +35,29 @@ interface GaugeSample {
   attributes: Record<string, AttributeValue>;
 }
 
+type DirectMetricKind = "counter" | "histogram" | "gauge";
+
+interface DirectMetricSample {
+  kind: DirectMetricKind;
+  name: string;
+  value: number;
+  attributes: Record<string, AttributeValue>;
+  timestampUnixNano: string;
+}
+
 const counters = new Map<string, Counter>();
 const histograms = new Map<string, Histogram>();
 const gauges = new Map<
   string,
   { instrument: ObservableGauge; samples: Map<string, GaugeSample> }
 >();
+const directQueue: DirectMetricSample[] = [];
+const directCounterTotals = new Map<string, { value: number; startTimeUnixNano: string }>();
+let directFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
+const DIRECT_FLUSH_DELAY_MS = 1_000;
+const DIRECT_MAX_BATCH_SIZE = 100;
+const HISTOGRAM_BOUNDS = [0, 10, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000];
 
 function getMeter() {
   return getGlobalMetricsAPI()?.getMeter("veryfront.project.metrics");
@@ -118,13 +135,229 @@ function getGauge(name: string, options?: MetricInstrumentOptions) {
   return gauge;
 }
 
+function readEnv(name: string): string | undefined {
+  try {
+    return Deno.env.get(name);
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveOtlpMetricsUrl(): string | null {
+  if (readEnv("OTEL_METRICS_ENABLED") !== "true") return null;
+  const endpoint = readEnv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT") ??
+    readEnv("OTEL_EXPORTER_OTLP_ENDPOINT");
+  if (!endpoint) return null;
+  const trimmed = endpoint.replace(/\/$/, "");
+  return trimmed.endsWith("/v1/metrics") ? trimmed : `${trimmed}/v1/metrics`;
+}
+
+function parseHeaders(headerInput: string | undefined): Record<string, string> {
+  if (!headerInput) return {};
+  if (headerInput.startsWith("Basic ")) return { Authorization: headerInput };
+  if (headerInput.startsWith("Authorization=")) {
+    return { Authorization: headerInput.slice("Authorization=".length) };
+  }
+
+  const result: Record<string, string> = {};
+  for (const part of headerInput.split(",")) {
+    const [key, ...valueParts] = part.split("=");
+    if (key && valueParts.length > 0) {
+      result[key.trim()] = valueParts.join("=").trim();
+    }
+  }
+  return result;
+}
+
+function toOtlpValue(value: AttributeValue) {
+  if (typeof value === "boolean") return { boolValue: value };
+  if (typeof value === "number") return { doubleValue: value };
+  return { stringValue: String(value) };
+}
+
+function toOtlpAttributes(attributes: Record<string, AttributeValue>) {
+  return Object.entries(attributes).map(([key, value]) => ({
+    key,
+    value: toOtlpValue(value),
+  }));
+}
+
+function getUnixNanoTimestamp(): string {
+  return String(BigInt(Date.now()) * 1_000_000n);
+}
+
+function buildHistogramBuckets(value: number): number[] {
+  const counts = new Array(HISTOGRAM_BOUNDS.length + 1).fill(0);
+  const bucketIndex = HISTOGRAM_BOUNDS.findIndex((bound) => value <= bound);
+  counts[bucketIndex === -1 ? counts.length - 1 : bucketIndex] = 1;
+  return counts;
+}
+
+function buildDirectMetric(sample: DirectMetricSample) {
+  const attributes = toOtlpAttributes(sample.attributes);
+  if (sample.kind === "counter") {
+    const key = `${sample.name}:${attributesKey(sample.attributes)}`;
+    const total = directCounterTotals.get(key) ?? {
+      value: 0,
+      startTimeUnixNano: sample.timestampUnixNano,
+    };
+    total.value += sample.value;
+    directCounterTotals.set(key, total);
+
+    return {
+      name: sample.name,
+      sum: {
+        dataPoints: [{
+          attributes,
+          startTimeUnixNano: total.startTimeUnixNano,
+          timeUnixNano: sample.timestampUnixNano,
+          asDouble: total.value,
+        }],
+        aggregationTemporality: 2,
+        isMonotonic: true,
+      },
+    };
+  }
+
+  if (sample.kind === "histogram") {
+    return {
+      name: sample.name,
+      histogram: {
+        dataPoints: [{
+          attributes,
+          startTimeUnixNano: sample.timestampUnixNano,
+          timeUnixNano: sample.timestampUnixNano,
+          count: 1,
+          sum: sample.value,
+          explicitBounds: HISTOGRAM_BOUNDS,
+          bucketCounts: buildHistogramBuckets(sample.value),
+        }],
+        aggregationTemporality: 1,
+      },
+    };
+  }
+
+  return {
+    name: sample.name,
+    gauge: {
+      dataPoints: [{
+        attributes,
+        timeUnixNano: sample.timestampUnixNano,
+        asDouble: sample.value,
+      }],
+    },
+  };
+}
+
+function buildDirectOtlpBody(samples: DirectMetricSample[]) {
+  return {
+    resourceMetrics: [{
+      resource: {
+        attributes: toOtlpAttributes({
+          "service.name": readEnv("OTEL_SERVICE_NAME") ?? "veryfront",
+          "service.version": readEnv("VERYFRONT_VERSION") ??
+            readEnv("RELEASE_VERSION") ??
+            "unknown",
+        }),
+      },
+      scopeMetrics: [{
+        scope: {
+          name: "veryfront.project.metrics",
+        },
+        metrics: samples.map(buildDirectMetric),
+      }],
+    }],
+  };
+}
+
+function logDirectExportFailure(error: unknown): void {
+  if (readEnv("VERYFRONT_DEBUG") !== "1") return;
+  console.warn("[metrics] direct OTLP export failed", error);
+}
+
+async function flushDirectMetrics(): Promise<void> {
+  if (directFlushTimer) {
+    clearTimeout(directFlushTimer);
+    directFlushTimer = null;
+  }
+
+  const url = resolveOtlpMetricsUrl();
+  if (!url || directQueue.length === 0) {
+    directQueue.length = 0;
+    return;
+  }
+
+  const batch = directQueue.splice(0, DIRECT_MAX_BATCH_SIZE);
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        ...parseHeaders(readEnv("OTEL_EXPORTER_OTLP_HEADERS")),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(buildDirectOtlpBody(batch)),
+    });
+    if (!response.ok) {
+      logDirectExportFailure(`HTTP ${response.status}`);
+    }
+  } catch (error) {
+    logDirectExportFailure(error);
+  }
+
+  if (directQueue.length > 0) {
+    scheduleDirectFlush();
+  }
+}
+
+function scheduleDirectFlush(): void {
+  if (directFlushTimer || resolveOtlpMetricsUrl() === null) return;
+  directFlushTimer = setTimeout(() => {
+    void flushDirectMetrics();
+  }, DIRECT_FLUSH_DELAY_MS);
+  try {
+    if (typeof directFlushTimer === "number") {
+      Deno.unrefTimer(directFlushTimer);
+    } else {
+      (directFlushTimer as { unref?: () => void }).unref?.();
+    }
+  } catch {
+    // Some runtimes do not expose unref support; exporting still works there.
+  }
+}
+
+function enqueueDirectMetric(
+  kind: DirectMetricKind,
+  name: string,
+  value: number,
+  attributes: Record<string, AttributeValue>,
+): void {
+  if (resolveOtlpMetricsUrl() === null) return;
+  directQueue.push({
+    kind,
+    name,
+    value,
+    attributes,
+    timestampUnixNano: getUnixNanoTimestamp(),
+  });
+  if (directQueue.length >= DIRECT_MAX_BATCH_SIZE) {
+    void flushDirectMetrics();
+    return;
+  }
+  scheduleDirectFlush();
+}
+
 export function counter(
   name: string,
   value = 1,
   attributes?: MetricAttributes,
   options?: MetricInstrumentOptions,
 ): void {
-  getCounter(name, options)?.add(value, normalizeAttributes(attributes));
+  const normalizedAttributes = normalizeAttributes(attributes);
+  if (resolveOtlpMetricsUrl() === null) {
+    getCounter(name, options)?.add(value, normalizedAttributes);
+    return;
+  }
+  enqueueDirectMetric("counter", name, value, normalizedAttributes);
 }
 
 export function histogram(
@@ -133,7 +366,12 @@ export function histogram(
   attributes?: MetricAttributes,
   options?: MetricInstrumentOptions,
 ): void {
-  getHistogram(name, options)?.record(value, normalizeAttributes(attributes));
+  const normalizedAttributes = normalizeAttributes(attributes);
+  if (resolveOtlpMetricsUrl() === null) {
+    getHistogram(name, options)?.record(value, normalizedAttributes);
+    return;
+  }
+  enqueueDirectMetric("histogram", name, value, normalizedAttributes);
 }
 
 export function gauge(
@@ -143,6 +381,10 @@ export function gauge(
   options?: MetricInstrumentOptions,
 ): void {
   const normalizedAttributes = normalizeAttributes(attributes);
+  if (resolveOtlpMetricsUrl() !== null) {
+    enqueueDirectMetric("gauge", name, value, normalizedAttributes);
+    return;
+  }
   const target = getGauge(name, options);
   if (!target) return;
 
@@ -156,9 +398,18 @@ export const metrics = {
   counter,
   histogram,
   gauge,
+  async __flushForTests(): Promise<void> {
+    await flushDirectMetrics();
+  },
   __resetForTests(): void {
     counters.clear();
     histograms.clear();
     gauges.clear();
+    directQueue.length = 0;
+    directCounterTotals.clear();
+    if (directFlushTimer) {
+      clearTimeout(directFlushTimer);
+      directFlushTimer = null;
+    }
   },
 };

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.911";
+export const VERSION = "0.1.912";


### PR DESCRIPTION
## Summary
- add a direct OTLP JSON export path for project metrics when OTEL metrics env vars are configured
- keep SDK meter recording as the fallback when direct OTLP is not configured
- bump Veryfront to 0.1.912

## Verification
- deno test --no-check --allow-all src/metrics/index.test.ts
- deno fmt --check src/metrics/index.ts src/metrics/index.test.ts deno.json src/utils/version-constant.ts
- deno lint src/metrics/index.ts src/metrics/index.test.ts
- deno task typecheck
- deno task lint