### PR TITLE
Release veryfront 0.1.992

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.991",
+  "version": "0.1.992",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.991";
+export const VERSION = "0.1.992";


### PR DESCRIPTION
## Summary
- Bump veryfront package/runtime version to 0.1.992.
- Includes the merged document fallback extraction timeout hardening from #2736.

## Test Plan
- deno fmt --check deno.json src/utils/version-constant.ts
- env -u GRAFANA_SERVICE_ACCOUNT_TOKEN -u GRAFANA_URL -u OTEL_EXPORTER_OTLP_ENDPOINT -u OTEL_EXPORTER_OTLP_HEADERS -u OTEL_EXPORTER_OTLP_PROTOCOL -u OTEL_LOGS_EXPORTER -u OTEL_METRICS_EXPORTER -u OTEL_RESOURCE_ATTRIBUTES -u OTEL_TRACES_EXPORTER deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/observability/metrics/config.test.ts src/config/runtime-config.test.ts
- pre-push hook under cleaned OTEL/Grafana env: format, lint, typecheck, 2225 unit tests