### PR TITLE
Add LLM groundedness judges for evals

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.946",
+  "version": "0.1.947",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/api-reference/veryfront/eval.md
+++ b/docs/api-reference/veryfront/eval.md
@@ -104,6 +104,7 @@ const report = await runEval(definition, {
 | `EvalKnowledgeExpectedSource` | Expected knowledge source or passage for retrieval-quality metrics. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L87) |
 | `EvalKnowledgeMrrMetricOptions` | Options for mean reciprocal rank over retrieved knowledge. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L109) |
 | `EvalKnowledgeRetrievalMetricOptions` | Options shared by knowledge retrieval metrics. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L101) |
+| `EvalLlmGroundednessJudgeOptions` | Options for the built-in LLM groundedness judge. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/judges.ts#L9) |
 | `EvalMetric` | Metric contract used by eval definitions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L186) |
 | `EvalMetricContext` | Optional runtime context passed to metric evaluators. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L181) |
 | `EvalMetricDeltaSummary` | Per-metric delta between a current eval report and a baseline report. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/types.ts#L363) |
@@ -145,7 +146,8 @@ const report = await runEval(definition, {
 | `getEvalSourcePatchSchema` | Schema for a source patch submitted from an Eval editor. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L166) |
 | `getEvalSourceReferenceSchema` | Schema for an Eval source reference. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L28) |
 | `getEvalStudioCapabilitySchema` | Schema for Eval Studio capabilities. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/studio.ts#L6) |
-| `metrics` | Metric factories for deterministic answers, agent behavior, operations, and judges. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/metrics.ts#L433) |
+| `judges` | Built-in judge factories for semantic eval metrics. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/judges.ts#L225) |
+| `metrics` | Metric factories for deterministic answers, agent behavior, operations, and judges. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/eval/metrics.ts#L489) |
 
 ## Deep imports
 

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -232,32 +232,17 @@ Use `answer.groundedness` when the judge should compare the final answer against
 retrieved knowledge evidence:
 
 ```ts
-function simpleGroundingJudge(input: {
-  output: Record<string, unknown>;
-  evidence: string[];
-}) {
-  const answer = String(input.output.text ?? "").toLowerCase();
-  const evidence = input.evidence.join("\n").toLowerCase();
-  const pass = answer.length > 0 &&
-    answer.split(/\s+/).some((word) => word.length > 4 && evidence.includes(word));
-
-  return {
-    score: pass ? 1 : 0,
-    pass,
-    explanation: pass
-      ? "The answer overlaps with retrieved evidence."
-      : "The answer is not supported by retrieved evidence.",
-  };
-}
+import { judges, metrics } from "veryfront/eval";
 
 metrics.answer.groundedness({
-  judge: async ({ output, evidence }) => simpleGroundingJudge({ output, evidence }),
+  judge: judges.llm.groundedness(),
 }).gate({ min: 0.8 });
 ```
 
-The helper extracts evidence from `search_knowledge` by default and passes it to
-your judge. This keeps model choice and credentials in project code while the
-eval report uses the standard Veryfront metric shape.
+The metric extracts evidence from `search_knowledge` by default and passes it to
+the judge. The built-in LLM judge asks for structured JSON, fails closed when
+the response is malformed, and checks semantic support instead of brittle string
+overlap.
 
 ## Checks
 

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -45,6 +45,7 @@
 
 export { datasets } from "./datasets.ts";
 export { evalAgent, isEvalDefinition } from "./factory.ts";
+export { judges } from "./judges.ts";
 export { metrics } from "./metrics.ts";
 export { createEvalReport, summarizeEvalRecords } from "./report.ts";
 export { compareEvalReports } from "./baseline.ts";
@@ -61,6 +62,8 @@ export {
 } from "./studio.ts";
 
 export type { DiscoveredEval, EvalDiscoveryOptions, EvalDiscoveryResult } from "./discovery.ts";
+export type { EvalLlmGroundednessJudgeOptions } from "./judges.ts";
+
 export type {
   EvalAgentAdapter,
   EvalAgentAdapterContext,

--- a/src/eval/judges.test.ts
+++ b/src/eval/judges.test.ts
@@ -1,0 +1,142 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ModelRuntime } from "veryfront/provider";
+import { judges } from "veryfront/eval";
+
+function createJudgeModel(text: string, calls: unknown[]): ModelRuntime {
+  return {
+    provider: "test",
+    modelId: "test/judge",
+    async doGenerate(options) {
+      calls.push(options);
+      return {
+        content: [{ type: "text", text }],
+      };
+    },
+    async doStream() {
+      throw new Error("doStream should not be called");
+    },
+  };
+}
+
+describe("eval/judges", () => {
+  it("creates an LLM groundedness judge from structured JSON", async () => {
+    const calls: unknown[] = [];
+    const judge = judges.llm.groundedness({
+      model: createJudgeModel(
+        JSON.stringify({
+          score: 0.92,
+          pass: true,
+          explanation: "The answer is supported by the retrieved runbook.",
+          unsupportedClaims: [],
+          missingEvidence: [],
+        }),
+        calls,
+      ),
+    });
+
+    const result = await judge({
+      rubric: "Grade only against the retrieved evidence.",
+      input: { subject: "Deployment errors after migration" },
+      output: { text: "Check impact, runtime logs, and rollback options." },
+      reference: "The answer should treat this as a deployment incident.",
+      metadata: { severity: "critical" },
+      evidence: ["Deployment incidents require impact, runtime logs, and rollback review."],
+      sources: ["knowledge/deployment-incident-triage.md"],
+    });
+
+    assertEquals(result, {
+      score: 0.92,
+      pass: true,
+      explanation: "The answer is supported by the retrieved runbook.",
+    });
+
+    assertEquals(calls.length, 1);
+    const [call] = calls as Array<{
+      prompt: Array<{ content: Array<{ type: string; text: string }> }>;
+    }>;
+    const promptText = call.prompt[0]?.content[0]?.text ?? "";
+    assertStringIncludes(promptText, "Deployment errors after migration");
+    assertStringIncludes(promptText, "knowledge/deployment-incident-triage.md");
+  });
+
+  it("accepts fenced JSON and clamps scores", async () => {
+    const calls: unknown[] = [];
+    const judge = judges.llm.groundedness({
+      model: createJudgeModel(
+        '```json\n{"score":1.5,"pass":true,"explanation":"Supported."}\n```',
+        calls,
+      ),
+    });
+
+    const result = await judge({
+      rubric: "Grounded answer.",
+      input: "Question",
+      output: { text: "Answer" },
+      metadata: {},
+      evidence: ["Evidence"],
+      sources: [],
+    });
+
+    assertEquals(result, {
+      score: 1,
+      pass: true,
+      explanation: "Supported.",
+    });
+  });
+
+  it("requires both model pass and threshold pass", async () => {
+    const calls: unknown[] = [];
+    const judge = judges.llm.groundedness({
+      threshold: 0.8,
+      model: createJudgeModel(
+        [
+          "The structured decision follows.",
+          JSON.stringify({
+            score: 0.94,
+            pass: false,
+            explanation: "The answer invents an unsupported rollback result.",
+            unsupportedClaims: ["Rollback already completed"],
+            missingEvidence: [],
+          }),
+        ].join("\n"),
+        calls,
+      ),
+    });
+
+    const result = await judge({
+      rubric: "Grounded answer.",
+      input: "Question",
+      output: { text: "Answer" },
+      metadata: {},
+      evidence: ["Evidence"],
+      sources: [],
+    });
+
+    assertEquals(result.score, 0.94);
+    assertEquals(result.pass, false);
+    assertStringIncludes(result.explanation ?? "", "unsupported rollback result");
+    assertStringIncludes(result.explanation ?? "", "Rollback already completed");
+  });
+
+  it("fails closed when the judge does not return valid JSON", async () => {
+    const calls: unknown[] = [];
+    const judge = judges.llm.groundedness({
+      model: createJudgeModel("Looks good to me.", calls),
+    });
+
+    const result = await judge({
+      rubric: "Grounded answer.",
+      input: "Question",
+      output: { text: "Answer" },
+      metadata: {},
+      evidence: ["Evidence"],
+      sources: [],
+    });
+
+    assertEquals(result.score, 0);
+    assertEquals(result.pass, false);
+    assertStringIncludes(result.explanation ?? "", "valid JSON");
+  });
+});

--- a/src/eval/judges.ts
+++ b/src/eval/judges.ts
@@ -1,0 +1,231 @@
+import { resolveRuntimeModel } from "#veryfront/agent/runtime/model-resolution.ts";
+import { type ModelRuntime, resolveModel } from "#veryfront/provider";
+import { generateText } from "#veryfront/runtime/runtime-bridge.ts";
+
+import type { EvalAnswerGroundednessMetricOptions } from "./types.ts";
+
+type GroundednessJudge = NonNullable<EvalAnswerGroundednessMetricOptions["judge"]>;
+
+/** Options for the built-in LLM groundedness judge. */
+export interface EvalLlmGroundednessJudgeOptions {
+  /** Model id or runtime used to judge answer grounding. Defaults to the runtime auto model. */
+  model?: string | ModelRuntime;
+  /** Minimum score required for the judge to pass. Defaults to 0.8. */
+  threshold?: number;
+  /** Maximum retrieved evidence characters included in the judge prompt. Defaults to 12000. */
+  maxEvidenceChars?: number;
+  /** Maximum judge response tokens. Defaults to 800. */
+  maxOutputTokens?: number;
+  /** Judge model temperature. Defaults to 0 for repeatability. */
+  temperature?: number;
+  /** Provider-specific options forwarded to the model runtime. */
+  providerOptions?: Record<string, unknown>;
+}
+
+const DEFAULT_JUDGE_MODEL = "auto";
+const DEFAULT_THRESHOLD = 0.8;
+const DEFAULT_MAX_EVIDENCE_CHARS = 12_000;
+const DEFAULT_MAX_OUTPUT_TOKENS = 800;
+
+function asJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function clampScore(score: number): number {
+  if (!Number.isFinite(score)) return 0;
+  return Math.max(0, Math.min(1, score));
+}
+
+function resolveJudgeModel(model: string | ModelRuntime | undefined): ModelRuntime {
+  if (model && typeof model === "object") return model;
+  return resolveModel(resolveRuntimeModel(model ?? DEFAULT_JUDGE_MODEL));
+}
+
+function truncate(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, Math.max(0, maxChars - 24))}\n[truncated]`;
+}
+
+function buildEvidenceBlock(evidence: string[], sources: string[], maxChars: number): string {
+  const entries = evidence.length > 0 ? evidence : ["No retrieved evidence was provided."];
+  const block = entries.map((entry, index) => {
+    const source = sources[index] ?? `evidence-${index + 1}`;
+    return `[${index + 1}] ${source}\n${entry}`;
+  }).join("\n\n");
+  return truncate(block, maxChars);
+}
+
+function buildGroundednessPrompt(
+  input: Parameters<GroundednessJudge>[0],
+  options: Required<Pick<EvalLlmGroundednessJudgeOptions, "threshold" | "maxEvidenceChars">>,
+): string {
+  return `Evaluate whether an agent answer is grounded in retrieved evidence.
+
+Rubric:
+${input.rubric}
+
+Rules:
+- Grade only against the evidence and the reference.
+- Treat unsupported factual claims, unsupported instructions, or missing required actions as failures.
+- Do not reward keyword overlap by itself. Judge semantic support.
+- Use score 1.0 only when all material claims are supported and the answer satisfies the reference.
+- Use score 0.8 for mostly grounded answers with only minor omissions.
+- Use score 0.5 for partially grounded answers with material omissions.
+- Use score 0.0 for ungrounded, contradictory, or non-responsive answers.
+- Pass only when score is at least ${options.threshold}.
+
+Return only valid JSON with this shape:
+{
+  "score": 0.0,
+  "pass": false,
+  "explanation": "Short reason.",
+  "unsupportedClaims": ["claim not supported by evidence"],
+  "missingEvidence": ["required point missing from the answer"]
+}
+
+Input:
+${asJson(input.input)}
+
+Reference:
+${asJson(input.reference)}
+
+Metadata:
+${asJson(input.metadata)}
+
+Answer:
+${asJson(input.output)}
+
+Evidence:
+${buildEvidenceBlock(input.evidence, input.sources, options.maxEvidenceChars)}
+`;
+}
+
+function stripJsonFence(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("```")) return trimmed;
+  return trimmed.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "").trim();
+}
+
+function extractJsonObject(value: string): string | null {
+  const stripped = stripJsonFence(value);
+  try {
+    JSON.parse(stripped);
+    return stripped;
+  } catch {
+    // Continue and extract the first balanced object from explanatory text.
+  }
+
+  const start = stripped.indexOf("{");
+  if (start === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = start; index < stripped.length; index++) {
+    const char = stripped[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (inString && char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+
+    if (char === "{") depth += 1;
+    if (char === "}") depth -= 1;
+    if (depth === 0) return stripped.slice(start, index + 1);
+  }
+
+  return null;
+}
+
+function stringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.trim() !== "");
+}
+
+function parseJudgeResponse(
+  text: string,
+  threshold: number,
+): { score: number; pass: boolean; explanation: string } {
+  const json = extractJsonObject(text);
+  if (!json) {
+    return {
+      score: 0,
+      pass: false,
+      explanation: "LLM judge did not return valid JSON.",
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    const score = clampScore(typeof parsed.score === "number" ? parsed.score : 0);
+    const modelPass = typeof parsed.pass === "boolean" ? parsed.pass : true;
+    const unsupportedClaims = stringList(parsed.unsupportedClaims);
+    const missingEvidence = stringList(parsed.missingEvidence);
+    const details = [
+      typeof parsed.explanation === "string" && parsed.explanation.trim()
+        ? parsed.explanation.trim()
+        : "LLM judge returned a structured groundedness score.",
+      ...(unsupportedClaims.length > 0
+        ? [`Unsupported claims: ${unsupportedClaims.join("; ")}`]
+        : []),
+      ...(missingEvidence.length > 0 ? [`Missing evidence: ${missingEvidence.join("; ")}`] : []),
+    ];
+
+    return {
+      score,
+      pass: modelPass && score >= threshold,
+      explanation: details.join(" "),
+    };
+  } catch {
+    return {
+      score: 0,
+      pass: false,
+      explanation: "LLM judge returned malformed JSON.",
+    };
+  }
+}
+
+function createLlmGroundednessJudge(
+  options: EvalLlmGroundednessJudgeOptions = {},
+): GroundednessJudge {
+  const threshold = options.threshold ?? DEFAULT_THRESHOLD;
+  const maxEvidenceChars = options.maxEvidenceChars ?? DEFAULT_MAX_EVIDENCE_CHARS;
+  const maxOutputTokens = options.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
+
+  return async (input) => {
+    const model = resolveJudgeModel(options.model);
+    const response = await generateText({
+      model,
+      messages: [{
+        role: "user",
+        content: buildGroundednessPrompt(input, { threshold, maxEvidenceChars }),
+      }],
+      maxOutputTokens,
+      temperature: options.temperature ?? 0,
+      ...(options.providerOptions ? { providerOptions: options.providerOptions } : {}),
+    });
+
+    return parseJudgeResponse(response.text, threshold);
+  };
+}
+
+/** Built-in judge factories for semantic eval metrics. */
+export const judges = {
+  llm: {
+    /** Create an LLM judge for `metrics.answer.groundedness`. */
+    groundedness: createLlmGroundednessJudge,
+  },
+} as const;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.946";
+export const VERSION = "0.1.947";


### PR DESCRIPTION
## Summary
- add a built-in judges.llm.groundedness helper for semantic answer grounding evals
- fail closed on malformed judge output and require both structured model pass and score threshold
- document the public judge helper and replace the brittle string-overlap guide example
- bump framework version to 0.1.947

## Verification
- deno task fmt:check
- deno check src/eval/index.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/eval/judges.test.ts src/eval/metrics.test.ts src/eval/studio.test.ts
- deno task docs:validate
- pre-push hook: formatting, lint, typecheck, full unit suite: 2210 passed, 0 failed