### PR TITLE
Export veryfront/task subpath

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -98,6 +98,7 @@
     "./runs": "./src/runs/index.ts",
     "./skill": "./src/skill/index.ts",
     "./trigger": "./src/trigger/index.ts",
+    "./task": "./src/task/index.ts",
     "./schedule": "./src/schedule/index.ts",
     "./webhook": "./src/webhook/index.ts",
     "./mcp": "./src/mcp/index.ts",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.996",
+  "version": "0.1.997",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -39,6 +39,7 @@ order: 1
 | [`veryfront/schemas`](./veryfront/schemas.md) | Validation schemas. |
 | [`veryfront/server`](./veryfront/server.md) | Server runtime helpers. |
 | [`veryfront/skill`](./veryfront/skill.md) | Agent skills. Public API for the agent skills system. Skills are project-level capabilities defined as SKILL.md files following the agentskills.io specification. |
+| [`veryfront/task`](./veryfront/task.md) | Source-defined tasks for Veryfront projects. |
 | [`veryfront/testing`](./veryfront/testing.md) | Test utilities. |
 | [`veryfront/tool`](./veryfront/tool.md) | Tool definitions and execution. |
 | [`veryfront/trigger`](./veryfront/trigger.md) | Shared source-trigger discovery and local execution primitives. |

--- a/docs/api-reference/veryfront/task.md
+++ b/docs/api-reference/veryfront/task.md
@@ -1,0 +1,56 @@
+---
+title: "veryfront/task"
+description: "Source-defined tasks for Veryfront projects."
+order: 31
+---
+
+## Import
+
+```ts
+import {
+  deriveTaskId,
+  discoverTasks,
+  findTaskById,
+  isTaskDefinition,
+  runTask,
+} from "veryfront/task";
+```
+
+## Examples
+
+### Define a task in tasks/sync-data.ts
+
+```ts
+import type { TaskContext } from "veryfront/task";
+
+export default {
+  name: "Sync external data",
+  async run(ctx: TaskContext) {
+    return { synced: 42 };
+  },
+};
+```
+
+## Exports
+
+### Functions
+
+| Name | Description | Source |
+|------|-------------|--------|
+| `deriveTaskId` | Derive task ID from file path (e.g., "tasks/sync-data.ts" → "sync-data") | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L166) |
+| `discoverTasks` | Discover all tasks in a project | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L180) |
+| `findTaskById` | Find a specific task by ID, short-circuiting discovery once found. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L252) |
+| `isTaskDefinition` | Type guard: checks if a value looks like a TaskDefinition | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/types.ts#L42) |
+| `runTask` | Run a task with the given options | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/runner.ts#L56) |
+
+### Types
+
+| Name | Description | Source |
+|------|-------------|--------|
+| `DiscoveredTask` | Discovered task info | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L45) |
+| `RunTaskOptions` | Options for running a task | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/runner.ts#L19) |
+| `TaskContext` | Context passed to task run() function | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/types.ts#L12) |
+| `TaskDefinition` | Task definition exported from a tasks/ file | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/types.ts#L24) |
+| `TaskDiscoveryOptions` | Options for task discovery | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L65) |
+| `TaskDiscoveryResult` | Result of task discovery | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L85) |
+| `TaskRunResult` | Result of running a task | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/runner.ts#L39) |

--- a/docs/api-reference/veryfront/task.md
+++ b/docs/api-reference/veryfront/task.md
@@ -9,10 +9,11 @@ order: 31
 ```ts
 import {
   deriveTaskId,
+  discoverProjectTaskRuntime,
   discoverTasks,
+  findProjectRuntimeTask,
   findTaskById,
-  isTaskDefinition,
-  runTask,
+  formatProjectRuntimeDiscoveryErrors,
 } from "veryfront/task";
 ```
 
@@ -37,20 +38,26 @@ export default {
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `deriveTaskId` | Derive task ID from file path (e.g., "tasks/sync-data.ts" → "sync-data") | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L166) |
-| `discoverTasks` | Discover all tasks in a project | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L180) |
-| `findTaskById` | Find a specific task by ID, short-circuiting discovery once found. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L252) |
+| `deriveTaskId` | Derive task ID from file path (e.g., "tasks/sync-data.ts" -> "sync-data"). | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L177) |
+| `discoverProjectTaskRuntime` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/project-runtime.ts#L28) |
+| `discoverTasks` | Discover all tasks in a project with the legacy file-based path. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L193) |
+| `findProjectRuntimeTask` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/project-runtime.ts#L53) |
+| `findTaskById` | Find a specific task by ID through the legacy file-based path. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L268) |
+| `formatProjectRuntimeDiscoveryErrors` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/project-runtime.ts#L22) |
 | `isTaskDefinition` | Type guard: checks if a value looks like a TaskDefinition | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/types.ts#L42) |
-| `runTask` | Run a task with the given options | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/runner.ts#L56) |
+| `listProjectRuntimeTasks` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/project-runtime.ts#L67) |
+| `runTask` | Run a task with the given options | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/runner.ts#L67) |
 
 ### Types
 
 | Name | Description | Source |
 |------|-------------|--------|
-| `DiscoveredTask` | Discovered task info | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L45) |
-| `RunTaskOptions` | Options for running a task | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/runner.ts#L19) |
+| `DiscoveredTask` | Discovered task info. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L49) |
+| `ProjectTaskRuntimeOptions` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/project-runtime.ts#L8) |
+| `RunnableTask` |  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/runner.ts#L16) |
+| `RunTaskOptions` | Options for running a task | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/runner.ts#L30) |
 | `TaskContext` | Context passed to task run() function | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/types.ts#L12) |
 | `TaskDefinition` | Task definition exported from a tasks/ file | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/types.ts#L24) |
-| `TaskDiscoveryOptions` | Options for task discovery | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L65) |
-| `TaskDiscoveryResult` | Result of task discovery | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L85) |
-| `TaskRunResult` | Result of running a task | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/runner.ts#L39) |
+| `TaskDiscoveryOptions` | Options for file-based task discovery. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L71) |
+| `TaskDiscoveryResult` | Result of file-based task discovery. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/discovery.ts#L93) |
+| `TaskRunResult` | Result of running a task | [source](https://github.com/veryfront/veryfront-code/blob/main/src/task/runner.ts#L50) |

--- a/src/task/index.ts
+++ b/src/task/index.ts
@@ -1,6 +1,19 @@
 /**
- * Task system public exports.
- * @module
+ * Source-defined tasks for Veryfront projects.
+ *
+ * @module task
+ *
+ * @example Define a task in tasks/sync-data.ts
+ * ```ts
+ * import type { TaskContext } from "veryfront/task";
+ *
+ * export default {
+ *   name: "Sync external data",
+ *   async run(ctx: TaskContext) {
+ *     return { synced: 42 };
+ *   },
+ * };
+ * ```
  */
 export type { TaskContext, TaskDefinition } from "./types.ts";
 export { isTaskDefinition } from "./types.ts";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.996";
+export const VERSION = "0.1.997";


### PR DESCRIPTION
## Summary
- Add `./task` to the `deno.json` exports map so `veryfront/task` is importable from both the Deno module and the published npm package (the npm exports map is generated from `deno.json` by `scripts/build/build-npm-dnt.ts`).

## Motivation
Task authors currently cannot import the task contract types. `TaskContext` and `TaskDefinition` are exported from `src/task/index.ts` but the subpath is unreachable through the package exports map, so downstream projects hand-roll the types (see `veryfront-ops-agent` `tasks/run-triage-sweep.ts`, flagged in review of veryfront-ops-agent#3). Hand-rolled copies drift from the real contract silently.

## Verification
- `deno fmt --check deno.json`
- `deno task lint:dependency-boundaries`
- CI npm install smoke exercises the generated exports map.