### PR TITLE
[codex] Fix Kreuzberg native runtime fallback

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.989",
+  "version": "0.1.990",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/extensions/ext-document-kreuzberg/src/index.test.ts
+++ b/extensions/ext-document-kreuzberg/src/index.test.ts
@@ -294,8 +294,7 @@ describe("ext-document-kreuzberg extension", () => {
     );
   });
 
-  it("falls back to the Deno worker when native PDF extraction is unavailable", async () => {
-    const workerCalls: Array<{ bytes: string; mimeType: string }> = [];
+  it("fails instead of using the OOM-prone PDF worker fallback when native extraction is unavailable", async () => {
     const deps: KreuzbergDocumentExtractorDeps = {
       isDenoRuntime: true,
       loadNativeKreuzberg: async () => {
@@ -303,17 +302,56 @@ describe("ext-document-kreuzberg extension", () => {
           cause: new Error("Cannot find module '@kreuzberg/node-linux-x64'"),
         });
       },
-      extractInWorkerDeno: async (buffer, mimeType) => {
-        workerCalls.push({ bytes: new TextDecoder().decode(buffer), mimeType });
-        return "worker pdf text";
+      extractInWorkerDeno: async () => {
+        throw new Error("worker should not be used for PDFs without native extraction");
       },
     };
     const extractor = new KreuzbergDocumentExtractor(deps);
     const buffer = new TextEncoder().encode("%PDF-1.4\n").buffer.slice(0) as ArrayBuffer;
 
-    const content = await extractor.extractInWorker(buffer, "application/pdf");
+    let error: unknown;
+    try {
+      await extractor.extractInWorker(buffer, "application/pdf");
+    } catch (caught) {
+      error = caught;
+    }
 
-    assertEquals(content, "worker pdf text");
-    assertEquals(workerCalls, [{ bytes: "%PDF-1.4\n", mimeType: "application/pdf" }]);
+    assertExists(error);
+    assertStringIncludes(
+      error instanceof Error ? error.message : String(error),
+      "Native document extraction is unavailable",
+    );
+  });
+
+  it("fails instead of using opaque extraction when progress native binding is unavailable", async () => {
+    const deps: KreuzbergDocumentExtractorDeps = {
+      isDenoRuntime: true,
+      extractWithNativeProgressDeno: async () => {
+        throw new Error(
+          "Failed to load Kreuzberg native bindings. Underlying error: Cannot find native binding.",
+        );
+      },
+      loadNativeKreuzberg: async () => ({
+        extractBytes: async () => ({ content: "opaque pdf text" }),
+      }),
+      extractInWorkerDeno: async () => {
+        throw new Error("worker should not be used when progress native binding is missing");
+      },
+    };
+    const extractor = new KreuzbergDocumentExtractor(deps);
+    const buffer = new TextEncoder().encode("%PDF-1.4\n").buffer.slice(0) as ArrayBuffer;
+
+    let error: unknown;
+    try {
+      await extractor.extractInWorker(buffer, "application/pdf", { onProgress: () => {} });
+    } catch (caught) {
+      error = caught;
+    }
+
+    assertExists(error);
+    assertStringIncludes(
+      error instanceof Error ? error.message : String(error),
+      "Native document extraction is unavailable",
+    );
   });
 });

--- a/extensions/ext-document-kreuzberg/src/index.ts
+++ b/extensions/ext-document-kreuzberg/src/index.ts
@@ -114,6 +114,13 @@ function warningDetails(mimeType: string, error: unknown): Record<string, string
   };
 }
 
+function createNativeBindingUnavailableError(error: unknown): Error {
+  return new Error(
+    "Native document extraction is unavailable because the Kreuzberg native binding could not be loaded. Install the Kreuzberg native package for this platform or disable document extraction for this file type.",
+    { cause: error },
+  );
+}
+
 function extractWithNativeProgressDeno(
   buffer: ArrayBuffer,
   mimeType: string,
@@ -232,6 +239,10 @@ export class KreuzbergDocumentExtractor implements DocumentExtractor {
           options,
         );
       } catch (error) {
+        if (isMissingPackageError(error)) {
+          throw createNativeBindingUnavailableError(error);
+        }
+
         // Keep progress opportunistic: if page/slide extraction cannot handle a
         // document, fall back to the previous opaque extraction path.
         const message =
@@ -253,7 +264,10 @@ export class KreuzbergDocumentExtractor implements DocumentExtractor {
           this.deps.loadNativeKreuzberg ?? loadKreuzbergNative,
         );
       } catch (error) {
-        if (!isMissingPackageError(error)) throw error;
+        if (isMissingPackageError(error)) {
+          throw createNativeBindingUnavailableError(error);
+        }
+        throw error;
       }
     }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.989";
+export const VERSION = "0.1.990";


### PR DESCRIPTION
## Summary

Fix the staging runtime failure found while proving `veryfront-studio#5484`:

- bump `veryfront` to `0.1.990`
- keep the native Kreuzberg PDF/PPT progress path, but stop falling back to the OOM-prone Deno worker path when the native binding is missing
- return a structured extraction failure instead of letting a large PDF push the server pod into OOMKilled/HTTP 502
- add regression tests for missing native bindings with and without progress extraction

## Root Cause

The post-merge staging proof did not reach successful PDF extraction. The runtime pod logged that `@kreuzberg/node` could not load its platform native binding, fell back to the previous opaque extraction path, then Kubernetes OOMKilled the `veryfront-server` pod. The API only surfaced that process death as `Runtime execution returned HTTP 502`.

## Verification

- `deno task test` in `extensions/ext-document-kreuzberg`
- `deno fmt --check deno.json src/utils/version-constant.ts extensions/ext-document-kreuzberg/src/index.ts extensions/ext-document-kreuzberg/src/index.test.ts`
- `git diff --check`
- pre-push hook with observability env unset: formatting, lint, typecheck, and unit tests: `2223 passed (19094 steps), 0 failed`

## Notes

This PR pairs with the `veryfront-server` PR that stages `@kreuzberg/node-linux-x64-gnu` into the server image so the native path is actually available in staging.
