### PR TITLE
[codex] Keep follow-up tools after agent writes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.944",
+  "version": "0.1.945",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -157,7 +157,7 @@ import { resolveAgentModelTransport, type ResolvedModelTransport } from "./model
 
 const logger = serverLogger.component("agent");
 
-function shouldDisableToolsForFinalResponseAfterToolSuccess(toolName: string): boolean {
+function shouldHideProjectToolAfterAgentWriteSuccess(toolName: string): boolean {
   return toolName === "create_agent" || toolName === "update_agent";
 }
 
@@ -892,7 +892,7 @@ export class AgentRuntime {
     const remoteToolSources = getRuntimeRemoteToolSources(this.config);
     let currentSystemPrompt = systemPrompt;
     let currentRuntimeContext = runtimeContext;
-    let toolsDisabledForFinalResponse = false;
+    let agentWriteFinalResponseToolGuardEnabled = false;
 
     for (let step = 0; step < maxSteps; step++) {
       throwIfAborted(abortSignal);
@@ -922,8 +922,12 @@ export class AgentRuntime {
       currentSystemPrompt = preparedStep.systemPrompt;
       currentRuntimeContext = preparedStep.runtimeContext;
       const toolContext = preparedStep.toolContext;
-      const tools = toolsDisabledForFinalResponse ? [] : preparedStep.tools;
-      const stepProviderTools = toolsDisabledForFinalResponse ? [] : providerTools;
+      const tools = agentWriteFinalResponseToolGuardEnabled
+        ? preparedStep.tools.filter((tool) =>
+          !shouldHideProjectToolAfterAgentWriteSuccess(tool.name)
+        )
+        : preparedStep.tools;
+      const stepProviderTools = agentWriteFinalResponseToolGuardEnabled ? [] : providerTools;
 
       const runtimeTools = convertToolsToRuntimeTools(tools, {
         model: effectiveModel,
@@ -1116,8 +1120,8 @@ export class AgentRuntime {
           toolCalls.push(toolCall);
 
           if (matchingResult.error === undefined) {
-            if (shouldDisableToolsForFinalResponseAfterToolSuccess(tc.name)) {
-              toolsDisabledForFinalResponse = true;
+            if (shouldHideProjectToolAfterAgentWriteSuccess(tc.name)) {
+              agentWriteFinalResponseToolGuardEnabled = true;
             }
             if (tc.name === LOAD_SKILL_TOOL_ID) {
               activeSkillId = extractSkillId(matchingResult.output);
@@ -1148,8 +1152,8 @@ export class AgentRuntime {
           toolCall.error = persistedError;
           toolCalls.push(toolCall);
           if (persistedError === undefined) {
-            if (shouldDisableToolsForFinalResponseAfterToolSuccess(tc.name)) {
-              toolsDisabledForFinalResponse = true;
+            if (shouldHideProjectToolAfterAgentWriteSuccess(tc.name)) {
+              agentWriteFinalResponseToolGuardEnabled = true;
             }
             if (tc.name === LOAD_SKILL_TOOL_ID) {
               activeSkillId = extractSkillId(persistedResult.result);
@@ -1282,8 +1286,8 @@ export class AgentRuntime {
             hasSubmittedFormInputInLoop = true;
             currentRuntimeContext = markSubmittedFormInputRuntimeContext(currentRuntimeContext);
           }
-          if (shouldDisableToolsForFinalResponseAfterToolSuccess(tc.name)) {
-            toolsDisabledForFinalResponse = true;
+          if (shouldHideProjectToolAfterAgentWriteSuccess(tc.name)) {
+            agentWriteFinalResponseToolGuardEnabled = true;
           }
 
           const dynamic = isDynamicTool(tc.name);

--- a/src/agent/runtime/refresh.test.ts
+++ b/src/agent/runtime/refresh.test.ts
@@ -294,6 +294,163 @@ describe("agent runtime refresh hooks", () => {
     assertEquals(toolNamesByStep[1], []);
   });
 
+  for (const agentWriteToolName of ["create_agent", "update_agent"] as const) {
+    it(`keeps follow-up project tools available after ${agentWriteToolName} for scheduled-agent flows`, async () => {
+      const toolNamesByStep: string[][] = [];
+      const executedTools: string[] = [];
+      let callCount = 0;
+      const model: ModelRuntime = {
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-6",
+        async doGenerate() {
+          return {
+            content: [{ type: "text", text: "unused" }],
+            finishReason: "stop",
+            usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+          };
+        },
+        async doStream(options) {
+          const rawTools = (options as { tools?: unknown }).tools;
+          const toolNames = Array.isArray(rawTools)
+            ? rawTools.map((entry) =>
+              (entry as { name?: string; id?: string }).name ??
+                (entry as { name?: string; id?: string }).id ?? ""
+            )
+            : Object.keys((rawTools as Record<string, unknown> | undefined) ?? {});
+          toolNamesByStep.push(toolNames);
+          callCount++;
+
+          if (callCount === 1) {
+            return {
+              stream: createRuntimeStream([
+                {
+                  type: "tool-call",
+                  toolCallId: "agent-write-1",
+                  toolName: agentWriteToolName,
+                  input: '{"id":"hourly-triage-agent"}',
+                },
+                {
+                  type: "finish",
+                  finishReason: "tool-calls",
+                  usage: { inputTokens: 1, outputTokens: 1 },
+                },
+              ]),
+            };
+          }
+
+          if (callCount === 2 && toolNames.includes("create_schedule")) {
+            return {
+              stream: createRuntimeStream([
+                {
+                  type: "tool-call",
+                  toolCallId: "create-schedule-1",
+                  toolName: "create_schedule",
+                  input: JSON.stringify({
+                    target: {
+                      kind: "agent",
+                      id: "hourly-triage-agent",
+                      conversation_mode: "create_new",
+                    },
+                    schedule: "0 * * * *",
+                    timezone: "Europe/Berlin",
+                    config: {
+                      prompt: "Check project status and report whether any tasks need attention.",
+                    },
+                  }),
+                },
+                {
+                  type: "finish",
+                  finishReason: "tool-calls",
+                  usage: { inputTokens: 1, outputTokens: 1 },
+                },
+              ]),
+            };
+          }
+
+          return {
+            stream: createRuntimeStream([
+              { type: "text-delta", text: "Scheduled agent created." },
+              {
+                type: "finish",
+                finishReason: "stop",
+                usage: { inputTokens: 1, outputTokens: 1 },
+              },
+            ]),
+          };
+        },
+      };
+
+      const agentWriteTool = tool({
+        id: agentWriteToolName,
+        description: agentWriteToolName === "create_agent"
+          ? "Create a Studio project agent"
+          : "Update a Studio project agent",
+        inputSchema: defineSchema((v) => v.object({ id: v.string() }))(),
+        execute: async ({ id }) => {
+          executedTools.push(agentWriteToolName);
+          return {
+            id,
+            name: "Hourly Triage Agent",
+            source_path: `agents/${id}.ts`,
+          };
+        },
+      });
+
+      const createSchedule = tool({
+        id: "create_schedule",
+        description: "Create a Studio schedule",
+        inputSchema: defineSchema((v) =>
+          v.object({
+            target: v.object({
+              kind: v.literal("agent"),
+              id: v.string(),
+              conversation_mode: v.string(),
+            }),
+            schedule: v.string(),
+            timezone: v.string(),
+            config: v.object({ prompt: v.string() }),
+          })
+        )(),
+        execute: async ({ target, schedule, timezone }) => {
+          executedTools.push("create_schedule");
+          return {
+            id: "schedule-hourly-triage",
+            status: "active",
+            target,
+            schedule,
+            timezone,
+          };
+        },
+      });
+
+      const assistant = agent({
+        model: "anthropic/claude-sonnet-4-6",
+        system:
+          `Create scheduled agents. After ${agentWriteToolName} succeeds, call create_schedule before final output.`,
+        tools: {
+          [agentWriteToolName]: agentWriteTool,
+          create_schedule: createSchedule,
+        },
+        providerTools: ["web_search", "web_fetch"],
+        maxSteps: 4,
+        resolveModelTransport: async () => ({ model }),
+      });
+
+      const response = (await assistant.stream({
+        input: "Create or update an agent and schedule it hourly.",
+      })).toDataStreamResponse();
+
+      await response.text();
+      assertEquals(toolNamesByStep[0]?.includes(agentWriteToolName), true);
+      assertEquals(toolNamesByStep[0]?.includes("create_schedule"), true);
+      assertEquals(toolNamesByStep[0]?.includes("web_search"), true);
+      assertEquals(toolNamesByStep[0]?.includes("web_fetch"), true);
+      assertEquals(toolNamesByStep[1], ["create_schedule"]);
+      assertEquals(toolNamesByStep.length, 3);
+      assertEquals(executedTools, [agentWriteToolName, "create_schedule"]);
+    });
+  }
+
   it("keeps tools available after a failed create_agent attempt", async () => {
     const toolNamesByStep: string[][] = [];
     let callCount = 0;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.944";
+export const VERSION = "0.1.945";


### PR DESCRIPTION
## Summary
- Narrow the streaming runtime guard after successful `create_agent` / `update_agent` so it hides only repeat agent-write tools and provider-native tools.
- Keep follow-up project tools such as `create_schedule` available for the next step, fixing scheduled-agent flows that need `create_agent -> create_schedule` in one run.
- Bump Veryfront code version from `0.1.944` to `0.1.945`.

## Root Cause
The streaming runtime set a final-response guard after successful agent writes and then sent the next model call with no tools at all. That made `create_schedule` unavailable after `create_agent`, so the model could only finish with text.

## Regression Coverage
The new refresh regression covers both `create_agent` and `update_agent` followed by `create_schedule`. It asserts provider-native tools are removed while the local follow-up schedule tool remains available and executes.

## Audit
A targeted scan found no other post-success broad tool-call wipe. Remaining tool filters are explicit allowlist, form-input, sandbox, or provider-compatibility filters.

Refs veryfront/veryfront-studio#5343

## Verification
- `deno test --config deno.json --allow-all src/agent/runtime/refresh.test.ts`
- `deno test --config deno.json --allow-all src/agent/runtime/agent-runtime-step.test.ts src/agent/runtime/skill-policy.test.ts src/agent/runtime/tool-result-continuation.test.ts src/agent/runtime/refresh.test.ts`
- `deno fmt --check src/agent/runtime/index.ts src/agent/runtime/refresh.test.ts deno.json`
- `deno lint --config deno.json src/agent/runtime/index.ts src/agent/runtime/refresh.test.ts`
- `deno check --config deno.json src/agent/runtime/index.ts src/agent/runtime/refresh.test.ts`
- `deno test --config deno.json --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts`
- `env -u <local observability env> deno task test:unit` -> `2208 passed`, `0 failed`
- pre-push hook -> format, lint, typecheck, `deno task test:unit` -> `2208 passed`, `0 failed`