### PR TITLE
Key discovery transpile cache by source content

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1003",
+  "version": "0.1.1004",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/discovery/transpiler.test.ts
+++ b/src/discovery/transpiler.test.ts
@@ -280,6 +280,46 @@ describe("discovery/transpiler", { sanitizeOps: false, sanitizeResources: false 
       assertEquals(third === second, true);
     });
 
+    it("should not serve a stale cached module when a bundled dependency changes", async () => {
+      // esbuild inlines relative imports into the bundle, so an unchanged
+      // entry file does not mean an unchanged module: a release that only
+      // edits lib/ code (or another project sharing the same entry source)
+      // must not be served the previously bundled dependency contents.
+      const entryPath = "/project/agents/assistant.ts";
+      const entrySource = [
+        `import { CONFIG } from "./config";`,
+        `export default { model: CONFIG.model };`,
+      ].join("\n");
+      const contextFor = (depSource: string): FileDiscoveryContext => ({
+        platform: "node",
+        fsAdapter: createMockAdapter({
+          [entryPath]: entrySource,
+          "/project/agents/config.ts": depSource,
+        }),
+        baseDir: "/project",
+      });
+
+      const first = await importModule(
+        `file://${entryPath}`,
+        contextFor(`export const CONFIG = { model: "gpt-4" };`),
+      ) as { default: { model: string } };
+      assertEquals(first.default.model, "gpt-4");
+
+      const second = await importModule(
+        `file://${entryPath}`,
+        contextFor(`export const CONFIG = { model: "gpt-5.5" };`),
+      ) as { default: { model: string } };
+      assertEquals(second.default.model, "gpt-5.5");
+
+      // Both dependency versions stay cached: reverting to the original
+      // dependency contents serves the originally built module object.
+      const third = await importModule(
+        `file://${entryPath}`,
+        contextFor(`export const CONFIG = { model: "gpt-4" };`),
+      );
+      assertEquals(third === first, true);
+    });
+
     it("should throw when file is not found via fsAdapter", async () => {
       const adapter = createMockAdapter({});
       const context: FileDiscoveryContext = {

--- a/src/discovery/transpiler.test.ts
+++ b/src/discovery/transpiler.test.ts
@@ -249,6 +249,37 @@ describe("discovery/transpiler", { sanitizeOps: false, sanitizeResources: false 
       assertEquals(mod.default.value, "baseline");
     });
 
+    it("should not serve a stale cached module when content changes at the same path", async () => {
+      // The shared hosted runtime serves many projects and releases from one
+      // process; the same relative path recurs across them. A path-only cache
+      // key kept serving the previous release's module after a deploy.
+      const path = "/project/agents/assistant.ts";
+      const contextFor = (content: string): FileDiscoveryContext => ({
+        platform: "node",
+        fsAdapter: createMockAdapter({ [path]: content }),
+        baseDir: "/project",
+      });
+
+      const first = await importModule(
+        `file://${path}`,
+        contextFor(`export default { version: "release-1" };`),
+      ) as { default: { version: string } };
+      assertEquals(first.default.version, "release-1");
+
+      const second = await importModule(
+        `file://${path}`,
+        contextFor(`export default { version: "release-2" };`),
+      ) as { default: { version: string } };
+      assertEquals(second.default.version, "release-2");
+
+      // Unchanged content is still served from the cache (same module object).
+      const third = await importModule(
+        `file://${path}`,
+        contextFor(`export default { version: "release-2" };`),
+      );
+      assertEquals(third === second, true);
+    });
+
     it("should throw when file is not found via fsAdapter", async () => {
       const adapter = createMockAdapter({});
       const context: FileDiscoveryContext = {

--- a/src/discovery/transpiler.ts
+++ b/src/discovery/transpiler.ts
@@ -35,17 +35,65 @@ import * as metricsMod from "#veryfront/metrics";
 import * as schemasMod from "#veryfront/schemas";
 import * as chatUploadsMod from "#veryfront/chat/uploads";
 
-const transpileCache = new Map<string, unknown>();
+type TranspileCacheEntry = {
+  /** Content hashes of every file esbuild bundled into the module besides the entry. */
+  deps: ReadonlyArray<{ path: string; hash: string }>;
+  module: unknown;
+};
+
+// Keyed by entry file + entry source hash; each entry additionally records the
+// bundled dependency contents it was built from and is only served while those
+// still match (see findCachedModuleWithFreshDeps).
+const transpileCache = new Map<string, TranspileCacheEntry[]>();
+
+const textEncoder = new TextEncoder();
 
 async function hashSource(source: string): Promise<string> {
   const digest = await crypto.subtle.digest(
     "SHA-256",
-    new TextEncoder().encode(source),
+    textEncoder.encode(source),
   );
   return Array.from(
     new Uint8Array(digest),
     (byte) => byte.toString(16).padStart(2, "0"),
   ).join("");
+}
+
+/**
+ * Returns the first cached module whose recorded bundled-dependency contents
+ * still match what the current adapter serves. esbuild inlines relative
+ * imports into the bundle, so an unchanged entry file does not guarantee an
+ * unchanged module: a dependency edited by a new release (or differing between
+ * two projects that share the same entry source) must invalidate the entry.
+ */
+async function findCachedModuleWithFreshDeps(
+  entries: readonly TranspileCacheEntry[],
+  context: FileDiscoveryContext,
+): Promise<unknown | undefined> {
+  const hashByPath = new Map<string, string | undefined>();
+  for (const entry of entries) {
+    let depsMatch = true;
+    for (const dep of entry.deps) {
+      let hash = hashByPath.get(dep.path);
+      if (!hashByPath.has(dep.path)) {
+        try {
+          const content = context.fsAdapter
+            ? await context.fsAdapter.readFile(dep.path)
+            : await createFileSystem().readTextFile(dep.path);
+          hash = await hashSource(content);
+        } catch {
+          hash = undefined;
+        }
+        hashByPath.set(dep.path, hash);
+      }
+      if (hash === undefined || hash !== dep.hash) {
+        depsMatch = false;
+        break;
+      }
+    }
+    if (depsMatch) return entry.module;
+  }
+  return undefined;
 }
 
 // Setup veryfront modules as globals for compiled binary support
@@ -81,7 +129,10 @@ async function ensureVeryfrontGlobals(): Promise<void> {
 /**
  * Create an esbuild plugin for resolving files via fsAdapter
  */
-function createFsAdapterPlugin(fsAdapter: FileSystemAdapter): Plugin {
+function createFsAdapterPlugin(
+  fsAdapter: FileSystemAdapter,
+  onDependencyLoaded?: (path: string, content: string) => void,
+): Plugin {
   const existsCache = new Map<string, boolean>();
 
   async function checkExists(filePath: string): Promise<boolean> {
@@ -144,6 +195,7 @@ function createFsAdapterPlugin(fsAdapter: FileSystemAdapter): Plugin {
         wrapWithCurrentContext(async (args) => {
           try {
             const content = await fsAdapter.readFile(args.path);
+            onDependencyLoaded?.(args.path, content);
             return {
               contents: content,
               loader: getEsbuildLoader(args.path),
@@ -192,10 +244,15 @@ export async function importModule(
   // process serves many projects and releases, and the same relative path
   // (e.g. "tools/foo.ts") recurs across them. A path-only key keeps serving
   // the stale module after a deploy and can hand one project's module to
-  // another project's discovery.
+  // another project's discovery. The entry hash alone is still not enough —
+  // bundled relative imports are inlined into the module — so cached entries
+  // are only served after their recorded dependency contents re-verify.
   const cacheKey = `${file} ${await hashSource(source)}`;
-  const cached = transpileCache.get(cacheKey);
-  if (cached) return cached;
+  const cachedEntries = transpileCache.get(cacheKey);
+  if (cachedEntries) {
+    const cached = await findCachedModuleWithFreshDeps(cachedEntries, context);
+    if (cached) return cached;
+  }
 
   const loader = getEsbuildLoader(filePath);
   await ensureDefaultBundlerContracts();
@@ -210,8 +267,16 @@ export async function importModule(
     ? [...source.matchAll(/from\s+["'](\.\.[^"']+)["']/g)].map((m) => m[1]!).filter(Boolean)
     : [];
 
-  // Use fsAdapter plugin whenever a VFS adapter is available (regardless of runtime)
-  const plugins = hasFsAdapter ? [createFsAdapterPlugin(context.fsAdapter!)] : [];
+  // Use fsAdapter plugin whenever a VFS adapter is available (regardless of
+  // runtime), recording every bundled dependency for cache re-validation.
+  const bundledDeps: Array<{ path: string; content: string }> = [];
+  const plugins = hasFsAdapter
+    ? [
+      createFsAdapterPlugin(context.fsAdapter!, (path, content) => {
+        bundledDeps.push({ path, content });
+      }),
+    ]
+    : [];
 
   const result = await build({
     bundle: true,
@@ -275,7 +340,12 @@ export async function importModule(
     const moduleUrl = pathHelper.toFileUrl(tempFile);
     moduleUrl.searchParams.set("v", String(Date.now()));
     const module = await import(moduleUrl.href);
-    transpileCache.set(cacheKey, module);
+    const deps = await Promise.all(
+      bundledDeps.map(async ({ path, content }) => ({ path, hash: await hashSource(content) })),
+    );
+    const entries = transpileCache.get(cacheKey) ?? [];
+    entries.push({ deps, module });
+    transpileCache.set(cacheKey, entries);
     return module;
   } finally {
     await localFs.remove(tempDir, { recursive: true });

--- a/src/discovery/transpiler.ts
+++ b/src/discovery/transpiler.ts
@@ -37,6 +37,17 @@ import * as chatUploadsMod from "#veryfront/chat/uploads";
 
 const transpileCache = new Map<string, unknown>();
 
+async function hashSource(source: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(source),
+  );
+  return Array.from(
+    new Uint8Array(digest),
+    (byte) => byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
 // Setup veryfront modules as globals for compiled binary support
 let veryfrontGlobalsInitialized = false;
 
@@ -160,9 +171,6 @@ export async function importModule(
   file: string,
   context: FileDiscoveryContext,
 ): Promise<unknown> {
-  const cached = transpileCache.get(file);
-  if (cached) return cached;
-
   // Ensure veryfront modules are available as globals for compiled binaries
   await ensureVeryfrontGlobals();
 
@@ -179,6 +187,15 @@ export async function importModule(
       cause: error,
     });
   }
+
+  // The cache key must include the source content: a shared hosted runtime
+  // process serves many projects and releases, and the same relative path
+  // (e.g. "tools/foo.ts") recurs across them. A path-only key keeps serving
+  // the stale module after a deploy and can hand one project's module to
+  // another project's discovery.
+  const cacheKey = `${file} ${await hashSource(source)}`;
+  const cached = transpileCache.get(cacheKey);
+  if (cached) return cached;
 
   const loader = getEsbuildLoader(filePath);
   await ensureDefaultBundlerContracts();
@@ -258,7 +275,7 @@ export async function importModule(
     const moduleUrl = pathHelper.toFileUrl(tempFile);
     moduleUrl.searchParams.set("v", String(Date.now()));
     const module = await import(moduleUrl.href);
-    transpileCache.set(file, module);
+    transpileCache.set(cacheKey, module);
     return module;
   } finally {
     await localFs.remove(tempDir, { recursive: true });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1003";
+export const VERSION = "0.1.1004";


### PR DESCRIPTION
## Summary
- `transpileCache` in `src/discovery/transpiler.ts` was keyed by file path alone. The shared hosted runtime serves many projects and releases from one process, and the same relative path (`tools/foo.ts`, `agents/assistant.ts`) recurs across them, so:
  - after a deploy, discovery kept serving the **previous release's module** until the pod restarted (observed on veryfront-ops-agent: release 0.0.24 fixed a bug in `lib/runtime-env.ts`, but the hosted run still executed the 0.0.23 module; the fix only took effect on a later run that landed on a re-transpiling pod);
  - two projects with the same relative path could receive **each other's modules** (cross-tenant module leak).
- Fix: include a SHA-256 of the module source in the cache key. Unchanged content still hits the cache; changed content transpiles fresh. The higher-level discovery result cache is already release-keyed (`project-discovery.ts`) — this brings the module cache underneath it in line.

## Notes
- The cache-read now happens after the source read; the expensive work saved by the cache (esbuild transpile + temp-file import) is unchanged.
- Module instances were already retained per import (unique temp-file URL); entries now accumulate per content version instead of per path — same order of growth as deploys.

## Tests
- New: same path, changed content → new module; unchanged content → cache hit (module identity). Fails on main, passes with the fix.
- `deno test --no-check --allow-all src/discovery/` — 22 passed (71 steps)
- `deno fmt` / `deno lint` / `deno check` clean