### PR TITLE
Tag eval runs for gateway billing reconciliation

### DIFF
--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -5,6 +5,7 @@ import type { AgentResponse } from "veryfront/agent";
 import { compareEvalReports, type DiscoveredEval, type EvalReport } from "veryfront/eval";
 import { saveToken } from "../../auth/token-store.ts";
 import {
+  applyGatewayBillingGroupFinalization,
   createDefaultEvalReportDir,
   createEvalArtifactPaths,
   createEvalExitCode,
@@ -436,6 +437,31 @@ describe("eval CLI command helpers", () => {
       JSON.parse(line) as { id: string }
     );
     assertEquals(lines.map((record) => record.id), ["q1:1", "q2:1"]);
+  });
+
+  it("applies gateway billing group finalization to eval summary usage", () => {
+    const report = createReport();
+
+    const finalized = applyGatewayBillingGroupFinalization(report, {
+      billing_group_id: "evalrun_test_anthropic__claude-sonnet-4-6",
+      charged_credits: 16,
+      target_credits: 1,
+      adjustment_credits: 15,
+      provider_cost_usd: 0.02465,
+      veryfront_charge_usd: 0.07395,
+      veryfront_billed_usd: 0.1,
+    });
+
+    assertEquals(finalized.summary.usage, {
+      ...report.summary.usage,
+      providerCostUsd: 0.02465,
+      veryfrontChargeUsd: 0.07395,
+      veryfrontBilledUsd: 0.1,
+      costCredits: 1,
+      costSource: "gateway",
+      billingMode: "direct",
+      usageCaptureStatus: "complete",
+    });
   });
 
   it("renders a markdown eval report", () => {

--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -3,6 +3,8 @@ import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/te
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { AgentResponse } from "veryfront/agent";
 import { compareEvalReports, type DiscoveredEval, type EvalReport } from "veryfront/eval";
+import { createEvalReportExporterRegistry } from "veryfront/extensions/eval";
+import { markCurrentVeryfrontCloudBillingGroupUsed } from "veryfront/provider";
 import { saveToken } from "../../auth/token-store.ts";
 import {
   applyGatewayBillingGroupFinalization,
@@ -17,6 +19,7 @@ import {
   createResolvedEvalModelComparisonConfig,
   createResultsJsonl,
   createSummaryArtifact,
+  exportEvalReportForCli,
   findEvalForCliId,
   hydrateEvalRuntimeAuth,
   loadEvalModelComparisonPolicy,
@@ -24,14 +27,17 @@ import {
   normalizeEvalInputForAgent,
   normalizeToolCalls,
   normalizeUsage,
+  runEvalWithGatewayBillingGroup,
   summarizeReportForCli,
   writeEvalArtifacts,
 } from "./command.ts";
 import { parseEvalArgs } from "./handler.ts";
 
 const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
 const originalProjectSlug = Deno.env.get("VERYFRONT_PROJECT_SLUG");
 const originalXdgConfigHome = Deno.env.get("XDG_CONFIG_HOME");
+const originalFetch = globalThis.fetch;
 
 function restoreEnv(): void {
   if (originalApiToken === undefined) {
@@ -46,11 +52,19 @@ function restoreEnv(): void {
     Deno.env.set("VERYFRONT_PROJECT_SLUG", originalProjectSlug);
   }
 
+  if (originalApiBaseUrl === undefined) {
+    Deno.env.delete("VERYFRONT_API_BASE_URL");
+  } else {
+    Deno.env.set("VERYFRONT_API_BASE_URL", originalApiBaseUrl);
+  }
+
   if (originalXdgConfigHome === undefined) {
     Deno.env.delete("XDG_CONFIG_HOME");
   } else {
     Deno.env.set("XDG_CONFIG_HOME", originalXdgConfigHome);
   }
+
+  globalThis.fetch = originalFetch;
 }
 
 function createReport(): EvalReport {
@@ -462,6 +476,91 @@ describe("eval CLI command helpers", () => {
       billingMode: "direct",
       usageCaptureStatus: "complete",
     });
+  });
+
+  it("finalizes a gateway billing group when an eval throws after gateway usage", async () => {
+    Deno.env.set("VERYFRONT_API_TOKEN", "test-token");
+    Deno.env.set("VERYFRONT_API_BASE_URL", "https://api.test");
+    const requests: Request[] = [];
+    globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      requests.push(request);
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            billing_group_id: "evalrun_test_model",
+            already_finalized: false,
+            request_count: 1,
+            charged_credits: 4,
+            target_credits: 1,
+            adjustment_credits: 3,
+            adjustment: "refund",
+            provider_cost_usd: 0.01,
+            veryfront_charge_usd: 0.03,
+            veryfront_billed_usd: 0.4,
+            usage_capture_status: "complete",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+    };
+
+    await assertRejects(
+      () =>
+        runEvalWithGatewayBillingGroup("evalrun_test_model", async () => {
+          markCurrentVeryfrontCloudBillingGroupUsed();
+          throw new Error("custom metric failed");
+        }),
+      Error,
+      "custom metric failed",
+    );
+
+    assertEquals(requests.length, 1);
+    const request = requests[0];
+    if (!request) throw new Error("Expected billing finalization request.");
+    assertEquals(request.url, "https://api.test/ai/gateway/billing/finalize");
+    assertEquals(request.headers.get("Authorization"), "Bearer test-token");
+    assertEquals(await request.json(), { billing_group_id: "evalrun_test_model" });
+  });
+
+  it("exports CLI eval reports after gateway billing finalization", async () => {
+    const registry = createEvalReportExporterRegistry();
+    const finalized = applyGatewayBillingGroupFinalization(createReport(), {
+      billing_group_id: "evalrun_test_model",
+      charged_credits: 4,
+      target_credits: 1,
+      adjustment_credits: 3,
+      provider_cost_usd: 0.02465,
+      veryfront_charge_usd: 0.07395,
+      veryfront_billed_usd: 0.4,
+    });
+    let exportedUsage: EvalReport["summary"]["usage"] | undefined;
+
+    registry.register({
+      id: "capture",
+      export(report) {
+        exportedUsage = report.summary.usage;
+        return { externalRunId: report.runId };
+      },
+    });
+
+    const exported = await exportEvalReportForCli(finalized, {
+      registry,
+      exporterIds: ["capture"],
+    });
+
+    assertEquals(exportedUsage, finalized.summary.usage);
+    assertEquals(exported.exports, [
+      {
+        exporterId: "capture",
+        ok: true,
+        receipt: { externalRunId: finalized.runId },
+      },
+    ]);
   });
 
   it("renders a markdown eval report", () => {

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -30,6 +30,11 @@ import {
 } from "veryfront/eval";
 import { applyRuntimeAuthContext } from "#cli/shared/runtime-auth";
 import { cliLogger, exitProcess, VERSION } from "#cli/utils";
+import { getVeryfrontCloudBootstrap } from "#veryfront/platform/cloud/resolver.ts";
+import {
+  getCurrentVeryfrontCloudContext,
+  runWithVeryfrontCloudContextAsync,
+} from "#veryfront/provider/veryfront-cloud/context.ts";
 import {
   createErrorEnvelope,
   createSuccessEnvelope,
@@ -82,6 +87,16 @@ type EvalSummaryArtifact = {
   metadata?: EvalReport["metadata"];
   exports?: EvalReport["exports"];
   baseline?: EvalReportComparison;
+};
+
+type GatewayBillingGroupFinalization = {
+  billing_group_id: string;
+  charged_credits: number;
+  target_credits: number;
+  adjustment_credits: number;
+  provider_cost_usd: number;
+  veryfront_charge_usd: number;
+  veryfront_billed_usd: number;
 };
 
 type EvalModelComparisonPolicy = Omit<EvalModelComparisonOptions, "baselineModel">;
@@ -271,6 +286,139 @@ export function createSummaryArtifact(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function joinApiUrl(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
+function readFiniteNumber(
+  record: Record<string, unknown>,
+  field: keyof GatewayBillingGroupFinalization,
+): number | undefined {
+  const value = record[field];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function parseGatewayBillingGroupFinalization(
+  payload: unknown,
+): GatewayBillingGroupFinalization | undefined {
+  if (!isRecord(payload) || typeof payload.billing_group_id !== "string") return undefined;
+  const chargedCredits = readFiniteNumber(payload, "charged_credits");
+  const targetCredits = readFiniteNumber(payload, "target_credits");
+  const adjustmentCredits = readFiniteNumber(payload, "adjustment_credits");
+  const providerCostUsd = readFiniteNumber(payload, "provider_cost_usd");
+  const veryfrontChargeUsd = readFiniteNumber(payload, "veryfront_charge_usd");
+  const veryfrontBilledUsd = readFiniteNumber(payload, "veryfront_billed_usd");
+
+  if (
+    chargedCredits === undefined ||
+    targetCredits === undefined ||
+    adjustmentCredits === undefined ||
+    providerCostUsd === undefined ||
+    veryfrontChargeUsd === undefined ||
+    veryfrontBilledUsd === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    billing_group_id: payload.billing_group_id,
+    charged_credits: chargedCredits,
+    target_credits: targetCredits,
+    adjustment_credits: adjustmentCredits,
+    provider_cost_usd: providerCostUsd,
+    veryfront_charge_usd: veryfrontChargeUsd,
+    veryfront_billed_usd: veryfrontBilledUsd,
+  };
+}
+
+export function applyGatewayBillingGroupFinalization(
+  report: EvalReport,
+  finalization: GatewayBillingGroupFinalization,
+): EvalReport {
+  return {
+    ...report,
+    summary: {
+      ...report.summary,
+      usage: {
+        ...(report.summary.usage ?? {}),
+        providerCostUsd: finalization.provider_cost_usd,
+        veryfrontChargeUsd: finalization.veryfront_charge_usd,
+        veryfrontBilledUsd: finalization.veryfront_billed_usd,
+        costCredits: finalization.target_credits,
+        costSource: "gateway",
+        billingMode: "direct",
+        usageCaptureStatus: "complete",
+      },
+    },
+  };
+}
+
+function hasGatewayUsage(report: EvalReport): boolean {
+  const usage = report.summary.usage;
+  return Boolean(
+    usage?.costSource === "gateway" ||
+      usage?.veryfrontChargeUsd !== undefined ||
+      usage?.veryfrontBilledUsd !== undefined,
+  );
+}
+
+async function finalizeGatewayBillingGroup(
+  billingGroupId: string,
+): Promise<GatewayBillingGroupFinalization | undefined> {
+  const bootstrap = getVeryfrontCloudBootstrap();
+  if (!bootstrap.apiToken) return undefined;
+
+  let response: Response;
+  try {
+    response = await fetch(joinApiUrl(bootstrap.apiBaseUrl, "ai/gateway/billing/finalize"), {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${bootstrap.apiToken}`,
+        "Content-Type": "application/json",
+        ...(bootstrap.projectSlug ? { "x-veryfront-project-slug": bootstrap.projectSlug } : {}),
+      },
+      body: JSON.stringify({ billing_group_id: billingGroupId }),
+    });
+  } catch (error) {
+    cliLogger.warn(
+      `Gateway billing finalization skipped for ${billingGroupId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return undefined;
+  }
+
+  if (!response.ok) {
+    const message = await response.text().catch(() => "");
+    cliLogger.warn(
+      `Gateway billing finalization skipped for ${billingGroupId}: ${response.status}${
+        message ? ` ${message}` : ""
+      }`,
+    );
+    return undefined;
+  }
+
+  const finalization = parseGatewayBillingGroupFinalization(await response.json());
+  if (!finalization) {
+    cliLogger.warn(`Gateway billing finalization skipped for ${billingGroupId}: invalid response`);
+  }
+  return finalization;
+}
+
+async function runEvalWithGatewayBillingGroup(
+  billingGroupId: string,
+  operation: () => Promise<EvalReport>,
+): Promise<EvalReport> {
+  const currentContext = getCurrentVeryfrontCloudContext();
+  const report = await runWithVeryfrontCloudContextAsync(
+    { ...(currentContext ?? {}), billingGroupId },
+    operation,
+  );
+  if (!hasGatewayUsage(report)) return report;
+  const finalization = await finalizeGatewayBillingGroup(billingGroupId);
+  return finalization ? applyGatewayBillingGroupFinalization(report, finalization) : report;
 }
 
 function readNumberField(
@@ -944,18 +1092,28 @@ async function runEvalModelComparison(input: {
   for (const model of input.config.models) {
     const modelPaths = paths.models[model]!;
     const modelOptions = { ...input.options, model, report: undefined };
-    const report = await runEval(input.evalItem.definition, {
-      baseDir: input.options.datasetBase ?? input.projectDir,
-      runId: `${runId}_${sanitizeModelIdForPath(model)}`,
-      adapters: {
-        agent: createAgentAdapterForModel(input.agent, input.options, model),
-      },
-      metadata: {
-        model,
-        provenance,
-      },
-      export: createEvalCliExportConfig(input.evalItem, modelOptions, input.projectDir, modelPaths),
-    });
+    const modelRunId = `${runId}_${sanitizeModelIdForPath(model)}`;
+    const report = await runEvalWithGatewayBillingGroup(
+      modelRunId,
+      () =>
+        runEval(input.evalItem.definition, {
+          baseDir: input.options.datasetBase ?? input.projectDir,
+          runId: modelRunId,
+          adapters: {
+            agent: createAgentAdapterForModel(input.agent, input.options, model),
+          },
+          metadata: {
+            model,
+            provenance,
+          },
+          export: createEvalCliExportConfig(
+            input.evalItem,
+            modelOptions,
+            input.projectDir,
+            modelPaths,
+          ),
+        }),
+    );
     reports.push(report);
     await writeEvalArtifacts(report, modelPaths);
     await writeTextFileEnsuringDir(modelPaths.junit, createJunitXml(report));
@@ -1142,18 +1300,25 @@ export async function evalCommand(options: EvalOptions): Promise<void> {
       projectDir,
       frameworkVersion: VERSION,
     });
-    const report = await runEval(evalItem.definition, {
-      baseDir: options.datasetBase ?? projectDir,
-      runId,
-      adapters: {
-        agent: createAgentAdapter(agent, options),
-      },
-      metadata: {
-        provenance,
-        ...(options.model ? { model: options.model } : {}),
-      },
-      export: createEvalCliExportConfig(evalItem, options, projectDir, artifactPaths),
-    });
+    const billingGroupId = options.model
+      ? `${runId}_${sanitizeModelIdForPath(options.model)}`
+      : runId;
+    const report = await runEvalWithGatewayBillingGroup(
+      billingGroupId,
+      () =>
+        runEval(evalItem.definition, {
+          baseDir: options.datasetBase ?? projectDir,
+          runId,
+          adapters: {
+            agent: createAgentAdapter(agent, options),
+          },
+          metadata: {
+            provenance,
+            ...(options.model ? { model: options.model } : {}),
+          },
+          export: createEvalCliExportConfig(evalItem, options, projectDir, artifactPaths),
+        }),
+    );
 
     const baseline = options.baseline
       ? compareEvalReports(report, await readEvalReport(options.baseline))

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -25,16 +25,17 @@ import {
   compareEvalReports,
   createEvalModelComparisonMarkdown,
   discoverEvals,
+  exportEvalReport,
   resolveEvalRunProvenance,
   runEval,
 } from "veryfront/eval";
-import { applyRuntimeAuthContext } from "#cli/shared/runtime-auth";
-import { cliLogger, exitProcess, VERSION } from "#cli/utils";
-import { getVeryfrontCloudBootstrap } from "#veryfront/platform/cloud/resolver.ts";
 import {
   getCurrentVeryfrontCloudContext,
+  getVeryfrontCloudBootstrap,
   runWithVeryfrontCloudContextAsync,
-} from "#veryfront/provider/veryfront-cloud/context.ts";
+} from "veryfront/provider";
+import { applyRuntimeAuthContext } from "#cli/shared/runtime-auth";
+import { cliLogger, exitProcess, VERSION } from "#cli/utils";
 import {
   createErrorEnvelope,
   createSuccessEnvelope,
@@ -407,18 +408,32 @@ async function finalizeGatewayBillingGroup(
   return finalization;
 }
 
-async function runEvalWithGatewayBillingGroup(
+export async function runEvalWithGatewayBillingGroup(
   billingGroupId: string,
   operation: () => Promise<EvalReport>,
 ): Promise<EvalReport> {
   const currentContext = getCurrentVeryfrontCloudContext();
-  const report = await runWithVeryfrontCloudContextAsync(
-    { ...(currentContext ?? {}), billingGroupId },
-    operation,
-  );
-  if (!hasGatewayUsage(report)) return report;
+  const billingContext = { ...(currentContext ?? {}), billingGroupId };
+  let report: EvalReport;
+  try {
+    report = await runWithVeryfrontCloudContextAsync(billingContext, operation);
+  } catch (error) {
+    if (billingContext.billingGroupUsed) {
+      await finalizeGatewayBillingGroup(billingGroupId);
+    }
+    throw error;
+  }
+  if (!billingContext.billingGroupUsed && !hasGatewayUsage(report)) return report;
   const finalization = await finalizeGatewayBillingGroup(billingGroupId);
   return finalization ? applyGatewayBillingGroupFinalization(report, finalization) : report;
+}
+
+export async function exportEvalReportForCli(
+  report: EvalReport,
+  config?: EvalReportExportConfig,
+): Promise<EvalReport> {
+  const exports = await exportEvalReport(report, config);
+  return exports === undefined ? report : { ...report, exports };
 }
 
 function readNumberField(
@@ -1093,7 +1108,13 @@ async function runEvalModelComparison(input: {
     const modelPaths = paths.models[model]!;
     const modelOptions = { ...input.options, model, report: undefined };
     const modelRunId = `${runId}_${sanitizeModelIdForPath(model)}`;
-    const report = await runEvalWithGatewayBillingGroup(
+    const exportConfig = createEvalCliExportConfig(
+      input.evalItem,
+      modelOptions,
+      input.projectDir,
+      modelPaths,
+    );
+    const finalizedReport = await runEvalWithGatewayBillingGroup(
       modelRunId,
       () =>
         runEval(input.evalItem.definition, {
@@ -1106,14 +1127,9 @@ async function runEvalModelComparison(input: {
             model,
             provenance,
           },
-          export: createEvalCliExportConfig(
-            input.evalItem,
-            modelOptions,
-            input.projectDir,
-            modelPaths,
-          ),
         }),
     );
+    const report = await exportEvalReportForCli(finalizedReport, exportConfig);
     reports.push(report);
     await writeEvalArtifacts(report, modelPaths);
     await writeTextFileEnsuringDir(modelPaths.junit, createJunitXml(report));
@@ -1303,7 +1319,8 @@ export async function evalCommand(options: EvalOptions): Promise<void> {
     const billingGroupId = options.model
       ? `${runId}_${sanitizeModelIdForPath(options.model)}`
       : runId;
-    const report = await runEvalWithGatewayBillingGroup(
+    const exportConfig = createEvalCliExportConfig(evalItem, options, projectDir, artifactPaths);
+    const finalizedReport = await runEvalWithGatewayBillingGroup(
       billingGroupId,
       () =>
         runEval(evalItem.definition, {
@@ -1316,9 +1333,9 @@ export async function evalCommand(options: EvalOptions): Promise<void> {
             provenance,
             ...(options.model ? { model: options.model } : {}),
           },
-          export: createEvalCliExportConfig(evalItem, options, projectDir, artifactPaths),
         }),
     );
+    const report = await exportEvalReportForCli(finalizedReport, exportConfig);
 
     const baseline = options.baseline
       ? compareEvalReports(report, await readEvalReport(options.baseline))

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.971",
+  "version": "0.1.972",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -51,7 +51,7 @@ export { createEvalReport, summarizeEvalRecords } from "./report.ts";
 export { compareEvalReports } from "./baseline.ts";
 export { compareEvalModelReports, createEvalModelComparisonMarkdown } from "./model-comparison.ts";
 export { createEvalRunProvenance, resolveEvalRunProvenance } from "./provenance.ts";
-export { runEval } from "./runner.ts";
+export { exportEvalReport, runEval } from "./runner.ts";
 export { deriveEvalId, discoverEvals, findEvalById } from "./discovery.ts";
 export {
   createEvalSourceDocument,

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -195,7 +195,7 @@ async function exportWithSelectedExporter(
   };
 }
 
-async function exportEvalReport(
+export async function exportEvalReport(
   report: ReturnType<typeof createEvalReport>,
   config?: EvalReportExportConfig,
 ): Promise<EvalReportExportResult[] | undefined> {

--- a/src/platform/cloud/resolver.test.ts
+++ b/src/platform/cloud/resolver.test.ts
@@ -153,4 +153,13 @@ describe("platform/cloud/resolver", () => {
       assertEquals(getVeryfrontCloudAuthToken(), "vf_scoped_token");
     });
   });
+
+  it("does not treat a billing group id as cloud runtime context", () => {
+    setEnv("VERYFRONT_API_TOKEN", "vf_host_token");
+
+    runWithVeryfrontCloudContext({ billingGroupId: "evalrun_20260628_kimi" }, () => {
+      assertEquals(isVeryfrontCloudEnabled(), false);
+      assertEquals(getVeryfrontCloudAuthToken(), "vf_host_token");
+    });
+  });
 });

--- a/src/platform/cloud/resolver.ts
+++ b/src/platform/cloud/resolver.ts
@@ -1,6 +1,9 @@
 import { getCurrentRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
-import { getCurrentVeryfrontCloudContext } from "#veryfront/provider/veryfront-cloud/context.ts";
+import {
+  getCurrentVeryfrontCloudContext,
+  type VeryfrontCloudContext,
+} from "#veryfront/provider/veryfront-cloud/context.ts";
 
 // ---------------------------------------------------------------------------
 // GlobalThis bridges — config/ is a middle layer, platform/ is bottom layer.
@@ -74,6 +77,12 @@ function normalizeServiceLayer(value: string | undefined): string | undefined {
   return normalized?.length ? normalized : undefined;
 }
 
+function hasScopedRuntimeContext(context: VeryfrontCloudContext | undefined): boolean {
+  return Boolean(
+    context?.apiBaseUrl || context?.apiToken || context?.projectSlug || context?.serviceLayer,
+  );
+}
+
 function getResolvedVeryfrontCloudContext(): Omit<VeryfrontCloudBootstrap, "apiBaseUrl"> {
   const requestContext = getCurrentRequestContext();
   const scopedContext = getCurrentVeryfrontCloudContext();
@@ -90,7 +99,7 @@ function getResolvedVeryfrontCloudContext(): Omit<VeryfrontCloudBootstrap, "apiB
       runtimeBootstrap.projectSlug,
     serviceLayer: normalizeServiceLayer(scopedContext?.serviceLayer) ??
       normalizeServiceLayer(getHostEnv("VERYFRONT_SERVICE_LAYER")),
-    hasRequestContext: requestContext !== null || scopedContext !== undefined,
+    hasRequestContext: requestContext !== null || hasScopedRuntimeContext(scopedContext),
     usesVeryfrontFs: runtimeBootstrap.usesVeryfrontFs,
   };
 }

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -22,10 +22,14 @@ export {
 export type { ModelProviderFactory } from "./model-registry.ts";
 export type { ModelRuntime } from "./types.ts";
 export {
+  getCurrentVeryfrontCloudContext,
+  markCurrentVeryfrontCloudBillingGroupUsed,
   runWithVeryfrontCloudContext,
   runWithVeryfrontCloudContextAsync,
 } from "./veryfront-cloud/context.ts";
 export type { VeryfrontCloudContext } from "./veryfront-cloud/context.ts";
+export { getVeryfrontCloudBootstrap } from "../platform/cloud/resolver.ts";
+export type { VeryfrontCloudBootstrap } from "../platform/cloud/resolver.ts";
 export type { VeryfrontCloudProviderId } from "./veryfront-cloud/shared.ts";
 export {
   DEFAULT_VERYFRONT_CLOUD_MODEL_ID,

--- a/src/provider/veryfront-cloud/context.ts
+++ b/src/provider/veryfront-cloud/context.ts
@@ -5,6 +5,7 @@ export interface VeryfrontCloudContext {
   apiBaseUrl?: string;
   apiToken?: string;
   billingGroupId?: string;
+  billingGroupUsed?: boolean;
   projectSlug?: string;
   serviceLayer?: string;
 }
@@ -29,4 +30,11 @@ export function runWithVeryfrontCloudContextAsync<T>(
 
 export function getCurrentVeryfrontCloudContext(): VeryfrontCloudContext | undefined {
   return veryfrontCloudContextStorage.getStore();
+}
+
+export function markCurrentVeryfrontCloudBillingGroupUsed(): void {
+  const context = veryfrontCloudContextStorage.getStore();
+  if (context?.billingGroupId) {
+    context.billingGroupUsed = true;
+  }
 }

--- a/src/provider/veryfront-cloud/context.ts
+++ b/src/provider/veryfront-cloud/context.ts
@@ -4,6 +4,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 export interface VeryfrontCloudContext {
   apiBaseUrl?: string;
   apiToken?: string;
+  billingGroupId?: string;
   projectSlug?: string;
   serviceLayer?: string;
 }

--- a/src/provider/veryfront-cloud/shared.test.ts
+++ b/src/provider/veryfront-cloud/shared.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { runWithVeryfrontCloudContext } from "#veryfront/provider";
 import {
   createVeryfrontCloudFetch,
   getVeryfrontCloudGatewayBaseUrl,
@@ -82,5 +83,26 @@ describe("provider/veryfront-cloud/shared", () => {
     assertEquals(capturedRequest?.headers.get("x-api-key"), null);
     assertEquals(capturedRequest?.headers.get("x-goog-api-key"), null);
     assertEquals(capturedRequest?.headers.get("x-extra-header"), "kept");
+    assertEquals(capturedRequest?.headers.get("x-veryfront-billing-group-id"), null);
+  });
+
+  it("forwards the request-scoped billing group id to the gateway", async () => {
+    let capturedRequest: Request | undefined;
+    globalThis.fetch = ((input: URL | Request | string, init?: RequestInit) => {
+      capturedRequest = new Request(input, init);
+      return Promise.resolve(new Response(null, { status: 204 }));
+    }) as typeof fetch;
+
+    const wrappedFetch = createVeryfrontCloudFetch("vf_test_provider");
+
+    await runWithVeryfrontCloudContext(
+      { billingGroupId: "evalrun_20260628_kimi" },
+      () => wrappedFetch("https://api.veryfront.com/ai/gateway/openai/v1/chat/completions"),
+    );
+
+    assertEquals(
+      capturedRequest?.headers.get("x-veryfront-billing-group-id"),
+      "evalrun_20260628_kimi",
+    );
   });
 });

--- a/src/provider/veryfront-cloud/shared.ts
+++ b/src/provider/veryfront-cloud/shared.ts
@@ -1,6 +1,9 @@
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import { getVeryfrontCloudBootstrap } from "#veryfront/platform/cloud/resolver.ts";
-import { getCurrentVeryfrontCloudContext } from "./context.ts";
+import {
+  getCurrentVeryfrontCloudContext,
+  markCurrentVeryfrontCloudBillingGroupUsed,
+} from "./context.ts";
 import { isSupportedMistralModelId } from "./model-catalog.ts";
 
 /** Public API contract for Veryfront Cloud provider ID. */
@@ -155,6 +158,7 @@ export function createVeryfrontCloudFetch(
     const billingGroupId = getCurrentVeryfrontCloudContext()?.billingGroupId?.trim();
     if (billingGroupId) {
       headers.set("x-veryfront-billing-group-id", billingGroupId);
+      markCurrentVeryfrontCloudBillingGroupUsed();
     }
 
     return fetch(new Request(request, { headers }));

--- a/src/provider/veryfront-cloud/shared.ts
+++ b/src/provider/veryfront-cloud/shared.ts
@@ -1,5 +1,6 @@
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import { getVeryfrontCloudBootstrap } from "#veryfront/platform/cloud/resolver.ts";
+import { getCurrentVeryfrontCloudContext } from "./context.ts";
 import { isSupportedMistralModelId } from "./model-catalog.ts";
 
 /** Public API contract for Veryfront Cloud provider ID. */
@@ -149,6 +150,11 @@ export function createVeryfrontCloudFetch(
 
     if (projectSlug) {
       headers.set("x-veryfront-project-slug", projectSlug);
+    }
+
+    const billingGroupId = getCurrentVeryfrontCloudContext()?.billingGroupId?.trim();
+    if (billingGroupId) {
+      headers.set("x-veryfront-billing-group-id", billingGroupId);
     }
 
     return fetch(new Request(request, { headers }));

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.971";
+export const VERSION = "0.1.972";


### PR DESCRIPTION
## Summary
- Add request-scoped gateway billing group ids around eval and model-comparison runs.
- Finalize the group after a run and update eval report summary usage from the API response.
- Keep billing metadata from enabling cloud mode by itself.
- Bump veryfront to 0.1.972 for release.

## Verification
- deno test --no-check --allow-all cli/commands/eval/command.test.ts src/eval/model-comparison.test.ts src/eval/report.test.ts src/provider/veryfront-cloud/shared.test.ts src/platform/cloud/resolver.test.ts src/utils/version.test.ts
- deno task fmt:check
- deno task lint
- deno task typecheck
- deno task test:unit: 2212 passed, 0 failed
- pre-push checks passed

## Dependency
Depends on https://github.com/veryfront/veryfront-api/pull/3744 being merged and deployed before this framework release is used for live eval billing finalization.