### PR TITLE
Generate markdown eval reports

### DIFF
--- a/cli/commands/eval/command-help.ts
+++ b/cli/commands/eval/command-help.ts
@@ -20,7 +20,7 @@ export const evalHelp: CommandHelp = {
     },
     {
       flag: "--report-dir <path>",
-      description: "Write summary.json and results.jsonl artifacts to a directory",
+      description: "Write summary.json, results.jsonl, and report.md artifacts to a directory",
     },
     {
       flag: "--junit <path>",

--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -8,6 +8,7 @@ import {
   createDefaultEvalReportDir,
   createEvalArtifactPaths,
   createEvalExitCode,
+  createEvalMarkdownReport,
   createEvalModelArtifactPaths,
   createEvalModelComparisonArtifact,
   createEvalModelComparisonExitCode,
@@ -76,6 +77,19 @@ function createReport(): EvalReport {
           passRate: 0.5,
         },
       ],
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        totalTokens: 120,
+        billableInputTokens: 90,
+        billableOutputTokens: 18,
+        providerCostUsd: 0.001,
+        veryfrontChargeUsd: 0.0025,
+        veryfrontBilledUsd: 0.1,
+        costCredits: 1,
+        costSource: "gateway",
+        usageCaptureStatus: "complete",
+      },
     },
     records: [
       {
@@ -88,7 +102,7 @@ function createReport(): EvalReport {
         reference: "Paris",
         metadata: {},
         trace: { events: [], toolCalls: [] },
-        usage: { totalTokens: 12 },
+        usage: { totalTokens: 12, veryfrontBilledUsd: 0.06, costCredits: 0.6 },
         durationMs: 12,
         completed: true,
         metrics: [
@@ -112,7 +126,7 @@ function createReport(): EvalReport {
         reference: "Paris",
         metadata: {},
         trace: { events: [], toolCalls: [] },
-        usage: { totalTokens: 10 },
+        usage: { totalTokens: 10, veryfrontBilledUsd: 0.04, costCredits: 0.4 },
         durationMs: 10,
         completed: true,
         metrics: [
@@ -355,6 +369,7 @@ describe("eval CLI command helpers", () => {
       directory: ".veryfront/evals/run-1",
       summary: ".veryfront/evals/run-1/summary.json",
       results: ".veryfront/evals/run-1/results.jsonl",
+      reportMarkdown: ".veryfront/evals/run-1/report.md",
     });
     assertEquals(
       createEvalModelArtifactPaths(".veryfront/evals/run-1", "anthropic/claude-opus-4-6"),
@@ -362,6 +377,7 @@ describe("eval CLI command helpers", () => {
         directory: ".veryfront/evals/run-1/models/anthropic__claude-opus-4-6",
         summary: ".veryfront/evals/run-1/models/anthropic__claude-opus-4-6/summary.json",
         results: ".veryfront/evals/run-1/models/anthropic__claude-opus-4-6/results.jsonl",
+        reportMarkdown: ".veryfront/evals/run-1/models/anthropic__claude-opus-4-6/report.md",
         junit: ".veryfront/evals/run-1/models/anthropic__claude-opus-4-6/junit.xml",
       },
     );
@@ -399,7 +415,17 @@ describe("eval CLI command helpers", () => {
     assertEquals(lines.map((record) => record.id), ["q1:1", "q2:1"]);
   });
 
-  it("writes summary and JSONL artifacts to the report directory", async () => {
+  it("renders a markdown eval report", () => {
+    const markdown = createEvalMarkdownReport(createReport());
+
+    assertStringIncludes(markdown, "# Eval report: eval:answers");
+    assertStringIncludes(markdown, "Result: `1/2 passed (50%)`");
+    assertStringIncludes(markdown, "| Veryfront billed USD | `$0.10` |");
+    assertStringIncludes(markdown, "| `q1:1` | PASS | 0.012s | 12 | `$0.06` | 0.6 |");
+    assertStringIncludes(markdown, "| `q2:1` | FAIL | 0.010s | 10 | `$0.04` | 0.4 |");
+  });
+
+  it("writes summary, JSONL, and markdown artifacts to the report directory", async () => {
     const tempDir = await Deno.makeTempDir();
     try {
       const paths = createEvalArtifactPaths(`${tempDir}/eval-report`);
@@ -410,10 +436,13 @@ describe("eval CLI command helpers", () => {
         summary: { records: number };
       };
       const results = (await Deno.readTextFile(paths.results)).trimEnd().split("\n");
+      const markdown = await Deno.readTextFile(paths.reportMarkdown);
 
       assertEquals(summary.kind, "eval-summary");
       assertEquals(summary.summary.records, 2);
       assertEquals(results.length, 2);
+      assertStringIncludes(markdown, "# Eval report: eval:answers");
+      assertStringIncludes(markdown, "| Veryfront billed USD | `$0.10` |");
     } finally {
       await Deno.remove(tempDir, { recursive: true });
     }

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -17,6 +17,7 @@ import type {
   EvalReportComparison,
   EvalReportExportConfig,
   EvalToolCall,
+  EvalUsage,
 } from "veryfront/eval";
 import { createProjectDiscoveryConfig, discoverAll } from "veryfront/discovery";
 import {
@@ -55,6 +56,7 @@ type EvalArtifactPaths = {
   directory: string;
   summary: string;
   results: string;
+  reportMarkdown: string;
 };
 
 type EvalModelArtifactPaths = EvalArtifactPaths & {
@@ -124,6 +126,7 @@ export function createEvalArtifactPaths(reportDir: string): EvalArtifactPaths {
     directory: reportDir,
     summary: join(reportDir, "summary.json"),
     results: join(reportDir, "results.jsonl"),
+    reportMarkdown: join(reportDir, "report.md"),
   };
 }
 
@@ -140,6 +143,7 @@ export function createEvalModelArtifactPaths(
     directory,
     summary: join(directory, "summary.json"),
     results: join(directory, "results.jsonl"),
+    reportMarkdown: join(directory, "report.md"),
     junit: join(directory, "junit.xml"),
   };
 }
@@ -421,6 +425,147 @@ export function createResultsJsonl(report: EvalReport): string {
   return `${report.records.map((record) => JSON.stringify(record)).join("\n")}\n`;
 }
 
+function markdownCell(value: string): string {
+  return value.replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+function numberCell(value: number | undefined): string {
+  return value === undefined ? "-" : String(Math.round(value));
+}
+
+function decimalCell(value: number | undefined): string {
+  if (value === undefined) return "-";
+  if (Number.isInteger(value)) return String(value);
+  return value.toFixed(4).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+function percentCell(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function durationCell(valueMs: number | undefined): string {
+  return valueMs === undefined ? "-" : `${(valueMs / 1000).toFixed(3)}s`;
+}
+
+function usdCell(value: number | undefined): string {
+  if (value === undefined) return "-";
+  const absolute = Math.abs(value);
+  if (absolute >= 0.01) return `$${value.toFixed(2)}`;
+  return `$${value.toFixed(6).replace(/0+$/, "").replace(/\.$/, "")}`;
+}
+
+function examplePassed(record: EvalRecord): boolean {
+  return [...(record.metrics ?? []), ...(record.checks ?? [])].every((result) =>
+    result.skipped || result.pass !== false
+  );
+}
+
+function usageRows(usage: EvalUsage | undefined): Array<[string, string]> {
+  if (!usage) return [];
+  const rows: Array<[string, string]> = [
+    ["Input tokens", numberCell(usage.inputTokens)],
+    ["Output tokens", numberCell(usage.outputTokens)],
+    ["Total tokens", numberCell(usage.totalTokens)],
+    ["Billable input tokens", numberCell(usage.billableInputTokens)],
+    ["Billable output tokens", numberCell(usage.billableOutputTokens)],
+    ["Provider cost USD", usdCell(usage.providerCostUsd ?? usage.costUsd)],
+    ["Veryfront charge USD", usdCell(usage.veryfrontChargeUsd)],
+    ["Veryfront billed USD", usdCell(usage.veryfrontBilledUsd)],
+    ["Cost credits", decimalCell(usage.costCredits)],
+    ["Cost source", usage.costSource ?? "-"],
+    ["Usage capture status", usage.usageCaptureStatus ?? "-"],
+  ];
+  return rows.filter(([, value]) => value !== "-");
+}
+
+/** Render a human-reviewable markdown report for a single eval run. */
+export function createEvalMarkdownReport(
+  report: EvalReport,
+  baseline?: EvalReportComparison,
+): string {
+  const lines = [
+    `# Eval report: ${markdownCell(report.definitionId)}`,
+    "",
+    `Run: \`${markdownCell(report.runId)}\``,
+    `Target: \`${markdownCell(report.target)}\``,
+    ...(report.metadata?.model ? [`Model: \`${markdownCell(report.metadata.model)}\``] : []),
+    `Result: \`${report.summary.passed}/${report.summary.records} passed (${
+      percentCell(report.summary.passRate)
+    })\``,
+    "",
+    "## Metrics",
+    "",
+    "| Metric | Severity | Passed | Failed | Pass rate |",
+    "| --- | --- | ---: | ---: | ---: |",
+  ];
+
+  for (const metric of report.summary.metrics) {
+    lines.push(
+      `| \`${
+        markdownCell(metric.name)
+      }\` | ${metric.severity} | ${metric.passed} | ${metric.failed} | ${
+        percentCell(metric.passRate)
+      } |`,
+    );
+  }
+
+  const rows = usageRows(report.summary.usage);
+  if (rows.length > 0) {
+    lines.push("", "## Usage", "", "| Usage | Value |", "| --- | ---: |");
+    for (const [label, value] of rows) {
+      lines.push(`| ${label} | ${value.startsWith("$") ? `\`${value}\`` : value} |`);
+    }
+  }
+
+  lines.push(
+    "",
+    "## Examples",
+    "",
+    "| Example | Result | Duration | Tokens | Billed USD | Credits |",
+    "| --- | ---: | ---: | ---: | ---: | ---: |",
+  );
+
+  for (const record of report.records) {
+    lines.push(
+      `| \`${markdownCell(record.id)}\` | ${examplePassed(record) ? "PASS" : "FAIL"} | ${
+        durationCell(record.durationMs)
+      } | ${numberCell(record.usage.totalTokens)} | ${
+        record.usage.veryfrontBilledUsd === undefined
+          ? "-"
+          : `\`${usdCell(record.usage.veryfrontBilledUsd)}\``
+      } | ${decimalCell(record.usage.costCredits)} |`,
+    );
+  }
+
+  if (baseline) {
+    const direction = baseline.passRateDelta >= 0 ? "+" : "";
+    lines.push(
+      "",
+      "## Baseline",
+      "",
+      `Status: \`${baseline.regressed ? "regressed" : "ok"}\``,
+      `Pass rate delta: \`${direction}${Math.round(baseline.passRateDelta * 100)} pp\``,
+    );
+    if (baseline.newFailedExamples.length > 0) {
+      lines.push(`New failed examples: ${baseline.newFailedExamples.map(markdownCell).join(", ")}`);
+    }
+  }
+
+  if (report.exports?.length) {
+    lines.push("", "## Exports", "");
+    for (const result of report.exports) {
+      lines.push(
+        `- \`${markdownCell(result.exporterId)}\`: ${
+          result.ok ? "ok" : `failed, ${markdownCell(result.error)}`
+        }`,
+      );
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
 export function createJunitXml(report: EvalReport): string {
   const skipped = report.records.reduce(
     (count, record) => count + skippedResults(record).length,
@@ -482,6 +627,7 @@ export async function writeEvalArtifacts(
     JSON.stringify(createSummaryArtifact(report, baseline), null, 2),
   );
   await Deno.writeTextFile(paths.results, createResultsJsonl(report));
+  await Deno.writeTextFile(paths.reportMarkdown, createEvalMarkdownReport(report, baseline));
 }
 
 async function readEvalReport(path: string): Promise<EvalReport> {
@@ -993,6 +1139,7 @@ export async function evalCommand(options: EvalOptions): Promise<void> {
     } else {
       printReport(report, baseline);
       cliLogger.info(`Report directory: ${artifactPaths.directory}`);
+      cliLogger.info(`Report markdown: ${artifactPaths.reportMarkdown}`);
       if (options.report) cliLogger.info(`Report: ${options.report}`);
       if (options.junit) cliLogger.info(`JUnit: ${options.junit}`);
       if (options.writeBaseline) cliLogger.info(`Baseline written: ${options.writeBaseline}`);

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.963",
+  "version": "0.1.964",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.963";
+export const VERSION = "0.1.964";


### PR DESCRIPTION
## Summary
- generate report.md beside summary.json and results.jsonl for single eval report directories
- include metrics, usage, per-example billing, baseline, and export sections in the Markdown report
- print the report.md path after single eval runs and update eval help text
- bump version to 0.1.964 for release

## Verification
- deno fmt --check cli/commands/eval/command.ts cli/commands/eval/command.test.ts cli/commands/eval/command-help.ts deno.json src/utils/version-constant.ts
- deno test -A cli/commands/eval/command.test.ts src/eval/model-comparison.test.ts
- deno check cli/main.ts src/eval/index.ts
- git diff --check
- source CLI smoke in customer-operations-agent generated summary.json, results.jsonl, and report.md
- pre-push full suite passed: 2212 passed, 0 failed