### PR TITLE
Fix eval auth and knowledge grounding evidence

### DIFF
--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -1,7 +1,9 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import type { AgentResponse } from "veryfront/agent";
 import { compareEvalReports, type DiscoveredEval, type EvalReport } from "veryfront/eval";
+import { saveToken } from "../../auth/token-store.ts";
 import {
   createDefaultEvalReportDir,
   createEvalArtifactPaths,
@@ -10,12 +12,38 @@ import {
   createResultsJsonl,
   createSummaryArtifact,
   findEvalForCliId,
+  hydrateEvalRuntimeAuth,
   normalizeEvalCliId,
   normalizeEvalInputForAgent,
+  normalizeToolCalls,
   summarizeReportForCli,
   writeEvalArtifacts,
 } from "./command.ts";
 import { parseEvalArgs } from "./handler.ts";
+
+const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+const originalProjectSlug = Deno.env.get("VERYFRONT_PROJECT_SLUG");
+const originalXdgConfigHome = Deno.env.get("XDG_CONFIG_HOME");
+
+function restoreEnv(): void {
+  if (originalApiToken === undefined) {
+    Deno.env.delete("VERYFRONT_API_TOKEN");
+  } else {
+    Deno.env.set("VERYFRONT_API_TOKEN", originalApiToken);
+  }
+
+  if (originalProjectSlug === undefined) {
+    Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+  } else {
+    Deno.env.set("VERYFRONT_PROJECT_SLUG", originalProjectSlug);
+  }
+
+  if (originalXdgConfigHome === undefined) {
+    Deno.env.delete("XDG_CONFIG_HOME");
+  } else {
+    Deno.env.set("XDG_CONFIG_HOME", originalXdgConfigHome);
+  }
+}
 
 function createReport(): EvalReport {
   return {
@@ -98,6 +126,10 @@ function createReport(): EvalReport {
 }
 
 describe("eval CLI command helpers", () => {
+  afterEach(() => {
+    restoreEnv();
+  });
+
   it("parses eval command arguments", () => {
     const parsed = parseEvalArgs({
       _: ["eval", "deep-research"],
@@ -150,6 +182,83 @@ describe("eval CLI command helpers", () => {
       "What changed?",
     );
     assertEquals(normalizeEvalInputForAgent({ custom: true }), '{"custom":true}');
+  });
+
+  it("preserves agent tool input and output in eval traces", () => {
+    const response = {
+      text: "done",
+      messages: [],
+      status: "completed",
+      toolCalls: [
+        {
+          id: "call-1",
+          name: "search_knowledge",
+          args: { query: "sso login" },
+          status: "completed",
+          result: {
+            data: [
+              {
+                path: "knowledge/login-troubleshooting.md",
+                frontmatter: [{ key: "title", value: "Login troubleshooting" }],
+              },
+            ],
+          },
+        },
+        {
+          id: "call-2",
+          name: "execute_skill_script",
+          args: { script: "missing.sh" },
+          status: "error",
+          error: "File not found",
+        },
+      ],
+    } satisfies AgentResponse;
+
+    assertEquals(normalizeToolCalls(response), [
+      {
+        id: "call-1",
+        name: "search_knowledge",
+        status: "ok",
+        input: { query: "sso login" },
+        output: {
+          data: [
+            {
+              path: "knowledge/login-troubleshooting.md",
+              frontmatter: [{ key: "title", value: "Login troubleshooting" }],
+            },
+          ],
+        },
+      },
+      {
+        id: "call-2",
+        name: "execute_skill_script",
+        status: "error",
+        input: { script: "missing.sh" },
+        error: "File not found",
+      },
+    ]);
+  });
+
+  it("hydrates runtime auth from the stored login token and eval project config", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-eval-command-" });
+    const configHome = await Deno.makeTempDir({ prefix: "vf-eval-auth-" });
+
+    try {
+      Deno.env.delete("VERYFRONT_API_TOKEN");
+      Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      Deno.env.set("XDG_CONFIG_HOME", configHome);
+      await saveToken("stored-token");
+
+      await hydrateEvalRuntimeAuth(projectDir, {
+        projectSlug: "configured-eval-project",
+      });
+
+      assertEquals(Deno.env.get("VERYFRONT_API_TOKEN"), "stored-token");
+      assertEquals(Deno.env.get("VERYFRONT_PROJECT_SLUG"), "configured-eval-project");
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(configHome, { recursive: true });
+    }
   });
 
   it("summarizes reports for JSON and human CLI output", () => {

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -25,7 +25,6 @@ import {
   isJsonMode,
   outputJson,
 } from "../../shared/json-output.ts";
-import { readConfigFile } from "../../shared/config.ts";
 import { withProjectSourceContext } from "../../shared/project-source-context.ts";
 import type { EvalArgs } from "./handler.ts";
 
@@ -438,11 +437,6 @@ async function outputAgentNotFound(agentId: string): Promise<void> {
 
 export async function evalCommand(options: EvalOptions): Promise<void> {
   const projectDir = Deno.cwd();
-  const configFile = await readConfigFile(projectDir);
-
-  if (configFile?.projectSlug) {
-    await hydrateEvalRuntimeAuth(projectDir, configFile);
-  }
 
   await withProjectSourceContext(projectDir, async ({ adapter, config }) => {
     await hydrateEvalRuntimeAuth(projectDir, config);

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -4,6 +4,7 @@
 
 import { dirname, join, relative } from "@std/path";
 import type { Agent, AgentResponse } from "veryfront/agent";
+import type { VeryfrontConfig } from "veryfront/config";
 import type {
   DiscoveredEval,
   EvalAgentAdapterContext,
@@ -16,6 +17,7 @@ import type {
 } from "veryfront/eval";
 import { createProjectDiscoveryConfig, discoverAll } from "veryfront/discovery";
 import { compareEvalReports, discoverEvals, runEval } from "veryfront/eval";
+import { applyRuntimeAuthContext } from "#cli/shared/runtime-auth";
 import { cliLogger, exitProcess } from "#cli/utils";
 import {
   createErrorEnvelope,
@@ -23,6 +25,7 @@ import {
   isJsonMode,
   outputJson,
 } from "../../shared/json-output.ts";
+import { readConfigFile } from "../../shared/config.ts";
 import { withProjectSourceContext } from "../../shared/project-source-context.ts";
 import type { EvalArgs } from "./handler.ts";
 
@@ -263,6 +266,26 @@ function resolveAgentTargetId(target: string): string {
   return target.startsWith("agent:") ? target.slice("agent:".length) : target;
 }
 
+type EvalRuntimeAuthConfig = Pick<VeryfrontConfig, "projectSlug" | "fs"> & {
+  projectSlug?: string;
+};
+
+function resolveEvalRuntimeProjectSlug(
+  config: EvalRuntimeAuthConfig | null | undefined,
+): string | undefined {
+  return config?.projectSlug ?? config?.fs?.veryfront?.projectSlug;
+}
+
+export async function hydrateEvalRuntimeAuth(
+  projectDir: string,
+  config: EvalRuntimeAuthConfig | null | undefined,
+) {
+  return await applyRuntimeAuthContext({
+    projectDir,
+    projectSlug: resolveEvalRuntimeProjectSlug(config),
+  });
+}
+
 function normalizeUsage(response: AgentResponse) {
   return response.usage
     ? {
@@ -273,11 +296,17 @@ function normalizeUsage(response: AgentResponse) {
     : {};
 }
 
-function normalizeToolCalls(response: AgentResponse): EvalToolCall[] {
+export function normalizeToolCalls(response: AgentResponse): EvalToolCall[] {
   return response.toolCalls.map((toolCall) => ({
+    id: toolCall.id,
     name: toolCall.name,
     status: toolCall.status === "error" ? "error" : "ok",
+    input: toolCall.args,
+    ...(Object.hasOwn(toolCall, "result") ? { output: toolCall.result } : {}),
     ...(toolCall.error ? { error: toolCall.error } : {}),
+    ...(toolCall.executionTime !== undefined
+      ? { metadata: { executionTime: toolCall.executionTime } }
+      : {}),
   }));
 }
 
@@ -409,8 +438,15 @@ async function outputAgentNotFound(agentId: string): Promise<void> {
 
 export async function evalCommand(options: EvalOptions): Promise<void> {
   const projectDir = Deno.cwd();
+  const configFile = await readConfigFile(projectDir);
+
+  if (configFile?.projectSlug) {
+    await hydrateEvalRuntimeAuth(projectDir, configFile);
+  }
 
   await withProjectSourceContext(projectDir, async ({ adapter, config }) => {
+    await hydrateEvalRuntimeAuth(projectDir, config);
+
     const evalDiscovery = await discoverEvals({ projectDir, adapter, config });
 
     if (options.debug) {

--- a/cli/commands/workflow/command.ts
+++ b/cli/commands/workflow/command.ts
@@ -1,7 +1,6 @@
 import { cliLogger } from "#cli/utils";
 import { exitProcess } from "#cli/utils";
 import { withProjectSourceContext } from "#cli/shared/project-source-context";
-import { applyRuntimeAuthContext } from "#cli/shared/runtime-auth";
 import { agentRegistry } from "../../../src/agent/composition/index.ts";
 import { discoverProjectAgentRuntime } from "../../../src/agent/project/agent-runtime.ts";
 import type { DiscoveryResult } from "../../../src/discovery/types.ts";
@@ -160,12 +159,6 @@ export async function runWorkflowCommand(
   }
 
   const projectDir = options.projectDir ?? Deno.cwd();
-  const { readConfigFile } = await import("#cli/shared/config");
-  const configFile = await readConfigFile(projectDir);
-  await applyRuntimeAuthContext({
-    projectDir,
-    projectSlug: configFile?.projectSlug,
-  });
 
   const discoverRuntime: (
     input: Parameters<typeof discoverProjectAgentRuntime>[0],

--- a/cli/shared/project-source-context.test.ts
+++ b/cli/shared/project-source-context.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { getProxyProjectSourceContext } from "./project-source-context.ts";
+import type { VeryfrontConfig } from "veryfront/config";
+import { saveToken } from "../auth/token-store.ts";
+import {
+  applyProjectSourceRuntimeAuth,
+  getProxyProjectSourceContext,
+  withProjectSourceContext,
+} from "./project-source-context.ts";
 
 const ENV_KEYS = [
   "VERYFRONT_PROJECT_SLUG",
@@ -8,13 +14,25 @@ const ENV_KEYS = [
   "VERYFRONT_PROJECT_ID",
   "VERYFRONT_BRANCH_REF",
   "TENANT_BRANCH_ID",
-];
+  "XDG_CONFIG_HOME",
+] as const;
+
+const originalEnv = new Map(ENV_KEYS.map((key) => [key, Deno.env.get(key)]));
+
+function restoreEnv(): void {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      Deno.env.delete(key);
+    } else {
+      Deno.env.set(key, value);
+    }
+  }
+}
 
 describe("getProxyProjectSourceContext", () => {
   afterEach(() => {
-    for (const key of ENV_KEYS) {
-      Deno.env.delete(key);
-    }
+    restoreEnv();
   });
 
   it("uses VERYFRONT_BRANCH_REF when it is set", () => {
@@ -43,5 +61,59 @@ describe("getProxyProjectSourceContext", () => {
       projectId: undefined,
       branchRef: "branch-id",
     });
+  });
+});
+
+describe("project source runtime auth", () => {
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it("hydrates runtime auth from fs.veryfront.projectSlug", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-project-source-" });
+    const configHome = await Deno.makeTempDir({ prefix: "vf-project-source-auth-" });
+
+    try {
+      Deno.env.delete("VERYFRONT_API_TOKEN");
+      Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      Deno.env.set("XDG_CONFIG_HOME", configHome);
+      await saveToken("stored-token");
+
+      const config = {
+        fs: { veryfront: { projectSlug: "configured-fs-project" } },
+      } satisfies VeryfrontConfig;
+
+      await applyProjectSourceRuntimeAuth(projectDir, config);
+
+      assertEquals(Deno.env.get("VERYFRONT_API_TOKEN"), "stored-token");
+      assertEquals(Deno.env.get("VERYFRONT_PROJECT_SLUG"), "configured-fs-project");
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(configHome, { recursive: true });
+    }
+  });
+
+  it("hydrates runtime auth before invoking project source callbacks", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-project-source-" });
+    const configHome = await Deno.makeTempDir({ prefix: "vf-project-source-auth-" });
+
+    try {
+      Deno.env.delete("VERYFRONT_API_TOKEN");
+      Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      Deno.env.set("XDG_CONFIG_HOME", configHome);
+      await saveToken("stored-token");
+      await Deno.writeTextFile(
+        `${projectDir}/veryfront.config.ts`,
+        'export default { projectSlug: "configured-source-project" };\n',
+      );
+
+      await withProjectSourceContext(projectDir, async () => {
+        assertEquals(Deno.env.get("VERYFRONT_API_TOKEN"), "stored-token");
+        assertEquals(Deno.env.get("VERYFRONT_PROJECT_SLUG"), "configured-source-project");
+      });
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(configHome, { recursive: true });
+    }
   });
 });

--- a/cli/shared/project-source-context.ts
+++ b/cli/shared/project-source-context.ts
@@ -6,6 +6,7 @@ import {
   runtime,
   type RuntimeAdapter,
 } from "veryfront/platform";
+import { applyRuntimeAuthContext } from "./runtime-auth.ts";
 
 interface ProxyProjectSourceContext {
   projectSlug: string;
@@ -51,12 +52,23 @@ async function loadProjectConfig(
   return await getConfig(projectDir, adapter, cacheKey ? { cacheKey } : undefined);
 }
 
+export async function applyProjectSourceRuntimeAuth(
+  projectDir: string,
+  config: VeryfrontConfig,
+) {
+  return await applyRuntimeAuthContext({
+    projectDir,
+    projectSlug: config.projectSlug ?? config.fs?.veryfront?.projectSlug,
+  });
+}
+
 export async function withProjectSourceContext<T>(
   projectDir: string,
   run: (context: ProjectSourceExecutionContext) => Promise<T>,
 ): Promise<T> {
   const baseAdapter = await runtime.get();
   const initialConfig = await getConfig(projectDir, baseAdapter);
+  await applyProjectSourceRuntimeAuth(projectDir, initialConfig);
   const adapter = await enhanceAdapterWithFS(baseAdapter, initialConfig as any, projectDir);
   const proxyContext = getProxyProjectSourceContext();
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.945",
+  "version": "0.1.946",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/api-reference/veryfront/knowledge.md
+++ b/docs/api-reference/veryfront/knowledge.md
@@ -18,9 +18,10 @@ import {
 
 ## Examples
 
-### Search OKF knowledge metadata locally
+### Search OKF knowledge locally
 
-Use this for the same compact frontmatter lookup shape as Veryfront Cloud's `search_knowledge` tool.
+Use this for the same compact lookup shape as Veryfront Cloud's `search_knowledge` tool.
+Search responses return paths, matched fields, and frontmatter.
 
 ```ts
 import { projectKnowledge } from "veryfront/knowledge";
@@ -30,6 +31,14 @@ const knowledge = projectKnowledge();
 const result = await knowledge.lookup({
   query: "billing escalation",
   limit: 5,
+});
+```
+
+Use `lookup_target` when the agent needs a specific document body after search:
+
+```ts
+const article = await knowledge.lookup({
+  lookup_target: { path: "knowledge/billing-escalation.md" },
 });
 ```
 
@@ -59,13 +68,13 @@ const result = await knowledge.retrieve("SSO login failure");
 
 ### Functions
 
-| Name                        | Description                                                              | Source                                                                                      |
-| --------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
-| `createSearchKnowledgeTool` | Create a local `search_knowledge` tool backed by OKF frontmatter files.  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts)      |
-| `formatKnowledgeContext`    | Format search results into a deterministic prompt context block.         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L102) |
-| `normalizeKnowledgeQuery`   | Normalize a knowledge query before retrieval.                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L94)  |
-| `projectKnowledge`          | Create a project knowledge helper backed by the configured RAG store.    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L109) |
-| `searchProjectKnowledge`    | Search local OKF frontmatter with the `search_knowledge` response shape. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts)      |
+| Name                        | Description                                                           | Source                                                                                      |
+| --------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `createSearchKnowledgeTool` | Create a local `search_knowledge` tool backed by OKF files.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts)      |
+| `formatKnowledgeContext`    | Format search results into a deterministic prompt context block.      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L102) |
+| `normalizeKnowledgeQuery`   | Normalize a knowledge query before retrieval.                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L94)  |
+| `projectKnowledge`          | Create a project knowledge helper backed by the configured RAG store. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts#L109) |
+| `searchProjectKnowledge`    | Search local OKF files with the `search_knowledge` response shape.    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/knowledge/index.ts)      |
 
 ### Types
 

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -232,11 +232,26 @@ Use `answer.groundedness` when the judge should compare the final answer against
 retrieved knowledge evidence:
 
 ```ts
+function simpleGroundingJudge(input: {
+  output: Record<string, unknown>;
+  evidence: string[];
+}) {
+  const answer = String(input.output.text ?? "").toLowerCase();
+  const evidence = input.evidence.join("\n").toLowerCase();
+  const pass = answer.length > 0 &&
+    answer.split(/\s+/).some((word) => word.length > 4 && evidence.includes(word));
+
+  return {
+    score: pass ? 1 : 0,
+    pass,
+    explanation: pass
+      ? "The answer overlaps with retrieved evidence."
+      : "The answer is not supported by retrieved evidence.",
+  };
+}
+
 metrics.answer.groundedness({
-  judge: async ({ output, evidence, sources }) => {
-    const score = await judgeGrounding({ output, evidence, sources });
-    return { score, pass: score >= 0.8 };
-  },
+  judge: async ({ output, evidence }) => simpleGroundingJudge({ output, evidence }),
 }).gate({ min: 0.8 });
 ```
 

--- a/src/eval/metrics.test.ts
+++ b/src/eval/metrics.test.ts
@@ -395,4 +395,65 @@ describe("eval/metrics", () => {
       },
     );
   });
+
+  it("uses compact search_knowledge results as groundedness evidence", async () => {
+    const groundedness = metrics.answer.groundedness({
+      judge: async ({ evidence, output, sources }) => {
+        const joinedEvidence = evidence.join("\n");
+        const pass = joinedEvidence.includes("identity provider metadata") &&
+          joinedEvidence.includes("callback URL") &&
+          String(output.text).includes("SSO metadata") &&
+          sources.includes("knowledge/login-troubleshooting.md");
+
+        return {
+          score: pass ? 0.95 : 0.1,
+          pass,
+          explanation: "Compact knowledge result contains enough support for the answer.",
+        };
+      },
+    }).gate({ min: 0.8 });
+
+    assertEquals(
+      await groundedness.evaluate(createRecord({
+        output: { text: "Ask whether the SSO metadata or callback URL changed recently." },
+        trace: {
+          events: [],
+          toolCalls: [
+            {
+              name: "search_knowledge",
+              status: "ok",
+              output: {
+                data: [
+                  {
+                    path: "knowledge/login-troubleshooting.md",
+                    matched_fields: [
+                      "identity provider metadata",
+                      "callback URL",
+                    ],
+                    frontmatter: {
+                      title: "Login troubleshooting",
+                      summary: "Check SSO metadata, callback URL, and group mapping changes.",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      })),
+      {
+        name: "answer.groundedness",
+        family: "answer",
+        severity: "gate",
+        score: 0.95,
+        pass: true,
+        explanation: "Compact knowledge result contains enough support for the answer.",
+        evidence: {
+          tool: "search_knowledge",
+          evidenceCount: 2,
+          sources: ["knowledge/login-troubleshooting.md"],
+        },
+      },
+    );
+  });
 });

--- a/src/eval/metrics.ts
+++ b/src/eval/metrics.ts
@@ -26,6 +26,7 @@ type KnowledgeEntry = {
   source: string;
   sourceCandidates: string[];
   contentCandidates: string[];
+  evidenceCandidates: string[];
 };
 
 type JudgeRubricInput = {
@@ -67,6 +68,7 @@ const KNOWLEDGE_CONTENT_KEYS = [
   "verification_quote",
   "verificationQuote",
 ];
+const KNOWLEDGE_MATCHED_FIELD_KEYS = ["matched_fields", "matchedFields"];
 const KNOWLEDGE_STOP_WORDS = new Set([
   "the",
   "and",
@@ -156,15 +158,59 @@ function collectStringField(record: Record<string, unknown>, key: string): strin
   return typeof value === "string" && value.trim() ? [value] : [];
 }
 
+function collectLeafStrings(value: unknown): string[] {
+  if (typeof value === "string") return value.trim() ? [value] : [];
+  if (typeof value === "number" || typeof value === "boolean") return [String(value)];
+  if (Array.isArray(value)) return value.flatMap(collectLeafStrings);
+  if (!isRecord(value)) return [];
+  return Object.values(value).flatMap(collectLeafStrings);
+}
+
 function collectFrontmatterValues(value: unknown): string[] {
-  if (!Array.isArray(value)) return [];
+  if (!Array.isArray(value)) return collectLeafStrings(value);
+
   const values: string[] = [];
   for (const entry of value) {
-    if (!isRecord(entry)) continue;
+    if (!isRecord(entry)) {
+      values.push(...collectLeafStrings(entry));
+      continue;
+    }
     const fieldValue = entry.value;
     if (typeof fieldValue === "string" && fieldValue.trim()) values.push(fieldValue);
   }
   return values;
+}
+
+function formatFrontmatterEvidence(value: unknown): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    const pairs = value.flatMap((entry) => {
+      if (!isRecord(entry)) return collectLeafStrings(entry);
+      const key = typeof entry.key === "string" && entry.key.trim() ? `${entry.key}: ` : "";
+      return collectLeafStrings(entry.value).map((fieldValue) => `${key}${fieldValue}`);
+    });
+    return pairs.length > 0 ? [`frontmatter: ${pairs.join("; ")}`] : [];
+  }
+
+  if (isRecord(value)) {
+    const pairs = Object.entries(value).flatMap(([key, fieldValue]) =>
+      collectLeafStrings(fieldValue).map((item) => `${key}: ${item}`)
+    );
+    return pairs.length > 0 ? [`frontmatter: ${pairs.join("; ")}`] : [];
+  }
+
+  const values = collectLeafStrings(value);
+  return values.length > 0 ? [`frontmatter: ${values.join("; ")}`] : [];
+}
+
+function collectCompactEvidence(item: Record<string, unknown>): string[] {
+  const matchedFields = KNOWLEDGE_MATCHED_FIELD_KEYS.flatMap((key) =>
+    collectLeafStrings(item[key])
+  );
+  return [
+    ...(matchedFields.length > 0 ? [`matched_fields: ${matchedFields.join("; ")}`] : []),
+    ...formatFrontmatterEvidence(item.frontmatter),
+  ];
 }
 
 function extractKnowledgeItems(output: unknown): unknown[] {
@@ -182,7 +228,12 @@ function extractKnowledgeItems(output: unknown): unknown[] {
 function createKnowledgeEntry(item: unknown): KnowledgeEntry | null {
   if (!isRecord(item)) {
     if (typeof item === "string" && item.trim()) {
-      return { source: item, sourceCandidates: [item], contentCandidates: [item] };
+      return {
+        source: item,
+        sourceCandidates: [item],
+        contentCandidates: [item],
+        evidenceCandidates: [item],
+      };
     }
     return null;
   }
@@ -195,11 +246,16 @@ function createKnowledgeEntry(item: unknown): KnowledgeEntry | null {
     KNOWLEDGE_CONTENT_KEYS.flatMap((key) => collectStringField(item, key)),
   );
   const source = sourceCandidates[0] ?? contentCandidates[0] ?? stableStringify(item);
+  const evidenceCandidates = uniqueStrings([
+    ...contentCandidates,
+    ...collectCompactEvidence(item),
+  ]);
 
   return {
     source,
     sourceCandidates: sourceCandidates.length === 0 ? [source] : sourceCandidates,
     contentCandidates,
+    evidenceCandidates: evidenceCandidates.length === 0 ? [source] : evidenceCandidates,
   };
 }
 
@@ -476,7 +532,7 @@ export const metrics = {
       return createMetric("answer.groundedness", "answer", async (record) => {
         const tool = options.tool ?? DEFAULT_KNOWLEDGE_TOOL;
         const entries = getKnowledgeEntries(record, tool);
-        const evidence = uniqueStrings(entries.flatMap((entry) => entry.contentCandidates));
+        const evidence = uniqueStrings(entries.flatMap((entry) => entry.evidenceCandidates));
         const sources = uniqueStrings(retrievedSources(entries));
 
         if (!options.judge) {

--- a/src/knowledge/index.test.ts
+++ b/src/knowledge/index.test.ts
@@ -169,6 +169,41 @@ describe("projectKnowledge", () => {
     });
   });
 
+  it("returns document content for explicit local knowledge lookup targets", async () => {
+    await withTempDir(async (projectDir) => {
+      await mkdir(join(projectDir, "knowledge"), { recursive: true });
+      await writeTextFile(
+        join(projectDir, "knowledge", "login-troubleshooting.md"),
+        [
+          "---",
+          "type: runbook",
+          "title: Login troubleshooting",
+          "description: Diagnose SSO failures after releases.",
+          "---",
+          "",
+          "# Login troubleshooting",
+          "",
+          "Check identity provider metadata and callback URL changes.",
+        ].join("\n"),
+      );
+
+      const knowledge = projectKnowledge({ projectDir });
+      const searchResult = await knowledge.lookup({ query: "login troubleshooting" });
+      const lookupResult = await knowledge.lookup({
+        query: "login troubleshooting",
+        lookup_target: { path: "knowledge/login-troubleshooting.md" },
+      });
+
+      assertEquals(searchResult.data[0]?.content, undefined);
+      assertEquals(lookupResult.returned, 1);
+      assertEquals(lookupResult.data[0]?.path, "knowledge/login-troubleshooting.md");
+      assertStringIncludes(
+        lookupResult.data[0]?.content ?? "",
+        "Check identity provider metadata and callback URL changes.",
+      );
+    });
+  });
+
   it("falls back to browse order and paginates local knowledge lookups", async () => {
     await withTempDir(async (projectDir) => {
       await mkdir(join(projectDir, "knowledge"), { recursive: true });

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -111,6 +111,7 @@ export interface ProjectKnowledgeLookupItem {
   path: string;
   matched_fields: string[];
   frontmatter: ProjectKnowledgeLookupFrontmatterField[];
+  content?: string;
 }
 
 export interface ProjectKnowledgeLookupPageInfo {
@@ -147,6 +148,7 @@ interface ProjectKnowledgeManifestEntry {
   path: string;
   frontmatter: ProjectKnowledgeLookupFrontmatterField[];
   searchableFrontmatter: ProjectKnowledgeLookupFrontmatterField[];
+  content?: string;
 }
 
 interface SearchableProjectKnowledgeManifestEntry extends ProjectKnowledgeManifestEntry {
@@ -197,7 +199,7 @@ const SEARCH_KNOWLEDGE_INPUT_SCHEMA: JsonSchema = {
     lookup_target: {
       type: "object",
       additionalProperties: true,
-      description: "Hosted lookup target accepted for API parity and ignored locally.",
+      description: "Optional target such as { path } for retrieving a specific knowledge document.",
     },
     limit: {
       type: "integer",
@@ -225,9 +227,10 @@ export interface ProjectKnowledge {
    */
   index(): Promise<void>;
   /**
-   * Search the local OKF knowledge manifest using the same compact
-   * frontmatter-only response shape as Veryfront Cloud's `search_knowledge`
-   * tool. This does not build or query the embedding index.
+   * Search the local OKF knowledge manifest using the same compact response
+   * shape as Veryfront Cloud's `search_knowledge` tool. Explicit
+   * `lookup_target` calls include document content. This does not build or
+   * query the embedding index.
    */
   lookup(input: ProjectKnowledgeLookupInput): Promise<ProjectKnowledgeLookupOutput>;
   retrieve(
@@ -252,6 +255,10 @@ function stripTrailingSlash(path: string): string {
 
 function trimLeadingSlash(path: string): string {
   return toPosixPath(path).replace(/^\/+/, "");
+}
+
+function normalizeManifestPath(path: string): string {
+  return trimLeadingSlash(path).replace(/^\.\//, "");
 }
 
 function buildHostedManifestPath(contentDir: string, filePath: string): string | null {
@@ -430,6 +437,36 @@ function toSearchableEntry(
   };
 }
 
+function getLookupTargetPath(lookupTarget: unknown): string | null {
+  if (typeof lookupTarget === "string" && lookupTarget.trim()) {
+    return normalizeManifestPath(lookupTarget);
+  }
+  if (!lookupTarget || typeof lookupTarget !== "object" || Array.isArray(lookupTarget)) {
+    return null;
+  }
+
+  const record = lookupTarget as Record<string, unknown>;
+  for (const key of ["path", "source", "id", "documentCode", "document_code"]) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) return normalizeManifestPath(value);
+  }
+
+  return null;
+}
+
+function createLookupItem(
+  entry: ProjectKnowledgeManifestEntry,
+  matchedFields: string[],
+  includeContent = false,
+): ProjectKnowledgeLookupItem {
+  return {
+    path: entry.path,
+    matched_fields: matchedFields,
+    frontmatter: entry.frontmatter,
+    ...(includeContent && entry.content ? { content: entry.content } : {}),
+  };
+}
+
 function encodeCursor(state: ProjectKnowledgeLookupCursorState): string {
   const bytes = new TextEncoder().encode(JSON.stringify(state));
   let binary = "";
@@ -552,7 +589,14 @@ async function getProjectKnowledgeManifest(
   for (const file of files) {
     let parsedFrontmatter: Record<string, unknown> = {};
     try {
-      parsedFrontmatter = extract<Record<string, unknown>>(await readTextFile(file)).attrs;
+      const content = await readTextFile(file);
+      parsedFrontmatter = extract<Record<string, unknown>>(content).attrs;
+      manifest.push({
+        path: buildManifestPath(config, file),
+        content,
+        ...sanitizeFrontmatter(parsedFrontmatter),
+      });
+      continue;
     } catch {
       parsedFrontmatter = {};
     }
@@ -659,6 +703,7 @@ async function getHostedProjectKnowledgeManifest(
 
     manifest.push({
       path: manifestPath,
+      content: file.content,
       ...sanitizeFrontmatter(parsedFrontmatter),
     });
   }
@@ -673,8 +718,9 @@ function lookupKnowledgeManifest(
   const cursorState = input.cursor ? decodeCursor(input.cursor) : null;
   const providedQuery = input.query?.trim() ?? "";
   const resolvedQuery = (cursorState?.query ?? providedQuery).trim();
+  const lookupTargetPath = cursorState ? null : getLookupTargetPath(input.lookup_target);
 
-  if (!resolvedQuery) {
+  if (!resolvedQuery && !lookupTargetPath) {
     throw new Error("search_knowledge requires a non-empty query");
   }
 
@@ -691,6 +737,29 @@ function lookupKnowledgeManifest(
 
   if (resolvedShardIndex < 0 || resolvedShardIndex >= resolvedShardCount) {
     throw new Error("search_knowledge shard_index must be within shard_count");
+  }
+
+  if (lookupTargetPath) {
+    const entry = manifest.find((item) => normalizeManifestPath(item.path) === lookupTargetPath);
+    const data = entry ? [createLookupItem(entry, ["path"], true)] : [];
+    return {
+      query: resolvedQuery || lookupTargetPath,
+      mode: "search",
+      data,
+      page_info: {
+        self: null,
+        first: null,
+        next: null,
+        prev: null,
+      },
+      returned: data.length,
+      total_matches: data.length,
+      shard: {
+        shard_index: resolvedShardIndex,
+        shard_count: resolvedShardCount,
+        total_items: manifest.length,
+      },
+    };
   }
 
   const resolvedLimit = Math.min(
@@ -736,11 +805,7 @@ function lookupKnowledgeManifest(
   return {
     query: resolvedQuery,
     mode,
-    data: pageEntries.map(({ entry, matchedFields }) => ({
-      path: entry.path,
-      matched_fields: matchedFields,
-      frontmatter: entry.frontmatter,
-    })),
+    data: pageEntries.map(({ entry, matchedFields }) => createLookupItem(entry, matchedFields)),
     page_info: {
       self: input.cursor ?? null,
       first: null,
@@ -815,7 +880,7 @@ export function createSearchKnowledgeTool(
   return tool<ProjectKnowledgeLookupInput, ProjectKnowledgeLookupOutput>({
     id,
     description: description ??
-      "Retrieve a compact, cursor-based slice of the project knowledge manifest.",
+      "Retrieve a compact, cursor-based slice of project knowledge, or a specific document by lookup target.",
     inputSchema: SEARCH_KNOWLEDGE_INPUT_SCHEMA,
     execute: (input, context) =>
       searchProjectKnowledge(coerceSearchKnowledgeInput(input), config, context),

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.945";
+export const VERSION = "0.1.946";


### PR DESCRIPTION
## Summary
- hydrate eval CLI runtime auth from stored `veryfront login` tokens and project config
- preserve tool inputs/outputs in eval traces so metrics can inspect `search_knowledge` results
- use compact `search_knowledge` output as groundedness evidence and return document content for explicit local `lookup_target` calls
- make the eval guide snippet copyable and update knowledge API docs
- bump package version to `0.1.946` for release automation

## Review feedback addressed
- PR #2664 comment: `judgeGrounding` was undefined in the docs snippet
- PR #2664 comment: compact default `search_knowledge` output was not usable as groundedness evidence

## Validation
- `deno task verify:quick`
- `deno check --frozen cli/commands/eval/command.ts src/eval/metrics.ts src/eval/index.ts src/knowledge/index.ts`
- `deno test --frozen --preload=src/schemas/_test-setup.ts --no-check --allow-all cli/commands/eval/command.test.ts src/eval/metrics.test.ts src/knowledge/index.test.ts cli/shared/runtime-auth.test.ts src/utils/version.test.ts`
- customer-operations-agent real eval: `support-triage` passed 4/4, no gate failures, all knowledge and groundedness metrics passed
- pre-push hook: full unit suite `2208 passed / 0 failed`
