### PR TITLE
Fix Opus 4.8 adaptive thinking options

### DIFF
--- a/src/provider/veryfront-cloud/model-catalog.test.ts
+++ b/src/provider/veryfront-cloud/model-catalog.test.ts
@@ -169,6 +169,26 @@ describe("provider/veryfront-cloud/model-catalog", () => {
     );
   });
 
+  it("maps Claude Opus 4.8 thinking overrides to adaptive provider options", () => {
+    assertEquals(
+      resolveVeryfrontCloudThinkingProviderOptions("anthropic/claude-opus-4-8", {
+        enabled: true,
+        budgetTokens: 2048,
+      }),
+      {
+        anthropic: {
+          thinking: {
+            type: "adaptive",
+            display: "summarized",
+          },
+          output_config: {
+            effort: "high",
+          },
+        },
+      },
+    );
+  });
+
   it("omits disabled, missing-budget, and non-Anthropic thinking options", () => {
     assertEquals(
       resolveVeryfrontCloudThinkingProviderOptions("anthropic/claude-sonnet-4-6", {

--- a/src/provider/veryfront-cloud/model-catalog.ts
+++ b/src/provider/veryfront-cloud/model-catalog.ts
@@ -29,6 +29,10 @@ const VERYFRONT_CLOUD_GATEWAY_MODEL_PROVIDER_PREFIXES = [
   "mistral/",
   "moonshotai/",
 ];
+const ANTHROPIC_ADAPTIVE_THINKING_ONLY_MODELS = new Set([
+  "anthropic/claude-opus-4-7",
+  "anthropic/claude-opus-4-8",
+]);
 
 export function isSupportedMistralModelId(modelId: string): boolean {
   return VERYFRONT_CLOUD_CHAT_MODELS.some((model) => model.modelId === modelId);
@@ -231,6 +235,21 @@ export function resolveVeryfrontCloudThinkingProviderOptions(
   const provider = getVeryfrontCloudProviderFromModelId(modelId);
   if (provider !== "anthropic") {
     return undefined;
+  }
+
+  const normalizedModelId = normalizeVeryfrontCloudModelId(modelId);
+  if (ANTHROPIC_ADAPTIVE_THINKING_ONLY_MODELS.has(normalizedModelId)) {
+    return {
+      anthropic: {
+        thinking: {
+          type: "adaptive",
+          display: "summarized",
+        },
+        output_config: {
+          effort: "high",
+        },
+      },
+    };
   }
 
   return {


### PR DESCRIPTION
## Summary
- map Claude Opus 4.8/4.7 thinking overrides to Anthropic adaptive thinking options
- avoid manual budget_tokens/temperature options for adaptive-only Opus models
- add a regression test for Opus 4.8 provider options

Refs veryfront-studio#5276.

## Verification
- deno test --allow-all src/provider/veryfront-cloud/model-catalog.test.ts src/agent/runtime/provider-transport.test.ts src/agent/runtime/default-provider-options.test.ts
- deno fmt --check src/provider/veryfront-cloud/model-catalog.ts src/provider/veryfront-cloud/model-catalog.test.ts

Note: the full local pre-push suite was blocked by exported OTEL/Grafana env affecting unrelated observability tests; targeted regression coverage passed.