### PR TITLE
Route runtime knowledge ingest uploads through API

### DIFF
--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -8,6 +8,7 @@ import { createAgentServiceEvalAdapter } from "#veryfront/eval/agent-service.ts"
 import { runEval as runEvalDefinition } from "#veryfront/eval/runner.ts";
 import { datasets, evalAgent, type EvalReport, metrics } from "veryfront/eval";
 import {
+  downloadRuntimeUploadToFile,
   ProjectRunExecuteHandler,
   type ProjectRunExecuteHandlerDeps,
 } from "./project-run-execute.handler.ts";
@@ -277,6 +278,33 @@ describe("server/handlers/request/project-run-execute.handler", () => {
       duration_ms: 51,
     });
     assertEquals(receivedConfig, { upload_ids: ["upload-1"] });
+  });
+
+  it("downloads knowledge ingest uploads through the API content endpoint", async () => {
+    const tempDir = await Deno.makeTempDir();
+    const calls: string[] = [];
+    const client = {
+      getBytes: async (path: string) => {
+        calls.push(path);
+        return new TextEncoder().encode("knowledge source");
+      },
+    };
+
+    try {
+      const result = await downloadRuntimeUploadToFile(
+        client,
+        "my-project",
+        "knowledge/source.md",
+        tempDir,
+      );
+
+      assertEquals(calls, ["/projects/my-project/uploads/knowledge%2Fsource.md/content"]);
+      assertStringIncludes(result.localPath, "/knowledge/source.md");
+      assertEquals(await Deno.readTextFile(result.localPath), "knowledge source");
+      assertEquals(result.bytes, 16);
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
   });
 
   it("runs a discovered workflow with the canonical run id and input", async () => {

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -40,6 +40,7 @@ import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } 
 import { BaseHandler } from "../response/base.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 import { parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
+import { dirname } from "veryfront/platform/path";
 
 const EXECUTE_PATH_REGEX = /^\/api\/control-plane\/runs\/([^/]+)\/execute$/;
 const DEFAULT_WORKFLOW_STATUS_POLL_INTERVAL_MS = 100;
@@ -424,6 +425,7 @@ async function executeWorkflowRun(
 
 interface RuntimeApiClient {
   get<T>(path: string, params?: Record<string, string>): Promise<T>;
+  getBytes(path: string, params?: Record<string, string>): Promise<Uint8Array>;
   post<T>(path: string, body?: unknown): Promise<T>;
   put<T>(path: string, body?: unknown): Promise<T>;
   patch<T>(path: string, body?: unknown): Promise<T>;
@@ -616,9 +618,36 @@ function createRuntimeApiClient(req: Request, ctx: HandlerContext): RuntimeApiCl
     return response.json() as Promise<T>;
   }
 
+  async function requestBytes(
+    path: string,
+    params?: Record<string, string>,
+  ): Promise<Uint8Array> {
+    const url = new URL(`${apiUrl}${path}`);
+    for (const [key, value] of Object.entries(params ?? {})) {
+      url.searchParams.set(key, value);
+    }
+
+    const response = await fetch(url.toString(), {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/octet-stream",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Veryfront API request failed: ${response.status} ${response.statusText}`);
+    }
+
+    return new Uint8Array(await response.arrayBuffer());
+  }
+
   return {
     get<T>(path: string, params?: Record<string, string>): Promise<T> {
       return requestJson<T>("GET", path, undefined, params);
+    },
+    getBytes(path: string, params?: Record<string, string>): Promise<Uint8Array> {
+      return requestBytes(path, params);
     },
     post<T>(path: string, body?: unknown): Promise<T> {
       return requestJson<T>("POST", path, body);
@@ -633,6 +662,27 @@ function createRuntimeApiClient(req: Request, ctx: HandlerContext): RuntimeApiCl
       return requestJson<T>("DELETE", path);
     },
   };
+}
+
+export async function downloadRuntimeUploadToFile(
+  client: Pick<RuntimeApiClient, "getBytes">,
+  projectReference: string,
+  uploadPath: string,
+  outputDir: string,
+): Promise<{ uploadPath: string; localPath: string; bytes: number }> {
+  const { resolveUploadOutputPath } = await import("#cli/commands/uploads/command");
+  const normalizedPath = uploadPath.replace(/^\/+/, "");
+  const localPath = resolveUploadOutputPath(uploadPath, outputDir);
+  const bytes = await client.getBytes(
+    `/projects/${encodeURIComponent(projectReference)}/uploads/${
+      encodeURIComponent(normalizedPath)
+    }/content`,
+  );
+
+  await Deno.mkdir(dirname(localPath), { recursive: true });
+  await Deno.writeFile(localPath, bytes);
+
+  return { uploadPath: normalizedPath, localPath, bytes: bytes.byteLength };
 }
 
 async function uploadEvalReportToProjectFiles(
@@ -737,7 +787,6 @@ async function executeKnowledgeIngestRun(input: {
       resolveKnowledgeDownloadOutputDir,
       runKnowledgeParser,
     } = await import("#cli/commands/knowledge/command");
-    const { downloadUploadToFile } = await import("#cli/commands/uploads/command");
     const { putRemoteFileFromLocal } = await import("#cli/commands/files/command");
 
     const uploadIds = getStringArrayConfig(config, ["upload_ids", "uploadIds"]);
@@ -783,7 +832,7 @@ async function executeKnowledgeIngestRun(input: {
       downloadUploads: (uploadTargets) =>
         Promise.all(
           uploadTargets.map((uploadPath) =>
-            downloadUploadToFile(client, projectReference, uploadPath, downloadOutputDir)
+            downloadRuntimeUploadToFile(client, projectReference, uploadPath, downloadOutputDir)
           ),
         ),
     });


### PR DESCRIPTION
## Summary
- Adds a runtime byte-fetch method for authenticated API downloads.
- Changes built-in task:knowledge-ingest upload collection to use the API /content endpoint instead of the CLI signed-URL download helper.
- Leaves CLI upload pull behavior unchanged.

## Root cause evidence
Staging canary run run_fb04ffac-20c0-4028-a94a-86cae589e317 failed inside task:knowledge-ingest while fetching a signed storage URL directly. API run creation, upload metadata resolution, and runtime invocation were working, so the runtime download boundary is the failing path.

## Tests
- RED: project-run-execute.handler.test.ts failed before implementation with missing downloadRuntimeUploadToFile export.
- GREEN: deno test -A src/server/handlers/request/project-run-execute.handler.test.ts
- GREEN: deno fmt --check src/server/handlers/request/project-run-execute.handler.ts src/server/handlers/request/project-run-execute.handler.test.ts
- GREEN: deno check src/server/handlers/request/project-run-execute.handler.ts src/server/handlers/request/project-run-execute.handler.test.ts
- GREEN: pre-commit verify:quick passed.

## Not tested
- Staging canary needs rerun after paired veryfront-api endpoint deploys.

Depends on veryfront/veryfront-api PR for the /content endpoint.
Refs veryfront/veryfront-studio#5302