### PR TITLE
Run task targets with project runtime discovery

### DIFF
--- a/cli/commands/schedule/handler.ts
+++ b/cli/commands/schedule/handler.ts
@@ -33,7 +33,8 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
   const projectDir = Deno.cwd();
   const input = opts.input ? await readJsonFile(opts.input, "--input JSON file") : undefined;
 
-  await withProjectSourceContext(projectDir, async ({ adapter, config, projectId }) => {
+  await withProjectSourceContext(projectDir, async (context) => {
+    const { adapter, config, configCacheKey, projectId } = context;
     const result = await discoverSchedules({ projectDir, adapter, config });
     if (result.errors.length > 0) {
       throw new Error(`Schedule discovery failed: ${result.errors[0]?.message}`);
@@ -48,6 +49,7 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
       projectDir,
       adapter,
       config,
+      cacheKey: configCacheKey,
       projectId,
       target: schedule.target,
       input: input ?? schedule.input ?? {},

--- a/cli/commands/task/command.ts
+++ b/cli/commands/task/command.ts
@@ -14,10 +14,22 @@ import type { TaskArgs } from "./handler.ts";
 
 export interface TaskOptions extends TaskArgs {}
 
+function logRuntimeDiscoveryWarnings(
+  errors: Array<{ file: string; error: Error }>,
+  debug: boolean | undefined,
+): void {
+  if (errors.length === 0 || !debug) return;
+
+  for (const err of errors) {
+    cliLogger.warn(`  Warning: ${err.file}: ${err.error.message}`);
+  }
+}
+
 export async function taskCommand(options: TaskOptions): Promise<void> {
-  const { discoverTasks } = await import(
-    "../../../src/task/discovery.ts"
-  );
+  const { discoverProjectTaskRuntime, findProjectRuntimeTask, listProjectRuntimeTasks } =
+    await import(
+      "../../../src/task/project-runtime.ts"
+    );
   const { runTask } = await import(
     "../../../src/task/runner.ts"
   );
@@ -32,7 +44,7 @@ export async function taskCommand(options: TaskOptions): Promise<void> {
   const projectDir = Deno.cwd();
   await withProjectSourceContext(
     projectDir,
-    async ({ adapter, config, projectId, proxyContext }) => {
+    async ({ adapter, config, configCacheKey, projectId, proxyContext }) => {
       const sourceLabel = proxyContext?.branchRef
         ? `branch ${proxyContext.branchRef}`
         : proxyContext
@@ -41,22 +53,25 @@ export async function taskCommand(options: TaskOptions): Promise<void> {
 
       cliLogger.info(`Discovering tasks in ${sourceLabel}`);
 
-      const { tasks, errors } = await discoverTasks({
+      const discovery = await discoverProjectTaskRuntime({
         projectDir,
         adapter,
         config,
+        fsAdapter: adapter.fs,
+        cacheKey: configCacheKey,
         debug: options.debug,
       });
+      logRuntimeDiscoveryWarnings(discovery.errors, options.debug);
 
-      if (errors.length > 0 && options.debug) {
-        for (const err of errors) {
-          cliLogger.warn(`  Warning: ${err.filePath}: ${err.error}`);
-        }
-      }
-
-      const task = tasks.find((t) => t.id === taskName);
+      const task = findProjectRuntimeTask(discovery, taskName);
       if (!task) {
         cliLogger.error(`Task "${taskName}" not found.`);
+        if (discovery.errors.length > 0 && !options.debug) {
+          cliLogger.warn(
+            "Some project files could not be loaded. Re-run with --debug for details.",
+          );
+        }
+        const tasks = listProjectRuntimeTasks(discovery);
         if (tasks.length > 0) {
           cliLogger.info("Available tasks:");
           for (const t of tasks) {

--- a/cli/commands/webhook/handler.ts
+++ b/cli/commands/webhook/handler.ts
@@ -33,7 +33,8 @@ export async function handleWebhookCommand(args: ParsedArgs): Promise<void> {
   const projectDir = Deno.cwd();
   const payload = await readJsonFile(opts.payload, "--payload JSON file");
 
-  await withProjectSourceContext(projectDir, async ({ adapter, config, projectId }) => {
+  await withProjectSourceContext(projectDir, async (context) => {
+    const { adapter, config, configCacheKey, projectId } = context;
     const result = await discoverWebhooks({ projectDir, adapter, config });
     if (result.errors.length > 0) {
       throw new Error(`Webhook discovery failed: ${result.errors[0]?.message}`);
@@ -48,6 +49,7 @@ export async function handleWebhookCommand(args: ParsedArgs): Promise<void> {
       projectDir,
       adapter,
       config,
+      cacheKey: configCacheKey,
       projectId,
       target: webhook.target,
       input: payload,

--- a/cli/commands/workflow/command.ts
+++ b/cli/commands/workflow/command.ts
@@ -165,7 +165,8 @@ export async function runWorkflowCommand(
   ) => Promise<DiscoveryResult> = dependencies.discoverProjectAgentRuntime ??
     discoverProjectAgentRuntime;
 
-  await withProjectSourceContext(projectDir, async ({ adapter, proxyContext }) => {
+  await withProjectSourceContext(projectDir, async (context) => {
+    const { adapter, config, configCacheKey, proxyContext } = context;
     const sourceLabel = proxyContext?.branchRef
       ? `branch ${proxyContext.branchRef}`
       : proxyContext
@@ -177,6 +178,9 @@ export async function runWorkflowCommand(
     const discovery = await discoverRuntime({
       projectDir,
       adapter,
+      config,
+      fsAdapter: adapter.fs,
+      cacheKey: configCacheKey,
       verbose: options.debug,
     });
 

--- a/cli/shared/project-source-context.ts
+++ b/cli/shared/project-source-context.ts
@@ -19,6 +19,7 @@ export interface ProjectSourceExecutionContext {
   adapter: RuntimeAdapter;
   config: VeryfrontConfig;
   projectDir: string;
+  configCacheKey?: string;
   projectId?: string;
   proxyContext?: ProxyProjectSourceContext;
 }
@@ -48,8 +49,14 @@ async function loadProjectConfig(
   adapter: RuntimeAdapter,
   proxyContext?: ProxyProjectSourceContext,
 ): Promise<VeryfrontConfig> {
-  const cacheKey = proxyContext?.projectId ?? proxyContext?.projectSlug;
+  const cacheKey = getProjectSourceConfigCacheKey(proxyContext);
   return await getConfig(projectDir, adapter, cacheKey ? { cacheKey } : undefined);
+}
+
+function getProjectSourceConfigCacheKey(
+  proxyContext?: ProxyProjectSourceContext,
+): string | undefined {
+  return proxyContext?.projectId ?? proxyContext?.projectSlug;
 }
 
 export async function applyProjectSourceRuntimeAuth(
@@ -86,6 +93,7 @@ export async function withProjectSourceContext<T>(
           adapter,
           config,
           projectDir,
+          configCacheKey: getProjectSourceConfigCacheKey(proxyContext),
           projectId: proxyContext.projectId,
           proxyContext,
         });
@@ -103,6 +111,7 @@ export async function withProjectSourceContext<T>(
     adapter,
     config,
     projectDir,
+    configCacheKey: getProjectSourceConfigCacheKey(proxyContext ?? undefined),
     projectId: proxyContext?.projectId,
     proxyContext: proxyContext ?? undefined,
   });

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.995",
+  "version": "0.1.996",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/guides/pages-and-routing.md
+++ b/docs/guides/pages-and-routing.md
@@ -219,8 +219,8 @@ export default function Filters() {
 
 By default a query-only navigation refetches the page so server data that
 depends on the query is never shown stale. If a page's query is purely
-client-side state (tabs, filters), opt into the soft fast path — updating the
-URL and re-rendering without a refetch — with the router's `shouldRevalidate`
+client-side state (tabs, filters), opt into the soft fast path: updating the
+URL and re-rendering without a refetch, with the router's `shouldRevalidate`
 option.
 
 ## Verify it worked

--- a/src/agent/project/agent-runtime.ts
+++ b/src/agent/project/agent-runtime.ts
@@ -5,8 +5,9 @@ import {
   createProjectDiscoveryConfig,
   discoverAll,
 } from "#veryfront/discovery/index.ts";
-import { getConfig } from "#veryfront/config";
+import { getConfig, type VeryfrontConfig } from "#veryfront/config";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
 import { clearMCPRegistry } from "#veryfront/mcp";
 import { workflowRegistry } from "#veryfront/workflow/registry.ts";
 import { agentRegistry } from "../composition/index.ts";
@@ -30,6 +31,9 @@ export type ProjectAgentRuntimeAgentIdCandidates = {
 export type DiscoverProjectAgentRuntimeInput = {
   projectDir: string;
   adapter: RuntimeAdapter;
+  config?: VeryfrontConfig | null;
+  fsAdapter?: FileSystemAdapter;
+  cacheKey?: string;
   verbose?: boolean;
 };
 
@@ -69,10 +73,16 @@ export async function discoverProjectAgentRuntime(
 ): Promise<DiscoveryResult> {
   clearProjectAgentRuntimeRegistries();
 
-  const config = await getConfig(input.projectDir, input.adapter);
+  const config = input.config ??
+    await getConfig(
+      input.projectDir,
+      input.adapter,
+      input.cacheKey ? { cacheKey: input.cacheKey } : undefined,
+    );
   const discoveryOptions = createProjectDiscoveryConfig({
     projectDir: input.projectDir,
     config,
+    fsAdapter: input.fsAdapter,
     verbose: input.verbose,
   });
 

--- a/src/channels/control-plane.ts
+++ b/src/channels/control-plane.ts
@@ -177,7 +177,7 @@ export type ControlPlaneClaims = InferSchema<ReturnType<typeof getControlPlaneCl
 
 /** Public API contract for runtime agent discovery deps. */
 export interface RuntimeAgentDiscoveryDeps {
-  ensureProjectDiscovery: (ctx: HandlerContext) => Promise<void>;
+  ensureProjectDiscovery: (ctx: HandlerContext) => Promise<unknown>;
   getAgent: (id: string) => Agent | undefined;
   getAllAgentIds: () => string[];
 }

--- a/src/discovery/discovery-engine.ts
+++ b/src/discovery/discovery-engine.ts
@@ -32,7 +32,6 @@ import {
 } from "./handlers/index.ts";
 import { discoverRuntimeAgentMarkdownDefinitions } from "./handlers/runtime-agent-markdown-handler.ts";
 import { filenameToId } from "./discovery-utils.ts";
-import { join } from "#veryfront/compat/path";
 
 const logger = agentLogger.component("discovery");
 
@@ -51,6 +50,11 @@ function compareDiscoveryFiles(a: string, b: string): number {
   const bIsIndex = isIndexModule(b);
   if (aIsIndex !== bIsIndex) return aIsIndex ? 1 : -1;
   return a.localeCompare(b);
+}
+
+function resolveDiscoveryDir(baseDir: string, dir: string): string {
+  if (baseDir === "") return dir;
+  return `${baseDir}/${dir}`;
 }
 
 function collectDiscoveryCandidates<T>(
@@ -152,6 +156,26 @@ async function discoverItems<T>(
   }
 }
 
+async function discoverConfiguredItems<T>(
+  dirs: string[] | undefined,
+  defaultDirs: string[],
+  baseDir: string,
+  result: DiscoveryResult,
+  context: FileDiscoveryContext,
+  handler: DiscoveryHandler<T>,
+  verbose?: boolean,
+): Promise<void> {
+  for (const dir of dirs ?? defaultDirs) {
+    await discoverItems(
+      resolveDiscoveryDir(baseDir, dir),
+      result,
+      context,
+      handler,
+      verbose,
+    );
+  }
+}
+
 /**
  * Discover all items in configured directories
  */
@@ -180,9 +204,15 @@ export async function discoverAll(config: DiscoveryConfig): Promise<DiscoveryRes
   };
 
   // Discover tools
-  for (const dir of config.toolDirs ?? ["tools"]) {
-    await discoverItems(`${baseDir}/${dir}`, result, context, toolHandler, config.verbose);
-  }
+  await discoverConfiguredItems(
+    config.toolDirs,
+    ["tools"],
+    baseDir,
+    result,
+    context,
+    toolHandler,
+    config.verbose,
+  );
 
   // Clear stale skills before any skill registration so deleted/renamed
   // skills are removed. Global skills are discovered BEFORE agents so that
@@ -194,7 +224,7 @@ export async function discoverAll(config: DiscoveryConfig): Promise<DiscoveryRes
   // Discover skills (parallel path — markdown-based, not TypeScript import)
   for (const dir of config.skillDirs ?? ["skills"]) {
     const skillResult = await discoverSkills(
-      join(baseDir, dir),
+      resolveDiscoveryDir(baseDir, dir),
       context,
       config.verbose,
     );
@@ -213,49 +243,98 @@ export async function discoverAll(config: DiscoveryConfig): Promise<DiscoveryRes
 
   // Discover agents
   for (const dir of config.agentDirs ?? ["agents"]) {
-    await discoverItems(`${baseDir}/${dir}`, result, context, agentHandler, config.verbose);
-    await discoverRuntimeAgentMarkdownDefinitions(`${baseDir}/${dir}`, result, context);
+    const agentDir = resolveDiscoveryDir(baseDir, dir);
+    await discoverItems(agentDir, result, context, agentHandler, config.verbose);
+    await discoverRuntimeAgentMarkdownDefinitions(agentDir, result, context);
   }
 
   // Discover resources
-  for (const dir of config.resourceDirs ?? ["resources"]) {
-    await discoverItems(`${baseDir}/${dir}`, result, context, resourceHandler, config.verbose);
-  }
+  await discoverConfiguredItems(
+    config.resourceDirs,
+    ["resources"],
+    baseDir,
+    result,
+    context,
+    resourceHandler,
+    config.verbose,
+  );
 
   // Discover prompts
-  for (const dir of config.promptDirs ?? ["prompts"]) {
-    await discoverItems(`${baseDir}/${dir}`, result, context, promptHandler, config.verbose);
-  }
+  await discoverConfiguredItems(
+    config.promptDirs,
+    ["prompts"],
+    baseDir,
+    result,
+    context,
+    promptHandler,
+    config.verbose,
+  );
 
   // Discover workflows
-  for (const dir of config.workflowDirs ?? ["workflows"]) {
-    await discoverItems(`${baseDir}/${dir}`, result, context, workflowHandler, config.verbose);
-  }
+  await discoverConfiguredItems(
+    config.workflowDirs,
+    ["workflows"],
+    baseDir,
+    result,
+    context,
+    workflowHandler,
+    config.verbose,
+  );
 
   // Discover Work definitions
-  for (const dir of config.workDirs ?? ["work"]) {
-    await discoverItems(`${baseDir}/${dir}`, result, context, workHandler, config.verbose);
-  }
+  await discoverConfiguredItems(
+    config.workDirs,
+    ["work"],
+    baseDir,
+    result,
+    context,
+    workHandler,
+    config.verbose,
+  );
 
   // Discover tasks
-  for (const dir of config.taskDirs ?? ["tasks"]) {
-    await discoverItems(`${baseDir}/${dir}`, result, context, taskHandler, config.verbose);
-  }
+  await discoverConfiguredItems(
+    config.taskDirs,
+    ["tasks"],
+    baseDir,
+    result,
+    context,
+    taskHandler,
+    config.verbose,
+  );
 
   // Discover schedules
-  for (const dir of config.scheduleDirs ?? ["schedules"]) {
-    await discoverItems(`${baseDir}/${dir}`, result, context, scheduleHandler, config.verbose);
-  }
+  await discoverConfiguredItems(
+    config.scheduleDirs,
+    ["schedules"],
+    baseDir,
+    result,
+    context,
+    scheduleHandler,
+    config.verbose,
+  );
 
   // Discover webhooks
-  for (const dir of config.webhookDirs ?? ["webhooks"]) {
-    await discoverItems(`${baseDir}/${dir}`, result, context, webhookHandler, config.verbose);
-  }
+  await discoverConfiguredItems(
+    config.webhookDirs,
+    ["webhooks"],
+    baseDir,
+    result,
+    context,
+    webhookHandler,
+    config.verbose,
+  );
 
   // Discover eval definitions
-  for (const dir of config.evalDirs ?? ["evals"]) {
-    await discoverItems(`${baseDir}/${dir}`, result, context, evalHandler, config.verbose);
-  }
+  await discoverConfiguredItems(
+    config.evalDirs,
+    ["evals"],
+    baseDir,
+    result,
+    context,
+    evalHandler,
+    config.verbose,
+  );
 
   return result;
 }

--- a/src/discovery/handlers/task-handler.ts
+++ b/src/discovery/handlers/task-handler.ts
@@ -10,8 +10,11 @@ export const taskHandler: DiscoveryHandler<TaskDefinition> = {
   typeName: "task",
   validate: (item): item is TaskDefinition => isTaskDefinition(item),
   getId: (_task, file, dir) => {
+    const normalizedFile = file.startsWith("file://") ? file.slice("file://".length) : file;
     const prefix = dir.endsWith("/") ? dir : `${dir}/`;
-    const relative = file.startsWith(prefix) ? file.slice(prefix.length) : file;
+    const relative = normalizedFile.startsWith(prefix)
+      ? normalizedFile.slice(prefix.length)
+      : normalizedFile;
     return relative.replace(/\.(ts|tsx|js|jsx)$/, "");
   },
   register: (_id, task) => task,

--- a/src/discovery/project-discovery-config.ts
+++ b/src/discovery/project-discovery-config.ts
@@ -56,13 +56,21 @@ function resolveDiscoveryPaths(
   return discovery?.paths ?? defaultPaths;
 }
 
+function resolveProjectDiscoveryBaseDir(
+  projectDir: string,
+  config?: VeryfrontConfig | null,
+): string {
+  const fsType = config?.fs?.type ?? "local";
+  return fsType === "github" || fsType === "veryfront-api" ? "" : projectDir;
+}
+
 export function createProjectDiscoveryConfig(
   input: ProjectDiscoveryConfigInput,
 ): ProjectDiscoveryConfig {
   const aiConfig = input.config?.ai;
 
   return {
-    baseDir: input.projectDir,
+    baseDir: resolveProjectDiscoveryBaseDir(input.projectDir, input.config),
     toolDirs: resolveDiscoveryPaths(
       aiConfig?.tools?.discovery,
       DEFAULT_PROJECT_DISCOVERY_DIRS.toolDirs,

--- a/src/server/handlers/request/api/project-discovery.test.ts
+++ b/src/server/handlers/request/api/project-discovery.test.ts
@@ -2,7 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { getAgent } from "#veryfront/agent";
 import { toolRegistry } from "#veryfront/tool";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { runWithCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
 import type { HandlerContext } from "../../types.ts";
@@ -246,6 +246,68 @@ describe(
       assertExists(discoveredAgent);
       assertEquals(toolRegistry.has("getWeather"), true);
       assertExists(skillRegistry.get("writer-helper"));
+    });
+
+    it("uses relative discovery paths for API-backed project files", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+      skillRegistry.clearAll();
+
+      const ctx = createHandlerContext(
+        "/runtime/project",
+        "api-backed-project",
+        "preview",
+      );
+      ctx.config = {
+        fs: { type: "veryfront-api" },
+      } as HandlerContext["config"];
+
+      await ctx.adapter.fs.writeFile(
+        "tools/relative-tool.ts",
+        [
+          'import { tool } from "veryfront/tool";',
+          'import { defineSchema } from "veryfront/schemas";',
+          "",
+          "export default tool({",
+          '  id: "relative_tool",',
+          '  description: "Uses API-backed relative discovery.",',
+          "  inputSchema: defineSchema((v) => v.object({}))(),",
+          "  execute: async () => ({ ok: true }),",
+          "});",
+          "",
+        ].join("\n"),
+      );
+
+      const discovery = await ensureProjectDiscovery(ctx);
+
+      assertEquals(discovery.tools.has("relative_tool"), true);
+      assertEquals(toolRegistry.has("relative_tool"), true);
+    });
+
+    it("rethrows hard primitive discovery failures instead of returning an empty result", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+      skillRegistry.clearAll();
+
+      const ctx = createHandlerContext(
+        "/hard-failure-project",
+        "hard-failure-project",
+        "preview",
+      );
+      const exists = ctx.adapter.fs.exists.bind(ctx.adapter.fs);
+      ctx.adapter.fs.exists = (path: string) => {
+        if (path === `${ctx.projectDir}/skills`) {
+          throw new Error("VFS unavailable");
+        }
+        return exists(path);
+      };
+
+      const error = await assertRejects(
+        () => ensureProjectDiscovery(ctx),
+        Error,
+        "Runtime discovery failed: VFS unavailable",
+      );
+      assertExists(error);
     });
 
     it("does not warn about zero agents and tools when AI primitive discovery is disabled", async () => {

--- a/src/server/handlers/request/api/project-discovery.ts
+++ b/src/server/handlers/request/api/project-discovery.ts
@@ -1,3 +1,4 @@
+import type { DiscoveryResult } from "#veryfront/discovery";
 import { serverLogger } from "#veryfront/utils";
 import { clearTrackedAgents, createProjectDiscoveryConfig } from "#veryfront/discovery";
 import { tryGetCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
@@ -15,7 +16,7 @@ const logger = serverLogger.component("api-wrapper");
  * allows retry on failure (the key is deleted if discovery rejects).
  */
 interface DiscoveryRecord {
-  promise: Promise<void>;
+  promise: Promise<DiscoveryResult>;
 }
 
 const discoveredProjects = new Map<string, DiscoveryRecord>();
@@ -57,7 +58,7 @@ function shouldCacheCompletedDiscovery(ctx: HandlerContext): boolean {
  * the correct remote project files and the agent registry uses the
  * correct project scope.
  */
-export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<void> {
+export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<DiscoveryResult> {
   const key = discoveryKey(ctx);
   const cacheCompletedDiscovery = shouldCacheCompletedDiscovery(ctx);
 
@@ -107,13 +108,15 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<void>
       } else {
         logger.info("Primitive discovery completed", logData);
       }
+
+      return result;
     })(),
   };
 
   discoveredProjects.set(key, discovery);
 
   try {
-    await discovery.promise;
+    return await discovery.promise;
   } catch (error) {
     // Allow retry on next request
     discoveredProjects.delete(key);
@@ -122,6 +125,9 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<void>
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
+    throw new Error(
+      `Runtime discovery failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
   } finally {
     if (!cacheCompletedDiscovery) {
       const current = discoveredProjects.get(key);

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -4,6 +4,8 @@ import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import type { Agent } from "#veryfront/agent";
 import type { Message } from "#veryfront/agent/types.ts";
 import { agentRegistry } from "#veryfront/agent/composition/index.ts";
+import type { DiscoveryResult } from "#veryfront/discovery";
+import type { HandlerContext } from "#veryfront/types";
 import { createAgentServiceEvalAdapter } from "#veryfront/eval/agent-service.ts";
 import { runEval as runEvalDefinition } from "#veryfront/eval/runner.ts";
 import { datasets, evalAgent, type EvalReport, metrics } from "veryfront/eval";
@@ -85,16 +87,6 @@ function createDeps(
   overrides: Partial<ProjectRunExecuteHandlerDeps> = {},
 ): ProjectRunExecuteHandlerDeps {
   return {
-    findTaskById: async (target) =>
-      target === "sync-calendar-events"
-        ? {
-          id: "sync-calendar-events",
-          name: "Sync calendar events",
-          filePath: "tasks/sync-calendar-events.ts",
-          exportName: "default",
-          definition: { name: "Sync calendar events", run: async () => ({ ok: true }) },
-        }
-        : null,
     runTask: async (_options) => ({
       success: true,
       result: { synced: 12 },
@@ -159,10 +151,34 @@ function createDeps(
       logs: null,
       duration_ms: 10,
     }),
-    ensureProjectDiscovery: async () => {},
+    ensureProjectDiscovery: async () => {
+      const discovery = createEmptyDiscoveryResult();
+      discovery.tasks.set("sync-calendar-events", {
+        name: "Sync calendar events",
+        run: async () => ({ ok: true }),
+      });
+      return discovery;
+    },
     sleep: async () => {},
     now: () => 0,
     ...overrides,
+  };
+}
+
+function createEmptyDiscoveryResult(): DiscoveryResult {
+  return {
+    tools: new Map(),
+    agents: new Map(),
+    skills: new Map(),
+    resources: new Map(),
+    prompts: new Map(),
+    workflows: new Map(),
+    works: new Map(),
+    tasks: new Map(),
+    schedules: new Map(),
+    webhooks: new Map(),
+    evals: new Map(),
+    errors: [],
   };
 }
 
@@ -247,6 +263,82 @@ describe("server/handlers/request/project-run-execute.handler", () => {
       logs: null,
     });
     assertEquals(receivedConfig, { dry_run: true });
+  });
+
+  it("runs cloud task targets from project runtime discovery", async () => {
+    const order: string[] = [];
+    const discovery = createEmptyDiscoveryResult();
+    discovery.tasks.set("sync-calendar-events", {
+      name: "Sync calendar events",
+      run: async () => ({ ok: true }),
+    });
+
+    const handler = new ProjectRunExecuteHandler(createDeps({
+      ensureProjectDiscovery: async () => {
+        order.push("discover");
+        return discovery;
+      },
+      runTask: async (options) => {
+        order.push(`run:${options.task.id}`);
+        return {
+          success: true,
+          result: { synced: 12 },
+          durationMs: 42,
+        };
+      },
+    }));
+    const body = {
+      runId: "run_task_runtime_1",
+      kind: "task",
+      target: "task:sync-calendar-events",
+      projectId: "proj-1",
+      config: { dry_run: true },
+    };
+    const { request, publicKeyPem } = await signedRequest(
+      "/api/control-plane/runs/run_task_runtime_1/execute",
+      body,
+    );
+
+    const result = await handler.handle(request, createCtx(publicKeyPem));
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(await result.response.json(), {
+      success: true,
+      result: { synced: 12 },
+      duration_ms: 42,
+      logs: null,
+    });
+    assertEquals(order, ["discover", "run:sync-calendar-events"]);
+  });
+
+  it("reports runtime discovery failures before task lookup", async () => {
+    const handler = new ProjectRunExecuteHandler(createDeps({
+      ensureProjectDiscovery: async () => {
+        throw new Error("Runtime discovery failed: VFS unavailable");
+      },
+    }));
+    const body = {
+      runId: "run_task_discovery_failed",
+      kind: "task",
+      target: "task:sync-calendar-events",
+      projectId: "proj-1",
+    };
+    const { request, publicKeyPem } = await signedRequest(
+      "/api/control-plane/runs/run_task_discovery_failed/execute",
+      body,
+    );
+
+    const result = await handler.handle(request, createCtx(publicKeyPem));
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(await result.response.json(), {
+      success: false,
+      error: "Runtime discovery failed: VFS unavailable",
+      logs: null,
+      duration_ms: 0,
+    });
   });
 
   it("dispatches built-in knowledge ingest runs through the reusable ingest executor", async () => {
@@ -761,6 +853,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     const handler = new ProjectRunExecuteHandler(createDeps({
       ensureProjectDiscovery: async () => {
         order.push("discover");
+        return createEmptyDiscoveryResult();
       },
       createWorkflowClient: (config) => {
         hasAgentRegistry = typeof config?.executor?.stepExecutor?.agentRegistry?.get ===
@@ -886,7 +979,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
           mode: "preview",
         },
         resolvedEnvironment: "preview",
-      };
+      } as HandlerContext;
 
       const result = await runWithRequestContext(
         {

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -12,7 +12,8 @@ import {
 import type { RuntimeAdapter } from "#veryfront/platform";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
-import { type DiscoveredTask, findTaskById } from "#veryfront/task/discovery.ts";
+import type { DiscoveryResult } from "#veryfront/discovery";
+import { findProjectRuntimeTask } from "#veryfront/task/project-runtime.ts";
 import { runTask, type RunTaskOptions, type TaskRunResult } from "#veryfront/task/runner.ts";
 import { type DiscoveredEval, findEvalById } from "#veryfront/eval/discovery.ts";
 import { runEval } from "#veryfront/eval/runner.ts";
@@ -100,15 +101,6 @@ interface WorkflowClientView {
 }
 
 export interface ProjectRunExecuteHandlerDeps {
-  findTaskById(
-    taskId: string,
-    options: {
-      projectDir: string;
-      adapter: RuntimeAdapter;
-      config?: VeryfrontConfig;
-      debug?: boolean;
-    },
-  ): Promise<DiscoveredTask | null>;
   runTask(options: RunTaskOptions): Promise<TaskRunResult>;
   findWorkflowById(
     workflowId: string,
@@ -134,7 +126,7 @@ export interface ProjectRunExecuteHandlerDeps {
   runEval(definition: EvalDefinition, options: RunEvalOptions): Promise<EvalReport>;
   createEvalAgentAdapter(config: AgentServiceEvalAdapterConfig): EvalAgentAdapter;
   uploadEvalReport(input: EvalReportUploadInput): Promise<string | null>;
-  ensureProjectDiscovery(ctx: HandlerContext): Promise<void>;
+  ensureProjectDiscovery(ctx: HandlerContext): Promise<DiscoveryResult>;
   executeKnowledgeIngest(input: {
     request: ProjectRunExecuteRequest;
     ctx: HandlerContext;
@@ -291,12 +283,8 @@ async function executeTaskRun(
     throw new Error("Knowledge ingest must be executed through the knowledge ingest executor");
   }
 
-  const task = await deps.findTaskById(taskId, {
-    projectDir: ctx.projectDir,
-    adapter: ctx.adapter,
-    config: ctx.config,
-    debug: ctx.debug,
-  });
+  const discovery = await deps.ensureProjectDiscovery(ctx);
+  const task = findProjectRuntimeTask(discovery, taskId);
 
   if (!task) {
     return {
@@ -1109,7 +1097,6 @@ async function executeReleaseAssetBuildRun(input: {
 }
 
 const defaultDeps: ProjectRunExecuteHandlerDeps = {
-  findTaskById,
   runTask,
   findWorkflowById,
   findEvalById,

--- a/src/task/discovery.test.ts
+++ b/src/task/discovery.test.ts
@@ -1,10 +1,14 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterAll, afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { FileSystemAdapter, RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 import { clearTranspileCache } from "#veryfront/discovery/transpiler.ts";
+import { clearConfigCache } from "#veryfront/config";
+import { toolRegistry } from "#veryfront/tool/registry.ts";
 import { deriveTaskId, discoverTasks, findTaskById } from "./discovery.ts";
+import { discoverProjectTaskRuntime } from "./project-runtime.ts";
+import { runTriggerTarget } from "../trigger/local-runner.ts";
 import { isTaskDefinition } from "./types.ts";
 
 function createMockAdapter(files: Record<string, string>): FileSystemAdapter {
@@ -99,11 +103,32 @@ function createRuntimeAdapter(files: Record<string, string>): RuntimeAdapter {
   };
 }
 
+function makeTaskSource(name: string): string {
+  return [
+    "export default {",
+    `  name: "${name}",`,
+    "  run: () => ({ ok: true }),",
+    "};",
+    "",
+  ].join("\n");
+}
+
+function markAdapterAsVirtual(adapter: RuntimeAdapter): void {
+  Object.assign(adapter.fs, {
+    getUnderlyingAdapter: () => adapter.fs,
+    getAdapterType: () => "VeryfrontFSAdapter",
+    isVeryfrontAdapter: () => true,
+    isMultiProjectMode: () => true,
+  });
+}
+
 // Discovery uses the shared esbuild service under the hood, which outlives
 // individual test cases until stopEsbuild() runs in afterAll.
 describe("task/discovery", { sanitizeOps: false, sanitizeResources: false }, () => {
   afterEach(() => {
     clearTranspileCache();
+    clearConfigCache();
+    toolRegistry.clear();
   });
 
   afterAll(async () => {
@@ -287,5 +312,142 @@ describe("task/discovery", { sanitizeOps: false, sanitizeResources: false }, () 
     assertEquals(task?.id, "ping");
     assertEquals(task?.name, "Ping task");
     assertEquals(task?.exportName, "pingTask");
+  });
+
+  it("discovers runtime tasks through adapter-backed project paths", async () => {
+    const adapter = createRuntimeAdapter({
+      "/project/remote-tasks/sync.ts": makeTaskSource("Remote Sync"),
+    });
+
+    const discovery = await discoverProjectTaskRuntime({
+      projectDir: "/local-checkout",
+      adapter,
+      config: {
+        fs: { type: "veryfront-api" },
+        ai: { tasks: { discovery: { paths: ["remote-tasks"] } } },
+      },
+      fsAdapter: adapter.fs,
+    });
+
+    assertEquals([...discovery.tasks.keys()], ["sync"]);
+  });
+
+  it("isolates virtual project runtime config by cache key", async () => {
+    const firstAdapter = createRuntimeAdapter({
+      "/veryfront.config.ts": [
+        "export default {",
+        '  fs: { type: "veryfront-api" },',
+        '  ai: { tasks: { discovery: { paths: ["first-tasks"] } } },',
+        "};",
+        "",
+      ].join("\n"),
+      "/project/first-tasks/first.ts": makeTaskSource("First"),
+    });
+    markAdapterAsVirtual(firstAdapter);
+
+    const first = await discoverProjectTaskRuntime({
+      projectDir: "/same-local-dir",
+      adapter: firstAdapter,
+      fsAdapter: firstAdapter.fs,
+      cacheKey: "project-a",
+    });
+    assertEquals([...first.tasks.keys()], ["first"]);
+
+    const secondAdapter = createRuntimeAdapter({
+      "/veryfront.config.ts": [
+        "export default {",
+        '  fs: { type: "veryfront-api" },',
+        '  ai: { tasks: { discovery: { paths: ["second-tasks"] } } },',
+        "};",
+        "",
+      ].join("\n"),
+      "/project/second-tasks/second.ts": makeTaskSource("Second"),
+    });
+    markAdapterAsVirtual(secondAdapter);
+
+    const second = await discoverProjectTaskRuntime({
+      projectDir: "/same-local-dir",
+      adapter: secondAdapter,
+      fsAdapter: secondAdapter.fs,
+      cacheKey: "project-b",
+    });
+
+    assertEquals([...second.tasks.keys()], ["second"]);
+  });
+
+  it("returns runtime tasks alongside unrelated discovery errors by default", async () => {
+    const adapter = createRuntimeAdapter({
+      "/project/tasks/sync.ts": makeTaskSource("Sync"),
+      "/project/tools/broken.ts": 'import "./missing.ts"; export default {};\n',
+    });
+
+    const discovery = await discoverProjectTaskRuntime({
+      projectDir: "/project",
+      adapter,
+      config: { fs: { type: "veryfront-api" } },
+      fsAdapter: adapter.fs,
+    });
+
+    assertEquals([...discovery.tasks.keys()], ["sync"]);
+    assertEquals(discovery.errors.length, 1);
+  });
+
+  it("reports all runtime discovery errors in strict mode", async () => {
+    const adapter = createRuntimeAdapter({
+      "/project/tools/first.ts": 'import "./missing-one.ts";\n',
+      "/project/tools/second.ts": 'import "./missing-two.ts";\n',
+    });
+
+    await assertRejects(
+      () =>
+        discoverProjectTaskRuntime({
+          projectDir: "/project",
+          adapter,
+          config: { fs: { type: "veryfront-api" } },
+          fsAdapter: adapter.fs,
+          throwOnErrors: true,
+        }),
+      Error,
+      "Runtime discovery failed with 2 errors",
+    );
+  });
+
+  it("runs task targets after project runtime discovery", async () => {
+    const adapter = createRuntimeAdapter({
+      "/project/tools/runtime-marker.ts": [
+        'import { tool } from "veryfront/tool";',
+        'import { defineSchema } from "veryfront/schemas";',
+        "",
+        "export default tool({",
+        '  id: "runtime_marker",',
+        '  description: "Marks project runtime discovery.",',
+        "  inputSchema: defineSchema((v) => v.object({}))(),",
+        "  execute: () => ({ ok: true }),",
+        "});",
+        "",
+      ].join("\n"),
+      "/project/tasks/probe-runtime.ts": [
+        'import { toolRegistry } from "veryfront/tool";',
+        "",
+        "export default {",
+        '  name: "Probe runtime",',
+        "  run() {",
+        '    return { hasRuntimeTool: toolRegistry.has("runtime_marker") };',
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    });
+
+    const result = await runTriggerTarget({
+      projectDir: "/project",
+      adapter,
+      config: { fs: { type: "veryfront-api" } },
+      target: { kind: "task", id: "probe-runtime" },
+    });
+
+    assertEquals(result.kind, "task");
+    assertEquals(result.id, "probe-runtime");
+    assertEquals(result.output, { hasRuntimeTool: true });
   });
 });

--- a/src/task/discovery.ts
+++ b/src/task/discovery.ts
@@ -40,7 +40,11 @@ const TASK_IGNORE_PATTERNS = [
 ] as const;
 
 /**
- * Discovered task info
+ * Discovered task info.
+ *
+ * @deprecated Use project runtime discovery helpers from `veryfront/task`
+ * instead. Runtime discovery keeps tasks, tools, agents, and cloud runs on the
+ * same project discovery path.
  */
 export interface DiscoveredTask {
   /** Task ID derived from file path (e.g., "sync-data" from tasks/sync-data.ts) */
@@ -60,7 +64,9 @@ export interface DiscoveredTask {
 }
 
 /**
- * Options for task discovery
+ * Options for file-based task discovery.
+ *
+ * @deprecated Use `discoverProjectTaskRuntime` instead.
  */
 export interface TaskDiscoveryOptions {
   /** Project directory */
@@ -80,7 +86,9 @@ export interface TaskDiscoveryOptions {
 }
 
 /**
- * Result of task discovery
+ * Result of file-based task discovery.
+ *
+ * @deprecated Use `DiscoveryResult` from project runtime discovery instead.
  */
 export interface TaskDiscoveryResult {
   /** All discovered tasks */
@@ -161,7 +169,10 @@ function logDiscoveredTask(task: DiscoveredTask, debug: boolean): void {
 }
 
 /**
- * Derive task ID from file path (e.g., "tasks/sync-data.ts" → "sync-data")
+ * Derive task ID from file path (e.g., "tasks/sync-data.ts" -> "sync-data").
+ *
+ * @deprecated Use project runtime task IDs from `discoverProjectTaskRuntime`
+ * instead.
  */
 export function deriveTaskId(filePath: string, tasksDir: string): string {
   // Remove the tasks dir prefix and extension
@@ -175,7 +186,9 @@ export function deriveTaskId(filePath: string, tasksDir: string): string {
 }
 
 /**
- * Discover all tasks in a project
+ * Discover all tasks in a project with the legacy file-based path.
+ *
+ * @deprecated Use `discoverProjectTaskRuntime` instead.
  */
 export async function discoverTasks(
   options: TaskDiscoveryOptions,
@@ -247,7 +260,10 @@ export async function discoverTasks(
 }
 
 /**
- * Find a specific task by ID, short-circuiting discovery once found.
+ * Find a specific task by ID through the legacy file-based path.
+ *
+ * @deprecated Use `discoverProjectTaskRuntime` and `findProjectRuntimeTask`
+ * instead.
  */
 export async function findTaskById(
   taskId: string,

--- a/src/task/index.ts
+++ b/src/task/index.ts
@@ -7,4 +7,11 @@ export { isTaskDefinition } from "./types.ts";
 export { deriveTaskId, discoverTasks, findTaskById } from "./discovery.ts";
 export type { DiscoveredTask, TaskDiscoveryOptions, TaskDiscoveryResult } from "./discovery.ts";
 export { runTask } from "./runner.ts";
-export type { RunTaskOptions, TaskRunResult } from "./runner.ts";
+export type { RunnableTask, RunTaskOptions, TaskRunResult } from "./runner.ts";
+export {
+  discoverProjectTaskRuntime,
+  findProjectRuntimeTask,
+  formatProjectRuntimeDiscoveryErrors,
+  listProjectRuntimeTasks,
+} from "./project-runtime.ts";
+export type { ProjectTaskRuntimeOptions } from "./project-runtime.ts";

--- a/src/task/project-runtime.ts
+++ b/src/task/project-runtime.ts
@@ -1,0 +1,73 @@
+import { discoverProjectAgentRuntime } from "#veryfront/agent/project/agent-runtime.ts";
+import type { DiscoveryResult } from "#veryfront/discovery";
+import type { RuntimeAdapter } from "#veryfront/platform";
+import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { VeryfrontConfig } from "#veryfront/config";
+import type { RunnableTask } from "./runner.ts";
+
+export interface ProjectTaskRuntimeOptions {
+  projectDir: string;
+  adapter: RuntimeAdapter;
+  config?: VeryfrontConfig | null;
+  fsAdapter?: FileSystemAdapter;
+  cacheKey?: string;
+  debug?: boolean;
+  throwOnErrors?: boolean;
+}
+
+function formatRuntimeDiscoveryError(error: DiscoveryResult["errors"][number]): string {
+  return `${error.file}: ${error.error.message}`;
+}
+
+export function formatProjectRuntimeDiscoveryErrors(
+  errors: DiscoveryResult["errors"],
+): string[] {
+  return errors.map(formatRuntimeDiscoveryError);
+}
+
+export async function discoverProjectTaskRuntime(
+  options: ProjectTaskRuntimeOptions,
+): Promise<DiscoveryResult> {
+  const discovery = await discoverProjectAgentRuntime({
+    projectDir: options.projectDir,
+    adapter: options.adapter,
+    config: options.config,
+    fsAdapter: options.fsAdapter,
+    cacheKey: options.cacheKey,
+    verbose: options.debug,
+  });
+
+  if (options.throwOnErrors && discovery.errors.length > 0) {
+    const lines = formatProjectRuntimeDiscoveryErrors(discovery.errors);
+    throw new Error(
+      [
+        `Runtime discovery failed with ${discovery.errors.length} errors:`,
+        ...lines.map((line) => `- ${line}`),
+      ].join("\n"),
+    );
+  }
+
+  return discovery;
+}
+
+export function findProjectRuntimeTask(
+  discovery: DiscoveryResult,
+  taskId: string,
+): RunnableTask | null {
+  const definition = discovery.tasks.get(taskId);
+  if (!definition) return null;
+
+  return {
+    id: taskId,
+    name: definition.name || taskId,
+    definition,
+  };
+}
+
+export function listProjectRuntimeTasks(discovery: DiscoveryResult): RunnableTask[] {
+  return [...discovery.tasks].map(([id, definition]) => ({
+    id,
+    name: definition.name || id,
+    definition,
+  }));
+}

--- a/src/task/runner.ts
+++ b/src/task/runner.ts
@@ -8,17 +8,28 @@
 import { logger as baseLogger } from "#veryfront/utils";
 import { env as getProcessEnv } from "#veryfront/compat/process.ts";
 import { buildTaskContextEnv } from "#veryfront/runs/runtime-env.ts";
-import type { DiscoveredTask } from "./discovery.ts";
 import type { TaskContext } from "./types.ts";
+import type { TaskDefinition } from "./types.ts";
 
 const logger = baseLogger.component("task-runner");
+
+export interface RunnableTask {
+  /** Stable task id used by CLI, triggers, and cloud runs. */
+  id: string;
+
+  /** Human-readable task name. */
+  name: string;
+
+  /** The task definition to execute. */
+  definition: TaskDefinition;
+}
 
 /**
  * Options for running a task
  */
 export interface RunTaskOptions {
   /** The discovered task to run */
-  task: DiscoveredTask;
+  task: RunnableTask;
 
   /** Additional config to pass to the task */
   config?: Record<string, unknown>;

--- a/src/trigger/local-runner.ts
+++ b/src/trigger/local-runner.ts
@@ -1,10 +1,12 @@
 import { agentRegistry } from "#veryfront/agent/composition/index.ts";
-import { discoverProjectAgentRuntime } from "#veryfront/agent/project/agent-runtime.ts";
 import type { RuntimeAdapter } from "#veryfront/platform";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { toolRegistry } from "#veryfront/tool/registry.ts";
 import { createWorkflowClient } from "#veryfront/workflow/api/workflow-client.ts";
-import { discoverTasks } from "#veryfront/task/discovery.ts";
+import {
+  discoverProjectTaskRuntime,
+  findProjectRuntimeTask,
+} from "#veryfront/task/project-runtime.ts";
 import { runTask } from "#veryfront/task/runner.ts";
 import type { TriggerTarget } from "./target.ts";
 
@@ -12,6 +14,7 @@ export interface RunTriggerTargetOptions {
   projectDir: string;
   adapter: RuntimeAdapter;
   config?: VeryfrontConfig;
+  cacheKey?: string;
   projectId?: string;
   target: TriggerTarget;
   input?: unknown;
@@ -33,18 +36,21 @@ function toRecordInput(input: unknown): Record<string, unknown> {
   return { payload: input };
 }
 
-async function runTaskTarget(options: RunTriggerTargetOptions): Promise<TriggerTargetRunResult> {
-  const { tasks, errors } = await discoverTasks({
+async function discoverRuntimeOrThrow(options: RunTriggerTargetOptions) {
+  return await discoverProjectTaskRuntime({
     projectDir: options.projectDir,
     adapter: options.adapter,
     config: options.config,
+    fsAdapter: options.adapter.fs,
+    cacheKey: options.cacheKey,
     debug: options.debug,
+    throwOnErrors: true,
   });
-  if (errors.length > 0) {
-    throw new Error(`Task discovery failed: ${errors[0]?.filePath}: ${errors[0]?.error}`);
-  }
+}
 
-  const task = tasks.find((candidate) => candidate.id === options.target.id);
+async function runTaskTarget(options: RunTriggerTargetOptions): Promise<TriggerTargetRunResult> {
+  const discovery = await discoverRuntimeOrThrow(options);
+  const task = findProjectRuntimeTask(discovery, options.target.id);
   if (!task) {
     throw new Error(`Task target "${options.target.id}" not found.`);
   }
@@ -72,15 +78,7 @@ async function runWorkflowTarget(
   options: RunTriggerTargetOptions,
 ): Promise<TriggerTargetRunResult> {
   const start = Date.now();
-  const discovery = await discoverProjectAgentRuntime({
-    projectDir: options.projectDir,
-    adapter: options.adapter,
-    verbose: options.debug,
-  });
-  if (discovery.errors.length > 0) {
-    const first = discovery.errors[0];
-    throw new Error(`Runtime discovery failed: ${first?.file}: ${first?.error.message}`);
-  }
+  const discovery = await discoverRuntimeOrThrow(options);
 
   const workflow = discovery.workflows.get(options.target.id);
   if (!workflow) {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.995";
+export const VERSION = "0.1.996";

--- a/src/workflow/worker/dynamic-run-entrypoint.ts
+++ b/src/workflow/worker/dynamic-run-entrypoint.ts
@@ -144,6 +144,8 @@ export async function runDynamicWorkflowRun(
         const discoveryResult = await discoverProjectAgentRuntime({
           projectDir: "", // Root of project (relative paths with API)
           adapter,
+          fsAdapter: adapter.fs,
+          cacheKey: tenant.projectId ?? tenant.projectSlug,
           verbose: debug,
         });
 


### PR DESCRIPTION
## Summary
- Run task targets through project agent runtime discovery before execution.
- Use the same runtime discovery path for direct `veryfront task` runs.
- Add a focused regression test proving task targets see tools registered by project runtime discovery.
- Normalize task ids discovered from `file://` module paths.

## Verification
- `deno task fmt:check`
- `deno task lint`
- `deno task lint:core-deps && deno task lint:dependency-boundaries && deno task lint:extension-contracts && deno task lint:extension-capabilities && deno task lint:ban-test-only && deno task lint:sanitizer-baseline`
- `deno task typecheck`
- `deno test -A src/trigger/local-runner.test.ts src/task/runner.test.ts src/task/discovery.test.ts src/agent/project/agent-runtime.test.ts`
- Pre-push hook passed after final amend: formatting, lint, typecheck, unit tests (`2237 passed`, `0 failed`).
- GitHub PR checks are green, including format, lint, typecheck, unit, integration, binary e2e, npm install smoke, rsc browser e2e, coverage, CLA, and CodeQL.
- Proved from `veryfront-ops-agent` via local `../veryfront-code` source CLI: a task loaded the project `triage-sweep` skill through runtime discovery and returned `OPS_AGENT_RUNTIME_DISCOVERY_OK`.
