### PR TITLE
Route hosted project metrics through API proxy

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.912",
+  "version": "0.1.913",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -299,6 +299,46 @@ describe("metrics public SDK", () => {
     );
   });
 
+  it("routes hosted project metrics through the internal API proxy", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+
+    Deno.env.set("OTEL_METRICS_ENABLED", "true");
+    Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.example/otlp");
+    Deno.env.set("OTEL_EXPORTER_OTLP_HEADERS", "Authorization=Basic external-secret");
+    Deno.env.set("VERYFRONT_API_BASE_URL", "http://veryfront-api:80");
+    Deno.env.set("VERYFRONT_API_INTERNAL_USER", "internal-user");
+    Deno.env.set("VERYFRONT_API_INTERNAL_PASS", "internal-pass");
+
+    globalThis.fetch = ((url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init });
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as typeof fetch;
+
+    try {
+      metrics.counter("vf_eval_result_total", 1, { project_id: "project-123" });
+      await (metrics as unknown as { __flushForTests(): Promise<void> }).__flushForTests();
+    } finally {
+      globalThis.fetch = originalFetch;
+      Deno.env.delete("OTEL_METRICS_ENABLED");
+      Deno.env.delete("OTEL_EXPORTER_OTLP_ENDPOINT");
+      Deno.env.delete("OTEL_EXPORTER_OTLP_HEADERS");
+      Deno.env.delete("VERYFRONT_API_BASE_URL");
+      Deno.env.delete("VERYFRONT_API_INTERNAL_USER");
+      Deno.env.delete("VERYFRONT_API_INTERNAL_PASS");
+    }
+
+    assertEquals(requests.length, 1);
+    assertEquals(
+      requests[0]?.url,
+      "http://veryfront-api:80/internal/metrics/otlp/v1/metrics",
+    );
+    assertEquals(
+      (requests[0]?.init?.headers as Record<string, string>).Authorization,
+      "Basic aW50ZXJuYWwtdXNlcjppbnRlcm5hbC1wYXNz",
+    );
+  });
+
   it("exports gauges directly even when no SDK meter is installed", async () => {
     const originalFetch = globalThis.fetch;
     const requests: Array<{ url: string; init?: RequestInit }> = [];

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -45,6 +45,11 @@ interface DirectMetricSample {
   timestampUnixNano: string;
 }
 
+interface DirectMetricsTarget {
+  url: string;
+  headers: Record<string, string>;
+}
+
 const counters = new Map<string, Counter>();
 const histograms = new Map<string, Histogram>();
 const gauges = new Map<
@@ -152,6 +157,20 @@ function resolveOtlpMetricsUrl(): string | null {
   return trimmed.endsWith("/v1/metrics") ? trimmed : `${trimmed}/v1/metrics`;
 }
 
+function resolveInternalMetricsUrl(): string | null {
+  if (readEnv("OTEL_METRICS_ENABLED") !== "true") return null;
+  const apiBaseUrl = readEnv("VERYFRONT_API_BASE_URL") ?? readEnv("VERYFRONT_API_URL");
+  const username = readEnv("VERYFRONT_API_INTERNAL_USER");
+  const password = readEnv("VERYFRONT_API_INTERNAL_PASS");
+  if (!apiBaseUrl || !username || !password) return null;
+  return `${apiBaseUrl.replace(/\/$/, "")}/internal/metrics/otlp/v1/metrics`;
+}
+
+function buildBasicAuth(username: string, password: string): string {
+  const credentials = `${username}:${password}`;
+  return `Basic ${globalThis.btoa(credentials)}`;
+}
+
 function parseHeaders(headerInput: string | undefined): Record<string, string> {
   if (!headerInput) return {};
   if (headerInput.startsWith("Basic ")) return { Authorization: headerInput };
@@ -167,6 +186,28 @@ function parseHeaders(headerInput: string | undefined): Record<string, string> {
     }
   }
   return result;
+}
+
+function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
+  const internalUrl = resolveInternalMetricsUrl();
+  if (internalUrl) {
+    return {
+      url: internalUrl,
+      headers: {
+        Authorization: buildBasicAuth(
+          readEnv("VERYFRONT_API_INTERNAL_USER") ?? "",
+          readEnv("VERYFRONT_API_INTERNAL_PASS") ?? "",
+        ),
+      },
+    };
+  }
+
+  const otlpUrl = resolveOtlpMetricsUrl();
+  if (!otlpUrl) return null;
+  return {
+    url: otlpUrl,
+    headers: parseHeaders(readEnv("OTEL_EXPORTER_OTLP_HEADERS")),
+  };
 }
 
 function toOtlpValue(value: AttributeValue) {
@@ -281,18 +322,18 @@ async function flushDirectMetrics(): Promise<void> {
     directFlushTimer = null;
   }
 
-  const url = resolveOtlpMetricsUrl();
-  if (!url || directQueue.length === 0) {
+  const target = resolveDirectMetricsTarget();
+  if (!target || directQueue.length === 0) {
     directQueue.length = 0;
     return;
   }
 
   const batch = directQueue.splice(0, DIRECT_MAX_BATCH_SIZE);
   try {
-    const response = await fetch(url, {
+    const response = await fetch(target.url, {
       method: "POST",
       headers: {
-        ...parseHeaders(readEnv("OTEL_EXPORTER_OTLP_HEADERS")),
+        ...target.headers,
         "Content-Type": "application/json",
       },
       body: JSON.stringify(buildDirectOtlpBody(batch)),
@@ -310,7 +351,7 @@ async function flushDirectMetrics(): Promise<void> {
 }
 
 function scheduleDirectFlush(): void {
-  if (directFlushTimer || resolveOtlpMetricsUrl() === null) return;
+  if (directFlushTimer || resolveDirectMetricsTarget() === null) return;
   directFlushTimer = setTimeout(() => {
     void flushDirectMetrics();
   }, DIRECT_FLUSH_DELAY_MS);
@@ -331,7 +372,7 @@ function enqueueDirectMetric(
   value: number,
   attributes: Record<string, AttributeValue>,
 ): void {
-  if (resolveOtlpMetricsUrl() === null) return;
+  if (resolveDirectMetricsTarget() === null) return;
   directQueue.push({
     kind,
     name,
@@ -353,7 +394,7 @@ export function counter(
   options?: MetricInstrumentOptions,
 ): void {
   const normalizedAttributes = normalizeAttributes(attributes);
-  if (resolveOtlpMetricsUrl() === null) {
+  if (resolveDirectMetricsTarget() === null) {
     getCounter(name, options)?.add(value, normalizedAttributes);
     return;
   }
@@ -367,7 +408,7 @@ export function histogram(
   options?: MetricInstrumentOptions,
 ): void {
   const normalizedAttributes = normalizeAttributes(attributes);
-  if (resolveOtlpMetricsUrl() === null) {
+  if (resolveDirectMetricsTarget() === null) {
     getHistogram(name, options)?.record(value, normalizedAttributes);
     return;
   }
@@ -381,7 +422,7 @@ export function gauge(
   options?: MetricInstrumentOptions,
 ): void {
   const normalizedAttributes = normalizeAttributes(attributes);
-  if (resolveOtlpMetricsUrl() !== null) {
+  if (resolveDirectMetricsTarget() !== null) {
     enqueueDirectMetric("gauge", name, value, normalizedAttributes);
     return;
   }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.912";
+export const VERSION = "0.1.913";


### PR DESCRIPTION
## Summary
- route hosted runtime project metrics to the Veryfront API internal OTLP proxy when internal API credentials are present
- keep the direct OTLP exporter path as a fallback for local/dedicated deployments
- bump veryfront to 0.1.913

## Why
Shared renderer environments intentionally do not have direct external egress to Grafana OTLP. Project metrics should go through the API boundary so telemetry credentials and environment-specific exporter configuration stay centralized.

## Verification
- deno test --no-check --allow-all src/metrics/index.test.ts
- deno fmt --check src/metrics/index.ts src/metrics/index.test.ts deno.json src/utils/version-constant.ts
- deno lint src/metrics/index.ts src/metrics/index.test.ts
- deno task typecheck
- deno task lint