### PR TITLE
Honor cloud chat bootstrap watchdog timeouts

### DIFF
--- a/src/agent/hosted/cloud-prepared-chat-execution-runtime.test.ts
+++ b/src/agent/hosted/cloud-prepared-chat-execution-runtime.test.ts
@@ -1,11 +1,14 @@
 import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createChatStreamWatchdog } from "#veryfront/chat/stream-watchdog.ts";
+import { deleteEnv, getEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import type { AgentTraceAttributes } from "./trace-attributes.ts";
 import type { HostedAgentRunTracer } from "./agent-run-lifecycle.ts";
 import {
   createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions,
   resolveVeryfrontCloudChatStreamWatchdogOptions,
+  VERYFRONT_CHAT_STREAM_IDLE_TIMEOUT_ENV,
+  VERYFRONT_CHAT_STREAM_TOOL_TIMEOUT_ENV,
 } from "./cloud-prepared-chat-execution-runtime.ts";
 
 function createTracer(): HostedAgentRunTracer {
@@ -16,6 +19,15 @@ function createTracer(): HostedAgentRunTracer {
       withContext: (fn) => fn(),
     }),
   };
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    deleteEnv(key);
+    return;
+  }
+
+  setEnv(key, value);
 }
 
 describe("agent/veryfront-cloud-prepared-hosted-chat-execution-runtime", () => {
@@ -85,5 +97,26 @@ describe("agent/veryfront-cloud-prepared-hosted-chat-execution-runtime", () => {
       }),
       {},
     );
+  });
+
+  it("derives bootstrap watchdog timing from cloud stream timeout environment values", () => {
+    const previousIdleTimeout = getEnv(VERYFRONT_CHAT_STREAM_IDLE_TIMEOUT_ENV);
+    const previousToolTimeout = getEnv(VERYFRONT_CHAT_STREAM_TOOL_TIMEOUT_ENV);
+
+    try {
+      setEnv(VERYFRONT_CHAT_STREAM_IDLE_TIMEOUT_ENV, "30000");
+      setEnv(VERYFRONT_CHAT_STREAM_TOOL_TIMEOUT_ENV, "600000");
+
+      const options = createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions({
+        apiUrl: "https://api.example.com",
+        tracer: createTracer(),
+      });
+
+      assertEquals(options.streamBootstrapKeepaliveIntervalMs, 15_000);
+      assertEquals(options.streamBootstrapTimeoutMs, 600_000);
+    } finally {
+      restoreEnv(VERYFRONT_CHAT_STREAM_IDLE_TIMEOUT_ENV, previousIdleTimeout);
+      restoreEnv(VERYFRONT_CHAT_STREAM_TOOL_TIMEOUT_ENV, previousToolTimeout);
+    }
   });
 });

--- a/src/agent/hosted/cloud-prepared-chat-execution-runtime.ts
+++ b/src/agent/hosted/cloud-prepared-chat-execution-runtime.ts
@@ -40,6 +40,27 @@ export function resolveVeryfrontCloudChatStreamWatchdogOptions(
   };
 }
 
+/** Derive hosted chat bootstrap watchdog options from resolved root stream watchdog options. */
+export function resolveVeryfrontCloudStreamBootstrapWatchdogOptions(
+  options: Pick<ChatStreamWatchdogOptions, "idleTimeoutMs" | "toolRunningTimeoutMs">,
+): Pick<
+  PreparedHostedChatExecutionRuntimeOptions,
+  "streamBootstrapKeepaliveIntervalMs" | "streamBootstrapTimeoutMs"
+> {
+  const streamBootstrapKeepaliveIntervalMs = typeof options.idleTimeoutMs === "number"
+    ? Math.max(1, Math.floor(options.idleTimeoutMs / 2))
+    : undefined;
+
+  return {
+    ...(streamBootstrapKeepaliveIntervalMs !== undefined
+      ? { streamBootstrapKeepaliveIntervalMs }
+      : {}),
+    ...(options.toolRunningTimeoutMs !== undefined
+      ? { streamBootstrapTimeoutMs: options.toolRunningTimeoutMs }
+      : {}),
+  };
+}
+
 /** Input payload for create Veryfront Cloud prepared hosted chat execution runtime options. */
 export type CreateVeryfrontCloudPreparedHostedChatExecutionRuntimeOptionsInput = {
   apiUrl: string | URL;
@@ -49,12 +70,23 @@ export type CreateVeryfrontCloudPreparedHostedChatExecutionRuntimeOptionsInput =
   traceStream?: <TResult>(operation: () => Promise<TResult>) => Promise<TResult>;
   setActiveSpanAttributes?: (attributes: AgentTraceAttributes) => void;
   createRootStreamWatchdog?: PreparedHostedChatExecutionRuntimeOptions["createRootStreamWatchdog"];
+  streamBootstrapKeepaliveIntervalMs?: PreparedHostedChatExecutionRuntimeOptions[
+    "streamBootstrapKeepaliveIntervalMs"
+  ];
+  streamBootstrapTimeoutMs?: PreparedHostedChatExecutionRuntimeOptions[
+    "streamBootstrapTimeoutMs"
+  ];
 };
 
 /** Options accepted by create Veryfront Cloud prepared hosted chat execution runtime. */
 export function createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions(
   input: CreateVeryfrontCloudPreparedHostedChatExecutionRuntimeOptionsInput,
 ): PreparedHostedChatExecutionRuntimeOptions {
+  const watchdogOptions = resolveVeryfrontCloudChatStreamWatchdogOptions();
+  const streamBootstrapOptions = resolveVeryfrontCloudStreamBootstrapWatchdogOptions(
+    watchdogOptions,
+  );
+
   return {
     apiUrl: input.apiUrl,
     tracer: input.tracer,
@@ -64,10 +96,14 @@ export function createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions(
     createRootStreamWatchdog: input.createRootStreamWatchdog ??
       (() =>
         createChatStreamWatchdog({
-          ...resolveVeryfrontCloudChatStreamWatchdogOptions(),
+          ...watchdogOptions,
           setTimeoutFn: globalThis.setTimeout,
           clearTimeoutFn: globalThis.clearTimeout,
         })),
+    streamBootstrapKeepaliveIntervalMs: input.streamBootstrapKeepaliveIntervalMs ??
+      streamBootstrapOptions.streamBootstrapKeepaliveIntervalMs,
+    streamBootstrapTimeoutMs: input.streamBootstrapTimeoutMs ??
+      streamBootstrapOptions.streamBootstrapTimeoutMs,
     logger: input.logger,
     setActiveSpanAttributes: input.setActiveSpanAttributes,
   };

--- a/src/agent/hosted/prepared-chat-execution.test.ts
+++ b/src/agent/hosted/prepared-chat-execution.test.ts
@@ -1,8 +1,12 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { FakeTime } from "#std/testing/time";
 import type { ChatUiMessageChunk, MessageMetadata } from "../../chat/types.ts";
 import type { HostedAgentRunSpan, HostedAgentRunTracer } from "./agent-run-lifecycle.ts";
-import type { HostedChatRuntimeToUiMessageStreamOptions } from "./chat-runtime-contract.ts";
+import type {
+  HostedChatRuntimeAgent,
+  HostedChatRuntimeToUiMessageStreamOptions,
+} from "./chat-runtime-contract.ts";
 import type { HostedConversationRootRunContext } from "../conversation/root-run-lifecycle.ts";
 import type { AgUiRuntimeRequest } from "../runtime/ag-ui-contract.ts";
 import {
@@ -102,17 +106,18 @@ function createPreparedExecution(input?: {
   captureStreamOptions?: (options?: HostedChatRuntimeToUiMessageStreamOptions) => void;
   waitForSteps?: Promise<readonly unknown[]>;
   cleanup?: () => Promise<void>;
+  stream?: HostedChatRuntimeAgent["stream"];
 }): PreparedHostedChatExecution {
   return {
     authToken: "auth-token",
     agent: {
-      stream: async () => ({
+      stream: input?.stream ?? (async () => ({
         steps: input?.waitForSteps ?? Promise.resolve([{}]),
         toUIMessageStream: (options) => {
           input?.captureStreamOptions?.(options);
           return emptyStream();
         },
-      }),
+      })),
     },
     agentId: "agent-1",
     modelId: "openai/gpt-test",
@@ -157,6 +162,107 @@ describe("agent/prepared-hosted-chat-execution", () => {
       "agent.runtime.kind": "framework",
     }]);
     assertEquals(capturedOptions.generateMessageId?.(), "ag-ui-run-1:assistant");
+  });
+
+  it("passes stream bootstrap watchdog timing through prepared runtime options", async () => {
+    using time = new FakeTime();
+    const observedChunks: ChatUiMessageChunk<MessageMetadata>[] = [];
+    let releaseStream!: () => void;
+    const streamGate = new Promise<void>((resolve) => {
+      releaseStream = resolve;
+    });
+    const runtime = {
+      ...createRuntimeOptions(),
+      streamBootstrapKeepaliveIntervalMs: 1,
+      createRootStreamWatchdog: () => ({
+        signal: new AbortController().signal,
+        get lastTimeoutState() {
+          return null;
+        },
+        observe: (chunk) => {
+          observedChunks.push(chunk);
+        },
+        dispose: () => {},
+      }),
+    } as PreparedHostedChatExecutionRuntimeOptions & {
+      streamBootstrapKeepaliveIntervalMs: number;
+    };
+    const responsePromise = streamPreparedHostedChatExecutionToAgUiResponse({
+      execution: {
+        ...createPreparedExecution({
+          stream: async () => {
+            await streamGate;
+            return {
+              steps: Promise.resolve([{}]),
+              toUIMessageStream: () => emptyStream(),
+            };
+          },
+        }),
+        requestAbortSignal: new AbortController().signal,
+        agUiInput: createAgUiInput(),
+      },
+      runtime,
+    });
+
+    try {
+      time.tick(1);
+      await Promise.resolve();
+
+      assertEquals(observedChunks.length > 0, true);
+    } finally {
+      releaseStream();
+      const response = await responsePromise;
+      await response.body?.cancel();
+    }
+  });
+
+  it("preserves stream bootstrap watchdog timing from prepared execution input", async () => {
+    using time = new FakeTime();
+    const observedChunks: ChatUiMessageChunk<MessageMetadata>[] = [];
+    let releaseStream!: () => void;
+    const streamGate = new Promise<void>((resolve) => {
+      releaseStream = resolve;
+    });
+    const responsePromise = streamPreparedHostedChatExecutionToAgUiResponse({
+      execution: {
+        ...createPreparedExecution({
+          stream: async () => {
+            await streamGate;
+            return {
+              steps: Promise.resolve([{}]),
+              toUIMessageStream: () => emptyStream(),
+            };
+          },
+        }),
+        streamBootstrapKeepaliveIntervalMs: 1,
+        requestAbortSignal: new AbortController().signal,
+        agUiInput: createAgUiInput(),
+      },
+      runtime: {
+        ...createRuntimeOptions(),
+        createRootStreamWatchdog: () => ({
+          signal: new AbortController().signal,
+          get lastTimeoutState() {
+            return null;
+          },
+          observe: (chunk) => {
+            observedChunks.push(chunk);
+          },
+          dispose: () => {},
+        }),
+      },
+    });
+
+    try {
+      time.tick(1);
+      await Promise.resolve();
+
+      assertEquals(observedChunks.length > 0, true);
+    } finally {
+      releaseStream();
+      const response = await responsePromise;
+      await response.body?.cancel();
+    }
   });
 
   it("runs a prepared execution detached and waits for finalization", async () => {

--- a/src/agent/hosted/prepared-chat-execution.ts
+++ b/src/agent/hosted/prepared-chat-execution.ts
@@ -41,6 +41,8 @@ export type PreparedHostedChatExecutionRuntimeOptions =
     | "terminalErrorCode"
     | "incompleteToolCallsPartErrorText"
     | "createRootStreamWatchdog"
+    | "streamBootstrapKeepaliveIntervalMs"
+    | "streamBootstrapTimeoutMs"
     | "createTerminalAdapter"
   >
   & {
@@ -104,6 +106,12 @@ function createBootstrappedPreparedHostedChatExecutionRuntime(input: {
     terminalErrorCode: input.runtime.terminalErrorCode,
     incompleteToolCallsPartErrorText: input.runtime.incompleteToolCallsPartErrorText,
     createRootStreamWatchdog: input.runtime.createRootStreamWatchdog,
+    ...(input.runtime.streamBootstrapKeepaliveIntervalMs !== undefined
+      ? { streamBootstrapKeepaliveIntervalMs: input.runtime.streamBootstrapKeepaliveIntervalMs }
+      : {}),
+    ...(input.runtime.streamBootstrapTimeoutMs !== undefined
+      ? { streamBootstrapTimeoutMs: input.runtime.streamBootstrapTimeoutMs }
+      : {}),
     createTerminalAdapter: input.runtime.createTerminalAdapter,
     ...(input.responseMessageId ? { responseMessageId: input.responseMessageId } : {}),
   });


### PR DESCRIPTION
## Summary
- thread stream bootstrap watchdog timing through prepared hosted runtime options
- derive Veryfront Cloud bootstrap keepalive/cap values from the same env-configured root watchdog timeouts
- add regression coverage for cloud env timeout derivation and prepared runtime pass-through

## Review context
Addresses the automated review thread from #2777: https://github.com/veryfront/veryfront-code/pull/2777#discussion_r3525095785

## Tests
- deno test --allow-env src/agent/hosted/cloud-prepared-chat-execution-runtime.test.ts src/agent/hosted/prepared-chat-execution.test.ts src/agent/hosted/chat-execution-runtime.test.ts
- deno task fmt:check
- deno task lint
- deno task typecheck
- pre-push hook: full unit suite, 2292 passed / 0 failed