### PR TITLE
[codex] Increase document fallback extraction timeout

### DIFF
--- a/extensions/ext-document-kreuzberg/src/index.test.ts
+++ b/extensions/ext-document-kreuzberg/src/index.test.ts
@@ -144,8 +144,8 @@ describe("ext-document-kreuzberg extension", () => {
     assertEquals(typeof extractor.extractInWorker, "function");
   });
 
-  it("uses a two minute timeout for fallback worker extraction", () => {
-    assertEquals(EXTRACTION_TIMEOUT_MS, 120_000);
+  it("uses a ten-minute timeout for fallback worker extraction", () => {
+    assertEquals(EXTRACTION_TIMEOUT_MS, 10 * 60_000);
   });
 
   it("uses native extraction for PDFs in Deno before falling back to the WASM worker", async () => {

--- a/extensions/ext-document-kreuzberg/src/index.ts
+++ b/extensions/ext-document-kreuzberg/src/index.ts
@@ -18,10 +18,10 @@ import { isMissingPackageError, loadKreuzberg, loadKreuzbergNative } from "./kre
 import { extractionConfigForMimeType } from "./extraction-config.ts";
 import { isDeno } from "./runtime.ts";
 
-/** Maximum time to wait for fallback worker extraction before aborting. */
-export const EXTRACTION_TIMEOUT_MS = 120_000;
 export const NATIVE_PROGRESS_IDLE_TIMEOUT_MS = 120_000;
 export const NATIVE_PROGRESS_HARD_TIMEOUT_MS = 10 * 60_000;
+/** Maximum time to wait for fallback worker extraction before aborting. */
+export const EXTRACTION_TIMEOUT_MS = NATIVE_PROGRESS_HARD_TIMEOUT_MS;
 
 function extractInWorkerDeno(
   buffer: ArrayBuffer,


### PR DESCRIPTION
## Summary
- increase the fallback Deno document extraction worker timeout from 120s to 10 minutes
- keep the timeout aligned with the existing native-progress hard timeout
- update the regression test that pins the fallback worker budget

## Why
Staging proof run `run_7f806a82-d68d-4008-818a-d701c46cd9de` no longer 504s after the server timeout change, but still fails semantically because native progress extraction is unavailable and the fallback opaque worker aborts after 120s on the Bosch PDF.

## Verification
- RED: `deno test --no-check --allow-all extensions/ext-document-kreuzberg/src/index.test.ts` failed with actual `120000`, expected `600000`
- GREEN: `deno test --no-check --allow-all extensions/ext-document-kreuzberg/src/index.test.ts`
- `deno test --no-check --allow-all cli/commands/knowledge/command.test.ts`
- `deno fmt --check extensions/ext-document-kreuzberg/src/index.ts extensions/ext-document-kreuzberg/src/index.test.ts`
- pre-push with observability env cleared: formatting, linter, typecheck, and `2225` unit tests passed

Tracking: veryfront/veryfront-studio#5484