### PR TITLE
Preserve date-only OKF frontmatter values

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.935",
+  "version": "0.1.936",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/knowledge/index.test.ts
+++ b/src/knowledge/index.test.ts
@@ -116,6 +116,7 @@ describe("projectKnowledge", () => {
           "type: runbook",
           "title: Billing escalation",
           "description: Escalate billing disputes to finance after account review.",
+          "added: 2026-06-26",
           "tags:",
           "  - billing",
           "  - escalation",
@@ -155,6 +156,10 @@ describe("projectKnowledge", () => {
       assertEquals(
         result.data[0]?.frontmatter.find((field) => field.key === "title")?.value,
         "Billing escalation",
+      );
+      assertEquals(
+        result.data[0]?.frontmatter.find((field) => field.key === "added")?.value,
+        "2026-06-26",
       );
       assertEquals(result.shard, { shard_index: 0, shard_count: 1, total_items: 2 });
     });

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -307,6 +307,10 @@ function collapseFrontmatterValue(value: unknown): string | null {
     stringValue = value;
   } else if (typeof value === "number" || typeof value === "boolean") {
     stringValue = String(value);
+  } else if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) return null;
+    const iso = value.toISOString();
+    stringValue = iso.endsWith("T00:00:00.000Z") ? iso.slice(0, 10) : iso;
   } else if (Array.isArray(value)) {
     stringValue = value
       .map((item) => collapseFrontmatterValue(item))

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.935";
+export const VERSION = "0.1.936";


### PR DESCRIPTION
## Summary
- preserve YAML date-only OKF frontmatter values as YYYY-MM-DD in local knowledge search results
- keep non-midnight Date values as ISO strings and invalid Date values out of scalar output
- bump the framework package to 0.1.936 for release

## Verification
- deno fmt --check deno.json src/utils/version-constant.ts src/knowledge/index.ts src/knowledge/index.test.ts
- deno test -A src/utils/version.test.ts src/utils/logger/logger.test.ts src/knowledge/index.test.ts