### PR TITLE
Fix Deno scaffold CLI bundler dependency

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1015",
+  "version": "0.1.1016",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -256,6 +256,10 @@ await build({
 		pkg.type = "module"; // Required for ESM imports without warnings
 		pkg.types = "./esm/src/index.d.ts";
 		pkg.bin = { veryfront: "bin/veryfront.js" };
+		pkg.dependencies ??= {};
+		// Add after build-local npm install so releases do not require the
+		// just-built extension version to already exist in the registry.
+		pkg.dependencies["@veryfront/ext-bundler-esbuild"] = `^${version}`;
 		pkg.files = ["esm", "script", "bin", "assets", "tsconfig.json", "LICENSE", "NOTICE", "README.md"];
 		pkg.exports["./tsconfig.json"] = "./tsconfig.json";
 		addTypesExportEntries(pkg.exports);

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -259,7 +259,7 @@ await build({
 		pkg.dependencies ??= {};
 		// Add after build-local npm install so releases do not require the
 		// just-built extension version to already exist in the registry.
-		pkg.dependencies["@veryfront/ext-bundler-esbuild"] = `^${version}`;
+		pkg.dependencies["@veryfront/ext-bundler-esbuild"] = version;
 		pkg.files = ["esm", "script", "bin", "assets", "tsconfig.json", "LICENSE", "NOTICE", "README.md"];
 		pkg.exports["./tsconfig.json"] = "./tsconfig.json";
 		addTypesExportEntries(pkg.exports);

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -51,6 +51,24 @@ Deno.test("root npm build metadata does not inject extension implementation depe
   }
 });
 
+Deno.test("root npm CLI package declares the bundler extension after local install", async () => {
+  const source = await Deno.readTextFile("scripts/build/build-npm-dnt.ts");
+  const installIndex = source.indexOf('const { code } = await npmInstall.output();');
+  const dependencyIndex = source.indexOf(
+    'pkg.dependencies["@veryfront/ext-bundler-esbuild"] = `^${version}`;',
+  );
+
+  assertStringIncludes(
+    source,
+    'pkg.dependencies["@veryfront/ext-bundler-esbuild"] = `^${version}`;',
+  );
+  assertEquals(
+    dependencyIndex > installIndex,
+    true,
+    "bundler extension dependency must be added after build-local npm install so prerelease builds do not require the extension to already be published",
+  );
+});
+
 // Extensions whose implementations are statically imported by
 // src/extensions/builtin-extensions.ts and therefore ship inside the root
 // npm package. Their dependencies must stay in root; every other workspace

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -53,20 +53,87 @@ Deno.test("root npm build metadata does not inject extension implementation depe
 
 Deno.test("root npm CLI package declares the bundler extension after local install", async () => {
   const source = await Deno.readTextFile("scripts/build/build-npm-dnt.ts");
-  const installIndex = source.indexOf('const { code } = await npmInstall.output();');
+  const installIndex = source.indexOf(
+    "const { code } = await npmInstall.output();",
+  );
   const dependencyIndex = source.indexOf(
-    'pkg.dependencies["@veryfront/ext-bundler-esbuild"] = `^${version}`;',
+    'pkg.dependencies["@veryfront/ext-bundler-esbuild"] = version;',
   );
 
   assertStringIncludes(
     source,
-    'pkg.dependencies["@veryfront/ext-bundler-esbuild"] = `^${version}`;',
+    'pkg.dependencies["@veryfront/ext-bundler-esbuild"] = version;',
   );
   assertEquals(
     dependencyIndex > installIndex,
     true,
     "bundler extension dependency must be added after build-local npm install so prerelease builds do not require the extension to already be published",
   );
+});
+
+Deno.test("npm publish version bump pins first-party extension dependencies to the publish version", async () => {
+  const packageDir = await Deno.makeTempDir();
+  const packagePath = `${packageDir}/package.json`;
+  const publishVersion = "0.1.1016-rc.123";
+
+  try {
+    await Deno.writeTextFile(
+      packagePath,
+      JSON.stringify(
+        {
+          name: "veryfront",
+          version: "0.1.1016",
+          dependencies: {
+            veryfront: "^0.1.1016",
+            "@veryfront/ext-bundler-esbuild": "0.1.1016",
+            "@veryfront/ext-content-mdx": "^0.1.1016",
+            "@veryfront/not-an-extension": "^0.1.1016",
+            zod: "4.3.6",
+          },
+          peerDependencies: {
+            veryfront: "^0.1.1016",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const output = await new Deno.Command("bash", {
+      args: [
+        "-c",
+        [
+          "set -euo pipefail",
+          'source "$SCRIPT_PATH"',
+          'VERSION="$PUBLISH_VERSION" update_package_version "$PACKAGE_DIR"',
+        ].join("\n"),
+      ],
+      env: {
+        PACKAGE_DIR: packageDir,
+        PUBLISH_VERSION: publishVersion,
+        SCRIPT_PATH: `${Deno.cwd()}/scripts/ci/publish-npm-packages.sh`,
+      },
+      stderr: "piped",
+      stdout: "piped",
+    }).output();
+
+    assertEquals(output.code, 0, new TextDecoder().decode(output.stderr));
+
+    const pkg = JSON.parse(await Deno.readTextFile(packagePath));
+    assertEquals(pkg.version, publishVersion);
+    assertEquals(pkg.dependencies, {
+      veryfront: `^${publishVersion}`,
+      "@veryfront/ext-bundler-esbuild": publishVersion,
+      "@veryfront/ext-content-mdx": publishVersion,
+      "@veryfront/not-an-extension": "^0.1.1016",
+      zod: "4.3.6",
+    });
+    assertEquals(pkg.peerDependencies, {
+      veryfront: `^${publishVersion}`,
+    });
+  } finally {
+    await Deno.remove(packageDir, { recursive: true });
+  }
 });
 
 // Extensions whose implementations are statically imported by

--- a/scripts/ci/publish-npm-packages.sh
+++ b/scripts/ci/publish-npm-packages.sh
@@ -55,9 +55,17 @@ package_names_from_workspace() {
 update_package_version() {
   PACKAGE_DIR="$1"
   jq --arg v "$VERSION" '
+    def update_first_party_extension_deps:
+      if .dependencies then
+        .dependencies |= with_entries(
+          if (.key | startswith("@veryfront/ext-")) then .value = $v else . end
+        )
+      else . end;
+
     .version = $v
     | if .peerDependencies?.veryfront then .peerDependencies.veryfront = "^" + $v else . end
     | if .dependencies?.veryfront then .dependencies.veryfront = "^" + $v else . end
+    | update_first_party_extension_deps
   ' "${PACKAGE_DIR}/package.json" > "${PACKAGE_DIR}/package.json.tmp"
   mv "${PACKAGE_DIR}/package.json.tmp" "${PACKAGE_DIR}/package.json"
 }
@@ -163,10 +171,12 @@ run_release_publish() {
   done
 }
 
-MODE="${1:-}"
-case "${MODE}" in
-  rc-publish) run_rc_publish ;;
-  preflight) run_preflight ;;
-  release-publish) run_release_publish ;;
-  *) usage ;;
-esac
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  MODE="${1:-}"
+  case "${MODE}" in
+    rc-publish) run_rc_publish ;;
+    preflight) run_preflight ;;
+    release-publish) run_release_publish ;;
+    *) usage ;;
+  esac
+fi

--- a/scripts/test/npm-install-smoke.sh
+++ b/scripts/test/npm-install-smoke.sh
@@ -3,7 +3,7 @@
 #
 # Verifies, against the real `deno task build:npm` artifacts installed into a
 # throwaway npm project, that:
-#   1. a bare `veryfront` install runs the CLI under Node
+#   1. a `veryfront` install with co-published required packages runs the CLI under Node
 #   2. the @huggingface/transformers optional peer is declared
 #   3. loading a missing extension fails naming the installable package
 #   4. installing @veryfront/ext-auth-jwt makes the extension load
@@ -23,29 +23,31 @@ fail() {
 }
 
 [ -d "$ROOT_DIR/npm" ] || fail "npm build output missing; run 'deno task build:npm' first"
+[ -d "$ROOT_DIR/npm/extensions/ext-bundler-esbuild" ] || fail "ext-bundler-esbuild package output missing"
 [ -d "$ROOT_DIR/npm/extensions/ext-auth-jwt" ] || fail "ext-auth-jwt package output missing"
 
 (cd "$ROOT_DIR/npm" && npm pack --silent --pack-destination "$WORKDIR" >/dev/null)
+(cd "$ROOT_DIR/npm/extensions/ext-bundler-esbuild" && npm pack --silent --pack-destination "$WORKDIR" >/dev/null)
 (cd "$ROOT_DIR/npm/extensions/ext-auth-jwt" && npm pack --silent --pack-destination "$WORKDIR" >/dev/null)
 
 cd "$WORKDIR"
 npm init -y >/dev/null 2>&1
-npm install --no-fund --no-audit --silent --ignore-scripts ./veryfront-[0-9]*.tgz
+npm install --no-fund --no-audit --silent --ignore-scripts ./veryfront-[0-9]*.tgz ./veryfront-ext-bundler-esbuild-*.tgz
 
-echo "== 1. bare install: CLI runs under Node"
+echo "== 1. root install: CLI runs under Node"
 node node_modules/veryfront/bin/veryfront.js --version | grep -q "Veryfront CLI" ||
-  fail "CLI --version failed on bare install"
+  fail "CLI --version failed on root install"
 node node_modules/veryfront/bin/veryfront.js schema --json >/dev/null ||
-  fail "CLI schema --json failed on bare install (bundled ext-schema-zod broken)"
+  fail "CLI schema --json failed on root install (bundled ext-schema-zod broken)"
 
-echo "== 2. bare install: transformers optional peer declared"
+echo "== 2. root install: transformers optional peer declared"
 node -e "
 const p = require('./node_modules/veryfront/package.json');
 if (!p.peerDependencies?.['@huggingface/transformers']) process.exit(1);
 if (p.peerDependenciesMeta?.['@huggingface/transformers']?.optional !== true) process.exit(1);
 " || fail "@huggingface/transformers optional peer missing from root package.json"
 
-echo "== 3. bare install: missing extension failure names the installable package"
+echo "== 3. root install: missing extension failure names the installable package"
 set +e
 MISSING_OUTPUT="$(node -e "
 import('./node_modules/veryfront/esm/src/extensions/first-party-import.js').then(async (m) => {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1015";
+export const VERSION = "0.1.1016";


### PR DESCRIPTION
## Summary
- Adds `@veryfront/ext-bundler-esbuild` to the published root `veryfront` npm package because the CLI imports it before project bootstrap.
- Injects the dependency after the build-local `npm install` step so prerelease builds do not require the just-built extension version to already be published.
- Adds a metadata regression test that guards the dependency and its placement.

## Root Cause
`create-veryfront` only delegates to `veryfront init`; it does not own the generated templates. Fresh scaffold output already includes first-party extension packages, but older Deno projects can keep `veryfront` on a caret range without those extension deps. When those projects float to a newer CLI, `deno task dev` runs `npm:veryfront`, and the CLI cannot resolve `@veryfront/ext-bundler-esbuild` before bootstrap.

## Test Plan
- `deno task build:npm`
- `deno test --config=scripts/test.deno.json --no-check --allow-read scripts/build/npm-package-metadata.test.ts scripts/build/npm-extension-package-metadata.test.ts`
- `deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all cli/commands/init/config-generator.test.ts cli/commands/init/deno-config-generator.test.ts`
- Packed local CLI smoke from an old Deno scaffold without extension deps reached `Server ready`.
- Pre-push hook passed: format, lint, typecheck, and `test:unit` with `2299 passed`.

## Not Tested
- Full registry `npm:veryfront` publish/install path, because local Deno `npm:` resolution does not reliably consume local tarball metadata.