### PR TITLE
Release veryfront 0.1.915 eval report artifacts

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.908",
+  "version": "0.1.909",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.907",
+  "version": "0.1.908",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -131,6 +131,7 @@ function createDeps(
       records: [],
     }),
     createEvalAgentAdapter: () => async () => ({ text: "Paris" }),
+    uploadEvalReport: async () => null,
     executeKnowledgeIngest: async () => ({
       success: true,
       result: { kind: "knowledge_ingest", summary: { ingested_count: 1 } },
@@ -406,6 +407,59 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     assertEquals(receivedEnvironmentId, "env-1");
     assertEquals(receivedProjectIdHeader, "proj-1");
     assertEquals(receivedBranchName, "main");
+  });
+
+  it("returns an eval report artifact path when report upload succeeds", async () => {
+    const report: EvalReport = {
+      kind: "eval-report",
+      runId: "run_eval_report_artifact",
+      definitionId: "eval:deep-research",
+      targetKind: "agent",
+      target: "agent:researcher",
+      startedAt: "2026-06-20T10:00:00.000Z",
+      endedAt: "2026-06-20T10:00:01.000Z",
+      summary: { records: 1, passed: 1, failed: 0, passRate: 1, metrics: [] },
+      records: [],
+    };
+    const reportPath = "evals/reports/deep-research/run_eval_report_artifact.json";
+    let receivedReport: EvalReport | undefined;
+    let receivedProjectReference: string | undefined;
+    let receivedReportPath: string | undefined;
+    const handler = new ProjectRunExecuteHandler(createDeps({
+      runEval: async () => report,
+      uploadEvalReport: async (input) => {
+        receivedReport = input.report;
+        receivedProjectReference = input.projectReference;
+        receivedReportPath = input.reportPath;
+        return input.reportPath;
+      },
+    }));
+    const body = {
+      runId: "run_eval_report_artifact",
+      kind: "eval",
+      target: "eval:deep-research",
+      projectId: "proj-1",
+    };
+    const { request, publicKeyPem } = await signedRequest(
+      "/api/control-plane/runs/run_eval_report_artifact/execute",
+      body,
+      { "x-token": "runtime-token" },
+    );
+
+    const result = await handler.handle(request, createCtx(publicKeyPem));
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(await result.response.json(), {
+      success: true,
+      result: { ...report, reportPath },
+      artifacts: [{ kind: "eval-report", path: reportPath, contentType: "application/json" }],
+      duration_ms: 0,
+      logs: null,
+    });
+    assertEquals(receivedReport, report);
+    assertEquals(receivedProjectReference, "demo-project");
+    assertEquals(receivedReportPath, reportPath);
   });
 
   it("uses the local AG-UI adapter endpoint when the runtime endpoint is local", async () => {

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -67,6 +67,15 @@ export interface ProjectRunExecuteResponse {
   artifacts?: unknown[];
 }
 
+interface EvalReportUploadInput {
+  request: ProjectRunExecuteRequest;
+  ctx: HandlerContext;
+  req: Request;
+  report: EvalReport;
+  projectReference: string;
+  reportPath: string;
+}
+
 interface WorkflowRunView {
   status: string;
   output?: unknown;
@@ -124,6 +133,7 @@ export interface ProjectRunExecuteHandlerDeps {
   ): WorkflowClientView | Promise<WorkflowClientView>;
   runEval(definition: EvalDefinition, options: RunEvalOptions): Promise<EvalReport>;
   createEvalAgentAdapter(config: AgentServiceEvalAdapterConfig): EvalAgentAdapter;
+  uploadEvalReport(input: EvalReportUploadInput): Promise<string | null>;
   ensureProjectDiscovery(ctx: HandlerContext): Promise<void>;
   executeKnowledgeIngest(input: {
     request: ProjectRunExecuteRequest;
@@ -194,6 +204,25 @@ function parseExecuteRequest(value: unknown, pathRunId: string): ProjectRunExecu
     config: parseRecord(value.config),
     input: parseRecord(value.input),
   };
+}
+
+function sanitizePathSegment(value: string, fallback: string): string {
+  const normalized = value
+    .replace(/^eval:/, "")
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 120);
+  return normalized || fallback;
+}
+
+function buildEvalReportPath(report: EvalReport, request: ProjectRunExecuteRequest): string {
+  const evalId = sanitizePathSegment(report.definitionId || request.target, "eval");
+  const runId = sanitizePathSegment(request.runId, "run");
+  return `evals/reports/${evalId}/${runId}.json`;
+}
+
+function createEvalReportArtifact(path: string): Record<string, string> {
+  return { kind: "eval-report", path, contentType: "application/json" };
 }
 
 function getRunId(pathname: string): string | null {
@@ -606,6 +635,20 @@ function createRuntimeApiClient(req: Request, ctx: HandlerContext): RuntimeApiCl
   };
 }
 
+async function uploadEvalReportToProjectFiles(
+  input: EvalReportUploadInput,
+): Promise<string | null> {
+  const client = createRuntimeApiClient(input.req, input.ctx);
+  const encodedProject = encodeURIComponent(input.projectReference);
+  const encodedPath = encodeURIComponent(input.reportPath);
+  const reportWithPath = { ...input.report, reportPath: input.reportPath };
+  const response = await client.put<{ path?: string }>(
+    `/projects/${encodedProject}/files/${encodedPath}`,
+    { content: `${JSON.stringify(reportWithPath, null, 2)}\n` },
+  );
+  return response.path ?? input.reportPath;
+}
+
 function getStringArrayConfig(
   config: Record<string, unknown>,
   keys: readonly string[],
@@ -940,12 +983,28 @@ async function executeEvalRun(
     runId: request.runId,
   });
   const failed = Math.max(report.summary.failed, countFailedEvalRecords(report));
+  const projectReference = ctx.projectSlug ?? request.projectId;
+  const requestedReportPath = buildEvalReportPath(report, request);
+  let uploadError: string | null = null;
+  const reportPath = await deps.uploadEvalReport({
+    request,
+    ctx,
+    req,
+    report,
+    projectReference,
+    reportPath: requestedReportPath,
+  }).catch((error) => {
+    uploadError = `Eval report upload failed: ${errorMessage(error)}`;
+    return null;
+  });
+  const result = reportPath ? { ...report, reportPath } : report;
 
   return {
     success: failed === 0,
-    result: report,
+    result,
+    ...(reportPath ? { artifacts: [createEvalReportArtifact(reportPath)] } : {}),
     ...(failed > 0 ? { error: `${failed} eval record${failed === 1 ? "" : "s"} failed` } : {}),
-    logs: null,
+    logs: uploadError,
     duration_ms: Math.max(0, deps.now() - startedAt),
   };
 }
@@ -1057,6 +1116,7 @@ const defaultDeps: ProjectRunExecuteHandlerDeps = {
   createWorkflowClient: createRuntimeWorkflowClient,
   runEval,
   createEvalAgentAdapter: createAgentServiceEvalAdapter,
+  uploadEvalReport: uploadEvalReportToProjectFiles,
   ensureProjectDiscovery,
   executeKnowledgeIngest: executeKnowledgeIngestRun,
   executeReleaseAssetBuild: executeReleaseAssetBuildRun,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.907";
+export const VERSION = "0.1.908";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.908";
+export const VERSION = "0.1.909";


### PR DESCRIPTION
## Summary
- Persist completed eval run reports as JSON project-file artifacts under evals/reports/<eval>/<run>.json.
- Return the persisted eval report artifact path in project run execution output for Studio history/report viewing.
- Bump veryfront package metadata to 0.1.915 because main is already at 0.1.914.

## Verification
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- deno test --no-check --allow-all src/eval src/server/handlers/request/project-run-execute.handler.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts src/server/handlers/request/project-run-execute.handler.ts src/server/handlers/request/project-run-execute.handler.test.ts
- deno lint src/utils/version-constant.ts src/server/handlers/request/project-run-execute.handler.ts src/server/handlers/request/project-run-execute.handler.test.ts
- deno check src/utils/version-constant.ts src/server/handlers/request/project-run-execute.handler.ts src/server/handlers/request/project-run-execute.handler.test.ts
- git diff --check
- pre-push hook before main merge: format, lint, typecheck, unit tests, 2203 passed, 18879 steps, 0 failed
- pre-push hook after main merge: format, lint, typecheck, unit tests, 2203 passed, 18886 steps, 0 failed