### PR TITLE
Add explicit project knowledge API

### DIFF
--- a/cli/commands/init/init.integration.test.ts
+++ b/cli/commands/init/init.integration.test.ts
@@ -216,8 +216,9 @@ describe("init command integration", () => {
           assertEquals(await exists(join(dir, "AGENTS.md")), true);
 
           const content = await readTextFile(join(dir, "AGENTS.md"));
-          assertEquals(content.includes("vf_bootstrap"), true);
+          assertEquals(content.includes("veryfront dev"), true);
           assertEquals(content.includes("veryfront schema --json"), true);
+          assertEquals(content.includes("veryfront routes"), true);
           assertEquals(content.includes("src/pages"), false);
         } finally {
           await remove(dir, { recursive: true }).catch(() => {});

--- a/cli/commands/install/install.integration.test.ts
+++ b/cli/commands/install/install.integration.test.ts
@@ -82,7 +82,8 @@ describe("install command integration", () => {
       await assertInstallCreatesFile("cursor", ".cursorrules", [
         "Veryfront",
         "veryfront dev",
-        "veryfront generate agent research-agent",
+        "veryfront generate <type> <name>",
+        "veryfront schema --json",
         "veryfront.com/docs",
       ]);
     });
@@ -138,8 +139,9 @@ describe("install command integration", () => {
     it("should install AGENTS.md", async () => {
       await assertInstallCreatesFile("agents", "AGENTS.md", [
         "Veryfront",
-        "veryfront generate agent research-agent",
-        "vf_bootstrap",
+        "veryfront generate <type> <name>",
+        "veryfront schema --json",
+        "veryfront routes",
       ]);
     });
   });

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.933",
+  "version": "0.1.934",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {
@@ -109,6 +109,7 @@
     "./integrations": "./src/integrations/index.ts",
     "./sandbox": "./src/sandbox/index.ts",
     "./embedding": "./src/embedding/index.ts",
+    "./knowledge": "./src/knowledge/index.ts",
     "./extensions": "./src/extensions/index.ts",
     "./extensions/llm": "./src/extensions/llm/index.ts",
     "./extensions/auth": "./src/extensions/auth/index.ts",
@@ -150,6 +151,7 @@
     "veryfront/components/chat": "./src/react/components/chat/index.ts",
     "veryfront/sandbox": "./src/sandbox/index.ts",
     "veryfront/embedding": "./src/embedding/index.ts",
+    "veryfront/knowledge": "./src/knowledge/index.ts",
     "veryfront/runs": "./src/runs/index.ts",
     "veryfront/eval": "./src/eval/index.ts",
     "veryfront/metrics": "./src/metrics/index.ts",
@@ -235,6 +237,7 @@
     "#veryfront/discovery": "./src/discovery/index.ts",
     "#veryfront/data": "./src/data/index.ts",
     "#veryfront/errors": "./src/errors/index.ts",
+    "#veryfront/knowledge": "./src/knowledge/index.ts",
     "#veryfront/eval": "./src/eval/index.ts",
     "#veryfront/eval/agent-service": "./src/eval/agent-service.ts",
     "#veryfront/metrics": "./src/metrics/index.ts",

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -7,38 +7,39 @@ order: 1
 
 ## Contents
 
-| Import | Description |
-|--------|-------------|
-| [`veryfront`](./veryfront/index.md) | Core app config and routing. |
-| [`veryfront/agent`](./veryfront/agent.md) | Agents, AG-UI handlers, and memory. |
-| [`veryfront/chat`](./veryfront/chat.md) | Chat components and hooks. |
-| [`veryfront/cli`](./veryfront/cli.md) | CLI runtime helpers. |
-| [`veryfront/context`](./veryfront/context.md) | Page context. |
-| [`veryfront/embedding`](./veryfront/embedding.md) | Embedding and retrieval helpers. |
-| [`veryfront/eval`](./veryfront/eval.md) | First-class eval primitives for agent quality checks. |
-| [`veryfront/extensions`](./veryfront/extensions.md) | Extension contracts and loader helpers. |
-| [`veryfront/fonts`](./veryfront/fonts.md) | Font components. |
-| [`veryfront/fs`](./veryfront/fs.md) | Filesystem and path utilities. |
-| [`veryfront/head`](./veryfront/head.md) | Document metadata components. |
-| [`veryfront/integrations`](./veryfront/integrations.md) | Connector metadata and remote tools. |
-| [`veryfront/markdown`](./veryfront/markdown.md) | Markdown rendering. |
-| [`veryfront/mcp`](./veryfront/mcp.md) | MCP server helpers. |
-| [`veryfront/mdx`](./veryfront/mdx.md) | MDX component overrides. |
-| [`veryfront/metrics`](./veryfront/metrics.md) | Runtime/application metric hooks for project code. |
-| [`veryfront/middleware`](./veryfront/middleware.md) | HTTP middleware. |
-| [`veryfront/oauth`](./veryfront/oauth.md) | OAuth provider helpers. |
-| [`veryfront/observability`](./veryfront/observability.md) | Tracing, metrics, errors, and logs. |
-| [`veryfront/prompt`](./veryfront/prompt.md) | MCP prompt definitions. |
-| [`veryfront/provider`](./veryfront/provider.md) | Model provider registry. |
-| [`veryfront/resource`](./veryfront/resource.md) | MCP resource definitions. |
-| [`veryfront/router`](./veryfront/router.md) | Client navigation and route context. |
-| [`veryfront/runs`](./veryfront/runs.md) | Canonical durable task and workflow runs. |
-| [`veryfront/sandbox`](./veryfront/sandbox.md) | Isolated execution. |
-| [`veryfront/schemas`](./veryfront/schemas.md) | Validation schemas. |
-| [`veryfront/server`](./veryfront/server.md) | Server runtime helpers. |
-| [`veryfront/skill`](./veryfront/skill.md) | Agent skills. Public API for the agent skills system. Skills are project-level capabilities defined as SKILL.md files following the agentskills.io specification. |
-| [`veryfront/testing`](./veryfront/testing.md) | Test utilities. |
-| [`veryfront/tool`](./veryfront/tool.md) | Tool definitions and execution. |
-| [`veryfront/utils`](./veryfront/utils.md) | Runtime utilities. |
-| [`veryfront/work`](./veryfront/work.md) | Business process outcome definitions. |
-| [`veryfront/workflow`](./veryfront/workflow.md) | Workflows. |
+| Import                                                    | Description                                                                                                                                                       |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`veryfront`](./veryfront/index.md)                       | Core app config and routing.                                                                                                                                      |
+| [`veryfront/agent`](./veryfront/agent.md)                 | Agents, AG-UI handlers, and memory.                                                                                                                               |
+| [`veryfront/chat`](./veryfront/chat.md)                   | Chat components and hooks.                                                                                                                                        |
+| [`veryfront/cli`](./veryfront/cli.md)                     | CLI runtime helpers.                                                                                                                                              |
+| [`veryfront/context`](./veryfront/context.md)             | Page context.                                                                                                                                                     |
+| [`veryfront/embedding`](./veryfront/embedding.md)         | Embedding and retrieval helpers.                                                                                                                                  |
+| [`veryfront/eval`](./veryfront/eval.md)                   | First-class eval primitives for agent quality checks.                                                                                                             |
+| [`veryfront/extensions`](./veryfront/extensions.md)       | Extension contracts and loader helpers.                                                                                                                           |
+| [`veryfront/fonts`](./veryfront/fonts.md)                 | Font components.                                                                                                                                                  |
+| [`veryfront/fs`](./veryfront/fs.md)                       | Filesystem and path utilities.                                                                                                                                    |
+| [`veryfront/head`](./veryfront/head.md)                   | Document metadata components.                                                                                                                                     |
+| [`veryfront/integrations`](./veryfront/integrations.md)   | Connector metadata and remote tools.                                                                                                                              |
+| [`veryfront/knowledge`](./veryfront/knowledge.md)         | Project knowledge retrieval helpers.                                                                                                                              |
+| [`veryfront/markdown`](./veryfront/markdown.md)           | Markdown rendering.                                                                                                                                               |
+| [`veryfront/mcp`](./veryfront/mcp.md)                     | MCP server helpers.                                                                                                                                               |
+| [`veryfront/mdx`](./veryfront/mdx.md)                     | MDX component overrides.                                                                                                                                          |
+| [`veryfront/metrics`](./veryfront/metrics.md)             | Runtime/application metric hooks for project code.                                                                                                                |
+| [`veryfront/middleware`](./veryfront/middleware.md)       | HTTP middleware.                                                                                                                                                  |
+| [`veryfront/oauth`](./veryfront/oauth.md)                 | OAuth provider helpers.                                                                                                                                           |
+| [`veryfront/observability`](./veryfront/observability.md) | Tracing, metrics, errors, and logs.                                                                                                                               |
+| [`veryfront/prompt`](./veryfront/prompt.md)               | MCP prompt definitions.                                                                                                                                           |
+| [`veryfront/provider`](./veryfront/provider.md)           | Model provider registry.                                                                                                                                          |
+| [`veryfront/resource`](./veryfront/resource.md)           | MCP resource definitions.                                                                                                                                         |
+| [`veryfront/router`](./veryfront/router.md)               | Client navigation and route context.                                                                                                                              |
+| [`veryfront/runs`](./veryfront/runs.md)                   | Canonical durable task and workflow runs.                                                                                                                         |
+| [`veryfront/sandbox`](./veryfront/sandbox.md)             | Isolated execution.                                                                                                                                               |
+| [`veryfront/schemas`](./veryfront/schemas.md)             | Validation schemas.                                                                                                                                               |
+| [`veryfront/server`](./veryfront/server.md)               | Server runtime helpers.                                                                                                                                           |
+| [`veryfront/skill`](./veryfront/skill.md)                 | Agent skills. Public API for the agent skills system. Skills are project-level capabilities defined as SKILL.md files following the agentskills.io specification. |
+| [`veryfront/testing`](./veryfront/testing.md)             | Test utilities.                                                                                                                                                   |
+| [`veryfront/tool`](./veryfront/tool.md)                   | Tool definitions and execution.                                                                                                                                   |
+| [`veryfront/utils`](./veryfront/utils.md)                 | Runtime utilities.                                                                                                                                                |
+| [`veryfront/work`](./veryfront/work.md)                   | Business process outcome definitions.                                                                                                                             |
+| [`veryfront/workflow`](./veryfront/workflow.md)           | Workflows.                                                                                                                                                        |

--- a/docs/api-reference/veryfront/agent.md
+++ b/docs/api-reference/veryfront/agent.md
@@ -320,7 +320,7 @@ Clear all stored messages from memory.
 | `bootstrapHostedChildRun` | Bootstrap hosted child run helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/child-bootstrap.ts#L51) |
 | `buildAgentDelegateTools` | Builds the opt-in delegate tools for a coordinator agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/agent-delegation.ts#L62) |
 | `buildAgentRunTraceAttributes` | Builds agent run trace attributes. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/trace-attributes.ts#L98) |
-| `buildAgUiBrowserFinalizeResponse` | Response payload for build AG-UI browser finalize. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-encoder.ts#L220) |
+| `buildAgUiBrowserFinalizeResponse` | Response payload for build AG-UI browser finalize. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-encoder.ts#L234) |
 | `buildAgUiSseTraceSignature` | Build a compact ordered event-type signature for regression checks. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/sse-parser.ts#L74) |
 | `buildChatStreamChunkMessageMetadata` | Builds chat stream chunk message metadata. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/chat-ui-message-helpers.ts#L141) |
 | `buildChildRunExecutionSnapshot` | Builds child run execution snapshot. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/child-run/execution-snapshot.ts#L76) |
@@ -403,7 +403,7 @@ Clear all stored messages from memory.
 | `createAgentServiceRuntime` | Create agent service runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/service/runtime.ts#L194) |
 | `createAgentServiceServerRuntime` | Create agent service server runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/service/server.ts#L53) |
 | `createAgUiBrowserChunkEncoder` | Create AG-UI browser chunk encoder. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-chunk-encoder.ts#L45) |
-| `createAgUiBrowserEncoderState` | State for create AG-UI browser encoder. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-encoder.ts#L42) |
+| `createAgUiBrowserEncoderState` | State for create AG-UI browser encoder. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-encoder.ts#L43) |
 | `createAgUiBrowserFinalizeTracker` | Create AG-UI browser finalize tracker. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-finalize-tracker.ts#L22) |
 | `createAgUiBrowserResponseStream` | Create AG-UI browser response stream. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-response-stream.ts#L60) |
 | `createAgUiCancelHandler` | Handler for create AG-UI cancel. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/run-control.ts#L133) |
@@ -411,16 +411,16 @@ Clear all stored messages from memory.
 | `createAgUiChatUiTrackedBrowserResponse` | Response payload for create AG-UI chat UI tracked browser. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/chat-ui-chunk-browser-encoder.ts#L189) |
 | `createAgUiChunkEncoderBridge` | Create AG-UI chunk encoder bridge. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/chunk-encoder-bridge.ts#L23) |
 | `createAgUiDetachedStartHandler` | Handler for create AG-UI detached start. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/detached-start.ts#L388) |
-| `createAgUiHandler` | Handler for create AG-UI. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/handler.ts#L391) |
-| `createAgUiHandler` | Handler for create AG-UI. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/handler.ts#L396) |
-| `createAgUiHandler` | Handler for create AG-UI. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/handler.ts#L401) |
+| `createAgUiHandler` | Handler for create AG-UI. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/handler.ts#L404) |
+| `createAgUiHandler` | Handler for create AG-UI. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/handler.ts#L409) |
+| `createAgUiHandler` | Handler for create AG-UI. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/handler.ts#L414) |
 | `createAgUiResumeHandler` | Handler for create AG-UI resume. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/run-control.ts#L69) |
 | `createAgUiRunErrorEvent` | Event emitted for create AG-UI run error. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/host-support.ts#L412) |
 | `createAgUiRuntimeBrowserResponse` | Response payload for create AG-UI runtime browser. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-browser-response.ts#L28) |
 | `createAgUiRuntimeChatStreamEncoder` | Create AG-UI runtime chat stream encoder. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-chat-stream-encoder.ts#L103) |
 | `createAgUiRuntimeContextMap` | Create AG-UI runtime context map. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/forwarded-context.ts#L11) |
 | `createAgUiRuntimeEventEncoder` | Create AG-UI runtime event encoder. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-event-encoder.ts#L24) |
-| `createAgUiRuntimeHandler` | Handler for create AG-UI runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L366) |
+| `createAgUiRuntimeHandler` | Handler for create AG-UI runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L379) |
 | `createAgUiSseErrorResponse` | Response payload for create AG-UI sse error. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/host-support.ts#L423) |
 | `createAgUiSseResponse` | Response payload for create AG-UI sse. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/host-support.ts#L436) |
 | `createAgUiTrackedBrowserResponse` | Response payload for create AG-UI tracked browser. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/tracked-browser-response.ts#L23) |
@@ -542,7 +542,7 @@ Clear all stored messages from memory.
 | `fetchLatestConversationUserText` | Fetch latest conversation user text helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/artifacts/default-research-artifact-support.ts#L111) |
 | `filterAgentTraceAttributes` | Filter agent trace attributes. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/trace-attributes.ts#L40) |
 | `filterHostedChatRuntimeLocalTools` | Filter hosted chat runtime local tools. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/chat-runtime-tool-assembly.ts#L121) |
-| `finalizeAgUiBrowserEvents` | Finalize AG-UI browser events helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-encoder.ts#L640) |
+| `finalizeAgUiBrowserEvents` | Finalize AG-UI browser events helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-encoder.ts#L657) |
 | `finalizeChildRunExecutionResources` | Finalize child run execution resources helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/child-run/execution-cleanup.ts#L25) |
 | `finalizeConversationAgentRun` | Finalize conversation agent run helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/conversation/durable.ts#L1053) |
 | `finalizeHostedChildForkCompletion` | Finalize hosted child fork completion helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/hosted/child-fork-stream-execution.ts#L153) |
@@ -635,7 +635,7 @@ Clear all stored messages from memory.
 | `mapAgUiRuntimeEventToForkParts` | Map AG-UI runtime event to fork parts. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/streaming/fork-runtime-part-mapper.ts#L174) |
 | `mapFrameworkEventToForkParts` | Handles map framework event to fork parts. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/streaming/fork-runtime-part-mapper.ts#L340) |
 | `mapHostedStreamPartToChatUiChunks` | Map hosted stream part to chat UI chunks. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/chat/hosted-ui-chunk-mapping.ts#L218) |
-| `mapRuntimeStreamEventToAgUiBrowserEvents` | Map runtime stream event to AG-UI browser events. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-encoder.ts#L411) |
+| `mapRuntimeStreamEventToAgUiBrowserEvents` | Map runtime stream event to AG-UI browser events. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-encoder.ts#L428) |
 | `mergeToolCallInput` | Input payload for merge tool call. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/streaming/tool-input.ts#L107) |
 | `mergeToolInputDelta` | Merge tool input delta helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/streaming/tool-input.ts#L49) |
 | `mirrorDefaultResearchRunArtifact` | Mirror default research run artifact helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/artifacts/default-research-artifact-support.ts#L298) |
@@ -939,8 +939,8 @@ Clear all stored messages from memory.
 | `AgUiBeforeStreamMessageInput` | Input payload for AG-UI before stream message. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/service/before-stream.ts#L3) |
 | `AgUiBeforeStreamResult` | Result returned from AG-UI before stream. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/service/before-stream.ts#L24) |
 | `AgUiBrowserChunkEncoder` | Public API contract for AG-UI browser chunk encoder. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-chunk-encoder.ts#L13) |
-| `AgUiBrowserEncodedEvent` | Event emitted for AG-UI browser encoded. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-encoder.ts#L36) |
-| `AgUiBrowserEncoderState` | State for AG-UI browser encoder. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-encoder.ts#L21) |
+| `AgUiBrowserEncodedEvent` | Event emitted for AG-UI browser encoded. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-encoder.ts#L37) |
+| `AgUiBrowserEncoderState` | State for AG-UI browser encoder. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-encoder.ts#L22) |
 | `AgUiBrowserFinalizeTracker` | Public API contract for AG-UI browser finalize tracker. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-finalize-tracker.ts#L8) |
 | `AgUiBrowserResponseEncoder` | Public API contract for AG-UI browser response encoder. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-response-stream.ts#L35) |
 | `AgUiBrowserResponseExecution` | Public API contract for AG-UI browser response execution. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/browser-response-stream.ts#L28) |
@@ -954,8 +954,8 @@ Clear all stored messages from memory.
 | `AgUiDetachedStartHandlerOptions` | Options accepted by AG-UI detached start handler. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/detached-start.ts#L219) |
 | `AgUiDetachedStartRequest` | Request payload for AG-UI detached start. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/detached-start.ts#L99) |
 | `AgUiForwardedConfigOptions` | Options accepted by AG-UI forwarded config. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/forwarded-context.ts#L5) |
-| `AgUiHandlerConfigWithAgent` | Public API contract for AG-UI handler config with agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/handler.ts#L378) |
-| `AgUiHandlerOptions` | Options accepted by AG-UI handler. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/handler.ts#L369) |
+| `AgUiHandlerConfigWithAgent` | Public API contract for AG-UI handler config with agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/handler.ts#L391) |
+| `AgUiHandlerOptions` | Options accepted by AG-UI handler. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/handler.ts#L382) |
 | `AgUiInjectedTool` | Public API contract for AG-UI injected tool. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/host-support.ts#L122) |
 | `AgUiRequest` | Request payload for AG-UI. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/host-support.ts#L126) |
 | `AgUiResumeHandlerOptions` | Options accepted by AG-UI resume handler. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/run-control.ts#L48) |
@@ -965,11 +965,11 @@ Clear all stored messages from memory.
 | `AgUiRuntimeChatStreamEncoderState` | State for AG-UI runtime chat stream encoder. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-chat-stream-encoder.ts#L9) |
 | `AgUiRuntimeContextItem` | Public API contract for AG-UI runtime context item. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L189) |
 | `AgUiRuntimeEventEncoder` | Public API contract for AG-UI runtime event encoder. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-event-encoder.ts#L12) |
-| `AgUiRuntimeHandlerConfig` | Configuration used by AG-UI runtime handler. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L361) |
-| `AgUiRuntimeHandlerConfigWithAgent` | Public API contract for AG-UI runtime handler config with agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L356) |
-| `AgUiRuntimeHandlerExecute` | Public API contract for AG-UI runtime handler execute. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L320) |
-| `AgUiRuntimeHandlerExecuteInput` | Input payload for AG-UI runtime handler execute. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L312) |
-| `AgUiRuntimeHandlerOptions` | Options accepted by AG-UI runtime handler. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L342) |
+| `AgUiRuntimeHandlerConfig` | Configuration used by AG-UI runtime handler. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L374) |
+| `AgUiRuntimeHandlerConfigWithAgent` | Public API contract for AG-UI runtime handler config with agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L369) |
+| `AgUiRuntimeHandlerExecute` | Public API contract for AG-UI runtime handler execute. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L333) |
+| `AgUiRuntimeHandlerExecuteInput` | Input payload for AG-UI runtime handler execute. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L325) |
+| `AgUiRuntimeHandlerOptions` | Options accepted by AG-UI runtime handler. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L355) |
 | `AgUiRuntimeInjectedTool` | Public API contract for AG-UI runtime injected tool. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L185) |
 | `AgUiRuntimeLifecycleContext` | Context for AG-UI runtime lifecycle. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/ag-ui/runtime-handler.ts#L31) |
 | `AgUiRuntimeMessage` | Message shape for AG-UI runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/agent/runtime/ag-ui-contract.ts#L193) |

--- a/docs/api-reference/veryfront/eval.md
+++ b/docs/api-reference/veryfront/eval.md
@@ -35,18 +35,6 @@ export default evalAgent({
 });
 ```
 
-Use agent behavior metrics to assert that a real runtime trace used the right
-tools and avoided dangerous tools:
-
-```ts
-metrics.agent.calledTool("orders_lookup", {
-  input: { orderId: "A1049" },
-  match: "partial",
-}).gate();
-metrics.agent.notCalledTool("refunds_issue").gate();
-metrics.agent.toolCallCount("orders_lookup", { exact: 1 }).gate();
-```
-
 ### Live agent-service eval
 
 ```ts
@@ -84,7 +72,7 @@ const report = await runEval(definition, {
 | `evalAgent` | Define a V1 eval that targets a Veryfront agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/factory.ts#L26) |
 | `findEvalById` | Discover and return one eval definition by ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L195) |
 | `isEvalDefinition` | Check whether a value is a normalized eval definition. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/factory.ts#L48) |
-| `runEval` | Execute an eval locally with injected target adapters. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/runner.ts#L213) |
+| `runEval` | Execute an eval locally with injected target adapters. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/runner.ts#L282) |
 | `summarizeEvalRecords` | Summarize eval records into pass/fail and metric aggregates. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/report.ts#L195) |
 
 ### Types
@@ -93,54 +81,54 @@ const report = await runEval(definition, {
 |------|-------------|--------|
 | `CreateEvalSourceDocumentOptions` | Options for creating a Studio source document from a discovered eval. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L230) |
 | `DiscoveredEval` | Eval definition discovered from project source. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L22) |
-| `EvalAgentAdapter` | Adapter used by `runEval` to execute V1 agent targets. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L211) |
-| `EvalAgentAdapterContext` | Context passed to an agent adapter when `runEval` executes an example. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L192) |
-| `EvalAgentAdapterResult` | Agent adapter result normalized into an eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L199) |
-| `EvalAgentInput` | Input accepted by `evalAgent`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L178) |
-| `EvalCheckContext` | Context passed to an eval definition's `check` callback. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L146) |
+| `EvalAgentAdapter` | Adapter used by `runEval` to execute V1 agent targets. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L236) |
+| `EvalAgentAdapterContext` | Context passed to an agent adapter when `runEval` executes an example. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L217) |
+| `EvalAgentAdapterResult` | Agent adapter result normalized into an eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L224) |
+| `EvalAgentInput` | Input accepted by `evalAgent`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L203) |
+| `EvalCheckContext` | Context passed to an eval definition's `check` callback. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L171) |
 | `EvalDataset` | Dataset loader used by an eval definition. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L52) |
 | `EvalDatasetLoadContext` | Context passed to dataset loaders. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L47) |
-| `EvalDefinition` | First-class eval definition discovered from project source. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L161) |
+| `EvalDefinition` | First-class eval definition discovered from project source. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L186) |
 | `EvalDiscoveryOptions` | Options for project-local eval discovery. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L37) |
 | `EvalDiscoveryResult` | Result returned by eval discovery. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/discovery.ts#L47) |
-| `EvalDurationSummary` | Duration aggregate for an eval report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L245) |
+| `EvalDurationSummary` | Duration aggregate for an eval report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L270) |
 | `EvalEditableField` | Form-editable Eval source field name. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L219) |
 | `EvalExample` | Normalized dataset example used by eval runners and reports. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L31) |
 | `EvalExampleInput` | Dataset example shape accepted by eval definitions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L39) |
-| `EvalExpect` | Built-in expectation helpers available inside `check`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L139) |
-| `EvalExpectation` | Fluent severity helpers for `check` expectations. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L132) |
-| `EvalFailedExampleSummary` | Per-example failure aggregate included in a report summary. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L275) |
-| `EvalFlakeSummary` | Flake classification for repeated eval examples. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L285) |
-| `EvalGateFailureSummary` | Blocking failure included in a report summary. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L263) |
-| `EvalMetric` | Metric contract used by eval definitions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L119) |
-| `EvalMetricContext` | Optional runtime context passed to metric evaluators. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L114) |
-| `EvalMetricDeltaSummary` | Per-metric delta between a current eval report and a baseline report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L293) |
+| `EvalExpect` | Built-in expectation helpers available inside `check`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L161) |
+| `EvalExpectation` | Fluent severity helpers for `check` expectations. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L154) |
+| `EvalFailedExampleSummary` | Per-example failure aggregate included in a report summary. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L300) |
+| `EvalFlakeSummary` | Flake classification for repeated eval examples. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L310) |
+| `EvalGateFailureSummary` | Blocking failure included in a report summary. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L288) |
+| `EvalMetric` | Metric contract used by eval definitions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L141) |
+| `EvalMetricContext` | Optional runtime context passed to metric evaluators. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L136) |
+| `EvalMetricDeltaSummary` | Per-metric delta between a current eval report and a baseline report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L318) |
 | `EvalMetricFamily` | Metric family used for grouping report summaries. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L19) |
-| `EvalMetricResult` | Result emitted by a metric or check assertion. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L101) |
-| `EvalMetricSummary` | Aggregate pass/fail summary for one metric. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L234) |
+| `EvalMetricResult` | Result emitted by a metric or check assertion. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L123) |
+| `EvalMetricSummary` | Aggregate pass/fail summary for one metric. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L259) |
 | `EvalMetricThreshold` | Numeric threshold attached to score-based metrics. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L22) |
-| `EvalRecord` | One executed example and repetition inside an eval report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L82) |
-| `EvalReport` | JSON-serializable report produced by `runEval`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L342) |
-| `EvalReportComparison` | Baseline comparison for a current eval report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L307) |
-| `EvalReportExportConfig` | Export configuration for a completed eval report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L227) |
-| `EvalReportSummary` | Aggregate pass/fail summary for one eval report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L321) |
+| `EvalRecord` | One executed example and repetition inside an eval report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L104) |
+| `EvalReport` | JSON-serializable report produced by `runEval`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L367) |
+| `EvalReportComparison` | Baseline comparison for a current eval report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L332) |
+| `EvalReportExportConfig` | Export configuration for a completed eval report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L252) |
+| `EvalReportSummary` | Aggregate pass/fail summary for one eval report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L346) |
 | `EvalRun` | V2-ready Eval run projection. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L227) |
 | `EvalSeverity` | How a metric result affects the final eval result. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L16) |
-| `EvalSource` | Source location for a discovered eval definition. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L155) |
+| `EvalSource` | Source location for a discovered eval definition. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L180) |
 | `EvalSourceDocument` | Studio-editable Eval source document. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L223) |
 | `EvalSourcePatch` | Eval source patch submitted by Studio forms. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L225) |
 | `EvalSourceReference` | Source location for an Eval definition. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L221) |
 | `EvalStudioCapability` | Capability string Studio uses for Eval source and run actions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L217) |
 | `EvalTargetKind` | Primitive kind an eval can execute. V1 supports agent targets. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L13) |
-| `EvalToolCall` | Tool call metadata captured during one eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L68) |
+| `EvalToolCall` | Tool call metadata captured during one eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L87) |
 | `EvalToolCallCountOptions` | Options for checking how often a tool was called. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L80) |
 | `EvalToolCallMatchOptions` | Options for matching a required tool call. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L74) |
 | `EvalToolCallStatus` | Normalized status for a tool call captured during an eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L68) |
 | `EvalToolInputMatchMode` | How expected tool input is compared to the captured tool input. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L71) |
-| `EvalTrace` | Trace metadata captured for one eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L76) |
+| `EvalTrace` | Trace metadata captured for one eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L98) |
 | `EvalUsage` | Token and cost usage captured for one eval record. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L60) |
-| `EvalUsageSummary` | Usage totals for an eval report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L255) |
-| `RunEvalOptions` | Options for running an eval locally. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L216) |
+| `EvalUsageSummary` | Usage totals for an eval report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L280) |
+| `RunEvalOptions` | Options for running an eval locally. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L241) |
 
 ### Constants
 
@@ -153,7 +141,7 @@ const report = await runEval(definition, {
 | `getEvalSourcePatchSchema` | Schema for a source patch submitted from an Eval editor. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L166) |
 | `getEvalSourceReferenceSchema` | Schema for an Eval source reference. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L28) |
 | `getEvalStudioCapabilitySchema` | Schema for Eval Studio capabilities. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L6) |
-| `metrics` | Metric factories for deterministic answers, agent behavior, operations, and judges. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/metrics.ts#L133) |
+| `metrics` | Metric factories for deterministic answers, agent behavior, operations, and judges. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/metrics.ts#L137) |
 
 ## Deep imports
 
@@ -169,7 +157,7 @@ import { assertCompleted, assertNoMalformedCreateFileToolCalls, buildAgentServic
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `DEFAULT_AGENT_SERVICE_EVAL_ENDPOINT` | Default local AG-UI endpoint used by agent-service evals. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L19) |
+| `DEFAULT_AGENT_SERVICE_EVAL_ENDPOINT` | Default local AG-UI endpoint used by agent-service evals. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L21) |
 | `DEFAULT_DURABLE_RUN_CANARY_TIMEOUT_MS` | Default value for durable run canary timeout ms. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/environment.ts#L15) |
 | `DEFAULT_LIVE_EVAL_AREA_TAG_RULES` | Default value for live eval area tag rules. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/metadata.ts#L36) |
 | `DEFAULT_LIVE_EVAL_ENDPOINT` | Default value for live eval endpoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/environment.ts#L16) |
@@ -181,7 +169,7 @@ import { assertCompleted, assertNoMalformedCreateFileToolCalls, buildAgentServic
 |------|-------------|--------|
 | `assertCompleted` | Assert that a durable run canary completed successfully. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/validation.ts#L31) |
 | `assertNoMalformedCreateFileToolCalls` | Assert no malformed create file tool calls helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/validation.ts#L78) |
-| `buildAgentServiceEvalRequestBody` | Build the AG-UI request body for a single eval example. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L338) |
+| `buildAgentServiceEvalRequestBody` | Build the AG-UI request body for a single eval example. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L459) |
 | `buildFailureSuffix` | Builds failure suffix. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/formatting.ts#L79) |
 | `buildLiveEvalCaseMetadata` | Builds live eval case metadata. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/metadata.ts#L121) |
 | `buildLiveEvalCaseTagSummary` | Builds live eval case tag summary. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/report.ts#L40) |
@@ -193,14 +181,14 @@ import { assertCompleted, assertNoMalformedCreateFileToolCalls, buildAgentServic
 | `cancelLiveEvalInputRequest` | Request payload for cancel live eval input. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L569) |
 | `collectAssistantText` | Collect assistant text helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/validation.ts#L70) |
 | `containsOrderedSubsequence` | Contains ordered subsequence helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/formatting.ts#L92) |
-| `containsSkillLoad` | Contains skill load helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L478) |
-| `countStepStartedEvents` | Count step started events helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L483) |
-| `createAgentServiceEvalAdapter` | Create an `EvalAgentAdapter` that executes examples against an AG-UI agent-service endpoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L368) |
+| `containsSkillLoad` | Contains skill load helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L483) |
+| `countStepStartedEvents` | Count step started events helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L488) |
+| `createAgentServiceEvalAdapter` | Create an `EvalAgentAdapter` that executes examples against an AG-UI agent-service endpoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L489) |
 | `createDurableRunCanaryApiClient` | Create durable run canary API client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L257) |
 | `createDurableRunCanaryRunner` | Create durable run canary runner. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L503) |
 | `createFailedEvalResult` | Result returned from create failed eval. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/result.ts#L79) |
 | `createLiveEvalApiClient` | Create live eval API client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L266) |
-| `createLiveEvalCaseSupport` | Create live eval case support. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L488) |
+| `createLiveEvalCaseSupport` | Create live eval case support. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L493) |
 | `createLiveEvalConversation` | Create live eval conversation. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L282) |
 | `createLiveEvalProjectUploadFixture` | Create live eval project upload fixture. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L334) |
 | `createLiveEvalRelease` | Create live eval release. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L429) |
@@ -209,16 +197,16 @@ import { assertCompleted, assertNoMalformedCreateFileToolCalls, buildAgentServic
 | `createSkippedEvalResult` | Result returned from create skipped eval. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/result.ts#L61) |
 | `deleteLiveEvalConversation` | Delete live eval conversation helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L311) |
 | `deleteLiveEvalProjectFile` | Delete live eval project file helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L464) |
-| `evaluateAgentServiceEvalEnvironment` | Evaluate whether the required live agent-service eval environment is present. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L317) |
+| `evaluateAgentServiceEvalEnvironment` | Evaluate whether the required live agent-service eval environment is present. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L438) |
 | `evaluateRuntimeConfidenceEnv` | Evaluate runtime confidence env helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/preflight.ts#L13) |
 | `findAssistantMessage` | Message shape for find assistant. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/validation.ts#L42) |
 | `getLiveEvalProjectFile` | Return live eval project file. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L395) |
 | `hasEveryLiveEvalTag` | Check whether every live eval tag is present. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/report.ts#L26) |
-| `hasFinished` | Check whether finished is present. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L473) |
+| `hasFinished` | Check whether finished is present. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L478) |
 | `listOpenLiveEvalInputRequests` | List open live eval input requests. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/api-client.ts#L490) |
 | `parseDurableRunCanaryRunSummary` | Parses durable run canary run summary. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L111) |
 | `printRuntimeConfidencePreflight` | Print runtime confidence preflight helper. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/preflight.ts#L39) |
-| `resolveAgentServiceEvalEnvironment` | Resolve environment values for live agent-service eval execution. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L292) |
+| `resolveAgentServiceEvalEnvironment` | Resolve environment values for live agent-service eval execution. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L413) |
 | `resolveDurableRunCanaryEnvironment` | Resolves durable run canary environment. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/environment.ts#L18) |
 | `resolveLiveEvalEnvironment` | Resolves live eval environment. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/environment.ts#L19) |
 | `resolveLiveEvalRequestedCaseIds` | Resolves live eval requested case IDs. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/report.ts#L87) |
@@ -234,13 +222,13 @@ import { assertCompleted, assertNoMalformedCreateFileToolCalls, buildAgentServic
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `AgentServiceEvalAdapterConfig` | Configuration for the live agent-service eval adapter. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L91) |
-| `AgentServiceEvalEnvironment` | Resolved environment values for live agent-service evals. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L25) |
-| `AgentServiceEvalEnvironmentInput` | Environment input accepted by agent-service eval helpers. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L22) |
-| `AgentServiceEvalEnvironmentPreflightResult` | Preflight result for a live agent-service eval environment. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L36) |
-| `AgentServiceEvalForwardedProps` | Veryfront forwarded props included in an AG-UI eval request. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L43) |
-| `AgentServiceEvalRequestBody` | AG-UI request body sent to an agent-service endpoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L71) |
-| `BuildAgentServiceEvalRequestBodyInput` | Input accepted by `buildAgentServiceEvalRequestBody`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L56) |
+| `AgentServiceEvalAdapterConfig` | Configuration for the live agent-service eval adapter. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L93) |
+| `AgentServiceEvalEnvironment` | Resolved environment values for live agent-service evals. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L27) |
+| `AgentServiceEvalEnvironmentInput` | Environment input accepted by agent-service eval helpers. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L24) |
+| `AgentServiceEvalEnvironmentPreflightResult` | Preflight result for a live agent-service eval environment. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L38) |
+| `AgentServiceEvalForwardedProps` | Veryfront forwarded props included in an AG-UI eval request. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L45) |
+| `AgentServiceEvalRequestBody` | AG-UI request body sent to an agent-service endpoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L73) |
+| `BuildAgentServiceEvalRequestBodyInput` | Input accepted by `buildAgentServiceEvalRequestBody`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service.ts#L58) |
 | `BuildLiveEvalCaseMetadataInput` | Input payload for build live eval case metadata. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/metadata.ts#L22) |
 | `BuildLiveEvalRequestBodyInput` | Input payload for build live eval request body. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/request.ts#L18) |
 | `DurableRunCanaryApiClient` | Public API contract for durable run canary API client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L246) |
@@ -299,4 +287,4 @@ import { assertCompleted, assertNoMalformedCreateFileToolCalls, buildAgentServic
 |------|-------------|--------|
 | `durableRunCanaryRunnerInternals` | White-box helpers used by durable run canary tests. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L611) |
 | `getDurableRunCanaryMessageSchema` | Zod schema for get durable run canary message. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/durable-run-canaries/runner.ts#L37) |
-| `liveEvalRunnerInternals` | White-box helpers used by live eval runner tests. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L631) |
+| `liveEvalRunnerInternals` | White-box helpers used by live eval runner tests. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/agent-service/live-evals/runner.ts#L636) |

--- a/docs/api-reference/veryfront/knowledge.md
+++ b/docs/api-reference/veryfront/knowledge.md
@@ -1,0 +1,44 @@
+---
+title: "veryfront/knowledge"
+description: "Project knowledge retrieval helpers."
+order: 13
+---
+
+## Import
+
+```ts
+import {
+  formatKnowledgeContext,
+  normalizeKnowledgeQuery,
+  projectKnowledge,
+} from "veryfront/knowledge";
+```
+
+## Examples
+
+```ts
+import { projectKnowledge } from "veryfront/knowledge";
+
+const knowledge = projectKnowledge();
+await knowledge.index();
+const result = await knowledge.retrieve("SSO login failure");
+```
+
+## Exports
+
+### Functions
+
+| Name                      | Description                                                           | Source                                                                                      |
+| ------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `formatKnowledgeContext`  | Format search results into a deterministic prompt context block.      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L102) |
+| `normalizeKnowledgeQuery` | Normalize a knowledge query before retrieval.                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L94)  |
+| `projectKnowledge`        | Create a project knowledge helper backed by the configured RAG store. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L109) |
+
+### Types
+
+| Name                              | Description                                                 | Source                                                                                     |
+| --------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `ProjectKnowledge`                | Helper for indexing and retrieving project knowledge.       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L73) |
+| `ProjectKnowledgeConfig`          | Configuration for project knowledge indexing and retrieval. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L30) |
+| `ProjectKnowledgeResult`          | Result returned from project knowledge retrieval.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L66) |
+| `ProjectKnowledgeRetrieveOptions` | Per-call options for project knowledge retrieval.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L61) |

--- a/docs/api-reference/veryfront/markdown.md
+++ b/docs/api-reference/veryfront/markdown.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/markdown"
 description: "Markdown rendering with syntax highlighting and diagrams."
-order: 13
+order: 14
 ---
 
 ## Import

--- a/docs/api-reference/veryfront/mcp.md
+++ b/docs/api-reference/veryfront/mcp.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/mcp"
 description: "MCP server exposing tools, prompts, and resources."
-order: 14
+order: 15
 ---
 
 ## Import

--- a/docs/api-reference/veryfront/mdx.md
+++ b/docs/api-reference/veryfront/mdx.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/mdx"
 description: "Component overrides for `.mdx` page rendering."
-order: 15
+order: 16
 ---
 
 ## Import

--- a/docs/api-reference/veryfront/metrics.md
+++ b/docs/api-reference/veryfront/metrics.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/metrics"
 description: "Runtime/application metric hooks for project code."
-order: 16
+order: 17
 ---
 
 ## Import
@@ -31,9 +31,9 @@ metrics.gauge("vf_eval_queue_depth", 3);
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `counter` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L116) |
-| `gauge` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L134) |
-| `histogram` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L125) |
+| `counter` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L411) |
+| `gauge` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L439) |
+| `histogram` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L425) |
 
 ### Types
 
@@ -47,4 +47,4 @@ metrics.gauge("vf_eval_queue_depth", 3);
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `metrics` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L150) |
+| `metrics` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L459) |

--- a/docs/api-reference/veryfront/middleware.md
+++ b/docs/api-reference/veryfront/middleware.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/middleware"
 description: "CORS, rate limiting, logging, and timeout middleware."
-order: 17
+order: 18
 ---
 
 ## Import

--- a/docs/api-reference/veryfront/oauth.md
+++ b/docs/api-reference/veryfront/oauth.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/oauth"
 description: "OAuth 2.0 with pre-configured providers. Default supported integrations are visible in the CLI/MCP/runtime connector surface. Additional provider configs are retained for feature-gated integrations enabled with VERYFRONT_EXPERIMENTAL_INTEGRATIONS."
-order: 18
+order: 19
 ---
 
 ## Import
@@ -71,7 +71,7 @@ export const GET = createOAuthCallbackHandler(gmailConfig);
 |------|-------------|--------|
 | `airtableConfig` | Configuration used by airtable. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/common.ts#L102) |
 | `asanaConfig` | Configuration used by asana. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/common.ts#L164) |
-| `bitbucketConfig` | Configuration used by bitbucket. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/atlassian.ts#L46) |
+| `bitbucketConfig` | Configuration used by bitbucket. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/atlassian.ts#L49) |
 | `boxConfig` | Configuration used by box. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/common.ts#L288) |
 | `calendarConfig` | Configuration used by calendar. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/google.ts#L34) |
 | `clickupConfig` | Configuration used by clickup. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/common.ts#L330) |

--- a/docs/api-reference/veryfront/observability.md
+++ b/docs/api-reference/veryfront/observability.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/observability"
 description: "Tracing, metrics, OTLP export, and structured logs."
-order: 19
+order: 20
 ---
 
 ## Import

--- a/docs/api-reference/veryfront/prompt.md
+++ b/docs/api-reference/veryfront/prompt.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/prompt"
 description: "Declare and register prompts exposable over MCP."
-order: 20
+order: 21
 ---
 
 ## Import

--- a/docs/api-reference/veryfront/provider.md
+++ b/docs/api-reference/veryfront/provider.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/provider"
 description: "Model provider registry and runtime resolution."
-order: 21
+order: 22
 ---
 
 ## Import
@@ -66,7 +66,7 @@ Clear all registered model providers (for testing).
 | Name | Description | Source |
 |------|-------------|--------|
 | `DEFAULT_VERYFRONT_CLOUD_MODEL_ID` | Default value for Veryfront Cloud model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L19) |
-| `VERYFRONT_CLOUD_CHAT_MODELS` | Shared Veryfront Cloud chat models value. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L37) |
+| `VERYFRONT_CLOUD_CHAT_MODELS` | Shared Veryfront Cloud chat models value. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L41) |
 | `VERYFRONT_CLOUD_MODEL_PREFIX` | Shared Veryfront Cloud model prefix value. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L21) |
 
 ### Functions
@@ -75,22 +75,22 @@ Clear all registered model providers (for testing).
 |------|-------------|--------|
 | `clearModelProviders` | Clear all registered model providers (for testing). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/model-registry.ts#L293) |
 | `ensureModelReady` | Eagerly verify that the resolved model's runtime is available. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/model-registry.ts#L281) |
-| `findVeryfrontCloudModel` | Find Veryfront Cloud model. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L99) |
-| `findVeryfrontCloudModelByModelId` | Find Veryfront Cloud model by model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L111) |
+| `findVeryfrontCloudModel` | Find Veryfront Cloud model. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L103) |
+| `findVeryfrontCloudModelByModelId` | Find Veryfront Cloud model by model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L115) |
 | `getRegisteredModelProviders` | Get list of registered model provider names (project-scoped + shared). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/model-registry.ts#L263) |
-| `getVeryfrontCloudProviderFromModelId` | Return Veryfront Cloud provider from model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L119) |
-| `groupVeryfrontCloudModelsByProvider` | Group Veryfront Cloud models by provider. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L263) |
+| `getVeryfrontCloudProviderFromModelId` | Return Veryfront Cloud provider from model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L123) |
+| `groupVeryfrontCloudModelsByProvider` | Group Veryfront Cloud models by provider. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L282) |
 | `hasModelProvider` | Check if a model provider is registered (project-scoped or shared). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/model-registry.ts#L255) |
-| `normalizeVeryfrontCloudModelId` | Normalizes Veryfront Cloud model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L104) |
+| `normalizeVeryfrontCloudModelId` | Normalizes Veryfront Cloud model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L108) |
 | `registerModelProvider` | Register a custom model provider factory for the current project. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/model-registry.ts#L46) |
 | `resolveModel` | Resolve a "provider/model" string to a framework-compatible model runtime. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/model-registry.ts#L211) |
-| `resolveVeryfrontCloudGatewayModelId` | Resolves Veryfront Cloud gateway model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L174) |
-| `resolveVeryfrontCloudModelId` | Resolves Veryfront Cloud model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L150) |
-| `resolveVeryfrontCloudModelThinking` | Resolves Veryfront Cloud model thinking. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L201) |
-| `resolveVeryfrontCloudThinkingProviderOptions` | Options accepted by resolve Veryfront Cloud thinking provider. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L220) |
+| `resolveVeryfrontCloudGatewayModelId` | Resolves Veryfront Cloud gateway model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L178) |
+| `resolveVeryfrontCloudModelId` | Resolves Veryfront Cloud model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L154) |
+| `resolveVeryfrontCloudModelThinking` | Resolves Veryfront Cloud model thinking. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L205) |
+| `resolveVeryfrontCloudThinkingProviderOptions` | Options accepted by resolve Veryfront Cloud thinking provider. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L224) |
 | `runWithVeryfrontCloudContext` | Context for run with Veryfront Cloud. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/context.ts#L13) |
 | `runWithVeryfrontCloudContextAsync` | Run with Veryfront Cloud context async. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/context.ts#L21) |
-| `tryGetVeryfrontCloudProviderFromModelId` | Try to get Veryfront Cloud provider from model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L139) |
+| `tryGetVeryfrontCloudProviderFromModelId` | Try to get Veryfront Cloud provider from model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L143) |
 
 ### Types
 
@@ -107,7 +107,7 @@ Clear all registered model providers (for testing).
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `resolveHostedVeryfrontCloudModelId` | Resolves hosted Veryfront Cloud model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L276) |
+| `resolveHostedVeryfrontCloudModelId` | Resolves hosted Veryfront Cloud model ID. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/provider/veryfront-cloud/model-catalog.ts#L295) |
 
 ## Deep imports
 

--- a/docs/api-reference/veryfront/resource.md
+++ b/docs/api-reference/veryfront/resource.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/resource"
 description: "Declare and register resources exposable over MCP."
-order: 22
+order: 23
 ---
 
 ## Import

--- a/docs/api-reference/veryfront/router.md
+++ b/docs/api-reference/veryfront/router.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/router"
 description: "React router exports for client navigation and route context."
-order: 23
+order: 24
 ---
 
 ## Import

--- a/docs/api-reference/veryfront/runs.md
+++ b/docs/api-reference/veryfront/runs.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/runs"
 description: "Canonical durable runs for task, workflow, and eval execution."
-order: 24
+order: 25
 ---
 
 ## Import

--- a/docs/api-reference/veryfront/sandbox.md
+++ b/docs/api-reference/veryfront/sandbox.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/sandbox"
 description: "Ephemeral compute environments for isolated execution."
-order: 25
+order: 26
 ---
 
 ## Import

--- a/docs/api-reference/veryfront/schemas.md
+++ b/docs/api-reference/veryfront/schemas.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/schemas"
 description: "Reusable validation schemas and the `defineSchema` helper."
-order: 26
+order: 27
 ---
 
 ## Import

--- a/docs/api-reference/veryfront/server.md
+++ b/docs/api-reference/veryfront/server.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/server"
 description: "Create and run Veryfront servers."
-order: 27
+order: 28
 ---
 
 ## Import

--- a/docs/api-reference/veryfront/skill.md
+++ b/docs/api-reference/veryfront/skill.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/skill"
 description: "Agent skills. Public API for the agent skills system. Skills are project-level capabilities defined as SKILL.md files following the agentskills.io specification."
-order: 28
+order: 29
 ---
 
 ## Import

--- a/docs/api-reference/veryfront/testing.md
+++ b/docs/api-reference/veryfront/testing.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/testing"
 description: "Cross-runtime BDD assertions and test helpers."
-order: 29
+order: 30
 ---
 
 ## Import

--- a/docs/api-reference/veryfront/tool.md
+++ b/docs/api-reference/veryfront/tool.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/tool"
 description: "Define tools with schema-backed inputs for agents and MCP."
-order: 30
+order: 31
 ---
 
 ## Import

--- a/docs/api-reference/veryfront/utils.md
+++ b/docs/api-reference/veryfront/utils.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/utils"
 description: "Runtime detection, logging, constants, hashing, and feature flags."
-order: 31
+order: 32
 ---
 
 ## Import

--- a/docs/api-reference/veryfront/work.md
+++ b/docs/api-reference/veryfront/work.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/work"
 description: "Declare source-backed Work definitions for business process observability."
-order: 32
+order: 33
 ---
 
 ## Import

--- a/docs/api-reference/veryfront/workflow.md
+++ b/docs/api-reference/veryfront/workflow.md
@@ -1,7 +1,7 @@
 ---
 title: "veryfront/workflow"
 description: "DAG-based agentic workflows with human-in-the-loop support."
-order: 33
+order: 34
 ---
 
 ## Import
@@ -363,20 +363,20 @@ import { createDynamicWorkflowRunEntrypoint, createWorkflowRunEntrypoint, create
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `DYNAMIC_EXIT_CODES` | Exit codes for the dynamic workflow run entrypoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/dynamic-run-entrypoint.ts#L48) |
-| `EXIT_CODES` | Exit codes for the workflow run entrypoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/run-entrypoint.ts#L54) |
+| `DYNAMIC_EXIT_CODES` | Exit codes for the dynamic workflow run entrypoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/dynamic-run-entrypoint.ts#L49) |
+| `EXIT_CODES` | Exit codes for the workflow run entrypoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/run-entrypoint.ts#L56) |
 
 #### Functions
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `createDynamicWorkflowRunEntrypoint` | Create a dynamic workflow run entrypoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/dynamic-run-entrypoint.ts#L239) |
-| `createWorkflowRunEntrypoint` | Create a workflow run entrypoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/run-entrypoint.ts#L189) |
+| `createDynamicWorkflowRunEntrypoint` | Create a dynamic workflow run entrypoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/dynamic-run-entrypoint.ts#L243) |
+| `createWorkflowRunEntrypoint` | Create a workflow run entrypoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/run-entrypoint.ts#L191) |
 | `createWorkflowRunManager` | Create a workflow run manager backed by run executors. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/run-manager.ts#L465) |
 | `createWorkflowWorker` | Create a workflow worker | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/workflow-worker.ts#L333) |
 | `isRunExecutor` | Type guard to check if an object implements RunExecutor | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/executors/types.ts#L129) |
-| `runDynamicWorkflowRun` | Run a workflow run with dynamic discovery. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/dynamic-run-entrypoint.ts#L78) |
-| `runWorkflowRun` | Run the workflow run entrypoint | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/run-entrypoint.ts#L89) |
+| `runDynamicWorkflowRun` | Run a workflow run with dynamic discovery. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/dynamic-run-entrypoint.ts#L79) |
+| `runWorkflowRun` | Run the workflow run entrypoint | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/run-entrypoint.ts#L91) |
 
 #### Classes
 
@@ -390,9 +390,9 @@ import { createDynamicWorkflowRunEntrypoint, createWorkflowRunEntrypoint, create
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `CreateDynamicWorkflowRunEntrypointOptions` | Create a dynamic workflow run entrypoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/dynamic-run-entrypoint.ts#L230) |
-| `CreateWorkflowRunEntrypointOptions` | Create a simple workflow run entrypoint script. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/run-entrypoint.ts#L177) |
-| `DynamicWorkflowRunEntrypointConfig` | Configuration for the dynamic workflow run entrypoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/dynamic-run-entrypoint.ts#L59) |
+| `CreateDynamicWorkflowRunEntrypointOptions` | Create a dynamic workflow run entrypoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/dynamic-run-entrypoint.ts#L234) |
+| `CreateWorkflowRunEntrypointOptions` | Create a simple workflow run entrypoint script. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/run-entrypoint.ts#L179) |
+| `DynamicWorkflowRunEntrypointConfig` | Configuration for the dynamic workflow run entrypoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/dynamic-run-entrypoint.ts#L60) |
 | `ManagerStats` | Manager statistics | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/run-manager.ts#L73) |
 | `ManagerStatus` | Manager status | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/run-manager.ts#L68) |
 | `ProcessRunExecutorConfig` | Process run executor configuration | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/executors/process.ts#L23) |
@@ -402,6 +402,6 @@ import { createDynamicWorkflowRunEntrypoint, createWorkflowRunEntrypoint, create
 | `RunExecutor` | Run Executor Interface | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/executors/types.ts#L90) |
 | `WorkerStats` | Worker statistics | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/workflow-worker.ts#L59) |
 | `WorkerStatus` | Worker status | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/workflow-worker.ts#L54) |
-| `WorkflowRunEntrypointConfig` | Configuration for the workflow run entrypoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/run-entrypoint.ts#L40) |
+| `WorkflowRunEntrypointConfig` | Configuration for the workflow run entrypoint. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/run-entrypoint.ts#L42) |
 | `WorkflowRunManagerConfig` | Configuration for the workflow run manager backed by run executors. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/run-manager.ts#L39) |
 | `WorkflowWorkerConfig` | Configuration for the workflow worker | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/worker/workflow-worker.ts#L28) |

--- a/scripts/docs/generate-api-reference.ts
+++ b/scripts/docs/generate-api-reference.ts
@@ -815,6 +815,7 @@ const API_REFERENCE_INDEX_DESCRIPTIONS: Record<string, string> = {
   "veryfront/fs": "Filesystem and path utilities.",
   "veryfront/head": "Document metadata components.",
   "veryfront/integrations": "Connector metadata and remote tools.",
+  "veryfront/knowledge": "Project knowledge retrieval helpers.",
   "veryfront/runs": "Canonical durable task and workflow runs.",
   "veryfront/markdown": "Markdown rendering.",
   "veryfront/mcp": "MCP server helpers.",

--- a/src/README.md
+++ b/src/README.md
@@ -61,6 +61,7 @@
 | **`mcp/`**       | `veryfront/mcp`        | Model Context Protocol server (SSE, sessions)         |
 | **`provider/`**  | `veryfront/provider`   | AI model providers (OpenAI, Anthropic, Google)        |
 | **`embedding/`** | `veryfront/embedding`  | Vector embeddings for semantic search                 |
+| **`knowledge/`** | `veryfront/knowledge`  | Project knowledge retrieval helpers                   |
 | **`discovery/`** | `#veryfront/discovery` | Auto-discovery of tools, agents, workflows            |
 
 ### Services & Infrastructure
@@ -580,6 +581,14 @@ See [`transforms/import-rewriter/README.md`](./transforms/import-rewriter/README
 
 - Vector embedding generation
 - Semantic search support
+
+#### `knowledge/` - Project Knowledge
+
+**Exports**: `veryfront/knowledge`
+
+- Standard `knowledge/` folder retrieval
+- Prompt-ready context formatting
+- Explicit indexing over local JSON or Veryfront Cloud RAG backends
 
 #### `discovery/` - Auto-Discovery
 

--- a/src/discovery/import-rewriter.metrics.test.ts
+++ b/src/discovery/import-rewriter.metrics.test.ts
@@ -10,4 +10,11 @@ describe("discovery import rewriter metrics module", () => {
       "veryfront/metrics should be available to discovered project modules",
     );
   });
+
+  it("makes veryfront/knowledge available to project-authored modules", () => {
+    assert(
+      DISCOVERY_GLOBAL_VERYFRONT_MODULES.includes("veryfront/knowledge"),
+      "veryfront/knowledge should be available to discovered project modules",
+    );
+  });
 });

--- a/src/discovery/import-rewriter.test.ts
+++ b/src/discovery/import-rewriter.test.ts
@@ -10,6 +10,7 @@ describe("discovery/import-rewriter", () => {
       [
         'import { defineSchema } from "veryfront/schemas";',
         'import { tool } from "veryfront/tool";',
+        'import { projectKnowledge } from "veryfront/knowledge";',
         'import { step, workflow } from "veryfront/workflow";',
         'import { work } from "veryfront/work";',
         'import { evalAgent } from "veryfront/eval";',
@@ -19,6 +20,7 @@ describe("discovery/import-rewriter", () => {
 
     assertStringIncludes(transformed, import.meta.resolve("veryfront/schemas"));
     assertStringIncludes(transformed, import.meta.resolve("veryfront/tool"));
+    assertStringIncludes(transformed, import.meta.resolve("veryfront/knowledge"));
     assertStringIncludes(transformed, import.meta.resolve("veryfront/workflow"));
     assertStringIncludes(transformed, import.meta.resolve("veryfront/work"));
     assertStringIncludes(transformed, import.meta.resolve("veryfront/eval"));
@@ -30,6 +32,7 @@ describe("discovery/import-rewriter", () => {
       [
         'import { defineSchema } from "veryfront/schemas";',
         'import { tool } from "veryfront/tool";',
+        'import { projectKnowledge } from "veryfront/knowledge";',
         'import { step, workflow } from "veryfront/workflow";',
         'import { work } from "veryfront/work";',
         'import { evalAgent } from "veryfront/eval";',
@@ -45,6 +48,10 @@ describe("discovery/import-rewriter", () => {
     assertStringIncludes(
       transformed,
       'const { tool } = globalThis.__VERYFRONT_MODULES__["veryfront/tool"]',
+    );
+    assertStringIncludes(
+      transformed,
+      'const { projectKnowledge } = globalThis.__VERYFRONT_MODULES__["veryfront/knowledge"]',
     );
     assertStringIncludes(
       transformed,

--- a/src/discovery/import-rewriter.ts
+++ b/src/discovery/import-rewriter.ts
@@ -17,6 +17,7 @@ export const DISCOVERY_GLOBAL_VERYFRONT_MODULES = [
   "veryfront/prompt",
   "veryfront/resource",
   "veryfront/embedding",
+  "veryfront/knowledge",
   "veryfront/workflow",
   "veryfront/work",
   "veryfront/eval",

--- a/src/discovery/transpiler.test.ts
+++ b/src/discovery/transpiler.test.ts
@@ -6,6 +6,7 @@ import { clearTranspileCache, importModule } from "./transpiler.ts";
 import type { FileDiscoveryContext } from "./types.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 import * as embeddingMod from "#veryfront/embedding/index.ts";
+import * as knowledgeMod from "#veryfront/knowledge";
 
 /**
  * Creates a mock FileSystemAdapter backed by an in-memory file map.
@@ -85,6 +86,12 @@ describe("embedding module static import", () => {
 
   it("exports loadUpload", () => {
     assertEquals(typeof embeddingMod.loadUpload, "function");
+  });
+});
+
+describe("knowledge module static import", () => {
+  it("exports projectKnowledge", () => {
+    assertEquals(typeof knowledgeMod.projectKnowledge, "function");
   });
 });
 

--- a/src/discovery/transpiler.ts
+++ b/src/discovery/transpiler.ts
@@ -26,6 +26,7 @@ import * as platformMod from "#veryfront/platform";
 import * as promptMod from "#veryfront/prompt";
 import * as resourceMod from "#veryfront/resource";
 import * as embeddingMod from "#veryfront/embedding/index.ts";
+import * as knowledgeMod from "#veryfront/knowledge";
 import * as workflowMod from "#veryfront/workflow";
 import * as workMod from "#veryfront/work";
 import * as evalMod from "#veryfront/eval";
@@ -50,6 +51,7 @@ async function ensureVeryfrontGlobals(): Promise<void> {
     "veryfront/prompt": promptMod,
     "veryfront/resource": resourceMod,
     "veryfront/embedding": embeddingMod,
+    "veryfront/knowledge": knowledgeMod,
     "veryfront/workflow": workflowMod,
     "veryfront/work": workMod,
     "veryfront/eval": evalMod,

--- a/src/knowledge/index.test.ts
+++ b/src/knowledge/index.test.ts
@@ -1,0 +1,190 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { exists, mkdir, withTempDir, writeTextFile } from "#veryfront/testing/deno-compat.ts";
+import { join } from "#veryfront/compat/path";
+import { clearEmbeddingProviders, registerEmbeddingProvider } from "#veryfront/embedding/index.ts";
+import { formatKnowledgeContext, projectKnowledge } from "./index.ts";
+
+function registerTestEmbeddingProvider(): void {
+  registerEmbeddingProvider("test", () =>
+    ({
+      specificationVersion: "v2",
+      provider: "test",
+      modelId: "test/demo",
+      maxEmbeddingsPerCall: undefined,
+      supportsParallelCalls: true,
+      async doEmbed({ values }: { values: string[] }) {
+        return {
+          embeddings: values.map((value) => {
+            const vector = new Array<number>(1536).fill(0);
+            vector[0] = value.toLowerCase().includes("login") ? 10 : value.length;
+            vector[1] = value.toLowerCase().includes("sso") ? 10 : 0;
+            return vector;
+          }),
+          usage: { tokens: 0 },
+          rawResponse: undefined,
+          warnings: [],
+        };
+      },
+    }) as never);
+}
+
+describe("projectKnowledge", () => {
+  afterEach(() => {
+    clearEmbeddingProviders();
+  });
+
+  it("retrieves source-controlled project knowledge with default paths", async () => {
+    registerTestEmbeddingProvider();
+
+    await withTempDir(async (projectDir) => {
+      await mkdir(join(projectDir, "knowledge"), { recursive: true });
+      await writeTextFile(
+        join(projectDir, "knowledge", "login-troubleshooting.md"),
+        [
+          "# Login troubleshooting",
+          "",
+          "Escalate blocked SSO login issues after a deployment.",
+        ].join("\n"),
+      );
+
+      const knowledge = projectKnowledge({
+        projectDir,
+        model: "test/demo",
+      });
+      await knowledge.index();
+
+      const result = await knowledge.retrieve("SSO login after deployment");
+
+      assertEquals(result.query, "SSO login after deployment");
+      assertEquals(result.matches.length, 1);
+      assertEquals(result.matches[0]?.title, "login-troubleshooting");
+      assertStringIncludes(result.context, "[login-troubleshooting]");
+      assertStringIncludes(result.context, "Escalate blocked SSO login issues");
+      assertEquals(await exists(join(projectDir, "data", "knowledge-index.json")), true);
+    });
+  });
+
+  it("does not index or search for blank queries", async () => {
+    registerTestEmbeddingProvider();
+
+    await withTempDir(async (projectDir) => {
+      await mkdir(join(projectDir, "knowledge"), { recursive: true });
+      await writeTextFile(join(projectDir, "knowledge", "login.md"), "Login help");
+
+      const knowledge = projectKnowledge({
+        projectDir,
+        model: "test/demo",
+      });
+      const result = await knowledge.retrieve(" \n\t ");
+
+      assertEquals(result, { query: "", matches: [], context: "" });
+      assertEquals(await exists(join(projectDir, "data", "knowledge-index.json")), false);
+    });
+  });
+
+  it("keeps indexing explicit on non-blank retrieval", async () => {
+    registerTestEmbeddingProvider();
+
+    await withTempDir(async (projectDir) => {
+      await mkdir(join(projectDir, "knowledge"), { recursive: true });
+      await writeTextFile(
+        join(projectDir, "knowledge", "login.md"),
+        "Login troubleshooting content.",
+      );
+
+      const knowledge = projectKnowledge({
+        projectDir,
+        model: "test/demo",
+      });
+      const result = await knowledge.retrieve("login");
+
+      assertEquals(result.matches, []);
+      assertEquals(result.context, "");
+      assertEquals(await exists(join(projectDir, "data", "knowledge-index.json")), false);
+    });
+  });
+
+  it("indexes project knowledge when requested explicitly", async () => {
+    registerTestEmbeddingProvider();
+
+    await withTempDir(async (projectDir) => {
+      await mkdir(join(projectDir, "knowledge"), { recursive: true });
+      await writeTextFile(
+        join(projectDir, "knowledge", "login.md"),
+        "Login troubleshooting content.",
+      );
+
+      const knowledge = projectKnowledge({
+        projectDir,
+        model: "test/demo",
+      });
+
+      await knowledge.index();
+      await writeTextFile(
+        join(projectDir, "knowledge", "billing.md"),
+        "Billing troubleshooting content.",
+      );
+      const beforeRefresh = await knowledge.retrieve("billing");
+
+      const indexPayload = JSON.parse(
+        await Deno.readTextFile(join(projectDir, "data", "knowledge-index.json")),
+      ) as { documents: Array<{ source: string }> };
+
+      assertEquals(beforeRefresh.matches.length, 1);
+      assertEquals(
+        indexPayload.documents.map((document) => document.source),
+        [join(projectDir, "knowledge", "login.md")],
+      );
+
+      await knowledge.index();
+
+      const refreshedPayload = JSON.parse(
+        await Deno.readTextFile(join(projectDir, "data", "knowledge-index.json")),
+      ) as { documents: Array<{ source: string }> };
+
+      assertEquals(
+        refreshedPayload.documents.map((document) => document.source),
+        [
+          join(projectDir, "knowledge", "login.md"),
+          join(projectDir, "knowledge", "billing.md"),
+        ],
+      );
+    });
+  });
+
+  it("formats retrieved knowledge into a deterministic context block", () => {
+    const context = formatKnowledgeContext([
+      {
+        documentId: "doc-1",
+        title: "Runbook",
+        source: "knowledge/runbook.md",
+        type: "md",
+        score: 0.9876,
+        text: "Step one.\n\nStep two.",
+      },
+      {
+        documentId: "doc-2",
+        title: "Policy",
+        source: "knowledge/policy.md",
+        type: "md",
+        score: 0.1234,
+        text: "Use approved escalation paths.",
+      },
+    ]);
+
+    assertEquals(
+      context,
+      [
+        "[Runbook] (score: 0.99)",
+        "Step one.\n\nStep two.",
+        "",
+        "---",
+        "",
+        "[Policy] (score: 0.12)",
+        "Use approved escalation paths.",
+      ].join("\n"),
+    );
+  });
+});

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -1,0 +1,161 @@
+/**
+ * Project knowledge retrieval helpers.
+ *
+ * @module knowledge
+ *
+ * @example
+ * ```ts
+ * import { projectKnowledge } from "veryfront/knowledge";
+ *
+ * const knowledge = projectKnowledge();
+ * await knowledge.index();
+ * const result = await knowledge.retrieve("SSO login failure");
+ * ```
+ */
+
+import { ragStore } from "#veryfront/embedding/index.ts";
+import type {
+  RagSearchOptions,
+  RagSearchResult,
+  RagStore,
+  RagStoreBackend,
+} from "#veryfront/embedding/index.ts";
+import { isAbsolute, join } from "#veryfront/platform/compat/path/index.ts";
+
+const DEFAULT_CONTENT_DIR = "knowledge";
+const DEFAULT_STORAGE_PATH = "data/knowledge-index.json";
+const DEFAULT_TOP_K = 3;
+const DEFAULT_QUERY_MAX_CHARS = 500;
+
+/** Configuration for project knowledge indexing and retrieval. */
+export interface ProjectKnowledgeConfig {
+  /**
+   * Project root used to resolve relative local paths.
+   *
+   * Hosted Veryfront Cloud request contexts ignore this for release-backed
+   * content lookup, but local development uses it to find `knowledge/` and
+   * `data/knowledge-index.json`.
+   */
+  projectDir?: string;
+  /**
+   * Directory containing source-controlled knowledge files.
+   *
+   * Defaults to `knowledge`.
+   */
+  contentDir?: string;
+  /**
+   * Local JSON index path.
+   *
+   * Defaults to `data/knowledge-index.json`.
+   */
+  storagePath?: string;
+  contentExtensions?: string[];
+  model?: string;
+  backend?: RagStoreBackend;
+  branch?: string;
+  topK?: number;
+  threshold?: number;
+  maxQueryChars?: number;
+}
+
+/** Per-call options for project knowledge retrieval. */
+export interface ProjectKnowledgeRetrieveOptions extends RagSearchOptions {
+  maxQueryChars?: number;
+}
+
+/** Result returned from project knowledge retrieval. */
+export interface ProjectKnowledgeResult {
+  query: string;
+  matches: RagSearchResult[];
+  context: string;
+}
+
+/** Helper for indexing and retrieving project knowledge. */
+export interface ProjectKnowledge {
+  /**
+   * Index configured project knowledge explicitly.
+   *
+   * Keep this out of the chat request path. Use it during setup, deploy,
+   * ingestion, or another controlled lifecycle step.
+   */
+  index(): Promise<void>;
+  retrieve(
+    query: string,
+    options?: ProjectKnowledgeRetrieveOptions,
+  ): Promise<ProjectKnowledgeResult>;
+  search(query: string, options?: RagSearchOptions): Promise<RagSearchResult[]>;
+}
+
+function resolveProjectPath(projectDir: string | undefined, path: string): string {
+  if (!projectDir || isAbsolute(path)) return path;
+  return join(projectDir, path);
+}
+
+/** Normalize a knowledge query before retrieval. */
+export function normalizeKnowledgeQuery(
+  query: string,
+  maxChars: number = DEFAULT_QUERY_MAX_CHARS,
+): string {
+  return query.replace(/\s+/g, " ").trim().slice(0, maxChars);
+}
+
+/** Format search results into a deterministic prompt context block. */
+export function formatKnowledgeContext(results: RagSearchResult[]): string {
+  return results
+    .map((result) => `[${result.title}] (score: ${result.score.toFixed(2)})\n${result.text}`)
+    .join("\n\n---\n\n");
+}
+
+/** Create a project knowledge helper backed by the configured RAG store. */
+export function projectKnowledge(config: ProjectKnowledgeConfig = {}): ProjectKnowledge {
+  const store: RagStore = ragStore({
+    model: config.model,
+    backend: config.backend,
+    branch: config.branch,
+    contentDir: resolveProjectPath(config.projectDir, config.contentDir ?? DEFAULT_CONTENT_DIR),
+    storagePath: resolveProjectPath(config.projectDir, config.storagePath ?? DEFAULT_STORAGE_PATH),
+    contentExtensions: config.contentExtensions,
+  });
+
+  async function index(): Promise<void> {
+    await store.indexContentDir();
+  }
+
+  async function search(
+    query: string,
+    options?: RagSearchOptions,
+  ): Promise<RagSearchResult[]> {
+    const normalizedQuery = normalizeKnowledgeQuery(query, config.maxQueryChars);
+    if (!normalizedQuery) return [];
+    return store.search(normalizedQuery, {
+      topK: options?.topK ?? config.topK ?? DEFAULT_TOP_K,
+      threshold: options?.threshold ?? config.threshold,
+    });
+  }
+
+  return {
+    index,
+    async retrieve(
+      query: string,
+      options?: ProjectKnowledgeRetrieveOptions,
+    ): Promise<ProjectKnowledgeResult> {
+      const normalizedQuery = normalizeKnowledgeQuery(
+        query,
+        options?.maxQueryChars ?? config.maxQueryChars,
+      );
+      if (!normalizedQuery) return { query: "", matches: [], context: "" };
+
+      const matches = await store.search(normalizedQuery, {
+        topK: options?.topK ?? config.topK ?? DEFAULT_TOP_K,
+        threshold: options?.threshold ?? config.threshold,
+      });
+
+      return {
+        query: normalizedQuery,
+        matches,
+        context: formatKnowledgeContext(matches),
+      };
+    },
+    search,
+  };
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.933";
+export const VERSION = "0.1.934";


### PR DESCRIPTION
## Summary
- add `veryfront/knowledge` with `projectKnowledge()` for project-level retrieval
- make indexing explicit through `knowledge.index()` while `retrieve()` and `search()` stay read-only
- route the new public import through discovery/transpilation and generated API docs
- bump the package version to `0.1.934` for release

## Rationale
The demo and docs should not carry an `ensureKnowledgeIndexed` helper that re-indexes on request paths. Knowledge indexing is now a lifecycle/user responsibility: call `knowledge.index()` from an ingest route, deploy hook, admin action, or setup script, then use `knowledge.retrieve(query)` from agents/tools.

`projectKnowledge()` uses the existing RAG store resolution, so local projects keep JSON-backed storage and Cloud deployments can use the shared Veryfront Cloud RAG backend through the existing runtime context.

## Verification
- `deno fmt --check src/knowledge/index.ts src/knowledge/index.test.ts src/discovery/import-rewriter.ts src/discovery/import-rewriter.test.ts src/discovery/import-rewriter.metrics.test.ts src/discovery/transpiler.ts src/discovery/transpiler.test.ts cli/commands/init/init.integration.test.ts cli/commands/install/install.integration.test.ts scripts/docs/generate-api-reference.ts deno.json`
- `deno task docs:validate`
- `deno check src/knowledge/index.ts src/discovery/transpiler.ts src/discovery/import-rewriter.ts`
- `deno test --no-check --allow-all src/knowledge/index.test.ts src/discovery/import-rewriter.test.ts src/discovery/import-rewriter.metrics.test.ts src/discovery/transpiler.test.ts cli/commands/init/init.integration.test.ts cli/commands/install/install.integration.test.ts`
- `deno task typecheck`
- `deno task docs:verify-npm`
- `deno task test`
- pre-push hook: `ok | 2207 passed (18915 steps) | 0 failed | 0 ignored (5 steps)`