### PR TITLE
Bump version to 0.1.1010

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1009",
+  "version": "0.1.1010",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1009";
+export const VERSION = "0.1.1010";


### PR DESCRIPTION
Bumps Veryfront from 0.1.1009 to 0.1.1010 after #2773 merged.\n\nUpdated:\n- deno.json\n- src/utils/version-constant.ts\n\nLocal verification:\n- deno fmt --check deno.json src/utils/version-constant.ts\n- deno check src/utils/version-constant.ts cli/main.ts\n- deno test --no-check --allow-all cli/router.test.ts cli/shared/config.test.ts -> 6 passed, 78 steps, 0 failed\n- pre-push hook before branch push -> formatting, lint, typecheck, unit tests passed; 2292 passed, 0 failed