### PR TITLE
Remove redundant skill file-tool prompt notes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.952",
+  "version": "0.1.953",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/skill/tools.test.ts
+++ b/src/skill/tools.test.ts
@@ -112,7 +112,7 @@ Review the asset files.`,
     assertEquals(result.references, ["assets/checklist.txt"]);
   });
 
-  it("load_skill should note when no references or scripts are available", async () => {
+  it("load_skill should omit prompt notes for unavailable file tools", async () => {
     const fsAdapter = createSkillTestAdapter({
       "/project/skills/my-skill/SKILL.md": `---
 name: my-skill
@@ -126,14 +126,9 @@ Do work.`,
     const tool = createLoadSkillTool();
     const result = await tool.execute({ skillId: "my-skill" });
 
-    assertEquals(
-      result.note,
-      "This skill has no scripts or reference files. Do NOT call execute_skill_script or load_skill_reference.",
-    );
-  });
+    assertEquals(result.note, undefined);
 
-  it("load_skill should note when only references are available", async () => {
-    const fsAdapter = createSkillTestAdapter({
+    const referencesOnlyAdapter = createSkillTestAdapter({
       "/project/skills/my-skill/SKILL.md": `---
 name: my-skill
 description: Skill from adapter
@@ -142,16 +137,13 @@ description: Skill from adapter
 Do work.`,
       "/project/skills/my-skill/references/guide.md": "Guide",
     });
-    registerSkill("my-skill", createTestSkill(fsAdapter));
+    registerSkill("my-skill", createTestSkill(referencesOnlyAdapter));
 
-    const tool = createLoadSkillTool();
-    const result = await tool.execute({ skillId: "my-skill" });
+    const referencesOnly = await tool.execute({ skillId: "my-skill" });
 
-    assertEquals(result.note, "This skill has no scripts. Do NOT call execute_skill_script.");
-  });
+    assertEquals(referencesOnly.note, undefined);
 
-  it("load_skill should note when only scripts are available", async () => {
-    const fsAdapter = createSkillTestAdapter({
+    const scriptsOnlyAdapter = createSkillTestAdapter({
       "/project/skills/my-skill/SKILL.md": `---
 name: my-skill
 description: Skill from adapter
@@ -160,15 +152,11 @@ description: Skill from adapter
 Do work.`,
       "/project/skills/my-skill/scripts/run.sh": "echo run",
     });
-    registerSkill("my-skill", createTestSkill(fsAdapter));
+    registerSkill("my-skill", createTestSkill(scriptsOnlyAdapter));
 
-    const tool = createLoadSkillTool();
-    const result = await tool.execute({ skillId: "my-skill" });
+    const scriptsOnly = await tool.execute({ skillId: "my-skill" });
 
-    assertEquals(
-      result.note,
-      "This skill has no reference files. Do NOT call load_skill_reference.",
-    );
+    assertEquals(scriptsOnly.note, undefined);
   });
 
   it("load_skill_reference should read content via fsAdapter", async () => {

--- a/src/skill/tools.ts
+++ b/src/skill/tools.ts
@@ -104,19 +104,6 @@ function resolveVisibleSkillOrThrow(
   return skill;
 }
 
-function buildSkillAvailabilityNote(references: string[], scripts: string[]): string | undefined {
-  if (scripts.length === 0 && references.length === 0) {
-    return "This skill has no scripts or reference files. Do NOT call execute_skill_script or load_skill_reference.";
-  }
-  if (scripts.length === 0) {
-    return "This skill has no scripts. Do NOT call execute_skill_script.";
-  }
-  if (references.length === 0) {
-    return "This skill has no reference files. Do NOT call load_skill_reference.";
-  }
-  return undefined;
-}
-
 function hasRuntimeSkillBoundary(
   context: ToolExecutionContext | undefined,
 ): context is ToolExecutionContext {
@@ -215,7 +202,6 @@ export function createLoadSkillTool(): Tool {
         ),
       ]);
       const loadableReferences = [...references, ...resources, ...assets];
-      const note = buildSkillAvailabilityNote(loadableReferences, scripts);
 
       return {
         skillId: skill.id,
@@ -223,7 +209,6 @@ export function createLoadSkillTool(): Tool {
         allowedTools: skill.metadata.allowedTools,
         references: loadableReferences,
         scripts,
-        ...(note ? { note } : {}),
       };
     },
   });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.952";
+export const VERSION = "0.1.953";


### PR DESCRIPTION
## Summary
- remove generated `load_skill` notes that told models not to call unavailable skill file tools
- keep the real boundary in runtime tool filtering and executor-level active-skill validation
- bump the framework version to `0.1.953`

## Why
`load_skill_reference` and `execute_skill_script` are now constrained by the active loaded skill id and the files advertised by `load_skill`. The extra "Do NOT call ..." notes were redundant prompt engineering and surfaced in the demo eval trace.

This keeps the split cleaner: the agent prompt defines the agent, the skill defines the work process, and runtime code enforces tool access.

## Verification
- `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/skill/tools.test.ts src/skill/allowed-tools.test.ts src/agent/runtime/skill-policy.test.ts src/agent/runtime/agent-runtime-step.test.ts`
- `deno task verify:quick`
- `deno task test:unit`
- pre-push checks: formatting, lint, typecheck, unit tests