### PR TITLE
Preserve gateway usage in eval reports

### DIFF
--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -21,6 +21,7 @@ import {
   normalizeEvalCliId,
   normalizeEvalInputForAgent,
   normalizeToolCalls,
+  normalizeUsage,
   summarizeReportForCli,
   writeEvalArtifacts,
 } from "./command.ts";
@@ -193,6 +194,50 @@ describe("eval CLI command helpers", () => {
       "What changed?",
     );
     assertEquals(normalizeEvalInputForAgent({ custom: true }), '{"custom":true}');
+  });
+
+  it("preserves gateway usage metadata in eval usage", () => {
+    const response = {
+      text: "done",
+      messages: [],
+      status: "completed",
+      toolCalls: [],
+      usage: {
+        promptTokens: 12,
+        completionTokens: 5,
+        totalTokens: 17,
+        cachedInputTokens: 3,
+        cacheCreationInputTokens: 2,
+        cacheReadInputTokens: 1,
+        reasoningTokens: 4,
+        billableInputTokens: 10,
+        billableOutputTokens: 5,
+        costUsd: 0.001,
+        providerCostUsd: 0.001,
+        veryfrontChargeUsd: 0.0025,
+        costCredits: 0.025,
+        costSource: "gateway",
+        usageCaptureStatus: "complete",
+      },
+    } satisfies AgentResponse;
+
+    assertEquals(normalizeUsage(response), {
+      inputTokens: 12,
+      outputTokens: 5,
+      totalTokens: 17,
+      cachedInputTokens: 3,
+      cacheCreationInputTokens: 2,
+      cacheReadInputTokens: 1,
+      reasoningTokens: 4,
+      billableInputTokens: 10,
+      billableOutputTokens: 5,
+      costUsd: 0.001,
+      providerCostUsd: 0.001,
+      veryfrontChargeUsd: 0.0025,
+      costCredits: 0.025,
+      costSource: "gateway",
+      usageCaptureStatus: "complete",
+    });
   });
 
   it("preserves agent tool input and output in eval traces", () => {

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -519,12 +519,44 @@ export async function hydrateEvalRuntimeAuth(
   });
 }
 
-function normalizeUsage(response: AgentResponse) {
+export function normalizeUsage(response: AgentResponse) {
   return response.usage
     ? {
       inputTokens: response.usage.promptTokens,
       outputTokens: response.usage.completionTokens,
       totalTokens: response.usage.totalTokens,
+      ...(response.usage.cachedInputTokens !== undefined
+        ? { cachedInputTokens: response.usage.cachedInputTokens }
+        : {}),
+      ...(response.usage.cacheCreationInputTokens !== undefined
+        ? { cacheCreationInputTokens: response.usage.cacheCreationInputTokens }
+        : {}),
+      ...(response.usage.cacheReadInputTokens !== undefined
+        ? { cacheReadInputTokens: response.usage.cacheReadInputTokens }
+        : {}),
+      ...(response.usage.reasoningTokens !== undefined
+        ? { reasoningTokens: response.usage.reasoningTokens }
+        : {}),
+      ...(response.usage.billableInputTokens !== undefined
+        ? { billableInputTokens: response.usage.billableInputTokens }
+        : {}),
+      ...(response.usage.billableOutputTokens !== undefined
+        ? { billableOutputTokens: response.usage.billableOutputTokens }
+        : {}),
+      ...(response.usage.costUsd !== undefined ? { costUsd: response.usage.costUsd } : {}),
+      ...(response.usage.providerCostUsd !== undefined
+        ? { providerCostUsd: response.usage.providerCostUsd }
+        : {}),
+      ...(response.usage.veryfrontChargeUsd !== undefined
+        ? { veryfrontChargeUsd: response.usage.veryfrontChargeUsd }
+        : {}),
+      ...(response.usage.costCredits !== undefined
+        ? { costCredits: response.usage.costCredits }
+        : {}),
+      ...(response.usage.costSource !== undefined ? { costSource: response.usage.costSource } : {}),
+      ...(response.usage.usageCaptureStatus !== undefined
+        ? { usageCaptureStatus: response.usage.usageCaptureStatus }
+        : {}),
     }
     : {};
 }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.958",
+  "version": "0.1.959",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.958";
+export const VERSION = "0.1.959";


### PR DESCRIPTION
## Summary
- preserve gateway usage metadata when CLI evals normalize agent responses
- add regression coverage for billable token, cost, and capture status fields
- bump package version to 0.1.959 for release

## Root cause
The eval CLI adapter mapped AgentResponse.usage down to prompt/completion/total tokens only. Gateway billing metadata was already present on the agent response, but was discarded before eval records and comparison reports were built.

## Verification
- deno test --allow-all cli/commands/eval/command.test.ts src/eval/report.test.ts src/eval/model-comparison.test.ts
- deno task fmt:check
- deno task lint
- deno task typecheck
- deno task verify:quick
- pre-push hook: 2212 passed / 19001 steps / 0 failed
