### PR TITLE
Fix API HTTP imports and proxy WebSocket idle timeout

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1005",
+  "version": "0.1.1006",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/platform/compat/http/types.ts
+++ b/src/platform/compat/http/types.ts
@@ -20,4 +20,5 @@ export interface WebSocketUpgradeResult {
 export interface WebSocketUpgradeOptions {
   protocol?: string;
   headers?: Headers | Record<string, string>;
+  idleTimeout?: number;
 }

--- a/src/platform/compat/http/websocket.test.ts
+++ b/src/platform/compat/http/websocket.test.ts
@@ -1,7 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { isWebSocketUpgrade, upgradeWebSocket } from "./websocket.ts";
+import {
+  isWebSocketUpgrade,
+  resolveDenoUpgradeWebSocketOptions,
+  upgradeWebSocket,
+} from "./websocket.ts";
 
 describe("platform/compat/http/websocket", () => {
   describe("isWebSocketUpgrade", () => {
@@ -60,6 +64,14 @@ describe("platform/compat/http/websocket", () => {
       } catch (e) {
         assertExists(e);
       }
+    });
+
+    it("passes idleTimeout through to Deno upgrade options", () => {
+      assertEquals(resolveDenoUpgradeWebSocketOptions({ idleTimeout: 0 }), { idleTimeout: 0 });
+      assertEquals(resolveDenoUpgradeWebSocketOptions({ protocol: "hmr", idleTimeout: 60 }), {
+        protocol: "hmr",
+        idleTimeout: 60,
+      });
     });
   });
 });

--- a/src/platform/compat/http/websocket.ts
+++ b/src/platform/compat/http/websocket.ts
@@ -34,10 +34,20 @@ function upgradeWebSocketDeno(
     });
   }
 
-  const denoOptions: Deno.UpgradeWebSocketOptions | undefined = options?.protocol
-    ? { protocol: options.protocol }
-    : undefined;
-
-  const { socket, response } = nativeDeno.upgradeWebSocket(request, denoOptions);
+  const { socket, response } = nativeDeno.upgradeWebSocket(
+    request,
+    resolveDenoUpgradeWebSocketOptions(options),
+  );
   return { socket, response };
+}
+
+export function resolveDenoUpgradeWebSocketOptions(
+  options?: WebSocketUpgradeOptions,
+): Deno.UpgradeWebSocketOptions | undefined {
+  if (!options?.protocol && options?.idleTimeout === undefined) return undefined;
+
+  return {
+    ...(options.protocol ? { protocol: options.protocol } : {}),
+    ...(options.idleTimeout !== undefined ? { idleTimeout: options.idleTimeout } : {}),
+  };
 }

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -23,7 +23,11 @@
 import { createProxyHandler, INTERNAL_PROXY_HEADERS, type ProxyConfig } from "./handler.ts";
 import { createCacheFromEnv } from "./cache/index.ts";
 import { isRetryableConnectionError } from "./retry.ts";
-import { closeBridgePeer, getServerWebSocketErrorLogLevel } from "./websocket-bridge.ts";
+import {
+  closeBridgePeer,
+  createProxyClientWebSocketUpgradeOptions,
+  getServerWebSocketErrorLogLevel,
+} from "./websocket-bridge.ts";
 import { register } from "../extensions/contracts.ts";
 import { importFirstPartyExtensionModule } from "#veryfront/extensions/first-party-import.ts";
 import type { AuthProvider } from "#veryfront/extensions/auth/index.ts";
@@ -199,7 +203,10 @@ function handleWebSocketUpgrade(req: Request, url: URL): Response {
     targetUrl: targetUrl.toString(),
   });
 
-  const { socket: clientSocket, response } = upgradeWebSocket(req);
+  const { socket: clientSocket, response } = upgradeWebSocket(
+    req,
+    createProxyClientWebSocketUpgradeOptions(),
+  );
 
   let serverSocket: WebSocket | null = null;
   let connectTimeoutId: ReturnType<typeof setTimeout> | null = null;

--- a/src/proxy/websocket-bridge.ts
+++ b/src/proxy/websocket-bridge.ts
@@ -1,3 +1,5 @@
+import type { WebSocketUpgradeOptions } from "#veryfront/platform/compat/http/index.ts";
+
 type BridgePeer = Pick<WebSocket, "close" | "readyState">;
 
 export type ServerWebSocketErrorLogLevel = "warn" | "error";
@@ -19,4 +21,10 @@ export function closeBridgePeer(peer: BridgePeer | null, code: number, reason: s
   if (!peer) return;
   if (peer.readyState !== WebSocket.OPEN && peer.readyState !== WebSocket.CONNECTING) return;
   peer.close(code, reason);
+}
+
+export function createProxyClientWebSocketUpgradeOptions(): WebSocketUpgradeOptions {
+  // Proxied project sockets use app-level heartbeats; Deno's transport idle timeout
+  // can close otherwise healthy bridges before the browser sends a data frame.
+  return { idleTimeout: 0 };
 }

--- a/src/proxy/websocket-proxy.test.ts
+++ b/src/proxy/websocket-proxy.test.ts
@@ -2,7 +2,11 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import { parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
-import { closeBridgePeer, getServerWebSocketErrorLogLevel } from "./websocket-bridge.ts";
+import {
+  closeBridgePeer,
+  createProxyClientWebSocketUpgradeOptions,
+  getServerWebSocketErrorLogLevel,
+} from "./websocket-bridge.ts";
 
 function isWebSocketUpgrade(req: Request): boolean {
   return req.headers.get("upgrade")?.toLowerCase() === "websocket";
@@ -164,6 +168,12 @@ describe("Proxy WebSocket Handler Tests", () => {
       closeBridgePeer(socket, 1011, "Server connection error");
 
       assertEquals(calls, [{ code: 1011, reason: "Server connection error" }]);
+    });
+  });
+
+  describe("Proxy client WebSocket upgrade options", () => {
+    it("disables Deno transport idle timeout for proxied browser sockets", () => {
+      assertEquals(createProxyClientWebSocketUpgradeOptions(), { idleTimeout: 0 });
     });
   });
 });

--- a/src/routing/api/module-loader/esbuild-plugin.test.ts
+++ b/src/routing/api/module-loader/esbuild-plugin.test.ts
@@ -1,9 +1,15 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { computeIntegrity } from "#veryfront/utils";
 import { createHTTPPlugin } from "./esbuild-plugin.ts";
 import * as esbuild from "veryfront/extensions/bundler";
-import type { OnResolveArgs, PluginBuild, ResolveResult } from "veryfront/extensions/bundler";
+import type {
+  OnLoadArgs,
+  OnResolveArgs,
+  PluginBuild,
+  ResolveResult,
+} from "veryfront/extensions/bundler";
 
 function createMockBuild(
   onResolve: PluginBuild["onResolve"],
@@ -16,7 +22,6 @@ function createMockBuild(
     external: false,
     sideEffects: false,
     namespace: "",
-    suffix: "",
     pluginData: null,
   };
 
@@ -29,7 +34,7 @@ function createMockBuild(
     onLoad,
     onDispose: () => {},
     esbuild,
-  };
+  } as unknown as PluginBuild;
 }
 
 describe("routing/api/module-loader/esbuild-plugin", () => {
@@ -265,6 +270,194 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
 
       assertEquals((result as { path: string }).path, "https://esm.sh/react");
       assertEquals((result as { namespace: string }).namespace, "http-url");
+    });
+
+    it("serves a previously fetched remote module when the CDN later returns an error", async () => {
+      const originalFetch = globalThis.fetch;
+      const projectDir = await Deno.makeTempDir();
+      const moduleSource = "export const parsed = true;";
+      const requestUrl = "https://esm.sh/yaml@2";
+      const resolvedUrl = "https://esm.sh/yaml@2?target=es2020&bundle=true";
+
+      const load = (fetchImpl: typeof fetch) => {
+        globalThis.fetch = fetchImpl;
+        let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
+        const plugin = createHTTPPlugin({ allowedHosts: ["https://esm.sh"], projectDir });
+        const mockBuild = createMockBuild(
+          () => {},
+          (_opts, fn) => {
+            loadHandler = fn;
+          },
+        );
+        plugin.setup(mockBuild);
+        assertExists(loadHandler);
+        return loadHandler({
+          path: requestUrl,
+          namespace: "http-url",
+          pluginData: undefined,
+          suffix: "",
+        });
+      };
+
+      try {
+        const first = await load(
+          (async () =>
+            new Response(moduleSource, {
+              status: 200,
+              headers: { "content-type": "application/javascript" },
+            })) as typeof fetch,
+        );
+        assertEquals((first as { contents: string }).contents, moduleSource);
+
+        const lockfileText = await Deno.readTextFile(`${projectDir}/veryfront.lock`);
+        const lockfile = JSON.parse(lockfileText) as {
+          imports: Record<string, { resolved: string; integrity: string }>;
+        };
+        assertEquals(lockfile.imports[requestUrl]?.resolved, resolvedUrl);
+        assertEquals(lockfile.imports[requestUrl]?.integrity, await computeIntegrity(moduleSource));
+
+        const second = await load(
+          (async () => new Response("cdn unavailable", { status: 599 })) as typeof fetch,
+        );
+        assertEquals((second as { contents: string }).contents, moduleSource);
+      } finally {
+        globalThis.fetch = originalFetch;
+        await Deno.remove(projectDir, { recursive: true }).catch(() => {});
+      }
+    });
+
+    it("retries transient remote module fetch failures before returning an error", async () => {
+      const originalFetch = globalThis.fetch;
+      let attempts = 0;
+      let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
+      const plugin = createHTTPPlugin({ allowedHosts: ["https://esm.sh"] });
+      const mockBuild = createMockBuild(
+        () => {},
+        (_opts, fn) => {
+          loadHandler = fn;
+        },
+      );
+      plugin.setup(mockBuild);
+      assertExists(loadHandler);
+
+      try {
+        globalThis.fetch = (async () => {
+          attempts += 1;
+          if (attempts < 3) return new Response("unavailable", { status: 503 });
+          return new Response("export const ok = true;", { status: 200 });
+        }) as typeof fetch;
+
+        const result = await loadHandler({
+          path: "https://esm.sh/yaml@2",
+          namespace: "http-url",
+          pluginData: undefined,
+          suffix: "",
+        });
+
+        assertEquals((result as { contents: string }).contents, "export const ok = true;");
+        assertEquals(attempts, 3);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("rejects cached remote modules whose integrity no longer matches the lockfile", async () => {
+      const originalFetch = globalThis.fetch;
+      const projectDir = await Deno.makeTempDir();
+      const firstSource = "export const value = 'first';";
+      const secondSource = "export const value = 'second';";
+      const requestUrl = "https://esm.sh/yaml@2";
+      const firstIntegrity = await computeIntegrity(firstSource);
+
+      const load = (fetchImpl: typeof fetch) => {
+        globalThis.fetch = fetchImpl;
+        let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
+        const plugin = createHTTPPlugin({ allowedHosts: ["https://esm.sh"], projectDir });
+        const mockBuild = createMockBuild(
+          () => {},
+          (_opts, fn) => {
+            loadHandler = fn;
+          },
+        );
+        plugin.setup(mockBuild);
+        assertExists(loadHandler);
+        return loadHandler({
+          path: requestUrl,
+          namespace: "http-url",
+          pluginData: undefined,
+          suffix: "",
+        });
+      };
+
+      try {
+        await load((async () => new Response(firstSource, { status: 200 })) as typeof fetch);
+
+        const lockfileText = await Deno.readTextFile(`${projectDir}/veryfront.lock`);
+        const lockfile = JSON.parse(lockfileText) as {
+          imports: Record<string, { resolved: string; integrity: string }>;
+        };
+        assertEquals(lockfile.imports[requestUrl]?.integrity, firstIntegrity);
+        lockfile.imports[requestUrl]!.integrity = await computeIntegrity(secondSource);
+        await Deno.writeTextFile(`${projectDir}/veryfront.lock`, JSON.stringify(lockfile));
+
+        const result = await load(
+          (async () => new Response("cdn unavailable", { status: 599 })) as typeof fetch,
+        );
+
+        assertEquals("errors" in (result as Record<string, unknown>), true);
+      } finally {
+        globalThis.fetch = originalFetch;
+        await Deno.remove(projectDir, { recursive: true }).catch(() => {});
+      }
+    });
+
+    it("refetches instead of serving stale cache when a lockfile URL returns new content", async () => {
+      const originalFetch = globalThis.fetch;
+      const projectDir = await Deno.makeTempDir();
+      const oldSource = "export const value = 'old';";
+      const newSource = "export const value = 'new';";
+      const requestUrl = "https://esm.sh/yaml@2";
+      let fetchMode: "old" | "new" = "old";
+      let attempts = 0;
+
+      const load = () => {
+        globalThis.fetch = (async () => {
+          attempts += 1;
+          return new Response(fetchMode === "old" ? oldSource : newSource, { status: 200 });
+        }) as typeof fetch;
+
+        let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
+        const plugin = createHTTPPlugin({ allowedHosts: ["https://esm.sh"], projectDir });
+        const mockBuild = createMockBuild(
+          () => {},
+          (_opts, fn) => {
+            loadHandler = fn;
+          },
+        );
+        plugin.setup(mockBuild);
+        assertExists(loadHandler);
+        return loadHandler({
+          path: requestUrl,
+          namespace: "http-url",
+          pluginData: undefined,
+          suffix: "",
+        });
+      };
+
+      try {
+        const first = await load();
+        assertEquals((first as { contents: string }).contents, oldSource);
+
+        fetchMode = "new";
+        attempts = 0;
+        const second = await load();
+
+        assertEquals((second as { contents: string }).contents, newSource);
+        assertEquals(attempts, 2);
+      } finally {
+        globalThis.fetch = originalFetch;
+        await Deno.remove(projectDir, { recursive: true }).catch(() => {});
+      }
     });
   });
 });

--- a/src/routing/api/module-loader/esbuild-plugin.ts
+++ b/src/routing/api/module-loader/esbuild-plugin.ts
@@ -1,4 +1,5 @@
 import {
+  computeHash,
   computeIntegrity,
   createLockfileManager,
   HTTP_MODULE_FETCH_TIMEOUT_MS,
@@ -6,9 +7,14 @@ import {
   type LockfileManager,
   serverLogger,
 } from "#veryfront/utils";
+import { createFileSystem, type FileSystem } from "#veryfront/platform/compat/fs.ts";
+import * as pathHelper from "#veryfront/compat/path";
 import type { Message, Plugin } from "veryfront/extensions/bundler";
 
 const logger = serverLogger.component("api");
+const HTTP_MODULE_CACHE_DIR = ".veryfront/cache/api-http-imports";
+const HTTP_MODULE_FETCH_MAX_ATTEMPTS = 3;
+const HTTP_MODULE_FETCH_RETRY_DELAY_MS = 100;
 
 interface HTTPPluginOptions {
   allowedHosts: string[];
@@ -17,11 +23,120 @@ interface HTTPPluginOptions {
   strict?: boolean;
 }
 
+interface CachedHTTPModuleMetadata {
+  url: string;
+  resolvedUrl: string;
+  integrity: string;
+  fetchedAt: string;
+}
+
+interface HTTPModuleCache {
+  read(url: string, expectedIntegrity?: string): Promise<string | null>;
+  write(
+    url: string,
+    contents: string,
+    resolvedUrl: string,
+    integrity: string,
+  ): Promise<void>;
+}
+
+function createHTTPModuleCache(projectDir: string | undefined): HTTPModuleCache | null {
+  if (!projectDir) return null;
+
+  const fs = createFileSystem();
+  const cacheDir = pathHelper.join(projectDir, HTTP_MODULE_CACHE_DIR);
+
+  async function cachePaths(
+    url: string,
+    integrity: string,
+  ): Promise<{ sourcePath: string; metadataPath: string }> {
+    const key = await computeHash(`${url}\n${integrity}`);
+    return {
+      sourcePath: pathHelper.join(cacheDir, `${key}.mjs`),
+      metadataPath: pathHelper.join(cacheDir, `${key}.json`),
+    };
+  }
+
+  async function readMetadata(
+    metadataPath: string,
+    fs: FileSystem,
+  ): Promise<CachedHTTPModuleMetadata | null> {
+    if (!await fs.exists(metadataPath)) return null;
+
+    try {
+      return JSON.parse(await fs.readTextFile(metadataPath)) as CachedHTTPModuleMetadata;
+    } catch (error) {
+      logger.debug(`[http] ignoring unreadable module cache metadata: ${error}`);
+      return null;
+    }
+  }
+
+  return {
+    async read(url: string, expectedIntegrity?: string): Promise<string | null> {
+      if (!expectedIntegrity) return null;
+
+      try {
+        const { sourcePath, metadataPath } = await cachePaths(url, expectedIntegrity);
+        if (!await fs.exists(sourcePath)) return null;
+
+        const contents = await fs.readTextFile(sourcePath);
+        const integrity = await computeIntegrity(contents);
+        if (expectedIntegrity && integrity !== expectedIntegrity) {
+          logger.warn(`[http] cached module integrity mismatch: ${url}`);
+          return null;
+        }
+
+        const metadata = await readMetadata(metadataPath, fs);
+        if (metadata?.integrity && metadata.integrity !== integrity) {
+          logger.warn(`[http] cached module metadata integrity mismatch: ${url}`);
+          return null;
+        }
+
+        return contents;
+      } catch (error) {
+        logger.debug(`[http] module cache read miss for ${url}: ${error}`);
+        return null;
+      }
+    },
+
+    async write(
+      url: string,
+      contents: string,
+      resolvedUrl: string,
+      integrity: string,
+    ): Promise<void> {
+      try {
+        await fs.mkdir(cacheDir, { recursive: true });
+        const { sourcePath, metadataPath } = await cachePaths(url, integrity);
+        await fs.writeTextFile(sourcePath, contents);
+        await fs.writeTextFile(
+          metadataPath,
+          `${
+            JSON.stringify(
+              {
+                url,
+                resolvedUrl,
+                integrity,
+                fetchedAt: new Date().toISOString(),
+              } satisfies CachedHTTPModuleMetadata,
+              null,
+              2,
+            )
+          }\n`,
+        );
+      } catch (error) {
+        logger.debug(`[http] could not update module cache for ${url}: ${error}`);
+      }
+    },
+  };
+}
+
 export function createHTTPPlugin(options: HTTPPluginOptions | string[]): Plugin {
   const opts: HTTPPluginOptions = Array.isArray(options) ? { allowedHosts: options } : options;
   const { allowedHosts, strict = false } = opts;
   const lockfile = opts.lockfile ??
     (opts.projectDir ? createLockfileManager(opts.projectDir) : null);
+  const moduleCache = createHTTPModuleCache(opts.projectDir);
 
   return {
     name: "vf-api-http-fetch",
@@ -42,6 +157,36 @@ export function createHTTPPlugin(options: HTTPPluginOptions | string[]): Plugin 
         } finally {
           clearTimeout(timeout);
         }
+      }
+
+      function shouldRetryFetch(status: number): boolean {
+        return status === 429 || status >= 500 || status === HTTP_NETWORK_CONNECT_TIMEOUT;
+      }
+
+      function delay(ms: number): Promise<void> {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+      }
+
+      async function fetchRemoteModule(url: string): Promise<Response> {
+        for (let attempt = 1; attempt <= HTTP_MODULE_FETCH_MAX_ATTEMPTS; attempt += 1) {
+          const response = await fetchWithTimeout(url).catch((error) =>
+            new Response(String(error?.message ?? error), {
+              status: HTTP_NETWORK_CONNECT_TIMEOUT,
+            })
+          );
+          if (!shouldRetryFetch(response.status) || attempt === HTTP_MODULE_FETCH_MAX_ATTEMPTS) {
+            return response;
+          }
+
+          logger.warn(
+            `[http] fetch attempt ${attempt} failed ${url} ${response.status}; retrying`,
+          );
+          await delay(HTTP_MODULE_FETCH_RETRY_DELAY_MS * attempt);
+        }
+
+        return new Response("Remote module fetch failed", {
+          status: HTTP_NETWORK_CONNECT_TIMEOUT,
+        });
       }
 
       build.onResolve({ filter: /^(http|https):\/\// }, (args) => ({
@@ -118,44 +263,81 @@ export function createHTTPPlugin(options: HTTPPluginOptions | string[]): Plugin 
           logger.warn("API URL parse failed", e);
         }
 
-        if (lockfile) {
-          const cached = await lockfile.get(args.path);
-          if (cached) {
-            logger.debug(`[http] lockfile hit: ${args.path}`);
-            try {
-              const res = await fetchWithTimeout(cached.resolved);
-              if (res.ok) {
-                const text = await res.text();
-                const integrity = await computeIntegrity(text);
+        const readCachedModule = async (
+          url: string | undefined,
+          expectedIntegrity?: string,
+        ): Promise<string | null> => {
+          if (!url || !moduleCache) return null;
+          return await moduleCache.read(url, expectedIntegrity);
+        };
 
-                if (integrity === cached.integrity) {
-                  return { contents: text, loader: "js" } as const;
-                }
+        const lockfileEntry = lockfile ? await lockfile.get(args.path) : null;
 
-                if (strict) {
-                  return {
-                    errors: [
-                      {
-                        text:
-                          `Integrity mismatch for ${args.path}: expected ${cached.integrity}, got ${integrity}`,
-                      } as Message,
-                    ],
-                  };
-                }
+        if (lockfileEntry) {
+          let canUseLockfileCacheFallback = true;
+          logger.debug(`[http] lockfile hit: ${args.path}`);
+          try {
+            const res = await fetchRemoteModule(lockfileEntry.resolved);
+            if (res.ok) {
+              const text = await res.text();
+              const integrity = await computeIntegrity(text);
 
-                logger.warn(`[http] integrity mismatch, refetching: ${args.path}`);
+              if (integrity === lockfileEntry.integrity) {
+                await moduleCache?.write(args.path, text, lockfileEntry.resolved, integrity);
+                await moduleCache?.write(
+                  lockfileEntry.resolved,
+                  text,
+                  lockfileEntry.resolved,
+                  integrity,
+                );
+                return { contents: text, loader: "js" } as const;
               }
-            } catch (_error) {
-              logger.warn(`[http] cached URL failed, refetching: ${args.path}`);
+
+              if (strict) {
+                return {
+                  errors: [
+                    {
+                      text:
+                        `Integrity mismatch for ${args.path}: expected ${lockfileEntry.integrity}, got ${integrity}`,
+                    } as Message,
+                  ],
+                };
+              }
+
+              canUseLockfileCacheFallback = false;
+              logger.warn(`[http] integrity mismatch, refetching: ${args.path}`);
+            } else {
+              logger.warn(
+                `[http] cached URL returned ${res.status}, trying module cache: ${args.path}`,
+              );
+            }
+          } catch (_error) {
+            logger.warn(`[http] cached URL failed, trying module cache: ${args.path}`);
+          }
+
+          if (canUseLockfileCacheFallback) {
+            const cachedText =
+              await readCachedModule(lockfileEntry.resolved, lockfileEntry.integrity) ??
+                await readCachedModule(args.path, lockfileEntry.integrity);
+            if (cachedText) {
+              logger.warn(`[http] serving cached remote import for ${args.path}`);
+              return { contents: cachedText, loader: "js" } as const;
             }
           }
         }
 
-        const res = await fetchWithTimeout(requestUrl).catch((e) => {
-          return new Response(String(e?.message ?? e), { status: HTTP_NETWORK_CONNECT_TIMEOUT });
-        });
+        const res = await fetchRemoteModule(requestUrl);
 
         if (!res.ok) {
+          const cachedText =
+            await readCachedModule(lockfileEntry?.resolved, lockfileEntry?.integrity) ??
+              await readCachedModule(requestUrl, lockfileEntry?.integrity) ??
+              await readCachedModule(args.path, lockfileEntry?.integrity);
+          if (cachedText) {
+            logger.warn(`[http] serving cached remote import for ${args.path}`);
+            return { contents: cachedText, loader: "js" } as const;
+          }
+
           logger.error(`[http] fetch failed ${requestUrl} ${res.status}`);
           return {
             errors: [
@@ -168,9 +350,9 @@ export function createHTTPPlugin(options: HTTPPluginOptions | string[]): Plugin 
 
         const text = await res.text();
         const resolvedUrl = res.url || requestUrl;
+        const integrity = await computeIntegrity(text);
 
         if (lockfile) {
-          const integrity = await computeIntegrity(text);
           await lockfile.set(args.path, {
             resolved: resolvedUrl,
             integrity,
@@ -179,6 +361,9 @@ export function createHTTPPlugin(options: HTTPPluginOptions | string[]): Plugin 
           await lockfile.flush();
           logger.debug(`[http] lockfile updated: ${args.path} -> ${resolvedUrl}`);
         }
+        await moduleCache?.write(args.path, text, resolvedUrl, integrity);
+        await moduleCache?.write(requestUrl, text, resolvedUrl, integrity);
+        await moduleCache?.write(resolvedUrl, text, resolvedUrl, integrity);
 
         return { contents: text, loader: "js" } as const;
       });

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -370,7 +370,7 @@ function loadAndTranspileModule(
         plugins: [
           createImportMapPlugin(projectDir, adapter, config),
           createAdapterResolvePlugin(adapter, projectDir),
-          createHTTPPlugin(allowedHosts),
+          createHTTPPlugin({ allowedHosts, projectDir }),
         ],
       });
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1005";
+export const VERSION = "0.1.1006";


### PR DESCRIPTION
## Summary
- Add retry plus integrity-verified persistent cache fallback for API HTTP imports used by request-time handler builds.
- Pass projectDir into the API HTTP plugin so lockfile and cache state are available during API handler builds.
- Disable Deno's default WebSocket idle timeout for browser sockets accepted by the proxy bridge while preserving app-level heartbeats.

## Issues
- Fixes veryfront/veryfront-studio#5538
- Fixes veryfront/veryfront-studio#5521

## Proof
- `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/routing/api/module-loader/esbuild-plugin.test.ts src/platform/compat/http/websocket.test.ts src/proxy/websocket-proxy.test.ts src/proxy/tracing.test.ts src/proxy/token-manager.test.ts src/discovery/transpiler.test.ts` passed: 9 files, 85 steps.
- `deno check src/routing/api/module-loader/esbuild-plugin.test.ts` passed.
- `deno fmt --check` passed for changed files.
- `deno lint` passed for changed files.
- `deno task typecheck` passed.
- Pre-push gate passed after clearing local telemetry env: format, lint, typecheck, and full unit suite `2292 passed (19374 steps), 0 failed`.

## Critical review
- Subagent critical review score: 94/100.
- Reviewer found no blocking issues after iteration. Remaining noted gap is live Deno socket behavior not covered by a real network E2E, but the platform adapter mapping and proxy option contract are covered directly.