### PR TITLE
Wire OTLP tracing SDK in standalone proxy startup

### DIFF
--- a/src/proxy/tracing.test.ts
+++ b/src/proxy/tracing.test.ts
@@ -1,0 +1,235 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertNotEquals } from "#veryfront/testing/assert";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd";
+import {
+  _resetShimForTests,
+  getGlobalTracerProvider,
+  type Span,
+  type Tracer,
+} from "#veryfront/observability/tracing/api-shim.ts";
+import type { TracingExporter } from "#veryfront/extensions/observability/tracing-exporter.ts";
+import {
+  _resetOTLPForTests,
+  initializeOTLPWithApis,
+  resolveOtlpGate,
+  shutdownOTLP,
+  startServerSpan,
+} from "./tracing.ts";
+
+const OTEL_ENV_KEYS = [
+  "OTEL_TRACES_ENABLED",
+  "OTEL_SERVICE_NAME",
+  "OTEL_EXPORTER_OTLP_ENDPOINT",
+  "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+] as const;
+
+function setOtelEnv(vars: Partial<Record<(typeof OTEL_ENV_KEYS)[number], string>>): void {
+  for (const key of OTEL_ENV_KEYS) {
+    const value = vars[key];
+    if (value === undefined) Deno.env.delete(key);
+    else Deno.env.set(key, value);
+  }
+}
+
+function createFakeSpan(): Span {
+  return {
+    setAttribute: () => createFakeSpan(),
+    setAttributes: () => createFakeSpan(),
+    setStatus: () => createFakeSpan(),
+    recordException: () => {},
+    addEvent: () => createFakeSpan(),
+    end: () => {},
+    spanContext: () => ({ traceId: "0".repeat(32), spanId: "0".repeat(16), traceFlags: 1 }),
+    updateName: () => {},
+  } as unknown as Span;
+}
+
+function createFakeExporter(overrides: Partial<TracingExporter> = {}): {
+  exporter: TracingExporter;
+  calls: { start: number; shutdown: number };
+} {
+  const calls = { start: 0, shutdown: 0 };
+  const fakeTracer: Tracer = {
+    startSpan: () => createFakeSpan(),
+    startActiveSpan: ((_name: string, ...rest: unknown[]) => {
+      const fn = rest.find((arg) => typeof arg === "function") as
+        | ((span: Span) => unknown)
+        | undefined;
+      return fn?.(createFakeSpan());
+    }) as Tracer["startActiveSpan"],
+  };
+  const exporter: TracingExporter = {
+    // deno-lint-ignore require-await
+    start: async () => {
+      calls.start++;
+    },
+    // deno-lint-ignore require-await
+    export: async () => {},
+    // deno-lint-ignore require-await
+    shutdown: async () => {
+      calls.shutdown++;
+    },
+    getProvider: () => ({ getTracer: () => fakeTracer }),
+    getMetricsAPI: () => null,
+    getTraceAPI: () => null,
+    ...overrides,
+  };
+  return { exporter, calls };
+}
+
+describe("proxy otlp gate", () => {
+  it('disables tracing when OTEL_TRACES_ENABLED is not "true"', () => {
+    const gate = resolveOtlpGate({ enabled: false, endpoint: "http://collector" });
+    assertEquals(gate.ok, false);
+    if (!gate.ok) assertEquals(gate.reason.includes("OTEL_TRACES_ENABLED"), true);
+  });
+
+  it("disables tracing when no OTLP endpoint is configured", () => {
+    const gate = resolveOtlpGate({ enabled: true, endpoint: "" });
+    assertEquals(gate.ok, false);
+    if (!gate.ok) assertEquals(gate.reason.includes("OTLP endpoint"), true);
+  });
+
+  it("passes when tracing is enabled and an endpoint is set", () => {
+    assertEquals(resolveOtlpGate({ enabled: true, endpoint: "http://collector" }).ok, true);
+  });
+});
+
+describe("proxy otlp initialization", () => {
+  const savedEnv = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const key of OTEL_ENV_KEYS) savedEnv.set(key, Deno.env.get(key));
+    _resetOTLPForTests();
+    _resetShimForTests();
+  });
+
+  afterEach(async () => {
+    await shutdownOTLP();
+    _resetOTLPForTests();
+    _resetShimForTests();
+    for (const [key, value] of savedEnv) {
+      if (value === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, value);
+    }
+  });
+
+  it("does not load the exporter when tracing is disabled", async () => {
+    setOtelEnv({});
+    let loaderCalls = 0;
+    // deno-lint-ignore require-await
+    await initializeOTLPWithApis(async () => {
+      loaderCalls++;
+      return createFakeExporter().exporter;
+    });
+
+    assertEquals(loaderCalls, 0);
+    assertEquals(startServerSpan("GET", "/"), null);
+  });
+
+  it("starts the exporter and wires the shim provider when enabled", async () => {
+    setOtelEnv({
+      OTEL_TRACES_ENABLED: "true",
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://127.0.0.1:9",
+      OTEL_SERVICE_NAME: "proxy-test",
+    });
+    const { exporter, calls } = createFakeExporter();
+    const noopProvider = getGlobalTracerProvider();
+
+    // deno-lint-ignore require-await
+    await initializeOTLPWithApis(async () => exporter);
+
+    assertEquals(calls.start, 1);
+    assertNotEquals(getGlobalTracerProvider(), noopProvider);
+    assertNotEquals(startServerSpan("GET", "/"), null);
+  });
+
+  it("prefers OTEL_EXPORTER_OTLP_TRACES_ENDPOINT as the endpoint gate", async () => {
+    setOtelEnv({
+      OTEL_TRACES_ENABLED: "true",
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://127.0.0.1:9/v1/traces",
+    });
+    const { exporter, calls } = createFakeExporter();
+
+    // deno-lint-ignore require-await
+    await initializeOTLPWithApis(async () => exporter);
+
+    assertEquals(calls.start, 1);
+    assertNotEquals(startServerSpan("GET", "/"), null);
+  });
+
+  it("degrades gracefully when the exporter cannot be loaded", async () => {
+    setOtelEnv({
+      OTEL_TRACES_ENABLED: "true",
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://127.0.0.1:9",
+    });
+
+    // deno-lint-ignore require-await
+    await initializeOTLPWithApis(async () => null);
+
+    assertEquals(startServerSpan("GET", "/"), null);
+  });
+
+  it("does not throw when exporter startup fails", async () => {
+    setOtelEnv({
+      OTEL_TRACES_ENABLED: "true",
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://127.0.0.1:9",
+    });
+    const { exporter } = createFakeExporter({
+      start: () => Promise.reject(new Error("collector unreachable")),
+    });
+
+    // deno-lint-ignore require-await
+    await initializeOTLPWithApis(async () => exporter);
+
+    assertEquals(startServerSpan("GET", "/"), null);
+  });
+
+  it("initializes only once", async () => {
+    setOtelEnv({
+      OTEL_TRACES_ENABLED: "true",
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://127.0.0.1:9",
+    });
+    const { exporter, calls } = createFakeExporter();
+    // deno-lint-ignore require-await
+    const loader = async (): Promise<TracingExporter | null> => exporter;
+
+    await initializeOTLPWithApis(loader);
+    await initializeOTLPWithApis(loader);
+
+    assertEquals(calls.start, 1);
+  });
+
+  it("flushes the exporter on shutdown and deactivates spans", async () => {
+    setOtelEnv({
+      OTEL_TRACES_ENABLED: "true",
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://127.0.0.1:9",
+    });
+    const { exporter, calls } = createFakeExporter();
+    // deno-lint-ignore require-await
+    await initializeOTLPWithApis(async () => exporter);
+
+    await shutdownOTLP();
+
+    assertEquals(calls.shutdown, 1);
+    assertEquals(startServerSpan("GET", "/"), null);
+  });
+
+  it("shutdown is safe when tracing was never initialized", async () => {
+    await shutdownOTLP();
+  });
+
+  it("shutdown swallows exporter shutdown failures", async () => {
+    setOtelEnv({
+      OTEL_TRACES_ENABLED: "true",
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://127.0.0.1:9",
+    });
+    const { exporter } = createFakeExporter({
+      shutdown: () => Promise.reject(new Error("flush failed")),
+    });
+    // deno-lint-ignore require-await
+    await initializeOTLPWithApis(async () => exporter);
+
+    await shutdownOTLP();
+  });
+});

--- a/src/proxy/tracing.ts
+++ b/src/proxy/tracing.ts
@@ -1,11 +1,15 @@
 /****
  * OpenTelemetry OTLP tracing for proxy.
  *
- * Uses the core api-shim for in-process tracing; when ext-observability-opentelemetry
- * is loaded, the shim delegates to the real SDK provider.
+ * The standalone proxy (split mode) does not run the server bootstrap, so it
+ * wires the OTLP SDK itself: it loads ext-observability-opentelemetry, starts
+ * its `OtlpTracingExporter`, and registers the SDK provider with the core
+ * api-shim BEFORE caching a tracer. Without this wiring the shim only ever
+ * hands out no-op tracers and nothing is exported (issue #2723).
  *
  * Env: OTEL_TRACES_ENABLED, OTEL_SERVICE_NAME, OTEL_EXPORTER_OTLP_ENDPOINT,
- *      OTEL_EXPORTER_OTLP_HEADERS
+ *      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, OTEL_EXPORTER_OTLP_HEADERS
+ * (endpoint/headers are consumed by the extension itself.)
  */
 
 import {
@@ -14,6 +18,9 @@ import {
   defaultTextMapGetter,
   defaultTextMapSetter,
   propagation as shimPropagation,
+  setGlobalActiveSpanAccessor,
+  setGlobalMetricsAPI,
+  setGlobalTracerProvider,
   type Span,
   SpanKind,
   SpanStatusCode,
@@ -21,61 +28,149 @@ import {
   type Tracer,
 } from "#veryfront/observability/tracing/api-shim.ts";
 import { getHostTelemetryEnv } from "#veryfront/observability/tracing/telemetry-env.ts";
+import type { TracingExporter } from "#veryfront/extensions/observability/tracing-exporter.ts";
+import {
+  importFirstPartyExtensionModule,
+  isMissingFirstPartyExtensionModule,
+} from "#veryfront/extensions/first-party-import.ts";
 import { proxyLogger } from "./logger.ts";
+
+const TRACING_EXTENSION_SOURCE_DIRECTORY = "ext-observability-opentelemetry";
+const TRACING_EXTENSION_PACKAGE = "@veryfront/ext-observability-opentelemetry";
 
 let initialized = false;
 let tracer: Tracer | null = null;
+let exporter: TracingExporter | null = null;
 
 interface OTLPConfig {
   serviceName: string;
   endpoint: string;
-  headers: Record<string, string>;
   enabled: boolean;
-}
-
-function parseHeaders(headerString: string | undefined): Record<string, string> {
-  if (!headerString) return {};
-
-  const headers: Record<string, string> = {};
-  for (const part of headerString.split(",")) {
-    const [key, ...valueParts] = part.split("=");
-    if (!key || valueParts.length === 0) continue;
-    headers[key.trim()] = valueParts.join("=").trim();
-  }
-  return headers;
 }
 
 function getConfig(): OTLPConfig {
   return {
     enabled: getHostTelemetryEnv("OTEL_TRACES_ENABLED") === "true",
     serviceName: getHostTelemetryEnv("OTEL_SERVICE_NAME") || "veryfront-proxy",
-    endpoint: getHostTelemetryEnv("OTEL_EXPORTER_OTLP_ENDPOINT") || "",
-    headers: parseHeaders(getHostTelemetryEnv("OTEL_EXPORTER_OTLP_HEADERS")),
+    // The extension prefers the traces-specific endpoint; mirror that here so
+    // the gate agrees with what the exporter will actually use.
+    endpoint: getHostTelemetryEnv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") ||
+      getHostTelemetryEnv("OTEL_EXPORTER_OTLP_ENDPOINT") || "",
   };
 }
 
-export async function initializeOTLPWithApis(): Promise<void> {
+export type OtlpGateResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Decide whether OTLP tracing should be initialized for this process.
+ * Pure so the decision (and its logged reason) is unit-testable.
+ */
+export function resolveOtlpGate(
+  config: { enabled: boolean; endpoint: string },
+): OtlpGateResult {
+  if (!config.enabled) {
+    return { ok: false, reason: 'Tracing disabled: OTEL_TRACES_ENABLED is not "true"' };
+  }
+  if (!config.endpoint) {
+    return {
+      ok: false,
+      reason:
+        "Tracing disabled: no OTLP endpoint (set OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)",
+    };
+  }
+  return { ok: true };
+}
+
+type TracingExporterModule = {
+  OtlpTracingExporter: new () => TracingExporter;
+};
+
+/**
+ * Load the OTLP tracing exporter from ext-observability-opentelemetry.
+ *
+ * Resolves the workspace source in repo/binary runs and the npm package in
+ * Node installs. Returns `null` (after logging why) when the extension is not
+ * installed or fails to load — telemetry must never crash the proxy.
+ */
+async function loadTracingExporter(): Promise<TracingExporter | null> {
+  try {
+    const mod = await importFirstPartyExtensionModule<TracingExporterModule>(
+      TRACING_EXTENSION_SOURCE_DIRECTORY,
+      TRACING_EXTENSION_PACKAGE,
+    );
+    if (typeof mod.OtlpTracingExporter !== "function") {
+      proxyLogger.warn(
+        `[otel] Tracing disabled: ${TRACING_EXTENSION_PACKAGE} has no OtlpTracingExporter export`,
+      );
+      return null;
+    }
+    return new mod.OtlpTracingExporter();
+  } catch (error) {
+    if (
+      isMissingFirstPartyExtensionModule(error, [
+        `extensions/${TRACING_EXTENSION_SOURCE_DIRECTORY}/src/index`,
+        TRACING_EXTENSION_PACKAGE,
+      ])
+    ) {
+      proxyLogger.warn(
+        `[otel] Tracing disabled: ${TRACING_EXTENSION_PACKAGE} is not installed; install it alongside veryfront to export traces`,
+      );
+      return null;
+    }
+    proxyLogger.error("[otel] Failed to load tracing extension", error);
+    return null;
+  }
+}
+
+/**
+ * Initialize OTLP tracing for the standalone proxy.
+ *
+ * Loads ext-observability-opentelemetry, starts its exporter, wires the SDK
+ * provider (plus metrics API and active-span accessor) into the core shim,
+ * and only then caches a tracer. Logs `[otel] Initialized` only when a real
+ * provider is wired; otherwise logs why tracing is disabled. Never throws.
+ *
+ * @param loadExporter Test seam; production callers use the default loader.
+ */
+export async function initializeOTLPWithApis(
+  loadExporter: () => Promise<TracingExporter | null> = loadTracingExporter,
+): Promise<void> {
   if (initialized) return;
+  initialized = true;
 
   const config = getConfig();
-
-  if (!config.enabled) {
-    initialized = true;
-    return;
-  }
-
-  if (!config.endpoint) {
-    proxyLogger.warn("[otel] No endpoint configured");
-    initialized = true;
+  const gate = resolveOtlpGate(config);
+  if (!gate.ok) {
+    proxyLogger.info(`[otel] ${gate.reason}`);
     return;
   }
 
   try {
-    // The shim's provider is wired by ext-observability-opentelemetry via bootstrap.ts.
-    // We simply get a tracer from the shim — it delegates to the real SDK
-    // when the extension is active, otherwise returns the no-op tracer.
+    const exporterImpl = await loadExporter();
+    if (!exporterImpl) return; // loader already logged the reason
+
+    // The exporter reads OTEL_* env itself (endpoint, headers, signal gates)
+    // and creates the SDK tracer provider with a batch OTLP span processor.
+    await exporterImpl.start({});
+    exporter = exporterImpl;
+
+    // Wire the shim globals before getTracer() — the tracer is cached below,
+    // so wiring afterwards would freeze the no-op tracer forever.
+    setGlobalTracerProvider(
+      exporterImpl.getProvider() as Parameters<typeof setGlobalTracerProvider>[0],
+    );
+    const metricsApi = exporterImpl.getMetricsAPI();
+    if (metricsApi) {
+      setGlobalMetricsAPI(metricsApi as Parameters<typeof setGlobalMetricsAPI>[0]);
+    }
+    const traceApi = exporterImpl.getTraceAPI?.();
+    if (traceApi) {
+      setGlobalActiveSpanAccessor(
+        traceApi as Parameters<typeof setGlobalActiveSpanAccessor>[0],
+      );
+    }
+
     tracer = shimTrace.getTracer(config.serviceName);
-    initialized = true;
 
     proxyLogger.info("[otel] Initialized", {
       serviceName: config.serviceName,
@@ -83,12 +178,32 @@ export async function initializeOTLPWithApis(): Promise<void> {
     });
   } catch (error) {
     proxyLogger.error("[otel] Init failed", error);
-    initialized = true;
   }
 }
 
+/** Flush pending spans and release the exporter. Safe to call when disabled. */
 export async function shutdownOTLP(): Promise<void> {
+  const active = exporter;
+  exporter = null;
+  tracer = null;
+
+  if (active) {
+    try {
+      await active.shutdown();
+    } catch (error) {
+      proxyLogger.warn("[otel] Exporter shutdown failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
   proxyLogger.info("[otel] Shutdown complete");
+}
+
+/** Reset module state between tests. Mirrors api-shim's `_resetShimForTests`. */
+export function _resetOTLPForTests(): void {
+  initialized = false;
+  tracer = null;
+  exporter = null;
 }
 
 export function extractContext(headers: Headers): Context | undefined {


### PR DESCRIPTION
## Summary

Fixes #2723. The split-mode proxy never ran the server bootstrap, so `ext-observability-opentelemetry` never loaded and the tracing shim kept its no-op provider forever — while logging a misleading `[otel] Initialized`. The proxy has never exported a single trace despite `OTEL_TRACES_ENABLED=true`.

`initializeOTLPWithApis()` now loads the extension's `OtlpTracingExporter` via `importFirstPartyExtensionModule` (workspace source in repo/binary runs, `@veryfront/ext-observability-opentelemetry` in npm installs), starts it, and wires the SDK provider into the api-shim **before** caching a tracer. Missing extension → clear warning naming the package, proxy keeps serving. `shutdownOTLP()` now flushes batched spans on SIGTERM. `[otel] Initialized` is only logged when a real provider is wired; otherwise the disabled reason is logged.

## Verification

- New `src/proxy/tracing.test.ts` (12 steps): gate decision, shim wiring, graceful degradation, idempotency, shutdown flush
- Full `src/proxy` suite: 27 passed (214 steps)
- **Runtime smoke**: proxy from source against a fake OTLP collector — with the flag on, collector received the batch export + the SIGTERM flush and the proxy logged `[otel] Initialized`; with the flag off, healthy boot, honest disabled log, zero collector requests
- fmt / lint / check clean; `first-party-import` tests green

## After merge

Once deployed, add `veryfront-proxy` / `veryfront-proxy-staging` to the "Telemetry Health" alert group in Grafana (currently excluded because they would fire immediately).