### PR TITLE
Truncate oversized run-event payloads at the durable append boundary

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1008",
+  "version": "0.1.1009",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/conversation/durable-append-errors.test.ts
+++ b/src/agent/conversation/durable-append-errors.test.ts
@@ -5,6 +5,7 @@ import {
   AppendConversationRunEventsError,
   isCursorMismatchConversationRunAppendError,
   isIgnorableConversationRunAppendError,
+  isPayloadTooLargeConversationRunAppendError,
   parseAppendConversationRunEventsErrorBody,
 } from "./durable-append-errors.ts";
 
@@ -50,5 +51,31 @@ describe("agent/durable-append-errors", () => {
     assertEquals(isIgnorableConversationRunAppendError(upstreamFailure), false);
     assertEquals(isCursorMismatchConversationRunAppendError(cursorMismatch), true);
     assertEquals(isCursorMismatchConversationRunAppendError(terminal), false);
+  });
+
+  it("classifies oversized payload append failures as permanent", () => {
+    const oversizedEvent = new AppendConversationRunEventsError({
+      status: 400,
+      detail: "Agent run event payload must be less than 256 KB",
+    });
+    const oversizedSnapshot = new AppendConversationRunEventsError({
+      status: 400,
+      detail: "Agent run request snapshot payload must be less than 2 MB",
+    });
+    const cursorMismatch = new AppendConversationRunEventsError({
+      status: 400,
+      detail: "External run event cursor mismatch",
+    });
+    const upstreamFailure = new AppendConversationRunEventsError({
+      status: 500,
+      detail: "internal failure",
+    });
+
+    assertEquals(isPayloadTooLargeConversationRunAppendError(oversizedEvent), true);
+    assertEquals(isPayloadTooLargeConversationRunAppendError(oversizedSnapshot), true);
+    assertEquals(isPayloadTooLargeConversationRunAppendError(cursorMismatch), false);
+    assertEquals(isPayloadTooLargeConversationRunAppendError(upstreamFailure), false);
+    // A permanent oversize rejection must NOT be retried as a transient failure.
+    assertEquals(isIgnorableConversationRunAppendError(oversizedEvent), false);
   });
 });

--- a/src/agent/conversation/durable-append-errors.ts
+++ b/src/agent/conversation/durable-append-errors.ts
@@ -58,6 +58,23 @@ export function isIgnorableConversationRunAppendError(
   );
 }
 
+/**
+ * A payload-too-large rejection is permanent: the same bytes will be rejected on
+ * every retry, so the mirror must stop rather than retry-storm the API. The runtime
+ * normalizes events under the limit before appending, so reaching this is a bug —
+ * classify it distinctly so it can be surfaced loudly instead of silently ignored.
+ */
+export function isPayloadTooLargeConversationRunAppendError(
+  error: unknown,
+): error is AppendConversationRunEventsError {
+  return (
+    error instanceof AppendConversationRunEventsError &&
+    error.status === 400 &&
+    typeof error.detail === "string" &&
+    error.detail.includes("payload must be less than")
+  );
+}
+
 /** Error shape for is cursor mismatch conversation run append. */
 export function isCursorMismatchConversationRunAppendError(
   error: unknown,

--- a/src/agent/conversation/durable-contracts.ts
+++ b/src/agent/conversation/durable-contracts.ts
@@ -192,7 +192,11 @@ export interface ConversationRunEventQueueController {
       pendingEventCount: 0;
       consecutiveFailures: number;
       disabled: true;
-      disableReason?: "cursor_resyncs_exhausted" | "non_appendable" | "ignorable_append_rejection";
+      disableReason?:
+        | "cursor_resyncs_exhausted"
+        | "non_appendable"
+        | "ignorable_append_rejection"
+        | "payload_too_large";
     }
     | {
       outcome: "retry_scheduled";

--- a/src/agent/conversation/durable.test.ts
+++ b/src/agent/conversation/durable.test.ts
@@ -393,6 +393,48 @@ describe("agent/durable", () => {
     });
   });
 
+  it("clamps oversized events to the payload limit before appending", async () => {
+    const fetchCalls = stubFetchSequence(
+      jsonResponse(
+        {
+          latest_event_id: 2,
+          latest_external_event_sequence: 2,
+          appended_count: 1,
+          run: {
+            run_id: "run_root_1",
+            conversation_id: CONVERSATION_ID,
+            latest_event_id: 2,
+            latest_external_event_sequence: 2,
+          },
+        },
+        200,
+      ),
+    );
+
+    // A raw, un-normalized oversized tool result — as produced by any append path
+    // that skipped normalization. The chokepoint must clamp it so the API (256 KB
+    // per-event limit) never sees an oversized event.
+    await appendConversationRunEvents({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      runId: "run_root_1",
+      events: [{
+        type: "TOOL_CALL_RESULT",
+        toolCallId: "tc_big",
+        content: "z".repeat(400 * 1024),
+      }],
+    });
+
+    const body = JSON.parse(String(fetchCalls[0]?.[1]?.body));
+    for (const event of body.events) {
+      assertEquals(
+        new TextEncoder().encode(JSON.stringify(event)).byteLength <= 256 * 1024,
+        true,
+      );
+    }
+  });
+
   it("appends conversation run events and parses snake_case responses", async () => {
     const fetchCalls = stubFetchSequence(
       jsonResponse(
@@ -1283,6 +1325,29 @@ describe("agent/durable", () => {
         latestEventId: 2,
         latestExternalEventSequence: 4,
         disableReason: "ignorable_append_rejection",
+      },
+    );
+
+    assertEquals(
+      await recoverConversationRunAppendFailure({
+        error: new AppendConversationRunEventsError({
+          status: 400,
+          detail: "Agent run event payload must be less than 256 KB",
+        }),
+        authToken: AUTH_TOKEN,
+        apiUrl: API_URL,
+        conversationId: CONVERSATION_ID,
+        runId: "run_append_failure_oversized",
+        latestEventId: 2,
+        latestExternalEventSequence: 4,
+        cursorResyncsThisFlush: 0,
+        maxCursorResyncsPerFlush: 3,
+      }),
+      {
+        outcome: "stopped",
+        latestEventId: 2,
+        latestExternalEventSequence: 4,
+        disableReason: "payload_too_large",
       },
     );
 

--- a/src/agent/conversation/durable.ts
+++ b/src/agent/conversation/durable.ts
@@ -22,6 +22,7 @@ import {
   AppendConversationRunEventsError,
   isCursorMismatchConversationRunAppendError,
   isIgnorableConversationRunAppendError,
+  isPayloadTooLargeConversationRunAppendError,
   parseAppendConversationRunEventsErrorBody,
 } from "./durable-append-errors.ts";
 
@@ -46,6 +47,7 @@ export {
   isIgnorableConversationRunAppendError,
   parseAppendConversationRunEventsErrorBody,
 } from "./durable-append-errors.ts";
+import { normalizeConversationRunEvents } from "./run-event-normalization.ts";
 export type {
   ActiveConversationRunStatus,
   AppendConversationRunEventsResponse,
@@ -256,7 +258,11 @@ export async function recoverConversationRunAppendFailure(input: {
   outcome: ConversationRunAppendFailureOutcome;
   latestEventId: number;
   latestExternalEventSequence: number;
-  disableReason?: "cursor_resyncs_exhausted" | "non_appendable" | "ignorable_append_rejection";
+  disableReason?:
+    | "cursor_resyncs_exhausted"
+    | "non_appendable"
+    | "ignorable_append_rejection"
+    | "payload_too_large";
   errorMessage?: string;
   run?: ConversationRunProjection;
 }> {
@@ -302,6 +308,18 @@ export async function recoverConversationRunAppendFailure(input: {
     };
   }
 
+  // Permanent: the same bytes fail every retry. Stop instead of retry-storming the
+  // API (the runtime normalizes under the limit before appending, so this is a bug).
+  if (isPayloadTooLargeConversationRunAppendError(input.error)) {
+    return {
+      outcome: "stopped",
+      latestEventId: cursorRecovery.latestEventId,
+      latestExternalEventSequence: cursorRecovery.latestExternalEventSequence,
+      disableReason: "payload_too_large",
+      ...(cursorRecovery.run ? { run: cursorRecovery.run } : {}),
+    };
+  }
+
   return {
     outcome: "retry_scheduled",
     latestEventId: cursorRecovery.latestEventId,
@@ -338,7 +356,11 @@ export async function recoverConversationRunAppendExecution(input: {
     outcome: "stopped";
     latestEventId: number;
     latestExternalEventSequence: number;
-    disableReason?: "cursor_resyncs_exhausted" | "non_appendable" | "ignorable_append_rejection";
+    disableReason?:
+    | "cursor_resyncs_exhausted"
+    | "non_appendable"
+    | "ignorable_append_rejection"
+    | "payload_too_large";
   }
   | {
     outcome: "retry_scheduled";
@@ -464,7 +486,11 @@ export async function flushConversationRunEventBatches(input: {
     outcome: "stopped";
     latestEventId: number;
     latestExternalEventSequence: number;
-    disableReason?: "cursor_resyncs_exhausted" | "non_appendable" | "ignorable_append_rejection";
+    disableReason?:
+    | "cursor_resyncs_exhausted"
+    | "non_appendable"
+    | "ignorable_append_rejection"
+    | "payload_too_large";
   }
 > {
   const batches = buildConversationRunEventBatches({
@@ -563,7 +589,11 @@ export async function flushConversationRunEventQueue(input: {
     outcome: "stopped";
     latestEventId: number;
     latestExternalEventSequence: number;
-    disableReason?: "cursor_resyncs_exhausted" | "non_appendable" | "ignorable_append_rejection";
+    disableReason?:
+    | "cursor_resyncs_exhausted"
+    | "non_appendable"
+    | "ignorable_append_rejection"
+    | "payload_too_large";
   }
   | {
     outcome: "retry_scheduled";
@@ -953,7 +983,14 @@ export async function appendConversationRunEvents(input: {
                 input.expectedPreviousExternalEventSequence,
             }
             : {}),
-          events: input.events,
+          // Chokepoint guard: every append path funnels through here, so enforce the
+          // per-event size limit here too. Upstream mirrors already normalize, but
+          // direct callers (hosted lifecycle, child-run progress) do not — this makes
+          // it impossible to POST an event the API would reject for size. Idempotent
+          // on already-normalized events.
+          events: normalizeConversationRunEvents(
+            input.events as Parameters<typeof normalizeConversationRunEvents>[0],
+          ),
         }),
         signal: timedAbort.signal,
       },

--- a/src/agent/conversation/durable.ts
+++ b/src/agent/conversation/durable.ts
@@ -357,10 +357,10 @@ export async function recoverConversationRunAppendExecution(input: {
     latestEventId: number;
     latestExternalEventSequence: number;
     disableReason?:
-    | "cursor_resyncs_exhausted"
-    | "non_appendable"
-    | "ignorable_append_rejection"
-    | "payload_too_large";
+      | "cursor_resyncs_exhausted"
+      | "non_appendable"
+      | "ignorable_append_rejection"
+      | "payload_too_large";
   }
   | {
     outcome: "retry_scheduled";
@@ -487,10 +487,10 @@ export async function flushConversationRunEventBatches(input: {
     latestEventId: number;
     latestExternalEventSequence: number;
     disableReason?:
-    | "cursor_resyncs_exhausted"
-    | "non_appendable"
-    | "ignorable_append_rejection"
-    | "payload_too_large";
+      | "cursor_resyncs_exhausted"
+      | "non_appendable"
+      | "ignorable_append_rejection"
+      | "payload_too_large";
   }
 > {
   const batches = buildConversationRunEventBatches({
@@ -590,10 +590,10 @@ export async function flushConversationRunEventQueue(input: {
     latestEventId: number;
     latestExternalEventSequence: number;
     disableReason?:
-    | "cursor_resyncs_exhausted"
-    | "non_appendable"
-    | "ignorable_append_rejection"
-    | "payload_too_large";
+      | "cursor_resyncs_exhausted"
+      | "non_appendable"
+      | "ignorable_append_rejection"
+      | "payload_too_large";
   }
   | {
     outcome: "retry_scheduled";

--- a/src/agent/conversation/run-chunk-mirror.ts
+++ b/src/agent/conversation/run-chunk-mirror.ts
@@ -294,6 +294,20 @@ function recordHostedChunkMirrorStopped(input: {
     return;
   }
 
+  if (input.flushAttempt.disableReason === "payload_too_large") {
+    input.instrumentation?.error?.(
+      "Disabling durable run mirroring after an oversized event was rejected; " +
+        "an event exceeded the durable payload limit despite normalization",
+      {
+        conversationId: input.conversationId,
+        runId: input.runId,
+        latestEventId: input.flushAttempt.latestEventId,
+        latestExternalEventSequence: input.flushAttempt.latestExternalEventSequence,
+      },
+    );
+    return;
+  }
+
   if (input.flushAttempt.disableReason === "ignorable_append_rejection") {
     input.instrumentation?.warn?.(
       "Disabling durable run mirroring after external append rejection",

--- a/src/agent/conversation/run-event-normalization.test.ts
+++ b/src/agent/conversation/run-event-normalization.test.ts
@@ -3,6 +3,7 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   getConversationRunEventJsonByteLength,
+  MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES,
   normalizeConversationRunEvent,
   normalizeConversationRunEvents,
 } from "./run-event-normalization.ts";
@@ -48,6 +49,38 @@ describe("agent/conversation-run-event-normalization", () => {
     );
   });
 
+  it("keeps oversized tool results with escape-heavy content within the byte limit", () => {
+    // Every `"` serializes to `\"` (2 bytes) in JSON, so truncating by raw UTF-8
+    // bytes undershoots the JSON-measured limit the API actually enforces.
+    const escapeHeavyContent = '"'.repeat(300 * 1024);
+    const [result] = normalizeConversationRunEvent({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "tc_escape",
+      content: escapeHeavyContent,
+    });
+
+    assertEquals(
+      getConversationRunEventJsonByteLength(result) <= MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES,
+      true,
+    );
+  });
+
+  it("keeps tool results whose oversized data is outside content within the byte limit", () => {
+    // The large payload lives in `input`, not `content`; the tool-result summarizer
+    // must still clamp the whole event, not just the `content` field.
+    const [result] = normalizeConversationRunEvent({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "tc_input",
+      content: "ok",
+      input: { blob: "x".repeat(300 * 1024) },
+    });
+
+    assertEquals(
+      getConversationRunEventJsonByteLength(result) <= MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES,
+      true,
+    );
+  });
+
   it("summarizes oversized generic events", () => {
     const [result] = normalizeConversationRunEvent({
       type: "SOME_OTHER_TYPE",
@@ -59,6 +92,34 @@ describe("agent/conversation-run-event-normalization", () => {
       String(result?.note ?? "").includes("summarized to stay within storage limits"),
       true,
     );
+  });
+
+  it("keeps oversized generic events within the byte limit", () => {
+    const [result] = normalizeConversationRunEvent({
+      type: "SOME_OTHER_TYPE",
+      payload: "x".repeat(300 * 1024),
+    });
+
+    assertEquals(
+      getConversationRunEventJsonByteLength(result) <= MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES,
+      true,
+    );
+  });
+
+  it("keeps every split part of escape-heavy delta events within the byte limit", () => {
+    const escapeHeavyDelta = '"'.repeat(300 * 1024);
+    const parts = normalizeConversationRunEvent({
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "m1",
+      delta: escapeHeavyDelta,
+    });
+
+    for (const part of parts) {
+      assertEquals(
+        getConversationRunEventJsonByteLength(part) <= MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES,
+        true,
+      );
+    }
   });
 
   it("normalizes whole event lists", () => {

--- a/src/agent/conversation/run-event-normalization.ts
+++ b/src/agent/conversation/run-event-normalization.ts
@@ -1,4 +1,4 @@
-const MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES = 240 * 1024;
+export const MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES = 240 * 1024;
 const MAX_SUMMARY_DEPTH = 4;
 const MAX_SUMMARY_ARRAY_ITEMS = 8;
 const MAX_SUMMARY_OBJECT_KEYS = 24;
@@ -32,6 +32,14 @@ export function normalizeConversationRunEvent(
     return [event];
   }
 
+  // Every summarizer output passes through enforceEventSizeLimit so the byte-limit
+  // invariant holds regardless of which branch (or future event type) ran.
+  return summarizeOversizedEvent(event).map(enforceEventSizeLimit);
+}
+
+function summarizeOversizedEvent(
+  event: ConversationRunEventRecord,
+): ConversationRunEventRecord[] {
   switch (event.type) {
     case "TEXT_MESSAGE_CONTENT":
     case "REASONING_CONTENT":
@@ -47,6 +55,34 @@ export function normalizeConversationRunEvent(
   }
 }
 
+/**
+ * Final invariant guard. Forces any event a type-specific summarizer left oversized
+ * (escape-heavy split parts, or a large non-string field) under the byte limit, so
+ * no normalization path can emit an event the API will reject.
+ */
+function enforceEventSizeLimit(event: ConversationRunEventRecord): ConversationRunEventRecord {
+  if (getConversationRunEventJsonByteLength(event) <= MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES) {
+    return event;
+  }
+
+  for (const field of ["delta", "content"] as const) {
+    if (typeof event[field] === "string") {
+      const clamped = truncateEventStringFieldToLimit(event, field, " [truncated]");
+      if (clamped) {
+        return clamped;
+      }
+    }
+  }
+
+  return {
+    type: event.type,
+    ...(typeof event.messageId === "string" ? { messageId: event.messageId } : {}),
+    ...(typeof event.toolCallId === "string" ? { toolCallId: event.toolCallId } : {}),
+    truncated: true,
+    note: "Conversation-run event payload exceeded the size limit and was omitted.",
+  };
+}
+
 /** Normalizes conversation run events. */
 export function normalizeConversationRunEvents(
   events: ConversationRunEventRecord[],
@@ -59,32 +95,37 @@ function summarizeToolResultEvent(event: ConversationRunEventRecord): Conversati
     return event;
   }
 
-  if (typeof event.content === "string") {
-    const maxResultBytes = getStringFieldBudget(event, "content");
-    return {
-      ...event,
-      content: truncateUtf8String(
-        event.content,
-        maxResultBytes,
-        " [tool result truncated in conversation-run event]",
-      ),
-    };
-  }
+  // The original tool `input` is redundant with the TOOL_CALL_ARGS event and can
+  // itself exceed the budget, so truncating only `content` would leave the event
+  // oversized. Drop it before measuring.
+  const { input: _input, ...eventWithoutInput } = event;
 
-  const summarizedEvent = {
-    ...event,
-    content: summarizeValue(event.content),
-  } satisfies ConversationRunEventRecord;
+  if (typeof eventWithoutInput.content === "string") {
+    const clamped = truncateEventStringFieldToLimit(
+      eventWithoutInput,
+      "content",
+      " [tool result truncated in conversation-run event]",
+    );
+    if (clamped) {
+      return clamped;
+    }
+    // The envelope alone exceeds the limit — fall through to the omitted-content placeholder.
+  } else {
+    const summarizedEvent = {
+      ...eventWithoutInput,
+      content: summarizeValue(eventWithoutInput.content),
+    } satisfies ConversationRunEventRecord;
 
-  if (
-    getConversationRunEventJsonByteLength(summarizedEvent) <=
-      MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES
-  ) {
-    return summarizedEvent;
+    if (
+      getConversationRunEventJsonByteLength(summarizedEvent) <=
+        MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES
+    ) {
+      return summarizedEvent;
+    }
   }
 
   return {
-    ...event,
+    ...eventWithoutInput,
     content: {
       truncated: true,
       originalType: describeValueType(event.content),
@@ -94,11 +135,67 @@ function summarizeToolResultEvent(event: ConversationRunEventRecord): Conversati
   };
 }
 
+/**
+ * Truncate a string field so the WHOLE event serializes within the byte limit.
+ * Measures the JSON-serialized event (not the raw string), so it stays correct
+ * for escape-heavy content that expands under JSON.stringify — the same unit the
+ * API enforces. Returns null when the envelope alone already exceeds the limit.
+ */
+function truncateEventStringFieldToLimit(
+  event: ConversationRunEventRecord,
+  field: "content" | "delta",
+  suffix: string,
+): ConversationRunEventRecord | null {
+  const value = event[field];
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const buildCandidate = (prefixLength: number): ConversationRunEventRecord =>
+    prefixLength >= value.length
+      ? event
+      : { ...event, [field]: `${value.slice(0, prefixLength)}${suffix}` };
+
+  if (
+    getConversationRunEventJsonByteLength(buildCandidate(value.length)) <=
+      MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES
+  ) {
+    return event;
+  }
+
+  if (
+    getConversationRunEventJsonByteLength(buildCandidate(0)) >
+      MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES
+  ) {
+    return null;
+  }
+
+  let low = 0;
+  let high = value.length;
+  let best = 0;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    if (
+      getConversationRunEventJsonByteLength(buildCandidate(mid)) <=
+        MAX_CONVERSATION_RUN_EVENT_PAYLOAD_BYTES
+    ) {
+      best = mid;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return buildCandidate(best);
+}
+
 function summarizeGenericEvent(event: ConversationRunEventRecord): ConversationRunEventRecord {
+  const { type, ...rest } = event;
   return {
-    ...event,
+    type,
     truncated: true,
     note: "Conversation-run event payload was summarized to stay within storage limits.",
+    summary: summarizeValue(rest),
   };
 }
 

--- a/src/agent/conversation/run-mirror.ts
+++ b/src/agent/conversation/run-mirror.ts
@@ -19,7 +19,11 @@ export interface ConversationRunMirrorStoppedState {
   pendingEventCount: 0;
   consecutiveFailures: number;
   disabled: true;
-  disableReason?: "cursor_resyncs_exhausted" | "non_appendable" | "ignorable_append_rejection";
+  disableReason?:
+    | "cursor_resyncs_exhausted"
+    | "non_appendable"
+    | "ignorable_append_rejection"
+    | "payload_too_large";
 }
 
 /** State for conversation run mirror retry scheduled. */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1008";
+export const VERSION = "0.1.1009";


### PR DESCRIPTION
## What & why

An agent run could **silently drop an oversized tool result and still report `completed`**, leaving the durable event log with a hole and the UI waiting on a tool result that never arrived (observed on staging as a run stuck on "Fetching from the web… / Continuing…"). Tracked in veryfront/veryfront-studio#5552.

Root cause: a large tool result (e.g. a big `web_fetch`) serializes past the API's 256 KB per-event limit on the durable append endpoint. A truncation layer already existed (`run-event-normalization.ts`) but was **bypassable** (only wired into some producer paths, not the append chokepoint) and **not size-correct** (it truncated by raw UTF-8 bytes while the API measures JSON-escaped bytes, never re-checked the total, and ignored the redundant `input` field). The rejected event was then retried ~34× with no give-up, and completion is decided on a separate lifecycle path, so the run reported success with the result missing.

## Changes

- **Enforce the size limit at the append chokepoint.** `appendConversationRunEvents` now normalizes every batch immediately before POST, so no producer path (hosted lifecycle, child-run progress, or a direct enqueue) can bypass it. Idempotent on already-normalized events.
- **Make normalization total and correct.** Measure JSON-serialized bytes (the unit the API enforces), drop the redundant tool `input`, truncate via a whole-event binary search, and add a backstop that guarantees **every** normalized event fits — regardless of event type, which field holds the bulk, or JSON escaping.
- **No more retry storm.** A payload-too-large rejection is now classified as permanent, so the durable mirror stops with an ERROR-level log instead of retrying the same rejected bytes forever.

## Why runtime-only (no API change)

Layers above make an oversized event unreachable at the source, and the API already degrades gracefully: `normalizeTerminalToolCallStates` flips any orphaned (result-less) tool call to a terminal state at finalize, so there is no permanent-pending. A schema flag / compensating-event layer / append-validation reorder would be over-engineering a now-near-impossible state — deliberately omitted.

## Testing

- TDD throughout (RED → GREEN). New tests: escape-heavy / non-`content` / generic / split-delta all stay within the byte limit; the append chokepoint clamps a raw oversized event; the oversize classifier + failure-handler routing to a permanent stop.
- Full `src/agent/conversation` unit suite green (18 files / 129 steps); `deno check` clean on all changed files.

## Follow-up

After this ships to npm, bump the `veryfront` dependency in `veryfront-agent` to pick it up on the hosted runtime.
