### PR TITLE
Fix RSC module hydration in proxy deployments

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.931",
+  "version": "0.1.932",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/handlers/request/rsc/index.test.ts
+++ b/src/server/handlers/request/rsc/index.test.ts
@@ -89,4 +89,72 @@ describe("server/handlers/request/rsc", () => {
     assertEquals(response.status, 400);
     assertEquals(await response.text(), "Missing rel query parameter");
   });
+
+  it("serves app router client module requests inside the multi-project filesystem context", async () => {
+    const handler = new RSCHandler();
+    let contextActive = false;
+    let runWithContextArgs: unknown[] | undefined;
+    const adapter = createMockAdapter({
+      exists: () => {
+        if (!contextActive) {
+          throw new Error("missing multi-project context");
+        }
+        return Promise.resolve(false);
+      },
+    });
+
+    adapter.fs = {
+      ...adapter.fs,
+      isVeryfrontAdapter: () => true,
+      getUnderlyingAdapter: () => ({}),
+      isMultiProjectMode: () => true,
+      isContextualMode: () => false,
+      runWithContext: async (
+        slug: string,
+        token: string,
+        fn: () => Promise<unknown>,
+        projectId?: string,
+        options?: unknown,
+      ) => {
+        runWithContextArgs = [slug, token, projectId, options];
+        contextActive = true;
+        try {
+          return await fn();
+        } finally {
+          contextActive = false;
+        }
+      },
+    } as RuntimeAdapter["fs"];
+
+    const result = await handler.handle(
+      new Request("http://localhost/_veryfront/rsc/module?rel=app%2Fpage.tsx"),
+      makeCtx({
+        adapter,
+        projectSlug: "customer-operations-agent",
+        projectId: "proj-123",
+        proxyToken: "proxy-token",
+        releaseId: "rel-123",
+        environmentName: "Preview",
+        resolvedEnvironment: "preview",
+        requestContext: {
+          slug: "customer-operations-agent",
+          branch: "main",
+          mode: "preview",
+          token: "proxy-token",
+        },
+      }),
+    );
+
+    const response = result.response!;
+    assertEquals(response.status, 404);
+    assertEquals(runWithContextArgs?.[0], "customer-operations-agent");
+    assertEquals(runWithContextArgs?.[1], "proxy-token");
+    assertEquals(runWithContextArgs?.[2], "proj-123");
+    assertEquals(runWithContextArgs?.[3], {
+      productionMode: false,
+      releaseId: "rel-123",
+      branch: "main",
+      environmentName: "Preview",
+    });
+  });
 });

--- a/src/server/handlers/request/rsc/index.ts
+++ b/src/server/handlers/request/rsc/index.ts
@@ -18,6 +18,8 @@ import { applyCORSHeaders } from "#veryfront/security";
 import { HTTP_NOT_FOUND, PRIORITY_MEDIUM } from "#veryfront/utils/constants/index.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { generateNonce } from "#veryfront/security/http/response/security-handler.ts";
+import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 export class RSCHandler extends BaseHandler {
   metadata: HandlerMetadata = {
@@ -52,15 +54,37 @@ export class RSCHandler extends BaseHandler {
         }
 
         const nonce = generateNonce();
-        const res = await handleRSCEndpoint({
-          req,
-          pathname,
-          projectDir: ctx.projectDir,
-          projectId: ctx.projectId,
-          adapter: ctx.adapter,
-          config: ctx.config,
-          nonce,
-        });
+        const execute = () =>
+          handleRSCEndpoint({
+            req,
+            pathname,
+            projectDir: ctx.projectDir,
+            projectId: ctx.projectId,
+            adapter: ctx.adapter,
+            config: ctx.config,
+            nonce,
+          });
+        const fsAdapter = ctx.adapter.fs;
+        const isMultiProject = ctx.projectSlug &&
+          isExtendedFSAdapter(fsAdapter) &&
+          fsAdapter.isMultiProjectMode();
+
+        const res = isMultiProject
+          ? await fsAdapter.runWithContext(
+            ctx.projectSlug!,
+            ctx.proxyToken || getHostEnv("VERYFRONT_API_TOKEN") || "",
+            execute,
+            ctx.projectId,
+            {
+              productionMode: isRSCProductionMode(ctx),
+              releaseId: ctx.releaseId,
+              branch: ctx.resolvedEnvironment === "production"
+                ? null
+                : ctx.requestContext?.branch ?? ctx.parsedDomain?.branch ?? null,
+              environmentName: ctx.environmentName,
+            },
+          )
+          : await execute();
 
         if (!res) {
           return this.continue();
@@ -85,4 +109,9 @@ export class RSCHandler extends BaseHandler {
       { "rsc.pathname": pathname, "rsc.endpoint": endpoint },
     );
   }
+}
+
+function isRSCProductionMode(ctx: HandlerContext): boolean {
+  if (ctx.config?.fs?.veryfront?.productionMode === true) return true;
+  return (ctx.resolvedEnvironment ?? ctx.requestContext?.mode) === "production";
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.931";
+export const VERSION = "0.1.932";


### PR DESCRIPTION
## Summary
- Wrap RSC endpoint handling in the multi-project filesystem context when proxy mode is active
- Preserve project/release/branch/environment context for app-router client module hydration
- Bump framework package version to 0.1.932 for release automation
- Add regression coverage for RSC module requests using proxy filesystem context

## Verification
- deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/server/handlers/request/rsc/index.test.ts src/server/services/rsc/endpoints/endpoint-router.test.ts
- deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- deno task fmt:check && deno task typecheck
- deno task test:unit (2205 passed, 0 failed)
- pre-push hook passed formatting, lint, typecheck, and unit tests

## Follow-up
After this publishes, redeploy customer-operations-agent and smoke the preview URL for clean RSC module hydration.