### PR TITLE
Normalize Apache license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -48,7 +49,7 @@
       "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright owner
+      submitted to Licensor for inclusion in the Work by the copyright owner
       or by an individual or Legal Entity authorized to submit on behalf of
       the copyright owner. For the purposes of this definition, "submitted"
       means any form of electronic, verbal, or written communication sent
@@ -60,7 +61,7 @@
       designated in writing by the copyright owner as "Not a Contribution."
 
       "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by the Licensor and
+      on behalf of whom a Contribution has been received by Licensor and
       subsequently incorporated within the Work.
 
    2. Grant of Copyright License. Subject to the terms and conditions of
@@ -106,7 +107,7 @@
       (d) If the Work includes a "NOTICE" text file as part of its
           distribution, then any Derivative Works that You distribute must
           include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding any notices that do not
+          within such NOTICE file, excluding those notices that do not
           pertain to any part of the Derivative Works, in at least one
           of the following places: within a NOTICE text file distributed
           as part of the Derivative Works; within the Source form or
@@ -175,7 +176,18 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2025 Veryfront GmbH
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,2 @@
+Veryfront Code
+Copyright 2026 Veryfront GmbH


### PR DESCRIPTION
## Summary
- Keep `LICENSE` as the canonical Apache License 2.0 text.
- Move project copyright attribution to `NOTICE` with `Copyright 2026 Veryfront GmbH`.

## Grounding
- Apache License 2.0 page says to include the Apache License, typically in `LICENSE`, and consider a `NOTICE` file: https://www.apache.org/licenses/LICENSE-2.0
- Apache License 2.0 section 4(d) defines the `NOTICE` file and says NOTICE contents are informational and do not modify the license: https://www.apache.org/licenses/LICENSE-2.0
- ASF applying-license guidance says to copy `LICENSE-2.0.txt` into top-level `LICENSE` and include a correct `NOTICE` file in the same directory: https://www.apache.org/legal/apply-license.html

## Verification
- `curl -fsSL https://www.apache.org/licenses/LICENSE-2.0.txt | diff -u - LICENSE`
- `git diff --check`
- Pre-push hook: format, lint, type check, and unit tests passed (2220 passed, 0 failed).