### PR TITLE
Create deploy releases from the selected branch

### DIFF
--- a/cli/commands/deploy/command.test.ts
+++ b/cli/commands/deploy/command.test.ts
@@ -215,7 +215,7 @@ describe("createRelease", () => {
     });
 
     await createRelease(mockClient, "my-project", { branch: "develop" });
-    assertEquals(capturedBody, { branch: "develop" });
+    assertEquals(capturedBody, { branch_reference: "develop" });
   });
 
   it("should create release with name and branch", async () => {
@@ -229,7 +229,7 @@ describe("createRelease", () => {
     });
 
     await createRelease(mockClient, "my-project", { name: "v2.0.0", branch: "develop" });
-    assertEquals(capturedBody, { name: "v2.0.0", branch: "develop" });
+    assertEquals(capturedBody, { name: "v2.0.0", branch_reference: "develop" });
   });
 });
 

--- a/cli/commands/deploy/command.ts
+++ b/cli/commands/deploy/command.ts
@@ -128,7 +128,7 @@ export function createRelease(
 ): Promise<Release> {
   const body: Record<string, string> = {};
   if (options?.name) body.name = options.name;
-  if (options?.branch) body.branch = options.branch;
+  if (options?.branch) body.branch_reference = options.branch;
 
   return client.post<Release>(`/projects/${projectSlug}/releases`, body);
 }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.938",
+  "version": "0.1.939",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.938";
+export const VERSION = "0.1.939";


### PR DESCRIPTION
## Summary
- serialize CLI deploy branch selection as the REST API `branch_reference` field
- update deploy tests so branch releases assert the API contract
- bump the runtime version to `0.1.939` for release

## Validation
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all cli/commands/deploy/command.test.ts cli/mcp/tools/deploy-tool.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts`
- pre-push hook: formatting, lint, typecheck, full unit suite \(2,207 passed / 0 failed\)