### PR TITLE
Fix PDF knowledge ingest extraction

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.986",
+  "version": "0.1.987",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/extensions/ext-document-kreuzberg/src/index.test.ts
+++ b/extensions/ext-document-kreuzberg/src/index.test.ts
@@ -84,4 +84,27 @@ describe("ext-document-kreuzberg extension", () => {
     assertEquals(content, "native pdf text");
     assertEquals(calls, [{ bytes: "%PDF-1.4\n", mimeType: "application/pdf" }]);
   });
+
+  it("falls back to the Deno worker when native PDF extraction is unavailable", async () => {
+    const workerCalls: Array<{ bytes: string; mimeType: string }> = [];
+    const deps: KreuzbergDocumentExtractorDeps = {
+      isDenoRuntime: true,
+      loadNativeKreuzberg: async () => {
+        throw new Error("Cannot find native binding", {
+          cause: new Error("Cannot find module '@kreuzberg/node-linux-x64'"),
+        });
+      },
+      extractInWorkerDeno: async (buffer, mimeType) => {
+        workerCalls.push({ bytes: new TextDecoder().decode(buffer), mimeType });
+        return "worker pdf text";
+      },
+    };
+    const extractor = new KreuzbergDocumentExtractor(deps);
+    const buffer = new TextEncoder().encode("%PDF-1.4\n").buffer.slice(0) as ArrayBuffer;
+
+    const content = await extractor.extractInWorker(buffer, "application/pdf");
+
+    assertEquals(content, "worker pdf text");
+    assertEquals(workerCalls, [{ bytes: "%PDF-1.4\n", mimeType: "application/pdf" }]);
+  });
 });

--- a/extensions/ext-document-kreuzberg/src/index.test.ts
+++ b/extensions/ext-document-kreuzberg/src/index.test.ts
@@ -9,7 +9,10 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 import type { ExtensionContext, ExtensionLogger } from "veryfront/extensions";
-import factory, { KreuzbergDocumentExtractor } from "./index.ts";
+import factory, {
+  KreuzbergDocumentExtractor,
+  type KreuzbergDocumentExtractorDeps,
+} from "./index.ts";
 
 function silentLogger(): ExtensionLogger {
   return {
@@ -57,5 +60,28 @@ describe("ext-document-kreuzberg extension", () => {
     assertExists(extractor);
     assertEquals(typeof extractor.importKreuzberg, "function");
     assertEquals(typeof extractor.extractInWorker, "function");
+  });
+
+  it("uses native extraction for PDFs in Deno before falling back to the WASM worker", async () => {
+    const calls: Array<{ bytes: string; mimeType: string }> = [];
+    const deps: KreuzbergDocumentExtractorDeps = {
+      isDenoRuntime: true,
+      loadNativeKreuzberg: async () => ({
+        extractBytes: async (data, mimeType) => {
+          calls.push({ bytes: new TextDecoder().decode(data), mimeType });
+          return { content: "native pdf text" };
+        },
+      }),
+      extractInWorkerDeno: async () => {
+        throw new Error("worker should not be used for PDFs when native extraction is available");
+      },
+    };
+    const extractor = new KreuzbergDocumentExtractor(deps);
+    const buffer = new TextEncoder().encode("%PDF-1.4\n").buffer.slice(0) as ArrayBuffer;
+
+    const content = await extractor.extractInWorker(buffer, "application/pdf");
+
+    assertEquals(content, "native pdf text");
+    assertEquals(calls, [{ bytes: "%PDF-1.4\n", mimeType: "application/pdf" }]);
   });
 });

--- a/extensions/ext-document-kreuzberg/src/index.test.ts
+++ b/extensions/ext-document-kreuzberg/src/index.test.ts
@@ -10,6 +10,7 @@ import { assertEquals, assertExists } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 import type { ExtensionContext, ExtensionLogger } from "veryfront/extensions";
 import factory, {
+  EXTRACTION_TIMEOUT_MS,
   KreuzbergDocumentExtractor,
   type KreuzbergDocumentExtractorDeps,
 } from "./index.ts";
@@ -60,6 +61,10 @@ describe("ext-document-kreuzberg extension", () => {
     assertExists(extractor);
     assertEquals(typeof extractor.importKreuzberg, "function");
     assertEquals(typeof extractor.extractInWorker, "function");
+  });
+
+  it("uses a two minute timeout for fallback worker extraction", () => {
+    assertEquals(EXTRACTION_TIMEOUT_MS, 120_000);
   });
 
   it("uses native extraction for PDFs in Deno before falling back to the WASM worker", async () => {

--- a/extensions/ext-document-kreuzberg/src/index.ts
+++ b/extensions/ext-document-kreuzberg/src/index.ts
@@ -12,8 +12,8 @@ import type { DocumentExtractor, KreuzbergExtractor } from "veryfront/extensions
 import { isMissingPackageError, loadKreuzberg, loadKreuzbergNative } from "./kreuzberg.ts";
 import { isDeno } from "./runtime.ts";
 
-/** Maximum time to wait for document text extraction before aborting. */
-const EXTRACTION_TIMEOUT_MS = 30_000;
+/** Maximum time to wait for fallback worker extraction before aborting. */
+export const EXTRACTION_TIMEOUT_MS = 120_000;
 
 function extractInWorkerDeno(
   buffer: ArrayBuffer,

--- a/extensions/ext-document-kreuzberg/src/index.ts
+++ b/extensions/ext-document-kreuzberg/src/index.ts
@@ -9,7 +9,7 @@
 
 import type { ExtensionFactory } from "veryfront/extensions";
 import type { DocumentExtractor, KreuzbergExtractor } from "veryfront/extensions/compat";
-import { loadKreuzberg } from "./kreuzberg.ts";
+import { loadKreuzberg, loadKreuzbergNative } from "./kreuzberg.ts";
 import { isDeno } from "./runtime.ts";
 
 /** Maximum time to wait for document text extraction before aborting. */
@@ -62,21 +62,68 @@ function extractInWorkerDeno(
   });
 }
 
+export interface KreuzbergDocumentExtractorDeps {
+  isDenoRuntime?: boolean;
+  loadNativeKreuzberg?: () => Promise<KreuzbergExtractor>;
+  extractInWorkerDeno?: typeof extractInWorkerDeno;
+}
+
+function isPdfMimeType(mimeType: string): boolean {
+  return mimeType.toLowerCase().split(";")[0]?.trim() === "application/pdf";
+}
+
+function isNativeKreuzbergUnavailable(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("@kreuzberg/node") ||
+    message.includes("ERR_MODULE_NOT_FOUND") ||
+    message.includes("Cannot find module") ||
+    message.includes("Cannot find package") ||
+    message.includes("Module not found");
+}
+
+async function extractWithNativeKreuzberg(
+  buffer: ArrayBuffer,
+  mimeType: string,
+  loadNative: () => Promise<KreuzbergExtractor>,
+): Promise<string> {
+  const { extractBytes } = await loadNative();
+  const result = await extractBytes(new Uint8Array(buffer), mimeType);
+  return result.content;
+}
+
 export class KreuzbergDocumentExtractor implements DocumentExtractor {
+  constructor(private readonly deps: KreuzbergDocumentExtractorDeps = {}) {}
+
   importKreuzberg(): Promise<KreuzbergExtractor> {
     return loadKreuzberg();
   }
 
   async extractInWorker(buffer: ArrayBuffer, mimeType: string): Promise<string> {
-    // Only a real Deno runtime gets the isolated Worker; Node/Bun extract
-    // in-process via @kreuzberg/node. See ./runtime.ts for why a bare `Deno`
-    // check is unreliable in the dnt npm build.
-    if (!isDeno) {
+    const isDenoRuntime = this.deps.isDenoRuntime ?? isDeno;
+    const extractWithWorker = this.deps.extractInWorkerDeno ?? extractInWorkerDeno;
+
+    // Node/Bun extract in-process via @kreuzberg/node. Deno keeps the isolated
+    // Worker fallback, but PDFs first try the native extractor because the WASM
+    // PDF path can hang on valid large manuals.
+    if (!isDenoRuntime) {
       const { extractBytes } = await loadKreuzberg();
       const result = await extractBytes(new Uint8Array(buffer), mimeType);
       return result.content;
     }
-    return extractInWorkerDeno(buffer, mimeType);
+
+    if (isPdfMimeType(mimeType)) {
+      try {
+        return await extractWithNativeKreuzberg(
+          buffer,
+          mimeType,
+          this.deps.loadNativeKreuzberg ?? loadKreuzbergNative,
+        );
+      } catch (error) {
+        if (!isNativeKreuzbergUnavailable(error)) throw error;
+      }
+    }
+
+    return extractWithWorker(buffer, mimeType);
   }
 }
 

--- a/extensions/ext-document-kreuzberg/src/index.ts
+++ b/extensions/ext-document-kreuzberg/src/index.ts
@@ -9,7 +9,7 @@
 
 import type { ExtensionFactory } from "veryfront/extensions";
 import type { DocumentExtractor, KreuzbergExtractor } from "veryfront/extensions/compat";
-import { loadKreuzberg, loadKreuzbergNative } from "./kreuzberg.ts";
+import { isMissingPackageError, loadKreuzberg, loadKreuzbergNative } from "./kreuzberg.ts";
 import { isDeno } from "./runtime.ts";
 
 /** Maximum time to wait for document text extraction before aborting. */
@@ -72,15 +72,6 @@ function isPdfMimeType(mimeType: string): boolean {
   return mimeType.toLowerCase().split(";")[0]?.trim() === "application/pdf";
 }
 
-function isNativeKreuzbergUnavailable(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.includes("@kreuzberg/node") ||
-    message.includes("ERR_MODULE_NOT_FOUND") ||
-    message.includes("Cannot find module") ||
-    message.includes("Cannot find package") ||
-    message.includes("Module not found");
-}
-
 async function extractWithNativeKreuzberg(
   buffer: ArrayBuffer,
   mimeType: string,
@@ -119,7 +110,7 @@ export class KreuzbergDocumentExtractor implements DocumentExtractor {
           this.deps.loadNativeKreuzberg ?? loadKreuzbergNative,
         );
       } catch (error) {
-        if (!isNativeKreuzbergUnavailable(error)) throw error;
+        if (!isMissingPackageError(error)) throw error;
       }
     }
 

--- a/extensions/ext-document-kreuzberg/src/kreuzberg.ts
+++ b/extensions/ext-document-kreuzberg/src/kreuzberg.ts
@@ -20,14 +20,13 @@ type KreuzbergModule = {
   ) => Promise<{ content: string }>;
 };
 
-// deno-lint-ignore no-explicit-any
-async function loadKreuzbergNode(): Promise<any> {
+export async function loadKreuzbergNative(): Promise<KreuzbergExtractor> {
   try {
-    return await import("@kreuzberg/node");
+    return await import("@kreuzberg/node") as unknown as KreuzbergExtractor;
   } catch (error) {
     if (!isMissingPackageError(error)) throw error;
     throw new Error(
-      'Document extraction on Node requires the optional package "@kreuzberg/node". ' +
+      'Native document extraction requires the optional package "@kreuzberg/node". ' +
         "Install @kreuzberg/node@^4.4.2 or disable document extraction.",
     );
   }
@@ -37,7 +36,7 @@ export async function loadKreuzberg(): Promise<KreuzbergExtractor> {
   // Node/Bun load the native @kreuzberg/node; only a real Deno runtime uses the
   // WASM build. See ./runtime.ts for why a bare `Deno` check is unreliable here.
   if (!isDeno) {
-    return loadKreuzbergNode();
+    return loadKreuzbergNative();
   }
 
   const mod = await importKreuzbergWasm();

--- a/extensions/ext-document-kreuzberg/src/kreuzberg.ts
+++ b/extensions/ext-document-kreuzberg/src/kreuzberg.ts
@@ -28,6 +28,7 @@ export async function loadKreuzbergNative(): Promise<KreuzbergExtractor> {
     throw new Error(
       'Native document extraction requires the optional package "@kreuzberg/node". ' +
         "Install @kreuzberg/node@^4.4.2 or disable document extraction.",
+      { cause: error },
     );
   }
 }
@@ -69,14 +70,30 @@ async function importKreuzbergWasm(): Promise<KreuzbergModule> {
     throw new Error(
       'Document extraction on Deno requires the optional package "@kreuzberg/wasm". ' +
         "Install @kreuzberg/wasm@4.5.2 or disable document extraction.",
+      { cause: error },
     );
   }
 }
 
-function isMissingPackageError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.includes("Cannot find package") ||
-    message.includes("Cannot find module") ||
-    message.includes("ERR_MODULE_NOT_FOUND") ||
-    message.includes("Module not found");
+export function isMissingPackageError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+
+  while (current !== undefined && current !== null && !seen.has(current)) {
+    seen.add(current);
+    const message = current instanceof Error ? current.message : String(current);
+    if (
+      message.includes("Cannot find package") ||
+      message.includes("Cannot find module") ||
+      message.includes("Cannot find native binding") ||
+      message.includes("ERR_MODULE_NOT_FOUND") ||
+      message.includes("Module not found")
+    ) {
+      return true;
+    }
+
+    current = current instanceof Error ? current.cause : undefined;
+  }
+
+  return false;
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.986";
+export const VERSION = "0.1.987";


### PR DESCRIPTION
## Summary
- Route Deno PDF extraction through the native `@kreuzberg/node` extractor before falling back to the existing WASM worker.
- Keep the WASM worker path for non-PDF Deno extraction and for environments where native Kreuzberg is unavailable.
- Add a regression test that proves PDF extraction does not enter the Deno WASM worker when native extraction is available.

Fixes veryfront/veryfront-studio#5470.

## Reproduction
- Disposable `origin/main` worktree, exact Bosch PDF `9001682797_E.pdf`: `runKnowledgeParser(...)` failed after `30.62s` with `Text extraction timed out after 30s` and exit status `1`.
- Test-only `origin/main` worktree with the new regression test failed red: `Error extracting from bytes: Parsing error: Invalid PDF: PdfiumLibraryInternalError: FormatError`.

## Verification
- `deno fmt --check extensions/ext-document-kreuzberg/src/index.ts extensions/ext-document-kreuzberg/src/index.test.ts extensions/ext-document-kreuzberg/src/kreuzberg.ts`
- `deno lint extensions/ext-document-kreuzberg/src/index.ts extensions/ext-document-kreuzberg/src/index.test.ts extensions/ext-document-kreuzberg/src/kreuzberg.ts`
- `git diff --check`
- `deno task --config extensions/ext-document-kreuzberg/deno.json test`
- `deno test --no-check --allow-all --unstable-worker-options --unstable-net cli/commands/knowledge/command.test.ts`
- Exact Bosch PDF parse on fixed branch: `Extracted PDF text with Kreuzberg (140011 chars)`, `3612` lines, `145298` byte markdown output, `0.24s` real time.
- Pre-push hook after clearing host telemetry env leakage: fmt, lint, typecheck, and `deno task test:unit` all passed: `2221 passed`, `0 failed`.