### PR TITLE
Give Kimi thinking models an output-token budget (fix empty final message)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1018",
+  "version": "0.1.1019",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1019",
+  "version": "0.1.1020",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/agent/runtime/constants.test.ts
+++ b/src/agent/runtime/constants.test.ts
@@ -28,6 +28,8 @@ describe("getModelMaxOutputTokens", () => {
   });
 
   it("returns a large limit for Kimi thinking models so reasoning_content does not exhaust the budget", () => {
+    assertEquals(getModelMaxOutputTokens("moonshotai/kimi-k2"), 32_000);
+    assertEquals(getModelMaxOutputTokens("veryfront-cloud/moonshotai/kimi-k2"), 32_000);
     assertEquals(getModelMaxOutputTokens("moonshotai/kimi-k2.6"), 32_000);
     assertEquals(getModelMaxOutputTokens("veryfront-cloud/moonshotai/kimi-k2.6"), 32_000);
     assertEquals(getModelMaxOutputTokens("moonshotai/kimi-k2.5"), 32_000);

--- a/src/agent/runtime/constants.test.ts
+++ b/src/agent/runtime/constants.test.ts
@@ -27,6 +27,12 @@ describe("getModelMaxOutputTokens", () => {
     assertEquals(getModelMaxOutputTokens("veryfront-cloud/mistral/mistral-large-2512"), 1_024);
   });
 
+  it("returns a large limit for Kimi thinking models so reasoning_content does not exhaust the budget", () => {
+    assertEquals(getModelMaxOutputTokens("moonshotai/kimi-k2.6"), 32_000);
+    assertEquals(getModelMaxOutputTokens("veryfront-cloud/moonshotai/kimi-k2.6"), 32_000);
+    assertEquals(getModelMaxOutputTokens("moonshotai/kimi-k2.5"), 32_000);
+  });
+
   it("returns undefined for unknown models", () => {
     assertEquals(getModelMaxOutputTokens("unknown/model"), undefined);
   });

--- a/src/agent/runtime/constants.ts
+++ b/src/agent/runtime/constants.ts
@@ -20,10 +20,7 @@ const MODEL_MAX_OUTPUT_TOKENS: Record<string, number> = {
   "google-ai-studio/gemini-2.5-pro": 65_536,
   "google-ai-studio/gemini-2.5-flash": 65_536,
   "mistral/mistral-large-2512": 1_024,
-  // Kimi K2 models are thinking models: reasoning_content can consume several
-  // thousand tokens before any answer content is emitted. Without an entry here
-  // they fall back to DEFAULT_MAX_TOKENS and hit finish_reason "length"
-  // mid-reasoning, returning an empty final message. Give them ample budget.
+  "moonshotai/kimi-k2": 32_000,
   "moonshotai/kimi-k2.6": 32_000,
   "moonshotai/kimi-k2.5": 32_000,
 };

--- a/src/agent/runtime/constants.ts
+++ b/src/agent/runtime/constants.ts
@@ -20,6 +20,12 @@ const MODEL_MAX_OUTPUT_TOKENS: Record<string, number> = {
   "google-ai-studio/gemini-2.5-pro": 65_536,
   "google-ai-studio/gemini-2.5-flash": 65_536,
   "mistral/mistral-large-2512": 1_024,
+  // Kimi K2 models are thinking models: reasoning_content can consume several
+  // thousand tokens before any answer content is emitted. Without an entry here
+  // they fall back to DEFAULT_MAX_TOKENS (4_096) and hit finish_reason "length"
+  // mid-reasoning, returning an empty final message. Give them ample budget.
+  "moonshotai/kimi-k2.6": 32_000,
+  "moonshotai/kimi-k2.5": 32_000,
 };
 
 const MODEL_MAX_OUTPUT_TOKEN_ALIASES: Record<string, string> = {

--- a/src/agent/runtime/constants.ts
+++ b/src/agent/runtime/constants.ts
@@ -22,7 +22,7 @@ const MODEL_MAX_OUTPUT_TOKENS: Record<string, number> = {
   "mistral/mistral-large-2512": 1_024,
   // Kimi K2 models are thinking models: reasoning_content can consume several
   // thousand tokens before any answer content is emitted. Without an entry here
-  // they fall back to DEFAULT_MAX_TOKENS (4_096) and hit finish_reason "length"
+  // they fall back to DEFAULT_MAX_TOKENS and hit finish_reason "length"
   // mid-reasoning, returning an empty final message. Give them ample budget.
   "moonshotai/kimi-k2.6": 32_000,
   "moonshotai/kimi-k2.5": 32_000,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1019";
+export const VERSION = "0.1.1020";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1018";
+export const VERSION = "0.1.1019";


### PR DESCRIPTION
## Problem

Agents pinned to Kimi (`moonshotai/kimi-k2.6` / `kimi-k2.5`) intermittently return an **empty final message** — they do all the tool work correctly, then emit no answer.

## Root cause

Kimi K2 are **thinking models**: they stream substantial `reasoning_content` before any answer `content`. They were **missing from `MODEL_MAX_OUTPUT_TOKENS`**, so `getModelMaxOutputTokens()` returned `undefined` and the runtime fell back to `DEFAULT_MAX_TOKENS` (**4_096**). On a reasoning-heavy turn Kimi spends the whole 4_096-token budget on reasoning and hits `finish_reason: "length"` **before emitting any content**.

Confirmed by instrumenting the chat-stream parser against the live gateway. The failing final turn:

```
content=0  reasoning=16735 chars (~4180 tokens)  finish="length"
```

~4,180 reasoning tokens ≈ the 4,096 cap, with zero budget left for the answer. Every other cloud model has an explicit multi-thousand-token entry (Sonnet 64k, GPT 128k, Gemini 65k); Kimi silently got the 4k default.

## Fix

Add explicit `32_000`-token limits for `kimi-k2.6` / `kimi-k2.5` so reasoning **plus** the answer fit.

After the fix, the same sweep that returned an empty report now completes:

```
content=5189  reasoning=2059  finish="stop"
```

## Verification

- New unit test in `constants.test.ts` (bare + `veryfront-cloud/` prefix) — green.
- End-to-end against the veryfront-cloud gateway (`claude`-equivalent harness on Kimi): a previously-empty triage sweep now returns a full written report and passes its eval (`doubled-secret-prefix` went from 0/7 → repeatedly green).

Bumps to `0.1.1019`.