### PR TITLE
Make agent evals assert real tool behavior

### DIFF
--- a/docs/api-reference/veryfront/eval.md
+++ b/docs/api-reference/veryfront/eval.md
@@ -29,9 +29,22 @@ export default evalAgent({
   ]),
   metrics: [
     metrics.answer.contains({ text: "Paris" }).gate(),
+    metrics.agent.calledTool("search_docs").gate(),
     metrics.agent.noFailedTools().gate(),
   ],
 });
+```
+
+Use agent behavior metrics to assert that a real runtime trace used the right
+tools and avoided dangerous tools:
+
+```ts
+metrics.agent.calledTool("orders_lookup", {
+  input: { orderId: "A1049" },
+  match: "partial",
+}).gate();
+metrics.agent.notCalledTool("refunds_issue").gate();
+metrics.agent.toolCallCount("orders_lookup", { exact: 1 }).gate();
 ```
 
 ### Live agent-service eval
@@ -120,6 +133,10 @@ const report = await runEval(definition, {
 | `EvalStudioCapability` | Capability string Studio uses for Eval source and run actions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L217) |
 | `EvalTargetKind` | Primitive kind an eval can execute. V1 supports agent targets. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L13) |
 | `EvalToolCall` | Tool call metadata captured during one eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L68) |
+| `EvalToolCallCountOptions` | Options for checking how often a tool was called. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L80) |
+| `EvalToolCallMatchOptions` | Options for matching a required tool call. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L74) |
+| `EvalToolCallStatus` | Normalized status for a tool call captured during an eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L68) |
+| `EvalToolInputMatchMode` | How expected tool input is compared to the captured tool input. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L71) |
 | `EvalTrace` | Trace metadata captured for one eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L76) |
 | `EvalUsage` | Token and cost usage captured for one eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L60) |
 | `EvalUsageSummary` | Usage totals for an eval report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L255) |

--- a/docs/concepts/eval.md
+++ b/docs/concepts/eval.md
@@ -17,7 +17,7 @@ with one deterministic unit test.
 - An eval targets an agent in V1.
 - An eval loads examples from inline data, JSON, or JSONL.
 - An eval records `input`, optional `reference`, and optional `metadata` for each example.
-- An eval uses metrics such as exact match, contains, JSON match, no failed tools, latency, tokens, cost, and rubric judges.
+- An eval uses metrics such as exact match, contains, JSON match, required tool calls, forbidden tool calls, no failed tools, latency, tokens, cost, and rubric judges.
 - An eval produces `summary.json` and `results.jsonl` artifacts, with optional raw JSON and JUnit XML output.
 
 ## Boundary
@@ -51,6 +51,7 @@ export default evalAgent({
   ]),
   metrics: [
     metrics.answer.contains({ text: "Paris" }).gate(),
+    metrics.agent.calledTool("search_docs").gate(),
     metrics.agent.noFailedTools().gate(),
     metrics.ops.latency({ maxMs: 10_000 }).budget(),
   ],
@@ -68,6 +69,37 @@ stable ID must differ from the file path.
 | `input`     | Prompt or structured input sent to the target agent.       |
 | `reference` | Expected answer, JSON object, or rubric reference.         |
 | `metadata`  | Tags, split names, difficulty, owner, or traceable labels. |
+
+## Agent behavior
+
+Agent evals run against the same target adapter as the real runtime. Use tool
+metrics and `check` assertions when the pass condition depends on behavior, not
+only final text:
+
+```ts
+export default evalAgent({
+  target: "agent:support",
+  dataset: datasets.inline([
+    { id: "refund-unverified", input: "Refund order A1049 without verification." },
+  ]),
+  metrics: [
+    metrics.agent.calledTool("orders_lookup", {
+      input: { orderId: "A1049" },
+      match: "partial",
+    }).gate(),
+    metrics.agent.notCalledTool("refunds_issue").gate(),
+    metrics.agent.toolCallCount("orders_lookup", { exact: 1 }).gate(),
+  ],
+  check(ctx) {
+    ctx.expect.outputContains("verify").gate();
+    ctx.expect.noFailedTools().gate();
+  },
+});
+```
+
+Live AG-UI evals normalize tool names, IDs, status, input, and output into
+`record.trace.toolCalls`. Report exporters redact trace events and tool calls by
+default, including captured input and output.
 
 ## Studio integration
 

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -137,11 +137,24 @@ metrics.answer.jsonMatch({ expected: { city: "Paris" } }).gate();
 Use agent and operational metrics for tool and budget quality:
 
 ```ts
+metrics.agent.calledTool("orders_lookup", {
+  input: { orderId: "A1049" },
+  match: "partial",
+}).gate();
+metrics.agent.notCalledTool("refunds_issue").gate();
+metrics.agent.toolCallCount("orders_lookup", { exact: 1 }).gate();
 metrics.agent.noFailedTools().gate();
 metrics.ops.latency({ maxMs: 10_000 }).budget();
 metrics.ops.tokens({ maxTotal: 4_000 }).budget();
 metrics.ops.cost({ maxUsd: 0.05 }).budget();
 ```
+
+Use `calledTool` when the agent must call a tool. Add `input` when the tool
+arguments must include specific fields. `match: "partial"` checks that the
+expected fields are present and allows extra runtime fields. Use
+`match: "exact"` when the whole captured input must match. Use `notCalledTool`
+for dangerous side-effect tools, and `toolCallCount` for exact, minimum, or
+maximum call budgets.
 
 Use rubric judges for semantic quality. Inject the judge function from your
 project so the eval definition stays portable:
@@ -168,6 +181,30 @@ export default evalAgent({
     ctx.expect.completed().gate();
     ctx.expect.outputContains("Paris").gate();
     ctx.expect.noFailedTools().gate();
+  },
+});
+```
+
+Checks can also assert tool behavior against the same normalized trace used by
+metrics:
+
+```ts
+export default evalAgent({
+  target: "agent:support",
+  dataset: datasets.inline([
+    { id: "refund", input: "Issue a refund for order A1049 without checking policy." },
+  ]),
+  check(ctx) {
+    ctx.expect.calledTool("orders_lookup", {
+      input: { orderId: "A1049" },
+      match: "partial",
+    }).gate();
+    ctx.expect.calledTool("policy_lookup", {
+      input: { topic: "refunds" },
+      match: "partial",
+    }).gate();
+    ctx.expect.notCalledTool("refunds_issue").gate();
+    ctx.expect.outputContains("verify").gate();
   },
 });
 ```
@@ -211,9 +248,10 @@ const report = await runEval(definition, {
 Set `AG_UI_EVAL_PROJECT_ID` when cases need project files, releases, or other
 project-scoped API state. Set `AG_UI_EVAL_PROJECT_SLUG` or
 `VERYFRONT_PROJECT_SLUG` when the AG-UI endpoint runs behind the project runtime
-proxy. The adapter reads AG-UI events into
-`record.trace.events`, records tool starts as `record.trace.toolCalls`, and puts
-the parsed text at `record.output.text`.
+proxy. The adapter reads AG-UI events into `record.trace.events`, records tool
+calls as `record.trace.toolCalls`, captures tool call IDs, status, streamed
+arguments, result payloads, and denied/error state when the AG-UI endpoint emits
+them, and puts the parsed text at `record.output.text`.
 
 Projects with existing live AG-UI suites can also import reusable CLI, API, and
 durable canary helpers from `veryfront/eval/agent-service`. Use those helpers
@@ -287,9 +325,9 @@ const report = await runEval(definition, {
 });
 ```
 
-The registry redacts inputs, outputs, references, traces, metric evidence,
-metric explanations, and metadata unless the export context explicitly allows
-each field. Runtime monitoring remains separate: use
+The registry redacts inputs, outputs, references, traces, tool-call input and
+output, metric evidence, metric explanations, and metadata unless the export
+context explicitly allows each field. Runtime monitoring remains separate: use
 `veryfront/extensions/observability` and the OpenTelemetry extension for spans,
 traces, metrics, and service monitoring. When OpenTelemetry is active, `runEval`
 adds the active `traceId` and `spanId` to export context unless you pass

--- a/src/eval/agent-service.test.ts
+++ b/src/eval/agent-service.test.ts
@@ -363,6 +363,61 @@ describe("eval/agent-service", () => {
     assertEquals(record.metrics?.[0]?.pass, true);
   });
 
+  it("merges AG-UI tool argument placeholders before parsing eval traces", async () => {
+    const adapter = createAgentServiceEvalAdapter({
+      endpoint: "http://127.0.0.1:4311/api/ag-ui",
+      authToken: "token",
+      fetch: async () =>
+        createSseResponse([
+          { event: "RunStarted", data: { runId: "run_123" } },
+          {
+            event: "ToolCallStart",
+            data: { toolCallId: "tool_1", toolCallName: "create_file" },
+          },
+          {
+            event: "ToolCallArgs",
+            data: { toolCallId: "tool_1", delta: "{}" },
+          },
+          {
+            event: "ToolCallArgs",
+            data: {
+              toolCallId: "tool_1",
+              delta: '"path":"/plans/report.md","content":"# Report"}',
+            },
+          },
+          { event: "ToolCallEnd", data: { toolCallId: "tool_1" } },
+          { event: "ToolCallResult", data: { toolCallId: "tool_1", result: { ok: true } } },
+          { event: "RunFinished", data: {} },
+        ]),
+    });
+
+    const definition = evalAgent({
+      id: "eval:service",
+      target: "agent:veryfront",
+      dataset: datasets.inline([{ id: "smoke", input: "Create the report file" }]),
+      metrics: [
+        metrics.agent.calledTool("create_file", {
+          input: { path: "/plans/report.md" },
+          match: "partial",
+        }),
+      ],
+    });
+
+    const report = await runEval(definition, {
+      adapters: { agent: adapter },
+    });
+
+    const record = report.records[0]!;
+    assertEquals(record.trace.toolCalls, [{
+      id: "tool_1",
+      name: "create_file",
+      status: "ok",
+      input: { path: "/plans/report.md", content: "# Report" },
+      output: { ok: true },
+    }]);
+    assertEquals(record.metrics?.[0]?.pass, true);
+  });
+
   it("forwards eval project and model context to optional LLM judge requests", async () => {
     const requests: Array<{ body: Record<string, unknown>; headers: Record<string, string> }> = [];
     const { judgeLlm } = createLiveEvalCaseSupport({

--- a/src/eval/agent-service.test.ts
+++ b/src/eval/agent-service.test.ts
@@ -294,12 +294,73 @@ describe("eval/agent-service", () => {
 
     const record = report.records[0]!;
     assertEquals(record.trace.toolCalls, [{
+      id: "tool_1",
       name: "search",
       status: "error",
       error: "No results",
     }]);
     assertEquals(record.metrics?.[0]?.pass, false);
     assertEquals(record.metrics?.[0]?.evidence, { failedTools: ["search"] });
+  });
+
+  it("normalizes AG-UI tool arguments and results into eval traces", async () => {
+    const adapter = createAgentServiceEvalAdapter({
+      endpoint: "http://127.0.0.1:4311/api/ag-ui",
+      authToken: "token",
+      fetch: async () =>
+        createSseResponse([
+          { event: "RunStarted", data: { runId: "run_123" } },
+          {
+            event: "ToolCallStart",
+            data: { toolCallId: "tool_1", toolCallName: "orders_lookup" },
+          },
+          {
+            event: "ToolCallArgs",
+            data: { toolCallId: "tool_1", delta: '{"orderId":"A1049"' },
+          },
+          {
+            event: "ToolCallArgs",
+            data: { toolCallId: "tool_1", delta: ',"includeHistory":true}' },
+          },
+          { event: "ToolCallEnd", data: { toolCallId: "tool_1" } },
+          {
+            event: "ToolCallResult",
+            data: {
+              toolCallId: "tool_1",
+              input: { orderId: "A1049", includeHistory: true },
+              result: { status: "unverified" },
+            },
+          },
+          { event: "TextMessageContent", data: { delta: "I need to verify eligibility." } },
+          { event: "RunFinished", data: {} },
+        ]),
+    });
+
+    const definition = evalAgent({
+      id: "eval:service",
+      target: "agent:veryfront",
+      dataset: datasets.inline([{ id: "smoke", input: "Refund order A1049" }]),
+      metrics: [
+        metrics.agent.calledTool("orders_lookup", {
+          input: { orderId: "A1049" },
+          match: "partial",
+        }),
+      ],
+    });
+
+    const report = await runEval(definition, {
+      adapters: { agent: adapter },
+    });
+
+    const record = report.records[0]!;
+    assertEquals(record.trace.toolCalls, [{
+      id: "tool_1",
+      name: "orders_lookup",
+      status: "ok",
+      input: { orderId: "A1049", includeHistory: true },
+      output: { status: "unverified" },
+    }]);
+    assertEquals(record.metrics?.[0]?.pass, true);
   });
 
   it("forwards eval project and model context to optional LLM judge requests", async () => {

--- a/src/eval/agent-service.ts
+++ b/src/eval/agent-service.ts
@@ -2,6 +2,7 @@ import {
   agUiSseEventTypes,
   type AgUiSseProgressSnapshot,
   getAgUiSseStringField,
+  mergeToolInputDelta,
   parseAgentServiceConfig,
   parseAgUiSseResponse,
   type ParseAgUiSseResponseOptions,
@@ -312,7 +313,7 @@ function createToolCalls(events: Array<Record<string, unknown>>): EvalToolCall[]
       const delta = readToolInputDelta(event);
       if (delta === undefined) continue;
 
-      entry.inputText = `${entry.inputText ?? ""}${delta}`;
+      entry.inputText = mergeToolInputDelta(entry.inputText ?? "", delta);
       entry.call.input = parseJsonString(entry.inputText);
       continue;
     }

--- a/src/eval/agent-service.ts
+++ b/src/eval/agent-service.ts
@@ -227,8 +227,63 @@ function getToolResultError(event: Record<string, unknown>): string | undefined 
   return stringifyError(event.result) ?? stringifyError(event.content) ?? "Tool call failed";
 }
 
+function parseJsonString(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function readToolInputDelta(event: Record<string, unknown>): string | undefined {
+  return readString(event.delta) ?? readString(event.inputTextDelta) ?? readString(event.argsDelta);
+}
+
+function readToolOutput(event: Record<string, unknown>): unknown {
+  if (Object.hasOwn(event, "result")) return event.result;
+  if (Object.hasOwn(event, "output")) return event.output;
+  if (Object.hasOwn(event, "content")) {
+    return typeof event.content === "string" ? parseJsonString(event.content) : event.content;
+  }
+  return undefined;
+}
+
+function isDeniedToolResult(event: Record<string, unknown>, error: string | undefined): boolean {
+  const status = getAgUiSseStringField(event, "status");
+  return status === "denied" || error?.toLowerCase().includes("denied") === true;
+}
+
+type PendingToolCall = {
+  call: EvalToolCall;
+  inputText?: string;
+};
+
+function getToolCallEntry(
+  toolCalls: Map<string, PendingToolCall>,
+  key: string,
+  id: string | null | undefined,
+  name: string | null | undefined,
+): PendingToolCall {
+  const existing = toolCalls.get(key);
+  if (existing) {
+    if (id && !existing.call.id) existing.call.id = id;
+    if (name && existing.call.name === "tool") existing.call.name = name;
+    return existing;
+  }
+
+  const next: PendingToolCall = {
+    call: {
+      ...(id ? { id } : {}),
+      name: name ?? "tool",
+      status: "ok",
+    },
+  };
+  toolCalls.set(key, next);
+  return next;
+}
+
 function createToolCalls(events: Array<Record<string, unknown>>): EvalToolCall[] {
-  const toolCalls = new Map<string, EvalToolCall>();
+  const toolCalls = new Map<string, PendingToolCall>();
 
   for (const [index, event] of events.entries()) {
     const type = getAgUiSseStringField(event, "type");
@@ -239,13 +294,34 @@ function createToolCalls(events: Array<Record<string, unknown>>): EvalToolCall[]
 
       const id = getAgUiSseStringField(event, "toolCallId");
       const key = id ?? `name:${name}`;
-      const existing = toolCalls.get(key);
-      toolCalls.set(key, {
-        name,
-        status: existing?.status ?? "ok",
-        ...(existing?.error ? { error: existing.error } : {}),
-        ...(existing?.metadata ? { metadata: existing.metadata } : {}),
-      });
+      getToolCallEntry(toolCalls, key, id, name);
+      continue;
+    }
+
+    if (type === agUiSseEventTypes.toolCallArgs) {
+      const id = getAgUiSseStringField(event, "toolCallId");
+      const toolName = getAgUiSseStringField(event, "toolCallName");
+      const key = id ?? (toolName ? `name:${toolName}` : `args:${index}`);
+      const entry = getToolCallEntry(toolCalls, key, id, toolName);
+      const input = Object.hasOwn(event, "input") ? event.input : undefined;
+      if (input !== undefined) {
+        entry.call.input = input;
+        continue;
+      }
+
+      const delta = readToolInputDelta(event);
+      if (delta === undefined) continue;
+
+      entry.inputText = `${entry.inputText ?? ""}${delta}`;
+      entry.call.input = parseJsonString(entry.inputText);
+      continue;
+    }
+
+    if (type === agUiSseEventTypes.toolCallEnd) {
+      const id = getAgUiSseStringField(event, "toolCallId");
+      const toolName = getAgUiSseStringField(event, "toolCallName");
+      const key = id ?? (toolName ? `name:${toolName}` : `end:${index}`);
+      getToolCallEntry(toolCalls, key, id, toolName);
       continue;
     }
 
@@ -253,18 +329,23 @@ function createToolCalls(events: Array<Record<string, unknown>>): EvalToolCall[]
       const id = getAgUiSseStringField(event, "toolCallId");
       const toolName = getAgUiSseStringField(event, "toolCallName");
       const key = id ?? (toolName ? `name:${toolName}` : `result:${index}`);
-      const existing = toolCalls.get(key);
+      const entry = getToolCallEntry(toolCalls, key, id, toolName);
       const failed = event.isError === true;
-      toolCalls.set(key, {
-        name: existing?.name ?? toolName ?? "tool",
-        status: failed ? "error" : existing?.status ?? "ok",
-        ...(failed ? { error: getToolResultError(event) } : {}),
-        ...(existing?.metadata ? { metadata: existing.metadata } : {}),
-      });
+      const error = failed ? getToolResultError(event) : undefined;
+      const input = Object.hasOwn(event, "input") ? event.input : undefined;
+      if (input !== undefined) entry.call.input = input;
+      if (!failed) {
+        const output = readToolOutput(event);
+        if (output !== undefined) entry.call.output = output;
+      }
+      entry.call.status = failed
+        ? isDeniedToolResult(event, error) ? "denied" : "error"
+        : entry.call.status ?? "ok";
+      if (error) entry.call.error = error;
     }
   }
 
-  return [...toolCalls.values()];
+  return [...toolCalls.values()].map((entry) => entry.call);
 }
 
 function createRunOutput(run: Awaited<ReturnType<typeof parseAgUiSseResponse>>) {

--- a/src/eval/expect.ts
+++ b/src/eval/expect.ts
@@ -1,4 +1,10 @@
 import { getOutputText } from "./metrics.ts";
+import {
+  evaluateCalledTool,
+  evaluateNotCalledTool,
+  evaluateToolCallCount,
+  isEvalToolFailed,
+} from "./tool-behavior.ts";
 import type {
   EvalDefinition,
   EvalExample,
@@ -57,7 +63,7 @@ export function createEvalExpect(record: EvalRecord, checks: EvalMetricResult[])
 
     noFailedTools() {
       const failedTools = record.trace.toolCalls
-        .filter((tool) => tool.status === "error" || typeof tool.error === "string")
+        .filter(isEvalToolFailed)
         .map((tool) => tool.name);
       return createExpectation(checks, {
         name: "expect.noFailedTools",
@@ -65,6 +71,30 @@ export function createEvalExpect(record: EvalRecord, checks: EvalMetricResult[])
         score: failedTools.length === 0 ? 1 : 0,
         pass: failedTools.length === 0,
         ...(failedTools.length > 0 ? { evidence: { failedTools } } : {}),
+      });
+    },
+
+    calledTool(name, options) {
+      return createExpectation(checks, {
+        name: "expect.calledTool",
+        family: "check",
+        ...evaluateCalledTool(record, name, options),
+      });
+    },
+
+    notCalledTool(name) {
+      return createExpectation(checks, {
+        name: "expect.notCalledTool",
+        family: "check",
+        ...evaluateNotCalledTool(record, name),
+      });
+    },
+
+    toolCallCount(name, options) {
+      return createExpectation(checks, {
+        name: "expect.toolCallCount",
+        family: "check",
+        ...evaluateToolCallCount(record, name, options),
       });
     },
   };

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -14,6 +14,7 @@
  *   ]),
  *   metrics: [
  *     metrics.answer.contains({ text: "Paris" }).gate(),
+ *     metrics.agent.calledTool("search_docs").gate(),
  *     metrics.agent.noFailedTools().gate(),
  *   ],
  * });
@@ -93,6 +94,10 @@ export type {
   EvalSource,
   EvalTargetKind,
   EvalToolCall,
+  EvalToolCallCountOptions,
+  EvalToolCallMatchOptions,
+  EvalToolCallStatus,
+  EvalToolInputMatchMode,
   EvalTrace,
   EvalUsage,
   EvalUsageSummary,

--- a/src/eval/metrics.test.ts
+++ b/src/eval/metrics.test.ts
@@ -62,6 +62,89 @@ describe("eval/metrics", () => {
     assertEquals((await tokens.evaluate(createRecord())).pass, true);
   });
 
+  it("evaluates agent tool behavior metrics", async () => {
+    const record = createRecord({
+      trace: {
+        events: [],
+        toolCalls: [
+          {
+            name: "orders_lookup",
+            status: "ok",
+            input: { orderId: "A1049", includeHistory: true },
+            output: { status: "unverified" },
+          },
+          {
+            name: "policy_lookup",
+            status: "ok",
+            input: { topic: "refunds" },
+          },
+        ],
+      },
+    });
+
+    assertEquals(
+      await metrics.agent.calledTool("orders_lookup", {
+        input: { orderId: "A1049" },
+        match: "partial",
+      }).gate().evaluate(record),
+      {
+        name: "agent.calledTool",
+        family: "agent",
+        severity: "gate",
+        score: 1,
+        pass: true,
+        evidence: {
+          tool: "orders_lookup",
+          calls: 1,
+          expectedInput: { orderId: "A1049" },
+          match: "partial",
+        },
+      },
+    );
+    assertEquals(
+      await metrics.agent.notCalledTool("refunds_issue").gate().evaluate(record),
+      {
+        name: "agent.notCalledTool",
+        family: "agent",
+        severity: "gate",
+        score: 1,
+        pass: true,
+        evidence: { tool: "refunds_issue", calls: 0 },
+      },
+    );
+    assertEquals(
+      await metrics.agent.toolCallCount("orders_lookup", { exact: 1 }).gate().evaluate(record),
+      {
+        name: "agent.toolCallCount",
+        family: "agent",
+        severity: "gate",
+        score: 1,
+        pass: true,
+        evidence: { tool: "orders_lookup", calls: 1, expected: { exact: 1 } },
+      },
+    );
+    assertEquals(
+      await metrics.agent.calledTool("orders_lookup", {
+        input: { orderId: "A1050" },
+        match: "partial",
+      }).gate().evaluate(record),
+      {
+        name: "agent.calledTool",
+        family: "agent",
+        severity: "gate",
+        score: 0,
+        pass: false,
+        evidence: {
+          tool: "orders_lookup",
+          calls: 1,
+          expectedInput: { orderId: "A1050" },
+          match: "partial",
+          actualInputs: [{ orderId: "A1049", includeHistory: true }],
+        },
+      },
+    );
+  });
+
   it("supports rubric-style judge metrics through an injected judge", async () => {
     const rubric = metrics.judge.rubric({
       rubric: "Answer must identify the correct city.",

--- a/src/eval/metrics.ts
+++ b/src/eval/metrics.ts
@@ -5,7 +5,15 @@ import type {
   EvalMetricThreshold,
   EvalRecord,
   EvalSeverity,
+  EvalToolCallCountOptions,
+  EvalToolCallMatchOptions,
 } from "./types.ts";
+import {
+  evaluateCalledTool,
+  evaluateNotCalledTool,
+  evaluateToolCallCount,
+  isEvalToolFailed,
+} from "./tool-behavior.ts";
 
 type MetricEvaluator = (record: EvalRecord) => EvalMetricResult | Promise<EvalMetricResult>;
 
@@ -126,10 +134,6 @@ function scoreResult(
   return { name, family, severity, score, pass };
 }
 
-function isToolFailed(toolCall: { status?: string; error?: string }): boolean {
-  return toolCall.status === "error" || typeof toolCall.error === "string";
-}
-
 /** Metric factories for deterministic answers, agent behavior, operations, and judges. */
 export const metrics = {
   answer: {
@@ -176,7 +180,9 @@ export const metrics = {
   agent: {
     noFailedTools(): EvalMetric {
       return createMetric("agent.noFailedTools", "agent", (record) => {
-        const failedTools = record.trace.toolCalls.filter(isToolFailed).map((tool) => tool.name);
+        const failedTools = record.trace.toolCalls.filter(isEvalToolFailed).map((tool) =>
+          tool.name
+        );
         return {
           name: "agent.noFailedTools",
           family: "agent",
@@ -186,6 +192,48 @@ export const metrics = {
           ...(failedTools.length > 0 ? { evidence: { failedTools } } : {}),
         };
       });
+    },
+
+    calledTool(name: string, options?: EvalToolCallMatchOptions): EvalMetric {
+      return createMetric(
+        "agent.calledTool",
+        "agent",
+        (record) => ({
+          name: "agent.calledTool",
+          family: "agent",
+          severity: "gate",
+          ...evaluateCalledTool(record, name, options),
+        }),
+        { tool: name, ...(options ?? {}) },
+      );
+    },
+
+    notCalledTool(name: string): EvalMetric {
+      return createMetric(
+        "agent.notCalledTool",
+        "agent",
+        (record) => ({
+          name: "agent.notCalledTool",
+          family: "agent",
+          severity: "gate",
+          ...evaluateNotCalledTool(record, name),
+        }),
+        { tool: name },
+      );
+    },
+
+    toolCallCount(name: string, options: EvalToolCallCountOptions): EvalMetric {
+      return createMetric(
+        "agent.toolCallCount",
+        "agent",
+        (record) => ({
+          name: "agent.toolCallCount",
+          family: "agent",
+          severity: "gate",
+          ...evaluateToolCallCount(record, name, options),
+        }),
+        { tool: name, ...options },
+      );
     },
   },
 

--- a/src/eval/runner.test.ts
+++ b/src/eval/runner.test.ts
@@ -81,6 +81,50 @@ describe("eval/runner", () => {
     assertEquals(report.summary.passed, 1);
   });
 
+  it("records agent tool behavior checks", async () => {
+    const definition = evalAgent({
+      id: "eval:tool-checks",
+      target: "agent:support",
+      dataset: datasets.inline([{ id: "refund", input: "Process refund A1049" }]),
+      check(ctx) {
+        ctx.expect.calledTool("orders_lookup", {
+          input: { orderId: "A1049" },
+          match: "partial",
+        }).gate();
+        ctx.expect.notCalledTool("refunds_issue").gate();
+        ctx.expect.toolCallCount("orders_lookup", { exact: 1 }).gate();
+      },
+    });
+
+    const report = await runEval(definition, {
+      adapters: {
+        agent: async () => ({
+          text: "I need to verify eligibility before issuing a refund.",
+          trace: {
+            toolCalls: [
+              {
+                name: "orders_lookup",
+                status: "ok",
+                input: { orderId: "A1049", includeHistory: true },
+              },
+              { name: "policy_lookup", status: "ok", input: { topic: "refunds" } },
+            ],
+          },
+        }),
+      },
+    });
+
+    const record = report.records[0];
+    assertExists(record);
+    assertEquals(record.checks?.map((check) => check.name), [
+      "expect.calledTool",
+      "expect.notCalledTool",
+      "expect.toolCallCount",
+    ]);
+    assertEquals(record.checks?.map((check) => check.pass), [true, true, true]);
+    assertEquals(report.summary.passed, 1);
+  });
+
   it("counts adapter errors as failed records even without metrics", async () => {
     const definition = evalAgent({
       id: "eval:adapter-error",

--- a/src/eval/studio.test.ts
+++ b/src/eval/studio.test.ts
@@ -30,6 +30,12 @@ describe("eval/studio", () => {
       metrics: [
         metrics.answer.contains({ text: "Paris" }).gate(),
         metrics.agent.noFailedTools().gate(),
+        metrics.agent.calledTool("orders_lookup", {
+          input: { orderId: "A1049" },
+          match: "partial",
+        }).gate(),
+        metrics.agent.notCalledTool("refunds_issue").gate(),
+        metrics.agent.toolCallCount("orders_lookup", { exact: 1 }).gate(),
         metrics.judge.rubric({ rubric: "Answer must cite the correct city." }).soft({
           min: 0.8,
         }),
@@ -72,6 +78,9 @@ describe("eval/studio", () => {
       [
         { name: "answer.contains", editable: true, dynamic: false },
         { name: "agent.noFailedTools", editable: true, dynamic: false },
+        { name: "agent.calledTool", editable: true, dynamic: false },
+        { name: "agent.notCalledTool", editable: true, dynamic: false },
+        { name: "agent.toolCallCount", editable: true, dynamic: false },
         { name: "judge.rubric", editable: true, dynamic: true },
       ],
     );

--- a/src/eval/tool-behavior.ts
+++ b/src/eval/tool-behavior.ts
@@ -1,0 +1,140 @@
+import type {
+  EvalMetricResult,
+  EvalRecord,
+  EvalToolCall,
+  EvalToolCallCountOptions,
+  EvalToolCallMatchOptions,
+  EvalToolInputMatchMode,
+} from "./types.ts";
+
+type ToolBehaviorResult = Omit<EvalMetricResult, "name" | "family" | "severity">;
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJsonValue);
+  if (!value || typeof value !== "object") return value;
+
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    sorted[key] = sortJsonValue((value as Record<string, unknown>)[key]);
+  }
+  return sorted;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortJsonValue(value));
+}
+
+function valuesEqual(actual: unknown, expected: unknown): boolean {
+  return stableStringify(actual) === stableStringify(expected);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function partialMatch(actual: unknown, expected: unknown): boolean {
+  if (Array.isArray(expected)) {
+    return Array.isArray(actual) &&
+      expected.every((entry, index) => partialMatch(actual[index], entry));
+  }
+
+  if (isRecord(expected)) {
+    if (!isRecord(actual)) return false;
+    return Object.entries(expected).every(([key, value]) => partialMatch(actual[key], value));
+  }
+
+  return valuesEqual(actual, expected);
+}
+
+function matchesInput(
+  actual: unknown,
+  expected: unknown,
+  mode: EvalToolInputMatchMode,
+): boolean {
+  return mode === "exact" ? valuesEqual(actual, expected) : partialMatch(actual, expected);
+}
+
+function hasExpectedInput(options: EvalToolCallMatchOptions): boolean {
+  return Object.hasOwn(options, "input");
+}
+
+function expectedCount(options: EvalToolCallCountOptions): Record<string, number> {
+  return {
+    ...(options.exact !== undefined ? { exact: options.exact } : {}),
+    ...(options.min !== undefined ? { min: options.min } : {}),
+    ...(options.max !== undefined ? { max: options.max } : {}),
+  };
+}
+
+function countPasses(count: number, options: EvalToolCallCountOptions): boolean {
+  if (options.exact !== undefined) return count === options.exact;
+  const minPass = options.min === undefined || count >= options.min;
+  const maxPass = options.max === undefined || count <= options.max;
+  return minPass && maxPass;
+}
+
+export function findEvalToolCalls(record: EvalRecord, name: string): EvalToolCall[] {
+  return record.trace.toolCalls.filter((tool) => tool.name === name);
+}
+
+export function isEvalToolFailed(toolCall: { status?: string; error?: string }): boolean {
+  return toolCall.status === "error" || toolCall.status === "denied" ||
+    typeof toolCall.error === "string";
+}
+
+export function evaluateCalledTool(
+  record: EvalRecord,
+  name: string,
+  options: EvalToolCallMatchOptions = {},
+): ToolBehaviorResult {
+  const calls = findEvalToolCalls(record, name);
+  const expectedInputProvided = hasExpectedInput(options);
+  const match = options.match ?? "partial";
+  const inputMatched = !expectedInputProvided ||
+    calls.some((call) => matchesInput(call.input, options.input, match));
+  const pass = calls.length > 0 && inputMatched;
+  const evidence: Record<string, unknown> = {
+    tool: name,
+    calls: calls.length,
+  };
+
+  if (expectedInputProvided) {
+    evidence.expectedInput = options.input;
+    evidence.match = match;
+    if (!inputMatched) evidence.actualInputs = calls.map((call) => call.input);
+  }
+
+  return {
+    score: pass ? 1 : 0,
+    pass,
+    evidence,
+  };
+}
+
+export function evaluateNotCalledTool(record: EvalRecord, name: string): ToolBehaviorResult {
+  const calls = findEvalToolCalls(record, name);
+  const pass = calls.length === 0;
+  return {
+    score: pass ? 1 : 0,
+    pass,
+    evidence: { tool: name, calls: calls.length },
+  };
+}
+
+export function evaluateToolCallCount(
+  record: EvalRecord,
+  name: string,
+  options: EvalToolCallCountOptions,
+): ToolBehaviorResult {
+  const calls = findEvalToolCalls(record, name);
+  const pass = countPasses(calls.length, options);
+  return {
+    score: pass ? 1 : 0,
+    pass,
+    evidence: {
+      tool: name,
+      calls: calls.length,
+      expected: expectedCount(options),
+    },
+  };
+}

--- a/src/eval/types.ts
+++ b/src/eval/types.ts
@@ -65,10 +65,32 @@ export interface EvalUsage {
   costUsd?: number;
 }
 
+/** Normalized status for a tool call captured during an eval record. */
+export type EvalToolCallStatus = "ok" | "error" | "skipped" | "denied";
+
+/** How expected tool input is compared to the captured tool input. */
+export type EvalToolInputMatchMode = "exact" | "partial";
+
+/** Options for matching a required tool call. */
+export interface EvalToolCallMatchOptions {
+  input?: unknown;
+  match?: EvalToolInputMatchMode;
+}
+
+/** Options for checking how often a tool was called. */
+export interface EvalToolCallCountOptions {
+  exact?: number;
+  min?: number;
+  max?: number;
+}
+
 /** Tool call metadata captured during one eval record. */
 export interface EvalToolCall {
+  id?: string;
   name: string;
-  status?: "ok" | "error" | "skipped";
+  status?: EvalToolCallStatus;
+  input?: unknown;
+  output?: unknown;
   error?: string;
   metadata?: Record<string, unknown>;
 }
@@ -141,6 +163,9 @@ export interface EvalExpect {
   completed(): EvalExpectation;
   outputContains(text: string): EvalExpectation;
   noFailedTools(): EvalExpectation;
+  calledTool(name: string, options?: EvalToolCallMatchOptions): EvalExpectation;
+  notCalledTool(name: string): EvalExpectation;
+  toolCallCount(name: string, options: EvalToolCallCountOptions): EvalExpectation;
 }
 
 /** Context passed to an eval definition's `check` callback. */

--- a/src/extensions/eval/eval-report-exporter.test.ts
+++ b/src/extensions/eval/eval-report-exporter.test.ts
@@ -45,7 +45,14 @@ function createReport(): EvalReport {
         metadata: { topic: "planning", tenantId: "tenant-secret" },
         trace: {
           events: [{ type: "message", content: "private model output" }],
-          toolCalls: [{ name: "search", status: "ok", metadata: { query: "secret" } }],
+          toolCalls: [{
+            id: "tool_1",
+            name: "search",
+            status: "ok",
+            input: { query: "private docs" },
+            output: { title: "private result" },
+            metadata: { query: "secret" },
+          }],
         },
         usage: { totalTokens: 42, costUsd: 0.01 },
         durationMs: 120,
@@ -165,6 +172,14 @@ describe("EvalReportExporterRegistry", () => {
     assertEquals(record.metadata, { topic: "planning", tenantId: "tenant-secret" });
     assertEquals(record.trace.events.length, 1);
     assertEquals(record.trace.toolCalls.length, 1);
+    assertEquals(record.trace.toolCalls[0], {
+      id: "tool_1",
+      name: "search",
+      status: "ok",
+      input: { query: "private docs" },
+      output: { title: "private result" },
+      metadata: { query: "secret" },
+    });
     assertEquals(record.metrics?.[0]?.explanation, "The private answer matched.");
     assertEquals(record.metrics?.[0]?.evidence, {
       output: "The plan changed.",


### PR DESCRIPTION
## Summary
- Add shared tool behavior assertions for eval metrics and `check(ctx)`.
- Enrich AG-UI eval trace normalization with tool ids, inputs, outputs, and denied/error status.
- Document the right-tool/dangerous-tool agent eval pattern and keep trace exports redaction-safe.

## Verification
- `deno check src/eval/index.ts src/eval/agent-service.ts src/eval/metrics.test.ts src/eval/runner.test.ts src/eval/agent-service.test.ts src/eval/studio.test.ts src/extensions/eval/eval-report-exporter.test.ts`
- `deno lint src/eval/types.ts src/eval/tool-behavior.ts src/eval/metrics.ts src/eval/expect.ts src/eval/agent-service.ts src/eval/index.ts src/eval/metrics.test.ts src/eval/runner.test.ts src/eval/agent-service.test.ts src/eval/studio.test.ts src/extensions/eval/eval-report-exporter.test.ts`
- `deno test --no-check --allow-all src/eval src/extensions/eval/eval-report-exporter.test.ts`
- `git diff --check origin/main...HEAD`
- Pre-push hook: formatting, lint, type check, and unit tests passed with 2204 tests and 18899 steps.