### PR TITLE
Address #2757 review follow-ups (attachment inlining resilience + BYOK Responses hardening)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1002",
+  "version": "0.1.1003",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts
+++ b/extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts
@@ -149,6 +149,31 @@ describe("ext-llm-openai/openai-chat-request-builder", () => {
     assertEquals(body.service_tier, "default");
   });
 
+  it("lets an openai max_tokens override beat a legacy openai-compatible max_completion_tokens", () => {
+    const warnings = createWarningCollector();
+
+    const body = buildOpenAIChatRequest(
+      "gpt-4o-mini",
+      "openai",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        providerOptions: {
+          "openai-compatible": {
+            max_completion_tokens: 111,
+          },
+          openai: {
+            max_tokens: 222,
+          },
+        },
+      },
+      true,
+      warnings,
+    );
+
+    assertEquals(body.max_completion_tokens, 222);
+    assertEquals(body.max_tokens, undefined);
+  });
+
   it("preserves chat request shaping, provider option merge order, and warnings", () => {
     const prompt: RuntimePromptMessage[] = [
       { role: "system", content: "You are concise." },

--- a/extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts
+++ b/extensions/ext-llm-openai/src/openai-chat-request-builder.test.ts
@@ -123,6 +123,32 @@ describe("ext-llm-openai/openai-chat-request-builder", () => {
     assertEquals(warnings.drain().map((warning) => warning.setting), ["temperature"]);
   });
 
+  it("merges the legacy openai-compatible provider options bucket below openai keys", () => {
+    const warnings = createWarningCollector();
+
+    const body = buildOpenAIChatRequest(
+      "gpt-4o-mini",
+      "openai",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        providerOptions: {
+          "openai-compatible": {
+            custom_compat: true,
+            service_tier: "flex",
+          },
+          openai: {
+            service_tier: "default",
+          },
+        },
+      },
+      true,
+      warnings,
+    );
+
+    assertEquals(body.custom_compat, true);
+    assertEquals(body.service_tier, "default");
+  });
+
   it("preserves chat request shaping, provider option merge order, and warnings", () => {
     const prompt: RuntimePromptMessage[] = [
       { role: "system", content: "You are concise." },

--- a/extensions/ext-llm-openai/src/openai-chat-request-builder.ts
+++ b/extensions/ext-llm-openai/src/openai-chat-request-builder.ts
@@ -182,7 +182,14 @@ export function buildOpenAIChatRequest(
       : {}),
   };
 
-  const providerOpts = readProviderOptions(options.providerOptions, "openai", providerName);
+  // Env-BYOK users historically registered options under "openai-compatible";
+  // keep merging that bucket at the lowest precedence.
+  const providerOpts = readProviderOptions(
+    options.providerOptions,
+    ...(providerName === "openai" ? ["openai-compatible"] : []),
+    "openai",
+    providerName,
+  );
 
   // Normalize max_tokens to max_completion_tokens for native OpenAI models.
   if (isNativeOpenAIModel(modelId) && "max_tokens" in providerOpts) {

--- a/extensions/ext-llm-openai/src/openai-chat-request-builder.ts
+++ b/extensions/ext-llm-openai/src/openai-chat-request-builder.ts
@@ -183,22 +183,39 @@ export function buildOpenAIChatRequest(
   };
 
   // Env-BYOK users historically registered options under "openai-compatible";
-  // keep merging that bucket at the lowest precedence.
-  const providerOpts = readProviderOptions(
-    options.providerOptions,
+  // keep merging that bucket at the lowest precedence. max_tokens is normalized
+  // per bucket BEFORE merging so a higher-precedence bucket's max_tokens
+  // override still beats a lower bucket's max_completion_tokens.
+  const bucketNames = [
     ...(providerName === "openai" ? ["openai-compatible"] : []),
     "openai",
     providerName,
-  );
-
-  // Normalize max_tokens to max_completion_tokens for native OpenAI models.
-  if (isNativeOpenAIModel(modelId) && "max_tokens" in providerOpts) {
-    if (!("max_completion_tokens" in providerOpts)) {
-      providerOpts.max_completion_tokens = providerOpts.max_tokens;
-    }
-    delete providerOpts.max_tokens;
+  ];
+  const providerOpts: Record<string, unknown> = {};
+  for (const bucketName of bucketNames) {
+    Object.assign(
+      providerOpts,
+      normalizeNativeMaxTokens(readProviderOptions(options.providerOptions, bucketName), modelId),
+    );
   }
 
   Object.assign(body, providerOpts);
   return body;
+}
+
+/** Normalizes max_tokens to max_completion_tokens for native OpenAI models. */
+function normalizeNativeMaxTokens(
+  bucket: Record<string, unknown>,
+  modelId: string,
+): Record<string, unknown> {
+  if (!isNativeOpenAIModel(modelId) || !("max_tokens" in bucket)) {
+    return bucket;
+  }
+
+  const normalized = { ...bucket };
+  if (!("max_completion_tokens" in normalized)) {
+    normalized.max_completion_tokens = normalized.max_tokens;
+  }
+  delete normalized.max_tokens;
+  return normalized;
 }

--- a/extensions/ext-llm-openai/src/openai-provider.test.ts
+++ b/extensions/ext-llm-openai/src/openai-provider.test.ts
@@ -385,7 +385,7 @@ describe("openai-provider", () => {
 
     assertEquals(runtime.provider, "prod-openai");
     assertEquals(requestedUrl, "https://example.openai.test/v1/responses");
-    assertEquals(requestBody.reasoning, { effort: "medium", summary: "auto" });
+    assertEquals(requestBody.reasoning, { effort: "medium" });
     assertEquals(parts.map((part) => (part as { type: string }).type), [
       "reasoning-start",
       "reasoning-delta",

--- a/extensions/ext-llm-openai/src/openai-reasoning-models.test.ts
+++ b/extensions/ext-llm-openai/src/openai-reasoning-models.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   getDefaultOpenAIReasoningEffort,
   rejectsOpenAISamplingParams,
+  shouldRequestOpenAIReasoningSummary,
 } from "./openai-reasoning-models.ts";
 
 describe("ext-llm-openai/openai-reasoning-models", () => {
@@ -32,6 +33,28 @@ describe("ext-llm-openai/openai-reasoning-models", () => {
     assertEquals(getDefaultOpenAIReasoningEffort("gpt-5.4-nano", "veryfront-cloud"), "medium");
     assertEquals(getDefaultOpenAIReasoningEffort("gpt-5.4-nano", "azure"), undefined);
     assertEquals(getDefaultOpenAIReasoningEffort("gpt-5.4-nano", "moonshot"), undefined);
+  });
+
+  it("requests reasoning summaries only for explicit reasoning or Veryfront Cloud", () => {
+    assertEquals(
+      shouldRequestOpenAIReasoningSummary("openai", { effort: "medium", source: "default" }),
+      false,
+    );
+    assertEquals(
+      shouldRequestOpenAIReasoningSummary("openai", { effort: "high", source: "explicit" }),
+      true,
+    );
+    assertEquals(
+      shouldRequestOpenAIReasoningSummary("veryfront-cloud", {
+        effort: "medium",
+        source: "default",
+      }),
+      true,
+    );
+    assertEquals(
+      shouldRequestOpenAIReasoningSummary("azure", { effort: "medium", source: "default" }),
+      false,
+    );
   });
 
   it("detects models that reject sampling params separately from default reasoning params", () => {

--- a/extensions/ext-llm-openai/src/openai-reasoning-models.ts
+++ b/extensions/ext-llm-openai/src/openai-reasoning-models.ts
@@ -100,7 +100,9 @@ export function shouldRequestOpenAIReasoningSummary(
   providerName: string,
   reasoning: ResolvedOpenAIReasoning,
 ): boolean {
-  return reasoning.source === "explicit" || supportsDefaultReasoningParams(providerName);
+  // Default-reasoning BYOK "openai" requests must not ask for summaries:
+  // unverified customer organizations get a 400 from the Responses API.
+  return reasoning.source === "explicit" || providerName.toLowerCase() === "veryfront-cloud";
 }
 
 export function isOpenAIReasoningModel(modelId: string, providerName = "openai"): boolean {

--- a/extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts
+++ b/extensions/ext-llm-openai/src/openai-responses-request-builder.test.ts
@@ -42,11 +42,12 @@ describe("ext-llm-openai/openai-responses-request-builder", () => {
     );
 
     assertEquals(body.reasoning, { effort: "medium", summary: "auto" });
+    assertEquals(body.store, false);
     assertEquals(body.temperature, undefined);
     assertEquals(warnings.drain().map((warning) => warning.setting), ["temperature"]);
   });
 
-  it("requests reasoning summaries for direct OpenAI default reasoning requests", () => {
+  it("omits reasoning summaries for direct OpenAI default reasoning requests", () => {
     const warnings = createWarningCollector();
 
     const body = buildOpenAIResponsesRequest(
@@ -59,7 +60,34 @@ describe("ext-llm-openai/openai-responses-request-builder", () => {
       warnings,
     );
 
-    assertEquals(body.reasoning, { effort: "medium", summary: "auto" });
+    assertEquals(body.reasoning, { effort: "medium" });
+    assertEquals(body.store, false);
+  });
+
+  it("merges the legacy openai-compatible provider options bucket below openai keys", () => {
+    const warnings = createWarningCollector();
+
+    const body = buildOpenAIResponsesRequest(
+      "gpt-4o-mini",
+      "openai",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        providerOptions: {
+          "openai-compatible": {
+            custom_compat: true,
+            service_tier: "flex",
+          },
+          openai: {
+            service_tier: "default",
+          },
+        },
+      },
+      true,
+      warnings,
+    );
+
+    assertEquals(body.custom_compat, true);
+    assertEquals(body.service_tier, "default");
   });
 
   it("keeps explicit reasoning summaries for direct OpenAI requests", () => {
@@ -226,6 +254,7 @@ describe("ext-llm-openai/openai-responses-request-builder", () => {
 
     assertEquals(body, {
       model: "o4-mini",
+      store: false,
       input: [
         {
           role: "user",

--- a/extensions/ext-llm-openai/src/openai-responses-request-builder.ts
+++ b/extensions/ext-llm-openai/src/openai-responses-request-builder.ts
@@ -19,6 +19,7 @@ export type OpenAIResponsesInputItem = Record<string, unknown>;
 export type OpenAIResponsesRequest = {
   model: string;
   input: OpenAIResponsesInputItem[];
+  store?: boolean;
   instructions?: string;
   stream?: boolean;
   max_output_tokens?: number;
@@ -236,6 +237,8 @@ export function buildOpenAIResponsesRequest(
   const body: OpenAIResponsesRequest = {
     model: modelId,
     input,
+    // Stay stateless: encrypted reasoning content is never round-tripped via include.
+    store: false,
     ...(instructions !== undefined ? { instructions } : {}),
     ...(stream ? { stream: true } : {}),
     ...(options.maxOutputTokens !== undefined
@@ -283,6 +286,16 @@ export function buildOpenAIResponsesRequest(
       : {}),
   };
 
-  Object.assign(body, readProviderOptions(options.providerOptions, "openai", providerName));
+  // Env-BYOK users historically registered options under "openai-compatible";
+  // keep merging that bucket at the lowest precedence.
+  Object.assign(
+    body,
+    readProviderOptions(
+      options.providerOptions,
+      ...(providerName === "openai" ? ["openai-compatible"] : []),
+      "openai",
+      providerName,
+    ),
+  );
   return body;
 }

--- a/src/agent/runtime/message-file-url-refresh.test.ts
+++ b/src/agent/runtime/message-file-url-refresh.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import type { ChatUiMessage } from "../../chat/types.ts";
-import { resolveRuntimeMessageFileUrls } from "./message-file-url-refresh.ts";
+import { composeAbortSignals, resolveRuntimeMessageFileUrls } from "./message-file-url-refresh.ts";
 
 function userMessage(parts: ChatUiMessage["parts"]): ChatUiMessage {
   return {
@@ -76,4 +76,30 @@ Deno.test("resolveRuntimeMessageFileUrls keeps existing parts when resolver retu
     await resolveRuntimeMessageFileUrls(messages, () => Promise.resolve(undefined)),
     messages,
   );
+});
+
+Deno.test("composeAbortSignals aborts immediately when a source signal is already aborted", () => {
+  const alreadyAborted = new AbortController();
+  const reason = new Error("already aborted");
+  alreadyAborted.abort(reason);
+  const pending = new AbortController();
+
+  const signal = composeAbortSignals([pending.signal, alreadyAborted.signal]);
+
+  assertEquals(signal.aborted, true);
+  assertEquals(signal.reason, reason);
+});
+
+Deno.test("composeAbortSignals propagates aborts from any source signal", () => {
+  const first = new AbortController();
+  const second = new AbortController();
+
+  const signal = composeAbortSignals([first.signal, second.signal]);
+  assertEquals(signal.aborted, false);
+
+  const reason = new Error("second source aborted");
+  second.abort(reason);
+
+  assertEquals(signal.aborted, true);
+  assertEquals(signal.reason, reason);
 });

--- a/src/agent/runtime/message-file-url-refresh.ts
+++ b/src/agent/runtime/message-file-url-refresh.ts
@@ -5,6 +5,7 @@ import {
 } from "../../chat/types.ts";
 
 const MAX_INLINE_FILE_CONTENT_CHARS = 200_000;
+const MAX_TOTAL_INLINE_FILE_CONTENT_CHARS = 400_000;
 const DEFAULT_RUNTIME_FILE_CONTENT_FETCH_TIMEOUT_MS = 15_000;
 
 /** Input payload for runtime file URL resolver. */
@@ -113,49 +114,109 @@ export async function inlineRuntimeMessageFileContents(
     fetchTimeoutMs?: number;
   } = {},
 ): Promise<ChatUiMessage[]> {
-  const contentByUrl = new Map<string, Promise<string | undefined>>();
+  const contentByUrl = new Map<string, Promise<InlineFileContent | undefined>>();
+  const newestUserMessageIndex = findNewestUserMessageIndex(messages);
+  const inlineTextByPart = new Map<string, string>();
+  let remainingBudget = MAX_TOTAL_INLINE_FILE_CONTENT_CHARS;
 
-  return Promise.all(
-    messages.map(async (message) => {
-      if (!message.parts.some((part) => shouldInlineFileContent(part))) {
-        return message;
+  // Allocate the aggregate inline budget newest-first so the most recent
+  // attachments win, then skip fetching entirely once the budget is spent.
+  for (let messageIndex = messages.length - 1; messageIndex >= 0; messageIndex--) {
+    const message = messages[messageIndex]!;
+    for (let partIndex = 0; partIndex < message.parts.length; partIndex++) {
+      const file = getInlineableFilePart(message.parts[partIndex]);
+      if (!file) continue;
+
+      if (remainingBudget <= 0) {
+        inlineTextByPart.set(
+          `${messageIndex}:${partIndex}`,
+          "[attachment content omitted: inline budget exceeded]",
+        );
+        continue;
       }
 
-      const parts: ChatUiMessage["parts"] = [];
-      for (const part of message.parts) {
-        parts.push(part);
+      let contentPromise = contentByUrl.get(file.url);
+      if (!contentPromise) {
+        contentPromise = fetchFileContent({
+          url: file.url,
+          mediaType: file.mediaType,
+          ...(file.filename ? { filename: file.filename } : {}),
+          ...(file.uploadId ? { uploadId: file.uploadId } : {}),
+          ...(file.uploadPath ? { uploadPath: file.uploadPath } : {}),
+          ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
+          ...(options.fetchTimeoutMs != null ? { timeoutMs: options.fetchTimeoutMs } : {}),
+          part: file,
+          message,
+        }).then(normalizeInlineFileContent);
+        contentByUrl.set(file.url, contentPromise);
+      }
 
-        const file = getInlineableFilePart(part);
-        if (!file) continue;
-
-        let contentPromise = contentByUrl.get(file.url);
-        if (!contentPromise) {
-          contentPromise = fetchFileContent({
-            url: file.url,
-            mediaType: file.mediaType,
-            ...(file.filename ? { filename: file.filename } : {}),
-            ...(file.uploadId ? { uploadId: file.uploadId } : {}),
-            ...(file.uploadPath ? { uploadPath: file.uploadPath } : {}),
-            ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
-            ...(options.fetchTimeoutMs != null ? { timeoutMs: options.fetchTimeoutMs } : {}),
-            part: file,
-            message,
-          }).then(normalizeInlineFileContent);
-          contentByUrl.set(file.url, contentPromise);
+      let inlineContent: InlineFileContent | undefined;
+      try {
+        inlineContent = await contentPromise;
+      } catch (error) {
+        // Attachments on the newest user message must stay hard failures, and
+        // caller aborts always propagate; stale history attachments degrade.
+        if (messageIndex === newestUserMessageIndex || options.abortSignal?.aborted) {
+          throw error;
         }
-
-        const content = await contentPromise;
-        if (!content) continue;
-
-        parts.push({
-          type: "text",
-          text: buildInlineFileContentText(file, content),
-        });
+        inlineTextByPart.set(
+          `${messageIndex}:${partIndex}`,
+          `[attachment unavailable: ${file.filename ?? file.uploadId ?? "file"}]`,
+        );
+        continue;
       }
+      if (!inlineContent) continue;
 
-      return { ...message, parts };
-    }),
-  );
+      let content = inlineContent.content;
+      let truncated = inlineContent.truncated;
+      if (content.length > remainingBudget) {
+        content = content.slice(0, remainingBudget);
+        truncated = true;
+      }
+      remainingBudget -= content.length;
+
+      inlineTextByPart.set(
+        `${messageIndex}:${partIndex}`,
+        buildInlineFileContentText(
+          file,
+          truncated ? `${content}\n\n[Attachment content truncated]` : content,
+        ),
+      );
+    }
+  }
+
+  return messages.map((message, messageIndex) => {
+    if (!message.parts.some((part) => shouldInlineFileContent(part))) {
+      return message;
+    }
+
+    const parts: ChatUiMessage["parts"] = [];
+    for (let partIndex = 0; partIndex < message.parts.length; partIndex++) {
+      parts.push(message.parts[partIndex]!);
+
+      const text = inlineTextByPart.get(`${messageIndex}:${partIndex}`);
+      if (text) {
+        parts.push({ type: "text", text });
+      }
+    }
+
+    return { ...message, parts };
+  });
+}
+
+type InlineFileContent = {
+  content: string;
+  truncated: boolean;
+};
+
+function findNewestUserMessageIndex(messages: readonly ChatUiMessage[]): number {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index]?.role === "user") {
+      return index;
+    }
+  }
+  return -1;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -324,6 +385,26 @@ function appendRuntimeTextContentUntilInlineLimit(
   return { content: `${content}${decoded}`, reachedLimit: false };
 }
 
+/** Composes abort signals manually for runtimes without AbortSignal.any (Node < 20.3). */
+export function composeAbortSignals(signals: readonly AbortSignal[]): AbortSignal {
+  const controller = new AbortController();
+  for (const signal of signals) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+      return controller.signal;
+    }
+    signal.addEventListener("abort", () => controller.abort(signal.reason), { once: true });
+  }
+  return controller.signal;
+}
+
+function anyAbortSignal(signals: readonly AbortSignal[]): AbortSignal {
+  if (typeof AbortSignal.any === "function") {
+    return AbortSignal.any([...signals]);
+  }
+  return composeAbortSignals(signals);
+}
+
 function createRuntimeFileContentFetchSignal(
   abortSignal: AbortSignal | undefined,
   timeoutMs: number,
@@ -342,7 +423,7 @@ function createRuntimeFileContentFetchSignal(
   }
 
   return {
-    signal: AbortSignal.any([abortSignal, timeoutSignal]),
+    signal: anyAbortSignal([abortSignal, timeoutSignal]),
     wasAbortedByCaller: () => abortSignal.aborted,
     didTimeout: () => timeoutSignal.aborted,
   };
@@ -436,14 +517,14 @@ function isFetchableRuntimeFileContentUrl(
   return trustedUrls?.has(url) ?? false;
 }
 
-function normalizeInlineFileContent(content: string | undefined): string | undefined {
+function normalizeInlineFileContent(content: string | undefined): InlineFileContent | undefined {
   if (!content || content.trim().length === 0) return undefined;
 
   if (content.length <= MAX_INLINE_FILE_CONTENT_CHARS) {
-    return content;
+    return { content, truncated: false };
   }
 
-  return `${content.slice(0, MAX_INLINE_FILE_CONTENT_CHARS)}\n\n[Attachment content truncated]`;
+  return { content: content.slice(0, MAX_INLINE_FILE_CONTENT_CHARS), truncated: true };
 }
 
 function escapeXmlAttr(value: string): string {

--- a/src/agent/runtime/message-file-url-refresh.ts
+++ b/src/agent/runtime/message-file-url-refresh.ts
@@ -388,13 +388,26 @@ function appendRuntimeTextContentUntilInlineLimit(
 /** Composes abort signals manually for runtimes without AbortSignal.any (Node < 20.3). */
 export function composeAbortSignals(signals: readonly AbortSignal[]): AbortSignal {
   const controller = new AbortController();
+  const removeListeners: Array<() => void> = [];
+  const detachAll = () => {
+    for (const removeListener of removeListeners) {
+      removeListener();
+    }
+    removeListeners.length = 0;
+  };
   for (const signal of signals) {
     if (signal.aborted) {
+      detachAll();
       controller.abort(signal.reason);
       return controller.signal;
     }
-    signal.addEventListener("abort", () => controller.abort(signal.reason), { once: true });
+    const onAbort = () => controller.abort(signal.reason);
+    signal.addEventListener("abort", onAbort, { once: true });
+    removeListeners.push(() => signal.removeEventListener("abort", onAbort));
   }
+  // Detach listeners from the still-pending source signals once any of them
+  // fires, so long-lived caller signals don't accumulate stale listeners.
+  controller.signal.addEventListener("abort", detachAll, { once: true });
   return controller.signal;
 }
 

--- a/src/agent/runtime/message-preparation.test.ts
+++ b/src/agent/runtime/message-preparation.test.ts
@@ -301,6 +301,276 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages surfaces trusted text attac
   }
 });
 
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages degrades history attachment fetch failures to unavailable markers", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input, _init): Promise<Response> => {
+    if (input.toString() === "https://signed.example.com/notes.txt") {
+      return Promise.reject(new Error("signed attachment unavailable"));
+    }
+    return Promise.resolve(new Response("Latest attachment body.", { status: 200 }));
+  };
+
+  try {
+    const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+      messages: [
+        {
+          id: "user-1",
+          role: "user",
+          parts: [
+            { type: "text", text: "Old question." },
+            {
+              type: "file",
+              mediaType: "text/plain",
+              filename: "notes.txt",
+              uploadId: "upload-1",
+              url: "https://files.example.com/notes.txt",
+            },
+          ],
+        },
+        {
+          id: "assistant-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "Old answer." }],
+        },
+        {
+          id: "user-2",
+          role: "user",
+          parts: [
+            { type: "text", text: "New question." },
+            {
+              type: "file",
+              mediaType: "text/plain",
+              filename: "latest.txt",
+              uploadId: "upload-2",
+              url: "https://files.example.com/latest.txt",
+            },
+          ],
+        },
+      ],
+      resolveFileUrl: async ({ uploadId }) =>
+        uploadId === "upload-1"
+          ? "https://signed.example.com/notes.txt"
+          : "https://signed.example.com/latest.txt",
+    });
+
+    const historyText = (messages[0]?.parts ?? [])
+      .flatMap((part) => part.type === "text" && "text" in part ? [part.text] : [])
+      .join("\n");
+    assertStringIncludes(historyText, "[attachment unavailable: notes.txt]");
+    assertEquals(historyText.includes("<file_content"), false);
+
+    const newestText = (messages[2]?.parts ?? [])
+      .flatMap((part) => part.type === "text" && "text" in part ? [part.text] : [])
+      .join("\n");
+    assertStringIncludes(newestText, "Latest attachment body.");
+    assertEquals(newestText.includes("[attachment unavailable"), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages still propagates caller aborts for history attachment fetches", async () => {
+  const requestedUrls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = createAbortAwarePendingFetch(requestedUrls);
+  const abortController = new AbortController();
+  let cancelPendingGuard = () => {};
+
+  try {
+    const preparation = prepareAgentRuntimeMessagesFromUiMessages({
+      messages: [
+        {
+          id: "user-1",
+          role: "user",
+          parts: [
+            { type: "text", text: "Old question." },
+            {
+              type: "file",
+              mediaType: "text/plain",
+              filename: "notes.txt",
+              uploadId: "upload-1",
+              url: "https://files.example.com/notes.txt",
+            },
+          ],
+        },
+        {
+          id: "assistant-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "Old answer." }],
+        },
+        {
+          id: "user-2",
+          role: "user",
+          parts: [{ type: "text", text: "Follow up." }],
+        },
+      ],
+      resolveFileUrl: async () => "https://signed.example.com/notes.txt",
+      abortSignal: abortController.signal,
+    });
+    const guarded = rejectIfStillPending(preparation, 50, "still pending after abort");
+    cancelPendingGuard = guarded.cancel;
+
+    abortController.abort(new Error("caller aborted"));
+
+    await assertRejects(
+      () => guarded.promise,
+      Error,
+      "Failed to fetch text attachment content for notes.txt: request aborted",
+    );
+    assertEquals(requestedUrls, ["https://signed.example.com/notes.txt"]);
+  } finally {
+    cancelPendingGuard();
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages allocates the aggregate inline budget newest-first", async () => {
+  const contentByUrl: Record<string, string> = {
+    "https://signed.example.com/a.txt": "X".repeat(180_000),
+    "https://signed.example.com/b.txt": "Y".repeat(180_000),
+    "https://signed.example.com/c.txt": "Z".repeat(180_000),
+  };
+
+  const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+    messages: [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{
+          type: "file",
+          mediaType: "text/plain",
+          filename: "a.txt",
+          url: "https://signed.example.com/a.txt",
+        }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "Noted." }],
+      },
+      {
+        id: "user-2",
+        role: "user",
+        parts: [{
+          type: "file",
+          mediaType: "text/plain",
+          filename: "b.txt",
+          url: "https://signed.example.com/b.txt",
+        }],
+      },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        parts: [{ type: "text", text: "Noted." }],
+      },
+      {
+        id: "user-3",
+        role: "user",
+        parts: [{
+          type: "file",
+          mediaType: "text/plain",
+          filename: "c.txt",
+          url: "https://signed.example.com/c.txt",
+        }],
+      },
+    ],
+    fetchFileContent: async ({ url }) => contentByUrl[url],
+  });
+
+  const textOf = (index: number) =>
+    (messages[index]?.parts ?? [])
+      .flatMap((part) => part.type === "text" && "text" in part ? [part.text] : [])
+      .join("\n");
+
+  const inlinedChars = (index: number, filler: string) =>
+    (textOf(index).match(new RegExp(filler, "g")) ?? []).length;
+
+  // Newest two fit fully; the oldest only gets the remaining budget.
+  assertEquals(inlinedChars(4, "Z"), 180_000);
+  assertEquals(inlinedChars(2, "Y"), 180_000);
+  assertEquals(inlinedChars(0, "X"), 40_000);
+  assertStringIncludes(textOf(0), "[Attachment content truncated]");
+  assertEquals(textOf(2).includes("[Attachment content truncated]"), false);
+  assertEquals(
+    inlinedChars(0, "X") + inlinedChars(2, "Y") + inlinedChars(4, "Z") <= 400_000,
+    true,
+  );
+});
+
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages omits older attachments without fetching once the inline budget is spent", async () => {
+  const fetchedUrls: string[] = [];
+  const contentByUrl: Record<string, string> = {
+    "https://signed.example.com/a.txt": "X".repeat(250_000),
+    "https://signed.example.com/b.txt": "Y".repeat(250_000),
+    "https://signed.example.com/c.txt": "Z".repeat(250_000),
+  };
+
+  const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+    messages: [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{
+          type: "file",
+          mediaType: "text/plain",
+          filename: "a.txt",
+          url: "https://signed.example.com/a.txt",
+        }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "Noted." }],
+      },
+      {
+        id: "user-2",
+        role: "user",
+        parts: [{
+          type: "file",
+          mediaType: "text/plain",
+          filename: "b.txt",
+          url: "https://signed.example.com/b.txt",
+        }],
+      },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        parts: [{ type: "text", text: "Noted." }],
+      },
+      {
+        id: "user-3",
+        role: "user",
+        parts: [{
+          type: "file",
+          mediaType: "text/plain",
+          filename: "c.txt",
+          url: "https://signed.example.com/c.txt",
+        }],
+      },
+    ],
+    fetchFileContent: async ({ url }) => {
+      fetchedUrls.push(url);
+      return contentByUrl[url];
+    },
+  });
+
+  const textOf = (index: number) =>
+    (messages[index]?.parts ?? [])
+      .flatMap((part) => part.type === "text" && "text" in part ? [part.text] : [])
+      .join("\n");
+
+  // Newest two exhaust the budget at the per-URL cap; the oldest is omitted
+  // and never fetched (budget allocation intentionally skips the fetch).
+  assertEquals((textOf(4).match(/Z/g) ?? []).length, 200_000);
+  assertEquals((textOf(2).match(/Y/g) ?? []).length, 200_000);
+  assertStringIncludes(textOf(0), "[attachment content omitted: inline budget exceeded]");
+  assertEquals(textOf(0).includes("X"), false);
+  assertEquals(fetchedUrls, [
+    "https://signed.example.com/c.txt",
+    "https://signed.example.com/b.txt",
+  ]);
+});
+
 Deno.test("prepareAgentRuntimeMessagesFromUiMessages aborts stalled trusted text attachment fetches", async () => {
   const requestedUrls: string[] = [];
   const originalFetch = globalThis.fetch;

--- a/src/provider/model-registry.test.ts
+++ b/src/provider/model-registry.test.ts
@@ -75,11 +75,88 @@ describe("provider/model-registry", () => {
 
     assertEquals(requestedUrl, "https://api.openai.com/v1/responses");
     assertEquals(requestedBody?.model, "gpt-5.4-nano");
-    assertEquals(requestedBody?.reasoning, { effort: "medium", summary: "auto" });
+    assertEquals(requestedBody?.store, false);
+    assertEquals(requestedBody?.reasoning, { effort: "medium" });
     assertEquals(
       (requestedBody?.tools as Array<{ name?: string }> | undefined)?.[0]?.name,
       "lookup_order",
     );
     assertEquals(result.content, [{ type: "text", text: "Found order." }]);
+  });
+
+  it("keeps reasoning summaries for explicit reasoning on env-backed OpenAI Responses models", async () => {
+    setEnv("OPENAI_API_KEY", "sk-test-openai");
+    let requestedBody: Record<string, unknown> | undefined;
+
+    globalThis.fetch = (async (input: URL | Request | string, init?: RequestInit) => {
+      const request = new Request(input, init);
+      requestedBody = JSON.parse(await request.text()) as Record<string, unknown>;
+
+      return new Response(
+        JSON.stringify({
+          status: "completed",
+          output: [{
+            type: "message",
+            content: [{ type: "output_text", text: "Done." }],
+          }],
+          usage: { input_tokens: 4, output_tokens: 2, total_tokens: 6 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const runtime = resolveModel("openai/gpt-5.4-nano");
+    await runtime.doGenerate({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Think hard." }],
+      }],
+      reasoning: { enabled: true, effort: "high" },
+    });
+
+    assertEquals(requestedBody?.store, false);
+    assertEquals(requestedBody?.reasoning, { effort: "high", summary: "auto" });
+  });
+
+  it("merges legacy openai-compatible provider options into env-backed OpenAI request bodies", async () => {
+    setEnv("OPENAI_API_KEY", "sk-test-openai");
+    let requestedBody: Record<string, unknown> | undefined;
+
+    globalThis.fetch = (async (input: URL | Request | string, init?: RequestInit) => {
+      const request = new Request(input, init);
+      requestedBody = JSON.parse(await request.text()) as Record<string, unknown>;
+
+      return new Response(
+        JSON.stringify({
+          status: "completed",
+          output: [{
+            type: "message",
+            content: [{ type: "output_text", text: "Done." }],
+          }],
+          usage: { input_tokens: 4, output_tokens: 2, total_tokens: 6 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const runtime = resolveModel("openai/gpt-5.4-nano");
+    await runtime.doGenerate({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Hi" }],
+      }],
+      providerOptions: {
+        "openai-compatible": {
+          custom_compat: true,
+          service_tier: "flex",
+        },
+        openai: {
+          service_tier: "default",
+        },
+      },
+    });
+
+    assertEquals(requestedBody?.custom_compat, true);
+    assertEquals(requestedBody?.service_tier, "default");
   });
 });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1002";
+export const VERSION = "0.1.1003";


### PR DESCRIPTION
## Summary

Addresses the four follow-up findings from the #2757 review (filed as veryfront-studio issues):

- **Fail-soft attachment inlining for history messages** — trusted attachment fetch failures on history messages now degrade to an `[attachment unavailable: <name>]` text part instead of failing the whole run; attachments on the newest user message still hard-fail (silent omission there is what caused #2751), and caller aborts always propagate. One permanently unfetchable old attachment can no longer brick a conversation.
- **Aggregate inline content budget** — new `MAX_TOTAL_INLINE_FILE_CONTENT_CHARS = 400_000` across all inlined attachments per preparation, allocated newest-first; once spent, older attachments get `[attachment content omitted: inline budget exceeded]` and their fetch is skipped entirely. Keeps prepared messages well under the 1MB internal `AgentStreamRequest` cap (mitigates the studio#4617 amplification).
- **`AbortSignal.any` fallback** — feature-detected manual composition (`composeAbortSignals`) so the npm-consumed message-preparation path works on Node < 20.3 within the package's declared `engines: >=18` range.
- **BYOK OpenAI Responses side effects** — Responses requests now set `store: false` explicitly (no silent 30-day retention in customer orgs; still overridable via providerOptions), reasoning `summary: "auto"` is only requested for explicit reasoning or `veryfront-cloud` (unverified BYOK orgs got 400s), and the legacy `"openai-compatible"` providerOptions bucket is merged again at lowest precedence for env-BYOK `openai` requests.

Also bumps the package version to `0.1.1003` so merging publishes these fixes to npm.

Closes veryfront/veryfront-studio#5511
Closes veryfront/veryfront-studio#5512
Closes veryfront/veryfront-studio#5513
Closes veryfront/veryfront-studio#5514

## Verification

- `deno task typecheck` — clean
- `deno fmt --check` / `deno lint` on all changed files — clean
- Full `src/agent/runtime/` + `src/agent/hosted/` suites, `src/provider/model-registry.test.ts`, `src/provider/veryfront-cloud/provider.test.ts`, `src/utils/version.test.ts`, and the ext-llm-openai suite — 0 failures
- veryfront-cloud reasoning-summary expectations unchanged and passing; the only intentionally updated #2757 expectations are the env-BYOK `summary` assertions
