### PR TITLE
Fix Confluence OAuth scopes for follow-up tool calls

### DIFF
--- a/cli/templates/integrations/confluence/README.md
+++ b/cli/templates/integrations/confluence/README.md
@@ -45,6 +45,11 @@ confluence/
    - **Scopes**:
      - `read:confluence-content.all`
      - `write:confluence-content`
+     - `read:confluence-space.summary`
+     - `read:confluence-user`
+     - `search:confluence`
+     - `read:page:confluence`
+     - `write:page:confluence`
      - `offline_access` (for refresh tokens)
 
 ### 2. Configure Environment Variables

--- a/cli/templates/integrations/confluence/connector.json
+++ b/cli/templates/integrations/confluence/connector.json
@@ -10,7 +10,13 @@
     "tokenUrl": "https://auth.atlassian.com/oauth/token",
     "scopes": [
       "read:confluence-content.all",
-      "write:confluence-content"
+      "write:confluence-content",
+      "read:confluence-space.summary",
+      "read:confluence-user",
+      "search:confluence",
+      "read:page:confluence",
+      "write:page:confluence",
+      "offline_access"
     ],
     "callbackPath": "/api/auth/confluence/callback",
     "tokenAuthMethod": "client_secret_post",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.922",
+  "version": "0.1.923",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/integrations/_data.test.ts
+++ b/src/integrations/_data.test.ts
@@ -984,6 +984,30 @@ describe("integration endpoint specs", () => {
       confluence.auth.additionalAuthParams?.audience,
       "api.atlassian.com",
     );
+    assertEquals(
+      confluence.auth.scopes?.includes("offline_access"),
+      true,
+    );
+    assertEquals(
+      confluence.auth.scopes?.includes("read:confluence-space.summary"),
+      true,
+    );
+    assertEquals(
+      confluence.auth.scopes?.includes("read:confluence-user"),
+      true,
+    );
+    assertEquals(
+      confluence.auth.scopes?.includes("search:confluence"),
+      true,
+    );
+    assertEquals(
+      confluence.auth.scopes?.includes("read:page:confluence"),
+      true,
+    );
+    assertEquals(
+      confluence.auth.scopes?.includes("write:page:confluence"),
+      true,
+    );
   });
 
   it("keeps newly added static endpoints executor-compatible", () => {

--- a/src/integrations/_data.ts
+++ b/src/integrations/_data.ts
@@ -12211,7 +12211,16 @@ export const connectors: IntegrationConfig[] = [
       "provider": "atlassian",
       "authorizationUrl": "https://auth.atlassian.com/authorize",
       "tokenUrl": "https://auth.atlassian.com/oauth/token",
-      "scopes": ["read:confluence-content.all", "write:confluence-content"],
+      "scopes": [
+        "read:confluence-content.all",
+        "write:confluence-content",
+        "read:confluence-space.summary",
+        "read:confluence-user",
+        "search:confluence",
+        "read:page:confluence",
+        "write:page:confluence",
+        "offline_access",
+      ],
       "tokenAuthMethod": "client_secret_post",
       "requiredApis": [{
         "name": "Atlassian OAuth 2.0 App",

--- a/src/oauth/providers/atlassian.test.ts
+++ b/src/oauth/providers/atlassian.test.ts
@@ -1,0 +1,17 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { confluenceConfig } from "./atlassian.ts";
+
+async function readConfluenceConnectorScopes(): Promise<string[]> {
+  const connector = JSON.parse(
+    await Deno.readTextFile("cli/templates/integrations/confluence/connector.json"),
+  ) as { auth: { scopes: string[] } };
+  return connector.auth.scopes;
+}
+
+describe("Atlassian OAuth provider configs", () => {
+  it("keeps Confluence runtime scopes aligned with the connector surface", async () => {
+    assertEquals(confluenceConfig.defaultScopes, await readConfluenceConnectorScopes());
+  });
+});

--- a/src/oauth/providers/atlassian.ts
+++ b/src/oauth/providers/atlassian.ts
@@ -39,6 +39,9 @@ export const confluenceConfig: OAuthServiceConfig = {
     "write:confluence-content",
     "read:confluence-space.summary",
     "read:confluence-user",
+    "search:confluence",
+    "read:page:confluence",
+    "write:page:confluence",
     "offline_access",
   ],
 };

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.922";
+export const VERSION = "0.1.923";


### PR DESCRIPTION
## Summary
- expand the Confluence connector OAuth scopes to cover spaces, CQL search, v2 page read/write, and refresh tokens
- align `confluenceConfig.defaultScopes` with the connector surface
- bump `veryfront` package version to `0.1.923` so downstream services can consume the catalog fix
- add regression tests so catalog and provider scopes cannot drift

## Root cause
The provided debug snapshot and browser retest showed `confluence__list_sites` succeeded, but `confluence__list_spaces` and `confluence__search_content` returned `reconnect_required`. Backend OAuth/project status reported Confluence connected, so this was not another Studio reconnect retry race. The token grant only exposed the original connector scopes, which were enough for Atlassian accessible-resources but not for the subsequent Confluence endpoints.

Official Atlassian docs list `search:confluence` for CQL search, and the v2 page endpoints require page read/write scopes.

## Red / Green
Red:
- `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/integrations/_data.test.ts` failed before the scope expansion because `search:confluence` was missing.

Green:
- `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/integrations/_data.test.ts src/oauth/providers/atlassian.test.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/integrations/_data.test.ts src/integrations/_data.ts src/oauth/providers/atlassian.ts src/oauth/providers/atlassian.test.ts`
- `deno check src/oauth/providers/atlassian.test.ts src/integrations/_data.test.ts`
- pre-commit `verify:quick` passed: manifest checks, fmt, lint, style/boundary/docs checks, and typecheck

## Deployment note
Existing connected users will need to reconnect Confluence after deployment to obtain the expanded Atlassian grant. After `veryfront@0.1.923` is published, update `veryfront-api` to consume that version.

Follow-up for veryfront-studio#5304.