### PR TITLE
Avoid fake winners in eval model comparisons

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.981",
+  "version": "0.1.982",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/eval/model-comparison.test.ts
+++ b/src/eval/model-comparison.test.ts
@@ -385,6 +385,44 @@ describe("eval/model-comparison", () => {
     assertEquals(comparison.recommendation.decision, "promote-candidate");
   });
 
+  it("does not rank multiple default-promotable candidates by insertion order", () => {
+    const comparison = compareEvalModelReports(
+      [
+        createReport("anthropic/claude-sonnet-4-6", {
+          veryfrontChargeUsd: 0.34,
+          p95Ms: 22_000,
+          totalTokens: 33_000,
+          costSource: "gateway",
+        }),
+        createReport("moonshotai/kimi-k2.6", {
+          veryfrontChargeUsd: 0.08,
+          p95Ms: 44_000,
+          totalTokens: 21_000,
+          costSource: "gateway",
+        }),
+        createReport("openai/gpt-5.4-nano", {
+          veryfrontChargeUsd: 0.02,
+          p95Ms: 8_000,
+          totalTokens: 20_000,
+          costSource: "gateway",
+        }),
+      ],
+      { baselineModel: "anthropic/claude-sonnet-4-6" },
+    );
+
+    assertEquals(
+      comparison.candidates.map((candidate) => candidate.decision),
+      ["promote-candidate", "promote-candidate"],
+    );
+    assertEquals(comparison.recommendation, {
+      decision: "promote-candidate",
+      reasons: [
+        "multiple candidate models are promotable: moonshotai/kimi-k2.6, openai/gpt-5.4-nano",
+        "configure --comparison-policy objectives to rank candidates by your product requirements",
+      ],
+    });
+  });
+
   it("keeps objective scores finite when the baseline metric is zero", () => {
     const comparison = compareEvalModelReports(
       [

--- a/src/eval/model-comparison.ts
+++ b/src/eval/model-comparison.ts
@@ -543,14 +543,36 @@ function compareCandidate(
 function pickRecommendation(
   candidates: EvalModelCandidateComparison[],
 ): EvalModelComparison["recommendation"] {
-  const promotable = candidates
-    .filter((candidate) => candidate.decision === "promote-candidate")
-    .sort((a, b) => (b.objectiveScore ?? 0) - (a.objectiveScore ?? 0))[0];
-  if (promotable) {
+  const promotable = candidates.filter((candidate) => candidate.decision === "promote-candidate");
+  if (promotable.length === 1) {
+    const candidate = promotable[0];
+    if (candidate) {
+      return {
+        decision: "promote-candidate",
+        model: candidate.model,
+        reasons: candidate.reasons,
+      };
+    }
+  }
+  if (promotable.length > 1) {
+    const scoredPromotable = promotable
+      .filter((candidate) => candidate.objectiveScore !== undefined)
+      .sort((a, b) => (b.objectiveScore ?? 0) - (a.objectiveScore ?? 0))[0];
+    if (scoredPromotable) {
+      return {
+        decision: "promote-candidate",
+        model: scoredPromotable.model,
+        reasons: scoredPromotable.reasons,
+      };
+    }
     return {
       decision: "promote-candidate",
-      model: promotable.model,
-      reasons: promotable.reasons,
+      reasons: [
+        `multiple candidate models are promotable: ${
+          promotable.map((candidate) => candidate.model).join(", ")
+        }`,
+        "configure --comparison-policy objectives to rank candidates by your product requirements",
+      ],
     };
   }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.981";
+export const VERSION = "0.1.982";


### PR DESCRIPTION
## Summary
- stop selecting the first promotable candidate as the recommendation when no comparison objectives are configured
- keep objective-score ranking for explicit comparison policies
- bump veryfront to 0.1.982 and keep VERSION in sync

## Testing
- deno task fmt:check
- deno task test src/eval/model-comparison.test.ts
- deno task test src/utils/version.test.ts src/utils/logger/logger.test.ts src/eval/model-comparison.test.ts
- deno task typecheck
- deno task lint
- git diff --check