### PR TITLE
Harden npm release infrastructure

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -435,41 +435,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           deno task build:npm
-
-          package_dirs() {
-            printf '%s\n' npm
-            find npm/extensions -mindepth 1 -maxdepth 1 -type d | sort
-          }
-
-          update_package_version() {
-            PACKAGE_DIR="$1"
-            jq --arg v "$VERSION" '
-              .version = $v
-              | if .peerDependencies?.veryfront then .peerDependencies.veryfront = "^" + $v else . end
-              | if .dependencies?.veryfront then .dependencies.veryfront = "^" + $v else . end
-            ' "${PACKAGE_DIR}/package.json" > "${PACKAGE_DIR}/package.json.tmp"
-            mv "${PACKAGE_DIR}/package.json.tmp" "${PACKAGE_DIR}/package.json"
-          }
-
-          publish_package_dir() {
-            PACKAGE_DIR="$1"
-            PACKAGE_NAME="$(jq -r '.name' "${PACKAGE_DIR}/package.json")"
-            if npm view "${PACKAGE_NAME}@${VERSION}" version 2>/dev/null; then
-              echo "::notice::${PACKAGE_NAME}@${VERSION} already published to npm; skipping publish"
-              return 0
-            fi
-
-            echo "Publishing ${PACKAGE_NAME}@${VERSION} with rc tag"
-            (cd "${PACKAGE_DIR}" && npm publish --provenance --access public --tag rc)
-          }
-
-          for PACKAGE_DIR in $(package_dirs); do
-            update_package_version "${PACKAGE_DIR}"
-          done
-
-          for PACKAGE_DIR in $(package_dirs); do
-            publish_package_dir "${PACKAGE_DIR}"
-          done
+          scripts/ci/publish-npm-packages.sh rc-publish
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
@@ -594,42 +560,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           TAG="v${VERSION}"
-          package_names() {
-            printf '%s\n' veryfront
-            jq -r '.workspace[] | select(startswith("./extensions/")) | .[2:] + "/deno.json"' deno.json \
-              | while read -r MANIFEST_PATH; do
-                jq -r '.name' "${MANIFEST_PATH}"
-              done \
-              | sort
-          }
-
-          wait_for_existing_npm_git_head() {
-            PACKAGE_NAME="$1"
-            for attempt in $(seq 1 24); do
-              PUBLISHED_GIT_HEAD="$(npm view "${PACKAGE_NAME}@${VERSION}" gitHead 2>/dev/null || true)"
-              if [ "${PUBLISHED_GIT_HEAD}" = "${GITHUB_SHA}" ]; then
-                return 0
-              fi
-              if [ -n "${PUBLISHED_GIT_HEAD}" ]; then
-                return 1
-              fi
-              echo "Waiting for npm registry metadata for ${PACKAGE_NAME}@${VERSION} (attempt ${attempt}/24)."
-              sleep 5
-            done
-
-            PUBLISHED_GIT_HEAD="$(npm view "${PACKAGE_NAME}@${VERSION}" gitHead 2>/dev/null || true)"
-            [ "${PUBLISHED_GIT_HEAD}" = "${GITHUB_SHA}" ]
-          }
-
-          for PACKAGE_NAME in $(package_names); do
-            if npm view "${PACKAGE_NAME}@${VERSION}" version 2>/dev/null; then
-              if ! wait_for_existing_npm_git_head "${PACKAGE_NAME}"; then
-                echo "::error::${PACKAGE_NAME}@${VERSION} already exists on npm for ${PUBLISHED_GIT_HEAD}. Bump deno.json before releasing."
-                exit 1
-              fi
-              echo "${PACKAGE_NAME}@${VERSION} already exists on npm for this commit; continuing release metadata."
-            fi
-          done
+          scripts/ci/publish-npm-packages.sh preflight
           if git ls-remote --tags origin | grep -q "refs/tags/${TAG}$"; then
             echo "::error::Tag ${TAG} already exists on source repo. Bump deno.json before releasing."
             exit 1
@@ -656,63 +587,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           deno task build:npm
-
-          package_dirs() {
-            printf '%s\n' npm
-            find npm/extensions -mindepth 1 -maxdepth 1 -type d | sort
-          }
-
-          wait_for_npm_git_head() {
-            PACKAGE_NAME="$1"
-            for attempt in $(seq 1 24); do
-              PUBLISHED_GIT_HEAD="$(npm view "${PACKAGE_NAME}@${VERSION}" gitHead 2>/dev/null || true)"
-              if [ "${PUBLISHED_GIT_HEAD}" = "${GITHUB_SHA}" ]; then
-                return 0
-              fi
-              if [ -n "${PUBLISHED_GIT_HEAD}" ]; then
-                return 1
-              fi
-              echo "Waiting for npm registry metadata for ${PACKAGE_NAME}@${VERSION} (attempt ${attempt}/24)."
-              sleep 5
-            done
-
-            PUBLISHED_GIT_HEAD="$(npm view "${PACKAGE_NAME}@${VERSION}" gitHead 2>/dev/null || true)"
-            [ "${PUBLISHED_GIT_HEAD}" = "${GITHUB_SHA}" ]
-          }
-
-          publish_package_dir() {
-            PACKAGE_DIR="$1"
-            PACKAGE_NAME="$(jq -r '.name' "${PACKAGE_DIR}/package.json")"
-            PUBLISHED_GIT_HEAD="$(npm view "${PACKAGE_NAME}@${VERSION}" gitHead 2>/dev/null || true)"
-            if [ "${PUBLISHED_GIT_HEAD}" = "${GITHUB_SHA}" ]; then
-              echo "${PACKAGE_NAME}@${VERSION} is already published for this commit; skipping npm publish."
-            else
-              echo "Publishing ${PACKAGE_NAME}@${VERSION}"
-              set +e
-              PUBLISH_OUTPUT="$(cd "${PACKAGE_DIR}" && npm publish --provenance --access public 2>&1)"
-              PUBLISH_STATUS=$?
-              set -e
-              printf '%s\n' "${PUBLISH_OUTPUT}"
-
-              if [ "${PUBLISH_STATUS}" -ne 0 ]; then
-                if printf '%s\n' "${PUBLISH_OUTPUT}" | grep -Fq "previously published versions: ${VERSION}" \
-                  && wait_for_npm_git_head "${PACKAGE_NAME}"; then
-                  echo "npm reports ${PACKAGE_NAME}@${VERSION} already exists, and gitHead matches this commit; continuing."
-                else
-                  exit "${PUBLISH_STATUS}"
-                fi
-              fi
-            fi
-
-            if ! wait_for_npm_git_head "${PACKAGE_NAME}"; then
-              echo "::error::Published ${PACKAGE_NAME}@${VERSION} gitHead is ${PUBLISHED_GIT_HEAD}, expected ${GITHUB_SHA}."
-              exit 1
-            fi
-          }
-
-          for PACKAGE_DIR in $(package_dirs); do
-            publish_package_dir "${PACKAGE_DIR}"
-          done
+          scripts/ci/publish-npm-packages.sh release-publish
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:

--- a/scripts/build/build-npm-extension-packages.ts
+++ b/scripts/build/build-npm-extension-packages.ts
@@ -1,6 +1,7 @@
 import { build, emptyDir } from "#dnt";
 import { dirname } from "#std/path";
 import {
+  bareImportPackageNames,
   createExtensionPackageSpec,
   createVeryfrontPeerTypeImportReplacements,
   type ExtensionManifest,
@@ -90,6 +91,11 @@ export async function buildExtensionPackages(
         await removeDntImportMapArtifacts(outDir);
         await removeUnreferencedTopLevelDir(outDir, "react");
         await removeUnreferencedDntDeps(outDir);
+
+        await assertEmittedBareImportsAreDeclared({
+          outDir,
+          packageName: spec.packageName,
+        });
       },
     });
   }
@@ -156,12 +162,55 @@ async function removeUnreferencedDntDeps(outDir: string): Promise<void> {
   await Deno.remove(depsDir, { recursive: true });
 }
 
+async function assertEmittedBareImportsAreDeclared(input: {
+  outDir: string;
+  packageName: string;
+}): Promise<void> {
+  const pkg = JSON.parse(
+    await Deno.readTextFile(`${input.outDir}/package.json`),
+  ) as {
+    dependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+  };
+  const declared = new Set([
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.peerDependencies ?? {}),
+    ...Object.keys(pkg.optionalDependencies ?? {}),
+  ]);
+
+  const missing = new Map<string, Set<string>>();
+  for await (const filePath of walkFiles(`${input.outDir}/esm`)) {
+    if (!filePath.endsWith(".js")) continue;
+
+    const text = await Deno.readTextFile(filePath);
+    for (const packageName of bareImportPackageNames(text)) {
+      if (declared.has(packageName)) continue;
+      const files = missing.get(packageName) ?? new Set<string>();
+      files.add(filePath.slice(`${input.outDir}/`.length));
+      missing.set(packageName, files);
+    }
+  }
+
+  if (missing.size === 0) return;
+
+  const details = [...missing.entries()]
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([packageName, files]) =>
+      `  ${packageName} (imported by ${[...files].toSorted().join(", ")})`
+    )
+    .join("\n");
+  throw new Error(
+    `${input.packageName} emits imports of npm packages that are not declared in its package.json dependencies, peerDependencies, or optionalDependencies:\n${details}\nDeclare them in the extension's deno.json imports so they are published as dependencies.`,
+  );
+}
+
 async function hasGeneratedRootSourceReferences(
   outDir: string,
 ): Promise<boolean> {
   const rootSourceDir = `${outDir}/esm/src`;
   const relativeRootSourceSpecifier =
-    /(?:from\s+|import\s*\(\s*)["'](?:\.\.\/)+src\//;
+    /(?:from\s+|import\s*\(\s*|import\s+)["'](?:\.\.\/)+src\//;
 
   for await (const filePath of walkFiles(`${outDir}/esm`)) {
     if (filePath.startsWith(`${rootSourceDir}/`)) continue;
@@ -180,7 +229,7 @@ async function hasGeneratedDntImportMapReferences(
   outDir: string,
 ): Promise<boolean> {
   const dntImportMapSpecifier =
-    /(?:from\s+|import\s*\(\s*)["'](?:\.\.\/)+deno\.js["']/;
+    /(?:from\s+|import\s*\(\s*|import\s+)["'](?:\.\.\/)+deno\.js["']/;
 
   for await (const filePath of walkFiles(`${outDir}/esm`)) {
     if (filePath === `${outDir}/esm/deno.js`) continue;

--- a/scripts/build/npm-extension-package-metadata.test.ts
+++ b/scripts/build/npm-extension-package-metadata.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertStringIncludes } from "#std/assert";
 import { describe, it } from "#std/testing/bdd";
 import {
+  bareImportPackageNames,
   createExtensionPackageSpec,
   createVeryfrontPeerTypeImportReplacements,
   type ExtensionManifest,
@@ -168,6 +169,90 @@ describe("createExtensionPackageSpec", () => {
       mappings.some((mapping) => mapping.subPath === "transforms/frontmatter"),
       false,
     );
+  });
+});
+
+describe("bareImportPackageNames", () => {
+  it("extracts bare specifiers from static, dynamic, side-effect, and require imports", () => {
+    const source = [
+      `import { z } from "zod";`,
+      `import defaultExport from "bash-tool";`,
+      `import "polyfill-package";`,
+      `export { helper } from "@scope/helpers";`,
+      `export * from "@scope/helpers/subpath";`,
+      `const lazy = await import("lazy-loaded/deep/module");`,
+      `const legacy = require("legacy-package");`,
+    ].join("\n");
+
+    assertEquals(bareImportPackageNames(source), [
+      "@scope/helpers",
+      "bash-tool",
+      "lazy-loaded",
+      "legacy-package",
+      "polyfill-package",
+      "zod",
+    ]);
+  });
+
+  it("reduces subpath imports to their package name, including scoped packages", () => {
+    const source = [
+      `import glue from "@kreuzberg/wasm/dist/pkg/kreuzberg_wasm.js";`,
+      `import worker from "just-bash/worker";`,
+    ].join("\n");
+
+    assertEquals(bareImportPackageNames(source), [
+      "@kreuzberg/wasm",
+      "just-bash",
+    ]);
+  });
+
+  it("handles multi-line static imports", () => {
+    const source = [
+      `import {`,
+      `  first,`,
+      `  second,`,
+      `} from "multi-line-package";`,
+    ].join("\n");
+
+    assertEquals(bareImportPackageNames(source), ["multi-line-package"]);
+  });
+
+  it("ignores relative, absolute, and scheme-prefixed specifiers", () => {
+    const source = [
+      `import local from "./local.js";`,
+      `import parent from "../parent.js";`,
+      `import "../side-effect.js";`,
+      `import absolute from "/absolute/path.js";`,
+      `import fs from "node:fs";`,
+      `import remote from "https://example.com/mod.js";`,
+      `const dynamicLocal = await import("./dynamic.js");`,
+      `const requiredLocal = require("./required.js");`,
+    ].join("\n");
+
+    assertEquals(bareImportPackageNames(source), []);
+  });
+
+  it("does not treat quoted strings in ordinary code as imports", () => {
+    const source = [
+      `const query = 'select * from "users"';`,
+      `const sql = \``,
+      `select *`,
+      `from "accounts"`,
+      `\`;`,
+      `const label = "import";`,
+    ].join("\n");
+
+    assertEquals(bareImportPackageNames(source), []);
+  });
+
+  it("deduplicates repeated imports of the same package", () => {
+    const source = [
+      `import { a } from "shared-package";`,
+      `import { b } from "shared-package/subpath";`,
+      `const c = await import("shared-package");`,
+    ].join("\n");
+
+    assertEquals(bareImportPackageNames(source), ["shared-package"]);
   });
 });
 

--- a/scripts/build/npm-extension-package-metadata.ts
+++ b/scripts/build/npm-extension-package-metadata.ts
@@ -214,6 +214,51 @@ export function normalizeExtensionPackageJson(input: {
   return pkg;
 }
 
+const BARE_IMPORT_SPECIFIER_PATTERNS = [
+  // Static imports with bindings: `import x from "pkg"`, `import { a } from "pkg"`.
+  /^\s*import\s[^"'()]*?from\s*["']([^"'\n]+)["']/gm,
+  // Side-effect-only static imports: `import "pkg";`.
+  /^\s*import\s*["']([^"'\n]+)["']/gm,
+  // Re-exports: `export { a } from "pkg"`, `export * from "pkg"`.
+  /^\s*export\s[^"'()]*?from\s*["']([^"'\n]+)["']/gm,
+  // Dynamic imports: `import("pkg")`.
+  /\bimport\s*\(\s*["']([^"'\n]+)["']\s*\)/g,
+  // CommonJS requires: `require("pkg")`.
+  /\brequire\s*\(\s*["']([^"'\n]+)["']\s*\)/g,
+];
+
+/**
+ * Extracts the npm package names imported via bare specifiers in emitted
+ * JavaScript source. Relative/absolute specifiers and scheme-prefixed
+ * specifiers such as `node:` builtins are ignored, and subpath imports
+ * (`pkg/sub`, `@scope/pkg/sub`) are reduced to their package name.
+ */
+export function bareImportPackageNames(source: string): string[] {
+  const packageNames = new Set<string>();
+
+  for (const pattern of BARE_IMPORT_SPECIFIER_PATTERNS) {
+    for (const match of source.matchAll(pattern)) {
+      const packageName = bareSpecifierPackageName(match[1]!);
+      if (packageName) packageNames.add(packageName);
+    }
+  }
+
+  return [...packageNames].toSorted();
+}
+
+function bareSpecifierPackageName(specifier: string): string | undefined {
+  if (specifier.startsWith(".") || specifier.startsWith("/")) return undefined;
+  // Scheme-prefixed specifiers (node:, data:, https:, ...) are not npm packages.
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(specifier)) return undefined;
+
+  const segments = specifier.split("/");
+  if (specifier.startsWith("@")) {
+    if (segments.length < 2 || !segments[1]) return undefined;
+    return `${segments[0]}/${segments[1]}`;
+  }
+  return segments[0] || undefined;
+}
+
 export function createVeryfrontPeerTypeImportReplacements(input: {
   rootConfig: RootPackageConfig;
   outDir: string;

--- a/scripts/ci/publish-npm-packages.sh
+++ b/scripts/ci/publish-npm-packages.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Publish the veryfront npm packages (root `veryfront` plus every
+# @veryfront/ext-* extension package) from CI.
+#
+# Usage:
+#   scripts/ci/publish-npm-packages.sh <mode>
+#
+# Modes:
+#   rc-publish       Version-bump the `deno task build:npm` output to $VERSION
+#                    and publish every package with `--tag rc`, skipping
+#                    packages already published at $VERSION.
+#                    Requires: VERSION.
+#   preflight        Runs BEFORE the build: enumerate package names from the
+#                    deno.json workspace and fail if any name@$VERSION already
+#                    exists on npm for a different commit than $GITHUB_SHA.
+#                    Requires: VERSION, GITHUB_SHA.
+#   release-publish  Version-bump the `deno task build:npm` output to $VERSION,
+#                    publish every package to the latest tag with provenance
+#                    (skipping packages already published for this commit), and
+#                    verify each published package's gitHead matches
+#                    $GITHUB_SHA. Requires: VERSION, GITHUB_SHA.
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <rc-publish|preflight|release-publish>" >&2
+  exit 2
+}
+
+require_env() {
+  for NAME in "$@"; do
+    if [ -z "${!NAME:-}" ]; then
+      echo "::error::${NAME} must be set for this mode." >&2
+      exit 1
+    fi
+  done
+}
+
+# Package directories in the `deno task build:npm` output (publish modes).
+package_dirs() {
+  printf '%s\n' npm
+  find npm/extensions -mindepth 1 -maxdepth 1 -type d | sort
+}
+
+# Package names derived from the deno.json workspace (preflight runs before
+# the build, so the npm output does not exist yet).
+package_names_from_workspace() {
+  printf '%s\n' veryfront
+  jq -r '.workspace[] | select(startswith("./extensions/")) | .[2:] + "/deno.json"' deno.json \
+    | while read -r MANIFEST_PATH; do
+      jq -r '.name' "${MANIFEST_PATH}"
+    done \
+    | sort
+}
+
+update_package_version() {
+  PACKAGE_DIR="$1"
+  jq --arg v "$VERSION" '
+    .version = $v
+    | if .peerDependencies?.veryfront then .peerDependencies.veryfront = "^" + $v else . end
+    | if .dependencies?.veryfront then .dependencies.veryfront = "^" + $v else . end
+  ' "${PACKAGE_DIR}/package.json" > "${PACKAGE_DIR}/package.json.tmp"
+  mv "${PACKAGE_DIR}/package.json.tmp" "${PACKAGE_DIR}/package.json"
+}
+
+# Poll the npm registry until PACKAGE_NAME@VERSION reports a gitHead. Succeeds
+# only when that gitHead matches GITHUB_SHA. Leaves the last observed value in
+# the global PUBLISHED_GIT_HEAD for callers' error messages.
+wait_for_npm_git_head() {
+  PACKAGE_NAME="$1"
+  for attempt in $(seq 1 24); do
+    PUBLISHED_GIT_HEAD="$(npm view "${PACKAGE_NAME}@${VERSION}" gitHead 2>/dev/null || true)"
+    if [ "${PUBLISHED_GIT_HEAD}" = "${GITHUB_SHA}" ]; then
+      return 0
+    fi
+    if [ -n "${PUBLISHED_GIT_HEAD}" ]; then
+      return 1
+    fi
+    echo "Waiting for npm registry metadata for ${PACKAGE_NAME}@${VERSION} (attempt ${attempt}/24)."
+    sleep 5
+  done
+
+  PUBLISHED_GIT_HEAD="$(npm view "${PACKAGE_NAME}@${VERSION}" gitHead 2>/dev/null || true)"
+  [ "${PUBLISHED_GIT_HEAD}" = "${GITHUB_SHA}" ]
+}
+
+rc_publish_package_dir() {
+  PACKAGE_DIR="$1"
+  PACKAGE_NAME="$(jq -r '.name' "${PACKAGE_DIR}/package.json")"
+  if npm view "${PACKAGE_NAME}@${VERSION}" version 2>/dev/null; then
+    echo "::notice::${PACKAGE_NAME}@${VERSION} already published to npm; skipping publish"
+    return 0
+  fi
+
+  echo "Publishing ${PACKAGE_NAME}@${VERSION} with rc tag"
+  (cd "${PACKAGE_DIR}" && npm publish --provenance --access public --tag rc)
+}
+
+release_publish_package_dir() {
+  PACKAGE_DIR="$1"
+  PACKAGE_NAME="$(jq -r '.name' "${PACKAGE_DIR}/package.json")"
+  PUBLISHED_GIT_HEAD="$(npm view "${PACKAGE_NAME}@${VERSION}" gitHead 2>/dev/null || true)"
+  if [ "${PUBLISHED_GIT_HEAD}" = "${GITHUB_SHA}" ]; then
+    echo "${PACKAGE_NAME}@${VERSION} is already published for this commit; skipping npm publish."
+  else
+    echo "Publishing ${PACKAGE_NAME}@${VERSION}"
+    set +e
+    PUBLISH_OUTPUT="$(cd "${PACKAGE_DIR}" && npm publish --provenance --access public 2>&1)"
+    PUBLISH_STATUS=$?
+    set -e
+    printf '%s\n' "${PUBLISH_OUTPUT}"
+
+    if [ "${PUBLISH_STATUS}" -ne 0 ]; then
+      if printf '%s\n' "${PUBLISH_OUTPUT}" | grep -Fq "previously published versions: ${VERSION}" \
+        && wait_for_npm_git_head "${PACKAGE_NAME}"; then
+        echo "npm reports ${PACKAGE_NAME}@${VERSION} already exists, and gitHead matches this commit; continuing."
+      else
+        exit "${PUBLISH_STATUS}"
+      fi
+    fi
+  fi
+
+  if ! wait_for_npm_git_head "${PACKAGE_NAME}"; then
+    echo "::error::Published ${PACKAGE_NAME}@${VERSION} gitHead is ${PUBLISHED_GIT_HEAD}, expected ${GITHUB_SHA}."
+    exit 1
+  fi
+}
+
+run_rc_publish() {
+  require_env VERSION
+
+  for PACKAGE_DIR in $(package_dirs); do
+    update_package_version "${PACKAGE_DIR}"
+  done
+
+  for PACKAGE_DIR in $(package_dirs); do
+    rc_publish_package_dir "${PACKAGE_DIR}"
+  done
+}
+
+run_preflight() {
+  require_env VERSION GITHUB_SHA
+
+  for PACKAGE_NAME in $(package_names_from_workspace); do
+    if npm view "${PACKAGE_NAME}@${VERSION}" version 2>/dev/null; then
+      if ! wait_for_npm_git_head "${PACKAGE_NAME}"; then
+        echo "::error::${PACKAGE_NAME}@${VERSION} already exists on npm for ${PUBLISHED_GIT_HEAD}. Bump deno.json before releasing."
+        exit 1
+      fi
+      echo "${PACKAGE_NAME}@${VERSION} already exists on npm for this commit; continuing release metadata."
+    fi
+  done
+}
+
+run_release_publish() {
+  require_env VERSION GITHUB_SHA
+
+  for PACKAGE_DIR in $(package_dirs); do
+    update_package_version "${PACKAGE_DIR}"
+  done
+
+  for PACKAGE_DIR in $(package_dirs); do
+    release_publish_package_dir "${PACKAGE_DIR}"
+  done
+}
+
+MODE="${1:-}"
+case "${MODE}" in
+  rc-publish) run_rc_publish ;;
+  preflight) run_preflight ;;
+  release-publish) run_release_publish ;;
+  *) usage ;;
+esac

--- a/src/security/repository-hardening.test.ts
+++ b/src/security/repository-hardening.test.ts
@@ -81,13 +81,22 @@ describe("repository hardening", () => {
 
   it("keeps npm publishing tokenless and provenance-backed", async () => {
     const workflow = await readText(".github/workflows/cicd.yml");
+    // The publish commands live in the shared CI script; the workflow only
+    // invokes its modes with OIDC credentials.
+    const publishScript = await readText("scripts/ci/publish-npm-packages.sh");
 
     assertEquals(workflow.includes("secrets.NPM_TOKEN"), false);
     assertEquals(workflow.includes("NODE_AUTH_TOKEN"), false);
     assert(workflow.includes("id-token: write"));
     assert(workflow.includes("package-manager-cache: false"));
-    assert(workflow.includes("npm publish --provenance --access public --tag rc"));
-    assert(workflow.includes("npm publish --provenance --access public 2>&1"));
+    assert(workflow.includes("scripts/ci/publish-npm-packages.sh rc-publish"));
+    assert(workflow.includes("scripts/ci/publish-npm-packages.sh preflight"));
+    assert(workflow.includes("scripts/ci/publish-npm-packages.sh release-publish"));
+
+    assertEquals(publishScript.includes("NPM_TOKEN"), false);
+    assertEquals(publishScript.includes("NODE_AUTH_TOKEN"), false);
+    assert(publishScript.includes("npm publish --provenance --access public --tag rc"));
+    assert(publishScript.includes("npm publish --provenance --access public 2>&1"));
   });
 
   it("uses scoped GitHub App tokens instead of release PATs", async () => {


### PR DESCRIPTION
## Summary

Follow-ups from the #2719 review, deferred out of the release push:

1. **One publish script instead of three inline copies** — `scripts/ci/publish-npm-packages.sh` with `rc-publish` / `preflight` / `release-publish` modes replaces the triplicated shell in cicd.yml (−131 lines of workflow shell). Behavior-preserving: same npm commands, skip conditions, gitHead polling, and error semantics.
2. **Missing-dependency build guard** — `normalizeExtensionPackageJson` replaces dnt-discovered deps with manifest-derived ones; a dep reached through the module graph but absent from the extension manifest previously published green and failed at install. The build now scans every emitted `esm/**/*.js` for bare imports and throws if any package is undeclared, with file attribution.
3. **Side-effect-import fix** — the `removeUnusedBundledRootSource` reference scan missed `import "../../src/x.js";` (side-effect-only form), which could delete bundled root modules still in use.

The `repository hardening` security test now asserts the tokenless/provenance publish contract against both the workflow (script invocations, id-token) and the script itself (publish commands, no token env references).

## Verification

- `deno test --config=scripts/test.deno.json` on both metadata test files (new specifier-extraction tests included)
- `deno test src/security/repository-hardening.test.ts` (updated for the script split)
- Full `deno task build:npm` — the new guard passes on all 15 real extension packages (no false positives)
- `bash scripts/test/npm-install-smoke.sh` against the build output
- `bash -n` on the script; workflow YAML parses; preflight mode dry-ran against the registry (16 package names, exit 0)
- Pre-push hook: full suite green