### PR TITLE
Bump veryfront release version

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.917",
+  "version": "0.1.918",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.917";
+export const VERSION = "0.1.918";


### PR DESCRIPTION
## Summary
- bump deno.json from 0.1.917 to 0.1.918 so the already-merged Opus 4.8 fix can publish

The previous main release failed because veryfront@0.1.917 already exists on npm for b8523181.

## Verification
- deno fmt --check deno.json
- npm view veryfront@0.1.918 version returned no published version