### PR TITLE
Wait for async gateway usage before eval billing finalization

### DIFF
--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -589,6 +589,66 @@ describe("eval CLI command helpers", () => {
     assertEquals(finalization?.veryfront_billed_usd, 0.4);
   });
 
+  it("retries default gateway billing finalization long enough for delayed usage capture", async () => {
+    Deno.env.set("VERYFRONT_API_TOKEN", "test-token");
+    Deno.env.set("VERYFRONT_API_BASE_URL", "https://api.test");
+    const requests: Request[] = [];
+    const sleeps: number[] = [];
+    globalThis.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      requests.push(request);
+      if (requests.length <= 6) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              error: "Gateway billing group usage is not ready to finalize",
+              code: "gateway_billing_group_usage_not_ready",
+            }),
+            {
+              status: 409,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+      }
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            billing_group_id: "evalrun_test_model",
+            already_finalized: false,
+            request_count: 1,
+            charged_credits: 4,
+            target_credits: 1,
+            adjustment_credits: 3,
+            adjustment: "refund",
+            provider_cost_usd: 0.01,
+            veryfront_charge_usd: 0.03,
+            veryfront_billed_usd: 0.4,
+            usage_capture_status: "complete",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+    };
+
+    const finalization = await finalizeGatewayBillingGroup("evalrun_test_model", {
+      sleep: (ms) => {
+        sleeps.push(ms);
+        return Promise.resolve();
+      },
+    });
+
+    assertEquals(requests.length, 7);
+    assertEquals(sleeps.length, 6);
+    assertEquals(finalization?.target_credits, 1);
+    assertEquals(finalization?.veryfront_billed_usd, 0.4);
+  });
+
   it("exports CLI eval reports after gateway billing finalization", async () => {
     const registry = createEvalReportExporterRegistry();
     const finalized = applyGatewayBillingGroupFinalization(createReport(), {

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -114,7 +114,15 @@ type GatewayBillingFinalizeOptions = {
 type EvalModelComparisonPolicy = Omit<EvalModelComparisonOptions, "baselineModel">;
 
 const GATEWAY_BILLING_GROUP_USAGE_NOT_READY_CODE = "gateway_billing_group_usage_not_ready";
-const DEFAULT_GATEWAY_BILLING_FINALIZE_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000, 4_000] as const;
+// Gateway usage capture is eventually consistent after model streams close.
+const DEFAULT_GATEWAY_BILLING_FINALIZE_RETRY_DELAYS_MS = [
+  500,
+  1_000,
+  2_000,
+  4_000,
+  8_000,
+  15_000,
+] as const;
 
 const MODEL_COMPARISON_METRICS = [
   "passRate",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.980",
+  "version": "0.1.981",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.980";
+export const VERSION = "0.1.981";


### PR DESCRIPTION
## Summary
- extend the eval billing finalization retry window for delayed gateway usage capture
- add a regression test where usage becomes ready after the previous default retry budget
- bump the package version to 0.1.981 for release

## Verification
- VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all cli/commands/eval/command.test.ts src/utils/version.test.ts
- deno fmt --check cli/commands/eval/command.ts cli/commands/eval/command.test.ts deno.json src/utils/version-constant.ts
- deno lint cli/commands/eval/command.ts cli/commands/eval/command.test.ts src/utils/version-constant.ts
- pre-push checks: format, lint, typecheck, generated manifests, unit suite (2217 passed, 0 failed)

## Notes
The CLI still finalizes billing synchronously for deterministic eval reports. The backend usage capture remains asynchronous and is handled through bounded readiness polling.