### PR TITLE
Avoid eval run id collisions

### DIFF
--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -24,6 +24,7 @@ import {
   compareEvalModelReports,
   compareEvalReports,
   createEvalModelComparisonMarkdown,
+  createEvalRunId,
   discoverEvals,
   exportEvalReport,
   resolveEvalRunProvenance,
@@ -127,10 +128,6 @@ function xmlEscape(value: string): string {
 function stripFileProtocol(path: string): string {
   if (!path.startsWith("file://")) return path;
   return decodeURIComponent(new URL(path).pathname);
-}
-
-function createCliRunId(now = new Date()): string {
-  return `evalrun_${now.toISOString().replace(/[-:.]/g, "").replace("T", "_").replace("Z", "")}`;
 }
 
 function createEvalReportDirTimestamp(runId: string): string {
@@ -1094,7 +1091,7 @@ async function runEvalModelComparison(input: {
   config: EvalModelComparisonConfig;
   policy: EvalModelComparisonPolicy;
 }): Promise<void> {
-  const runId = createCliRunId();
+  const runId = createEvalRunId();
   const reportDir = input.options.reportDir ??
     createDefaultEvalReportDir(runId, input.evalItem.id);
   const paths = createEvalModelComparisonArtifactPaths(reportDir, input.config.models);
@@ -1308,7 +1305,7 @@ export async function evalCommand(options: EvalOptions): Promise<void> {
       return;
     }
 
-    const runId = createCliRunId();
+    const runId = createEvalRunId();
     const artifactPaths = createEvalArtifactPaths(
       options.reportDir ?? createDefaultEvalReportDir(runId, evalItem.id),
     );

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.972",
+  "version": "0.1.973",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -51,6 +51,7 @@ export { createEvalReport, summarizeEvalRecords } from "./report.ts";
 export { compareEvalReports } from "./baseline.ts";
 export { compareEvalModelReports, createEvalModelComparisonMarkdown } from "./model-comparison.ts";
 export { createEvalRunProvenance, resolveEvalRunProvenance } from "./provenance.ts";
+export { createEvalRunId } from "./run-id.ts";
 export { exportEvalReport, runEval } from "./runner.ts";
 export { deriveEvalId, discoverEvals, findEvalById } from "./discovery.ts";
 export {

--- a/src/eval/run-id.test.ts
+++ b/src/eval/run-id.test.ts
@@ -1,0 +1,21 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createEvalRunId } from "./run-id.ts";
+
+describe("eval/run-id", () => {
+  it("keeps timestamp-sortable run ids and adds a collision-resistant suffix", () => {
+    const now = new Date("2026-06-21T01:02:03.004Z");
+
+    assertEquals(createEvalRunId(now, () => "abcdef12"), "evalrun_20260621_010203004_abcdef12");
+  });
+
+  it("generates unique ids for runs started in the same millisecond", () => {
+    const now = new Date("2026-06-21T01:02:03.004Z");
+    const first = createEvalRunId(now);
+    const second = createEvalRunId(now);
+
+    if (first === second) {
+      throw new Error(`Expected unique eval run ids, received ${first}`);
+    }
+  });
+});

--- a/src/eval/run-id.ts
+++ b/src/eval/run-id.ts
@@ -1,0 +1,14 @@
+function createEvalRunIdSuffix(): string {
+  const bytes = new Uint8Array(8);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+/** Create a timestamp-sortable eval run id with a collision-resistant suffix. */
+export function createEvalRunId(
+  now = new Date(),
+  createSuffix: () => string = createEvalRunIdSuffix,
+): string {
+  const timestamp = now.toISOString().replace(/[-:.]/g, "").replace("T", "_").replace("Z", "");
+  return `evalrun_${timestamp}_${createSuffix()}`;
+}

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -1,5 +1,6 @@
 import { createEvalCheckContext } from "./expect.ts";
 import { createEvalReport } from "./report.ts";
+import { createEvalRunId } from "./run-id.ts";
 import { metrics as runtimeMetrics } from "#veryfront/metrics";
 import {
   createEvalReportExporterRegistry,
@@ -21,10 +22,6 @@ import type {
   EvalUsage,
   RunEvalOptions,
 } from "./types.ts";
-
-function createRunId(now: Date): string {
-  return `evalrun_${now.toISOString().replace(/[-:.]/g, "").replace("T", "_").replace("Z", "")}`;
-}
 
 function normalizeTrace(trace?: Partial<EvalTrace>): EvalTrace {
   return {
@@ -299,7 +296,7 @@ export async function runEval(
   const report = createEvalReport({
     definition,
     records,
-    runId: options.runId ?? createRunId(startedAt),
+    runId: options.runId ?? createEvalRunId(startedAt),
     startedAt,
     endedAt,
     metadata: options.metadata,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.972";
+export const VERSION = "0.1.973";


### PR DESCRIPTION
## Summary
- add a shared timestamp-sortable eval run id helper with a random suffix
- use it for CLI eval runs and programmatic runEval defaults
- bump veryfront to 0.1.973 for release

## Verification
- deno test --no-check --allow-all src/eval/run-id.test.ts cli/commands/eval/command.test.ts src/eval/runner.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/eval/run-id.test.ts cli/commands/eval/command.test.ts src/eval/runner.test.ts
- DENO_FROZEN_LOCKFILE=1 deno task verify:quick
- pre-push hook: format, lint, typecheck, unit tests