### PR TITLE
Bump Veryfront release to 0.1.924

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.923",
+  "version": "0.1.924",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.923";
+export const VERSION = "0.1.924";


### PR DESCRIPTION
## Summary
- Bumps the Veryfront package version from 0.1.923 to 0.1.924.
- Keeps the shared runtime version constant in sync for the release that includes agent eval behavior metrics and AG-UI tool trace fixes.

## Verification
- deno fmt --check deno.json src/utils/version-constant.ts
- deno check src/utils/version-constant.ts
- deno test --no-check --allow-all src/utils/version.test.ts
- git diff --check
- pre-push hook: format, lint, deno check src/index.ts, full unit suite: 2204 passed, 0 failed
