### PR TITLE
Expose project tools in project-agent stream runs

### DIFF
--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -126,6 +126,65 @@ describe("internal-agents/run-stream", () => {
     assertEquals(capturedToolNames, ["gmail__list_emails", "web_search"]);
   });
 
+  it("uses supplied local tool objects for boolean source tool declarations", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedTool: unknown;
+
+    const agent = {
+      id: "ops-agent",
+      config: {
+        id: "ops-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        tools: {
+          read_baseline: true,
+        },
+      },
+    } as unknown as Agent;
+
+    const readBaselineTool = {
+      id: "read_baseline",
+      description: "Read baseline",
+      inputSchema: { parse: (value: unknown) => value },
+      execute: () => ({ ok: true }),
+    } as unknown as Tool;
+
+    const input = {
+      agentId: "ops-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        localTools: {
+          read_baseline: readBaselineTool,
+        },
+        createRuntime: (_agent, mergedTools) => {
+          capturedTool = typeof mergedTools === "object" && mergedTools !== null
+            ? (mergedTools as Record<string, unknown>).read_baseline
+            : undefined;
+          return {
+            stream: async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+          };
+        },
+      },
+    );
+
+    assertEquals(capturedTool, readBaselineTool);
+  });
+
   it("preserves explicitly allowed source remote tool declarations before constructing the runtime", async () => {
     const sessionManager = new AgentRunSessionManager();
     let capturedToolNames: string[] = [];

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -74,6 +74,7 @@ function mergeRemoteToolNames(source: string[], forwarded: string[]): string[] {
 
 export interface RuntimeAgentStreamExecutionDeps {
   sessionManager: AgentRunSessionManager;
+  localTools?: Record<string, Tool | boolean>;
   projectAgentSandbox?: {
     apiUrl?: string;
     authToken?: string;
@@ -426,12 +427,16 @@ export async function createRuntimeAgentStreamResponse(
   const forwardedIntegrationToolDefs = getForwardedIntegrationToolDefinitions(input.forwardedProps);
   const availableForwardedToolNames = forwardedIntegrationToolDefs?.map((tool) => tool.name);
   const sandboxTools = await buildProjectAgentSandboxTools({ agent, deps });
+  const availableLocalTools = {
+    ...(deps.localTools ?? {}),
+    ...(sandboxTools.tools ?? {}),
+  };
   const mergedTools = buildMergedTools(
     agent,
     input,
     deps.sessionManager,
     availableForwardedToolNames,
-    sandboxTools.tools,
+    Object.keys(availableLocalTools).length > 0 ? availableLocalTools : undefined,
   );
   const runtimeAgent: RuntimeFilteredAgent = {
     ...agent,

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -7,6 +7,7 @@ import {
 } from "#veryfront/tool";
 import { defaultChannelInvokeDeps } from "#veryfront/channels/invoke.ts";
 import { type RuntimeAgentDiscoveryDeps } from "#veryfront/channels/control-plane.ts";
+import { getDiscoveredHostTools } from "#veryfront/agent/hosted/veryfront-cloud-agent-service.ts";
 import {
   createRuntimeAgentStreamResponse,
   type RuntimeAgentStreamExecutionDeps,
@@ -63,12 +64,15 @@ import {
 export interface AgentStreamHandlerDeps
   extends RuntimeAgentDiscoveryDeps, RuntimeAgentStreamExecutionDeps {
   resolveRuntimeOwnerInvokeUrl?: typeof resolveRuntimeOwnerInvokeUrl;
+  getLocalTools?: (agentId: string) => RuntimeAgentStreamExecutionDeps["localTools"];
 }
 
 const defaultDeps: AgentStreamHandlerDeps = {
   ...defaultChannelInvokeDeps,
   sessionManager: agentRunSessionManager,
   resolveRuntimeOwnerInvokeUrl,
+  getLocalTools: (agentId) =>
+    getDiscoveredHostTools({ agentId }) as RuntimeAgentStreamExecutionDeps["localTools"],
 };
 const logger = serverLogger.component("agent-stream-handler");
 const RUN_STREAM_PATH_REGEX = /^\/api\/control-plane\/runs\/([^/]+)\/stream$/;
@@ -666,6 +670,7 @@ export class AgentStreamHandler extends BaseHandler {
               ? createRuntimeAgentFromMarkdownDefinition(payload.agentConfig)
               : agent;
             const runtimeInput = sanitizeRuntimeRunAgentInput(toRuntimeRunAgentInput(payload));
+            const localTools = this.deps.getLocalTools?.(runtimeBaseAgent.id);
             const apiAuthToken = payload.credentials?.authToken || ctx.proxyToken ||
               getHostEnv("VERYFRONT_API_TOKEN") || "";
             const platformRuntimeAgent = await withVeryfrontPlatformRemoteTools({
@@ -709,6 +714,7 @@ export class AgentStreamHandler extends BaseHandler {
             const runAgentStream = () =>
               createRuntimeAgentStreamResponse(runtimeInput, runtimeAgent, {
                 ...this.deps,
+                localTools,
                 projectAgentSandbox: {
                   apiUrl: getHostEnv("VERYFRONT_API_URL") ?? "https://api.veryfront.com",
                   authToken: apiAuthToken || undefined,


### PR DESCRIPTION
## Summary
- Pass discovered host tool objects into project-agent stream runs.
- Let boolean source tool declarations resolve to concrete local tools before runtime construction.
- Add regression coverage for boolean source tool declarations backed by supplied local tools.

## Tests
- deno test --no-check --allow-all src/internal-agents/run-stream.test.ts
- deno test --no-check --allow-all src/server/handlers/request/agent-stream.handler.test.ts
- deno check src/internal-agents/run-stream.ts src/server/handlers/request/agent-stream.handler.ts
- deno fmt --check src/internal-agents/run-stream.ts src/internal-agents/run-stream.test.ts src/server/handlers/request/agent-stream.handler.ts
- git diff --check origin/main...HEAD
- clean-env pre-push hook: formatting, lint, typecheck, unit tests: 2274 passed / 0 failed

## Why
Hosted project-agent runs were only seeing skill-loader tools when the agent declared project tools by boolean name. This blocks the ops-agent proof run because `read_baseline` and telemetry tools are never exposed to the runtime.