### PR TITLE
Retry eval billing finalization after usage lag

### DIFF
--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -20,6 +20,7 @@ import {
   createResultsJsonl,
   createSummaryArtifact,
   exportEvalReportForCli,
+  finalizeGatewayBillingGroup,
   findEvalForCliId,
   hydrateEvalRuntimeAuth,
   loadEvalModelComparisonPolicy,
@@ -525,6 +526,67 @@ describe("eval CLI command helpers", () => {
     assertEquals(request.url, "https://api.test/ai/gateway/billing/finalize");
     assertEquals(request.headers.get("Authorization"), "Bearer test-token");
     assertEquals(await request.json(), { billing_group_id: "evalrun_test_model" });
+  });
+
+  it("retries gateway billing finalization while usage capture is not ready", async () => {
+    Deno.env.set("VERYFRONT_API_TOKEN", "test-token");
+    Deno.env.set("VERYFRONT_API_BASE_URL", "https://api.test");
+    const requests: Request[] = [];
+    const sleeps: number[] = [];
+    globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      requests.push(request);
+      if (requests.length === 1) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              error: "Gateway billing group usage is not ready to finalize",
+              code: "gateway_billing_group_usage_not_ready",
+            }),
+            {
+              status: 409,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+      }
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            billing_group_id: "evalrun_test_model",
+            already_finalized: false,
+            request_count: 1,
+            charged_credits: 4,
+            target_credits: 1,
+            adjustment_credits: 3,
+            adjustment: "refund",
+            provider_cost_usd: 0.01,
+            veryfront_charge_usd: 0.03,
+            veryfront_billed_usd: 0.4,
+            usage_capture_status: "complete",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+    };
+
+    const finalization = await finalizeGatewayBillingGroup("evalrun_test_model", {
+      retryDelaysMs: [25],
+      sleep: (ms) => {
+        sleeps.push(ms);
+        return Promise.resolve();
+      },
+    });
+
+    assertEquals(requests.length, 2);
+    assertEquals(sleeps, [25]);
+    assertEquals(finalization?.target_credits, 1);
+    assertEquals(finalization?.veryfront_billed_usd, 0.4);
   });
 
   it("exports CLI eval reports after gateway billing finalization", async () => {

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -101,7 +101,20 @@ type GatewayBillingGroupFinalization = {
   veryfront_billed_usd: number;
 };
 
+type GatewayBillingFinalizeError = {
+  bodyText: string;
+  code?: string;
+};
+
+type GatewayBillingFinalizeOptions = {
+  retryDelaysMs?: readonly number[];
+  sleep?: (ms: number) => Promise<void>;
+};
+
 type EvalModelComparisonPolicy = Omit<EvalModelComparisonOptions, "baselineModel">;
+
+const GATEWAY_BILLING_GROUP_USAGE_NOT_READY_CODE = "gateway_billing_group_usage_not_ready";
+const DEFAULT_GATEWAY_BILLING_FINALIZE_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000, 4_000] as const;
 
 const MODEL_COMPARISON_METRICS = [
   "passRate",
@@ -331,6 +344,45 @@ function parseGatewayBillingGroupFinalization(
   };
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function readGatewayBillingFinalizeError(
+  response: Response,
+): Promise<GatewayBillingFinalizeError> {
+  const bodyText = await response.text().catch(() => "");
+  if (!bodyText) return { bodyText };
+
+  try {
+    const payload = JSON.parse(bodyText) as unknown;
+    if (isRecord(payload) && typeof payload.code === "string") {
+      return { bodyText, code: payload.code };
+    }
+  } catch {
+    // Keep the raw body text for the warning below.
+  }
+
+  return { bodyText };
+}
+
+function isGatewayBillingUsageNotReady(
+  response: Response,
+  error: GatewayBillingFinalizeError,
+): boolean {
+  if (response.status !== 409) return false;
+  return error.code === GATEWAY_BILLING_GROUP_USAGE_NOT_READY_CODE;
+}
+
+function formatGatewayBillingFinalizeWarning(
+  billingGroupId: string,
+  response: Response,
+  error: GatewayBillingFinalizeError,
+): string {
+  const body = error.bodyText ? ` ${error.bodyText}` : "";
+  return `Gateway billing finalization skipped for ${billingGroupId}: ${response.status}${body}`;
+}
+
 export function applyGatewayBillingGroupFinalization(
   report: EvalReport,
   finalization: GatewayBillingGroupFinalization,
@@ -362,47 +414,57 @@ function hasGatewayUsage(report: EvalReport): boolean {
   );
 }
 
-async function finalizeGatewayBillingGroup(
+export async function finalizeGatewayBillingGroup(
   billingGroupId: string,
+  options: GatewayBillingFinalizeOptions = {},
 ): Promise<GatewayBillingGroupFinalization | undefined> {
   const bootstrap = getVeryfrontCloudBootstrap();
   if (!bootstrap.apiToken) return undefined;
 
-  let response: Response;
-  try {
-    response = await fetch(joinApiUrl(bootstrap.apiBaseUrl, "ai/gateway/billing/finalize"), {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${bootstrap.apiToken}`,
-        "Content-Type": "application/json",
-        ...(bootstrap.projectSlug ? { "x-veryfront-project-slug": bootstrap.projectSlug } : {}),
-      },
-      body: JSON.stringify({ billing_group_id: billingGroupId }),
-    });
-  } catch (error) {
-    cliLogger.warn(
-      `Gateway billing finalization skipped for ${billingGroupId}: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-    return undefined;
-  }
+  const retryDelaysMs = options.retryDelaysMs ?? DEFAULT_GATEWAY_BILLING_FINALIZE_RETRY_DELAYS_MS;
+  const sleepFn = options.sleep ?? sleep;
 
-  if (!response.ok) {
-    const message = await response.text().catch(() => "");
-    cliLogger.warn(
-      `Gateway billing finalization skipped for ${billingGroupId}: ${response.status}${
-        message ? ` ${message}` : ""
-      }`,
-    );
-    return undefined;
-  }
+  for (let attempt = 0;; attempt += 1) {
+    let response: Response;
+    try {
+      response = await fetch(joinApiUrl(bootstrap.apiBaseUrl, "ai/gateway/billing/finalize"), {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${bootstrap.apiToken}`,
+          "Content-Type": "application/json",
+          ...(bootstrap.projectSlug ? { "x-veryfront-project-slug": bootstrap.projectSlug } : {}),
+        },
+        body: JSON.stringify({ billing_group_id: billingGroupId }),
+      });
+    } catch (error) {
+      cliLogger.warn(
+        `Gateway billing finalization skipped for ${billingGroupId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return undefined;
+    }
 
-  const finalization = parseGatewayBillingGroupFinalization(await response.json());
-  if (!finalization) {
-    cliLogger.warn(`Gateway billing finalization skipped for ${billingGroupId}: invalid response`);
+    if (!response.ok) {
+      const error = await readGatewayBillingFinalizeError(response);
+      const retryDelayMs = retryDelaysMs[attempt];
+      if (isGatewayBillingUsageNotReady(response, error) && retryDelayMs !== undefined) {
+        await sleepFn(retryDelayMs);
+        continue;
+      }
+
+      cliLogger.warn(formatGatewayBillingFinalizeWarning(billingGroupId, response, error));
+      return undefined;
+    }
+
+    const finalization = parseGatewayBillingGroupFinalization(await response.json());
+    if (!finalization) {
+      cliLogger.warn(
+        `Gateway billing finalization skipped for ${billingGroupId}: invalid response`,
+      );
+    }
+    return finalization;
   }
-  return finalization;
 }
 
 export async function runEvalWithGatewayBillingGroup(

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.979",
+  "version": "0.1.980",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.979";
+export const VERSION = "0.1.980";


### PR DESCRIPTION
## Summary
- retry eval gateway billing finalization when API reports usage capture is not ready
- retry only the stable `gateway_billing_group_usage_not_ready` code, not arbitrary 409s or prose text
- add test coverage for the delayed-ready path
- bump package version to `0.1.980`

## Root cause
Eval runs aggregate multiple internal gateway calls under one billing group. Usage capture can lag finalization, so the CLI sometimes finalized before all usage rows were ready and printed a warning.

## Dependency
Requires veryfront/veryfront-api#3759 so the API returns a machine-readable usage-not-ready code.

## Verification
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all cli/commands/eval/command.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts cli/commands/eval/command.test.ts`
- `deno fmt --check src/utils/version-constant.ts cli/commands/eval/command.ts cli/commands/eval/command.test.ts deno.json`
- `deno lint src/utils/version-constant.ts cli/commands/eval/command.ts cli/commands/eval/command.test.ts`
- normal pre-push hook passed during `git push`
