### PR TITLE
Release 0.1.988

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.987",
+  "version": "0.1.988",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.987";
+export const VERSION = "0.1.988";


### PR DESCRIPTION
Ships the standalone proxy OTLP tracing fix (#2723 / #2728) — the proxy exports traces for the first time. Also the **first release through the consolidated `scripts/ci/publish-npm-packages.sh` pipeline** from #2725 (rc-publish → preflight → release-publish modes), worth watching for that reason. After the release, the server image auto-builds against it and the staging proxy should start tracing; the Telemetry Health alert group then gains `veryfront-proxy` entries.