### PR TITLE
Package auto-loaded CLI extensions with root npm release

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1021",
+  "version": "0.1.1022",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -258,8 +258,10 @@ await build({
 		pkg.bin = { veryfront: "bin/veryfront.js" };
 		pkg.dependencies ??= {};
 		// Add after build-local npm install so releases do not require the
-		// just-built extension version to already exist in the registry.
+		// just-built auto-loaded extension versions to already exist in the registry.
 		pkg.dependencies["@veryfront/ext-bundler-esbuild"] = version;
+		pkg.dependencies["@veryfront/ext-content-mdx"] = version;
+		pkg.dependencies["@veryfront/ext-css-tailwind"] = version;
 		pkg.files = ["esm", "script", "bin", "assets", "tsconfig.json", "LICENSE", "NOTICE", "README.md"];
 		pkg.exports["./tsconfig.json"] = "./tsconfig.json";
 		addTypesExportEntries(pkg.exports);

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -412,6 +412,28 @@ describe("npm supply-chain policy", () => {
     assertEquals(source.includes("importFirstPartyExtensionModule"), false);
   });
 
+  it("packs auto-loaded extension tarballs for npm install smoke tests", async () => {
+    const source = await Deno.readTextFile("scripts/test/npm-install-smoke.sh");
+    const autoLoadedExtensions = [
+      "ext-bundler-esbuild",
+      "ext-content-mdx",
+      "ext-css-tailwind",
+    ];
+
+    for (const extensionName of autoLoadedExtensions) {
+      const tarballName = `veryfront-${extensionName}-*.tgz`;
+
+      assertStringIncludes(
+        source,
+        `npm/extensions/${extensionName}`,
+      );
+      assertStringIncludes(
+        source,
+        tarballName,
+      );
+    }
+  });
+
   it("loads CLI command handlers after global routing decisions", async () => {
     const source = await Deno.readTextFile("cli/router.ts");
 

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -51,24 +51,29 @@ Deno.test("root npm build metadata does not inject extension implementation depe
   }
 });
 
-Deno.test("root npm CLI package declares the bundler extension after local install", async () => {
+Deno.test("root npm CLI package declares auto-loaded first-party extensions after local install", async () => {
   const source = await Deno.readTextFile("scripts/build/build-npm-dnt.ts");
   const installIndex = source.indexOf(
     "const { code } = await npmInstall.output();",
   );
-  const dependencyIndex = source.indexOf(
-    'pkg.dependencies["@veryfront/ext-bundler-esbuild"] = version;',
-  );
+  for (
+    const packageName of [
+      "@veryfront/ext-bundler-esbuild",
+      "@veryfront/ext-content-mdx",
+      "@veryfront/ext-css-tailwind",
+    ]
+  ) {
+    const dependencyAssignment =
+      `pkg.dependencies["${packageName}"] = version;`;
+    const dependencyIndex = source.indexOf(dependencyAssignment);
 
-  assertStringIncludes(
-    source,
-    'pkg.dependencies["@veryfront/ext-bundler-esbuild"] = version;',
-  );
-  assertEquals(
-    dependencyIndex > installIndex,
-    true,
-    "bundler extension dependency must be added after build-local npm install so prerelease builds do not require the extension to already be published",
-  );
+    assertStringIncludes(source, dependencyAssignment);
+    assertEquals(
+      dependencyIndex > installIndex,
+      true,
+      `${packageName} dependency must be added after build-local npm install so prerelease builds do not require the extension to already be published`,
+    );
+  }
 });
 
 Deno.test("npm publish version bump pins first-party extension dependencies to the publish version", async () => {
@@ -87,6 +92,7 @@ Deno.test("npm publish version bump pins first-party extension dependencies to t
             veryfront: "^0.1.1016",
             "@veryfront/ext-bundler-esbuild": "0.1.1016",
             "@veryfront/ext-content-mdx": "^0.1.1016",
+            "@veryfront/ext-css-tailwind": "^0.1.1016",
             "@veryfront/not-an-extension": "^0.1.1016",
             zod: "4.3.6",
           },
@@ -125,6 +131,7 @@ Deno.test("npm publish version bump pins first-party extension dependencies to t
       veryfront: `^${publishVersion}`,
       "@veryfront/ext-bundler-esbuild": publishVersion,
       "@veryfront/ext-content-mdx": publishVersion,
+      "@veryfront/ext-css-tailwind": publishVersion,
       "@veryfront/not-an-extension": "^0.1.1016",
       zod: "4.3.6",
     });

--- a/scripts/test/npm-install-smoke.sh
+++ b/scripts/test/npm-install-smoke.sh
@@ -24,15 +24,19 @@ fail() {
 
 [ -d "$ROOT_DIR/npm" ] || fail "npm build output missing; run 'deno task build:npm' first"
 [ -d "$ROOT_DIR/npm/extensions/ext-bundler-esbuild" ] || fail "ext-bundler-esbuild package output missing"
+[ -d "$ROOT_DIR/npm/extensions/ext-content-mdx" ] || fail "ext-content-mdx package output missing"
+[ -d "$ROOT_DIR/npm/extensions/ext-css-tailwind" ] || fail "ext-css-tailwind package output missing"
 [ -d "$ROOT_DIR/npm/extensions/ext-auth-jwt" ] || fail "ext-auth-jwt package output missing"
 
 (cd "$ROOT_DIR/npm" && npm pack --silent --pack-destination "$WORKDIR" >/dev/null)
 (cd "$ROOT_DIR/npm/extensions/ext-bundler-esbuild" && npm pack --silent --pack-destination "$WORKDIR" >/dev/null)
+(cd "$ROOT_DIR/npm/extensions/ext-content-mdx" && npm pack --silent --pack-destination "$WORKDIR" >/dev/null)
+(cd "$ROOT_DIR/npm/extensions/ext-css-tailwind" && npm pack --silent --pack-destination "$WORKDIR" >/dev/null)
 (cd "$ROOT_DIR/npm/extensions/ext-auth-jwt" && npm pack --silent --pack-destination "$WORKDIR" >/dev/null)
 
 cd "$WORKDIR"
 npm init -y >/dev/null 2>&1
-npm install --no-fund --no-audit --silent --ignore-scripts ./veryfront-[0-9]*.tgz ./veryfront-ext-bundler-esbuild-*.tgz
+npm install --no-fund --no-audit --silent --ignore-scripts ./veryfront-[0-9]*.tgz ./veryfront-ext-bundler-esbuild-*.tgz ./veryfront-ext-content-mdx-*.tgz ./veryfront-ext-css-tailwind-*.tgz
 
 echo "== 1. root install: CLI runs under Node"
 node node_modules/veryfront/bin/veryfront.js --version | grep -q "Veryfront CLI" ||

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1021";
+export const VERSION = "0.1.1022";


### PR DESCRIPTION
## Summary
- Add root npm package dependencies for auto-loaded `@veryfront/ext-content-mdx` and `@veryfront/ext-css-tailwind`.
- Keep the existing bundler extension pinning behavior and broaden metadata coverage to all root auto-loaded first-party extensions.
- Cover publish-version pinning for the Tailwind extension package.
- Bump the root package version to `0.1.1022` and keep the shared runtime version constant in sync.
- Update the npm install smoke test to pack and install the local auto-loaded extension tarballs before publish.

## Verification
- `VF_DISABLE_LRU_INTERVAL=1 deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 deno test --config=scripts/test.deno.json --no-check --allow-read --allow-write --allow-run scripts/build/npm-package-metadata.test.ts`
- `deno task build:npm`
- `scripts/test/npm-install-smoke.sh`
- `deno fmt --check --config=scripts/test.deno.json scripts/build/npm-package-metadata.test.ts`
- `deno lint --config=scripts/test.deno.json scripts/build/build-npm-dnt.ts scripts/build/npm-package-metadata.test.ts`
- `bash -n scripts/test/npm-install-smoke.sh`
- Pre-push hook after smoke-test fix: formatting, lint, type check, and unit tests: `2301 passed (19431 steps), 0 failed`

## Notes
This fixes npm installs where the CLI treats MDX and Tailwind processors as built-ins but the published root package did not install their separate `@veryfront/ext-*` packages.
