### PR TITLE
Export direct histograms with cumulative temporality

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.913",
+  "version": "0.1.914",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -339,6 +339,45 @@ describe("metrics public SDK", () => {
     );
   });
 
+  it("exports direct histograms with cumulative temporality", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+
+    Deno.env.set("OTEL_METRICS_ENABLED", "true");
+    Deno.env.set("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "https://collector.example/v1/metrics");
+
+    globalThis.fetch = ((url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init });
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as typeof fetch;
+
+    try {
+      metrics.histogram("vf_eval_duration_ms", 42, { project_id: "project-123" });
+      metrics.histogram("vf_eval_duration_ms", 120, { project_id: "project-123" });
+      await (metrics as unknown as { __flushForTests(): Promise<void> }).__flushForTests();
+    } finally {
+      globalThis.fetch = originalFetch;
+      Deno.env.delete("OTEL_METRICS_ENABLED");
+      Deno.env.delete("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
+    }
+
+    assertEquals(requests.length, 1);
+    const body = JSON.parse(String(requests[0]?.init?.body));
+    const emittedMetrics = body.resourceMetrics[0].scopeMetrics[0].metrics;
+    const metric = emittedMetrics.at(-1);
+    assertEquals(metric.name, "vf_eval_duration_ms");
+    assertEquals(metric.histogram.aggregationTemporality, 2);
+    assertEquals(metric.histogram.dataPoints[0].count, 2);
+    assertEquals(metric.histogram.dataPoints[0].sum, 162);
+    assertEquals(
+      metric.histogram.dataPoints[0].bucketCounts.reduce(
+        (sum: number, count: number) => sum + count,
+        0,
+      ),
+      2,
+    );
+  });
+
   it("exports gauges directly even when no SDK meter is installed", async () => {
     const originalFetch = globalThis.fetch;
     const requests: Array<{ url: string; init?: RequestInit }> = [];

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -58,6 +58,15 @@ const gauges = new Map<
 >();
 const directQueue: DirectMetricSample[] = [];
 const directCounterTotals = new Map<string, { value: number; startTimeUnixNano: string }>();
+const directHistogramTotals = new Map<
+  string,
+  {
+    count: number;
+    sum: number;
+    bucketCounts: number[];
+    startTimeUnixNano: string;
+  }
+>();
 let directFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
 const DIRECT_FLUSH_DELAY_MS = 1_000;
@@ -261,19 +270,32 @@ function buildDirectMetric(sample: DirectMetricSample) {
   }
 
   if (sample.kind === "histogram") {
+    const key = `${sample.name}:${attributesKey(sample.attributes)}`;
+    const total = directHistogramTotals.get(key) ?? {
+      count: 0,
+      sum: 0,
+      bucketCounts: new Array(HISTOGRAM_BOUNDS.length + 1).fill(0),
+      startTimeUnixNano: sample.timestampUnixNano,
+    };
+    const sampleBuckets = buildHistogramBuckets(sample.value);
+    total.count += 1;
+    total.sum += sample.value;
+    total.bucketCounts = total.bucketCounts.map((count, index) => count + sampleBuckets[index]);
+    directHistogramTotals.set(key, total);
+
     return {
       name: sample.name,
       histogram: {
         dataPoints: [{
           attributes,
-          startTimeUnixNano: sample.timestampUnixNano,
+          startTimeUnixNano: total.startTimeUnixNano,
           timeUnixNano: sample.timestampUnixNano,
-          count: 1,
-          sum: sample.value,
+          count: total.count,
+          sum: total.sum,
           explicitBounds: HISTOGRAM_BOUNDS,
-          bucketCounts: buildHistogramBuckets(sample.value),
+          bucketCounts: total.bucketCounts,
         }],
-        aggregationTemporality: 1,
+        aggregationTemporality: 2,
       },
     };
   }
@@ -448,6 +470,7 @@ export const metrics = {
     gauges.clear();
     directQueue.length = 0;
     directCounterTotals.clear();
+    directHistogramTotals.clear();
     if (directFlushTimer) {
       clearTimeout(directFlushTimer);
       directFlushTimer = null;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.913";
+export const VERSION = "0.1.914";


### PR DESCRIPTION
## Summary
- export direct OTLP histograms as cumulative points instead of delta points
- accumulate histogram count, sum, and bucket counts per metric/label set
- bump package version to 0.1.914

## Root cause
Staging eval metrics reached the API-owned internal OTLP proxy, but Grafana/Mimir rejected `vf_eval_duration_ms` with `invalid temporality and type combination`. The direct runtime encoder emitted histogram data with delta temporality.

## Verification
- `deno test --no-check --allow-all src/metrics/index.test.ts`
- `deno fmt --check src/metrics/index.ts src/metrics/index.test.ts deno.json src/utils/version-constant.ts`
- `deno lint src/metrics/index.ts src/metrics/index.test.ts`
- `deno task typecheck`
- `deno task lint`
- pre-push hook: full format/lint/typecheck and unit suite, 2203 passed
