### PR TITLE
Handle read-only API import lockfiles

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1007",
+  "version": "0.1.1008",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/routing/api/module-loader/esbuild-plugin.test.ts
+++ b/src/routing/api/module-loader/esbuild-plugin.test.ts
@@ -361,6 +361,48 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
       }
     });
 
+    it("serves fetched modules when lockfile persistence fails", async () => {
+      const originalFetch = globalThis.fetch;
+      const moduleSource = "export const ok = true;";
+      let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
+      const plugin = createHTTPPlugin({
+        allowedHosts: ["https://esm.sh"],
+        lockfile: {
+          read: () => Promise.resolve(null),
+          write: () => Promise.reject(new Error("read-only filesystem")),
+          get: () => Promise.resolve(null),
+          set: () => Promise.resolve(),
+          has: () => Promise.resolve(false),
+          clear: () => Promise.resolve(),
+          flush: () => Promise.reject(new Error("read-only filesystem")),
+        },
+      });
+      const mockBuild = createMockBuild(
+        () => {},
+        (_opts, fn) => {
+          loadHandler = fn;
+        },
+      );
+      plugin.setup(mockBuild);
+      assertExists(loadHandler);
+
+      try {
+        globalThis.fetch = (async () =>
+          new Response(moduleSource, { status: 200 })) as typeof fetch;
+
+        const result = await loadHandler({
+          path: "https://esm.sh/yaml@2",
+          namespace: "http-url",
+          pluginData: undefined,
+          suffix: "",
+        });
+
+        assertEquals((result as { contents: string }).contents, moduleSource);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
     it("rejects cached remote modules whose integrity no longer matches the lockfile", async () => {
       const originalFetch = globalThis.fetch;
       const projectDir = await Deno.makeTempDir();

--- a/src/routing/api/module-loader/esbuild-plugin.test.ts
+++ b/src/routing/api/module-loader/esbuild-plugin.test.ts
@@ -363,7 +363,9 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
 
     it("serves fetched modules when lockfile persistence fails", async () => {
       const originalFetch = globalThis.fetch;
+      const originalWarn = console.warn;
       const moduleSource = "export const ok = true;";
+      const warnings: string[] = [];
       let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
       const plugin = createHTTPPlugin({
         allowedHosts: ["https://esm.sh"],
@@ -374,7 +376,8 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
           set: () => Promise.resolve(),
           has: () => Promise.resolve(false),
           clear: () => Promise.resolve(),
-          flush: () => Promise.reject(new Error("read-only filesystem")),
+          flush: () =>
+            Promise.reject(new Error("read-only filesystem: /app/project/veryfront.lock")),
         },
       });
       const mockBuild = createMockBuild(
@@ -387,6 +390,9 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
       assertExists(loadHandler);
 
       try {
+        console.warn = ((...args: unknown[]) => {
+          warnings.push(args.map(String).join(" "));
+        }) as typeof console.warn;
         globalThis.fetch = (async () =>
           new Response(moduleSource, { status: 200 })) as typeof fetch;
 
@@ -398,8 +404,12 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
         });
 
         assertEquals((result as { contents: string }).contents, moduleSource);
+        assertEquals(warnings.some((warning) => warning.includes("Error")), true);
+        assertEquals(warnings.some((warning) => warning.includes("veryfront.lock")), false);
+        assertEquals(warnings.some((warning) => warning.includes("/app/project")), false);
       } finally {
         globalThis.fetch = originalFetch;
+        console.warn = originalWarn;
       }
     });
 

--- a/src/routing/api/module-loader/esbuild-plugin.ts
+++ b/src/routing/api/module-loader/esbuild-plugin.ts
@@ -167,6 +167,25 @@ export function createHTTPPlugin(options: HTTPPluginOptions | string[]): Plugin 
         return new Promise((resolve) => setTimeout(resolve, ms));
       }
 
+      async function persistLockfileEntry(
+        url: string,
+        entry: {
+          resolved: string;
+          integrity: string;
+          fetchedAt: string;
+        },
+      ): Promise<void> {
+        if (!lockfile) return;
+
+        try {
+          await lockfile.set(url, entry);
+          await lockfile.flush();
+          logger.debug(`[http] lockfile updated: ${url} -> ${entry.resolved}`);
+        } catch (error) {
+          logger.warn(`[http] could not persist lockfile entry for ${url}: ${error}`);
+        }
+      }
+
       async function fetchRemoteModule(url: string): Promise<Response> {
         for (let attempt = 1; attempt <= HTTP_MODULE_FETCH_MAX_ATTEMPTS; attempt += 1) {
           const response = await fetchWithTimeout(url).catch((error) =>
@@ -352,15 +371,11 @@ export function createHTTPPlugin(options: HTTPPluginOptions | string[]): Plugin 
         const resolvedUrl = res.url || requestUrl;
         const integrity = await computeIntegrity(text);
 
-        if (lockfile) {
-          await lockfile.set(args.path, {
-            resolved: resolvedUrl,
-            integrity,
-            fetchedAt: new Date().toISOString(),
-          });
-          await lockfile.flush();
-          logger.debug(`[http] lockfile updated: ${args.path} -> ${resolvedUrl}`);
-        }
+        await persistLockfileEntry(args.path, {
+          resolved: resolvedUrl,
+          integrity,
+          fetchedAt: new Date().toISOString(),
+        });
         await moduleCache?.write(args.path, text, resolvedUrl, integrity);
         await moduleCache?.write(requestUrl, text, resolvedUrl, integrity);
         await moduleCache?.write(resolvedUrl, text, resolvedUrl, integrity);

--- a/src/routing/api/module-loader/esbuild-plugin.ts
+++ b/src/routing/api/module-loader/esbuild-plugin.ts
@@ -167,6 +167,14 @@ export function createHTTPPlugin(options: HTTPPluginOptions | string[]): Plugin 
         return new Promise((resolve) => setTimeout(resolve, ms));
       }
 
+      function describePersistenceError(error: unknown): string {
+        if (!(error instanceof Error)) return typeof error;
+
+        const code = (error as { code?: unknown }).code;
+        const name = error.name || "Error";
+        return typeof code === "string" && code ? `${name}(${code})` : name;
+      }
+
       async function persistLockfileEntry(
         url: string,
         entry: {
@@ -182,7 +190,11 @@ export function createHTTPPlugin(options: HTTPPluginOptions | string[]): Plugin 
           await lockfile.flush();
           logger.debug(`[http] lockfile updated: ${url} -> ${entry.resolved}`);
         } catch (error) {
-          logger.warn(`[http] could not persist lockfile entry for ${url}: ${error}`);
+          logger.warn(
+            `[http] could not persist lockfile entry for ${url}: ${
+              describePersistenceError(error)
+            }`,
+          );
         }
       }
 

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -790,6 +790,52 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
       /escapes project|Failed to load/i,
     );
   });
+
+  it("loads API handlers with remote imports when the project lockfile cannot be written", async () => {
+    const originalFetch = globalThis.fetch;
+    const realDir = await makeTempDir();
+    await fs.mkdir(join(realDir, "pages", "api"), { recursive: true });
+
+    await fs.writeTextFile(
+      join(realDir, "pages", "api", "articles-2.ts"),
+      [
+        `import { parse as parseYaml } from "https://esm.sh/yaml@2";`,
+        `export function GET() { return new Response(typeof parseYaml); }`,
+      ].join("\n"),
+    );
+
+    const tempRoot = await makeTempDir();
+    const virtualBase = join(tempRoot, `vf-nonexistent-${Date.now()}`);
+    const toReal = (path: string): string => path.replace(virtualBase, realDir);
+
+    const virtualAdapter: RuntimeAdapter = {
+      ...adapter,
+      fs: {
+        ...adapter.fs,
+        readFile: (path: string) => fs.readTextFile(toReal(path)),
+        exists: (path: string) => fs.exists(toReal(path)),
+      },
+    };
+
+    try {
+      globalThis.fetch = (async () =>
+        new Response(`export function parse() { return {}; }`, {
+          status: 200,
+          headers: { "content-type": "application/javascript" },
+        })) as typeof fetch;
+
+      const route = await loadHandlerModule({
+        projectDir: virtualBase,
+        modulePath: join(virtualBase, "pages", "api", "articles-2.ts"),
+        adapter: virtualAdapter,
+        config: undefined,
+      });
+
+      assertEquals(typeof route?.GET, "function");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 // VULN-FS-5: compiled-binary CJS loader must enforce project-root containment

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1007";
+export const VERSION = "0.1.1008";


### PR DESCRIPTION
## Summary
- Make API HTTP import lockfile persistence best-effort so read-only app filesystems do not abort handler builds.
- Keep successfully fetched remote modules usable even when veryfront.lock cannot be written.
- Add plugin-level and loader-level regressions for remote API imports with unwritable lockfiles.

## Test Plan
- deno fmt src/routing/api/module-loader/esbuild-plugin.ts src/routing/api/module-loader/esbuild-plugin.test.ts src/routing/api/module-loader/loader.test.ts
- deno test --no-check --allow-all src/routing/api/module-loader/esbuild-plugin.test.ts src/routing/api/module-loader/loader.test.ts
- pre-push hook: format, lint, type check, unit tests