### PR TITLE
Recover branch previews from silent snapshot misses

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1022",
+  "version": "0.1.1023",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -787,6 +787,116 @@ describe("VeryfrontFSAdapter", () => {
       assertEquals(listAllFilesCalls, 3);
     });
 
+    it("refreshes a stale branch snapshot when resolveFile returns a cached miss", async () => {
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          contentSource: { type: "branch", branch: "main" },
+          cache: { enabled: true },
+        },
+      });
+
+      const staleFiles = [{
+        path: "components/GraphViewer.tsx",
+        content: "import '../lib/graph-performance';",
+      }];
+      const refreshedFiles = [
+        ...staleFiles,
+        {
+          path: "lib/graph-performance.ts",
+          content: "export const chooseSampleSize = () => 10000;",
+        },
+      ];
+
+      let listAllFilesCalls = 0;
+      const client = (adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          listAllFiles: () => Promise<Array<{ path: string; content?: string }>>;
+          searchFiles: (_pattern: string) => Promise<Array<{ path: string }>>;
+        };
+      }).client;
+
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+      client.listAllFiles = () => {
+        listAllFilesCalls++;
+        return Promise.resolve(listAllFilesCalls === 1 ? staleFiles : refreshedFiles);
+      };
+      client.searchFiles = () => Promise.resolve([]);
+
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      await adapter.initialize();
+
+      const resolvedPath = await adapter.resolveFile("lib/graph-performance");
+
+      assertEquals(resolvedPath, "lib/graph-performance.ts");
+      assertEquals(listAllFilesCalls, 2);
+    });
+
+    it("refreshes a stale branch snapshot when readdir sees a new empty directory miss", async () => {
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          contentSource: { type: "branch", branch: "main" },
+          cache: { enabled: true },
+        },
+      });
+
+      const staleFiles = [{
+        path: "components/GraphViewer.tsx",
+        content: "import '../lib/graph-performance';",
+      }];
+      const refreshedFiles = [
+        ...staleFiles,
+        {
+          path: "lib/graph-performance.ts",
+          content: "export const chooseSampleSize = () => 10000;",
+        },
+      ];
+
+      let listAllFilesCalls = 0;
+      const client = (adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          listAllFiles: () => Promise<Array<{ path: string; content?: string }>>;
+        };
+      }).client;
+
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+      client.listAllFiles = () => {
+        listAllFilesCalls++;
+        return Promise.resolve(listAllFilesCalls === 1 ? staleFiles : refreshedFiles);
+      };
+
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      await adapter.initialize();
+
+      const entries = await adapter.readdir("lib");
+
+      assertEquals(entries.map((entry) => entry.path), ["lib/graph-performance.ts"]);
+      assertEquals(listAllFilesCalls, 2);
+    });
+
     it("should rehydrate a missing file list cache in the background", async () => {
       const adapter = createAdapter({
         veryfront: {

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -3,9 +3,14 @@ import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import { VeryfrontFSAdapter } from "./adapter.ts";
-import { buildFileListCacheKey } from "./cache-keys.ts";
+import { buildFileCacheKeyPrefix, buildFileListCacheKey } from "./cache-keys.ts";
 import { createAdapter, seedCachedFiles, waitFor } from "./adapter.test-helpers.ts";
 import type { ResolvedContentContext } from "./types.ts";
+import {
+  addPendingInvalidation,
+  clearAllPendingInvalidations,
+  removePendingInvalidation,
+} from "./invalidation-state.ts";
 import {
   clearReleaseAssetManifestCache,
   getReadyManifestForRender,
@@ -13,6 +18,10 @@ import {
 import { RELEASE_ASSET_MANIFEST_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
 
 describe("VeryfrontFSAdapter", () => {
+  afterEach(() => {
+    clearAllPendingInvalidations();
+  });
+
   describe("class", () => {
     it("should export VeryfrontFSAdapter class", () => {
       assertExists(VeryfrontFSAdapter);
@@ -836,11 +845,69 @@ describe("VeryfrontFSAdapter", () => {
         .connect = () => {};
 
       await adapter.initialize();
+      assertEquals(
+        await adapter.resolveFile("components/GraphViewer"),
+        "components/GraphViewer.tsx",
+      );
 
-      const resolvedPath = await adapter.resolveFile("lib/graph-performance");
+      const branchSourcePrefix = buildFileCacheKeyPrefix(adapter.getContentContext());
+      let resolvedPath: string | null;
+      try {
+        addPendingInvalidation(branchSourcePrefix);
+        resolvedPath = await adapter.resolveFile("lib/graph-performance");
+      } finally {
+        removePendingInvalidation(branchSourcePrefix);
+      }
 
       assertEquals(resolvedPath, "lib/graph-performance.ts");
-      assertEquals(listAllFilesCalls, 2);
+      assertEquals(listAllFilesCalls, 3);
+    });
+
+    it("does not refresh a normal resolveFile miss without pending branch invalidation", async () => {
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          contentSource: { type: "branch", branch: "main" },
+          cache: { enabled: true },
+        },
+      });
+
+      let listAllFilesCalls = 0;
+      const client = (adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          listAllFiles: () => Promise<Array<{ path: string; content?: string }>>;
+          searchFiles: (_pattern: string) => Promise<Array<{ path: string }>>;
+        };
+      }).client;
+
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+      client.listAllFiles = () => {
+        listAllFilesCalls++;
+        return Promise.resolve([{
+          path: "pages/index.tsx",
+          content: "export default function Page() { return null; }",
+        }]);
+      };
+      client.searchFiles = () => Promise.resolve([]);
+
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      await adapter.initialize();
+
+      const resolvedPath = await adapter.resolveFile("optional/missing-page");
+
+      assertEquals(resolvedPath, null);
+      assertEquals(listAllFilesCalls, 1);
     });
 
     it("refreshes a stale branch snapshot when readdir sees a new empty directory miss", async () => {
@@ -890,11 +957,66 @@ describe("VeryfrontFSAdapter", () => {
         .connect = () => {};
 
       await adapter.initialize();
+      assertEquals((await adapter.readdir("components")).map((entry) => entry.path), [
+        "components/GraphViewer.tsx",
+      ]);
 
-      const entries = await adapter.readdir("lib");
+      const branchSourcePrefix = buildFileCacheKeyPrefix(adapter.getContentContext());
+      let entries: Array<{ path: string }>;
+      try {
+        addPendingInvalidation(branchSourcePrefix);
+        entries = await adapter.readdir("lib");
+      } finally {
+        removePendingInvalidation(branchSourcePrefix);
+      }
 
       assertEquals(entries.map((entry) => entry.path), ["lib/graph-performance.ts"]);
-      assertEquals(listAllFilesCalls, 2);
+      assertEquals(listAllFilesCalls, 3);
+    });
+
+    it("does not refresh a normal empty directory listing without pending branch invalidation", async () => {
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          contentSource: { type: "branch", branch: "main" },
+          cache: { enabled: true },
+        },
+      });
+
+      let listAllFilesCalls = 0;
+      const client = (adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          listAllFiles: () => Promise<Array<{ path: string; content?: string }>>;
+        };
+      }).client;
+
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+      client.listAllFiles = () => {
+        listAllFilesCalls++;
+        return Promise.resolve([{
+          path: "pages/index.tsx",
+          content: "export default function Page() { return null; }",
+        }]);
+      };
+
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      await adapter.initialize();
+
+      const entries = await adapter.readdir("optional");
+
+      assertEquals(entries, []);
+      assertEquals(listAllFilesCalls, 1);
     });
 
     it("should rehydrate a missing file list cache in the background", async () => {

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -51,6 +51,10 @@ import { parseReleaseAssetManifest } from "#veryfront/release-assets/manifest-sc
 const logger = baseLogger.component("veryfront-fs-adapter");
 const BRANCH_MISS_RECOVERY_FAILURE_TTL_MS = 5_000;
 
+interface BranchSnapshotRecoveryOptions<T> {
+  isRecoverableMissResult?: (result: T) => boolean;
+}
+
 /**
  * Build a project-scoped manifest fetcher backed by the given API client.
  *
@@ -88,6 +92,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
   private fileListWarmupKey: string | null = null;
   /** Single-flight foreground refresh when a branch preview read misses a newly pushed file. */
   private branchMissRecoveryPromise: Promise<void> | null = null;
+  private branchMissRecoveryGeneration = 0;
   private readonly branchMissRecoveryFailures = new Map<string, number>();
 
   private projectData?: Project;
@@ -479,20 +484,35 @@ export class VeryfrontFSAdapter implements FSAdapter {
     return !this.hasRecentBranchMissRecoveryFailure(recoveryKey);
   }
 
-  private async refreshBranchSnapshotAfterMiss(path: string): Promise<void> {
-    if (this.branchMissRecoveryPromise) {
-      await this.branchMissRecoveryPromise;
-      return;
-    }
+  private shouldRecoverBranchMissResult<T>(
+    path: string,
+    result: T,
+    options?: BranchSnapshotRecoveryOptions<T>,
+  ): boolean {
+    if (this.contentContext?.sourceType !== "branch") return false;
+    if (!options?.isRecoverableMissResult?.(result)) return false;
 
-    const normalizedPath = this.normalizer.normalize(path);
-    const recoveryPromise = this.refreshSourceSnapshot(`branch-miss:${normalizedPath}`);
-    this.branchMissRecoveryPromise = recoveryPromise;
+    const recoveryKey = this.getBranchMissRecoveryKey(path);
+    return !this.hasRecentBranchMissRecoveryFailure(recoveryKey);
+  }
+
+  private async refreshBranchSnapshotAfterMiss(path: string): Promise<void> {
+    let recoveryPromise = this.branchMissRecoveryPromise;
+    let ownsRecovery = false;
+    let recoveryGeneration = this.branchMissRecoveryGeneration;
+
+    if (!recoveryPromise) {
+      const normalizedPath = this.normalizer.normalize(path);
+      recoveryPromise = this.refreshSourceSnapshot(`branch-miss:${normalizedPath}`);
+      this.branchMissRecoveryPromise = recoveryPromise;
+      recoveryGeneration = ++this.branchMissRecoveryGeneration;
+      ownsRecovery = true;
+    }
 
     try {
       await recoveryPromise;
     } finally {
-      if (this.branchMissRecoveryPromise === recoveryPromise) {
+      if (ownsRecovery && this.branchMissRecoveryGeneration === recoveryGeneration) {
         this.branchMissRecoveryPromise = null;
       }
     }
@@ -501,9 +521,31 @@ export class VeryfrontFSAdapter implements FSAdapter {
   private async withBranchSnapshotRecovery<T>(
     path: string,
     operation: () => Promise<T>,
+    options?: BranchSnapshotRecoveryOptions<T>,
   ): Promise<T> {
     try {
-      return await operation();
+      const result = await operation();
+      if (!this.shouldRecoverBranchMissResult(path, result, options)) return result;
+
+      const recoveryKey = this.getBranchMissRecoveryKey(path);
+      try {
+        await this.refreshBranchSnapshotAfterMiss(path);
+      } catch (refreshError) {
+        this.branchMissRecoveryFailures.set(recoveryKey, Date.now());
+        logger.warn("Branch snapshot recovery failed after result miss", {
+          path: this.normalizer.normalize(path),
+          projectSlug: this.projectSlug,
+          branch: this.requestBranch ?? this.contentContext?.branch,
+          error: refreshError instanceof Error ? refreshError.message : String(refreshError),
+        });
+        return result;
+      }
+
+      const retryResult = await operation();
+      if (options?.isRecoverableMissResult?.(retryResult)) {
+        this.branchMissRecoveryFailures.set(recoveryKey, Date.now());
+      }
+      return retryResult;
     } catch (error) {
       if (!this.shouldRecoverBranchMiss(path, error)) throw error;
 
@@ -683,7 +725,11 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
   async readdir(path: string): Promise<DirectoryEntry[]> {
     await this.ensureInitialized();
-    return this.withBranchSnapshotRecovery(path, () => this.dirOps.readdir(path));
+    return this.withBranchSnapshotRecovery(
+      path,
+      () => this.dirOps.readdir(path),
+      { isRecoverableMissResult: (entries) => entries.length === 0 },
+    );
   }
 
   async stat(path: string): Promise<FileInfo> {
@@ -709,6 +755,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
     return this.withBranchSnapshotRecovery(
       basePath,
       () => this.statOps.resolveFile(basePath, options),
+      { isRecoverableMissResult: (resolvedPath) => resolvedPath === null },
     );
   }
 
@@ -721,6 +768,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
     this.fileListWarmupPromise = null;
     this.fileListWarmupKey = null;
     this.branchMissRecoveryPromise = null;
+    this.branchMissRecoveryGeneration++;
     this.branchMissRecoveryFailures.clear();
 
     logger.debug("Disposed");
@@ -879,6 +927,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
       this.fileListWarmupPromise = null;
       this.fileListWarmupKey = null;
       this.branchMissRecoveryPromise = null;
+      this.branchMissRecoveryGeneration++;
       this.branchMissRecoveryFailures.clear();
       logger.debug("Cleared index and dirTree due to context change", {
         oldContext,

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -53,6 +53,7 @@ const BRANCH_MISS_RECOVERY_FAILURE_TTL_MS = 5_000;
 
 interface BranchSnapshotRecoveryOptions<T> {
   isRecoverableMissResult?: (result: T) => boolean;
+  requirePendingSourceInvalidation?: boolean;
 }
 
 /**
@@ -491,6 +492,12 @@ export class VeryfrontFSAdapter implements FSAdapter {
   ): boolean {
     if (this.contentContext?.sourceType !== "branch") return false;
     if (!options?.isRecoverableMissResult?.(result)) return false;
+    if (
+      options.requirePendingSourceInvalidation &&
+      !this.isPersistentCacheInvalidated(buildFileCacheKeyPrefix(this.contentContext))
+    ) {
+      return false;
+    }
 
     const recoveryKey = this.getBranchMissRecoveryKey(path);
     return !this.hasRecentBranchMissRecoveryFailure(recoveryKey);
@@ -728,7 +735,10 @@ export class VeryfrontFSAdapter implements FSAdapter {
     return this.withBranchSnapshotRecovery(
       path,
       () => this.dirOps.readdir(path),
-      { isRecoverableMissResult: (entries) => entries.length === 0 },
+      {
+        isRecoverableMissResult: (entries) => entries.length === 0,
+        requirePendingSourceInvalidation: true,
+      },
     );
   }
 
@@ -755,7 +765,10 @@ export class VeryfrontFSAdapter implements FSAdapter {
     return this.withBranchSnapshotRecovery(
       basePath,
       () => this.statOps.resolveFile(basePath, options),
-      { isRecoverableMissResult: (resolvedPath) => resolvedPath === null },
+      {
+        isRecoverableMissResult: (resolvedPath) => resolvedPath === null,
+        requirePendingSourceInvalidation: true,
+      },
     );
   }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1022";
+export const VERSION = "0.1.1023";


### PR DESCRIPTION
## Summary
- handle stale branch snapshot misses when `resolveFile()` returns `null` instead of throwing
- handle stale branch snapshot misses when `readdir()` returns an empty listing for a newly pushed directory
- replace promise identity cleanup with a generation token to avoid the CodeQL missing-await warning while preserving single-flight recovery cleanup

## Review comments addressed
- #2796 discussion_r3529051451: refresh branch snapshots when resolve returns null
- #2796 discussion_r3529051456: refresh branch snapshots for empty directory misses
- #2796 discussion_r3529053343 / discussion_r3529060730: remove promise-comparison pattern flagged as missing await

## Verification
- Red test confirmed both new regressions failed before implementation
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/platform/adapters/fs/veryfront/adapter.test.ts src/platform/adapters/fs/veryfront/read-operations.test.ts src/platform/adapters/fs/veryfront/stat-operations.test.ts src/platform/adapters/fs/veryfront/directory-operations.test.ts src/platform/adapters/fs/veryfront/file-list-index.test.ts src/platform/adapters/fs/veryfront/file-list-access.test.ts src/platform/adapters/fs/veryfront/websocket-manager.test.ts`
- `deno fmt --check src/platform/adapters/fs/veryfront/adapter.ts src/platform/adapters/fs/veryfront/adapter.test.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/platform/adapters/fs/veryfront/adapter.ts src/platform/adapters/fs/veryfront/adapter.test.ts`
- `deno check src/platform/adapters/fs/veryfront/adapter.ts src/platform/adapters/fs/veryfront/adapter.test.ts`
- `deno task typecheck`
- pre-push full gate: format, lint, typecheck, unit tests; `2301 passed (19434 steps), 0 failed`