### PR TITLE
Fix workflow CLI project registries

### DIFF
--- a/cli/commands/workflow/command.test.ts
+++ b/cli/commands/workflow/command.test.ts
@@ -1,8 +1,44 @@
+import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
-import { formatWorkflowDiscoveryErrors } from "./command.ts";
+import { afterAll, afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { stop as stopEsbuild } from "veryfront/extensions/bundler";
+import { clearProjectAgentRuntimeRegistries } from "../../../src/agent/project/agent-runtime.ts";
+import { formatWorkflowDiscoveryErrors, workflowCommand } from "./command.ts";
+
+const originalRedisUrl = Deno.env.get("REDIS_URL");
+const originalRunResultPath = Deno.env.get("VERYFRONT_RUN_RESULT_PATH");
+
+async function writeProjectFile(projectDir: string, filePath: string, content: string) {
+  const path = `${projectDir}/${filePath}`;
+  const dir = path.slice(0, path.lastIndexOf("/"));
+  await Deno.mkdir(dir, { recursive: true });
+  await Deno.writeTextFile(path, content);
+}
+
+function restoreEnv() {
+  if (originalRedisUrl === undefined) {
+    Deno.env.delete("REDIS_URL");
+  } else {
+    Deno.env.set("REDIS_URL", originalRedisUrl);
+  }
+
+  if (originalRunResultPath === undefined) {
+    Deno.env.delete("VERYFRONT_RUN_RESULT_PATH");
+  } else {
+    Deno.env.set("VERYFRONT_RUN_RESULT_PATH", originalRunResultPath);
+  }
+}
 
 describe("workflow command", () => {
+  afterEach(() => {
+    restoreEnv();
+    clearProjectAgentRuntimeRegistries();
+  });
+
+  afterAll(async () => {
+    await stopEsbuild();
+  });
+
   it("formats workflow load errors for non-debug logs", () => {
     const lines = formatWorkflowDiscoveryErrors([
       {
@@ -26,5 +62,59 @@ describe("workflow command", () => {
 
     assertEquals(lines.length, 6);
     assertEquals(lines.at(-1), "  - 1 more workflow file failed to load");
+  });
+
+  it("runs project workflows with discovered project tool steps", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-workflow-command-" });
+    const resultPath = `${projectDir}/.veryfront/result.json`;
+
+    try {
+      await writeProjectFile(
+        projectDir,
+        "tools/echo.ts",
+        [
+          'import { defineSchema } from "veryfront/schemas";',
+          'import { tool } from "veryfront/tool";',
+          "",
+          "export default tool({",
+          '  id: "echo",',
+          '  description: "Echo workflow input.",',
+          "  inputSchema: defineSchema((v) => v.object({ message: v.string() }))(),",
+          "  execute: async (input) => ({ echoed: input.message }),",
+          "});",
+        ].join("\n"),
+      );
+
+      await writeProjectFile(
+        projectDir,
+        "workflows/echo.ts",
+        [
+          'import { step, workflow } from "veryfront/workflow";',
+          "",
+          "export default workflow({",
+          '  id: "echo",',
+          '  description: "Echo a message through a project-local tool.",',
+          '  steps: [step("start", { tool: "echo", input: { message: "hello" } })],',
+          "});",
+        ].join("\n"),
+      );
+
+      Deno.env.delete("REDIS_URL");
+      Deno.env.set("VERYFRONT_RUN_RESULT_PATH", resultPath);
+
+      await workflowCommand({
+        action: "run",
+        name: "echo",
+        input: undefined,
+        debug: false,
+        projectDir,
+      });
+
+      assertEquals(JSON.parse(await Deno.readTextFile(resultPath)), {
+        start: { echoed: "hello" },
+      });
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
   });
 });

--- a/cli/commands/workflow/command.ts
+++ b/cli/commands/workflow/command.ts
@@ -1,6 +1,10 @@
 import { cliLogger } from "#cli/utils";
 import { exitProcess } from "#cli/utils";
 import { withProjectSourceContext } from "#cli/shared/project-source-context";
+import { agentRegistry } from "../../../src/agent/composition/index.ts";
+import { discoverProjectAgentRuntime } from "../../../src/agent/project/agent-runtime.ts";
+import { toolRegistry } from "../../../src/tool/registry.ts";
+import type { WorkflowClientConfig } from "../../../src/workflow/api/workflow-client.ts";
 import { sanitizeRunOutputForLogging } from "../../utils/sanitize-run-output.ts";
 import { writeRunResultIfConfigured } from "../../utils/write-run-result.ts";
 import { getEnv } from "veryfront/platform";
@@ -9,7 +13,9 @@ import type { WorkflowArgs } from "./handler.ts";
 const WORKFLOW_STATUS_POLL_INTERVAL_MS = 1_000;
 const MAX_DISCOVERY_ERRORS_TO_PRINT = 5;
 
-export interface WorkflowOptions extends WorkflowArgs {}
+export interface WorkflowOptions extends WorkflowArgs {
+  projectDir?: string;
+}
 
 export interface WorkflowDiscoveryError {
   filePath: string;
@@ -30,26 +36,51 @@ export function formatWorkflowDiscoveryErrors(
   return lines;
 }
 
-async function createWorkflowClient(debug: boolean) {
+function formatRuntimeDiscoveryError(
+  error: { file: string; error: Error },
+): WorkflowDiscoveryError {
+  return {
+    filePath: error.file,
+    error: error.error.message,
+  };
+}
+
+function withProjectStepRegistries(config: WorkflowClientConfig): WorkflowClientConfig {
+  return {
+    ...config,
+    executor: {
+      ...config.executor,
+      stepExecutor: {
+        ...config.executor?.stepExecutor,
+        agentRegistry: config.executor?.stepExecutor?.agentRegistry ?? agentRegistry,
+        toolRegistry: config.executor?.stepExecutor?.toolRegistry ?? toolRegistry,
+      },
+    },
+  };
+}
+
+async function createWorkflowClient(config: WorkflowClientConfig) {
   const { createWorkflowClient } = await import(
     "../../../src/workflow/api/workflow-client.ts"
   );
+  const clientConfig = withProjectStepRegistries(config);
 
   const redisUrl = getEnv("REDIS_URL")?.trim();
   if (!redisUrl) {
-    return createWorkflowClient({ debug });
+    return createWorkflowClient(clientConfig);
   }
 
   const { RedisBackend } = await import(
     "../../../src/workflow/backends/redis.ts"
   );
 
+  const debug = clientConfig.debug ?? false;
   const backend = new RedisBackend({ url: redisUrl, debug });
   if (backend.initialize) {
     await backend.initialize();
   }
 
-  return createWorkflowClient({ backend, debug });
+  return createWorkflowClient({ ...clientConfig, backend });
 }
 
 async function waitForWorkflowExit(
@@ -115,44 +146,44 @@ export async function workflowCommand(options: WorkflowOptions): Promise<void> {
     }
   }
 
-  const { discoverWorkflows } = await import(
-    "../../../src/workflow/discovery/index.ts"
-  );
+  const projectDir = options.projectDir ?? Deno.cwd();
 
-  await withProjectSourceContext(Deno.cwd(), async ({ adapter, config, proxyContext }) => {
+  await withProjectSourceContext(projectDir, async ({ adapter, proxyContext }) => {
     const sourceLabel = proxyContext?.branchRef
       ? `branch ${proxyContext.branchRef}`
       : proxyContext
       ? "main"
-      : `${Deno.cwd()}/workflows/...`;
+      : `${projectDir}/workflows/...`;
 
     cliLogger.info(`Discovering workflows in ${sourceLabel}`);
 
-    const discovery = await discoverWorkflows({
-      projectDir: Deno.cwd(),
+    const discovery = await discoverProjectAgentRuntime({
+      projectDir,
       adapter,
-      config,
-      debug: options.debug,
+      verbose: options.debug,
     });
 
+    const workflows = [...discovery.workflows.values()];
+
     if (discovery.errors.length > 0 && options.debug) {
-      for (const err of discovery.errors) {
+      for (const err of discovery.errors.map(formatRuntimeDiscoveryError)) {
         cliLogger.warn(`  Warning: ${err.filePath}: ${err.error}`);
       }
     }
 
-    const workflow = discovery.workflows.find((candidate) => candidate.id === workflowId);
+    const workflow = workflows.find((candidate) => candidate.id === workflowId);
     if (!workflow) {
       cliLogger.error(`Workflow "${workflowId}" not found.`);
       if (discovery.errors.length > 0 && !options.debug) {
         cliLogger.warn("Some workflow files could not be loaded:");
-        for (const line of formatWorkflowDiscoveryErrors(discovery.errors)) {
+        const errors = discovery.errors.map(formatRuntimeDiscoveryError);
+        for (const line of formatWorkflowDiscoveryErrors(errors)) {
           cliLogger.warn(line);
         }
       }
-      if (discovery.workflows.length > 0) {
+      if (workflows.length > 0) {
         cliLogger.info("Available workflows:");
-        for (const candidate of discovery.workflows) {
+        for (const candidate of workflows) {
           cliLogger.info(`  - ${candidate.id}`);
         }
       } else {
@@ -162,7 +193,7 @@ export async function workflowCommand(options: WorkflowOptions): Promise<void> {
       return;
     }
 
-    const client = await createWorkflowClient(options.debug);
+    const client = await createWorkflowClient({ debug: options.debug });
 
     try {
       client.register(workflow.definition);

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.924",
+  "version": "0.1.925",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.924";
+export const VERSION = "0.1.925";

--- a/src/workflow/worker/dynamic-run-entrypoint.ts
+++ b/src/workflow/worker/dynamic-run-entrypoint.ts
@@ -29,8 +29,9 @@ import { logger as baseLogger } from "#veryfront/utils";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
 import { enhanceAdapterWithFS } from "#veryfront/platform/adapters/fs/integration.ts";
 import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
-import { discoverWorkflows } from "../discovery/index.ts";
-import type { VeryfrontConfig } from "#veryfront/config";
+import { agentRegistry } from "#veryfront/agent/composition/index.ts";
+import { discoverProjectAgentRuntime } from "#veryfront/agent/project/agent-runtime.ts";
+import { toolRegistry } from "#veryfront/tool/registry.ts";
 import type { WorkflowBackend } from "../backends/types.ts";
 import { WorkflowExecutor } from "../executor/workflow-executor.ts";
 import {
@@ -139,50 +140,53 @@ export async function runDynamicWorkflowRun(
           logger.info("FS adapter initialized");
         }
 
-        // Discover workflows from user's project
-        const discoveryResult = await discoverWorkflows({
+        // Discover workflows and the project-local agent/tool registries they may reference.
+        const discoveryResult = await discoverProjectAgentRuntime({
           projectDir: "", // Root of project (relative paths with API)
           adapter,
-          config: fsConfig as Partial<VeryfrontConfig> as VeryfrontConfig,
-          debug,
+          verbose: debug,
         });
 
         if (discoveryResult.errors.length > 0 && debug) {
           logger.warn("Some workflow files failed to load:", discoveryResult.errors);
         }
 
-        if (discoveryResult.workflows.length === 0) {
+        const workflows = [...discoveryResult.workflows.values()];
+
+        if (workflows.length === 0) {
           logger.error("No workflows discovered");
           return DYNAMIC_EXIT_CODES.DISCOVERY_FAILED;
         }
 
         if (debug) {
           logger.info(
-            `[DynamicWorkflowRun] Discovered ${discoveryResult.workflows.length} workflows:`,
-            discoveryResult.workflows.map((w) => w.id),
+            `[DynamicWorkflowRun] Discovered ${workflows.length} workflows:`,
+            workflows.map((w) => w.id),
           );
         }
 
         // Find the matching workflow
-        const workflow = discoveryResult.workflows.find((w) => w.id === run.workflowId);
+        const workflow = workflows.find((w) => w.id === run.workflowId);
         if (!workflow) {
           logger.error(`Workflow not found: ${run.workflowId}`);
           logger.error(
-            `[DynamicWorkflowRun] Available workflows: ${
-              discoveryResult.workflows.map((w) => w.id).join(", ")
-            }`,
+            `[DynamicWorkflowRun] Available workflows: ${workflows.map((w) => w.id).join(", ")}`,
           );
           return DYNAMIC_EXIT_CODES.NOT_FOUND;
         }
 
         if (debug) {
-          logger.info(`Found workflow "${workflow.id}" at ${workflow.filePath}`);
+          logger.info(`Found workflow "${workflow.id}"`);
         }
 
         // Create executor and register the workflow
         const executor = new WorkflowExecutor({
           backend,
           debug,
+          stepExecutor: {
+            agentRegistry,
+            toolRegistry,
+          },
         });
 
         executor.register(workflow.definition);

--- a/src/workflow/worker/run-entrypoint.ts
+++ b/src/workflow/worker/run-entrypoint.ts
@@ -22,6 +22,8 @@
 
 import { logger as baseLogger } from "#veryfront/utils";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { agentRegistry } from "#veryfront/agent/composition/index.ts";
+import { toolRegistry } from "#veryfront/tool/registry.ts";
 import type { WorkflowBackend } from "../backends/types.ts";
 import type { WorkflowExecutor } from "../executor/workflow-executor.ts";
 import type { WorkflowDefinition } from "../types.ts";
@@ -202,6 +204,10 @@ export async function createWorkflowRunEntrypoint(
   const executor = new WorkflowExecutor({
     backend,
     debug: options.debug,
+    stepExecutor: {
+      agentRegistry,
+      toolRegistry,
+    },
   });
 
   // Register workflows


### PR DESCRIPTION
## Summary
- discover the full project agent runtime for `veryfront workflow run`
- pass project-local agent/tool registries into CLI and worker workflow execution
- bump release version to `0.1.925`

## Verification
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all cli/commands/workflow/command.test.ts cli/commands/start/command.test.ts src/utils/version.test.ts src/utils/logger/logger.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/workflow/worker/run-entrypoint.test.ts`
- `deno check cli/commands/workflow/command.ts cli/commands/workflow/command.test.ts src/utils/version-constant.ts`
- `deno task fmt:check`
- `deno task lint:cli-boundary`
- pre-push hook: formatting, lint, typecheck, and full unit suite (`2204 passed`)
- demo workflow: source CLI ran `escalate-ticket` through support-agent skill/tool workflow successfully

## Similar issue audit
- checked other `WorkflowExecutor` / `createWorkflowClient` construction sites
- server request execution already uses runtime registries
- dev dashboard workflow client already receives registries
- CLI and worker entrypoints are covered by this PR
- remaining constructor call sites are low-level tests or explicit low-level API surfaces