### PR TITLE
Release 0.1.1015

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1014",
+  "version": "0.1.1015",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1014";
+export const VERSION = "0.1.1015";


### PR DESCRIPTION
## Summary

Patch version bump `0.1.1014` → `0.1.1015` to cut a new release.

- `deno.json` and `src/utils/version-constant.ts` bumped together (repo convention; `src/utils/version.test.ts` passes — 21 steps).
- CI derives the publish version from `deno.json`, so no workflow changes needed.

## Included since 0.1.1014

- #2783 — Harden conversation run mirroring and finalization (unhandled-rejection crash fix in the run mirror, flush drain guarantee, retryable run finalization, append cursor race fixes, API timeout covering body reads, tool-call state cleanup, `tool_call` part persistence, turn-compression index fix)
- #2782 — Context retention policy hardening
- #2781 — Bootstrap watchdog explicit keepalive