### PR TITLE
Normalize MoonshotAI tool schemas in runtime

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.973",
+  "version": "0.1.974",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/model-tool-converter.test.ts
+++ b/src/agent/runtime/model-tool-converter.test.ts
@@ -349,4 +349,37 @@ describe("model-tool-converter", () => {
       ],
     );
   });
+
+  it("normalizes Moonshot-compatible runtime tool schemas", () => {
+    const result = convertToolsToRuntimeTools([
+      {
+        name: "form_input",
+        description: "Collect structured form input",
+        parameters: {
+          type: "object",
+          properties: {
+            acceptance_criteria: {
+              $ref: "#/definitions/acceptanceCriteria",
+            },
+          },
+          definitions: {
+            acceptanceCriteria: {
+              type: "array",
+              items: { type: "string" },
+            },
+          },
+        },
+      },
+    ] as never, {
+      model: "veryfront-cloud/moonshotai/kimi-k2.6",
+    });
+
+    const schema = getRuntimeToolSchema(result?.form_input) as Record<string, unknown>;
+    const properties = schema.properties as Record<string, Record<string, unknown>>;
+    const defs = schema.$defs as Record<string, Record<string, unknown>>;
+
+    assertEquals(properties.acceptance_criteria?.$ref, "#/$defs/acceptanceCriteria");
+    assertEquals(schema.definitions, undefined);
+    assertEquals(defs.acceptanceCriteria?.type, "array");
+  });
 });

--- a/src/agent/runtime/provider-tool-compat.test.ts
+++ b/src/agent/runtime/provider-tool-compat.test.ts
@@ -154,6 +154,76 @@ describe("provider-tool-compat", () => {
     assertEquals(sanitized.properties?.labelIds?.items, {});
   });
 
+  it("normalizes Moonshot tool schemas to use $defs references", () => {
+    const sanitized = sanitizeProviderToolSchema(
+      {
+        type: "object",
+        properties: {
+          acceptance_criteria: {
+            $ref: "#/definitions/acceptanceCriteria",
+          },
+        },
+        definitions: {
+          acceptanceCriteria: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                label: { type: "string" },
+              },
+              required: ["label"],
+            },
+          },
+        },
+      } as never,
+      { model: "veryfront-cloud/moonshotai/kimi-k2.6" },
+    );
+    const sanitizedRecord = sanitized as Record<string, Record<string, unknown> | undefined>;
+    const properties = sanitizedRecord.properties as Record<string, Record<string, unknown>>;
+    const defs = sanitizedRecord.$defs as Record<string, Record<string, unknown>>;
+
+    assertEquals(properties.acceptance_criteria?.$ref, "#/$defs/acceptanceCriteria");
+    assertEquals(sanitizedRecord.definitions, undefined);
+    assertEquals(defs.acceptanceCriteria?.type, "array");
+  });
+
+  it("preserves Moonshot tool properties named definitions", () => {
+    const sanitized = sanitizeProviderToolSchema(
+      {
+        type: "object",
+        properties: {
+          definitions: {
+            type: "string",
+            description: "User-provided glossary text.",
+          },
+          nested: {
+            type: "object",
+            properties: {
+              definitions: {
+                type: "number",
+              },
+            },
+            required: ["definitions"],
+          },
+        },
+        required: ["definitions", "nested"],
+      } as never,
+      { model: "veryfront-cloud/moonshotai/kimi-k2.6" },
+    );
+    const sanitizedRecord = sanitized as Record<string, unknown>;
+    const properties = sanitizedRecord.properties as Record<string, Record<string, unknown>>;
+    const nested = properties.nested as {
+      properties?: Record<string, unknown>;
+      required?: string[];
+    };
+
+    assertEquals(properties.definitions?.type, "string");
+    assertEquals(nested.properties?.definitions, { type: "number" });
+    assertEquals(nested.required, ["definitions"]);
+    assertEquals(sanitizedRecord.required, ["definitions", "nested"]);
+    assertEquals(sanitizedRecord.$defs, undefined);
+  });
+
   it("removes Anthropic-incompatible property keys and matching required entries", () => {
     const sanitized = sanitizeProviderToolSchema(
       {

--- a/src/agent/runtime/provider-tool-compat.ts
+++ b/src/agent/runtime/provider-tool-compat.ts
@@ -65,8 +65,8 @@ export function getProviderToolProfile(model?: string): ProviderToolProfile {
     return { provider: "anthropic", sanitizeSchema: true };
   }
 
-  if (provider === "moonshot") {
-    return { provider: "moonshot", sanitizeSchema: false };
+  if (provider === "moonshot" || provider === "moonshotai") {
+    return { provider: "moonshot", sanitizeSchema: true };
   }
 
   return { provider: "unknown", sanitizeSchema: false };
@@ -298,6 +298,44 @@ function sanitizeGoogleSchemaValue(value: unknown): unknown {
   return sanitized;
 }
 
+function sanitizeMoonshotSchemaValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeMoonshotSchemaValue(item));
+  }
+
+  if (!isPlainRecord(value)) {
+    return value;
+  }
+
+  const sanitized: Record<string, unknown> = {};
+
+  for (const [key, child] of Object.entries(value)) {
+    if (key === "$ref" && typeof child === "string") {
+      sanitized.$ref = child.replace(/^#\/definitions\//, "#/$defs/");
+      continue;
+    }
+
+    if (key === "definitions") {
+      sanitized.$defs = sanitizeMoonshotSchemaValue(child);
+      continue;
+    }
+
+    if (key === "properties" && isPlainRecord(child)) {
+      sanitized.properties = Object.fromEntries(
+        Object.entries(child).map(([propertyName, propertySchema]) => [
+          propertyName,
+          sanitizeMoonshotSchemaValue(propertySchema),
+        ]),
+      );
+      continue;
+    }
+
+    sanitized[key] = sanitizeMoonshotSchemaValue(child);
+  }
+
+  return sanitized;
+}
+
 /**
  * Normalize a provider tool input schema so every function tool has a
  * provider-safe JSON Schema object at the root. Remote/MCP tools can omit the
@@ -330,6 +368,10 @@ export function sanitizeProviderToolSchema(
 
   if (profile.provider === "google") {
     return sanitizeGoogleSchemaValue(propertyKeySafeSchema) as JsonSchema;
+  }
+
+  if (profile.provider === "moonshot") {
+    return sanitizeMoonshotSchemaValue(propertyKeySafeSchema) as JsonSchema;
   }
 
   return propertyKeySafeSchema as JsonSchema;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.973";
+export const VERSION = "0.1.974";


### PR DESCRIPTION
## Summary
- treats `moonshotai` model IDs as the Moonshot tool-compat profile
- rewrites legacy JSON Schema `definitions` refs to `$defs` for Moonshot/Kimi tool schemas
- adds provider-compat and runtime-converter regressions for the `acceptance_criteria` schema shape that failed in staging

## Staging evidence
- `project_agent` conversation `a18486c5-aa27-48e6-b23e-1204103650d8` completed three Kimi 2.6 runs.
- `veryfront` chat conversation `ea3c0bf5-7949-4454-8668-ee028e5365f2` failed three runs with `STREAM_ERROR`.
- Failure message: Moonshot rejected `tools.function.parameters` because `properties.acceptance_criteria.$ref` used `#/definitions/...` instead of `#/$defs/...`.
- `veryfront-agent` pod logs show the failing runtime using pre-converted built-in schemas immediately before the Moonshot rejection.

## Validation
- `deno test --allow-all src/agent/runtime/provider-tool-compat.test.ts src/agent/runtime/model-tool-converter.test.ts`
- commit hook `verify:quick` passed during commit

## Follow-up after merge
- release/publish the updated `veryfront` package
- rebuild/deploy `veryfront-agent` to staging
- retest `veryfront-agent` with Kimi 2.6 in the failing conversation path
