### PR TITLE
Keep branch previews fresh after missed push events

### DIFF
--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -717,6 +717,76 @@ describe("VeryfrontFSAdapter", () => {
       });
     });
 
+    it("refreshes a stale branch snapshot once when a pushed file is missing", async () => {
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          contentSource: { type: "branch", branch: "main" },
+          cache: { enabled: true },
+        },
+      });
+
+      const staleFiles = [{
+        path: "components/GraphViewer.tsx",
+        content: "import '../lib/graph-performance';",
+      }];
+      const refreshedFiles = [
+        ...staleFiles,
+        {
+          path: "lib/graph-performance.ts",
+          content: "export const chooseSampleSize = () => 10000;",
+        },
+      ];
+      const secondRefreshFiles = [
+        ...refreshedFiles,
+        {
+          path: "lib/second-pushed-file.ts",
+          content: "export const second = true;",
+        },
+      ];
+
+      let listAllFilesCalls = 0;
+      const client = (adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          listAllFiles: () => Promise<Array<{ path: string; content?: string }>>;
+          getFileContent: (path: string) => Promise<string>;
+        };
+      }).client;
+
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+      client.listAllFiles = () => {
+        listAllFilesCalls++;
+        if (listAllFilesCalls === 1) return Promise.resolve(staleFiles);
+        if (listAllFilesCalls === 2) return Promise.resolve(refreshedFiles);
+        return Promise.resolve(secondRefreshFiles);
+      };
+      client.getFileContent = (path: string) => Promise.resolve(`network content for ${path}`);
+
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      await adapter.initialize();
+
+      const content = await adapter.readTextFile("lib/graph-performance.ts");
+
+      assertEquals(content, "export const chooseSampleSize = () => 10000;");
+      assertEquals(listAllFilesCalls, 2);
+
+      const secondContent = await adapter.readTextFile("lib/second-pushed-file.ts");
+
+      assertEquals(secondContent, "export const second = true;");
+      assertEquals(listAllFilesCalls, 3);
+    });
+
     it("should rehydrate a missing file list cache in the background", async () => {
       const adapter = createAdapter({
         veryfront: {

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -19,7 +19,12 @@ import { PathNormalizer } from "./path-normalizer.ts";
 import { ReadOperations } from "./read-operations.ts";
 import { DirectoryOperations } from "./directory-operations.ts";
 import { StatOperations } from "./stat-operations.ts";
-import { buildFileCacheKeyPrefix, buildFileListCacheKey } from "./cache-keys.ts";
+import {
+  buildDirCacheKeyPrefix,
+  buildFileCacheKeyPrefix,
+  buildFileListCacheKey,
+  buildStatCacheKeyPrefix,
+} from "./cache-keys.ts";
 import { isPrefixBeingInvalidated } from "./invalidation-state.ts";
 import { WebSocketManager } from "./websocket-manager.ts";
 import {
@@ -34,6 +39,7 @@ import {
   buildRetryConfig,
   shouldBackgroundPregenerateStyles,
 } from "./adapter-helpers.ts";
+import { isNotFoundLikeError } from "./read-operations-helpers.ts";
 
 import {
   clearCachedReleaseAssetManifests,
@@ -43,6 +49,7 @@ import {
 import { parseReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
 
 const logger = baseLogger.component("veryfront-fs-adapter");
+const BRANCH_MISS_RECOVERY_FAILURE_TTL_MS = 5_000;
 
 /**
  * Build a project-scoped manifest fetcher backed by the given API client.
@@ -79,6 +86,9 @@ export class VeryfrontFSAdapter implements FSAdapter {
   /** Single-flight background rewarm when the file list cache disappears */
   private fileListWarmupPromise: Promise<void> | null = null;
   private fileListWarmupKey: string | null = null;
+  /** Single-flight foreground refresh when a branch preview read misses a newly pushed file. */
+  private branchMissRecoveryPromise: Promise<void> | null = null;
+  private readonly branchMissRecoveryFailures = new Map<string, number>();
 
   private projectData?: Project;
   private apiBaseUrl: string;
@@ -445,6 +455,83 @@ export class VeryfrontFSAdapter implements FSAdapter {
     return shouldBackgroundPregenerateStyles(this.contentContext);
   }
 
+  private getBranchMissRecoveryKey(path: string): string {
+    const normalizedPath = this.normalizer.normalize(path);
+    const branch = this.requestBranch ?? this.contentContext?.branch ?? "main";
+    return `${this.projectSlug}:${branch}:${normalizedPath}`;
+  }
+
+  private hasRecentBranchMissRecoveryFailure(key: string): boolean {
+    const failedAt = this.branchMissRecoveryFailures.get(key);
+    if (!failedAt) return false;
+
+    if (Date.now() - failedAt < BRANCH_MISS_RECOVERY_FAILURE_TTL_MS) return true;
+
+    this.branchMissRecoveryFailures.delete(key);
+    return false;
+  }
+
+  private shouldRecoverBranchMiss(path: string, error: unknown): boolean {
+    if (this.contentContext?.sourceType !== "branch") return false;
+    if (!isNotFoundLikeError(error)) return false;
+
+    const recoveryKey = this.getBranchMissRecoveryKey(path);
+    return !this.hasRecentBranchMissRecoveryFailure(recoveryKey);
+  }
+
+  private async refreshBranchSnapshotAfterMiss(path: string): Promise<void> {
+    if (this.branchMissRecoveryPromise) {
+      await this.branchMissRecoveryPromise;
+      return;
+    }
+
+    const normalizedPath = this.normalizer.normalize(path);
+    const recoveryPromise = this.refreshSourceSnapshot(`branch-miss:${normalizedPath}`);
+    this.branchMissRecoveryPromise = recoveryPromise;
+
+    try {
+      await recoveryPromise;
+    } finally {
+      if (this.branchMissRecoveryPromise === recoveryPromise) {
+        this.branchMissRecoveryPromise = null;
+      }
+    }
+  }
+
+  private async withBranchSnapshotRecovery<T>(
+    path: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    try {
+      return await operation();
+    } catch (error) {
+      if (!this.shouldRecoverBranchMiss(path, error)) throw error;
+
+      const recoveryKey = this.getBranchMissRecoveryKey(path);
+      try {
+        await this.refreshBranchSnapshotAfterMiss(path);
+      } catch (refreshError) {
+        this.branchMissRecoveryFailures.set(recoveryKey, Date.now());
+        logger.warn("Branch snapshot recovery failed after not-found miss", {
+          path: this.normalizer.normalize(path),
+          projectSlug: this.projectSlug,
+          branch: this.requestBranch ?? this.contentContext?.branch,
+          error: refreshError instanceof Error ? refreshError.message : String(refreshError),
+        });
+        throw error;
+      }
+
+      try {
+        return await operation();
+      } catch (retryError) {
+        if (isNotFoundLikeError(retryError)) {
+          this.branchMissRecoveryFailures.set(recoveryKey, Date.now());
+        }
+        throw retryError;
+      }
+    }
+  }
+
   private scheduleFileListWarmup(reason: string, cacheKey?: string): void {
     if (!this.initialized || !this.contentContext) return;
 
@@ -539,11 +626,17 @@ export class VeryfrontFSAdapter implements FSAdapter {
     this.statOps.clearIndex();
     this.dirOps.clearTree();
 
-    await this.cache.deleteAsync(cacheKey);
+    await Promise.all([
+      this.cache.deleteByPrefixAsync(buildFileCacheKeyPrefix(refreshContext)),
+      this.cache.deleteByPrefixAsync(buildStatCacheKeyPrefix(refreshContext)),
+      this.cache.deleteByPrefixAsync(buildDirCacheKeyPrefix(refreshContext)),
+      this.cache.deleteAsync(cacheKey),
+    ]);
 
     const files = await fetchFileListForContext(this.client, refreshContext);
     await this.cache.setAsync(cacheKey, files);
     const fileSummary = summarizeFileList(files);
+    this.branchMissRecoveryFailures.clear();
 
     if (fileSummary.sourceFilesWithContent > 0 && this.shouldBackgroundPregenerateStyles()) {
       this.triggerCSSPregeneration(files).catch(() => {
@@ -575,32 +668,37 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
   async readFile(path: string): Promise<string> {
     await this.ensureInitialized();
-    return this.readOps.readTextFile(path);
+    return this.withBranchSnapshotRecovery(path, () => this.readOps.readTextFile(path));
   }
 
   async readFileBytes(path: string): Promise<Uint8Array> {
     await this.ensureInitialized();
-    return this.readOps.readFile(path);
+    return this.withBranchSnapshotRecovery(path, () => this.readOps.readFile(path));
   }
 
   async readTextFile(path: string): Promise<string> {
     await this.ensureInitialized();
-    return this.readOps.readTextFile(path);
+    return this.withBranchSnapshotRecovery(path, () => this.readOps.readTextFile(path));
   }
 
   async readdir(path: string): Promise<DirectoryEntry[]> {
     await this.ensureInitialized();
-    return this.dirOps.readdir(path);
+    return this.withBranchSnapshotRecovery(path, () => this.dirOps.readdir(path));
   }
 
   async stat(path: string): Promise<FileInfo> {
     await this.ensureInitialized();
-    return this.statOps.stat(path);
+    return this.withBranchSnapshotRecovery(path, () => this.statOps.stat(path));
   }
 
   async exists(path: string): Promise<boolean> {
     await this.ensureInitialized();
-    return this.statOps.exists(path);
+    try {
+      await this.withBranchSnapshotRecovery(path, () => this.statOps.stat(path));
+      return true;
+    } catch (_) {
+      return false;
+    }
   }
 
   async resolveFile(
@@ -608,7 +706,10 @@ export class VeryfrontFSAdapter implements FSAdapter {
     options?: ResolveFileOptions,
   ): Promise<string | null> {
     await this.ensureInitialized();
-    return this.statOps.resolveFile(basePath, options);
+    return this.withBranchSnapshotRecovery(
+      basePath,
+      () => this.statOps.resolveFile(basePath, options),
+    );
   }
 
   dispose(): void {
@@ -619,6 +720,8 @@ export class VeryfrontFSAdapter implements FSAdapter {
     this.initialized = false;
     this.fileListWarmupPromise = null;
     this.fileListWarmupKey = null;
+    this.branchMissRecoveryPromise = null;
+    this.branchMissRecoveryFailures.clear();
 
     logger.debug("Disposed");
   }
@@ -775,6 +878,8 @@ export class VeryfrontFSAdapter implements FSAdapter {
       this.dirOps.clearTree();
       this.fileListWarmupPromise = null;
       this.fileListWarmupKey = null;
+      this.branchMissRecoveryPromise = null;
+      this.branchMissRecoveryFailures.clear();
       logger.debug("Cleared index and dirTree due to context change", {
         oldContext,
         newContext: context,


### PR DESCRIPTION
## Summary
- add branch-preview not-found recovery that refreshes the scoped source snapshot and retries reads/stat/resolve once
- clear scoped file/stat/dir/file-list caches during source snapshot refresh so stale negative resolve entries cannot survive a missed push event
- add a regression test for sequential newly pushed files missing from a stale branch file list

## Verification
- VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/platform/adapters/fs/veryfront/adapter.test.ts src/platform/adapters/fs/veryfront/read-operations.test.ts src/platform/adapters/fs/veryfront/stat-operations.test.ts src/platform/adapters/fs/veryfront/directory-operations.test.ts src/platform/adapters/fs/veryfront/file-list-index.test.ts src/platform/adapters/fs/veryfront/file-list-access.test.ts src/platform/adapters/fs/veryfront/websocket-manager.test.ts
- deno fmt --check src/platform/adapters/fs/veryfront/adapter.ts src/platform/adapters/fs/veryfront/adapter.test.ts
- DENO_NO_PACKAGE_JSON=1 deno lint src/platform/adapters/fs/veryfront/adapter.ts src/platform/adapters/fs/veryfront/adapter.test.ts
- deno check src/platform/adapters/fs/veryfront/adapter.ts src/platform/adapters/fs/veryfront/adapter.test.ts
- deno task typecheck
- pre-push hook: full fmt, lint, typecheck, and test:unit (2301 passed, 0 failed)