### PR TITLE
Run Deno scaffold tasks through pinned Deno npm specs

### DIFF
--- a/cli/commands/init/deno-config-generator.test.ts
+++ b/cli/commands/init/deno-config-generator.test.ts
@@ -20,18 +20,18 @@ describe("deno-config-generator", () => {
       }
     });
 
-    it("writes dev, build, preview tasks invoking npm:veryfront@latest", async () => {
+    it("writes dev, build, preview tasks invoking the installed Veryfront CLI", async () => {
       const tmpDir = await Deno.makeTempDir();
       try {
         await createDenoConfig(tmpDir);
         const parsed = JSON.parse(
           await Deno.readTextFile(join(tmpDir, "deno.json")),
         );
-        assertEquals(parsed.tasks.dev, "deno run -A npm:veryfront@latest dev");
-        assertEquals(parsed.tasks.build, "deno run -A npm:veryfront@latest build");
+        assertEquals(parsed.tasks.dev, "veryfront dev");
+        assertEquals(parsed.tasks.build, "veryfront build");
         assertEquals(
           parsed.tasks.preview,
-          "deno run -A npm:veryfront@latest preview",
+          "veryfront preview",
         );
       } finally {
         await Deno.remove(tmpDir, { recursive: true });

--- a/cli/commands/init/deno-config-generator.test.ts
+++ b/cli/commands/init/deno-config-generator.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { VERSION } from "#cli/utils";
 import { join } from "veryfront/platform/path";
 
 import { createDenoConfig } from "./deno-config-generator.ts";
@@ -20,19 +21,35 @@ describe("deno-config-generator", () => {
       }
     });
 
-    it("writes dev, build, preview tasks invoking the installed Veryfront CLI", async () => {
+    it("writes dev, build, preview tasks through pinned Deno npm specs", async () => {
       const tmpDir = await Deno.makeTempDir();
       try {
         await createDenoConfig(tmpDir);
         const parsed = JSON.parse(
           await Deno.readTextFile(join(tmpDir, "deno.json")),
         );
-        assertEquals(parsed.tasks.dev, "veryfront dev");
-        assertEquals(parsed.tasks.build, "veryfront build");
+        assertEquals(parsed.tasks.dev, `deno run -A npm:veryfront@${VERSION} dev`);
+        assertEquals(parsed.tasks.build, `deno run -A npm:veryfront@${VERSION} build`);
         assertEquals(
           parsed.tasks.preview,
-          "veryfront preview",
+          `deno run -A npm:veryfront@${VERSION} preview`,
         );
+      } finally {
+        await Deno.remove(tmpDir, { recursive: true });
+      }
+    });
+
+    it("does not use @latest or the Node-based local npm bin wrapper", async () => {
+      const tmpDir = await Deno.makeTempDir();
+      try {
+        await createDenoConfig(tmpDir);
+        const parsed = JSON.parse(
+          await Deno.readTextFile(join(tmpDir, "deno.json")),
+        );
+        for (const task of Object.values(parsed.tasks)) {
+          assertEquals(String(task).includes("@latest"), false);
+          assertEquals(String(task).startsWith("veryfront "), false);
+        }
       } finally {
         await Deno.remove(tmpDir, { recursive: true });
       }

--- a/cli/commands/init/deno-config-generator.ts
+++ b/cli/commands/init/deno-config-generator.ts
@@ -4,9 +4,9 @@ import { createFileSystem } from "veryfront/platform";
 const DENO_CONFIG = {
   nodeModulesDir: "auto",
   tasks: {
-    dev: "deno run -A npm:veryfront@latest dev",
-    build: "deno run -A npm:veryfront@latest build",
-    preview: "deno run -A npm:veryfront@latest preview",
+    dev: "veryfront dev",
+    build: "veryfront build",
+    preview: "veryfront preview",
   },
 };
 

--- a/cli/commands/init/deno-config-generator.ts
+++ b/cli/commands/init/deno-config-generator.ts
@@ -1,19 +1,22 @@
+import { VERSION } from "#cli/utils";
 import { join } from "veryfront/platform/path";
 import { createFileSystem } from "veryfront/platform";
+
+const VERYFRONT_DENO_SPEC = `npm:veryfront@${VERSION}`;
 
 const DENO_CONFIG = {
   nodeModulesDir: "auto",
   tasks: {
-    dev: "veryfront dev",
-    build: "veryfront build",
-    preview: "veryfront preview",
+    dev: `deno run -A ${VERYFRONT_DENO_SPEC} dev`,
+    build: `deno run -A ${VERYFRONT_DENO_SPEC} build`,
+    preview: `deno run -A ${VERYFRONT_DENO_SPEC} preview`,
   },
 };
 
 /**
  * Write a thin `deno.json` to the scaffolded project directory. Relies on
- * `nodeModulesDir: "auto"` so Deno reads dependencies from the
- * sibling `package.json` and materializes `node_modules/` on first task run.
+ * exact-version `npm:` specs so task execution stays hosted by Deno without
+ * drifting to a newer CLI than the scaffolded dependencies.
  *
  * Throws if `deno.json` already exists at the destination — no template
  * ships one today, so an existing file means something unexpected.

--- a/cli/commands/init/init.integration.test.ts
+++ b/cli/commands/init/init.integration.test.ts
@@ -426,7 +426,7 @@ describe("init command integration", () => {
         await readTextFile(join(projectDir, "deno.json")),
       );
       assertEquals(parsed.nodeModulesDir, "auto");
-      assertEquals(parsed.tasks.dev, "deno run -A npm:veryfront@latest dev");
+      assertEquals(parsed.tasks.dev, "veryfront dev");
       assertExists(parsed.tasks.build);
       assertExists(parsed.tasks.preview);
     });

--- a/cli/commands/init/init.integration.test.ts
+++ b/cli/commands/init/init.integration.test.ts
@@ -11,6 +11,7 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { VERSION } from "#cli/utils";
 import { join } from "#veryfront/compat/path/index.ts";
 import { exists, makeTempDir, readTextFile, remove, stat } from "#veryfront/testing/deno-compat.ts";
 import { runCommand } from "#veryfront/compat/process.ts";
@@ -426,7 +427,7 @@ describe("init command integration", () => {
         await readTextFile(join(projectDir, "deno.json")),
       );
       assertEquals(parsed.nodeModulesDir, "auto");
-      assertEquals(parsed.tasks.dev, "veryfront dev");
+      assertEquals(parsed.tasks.dev, `deno run -A npm:veryfront@${VERSION} dev`);
       assertExists(parsed.tasks.build);
       assertExists(parsed.tasks.preview);
     });

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1017",
+  "version": "0.1.1018",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1017";
+export const VERSION = "0.1.1018";


### PR DESCRIPTION
## Summary
- change generated Deno `deno task` commands from `deno run -A npm:veryfront@latest ...` to exact-version `deno run -A npm:veryfront@<release> ...` commands
- keep Deno scaffold execution hosted by Deno instead of the Node-shebang npm bin wrapper
- preserve CLI/extension release alignment by deriving the task spec from `VERSION` and keeping generated package dependencies on the same release range
- add regression expectations so Deno scaffolds emit neither `@latest` nor bare `veryfront ...` task commands

## Why
PR #2787 fixed stale bare `npm:veryfront` lock reuse, but the `@latest` task form can drift the CLI ahead of the extension versions installed by the generated app. A follow-up review also caught that bare local-bin task commands resolve to the published npm bin wrapper, which uses `#!/usr/bin/env node`; that breaks Deno-only machines. Exact `npm:veryfront@<release>` task specs keep the execution path Deno-hosted and version-pinned.

## Extension default stance
This keeps the default extension policy from #2787:
- globally install only extensions reachable from all default scaffold files/routes
- add template-specific extensions where generated templates require them, e.g. `docs-agent` and `@veryfront/ext-document-kreuzberg`
- do not install every first-party extension by default, because optional auth/db/cache/observability/sandbox/provider packages would broaden install size and failure surface without being used by most starters

## Testing
- `deno test --config=deno.json --no-check --allow-all cli/commands/init/deno-config-generator.test.ts cli/commands/init/init.integration.test.ts`
- source scaffold smoke verified generated minimal Deno tasks use `deno run -A npm:veryfront@0.1.1018 ...` and package dependencies remain aligned on `^0.1.1018`
- `deno run -A npm:veryfront@0.1.1017 --version` verified the current published package entry runs under Deno
- `deno fmt --check cli/commands/init/deno-config-generator.ts cli/commands/init/deno-config-generator.test.ts cli/commands/init/init.integration.test.ts`
- `deno check --config=deno.json cli/commands/init/deno-config-generator.ts cli/commands/init/init-command.ts`
- `git diff --check`
- pre-push hook passed: format, lint, typecheck, and `deno task test:unit` (`2299 passed`, `0 failed`)
