### PR TITLE
Constrain skill file tools to loaded skill capabilities

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.951",
+  "version": "0.1.952",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/agent-runtime-step.test.ts
+++ b/src/agent/runtime/agent-runtime-step.test.ts
@@ -42,6 +42,7 @@ describe("agent/runtime-step", () => {
     const prepared = await prepareAgentRuntimeStep({
       agentId: "agent_1",
       activeSkillPolicy: ["allowed_tool"],
+      activeSkillToolAvailability: undefined,
       allowedRemoteToolNames: ["remote_allowed"],
       config,
       forwardedRemoteToolDefinitions: [toolDefinition("forwarded_remote")],
@@ -97,10 +98,44 @@ describe("agent/runtime-step", () => {
     assertEquals(prepared.tools.map((tool) => tool.name), ["allowed_tool"]);
   });
 
+  it("passes active skill state to tool execution context", async () => {
+    const prepared = await prepareAgentRuntimeStep({
+      agentId: "agent_1",
+      activeSkillId: "support-escalation",
+      activeSkillPolicy: ["search_knowledge"],
+      activeSkillToolAvailability: {
+        hasActiveSkill: true,
+        references: ["references/guide.md"],
+        scripts: ["scripts/run.sh"],
+      },
+      allowedRemoteToolNames: undefined,
+      config: { model: "auto", system: "Base", tools: true } as AgentConfig,
+      forwardedRemoteToolDefinitions: undefined,
+      isLocalModel: false,
+      messages: [],
+      mode: "stream",
+      remoteToolSources: [],
+      runtimeContext: undefined,
+      step: 1,
+      systemPrompt: "Base",
+      toolContextBase: undefined,
+      getAvailableTools: async () => [toolDefinition("search_knowledge")],
+      resolveRuntimeState: async () => ({ systemPrompt: "Base", context: undefined }),
+    });
+
+    assertEquals(prepared.toolContext.activeSkillId, "support-escalation");
+    assertEquals(prepared.toolContext.activeSkillToolAvailability, {
+      hasActiveSkill: true,
+      references: ["references/guide.md"],
+      scripts: ["scripts/run.sh"],
+    });
+  });
+
   it("skips tool loading for local models", async () => {
     const prepared = await prepareAgentRuntimeStep({
       agentId: "agent_1",
       activeSkillPolicy: undefined,
+      activeSkillToolAvailability: undefined,
       allowedRemoteToolNames: undefined,
       config: { model: "local/test", system: "Local", tools: true } as AgentConfig,
       forwardedRemoteToolDefinitions: undefined,
@@ -138,6 +173,7 @@ describe("agent/runtime-step", () => {
     const prepared = await prepareAgentRuntimeStep({
       agentId: "agent_1",
       activeSkillPolicy: undefined,
+      activeSkillToolAvailability: undefined,
       allowedRemoteToolNames: undefined,
       config: { model: "auto", system: "Base", tools: true, skills: true } as AgentConfig,
       forwardedRemoteToolDefinitions: undefined,
@@ -170,6 +206,7 @@ describe("agent/runtime-step", () => {
     const prepared = await prepareAgentRuntimeStep({
       agentId: "agent_1",
       activeSkillPolicy: undefined,
+      activeSkillToolAvailability: undefined,
       allowedRemoteToolNames: undefined,
       config: { model: "auto", system: "Base", tools: true, skills: true } as AgentConfig,
       forwardedRemoteToolDefinitions: undefined,
@@ -225,6 +262,7 @@ describe("agent/runtime-step", () => {
     const prepared = await prepareAgentRuntimeStep({
       agentId: "agent_1",
       activeSkillPolicy: undefined,
+      activeSkillToolAvailability: undefined,
       allowedRemoteToolNames: undefined,
       config: { model: "auto", system: "Base", tools: true, skills: true } as AgentConfig,
       forwardedRemoteToolDefinitions: undefined,
@@ -249,6 +287,76 @@ describe("agent/runtime-step", () => {
       "form_input",
       "load_skill",
       "invoke_agent",
+    ]);
+  });
+
+  it("hides load_skill_reference when the active skill has no references", async () => {
+    const prepared = await prepareAgentRuntimeStep({
+      agentId: "agent_1",
+      activeSkillPolicy: ["search_knowledge"],
+      activeSkillToolAvailability: {
+        hasActiveSkill: true,
+        references: [],
+        scripts: [],
+      },
+      allowedRemoteToolNames: undefined,
+      config: { model: "auto", system: "Base", tools: true, skills: true } as AgentConfig,
+      forwardedRemoteToolDefinitions: undefined,
+      isLocalModel: false,
+      messages: [],
+      mode: "stream",
+      remoteToolSources: [],
+      runtimeContext: undefined,
+      step: 1,
+      systemPrompt: "Base",
+      toolContextBase: undefined,
+      getAvailableTools: async () => [
+        toolDefinition("search_knowledge"),
+        toolDefinition("load_skill"),
+        toolDefinition("load_skill_reference"),
+        toolDefinition("execute_skill_script"),
+      ],
+      resolveRuntimeState: async () => ({ systemPrompt: "Base", context: undefined }),
+    });
+
+    assertEquals(prepared.tools.map((tool) => tool.name), [
+      "search_knowledge",
+      "load_skill",
+    ]);
+  });
+
+  it("hides skill file tools before any skill is active", async () => {
+    const prepared = await prepareAgentRuntimeStep({
+      agentId: "agent_1",
+      activeSkillPolicy: undefined,
+      activeSkillToolAvailability: {
+        hasActiveSkill: false,
+        references: [],
+        scripts: [],
+      },
+      allowedRemoteToolNames: undefined,
+      config: { model: "auto", system: "Base", tools: true, skills: true } as AgentConfig,
+      forwardedRemoteToolDefinitions: undefined,
+      isLocalModel: false,
+      messages: [],
+      mode: "stream",
+      remoteToolSources: [],
+      runtimeContext: undefined,
+      step: 0,
+      systemPrompt: "Base",
+      toolContextBase: undefined,
+      getAvailableTools: async () => [
+        toolDefinition("read_file"),
+        toolDefinition("load_skill"),
+        toolDefinition("load_skill_reference"),
+        toolDefinition("execute_skill_script"),
+      ],
+      resolveRuntimeState: async () => ({ systemPrompt: "Base", context: undefined }),
+    });
+
+    assertEquals(prepared.tools.map((tool) => tool.name), [
+      "read_file",
+      "load_skill",
     ]);
   });
 });

--- a/src/agent/runtime/agent-runtime-step.ts
+++ b/src/agent/runtime/agent-runtime-step.ts
@@ -1,6 +1,6 @@
 import type { RemoteToolSource, ToolDefinition, ToolExecutionContext } from "#veryfront/tool";
 import type { AgentConfig, Message } from "../types.ts";
-import { filterToolsForSkill } from "#veryfront/skill/allowed-tools.ts";
+import { filterToolsForSkill, type SkillToolAvailability } from "#veryfront/skill/allowed-tools.ts";
 import type { ToolConfigEntry } from "./tool-helpers.ts";
 import { filterToolsAfterSubmittedFormInput } from "./skill-policy-enforcement.ts";
 
@@ -34,7 +34,9 @@ export type RuntimeStepStateResolver = (
 
 export interface PrepareAgentRuntimeStepInput {
   agentId: string;
+  activeSkillId?: string | undefined;
   activeSkillPolicy: string[] | undefined;
+  activeSkillToolAvailability: SkillToolAvailability | undefined;
   allowedRemoteToolNames: string[] | undefined;
   config: AgentConfig;
   forwardedRemoteToolDefinitions: ToolDefinition[] | undefined;
@@ -68,7 +70,13 @@ export async function prepareAgentRuntimeStep(
     input.step,
     input.systemPrompt,
   );
-  const toolContext = { ...input.toolContextBase, ...runtimeState.context };
+  const toolContext: ToolExecutionContext = { ...input.toolContextBase, ...runtimeState.context };
+  if (input.activeSkillId !== undefined) {
+    toolContext.activeSkillId = input.activeSkillId;
+  }
+  if (input.activeSkillToolAvailability !== undefined) {
+    toolContext.activeSkillToolAvailability = input.activeSkillToolAvailability;
+  }
 
   let tools = input.isLocalModel ? [] : await input.getAvailableTools(input.config.tools, {
     callerAgentId: input.agentId,
@@ -79,8 +87,12 @@ export async function prepareAgentRuntimeStep(
     remoteToolContext: toolContext,
   });
 
-  if (input.activeSkillPolicy) {
-    tools = filterToolsForSkill(tools, input.activeSkillPolicy);
+  if (input.activeSkillPolicy || input.activeSkillToolAvailability) {
+    tools = filterToolsForSkill(
+      tools,
+      input.activeSkillPolicy,
+      input.activeSkillToolAvailability,
+    );
   }
   tools = filterToolsAfterSubmittedFormInput(tools, input.messages, runtimeState.context);
 

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -65,9 +65,11 @@ import {
   enforceSkillPolicy,
   extractSkillId,
   extractSkillPolicy,
+  extractSkillToolAvailability,
   FORM_INPUT_TOOL_ID,
   hasSubmittedFormInputResult,
   hydrateActiveSkillStateFromMessages,
+  INACTIVE_SKILL_TOOL_AVAILABILITY,
   LOAD_SKILL_TOOL_ID,
   removeFormInputAfterSubmission,
   SUBMITTED_FORM_INPUT_CONTEXT_KEY,
@@ -551,6 +553,7 @@ export class AgentRuntime {
       const hydratedSkillState = hydrateActiveSkillStateFromMessages(currentMessages);
       let activeSkillId = hydratedSkillState.activeSkillId;
       let activeSkillPolicy = hydratedSkillState.activeSkillPolicy;
+      let activeSkillToolAvailability = hydratedSkillState.activeSkillToolAvailability;
       let activeSkillDelegationOverrides = hydratedSkillState.activeSkillDelegationOverrides;
       let hasSubmittedFormInputInLoop = hasSubmittedFormInputResult(currentMessages) ||
         runtimeContext?.[SUBMITTED_FORM_INPUT_CONTEXT_KEY] === true;
@@ -570,7 +573,9 @@ export class AgentRuntime {
 
         const preparedStep = await prepareAgentRuntimeStep({
           agentId: this.id,
+          activeSkillId,
           activeSkillPolicy,
+          activeSkillToolAvailability,
           allowedRemoteToolNames,
           config: this.config,
           forwardedRemoteToolDefinitions,
@@ -718,6 +723,7 @@ export class AgentRuntime {
               mustLoadSkillFirst,
               {
                 hasSubmittedFormInput: hasSubmittedFormInputInLoop,
+                skillToolAvailability: activeSkillToolAvailability,
               },
             );
             if (!policyCheck.allowed) {
@@ -784,6 +790,8 @@ export class AgentRuntime {
               if (tc.toolName === LOAD_SKILL_TOOL_ID) {
                 activeSkillId = extractSkillId(result);
                 activeSkillPolicy = extractSkillPolicy(result);
+                activeSkillToolAvailability = extractSkillToolAvailability(result) ??
+                  INACTIVE_SKILL_TOOL_AVAILABILITY;
                 activeSkillDelegationOverrides = extractSkillDelegationOverrides(result);
                 mustLoadSkillFirst = false;
               }
@@ -884,6 +892,7 @@ export class AgentRuntime {
     const hydratedSkillState = hydrateActiveSkillStateFromMessages(currentMessages);
     let activeSkillId = hydratedSkillState.activeSkillId;
     let activeSkillPolicy = hydratedSkillState.activeSkillPolicy;
+    let activeSkillToolAvailability = hydratedSkillState.activeSkillToolAvailability;
     let activeSkillDelegationOverrides = hydratedSkillState.activeSkillDelegationOverrides;
     let hasSubmittedFormInputInLoop = hasSubmittedFormInputResult(currentMessages) ||
       runtimeContext?.[SUBMITTED_FORM_INPUT_CONTEXT_KEY] === true;
@@ -907,7 +916,9 @@ export class AgentRuntime {
 
       const preparedStep = await prepareAgentRuntimeStep({
         agentId: this.id,
+        activeSkillId,
         activeSkillPolicy,
+        activeSkillToolAvailability,
         allowedRemoteToolNames,
         config: this.config,
         forwardedRemoteToolDefinitions,
@@ -1132,6 +1143,8 @@ export class AgentRuntime {
             if (tc.name === LOAD_SKILL_TOOL_ID) {
               activeSkillId = extractSkillId(matchingResult.output);
               activeSkillPolicy = extractSkillPolicy(matchingResult.output);
+              activeSkillToolAvailability = extractSkillToolAvailability(matchingResult.output) ??
+                INACTIVE_SKILL_TOOL_AVAILABILITY;
               activeSkillDelegationOverrides = extractSkillDelegationOverrides(
                 matchingResult.output,
               );
@@ -1164,6 +1177,8 @@ export class AgentRuntime {
             if (tc.name === LOAD_SKILL_TOOL_ID) {
               activeSkillId = extractSkillId(persistedResult.result);
               activeSkillPolicy = extractSkillPolicy(persistedResult.result);
+              activeSkillToolAvailability = extractSkillToolAvailability(persistedResult.result) ??
+                INACTIVE_SKILL_TOOL_AVAILABILITY;
               activeSkillDelegationOverrides = extractSkillDelegationOverrides(
                 persistedResult.result,
               );
@@ -1220,6 +1235,7 @@ export class AgentRuntime {
           mustLoadSkillFirst,
           {
             hasSubmittedFormInput: hasSubmittedFormInputInLoop,
+            skillToolAvailability: activeSkillToolAvailability,
           },
         );
         if (!policyCheck.allowed) {
@@ -1279,6 +1295,8 @@ export class AgentRuntime {
           if (tc.name === LOAD_SKILL_TOOL_ID) {
             activeSkillId = extractSkillId(result);
             activeSkillPolicy = extractSkillPolicy(result);
+            activeSkillToolAvailability = extractSkillToolAvailability(result) ??
+              INACTIVE_SKILL_TOOL_AVAILABILITY;
             activeSkillDelegationOverrides = extractSkillDelegationOverrides(result);
             mustLoadSkillFirst = false;
           }

--- a/src/agent/runtime/refresh.test.ts
+++ b/src/agent/runtime/refresh.test.ts
@@ -536,6 +536,97 @@ describe("agent runtime refresh hooks", () => {
     assertEquals(toolNamesByStep[1]?.includes("web_fetch"), true);
   });
 
+  it("keeps skill file tools hidden after a failed load_skill attempt", async () => {
+    const toolNamesByStep: string[][] = [];
+    let callCount = 0;
+    const model: ModelRuntime = {
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "unused" }],
+          finishReason: "stop",
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        };
+      },
+      async doStream(options) {
+        const rawTools = (options as { tools?: unknown }).tools;
+        const toolNames = Array.isArray(rawTools)
+          ? rawTools.map((entry) =>
+            (entry as { name?: string; id?: string }).name ??
+              (entry as { name?: string; id?: string }).id ?? ""
+          )
+          : Object.keys((rawTools as Record<string, unknown> | undefined) ?? {});
+        toolNamesByStep.push(toolNames);
+        callCount++;
+
+        if (callCount === 1) {
+          return {
+            stream: createRuntimeStream([
+              {
+                type: "tool-call",
+                toolCallId: "load-missing-skill",
+                toolName: "load_skill",
+                input: '{"skillId":"missing"}',
+              },
+              {
+                type: "finish",
+                finishReason: "tool-calls",
+                usage: { inputTokens: 1, outputTokens: 1 },
+              },
+            ]),
+          };
+        }
+
+        return {
+          stream: createRuntimeStream([
+            { type: "text-delta", text: "I could not load that skill." },
+            {
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 1, outputTokens: 1 },
+            },
+          ]),
+        };
+      },
+    };
+
+    const loadSkill = tool({
+      id: "load_skill",
+      description: "Load a skill",
+      inputSchema: defineSchema((v) => v.object({ skillId: v.string() }))(),
+      execute: () => ({ error: "Skill not found" }),
+    });
+    const loadSkillReference = tool({
+      id: "load_skill_reference",
+      description: "Load a skill reference",
+      inputSchema: defineSchema((v) => v.object({ skillId: v.string(), reference: v.string() }))(),
+      execute: () => ({ content: "reference" }),
+    });
+
+    const assistant = agent({
+      model: "anthropic/claude-sonnet-4-6",
+      system: "Recover from a missing skill.",
+      tools: {
+        load_skill: loadSkill,
+        load_skill_reference: loadSkillReference,
+      },
+      maxSteps: 3,
+      resolveModelTransport: async () => ({ model }),
+    });
+
+    const response = (await assistant.stream({
+      input: "Load the missing skill",
+    })).toDataStreamResponse();
+
+    await response.text();
+    assertEquals(toolNamesByStep.length, 2);
+    assertEquals(toolNamesByStep[0]?.includes("load_skill"), true);
+    assertEquals(toolNamesByStep[0]?.includes("load_skill_reference"), false);
+    assertEquals(toolNamesByStep[1]?.includes("load_skill"), true);
+    assertEquals(toolNamesByStep[1]?.includes("load_skill_reference"), false);
+  });
+
   it("removes provider-native tools from the forced final response after update_agent", async () => {
     const toolNamesByStep: string[][] = [];
     let callCount = 0;

--- a/src/agent/runtime/skill-policy-enforcement.ts
+++ b/src/agent/runtime/skill-policy-enforcement.ts
@@ -3,6 +3,7 @@ import type { ToolDefinition } from "#veryfront/tool";
 import { serverLogger } from "#veryfront/utils";
 import {
   isToolAllowedBySkill,
+  type SkillToolAvailability,
   validateAllowedToolPatterns,
 } from "#veryfront/skill/allowed-tools.ts";
 import { isToolResultPart } from "./tool-result-continuation.ts";
@@ -17,6 +18,12 @@ export const LOAD_SKILL_TOOL_ID = "load_skill";
 export const FORM_INPUT_TOOL_ID = "form_input";
 export const INVOKE_AGENT_TOOL_ID = "invoke_agent";
 export const SUBMITTED_FORM_INPUT_CONTEXT_KEY = "hasSubmittedFormInputResult";
+
+export const INACTIVE_SKILL_TOOL_AVAILABILITY: SkillToolAvailability = {
+  hasActiveSkill: false,
+  references: [],
+  scripts: [],
+};
 
 const POST_SUBMITTED_FORM_INPUT_BLOCKED_TOOL_IDS = new Set([
   FORM_INPUT_TOOL_ID,
@@ -33,10 +40,12 @@ export function hydrateActiveSkillStateFromMessages(
 ): {
   activeSkillId: string | undefined;
   activeSkillPolicy: string[] | undefined;
+  activeSkillToolAvailability: SkillToolAvailability | undefined;
   activeSkillDelegationOverrides: SkillDelegationOverrides | undefined;
 } {
   let activeSkillId: string | undefined;
   let activeSkillPolicy: string[] | undefined;
+  let activeSkillToolAvailability: SkillToolAvailability = INACTIVE_SKILL_TOOL_AVAILABILITY;
   let activeSkillDelegationOverrides: SkillDelegationOverrides | undefined;
 
   for (const message of messages) {
@@ -44,11 +53,18 @@ export function hydrateActiveSkillStateFromMessages(
       if (!isToolResultPart(part) || part.toolName !== LOAD_SKILL_TOOL_ID) continue;
       activeSkillId = extractSkillId(part.result);
       activeSkillPolicy = extractSkillPolicy(part.result);
+      activeSkillToolAvailability = extractSkillToolAvailability(part.result) ??
+        INACTIVE_SKILL_TOOL_AVAILABILITY;
       activeSkillDelegationOverrides = extractSkillDelegationOverrides(part.result);
     }
   }
 
-  return { activeSkillId, activeSkillPolicy, activeSkillDelegationOverrides };
+  return {
+    activeSkillId,
+    activeSkillPolicy,
+    activeSkillToolAvailability,
+    activeSkillDelegationOverrides,
+  };
 }
 
 export function extractSkillId(result: unknown): string | undefined {
@@ -82,6 +98,34 @@ export function extractSkillPolicy(result: unknown): string[] | undefined {
     );
     return [];
   }
+}
+
+function extractStringArrayField(result: Record<string, unknown>, field: string): string[] {
+  const raw = result[field];
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((value): value is string => typeof value === "string");
+}
+
+export function extractSkillToolAvailability(
+  result: unknown,
+): SkillToolAvailability | undefined {
+  if (!result || typeof result !== "object") return undefined;
+  const skillResult = result as Record<string, unknown>;
+  if (typeof skillResult.error === "string") return undefined;
+
+  const looksLikeLoadedSkill = typeof skillResult.instructions === "string" ||
+    typeof skillResult.skillId === "string" ||
+    "allowedTools" in skillResult ||
+    "references" in skillResult ||
+    "scripts" in skillResult;
+
+  if (!looksLikeLoadedSkill) return undefined;
+
+  return {
+    hasActiveSkill: true,
+    references: extractStringArrayField(skillResult, "references"),
+    scripts: extractStringArrayField(skillResult, "scripts"),
+  };
 }
 
 function parseToolResultJson(result: string): unknown {
@@ -208,6 +252,7 @@ export type SkillPolicyResult =
 
 export type SkillPolicyOptions = {
   hasSubmittedFormInput?: boolean;
+  skillToolAvailability?: SkillToolAvailability;
 };
 
 export function enforceSkillPolicy(
@@ -231,11 +276,13 @@ export function enforceSkillPolicy(
     };
   }
 
-  if (activeSkillPolicy && !isToolAllowedBySkill(toolName, activeSkillPolicy)) {
+  if (
+    !isToolAllowedBySkill(toolName, activeSkillPolicy, options.skillToolAvailability)
+  ) {
     return {
       allowed: false,
       error: `Tool "${toolName}" is not allowed by the active skill policy. Allowed: ${
-        activeSkillPolicy.join(", ")
+        activeSkillPolicy?.join(", ") ?? "none"
       }`,
     };
   }

--- a/src/agent/runtime/skill-policy.test.ts
+++ b/src/agent/runtime/skill-policy.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   enforceSkillPolicy,
   extractSkillPolicy,
+  extractSkillToolAvailability,
   hasSubmittedFormInputResult,
   hydrateActiveSkillStateFromMessages,
   removeFormInputAfterSubmission,
@@ -125,14 +126,54 @@ describe("src/agent/runtime skill policy helpers", () => {
       );
     });
 
-    it("should always allow skill system tools regardless of policy", () => {
+    it("should always allow load_skill regardless of policy", () => {
       assertEquals(enforceSkillPolicy("load_skill", ["Read"], false), { allowed: true });
-      assertEquals(enforceSkillPolicy("load_skill_reference", ["Read"], false), {
-        allowed: true,
+      assertEquals(enforceSkillPolicy("load_skill_reference", ["Read"], false).allowed, false);
+      assertEquals(enforceSkillPolicy("execute_skill_script", ["Read"], false).allowed, false);
+    });
+
+    it("allows load_skill_reference only when the active skill advertised references", () => {
+      assertEquals(
+        enforceSkillPolicy("load_skill_reference", ["Read"], false, {
+          skillToolAvailability: {
+            hasActiveSkill: true,
+            references: ["references/guide.md"],
+            scripts: [],
+          },
+        }),
+        { allowed: true },
+      );
+
+      const result = enforceSkillPolicy("load_skill_reference", ["Read"], false, {
+        skillToolAvailability: {
+          hasActiveSkill: true,
+          references: [],
+          scripts: [],
+        },
       });
-      assertEquals(enforceSkillPolicy("execute_skill_script", ["Read"], false), {
-        allowed: true,
+      assertEquals(result.allowed, false);
+    });
+
+    it("allows execute_skill_script only when the active skill advertised scripts", () => {
+      assertEquals(
+        enforceSkillPolicy("execute_skill_script", ["Read"], false, {
+          skillToolAvailability: {
+            hasActiveSkill: true,
+            references: [],
+            scripts: ["scripts/run.sh"],
+          },
+        }),
+        { allowed: true },
+      );
+
+      const result = enforceSkillPolicy("execute_skill_script", ["Read"], false, {
+        skillToolAvailability: {
+          hasActiveSkill: true,
+          references: [],
+          scripts: [],
+        },
       });
+      assertEquals(result.allowed, false);
     });
 
     it("should allow wildcard-matched tools", () => {
@@ -161,6 +202,48 @@ describe("src/agent/runtime skill policy helpers", () => {
       assertEquals(enforceSkillPolicy("Read", undefined, false), { allowed: true });
       assertEquals(enforceSkillPolicy("Write", undefined, false), { allowed: true });
       assertEquals(enforceSkillPolicy("Bash", undefined, false), { allowed: true });
+    });
+  });
+
+  describe("extractSkillToolAvailability", () => {
+    it("extracts references and scripts from load_skill results", () => {
+      assertEquals(
+        extractSkillToolAvailability({
+          instructions: "# Support",
+          references: ["references/guide.md"],
+          scripts: ["scripts/run.sh"],
+        }),
+        {
+          hasActiveSkill: true,
+          references: ["references/guide.md"],
+          scripts: ["scripts/run.sh"],
+        },
+      );
+    });
+
+    it("returns an active skill with empty file capabilities for no-reference skills", () => {
+      assertEquals(
+        extractSkillToolAvailability({
+          instructions: "# Support",
+          allowedTools: ["search_knowledge"],
+          references: [],
+          scripts: [],
+        }),
+        {
+          hasActiveSkill: true,
+          references: [],
+          scripts: [],
+        },
+      );
+    });
+
+    it("ignores non-load-skill error results", () => {
+      assertEquals(
+        extractSkillToolAvailability({
+          error: "Skill not found",
+        }),
+        undefined,
+      );
     });
   });
 
@@ -319,6 +402,16 @@ describe("src/agent/runtime skill policy helpers", () => {
   });
 
   describe("hydrateActiveSkillStateFromMessages", () => {
+    it("returns inactive skill tool availability before a skill is loaded", () => {
+      const hydrated = hydrateActiveSkillStateFromMessages([]);
+
+      assertEquals(hydrated.activeSkillToolAvailability, {
+        hasActiveSkill: false,
+        references: [],
+        scripts: [],
+      });
+    });
+
     it("detects a submitted form_input result in message history", () => {
       const messages: Message[] = [
         {
@@ -407,6 +500,8 @@ describe("src/agent/runtime skill policy helpers", () => {
             result: {
               skillId: "old",
               allowedTools: ["Read"],
+              references: ["references/old.md"],
+              scripts: [],
               model: "anthropic/claude-sonnet-4-5",
               thinking: true,
               maxSteps: 4,
@@ -433,6 +528,8 @@ describe("src/agent/runtime skill policy helpers", () => {
             result: {
               skillId: "new",
               allowedTools: ["Write"],
+              references: [],
+              scripts: ["scripts/run.sh"],
               model: "openai/gpt-5.1",
               thinking: false,
               maxSteps: 8,
@@ -445,6 +542,11 @@ describe("src/agent/runtime skill policy helpers", () => {
 
       assertEquals(hydrated.activeSkillId, "new");
       assertEquals(hydrated.activeSkillPolicy, ["Write"]);
+      assertEquals(hydrated.activeSkillToolAvailability, {
+        hasActiveSkill: true,
+        references: [],
+        scripts: ["scripts/run.sh"],
+      });
       assertEquals(hydrated.activeSkillDelegationOverrides, {
         model: "openai/gpt-5.1",
         thinking: false,

--- a/src/skill/allowed-tools.test.ts
+++ b/src/skill/allowed-tools.test.ts
@@ -49,23 +49,68 @@ describe("src/skill/allowed-tools", () => {
       { name: "Write", description: "Write", parameters: {} },
       { name: "api:list", description: "API", parameters: {} },
       { name: "load_skill", description: "Load", parameters: {} },
+      { name: "load_skill_reference", description: "Load reference", parameters: {} },
+      { name: "execute_skill_script", description: "Execute script", parameters: {} },
     ];
 
     it("should return all tools when allowedTools is undefined", () => {
       const result = filterToolsForSkill(tools, undefined);
-      assertEquals(result.length, 4);
+      assertEquals(result.length, 6);
     });
 
-    it("should return only skill tools when allowedTools is empty", () => {
+    it("should constrain skill infrastructure tools when allowedTools is undefined", () => {
+      const result = filterToolsForSkill(tools, undefined, {
+        hasActiveSkill: true,
+        references: [],
+        scripts: [],
+      });
+
+      assertEquals(result.map((t) => t.name), [
+        "Read",
+        "Write",
+        "api:list",
+        "load_skill",
+      ]);
+    });
+
+    it("should return only load_skill when allowedTools is empty and no skill files are available", () => {
       const result = filterToolsForSkill(tools, []);
       assertEquals(result.length, 1);
       assertEquals(result.map((t) => t.name), ["load_skill"]);
     });
 
-    it("should filter to only allowed tools + skill tools", () => {
+    it("should filter to allowed tools plus load_skill when no skill files are available", () => {
       const result = filterToolsForSkill(tools, ["Read"]);
       assertEquals(result.length, 2); // Read + load_skill
       assertEquals(result.map((t) => t.name).sort(), ["Read", "load_skill"]);
+    });
+
+    it("should expose load_skill_reference only when the active skill has references", () => {
+      const result = filterToolsForSkill(tools, ["Read"], {
+        hasActiveSkill: true,
+        references: ["references/guide.md"],
+        scripts: [],
+      });
+
+      assertEquals(result.map((t) => t.name).sort(), [
+        "Read",
+        "load_skill",
+        "load_skill_reference",
+      ]);
+    });
+
+    it("should expose execute_skill_script only when the active skill has scripts", () => {
+      const result = filterToolsForSkill(tools, ["Read"], {
+        hasActiveSkill: true,
+        references: [],
+        scripts: ["scripts/run.sh"],
+      });
+
+      assertEquals(result.map((t) => t.name).sort(), [
+        "Read",
+        "execute_skill_script",
+        "load_skill",
+      ]);
     });
 
     it("should support prefix wildcards", () => {
@@ -73,9 +118,11 @@ describe("src/skill/allowed-tools", () => {
       assertEquals(result.length, 2); // api:list + load_skill
     });
 
-    it("should always include skill tools", () => {
+    it("should always include load_skill", () => {
       const result = filterToolsForSkill(tools, ["Write"]);
       assertEquals(result.some((t) => t.name === "load_skill"), true);
+      assertEquals(result.some((t) => t.name === "load_skill_reference"), false);
+      assertEquals(result.some((t) => t.name === "execute_skill_script"), false);
     });
   });
 
@@ -84,14 +131,33 @@ describe("src/skill/allowed-tools", () => {
       assertEquals(isToolAllowedBySkill("anything", undefined), true);
     });
 
+    it("should still constrain skill infrastructure tools when no policy", () => {
+      assertEquals(
+        isToolAllowedBySkill("load_skill_reference", undefined, {
+          hasActiveSkill: true,
+          references: [],
+          scripts: [],
+        }),
+        false,
+      );
+      assertEquals(
+        isToolAllowedBySkill("Read", undefined, {
+          hasActiveSkill: true,
+          references: [],
+          scripts: [],
+        }),
+        true,
+      );
+    });
+
     it("should deny non-skill tools when empty policy", () => {
       assertEquals(isToolAllowedBySkill("anything", []), false);
     });
 
-    it("should allow skill tools when empty policy", () => {
+    it("should allow only load_skill when empty policy and no active skill files are available", () => {
       assertEquals(isToolAllowedBySkill("load_skill", []), true);
-      assertEquals(isToolAllowedBySkill("load_skill_reference", []), true);
-      assertEquals(isToolAllowedBySkill("execute_skill_script", []), true);
+      assertEquals(isToolAllowedBySkill("load_skill_reference", []), false);
+      assertEquals(isToolAllowedBySkill("execute_skill_script", []), false);
     });
 
     it("should allow matching tool", () => {
@@ -102,10 +168,48 @@ describe("src/skill/allowed-tools", () => {
       assertEquals(isToolAllowedBySkill("Bash", ["Read", "Write"]), false);
     });
 
-    it("should always allow skill system tools", () => {
+    it("should always allow load_skill", () => {
       assertEquals(isToolAllowedBySkill("load_skill", ["Read"]), true);
-      assertEquals(isToolAllowedBySkill("load_skill_reference", ["Read"]), true);
-      assertEquals(isToolAllowedBySkill("execute_skill_script", ["Read"]), true);
+      assertEquals(isToolAllowedBySkill("load_skill_reference", ["Read"]), false);
+      assertEquals(isToolAllowedBySkill("execute_skill_script", ["Read"]), false);
+    });
+
+    it("should allow load_skill_reference only when the active skill has references", () => {
+      assertEquals(
+        isToolAllowedBySkill("load_skill_reference", ["Read"], {
+          hasActiveSkill: true,
+          references: ["references/guide.md"],
+          scripts: [],
+        }),
+        true,
+      );
+      assertEquals(
+        isToolAllowedBySkill("load_skill_reference", ["Read"], {
+          hasActiveSkill: true,
+          references: [],
+          scripts: [],
+        }),
+        false,
+      );
+    });
+
+    it("should allow execute_skill_script only when the active skill has scripts", () => {
+      assertEquals(
+        isToolAllowedBySkill("execute_skill_script", ["Read"], {
+          hasActiveSkill: true,
+          references: [],
+          scripts: ["scripts/run.sh"],
+        }),
+        true,
+      );
+      assertEquals(
+        isToolAllowedBySkill("execute_skill_script", ["Read"], {
+          hasActiveSkill: true,
+          references: [],
+          scripts: [],
+        }),
+        false,
+      );
     });
   });
 

--- a/src/skill/allowed-tools.ts
+++ b/src/skill/allowed-tools.ts
@@ -11,6 +11,40 @@
 import { SKILL_ALLOWED_TOOL_PATTERN_REGEX, SKILL_TOOL_IDS } from "./types.ts";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 
+/** Active skill file-backed capabilities available to skill infrastructure tools. */
+export type SkillToolAvailability = {
+  hasActiveSkill?: boolean;
+  references?: readonly string[];
+  scripts?: readonly string[];
+};
+
+const LOAD_SKILL_TOOL_ID = "load_skill";
+const LOAD_SKILL_REFERENCE_TOOL_ID = "load_skill_reference";
+const EXECUTE_SKILL_SCRIPT_TOOL_ID = "execute_skill_script";
+
+function isSkillInfrastructureToolAllowed(
+  toolName: string,
+  availability: SkillToolAvailability = {},
+): boolean | undefined {
+  if (!SKILL_TOOL_IDS.has(toolName)) {
+    return undefined;
+  }
+
+  if (toolName === LOAD_SKILL_TOOL_ID) {
+    return true;
+  }
+
+  if (toolName === LOAD_SKILL_REFERENCE_TOOL_ID) {
+    return availability.hasActiveSkill === true && (availability.references?.length ?? 0) > 0;
+  }
+
+  if (toolName === EXECUTE_SKILL_SCRIPT_TOOL_ID) {
+    return availability.hasActiveSkill === true && (availability.scripts?.length ?? 0) > 0;
+  }
+
+  return false;
+}
+
 /**
  * Check if a tool name matches a single allowed-tools pattern.
  *
@@ -47,13 +81,25 @@ export function matchesAllowedTool(toolName: string, pattern: string): boolean {
 export function filterToolsForSkill<T extends { name: string }>(
   tools: T[],
   allowedTools: string[] | undefined,
+  skillToolAvailability?: SkillToolAvailability,
 ): T[] {
   if (allowedTools === undefined) {
-    return tools;
+    if (!skillToolAvailability) {
+      return tools;
+    }
+
+    return tools.filter((tool) => {
+      const skillToolAllowed = isSkillInfrastructureToolAllowed(
+        tool.name,
+        skillToolAvailability,
+      );
+      return skillToolAllowed ?? true;
+    });
   }
 
   return tools.filter((tool) => {
-    if (SKILL_TOOL_IDS.has(tool.name)) return true;
+    const skillToolAllowed = isSkillInfrastructureToolAllowed(tool.name, skillToolAvailability);
+    if (skillToolAllowed !== undefined) return skillToolAllowed;
     return allowedTools.some((pattern) => matchesAllowedTool(tool.name, pattern));
   });
 }
@@ -68,9 +114,11 @@ export function filterToolsForSkill<T extends { name: string }>(
 export function isToolAllowedBySkill(
   toolName: string,
   allowedTools: string[] | undefined,
+  skillToolAvailability?: SkillToolAvailability,
 ): boolean {
+  const skillToolAllowed = isSkillInfrastructureToolAllowed(toolName, skillToolAvailability);
+  if (skillToolAllowed !== undefined) return skillToolAllowed;
   if (allowedTools === undefined) return true;
-  if (SKILL_TOOL_IDS.has(toolName)) return true;
   return allowedTools.some((pattern) => matchesAllowedTool(toolName, pattern));
 }
 

--- a/src/skill/prompt-augmentation.ts
+++ b/src/skill/prompt-augmentation.ts
@@ -38,10 +38,10 @@ export function buildSkillManifestPrompt(skills: Map<string, Skill>): string {
     "- load_skill: Call with { skillId } to load a skill's full instructions and available references/resources/scripts",
   );
   lines.push(
-    "- load_skill_reference: Call with { skillId, reference } to read a file from the skill's references/, resources/, or assets/ directory",
+    "- load_skill_reference: Call with { skillId, reference } only after load_skill lists reference files for that skill",
   );
   lines.push(
-    "- execute_skill_script: Call with { skillId, script, args?, env?, timeoutMs? } to execute a script",
+    "- execute_skill_script: Call with { skillId, script, args?, env?, timeoutMs? } only after load_skill lists scripts for that skill",
   );
 
   return lines.join("\n");

--- a/src/skill/skill-owner-scope.test.ts
+++ b/src/skill/skill-owner-scope.test.ts
@@ -209,8 +209,9 @@ Deno.test("load_skill loads the caller's own skill via its short name", async ()
     const content = await loadSkill.execute(
       { skillId: "cite" },
       { agentId: "researcher" },
-    ) as { instructions: string };
+    ) as { instructions: string; skillId: string };
 
+    assertEquals(content.skillId, "researcher--cite");
     assertEquals(content.instructions.trim(), "Always cite primary sources.");
   } finally {
     skillRegistry.clearAll();

--- a/src/skill/tools.test.ts
+++ b/src/skill/tools.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { registerSkill, skillRegistry } from "./registry.ts";
 import {
@@ -19,6 +19,18 @@ function createTestSkill(fsAdapter: FileSystemAdapter): Skill {
       description: "Skill from adapter",
     },
     rootPath: "/project/skills/my-skill",
+    fsAdapter,
+  };
+}
+
+function createNamedTestSkill(id: string, fsAdapter: FileSystemAdapter): Skill {
+  return {
+    id,
+    metadata: {
+      name: id,
+      description: `Skill ${id}`,
+    },
+    rootPath: `/project/skills/${id}`,
     fsAdapter,
   };
 }
@@ -58,6 +70,7 @@ Do work.`,
     const tool = createLoadSkillTool();
     const result = await tool.execute({ skillId: "my-skill" });
 
+    assertEquals(result.skillId, "my-skill");
     assertEquals(result.allowedTools, ["Read", "api:*"]);
     assertEquals(result.references, ["references/guide.md"]);
     assertEquals(result.scripts, ["scripts/run.sh"]);
@@ -79,6 +92,24 @@ Review the resource files.`,
     const result = await tool.execute({ skillId: "my-skill" });
 
     assertEquals(result.references, ["resources/article-30.md"]);
+  });
+
+  it("load_skill should list assets as loadable references via fsAdapter", async () => {
+    const fsAdapter = createSkillTestAdapter({
+      "/project/skills/my-skill/SKILL.md": `---
+name: my-skill
+description: Skill from adapter
+---
+# Instructions
+Review the asset files.`,
+      "/project/skills/my-skill/assets/checklist.txt": "Checklist",
+    });
+    registerSkill("my-skill", createTestSkill(fsAdapter));
+
+    const tool = createLoadSkillTool();
+    const result = await tool.execute({ skillId: "my-skill" });
+
+    assertEquals(result.references, ["assets/checklist.txt"]);
   });
 
   it("load_skill should note when no references or scripts are available", async () => {
@@ -188,6 +219,89 @@ Do work.`,
     assertEquals(result.path, "resources/article-30.md");
   });
 
+  it("load_skill_reference should allow the active skill through its short name", async () => {
+    const fsAdapter = createSkillTestAdapter({
+      "/project/skills/researcher--cite/references/guide.md": "Citation guide",
+    });
+    registerSkill("researcher--cite", {
+      ...createNamedTestSkill("researcher--cite", fsAdapter),
+      ownerAgentId: "researcher",
+      shortName: "cite",
+    });
+
+    const tool = createLoadSkillReferenceTool();
+    const result = await tool.execute({
+      skillId: "cite",
+      reference: "references/guide.md",
+    }, {
+      agentId: "researcher",
+      activeSkillId: "researcher--cite",
+      activeSkillToolAvailability: {
+        hasActiveSkill: true,
+        references: ["references/guide.md"],
+        scripts: [],
+      },
+    });
+
+    assertEquals(result.content, "Citation guide");
+    assertEquals(result.path, "references/guide.md");
+  });
+
+  it("load_skill_reference should reject a different skill than the active loaded skill", async () => {
+    const activeAdapter = createSkillTestAdapter({
+      "/project/skills/my-skill/references/guide.md": "Guide",
+    });
+    const otherAdapter = createSkillTestAdapter({
+      "/project/skills/other-skill/references/secret.md": "Secret",
+    });
+    registerSkill("my-skill", createNamedTestSkill("my-skill", activeAdapter));
+    registerSkill("other-skill", createNamedTestSkill("other-skill", otherAdapter));
+
+    const tool = createLoadSkillReferenceTool();
+
+    await assertRejects(
+      () =>
+        tool.execute({
+          skillId: "other-skill",
+          reference: "references/secret.md",
+        }, {
+          activeSkillId: "my-skill",
+          activeSkillToolAvailability: {
+            hasActiveSkill: true,
+            references: ["references/guide.md"],
+            scripts: [],
+          },
+        }),
+      Error,
+    );
+  });
+
+  it("load_skill_reference should reject files not advertised by the active skill", async () => {
+    const fsAdapter = createSkillTestAdapter({
+      "/project/skills/my-skill/references/guide.md": "Guide",
+      "/project/skills/my-skill/references/hidden.md": "Hidden",
+    });
+    registerSkill("my-skill", createNamedTestSkill("my-skill", fsAdapter));
+
+    const tool = createLoadSkillReferenceTool();
+
+    await assertRejects(
+      () =>
+        tool.execute({
+          skillId: "my-skill",
+          reference: "references/hidden.md",
+        }, {
+          activeSkillId: "my-skill",
+          activeSkillToolAvailability: {
+            hasActiveSkill: true,
+            references: ["references/guide.md"],
+            scripts: [],
+          },
+        }),
+      Error,
+    );
+  });
+
   it("execute_skill_script should run a local script from the skill directory", async () => {
     const tempDir = await Deno.makeTempDir({ prefix: "vf-skill-script-" });
 
@@ -219,6 +333,48 @@ Do work.`,
       assertEquals(result.exitCode, 0);
       assertEquals(result.stderr, "");
       assertEquals(result.stdout.trim(), "style=tight voice=active");
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("execute_skill_script should reject scripts not advertised by the active skill", async () => {
+    const tempDir = await Deno.makeTempDir({ prefix: "vf-skill-script-policy-" });
+
+    try {
+      const skillRoot = `${tempDir}/my-skill`;
+      await Deno.mkdir(`${skillRoot}/scripts`, { recursive: true });
+      await Deno.writeTextFile(
+        `${skillRoot}/scripts/hidden.sh`,
+        [
+          "#!/usr/bin/env bash",
+          'echo "hidden"',
+        ].join("\n"),
+      );
+
+      registerSkill("my-skill", {
+        id: "my-skill",
+        metadata: { name: "my-skill", description: "Executes scripts" },
+        rootPath: skillRoot,
+      });
+
+      const tool = createExecuteSkillScriptTool();
+
+      await assertRejects(
+        () =>
+          tool.execute({
+            skillId: "my-skill",
+            script: "scripts/hidden.sh",
+          }, {
+            activeSkillId: "my-skill",
+            activeSkillToolAvailability: {
+              hasActiveSkill: true,
+              references: [],
+              scripts: ["scripts/run.sh"],
+            },
+          }),
+        Error,
+      );
     } finally {
       await Deno.remove(tempDir, { recursive: true });
     }

--- a/src/skill/tools.ts
+++ b/src/skill/tools.ts
@@ -31,6 +31,8 @@ import {
 /** Maximum allowed script execution timeout in milliseconds (5 minutes) */
 const MAX_SCRIPT_TIMEOUT_MS = 300_000;
 
+type SkillFileKind = "reference" | "script";
+
 const getLoadSkillInputSchema = defineSchema((v) =>
   v.object({
     skillId: v.string().describe("The ID of the skill to load"),
@@ -115,6 +117,60 @@ function buildSkillAvailabilityNote(references: string[], scripts: string[]): st
   return undefined;
 }
 
+function hasRuntimeSkillBoundary(
+  context: ToolExecutionContext | undefined,
+): context is ToolExecutionContext {
+  if (!context) return false;
+  return context.activeSkillId !== undefined ||
+    context.activeSkillToolAvailability !== undefined;
+}
+
+function assertActiveSkillFileAvailable(
+  input: {
+    toolName: string;
+    skillId: string;
+    requestedSkillId: string;
+    path: string;
+    kind: SkillFileKind;
+  },
+  context: ToolExecutionContext | undefined,
+): void {
+  if (!hasRuntimeSkillBoundary(context)) return;
+
+  const activeSkillId = context.activeSkillId;
+  const availability = context.activeSkillToolAvailability;
+  if (!activeSkillId || availability?.hasActiveSkill !== true) {
+    throw toError(
+      createError({
+        type: "agent",
+        message: `${input.toolName} requires an active loaded skill.`,
+      }),
+    );
+  }
+
+  if (input.skillId !== activeSkillId) {
+    throw toError(
+      createError({
+        type: "agent",
+        message:
+          `${input.toolName} can only access the active loaded skill "${activeSkillId}". Requested "${input.requestedSkillId}".`,
+      }),
+    );
+  }
+
+  const advertised = input.kind === "reference"
+    ? availability.references ?? []
+    : availability.scripts ?? [];
+  if (!advertised.includes(input.path)) {
+    throw toError(
+      createError({
+        type: "agent",
+        message: `${input.toolName} can only access ${input.kind} files advertised by load_skill.`,
+      }),
+    );
+  }
+}
+
 /**
  * Create the load_skill tool.
  * Loads a skill's full instructions, available references, and scripts.
@@ -136,7 +192,7 @@ export function createLoadSkillTool(): Tool {
       const parsed = await parseSkillFrontmatter(content);
 
       // List available files the agent can load through load_skill_reference.
-      const [references, resources, scripts] = await Promise.all([
+      const [references, resources, assets, scripts] = await Promise.all([
         listSkillSubdir(
           skill.rootPath,
           SKILL_REFERENCES_DIR,
@@ -149,14 +205,20 @@ export function createLoadSkillTool(): Tool {
         ),
         listSkillSubdir(
           skill.rootPath,
+          SKILL_ASSETS_DIR,
+          skill.fsAdapter,
+        ),
+        listSkillSubdir(
+          skill.rootPath,
           SKILL_SCRIPTS_DIR,
           skill.fsAdapter,
         ),
       ]);
-      const loadableReferences = [...references, ...resources];
+      const loadableReferences = [...references, ...resources, ...assets];
       const note = buildSkillAvailabilityNote(loadableReferences, scripts);
 
       return {
+        skillId: skill.id,
         instructions: parsed.body,
         allowedTools: skill.metadata.allowedTools,
         references: loadableReferences,
@@ -179,6 +241,16 @@ export function createLoadSkillReferenceTool(): Tool {
     inputSchema: getLoadSkillReferenceInputSchema(),
     execute: async (input, context): Promise<{ content: string; path: string }> => {
       const skill = resolveVisibleSkillOrThrow(input.skillId, context);
+      assertActiveSkillFileAvailable(
+        {
+          toolName: "load_skill_reference",
+          skillId: skill.id,
+          requestedSkillId: input.skillId,
+          path: input.reference,
+          kind: "reference",
+        },
+        context,
+      );
 
       // Validate path safety before reading skill-provided context.
       const validatedPath = await validateSkillPath(
@@ -206,6 +278,16 @@ export function createExecuteSkillScriptTool(): Tool {
     inputSchema: getExecuteSkillScriptInputSchema(),
     execute: async (input, context) => {
       const skill = resolveVisibleSkillOrThrow(input.skillId, context);
+      assertActiveSkillFileAvailable(
+        {
+          toolName: "execute_skill_script",
+          skillId: skill.id,
+          requestedSkillId: input.skillId,
+          path: input.script,
+          kind: "script",
+        },
+        context,
+      );
 
       // Validate path safety (only scripts/ allowed)
       const validatedPath = await validateSkillPath(

--- a/src/skill/types.ts
+++ b/src/skill/types.ts
@@ -57,6 +57,8 @@ export interface SkillMetadata {
 
 /** Full skill content returned by load_skill tool */
 export interface SkillContent {
+  /** Loaded skill identifier */
+  skillId: string;
   /** Markdown instructions (body after frontmatter) */
   instructions: string;
   /** Tool access restrictions from frontmatter */

--- a/src/tool/types.ts
+++ b/src/tool/types.ts
@@ -85,6 +85,20 @@ export interface ToolExecutionContext {
   branch?: string | null;
   /** Environment name associated with project content */
   environmentName?: string | null;
+  /** Canonical id of the active skill loaded by the current agent run step. */
+  activeSkillId?: string;
+  /**
+   * File-backed capabilities advertised by the active loaded skill.
+   *
+   * Framework skill file tools use this to reject references/scripts that were
+   * not listed by `load_skill`, even if the model guesses a valid path under a
+   * skill directory.
+   */
+  activeSkillToolAvailability?: {
+    hasActiveSkill?: boolean;
+    references?: readonly string[];
+    scripts?: readonly string[];
+  };
   /** Abort signal for cooperative cancellation during long-running tool execution */
   abortSignal?: AbortSignal;
   /** Progress token for sending progress notifications (MCP 2025-11-25) */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.951";
+export const VERSION = "0.1.952";


### PR DESCRIPTION
## Summary
- gate `load_skill_reference` and `execute_skill_script` on the active loaded skill's advertised references/scripts
- keep `load_skill` as the only always-available skill infrastructure tool
- apply the same policy at planning-time tool filtering and execution-time enforcement
- include `skillId` in `load_skill` results so runtime state can identify loaded skill capability context
- bump framework version to `0.1.952`

## Why
The model-comparison eval exposed a brittle behavior: a cheaper candidate retrieved the right knowledge, then called `load_skill_reference` for a skill that did not advertise references. Prompt guidance alone would still leave invalid tools in weaker model planning surfaces. This makes unavailable skill file tools invisible and rejects them if a model still sends one.

## Verification
- `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/skill/allowed-tools.test.ts src/skill/tools.test.ts src/skill/prompt-augmentation.test.ts src/skill/skill-owner-scope.test.ts src/agent/runtime/skill-policy.test.ts src/agent/runtime/agent-runtime-step.test.ts src/agent/runtime/refresh.test.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/tool-result-continuation.test.ts`
- `deno task verify:quick`
- `deno task test:unit`
- pre-push hook reran format, lint, typecheck, and full unit tests: `2212 passed (18980 steps), 0 failed`