### PR TITLE
Fix hosted knowledge lookup context

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.941",
+  "version": "0.1.942",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/knowledge/index.test.ts
+++ b/src/knowledge/index.test.ts
@@ -4,7 +4,10 @@ import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { exists, mkdir, withTempDir, writeTextFile } from "#veryfront/testing/deno-compat.ts";
 import { join } from "#veryfront/compat/path";
 import { clearEmbeddingProviders, registerEmbeddingProvider } from "#veryfront/embedding/index.ts";
+import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
 import { createSearchKnowledgeTool, formatKnowledgeContext, projectKnowledge } from "./index.ts";
+
+const originalFetch = globalThis.fetch;
 
 function registerTestEmbeddingProvider(): void {
   registerEmbeddingProvider("test", () =>
@@ -33,6 +36,7 @@ function registerTestEmbeddingProvider(): void {
 describe("projectKnowledge", () => {
   afterEach(() => {
     clearEmbeddingProviders();
+    globalThis.fetch = originalFetch;
   });
 
   it("retrieves source-controlled project knowledge with default paths", async () => {
@@ -234,6 +238,90 @@ describe("projectKnowledge", () => {
       assertEquals(searchKnowledge.inputSchemaJson?.properties?.query?.type, "string");
       assertEquals(result.data.map((item) => item.path), ["knowledge/billing.md"]);
     });
+  });
+
+  it("looks up hosted OKF knowledge from the request-scoped project context", async () => {
+    const requestedUrls: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      requestedUrls.push(url);
+      assertEquals(new Headers(init?.headers).get("Authorization"), "Bearer tenant-token");
+
+      const parsed = new URL(url);
+      if (
+        parsed.pathname === "/projects/acme/releases/release-1/files" &&
+        parsed.searchParams.get("include_server_functions") === "true"
+      ) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: "file-1",
+                version_id: "version-1",
+                path: "knowledge/login-troubleshooting.md",
+                content: [
+                  "---",
+                  "type: runbook",
+                  "title: Login troubleshooting",
+                  "description: Diagnose SSO failures after releases.",
+                  "---",
+                  "",
+                  "# Login troubleshooting",
+                ].join("\n"),
+                type: "file",
+                size: 128,
+                updated_at: "2026-06-26T00:00:00.000Z",
+              },
+              {
+                id: "file-2",
+                version_id: "version-2",
+                path: "app/page.tsx",
+                content: "export default function Page() { return null; }",
+                type: "file",
+                size: 48,
+                updated_at: "2026-06-26T00:00:00.000Z",
+              },
+            ],
+            page_info: {
+              self: null,
+              first: null,
+              next: null,
+              prev: null,
+            },
+            release_id: "release-1",
+            release_version: "1",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response(JSON.stringify({ error: "unexpected request", url }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const searchKnowledge = createSearchKnowledgeTool();
+    const result = await runWithRequestContext(
+      {
+        projectSlug: "acme",
+        projectId: "project-1",
+        token: "tenant-token",
+        productionMode: true,
+        releaseId: "release-1",
+      },
+      () => searchKnowledge.execute({ query: "sso release" }),
+    );
+
+    assertEquals(result.mode, "search");
+    assertEquals(result.returned, 1);
+    assertEquals(result.data[0]?.path, "knowledge/login-troubleshooting.md");
+    assertEquals(
+      result.data[0]?.frontmatter.find((field) => field.key === "title")?.value,
+      "Login troubleshooting",
+    );
+    assertEquals(requestedUrls.length, 1);
+    assertStringIncludes(requestedUrls[0] ?? "", "/projects/acme/releases/release-1/files");
   });
 
   it("indexes project knowledge when requested explicitly", async () => {

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -23,9 +23,12 @@ import type {
 import { exists, readDir, readTextFile } from "#veryfront/platform/compat/index.ts";
 import { extract } from "#veryfront/compat/std/front-matter-yaml.ts";
 import { isAbsolute, join, relative } from "#veryfront/platform/compat/path/index.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
+import { getCurrentRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
+import { VeryfrontApiClient } from "#veryfront/platform/adapters/veryfront-api-client/client.ts";
 import { tool } from "#veryfront/tool/factory.ts";
 import type { JsonSchema } from "#veryfront/tool/schema/index.ts";
-import type { Tool } from "#veryfront/tool/types.ts";
+import type { Tool, ToolExecutionContext } from "#veryfront/tool/types.ts";
 
 const DEFAULT_CONTENT_DIR = "knowledge";
 const DEFAULT_STORAGE_PATH = "data/knowledge-index.json";
@@ -165,6 +168,17 @@ interface ProjectKnowledgeLookupCursorState {
   shardIndex: number;
 }
 
+interface HostedKnowledgeContext {
+  projectRef: string;
+  projectSlug?: string;
+  projectId?: string;
+  authToken: string;
+  productionMode: boolean;
+  releaseId?: string | null;
+  branch?: string | null;
+  environmentName?: string | null;
+}
+
 const SEARCH_KNOWLEDGE_INPUT_SCHEMA: JsonSchema = {
   type: "object",
   properties: {
@@ -234,6 +248,29 @@ function toPosixPath(path: string): string {
 
 function stripTrailingSlash(path: string): string {
   return toPosixPath(path).replace(/\/+$/, "");
+}
+
+function trimLeadingSlash(path: string): string {
+  return toPosixPath(path).replace(/^\/+/, "");
+}
+
+function buildHostedManifestPath(contentDir: string, filePath: string): string | null {
+  const normalizedPath = trimLeadingSlash(filePath);
+  const normalizedContentDir = stripTrailingSlash(trimLeadingSlash(contentDir)).replace(
+    /^\.\//,
+    "",
+  );
+
+  if (
+    normalizedPath === normalizedContentDir || !normalizedPath.startsWith(
+      `${normalizedContentDir}/`,
+    )
+  ) {
+    return null;
+  }
+
+  if (!normalizedPath.endsWith(".md")) return null;
+  return normalizedPath;
 }
 
 function buildManifestPath(config: ProjectKnowledgeConfig, absolutePath: string): string {
@@ -496,7 +533,13 @@ function scoreEntry(
 
 async function getProjectKnowledgeManifest(
   config: ProjectKnowledgeConfig,
+  context?: ToolExecutionContext,
 ): Promise<ProjectKnowledgeManifestEntry[]> {
+  if (!config.projectDir) {
+    const hostedManifest = await getHostedProjectKnowledgeManifest(config, context);
+    if (hostedManifest) return hostedManifest;
+  }
+
   const contentDir = resolveProjectPath(
     config.projectDir,
     config.contentDir ?? DEFAULT_CONTENT_DIR,
@@ -521,6 +564,105 @@ async function getProjectKnowledgeManifest(
   }
 
   return manifest;
+}
+
+function getHostedKnowledgeContext(context?: ToolExecutionContext): HostedKnowledgeContext | null {
+  const requestContext = getCurrentRequestContext();
+  const authToken = typeof context?.authToken === "string" && context.authToken
+    ? context.authToken
+    : requestContext?.token;
+  const projectSlug = typeof context?.projectSlug === "string" && context.projectSlug
+    ? context.projectSlug
+    : requestContext?.projectSlug;
+  const projectId = typeof context?.projectId === "string" && context.projectId
+    ? context.projectId
+    : requestContext?.projectId;
+  const projectRef = projectSlug ?? projectId;
+
+  if (!authToken || !projectRef) return null;
+
+  const productionMode = typeof context?.productionMode === "boolean"
+    ? context.productionMode
+    : requestContext?.productionMode ?? false;
+  const releaseId = typeof context?.releaseId === "string" || context?.releaseId === null
+    ? context.releaseId
+    : requestContext?.releaseId ?? null;
+  const branch = typeof context?.branch === "string" || context?.branch === null
+    ? context.branch
+    : requestContext?.branch ?? null;
+  const environmentName =
+    typeof context?.environmentName === "string" || context?.environmentName === null
+      ? context.environmentName
+      : requestContext?.environmentName ?? null;
+
+  return {
+    projectRef,
+    projectSlug,
+    projectId,
+    authToken,
+    productionMode,
+    releaseId,
+    branch,
+    environmentName,
+  };
+}
+
+function createHostedKnowledgeClient(hostedContext: HostedKnowledgeContext): VeryfrontApiClient {
+  const client = new VeryfrontApiClient({
+    apiBaseUrl: getHostEnv("VERYFRONT_API_URL") || "https://api.veryfront.com",
+    proxyMode: true,
+    projectId: hostedContext.projectId,
+    projectSlug: hostedContext.projectRef,
+  });
+
+  client.setRequestToken(hostedContext.authToken);
+  client.setProjectSlug(hostedContext.projectRef);
+
+  if (hostedContext.productionMode && hostedContext.releaseId) {
+    client.setContext({ type: "release", version: hostedContext.releaseId });
+  } else if (hostedContext.productionMode && hostedContext.environmentName) {
+    client.setContext({ type: "environment", name: hostedContext.environmentName });
+  } else {
+    client.setContext({ type: "branch", name: hostedContext.branch ?? "main" });
+  }
+
+  return client;
+}
+
+async function getHostedProjectKnowledgeManifest(
+  config: ProjectKnowledgeConfig,
+  context?: ToolExecutionContext,
+): Promise<ProjectKnowledgeManifestEntry[] | null> {
+  const hostedContext = getHostedKnowledgeContext(context);
+  if (!hostedContext) return null;
+
+  const contentDir = config.contentDir ?? DEFAULT_CONTENT_DIR;
+  const client = createHostedKnowledgeClient(hostedContext);
+  const files = await client.listAllFiles({
+    pattern: stripTrailingSlash(trimLeadingSlash(contentDir)),
+    sortBy: "path",
+    sortOrder: "asc",
+  });
+
+  const manifest: ProjectKnowledgeManifestEntry[] = [];
+  for (const file of files) {
+    const manifestPath = buildHostedManifestPath(contentDir, file.path);
+    if (!manifestPath || typeof file.content !== "string") continue;
+
+    let parsedFrontmatter: Record<string, unknown> = {};
+    try {
+      parsedFrontmatter = extract<Record<string, unknown>>(file.content).attrs;
+    } catch {
+      parsedFrontmatter = {};
+    }
+
+    manifest.push({
+      path: manifestPath,
+      ...sanitizeFrontmatter(parsedFrontmatter),
+    });
+  }
+
+  return manifest.sort((left, right) => left.path.localeCompare(right.path));
 }
 
 function lookupKnowledgeManifest(
@@ -657,8 +799,9 @@ export function formatKnowledgeContext(results: RagSearchResult[]): string {
 export async function searchProjectKnowledge(
   input: ProjectKnowledgeLookupInput,
   config: ProjectKnowledgeConfig = {},
+  context?: ToolExecutionContext,
 ): Promise<ProjectKnowledgeLookupOutput> {
-  const manifest = await getProjectKnowledgeManifest(config);
+  const manifest = await getProjectKnowledgeManifest(config, context);
   return lookupKnowledgeManifest(manifest, input);
 }
 
@@ -671,9 +814,10 @@ export function createSearchKnowledgeTool(
   return tool<ProjectKnowledgeLookupInput, ProjectKnowledgeLookupOutput>({
     id,
     description: description ??
-      "Retrieve a compact, cursor-based slice of the local project knowledge manifest.",
+      "Retrieve a compact, cursor-based slice of the project knowledge manifest.",
     inputSchema: SEARCH_KNOWLEDGE_INPUT_SCHEMA,
-    execute: (input) => searchProjectKnowledge(coerceSearchKnowledgeInput(input), config),
+    execute: (input, context) =>
+      searchProjectKnowledge(coerceSearchKnowledgeInput(input), config, context),
   });
 }
 

--- a/src/tool/types.ts
+++ b/src/tool/types.ts
@@ -73,8 +73,18 @@ export interface ToolExecutionContext {
   toolCallId?: string;
   /** Project identity used by integration token resolution */
   projectId?: string;
+  /** Project slug/reference for project-local platform API tools */
+  projectSlug?: string;
   /** Request-scoped Veryfront auth token for project-local platform API tools */
   authToken?: string;
+  /** Whether the tool should read production release-backed project content */
+  productionMode?: boolean;
+  /** Release ID for production release-backed project content */
+  releaseId?: string | null;
+  /** Branch name or ID for preview project content */
+  branch?: string | null;
+  /** Environment name associated with project content */
+  environmentName?: string | null;
   /** Abort signal for cooperative cancellation during long-running tool execution */
   abortSignal?: AbortSignal;
   /** Progress token for sending progress notifications (MCP 2025-11-25) */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.941";
+export const VERSION = "0.1.942";

--- a/src/workflow/api.test.ts
+++ b/src/workflow/api.test.ts
@@ -1,0 +1,45 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
+import { api } from "./api.ts";
+
+describe("workflow api", () => {
+  it("configures release-backed file context from the current tenant", async () => {
+    await runWithRequestContext(
+      {
+        projectSlug: "acme",
+        projectId: "project-1",
+        token: "tenant-token",
+        productionMode: true,
+        releaseId: "release-1",
+        environmentName: "production",
+      },
+      async () => {
+        assertEquals(api._getClient().getContext(), {
+          type: "release",
+          version: "release-1",
+        });
+      },
+    );
+  });
+
+  it("configures branch file context for preview tenants", async () => {
+    await runWithRequestContext(
+      {
+        projectSlug: "acme",
+        projectId: "project-1",
+        token: "tenant-token",
+        productionMode: false,
+        branch: "feature/demo",
+        environmentName: "preview",
+      },
+      async () => {
+        assertEquals(api._getClient().getContext(), {
+          type: "branch",
+          name: "feature/demo",
+        });
+      },
+    );
+  });
+});

--- a/src/workflow/api.ts
+++ b/src/workflow/api.ts
@@ -95,6 +95,14 @@ function getClient(): VeryfrontApiClient {
   client.setRequestToken(tenant.token);
   client.setProjectSlug(tenant.projectSlug);
 
+  if (tenant.productionMode && tenant.releaseId) {
+    client.setContext({ type: "release", version: tenant.releaseId });
+  } else if (tenant.productionMode && tenant.environmentName) {
+    client.setContext({ type: "environment", name: tenant.environmentName });
+  } else {
+    client.setContext({ type: "branch", name: tenant.branch ?? "main" });
+  }
+
   return client;
 }
 

--- a/src/workflow/api/workflow-client.test.ts
+++ b/src/workflow/api/workflow-client.test.ts
@@ -5,7 +5,7 @@ import { VeryfrontError } from "#veryfront/errors";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { runWithCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
-import type { Tool } from "#veryfront/tool";
+import type { Tool, ToolExecutionContext } from "#veryfront/tool";
 import { toolRegistry } from "#veryfront/tool";
 import { createWorkflowClient, WorkflowClient } from "./workflow-client.ts";
 import { MemoryBackend } from "../backends/memory.ts";
@@ -184,6 +184,65 @@ describe("WorkflowClient", () => {
       assertEquals((run.output as Record<string, unknown>)["_tenant"], undefined);
       assertEquals((run.context as Record<string, unknown>)["_tenant"], undefined);
       assertEquals(run.output, { "tenant-step": { result: "ok" } });
+    });
+
+    it("passes captured tenant metadata to workflow tool execution context", async () => {
+      let capturedContext: ToolExecutionContext | undefined;
+      const contextTool: Tool = {
+        id: "context-tool",
+        type: "function",
+        description: "Capture workflow tool context",
+        inputSchema: defineSchema((v) => v.object({}).passthrough())(),
+        execute: (_input, context) => {
+          capturedContext = context;
+          return {
+            projectSlug: context?.projectSlug,
+            projectId: context?.projectId,
+            authToken: context?.authToken,
+            productionMode: context?.productionMode,
+            releaseId: context?.releaseId,
+            branch: context?.branch,
+            environmentName: context?.environmentName,
+          };
+        },
+      };
+      const tenantWorkflow = workflow({
+        id: "tenant-tool-context-workflow",
+        steps: [
+          step("tenant-step", {
+            tool: contextTool,
+          }),
+        ],
+      });
+
+      client.register(tenantWorkflow);
+
+      const handle = await runWithRequestContext(
+        {
+          projectSlug: "tests-1d0745b0",
+          projectId: "project-1",
+          token: "internal-runtime-token",
+          productionMode: true,
+          releaseId: "release-1",
+          environmentName: "production",
+        },
+        () => client.start("tenant-tool-context-workflow", { topic: "test" }),
+      );
+
+      const output = await handle.result();
+
+      assertEquals(capturedContext?.agentId, "workflow");
+      assertEquals(output, {
+        "tenant-step": {
+          projectSlug: "tests-1d0745b0",
+          projectId: "project-1",
+          authToken: "internal-runtime-token",
+          productionMode: true,
+          releaseId: "release-1",
+          branch: null,
+          environmentName: "production",
+        },
+      });
     });
 
     it("resolves project-scoped tools from stored tenant context when resuming a run", async () => {

--- a/src/workflow/executor/step-executor.ts
+++ b/src/workflow/executor/step-executor.ts
@@ -257,7 +257,7 @@ export class StepExecutor {
     context: WorkflowContext,
   ): Promise<unknown> {
     if (config.agent) return this.executeAgent(config.agent, input, context);
-    if (config.tool) return this.executeTool(config.tool, input);
+    if (config.tool) return this.executeTool(config.tool, input, context);
     throw INVALID_ARGUMENT.create({ detail: "Step must have either 'agent' or 'tool' specified" });
   }
 
@@ -279,12 +279,24 @@ export class StepExecutor {
     };
   }
 
-  private async executeTool(tool: string | Tool, input: unknown): Promise<unknown> {
+  private async executeTool(
+    tool: string | Tool,
+    input: unknown,
+    context: WorkflowContext,
+  ): Promise<unknown> {
     const resolvedTool = typeof tool === "string" ? this.getTool(tool) : tool;
+    const tenant = context._tenant ?? getWorkflowTenant();
 
     return resolvedTool.execute(input as Record<string, unknown>, {
       agentId: "workflow",
       blobStorage: this.config.blobStorage,
+      projectId: tenant?.projectId,
+      projectSlug: tenant?.projectSlug,
+      authToken: tenant?.token,
+      productionMode: tenant?.productionMode,
+      releaseId: tenant?.releaseId,
+      branch: tenant?.branch,
+      environmentName: tenant?.environmentName,
     });
   }
 


### PR DESCRIPTION
## Summary
- pass stored workflow tenant metadata into direct workflow tool execution context
- make the standard search_knowledge tool read OKF files through the release/branch-aware Veryfront API client when running hosted
- align workflow api.files with release/branch/environment file context
- bump framework version to 0.1.942 for release

## Verification
- deno test --no-check --allow-all src/knowledge/index.test.ts src/workflow/api.test.ts src/workflow/api/workflow-client.test.ts src/utils/version.test.ts
- deno task verify:quick
- pre-push full unit suite: 2208 passed, 0 failed