### PR TITLE
[codex] Preserve agent service skills

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.989",
+  "version": "0.1.990",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/service/runtime.test.ts
+++ b/src/agent/service/runtime.test.ts
@@ -81,6 +81,41 @@ describe("agent/agent-service-runtime", () => {
     assertEquals(ready.status, 200);
   });
 
+  it("preserves configured skills and tools on the service agent", () => {
+    const bundle = createAgentServiceRuntime({
+      serviceName: "test-agent-service",
+      getConfig: () => ({
+        VERYFRONT_API_URL: "https://api.example.test",
+        NODE_ENV: "test",
+        PORT: 3180,
+        ALLOWED_ORIGINS: ["https://studio.example.test"],
+      }),
+      getAgentConfig: () => ({
+        id: "assistant",
+        name: "Assistant",
+        description: "",
+        instructions: "You are a test assistant.",
+        skills: ["support-triage"],
+        tools: ["search_knowledge", "get_file"],
+      }),
+      logger: createLogger(),
+      prepareExecution: async () => ({ ok: true }),
+      streamExecutionToAgUiResponse: () => new Response("streamed"),
+      startDetachedExecution: async () => {},
+    });
+
+    const serviceAgent = bundle.runtime.contract.agents.assistant;
+
+    assertEquals(serviceAgent?.config.skills, ["support-triage"]);
+    assertEquals(serviceAgent?.config.tools, {
+      search_knowledge: true,
+      get_file: true,
+      load_skill: true,
+      load_skill_reference: true,
+      execute_skill_script: true,
+    });
+  });
+
   it("starts the node agent service server from the assembled runtime", async () => {
     const service = await startNodeAgentService({
       serviceName: "node-test-agent-service",

--- a/src/agent/service/runtime.ts
+++ b/src/agent/service/runtime.ts
@@ -1,4 +1,5 @@
 import { agent } from "../factory.ts";
+import type { AgentConfig } from "../types.ts";
 import {
   type AgentServiceRoute,
   type AgentServiceRuntime,
@@ -171,6 +172,16 @@ function defaultTrace<TResult>(
   return operation();
 }
 
+function normalizeAgentServiceTools(
+  tools: RuntimeAgentMarkdownDefinition["tools"],
+): AgentConfig["tools"] {
+  if (tools === undefined || tools === true) {
+    return tools;
+  }
+
+  return Object.fromEntries(tools.map((toolId) => [toolId, true]));
+}
+
 function combineAgentServiceLifecycle(
   primary: AgentServiceServerLifecycle,
   secondary: AgentServiceServerLifecycle | undefined,
@@ -228,6 +239,9 @@ export function createAgentServiceRuntime<
       model: agentConfig.model,
       temperature: agentConfig.temperature,
       maxSteps: agentConfig.maxSteps,
+      providerTools: agentConfig.providerTools,
+      skills: agentConfig.skills,
+      tools: normalizeAgentServiceTools(agentConfig.tools),
     }),
     server: {
       port: config.PORT,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.989";
+export const VERSION = "0.1.990";


### PR DESCRIPTION
## Summary
- Preserve `skills`, `providerTools`, and selected `tools` when `createAgentServiceRuntime()` turns a runtime markdown agent config into a service agent.
- Normalize markdown `tools: string[]` into the agent factory boolean tool map so skill tools and project tools are both available.
- Add a regression test for the `support-triage` style project-agent config.

## Root Cause
Staging showed `AGENT_RUN_REQUEST_ENQUEUED.agentConfig.skills=["support-triage"]`, but `load_skill` returned `Skill "support-triage" not found. Available skills: none`. The API was enqueueing the config correctly; `veryfront-code` dropped `skills` and `tools` while creating the actual service agent.

## Staging Repro
Conversation: https://veryfront.org/projects/customer-operations-agent-1ee58d5f?panels=agents%2Cchat&chat=conv%3A05fa5fdf-7acd-4e79-b6e9-355d37e81d56&conversation_id=05fa5fdf-7acd-4e79-b6e9-355d37e81d56
Run: `run_stage_ops_project_1783025483038`
Issue: veryfront/veryfront-studio#5338

## Validation
- `deno test --allow-all src/agent/service/runtime.test.ts`
- `deno test --allow-all src/agent/factory.test.ts src/agent/service/runtime.test.ts`
- `deno fmt --check src/agent/service/runtime.ts src/agent/service/runtime.test.ts`
- `deno check src/agent/service/runtime.ts src/agent/service/runtime.test.ts`
- Pre-push hook with host OTEL/Grafana env unset: format, lint, typecheck, full unit suite: `2223 passed (19092 steps)`
