### PR TITLE
Add eval model comparison reporting

### DIFF
--- a/cli/commands/eval/command-help.ts
+++ b/cli/commands/eval/command-help.ts
@@ -43,6 +43,15 @@ export const evalHelp: CommandHelp = {
       description: "Override the target agent model",
     },
     {
+      flag: "--baseline-model <provider/model>",
+      description: "Baseline model for model comparison runs",
+    },
+    {
+      flag: "--candidate-model <provider/model>",
+      description:
+        "Candidate model to compare against --baseline-model; repeat for multiple candidates",
+    },
+    {
       flag: "--max-output-tokens <count>",
       description: "Limit target agent output tokens",
     },
@@ -57,6 +66,7 @@ export const evalHelp: CommandHelp = {
     "veryfront eval eval:deep-research --report-dir .veryfront/evals/deep-research",
     "veryfront eval eval:deep-research --report .veryfront/evals/deep-research/report.json --junit .veryfront/evals/deep-research/junit.xml",
     "veryfront eval deep-research --baseline .veryfront/evals/baseline.json --json",
+    "veryfront eval deep-research --baseline-model anthropic/claude-sonnet-4-6 --candidate-model moonshotai/kimi-k2",
     "veryfront eval deep-research --export braintrust,langfuse --json",
     "veryfront eval deep-research --json",
   ],

--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -8,6 +8,9 @@ import {
   createDefaultEvalReportDir,
   createEvalArtifactPaths,
   createEvalExitCode,
+  createEvalModelArtifactPaths,
+  createEvalModelComparisonArtifact,
+  createEvalModelComparisonExitCode,
   createJunitXml,
   createResultsJsonl,
   createSummaryArtifact,
@@ -142,6 +145,8 @@ describe("eval CLI command helpers", () => {
       "write-baseline": "reports/next-baseline.json",
       export: "braintrust,langfuse",
       debug: true,
+      "baseline-model": "anthropic/claude-opus-4-6",
+      "candidate-model": ["moonshotai/kimi-k2"],
     });
 
     assertEquals(parsed.success, true);
@@ -155,6 +160,8 @@ describe("eval CLI command helpers", () => {
       assertEquals(parsed.data.writeBaseline, "reports/next-baseline.json");
       assertEquals(parsed.data.exporters, ["braintrust", "langfuse"]);
       assertEquals(parsed.data.debug, true);
+      assertEquals(parsed.data.baselineModel, "anthropic/claude-opus-4-6");
+      assertEquals(parsed.data.candidateModels, ["moonshotai/kimi-k2"]);
     }
   });
 
@@ -298,6 +305,15 @@ describe("eval CLI command helpers", () => {
       summary: ".veryfront/evals/run-1/summary.json",
       results: ".veryfront/evals/run-1/results.jsonl",
     });
+    assertEquals(
+      createEvalModelArtifactPaths(".veryfront/evals/run-1", "anthropic/claude-opus-4-6"),
+      {
+        directory: ".veryfront/evals/run-1/models/anthropic__claude-opus-4-6",
+        summary: ".veryfront/evals/run-1/models/anthropic__claude-opus-4-6/summary.json",
+        results: ".veryfront/evals/run-1/models/anthropic__claude-opus-4-6/results.jsonl",
+        junit: ".veryfront/evals/run-1/models/anthropic__claude-opus-4-6/junit.xml",
+      },
+    );
   });
 
   it("serializes eval summary and record artifacts", () => {
@@ -352,6 +368,53 @@ describe("eval CLI command helpers", () => {
     }
   });
 
+  it("creates a model comparison artifact for JSON and report output", () => {
+    const baseline = {
+      ...createReport(),
+      runId: "evalrun_baseline",
+      metadata: { model: "anthropic/claude-opus-4-6" },
+      summary: {
+        ...createReport().summary,
+        passed: 2,
+        failed: 0,
+        passRate: 1,
+        failedExamples: [],
+        metrics: [
+          ...createReport().summary.metrics,
+          {
+            name: "answer.groundedness",
+            family: "answer",
+            severity: "gate",
+            passed: 2,
+            failed: 0,
+            skipped: 0,
+            passRate: 0.9,
+          },
+        ],
+        usage: { totalTokens: 100, costUsd: 1 },
+      },
+    };
+    const candidate = {
+      ...baseline,
+      runId: "evalrun_candidate",
+      metadata: { model: "moonshotai/kimi-k2" },
+      summary: {
+        ...baseline.summary,
+        usage: { totalTokens: 90, costUsd: 0.5 },
+      },
+    };
+
+    const artifact = createEvalModelComparisonArtifact(
+      [baseline, candidate],
+      "anthropic/claude-opus-4-6",
+    );
+
+    assertEquals(artifact.kind, "eval-model-comparison");
+    assertEquals(artifact.baselineModel, "anthropic/claude-opus-4-6");
+    assertEquals(artifact.candidateModels, ["moonshotai/kimi-k2"]);
+    assertEquals(artifact.recommendation.decision, "promote-candidate");
+  });
+
   it("serializes eval reports to JUnit XML", () => {
     const xml = createJunitXml(createReport());
 
@@ -383,5 +446,16 @@ describe("eval CLI command helpers", () => {
       createEvalExitCode({ ...report, summary: { ...report.summary, failed: 0 } }, baseline),
       1,
     );
+  });
+
+  it("fails model comparison exit code only when an evaluated report fails", () => {
+    const passing = {
+      ...createReport(),
+      summary: { ...createReport().summary, failed: 0, passed: 2, passRate: 1 },
+    };
+    const failing = createReport();
+
+    assertEquals(createEvalModelComparisonExitCode([passing]), 0);
+    assertEquals(createEvalModelComparisonExitCode([passing, failing]), 1);
   });
 });

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -9,6 +9,7 @@ import type {
   DiscoveredEval,
   EvalAgentAdapterContext,
   EvalMetricResult,
+  EvalModelComparison,
   EvalRecord,
   EvalReport,
   EvalReportComparison,
@@ -16,9 +17,16 @@ import type {
   EvalToolCall,
 } from "veryfront/eval";
 import { createProjectDiscoveryConfig, discoverAll } from "veryfront/discovery";
-import { compareEvalReports, discoverEvals, runEval } from "veryfront/eval";
+import {
+  compareEvalModelReports,
+  compareEvalReports,
+  createEvalModelComparisonMarkdown,
+  discoverEvals,
+  resolveEvalRunProvenance,
+  runEval,
+} from "veryfront/eval";
 import { applyRuntimeAuthContext } from "#cli/shared/runtime-auth";
-import { cliLogger, exitProcess } from "#cli/utils";
+import { cliLogger, exitProcess, VERSION } from "#cli/utils";
 import {
   createErrorEnvelope,
   createSuccessEnvelope,
@@ -47,6 +55,17 @@ type EvalArtifactPaths = {
   results: string;
 };
 
+type EvalModelArtifactPaths = EvalArtifactPaths & {
+  junit: string;
+};
+
+type EvalModelComparisonArtifactPaths = {
+  directory: string;
+  comparisonJson: string;
+  comparisonMarkdown: string;
+  models: Record<string, EvalModelArtifactPaths>;
+};
+
 type EvalSummaryArtifact = {
   kind: "eval-summary";
   runId: string;
@@ -56,6 +75,7 @@ type EvalSummaryArtifact = {
   startedAt: string;
   endedAt: string;
   summary: EvalReport["summary"];
+  metadata?: EvalReport["metadata"];
   exports?: EvalReport["exports"];
   baseline?: EvalReportComparison;
 };
@@ -87,6 +107,37 @@ export function createEvalArtifactPaths(reportDir: string): EvalArtifactPaths {
     directory: reportDir,
     summary: join(reportDir, "summary.json"),
     results: join(reportDir, "results.jsonl"),
+  };
+}
+
+function sanitizeModelIdForPath(model: string): string {
+  return model.trim().replace(/[^A-Za-z0-9._-]+/g, "__").replace(/^_+|_+$/g, "") || "model";
+}
+
+export function createEvalModelArtifactPaths(
+  reportDir: string,
+  model: string,
+): EvalModelArtifactPaths {
+  const directory = join(reportDir, "models", sanitizeModelIdForPath(model));
+  return {
+    directory,
+    summary: join(directory, "summary.json"),
+    results: join(directory, "results.jsonl"),
+    junit: join(directory, "junit.xml"),
+  };
+}
+
+function createEvalModelComparisonArtifactPaths(
+  reportDir: string,
+  models: string[],
+): EvalModelComparisonArtifactPaths {
+  return {
+    directory: reportDir,
+    comparisonJson: join(reportDir, "comparison.json"),
+    comparisonMarkdown: join(reportDir, "comparison.md"),
+    models: Object.fromEntries(
+      models.map((model) => [model, createEvalModelArtifactPaths(reportDir, model)]),
+    ),
   };
 }
 
@@ -177,9 +228,21 @@ export function createSummaryArtifact(
     startedAt: report.startedAt,
     endedAt: report.endedAt,
     summary: report.summary,
+    ...(report.metadata ? { metadata: report.metadata } : {}),
     ...(report.exports ? { exports: report.exports } : {}),
     ...(baseline ? { baseline } : {}),
   };
+}
+
+export function createEvalModelComparisonArtifact(
+  reports: EvalReport[],
+  baselineModel: string,
+): EvalModelComparison {
+  return compareEvalModelReports(reports, { baselineModel });
+}
+
+export function createEvalModelComparisonExitCode(reports: EvalReport[]): 0 | 1 {
+  return reports.some((report) => report.summary.failed > 0) ? 1 : 0;
 }
 
 export function createResultsJsonl(report: EvalReport): string {
@@ -402,6 +465,131 @@ function createEvalCliExportConfig(
   };
 }
 
+type EvalModelComparisonConfig = {
+  baselineModel: string;
+  candidateModels: string[];
+  models: string[];
+};
+
+function uniqueValues(values: string[]): string[] {
+  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
+}
+
+function resolveEvalModelComparisonConfig(
+  options: EvalOptions,
+): EvalModelComparisonConfig | undefined {
+  const candidateModels = uniqueValues(options.candidateModels);
+  const baselineModel = options.baselineModel?.trim();
+  if (!baselineModel && candidateModels.length === 0) return undefined;
+
+  if (!baselineModel) {
+    throw new Error("--baseline-model is required when using --candidate-model.");
+  }
+  if (candidateModels.length === 0) {
+    throw new Error("--candidate-model is required when using --baseline-model.");
+  }
+  if (options.model) {
+    throw new Error(
+      "--model is for single eval runs. Use --baseline-model with --candidate-model for comparisons.",
+    );
+  }
+  if (options.baseline || options.writeBaseline) {
+    throw new Error(
+      "--baseline and --write-baseline are for saved single-run reports, not model comparisons.",
+    );
+  }
+
+  return {
+    baselineModel,
+    candidateModels: candidateModels.filter((model) => model !== baselineModel),
+    models: uniqueValues([baselineModel, ...candidateModels]),
+  };
+}
+
+function createAgentAdapterForModel(agent: Agent, options: EvalOptions, model: string) {
+  return createAgentAdapter(agent, { ...options, model });
+}
+
+async function writeEvalModelComparisonArtifacts(
+  comparison: EvalModelComparison,
+  paths: EvalModelComparisonArtifactPaths,
+): Promise<void> {
+  await Deno.mkdir(paths.directory, { recursive: true });
+  await Deno.writeTextFile(paths.comparisonJson, JSON.stringify(comparison, null, 2));
+  await Deno.writeTextFile(paths.comparisonMarkdown, createEvalModelComparisonMarkdown(comparison));
+}
+
+async function runEvalModelComparison(input: {
+  evalItem: DiscoveredEval;
+  agent: Agent;
+  options: EvalOptions;
+  projectDir: string;
+  config: EvalModelComparisonConfig;
+}): Promise<void> {
+  const runId = createCliRunId();
+  const reportDir = input.options.reportDir ?? createDefaultEvalReportDir(runId);
+  const paths = createEvalModelComparisonArtifactPaths(reportDir, input.config.models);
+  const provenance = await resolveEvalRunProvenance({
+    projectDir: input.projectDir,
+    frameworkVersion: VERSION,
+  });
+  const reports: EvalReport[] = [];
+
+  for (const model of input.config.models) {
+    const modelPaths = paths.models[model]!;
+    const modelOptions = { ...input.options, model, report: undefined };
+    const report = await runEval(input.evalItem.definition, {
+      baseDir: input.options.datasetBase ?? input.projectDir,
+      runId: `${runId}_${sanitizeModelIdForPath(model)}`,
+      adapters: {
+        agent: createAgentAdapterForModel(input.agent, input.options, model),
+      },
+      metadata: {
+        model,
+        provenance,
+      },
+      export: createEvalCliExportConfig(input.evalItem, modelOptions, input.projectDir, modelPaths),
+    });
+    reports.push(report);
+    await writeEvalArtifacts(report, modelPaths);
+    await writeTextFileEnsuringDir(modelPaths.junit, createJunitXml(report));
+  }
+
+  const comparison = createEvalModelComparisonArtifact(reports, input.config.baselineModel);
+  await writeEvalModelComparisonArtifacts(comparison, paths);
+  if (input.options.report) {
+    await writeTextFileEnsuringDir(input.options.report, JSON.stringify(comparison, null, 2));
+  }
+
+  if (isJsonMode()) {
+    await outputJson(createSuccessEnvelope("eval", {
+      reports,
+      comparison,
+      artifacts: paths,
+    }));
+  } else {
+    for (const report of reports) {
+      const model = report.metadata?.model ?? report.runId;
+      cliLogger.info(`Model: ${model}`);
+      printReport(report);
+    }
+    cliLogger.info(
+      `Recommendation: ${comparison.recommendation.decision}${
+        comparison.recommendation.model ? ` (${comparison.recommendation.model})` : ""
+      }`,
+    );
+    for (const reason of comparison.recommendation.reasons) {
+      cliLogger.info(`  - ${reason}`);
+    }
+    cliLogger.info(`Report directory: ${paths.directory}`);
+    cliLogger.info(`Comparison: ${paths.comparisonJson}`);
+    cliLogger.info(`Comparison markdown: ${paths.comparisonMarkdown}`);
+    if (input.options.report) cliLogger.info(`Report: ${input.options.report}`);
+  }
+
+  exitProcess(createEvalModelComparisonExitCode(reports));
+}
+
 async function outputEvalNotFound(id: string, evals: DiscoveredEval[]): Promise<void> {
   if (isJsonMode()) {
     await outputJson(createErrorEnvelope("eval", {
@@ -433,6 +621,19 @@ async function outputAgentNotFound(agentId: string): Promise<void> {
     cliLogger.error(`Agent "${agentId}" not found for eval target.`);
   }
   exitProcess(1);
+}
+
+async function outputEvalUsageError(message: string): Promise<void> {
+  if (isJsonMode()) {
+    await outputJson(createErrorEnvelope("eval", {
+      code: "USAGE_ERROR",
+      slug: "eval-usage-error",
+      message,
+    }));
+  } else {
+    cliLogger.error(message);
+  }
+  exitProcess(2);
 }
 
 export async function evalCommand(options: EvalOptions): Promise<void> {
@@ -503,15 +704,42 @@ export async function evalCommand(options: EvalOptions): Promise<void> {
       return;
     }
 
+    let modelComparisonConfig: EvalModelComparisonConfig | undefined;
+    try {
+      modelComparisonConfig = resolveEvalModelComparisonConfig(options);
+    } catch (error) {
+      await outputEvalUsageError(error instanceof Error ? error.message : String(error));
+      return;
+    }
+
+    if (modelComparisonConfig) {
+      await runEvalModelComparison({
+        evalItem,
+        agent,
+        options,
+        projectDir,
+        config: modelComparisonConfig,
+      });
+      return;
+    }
+
     const runId = createCliRunId();
     const artifactPaths = createEvalArtifactPaths(
       options.reportDir ?? createDefaultEvalReportDir(runId),
     );
+    const provenance = await resolveEvalRunProvenance({
+      projectDir,
+      frameworkVersion: VERSION,
+    });
     const report = await runEval(evalItem.definition, {
       baseDir: options.datasetBase ?? projectDir,
       runId,
       adapters: {
         agent: createAgentAdapter(agent, options),
+      },
+      metadata: {
+        provenance,
+        ...(options.model ? { model: options.model } : {}),
       },
       export: createEvalCliExportConfig(evalItem, options, projectDir, artifactPaths),
     });

--- a/cli/commands/eval/handler.ts
+++ b/cli/commands/eval/handler.ts
@@ -16,6 +16,8 @@ const getEvalArgsSchema = defineSchema((v) =>
     exporters: v.array(v.string()).default([]),
     debug: v.boolean().default(false),
     model: v.string().optional(),
+    baselineModel: v.string().optional(),
+    candidateModels: v.array(v.string()).default([]),
     maxOutputTokens: v.number().int().positive().optional(),
   })
 );
@@ -36,6 +38,8 @@ export const parseEvalArgs = createArgParser(EvalArgsSchema, {
   exporters: { keys: ["export"], type: "array" },
   debug: { keys: ["debug"], type: "boolean" },
   model: { keys: ["model"], type: "string" },
+  baselineModel: { keys: ["baseline-model"], type: "string" },
+  candidateModels: { keys: ["candidate-model", "candidate-models"], type: "array" },
   maxOutputTokens: { keys: ["max-output-tokens"], type: "number" },
 });
 

--- a/cli/shared/args.test.ts
+++ b/cli/shared/args.test.ts
@@ -224,6 +224,18 @@ describe("cli/shared/args", () => {
       ]);
     });
 
+    it("should handle repeated --candidate-model values as an array flag", () => {
+      assertEquals(
+        parseCliArgs([
+          "--candidate-model",
+          "moonshotai/kimi-k2",
+          "--candidate-model",
+          "openai/gpt-5.5",
+        ])["candidate-model"],
+        ["moonshotai/kimi-k2", "openai/gpt-5.5"],
+      );
+    });
+
     it("should not set default port", () => {
       assertEquals(parseCliArgs([]).port, undefined);
     });

--- a/cli/shared/args.ts
+++ b/cli/shared/args.ts
@@ -170,7 +170,7 @@ export const CommonArgs = {
 // Low-level parser that converts process argv into a ParsedArgs object.
 // Used once in cli/main.ts before routing to individual command handlers.
 
-const ARRAY_FLAGS = new Set(["with"]);
+const ARRAY_FLAGS = new Set(["with", "candidate-model"]);
 
 function maybeNumber(val: unknown): unknown {
   if (typeof val === "string" && /^\d+$/.test(val)) return parseInt(val, 10);

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.949",
+  "version": "0.1.950",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -90,6 +90,30 @@ veryfront eval deep-research \
   --json
 ```
 
+Compare candidate models against a baseline model when you want to lower cost
+or latency without weakening quality:
+
+```bash
+veryfront eval deep-research \
+  --baseline-model anthropic/claude-sonnet-4-6 \
+  --candidate-model moonshotai/kimi-k2 \
+  --report-dir .veryfront/evals/deep-research-models \
+  --json
+```
+
+Model comparison runs the same eval once per model. It writes one report per
+model under `models/<model-id>/`, plus `comparison.json` and `comparison.md` at
+the report root. `comparison.json` keeps `baselineModel` and `candidateModels`
+separate, then includes `models[]` for the per-model metric summaries. The
+recommendation is conservative: a candidate is promoted only when it has no
+failed runs, introduces no newly failed examples, satisfies the groundedness
+threshold when measured, and improves cost, token use, or p95 latency. Otherwise
+the comparison keeps the baseline or asks for review.
+
+Each report includes provenance metadata. Local runs record git SHA, branch,
+dirty state, and a dirty hash. Cloud runs prefer release, deployment, or preview
+identity when those values are present.
+
 ## Datasets
 
 Use inline data for smoke coverage:

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -49,6 +49,8 @@ export { judges } from "./judges.ts";
 export { metrics } from "./metrics.ts";
 export { createEvalReport, summarizeEvalRecords } from "./report.ts";
 export { compareEvalReports } from "./baseline.ts";
+export { compareEvalModelReports, createEvalModelComparisonMarkdown } from "./model-comparison.ts";
+export { createEvalRunProvenance, resolveEvalRunProvenance } from "./provenance.ts";
 export { runEval } from "./runner.ts";
 export { deriveEvalId, discoverEvals, findEvalById } from "./discovery.ts";
 export {
@@ -92,11 +94,18 @@ export type {
   EvalMetricResult,
   EvalMetricSummary,
   EvalMetricThreshold,
+  EvalModelCandidateComparison,
+  EvalModelComparison,
+  EvalModelComparisonDecision,
+  EvalModelComparisonOptions,
+  EvalModelReportSummary,
   EvalRecord,
   EvalReport,
   EvalReportComparison,
   EvalReportExportConfig,
+  EvalReportMetadata,
   EvalReportSummary,
+  EvalRunProvenance,
   EvalSeverity,
   EvalSource,
   EvalTargetKind,

--- a/src/eval/model-comparison.test.ts
+++ b/src/eval/model-comparison.test.ts
@@ -1,0 +1,211 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { EvalReport } from "veryfront/eval";
+import { compareEvalModelReports, createEvalModelComparisonMarkdown } from "./model-comparison.ts";
+
+function createReport(
+  model: string,
+  overrides: {
+    runId?: string;
+    passed?: number;
+    failed?: number;
+    totalTokens?: number;
+    costUsd?: number;
+    p95Ms?: number;
+    groundednessScore?: number;
+    measureGroundedness?: boolean;
+    failedExamples?: string[];
+  } = {},
+): EvalReport {
+  const measureGroundedness = overrides.measureGroundedness ?? true;
+  const records = (overrides.failedExamples ?? []).map((exampleId) => ({
+    id: `${exampleId}:1`,
+    evalId: "eval:support",
+    exampleId,
+    repetition: 1,
+    input: "question",
+    output: { text: "answer" },
+    metadata: {},
+    trace: { events: [], toolCalls: [] },
+    usage: {},
+    durationMs: 100,
+    completed: true,
+    metrics: measureGroundedness
+      ? [
+        {
+          name: "answer.groundedness",
+          family: "answer" as const,
+          severity: "gate" as const,
+          score: overrides.groundednessScore ?? 1,
+          pass: (overrides.groundednessScore ?? 1) >= 0.8,
+        },
+      ]
+      : [],
+  }));
+  const passed = overrides.passed ?? 4;
+  const failed = overrides.failed ?? 0;
+  return {
+    kind: "eval-report",
+    runId: overrides.runId ?? `evalrun_${model.replaceAll("/", "_")}`,
+    definitionId: "eval:support",
+    targetKind: "agent",
+    target: "agent:support",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    endedAt: "2026-01-01T00:00:01.000Z",
+    metadata: { model },
+    summary: {
+      records: passed + failed,
+      passed,
+      failed,
+      passRate: passed / (passed + failed),
+      metrics: measureGroundedness
+        ? [
+          {
+            name: "answer.groundedness",
+            family: "answer",
+            severity: "gate",
+            passed,
+            failed,
+            skipped: 0,
+            passRate: failed === 0 ? 1 : passed / (passed + failed),
+          },
+        ]
+        : [],
+      duration: {
+        totalMs: (passed + failed) * 100,
+        minMs: 80,
+        maxMs: overrides.p95Ms ?? 100,
+        meanMs: 100,
+        p50Ms: 95,
+        p95Ms: overrides.p95Ms ?? 100,
+      },
+      usage: {
+        totalTokens: overrides.totalTokens,
+        costUsd: overrides.costUsd,
+      },
+      gateFailures: failed === 0 ? [] : [
+        {
+          recordId: `${overrides.failedExamples?.[0] ?? "q1"}:1`,
+          exampleId: overrides.failedExamples?.[0] ?? "q1",
+          repetition: 1,
+          name: "answer.groundedness",
+          family: "answer",
+          severity: "gate",
+        },
+      ],
+      failedExamples: (overrides.failedExamples ?? []).map((exampleId) => ({
+        exampleId,
+        records: 1,
+        passed: 0,
+        failed: 1,
+        passRate: 0,
+        flaky: false,
+      })),
+    },
+    records,
+  };
+}
+
+describe("eval/model-comparison", () => {
+  it("recommends promotion when the candidate preserves quality and has a cheaper signal", () => {
+    const comparison = compareEvalModelReports(
+      [
+        createReport("anthropic/claude-opus-4-6", { totalTokens: 10_000, costUsd: 1 }),
+        createReport("moonshotai/kimi-k2", { totalTokens: 9_000, costUsd: 0.5 }),
+      ],
+      { baselineModel: "anthropic/claude-opus-4-6" },
+    );
+
+    assertEquals(comparison.baselineModel, "anthropic/claude-opus-4-6");
+    assertEquals(comparison.candidateModels, ["moonshotai/kimi-k2"]);
+    assertEquals(comparison.recommendation, {
+      decision: "promote-candidate",
+      model: "moonshotai/kimi-k2",
+      reasons: [
+        "candidate has no quality regressions",
+        "groundedness is at or above 0.8",
+        "cost improved by 50%",
+      ],
+    });
+  });
+
+  it("keeps the baseline when a cheaper candidate introduces new failed examples", () => {
+    const comparison = compareEvalModelReports(
+      [
+        createReport("anthropic/claude-opus-4-6", { totalTokens: 10_000, costUsd: 1 }),
+        createReport("moonshotai/kimi-k2", {
+          passed: 3,
+          failed: 1,
+          totalTokens: 7_500,
+          costUsd: 0.4,
+          failedExamples: ["refund-escalation"],
+        }),
+      ],
+      { baselineModel: "anthropic/claude-opus-4-6" },
+    );
+
+    assertEquals(comparison.recommendation.decision, "keep-baseline");
+    assertEquals(comparison.candidates[0]?.newFailedExamples, ["refund-escalation"]);
+  });
+
+  it("promotes cheaper candidates when deterministic evals do not measure groundedness", () => {
+    const comparison = compareEvalModelReports(
+      [
+        createReport("anthropic/claude-opus-4-6", {
+          measureGroundedness: false,
+          totalTokens: 10_000,
+          costUsd: 1,
+        }),
+        createReport("moonshotai/kimi-k2", {
+          measureGroundedness: false,
+          totalTokens: 9_000,
+          costUsd: 0.5,
+        }),
+      ],
+      { baselineModel: "anthropic/claude-opus-4-6" },
+    );
+
+    assertEquals(comparison.recommendation, {
+      decision: "promote-candidate",
+      model: "moonshotai/kimi-k2",
+      reasons: [
+        "candidate has no quality regressions",
+        "groundedness was not measured",
+        "cost improved by 50%",
+      ],
+    });
+  });
+
+  it("asks for review when quality passes but no efficiency signal is measurable", () => {
+    const comparison = compareEvalModelReports(
+      [
+        createReport("anthropic/claude-opus-4-6"),
+        createReport("moonshotai/kimi-k2"),
+      ],
+      { baselineModel: "anthropic/claude-opus-4-6" },
+    );
+
+    assertEquals(comparison.recommendation.decision, "needs-review");
+    assertEquals(comparison.recommendation.reasons, [
+      "candidate has no quality regressions",
+      "groundedness is at or above 0.8",
+      "no cost, token, or latency improvement could be measured",
+    ]);
+  });
+
+  it("renders a compact markdown report", () => {
+    const comparison = compareEvalModelReports(
+      [
+        createReport("anthropic/claude-opus-4-6", { totalTokens: 10_000, costUsd: 1 }),
+        createReport("moonshotai/kimi-k2", { totalTokens: 9_000, costUsd: 0.5 }),
+      ],
+      { baselineModel: "anthropic/claude-opus-4-6" },
+    );
+
+    assertEquals(
+      createEvalModelComparisonMarkdown(comparison).includes("| moonshotai/kimi-k2 | candidate |"),
+      true,
+    );
+  });
+});

--- a/src/eval/model-comparison.ts
+++ b/src/eval/model-comparison.ts
@@ -1,0 +1,292 @@
+import { compareEvalReports } from "./baseline.ts";
+import type {
+  EvalMetricResult,
+  EvalModelCandidateComparison,
+  EvalModelComparison,
+  EvalModelComparisonOptions,
+  EvalModelReportSummary,
+  EvalReport,
+} from "./types.ts";
+
+const DEFAULT_MIN_GROUNDEDNESS = 0.8;
+const DEFAULT_MIN_EFFICIENCY_IMPROVEMENT = 0.1;
+
+function reportModel(report: EvalReport): string {
+  return report.metadata?.model ?? report.runId;
+}
+
+function failedExampleIds(report: EvalReport): string[] {
+  return (report.summary.failedExamples ?? []).map((example) => example.exampleId).sort();
+}
+
+function allMetricResults(report: EvalReport): EvalMetricResult[] {
+  return report.records.flatMap((record) => [...(record.metrics ?? []), ...(record.checks ?? [])]);
+}
+
+function average(values: number[]): number | undefined {
+  if (values.length === 0) return undefined;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function metricPassRate(report: EvalReport, metricName: string): number | undefined {
+  return report.summary.metrics.find((metric) => metric.name === metricName)?.passRate;
+}
+
+function groundednessScore(report: EvalReport): number | undefined {
+  return average(
+    allMetricResults(report)
+      .filter((result) => result.name === "answer.groundedness" && result.score !== undefined)
+      .map((result) => result.score!),
+  ) ?? metricPassRate(report, "answer.groundedness");
+}
+
+function improvementPct(
+  baseline: number | undefined,
+  candidate: number | undefined,
+): number | undefined {
+  if (baseline === undefined || candidate === undefined || baseline <= 0) return undefined;
+  return (baseline - candidate) / baseline;
+}
+
+function meetsImprovement(value: number | undefined, threshold: number): boolean {
+  return value !== undefined && value >= threshold;
+}
+
+function formatPct(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function modelSummary(
+  report: EvalReport,
+  baselineModel: string,
+): EvalModelReportSummary {
+  const model = reportModel(report);
+  const groundedness = groundednessScore(report);
+  return {
+    model,
+    role: model === baselineModel ? "baseline" : "candidate",
+    runId: report.runId,
+    passed: report.summary.passed,
+    failed: report.summary.failed,
+    passRate: report.summary.passRate,
+    failedExamples: failedExampleIds(report),
+    gateFailures: report.summary.gateFailures?.length ?? 0,
+    ...(report.summary.usage?.totalTokens !== undefined
+      ? { totalTokens: report.summary.usage.totalTokens }
+      : {}),
+    ...(report.summary.usage?.costUsd !== undefined
+      ? { costUsd: report.summary.usage.costUsd }
+      : {}),
+    ...(report.summary.duration?.p95Ms !== undefined
+      ? { p95Ms: report.summary.duration.p95Ms }
+      : {}),
+    ...(groundedness !== undefined ? { groundednessScore: groundedness } : {}),
+  };
+}
+
+function createCandidateDecision(input: {
+  candidate: EvalReport;
+  baseline: EvalReport;
+  options: Required<EvalModelComparisonOptions>;
+}): Pick<EvalModelCandidateComparison, "decision" | "reasons"> {
+  const baselineModel = input.options.baselineModel;
+  const baselineSummary = modelSummary(input.baseline, baselineModel);
+  const candidateSummary = modelSummary(input.candidate, baselineModel);
+  const baselineComparison = compareEvalReports(input.candidate, input.baseline);
+  const reasons: string[] = [];
+
+  if (
+    input.candidate.summary.failed > 0 || baselineComparison.regressed ||
+    baselineComparison.newFailedExamples.length > 0
+  ) {
+    reasons.push("candidate has quality regressions");
+    if (baselineComparison.newFailedExamples.length > 0) {
+      reasons.push(`new failed examples: ${baselineComparison.newFailedExamples.join(", ")}`);
+    }
+    return { decision: "keep-baseline", reasons };
+  }
+
+  reasons.push("candidate has no quality regressions");
+
+  if (
+    candidateSummary.groundednessScore !== undefined &&
+    candidateSummary.groundednessScore < input.options.minGroundedness
+  ) {
+    reasons.push(`groundedness is below ${input.options.minGroundedness}`);
+    return { decision: "keep-baseline", reasons };
+  }
+
+  if (candidateSummary.groundednessScore === undefined) {
+    reasons.push("groundedness was not measured");
+  } else {
+    reasons.push(`groundedness is at or above ${input.options.minGroundedness}`);
+  }
+
+  const costImprovement = improvementPct(baselineSummary.costUsd, candidateSummary.costUsd);
+  const tokenImprovement = improvementPct(
+    baselineSummary.totalTokens,
+    candidateSummary.totalTokens,
+  );
+  const latencyImprovement = improvementPct(baselineSummary.p95Ms, candidateSummary.p95Ms);
+
+  if (meetsImprovement(costImprovement, input.options.minCostImprovementPct)) {
+    reasons.push(`cost improved by ${formatPct(costImprovement!)}`);
+    return { decision: "promote-candidate", reasons };
+  }
+  if (meetsImprovement(tokenImprovement, input.options.minTokenImprovementPct)) {
+    reasons.push(`tokens improved by ${formatPct(tokenImprovement!)}`);
+    return { decision: "promote-candidate", reasons };
+  }
+  if (meetsImprovement(latencyImprovement, input.options.minLatencyImprovementPct)) {
+    reasons.push(`p95 latency improved by ${formatPct(latencyImprovement!)}`);
+    return { decision: "promote-candidate", reasons };
+  }
+
+  reasons.push("no cost, token, or latency improvement could be measured");
+  return { decision: "needs-review", reasons };
+}
+
+function compareCandidate(
+  candidate: EvalReport,
+  baseline: EvalReport,
+  options: Required<EvalModelComparisonOptions>,
+): EvalModelCandidateComparison {
+  const baselineComparison = compareEvalReports(candidate, baseline);
+  const candidateSummary = modelSummary(candidate, options.baselineModel);
+  const baselineSummary = modelSummary(baseline, options.baselineModel);
+  const decision = createCandidateDecision({ candidate, baseline, options });
+  const costImprovement = improvementPct(baselineSummary.costUsd, candidateSummary.costUsd);
+  const tokenImprovement = improvementPct(
+    baselineSummary.totalTokens,
+    candidateSummary.totalTokens,
+  );
+  const latencyImprovement = improvementPct(baselineSummary.p95Ms, candidateSummary.p95Ms);
+
+  return {
+    model: reportModel(candidate),
+    baselineModel: options.baselineModel,
+    passRateDelta: baselineComparison.passRateDelta,
+    failedDelta: baselineComparison.failedDelta,
+    newFailedExamples: baselineComparison.newFailedExamples,
+    ...(candidateSummary.groundednessScore !== undefined
+      ? { groundednessScore: candidateSummary.groundednessScore }
+      : {}),
+    ...(costImprovement !== undefined ? { costImprovementPct: costImprovement } : {}),
+    ...(tokenImprovement !== undefined ? { tokenImprovementPct: tokenImprovement } : {}),
+    ...(latencyImprovement !== undefined ? { latencyImprovementPct: latencyImprovement } : {}),
+    decision: decision.decision,
+    reasons: decision.reasons,
+  };
+}
+
+function pickRecommendation(
+  candidates: EvalModelCandidateComparison[],
+): EvalModelComparison["recommendation"] {
+  const promotable = candidates.find((candidate) => candidate.decision === "promote-candidate");
+  if (promotable) {
+    return {
+      decision: "promote-candidate",
+      model: promotable.model,
+      reasons: promotable.reasons,
+    };
+  }
+
+  const needsReview = candidates.find((candidate) => candidate.decision === "needs-review");
+  if (needsReview) {
+    return {
+      decision: "needs-review",
+      model: needsReview.model,
+      reasons: needsReview.reasons,
+    };
+  }
+
+  const firstCandidate = candidates[0];
+  return {
+    decision: "keep-baseline",
+    ...(firstCandidate ? { model: firstCandidate.model } : {}),
+    reasons: firstCandidate?.reasons ?? ["no candidate models were compared"],
+  };
+}
+
+function normalizeOptions(
+  options: EvalModelComparisonOptions,
+): Required<EvalModelComparisonOptions> {
+  return {
+    baselineModel: options.baselineModel,
+    minGroundedness: options.minGroundedness ?? DEFAULT_MIN_GROUNDEDNESS,
+    minCostImprovementPct: options.minCostImprovementPct ?? DEFAULT_MIN_EFFICIENCY_IMPROVEMENT,
+    minTokenImprovementPct: options.minTokenImprovementPct ?? DEFAULT_MIN_EFFICIENCY_IMPROVEMENT,
+    minLatencyImprovementPct: options.minLatencyImprovementPct ??
+      DEFAULT_MIN_EFFICIENCY_IMPROVEMENT,
+  };
+}
+
+/** Compare eval reports from multiple models using conservative promotion rules. */
+export function compareEvalModelReports(
+  reports: EvalReport[],
+  options: EvalModelComparisonOptions,
+): EvalModelComparison {
+  const normalized = normalizeOptions(options);
+  const baseline = reports.find((report) => reportModel(report) === normalized.baselineModel);
+  if (!baseline) {
+    throw new Error(
+      `Baseline model "${normalized.baselineModel}" was not present in eval reports.`,
+    );
+  }
+
+  const candidates = reports
+    .filter((report) => reportModel(report) !== normalized.baselineModel)
+    .map((report) => compareCandidate(report, baseline, normalized));
+
+  return {
+    kind: "eval-model-comparison",
+    baselineModel: normalized.baselineModel,
+    candidateModels: candidates.map((candidate) => candidate.model),
+    models: reports.map((report) => modelSummary(report, normalized.baselineModel)),
+    candidates,
+    recommendation: pickRecommendation(candidates),
+  };
+}
+
+function numberCell(value: number | undefined): string {
+  return value === undefined ? "-" : String(Math.round(value));
+}
+
+function decimalCell(value: number | undefined): string {
+  return value === undefined ? "-" : value.toFixed(2);
+}
+
+/** Render a human-reviewable markdown summary for a model comparison report. */
+export function createEvalModelComparisonMarkdown(comparison: EvalModelComparison): string {
+  const lines = [
+    "# Eval Model Comparison",
+    "",
+    `Baseline: ${comparison.baselineModel}`,
+    `Candidates: ${comparison.candidateModels.join(", ") || "-"}`,
+    `Recommendation: ${comparison.recommendation.decision}${
+      comparison.recommendation.model ? ` (${comparison.recommendation.model})` : ""
+    }`,
+    "",
+    "## Models",
+    "",
+    "| Model | Role | Passed | Failed | Pass rate | Groundedness | Tokens | Cost USD | p95 ms |",
+    "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+  ];
+
+  for (const model of comparison.models) {
+    lines.push(
+      `| ${model.model} | ${model.role} | ${model.passed} | ${model.failed} | ${
+        Math.round(model.passRate * 100)
+      }% | ${decimalCell(model.groundednessScore)} | ${numberCell(model.totalTokens)} | ${
+        decimalCell(model.costUsd)
+      } | ${numberCell(model.p95Ms)} |`,
+    );
+  }
+
+  lines.push("", "## Decision", "");
+  for (const reason of comparison.recommendation.reasons) {
+    lines.push(`- ${reason}`);
+  }
+  lines.push("");
+  return `${lines.join("\n")}`;
+}

--- a/src/eval/provenance.test.ts
+++ b/src/eval/provenance.test.ts
@@ -1,0 +1,107 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createEvalRunProvenance, resolveEvalRunProvenance } from "./provenance.ts";
+
+describe("eval/provenance", () => {
+  it("prefers release provenance when Cloud release env is present", () => {
+    assertEquals(
+      createEvalRunProvenance({
+        env: {
+          TENANT_PROJECT_ID: "project-1",
+          TENANT_PROJECT_SLUG: "support-agent",
+          TENANT_RELEASE_ID: "release-1",
+          TENANT_BRANCH_ID: "branch-1",
+        },
+        git: { sha: "abc", branch: "main", dirty: false },
+        frameworkVersion: "0.1.950",
+      }),
+      {
+        kind: "eval-run-provenance",
+        environment: "cloud",
+        source: { kind: "release", id: "release-1" },
+        frameworkVersion: "0.1.950",
+        cloud: {
+          projectId: "project-1",
+          projectSlug: "support-agent",
+          releaseId: "release-1",
+          branchId: "branch-1",
+        },
+        git: { sha: "abc", branch: "main", dirty: false },
+      },
+    );
+  });
+
+  it("uses preview branch provenance when no release exists", () => {
+    assertEquals(
+      createEvalRunProvenance({
+        env: {
+          VERYFRONT_PROJECT_ID: "project-1",
+          VERYFRONT_PROJECT_SLUG: "support-agent",
+          VERYFRONT_BRANCH_REF: "main",
+        },
+      }).source,
+      { kind: "preview", id: "main" },
+    );
+  });
+
+  it("captures local git provenance without failing when git commands work", async () => {
+    const commands: string[][] = [];
+    const provenance = await resolveEvalRunProvenance({
+      projectDir: "/repo",
+      env: {},
+      commandRunner: async (command, args) => {
+        commands.push([command, ...args]);
+        if (args.join(" ") === "rev-parse HEAD") return { code: 0, stdout: "abc123\n" };
+        if (args.join(" ") === "rev-parse --abbrev-ref HEAD") return { code: 0, stdout: "main\n" };
+        if (args.join(" ") === "status --porcelain=v1") {
+          return { code: 0, stdout: " M src/file.ts\n?? notes.md\n" };
+        }
+        if (args.join(" ") === "diff --binary HEAD --") return { code: 0, stdout: "diff" };
+        if (args.join(" ") === "ls-files --others --exclude-standard -z") {
+          return { code: 0, stdout: "notes.md\0" };
+        }
+        return { code: 1, stdout: "" };
+      },
+      fileReader: async () => new TextEncoder().encode("untracked content"),
+      frameworkVersion: "0.1.950",
+    });
+
+    assertEquals(provenance.environment, "local");
+    assertEquals(provenance.source, { kind: "git", id: "abc123" });
+    assertEquals(provenance.git?.sha, "abc123");
+    assertEquals(provenance.git?.branch, "main");
+    assertEquals(provenance.git?.dirty, true);
+    assertEquals(typeof provenance.git?.dirtyHash, "string");
+    assertEquals(commands.length, 5);
+  });
+
+  it("includes untracked file contents in local dirty hashes", async () => {
+    const commandRunner = async (_command: string, args: string[]) => {
+      if (args.join(" ") === "rev-parse HEAD") return { code: 0, stdout: "abc123\n" };
+      if (args.join(" ") === "rev-parse --abbrev-ref HEAD") return { code: 0, stdout: "main\n" };
+      if (args.join(" ") === "status --porcelain=v1") return { code: 0, stdout: "?? data.json\n" };
+      if (args.join(" ") === "diff --binary HEAD --") return { code: 0, stdout: "" };
+      if (args.join(" ") === "ls-files --others --exclude-standard -z") {
+        return { code: 0, stdout: "data.json\0" };
+      }
+      return { code: 1, stdout: "" };
+    };
+    const first = await resolveEvalRunProvenance({
+      projectDir: "/repo",
+      env: {},
+      commandRunner,
+      fileReader: async () => new TextEncoder().encode("alpha"),
+      frameworkVersion: "0.1.950",
+    });
+    const second = await resolveEvalRunProvenance({
+      projectDir: "/repo",
+      env: {},
+      commandRunner,
+      fileReader: async () => new TextEncoder().encode("beta"),
+      frameworkVersion: "0.1.950",
+    });
+
+    assertNotEquals(first.git?.dirtyHash, second.git?.dirtyHash);
+  });
+});

--- a/src/eval/provenance.ts
+++ b/src/eval/provenance.ts
@@ -1,0 +1,271 @@
+import { join } from "@std/path";
+import { VERSION } from "#veryfront/utils/version-constant.ts";
+import type { EvalRunProvenance } from "./types.ts";
+
+type Env = Record<string, string | undefined>;
+
+export type EvalGitProvenance = NonNullable<EvalRunProvenance["git"]>;
+
+export type EvalCommandResult = {
+  code: number;
+  stdout: string;
+  stderr?: string;
+};
+
+export type EvalCommandRunner = (
+  command: string,
+  args: string[],
+  options: { cwd: string },
+) => Promise<EvalCommandResult>;
+
+export type EvalFileReader = (path: string) => Promise<Uint8Array>;
+
+export interface CreateEvalRunProvenanceOptions {
+  env?: Env;
+  git?: EvalGitProvenance;
+  frameworkVersion?: string;
+}
+
+export interface ResolveEvalRunProvenanceOptions extends CreateEvalRunProvenanceOptions {
+  projectDir?: string;
+  commandRunner?: EvalCommandRunner;
+  fileReader?: EvalFileReader;
+}
+
+function firstValue(env: Env, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = env[key];
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
+  return undefined;
+}
+
+function collectEnv(): Env {
+  return {
+    AG_UI_EVAL_BRANCH_ID: Deno.env.get("AG_UI_EVAL_BRANCH_ID"),
+    AG_UI_EVAL_PROJECT_ID: Deno.env.get("AG_UI_EVAL_PROJECT_ID"),
+    AG_UI_EVAL_PROJECT_SLUG: Deno.env.get("AG_UI_EVAL_PROJECT_SLUG"),
+    AG_UI_EVAL_RELEASE_ID: Deno.env.get("AG_UI_EVAL_RELEASE_ID"),
+    CI: Deno.env.get("CI"),
+    GITHUB_ACTIONS: Deno.env.get("GITHUB_ACTIONS"),
+    GITHUB_REF_NAME: Deno.env.get("GITHUB_REF_NAME"),
+    GITHUB_SHA: Deno.env.get("GITHUB_SHA"),
+    TENANT_BRANCH_ID: Deno.env.get("TENANT_BRANCH_ID"),
+    TENANT_DEPLOYMENT_ID: Deno.env.get("TENANT_DEPLOYMENT_ID"),
+    TENANT_ENVIRONMENT: Deno.env.get("TENANT_ENVIRONMENT"),
+    TENANT_PROJECT_ID: Deno.env.get("TENANT_PROJECT_ID"),
+    TENANT_PROJECT_SLUG: Deno.env.get("TENANT_PROJECT_SLUG"),
+    TENANT_RELEASE_ID: Deno.env.get("TENANT_RELEASE_ID"),
+    VERCEL_ENV: Deno.env.get("VERCEL_ENV"),
+    VERYFRONT_BRANCH_REF: Deno.env.get("VERYFRONT_BRANCH_REF"),
+    VERYFRONT_DEPLOYMENT_ID: Deno.env.get("VERYFRONT_DEPLOYMENT_ID"),
+    VERYFRONT_ENVIRONMENT: Deno.env.get("VERYFRONT_ENVIRONMENT"),
+    VERYFRONT_PROJECT_ID: Deno.env.get("VERYFRONT_PROJECT_ID"),
+    VERYFRONT_PROJECT_SLUG: Deno.env.get("VERYFRONT_PROJECT_SLUG"),
+    VERYFRONT_RELEASE_ID: Deno.env.get("VERYFRONT_RELEASE_ID"),
+  };
+}
+
+function createCloudProvenance(env: Env): EvalRunProvenance["cloud"] | undefined {
+  const entries = Object.entries({
+    projectId: firstValue(env, [
+      "TENANT_PROJECT_ID",
+      "VERYFRONT_PROJECT_ID",
+      "AG_UI_EVAL_PROJECT_ID",
+    ]),
+    projectSlug: firstValue(env, [
+      "TENANT_PROJECT_SLUG",
+      "VERYFRONT_PROJECT_SLUG",
+      "AG_UI_EVAL_PROJECT_SLUG",
+    ]),
+    releaseId: firstValue(env, [
+      "TENANT_RELEASE_ID",
+      "VERYFRONT_RELEASE_ID",
+      "AG_UI_EVAL_RELEASE_ID",
+    ]),
+    deploymentId: firstValue(env, ["TENANT_DEPLOYMENT_ID", "VERYFRONT_DEPLOYMENT_ID"]),
+    branchId: firstValue(env, ["TENANT_BRANCH_ID", "AG_UI_EVAL_BRANCH_ID"]),
+    branchRef: firstValue(env, ["VERYFRONT_BRANCH_REF", "GITHUB_REF_NAME"]),
+    environment: firstValue(env, ["VERYFRONT_ENVIRONMENT", "TENANT_ENVIRONMENT", "VERCEL_ENV"]),
+  }).filter((entry): entry is [keyof NonNullable<EvalRunProvenance["cloud"]>, string] =>
+    entry[1] !== undefined
+  );
+
+  return entries.length > 0
+    ? Object.fromEntries(entries) as NonNullable<EvalRunProvenance["cloud"]>
+    : undefined;
+}
+
+function createSource(
+  cloud: EvalRunProvenance["cloud"] | undefined,
+  git: EvalGitProvenance | undefined,
+): EvalRunProvenance["source"] {
+  if (cloud?.releaseId) return { kind: "release", id: cloud.releaseId };
+  if (cloud?.deploymentId) return { kind: "deployment", id: cloud.deploymentId };
+  if (cloud?.branchId) return { kind: "preview", id: cloud.branchId };
+  if (cloud?.branchRef) return { kind: "preview", id: cloud.branchRef };
+  if (git?.sha) return { kind: "git", id: git.sha };
+  if (cloud?.projectId || cloud?.projectSlug) {
+    return { kind: "workspace", id: cloud.projectSlug ?? cloud.projectId };
+  }
+  return { kind: "unknown" };
+}
+
+function createEnvironment(
+  env: Env,
+  cloud: EvalRunProvenance["cloud"] | undefined,
+  git: EvalGitProvenance | undefined,
+): EvalRunProvenance["environment"] {
+  if (
+    cloud?.releaseId || cloud?.deploymentId || cloud?.branchId || cloud?.projectId ||
+    cloud?.projectSlug
+  ) {
+    return "cloud";
+  }
+  if (env.GITHUB_ACTIONS === "true" || env.CI === "true") return "ci";
+  if (git?.sha || git?.branch) return "local";
+  return "unknown";
+}
+
+/** Build stable provenance metadata from explicit git/cloud inputs. */
+export function createEvalRunProvenance(
+  options: CreateEvalRunProvenanceOptions = {},
+): EvalRunProvenance {
+  const env = options.env ?? collectEnv();
+  const ciGit = firstValue(env, ["GITHUB_SHA"]);
+  const git = options.git ?? (ciGit
+    ? {
+      sha: ciGit,
+      branch: firstValue(env, ["GITHUB_REF_NAME"]),
+    }
+    : undefined);
+  const cloud = createCloudProvenance(env);
+
+  return {
+    kind: "eval-run-provenance",
+    environment: createEnvironment(env, cloud, git),
+    source: createSource(cloud, git),
+    frameworkVersion: options.frameworkVersion ?? VERSION,
+    ...(git ? { git } : {}),
+    ...(cloud ? { cloud } : {}),
+  };
+}
+
+async function defaultCommandRunner(
+  command: string,
+  args: string[],
+  options: { cwd: string },
+): Promise<EvalCommandResult> {
+  const result = await new Deno.Command(command, {
+    args,
+    cwd: options.cwd,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  const decoder = new TextDecoder();
+  return {
+    code: result.code,
+    stdout: decoder.decode(result.stdout),
+    stderr: decoder.decode(result.stderr),
+  };
+}
+
+async function runGit(
+  runner: EvalCommandRunner,
+  projectDir: string,
+  args: string[],
+  options: { trim?: boolean } = {},
+): Promise<string | undefined> {
+  try {
+    const result = await runner("git", args, { cwd: projectDir });
+    if (result.code !== 0) return undefined;
+    return options.trim === false ? result.stdout : result.stdout.trim();
+  } catch {
+    return undefined;
+  }
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  return sha256Bytes(new TextEncoder().encode(value));
+}
+
+async function sha256Bytes(value: Uint8Array): Promise<string> {
+  const bytes = new Uint8Array(value.byteLength);
+  bytes.set(value);
+  const hash = await crypto.subtle.digest("SHA-256", bytes.buffer);
+  return Array.from(new Uint8Array(hash))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function parseNullSeparated(value: string | undefined): string[] {
+  if (!value) return [];
+  return value.split("\0").filter(Boolean).sort();
+}
+
+async function hashUntrackedFiles(
+  projectDir: string,
+  paths: string[],
+  readFile: EvalFileReader,
+): Promise<string> {
+  const entries: string[] = [];
+  for (const relativePath of paths) {
+    try {
+      const content = await readFile(join(projectDir, relativePath));
+      entries.push(`${relativePath}\0${await sha256Bytes(content)}`);
+    } catch {
+      entries.push(`${relativePath}\0unreadable`);
+    }
+  }
+  return entries.join("\0");
+}
+
+async function resolveGitProvenance(
+  projectDir: string,
+  runner: EvalCommandRunner,
+  readFile: EvalFileReader,
+): Promise<EvalGitProvenance | undefined> {
+  const sha = await runGit(runner, projectDir, ["rev-parse", "HEAD"]);
+  const branch = await runGit(runner, projectDir, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  const status = await runGit(runner, projectDir, ["status", "--porcelain=v1"]);
+  const diff = await runGit(runner, projectDir, ["diff", "--binary", "HEAD", "--"]);
+  const untracked = await runGit(runner, projectDir, [
+    "ls-files",
+    "--others",
+    "--exclude-standard",
+    "-z",
+  ], { trim: false });
+  const dirty = status !== undefined ? status.length > 0 : undefined;
+
+  if (!sha && !branch && dirty === undefined) return undefined;
+
+  const untrackedHashInput = await hashUntrackedFiles(
+    projectDir,
+    parseNullSeparated(untracked),
+    readFile,
+  );
+
+  return {
+    ...(sha ? { sha } : {}),
+    ...(branch ? { branch } : {}),
+    ...(dirty !== undefined ? { dirty } : {}),
+    ...(dirty
+      ? { dirtyHash: await sha256Hex(`${status ?? ""}\n${diff ?? ""}\n${untrackedHashInput}`) }
+      : {}),
+  };
+}
+
+/** Resolve local or Cloud provenance for an eval run without failing the eval if git metadata is unavailable. */
+export async function resolveEvalRunProvenance(
+  options: ResolveEvalRunProvenanceOptions = {},
+): Promise<EvalRunProvenance> {
+  const projectDir = options.projectDir ?? Deno.cwd();
+  const runner = options.commandRunner ?? defaultCommandRunner;
+  const readFile = options.fileReader ?? Deno.readFile;
+  const git = options.git ?? await resolveGitProvenance(projectDir, runner, readFile);
+  return createEvalRunProvenance({
+    env: options.env,
+    git,
+    frameworkVersion: options.frameworkVersion,
+  });
+}

--- a/src/eval/report.ts
+++ b/src/eval/report.ts
@@ -8,6 +8,7 @@ import type {
   EvalMetricSummary,
   EvalRecord,
   EvalReport,
+  EvalReportMetadata,
   EvalReportSummary,
   EvalUsageSummary,
 } from "./types.ts";
@@ -222,6 +223,7 @@ export function createEvalReport(input: {
   runId: string;
   startedAt: Date;
   endedAt: Date;
+  metadata?: EvalReportMetadata;
 }): EvalReport {
   return {
     kind: "eval-report",
@@ -233,5 +235,6 @@ export function createEvalReport(input: {
     endedAt: input.endedAt.toISOString(),
     summary: summarizeEvalRecords(input.records),
     records: input.records,
+    ...(input.metadata ? { metadata: input.metadata } : {}),
   };
 }

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -302,6 +302,7 @@ export async function runEval(
     runId: options.runId ?? createRunId(startedAt),
     startedAt,
     endedAt,
+    metadata: options.metadata,
   });
   emitEvalRuntimeMetrics(report);
   const exports = await exportEvalReport(report, options.export);

--- a/src/eval/types.ts
+++ b/src/eval/types.ts
@@ -292,6 +292,7 @@ export interface RunEvalOptions {
   runId?: string;
   now?: () => Date;
   export?: EvalReportExportConfig;
+  metadata?: EvalReportMetadata;
 }
 
 /** Export configuration for a completed eval report. */
@@ -388,6 +389,98 @@ export interface EvalReportComparison {
   regressed: boolean;
 }
 
+/** Runtime and source identity attached to an eval report. */
+export interface EvalRunProvenance {
+  kind: "eval-run-provenance";
+  environment: "local" | "cloud" | "ci" | "unknown";
+  source: {
+    kind: "git" | "release" | "deployment" | "preview" | "workspace" | "unknown";
+    id?: string;
+  };
+  frameworkVersion?: string;
+  git?: {
+    sha?: string;
+    branch?: string;
+    dirty?: boolean;
+    dirtyHash?: string;
+  };
+  cloud?: {
+    projectId?: string;
+    projectSlug?: string;
+    releaseId?: string;
+    deploymentId?: string;
+    branchId?: string;
+    branchRef?: string;
+    environment?: string;
+  };
+}
+
+/** Additional report metadata that should not affect pass/fail semantics. */
+export interface EvalReportMetadata {
+  model?: string;
+  provenance?: EvalRunProvenance;
+}
+
+/** Per-model row in an eval model comparison report. */
+export interface EvalModelReportSummary {
+  model: string;
+  role: "baseline" | "candidate";
+  runId: string;
+  passed: number;
+  failed: number;
+  passRate: number;
+  failedExamples: string[];
+  gateFailures: number;
+  totalTokens?: number;
+  costUsd?: number;
+  p95Ms?: number;
+  groundednessScore?: number;
+}
+
+/** Candidate-vs-baseline comparison used to decide whether a model is promotable. */
+export interface EvalModelCandidateComparison {
+  model: string;
+  baselineModel: string;
+  passRateDelta: number;
+  failedDelta: number;
+  newFailedExamples: string[];
+  groundednessScore?: number;
+  costImprovementPct?: number;
+  tokenImprovementPct?: number;
+  latencyImprovementPct?: number;
+  decision: EvalModelComparisonDecision;
+  reasons: string[];
+}
+
+/** Conservative model comparison recommendation. */
+export type EvalModelComparisonDecision =
+  | "promote-candidate"
+  | "keep-baseline"
+  | "needs-review";
+
+/** Aggregate report for comparing one baseline model against candidate models. */
+export interface EvalModelComparison {
+  kind: "eval-model-comparison";
+  baselineModel: string;
+  candidateModels: string[];
+  models: EvalModelReportSummary[];
+  candidates: EvalModelCandidateComparison[];
+  recommendation: {
+    decision: EvalModelComparisonDecision;
+    model?: string;
+    reasons: string[];
+  };
+}
+
+/** Promotion thresholds for model comparison. */
+export interface EvalModelComparisonOptions {
+  baselineModel: string;
+  minGroundedness?: number;
+  minCostImprovementPct?: number;
+  minTokenImprovementPct?: number;
+  minLatencyImprovementPct?: number;
+}
+
 /** Aggregate pass/fail summary for one eval report. */
 export interface EvalReportSummary {
   records: number;
@@ -421,4 +514,5 @@ export interface EvalReport {
   summary: EvalReportSummary;
   records: EvalRecord[];
   exports?: EvalReportExportResult[];
+  metadata?: EvalReportMetadata;
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.949";
+export const VERSION = "0.1.950";


### PR DESCRIPTION
## Summary
- add baseline-vs-candidate model comparison reports for `veryfront eval`
- attach model/provenance metadata to eval reports for local and cloud runs
- document the model comparison workflow and artifacts

## Verification
- `deno task verify:quick`
- `deno task docs:validate`
- `deno test --no-check --allow-all cli/shared/args.test.ts cli/commands/eval/command.test.ts src/eval/model-comparison.test.ts src/eval/provenance.test.ts`
- `deno test --no-check --allow-all src/eval/runner.test.ts src/eval/report.test.ts src/eval/baseline.test.ts src/eval/metrics.test.ts`
- `deno check src/eval/index.ts cli/main.ts`