### PR TITLE
Make Deno scaffolds install runnable default extensions

### DIFF
--- a/cli/commands/init/config-generator.test.ts
+++ b/cli/commands/init/config-generator.test.ts
@@ -58,6 +58,22 @@ describe("config-generator", () => {
       }
     });
 
+    it("aligns template-owned first-party extensions to the framework version", async () => {
+      const tmpDir = await Deno.makeTempDir();
+      try {
+        await createPackageJson(tmpDir, "test-project", {
+          firstPartyExtensions: ["@veryfront/ext-document-kreuzberg"],
+        });
+        const pkg = JSON.parse(await Deno.readTextFile(join(tmpDir, "package.json")));
+        assertEquals(
+          pkg.dependencies["@veryfront/ext-document-kreuzberg"],
+          pkg.dependencies.veryfront,
+        );
+      } finally {
+        await Deno.remove(tmpDir, { recursive: true });
+      }
+    });
+
     it("merges npmDependencies from selected integrations", async () => {
       const tmpDir = await Deno.makeTempDir();
       try {

--- a/cli/commands/init/config-generator.ts
+++ b/cli/commands/init/config-generator.ts
@@ -14,6 +14,8 @@ const REQUIRED_INIT_EXTENSION_PACKAGES = [
 export interface CreatePackageJsonOptions {
   /** Template-owned dependencies that must be installed for generated apps. */
   dependencies?: Record<string, string>;
+  /** Template-owned first-party extension packages aligned to the Veryfront version. */
+  firstPartyExtensions?: readonly string[];
   /**
    * Selected integrations whose `connector.json#npmDependencies` should be
    * merged into the generated project's `package.json#dependencies`.
@@ -61,8 +63,15 @@ export async function createPackageJson(
 
   const dirName = projectDir.split(/[/\\]/).pop();
   const veryfrontVersionRange = `^${VERSION}`;
+  const firstPartyExtensionPackages = [
+    ...REQUIRED_INIT_EXTENSION_PACKAGES,
+    ...(options.firstPartyExtensions ?? []),
+  ];
   const requiredExtensionDeps = Object.fromEntries(
-    REQUIRED_INIT_EXTENSION_PACKAGES.map((packageName) => [packageName, veryfrontVersionRange]),
+    [...new Set(firstPartyExtensionPackages)].map((packageName) => [
+      packageName,
+      veryfrontVersionRange,
+    ]),
   );
   const packageJson = {
     name: projectName ?? dirName ?? "veryfront-project",

--- a/cli/commands/init/deno-config-generator.test.ts
+++ b/cli/commands/init/deno-config-generator.test.ts
@@ -20,18 +20,18 @@ describe("deno-config-generator", () => {
       }
     });
 
-    it("writes dev, build, preview tasks invoking npm:veryfront", async () => {
+    it("writes dev, build, preview tasks invoking npm:veryfront@latest", async () => {
       const tmpDir = await Deno.makeTempDir();
       try {
         await createDenoConfig(tmpDir);
         const parsed = JSON.parse(
           await Deno.readTextFile(join(tmpDir, "deno.json")),
         );
-        assertEquals(parsed.tasks.dev, "deno run -A npm:veryfront dev");
-        assertEquals(parsed.tasks.build, "deno run -A npm:veryfront build");
+        assertEquals(parsed.tasks.dev, "deno run -A npm:veryfront@latest dev");
+        assertEquals(parsed.tasks.build, "deno run -A npm:veryfront@latest build");
         assertEquals(
           parsed.tasks.preview,
-          "deno run -A npm:veryfront preview",
+          "deno run -A npm:veryfront@latest preview",
         );
       } finally {
         await Deno.remove(tmpDir, { recursive: true });

--- a/cli/commands/init/deno-config-generator.ts
+++ b/cli/commands/init/deno-config-generator.ts
@@ -4,9 +4,9 @@ import { createFileSystem } from "veryfront/platform";
 const DENO_CONFIG = {
   nodeModulesDir: "auto",
   tasks: {
-    dev: "deno run -A npm:veryfront dev",
-    build: "deno run -A npm:veryfront build",
-    preview: "deno run -A npm:veryfront preview",
+    dev: "deno run -A npm:veryfront@latest dev",
+    build: "deno run -A npm:veryfront@latest build",
+    preview: "deno run -A npm:veryfront@latest preview",
   },
 };
 

--- a/cli/commands/init/init-command.ts
+++ b/cli/commands/init/init-command.ts
@@ -482,6 +482,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
     if (!options.quiet) {
       await createPackageJson(projectDir, projectName, {
         dependencies: templateConfig?.npmDependencies,
+        firstPartyExtensions: templateConfig?.firstPartyExtensions,
         integrations: loadedIntegrations.map((integration) => ({
           name: integration.config.name,
           npmDependencies: integration.config.npmDependencies,

--- a/cli/commands/init/init.integration.test.ts
+++ b/cli/commands/init/init.integration.test.ts
@@ -422,7 +422,7 @@ describe("init command integration", () => {
         await readTextFile(join(projectDir, "deno.json")),
       );
       assertEquals(parsed.nodeModulesDir, "auto");
-      assertEquals(parsed.tasks.dev, "deno run -A npm:veryfront dev");
+      assertEquals(parsed.tasks.dev, "deno run -A npm:veryfront@latest dev");
       assertExists(parsed.tasks.build);
       assertExists(parsed.tasks.preview);
     });

--- a/cli/commands/init/init.integration.test.ts
+++ b/cli/commands/init/init.integration.test.ts
@@ -261,6 +261,10 @@ describe("init command integration", () => {
       const pkg = JSON.parse(await readTextFile(join(projectDir, "package.json")));
       assertEquals(pkg.dependencies["@kreuzberg/node"], "^4.4.2");
       assertEquals(pkg.dependencies["@kreuzberg/wasm"], "4.5.2");
+      assertEquals(
+        pkg.dependencies["@veryfront/ext-document-kreuzberg"],
+        pkg.dependencies.veryfront,
+      );
     });
 
     it("does not write a partial package.json for quiet docs-agent projects", async () => {

--- a/cli/templates/index.test.ts
+++ b/cli/templates/index.test.ts
@@ -52,6 +52,9 @@ describe("cli/templates", () => {
     );
     assertEquals(templateConfigs["docs-agent"]?.npmDependencies?.["@kreuzberg/node"], "^4.4.2");
     assertEquals(templateConfigs["docs-agent"]?.npmDependencies?.["@kreuzberg/wasm"], "4.5.2");
+    assertEquals(templateConfigs["docs-agent"]?.firstPartyExtensions, [
+      "@veryfront/ext-document-kreuzberg",
+    ]);
   });
 
   it("ships a Tailwind entry stylesheet for styled starter templates", async () => {

--- a/cli/templates/index.ts
+++ b/cli/templates/index.ts
@@ -46,6 +46,7 @@ export {
 
 export const templateConfigs: Partial<Record<TemplateName, TemplateConfig>> = {
   "docs-agent": {
+    firstPartyExtensions: ["@veryfront/ext-document-kreuzberg"],
     npmDependencies: {
       "@kreuzberg/node": "^4.4.2",
       "@kreuzberg/wasm": "4.5.2",

--- a/cli/templates/types.ts
+++ b/cli/templates/types.ts
@@ -22,6 +22,7 @@ export interface TemplateFile {
 export interface TemplateConfig {
   envVars?: EnvVarConfig[];
   npmDependencies?: Record<string, string>;
+  firstPartyExtensions?: string[];
 }
 
 export type TemplateName =

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1016",
+  "version": "0.1.1017",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1016";
+export const VERSION = "0.1.1017";


### PR DESCRIPTION
## Summary
- change generated Deno `deno task` commands to call `npm:veryfront@latest`
- bump the release version to `0.1.1017` so the scaffold fixes can ship in a new npm release
- keep global scaffold extension defaults aligned to `veryfront`
- add template-scoped first-party extension metadata so `docs-agent` installs `@veryfront/ext-document-kreuzberg` for its upload flow

## Default extension audit
Generated apps need these first-party extensions out of the box:
- `@veryfront/ext-bundler-esbuild` for `Bundler` / `ModuleLexer`
- `@veryfront/ext-content-mdx` for `.md` / `.mdx` pages, including the minimal template's `app/about/page.mdx`
- `@veryfront/ext-css-tailwind` for starter `globals.css` / Tailwind processing
- `@veryfront/ext-parser-babel` for `CodeParser` in RSC/export analysis

`docs-agent` additionally needs:
- `@veryfront/ext-document-kreuzberg` for `DocumentExtractor` used by `createUploadHandler()` on PDF/DOCX/XLSX/PPTX/rich uploads

`@veryfront/ext-schema-zod` is root-bundled, and provider/auth/db/observability/sandbox extensions remain opt-in because default starter routes do not require those contracts.

## Testing
- `deno test --config=deno.json --no-check --allow-all cli/commands/init/config-generator.test.ts cli/commands/init/deno-config-generator.test.ts cli/commands/init/init.integration.test.ts cli/templates/index.test.ts`
- `deno fmt --check cli/templates/types.ts cli/templates/index.ts cli/templates/index.test.ts cli/commands/init/config-generator.ts cli/commands/init/config-generator.test.ts cli/commands/init/init-command.ts cli/commands/init/init.integration.test.ts`
- `deno check --config=deno.json cli/templates/index.ts cli/templates/types.ts cli/commands/init/config-generator.ts cli/commands/init/init-command.ts`
- local source scaffold smoke for `minimal` and `docs-agent` Deno projects verified extension dependencies and `npm:veryfront@latest` tasks
- pre-push hook passed: format, lint, typecheck, and `deno task test:unit` (`2299 passed`, `0 failed`)