### PR TITLE
Keep eval provider billing distinct from user credits

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.915",
+  "version": "0.1.916",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/chat/provider-errors.test.ts
+++ b/src/chat/provider-errors.test.ts
@@ -78,6 +78,34 @@ describe("chat/provider-errors", () => {
     );
   });
 
+  it("classifies upstream provider billing failures separately from user credits", () => {
+    const expected = {
+      code: "AI_PROVIDER_BILLING_ERROR",
+      message:
+        "The configured AI provider account cannot process this request. Try a different model, or ask an administrator to check provider billing.",
+      status: 502,
+    };
+
+    assertEquals(
+      parseProviderError({
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          message:
+            "Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.",
+        },
+      }),
+      expected,
+    );
+
+    assertEquals(
+      parseProviderError(
+        'veryfront-cloud request failed: {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."},"request_id":"req_test"}',
+      ),
+      expected,
+    );
+  });
+
   it("classifies unsupported assistant prefill provider rejections as model capability errors", () => {
     const expected = {
       code: "MODEL_UNSUPPORTED_ASSISTANT_PREFILL",

--- a/src/chat/provider-errors.ts
+++ b/src/chat/provider-errors.ts
@@ -29,6 +29,13 @@ const AI_PROVIDER_SPEND_LIMIT_ERROR = {
   status: 402,
 } as const;
 
+const AI_PROVIDER_BILLING_ERROR = {
+  code: "AI_PROVIDER_BILLING_ERROR",
+  message:
+    "The configured AI provider account cannot process this request. Try a different model, or ask an administrator to check provider billing.",
+  status: 502,
+} as const;
+
 function isErrorRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -117,6 +124,20 @@ function isAssistantPrefillUnsupportedMessage(message: string): boolean {
   return mentionsAssistantPrefill && rejectsAssistantPrefill;
 }
 
+function isProviderBillingMessage(normalizedMessage: string): boolean {
+  const mentionsProviderApi = normalizedMessage.includes("anthropic api") ||
+    normalizedMessage.includes("openai api") ||
+    normalizedMessage.includes("google api") ||
+    normalizedMessage.includes("mistral api");
+  const mentionsProviderBilling = normalizedMessage.includes("plans & billing") ||
+    normalizedMessage.includes("provider billing") ||
+    normalizedMessage.includes("provider account");
+  const mentionsProviderCredits = normalizedMessage.includes("credit balance is too low") ||
+    normalizedMessage.includes("provider credits");
+
+  return mentionsProviderApi && mentionsProviderCredits && mentionsProviderBilling;
+}
+
 function parseKnownProviderBody(
   body: unknown,
   seen: WeakSet<object> = new WeakSet(),
@@ -171,10 +192,14 @@ function parseKnownProviderBody(
   }
 
   if (body.type === "invalid_request_error" && typeof body.message === "string") {
+    const normalizedMessage = body.message.toLowerCase();
+    if (isProviderBillingMessage(normalizedMessage)) {
+      return AI_PROVIDER_BILLING_ERROR;
+    }
     if (isAssistantPrefillUnsupportedMessage(body.message)) {
       return MODEL_UNSUPPORTED_ASSISTANT_PREFILL_ERROR;
     }
-    if (body.message.includes("too long")) {
+    if (normalizedMessage.includes("too long")) {
       return { code: "CONTEXT_LENGTH_EXCEEDED", message: "Conversation is too long" };
     }
   }
@@ -271,6 +296,9 @@ function parseProviderErrorInner(error: unknown, seen: WeakSet<object>): ParsedP
     const normalizedMessage = message.toLowerCase();
     if (isAssistantPrefillUnsupportedMessage(message)) {
       return MODEL_UNSUPPORTED_ASSISTANT_PREFILL_ERROR;
+    }
+    if (isProviderBillingMessage(normalizedMessage)) {
+      return AI_PROVIDER_BILLING_ERROR;
     }
     if (isCreditLimitMessage(normalizedMessage)) {
       return { code: "INSUFFICIENT_CREDITS", message: "Insufficient AI credits", status: 402 };

--- a/src/eval/agent-service.test.ts
+++ b/src/eval/agent-service.test.ts
@@ -6,6 +6,7 @@ import { datasets, evalAgent, metrics, runEval } from "veryfront/eval";
 import {
   buildAgentServiceEvalRequestBody,
   createAgentServiceEvalAdapter,
+  createLiveEvalCaseSupport,
   evaluateAgentServiceEvalEnvironment,
   evaluateRuntimeConfidenceEnv,
   resolveAgentServiceEvalEnvironment,
@@ -277,6 +278,53 @@ describe("eval/agent-service", () => {
     }]);
     assertEquals(record.metrics?.[0]?.pass, false);
     assertEquals(record.metrics?.[0]?.evidence, { failedTools: ["search"] });
+  });
+
+  it("forwards eval project and model context to optional LLM judge requests", async () => {
+    const requests: Array<{ body: Record<string, unknown>; headers: Record<string, string> }> = [];
+    const { judgeLlm } = createLiveEvalCaseSupport({
+      endpoint: "http://127.0.0.1:4311/api/ag-ui",
+      authToken: "token",
+      apiUrl: "https://api.example.test",
+      projectId: "project_123",
+      branchId: "branch_123",
+      model: "openai/gpt-5.5",
+      requestTimeoutMs: 240_000,
+      progressLogIntervalMs: 15_000,
+      enableLlmJudge: true,
+      fetch: async (_input, init) => {
+        requests.push({
+          body: JSON.parse(String(init?.body)),
+          headers: init?.headers as Record<string, string>,
+        });
+        return createSseResponse([
+          { event: "RunStarted", data: { runId: "run_judge" } },
+          { event: "TextMessageContent", data: { delta: "PASS enough evidence" } },
+          { event: "RunFinished", data: {} },
+        ]);
+      },
+    });
+
+    const result = await judgeLlm({
+      question: "What happened?",
+      answer: "The run used the gateway.",
+      criteria: "Pass if the answer identifies the gateway.",
+    });
+
+    assertEquals(result, { pass: true, reason: "PASS enough evidence" });
+    assertEquals(requests.length, 1);
+    assertEquals(requests[0]?.headers.Authorization, "Bearer token");
+    assertEquals(requests[0]?.body.forwardedProps, {
+      veryfront: {
+        projectId: "project_123",
+        branchId: "branch_123",
+        model: "openai/gpt-5.5",
+        runtimeOverrides: {
+          allowedTools: [],
+          maxSteps: 2,
+        },
+      },
+    });
   });
 
   it("exports the agent-service module from the public import map", async () => {

--- a/src/eval/agent-service/live-evals/runner.ts
+++ b/src/eval/agent-service/live-evals/runner.ts
@@ -104,7 +104,10 @@ function resolveFetch(config: Pick<LiveEvalRunnerConfig, "fetch">) {
 }
 
 function createLiveEvalJudgeSupport(
-  config: Pick<LiveEvalRunnerConfig, "endpoint" | "authToken" | "enableLlmJudge" | "fetch">,
+  config: Pick<
+    LiveEvalRunnerConfig,
+    "endpoint" | "authToken" | "projectId" | "branchId" | "model" | "enableLlmJudge" | "fetch"
+  >,
 ): {
   judgeLlm: (input: LiveEvalJudgeRequest) => Promise<LiveEvalJudgeResult>;
   withJudge: (
@@ -127,7 +130,9 @@ CRITERIA: ${input.criteria}
 Respond with exactly one line: PASS or FAIL followed by a brief reason.
 Example: "PASS — correctly explains the pattern with accurate details"
 Example: "FAIL — mentions the wrong file convention"`,
-        projectId: null,
+        projectId: config.projectId,
+        ...(config.branchId ? { branchId: config.branchId } : {}),
+        ...(config.model ? { model: config.model } : {}),
         allowedTools: [],
         forceRuntimeOverrides: true,
         maxSteps: 2,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.915";
+export const VERSION = "0.1.916";


### PR DESCRIPTION
## Summary
- classify upstream provider-account billing failures as provider billing errors instead of Veryfront user credit failures
- forward eval project, branch, and model context to optional LLM judge requests so gateway attribution stays aligned with the eval run
- bump veryfront package version to 0.1.916 for release

## Verification
- deno test --no-check --allow-all src/chat/provider-errors.test.ts src/eval/agent-service.test.ts src/utils/version.test.ts
- deno check src/chat/provider-errors.ts src/chat/provider-errors.test.ts src/eval/agent-service/live-evals/runner.ts src/eval/agent-service.test.ts src/utils/version-constant.ts src/utils/version.test.ts
- deno fmt --check deno.json src/chat/provider-errors.ts src/chat/provider-errors.test.ts src/eval/agent-service/live-evals/runner.ts src/eval/agent-service.test.ts src/utils/version-constant.ts src/utils/version.test.ts
- deno lint src/chat/provider-errors.ts src/chat/provider-errors.test.ts src/eval/agent-service/live-evals/runner.ts src/eval/agent-service.test.ts src/utils/version-constant.ts src/utils/version.test.ts
- pre-push hook: full fmt, lint, type check, and unit tests passed (2203 tests, 18888 steps)