### PR TITLE
Release 0.1.986

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.986-rc.1",
+  "version": "0.1.986",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.986-rc.1";
+export const VERSION = "0.1.986";


### PR DESCRIPTION
## Summary

Stable release publishing root `veryfront` plus all fifteen generated `@veryfront/ext-*` extension packages.

## Validation already performed

- `0.1.986-rc.1.6421` prerelease published all sixteen packages via npm trusted publishing (OIDC) with provenance attestations, gitHead `0a3ad1ae3`
- Clean-room registry install smoke: `npm i veryfront@rc @veryfront/ext-auth-jwt@rc` — CLI `--version` and `schema --json` under Node, extension loads through the npm package fallback
- `tests (npm install smoke)` CI job gates this release on the same artifact checks

## After merge

The release job publishes `latest`, tags `v0.1.986`, uploads binaries, and updates homebrew.