### PR TITLE
[codex] Use text-only PDF extraction config

### DIFF
--- a/extensions/ext-document-kreuzberg/src/extraction-config.ts
+++ b/extensions/ext-document-kreuzberg/src/extraction-config.ts
@@ -1,0 +1,19 @@
+const PDF_TEXT_ONLY_EXTRACTION_CONFIG = {
+  images: { extractImages: false },
+  pdfOptions: {
+    extractImages: false,
+    extractMetadata: false,
+    extractAnnotations: false,
+    hierarchy: { enabled: false, includeBbox: false },
+  },
+} as const;
+
+function normalizeMimeType(mimeType: string): string {
+  return mimeType.toLowerCase().split(";")[0]?.trim() ?? "";
+}
+
+export function extractionConfigForMimeType(mimeType: string): Record<string, unknown> | undefined {
+  return normalizeMimeType(mimeType) === "application/pdf"
+    ? PDF_TEXT_ONLY_EXTRACTION_CONFIG
+    : undefined;
+}

--- a/extensions/ext-document-kreuzberg/src/index.test.ts
+++ b/extensions/ext-document-kreuzberg/src/index.test.ts
@@ -149,12 +149,12 @@ describe("ext-document-kreuzberg extension", () => {
   });
 
   it("uses native extraction for PDFs in Deno before falling back to the WASM worker", async () => {
-    const calls: Array<{ bytes: string; mimeType: string }> = [];
+    const calls: Array<{ bytes: string; mimeType: string; config: unknown }> = [];
     const deps: KreuzbergDocumentExtractorDeps = {
       isDenoRuntime: true,
       loadNativeKreuzberg: async () => ({
-        extractBytes: async (data, mimeType) => {
-          calls.push({ bytes: new TextDecoder().decode(data), mimeType });
+        extractBytes: async (data, mimeType, config) => {
+          calls.push({ bytes: new TextDecoder().decode(data), mimeType, config });
           return { content: "native pdf text" };
         },
       }),
@@ -168,7 +168,19 @@ describe("ext-document-kreuzberg extension", () => {
     const content = await extractor.extractInWorker(buffer, "application/pdf");
 
     assertEquals(content, "native pdf text");
-    assertEquals(calls, [{ bytes: "%PDF-1.4\n", mimeType: "application/pdf" }]);
+    assertEquals(calls, [{
+      bytes: "%PDF-1.4\n",
+      mimeType: "application/pdf",
+      config: {
+        images: { extractImages: false },
+        pdfOptions: {
+          extractImages: false,
+          extractMetadata: false,
+          extractAnnotations: false,
+          hierarchy: { enabled: false, includeBbox: false },
+        },
+      },
+    }]);
   });
 
   it("uses progress-capable native extraction for PDFs in Deno when progress is requested", async () => {
@@ -234,7 +246,7 @@ describe("ext-document-kreuzberg extension", () => {
   });
 
   it("falls back to the previous PDF extraction path when progress extraction fails", async () => {
-    const nativeCalls: Array<{ bytes: string; mimeType: string }> = [];
+    const nativeCalls: Array<{ bytes: string; mimeType: string; config: unknown }> = [];
     const warnings: Array<{ message: string; details: unknown[] }> = [];
     const deps: KreuzbergDocumentExtractorDeps = {
       isDenoRuntime: true,
@@ -247,8 +259,8 @@ describe("ext-document-kreuzberg extension", () => {
         throw new Error("page split failed");
       },
       loadNativeKreuzberg: async () => ({
-        extractBytes: async (data, mimeType) => {
-          nativeCalls.push({ bytes: new TextDecoder().decode(data), mimeType });
+        extractBytes: async (data, mimeType, config) => {
+          nativeCalls.push({ bytes: new TextDecoder().decode(data), mimeType, config });
           return { content: "native fallback pdf text" };
         },
       }),
@@ -264,7 +276,19 @@ describe("ext-document-kreuzberg extension", () => {
     });
 
     assertEquals(content, "native fallback pdf text");
-    assertEquals(nativeCalls, [{ bytes: "%PDF-1.4\n", mimeType: "application/pdf" }]);
+    assertEquals(nativeCalls, [{
+      bytes: "%PDF-1.4\n",
+      mimeType: "application/pdf",
+      config: {
+        images: { extractImages: false },
+        pdfOptions: {
+          extractImages: false,
+          extractMetadata: false,
+          extractAnnotations: false,
+          hierarchy: { enabled: false, includeBbox: false },
+        },
+      },
+    }]);
     assertEquals(warnings, [{
       message:
         "[ext-document-kreuzberg] native progress extraction failed; falling back to opaque extraction",

--- a/extensions/ext-document-kreuzberg/src/index.ts
+++ b/extensions/ext-document-kreuzberg/src/index.ts
@@ -15,6 +15,7 @@ import type {
   KreuzbergExtractor,
 } from "veryfront/extensions/compat";
 import { isMissingPackageError, loadKreuzberg, loadKreuzbergNative } from "./kreuzberg.ts";
+import { extractionConfigForMimeType } from "./extraction-config.ts";
 import { isDeno } from "./runtime.ts";
 
 /** Maximum time to wait for fallback worker extraction before aborting. */
@@ -98,7 +99,11 @@ async function extractWithNativeKreuzberg(
   loadNative: () => Promise<KreuzbergExtractor>,
 ): Promise<string> {
   const { extractBytes } = await loadNative();
-  const result = await extractBytes(new Uint8Array(buffer), mimeType);
+  const result = await extractBytes(
+    new Uint8Array(buffer),
+    mimeType,
+    extractionConfigForMimeType(mimeType),
+  );
   return result.content;
 }
 
@@ -220,7 +225,11 @@ export class KreuzbergDocumentExtractor implements DocumentExtractor {
     // PDF path can hang on valid large manuals.
     if (!isDenoRuntime) {
       const { extractBytes } = await loadKreuzberg();
-      const result = await extractBytes(new Uint8Array(buffer), mimeType);
+      const result = await extractBytes(
+        new Uint8Array(buffer),
+        mimeType,
+        extractionConfigForMimeType(mimeType),
+      );
       return result.content;
     }
 

--- a/extensions/ext-document-kreuzberg/src/kreuzberg.ts
+++ b/extensions/ext-document-kreuzberg/src/kreuzberg.ts
@@ -12,12 +12,8 @@
 import type { KreuzbergExtractor } from "veryfront/extensions/compat";
 import { isDeno } from "./runtime.ts";
 
-type KreuzbergModule = {
+type KreuzbergModule = KreuzbergExtractor & {
   initWasm?: () => Promise<void>;
-  extractBytes: (
-    data: Uint8Array,
-    mimeType: string,
-  ) => Promise<{ content: string }>;
 };
 
 export async function loadKreuzbergNative(): Promise<KreuzbergExtractor> {

--- a/extensions/ext-document-kreuzberg/src/native-progress-extraction-worker.ts
+++ b/extensions/ext-document-kreuzberg/src/native-progress-extraction-worker.ts
@@ -148,6 +148,7 @@ async function extractPdfByPage(buffer: ArrayBuffer): Promise<string> {
   const source = await PDFDocument.load(buffer, { ignoreEncryption: true });
   const total = source.getPageCount();
   const pages: string[] = [];
+  const pdfConfig = extractionConfigForMimeType("application/pdf");
 
   for (let index = 0; index < total; index += 1) {
     const singlePage = await PDFDocument.create();
@@ -157,7 +158,7 @@ async function extractPdfByPage(buffer: ArrayBuffer): Promise<string> {
     const result = await extractBytes(
       new Uint8Array(bytes),
       "application/pdf",
-      extractionConfigForMimeType("application/pdf"),
+      pdfConfig,
     );
     const content = result.content.trim();
     pages.push(content);

--- a/extensions/ext-document-kreuzberg/src/native-progress-extraction-worker.ts
+++ b/extensions/ext-document-kreuzberg/src/native-progress-extraction-worker.ts
@@ -12,6 +12,7 @@
 import { PDFDocument } from "pdf-lib";
 import JSZip from "jszip";
 import type { DocumentExtractionProgressEvent } from "veryfront/extensions/compat";
+import { extractionConfigForMimeType } from "./extraction-config.ts";
 import { loadKreuzbergNative } from "./kreuzberg.ts";
 
 interface ExtractRequest {
@@ -153,7 +154,11 @@ async function extractPdfByPage(buffer: ArrayBuffer): Promise<string> {
     const [page] = await singlePage.copyPages(source, [index]);
     singlePage.addPage(page);
     const bytes = await singlePage.save({ useObjectStreams: false });
-    const result = await extractBytes(new Uint8Array(bytes), "application/pdf");
+    const result = await extractBytes(
+      new Uint8Array(bytes),
+      "application/pdf",
+      extractionConfigForMimeType("application/pdf"),
+    );
     const content = result.content.trim();
     pages.push(content);
     postProgress({

--- a/extensions/ext-document-kreuzberg/src/upload-extraction-worker.ts
+++ b/extensions/ext-document-kreuzberg/src/upload-extraction-worker.ts
@@ -17,6 +17,7 @@
 /// <reference lib="deno.worker" />
 
 import { loadKreuzberg } from "./kreuzberg.ts";
+import { extractionConfigForMimeType } from "./extraction-config.ts";
 
 interface ExtractRequest {
   buffer: ArrayBuffer;
@@ -41,7 +42,11 @@ self.onmessage = async (event: MessageEvent<ExtractRequest>) => {
   try {
     const { buffer, mimeType } = event.data;
     const { extractBytes } = await loadKreuzberg();
-    const result = await extractBytes(new Uint8Array(buffer), mimeType);
+    const result = await extractBytes(
+      new Uint8Array(buffer),
+      mimeType,
+      extractionConfigForMimeType(mimeType),
+    );
     self.postMessage({ content: result.content } satisfies ExtractResponse);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/scripts/build/build-npm-extension-packages.ts
+++ b/scripts/build/build-npm-extension-packages.ts
@@ -308,7 +308,7 @@ async function transpileDocumentExtractionWorker(
       await Deno.mkdir(dirname(workerDest), { recursive: true });
       await Deno.writeTextFile(
         workerDest,
-        transpiled.code.replaceAll("./kreuzberg.ts", "./kreuzberg.js"),
+        rewriteLocalTypeScriptImports(transpiled.code),
       );
     }
     console.log(
@@ -317,6 +317,22 @@ async function transpileDocumentExtractionWorker(
   } finally {
     await esbuild.stop();
   }
+}
+
+function rewriteLocalTypeScriptImports(code: string): string {
+  const rewritten = code.replaceAll(
+    /(["'])\.\/([^"']+)\.ts\1/g,
+    "$1./$2.js$1",
+  );
+
+  const leftoverLocalTypeScriptImport = /["']\.\/[^"']+\.ts["']/;
+  if (leftoverLocalTypeScriptImport.test(rewritten)) {
+    throw new Error(
+      "Transpiled extraction worker still contains a local .ts import",
+    );
+  }
+
+  return rewritten;
 }
 
 async function* walkFiles(root: string): AsyncGenerator<string> {

--- a/src/extensions/compat/native-services.ts
+++ b/src/extensions/compat/native-services.ts
@@ -42,6 +42,7 @@ export interface KreuzbergExtractor {
   extractBytes(
     data: Uint8Array,
     mimeType: string,
+    config?: Record<string, unknown> | null,
   ): Promise<{ content: string }>;
 }
 

--- a/src/platform/compat/opaque-deps.ts
+++ b/src/platform/compat/opaque-deps.ts
@@ -18,7 +18,10 @@
 import { tryResolve } from "#veryfront/extensions/contracts.ts";
 import { isDeno } from "./runtime.ts";
 import { dynamicImport } from "./dynamic-import.ts";
-import type { DocumentExtractor } from "#veryfront/extensions/compat/native-services.ts";
+import type {
+  DocumentExtractor,
+  KreuzbergExtractor,
+} from "#veryfront/extensions/compat/native-services.ts";
 import { OPAQUE_DEPENDENCY_VERSIONS } from "./opaque-dependency-versions.ts";
 
 function resolve(pkg: string, version: string): string {
@@ -58,12 +61,7 @@ export function importClaudeAgentSDK(): Promise<OpaqueModule> {
  * Node/Bun path: `@kreuzberg/node` resolved from the project's node_modules at
  * runtime. The extension handles that dynamic import internally.
  */
-export async function importKreuzberg(): Promise<{
-  extractBytes: (
-    data: Uint8Array,
-    mimeType: string,
-  ) => Promise<{ content: string }>;
-}> {
+export async function importKreuzberg(): Promise<KreuzbergExtractor> {
   const extractor = tryResolve<DocumentExtractor>("DocumentExtractor");
   if (extractor?.importKreuzberg) {
     return extractor.importKreuzberg();


### PR DESCRIPTION
## What changed

- Pass a text-only Kreuzberg config for PDF extraction in native and worker paths.
- Disable PDF image, metadata, annotation, and hierarchy extraction for knowledge ingestion.
- Cover the native PDF path with regression assertions for the extraction config.

## Why

Staging proved the native binding now loads, but whole-document PDF extraction for the Bosch manual still consumed too much memory and hit runtime timeout/OOM behavior. Knowledge ingest only needs extracted text, so the PDF parser should avoid optional heavy extraction work.

## Verification

- `deno test --allow-all extensions/ext-document-kreuzberg/src/index.test.ts`
- `deno test --no-check --allow-all extensions/ext-document-kreuzberg/src/kreuzberg.integration.test.ts`
- `deno test --no-check --allow-all cli/commands/knowledge/command.test.ts`
- Local Bosch PDF smoke: 52 page progress events, one markdown output, 140147 markdown characters, ~1.6s
- Pre-push hook with ambient OTEL/Grafana vars cleared: formatting, lint, type check, generated assets, and 2223 unit tests passed

Refs veryfront/veryfront-studio#5484