### PR TITLE
Avoid stale config bridge during cloud model resolution

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.953",
+  "version": "0.1.954",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -196,10 +196,3 @@ export function getOtelMetricsConfig(env: EnvironmentConfig = getEnvironmentConf
     exporter: env.otelMetricsExporter,
   };
 }
-
-// ============================================================================
-// GlobalThis Bridge
-// ============================================================================
-// Register on globalThis so bottom-layer code (platform/) can access the API
-// base URL without importing from config/ (which would violate layer rules).
-(globalThis as Record<string, unknown>).__vfGetApiBaseUrlEnv = getApiBaseUrlEnv;

--- a/src/platform/cloud/resolver.test.ts
+++ b/src/platform/cloud/resolver.test.ts
@@ -19,7 +19,9 @@ import {
 } from "./resolver.ts";
 
 const CLOUD_ENV_KEYS = [
+  "VERYFRONT_API_BASE_URL",
   "VERYFRONT_API_TOKEN",
+  "VERYFRONT_API_URL",
   "VERYFRONT_PROJECT_SLUG",
   "VERYFRONT_SERVICE_LAYER",
   "VERYFRONT_DEFAULT_MODEL",
@@ -121,6 +123,28 @@ describe("platform/cloud/resolver", () => {
 
     assertEquals(getVeryfrontCloudAuthToken(), "vf_env_token");
     assertEquals(getVeryfrontCloudProjectSlug(), "env-project");
+  });
+
+  it("resolves the API base URL from host env without the config bridge", () => {
+    const globals = globalThis as Record<string, unknown>;
+    const originalBridge = globals.__vfGetApiBaseUrlEnv;
+    globals.__vfGetApiBaseUrlEnv = () => {
+      throw new Error("config bridge should not be called");
+    };
+    setEnv("VERYFRONT_API_URL", "https://api.staging.veryfront.org/graphql");
+
+    try {
+      assertEquals(
+        getVeryfrontCloudBootstrap().apiBaseUrl,
+        "https://api.staging.veryfront.org/api",
+      );
+    } finally {
+      if (originalBridge === undefined) {
+        delete globals.__vfGetApiBaseUrlEnv;
+      } else {
+        globals.__vfGetApiBaseUrlEnv = originalBridge;
+      }
+    }
   });
 
   it("treats scoped cloud context as sufficient runtime context even without projectSlug", () => {

--- a/src/platform/cloud/resolver.ts
+++ b/src/platform/cloud/resolver.ts
@@ -29,10 +29,7 @@ function isRuntimeConfigInitialized(): boolean {
 const DEFAULT_API_BASE_URL = "https://api.veryfront.com";
 
 function getApiBaseUrlEnv(): string {
-  const getter = (globalThis as Record<string, unknown>).__vfGetApiBaseUrlEnv as
-    | (() => string)
-    | undefined;
-  return getter?.() ?? getHostEnv("VERYFRONT_API_BASE_URL") ??
+  return getHostEnv("VERYFRONT_API_BASE_URL") ??
     getHostEnv("VERYFRONT_API_URL")?.replace("/graphql", "/api") ?? DEFAULT_API_BASE_URL;
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.953";
+export const VERSION = "0.1.954";


### PR DESCRIPTION
## Summary
- Resolve the Veryfront Cloud API base URL directly from host env in `platform/cloud/resolver`
- Remove the unused `__vfGetApiBaseUrlEnv` config bridge
- Add a regression test proving a stale/throwing API-base bridge is ignored
- Bump framework version to `0.1.954` for release

## Why
`veryfront eval` can run with a globally installed CLI while project agents load a local `veryfront` package. The old API-base bridge could point at the project-local config module, whose env-loader flag was not initialized by the global CLI. That produced a false early `EnvironmentConfig` warning during model resolution.

## Verification
- `deno test --no-check --allow-all src/platform/cloud/resolver.test.ts src/config/env.test.ts src/agent/runtime/model-resolution.test.ts`
- `VERYFRONT_DEBUG_RUNTIME_ENV=1 deno run --config <local-path> --allow-all <local-path> eval support-triage --model moonshotai/kimi-k2.6 --max-output-tokens 1 --report-dir .veryfront/evals/env-warning-repro-local-0954`
- `deno task verify:quick`
- pre-push hook: formatting, lint, typecheck, `deno task test:unit` (`2212 passed`)
