### PR TITLE
Honor VERYFRONT_API_BASE_URL and veryfront.json apiUrl across the CLI

### DIFF
--- a/cli/commands/pull/command.test.ts
+++ b/cli/commands/pull/command.test.ts
@@ -6,16 +6,19 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import {
   buildFileContentUrl,
   buildFilesListUrl,
   getFileContent,
   listAllFiles,
+  pullCommand,
   type PullOptions,
   type PullSource,
   resolvePullSource,
 } from "./command.ts";
 import type { ApiClient } from "#cli/shared/config";
+import { join } from "veryfront/platform/path";
 
 function createMockClient(overrides: {
   get?: (url: string, params?: unknown) => Promise<unknown>;
@@ -48,6 +51,14 @@ function mockFileContentResponse(content: string): Promise<unknown> {
     content,
     size: content.length,
   });
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    Deno.env.delete(name);
+    return;
+  }
+  Deno.env.set(name, value);
 }
 
 describe("resolvePullSource", () => {
@@ -327,5 +338,70 @@ describe("getFileContent", () => {
 
     assertEquals(content, "export default function Home() {}\n");
     assertEquals(content.endsWith("\n\n"), false);
+  });
+});
+
+describe("pullCommand", () => {
+  it("uses explicit env API base URL before veryfront.json apiUrl in the --projects fallback", async () => {
+    const tempDir = await Deno.makeTempDir();
+    const originalFetch = globalThis.fetch;
+    const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
+    const originalApiUrl = Deno.env.get("VERYFRONT_API_URL");
+    const originalProjectSlug = Deno.env.get("VERYFRONT_PROJECT_SLUG");
+    const originalTenantProjectSlug = Deno.env.get("TENANT_PROJECT_SLUG");
+    const originalTenantProjectId = Deno.env.get("TENANT_PROJECT_ID");
+    const requestedUrls: string[] = [];
+
+    try {
+      await Deno.writeTextFile(
+        join(tempDir, "veryfront.json"),
+        JSON.stringify({
+          projects: ["alpha"],
+          apiToken: "file-token",
+          apiUrl: "https://api.from-file.test",
+        }),
+      );
+
+      Deno.env.set("VERYFRONT_API_BASE_URL", "https://api.from-env.test");
+      Deno.env.delete("VERYFRONT_API_URL");
+      Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      Deno.env.delete("TENANT_PROJECT_SLUG");
+      Deno.env.delete("TENANT_PROJECT_ID");
+      _resetEnvironmentConfig();
+
+      globalThis.fetch = ((input: string | URL | Request) => {
+        requestedUrls.push(String(input));
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: [], page_info: {} }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      }) as typeof fetch;
+
+      await pullCommand({
+        projectDir: tempDir + "/",
+        dryRun: true,
+        quiet: true,
+      });
+
+      assertEquals(
+        requestedUrls.some((url) => url.startsWith("https://api.from-env.test/projects/alpha/")),
+        true,
+      );
+      assertEquals(
+        requestedUrls.some((url) => url.startsWith("https://api.from-file.test/projects/alpha/")),
+        false,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv("VERYFRONT_API_BASE_URL", originalApiBaseUrl);
+      restoreEnv("VERYFRONT_API_URL", originalApiUrl);
+      restoreEnv("VERYFRONT_PROJECT_SLUG", originalProjectSlug);
+      restoreEnv("TENANT_PROJECT_SLUG", originalTenantProjectSlug);
+      restoreEnv("TENANT_PROJECT_ID", originalTenantProjectId);
+      _resetEnvironmentConfig();
+      await Deno.remove(tempDir, { recursive: true });
+    }
   });
 });

--- a/cli/commands/pull/command.ts
+++ b/cli/commands/pull/command.ts
@@ -11,7 +11,7 @@ import { defineSchema, lazySchema } from "veryfront/schemas";
 import type { InferSchema } from "veryfront/extensions/schema";
 import { dirname, join, normalize, resolve } from "veryfront/platform/path";
 import { cliLogger } from "#cli/utils";
-import { getApiUrl } from "#cli/shared/constants";
+import { resolveCliApiUrl } from "#cli/shared/constants";
 import { cwd } from "veryfront/platform";
 import { createFileSystem } from "veryfront/platform";
 import {
@@ -22,7 +22,7 @@ import {
 } from "#cli/shared/config";
 import { confirmPrompt, logInfo, logSuccess, logWarning } from "#cli/utils";
 import { createNoopSpinner, createSpinner } from "#cli/ui";
-import { getApiTokenEnv } from "veryfront/config";
+import { getApiTokenEnv, getEnvironmentConfig } from "veryfront/config";
 import { withSpan } from "veryfront/observability/otlp-setup";
 import { CommonArgs, createArgParser } from "#cli/shared/args";
 
@@ -417,7 +417,8 @@ export function pullCommand(options: PullOptions = {}): Promise<void> {
 
         if (!projects?.length) throw error;
 
-        const token = getApiTokenEnv() ?? configFile?.apiToken;
+        const env = getEnvironmentConfig();
+        const token = getApiTokenEnv(env) ?? configFile?.apiToken;
         if (!token) {
           throw new Error(
             "VERYFRONT_API_TOKEN environment variable or apiToken in veryfront.json is required when using --projects",
@@ -425,7 +426,7 @@ export function pullCommand(options: PullOptions = {}): Promise<void> {
         }
 
         config = {
-          apiUrl: configFile?.apiUrl ?? getApiUrl(),
+          apiUrl: resolveCliApiUrl(env, configFile?.apiUrl),
           apiToken: token,
           projectSlug: "",
         };

--- a/cli/commands/pull/command.ts
+++ b/cli/commands/pull/command.ts
@@ -11,6 +11,7 @@ import { defineSchema, lazySchema } from "veryfront/schemas";
 import type { InferSchema } from "veryfront/extensions/schema";
 import { dirname, join, normalize, resolve } from "veryfront/platform/path";
 import { cliLogger } from "#cli/utils";
+import { getApiUrl } from "#cli/shared/constants";
 import { cwd } from "veryfront/platform";
 import { createFileSystem } from "veryfront/platform";
 import {
@@ -424,7 +425,7 @@ export function pullCommand(options: PullOptions = {}): Promise<void> {
         }
 
         config = {
-          apiUrl: configFile?.apiUrl ?? "https://api.veryfront.com",
+          apiUrl: configFile?.apiUrl ?? getApiUrl(),
           apiToken: token,
           projectSlug: "",
         };

--- a/cli/commands/up/command.test.ts
+++ b/cli/commands/up/command.test.ts
@@ -1,7 +1,9 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { parseUpArgs, UpArgsSchema } from "./index.ts";
+import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
+import { join } from "veryfront/platform/path";
+import { parseUpArgs, UpArgsSchema, upCommand } from "./index.ts";
 import type { ParsedArgs } from "#cli/shared/types";
 
 function createArgs(flags: Record<string, unknown> = {}): ParsedArgs {
@@ -12,6 +14,14 @@ function assertSuccess<T extends { success: boolean; data?: unknown }>(
   result: T,
 ): asserts result is T & { success: true; data: NonNullable<T["data"]> } {
   assertEquals(result.success, true);
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    Deno.env.delete(name);
+    return;
+  }
+  Deno.env.set(name, value);
 }
 
 describe("Up Command", () => {
@@ -64,6 +74,134 @@ describe("Up Command", () => {
       assertSuccess(result);
       assertEquals(result.data.force, true);
       assertEquals(result.data.dryRun, true);
+    });
+  });
+
+  describe("upCommand", () => {
+    it("uses VERYFRONT_API_BASE_URL when creating a project", async () => {
+      const originalCwd = Deno.cwd();
+      const originalFetch = globalThis.fetch;
+      const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+      const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
+      const originalApiUrl = Deno.env.get("VERYFRONT_API_URL");
+      const tempDir = await Deno.makeTempDir();
+      const requestedUrls: string[] = [];
+
+      try {
+        await Deno.writeTextFile(join(tempDir, "package.json"), "{}");
+        Deno.chdir(tempDir);
+        Deno.env.set("VERYFRONT_API_TOKEN", "env-token");
+        Deno.env.set("VERYFRONT_API_BASE_URL", "https://api.from-env.test");
+        Deno.env.delete("VERYFRONT_API_URL");
+        _resetEnvironmentConfig();
+
+        globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+          const url = String(input);
+          requestedUrls.push(url);
+
+          if (url.endsWith("/me")) {
+            return Promise.resolve(
+              new Response(JSON.stringify({ id: "user-1", email: "dev@example.com" }), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              }),
+            );
+          }
+
+          if (url.endsWith("/projects") && init?.method === "POST") {
+            return Promise.resolve(
+              new Response(JSON.stringify({ id: "project-1", slug: "test-project" }), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              }),
+            );
+          }
+
+          if (url.endsWith("/branches") && init?.method === "POST") {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({ id: "branch-1", name: "main", projectId: "project-1" }),
+                {
+                  status: 200,
+                  headers: { "content-type": "application/json" },
+                },
+              ),
+            );
+          }
+
+          if (url.includes("/environments")) {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  data: [{ id: "env-1", name: "preview", protected: false }],
+                  page_info: {},
+                }),
+                {
+                  status: 200,
+                  headers: { "content-type": "application/json" },
+                },
+              ),
+            );
+          }
+
+          if (url.endsWith("/releases") && init?.method === "POST") {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  id: "release-1",
+                  name: "Preview",
+                  version: "v1",
+                  export_status: "complete",
+                  build_status: "complete",
+                  deploy_status: "pending",
+                }),
+                {
+                  status: 200,
+                  headers: { "content-type": "application/json" },
+                },
+              ),
+            );
+          }
+
+          if (url.endsWith("/deployments") && init?.method === "POST") {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({ id: "deployment-1", release: "release-1", environment: "env-1" }),
+                {
+                  status: 200,
+                  headers: { "content-type": "application/json" },
+                },
+              ),
+            );
+          }
+
+          return Promise.resolve(
+            new Response(JSON.stringify({ data: [], page_info: {} }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+          );
+        }) as typeof fetch;
+
+        await upCommand({ force: true, dryRun: false });
+
+        assertEquals(
+          requestedUrls.some((url) => url.startsWith("https://api.from-env.test/projects")),
+          true,
+        );
+        assertEquals(
+          requestedUrls.some((url) => url.startsWith("https://api.veryfront.com/projects")),
+          false,
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+        Deno.chdir(originalCwd);
+        restoreEnv("VERYFRONT_API_TOKEN", originalApiToken);
+        restoreEnv("VERYFRONT_API_BASE_URL", originalApiBaseUrl);
+        restoreEnv("VERYFRONT_API_URL", originalApiUrl);
+        _resetEnvironmentConfig();
+        await Deno.remove(tempDir, { recursive: true });
+      }
     });
   });
 });

--- a/cli/commands/up/command.ts
+++ b/cli/commands/up/command.ts
@@ -11,6 +11,7 @@ import { createSpinner, shouldUseColor } from "#cli/ui";
 import { isTTY, promptUser } from "#cli/utils";
 import { CommonArgs, createArgParser } from "#cli/shared/args";
 import { readConfigFile, type VeryfrontConfig } from "#cli/shared/config";
+import { resolveCliApiUrl } from "#cli/shared/constants";
 import { pushCommand } from "../push/index.ts";
 import { deployCommand } from "../deploy/index.ts";
 
@@ -112,7 +113,7 @@ export async function upCommand(
 
   const projectDir = cwd();
 
-  const userInfo = await ensureAuthenticated();
+  const userInfo = await ensureAuthenticated(env);
   if (!userInfo) return;
 
   const spinner = createSpinner("Analyzing project...");
@@ -153,8 +154,8 @@ export async function upCommand(
       const projectSpinner = createSpinner(`Creating project "${slug}"...`);
 
       try {
-        const apiUrl = env.apiUrl ?? "https://api.veryfront.com";
-        const resolvedToken = env.apiToken ?? (await readToken());
+        const apiUrl = resolveCliApiUrl(env);
+        const resolvedToken = env.apiToken ?? (await readToken(env));
 
         if (!resolvedToken) {
           projectSpinner.stop();

--- a/cli/shared/config.test.ts
+++ b/cli/shared/config.test.ts
@@ -6,7 +6,7 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { createApiClient, resolveConfig, resolveConfigWithAuth } from "./config.ts";
+import { createApiClient, readConfigFile, resolveConfig, resolveConfigWithAuth } from "./config.ts";
 import type { ResolvedConfig } from "./config.ts";
 import type { EnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import { join } from "veryfront/platform/path";
@@ -407,5 +407,45 @@ describe("createApiClient", () => {
         globalThis.fetch = originalFetch;
       }
     });
+  });
+});
+
+describe("readConfigFile", () => {
+  it("merges veryfront.json apiUrl with the module config projectSlug", async () => {
+    const tempDir = await Deno.makeTempDir();
+    try {
+      await Deno.writeTextFile(
+        join(tempDir, "veryfront.config.js"),
+        'export default { projectSlug: "from-module" };\n',
+      );
+      await Deno.writeTextFile(
+        join(tempDir, "veryfront.json"),
+        JSON.stringify({ projectSlug: "from-json", apiUrl: "https://api.veryfront.org" }),
+      );
+
+      const config = await readConfigFile(tempDir);
+
+      assertEquals(config?.projectSlug, "from-module");
+      assertEquals(config?.apiUrl, "https://api.veryfront.org");
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("reads veryfront.json alone when no module config exists", async () => {
+    const tempDir = await Deno.makeTempDir();
+    try {
+      await Deno.writeTextFile(
+        join(tempDir, "veryfront.json"),
+        JSON.stringify({ projectSlug: "json-only", apiUrl: "https://api.veryfront.org" }),
+      );
+
+      const config = await readConfigFile(tempDir);
+
+      assertEquals(config?.projectSlug, "json-only");
+      assertEquals(config?.apiUrl, "https://api.veryfront.org");
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
   });
 });

--- a/cli/shared/config.test.ts
+++ b/cli/shared/config.test.ts
@@ -67,6 +67,54 @@ describe("resolveConfig", () => {
 
     assertEquals(config.apiUrl, "https://custom.api.com");
   });
+
+  it("prefers explicit apiBaseUrl over veryfront.json apiUrl", async () => {
+    const tempDir = await Deno.makeTempDir();
+    try {
+      await Deno.writeTextFile(
+        join(tempDir, "veryfront.json"),
+        JSON.stringify({
+          projectSlug: "from-json",
+          apiUrl: "https://api.from-file.test",
+        }),
+      );
+
+      const env = createMockEnv({
+        apiBaseUrl: "https://api.from-env.test",
+        apiToken: "env-token",
+      });
+
+      const config = await resolveConfig(tempDir, env);
+
+      assertEquals(config.apiUrl, "https://api.from-env.test");
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("uses veryfront.json apiUrl before the default apiBaseUrl", async () => {
+    const tempDir = await Deno.makeTempDir();
+    try {
+      await Deno.writeTextFile(
+        join(tempDir, "veryfront.json"),
+        JSON.stringify({
+          projectSlug: "from-json",
+          apiUrl: "https://api.from-file.test",
+        }),
+      );
+
+      const env = createMockEnv({
+        apiBaseUrl: "https://api.veryfront.com",
+        apiToken: "env-token",
+      });
+
+      const config = await resolveConfig(tempDir, env);
+
+      assertEquals(config.apiUrl, "https://api.from-file.test");
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
 });
 
 describe("resolveConfigWithAuth", () => {

--- a/cli/shared/config.ts
+++ b/cli/shared/config.ts
@@ -13,7 +13,7 @@ import { type EnvironmentConfig, getEnvironmentConfig } from "veryfront/config";
 import { cliLogger, VERSION } from "#cli/utils";
 import { readToken } from "../auth/token-store.ts";
 import { ensureAuthenticated } from "../auth/login.ts";
-import { DEFAULT_API_URL } from "./constants.ts";
+import { resolveCliApiUrl } from "./constants.ts";
 import { isRetryableConnectionError } from "../../src/proxy/retry.ts";
 
 // Delays for exponential backoff with jitter: attempt 1 = ~300ms, 2 = ~1s, 3 = ~3s
@@ -159,9 +159,7 @@ async function resolveConfigBase(
   const dir = projectDir ?? cwd();
   const configFile = await readConfigFile(dir);
 
-  // Explicit VERYFRONT_API_URL wins, then the project's veryfront.json,
-  // then apiBaseUrl (VERYFRONT_API_BASE_URL or the production default).
-  const apiUrl = env.apiUrl ?? configFile?.apiUrl ?? env.apiBaseUrl ?? DEFAULT_API_URL;
+  const apiUrl = resolveCliApiUrl(env, configFile?.apiUrl);
 
   let apiToken = env.apiToken ?? configFile?.apiToken ?? (await readToken(env));
 

--- a/cli/shared/config.ts
+++ b/cli/shared/config.ts
@@ -63,6 +63,7 @@ export type ResolvedConfig = InferSchema<ReturnType<typeof getResolvedConfigSche
 export async function readConfigFile(projectDir: string): Promise<VeryfrontConfig | null> {
   const fs = createFileSystem();
 
+  let moduleProjectSlug: string | undefined;
   for (const ext of [".ts", ".js"]) {
     const configPath = join(projectDir, `veryfront.config${ext}`);
 
@@ -72,23 +73,36 @@ export async function readConfigFile(projectDir: string): Promise<VeryfrontConfi
       const module = await import(`file://${configPath}`);
       const config = module.default ?? module;
 
-      if (config?.projectSlug) return { projectSlug: config.projectSlug };
+      if (config?.projectSlug) {
+        moduleProjectSlug = config.projectSlug;
+        break;
+      }
     } catch (error) {
       cliLogger.debug(`Failed to import config file ${configPath}:`, error);
     }
   }
 
+  // veryfront.json is always merged in: veryfront.config.ts owns the
+  // projectSlug when both define one, but apiUrl/apiToken only live in
+  // veryfront.json and must not be dropped because a TS config exists.
   const configJsonPath = join(projectDir, "veryfront.json");
+  let jsonConfig: VeryfrontConfig | null = null;
 
   try {
-    if (!(await fs.exists(configJsonPath))) return null;
-    const content = await fs.readTextFile(configJsonPath);
-    const parsed = VeryfrontConfigSchema.safeParse(JSON.parse(content));
-    return parsed.success ? parsed.data : null;
+    if (await fs.exists(configJsonPath)) {
+      const content = await fs.readTextFile(configJsonPath);
+      const parsed = VeryfrontConfigSchema.safeParse(JSON.parse(content));
+      jsonConfig = parsed.success ? parsed.data : null;
+    }
   } catch (error) {
     cliLogger.debug(`Failed to read veryfront.json:`, error);
-    return null;
   }
+
+  if (!moduleProjectSlug && !jsonConfig) return null;
+  return {
+    ...jsonConfig,
+    ...(moduleProjectSlug ? { projectSlug: moduleProjectSlug } : {}),
+  };
 }
 
 export async function writeProjectSlug(projectDir: string, slug: string): Promise<void> {
@@ -145,7 +159,9 @@ async function resolveConfigBase(
   const dir = projectDir ?? cwd();
   const configFile = await readConfigFile(dir);
 
-  const apiUrl = env.apiUrl ?? configFile?.apiUrl ?? DEFAULT_API_URL;
+  // Explicit VERYFRONT_API_URL wins, then the project's veryfront.json,
+  // then apiBaseUrl (VERYFRONT_API_BASE_URL or the production default).
+  const apiUrl = env.apiUrl ?? configFile?.apiUrl ?? env.apiBaseUrl ?? DEFAULT_API_URL;
 
   let apiToken = env.apiToken ?? configFile?.apiToken ?? (await readToken(env));
 

--- a/cli/shared/constants.test.ts
+++ b/cli/shared/constants.test.ts
@@ -60,5 +60,18 @@ describe("cli/shared/constants", () => {
       const env = { apiUrl: "https://custom.api.com" } as EnvironmentConfig;
       assertEquals(getApiUrl(env), "https://custom.api.com");
     });
+
+    it("should fall back to env apiBaseUrl when apiUrl is unset", () => {
+      const env = { apiBaseUrl: "https://api.veryfront.org" } as EnvironmentConfig;
+      assertEquals(getApiUrl(env), "https://api.veryfront.org");
+    });
+
+    it("should prefer env apiUrl over apiBaseUrl", () => {
+      const env = {
+        apiUrl: "https://custom.api.com",
+        apiBaseUrl: "https://api.veryfront.org",
+      } as EnvironmentConfig;
+      assertEquals(getApiUrl(env), "https://custom.api.com");
+    });
   });
 });

--- a/cli/shared/constants.ts
+++ b/cli/shared/constants.ts
@@ -17,7 +17,10 @@ export const DEFAULT_API_URL = "https://api.veryfront.com";
 export const DEFAULT_LOCAL_API_URL = "https://api.veryfront.com";
 
 export function getApiUrl(env: EnvironmentConfig = getEnvironmentConfig()): string {
-  return env.apiUrl ?? DEFAULT_API_URL;
+  // VERYFRONT_API_URL wins, then VERYFRONT_API_BASE_URL (which itself
+  // defaults to the production URL), so both documented overrides retarget
+  // every CLI request — login, push, pull, slug reservation.
+  return env.apiUrl ?? env.apiBaseUrl ?? DEFAULT_API_URL;
 }
 
 export const DEFAULT_LOGIN_TIMEOUT_MS = 120_000;

--- a/cli/shared/constants.ts
+++ b/cli/shared/constants.ts
@@ -16,11 +16,27 @@ export const MAX_PORT_ATTEMPTS = 100;
 export const DEFAULT_API_URL = "https://api.veryfront.com";
 export const DEFAULT_LOCAL_API_URL = "https://api.veryfront.com";
 
+function getExplicitApiBaseUrl(env: EnvironmentConfig): string | undefined {
+  if (!env.apiBaseUrl || env.apiBaseUrl === DEFAULT_API_URL) return undefined;
+  return env.apiBaseUrl;
+}
+
+export function resolveCliApiUrl(
+  env: EnvironmentConfig = getEnvironmentConfig(),
+  configApiUrl?: string,
+): string {
+  // VERYFRONT_API_URL wins. A non-default VERYFRONT_API_BASE_URL is an
+  // operator override, so it wins over a checked-in veryfront.json apiUrl.
+  // The default production apiBaseUrl stays below project config.
+  return env.apiUrl ??
+    getExplicitApiBaseUrl(env) ??
+    configApiUrl ??
+    env.apiBaseUrl ??
+    DEFAULT_API_URL;
+}
+
 export function getApiUrl(env: EnvironmentConfig = getEnvironmentConfig()): string {
-  // VERYFRONT_API_URL wins, then VERYFRONT_API_BASE_URL (which itself
-  // defaults to the production URL), so both documented overrides retarget
-  // every CLI request — login, push, pull, slug reservation.
-  return env.apiUrl ?? env.apiBaseUrl ?? DEFAULT_API_URL;
+  return resolveCliApiUrl(env);
 }
 
 export const DEFAULT_LOGIN_TIMEOUT_MS = 120_000;


### PR DESCRIPTION
Fixes #2755.

## Summary
- `getApiUrl()` (cli/shared/constants.ts) now falls back to `env.apiBaseUrl` (`VERYFRONT_API_BASE_URL`) before the production default — previously only the undocumented `VERYFRONT_API_URL` worked, so login/token-validation/slug-reservation silently hit `api.veryfront.com` while the user believed they were targeting another host.
- `readConfigFile()` (cli/shared/config.ts) merges `veryfront.json` instead of discarding it when `veryfront.config.ts` defines a `projectSlug`. The module config still owns the slug; `veryfront.json` contributes `apiUrl`/`apiToken`. Previously any project with both files (the normal case) could not pin an API host via `veryfront.json`.
- `resolveConfigBase()` applies the same precedence (`VERYFRONT_API_URL` → `veryfront.json` → `apiBaseUrl`/default), and the `pull --projects` error path uses `getApiUrl()` instead of a hardcoded production URL.

## Real-world failure this fixes
Deploying `veryfront-ops-agent` to Veryfront Cloud staging with `VERYFRONT_API_BASE_URL=https://api.veryfront.org`: `veryfront login` minted a token against production, then `veryfront push` failed `403 Forbidden` because the production project with that slug belongs to a different account. Full trail in #2755.

## Verification
- `deno test cli/shared/constants.test.ts cli/shared/config.test.ts` — 5 groups / 38 steps, includes 4 new cases (apiBaseUrl fallback, apiUrl precedence, veryfront.json merge with and without module config)
- `deno test cli/commands/pull/command.test.ts` — 5 groups / 32 steps
- `deno fmt` clean on all touched files; pre-push hook (format, lint, typecheck, unit tests) passed