### PR TITLE
Preserve Anthropic gateway billing usage

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.957",
+  "version": "0.1.958",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/extensions/ext-llm-anthropic/src/anthropic-provider.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-provider.test.ts
@@ -129,6 +129,57 @@ describe("anthropic-provider", () => {
     });
   });
 
+  it("preserves Veryfront gateway billing metadata for generate usage", async () => {
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: [{ type: "text", text: "Done." }],
+              stop_reason: "end_turn",
+              usage: {
+                input_tokens: 8,
+                output_tokens: 2,
+                veryfront: {
+                  billable_input_tokens: 8,
+                  billable_output_tokens: 2,
+                  provider_cost_usd: 0.001,
+                  veryfront_charge_usd: 0.0025,
+                  cost_credits: 0.025,
+                  cost_source: "gateway",
+                  usage_capture_status: "complete",
+                },
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        ),
+    }, "claude-sonnet-4-20250514");
+
+    const result = await runtime.doGenerate({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Triage this." }],
+      }],
+      maxOutputTokens: 64,
+    });
+
+    assertEquals(result.usage, {
+      inputTokens: 8,
+      outputTokens: 2,
+      totalTokens: 10,
+      billableInputTokens: 8,
+      billableOutputTokens: 2,
+      providerCostUsd: 0.001,
+      veryfrontChargeUsd: 0.0025,
+      costCredits: 0.025,
+      costSource: "gateway",
+      usageCaptureStatus: "complete",
+    });
+  });
+
   it("sends image URL user parts as Anthropic vision content", async () => {
     let requestedInit: RequestInit | undefined;
 

--- a/extensions/ext-llm-anthropic/src/anthropic-provider.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-provider.ts
@@ -9,6 +9,7 @@
  */
 
 import type { LLMProvider, LLMProviderConfig } from "veryfront/extensions/llm";
+import type { RuntimeUsage } from "veryfront/provider/shared";
 import type { ModelRuntime } from "veryfront/provider/types";
 import {
   buildProviderError,
@@ -61,14 +62,6 @@ export interface AnthropicRuntimeConfig {
   name?: string;
   fetch?: typeof globalThis.fetch;
 }
-
-type RuntimeUsage = {
-  inputTokens?: number;
-  outputTokens?: number;
-  totalTokens?: number;
-  cacheCreationInputTokens?: number;
-  cacheReadInputTokens?: number;
-};
 
 // ---------------------------------------------------------------------------
 // Anthropic helper functions

--- a/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
@@ -111,6 +111,62 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
     ]);
   });
 
+  it("preserves Veryfront gateway billing metadata from usage envelopes", async () => {
+    const parts = await collectParts(streamFromText([
+      data({
+        type: "message_start",
+        message: {
+          usage: {
+            input_tokens: 8,
+            cache_read_input_tokens: 3,
+          },
+        },
+      }),
+      data({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "Done." },
+      }),
+      data({
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: {
+          output_tokens: 5,
+          veryfront: {
+            billable_input_tokens: 8,
+            billable_output_tokens: 5,
+            provider_cost_usd: 0.001,
+            veryfront_charge_usd: 0.0025,
+            cost_credits: 0.025,
+            cost_source: "gateway",
+            usage_capture_status: "complete",
+          },
+        },
+      }),
+    ].join("")));
+
+    assertEquals(parts, [
+      { type: "text-delta", delta: "Done." },
+      {
+        type: "finish",
+        finishReason: { unified: "stop", raw: "end_turn" },
+        usage: {
+          inputTokens: 8,
+          outputTokens: 5,
+          totalTokens: 13,
+          cacheReadInputTokens: 3,
+          billableInputTokens: 8,
+          billableOutputTokens: 5,
+          providerCostUsd: 0.001,
+          veryfrontChargeUsd: 0.0025,
+          costCredits: 0.025,
+          costSource: "gateway",
+          usageCaptureStatus: "complete",
+        },
+      },
+    ]);
+  });
+
   it("emits zero-length reasoning blocks for redacted thinking", async () => {
     const parts = await collectParts(streamFromText([
       data({

--- a/extensions/ext-llm-anthropic/src/anthropic-stream.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.ts
@@ -4,14 +4,7 @@ import {
   readRecord,
   stringifyJsonValue,
 } from "veryfront/provider/shared";
-
-type RuntimeUsage = {
-  inputTokens?: number;
-  outputTokens?: number;
-  totalTokens?: number;
-  cacheCreationInputTokens?: number;
-  cacheReadInputTokens?: number;
-};
+import type { RuntimeUsage } from "veryfront/provider/shared";
 
 type AnthropicStreamToolCallState = {
   id: string;
@@ -67,6 +60,9 @@ export function extractAnthropicUsage(payload: unknown): RuntimeUsage | undefine
   const outputTokens = usage.output_tokens;
   const cacheCreationInputTokens = usage.cache_creation_input_tokens;
   const cacheReadInputTokens = usage.cache_read_input_tokens;
+  const veryfront = readRecord(usage.veryfront);
+  const costSource = veryfront?.cost_source;
+  const usageCaptureStatus = veryfront?.usage_capture_status;
 
   return {
     inputTokens: typeof inputTokens === "number" ? inputTokens : undefined,
@@ -77,6 +73,27 @@ export function extractAnthropicUsage(payload: unknown): RuntimeUsage | undefine
       : undefined,
     ...(typeof cacheCreationInputTokens === "number" ? { cacheCreationInputTokens } : {}),
     ...(typeof cacheReadInputTokens === "number" ? { cacheReadInputTokens } : {}),
+    ...(typeof veryfront?.billable_input_tokens === "number"
+      ? { billableInputTokens: veryfront.billable_input_tokens }
+      : {}),
+    ...(typeof veryfront?.billable_output_tokens === "number"
+      ? { billableOutputTokens: veryfront.billable_output_tokens }
+      : {}),
+    ...(typeof veryfront?.provider_cost_usd === "number"
+      ? { providerCostUsd: veryfront.provider_cost_usd }
+      : {}),
+    ...(typeof veryfront?.veryfront_charge_usd === "number"
+      ? { veryfrontChargeUsd: veryfront.veryfront_charge_usd }
+      : {}),
+    ...(typeof veryfront?.cost_credits === "number" ? { costCredits: veryfront.cost_credits } : {}),
+    ...(costSource === "gateway" || costSource === "missing" || costSource === "partial"
+      ? { costSource }
+      : {}),
+    ...(usageCaptureStatus === "complete" ||
+        usageCaptureStatus === "missing" ||
+        usageCaptureStatus === "partial"
+      ? { usageCaptureStatus }
+      : {}),
   };
 }
 

--- a/src/provider/runtime-loader/provider-usage-merge.test.ts
+++ b/src/provider/runtime-loader/provider-usage-merge.test.ts
@@ -66,4 +66,34 @@ describe("provider/runtime-loader/provider-usage mergeUsage", () => {
       reasoningTokens: 2,
     });
   });
+
+  it("preserves gateway billing metadata from a final usage event", () => {
+    const merged = mergeUsage(
+      { inputTokens: 10, cacheReadInputTokens: 4 },
+      {
+        outputTokens: 5,
+        billableInputTokens: 10,
+        billableOutputTokens: 5,
+        providerCostUsd: 0.001,
+        veryfrontChargeUsd: 0.0025,
+        costCredits: 0.025,
+        costSource: "gateway",
+        usageCaptureStatus: "complete",
+      },
+    );
+
+    assertEquals(merged, {
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+      cacheReadInputTokens: 4,
+      billableInputTokens: 10,
+      billableOutputTokens: 5,
+      providerCostUsd: 0.001,
+      veryfrontChargeUsd: 0.0025,
+      costCredits: 0.025,
+      costSource: "gateway",
+      usageCaptureStatus: "complete",
+    });
+  });
 });

--- a/src/provider/runtime-loader/provider-usage.ts
+++ b/src/provider/runtime-loader/provider-usage.ts
@@ -8,6 +8,13 @@ export type RuntimeUsage = {
   cacheCreationInputTokens?: number;
   cacheReadInputTokens?: number;
   reasoningTokens?: number;
+  billableInputTokens?: number;
+  billableOutputTokens?: number;
+  providerCostUsd?: number;
+  veryfrontChargeUsd?: number;
+  costCredits?: number;
+  costSource?: "gateway" | "missing" | "partial";
+  usageCaptureStatus?: "complete" | "partial" | "missing";
 };
 
 export function extractAnthropicUsage(payload: unknown): RuntimeUsage | undefined {
@@ -136,6 +143,13 @@ export function mergeUsage(
     current.cacheCreationInputTokens;
   const cacheReadInputTokens = next.cacheReadInputTokens ?? current.cacheReadInputTokens;
   const reasoningTokens = next.reasoningTokens ?? current.reasoningTokens;
+  const billableInputTokens = next.billableInputTokens ?? current.billableInputTokens;
+  const billableOutputTokens = next.billableOutputTokens ?? current.billableOutputTokens;
+  const providerCostUsd = next.providerCostUsd ?? current.providerCostUsd;
+  const veryfrontChargeUsd = next.veryfrontChargeUsd ?? current.veryfrontChargeUsd;
+  const costCredits = next.costCredits ?? current.costCredits;
+  const costSource = next.costSource ?? current.costSource;
+  const usageCaptureStatus = next.usageCaptureStatus ?? current.usageCaptureStatus;
 
   // Prefer the provider-reported total (latest non-undefined wins, matching the
   // ?? semantics used for input/output above). Providers like Gemini 2.5
@@ -156,5 +170,12 @@ export function mergeUsage(
     ...(cacheCreationInputTokens !== undefined ? { cacheCreationInputTokens } : {}),
     ...(cacheReadInputTokens !== undefined ? { cacheReadInputTokens } : {}),
     ...(reasoningTokens !== undefined ? { reasoningTokens } : {}),
+    ...(billableInputTokens !== undefined ? { billableInputTokens } : {}),
+    ...(billableOutputTokens !== undefined ? { billableOutputTokens } : {}),
+    ...(providerCostUsd !== undefined ? { providerCostUsd } : {}),
+    ...(veryfrontChargeUsd !== undefined ? { veryfrontChargeUsd } : {}),
+    ...(costCredits !== undefined ? { costCredits } : {}),
+    ...(costSource !== undefined ? { costSource } : {}),
+    ...(usageCaptureStatus !== undefined ? { usageCaptureStatus } : {}),
   };
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.957";
+export const VERSION = "0.1.958";


### PR DESCRIPTION
## Summary
- parse Veryfront gateway billing metadata from Anthropic JSON and streaming usage envelopes
- carry billable input/output tokens, provider cost, Veryfront charge, credits, source, and capture status through runtime usage
- keep final gateway usage metadata as latest non-undefined values during usage merges
- bump deno/version constants to 0.1.958 for release

## Verification
- deno test --allow-all src/provider/runtime-loader/provider-usage-merge.test.ts extensions/ext-llm-anthropic/src/anthropic-stream.test.ts extensions/ext-llm-anthropic/src/anthropic-provider.test.ts
- deno test --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- git push pre-push gate: deno fmt --check, deno lint, typecheck, generated manifests/bundles, full unit suite: 2212 passed / 0 failed