### PR TITLE
Prefer USD cost in eval model comparisons

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.961",
+  "version": "0.1.962",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/eval/model-comparison.test.ts
+++ b/src/eval/model-comparison.test.ts
@@ -232,7 +232,7 @@ describe("eval/model-comparison", () => {
     assertEquals(comparison.models[1]?.veryfrontBilledUsd, 1.5);
   });
 
-  it("uses gateway credits for comparison when billed USD is omitted", () => {
+  it("uses metered gateway cost before credits when billed USD is omitted", () => {
     const comparison = compareEvalModelReports(
       [
         createReport("anthropic/claude-sonnet-4-6", {
@@ -249,9 +249,32 @@ describe("eval/model-comparison", () => {
       { baselineModel: "anthropic/claude-sonnet-4-6" },
     );
 
-    assertEquals(comparison.candidates[0]?.decision, "needs-review");
+    assertEquals(comparison.candidates[0]?.decision, "promote-candidate");
+    assertEquals(comparison.candidates[0]?.costImprovementPct, 0.4285714285714286);
     assertEquals(comparison.models[0]?.veryfrontBilledUsd, undefined);
     assertEquals(comparison.models[1]?.veryfrontBilledUsd, undefined);
+    assertEquals(
+      comparison.candidates[0]?.reasons.includes("Veryfront metered cost improved by 43%"),
+      true,
+    );
+  });
+
+  it("uses gateway credits for comparison only when USD costs are omitted", () => {
+    const comparison = compareEvalModelReports(
+      [
+        createReport("anthropic/claude-sonnet-4-6", {
+          costCredits: 4,
+          costSource: "gateway",
+        }),
+        createReport("moonshotai/kimi-k2.6", {
+          costCredits: 16,
+          costSource: "gateway",
+        }),
+      ],
+      { baselineModel: "anthropic/claude-sonnet-4-6" },
+    );
+
+    assertEquals(comparison.candidates[0]?.decision, "needs-review");
     assertEquals(
       comparison.candidates[0]?.reasons.includes("Veryfront credits regressed by 300%"),
       true,

--- a/src/eval/model-comparison.ts
+++ b/src/eval/model-comparison.ts
@@ -110,18 +110,6 @@ function defaultCostComparison(
     };
   }
   if (
-    baselineSummary.costSource === "gateway" &&
-    candidateSummary.costSource === "gateway" &&
-    baselineSummary.costCredits !== undefined &&
-    candidateSummary.costCredits !== undefined
-  ) {
-    return {
-      baseline: baselineSummary.costCredits,
-      candidate: candidateSummary.costCredits,
-      label: "Veryfront credits",
-    };
-  }
-  if (
     baselineSummary.veryfrontChargeUsd !== undefined &&
     candidateSummary.veryfrontChargeUsd !== undefined
   ) {
@@ -146,6 +134,18 @@ function defaultCostComparison(
       baseline: baselineSummary.providerCostUsd,
       candidate: candidateSummary.providerCostUsd,
       label: "provider cost",
+    };
+  }
+  if (
+    baselineSummary.costSource === "gateway" &&
+    candidateSummary.costSource === "gateway" &&
+    baselineSummary.costCredits !== undefined &&
+    candidateSummary.costCredits !== undefined
+  ) {
+    return {
+      baseline: baselineSummary.costCredits,
+      candidate: candidateSummary.costCredits,
+      label: "Veryfront credits",
     };
   }
   return undefined;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.961";
+export const VERSION = "0.1.962";


### PR DESCRIPTION
## Summary
- Prefer dollar-denominated gateway costs before opaque credit counts in eval model comparison decisions.
- Keep credits as a fallback only when no comparable USD cost fields are available.
- Bump framework version to 0.1.962 for release.

## Why
The customer-operations-agent comparison report had gateway USD costs for both models and showed Kimi cheaper on metered USD, but the decision still used credits first and marked the candidate as a cost regression. That made the report inconsistent and too easy to misread.

## Validation
- deno test --allow-all src/eval/model-comparison.test.ts
- deno task verify:quick
- deno task test:unit
- pre-push hook: formatting, lint, typecheck, unit tests
