### PR TITLE
Allow explicit eval IDs in CLI lookup

### DIFF
--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { compareEvalReports, type EvalReport } from "veryfront/eval";
+import { compareEvalReports, type DiscoveredEval, type EvalReport } from "veryfront/eval";
 import {
   createDefaultEvalReportDir,
   createEvalArtifactPaths,
@@ -9,6 +9,7 @@ import {
   createJunitXml,
   createResultsJsonl,
   createSummaryArtifact,
+  findEvalForCliId,
   normalizeEvalCliId,
   normalizeEvalInputForAgent,
   summarizeReportForCli,
@@ -128,6 +129,17 @@ describe("eval CLI command helpers", () => {
   it("normalizes eval ids without requiring users to type the namespace", () => {
     assertEquals(normalizeEvalCliId("deep-research"), "eval:deep-research");
     assertEquals(normalizeEvalCliId("eval:deep-research"), "eval:deep-research");
+  });
+
+  it("finds explicit eval ids without forcing the namespace", () => {
+    const evals = [
+      { id: "custom-capital" },
+      { id: "eval:deep-research" },
+    ] as DiscoveredEval[];
+
+    assertEquals(findEvalForCliId(evals, "custom-capital")?.id, "custom-capital");
+    assertEquals(findEvalForCliId(evals, "deep-research")?.id, "eval:deep-research");
+    assertEquals(findEvalForCliId(evals, "eval:custom-capital")?.id, "custom-capital");
   });
 
   it("normalizes structured eval inputs into agent prompts", () => {

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -125,6 +125,19 @@ export function normalizeEvalCliId(id: string): string {
   return id.startsWith("eval:") ? id : `eval:${id}`;
 }
 
+function createEvalCliIdCandidates(id: string): string[] {
+  const normalized = normalizeEvalCliId(id);
+  const bare = normalized.startsWith("eval:") ? normalized.slice("eval:".length) : normalized;
+  return Array.from(new Set([id, normalized, bare]));
+}
+
+export function findEvalForCliId(evals: DiscoveredEval[], id: string): DiscoveredEval | undefined {
+  const candidates = createEvalCliIdCandidates(id);
+  return candidates
+    .map((candidate) => evals.find((item) => item.id === candidate))
+    .find((item) => item !== undefined);
+}
+
 export function normalizeEvalInputForAgent(input: unknown): string {
   if (typeof input === "string") return input;
   if (input && typeof input === "object") {
@@ -440,7 +453,7 @@ export async function evalCommand(options: EvalOptions): Promise<void> {
     }
 
     const evalId = normalizeEvalCliId(options.id);
-    const evalItem = evalDiscovery.evals.find((item) => item.id === evalId);
+    const evalItem = findEvalForCliId(evalDiscovery.evals, options.id);
     if (!evalItem) {
       await outputEvalNotFound(evalId, evalDiscovery.evals);
       return;

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.929",
+  "version": "0.1.930",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.929";
+export const VERSION = "0.1.930";


### PR DESCRIPTION
## Summary
- Fixes eval CLI lookup so explicit IDs like `id: "capital"` can be run with `veryfront eval capital`.
- Preserves existing short-name lookup for file-derived `eval:<path>` IDs.
- Adds regression coverage for exact, namespaced, and bare eval ID forms.

## Test plan
- `deno fmt --check cli/commands/eval/command.ts cli/commands/eval/command.test.ts`
- `deno check cli/commands/eval/command.ts cli/commands/eval/command.test.ts`
- `deno lint cli/commands/eval/command.ts cli/commands/eval/command.test.ts`
- `deno test --no-check --allow-all cli/commands/eval/command.test.ts src/eval/discovery.test.ts src/eval/runner.test.ts src/eval/factory.test.ts src/eval/metrics.test.ts src/eval/datasets.test.ts src/eval/baseline.test.ts src/eval/report.test.ts src/eval/studio.test.ts src/eval/agent-service.test.ts`
- Pre-push hook: full formatting, lint, typecheck, and unit tests (`2204 passed`, `0 failed`).