### PR TITLE
Harden public release path before opening repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Default maintainers for the public repository.
+* @kojiwakayama @kwakayama
+
+# Repository governance and security surfaces.
+/.github/ @kojiwakayama @kwakayama
+/.github/CODEOWNERS @kojiwakayama @kwakayama
+/SECURITY.md @kojiwakayama @kwakayama
+/CONTRIBUTING.md @kojiwakayama @kwakayama
+/CLA.md @kojiwakayama @kwakayama
+/CLA-CORPORATE.md @kojiwakayama @kwakayama
+/LICENSE @kojiwakayama @kwakayama
+
+# Release, dependency, and security-sensitive code.
+/deno.json @kojiwakayama @kwakayama
+/deno.lock @kojiwakayama @kwakayama
+/scripts/ @kojiwakayama @kwakayama
+/src/security/ @kojiwakayama @kwakayama

--- a/.github/SECURITY-HARDENING.md
+++ b/.github/SECURITY-HARDENING.md
@@ -1,0 +1,66 @@
+# Public repository hardening
+
+Use this checklist before changing `veryfront/veryfront-code` from private to public, and repeat it after the visibility change is complete.
+
+## GitHub settings
+
+Verify these settings from repository settings or the GitHub REST API.
+
+| Setting                               | Required state                         | Evidence                                                                                  |
+| ------------------------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Code security                         | Enabled                                | `security_and_analysis.code_security.status == "enabled"`                                 |
+| Secret scanning                       | Enabled                                | `security_and_analysis.secret_scanning.status == "enabled"`                               |
+| Secret scanning non-provider patterns | Enabled                                | `security_and_analysis.secret_scanning_non_provider_patterns.status == "enabled"`         |
+| Secret scanning AI detection          | Enabled                                | `security_and_analysis.secret_scanning_ai_detection.status == "enabled"`                  |
+| Secret scanning validity checks       | Enabled                                | `security_and_analysis.secret_scanning_validity_checks.status == "enabled"`               |
+| Push protection                       | Enabled                                | `security_and_analysis.secret_scanning_push_protection.status == "enabled"`               |
+| Dependabot security updates           | Enabled                                | `security_and_analysis.dependabot_security_updates.status == "enabled"`                   |
+| Workflow token default                | Read-only                              | `default_workflow_permissions == "read"`                                                  |
+| GitHub Actions PR review approval     | Disabled                               | `can_approve_pull_request_reviews == false`                                               |
+| GitHub Actions SHA pinning            | Required                               | `sha_pinning_required == true`                                                            |
+| Private fork PR workflows             | Disabled                               | `run_workflows_from_fork_pull_requests == false`                                          |
+| Code owner review on `main`           | Required                               | `required_pull_request_reviews.require_code_owner_reviews == true`                        |
+| Private vulnerability reporting       | Enabled after the repository is public | `GET /repos/{owner}/{repo}/private-vulnerability-reporting` returns `{ "enabled": true }` |
+
+Private vulnerability reporting is a public repository feature. If the repository is still private, verify the API again immediately after the visibility change and enable it before announcing the repository.
+
+## Pull requests from forks
+
+External fork pull requests must not execute code-checking CI. The repository still accepts fork pull requests, but code-executing workflows must be guarded so only push, manual, scheduled, and same-repository pull request events run jobs.
+
+Required guard for code-executing pull request workflows:
+
+```yaml
+if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+```
+
+The CLA workflow uses `pull_request_target` so it can comment on external pull requests. It must not check out or execute contributor code.
+
+## npm supply-chain release controls
+
+Recent npm compromises have used maintainer account takeover, malicious pull requests, new transitive dependencies, and install-time payloads to steal CI and registry credentials. Veryfront release automation must avoid long-lived npm publish tokens and must not execute npm dependency lifecycle scripts during package assembly.
+
+Required controls:
+
+- Configure npm trusted publishing for package `veryfront`: GitHub Actions publisher, owner `veryfront`, repository `veryfront-code`, workflow filename `cicd.yml`, environment `production`, action `npm publish`.
+- Keep `.github/workflows/cicd.yml` release jobs on `permissions: id-token: write` and publish with `npm publish --provenance --access public`.
+- Do not reference `secrets.NPM_TOKEN` or `NODE_AUTH_TOKEN` in npm publish steps.
+- Remove the repository `NPM_TOKEN` secret after trusted publishing is configured and one dry release check confirms npm accepts OIDC authentication.
+- Keep release `actions/setup-node` caching disabled.
+- Keep generated npm package metadata pointed at `github.com/veryfront/veryfront-code` so npm provenance links to the publishing source.
+- Keep `scripts/build/build-npm-dnt.ts` npm install calls on `--ignore-scripts`.
+- Keep `deno task lint:deps` and `deno task audit` in CI.
+
+## Validation commands
+
+Run these checks after changing hardening files or workflows:
+
+```bash
+deno test --no-lock --no-check --allow-read src/security/repository-hardening.test.ts
+deno fmt --check SECURITY.md .github/SECURITY-HARDENING.md src/security/repository-hardening.test.ts
+deno test --config=scripts/test.deno.json --no-lock --no-check --allow-read \
+  --filter "npm package provenance metadata points at veryfront-code" \
+  scripts/build/npm-package-metadata.test.ts
+deno task lint:deps
+deno task audit
+```

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -19,6 +19,7 @@ jobs:
   # CI: Quality Checks
   # ============================================
   ci:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -40,6 +41,7 @@ jobs:
   # ============================================
 
   tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -65,6 +67,7 @@ jobs:
             fi
 
   coverage-shards:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     name: coverage shard ${{ matrix.shard }}/8
@@ -99,7 +102,7 @@ jobs:
     timeout-minutes: 5
     name: coverage gate
     needs: [coverage-shards]
-    if: ${{ always() }}
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
       - name: Require coverage shards
         env:
@@ -126,6 +129,7 @@ jobs:
         run: echo "### Coverage shard merge completed in ${{ steps.coverage.outputs.duration }}" >> "$GITHUB_STEP_SUMMARY"
 
   tests-e2e-rsc-browser:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     name: tests (rsc browser e2e)
@@ -184,6 +188,7 @@ jobs:
   # ============================================
 
   tests-binary-e2e:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     name: tests (binary e2e)
@@ -243,7 +248,7 @@ jobs:
   # ============================================
 
   tests-split-mode:
-    if: vars.RUN_SPLIT_MODE_TEST == 'true'
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && vars.RUN_SPLIT_MODE_TEST == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     name: tests (split mode)
@@ -300,7 +305,7 @@ jobs:
   # ============================================
 
   version-check:
-    if: github.ref == 'refs/heads/main'
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.check.outputs.version }}
@@ -326,7 +331,7 @@ jobs:
   # ============================================
 
   build-binaries:
-    if: github.ref == 'refs/heads/main'
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.ref == 'refs/heads/main' }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ contains(matrix.os, 'windows') }}
     strategy:
@@ -373,9 +378,10 @@ jobs:
   # ============================================
 
   prerelease:
-    if: needs.version-check.outputs.is_stable == 'false'
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && needs.version-check.outputs.is_stable == 'false' }}
     needs: [ci, tests, coverage, tests-binary-e2e, build-binaries, version-check]
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: write
       id-token: write
@@ -386,8 +392,9 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Compute RC version
         id: version
@@ -400,7 +407,6 @@ jobs:
       - name: Build and publish
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if npm view veryfront@"${VERSION}" version 2>/dev/null; then
             echo "::notice::v${VERSION} already published to npm — skipping publish"
@@ -408,7 +414,7 @@ jobs:
             deno task build:npm
             cd npm
             jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
-            npm publish --access public --tag rc
+            npm publish --provenance --access public --tag rc
           fi
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
@@ -483,7 +489,7 @@ jobs:
   # ============================================
 
   release:
-    if: needs.version-check.outputs.is_stable == 'true'
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && needs.version-check.outputs.is_stable == 'true' }}
     needs: [ci, tests, coverage, tests-binary-e2e, build-binaries, version-check]
     runs-on: ubuntu-latest
     environment: production
@@ -546,12 +552,12 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Build and publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           deno task build:npm
@@ -579,7 +585,7 @@ jobs:
             echo "veryfront@${VERSION} is already published for this commit; skipping npm publish."
           else
             set +e
-            PUBLISH_OUTPUT="$(npm publish --access public 2>&1)"
+            PUBLISH_OUTPUT="$(npm publish --provenance --access public 2>&1)"
             PUBLISH_STATUS=$?
             set -e
             printf '%s\n' "${PUBLISH_OUTPUT}"
@@ -696,6 +702,7 @@ jobs:
   # ============================================
 
   update-homebrew:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: [release, version-check]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   analyze:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     name: Analyze
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -30,6 +30,7 @@ permissions:
 
 jobs:
   npm-audit:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     name: NPM Dependency Audit
     steps:
@@ -67,7 +68,7 @@ jobs:
 
   submit-dependency-snapshot:
     # Only push/schedule/manual — PRs from forks lack write access.
-    if: github.event_name != 'pull_request'
+    if: ${{ github.event_name != 'pull_request' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     name: Submit Dependency Snapshot
     permissions:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,47 +11,53 @@ Please **do not** open a public issue for security concerns. Email the details d
 If you require encrypted communication, request our PGP key at the same address. We will respond with a current key fingerprint over a separate channel.
 
 ### What to include
+
 - A description of the vulnerability and its impact
-- Steps to reproduce (a minimal repro is ideal — code, manifest, command-line)
-- Affected version(s) — `deno.json` version field or commit SHA
+- Steps to reproduce (a minimal repro is ideal: code, manifest, command-line)
+- Affected version(s): `deno.json` version field or commit SHA
 - Whether you have already disclosed elsewhere (CVE, advisory, vendor)
 
 ### Embargo and disclosure
+
 - We treat reports as embargoed until either a fix ships or 90 days pass, whichever is sooner.
 - We will keep you informed of remediation progress and credit you in the advisory unless you prefer otherwise.
 
 ## Supported Versions
 
-| Version | Status |
-|---|---|
-| `0.1.x` (latest minor) | Active — receives security patches |
-| `< 0.1.<latest>` | End of life — please upgrade |
+| Version                | Status                            |
+| ---------------------- | --------------------------------- |
+| `0.1.x` (latest minor) | Active, receives security patches |
+| `< 0.1.<latest>`       | End of life, please upgrade       |
 
 Pin a recent `0.1.x` release. Versions older than the current minor receive **no** patches.
 
 ## Scope
 
 In scope for this policy:
+
 - The `veryfront` core (this repository: `src/`, `cli/`).
 - First-party extensions published from this monorepo (`extensions/ext-*`).
 - Build, release, and CI scripts (`scripts/`, `.github/workflows/`).
 - The compiled binary distributed via official channels.
 
 Out of scope (report through the usual project channels, not security@):
+
 - Demo applications and example sites.
 - Third-party plugins not in `extensions/`.
-- Vulnerabilities in dependencies that are already CVE-tracked upstream — we monitor those automatically (see Supply Chain).
+- Vulnerabilities in dependencies that are already CVE-tracked upstream. Veryfront monitors those automatically (see Supply Chain).
 
 ## Supply Chain Posture
 
 We are working to make the framework's supply chain auditable and tamper-evident. The following describes today's reality; rolling improvements are tracked in the issue tracker.
 
 - **SBOM:** `deno task sbom` generates a CycloneDX 1.5 SBOM (`dist/sbom.json`) from the npm and `esm.sh` imports declared in `deno.json`. Coverage of transitive dependencies is in progress.
-- **Continuous scanning:** CodeQL (`security-and-quality` queries) and an `npm audit` job run weekly and on every pull request that touches `deno.json` (see `.github/workflows/codeql.yml`, `.github/workflows/security-audit.yml`). Socket.dev is configured via `socket.yml` and reviews pull requests as a GitHub App.
+- **Continuous scanning:** CodeQL (`security-and-quality` queries) and an `npm audit` job run weekly and on same-repository pull requests that touch `deno.json` (see `.github/workflows/codeql.yml`, `.github/workflows/security-audit.yml`). External fork pull requests do not run code-checking CI. Socket.dev is configured via `socket.yml` and reviews pull requests as a GitHub App.
+- **Release publishing:** npm releases use GitHub Actions OIDC trusted publishing with npm provenance. Release jobs do not use a long-lived npm publish token.
 - **Pinned dependencies:** all `npm:` and `esm.sh` imports are required to declare exact `x.y.z` versions, enforced by `scripts/lint/audit-deps.ts` (`deno task lint:deps`). Git URL and tarball imports are rejected outright.
+- **Install-script suppression:** npm package assembly runs dependency installation with npm lifecycle scripts disabled.
 - **Capability descriptors:** each first-party extension declares the capabilities it requires (e.g. `net`, `fs`, `env`) in its `deno.json`. These are descriptive today; runtime enforcement is on the roadmap.
 - **Install-script allow-list:** native postinstall scripts are explicitly allow- or deny-listed in `deno.json`'s `allowScripts` field. Unlisted packages cannot run install hooks.
-- **Reproducible builds, lockfile enforcement, SHA-pinned GitHub Actions, automated dependency PRs, and release-artifact signing/provenance are in progress.** We will update this section as each lands; until then, do not assume any of those controls are active.
+- **Reproducible builds, lockfile enforcement, automated dependency PRs, and release-artifact signing are in progress.** We will update this section as each lands; until then, do not assume any of those controls are active.
 
 ## Security Hardening Recommendations for Operators
 
@@ -65,6 +71,7 @@ When deploying veryfront to production:
 ## Changelog
 
 Security advisories are published as GitHub Security Advisories on this repository. Each advisory includes:
+
 - Affected versions
 - CVSS v3.1 score
 - A patched version reference

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -128,10 +128,10 @@ await build({
 		author: "Veryfront",
 		repository: {
 			type: "git",
-			url: "git+https://github.com/veryfront/veryfront.git",
+			url: "git+https://github.com/veryfront/veryfront-code.git",
 		},
 		bugs: {
-			url: "https://github.com/veryfront/veryfront/issues",
+			url: "https://github.com/veryfront/veryfront-code/issues",
 		},
 		homepage: "https://veryfront.com",
 		engines: {
@@ -182,10 +182,11 @@ await build({
 		normalizeNpmPackageMetadata(initialPkg);
 		await Deno.writeTextFile(pkgPath, JSON.stringify(initialPkg, null, 2));
 
-		// Run npm install with --legacy-peer-deps to avoid peer dep conflicts
+		// Run npm install with scripts disabled to avoid supply-chain install hooks.
+		// Keep --legacy-peer-deps to avoid peer dep conflicts
 		// (e.g., @ai-sdk/react requires react ~19.1.2 but framework uses 19.1.1)
 		const npmInstall = new Deno.Command("npm", {
-			args: ["install", "--legacy-peer-deps"],
+			args: ["install", "--ignore-scripts", "--legacy-peer-deps"],
 			cwd: "./npm",
 			stdout: "inherit",
 			stderr: "inherit",

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -15,6 +15,14 @@ Deno.test("exports agent skill helpers as a public package subpath", async () =>
 	assertEquals(imports["veryfront/skill"], "./src/skill/index.ts");
 });
 
+Deno.test("npm package provenance metadata points at veryfront-code", async () => {
+	const source = await Deno.readTextFile("scripts/build/build-npm-dnt.ts");
+
+	assertStringIncludes(source, 'url: "git+https://github.com/veryfront/veryfront-code.git"');
+	assertStringIncludes(source, 'url: "https://github.com/veryfront/veryfront-code/issues"');
+	assertEquals(source.includes("github.com/veryfront/veryfront.git"), false);
+});
+
 describe("normalizeNpmPackageMetadata", () => {
 	it("removes source files from the published npm file list", () => {
 		const pkg = normalizeNpmPackageMetadata({

--- a/src/config/cicd-coverage-workflow.test.ts
+++ b/src/config/cicd-coverage-workflow.test.ts
@@ -24,7 +24,10 @@ Deno.test("CI keeps the required coverage gate as a fast merge job", () => {
   assertStringIncludes(workflow, "coverage:");
   assertStringIncludes(workflow, "name: coverage gate");
   assertStringIncludes(workflow, "needs: [coverage-shards]");
-  assertStringIncludes(workflow, "if: ${{ always() }}");
+  assertStringIncludes(
+    workflow,
+    "if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}",
+  );
   assertStringIncludes(workflow, "timeout-minutes: 5");
   assertStringIncludes(workflow, "actions/download-artifact");
   assertStringIncludes(workflow, "Download unit coverage lcov files");

--- a/src/security/repository-hardening.test.ts
+++ b/src/security/repository-hardening.test.ts
@@ -1,0 +1,124 @@
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+
+const WORKFLOW_PR_GUARD =
+  "github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository";
+
+async function readText(path: string): Promise<string> {
+  return await Deno.readTextFile(path);
+}
+
+function stripComments(text: string): string {
+  return text
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("#"))
+    .join("\n");
+}
+
+function topLevelJobNames(workflow: string): string[] {
+  const jobsStart = workflow.indexOf("\njobs:\n");
+  if (jobsStart === -1) return [];
+
+  const jobsBlock = workflow.slice(jobsStart + "\njobs:\n".length);
+  const matches = jobsBlock.matchAll(/^[ ]{2}([A-Za-z0-9_-]+):\s*$/gm);
+  return Array.from(matches, (match) => match[1]);
+}
+
+function jobBlock(workflow: string, jobName: string): string {
+  const marker = `\n  ${jobName}:\n`;
+  const start = workflow.indexOf(marker);
+  assert(start >= 0, `expected ${jobName} job to exist`);
+
+  const rest = workflow.slice(start + marker.length);
+  const nextJob = rest.search(/\n[ ]{2}[A-Za-z0-9_-]+:\n/);
+  return nextJob === -1 ? rest : rest.slice(0, nextJob);
+}
+
+describe("repository hardening", () => {
+  it("keeps CODEOWNERS in force for public governance files", async () => {
+    const codeowners = await readText(".github/CODEOWNERS");
+
+    assert(codeowners.includes("* @kojiwakayama @kwakayama"));
+    assert(codeowners.includes("/.github/ @kojiwakayama @kwakayama"));
+    assert(codeowners.includes("/SECURITY.md @kojiwakayama @kwakayama"));
+    assert(codeowners.includes("/.github/CODEOWNERS @kojiwakayama @kwakayama"));
+  });
+
+  it("documents the owner-only public repository hardening settings", async () => {
+    const checklist = await readText(".github/SECURITY-HARDENING.md");
+
+    for (
+      const required of [
+        "Private vulnerability reporting",
+        "Secret scanning",
+        "Push protection",
+        "Code security",
+        "Dependabot security updates",
+        "External fork pull requests",
+      ]
+    ) {
+      assert(
+        checklist.includes(required),
+        `expected hardening checklist to mention ${required}`,
+      );
+    }
+  });
+
+  it("keeps SECURITY.md aligned with the external fork CI policy", async () => {
+    const policy = await readText("SECURITY.md");
+
+    assert(policy.includes("same-repository pull requests"));
+    assert(policy.includes("External fork pull requests do not run code-checking CI"));
+  });
+
+  it("keeps npm publishing tokenless and provenance-backed", async () => {
+    const workflow = await readText(".github/workflows/cicd.yml");
+
+    assertEquals(workflow.includes("secrets.NPM_TOKEN"), false);
+    assertEquals(workflow.includes("NODE_AUTH_TOKEN"), false);
+    assert(workflow.includes("id-token: write"));
+    assert(workflow.includes("package-manager-cache: false"));
+    assert(workflow.includes("npm publish --provenance --access public --tag rc"));
+    assert(workflow.includes("npm publish --provenance --access public 2>&1"));
+  });
+
+  it("does not run npm lifecycle scripts while building the npm package", async () => {
+    const buildScript = await readText("scripts/build/build-npm-dnt.ts");
+
+    assert(buildScript.includes('"install", "--ignore-scripts", "--legacy-peer-deps"'));
+  });
+
+  it("does not execute code-checking workflows for fork pull requests", async () => {
+    for (
+      const path of [
+        ".github/workflows/cicd.yml",
+        ".github/workflows/codeql.yml",
+        ".github/workflows/security-audit.yml",
+      ]
+    ) {
+      const workflow = stripComments(await readText(path));
+      assert(
+        workflow.includes("pull_request:"),
+        `expected ${path} to define pull_request triggers`,
+      );
+
+      const jobs = topLevelJobNames(workflow);
+      assert(jobs.length > 0, `expected ${path} to define jobs`);
+
+      for (const jobName of jobs) {
+        const block = jobBlock(workflow, jobName);
+        assert(
+          block.includes(WORKFLOW_PR_GUARD),
+          `expected ${path} job ${jobName} to gate fork pull requests`,
+        );
+      }
+    }
+  });
+
+  it("leaves the CLA workflow non-executing for contributor code", async () => {
+    const workflow = await readText(".github/workflows/cla.yml");
+
+    assert(workflow.includes("pull_request_target:"));
+    assertEquals(workflow.includes("actions/checkout"), false);
+  });
+});


### PR DESCRIPTION
## Summary

- Add CODEOWNERS and a public repository hardening checklist for the private-to-public transition.
- Gate code-executing GitHub Actions jobs so external fork pull requests do not run CI code.
- Move npm publishing toward trusted publishing with provenance, disable npm lifecycle scripts during package assembly, and align npm package metadata with `veryfront/veryfront-code`.
- Update SECURITY.md and regression tests to keep the hardening posture from drifting.

## Verification

- `DENO_NO_LOCK=1 deno fmt --check SECURITY.md .github/SECURITY-HARDENING.md src/security/repository-hardening.test.ts scripts/build/build-npm-dnt.ts scripts/build/npm-package-metadata.test.ts`
- `DENO_NO_LOCK=1 deno test --no-lock --no-check --allow-read src/security/repository-hardening.test.ts`
- `DENO_NO_LOCK=1 deno test --config=scripts/test.deno.json --no-lock --no-check --allow-read --filter "npm package provenance metadata points at veryfront-code" scripts/build/npm-package-metadata.test.ts`
- `DENO_NO_LOCK=1 deno test --no-lock --no-check --allow-read src/config/cicd-coverage-workflow.test.ts`
- `DENO_NO_LOCK=1 deno task lint:deps`
- `DENO_NO_LOCK=1 deno task audit`
- `git diff --check`
- Pre-push hook: format, lint, typecheck, and `deno task test:unit` passed with `2220 passed (19058 steps), 0 failed`.

## Remaining work tracked

- #2707 Configure npm trusted publishing for `veryfront` releases.
- #2708 Enable private vulnerability reporting after the repository becomes public.
- #2709 Replace release PAT secrets with scoped GitHub App credentials.
