### PR TITLE
Fix Cloud RAG contentDir indexing in deployed releases

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.932",
+  "version": "0.1.933",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/embedding/rag-store.test.ts
+++ b/src/embedding/rag-store.test.ts
@@ -576,6 +576,146 @@ describe("ragStore", () => {
     );
   });
 
+  it("indexes contentDir from published release files in request context", async () => {
+    registerTestEmbeddingProvider();
+
+    const ragDocuments = new Map<string, {
+      id: string;
+      title: string;
+      source: string;
+      type: string;
+      created_at: string;
+      updated_at: string;
+      metadata?: Record<string, unknown>;
+    }>();
+    const fileChunks = new Map<
+      string,
+      Array<{
+        id: string;
+        index: number;
+        content: string;
+        metadata?: Record<string, unknown>;
+      }>
+    >();
+    const requestedPaths: string[] = [];
+
+    await withMockFetch(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const url = new URL(request.url);
+        requestedPaths.push(url.pathname);
+
+        if (
+          request.method === "GET" &&
+          url.pathname === "/projects/cloud-project/releases/rel-abc/files"
+        ) {
+          return Response.json({
+            data: [
+              {
+                id: "file-login",
+                version_id: "version-login",
+                path: "knowledge/login-troubleshooting.md",
+                content: "# Login troubleshooting\n\nEscalate blocked SSO login issues.",
+                size: 62,
+                type: "file",
+                updated_at: "2026-06-25T00:00:00.000Z",
+                release_id: "rel-abc",
+                release_version: "0.0.1",
+              },
+            ],
+            page_info: { next: null },
+            release_id: "rel-abc",
+            release_version: "0.0.1",
+          });
+        }
+
+        const ragDocMatch = url.pathname.match(/^\/projects\/[^/]+\/rag\/documents(?:\/(.+))?$/);
+        if (ragDocMatch !== null) {
+          const docId = ragDocMatch[1] ? decodeURIComponent(ragDocMatch[1]) : null;
+
+          if (request.method === "GET" && !docId) {
+            return Response.json({ documents: [...ragDocuments.values()] });
+          }
+
+          if (request.method === "POST" && !docId) {
+            const body = await request.json() as {
+              id: string;
+              title: string;
+              source: string;
+              type: string;
+              metadata?: Record<string, unknown>;
+            };
+            ragDocuments.set(body.id, {
+              ...body,
+              created_at: "2026-06-25T00:00:00.000Z",
+              updated_at: "2026-06-25T00:00:00.000Z",
+            });
+            return Response.json({ document: ragDocuments.get(body.id) });
+          }
+        }
+
+        const fileMatch = url.pathname.match(
+          /^\/projects\/[^/]+\/branches\/[^/]+\/files\/(.+)\/chunks$/,
+        );
+        const filePath = fileMatch ? decodeURIComponent(fileMatch[1] ?? "") : null;
+
+        if (request.method === "POST" && filePath) {
+          const body = await request.json() as {
+            chunks: Array<{
+              chunk_index: number;
+              content: string;
+              metadata?: Record<string, unknown>;
+            }>;
+          };
+          const stored = body.chunks.map((chunk) => ({
+            id: `${filePath}:${chunk.chunk_index}`,
+            index: chunk.chunk_index,
+            content: chunk.content,
+            metadata: chunk.metadata,
+          }));
+          fileChunks.set(filePath, stored);
+          return Response.json({
+            chunks: stored.map(({ id, index }) => ({ id, index })),
+          });
+        }
+
+        if (request.method === "POST" && url.pathname.endsWith("/embeddings")) {
+          return Response.json({
+            embeddings: [{ id: "embedding-1", model: "test/demo", status: "ready" }],
+          });
+        }
+
+        throw new Error(`Unhandled ${request.method} ${url.pathname}`);
+      },
+      async () => {
+        const store = ragStore({
+          contentDir: "knowledge",
+          model: "test/demo",
+        });
+
+        await runWithRequestContext(
+          {
+            projectSlug: "cloud-project",
+            token: "vf_request_token",
+            productionMode: true,
+            releaseId: "rel-abc",
+          },
+          () => store.indexContentDir(),
+        );
+
+        const documents = [...ragDocuments.values()];
+        assertEquals(documents.length, 1);
+        assertEquals(documents[0]?.title, "login-troubleshooting");
+        assertEquals(documents[0]?.source, "knowledge/login-troubleshooting.md");
+        assertEquals(fileChunks.size, 1);
+        assertEquals(
+          requestedPaths.includes("/projects/cloud-project/releases/rel-abc/files"),
+          true,
+        );
+      },
+    );
+  });
+
   it("respects VERYFRONT_RAG_BACKEND=local-json as an override", async () => {
     setEnv("VERYFRONT_API_TOKEN", "vf_test_cloud");
     setEnv("VERYFRONT_PROJECT_SLUG", "cloud-project");

--- a/src/embedding/veryfront-cloud/rag-store.ts
+++ b/src/embedding/veryfront-cloud/rag-store.ts
@@ -77,6 +77,9 @@ interface CloudStoreContext {
   fetch: typeof fetch;
   projectSlug: string;
   branch: string;
+  environmentName?: string | null;
+  hasRequestContext: boolean;
+  releaseId?: string | null;
 }
 
 interface ChunkMutationInput {
@@ -89,6 +92,26 @@ interface ChunkMutationInput {
 }
 
 type ResolvedCloudRagStoreConfig = RagStoreConfig & { model: string };
+
+interface ContentFile {
+  path: string;
+  content?: string;
+}
+
+interface CloudFileListResponse {
+  data: Array<{
+    path: string;
+    content?: string;
+  }>;
+  page_info?: {
+    next?: string | null;
+  };
+}
+
+interface CloudFileDetailResponse {
+  path: string;
+  content: string;
+}
 
 function buildUrl(base: string, path: string): string {
   return `${base.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
@@ -212,6 +235,7 @@ async function requestJson<T>(
 
 function getCloudStoreContext(config: RagStoreConfig): CloudStoreContext {
   const bootstrap = requireVeryfrontCloudBootstrap();
+  const requestContext = getCurrentRequestContext();
   if (!bootstrap.projectSlug) {
     throw INVALID_ARGUMENT.create({
       detail:
@@ -223,7 +247,10 @@ function getCloudStoreContext(config: RagStoreConfig): CloudStoreContext {
     apiBaseUrl: bootstrap.apiBaseUrl,
     fetch: createVeryfrontCloudFetch(bootstrap.apiToken),
     projectSlug: bootstrap.projectSlug,
-    branch: config.branch ?? getCurrentRequestContext()?.branch ?? "main",
+    branch: config.branch ?? requestContext?.branch ?? "main",
+    environmentName: requestContext?.environmentName ?? null,
+    hasRequestContext: requestContext !== null,
+    releaseId: requestContext?.releaseId ?? null,
   };
 }
 
@@ -459,8 +486,8 @@ function createEmbedder(config: ResolvedCloudRagStoreConfig) {
 async function listContentFiles(
   contentDir: string,
   contentExtensions: Set<string>,
-): Promise<string[]> {
-  const files: string[] = [];
+): Promise<ContentFile[]> {
+  const files: ContentFile[] = [];
 
   try {
     for await (const entry of readDir(contentDir)) {
@@ -468,7 +495,7 @@ async function listContentFiles(
       if (entry.isDirectory) {
         files.push(...(await listContentFiles(fullPath, contentExtensions)));
       } else if (entry.isFile && contentExtensions.has(extname(entry.name))) {
-        files.push(fullPath);
+        files.push({ path: fullPath });
       }
     }
   } catch (_) {
@@ -476,6 +503,117 @@ async function listContentFiles(
   }
 
   return files;
+}
+
+function buildContentDirPattern(contentDir: string): string {
+  return `${contentDir.replace(/\/+$/, "")}/**`;
+}
+
+function buildContentFilesQuery(
+  context: CloudStoreContext,
+  contentDir: string,
+  cursor?: string | null,
+): string {
+  const params = new URLSearchParams({
+    include_server_functions: "true",
+    limit: "100",
+    pattern: buildContentDirPattern(contentDir),
+  });
+
+  if (!context.releaseId && !context.environmentName) {
+    params.set("branch", context.branch);
+  }
+
+  if (cursor) {
+    params.set("cursor", cursor);
+  }
+
+  return params.toString();
+}
+
+function getPublishedFileListPath(
+  context: CloudStoreContext,
+  contentDir: string,
+  cursor?: string | null,
+): string {
+  const query = buildContentFilesQuery(context, contentDir, cursor);
+  const projectRef = encodeURIComponent(context.projectSlug);
+
+  if (context.releaseId) {
+    return `/projects/${projectRef}/releases/${
+      encodeURIComponent(context.releaseId)
+    }/files?${query}`;
+  }
+
+  if (context.environmentName) {
+    return `/projects/${projectRef}/environments/${
+      encodeURIComponent(context.environmentName)
+    }/files?${query}`;
+  }
+
+  return `/projects/${projectRef}/files?${query}`;
+}
+
+function getPublishedFileDetailPath(context: CloudStoreContext, path: string): string {
+  const query = new URLSearchParams({ include_server_functions: "true" });
+  const projectRef = encodeURIComponent(context.projectSlug);
+  const encodedPath = encodeURIComponent(path);
+
+  if (context.releaseId) {
+    return `/projects/${projectRef}/releases/${
+      encodeURIComponent(context.releaseId)
+    }/files/${encodedPath}?${query}`;
+  }
+
+  if (context.environmentName) {
+    return `/projects/${projectRef}/environments/${
+      encodeURIComponent(context.environmentName)
+    }/files/${encodedPath}?${query}`;
+  }
+
+  query.set("branch", context.branch);
+  return `/projects/${projectRef}/files/${encodedPath}?${query}`;
+}
+
+async function listPublishedContentFiles(
+  context: CloudStoreContext,
+  contentDir: string,
+  contentExtensions: Set<string>,
+): Promise<ContentFile[]> {
+  const files: ContentFile[] = [];
+  let cursor: string | null | undefined;
+
+  do {
+    const response = await requestJson<CloudFileListResponse>(
+      context,
+      getPublishedFileListPath(context, contentDir, cursor),
+    );
+
+    files.push(
+      ...(response?.data ?? [])
+        .filter((file) => contentExtensions.has(extname(file.path)))
+        .map((file) => ({ path: file.path, content: file.content })),
+    );
+
+    cursor = response?.page_info?.next ?? null;
+  } while (cursor);
+
+  return files;
+}
+
+async function readContentFile(
+  context: CloudStoreContext,
+  file: ContentFile,
+): Promise<string> {
+  if (file.content !== undefined) return file.content;
+  if (!context.hasRequestContext) return readTextFile(file.path);
+
+  const response = await requestJson<CloudFileDetailResponse>(
+    context,
+    getPublishedFileDetailPath(context, file.path),
+  );
+
+  return response?.content ?? "";
 }
 
 export function createVeryfrontCloudRagStore(config: ResolvedCloudRagStoreConfig): RagStore {
@@ -574,28 +712,30 @@ export function createVeryfrontCloudRagStore(config: ResolvedCloudRagStoreConfig
       const context = getCloudStoreContext(config);
       const existingDocuments = await listRagDocuments(context);
       const indexedSources = new Set(existingDocuments.map((doc) => doc.source));
-      const files = await listContentFiles(contentDir, contentExtensions);
-      const newFiles = files.filter((file) => !indexedSources.has(file));
+      const files = context.hasRequestContext
+        ? await listPublishedContentFiles(context, contentDir, contentExtensions)
+        : await listContentFiles(contentDir, contentExtensions);
+      const newFiles = files.filter((file) => !indexedSources.has(file.path));
 
       for (const file of newFiles) {
-        const content = await readTextFile(file);
+        const content = await readContentFile(context, file);
         if (!content?.trim()) continue;
         if (content.length > MAX_TEXT_LENGTH) {
           serverLogger.warn(
-            `[rag-store/cloud] Skipping ${file}: exceeds ${
+            `[rag-store/cloud] Skipping ${file.path}: exceeds ${
               MAX_TEXT_LENGTH / 1024 / 1024
             } MB text limit`,
           );
           continue;
         }
 
-        const title = file.startsWith(contentDir + "/")
-          ? file.slice(contentDir.length + 1).replace(/\.[^.]+$/, "")
-          : file.replace(/\.[^.]+$/, "");
-        const type = extname(file).slice(1);
+        const title = file.path.startsWith(contentDir + "/")
+          ? file.path.slice(contentDir.length + 1).replace(/\.[^.]+$/, "")
+          : file.path.replace(/\.[^.]+$/, "");
+        const type = extname(file.path).slice(1);
 
         await ingestDocument(context, config, title, content, {
-          source: file,
+          source: file.path,
           type,
         });
       }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.932";
+export const VERSION = "0.1.933";


### PR DESCRIPTION
## Summary
- read Cloud RAG contentDir files from release/environment/branch file APIs when running in request context
- keep local contentDir indexing on local files outside request context
- add a regression test for deployed release-file indexing
- bump package version to 0.1.933 for release

## Verification
- focused rag-store regression test
- deno task fmt:check
- deno task typecheck
- deno task test:unit
- pre-push gate: format, lint, typecheck, full unit suite