### PR TITLE
Release veryfront 0.1.989

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.988",
+  "version": "0.1.989",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.988";
+export const VERSION = "0.1.989";


### PR DESCRIPTION
## Summary
- Bump `veryfront` from `0.1.988` to `0.1.989`.
- Keep `src/utils/version-constant.ts` in sync with `deno.json`.
- Unblock the post-merge release job after PR #2727, which failed because `0.1.988` already exists on npm for `f8dc476196bd3b222bd0d906605f6ada99837b51`.

## Test Plan
- `deno test --preload=src/schemas/_test-setup.ts --allow-all src/utils/version.test.ts`
- `VERSION=0.1.989 GITHUB_SHA=$(git rev-parse HEAD) scripts/ci/publish-npm-packages.sh preflight`
- Pre-push hook with local OTEL/Grafana env unset: format, lint, typecheck, unit tests (`2223 passed`).