### PR TITLE
Replace release PAT use with scoped app tokens

### DIFF
--- a/.github/SECURITY-HARDENING.md
+++ b/.github/SECURITY-HARDENING.md
@@ -45,11 +45,27 @@ Required controls:
 - Configure npm trusted publishing for package `veryfront`: GitHub Actions publisher, owner `veryfront`, repository `veryfront-code`, workflow filename `cicd.yml`, environment `production`, action `npm publish`.
 - Keep `.github/workflows/cicd.yml` release jobs on `permissions: id-token: write` and publish with `npm publish --provenance --access public`.
 - Do not reference `secrets.NPM_TOKEN` or `NODE_AUTH_TOKEN` in npm publish steps.
-- Remove the repository `NPM_TOKEN` secret after trusted publishing is configured and one dry release check confirms npm accepts OIDC authentication.
+- Remove the repository or organization `NPM_TOKEN` secret after trusted publishing is configured and one dry release check confirms npm accepts OIDC authentication.
 - Keep release `actions/setup-node` caching disabled.
 - Keep generated npm package metadata pointed at `github.com/veryfront/veryfront-code` so npm provenance links to the publishing source.
 - Keep `scripts/build/build-npm-dnt.ts` npm install calls on `--ignore-scripts`.
 - Keep `deno task lint:deps` and `deno task audit` in CI.
+
+## GitHub App release credentials
+
+Release automation must use short-lived GitHub App installation tokens instead of user PAT secrets.
+
+Configure these GitHub Apps before the first release after this checklist lands:
+
+| Purpose                               | Repository access                                                            | Required permissions                  | Variables and secrets                                                  |
+| ------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------- | ---------------------------------------------------------------------- |
+| Release artifacts and deploy dispatch | `veryfront`, `veryfront-server`, `veryfront-job-runner`, `veryfront-sandbox` | Contents: write                       | `VERYFRONT_RELEASE_APP_CLIENT_ID`, `VERYFRONT_RELEASE_APP_PRIVATE_KEY` |
+| Docs sync                             | `veryfront-docs`                                                             | Contents: write                       | `VERYFRONT_DOCS_APP_CLIENT_ID`, `VERYFRONT_DOCS_APP_PRIVATE_KEY`       |
+| Homebrew tap                          | `homebrew-tap`                                                               | Contents: write, Pull requests: write | `HOMEBREW_TAP_APP_CLIENT_ID`, `HOMEBREW_TAP_APP_PRIVATE_KEY`           |
+
+Store app client IDs as GitHub Actions variables. Store private keys as `production` environment secrets where the workflow uses `environment: production`; use the narrowest available scope for any workflow that cannot use an environment.
+
+After a successful dry release or equivalent workflow validation, remove the old repository secrets `GH_PAT_VERYFRONT` and `GH_PAT_HOMEBREW_TAP`.
 
 ## Validation commands
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -426,10 +426,24 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: deno task sbom:all --output-dir "dist/sbom-${VERSION}"
 
+      - name: Create release GitHub App token
+        id: release-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ vars.VERYFRONT_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.VERYFRONT_RELEASE_APP_PRIVATE_KEY }}
+          owner: veryfront
+          repositories: |
+            veryfront
+            veryfront-server
+            veryfront-job-runner
+            veryfront-sandbox
+          permission-contents: write
+
       - name: Create GitHub pre-release
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          GH_TOKEN: ${{ secrets.GH_PAT_VERYFRONT }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
         run: |
           # Collect available binaries dynamically (Windows build is optional)
           BINARIES=""
@@ -461,7 +475,7 @@ jobs:
       - name: Trigger server deploy
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
         with:
-          token: ${{ secrets.GH_PAT_VERYFRONT }}
+          token: ${{ steps.release-app-token.outputs.token }}
           repository: veryfront/veryfront-server
           event-type: veryfront-code-released
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
@@ -469,7 +483,7 @@ jobs:
       - name: Trigger job-runner deploy
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
         with:
-          token: ${{ secrets.GH_PAT_VERYFRONT }}
+          token: ${{ steps.release-app-token.outputs.token }}
           repository: veryfront/veryfront-job-runner
           event-type: veryfront-code-released
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
@@ -477,7 +491,7 @@ jobs:
       - name: Trigger sandbox deploy
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
         with:
-          token: ${{ secrets.GH_PAT_VERYFRONT }}
+          token: ${{ steps.release-app-token.outputs.token }}
           repository: veryfront/veryfront-sandbox
           event-type: veryfront-code-released
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
@@ -505,9 +519,24 @@ jobs:
           echo "version=${{ needs.version-check.outputs.version }}" >> $GITHUB_OUTPUT
           echo "Publishing stable: ${{ needs.version-check.outputs.version }}"
 
+      - name: Create release GitHub App token
+        id: release-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ vars.VERYFRONT_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.VERYFRONT_RELEASE_APP_PRIVATE_KEY }}
+          owner: veryfront
+          repositories: |
+            veryfront
+            veryfront-server
+            veryfront-job-runner
+            veryfront-sandbox
+          permission-contents: write
+
       - name: Ensure stable version is unpublished
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_VERYFRONT }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          SOURCE_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           TAG="v${VERSION}"
@@ -543,7 +572,7 @@ jobs:
             echo "::error::Release ${TAG} already exists on veryfront/veryfront. Bump deno.json before releasing."
             exit 1
           fi
-          if gh release view "${TAG}" &>/dev/null; then
+          if GH_TOKEN="${SOURCE_REPO_TOKEN}" gh release view "${TAG}" &>/dev/null; then
             echo "::error::Release ${TAG} already exists on source repo. Bump deno.json before releasing."
             exit 1
           fi
@@ -626,7 +655,7 @@ jobs:
       - name: Create GitHub releases
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          GH_TOKEN: ${{ secrets.GH_PAT_VERYFRONT }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
         run: |
           # Collect available binaries dynamically (Windows build is optional)
           BINARIES=""
@@ -676,7 +705,7 @@ jobs:
       - name: Trigger server deploy
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
         with:
-          token: ${{ secrets.GH_PAT_VERYFRONT }}
+          token: ${{ steps.release-app-token.outputs.token }}
           repository: veryfront/veryfront-server
           event-type: veryfront-code-released
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
@@ -684,7 +713,7 @@ jobs:
       - name: Trigger job-runner deploy
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
         with:
-          token: ${{ secrets.GH_PAT_VERYFRONT }}
+          token: ${{ steps.release-app-token.outputs.token }}
           repository: veryfront/veryfront-job-runner
           event-type: veryfront-code-released
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
@@ -692,7 +721,7 @@ jobs:
       - name: Trigger sandbox deploy
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
         with:
-          token: ${{ secrets.GH_PAT_VERYFRONT }}
+          token: ${{ steps.release-app-token.outputs.token }}
           repository: veryfront/veryfront-sandbox
           event-type: veryfront-code-released
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
@@ -705,13 +734,25 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: [release, version-check]
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Create Homebrew tap GitHub App token
+        id: homebrew-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ vars.HOMEBREW_TAP_APP_CLIENT_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: veryfront
+          repositories: homebrew-tap
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Update Homebrew tap
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         env:
-          HOMEBREW_TAP_PAT: ${{ secrets.GH_PAT_HOMEBREW_TAP || secrets.GH_PAT_VERYFRONT }}
+          HOMEBREW_TAP_TOKEN: ${{ steps.homebrew-app-token.outputs.token }}
         with:
           timeout_minutes: 5
           max_attempts: 3
@@ -736,7 +777,7 @@ jobs:
 
             # Create PR against tap repo (branch protection requires PRs)
             rm -rf tap
-            git clone "https://x-access-token:${HOMEBREW_TAP_PAT}@github.com/veryfront/homebrew-tap.git" tap
+            git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/veryfront/homebrew-tap.git" tap
             mkdir -p tap/Formula
             echo "$FORMULA" > tap/Formula/veryfront.rb
             cd tap
@@ -750,14 +791,14 @@ jobs:
             git commit -m "Update veryfront to v${VERSION}"
             git push -u origin "${BRANCH}" || git push -u origin "${BRANCH}" --force-with-lease
 
-            PR_NUMBER=$(GH_TOKEN="${HOMEBREW_TAP_PAT}" gh api \
+            PR_NUMBER=$(GH_TOKEN="${HOMEBREW_TAP_TOKEN}" gh api \
               --method GET \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "/repos/veryfront/homebrew-tap/pulls?state=open&head=veryfront:${BRANCH}&base=main&per_page=1" \
               --jq '.[0].number // empty')
 
             if [ -z "${PR_NUMBER}" ]; then
-              CREATE_PR_OUTPUT=$(GH_TOKEN="${HOMEBREW_TAP_PAT}" gh api \
+              CREATE_PR_OUTPUT=$(GH_TOKEN="${HOMEBREW_TAP_TOKEN}" gh api \
                 --method POST \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 "/repos/veryfront/homebrew-tap/pulls" \
@@ -767,7 +808,7 @@ jobs:
                 -f body="Automated update from CI - veryfront v${VERSION}" \
                 --jq '.number' 2>&1) || {
                   if echo "${CREATE_PR_OUTPUT}" | grep -q "Resource not accessible by personal access token"; then
-                    echo "::error::Homebrew tap update requires a token with Pull requests: write and Contents: write on veryfront/homebrew-tap (set GH_PAT_HOMEBREW_TAP or fix GH_PAT_VERYFRONT)."
+                    echo "::error::Homebrew tap update requires a GitHub App token with Pull requests: write and Contents: write on veryfront/homebrew-tap."
                   fi
                   echo "${CREATE_PR_OUTPUT}"
                   exit 1
@@ -779,7 +820,7 @@ jobs:
             MERGEABLE=""
             MERGEABLE_STATE=""
             for attempt in {1..24}; do
-              PR_JSON=$(GH_TOKEN="${HOMEBREW_TAP_PAT}" gh api \
+              PR_JSON=$(GH_TOKEN="${HOMEBREW_TAP_TOKEN}" gh api \
                 --method GET \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 "/repos/veryfront/homebrew-tap/pulls/${PR_NUMBER}")
@@ -803,7 +844,7 @@ jobs:
               exit 1
             fi
 
-            GH_TOKEN="${HOMEBREW_TAP_PAT}" gh api \
+            GH_TOKEN="${HOMEBREW_TAP_TOKEN}" gh api \
               --method PUT \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "/repos/veryfront/homebrew-tap/pulls/${PR_NUMBER}/merge" \

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -20,10 +20,21 @@ permissions:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
+    environment: production
     steps:
-      - uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+      - name: Create docs GitHub App token
+        id: docs-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          token: ${{ secrets.GH_PAT_VERYFRONT }}
+          client-id: ${{ vars.VERYFRONT_DOCS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.VERYFRONT_DOCS_APP_PRIVATE_KEY }}
+          owner: veryfront
+          repositories: veryfront-docs
+          permission-contents: write
+
+      - uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
+        with:
+          token: ${{ steps.docs-app-token.outputs.token }}
           repository: veryfront/veryfront-docs
           event-type: docs-update
           client-payload: '{"sha": "${{ github.sha }}"}'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,7 +52,7 @@ We are working to make the framework's supply chain auditable and tamper-evident
 
 - **SBOM:** `deno task sbom` generates a CycloneDX 1.5 SBOM (`dist/sbom.json`) from the npm and `esm.sh` imports declared in `deno.json`. Coverage of transitive dependencies is in progress.
 - **Continuous scanning:** CodeQL (`security-and-quality` queries) and an `npm audit` job run weekly and on same-repository pull requests that touch `deno.json` (see `.github/workflows/codeql.yml`, `.github/workflows/security-audit.yml`). External fork pull requests do not run code-checking CI. Socket.dev is configured via `socket.yml` and reviews pull requests as a GitHub App.
-- **Release publishing:** npm releases use GitHub Actions OIDC trusted publishing with npm provenance. Release jobs do not use a long-lived npm publish token.
+- **Release publishing:** npm releases use GitHub Actions OIDC trusted publishing with npm provenance. Release jobs do not use a long-lived npm publish token. GitHub release and deploy automation uses short-lived GitHub App installation tokens instead of user PATs.
 - **Pinned dependencies:** all `npm:` and `esm.sh` imports are required to declare exact `x.y.z` versions, enforced by `scripts/lint/audit-deps.ts` (`deno task lint:deps`). Git URL and tarball imports are rejected outright.
 - **Install-script suppression:** npm package assembly runs dependency installation with npm lifecycle scripts disabled.
 - **Capability descriptors:** each first-party extension declares the capabilities it requires (e.g. `net`, `fs`, `env`) in its `deno.json`. These are descriptive today; runtime enforcement is on the roadmap.

--- a/src/security/repository-hardening.test.ts
+++ b/src/security/repository-hardening.test.ts
@@ -3,6 +3,8 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 
 const WORKFLOW_PR_GUARD =
   "github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository";
+const CREATE_APP_TOKEN_ACTION =
+  "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1";
 
 async function readText(path: string): Promise<string> {
   return await Deno.readTextFile(path);
@@ -55,6 +57,12 @@ describe("repository hardening", () => {
         "Code security",
         "Dependabot security updates",
         "External fork pull requests",
+        "GitHub App release credentials",
+        "VERYFRONT_RELEASE_APP_CLIENT_ID",
+        "VERYFRONT_DOCS_APP_CLIENT_ID",
+        "HOMEBREW_TAP_APP_CLIENT_ID",
+        "GH_PAT_VERYFRONT",
+        "GH_PAT_HOMEBREW_TAP",
       ]
     ) {
       assert(
@@ -80,6 +88,43 @@ describe("repository hardening", () => {
     assert(workflow.includes("package-manager-cache: false"));
     assert(workflow.includes("npm publish --provenance --access public --tag rc"));
     assert(workflow.includes("npm publish --provenance --access public 2>&1"));
+  });
+
+  it("uses scoped GitHub App tokens instead of release PATs", async () => {
+    const releaseWorkflow = await readText(".github/workflows/cicd.yml");
+    const docsWorkflow = await readText(".github/workflows/sync-docs.yml");
+    const workflows = `${releaseWorkflow}\n${docsWorkflow}`;
+
+    assertEquals(workflows.includes("GH_PAT_"), false);
+    assertEquals(workflows.includes("HOMEBREW_TAP_PAT"), false);
+
+    for (
+      const required of [
+        CREATE_APP_TOKEN_ACTION,
+        "client-id: ${{ vars.VERYFRONT_RELEASE_APP_CLIENT_ID }}",
+        "private-key: ${{ secrets.VERYFRONT_RELEASE_APP_PRIVATE_KEY }}",
+        "client-id: ${{ vars.VERYFRONT_DOCS_APP_CLIENT_ID }}",
+        "private-key: ${{ secrets.VERYFRONT_DOCS_APP_PRIVATE_KEY }}",
+        "client-id: ${{ vars.HOMEBREW_TAP_APP_CLIENT_ID }}",
+        "private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}",
+        "repositories: |",
+        "veryfront-server",
+        "veryfront-job-runner",
+        "veryfront-sandbox",
+        "veryfront-docs",
+        "homebrew-tap",
+        "permission-contents: write",
+        "permission-pull-requests: write",
+        "steps.release-app-token.outputs.token",
+        "steps.docs-app-token.outputs.token",
+        "steps.homebrew-app-token.outputs.token",
+      ]
+    ) {
+      assert(
+        workflows.includes(required),
+        `expected workflows to use ${required}`,
+      );
+    }
   });
 
   it("does not run npm lifecycle scripts while building the npm package", async () => {


### PR DESCRIPTION
## Summary

Refs #2709.

This changes the release, deploy-dispatch, Homebrew tap, and docs-sync workflow paths to mint scoped GitHub App installation tokens instead of using broad PAT-style repository secrets.

## What changed

- Use `actions/create-github-app-token` with pinned SHAs in `cicd.yml` and `sync-docs.yml`.
- Scope release automation to the exact target repositories and permissions needed.
- Move the expected GitHub App client IDs/private keys into the public hardening checklist.
- Add regression coverage that fails if `GH_PAT_*` or `HOMEBREW_TAP_PAT` returns to workflow files.
- Document that GitHub release/deploy automation should use short-lived GitHub App installation tokens.

## Verification

- `DENO_NO_LOCK=1 deno fmt --check SECURITY.md .github/SECURITY-HARDENING.md src/security/repository-hardening.test.ts`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/cicd.yml .github/workflows/sync-docs.yml .github/workflows/codeql.yml .github/workflows/security-audit.yml`
- `rg -n "secrets\\.GH_PAT|GH_PAT_|HOMEBREW_TAP_PAT" .github/workflows` returned no matches
- `DENO_NO_LOCK=1 deno test --no-lock --no-check --allow-read src/security/repository-hardening.test.ts`
- `DENO_NO_LOCK=1 deno test --no-lock --no-check --allow-read src/config/cicd-coverage-workflow.test.ts`
- `DENO_NO_LOCK=1 deno task lint:deps`
- `DENO_NO_LOCK=1 deno task audit`
- pre-push hook: fmt, lint, typecheck, unit tests, `2220 passed`, `0 failed`

## Remaining external setup

This PR prepares the workflows, but #2709 should stay open until the protected `production` environment has the listed GitHub App variables/secrets, a release dry-run succeeds, and `GH_PAT_VERYFRONT` plus `GH_PAT_HOMEBREW_TAP` are deleted.
