### PR TITLE
Fix Tailwind plugin loading in Deno npm runtime

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1018",
+  "version": "0.1.1019",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/html/styles-builder/plugin-loader.test.ts
+++ b/src/html/styles-builder/plugin-loader.test.ts
@@ -228,6 +228,37 @@ describe("styles-builder/plugin-loader", () => {
     }
   });
 
+  it("does not depend on Deno.makeTempFile for plugin module imports", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalMakeTempFile = Deno.makeTempFile;
+    let fetchCallCount = 0;
+
+    globalThis.fetch = (() => {
+      fetchCallCount++;
+      if (fetchCallCount === 1) {
+        return Promise.resolve(
+          new Response(`export * from "/v1/temp-dir-plugin.bundle.mjs";`, { status: 200 }),
+        );
+      }
+      return Promise.resolve(
+        new Response(`export default { id: "temp-dir-plugin" };`, { status: 200 }),
+      );
+    }) as typeof fetch;
+
+    Deno.makeTempFile = (() =>
+      Promise.reject(
+        new Error("Deno.makeTempFile must not be used for plugin module imports"),
+      )) as typeof Deno.makeTempFile;
+
+    try {
+      const plugin = await loadModuleFromEsmSh("@tailwindcss/typography");
+      assertEquals((plugin as { default?: { id?: string } }).default?.id, "temp-dir-plugin");
+    } finally {
+      globalThis.fetch = originalFetch;
+      Deno.makeTempFile = originalMakeTempFile;
+    }
+  });
+
   it("uses the non-Deno import path in Node-like runtimes with Deno shims", async () => {
     const originalFetch = globalThis.fetch;
     const originalProcess = Object.getOwnPropertyDescriptor(globalThis, "process");

--- a/src/html/styles-builder/plugin-loader.ts
+++ b/src/html/styles-builder/plugin-loader.ts
@@ -16,7 +16,8 @@ import {
   VeryfrontError,
 } from "#veryfront/errors";
 import { getTailwindPluginBundleUrl } from "#veryfront/build/binary-plugin-includes.ts";
-import { isDeno } from "#veryfront/platform/compat/runtime.ts";
+import { getDenoRuntime, isDeno } from "#veryfront/platform/compat/runtime.ts";
+import { join, toFileUrl } from "#veryfront/platform/compat/path/index.ts";
 import {
   bareName,
   PACKAGE_SPEC_RE,
@@ -118,16 +119,24 @@ async function importBundledModule(code: string): Promise<unknown> {
     return await import(dataUrl);
   }
 
-  const tempPath = await Deno.makeTempFile({ prefix: "vf_tw_plugin_", suffix: ".mjs" });
-  await Deno.writeTextFile(tempPath, code);
+  const deno = getDenoRuntime();
+  if (!deno) {
+    throw IMPORT_RESOLUTION_ERROR.create({
+      detail: "Deno runtime was expected while importing a Tailwind plugin module",
+    });
+  }
+
+  const tempDir = await deno.makeTempDir({ prefix: "vf_tw_plugin_" });
+  const tempPath = join(tempDir, "plugin.mjs");
+  await deno.writeTextFile(tempPath, code);
   logger.debug("Wrote plugin to temp file", { path: tempPath });
 
   try {
-    return await import(`file://${tempPath}`);
+    return await import(toFileUrl(tempPath).href);
   } finally {
-    await Deno.remove(tempPath).catch((error) => {
-      logger.error("Failed to clean up temp plugin file", {
-        path: tempPath,
+    await deno.remove(tempDir, { recursive: true }).catch((error) => {
+      logger.error("Failed to clean up temp plugin directory", {
+        path: tempDir,
         error: error instanceof Error ? error.message : String(error),
       });
     });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1018";
+export const VERSION = "0.1.1019";


### PR DESCRIPTION
## Summary
- avoid the dnt `@deno/shim-deno` `makeTempFile({ prefix })` path for Tailwind npm plugin imports
- load Deno npm plugins through a real Deno temp directory and file URL, while keeping the Node/Bun data URL import path unchanged
- add regression coverage and bump the release version to 0.1.1019

## Validation
- `deno test --config=deno.json --no-check --allow-all src/html/styles-builder/plugin-loader.test.ts`
- `deno check --config=deno.json src/html/styles-builder/plugin-loader.ts src/html/styles-builder/plugin-loader.test.ts`
- `deno test --config=scripts/test.deno.json --no-check --allow-read --allow-write --allow-run scripts/build/npm-package-metadata.test.ts`
- `deno task build:npm`
- packed npm smoke: Deno real `generateTailwindCSS` typography compile returned CSS (`cssLength: 21150`)
- packed npm smoke: Node fake plugin load returned `id: node-fake`
- packed npm smoke: Bun fake plugin load returned `id: bun-fake`
- pre-push hook passed: format, lint, type check, and `deno task test:unit` (`2299 passed`, `0 failed`)

## Notes
This fixes the generated npm package path that Deno users hit after `npm create veryfront`. The missing typography banner was caused by the plugin temp-file import failing before the extension dependency could load.