### PR TITLE
Tighten toolAllowlist semantics: no implicit integration grants, cap providerTools

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1006",
+  "version": "0.1.1007",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/deno.lock
+++ b/deno.lock
@@ -5,6 +5,7 @@
     "jsr:@std/assert@^1.0.17": "1.0.19",
     "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/async@1.2.0": "1.2.0",
+    "jsr:@std/async@^1.1.0": "1.2.0",
     "jsr:@std/cli@1.0.28": "1.0.28",
     "jsr:@std/data-structures@^1.0.10": "1.1.1",
     "jsr:@std/dotenv@0.225.6": "0.225.6",
@@ -127,6 +128,7 @@
       "integrity": "87bdc2700fa98249d48a17cd72413352d3d3680dcfbdb64947fd0982d6bbf681",
       "dependencies": [
         "jsr:@std/assert@^1.0.17",
+        "jsr:@std/async@^1.1.0",
         "jsr:@std/data-structures",
         "jsr:@std/internal@^1.0.12"
       ]

--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -8,10 +8,23 @@ import type {
   AgentServiceSandboxToolsResult,
   CreateSandboxBashTool,
 } from "#veryfront/sandbox";
-import { type Tool, toolRegistry } from "#veryfront/tool";
+import { type RemoteToolSource, type Tool, toolRegistry } from "#veryfront/tool";
 import { __resetLoggerConfigForTests, type LogEntry } from "#veryfront/utils/logger/logger.ts";
 import { AgentRunSessionManager } from "./session-manager.ts";
 import { createRuntimeAgentStreamResponse } from "./run-stream.ts";
+
+function remoteToolSource(toolNames: string[]): RemoteToolSource {
+  return {
+    id: "test-remote-source",
+    listTools: async () =>
+      toolNames.map((name) => ({
+        name,
+        description: `${name} description`,
+        parameters: { type: "object", properties: {} },
+      })),
+    executeTool: async () => ({}),
+  };
+}
 
 function captureConsoleJsonLogs(): { getEntries: () => LogEntry[]; restore: () => void } {
   const originalLog = console.log;
@@ -556,6 +569,408 @@ describe("internal-agents/run-stream", () => {
     );
 
     assertEquals(capturedToolNames, []);
+  });
+
+  it("does not grant remote integration tools via the toolAllowlist fallback", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedAllowedRemoteTools: string[] | undefined;
+
+    const agent = {
+      id: "ops-agent",
+      config: {
+        id: "ops-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        tools: {
+          read_baseline: { description: "Read the telemetry baseline" },
+        },
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "ops-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+      forwardedProps: {
+        runtimeOverrides: {
+          // gmail__list_emails is integration-patterned and was neither
+          // granted nor forwarded as a definition: the fallback remote filter
+          // must not turn the allowlist entry into an implicit grant.
+          toolAllowlist: ["read_baseline", "gmail__list_emails"],
+        },
+      },
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        createRuntime: (runtimeAgent) => {
+          capturedAllowedRemoteTools = (
+            runtimeAgent.config as Agent["config"] & { __vfAllowedRemoteTools?: string[] }
+          ).__vfAllowedRemoteTools;
+          return {
+            stream: async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+          };
+        },
+      },
+    );
+
+    assertEquals(capturedAllowedRemoteTools, []);
+  });
+
+  it("does not treat forwarded integration defs as grants without allowedTools", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedAllowedRemoteTools: string[] | undefined;
+
+    const agent = {
+      id: "ops-agent",
+      config: {
+        id: "ops-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        tools: {
+          read_baseline: { description: "Read the telemetry baseline" },
+        },
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "ops-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+      forwardedProps: {
+        runtimeOverrides: {
+          // The caller forwarded a definition for gmail__list_emails, so the
+          // runtime can render metadata if it is otherwise granted, but the
+          // definition itself is not the grant channel.
+          toolAllowlist: ["gmail__list_emails"],
+          integrationToolDefinitions: [
+            {
+              name: "gmail__list_emails",
+              description: "List emails",
+              parameters: { type: "object", properties: {} },
+            },
+          ],
+        },
+      },
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        createRuntime: (runtimeAgent) => {
+          capturedAllowedRemoteTools = (
+            runtimeAgent.config as Agent["config"] & { __vfAllowedRemoteTools?: string[] }
+          ).__vfAllowedRemoteTools;
+          return {
+            stream: async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+          };
+        },
+      },
+    );
+
+    assertEquals(capturedAllowedRemoteTools, []);
+  });
+
+  it("keeps allowlisted forwarded integration tools granted by allowedTools", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedAllowedRemoteTools: string[] | undefined;
+
+    const agent = {
+      id: "ops-agent",
+      config: {
+        id: "ops-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        tools: {
+          read_baseline: { description: "Read the telemetry baseline" },
+        },
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "ops-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+      forwardedProps: {
+        runtimeOverrides: {
+          toolAllowlist: ["gmail__list_emails"],
+          allowedTools: ["gmail__list_emails"],
+          integrationToolDefinitions: [
+            {
+              name: "gmail__list_emails",
+              description: "List emails",
+              parameters: { type: "object", properties: {} },
+            },
+          ],
+        },
+      },
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        createRuntime: (runtimeAgent) => {
+          capturedAllowedRemoteTools = (
+            runtimeAgent.config as Agent["config"] & { __vfAllowedRemoteTools?: string[] }
+          ).__vfAllowedRemoteTools;
+          return {
+            stream: async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+          };
+        },
+      },
+    );
+
+    assertEquals(capturedAllowedRemoteTools, ["gmail__list_emails"]);
+  });
+
+  it("allows a toolAllowlist subset of declared remote-source tools named like integrations", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedAllowedRemoteTools: string[] | undefined;
+
+    const agent = {
+      id: "ops-agent",
+      config: {
+        id: "ops-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        tools: true,
+        __vfRemoteToolSources: [remoteToolSource([
+          "github__list_issues",
+          "github__delete_issue",
+        ])],
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "ops-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+      forwardedProps: {
+        runtimeOverrides: {
+          toolAllowlist: ["github__list_issues"],
+        },
+      },
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        createRuntime: (runtimeAgent) => {
+          capturedAllowedRemoteTools = (
+            runtimeAgent.config as Agent["config"] & { __vfAllowedRemoteTools?: string[] }
+          ).__vfAllowedRemoteTools;
+          return {
+            stream: async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+          };
+        },
+      },
+    );
+
+    assertEquals(capturedAllowedRemoteTools, ["github__list_issues"]);
+  });
+
+  it("strips all tools for an explicitly empty toolAllowlist", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedToolNames: string[] = [];
+
+    const agent = {
+      id: "ops-agent",
+      config: {
+        id: "ops-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        tools: {
+          read_baseline: { description: "Read the telemetry baseline" },
+        },
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "ops-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+      forwardedProps: {
+        runtimeOverrides: {
+          toolAllowlist: [],
+        },
+      },
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        createRuntime: (_agent, mergedTools) => {
+          capturedToolNames = Object.keys(mergedTools ?? {}).sort();
+          return {
+            stream: async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+          };
+        },
+      },
+    );
+
+    assertEquals(capturedToolNames, []);
+  });
+
+  it("caps providerTools to the toolAllowlist", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedProviderTools: string[] | undefined;
+
+    const agent = {
+      id: "ops-agent",
+      config: {
+        id: "ops-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        providerTools: ["web_search"],
+        tools: {
+          read_baseline: { description: "Read the telemetry baseline" },
+        },
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "ops-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+      forwardedProps: {
+        runtimeOverrides: {
+          toolAllowlist: ["read_baseline"],
+        },
+      },
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        createRuntime: (runtimeAgent) => {
+          capturedProviderTools = runtimeAgent.config.providerTools;
+          return {
+            stream: async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+          };
+        },
+      },
+    );
+
+    assertEquals(capturedProviderTools, []);
+  });
+
+  it("preserves invoke_agent delegation for skill-enabled agents under toolAllowlist", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedToolNames: string[] = [];
+
+    const agent = {
+      id: "ops-agent",
+      config: {
+        id: "ops-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        skills: true,
+        tools: {
+          read_baseline: { description: "Read the telemetry baseline" },
+          create_issue: { description: "File a GitHub issue" },
+          invoke_agent: { description: "Delegate to another agent" },
+        },
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "ops-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+      forwardedProps: {
+        runtimeOverrides: {
+          toolAllowlist: ["read_baseline"],
+        },
+      },
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(
+      input,
+      agent,
+      {
+        sessionManager,
+        createRuntime: (_agent, mergedTools) => {
+          capturedToolNames = Object.keys(mergedTools ?? {}).sort();
+          return {
+            stream: async () =>
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+          };
+        },
+      },
+    );
+
+    // Documented semantics (see applyRuntimeToolAllowlist): delegation tools
+    // survive the allowlist for skill-enabled agents, and child runs are NOT
+    // capped by this run's allowlist.
+    assertEquals(capturedToolNames, ["invoke_agent", "read_baseline"]);
   });
 
   it("compacts oversized internal runtime message history before streaming", async () => {

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -6,7 +6,10 @@ import {
 } from "#veryfront/agent";
 import { normalizeAgUiRuntimeMessages } from "#veryfront/agent/ag-ui/runtime-support.ts";
 import { compactForStep, estimateOverhead } from "#veryfront/chat/message-prep.ts";
-import type { RuntimeRemoteToolConfig } from "#veryfront/agent/runtime/mcp-server-tool-sources.ts";
+import {
+  getRuntimeRemoteToolSources,
+  type RuntimeRemoteToolConfig,
+} from "#veryfront/agent/runtime/mcp-server-tool-sources.ts";
 import {
   convertAgentRuntimeMessagesToProviderMessages,
   convertProviderMessagesToAgentRuntimeMessages,
@@ -24,7 +27,12 @@ import {
 } from "#veryfront/extensions/sandbox/index.ts";
 import { resolveHostedRuntimeAllowedToolNames } from "#veryfront/agent/hosted/runtime-essential-tools.ts";
 import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
-import { isToolVisibleTo, type Tool, toolRegistry } from "#veryfront/tool";
+import {
+  isToolVisibleTo,
+  type Tool,
+  type ToolExecutionContext,
+  toolRegistry,
+} from "#veryfront/tool";
 import { defineSchema, lazySchema } from "#veryfront/schemas/index.ts";
 import type { Schema } from "#veryfront/extensions/schema/index.ts";
 import {
@@ -376,14 +384,25 @@ function getRuntimeToolAllowlist(
  * Intersects the merged run tool set with the restrictive tool allowlist.
  * Skill runtime/delegation tools are preserved for skill-enabled agents,
  * mirroring the hosted chat runtime's allowlist semantics.
+ *
+ * The allowlist bounds this run's direct tool surface only: preserved skill
+ * delegation tools (`invoke_agent`) can spawn child runs whose tool assembly
+ * derives from the child agent's own config and is not capped by this run's
+ * allowlist. Strict schedules must exclude delegation via agent config.
  */
 function applyRuntimeToolAllowlist(
   mergedTools: Agent["config"]["tools"],
   toolAllowlist: ReadonlySet<string> | null,
   agent: Agent,
 ): Agent["config"]["tools"] {
-  if (!toolAllowlist || !mergedTools || mergedTools === true) {
+  if (!toolAllowlist || !mergedTools) {
     return mergedTools;
+  }
+  if (mergedTools === true) {
+    // buildMergedTools always expands `tools: true` into a concrete record,
+    // so this is unreachable; if that invariant ever breaks, fail closed
+    // rather than silently skipping enforcement.
+    return {};
   }
   const availableSkillIds = agent.config.skills === true
     ? ["*"]
@@ -448,6 +467,58 @@ function getForwardedIntegrationToolDefinitions(
   }));
 }
 
+function getRemoteToolDiscoveryContext(input: {
+  agent: Agent;
+  runInput: RuntimeRunAgentInput;
+  deps: RuntimeAgentStreamExecutionDeps;
+}): ToolExecutionContext {
+  return {
+    agentId: input.agent.id,
+    runId: input.runInput.runId,
+    ...(input.deps.projectAgentSandbox?.authToken
+      ? { authToken: input.deps.projectAgentSandbox.authToken }
+      : {}),
+    ...(input.deps.projectAgentSandbox?.projectId
+      ? { projectId: input.deps.projectAgentSandbox.projectId }
+      : {}),
+    ...(input.runInput.parentRunId ? { parentRunId: input.runInput.parentRunId } : {}),
+    ...(input.runInput.state !== undefined ? { state: input.runInput.state } : {}),
+    context: input.runInput.context,
+    forwardedProps: input.runInput.forwardedProps,
+  };
+}
+
+async function getDeclaredRemoteSourceToolNames(input: {
+  agent: Agent;
+  runInput: RuntimeRunAgentInput;
+  deps: RuntimeAgentStreamExecutionDeps;
+}): Promise<string[]> {
+  const sources = getRuntimeRemoteToolSources(input.agent.config);
+  if (!sources?.length) {
+    return [];
+  }
+
+  const context = getRemoteToolDiscoveryContext(input);
+  const toolNames = new Set<string>();
+  for (const source of sources) {
+    try {
+      for (const definition of await source.listTools(context)) {
+        if (typeof definition.name === "string" && definition.name.length > 0) {
+          toolNames.add(definition.name);
+        }
+      }
+    } catch (error) {
+      logger.warn("Failed to inspect remote tool source for restrictive allowlist fallback", {
+        runId: input.runInput.runId,
+        agentId: input.agent.id,
+        sourceId: source.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return [...toolNames];
+}
+
 function compactRuntimeMessagesForStream(
   messages: Message[],
   mergedTools: Agent["config"]["tools"],
@@ -487,22 +558,34 @@ export async function createRuntimeAgentStreamResponse(
       sourceAllowedRemoteToolNames,
       forwardedAllowedRemoteToolNames,
     );
+  const runtimeToolAllowlist = getRuntimeToolAllowlist(input.forwardedProps);
+  if (runtimeToolAllowlist === null && forwardedAllowedRemoteToolNames !== undefined) {
+    logger.debug(
+      "runtimeOverrides.allowedTools is additive on internal runs; use runtimeOverrides.toolAllowlist to restrict the run tool surface",
+      { runId: input.runId, agentId: agent.id },
+    );
+  }
+  const forwardedIntegrationToolDefs = getForwardedIntegrationToolDefinitions(input.forwardedProps);
+  const availableForwardedToolNames = forwardedIntegrationToolDefs?.map((tool) => tool.name);
   // A restrictive toolAllowlist caps remote exposure too: it intersects the
   // tightest existing remote filter (forwarded grants, else the agent source's
-  // own __vfAllowedRemoteTools), and with neither present it becomes the
-  // remote filter directly. It can only narrow what the agent's sources
-  // already expose, never add.
-  const runtimeToolAllowlist = getRuntimeToolAllowlist(input.forwardedProps);
+  // own __vfAllowedRemoteTools). With neither present, discover the agent's
+  // declared remote-source surface and intersect with that. A bare allowlist
+  // entry can narrow actual remote sources, but never becomes an implicit
+  // project-scoped integration grant (#2768).
   const sourceRemoteFilterBase = Object.hasOwn(agent.config, "__vfAllowedRemoteTools")
     ? sourceAllowedRemoteToolNames
     : undefined;
+  const remoteFallbackBase = runtimeToolAllowlist !== null &&
+      grantedRemoteToolNames === undefined &&
+      sourceRemoteFilterBase === undefined
+    ? await getDeclaredRemoteSourceToolNames({ agent, runInput: input, deps })
+    : undefined;
   const allowedRemoteToolNames = runtimeToolAllowlist === null
     ? grantedRemoteToolNames
-    : (grantedRemoteToolNames ?? sourceRemoteFilterBase ?? [...runtimeToolAllowlist]).filter(
+    : (grantedRemoteToolNames ?? sourceRemoteFilterBase ?? remoteFallbackBase ?? []).filter(
       (toolName) => runtimeToolAllowlist.has(toolName),
     );
-  const forwardedIntegrationToolDefs = getForwardedIntegrationToolDefinitions(input.forwardedProps);
-  const availableForwardedToolNames = forwardedIntegrationToolDefs?.map((tool) => tool.name);
   const sandboxTools = await buildProjectAgentSandboxTools({ agent, deps });
   const availableLocalTools = {
     ...(deps.localTools ?? {}),
@@ -519,11 +602,20 @@ export async function createRuntimeAgentStreamResponse(
     runtimeToolAllowlist,
     agent,
   );
+  // Provider-native tools (e.g. web_search) are provider-side and bypass the
+  // merged tool record, so cap them against the allowlist explicitly.
+  const cappedProviderTools =
+    runtimeToolAllowlist !== null && Array.isArray(agent.config.providerTools)
+      ? agent.config.providerTools.filter(
+        (toolName) => typeof toolName === "string" && runtimeToolAllowlist.has(toolName),
+      )
+      : undefined;
   const runtimeAgent: RuntimeFilteredAgent = {
     ...agent,
     config: {
       ...agent.config,
       tools: mergedTools,
+      ...(cappedProviderTools !== undefined ? { providerTools: cappedProviderTools } : {}),
       ...(allowedRemoteToolNames !== undefined
         ? { __vfAllowedRemoteTools: allowedRemoteToolNames }
         : {}),

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1006";
+export const VERSION = "0.1.1007";


### PR DESCRIPTION
## Summary

Tightens the `runtimeOverrides.toolAllowlist` contract shipped in #2767 so "restrictive, never widens" holds for the direct internal-agent run surface. Addresses #2768 and the MCP/tool-name regression called out in PR review.

## Changes

**1. Remote fallback no longer acts as an implicit integration grant** (`run-stream.ts`). When a run has no forwarded `allowedTools` grant and the agent has no `__vfAllowedRemoteTools`, the fallback now enumerates the agent's declared remote sources and intersects those declared tool names with `toolAllowlist`. A bare allowlist entry like `gmail__list_emails` no longer becomes an implicit project-scoped integration grant.

**2. MCP/source tools with double-underscore names are preserved.** The fallback no longer uses a brittle `x__y` name-shape heuristic. Legitimate source-backed tools such as `github__list_issues` survive when they are actually declared by a remote source and included in `toolAllowlist`.

**3. Forwarded integration definitions are metadata, not grants.** `integrationToolDefinitions` alone no longer grants access. Forwarded `allowedTools` remains the sanitized grant path for project-scoped remote integrations.

**4. `providerTools` are capped by the allowlist.** Provider-native tools such as `web_search` are intersected with `toolAllowlist` on the runtime agent config. Absent allowlist means unchanged behavior.

**5. Fail-closed guard + docs.** The defensive `mergedTools === true` branch now returns `{}` if that invariant ever breaks, and the `applyRuntimeToolAllowlist` JSDoc documents the `invoke_agent` delegation boundary.

**6. Version bump for publishing.** Bumps `0.1.1006 -> 0.1.1007` in `deno.json` and `src/utils/version-constant.ts`, and updates `deno.lock` so frozen/publish checks use the committed lockfile. `0.1.1006` is already published from `main` and would not carry this security fix.

## Tests

Added/updated focused coverage in `run-stream.test.ts` for:
- integration-patterned allowlist entry without grants -> excluded from the remote filter
- forwarded integration definitions without `allowedTools` -> not treated as grants
- forwarded integration tools granted by `allowedTools` -> kept
- source-backed double-underscore tools such as `github__list_issues` -> preserved when declared and allowlisted
- explicitly empty `toolAllowlist: []` -> all tools stripped
- `providerTools` capped to the allowlist
- `invoke_agent` preserved for skill-enabled agents under the documented delegation contract

Verification run locally after the `0.1.1007` bump:
- `deno test --no-check --allow-all src/utils/version.test.ts` — passed, 1 file / 21 steps / 0 failed
- `deno test --no-check --allow-all src/internal-agents/run-stream.test.ts` — passed, 1 file / 23 steps / 0 failed
- `deno fmt --check deno.json src/utils/version-constant.ts src/utils/version.test.ts src/internal-agents/run-stream.ts src/internal-agents/run-stream.test.ts` — passed
- `deno lint src/utils/version-constant.ts src/utils/version.test.ts src/internal-agents/run-stream.ts src/internal-agents/run-stream.test.ts` — passed
- `deno check src/utils/version-constant.ts src/utils/version.test.ts src/internal-agents/run-stream.ts src/internal-agents/run-stream.test.ts` — passed
- `deno check --frozen --lock=deno.lock src/utils/version-constant.ts src/utils/version.test.ts src/internal-agents/run-stream.ts src/internal-agents/run-stream.test.ts` — passed
- `deno test --frozen --lock=deno.lock --no-check --allow-all src/utils/version.test.ts src/internal-agents/run-stream.test.ts` — passed, 2 files / 44 steps / 0 failed

Closes #2768
