### PR TITLE
Enforce restrictive runtimeOverrides.toolAllowlist on internal agent runs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1004",
+  "version": "0.1.1005",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -328,6 +328,236 @@ describe("internal-agents/run-stream", () => {
     assertEquals(capturedToolNames, ["gmail__list_emails", "list_projects"]);
   });
 
+  it("restricts the run tool surface to runtimeOverrides.toolAllowlist", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedToolNames: string[] = [];
+
+    const agent = {
+      id: "ops-agent",
+      config: {
+        id: "ops-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        tools: {
+          read_baseline: { description: "Read the telemetry baseline" },
+          create_issue: { description: "File a GitHub issue" },
+        },
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "ops-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [
+        {
+          name: "web_search",
+          description: "Search the web",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+      context: [],
+      forwardedProps: {
+        runtimeOverrides: {
+          toolAllowlist: ["read_baseline"],
+          allowedTools: ["gmail__list_emails"],
+          integrationToolDefinitions: [
+            {
+              name: "gmail__list_emails",
+              description: "List emails",
+              parameters: { type: "object", properties: {} },
+            },
+          ],
+        },
+      },
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        createRuntime: (_agent, mergedTools) => {
+          capturedToolNames = Object.keys(mergedTools ?? {}).sort();
+          return {
+            stream: async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+          };
+        },
+      },
+    );
+
+    // Agent source tools outside the allowlist, injected caller tools, and
+    // granted integration tools are all withheld from the model.
+    assertEquals(capturedToolNames, ["read_baseline"]);
+  });
+
+  it("preserves skill runtime tools for skill-enabled agents under toolAllowlist", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedToolNames: string[] = [];
+
+    const agent = {
+      id: "ops-agent",
+      config: {
+        id: "ops-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        skills: true,
+        tools: {
+          read_baseline: { description: "Read the telemetry baseline" },
+          create_issue: { description: "File a GitHub issue" },
+          load_skill: { description: "Load a skill" },
+        },
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "ops-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+      forwardedProps: {
+        runtimeOverrides: {
+          toolAllowlist: ["read_baseline"],
+        },
+      },
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        createRuntime: (_agent, mergedTools) => {
+          capturedToolNames = Object.keys(mergedTools ?? {}).sort();
+          return {
+            stream: async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+          };
+        },
+      },
+    );
+
+    assertEquals(capturedToolNames, ["load_skill", "read_baseline"]);
+  });
+
+  it("intersects toolAllowlist with the agent source remote tool filter", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedAllowedRemoteTools: string[] | undefined;
+
+    const agent = {
+      id: "ops-agent",
+      config: {
+        id: "ops-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        __vfAllowedRemoteTools: ["list_projects", "search_knowledge"],
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "ops-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+      forwardedProps: {
+        runtimeOverrides: {
+          // create_issue is not source-allowed as a remote tool: the
+          // restrictive allowlist must not widen remote exposure.
+          toolAllowlist: ["search_knowledge", "create_issue"],
+        },
+      },
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        createRuntime: (runtimeAgent) => {
+          capturedAllowedRemoteTools = (
+            runtimeAgent.config as Agent["config"] & { __vfAllowedRemoteTools?: string[] }
+          ).__vfAllowedRemoteTools;
+          return {
+            stream: async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+          };
+        },
+      },
+    );
+
+    assertEquals(capturedAllowedRemoteTools, ["search_knowledge"]);
+  });
+
+  it("fails closed when toolAllowlist is present but malformed", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedToolNames: string[] = [];
+
+    const agent = {
+      id: "ops-agent",
+      config: {
+        id: "ops-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        tools: {
+          read_baseline: { description: "Read the telemetry baseline" },
+        },
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "ops-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+      forwardedProps: {
+        runtimeOverrides: {
+          toolAllowlist: "read_baseline",
+        },
+      },
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        createRuntime: (_agent, mergedTools) => {
+          capturedToolNames = Object.keys(mergedTools ?? {}).sort();
+          return {
+            stream: async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+          };
+        },
+      },
+    );
+
+    assertEquals(capturedToolNames, []);
+  });
+
   it("compacts oversized internal runtime message history before streaming", async () => {
     const sessionManager = new AgentRunSessionManager();
     let capturedMessages: AgentMessage[] = [];

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -22,6 +22,7 @@ import {
   type SandboxShellToolsProvider,
   SandboxShellToolsProviderName,
 } from "#veryfront/extensions/sandbox/index.ts";
+import { resolveHostedRuntimeAllowedToolNames } from "#veryfront/agent/hosted/runtime-essential-tools.ts";
 import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
 import { isToolVisibleTo, type Tool, toolRegistry } from "#veryfront/tool";
 import { defineSchema, lazySchema } from "#veryfront/schemas/index.ts";
@@ -340,6 +341,68 @@ function getAllowedRemoteToolNames(
   return allowedTools.every((toolName) => typeof toolName === "string") ? allowedTools : [];
 }
 
+/**
+ * Reads the restrictive `runtimeOverrides.toolAllowlist` override.
+ *
+ * Unlike `runtimeOverrides.allowedTools` — which this path treats as an
+ * additive grant list (Studio forwards integration/studio tool names it wants
+ * attached on top of the agent's own surface) — `toolAllowlist` is a hard
+ * restriction: the model-visible tool set of the run is intersected with it.
+ * Scheduled automations declare it via schedule `input.runtimeOverrides` for
+ * defense in depth. Returns null when absent (no restriction); a present but
+ * malformed value fails closed to an empty allowlist.
+ */
+function getRuntimeToolAllowlist(
+  forwardedProps: RuntimeRunAgentInput["forwardedProps"],
+): ReadonlySet<string> | null {
+  const runtimeOverrides = isRecord(forwardedProps?.runtimeOverrides)
+    ? forwardedProps.runtimeOverrides
+    : null;
+  if (!runtimeOverrides || !Object.hasOwn(runtimeOverrides, "toolAllowlist")) {
+    return null;
+  }
+  const toolAllowlist = runtimeOverrides.toolAllowlist;
+  if (!Array.isArray(toolAllowlist)) {
+    return new Set();
+  }
+  return new Set(
+    toolAllowlist.filter((toolName): toolName is string =>
+      typeof toolName === "string" && toolName.length > 0
+    ),
+  );
+}
+
+/**
+ * Intersects the merged run tool set with the restrictive tool allowlist.
+ * Skill runtime/delegation tools are preserved for skill-enabled agents,
+ * mirroring the hosted chat runtime's allowlist semantics.
+ */
+function applyRuntimeToolAllowlist(
+  mergedTools: Agent["config"]["tools"],
+  toolAllowlist: ReadonlySet<string> | null,
+  agent: Agent,
+): Agent["config"]["tools"] {
+  if (!toolAllowlist || !mergedTools || mergedTools === true) {
+    return mergedTools;
+  }
+  const availableSkillIds = agent.config.skills === true
+    ? ["*"]
+    : Array.isArray(agent.config.skills)
+    ? agent.config.skills
+    : undefined;
+  const allowedToolNames = resolveHostedRuntimeAllowedToolNames({
+    allowedToolNames: toolAllowlist,
+    localToolNames: Object.keys(mergedTools),
+    ...(availableSkillIds ? { availableSkillIds } : {}),
+  });
+  if (!allowedToolNames) {
+    return mergedTools;
+  }
+  return Object.fromEntries(
+    Object.entries(mergedTools).filter(([toolName]) => allowedToolNames.has(toolName)),
+  );
+}
+
 function getServerResolvedProjectToolNames(
   forwardedProps: RuntimeRunAgentInput["forwardedProps"],
 ): Set<string> {
@@ -418,11 +481,25 @@ export async function createRuntimeAgentStreamResponse(
 
   const forwardedAllowedRemoteToolNames = getAllowedRemoteToolNames(input.forwardedProps);
   const sourceAllowedRemoteToolNames = getAgentAllowedRemoteToolNames(agent);
-  const allowedRemoteToolNames = forwardedAllowedRemoteToolNames === undefined
+  const grantedRemoteToolNames = forwardedAllowedRemoteToolNames === undefined
     ? undefined
     : mergeRemoteToolNames(
       sourceAllowedRemoteToolNames,
       forwardedAllowedRemoteToolNames,
+    );
+  // A restrictive toolAllowlist caps remote exposure too: it intersects the
+  // tightest existing remote filter (forwarded grants, else the agent source's
+  // own __vfAllowedRemoteTools), and with neither present it becomes the
+  // remote filter directly. It can only narrow what the agent's sources
+  // already expose, never add.
+  const runtimeToolAllowlist = getRuntimeToolAllowlist(input.forwardedProps);
+  const sourceRemoteFilterBase = Object.hasOwn(agent.config, "__vfAllowedRemoteTools")
+    ? sourceAllowedRemoteToolNames
+    : undefined;
+  const allowedRemoteToolNames = runtimeToolAllowlist === null
+    ? grantedRemoteToolNames
+    : (grantedRemoteToolNames ?? sourceRemoteFilterBase ?? [...runtimeToolAllowlist]).filter(
+      (toolName) => runtimeToolAllowlist.has(toolName),
     );
   const forwardedIntegrationToolDefs = getForwardedIntegrationToolDefinitions(input.forwardedProps);
   const availableForwardedToolNames = forwardedIntegrationToolDefs?.map((tool) => tool.name);
@@ -431,12 +508,16 @@ export async function createRuntimeAgentStreamResponse(
     ...(deps.localTools ?? {}),
     ...(sandboxTools.tools ?? {}),
   };
-  const mergedTools = buildMergedTools(
+  const mergedTools = applyRuntimeToolAllowlist(
+    buildMergedTools(
+      agent,
+      input,
+      deps.sessionManager,
+      availableForwardedToolNames,
+      Object.keys(availableLocalTools).length > 0 ? availableLocalTools : undefined,
+    ),
+    runtimeToolAllowlist,
     agent,
-    input,
-    deps.sessionManager,
-    availableForwardedToolNames,
-    Object.keys(availableLocalTools).length > 0 ? availableLocalTools : undefined,
   );
   const runtimeAgent: RuntimeFilteredAgent = {
     ...agent,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1004";
+export const VERSION = "0.1.1005";


### PR DESCRIPTION
## Summary

Scheduled automation runs had no way to restrict the tool surface exposed to the model: the veryfront-ops-agent schedule declared `input.runtimeOverrides.allowedTools: ["read_baseline"]` and the run still called `fingerprint_finding`, `search_issues`, and `create_issue` (#2766, observed on `run_debb1931` via api.veryfront.org).

Root cause is a semantics collision, not a missing forward: veryfront-api spreads schedule `input` verbatim into the run's `forwardedProps` (`trigger-schedule-run.ts`), so `runtimeOverrides.allowedTools` **did** reach the internal agent run path — but that path treats `allowedTools` as an **additive grant list** (Studio forwards integration/studio tool names to attach on top of the agent's own surface; see `mergeRemoteToolNames` and the handler's Studio-gating sanitizer). Reinterpreting the same field as a restriction would strip agents' own tools on every Studio run that forwards integration grants, so it cannot be changed in place.

## Fix

New explicitly-restrictive override, enforced in `createRuntimeAgentStreamResponse`:

- **`runtimeOverrides.toolAllowlist: string[]`** — the run's model-visible tool set is intersected with it: agent source tools, injected caller tools (`input.tools`), granted integration tools, and remote tool exposure are all capped. Skill runtime/delegation tools are preserved for skill-enabled agents, mirroring the hosted chat runtime's allowlist semantics (`resolveHostedRuntimeAllowedToolNames`).
- **Never widens**: remote exposure intersects the tightest existing filter (forwarded grants, else the agent source's own `__vfAllowedRemoteTools`); an allowlist entry naming a non-granted remote tool does not grant it.
- **Fails closed**: a present-but-malformed `toolAllowlist` yields an empty tool set, and it needs no trust sanitization because it can only remove capability.
- `allowedTools` keeps its existing additive contract on this path (now documented in code).

Schedule authors write:

```ts
input: { runtimeOverrides: { toolAllowlist: ["read_baseline"] } }
```

which flows through the API verbatim — no veryfront-api change needed.

Also bumps the package version to `0.1.1005` so merging publishes the enforcement.

Closes #2766

## Tests

- 4 new tests in `run-stream.test.ts` (restriction across source/injected/integration tools, skill-tool preservation, remote intersection incl. the no-widening case, malformed fail-closed) — all four verified to FAIL against main before the fix.
- `deno test --no-check --allow-all src/internal-agents/` — 11 passed (68 steps)
- `src/utils/version.test.ts` — passing with the bump pair
- `deno task typecheck` / `deno fmt --check` / `deno lint` — clean
