### PR TITLE
Avoid fake source mapping in groundedness judges

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.947",
+  "version": "0.1.948",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/eval/judges.test.ts
+++ b/src/eval/judges.test.ts
@@ -59,6 +59,8 @@ describe("eval/judges", () => {
     const promptText = call.prompt[0]?.content[0]?.text ?? "";
     assertStringIncludes(promptText, "Deployment errors after migration");
     assertStringIncludes(promptText, "knowledge/deployment-incident-triage.md");
+    assertStringIncludes(promptText, "[source 1] knowledge/deployment-incident-triage.md");
+    assertStringIncludes(promptText, "[evidence 1]");
   });
 
   it("accepts fenced JSON and clamps scores", async () => {
@@ -118,6 +120,37 @@ describe("eval/judges", () => {
     assertEquals(result.pass, false);
     assertStringIncludes(result.explanation ?? "", "unsupported rollback result");
     assertStringIncludes(result.explanation ?? "", "Rollback already completed");
+  });
+
+  it("does not imply source-to-evidence alignment", async () => {
+    const calls: unknown[] = [];
+    const judge = judges.llm.groundedness({
+      model: createJudgeModel(
+        JSON.stringify({
+          score: 1,
+          pass: true,
+          explanation: "Supported.",
+        }),
+        calls,
+      ),
+    });
+
+    await judge({
+      rubric: "Grounded answer.",
+      input: "Question",
+      output: { text: "Answer" },
+      metadata: {},
+      evidence: ["First evidence snippet", "Second evidence snippet"],
+      sources: ["knowledge/a.md", "knowledge/b.md"],
+    });
+
+    const [call] = calls as Array<{
+      prompt: Array<{ content: Array<{ type: string; text: string }> }>;
+    }>;
+    const promptText = call.prompt[0]?.content[0]?.text ?? "";
+    assertStringIncludes(promptText, "Retrieved sources:");
+    assertStringIncludes(promptText, "Evidence snippets:");
+    assertEquals(promptText.includes("knowledge/a.md\nFirst evidence snippet"), false);
   });
 
   it("fails closed when the judge does not return valid JSON", async () => {

--- a/src/eval/judges.ts
+++ b/src/eval/judges.ts
@@ -52,10 +52,17 @@ function truncate(value: string, maxChars: number): string {
 
 function buildEvidenceBlock(evidence: string[], sources: string[], maxChars: number): string {
   const entries = evidence.length > 0 ? evidence : ["No retrieved evidence was provided."];
-  const block = entries.map((entry, index) => {
-    const source = sources[index] ?? `evidence-${index + 1}`;
-    return `[${index + 1}] ${source}\n${entry}`;
-  }).join("\n\n");
+  const sourceBlock = sources.length > 0
+    ? sources.map((source, index) => `- [source ${index + 1}] ${source}`).join("\n")
+    : "- none";
+  const evidenceBlock = entries.map((entry, index) => `[evidence ${index + 1}]\n${entry}`).join(
+    "\n\n",
+  );
+  const block = `Retrieved sources:
+${sourceBlock}
+
+Evidence snippets:
+${evidenceBlock}`;
   return truncate(block, maxChars);
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.947";
+export const VERSION = "0.1.948";


### PR DESCRIPTION
## Summary
- list retrieved sources separately from evidence snippets in the built-in groundedness judge prompt
- add a regression test so the judge prompt does not imply source-to-evidence alignment
- bump framework version to 0.1.948 for the follow-up release

## Verification
- deno task fmt:check
- deno check src/eval/index.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/eval/judges.test.ts src/eval/metrics.test.ts
- pre-push hook: formatting, lint, typecheck, full unit suite: 2210 passed, 0 failed