### PR TITLE
Fix default reasoning events for Veryfront Cloud models

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.990",
+  "version": "0.1.991",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/hosted/child-fork-execution-runner.test.ts
+++ b/src/agent/hosted/child-fork-execution-runner.test.ts
@@ -268,7 +268,7 @@ Deno.test("executeHostedChildForkWithPreparedTools allows injecting the run cont
 Deno.test("executeHostedChildForkToolInput resolves runtime config and prepares tools", async () => {
   const callbacks: string[] = [];
 
-  const result = await executeHostedChildForkToolInput({
+  const input = {
     authToken: "token",
     apiUrl: "https://api.example.com",
     projectId: "project-1",
@@ -298,6 +298,7 @@ Deno.test("executeHostedChildForkToolInput resolves runtime config and prepares 
       forkModel,
       thinkingConfig,
     }),
+    resolveReasoning: (_forkModel: string, thinkingConfig: unknown) => thinkingConfig,
     onRuntimeConfig: (runtimeConfig) => {
       callbacks.push(`runtime:${runtimeConfig.forkModel}`);
     },
@@ -343,6 +344,10 @@ Deno.test("executeHostedChildForkToolInput resolves runtime config and prepares 
         forkModel: "resolved-sonnet",
         thinkingConfig: { enabled: true, budgetTokens: 256 },
       });
+      assertEquals((input as { reasoning?: unknown }).reasoning, {
+        enabled: true,
+        budgetTokens: 256,
+      });
       return {
         forkStreamAbortController: new AbortController(),
         childRunMonitorAbortController: null,
@@ -365,7 +370,11 @@ Deno.test("executeHostedChildForkToolInput resolves runtime config and prepares 
         },
       };
     },
-  });
+  } as Parameters<typeof executeHostedChildForkToolInput>[0] & {
+    resolveReasoning: (forkModel: string, thinkingConfig: unknown) => unknown;
+  };
+
+  const result = await executeHostedChildForkToolInput(input);
 
   assertEquals(callbacks, [
     "project:project-2",

--- a/src/agent/hosted/child-fork-execution-runner.ts
+++ b/src/agent/hosted/child-fork-execution-runner.ts
@@ -33,6 +33,7 @@ import type {
   ChildRunExecutionResult,
   ChildRunExecutionSnapshot,
 } from "../child-run/execution-snapshot.ts";
+import type { RuntimeReasoningOption } from "../types.ts";
 import type {
   HostedConversationRunChunkMirrorInstrumentation,
   HostedConversationRunChunkMirrorTraceAttributes,
@@ -117,6 +118,7 @@ export type ExecuteHostedChildForkWithPreparedToolsInput<
   logger?: HostedChildForkStreamLogger;
   instrumentation?: HostedChildForkExecutionInstrumentation<TAttributes>;
   providerOptions?: Record<string, unknown>;
+  reasoning?: RuntimeReasoningOption;
   maxContinuationSteps?: number;
   resolveSystem?: HostedChildForkRuntimeStepSystemResolver;
   buildInstructions?: () => string;
@@ -199,6 +201,7 @@ export type ExecuteHostedChildForkToolInputOptions<
     | "effectivePrompt"
     | "toolAssembly"
     | "providerOptions"
+    | "reasoning"
   >
   & {
     forkInput: HostedChildForkToolInput;
@@ -220,6 +223,11 @@ export type ExecuteHostedChildForkToolInputOptions<
       forkModel: string,
       thinkingConfig: HostedChildForkRuntimeConfig["thinkingConfig"],
     ) => Record<string, unknown> | undefined;
+    resolveReasoning?: (
+      forkModel: string,
+      thinkingConfig: HostedChildForkRuntimeConfig["thinkingConfig"],
+    ) => RuntimeReasoningOption | undefined;
+    resolveModelThinking?: ResolveHostedChildForkRuntimeConfigInput["resolveModelThinking"];
     onRuntimeConfig?: (runtimeConfig: HostedChildForkRuntimeConfig) => void | Promise<void>;
   };
 
@@ -246,6 +254,7 @@ export async function executeHostedChildForkToolInput<
     runId: input.durableChildRun?.childRunId ?? input.toolCallId,
     resolveModelId: input.resolveModelId,
     resolveProvider: input.resolveProvider,
+    resolveModelThinking: input.resolveModelThinking,
   });
 
   await input.onRuntimeConfig?.(runtimeConfig);
@@ -265,6 +274,10 @@ export async function executeHostedChildForkToolInput<
     effectivePrompt: runtimeConfig.effectivePrompt,
     toolAssembly,
     providerOptions: input.resolveProviderOptions?.(
+      runtimeConfig.forkModel,
+      runtimeConfig.thinkingConfig,
+    ),
+    reasoning: input.resolveReasoning?.(
       runtimeConfig.forkModel,
       runtimeConfig.thinkingConfig,
     ),
@@ -338,6 +351,7 @@ export async function executeHostedChildForkWithPreparedTools<
       forkTools: input.toolAssembly.forkTools,
       forkToolNames: input.toolAssembly.availableToolNames,
       providerOptions: input.providerOptions,
+      reasoning: input.reasoning,
       buildInstructions,
       onBeforeStop: input.onBeforeStop ?? (() => null),
       durableChildRun: input.durableChildRun,

--- a/src/agent/hosted/child-tool-input.test.ts
+++ b/src/agent/hosted/child-tool-input.test.ts
@@ -185,6 +185,55 @@ Deno.test("resolveHostedChildForkRuntimeConfig resolves reusable child fork runt
   );
 });
 
+Deno.test("resolveHostedChildForkRuntimeConfig defaults child thinking from the resolved model", () => {
+  const result = resolveHostedChildForkRuntimeConfig(
+    {
+      forkInput: {
+        description: "write tests",
+        prompt: "Write focused tests.",
+        context: {},
+        model: "gpt-5.4-nano",
+      },
+      contextModel: "opus",
+      defaultModel: "haiku",
+      defaultMaxSteps: 80,
+      runId: "tool-call-1",
+      resolveModelId: (modelId) => modelId,
+      resolveProvider: (modelId) => `provider-for-${modelId}`,
+      resolveModelThinking: (modelId) => modelId === "gpt-5.4-nano" ? { enabled: true } : undefined,
+    } as Parameters<typeof resolveHostedChildForkRuntimeConfig>[0] & {
+      resolveModelThinking: (modelId: string) => { enabled: boolean } | undefined;
+    },
+  );
+
+  assertEquals(result.thinkingConfig, { enabled: true });
+});
+
+Deno.test("resolveHostedChildForkRuntimeConfig preserves explicit child thinking opt-out", () => {
+  const result = resolveHostedChildForkRuntimeConfig(
+    {
+      forkInput: {
+        description: "write tests",
+        prompt: "Write focused tests.",
+        context: {},
+        model: "gpt-5.4-nano",
+        thinking: 0,
+      },
+      contextModel: "opus",
+      defaultModel: "haiku",
+      defaultMaxSteps: 80,
+      runId: "tool-call-1",
+      resolveModelId: (modelId) => modelId,
+      resolveProvider: (modelId) => `provider-for-${modelId}`,
+      resolveModelThinking: () => ({ enabled: true }),
+    } as Parameters<typeof resolveHostedChildForkRuntimeConfig>[0] & {
+      resolveModelThinking: () => { enabled: boolean };
+    },
+  );
+
+  assertEquals(result.thinkingConfig, { enabled: false });
+});
+
 Deno.test("resolveHostedChildForkRuntimeConfig raises low requested child max steps to the hosted minimum", () => {
   const result = resolveHostedChildForkRuntimeConfig({
     forkInput: {

--- a/src/agent/hosted/child-tool-input.ts
+++ b/src/agent/hosted/child-tool-input.ts
@@ -141,6 +141,7 @@ export type ResolveHostedChildForkRuntimeConfigInput = {
   runId: string;
   resolveModelId: (modelId: string) => string;
   resolveProvider: (modelId: string) => string;
+  resolveModelThinking?: (modelId: string) => RuntimeAgentThinkingConfig | undefined;
 };
 
 /** Resolves hosted child fork thinking override. */
@@ -190,6 +191,8 @@ export function resolveHostedChildForkRuntimeConfig(
   const { description, prompt, context, tools, model, thinking, max_steps } = input.forkInput;
   const forkModel = input.resolveModelId(model || input.contextModel || input.defaultModel);
   const requestedMaxSteps = typeof max_steps === "number" ? max_steps : undefined;
+  const thinkingConfig = resolveHostedChildForkThinkingOverride(thinking) ??
+    input.resolveModelThinking?.(forkModel);
 
   return {
     description,
@@ -203,6 +206,6 @@ export function resolveHostedChildForkRuntimeConfig(
     forkModel,
     provider: input.resolveProvider(forkModel),
     maxSteps: Math.max(requestedMaxSteps ?? input.defaultMaxSteps, input.defaultMaxSteps),
-    thinkingConfig: resolveHostedChildForkThinkingOverride(thinking),
+    thinkingConfig,
   };
 }

--- a/src/agent/hosted/default-chat-runtime.ts
+++ b/src/agent/hosted/default-chat-runtime.ts
@@ -6,6 +6,8 @@ import {
 import { runWithRequestContextAsync, serverLogger } from "#veryfront/utils";
 import {
   resolveVeryfrontCloudModelId,
+  resolveVeryfrontCloudModelThinking,
+  resolveVeryfrontCloudReasoningOption,
   resolveVeryfrontCloudThinkingProviderOptions,
 } from "#veryfront/provider/veryfront-cloud/model-catalog.ts";
 import {
@@ -246,11 +248,14 @@ function createRuntimeAgentConfig(input: {
     temperature: input.options.temperature,
     maxSteps: input.options.maxSteps ?? 50,
     resolveModelTransport: ({ resolvedModel }) => {
+      const thinking = input.options.thinking ??
+        resolveVeryfrontCloudModelThinking(resolvedModel);
       const providerOptions = resolveVeryfrontCloudThinkingProviderOptions(
         resolvedModel,
-        input.options.thinking,
+        thinking,
       );
-      return providerOptions ? { providerOptions } : {};
+      const reasoning = resolveVeryfrontCloudReasoningOption(resolvedModel, thinking);
+      return providerOptions || reasoning ? { providerOptions, reasoning } : {};
     },
     resolveRuntimeState: createHostedRuntimeStateResolver({
       taskContext: input.taskContext,

--- a/src/agent/hosted/default-invoke-agent-tool.ts
+++ b/src/agent/hosted/default-invoke-agent-tool.ts
@@ -59,6 +59,7 @@ import type {
 } from "./child-requested-tools.ts";
 import { prepareDefaultHostedChildForkToolAssembly } from "./child-requested-tools.ts";
 import type { RuntimeClientProfile } from "../runtime/client-profile.ts";
+import type { RuntimeReasoningOption } from "../types.ts";
 import { withRootOwnedChildResultHint } from "../conversation/delegation-policy.ts";
 
 /** Context for default hosted invoke agent. */
@@ -130,6 +131,11 @@ export type DefaultHostedInvokeAgentToolOptions<TContext extends DefaultHostedIn
       forkModel: string,
       thinkingConfig: HostedChildForkRuntimeConfig["thinkingConfig"],
     ) => Record<string, unknown> | undefined;
+    resolveReasoning?: (
+      forkModel: string,
+      thinkingConfig: HostedChildForkRuntimeConfig["thinkingConfig"],
+    ) => RuntimeReasoningOption | undefined;
+    resolveModelThinking?: (modelId: string) => HostedChildForkRuntimeConfig["thinkingConfig"];
     shouldRethrowError?: (error: unknown) => boolean;
     buildGlobalTools?: (context: TContext) => HostToolSet;
     refreshProjectSkillIds?: DefaultHostedInvokeAgentProjectRefresh<TContext>;
@@ -355,6 +361,7 @@ async function executeForkTask<TContext extends DefaultHostedInvokeAgentContext>
     defaultMaxSteps: options.defaultMaxSteps ?? DEFAULT_USER_AGENT_MAX_STEPS,
     resolveModelId: options.resolveModelId,
     resolveProvider: options.resolveProvider,
+    resolveModelThinking: options.resolveModelThinking,
     onRequestedProjectId: (projectId) => applyRequestedProjectId(options, projectId),
     onRuntimeConfig: (runtimeConfig) => {
       options.logger.info("Starting child fork", {
@@ -376,6 +383,7 @@ async function executeForkTask<TContext extends DefaultHostedInvokeAgentContext>
         abortSignal,
       }),
     resolveProviderOptions: options.resolveProviderOptions,
+    resolveReasoning: options.resolveReasoning,
     forkContext: options.context,
     abortSignal: execution.abortSignal,
     durableChildRun: runtimeOptions.durableChildRun,

--- a/src/agent/hosted/veryfront-cloud-agent-service.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.ts
@@ -37,6 +37,8 @@ import { nodeAdapter } from "../../platform/adapters/node.ts";
 import {
   getVeryfrontCloudProviderFromModelId,
   resolveVeryfrontCloudModelId,
+  resolveVeryfrontCloudModelThinking,
+  resolveVeryfrontCloudReasoningOption,
   resolveVeryfrontCloudThinkingProviderOptions,
 } from "../../provider/index.ts";
 import { __registerTraceContextGetter } from "../../utils/logger/logger.ts";
@@ -712,7 +714,9 @@ function createInvokeAgentTool(
     createBashTool: context.options.createBashTool,
     resolveModelId: resolveVeryfrontCloudModelId,
     resolveProvider: getVeryfrontCloudProviderFromModelId,
+    resolveModelThinking: resolveVeryfrontCloudModelThinking,
     resolveProviderOptions: resolveVeryfrontCloudThinkingProviderOptions,
+    resolveReasoning: resolveVeryfrontCloudReasoningOption,
     shouldRethrowError: shouldRethrowInvokeAgentError,
     buildGlobalTools: (globalToolContext) => ({
       load_skill: createLoadSkillTool(context, globalToolContext),

--- a/src/agent/runtime/default-provider-options.test.ts
+++ b/src/agent/runtime/default-provider-options.test.ts
@@ -43,10 +43,20 @@ describe("resolveProviderOptionsWithDefaults", () => {
     );
   });
 
-  it("does not enable extended thinking for Claude Opus 4.8", () => {
+  it("enables adaptive thinking for Claude Opus 4.8", () => {
     assertEquals(
       resolveProviderOptionsWithDefaults("anthropic/claude-opus-4-8", undefined),
-      undefined,
+      {
+        anthropic: {
+          thinking: {
+            type: "adaptive",
+            display: "summarized",
+          },
+          output_config: {
+            effort: "high",
+          },
+        },
+      },
     );
   });
 

--- a/src/agent/runtime/default-provider-options.ts
+++ b/src/agent/runtime/default-provider-options.ts
@@ -7,7 +7,10 @@
  * `AgentConfig.resolveModelTransport`.
  */
 
-import { resolveVeryfrontCloudModelThinking } from "#veryfront/provider/veryfront-cloud/model-catalog.ts";
+import {
+  resolveVeryfrontCloudModelThinking,
+  resolveVeryfrontCloudThinkingProviderOptions,
+} from "#veryfront/provider/veryfront-cloud/model-catalog.ts";
 
 const VERYFRONT_CLOUD_PREFIX = "veryfront-cloud/";
 const ANTHROPIC_PREFIX = "anthropic/";
@@ -26,17 +29,6 @@ function hasAnthropicThinkingConfig(existing: Record<string, unknown> | undefine
   return "thinking" in (anthropic as Record<string, unknown>);
 }
 
-function resolveAnthropicThinkingBudgetTokens(modelString: string): number | undefined {
-  const thinking = resolveVeryfrontCloudModelThinking(modelString);
-  if (
-    thinking?.enabled !== true || typeof thinking.budgetTokens !== "number" ||
-    thinking.budgetTokens <= 0
-  ) {
-    return undefined;
-  }
-  return Math.floor(thinking.budgetTokens);
-}
-
 export function resolveProviderOptionsWithDefaults(
   modelString: string,
   existing: Record<string, unknown> | undefined,
@@ -49,8 +41,12 @@ export function resolveProviderOptionsWithDefaults(
     return existing;
   }
 
-  const budgetTokens = resolveAnthropicThinkingBudgetTokens(modelString);
-  if (!budgetTokens) {
+  const thinking = resolveVeryfrontCloudModelThinking(modelString);
+  const defaults = thinking
+    ? resolveVeryfrontCloudThinkingProviderOptions(modelString, thinking)
+    : undefined;
+  const defaultAnthropic = defaults?.anthropic as Record<string, unknown> | undefined;
+  if (!defaultAnthropic) {
     return existing;
   }
 
@@ -60,9 +56,9 @@ export function resolveProviderOptionsWithDefaults(
     anthropic: {
       // Defaults first; host-supplied fields (e.g. temperature) override them.
       // Only `thinking` is forced because we already confirmed it isn't set.
-      temperature: 1,
+      ...defaultAnthropic,
       ...existingAnthropic,
-      thinking: { type: "enabled", budget_tokens: budgetTokens },
+      thinking: defaultAnthropic.thinking,
     },
   };
 }

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -20,6 +20,7 @@ import {
   type Message,
   type MessagePart,
   type ResolvedRuntimeState,
+  type RuntimeReasoningOption,
   type ToolCall,
   type ToolExecutionResultRequest,
   type ToolResultPart,
@@ -410,6 +411,7 @@ export class AgentRuntime {
             transport.languageModel,
             transport.headers,
             transport.providerOptions,
+            transport.reasoning,
             maxOutputTokensOverride,
             requestedModel,
           ),
@@ -533,6 +535,7 @@ export class AgentRuntime {
                 languageModel,
                 transport.headers,
                 transport.providerOptions,
+                transport.reasoning,
                 maxOutputTokensOverride,
                 streamAbortSignal,
                 requestedModel,
@@ -597,6 +600,7 @@ export class AgentRuntime {
     resolvedModel?: ModelRuntime,
     headers?: HeadersInit,
     providerOptions?: Record<string, unknown>,
+    reasoning?: RuntimeReasoningOption,
     maxOutputTokensOverride?: number,
     temperatureModelString?: string,
   ): Promise<AgentResponse> {
@@ -684,6 +688,7 @@ export class AgentRuntime {
             ...(temperature === undefined ? {} : { temperature }),
             ...(headers ? { headers } : {}),
             ...(providerOptions ? { providerOptions } : {}),
+            ...(reasoning ? { reasoning } : {}),
           });
         });
 
@@ -950,6 +955,7 @@ export class AgentRuntime {
     resolvedModel?: ModelRuntime,
     headers?: HeadersInit,
     providerOptions?: Record<string, unknown>,
+    reasoning?: RuntimeReasoningOption,
     maxOutputTokensOverride?: number,
     abortSignal?: AbortSignal,
     temperatureModelString?: string,
@@ -1044,6 +1050,7 @@ export class AgentRuntime {
         ...(temperature === undefined ? {} : { temperature }),
         ...(headers ? { headers } : {}),
         ...(providerOptions ? { providerOptions } : {}),
+        ...(reasoning ? { reasoning } : {}),
         abortSignal,
       });
 

--- a/src/agent/runtime/model-capabilities.ts
+++ b/src/agent/runtime/model-capabilities.ts
@@ -26,7 +26,7 @@ function isThinkingDisabled(options: Record<string, unknown> | undefined): boole
   return thinking?.type === "disabled";
 }
 
-function hasDisabledThinking(providerOptions?: Record<string, unknown>): boolean {
+export function hasDisabledThinking(providerOptions?: Record<string, unknown>): boolean {
   if (!providerOptions) return false;
   if (isThinkingDisabled(providerOptions)) return true;
 

--- a/src/agent/runtime/model-transport.test.ts
+++ b/src/agent/runtime/model-transport.test.ts
@@ -24,10 +24,10 @@ function createModel(modelId: string): ModelRuntime {
 
 describe("resolveAgentModelTransport", () => {
   it("resolves the configured runtime model when no host transport hook is present", async () => {
-    const config = {
+    const config: AgentConfig = {
       model: "local/qwen3.5-0.8b",
       system: "You are a helpful assistant.",
-    } as AgentConfig;
+    };
 
     const transport = await resolveAgentModelTransport({
       agentId: "agent-1",
@@ -42,10 +42,10 @@ describe("resolveAgentModelTransport", () => {
     assertEquals(transport.languageModel.modelId, "local/qwen3.5-0.8b");
   });
 
-  it("lets the host override model runtime, headers, and provider options", async () => {
+  it("lets the host override model runtime, headers, provider options, and reasoning", async () => {
     const hostModel = createModel("hosted/gateway-model");
     let capturedRequest: ModelTransportRequest | undefined;
-    const config = {
+    const config: AgentConfig = {
       model: "host/default-model",
       system: "You are a helpful assistant.",
       resolveModelTransport: (request: ModelTransportRequest) => {
@@ -54,9 +54,10 @@ describe("resolveAgentModelTransport", () => {
           model: hostModel,
           headers: { Authorization: "Bearer vf_test" },
           providerOptions: { veryfront: { projectSlug: request.context?.projectSlug } },
+          reasoning: { enabled: false },
         };
       },
-    } as AgentConfig;
+    };
 
     const transport = await resolveAgentModelTransport({
       agentId: "agent-1",
@@ -76,5 +77,46 @@ describe("resolveAgentModelTransport", () => {
     assertStrictEquals(transport.languageModel, hostModel);
     assertEquals(new Headers(transport.headers).get("Authorization"), "Bearer vf_test");
     assertEquals(transport.providerOptions, { veryfront: { projectSlug: "demo-project" } });
+    assertEquals((transport as { reasoning?: unknown }).reasoning, { enabled: false });
+  });
+
+  it("defaults reasoning for non-Anthropic thinking-capable Veryfront Cloud models", async () => {
+    const hostModel = createModel("veryfront-cloud/google-ai-studio/gemini-2.5-pro");
+    const config: AgentConfig = {
+      model: "veryfront-cloud/google-ai-studio/gemini-2.5-pro",
+      system: "You are a helpful assistant.",
+      resolveModelTransport: () => ({ model: hostModel }),
+    };
+
+    const transport = await resolveAgentModelTransport({
+      agentId: "agent-1",
+      config,
+      context: undefined,
+      mode: "stream",
+      modelOverride: undefined,
+    });
+
+    assertEquals((transport as { reasoning?: unknown }).reasoning, { enabled: true });
+  });
+
+  it("preserves provider option thinking opt-outs over Veryfront Cloud reasoning defaults", async () => {
+    const hostModel = createModel("veryfront-cloud/moonshotai/kimi-k2.6");
+    const providerOptions = { openai: { thinking: { type: "disabled" } } };
+    const config: AgentConfig = {
+      model: "veryfront-cloud/moonshotai/kimi-k2.6",
+      system: "You are a helpful assistant.",
+      resolveModelTransport: () => ({ model: hostModel, providerOptions }),
+    };
+
+    const transport = await resolveAgentModelTransport({
+      agentId: "agent-1",
+      config,
+      context: undefined,
+      mode: "stream",
+      modelOverride: undefined,
+    });
+
+    assertEquals(transport.providerOptions, providerOptions);
+    assertEquals(transport.reasoning, { enabled: false });
   });
 });

--- a/src/agent/runtime/model-transport.ts
+++ b/src/agent/runtime/model-transport.ts
@@ -4,10 +4,16 @@
  * @module agent/runtime/model-transport
  */
 
-import { type AgentConfig } from "../types.ts";
+import { type AgentConfig, type RuntimeReasoningOption } from "../types.ts";
 import { type ModelRuntime, resolveModel } from "#veryfront/provider";
 import { resolveProviderOptionsWithDefaults } from "./default-provider-options.ts";
 import { resolveConfiguredAgentModel, resolveRuntimeModel } from "./model-resolution.ts";
+import {
+  resolveVeryfrontCloudModelThinking,
+  resolveVeryfrontCloudReasoningOption,
+  tryGetVeryfrontCloudProviderFromModelId,
+} from "#veryfront/provider/veryfront-cloud/model-catalog.ts";
+import { hasDisabledThinking } from "./model-capabilities.ts";
 
 export type ResolvedModelTransport = {
   requestedModel: string;
@@ -15,6 +21,7 @@ export type ResolvedModelTransport = {
   languageModel: ModelRuntime;
   headers?: HeadersInit;
   providerOptions?: Record<string, unknown>;
+  reasoning?: RuntimeReasoningOption;
 };
 
 export interface ResolveAgentModelTransportInput {
@@ -23,6 +30,27 @@ export interface ResolveAgentModelTransportInput {
   context: Record<string, unknown> | undefined;
   modelOverride: string | undefined;
   mode: "generate" | "stream";
+}
+
+function resolveReasoningWithDefaults(
+  modelString: string,
+  existing: RuntimeReasoningOption | undefined,
+  providerOptions: Record<string, unknown> | undefined,
+): RuntimeReasoningOption | undefined {
+  if (existing) {
+    return existing;
+  }
+
+  if (hasDisabledThinking(providerOptions)) {
+    return { enabled: false };
+  }
+
+  if (tryGetVeryfrontCloudProviderFromModelId(modelString) === "anthropic") {
+    return undefined;
+  }
+
+  const thinking = resolveVeryfrontCloudModelThinking(modelString);
+  return resolveVeryfrontCloudReasoningOption(modelString, thinking);
 }
 
 export async function resolveAgentModelTransport(
@@ -38,14 +66,21 @@ export async function resolveAgentModelTransport(
     mode: input.mode,
   });
 
+  const providerOptions = resolveProviderOptionsWithDefaults(
+    resolvedModelString,
+    transport?.providerOptions,
+  );
+
   return {
     requestedModel,
     resolvedModelString,
     languageModel: transport?.model ?? resolveModel(resolvedModelString),
     headers: transport?.headers,
-    providerOptions: resolveProviderOptionsWithDefaults(
+    providerOptions,
+    reasoning: resolveReasoningWithDefaults(
       resolvedModelString,
-      transport?.providerOptions,
+      transport?.reasoning,
+      providerOptions,
     ),
   };
 }

--- a/src/agent/streaming/fork-runtime-stream.test.ts
+++ b/src/agent/streaming/fork-runtime-stream.test.ts
@@ -629,4 +629,43 @@ describe("agent/fork-runtime-stream", () => {
       "Artifact written.",
     ]);
   });
+
+  it("passes reasoning options to fork run steps", async () => {
+    let capturedReasoning: unknown;
+    const streamResult = startAgentRuntimeFork(
+      {
+        apiUrl: "https://api.example.com",
+        authToken: "auth-token",
+        projectId: null,
+        model: "model-1",
+        maxSteps: 1,
+        prompt: "Prepare.",
+        forkToolNames: [],
+        runtimeTools: {},
+        reasoning: { enabled: true, budgetTokens: 2048 },
+        buildInstructions: () => "Base instructions.",
+        runStep: async (input) => {
+          capturedReasoning = (input as Record<string, unknown>).reasoning;
+          return {
+            stream: createRuntimeEventStream([{ type: "text-delta", delta: "Ready." }]),
+            responsePromise: Promise.resolve({
+              text: "Ready.",
+              messages: [],
+              toolCalls: [],
+              status: "completed",
+              metadata: { finishReason: "stop" },
+            }),
+          };
+        },
+      } as Parameters<typeof startAgentRuntimeFork>[0] & {
+        reasoning: { enabled: boolean; budgetTokens: number };
+      },
+    );
+
+    for await (const _part of streamResult.fullStream) {
+      // Drain stream.
+    }
+
+    assertEquals(capturedReasoning, { enabled: true, budgetTokens: 2048 });
+  });
 });

--- a/src/agent/streaming/fork-runtime-stream.ts
+++ b/src/agent/streaming/fork-runtime-stream.ts
@@ -25,6 +25,7 @@ import {
 } from "../runtime/provider-native-tool-inventory.ts";
 import { AgentRuntime } from "../runtime/index.ts";
 import type { AgentResponse, Message as AgentMessage } from "../schemas/index.ts";
+import type { RuntimeReasoningOption } from "../types.ts";
 import {
   commitForkRuntimeStep,
   createForkRuntimeProgress,
@@ -188,6 +189,7 @@ export type StartAgentRuntimeForkInput = {
   providerToolNames?: string[];
   runtimeTools: Record<string, Tool | boolean>;
   providerOptions?: Record<string, unknown>;
+  reasoning?: RuntimeReasoningOption;
   buildInstructions: () => string;
   onBeforeStop?: ForkRuntimeContinuationPromptResolver;
   initialMessages?: readonly AgentMessage[];
@@ -257,6 +259,7 @@ export function startAgentRuntimeForkWithHostTools<
       providerToolNames,
       runtimeTools,
       providerOptions: input.providerOptions,
+      reasoning: input.reasoning,
       buildInstructions: input.buildInstructions,
       onBeforeStop: input.onBeforeStop,
       initialMessages: input.initialMessages,
@@ -321,6 +324,7 @@ export type RunAgentRuntimeForkStepInput = {
   providerToolNames?: string[];
   runtimeTools: Record<string, Tool | boolean>;
   providerOptions?: Record<string, unknown>;
+  reasoning?: RuntimeReasoningOption;
 };
 
 /** Input payload for run framework fork step. */
@@ -357,8 +361,13 @@ export async function runAgentRuntimeForkStep(input: RunAgentRuntimeForkStepInpu
     tools: input.runtimeTools,
     providerTools: input.providerToolNames ?? [],
     maxSteps: 1,
-    ...(input.providerOptions
-      ? { resolveModelTransport: () => ({ providerOptions: input.providerOptions }) }
+    ...(input.providerOptions || input.reasoning
+      ? {
+        resolveModelTransport: () => ({
+          providerOptions: input.providerOptions,
+          reasoning: input.reasoning,
+        }),
+      }
       : {}),
     __vfAllowedRemoteTools: input.forkToolNames,
   };
@@ -411,6 +420,7 @@ export function runFrameworkForkStep(input: RunFrameworkForkStepInput): Promise<
     ...(input.providerToolNames ? { providerToolNames: input.providerToolNames } : {}),
     runtimeTools: input.frameworkTools,
     ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
+    ...(input.reasoning ? { reasoning: input.reasoning } : {}),
   });
 }
 
@@ -536,6 +546,7 @@ export function startAgentRuntimeFork(input: StartAgentRuntimeForkInput): ForkRu
             ...(input.providerToolNames ? { providerToolNames: input.providerToolNames } : {}),
             runtimeTools: input.runtimeTools,
             ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
+            ...(input.reasoning ? { reasoning: input.reasoning } : {}),
           });
 
           for await (const event of streamDataStreamEvents(stream)) {

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -235,11 +235,19 @@ export interface ModelTransportRequest {
   mode: "generate" | "stream";
 }
 
+/** Provider-neutral reasoning / thinking option for model transport. */
+export type RuntimeReasoningOption = {
+  enabled?: boolean;
+  effort?: "low" | "medium" | "high" | "max";
+  budgetTokens?: number;
+};
+
 /** Public API contract for resolved model transport. */
 export interface ResolvedModelTransport {
   model?: ModelRuntime;
   headers?: HeadersInit;
   providerOptions?: Record<string, unknown>;
+  reasoning?: RuntimeReasoningOption;
 }
 
 /** Public API contract for model transport resolver. */

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -42,6 +42,7 @@ export {
   resolveVeryfrontCloudGatewayModelId,
   resolveVeryfrontCloudModelId,
   resolveVeryfrontCloudModelThinking,
+  resolveVeryfrontCloudReasoningOption,
   resolveVeryfrontCloudThinkingProviderOptions,
   tryGetVeryfrontCloudProviderFromModelId,
   VERYFRONT_CLOUD_CHAT_MODELS,

--- a/src/provider/veryfront-cloud/model-catalog.test.ts
+++ b/src/provider/veryfront-cloud/model-catalog.test.ts
@@ -22,11 +22,17 @@ describe("provider/veryfront-cloud/model-catalog", () => {
     assertEquals(findVeryfrontCloudModel("sonnet")?.provider, "anthropic");
     assertEquals(opus.modelId, "anthropic/claude-opus-4-8");
     assertEquals(findVeryfrontCloudModel("gpt-5.5")?.provider, "openai");
+    assertEquals(findVeryfrontCloudModel("gpt-5.4-mini")?.provider, "openai");
+    assertEquals(findVeryfrontCloudModel("gpt-5.4")?.provider, "openai");
     assertEquals(findVeryfrontCloudModel("gpt-5.4-nano")?.provider, "openai");
+    assertEquals(findVeryfrontCloudModel("gpt-5.2")?.provider, "openai");
     assertEquals(findVeryfrontCloudModel("gemini-3.1-pro-preview")?.provider, "google");
     assertEquals(findVeryfrontCloudModel("gemini-3.5-flash")?.provider, "google");
+    assertEquals(findVeryfrontCloudModel("gemini-2.5-pro")?.provider, "google");
+    assertEquals(findVeryfrontCloudModel("gemini-2.5-flash")?.provider, "google");
     assertEquals(findVeryfrontCloudModel("mistral-large-2512")?.provider, "mistral");
     assertEquals(findVeryfrontCloudModel("kimi-k2.6")?.provider, "moonshotai");
+    assertEquals(findVeryfrontCloudModel("kimi-k2.5")?.provider, "moonshotai");
     assertEquals(findVeryfrontCloudModel("nonexistent"), undefined);
   });
 
@@ -59,7 +65,7 @@ describe("provider/veryfront-cloud/model-catalog", () => {
     assertEquals(
       findVeryfrontCloudModelByModelId("veryfront-cloud/anthropic/claude-opus-4-8")
         ?.thinkingBudgetTokens,
-      undefined,
+      2048,
     );
   });
 
@@ -83,7 +89,10 @@ describe("provider/veryfront-cloud/model-catalog", () => {
     assertEquals(resolveVeryfrontCloudModelId("opus"), "anthropic/claude-opus-4-8");
     assertEquals(resolveVeryfrontCloudModelId(), "openai/gpt-5.4-nano");
     assertEquals(resolveVeryfrontCloudModelId("gpt-5.5"), "openai/gpt-5.5");
+    assertEquals(resolveVeryfrontCloudModelId("gpt-5.4-mini"), "openai/gpt-5.4-mini");
+    assertEquals(resolveVeryfrontCloudModelId("gpt-5.4"), "openai/gpt-5.4");
     assertEquals(resolveVeryfrontCloudModelId("gpt-5.4-nano"), "openai/gpt-5.4-nano");
+    assertEquals(resolveVeryfrontCloudModelId("gpt-5.2"), "openai/gpt-5.2");
     assertEquals(resolveVeryfrontCloudModelId("mistral-large-2512"), "mistral/mistral-large-2512");
     assertEquals(resolveVeryfrontCloudModelId("openai/gpt-5.5"), "openai/gpt-5.5");
     assertThrows(
@@ -104,18 +113,44 @@ describe("provider/veryfront-cloud/model-catalog", () => {
   });
 
   it("resolves default thinking budgets for catalog models", () => {
-    assertEquals(resolveVeryfrontCloudModelThinking("anthropic/claude-opus-4-8"), undefined);
+    const thinkingModelIds = [
+      "anthropic/claude-opus-4-8",
+      "veryfront-cloud/anthropic/claude-opus-4-8",
+      "anthropic/claude-opus-4-6",
+      "anthropic/claude-sonnet-4-6",
+      "anthropic/claude-haiku-4-5-20251001",
+      "openai/gpt-5.5",
+      "openai/gpt-5.4-mini",
+      "openai/gpt-5.4",
+      "openai/gpt-5.4-nano",
+      "openai/gpt-5.2",
+      "google-ai-studio/gemini-3.1-pro-preview",
+      "google-ai-studio/gemini-2.5-pro",
+      "moonshotai/kimi-k2.6",
+      "moonshotai/kimi-k2.5",
+    ];
+
+    for (const modelId of thinkingModelIds) {
+      assertEquals(resolveVeryfrontCloudModelThinking(modelId)?.enabled, true);
+    }
+
     assertEquals(
-      resolveVeryfrontCloudModelThinking("veryfront-cloud/anthropic/claude-opus-4-8"),
+      resolveVeryfrontCloudModelThinking("anthropic/claude-sonnet-4-6")?.budgetTokens,
+      2048,
+    );
+    assertEquals(
+      resolveVeryfrontCloudModelThinking("anthropic/claude-haiku-4-5-20251001")?.budgetTokens,
+      1024,
+    );
+    assertEquals(
+      resolveVeryfrontCloudModelThinking("google-ai-studio/gemini-3.5-flash"),
       undefined,
     );
-    assertEquals(resolveVeryfrontCloudModelThinking("openai/gpt-5.5"), undefined);
-    assertEquals(resolveVeryfrontCloudModelThinking("openai/gpt-5.4-nano"), undefined);
-    assertEquals(resolveVeryfrontCloudModelThinking("anthropic/claude-sonnet-4-6")?.enabled, true);
     assertEquals(
-      resolveVeryfrontCloudModelThinking("anthropic/claude-haiku-4-5-20251001")?.enabled,
-      true,
+      resolveVeryfrontCloudModelThinking("google-ai-studio/gemini-2.5-flash"),
+      undefined,
     );
+    assertEquals(resolveVeryfrontCloudModelThinking("mistral/mistral-large-2512"), undefined);
   });
 
   it("prefixes direct provider model ids for the Veryfront Cloud gateway", () => {

--- a/src/provider/veryfront-cloud/model-catalog.ts
+++ b/src/provider/veryfront-cloud/model-catalog.ts
@@ -3,6 +3,7 @@ import type { VeryfrontCloudProviderId } from "./shared.ts";
 /** Configuration used by Veryfront Cloud model thinking. */
 export type VeryfrontCloudModelThinkingConfig = {
   enabled: boolean;
+  effort?: "low" | "medium" | "high" | "max";
   budgetTokens?: number;
 };
 
@@ -13,6 +14,7 @@ export type VeryfrontCloudChatModel = {
   provider: VeryfrontCloudProviderId;
   name: string;
   description: string;
+  thinking?: boolean;
   thinkingBudgetTokens?: number;
 };
 
@@ -46,6 +48,15 @@ export const VERYFRONT_CLOUD_CHAT_MODELS: VeryfrontCloudChatModel[] = [
     provider: "anthropic",
     name: "Claude Opus 4.8",
     description: "Most capable for ambitious work",
+    thinkingBudgetTokens: 2048,
+  },
+  {
+    id: "claude-opus-4-6",
+    modelId: "anthropic/claude-opus-4-6",
+    provider: "anthropic",
+    name: "Claude Opus 4.6",
+    description: "Previous Opus generation for compatibility-sensitive agents",
+    thinkingBudgetTokens: 2048,
   },
   {
     id: "sonnet",
@@ -69,13 +80,39 @@ export const VERYFRONT_CLOUD_CHAT_MODELS: VeryfrontCloudChatModel[] = [
     provider: "openai",
     name: "GPT-5.5",
     description: "Most capable OpenAI model",
+    thinking: true,
+  },
+  {
+    id: "gpt-5.4-mini",
+    modelId: "openai/gpt-5.4-mini",
+    provider: "openai",
+    name: "GPT-5.4 Mini",
+    description: "Fast OpenAI model for cost-efficient everyday work",
+    thinking: true,
+  },
+  {
+    id: "gpt-5.4",
+    modelId: "openai/gpt-5.4",
+    provider: "openai",
+    name: "GPT-5.4",
+    description: "Production-proven OpenAI frontier model",
+    thinking: true,
   },
   {
     id: "gpt-5.4-nano",
     modelId: "openai/gpt-5.4-nano",
     provider: "openai",
     name: "GPT-5.4 Nano",
-    description: "Default model for fast everyday tasks",
+    description: "Lowest-cost OpenAI model for lightweight work",
+    thinking: true,
+  },
+  {
+    id: "gpt-5.2",
+    modelId: "openai/gpt-5.2",
+    provider: "openai",
+    name: "GPT-5.2",
+    description: "Previous OpenAI frontier generation",
+    thinking: true,
   },
   {
     id: "gemini-3.1-pro-preview",
@@ -83,6 +120,7 @@ export const VERYFRONT_CLOUD_CHAT_MODELS: VeryfrontCloudChatModel[] = [
     provider: "google",
     name: "Gemini 3.1 Pro Preview",
     description: "Advanced reasoning and analysis",
+    thinking: true,
   },
   {
     id: "gemini-3.5-flash",
@@ -90,6 +128,21 @@ export const VERYFRONT_CLOUD_CHAT_MODELS: VeryfrontCloudChatModel[] = [
     provider: "google",
     name: "Gemini 3.5 Flash",
     description: "Fast and cost-efficient",
+  },
+  {
+    id: "gemini-2.5-pro",
+    modelId: "google-ai-studio/gemini-2.5-pro",
+    provider: "google",
+    name: "Gemini 2.5 Pro",
+    description: "Previous Google Pro model",
+    thinking: true,
+  },
+  {
+    id: "gemini-2.5-flash",
+    modelId: "google-ai-studio/gemini-2.5-flash",
+    provider: "google",
+    name: "Gemini 2.5 Flash",
+    description: "Previous Google Flash model",
   },
   {
     id: "mistral-large-2512",
@@ -104,6 +157,15 @@ export const VERYFRONT_CLOUD_CHAT_MODELS: VeryfrontCloudChatModel[] = [
     provider: "moonshotai",
     name: "Kimi K2.6",
     description: "Deep thinking and multimodal",
+    thinking: true,
+  },
+  {
+    id: "kimi-k2.5",
+    modelId: "moonshotai/kimi-k2.5",
+    provider: "moonshotai",
+    name: "Kimi K2.5",
+    description: "Previous Kimi generation",
+    thinking: true,
   },
 ];
 
@@ -218,13 +280,47 @@ export function resolveVeryfrontCloudModelThinking(
   }
 
   const model = findVeryfrontCloudModelByModelId(modelId) ?? findVeryfrontCloudModel(modelId);
-  if (typeof model?.thinkingBudgetTokens !== "number" || model.thinkingBudgetTokens <= 0) {
+  const budgetTokens = typeof model?.thinkingBudgetTokens === "number" &&
+      model.thinkingBudgetTokens > 0
+    ? model.thinkingBudgetTokens
+    : undefined;
+  if (model?.thinking !== true && budgetTokens === undefined) {
     return undefined;
   }
 
   return {
     enabled: true,
-    budgetTokens: model.thinkingBudgetTokens,
+    ...(budgetTokens !== undefined ? { budgetTokens } : {}),
+  };
+}
+
+/** Resolves provider-neutral runtime reasoning for a Veryfront Cloud model. */
+export function resolveVeryfrontCloudReasoningOption(
+  modelId: string,
+  thinking: VeryfrontCloudModelThinkingConfig | undefined,
+): VeryfrontCloudModelThinkingConfig | undefined {
+  if (!tryGetVeryfrontCloudProviderFromModelId(modelId)) {
+    return undefined;
+  }
+
+  if (!thinking) {
+    return undefined;
+  }
+
+  if (thinking.enabled === false) {
+    return { enabled: false };
+  }
+
+  if (thinking.enabled !== true) {
+    return undefined;
+  }
+
+  return {
+    enabled: true,
+    ...(thinking.effort ? { effort: thinking.effort } : {}),
+    ...(typeof thinking.budgetTokens === "number" && thinking.budgetTokens > 0
+      ? { budgetTokens: Math.floor(thinking.budgetTokens) }
+      : {}),
   };
 }
 
@@ -233,9 +329,7 @@ export function resolveVeryfrontCloudThinkingProviderOptions(
   modelId: string,
   thinking: VeryfrontCloudModelThinkingConfig | undefined,
 ): Record<string, unknown> | undefined {
-  if (
-    !thinking?.enabled || typeof thinking.budgetTokens !== "number" || thinking.budgetTokens <= 0
-  ) {
+  if (!thinking?.enabled) {
     return undefined;
   }
 
@@ -257,6 +351,10 @@ export function resolveVeryfrontCloudThinkingProviderOptions(
         },
       },
     };
+  }
+
+  if (typeof thinking.budgetTokens !== "number" || thinking.budgetTokens <= 0) {
+    return undefined;
   }
 
   return {

--- a/src/provider/veryfront-cloud/openai.ts
+++ b/src/provider/veryfront-cloud/openai.ts
@@ -21,6 +21,18 @@ export function createVeryfrontCloudOpenAIModel(
   });
 }
 
+export function createVeryfrontCloudOpenAIResponsesModel(
+  modelId: string,
+  config: VeryfrontCloudOpenAIConfig,
+): ModelRuntime {
+  return openLLMProvider.createResponses(modelId, {
+    credential: config.apiToken,
+    baseURL: config.baseURL,
+    name: "veryfront-cloud",
+    fetch: config.fetch,
+  });
+}
+
 export function createVeryfrontCloudOpenAIEmbeddingModel(
   modelId: string,
   config: VeryfrontCloudOpenAIConfig,

--- a/src/provider/veryfront-cloud/provider.test.ts
+++ b/src/provider/veryfront-cloud/provider.test.ts
@@ -115,6 +115,68 @@ describe("provider/veryfront-cloud", () => {
     });
   });
 
+  it("routes reasoning-capable OpenAI models through Responses with default reasoning", async () => {
+    setCloudBootstrap();
+    const encoder = new TextEncoder();
+    let capturedRequest: Request | undefined;
+    let capturedBody: Record<string, unknown> | undefined;
+
+    globalThis.fetch = (async (input: URL | Request | string, init?: RequestInit) => {
+      const request = new Request(input, init);
+      capturedRequest = request;
+      capturedBody = JSON.parse(await request.text()) as Record<string, unknown>;
+      const requestUrl = request.url;
+
+      if (requestUrl.endsWith("/responses")) {
+        return new Response(
+          ReadableStream.from([
+            encoder.encode(
+              'data: {"type":"response.output_item.added","item":{"id":"rs_1","type":"reasoning"}}\n\n',
+            ),
+            encoder.encode(
+              'data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_1","delta":"Thinking."}\n\n',
+            ),
+            encoder.encode(
+              'data: {"type":"response.output_item.done","item":{"id":"rs_1","type":"reasoning"}}\n\n',
+            ),
+            encoder.encode(
+              'data: {"type":"response.output_text.delta","item_id":"msg_1","delta":"Hello"}\n\n',
+            ),
+            encoder.encode(
+              'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}\n\n',
+            ),
+            encoder.encode("data: [DONE]\n\n"),
+          ]),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }
+
+      return new Response(
+        ReadableStream.from([
+          encoder.encode('data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n'),
+          encoder.encode('data: {"choices":[{"finish_reason":"stop"}]}\n\n'),
+          encoder.encode("data: [DONE]\n\n"),
+        ]),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      );
+    }) as typeof fetch;
+
+    const assistant = agent({
+      model: "veryfront-cloud/openai/gpt-5.4-nano",
+      system: "You are concise.",
+    });
+
+    const result = await assistant.generate({ input: "Hi" });
+
+    assertEquals(
+      capturedRequest?.url,
+      "https://api.veryfront.com/ai/gateway/openai/v1/responses",
+    );
+    assertEquals(capturedBody?.stream, true);
+    assertEquals(capturedBody?.reasoning, { effort: "medium", summary: "auto" });
+    assertEquals(result.text, "Hello");
+  });
+
   it("resolves veryfront-cloud moonshotai models without project ext-llm-openai installed", () => {
     setCloudBootstrap();
 

--- a/src/provider/veryfront-cloud/provider.ts
+++ b/src/provider/veryfront-cloud/provider.ts
@@ -7,10 +7,18 @@ import {
   parseVeryfrontCloudModelId,
   requireVeryfrontCloudBootstrap,
 } from "./shared.ts";
-import { createVeryfrontCloudOpenAIModel } from "./openai.ts";
+import {
+  createVeryfrontCloudOpenAIModel,
+  createVeryfrontCloudOpenAIResponsesModel,
+} from "./openai.ts";
+import { resolveVeryfrontCloudModelThinking } from "./model-catalog.ts";
 
 function preferStreamedGenerate(model: ModelRuntime): ModelRuntime {
   return Object.assign(model, { _generateViaStream: true as const });
+}
+
+function shouldUseOpenAIResponsesRuntime(upstreamModelId: string): boolean {
+  return resolveVeryfrontCloudModelThinking(`openai/${upstreamModelId}`)?.enabled === true;
 }
 
 export function createVeryfrontCloudModel(modelId: string): ModelRuntime {
@@ -48,7 +56,39 @@ export function createVeryfrontCloudModel(modelId: string): ModelRuntime {
       break;
     }
 
-    case "openai":
+    case "openai": {
+      const openai = registry.get("openai");
+      if (shouldUseOpenAIResponsesRuntime(upstreamModelId)) {
+        if (openai?.createResponses) {
+          return preferStreamedGenerate(openai.createResponses(upstreamModelId, {
+            credential: apiToken,
+            baseURL,
+            name: "veryfront-cloud",
+            fetch,
+          }));
+        }
+        return preferStreamedGenerate(createVeryfrontCloudOpenAIResponsesModel(upstreamModelId, {
+          apiToken,
+          baseURL,
+          fetch,
+        }));
+      }
+
+      if (openai) {
+        return preferStreamedGenerate(openai.createModel(upstreamModelId, {
+          credential: apiToken,
+          baseURL,
+          name: "veryfront-cloud",
+          fetch,
+        }));
+      }
+      return preferStreamedGenerate(createVeryfrontCloudOpenAIModel(upstreamModelId, {
+        apiToken,
+        baseURL,
+        fetch,
+      }));
+    }
+
     case "mistral":
     case "moonshotai": {
       const openai = registry.get("openai");

--- a/src/runtime/runtime-bridge.test-helpers.ts
+++ b/src/runtime/runtime-bridge.test-helpers.ts
@@ -15,6 +15,7 @@ export async function collectAsync<T>(iterable: AsyncIterable<T>): Promise<T[]> 
 type TestRuntimeOptions = {
   prompt: unknown[];
   tools?: unknown[];
+  reasoning?: unknown;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -29,6 +30,7 @@ export function getTestRuntimeOptions(options: unknown): TestRuntimeOptions {
   return {
     prompt: options.prompt,
     ...(Array.isArray(options.tools) ? { tools: options.tools } : {}),
+    ...("reasoning" in options ? { reasoning: options.reasoning } : {}),
   };
 }
 

--- a/src/runtime/runtime-bridge.test.ts
+++ b/src/runtime/runtime-bridge.test.ts
@@ -44,6 +44,25 @@ describe("runtime-bridge", () => {
     });
   });
 
+  it("forwards reasoning options to direct generate models", async () => {
+    const model = createGenerateModel("test", "test/reasoning-generate", async (options) => {
+      assertEquals(options.reasoning, { enabled: false });
+      return {
+        content: [{ type: "text", text: "ok" }],
+        finishReason: "stop",
+        usage: { inputTokens: 1, outputTokens: 1 },
+      };
+    });
+
+    const result = await generateText({
+      model,
+      messages: [{ role: "user", content: "Hello" }],
+      reasoning: { enabled: false },
+    });
+
+    assertEquals(result.text, "ok");
+  });
+
   it("buffers the stream path for models that prefer streamed generate", async () => {
     let called = false;
 
@@ -178,6 +197,26 @@ describe("runtime-bridge", () => {
         },
       },
     ]);
+  });
+
+  it("forwards reasoning options to direct stream models", async () => {
+    const model = createStreamModel("test", "test/reasoning-stream", async (options) => {
+      assertEquals(options.reasoning, { enabled: true, budgetTokens: 2048 });
+      return {
+        stream: ReadableStream.from([
+          { type: "text-delta", delta: "ok" },
+          { type: "finish", finishReason: "stop", usage: { inputTokens: 1, outputTokens: 1 } },
+        ]),
+      };
+    });
+
+    const result = streamText({
+      model,
+      messages: [{ role: "user", content: "Hello" }],
+      reasoning: { enabled: true, budgetTokens: 2048 },
+    });
+
+    assertEquals(await collectAsync(result.textStream), ["ok"]);
   });
 
   it("uses the direct generate path for ordinary function tools", async () => {

--- a/src/runtime/runtime-bridge.ts
+++ b/src/runtime/runtime-bridge.ts
@@ -18,6 +18,7 @@ import type {
   ModelRuntime,
   ModelRuntimeGenerateResult,
 } from "#veryfront/provider/types.ts";
+import type { RuntimeReasoningOption } from "#veryfront/agent/types.ts";
 
 type GenerateTextOptions = {
   model: ModelRuntime;
@@ -36,6 +37,7 @@ type GenerateTextOptions = {
   frequencyPenalty?: number;
   headers?: HeadersInit;
   providerOptions?: Record<string, unknown>;
+  reasoning?: RuntimeReasoningOption;
   abortSignal?: AbortSignal;
 };
 
@@ -56,6 +58,7 @@ type StreamTextOptions = {
   frequencyPenalty?: number;
   headers?: HeadersInit;
   providerOptions?: Record<string, unknown>;
+  reasoning?: RuntimeReasoningOption;
   includeRawChunks?: boolean;
   abortSignal?: AbortSignal;
 };
@@ -505,6 +508,7 @@ function buildDirectModelOptions(
       : {}),
     ...(options.headers ? { headers: options.headers } : {}),
     ...(options.providerOptions ? { providerOptions: options.providerOptions } : {}),
+    ...(options.reasoning ? { reasoning: options.reasoning } : {}),
     ...("includeRawChunks" in options && options.includeRawChunks !== undefined
       ? { includeRawChunks: options.includeRawChunks }
       : {}),

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.990";
+export const VERSION = "0.1.991";


### PR DESCRIPTION
## Summary

Fixes veryfront/veryfront-studio#5486.
Related to veryfront/veryfront-studio#5258 for child `invoke_agent` visibility.

- Adds the missing live Veryfront Cloud catalog models and marks thinking-capable models explicitly.
- Carries provider-neutral `reasoning` through model transport, root runtime calls, child `invoke_agent`, and fork run steps.
- Keeps Anthropic provider-specific thinking defaults, including Claude Opus adaptive thinking, in the catalog provider-options resolver.
- Routes Veryfront Cloud OpenAI thinking-capable catalog models such as `gpt-5.4-nano` through `/responses` with default reasoning summaries instead of `/chat/completions`.
- Preserves explicit providerOptions thinking opt-outs over catalog default reasoning.
- Bumps package version from `0.1.990` to `0.1.991`.

## TDD transcript / evidence

### Red

Initial targeted command:

```bash
deno test --allow-all \
  src/provider/veryfront-cloud/model-catalog.test.ts \
  src/provider/veryfront-cloud/provider.test.ts \
  src/runtime/runtime-bridge.test.ts \
  src/agent/runtime/model-transport.test.ts \
  src/agent/runtime/default-provider-options.test.ts \
  src/agent/hosted/child-tool-input.test.ts \
  src/agent/hosted/child-fork-execution-runner.test.ts \
  src/agent/streaming/fork-runtime-stream.test.ts
```

Expected failures before implementation included:

- `gpt-5.4-nano` expected `/ai/gateway/openai/v1/responses`, actual `/ai/gateway/openai/v1/chat/completions`.
- Runtime bridge expected forwarded `reasoning`, actual `undefined`.
- Child fork expected model-default thinking when omitted, actual `undefined`.
- Catalog expected `gpt-5.4-mini`, `gpt-5.4`, `gpt-5.2`, Gemini 2.5, and Kimi 2.5 entries/default thinking, actual missing/undefined.
- Claude Opus 4.8 expected adaptive provider options, actual `undefined`.

Review-feedback red test:

```bash
deno test --allow-all src/agent/runtime/model-transport.test.ts
```

Expected failure before the opt-out fix: providerOptions with `thinking: { type: "disabled" }` still resolved default reasoning as `{ enabled: true }`; expected `{ enabled: false }`.

### Green

Targeted regression suite:

```bash
deno test --allow-all \
  src/provider/veryfront-cloud/model-catalog.test.ts \
  src/provider/veryfront-cloud/provider.test.ts \
  src/runtime/runtime-bridge.test.ts \
  src/agent/runtime/model-transport.test.ts \
  src/agent/runtime/default-provider-options.test.ts \
  src/agent/hosted/child-tool-input.test.ts \
  src/agent/hosted/child-fork-execution-runner.test.ts \
  src/agent/streaming/fork-runtime-stream.test.ts
```

Result on rebased commit `44ff8be3a`: `ok | 27 passed (64 steps) | 0 failed`.

Project verification:

```bash
deno task verify:quick
```

Result on rebased commit `44ff8be3a`: passed, including manifest checks, fmt check, lint gates, docs validation, and typecheck.

Full unit note:

```bash
deno task test:unit
```

Result in this shell: `2223 passed`; 3 unrelated observability config assertions failed because the shell exports OTLP/Grafana env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_METRICS_EXPORTER`, etc.). The failing slice passes when those env vars are unset:

```bash
env -u OTEL_EXPORTER_OTLP_ENDPOINT \
    -u OTEL_EXPORTER_OTLP_HEADERS \
    -u OTEL_EXPORTER_OTLP_PROTOCOL \
    -u OTEL_LOGS_EXPORTER \
    -u OTEL_METRICS_EXPORTER \
    -u OTEL_RESOURCE_ATTRIBUTES \
    -u OTEL_TRACES_EXPORTER \
  deno test --allow-all \
    src/config/runtime-config.test.ts \
    src/observability/metrics/config.test.ts
```

Result: `ok | 2 passed (47 steps) | 0 failed`.

## Request proof covered locally

The new `veryfront-cloud/provider.test.ts` proves that `veryfront-cloud/openai/gpt-5.4-nano` now sends:

- URL: `https://api.veryfront.com/ai/gateway/openai/v1/responses`
- Body: `reasoning: { effort: "medium", summary: "auto" }`
- Stream parser emits/handles a reasoning summary event before final text.

Staging proof should be collected after this branch is deployed to staging.
