### PR TITLE
Route short Kimi aliases through Moonshot tool compatibility

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.975",
+  "version": "0.1.976",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/model-tool-converter.test.ts
+++ b/src/agent/runtime/model-tool-converter.test.ts
@@ -382,4 +382,37 @@ describe("model-tool-converter", () => {
     assertEquals(schema.definitions, undefined);
     assertEquals(defs.acceptanceCriteria?.type, "array");
   });
+
+  it("normalizes short Kimi alias runtime tool schemas", () => {
+    const result = convertToolsToRuntimeTools([
+      {
+        name: "form_input",
+        description: "Collect structured form input",
+        parameters: {
+          type: "object",
+          properties: {
+            acceptance_criteria: {
+              $ref: "#/definitions/acceptanceCriteria",
+            },
+          },
+          definitions: {
+            acceptanceCriteria: {
+              type: "array",
+              items: { type: "string" },
+            },
+          },
+        },
+      },
+    ] as never, {
+      model: "kimi-k2.6",
+    });
+
+    const schema = getRuntimeToolSchema(result?.form_input) as Record<string, unknown>;
+    const properties = schema.properties as Record<string, Record<string, unknown>>;
+    const defs = schema.$defs as Record<string, Record<string, unknown>>;
+
+    assertEquals(properties.acceptance_criteria?.$ref, "#/$defs/acceptanceCriteria");
+    assertEquals(schema.definitions, undefined);
+    assertEquals(defs.acceptanceCriteria?.type, "array");
+  });
 });

--- a/src/agent/runtime/provider-tool-compat.test.ts
+++ b/src/agent/runtime/provider-tool-compat.test.ts
@@ -2,6 +2,7 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ToolDefinition } from "#veryfront/tool";
 import {
+  getProviderToolProfile,
   sanitizeProviderToolSchema,
   selectProviderCompatibleToolNames,
   selectProviderCompatibleTools,
@@ -182,6 +183,35 @@ describe("provider-tool-compat", () => {
     const properties = sanitizedRecord.properties as Record<string, Record<string, unknown>>;
     const defs = sanitizedRecord.$defs as Record<string, Record<string, unknown>>;
 
+    assertEquals(properties.acceptance_criteria?.$ref, "#/$defs/acceptanceCriteria");
+    assertEquals(sanitizedRecord.definitions, undefined);
+    assertEquals(defs.acceptanceCriteria?.type, "array");
+  });
+
+  it("normalizes short Kimi aliases as Moonshot tool schemas", () => {
+    const profile = getProviderToolProfile("kimi-k2.6");
+    const sanitized = sanitizeProviderToolSchema(
+      {
+        type: "object",
+        properties: {
+          acceptance_criteria: {
+            $ref: "#/definitions/acceptanceCriteria",
+          },
+        },
+        definitions: {
+          acceptanceCriteria: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+      } as never,
+      { model: "kimi-k2.6" },
+    );
+    const sanitizedRecord = sanitized as Record<string, Record<string, unknown> | undefined>;
+    const properties = sanitizedRecord.properties as Record<string, Record<string, unknown>>;
+    const defs = sanitizedRecord.$defs as Record<string, Record<string, unknown>>;
+
+    assertEquals(profile, { provider: "moonshot", sanitizeSchema: true });
     assertEquals(properties.acceptance_criteria?.$ref, "#/$defs/acceptanceCriteria");
     assertEquals(sanitizedRecord.definitions, undefined);
     assertEquals(defs.acceptanceCriteria?.type, "array");

--- a/src/agent/runtime/provider-tool-compat.ts
+++ b/src/agent/runtime/provider-tool-compat.ts
@@ -52,6 +52,7 @@ export function getProviderToolProfile(model?: string): ProviderToolProfile {
   const normalized = normalizeModel(model);
   const parts = normalized.split("/").filter(Boolean);
   const provider = parts[0] === "veryfront-cloud" ? parts[1] : parts[0];
+  const modelName = parts.at(-1);
 
   if (provider === "openai") {
     return { provider: "openai", maxTools: OPENAI_MAX_TOOLS, sanitizeSchema: false };
@@ -65,7 +66,7 @@ export function getProviderToolProfile(model?: string): ProviderToolProfile {
     return { provider: "anthropic", sanitizeSchema: true };
   }
 
-  if (provider === "moonshot" || provider === "moonshotai") {
+  if (provider === "moonshot" || provider === "moonshotai" || modelName?.startsWith("kimi-")) {
     return { provider: "moonshot", sanitizeSchema: true };
   }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.975";
+export const VERSION = "0.1.976";


### PR DESCRIPTION
## Summary
- classify bare `kimi-*` aliases as Moonshot for provider tool schema compatibility
- add regression coverage for `kimi-k2.6` at provider profile and runtime tool conversion levels
- bump veryfront to `0.1.976`

## Verification
- `deno test --frozen --allow-all src/agent/runtime/provider-tool-compat.test.ts src/agent/runtime/model-tool-converter.test.ts`
- `deno task verify:quick`

Fixes veryfront/veryfront-studio#5384