### PR TITLE
Harden groundedness judge failure modes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.948",
+  "version": "0.1.949",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/eval/judges.test.ts
+++ b/src/eval/judges.test.ts
@@ -148,9 +148,66 @@ describe("eval/judges", () => {
       prompt: Array<{ content: Array<{ type: string; text: string }> }>;
     }>;
     const promptText = call.prompt[0]?.content[0]?.text ?? "";
-    assertStringIncludes(promptText, "Retrieved sources:");
     assertStringIncludes(promptText, "Evidence snippets:");
+    assertStringIncludes(promptText, "Retrieved sources:");
     assertEquals(promptText.includes("knowledge/a.md\nFirst evidence snippet"), false);
+  });
+
+  it("preserves evidence when source labels are long", async () => {
+    const calls: unknown[] = [];
+    const judge = judges.llm.groundedness({
+      maxEvidenceChars: 260,
+      model: createJudgeModel(
+        JSON.stringify({
+          score: 1,
+          pass: true,
+          explanation: "Supported.",
+        }),
+        calls,
+      ),
+    });
+
+    await judge({
+      rubric: "Grounded answer.",
+      input: "Question",
+      output: { text: "Answer" },
+      metadata: {},
+      evidence: ["Critical policy evidence that must reach the judge."],
+      sources: [`knowledge/${"very-long-source-name-".repeat(20)}.md`],
+    });
+
+    const [call] = calls as Array<{
+      prompt: Array<{ content: Array<{ type: string; text: string }> }>;
+    }>;
+    const promptText = call.prompt[0]?.content[0]?.text ?? "";
+    assertStringIncludes(promptText, "Critical policy evidence");
+    assertStringIncludes(promptText, "Retrieved sources:");
+  });
+
+  it("fails closed when the judge omits the pass field", async () => {
+    const calls: unknown[] = [];
+    const judge = judges.llm.groundedness({
+      model: createJudgeModel(
+        JSON.stringify({
+          score: 0.95,
+          explanation: "Looks supported.",
+        }),
+        calls,
+      ),
+    });
+
+    const result = await judge({
+      rubric: "Grounded answer.",
+      input: "Question",
+      output: { text: "Answer" },
+      metadata: {},
+      evidence: ["Evidence"],
+      sources: [],
+    });
+
+    assertEquals(result.score, 0);
+    assertEquals(result.pass, false);
+    assertStringIncludes(result.explanation ?? "", "boolean pass");
   });
 
   it("fails closed when the judge does not return valid JSON", async () => {

--- a/src/eval/judges.ts
+++ b/src/eval/judges.ts
@@ -26,6 +26,8 @@ const DEFAULT_JUDGE_MODEL = "auto";
 const DEFAULT_THRESHOLD = 0.8;
 const DEFAULT_MAX_EVIDENCE_CHARS = 12_000;
 const DEFAULT_MAX_OUTPUT_TOKENS = 800;
+const MAX_SOURCE_CHARS = 2_000;
+const SOURCE_BUDGET_RATIO = 0.25;
 
 function asJson(value: unknown): string {
   try {
@@ -46,24 +48,34 @@ function resolveJudgeModel(model: string | ModelRuntime | undefined): ModelRunti
 }
 
 function truncate(value: string, maxChars: number): string {
+  if (maxChars <= 0) return "";
   if (value.length <= maxChars) return value;
-  return `${value.slice(0, Math.max(0, maxChars - 24))}\n[truncated]`;
+  const marker = "\n[truncated]";
+  if (maxChars <= marker.length) return value.slice(0, maxChars);
+  return `${value.slice(0, maxChars - marker.length)}${marker}`;
 }
 
 function buildEvidenceBlock(evidence: string[], sources: string[], maxChars: number): string {
   const entries = evidence.length > 0 ? evidence : ["No retrieved evidence was provided."];
-  const sourceBlock = sources.length > 0
-    ? sources.map((source, index) => `- [source ${index + 1}] ${source}`).join("\n")
-    : "- none";
   const evidenceBlock = entries.map((entry, index) => `[evidence ${index + 1}]\n${entry}`).join(
     "\n\n",
   );
-  const block = `Retrieved sources:
-${sourceBlock}
+  const sourceBlock = sources.length > 0
+    ? sources.map((source, index) => `- [source ${index + 1}] ${source}`).join("\n")
+    : "- none";
+  const sourceBudget = Math.min(
+    sourceBlock.length,
+    MAX_SOURCE_CHARS,
+    Math.floor(maxChars * SOURCE_BUDGET_RATIO),
+  );
+  const sectionOverhead = "Evidence snippets:\n\n\nRetrieved sources:\n".length;
+  const evidenceBudget = Math.max(0, maxChars - sectionOverhead - sourceBudget);
 
-Evidence snippets:
-${evidenceBlock}`;
-  return truncate(block, maxChars);
+  return `Evidence snippets:
+${truncate(evidenceBlock, evidenceBudget)}
+
+Retrieved sources:
+${truncate(sourceBlock, sourceBudget)}`;
 }
 
 function buildGroundednessPrompt(
@@ -177,8 +189,23 @@ function parseJudgeResponse(
 
   try {
     const parsed = JSON.parse(json) as Record<string, unknown>;
-    const score = clampScore(typeof parsed.score === "number" ? parsed.score : 0);
-    const modelPass = typeof parsed.pass === "boolean" ? parsed.pass : true;
+    if (typeof parsed.score !== "number" || !Number.isFinite(parsed.score)) {
+      return {
+        score: 0,
+        pass: false,
+        explanation: "LLM judge response did not include a finite numeric score.",
+      };
+    }
+    if (typeof parsed.pass !== "boolean") {
+      return {
+        score: 0,
+        pass: false,
+        explanation: "LLM judge response did not include a boolean pass field.",
+      };
+    }
+
+    const score = clampScore(parsed.score);
+    const modelPass = parsed.pass;
     const unsupportedClaims = stringList(parsed.unsupportedClaims);
     const missingEvidence = stringList(parsed.missingEvidence);
     const details = [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.948";
+export const VERSION = "0.1.949";


### PR DESCRIPTION
## Summary
- fail closed when the LLM groundedness judge omits required boolean pass or finite numeric score
- reserve prompt budget for evidence so long source labels cannot hide evidence snippets
- bump framework version to 0.1.949

## Review comments addressed
- https://github.com/veryfront/veryfront-code/pull/2667#discussion_r3485578523
- https://github.com/veryfront/veryfront-code/pull/2668#discussion_r3485605456

## Verification
- deno task fmt:check
- deno check src/eval/index.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/eval/judges.test.ts src/eval/metrics.test.ts
- pre-push hook: formatting, lint, typecheck, full unit suite: 2210 passed, 0 failed