### PR TITLE
Fix VFS discovery sourcefile prefix doubling

### DIFF
--- a/src/discovery/transpiler.test.ts
+++ b/src/discovery/transpiler.test.ts
@@ -10,18 +10,31 @@ import * as knowledgeMod from "#veryfront/knowledge";
 
 /**
  * Creates a mock FileSystemAdapter backed by an in-memory file map.
+ *
+ * When `projectDir` is given, absolute paths under it are converted back to
+ * project-relative keys, mirroring the real veryfront adapter's
+ * PathNormalizer (hosted runs address the VFS with relative paths while the
+ * transpiler resolves imports against the process cwd).
  */
 function createMockAdapter(
   files: Record<string, string>,
+  options: { projectDir?: string } = {},
 ): FileSystemAdapter {
+  const normalize = (path: string): string => {
+    const { projectDir } = options;
+    if (projectDir && path.startsWith(projectDir)) {
+      return path.slice(projectDir.length).replace(/^\/+/, "");
+    }
+    return path;
+  };
   return {
     async readFile(path: string): Promise<string> {
-      const content = files[path];
+      const content = files[normalize(path)];
       if (content === undefined) throw new Error(`File not found: ${path}`);
       return content;
     },
     async exists(path: string): Promise<boolean> {
-      return path in files;
+      return normalize(path) in files;
     },
     async *readDir(path: string) {
       const prefix = path.endsWith("/") ? path : `${path}/`;
@@ -177,6 +190,35 @@ describe("discovery/transpiler", { sanitizeOps: false, sanitizeResources: false 
       ) as { default: { value: number } };
 
       assertEquals(mod.default.value, 42);
+    });
+
+    it("should resolve parent-directory imports on hosted runs with relative baseDir", async () => {
+      // Hosted (cloud) discovery uses baseDir "" and addresses the VFS with
+      // project-relative paths like "tools/foo.ts". Regression test for the
+      // esbuild stdin sourcefile doubling the directory prefix
+      // ("tools/tools/foo.ts"), which anchored ../ imports one directory too
+      // deep and made discovery skip every tool/agent.
+      const files: Record<string, string> = {
+        "tools/read-baseline.ts": [
+          `import { helper } from "../lib/util";`,
+          `export default { value: helper() };`,
+        ].join("\n"),
+        "lib/util.ts": `export function helper() { return "baseline"; }`,
+      };
+
+      const adapter = createMockAdapter(files, { projectDir: Deno.cwd() });
+      const context: FileDiscoveryContext = {
+        platform: "node",
+        fsAdapter: adapter,
+        baseDir: "",
+      };
+
+      const mod = await importModule(
+        "file://tools/read-baseline.ts",
+        context,
+      ) as { default: { value: string } };
+
+      assertEquals(mod.default.value, "baseline");
     });
 
     it("should throw when file is not found via fsAdapter", async () => {

--- a/src/discovery/transpiler.ts
+++ b/src/discovery/transpiler.ts
@@ -225,7 +225,12 @@ export async function importModule(
       contents: source,
       loader,
       resolveDir: fileDir,
-      sourcefile: filePath,
+      // Must be a basename: esbuild joins resolveDir + sourcefile to form the
+      // entry module path when sourcefile is relative. Passing the full
+      // relative filePath (e.g. "tools/foo.ts") on VFS runs (baseDir === "")
+      // doubles the prefix to "tools/tools/foo.ts", which anchors ../ imports
+      // one directory too deep.
+      sourcefile: pathHelper.basename(filePath),
     },
   });
 


### PR DESCRIPTION
## Summary
- Hosted primitive discovery runs with a relative base dir (`baseDir === ""`), so file paths reaching the transpiler already carry their directory prefix (`tools/foo.ts`).
- The esbuild `stdin` config passed that full relative path as `sourcefile` alongside `resolveDir: "tools"`; esbuild joins the two when `sourcefile` is relative, producing importer paths like `tools/tools/foo.ts`.
- The doubled importer anchored `../lib/...` imports one directory too deep (`/app/tools/lib/...` instead of `/app/lib/...`), so every tool/agent with a parent-directory import failed to compile and hosted runs logged `Primitive discovery found 0 agents and 0 tools` → `Runtime stream returned HTTP 404: Agent not found`.
- Fix: pass `pathHelper.basename(filePath)` as `sourcefile`. esbuild then reconstructs the original path in both modes — VFS (relative) and local (absolute `sourcefile` is never joined, so behavior is unchanged).

## Context
Unblocks the veryfront-ops-agent production proof (release `f6e82562` failed discovery with exactly this signature). Complements #2758, which exposes discovered project tools to stream runs — with 0 discovered tools that PR has nothing to expose.

## Tests
- New regression test: relative-`baseDir` VFS module with a `../lib/...` import, with the mock adapter mirroring the real `PathNormalizer` cwd-stripping. Fails on main (`Could not resolve \"../lib/util\" from \"tools/tools\"`), passes with the fix.
- `deno test --no-check --allow-all src/discovery/transpiler.test.ts` — 3 passed (13 steps), 0 failed
- `deno fmt` / `deno lint` / `deno check` on touched files