### PR TITLE
Bump package version to 0.1.1000

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.999",
+  "version": "0.1.1000",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.999";
+export const VERSION = "0.1.1000";


### PR DESCRIPTION
## Summary

Version bump `0.1.999` → `0.1.1000` (`deno.json` + `src/utils/version-constant.ts`, kept in sync per the version test).

Releases the regression fixes from #2757 (closes #2751, #2752, #2753, #2754 on the npm side): attachment inlining, lazy bundler registration, React `.d.ts` shims, and BYOK OpenAI Responses routing.

## Merge ordering

⚠️ **Do not merge before #2757.** This PR publishes `veryfront@0.1.1000` to npm on merge; if it lands first, the release ships without the fixes it's meant to deliver.

## Verification

- `deno test src/utils/version.test.ts` — 1 passed (21 steps), confirms both version files are in sync