### PR TITLE
Fix hosted knowledge lookup for project runs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.943",
+  "version": "0.1.944",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/knowledge/index.test.ts
+++ b/src/knowledge/index.test.ts
@@ -250,7 +250,9 @@ describe("projectKnowledge", () => {
       const parsed = new URL(url);
       if (
         parsed.pathname === "/projects/acme/releases/release-1/files" &&
-        parsed.searchParams.get("include_server_functions") === "true"
+        parsed.searchParams.get("include_server_functions") === "true" &&
+        parsed.searchParams.get("path") === "knowledge/" &&
+        !parsed.searchParams.has("pattern")
       ) {
         return new Response(
           JSON.stringify({
@@ -322,6 +324,7 @@ describe("projectKnowledge", () => {
     );
     assertEquals(requestedUrls.length, 1);
     assertStringIncludes(requestedUrls[0] ?? "", "/projects/acme/releases/release-1/files");
+    assertStringIncludes(requestedUrls[0] ?? "", "path=knowledge%2F");
   });
 
   it("indexes project knowledge when requested explicitly", async () => {

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -638,8 +638,9 @@ async function getHostedProjectKnowledgeManifest(
 
   const contentDir = config.contentDir ?? DEFAULT_CONTENT_DIR;
   const client = createHostedKnowledgeClient(hostedContext);
+  const contentPath = `${stripTrailingSlash(trimLeadingSlash(contentDir))}/`;
   const files = await client.listAllFiles({
-    pattern: stripTrailingSlash(trimLeadingSlash(contentDir)),
+    path: contentPath,
     sortBy: "path",
     sortOrder: "asc",
   });

--- a/src/platform/adapters/veryfront-api-client/operations.test.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.test.ts
@@ -155,6 +155,22 @@ describe("VeryfrontAPIOperations", () => {
       assertStringIncludes(requestedUrl, "include_server_functions=true");
     });
 
+    it("passes path filters through branch file list requests", async () => {
+      let requestedUrl = "";
+      stubJsonFetch((url) => {
+        requestedUrl = url;
+        return {
+          data: [],
+          page_info: { self: null, first: null, next: null, prev: null },
+        };
+      });
+
+      await createOps().listBranchFiles("project-slug", "main", { path: "knowledge/" });
+
+      const parsed = new URL(requestedUrl);
+      assertEquals(parsed.searchParams.get("path"), "knowledge/");
+    });
+
     it("requests branch file content with server functions for preview handlers", async () => {
       let requestedUrl = "";
       stubJsonFetch((url) => {

--- a/src/platform/adapters/veryfront-api-client/operations.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.ts
@@ -37,6 +37,7 @@ export type TokenProvider = () => string;
 export interface ListFilesOptions {
   cursor?: string;
   limit?: number;
+  path?: string;
   pattern?: string;
   sortBy?: "path" | "updated_at";
   sortOrder?: "asc" | "desc";
@@ -98,8 +99,14 @@ export interface ProjectStyleArtifactResolution {
 }
 
 function buildListParams(options: ListFilesOptions): URLSearchParams {
-  const { cursor, limit = DEFAULT_PAGE_LIMIT, pattern, sortBy = "updated_at", sortOrder = "desc" } =
-    options;
+  const {
+    cursor,
+    limit = DEFAULT_PAGE_LIMIT,
+    path,
+    pattern,
+    sortBy = "updated_at",
+    sortOrder = "desc",
+  } = options;
 
   const params = new URLSearchParams({
     limit: String(limit),
@@ -108,6 +115,7 @@ function buildListParams(options: ListFilesOptions): URLSearchParams {
   });
 
   if (cursor) params.set("cursor", cursor);
+  if (path) params.set("path", path);
   if (pattern) params.set("pattern", pattern);
 
   return params;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.943";
+export const VERSION = "0.1.944";


### PR DESCRIPTION
## Summary
- pass project file path filters through the Veryfront API client
- use `path=knowledge/` for hosted project knowledge discovery instead of the empty `pattern=knowledge` query
- bump the framework version to `0.1.944` for release

## Root cause
Hosted workflow runs called the project files API with `pattern=knowledge`, but production returns zero files for that filter. The same project returns the OKF markdown files with `path=knowledge/`, which is the filter the CLI file listing already uses.

## Verification
- `deno test --allow-read --allow-write --allow-env --allow-net src/knowledge/index.test.ts`
- `deno test --allow-read --allow-write --allow-env --allow-net src/platform/adapters/veryfront-api-client/operations.test.ts`
- `deno task verify:quick`
- `deno task test`
- pre-push checks: `2208 passed`, `0 failed`

## Follow-up
After merge and package publish, install `veryfront@latest`, deploy the updated server runtime if needed, then rerun the hosted customer operations workflow against Veryfront Cloud.