### PR TITLE
Document Salesforce MCP integration rationale

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.921",
+  "version": "0.1.922",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -11,24 +11,25 @@ clear.
 
 ## Contents
 
-| Concept                                             | Explains                                                   |
-| --------------------------------------------------- | ---------------------------------------------------------- |
-| [Veryfront Code](./framework-overview.md)           | How the main framework surfaces fit together.              |
-| [Framework primitives](./framework-primitives.md)   | Overview of framework primitives.                          |
-| [App](./app.md)                                     | The user-facing route and rendering boundary.              |
-| [Agent](./agent.md)                                 | The model reasoning loop and output boundary.              |
-| [Tool](./tool.md)                                   | The contract for one callable capability.                  |
-| [Skill](./skill.md)                                 | How skills package reusable agent instructions.            |
-| [Prompt](./prompt.md)                               | Reusable instruction templates for MCP.                    |
-| [Resource](./resource.md)                           | Read-only context exposed through MCP.                     |
-| [Eval](./eval.md)                                   | Repeatable quality checks for agents.                      |
-| [Work](./work.md)                                   | Business process outcomes and criteria.                    |
-| [Task](./task.md)                                   | Background work before it becomes a run.                   |
-| [Workflow](./workflow.md)                           | Multi-step work with visible process state.                |
-| [Run](./run.md)                                     | Durable records for background execution.                  |
-| [Schedule](./schedule.md)                           | Triggers that create runs.                                 |
-| [Integration](./integration.md)                     | External service access, auth, and remote tools.           |
-| [MCP server](./mcp-server.md)                       | Tools, prompts, and resources exposed to assistants.       |
-| [Sandbox](./sandbox.md)                             | Isolated command and file execution.                       |
-| [Framework conventions](./framework-conventions.md) | File layout, auto-discovery, shared code, content, config. |
-| [Framework extensions](./framework-extensions.md)   | Replaceable runtime infrastructure.                        |
+| Concept                                               | Explains                                                   |
+| ----------------------------------------------------- | ---------------------------------------------------------- |
+| [Veryfront Code](./framework-overview.md)             | How the main framework surfaces fit together.              |
+| [Framework primitives](./framework-primitives.md)     | Overview of framework primitives.                          |
+| [App](./app.md)                                       | The user-facing route and rendering boundary.              |
+| [Agent](./agent.md)                                   | The model reasoning loop and output boundary.              |
+| [Tool](./tool.md)                                     | The contract for one callable capability.                  |
+| [Skill](./skill.md)                                   | How skills package reusable agent instructions.            |
+| [Prompt](./prompt.md)                                 | Reusable instruction templates for MCP.                    |
+| [Resource](./resource.md)                             | Read-only context exposed through MCP.                     |
+| [Eval](./eval.md)                                     | Repeatable quality checks for agents.                      |
+| [Work](./work.md)                                     | Business process outcomes and criteria.                    |
+| [Task](./task.md)                                     | Background work before it becomes a run.                   |
+| [Workflow](./workflow.md)                             | Multi-step work with visible process state.                |
+| [Run](./run.md)                                       | Durable records for background execution.                  |
+| [Schedule](./schedule.md)                             | Triggers that create runs.                                 |
+| [Integration](./integration.md)                       | External service access, auth, and remote tools.           |
+| [Salesforce integration](./salesforce-integration.md) | Why Salesforce is routed through Veryfront's tool policy.  |
+| [MCP server](./mcp-server.md)                         | Tools, prompts, and resources exposed to assistants.       |
+| [Sandbox](./sandbox.md)                               | Isolated command and file execution.                       |
+| [Framework conventions](./framework-conventions.md)   | File layout, auto-discovery, shared code, content, config. |
+| [Framework extensions](./framework-extensions.md)     | Replaceable runtime infrastructure.                        |

--- a/docs/concepts/integration.md
+++ b/docs/concepts/integration.md
@@ -28,6 +28,10 @@ tools, and workflows use the capabilities it exposes.
 Keep product logic outside the integration. The integration should describe and
 authorize the external capability.
 
+Some integrations need a governed agent-facing layer rather than a raw provider
+surface. Salesforce is the clearest example: see
+[Salesforce integration](./salesforce-integration.md) for the rationale.
+
 ## Wrong fit
 
 Do not create an integration for one small local helper. Use a tool when the

--- a/docs/concepts/mcp-server.md
+++ b/docs/concepts/mcp-server.md
@@ -28,6 +28,12 @@ Use an MCP server when an assistant needs to inspect or operate on a project
 through a protocol. MCP is not the same as AG-UI or REST. AG-UI streams agent
 output to app clients. MCP exposes tools, prompts, and resources to assistants.
 
+Provider MCP servers can be useful remote tool sources, but production
+integrations may still route through Veryfront's integration layer when the
+agent-facing surface needs product policy, cross-system workflow context, or
+write-action governance. Salesforce follows that model; see
+[Salesforce integration](./salesforce-integration.md).
+
 ## Wrong fit
 
 Do not use MCP as the public API for normal app users. Use app routes or API

--- a/docs/concepts/salesforce-integration.md
+++ b/docs/concepts/salesforce-integration.md
@@ -1,0 +1,96 @@
+---
+title: "Salesforce integration"
+description: "Why Veryfront exposes Salesforce through a governed integration layer."
+order: 35
+---
+
+Veryfront treats Salesforce as an integration behind the Veryfront tool and MCP
+control plane, rather than asking agents to connect directly to Salesforce MCP.
+
+This is not because Salesforce MCP is the wrong protocol. Salesforce MCP is a
+useful provider surface for generic Salesforce access. The reason to route
+Salesforce through Veryfront is that customer support agents need a governed
+workflow surface, not only a raw CRM protocol surface.
+
+## The design choice
+
+Salesforce owns CRM data and CRM permissions. Veryfront owns the agent runtime:
+which tools an agent can discover, which user or project connection is used,
+which write actions are allowed, how tool calls are audited, and how Salesforce
+context is combined with other systems such as Outlook, Gmail, Slack,
+Confluence, Zendesk, or internal knowledge.
+
+That split matters because "customer support" is rarely only Salesforce. A
+support agent may need to read an Account and open Cases, inspect email history,
+search knowledge, draft a response, add an internal case comment, and escalate
+to a human. Direct Salesforce MCP can expose Salesforce capabilities, but it
+does not by itself define the whole cross-system workflow or the Veryfront
+project policy around that workflow.
+
+## Why not expose raw Salesforce MCP directly
+
+Raw provider MCP is attractive because it is broad and close to the source. For
+expert users, broad access can be useful. For production agents, broad access is
+also where most of the risk appears.
+
+Veryfront needs the agent-visible surface to be stable, scoped, and explainable.
+The Salesforce integration therefore exposes curated tools such as customer
+lookup, account search, case listing, case activity, knowledge search, and
+selected write actions. It also keeps a read-only SOQL escape hatch for expert
+inspection when the curated tools are not enough.
+
+This gives agents enough flexibility to work across Salesforce orgs while
+avoiding a brittle tool list full of every possible provider operation. It also
+lets Veryfront apply product policy consistently: read tools can be available by
+default, while mutating tools such as creating a case, adding a case comment, or
+updating a case can require explicit allowlisting before the agent sees or calls
+them.
+
+## Why this scales across Salesforce orgs
+
+Salesforce orgs differ. One org may model customers with Accounts and Contacts.
+Another may rely on Person Accounts, record types, custom fields, queues,
+entitlements, or custom objects. A tool literally named `list_customers` would
+hide those decisions behind an assumption that is often wrong.
+
+Veryfront instead keeps the durable layer close to Salesforce primitives:
+Account, Contact, Case, CaseComment, Knowledge, Opportunity, Lead, object
+metadata, and read-only SOQL. The agent can use prompts, skills, project
+instructions, and org metadata to learn what "customer" means in a specific org.
+That is more scalable than hard-coding one universal customer model.
+
+The curated tools still use business names where they are stable enough, for
+example "Find Customer" for support triage. Underneath, the implementation stays
+grounded in Salesforce objects and metadata, so consultants can adapt behavior
+to each customer org without replacing the integration architecture.
+
+## What Veryfront adds
+
+Veryfront adds a control plane around Salesforce access:
+
+- Project and user-scoped OAuth connections.
+- Environment-specific credentials for staging and production.
+- Tool discovery that matches runtime execution policy.
+- Explicit write-tool allowlisting for higher-risk operations.
+- Integration with agent skills, prompts, evals, metrics, traces, and run logs.
+- One agent workflow across Salesforce and non-Salesforce systems.
+
+The result is a smaller but more useful agent surface. It is not a claim that
+Veryfront should reimplement every Salesforce API. The goal is to expose the
+right Salesforce capabilities at the right abstraction level, with enough
+metadata escape hatches for consultants and advanced agents to adapt to real
+orgs.
+
+## When direct Salesforce MCP still makes sense
+
+Direct Salesforce MCP can be the right choice for exploratory admin work, data
+inspection, or a single assistant whose only job is to operate inside
+Salesforce. It is less suitable as the default surface for Veryfront production
+agents because it bypasses the product-level policy, observability, and
+cross-system orchestration that Veryfront provides.
+
+Veryfront can still consume external MCP servers where that is the right
+integration shape. For Salesforce, the preferred production path is the
+Veryfront Salesforce integration: curated tools first, metadata and read-only
+query escape hatches second, and explicitly enabled writes only where the
+project has chosen to allow them.

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.921";
+export const VERSION = "0.1.922";

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -25,6 +25,7 @@ const CONCEPT_FILES = new Set<string>([
   "concepts/work.md",
   "concepts/skill.md",
   "concepts/integration.md",
+  "concepts/salesforce-integration.md",
   "concepts/mcp-server.md",
   "concepts/sandbox.md",
   "concepts/framework-extensions.md",
@@ -439,6 +440,13 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "../api-reference/veryfront/integrations.md",
     ],
     snippets: ["connector metadata", "auth", "remote tool"],
+  },
+  "concepts/salesforce-integration.md": {
+    references: [
+      "./integration.md",
+      "./mcp-server.md",
+    ],
+    snippets: ["Salesforce MCP", "write-tool allowlisting", "cross-system"],
   },
   "concepts/mcp-server.md": {
     references: [


### PR DESCRIPTION
## Summary
- add a Salesforce integration concept page explaining why Veryfront routes Salesforce through a governed integration/tool layer instead of defaulting to direct Salesforce MCP
- link the rationale from the Integration and MCP concept pages
- add the new concept page to docs contracts
- bump veryfront-code from 0.1.921 to 0.1.922

## Verification
- deno task docs:validate
- deno fmt --check docs/concepts/salesforce-integration.md docs/concepts/index.md docs/concepts/integration.md docs/concepts/mcp-server.md tests/docs/guide-contracts.test.ts deno.json src/utils/version-constant.ts
- git diff --check
- pre-push checks: formatting, lint, typecheck, and unit tests passed (2203 passed / 18894 steps)