### PR TITLE
Harden historical tool input retention

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -72,9 +72,10 @@ details, see [API reference](../api-reference/index.md).
 
 ## Deploy and extend
 
-| Goal                                   | Guide                                               |
-| -------------------------------------- | --------------------------------------------------- |
-| Build and deploy a project             | [Build and deploy](./deploying.md)                  |
-| Run agents as separate services        | [Agent service runtime](./agent-service-runtime.md) |
-| Enable reusable runtime infrastructure | [Extensions](./extensions.md)                       |
-| Write, test, and package an extension  | [Author extensions](./extension-authoring.md)       |
+| Goal                                   | Guide                                                 |
+| -------------------------------------- | ----------------------------------------------------- |
+| Build and deploy a project             | [Build and deploy](./deploying.md)                    |
+| Review shipped UI components           | [Storybook UI workbench](./storybook-ui-workbench.md) |
+| Run agents as separate services        | [Agent service runtime](./agent-service-runtime.md)   |
+| Enable reusable runtime infrastructure | [Extensions](./extensions.md)                         |
+| Write, test, and package an extension  | [Author extensions](./extension-authoring.md)         |

--- a/docs/guides/storybook-ui-workbench.md
+++ b/docs/guides/storybook-ui-workbench.md
@@ -1,3 +1,9 @@
+---
+title: "Storybook UI workbench"
+description: "Run and verify the dev-only Storybook workbench for shipped Veryfront UI source."
+order: 42
+---
+
 # Storybook UI workbench
 
 Veryfront Code keeps shipped UI source in `src/react`.

--- a/src/agent/hosted/chat-preparation.test.ts
+++ b/src/agent/hosted/chat-preparation.test.ts
@@ -1043,6 +1043,60 @@ Deno.test("prepareHostedChatRuntimeMessages omits provider-owned remote tool his
   }]);
 });
 
+Deno.test("prepareHostedChatRuntimeMessages reports historical tool input compaction diagnostics", async () => {
+  const diagnostics: unknown[] = [];
+  const marker = "HOSTED_TOOL_INPUT_MARKER";
+  const messages = await prepareHostedChatRuntimeMessages(
+    [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Render the widget." }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{
+          type: "dynamic-tool",
+          toolName: "render_widget",
+          toolCallId: "tool-render-widget",
+          input: {
+            targetPath: "components/Widget.tsx",
+            source: `${marker}:${"export const widget = true;\n".repeat(2000)}`,
+          },
+          state: "output-available",
+          output: { ok: true },
+        }],
+      },
+      {
+        id: "user-2",
+        role: "user",
+        parts: [{ type: "text", text: "Update the widget." }],
+      },
+    ],
+    {
+      historicalToolInputRetention: {
+        diagnostics,
+        resolvePolicy: (toolName) =>
+          toolName === "render_widget"
+            ? {
+              compactCompletedInput: true,
+              compactAfterChars: 100,
+              retainInputFields: [{ inputName: "targetPath", outputName: "path" }],
+            }
+            : undefined,
+      },
+    },
+  );
+
+  const serialized = JSON.stringify(messages);
+  assertEquals(serialized.includes(marker), false);
+  assertEquals(diagnostics.length, 1);
+  assertEquals((diagnostics[0] as { source?: string }).source, "provider");
+  assertEquals((diagnostics[0] as { toolName?: string }).toolName, "render_widget");
+  assertEquals((diagnostics[0] as { toolCallId?: string }).toolCallId, "tool-render-widget");
+});
+
 Deno.test("prepareHostedChatRuntimeCreationOptions filters skills to the run agent's owner scope", async () => {
   const skills = [
     {

--- a/src/agent/hosted/chat-preparation.ts
+++ b/src/agent/hosted/chat-preparation.ts
@@ -3,6 +3,7 @@ import type {
   ChatSystemMessage,
   ChatUiMessage,
 } from "#veryfront/chat/types.ts";
+import type { HistoricalToolInputCompactionDiagnostic } from "#veryfront/chat/message-prep.ts";
 import type { AgentRuntimeMessage } from "../runtime/message-adapter.ts";
 import type { ConversationRunEvent } from "../conversation/run-events.ts";
 import type {
@@ -50,6 +51,7 @@ export type PrepareHostedChatRuntimeMessagesOptions =
     | "providerOwnedToolNames"
     | "abortSignal"
     | "fileContentFetchTimeoutMs"
+    | "historicalToolInputRetention"
   >
   & {
     authToken?: string;
@@ -220,6 +222,7 @@ export type HostedChatExecutionPreparationResult<
   runtime: TRuntimeResult;
   finalMessages: AgentRuntimeMessage[];
   contextBudgetDiagnostics?: ContextBudgetDiagnostics;
+  historicalToolInputCompactions?: HistoricalToolInputCompactionDiagnostic[];
   steering: HostedChatRuntimeCreationPreparationResult<
     TRuntimeAgentDefinition
   >["steering"];
@@ -407,6 +410,7 @@ export async function prepareHostedChatExecution<
     buildInstructions: input.buildInstructions,
   });
   const submittedFormInputResult = findSubmittedFormInputResult(normalized.effectiveMessages);
+  const historicalToolInputCompactions: HistoricalToolInputCompactionDiagnostic[] = [];
   const finalMessages = await prepareHostedChatRuntimeMessages(
     normalized.effectiveMessages,
     {
@@ -415,8 +419,16 @@ export async function prepareHostedChatExecution<
       projectId: input.request.projectId,
       providerOwnedToolNames: getProviderToolNames(input.agentConfig),
       abortSignal: input.abortSignal,
+      historicalToolInputRetention: {
+        diagnostics: historicalToolInputCompactions,
+      },
     },
   );
+  if (historicalToolInputCompactions.length > 0) {
+    input.contextBudget?.logger?.debug?.("Hosted chat historical tool inputs compacted", {
+      toolInputCompactions: historicalToolInputCompactions,
+    });
+  }
   let budgetedContext: Awaited<ReturnType<typeof applyContextBudget>> | undefined;
   if (input.contextBudget) {
     try {
@@ -451,6 +463,7 @@ export async function prepareHostedChatExecution<
     runtime,
     finalMessages: budgetedContext?.messages ?? finalMessages,
     contextBudgetDiagnostics: budgetedContext?.diagnostics,
+    ...(historicalToolInputCompactions.length > 0 ? { historicalToolInputCompactions } : {}),
     steering: runtimePreparation.steering,
     runtimeConfig: runtimePreparation.runtimeConfig,
   };
@@ -468,6 +481,7 @@ export async function prepareHostedChatRuntimeMessages(
       providerOwnedToolNames: options.providerOwnedToolNames,
       abortSignal: options.abortSignal,
       fileContentFetchTimeoutMs: options.fileContentFetchTimeoutMs,
+      historicalToolInputRetention: options.historicalToolInputRetention,
     });
   }
   const authToken = options.authToken;
@@ -479,6 +493,7 @@ export async function prepareHostedChatRuntimeMessages(
     providerOwnedToolNames: options.providerOwnedToolNames,
     abortSignal: options.abortSignal,
     fileContentFetchTimeoutMs: options.fileContentFetchTimeoutMs,
+    historicalToolInputRetention: options.historicalToolInputRetention,
     resolveFileUrl: ({ uploadId }) =>
       getRuntimeUploadUrl({
         apiUrl,

--- a/src/agent/hosted/durable-chat-run-start.test.ts
+++ b/src/agent/hosted/durable-chat-run-start.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ChatUiMessage } from "#veryfront/chat/types.ts";
 import {
@@ -7,6 +7,7 @@ import {
   type ParsedHostedChatRequest,
 } from "../index.ts";
 import {
+  durableChatRunStartInternals,
   executeHostedDurableChatRun,
   prepareDetachedStartMessages,
   resolveHostedDurableRunSetupErrorResponse,
@@ -123,6 +124,17 @@ describe("agent/hosted-durable-chat-run-start", () => {
     assertEquals(serialized.includes(childPromptMarker), false);
     assertStringIncludes(serialized, "historical_tool_input_summary");
     assertStringIncludes(serialized, "Build WebGL graph renderer");
+  });
+
+  it("rejects malformed accepted detached-start responses", async () => {
+    await assertRejects(
+      () =>
+        durableChatRunStartInternals.parseAcceptedDetachedStartResponse(
+          new Response("{", { status: 202 }),
+        ),
+      Error,
+      "Invalid detached start accepted response",
+    );
   });
 
   it("short-circuits duplicate active runs before preparing execution", async () => {

--- a/src/agent/hosted/durable-chat-run-start.ts
+++ b/src/agent/hosted/durable-chat-run-start.ts
@@ -1,5 +1,9 @@
 import { parseProviderError } from "../../chat/provider-errors.ts";
-import { compactHistoricalUiMessageToolInputs } from "../../chat/message-prep.ts";
+import {
+  compactHistoricalUiMessageToolInputs,
+  type HistoricalToolInputCompactionDiagnostic,
+  type HistoricalToolInputRetentionOptions,
+} from "../../chat/message-prep.ts";
 import type { ChatUiMessage } from "../../chat/types.ts";
 import {
   AgUiDetachedStartAcceptedSchema,
@@ -28,6 +32,7 @@ export type HostedDurableRunAuthErrorResponse = {
 
 /** Public API contract for hosted durable run logger. */
 export type HostedDurableRunLogger = {
+  debug?: (message: string, metadata?: Record<string, unknown>) => void;
   error(message: string, metadata?: Record<string, unknown>): void;
 };
 
@@ -58,14 +63,6 @@ export type ExecuteHostedDurableChatRunInput<TExecution> = {
   resolveAuthError?: (error: unknown) => HostedDurableRunAuthErrorResponse | null | undefined;
   logger?: HostedDurableRunLogger;
 };
-
-function readBooleanProperty(input: object | null, propertyName: string): boolean {
-  if (!input) {
-    return false;
-  }
-
-  return Object.getOwnPropertyDescriptor(input, propertyName)?.value === true;
-}
 
 function isDurableRunSetupErrorStatusCode(
   status: number | undefined,
@@ -117,25 +114,32 @@ async function parseAcceptedDetachedStartResponse(
     return { accepted: false, duplicate: false };
   }
 
-  const payload = await response.json().catch((): null => null);
-  const parsed = AgUiDetachedStartAcceptedSchema.safeParse(payload);
-  if (parsed.success) {
-    return {
-      accepted: parsed.data.accepted,
-      duplicate: parsed.data.duplicate,
-    };
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    throw new Error("Invalid detached start accepted response: malformed JSON", { cause: error });
   }
 
-  const payloadObject = typeof payload === "object" ? payload : null;
+  const parsed = AgUiDetachedStartAcceptedSchema.safeParse(payload);
+  if (!parsed.success) {
+    throw new Error("Invalid detached start accepted response: invalid payload");
+  }
+
   return {
-    accepted: readBooleanProperty(payloadObject, "accepted"),
-    duplicate: readBooleanProperty(payloadObject, "duplicate"),
+    accepted: parsed.data.accepted,
+    duplicate: parsed.data.duplicate,
   };
 }
 
 /** Prepare durable detached-start messages without carrying completed large historical tool inputs. */
-export function prepareDetachedStartMessages(messages: ChatUiMessage[]): ChatUiMessage[] {
-  return compactHistoricalUiMessageToolInputs(messages);
+export function prepareDetachedStartMessages(
+  messages: ChatUiMessage[],
+  options: {
+    historicalToolInputRetention?: HistoricalToolInputRetentionOptions;
+  } = {},
+): ChatUiMessage[] {
+  return compactHistoricalUiMessageToolInputs(messages, options.historicalToolInputRetention);
 }
 
 async function executeHostedDurableChatRunStart<TExecution>(
@@ -147,13 +151,25 @@ async function executeHostedDurableChatRunStart<TExecution>(
   }
 
   const execution = await input.prepareExecution(input.req);
+  const historicalToolInputCompactions: HistoricalToolInputCompactionDiagnostic[] = [];
   const detachedStartRequest = buildDetachedAgUiStartRequest({
     runId: durableRootRun.runId,
     threadId: conversationId,
-    messages: prepareDetachedStartMessages(input.req.messages),
+    messages: prepareDetachedStartMessages(input.req.messages, {
+      historicalToolInputRetention: {
+        diagnostics: historicalToolInputCompactions,
+      },
+    }),
     model: input.req.model,
     forwardedProps: input.req.forwardedProps,
   });
+  if (historicalToolInputCompactions.length > 0) {
+    input.logger?.debug?.("Detached durable start historical tool inputs compacted", {
+      runId: durableRootRun.runId,
+      conversationId,
+      toolInputCompactions: historicalToolInputCompactions,
+    });
+  }
   const detachedStartResponse = await executeAgUiDetachedStart(
     {
       sessionManager: input.tracker.sessionManager,
@@ -197,6 +213,11 @@ async function executeHostedDurableChatRunStart<TExecution>(
 
   return await parseAcceptedDetachedStartResponse(detachedStartResponse);
 }
+
+/** Test-only internals for durable chat run start behavior. */
+export const durableChatRunStartInternals = {
+  parseAcceptedDetachedStartResponse,
+};
 
 /** Execute hosted durable chat run. */
 export async function executeHostedDurableChatRun<TExecution>(

--- a/src/agent/runtime/message-preparation.ts
+++ b/src/agent/runtime/message-preparation.ts
@@ -1,4 +1,7 @@
-import { prepareProviderModelMessagesFromUiMessages } from "../../chat/message-prep.ts";
+import {
+  type HistoricalToolInputRetentionOptions,
+  prepareProviderModelMessagesFromUiMessages,
+} from "../../chat/message-prep.ts";
 import type { ChatUiMessage } from "../../chat/types.ts";
 import {
   type AgentRuntimeMessage,
@@ -24,6 +27,7 @@ export type PrepareAgentRuntimeMessagesFromUiMessagesOptions = {
   abortSignal?: AbortSignal;
   fileContentFetchTimeoutMs?: number;
   providerOwnedToolNames?: readonly string[];
+  historicalToolInputRetention?: HistoricalToolInputRetentionOptions;
 };
 
 /** Prepare agent runtime messages from UI messages. */
@@ -66,6 +70,7 @@ export async function prepareAgentRuntimeMessagesFromUiMessages(
   return convertProviderMessagesToAgentRuntimeMessages(
     prepareProviderModelMessagesFromUiMessages(messagesWithFileContent, {
       providerOwnedToolNames: options.providerOwnedToolNames,
+      historicalToolInputRetention: options.historicalToolInputRetention,
     }),
   );
 }

--- a/src/chat/message-prep.test.ts
+++ b/src/chat/message-prep.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertMatch, assertStringIncludes } from "#std/assert";
+import { assert, assertEquals, assertMatch, assertStringIncludes } from "#std/assert";
 import type { ProviderModelMessage } from "./types.ts";
 import {
   compactForStep,
@@ -987,6 +987,63 @@ Deno.test("prepareProviderModelMessagesFromUiMessages compacts large historical 
   assertStringIncludes(serialized, "components/GraphViewer.tsx");
   assertStringIncludes(serialized, "originalInputChars");
   assertStringIncludes(serialized, "originalInputHash");
+});
+
+Deno.test("prepareProviderModelMessagesFromUiMessages compacts custom tools through retention policy", () => {
+  const customMarker = "RENDER_CANVAS_SOURCE_MARKER";
+  const diagnostics: unknown[] = [];
+  const prepared = prepareProviderModelMessagesFromUiMessages(
+    [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Render the canvas." }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{
+          type: "dynamic-tool",
+          toolName: "render_canvas",
+          toolCallId: "tool-render",
+          input: {
+            targetPath: "components/Canvas.tsx",
+            source: `${customMarker}:${"const node = 1;\n".repeat(3000)}`,
+          },
+          state: "output-available",
+          output: { ok: true },
+        }],
+      },
+      {
+        id: "user-2",
+        role: "user",
+        parts: [{ type: "text", text: "Now make it interactive." }],
+      },
+    ],
+    {
+      historicalToolInputRetention: {
+        diagnostics,
+        resolvePolicy: (toolName) =>
+          toolName === "render_canvas"
+            ? {
+              compactCompletedInput: true,
+              compactAfterChars: 100,
+              retainInputFields: [{ inputName: "targetPath", outputName: "path" }],
+            }
+            : undefined,
+      },
+    },
+  );
+
+  const serialized = JSON.stringify(prepared);
+  assertEquals(serialized.includes(customMarker), false);
+  assertStringIncludes(serialized, "historical_tool_input_summary");
+  assertStringIncludes(serialized, "components/Canvas.tsx");
+  assertEquals(diagnostics.length, 1);
+  assertEquals((diagnostics[0] as { toolName?: string }).toolName, "render_canvas");
+  assertEquals((diagnostics[0] as { toolCallId?: string }).toolCallId, "tool-render");
+  assert((diagnostics[0] as { originalInputChars?: number }).originalInputChars! > 1_000);
+  assert((diagnostics[0] as { retainedInputChars?: number }).retainedInputChars! < 1_000);
 });
 
 Deno.test("compactForStep compacts old tool inputs while preserving latest-turn tool inputs", () => {

--- a/src/chat/message-prep.ts
+++ b/src/chat/message-prep.ts
@@ -20,11 +20,77 @@ import {
 import { historicalToolSummaries } from "../integrations/_tool_summaries.ts";
 import type { IntegrationEndpointHistoricalSummary } from "../integrations/schema.ts";
 
-const CHARS_PER_TOKEN = 4;
+/** Tunable limits used while preparing chat history for model context. */
+export type MessagePrepLimits = {
+  charsPerToken: number;
+  historicalToolOutputMaskChars: number;
+  historicalToolInputMaskChars: number;
+  retainedMetadataStringMaxChars: number;
+  retainedMetadataArrayMaxItems: number;
+  retainedMetadataObjectMaxEntries: number;
+};
+
+/** Default limits for chat history preparation. */
+export const DEFAULT_MESSAGE_PREP_LIMITS: MessagePrepLimits = {
+  charsPerToken: 4,
+  historicalToolOutputMaskChars: 500,
+  historicalToolInputMaskChars: 1_000,
+  retainedMetadataStringMaxChars: 200,
+  retainedMetadataArrayMaxItems: 20,
+  retainedMetadataObjectMaxEntries: 20,
+};
+
+const CHARS_PER_TOKEN = DEFAULT_MESSAGE_PREP_LIMITS.charsPerToken;
+
+/** Field selector retained in a historical tool-input summary. */
+export type HistoricalToolInputRetainedField =
+  | string
+  | {
+    inputName: string;
+    outputName?: string;
+  }
+  | {
+    inputNames: readonly string[];
+    outputName: string;
+  };
+
+/** Policy for compacting a completed historical tool-call input. */
+export type HistoricalToolInputRetentionPolicy = {
+  compactCompletedInput: boolean;
+  compactAfterChars?: number;
+  retainInputFields?: readonly HistoricalToolInputRetainedField[];
+};
+
+/** Resolves the retention policy for a completed historical tool input. */
+export type HistoricalToolInputRetentionPolicyResolver = (
+  toolName: string,
+  input: Record<string, unknown>,
+) => HistoricalToolInputRetentionPolicy | null | undefined;
+
+/** Diagnostic emitted when a completed historical tool input is compacted. */
+export type HistoricalToolInputCompactionDiagnostic = {
+  source: "provider" | "ui";
+  toolName: string;
+  toolCallId: string;
+  originalInputChars: number;
+  retainedInputChars: number;
+  originalInputTokens: number;
+  retainedInputTokens: number;
+  originalInputHash: string;
+  reason: "completed_historical_tool_input";
+};
+
+/** Options for historical tool-input compaction. */
+export type HistoricalToolInputRetentionOptions = {
+  resolvePolicy?: HistoricalToolInputRetentionPolicyResolver;
+  diagnostics?: HistoricalToolInputCompactionDiagnostic[];
+  limits?: Partial<MessagePrepLimits>;
+};
 
 /** Options accepted by prepare provider model messages from UI messages. */
 export interface PrepareProviderModelMessagesFromUiMessagesOptions {
   providerOwnedToolNames?: readonly string[];
+  historicalToolInputRetention?: HistoricalToolInputRetentionOptions;
 }
 
 /** Estimate tokens. */
@@ -308,8 +374,7 @@ const DEFAULT_CONTEXT_WINDOW = 200_000;
 const DEFAULT_TOKEN_BUDGET = Math.floor(DEFAULT_CONTEXT_WINDOW * BUDGET_RATIO);
 const TOKENS_PER_TOOL = 250;
 
-const MASK_THRESHOLD = 500;
-const TOOL_INPUT_MASK_THRESHOLD = 1_000;
+const MASK_THRESHOLD = DEFAULT_MESSAGE_PREP_LIMITS.historicalToolOutputMaskChars;
 const HISTORICAL_TOOL_INPUT_SUMMARY_KIND = "historical_tool_input_summary";
 const WRITE_TOOL_INPUT_NAMES = new Set([
   "create_file",
@@ -321,6 +386,27 @@ const WRITE_TOOL_INPUT_NAMES = new Set([
   "edit",
 ]);
 const CHILD_AGENT_TOOL_INPUT_NAMES = new Set(["invoke_agent"]);
+const DEFAULT_WRITE_TOOL_INPUT_RETAIN_FIELDS: readonly HistoricalToolInputRetainedField[] = [{
+  outputName: "path",
+  inputNames: [
+    "path",
+    "filePath",
+    "file_path",
+    "targetPath",
+    "target_path",
+    "filename",
+  ],
+}];
+const DEFAULT_CHILD_AGENT_TOOL_INPUT_RETAIN_FIELDS: readonly HistoricalToolInputRetainedField[] = [
+  "agent_id",
+  "agentId",
+  "model",
+  "description",
+  "tools",
+  "max_steps",
+  "maxSteps",
+  "thinking",
+];
 
 function serializedLength(value: unknown): number {
   return JSON.stringify(value ?? "").length;
@@ -369,29 +455,71 @@ function isChildAgentToolInput(toolName: string): boolean {
   return CHILD_AGENT_TOOL_INPUT_NAMES.has(normalizeToolInputName(toolName));
 }
 
-function shouldCompactHistoricalToolInput(
-  toolName: string,
-  input: unknown,
-): input is Record<string, unknown> {
-  return isRecord(input) && (isWriteToolInput(toolName) || isChildAgentToolInput(toolName));
+function resolveMessagePrepLimits(overrides?: Partial<MessagePrepLimits>): MessagePrepLimits {
+  return overrides ? { ...DEFAULT_MESSAGE_PREP_LIMITS, ...overrides } : DEFAULT_MESSAGE_PREP_LIMITS;
 }
 
-function compactMetadataValue(value: unknown): unknown {
-  if (typeof value === "string") return truncate(value, 200);
+function getDefaultHistoricalToolInputRetentionPolicy(
+  toolName: string,
+): HistoricalToolInputRetentionPolicy | undefined {
+  if (isWriteToolInput(toolName)) {
+    return {
+      compactCompletedInput: true,
+      retainInputFields: DEFAULT_WRITE_TOOL_INPUT_RETAIN_FIELDS,
+    };
+  }
+
+  if (isChildAgentToolInput(toolName)) {
+    return {
+      compactCompletedInput: true,
+      retainInputFields: DEFAULT_CHILD_AGENT_TOOL_INPUT_RETAIN_FIELDS,
+    };
+  }
+
+  return undefined;
+}
+
+function resolveHistoricalToolInputRetentionPolicy(
+  toolName: string,
+  input: Record<string, unknown>,
+  options: HistoricalToolInputRetentionOptions | undefined,
+): HistoricalToolInputRetentionPolicy | undefined {
+  if (options?.resolvePolicy) {
+    const resolved = options.resolvePolicy(toolName, input);
+    if (resolved !== undefined) {
+      return resolved ?? undefined;
+    }
+  }
+
+  return getDefaultHistoricalToolInputRetentionPolicy(toolName);
+}
+
+function shouldCompactHistoricalToolInput(
+  policy: HistoricalToolInputRetentionPolicy | undefined,
+  input: unknown,
+): input is Record<string, unknown> {
+  return policy?.compactCompletedInput === true && isRecord(input);
+}
+
+function compactMetadataValue(value: unknown, limits: MessagePrepLimits): unknown {
+  if (typeof value === "string") return truncate(value, limits.retainedMetadataStringMaxChars);
   if (typeof value === "number" || typeof value === "boolean") return value;
   if (Array.isArray(value)) {
     const compact = value
       .filter((entry) =>
         typeof entry === "string" || typeof entry === "number" || typeof entry === "boolean"
       )
-      .slice(0, 20);
+      .slice(0, limits.retainedMetadataArrayMaxItems);
     return compact.length > 0 ? compact : undefined;
   }
   if (isRecord(value)) {
     const compact: Record<string, unknown> = {};
-    for (const [key, entry] of Object.entries(value).slice(0, 20)) {
-      if (typeof entry === "string") compact[key] = truncate(entry, 200);
-      else if (typeof entry === "number" || typeof entry === "boolean") compact[key] = entry;
+    for (
+      const [key, entry] of Object.entries(value).slice(0, limits.retainedMetadataObjectMaxEntries)
+    ) {
+      if (typeof entry === "string") {
+        compact[key] = truncate(entry, limits.retainedMetadataStringMaxChars);
+      } else if (typeof entry === "number" || typeof entry === "boolean") compact[key] = entry;
     }
     return Object.keys(compact).length > 0 ? compact : undefined;
   }
@@ -403,9 +531,10 @@ function copyFirstMetadataField(
   input: Record<string, unknown>,
   outputName: string,
   inputNames: readonly string[],
+  limits: MessagePrepLimits,
 ): void {
   for (const name of inputNames) {
-    const value = compactMetadataValue(input[name]);
+    const value = compactMetadataValue(input[name], limits);
     if (value !== undefined) {
       target[outputName] = value;
       return;
@@ -417,11 +546,36 @@ function copyNamedMetadataFields(
   target: Record<string, unknown>,
   input: Record<string, unknown>,
   names: readonly string[],
+  limits: MessagePrepLimits,
 ): void {
   for (const name of names) {
-    const value = compactMetadataValue(input[name]);
+    const value = compactMetadataValue(input[name], limits);
     if (value !== undefined) {
       target[name] = value;
+    }
+  }
+}
+
+function copyRetainedMetadataFields(
+  target: Record<string, unknown>,
+  input: Record<string, unknown>,
+  fields: readonly HistoricalToolInputRetainedField[] | undefined,
+  limits: MessagePrepLimits,
+): void {
+  for (const field of fields ?? []) {
+    if (typeof field === "string") {
+      copyNamedMetadataFields(target, input, [field], limits);
+      continue;
+    }
+
+    if ("inputNames" in field) {
+      copyFirstMetadataField(target, input, field.outputName, field.inputNames, limits);
+      continue;
+    }
+
+    const value = compactMetadataValue(input[field.inputName], limits);
+    if (value !== undefined) {
+      target[field.outputName ?? field.inputName] = value;
     }
   }
 }
@@ -430,36 +584,19 @@ function compactHistoricalToolInput(
   toolName: string,
   input: Record<string, unknown>,
   charCount: number,
+  policy: HistoricalToolInputRetentionPolicy,
+  limits: MessagePrepLimits,
+  originalInputHash: string,
 ): Record<string, unknown> {
   const compact: Record<string, unknown> = {
     kind: HISTORICAL_TOOL_INPUT_SUMMARY_KIND,
     toolName,
     originalInputChars: charCount,
-    originalInputHash: stableHash(input),
+    originalInputHash,
     omitted: "Full historical tool input omitted after the tool completed.",
   };
 
-  if (isWriteToolInput(toolName)) {
-    copyFirstMetadataField(compact, input, "path", [
-      "path",
-      "filePath",
-      "file_path",
-      "targetPath",
-      "target_path",
-      "filename",
-    ]);
-  } else if (isChildAgentToolInput(toolName)) {
-    copyNamedMetadataFields(compact, input, [
-      "agent_id",
-      "agentId",
-      "model",
-      "description",
-      "tools",
-      "max_steps",
-      "maxSteps",
-      "thinking",
-    ]);
-  }
+  copyRetainedMetadataFields(compact, input, policy.retainInputFields, limits);
 
   return compact;
 }
@@ -886,7 +1023,7 @@ export function prepareProviderModelMessagesFromUiMessages(
   const patchedMessages = ensureToolCallInputs(dedupeToolHistory(providerModelMessages));
   const sanitized = sanitizeProviderModelMessages(patchedMessages);
   const masked = maskOldToolOutputs(sanitized);
-  const compactedInputs = compactOldToolInputs(masked);
+  const compactedInputs = compactOldToolInputs(masked, options.historicalToolInputRetention);
   const compacted = enforceTokenBudget(compactedInputs);
   const filtered = filterValidMessages(compacted);
   return repairToolPairs(filtered);
@@ -1244,8 +1381,30 @@ export function maskOldToolOutputs(messages: ProviderModelMessage[]): ProviderMo
   });
 }
 
+function recordHistoricalToolInputCompaction(
+  diagnostics: HistoricalToolInputCompactionDiagnostic[] | undefined,
+  input: {
+    source: "provider" | "ui";
+    toolName: string;
+    toolCallId: string;
+    originalInputChars: number;
+    retainedInputChars: number;
+    originalInputTokens: number;
+    retainedInputTokens: number;
+    originalInputHash: string;
+  },
+): void {
+  diagnostics?.push({
+    ...input,
+    reason: "completed_historical_tool_input",
+  });
+}
+
 /** Compact large historical tool-call inputs after matching results are available. */
-export function compactOldToolInputs(messages: ProviderModelMessage[]): ProviderModelMessage[] {
+export function compactOldToolInputs(
+  messages: ProviderModelMessage[],
+  options: HistoricalToolInputRetentionOptions = {},
+): ProviderModelMessage[] {
   let lastUserIdx = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
@@ -1258,6 +1417,7 @@ export function compactOldToolInputs(messages: ProviderModelMessage[]): Provider
   if (lastUserIdx <= 0) return messages;
 
   const historicalResultIds = collectHistoricalToolResultIds(messages, lastUserIdx);
+  const limits = resolveMessagePrepLimits(options.limits);
   let mutated = false;
 
   const result = messages.map((msg, idx) => {
@@ -1275,19 +1435,44 @@ export function compactOldToolInputs(messages: ProviderModelMessage[]): Provider
         return part;
       }
 
-      if (!shouldCompactHistoricalToolInput(part.toolName, part.input)) {
+      if (!isRecord(part.input)) {
+        return part;
+      }
+
+      const policy = resolveHistoricalToolInputRetentionPolicy(part.toolName, part.input, options);
+      if (!policy || !shouldCompactHistoricalToolInput(policy, part.input)) {
         return part;
       }
 
       const charCount = serializedLength(part.input);
-      if (charCount < TOOL_INPUT_MASK_THRESHOLD) {
+      if (charCount < (policy.compactAfterChars ?? limits.historicalToolInputMaskChars)) {
         return part;
       }
 
+      const originalInputHash = stableHash(part.input);
+      const compactedInput = compactHistoricalToolInput(
+        part.toolName,
+        part.input,
+        charCount,
+        policy,
+        limits,
+        originalInputHash,
+      );
+      const retainedInputChars = serializedLength(compactedInput);
+      recordHistoricalToolInputCompaction(options.diagnostics, {
+        source: "provider",
+        toolName: part.toolName,
+        toolCallId: part.toolCallId,
+        originalInputChars: charCount,
+        retainedInputChars,
+        originalInputTokens: Math.ceil(charCount / limits.charsPerToken),
+        retainedInputTokens: Math.ceil(retainedInputChars / limits.charsPerToken),
+        originalInputHash,
+      });
       messageMutated = true;
       return {
         ...part,
-        input: compactHistoricalToolInput(part.toolName, part.input, charCount),
+        input: compactedInput,
       };
     });
 
@@ -1303,7 +1488,10 @@ export function compactOldToolInputs(messages: ProviderModelMessage[]): Provider
 }
 
 /** Compact large historical UI-message tool inputs after matching results are available. */
-export function compactHistoricalUiMessageToolInputs(messages: ChatUiMessage[]): ChatUiMessage[] {
+export function compactHistoricalUiMessageToolInputs(
+  messages: ChatUiMessage[],
+  options: HistoricalToolInputRetentionOptions = {},
+): ChatUiMessage[] {
   let lastUserIdx = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
@@ -1316,6 +1504,7 @@ export function compactHistoricalUiMessageToolInputs(messages: ChatUiMessage[]):
   if (lastUserIdx <= 0) return messages;
 
   const historicalResultIds = collectHistoricalUiToolResultIds(messages, lastUserIdx);
+  const limits = resolveMessagePrepLimits(options.limits);
   let mutated = false;
 
   const result = messages.map((message, index) => {
@@ -1335,19 +1524,44 @@ export function compactHistoricalUiMessageToolInputs(messages: ChatUiMessage[]):
       }
 
       const toolName = getMessagePartToolName(part);
-      if (!toolName || !shouldCompactHistoricalToolInput(toolName, part.input)) {
+      if (!toolName || !isRecord(part.input)) {
+        return part;
+      }
+
+      const policy = resolveHistoricalToolInputRetentionPolicy(toolName, part.input, options);
+      if (!policy || !shouldCompactHistoricalToolInput(policy, part.input)) {
         return part;
       }
 
       const charCount = serializedLength(part.input);
-      if (charCount < TOOL_INPUT_MASK_THRESHOLD) {
+      if (charCount < (policy.compactAfterChars ?? limits.historicalToolInputMaskChars)) {
         return part;
       }
 
+      const originalInputHash = stableHash(part.input);
+      const compactedInput = compactHistoricalToolInput(
+        toolName,
+        part.input,
+        charCount,
+        policy,
+        limits,
+        originalInputHash,
+      );
+      const retainedInputChars = serializedLength(compactedInput);
+      recordHistoricalToolInputCompaction(options.diagnostics, {
+        source: "ui",
+        toolName,
+        toolCallId,
+        originalInputChars: charCount,
+        retainedInputChars,
+        originalInputTokens: Math.ceil(charCount / limits.charsPerToken),
+        retainedInputTokens: Math.ceil(retainedInputChars / limits.charsPerToken),
+        originalInputHash,
+      });
       messageMutated = true;
       return {
         ...part,
-        input: compactHistoricalToolInput(toolName, part.input, charCount),
+        input: compactedInput,
       };
     });
 
@@ -1555,9 +1769,12 @@ export function ensureToolCallInputs(messages: ProviderModelMessage[]): Provider
 export function compactForStep(
   messages: ProviderModelMessage[],
   overhead: number = 0,
+  options: {
+    historicalToolInputRetention?: HistoricalToolInputRetentionOptions;
+  } = {},
 ): ProviderModelMessage[] {
   const compacted = enforceTokenBudget(
-    compactOldToolInputs(maskOldToolOutputs(messages)),
+    compactOldToolInputs(maskOldToolOutputs(messages), options.historicalToolInputRetention),
     DEFAULT_TOKEN_BUDGET,
     overhead,
   );

--- a/src/eval/agent-service.test.ts
+++ b/src/eval/agent-service.test.ts
@@ -6,6 +6,7 @@ import { datasets, evalAgent, metrics, runEval } from "veryfront/eval";
 import {
   buildAgentServiceEvalRequestBody,
   createAgentServiceEvalAdapter,
+  createDurableRunTokenGrowthCanaryCase,
   createLiveEvalCaseSupport,
   evaluateAgentServiceEvalEnvironment,
   evaluateRuntimeConfidenceEnv,
@@ -516,10 +517,26 @@ describe("eval/agent-service", () => {
     assertEquals(typeof mod.createAgentServiceEvalAdapter, "function");
     assertEquals(typeof mod.runLiveEvalCli, "function");
     assertEquals(typeof mod.runDurableRunCanaryCli, "function");
+    assertEquals(typeof mod.createDurableRunTokenGrowthCanaryCase, "function");
     assertEquals(typeof mod.evaluateRuntimeConfidenceEnv, "function");
     assertEquals(typeof runLiveEvalCli, "function");
     assertEquals(typeof runDurableRunCanaryCli, "function");
+    assertEquals(typeof createDurableRunTokenGrowthCanaryCase, "function");
     assertEquals(typeof evaluateRuntimeConfidenceEnv, "function");
+  });
+
+  it("builds a two-turn durable token-growth canary", async () => {
+    const testCase = createDurableRunTokenGrowthCanaryCase({
+      conversationId: "11111111-1111-4111-8111-111111111111",
+      marker: "TOKEN_GROWTH_TEST_MARKER",
+    });
+
+    const prepared = await testCase.prepare();
+
+    assertEquals(testCase.id, "durable-token-growth-follow-up");
+    assertEquals(prepared.conversationId, "11111111-1111-4111-8111-111111111111");
+    assertStringIncludes(prepared.prompt, "TOKEN_GROWTH_TEST_MARKER");
+    assertStringIncludes(prepared.followUpPrompt ?? "", "TOKEN_GROWTH_TEST_MARKER");
   });
 
   it("does not revive the legacy agent testing import path", async () => {

--- a/src/eval/agent-service.test.ts
+++ b/src/eval/agent-service.test.ts
@@ -6,8 +6,11 @@ import { datasets, evalAgent, metrics, runEval } from "veryfront/eval";
 import {
   buildAgentServiceEvalRequestBody,
   createAgentServiceEvalAdapter,
+  createDurableRunCanaryRunner,
   createDurableRunTokenGrowthCanaryCase,
   createLiveEvalCaseSupport,
+  type DurableRunCanaryApiClient,
+  type DurableRunCanaryRunSummary,
   evaluateAgentServiceEvalEnvironment,
   evaluateRuntimeConfidenceEnv,
   resolveAgentServiceEvalEnvironment,
@@ -537,6 +540,81 @@ describe("eval/agent-service", () => {
     assertEquals(prepared.conversationId, "11111111-1111-4111-8111-111111111111");
     assertStringIncludes(prepared.prompt, "TOKEN_GROWTH_TEST_MARKER");
     assertStringIncludes(prepared.followUpPrompt ?? "", "TOKEN_GROWTH_TEST_MARKER");
+  });
+
+  it("fails a follow-up durable canary when its setup run fails", async () => {
+    const conversationId = "11111111-1111-4111-8111-111111111111";
+    const createdRunIds: string[] = [];
+    const startRunInputs: Array<{ prompt: string; runId: string }> = [];
+
+    function createRunSummary(
+      runId: string,
+      status: DurableRunCanaryRunSummary["status"],
+    ): DurableRunCanaryRunSummary {
+      return {
+        runId,
+        conversationId,
+        messageId: "22222222-2222-4222-8222-222222222222",
+        agentId: "veryfront",
+        status,
+        latestEventId: 1,
+        latestExternalEventSequence: null,
+        waitingToolCallId: null,
+        waitingToolName: null,
+        terminalErrorCode: status === "failed" ? "setup_failed" : null,
+        terminalErrorMessage: status === "failed" ? "setup failed" : null,
+        startedAt: "2026-07-05T19:00:00.000Z",
+        finishedAt: "2026-07-05T19:00:01.000Z",
+      };
+    }
+
+    const apiClient: DurableRunCanaryApiClient = {
+      createDurableRootRun: async ({ runId }) => {
+        createdRunIds.push(runId);
+      },
+      getRunSummary: async ({ runId }) =>
+        createRunSummary(runId, createdRunIds[0] === runId ? "failed" : "completed"),
+      listMessagesForCanary: async () => [],
+      sendUserMessageForCanary: async () => ({
+        id: "33333333-3333-4333-8333-333333333333",
+        role: "user",
+        parts: [],
+      }),
+      startDurableRun: async (input) => {
+        startRunInputs.push({ prompt: input.prompt, runId: input.runId });
+      },
+    };
+
+    const runner = createDurableRunCanaryRunner(
+      {
+        agentId: "veryfront",
+        apiUrl: "https://api.example.test",
+        authToken: "token",
+        keepSuccessfulEvidence: false,
+        projectId: "project_123",
+        requestTimeoutMs: 1_000,
+      },
+      apiClient,
+    );
+
+    const result = await runner.runCase({
+      id: "setup-failure",
+      label: "Setup failure",
+      prepare: async () => ({
+        cleanup: async () => {},
+        conversationId,
+        followUpPrompt: "follow up",
+        prompt: "setup",
+        title: "Setup failure",
+        validate: ({ run }) => {
+          assertEquals(run.status, "completed");
+        },
+      }),
+    });
+
+    assertEquals(result.status, "fail");
+    assertStringIncludes(result.details, "setup failed");
+    assertEquals(startRunInputs.map((input) => input.prompt), ["setup"]);
   });
 
   it("does not revive the legacy agent testing import path", async () => {

--- a/src/eval/agent-service/durable-run-canaries/index.ts
+++ b/src/eval/agent-service/durable-run-canaries/index.ts
@@ -28,6 +28,12 @@ export {
 } from "./runner.ts";
 
 export {
+  createDurableRunTokenGrowthCanaryCase,
+  DURABLE_RUN_TOKEN_GROWTH_CANARY_MARKER,
+  type DurableRunTokenGrowthCanaryCaseInput,
+} from "./token-growth.ts";
+
+export {
   assertCompleted,
   assertNoMalformedCreateFileToolCalls,
   collectAssistantText,

--- a/src/eval/agent-service/durable-run-canaries/runner.ts
+++ b/src/eval/agent-service/durable-run-canaries/runner.ts
@@ -470,6 +470,15 @@ function isTerminalRunStatus(status: string): boolean {
   return status === "completed" || status === "failed" || status === "cancelled";
 }
 
+function assertCompletedSetupRunBeforeFollowUp(run: DurableRunCanaryRunSummary): void {
+  if (run.status === "completed") {
+    return;
+  }
+
+  const reason = run.terminalErrorMessage ?? run.terminalErrorCode ?? `status ${run.status}`;
+  throw new Error(`Setup durable run did not complete before follow-up: ${reason}`);
+}
+
 function createDurableRunCanaryRunId(): string {
   return `run_${crypto.randomUUID()}`;
 }
@@ -588,6 +597,9 @@ export function createDurableRunCanaryRunner(
         prompt: prepared.prompt,
       });
       runId = initialRun.runId;
+      if (prepared.followUpPrompt) {
+        assertCompletedSetupRunBeforeFollowUp(initialRun.run);
+      }
       const terminalRun = prepared.followUpPrompt
         ? await executeDurableRunPrompt({
           conversationId: prepared.conversationId,

--- a/src/eval/agent-service/durable-run-canaries/runner.ts
+++ b/src/eval/agent-service/durable-run-canaries/runner.ts
@@ -356,6 +356,7 @@ export interface DurableRunCanaryPreparedCase {
   artifactPaths?: string[] | ((runId: string) => string[]);
   cleanup: (input?: { runId: string }) => Promise<void>;
   conversationId: string;
+  followUpPrompt?: string;
   prompt: string;
   startSidecar?: () => Promise<(() => Promise<void>) | void>;
   title: string;
@@ -384,6 +385,16 @@ interface RunSummaryLocator {
 
 interface WaitForRunInput extends RunSummaryLocator {
   getRunSummary: (input: RunSummaryLocator) => Promise<DurableRunCanaryRunSummary>;
+}
+
+interface ExecuteDurableRunPromptInput {
+  conversationId: string;
+  prompt: string;
+}
+
+interface ExecuteDurableRunPromptResult {
+  run: DurableRunCanaryRunSummary;
+  runId: string;
 }
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -521,6 +532,46 @@ export function createDurableRunCanaryRunner(
     return [...messages, ...childMessages.flat()];
   }
 
+  async function executeDurableRunPrompt(
+    input: ExecuteDurableRunPromptInput,
+  ): Promise<ExecuteDurableRunPromptResult> {
+    const userMessage = await apiClient.sendUserMessageForCanary({
+      conversationId: input.conversationId,
+      prompt: input.prompt,
+    });
+    const currentRunId = createDurableRunCanaryRunId();
+
+    await apiClient.createDurableRootRun({
+      conversationId: input.conversationId,
+      runId: currentRunId,
+    });
+    const visibleRun = await waitForRunSummaryVisibility({
+      conversationId: input.conversationId,
+      getRunSummary,
+      runId: currentRunId,
+    });
+
+    await apiClient.startDurableRun({
+      conversationId: input.conversationId,
+      messageId: visibleRun.messageId,
+      prompt: input.prompt,
+      runId: currentRunId,
+      userMessageId: userMessage.id,
+    });
+
+    const terminalRun = await waitForTerminalRun({
+      conversationId: input.conversationId,
+      getRunSummary,
+      requestTimeoutMs: config.requestTimeoutMs,
+      runId: currentRunId,
+    });
+
+    return {
+      run: terminalRun,
+      runId: currentRunId,
+    };
+  }
+
   async function runCase(testCase: DurableRunCanaryCase): Promise<DurableRunCanaryResult> {
     const startedAt = Date.now();
     const prepared = await testCase.prepare();
@@ -532,41 +583,23 @@ export function createDurableRunCanaryRunner(
         : prepared.artifactPaths;
 
     try {
-      const userMessage = await apiClient.sendUserMessageForCanary({
+      const initialRun = await executeDurableRunPrompt({
         conversationId: prepared.conversationId,
         prompt: prepared.prompt,
       });
-      runId = createDurableRunCanaryRunId();
-
-      await apiClient.createDurableRootRun({
-        conversationId: prepared.conversationId,
-        runId,
-      });
-      const visibleRun = await waitForRunSummaryVisibility({
-        conversationId: prepared.conversationId,
-        getRunSummary,
-        runId,
-      });
-
-      await apiClient.startDurableRun({
-        conversationId: prepared.conversationId,
-        messageId: visibleRun.messageId,
-        prompt: prepared.prompt,
-        runId,
-        userMessageId: userMessage.id,
-      });
-
-      const terminalRun = await waitForTerminalRun({
-        conversationId: prepared.conversationId,
-        getRunSummary,
-        requestTimeoutMs: config.requestTimeoutMs,
-        runId,
-      });
+      runId = initialRun.runId;
+      const terminalRun = prepared.followUpPrompt
+        ? await executeDurableRunPrompt({
+          conversationId: prepared.conversationId,
+          prompt: prepared.followUpPrompt,
+        })
+        : initialRun;
+      runId = terminalRun.runId;
       const messages = await listMessagesWithReferencedChildren(prepared.conversationId);
 
       await prepared.validate({
         messages,
-        run: terminalRun,
+        run: terminalRun.run,
       });
 
       const artifactPaths = resolveArtifactPaths(runId);

--- a/src/eval/agent-service/durable-run-canaries/token-growth.ts
+++ b/src/eval/agent-service/durable-run-canaries/token-growth.ts
@@ -1,0 +1,64 @@
+import type { DurableRunCanaryCase, DurableRunCanaryPreparedCase } from "./runner.ts";
+import {
+  assertCompleted,
+  assertNoMalformedCreateFileToolCalls,
+  collectAssistantText,
+  findAssistantMessage,
+} from "./validation.ts";
+
+/** Marker used by the durable run token-growth canary prompt. */
+export const DURABLE_RUN_TOKEN_GROWTH_CANARY_MARKER = "VF_DURABLE_TOKEN_GROWTH_CANARY";
+
+/** Input payload for create durable run token-growth canary case. */
+export type DurableRunTokenGrowthCanaryCaseInput = {
+  conversationId?: string;
+  cleanup?: DurableRunCanaryPreparedCase["cleanup"];
+  marker?: string;
+};
+
+function buildTokenGrowthSetupPrompt(marker: string): string {
+  return [
+    "Durable run token-growth canary setup.",
+    "If file tools are available, create or update `.veryfront-token-growth-canary.txt` with:",
+    `- first line: ${marker}`,
+    "- then 4000 short numbered lines that include the marker",
+    "Reply briefly when the setup work is done.",
+  ].join("\n");
+}
+
+function buildTokenGrowthFollowUpPrompt(marker: string): string {
+  return [
+    "Durable run token-growth canary follow-up.",
+    `Use the prior conversation context for ${marker}, but do not edit files.`,
+    "Reply with a brief completion confirmation.",
+  ].join("\n");
+}
+
+/** Create a two-turn durable run canary for historical tool-input token growth. */
+export function createDurableRunTokenGrowthCanaryCase(
+  input: DurableRunTokenGrowthCanaryCaseInput = {},
+): DurableRunCanaryCase {
+  const marker = input.marker ?? `${DURABLE_RUN_TOKEN_GROWTH_CANARY_MARKER}_${crypto.randomUUID()}`;
+
+  return {
+    id: "durable-token-growth-follow-up",
+    label: "Durable run historical tool-input token growth follow-up",
+    prepare: async () => ({
+      cleanup: input.cleanup ?? (async () => {}),
+      conversationId: input.conversationId ?? crypto.randomUUID(),
+      followUpPrompt: buildTokenGrowthFollowUpPrompt(marker),
+      prompt: buildTokenGrowthSetupPrompt(marker),
+      title: "Durable run token-growth follow-up",
+      validate: ({ messages, run }) => {
+        assertCompleted(run);
+        assertNoMalformedCreateFileToolCalls(messages);
+
+        const assistant = findAssistantMessage(messages, run.messageId);
+        const assistantText = collectAssistantText(assistant).trim();
+        if (!assistantText) {
+          throw new Error("Expected follow-up durable run to persist assistant text");
+        }
+      },
+    }),
+  };
+}


### PR DESCRIPTION
## Summary
- Add policy-driven historical tool-input retention so completed old inputs can be compacted for custom high-volume tools, not only the built-in write/subagent names.
- Surface compaction diagnostics with source, tool id/name, char counts, approximate token counts, and stable hashes through hosted chat and durable detached-start paths.
- Reject malformed 202 Accepted detached-start bodies instead of fabricating fallback booleans.
- Add a two-turn durable token-growth canary case and runner support for follow-up prompts.
- Fix existing Storybook guide docs metadata/indexing so verify:quick stays green.

## Verification
- deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/chat/message-prep.test.ts src/agent/hosted/durable-chat-run-start.test.ts src/agent/hosted/chat-preparation.test.ts src/eval/agent-service.test.ts
- deno task fmt:check
- deno task lint
- deno task typecheck
- deno task test:unit
- deno task verify:quick
- Pre-push hook passed after rebase: 2298 passed (19411 steps), 0 failed.

## Not run
- Live staging durable token-growth canary; local shell does not have VERYFRONT_TOKEN or AG_UI_EVAL_PROJECT_ID.