### PR TITLE
Hydrate CLI runtime context for workflow runs

### DIFF
--- a/cli/commands/config/handler.test.ts
+++ b/cli/commands/config/handler.test.ts
@@ -1,8 +1,24 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { join } from "veryfront/platform/path";
 import { createSuccessEnvelope } from "../../shared/json-output.ts";
-import { detectConfigSource, getEnvOverrides } from "./handler.ts";
+import { detectConfigSource, getConfigCommandData, getEnvOverrides } from "./handler.ts";
+
+async function withTempConfigProject(
+  files: Record<string, string>,
+  fn: (projectDir: string) => Promise<void>,
+): Promise<void> {
+  const projectDir = await Deno.makeTempDir();
+  try {
+    for (const [name, content] of Object.entries(files)) {
+      await Deno.writeTextFile(join(projectDir, name), content);
+    }
+    await fn(projectDir);
+  } finally {
+    await Deno.remove(projectDir, { recursive: true });
+  }
+}
 
 describe("Config Command", () => {
   describe("JSON output structure", () => {
@@ -60,6 +76,30 @@ describe("Config Command", () => {
     it("returns null for directory without config", async () => {
       const source = await detectConfigSource("/tmp");
       assertEquals(source, null);
+    });
+  });
+
+  describe("getConfigCommandData", () => {
+    it("reports projectSlug from veryfront.config.ts", async () => {
+      const saved = Deno.env.get("VERYFRONT_PROJECT_SLUG");
+      Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      try {
+        await withTempConfigProject(
+          {
+            "veryfront.config.ts": [
+              'export default { projectSlug: "ts-config-project" };',
+              "",
+            ].join("\n"),
+          },
+          async (projectDir) => {
+            const data = await getConfigCommandData(projectDir);
+            assertEquals(data.projectSlug, "ts-config-project");
+            assertEquals(data.configSource, "veryfront.config.ts");
+          },
+        );
+      } finally {
+        if (saved) Deno.env.set("VERYFRONT_PROJECT_SLUG", saved);
+      }
     });
   });
 

--- a/cli/commands/config/handler.ts
+++ b/cli/commands/config/handler.ts
@@ -40,26 +40,44 @@ export function getEnvOverrides(): string[] {
   return overrides;
 }
 
-export async function handleConfigCommand(_args: ParsedArgs): Promise<void> {
-  const { getEnvironmentConfig } = await import("veryfront/config");
-  const { cwd } = await import("veryfront/platform");
-  const config = getEnvironmentConfig();
+export type ConfigCommandData = {
+  projectSlug: string | null;
+  nodeEnv: string;
+  veryfrontEnv: string | null;
+  apiBaseUrl: string;
+  debug: boolean;
+  ci: boolean;
+  hasApiToken: boolean;
+  configSource: string | null;
+  envOverrides: string[];
+};
 
-  const projectDir = cwd();
+export async function getConfigCommandData(projectDir: string): Promise<ConfigCommandData> {
+  const { getEnvironmentConfig } = await import("veryfront/config");
+  const config = getEnvironmentConfig();
+  const { readConfigFile } = await import("#cli/shared/config");
+
   const configSource = await detectConfigSource(projectDir);
   const envOverrides = getEnvOverrides();
+  const fileConfig = await readConfigFile(projectDir);
 
-  const configData = {
-    projectSlug: config.projectSlug ?? null,
+  return {
+    projectSlug: config.projectSlug ?? fileConfig?.projectSlug ?? null,
     nodeEnv: config.nodeEnv,
     veryfrontEnv: config.veryfrontEnv || null,
     apiBaseUrl: config.apiBaseUrl,
     debug: config.debug,
     ci: config.ci,
-    hasApiToken: !!config.apiToken,
+    hasApiToken: !!(config.apiToken ?? fileConfig?.apiToken),
     configSource,
     envOverrides,
   };
+}
+
+export async function handleConfigCommand(_args: ParsedArgs): Promise<void> {
+  const { cwd } = await import("veryfront/platform");
+
+  const configData = await getConfigCommandData(cwd());
 
   if (isJsonMode()) {
     await outputJson(createSuccessEnvelope("config", configData));
@@ -83,8 +101,8 @@ export async function handleConfigCommand(_args: ParsedArgs): Promise<void> {
   cliLogger.info(
     `  ${dim("Config file:")}   ${configData.configSource ?? "(none)"}`,
   );
-  if (envOverrides.length > 0) {
-    cliLogger.info(`  ${dim("Env overrides:")}  ${envOverrides.join(", ")}`);
+  if (configData.envOverrides.length > 0) {
+    cliLogger.info(`  ${dim("Env overrides:")}  ${configData.envOverrides.join(", ")}`);
   }
   cliLogger.info("");
 }

--- a/cli/commands/workflow/command.test.ts
+++ b/cli/commands/workflow/command.test.ts
@@ -7,10 +7,14 @@ import { tool } from "#veryfront/tool";
 import { toolRegistry } from "#veryfront/tool/registry.ts";
 import { step, workflow } from "#veryfront/workflow";
 import { clearProjectAgentRuntimeRegistries } from "../../../src/agent/project/agent-runtime.ts";
+import { saveToken } from "../../auth/token-store.ts";
 import { formatWorkflowDiscoveryErrors, runWorkflowCommand } from "./command.ts";
 
 const originalRedisUrl = Deno.env.get("REDIS_URL");
 const originalRunResultPath = Deno.env.get("VERYFRONT_RUN_RESULT_PATH");
+const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+const originalProjectSlug = Deno.env.get("VERYFRONT_PROJECT_SLUG");
+const originalXdgConfigHome = Deno.env.get("XDG_CONFIG_HOME");
 
 function restoreEnv() {
   if (originalRedisUrl === undefined) {
@@ -23,6 +27,24 @@ function restoreEnv() {
     Deno.env.delete("VERYFRONT_RUN_RESULT_PATH");
   } else {
     Deno.env.set("VERYFRONT_RUN_RESULT_PATH", originalRunResultPath);
+  }
+
+  if (originalApiToken === undefined) {
+    Deno.env.delete("VERYFRONT_API_TOKEN");
+  } else {
+    Deno.env.set("VERYFRONT_API_TOKEN", originalApiToken);
+  }
+
+  if (originalProjectSlug === undefined) {
+    Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+  } else {
+    Deno.env.set("VERYFRONT_PROJECT_SLUG", originalProjectSlug);
+  }
+
+  if (originalXdgConfigHome === undefined) {
+    Deno.env.delete("XDG_CONFIG_HOME");
+  } else {
+    Deno.env.set("XDG_CONFIG_HOME", originalXdgConfigHome);
   }
 }
 
@@ -119,6 +141,65 @@ describe("workflow command", () => {
       });
     } finally {
       await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("hydrates runtime auth from the stored login token and project config", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-workflow-command-" });
+    const configHome = await Deno.makeTempDir({ prefix: "vf-workflow-auth-" });
+    const resultPath = `${projectDir}/.veryfront/result.json`;
+
+    try {
+      Deno.env.delete("VERYFRONT_API_TOKEN");
+      Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      Deno.env.delete("REDIS_URL");
+      Deno.env.set("XDG_CONFIG_HOME", configHome);
+      Deno.env.set("VERYFRONT_RUN_RESULT_PATH", resultPath);
+      await saveToken("stored-token");
+      await Deno.writeTextFile(
+        `${projectDir}/veryfront.config.ts`,
+        'export default { projectSlug: "configured-workflow-project" };\n',
+      );
+
+      const echoTool = tool({
+        id: "echo",
+        description: "Echo workflow input.",
+        inputSchema: defineSchema((v) => v.object({ message: v.string() }))(),
+        execute: (input) => ({ echoed: input.message }),
+      });
+
+      const echoWorkflow = workflow({
+        id: "echo",
+        description: "Echo a message through a project-local tool.",
+        steps: [step("start", { tool: "echo", input: { message: "hello" } })],
+      });
+
+      await runWorkflowCommand(
+        {
+          action: "run",
+          name: "echo",
+          input: undefined,
+          debug: false,
+          projectDir,
+        },
+        {
+          discoverProjectAgentRuntime: () => {
+            toolRegistry.register(echoTool.id, echoTool);
+
+            const discovery = createEmptyDiscoveryResult();
+            discovery.tools.set(echoTool.id, echoTool);
+            discovery.workflows.set(echoWorkflow.id, echoWorkflow);
+
+            return Promise.resolve(discovery);
+          },
+        },
+      );
+
+      assertEquals(Deno.env.get("VERYFRONT_API_TOKEN"), "stored-token");
+      assertEquals(Deno.env.get("VERYFRONT_PROJECT_SLUG"), "configured-workflow-project");
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(configHome, { recursive: true });
     }
   });
 });

--- a/cli/commands/workflow/command.ts
+++ b/cli/commands/workflow/command.ts
@@ -1,6 +1,7 @@
 import { cliLogger } from "#cli/utils";
 import { exitProcess } from "#cli/utils";
 import { withProjectSourceContext } from "#cli/shared/project-source-context";
+import { applyRuntimeAuthContext } from "#cli/shared/runtime-auth";
 import { agentRegistry } from "../../../src/agent/composition/index.ts";
 import { discoverProjectAgentRuntime } from "../../../src/agent/project/agent-runtime.ts";
 import type { DiscoveryResult } from "../../../src/discovery/types.ts";
@@ -159,6 +160,13 @@ export async function runWorkflowCommand(
   }
 
   const projectDir = options.projectDir ?? Deno.cwd();
+  const { readConfigFile } = await import("#cli/shared/config");
+  const configFile = await readConfigFile(projectDir);
+  await applyRuntimeAuthContext({
+    projectDir,
+    projectSlug: configFile?.projectSlug,
+  });
+
   const discoverRuntime: (
     input: Parameters<typeof discoverProjectAgentRuntime>[0],
   ) => Promise<DiscoveryResult> = dependencies.discoverProjectAgentRuntime ??

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.936",
+  "version": "0.1.937",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.936";
+export const VERSION = "0.1.937";


### PR DESCRIPTION
## Summary
- hydrate stored login token and configured project slug before local workflow execution
- make `veryfront config` report `projectSlug` from `veryfront.config.ts`
- bump package version to `0.1.937` for release

## Verification
- `deno test -A cli/commands/config/handler.test.ts cli/commands/workflow/command.test.ts cli/shared/runtime-auth.test.ts src/knowledge/index.test.ts`
- `deno test -A src/utils/version.test.ts src/utils/logger/logger.test.ts`
- pre-push: format, lint, typecheck, unit tests (2,207 passed)