### PR TITLE
Capture Anthropic gateway billing on tool turns

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.966",
+  "version": "0.1.967",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
@@ -3,11 +3,22 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { streamAnthropicCompatibleParts } from "./anthropic-stream.ts";
 
 function streamFromText(text: string): ReadableStream<Uint8Array> {
+  return streamFromChunks([text], { close: true });
+}
+
+function streamFromChunks(
+  chunks: string[],
+  options: { close: boolean },
+): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
   return new ReadableStream({
     start(controller) {
-      controller.enqueue(encoder.encode(text));
-      controller.close();
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      if (options.close) {
+        controller.close();
+      }
     },
   });
 }
@@ -18,6 +29,47 @@ async function collectParts(stream: ReadableStream<Uint8Array>): Promise<unknown
     parts.push(part);
   }
   return parts;
+}
+
+async function collectFirstParts(
+  stream: ReadableStream<Uint8Array>,
+  count: number,
+): Promise<unknown[]> {
+  const parts: unknown[] = [];
+  const iterator = streamAnthropicCompatibleParts(stream)[Symbol.asyncIterator]();
+  try {
+    for (let index = 0; index < count; index++) {
+      const next = await nextWithTimeout(iterator, 500);
+      if (next.done) {
+        break;
+      }
+      parts.push(next.value);
+    }
+  } finally {
+    await iterator.return?.();
+  }
+  return parts;
+}
+
+async function nextWithTimeout<T>(
+  iterator: AsyncIterator<T>,
+  timeoutMs: number,
+): Promise<IteratorResult<T>> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      iterator.next(),
+      new Promise<IteratorResult<T>>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error(`timed out after ${timeoutMs}ms waiting for stream part`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
 }
 
 function data(payload: unknown): string {
@@ -186,24 +238,26 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
   });
 
   it("preserves gateway billing metadata appended after a client tool-use step", async () => {
-    const parts = await collectParts(streamFromText([
-      data({
-        type: "content_block_start",
-        index: 0,
-        content_block: { type: "tool_use", id: "toolu_1", name: "bash" },
-      }),
-      data({
-        type: "content_block_delta",
-        index: 0,
-        delta: { type: "input_json_delta", partial_json: '{"command":"pwd"}' },
-      }),
-      data({ type: "content_block_stop", index: 0 }),
-      data({
-        type: "message_delta",
-        delta: { stop_reason: "tool_use" },
-        usage: { output_tokens: 4 },
-      }),
-      data({ type: "message_stop" }),
+    const parts = await collectParts(streamFromChunks([
+      [
+        data({
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "tool_use", id: "toolu_1", name: "bash" },
+        }),
+        data({
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "input_json_delta", partial_json: '{"command":"pwd"}' },
+        }),
+        data({ type: "content_block_stop", index: 0 }),
+        data({
+          type: "message_delta",
+          delta: { stop_reason: "tool_use" },
+          usage: { output_tokens: 4 },
+        }),
+        data({ type: "message_stop" }),
+      ].join(""),
       data({
         type: "message_delta",
         delta: {},
@@ -222,7 +276,7 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
           },
         },
       }),
-    ].join("")));
+    ], { close: true }));
 
     assertEquals(parts, [
       { type: "tool-input-start", id: "toolu_1", toolName: "bash" },
@@ -248,6 +302,54 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
           costCredits: 1,
           costSource: "gateway",
           usageCaptureStatus: "complete",
+        },
+      },
+    ]);
+  });
+
+  it("finishes a client tool-use step when trailing metadata never arrives", async () => {
+    const parts = await collectFirstParts(
+      streamFromChunks(
+        [
+          data({
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "tool_use", id: "toolu_1", name: "bash" },
+          }),
+          data({
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "input_json_delta", partial_json: '{"command":"pwd"}' },
+          }),
+          data({ type: "content_block_stop", index: 0 }),
+          data({
+            type: "message_delta",
+            delta: { stop_reason: "tool_use" },
+            usage: { output_tokens: 4 },
+          }),
+          data({ type: "message_stop" }),
+        ].join(""),
+        { close: false },
+      ),
+      4,
+    );
+
+    assertEquals(parts, [
+      { type: "tool-input-start", id: "toolu_1", toolName: "bash" },
+      { type: "tool-input-delta", id: "toolu_1", delta: '{"command":"pwd"}' },
+      {
+        type: "tool-call",
+        toolCallId: "toolu_1",
+        toolName: "bash",
+        input: '{"command":"pwd"}',
+      },
+      {
+        type: "finish",
+        finishReason: { unified: "tool-calls", raw: "tool_use" },
+        usage: {
+          inputTokens: undefined,
+          outputTokens: 4,
+          totalTokens: 4,
         },
       },
     ]);

--- a/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
@@ -12,15 +12,6 @@ function streamFromText(text: string): ReadableStream<Uint8Array> {
   });
 }
 
-function hangingStreamFromText(text: string): ReadableStream<Uint8Array> {
-  const encoder = new TextEncoder();
-  return new ReadableStream({
-    start(controller) {
-      controller.enqueue(encoder.encode(text));
-    },
-  });
-}
-
 async function collectParts(stream: ReadableStream<Uint8Array>): Promise<unknown[]> {
   const parts: unknown[] = [];
   for await (const part of streamAnthropicCompatibleParts(stream)) {
@@ -194,30 +185,44 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
     ]);
   });
 
-  it("ends a client tool-use step once the tool call is complete", async () => {
-    let timeoutId: number | undefined;
-    const parts = await Promise.race([
-      collectParts(hangingStreamFromText([
-        data({
-          type: "content_block_start",
-          index: 0,
-          content_block: { type: "tool_use", id: "toolu_1", name: "bash" },
-        }),
-        data({
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "input_json_delta", partial_json: '{"command":"pwd"}' },
-        }),
-        data({ type: "content_block_stop", index: 0 }),
-      ].join(""))),
-      new Promise<"timeout">((resolve) => {
-        timeoutId = setTimeout(() => resolve("timeout"), 50);
+  it("preserves gateway billing metadata appended after a client tool-use step", async () => {
+    const parts = await collectParts(streamFromText([
+      data({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "tool_use", id: "toolu_1", name: "bash" },
       }),
-    ]).finally(() => {
-      if (timeoutId !== undefined) {
-        clearTimeout(timeoutId);
-      }
-    });
+      data({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '{"command":"pwd"}' },
+      }),
+      data({ type: "content_block_stop", index: 0 }),
+      data({
+        type: "message_delta",
+        delta: { stop_reason: "tool_use" },
+        usage: { output_tokens: 4 },
+      }),
+      data({ type: "message_stop" }),
+      data({
+        type: "message_delta",
+        delta: {},
+        usage: {
+          input_tokens: 10,
+          output_tokens: 4,
+          veryfront: {
+            billable_input_tokens: 10,
+            billable_output_tokens: 4,
+            provider_cost_usd: 0.001,
+            veryfront_charge_usd: 0.0025,
+            veryfront_billed_usd: 0.1,
+            cost_credits: 1,
+            cost_source: "gateway",
+            usage_capture_status: "complete",
+          },
+        },
+      }),
+    ].join("")));
 
     assertEquals(parts, [
       { type: "tool-input-start", id: "toolu_1", toolName: "bash" },
@@ -231,6 +236,19 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
       {
         type: "finish",
         finishReason: { unified: "tool-calls", raw: "tool_use" },
+        usage: {
+          inputTokens: 10,
+          outputTokens: 4,
+          totalTokens: 14,
+          billableInputTokens: 10,
+          billableOutputTokens: 4,
+          providerCostUsd: 0.001,
+          veryfrontChargeUsd: 0.0025,
+          veryfrontBilledUsd: 0.1,
+          costCredits: 1,
+          costSource: "gateway",
+          usageCaptureStatus: "complete",
+        },
       },
     ]);
   });

--- a/extensions/ext-llm-anthropic/src/anthropic-stream.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.ts
@@ -358,12 +358,7 @@ export async function* streamAnthropicCompatibleParts(
     }
 
     if (completedClientToolUseStep && toolCalls.size === 0) {
-      yield {
-        type: "finish",
-        finishReason: { unified: "tool-calls", raw: "tool_use" },
-        ...(usage ? { usage } : {}),
-      };
-      return;
+      finishReason ??= { unified: "tool-calls", raw: "tool_use" };
     }
   }
 
@@ -380,7 +375,8 @@ export async function* streamAnthropicCompatibleParts(
 
   yield {
     type: "finish",
-    finishReason,
+    finishReason: finishReason ??
+      (completedClientToolUseStep ? { unified: "tool-calls", raw: "tool_use" } : null),
     ...(usage ? { usage } : {}),
   };
 }

--- a/extensions/ext-llm-anthropic/src/anthropic-stream.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.ts
@@ -20,6 +20,18 @@ type AnthropicStreamReasoningState = {
   redactedData?: string;
 };
 
+type AnthropicStreamOptions = {
+  clientToolUseTrailingUsageGraceMs?: number;
+};
+
+type AnthropicStreamReadResult =
+  | { kind: "chunk"; chunk: Uint8Array }
+  | { kind: "done" }
+  | { kind: "timeout" };
+
+const CLIENT_TOOL_USE_FINISH_REASON = { unified: "tool-calls", raw: "tool_use" } as const;
+const DEFAULT_CLIENT_TOOL_USE_TRAILING_USAGE_GRACE_MS = 100;
+
 function isEmptyRecord(value: unknown): value is Record<string, never> {
   return Boolean(
     value &&
@@ -112,271 +124,397 @@ export function extractAnthropicUsage(payload: unknown): RuntimeUsage | undefine
   };
 }
 
+function isToolCallsFinishReason(
+  finishReason: string | { unified: string; raw: string } | null,
+): boolean {
+  return finishReason === "tool-calls" ||
+    (typeof finishReason === "object" && finishReason?.unified === "tool-calls");
+}
+
+function hasGatewayUsageMetadata(usage: RuntimeUsage | undefined): boolean {
+  return usage?.billableInputTokens !== undefined ||
+    usage?.billableOutputTokens !== undefined ||
+    usage?.providerInputCostUsd !== undefined ||
+    usage?.providerOutputCostUsd !== undefined ||
+    usage?.providerCostUsd !== undefined ||
+    usage?.veryfrontInputChargeUsd !== undefined ||
+    usage?.veryfrontOutputChargeUsd !== undefined ||
+    usage?.veryfrontChargeUsd !== undefined ||
+    usage?.veryfrontBilledUsd !== undefined ||
+    usage?.costCredits !== undefined ||
+    usage?.costSource !== undefined ||
+    usage?.usageCaptureStatus !== undefined;
+}
+
+async function readStreamChunk(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  timeoutMs?: number,
+): Promise<AnthropicStreamReadResult> {
+  if (timeoutMs === undefined) {
+    const read = await reader.read();
+    return read.done ? { kind: "done" } : { kind: "chunk", chunk: read.value };
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const readPromise = reader.read().then((read): AnthropicStreamReadResult =>
+    read.done ? { kind: "done" } : { kind: "chunk", chunk: read.value }
+  );
+  const timeoutPromise = new Promise<AnthropicStreamReadResult>((resolve) => {
+    timeoutId = setTimeout(() => resolve({ kind: "timeout" }), Math.max(1, timeoutMs));
+  });
+
+  try {
+    const result = await Promise.race([readPromise, timeoutPromise]);
+    if (result.kind === "timeout") {
+      await cancelStreamReader(
+        reader,
+        "Timed out waiting for trailing Anthropic tool-use usage metadata",
+      );
+    }
+    return result;
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+async function cancelStreamReader(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  reason: string,
+): Promise<void> {
+  try {
+    await reader.cancel(reason);
+  } catch {
+    // The upstream body may already be closed or canceled by the runtime.
+  }
+}
+
 export async function* streamAnthropicCompatibleParts(
   stream: ReadableStream<Uint8Array>,
+  options: AnthropicStreamOptions = {},
 ): AsyncIterable<unknown> {
   const decoder = new TextDecoder();
+  const reader = stream.getReader();
+  const trailingUsageGraceMs = options.clientToolUseTrailingUsageGraceMs ??
+    DEFAULT_CLIENT_TOOL_USE_TRAILING_USAGE_GRACE_MS;
   let buffer = "";
   const toolCalls = new Map<number, AnthropicStreamToolCallState>();
   const reasoningBlocks = new Map<number, AnthropicStreamReasoningState>();
   let finishReason: string | { unified: string; raw: string } | null = null;
   let usage: RuntimeUsage | undefined;
   let completedClientToolUseStep = false;
+  let clientToolUseIdleDeadlineMs: number | null = null;
+  let clientToolUseTerminalDeadlineMs: number | null = null;
 
-  for await (const chunk of stream) {
-    buffer += decoder.decode(chunk, { stream: true });
-    const parsed = parseSseChunk(buffer);
+  const mergeTrailingBufferUsage = () => {
+    if (buffer.trim().length === 0) {
+      return;
+    }
+
+    const parsed = parseSseChunk(`${buffer}\n\n`);
     buffer = parsed.remainder;
-
     for (const event of parsed.events) {
       if (event === "[DONE]") {
         continue;
       }
-
       const record = readRecord(event);
-      const eventType = typeof record?.type === "string" ? record.type : undefined;
       usage = mergeUsage(usage, extractAnthropicUsage(record));
+    }
+  };
 
-      if (eventType === "message_start") {
-        usage = mergeUsage(usage, extractAnthropicUsage(record?.message));
-        continue;
+  const getClientToolUseReadTimeoutMs = () => {
+    if (!completedClientToolUseStep || toolCalls.size > 0) {
+      return undefined;
+    }
+
+    const deadline = isToolCallsFinishReason(finishReason)
+      ? clientToolUseTerminalDeadlineMs
+      : clientToolUseIdleDeadlineMs;
+    return deadline === null ? undefined : Math.max(1, deadline - Date.now());
+  };
+
+  const buildFinishPart = () => ({
+    type: "finish",
+    finishReason: finishReason ??
+      (completedClientToolUseStep ? CLIENT_TOOL_USE_FINISH_REASON : null),
+    ...(usage ? { usage } : {}),
+  });
+
+  try {
+    while (true) {
+      const read = await readStreamChunk(reader, getClientToolUseReadTimeoutMs());
+      if (read.kind === "timeout") {
+        mergeTrailingBufferUsage();
+        finishReason ??= CLIENT_TOOL_USE_FINISH_REASON;
+        yield buildFinishPart();
+        return;
       }
 
-      if (eventType === "content_block_start") {
-        const index = typeof record?.index === "number" ? record.index : 0;
-        const contentBlock = readRecord(record?.content_block);
-        const blockType = typeof contentBlock?.type === "string" ? contentBlock.type : undefined;
-
-        if (
-          blockType === "text" && typeof contentBlock?.text === "string" &&
-          contentBlock.text.length > 0
-        ) {
-          yield { type: "text-delta", delta: contentBlock.text };
-          continue;
-        }
-
-        if (blockType === "thinking") {
-          const reasoningId = `thinking-${index}`;
-          reasoningBlocks.set(index, { id: reasoningId, text: "" });
-          yield {
-            type: "reasoning-start",
-            id: reasoningId,
-          };
-
-          if (typeof contentBlock?.thinking === "string" && contentBlock.thinking.length > 0) {
-            const current = reasoningBlocks.get(index);
-            if (current) {
-              current.text += contentBlock.thinking;
-            }
-            yield {
-              type: "reasoning-delta",
-              id: reasoningId,
-              delta: contentBlock.thinking,
-            };
-          }
-          continue;
-        }
-
-        // Redacted thinking blocks arrive as opaque encrypted payloads when
-        // Claude's safety classifier flags the reasoning trace. Surface them
-        // as a zero-length reasoning block so callers know thinking happened
-        // without leaking the (legitimately hidden) contents.
-        if (blockType === "redacted_thinking") {
-          const reasoningId = `thinking-${index}`;
-          reasoningBlocks.set(index, {
-            id: reasoningId,
-            text: "",
-            ...(typeof contentBlock?.data === "string" ? { redactedData: contentBlock.data } : {}),
-          });
-          yield {
-            type: "reasoning-start",
-            id: reasoningId,
-          };
-          continue;
-        }
-
-        if (
-          (blockType === "tool_use" || blockType === "server_tool_use") &&
-          typeof contentBlock?.id === "string" &&
-          typeof contentBlock?.name === "string"
-        ) {
-          const providerExecuted = blockType === "server_tool_use" ? true : undefined;
-          const current: AnthropicStreamToolCallState = {
-            id: contentBlock.id,
-            name: contentBlock.name,
-            input: "",
-            ...(providerExecuted ? { providerExecuted } : {}),
-          };
-
-          toolCalls.set(index, current);
-          yield {
-            type: "tool-input-start",
-            id: current.id,
-            toolName: current.name,
-            ...(providerExecuted ? { providerExecuted } : {}),
-          };
-
-          const initialInput = contentBlock.input;
-          if (initialInput !== undefined && !isEmptyRecord(initialInput)) {
-            const serializedInput = stringifyJsonValue(initialInput);
-            current.input += serializedInput;
-            yield {
-              type: "tool-input-delta",
-              id: current.id,
-              delta: serializedInput,
-            };
-          }
-          continue;
-        }
-
-        if (
-          blockType === "web_search_tool_result" &&
-          typeof contentBlock?.tool_use_id === "string" &&
-          Array.isArray(contentBlock?.content)
-        ) {
-          yield {
-            type: "tool-result",
-            toolCallId: contentBlock.tool_use_id,
-            toolName: "web_search",
-            result: contentBlock.content,
-            providerExecuted: true,
-          };
-        }
-
-        if (
-          blockType === "web_fetch_tool_result" &&
-          typeof contentBlock?.tool_use_id === "string" &&
-          readRecord(contentBlock?.content)
-        ) {
-          yield {
-            type: "tool-result",
-            toolCallId: contentBlock.tool_use_id,
-            toolName: "web_fetch",
-            result: contentBlock.content,
-            providerExecuted: true,
-          };
-        }
-
-        continue;
+      if (read.kind === "done") {
+        break;
       }
 
-      if (eventType === "content_block_delta") {
-        const index = typeof record?.index === "number" ? record.index : 0;
-        const delta = readRecord(record?.delta);
-        const deltaType = typeof delta?.type === "string" ? delta.type : undefined;
+      buffer += decoder.decode(read.chunk, { stream: true });
+      const parsed = parseSseChunk(buffer);
+      buffer = parsed.remainder;
 
-        if (
-          deltaType === "text_delta" && typeof delta?.text === "string" && delta.text.length > 0
-        ) {
-          yield { type: "text-delta", delta: delta.text };
+      for (const event of parsed.events) {
+        if (event === "[DONE]") {
           continue;
         }
 
-        if (
-          deltaType === "thinking_delta" && typeof delta?.thinking === "string" &&
-          delta.thinking.length > 0
-        ) {
-          const current = reasoningBlocks.get(index);
-          if (!current) {
+        const record = readRecord(event);
+        const eventType = typeof record?.type === "string" ? record.type : undefined;
+        usage = mergeUsage(usage, extractAnthropicUsage(record));
+
+        if (eventType === "message_start") {
+          usage = mergeUsage(usage, extractAnthropicUsage(record?.message));
+          continue;
+        }
+
+        if (eventType === "content_block_start") {
+          const index = typeof record?.index === "number" ? record.index : 0;
+          const contentBlock = readRecord(record?.content_block);
+          const blockType = typeof contentBlock?.type === "string" ? contentBlock.type : undefined;
+
+          if (
+            blockType === "text" && typeof contentBlock?.text === "string" &&
+            contentBlock.text.length > 0
+          ) {
+            yield { type: "text-delta", delta: contentBlock.text };
             continue;
           }
 
-          current.text += delta.thinking;
-          yield {
-            type: "reasoning-delta",
-            id: current.id,
-            delta: delta.thinking,
-          };
-          continue;
-        }
+          if (blockType === "thinking") {
+            const reasoningId = `thinking-${index}`;
+            reasoningBlocks.set(index, { id: reasoningId, text: "" });
+            yield {
+              type: "reasoning-start",
+              id: reasoningId,
+            };
 
-        if (deltaType === "signature_delta" && typeof delta?.signature === "string") {
-          const current = reasoningBlocks.get(index);
-          if (current) {
-            current.signature = delta.signature;
+            if (typeof contentBlock?.thinking === "string" && contentBlock.thinking.length > 0) {
+              const current = reasoningBlocks.get(index);
+              if (current) {
+                current.text += contentBlock.thinking;
+              }
+              yield {
+                type: "reasoning-delta",
+                id: reasoningId,
+                delta: contentBlock.thinking,
+              };
+            }
+            continue;
           }
+
+          // Redacted thinking blocks arrive as opaque encrypted payloads when
+          // Claude's safety classifier flags the reasoning trace. Surface them
+          // as a zero-length reasoning block so callers know thinking happened
+          // without leaking the (legitimately hidden) contents.
+          if (blockType === "redacted_thinking") {
+            const reasoningId = `thinking-${index}`;
+            reasoningBlocks.set(index, {
+              id: reasoningId,
+              text: "",
+              ...(typeof contentBlock?.data === "string"
+                ? { redactedData: contentBlock.data }
+                : {}),
+            });
+            yield {
+              type: "reasoning-start",
+              id: reasoningId,
+            };
+            continue;
+          }
+
+          if (
+            (blockType === "tool_use" || blockType === "server_tool_use") &&
+            typeof contentBlock?.id === "string" &&
+            typeof contentBlock?.name === "string"
+          ) {
+            const providerExecuted = blockType === "server_tool_use" ? true : undefined;
+            const current: AnthropicStreamToolCallState = {
+              id: contentBlock.id,
+              name: contentBlock.name,
+              input: "",
+              ...(providerExecuted ? { providerExecuted } : {}),
+            };
+
+            toolCalls.set(index, current);
+            clientToolUseIdleDeadlineMs = null;
+            clientToolUseTerminalDeadlineMs = null;
+            yield {
+              type: "tool-input-start",
+              id: current.id,
+              toolName: current.name,
+              ...(providerExecuted ? { providerExecuted } : {}),
+            };
+
+            const initialInput = contentBlock.input;
+            if (initialInput !== undefined && !isEmptyRecord(initialInput)) {
+              const serializedInput = stringifyJsonValue(initialInput);
+              current.input += serializedInput;
+              yield {
+                type: "tool-input-delta",
+                id: current.id,
+                delta: serializedInput,
+              };
+            }
+            continue;
+          }
+
+          if (
+            blockType === "web_search_tool_result" &&
+            typeof contentBlock?.tool_use_id === "string" &&
+            Array.isArray(contentBlock?.content)
+          ) {
+            yield {
+              type: "tool-result",
+              toolCallId: contentBlock.tool_use_id,
+              toolName: "web_search",
+              result: contentBlock.content,
+              providerExecuted: true,
+            };
+          }
+
+          if (
+            blockType === "web_fetch_tool_result" &&
+            typeof contentBlock?.tool_use_id === "string" &&
+            readRecord(contentBlock?.content)
+          ) {
+            yield {
+              type: "tool-result",
+              toolCallId: contentBlock.tool_use_id,
+              toolName: "web_fetch",
+              result: contentBlock.content,
+              providerExecuted: true,
+            };
+          }
+
           continue;
         }
 
-        if (deltaType === "input_json_delta" && typeof delta?.partial_json === "string") {
+        if (eventType === "content_block_delta") {
+          const index = typeof record?.index === "number" ? record.index : 0;
+          const delta = readRecord(record?.delta);
+          const deltaType = typeof delta?.type === "string" ? delta.type : undefined;
+
+          if (
+            deltaType === "text_delta" && typeof delta?.text === "string" && delta.text.length > 0
+          ) {
+            yield { type: "text-delta", delta: delta.text };
+            continue;
+          }
+
+          if (
+            deltaType === "thinking_delta" && typeof delta?.thinking === "string" &&
+            delta.thinking.length > 0
+          ) {
+            const current = reasoningBlocks.get(index);
+            if (!current) {
+              continue;
+            }
+
+            current.text += delta.thinking;
+            yield {
+              type: "reasoning-delta",
+              id: current.id,
+              delta: delta.thinking,
+            };
+            continue;
+          }
+
+          if (deltaType === "signature_delta" && typeof delta?.signature === "string") {
+            const current = reasoningBlocks.get(index);
+            if (current) {
+              current.signature = delta.signature;
+            }
+            continue;
+          }
+
+          if (deltaType === "input_json_delta" && typeof delta?.partial_json === "string") {
+            const current = toolCalls.get(index);
+            if (!current) {
+              continue;
+            }
+
+            current.input += delta.partial_json;
+            yield {
+              type: "tool-input-delta",
+              id: current.id,
+              delta: delta.partial_json,
+            };
+          }
+
+          continue;
+        }
+
+        if (eventType === "content_block_stop") {
+          const index = typeof record?.index === "number" ? record.index : 0;
+          const reasoning = reasoningBlocks.get(index);
+          if (reasoning) {
+            yield {
+              type: "reasoning-end",
+              id: reasoning.id,
+              ...(reasoning.signature ? { signature: reasoning.signature } : {}),
+              ...(reasoning.redactedData ? { redactedData: reasoning.redactedData } : {}),
+            };
+            reasoningBlocks.delete(index);
+            continue;
+          }
+
           const current = toolCalls.get(index);
           if (!current) {
             continue;
           }
 
-          current.input += delta.partial_json;
           yield {
-            type: "tool-input-delta",
-            id: current.id,
-            delta: delta.partial_json,
+            type: "tool-call",
+            toolCallId: current.id,
+            toolName: current.name,
+            input: current.input.length > 0 ? current.input : "{}",
+            ...(current.providerExecuted ? { providerExecuted: true } : {}),
           };
-        }
-
-        continue;
-      }
-
-      if (eventType === "content_block_stop") {
-        const index = typeof record?.index === "number" ? record.index : 0;
-        const reasoning = reasoningBlocks.get(index);
-        if (reasoning) {
-          yield {
-            type: "reasoning-end",
-            id: reasoning.id,
-            ...(reasoning.signature ? { signature: reasoning.signature } : {}),
-            ...(reasoning.redactedData ? { redactedData: reasoning.redactedData } : {}),
-          };
-          reasoningBlocks.delete(index);
+          if (!current.providerExecuted) {
+            completedClientToolUseStep = true;
+            clientToolUseIdleDeadlineMs = null;
+          }
+          toolCalls.delete(index);
           continue;
         }
 
-        const current = toolCalls.get(index);
-        if (!current) {
-          continue;
+        if (eventType === "message_delta") {
+          const delta = readRecord(record?.delta);
+          const normalizedFinishReason = normalizeAnthropicFinishReason(delta?.stop_reason);
+          if (normalizedFinishReason) {
+            finishReason = normalizedFinishReason;
+          }
         }
-
-        yield {
-          type: "tool-call",
-          toolCallId: current.id,
-          toolName: current.name,
-          input: current.input.length > 0 ? current.input : "{}",
-          ...(current.providerExecuted ? { providerExecuted: true } : {}),
-        };
-        if (!current.providerExecuted) {
-          completedClientToolUseStep = true;
-        }
-        toolCalls.delete(index);
-        continue;
       }
 
-      if (eventType === "message_delta") {
-        const delta = readRecord(record?.delta);
-        const normalizedFinishReason = normalizeAnthropicFinishReason(delta?.stop_reason);
-        if (normalizedFinishReason) {
-          finishReason = normalizedFinishReason;
+      if (completedClientToolUseStep && toolCalls.size === 0) {
+        if (isToolCallsFinishReason(finishReason)) {
+          clientToolUseIdleDeadlineMs = null;
+          clientToolUseTerminalDeadlineMs ??= Date.now() + trailingUsageGraceMs;
+          if (hasGatewayUsageMetadata(usage)) {
+            await cancelStreamReader(
+              reader,
+              "Finished Anthropic tool-use turn after gateway usage metadata",
+            );
+            yield buildFinishPart();
+            return;
+          }
+        } else {
+          clientToolUseIdleDeadlineMs ??= Date.now() + trailingUsageGraceMs;
         }
       }
     }
-
-    if (completedClientToolUseStep && toolCalls.size === 0) {
-      finishReason ??= { unified: "tool-calls", raw: "tool_use" };
-    }
+  } finally {
+    reader.releaseLock();
   }
 
-  if (buffer.trim().length > 0) {
-    const parsed = parseSseChunk(`${buffer}\n\n`);
-    for (const event of parsed.events) {
-      if (event === "[DONE]") {
-        continue;
-      }
-      const record = readRecord(event);
-      usage = mergeUsage(usage, extractAnthropicUsage(record));
-    }
-  }
+  mergeTrailingBufferUsage();
 
-  yield {
-    type: "finish",
-    finishReason: finishReason ??
-      (completedClientToolUseStep ? { unified: "tool-calls", raw: "tool_use" } : null),
-    ...(usage ? { usage } : {}),
-  };
+  yield buildFinishPart();
 }

--- a/src/eval/model-comparison.test.ts
+++ b/src/eval/model-comparison.test.ts
@@ -555,6 +555,12 @@ describe("eval/model-comparison", () => {
     assertEquals(markdown.includes("| moonshotai/kimi-k2.6 | candidate |"), true);
     assertEquals(
       markdown.includes(
+        "Metered USD is the token-metered Veryfront charge before billing minimums.",
+      ),
+      true,
+    );
+    assertEquals(
+      markdown.includes(
         "| 7000 | 2000 | 9000 | 7000 | 2000 | 0.12 | 0.08 | 0.20 | 0.30 | 0.20 | 0.50 | 0.50 | 5.00 | gateway |",
       ),
       true,

--- a/src/eval/model-comparison.ts
+++ b/src/eval/model-comparison.ts
@@ -671,6 +671,11 @@ export function createEvalModelComparisonMarkdown(comparison: EvalModelCompariso
     );
   }
 
+  lines.push(
+    "",
+    "_Metered USD is the token-metered Veryfront charge before billing minimums. Billed USD and Credits include gateway request minimums and match the billed eval cost._",
+  );
+
   if (comparison.candidates.length > 0) {
     lines.push(
       "",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.966";
+export const VERSION = "0.1.967";


### PR DESCRIPTION
## Summary
- drain Anthropic tool-use streams through trailing gateway billing usage before emitting finish
- add a regression for billing metadata appended after a tool-use step
- clarify eval comparison reports: Metered USD vs Billed USD/Credits
- bump the framework version to 0.1.967

## Why
Claude eval reports were showing 4 credits while Kimi showed 16. The Kimi/OpenAI-compatible path captured all gateway usage events; the Anthropic parser returned early after tool-use and missed billing metadata for tool-call turns. That made Claude look artificially cheap.

After the fix, the same local demo eval reports Claude at 16 credits and Kimi at 15 credits. Kimi remains cheaper on token-metered USD, but short eval cases are dominated by gateway request minimums.

## Verification
- `deno fmt --check ...`
- `deno test --no-check --allow-all extensions/ext-llm-anthropic/src/anthropic-stream.test.ts extensions/ext-llm-anthropic/src/anthropic-provider.test.ts src/provider/runtime-loader/provider-usage-merge.test.ts src/eval/model-comparison.test.ts src/eval/report.test.ts src/eval/metrics.test.ts`
- `deno check extensions/ext-llm-anthropic/src/anthropic-stream.ts src/eval/model-comparison.ts`
- `deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts`
- pre-push: formatting, lint, typecheck, unit tests: 2212 passed
- local patched CLI eval: `veryfront eval support-triage --baseline-model anthropic/claude-sonnet-4-6 --candidate-model moonshotai/kimi-k2.6 --json`
