### PR TITLE
Route direct OpenAI reasoning models through Responses

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.991",
+  "version": "0.1.992",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/extensions/ext-llm-openai/src/openai-provider.test.ts
+++ b/extensions/ext-llm-openai/src/openai-provider.test.ts
@@ -12,6 +12,7 @@ import {
   createOpenAIEmbeddingRuntime,
   createOpenAIModelRuntime,
   createOpenAIResponsesRuntime,
+  OpenAIProvider,
 } from "./openai-provider.ts";
 
 // ---------------------------------------------------------------------------
@@ -325,6 +326,120 @@ describe("openai-provider", () => {
           totalTokens: 10,
         },
       },
+    ]);
+  });
+
+  it("routes direct OpenAI reasoning models with custom labels through Responses", async () => {
+    const encoder = new TextEncoder();
+    let requestedUrl = "";
+    let requestedInit: RequestInit | undefined;
+    const provider = new OpenAIProvider();
+    const runtime = provider.createModel("gpt-5.4-nano", {
+      credential: "test-openai-key",
+      baseURL: "https://example.openai.test/v1",
+      name: "prod-openai",
+      fetch: (input, init) => {
+        requestedUrl = String(input);
+        requestedInit = init;
+        return Promise.resolve(
+          new Response(
+            ReadableStream.from([
+              encoder.encode(
+                'data: {"type":"response.output_item.added","item":{"id":"rs_1","type":"reasoning"}}\n\n',
+              ),
+              encoder.encode(
+                'data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_1","delta":"Thinking."}\n\n',
+              ),
+              encoder.encode(
+                'data: {"type":"response.output_item.done","item":{"id":"rs_1","type":"reasoning"}}\n\n',
+              ),
+              encoder.encode(
+                'data: {"type":"response.output_item.added","item":{"id":"msg_1","type":"message"}}\n\n',
+              ),
+              encoder.encode(
+                'data: {"type":"response.output_text.delta","item_id":"msg_1","delta":"Done."}\n\n',
+              ),
+              encoder.encode(
+                'data: {"type":"response.output_item.done","item":{"id":"msg_1","type":"message"}}\n\n',
+              ),
+              encoder.encode(
+                'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":2,"output_tokens":3,"output_tokens_details":{"reasoning_tokens":2},"total_tokens":5}}}\n\n',
+              ),
+              encoder.encode("data: [DONE]\n\n"),
+            ]),
+            { status: 200, headers: { "content-type": "text/event-stream" } },
+          ),
+        );
+      },
+    });
+
+    const result = await runtime.doStream({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Solve a logic check." }],
+      }],
+    });
+
+    const requestBody = JSON.parse(readRequestBody(requestedInit) ?? "{}");
+    const parts = await collectAsync(result.stream);
+
+    assertEquals(runtime.provider, "prod-openai");
+    assertEquals(requestedUrl, "https://example.openai.test/v1/responses");
+    assertEquals(requestBody.reasoning, { effort: "medium", summary: "auto" });
+    assertEquals(parts.map((part) => (part as { type: string }).type), [
+      "reasoning-start",
+      "reasoning-delta",
+      "reasoning-end",
+      "text-delta",
+      "finish",
+    ]);
+  });
+
+  it("keeps OpenAI-compatible provider identity separate from display labels", async () => {
+    const encoder = new TextEncoder();
+    let requestedUrl = "";
+    let requestedInit: RequestInit | undefined;
+    const provider = new OpenAIProvider();
+    const runtime = provider.createModel("gpt-5.4-nano", {
+      credential: "test-openai-compatible-key",
+      baseURL: "https://example.compatible.test/v1",
+      name: "prod-compatible-openai",
+      providerName: "openai-compatible",
+      fetch: (input, init) => {
+        requestedUrl = String(input);
+        requestedInit = init;
+        return Promise.resolve(
+          new Response(
+            ReadableStream.from([
+              encoder.encode('data: {"choices":[{"delta":{"content":"Done."}}]}\n\n'),
+              encoder.encode(
+                'data: {"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}\n\n',
+              ),
+              encoder.encode("data: [DONE]\n\n"),
+            ]),
+            { status: 200, headers: { "content-type": "text/event-stream" } },
+          ),
+        );
+      },
+    });
+
+    const result = await runtime.doStream({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Use an OpenAI-compatible endpoint." }],
+      }],
+    });
+
+    const requestBody = JSON.parse(readRequestBody(requestedInit) ?? "{}");
+    const parts = await collectAsync(result.stream);
+
+    assertEquals(runtime.provider, "prod-compatible-openai");
+    assertEquals(requestedUrl, "https://example.compatible.test/v1/chat/completions");
+    assertEquals(requestBody.reasoning, undefined);
+    assertEquals(requestBody.reasoning_effort, undefined);
+    assertEquals(parts.map((part) => (part as { type: string }).type), [
+      "text-delta",
+      "finish",
     ]);
   });
 

--- a/extensions/ext-llm-openai/src/openai-provider.ts
+++ b/extensions/ext-llm-openai/src/openai-provider.ts
@@ -39,6 +39,7 @@ import {
 } from "./openai-chat-request-builder.ts";
 import { streamOpenAICompatibleParts } from "./openai-chat-stream.ts";
 import { buildOpenAIResponsesRequest } from "./openai-responses-request-builder.ts";
+import { isOpenAIReasoningModel } from "./openai-reasoning-models.ts";
 import {
   extractOpenAIResponsesUsage,
   normalizeOpenAIResponsesFinishReason,
@@ -63,8 +64,27 @@ export {
 export interface OpenAIRuntimeConfig {
   apiKey: string;
   baseURL?: string;
+  /** Display/telemetry label. */
   name?: string;
+  /** Provider identity for OpenAI request defaults. Defaults to `name` in low-level factories. */
+  providerName?: string;
   fetch?: typeof globalThis.fetch;
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function getOpenAIProviderLabel(config: { name?: string }): string {
+  return readNonEmptyString(config.name) ?? "openai";
+}
+
+function getRuntimeOpenAIProviderName(config: OpenAIRuntimeConfig): string {
+  return readNonEmptyString(config.providerName) ?? getOpenAIProviderLabel(config);
+}
+
+function getLLMOpenAIProviderName(config: LLMProviderConfig): string {
+  return readNonEmptyString(config.providerName) ?? "openai";
 }
 
 type OpenAICompatibleChoice = {
@@ -408,8 +428,10 @@ export function createOpenAIModelRuntime(
   modelId: string,
 ): ModelRuntime {
   const fetchImpl = config.fetch ?? globalThis.fetch;
+  const providerLabel = getOpenAIProviderLabel(config);
+  const providerName = getRuntimeOpenAIProviderName(config);
   return {
-    provider: config.name ?? "openai",
+    provider: providerLabel,
     modelId,
     specificationVersion: "v3",
     supportedUrls: {},
@@ -419,7 +441,7 @@ export function createOpenAIModelRuntime(
       const warnings = createWarningCollector();
       const body = buildOpenAIChatRequest(
         modelId,
-        config.name ?? "openai",
+        providerName,
         options,
         false,
         warnings,
@@ -427,7 +449,7 @@ export function createOpenAIModelRuntime(
       return requestJson({
         url,
         fetchImpl,
-        providerLabel: config.name ?? "openai",
+        providerLabel,
         providerKind: "openai",
         init: createOpenAIRequestInit({
           apiKey: config.apiKey,
@@ -449,7 +471,7 @@ export function createOpenAIModelRuntime(
       const warnings = createWarningCollector();
       const body = buildOpenAIChatRequest(
         modelId,
-        config.name ?? "openai",
+        providerName,
         options,
         true,
         warnings,
@@ -457,7 +479,7 @@ export function createOpenAIModelRuntime(
       return requestStream({
         url,
         fetchImpl,
-        providerLabel: config.name ?? "openai",
+        providerLabel,
         providerKind: "openai",
         init: createOpenAIRequestInit({
           apiKey: config.apiKey,
@@ -483,8 +505,10 @@ export function createOpenAIResponsesRuntime(
   modelId: string,
 ): ModelRuntime {
   const fetchImpl = config.fetch ?? globalThis.fetch;
+  const providerLabel = getOpenAIProviderLabel(config);
+  const providerName = getRuntimeOpenAIProviderName(config);
   return {
-    provider: config.name ?? "openai",
+    provider: providerLabel,
     modelId,
     specificationVersion: "v3",
     supportedUrls: {},
@@ -494,7 +518,7 @@ export function createOpenAIResponsesRuntime(
       const warnings = createWarningCollector();
       const body = buildOpenAIResponsesRequest(
         modelId,
-        config.name ?? "openai",
+        providerName,
         options,
         false,
         warnings,
@@ -502,7 +526,7 @@ export function createOpenAIResponsesRuntime(
       return requestJson({
         url,
         fetchImpl,
-        providerLabel: config.name ?? "openai",
+        providerLabel,
         providerKind: "openai",
         init: createOpenAIRequestInit({
           apiKey: config.apiKey,
@@ -524,7 +548,7 @@ export function createOpenAIResponsesRuntime(
       const warnings = createWarningCollector();
       const body = buildOpenAIResponsesRequest(
         modelId,
-        config.name ?? "openai",
+        providerName,
         options,
         true,
         warnings,
@@ -532,7 +556,7 @@ export function createOpenAIResponsesRuntime(
       return requestStream({
         url,
         fetchImpl,
-        providerLabel: config.name ?? "openai",
+        providerLabel,
         providerKind: "openai",
         init: createOpenAIRequestInit({
           apiKey: config.apiKey,
@@ -558,8 +582,9 @@ export function createOpenAIEmbeddingRuntime(
   modelId: string,
 ): EmbeddingRuntime {
   const fetchImpl = config.fetch ?? globalThis.fetch;
+  const providerLabel = getOpenAIProviderLabel(config);
   return {
-    provider: config.name ?? "openai",
+    provider: providerLabel,
     modelId,
     supportsParallelCalls: true,
     doEmbed({ values, abortSignal }) {
@@ -575,7 +600,7 @@ export function createOpenAIEmbeddingRuntime(
       return requestJson({
         url,
         fetchImpl,
-        providerLabel: config.name ?? "openai",
+        providerLabel,
         providerKind: "openai",
         init: createOpenAIRequestInit({
           apiKey: config.apiKey,
@@ -601,11 +626,27 @@ export class OpenAIProvider implements LLMProvider {
   readonly id = "openai";
 
   createModel(modelId: string, config: LLMProviderConfig): ModelRuntime {
+    const providerLabel = getOpenAIProviderLabel(config);
+    const providerName = getLLMOpenAIProviderName(config);
+    if (isOpenAIReasoningModel(modelId, providerName)) {
+      return createOpenAIResponsesRuntime(
+        {
+          apiKey: config.credential,
+          baseURL: config.baseURL,
+          name: providerLabel,
+          providerName,
+          fetch: config.fetch,
+        },
+        modelId,
+      );
+    }
+
     return createOpenAIModelRuntime(
       {
         apiKey: config.credential,
         baseURL: config.baseURL,
-        name: config.name ?? "openai",
+        name: providerLabel,
+        providerName,
         fetch: config.fetch,
       },
       modelId,
@@ -617,7 +658,7 @@ export class OpenAIProvider implements LLMProvider {
       {
         apiKey: config.credential,
         baseURL: config.baseURL,
-        name: config.name ?? "openai",
+        name: getOpenAIProviderLabel(config),
         fetch: config.fetch,
       },
       modelId,
@@ -629,7 +670,8 @@ export class OpenAIProvider implements LLMProvider {
       {
         apiKey: config.credential,
         baseURL: config.baseURL,
-        name: config.name ?? "openai",
+        name: getOpenAIProviderLabel(config),
+        providerName: getLLMOpenAIProviderName(config),
         fetch: config.fetch,
       },
       modelId,

--- a/extensions/ext-llm-openai/src/openai-reasoning-models.ts
+++ b/extensions/ext-llm-openai/src/openai-reasoning-models.ts
@@ -15,8 +15,9 @@ export type ResolvedOpenAIReasoning = {
 
 const DEFAULT_REASONING_EFFORT: OpenAIReasoningEffort = "medium";
 
-function supportsDefaultReasoningParams(providerName: string): boolean {
-  return providerName === "openai" || providerName === "veryfront-cloud";
+export function supportsDefaultReasoningParams(providerName: string): boolean {
+  const normalizedProvider = providerName.toLowerCase();
+  return normalizedProvider === "openai" || normalizedProvider === "veryfront-cloud";
 }
 
 function isGpt5ChatSnapshot(modelId: string): boolean {
@@ -45,9 +46,7 @@ export function getDefaultOpenAIReasoningEffort(
   providerName = "openai",
 ): OpenAIReasoningEffort | undefined {
   const normalized = modelId.toLowerCase();
-  const normalizedProvider = providerName.toLowerCase();
-
-  if (!supportsDefaultReasoningParams(normalizedProvider)) {
+  if (!supportsDefaultReasoningParams(providerName)) {
     return undefined;
   }
 
@@ -101,7 +100,7 @@ export function shouldRequestOpenAIReasoningSummary(
   providerName: string,
   reasoning: ResolvedOpenAIReasoning,
 ): boolean {
-  return reasoning.source === "explicit" || providerName.toLowerCase() === "veryfront-cloud";
+  return reasoning.source === "explicit" || supportsDefaultReasoningParams(providerName);
 }
 
 export function isOpenAIReasoningModel(modelId: string, providerName = "openai"): boolean {

--- a/extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts
+++ b/extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts
@@ -46,7 +46,7 @@ describe("ext-llm-openai/openai-responses-request-builder", () => {
     assertEquals(warnings.drain().map((warning) => warning.setting), ["temperature"]);
   });
 
-  it("omits reasoning summaries for direct OpenAI default reasoning requests", () => {
+  it("requests reasoning summaries for direct OpenAI default reasoning requests", () => {
     const warnings = createWarningCollector();
 
     const body = buildOpenAIResponsesRequest(
@@ -59,7 +59,7 @@ describe("ext-llm-openai/openai-responses-request-builder", () => {
       warnings,
     );
 
-    assertEquals(body.reasoning, { effort: "medium" });
+    assertEquals(body.reasoning, { effort: "medium", summary: "auto" });
   });
 
   it("keeps explicit reasoning summaries for direct OpenAI requests", () => {

--- a/src/provider/model-registry.ts
+++ b/src/provider/model-registry.ts
@@ -87,6 +87,7 @@ function autoInitializeFromEnv(): void {
         return provider.createModel(id, {
           credential: config.apiKey,
           baseURL: config.baseURL,
+          providerName: "openai-compatible",
         });
       }
       throw toError(createError({

--- a/src/provider/veryfront-cloud/openai.ts
+++ b/src/provider/veryfront-cloud/openai.ts
@@ -17,6 +17,7 @@ export function createVeryfrontCloudOpenAIModel(
     credential: config.apiToken,
     baseURL: config.baseURL,
     name: "veryfront-cloud",
+    providerName: "veryfront-cloud",
     fetch: config.fetch,
   });
 }
@@ -29,6 +30,7 @@ export function createVeryfrontCloudOpenAIResponsesModel(
     credential: config.apiToken,
     baseURL: config.baseURL,
     name: "veryfront-cloud",
+    providerName: "veryfront-cloud",
     fetch: config.fetch,
   });
 }

--- a/src/provider/veryfront-cloud/provider.ts
+++ b/src/provider/veryfront-cloud/provider.ts
@@ -64,6 +64,7 @@ export function createVeryfrontCloudModel(modelId: string): ModelRuntime {
             credential: apiToken,
             baseURL,
             name: "veryfront-cloud",
+            providerName: "veryfront-cloud",
             fetch,
           }));
         }
@@ -79,6 +80,7 @@ export function createVeryfrontCloudModel(modelId: string): ModelRuntime {
           credential: apiToken,
           baseURL,
           name: "veryfront-cloud",
+          providerName: "veryfront-cloud",
           fetch,
         }));
       }
@@ -97,6 +99,7 @@ export function createVeryfrontCloudModel(modelId: string): ModelRuntime {
           credential: apiToken,
           baseURL,
           name: "veryfront-cloud",
+          providerName: "openai-compatible",
           fetch,
         }));
       }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.991";
+export const VERSION = "0.1.992";


### PR DESCRIPTION
## Summary
- route direct OpenAI reasoning-capable models such as `gpt-5.4-nano` through the Responses runtime instead of Chat Completions
- request `reasoning.summary: \"auto\"` for direct OpenAI default reasoning requests, matching the Veryfront Cloud path
- bump package/runtime version to `0.1.992`

## Root Cause
Staging showed parent runs using `veryfront-cloud/openai/gpt-5.4-nano` emitted reasoning events, but child runs could resolve to direct `openai/gpt-5.4-nano` when direct OpenAI credentials were present. That direct OpenAI `createModel()` path still used Chat Completions, and the direct Responses request builder omitted default reasoning summaries, so child `invoke_agent` runs had no visible reasoning event stream even though the model is reasoning-capable.

## TDD / Verification
Red first:
- `deno test --allow-all extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts extensions/ext-llm-openai/src/openai-provider.test.ts`
- Failed because direct OpenAI default reasoning body was missing `summary: \"auto\"` and `OpenAIProvider.createModel(\"gpt-5.4-nano\")` hit `/chat/completions` instead of `/responses`.

Green:
- `deno test --frozen --allow-all extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts extensions/ext-llm-openai/src/openai-provider.test.ts` → 2 passed, 51 steps.
- `env -u OTEL_EXPORTER_OTLP_ENDPOINT -u OTEL_EXPORTER_OTLP_TRACES_ENDPOINT -u OTEL_EXPORTER_OTLP_METRICS_ENDPOINT -u OTEL_EXPORTER_OTLP_HEADERS -u OTEL_METRICS_EXPORTER -u OTEL_TRACES_EXPORTER -u OTEL_METRICS_ENABLED -u OTEL_TRACES_ENABLED -u OTEL_SERVICE_NAME deno test --frozen --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts extensions/ext-llm-openai/src/openai-provider.test.ts` → 4 passed, 127 steps.
- Pre-push hook: formatting, lint, typecheck, and unit tests → 2225 passed, 19101 steps.

Earlier broader targeted suite also passed after the code change:
- `deno test --allow-all extensions/ext-llm-openai/src/openai-reasoning-models.test.ts extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts extensions/ext-llm-openai/src/openai-chat-stream.test.ts extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts extensions/ext-llm-openai/src/openai-responses-stream.test.ts extensions/ext-llm-openai/src/openai-provider.test.ts src/provider/veryfront-cloud/provider.test.ts src/provider/veryfront-cloud/model-catalog.test.ts src/agent/runtime/model-resolution.test.ts src/agent/runtime/model-transport.test.ts src/agent/hosted/child-tool-input.test.ts src/agent/hosted/child-fork-execution-runner.test.ts src/agent/streaming/fork-runtime-stream.test.ts` → 32 passed, 123 steps.

## Staging Evidence Before This Fix
- Direct staging gateway probe to `/api/ai/gateway/openai/v1/responses` with `model: gpt-5.4-nano` and `reasoning.summary: auto` returned `response.reasoning_summary_text.delta` events and usage with `reasoning_tokens`, proving the gateway/provider can emit reasoning summaries.
- Full staging agent proof before this fix:
  - conversation: `f9c2f673-cbe0-4a3b-909e-ed6063381058`
  - parent run: `run_955f6f7b9d184a63a69b5d9af7f85d0c`
  - child run: `run_e0323dc3-15e6-44d9-9148-913efb7118bf`
  - parent DB count: 577 events, 432 `REASONING_*` events, 1893 reasoning delta chars, invoke-agent present
  - child DB count: 6 events, 0 `REASONING_*` events
  - child run metadata/logs showed direct `openai/gpt-5.4-nano`, which is the path fixed here

## Related
- veryfront/veryfront-studio#5486
- veryfront/veryfront-studio#5258