### PR TITLE
Expose eval billing mode in CLI reports

### DIFF
--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -92,6 +92,7 @@ function createReport(): EvalReport {
         veryfrontBilledUsd: 0.1,
         costCredits: 1,
         costSource: "gateway",
+        billingMode: "deferred",
         usageCaptureStatus: "complete",
       },
     },
@@ -240,6 +241,7 @@ describe("eval CLI command helpers", () => {
         veryfrontBilledUsd: 0.1,
         costCredits: 0.025,
         costSource: "gateway",
+        billingMode: "deferred",
         usageCaptureStatus: "complete",
       },
     } satisfies AgentResponse;
@@ -264,6 +266,7 @@ describe("eval CLI command helpers", () => {
       veryfrontBilledUsd: 0.1,
       costCredits: 0.025,
       costSource: "gateway",
+      billingMode: "deferred",
       usageCaptureStatus: "complete",
     });
   });
@@ -445,6 +448,7 @@ describe("eval CLI command helpers", () => {
     assertStringIncludes(markdown, "| Veryfront input charge USD | `$0.001` |");
     assertStringIncludes(markdown, "| Veryfront output charge USD | `$0.0015` |");
     assertStringIncludes(markdown, "| Veryfront billed USD | `$0.10` |");
+    assertStringIncludes(markdown, "| Billing mode | deferred |");
     assertStringIncludes(markdown, "| `q1:1` | PASS | 0.012s | 12 | `$0.06` | 0.6 |");
     assertStringIncludes(markdown, "| `q2:1` | FAIL | 0.010s | 10 | `$0.04` | 0.4 |");
   });

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -497,6 +497,7 @@ function usageRows(usage: EvalUsage | undefined): Array<[string, string]> {
     ["Veryfront billed USD", usdCell(usage.veryfrontBilledUsd)],
     ["Cost credits", decimalCell(usage.costCredits)],
     ["Cost source", usage.costSource ?? "-"],
+    ["Billing mode", usage.billingMode ?? "-"],
     ["Usage capture status", usage.usageCaptureStatus ?? "-"],
   ];
   return rows.filter(([, value]) => value !== "-");
@@ -739,6 +740,9 @@ export function normalizeUsage(response: AgentResponse) {
         ? { costCredits: response.usage.costCredits }
         : {}),
       ...(response.usage.costSource !== undefined ? { costSource: response.usage.costSource } : {}),
+      ...(response.usage.billingMode !== undefined
+        ? { billingMode: response.usage.billingMode }
+        : {}),
       ...(response.usage.usageCaptureStatus !== undefined
         ? { usageCaptureStatus: response.usage.usageCaptureStatus }
         : {}),

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.969",
+  "version": "0.1.970",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.969";
+export const VERSION = "0.1.970";


### PR DESCRIPTION
## Summary
- preserve `usage.billingMode` when normalizing AG-UI eval responses
- show the billing mode in markdown eval usage summaries
- bump the framework release version to `0.1.970` with the shared version constant in sync

## Verification
- `deno test --allow-all cli/commands/eval/command.test.ts src/eval/model-comparison.test.ts src/eval/report.test.ts src/eval/agent-service.test.ts src/provider/veryfront-cloud/provider.test.ts src/provider/runtime-loader/provider-usage-merge.test.ts`
- `deno test --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts cli/commands/eval/command.test.ts`
- `deno fmt --check src/utils/version-constant.ts deno.json cli/commands/eval/command.ts cli/commands/eval/command.test.ts`
- pre-push: format, lint, typecheck, 2212 unit tests passing
