### PR TITLE
Cover task targets in source schedules

### DIFF
--- a/src/discovery/auto-discovery.integration.test.ts
+++ b/src/discovery/auto-discovery.integration.test.ts
@@ -190,6 +190,22 @@ describe(
           ].join("\n"),
         );
         await Deno.writeTextFile(
+          `${tempDir}/schedules/triage-sweep.ts`,
+          [
+            'import { schedule } from "veryfront/schedule";',
+            "",
+            "export default schedule({",
+            '  id: "triage-sweep",',
+            '  name: "Triage sweep",',
+            '  schedule: "0 */6 * * *",',
+            '  timezone: "Etc/UTC",',
+            '  target: { kind: "task", id: "run-triage-sweep" },',
+            "  input: { windowHours: 6 },",
+            '  concurrencyPolicy: "Forbid",',
+            "});",
+          ].join("\n"),
+        );
+        await Deno.writeTextFile(
           `${tempDir}/webhooks/ticket-created.ts`,
           [
             'import { webhook } from "veryfront/webhook";',
@@ -219,6 +235,15 @@ describe(
         assertEquals(result.schedules.get("daily-triage")?.target, {
           kind: "workflow",
           id: "escalate-ticket",
+        });
+        assertEquals(result.schedules.get("triage-sweep"), {
+          id: "triage-sweep",
+          name: "Triage sweep",
+          schedule: "0 */6 * * *",
+          timezone: "Etc/UTC",
+          target: { kind: "task", id: "run-triage-sweep" },
+          input: { windowHours: 6 },
+          concurrencyPolicy: "Forbid",
         });
         assertEquals(result.webhooks.get("ticket-created")?.target, {
           kind: "workflow",

--- a/src/schedule/factory.test.ts
+++ b/src/schedule/factory.test.ts
@@ -28,6 +28,33 @@ describe("schedule/factory", () => {
     assertEquals(isScheduleDefinition(definition), true);
   });
 
+  it("preserves task targets for scheduled tasks", () => {
+    const definition = schedule({
+      id: "triage-sweep",
+      name: "Triage sweep",
+      schedule: "0 */6 * * *",
+      timezone: "Etc/UTC",
+      target: { kind: "task", id: "run-triage-sweep" },
+      input: { windowHours: 6 },
+      timeoutSeconds: 900,
+      backoffLimit: 1,
+      concurrencyPolicy: "Forbid",
+    });
+
+    assertEquals(definition, {
+      id: "triage-sweep",
+      name: "Triage sweep",
+      schedule: "0 */6 * * *",
+      timezone: "Etc/UTC",
+      target: { kind: "task", id: "run-triage-sweep" },
+      input: { windowHours: 6 },
+      timeoutSeconds: 900,
+      backoffLimit: 1,
+      concurrencyPolicy: "Forbid",
+    });
+    assertEquals(isScheduleDefinition(definition), true);
+  });
+
   it("rejects invalid ids and targets", () => {
     assertThrows(
       () =>


### PR DESCRIPTION
## Summary
- Add schedule factory coverage for `target: { kind: "task", id: "run-triage-sweep" }`.
- Extend source discovery integration coverage with a literal triage-sweep task schedule.

Refs veryfront/veryfront-studio#5510

## Test Plan
- `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/schedule/factory.test.ts src/discovery/auto-discovery.integration.test.ts`
- pre-push hook: `deno fmt --check`, `deno lint`, `deno check src/index.ts`, `deno task test:unit` (2274 passed / 0 failed, run with OTLP env cleared so default-config tests see repo defaults)