### PR TITLE
Timestamp eval report directories

### DIFF
--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -362,7 +362,15 @@ describe("eval CLI command helpers", () => {
       [
         ".veryfront",
         "evals",
-        "evalrun_20260621_010203000",
+        "20260621_010203000",
+      ].join("/"),
+    );
+    assertEquals(
+      createDefaultEvalReportDir("evalrun_20260621_010203000", "eval:support-triage"),
+      [
+        ".veryfront",
+        "evals",
+        "20260621_010203000-support-triage",
       ].join("/"),
     );
     assertEquals(createEvalArtifactPaths(".veryfront/evals/run-1"), {
@@ -423,6 +431,36 @@ describe("eval CLI command helpers", () => {
     assertStringIncludes(markdown, "| Veryfront billed USD | `$0.10` |");
     assertStringIncludes(markdown, "| `q1:1` | PASS | 0.012s | 12 | `$0.06` | 0.6 |");
     assertStringIncludes(markdown, "| `q2:1` | FAIL | 0.010s | 10 | `$0.04` | 0.4 |");
+  });
+
+  it("renders examples with only soft metric misses as passing", () => {
+    const report = createReport();
+    const softReport: EvalReport = {
+      ...report,
+      summary: {
+        ...report.summary,
+        passed: 2,
+        failed: 0,
+        passRate: 1,
+        metrics: report.summary.metrics.map((metric) => ({
+          ...metric,
+          severity: "soft",
+        })),
+        failedExamples: [],
+      },
+      records: report.records.map((record) => ({
+        ...record,
+        metrics: (record.metrics ?? []).map((metric) => ({
+          ...metric,
+          severity: "soft",
+        })),
+      })),
+    };
+
+    const markdown = createEvalMarkdownReport(softReport);
+
+    assertStringIncludes(markdown, "Result: `2/2 passed (100%)`");
+    assertStringIncludes(markdown, "| `q2:1` | PASS | 0.010s | 10 | `$0.04` | 0.4 |");
   });
 
   it("writes summary, JSONL, and markdown artifacts to the report directory", async () => {

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -117,8 +117,22 @@ function createCliRunId(now = new Date()): string {
   return `evalrun_${now.toISOString().replace(/[-:.]/g, "").replace("T", "_").replace("Z", "")}`;
 }
 
-export function createDefaultEvalReportDir(runId: string): string {
-  return join(".veryfront", "evals", runId);
+function createEvalReportDirTimestamp(runId: string): string {
+  return runId.startsWith("evalrun_") ? runId.slice("evalrun_".length) : runId;
+}
+
+function sanitizeEvalReportDirLabel(label: string): string {
+  const normalized = label.startsWith("eval:") ? label.slice("eval:".length) : label;
+  return normalized.trim().replace(/[^A-Za-z0-9._-]+/g, "-").replace(/-+/g, "-").replace(
+    /^[-._]+|[-._]+$/g,
+    "",
+  );
+}
+
+export function createDefaultEvalReportDir(runId: string, label?: string): string {
+  const timestamp = createEvalReportDirTimestamp(runId);
+  const suffix = label ? sanitizeEvalReportDirLabel(label) : "";
+  return join(".veryfront", "evals", suffix ? `${timestamp}-${suffix}` : timestamp);
 }
 
 export function createEvalArtifactPaths(reportDir: string): EvalArtifactPaths {
@@ -454,9 +468,15 @@ function usdCell(value: number | undefined): string {
   return `$${value.toFixed(6).replace(/0+$/, "").replace(/\.$/, "")}`;
 }
 
+function isBlockingEvalResultFailure(result: EvalMetricResult): boolean {
+  return !result.skipped && result.pass === false &&
+    (result.severity === "gate" || result.severity === "budget");
+}
+
 function examplePassed(record: EvalRecord): boolean {
+  if (!record.completed || record.error) return false;
   return [...(record.metrics ?? []), ...(record.checks ?? [])].every((result) =>
-    result.skipped || result.pass !== false
+    !isBlockingEvalResultFailure(result)
   );
 }
 
@@ -892,7 +912,8 @@ async function runEvalModelComparison(input: {
   policy: EvalModelComparisonPolicy;
 }): Promise<void> {
   const runId = createCliRunId();
-  const reportDir = input.options.reportDir ?? createDefaultEvalReportDir(runId);
+  const reportDir = input.options.reportDir ??
+    createDefaultEvalReportDir(runId, input.evalItem.id);
   const paths = createEvalModelComparisonArtifactPaths(reportDir, input.config.models);
   const provenance = await resolveEvalRunProvenance({
     projectDir: input.projectDir,
@@ -1095,7 +1116,7 @@ export async function evalCommand(options: EvalOptions): Promise<void> {
 
     const runId = createCliRunId();
     const artifactPaths = createEvalArtifactPaths(
-      options.reportDir ?? createDefaultEvalReportDir(runId),
+      options.reportDir ?? createDefaultEvalReportDir(runId, evalItem.id),
     );
     const provenance = await resolveEvalRunProvenance({
       projectDir,

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.964",
+  "version": "0.1.965",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.964";
+export const VERSION = "0.1.965";


### PR DESCRIPTION
## Summary

- Make default eval report directories start with the run timestamp, with the eval id as a readable suffix, e.g. `.veryfront/evals/20260628_114921425-support-triage`.
- Keep the internal run id unchanged as `evalrun_...`.
- Align markdown example PASS/FAIL labels with eval runner semantics so soft metric misses do not contradict a passing run summary.
- Bump CLI version to `0.1.965` for release.

## Verification

- `deno test -A cli/commands/eval/command.test.ts src/eval/model-comparison.test.ts`
- `deno check cli/main.ts src/eval/index.ts`
- `deno fmt --check cli/commands/eval/command.ts cli/commands/eval/command.test.ts deno.json src/utils/version-constant.ts && git diff --check`
- Source CLI single-model eval generated `.veryfront/evals/20260628_114727101-support-triage/report.md` with `4/4 passed` and all examples marked `PASS`.
- Source CLI model comparison generated `.veryfront/evals/20260628_114921425-support-triage/comparison.md`.
- Pre-push hook passed: format, lint, typecheck, and `2212` unit tests, `0` failures.

## Comparison result

Baseline: `anthropic/claude-opus-4-6`
Candidate: `moonshotai/kimi-k2.6`
Recommendation: `needs-review`

Both models passed `4/4`. Kimi used fewer total tokens and had lower provider/metered cost, but Veryfront billed cost regressed by `275%` in this run, so it should not be promoted automatically.
