### PR TITLE
[codex] Fix OpenAI reasoning defaults

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.987",
+  "version": "0.1.988",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/extensions/ext-llm-openai/README.md
+++ b/extensions/ext-llm-openai/README.md
@@ -57,7 +57,7 @@ Any model accessible through the OpenAI Chat Completions, Responses, or Embeddin
 
 - **Flagship:** `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`
 - **Frontier:** `gpt-5`, `gpt-5-mini`, `gpt-5-nano`
-- **Reasoning:** `o3`, `o4-mini`, `o1`, `o1-mini`, `o3-mini` (sampling parameters are automatically dropped with warnings)
+- **Reasoning:** `gpt-5.4-nano`, current `gpt-5`/`gpt-5.x` reasoning models, `o3`, `o4-mini`, `o1`, `o3-mini` (sampling parameters are automatically dropped with warnings)
 - **Embeddings:** `text-embedding-3-small`, `text-embedding-3-large`
 - **OpenAI-compatible:** Any third-party model reachable via an OpenAI-compatible endpoint (set `OPENAI_BASE_URL`)
 
@@ -74,7 +74,11 @@ The extension accepts configuration through `LLMProviderConfig` when creating ru
 
 ## Model-Specific Behavior
 
-### Reasoning Models (o3, o4-mini, o1)
+### Reasoning Models (GPT-5.x, o3, o4-mini, o1)
+
+Default reasoning params are applied only for native `openai` and `veryfront-cloud` providers.
+OpenAI-compatible providers require explicit `reasoning` options. `gpt-5-chat-latest`,
+`gpt-5.1`, `o1-mini`, and `o1-preview` are left unmodified by default.
 
 Reasoning models automatically:
 

--- a/extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts
+++ b/extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts
@@ -80,11 +80,11 @@ describe("ext-llm-openai/openai-chat-request-builder", () => {
     );
 
     assertEquals(body.reasoning_effort, undefined);
-    assertEquals(body.temperature, 0.2);
-    assertEquals(warnings.drain(), []);
+    assertEquals(body.temperature, undefined);
+    assertEquals(warnings.drain().map((warning) => warning.setting), ["temperature"]);
   });
 
-  it("does not set default reasoning effort for OpenAI-compatible providers", () => {
+  it("does not set default reasoning effort for OpenAI-compatible providers but still drops rejected sampling params", () => {
     const warnings = createWarningCollector();
 
     const body = buildOpenAIChatRequest(
@@ -99,8 +99,28 @@ describe("ext-llm-openai/openai-chat-request-builder", () => {
     );
 
     assertEquals(body.reasoning_effort, undefined);
-    assertEquals(body.temperature, 0.2);
-    assertEquals(warnings.drain(), []);
+    assertEquals(body.temperature, undefined);
+    assertEquals(warnings.drain().map((warning) => warning.setting), ["temperature"]);
+  });
+
+  it("drops rejected sampling params when explicit reasoning is disabled", () => {
+    const warnings = createWarningCollector();
+
+    const body = buildOpenAIChatRequest(
+      "o3-mini",
+      "openai",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Be concise." }] }],
+        reasoning: { enabled: false },
+        temperature: 0.2,
+      },
+      true,
+      warnings,
+    );
+
+    assertEquals(body.reasoning_effort, undefined);
+    assertEquals(body.temperature, undefined);
+    assertEquals(warnings.drain().map((warning) => warning.setting), ["temperature"]);
   });
 
   it("preserves chat request shaping, provider option merge order, and warnings", () => {

--- a/extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts
+++ b/extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts
@@ -27,6 +27,25 @@ function createWarningCollector() {
 }
 
 describe("ext-llm-openai/openai-chat-request-builder", () => {
+  it("sets default reasoning effort for GPT-5.5 chat requests", () => {
+    const warnings = createWarningCollector();
+
+    const body = buildOpenAIChatRequest(
+      "gpt-5.5",
+      "openai",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Think carefully." }] }],
+        temperature: 0.2,
+      },
+      true,
+      warnings,
+    );
+
+    assertEquals(body.reasoning_effort, "medium");
+    assertEquals(body.temperature, undefined);
+    assertEquals(warnings.drain().map((warning) => warning.setting), ["temperature"]);
+  });
+
   it("preserves chat request shaping, provider option merge order, and warnings", () => {
     const prompt: RuntimePromptMessage[] = [
       { role: "system", content: "You are concise." },

--- a/extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts
+++ b/extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts
@@ -46,6 +46,63 @@ describe("ext-llm-openai/openai-chat-request-builder", () => {
     assertEquals(warnings.drain().map((warning) => warning.setting), ["temperature"]);
   });
 
+  it("does not set default reasoning effort for GPT-5 chat snapshots", () => {
+    const warnings = createWarningCollector();
+
+    const body = buildOpenAIChatRequest(
+      "gpt-5-chat-latest",
+      "openai",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Be concise." }] }],
+        temperature: 0.2,
+      },
+      true,
+      warnings,
+    );
+
+    assertEquals(body.reasoning_effort, undefined);
+    assertEquals(body.temperature, 0.2);
+    assertEquals(warnings.drain(), []);
+  });
+
+  it("does not set default reasoning effort for legacy o1 chat variants", () => {
+    const warnings = createWarningCollector();
+
+    const body = buildOpenAIChatRequest(
+      "o1-mini",
+      "openai",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Be concise." }] }],
+        temperature: 0.2,
+      },
+      true,
+      warnings,
+    );
+
+    assertEquals(body.reasoning_effort, undefined);
+    assertEquals(body.temperature, 0.2);
+    assertEquals(warnings.drain(), []);
+  });
+
+  it("does not set default reasoning effort for OpenAI-compatible providers", () => {
+    const warnings = createWarningCollector();
+
+    const body = buildOpenAIChatRequest(
+      "gpt-5.5",
+      "azure",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Be concise." }] }],
+        temperature: 0.2,
+      },
+      true,
+      warnings,
+    );
+
+    assertEquals(body.reasoning_effort, undefined);
+    assertEquals(body.temperature, 0.2);
+    assertEquals(warnings.drain(), []);
+  });
+
   it("preserves chat request shaping, provider option merge order, and warnings", () => {
     const prompt: RuntimePromptMessage[] = [
       { role: "system", content: "You are concise." },

--- a/extensions/ext-llm-openai/src/openai-chat-request-builder.ts
+++ b/extensions/ext-llm-openai/src/openai-chat-request-builder.ts
@@ -5,6 +5,11 @@ import {
   unwrapToolInputSchema,
 } from "veryfront/provider/shared";
 import type { OpenAICompatibleChatRequest, RuntimePromptMessage } from "veryfront/provider/shared";
+import {
+  getDefaultOpenAIReasoningEffort,
+  isOpenAIReasoningModel,
+  type OpenAIReasoningEffort,
+} from "./openai-reasoning-models.ts";
 
 type ProviderReasoningEffort = "low" | "medium" | "high" | "max";
 
@@ -75,10 +80,6 @@ type WarningCollector = {
   }>;
 };
 
-function isOpenAIReasoningModel(modelId: string): boolean {
-  return /^o[134](-|$)/.test(modelId);
-}
-
 function isNativeOpenAIModel(modelId: string): boolean {
   return /^(gpt-|o[134](-|$)|chatgpt-)/.test(modelId);
 }
@@ -89,8 +90,12 @@ function isFixedSamplingModel(modelId: string): boolean {
 
 function resolveOpenAIReasoningEffort(
   option: ProviderReasoningOption | undefined,
-): "low" | "medium" | "high" | undefined {
-  if (!option || option.enabled !== true) {
+  defaultEffort: OpenAIReasoningEffort | undefined,
+): OpenAIReasoningEffort | undefined {
+  if (!option) {
+    return defaultEffort;
+  }
+  if (option.enabled !== true) {
     return undefined;
   }
   switch (option.effort) {
@@ -113,7 +118,10 @@ export function buildOpenAIChatRequest(
   warnings: WarningCollector,
 ): OpenAICompatibleChatRequest {
   const isReasoningModel = isOpenAIReasoningModel(modelId);
-  const reasoningEffort = resolveOpenAIReasoningEffort(options.reasoning);
+  const reasoningEffort = resolveOpenAIReasoningEffort(
+    options.reasoning,
+    getDefaultOpenAIReasoningEffort(modelId),
+  );
   const reasoningEnabled = isReasoningModel || reasoningEffort !== undefined;
   const fixedSampling = isFixedSamplingModel(modelId);
   const dropSamplingParams = reasoningEnabled || fixedSampling;
@@ -128,7 +136,7 @@ export function buildOpenAIChatRequest(
     });
   }
 
-  // Reasoning models (o1 / o3 / o4) and models with fixed sampling params
+  // Reasoning models and models with fixed sampling params
   // reject sampling params outright. Emit warnings.
   if (dropSamplingParams) {
     const dropped: Array<[keyof typeof options, string]> = [

--- a/extensions/ext-llm-openai/src/openai-chat-request-builder.ts
+++ b/extensions/ext-llm-openai/src/openai-chat-request-builder.ts
@@ -6,18 +6,9 @@ import {
 } from "veryfront/provider/shared";
 import type { OpenAICompatibleChatRequest, RuntimePromptMessage } from "veryfront/provider/shared";
 import {
-  getDefaultOpenAIReasoningEffort,
-  isOpenAIReasoningModel,
-  type OpenAIReasoningEffort,
+  type OpenAIProviderReasoningOption,
+  resolveOpenAIReasoningConfig,
 } from "./openai-reasoning-models.ts";
-
-type ProviderReasoningEffort = "low" | "medium" | "high" | "max";
-
-type ProviderReasoningOption = {
-  enabled?: boolean;
-  effort?: ProviderReasoningEffort;
-  budgetTokens?: number;
-};
 
 export type RuntimeToolDefinition =
   | {
@@ -49,7 +40,7 @@ export type OpenAICompatibleLanguageOptions = {
   providerOptions?: Record<string, unknown>;
   includeRawChunks?: boolean;
   abortSignal?: AbortSignal;
-  reasoning?: ProviderReasoningOption;
+  reasoning?: OpenAIProviderReasoningOption;
   userId?: string;
   serviceTier?: "auto" | "default" | "flex" | "scale";
   parallelToolCalls?: boolean;
@@ -88,28 +79,6 @@ function isFixedSamplingModel(modelId: string): boolean {
   return /^kimi-k2\.5/.test(modelId);
 }
 
-function resolveOpenAIReasoningEffort(
-  option: ProviderReasoningOption | undefined,
-  defaultEffort: OpenAIReasoningEffort | undefined,
-): OpenAIReasoningEffort | undefined {
-  if (!option) {
-    return defaultEffort;
-  }
-  if (option.enabled !== true) {
-    return undefined;
-  }
-  switch (option.effort) {
-    case "low":
-      return "low";
-    case "high":
-    case "max":
-      return "high";
-    case "medium":
-    default:
-      return "medium";
-  }
-}
-
 export function buildOpenAIChatRequest(
   modelId: string,
   providerName: string,
@@ -117,12 +86,8 @@ export function buildOpenAIChatRequest(
   stream: boolean,
   warnings: WarningCollector,
 ): OpenAICompatibleChatRequest {
-  const isReasoningModel = isOpenAIReasoningModel(modelId);
-  const reasoningEffort = resolveOpenAIReasoningEffort(
-    options.reasoning,
-    getDefaultOpenAIReasoningEffort(modelId),
-  );
-  const reasoningEnabled = isReasoningModel || reasoningEffort !== undefined;
+  const reasoning = resolveOpenAIReasoningConfig(modelId, providerName, options.reasoning);
+  const reasoningEnabled = reasoning !== undefined;
   const fixedSampling = isFixedSamplingModel(modelId);
   const dropSamplingParams = reasoningEnabled || fixedSampling;
 
@@ -186,7 +151,7 @@ export function buildOpenAIChatRequest(
     ...(!dropSamplingParams && options.frequencyPenalty !== undefined
       ? { frequency_penalty: options.frequencyPenalty }
       : {}),
-    ...(reasoningEffort !== undefined ? { reasoning_effort: reasoningEffort } : {}),
+    ...(reasoning !== undefined ? { reasoning_effort: reasoning.effort } : {}),
     ...(typeof options.userId === "string" && options.userId.length > 0
       ? { user: options.userId }
       : {}),

--- a/extensions/ext-llm-openai/src/openai-chat-request-builder.ts
+++ b/extensions/ext-llm-openai/src/openai-chat-request-builder.ts
@@ -7,6 +7,7 @@ import {
 import type { OpenAICompatibleChatRequest, RuntimePromptMessage } from "veryfront/provider/shared";
 import {
   type OpenAIProviderReasoningOption,
+  rejectsOpenAISamplingParams,
   resolveOpenAIReasoningConfig,
 } from "./openai-reasoning-models.ts";
 
@@ -88,8 +89,9 @@ export function buildOpenAIChatRequest(
 ): OpenAICompatibleChatRequest {
   const reasoning = resolveOpenAIReasoningConfig(modelId, providerName, options.reasoning);
   const reasoningEnabled = reasoning !== undefined;
+  const samplingRejected = rejectsOpenAISamplingParams(modelId);
   const fixedSampling = isFixedSamplingModel(modelId);
-  const dropSamplingParams = reasoningEnabled || fixedSampling;
+  const dropSamplingParams = reasoningEnabled || samplingRejected || fixedSampling;
 
   // OpenAI Chat Completions has no top_k surface.
   if (options.topK !== undefined) {
@@ -118,7 +120,9 @@ export function buildOpenAIChatRequest(
           setting: key,
           details: fixedSampling
             ? `Dropped because this model uses fixed sampling parameters.`
-            : `Dropped because OpenAI reasoning models reject ${openaiName}. Reasoning was active for this request.`,
+            : samplingRejected
+            ? `Dropped because this model rejects ${openaiName}.`
+            : `Dropped because reasoning was active for this request and OpenAI rejects ${openaiName} with reasoning.`,
         });
       }
     }

--- a/extensions/ext-llm-openai/src/openai-reasoning-models.test.ts
+++ b/extensions/ext-llm-openai/src/openai-reasoning-models.test.ts
@@ -1,0 +1,33 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { getDefaultOpenAIReasoningEffort } from "./openai-reasoning-models.ts";
+
+describe("ext-llm-openai/openai-reasoning-models", () => {
+  it("defaults known reasoning models while excluding chat snapshots and legacy o1 variants", () => {
+    const cases: Array<[string, "medium" | undefined]> = [
+      ["gpt-5", "medium"],
+      ["gpt-5-mini", "medium"],
+      ["gpt-5.4-nano", "medium"],
+      ["gpt-5.5", "medium"],
+      ["gpt-5.1", undefined],
+      ["gpt-5-chat-latest", undefined],
+      ["o1", "medium"],
+      ["o1-2024-12-17", "medium"],
+      ["o1-mini", undefined],
+      ["o1-preview", undefined],
+      ["o3-mini", "medium"],
+      ["o4-mini", "medium"],
+    ];
+
+    for (const [modelId, expected] of cases) {
+      assertEquals(getDefaultOpenAIReasoningEffort(modelId), expected, modelId);
+    }
+  });
+
+  it("only enables default reasoning params for native OpenAI providers", () => {
+    assertEquals(getDefaultOpenAIReasoningEffort("gpt-5.4-nano", "openai"), "medium");
+    assertEquals(getDefaultOpenAIReasoningEffort("gpt-5.4-nano", "veryfront-cloud"), "medium");
+    assertEquals(getDefaultOpenAIReasoningEffort("gpt-5.4-nano", "azure"), undefined);
+    assertEquals(getDefaultOpenAIReasoningEffort("gpt-5.4-nano", "moonshot"), undefined);
+  });
+});

--- a/extensions/ext-llm-openai/src/openai-reasoning-models.test.ts
+++ b/extensions/ext-llm-openai/src/openai-reasoning-models.test.ts
@@ -1,6 +1,9 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { getDefaultOpenAIReasoningEffort } from "./openai-reasoning-models.ts";
+import {
+  getDefaultOpenAIReasoningEffort,
+  rejectsOpenAISamplingParams,
+} from "./openai-reasoning-models.ts";
 
 describe("ext-llm-openai/openai-reasoning-models", () => {
   it("defaults known reasoning models while excluding chat snapshots and legacy o1 variants", () => {
@@ -29,5 +32,28 @@ describe("ext-llm-openai/openai-reasoning-models", () => {
     assertEquals(getDefaultOpenAIReasoningEffort("gpt-5.4-nano", "veryfront-cloud"), "medium");
     assertEquals(getDefaultOpenAIReasoningEffort("gpt-5.4-nano", "azure"), undefined);
     assertEquals(getDefaultOpenAIReasoningEffort("gpt-5.4-nano", "moonshot"), undefined);
+  });
+
+  it("detects models that reject sampling params separately from default reasoning params", () => {
+    const cases: Array<[string, boolean]> = [
+      ["gpt-5", true],
+      ["gpt-5-mini", true],
+      ["gpt-5.4-nano", true],
+      ["gpt-5.5", true],
+      ["gpt-5.1", false],
+      ["gpt-5-chat-latest", false],
+      ["o1", true],
+      ["o1-2024-12-17", true],
+      ["o1-mini", true],
+      ["o1-preview", true],
+      ["o1-pro", true],
+      ["o3-mini", true],
+      ["o4-mini", true],
+      ["gpt-4o-mini", false],
+    ];
+
+    for (const [modelId, expected] of cases) {
+      assertEquals(rejectsOpenAISamplingParams(modelId), expected, modelId);
+    }
   });
 });

--- a/extensions/ext-llm-openai/src/openai-reasoning-models.ts
+++ b/extensions/ext-llm-openai/src/openai-reasoning-models.ts
@@ -19,6 +19,27 @@ function supportsDefaultReasoningParams(providerName: string): boolean {
   return providerName === "openai" || providerName === "veryfront-cloud";
 }
 
+function isGpt5ChatSnapshot(modelId: string): boolean {
+  return /^gpt-5-chat($|-)/.test(modelId);
+}
+
+function isGpt51(modelId: string): boolean {
+  return /^gpt-5\.1($|-)/.test(modelId);
+}
+
+function isReasoningCapableGpt5(modelId: string): boolean {
+  if (isGpt5ChatSnapshot(modelId) || isGpt51(modelId)) {
+    return false;
+  }
+
+  if (/^gpt-5(-|$)/.test(modelId)) {
+    return true;
+  }
+
+  const gpt5Version = /^gpt-5\.(\d+)(-|$)/.exec(modelId)?.[1];
+  return gpt5Version !== undefined && Number.parseInt(gpt5Version, 10) >= 2;
+}
+
 export function getDefaultOpenAIReasoningEffort(
   modelId: string,
   providerName = "openai",
@@ -30,12 +51,12 @@ export function getDefaultOpenAIReasoningEffort(
     return undefined;
   }
 
-  if (/^gpt-5-chat($|-)/.test(normalized)) {
+  if (isGpt5ChatSnapshot(normalized)) {
     return undefined;
   }
 
   // GPT-5.1 defaults upstream reasoning to none unless callers opt in explicitly.
-  if (/^gpt-5\.1($|-)/.test(normalized)) {
+  if (isGpt51(normalized)) {
     return undefined;
   }
 
@@ -43,12 +64,7 @@ export function getDefaultOpenAIReasoningEffort(
     return DEFAULT_REASONING_EFFORT;
   }
 
-  if (/^gpt-5(-|$)/.test(normalized)) {
-    return DEFAULT_REASONING_EFFORT;
-  }
-
-  const gpt5Version = /^gpt-5\.(\d+)(-|$)/.exec(normalized)?.[1];
-  if (gpt5Version && Number.parseInt(gpt5Version, 10) >= 2) {
+  if (isReasoningCapableGpt5(normalized)) {
     return DEFAULT_REASONING_EFFORT;
   }
 
@@ -90,4 +106,10 @@ export function shouldRequestOpenAIReasoningSummary(
 
 export function isOpenAIReasoningModel(modelId: string, providerName = "openai"): boolean {
   return getDefaultOpenAIReasoningEffort(modelId, providerName) !== undefined;
+}
+
+export function rejectsOpenAISamplingParams(modelId: string): boolean {
+  const normalized = modelId.toLowerCase();
+
+  return /^o[134]($|-)/.test(normalized) || isReasoningCapableGpt5(normalized);
 }

--- a/extensions/ext-llm-openai/src/openai-reasoning-models.ts
+++ b/extensions/ext-llm-openai/src/openai-reasoning-models.ts
@@ -1,13 +1,45 @@
 export type OpenAIReasoningEffort = "low" | "medium" | "high";
 
+export type OpenAIProviderReasoningEffort = OpenAIReasoningEffort | "max";
+
+export type OpenAIProviderReasoningOption = {
+  enabled?: boolean;
+  effort?: OpenAIProviderReasoningEffort;
+  budgetTokens?: number;
+};
+
+export type ResolvedOpenAIReasoning = {
+  effort: OpenAIReasoningEffort;
+  source: "default" | "explicit";
+};
+
 const DEFAULT_REASONING_EFFORT: OpenAIReasoningEffort = "medium";
+
+function supportsDefaultReasoningParams(providerName: string): boolean {
+  return providerName === "openai" || providerName === "veryfront-cloud";
+}
 
 export function getDefaultOpenAIReasoningEffort(
   modelId: string,
+  providerName = "openai",
 ): OpenAIReasoningEffort | undefined {
   const normalized = modelId.toLowerCase();
+  const normalizedProvider = providerName.toLowerCase();
 
-  if (/^o[134](-|$)/.test(normalized)) {
+  if (!supportsDefaultReasoningParams(normalizedProvider)) {
+    return undefined;
+  }
+
+  if (/^gpt-5-chat($|-)/.test(normalized)) {
+    return undefined;
+  }
+
+  // GPT-5.1 defaults upstream reasoning to none unless callers opt in explicitly.
+  if (/^gpt-5\.1($|-)/.test(normalized)) {
+    return undefined;
+  }
+
+  if (/^o1($|-\d)/.test(normalized) || /^o[34](-|$)/.test(normalized)) {
     return DEFAULT_REASONING_EFFORT;
   }
 
@@ -23,6 +55,39 @@ export function getDefaultOpenAIReasoningEffort(
   return undefined;
 }
 
-export function isOpenAIReasoningModel(modelId: string): boolean {
-  return getDefaultOpenAIReasoningEffort(modelId) !== undefined;
+export function resolveOpenAIReasoningConfig(
+  modelId: string,
+  providerName: string,
+  option: OpenAIProviderReasoningOption | undefined,
+): ResolvedOpenAIReasoning | undefined {
+  if (!option) {
+    const effort = getDefaultOpenAIReasoningEffort(modelId, providerName);
+    return effort === undefined ? undefined : { effort, source: "default" };
+  }
+
+  if (option.enabled !== true) {
+    return undefined;
+  }
+
+  switch (option.effort) {
+    case "low":
+      return { effort: "low", source: "explicit" };
+    case "high":
+    case "max":
+      return { effort: "high", source: "explicit" };
+    case "medium":
+    default:
+      return { effort: "medium", source: "explicit" };
+  }
+}
+
+export function shouldRequestOpenAIReasoningSummary(
+  providerName: string,
+  reasoning: ResolvedOpenAIReasoning,
+): boolean {
+  return reasoning.source === "explicit" || providerName.toLowerCase() === "veryfront-cloud";
+}
+
+export function isOpenAIReasoningModel(modelId: string, providerName = "openai"): boolean {
+  return getDefaultOpenAIReasoningEffort(modelId, providerName) !== undefined;
 }

--- a/extensions/ext-llm-openai/src/openai-reasoning-models.ts
+++ b/extensions/ext-llm-openai/src/openai-reasoning-models.ts
@@ -1,0 +1,28 @@
+export type OpenAIReasoningEffort = "low" | "medium" | "high";
+
+const DEFAULT_REASONING_EFFORT: OpenAIReasoningEffort = "medium";
+
+export function getDefaultOpenAIReasoningEffort(
+  modelId: string,
+): OpenAIReasoningEffort | undefined {
+  const normalized = modelId.toLowerCase();
+
+  if (/^o[134](-|$)/.test(normalized)) {
+    return DEFAULT_REASONING_EFFORT;
+  }
+
+  if (/^gpt-5(-|$)/.test(normalized)) {
+    return DEFAULT_REASONING_EFFORT;
+  }
+
+  const gpt5Version = /^gpt-5\.(\d+)(-|$)/.exec(normalized)?.[1];
+  if (gpt5Version && Number.parseInt(gpt5Version, 10) >= 2) {
+    return DEFAULT_REASONING_EFFORT;
+  }
+
+  return undefined;
+}
+
+export function isOpenAIReasoningModel(modelId: string): boolean {
+  return getDefaultOpenAIReasoningEffort(modelId) !== undefined;
+}

--- a/extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts
+++ b/extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts
@@ -27,6 +27,25 @@ function createWarningCollector() {
 }
 
 describe("ext-llm-openai/openai-responses-request-builder", () => {
+  it("requests reasoning summaries by default for GPT-5.5 Responses models", () => {
+    const warnings = createWarningCollector();
+
+    const body = buildOpenAIResponsesRequest(
+      "gpt-5.5",
+      "openai",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Think carefully." }] }],
+        temperature: 0.2,
+      },
+      true,
+      warnings,
+    );
+
+    assertEquals(body.reasoning, { effort: "medium", summary: "auto" });
+    assertEquals(body.temperature, undefined);
+    assertEquals(warnings.drain().map((warning) => warning.setting), ["temperature"]);
+  });
+
   it("preserves Responses request shaping, provider option merge order, and warnings", () => {
     const prompt: RuntimePromptMessage[] = [
       { role: "system", content: "You are concise." },

--- a/extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts
+++ b/extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts
@@ -27,12 +27,12 @@ function createWarningCollector() {
 }
 
 describe("ext-llm-openai/openai-responses-request-builder", () => {
-  it("requests reasoning summaries by default for GPT-5.5 Responses models", () => {
+  it("requests reasoning summaries by default for Veryfront Cloud GPT-5.5 Responses models", () => {
     const warnings = createWarningCollector();
 
     const body = buildOpenAIResponsesRequest(
       "gpt-5.5",
-      "openai",
+      "veryfront-cloud",
       {
         prompt: [{ role: "user", content: [{ type: "text", text: "Think carefully." }] }],
         temperature: 0.2,
@@ -44,6 +44,58 @@ describe("ext-llm-openai/openai-responses-request-builder", () => {
     assertEquals(body.reasoning, { effort: "medium", summary: "auto" });
     assertEquals(body.temperature, undefined);
     assertEquals(warnings.drain().map((warning) => warning.setting), ["temperature"]);
+  });
+
+  it("omits reasoning summaries for direct OpenAI default reasoning requests", () => {
+    const warnings = createWarningCollector();
+
+    const body = buildOpenAIResponsesRequest(
+      "gpt-5.5",
+      "openai",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Think carefully." }] }],
+      },
+      true,
+      warnings,
+    );
+
+    assertEquals(body.reasoning, { effort: "medium" });
+  });
+
+  it("keeps explicit reasoning summaries for direct OpenAI requests", () => {
+    const warnings = createWarningCollector();
+
+    const body = buildOpenAIResponsesRequest(
+      "gpt-5.5",
+      "openai",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Think carefully." }] }],
+        reasoning: { enabled: true, effort: "high" },
+      },
+      true,
+      warnings,
+    );
+
+    assertEquals(body.reasoning, { effort: "high", summary: "auto" });
+  });
+
+  it("does not set default reasoning for OpenAI-compatible provider Responses requests", () => {
+    const warnings = createWarningCollector();
+
+    const body = buildOpenAIResponsesRequest(
+      "gpt-5.5",
+      "azure",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Think carefully." }] }],
+        temperature: 0.2,
+      },
+      true,
+      warnings,
+    );
+
+    assertEquals(body.reasoning, undefined);
+    assertEquals(body.temperature, 0.2);
+    assertEquals(warnings.drain(), []);
   });
 
   it("preserves Responses request shaping, provider option merge order, and warnings", () => {

--- a/extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts
+++ b/extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts
@@ -79,7 +79,7 @@ describe("ext-llm-openai/openai-responses-request-builder", () => {
     assertEquals(body.reasoning, { effort: "high", summary: "auto" });
   });
 
-  it("does not set default reasoning for OpenAI-compatible provider Responses requests", () => {
+  it("does not set default reasoning for OpenAI-compatible providers but still drops rejected sampling params", () => {
     const warnings = createWarningCollector();
 
     const body = buildOpenAIResponsesRequest(
@@ -94,8 +94,28 @@ describe("ext-llm-openai/openai-responses-request-builder", () => {
     );
 
     assertEquals(body.reasoning, undefined);
-    assertEquals(body.temperature, 0.2);
-    assertEquals(warnings.drain(), []);
+    assertEquals(body.temperature, undefined);
+    assertEquals(warnings.drain().map((warning) => warning.setting), ["temperature"]);
+  });
+
+  it("drops rejected sampling params when explicit reasoning is disabled", () => {
+    const warnings = createWarningCollector();
+
+    const body = buildOpenAIResponsesRequest(
+      "o3-mini",
+      "openai",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Think carefully." }] }],
+        reasoning: { enabled: false },
+        temperature: 0.2,
+      },
+      true,
+      warnings,
+    );
+
+    assertEquals(body.reasoning, undefined);
+    assertEquals(body.temperature, undefined);
+    assertEquals(warnings.drain().map((warning) => warning.setting), ["temperature"]);
   });
 
   it("preserves Responses request shaping, provider option merge order, and warnings", () => {

--- a/extensions/ext-llm-openai/src/openai-responses-request-builder.ts
+++ b/extensions/ext-llm-openai/src/openai-responses-request-builder.ts
@@ -9,6 +9,7 @@ import type {
   RuntimeToolDefinition,
 } from "./openai-chat-request-builder.ts";
 import {
+  rejectsOpenAISamplingParams,
   resolveOpenAIReasoningConfig,
   shouldRequestOpenAIReasoningSummary,
 } from "./openai-reasoning-models.ts";
@@ -197,6 +198,8 @@ export function buildOpenAIResponsesRequest(
 ): OpenAIResponsesRequest {
   const reasoning = resolveOpenAIReasoningConfig(modelId, providerName, options.reasoning);
   const reasoningEnabled = reasoning !== undefined;
+  const samplingRejected = rejectsOpenAISamplingParams(modelId);
+  const dropSamplingParams = reasoningEnabled || samplingRejected;
 
   if (options.topK !== undefined) {
     warnings.push({
@@ -206,7 +209,7 @@ export function buildOpenAIResponsesRequest(
       details: "OpenAI Responses API does not expose top_k; the value was dropped.",
     });
   }
-  if (reasoningEnabled) {
+  if (dropSamplingParams) {
     const dropped: Array<[keyof typeof options, string]> = [
       ["temperature", "temperature"],
       ["topP", "top_p"],
@@ -219,8 +222,9 @@ export function buildOpenAIResponsesRequest(
           type: "unsupported-setting",
           provider: "openai",
           setting: key,
-          details:
-            `Dropped because OpenAI reasoning models reject ${openaiName}. Reasoning was active for this request.`,
+          details: samplingRejected
+            ? `Dropped because this model rejects ${openaiName}.`
+            : `Dropped because reasoning was active for this request and OpenAI rejects ${openaiName} with reasoning.`,
         });
       }
     }
@@ -237,10 +241,10 @@ export function buildOpenAIResponsesRequest(
     ...(options.maxOutputTokens !== undefined
       ? { max_output_tokens: options.maxOutputTokens }
       : {}),
-    ...(!reasoningEnabled && options.temperature !== undefined
+    ...(!dropSamplingParams && options.temperature !== undefined
       ? { temperature: options.temperature }
       : {}),
-    ...(!reasoningEnabled && options.topP !== undefined ? { top_p: options.topP } : {}),
+    ...(!dropSamplingParams && options.topP !== undefined ? { top_p: options.topP } : {}),
     ...(responsesTools ? { tools: responsesTools } : {}),
     ...(options.toolChoice !== undefined ? { tool_choice: options.toolChoice } : {}),
     ...(reasoning !== undefined

--- a/extensions/ext-llm-openai/src/openai-responses-request-builder.ts
+++ b/extensions/ext-llm-openai/src/openai-responses-request-builder.ts
@@ -9,12 +9,9 @@ import type {
   RuntimeToolDefinition,
 } from "./openai-chat-request-builder.ts";
 import {
-  getDefaultOpenAIReasoningEffort,
-  isOpenAIReasoningModel,
-  type OpenAIReasoningEffort,
+  resolveOpenAIReasoningConfig,
+  shouldRequestOpenAIReasoningSummary,
 } from "./openai-reasoning-models.ts";
-
-type ProviderReasoningOption = OpenAICompatibleLanguageOptions["reasoning"];
 
 export type OpenAIResponsesInputItem = Record<string, unknown>;
 
@@ -51,28 +48,6 @@ type WarningCollector = {
     provider: string;
   }>;
 };
-
-function resolveOpenAIReasoningEffort(
-  option: ProviderReasoningOption | undefined,
-  defaultEffort: OpenAIReasoningEffort | undefined,
-): OpenAIReasoningEffort | undefined {
-  if (!option) {
-    return defaultEffort;
-  }
-  if (option.enabled !== true) {
-    return undefined;
-  }
-  switch (option.effort) {
-    case "low":
-      return "low";
-    case "high":
-    case "max":
-      return "high";
-    case "medium":
-    default:
-      return "medium";
-  }
-}
 
 function toSnakeCaseRecord(record: Record<string, unknown>): Record<string, unknown> {
   return Object.fromEntries(
@@ -220,12 +195,8 @@ export function buildOpenAIResponsesRequest(
   stream: boolean,
   warnings: WarningCollector,
 ): OpenAIResponsesRequest {
-  const isReasoningModel = isOpenAIReasoningModel(modelId);
-  const reasoningEffort = resolveOpenAIReasoningEffort(
-    options.reasoning,
-    getDefaultOpenAIReasoningEffort(modelId),
-  );
-  const reasoningEnabled = isReasoningModel || reasoningEffort !== undefined;
+  const reasoning = resolveOpenAIReasoningConfig(modelId, providerName, options.reasoning);
+  const reasoningEnabled = reasoning !== undefined;
 
   if (options.topK !== undefined) {
     warnings.push({
@@ -272,8 +243,15 @@ export function buildOpenAIResponsesRequest(
     ...(!reasoningEnabled && options.topP !== undefined ? { top_p: options.topP } : {}),
     ...(responsesTools ? { tools: responsesTools } : {}),
     ...(options.toolChoice !== undefined ? { tool_choice: options.toolChoice } : {}),
-    ...(reasoningEffort !== undefined
-      ? { reasoning: { effort: reasoningEffort, summary: "auto" } }
+    ...(reasoning !== undefined
+      ? {
+        reasoning: {
+          effort: reasoning.effort,
+          ...(shouldRequestOpenAIReasoningSummary(providerName, reasoning)
+            ? { summary: "auto" }
+            : {}),
+        },
+      }
       : {}),
     ...(typeof options.userId === "string" && options.userId.length > 0
       ? { user: options.userId }

--- a/extensions/ext-llm-openai/src/openai-responses-request-builder.ts
+++ b/extensions/ext-llm-openai/src/openai-responses-request-builder.ts
@@ -8,6 +8,11 @@ import type {
   OpenAICompatibleLanguageOptions,
   RuntimeToolDefinition,
 } from "./openai-chat-request-builder.ts";
+import {
+  getDefaultOpenAIReasoningEffort,
+  isOpenAIReasoningModel,
+  type OpenAIReasoningEffort,
+} from "./openai-reasoning-models.ts";
 
 type ProviderReasoningOption = OpenAICompatibleLanguageOptions["reasoning"];
 
@@ -47,14 +52,14 @@ type WarningCollector = {
   }>;
 };
 
-function isOpenAIReasoningModel(modelId: string): boolean {
-  return /^o[134](-|$)/.test(modelId);
-}
-
 function resolveOpenAIReasoningEffort(
   option: ProviderReasoningOption | undefined,
-): "low" | "medium" | "high" | undefined {
-  if (!option || option.enabled !== true) {
+  defaultEffort: OpenAIReasoningEffort | undefined,
+): OpenAIReasoningEffort | undefined {
+  if (!option) {
+    return defaultEffort;
+  }
+  if (option.enabled !== true) {
     return undefined;
   }
   switch (option.effort) {
@@ -216,7 +221,10 @@ export function buildOpenAIResponsesRequest(
   warnings: WarningCollector,
 ): OpenAIResponsesRequest {
   const isReasoningModel = isOpenAIReasoningModel(modelId);
-  const reasoningEffort = resolveOpenAIReasoningEffort(options.reasoning);
+  const reasoningEffort = resolveOpenAIReasoningEffort(
+    options.reasoning,
+    getDefaultOpenAIReasoningEffort(modelId),
+  );
   const reasoningEnabled = isReasoningModel || reasoningEffort !== undefined;
 
   if (options.topK !== undefined) {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.987";
+export const VERSION = "0.1.988";


### PR DESCRIPTION
## Summary
- Default native OpenAI/Veryfront Cloud reasoning-capable GPT-5 models to `medium`, including `gpt-5.4-nano`.
- Centralize OpenAI reasoning resolution for Chat and Responses so model/provider handling cannot drift.
- Exclude `gpt-5-chat-latest`, `gpt-5.1`, `o1-mini`, and `o1-preview` from default reasoning params; callers can still opt in explicitly with `reasoning`.
- Limit Responses API default `summary: "auto"` to `veryfront-cloud`; direct OpenAI/BYOK defaults now send only `effort`, while explicit `reasoning` still requests summaries.
- Keep compatible providers such as Azure/Moonshot free of default reasoning params unless explicitly requested.
- Decouple sampling-param drops from default-reasoning policy so o-series/GPT-5 models that reject sampling still drop temperature/top_p even when no default effort is sent.

Refs veryfront/veryfront-studio#5486
Refs veryfront/veryfront-studio#5258

## Red / Green transcript
Initial RED:
- `deno test -A extensions/ext-llm-openai/src/openai-reasoning-models.test.ts extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts`
- Failed as expected before the first fix: `gpt-5-chat-latest`, `o1-mini`, and Azure-compatible Chat requests were still getting `reasoning_effort: "medium"`; direct OpenAI Responses defaults still included `summary: "auto"`; Azure-compatible Responses requests still emitted default `reasoning`.

Review-feedback RED:
- Same command failed after adding the sampling-drop review tests because the new `rejectsOpenAISamplingParams` helper did not exist yet; the new assertions require `o1-mini`, Azure GPT-5.5, and explicit `reasoning: { enabled: false }` o-series requests to drop temperature while still omitting default reasoning params.

GREEN:
- Same command -> `3 passed (15 steps)`.

## Verification
- `deno test -A extensions/ext-llm-openai/src/openai-reasoning-models.test.ts extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts` -> `3 passed (15 steps)`.
- `deno test -A extensions/ext-llm-openai/src/openai-provider.test.ts extensions/ext-llm-openai/src/openai-chat-stream.test.ts extensions/ext-llm-openai/src/openai-responses-stream.test.ts` -> `3 passed (48 steps)`.
- `deno fmt --check` on touched OpenAI TS files -> `Checked 6 files`.
- `deno lint` on touched OpenAI TS files -> `Checked 6 files`.
- `git diff --check` -> clean.
- GitHub PR checks on `36572662c` -> passed: format, lint, typecheck, unit, integration, binary e2e, RSC browser e2e, npm install smoke, coverage shards/gate, CodeQL, dependency audit, CLA.

## Local broad check note
- Local `deno task verify:quick` still fails on unrelated pre-existing CLI boundary violations after manifest, fmt, lint, and style checks pass: `cli/shared/ensure-content-processor.ts`, `cli/shared/default-contracts.ts`, and `cli/commands/knowledge/parser.ts` deep-import `#veryfront/extensions/first-party-import.ts`.

## Staging proof
This branch is not deployed to staging yet. After staging deploy, proof should be: run a `veryfront-cloud/openai/gpt-5.4-nano` or `veryfront-cloud/openai/gpt-5.5` chat and verify the run events endpoint contains `REASONING_MESSAGE_START`, `REASONING_MESSAGE_CONTENT`, and `REASONING_MESSAGE_END` before `RUN_FINISHED`.