### PR TITLE
Fix npm package audit vulnerabilities

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.978",
+  "version": "0.1.979",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -143,7 +143,7 @@ await build({
 			"@types/react-dom": npmDependencyRange(denoConfigSet, "@types/react-dom"),
 			// Root deno.json intentionally rejects core npm imports; ws is a
 			// Node-only dynamic import used by the npm server/HMR path.
-			"ws": "8.18.0",
+			"ws": "8.21.0",
 			"@kreuzberg/node": npmDependencyRange(denoConfigSet, "@kreuzberg/node"),
 		},
 		// Native binary deps that should not block install if they fail

--- a/scripts/build/npm-dependency-sources.test.ts
+++ b/scripts/build/npm-dependency-sources.test.ts
@@ -8,9 +8,9 @@ import {
 
 describe("npm dependency source helpers", () => {
 	it("parses npm import map entries", () => {
-		assertEquals(parseNpmImport("npm:ws@8.18.0"), {
+		assertEquals(parseNpmImport("npm:ws@8.21.0"), {
 			name: "ws",
-			version: "8.18.0",
+			version: "8.21.0",
 		});
 		assertEquals(parseNpmImport("npm:@kreuzberg/wasm@4.5.2/dist/pkg/kreuzberg_wasm.js"), {
 			name: "@kreuzberg/wasm",
@@ -32,12 +32,12 @@ describe("npm dependency source helpers", () => {
 	it("derives npm ranges from import maps", () => {
 		const configs = [{
 			imports: {
-				ws: "npm:ws@8.18.0",
+				ws: "npm:ws@8.21.0",
 				react: "https://esm.sh/react@19.2.4?target=es2022",
 			},
 		}];
 
-		assertEquals(npmDependencyRange(configs, "ws"), "8.18.0");
+		assertEquals(npmDependencyRange(configs, "ws"), "8.21.0");
 		assertEquals(npmDependencyRange(configs, "react", ""), "19.2.4");
 	});
 

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -149,6 +149,9 @@ describe("normalizeNpmPackageMetadata", () => {
 			react: "^19.0.0",
 			"better-sqlite3": ">=9.0.0",
 		});
+		assertEquals(pkg.overrides, {
+			protobufjs: "8.6.5",
+		});
 	});
 });
 

--- a/scripts/build/npm-package-metadata.ts
+++ b/scripts/build/npm-package-metadata.ts
@@ -47,7 +47,7 @@ const STALE_DEV_DEPENDENCIES = [
 ] as const;
 
 const REQUIRED_NPM_OVERRIDES = {
-	protobufjs: "8.2.0",
+	protobufjs: "8.6.5",
 } as const;
 
 export function normalizeNpmPackageMetadata(pkg: PackageJson): PackageJson {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.978";
+export const VERSION = "0.1.979";

--- a/tests/build/npm-package-metadata.test.ts
+++ b/tests/build/npm-package-metadata.test.ts
@@ -21,6 +21,6 @@ Deno.test("keeps native sqlite support optional for npm consumers", () => {
     "better-sqlite3": { optional: true },
   });
   assertEquals(pkg.overrides, {
-    protobufjs: "8.2.0",
+    protobufjs: "8.6.5",
   });
 });


### PR DESCRIPTION
## Summary
- bump the npm package ws runtime dependency to 8.21.0
- update the generated npm package protobufjs override to 8.6.5
- bump Veryfront to 0.1.979 for release automation

## Verification
- deno test --config=scripts/test.deno.json --no-check --allow-read scripts/build/npm-dependency-sources.test.ts scripts/build/npm-package-metadata.test.ts
- deno task build:npm (generated npm package: found 0 vulnerabilities)
- deno task verify:quick
- pre-push unit suite: 2217 passed, 0 failed