### PR TITLE
Keep served AG-UI routes connected to Cloud credentials

### DIFF
--- a/cli/commands/routes/command.ts
+++ b/cli/commands/routes/command.ts
@@ -2,9 +2,8 @@ import { join, relative } from "#std/path.ts";
 import { runtime } from "veryfront/platform";
 import { getConfig } from "veryfront/config";
 import { cliLogger } from "#cli/utils";
-import { ApiRouteMatcher } from "#veryfront/routing/api/api-route-matcher.ts";
-import { discoverAppRoutes, discoverPagesRoutes } from "#veryfront/routing/api/route-discovery.ts";
-import { RouteDiscovery } from "#veryfront/server/dev-server/route-discovery.ts";
+import { ApiRouteMatcher, discoverAppRoutes, discoverPagesRoutes } from "veryfront/routing";
+import { RouteDiscovery } from "veryfront/server";
 
 export interface RoutesOptions {
   projectDir: string;

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.937",
+  "version": "0.1.938",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/platform/cloud/resolver.test.ts
+++ b/src/platform/cloud/resolver.test.ts
@@ -8,6 +8,7 @@ import {
   createTestConfig,
 } from "#veryfront/config/runtime-config.ts";
 import { runWithVeryfrontCloudContext } from "#veryfront/provider";
+import { runWithProjectEnv } from "#veryfront/server/project-env";
 import {
   getDefaultVeryfrontCloudEmbeddingModel,
   getDefaultVeryfrontCloudModel,
@@ -74,6 +75,19 @@ describe("platform/cloud/resolver", () => {
     setEnv("VERYFRONT_API_TOKEN", "vf_test_runtime");
 
     assertEquals(isVeryfrontCloudEnabled(), true);
+  });
+
+  it("uses host framework env under project env overlays", () => {
+    setEnv("VERYFRONT_API_TOKEN", "vf_host_token");
+    setEnv("VERYFRONT_PROJECT_SLUG", "host-project");
+    setEnv("VERYFRONT_DEFAULT_MODEL", "openai/gpt-5.2");
+
+    runWithProjectEnv({ VERYFRONT_API_TOKEN: "tenant-token" }, () => {
+      assertEquals(isVeryfrontCloudEnabled(), true);
+      assertEquals(getVeryfrontCloudAuthToken(), "vf_host_token");
+      assertEquals(getVeryfrontCloudProjectSlug(), "host-project");
+      assertEquals(getDefaultVeryfrontCloudModel(), "veryfront-cloud/openai/gpt-5.2");
+    });
   });
 
   it("normalizes default cloud model overrides without requiring the prefix", () => {

--- a/src/platform/cloud/resolver.ts
+++ b/src/platform/cloud/resolver.ts
@@ -1,5 +1,5 @@
 import { getCurrentRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
-import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { getCurrentVeryfrontCloudContext } from "#veryfront/provider/veryfront-cloud/context.ts";
 
 // ---------------------------------------------------------------------------
@@ -32,8 +32,8 @@ function getApiBaseUrlEnv(): string {
   const getter = (globalThis as Record<string, unknown>).__vfGetApiBaseUrlEnv as
     | (() => string)
     | undefined;
-  return getter?.() ?? getEnv("VERYFRONT_API_BASE_URL") ??
-    getEnv("VERYFRONT_API_URL")?.replace("/graphql", "/api") ?? DEFAULT_API_BASE_URL;
+  return getter?.() ?? getHostEnv("VERYFRONT_API_BASE_URL") ??
+    getHostEnv("VERYFRONT_API_URL")?.replace("/graphql", "/api") ?? DEFAULT_API_BASE_URL;
 }
 
 export const DEFAULT_VERYFRONT_CLOUD_MODEL = "veryfront-cloud/anthropic/claude-sonnet-4-6";
@@ -85,14 +85,14 @@ function getResolvedVeryfrontCloudContext(): Omit<VeryfrontCloudBootstrap, "apiB
   return {
     apiToken: requestContext?.token ??
       scopedContext?.apiToken ??
-      getEnv("VERYFRONT_API_TOKEN") ??
+      getHostEnv("VERYFRONT_API_TOKEN") ??
       runtimeBootstrap.apiToken,
     projectSlug: requestContext?.projectSlug ??
       scopedContext?.projectSlug ??
-      getEnv("VERYFRONT_PROJECT_SLUG") ??
+      getHostEnv("VERYFRONT_PROJECT_SLUG") ??
       runtimeBootstrap.projectSlug,
     serviceLayer: normalizeServiceLayer(scopedContext?.serviceLayer) ??
-      normalizeServiceLayer(getEnv("VERYFRONT_SERVICE_LAYER")),
+      normalizeServiceLayer(getHostEnv("VERYFRONT_SERVICE_LAYER")),
     hasRequestContext: requestContext !== null || scopedContext !== undefined,
     usesVeryfrontFs: runtimeBootstrap.usesVeryfrontFs,
   };
@@ -135,14 +135,14 @@ export function isVeryfrontCloudEnabled(): boolean {
 
 export function getDefaultVeryfrontCloudModel(): string {
   return normalizeCloudModelString(
-    getEnv("VERYFRONT_DEFAULT_MODEL"),
+    getHostEnv("VERYFRONT_DEFAULT_MODEL"),
     DEFAULT_VERYFRONT_CLOUD_MODEL,
   );
 }
 
 export function getDefaultVeryfrontCloudEmbeddingModel(): string {
   return normalizeCloudModelString(
-    getEnv("VERYFRONT_DEFAULT_EMBEDDING_MODEL"),
+    getHostEnv("VERYFRONT_DEFAULT_EMBEDDING_MODEL"),
     DEFAULT_VERYFRONT_CLOUD_EMBEDDING_MODEL,
   );
 }

--- a/src/routing/api/index.ts
+++ b/src/routing/api/index.ts
@@ -9,6 +9,7 @@ export type { APIContext, APIHandler, APIResponse, APIRoute } from "./handler.ts
 
 export { ApiRouteMatcher } from "./api-route-matcher.ts";
 export type { Route, RouteMatch } from "./api-route-matcher.ts";
+export { discoverAppRoutes, discoverPagesRoutes } from "./route-discovery.ts";
 
 export {
   badRequest,

--- a/src/routing/index.ts
+++ b/src/routing/index.ts
@@ -39,9 +39,12 @@ export {
 export type { APIContext, APIHandler, APIResponse, APIRoute } from "./api/index.ts";
 export {
   APIRouteHandler,
+  ApiRouteMatcher,
   applyCORSHeaders,
   badRequest,
   createContext,
+  discoverAppRoutes,
+  discoverPagesRoutes,
   forbidden,
   handleCORSPreflight,
   json,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -73,6 +73,7 @@ export type {
 };
 import { ReloadNotifier } from "./reload-notifier.ts";
 export { ReloadNotifier };
+export { RouteDiscovery } from "./dev-server/route-discovery.ts";
 export type { BuildOptions, BuildStats } from "./build-types.ts";
 export { defaultDistributedCacheInitializers } from "./distributed-cache-initializers.ts";
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.937";
+export const VERSION = "0.1.938";


### PR DESCRIPTION
## Summary
- read framework-owned VERYFRONT_* Cloud settings through host env inside the Cloud resolver
- add a regression test for project env overlays hiding tenant env from framework credentials
- expose route-discovery helpers through public surfaces so the CLI routes command satisfies boundary lint
- bump package version to 0.1.938 for release

## Verification
- deno test --frozen --allow-all src/platform/cloud/resolver.test.ts src/agent/ag-ui/handler.test.ts
- deno task --frozen verify:quick
- git push pre-push suite: 2,207 tests passed