### PR TITLE
Serve app-router hydration modules in production

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.930",
+  "version": "0.1.931",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/handlers/request/css.handler.test.ts
+++ b/src/server/handlers/request/css.handler.test.ts
@@ -1,0 +1,71 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { CSSHandler } from "./css.handler.ts";
+import type { HandlerContext } from "../types.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+
+function createMockAdapter(files: Record<string, string> = {}): RuntimeAdapter {
+  return {
+    id: "memory",
+    name: "mock",
+    capabilities: {
+      typescript: true,
+      jsx: true,
+      fileWatcher: false,
+      shell: false,
+      kvStore: false,
+      workers: false,
+    },
+    fs: {
+      exists: (path: string) => Promise.resolve(Object.hasOwn(files, path)),
+      readFile: (path: string) => {
+        const content = files[path];
+        if (content === undefined) return Promise.reject(new Error("Not found"));
+        return Promise.resolve(content);
+      },
+      writeFile: () => Promise.resolve(),
+      readDir: () => Promise.resolve([]),
+      mkdir: () => Promise.resolve(),
+      remove: () => Promise.resolve(),
+      stat: () => Promise.resolve({ isFile: false, isDirectory: false, size: 0, mtime: null }),
+    },
+    env: {
+      get: () => undefined,
+      set: () => {},
+      delete: () => {},
+      toObject: () => ({}),
+    },
+    server: { createHandler: () => () => new Response() },
+    serve: () => Promise.resolve({ close: () => Promise.resolve() } as any),
+  } as unknown as RuntimeAdapter;
+}
+
+function makeCtx(files: Record<string, string> = {}): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter: createMockAdapter(files),
+    securityConfig: {},
+    cspUserHeader: null,
+    config: {} as HandlerContext["config"],
+    parsedDomain: { allowIframeEmbed: false } as HandlerContext["parsedDomain"],
+  } as HandlerContext;
+}
+
+describe("server/handlers/request/css", () => {
+  it("serves built CSS files from local dist when the JIT cache misses", async () => {
+    const handler = new CSSHandler();
+
+    const result = await handler.handle(
+      new Request("http://localhost/_vf/css/jecaqb.css"),
+      makeCtx({
+        "/project/dist/_vf/css/jecaqb.css": ".flex{display:flex}",
+      }),
+    );
+
+    const response = result.response!;
+    assertEquals(response.status, 200);
+    assertEquals(response.headers.get("content-type"), "text/css; charset=utf-8");
+    assertEquals(await response.text(), ".flex{display:flex}");
+  });
+});

--- a/src/server/handlers/request/css.handler.ts
+++ b/src/server/handlers/request/css.handler.ts
@@ -11,6 +11,7 @@ import {
 } from "#veryfront/cache/cache-key-builder.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
+import { join } from "#veryfront/compat/path/index.ts";
 
 /** Pattern to match hashed CSS URLs: /_vf/css/[8-char-hash].css */
 const CSS_URL_PATTERN = /^\/_vf\/css\/([a-z0-9-]{1,16})\.css$/;
@@ -23,6 +24,20 @@ async function getCSSWithJITFallback(
   if (cached) return cached;
 
   return regenerateCSSByHash(cssHash, projectSlug);
+}
+
+async function getBuiltCSSFallback(
+  cssHash: string,
+  ctx: HandlerContext,
+): Promise<string | undefined> {
+  const builtCSSPath = join(ctx.projectDir, "dist", "_vf", "css", `${cssHash}.css`);
+  try {
+    const exists = await ctx.adapter.fs.exists(builtCSSPath);
+    if (!exists) return undefined;
+    return await ctx.adapter.fs.readFile(builtCSSPath);
+  } catch {
+    return undefined;
+  }
 }
 
 export class CSSHandler extends BaseHandler {
@@ -72,7 +87,9 @@ export class CSSHandler extends BaseHandler {
       )
       : await lookup();
 
-    if (!css) {
+    const resolvedCSS = css ?? await getBuiltCSSFallback(cssHash, ctx);
+
+    if (!resolvedCSS) {
       this.logInfo(
         `CSS not found and JIT regeneration failed: ${cssHash}. ` +
           `Server restart or cache expiry. Reload page to regenerate.`,
@@ -94,7 +111,7 @@ export class CSSHandler extends BaseHandler {
       return this.respond(response);
     }
 
-    const body = method === "HEAD" ? null : css;
+    const body = method === "HEAD" ? null : resolvedCSS;
 
     const response = this.createResponseBuilder(ctx)
       .withCORS(req, ctx.securityConfig?.cors)

--- a/src/server/handlers/request/rsc/index.test.ts
+++ b/src/server/handlers/request/rsc/index.test.ts
@@ -5,7 +5,9 @@ import { RSCHandler } from "./index.ts";
 import type { HandlerContext } from "../../types.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 
-function createMockAdapter(): RuntimeAdapter {
+function createMockAdapter(
+  overrides: Partial<RuntimeAdapter["fs"]> = {},
+): RuntimeAdapter {
   return {
     id: "memory",
     name: "mock",
@@ -25,6 +27,7 @@ function createMockAdapter(): RuntimeAdapter {
       mkdir: () => Promise.resolve(),
       remove: () => Promise.resolve(),
       stat: () => Promise.resolve({ isFile: false, isDirectory: false, size: 0, mtime: null }),
+      ...overrides,
     },
     env: {
       get: () => undefined,
@@ -70,5 +73,20 @@ describe("server/handlers/request/rsc", () => {
       true,
     );
     assertEquals(html.includes(`<script type="module" nonce="${nonce}">`), true);
+  });
+
+  it("passes app router client module requests through without the experimental RSC flag", async () => {
+    const handler = new RSCHandler();
+
+    const result = await handler.handle(
+      new Request("http://localhost/_veryfront/rsc/module"),
+      makeCtx({
+        config: {} as HandlerContext["config"],
+      }),
+    );
+
+    const response = result.response!;
+    assertEquals(response.status, 400);
+    assertEquals(await response.text(), "Missing rel query parameter");
   });
 });

--- a/src/server/handlers/request/rsc/index.ts
+++ b/src/server/handlers/request/rsc/index.ts
@@ -39,9 +39,15 @@ export class RSCHandler extends BaseHandler {
       "rsc.handle",
       async () => {
         const isHydrationScript = endpoint === "client.js" || endpoint === "dom.js";
+        const isClientModuleEndpoint = endpoint === "module";
         const isDeprecatedEndpoint = endpoint === "flight_page";
 
-        if (!isRSCEnabled(ctx.config) && !isHydrationScript && !isDeprecatedEndpoint) {
+        if (
+          !isRSCEnabled(ctx.config) &&
+          !isHydrationScript &&
+          !isClientModuleEndpoint &&
+          !isDeprecatedEndpoint
+        ) {
           return this.respond(new Response("Not Found", { status: HTTP_NOT_FOUND }));
         }
 

--- a/src/server/services/rsc/endpoints/endpoint-router.test.ts
+++ b/src/server/services/rsc/endpoints/endpoint-router.test.ts
@@ -110,14 +110,15 @@ describe("server/services/rsc/endpoints/endpoint-router", () => {
       assertEquals(result, null);
     });
 
-    it("returns null for module endpoint when RSC disabled", async () => {
+    it("keeps the module endpoint available when RSC disabled", async () => {
       const result = await handleRSCEndpoint(
         makeParams({
           pathname: "/_veryfront/rsc/module",
           config: rscDisabledConfig,
         }),
       );
-      assertEquals(result, null);
+      assertEquals(result instanceof Response, true);
+      assertEquals(result!.status, 400);
     });
   });
 
@@ -233,6 +234,38 @@ describe("server/services/rsc/endpoints/endpoint-router", () => {
       const body = await result!.text();
       assertStringIncludes(body, 'from "react/jsx-runtime"');
       assertStringIncludes(body, '"data-kind": "widget"');
+    });
+
+    it("ignores CSS side-effect imports for app router hydration modules", async () => {
+      const files: Record<string, string> = {
+        "/tmp/test-project/app/layout.tsx": [
+          'import "../globals.css";',
+          "export default function Layout({ children }: { children: React.ReactNode }) {",
+          "  return <html><body>{children}</body></html>;",
+          "}",
+        ].join("\n"),
+        "/tmp/test-project/globals.css": '@import "tailwindcss";',
+      };
+      const adapter = createMockAdapter({
+        exists: (path: string) => Promise.resolve(path in files),
+        readFile: (path: string) => Promise.resolve(files[path] ?? ""),
+      });
+
+      const result = await handleRSCEndpoint(
+        makeParams({
+          pathname: "/_veryfront/rsc/module",
+          config: rscDisabledConfig,
+          req: new Request("http://localhost/_veryfront/rsc/module?rel=app%2Flayout.tsx"),
+          adapter,
+          projectDir: "/tmp/test-project",
+        }),
+      );
+
+      assertEquals(result instanceof Response, true);
+      assertEquals(result!.status, 200);
+      const body = await result!.text();
+      assertStringIncludes(body, "function Layout");
+      assertEquals(body.includes("tailwindcss"), false);
     });
 
     it("returns 404 when file not found in any candidate root", async () => {

--- a/src/server/services/rsc/endpoints/endpoint-router.ts
+++ b/src/server/services/rsc/endpoints/endpoint-router.ts
@@ -53,14 +53,26 @@ export async function handleRSCEndpoint(
     return new Response("Flight endpoint removed. Use custom RSC endpoints.", { status: 410 });
   }
 
-  if (!isRSCEnabled(config)) {
-    return null;
-  }
-
   const url = new URL(req.url);
-  const handler = getRSCHandler(projectDir, projectId);
 
   try {
+    // App-router client-page hydration imports browser-safe page modules from
+    // this endpoint even when the broader RSC transport is not enabled.
+    if (sub === "module") {
+      return await handleModuleEndpoint({
+        searchParams: url.searchParams,
+        projectDir,
+        adapter,
+        config,
+      });
+    }
+
+    if (!isRSCEnabled(config)) {
+      return null;
+    }
+
+    const handler = getRSCHandler(projectDir, projectId);
+
     if (sub.startsWith("render/")) {
       return handler.handleRender(sub.replace("render/", ""), url.searchParams, req);
     }
@@ -108,15 +120,6 @@ export async function handleRSCEndpoint(
     if (sub === "payload") {
       metrics.recordRSC("page");
       return handlePayloadEndpoint({ handler, searchParams: url.searchParams });
-    }
-
-    if (sub === "module") {
-      return await handleModuleEndpoint({
-        searchParams: url.searchParams,
-        projectDir,
-        adapter,
-        config,
-      });
     }
 
     if (sub === "page") {

--- a/src/server/shared/browser-module-bundler.ts
+++ b/src/server/shared/browser-module-bundler.ts
@@ -1,5 +1,6 @@
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
+import type { OnLoadArgs, OnResolveArgs, Plugin, PluginBuild } from "veryfront/extensions/bundler";
 import { buildImportMapJson } from "#veryfront/html";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { getDirectory, getEsbuildLoader } from "#veryfront/utils/path-utils.ts";
@@ -8,6 +9,22 @@ import {
   createHttpExternalPlugin,
   createRelativeFsPlugin,
 } from "#veryfront/server/handlers/dev/files/esbuild-plugins.ts";
+
+function createIgnoreCSSImportsPlugin(): Plugin {
+  return {
+    name: "veryfront-ignore-css-imports",
+    setup(build: PluginBuild) {
+      build.onResolve({ filter: /\.css(?:\?.*)?$/ }, (args: OnResolveArgs) => ({
+        path: args.path,
+        namespace: "veryfront-empty-css",
+      }));
+      build.onLoad({ filter: /.*/, namespace: "veryfront-empty-css" }, (_args: OnLoadArgs) => ({
+        contents: "",
+        loader: "js",
+      }));
+    },
+  };
+}
 
 export interface BrowserModuleBundlerOptions {
   adapter: RuntimeAdapter;
@@ -47,6 +64,7 @@ export function bundleBrowserModule(
           sourcefile: absPath,
         },
         plugins: [
+          createIgnoreCSSImportsPlugin(),
           createRelativeFsPlugin(options.projectDir, options.adapter),
           createBareExternalPlugin({
             importMapImports: importMap.imports,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.930";
+export const VERSION = "0.1.931";


### PR DESCRIPTION
## Summary
- keep `/_veryfront/rsc/module` available for app-router hydration modules in hosted production, even when the broader RSC transport is not enabled
- ignore CSS side-effect imports while bundling browser-safe app-router modules
- serve built CSS artifacts from `dist/_vf/css` when the JIT CSS cache misses
- bump `deno.json` and `src/utils/version-constant.ts` to `0.1.931` for release

## Verification
- `deno test --no-check --allow-all src/server/handlers/request/rsc/index.test.ts src/server/services/rsc/endpoints/endpoint-router.test.ts src/server/handlers/request/css.handler.test.ts`
- `deno test --no-check --allow-all tests/integration/server/rsc/client-modules.test.ts tests/integration/server/rsc/endpoints-prod.test.ts src/rendering/rsc/client-module-strategy.test.ts src/html/hydration-script-builder/templates/renderer.test.ts`
- `deno task lint`
- `deno task typecheck`
- `deno fmt --check src/server/handlers/request/rsc/index.ts src/server/handlers/request/rsc/index.test.ts src/server/services/rsc/endpoints/endpoint-router.ts src/server/services/rsc/endpoints/endpoint-router.test.ts src/server/shared/browser-module-bundler.ts src/server/handlers/request/css.handler.ts src/server/handlers/request/css.handler.test.ts src/utils/version-constant.ts deno.json`
- `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts`

## Known gap
- Browser regression `tests/e2e/regressions/rsc-proxy-hydration.test.ts` could not complete locally because Chromium launch timed out before navigation; the same module route is covered by HTTP/integration tests above.