### PR TITLE
Fix Moonshot local tool schema refs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.977",
+  "version": "0.1.978",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/model-tool-converter.test.ts
+++ b/src/agent/runtime/model-tool-converter.test.ts
@@ -415,4 +415,43 @@ describe("model-tool-converter", () => {
     assertEquals(schema.definitions, undefined);
     assertEquals(defs.acceptanceCriteria?.type, "array");
   });
+
+  it("inlines Moonshot runtime tool refs that point outside $defs", () => {
+    const result = convertToolsToRuntimeTools([
+      {
+        name: "create_work",
+        description: "Create work with expectations",
+        parameters: {
+          type: "object",
+          properties: {
+            project_reference: { type: "string" },
+            expectations: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  id: { type: "string" },
+                  description: { type: "string" },
+                },
+                required: ["id", "description"],
+              },
+            },
+            acceptance_criteria: {
+              $ref: "#/properties/expectations",
+            },
+          },
+          required: ["project_reference", "expectations"],
+        },
+      },
+    ] as never, {
+      model: "moonshotai/kimi-k2.6",
+    });
+
+    const schema = getRuntimeToolSchema(result?.create_work) as Record<string, unknown>;
+    const properties = schema.properties as Record<string, Record<string, unknown>>;
+
+    assertEquals(properties.acceptance_criteria?.$ref, undefined);
+    assertEquals(properties.acceptance_criteria?.type, "array");
+    assertEquals(JSON.stringify(schema).includes("#/properties/"), false);
+  });
 });

--- a/src/agent/runtime/provider-tool-compat.test.ts
+++ b/src/agent/runtime/provider-tool-compat.test.ts
@@ -217,6 +217,37 @@ describe("provider-tool-compat", () => {
     assertEquals(defs.acceptanceCriteria?.type, "array");
   });
 
+  it("inlines Moonshot tool refs that point outside $defs", () => {
+    const sanitized = sanitizeProviderToolSchema(
+      {
+        type: "object",
+        properties: {
+          expectations: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                id: { type: "string" },
+                description: { type: "string" },
+              },
+              required: ["id", "description"],
+            },
+          },
+          acceptance_criteria: {
+            $ref: "#/properties/expectations",
+          },
+        },
+      } as never,
+      { model: "veryfront-cloud/moonshotai/kimi-k2.6" },
+    );
+    const sanitizedRecord = sanitized as Record<string, Record<string, unknown> | undefined>;
+    const properties = sanitizedRecord.properties as Record<string, Record<string, unknown>>;
+
+    assertEquals(properties.acceptance_criteria?.$ref, undefined);
+    assertEquals(properties.acceptance_criteria?.type, "array");
+    assertEquals(JSON.stringify(sanitized).includes("#/properties/"), false);
+  });
+
   it("preserves Moonshot tool properties named definitions", () => {
     const sanitized = sanitizeProviderToolSchema(
       {

--- a/src/agent/runtime/provider-tool-compat.ts
+++ b/src/agent/runtime/provider-tool-compat.ts
@@ -299,13 +299,61 @@ function sanitizeGoogleSchemaValue(value: unknown): unknown {
   return sanitized;
 }
 
-function sanitizeMoonshotSchemaValue(value: unknown): unknown {
+function decodeJsonPointerSegment(segment: string): string {
+  return segment.replaceAll("~1", "/").replaceAll("~0", "~");
+}
+
+function resolveLocalJsonPointer(root: unknown, ref: string): unknown {
+  if (!ref.startsWith("#/")) {
+    return undefined;
+  }
+
+  let current = root;
+  for (const rawSegment of ref.slice(2).split("/")) {
+    if (!isPlainRecord(current) && !Array.isArray(current)) {
+      return undefined;
+    }
+
+    const segment = decodeJsonPointerSegment(rawSegment);
+    current = Reflect.get(current, segment);
+  }
+
+  return current;
+}
+
+function sanitizeMoonshotSchemaValue(
+  value: unknown,
+  root: unknown = value,
+  seenRefs: ReadonlySet<string> = new Set(),
+): unknown {
   if (Array.isArray(value)) {
-    return value.map((item) => sanitizeMoonshotSchemaValue(item));
+    return value.map((item) => sanitizeMoonshotSchemaValue(item, root, seenRefs));
   }
 
   if (!isPlainRecord(value)) {
     return value;
+  }
+
+  if (
+    typeof value.$ref === "string" &&
+    !value.$ref.startsWith("#/$defs/") &&
+    !value.$ref.startsWith("#/definitions/") &&
+    !seenRefs.has(value.$ref)
+  ) {
+    const resolved = resolveLocalJsonPointer(root, value.$ref);
+    if (resolved !== undefined && resolved !== value) {
+      const nextSeenRefs = new Set(seenRefs);
+      nextSeenRefs.add(value.$ref);
+      const sanitizedResolved = sanitizeMoonshotSchemaValue(resolved, root, nextSeenRefs);
+      const { $ref: _ref, ...siblings } = value;
+      const sanitizedSiblings = Object.keys(siblings).length > 0
+        ? sanitizeMoonshotSchemaValue(siblings, root, nextSeenRefs)
+        : undefined;
+
+      return isPlainRecord(sanitizedResolved) && isPlainRecord(sanitizedSiblings)
+        ? { ...sanitizedResolved, ...sanitizedSiblings }
+        : sanitizedResolved;
+    }
   }
 
   const sanitized: Record<string, unknown> = {};
@@ -317,7 +365,7 @@ function sanitizeMoonshotSchemaValue(value: unknown): unknown {
     }
 
     if (key === "definitions") {
-      sanitized.$defs = sanitizeMoonshotSchemaValue(child);
+      sanitized.$defs = sanitizeMoonshotSchemaValue(child, root, seenRefs);
       continue;
     }
 
@@ -325,13 +373,13 @@ function sanitizeMoonshotSchemaValue(value: unknown): unknown {
       sanitized.properties = Object.fromEntries(
         Object.entries(child).map(([propertyName, propertySchema]) => [
           propertyName,
-          sanitizeMoonshotSchemaValue(propertySchema),
+          sanitizeMoonshotSchemaValue(propertySchema, root, seenRefs),
         ]),
       );
       continue;
     }
 
-    sanitized[key] = sanitizeMoonshotSchemaValue(child);
+    sanitized[key] = sanitizeMoonshotSchemaValue(child, root, seenRefs);
   }
 
   return sanitized;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.977";
+export const VERSION = "0.1.978";


### PR DESCRIPTION
## Summary
- inline Moonshot tool schema refs that point outside `#/$defs`
- cover the staging `create_work` / `acceptance_criteria` schema shape with regression tests
- bump `veryfront` to `0.1.978`

## Verification
- `deno test --frozen --allow-all src/agent/runtime/provider-tool-compat.test.ts src/agent/runtime/model-tool-converter.test.ts`
- `deno task verify:quick`

## Notes
Fresh live staging Kimi validation is currently gated by Moonshot credit availability; the persisted stream failure and staging MCP schema identify the rejected `$ref` shape.