### PR TITLE
Default agent model to GPT-5.4 Nano

### DIFF
--- a/docs/api-reference/veryfront/provider.md
+++ b/docs/api-reference/veryfront/provider.md
@@ -24,7 +24,7 @@ import {
 ```ts
 import { resolveModel } from "veryfront/provider";
 
-const model = resolveModel("veryfront-cloud/openai/gpt-5.2");
+const model = resolveModel("veryfront-cloud/openai/gpt-5.4-nano");
 ```
 
 ## API

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -317,7 +317,7 @@ export default agent({
 | `id`                  | `string`                                                                                               | Unique identifier used with `getAgent()`                                     |
 | `name`                | `string`                                                                                               | Human-readable display name for listings                                     |
 | `description`         | `string`                                                                                               | Optional summary for listings                                                |
-| `model`               | `string`                                                                                               | Optional provider/model override. Omit or use `"auto"` for runtime defaults. |
+| `model`               | `string`                                                                                               | Optional provider/model override. Omit for `openai/gpt-5.4-nano`; use `"auto"` for runtime selection. |
 | `system`              | `string \| () => string \| Promise<string>`                                                            | System prompt                                                                |
 | `resolveRuntimeState` | `(request: RuntimeStateRequest) => ResolvedRuntimeState \| Promise<ResolvedRuntimeState \| undefined>` | Refresh system/context before later model steps in the same run              |
 | `tools`               | `Record<string, boolean \| Tool>`                                                                      | Tools the agent can use                                                      |

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -202,7 +202,7 @@ defineConfig({
   ai: {
     providers: {
       openai: {
-        defaultModel: "gpt-4o-mini",
+        defaultModel: "gpt-5.4-nano",
       },
     },
     mcp: {

--- a/docs/guides/memory-and-streaming.md
+++ b/docs/guides/memory-and-streaming.md
@@ -12,7 +12,7 @@ isolated. Configure `memory` on the agent to persist history across calls, and
 use `createAgUiHandler` to stream the response back.
 
 Memory configuration is independent of model selection, so these examples omit
-`model` and follow the runtime default.
+`model` and use `openai/gpt-5.4-nano`.
 
 ## Prerequisites
 

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -11,7 +11,7 @@ Veryfront supports two agent composition patterns:
 
 Use agent-as-tool when the parent should choose the order at runtime. Use a workflow when the order is known in advance.
 
-Each agent can omit `model` and inherit the runtime default, or set an explicit `provider/model` override when you need one.
+Each agent can omit `model` and use `openai/gpt-5.4-nano`, set `"auto"` for runtime selection, or set an explicit `provider/model` override when you need one.
 
 ## Prerequisites
 

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -13,7 +13,7 @@ The provider registry resolves each string to one runtime:
 - an OpenAI-compatible service such as OpenRouter
 - a local model
 
-Omit `model` in most agents and let runtime conventions pick the backend.
+Omit `model` in most agents to use `openai/gpt-5.4-nano`.
 
 ## Prerequisites
 
@@ -27,8 +27,8 @@ Omit `model` in most agents and let runtime conventions pick the backend.
 
 ## Runtime conventions (recommended)
 
-For most projects, omit `model` entirely and let runtime defaults choose the
-right backend:
+For most projects, omit `model` entirely to use `openai/gpt-5.4-nano`. Set
+`model: "auto"` only when you want runtime conventions to choose the backend:
 
 ```ts
 import { agent } from "veryfront/agent";
@@ -49,7 +49,7 @@ curl -N http://localhost:3000/api/ag-ui \
 In a client UI, `useChat()` also exposes `inferenceMode` so you can confirm
 whether the response used cloud or server-local inference.
 
-By convention:
+For `model: "auto"`, runtime conventions are:
 
 - local development without cloud bootstrap uses explicit provider env vars or
   an explicit `local/*` model

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -78,8 +78,9 @@ export default agent({
 });
 ```
 
-In most projects, you can omit `model` and let runtime defaults choose local
-or Veryfront Cloud inference automatically.
+In most projects, you can omit `model` and use `openai/gpt-5.4-nano`. Set
+`model: "auto"` when you want runtime defaults to choose local or Veryfront
+Cloud inference automatically.
 
 When a user asks "What's the weather in Tokyo?", the agent:
 

--- a/src/agent/runtime/model-resolution.test.ts
+++ b/src/agent/runtime/model-resolution.test.ts
@@ -4,6 +4,7 @@ import { deleteEnv, setEnv } from "#veryfront/compat/process.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   AUTO_AGENT_MODEL,
+  DEFAULT_AGENT_MODEL,
   normalizeAgentModelConfig,
   resolveConfiguredAgentModel,
   resolveRuntimeModel,
@@ -36,8 +37,8 @@ describe("agent/runtime/model-resolution", () => {
     clearModelEnv();
   });
 
-  it("normalizes missing models to auto", () => {
-    assertEquals(normalizeAgentModelConfig(), AUTO_AGENT_MODEL);
+  it("normalizes omitted models to the default and blank models to auto", () => {
+    assertEquals(normalizeAgentModelConfig(), DEFAULT_AGENT_MODEL);
     assertEquals(normalizeAgentModelConfig("   "), AUTO_AGENT_MODEL);
   });
 
@@ -48,14 +49,14 @@ describe("agent/runtime/model-resolution", () => {
     );
   });
 
-  it("resolves auto to the default Veryfront Cloud model string", () => {
+  it("resolves omitted and auto model config separately", () => {
     assertEquals(
       resolveConfiguredAgentModel(),
-      "veryfront-cloud/anthropic/claude-sonnet-4-6",
+      "openai/gpt-5.4-nano",
     );
     assertEquals(
       resolveConfiguredAgentModel("auto"),
-      "veryfront-cloud/anthropic/claude-sonnet-4-6",
+      "veryfront-cloud/openai/gpt-5.4-nano",
     );
   });
 
@@ -101,22 +102,22 @@ describe("agent/runtime/model-resolution", () => {
     );
   });
 
-  it("uses the default Veryfront Cloud model for auto runtime resolution", () => {
+  it("uses the default model through Veryfront Cloud when cloud bootstrap is available", () => {
     setEnv("VERYFRONT_API_TOKEN", "vf_test_runtime");
     setEnv("VERYFRONT_PROJECT_SLUG", "demo-project");
 
     assertEquals(
       resolveRuntimeModel(),
-      "veryfront-cloud/anthropic/claude-sonnet-4-6",
+      "veryfront-cloud/openai/gpt-5.4-nano",
     );
   });
 
-  it("uses direct OpenAI credentials for auto runtime resolution without cloud bootstrap", () => {
+  it("uses direct OpenAI credentials for omitted model resolution without cloud bootstrap", () => {
     setEnv("OPENAI_API_KEY", "sk-test");
 
     assertEquals(
       resolveRuntimeModel(),
-      "openai/gpt-5.5",
+      "openai/gpt-5.4-nano",
     );
   });
 
@@ -136,8 +137,8 @@ describe("agent/runtime/model-resolution", () => {
     setEnv("OPENAI_API_KEY", "sk-test");
 
     assertEquals(
-      resolveRuntimeModel(),
-      "veryfront-cloud/anthropic/claude-sonnet-4-6",
+      resolveRuntimeModel("auto"),
+      "veryfront-cloud/openai/gpt-5.4-nano",
     );
   });
 

--- a/src/agent/runtime/model-resolution.ts
+++ b/src/agent/runtime/model-resolution.ts
@@ -11,6 +11,7 @@ import {
 } from "#veryfront/platform/cloud/resolver.ts";
 
 export const AUTO_AGENT_MODEL = "auto";
+export const DEFAULT_AGENT_MODEL = "openai/gpt-5.4-nano";
 
 const HOSTED_PROVIDER_NAMES = new Set([
   "anthropic",
@@ -27,7 +28,7 @@ const DIRECT_RUNTIME_PROVIDER_ALIASES: Record<string, string> = {
   "google-ai-studio": "google",
 };
 const DIRECT_AUTO_MODEL_DEFAULTS: Array<{ provider: string; modelId: string }> = [
-  { provider: "openai", modelId: "gpt-5.5" },
+  { provider: "openai", modelId: "gpt-5.4-nano" },
   { provider: "anthropic", modelId: "claude-sonnet-4-6" },
   { provider: "google-ai-studio", modelId: "gemini-3.5-flash" },
   { provider: "mistral", modelId: "mistral-large-2512" },
@@ -61,6 +62,8 @@ const LEGACY_MODEL_ALIASES: Record<string, string> = {
 };
 
 export function normalizeAgentModelConfig(model?: string): string {
+  if (model === undefined) return DEFAULT_AGENT_MODEL;
+
   const normalized = model?.trim();
   return normalized && normalized.length > 0 ? normalized : AUTO_AGENT_MODEL;
 }

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -135,7 +135,7 @@ export interface AgentConfig {
   /**
    * Optional model string in "provider/model" format.
    *
-   * When omitted or set to `"auto"`, Veryfront chooses the runtime default:
+   * When omitted, Veryfront uses `openai/gpt-5.4-nano`. Set `"auto"` to choose
    * Veryfront Cloud when bootstrap credentials are present, otherwise a
    * configured direct provider key when one exists.
    */

--- a/src/platform/cloud/resolver.ts
+++ b/src/platform/cloud/resolver.ts
@@ -36,7 +36,7 @@ function getApiBaseUrlEnv(): string {
     getHostEnv("VERYFRONT_API_URL")?.replace("/graphql", "/api") ?? DEFAULT_API_BASE_URL;
 }
 
-export const DEFAULT_VERYFRONT_CLOUD_MODEL = "veryfront-cloud/anthropic/claude-sonnet-4-6";
+export const DEFAULT_VERYFRONT_CLOUD_MODEL = "veryfront-cloud/openai/gpt-5.4-nano";
 export const DEFAULT_VERYFRONT_CLOUD_EMBEDDING_MODEL =
   "veryfront-cloud/openai/text-embedding-3-small";
 

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -7,7 +7,7 @@
  * ```ts
  * import { resolveModel } from "veryfront/provider";
  *
- * const model = resolveModel("veryfront-cloud/openai/gpt-5.2");
+ * const model = resolveModel("veryfront-cloud/openai/gpt-5.4-nano");
  * ```
  */
 

--- a/src/provider/veryfront-cloud/model-catalog.test.ts
+++ b/src/provider/veryfront-cloud/model-catalog.test.ts
@@ -22,6 +22,7 @@ describe("provider/veryfront-cloud/model-catalog", () => {
     assertEquals(findVeryfrontCloudModel("sonnet")?.provider, "anthropic");
     assertEquals(opus.modelId, "anthropic/claude-opus-4-8");
     assertEquals(findVeryfrontCloudModel("gpt-5.5")?.provider, "openai");
+    assertEquals(findVeryfrontCloudModel("gpt-5.4-nano")?.provider, "openai");
     assertEquals(findVeryfrontCloudModel("gemini-3.1-pro-preview")?.provider, "google");
     assertEquals(findVeryfrontCloudModel("gemini-3.5-flash")?.provider, "google");
     assertEquals(findVeryfrontCloudModel("mistral-large-2512")?.provider, "mistral");
@@ -80,7 +81,9 @@ describe("provider/veryfront-cloud/model-catalog", () => {
 
   it("resolves aliases and preserves direct model ids", () => {
     assertEquals(resolveVeryfrontCloudModelId("opus"), "anthropic/claude-opus-4-8");
+    assertEquals(resolveVeryfrontCloudModelId(), "openai/gpt-5.4-nano");
     assertEquals(resolveVeryfrontCloudModelId("gpt-5.5"), "openai/gpt-5.5");
+    assertEquals(resolveVeryfrontCloudModelId("gpt-5.4-nano"), "openai/gpt-5.4-nano");
     assertEquals(resolveVeryfrontCloudModelId("mistral-large-2512"), "mistral/mistral-large-2512");
     assertEquals(resolveVeryfrontCloudModelId("openai/gpt-5.5"), "openai/gpt-5.5");
     assertThrows(
@@ -107,6 +110,7 @@ describe("provider/veryfront-cloud/model-catalog", () => {
       undefined,
     );
     assertEquals(resolveVeryfrontCloudModelThinking("openai/gpt-5.5"), undefined);
+    assertEquals(resolveVeryfrontCloudModelThinking("openai/gpt-5.4-nano"), undefined);
     assertEquals(resolveVeryfrontCloudModelThinking("anthropic/claude-sonnet-4-6")?.enabled, true);
     assertEquals(
       resolveVeryfrontCloudModelThinking("anthropic/claude-haiku-4-5-20251001")?.enabled,

--- a/src/provider/veryfront-cloud/model-catalog.ts
+++ b/src/provider/veryfront-cloud/model-catalog.ts
@@ -17,7 +17,7 @@ export type VeryfrontCloudChatModel = {
 };
 
 /** Default value for Veryfront Cloud model ID. */
-export const DEFAULT_VERYFRONT_CLOUD_MODEL_ID = "opus";
+export const DEFAULT_VERYFRONT_CLOUD_MODEL_ID = "gpt-5.4-nano";
 /** Shared Veryfront Cloud model prefix value. */
 export const VERYFRONT_CLOUD_MODEL_PREFIX = "veryfront-cloud/";
 
@@ -69,6 +69,13 @@ export const VERYFRONT_CLOUD_CHAT_MODELS: VeryfrontCloudChatModel[] = [
     provider: "openai",
     name: "GPT-5.5",
     description: "Most capable OpenAI model",
+  },
+  {
+    id: "gpt-5.4-nano",
+    modelId: "openai/gpt-5.4-nano",
+    provider: "openai",
+    name: "GPT-5.4 Nano",
+    description: "Default model for fast everyday tasks",
   },
   {
     id: "gemini-3.1-pro-preview",

--- a/src/provider/veryfront-cloud/provider.test.ts
+++ b/src/provider/veryfront-cloud/provider.test.ts
@@ -44,7 +44,7 @@ describe("provider/veryfront-cloud", () => {
   it("resolves veryfront-cloud openai models without project ext-llm-openai installed", () => {
     setCloudBootstrap();
 
-    const model = resolveModel("veryfront-cloud/openai/gpt-5.2") as Record<string, unknown>;
+    const model = resolveModel("veryfront-cloud/openai/gpt-5.4-nano") as Record<string, unknown>;
 
     assertEquals(typeof model.doGenerate, "function");
     assertEquals(typeof model.doStream, "function");


### PR DESCRIPTION
## Summary
- makes omitted agent model resolve to openai/gpt-5.4-nano
- updates Veryfront Cloud fallback/catalog defaults to gpt-5.4-nano
- updates provider docs and agent model-resolution tests

## Verification
- deno test --no-check --allow-all src/provider/veryfront-cloud/model-catalog.test.ts src/provider/veryfront-cloud/provider.test.ts src/agent/runtime/model-resolution.test.ts
- deno fmt --check src/agent/runtime/model-resolution.ts src/agent/runtime/model-resolution.test.ts src/provider/veryfront-cloud/model-catalog.ts src/provider/veryfront-cloud/model-catalog.test.ts src/provider/veryfront-cloud/provider.test.ts src/platform/cloud/resolver.ts src/provider/index.ts src/agent/types.ts docs/api-reference/veryfront/provider.md docs/guides/agents.md docs/guides/configuration.md docs/guides/memory-and-streaming.md docs/guides/multi-agent.md docs/guides/providers.md docs/guides/tools.md
- deno check src/provider/index.ts src/provider/veryfront-cloud/model-catalog.ts src/platform/cloud/resolver.ts src/agent/runtime/model-resolution.ts src/agent/types.ts
- git diff --check

Note: full pre-push hook was interrupted after two unrelated tests stayed pending for over 8 minutes; the changed model/provider files passed focused verification.