### PR TITLE
Preserve project scope for workflow tool execution

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.939",
+  "version": "0.1.940",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.939";
+export const VERSION = "0.1.940";

--- a/src/workflow/api/workflow-client.test.ts
+++ b/src/workflow/api/workflow-client.test.ts
@@ -3,13 +3,16 @@ import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/as
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { VeryfrontError } from "#veryfront/errors";
 import { defineSchema } from "#veryfront/schemas/index.ts";
+import { runWithCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
 import type { Tool } from "#veryfront/tool";
+import { toolRegistry } from "#veryfront/tool";
 import { createWorkflowClient, WorkflowClient } from "./workflow-client.ts";
 import { MemoryBackend } from "../backends/memory.ts";
 import { workflow } from "../dsl/workflow.ts";
 import { step } from "../dsl/step.ts";
 import { waitForApproval } from "../dsl/wait.ts";
+import type { WorkflowRun } from "../types.ts";
 
 function createMockTool(name: string, output: unknown): Tool {
   return {
@@ -181,6 +184,65 @@ describe("WorkflowClient", () => {
       assertEquals((run.output as Record<string, unknown>)["_tenant"], undefined);
       assertEquals((run.context as Record<string, unknown>)["_tenant"], undefined);
       assertEquals(run.output, { "tenant-step": { result: "ok" } });
+    });
+
+    it("resolves project-scoped tools from stored tenant context when resuming a run", async () => {
+      const scopedTool = createMockTool("scoped-tool", { result: "ok" });
+      const scopedBackend = new MemoryBackend();
+      const scopedClient = createWorkflowClient({
+        backend: scopedBackend,
+        executor: {
+          stepExecutor: {
+            toolRegistry,
+          },
+        },
+      });
+
+      try {
+        runWithCacheKeyContext(
+          { projectId: "project-123", mode: "preview", versionId: "branch-123" },
+          () => {
+            toolRegistry.register(scopedTool.id, scopedTool);
+          },
+        );
+
+        const tenantWorkflow = workflow({
+          id: "tenant-scoped-tool-workflow",
+          steps: [step("tenant-step", { tool: "scoped-tool" })],
+        });
+        scopedClient.register(tenantWorkflow);
+
+        const run: WorkflowRun = {
+          id: "run-scoped-tool",
+          workflowId: tenantWorkflow.id,
+          status: "pending",
+          input: {},
+          nodeStates: {},
+          currentNodes: [],
+          context: { input: {} },
+          checkpoints: [],
+          pendingApprovals: [],
+          createdAt: new Date(),
+          _tenant: {
+            projectSlug: "acme",
+            token: "tenant-token",
+            projectId: "project-123",
+            productionMode: false,
+            releaseId: null,
+            branch: "branch-123",
+          },
+        };
+        await scopedBackend.createRun(run);
+
+        await scopedClient.resume(run.id);
+
+        const completedRun = await scopedBackend.getRun(run.id);
+        assertEquals(completedRun?.status, "completed");
+        assertEquals(completedRun?.output, { "tenant-step": { result: "ok" } });
+      } finally {
+        toolRegistry.clearAll();
+        await scopedClient.destroy();
+      }
     });
   });
 

--- a/src/workflow/executor/step-executor.ts
+++ b/src/workflow/executor/step-executor.ts
@@ -1,6 +1,10 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { Agent, AgentResponse } from "#veryfront/agent/types.ts";
 import type { Tool } from "#veryfront/tool/types.ts";
+import {
+  type CacheKeyContext,
+  runWithCacheKeyContext,
+} from "#veryfront/cache/cache-key-builder.ts";
 import { ensureError } from "#veryfront/errors/veryfront-error.ts";
 import {
   AGENT_NOT_FOUND,
@@ -39,6 +43,16 @@ export function getWorkflowTenant(): CapturedTenantContext | undefined {
   return workflowTenantStorage.getStore();
 }
 
+function cacheKeyContextFromWorkflowTenant(tenant: CapturedTenantContext): CacheKeyContext {
+  const mode = tenant.productionMode ? "production" : "preview";
+
+  return {
+    projectId: tenant.projectId || tenant.projectSlug || "default",
+    mode,
+    versionId: mode === "production" ? (tenant.releaseId || "latest") : (tenant.branch || "main"),
+  };
+}
+
 /**
  * Run a function with workflow tenant context available via AsyncLocalStorage.
  * If tenant is undefined, preserves any existing outer context.
@@ -48,7 +62,10 @@ export function runWithWorkflowTenant<T>(
   fn: () => Promise<T>,
 ): Promise<T> {
   if (!tenant) return fn();
-  return workflowTenantStorage.run(tenant, fn);
+  return workflowTenantStorage.run(
+    tenant,
+    () => runWithCacheKeyContext(cacheKeyContextFromWorkflowTenant(tenant), fn),
+  );
 }
 
 /** Default initial delay before first retry attempt */


### PR DESCRIPTION
## Summary
- preserve the project cache-key context when workflow steps execute from stored tenant metadata
- keep project-scoped tools available when durable workflow runs resume outside the original request context
- bump the framework version to 0.1.940

## Verification
- deno test --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- deno test --allow-all src/workflow/api/workflow-client.test.ts src/server/handlers/request/project-run-execute.handler.test.ts src/workflow/worker/shared.test.ts src/workflow/worker/run-entrypoint.test.ts
- deno task verify:quick
- pre-push: format, lint, typecheck, unit tests: 2207 passed, 0 failed

## Root cause
Workflow execution restored workflow tenant context, but project-scoped registries resolve tools through cache-key context. Durable workflow steps that resumed outside the original request context could therefore look in the default empty registry scope and fail to find project tools such as search_knowledge.