### PR TITLE
Bump package version to 0.1.1000

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.999",
+  "version": "0.1.1000",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.999";
+export const VERSION = "0.1.1000";


### PR DESCRIPTION
## Summary
Release `veryfront@0.1.1000` carrying the two hosted-runtime fixes for the ops-agent production proof:
- #2758 — expose discovered project tools as executable local tools in project-agent stream runs
- #2760 — fix VFS discovery sourcefile prefix doubling (`tools/tools/...` → 0 agents / 0 tools)

Merge order: this PR must land **after** #2758 and #2760 (branch-protection keeps it blocked while behind main, so it cannot publish without them).

## Tests
- `deno test --no-check --allow-all src/utils/version.test.ts` — version sync check passes