### PR TITLE
Reduce default npm supply-chain surface

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.984",
+  "version": "0.1.985",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/extensions/ext-sandbox-shell-tools/README.md
+++ b/extensions/ext-sandbox-shell-tools/README.md
@@ -15,6 +15,10 @@ This extension is a sensitive sandbox execution boundary. Keep `bash-tool`,
 `just-bash`, and related shell execution dependencies in this extension instead
 of importing them from core, CLI, React, or unrelated extensions.
 
+Npm installs of `veryfront` do not install `bash-tool` or `just-bash` by
+default. Apps that expose sandbox bash must install them in the app package or
+pass `createBashTool` explicitly.
+
 ## Capabilities
 
 - **sandbox `bash`:** Creates shell tools that execute commands through the

--- a/extensions/ext-sandbox-shell-tools/src/index.test.ts
+++ b/extensions/ext-sandbox-shell-tools/src/index.test.ts
@@ -1,7 +1,10 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 import { SandboxShellToolsProviderName } from "veryfront/extensions/sandbox";
-import extSandboxShellTools, { createSandboxShellToolsProvider } from "./index.ts";
+import extSandboxShellTools, {
+  createLazyBashSandboxShellToolsProvider,
+  createSandboxShellToolsProvider,
+} from "./index.ts";
 
 describe("ext-sandbox-shell-tools", () => {
   it("declares the sandbox shell tools contract", () => {
@@ -60,5 +63,31 @@ describe("ext-sandbox-shell-tools", () => {
       promptOptions: { toolPrompt: "tools" },
     });
     assertEquals(result, { tools: { bash: { description: "Run commands" } } });
+  });
+
+  it("reports missing opt-in shell dependencies with an actionable error", async () => {
+    const provider = createLazyBashSandboxShellToolsProvider(async () => {
+      throw Object.assign(new Error("Cannot find package 'bash-tool'"), {
+        code: "ERR_MODULE_NOT_FOUND",
+      });
+    });
+    const sandbox = {
+      executeCommand: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+    };
+
+    const error = await assertRejects(
+      () =>
+        provider({
+          sandbox,
+          destination: "/workspace",
+          promptOptions: { toolPrompt: "tools" },
+        }),
+      Error,
+      "Sandbox shell tools require optional peer dependencies",
+    );
+
+    assertStringIncludes(error.message, "bash-tool");
+    assertStringIncludes(error.message, "just-bash");
+    assertStringIncludes(error.message, "pass createBashTool explicitly");
   });
 });

--- a/extensions/ext-sandbox-shell-tools/src/index.ts
+++ b/extensions/ext-sandbox-shell-tools/src/index.ts
@@ -15,16 +15,60 @@ type BashToolFactory = (
   input: CreateSandboxShellToolsInput,
 ) => Promise<{ tools: Record<string, unknown> }>;
 
+type BashToolModule = {
+  createBashTool: BashToolFactory;
+};
+
+type BashToolModuleLoader = () => Promise<BashToolModule>;
+
 export function createSandboxShellToolsProvider(
   createBashToolImpl: BashToolFactory,
 ): SandboxShellToolsProvider {
   return async (input) => await createBashToolImpl(input);
 }
 
-const provider = createSandboxShellToolsProvider(async (input) => {
+async function loadDefaultBashToolModule(): Promise<BashToolModule> {
   const { createBashTool: createBashToolImpl } = await import("bash-tool");
-  return await createBashToolImpl(input);
-});
+  return { createBashTool: createBashToolImpl as BashToolFactory };
+}
+
+function isMissingOptionalPackageError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = typeof error === "object" && error !== null && "code" in error
+    ? String((error as { code?: unknown }).code)
+    : "";
+  return code === "ERR_MODULE_NOT_FOUND" ||
+    message.includes("Cannot find package") ||
+    message.includes("Cannot find module") ||
+    message.includes("Module not found");
+}
+
+function createMissingSandboxShellDependencyError(cause: unknown): Error {
+  const error = new Error(
+    'Sandbox shell tools require optional peer dependencies "bash-tool" and "just-bash". Install them in the application package or pass createBashTool explicitly.',
+  );
+  (error as { cause?: unknown }).cause = cause;
+  return error;
+}
+
+export function createLazyBashSandboxShellToolsProvider(
+  loadBashToolModule: BashToolModuleLoader = loadDefaultBashToolModule,
+): SandboxShellToolsProvider {
+  return createSandboxShellToolsProvider(async (input) => {
+    let bashToolModule: BashToolModule;
+    try {
+      bashToolModule = await loadBashToolModule();
+    } catch (error) {
+      if (isMissingOptionalPackageError(error)) {
+        throw createMissingSandboxShellDependencyError(error);
+      }
+      throw error;
+    }
+    return await bashToolModule.createBashTool(input);
+  });
+}
+
+const provider = createLazyBashSandboxShellToolsProvider();
 
 const extSandboxShellTools: ExtensionFactory = () => ({
   name: "ext-sandbox-shell-tools",

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -49,12 +49,11 @@ describe("normalizeNpmPackageMetadata", () => {
 		});
 
 		assertEquals(pkg.dependencies, { zod: "4.3.6" });
-		assertEquals(pkg.optionalDependencies, {
-			"@huggingface/transformers": "4.2.0",
-		});
+		assertEquals(pkg.optionalDependencies, undefined);
 		assertEquals(pkg.peerDependencies, {
 			"@kreuzberg/node": "^4.4.2",
 			"@kreuzberg/wasm": "4.5.2",
+			"@huggingface/transformers": "^4.2.0",
 			"@opentelemetry/api": "1.9.1",
 			"@opentelemetry/exporter-metrics-otlp-http": "0.219.0",
 			"@opentelemetry/sdk-metrics": "2.8.0",
@@ -64,6 +63,7 @@ describe("normalizeNpmPackageMetadata", () => {
 		assertEquals(pkg.peerDependenciesMeta, {
 			"@kreuzberg/node": { optional: true },
 			"@kreuzberg/wasm": { optional: true },
+			"@huggingface/transformers": { optional: true },
 			"@opentelemetry/api": { optional: true },
 			"@opentelemetry/exporter-metrics-otlp-http": { optional: true },
 			"@opentelemetry/sdk-metrics": { optional: true },
@@ -72,7 +72,7 @@ describe("normalizeNpmPackageMetadata", () => {
 		});
 	});
 
-	it("keeps auto-enabled sandbox shell extension packages installable at runtime", () => {
+	it("keeps sandbox shell packages out of automatic npm installs", () => {
 		const pkg = normalizeNpmPackageMetadata({
 			dependencies: {
 				"bash-tool": "1.3.16",
@@ -82,15 +82,16 @@ describe("normalizeNpmPackageMetadata", () => {
 		});
 
 		assertEquals(pkg.dependencies, { zod: "4.3.6" });
-		assertEquals(pkg.optionalDependencies, {
+		assertEquals(pkg.optionalDependencies, undefined);
+		assertEquals(pkg.peerDependencies, {
 			"bash-tool": "1.3.16",
+			"better-sqlite3": ">=9.0.0",
 			"just-bash": "2.14.5",
 		});
-		assertEquals(pkg.peerDependencies, {
-			"better-sqlite3": ">=9.0.0",
-		});
 		assertEquals(pkg.peerDependenciesMeta, {
+			"bash-tool": { optional: true },
 			"better-sqlite3": { optional: true },
+			"just-bash": { optional: true },
 		});
 	});
 
@@ -144,18 +145,21 @@ describe("normalizeNpmPackageMetadata", () => {
 
 		assertEquals(pkg.dependencies, {
 			"@types/react": "19.2.14",
-			"@deno/shim-deno": "0.18.0",
+			"@deno/shim-deno": "0.19.2",
 			zod: "4.3.6",
 		});
-		assertEquals(pkg.optionalDependencies, {
-			"just-bash": "2.14.5",
-		});
+		assertEquals(pkg.optionalDependencies, undefined);
 		assertEquals(pkg.devDependencies, {
 			"@types/node": "20.9.0",
 		});
 		assertEquals(pkg.peerDependencies, {
 			react: "^19.0.0",
 			"better-sqlite3": ">=9.0.0",
+			"just-bash": "^2.14.5",
+		});
+		assertEquals(pkg.peerDependenciesMeta, {
+			"better-sqlite3": { optional: true },
+			"just-bash": { optional: true },
 		});
 		assertEquals(pkg.overrides, {
 			protobufjs: "8.6.5",
@@ -370,5 +374,23 @@ describe("npm generated integration artifacts", () => {
 			source,
 			'pkg.files = ["esm", "script", "bin", "assets", "tsconfig.json", "LICENSE", "NOTICE", "README.md"];',
 		);
+	});
+
+	it("keeps high-risk feature packages opt-in in generated npm metadata", async () => {
+		const pkg = JSON.parse(await Deno.readTextFile("npm/package.json"));
+		const optInPackages = [
+			"@huggingface/transformers",
+			"bash-tool",
+			"just-bash",
+		];
+
+		for (const packageName of optInPackages) {
+			assertEquals(pkg.dependencies?.[packageName], undefined);
+			assertEquals(pkg.optionalDependencies?.[packageName], undefined);
+			assertEquals(typeof pkg.peerDependencies?.[packageName], "string");
+			assertEquals(pkg.peerDependenciesMeta?.[packageName], { optional: true });
+		}
+
+		assertEquals(pkg.dependencies?.["@deno/shim-deno"], "0.19.2");
 	});
 });

--- a/scripts/build/npm-package-metadata.ts
+++ b/scripts/build/npm-package-metadata.ts
@@ -18,6 +18,7 @@ const OPTIONAL_NATIVE_PEERS = {
 const OPTIONAL_FEATURE_PEERS = [
 	"@kreuzberg/node",
 	"@kreuzberg/wasm",
+	"@huggingface/transformers",
 	"@opentelemetry/api",
 	"@opentelemetry/auto-instrumentations-node",
 	"@opentelemetry/context-async-hooks",
@@ -29,9 +30,6 @@ const OPTIONAL_FEATURE_PEERS = [
 	"@opentelemetry/sdk-node",
 	"@opentelemetry/sdk-trace-base",
 	"@opentelemetry/semantic-conventions",
-] as const;
-
-const AUTO_ENABLED_EXTENSION_OPTIONAL_DEPENDENCIES = [
 	"bash-tool",
 	"just-bash",
 ] as const;
@@ -48,6 +46,10 @@ const STALE_DEV_DEPENDENCIES = [
 
 const REQUIRED_NPM_OVERRIDES = {
 	protobufjs: "8.6.5",
+} as const;
+
+const REQUIRED_NPM_DEPENDENCY_VERSIONS = {
+	"@deno/shim-deno": "0.19.2",
 } as const;
 
 export function normalizeNpmPackageMetadata(pkg: PackageJson): PackageJson {
@@ -69,10 +71,6 @@ export function normalizeNpmPackageMetadata(pkg: PackageJson): PackageJson {
 		movePackageToOptionalPeer(pkg, name);
 	}
 
-	for (const name of AUTO_ENABLED_EXTENSION_OPTIONAL_DEPENDENCIES) {
-		movePackageToOptionalDependency(pkg, name);
-	}
-
 	for (const name of STALE_DIRECT_DEPENDENCIES) {
 		delete pkg.dependencies?.[name];
 		delete pkg.optionalDependencies?.[name];
@@ -91,6 +89,7 @@ export function normalizeNpmPackageMetadata(pkg: PackageJson): PackageJson {
 	}
 
 	pinAutomaticDependencyRanges(pkg);
+	pinRequiredDependencyVersions(pkg);
 
 	return pkg;
 }
@@ -110,6 +109,16 @@ function stripLeadingRangeOperator(range: string): string {
 	return range.replace(/^[\^~]/, "");
 }
 
+function pinRequiredDependencyVersions(pkg: PackageJson): void {
+	if (!pkg.dependencies) return;
+
+	for (const [name, version] of Object.entries(REQUIRED_NPM_DEPENDENCY_VERSIONS)) {
+		if (name in pkg.dependencies) {
+			pkg.dependencies[name] = version;
+		}
+	}
+}
+
 function movePackageToOptionalPeer(pkg: PackageJson, name: string): void {
 	const range = pkg.dependencies?.[name] ?? pkg.optionalDependencies?.[name];
 	if (!range) return;
@@ -122,18 +131,6 @@ function movePackageToOptionalPeer(pkg: PackageJson, name: string): void {
 
 	pkg.peerDependenciesMeta ??= {};
 	pkg.peerDependenciesMeta[name] = { optional: true };
-}
-
-function movePackageToOptionalDependency(pkg: PackageJson, name: string): void {
-	const range = pkg.dependencies?.[name] ?? pkg.optionalDependencies?.[name];
-	if (!range) return;
-
-	delete pkg.dependencies?.[name];
-	delete pkg.peerDependencies?.[name];
-	delete pkg.peerDependenciesMeta?.[name];
-
-	pkg.optionalDependencies ??= {};
-	pkg.optionalDependencies[name] = range;
 }
 
 function deleteIfEmpty(

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.984";
+export const VERSION = "0.1.985";


### PR DESCRIPTION
## Summary
- Move local AI, document extraction, observability, and sandbox shell feature packages from automatic npm installs to optional peers.
- Pin the generated npm package dependency on `@deno/shim-deno` to `0.19.2`.
- Bump the package/runtime version to `0.1.985` for the next release.
- Add generated-package assertions so these high-capability packages stay opt-in.

## Dependency model
This PR is the immediate public-package hardening: ordinary `npm install veryfront` must not automatically install feature dependencies that execute shell commands, parse untrusted documents, load local AI runtimes, or start telemetry SDKs.

The long-term model is extension-owned npm packages, not raw implementation peers in every downstream host. That follow-up is tracked in #2718. Until those extension packages are published, hosts that expose a feature must install the optional peer packages directly or inject the provider explicitly.

## Socket impact
The low Socket score was driven largely by default install graph/capability heuristics, not `npm audit` vulnerabilities. After this change, the generated npm package no longer installs these packages or their flagged transitive dependencies by default:

- `@huggingface/transformers`
- `@kreuzberg/node`
- `@kreuzberg/wasm`
- OpenTelemetry SDK/exporter packages
- `bash-tool`
- `just-bash`
- `@mongodb-js/zstd`
- `picomatch`
- `boolean`

These features remain available when consumers explicitly install the optional peer packages or provide the corresponding extension/provider.

## Verification
- `deno task build:npm`
- `deno test --config=scripts/test.deno.json --no-lock --no-check --allow-read scripts/build/npm-package-metadata.test.ts`
- `deno test --no-lock --no-check --allow-read src/utils/version.test.ts`
- `cd npm && npm audit --omit=dev --json` (0 vulnerabilities)
- Generated npm metadata inspection: version `0.1.985`, 0 optional dependencies, opt-in packages absent from `dependencies` and `optionalDependencies`, present as optional peers
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno lint src/utils/version-constant.ts`
- `git diff --check`
- Pre-push hook: formatting, lint, typecheck, and unit suite (`2220 passed`, `0 failed`)

## Remaining risk
Socket may still flag expected framework capabilities, including network access, dynamic imports/MDX runtime loading, and Redis/server runtime code paths. Those are product/runtime capabilities rather than default dependency graph bloat.
