### PR TITLE
Bump package version to 0.1.1001

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1000",
+  "version": "0.1.1001",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1000";
+export const VERSION = "0.1.1001";


### PR DESCRIPTION
## Summary
Publish `veryfront@0.1.1001` including #2758 (project tools exposed as executable local tools in project-agent stream runs). 0.1.1000 was published before #2758 landed, so it carries only the discovery-path fix (#2760); the ops-agent hosted proof needs both.

**Merge order: only after #2758.** Auto-merge is intentionally NOT armed on this PR; it will be merged manually once #2758 is in main.

## Tests
- `deno test --no-check --allow-all src/utils/version.test.ts` — version sync check passes