### PR TITLE
Add hosted workflow tool regression

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.940",
+  "version": "0.1.941",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -1,17 +1,21 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import type { Agent } from "#veryfront/agent";
 import type { Message } from "#veryfront/agent/types.ts";
 import { agentRegistry } from "#veryfront/agent/composition/index.ts";
 import { createAgentServiceEvalAdapter } from "#veryfront/eval/agent-service.ts";
 import { runEval as runEvalDefinition } from "#veryfront/eval/runner.ts";
 import { datasets, evalAgent, type EvalReport, metrics } from "veryfront/eval";
+import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
+import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
+import { toolRegistry } from "#veryfront/tool";
 import {
   ProjectRunExecuteHandler,
   type ProjectRunExecuteHandlerDeps,
 } from "./project-run-execute.handler.ts";
 import { createControlPlaneSignature, createCtx } from "./internal-agent-run.test-helpers.ts";
+import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 
 const encoder = new TextEncoder();
 
@@ -204,6 +208,10 @@ async function withEnvValue<T>(
 }
 
 describe("server/handlers/request/project-run-execute.handler", () => {
+  afterAll(async () => {
+    await stopEsbuild();
+  });
+
   it("runs a discovered task and returns canonical runtime execution output", async () => {
     let receivedConfig: Record<string, unknown> | undefined;
     const handler = new ProjectRunExecuteHandler(createDeps({
@@ -803,6 +811,107 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     assertEquals(hasAgentRegistry, true);
     assertEquals(hasToolRegistry, true);
     assertEquals(order, ["discover", "create-client", "start"]);
+  });
+
+  it("executes discovered project tool steps from control-plane workflow runs", async () => {
+    agentRegistry.clearAll();
+    toolRegistry.clearAll();
+
+    const adapter = createMockAdapter();
+    const projectDir = "/runtime-tool-workflow-project";
+    await adapter.fs.writeFile(
+      `${projectDir}/tools/echo-tool.ts`,
+      [
+        'import { tool } from "veryfront/tool";',
+        "",
+        "export default tool({",
+        '  id: "echo_tool",',
+        '  description: "Echo the provided message",',
+        "  inputSchema: {",
+        '    type: "object",',
+        '    properties: { message: { type: "string" } },',
+        '    required: ["message"],',
+        "    additionalProperties: false,",
+        "  },",
+        '  execute: async ({ message }) => ({ message, source: "project-tool" }),',
+        "});",
+        "",
+      ].join("\n"),
+    );
+    await adapter.fs.writeFile(
+      `${projectDir}/workflows/remote-tool-workflow.ts`,
+      [
+        'import { step, workflow } from "veryfront/workflow";',
+        "",
+        "export default workflow({",
+        '  id: "remote-tool-workflow",',
+        '  description: "Run a project tool from the control-plane workflow path.",',
+        "  steps: [",
+        '    step("lookup", {',
+        '      tool: "echo_tool",',
+        '      input: { message: "hello from control plane" },',
+        "    }),",
+        "  ],",
+        "});",
+        "",
+      ].join("\n"),
+    );
+
+    const handler = new ProjectRunExecuteHandler();
+    const body = {
+      runId: "run_workflow_project_tool_1",
+      kind: "workflow",
+      target: "workflow:remote-tool-workflow",
+      projectId: "proj-1",
+      input: { ticket: "VF-1" },
+    };
+    const { request, publicKeyPem } = await signedRequest(
+      "/api/control-plane/runs/run_workflow_project_tool_1/execute",
+      body,
+      { "x-token": "runtime-token" },
+    );
+    adapter.env.set("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY", publicKeyPem);
+    const ctx = {
+      ...createCtx(publicKeyPem),
+      adapter,
+      projectDir,
+      config: {},
+      proxyToken: "runtime-token",
+      requestContext: {
+        token: "runtime-token",
+        slug: "demo-project",
+        branch: "main",
+        mode: "preview",
+      },
+      resolvedEnvironment: "preview",
+    };
+
+    const result = await runWithRequestContext(
+      {
+        projectSlug: "demo-project",
+        projectId: "proj-1",
+        token: "runtime-token",
+        productionMode: false,
+        branch: "main",
+      },
+      () => handler.handle(request, ctx),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    const response = await result.response.json();
+    assertEquals(response.success, true);
+    assertEquals(response.result, {
+      lookup: {
+        message: "hello from control plane",
+        source: "project-tool",
+      },
+    });
+    assertEquals(response.logs, null);
+    assertEquals(typeof response.duration_ms, "number");
+    assertEquals(response.duration_ms >= 0, true);
+    assertEquals(response.error, undefined);
+    assertEquals(response.artifacts, undefined);
   });
 
   it("waits for async workflow finalization before destroying the workflow client", async () => {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.940";
+export const VERSION = "0.1.941";


### PR DESCRIPTION
## Summary
- add a regression test for signed control-plane workflow execution resolving a project-discovered tool
- bump the framework version to 0.1.941 for the release workflow

## Verification
- deno test --no-check --allow-all src/server/handlers/request/project-run-execute.handler.test.ts src/utils/version.test.ts
- deno task verify:quick
- pre-push suite: 2207 tests / 18924 steps / 0 failed
- remote customer-operations-agent workflow run completed after the server production promotion: run_9267861f-4afa-4294-a875-06e5b14c19a0
