### PR TITLE
[codex] Complete PPTX Markdown extraction and RAG refresh

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.994",
+  "version": "0.1.995",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/api-reference/veryfront/embedding.md
+++ b/docs/api-reference/veryfront/embedding.md
@@ -39,7 +39,7 @@ export const { POST, GET, DELETE } = createUploadHandler(store, {
 | `createUploadHandler`       | Creates HTTP route handlers for upload, listing, and deletion.                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L239)   |
 | `embedding`                 | Creates an embedding facade.                                                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/embedding.ts#L26)         |
 | `loadUpload`                | Extracts embedding-ready text or Markdown from upload formats.                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-loader.ts#L18)     |
-| `ragStore`                  | Creates a persistent RAG store with lazy embedding and similarity search.          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/rag-store.ts#L172)        |
+| `ragStore`                  | Creates a persistent RAG store with lazy embedding and similarity search.          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/rag-store.ts#L174)        |
 | `registerEmbeddingProvider` | Register an embedding provider factory.                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/resolve.ts#L22)           |
 | `resolveEmbeddingModel`     | Resolve a "provider/model" string to an embedding runtime instance.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/resolve.ts#L109)          |
 | `similarity`                | Compute cosine similarity between two numeric vectors.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runtime/runtime-bridge.ts#L807)     |
@@ -48,26 +48,27 @@ export const { POST, GET, DELETE } = createUploadHandler(store, {
 
 ### Types
 
-| Name                        | Description                                | Source                                                                                                 |
-| --------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
-| `ChunkOptions`              | Options accepted by chunk.                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L25)             |
-| `Embedding`                 | Public API contract for embedding.         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L16)             |
-| `EmbeddingConfig`           | Configuration used by embedding.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L1)              |
-| `RagChunk`                  | Public API contract for rag chunk.         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L75)             |
-| `RagDocumentMeta`           | Public API contract for rag document meta. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L65)             |
-| `RagSearchOptions`          | Options accepted by rag search.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L117)            |
-| `RagSearchResult`           | Result returned from rag search.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L107)            |
-| `RagStore`                  | Public API contract for rag store.         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L123)            |
-| `RagStoreBackend`           | Public API contract for rag store backend. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L90)             |
-| `RagStoreConfig`            | Configuration used by rag store.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L93)             |
-| `RagStoreData`              | Public API contract for rag store data.    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L84)             |
-| `SearchOptions`             | Options accepted by search.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L37)             |
-| `SearchResult`              | Result returned from search.               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L46)             |
-| `UploadAuthorizationResult` |                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L88)    |
-| `UploadAuthorize`           |                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L90)    |
-| `UploadHandlerAuthConfig`   |                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L94)    |
-| `UploadHandlerConfig`       |                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L98)    |
-| `UseUploadsOptions`         | Options accepted by use uploads.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/react/use-uploads.ts#L12) |
-| `UseUploadsResult`          | Result returned from use uploads.          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/react/use-uploads.ts#L18) |
-| `VectorStore`               | Public API contract for vector store.      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L53)             |
-| `VectorStoreConfig`         | Configuration used by vector store.        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L32)             |
+| Name                        | Description                                                | Source                                                                                                 |
+| --------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `ChunkOptions`              | Options accepted by chunk.                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L25)             |
+| `Embedding`                 | Public API contract for embedding.                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L16)             |
+| `EmbeddingConfig`           | Configuration used by embedding.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L1)              |
+| `RagChunk`                  | Public API contract for rag chunk.                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L75)             |
+| `RagDocumentMeta`           | Public API contract for rag document meta.                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L65)             |
+| `RagRefreshOptions`         | Options accepted when refreshing an existing rag document. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L123)            |
+| `RagSearchOptions`          | Options accepted by rag search.                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L117)            |
+| `RagSearchResult`           | Result returned from rag search.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L107)            |
+| `RagStore`                  | Public API contract for rag store.                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L130)            |
+| `RagStoreBackend`           | Public API contract for rag store backend.                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L90)             |
+| `RagStoreConfig`            | Configuration used by rag store.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L93)             |
+| `RagStoreData`              | Public API contract for rag store data.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L84)             |
+| `SearchOptions`             | Options accepted by search.                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L37)             |
+| `SearchResult`              | Result returned from search.                               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L46)             |
+| `UploadAuthorizationResult` |                                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L88)    |
+| `UploadAuthorize`           |                                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L90)    |
+| `UploadHandlerAuthConfig`   |                                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L94)    |
+| `UploadHandlerConfig`       |                                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L98)    |
+| `UseUploadsOptions`         | Options accepted by use uploads.                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/react/use-uploads.ts#L12) |
+| `UseUploadsResult`          | Result returned from use uploads.                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/react/use-uploads.ts#L18) |
+| `VectorStore`               | Public API contract for vector store.                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L53)             |
+| `VectorStoreConfig`         | Configuration used by vector store.                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L32)             |

--- a/docs/api-reference/veryfront/embedding.md
+++ b/docs/api-reference/veryfront/embedding.md
@@ -20,7 +20,7 @@ import {
 ## Examples
 
 ```ts
-import { ragStore, createUploadHandler } from "veryfront/embedding";
+import { createUploadHandler, ragStore } from "veryfront/embedding";
 
 const store = ragStore({});
 export const { POST, GET, DELETE } = createUploadHandler(store, {
@@ -32,42 +32,42 @@ export const { POST, GET, DELETE } = createUploadHandler(store, {
 
 ### Functions
 
-| Name | Description | Source |
-|------|-------------|--------|
-| `chunk` | Splits text into overlapping chunks for embedding. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/chunk.ts#L23) |
-| `clearEmbeddingProviders` | Clear all registered embedding providers (for testing). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/resolve.ts#L153) |
-| `createUploadHandler` | Creates HTTP route handlers for upload, listing, and deletion. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L239) |
-| `embedding` | Creates an embedding facade. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/embedding.ts#L26) |
-| `loadUpload` | Extracts plain text from various upload formats. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-loader.ts#L16) |
-| `ragStore` | Creates a persistent RAG store with lazy embedding and similarity search. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/rag-store.ts#L172) |
-| `registerEmbeddingProvider` | Register an embedding provider factory. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/resolve.ts#L22) |
-| `resolveEmbeddingModel` | Resolve a "provider/model" string to an embedding runtime instance. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/resolve.ts#L109) |
-| `similarity` | Compute cosine similarity between two numeric vectors. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runtime/runtime-bridge.ts#L807) |
-| `useUploads` | useUploads hook for managing RAG upload lifecycle. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/react/use-uploads.ts#L40) |
-| `vectorStore` | Creates an in-memory vector store with integrated embedding and similarity search. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/vector-store.ts#L45) |
+| Name                        | Description                                                                        | Source                                                                                                 |
+| --------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `chunk`                     | Splits text into overlapping chunks for embedding.                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/chunk.ts#L23)             |
+| `clearEmbeddingProviders`   | Clear all registered embedding providers (for testing).                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/resolve.ts#L153)          |
+| `createUploadHandler`       | Creates HTTP route handlers for upload, listing, and deletion.                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L239)   |
+| `embedding`                 | Creates an embedding facade.                                                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/embedding.ts#L26)         |
+| `loadUpload`                | Extracts embedding-ready text or Markdown from upload formats.                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-loader.ts#L18)     |
+| `ragStore`                  | Creates a persistent RAG store with lazy embedding and similarity search.          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/rag-store.ts#L172)        |
+| `registerEmbeddingProvider` | Register an embedding provider factory.                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/resolve.ts#L22)           |
+| `resolveEmbeddingModel`     | Resolve a "provider/model" string to an embedding runtime instance.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/resolve.ts#L109)          |
+| `similarity`                | Compute cosine similarity between two numeric vectors.                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runtime/runtime-bridge.ts#L807)     |
+| `useUploads`                | useUploads hook for managing RAG upload lifecycle.                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/react/use-uploads.ts#L40) |
+| `vectorStore`               | Creates an in-memory vector store with integrated embedding and similarity search. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/vector-store.ts#L45)      |
 
 ### Types
 
-| Name | Description | Source |
-|------|-------------|--------|
-| `ChunkOptions` | Options accepted by chunk. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L25) |
-| `Embedding` | Public API contract for embedding. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L16) |
-| `EmbeddingConfig` | Configuration used by embedding. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L1) |
-| `RagChunk` | Public API contract for rag chunk. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L75) |
-| `RagDocumentMeta` | Public API contract for rag document meta. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L65) |
-| `RagSearchOptions` | Options accepted by rag search. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L117) |
-| `RagSearchResult` | Result returned from rag search. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L107) |
-| `RagStore` | Public API contract for rag store. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L123) |
-| `RagStoreBackend` | Public API contract for rag store backend. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L90) |
-| `RagStoreConfig` | Configuration used by rag store. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L93) |
-| `RagStoreData` | Public API contract for rag store data. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L84) |
-| `SearchOptions` | Options accepted by search. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L37) |
-| `SearchResult` | Result returned from search. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L46) |
-| `UploadAuthorizationResult` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L88) |
-| `UploadAuthorize` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L90) |
-| `UploadHandlerAuthConfig` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L94) |
-| `UploadHandlerConfig` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L98) |
-| `UseUploadsOptions` | Options accepted by use uploads. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/react/use-uploads.ts#L12) |
-| `UseUploadsResult` | Result returned from use uploads. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/react/use-uploads.ts#L18) |
-| `VectorStore` | Public API contract for vector store. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L53) |
-| `VectorStoreConfig` | Configuration used by vector store. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L32) |
+| Name                        | Description                                | Source                                                                                                 |
+| --------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| `ChunkOptions`              | Options accepted by chunk.                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L25)             |
+| `Embedding`                 | Public API contract for embedding.         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L16)             |
+| `EmbeddingConfig`           | Configuration used by embedding.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L1)              |
+| `RagChunk`                  | Public API contract for rag chunk.         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L75)             |
+| `RagDocumentMeta`           | Public API contract for rag document meta. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L65)             |
+| `RagSearchOptions`          | Options accepted by rag search.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L117)            |
+| `RagSearchResult`           | Result returned from rag search.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L107)            |
+| `RagStore`                  | Public API contract for rag store.         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L123)            |
+| `RagStoreBackend`           | Public API contract for rag store backend. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L90)             |
+| `RagStoreConfig`            | Configuration used by rag store.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L93)             |
+| `RagStoreData`              | Public API contract for rag store data.    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L84)             |
+| `SearchOptions`             | Options accepted by search.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L37)             |
+| `SearchResult`              | Result returned from search.               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L46)             |
+| `UploadAuthorizationResult` |                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L88)    |
+| `UploadAuthorize`           |                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L90)    |
+| `UploadHandlerAuthConfig`   |                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L94)    |
+| `UploadHandlerConfig`       |                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/upload-handler.ts#L98)    |
+| `UseUploadsOptions`         | Options accepted by use uploads.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/react/use-uploads.ts#L12) |
+| `UseUploadsResult`          | Result returned from use uploads.          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/react/use-uploads.ts#L18) |
+| `VectorStore`               | Public API contract for vector store.      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L53)             |
+| `VectorStoreConfig`         | Configuration used by vector store.        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/embedding/types.ts#L32)             |

--- a/docs/guides/build-a-rag-app.md
+++ b/docs/guides/build-a-rag-app.md
@@ -102,7 +102,10 @@ Upload ingestion does three things:
 
 OCR is not a separate step. For scanned PDFs or image-only files, run OCR before
 calling `store.ingest()`. Local mode fills embeddings on first search. Cloud
-mode chunks and embeds during ingestion.
+mode chunks and embeds during ingestion. When extraction behavior changes or an
+uploaded document needs reprocessing, call
+`store.refreshDocument(id, text, meta)` to keep the document ID while replacing
+its chunks and embeddings.
 
 ## Add bundled content ingestion
 

--- a/docs/guides/pages-and-routing.md
+++ b/docs/guides/pages-and-routing.md
@@ -219,8 +219,8 @@ export default function Filters() {
 
 By default a query-only navigation refetches the page so server data that
 depends on the query is never shown stale. If a page's query is purely
-client-side state (tabs, filters), opt into the soft fast path — updating the
-URL and re-rendering without a refetch — with the router's `shouldRevalidate`
+client-side state (tabs, filters), opt into the soft fast path, updating the
+URL and re-rendering without a refetch, with the router's `shouldRevalidate`
 option.
 
 ## Verify it worked

--- a/extensions/ext-document-kreuzberg/src/index.test.ts
+++ b/extensions/ext-document-kreuzberg/src/index.test.ts
@@ -47,6 +47,7 @@ function buildCtx(
 }
 
 const PPTX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+const PPT_MIME_TYPE = "application/vnd.ms-powerpoint";
 
 async function buildPptxWithPresentationOrder(): Promise<ArrayBuffer> {
   const zip = new JSZip();
@@ -74,9 +75,81 @@ async function buildPptxWithPresentationOrder(): Promise<ArrayBuffer> {
   );
   zip.file(
     "ppt/slides/slide2.xml",
-    `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
-      <p:cSld><p:spTree><p:sp><p:txBody><a:p><a:r><a:t>Presentation first</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld>
+    `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      <p:cSld>
+        <p:spTree>
+          <p:sp><p:txBody><a:p><a:r><a:t>Presentation first</a:t></a:r></a:p></p:txBody></p:sp>
+          <p:pic>
+            <p:nvPicPr><p:cNvPr id="4" name="Picture 1"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
+            <p:blipFill><a:blip r:embed="rIdImage1"/></p:blipFill>
+            <p:spPr/>
+          </p:pic>
+        </p:spTree>
+      </p:cSld>
     </p:sld>`,
+  );
+
+  const bytes = await zip.generateAsync({ type: "uint8array" });
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+async function buildPptxWithMalformedSlide(): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  zip.file(
+    "ppt/presentation.xml",
+    `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      <p:sldIdLst>
+        <p:sldId id="256" r:id="rId1"/>
+        <p:sldId id="257" r:id="rId2"/>
+      </p:sldIdLst>
+    </p:presentation>`,
+  );
+  zip.file(
+    "ppt/_rels/presentation.xml.rels",
+    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+      <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide2.xml"/>
+    </Relationships>`,
+  );
+  zip.file(
+    "ppt/slides/slide1.xml",
+    `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+      <p:cSld><p:spTree><p:sp><p:txBody><a:p><a:r><a:t>Valid slide</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld>
+    </p:sld>`,
+  );
+  zip.file(
+    "ppt/slides/slide2.xml",
+    `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+      <p:cSld><p:spTree><p:sp><p:txBody><a:p><a:r><a:t>Recoverable corrupt slide</a:t></a:r></a:p></p:txBody></p:sp>
+    </p:sld`,
+  );
+
+  const bytes = await zip.generateAsync({ type: "uint8array" });
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+async function buildPptxWithoutSlides(): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>
+</Types>`,
+  );
+  zip.file(
+    "_rels/.rels",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>
+</Relationships>`,
+  );
+  zip.file(
+    "ppt/presentation.xml",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"/>`,
   );
 
   const bytes = await zip.generateAsync({ type: "uint8array" });
@@ -150,6 +223,7 @@ describe("ext-document-kreuzberg extension", () => {
   });
 
   it("requests markdown extraction for rich document types", () => {
+    assertEquals(extractionConfigForMimeType(PPT_MIME_TYPE), { outputFormat: "markdown" });
     assertEquals(extractionConfigForMimeType(PPTX_MIME_TYPE), { outputFormat: "markdown" });
     assertEquals(extractionConfigForMimeType("application/pdf"), {
       outputFormat: "markdown",
@@ -321,7 +395,8 @@ describe("ext-document-kreuzberg extension", () => {
 
     const result = await extractPptxWithProgressWorker(buffer);
 
-    assertStringIncludes(result.content, "Presentation first\n\nFilename first");
+    assertStringIncludes(result.content, "# Presentation first\n\n# Filename first");
+    assertEquals(result.content.includes("![image]()"), false);
     assertEquals(
       result.events.map((event) => ({
         unit: event.unit,
@@ -333,6 +408,35 @@ describe("ext-document-kreuzberg extension", () => {
         { unit: "slide", current: 2, total: 2 },
       ],
     );
+  });
+
+  it("keeps PPTX slide progress when one slide cannot be parsed by Kreuzberg", async () => {
+    const buffer = await buildPptxWithMalformedSlide();
+
+    const result = await extractPptxWithProgressWorker(buffer);
+
+    assertStringIncludes(result.content, "# Valid slide");
+    assertStringIncludes(result.content, "Recoverable corrupt slide");
+    assertEquals(
+      result.events.map((event) => ({
+        unit: event.unit,
+        current: event.current,
+        total: event.total,
+      })),
+      [
+        { unit: "slide", current: 1, total: 2 },
+        { unit: "slide", current: 2, total: 2 },
+      ],
+    );
+  });
+
+  it("uses whole-file progress for PPTX files with no slide entries", async () => {
+    const buffer = await buildPptxWithoutSlides();
+
+    const result = await extractPptxWithProgressWorker(buffer);
+
+    assertEquals(typeof result.content, "string");
+    assertEquals(result.events, [{ unit: "file", current: 1, total: 1, characters: 0 }]);
   });
 
   it("falls back to the Deno worker when native PDF extraction is unavailable", async () => {

--- a/extensions/ext-document-kreuzberg/src/index.test.ts
+++ b/extensions/ext-document-kreuzberg/src/index.test.ts
@@ -156,6 +156,46 @@ async function buildPptxWithoutSlides(): Promise<ArrayBuffer> {
   return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 }
 
+async function buildPptxWithTitleBodyAndTextbox(): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  zip.file(
+    "ppt/presentation.xml",
+    `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      <p:sldIdLst><p:sldId id="256" r:id="rId1"/></p:sldIdLst>
+    </p:presentation>`,
+  );
+  zip.file(
+    "ppt/_rels/presentation.xml.rels",
+    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+    </Relationships>`,
+  );
+  zip.file(
+    "ppt/slides/slide1.xml",
+    `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+      <p:cSld>
+        <p:spTree>
+          <p:sp>
+            <p:nvSpPr><p:cNvPr id="2" name="Title 1"/><p:cNvSpPr/><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>
+            <p:txBody><a:p><a:r><a:t>Real Slide Title</a:t></a:r></a:p></p:txBody>
+          </p:sp>
+          <p:sp>
+            <p:nvSpPr><p:cNvPr id="3" name="Content Placeholder 2"/><p:cNvSpPr/><p:nvPr><p:ph type="body"/></p:nvPr></p:nvSpPr>
+            <p:txBody><a:p><a:r><a:t>Body paragraph from placeholder</a:t></a:r></a:p></p:txBody>
+          </p:sp>
+          <p:sp>
+            <p:nvSpPr><p:cNvPr id="4" name="TextBox 3"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+            <p:txBody><a:p><a:r><a:t>Freeform textbox content</a:t></a:r></a:p></p:txBody>
+          </p:sp>
+        </p:spTree>
+      </p:cSld>
+    </p:sld>`,
+  );
+
+  const bytes = await zip.generateAsync({ type: "uint8array" });
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
 type NativeProgressWorkerResponse =
   | { type: "done"; content: string }
   | { type: "error"; error: string }
@@ -437,6 +477,26 @@ describe("ext-document-kreuzberg extension", () => {
 
     assertEquals(typeof result.content, "string");
     assertEquals(result.events, [{ unit: "file", current: 1, total: 1, characters: 0 }]);
+  });
+
+  it("keeps PPTX body and textbox text out of top-level Markdown headings", async () => {
+    const buffer = await buildPptxWithTitleBodyAndTextbox();
+
+    const result = await extractPptxWithProgressWorker(buffer);
+
+    assertStringIncludes(result.content, "# Real Slide Title");
+    assertStringIncludes(result.content, "Body paragraph from placeholder");
+    assertStringIncludes(result.content, "Freeform textbox content");
+    assertEquals(result.content.includes("# Body paragraph from placeholder"), false);
+    assertEquals(result.content.includes("# Freeform textbox content"), false);
+    assertEquals(
+      result.events.map((event) => ({
+        unit: event.unit,
+        current: event.current,
+        total: event.total,
+      })),
+      [{ unit: "slide", current: 1, total: 1 }],
+    );
   });
 
   it("falls back to the Deno worker when native PDF extraction is unavailable", async () => {

--- a/extensions/ext-document-kreuzberg/src/index.test.ts
+++ b/extensions/ext-document-kreuzberg/src/index.test.ts
@@ -196,6 +196,55 @@ async function buildPptxWithTitleBodyAndTextbox(): Promise<ArrayBuffer> {
   return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 }
 
+async function buildPptxWithTitleAndTable(): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  zip.file(
+    "ppt/presentation.xml",
+    `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      <p:sldIdLst><p:sldId id="256" r:id="rId1"/></p:sldIdLst>
+    </p:presentation>`,
+  );
+  zip.file(
+    "ppt/_rels/presentation.xml.rels",
+    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+    </Relationships>`,
+  );
+  zip.file(
+    "ppt/slides/slide1.xml",
+    `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+      <p:cSld>
+        <p:spTree>
+          <p:sp>
+            <p:nvSpPr><p:cNvPr id="2" name="Title 1"/><p:cNvSpPr/><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>
+            <p:txBody><a:p><a:r><a:t>Quarterly Results</a:t></a:r></a:p></p:txBody>
+          </p:sp>
+          <p:graphicFrame>
+            <p:nvGraphicFramePr><p:cNvPr id="3" name="Table 2"/><p:cNvGraphicFramePr/><p:nvPr/></p:nvGraphicFramePr>
+            <a:graphic>
+              <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table">
+                <a:tbl>
+                  <a:tr>
+                    <a:tc><a:txBody><a:p><a:r><a:t>Region</a:t></a:r></a:p></a:txBody></a:tc>
+                    <a:tc><a:txBody><a:p><a:r><a:t>Revenue</a:t></a:r></a:p></a:txBody></a:tc>
+                  </a:tr>
+                  <a:tr>
+                    <a:tc><a:txBody><a:p><a:r><a:t>EMEA</a:t></a:r></a:p></a:txBody></a:tc>
+                    <a:tc><a:txBody><a:p><a:r><a:t>4.2M</a:t></a:r></a:p></a:txBody></a:tc>
+                  </a:tr>
+                </a:tbl>
+              </a:graphicData>
+            </a:graphic>
+          </p:graphicFrame>
+        </p:spTree>
+      </p:cSld>
+    </p:sld>`,
+  );
+
+  const bytes = await zip.generateAsync({ type: "uint8array" });
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
 type NativeProgressWorkerResponse =
   | { type: "done"; content: string }
   | { type: "error"; error: string }
@@ -489,6 +538,26 @@ describe("ext-document-kreuzberg extension", () => {
     assertStringIncludes(result.content, "Freeform textbox content");
     assertEquals(result.content.includes("# Body paragraph from placeholder"), false);
     assertEquals(result.content.includes("# Freeform textbox content"), false);
+    assertEquals(
+      result.events.map((event) => ({
+        unit: event.unit,
+        current: event.current,
+        total: event.total,
+      })),
+      [{ unit: "slide", current: 1, total: 1 }],
+    );
+  });
+
+  it("keeps PPTX table text when normalizing slide headings", async () => {
+    const buffer = await buildPptxWithTitleAndTable();
+
+    const result = await extractPptxWithProgressWorker(buffer);
+
+    assertStringIncludes(result.content, "# Quarterly Results");
+    assertStringIncludes(result.content, "Region");
+    assertStringIncludes(result.content, "Revenue");
+    assertStringIncludes(result.content, "EMEA");
+    assertStringIncludes(result.content, "4.2M");
     assertEquals(
       result.events.map((event) => ({
         unit: event.unit,

--- a/extensions/ext-document-kreuzberg/src/native-progress-extraction-worker.ts
+++ b/extensions/ext-document-kreuzberg/src/native-progress-extraction-worker.ts
@@ -62,6 +62,10 @@ function extractPptxSlideText(xml: string): string {
     .trim();
 }
 
+function normalizePptxText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
 function cleanExtractedMarkdown(value: string): string {
   return value
     .replace(/!\[[^\]\n]*\]\(\s*\)/g, "")
@@ -120,6 +124,38 @@ function pptxTextShapes(xml: string): PptxTextShape[] {
   return shapes;
 }
 
+function pptxShapeRoleQueues(xml: string): Map<string, PptxTextShapeRole[]> {
+  const roles = new Map<string, PptxTextShapeRole[]>();
+  for (const shape of pptxTextShapes(xml)) {
+    const key = normalizePptxText(shape.text);
+    if (!key) continue;
+    const queue = roles.get(key) ?? [];
+    queue.push(shape.role);
+    roles.set(key, queue);
+  }
+  return roles;
+}
+
+function normalizePptxMarkdownHeadings(markdown: string, xml: string): string {
+  const roles = pptxShapeRoleQueues(xml);
+  if (roles.size === 0) return markdown;
+
+  return cleanExtractedMarkdown(
+    markdown.split("\n").map((line) => {
+      const heading = line.match(/^#{1,6}\s+(.+?)\s*$/);
+      if (!heading) return line;
+
+      const text = heading[1] ?? "";
+      const queue = roles.get(normalizePptxText(text));
+      const role = queue?.shift();
+      if (!role) return line;
+      if (role === "title") return `# ${text}`;
+      if (role === "subtitle") return `## ${text}`;
+      return text;
+    }).join("\n"),
+  );
+}
+
 function formatPptxShapeText(shape: PptxTextShape): string {
   if (shape.role === "title") return `# ${shape.text}`;
   if (shape.role === "subtitle") return `## ${shape.text}`;
@@ -128,8 +164,9 @@ function formatPptxShapeText(shape: PptxTextShape): string {
 
 function formatPptxSlideText(xml: string): string {
   const shapes = pptxTextShapes(xml);
-  if (shapes.length === 0) return extractPptxSlideText(xml);
-  return shapes.map(formatPptxShapeText).join("\n\n").trim();
+  const nonShapeText = extractPptxSlideText(xml.replace(/<p:sp\b[\s\S]*?<\/p:sp>/g, ""));
+  if (shapes.length === 0) return nonShapeText || extractPptxSlideText(xml);
+  return [...shapes.map(formatPptxShapeText), nonShapeText].filter(Boolean).join("\n\n").trim();
 }
 
 function normalizeZipPath(path: string): string {
@@ -298,19 +335,19 @@ async function extractPptxBySlide(buffer: ArrayBuffer, mimeType: string): Promis
   for (const [index, path] of slidePaths.entries()) {
     const file = zip.file(path);
     const xml = file ? await file.async("text") : "";
-    let content = formatPptxSlideText(xml);
+    let content: string | undefined;
 
-    if (!content && nativeExtractor) {
+    if (nativeExtractor) {
       try {
         const slideBytes = await buildSingleSlidePptx(xml);
         const result = await nativeExtractor.extractBytes(slideBytes, mimeType, config);
-        content = cleanExtractedMarkdown(result.content);
+        content = normalizePptxMarkdownHeadings(cleanExtractedMarkdown(result.content), xml);
       } catch {
         // Fall back below to direct slide text so this slide still reports progress.
       }
     }
 
-    content ||= extractPptxSlideText(xml);
+    content ||= formatPptxSlideText(xml);
     slides.push(content);
     postProgress({
       unit: "slide",

--- a/extensions/ext-document-kreuzberg/src/native-progress-extraction-worker.ts
+++ b/extensions/ext-document-kreuzberg/src/native-progress-extraction-worker.ts
@@ -70,6 +70,13 @@ function cleanExtractedMarkdown(value: string): string {
     .trim();
 }
 
+type PptxTextShapeRole = "title" | "subtitle" | "body";
+
+interface PptxTextShape {
+  role: PptxTextShapeRole;
+  text: string;
+}
+
 function slideNumber(path: string): number {
   return Number(path.match(/\/slide(\d+)\.xml$/)?.[1] ?? 0);
 }
@@ -77,6 +84,52 @@ function slideNumber(path: string): number {
 function getXmlAttribute(tag: string, name: string): string | undefined {
   const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return tag.match(new RegExp(`\\s${escapedName}=(["'])(.*?)\\1`))?.[2];
+}
+
+function pptxShapeRole(shapeXml: string): PptxTextShapeRole {
+  const placeholderTag = shapeXml.match(/<(?:\w+:)?ph\b[^>]*>/)?.[0] ?? "";
+  const placeholderType = getXmlAttribute(placeholderTag, "type");
+  if (placeholderType === "title" || placeholderType === "ctrTitle") return "title";
+  if (placeholderType === "subTitle") return "subtitle";
+
+  const propertyTag = shapeXml.match(/<(?:\w+:)?cNvPr\b[^>]*>/)?.[0] ?? "";
+  const name = getXmlAttribute(propertyTag, "name")?.toLowerCase() ?? "";
+  if (name.includes("subtitle")) return "subtitle";
+  if (name.includes("title")) return "title";
+
+  return "body";
+}
+
+function pptxTextShapes(xml: string): PptxTextShape[] {
+  const shapes = Array.from(xml.matchAll(/<p:sp\b[\s\S]*?<\/p:sp>/g))
+    .map((match) => {
+      const shapeXml = match[0];
+      return {
+        role: pptxShapeRole(shapeXml),
+        text: extractPptxSlideText(shapeXml),
+      };
+    })
+    .filter((shape) => shape.text.length > 0);
+
+  const hasExplicitHeading = shapes.some((shape) =>
+    shape.role === "title" || shape.role === "subtitle"
+  );
+  if (!hasExplicitHeading && shapes.length === 1) {
+    return [{ ...shapes[0]!, role: "title" }];
+  }
+  return shapes;
+}
+
+function formatPptxShapeText(shape: PptxTextShape): string {
+  if (shape.role === "title") return `# ${shape.text}`;
+  if (shape.role === "subtitle") return `## ${shape.text}`;
+  return shape.text;
+}
+
+function formatPptxSlideText(xml: string): string {
+  const shapes = pptxTextShapes(xml);
+  if (shapes.length === 0) return extractPptxSlideText(xml);
+  return shapes.map(formatPptxShapeText).join("\n\n").trim();
 }
 
 function normalizeZipPath(path: string): string {
@@ -245,9 +298,9 @@ async function extractPptxBySlide(buffer: ArrayBuffer, mimeType: string): Promis
   for (const [index, path] of slidePaths.entries()) {
     const file = zip.file(path);
     const xml = file ? await file.async("text") : "";
-    let content: string | undefined;
+    let content = formatPptxSlideText(xml);
 
-    if (nativeExtractor) {
+    if (!content && nativeExtractor) {
       try {
         const slideBytes = await buildSingleSlidePptx(xml);
         const result = await nativeExtractor.extractBytes(slideBytes, mimeType, config);
@@ -257,7 +310,7 @@ async function extractPptxBySlide(buffer: ArrayBuffer, mimeType: string): Promis
       }
     }
 
-    content ??= extractPptxSlideText(xml);
+    content ||= extractPptxSlideText(xml);
     slides.push(content);
     postProgress({
       unit: "slide",

--- a/extensions/ext-document-kreuzberg/src/native-progress-extraction-worker.ts
+++ b/extensions/ext-document-kreuzberg/src/native-progress-extraction-worker.ts
@@ -62,6 +62,14 @@ function extractPptxSlideText(xml: string): string {
     .trim();
 }
 
+function cleanExtractedMarkdown(value: string): string {
+  return value
+    .replace(/!\[[^\]\n]*\]\(\s*\)/g, "")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 function slideNumber(path: string): number {
   return Number(path.match(/\/slide(\d+)\.xml$/)?.[1] ?? 0);
 }
@@ -143,6 +151,43 @@ async function pptxSlidePaths(zip: JSZip): Promise<string[]> {
   ];
 }
 
+async function buildSingleSlidePptx(slideXml: string): Promise<Uint8Array> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>
+  <Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>
+</Types>`,
+  );
+  zip.file(
+    "_rels/.rels",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>
+</Relationships>`,
+  );
+  zip.file(
+    "ppt/presentation.xml",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:sldIdLst><p:sldId id="256" r:id="rId1"/></p:sldIdLst>
+</p:presentation>`,
+  );
+  zip.file(
+    "ppt/_rels/presentation.xml.rels",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+</Relationships>`,
+  );
+  zip.file("ppt/slides/slide1.xml", slideXml);
+  return await zip.generateAsync({ type: "uint8array" });
+}
+
 async function extractPdfByPage(buffer: ArrayBuffer): Promise<string> {
   const { extractBytes } = await loadKreuzbergNative();
   const source = await PDFDocument.load(buffer, { ignoreEncryption: true });
@@ -176,23 +221,43 @@ async function extractPdfByPage(buffer: ArrayBuffer): Promise<string> {
 async function extractPptxBySlide(buffer: ArrayBuffer, mimeType: string): Promise<string> {
   const zip = await JSZip.loadAsync(buffer);
   const slidePaths = await pptxSlidePaths(zip);
+  const config = extractionConfigForMimeType(mimeType);
+  let nativeExtractor: Awaited<ReturnType<typeof loadKreuzbergNative>> | undefined;
+
+  try {
+    nativeExtractor = await loadKreuzbergNative();
+  } catch (error) {
+    if (!slidePaths.length) throw error;
+  }
 
   if (!slidePaths.length) {
-    const { extractBytes } = await loadKreuzbergNative();
-    const result = await extractBytes(
+    const result = await nativeExtractor!.extractBytes(
       new Uint8Array(buffer),
       mimeType,
-      extractionConfigForMimeType(mimeType),
+      config,
     );
-    postProgress({ unit: "file", current: 1, total: 1, characters: result.content.length });
-    return result.content;
+    const content = cleanExtractedMarkdown(result.content);
+    postProgress({ unit: "file", current: 1, total: 1, characters: content.length });
+    return content;
   }
 
   const slides: string[] = [];
   for (const [index, path] of slidePaths.entries()) {
     const file = zip.file(path);
     const xml = file ? await file.async("text") : "";
-    const content = extractPptxSlideText(xml);
+    let content: string | undefined;
+
+    if (nativeExtractor) {
+      try {
+        const slideBytes = await buildSingleSlidePptx(xml);
+        const result = await nativeExtractor.extractBytes(slideBytes, mimeType, config);
+        content = cleanExtractedMarkdown(result.content);
+      } catch {
+        // Fall back below to direct slide text so this slide still reports progress.
+      }
+    }
+
+    content ??= extractPptxSlideText(xml);
     slides.push(content);
     postProgress({
       unit: "slide",

--- a/src/embedding/index.ts
+++ b/src/embedding/index.ts
@@ -34,6 +34,7 @@ export type {
   EmbeddingConfig,
   RagChunk,
   RagDocumentMeta,
+  RagRefreshOptions,
   RagSearchOptions,
   RagSearchResult,
   RagStore,

--- a/src/embedding/rag-store.test.ts
+++ b/src/embedding/rag-store.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { exists, readTextFile, withTempDir } from "#veryfront/testing/deno-compat.ts";
 import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
@@ -118,7 +118,9 @@ describe("ragStore", () => {
       };
       assertEquals(embedded.chunks[0]?.embedding.length, 1536);
 
-      await store.refreshDocument(id, "# New Slide Title\n\nNew body text", {
+      const refresh = store.refreshDocument;
+      assert(refresh);
+      await refresh(id, "# New Slide Title\n\nNew body text", {
         title: "Deck Updated",
         source: "upload:deck-updated.pptx",
         type: "pptx",
@@ -661,23 +663,35 @@ describe("ragStore", () => {
           model: "test/demo",
         });
 
-        await store.refreshDocument("doc-pptx", "# Better Deck\n\nBody text", {
+        const refresh = store.refreshDocument;
+        assert(refresh);
+        await refresh("doc-pptx", "# Better Deck\n\nBody text", {
           title: "Better Deck",
           source: "upload:better.pptx",
           type: "pptx",
         });
 
         assertEquals(deletedFilePaths, [".veryfront/rag/documents/doc-pptx.pptx"]);
-        assertEquals([...ragDocuments.values()][0], {
+        const refreshedDocument = [...ragDocuments.values()][0];
+        const refreshedFilePath = refreshedDocument?.metadata?.filePath;
+        assertEquals(typeof refreshedFilePath, "string");
+        assertEquals(
+          (refreshedFilePath as string).startsWith(
+            ".veryfront/rag/documents/doc-pptx.refresh-",
+          ),
+          true,
+        );
+        assertEquals((refreshedFilePath as string).endsWith(".pptx"), true);
+        assertEquals(refreshedDocument, {
           id: "doc-pptx",
           title: "Better Deck",
           source: "upload:better.pptx",
           type: "pptx",
           created_at: "2026-06-25T00:00:00.000Z",
           updated_at: "2026-06-25T01:00:00.000Z",
-          metadata: { filePath: ".veryfront/rag/documents/doc-pptx.pptx" },
+          metadata: { filePath: refreshedFilePath },
         });
-        const chunks = fileChunks.get(".veryfront/rag/documents/doc-pptx.pptx") ?? [];
+        const chunks = fileChunks.get(refreshedFilePath as string) ?? [];
         assertEquals(chunks.length, 1);
         assertEquals(chunks[0]?.content, "# Better Deck\n\nBody text");
         assertEquals(chunks[0]?.metadata, {
@@ -688,6 +702,127 @@ describe("ragStore", () => {
           type: "pptx",
         });
         assertEquals(embeddingVectors.size, 1);
+
+        const listedDocuments = await store.listDocuments() as Array<Record<string, unknown>>;
+        assertEquals("filePath" in listedDocuments[0]!, false);
+      },
+    );
+  });
+
+  it("keeps old cloud chunks when refresh replacement embedding persistence fails", async () => {
+    setEnv("VERYFRONT_API_TOKEN", "vf_test_cloud");
+    setEnv("VERYFRONT_PROJECT_SLUG", "cloud-project");
+    registerTestEmbeddingProvider();
+
+    const fileChunks = new Map<
+      string,
+      Array<{ id: string; index: number; content: string; metadata?: Record<string, unknown> }>
+    >([
+      [
+        ".veryfront/rag/documents/doc-pptx.pptx",
+        [{
+          id: "old-chunk",
+          index: 0,
+          content: "Old flat PPTX content",
+          metadata: {
+            kind: "rag-document",
+            document_id: "doc-pptx",
+            title: "Old Deck",
+            source: "upload:old.pptx",
+            type: "pptx",
+          },
+        }],
+      ],
+    ]);
+    const ragDocuments = new Map<string, {
+      id: string;
+      title: string;
+      source: string;
+      type: string;
+      created_at: string;
+      updated_at: string;
+      metadata?: Record<string, unknown>;
+    }>([
+      [
+        "doc-pptx",
+        {
+          id: "doc-pptx",
+          title: "Old Deck",
+          source: "upload:old.pptx",
+          type: "pptx",
+          created_at: "2026-06-25T00:00:00.000Z",
+          updated_at: "2026-06-25T00:00:00.000Z",
+          metadata: { filePath: ".veryfront/rag/documents/doc-pptx.pptx" },
+        },
+      ],
+    ]);
+    const deletedFilePaths: string[] = [];
+
+    await withMockFetch(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const url = new URL(request.url);
+        const path = url.pathname;
+
+        const ragDocMatch = path.match(/^\/projects\/[^/]+\/rag\/documents(?:\/(.+))?$/);
+        if (ragDocMatch !== null && request.method === "GET" && !ragDocMatch[1]) {
+          return Response.json({ documents: [...ragDocuments.values()] });
+        }
+
+        const fileMatch = path.match(/^\/projects\/[^/]+\/branches\/[^/]+\/files\/(.+)\/chunks$/);
+        const filePath = fileMatch ? decodeURIComponent(fileMatch[1]!) : null;
+
+        if (request.method === "DELETE" && filePath) {
+          deletedFilePaths.push(filePath);
+          fileChunks.delete(filePath);
+          return Response.json({ deleted: 1 });
+        }
+
+        if (request.method === "POST" && filePath) {
+          const body = await request.json() as {
+            chunks: Array<{
+              chunk_index: number;
+              content: string;
+              metadata?: Record<string, unknown>;
+            }>;
+          };
+          const stored = body.chunks.map((chunk) => ({
+            id: `${filePath}:${chunk.chunk_index}`,
+            index: chunk.chunk_index,
+            content: chunk.content,
+            metadata: chunk.metadata,
+          }));
+          fileChunks.set(filePath, stored);
+          return Response.json({
+            chunks: stored.map(({ id, index }) => ({ id, index })),
+            created: stored.length,
+            updated: 0,
+          });
+        }
+
+        if (request.method === "POST" && path.endsWith("/embeddings")) {
+          return new Response("embedding write failed", { status: 500 });
+        }
+
+        return new Response(`Unhandled ${request.method} ${path}`, { status: 404 });
+      },
+      async () => {
+        const store = ragStore({ model: "test/demo" });
+        const refresh = store.refreshDocument;
+        assert(refresh);
+
+        await assertRejects(
+          () => refresh("doc-pptx", "# Better Deck\n\nBody text"),
+          Error,
+          "embedding write failed",
+        );
+
+        assertEquals(deletedFilePaths.includes(".veryfront/rag/documents/doc-pptx.pptx"), false);
+        assertEquals(
+          fileChunks.get(".veryfront/rag/documents/doc-pptx.pptx")?.[0]?.content,
+          "Old flat PPTX content",
+        );
+        assertEquals(ragDocuments.get("doc-pptx")?.title, "Old Deck");
       },
     );
   });

--- a/src/embedding/rag-store.test.ts
+++ b/src/embedding/rag-store.test.ts
@@ -98,6 +98,52 @@ describe("ragStore", () => {
     });
   });
 
+  it("refreshes an existing local document while preserving its id", async () => {
+    registerTestEmbeddingProvider();
+
+    await withTempDir(async (tempDir) => {
+      const storagePath = join(tempDir, "data", "index.json");
+      const store = ragStore({
+        model: "test/demo",
+        storagePath,
+      });
+      const id = await store.ingest("Deck", "Old slide text", {
+        source: "upload:deck.pptx",
+        type: "pptx",
+      });
+
+      await store.search("old");
+      const embedded = JSON.parse(await readTextFile(storagePath)) as {
+        chunks: Array<{ embedding: number[] }>;
+      };
+      assertEquals(embedded.chunks[0]?.embedding.length, 1536);
+
+      await store.refreshDocument(id, "# New Slide Title\n\nNew body text", {
+        title: "Deck Updated",
+        source: "upload:deck-updated.pptx",
+        type: "pptx",
+      });
+
+      const refreshed = JSON.parse(await readTextFile(storagePath)) as {
+        documents: Array<
+          { id: string; title: string; source: string; type: string; createdAt: number }
+        >;
+        chunks: Array<{ documentId: string; text: string; embedding: number[]; index: number }>;
+      };
+      assertEquals(refreshed.documents.length, 1);
+      assertEquals(refreshed.documents[0]?.id, id);
+      assertEquals(refreshed.documents[0]?.title, "Deck Updated");
+      assertEquals(refreshed.documents[0]?.source, "upload:deck-updated.pptx");
+      assertEquals(refreshed.documents[0]?.type, "pptx");
+      assertEquals(typeof refreshed.documents[0]?.createdAt, "number");
+      assertEquals(refreshed.chunks.length, 1);
+      assertEquals(refreshed.chunks[0]?.documentId, id);
+      assertEquals(refreshed.chunks[0]?.text, "# New Slide Title\n\nNew body text");
+      assertEquals(refreshed.chunks[0]?.embedding, []);
+      assertEquals(refreshed.chunks[0]?.index, 0);
+    });
+  });
+
   it("returns empty results for whitespace-only local queries", async () => {
     await withTempDir(async (tempDir) => {
       const storagePath = join(tempDir, "data", "index.json");
@@ -462,6 +508,186 @@ describe("ragStore", () => {
 
         await store.removeDocument(id);
         assertEquals(await store.listDocuments(), []);
+      },
+    );
+  });
+
+  it("refreshes cloud document chunks and embeddings under the existing id", async () => {
+    setEnv("VERYFRONT_API_TOKEN", "vf_test_cloud");
+    setEnv("VERYFRONT_PROJECT_SLUG", "cloud-project");
+    registerTestEmbeddingProvider();
+
+    const fileChunks = new Map<
+      string,
+      Array<{
+        id: string;
+        index: number;
+        content: string;
+        metadata?: Record<string, unknown>;
+      }>
+    >([
+      [
+        ".veryfront/rag/documents/doc-pptx.pptx",
+        [{
+          id: "old-chunk",
+          index: 0,
+          content: "Old flat PPTX content",
+          metadata: {
+            kind: "rag-document",
+            document_id: "doc-pptx",
+            title: "Old Deck",
+            source: "upload:old.pptx",
+            type: "pptx",
+          },
+        }],
+      ],
+    ]);
+    const ragDocuments = new Map<string, {
+      id: string;
+      title: string;
+      source: string;
+      type: string;
+      created_at: string;
+      updated_at: string;
+      metadata?: Record<string, unknown>;
+    }>([
+      [
+        "doc-pptx",
+        {
+          id: "doc-pptx",
+          title: "Old Deck",
+          source: "upload:old.pptx",
+          type: "pptx",
+          created_at: "2026-06-25T00:00:00.000Z",
+          updated_at: "2026-06-25T00:00:00.000Z",
+          metadata: { filePath: ".veryfront/rag/documents/doc-pptx.pptx" },
+        },
+      ],
+    ]);
+    const embeddingVectors = new Map<string, number[]>();
+    const deletedFilePaths: string[] = [];
+
+    await withMockFetch(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const url = new URL(request.url);
+        const path = url.pathname;
+
+        const ragDocMatch = path.match(/^\/projects\/[^/]+\/rag\/documents(?:\/(.+))?$/);
+        if (ragDocMatch !== null) {
+          const docId = ragDocMatch[1] ? decodeURIComponent(ragDocMatch[1]) : null;
+
+          if (request.method === "GET" && !docId) {
+            return Response.json({
+              documents: [...ragDocuments.values()],
+            });
+          }
+
+          if (request.method === "POST" && !docId) {
+            const body = await request.json() as {
+              id: string;
+              title: string;
+              source: string;
+              type: string;
+              metadata?: Record<string, unknown>;
+            };
+            ragDocuments.set(body.id, {
+              ...body,
+              created_at: ragDocuments.get(body.id)?.created_at ??
+                "2026-06-25T00:00:00.000Z",
+              updated_at: "2026-06-25T01:00:00.000Z",
+            });
+            return Response.json({ document: ragDocuments.get(body.id) });
+          }
+        }
+
+        const fileMatch = path.match(/^\/projects\/[^/]+\/branches\/[^/]+\/files\/(.+)\/chunks$/);
+        const filePath = fileMatch ? decodeURIComponent(fileMatch[1]!) : null;
+
+        if (request.method === "DELETE" && filePath) {
+          deletedFilePaths.push(filePath);
+          fileChunks.delete(filePath);
+          return Response.json({ deleted: 1 });
+        }
+
+        if (request.method === "POST" && filePath) {
+          const body = await request.json() as {
+            chunks: Array<{
+              chunk_index: number;
+              content: string;
+              metadata?: Record<string, unknown>;
+            }>;
+          };
+          const stored = body.chunks.map((chunk) => ({
+            id: `${filePath}:${chunk.chunk_index}`,
+            index: chunk.chunk_index,
+            content: chunk.content,
+            metadata: chunk.metadata,
+          }));
+          fileChunks.set(filePath, stored);
+
+          return Response.json({
+            chunks: stored.map(({ id, index }) => ({ id, index })),
+            created: stored.length,
+            updated: 0,
+          });
+        }
+
+        if (request.method === "POST" && path.endsWith("/embeddings")) {
+          const body = await request.json() as {
+            chunk_ids: string[];
+            vectors: number[][];
+          };
+          body.chunk_ids.forEach((chunkId, index) => {
+            embeddingVectors.set(chunkId, body.vectors[index]!);
+          });
+
+          return Response.json({
+            embeddings: body.chunk_ids.map((chunkId) => ({
+              id: `embedding:${chunkId}`,
+              model: "test/demo",
+              status: "ready",
+              created_at: new Date().toISOString(),
+            })),
+            created: body.chunk_ids.length,
+            updated: 0,
+          });
+        }
+
+        return new Response(`Unhandled ${request.method} ${path}`, { status: 404 });
+      },
+      async () => {
+        const store = ragStore({
+          model: "test/demo",
+        });
+
+        await store.refreshDocument("doc-pptx", "# Better Deck\n\nBody text", {
+          title: "Better Deck",
+          source: "upload:better.pptx",
+          type: "pptx",
+        });
+
+        assertEquals(deletedFilePaths, [".veryfront/rag/documents/doc-pptx.pptx"]);
+        assertEquals([...ragDocuments.values()][0], {
+          id: "doc-pptx",
+          title: "Better Deck",
+          source: "upload:better.pptx",
+          type: "pptx",
+          created_at: "2026-06-25T00:00:00.000Z",
+          updated_at: "2026-06-25T01:00:00.000Z",
+          metadata: { filePath: ".veryfront/rag/documents/doc-pptx.pptx" },
+        });
+        const chunks = fileChunks.get(".veryfront/rag/documents/doc-pptx.pptx") ?? [];
+        assertEquals(chunks.length, 1);
+        assertEquals(chunks[0]?.content, "# Better Deck\n\nBody text");
+        assertEquals(chunks[0]?.metadata, {
+          kind: "rag-document",
+          document_id: "doc-pptx",
+          title: "Better Deck",
+          source: "upload:better.pptx",
+          type: "pptx",
+        });
+        assertEquals(embeddingVectors.size, 1);
       },
     );
   });

--- a/src/embedding/rag-store.ts
+++ b/src/embedding/rag-store.ts
@@ -17,6 +17,7 @@ import { resolveConfiguredEmbeddingModel } from "./model-resolution.ts";
 import type {
   RagChunk,
   RagDocumentMeta,
+  RagRefreshOptions,
   RagSearchOptions,
   RagSearchResult,
   RagStore,
@@ -190,6 +191,9 @@ export function ragStore(config: RagStoreConfig): RagStore {
   return {
     ingest(title, text, meta) {
       return getStore().ingest(title, text, meta);
+    },
+    refreshDocument(id, text, meta) {
+      return getStore().refreshDocument(id, text, meta);
     },
     search(query, options) {
       return getStore().search(query, options);
@@ -498,6 +502,46 @@ function createLocalJsonRagStore(config: ResolvedRagStoreConfig): RagStore {
         await save(data);
 
         return documentId;
+      });
+    },
+
+    async refreshDocument(
+      id: string,
+      text: string,
+      meta?: RagRefreshOptions,
+    ): Promise<void> {
+      return withLock(async () => {
+        const data = await load();
+        const document = data.documents.find((doc) => doc.id === id);
+        if (!document) {
+          throw INVALID_ARGUMENT.create({ detail: `RAG document not found: ${id}` });
+        }
+
+        if (text.length > MAX_TEXT_LENGTH) {
+          throw INVALID_ARGUMENT.create({
+            detail: `Upload text exceeds ${MAX_TEXT_LENGTH / 1024 / 1024} MB limit`,
+          });
+        }
+
+        const chunks = await chunk(text, chunkOptions);
+        if (chunks.length === 0) {
+          throw INVALID_ARGUMENT.create({ detail: "Upload contains no extractable text" });
+        }
+
+        document.title = meta?.title ?? document.title;
+        document.source = meta?.source ?? document.source;
+        document.type = meta?.type ?? document.type;
+        data.chunks = data.chunks.filter((chunk) => chunk.documentId !== id);
+        data.chunks.push(
+          ...chunks.map((chunkText, index) => ({
+            id: crypto.randomUUID(),
+            documentId: id,
+            text: chunkText,
+            embedding: [] as number[],
+            index,
+          })),
+        );
+        await save(data);
       });
     },
 

--- a/src/embedding/rag-store.ts
+++ b/src/embedding/rag-store.ts
@@ -193,7 +193,11 @@ export function ragStore(config: RagStoreConfig): RagStore {
       return getStore().ingest(title, text, meta);
     },
     refreshDocument(id, text, meta) {
-      return getStore().refreshDocument(id, text, meta);
+      const store = getStore();
+      if (!store.refreshDocument) {
+        throw INVALID_ARGUMENT.create({ detail: "RAG store does not support document refresh" });
+      }
+      return store.refreshDocument(id, text, meta);
     },
     search(query, options) {
       return getStore().search(query, options);

--- a/src/embedding/types.ts
+++ b/src/embedding/types.ts
@@ -120,9 +120,17 @@ export interface RagSearchOptions {
   threshold?: number; // minimum similarity score
 }
 
+/** Options accepted when refreshing an existing rag document. */
+export interface RagRefreshOptions {
+  title?: string;
+  source?: string;
+  type?: string;
+}
+
 /** Public API contract for rag store. */
 export interface RagStore {
   ingest(title: string, text: string, meta?: { source?: string; type?: string }): Promise<string>;
+  refreshDocument(id: string, text: string, meta?: RagRefreshOptions): Promise<void>;
   search(query: string, options?: RagSearchOptions): Promise<RagSearchResult[]>;
   listDocuments(): Promise<RagDocumentMeta[]>;
   removeDocument(id: string): Promise<void>;

--- a/src/embedding/types.ts
+++ b/src/embedding/types.ts
@@ -130,7 +130,7 @@ export interface RagRefreshOptions {
 /** Public API contract for rag store. */
 export interface RagStore {
   ingest(title: string, text: string, meta?: { source?: string; type?: string }): Promise<string>;
-  refreshDocument(id: string, text: string, meta?: RagRefreshOptions): Promise<void>;
+  refreshDocument?(id: string, text: string, meta?: RagRefreshOptions): Promise<void>;
   search(query: string, options?: RagSearchOptions): Promise<RagSearchResult[]>;
   listDocuments(): Promise<RagDocumentMeta[]>;
   removeDocument(id: string): Promise<void>;

--- a/src/embedding/upload-handler.test.ts
+++ b/src/embedding/upload-handler.test.ts
@@ -38,6 +38,7 @@ function createStubStore(overrides: Partial<RagStore> = {}): RagStore {
     async listDocuments() {
       return [];
     },
+    async refreshDocument(_id: string, _text: string): Promise<void> {},
     async removeDocument(_id: string): Promise<void> {},
     async indexContentDir(): Promise<void> {},
     ...overrides,

--- a/src/embedding/upload-loader.test.ts
+++ b/src/embedding/upload-loader.test.ts
@@ -1,6 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { register, unregister } from "#veryfront/extensions/contracts.ts";
+import type { DocumentExtractor } from "#veryfront/extensions/compat/native-services.ts";
 import { loadUpload } from "./upload-loader.ts";
 
 function toBuffer(text: string): ArrayBuffer {
@@ -125,6 +127,28 @@ describe("upload-loader", () => {
         true,
         `expected actionable DocumentExtractor error, got: ${err.message}`,
       );
+    });
+
+    it("returns structured markdown from the DocumentExtractor unchanged", async () => {
+      const extracted = "# Extracted Upload\n\n## Section\n\nBody text.";
+      const calls: Array<{ bytes: string; mimeType: string }> = [];
+      const extractor: DocumentExtractor = {
+        extractInWorker: (buffer, mimeType) => {
+          calls.push({ bytes: new TextDecoder().decode(buffer), mimeType });
+          return Promise.resolve(extracted);
+        },
+      };
+
+      try {
+        register<DocumentExtractor>("DocumentExtractor", extractor);
+
+        const result = await loadUpload(toBuffer("pdf bytes"), "application/pdf");
+
+        assertEquals(result, extracted);
+        assertEquals(calls, [{ bytes: "pdf bytes", mimeType: "application/pdf" }]);
+      } finally {
+        unregister("DocumentExtractor");
+      }
     });
   });
 });

--- a/src/embedding/upload-loader.ts
+++ b/src/embedding/upload-loader.ts
@@ -2,16 +2,17 @@ import { tryResolve } from "#veryfront/extensions/contracts.ts";
 import type { DocumentExtractor } from "#veryfront/extensions/compat/native-services.ts";
 
 /**
- * Extracts plain text from various upload formats.
+ * Extracts embedding-ready text or Markdown from upload formats.
  *
  * Text and CSV are handled inline (CSV uses a RAG-optimized format that
  * denormalizes headers into every row). All other formats (PDF, DOCX, XLSX,
- * PPTX, HTML, RTF, EPUB, etc.) are delegated to the `DocumentExtractor` extension
- * contract, which owns kreuzberg and the Worker isolation on Deno.
+ * PPTX, HTML, RTF, EPUB, etc.) are delegated to the `DocumentExtractor`
+ * extension contract, which owns kreuzberg, Markdown extraction, and Worker
+ * isolation on Deno.
  *
  * @example
  * ```ts
- * const text = await loadUpload(buffer, "application/pdf");
+ * const markdown = await loadUpload(buffer, "application/pdf");
  * ```
  */
 export async function loadUpload(buffer: ArrayBuffer, mimeType: string): Promise<string> {

--- a/src/embedding/veryfront-cloud/rag-store.ts
+++ b/src/embedding/veryfront-cloud/rag-store.ts
@@ -11,6 +11,7 @@ import { chunk } from "../chunk.ts";
 import { embedding } from "../embedding.ts";
 import type {
   RagDocumentMeta,
+  RagRefreshOptions,
   RagSearchOptions,
   RagSearchResult,
   RagStore,
@@ -411,6 +412,47 @@ async function ingestDocument(
   text: string,
   meta?: { source?: string; type?: string },
 ): Promise<string> {
+  const documentId = crypto.randomUUID();
+  await writeDocumentContent(context, config, documentId, title, text, meta);
+  return documentId;
+}
+
+async function refreshCloudDocument(
+  context: CloudStoreContext,
+  config: ResolvedCloudRagStoreConfig,
+  documentId: string,
+  text: string,
+  meta?: RagRefreshOptions,
+): Promise<void> {
+  const documents = await listRagDocuments(context);
+  const existing = documents.find((doc) => doc.id === documentId);
+  if (!existing) {
+    throw INVALID_ARGUMENT.create({ detail: `RAG document not found: ${documentId}` });
+  }
+
+  await writeDocumentContent(
+    context,
+    config,
+    documentId,
+    meta?.title ?? existing.title,
+    text,
+    {
+      source: meta?.source ?? existing.source,
+      type: meta?.type ?? existing.type,
+    },
+    { replaceFilePath: buildDocumentFilePath(documentId, existing.type) },
+  );
+}
+
+async function writeDocumentContent(
+  context: CloudStoreContext,
+  config: ResolvedCloudRagStoreConfig,
+  documentId: string,
+  title: string,
+  text: string,
+  meta?: { source?: string; type?: string },
+  options?: { replaceFilePath?: string },
+): Promise<void> {
   if (text.length > MAX_TEXT_LENGTH) {
     throw INVALID_ARGUMENT.create({
       detail: `Upload text exceeds ${MAX_TEXT_LENGTH / 1024 / 1024} MB limit`,
@@ -422,7 +464,6 @@ async function ingestDocument(
     throw INVALID_ARGUMENT.create({ detail: "Upload contains no extractable text" });
   }
 
-  const documentId = crypto.randomUUID();
   const filePath = buildDocumentFilePath(documentId, meta?.type);
   const embedder = createEmbedder(config);
   const vectors = await embedder.embedMany(chunkTexts);
@@ -436,6 +477,10 @@ async function ingestDocument(
   });
 
   try {
+    if (options?.replaceFilePath) {
+      await deleteFileChunks(context, options.replaceFilePath);
+    }
+
     const createdChunks = await upsertFileChunks(context, filePath, chunkInputs);
     const chunkIds = createdChunks.map((entry) => entry.id);
 
@@ -470,8 +515,6 @@ async function ingestDocument(
     type: meta?.type ?? "",
     metadata: { filePath },
   });
-
-  return documentId;
 }
 
 function createEmbedder(config: ResolvedCloudRagStoreConfig) {
@@ -628,6 +671,15 @@ export function createVeryfrontCloudRagStore(config: ResolvedCloudRagStoreConfig
     ): Promise<string> {
       const context = getCloudStoreContext(config);
       return ingestDocument(context, config, title, text, meta);
+    },
+
+    async refreshDocument(
+      id: string,
+      text: string,
+      meta?: RagRefreshOptions,
+    ): Promise<void> {
+      const context = getCloudStoreContext(config);
+      await refreshCloudDocument(context, config, id, text, meta);
     },
 
     async search(

--- a/src/embedding/veryfront-cloud/rag-store.ts
+++ b/src/embedding/veryfront-cloud/rag-store.ts
@@ -94,6 +94,8 @@ interface ChunkMutationInput {
 
 type ResolvedCloudRagStoreConfig = RagStoreConfig & { model: string };
 
+type CloudRagDocumentMeta = RagDocumentMeta & { filePath?: string };
+
 interface ContentFile {
   path: string;
   content?: string;
@@ -168,12 +170,28 @@ function buildDocumentFilePath(documentId: string, type?: string): string {
   return `${DOCUMENTS_DIR}/${documentId}.${extension || "txt"}`;
 }
 
+function buildRefreshDocumentFilePath(documentId: string, type?: string): string {
+  const extension = type?.trim().toLowerCase().replace(/[^a-z0-9]+/g, "");
+  return `${DOCUMENTS_DIR}/${documentId}.refresh-${crypto.randomUUID()}.${extension || "txt"}`;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
 function toStringValue(value: unknown, fallback = ""): string {
   return typeof value === "string" ? value : fallback;
+}
+
+function toPublicRagDocumentMeta(document: CloudRagDocumentMeta): RagDocumentMeta {
+  return {
+    id: document.id,
+    title: document.title,
+    source: document.source,
+    type: document.type,
+    createdAt: document.createdAt,
+    url: document.url,
+  };
 }
 
 function buildDocumentChunks(
@@ -348,7 +366,7 @@ async function upsertEmbeddings(
 
 async function listRagDocuments(
   context: CloudStoreContext,
-): Promise<RagDocumentMeta[]> {
+): Promise<CloudRagDocumentMeta[]> {
   const response = await requestJson<CloudListRagDocumentsResponse>(
     context,
     getRagDocumentsPath(context),
@@ -360,6 +378,7 @@ async function listRagDocuments(
     source: doc.source,
     type: doc.type,
     createdAt: new Date(doc.created_at).getTime(),
+    filePath: typeof doc.metadata?.filePath === "string" ? doc.metadata.filePath : undefined,
   }));
 }
 
@@ -430,6 +449,10 @@ async function refreshCloudDocument(
     throw INVALID_ARGUMENT.create({ detail: `RAG document not found: ${documentId}` });
   }
 
+  const type = meta?.type ?? existing.type;
+  const previousFilePath = existing.filePath ?? buildDocumentFilePath(documentId, existing.type);
+  const filePath = buildRefreshDocumentFilePath(documentId, type);
+
   await writeDocumentContent(
     context,
     config,
@@ -438,10 +461,14 @@ async function refreshCloudDocument(
     text,
     {
       source: meta?.source ?? existing.source,
-      type: meta?.type ?? existing.type,
+      type,
     },
-    { replaceFilePath: buildDocumentFilePath(documentId, existing.type) },
+    { filePath },
   );
+
+  if (previousFilePath !== filePath) {
+    await deleteFileChunks(context, previousFilePath);
+  }
 }
 
 async function writeDocumentContent(
@@ -451,7 +478,7 @@ async function writeDocumentContent(
   title: string,
   text: string,
   meta?: { source?: string; type?: string },
-  options?: { replaceFilePath?: string },
+  options?: { filePath?: string },
 ): Promise<void> {
   if (text.length > MAX_TEXT_LENGTH) {
     throw INVALID_ARGUMENT.create({
@@ -464,7 +491,7 @@ async function writeDocumentContent(
     throw INVALID_ARGUMENT.create({ detail: "Upload contains no extractable text" });
   }
 
-  const filePath = buildDocumentFilePath(documentId, meta?.type);
+  const filePath = options?.filePath ?? buildDocumentFilePath(documentId, meta?.type);
   const embedder = createEmbedder(config);
   const vectors = await embedder.embedMany(chunkTexts);
   const dimension = toSupportedDimension(vectors[0]?.length ?? 0);
@@ -477,10 +504,6 @@ async function writeDocumentContent(
   });
 
   try {
-    if (options?.replaceFilePath) {
-      await deleteFileChunks(context, options.replaceFilePath);
-    }
-
     const createdChunks = await upsertFileChunks(context, filePath, chunkInputs);
     const chunkIds = createdChunks.map((entry) => entry.id);
 
@@ -730,7 +753,8 @@ export function createVeryfrontCloudRagStore(config: ResolvedCloudRagStoreConfig
 
     async listDocuments(): Promise<RagDocumentMeta[]> {
       const context = getCloudStoreContext(config);
-      return listRagDocuments(context);
+      const documents = await listRagDocuments(context);
+      return documents.map(toPublicRagDocumentMeta);
     },
 
     async removeDocument(id: string): Promise<void> {
@@ -745,7 +769,7 @@ export function createVeryfrontCloudRagStore(config: ResolvedCloudRagStoreConfig
 
       // Best-effort cleanup of file chunks
       if (target) {
-        const filePath = buildDocumentFilePath(id, target.type);
+        const filePath = target.filePath ?? buildDocumentFilePath(id, target.type);
         try {
           await deleteFileChunks(context, filePath);
         } catch (error) {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.994";
+export const VERSION = "0.1.995";


### PR DESCRIPTION
## Summary

- Preserve PPTX Markdown structure with real slide progress by keeping Kreuzberg as the primary PPTX content extractor when native extraction is available.
- Use PPTX slide XML placeholder roles only to normalize heading levels: title placeholders stay `#`, subtitle placeholders become `##`, and body/textbox shape headings are demoted to body text.
- Preserve non-shape content such as PPTX tables by post-processing Kreuzberg output instead of replacing it with shape-only XML extraction.
- Keep the same knowledge/RAG output contract: one Markdown document per uploaded source, with real page/slide progress events where available.
- Add `RagStore.refreshDocument(id, text, meta)` for built-in local JSON and Veryfront Cloud stores so existing documents can be reprocessed under the same document ID while replacing chunks and embeddings.
- Make `refreshDocument` optional on the public `RagStore` interface so external store implementations are not broken by the added capability.
- Update docs/API reference and bump Veryfront to `0.1.995`.

## Root Cause

#2744 correctly requested Kreuzberg Markdown output for rich documents, but the original PPTX progress worker still used a custom XML text path for normal slide decks. That kept progress, but flattened all slide structure before ingestion.

A later attempt moved heading formatting into local PPTX shape parsing, but that was wrong as the primary extraction path: it only walked `<p:sp>` text shapes and silently dropped `<p:graphicFrame>` content such as tables. This PR now keeps Kreuzberg as the source of extracted content and uses local XML roles only as a heading-level correction pass.

Kreuzberg's `resultFormat: "element_based"` mode was checked against `@kreuzberg/node@4.4.2`; for PPTX it returns a single `narrative_text` element and does not expose useful title/body shape roles.

## Embedding Refresh

Existing PPTX uploads may have chunks/vectors created from old flat output. The built-in stores now expose a reprocess primitive instead of changing document IDs or duplicating uploads:

- Local store: `refreshDocument` preserves the existing document record, replaces chunks, and clears chunk embeddings so search lazily re-embeds refreshed text.
- Veryfront Cloud store: `refreshDocument` writes replacement chunks/embeddings to a new document file path first, updates the same server-side document ID, and only then deletes the previous file chunks. If replacement persistence fails, old chunks remain in place.

## Validation

- Red table regression observed before fix: PPTX output was only `# Quarterly Results`; table cells `Region`, `Revenue`, `EMEA`, and `4.2M` were missing.
- Red cloud refresh failure test observed before fix: old cloud chunks were deleted when replacement embedding persistence failed.
- Red public metadata test observed before fix: internal cloud `filePath` leaked through `listDocuments()`.
- `deno test --no-check --allow-all extensions/ext-document-kreuzberg/src/index.test.ts src/embedding/rag-store.test.ts src/embedding/upload-handler.test.ts` -> 3 passed, 47 steps
- `deno task fmt:check`
- `deno task lint`
- `deno task docs:validate`
- `deno task typecheck`
