### PR TITLE
Respect soft metrics in eval model comparison

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.954",
+  "version": "0.1.955",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/eval/model-comparison.test.ts
+++ b/src/eval/model-comparison.test.ts
@@ -149,6 +149,44 @@ describe("eval/model-comparison", () => {
     assertEquals(comparison.candidates[0]?.newFailedExamples, ["refund-escalation"]);
   });
 
+  it("promotes cheaper candidates that pass gates even when soft metrics drop", () => {
+    const baseline = createReport("anthropic/claude-opus-4-6", {
+      passed: 3,
+      failed: 1,
+      totalTokens: 10_000,
+      failedExamples: ["sso-login-after-release"],
+    });
+    baseline.summary.metrics.push({
+      name: "knowledge.precisionAtK",
+      family: "knowledge",
+      severity: "soft",
+      passed: 4,
+      failed: 0,
+      skipped: 0,
+      passRate: 1,
+    });
+
+    const candidate = createReport("moonshotai/kimi-k2.6", {
+      totalTokens: 6_000,
+    });
+    candidate.summary.metrics.push({
+      name: "knowledge.precisionAtK",
+      family: "knowledge",
+      severity: "soft",
+      passed: 3,
+      failed: 1,
+      skipped: 0,
+      passRate: 0.75,
+    });
+
+    const comparison = compareEvalModelReports([baseline, candidate], {
+      baselineModel: "anthropic/claude-opus-4-6",
+    });
+
+    assertEquals(comparison.candidates[0]?.decision, "promote-candidate");
+    assertEquals(comparison.recommendation.decision, "promote-candidate");
+  });
+
   it("promotes cheaper candidates when deterministic evals do not measure groundedness", () => {
     const comparison = compareEvalModelReports(
       [

--- a/src/eval/model-comparison.ts
+++ b/src/eval/model-comparison.ts
@@ -56,6 +56,14 @@ function formatPct(value: number): string {
   return `${Math.round(value * 100)}%`;
 }
 
+function hasBlockingRegression(
+  comparison: ReturnType<typeof compareEvalReports>,
+): boolean {
+  return comparison.passRateDelta < 0 || comparison.failedDelta > 0 ||
+    comparison.newFailedExamples.length > 0 ||
+    comparison.metricDeltas.some((metric) => metric.severity !== "soft" && metric.regressed);
+}
+
 function modelSummary(
   report: EvalReport,
   baselineModel: string,
@@ -96,7 +104,7 @@ function createCandidateDecision(input: {
   const reasons: string[] = [];
 
   if (
-    input.candidate.summary.failed > 0 || baselineComparison.regressed ||
+    input.candidate.summary.failed > 0 || hasBlockingRegression(baselineComparison) ||
     baselineComparison.newFailedExamples.length > 0
   ) {
     reasons.push("candidate has quality regressions");

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.954";
+export const VERSION = "0.1.955";


### PR DESCRIPTION
## Summary
- Treat soft metric drops as non-blocking in eval model comparison decisions
- Keep candidates blocked on failed examples, failed gates, and gate/budget metric regressions
- Add a regression test for a cheaper candidate that passes gates while soft precision drops
- Bump Veryfront Code to 0.1.955 for release

## Verification
- deno test -A src/eval/model-comparison.test.ts
- deno test -A src/eval/baseline.test.ts src/eval/model-comparison.test.ts
- deno task verify:quick

## Notes
- `deno task verify:quick` emits the existing EnvironmentConfig guide-example warning, but exits 0.
