### PR TITLE
Release framework binaries for Gmail runtime fix

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.970",
+  "version": "0.1.971",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.970";
+export const VERSION = "0.1.971";


### PR DESCRIPTION
## Summary
- bump framework version from 0.1.970 to 0.1.971 so the release workflow can publish fresh binaries
- unblock veryfront-server, which downloads the compiled GitHub release binary rather than the npm package

## Context
- Gmail runtime allowlist fix merged in #2689 and npm published 0.1.970
- the public GitHub release for v0.1.970 is draft/no-assets, so veryfront-server cannot consume it
- the later main release failed because npm 0.1.970 already points at the earlier merge commit

## Verification
- jq -r '.version' deno.json -> 0.1.971
- deno fmt --check deno.json src/utils/version-constant.ts
- pre-push hook: format, lint, typecheck, unit tests
- unit summary: 2212 passed (19010 steps), 0 failed

## Notes
Local direct run of src/server/handlers/request/agent-stream.handler.test.ts timed out during Deno startup with no assertion output; the unchanged Gmail regression already passed on PR #2689 and the full pre-push unit suite passed here.