### PR TITLE
Fix app-router route listing and SSG output writes

### DIFF
--- a/cli/commands/routes/command.ts
+++ b/cli/commands/routes/command.ts
@@ -1,9 +1,10 @@
-import { join } from "#std/path.ts";
+import { join, relative } from "#std/path.ts";
 import { runtime } from "veryfront/platform";
-import { APIRouteHandler } from "veryfront/routing";
 import { getConfig } from "veryfront/config";
 import { cliLogger } from "#cli/utils";
-import { createFileSystem, type FileSystem } from "veryfront/platform";
+import { ApiRouteMatcher } from "#veryfront/routing/api/api-route-matcher.ts";
+import { discoverAppRoutes, discoverPagesRoutes } from "#veryfront/routing/api/route-discovery.ts";
+import { RouteDiscovery } from "#veryfront/server/dev-server/route-discovery.ts";
 
 export interface RoutesOptions {
   projectDir: string;
@@ -14,36 +15,50 @@ export async function routesCommand(
   projectDir: string,
   options: { json?: boolean } = {},
 ): Promise<void> {
-  const fs = createFileSystem();
   const adapter = await runtime.get();
-  await getConfig(projectDir, adapter);
+  const config = await getConfig(projectDir, adapter);
 
-  const apiHandler = new APIRouteHandler(projectDir, adapter);
-  await apiHandler.initialize();
-
-  const pages: Array<{ pattern: string; file: string }> = [];
-  const pagesDir = join(projectDir, "pages");
-
+  const pageRouter = new ApiRouteMatcher();
+  let pageRoutes: Array<{ pattern: string; page: string }> = [];
   try {
-    const entries = fs.readDir(pagesDir);
-    for await (const entry of entries) {
-      if (!entry.isFile) continue;
-      if (!entry.name.endsWith(".mdx") && !entry.name.endsWith(".tsx")) continue;
+    await new RouteDiscovery(projectDir, adapter, pageRouter, config).discoverRoutes();
+    pageRoutes = pageRouter.listRoutes();
+  } finally {
+    pageRouter.destroy();
+  }
 
-      const slug = entry.name.replace(/\.(mdx|tsx)$/i, "");
-      const path = slug === "index" ? "/" : `/${slug}`;
-      pages.push({ pattern: path, file: `pages/${entry.name}` });
+  const pages = pageRoutes
+    .map((route) => ({
+      pattern: route.pattern,
+      file: toProjectRelativePath(projectDir, route.page),
+    }))
+    .sort((a, b) => a.pattern.localeCompare(b.pattern));
+
+  const apiRouter = new ApiRouteMatcher();
+  let apiRoutes: Array<{ pattern: string; page: string }> = [];
+  try {
+    const pagesDir = config.directories?.pages ?? "pages";
+    const apiDir = join(projectDir, pagesDir, "api");
+    if (await adapter.fs.exists(apiDir)) {
+      await discoverPagesRoutes(apiRouter, apiDir, "/api", adapter);
     }
-  } catch (error) {
-    // Pages directory might not exist, which is okay for app router projects
-    cliLogger.debug("Could not read pages directory:", error);
+
+    const appDir = join(projectDir, config.directories?.app ?? "app");
+    if (await adapter.fs.exists(appDir)) {
+      await discoverAppRoutes(apiRouter, appDir, "", adapter);
+    }
+
+    apiRoutes = apiRouter.listRoutes();
+  } finally {
+    apiRouter.destroy();
   }
 
-  const apis: string[] = [];
-  const apiDir = join(projectDir, "pages", "api");
-  if (await fs.exists(apiDir)) {
-    await collectApiPatterns(fs, apiDir, "/api", apis);
-  }
+  const apis = apiRoutes
+    .map((route) => ({
+      pattern: route.pattern,
+      file: toProjectRelativePath(projectDir, route.page),
+    }))
+    .sort((a, b) => a.pattern.localeCompare(b.pattern));
 
   if (options.json) {
     console.log(JSON.stringify({ pages, apis }, null, 2));
@@ -57,32 +72,10 @@ export async function routesCommand(
 
   cliLogger.info("\nAPI:");
   for (const a of apis) {
-    cliLogger.info(`  ${a}`);
+    cliLogger.info(`  ${a.pattern} -> ${a.file}`);
   }
 }
 
-async function collectApiPatterns(
-  fs: FileSystem,
-  dir: string,
-  prefix: string,
-  out: string[],
-): Promise<void> {
-  const entries = fs.readDir(dir);
-
-  for await (const entry of entries) {
-    const fullPath = join(dir, entry.name);
-
-    if (entry.isDirectory) {
-      await collectApiPatterns(fs, fullPath, `${prefix}/${entry.name}`, out);
-      continue;
-    }
-
-    if (!entry.isFile || !/\.(ts|js|tsx|jsx)$/i.test(entry.name)) continue;
-
-    const nameWithoutExt = entry.name.replace(/\.(ts|js|tsx|jsx)$/i, "");
-    const routePath = `${prefix}/${nameWithoutExt}`;
-    const pattern = routePath.replace(/\/index$/, "");
-
-    out.push(pattern);
-  }
+function toProjectRelativePath(projectDir: string, path: string): string {
+  return path.startsWith(projectDir) ? relative(projectDir, path) : path;
 }

--- a/cli/commands/routes/routes.integration.test.ts
+++ b/cli/commands/routes/routes.integration.test.ts
@@ -19,12 +19,32 @@ async function setupPagesRouter(context: TestContext): Promise<void> {
   );
 }
 
+async function setupAppRouter(context: TestContext): Promise<void> {
+  await remove(join(context.projectDir, "pages"), { recursive: true });
+
+  await mkdir(join(context.projectDir, "app", "api", "ag-ui"), { recursive: true });
+  await mkdir(join(context.projectDir, "app", "blog", "[slug]"), { recursive: true });
+
+  await writeTextFile(
+    join(context.projectDir, "app", "page.tsx"),
+    "export default function Home(){return <h1>Home</h1>}\n",
+  );
+  await writeTextFile(
+    join(context.projectDir, "app", "blog", "[slug]", "page.tsx"),
+    "export default function Blog(){return <h1>Blog</h1>}\n",
+  );
+  await writeTextFile(
+    join(context.projectDir, "app", "api", "ag-ui", "route.ts"),
+    "export const POST=()=>new Response('ok')\n",
+  );
+}
+
 async function captureConsoleLog(run: () => Promise<void>): Promise<string> {
   const output: string[] = [];
   const origLog = console.log;
 
   try {
-    console.log = (msg?: any, ...rest: any[]) => {
+    console.log = (msg?: unknown, ...rest: unknown[]) => {
       output.push(String(msg), ...rest.map(String));
     };
     await run();
@@ -118,12 +138,28 @@ describe("CLI routes command", () => {
       const jsonText = extractJson(text);
       const parsed = JSON.parse(jsonText) as {
         pages: Array<{ pattern: string; file: string }>;
-        apis: string[];
+        apis: Array<{ pattern: string; file: string }>;
       };
 
       if (!Array.isArray(parsed.pages) || !Array.isArray(parsed.apis)) {
         throw new Error("invalid json");
       }
+    });
+  });
+
+  it("prints app router pages and api routes", async () => {
+    await withTestContext("routes-app-router", async (context: TestContext) => {
+      await setupAppRouter(context);
+
+      const text = await captureConsoleLog(async () => {
+        await routesCommand(context.projectDir);
+      });
+
+      assertStringIncludes(text, "Pages:");
+      assertStringIncludes(text, "/ -> app/page.tsx");
+      assertStringIncludes(text, "/blog/[slug] -> app/blog/[slug]/page.tsx");
+      assertStringIncludes(text, "API:");
+      assertStringIncludes(text, "/api/ag-ui -> app/api/ag-ui/route.ts");
     });
   });
 });

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.927",
+  "version": "0.1.928",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/build/production-build/build/output-generator.test.ts
+++ b/src/build/production-build/build/output-generator.test.ts
@@ -24,8 +24,13 @@ describe("build/production-build/build/output-generator", () => {
 
     it("should write all production client scripts", async () => {
       const writes: { path: string; content: string }[] = [];
+      const mkdirs: string[] = [];
       const adapter = {
         fs: {
+          mkdir(path: string) {
+            mkdirs.push(path);
+            return Promise.resolve();
+          },
           writeFile(path: string, content: string) {
             writes.push({ path, content });
             return Promise.resolve();
@@ -40,6 +45,7 @@ describe("build/production-build/build/output-generator", () => {
       assertEquals(writes.some((write) => write.path.endsWith("_veryfront/client.js")), true);
       assertEquals(writes.some((write) => write.path.endsWith("_veryfront/router.js")), true);
       assertEquals(writes.some((write) => write.path.endsWith("_veryfront/prefetch.js")), true);
+      assertEquals(mkdirs.some((path) => path.endsWith("_veryfront")), true);
       assertEquals(
         writes.some((write) => write.path.endsWith("_veryfront/hydration-runtime.js")),
         true,

--- a/src/build/production-build/build/output-generator.ts
+++ b/src/build/production-build/build/output-generator.ts
@@ -10,7 +10,7 @@
  */
 
 import { serverLogger as logger } from "#veryfront/utils";
-import { join } from "#veryfront/compat/path/index.ts";
+import { dirname, join } from "#veryfront/compat/path/index.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { ChunkManifest } from "#veryfront/build/bundler/index.ts";
 import type { AppRouteInfo, BuildStats, RouteInfo } from "#veryfront/server/build-types.ts";
@@ -57,25 +57,42 @@ export async function generateClientScripts(
 
   if (dryRun) return;
 
-  await adapter.fs.writeFile(join(outputDir, "_veryfront/app.js"), generateAppModule());
-  await adapter.fs.writeFile(join(outputDir, "_veryfront/client.js"), await generateClientModule());
-  await adapter.fs.writeFile(
+  await writeOutputFile(adapter, join(outputDir, "_veryfront/app.js"), generateAppModule());
+  await writeOutputFile(
+    adapter,
+    join(outputDir, "_veryfront/client.js"),
+    await generateClientModule(),
+  );
+  await writeOutputFile(
+    adapter,
     join(outputDir, "_veryfront/router.js"),
     await generateRouterScript(adapter),
   );
-  await adapter.fs.writeFile(
+  await writeOutputFile(
+    adapter,
     join(outputDir, "_veryfront/prefetch.js"),
     await generatePrefetchScript(adapter),
   );
   const hydrationRuntime = generateProdHydrationModule();
-  await adapter.fs.writeFile(
+  await writeOutputFile(
+    adapter,
     join(outputDir, "_veryfront/hydration-runtime.js"),
     hydrationRuntime,
   );
-  await adapter.fs.writeFile(
+  await writeOutputFile(
+    adapter,
     join(outputDir, getProdHydrationModulePath().slice(1)),
     hydrationRuntime,
   );
+}
+
+async function writeOutputFile(
+  adapter: RuntimeAdapter,
+  path: string,
+  content: string,
+): Promise<void> {
+  await adapter.fs.mkdir(dirname(path), { recursive: true });
+  await adapter.fs.writeFile(path, content);
 }
 
 /**

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.927";
+export const VERSION = "0.1.928";


### PR DESCRIPTION
## Summary
- make `veryfront routes` use the same route discovery path as runtime/build, including app-router pages and app/api routes
- create runtime output directories before writing `_veryfront/*` client scripts during production SSG builds
- bump package version to `0.1.928` for release validation

## Verification
- `deno fmt --check cli/commands/routes/command.ts cli/commands/routes/routes.integration.test.ts src/build/production-build/build/output-generator.ts src/build/production-build/build/output-generator.test.ts deno.json src/utils/version-constant.ts`
- `deno lint --config=scripts/test.deno.json cli/commands/routes/command.ts cli/commands/routes/routes.integration.test.ts src/build/production-build/build/output-generator.ts src/build/production-build/build/output-generator.test.ts`
- `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/build/production-build/build/output-generator.test.ts cli/commands/routes/routes.integration.test.ts cli/commands/routes/command.test.ts`
- `deno run --allow-read scripts/lint/check-sanitizer-baseline.ts`
- pre-push gate: format, lint, typecheck, and unit tests passed (2204 tests / 18901 steps)
- patched local CLI verified against `customer-operations-agent`: `routes` lists `app/page.tsx` and `app/api/ag-ui/route.ts`; `build --ssg` completes successfully