### PR TITLE
Fix veryfront-code issue regressions

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1001",
+  "version": "0.1.1002",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/scripts/build/npm-react-shims.test.ts
+++ b/scripts/build/npm-react-shims.test.ts
@@ -61,6 +61,39 @@ Deno.test("normalizeEsmShReactNpmShims rewrites React ecosystem esm.sh shims to 
   }
 });
 
+Deno.test("normalizeEsmShReactNpmShims rewrites React ecosystem esm.sh declaration shims to npm package exports", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await Deno.mkdir(`${root}/react@19.2.4`);
+    await Deno.mkdir(`${root}/react-dom@19.2.4`);
+    await Deno.writeTextFile(`${root}/react@19.2.4.d.ts`, "export {};\n");
+    await Deno.writeTextFile(
+      `${root}/react@19.2.4/jsx-runtime.d.ts`,
+      "export {};\n",
+    );
+    await Deno.writeTextFile(
+      `${root}/react-dom@19.2.4/client.d.ts`,
+      "export {};\n",
+    );
+
+    assertEquals(normalizeEsmShReactNpmShims(root), 3);
+    assertEquals(
+      await Deno.readTextFile(`${root}/react@19.2.4.d.ts`),
+      '/* npm package shim for esm.sh react@19.2.4.d.ts */\nexport * from "react";\nexport { default } from "react";\n',
+    );
+    assertEquals(
+      await Deno.readTextFile(`${root}/react@19.2.4/jsx-runtime.d.ts`),
+      '/* npm package shim for esm.sh react@19.2.4/jsx-runtime.d.ts */\nexport * from "react/jsx-runtime";\nexport { default } from "react/jsx-runtime";\n',
+    );
+    assertEquals(
+      await Deno.readTextFile(`${root}/react-dom@19.2.4/client.d.ts`),
+      '/* npm package shim for esm.sh react-dom@19.2.4/client.d.ts */\nexport * from "react-dom/client";\nexport { default } from "react-dom/client";\n',
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
 Deno.test("normalizeEsmShReactNpmShims rejects unhandled React internal imports", async () => {
   const root = await Deno.makeTempDir();
   try {

--- a/scripts/build/npm-react-shims.test.ts
+++ b/scripts/build/npm-react-shims.test.ts
@@ -112,3 +112,22 @@ Deno.test("normalizeEsmShReactNpmShims rejects unhandled React internal imports"
     await Deno.remove(root, { recursive: true });
   }
 });
+
+Deno.test("normalizeEsmShReactNpmShims rejects unhandled React internal declaration imports", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await Deno.mkdir(`${root}/unhandled`);
+    await Deno.writeTextFile(
+      `${root}/unhandled/entry.d.ts`,
+      'export * from "react-dom/X-ZGNzc3R5cGVAMy4yLjMKZXJlYWN0/es2022/unknown.d.ts";\n',
+    );
+
+    assertThrows(
+      () => normalizeEsmShReactNpmShims(root),
+      Error,
+      "esm.sh React internals",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});

--- a/scripts/build/npm-react-shims.ts
+++ b/scripts/build/npm-react-shims.ts
@@ -8,7 +8,7 @@ export function normalizeEsmShReactNpmShims(root: string): number {
   for (const entry of Deno.readDirSync(root)) {
     if (
       entry.isFile && entry.name.startsWith(REACT_ROOT_PREFIX) &&
-      entry.name.endsWith(".js")
+      isShimFile(entry.name)
     ) {
       patchedCount += writeNpmShim(
         `${root}/${entry.name}`,
@@ -20,7 +20,7 @@ export function normalizeEsmShReactNpmShims(root: string): number {
 
     if (
       entry.isFile && entry.name.startsWith(REACT_DOM_ROOT_PREFIX) &&
-      entry.name.endsWith(".js")
+      isShimFile(entry.name)
     ) {
       // The chat UI portals import `react-dom` (createPortal), so dnt now
       // emits a top-level react-dom root file too — shim it like react's.
@@ -34,7 +34,7 @@ export function normalizeEsmShReactNpmShims(root: string): number {
 
     if (
       entry.isFile && entry.name.startsWith(SCHEDULER_ROOT_PREFIX) &&
-      entry.name.endsWith(".js")
+      isShimFile(entry.name)
     ) {
       patchedCount += writeNpmShim(
         `${root}/${entry.name}`,
@@ -54,9 +54,19 @@ export function normalizeEsmShReactNpmShims(root: string): number {
         `${entry.name}/jsx-runtime.js`,
       );
       patchedCount += writeNpmShimIfExists(
+        `${packageRoot}/jsx-runtime.d.ts`,
+        "react/jsx-runtime",
+        `${entry.name}/jsx-runtime.d.ts`,
+      );
+      patchedCount += writeNpmShimIfExists(
         `${packageRoot}/jsx-dev-runtime.js`,
         "react/jsx-dev-runtime",
         `${entry.name}/jsx-dev-runtime.js`,
+      );
+      patchedCount += writeNpmShimIfExists(
+        `${packageRoot}/jsx-dev-runtime.d.ts`,
+        "react/jsx-dev-runtime",
+        `${entry.name}/jsx-dev-runtime.d.ts`,
       );
       continue;
     }
@@ -69,15 +79,29 @@ export function normalizeEsmShReactNpmShims(root: string): number {
         `${entry.name}/client.js`,
       );
       patchedCount += writeNpmShimIfExists(
+        `${packageRoot}/client.d.ts`,
+        "react-dom/client",
+        `${entry.name}/client.d.ts`,
+      );
+      patchedCount += writeNpmShimIfExists(
         `${packageRoot}/server.js`,
         "react-dom/server",
         `${entry.name}/server.js`,
+      );
+      patchedCount += writeNpmShimIfExists(
+        `${packageRoot}/server.d.ts`,
+        "react-dom/server",
+        `${entry.name}/server.d.ts`,
       );
     }
   }
 
   assertNoReactInternalPackageImports(root);
   return patchedCount;
+}
+
+function isShimFile(name: string): boolean {
+  return name.endsWith(".js") || name.endsWith(".d.ts");
 }
 
 function writeNpmShimIfExists(

--- a/scripts/build/npm-react-shims.ts
+++ b/scripts/build/npm-react-shims.ts
@@ -143,7 +143,7 @@ function assertNoReactInternalPackageImports(root: string): void {
 function findReactInternalPackageImports(root: string): string[] {
   const matches: string[] = [];
   for (const path of walkFiles(root)) {
-    if (!path.endsWith(".js")) continue;
+    if (!isShimFile(path)) continue;
 
     const content = Deno.readTextFileSync(path);
     if (content.includes('from "react/') && content.includes("/es2022/")) {

--- a/src/agent/hosted/chat-preparation.test.ts
+++ b/src/agent/hosted/chat-preparation.test.ts
@@ -37,6 +37,41 @@ function isRuntimeTextPart(part: unknown): part is { type: "text"; text: string 
     "text" in part && typeof part.text === "string";
 }
 
+function rejectIfStillPending<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): { promise: Promise<T>; cancel: () => void } {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+
+  return {
+    promise: Promise.race([promise, timeout]),
+    cancel: () => {
+      if (timeoutId) clearTimeout(timeoutId);
+    },
+  };
+}
+
+function pendingResponseUntilAbort(signal: AbortSignal | null | undefined): Promise<Response> {
+  if (!(signal instanceof AbortSignal)) {
+    return new Promise(() => {});
+  }
+
+  return new Promise((_resolve, reject) => {
+    const rejectAbort = () => {
+      reject(signal.reason instanceof Error ? signal.reason : new Error("fetch aborted"));
+    };
+    if (signal.aborted) {
+      rejectAbort();
+      return;
+    }
+    signal.addEventListener("abort", rejectAbort, { once: true });
+  });
+}
+
 function createParsedHostedChatRequest(
   overrides: Partial<ParsedHostedChatRequest> = {},
 ): ParsedHostedChatRequest {
@@ -786,6 +821,124 @@ Deno.test("prepareHostedChatRuntimeMessages refreshes uploaded file URLs through
       true,
     );
   } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("prepareHostedChatExecution aborts stalled signed attachment fetch before runtime creation", async () => {
+  const originalFetch = globalThis.fetch;
+  const abortController = new AbortController();
+  let resolveSignedFetchStarted: (() => void) | undefined;
+  const signedFetchStarted = new Promise<void>((resolve) => {
+    resolveSignedFetchStarted = resolve;
+  });
+  let createRuntimeCalls = 0;
+  let cancelStartGuard = () => {};
+  let cancelPreparationGuard = () => {};
+
+  globalThis.fetch = (input, init): Promise<Response> => {
+    const url = input.toString();
+    if (url === "https://api.example.com/projects/project-1/uploads/upload-1/url") {
+      return Promise.resolve(
+        new Response(JSON.stringify({ signed_url: "https://signed.example.com/notes.txt" }), {
+          status: 200,
+        }),
+      );
+    }
+    if (url === "https://signed.example.com/notes.txt") {
+      resolveSignedFetchStarted?.();
+      return pendingResponseUntilAbort(init?.signal);
+    }
+
+    return Promise.reject(new Error(`unexpected fetch ${url}`));
+  };
+
+  try {
+    const preparation = prepareHostedChatExecution({
+      request: createParsedHostedChatRequest({
+        conversationId: "conversation-1",
+        projectId: "project-1",
+        durableRootRun: {
+          runId: "run-1",
+          messageId: "message-1",
+          latestEventId: 3,
+          latestExternalEventSequence: 2,
+        },
+        messages: [{
+          id: "message-1",
+          role: "user",
+          parts: [
+            { type: "text", text: "Use this file." },
+            {
+              type: "file",
+              mediaType: "text/plain",
+              filename: "notes.txt",
+              uploadId: "upload-1",
+              url: "https://files.example.com/original.txt",
+            },
+          ],
+        }],
+      }),
+      agentConfig: {
+        id: "agent-1",
+        model: "configured-model",
+      },
+      apiUrl: "https://api.example.com",
+      abortSignal: abortController.signal,
+      resolveModelId: (modelId) => modelId ? `resolved:${modelId}` : undefined,
+      fetchSteering: () =>
+        Promise.resolve({
+          instructions: "Project instructions",
+          skills: [],
+        }),
+      buildInstructions: (input) => [
+        {
+          role: "system",
+          content: `${input.agentConfig.id}:${input.instructions}`,
+        },
+      ],
+      createRuntime: (options) => {
+        createRuntimeCalls++;
+        return Promise.resolve({
+          runtimeKind: "framework",
+          modelId: options.model ?? "resolved:configured-model",
+          cleanup: () => Promise.resolve(),
+          agent: {
+            stream: () =>
+              Promise.resolve({
+                steps: Promise.resolve([]),
+                toUIMessageStream: async function* () {},
+              }),
+          },
+        });
+      },
+    });
+
+    const startGuard = rejectIfStillPending(
+      signedFetchStarted,
+      50,
+      "signed content fetch was not started",
+    );
+    cancelStartGuard = startGuard.cancel;
+    await startGuard.promise;
+
+    const preparationGuard = rejectIfStillPending(
+      preparation,
+      50,
+      "hosted execution still pending after abort",
+    );
+    cancelPreparationGuard = preparationGuard.cancel;
+    abortController.abort(new Error("caller aborted"));
+
+    await assertRejects(
+      () => preparationGuard.promise,
+      Error,
+      "Failed to fetch text attachment content for notes.txt: request aborted",
+    );
+    assertEquals(createRuntimeCalls, 0);
+  } finally {
+    cancelStartGuard();
+    cancelPreparationGuard();
     globalThis.fetch = originalFetch;
   }
 });

--- a/src/agent/hosted/chat-preparation.test.ts
+++ b/src/agent/hosted/chat-preparation.test.ts
@@ -31,6 +31,12 @@ function isRuntimeFilePart(
     "mediaType" in part && typeof part.mediaType === "string";
 }
 
+function isRuntimeTextPart(part: unknown): part is { type: "text"; text: string } {
+  return typeof part === "object" && part !== null &&
+    "type" in part && part.type === "text" &&
+    "text" in part && typeof part.text === "string";
+}
+
 function createParsedHostedChatRequest(
   overrides: Partial<ParsedHostedChatRequest> = {},
 ): ParsedHostedChatRequest {
@@ -773,11 +779,52 @@ Deno.test("prepareHostedChatRuntimeMessages refreshes uploaded file URLs through
     );
     assertEquals(
       messages[0]?.parts.some((part) =>
-        part.type === "text" &&
+        isRuntimeTextPart(part) &&
         part.text.includes('<file_content name="notes.txt" type="text/plain">') &&
         part.text.includes("Remember Order #4587.")
       ),
       true,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("prepareHostedChatRuntimeMessages does not fetch caller-controlled file URLs", async () => {
+  const requestedUrls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input, _init): Promise<Response> => {
+    requestedUrls.push(input.toString());
+    return Promise.reject(new Error("unexpected hosted attachment fetch"));
+  };
+
+  try {
+    const messages = await prepareHostedChatRuntimeMessages([
+      {
+        id: "message-1",
+        role: "user",
+        parts: [
+          { type: "text", text: "Use this file." },
+          {
+            type: "file",
+            mediaType: "text/plain",
+            filename: "notes.txt",
+            url: "http://127.0.0.1:9876/internal-notes.txt",
+          },
+        ],
+      },
+    ], {
+      apiUrl: "https://api.example.com",
+      authToken: "token-1",
+      projectId: "project-1",
+    });
+
+    assertEquals(requestedUrls, []);
+    assertEquals(
+      messages[0]?.parts.some((part) =>
+        isRuntimeTextPart(part) && part.text.includes("<file_content")
+      ),
+      false,
     );
   } finally {
     globalThis.fetch = originalFetch;

--- a/src/agent/hosted/chat-preparation.test.ts
+++ b/src/agent/hosted/chat-preparation.test.ts
@@ -724,7 +724,12 @@ Deno.test("prepareHostedChatRuntimeMessages refreshes uploaded file URLs through
   const requestedUrls: string[] = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (input, _init): Promise<Response> => {
-    requestedUrls.push(input.toString());
+    const url = input.toString();
+    requestedUrls.push(url);
+    if (url === "https://signed.example.com/notes.txt") {
+      return Promise.resolve(new Response("Remember Order #4587.", { status: 200 }));
+    }
+
     return Promise.resolve(
       new Response(JSON.stringify({ signed_url: "https://signed.example.com/notes.txt" }), {
         status: 200,
@@ -756,12 +761,21 @@ Deno.test("prepareHostedChatRuntimeMessages refreshes uploaded file URLs through
 
     assertEquals(requestedUrls, [
       "https://api.example.com/projects/project-1/uploads/upload-1/url",
+      "https://signed.example.com/notes.txt",
     ]);
     assertEquals(
       messages[0]?.parts.some((part) =>
         isRuntimeFilePart(part) &&
         part.url === "https://signed.example.com/notes.txt" &&
         part.mediaType === "text/plain"
+      ),
+      true,
+    );
+    assertEquals(
+      messages[0]?.parts.some((part) =>
+        part.type === "text" &&
+        part.text.includes('<file_content name="notes.txt" type="text/plain">') &&
+        part.text.includes("Remember Order #4587.")
       ),
       true,
     );

--- a/src/agent/hosted/chat-preparation.ts
+++ b/src/agent/hosted/chat-preparation.ts
@@ -46,7 +46,10 @@ export type NormalizedHostedChatRequest = {
 export type PrepareHostedChatRuntimeMessagesOptions =
   & Pick<
     PrepareAgentRuntimeMessagesFromUiMessagesOptions,
-    "emptyConversationPrompt" | "providerOwnedToolNames"
+    | "emptyConversationPrompt"
+    | "providerOwnedToolNames"
+    | "abortSignal"
+    | "fileContentFetchTimeoutMs"
   >
   & {
     authToken?: string;
@@ -411,6 +414,7 @@ export async function prepareHostedChatExecution<
       apiUrl: input.apiUrl,
       projectId: input.request.projectId,
       providerOwnedToolNames: getProviderToolNames(input.agentConfig),
+      abortSignal: input.abortSignal,
     },
   );
   let budgetedContext: Awaited<ReturnType<typeof applyContextBudget>> | undefined;
@@ -462,6 +466,8 @@ export async function prepareHostedChatRuntimeMessages(
       messages,
       emptyConversationPrompt: options.emptyConversationPrompt,
       providerOwnedToolNames: options.providerOwnedToolNames,
+      abortSignal: options.abortSignal,
+      fileContentFetchTimeoutMs: options.fileContentFetchTimeoutMs,
     });
   }
   const authToken = options.authToken;
@@ -471,6 +477,8 @@ export async function prepareHostedChatRuntimeMessages(
     messages,
     emptyConversationPrompt: options.emptyConversationPrompt,
     providerOwnedToolNames: options.providerOwnedToolNames,
+    abortSignal: options.abortSignal,
+    fileContentFetchTimeoutMs: options.fileContentFetchTimeoutMs,
     resolveFileUrl: ({ uploadId }) =>
       getRuntimeUploadUrl({
         apiUrl,

--- a/src/agent/runtime/message-file-url-refresh.ts
+++ b/src/agent/runtime/message-file-url-refresh.ts
@@ -254,12 +254,74 @@ async function fetchRuntimeTextFileContent(
       }: HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ""}`,
     );
   }
-  return await waitForRuntimeFileContentFetchOperation(
-    response.text(),
-    input,
-    fetchSignal,
-    timeoutMs,
-  );
+  return await readRuntimeTextFileContent(response, input, fetchSignal, timeoutMs);
+}
+
+async function readRuntimeTextFileContent(
+  response: Response,
+  input: RuntimeFileContentFetcherInput,
+  fetchSignal: ReturnType<typeof createRuntimeFileContentFetchSignal>,
+  timeoutMs: number,
+): Promise<string | undefined> {
+  if (!response.body) {
+    return "";
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let content = "";
+  let shouldCancelReader = false;
+
+  try {
+    while (content.length <= MAX_INLINE_FILE_CONTENT_CHARS) {
+      const result = await waitForRuntimeFileContentFetchOperation(
+        reader.read(),
+        input,
+        fetchSignal,
+        timeoutMs,
+      );
+      if (result.done) {
+        return appendRuntimeTextContentUntilInlineLimit(content, decoder.decode()).content;
+      }
+
+      const nextContent = appendRuntimeTextContentUntilInlineLimit(
+        content,
+        decoder.decode(result.value, { stream: true }),
+      );
+      content = nextContent.content;
+      if (nextContent.reachedLimit) {
+        shouldCancelReader = true;
+        return content;
+      }
+    }
+
+    return content;
+  } finally {
+    if (shouldCancelReader || fetchSignal.signal.aborted) {
+      void reader.cancel().catch(() => {});
+    }
+    try {
+      reader.releaseLock();
+    } catch {
+      // Ignore release failures after cancellation has already been requested.
+    }
+  }
+}
+
+function appendRuntimeTextContentUntilInlineLimit(
+  content: string,
+  decoded: string,
+): { content: string; reachedLimit: boolean } {
+  const readLimit = MAX_INLINE_FILE_CONTENT_CHARS + 1;
+  const remainingChars = readLimit - content.length;
+  if (decoded.length >= remainingChars) {
+    return {
+      content: `${content}${decoded.slice(0, Math.max(0, remainingChars))}`,
+      reachedLimit: true,
+    };
+  }
+
+  return { content: `${content}${decoded}`, reachedLimit: false };
 }
 
 function createRuntimeFileContentFetchSignal(

--- a/src/agent/runtime/message-file-url-refresh.ts
+++ b/src/agent/runtime/message-file-url-refresh.ts
@@ -1,4 +1,10 @@
-import type { ChatUiMessage, FileUIPartWithUpload } from "../../chat/types.ts";
+import {
+  type ChatUiMessage,
+  type FileUIPartWithUpload,
+  isTextPreviewFile,
+} from "../../chat/types.ts";
+
+const MAX_INLINE_FILE_CONTENT_CHARS = 200_000;
 
 /** Input payload for runtime file URL resolver. */
 export type RuntimeFileUrlResolverInput = {
@@ -10,6 +16,22 @@ export type RuntimeFileUrlResolverInput = {
 /** Public API contract for runtime file URL resolver. */
 export type RuntimeFileUrlResolver = (
   input: RuntimeFileUrlResolverInput,
+) => Promise<string | undefined>;
+
+/** Input payload for runtime file content fetcher. */
+export type RuntimeFileContentFetcherInput = {
+  url: string;
+  mediaType: string;
+  filename?: string;
+  uploadId?: string;
+  uploadPath?: string;
+  part: FileUIPartWithUpload;
+  message: ChatUiMessage;
+};
+
+/** Public API contract for runtime file content fetcher. */
+export type RuntimeFileContentFetcher = (
+  input: RuntimeFileContentFetcherInput,
 ) => Promise<string | undefined>;
 
 /** Resolves runtime message file urls. */
@@ -55,6 +77,54 @@ export async function resolveRuntimeMessageFileUrls(
   );
 }
 
+/** Fetches text attachment bodies and adds them as adjacent text parts. */
+export async function inlineRuntimeMessageFileContents(
+  messages: readonly ChatUiMessage[],
+  fetchFileContent: RuntimeFileContentFetcher = fetchRuntimeTextFileContent,
+): Promise<ChatUiMessage[]> {
+  const contentByUrl = new Map<string, Promise<string | undefined>>();
+
+  return Promise.all(
+    messages.map(async (message) => {
+      if (!message.parts.some((part) => shouldInlineFileContent(part))) {
+        return message;
+      }
+
+      const parts: ChatUiMessage["parts"] = [];
+      for (const part of message.parts) {
+        parts.push(part);
+
+        const file = getInlineableFilePart(part);
+        if (!file) continue;
+
+        let contentPromise = contentByUrl.get(file.url);
+        if (!contentPromise) {
+          contentPromise = fetchFileContent({
+            url: file.url,
+            mediaType: file.mediaType,
+            ...(file.filename ? { filename: file.filename } : {}),
+            ...(file.uploadId ? { uploadId: file.uploadId } : {}),
+            ...(file.uploadPath ? { uploadPath: file.uploadPath } : {}),
+            part: file,
+            message,
+          }).then(normalizeInlineFileContent).catch(() => undefined);
+          contentByUrl.set(file.url, contentPromise);
+        }
+
+        const content = await contentPromise;
+        if (!content) continue;
+
+        parts.push({
+          type: "text",
+          text: buildInlineFileContentText(file, content),
+        });
+      }
+
+      return { ...message, parts };
+    }),
+  );
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -72,6 +142,10 @@ function getUploadId(part: unknown): string | undefined {
   }
 
   return getStringField(part, "uploadId") ?? getStringField(part, "upload_id");
+}
+
+function getUploadPath(part: unknown): string | undefined {
+  return getStringField(part, "uploadPath") ?? getStringField(part, "upload_path");
 }
 
 function getMediaType(part: unknown): string | undefined {
@@ -103,6 +177,65 @@ function normalizeUploadedFilePart(
     uploadId,
     ...(uploadPath ? { uploadPath } : {}),
   } as ChatUiMessage["parts"][number];
+}
+
+function shouldInlineFileContent(part: unknown): boolean {
+  return getInlineableFilePart(part) !== null;
+}
+
+function getInlineableFilePart(part: unknown): FileUIPartWithUpload | null {
+  if (!isRecord(part) || part.type !== "file") return null;
+
+  const mediaType = getMediaType(part);
+  const url = getStringField(part, "url");
+  if (!mediaType || !url) return null;
+
+  const filename = getStringField(part, "filename");
+  if (!isTextPreviewFile(filename, mediaType)) return null;
+
+  return {
+    type: "file",
+    mediaType,
+    url,
+    ...(filename ? { filename } : {}),
+    ...(getUploadId(part) ? { uploadId: getUploadId(part) } : {}),
+    ...(getUploadPath(part) ? { uploadPath: getUploadPath(part) } : {}),
+  };
+}
+
+async function fetchRuntimeTextFileContent(
+  input: RuntimeFileContentFetcherInput,
+): Promise<string | undefined> {
+  const response = await fetch(input.url);
+  if (!response.ok) return undefined;
+  return await response.text();
+}
+
+function normalizeInlineFileContent(content: string | undefined): string | undefined {
+  if (!content || content.trim().length === 0) return undefined;
+
+  if (content.length <= MAX_INLINE_FILE_CONTENT_CHARS) {
+    return content;
+  }
+
+  return `${content.slice(0, MAX_INLINE_FILE_CONTENT_CHARS)}\n\n[Attachment content truncated]`;
+}
+
+function escapeXmlAttr(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(
+    />/g,
+    "&gt;",
+  );
+}
+
+function buildInlineFileContentText(
+  part: FileUIPartWithUpload,
+  content: string,
+): string {
+  const name = part.filename ?? part.uploadId ?? "file";
+  return `Attached file content:\n\n<file_content name="${escapeXmlAttr(name)}" type="${
+    escapeXmlAttr(part.mediaType)
+  }">\n${content}\n</file_content>`;
 }
 
 function toResolverPart(

--- a/src/agent/runtime/message-file-url-refresh.ts
+++ b/src/agent/runtime/message-file-url-refresh.ts
@@ -221,8 +221,19 @@ async function fetchRuntimeTextFileContent(
   input: RuntimeFileContentFetcherInput,
 ): Promise<string | undefined> {
   const response = await fetch(input.url);
-  if (!response.ok) return undefined;
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch text attachment content${
+        formatFileContentFetchLabel(input)
+      }: HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ""}`,
+    );
+  }
   return await response.text();
+}
+
+function formatFileContentFetchLabel(input: RuntimeFileContentFetcherInput): string {
+  const label = input.filename ?? input.uploadId ?? input.uploadPath;
+  return label ? ` for ${label}` : "";
 }
 
 function isFetchableRuntimeFileContentUrl(

--- a/src/agent/runtime/message-file-url-refresh.ts
+++ b/src/agent/runtime/message-file-url-refresh.ts
@@ -5,6 +5,7 @@ import {
 } from "../../chat/types.ts";
 
 const MAX_INLINE_FILE_CONTENT_CHARS = 200_000;
+const DEFAULT_RUNTIME_FILE_CONTENT_FETCH_TIMEOUT_MS = 15_000;
 
 /** Input payload for runtime file URL resolver. */
 export type RuntimeFileUrlResolverInput = {
@@ -25,6 +26,8 @@ export type RuntimeFileContentFetcherInput = {
   filename?: string;
   uploadId?: string;
   uploadPath?: string;
+  abortSignal?: AbortSignal;
+  timeoutMs?: number;
   part: FileUIPartWithUpload;
   message: ChatUiMessage;
 };
@@ -36,7 +39,11 @@ export type RuntimeFileContentFetcher = (
 
 /** Creates a safe runtime file content fetcher. */
 export function createRuntimeFileContentFetcher(
-  options: { trustedUrls?: ReadonlySet<string> } = {},
+  options: {
+    trustedUrls?: ReadonlySet<string>;
+    abortSignal?: AbortSignal;
+    timeoutMs?: number;
+  } = {},
 ): RuntimeFileContentFetcher {
   const trustedUrls = options.trustedUrls;
   return async (input) => {
@@ -44,7 +51,13 @@ export function createRuntimeFileContentFetcher(
       return undefined;
     }
 
-    return await fetchRuntimeTextFileContent(input);
+    const abortSignal = input.abortSignal ?? options.abortSignal;
+    const timeoutMs = input.timeoutMs ?? options.timeoutMs;
+    return await fetchRuntimeTextFileContent({
+      ...input,
+      ...(abortSignal ? { abortSignal } : {}),
+      ...(timeoutMs != null ? { timeoutMs } : {}),
+    });
   };
 }
 
@@ -95,6 +108,10 @@ export async function resolveRuntimeMessageFileUrls(
 export async function inlineRuntimeMessageFileContents(
   messages: readonly ChatUiMessage[],
   fetchFileContent: RuntimeFileContentFetcher = createRuntimeFileContentFetcher(),
+  options: {
+    abortSignal?: AbortSignal;
+    fetchTimeoutMs?: number;
+  } = {},
 ): Promise<ChatUiMessage[]> {
   const contentByUrl = new Map<string, Promise<string | undefined>>();
 
@@ -119,6 +136,8 @@ export async function inlineRuntimeMessageFileContents(
             ...(file.filename ? { filename: file.filename } : {}),
             ...(file.uploadId ? { uploadId: file.uploadId } : {}),
             ...(file.uploadPath ? { uploadPath: file.uploadPath } : {}),
+            ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
+            ...(options.fetchTimeoutMs != null ? { timeoutMs: options.fetchTimeoutMs } : {}),
             part: file,
             message,
           }).then(normalizeInlineFileContent);
@@ -220,7 +239,14 @@ function getInlineableFilePart(part: unknown): FileUIPartWithUpload | null {
 async function fetchRuntimeTextFileContent(
   input: RuntimeFileContentFetcherInput,
 ): Promise<string | undefined> {
-  const response = await fetch(input.url);
+  const timeoutMs = input.timeoutMs ?? DEFAULT_RUNTIME_FILE_CONTENT_FETCH_TIMEOUT_MS;
+  const fetchSignal = createRuntimeFileContentFetchSignal(input.abortSignal, timeoutMs);
+  const response = await waitForRuntimeFileContentFetchOperation(
+    fetch(input.url, { signal: fetchSignal.signal }),
+    input,
+    fetchSignal,
+    timeoutMs,
+  );
   if (!response.ok) {
     throw new Error(
       `Failed to fetch text attachment content${
@@ -228,7 +254,108 @@ async function fetchRuntimeTextFileContent(
       }: HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ""}`,
     );
   }
-  return await response.text();
+  return await waitForRuntimeFileContentFetchOperation(
+    response.text(),
+    input,
+    fetchSignal,
+    timeoutMs,
+  );
+}
+
+function createRuntimeFileContentFetchSignal(
+  abortSignal: AbortSignal | undefined,
+  timeoutMs: number,
+): {
+  signal: AbortSignal;
+  wasAbortedByCaller: () => boolean;
+  didTimeout: () => boolean;
+} {
+  const timeoutSignal = AbortSignal.timeout(Math.max(0, timeoutMs));
+  if (!abortSignal) {
+    return {
+      signal: timeoutSignal,
+      wasAbortedByCaller: () => false,
+      didTimeout: () => timeoutSignal.aborted,
+    };
+  }
+
+  return {
+    signal: AbortSignal.any([abortSignal, timeoutSignal]),
+    wasAbortedByCaller: () => abortSignal.aborted,
+    didTimeout: () => timeoutSignal.aborted,
+  };
+}
+
+async function waitForRuntimeFileContentFetchOperation<T>(
+  operation: Promise<T>,
+  input: RuntimeFileContentFetcherInput,
+  fetchSignal: ReturnType<typeof createRuntimeFileContentFetchSignal>,
+  timeoutMs: number,
+): Promise<T> {
+  let abortError: Error | undefined;
+  let removeAbortListener = () => {};
+  const abortPromise = new Promise<never>((_, reject) => {
+    const rejectAbort = () => {
+      abortError = createRuntimeFileContentAbortError(
+        input,
+        fetchSignal,
+        timeoutMs,
+      );
+      reject(abortError);
+    };
+    if (fetchSignal.signal.aborted) {
+      rejectAbort();
+      return;
+    }
+
+    fetchSignal.signal.addEventListener("abort", rejectAbort, { once: true });
+    removeAbortListener = () => fetchSignal.signal.removeEventListener("abort", rejectAbort);
+  });
+
+  try {
+    return await Promise.race([operation, abortPromise]);
+  } catch (error) {
+    if (error === abortError) {
+      throw error;
+    }
+    const abortFailure = createRuntimeFileContentAbortError(
+      input,
+      fetchSignal,
+      timeoutMs,
+      error,
+    );
+    if (abortFailure) {
+      throw abortFailure;
+    }
+    throw error;
+  } finally {
+    removeAbortListener();
+  }
+}
+
+function createRuntimeFileContentAbortError(
+  input: RuntimeFileContentFetcherInput,
+  fetchSignal: ReturnType<typeof createRuntimeFileContentFetchSignal>,
+  timeoutMs: number,
+  cause?: unknown,
+): Error | undefined {
+  if (fetchSignal.wasAbortedByCaller()) {
+    return new Error(
+      `Failed to fetch text attachment content${
+        formatFileContentFetchLabel(input)
+      }: request aborted`,
+      { cause },
+    );
+  }
+  if (fetchSignal.didTimeout()) {
+    return new Error(
+      `Failed to fetch text attachment content${
+        formatFileContentFetchLabel(input)
+      }: request timed out after ${timeoutMs}ms`,
+      { cause },
+    );
+  }
+  return undefined;
 }
 
 function formatFileContentFetchLabel(input: RuntimeFileContentFetcherInput): string {

--- a/src/agent/runtime/message-file-url-refresh.ts
+++ b/src/agent/runtime/message-file-url-refresh.ts
@@ -34,6 +34,20 @@ export type RuntimeFileContentFetcher = (
   input: RuntimeFileContentFetcherInput,
 ) => Promise<string | undefined>;
 
+/** Creates a safe runtime file content fetcher. */
+export function createRuntimeFileContentFetcher(
+  options: { trustedUrls?: ReadonlySet<string> } = {},
+): RuntimeFileContentFetcher {
+  const trustedUrls = options.trustedUrls;
+  return async (input) => {
+    if (!isFetchableRuntimeFileContentUrl(input.url, trustedUrls)) {
+      return undefined;
+    }
+
+    return await fetchRuntimeTextFileContent(input);
+  };
+}
+
 /** Resolves runtime message file urls. */
 export async function resolveRuntimeMessageFileUrls(
   messages: readonly ChatUiMessage[],
@@ -80,7 +94,7 @@ export async function resolveRuntimeMessageFileUrls(
 /** Fetches text attachment bodies and adds them as adjacent text parts. */
 export async function inlineRuntimeMessageFileContents(
   messages: readonly ChatUiMessage[],
-  fetchFileContent: RuntimeFileContentFetcher = fetchRuntimeTextFileContent,
+  fetchFileContent: RuntimeFileContentFetcher = createRuntimeFileContentFetcher(),
 ): Promise<ChatUiMessage[]> {
   const contentByUrl = new Map<string, Promise<string | undefined>>();
 
@@ -107,7 +121,7 @@ export async function inlineRuntimeMessageFileContents(
             ...(file.uploadPath ? { uploadPath: file.uploadPath } : {}),
             part: file,
             message,
-          }).then(normalizeInlineFileContent).catch(() => undefined);
+          }).then(normalizeInlineFileContent);
           contentByUrl.set(file.url, contentPromise);
         }
 
@@ -209,6 +223,17 @@ async function fetchRuntimeTextFileContent(
   const response = await fetch(input.url);
   if (!response.ok) return undefined;
   return await response.text();
+}
+
+function isFetchableRuntimeFileContentUrl(
+  url: string,
+  trustedUrls: ReadonlySet<string> | undefined,
+): boolean {
+  if (url.startsWith("data:")) {
+    return true;
+  }
+
+  return trustedUrls?.has(url) ?? false;
 }
 
 function normalizeInlineFileContent(content: string | undefined): string | undefined {

--- a/src/agent/runtime/message-preparation.test.ts
+++ b/src/agent/runtime/message-preparation.test.ts
@@ -424,6 +424,62 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages times out stalled trusted t
   }
 });
 
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages stops reading oversized trusted text attachment bodies at the inline cap", async () => {
+  const originalFetch = globalThis.fetch;
+  const encoder = new TextEncoder();
+  const chunk = encoder.encode("x".repeat(50_000));
+  const totalChunks = 6;
+  let pulledChunks = 0;
+  let cancelCalled = false;
+  globalThis.fetch = (): Promise<Response> =>
+    Promise.resolve(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (pulledChunks >= totalChunks) {
+              controller.close();
+              return;
+            }
+
+            pulledChunks++;
+            controller.enqueue(chunk);
+          },
+          cancel() {
+            cancelCalled = true;
+          },
+        }, { highWaterMark: 0 }),
+        { status: 200 },
+      ),
+    );
+
+  try {
+    const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+      messages: [
+        userMessage([
+          { type: "text", text: "Use this upload." },
+          {
+            type: "file",
+            mediaType: "text/plain",
+            filename: "notes.txt",
+            uploadId: "upload-1",
+            url: "https://files.example.com/original.txt",
+          },
+        ]),
+      ],
+      resolveFileUrl: async () => "https://signed.example.com/notes.txt",
+    });
+
+    assertEquals(cancelCalled, true);
+    assertEquals(pulledChunks < totalChunks, true);
+    const text = (messages[0]?.parts ?? [])
+      .flatMap((part) => part.type === "text" && "text" in part ? [part.text] : [])
+      .join("\n");
+    assertStringIncludes(text, "[Attachment content truncated]");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 Deno.test("prepareAgentRuntimeMessagesFromUiMessages preserves persisted uploaded image parts for vision models", async () => {
   const resolvedUploadIds: string[] = [];
   const messages = await prepareAgentRuntimeMessagesFromUiMessages({

--- a/src/agent/runtime/message-preparation.test.ts
+++ b/src/agent/runtime/message-preparation.test.ts
@@ -18,6 +18,45 @@ function userMessage(parts: ChatUiMessage["parts"]): ChatUiMessage {
   };
 }
 
+function rejectIfStillPending<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): { promise: Promise<T>; cancel: () => void } {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+
+  return {
+    promise: Promise.race([promise, timeout]),
+    cancel: () => {
+      if (timeoutId) clearTimeout(timeoutId);
+    },
+  };
+}
+
+function createAbortAwarePendingFetch(requestedUrls: string[] = []): typeof fetch {
+  return (input, init): Promise<Response> => {
+    requestedUrls.push(input.toString());
+    const signal = init?.signal;
+    if (!(signal instanceof AbortSignal)) {
+      return new Promise(() => {});
+    }
+
+    return new Promise((_resolve, reject) => {
+      const rejectAbort = () => {
+        reject(signal.reason instanceof Error ? signal.reason : new Error("fetch aborted"));
+      };
+      if (signal.aborted) {
+        rejectAbort();
+        return;
+      }
+      signal.addEventListener("abort", rejectAbort, { once: true });
+    });
+  };
+}
+
 Deno.test("prepareAgentRuntimeMessagesFromUiMessages returns an empty-conversation prompt", async () => {
   const messages = await prepareAgentRuntimeMessagesFromUiMessages({
     messages: [],
@@ -258,6 +297,129 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages surfaces trusted text attac
       "Failed to fetch text attachment content for notes.txt: HTTP 403 Forbidden",
     );
   } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages aborts stalled trusted text attachment fetches", async () => {
+  const requestedUrls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = createAbortAwarePendingFetch(requestedUrls);
+  const abortController = new AbortController();
+  let cancelPendingGuard = () => {};
+
+  try {
+    const preparation = prepareAgentRuntimeMessagesFromUiMessages({
+      messages: [
+        userMessage([
+          { type: "text", text: "Use this upload." },
+          {
+            type: "file",
+            mediaType: "text/plain",
+            filename: "notes.txt",
+            uploadId: "upload-1",
+            url: "https://files.example.com/original.txt",
+          },
+        ]),
+      ],
+      resolveFileUrl: async () => "https://signed.example.com/notes.txt",
+      abortSignal: abortController.signal,
+    });
+    const guarded = rejectIfStillPending(preparation, 50, "still pending after abort");
+    cancelPendingGuard = guarded.cancel;
+
+    abortController.abort(new Error("caller aborted"));
+
+    await assertRejects(
+      () => guarded.promise,
+      Error,
+      "Failed to fetch text attachment content for notes.txt: request aborted",
+    );
+    assertEquals(requestedUrls, ["https://signed.example.com/notes.txt"]);
+  } finally {
+    cancelPendingGuard();
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages times out stalled trusted text attachment fetches", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = createAbortAwarePendingFetch();
+  let cancelPendingGuard = () => {};
+
+  try {
+    const preparation = prepareAgentRuntimeMessagesFromUiMessages({
+      messages: [
+        userMessage([
+          { type: "text", text: "Use this upload." },
+          {
+            type: "file",
+            mediaType: "text/plain",
+            filename: "notes.txt",
+            uploadId: "upload-1",
+            url: "https://files.example.com/original.txt",
+          },
+        ]),
+      ],
+      resolveFileUrl: async () => "https://signed.example.com/notes.txt",
+      fileContentFetchTimeoutMs: 5,
+    });
+    const guarded = rejectIfStillPending(preparation, 100, "still pending after timeout");
+    cancelPendingGuard = guarded.cancel;
+
+    await assertRejects(
+      () => guarded.promise,
+      Error,
+      "Failed to fetch text attachment content for notes.txt: request timed out after 5ms",
+    );
+  } finally {
+    cancelPendingGuard();
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages times out stalled trusted text attachment body reads", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (): Promise<Response> =>
+    Promise.resolve(
+      new Response(
+        new ReadableStream({
+          start() {
+            // Leave the body open to simulate a signed URL that sends headers then stalls.
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+  let cancelPendingGuard = () => {};
+
+  try {
+    const preparation = prepareAgentRuntimeMessagesFromUiMessages({
+      messages: [
+        userMessage([
+          { type: "text", text: "Use this upload." },
+          {
+            type: "file",
+            mediaType: "text/plain",
+            filename: "notes.txt",
+            uploadId: "upload-1",
+            url: "https://files.example.com/original.txt",
+          },
+        ]),
+      ],
+      resolveFileUrl: async () => "https://signed.example.com/notes.txt",
+      fileContentFetchTimeoutMs: 5,
+    });
+    const guarded = rejectIfStillPending(preparation, 100, "still pending after body timeout");
+    cancelPendingGuard = guarded.cancel;
+
+    await assertRejects(
+      () => guarded.promise,
+      Error,
+      "Failed to fetch text attachment content for notes.txt: request timed out after 5ms",
+    );
+  } finally {
+    cancelPendingGuard();
     globalThis.fetch = originalFetch;
   }
 });

--- a/src/agent/runtime/message-preparation.test.ts
+++ b/src/agent/runtime/message-preparation.test.ts
@@ -231,6 +231,37 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages surfaces trusted text attac
   }
 });
 
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages surfaces trusted text attachment non-ok responses", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (): Promise<Response> =>
+    Promise.resolve(new Response("forbidden", { status: 403, statusText: "Forbidden" }));
+
+  try {
+    await assertRejects(
+      () =>
+        prepareAgentRuntimeMessagesFromUiMessages({
+          messages: [
+            userMessage([
+              { type: "text", text: "Use this upload." },
+              {
+                type: "file",
+                mediaType: "text/plain",
+                filename: "notes.txt",
+                uploadId: "upload-1",
+                url: "https://files.example.com/original.txt",
+              },
+            ]),
+          ],
+          resolveFileUrl: async () => "https://signed.example.com/notes.txt",
+        }),
+      Error,
+      "Failed to fetch text attachment content for notes.txt: HTTP 403 Forbidden",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 Deno.test("prepareAgentRuntimeMessagesFromUiMessages preserves persisted uploaded image parts for vision models", async () => {
   const resolvedUploadIds: string[] = [];
   const messages = await prepareAgentRuntimeMessagesFromUiMessages({

--- a/src/agent/runtime/message-preparation.test.ts
+++ b/src/agent/runtime/message-preparation.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import type { ChatUiMessage } from "../../chat/types.ts";
 import { generateText } from "../../runtime/runtime-bridge.ts";
 import { createGenerateModel } from "../../runtime/runtime-bridge.test-helpers.ts";
@@ -128,6 +128,107 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages decodes text data URL attac
   assertStringIncludes(text, "Summarize the attachment.");
   assertStringIncludes(text, "Order #4587");
   assertStringIncludes(text, "billing-note.txt");
+});
+
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages does not fetch caller-controlled remote file URLs by default", async () => {
+  const requestedUrls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input, _init): Promise<Response> => {
+    requestedUrls.push(input.toString());
+    return Promise.reject(new Error("unexpected server-side attachment fetch"));
+  };
+
+  try {
+    const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+      messages: [
+        userMessage([
+          { type: "text", text: "Summarize this attachment." },
+          {
+            type: "file",
+            mediaType: "text/plain",
+            filename: "notes.txt",
+            url: "http://127.0.0.1:9876/internal-notes.txt",
+          },
+        ]),
+      ],
+    });
+
+    assertEquals(requestedUrls, []);
+    const text = (messages[0]?.parts ?? [])
+      .flatMap((part) => part.type === "text" && "text" in part ? [part.text] : [])
+      .join("\n");
+    assertStringIncludes(text, "Summarize this attachment.");
+    assertEquals(text.includes("<file_content"), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages does not fetch original upload URL when resolver cannot sign it", async () => {
+  const requestedUrls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input, _init): Promise<Response> => {
+    requestedUrls.push(input.toString());
+    return Promise.reject(new Error("unexpected unresolved upload fetch"));
+  };
+
+  try {
+    const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+      messages: [
+        userMessage([
+          { type: "text", text: "Use this upload." },
+          {
+            type: "file",
+            mediaType: "text/plain",
+            filename: "notes.txt",
+            uploadId: "upload-1",
+            url: "http://127.0.0.1:9876/internal-notes.txt",
+          },
+        ]),
+      ],
+      resolveFileUrl: async () => undefined,
+    });
+
+    assertEquals(requestedUrls, []);
+    const text = (messages[0]?.parts ?? [])
+      .flatMap((part) => part.type === "text" && "text" in part ? [part.text] : [])
+      .join("\n");
+    assertStringIncludes(text, "Use this upload.");
+    assertEquals(text.includes("<file_content"), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages surfaces trusted text attachment fetch failures", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (): Promise<Response> =>
+    Promise.reject(new Error("signed attachment unavailable"));
+
+  try {
+    await assertRejects(
+      () =>
+        prepareAgentRuntimeMessagesFromUiMessages({
+          messages: [
+            userMessage([
+              { type: "text", text: "Use this upload." },
+              {
+                type: "file",
+                mediaType: "text/plain",
+                filename: "notes.txt",
+                uploadId: "upload-1",
+                url: "https://files.example.com/original.txt",
+              },
+            ]),
+          ],
+          resolveFileUrl: async () => "https://signed.example.com/notes.txt",
+        }),
+      Error,
+      "signed attachment unavailable",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 Deno.test("prepareAgentRuntimeMessagesFromUiMessages preserves persisted uploaded image parts for vision models", async () => {

--- a/src/agent/runtime/message-preparation.test.ts
+++ b/src/agent/runtime/message-preparation.test.ts
@@ -58,6 +58,7 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages preserves source message id
 
 Deno.test("prepareAgentRuntimeMessagesFromUiMessages refreshes upload file URLs before conversion", async () => {
   const resolvedUploadIds: string[] = [];
+  const fetchedUrls: string[] = [];
   const messages = await prepareAgentRuntimeMessagesFromUiMessages({
     messages: [
       userMessage([
@@ -75,9 +76,14 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages refreshes upload file URLs 
       resolvedUploadIds.push(uploadId);
       return "https://signed.example.com/file.txt";
     },
+    fetchFileContent: async ({ url }) => {
+      fetchedUrls.push(url);
+      return "Billing note: Order #4587 needs a refund.";
+    },
   });
 
   assertEquals(resolvedUploadIds, ["upload-1"]);
+  assertEquals(fetchedUrls, ["https://signed.example.com/file.txt"]);
   const parts = messages[0]?.parts ?? [];
   assertEquals(
     parts.some((part) =>
@@ -92,10 +98,36 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages refreshes upload file URLs 
   const text = parts.flatMap((part) => part.type === "text" && "text" in part ? [part.text] : [])
     .join("\n");
   assertStringIncludes(text, "Use these files.");
+  assertStringIncludes(text, "Order #4587");
   assertStringIncludes(text, "<uploaded_files>");
   assertStringIncludes(text, "notes.txt");
   assertStringIncludes(text, "upload-1");
   assertStringIncludes(text, "https://signed.example.com/file.txt");
+});
+
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages decodes text data URL attachments into prompt content", async () => {
+  const content = btoa("Inline note: Order #4587 was shipped twice.");
+  const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+    messages: [
+      userMessage([
+        { type: "text", text: "Summarize the attachment." },
+        {
+          type: "file",
+          mediaType: "text/plain",
+          filename: "billing-note.txt",
+          url: `data:text/plain;base64,${content}`,
+        },
+      ]),
+    ],
+  });
+
+  const text = (messages[0]?.parts ?? [])
+    .flatMap((part) => part.type === "text" && "text" in part ? [part.text] : [])
+    .join("\n");
+
+  assertStringIncludes(text, "Summarize the attachment.");
+  assertStringIncludes(text, "Order #4587");
+  assertStringIncludes(text, "billing-note.txt");
 });
 
 Deno.test("prepareAgentRuntimeMessagesFromUiMessages preserves persisted uploaded image parts for vision models", async () => {

--- a/src/agent/runtime/message-preparation.ts
+++ b/src/agent/runtime/message-preparation.ts
@@ -21,6 +21,8 @@ export type PrepareAgentRuntimeMessagesFromUiMessagesOptions = {
   emptyConversationPrompt?: string;
   resolveFileUrl?: RuntimeFileUrlResolver;
   fetchFileContent?: RuntimeFileContentFetcher;
+  abortSignal?: AbortSignal;
+  fileContentFetchTimeoutMs?: number;
   providerOwnedToolNames?: readonly string[];
 };
 
@@ -53,6 +55,12 @@ export async function prepareAgentRuntimeMessagesFromUiMessages(
     options.fetchFileContent ?? createRuntimeFileContentFetcher({
       trustedUrls: trustedFileContentUrls,
     }),
+    {
+      ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
+      ...(options.fileContentFetchTimeoutMs != null
+        ? { fetchTimeoutMs: options.fileContentFetchTimeoutMs }
+        : {}),
+    },
   );
 
   return convertProviderMessagesToAgentRuntimeMessages(

--- a/src/agent/runtime/message-preparation.ts
+++ b/src/agent/runtime/message-preparation.ts
@@ -5,6 +5,7 @@ import {
   convertProviderMessagesToAgentRuntimeMessages,
 } from "./message-adapter.ts";
 import {
+  createRuntimeFileContentFetcher,
   inlineRuntimeMessageFileContents,
   resolveRuntimeMessageFileUrls,
   type RuntimeFileContentFetcher,
@@ -36,12 +37,22 @@ export async function prepareAgentRuntimeMessagesFromUiMessages(
     ]);
   }
 
-  const refreshedMessages = options.resolveFileUrl
-    ? await resolveRuntimeMessageFileUrls(options.messages, options.resolveFileUrl)
+  const trustedFileContentUrls = new Set<string>();
+  const resolveFileUrl = options.resolveFileUrl;
+  const refreshedMessages = resolveFileUrl
+    ? await resolveRuntimeMessageFileUrls(options.messages, async (input) => {
+      const url = await resolveFileUrl(input);
+      if (url) {
+        trustedFileContentUrls.add(url);
+      }
+      return url;
+    })
     : [...options.messages];
   const messagesWithFileContent = await inlineRuntimeMessageFileContents(
     refreshedMessages,
-    options.fetchFileContent,
+    options.fetchFileContent ?? createRuntimeFileContentFetcher({
+      trustedUrls: trustedFileContentUrls,
+    }),
   );
 
   return convertProviderMessagesToAgentRuntimeMessages(

--- a/src/agent/runtime/message-preparation.ts
+++ b/src/agent/runtime/message-preparation.ts
@@ -5,7 +5,9 @@ import {
   convertProviderMessagesToAgentRuntimeMessages,
 } from "./message-adapter.ts";
 import {
+  inlineRuntimeMessageFileContents,
   resolveRuntimeMessageFileUrls,
+  type RuntimeFileContentFetcher,
   type RuntimeFileUrlResolver,
 } from "./message-file-url-refresh.ts";
 
@@ -17,6 +19,7 @@ export type PrepareAgentRuntimeMessagesFromUiMessagesOptions = {
   messages: readonly ChatUiMessage[];
   emptyConversationPrompt?: string;
   resolveFileUrl?: RuntimeFileUrlResolver;
+  fetchFileContent?: RuntimeFileContentFetcher;
   providerOwnedToolNames?: readonly string[];
 };
 
@@ -36,9 +39,13 @@ export async function prepareAgentRuntimeMessagesFromUiMessages(
   const refreshedMessages = options.resolveFileUrl
     ? await resolveRuntimeMessageFileUrls(options.messages, options.resolveFileUrl)
     : [...options.messages];
+  const messagesWithFileContent = await inlineRuntimeMessageFileContents(
+    refreshedMessages,
+    options.fetchFileContent,
+  );
 
   return convertProviderMessagesToAgentRuntimeMessages(
-    prepareProviderModelMessagesFromUiMessages(refreshedMessages, {
+    prepareProviderModelMessagesFromUiMessages(messagesWithFileContent, {
       providerOwnedToolNames: options.providerOwnedToolNames,
     }),
   );

--- a/src/discovery/transpiler.test.ts
+++ b/src/discovery/transpiler.test.ts
@@ -5,6 +5,7 @@ import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
 import { clearTranspileCache, importModule } from "./transpiler.ts";
 import type { FileDiscoveryContext } from "./types.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
+import { reset, tryResolve } from "#veryfront/extensions/contracts.ts";
 import * as embeddingMod from "#veryfront/embedding/index.ts";
 import * as knowledgeMod from "#veryfront/knowledge";
 
@@ -124,6 +125,33 @@ describe("discovery/transpiler", { sanitizeOps: false, sanitizeResources: false 
       ) as { default: { name: string } };
 
       assertEquals(mod.default.name, "test-agent");
+    });
+
+    it("lazily registers the installed default bundler before discovery transpilation", async () => {
+      reset();
+      assertEquals(tryResolve("Bundler"), undefined);
+      assertEquals(tryResolve("ModuleLexer"), undefined);
+
+      const files: Record<string, string> = {
+        "/project/schedules/daily.ts":
+          `export default { id: "daily", schedule: "0 8 * * *", target: "noop" };`,
+      };
+
+      const adapter = createMockAdapter(files);
+      const context: FileDiscoveryContext = {
+        platform: "node",
+        fsAdapter: adapter,
+        baseDir: "/project",
+      };
+
+      const mod = await importModule(
+        "file:///project/schedules/daily.ts",
+        context,
+      ) as { default: { id: string } };
+
+      assertEquals(mod.default.id, "daily");
+      assertEquals(typeof tryResolve<{ bundle?: unknown }>("Bundler")?.bundle, "function");
+      assertEquals(typeof tryResolve<{ parse?: unknown }>("ModuleLexer")?.parse, "function");
     });
 
     it("should resolve relative imports via fsAdapter plugin", async () => {

--- a/src/discovery/transpiler.ts
+++ b/src/discovery/transpiler.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Plugin, PluginBuild } from "veryfront/extensions/bundler";
+import { ensureDefaultBundlerContracts } from "#veryfront/extensions/bundler/defaults.ts";
 import { isDeno, isDenoCompiled } from "#veryfront/platform/compat/runtime.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import * as pathHelper from "#veryfront/compat/path";
@@ -180,6 +181,7 @@ export async function importModule(
   }
 
   const loader = getEsbuildLoader(filePath);
+  await ensureDefaultBundlerContracts();
   const { build } = await import("veryfront/extensions/bundler");
   const fileDir = pathHelper.dirname(filePath);
 

--- a/src/extensions/builtin-extensions.test.ts
+++ b/src/extensions/builtin-extensions.test.ts
@@ -105,7 +105,7 @@ describe("createBuiltinExtensions", () => {
   });
 
   it("does not statically import optional implementation extensions", async () => {
-    const source = await Deno.readTextFile("src/extensions/builtin-extensions.ts");
+    const source = await Deno.readTextFile(new URL("./builtin-extensions.ts", import.meta.url));
 
     assertEquals(source.includes('from "../../extensions/ext-auth-jwt/src/index.ts"'), false);
     assertEquals(

--- a/src/extensions/bundler/defaults.ts
+++ b/src/extensions/bundler/defaults.ts
@@ -1,0 +1,34 @@
+import { register, tryResolve } from "../contracts.ts";
+import {
+  importFirstPartyExtensionModule,
+  isMissingFirstPartyExtensionModule,
+} from "../first-party-import.ts";
+import type { Bundler } from "./bundler.ts";
+import type { ModuleLexer } from "./module-lexer.ts";
+
+type DefaultBundlerModule = {
+  EsbuildBundler: new () => Bundler;
+  EsModuleLexer: new () => ModuleLexer;
+};
+
+/**
+ * Lazily register the first-party Bundler + ModuleLexer implementation when it
+ * is available from workspace source or an installed @veryfront/ext package.
+ */
+export async function ensureDefaultBundlerContracts(): Promise<void> {
+  if (tryResolve("Bundler") && tryResolve("ModuleLexer")) return;
+
+  try {
+    const { EsbuildBundler, EsModuleLexer } = await importFirstPartyExtensionModule<
+      DefaultBundlerModule
+    >(
+      "ext-bundler-esbuild",
+      "@veryfront/ext-bundler-esbuild",
+    );
+
+    if (!tryResolve("Bundler")) register("Bundler", new EsbuildBundler());
+    if (!tryResolve("ModuleLexer")) register("ModuleLexer", new EsModuleLexer());
+  } catch (error) {
+    if (!isMissingFirstPartyExtensionModule(error)) throw error;
+  }
+}

--- a/src/integrations/remote-tools.test.ts
+++ b/src/integrations/remote-tools.test.ts
@@ -58,14 +58,14 @@ afterEach(() => {
 
 describe("integrations/remote-tools", () => {
   it("does not keep a legacy string end-user overload for remote tool execution", async () => {
-    const source = await Deno.readTextFile("src/integrations/remote-tools.ts");
+    const source = await Deno.readTextFile(new URL("./remote-tools.ts", import.meta.url));
 
     assertEquals(source.includes("contextOrEndUserId"), false);
     assertEquals(source.includes('typeof contextOrEndUserId === "string"'), false);
   });
 
   it("does not keep legacy OAuth caller identity URL sanitizers in live remote tools", async () => {
-    const source = await Deno.readTextFile("src/integrations/remote-tools.ts");
+    const source = await Deno.readTextFile(new URL("./remote-tools.ts", import.meta.url));
     const legacyCallerIdentityParam = ["end", "User", "Id"].join("");
 
     assertEquals(source.includes(legacyCallerIdentityParam), false);

--- a/src/provider/model-registry.test.ts
+++ b/src/provider/model-registry.test.ts
@@ -1,0 +1,85 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { deleteEnv, setEnv } from "#veryfront/compat/process.ts";
+import { clearModelProviders, resolveModel } from "./model-registry.ts";
+
+const MODEL_REGISTRY_ENV_KEYS = [
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+  "VERYFRONT_API_TOKEN",
+  "VERYFRONT_PROJECT_SLUG",
+] as const;
+
+function clearModelRegistryEnv(): void {
+  for (const key of MODEL_REGISTRY_ENV_KEYS) {
+    try {
+      deleteEnv(key);
+    } catch {
+      // expected: env may already be unset
+    }
+  }
+}
+
+describe("provider/model-registry", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    clearModelRegistryEnv();
+    clearModelProviders();
+  });
+
+  it("routes env-backed OpenAI reasoning models with tools through Responses", async () => {
+    setEnv("OPENAI_API_KEY", "sk-test-openai");
+    let requestedUrl = "";
+    let requestedBody: Record<string, unknown> | undefined;
+
+    globalThis.fetch = (async (input: URL | Request | string, init?: RequestInit) => {
+      const request = new Request(input, init);
+      requestedUrl = request.url;
+      requestedBody = JSON.parse(await request.text()) as Record<string, unknown>;
+
+      return new Response(
+        JSON.stringify({
+          status: "completed",
+          output: [{
+            type: "message",
+            content: [{ type: "output_text", text: "Found order." }],
+          }],
+          usage: { input_tokens: 4, output_tokens: 2, total_tokens: 6 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const runtime = resolveModel("openai/gpt-5.4-nano");
+    const result = await runtime.doGenerate({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Find order #4587" }],
+      }],
+      tools: [{
+        type: "function",
+        name: "lookup_order",
+        description: "Lookup an order by id",
+        inputSchema: {
+          type: "object",
+          properties: { orderId: { type: "string" } },
+          required: ["orderId"],
+          additionalProperties: false,
+        },
+      }],
+      toolChoice: "auto",
+    });
+
+    assertEquals(requestedUrl, "https://api.openai.com/v1/responses");
+    assertEquals(requestedBody?.model, "gpt-5.4-nano");
+    assertEquals(requestedBody?.reasoning, { effort: "medium", summary: "auto" });
+    assertEquals(
+      (requestedBody?.tools as Array<{ name?: string }> | undefined)?.[0]?.name,
+      "lookup_order",
+    );
+    assertEquals(result.content, [{ type: "text", text: "Found order." }]);
+  });
+});

--- a/src/provider/model-registry.ts
+++ b/src/provider/model-registry.ts
@@ -36,6 +36,20 @@ const manager = new ProjectScopedRegistryManager<ModelProviderFactory>(
 );
 let autoInitialized = false;
 
+function isOpenAIBaseURL(baseURL: string | undefined): boolean {
+  if (!baseURL) return true;
+  try {
+    const hostname = new URL(baseURL).hostname.toLowerCase();
+    return hostname === "api.openai.com" || hostname.endsWith(".api.openai.com");
+  } catch {
+    return false;
+  }
+}
+
+function getOpenAIEnvProviderName(baseURL: string | undefined): "openai" | "openai-compatible" {
+  return isOpenAIBaseURL(baseURL) ? "openai" : "openai-compatible";
+}
+
 /**
  * Register a custom model provider factory for the current project.
  *
@@ -87,7 +101,7 @@ function autoInitializeFromEnv(): void {
         return provider.createModel(id, {
           credential: config.apiKey,
           baseURL: config.baseURL,
-          providerName: "openai-compatible",
+          providerName: getOpenAIEnvProviderName(config.baseURL),
         });
       }
       throw toError(createError({

--- a/src/testing/init.ts
+++ b/src/testing/init.ts
@@ -10,11 +10,7 @@
  * @module
  */
 
-import { register as registerContract, tryResolve } from "#veryfront/extensions/contracts.ts";
-import {
-  importFirstPartyExtensionModule,
-  isMissingFirstPartyExtensionModule,
-} from "#veryfront/extensions/first-party-import.ts";
+import { ensureDefaultBundlerContracts } from "#veryfront/extensions/bundler/defaults.ts";
 
 const g = globalThis as Record<string, unknown>;
 
@@ -27,20 +23,4 @@ g.__vfTestEnvMask = {
 // Tests don't run the extension orchestrator; prime the Bundler + ModuleLexer
 // contracts here so transforms that depend on them (lexer.ts, parse-cache.ts,
 // the platform/compat/esbuild shim, and bundler call-sites) work in tests.
-await registerDefaultBundlerContracts();
-
-async function registerDefaultBundlerContracts(): Promise<void> {
-  if (tryResolve("Bundler") && tryResolve("ModuleLexer")) return;
-
-  try {
-    const { EsbuildBundler, EsModuleLexer } = await importFirstPartyExtensionModule<{
-      EsbuildBundler: new () => unknown;
-      EsModuleLexer: new () => unknown;
-    }>("ext-bundler-esbuild", "@veryfront/ext-bundler-esbuild");
-
-    if (!tryResolve("Bundler")) registerContract("Bundler", new EsbuildBundler());
-    if (!tryResolve("ModuleLexer")) registerContract("ModuleLexer", new EsModuleLexer());
-  } catch (error) {
-    if (!isMissingFirstPartyExtensionModule(error)) throw error;
-  }
-}
+await ensureDefaultBundlerContracts();

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1001";
+export const VERSION = "0.1.1002";


### PR DESCRIPTION
## Summary

Fixes the four queued veryfront-code regressions:

- #2751: inline text file-part contents after refreshing uploaded file URLs so runtime prompts can see attachment bodies.
- #2752: lazily register the installed esbuild bundler extension before discovery/transpilation paths that need `Bundler`/`ModuleLexer` contracts.
- #2753: rewrite npm React shim `.d.ts` files alongside JS shims so the package does not ship empty vendored React declarations.
- #2754: route BYOK OpenAI `gpt-5.4-nano` tool runs through the official OpenAI Responses path instead of OpenAI-compatible chat completions.

Also bumps the package version to `0.1.1002` (`deno.json` + `src/utils/version-constant.ts`) so merging this PR publishes the fixes to npm directly — no separate release PR needed.

Also hardens a few source-inspection tests that were cwd-sensitive under the repo's parallel pre-push test hook.

## Verification

- `deno task typecheck`
- `deno fmt --check` / `deno lint` for touched root files
- `deno fmt --config=scripts/test.deno.json --check` / `deno lint --config=scripts/test.deno.json` for npm shim script files
- Targeted Deno tests for runtime message prep, hosted chat prep, discovery transpiler, OpenAI model registry/provider, npm shim generation, builtin extensions, and remote tools
- Full repo pre-push hook passed on push: formatting, linting, typecheck, generation, and `2274 passed (19351 steps)` unit tests

Closes #2751
Closes #2752
Closes #2753
Closes #2754

