### PR TITLE
Preserve Gmail integration tools in runtime streams

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.969",
+  "version": "0.1.970",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -593,6 +593,93 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(capturedAllowedTools, undefined);
   });
 
+  it("preserves server-resolved integration tool allowlists forwarded by the control plane", async () => {
+    let capturedAllowedTools: string[] | undefined;
+
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: (id) =>
+        id === "assistant-1"
+          ? createAgentWithConfig("assistant-1", {
+            tools: {
+              "get-current-date": true,
+              gmail__list_emails: true,
+              gmail__delete_email: true,
+            },
+          })
+          : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager: new AgentRunSessionManager(),
+      createRuntime: (agent) => {
+        capturedAllowedTools = (agent.config as typeof agent.config & RuntimeRemoteToolConfig)
+          .__vfAllowedRemoteTools;
+
+        return {
+          stream: async (_messages, _context, callbacks) => {
+            callbacks?.onFinish?.({
+              text: "ok",
+              messages: [],
+              toolCalls: [],
+              status: "completed",
+              usage: {
+                promptTokens: 1,
+                completionTokens: 1,
+                totalTokens: 2,
+              },
+            });
+
+            return new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.close();
+              },
+            });
+          },
+        };
+      },
+    });
+
+    const body = createAgentStreamRequestBody({
+      tools: [{
+        name: "get-current-date",
+        description: "Return the current date",
+        inputSchema: { type: "object", properties: {} },
+      }],
+      forwardedProps: {
+        runtimeOverrides: {
+          allowedTools: [
+            "get-current-date",
+            "gmail__list_emails",
+            "list_emails",
+            "gmail__delete_email",
+          ],
+          serverResolvedIntegrationTools: ["gmail__list_emails"],
+          integrationToolDefinitions: [{
+            name: "gmail__list_emails",
+            description: "List Gmail emails",
+            inputSchema: { type: "object", properties: {} },
+          }],
+        },
+      },
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(capturedAllowedTools, ["get-current-date", "gmail__list_emails"]);
+  });
+
   it("drops undeclared Studio runtime tool allowlists for untrusted clients", async () => {
     let capturedAllowedTools: string[] | undefined;
 

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -175,6 +175,33 @@ function getForwardedAllowedRemoteToolNames(
     : [];
 }
 
+function getForwardedIntegrationToolNames(
+  runtimeOverrides: Record<string, unknown>,
+): Set<string> {
+  const toolNames = new Set<string>();
+  const serverResolvedTools = runtimeOverrides.serverResolvedIntegrationTools;
+  if (Array.isArray(serverResolvedTools)) {
+    for (const toolName of serverResolvedTools) {
+      if (typeof toolName === "string" && toolName.length > 0) {
+        toolNames.add(toolName);
+      }
+    }
+  }
+
+  const definitions = runtimeOverrides.integrationToolDefinitions;
+  if (Array.isArray(definitions)) {
+    for (const definition of definitions) {
+      if (
+        isRecord(definition) && typeof definition.name === "string" && definition.name.length > 0
+      ) {
+        toolNames.add(definition.name);
+      }
+    }
+  }
+
+  return toolNames;
+}
+
 function getRequestedStudioToolNames(input: {
   forwardedProps?: Record<string, unknown>;
   availableToolNames?: string[];
@@ -213,12 +240,14 @@ function sanitizeForwardedRuntimeAllowedTools(input: {
   }
 
   const availableToolNames = new Set(input.availableToolNames);
+  const forwardedIntegrationToolNames = getForwardedIntegrationToolNames(runtimeOverrides);
   // Platform remote tools are gated separately by the child agent config in
   // withVeryfrontPlatformRemoteTools. The Studio path is the one that consumes
   // forwarded allowedTools, and Studio-only runtime tools are preserved only
   // for trusted Studio clients that can already attach the Studio MCP surface.
   const sanitizedAllowedTools = allowedTools.filter((toolName) =>
     availableToolNames.has(toolName) ||
+    forwardedIntegrationToolNames.has(toolName) ||
     (input.allowStudioRuntimeTools && STUDIO_RUNTIME_REMOTE_TOOL_NAMES.has(toolName))
   );
   if (sanitizedAllowedTools.length === allowedTools.length) {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.969";
+export const VERSION = "0.1.970";


### PR DESCRIPTION
## Summary
- Preserve server-resolved integration tool ids when sanitizing trusted control-plane runtime allowedTools.
- Add regression coverage for Gmail tools forwarded outside payload.tools.
- Bump framework version to 0.1.970 so veryfront-agent can consume a released package after merge.

## Why
Production Gmail runs had signed forwarded integration metadata, but the runtime stream handler narrowed allowedTools to local payload tools before agent setup. That removed gmail__* tool definitions and produced Unknown tool references before any model usage.

## Verification
- Red/green targeted handler test
- deno test src/server/handlers/request/agent-stream.handler.test.ts
- deno test src/internal-agents/run-stream.test.ts
- deno check src/server/handlers/request/agent-stream.handler.ts src/server/handlers/request/agent-stream.handler.test.ts
- deno lint src/server/handlers/request/agent-stream.handler.ts src/server/handlers/request/agent-stream.handler.test.ts
- deno task test:unit
- deno task release patch --yes --no-publish reached post-test release phase with 2559 passed / 0 failed; stopped on missing verify:dist task
- deno task build
- deno task build:npm
- pre-push hook: fmt, lint, typecheck, test:unit