### PR TITLE
Prefix all integration tool IDs

### DIFF
--- a/cli/templates/integrations/activecampaign/connector.json
+++ b/cli/templates/integrations/activecampaign/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_contacts",
+      "id": "activecampaign__list_contacts",
       "name": "List Contacts",
       "description": "List or search contacts in ActiveCampaign",
       "requiresWrite": false,
@@ -83,7 +83,7 @@
       }
     },
     {
-      "id": "get_contact",
+      "id": "activecampaign__get_contact",
       "name": "Get Contact",
       "description": "Get details of an ActiveCampaign contact",
       "requiresWrite": false,
@@ -107,7 +107,7 @@
       }
     },
     {
-      "id": "create_contact",
+      "id": "activecampaign__create_contact",
       "name": "Create Contact",
       "description": "Create a new contact in ActiveCampaign",
       "requiresWrite": true,
@@ -135,7 +135,7 @@
       }
     },
     {
-      "id": "update_contact",
+      "id": "activecampaign__update_contact",
       "name": "Update Contact",
       "description": "Update an existing ActiveCampaign contact",
       "requiresWrite": true,
@@ -169,7 +169,7 @@
       }
     },
     {
-      "id": "list_deals",
+      "id": "activecampaign__list_deals",
       "name": "List Deals",
       "description": "List deals in ActiveCampaign",
       "requiresWrite": false,
@@ -204,7 +204,7 @@
       }
     },
     {
-      "id": "create_deal",
+      "id": "activecampaign__create_deal",
       "name": "Create Deal",
       "description": "Create a new deal in ActiveCampaign",
       "requiresWrite": true,
@@ -232,7 +232,7 @@
       }
     },
     {
-      "id": "list_accounts",
+      "id": "activecampaign__list_accounts",
       "name": "List Accounts",
       "description": "List accounts (companies) in ActiveCampaign",
       "requiresWrite": false,

--- a/cli/templates/integrations/adyen/connector.json
+++ b/cli/templates/integrations/adyen/connector.json
@@ -34,7 +34,7 @@
   ],
   "tools": [
     {
-      "id": "create_payment_session",
+      "id": "adyen__create_payment_session",
       "name": "Create Payment Session",
       "description": "Create an Adyen Checkout payment session that a Drop-in or Component can use to collect payment",
       "requiresWrite": true,
@@ -87,7 +87,7 @@
       }
     },
     {
-      "id": "get_session_result",
+      "id": "adyen__get_session_result",
       "name": "Get Session Result",
       "description": "Get the final result of an Adyen payment session, including authorized payments and status",
       "requiresWrite": false,
@@ -118,7 +118,7 @@
       }
     },
     {
-      "id": "list_payment_methods",
+      "id": "adyen__list_payment_methods",
       "name": "List Payment Methods",
       "description": "List the payment methods available for a merchant account, amount, and shopper country",
       "requiresWrite": false,
@@ -160,7 +160,7 @@
       }
     },
     {
-      "id": "create_payment_link",
+      "id": "adyen__create_payment_link",
       "name": "Create Payment Link",
       "description": "Create a hosted Pay by Link URL the shopper can open to pay, without needing a Drop-in or Component frontend",
       "requiresWrite": true,
@@ -224,7 +224,7 @@
       }
     },
     {
-      "id": "capture_payment",
+      "id": "adyen__capture_payment",
       "name": "Capture Payment",
       "description": "Capture an authorised Adyen payment (for manual-capture flows); the outcome arrives asynchronously via a CAPTURE webhook",
       "requiresWrite": true,
@@ -265,7 +265,7 @@
       }
     },
     {
-      "id": "create_refund",
+      "id": "adyen__create_refund",
       "name": "Create Refund",
       "description": "Refund all or part of a captured Adyen payment; the outcome arrives asynchronously via a REFUND webhook",
       "requiresWrite": true,

--- a/cli/templates/integrations/airtable/connector.json
+++ b/cli/templates/integrations/airtable/connector.json
@@ -42,7 +42,7 @@
   ],
   "tools": [
     {
-      "id": "list_bases",
+      "id": "airtable__list_bases",
       "name": "List Bases",
       "description": "List all accessible Airtable bases",
       "requiresWrite": false,
@@ -68,7 +68,7 @@
       }
     },
     {
-      "id": "get_base",
+      "id": "airtable__get_base",
       "name": "Get Base",
       "description": "Get schema information for a specific base",
       "requiresWrite": false,
@@ -86,7 +86,7 @@
       }
     },
     {
-      "id": "list_records",
+      "id": "airtable__list_records",
       "name": "List Records",
       "description": "List records from a table with optional filtering",
       "requiresWrite": false,
@@ -139,7 +139,7 @@
       }
     },
     {
-      "id": "get_record",
+      "id": "airtable__get_record",
       "name": "Get Record",
       "description": "Get a specific record by ID",
       "requiresWrite": false,
@@ -169,7 +169,7 @@
       }
     },
     {
-      "id": "create_record",
+      "id": "airtable__create_record",
       "name": "Create Record",
       "description": "Create a new record in a table",
       "requiresWrite": true,
@@ -205,7 +205,7 @@
       }
     },
     {
-      "id": "create_records",
+      "id": "airtable__create_records",
       "name": "Create Records",
       "description": "Create multiple records in a table",
       "requiresWrite": true,
@@ -244,7 +244,7 @@
       }
     },
     {
-      "id": "update_record",
+      "id": "airtable__update_record",
       "name": "Update Record",
       "description": "Update fields on an existing record",
       "requiresWrite": true,
@@ -286,7 +286,7 @@
       }
     },
     {
-      "id": "delete_record",
+      "id": "airtable__delete_record",
       "name": "Delete Record",
       "description": "Delete a record from a table",
       "requiresWrite": true,
@@ -316,7 +316,7 @@
       }
     },
     {
-      "id": "create_table",
+      "id": "airtable__create_table",
       "name": "Create Table",
       "description": "Create a new table in an Airtable base",
       "requiresWrite": true,
@@ -350,7 +350,7 @@
       }
     },
     {
-      "id": "update_table",
+      "id": "airtable__update_table",
       "name": "Update Table",
       "description": "Update table metadata such as name or description using the table ID",
       "requiresWrite": true,
@@ -384,7 +384,7 @@
       }
     },
     {
-      "id": "create_field",
+      "id": "airtable__create_field",
       "name": "Create Field",
       "description": "Create a new field in an Airtable table",
       "requiresWrite": true,

--- a/cli/templates/integrations/algolia/connector.json
+++ b/cli/templates/integrations/algolia/connector.json
@@ -36,7 +36,7 @@
   ],
   "tools": [
     {
-      "id": "list_indices",
+      "id": "algolia__list_indices",
       "name": "List Indices",
       "description": "List the indices in the Algolia application",
       "requiresWrite": false,
@@ -75,7 +75,7 @@
       }
     },
     {
-      "id": "search_index",
+      "id": "algolia__search_index",
       "name": "Search Index",
       "description": "Run a search query against an index",
       "requiresWrite": false,
@@ -124,7 +124,7 @@
       }
     },
     {
-      "id": "browse_index",
+      "id": "algolia__browse_index",
       "name": "Browse Index",
       "description": "Browse all records in an index with cursor-based pagination",
       "requiresWrite": false,
@@ -163,7 +163,7 @@
       }
     },
     {
-      "id": "get_object",
+      "id": "algolia__get_object",
       "name": "Get Object",
       "description": "Retrieve a single record from an index by objectID",
       "requiresWrite": false,
@@ -198,7 +198,7 @@
       }
     },
     {
-      "id": "save_objects",
+      "id": "algolia__save_objects",
       "name": "Save Objects",
       "description": "Add or update records in an index via a batch operation",
       "requiresWrite": true,

--- a/cli/templates/integrations/alphavantage/connector.json
+++ b/cli/templates/integrations/alphavantage/connector.json
@@ -27,7 +27,7 @@
   ],
   "tools": [
     {
-      "id": "quote",
+      "id": "alphavantage__quote",
       "name": "Get Quote",
       "description": "Get the latest price and volume information for an equity ticker",
       "requiresWrite": false,
@@ -51,7 +51,7 @@
       }
     },
     {
-      "id": "daily_time_series",
+      "id": "alphavantage__daily_time_series",
       "name": "Daily Time Series",
       "description": "Get daily open, high, low, close, and volume history for an equity ticker",
       "requiresWrite": false,
@@ -81,7 +81,7 @@
       }
     },
     {
-      "id": "symbol_search",
+      "id": "alphavantage__symbol_search",
       "name": "Symbol Search",
       "description": "Search for ticker symbols and companies matching keywords",
       "requiresWrite": false,
@@ -105,7 +105,7 @@
       }
     },
     {
-      "id": "company_overview",
+      "id": "alphavantage__company_overview",
       "name": "Company Overview",
       "description": "Get company information and key fundamentals (market cap, PE ratio, EPS, sector) for an equity ticker",
       "requiresWrite": false,
@@ -129,7 +129,7 @@
       }
     },
     {
-      "id": "fx_rate",
+      "id": "alphavantage__fx_rate",
       "name": "FX Exchange Rate",
       "description": "Get the realtime exchange rate between two currencies (physical or digital, e.g. USD to EUR or BTC to USD)",
       "requiresWrite": false,

--- a/cli/templates/integrations/amplitude/connector.json
+++ b/cli/templates/integrations/amplitude/connector.json
@@ -33,7 +33,7 @@
   ],
   "tools": [
     {
-      "id": "list_events",
+      "id": "amplitude__list_events",
       "name": "List Events",
       "description": "List event types visible in the project with current week totals",
       "requiresWrite": false,
@@ -66,7 +66,7 @@
       }
     },
     {
-      "id": "query_event_segmentation",
+      "id": "amplitude__query_event_segmentation",
       "name": "Query Event Segmentation",
       "description": "Get metrics for an event over a date range (Event Segmentation chart data)",
       "requiresWrite": false,
@@ -122,7 +122,7 @@
       }
     },
     {
-      "id": "query_active_users",
+      "id": "amplitude__query_active_users",
       "name": "Query Active Users",
       "description": "Get active or new user counts over a date range",
       "requiresWrite": false,
@@ -172,7 +172,7 @@
       }
     },
     {
-      "id": "get_chart_results",
+      "id": "amplitude__get_chart_results",
       "name": "Get Chart Results",
       "description": "Get JSON results from a saved Amplitude chart by chart ID",
       "requiresWrite": false,
@@ -196,7 +196,7 @@
       }
     },
     {
-      "id": "track_event",
+      "id": "amplitude__track_event",
       "name": "Track Event",
       "description": "Send events to Amplitude via the HTTP V2 ingestion API",
       "requiresWrite": true,

--- a/cli/templates/integrations/anthropic/connector.json
+++ b/cli/templates/integrations/anthropic/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_workspaces",
+      "id": "anthropic__list_workspaces",
       "name": "list-workspaces",
       "description": "List all workspaces in the organization",
       "requiresWrite": false,
@@ -75,7 +75,7 @@
       }
     },
     {
-      "id": "get_usage",
+      "id": "anthropic__get_usage",
       "name": "get-usage",
       "description": "Get API usage statistics for a date range",
       "requiresWrite": false,
@@ -121,7 +121,7 @@
       }
     },
     {
-      "id": "list_api_keys",
+      "id": "anthropic__list_api_keys",
       "name": "list-api-keys",
       "description": "List API keys for a workspace or organization",
       "requiresWrite": false,
@@ -177,7 +177,7 @@
       }
     },
     {
-      "id": "list_members",
+      "id": "anthropic__list_members",
       "name": "list-members",
       "description": "List all members in the organization",
       "requiresWrite": false,
@@ -227,7 +227,7 @@
       }
     },
     {
-      "id": "get_organization",
+      "id": "anthropic__get_organization",
       "name": "get-organization",
       "description": "Get organization details and settings",
       "requiresWrite": false,

--- a/cli/templates/integrations/apify/connector.json
+++ b/cli/templates/integrations/apify/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_actors",
+      "id": "apify__list_actors",
       "name": "List Actors",
       "description": "List actors in your Apify account",
       "requiresWrite": false,
@@ -72,7 +72,7 @@
       }
     },
     {
-      "id": "run_actor_sync",
+      "id": "apify__run_actor_sync",
       "name": "Run Actor (Sync)",
       "description": "Run an actor, wait for it to finish (up to 300s), and return its dataset items (consumes platform credits)",
       "requiresWrite": true,
@@ -114,7 +114,7 @@
       }
     },
     {
-      "id": "get_run",
+      "id": "apify__get_run",
       "name": "Get Run",
       "description": "Get the status and details of an actor run, including its defaultDatasetId",
       "requiresWrite": false,
@@ -135,7 +135,7 @@
       }
     },
     {
-      "id": "list_runs",
+      "id": "apify__list_runs",
       "name": "List Runs",
       "description": "List recent actor runs in your account",
       "requiresWrite": false,
@@ -168,7 +168,7 @@
       }
     },
     {
-      "id": "get_dataset_items",
+      "id": "apify__get_dataset_items",
       "name": "Get Dataset Items",
       "description": "Fetch items from a dataset produced by an actor run",
       "requiresWrite": false,

--- a/cli/templates/integrations/apollo/connector.json
+++ b/cli/templates/integrations/apollo/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "search_people",
+      "id": "apollo__search_people",
       "name": "Search People",
       "description": "Search the Apollo database for people by keywords, titles, and locations",
       "requiresWrite": false,
@@ -80,7 +80,7 @@
       }
     },
     {
-      "id": "search_organizations",
+      "id": "apollo__search_organizations",
       "name": "Search Organizations",
       "description": "Search the Apollo database for companies; consumes Apollo credits",
       "requiresWrite": true,
@@ -114,7 +114,7 @@
       }
     },
     {
-      "id": "enrich_person",
+      "id": "apollo__enrich_person",
       "name": "Enrich Person",
       "description": "Enrich a person's profile by name, email, domain, or LinkedIn URL; consumes Apollo credits",
       "requiresWrite": true,
@@ -161,7 +161,7 @@
       }
     },
     {
-      "id": "enrich_organization",
+      "id": "apollo__enrich_organization",
       "name": "Enrich Organization",
       "description": "Enrich a company profile from its domain; consumes Apollo credits",
       "requiresWrite": true,
@@ -182,7 +182,7 @@
       }
     },
     {
-      "id": "search_contacts",
+      "id": "apollo__search_contacts",
       "name": "Search Contacts",
       "description": "Search contacts already saved to your Apollo account",
       "requiresWrite": false,
@@ -212,7 +212,7 @@
       }
     },
     {
-      "id": "create_contact",
+      "id": "apollo__create_contact",
       "name": "Create Contact",
       "description": "Create a new contact in your Apollo account",
       "requiresWrite": true,
@@ -252,7 +252,7 @@
       }
     },
     {
-      "id": "update_contact",
+      "id": "apollo__update_contact",
       "name": "Update Contact",
       "description": "Update an existing contact in your Apollo account",
       "requiresWrite": true,

--- a/cli/templates/integrations/asana/connector.json
+++ b/cli/templates/integrations/asana/connector.json
@@ -37,7 +37,7 @@
   ],
   "tools": [
     {
-      "id": "list_tasks",
+      "id": "asana__list_tasks",
       "name": "List Tasks",
       "description": "List tasks in a project or assigned to a user",
       "requiresWrite": false,
@@ -188,7 +188,7 @@
       }
     },
     {
-      "id": "get_task",
+      "id": "asana__get_task",
       "name": "Get Task",
       "description": "Get details of a specific task",
       "requiresWrite": false,
@@ -214,7 +214,7 @@
       }
     },
     {
-      "id": "create_task",
+      "id": "asana__create_task",
       "name": "Create Task",
       "description": "Create a new task in a project",
       "requiresWrite": true,
@@ -234,7 +234,7 @@
       }
     },
     {
-      "id": "update_task",
+      "id": "asana__update_task",
       "name": "Update Task",
       "description": "Update an existing task",
       "requiresWrite": true,
@@ -262,7 +262,7 @@
       }
     },
     {
-      "id": "delete_task",
+      "id": "asana__delete_task",
       "name": "Delete Task",
       "description": "Delete an Asana task by GID",
       "requiresWrite": true,
@@ -280,7 +280,7 @@
       }
     },
     {
-      "id": "list_projects",
+      "id": "asana__list_projects",
       "name": "List Projects",
       "description": "List all projects in the workspace",
       "requiresWrite": false,
@@ -426,7 +426,7 @@
       }
     },
     {
-      "id": "list_workspaces",
+      "id": "asana__list_workspaces",
       "name": "List Workspaces",
       "description": "List Asana workspaces accessible to the authenticated user",
       "requiresWrite": false,
@@ -556,7 +556,7 @@
       }
     },
     {
-      "id": "list_users",
+      "id": "asana__list_users",
       "name": "List Users",
       "description": "List users in an Asana workspace",
       "requiresWrite": false,
@@ -641,7 +641,7 @@
       }
     },
     {
-      "id": "list_teams",
+      "id": "asana__list_teams",
       "name": "List Teams",
       "description": "List teams in an Asana workspace",
       "requiresWrite": false,
@@ -783,7 +783,7 @@
       }
     },
     {
-      "id": "add_task_comment",
+      "id": "asana__add_task_comment",
       "name": "Add Task Comment",
       "description": "Add a story/comment to an Asana task",
       "requiresWrite": true,
@@ -811,7 +811,7 @@
       }
     },
     {
-      "id": "list_task_comments",
+      "id": "asana__list_task_comments",
       "name": "List Task Comments",
       "description": "List comment stories for an Asana task",
       "requiresWrite": false,
@@ -900,7 +900,7 @@
       }
     },
     {
-      "id": "get_project",
+      "id": "asana__get_project",
       "name": "Get Project",
       "description": "Get details of a specific Asana project",
       "requiresWrite": false,

--- a/cli/templates/integrations/ashby/connector.json
+++ b/cli/templates/integrations/ashby/connector.json
@@ -34,7 +34,7 @@
   ],
   "tools": [
     {
-      "id": "list_candidates",
+      "id": "ashby__list_candidates",
       "name": "List Candidates",
       "description": "List all candidates in the organization (read-only RPC via POST)",
       "requiresWrite": false,
@@ -73,7 +73,7 @@
       }
     },
     {
-      "id": "get_candidate",
+      "id": "ashby__get_candidate",
       "name": "Get Candidate",
       "description": "Get a candidate by ID (read-only RPC via POST)",
       "requiresWrite": false,
@@ -93,7 +93,7 @@
       }
     },
     {
-      "id": "search_candidates",
+      "id": "ashby__search_candidates",
       "name": "Search Candidates",
       "description": "Search candidates by email or name (read-only RPC via POST)",
       "requiresWrite": false,
@@ -116,7 +116,7 @@
       }
     },
     {
-      "id": "create_candidate",
+      "id": "ashby__create_candidate",
       "name": "Create Candidate",
       "description": "Create a new candidate",
       "requiresWrite": true,
@@ -148,7 +148,7 @@
       }
     },
     {
-      "id": "list_jobs",
+      "id": "ashby__list_jobs",
       "name": "List Jobs",
       "description": "List jobs, optionally filtered by status (read-only RPC via POST)",
       "requiresWrite": false,
@@ -176,7 +176,7 @@
       }
     },
     {
-      "id": "list_applications",
+      "id": "ashby__list_applications",
       "name": "List Applications",
       "description": "List applications, optionally filtered by job or status (read-only RPC via POST)",
       "requiresWrite": false,

--- a/cli/templates/integrations/assemblyai/connector.json
+++ b/cli/templates/integrations/assemblyai/connector.json
@@ -25,7 +25,7 @@
   ],
   "tools": [
     {
-      "id": "submit_transcript",
+      "id": "assemblyai__submit_transcript",
       "name": "Submit Transcript",
       "description": "Submit an audio or video URL for transcription (processing is asynchronous)",
       "requiresWrite": true,
@@ -50,7 +50,7 @@
       }
     },
     {
-      "id": "get_transcript",
+      "id": "assemblyai__get_transcript",
       "name": "Get Transcript",
       "description": "Get the status and text of a transcript by ID",
       "requiresWrite": false,
@@ -68,7 +68,7 @@
       }
     },
     {
-      "id": "list_transcripts",
+      "id": "assemblyai__list_transcripts",
       "name": "List Transcripts",
       "description": "List transcripts created by the account",
       "requiresWrite": false,
@@ -115,7 +115,7 @@
       }
     },
     {
-      "id": "delete_transcript",
+      "id": "assemblyai__delete_transcript",
       "name": "Delete Transcript",
       "description": "Permanently delete a transcript and its data",
       "requiresWrite": true,

--- a/cli/templates/integrations/attio/connector.json
+++ b/cli/templates/integrations/attio/connector.json
@@ -40,7 +40,7 @@
   ],
   "tools": [
     {
-      "id": "list_objects",
+      "id": "attio__list_objects",
       "name": "List Objects",
       "description": "List object types in the Attio workspace (people, companies, deals, and custom objects)",
       "requiresWrite": false,
@@ -53,7 +53,7 @@
       }
     },
     {
-      "id": "query_records",
+      "id": "attio__query_records",
       "name": "Query Records",
       "description": "Query records of an object with optional filters and sorts",
       "requiresWrite": false,
@@ -105,7 +105,7 @@
       }
     },
     {
-      "id": "get_record",
+      "id": "attio__get_record",
       "name": "Get Record",
       "description": "Get a single record of an object by ID",
       "requiresWrite": false,
@@ -132,7 +132,7 @@
       }
     },
     {
-      "id": "create_record",
+      "id": "attio__create_record",
       "name": "Create Record",
       "description": "Create a new record of an object (person, company, deal, or custom object)",
       "requiresWrite": true,
@@ -160,7 +160,7 @@
       }
     },
     {
-      "id": "update_record",
+      "id": "attio__update_record",
       "name": "Update Record",
       "description": "Update attribute values on an existing record",
       "requiresWrite": true,
@@ -194,7 +194,7 @@
       }
     },
     {
-      "id": "list_lists",
+      "id": "attio__list_lists",
       "name": "List Lists",
       "description": "List all lists in the Attio workspace",
       "requiresWrite": false,

--- a/cli/templates/integrations/axiom/connector.json
+++ b/cli/templates/integrations/axiom/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_datasets",
+      "id": "axiom__list_datasets",
       "name": "List Datasets",
       "description": "List datasets in the Axiom organization",
       "requiresWrite": false,
@@ -49,7 +49,7 @@
       }
     },
     {
-      "id": "get_dataset",
+      "id": "axiom__get_dataset",
       "name": "Get Dataset",
       "description": "Get a dataset's details",
       "requiresWrite": false,
@@ -67,7 +67,7 @@
       }
     },
     {
-      "id": "query_apl",
+      "id": "axiom__query_apl",
       "name": "Run APL Query",
       "description": "Run an APL (Axiom Processing Language) query across datasets",
       "requiresWrite": false,
@@ -100,7 +100,7 @@
       }
     },
     {
-      "id": "ingest_events",
+      "id": "axiom__ingest_events",
       "name": "Ingest Events",
       "description": "Ingest a batch of JSON events into a dataset",
       "requiresWrite": true,

--- a/cli/templates/integrations/azure-blob-storage/connector.json
+++ b/cli/templates/integrations/azure-blob-storage/connector.json
@@ -49,7 +49,7 @@
   ],
   "tools": [
     {
-      "id": "list_containers",
+      "id": "azure-blob-storage__list_containers",
       "name": "List Containers",
       "description": "List blob containers in a storage account; the response is XML (EnumerationResults), not JSON",
       "requiresWrite": false,
@@ -84,7 +84,7 @@
       }
     },
     {
-      "id": "list_blobs",
+      "id": "azure-blob-storage__list_blobs",
       "name": "List Blobs",
       "description": "List blobs in a container, optionally filtered by name prefix; the response is XML (EnumerationResults), not JSON",
       "requiresWrite": false,
@@ -125,7 +125,7 @@
       }
     },
     {
-      "id": "download_blob",
+      "id": "azure-blob-storage__download_blob",
       "name": "Download Blob",
       "description": "Download a blob's content (Get Blob); blob properties are returned as x-ms-* response headers",
       "requiresWrite": false,
@@ -161,7 +161,7 @@
       }
     },
     {
-      "id": "upload_blob",
+      "id": "azure-blob-storage__upload_blob",
       "name": "Upload Blob",
       "description": "Create or overwrite a block blob with the given content (Put Blob)",
       "requiresWrite": true,
@@ -218,7 +218,7 @@
       }
     },
     {
-      "id": "delete_blob",
+      "id": "azure-blob-storage__delete_blob",
       "name": "Delete Blob",
       "description": "Delete a blob from a container (Delete Blob); errors are returned as XML",
       "requiresWrite": true,
@@ -254,7 +254,7 @@
       }
     },
     {
-      "id": "create_container",
+      "id": "azure-blob-storage__create_container",
       "name": "Create Container",
       "description": "Create a new blob container in the storage account (Create Container); fails with 409 if a container with the same name already exists",
       "requiresWrite": true,
@@ -289,7 +289,7 @@
       }
     },
     {
-      "id": "copy_blob",
+      "id": "azure-blob-storage__copy_blob",
       "name": "Copy Blob",
       "description": "Server-side copy of a blob to a destination within the storage account (Copy Blob) — no download/re-upload needed; returns 202 with x-ms-copy-status 'success' or 'pending' (poll the destination blob until the copy finishes)",
       "requiresWrite": true,

--- a/cli/templates/integrations/azure-document-intelligence/connector.json
+++ b/cli/templates/integrations/azure-document-intelligence/connector.json
@@ -34,7 +34,7 @@
   ],
   "tools": [
     {
-      "id": "analyze_invoice",
+      "id": "azure-document-intelligence__analyze_invoice",
       "name": "Analyze Invoice",
       "description": "Start analysis of an invoice with the prebuilt-invoice model (vendor, customer, line items, totals, taxes, payment terms). Asynchronous: the API responds 202 Accepted with an Operation-Location header containing the result ID — poll Get Analyze Result with that ID to fetch the extracted fields.",
       "requiresWrite": true,
@@ -72,7 +72,7 @@
       }
     },
     {
-      "id": "analyze_receipt",
+      "id": "azure-document-intelligence__analyze_receipt",
       "name": "Analyze Receipt",
       "description": "Start analysis of a sales receipt with the prebuilt-receipt model (merchant, transaction date/time, line items, tax, tip, total). Asynchronous: responds 202 Accepted with an Operation-Location header containing the result ID — poll Get Analyze Result with that ID.",
       "requiresWrite": true,
@@ -110,7 +110,7 @@
       }
     },
     {
-      "id": "analyze_layout",
+      "id": "azure-document-intelligence__analyze_layout",
       "name": "Analyze Layout",
       "description": "Start analysis of any document with the prebuilt-layout model to extract text, tables, selection marks, and document structure (optionally as Markdown). Asynchronous: responds 202 Accepted with an Operation-Location header containing the result ID — poll Get Analyze Result with that ID.",
       "requiresWrite": true,
@@ -148,7 +148,7 @@
       }
     },
     {
-      "id": "get_analyze_result",
+      "id": "azure-document-intelligence__get_analyze_result",
       "name": "Get Analyze Result",
       "description": "Fetch the result of a previously started analysis. Use the result ID (GUID) from the Operation-Location response header of an analyze call, and the same model ID that started it. While status is 'running', wait and poll again; when status is 'succeeded', the extracted fields are in analyzeResult.",
       "requiresWrite": false,
@@ -178,7 +178,7 @@
       }
     },
     {
-      "id": "analyze_read",
+      "id": "azure-document-intelligence__analyze_read",
       "name": "Analyze Read (OCR)",
       "description": "Start pure OCR text extraction with the prebuilt-read model — the cheapest option for plain scans where only the text matters (no tables or key-value pairs). Asynchronous: responds 202 Accepted with an Operation-Location header containing the result ID — poll Get Analyze Result with that ID.",
       "requiresWrite": true,
@@ -216,7 +216,7 @@
       }
     },
     {
-      "id": "list_document_models",
+      "id": "azure-document-intelligence__list_document_models",
       "name": "List Document Models",
       "description": "List the document models available on the resource (prebuilt and custom) with their model IDs and descriptions — use this to discover valid model IDs",
       "requiresWrite": false,

--- a/cli/templates/integrations/azure/connector.json
+++ b/cli/templates/integrations/azure/connector.json
@@ -41,7 +41,7 @@
   ],
   "tools": [
     {
-      "id": "list_subscriptions",
+      "id": "azure__list_subscriptions",
       "name": "List Subscriptions",
       "description": "List all Azure subscriptions the signed-in user can access; use this first to get subscription IDs for the other tools",
       "requiresWrite": false,
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "list_resource_groups",
+      "id": "azure__list_resource_groups",
       "name": "List Resource Groups",
       "description": "List the resource groups in an Azure subscription",
       "requiresWrite": false,
@@ -99,7 +99,7 @@
       }
     },
     {
-      "id": "list_virtual_machines",
+      "id": "azure__list_virtual_machines",
       "name": "List Virtual Machines",
       "description": "List all virtual machines in an Azure subscription, optionally with runtime power state",
       "requiresWrite": false,
@@ -131,7 +131,7 @@
       }
     },
     {
-      "id": "start_virtual_machine",
+      "id": "azure__start_virtual_machine",
       "name": "Start Virtual Machine",
       "description": "Start a stopped or deallocated virtual machine (returns 202 Accepted; the operation completes asynchronously)",
       "requiresWrite": true,
@@ -167,7 +167,7 @@
       }
     },
     {
-      "id": "deallocate_virtual_machine",
+      "id": "azure__deallocate_virtual_machine",
       "name": "Deallocate Virtual Machine",
       "description": "Shut down a virtual machine and release its compute resources so it stops incurring compute charges (returns 202 Accepted)",
       "requiresWrite": true,
@@ -208,7 +208,7 @@
       }
     },
     {
-      "id": "list_storage_accounts",
+      "id": "azure__list_storage_accounts",
       "name": "List Storage Accounts",
       "description": "List all storage accounts in an Azure subscription (storage keys are not returned)",
       "requiresWrite": false,
@@ -235,7 +235,7 @@
       }
     },
     {
-      "id": "list_function_apps",
+      "id": "azure__list_function_apps",
       "name": "List Function and Web Apps",
       "description": "List all App Service sites (function apps and web apps, Microsoft.Web/sites) in an Azure subscription; function apps have kind 'functionapp'",
       "requiresWrite": false,
@@ -262,7 +262,7 @@
       }
     },
     {
-      "id": "restart_virtual_machine",
+      "id": "azure__restart_virtual_machine",
       "name": "Restart Virtual Machine",
       "description": "Restart a running virtual machine (returns 202 Accepted; the operation completes asynchronously)",
       "requiresWrite": true,
@@ -298,7 +298,7 @@
       }
     },
     {
-      "id": "get_vm_instance_view",
+      "id": "azure__get_vm_instance_view",
       "name": "Get VM Instance View",
       "description": "Get the runtime state of a single virtual machine, including power state (statuses with code PowerState/running etc.), OS info, and boot diagnostics — cheaper than listing all VMs with statusOnly",
       "requiresWrite": false,
@@ -334,7 +334,7 @@
       }
     },
     {
-      "id": "list_resources",
+      "id": "azure__list_resources",
       "name": "List Resources",
       "description": "List all resources in an Azure subscription across every resource type — a generic inventory beyond the dedicated list tools",
       "requiresWrite": false,

--- a/cli/templates/integrations/bamboohr/connector.json
+++ b/cli/templates/integrations/bamboohr/connector.json
@@ -36,7 +36,7 @@
   ],
   "tools": [
     {
-      "id": "get_employee_directory",
+      "id": "bamboohr__get_employee_directory",
       "name": "Get Employee Directory",
       "description": "Get the company employee directory with names, job titles, departments, and contact details",
       "requiresWrite": false,
@@ -64,7 +64,7 @@
       }
     },
     {
-      "id": "get_employee",
+      "id": "bamboohr__get_employee",
       "name": "Get Employee",
       "description": "Get a single employee record with the specific fields you request",
       "requiresWrite": false,
@@ -107,7 +107,7 @@
       }
     },
     {
-      "id": "list_time_off_requests",
+      "id": "bamboohr__list_time_off_requests",
       "name": "List Time-Off Requests",
       "description": "List time-off requests that overlap a date range, optionally filtered by employee or status",
       "requiresWrite": false,
@@ -164,7 +164,7 @@
       }
     },
     {
-      "id": "create_time_off_request",
+      "id": "bamboohr__create_time_off_request",
       "name": "Create Time-Off Request",
       "description": "Create a time-off request for an employee; it must be approved before it appears in history",
       "requiresWrite": true,
@@ -230,7 +230,7 @@
       }
     },
     {
-      "id": "list_time_off_types",
+      "id": "bamboohr__list_time_off_types",
       "name": "List Time-Off Types",
       "description": "List the company's time-off types and their IDs - needed to fill the timeOffTypeId field when creating a time-off request",
       "requiresWrite": false,
@@ -255,7 +255,7 @@
       }
     },
     {
-      "id": "update_time_off_request_status",
+      "id": "bamboohr__update_time_off_request_status",
       "name": "Update Time-Off Request Status",
       "description": "Approve, deny, or cancel an existing time-off request (the API user must have approval permissions)",
       "requiresWrite": true,
@@ -297,7 +297,7 @@
       }
     },
     {
-      "id": "list_fields",
+      "id": "bamboohr__list_fields",
       "name": "List Field Metadata",
       "description": "List all employee fields available in the account (standard and custom) so agents know which field names Get Employee accepts",
       "requiresWrite": false,
@@ -322,7 +322,7 @@
       }
     },
     {
-      "id": "list_whos_out",
+      "id": "bamboohr__list_whos_out",
       "name": "List Who's Out",
       "description": "List approved time off and company holidays in a date range to see who is out of office",
       "requiresWrite": false,

--- a/cli/templates/integrations/basecamp/connector.json
+++ b/cli/templates/integrations/basecamp/connector.json
@@ -36,7 +36,7 @@
   ],
   "tools": [
     {
-      "id": "list_projects",
+      "id": "basecamp__list_projects",
       "name": "List Projects",
       "description": "List active projects in a Basecamp account",
       "requiresWrite": false,
@@ -102,7 +102,7 @@
       }
     },
     {
-      "id": "get_project",
+      "id": "basecamp__get_project",
       "name": "Get Project",
       "description": "Get a project including its dock (the todoset ID needed for to-do tools is in the dock entry named 'todoset')",
       "requiresWrite": false,
@@ -126,7 +126,7 @@
       }
     },
     {
-      "id": "create_project",
+      "id": "basecamp__create_project",
       "name": "Create Project",
       "description": "Create a new Basecamp project",
       "requiresWrite": true,
@@ -155,7 +155,7 @@
       }
     },
     {
-      "id": "list_todolists",
+      "id": "basecamp__list_todolists",
       "name": "List To-do Lists",
       "description": "List to-do lists in a project's todoset (get the todoset ID from Get Project's dock)",
       "requiresWrite": false,
@@ -227,7 +227,7 @@
       }
     },
     {
-      "id": "list_todos",
+      "id": "basecamp__list_todos",
       "name": "List To-dos",
       "description": "List to-dos in a to-do list",
       "requiresWrite": false,
@@ -303,7 +303,7 @@
       }
     },
     {
-      "id": "create_todo",
+      "id": "basecamp__create_todo",
       "name": "Create To-do",
       "description": "Create a to-do in a to-do list",
       "requiresWrite": true,
@@ -354,7 +354,7 @@
       }
     },
     {
-      "id": "complete_todo",
+      "id": "basecamp__complete_todo",
       "name": "Complete To-do",
       "description": "Mark a Basecamp to-do as completed",
       "requiresWrite": true,

--- a/cli/templates/integrations/betterstack/connector.json
+++ b/cli/templates/integrations/betterstack/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_monitors",
+      "id": "betterstack__list_monitors",
       "name": "List Monitors",
       "description": "List uptime monitors, optionally filtered by URL or name",
       "requiresWrite": false,
@@ -72,7 +72,7 @@
       }
     },
     {
-      "id": "get_monitor",
+      "id": "betterstack__get_monitor",
       "name": "Get Monitor",
       "description": "Get a monitor's configuration and current status",
       "requiresWrite": false,
@@ -93,7 +93,7 @@
       }
     },
     {
-      "id": "get_monitor_sla",
+      "id": "betterstack__get_monitor_sla",
       "name": "Get Monitor Availability",
       "description": "Get a monitor's availability (SLA) summary for a time range",
       "requiresWrite": false,
@@ -124,7 +124,7 @@
       }
     },
     {
-      "id": "list_incidents",
+      "id": "betterstack__list_incidents",
       "name": "List Incidents",
       "description": "List incidents, optionally limited to a date range or unresolved only",
       "requiresWrite": false,
@@ -162,7 +162,7 @@
       }
     },
     {
-      "id": "list_heartbeats",
+      "id": "betterstack__list_heartbeats",
       "name": "List Heartbeats",
       "description": "List heartbeat (cron/job) monitors and their status",
       "requiresWrite": false,

--- a/cli/templates/integrations/bigcommerce/connector.json
+++ b/cli/templates/integrations/bigcommerce/connector.json
@@ -34,7 +34,7 @@
   ],
   "tools": [
     {
-      "id": "list_orders",
+      "id": "bigcommerce__list_orders",
       "name": "List Orders",
       "description": "List store orders with optional status, customer, and date filtering (Orders are served by the v2 API)",
       "requiresWrite": false,
@@ -85,7 +85,7 @@
       }
     },
     {
-      "id": "get_order",
+      "id": "bigcommerce__get_order",
       "name": "Get Order",
       "description": "Get full details of a single order (Orders are served by the v2 API)",
       "requiresWrite": false,
@@ -109,7 +109,7 @@
       }
     },
     {
-      "id": "list_order_products",
+      "id": "bigcommerce__list_order_products",
       "name": "List Order Products",
       "description": "List the line items of an order — v2 order responses do not embed products, so use this to see what was bought",
       "requiresWrite": false,
@@ -145,7 +145,7 @@
       }
     },
     {
-      "id": "update_order",
+      "id": "bigcommerce__update_order",
       "name": "Update Order",
       "description": "Update an order, e.g. change its status to Shipped/Cancelled/Refunded or add staff notes",
       "requiresWrite": true,
@@ -183,7 +183,7 @@
       }
     },
     {
-      "id": "list_products",
+      "id": "bigcommerce__list_products",
       "name": "List Products",
       "description": "List catalog products with optional keyword, SKU, and availability filtering",
       "requiresWrite": false,
@@ -236,7 +236,7 @@
       }
     },
     {
-      "id": "get_product",
+      "id": "bigcommerce__get_product",
       "name": "Get Product",
       "description": "Get full details of a single catalog product",
       "requiresWrite": false,
@@ -268,7 +268,7 @@
       }
     },
     {
-      "id": "list_customers",
+      "id": "bigcommerce__list_customers",
       "name": "List Customers",
       "description": "List store customers with optional email and name filtering",
       "requiresWrite": false,
@@ -311,7 +311,7 @@
       }
     },
     {
-      "id": "create_product",
+      "id": "bigcommerce__create_product",
       "name": "Create Product",
       "description": "Create a new product in the catalog",
       "requiresWrite": true,
@@ -374,7 +374,7 @@
       }
     },
     {
-      "id": "update_product",
+      "id": "bigcommerce__update_product",
       "name": "Update Product",
       "description": "Update fields of an existing catalog product, such as price, visibility, or inventory",
       "requiresWrite": true,

--- a/cli/templates/integrations/billbee/connector.json
+++ b/cli/templates/integrations/billbee/connector.json
@@ -44,7 +44,7 @@
   ],
   "tools": [
     {
-      "id": "list_orders",
+      "id": "billbee__list_orders",
       "name": "List Orders",
       "description": "List orders across all connected shops, optionally filtered by date range, modification time, or order state",
       "requiresWrite": false,
@@ -93,7 +93,7 @@
       }
     },
     {
-      "id": "get_order",
+      "id": "billbee__get_order",
       "name": "Get Order",
       "description": "Get a single order with positions, addresses, and payment details by its internal Billbee ID",
       "requiresWrite": false,
@@ -111,7 +111,7 @@
       }
     },
     {
-      "id": "update_order_state",
+      "id": "billbee__update_order_state",
       "name": "Update Order State",
       "description": "Change the main state of an order, e.g. mark it as confirmed, paid, or shipped",
       "requiresWrite": true,
@@ -136,7 +136,7 @@
       }
     },
     {
-      "id": "list_products",
+      "id": "billbee__list_products",
       "name": "List Products",
       "description": "List products (articles) in the Billbee account",
       "requiresWrite": false,
@@ -165,7 +165,7 @@
       }
     },
     {
-      "id": "list_customers",
+      "id": "billbee__list_customers",
       "name": "List Customers",
       "description": "List customers in the Billbee account",
       "requiresWrite": false,
@@ -189,7 +189,7 @@
       }
     },
     {
-      "id": "list_invoices",
+      "id": "billbee__list_invoices",
       "name": "List Invoices",
       "description": "List invoices with positions and amounts over a date range — the export feed into accounting tools. Throttled to 1 request per minute for the same page and minInvoiceDate.",
       "requiresWrite": false,
@@ -228,7 +228,7 @@
       }
     },
     {
-      "id": "get_order_states",
+      "id": "billbee__get_order_states",
       "name": "Get Order States",
       "description": "List all defined order state IDs and names — resolves the NewStateId values used by Update Order State",
       "requiresWrite": false,
@@ -238,7 +238,7 @@
       }
     },
     {
-      "id": "update_stock",
+      "id": "billbee__update_stock",
       "name": "Update Stock",
       "description": "Set the absolute stock quantity of a product by SKU or Billbee product ID — the most common multichannel write; the change is pushed to connected shops",
       "requiresWrite": true,

--- a/cli/templates/integrations/bitbucket/connector.json
+++ b/cli/templates/integrations/bitbucket/connector.json
@@ -34,7 +34,7 @@
   ],
   "tools": [
     {
-      "id": "list_repositories",
+      "id": "bitbucket__list_repositories",
       "name": "List Repositories",
       "description": "Get list of user's repositories",
       "requiresWrite": false,
@@ -129,7 +129,7 @@
       }
     },
     {
-      "id": "get_repository",
+      "id": "bitbucket__get_repository",
       "name": "Get Repository",
       "description": "Get details of a specific repository",
       "requiresWrite": false,
@@ -153,7 +153,7 @@
       }
     },
     {
-      "id": "list_pull_requests",
+      "id": "bitbucket__list_pull_requests",
       "name": "List Pull Requests",
       "description": "Get pull requests for a repository",
       "requiresWrite": false,
@@ -245,7 +245,7 @@
       }
     },
     {
-      "id": "get_pull_request",
+      "id": "bitbucket__get_pull_request",
       "name": "Get Pull Request",
       "description": "Get details of a specific pull request",
       "requiresWrite": false,
@@ -275,7 +275,7 @@
       }
     },
     {
-      "id": "create_pull_request",
+      "id": "bitbucket__create_pull_request",
       "name": "Create Pull Request",
       "description": "Create a new pull request",
       "requiresWrite": true,
@@ -327,7 +327,7 @@
       }
     },
     {
-      "id": "add_pull_request_comment",
+      "id": "bitbucket__add_pull_request_comment",
       "name": "Add Pull Request Comment",
       "description": "Add a comment to a pull request",
       "requiresWrite": true,
@@ -364,7 +364,7 @@
       }
     },
     {
-      "id": "list_issues",
+      "id": "bitbucket__list_issues",
       "name": "List Issues",
       "description": "Get issues for a repository",
       "requiresWrite": false,

--- a/cli/templates/integrations/box/connector.json
+++ b/cli/templates/integrations/box/connector.json
@@ -39,7 +39,7 @@
   ],
   "tools": [
     {
-      "id": "list_folder_items",
+      "id": "box__list_folder_items",
       "name": "List Folder Items",
       "description": "List files and subfolders inside a Box folder (folder 0 is the root)",
       "requiresWrite": false,
@@ -114,7 +114,7 @@
       }
     },
     {
-      "id": "get_file",
+      "id": "box__get_file",
       "name": "Get File",
       "description": "Get metadata about a Box file",
       "requiresWrite": false,
@@ -137,7 +137,7 @@
       }
     },
     {
-      "id": "get_folder",
+      "id": "box__get_folder",
       "name": "Get Folder",
       "description": "Get metadata about a Box folder",
       "requiresWrite": false,
@@ -155,7 +155,7 @@
       }
     },
     {
-      "id": "search",
+      "id": "box__search",
       "name": "Search",
       "description": "Search for files and folders across the Box account",
       "requiresWrite": false,
@@ -195,7 +195,7 @@
       }
     },
     {
-      "id": "create_folder",
+      "id": "box__create_folder",
       "name": "Create Folder",
       "description": "Create a new folder inside a Box parent folder",
       "requiresWrite": true,
@@ -213,14 +213,14 @@
             "description": "Parent folder reference, e.g. { \"id\": \"0\" } for the root folder",
             "required": true,
             "default": {
-              "id": "0"
+              "id": "box__0"
             }
           }
         }
       }
     },
     {
-      "id": "upload_file",
+      "id": "box__upload_file",
       "name": "Upload File",
       "description": "Upload a new file (up to 50 MB) into a Box folder; larger files require Box's chunked upload API",
       "requiresWrite": true,
@@ -258,7 +258,7 @@
       }
     },
     {
-      "id": "upload_file_version",
+      "id": "box__upload_file_version",
       "name": "Upload File Version",
       "description": "Upload a new version of an existing Box file (up to 50 MB)",
       "requiresWrite": true,
@@ -297,7 +297,7 @@
       }
     },
     {
-      "id": "list_file_comments",
+      "id": "box__list_file_comments",
       "name": "List File Comments",
       "description": "List comments on a Box file",
       "requiresWrite": false,
@@ -327,7 +327,7 @@
       }
     },
     {
-      "id": "add_comment",
+      "id": "box__add_comment",
       "name": "Add Comment",
       "description": "Add a comment to a Box file",
       "requiresWrite": true,
@@ -349,7 +349,7 @@
       }
     },
     {
-      "id": "download_file",
+      "id": "box__download_file",
       "name": "Download File",
       "description": "Download a file's content; Box responds with a 302 redirect to a short-lived dl.boxcloud.com URL that is followed to fetch the binary content (a 202 with Retry-After means the file is not yet ready)",
       "requiresWrite": false,

--- a/cli/templates/integrations/brave-search/connector.json
+++ b/cli/templates/integrations/brave-search/connector.json
@@ -27,7 +27,7 @@
   ],
   "tools": [
     {
-      "id": "web_search",
+      "id": "brave-search__web_search",
       "name": "Web Search",
       "description": "Search the web and get ranked results from Brave's independent index",
       "requiresWrite": false,
@@ -85,7 +85,7 @@
       }
     },
     {
-      "id": "news_search",
+      "id": "brave-search__news_search",
       "name": "News Search",
       "description": "Search recent and historical news articles from trusted outlets worldwide",
       "requiresWrite": false,
@@ -152,7 +152,7 @@
       }
     },
     {
-      "id": "image_search",
+      "id": "brave-search__image_search",
       "name": "Image Search",
       "description": "Search Brave's image index and get image URLs with source page metadata",
       "requiresWrite": false,
@@ -194,7 +194,7 @@
       }
     },
     {
-      "id": "video_search",
+      "id": "brave-search__video_search",
       "name": "Video Search",
       "description": "Search for videos and get results with titles, creators, durations, and thumbnails",
       "requiresWrite": false,
@@ -246,7 +246,7 @@
       }
     },
     {
-      "id": "local_descriptions",
+      "id": "brave-search__local_descriptions",
       "name": "Get Local Descriptions",
       "description": "Get AI-generated text descriptions for up to 20 locations using location IDs returned in a Web Search response's locations results",
       "requiresWrite": false,
@@ -264,7 +264,7 @@
       }
     },
     {
-      "id": "local_pois",
+      "id": "brave-search__local_pois",
       "name": "Get Local Places",
       "description": "Get rich details (address, hours, ratings, pictures) for up to 20 locations using location IDs returned in a Web Search response's locations results",
       "requiresWrite": false,

--- a/cli/templates/integrations/brevo/connector.json
+++ b/cli/templates/integrations/brevo/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "send_email",
+      "id": "brevo__send_email",
       "name": "Send Email",
       "description": "Send a transactional email",
       "requiresWrite": true,
@@ -65,7 +65,7 @@
       }
     },
     {
-      "id": "list_contacts",
+      "id": "brevo__list_contacts",
       "name": "List Contacts",
       "description": "List contacts in the account",
       "requiresWrite": false,
@@ -116,7 +116,7 @@
       }
     },
     {
-      "id": "get_contact",
+      "id": "brevo__get_contact",
       "name": "Get Contact",
       "description": "Get a contact by email address or numeric ID",
       "requiresWrite": false,
@@ -134,7 +134,7 @@
       }
     },
     {
-      "id": "create_contact",
+      "id": "brevo__create_contact",
       "name": "Create Contact",
       "description": "Create a new contact",
       "requiresWrite": true,
@@ -164,7 +164,7 @@
       }
     },
     {
-      "id": "list_lists",
+      "id": "brevo__list_lists",
       "name": "List Lists",
       "description": "List contact lists",
       "requiresWrite": false,
@@ -188,7 +188,7 @@
       }
     },
     {
-      "id": "list_email_campaigns",
+      "id": "brevo__list_email_campaigns",
       "name": "List Email Campaigns",
       "description": "List email campaigns with status and scheduling info",
       "requiresWrite": false,

--- a/cli/templates/integrations/browserbase/connector.json
+++ b/cli/templates/integrations/browserbase/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_sessions",
+      "id": "browserbase__list_sessions",
       "name": "List Sessions",
       "description": "List browser sessions, optionally filtered by status",
       "requiresWrite": false,
@@ -58,7 +58,7 @@
       }
     },
     {
-      "id": "create_session",
+      "id": "browserbase__create_session",
       "name": "Create Session",
       "description": "Create a new cloud browser session (consumes plan browser minutes)",
       "requiresWrite": true,
@@ -90,7 +90,7 @@
       }
     },
     {
-      "id": "get_session",
+      "id": "browserbase__get_session",
       "name": "Get Session",
       "description": "Get a session's status, connection URL, and metadata",
       "requiresWrite": false,
@@ -108,7 +108,7 @@
       }
     },
     {
-      "id": "release_session",
+      "id": "browserbase__release_session",
       "name": "Release Session",
       "description": "Request release of a running session to stop billing for it",
       "requiresWrite": true,
@@ -138,7 +138,7 @@
       }
     },
     {
-      "id": "list_projects",
+      "id": "browserbase__list_projects",
       "name": "List Projects",
       "description": "List the Browserbase projects available to the API key",
       "requiresWrite": false,

--- a/cli/templates/integrations/buildkite/connector.json
+++ b/cli/templates/integrations/buildkite/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_organizations",
+      "id": "buildkite__list_organizations",
       "name": "List Organizations",
       "description": "List Buildkite organizations the token can access",
       "requiresWrite": false,
@@ -36,7 +36,7 @@
       }
     },
     {
-      "id": "list_pipelines",
+      "id": "buildkite__list_pipelines",
       "name": "List Pipelines",
       "description": "List pipelines in an organization",
       "requiresWrite": false,
@@ -79,7 +79,7 @@
       }
     },
     {
-      "id": "get_pipeline",
+      "id": "buildkite__get_pipeline",
       "name": "Get Pipeline",
       "description": "Get a pipeline's configuration and build stats",
       "requiresWrite": false,
@@ -103,7 +103,7 @@
       }
     },
     {
-      "id": "list_builds",
+      "id": "buildkite__list_builds",
       "name": "List Builds",
       "description": "List builds for a pipeline, optionally filtered by branch or state",
       "requiresWrite": false,
@@ -163,7 +163,7 @@
       }
     },
     {
-      "id": "get_build",
+      "id": "buildkite__get_build",
       "name": "Get Build",
       "description": "Get a build including its jobs and their states",
       "requiresWrite": false,
@@ -193,7 +193,7 @@
       }
     },
     {
-      "id": "create_build",
+      "id": "buildkite__create_build",
       "name": "Create Build",
       "description": "Trigger a new build on a pipeline",
       "requiresWrite": true,

--- a/cli/templates/integrations/cal-com/connector.json
+++ b/cli/templates/integrations/cal-com/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "list_bookings",
+      "id": "cal-com__list_bookings",
       "name": "List Bookings",
       "description": "List bookings for the authenticated user with optional status, event type, and attendee filters",
       "requiresWrite": false,
@@ -76,7 +76,7 @@
       }
     },
     {
-      "id": "list_event_types",
+      "id": "cal-com__list_event_types",
       "name": "List Event Types",
       "description": "List event types so the agent can find the event type ID needed for slots and bookings",
       "requiresWrite": false,
@@ -113,7 +113,7 @@
       }
     },
     {
-      "id": "get_available_slots",
+      "id": "cal-com__get_available_slots",
       "name": "Get Available Slots",
       "description": "Find available time slots for an event type within a date range, e.g. before creating a booking",
       "requiresWrite": false,
@@ -172,7 +172,7 @@
       }
     },
     {
-      "id": "create_booking",
+      "id": "cal-com__create_booking",
       "name": "Create Booking",
       "description": "Book a time slot on an event type for an attendee",
       "requiresWrite": true,
@@ -226,7 +226,7 @@
       }
     },
     {
-      "id": "get_booking",
+      "id": "cal-com__get_booking",
       "name": "Get Booking",
       "description": "Get a single booking by UID, e.g. to confirm details before rescheduling or cancelling",
       "requiresWrite": false,
@@ -254,7 +254,7 @@
       }
     },
     {
-      "id": "reschedule_booking",
+      "id": "cal-com__reschedule_booking",
       "name": "Reschedule Booking",
       "description": "Move an existing booking to a new start time (only accepted or pending bookings can be rescheduled)",
       "requiresWrite": true,
@@ -297,7 +297,7 @@
       }
     },
     {
-      "id": "confirm_booking",
+      "id": "cal-com__confirm_booking",
       "name": "Confirm Booking",
       "description": "Confirm a booking that is awaiting host approval (status unconfirmed in list_bookings)",
       "requiresWrite": true,
@@ -325,7 +325,7 @@
       }
     },
     {
-      "id": "cancel_booking",
+      "id": "cal-com__cancel_booking",
       "name": "Cancel Booking",
       "description": "Cancel an existing booking, optionally recording a cancellation reason",
       "requiresWrite": true,

--- a/cli/templates/integrations/calendar/connector.json
+++ b/cli/templates/integrations/calendar/connector.json
@@ -38,7 +38,7 @@
   ],
   "tools": [
     {
-      "id": "list_calendars",
+      "id": "calendar__list_calendars",
       "name": "List Calendars",
       "description": "List all calendars in the authenticated user's calendar list",
       "requiresWrite": false,
@@ -59,7 +59,7 @@
       }
     },
     {
-      "id": "list_events",
+      "id": "calendar__list_events",
       "name": "List Events",
       "description": "Get upcoming calendar events",
       "requiresWrite": false,
@@ -109,7 +109,7 @@
       }
     },
     {
-      "id": "create_event",
+      "id": "calendar__create_event",
       "name": "Create Event",
       "description": "Schedule a new calendar event",
       "requiresWrite": true,
@@ -157,7 +157,7 @@
       }
     },
     {
-      "id": "get_event",
+      "id": "calendar__get_event",
       "name": "Get Event",
       "description": "Get details of a specific calendar event",
       "requiresWrite": false,
@@ -182,7 +182,7 @@
       }
     },
     {
-      "id": "update_event",
+      "id": "calendar__update_event",
       "name": "Update Event",
       "description": "Update an existing calendar event",
       "requiresWrite": true,
@@ -239,7 +239,7 @@
       }
     },
     {
-      "id": "delete_event",
+      "id": "calendar__delete_event",
       "name": "Delete Event",
       "description": "Delete a calendar event by ID",
       "requiresWrite": true,
@@ -270,7 +270,7 @@
       }
     },
     {
-      "id": "find_free_time",
+      "id": "calendar__find_free_time",
       "name": "Find Free Time",
       "description": "Find available time slots in calendar",
       "requiresWrite": false,

--- a/cli/templates/integrations/calendly/connector.json
+++ b/cli/templates/integrations/calendly/connector.json
@@ -36,7 +36,7 @@
   ],
   "tools": [
     {
-      "id": "get_current_user",
+      "id": "calendly__get_current_user",
       "name": "Get Current User",
       "description": "Get the connected Calendly user, including their user URI and organization URI (needed by the other tools)",
       "requiresWrite": false,
@@ -49,7 +49,7 @@
       }
     },
     {
-      "id": "list_event_types",
+      "id": "calendly__list_event_types",
       "name": "List Event Types",
       "description": "List the user's or organization's event types (scheduling links)",
       "requiresWrite": false,
@@ -103,7 +103,7 @@
       }
     },
     {
-      "id": "list_scheduled_events",
+      "id": "calendly__list_scheduled_events",
       "name": "List Scheduled Events",
       "description": "List scheduled events for a user or organization",
       "requiresWrite": false,
@@ -167,7 +167,7 @@
       }
     },
     {
-      "id": "get_scheduled_event",
+      "id": "calendly__get_scheduled_event",
       "name": "Get Scheduled Event",
       "description": "Get details of a specific scheduled event",
       "requiresWrite": false,
@@ -188,7 +188,7 @@
       }
     },
     {
-      "id": "list_event_invitees",
+      "id": "calendly__list_event_invitees",
       "name": "List Event Invitees",
       "description": "List invitees of a scheduled event",
       "requiresWrite": false,
@@ -237,7 +237,7 @@
       }
     },
     {
-      "id": "cancel_event",
+      "id": "calendly__cancel_event",
       "name": "Cancel Event",
       "description": "Cancel a scheduled event",
       "requiresWrite": true,

--- a/cli/templates/integrations/chargebee/connector.json
+++ b/cli/templates/integrations/chargebee/connector.json
@@ -41,7 +41,7 @@
   ],
   "tools": [
     {
-      "id": "list_subscriptions",
+      "id": "chargebee__list_subscriptions",
       "name": "List Subscriptions",
       "description": "List subscriptions with optional status or customer filtering",
       "requiresWrite": false,
@@ -89,7 +89,7 @@
       }
     },
     {
-      "id": "get_subscription",
+      "id": "chargebee__get_subscription",
       "name": "Get Subscription",
       "description": "Retrieve a single subscription with its plan, status, and billing details",
       "requiresWrite": false,
@@ -113,7 +113,7 @@
       }
     },
     {
-      "id": "list_customers",
+      "id": "chargebee__list_customers",
       "name": "List Customers",
       "description": "List customers with optional email filtering",
       "requiresWrite": false,
@@ -156,7 +156,7 @@
       }
     },
     {
-      "id": "list_invoices",
+      "id": "chargebee__list_invoices",
       "name": "List Invoices",
       "description": "List invoices with optional status, customer, or subscription filtering",
       "requiresWrite": false,
@@ -209,7 +209,7 @@
       }
     },
     {
-      "id": "list_item_prices",
+      "id": "chargebee__list_item_prices",
       "name": "List Item Prices",
       "description": "List item prices (plans, addons, charges) in the catalog to find IDs and pricing for subscriptions",
       "requiresWrite": false,
@@ -267,7 +267,7 @@
       }
     },
     {
-      "id": "get_invoice",
+      "id": "chargebee__get_invoice",
       "name": "Get Invoice",
       "description": "Retrieve a single invoice with its line items, amounts due, and linked payments",
       "requiresWrite": false,
@@ -291,7 +291,7 @@
       }
     },
     {
-      "id": "list_transactions",
+      "id": "chargebee__list_transactions",
       "name": "List Transactions",
       "description": "List payment-level transactions (payments, refunds, authorizations) behind invoices, e.g. to review failed payments",
       "requiresWrite": false,
@@ -349,7 +349,7 @@
       }
     },
     {
-      "id": "create_customer",
+      "id": "chargebee__create_customer",
       "name": "Create Customer",
       "description": "Create a new customer record in Chargebee",
       "requiresWrite": true,

--- a/cli/templates/integrations/checkly/connector.json
+++ b/cli/templates/integrations/checkly/connector.json
@@ -36,7 +36,7 @@
   ],
   "tools": [
     {
-      "id": "list_checks",
+      "id": "checkly__list_checks",
       "name": "List Checks",
       "description": "List API and browser checks in the account",
       "requiresWrite": false,
@@ -74,7 +74,7 @@
       }
     },
     {
-      "id": "get_check",
+      "id": "checkly__get_check",
       "name": "Get Check",
       "description": "Get a check's full configuration",
       "requiresWrite": false,
@@ -92,7 +92,7 @@
       }
     },
     {
-      "id": "list_check_results",
+      "id": "checkly__list_check_results",
       "name": "List Check Results",
       "description": "List raw results for a check within a time window (from/to must be at most 6 hours apart)",
       "requiresWrite": false,
@@ -141,7 +141,7 @@
       }
     },
     {
-      "id": "list_check_statuses",
+      "id": "checkly__list_check_statuses",
       "name": "List Check Statuses",
       "description": "Get the current status of every check in the account",
       "requiresWrite": false,
@@ -151,7 +151,7 @@
       }
     },
     {
-      "id": "get_check_status",
+      "id": "checkly__get_check_status",
       "name": "Get Check Status",
       "description": "Get the current status of a single check",
       "requiresWrite": false,

--- a/cli/templates/integrations/circleci/connector.json
+++ b/cli/templates/integrations/circleci/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_pipelines",
+      "id": "circleci__list_pipelines",
       "name": "List Pipelines",
       "description": "List recent pipelines for a project",
       "requiresWrite": false,
@@ -90,7 +90,7 @@
       }
     },
     {
-      "id": "get_pipeline",
+      "id": "circleci__get_pipeline",
       "name": "Get Pipeline",
       "description": "Get a pipeline by its ID",
       "requiresWrite": false,
@@ -108,7 +108,7 @@
       }
     },
     {
-      "id": "trigger_pipeline",
+      "id": "circleci__trigger_pipeline",
       "name": "Trigger Pipeline",
       "description": "Trigger a new pipeline for a project on a branch or tag",
       "requiresWrite": true,
@@ -140,7 +140,7 @@
       }
     },
     {
-      "id": "list_workflows",
+      "id": "circleci__list_workflows",
       "name": "List Pipeline Workflows",
       "description": "List the workflows of a pipeline",
       "requiresWrite": false,
@@ -198,7 +198,7 @@
       }
     },
     {
-      "id": "get_workflow",
+      "id": "circleci__get_workflow",
       "name": "Get Workflow",
       "description": "Get a workflow by its ID",
       "requiresWrite": false,
@@ -216,7 +216,7 @@
       }
     },
     {
-      "id": "list_workflow_jobs",
+      "id": "circleci__list_workflow_jobs",
       "name": "List Workflow Jobs",
       "description": "List the jobs of a workflow with their statuses",
       "requiresWrite": false,
@@ -234,7 +234,7 @@
       }
     },
     {
-      "id": "cancel_workflow",
+      "id": "circleci__cancel_workflow",
       "name": "Cancel Workflow",
       "description": "Cancel a running workflow",
       "requiresWrite": true,

--- a/cli/templates/integrations/cleverreach/connector.json
+++ b/cli/templates/integrations/cleverreach/connector.json
@@ -41,7 +41,7 @@
   ],
   "tools": [
     {
-      "id": "list_groups",
+      "id": "cleverreach__list_groups",
       "name": "List Groups",
       "description": "List CleverReach groups (recipient lists) so agents can find a group ID before reading or adding recipients",
       "requiresWrite": false,
@@ -58,7 +58,7 @@
       }
     },
     {
-      "id": "list_group_receivers",
+      "id": "cleverreach__list_group_receivers",
       "name": "List Group Receivers",
       "description": "List the receivers (recipients) of a CleverReach group, with paging and email filters",
       "requiresWrite": false,
@@ -103,7 +103,7 @@
       }
     },
     {
-      "id": "add_receiver",
+      "id": "cleverreach__add_receiver",
       "name": "Add Receiver",
       "description": "Add (subscribe) a new receiver to a CleverReach group",
       "requiresWrite": true,
@@ -152,7 +152,7 @@
       }
     },
     {
-      "id": "list_mailings",
+      "id": "cleverreach__list_mailings",
       "name": "List Mailings",
       "description": "List CleverReach mailings (email campaigns) filtered by state, such as drafts or finished mailings",
       "requiresWrite": false,
@@ -195,7 +195,7 @@
       }
     },
     {
-      "id": "create_mailing",
+      "id": "cleverreach__create_mailing",
       "name": "Create Mailing Draft",
       "description": "Create a new CleverReach mailing as a draft with subject, sender, and HTML/text content; sending is triggered separately",
       "requiresWrite": true,
@@ -243,7 +243,7 @@
       }
     },
     {
-      "id": "get_mailing",
+      "id": "cleverreach__get_mailing",
       "name": "Get Mailing",
       "description": "Get a single mailing by ID, e.g. to inspect a draft created with Create Mailing Draft",
       "requiresWrite": false,
@@ -261,7 +261,7 @@
       }
     },
     {
-      "id": "deactivate_receiver",
+      "id": "cleverreach__deactivate_receiver",
       "name": "Deactivate Receiver",
       "description": "Deactivate (unsubscribe) a receiver in a group by ID or email — the counterpart to Add Receiver for unsubscribe handling",
       "requiresWrite": true,
@@ -285,7 +285,7 @@
       }
     },
     {
-      "id": "get_group_stats",
+      "id": "cleverreach__get_group_stats",
       "name": "Get Group Stats",
       "description": "Get list health statistics for a group: active, inactive, and bounced receiver counts",
       "requiresWrite": false,

--- a/cli/templates/integrations/clickhouse/connector.json
+++ b/cli/templates/integrations/clickhouse/connector.json
@@ -33,7 +33,7 @@
   ],
   "tools": [
     {
-      "id": "list_organizations",
+      "id": "clickhouse__list_organizations",
       "name": "List Organizations",
       "description": "List organizations the API key has access to",
       "requiresWrite": false,
@@ -56,7 +56,7 @@
       }
     },
     {
-      "id": "get_organization",
+      "id": "clickhouse__get_organization",
       "name": "Get Organization",
       "description": "Get details of an organization",
       "requiresWrite": false,
@@ -77,7 +77,7 @@
       }
     },
     {
-      "id": "list_services",
+      "id": "clickhouse__list_services",
       "name": "List Services",
       "description": "List all ClickHouse services in an organization",
       "requiresWrite": false,
@@ -112,7 +112,7 @@
       }
     },
     {
-      "id": "get_service",
+      "id": "clickhouse__get_service",
       "name": "Get Service",
       "description": "Get details of a ClickHouse service, including endpoints and state",
       "requiresWrite": false,

--- a/cli/templates/integrations/clickup/connector.json
+++ b/cli/templates/integrations/clickup/connector.json
@@ -36,7 +36,7 @@
   ],
   "tools": [
     {
-      "id": "list_workspaces",
+      "id": "clickup__list_workspaces",
       "name": "List Workspaces",
       "description": "List ClickUp Workspaces (teams) the authorized user can access",
       "requiresWrite": false,
@@ -46,7 +46,7 @@
       }
     },
     {
-      "id": "list_spaces",
+      "id": "clickup__list_spaces",
       "name": "List Spaces",
       "description": "List Spaces in a ClickUp Workspace",
       "requiresWrite": false,
@@ -70,7 +70,7 @@
       }
     },
     {
-      "id": "list_lists",
+      "id": "clickup__list_lists",
       "name": "List Lists",
       "description": "List folderless Lists in a ClickUp Space",
       "requiresWrite": false,
@@ -94,7 +94,7 @@
       }
     },
     {
-      "id": "list_tasks",
+      "id": "clickup__list_tasks",
       "name": "List Tasks",
       "description": "List tasks in a ClickUp List",
       "requiresWrite": false,
@@ -148,7 +148,7 @@
       }
     },
     {
-      "id": "get_task",
+      "id": "clickup__get_task",
       "name": "Get Task",
       "description": "Get details of a ClickUp task",
       "requiresWrite": false,
@@ -172,7 +172,7 @@
       }
     },
     {
-      "id": "create_task",
+      "id": "clickup__create_task",
       "name": "Create Task",
       "description": "Create a new task in a ClickUp List",
       "requiresWrite": true,
@@ -217,7 +217,7 @@
       }
     },
     {
-      "id": "update_task",
+      "id": "clickup__update_task",
       "name": "Update Task",
       "description": "Update fields on an existing ClickUp task",
       "requiresWrite": true,

--- a/cli/templates/integrations/close/connector.json
+++ b/cli/templates/integrations/close/connector.json
@@ -34,7 +34,7 @@
   ],
   "tools": [
     {
-      "id": "list_leads",
+      "id": "close__list_leads",
       "name": "List Leads",
       "description": "List or search leads in Close using the lead query language",
       "requiresWrite": false,
@@ -80,7 +80,7 @@
       }
     },
     {
-      "id": "get_lead",
+      "id": "close__get_lead",
       "name": "Get Lead",
       "description": "Get full details of a Close lead, including contacts and opportunities",
       "requiresWrite": false,
@@ -98,7 +98,7 @@
       }
     },
     {
-      "id": "create_lead",
+      "id": "close__create_lead",
       "name": "Create Lead",
       "description": "Create a new lead in Close, optionally with contacts",
       "requiresWrite": true,
@@ -131,7 +131,7 @@
       }
     },
     {
-      "id": "update_lead",
+      "id": "close__update_lead",
       "name": "Update Lead",
       "description": "Update fields on an existing Close lead",
       "requiresWrite": true,
@@ -167,7 +167,7 @@
       }
     },
     {
-      "id": "list_opportunities",
+      "id": "close__list_opportunities",
       "name": "List Opportunities",
       "description": "List opportunities, optionally filtered by lead",
       "requiresWrite": false,
@@ -196,7 +196,7 @@
       }
     },
     {
-      "id": "create_opportunity",
+      "id": "close__create_opportunity",
       "name": "Create Opportunity",
       "description": "Create an opportunity on a Close lead",
       "requiresWrite": true,
@@ -234,7 +234,7 @@
       }
     },
     {
-      "id": "list_contacts",
+      "id": "close__list_contacts",
       "name": "List Contacts",
       "description": "List contacts, optionally filtered by lead",
       "requiresWrite": false,

--- a/cli/templates/integrations/cloudflare/connector.json
+++ b/cli/templates/integrations/cloudflare/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "verify_token",
+      "id": "cloudflare__verify_token",
       "name": "Verify Token",
       "description": "Check that the configured Cloudflare API token is valid and active",
       "requiresWrite": false,
@@ -39,7 +39,7 @@
       }
     },
     {
-      "id": "list_zones",
+      "id": "cloudflare__list_zones",
       "name": "List Zones",
       "description": "List zones (domains) the token can access",
       "requiresWrite": false,
@@ -108,7 +108,7 @@
       }
     },
     {
-      "id": "get_zone",
+      "id": "cloudflare__get_zone",
       "name": "Get Zone",
       "description": "Get details of a zone by ID",
       "requiresWrite": false,
@@ -129,7 +129,7 @@
       }
     },
     {
-      "id": "list_dns_records",
+      "id": "cloudflare__list_dns_records",
       "name": "List DNS Records",
       "description": "List DNS records in a zone",
       "requiresWrite": false,
@@ -207,7 +207,7 @@
       }
     },
     {
-      "id": "create_dns_record",
+      "id": "cloudflare__create_dns_record",
       "name": "Create DNS Record",
       "description": "Create a DNS record in a zone",
       "requiresWrite": true,
@@ -259,7 +259,7 @@
       }
     },
     {
-      "id": "update_dns_record",
+      "id": "cloudflare__update_dns_record",
       "name": "Update DNS Record",
       "description": "Update fields of an existing DNS record",
       "requiresWrite": true,
@@ -308,7 +308,7 @@
       }
     },
     {
-      "id": "list_accounts",
+      "id": "cloudflare__list_accounts",
       "name": "List Accounts",
       "description": "List Cloudflare accounts the token can access (account IDs are needed for account-scoped APIs)",
       "requiresWrite": false,

--- a/cli/templates/integrations/coda/connector.json
+++ b/cli/templates/integrations/coda/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_docs",
+      "id": "coda__list_docs",
       "name": "List Docs",
       "description": "List Coda docs accessible to the token",
       "requiresWrite": false,
@@ -97,7 +97,7 @@
       }
     },
     {
-      "id": "get_doc",
+      "id": "coda__get_doc",
       "name": "Get Doc",
       "description": "Get metadata for a Coda doc",
       "requiresWrite": false,
@@ -115,7 +115,7 @@
       }
     },
     {
-      "id": "create_doc",
+      "id": "coda__create_doc",
       "name": "Create Doc",
       "description": "Create a new Coda doc, optionally copying an existing doc",
       "requiresWrite": true,
@@ -139,7 +139,7 @@
       }
     },
     {
-      "id": "list_pages",
+      "id": "coda__list_pages",
       "name": "List Pages",
       "description": "List pages in a Coda doc",
       "requiresWrite": false,
@@ -205,7 +205,7 @@
       }
     },
     {
-      "id": "get_page",
+      "id": "coda__get_page",
       "name": "Get Page",
       "description": "Get metadata for a page in a Coda doc",
       "requiresWrite": false,
@@ -229,7 +229,7 @@
       }
     },
     {
-      "id": "update_page",
+      "id": "coda__update_page",
       "name": "Update Page",
       "description": "Update a page's name, subtitle, or content in a Coda doc",
       "requiresWrite": true,

--- a/cli/templates/integrations/cohere/connector.json
+++ b/cli/templates/integrations/cohere/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_models",
+      "id": "cohere__list_models",
       "name": "List Models",
       "description": "List the Cohere models available to the API key",
       "requiresWrite": false,
@@ -68,7 +68,7 @@
       }
     },
     {
-      "id": "create_chat",
+      "id": "cohere__create_chat",
       "name": "Create Chat",
       "description": "Generate a chat response with a Cohere Command model (v2 Chat API)",
       "requiresWrite": true,
@@ -98,7 +98,7 @@
       }
     },
     {
-      "id": "create_embedding",
+      "id": "cohere__create_embedding",
       "name": "Create Embedding",
       "description": "Create embedding vectors for input texts (v2 Embed API)",
       "requiresWrite": true,
@@ -130,7 +130,7 @@
       }
     },
     {
-      "id": "rerank_documents",
+      "id": "cohere__rerank_documents",
       "name": "Rerank Documents",
       "description": "Rank a list of documents by relevance to a query (v2 Rerank API)",
       "requiresWrite": true,

--- a/cli/templates/integrations/confluence/connector.json
+++ b/cli/templates/integrations/confluence/connector.json
@@ -53,7 +53,7 @@
   ],
   "tools": [
     {
-      "id": "list_sites",
+      "id": "confluence__list_sites",
       "name": "List Atlassian Sites",
       "description": "List Atlassian cloud sites/resources the OAuth token can access; use the returned id as cloudId for Jira and Confluence tools",
       "requiresWrite": false,
@@ -92,7 +92,7 @@
       }
     },
     {
-      "id": "search_content",
+      "id": "confluence__search_content",
       "name": "Search Confluence",
       "description": "Search for pages and blog posts in Confluence",
       "requiresWrite": false,
@@ -191,7 +191,7 @@
       }
     },
     {
-      "id": "get_page",
+      "id": "confluence__get_page",
       "name": "Get Page",
       "description": "Get the content of a specific Confluence page (uses v2 API)",
       "requiresWrite": false,
@@ -221,7 +221,7 @@
       }
     },
     {
-      "id": "create_page",
+      "id": "confluence__create_page",
       "name": "Create Page",
       "description": "Create a new page in a Confluence space (uses v2 API; requires spaceId from list_spaces)",
       "requiresWrite": true,
@@ -265,7 +265,7 @@
       }
     },
     {
-      "id": "update_page",
+      "id": "confluence__update_page",
       "name": "Update Page",
       "description": "Update the content of an existing Confluence page (uses v2 API; version.number must be current+1)",
       "requiresWrite": true,
@@ -314,7 +314,7 @@
       }
     },
     {
-      "id": "list_spaces",
+      "id": "confluence__list_spaces",
       "name": "List Spaces",
       "description": "List all accessible Confluence spaces",
       "requiresWrite": false,
@@ -392,7 +392,7 @@
       }
     },
     {
-      "id": "add_comment",
+      "id": "confluence__add_comment",
       "name": "Add Comment",
       "description": "Add a comment to a Confluence page (uses v1 content API)",
       "requiresWrite": true,

--- a/cli/templates/integrations/customer-io/connector.json
+++ b/cli/templates/integrations/customer-io/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "search_customers",
+      "id": "customer-io__search_customers",
       "name": "Search Customers",
       "description": "Search Customer.io people by attribute or segment filter conditions",
       "requiresWrite": false,
@@ -61,7 +61,7 @@
       }
     },
     {
-      "id": "list_campaigns",
+      "id": "customer-io__list_campaigns",
       "name": "List Campaigns",
       "description": "List campaigns in the Customer.io workspace with their state and goals",
       "requiresWrite": false,
@@ -74,7 +74,7 @@
       }
     },
     {
-      "id": "get_campaign_metrics",
+      "id": "customer-io__get_campaign_metrics",
       "name": "Get Campaign Metrics",
       "description": "Get delivery and conversion metrics for a Customer.io campaign over a time period",
       "requiresWrite": false,
@@ -115,7 +115,7 @@
       }
     },
     {
-      "id": "get_person_attributes",
+      "id": "customer-io__get_person_attributes",
       "name": "Get Person Attributes",
       "description": "Get a person's full attribute profile by ID, email, or cio_id (Search Customers returns only identifiers)",
       "requiresWrite": false,
@@ -141,7 +141,7 @@
       }
     },
     {
-      "id": "list_transactional_messages",
+      "id": "customer-io__list_transactional_messages",
       "name": "List Transactional Messages",
       "description": "List the workspace's transactional message templates so agents can find a valid transactional_message_id before sending",
       "requiresWrite": false,
@@ -154,7 +154,7 @@
       }
     },
     {
-      "id": "trigger_broadcast",
+      "id": "customer-io__trigger_broadcast",
       "name": "Trigger Broadcast",
       "description": "Trigger an API-triggered broadcast campaign, optionally overriding the recipients and passing liquid data into the messages",
       "requiresWrite": true,
@@ -198,7 +198,7 @@
       }
     },
     {
-      "id": "list_segments",
+      "id": "customer-io__list_segments",
       "name": "List Segments",
       "description": "List segments in the Customer.io workspace so agents can target or filter people",
       "requiresWrite": false,
@@ -211,7 +211,7 @@
       }
     },
     {
-      "id": "send_transactional_email",
+      "id": "customer-io__send_transactional_email",
       "name": "Send Transactional Email",
       "description": "Send a transactional email to a recipient, using a transactional message template or inline subject and body",
       "requiresWrite": true,

--- a/cli/templates/integrations/databricks/connector.json
+++ b/cli/templates/integrations/databricks/connector.json
@@ -35,7 +35,7 @@
   ],
   "tools": [
     {
-      "id": "list_clusters",
+      "id": "databricks__list_clusters",
       "name": "List Clusters",
       "description": "List all-purpose and job compute clusters in the workspace with their state and configuration",
       "requiresWrite": false,
@@ -101,7 +101,7 @@
       }
     },
     {
-      "id": "list_jobs",
+      "id": "databricks__list_jobs",
       "name": "List Jobs",
       "description": "List jobs defined in the workspace, optionally filtered by name",
       "requiresWrite": false,
@@ -163,7 +163,7 @@
       }
     },
     {
-      "id": "run_job_now",
+      "id": "databricks__run_job_now",
       "name": "Run Job Now",
       "description": "Trigger an immediate run of an existing job, optionally overriding job parameters",
       "requiresWrite": true,
@@ -196,7 +196,7 @@
       }
     },
     {
-      "id": "list_job_runs",
+      "id": "databricks__list_job_runs",
       "name": "List Job Runs",
       "description": "List recent job runs, optionally filtered to one job or to active/completed runs",
       "requiresWrite": false,
@@ -271,7 +271,7 @@
       }
     },
     {
-      "id": "cancel_job_run",
+      "id": "databricks__cancel_job_run",
       "name": "Cancel Job Run",
       "description": "Cancel a job run; the cancellation happens asynchronously, so the run may still be running briefly",
       "requiresWrite": true,
@@ -296,7 +296,7 @@
       }
     },
     {
-      "id": "get_job_run",
+      "id": "databricks__get_job_run",
       "name": "Get Job Run",
       "description": "Get the status, timing, and task results of a job run (use the run_id returned by Run Job Now)",
       "requiresWrite": false,
@@ -320,7 +320,7 @@
       }
     },
     {
-      "id": "execute_sql_statement",
+      "id": "databricks__execute_sql_statement",
       "name": "Execute SQL Statement",
       "description": "Execute a SQL query against a SQL warehouse and return the result rows (queries; the warehouse enforces table permissions)",
       "requiresWrite": true,
@@ -367,7 +367,7 @@
       }
     },
     {
-      "id": "get_sql_statement",
+      "id": "databricks__get_sql_statement",
       "name": "Get SQL Statement",
       "description": "Poll the status and result of a previously submitted SQL statement, e.g. after an async or timed-out execution",
       "requiresWrite": false,
@@ -391,7 +391,7 @@
       }
     },
     {
-      "id": "list_sql_warehouses",
+      "id": "databricks__list_sql_warehouses",
       "name": "List SQL Warehouses",
       "description": "List SQL warehouses in the workspace to find a warehouse_id for executing SQL statements",
       "requiresWrite": false,

--- a/cli/templates/integrations/datadog/connector.json
+++ b/cli/templates/integrations/datadog/connector.json
@@ -40,7 +40,7 @@
   ],
   "tools": [
     {
-      "id": "validate_api_key",
+      "id": "datadog__validate_api_key",
       "name": "Validate API Key",
       "description": "Check that the configured Datadog API key is valid",
       "requiresWrite": false,
@@ -58,7 +58,7 @@
       }
     },
     {
-      "id": "list_monitors",
+      "id": "datadog__list_monitors",
       "name": "List Monitors",
       "description": "List monitors with optional name or tag filtering",
       "requiresWrite": false,
@@ -112,7 +112,7 @@
       }
     },
     {
-      "id": "get_monitor",
+      "id": "datadog__get_monitor",
       "name": "Get Monitor",
       "description": "Get details and current state of a monitor",
       "requiresWrite": false,
@@ -136,7 +136,7 @@
       }
     },
     {
-      "id": "mute_monitor",
+      "id": "datadog__mute_monitor",
       "name": "Mute Monitor",
       "description": "Mute notifications for a monitor",
       "requiresWrite": true,
@@ -165,7 +165,7 @@
       }
     },
     {
-      "id": "list_dashboards",
+      "id": "datadog__list_dashboards",
       "name": "List Dashboards",
       "description": "List all dashboards",
       "requiresWrite": false,
@@ -198,7 +198,7 @@
       }
     },
     {
-      "id": "query_timeseries",
+      "id": "datadog__query_timeseries",
       "name": "Query Timeseries Metrics",
       "description": "Query timeseries metric data over a time window",
       "requiresWrite": false,
@@ -234,7 +234,7 @@
       }
     },
     {
-      "id": "search_logs",
+      "id": "datadog__search_logs",
       "name": "Search Logs",
       "description": "Search log events with a Datadog log query",
       "requiresWrite": false,

--- a/cli/templates/integrations/datev/connector.json
+++ b/cli/templates/integrations/datev/connector.json
@@ -42,7 +42,7 @@
   ],
   "tools": [
     {
-      "id": "list_clients",
+      "id": "datev__list_clients",
       "name": "List Clients",
       "description": "List the DATEV clients (Mandanten) the connected user may upload documents for, including each client's ID needed by the other tools",
       "requiresWrite": false,
@@ -52,7 +52,7 @@
       }
     },
     {
-      "id": "list_document_types",
+      "id": "datev__list_document_types",
       "name": "List Document Types",
       "description": "List the document types (e.g. incoming invoices, outgoing invoices, cash receipts) available in Belege online for a specific DATEV client, used to classify uploads",
       "requiresWrite": false,
@@ -70,7 +70,7 @@
       }
     },
     {
-      "id": "upload_document",
+      "id": "datev__upload_document",
       "name": "Upload Document",
       "description": "Upload a receipt or invoice file to DATEV Unternehmen online (Belege online) for a client so the tax advisor can process it for bookkeeping",
       "requiresWrite": true,

--- a/cli/templates/integrations/daytona/connector.json
+++ b/cli/templates/integrations/daytona/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "list_sandboxes",
+      "id": "daytona__list_sandboxes",
       "name": "List Sandboxes",
       "description": "List sandboxes in the organization with optional name, label, and state filtering",
       "requiresWrite": false,
@@ -84,7 +84,7 @@
       }
     },
     {
-      "id": "create_sandbox",
+      "id": "daytona__create_sandbox",
       "name": "Create Sandbox",
       "description": "Create a new sandbox, optionally from a snapshot and with custom resources (starts billable compute)",
       "requiresWrite": true,
@@ -136,7 +136,7 @@
       }
     },
     {
-      "id": "get_sandbox",
+      "id": "daytona__get_sandbox",
       "name": "Get Sandbox",
       "description": "Get sandbox details by ID or name, including state, snapshot, resources, and timestamps",
       "requiresWrite": false,
@@ -159,7 +159,7 @@
       }
     },
     {
-      "id": "delete_sandbox",
+      "id": "daytona__delete_sandbox",
       "name": "Delete Sandbox",
       "description": "Delete a sandbox by ID or name, discarding its state and filesystem",
       "requiresWrite": true,
@@ -177,7 +177,7 @@
       }
     },
     {
-      "id": "execute_command",
+      "id": "daytona__execute_command",
       "name": "Execute Command",
       "description": "Execute a shell command inside a running sandbox via the toolbox and return its exit code and output (legacy REST route; Daytona's current toolbox API is SDK-first)",
       "requiresWrite": true,
@@ -211,7 +211,7 @@
       }
     },
     {
-      "id": "start_sandbox",
+      "id": "daytona__start_sandbox",
       "name": "Start Sandbox",
       "description": "Start a stopped sandbox — required before Execute Command, since sandboxes auto-stop after the autoStopInterval (15 minutes by default)",
       "requiresWrite": true,
@@ -229,7 +229,7 @@
       }
     },
     {
-      "id": "stop_sandbox",
+      "id": "daytona__stop_sandbox",
       "name": "Stop Sandbox",
       "description": "Stop a running sandbox to pause billable compute without destroying its state",
       "requiresWrite": true,
@@ -247,7 +247,7 @@
       }
     },
     {
-      "id": "list_snapshots",
+      "id": "daytona__list_snapshots",
       "name": "List Snapshots",
       "description": "List available snapshots (sandbox base images) — use these names or IDs in the snapshot field of Create Sandbox",
       "requiresWrite": false,

--- a/cli/templates/integrations/deel/connector.json
+++ b/cli/templates/integrations/deel/connector.json
@@ -22,7 +22,7 @@
   ],
   "tools": [
     {
-      "id": "list_contracts",
+      "id": "deel__list_contracts",
       "name": "List Contracts",
       "description": "List contracts in the Deel account, optionally filtered by contract type",
       "requiresWrite": false,
@@ -50,7 +50,7 @@
       }
     },
     {
-      "id": "get_contract",
+      "id": "deel__get_contract",
       "name": "Get Contract",
       "description": "Retrieve full details of a single contract by ID",
       "requiresWrite": false,
@@ -68,7 +68,7 @@
       }
     },
     {
-      "id": "list_people",
+      "id": "deel__list_people",
       "name": "List People",
       "description": "List people (workers) in the organization with their employment details",
       "requiresWrite": false,
@@ -97,7 +97,7 @@
       }
     },
     {
-      "id": "get_person",
+      "id": "deel__get_person",
       "name": "Get Person",
       "description": "Retrieve a single person (worker) with their employments, manager, and direct reports",
       "requiresWrite": false,
@@ -115,7 +115,7 @@
       }
     },
     {
-      "id": "list_invoices",
+      "id": "deel__list_invoices",
       "name": "List Invoices",
       "description": "List worker invoices; only paid invoices are returned unless status=all is passed",
       "requiresWrite": false,
@@ -154,7 +154,7 @@
       }
     },
     {
-      "id": "list_timesheets",
+      "id": "deel__list_timesheets",
       "name": "List Timesheets",
       "description": "List timesheet entries, optionally filtered to a single contract",
       "requiresWrite": false,
@@ -183,7 +183,7 @@
       }
     },
     {
-      "id": "create_timesheet",
+      "id": "deel__create_timesheet",
       "name": "Create Timesheet Entry",
       "description": "Submit a timesheet entry (work performed) for a contractor contract",
       "requiresWrite": true,
@@ -200,7 +200,7 @@
       }
     },
     {
-      "id": "review_timesheet",
+      "id": "deel__review_timesheet",
       "name": "Review Timesheet",
       "description": "Approve or decline a submitted timesheet entry; approved hours flow onto the contractor's invoice",
       "requiresWrite": true,

--- a/cli/templates/integrations/deepgram/connector.json
+++ b/cli/templates/integrations/deepgram/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "transcribe_url",
+      "id": "deepgram__transcribe_url",
       "name": "Transcribe URL",
       "description": "Transcribe a prerecorded audio file from a publicly accessible URL",
       "requiresWrite": true,
@@ -72,7 +72,7 @@
       }
     },
     {
-      "id": "list_projects",
+      "id": "deepgram__list_projects",
       "name": "List Projects",
       "description": "List the Deepgram projects associated with the API key",
       "requiresWrite": false,
@@ -93,7 +93,7 @@
       }
     },
     {
-      "id": "get_project_balances",
+      "id": "deepgram__get_project_balances",
       "name": "Get Project Balances",
       "description": "Get the outstanding credit balances for a project",
       "requiresWrite": false,
@@ -111,7 +111,7 @@
       }
     },
     {
-      "id": "list_models",
+      "id": "deepgram__list_models",
       "name": "List Models",
       "description": "List the speech-to-text and text-to-speech models Deepgram offers",
       "requiresWrite": false,

--- a/cli/templates/integrations/dialpad/connector.json
+++ b/cli/templates/integrations/dialpad/connector.json
@@ -36,7 +36,7 @@
   ],
   "tools": [
     {
-      "id": "list_contacts",
+      "id": "dialpad__list_contacts",
       "name": "List Contacts",
       "description": "List Dialpad contacts visible to the authenticated user",
       "requiresWrite": false,
@@ -81,7 +81,7 @@
       }
     },
     {
-      "id": "get_contact",
+      "id": "dialpad__get_contact",
       "name": "Get Contact",
       "description": "Get details of a Dialpad contact",
       "requiresWrite": false,
@@ -99,7 +99,7 @@
       }
     },
     {
-      "id": "create_contact",
+      "id": "dialpad__create_contact",
       "name": "Create Contact",
       "description": "Create a new contact in Dialpad",
       "requiresWrite": true,
@@ -137,7 +137,7 @@
       }
     },
     {
-      "id": "update_contact",
+      "id": "dialpad__update_contact",
       "name": "Update Contact",
       "description": "Update an existing Dialpad contact",
       "requiresWrite": true,
@@ -181,7 +181,7 @@
       }
     },
     {
-      "id": "list_users",
+      "id": "dialpad__list_users",
       "name": "List Users",
       "description": "List Dialpad users in the company",
       "requiresWrite": false,
@@ -208,7 +208,7 @@
       }
     },
     {
-      "id": "send_sms",
+      "id": "dialpad__send_sms",
       "name": "Send SMS",
       "description": "Send an SMS message on behalf of a Dialpad user",
       "requiresWrite": true,

--- a/cli/templates/integrations/digitalocean/connector.json
+++ b/cli/templates/integrations/digitalocean/connector.json
@@ -39,7 +39,7 @@
   ],
   "tools": [
     {
-      "id": "list_droplets",
+      "id": "digitalocean__list_droplets",
       "name": "List Droplets",
       "description": "List Droplets in the account",
       "requiresWrite": false,
@@ -111,7 +111,7 @@
       }
     },
     {
-      "id": "get_droplet",
+      "id": "digitalocean__get_droplet",
       "name": "Get Droplet",
       "description": "Get a Droplet by ID",
       "requiresWrite": false,
@@ -132,7 +132,7 @@
       }
     },
     {
-      "id": "create_droplet",
+      "id": "digitalocean__create_droplet",
       "name": "Create Droplet",
       "description": "Create a new Droplet (provisions billable infrastructure)",
       "requiresWrite": true,
@@ -180,7 +180,7 @@
       }
     },
     {
-      "id": "delete_droplet",
+      "id": "digitalocean__delete_droplet",
       "name": "Delete Droplet",
       "description": "Permanently destroy a Droplet by ID",
       "requiresWrite": true,
@@ -198,7 +198,7 @@
       }
     },
     {
-      "id": "list_databases",
+      "id": "digitalocean__list_databases",
       "name": "List Database Clusters",
       "description": "List managed database clusters in the account",
       "requiresWrite": false,
@@ -242,7 +242,7 @@
       }
     },
     {
-      "id": "get_account",
+      "id": "digitalocean__get_account",
       "name": "Get Account",
       "description": "Get account information and limits for the authenticated user",
       "requiresWrite": false,

--- a/cli/templates/integrations/discord/connector.json
+++ b/cli/templates/integrations/discord/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "get_bot_user",
+      "id": "discord__get_bot_user",
       "name": "Get Bot User",
       "description": "Get the bot's own user account to confirm the token works and learn the bot's ID and username",
       "requiresWrite": false,
@@ -38,7 +38,7 @@
       }
     },
     {
-      "id": "list_guilds",
+      "id": "discord__list_guilds",
       "name": "List Guilds",
       "description": "List the servers (guilds) the bot has been added to, so an agent can find a guild ID",
       "requiresWrite": false,
@@ -72,7 +72,7 @@
       }
     },
     {
-      "id": "list_guild_channels",
+      "id": "discord__list_guild_channels",
       "name": "List Guild Channels",
       "description": "List the channels in a server so an agent can find the right channel ID before reading or posting",
       "requiresWrite": false,
@@ -90,7 +90,7 @@
       }
     },
     {
-      "id": "get_channel_messages",
+      "id": "discord__get_channel_messages",
       "name": "Get Channel Messages",
       "description": "Read recent messages from a channel for summaries, support triage, or context before replying",
       "requiresWrite": false,
@@ -129,7 +129,7 @@
       }
     },
     {
-      "id": "send_message",
+      "id": "discord__send_message",
       "name": "Send Message",
       "description": "Post a message to a channel, optionally as a reply to an existing message",
       "requiresWrite": true,
@@ -163,7 +163,7 @@
       }
     },
     {
-      "id": "create_dm",
+      "id": "discord__create_dm",
       "name": "Create DM Channel",
       "description": "Open (or return the existing) direct-message channel with a user; use the returned channel ID with Send Message to DM the user",
       "requiresWrite": true,
@@ -180,7 +180,7 @@
       }
     },
     {
-      "id": "edit_message",
+      "id": "discord__edit_message",
       "name": "Edit Message",
       "description": "Edit the text of a message the bot previously sent, e.g. to update a status post or correct an announcement",
       "requiresWrite": true,
@@ -211,7 +211,7 @@
       }
     },
     {
-      "id": "search_guild_members",
+      "id": "discord__search_guild_members",
       "name": "Search Guild Members",
       "description": "Find members of a server whose username or nickname starts with a string, e.g. to resolve a name to a user ID for mentions or DMs",
       "requiresWrite": false,
@@ -241,7 +241,7 @@
       }
     },
     {
-      "id": "add_reaction",
+      "id": "discord__add_reaction",
       "name": "Add Reaction",
       "description": "React to a message with an emoji, e.g. to acknowledge or label it",
       "requiresWrite": true,
@@ -271,7 +271,7 @@
       }
     },
     {
-      "id": "create_thread",
+      "id": "discord__create_thread",
       "name": "Create Thread",
       "description": "Start a thread from an existing message to keep a discussion organized",
       "requiresWrite": true,

--- a/cli/templates/integrations/docs-google/connector.json
+++ b/cli/templates/integrations/docs-google/connector.json
@@ -44,7 +44,7 @@
   ],
   "tools": [
     {
-      "id": "list_documents",
+      "id": "docs-google__list_documents",
       "name": "List Documents",
       "description": "List recent Google Docs documents from Drive",
       "requiresWrite": false,
@@ -82,7 +82,7 @@
       }
     },
     {
-      "id": "get_document",
+      "id": "docs-google__get_document",
       "name": "Get Document",
       "description": "Get document content and metadata",
       "requiresWrite": false,
@@ -105,7 +105,7 @@
       }
     },
     {
-      "id": "create_document",
+      "id": "docs-google__create_document",
       "name": "Create Document",
       "description": "Create a new document with optional initial content",
       "requiresWrite": true,
@@ -122,7 +122,7 @@
       }
     },
     {
-      "id": "update_document",
+      "id": "docs-google__update_document",
       "name": "Update Document",
       "description": "Update document content using batch requests",
       "requiresWrite": true,
@@ -151,7 +151,7 @@
       }
     },
     {
-      "id": "search_documents",
+      "id": "docs-google__search_documents",
       "name": "Search Documents",
       "description": "Search for documents by query string",
       "requiresWrite": false,

--- a/cli/templates/integrations/docusign/connector.json
+++ b/cli/templates/integrations/docusign/connector.json
@@ -40,7 +40,7 @@
   ],
   "tools": [
     {
-      "id": "get_user_info",
+      "id": "docusign__get_user_info",
       "name": "Get User Info",
       "description": "Get the connected user's accounts from the OAuth userinfo endpoint - the source of the accountServer (base_uri host) and accountId values every other tool needs",
       "requiresWrite": false,
@@ -50,7 +50,7 @@
       }
     },
     {
-      "id": "list_envelopes",
+      "id": "docusign__list_envelopes",
       "name": "List Envelopes",
       "description": "List envelope status changes in an account to track what is sent, delivered, or completed",
       "requiresWrite": false,
@@ -104,7 +104,7 @@
       }
     },
     {
-      "id": "get_envelope",
+      "id": "docusign__get_envelope",
       "name": "Get Envelope",
       "description": "Get the status and details of a single envelope by ID",
       "requiresWrite": false,
@@ -139,7 +139,7 @@
       }
     },
     {
-      "id": "list_envelope_recipients",
+      "id": "docusign__list_envelope_recipients",
       "name": "List Envelope Recipients",
       "description": "List the recipients of an envelope and their signing status",
       "requiresWrite": false,
@@ -174,7 +174,7 @@
       }
     },
     {
-      "id": "create_envelope",
+      "id": "docusign__create_envelope",
       "name": "Create and Send Envelope",
       "description": "Create an envelope with documents and recipients and send it for signature",
       "requiresWrite": true,
@@ -224,7 +224,7 @@
       }
     },
     {
-      "id": "resend_envelope",
+      "id": "docusign__resend_envelope",
       "name": "Resend Envelope",
       "description": "Resend the signing request email to an in-progress envelope's pending recipients, e.g. to chase outstanding signers",
       "requiresWrite": true,
@@ -261,7 +261,7 @@
       }
     },
     {
-      "id": "list_templates",
+      "id": "docusign__list_templates",
       "name": "List Templates",
       "description": "List the reusable envelope templates in an account, e.g. to find a template before sending from it",
       "requiresWrite": false,
@@ -309,7 +309,7 @@
       }
     },
     {
-      "id": "download_envelope_documents",
+      "id": "docusign__download_envelope_documents",
       "name": "Download Envelope Documents",
       "description": "Download all documents of an envelope as a single combined PDF",
       "requiresWrite": false,

--- a/cli/templates/integrations/drive/connector.json
+++ b/cli/templates/integrations/drive/connector.json
@@ -37,7 +37,7 @@
   ],
   "tools": [
     {
-      "id": "list_files",
+      "id": "drive__list_files",
       "name": "List Files",
       "description": "List files and folders in a Google Drive folder or root",
       "requiresWrite": false,
@@ -74,7 +74,7 @@
       }
     },
     {
-      "id": "get_file",
+      "id": "drive__get_file",
       "name": "Get File",
       "description": "Get metadata and details about a specific file or folder",
       "requiresWrite": false,
@@ -98,7 +98,7 @@
       }
     },
     {
-      "id": "search_files",
+      "id": "drive__search_files",
       "name": "Search Files",
       "description": "Search for files and folders using queries",
       "requiresWrite": false,
@@ -136,7 +136,7 @@
       }
     },
     {
-      "id": "create_folder",
+      "id": "drive__create_folder",
       "name": "Create Folder",
       "description": "Create a new folder in Google Drive",
       "requiresWrite": true,
@@ -162,7 +162,7 @@
       }
     },
     {
-      "id": "upload_file",
+      "id": "drive__upload_file",
       "name": "Upload File",
       "description": "Upload or create a file in Google Drive",
       "requiresWrite": true,
@@ -207,7 +207,7 @@
       }
     },
     {
-      "id": "update_file",
+      "id": "drive__update_file",
       "name": "Update File",
       "description": "Rename a file, update its description, or move it to a different folder in Google Drive",
       "requiresWrite": true,
@@ -251,7 +251,7 @@
       }
     },
     {
-      "id": "delete_file",
+      "id": "drive__delete_file",
       "name": "Delete File",
       "description": "Permanently delete a file or folder from Google Drive",
       "requiresWrite": true,
@@ -269,7 +269,7 @@
       }
     },
     {
-      "id": "download_file",
+      "id": "drive__download_file",
       "name": "Download File",
       "description": "Download the content of a binary or text file stored in Google Drive (not Google Docs/Sheets/Slides; use export_file for those)",
       "requiresWrite": false,
@@ -293,7 +293,7 @@
       }
     },
     {
-      "id": "export_file",
+      "id": "drive__export_file",
       "name": "Export File",
       "description": "Export a Google Docs/Sheets/Slides file to another format such as text/plain, text/csv, or application/pdf",
       "requiresWrite": false,

--- a/cli/templates/integrations/e2b/connector.json
+++ b/cli/templates/integrations/e2b/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "list_sandboxes",
+      "id": "e2b__list_sandboxes",
       "name": "List Sandboxes",
       "description": "List all running sandboxes, optionally filtered by metadata key/value pairs",
       "requiresWrite": false,
@@ -45,7 +45,7 @@
       }
     },
     {
-      "id": "create_sandbox",
+      "id": "e2b__create_sandbox",
       "name": "Create Sandbox",
       "description": "Create a new sandbox from a template (starts a billable running sandbox)",
       "requiresWrite": true,
@@ -80,7 +80,7 @@
       }
     },
     {
-      "id": "get_sandbox",
+      "id": "e2b__get_sandbox",
       "name": "Get Sandbox",
       "description": "Get a sandbox by ID, including template, state, resources, and start/end times",
       "requiresWrite": false,
@@ -98,7 +98,7 @@
       }
     },
     {
-      "id": "kill_sandbox",
+      "id": "e2b__kill_sandbox",
       "name": "Kill Sandbox",
       "description": "Kill a sandbox by ID, immediately terminating it and discarding its state",
       "requiresWrite": true,
@@ -116,7 +116,7 @@
       }
     },
     {
-      "id": "list_templates",
+      "id": "e2b__list_templates",
       "name": "List Templates",
       "description": "List all sandbox templates available to the account, with CPU, memory, and disk defaults",
       "requiresWrite": false,
@@ -133,7 +133,7 @@
       }
     },
     {
-      "id": "pause_sandbox",
+      "id": "e2b__pause_sandbox",
       "name": "Pause Sandbox",
       "description": "Pause a running sandbox, preserving its state so it can be resumed later — the middle ground between running and killed (returns 204 on success)",
       "requiresWrite": true,
@@ -151,7 +151,7 @@
       }
     },
     {
-      "id": "resume_sandbox",
+      "id": "e2b__resume_sandbox",
       "name": "Resume Sandbox",
       "description": "Resume a paused sandbox with its preserved state and a fresh timeout",
       "requiresWrite": true,
@@ -176,7 +176,7 @@
       }
     },
     {
-      "id": "set_sandbox_timeout",
+      "id": "e2b__set_sandbox_timeout",
       "name": "Set Sandbox Timeout",
       "description": "Reset a running sandbox's TTL: the sandbox will expire the given number of seconds from now (each call overwrites the previous timeout) — use this to keep a sandbox alive mid-task (returns 204 on success)",
       "requiresWrite": true,

--- a/cli/templates/integrations/elevenlabs/connector.json
+++ b/cli/templates/integrations/elevenlabs/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_voices",
+      "id": "elevenlabs__list_voices",
       "name": "List Voices",
       "description": "List and search the voices available to the account",
       "requiresWrite": false,
@@ -72,7 +72,7 @@
       }
     },
     {
-      "id": "get_voice",
+      "id": "elevenlabs__get_voice",
       "name": "Get Voice",
       "description": "Get details about a specific voice",
       "requiresWrite": false,
@@ -90,7 +90,7 @@
       }
     },
     {
-      "id": "list_models",
+      "id": "elevenlabs__list_models",
       "name": "List Models",
       "description": "List the speech models available to the account",
       "requiresWrite": false,
@@ -100,7 +100,7 @@
       }
     },
     {
-      "id": "get_subscription",
+      "id": "elevenlabs__get_subscription",
       "name": "Get Subscription",
       "description": "Get subscription tier, character usage, and limits for the account",
       "requiresWrite": false,
@@ -110,7 +110,7 @@
       }
     },
     {
-      "id": "text_to_speech",
+      "id": "elevenlabs__text_to_speech",
       "name": "Text to Speech",
       "description": "Convert text to speech with a chosen voice; the response is binary audio (not JSON), so route the output to a file or player rather than parsing it",
       "requiresWrite": true,

--- a/cli/templates/integrations/exa/connector.json
+++ b/cli/templates/integrations/exa/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "search",
+      "id": "exa__search",
       "name": "Search",
       "description": "Search the web with Exa's neural and keyword search",
       "requiresWrite": false,
@@ -75,7 +75,7 @@
       }
     },
     {
-      "id": "get_contents",
+      "id": "exa__get_contents",
       "name": "Get Contents",
       "description": "Get parsed page contents, summaries, and metadata for a list of URLs",
       "requiresWrite": false,
@@ -105,7 +105,7 @@
       }
     },
     {
-      "id": "find_similar",
+      "id": "exa__find_similar",
       "name": "Find Similar Links",
       "description": "Find pages similar in meaning to a given URL",
       "requiresWrite": false,
@@ -131,7 +131,7 @@
       }
     },
     {
-      "id": "answer",
+      "id": "exa__answer",
       "name": "Answer",
       "description": "Get an LLM-generated answer to a question grounded in Exa search results with citations",
       "requiresWrite": true,

--- a/cli/templates/integrations/factorial/connector.json
+++ b/cli/templates/integrations/factorial/connector.json
@@ -27,7 +27,7 @@
   ],
   "tools": [
     {
-      "id": "list_employees",
+      "id": "factorial__list_employees",
       "name": "List Employees",
       "description": "List employees in the Factorial account, with filters for name, activity status, and team",
       "requiresWrite": false,
@@ -70,7 +70,7 @@
       }
     },
     {
-      "id": "get_employee",
+      "id": "factorial__get_employee",
       "name": "Get Employee",
       "description": "Get a single Factorial employee record by ID",
       "requiresWrite": false,
@@ -88,7 +88,7 @@
       }
     },
     {
-      "id": "list_leaves",
+      "id": "factorial__list_leaves",
       "name": "List Leaves",
       "description": "List time-off leaves (absences) with filters for employee, date range, and approval status",
       "requiresWrite": false,
@@ -143,7 +143,7 @@
       }
     },
     {
-      "id": "create_leave",
+      "id": "factorial__create_leave",
       "name": "Create Leave",
       "description": "Create a time-off leave (absence) for an employee, such as vacation or sick leave",
       "requiresWrite": true,
@@ -181,7 +181,7 @@
       }
     },
     {
-      "id": "list_teams",
+      "id": "factorial__list_teams",
       "name": "List Teams",
       "description": "List all teams in the Factorial account, useful before filtering employees by team",
       "requiresWrite": false,
@@ -199,7 +199,7 @@
       }
     },
     {
-      "id": "list_leave_types",
+      "id": "factorial__list_leave_types",
       "name": "List Leave Types",
       "description": "List the leave types configured in the account (vacation, sick leave, ...) with their IDs — required to pick a valid leave_type_id for Create Leave",
       "requiresWrite": false,
@@ -227,7 +227,7 @@
       }
     },
     {
-      "id": "delete_leave",
+      "id": "factorial__delete_leave",
       "name": "Delete Leave",
       "description": "Delete (cancel) a leave request by its ID",
       "requiresWrite": true,

--- a/cli/templates/integrations/fal/connector.json
+++ b/cli/templates/integrations/fal/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "run_model",
+      "id": "fal__run_model",
       "name": "Run Model",
       "description": "Run a fal model synchronously and wait for the result (best for fast models; billed per run). The model endpoint ID is split into owner / app / variant segments, e.g. fal-ai/flux/schnell",
       "requiresWrite": true,
@@ -64,7 +64,7 @@
       }
     },
     {
-      "id": "queue_submit",
+      "id": "fal__queue_submit",
       "name": "Submit Queue Request",
       "description": "Submit a request to the fal queue and return immediately with a request_id (billed per run)",
       "requiresWrite": true,
@@ -102,7 +102,7 @@
       }
     },
     {
-      "id": "queue_status",
+      "id": "fal__queue_status",
       "name": "Get Queue Status",
       "description": "Check the status of a queued request (IN_QUEUE, IN_PROGRESS, or COMPLETED). Use the base app ID without the variant segment, matching the status_url returned at submit time",
       "requiresWrite": false,
@@ -138,7 +138,7 @@
       }
     },
     {
-      "id": "queue_result",
+      "id": "fal__queue_result",
       "name": "Get Queue Result",
       "description": "Fetch the result of a completed queue request. Use the base app ID without the variant segment, matching the response_url returned at submit time",
       "requiresWrite": false,
@@ -168,7 +168,7 @@
       }
     },
     {
-      "id": "queue_cancel",
+      "id": "fal__queue_cancel",
       "name": "Cancel Queue Request",
       "description": "Cancel a queued request that has not started running yet",
       "requiresWrite": true,

--- a/cli/templates/integrations/fathom/connector.json
+++ b/cli/templates/integrations/fathom/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_meetings",
+      "id": "fathom__list_meetings",
       "name": "List Meetings",
       "description": "List recorded meetings, optionally including summaries and action items",
       "requiresWrite": false,
@@ -88,7 +88,7 @@
       }
     },
     {
-      "id": "get_transcript",
+      "id": "fathom__get_transcript",
       "name": "Get Transcript",
       "description": "Get the transcript of a recording",
       "requiresWrite": false,
@@ -106,7 +106,7 @@
       }
     },
     {
-      "id": "get_summary",
+      "id": "fathom__get_summary",
       "name": "Get Summary",
       "description": "Get the AI summary of a recording",
       "requiresWrite": false,
@@ -124,7 +124,7 @@
       }
     },
     {
-      "id": "list_teams",
+      "id": "fathom__list_teams",
       "name": "List Teams",
       "description": "List teams in the Fathom workspace",
       "requiresWrite": false,
@@ -141,7 +141,7 @@
       }
     },
     {
-      "id": "list_team_members",
+      "id": "fathom__list_team_members",
       "name": "List Team Members",
       "description": "List team members in the Fathom workspace",
       "requiresWrite": false,

--- a/cli/templates/integrations/figma/connector.json
+++ b/cli/templates/integrations/figma/connector.json
@@ -41,7 +41,7 @@
   ],
   "tools": [
     {
-      "id": "get_me",
+      "id": "figma__get_me",
       "name": "Get Me",
       "description": "Get the authenticated user's Figma profile (id, email, handle). Use this to verify the connection and identify the user.",
       "requiresWrite": false,
@@ -51,7 +51,7 @@
       }
     },
     {
-      "id": "get_file",
+      "id": "figma__get_file",
       "name": "Get File",
       "description": "Get detailed information about a Figma file, including pages, frames, components, and styles. Requires a Figma file key from a file or design URL.",
       "requiresWrite": false,
@@ -89,7 +89,7 @@
       }
     },
     {
-      "id": "get_comments",
+      "id": "figma__get_comments",
       "name": "Get Comments",
       "description": "Get all comments on a Figma file",
       "requiresWrite": false,
@@ -110,7 +110,7 @@
       }
     },
     {
-      "id": "post_comment",
+      "id": "figma__post_comment",
       "name": "Post Comment",
       "description": "Post a comment on a Figma file",
       "requiresWrite": true,

--- a/cli/templates/integrations/finapi/connector.json
+++ b/cli/templates/integrations/finapi/connector.json
@@ -35,7 +35,7 @@
   ],
   "tools": [
     {
-      "id": "search_banks",
+      "id": "finapi__search_banks",
       "name": "Search Banks",
       "description": "Search finAPI's database of supported banks by name, BLZ, BIC, or city, with interface and location filters",
       "requiresWrite": false,
@@ -106,7 +106,7 @@
       }
     },
     {
-      "id": "get_bank",
+      "id": "finapi__get_bank",
       "name": "Get Bank",
       "description": "Retrieve a single bank from finAPI's catalog by its identifier, including supported interfaces and login requirements",
       "requiresWrite": false,
@@ -124,7 +124,7 @@
       }
     },
     {
-      "id": "get_client_configuration",
+      "id": "finapi__get_client_configuration",
       "name": "Get Client Configuration",
       "description": "Get your finAPI client's configuration: token validity periods, callback URLs, enabled bank sets, and consent settings",
       "requiresWrite": false,
@@ -134,7 +134,7 @@
       }
     },
     {
-      "id": "create_user",
+      "id": "finapi__create_user",
       "name": "Create User",
       "description": "Provision a new finAPI end user (one per application end user); user-level operations then authenticate with that user's own token",
       "requiresWrite": true,

--- a/cli/templates/integrations/firecrawl/connector.json
+++ b/cli/templates/integrations/firecrawl/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "scrape",
+      "id": "firecrawl__scrape",
       "name": "Scrape Page",
       "description": "Scrape a single URL into markdown or other formats",
       "requiresWrite": false,
@@ -56,7 +56,7 @@
       }
     },
     {
-      "id": "search",
+      "id": "firecrawl__search",
       "name": "Search Web",
       "description": "Search the web and optionally scrape the results' content",
       "requiresWrite": false,
@@ -96,7 +96,7 @@
       }
     },
     {
-      "id": "map_site",
+      "id": "firecrawl__map_site",
       "name": "Map Site",
       "description": "Quickly list the URLs discovered on a website",
       "requiresWrite": false,
@@ -121,7 +121,7 @@
       }
     },
     {
-      "id": "start_crawl",
+      "id": "firecrawl__start_crawl",
       "name": "Start Crawl",
       "description": "Start an asynchronous crawl job over a website (returns a job ID)",
       "requiresWrite": true,
@@ -147,7 +147,7 @@
       }
     },
     {
-      "id": "get_crawl_status",
+      "id": "firecrawl__get_crawl_status",
       "name": "Get Crawl Status",
       "description": "Get the status and results of a crawl job",
       "requiresWrite": false,

--- a/cli/templates/integrations/fireflies/connector.json
+++ b/cli/templates/integrations/fireflies/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_transcripts",
+      "id": "fireflies__list_transcripts",
       "name": "List Transcripts",
       "description": "List meeting transcripts, optionally filtered by date, participants, or keyword",
       "requiresWrite": false,
@@ -94,7 +94,7 @@
       }
     },
     {
-      "id": "get_transcript",
+      "id": "fireflies__get_transcript",
       "name": "Get Transcript",
       "description": "Get a transcript with its sentences and AI summary",
       "requiresWrite": false,
@@ -117,7 +117,7 @@
       }
     },
     {
-      "id": "search_transcripts",
+      "id": "fireflies__search_transcripts",
       "name": "Search Transcripts",
       "description": "Keyword-search transcripts and return matches with summaries",
       "requiresWrite": false,
@@ -146,7 +146,7 @@
       }
     },
     {
-      "id": "list_users",
+      "id": "fireflies__list_users",
       "name": "List Users",
       "description": "List teammates in the Fireflies workspace",
       "requiresWrite": false,
@@ -161,7 +161,7 @@
       }
     },
     {
-      "id": "get_user",
+      "id": "fireflies__get_user",
       "name": "Get User",
       "description": "Get a workspace user by ID",
       "requiresWrite": false,

--- a/cli/templates/integrations/fireworks-ai/connector.json
+++ b/cli/templates/integrations/fireworks-ai/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_models",
+      "id": "fireworks-ai__list_models",
       "name": "List Models",
       "description": "List the models available on Fireworks AI",
       "requiresWrite": false,
@@ -49,7 +49,7 @@
       }
     },
     {
-      "id": "create_chat_completion",
+      "id": "fireworks-ai__create_chat_completion",
       "name": "Create Chat Completion",
       "description": "Generate a chat completion from a list of messages",
       "requiresWrite": true,
@@ -79,7 +79,7 @@
       }
     },
     {
-      "id": "create_completion",
+      "id": "fireworks-ai__create_completion",
       "name": "Create Completion",
       "description": "Generate a text completion from a raw prompt",
       "requiresWrite": true,
@@ -109,7 +109,7 @@
       }
     },
     {
-      "id": "create_embedding",
+      "id": "fireworks-ai__create_embedding",
       "name": "Create Embedding",
       "description": "Create an embedding vector for input text",
       "requiresWrite": true,

--- a/cli/templates/integrations/fly-io/connector.json
+++ b/cli/templates/integrations/fly-io/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_apps",
+      "id": "fly-io__list_apps",
       "name": "List Apps",
       "description": "List apps in a Fly.io organization",
       "requiresWrite": false,
@@ -72,7 +72,7 @@
       }
     },
     {
-      "id": "get_app",
+      "id": "fly-io__get_app",
       "name": "Get App",
       "description": "Get details about an app, including its organization and status",
       "requiresWrite": false,
@@ -90,7 +90,7 @@
       }
     },
     {
-      "id": "list_machines",
+      "id": "fly-io__list_machines",
       "name": "List Machines",
       "description": "List Machines of an app with their states",
       "requiresWrite": false,
@@ -150,7 +150,7 @@
       }
     },
     {
-      "id": "get_machine",
+      "id": "fly-io__get_machine",
       "name": "Get Machine",
       "description": "Get a Machine by ID, including its config and state",
       "requiresWrite": false,
@@ -174,7 +174,7 @@
       }
     },
     {
-      "id": "start_machine",
+      "id": "fly-io__start_machine",
       "name": "Start Machine",
       "description": "Start a stopped Machine",
       "requiresWrite": true,
@@ -198,7 +198,7 @@
       }
     },
     {
-      "id": "stop_machine",
+      "id": "fly-io__stop_machine",
       "name": "Stop Machine",
       "description": "Stop a running Machine",
       "requiresWrite": true,

--- a/cli/templates/integrations/folk/connector.json
+++ b/cli/templates/integrations/folk/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_people",
+      "id": "folk__list_people",
       "name": "List People",
       "description": "List people in the folk workspace with optional filters",
       "requiresWrite": false,
@@ -66,7 +66,7 @@
       }
     },
     {
-      "id": "get_person",
+      "id": "folk__get_person",
       "name": "Get Person",
       "description": "Get details of a person in folk",
       "requiresWrite": false,
@@ -87,7 +87,7 @@
       }
     },
     {
-      "id": "create_person",
+      "id": "folk__create_person",
       "name": "Create Person",
       "description": "Create a new person in folk",
       "requiresWrite": true,
@@ -126,7 +126,7 @@
       }
     },
     {
-      "id": "update_person",
+      "id": "folk__update_person",
       "name": "Update Person",
       "description": "Update fields on an existing person in folk",
       "requiresWrite": true,
@@ -169,7 +169,7 @@
       }
     },
     {
-      "id": "list_companies",
+      "id": "folk__list_companies",
       "name": "List Companies",
       "description": "List companies in the folk workspace",
       "requiresWrite": false,
@@ -195,7 +195,7 @@
       }
     },
     {
-      "id": "create_company",
+      "id": "folk__create_company",
       "name": "Create Company",
       "description": "Create a new company in folk",
       "requiresWrite": true,
@@ -227,7 +227,7 @@
       }
     },
     {
-      "id": "list_groups",
+      "id": "folk__list_groups",
       "name": "List Groups",
       "description": "List groups (pipelines/segments) in the folk workspace",
       "requiresWrite": false,

--- a/cli/templates/integrations/freshdesk/connector.json
+++ b/cli/templates/integrations/freshdesk/connector.json
@@ -34,7 +34,7 @@
   ],
   "tools": [
     {
-      "id": "list_tickets",
+      "id": "freshdesk__list_tickets",
       "name": "List Tickets",
       "description": "List support tickets in the Freshdesk account",
       "requiresWrite": false,
@@ -99,7 +99,7 @@
       }
     },
     {
-      "id": "get_ticket",
+      "id": "freshdesk__get_ticket",
       "name": "Get Ticket",
       "description": "Get details of a Freshdesk ticket",
       "requiresWrite": false,
@@ -128,7 +128,7 @@
       }
     },
     {
-      "id": "create_ticket",
+      "id": "freshdesk__create_ticket",
       "name": "Create Ticket",
       "description": "Create a new support ticket in Freshdesk",
       "requiresWrite": true,
@@ -179,7 +179,7 @@
       }
     },
     {
-      "id": "update_ticket",
+      "id": "freshdesk__update_ticket",
       "name": "Update Ticket",
       "description": "Update fields on an existing Freshdesk ticket",
       "requiresWrite": true,
@@ -217,7 +217,7 @@
       }
     },
     {
-      "id": "list_contacts",
+      "id": "freshdesk__list_contacts",
       "name": "List Contacts",
       "description": "List contacts in the Freshdesk account",
       "requiresWrite": false,

--- a/cli/templates/integrations/front/connector.json
+++ b/cli/templates/integrations/front/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "list_conversations",
+      "id": "front__list_conversations",
       "name": "List Conversations",
       "description": "List conversations across your Front inboxes, most recently updated first",
       "requiresWrite": false,
@@ -81,7 +81,7 @@
       }
     },
     {
-      "id": "get_conversation",
+      "id": "front__get_conversation",
       "name": "Get Conversation",
       "description": "Retrieve a single conversation with its subject, status, assignee, recipient, and tags",
       "requiresWrite": false,
@@ -99,7 +99,7 @@
       }
     },
     {
-      "id": "list_conversation_messages",
+      "id": "front__list_conversation_messages",
       "name": "List Conversation Messages",
       "description": "List the messages in a conversation thread, including bodies and authors",
       "requiresWrite": false,
@@ -144,7 +144,7 @@
       }
     },
     {
-      "id": "reply_to_conversation",
+      "id": "front__reply_to_conversation",
       "name": "Reply to Conversation",
       "description": "Send a reply message in an existing conversation (archives the conversation by default)",
       "requiresWrite": true,
@@ -197,7 +197,7 @@
       }
     },
     {
-      "id": "update_conversation",
+      "id": "front__update_conversation",
       "name": "Update Conversation",
       "description": "Update a conversation's assignee, status, inbox, or tags, e.g. to assign, archive, or reopen it without sending a message",
       "requiresWrite": true,
@@ -233,7 +233,7 @@
       }
     },
     {
-      "id": "search_conversations",
+      "id": "front__search_conversations",
       "name": "Search Conversations",
       "description": "Full-text search across conversations with operators like from:, tag:, inbox:, is:open, before:/after:",
       "requiresWrite": false,
@@ -280,7 +280,7 @@
       }
     },
     {
-      "id": "list_teammates",
+      "id": "front__list_teammates",
       "name": "List Teammates",
       "description": "List the teammates in the company to find teammate IDs for assignment and reply authorship",
       "requiresWrite": false,
@@ -305,7 +305,7 @@
       }
     },
     {
-      "id": "list_inboxes",
+      "id": "front__list_inboxes",
       "name": "List Inboxes",
       "description": "List the shared inboxes in the company to find inbox IDs and names",
       "requiresWrite": false,

--- a/cli/templates/integrations/gcp/connector.json
+++ b/cli/templates/integrations/gcp/connector.json
@@ -52,7 +52,7 @@
   ],
   "tools": [
     {
-      "id": "list_compute_instances",
+      "id": "gcp__list_compute_instances",
       "name": "List Compute Instances",
       "description": "List Compute Engine VM instances in a specific zone of a project",
       "requiresWrite": false,
@@ -95,7 +95,7 @@
       }
     },
     {
-      "id": "list_all_compute_instances",
+      "id": "gcp__list_all_compute_instances",
       "name": "List All Compute Instances",
       "description": "List Compute Engine VM instances across all zones of a project (aggregated list), useful when you don't know which zones are in use",
       "requiresWrite": false,
@@ -138,7 +138,7 @@
       }
     },
     {
-      "id": "get_compute_instance",
+      "id": "gcp__get_compute_instance",
       "name": "Get Compute Instance",
       "description": "Get one Compute Engine VM instance's details - machine type, status, IPs, and disks - e.g. to confirm a start or stop completed",
       "requiresWrite": false,
@@ -168,7 +168,7 @@
       }
     },
     {
-      "id": "list_zones",
+      "id": "gcp__list_zones",
       "name": "List Zones",
       "description": "List the Compute Engine zones available in a project, so agents can discover valid zone names for the zone-scoped tools",
       "requiresWrite": false,
@@ -205,7 +205,7 @@
       }
     },
     {
-      "id": "start_compute_instance",
+      "id": "gcp__start_compute_instance",
       "name": "Start Compute Instance",
       "description": "Start a stopped Compute Engine VM instance (returns a zone operation that completes asynchronously) — requires the full cloud-platform scope",
       "requiresWrite": true,
@@ -235,7 +235,7 @@
       }
     },
     {
-      "id": "stop_compute_instance",
+      "id": "gcp__stop_compute_instance",
       "name": "Stop Compute Instance",
       "description": "Stop a running Compute Engine VM instance so it stops incurring compute charges (returns a zone operation that completes asynchronously) — requires the full cloud-platform scope",
       "requiresWrite": true,
@@ -265,7 +265,7 @@
       }
     },
     {
-      "id": "list_cloud_run_services",
+      "id": "gcp__list_cloud_run_services",
       "name": "List Cloud Run Services",
       "description": "List Cloud Run services in a project location (region)",
       "requiresWrite": false,
@@ -309,7 +309,7 @@
       }
     },
     {
-      "id": "get_cloud_run_service",
+      "id": "gcp__get_cloud_run_service",
       "name": "Get Cloud Run Service",
       "description": "Get one Cloud Run service's details - URL, container image, environment, and traffic split",
       "requiresWrite": false,
@@ -339,7 +339,7 @@
       }
     },
     {
-      "id": "list_cloud_functions",
+      "id": "gcp__list_cloud_functions",
       "name": "List Cloud Functions",
       "description": "List Cloud Functions (2nd gen API) in a project location — requires the optional cloud-platform scope (the only scope the Cloud Functions API accepts)",
       "requiresWrite": false,

--- a/cli/templates/integrations/gemini/connector.json
+++ b/cli/templates/integrations/gemini/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_models",
+      "id": "gemini__list_models",
       "name": "List Models",
       "description": "List the Gemini models available to the API key",
       "requiresWrite": false,
@@ -63,7 +63,7 @@
       }
     },
     {
-      "id": "get_model",
+      "id": "gemini__get_model",
       "name": "Get Model",
       "description": "Get details about a specific Gemini model",
       "requiresWrite": false,
@@ -81,7 +81,7 @@
       }
     },
     {
-      "id": "generate_content",
+      "id": "gemini__generate_content",
       "name": "Generate Content",
       "description": "Generate a model response from text or multimodal content",
       "requiresWrite": true,
@@ -114,7 +114,7 @@
       }
     },
     {
-      "id": "embed_content",
+      "id": "gemini__embed_content",
       "name": "Embed Content",
       "description": "Create an embedding vector for input text",
       "requiresWrite": true,
@@ -147,7 +147,7 @@
       }
     },
     {
-      "id": "count_tokens",
+      "id": "gemini__count_tokens",
       "name": "Count Tokens",
       "description": "Count the tokens a prompt would use for a given model",
       "requiresWrite": false,
@@ -172,7 +172,7 @@
       }
     },
     {
-      "id": "generate_image",
+      "id": "gemini__generate_image",
       "name": "Generate Image",
       "description": "Generate or edit an image with a Nano Banana model via generateContent; the response returns image parts as base64 inlineData",
       "requiresWrite": true,
@@ -202,7 +202,7 @@
       }
     },
     {
-      "id": "edit_image",
+      "id": "gemini__edit_image",
       "name": "Edit Image",
       "description": "Edit an existing image with a Nano Banana model: send the source image as a base64 inlineData part plus a text instruction (add/remove/modify elements, change style, adjust color grading); the edited image is returned as base64 inlineData",
       "requiresWrite": true,
@@ -232,7 +232,7 @@
       }
     },
     {
-      "id": "imagen_generate",
+      "id": "gemini__imagen_generate",
       "name": "Generate Image (Imagen)",
       "description": "Generate text-to-image samples with an Imagen 4 model via the predict endpoint; returns base64-encoded images in predictions",
       "requiresWrite": true,
@@ -261,7 +261,7 @@
       }
     },
     {
-      "id": "upload_file",
+      "id": "gemini__upload_file",
       "name": "Upload File",
       "description": "Upload content to the Files API for use in later generateContent calls via its file URI; this simple media upload sends the decoded bytes directly as the request body (a custom displayName requires the multipart or resumable X-Goog-Upload protocol), and files expire after 48 hours",
       "requiresWrite": true,
@@ -295,7 +295,7 @@
       }
     },
     {
-      "id": "list_files",
+      "id": "gemini__list_files",
       "name": "List Files",
       "description": "List files uploaded to the Files API for this project",
       "requiresWrite": false,
@@ -333,7 +333,7 @@
       }
     },
     {
-      "id": "get_file",
+      "id": "gemini__get_file",
       "name": "Get File",
       "description": "Get metadata for an uploaded file, including its uri and processing state",
       "requiresWrite": false,
@@ -351,7 +351,7 @@
       }
     },
     {
-      "id": "delete_file",
+      "id": "gemini__delete_file",
       "name": "Delete File",
       "description": "Delete an uploaded file before its automatic 48-hour expiry",
       "requiresWrite": true,

--- a/cli/templates/integrations/github/connector.json
+++ b/cli/templates/integrations/github/connector.json
@@ -33,7 +33,7 @@
   ],
   "tools": [
     {
-      "id": "get_current_user",
+      "id": "github__get_current_user",
       "name": "Get Current User",
       "description": "Get the authenticated GitHub user identity",
       "requiresWrite": false,
@@ -43,7 +43,7 @@
       }
     },
     {
-      "id": "list_repos",
+      "id": "github__list_repos",
       "name": "List Repositories",
       "description": "Get list of user's repositories",
       "requiresWrite": false,
@@ -142,7 +142,7 @@
       }
     },
     {
-      "id": "get_user",
+      "id": "github__get_user",
       "name": "Get User",
       "description": "Get a GitHub user profile by username. Use this to verify repository owners, assignees, and other GitHub usernames before acting.",
       "requiresWrite": false,
@@ -160,7 +160,7 @@
       }
     },
     {
-      "id": "get_repo",
+      "id": "github__get_repo",
       "name": "Get Repository",
       "description": "Get details of a specific repository",
       "requiresWrite": false,
@@ -184,7 +184,7 @@
       }
     },
     {
-      "id": "list_prs",
+      "id": "github__list_prs",
       "name": "List Pull Requests",
       "description": "Get pull requests for a repository",
       "requiresWrite": false,
@@ -294,7 +294,7 @@
       }
     },
     {
-      "id": "create_issue",
+      "id": "github__create_issue",
       "name": "Create Issue",
       "description": "Create a new issue in a repository",
       "requiresWrite": true,
@@ -337,7 +337,7 @@
       }
     },
     {
-      "id": "get_pr_diff",
+      "id": "github__get_pr_diff",
       "name": "Get PR Diff",
       "description": "Get the diff for a pull request",
       "requiresWrite": false,
@@ -373,7 +373,7 @@
       }
     },
     {
-      "id": "list_issues",
+      "id": "github__list_issues",
       "name": "List Issues",
       "description": "List issues for a repository",
       "requiresWrite": false,
@@ -491,7 +491,7 @@
       }
     },
     {
-      "id": "get_issue",
+      "id": "github__get_issue",
       "name": "Get Issue",
       "description": "Get details of a GitHub issue",
       "requiresWrite": false,
@@ -582,7 +582,7 @@
       }
     },
     {
-      "id": "update_issue",
+      "id": "github__update_issue",
       "name": "Update Issue",
       "description": "Update, close, or reopen a GitHub issue",
       "requiresWrite": true,
@@ -634,7 +634,7 @@
       }
     },
     {
-      "id": "add_issue_comment",
+      "id": "github__add_issue_comment",
       "name": "Add Issue Comment",
       "description": "Add a comment to a GitHub issue or pull request",
       "requiresWrite": true,
@@ -671,7 +671,7 @@
       }
     },
     {
-      "id": "get_pr",
+      "id": "github__get_pr",
       "name": "Get Pull Request",
       "description": "Get details of a specific pull request (title, body, status, author, reviewers, labels)",
       "requiresWrite": false,
@@ -771,7 +771,7 @@
       }
     },
     {
-      "id": "create_pr",
+      "id": "github__create_pr",
       "name": "Create Pull Request",
       "description": "Create a new pull request in a repository",
       "requiresWrite": true,
@@ -821,7 +821,7 @@
       }
     },
     {
-      "id": "merge_pr",
+      "id": "github__merge_pr",
       "name": "Merge Pull Request",
       "description": "Merge an open pull request",
       "requiresWrite": true,
@@ -866,7 +866,7 @@
       }
     },
     {
-      "id": "list_commits",
+      "id": "github__list_commits",
       "name": "List Commits",
       "description": "List commits for a repository, branch, or file path",
       "requiresWrite": false,

--- a/cli/templates/integrations/gitlab/connector.json
+++ b/cli/templates/integrations/gitlab/connector.json
@@ -40,7 +40,7 @@
   ],
   "tools": [
     {
-      "id": "list_projects",
+      "id": "gitlab__list_projects",
       "name": "List Projects",
       "description": "List accessible GitLab projects",
       "requiresWrite": false,
@@ -81,7 +81,7 @@
       }
     },
     {
-      "id": "get_project",
+      "id": "gitlab__get_project",
       "name": "Get Project",
       "description": "Get detailed information about a GitLab project",
       "requiresWrite": false,
@@ -99,7 +99,7 @@
       }
     },
     {
-      "id": "search_issues",
+      "id": "gitlab__search_issues",
       "name": "Search Issues",
       "description": "Search for issues across projects",
       "requiresWrite": false,
@@ -145,7 +145,7 @@
       }
     },
     {
-      "id": "get_issue",
+      "id": "gitlab__get_issue",
       "name": "Get Issue",
       "description": "Get detailed information about a specific issue",
       "requiresWrite": false,
@@ -169,7 +169,7 @@
       }
     },
     {
-      "id": "create_issue",
+      "id": "gitlab__create_issue",
       "name": "Create Issue",
       "description": "Create a new issue in a project",
       "requiresWrite": true,
@@ -206,7 +206,7 @@
       }
     },
     {
-      "id": "update_issue",
+      "id": "gitlab__update_issue",
       "name": "Update Issue",
       "description": "Update, close, or reopen a GitLab issue",
       "requiresWrite": true,
@@ -252,7 +252,7 @@
       }
     },
     {
-      "id": "add_issue_comment",
+      "id": "gitlab__add_issue_comment",
       "name": "Add Issue Comment",
       "description": "Add a comment/note to a GitLab issue",
       "requiresWrite": true,
@@ -287,7 +287,7 @@
       }
     },
     {
-      "id": "list_merge_requests",
+      "id": "gitlab__list_merge_requests",
       "name": "List Merge Requests",
       "description": "List merge requests for a project or across projects",
       "requiresWrite": false,
@@ -328,7 +328,7 @@
       }
     },
     {
-      "id": "get_merge_request",
+      "id": "gitlab__get_merge_request",
       "name": "Get Merge Request",
       "description": "Get detailed information about a specific GitLab merge request",
       "requiresWrite": false,
@@ -352,7 +352,7 @@
       }
     },
     {
-      "id": "add_merge_request_comment",
+      "id": "gitlab__add_merge_request_comment",
       "name": "Add Merge Request Comment",
       "description": "Add a comment/note to a GitLab merge request",
       "requiresWrite": true,

--- a/cli/templates/integrations/gmail/connector.json
+++ b/cli/templates/integrations/gmail/connector.json
@@ -42,7 +42,7 @@
   ],
   "tools": [
     {
-      "id": "list_emails",
+      "id": "gmail__list_emails",
       "name": "List Emails",
       "description": "List Gmail message summaries with IDs, sender, recipient, subject, date, snippet, labels, and pagination tokens. Use get-email only when full message content is needed.",
       "requiresWrite": false,
@@ -104,7 +104,7 @@
       }
     },
     {
-      "id": "send_email",
+      "id": "gmail__send_email",
       "name": "Send Email",
       "description": "Send an email to recipients",
       "requiresWrite": true,
@@ -125,7 +125,7 @@
       }
     },
     {
-      "id": "get_email",
+      "id": "gmail__get_email",
       "name": "Get Email",
       "description": "Get a specific email by ID with full content",
       "requiresWrite": false,
@@ -154,7 +154,7 @@
       }
     },
     {
-      "id": "search_emails",
+      "id": "gmail__search_emails",
       "name": "Search Emails",
       "description": "Search Gmail messages and return summaries with IDs, sender, recipient, subject, date, snippet, labels, and pagination tokens.",
       "requiresWrite": false,
@@ -212,7 +212,7 @@
       }
     },
     {
-      "id": "mark_email_read",
+      "id": "gmail__mark_email_read",
       "name": "Mark Email Read",
       "description": "Mark an email as read",
       "requiresWrite": true,
@@ -239,7 +239,7 @@
       }
     },
     {
-      "id": "archive_email",
+      "id": "gmail__archive_email",
       "name": "Archive Email",
       "description": "Archive an email",
       "requiresWrite": true,
@@ -266,7 +266,7 @@
       }
     },
     {
-      "id": "list_labels",
+      "id": "gmail__list_labels",
       "name": "List Labels",
       "description": "List Gmail labels",
       "requiresWrite": false,
@@ -298,7 +298,7 @@
       }
     },
     {
-      "id": "get_label",
+      "id": "gmail__get_label",
       "name": "Get Label",
       "description": "Get a Gmail label",
       "requiresWrite": false,
@@ -316,7 +316,7 @@
       }
     },
     {
-      "id": "create_label",
+      "id": "gmail__create_label",
       "name": "Create Label",
       "description": "Create a Gmail user label",
       "requiresWrite": true,
@@ -345,7 +345,7 @@
       }
     },
     {
-      "id": "update_label",
+      "id": "gmail__update_label",
       "name": "Update Label",
       "description": "Update a Gmail user label",
       "requiresWrite": true,
@@ -382,7 +382,7 @@
       }
     },
     {
-      "id": "delete_label",
+      "id": "gmail__delete_label",
       "name": "Delete Label",
       "description": "Delete a Gmail user label",
       "requiresWrite": true,
@@ -400,7 +400,7 @@
       }
     },
     {
-      "id": "apply_labels",
+      "id": "gmail__apply_labels",
       "name": "Apply Labels",
       "description": "Apply or remove labels on an email",
       "requiresWrite": true,
@@ -428,7 +428,7 @@
       }
     },
     {
-      "id": "modify_email_labels",
+      "id": "gmail__modify_email_labels",
       "name": "Modify Email Labels",
       "description": "Modify labels on an email",
       "requiresWrite": true,
@@ -456,7 +456,7 @@
       }
     },
     {
-      "id": "trash_email",
+      "id": "gmail__trash_email",
       "name": "Trash Email",
       "description": "Move an email to trash",
       "requiresWrite": true,
@@ -474,7 +474,7 @@
       }
     },
     {
-      "id": "untrash_email",
+      "id": "gmail__untrash_email",
       "name": "Untrash Email",
       "description": "Remove an email from trash",
       "requiresWrite": true,
@@ -492,7 +492,7 @@
       }
     },
     {
-      "id": "delete_email",
+      "id": "gmail__delete_email",
       "name": "Delete Email",
       "description": "Permanently delete an email",
       "requiresWrite": true,
@@ -510,7 +510,7 @@
       }
     },
     {
-      "id": "batch_modify_emails",
+      "id": "gmail__batch_modify_emails",
       "name": "Batch Modify Emails",
       "description": "Modify labels on multiple emails",
       "requiresWrite": true,
@@ -535,7 +535,7 @@
       }
     },
     {
-      "id": "batch_delete_emails",
+      "id": "gmail__batch_delete_emails",
       "name": "Batch Delete Emails",
       "description": "Permanently delete multiple emails",
       "requiresWrite": true,
@@ -552,7 +552,7 @@
       }
     },
     {
-      "id": "list_threads",
+      "id": "gmail__list_threads",
       "name": "List Threads",
       "description": "List Gmail threads",
       "requiresWrite": false,
@@ -616,7 +616,7 @@
       }
     },
     {
-      "id": "get_thread",
+      "id": "gmail__get_thread",
       "name": "Get Thread",
       "description": "Get a Gmail thread",
       "requiresWrite": false,
@@ -640,7 +640,7 @@
       }
     },
     {
-      "id": "modify_thread_labels",
+      "id": "gmail__modify_thread_labels",
       "name": "Modify Thread Labels",
       "description": "Modify labels on a Gmail thread",
       "requiresWrite": true,
@@ -668,7 +668,7 @@
       }
     },
     {
-      "id": "trash_thread",
+      "id": "gmail__trash_thread",
       "name": "Trash Thread",
       "description": "Move a Gmail thread to trash",
       "requiresWrite": true,
@@ -686,7 +686,7 @@
       }
     },
     {
-      "id": "untrash_thread",
+      "id": "gmail__untrash_thread",
       "name": "Untrash Thread",
       "description": "Remove a Gmail thread from trash",
       "requiresWrite": true,
@@ -704,7 +704,7 @@
       }
     },
     {
-      "id": "delete_thread",
+      "id": "gmail__delete_thread",
       "name": "Delete Thread",
       "description": "Permanently delete a Gmail thread",
       "requiresWrite": true,
@@ -722,7 +722,7 @@
       }
     },
     {
-      "id": "create_draft",
+      "id": "gmail__create_draft",
       "name": "Create Draft",
       "description": "Create a Gmail draft",
       "requiresWrite": true,
@@ -739,7 +739,7 @@
       }
     },
     {
-      "id": "list_drafts",
+      "id": "gmail__list_drafts",
       "name": "List Drafts",
       "description": "List Gmail drafts",
       "requiresWrite": false,
@@ -795,7 +795,7 @@
       }
     },
     {
-      "id": "get_draft",
+      "id": "gmail__get_draft",
       "name": "Get Draft",
       "description": "Get a Gmail draft",
       "requiresWrite": false,
@@ -819,7 +819,7 @@
       }
     },
     {
-      "id": "update_draft",
+      "id": "gmail__update_draft",
       "name": "Update Draft",
       "description": "Replace a Gmail draft",
       "requiresWrite": true,
@@ -844,7 +844,7 @@
       }
     },
     {
-      "id": "send_draft",
+      "id": "gmail__send_draft",
       "name": "Send Draft",
       "description": "Send an existing Gmail draft",
       "requiresWrite": true,
@@ -861,7 +861,7 @@
       }
     },
     {
-      "id": "delete_draft",
+      "id": "gmail__delete_draft",
       "name": "Delete Draft",
       "description": "Permanently delete a Gmail draft",
       "requiresWrite": true,
@@ -879,7 +879,7 @@
       }
     },
     {
-      "id": "get_attachment",
+      "id": "gmail__get_attachment",
       "name": "Get Attachment",
       "description": "Get a Gmail message attachment",
       "requiresWrite": false,
@@ -903,7 +903,7 @@
       }
     },
     {
-      "id": "get_profile",
+      "id": "gmail__get_profile",
       "name": "Get Profile",
       "description": "Get the Gmail mailbox profile",
       "requiresWrite": false,
@@ -913,7 +913,7 @@
       }
     },
     {
-      "id": "list_history",
+      "id": "gmail__list_history",
       "name": "List History",
       "description": "List Gmail mailbox history changes",
       "requiresWrite": false,

--- a/cli/templates/integrations/gocardless/connector.json
+++ b/cli/templates/integrations/gocardless/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "list_customers",
+      "id": "gocardless__list_customers",
       "name": "List Customers",
       "description": "List GoCardless customers to find customer IDs and contact details",
       "requiresWrite": false,
@@ -66,7 +66,7 @@
       }
     },
     {
-      "id": "list_payments",
+      "id": "gocardless__list_payments",
       "name": "List Payments",
       "description": "List GoCardless payments with optional status, customer, or mandate filtering",
       "requiresWrite": false,
@@ -114,7 +114,7 @@
       }
     },
     {
-      "id": "get_payment",
+      "id": "gocardless__get_payment",
       "name": "Get Payment",
       "description": "Get a single GoCardless payment by ID to check its status, amount, and linked mandate",
       "requiresWrite": false,
@@ -139,7 +139,7 @@
       }
     },
     {
-      "id": "list_mandates",
+      "id": "gocardless__list_mandates",
       "name": "List Mandates",
       "description": "List Direct Debit mandates to find an active mandate before collecting a payment",
       "requiresWrite": false,
@@ -182,7 +182,7 @@
       }
     },
     {
-      "id": "create_payment",
+      "id": "gocardless__create_payment",
       "name": "Create Payment",
       "description": "Collect a one-off payment against an existing active Direct Debit mandate",
       "requiresWrite": true,
@@ -213,7 +213,7 @@
       }
     },
     {
-      "id": "create_subscription",
+      "id": "gocardless__create_subscription",
       "name": "Create Subscription",
       "description": "Set up a recurring payment collection against an existing active Direct Debit mandate",
       "requiresWrite": true,
@@ -244,7 +244,7 @@
       }
     },
     {
-      "id": "retry_payment",
+      "id": "gocardless__retry_payment",
       "name": "Retry Payment",
       "description": "Retry a failed payment if its mandate is still active; a payment can be retried at most three times",
       "requiresWrite": true,
@@ -269,7 +269,7 @@
       }
     },
     {
-      "id": "list_events",
+      "id": "gocardless__list_events",
       "name": "List Events",
       "description": "List GoCardless events (status changes such as payment failures, chargebacks, and mandate cancellations) for monitoring and audit workflows",
       "requiresWrite": false,

--- a/cli/templates/integrations/gong/connector.json
+++ b/cli/templates/integrations/gong/connector.json
@@ -33,7 +33,7 @@
   ],
   "tools": [
     {
-      "id": "list_calls",
+      "id": "gong__list_calls",
       "name": "List Calls",
       "description": "List calls in a date window (max 90 days per request)",
       "requiresWrite": false,
@@ -79,7 +79,7 @@
       }
     },
     {
-      "id": "get_call",
+      "id": "gong__get_call",
       "name": "Get Call",
       "description": "Get metadata for a single call",
       "requiresWrite": false,
@@ -100,7 +100,7 @@
       }
     },
     {
-      "id": "get_calls_extensive",
+      "id": "gong__get_calls_extensive",
       "name": "Get Calls Extensive",
       "description": "Retrieve detailed call data with content selectors (read-only retrieval via POST)",
       "requiresWrite": false,
@@ -125,7 +125,7 @@
       }
     },
     {
-      "id": "get_call_transcripts",
+      "id": "gong__get_call_transcripts",
       "name": "Get Call Transcripts",
       "description": "Retrieve transcripts for specific calls (read-only retrieval via POST)",
       "requiresWrite": false,
@@ -149,7 +149,7 @@
       }
     },
     {
-      "id": "list_users",
+      "id": "gong__list_users",
       "name": "List Users",
       "description": "List Gong users in the company",
       "requiresWrite": false,
@@ -166,7 +166,7 @@
       }
     },
     {
-      "id": "get_user",
+      "id": "gong__get_user",
       "name": "Get User",
       "description": "Get a Gong user by ID",
       "requiresWrite": false,

--- a/cli/templates/integrations/google-analytics/connector.json
+++ b/cli/templates/integrations/google-analytics/connector.json
@@ -40,7 +40,7 @@
   ],
   "tools": [
     {
-      "id": "list_account_summaries",
+      "id": "google-analytics__list_account_summaries",
       "name": "List Account Summaries",
       "description": "List GA4 accounts and their properties accessible to the connected user (use this to find property IDs)",
       "requiresWrite": false,
@@ -76,7 +76,7 @@
       }
     },
     {
-      "id": "run_report",
+      "id": "google-analytics__run_report",
       "name": "Run Report",
       "description": "Run a GA4 report for a property over one or more date ranges",
       "requiresWrite": false,
@@ -127,7 +127,7 @@
       }
     },
     {
-      "id": "run_realtime_report",
+      "id": "google-analytics__run_realtime_report",
       "name": "Run Realtime Report",
       "description": "Run a GA4 realtime report showing activity from the last 30 minutes",
       "requiresWrite": false,
@@ -161,7 +161,7 @@
       }
     },
     {
-      "id": "get_metadata",
+      "id": "google-analytics__get_metadata",
       "name": "Get Report Metadata",
       "description": "List the dimensions and metrics available for a GA4 property (use before building reports)",
       "requiresWrite": false,

--- a/cli/templates/integrations/google-bigquery/connector.json
+++ b/cli/templates/integrations/google-bigquery/connector.json
@@ -43,7 +43,7 @@
   ],
   "tools": [
     {
-      "id": "list_projects",
+      "id": "google-bigquery__list_projects",
       "name": "List Projects",
       "description": "List the Google Cloud projects the connected user can access, so agents can discover the projectId every other tool requires",
       "requiresWrite": false,
@@ -69,7 +69,7 @@
       }
     },
     {
-      "id": "list_datasets",
+      "id": "google-bigquery__list_datasets",
       "name": "List Datasets",
       "description": "List all BigQuery datasets in a Google Cloud project",
       "requiresWrite": false,
@@ -107,7 +107,7 @@
       }
     },
     {
-      "id": "list_tables",
+      "id": "google-bigquery__list_tables",
       "name": "List Tables",
       "description": "List tables and views in a BigQuery dataset",
       "requiresWrite": false,
@@ -145,7 +145,7 @@
       }
     },
     {
-      "id": "get_table",
+      "id": "google-bigquery__get_table",
       "name": "Get Table Schema",
       "description": "Get a table's metadata including its full column schema, row count, and size",
       "requiresWrite": false,
@@ -180,7 +180,7 @@
       }
     },
     {
-      "id": "preview_table_data",
+      "id": "google-bigquery__preview_table_data",
       "name": "Preview Table Data",
       "description": "Read sample rows directly from a table without running a query - no bytes are billed, ideal for inspecting data before writing SQL",
       "requiresWrite": false,
@@ -234,7 +234,7 @@
       }
     },
     {
-      "id": "run_query",
+      "id": "google-bigquery__run_query",
       "name": "Run SQL Query",
       "description": "Run a read/SELECT GoogleSQL query and return the first page of results. With the default read-only scope only SELECT queries work; DML statements (INSERT/UPDATE/DELETE) require the full https://www.googleapis.com/auth/bigquery scope.",
       "requiresWrite": false,
@@ -283,7 +283,7 @@
       }
     },
     {
-      "id": "get_query_results",
+      "id": "google-bigquery__get_query_results",
       "name": "Get Query Results",
       "description": "Fetch additional pages of results from a previously started query job, using the jobId and pageToken returned by Run SQL Query",
       "requiresWrite": false,

--- a/cli/templates/integrations/google-chat/connector.json
+++ b/cli/templates/integrations/google-chat/connector.json
@@ -39,7 +39,7 @@
   ],
   "tools": [
     {
-      "id": "list_spaces",
+      "id": "google-chat__list_spaces",
       "name": "List Spaces",
       "description": "List Google Chat spaces (rooms and direct messages) the authenticated user is a member of",
       "requiresWrite": false,
@@ -82,7 +82,7 @@
       }
     },
     {
-      "id": "get_space",
+      "id": "google-chat__get_space",
       "name": "Get Space",
       "description": "Get details of a Google Chat space",
       "requiresWrite": false,
@@ -100,7 +100,7 @@
       }
     },
     {
-      "id": "list_messages",
+      "id": "google-chat__list_messages",
       "name": "List Messages",
       "description": "List messages in a Google Chat space, including messages in threads",
       "requiresWrite": false,
@@ -155,7 +155,7 @@
       }
     },
     {
-      "id": "get_message",
+      "id": "google-chat__get_message",
       "name": "Get Message",
       "description": "Get details of a specific Google Chat message",
       "requiresWrite": false,
@@ -179,7 +179,7 @@
       }
     },
     {
-      "id": "send_message",
+      "id": "google-chat__send_message",
       "name": "Send Message",
       "description": "Send a text message to a Google Chat space",
       "requiresWrite": true,

--- a/cli/templates/integrations/google-cloud-storage/connector.json
+++ b/cli/templates/integrations/google-cloud-storage/connector.json
@@ -43,7 +43,7 @@
   ],
   "tools": [
     {
-      "id": "list_buckets",
+      "id": "google-cloud-storage__list_buckets",
       "name": "List Buckets",
       "description": "List Cloud Storage buckets in a Google Cloud project",
       "requiresWrite": false,
@@ -81,7 +81,7 @@
       }
     },
     {
-      "id": "get_bucket",
+      "id": "google-cloud-storage__get_bucket",
       "name": "Get Bucket Metadata",
       "description": "Get a bucket's metadata - location, storage class, versioning, and lifecycle configuration",
       "requiresWrite": false,
@@ -104,7 +104,7 @@
       }
     },
     {
-      "id": "list_objects",
+      "id": "google-cloud-storage__list_objects",
       "name": "List Objects",
       "description": "List objects in a bucket, optionally filtered by name prefix or grouped by delimiter",
       "requiresWrite": false,
@@ -146,7 +146,7 @@
       }
     },
     {
-      "id": "download_object",
+      "id": "google-cloud-storage__download_object",
       "name": "Download Object",
       "description": "Download an object's content (alt=media), or set alt=json to return the object's metadata instead",
       "requiresWrite": false,
@@ -176,7 +176,7 @@
       }
     },
     {
-      "id": "upload_object",
+      "id": "google-cloud-storage__upload_object",
       "name": "Upload Object",
       "description": "Upload content as a new object (or overwrite an existing one) using a simple media upload — requires the read-write scope",
       "requiresWrite": true,
@@ -221,7 +221,7 @@
       }
     },
     {
-      "id": "copy_object",
+      "id": "google-cloud-storage__copy_object",
       "name": "Copy Object",
       "description": "Copy an object to another name or bucket server-side (rewrite), without downloading and re-uploading - requires the read-write scope",
       "requiresWrite": true,
@@ -262,7 +262,7 @@
       }
     },
     {
-      "id": "delete_object",
+      "id": "google-cloud-storage__delete_object",
       "name": "Delete Object",
       "description": "Permanently delete an object from a bucket — requires the read-write scope",
       "requiresWrite": true,

--- a/cli/templates/integrations/google-contacts/connector.json
+++ b/cli/templates/integrations/google-contacts/connector.json
@@ -43,7 +43,7 @@
   ],
   "tools": [
     {
-      "id": "list_contacts",
+      "id": "google-contacts__list_contacts",
       "name": "List Contacts",
       "description": "List the authenticated user's contacts (connections) with the requested person fields",
       "requiresWrite": false,
@@ -81,7 +81,7 @@
       }
     },
     {
-      "id": "search_contacts",
+      "id": "google-contacts__search_contacts",
       "name": "Search Contacts",
       "description": "Search the user's contacts by prefix match on names, nicknames, email addresses, and phone numbers. For best results send a warmup request with an empty query first, then search.",
       "requiresWrite": false,
@@ -115,7 +115,7 @@
       }
     },
     {
-      "id": "get_contact",
+      "id": "google-contacts__get_contact",
       "name": "Get Contact",
       "description": "Get a single contact by person ID, including the etag needed for updates",
       "requiresWrite": false,
@@ -140,7 +140,7 @@
       }
     },
     {
-      "id": "list_contact_groups",
+      "id": "google-contacts__list_contact_groups",
       "name": "List Contact Groups",
       "description": "List the user's contact groups (labels), including system groups and member counts, e.g. to organize or filter contacts",
       "requiresWrite": false,
@@ -171,7 +171,7 @@
       }
     },
     {
-      "id": "create_contact",
+      "id": "google-contacts__create_contact",
       "name": "Create Contact",
       "description": "Create a new contact in the user's Google Contacts (requires the full contacts scope)",
       "requiresWrite": true,
@@ -212,7 +212,7 @@
       }
     },
     {
-      "id": "update_contact",
+      "id": "google-contacts__update_contact",
       "name": "Update Contact",
       "description": "Update an existing contact (requires the full contacts scope). You must pass updatePersonFields naming the fields you are changing, and the body must include the contact's current etag (fetch it with Get Contact including metadata first); a stale etag fails with a 400 failedPrecondition error.",
       "requiresWrite": true,

--- a/cli/templates/integrations/google-forms/connector.json
+++ b/cli/templates/integrations/google-forms/connector.json
@@ -44,7 +44,7 @@
   ],
   "tools": [
     {
-      "id": "get_form",
+      "id": "google-forms__get_form",
       "name": "Get Form",
       "description": "Get a form's metadata, settings, and items (questions) including the question IDs needed to interpret responses",
       "requiresWrite": false,
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "list_form_responses",
+      "id": "google-forms__list_form_responses",
       "name": "List Form Responses",
       "description": "List submitted responses for a form, with answers keyed by question ID",
       "requiresWrite": false,
@@ -99,7 +99,7 @@
       }
     },
     {
-      "id": "get_form_response",
+      "id": "google-forms__get_form_response",
       "name": "Get Form Response",
       "description": "Get a single response submitted to a form",
       "requiresWrite": false,
@@ -123,7 +123,7 @@
       }
     },
     {
-      "id": "create_form",
+      "id": "google-forms__create_form",
       "name": "Create Form",
       "description": "Create a new form with a title; add questions afterwards with Batch Update Form",
       "requiresWrite": true,
@@ -140,7 +140,7 @@
       }
     },
     {
-      "id": "set_publish_settings",
+      "id": "google-forms__set_publish_settings",
       "name": "Set Publish Settings",
       "description": "Publish or unpublish a form and toggle whether it accepts responses, e.g. to open a survey after building it or close it when done (requires the forms.body scope)",
       "requiresWrite": true,
@@ -169,7 +169,7 @@
       }
     },
     {
-      "id": "batch_update_form",
+      "id": "google-forms__batch_update_form",
       "name": "Batch Update Form",
       "description": "Apply a batch of updates to a form, such as adding questions, updating form info, or changing settings",
       "requiresWrite": true,

--- a/cli/templates/integrations/gorgias/connector.json
+++ b/cli/templates/integrations/gorgias/connector.json
@@ -41,7 +41,7 @@
   ],
   "tools": [
     {
-      "id": "list_tickets",
+      "id": "gorgias__list_tickets",
       "name": "List Tickets",
       "description": "List helpdesk tickets, optionally filtered by customer or ordered by creation/update time",
       "requiresWrite": false,
@@ -97,7 +97,7 @@
       }
     },
     {
-      "id": "get_ticket",
+      "id": "gorgias__get_ticket",
       "name": "Get Ticket",
       "description": "Retrieve a single ticket with its full details (customer, assignee, status, tags)",
       "requiresWrite": false,
@@ -121,7 +121,7 @@
       }
     },
     {
-      "id": "list_ticket_messages",
+      "id": "gorgias__list_ticket_messages",
       "name": "List Ticket Messages",
       "description": "List the messages (customer and agent) in a ticket's conversation thread",
       "requiresWrite": false,
@@ -176,7 +176,7 @@
       }
     },
     {
-      "id": "create_ticket_message",
+      "id": "gorgias__create_ticket_message",
       "name": "Create Ticket Message",
       "description": "Add a message to a ticket, e.g. an agent reply to the customer or an internal note",
       "requiresWrite": true,
@@ -228,7 +228,7 @@
       }
     },
     {
-      "id": "create_ticket",
+      "id": "gorgias__create_ticket",
       "name": "Create Ticket",
       "description": "Create a new helpdesk ticket with an initial message, e.g. to open an issue on behalf of a customer",
       "requiresWrite": true,
@@ -269,7 +269,7 @@
       }
     },
     {
-      "id": "list_customers",
+      "id": "gorgias__list_customers",
       "name": "List Customers",
       "description": "List or search helpdesk customers, e.g. to find a customer ID by email for ticket filtering",
       "requiresWrite": false,
@@ -328,7 +328,7 @@
       }
     },
     {
-      "id": "list_users",
+      "id": "gorgias__list_users",
       "name": "List Users",
       "description": "List helpdesk agents/users, e.g. to find the user IDs needed for ticket assignment and message senders",
       "requiresWrite": false,
@@ -381,7 +381,7 @@
       }
     },
     {
-      "id": "update_ticket_status",
+      "id": "gorgias__update_ticket_status",
       "name": "Update Ticket Status",
       "description": "Update a ticket, e.g. close or reopen it, or change its assignee",
       "requiresWrite": true,

--- a/cli/templates/integrations/grafana-cloud/connector.json
+++ b/cli/templates/integrations/grafana-cloud/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "search_dashboards",
+      "id": "grafana-cloud__search_dashboards",
       "name": "Search Dashboards",
       "description": "Search dashboards and folders in the Grafana stack",
       "requiresWrite": false,
@@ -85,7 +85,7 @@
       }
     },
     {
-      "id": "get_dashboard",
+      "id": "grafana-cloud__get_dashboard",
       "name": "Get Dashboard",
       "description": "Get a dashboard's full JSON model by UID",
       "requiresWrite": false,
@@ -109,7 +109,7 @@
       }
     },
     {
-      "id": "list_folders",
+      "id": "grafana-cloud__list_folders",
       "name": "List Folders",
       "description": "List dashboard folders in the Grafana stack",
       "requiresWrite": false,
@@ -133,7 +133,7 @@
       }
     },
     {
-      "id": "list_annotations",
+      "id": "grafana-cloud__list_annotations",
       "name": "List Annotations",
       "description": "List annotations and alert events in a time range",
       "requiresWrite": false,
@@ -177,7 +177,7 @@
       }
     },
     {
-      "id": "create_annotation",
+      "id": "grafana-cloud__create_annotation",
       "name": "Create Annotation",
       "description": "Create an annotation (e.g. mark a deploy) on a dashboard or globally",
       "requiresWrite": true,
@@ -222,7 +222,7 @@
       }
     },
     {
-      "id": "list_datasources",
+      "id": "grafana-cloud__list_datasources",
       "name": "List Data Sources",
       "description": "List data sources configured in the Grafana stack",
       "requiresWrite": false,

--- a/cli/templates/integrations/greenhouse/connector.json
+++ b/cli/templates/integrations/greenhouse/connector.json
@@ -35,7 +35,7 @@
   ],
   "tools": [
     {
-      "id": "list_jobs",
+      "id": "greenhouse__list_jobs",
       "name": "List Jobs",
       "description": "List jobs in the Greenhouse organization with optional status and date filtering",
       "requiresWrite": false,
@@ -73,7 +73,7 @@
       }
     },
     {
-      "id": "list_candidates",
+      "id": "greenhouse__list_candidates",
       "name": "List Candidates",
       "description": "List candidates with optional job, email, and date filtering",
       "requiresWrite": false,
@@ -116,7 +116,7 @@
       }
     },
     {
-      "id": "get_candidate",
+      "id": "greenhouse__get_candidate",
       "name": "Get Candidate",
       "description": "Get a candidate's full record, including applications, attachments, and contact details",
       "requiresWrite": false,
@@ -134,7 +134,7 @@
       }
     },
     {
-      "id": "list_applications",
+      "id": "greenhouse__list_applications",
       "name": "List Applications",
       "description": "List applications with optional job, status, and activity filtering",
       "requiresWrite": false,
@@ -177,7 +177,7 @@
       }
     },
     {
-      "id": "list_users",
+      "id": "greenhouse__list_users",
       "name": "List Users",
       "description": "List Greenhouse users to find the numeric user IDs needed for On-Behalf-Of headers and notes",
       "requiresWrite": false,
@@ -210,7 +210,7 @@
       }
     },
     {
-      "id": "list_job_stages",
+      "id": "greenhouse__list_job_stages",
       "name": "List Job Stages",
       "description": "List the interview stages of a job to find the stage IDs needed to move applications",
       "requiresWrite": false,
@@ -239,7 +239,7 @@
       }
     },
     {
-      "id": "move_application",
+      "id": "greenhouse__move_application",
       "name": "Move Application",
       "description": "Move an active application to another stage on the same job (the core pipeline action)",
       "requiresWrite": true,
@@ -275,7 +275,7 @@
       }
     },
     {
-      "id": "add_candidate_note",
+      "id": "greenhouse__add_candidate_note",
       "name": "Add Candidate Note",
       "description": "Create a note on a candidate's activity feed (requires the acting Greenhouse user's ID)",
       "requiresWrite": true,

--- a/cli/templates/integrations/groq/connector.json
+++ b/cli/templates/integrations/groq/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_models",
+      "id": "groq__list_models",
       "name": "List Models",
       "description": "List the models available on Groq",
       "requiresWrite": false,
@@ -50,7 +50,7 @@
       }
     },
     {
-      "id": "get_model",
+      "id": "groq__get_model",
       "name": "Get Model",
       "description": "Get details about a specific Groq model",
       "requiresWrite": false,
@@ -68,7 +68,7 @@
       }
     },
     {
-      "id": "create_chat_completion",
+      "id": "groq__create_chat_completion",
       "name": "Create Chat Completion",
       "description": "Generate a chat completion from a list of messages",
       "requiresWrite": true,
@@ -98,7 +98,7 @@
       }
     },
     {
-      "id": "list_batches",
+      "id": "groq__list_batches",
       "name": "List Batches",
       "description": "List the organization's batch jobs",
       "requiresWrite": false,

--- a/cli/templates/integrations/guru/connector.json
+++ b/cli/templates/integrations/guru/connector.json
@@ -34,7 +34,7 @@
   ],
   "tools": [
     {
-      "id": "search_cards",
+      "id": "guru__search_cards",
       "name": "Search Cards",
       "description": "Search the knowledge base for cards matching search terms",
       "requiresWrite": false,
@@ -73,7 +73,7 @@
       }
     },
     {
-      "id": "get_card",
+      "id": "guru__get_card",
       "name": "Get Card",
       "description": "Get a single card with its full content and additional details (collection, verifiers, collaborators)",
       "requiresWrite": false,
@@ -91,7 +91,7 @@
       }
     },
     {
-      "id": "list_collections",
+      "id": "guru__list_collections",
       "name": "List Collections",
       "description": "List the collections in the team to find collection IDs, names, and stats",
       "requiresWrite": false,
@@ -101,7 +101,7 @@
       }
     },
     {
-      "id": "create_card",
+      "id": "guru__create_card",
       "name": "Create Card",
       "description": "Create a new knowledge-base card in a collection",
       "requiresWrite": true,
@@ -135,7 +135,7 @@
       }
     },
     {
-      "id": "update_card",
+      "id": "guru__update_card",
       "name": "Update Card",
       "description": "Update an existing card's title, content, or visibility to keep knowledge current",
       "requiresWrite": true,
@@ -177,7 +177,7 @@
       }
     },
     {
-      "id": "verify_card",
+      "id": "guru__verify_card",
       "name": "Verify Card",
       "description": "Mark a card as verified, confirming its content is accurate and up to date",
       "requiresWrite": true,

--- a/cli/templates/integrations/gusto/connector.json
+++ b/cli/templates/integrations/gusto/connector.json
@@ -36,7 +36,7 @@
   ],
   "tools": [
     {
-      "id": "get_token_info",
+      "id": "gusto__get_token_info",
       "name": "Get Token Info",
       "description": "Get the resource (company) and scope associated with the current access token",
       "requiresWrite": false,
@@ -55,7 +55,7 @@
       }
     },
     {
-      "id": "get_company",
+      "id": "gusto__get_company",
       "name": "Get Company",
       "description": "Get a company's profile, locations, and entity details",
       "requiresWrite": false,
@@ -80,7 +80,7 @@
       }
     },
     {
-      "id": "list_employees",
+      "id": "gusto__list_employees",
       "name": "List Employees",
       "description": "List employees of a company",
       "requiresWrite": false,
@@ -140,7 +140,7 @@
       }
     },
     {
-      "id": "get_employee",
+      "id": "gusto__get_employee",
       "name": "Get Employee",
       "description": "Get a single employee",
       "requiresWrite": false,
@@ -165,7 +165,7 @@
       }
     },
     {
-      "id": "list_payrolls",
+      "id": "gusto__list_payrolls",
       "name": "List Payrolls",
       "description": "List payrolls for a company",
       "requiresWrite": false,
@@ -210,7 +210,7 @@
       }
     },
     {
-      "id": "get_payroll",
+      "id": "gusto__get_payroll",
       "name": "Get Payroll",
       "description": "Get a single payroll with totals",
       "requiresWrite": false,

--- a/cli/templates/integrations/harvest/connector.json
+++ b/cli/templates/integrations/harvest/connector.json
@@ -35,7 +35,7 @@
   ],
   "tools": [
     {
-      "id": "list_accounts",
+      "id": "harvest__list_accounts",
       "name": "List Accounts",
       "description": "List all Harvest accounts the authenticated user can access. Call this first to get your Harvest-Account-Id for subsequent API calls.",
       "requiresWrite": false,
@@ -67,7 +67,7 @@
       }
     },
     {
-      "id": "get_current_user",
+      "id": "harvest__get_current_user",
       "name": "Get Current User",
       "description": "Get the authenticated user's Harvest profile (id, name, email, timezone, roles)",
       "requiresWrite": false,
@@ -79,14 +79,14 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           }
         }
       }
     },
     {
-      "id": "list_users",
+      "id": "harvest__list_users",
       "name": "List Users",
       "description": "List all active users in the Harvest account",
       "requiresWrite": false,
@@ -98,7 +98,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "is_active": {
@@ -182,7 +182,7 @@
       }
     },
     {
-      "id": "list_time_entries",
+      "id": "harvest__list_time_entries",
       "name": "List Time Entries",
       "description": "List time entries (timesheets). Filter by user, project, client, or date range.",
       "requiresWrite": false,
@@ -194,7 +194,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "user_id": {
@@ -322,7 +322,7 @@
       }
     },
     {
-      "id": "get_time_entry",
+      "id": "harvest__get_time_entry",
       "name": "Get Time Entry",
       "description": "Get details of a specific time entry by ID",
       "requiresWrite": false,
@@ -334,7 +334,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "timeEntryId": {
@@ -347,7 +347,7 @@
       }
     },
     {
-      "id": "create_time_entry",
+      "id": "harvest__create_time_entry",
       "name": "Create Time Entry",
       "description": "Create a new time entry (timesheet). Provide either hours or start/end times.",
       "requiresWrite": true,
@@ -359,7 +359,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           }
         },
@@ -407,7 +407,7 @@
       }
     },
     {
-      "id": "update_time_entry",
+      "id": "harvest__update_time_entry",
       "name": "Update Time Entry",
       "description": "Update an existing time entry",
       "requiresWrite": true,
@@ -419,7 +419,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "timeEntryId": {
@@ -466,7 +466,7 @@
       }
     },
     {
-      "id": "delete_time_entry",
+      "id": "harvest__delete_time_entry",
       "name": "Delete Time Entry",
       "description": "Delete a time entry. Only unlocked, non-billed entries can be deleted.",
       "requiresWrite": true,
@@ -478,7 +478,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "timeEntryId": {
@@ -491,7 +491,7 @@
       }
     },
     {
-      "id": "stop_timer",
+      "id": "harvest__stop_timer",
       "name": "Stop Timer",
       "description": "Stop a running timer for a time entry",
       "requiresWrite": true,
@@ -503,7 +503,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "timeEntryId": {
@@ -516,7 +516,7 @@
       }
     },
     {
-      "id": "restart_timer",
+      "id": "harvest__restart_timer",
       "name": "Restart Timer",
       "description": "Restart a stopped timer for a time entry",
       "requiresWrite": true,
@@ -528,7 +528,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "timeEntryId": {
@@ -541,7 +541,7 @@
       }
     },
     {
-      "id": "list_projects",
+      "id": "harvest__list_projects",
       "name": "List Projects",
       "description": "List all projects in the Harvest account",
       "requiresWrite": false,
@@ -553,7 +553,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "is_active": {
@@ -642,7 +642,7 @@
       }
     },
     {
-      "id": "get_project",
+      "id": "harvest__get_project",
       "name": "Get Project",
       "description": "Get details of a specific project",
       "requiresWrite": false,
@@ -654,7 +654,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "projectId": {
@@ -667,7 +667,7 @@
       }
     },
     {
-      "id": "list_tasks",
+      "id": "harvest__list_tasks",
       "name": "List Tasks",
       "description": "List all tasks available in the Harvest account",
       "requiresWrite": false,
@@ -679,7 +679,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "is_active": {
@@ -759,7 +759,7 @@
       }
     },
     {
-      "id": "list_project_task_assignments",
+      "id": "harvest__list_project_task_assignments",
       "name": "List Project Task Assignments",
       "description": "List all task assignments for a specific project (tasks billable to this project)",
       "requiresWrite": false,
@@ -771,7 +771,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "projectId": {
@@ -859,7 +859,7 @@
       }
     },
     {
-      "id": "list_clients",
+      "id": "harvest__list_clients",
       "name": "List Clients",
       "description": "List all clients in the Harvest account",
       "requiresWrite": false,
@@ -871,7 +871,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "is_active": {
@@ -951,7 +951,7 @@
       }
     },
     {
-      "id": "get_client",
+      "id": "harvest__get_client",
       "name": "Get Client",
       "description": "Get details of a specific client",
       "requiresWrite": false,
@@ -963,7 +963,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "clientId": {
@@ -976,7 +976,7 @@
       }
     },
     {
-      "id": "list_invoices",
+      "id": "harvest__list_invoices",
       "name": "List Invoices",
       "description": "List all invoices. Filter by client, status, or date range.",
       "requiresWrite": false,
@@ -988,7 +988,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "client_id": {
@@ -1095,7 +1095,7 @@
       }
     },
     {
-      "id": "get_invoice",
+      "id": "harvest__get_invoice",
       "name": "Get Invoice",
       "description": "Get details of a specific invoice including line items",
       "requiresWrite": false,
@@ -1107,7 +1107,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "invoiceId": {
@@ -1120,7 +1120,7 @@
       }
     },
     {
-      "id": "create_invoice",
+      "id": "harvest__create_invoice",
       "name": "Create Invoice",
       "description": "Create a new invoice for a client",
       "requiresWrite": true,
@@ -1132,7 +1132,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           }
         },
@@ -1174,7 +1174,7 @@
       }
     },
     {
-      "id": "update_invoice",
+      "id": "harvest__update_invoice",
       "name": "Update Invoice",
       "description": "Update an existing invoice (subject, notes, dates, line items, state)",
       "requiresWrite": true,
@@ -1186,7 +1186,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "invoiceId": {
@@ -1221,7 +1221,7 @@
       }
     },
     {
-      "id": "list_invoice_payments",
+      "id": "harvest__list_invoice_payments",
       "name": "List Invoice Payments",
       "description": "List all payments recorded for an invoice",
       "requiresWrite": false,
@@ -1233,7 +1233,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "invoiceId": {
@@ -1314,7 +1314,7 @@
       }
     },
     {
-      "id": "create_invoice_payment",
+      "id": "harvest__create_invoice_payment",
       "name": "Create Invoice Payment",
       "description": "Record a payment for an invoice",
       "requiresWrite": true,
@@ -1326,7 +1326,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "invoiceId": {
@@ -1363,7 +1363,7 @@
       }
     },
     {
-      "id": "time_report_by_project",
+      "id": "harvest__time_report_by_project",
       "name": "Time Report by Project",
       "description": "Get a time report aggregated by project. Requires from and to date range.",
       "requiresWrite": false,
@@ -1375,7 +1375,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "from": {
@@ -1486,7 +1486,7 @@
       }
     },
     {
-      "id": "time_report_by_team",
+      "id": "harvest__time_report_by_team",
       "name": "Time Report by Team",
       "description": "Get a time report aggregated by team member. Requires from and to date range.",
       "requiresWrite": false,
@@ -1498,7 +1498,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "from": {
@@ -1598,7 +1598,7 @@
       }
     },
     {
-      "id": "time_report_by_client",
+      "id": "harvest__time_report_by_client",
       "name": "Time Report by Client",
       "description": "Get a time report aggregated by client. Requires from and to date range.",
       "requiresWrite": false,
@@ -1610,7 +1610,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "from": {
@@ -1710,7 +1710,7 @@
       }
     },
     {
-      "id": "time_report_by_task",
+      "id": "harvest__time_report_by_task",
       "name": "Time Report by Task",
       "description": "Get a time report aggregated by task. Requires from and to date range.",
       "requiresWrite": false,
@@ -1722,7 +1722,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "from": {
@@ -1822,7 +1822,7 @@
       }
     },
     {
-      "id": "invoice_report",
+      "id": "harvest__invoice_report",
       "name": "Invoice Report",
       "description": "Get an invoiced time and expenses report. Requires from and to date range.",
       "requiresWrite": false,
@@ -1834,7 +1834,7 @@
             "type": "string",
             "in": "header",
             "headerName": "Harvest-Account-Id",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true
           },
           "from": {

--- a/cli/templates/integrations/help-scout/connector.json
+++ b/cli/templates/integrations/help-scout/connector.json
@@ -39,7 +39,7 @@
   ],
   "tools": [
     {
-      "id": "list_mailboxes",
+      "id": "help-scout__list_mailboxes",
       "name": "List Mailboxes",
       "description": "List Help Scout mailboxes (inboxes) so agents can find a mailbox ID before reading conversations",
       "requiresWrite": false,
@@ -60,7 +60,7 @@
       }
     },
     {
-      "id": "list_conversations",
+      "id": "help-scout__list_conversations",
       "name": "List Conversations",
       "description": "List Help Scout conversations, optionally filtered by mailbox, status, tag, or assignee",
       "requiresWrite": false,
@@ -121,7 +121,7 @@
       }
     },
     {
-      "id": "get_conversation",
+      "id": "help-scout__get_conversation",
       "name": "Get Conversation",
       "description": "Get a Help Scout conversation by ID, including its message threads",
       "requiresWrite": false,
@@ -145,7 +145,7 @@
       }
     },
     {
-      "id": "list_customers",
+      "id": "help-scout__list_customers",
       "name": "List Customers",
       "description": "List Help Scout customers, optionally filtered by mailbox, name, or a search query",
       "requiresWrite": false,
@@ -196,7 +196,7 @@
       }
     },
     {
-      "id": "list_users",
+      "id": "help-scout__list_users",
       "name": "List Users",
       "description": "List Help Scout users (team members) so agents can find user IDs for assignment and reply attribution",
       "requiresWrite": false,
@@ -227,7 +227,7 @@
       }
     },
     {
-      "id": "add_note",
+      "id": "help-scout__add_note",
       "name": "Add Note",
       "description": "Add an internal note to a conversation - visible to the team only, never emailed to the customer",
       "requiresWrite": true,
@@ -256,7 +256,7 @@
       }
     },
     {
-      "id": "update_tags",
+      "id": "help-scout__update_tags",
       "name": "Update Tags",
       "description": "Replace the tag list of a conversation, e.g. to label it during triage. Send the full list: tags omitted from the payload are removed.",
       "requiresWrite": true,
@@ -281,7 +281,7 @@
       }
     },
     {
-      "id": "create_reply",
+      "id": "help-scout__create_reply",
       "name": "Reply to Conversation",
       "description": "Send a reply on an existing Help Scout conversation, optionally changing its status",
       "requiresWrite": true,
@@ -331,7 +331,7 @@
       }
     },
     {
-      "id": "create_conversation",
+      "id": "help-scout__create_conversation",
       "name": "Create Conversation",
       "description": "Create a new Help Scout conversation in a mailbox with an initial thread",
       "requiresWrite": true,

--- a/cli/templates/integrations/heroku/connector.json
+++ b/cli/templates/integrations/heroku/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_apps",
+      "id": "heroku__list_apps",
       "name": "List Apps",
       "description": "List apps the authenticated user can access",
       "requiresWrite": false,
@@ -68,7 +68,7 @@
       }
     },
     {
-      "id": "get_app",
+      "id": "heroku__get_app",
       "name": "Get App",
       "description": "Get details of an app",
       "requiresWrite": false,
@@ -93,7 +93,7 @@
       }
     },
     {
-      "id": "list_dynos",
+      "id": "heroku__list_dynos",
       "name": "List Dynos",
       "description": "List the dynos of an app with their state",
       "requiresWrite": false,
@@ -135,7 +135,7 @@
       }
     },
     {
-      "id": "restart_dyno",
+      "id": "heroku__restart_dyno",
       "name": "Restart Dyno",
       "description": "Restart a specific dyno of an app",
       "requiresWrite": true,
@@ -166,7 +166,7 @@
       }
     },
     {
-      "id": "restart_all_dynos",
+      "id": "heroku__restart_all_dynos",
       "name": "Restart All Dynos",
       "description": "Restart every dyno of an app",
       "requiresWrite": true,
@@ -191,7 +191,7 @@
       }
     },
     {
-      "id": "get_config_vars",
+      "id": "heroku__get_config_vars",
       "name": "Get Config Vars",
       "description": "Get the config vars (environment variables) of an app",
       "requiresWrite": false,
@@ -216,7 +216,7 @@
       }
     },
     {
-      "id": "list_releases",
+      "id": "heroku__list_releases",
       "name": "List Releases",
       "description": "List the release history of an app",
       "requiresWrite": false,

--- a/cli/templates/integrations/hetzner/connector.json
+++ b/cli/templates/integrations/hetzner/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "list_servers",
+      "id": "hetzner__list_servers",
       "name": "List Servers",
       "description": "List servers in the Hetzner Cloud project with optional name, label, and status filtering",
       "requiresWrite": false,
@@ -82,7 +82,7 @@
       }
     },
     {
-      "id": "get_server",
+      "id": "hetzner__get_server",
       "name": "Get Server",
       "description": "Get a server by ID, including status, server type, image, and public network info",
       "requiresWrite": false,
@@ -103,7 +103,7 @@
       }
     },
     {
-      "id": "create_server",
+      "id": "hetzner__create_server",
       "name": "Create Server",
       "description": "Create a new server (provisions billable infrastructure)",
       "requiresWrite": true,
@@ -151,7 +151,7 @@
       }
     },
     {
-      "id": "power_on_server",
+      "id": "hetzner__power_on_server",
       "name": "Power On Server",
       "description": "Power on a server by ID",
       "requiresWrite": true,
@@ -172,7 +172,7 @@
       }
     },
     {
-      "id": "power_off_server",
+      "id": "hetzner__power_off_server",
       "name": "Power Off Server",
       "description": "Cut power to a server by ID (hard power off, like pulling the plug; data may be lost if the OS is running)",
       "requiresWrite": true,
@@ -193,7 +193,7 @@
       }
     },
     {
-      "id": "list_images",
+      "id": "hetzner__list_images",
       "name": "List Images",
       "description": "List available images (system images, backups, snapshots) usable for server creation",
       "requiresWrite": false,
@@ -248,7 +248,7 @@
       }
     },
     {
-      "id": "list_server_types",
+      "id": "hetzner__list_server_types",
       "name": "List Server Types",
       "description": "List available server types (sizes) with cores, memory, disk, and pricing",
       "requiresWrite": false,
@@ -293,7 +293,7 @@
       }
     },
     {
-      "id": "shutdown_server",
+      "id": "hetzner__shutdown_server",
       "name": "Shutdown Server",
       "description": "Gracefully shut down a server by sending an ACPI shutdown signal to the OS — prefer this over Power Off for running workloads",
       "requiresWrite": true,
@@ -314,7 +314,7 @@
       }
     },
     {
-      "id": "reboot_server",
+      "id": "hetzner__reboot_server",
       "name": "Reboot Server",
       "description": "Gracefully reboot a server by sending an ACPI reboot signal to the OS",
       "requiresWrite": true,
@@ -335,7 +335,7 @@
       }
     },
     {
-      "id": "list_ssh_keys",
+      "id": "hetzner__list_ssh_keys",
       "name": "List SSH Keys",
       "description": "List SSH keys in the project — use these IDs or names in the ssh_keys field of Create Server",
       "requiresWrite": false,

--- a/cli/templates/integrations/hubspot/connector.json
+++ b/cli/templates/integrations/hubspot/connector.json
@@ -46,7 +46,7 @@
   ],
   "tools": [
     {
-      "id": "list_forms",
+      "id": "hubspot__list_forms",
       "name": "List Forms",
       "description": "List HubSpot forms so agents can find a form ID before reading submissions",
       "requiresWrite": false,
@@ -81,7 +81,7 @@
       }
     },
     {
-      "id": "list_form_submissions",
+      "id": "hubspot__list_form_submissions",
       "name": "List Form Submissions",
       "description": "List recent submissions for a HubSpot form in reverse chronological order",
       "requiresWrite": false,
@@ -113,7 +113,7 @@
       }
     },
     {
-      "id": "get_contact",
+      "id": "hubspot__get_contact",
       "name": "Get Contact",
       "description": "Get a HubSpot contact by ID or email before scoring, dedupe, or updates",
       "requiresWrite": false,
@@ -152,7 +152,7 @@
       }
     },
     {
-      "id": "search_contacts",
+      "id": "hubspot__search_contacts",
       "name": "Search Contacts",
       "description": "Search HubSpot contacts by filters for lead research and CRM lookup",
       "requiresWrite": false,
@@ -192,7 +192,7 @@
       }
     },
     {
-      "id": "create_contact",
+      "id": "hubspot__create_contact",
       "name": "Create Contact",
       "description": "Create a HubSpot contact from form submission or researched lead data",
       "requiresWrite": true,
@@ -209,7 +209,7 @@
       }
     },
     {
-      "id": "update_contact",
+      "id": "hubspot__update_contact",
       "name": "Update Contact",
       "description": "Update HubSpot contact properties, including lead score or research notes",
       "requiresWrite": true,
@@ -239,7 +239,7 @@
       }
     },
     {
-      "id": "get_lead",
+      "id": "hubspot__get_lead",
       "name": "Get Lead",
       "description": "Get a HubSpot CRM lead before scoring, routing, or updates",
       "requiresWrite": false,
@@ -273,7 +273,7 @@
       }
     },
     {
-      "id": "list_leads",
+      "id": "hubspot__list_leads",
       "name": "List Leads",
       "description": "List HubSpot CRM leads for scoring, spreadsheet updates, or research workflows",
       "requiresWrite": false,
@@ -315,7 +315,7 @@
       }
     },
     {
-      "id": "search_leads",
+      "id": "hubspot__search_leads",
       "name": "Search Leads",
       "description": "Search HubSpot CRM leads for dedupe, scoring, and routing workflows",
       "requiresWrite": false,
@@ -355,7 +355,7 @@
       }
     },
     {
-      "id": "create_lead",
+      "id": "hubspot__create_lead",
       "name": "Create Lead",
       "description": "Create a HubSpot CRM lead associated with an existing contact or company",
       "requiresWrite": true,
@@ -376,7 +376,7 @@
       }
     },
     {
-      "id": "update_lead",
+      "id": "hubspot__update_lead",
       "name": "Update Lead",
       "description": "Update a HubSpot CRM lead with score, qualification, owner, or research fields",
       "requiresWrite": true,
@@ -401,7 +401,7 @@
       }
     },
     {
-      "id": "get_company",
+      "id": "hubspot__get_company",
       "name": "Get Company",
       "description": "Get a HubSpot company by ID or domain before lead research or association",
       "requiresWrite": false,
@@ -440,7 +440,7 @@
       }
     },
     {
-      "id": "search_companies",
+      "id": "hubspot__search_companies",
       "name": "Search Companies",
       "description": "Search HubSpot companies by domain, name, or firmographic properties",
       "requiresWrite": false,
@@ -480,7 +480,7 @@
       }
     },
     {
-      "id": "create_company",
+      "id": "hubspot__create_company",
       "name": "Create Company",
       "description": "Create a HubSpot company for researched lead accounts",
       "requiresWrite": true,
@@ -497,7 +497,7 @@
       }
     },
     {
-      "id": "update_company",
+      "id": "hubspot__update_company",
       "name": "Update Company",
       "description": "Update HubSpot company properties with research or enrichment data",
       "requiresWrite": true,
@@ -527,7 +527,7 @@
       }
     },
     {
-      "id": "list_properties",
+      "id": "hubspot__list_properties",
       "name": "List Properties",
       "description": "List HubSpot CRM properties for contacts, leads, or companies before updating custom fields",
       "requiresWrite": false,
@@ -559,7 +559,7 @@
       }
     },
     {
-      "id": "list_owners",
+      "id": "hubspot__list_owners",
       "name": "List Owners",
       "description": "List HubSpot owners so agents can assign or route contacts and leads",
       "requiresWrite": false,
@@ -596,7 +596,7 @@
       }
     },
     {
-      "id": "list_association_labels",
+      "id": "hubspot__list_association_labels",
       "name": "List Association Labels",
       "description": "List HubSpot association labels between CRM object types before associating records",
       "requiresWrite": false,
@@ -623,7 +623,7 @@
       }
     },
     {
-      "id": "list_associations",
+      "id": "hubspot__list_associations",
       "name": "List Associations",
       "description": "List records associated with a HubSpot CRM record",
       "requiresWrite": false,
@@ -667,7 +667,7 @@
       }
     },
     {
-      "id": "associate_records",
+      "id": "hubspot__associate_records",
       "name": "Associate Records",
       "description": "Create a default HubSpot association between two CRM records",
       "requiresWrite": true,
@@ -703,7 +703,7 @@
       }
     },
     {
-      "id": "remove_association",
+      "id": "hubspot__remove_association",
       "name": "Remove Association",
       "description": "Remove all HubSpot associations between two CRM records",
       "requiresWrite": true,

--- a/cli/templates/integrations/huggingface/connector.json
+++ b/cli/templates/integrations/huggingface/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "search_models",
+      "id": "huggingface__search_models",
       "name": "Search Models",
       "description": "Search models on the Hugging Face Hub",
       "requiresWrite": false,
@@ -77,7 +77,7 @@
       }
     },
     {
-      "id": "get_model",
+      "id": "huggingface__get_model",
       "name": "Get Model",
       "description": "Get details about a model repository on the Hub",
       "requiresWrite": false,
@@ -101,7 +101,7 @@
       }
     },
     {
-      "id": "search_datasets",
+      "id": "huggingface__search_datasets",
       "name": "Search Datasets",
       "description": "Search datasets on the Hugging Face Hub",
       "requiresWrite": false,
@@ -129,7 +129,7 @@
       }
     },
     {
-      "id": "whoami",
+      "id": "huggingface__whoami",
       "name": "Who Am I",
       "description": "Get the account and permissions associated with the access token",
       "requiresWrite": false,
@@ -139,7 +139,7 @@
       }
     },
     {
-      "id": "create_chat_completion",
+      "id": "huggingface__create_chat_completion",
       "name": "Create Chat Completion",
       "description": "Generate a chat completion through the Hugging Face Inference Providers router (OpenAI-compatible)",
       "requiresWrite": true,

--- a/cli/templates/integrations/intercom/connector.json
+++ b/cli/templates/integrations/intercom/connector.json
@@ -36,7 +36,7 @@
   ],
   "tools": [
     {
-      "id": "list_contacts",
+      "id": "intercom__list_contacts",
       "name": "List Contacts",
       "description": "List contacts (users and leads) in the Intercom workspace",
       "requiresWrite": false,
@@ -80,7 +80,7 @@
       }
     },
     {
-      "id": "search_contacts",
+      "id": "intercom__search_contacts",
       "name": "Search Contacts",
       "description": "Search Intercom contacts with a field/operator/value query",
       "requiresWrite": false,
@@ -101,7 +101,7 @@
       }
     },
     {
-      "id": "get_contact",
+      "id": "intercom__get_contact",
       "name": "Get Contact",
       "description": "Get a single Intercom contact by ID",
       "requiresWrite": false,
@@ -119,7 +119,7 @@
       }
     },
     {
-      "id": "list_conversations",
+      "id": "intercom__list_conversations",
       "name": "List Conversations",
       "description": "List conversations in the Intercom workspace, newest first",
       "requiresWrite": false,
@@ -142,7 +142,7 @@
       }
     },
     {
-      "id": "reply_to_conversation",
+      "id": "intercom__reply_to_conversation",
       "name": "Reply To Conversation",
       "description": "Reply to an Intercom conversation as an admin (comment or internal note)",
       "requiresWrite": true,
@@ -184,7 +184,7 @@
       }
     },
     {
-      "id": "list_articles",
+      "id": "intercom__list_articles",
       "name": "List Articles",
       "description": "List help center articles in the Intercom workspace",
       "requiresWrite": false,

--- a/cli/templates/integrations/ionos/connector.json
+++ b/cli/templates/integrations/ionos/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "list_datacenters",
+      "id": "ionos__list_datacenters",
       "name": "List Data Centers",
       "description": "List virtual data centers in the account; each data center contains servers, volumes, and networks",
       "requiresWrite": false,
@@ -71,7 +71,7 @@
       }
     },
     {
-      "id": "list_servers",
+      "id": "ionos__list_servers",
       "name": "List Servers",
       "description": "List servers inside a virtual data center",
       "requiresWrite": false,
@@ -120,7 +120,7 @@
       }
     },
     {
-      "id": "get_server",
+      "id": "ionos__get_server",
       "name": "Get Server",
       "description": "Get a server in a data center, including name, vmState, cores, RAM, and boot device",
       "requiresWrite": false,
@@ -150,7 +150,7 @@
       }
     },
     {
-      "id": "start_server",
+      "id": "ionos__start_server",
       "name": "Start Server",
       "description": "Start (power on) an Enterprise server; CUBE servers cannot be started with this endpoint (they use suspend/resume instead)",
       "requiresWrite": true,
@@ -174,7 +174,7 @@
       }
     },
     {
-      "id": "stop_server",
+      "id": "ionos__stop_server",
       "name": "Stop Server",
       "description": "Stop (power off) an Enterprise server; the server is forcefully powered off and billing for compute stops; public IPv4 addresses that are not reserved are returned to the IPv4 pool (reserved IPs are kept). CUBE servers cannot be stopped with this endpoint (they use suspend/resume instead)",
       "requiresWrite": true,
@@ -198,7 +198,7 @@
       }
     },
     {
-      "id": "reboot_server",
+      "id": "ionos__reboot_server",
       "name": "Reboot Server",
       "description": "Force a hard reboot of a server (equivalent to powering it down and back on) — recovers hung servers without a separate stop/start cycle; not a graceful OS reboot",
       "requiresWrite": true,
@@ -222,7 +222,7 @@
       }
     },
     {
-      "id": "get_request_status",
+      "id": "ionos__get_request_status",
       "name": "Get Request Status",
       "description": "Poll the status of an asynchronous write operation (202 Accepted responses) until it reports DONE or FAILED; the request ID comes from the Location response header of the write call",
       "requiresWrite": false,

--- a/cli/templates/integrations/jira/connector.json
+++ b/cli/templates/integrations/jira/connector.json
@@ -45,7 +45,7 @@
   ],
   "tools": [
     {
-      "id": "list_sites",
+      "id": "jira__list_sites",
       "name": "List Atlassian Sites",
       "description": "List Atlassian cloud sites/resources the OAuth token can access; use the returned id as cloudId for Jira and Confluence tools",
       "requiresWrite": false,
@@ -163,7 +163,7 @@
       }
     },
     {
-      "id": "list_projects",
+      "id": "jira__list_projects",
       "name": "List Projects",
       "description": "List all accessible Jira projects",
       "requiresWrite": false,
@@ -306,7 +306,7 @@
       }
     },
     {
-      "id": "get_project",
+      "id": "jira__get_project",
       "name": "Get Project",
       "description": "Get detailed information about a Jira project",
       "requiresWrite": false,
@@ -330,7 +330,7 @@
       }
     },
     {
-      "id": "search_issues",
+      "id": "jira__search_issues",
       "name": "Search Issues",
       "description": "Search Jira issues using JQL (Jira Query Language)",
       "requiresWrite": false,
@@ -441,7 +441,7 @@
       }
     },
     {
-      "id": "get_issue",
+      "id": "jira__get_issue",
       "name": "Get Issue",
       "description": "Get detailed information about a specific Jira issue",
       "requiresWrite": false,
@@ -470,7 +470,7 @@
       }
     },
     {
-      "id": "create_issue",
+      "id": "jira__create_issue",
       "name": "Create Issue",
       "description": "Create a new Jira issue in a project",
       "requiresWrite": true,
@@ -495,7 +495,7 @@
       }
     },
     {
-      "id": "update_issue",
+      "id": "jira__update_issue",
       "name": "Update Issue",
       "description": "Update an existing Jira issue (status, fields, etc.)",
       "requiresWrite": true,
@@ -529,7 +529,7 @@
       }
     },
     {
-      "id": "list_comments",
+      "id": "jira__list_comments",
       "name": "List Comments",
       "description": "List comments on a Jira issue",
       "requiresWrite": false,
@@ -605,7 +605,7 @@
       }
     },
     {
-      "id": "add_comment",
+      "id": "jira__add_comment",
       "name": "Add Comment",
       "description": "Add a comment to a Jira issue",
       "requiresWrite": true,
@@ -636,7 +636,7 @@
       }
     },
     {
-      "id": "get_transitions",
+      "id": "jira__get_transitions",
       "name": "Get Transitions",
       "description": "List available workflow transitions for a Jira issue",
       "requiresWrite": false,
@@ -660,7 +660,7 @@
       }
     },
     {
-      "id": "transition_issue",
+      "id": "jira__transition_issue",
       "name": "Transition Issue",
       "description": "Move a Jira issue to a new workflow status. First call get_transitions to get valid transition IDs, then pass the ID here.",
       "requiresWrite": true,
@@ -699,7 +699,7 @@
       }
     },
     {
-      "id": "search_users",
+      "id": "jira__search_users",
       "name": "Search Users",
       "description": "Search Jira users by name or email to find the accountId needed for assigning issues",
       "requiresWrite": false,

--- a/cli/templates/integrations/jotform/connector.json
+++ b/cli/templates/integrations/jotform/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_forms",
+      "id": "jotform__list_forms",
       "name": "List Forms",
       "description": "List forms owned by the account",
       "requiresWrite": false,
@@ -80,7 +80,7 @@
       }
     },
     {
-      "id": "get_form",
+      "id": "jotform__get_form",
       "name": "Get Form",
       "description": "Get basic details of a form",
       "requiresWrite": false,
@@ -101,7 +101,7 @@
       }
     },
     {
-      "id": "get_form_questions",
+      "id": "jotform__get_form_questions",
       "name": "Get Form Questions",
       "description": "List the questions/fields on a form",
       "requiresWrite": false,
@@ -122,7 +122,7 @@
       }
     },
     {
-      "id": "list_submissions",
+      "id": "jotform__list_submissions",
       "name": "List Submissions",
       "description": "List submissions for a form",
       "requiresWrite": false,
@@ -166,7 +166,7 @@
       }
     },
     {
-      "id": "get_submission",
+      "id": "jotform__get_submission",
       "name": "Get Submission",
       "description": "Get a single submission with its answers",
       "requiresWrite": false,
@@ -187,7 +187,7 @@
       }
     },
     {
-      "id": "get_user",
+      "id": "jotform__get_user",
       "name": "Get User",
       "description": "Get the authenticated account profile and usage",
       "requiresWrite": false,

--- a/cli/templates/integrations/klarna/connector.json
+++ b/cli/templates/integrations/klarna/connector.json
@@ -33,7 +33,7 @@
   ],
   "tools": [
     {
-      "id": "get_order",
+      "id": "klarna__get_order",
       "name": "Get Order",
       "description": "Retrieve a Klarna order including status, amounts, order lines, captures, and refunds",
       "requiresWrite": false,
@@ -57,7 +57,7 @@
       }
     },
     {
-      "id": "capture_order",
+      "id": "klarna__capture_order",
       "name": "Capture Order",
       "description": "Capture a full or partial amount of an authorized order (activates the payment after fulfillment)",
       "requiresWrite": true,
@@ -96,7 +96,7 @@
       }
     },
     {
-      "id": "refund_order",
+      "id": "klarna__refund_order",
       "name": "Refund Order",
       "description": "Refund a full or partial captured amount back to the customer",
       "requiresWrite": true,
@@ -131,7 +131,7 @@
       }
     },
     {
-      "id": "cancel_order",
+      "id": "klarna__cancel_order",
       "name": "Cancel Order",
       "description": "Cancel an authorized order that has not been captured, releasing the full authorization",
       "requiresWrite": true,
@@ -155,7 +155,7 @@
       }
     },
     {
-      "id": "release_remaining_authorization",
+      "id": "klarna__release_remaining_authorization",
       "name": "Release Remaining Authorization",
       "description": "Release the remaining (uncaptured) authorized amount of an order after the final partial capture — the standard end-of-fulfillment step that frees the customer's remaining authorization",
       "requiresWrite": true,
@@ -179,7 +179,7 @@
       }
     },
     {
-      "id": "get_capture",
+      "id": "klarna__get_capture",
       "name": "Get Capture",
       "description": "Get a single capture of an order with its status and amounts",
       "requiresWrite": false,

--- a/cli/templates/integrations/klaviyo/connector.json
+++ b/cli/templates/integrations/klaviyo/connector.json
@@ -27,7 +27,7 @@
   ],
   "tools": [
     {
-      "id": "list_profiles",
+      "id": "klaviyo__list_profiles",
       "name": "List Profiles",
       "description": "List customer profiles",
       "requiresWrite": false,
@@ -75,7 +75,7 @@
       }
     },
     {
-      "id": "get_profile",
+      "id": "klaviyo__get_profile",
       "name": "Get Profile",
       "description": "Get a customer profile by ID",
       "requiresWrite": false,
@@ -102,7 +102,7 @@
       }
     },
     {
-      "id": "create_profile",
+      "id": "klaviyo__create_profile",
       "name": "Create Profile",
       "description": "Create a new customer profile",
       "requiresWrite": true,
@@ -130,7 +130,7 @@
       }
     },
     {
-      "id": "list_lists",
+      "id": "klaviyo__list_lists",
       "name": "List Lists",
       "description": "List marketing lists",
       "requiresWrite": false,
@@ -166,7 +166,7 @@
       }
     },
     {
-      "id": "list_segments",
+      "id": "klaviyo__list_segments",
       "name": "List Segments",
       "description": "List audience segments",
       "requiresWrite": false,
@@ -190,7 +190,7 @@
       }
     },
     {
-      "id": "list_metrics",
+      "id": "klaviyo__list_metrics",
       "name": "List Metrics",
       "description": "List tracked event metrics (e.g. Placed Order, Opened Email)",
       "requiresWrite": false,
@@ -214,7 +214,7 @@
       }
     },
     {
-      "id": "create_event",
+      "id": "klaviyo__create_event",
       "name": "Create Event",
       "description": "Track a custom event for a profile",
       "requiresWrite": true,

--- a/cli/templates/integrations/langfuse/connector.json
+++ b/cli/templates/integrations/langfuse/connector.json
@@ -33,7 +33,7 @@
   ],
   "tools": [
     {
-      "id": "list_traces",
+      "id": "langfuse__list_traces",
       "name": "List Traces",
       "description": "List traces in the Langfuse project with optional filters",
       "requiresWrite": false,
@@ -109,7 +109,7 @@
       }
     },
     {
-      "id": "get_trace",
+      "id": "langfuse__get_trace",
       "name": "Get Trace",
       "description": "Get a single trace with its full observation tree and scores",
       "requiresWrite": false,
@@ -133,7 +133,7 @@
       }
     },
     {
-      "id": "list_observations",
+      "id": "langfuse__list_observations",
       "name": "List Observations",
       "description": "List observations (spans, generations, events) with optional filters",
       "requiresWrite": false,
@@ -183,7 +183,7 @@
       }
     },
     {
-      "id": "create_score",
+      "id": "langfuse__create_score",
       "name": "Create Score",
       "description": "Attach a score (evaluation result) to a trace or observation",
       "requiresWrite": true,

--- a/cli/templates/integrations/langsmith/connector.json
+++ b/cli/templates/integrations/langsmith/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_projects",
+      "id": "langsmith__list_projects",
       "name": "List Projects",
       "description": "List tracing projects (tracer sessions) in your LangSmith workspace",
       "requiresWrite": false,
@@ -69,7 +69,7 @@
       }
     },
     {
-      "id": "query_runs",
+      "id": "langsmith__query_runs",
       "name": "Query Runs",
       "description": "Query traced runs with filters (project, trace filter expressions, root runs only)",
       "requiresWrite": false,
@@ -107,7 +107,7 @@
       }
     },
     {
-      "id": "get_run",
+      "id": "langsmith__get_run",
       "name": "Get Run",
       "description": "Get full details of a single run, including inputs, outputs, and errors",
       "requiresWrite": false,
@@ -125,7 +125,7 @@
       }
     },
     {
-      "id": "list_datasets",
+      "id": "langsmith__list_datasets",
       "name": "List Datasets",
       "description": "List evaluation datasets in your LangSmith workspace",
       "requiresWrite": false,
@@ -154,7 +154,7 @@
       }
     },
     {
-      "id": "list_examples",
+      "id": "langsmith__list_examples",
       "name": "List Examples",
       "description": "List examples in a LangSmith dataset",
       "requiresWrite": false,

--- a/cli/templates/integrations/launchdarkly/connector.json
+++ b/cli/templates/integrations/launchdarkly/connector.json
@@ -25,7 +25,7 @@
   ],
   "tools": [
     {
-      "id": "list_projects",
+      "id": "launchdarkly__list_projects",
       "name": "List Projects",
       "description": "List projects in the LaunchDarkly account",
       "requiresWrite": false,
@@ -53,7 +53,7 @@
       }
     },
     {
-      "id": "list_flags",
+      "id": "launchdarkly__list_flags",
       "name": "List Feature Flags",
       "description": "List feature flags in a project, optionally scoped to one environment",
       "requiresWrite": false,
@@ -107,7 +107,7 @@
       }
     },
     {
-      "id": "get_flag",
+      "id": "launchdarkly__get_flag",
       "name": "Get Feature Flag",
       "description": "Get a feature flag including its variations and per-environment configuration",
       "requiresWrite": false,
@@ -136,7 +136,7 @@
       }
     },
     {
-      "id": "list_environments",
+      "id": "launchdarkly__list_environments",
       "name": "List Environments",
       "description": "List environments in a LaunchDarkly project",
       "requiresWrite": false,
@@ -165,7 +165,7 @@
       }
     },
     {
-      "id": "toggle_flag",
+      "id": "launchdarkly__toggle_flag",
       "name": "Toggle Feature Flag",
       "description": "Turn a feature flag on or off in one environment using a semantic patch instruction",
       "requiresWrite": true,

--- a/cli/templates/integrations/lever/connector.json
+++ b/cli/templates/integrations/lever/connector.json
@@ -45,7 +45,7 @@
   ],
   "tools": [
     {
-      "id": "list_opportunities",
+      "id": "lever__list_opportunities",
       "name": "List Opportunities",
       "description": "List candidate opportunities",
       "requiresWrite": false,
@@ -118,7 +118,7 @@
       }
     },
     {
-      "id": "get_opportunity",
+      "id": "lever__get_opportunity",
       "name": "Get Opportunity",
       "description": "Get a single opportunity",
       "requiresWrite": false,
@@ -144,7 +144,7 @@
       }
     },
     {
-      "id": "list_postings",
+      "id": "lever__list_postings",
       "name": "List Postings",
       "description": "List job postings",
       "requiresWrite": false,
@@ -176,7 +176,7 @@
       }
     },
     {
-      "id": "get_posting",
+      "id": "lever__get_posting",
       "name": "Get Posting",
       "description": "Get a single job posting",
       "requiresWrite": false,
@@ -197,7 +197,7 @@
       }
     },
     {
-      "id": "list_stages",
+      "id": "lever__list_stages",
       "name": "List Stages",
       "description": "List pipeline stages",
       "requiresWrite": false,

--- a/cli/templates/integrations/lexoffice/connector.json
+++ b/cli/templates/integrations/lexoffice/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "list_vouchers",
+      "id": "lexoffice__list_vouchers",
       "name": "List Vouchers",
       "description": "List and filter bookkeeping vouchers (sales and purchase invoices, credit notes) via the voucherlist, e.g. to find open or overdue invoices",
       "requiresWrite": false,
@@ -94,7 +94,7 @@
       }
     },
     {
-      "id": "get_invoice",
+      "id": "lexoffice__get_invoice",
       "name": "Get Invoice",
       "description": "Retrieve a single invoice with line items, totals, tax conditions, and payment status",
       "requiresWrite": false,
@@ -112,7 +112,7 @@
       }
     },
     {
-      "id": "create_invoice",
+      "id": "lexoffice__create_invoice",
       "name": "Create Invoice",
       "description": "Create a sales invoice. Created as an editable draft by default; set finalize=true to immediately open it",
       "requiresWrite": true,
@@ -173,7 +173,7 @@
       }
     },
     {
-      "id": "list_contacts",
+      "id": "lexoffice__list_contacts",
       "name": "List Contacts",
       "description": "List and filter customers and vendors, e.g. to find the contactId for an invoice",
       "requiresWrite": false,
@@ -225,7 +225,7 @@
       }
     },
     {
-      "id": "create_contact",
+      "id": "lexoffice__create_contact",
       "name": "Create Contact",
       "description": "Create a customer or vendor contact for use on invoices and vouchers",
       "requiresWrite": true,
@@ -272,7 +272,7 @@
       }
     },
     {
-      "id": "upload_voucher_file",
+      "id": "lexoffice__upload_voucher_file",
       "name": "Upload Voucher File",
       "description": "Upload a receipt image or invoice file (pdf, jpg, png, xml; max 5 MB) for bookkeeping; returns the file id and the id of the voucher created for it",
       "requiresWrite": true,
@@ -304,7 +304,7 @@
       }
     },
     {
-      "id": "download_file",
+      "id": "lexoffice__download_file",
       "name": "Download File",
       "description": "Download an uploaded bookkeeping voucher file (receipt/invoice image) as binary data by its file id; Content-Type and Content-Disposition response headers carry the MIME type and suggested filename. For sales voucher documents prefer the document render flow.",
       "requiresWrite": false,
@@ -322,7 +322,7 @@
       }
     },
     {
-      "id": "get_invoice_document",
+      "id": "lexoffice__get_invoice_document",
       "name": "Get Invoice Document",
       "description": "Trigger PDF rendering for an invoice and return its documentFileId, which can then be downloaded via Download File. Required for invoices created through the API with status open; draft invoices have no document file and are rejected with 406.",
       "requiresWrite": false,
@@ -340,7 +340,7 @@
       }
     },
     {
-      "id": "get_payments",
+      "id": "lexoffice__get_payments",
       "name": "Get Payments",
       "description": "Get the payment status of an invoice or voucher: open amount, paid date, and payment items — the reliable way to check who actually paid",
       "requiresWrite": false,

--- a/cli/templates/integrations/linear/connector.json
+++ b/cli/templates/integrations/linear/connector.json
@@ -39,7 +39,7 @@
   ],
   "tools": [
     {
-      "id": "search_issues",
+      "id": "linear__search_issues",
       "name": "Search Issues",
       "description": "Search for Linear issues by title or description",
       "requiresWrite": false,
@@ -112,7 +112,7 @@
       }
     },
     {
-      "id": "get_issue",
+      "id": "linear__get_issue",
       "name": "Get Issue",
       "description": "Get detailed information about a specific Linear issue",
       "requiresWrite": false,
@@ -135,7 +135,7 @@
       }
     },
     {
-      "id": "create_issue",
+      "id": "linear__create_issue",
       "name": "Create Issue",
       "description": "Create a new Linear issue in a team",
       "requiresWrite": true,
@@ -174,7 +174,7 @@
       }
     },
     {
-      "id": "update_issue",
+      "id": "linear__update_issue",
       "name": "Update Issue",
       "description": "Update the status, assignee, or other properties of an issue",
       "requiresWrite": true,
@@ -212,7 +212,7 @@
       }
     },
     {
-      "id": "delete_issue",
+      "id": "linear__delete_issue",
       "name": "Delete Issue",
       "description": "Archive a Linear issue. By default this is non-permanent so canary-created issues do not remain active.",
       "requiresWrite": true,
@@ -241,7 +241,7 @@
       }
     },
     {
-      "id": "list_projects",
+      "id": "linear__list_projects",
       "name": "List Projects",
       "description": "List all projects in the workspace",
       "requiresWrite": false,
@@ -369,7 +369,7 @@
       }
     },
     {
-      "id": "list_teams",
+      "id": "linear__list_teams",
       "name": "List Teams",
       "description": "List Linear teams in the workspace so issues can be created in the right team",
       "requiresWrite": false,
@@ -497,7 +497,7 @@
       }
     },
     {
-      "id": "list_workflow_states",
+      "id": "linear__list_workflow_states",
       "name": "List Workflow States",
       "description": "List workflow states for a Linear team so issues can be moved to the right status",
       "requiresWrite": false,
@@ -625,7 +625,7 @@
       }
     },
     {
-      "id": "list_users",
+      "id": "linear__list_users",
       "name": "List Users",
       "description": "List Linear users in the workspace so issues can be assigned to the right person",
       "requiresWrite": false,
@@ -680,7 +680,7 @@
       }
     },
     {
-      "id": "add_comment",
+      "id": "linear__add_comment",
       "name": "Add Comment",
       "description": "Add a comment to a Linear issue",
       "requiresWrite": true,
@@ -709,7 +709,7 @@
       }
     },
     {
-      "id": "list_issue_labels",
+      "id": "linear__list_issue_labels",
       "name": "List Issue Labels",
       "description": "List Linear issue labels so the right label IDs can be applied when creating or updating issues",
       "requiresWrite": false,

--- a/cli/templates/integrations/mailchimp/connector.json
+++ b/cli/templates/integrations/mailchimp/connector.json
@@ -36,7 +36,7 @@
   ],
   "tools": [
     {
-      "id": "list_audiences",
+      "id": "mailchimp__list_audiences",
       "name": "List Audiences",
       "description": "List audiences (lists) in the Mailchimp account",
       "requiresWrite": false,
@@ -80,7 +80,7 @@
       }
     },
     {
-      "id": "list_members",
+      "id": "mailchimp__list_members",
       "name": "List Members",
       "description": "List members of a Mailchimp audience",
       "requiresWrite": false,
@@ -121,7 +121,7 @@
       }
     },
     {
-      "id": "get_member",
+      "id": "mailchimp__get_member",
       "name": "Get Member",
       "description": "Get a single audience member by email (MD5 hash of the lowercase address) or contact ID",
       "requiresWrite": false,
@@ -151,7 +151,7 @@
       }
     },
     {
-      "id": "add_member",
+      "id": "mailchimp__add_member",
       "name": "Add Member",
       "description": "Add a new member to a Mailchimp audience",
       "requiresWrite": true,
@@ -196,7 +196,7 @@
       }
     },
     {
-      "id": "list_campaigns",
+      "id": "mailchimp__list_campaigns",
       "name": "List Campaigns",
       "description": "List campaigns in the Mailchimp account",
       "requiresWrite": false,

--- a/cli/templates/integrations/metabase/connector.json
+++ b/cli/templates/integrations/metabase/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_databases",
+      "id": "metabase__list_databases",
       "name": "List Databases",
       "description": "List databases connected to the Metabase instance",
       "requiresWrite": false,
@@ -75,7 +75,7 @@
       }
     },
     {
-      "id": "list_cards",
+      "id": "metabase__list_cards",
       "name": "List Questions",
       "description": "List saved questions (cards) on the Metabase instance",
       "requiresWrite": false,
@@ -98,7 +98,7 @@
       }
     },
     {
-      "id": "run_card_query",
+      "id": "metabase__run_card_query",
       "name": "Run Question Query",
       "description": "Execute a saved question (card) and return its query results",
       "requiresWrite": false,
@@ -128,7 +128,7 @@
       }
     },
     {
-      "id": "search",
+      "id": "metabase__search",
       "name": "Search",
       "description": "Search questions, dashboards, collections, and tables across the instance",
       "requiresWrite": false,
@@ -157,7 +157,7 @@
       }
     },
     {
-      "id": "get_dashboard",
+      "id": "metabase__get_dashboard",
       "name": "Get Dashboard",
       "description": "Get a dashboard and its cards by ID",
       "requiresWrite": false,
@@ -181,7 +181,7 @@
       }
     },
     {
-      "id": "list_collections",
+      "id": "metabase__list_collections",
       "name": "List Collections",
       "description": "List collections that organize questions and dashboards",
       "requiresWrite": false,

--- a/cli/templates/integrations/mindee/connector.json
+++ b/cli/templates/integrations/mindee/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "parse_invoice",
+      "id": "mindee__parse_invoice",
       "name": "Parse Invoice",
       "description": "Extract structured fields (supplier, customer, line items, totals, taxes, dates, payment details) from an invoice PDF or image using the Invoice OCR model. Consumes a page of your Mindee quota per call.",
       "requiresWrite": true,
@@ -50,7 +50,7 @@
       }
     },
     {
-      "id": "parse_receipt",
+      "id": "mindee__parse_receipt",
       "name": "Parse Receipt",
       "description": "Extract structured fields (merchant, date, time, category, line items, taxes, total amounts, tip) from an expense receipt photo or PDF using the Receipt OCR model. Consumes a page of your Mindee quota per call.",
       "requiresWrite": true,
@@ -72,7 +72,7 @@
       }
     },
     {
-      "id": "parse_financial_document",
+      "id": "mindee__parse_financial_document",
       "name": "Parse Financial Document",
       "description": "Parse a document that may be either an invoice or a receipt: the Financial Document model classifies it and returns the union of invoice and receipt fields. Use this when the document type is unknown. Consumes a page of your Mindee quota per call.",
       "requiresWrite": true,

--- a/cli/templates/integrations/mistral/connector.json
+++ b/cli/templates/integrations/mistral/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_models",
+      "id": "mistral__list_models",
       "name": "List Models",
       "description": "List the Mistral models available to the API key",
       "requiresWrite": false,
@@ -50,7 +50,7 @@
       }
     },
     {
-      "id": "get_model",
+      "id": "mistral__get_model",
       "name": "Get Model",
       "description": "Get details about a specific Mistral model",
       "requiresWrite": false,
@@ -68,7 +68,7 @@
       }
     },
     {
-      "id": "create_chat_completion",
+      "id": "mistral__create_chat_completion",
       "name": "Create Chat Completion",
       "description": "Generate a chat completion from a list of messages",
       "requiresWrite": true,
@@ -98,7 +98,7 @@
       }
     },
     {
-      "id": "create_embedding",
+      "id": "mistral__create_embedding",
       "name": "Create Embedding",
       "description": "Create embedding vectors for input text",
       "requiresWrite": true,

--- a/cli/templates/integrations/mixpanel/connector.json
+++ b/cli/templates/integrations/mixpanel/connector.json
@@ -54,13 +54,13 @@
   ],
   "tools": [
     {
-      "id": "track_event",
+      "id": "mixpanel__track_event",
       "name": "Track Event",
       "description": "Track a custom event in Mixpanel with properties",
       "requiresWrite": true
     },
     {
-      "id": "query_events",
+      "id": "mixpanel__query_events",
       "name": "Query Events",
       "description": "Query and export event data from Mixpanel",
       "requiresWrite": false,
@@ -112,7 +112,7 @@
       }
     },
     {
-      "id": "get_funnel",
+      "id": "mixpanel__get_funnel",
       "name": "Get Funnel",
       "description": "Retrieve funnel analysis data to understand conversion rates",
       "requiresWrite": false,
@@ -159,7 +159,7 @@
       }
     },
     {
-      "id": "list_funnels",
+      "id": "mixpanel__list_funnels",
       "name": "List Funnels",
       "description": "List saved funnels with their names and funnel IDs",
       "requiresWrite": false,
@@ -183,7 +183,7 @@
       }
     },
     {
-      "id": "get_retention",
+      "id": "mixpanel__get_retention",
       "name": "Get Retention",
       "description": "Analyze user retention cohorts over time",
       "requiresWrite": false,
@@ -239,7 +239,7 @@
       }
     },
     {
-      "id": "list_cohorts",
+      "id": "mixpanel__list_cohorts",
       "name": "List Cohorts",
       "description": "List all user cohorts defined in your Mixpanel project",
       "requiresWrite": false,

--- a/cli/templates/integrations/mollie/connector.json
+++ b/cli/templates/integrations/mollie/connector.json
@@ -29,7 +29,7 @@
   ],
   "tools": [
     {
-      "id": "list_payments",
+      "id": "mollie__list_payments",
       "name": "List Payments",
       "description": "List Mollie payments in reverse chronological order to review recent transactions",
       "requiresWrite": false,
@@ -60,7 +60,7 @@
       }
     },
     {
-      "id": "get_payment",
+      "id": "mollie__get_payment",
       "name": "Get Payment",
       "description": "Retrieve a single Mollie payment with its current status and details",
       "requiresWrite": false,
@@ -83,7 +83,7 @@
       }
     },
     {
-      "id": "create_payment",
+      "id": "mollie__create_payment",
       "name": "Create Payment",
       "description": "Create a Mollie payment and get a checkout URL to send to the customer",
       "requiresWrite": true,
@@ -126,7 +126,7 @@
       }
     },
     {
-      "id": "list_customers",
+      "id": "mollie__list_customers",
       "name": "List Customers",
       "description": "List Mollie customers to find customer IDs for payments or refund context",
       "requiresWrite": false,
@@ -152,7 +152,7 @@
       }
     },
     {
-      "id": "list_payment_methods",
+      "id": "mollie__list_payment_methods",
       "name": "List Payment Methods",
       "description": "List the payment methods enabled on your Mollie profile, e.g. to pick a valid method for a new payment",
       "requiresWrite": false,
@@ -182,7 +182,7 @@
       }
     },
     {
-      "id": "create_payment_link",
+      "id": "mollie__create_payment_link",
       "name": "Create Payment Link",
       "description": "Create a shareable hosted payment link the customer can open to pay, without building a checkout",
       "requiresWrite": true,
@@ -219,7 +219,7 @@
       }
     },
     {
-      "id": "list_payment_refunds",
+      "id": "mollie__list_payment_refunds",
       "name": "List Payment Refunds",
       "description": "List the refunds created for a payment to review refund status and history",
       "requiresWrite": false,
@@ -251,7 +251,7 @@
       }
     },
     {
-      "id": "create_refund",
+      "id": "mollie__create_refund",
       "name": "Create Refund",
       "description": "Refund all or part of a Mollie payment back to the customer",
       "requiresWrite": true,

--- a/cli/templates/integrations/monday/connector.json
+++ b/cli/templates/integrations/monday/connector.json
@@ -37,7 +37,7 @@
   ],
   "tools": [
     {
-      "id": "list_boards",
+      "id": "monday__list_boards",
       "name": "List Boards",
       "description": "List boards in the monday.com account",
       "requiresWrite": false,
@@ -80,7 +80,7 @@
       }
     },
     {
-      "id": "list_items",
+      "id": "monday__list_items",
       "name": "List Items",
       "description": "List items on a monday.com board with their column values",
       "requiresWrite": false,
@@ -114,7 +114,7 @@
       }
     },
     {
-      "id": "get_item",
+      "id": "monday__get_item",
       "name": "Get Item",
       "description": "Get a monday.com item by ID with its column values and updates",
       "requiresWrite": false,
@@ -137,7 +137,7 @@
       }
     },
     {
-      "id": "create_item",
+      "id": "monday__create_item",
       "name": "Create Item",
       "description": "Create a new item on a monday.com board",
       "requiresWrite": true,
@@ -176,7 +176,7 @@
       }
     },
     {
-      "id": "update_column_values",
+      "id": "monday__update_column_values",
       "name": "Update Column Values",
       "description": "Update one or more column values on an existing monday.com item",
       "requiresWrite": true,

--- a/cli/templates/integrations/mongodb-atlas/connector.json
+++ b/cli/templates/integrations/mongodb-atlas/connector.json
@@ -34,7 +34,7 @@
   ],
   "tools": [
     {
-      "id": "list_projects",
+      "id": "mongodb-atlas__list_projects",
       "name": "List Projects",
       "description": "List Atlas projects (groups) the service account can access",
       "requiresWrite": false,
@@ -80,7 +80,7 @@
       }
     },
     {
-      "id": "list_clusters",
+      "id": "mongodb-atlas__list_clusters",
       "name": "List Clusters",
       "description": "List clusters in an Atlas project",
       "requiresWrite": false,
@@ -134,7 +134,7 @@
       }
     },
     {
-      "id": "get_cluster",
+      "id": "mongodb-atlas__get_cluster",
       "name": "Get Cluster",
       "description": "Get details of a cluster, including state and connection strings",
       "requiresWrite": false,
@@ -165,7 +165,7 @@
       }
     },
     {
-      "id": "list_database_users",
+      "id": "mongodb-atlas__list_database_users",
       "name": "List Database Users",
       "description": "List database users configured in an Atlas project",
       "requiresWrite": false,

--- a/cli/templates/integrations/moss/connector.json
+++ b/cli/templates/integrations/moss/connector.json
@@ -36,7 +36,7 @@
   ],
   "tools": [
     {
-      "id": "list_expenses",
+      "id": "moss__list_expenses",
       "name": "List Expenses",
       "description": "List expenses — card transactions, invoices, and reimbursements — with status, export status, and date filters; the basis for accounting exports",
       "requiresWrite": false,
@@ -112,7 +112,7 @@
       }
     },
     {
-      "id": "search_bank_transactions",
+      "id": "moss__search_bank_transactions",
       "name": "Search Bank Transactions",
       "description": "Search bank transactions of a Moss bank account within a booking-date window (read-only search query)",
       "requiresWrite": false,
@@ -137,7 +137,7 @@
       }
     },
     {
-      "id": "list_bank_accounts",
+      "id": "moss__list_bank_accounts",
       "name": "List Bank Accounts",
       "description": "List the company's bank accounts in Moss (use the IDs with Search Bank Transactions)",
       "requiresWrite": false,
@@ -147,7 +147,7 @@
       }
     },
     {
-      "id": "search_receipt_files",
+      "id": "moss__search_receipt_files",
       "name": "Search Receipt Files",
       "description": "Find receipt and invoice files attached to specific expenses (read-only search query); download via the returned file IDs",
       "requiresWrite": false,
@@ -168,7 +168,7 @@
       }
     },
     {
-      "id": "list_expense_accounts",
+      "id": "moss__list_expense_accounts",
       "name": "List Expense Accounts",
       "description": "List the chart of accounts used for ledger posting, for mapping expenses into your accounting system",
       "requiresWrite": false,
@@ -197,7 +197,7 @@
       }
     },
     {
-      "id": "list_suppliers",
+      "id": "moss__list_suppliers",
       "name": "List Suppliers",
       "description": "List supplier master data for spend-by-vendor analysis and accounting export enrichment",
       "requiresWrite": false,
@@ -236,7 +236,7 @@
       }
     },
     {
-      "id": "get_file_content",
+      "id": "moss__get_file_content",
       "name": "Get File Content",
       "description": "Download the binary content of a receipt or invoice file (application/octet-stream) using a file ID from Search Receipt Files",
       "requiresWrite": false,
@@ -254,7 +254,7 @@
       }
     },
     {
-      "id": "get_bank_account_balance",
+      "id": "moss__get_bank_account_balance",
       "name": "Get Bank Account Balance",
       "description": "Get the current balance of a Moss bank account for liquidity overviews",
       "requiresWrite": false,
@@ -272,7 +272,7 @@
       }
     },
     {
-      "id": "list_tax_rates",
+      "id": "moss__list_tax_rates",
       "name": "List Tax Rates",
       "description": "List VAT/tax rate master data for mapping expenses into the accounting system",
       "requiresWrite": false,

--- a/cli/templates/integrations/neo4j/connector.json
+++ b/cli/templates/integrations/neo4j/connector.json
@@ -42,7 +42,7 @@
   ],
   "tools": [
     {
-      "id": "run_cypher_query",
+      "id": "neo4j__run_cypher_query",
       "name": "Run Cypher Query",
       "description": "Execute a read-only Cypher query (MATCH ... RETURN) in an implicit transaction and get back fields and result rows — use for lookups, traversals, and GraphRAG retrieval. Note: the Query API does not enforce read-only access, so only submit read statements here (use a read-only database user to guarantee no writes)",
       "requiresWrite": false,
@@ -78,7 +78,7 @@
       }
     },
     {
-      "id": "run_cypher_write",
+      "id": "neo4j__run_cypher_write",
       "name": "Run Cypher Write",
       "description": "Execute a Cypher statement that modifies the graph (CREATE, MERGE, SET, DELETE) in an implicit transaction",
       "requiresWrite": true,

--- a/cli/templates/integrations/neon/connector.json
+++ b/cli/templates/integrations/neon/connector.json
@@ -38,7 +38,7 @@
   },
   "tools": [
     {
-      "id": "list_projects",
+      "id": "neon__list_projects",
       "name": "List Projects",
       "description": "List all Neon projects in your account",
       "requiresWrite": false,
@@ -76,7 +76,7 @@
       }
     },
     {
-      "id": "get_project",
+      "id": "neon__get_project",
       "name": "Get Project",
       "description": "Get details of a specific Neon project",
       "requiresWrite": false,
@@ -94,7 +94,7 @@
       }
     },
     {
-      "id": "list_branches",
+      "id": "neon__list_branches",
       "name": "List Branches",
       "description": "List all branches for a specific project",
       "requiresWrite": false,
@@ -127,7 +127,7 @@
       }
     },
     {
-      "id": "create_branch",
+      "id": "neon__create_branch",
       "name": "Create Branch",
       "description": "Create a new branch in a Neon project",
       "requiresWrite": true,
@@ -155,7 +155,7 @@
       }
     },
     {
-      "id": "list_databases",
+      "id": "neon__list_databases",
       "name": "List Databases",
       "description": "List databases on a specific branch of a project",
       "requiresWrite": false,
@@ -179,19 +179,19 @@
       }
     },
     {
-      "id": "query_database",
+      "id": "neon__query_database",
       "name": "Query Database",
       "description": "Execute SQL queries against the connected database",
       "requiresWrite": false
     },
     {
-      "id": "list_tables",
+      "id": "neon__list_tables",
       "name": "List Tables",
       "description": "List all tables in the connected database",
       "requiresWrite": false
     },
     {
-      "id": "describe_table",
+      "id": "neon__describe_table",
       "name": "Describe Table",
       "description": "Get detailed schema information for a specific table",
       "requiresWrite": false

--- a/cli/templates/integrations/netlify/connector.json
+++ b/cli/templates/integrations/netlify/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_sites",
+      "id": "netlify__list_sites",
       "name": "List Sites",
       "description": "List all sites the authenticated user has access to",
       "requiresWrite": false,
@@ -99,7 +99,7 @@
       }
     },
     {
-      "id": "get_site",
+      "id": "netlify__get_site",
       "name": "Get Site",
       "description": "Get a site by ID or custom domain",
       "requiresWrite": false,
@@ -117,7 +117,7 @@
       }
     },
     {
-      "id": "list_deploys",
+      "id": "netlify__list_deploys",
       "name": "List Deploys",
       "description": "List deploys for a site",
       "requiresWrite": false,
@@ -201,7 +201,7 @@
       }
     },
     {
-      "id": "get_deploy",
+      "id": "netlify__get_deploy",
       "name": "Get Deploy",
       "description": "Get a deploy by ID",
       "requiresWrite": false,
@@ -219,7 +219,7 @@
       }
     },
     {
-      "id": "trigger_build",
+      "id": "netlify__trigger_build",
       "name": "Trigger Build",
       "description": "Trigger a new build of a site from its linked repository",
       "requiresWrite": true,
@@ -244,7 +244,7 @@
       }
     },
     {
-      "id": "list_form_submissions",
+      "id": "netlify__list_form_submissions",
       "name": "List Form Submissions",
       "description": "List verified form submissions across all forms of a site",
       "requiresWrite": false,

--- a/cli/templates/integrations/new-relic/connector.json
+++ b/cli/templates/integrations/new-relic/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "run_nrql_query",
+      "id": "new-relic__run_nrql_query",
       "name": "Run NRQL Query",
       "description": "Run an NRQL query against a New Relic account and return the results",
       "requiresWrite": false,
@@ -55,7 +55,7 @@
       }
     },
     {
-      "id": "search_entities",
+      "id": "new-relic__search_entities",
       "name": "Search Entities",
       "description": "Search monitored entities (apps, hosts, services) with an entity search query",
       "requiresWrite": false,
@@ -95,7 +95,7 @@
       }
     },
     {
-      "id": "get_entity",
+      "id": "new-relic__get_entity",
       "name": "Get Entity",
       "description": "Get an entity's details and tags by GUID",
       "requiresWrite": false,
@@ -118,7 +118,7 @@
       }
     },
     {
-      "id": "list_issues",
+      "id": "new-relic__list_issues",
       "name": "List Issues",
       "description": "List alert issues from the last day in an account (queries the NrAiIssue event type via NRQL)",
       "requiresWrite": false,

--- a/cli/templates/integrations/north-data/connector.json
+++ b/cli/templates/integrations/north-data/connector.json
@@ -27,7 +27,7 @@
   ],
   "tools": [
     {
-      "id": "search_companies",
+      "id": "north-data__search_companies",
       "name": "Search Companies",
       "description": "Fuzzy universal search for companies (and optionally persons) by free-text query, e.g. 'Siemens, München'. Use this to find a company before fetching its details.",
       "requiresWrite": false,
@@ -72,7 +72,7 @@
       }
     },
     {
-      "id": "get_company",
+      "id": "north-data__get_company",
       "name": "Get Company",
       "description": "Retrieve a single company's profile (register info, address, status, financial indicators). Identify it either by name + address (city), or by registerId + registerCity, or by companyId from a previous search.",
       "requiresWrite": false,
@@ -115,7 +115,7 @@
       }
     },
     {
-      "id": "power_search",
+      "id": "north-data__power_search",
       "name": "Power Search",
       "description": "Structured company search with filters for location radius, industry segment, legal form, status, and countries. Billed per unique company returned, so keep filters narrow.",
       "requiresWrite": false,
@@ -162,7 +162,7 @@
       }
     },
     {
-      "id": "suggest",
+      "id": "north-data__suggest",
       "name": "Suggest Companies",
       "description": "Auto-complete suggestions for a partial company or person name. Free of charge — suggested companies do not count toward the monthly quota, so use this as a cheap first pass before Get Company.",
       "requiresWrite": false,
@@ -205,7 +205,7 @@
       }
     },
     {
-      "id": "get_person",
+      "id": "north-data__get_person",
       "name": "Get Person",
       "description": "Look up a person (officer, shareholder, representative) by name and address or by a person ID from a previous search result. Billed like company lookups.",
       "requiresWrite": false,

--- a/cli/templates/integrations/notion/connector.json
+++ b/cli/templates/integrations/notion/connector.json
@@ -36,7 +36,7 @@
   ],
   "tools": [
     {
-      "id": "search_notion",
+      "id": "notion__search_notion",
       "name": "Search Notion",
       "description": "Search pages and databases in the workspace",
       "requiresWrite": false,
@@ -80,7 +80,7 @@
       }
     },
     {
-      "id": "read_page",
+      "id": "notion__read_page",
       "name": "Read Page",
       "description": "Read the content of a Notion page",
       "requiresWrite": false,
@@ -118,7 +118,7 @@
       }
     },
     {
-      "id": "create_page",
+      "id": "notion__create_page",
       "name": "Create Page",
       "description": "Create a new page in a database or as a subpage",
       "requiresWrite": true,
@@ -152,7 +152,7 @@
       }
     },
     {
-      "id": "query_database",
+      "id": "notion__query_database",
       "name": "Query Database",
       "description": "Query a Notion database with filters and sorts",
       "requiresWrite": false,
@@ -198,7 +198,7 @@
       }
     },
     {
-      "id": "get_page",
+      "id": "notion__get_page",
       "name": "Get Page Metadata",
       "description": "Retrieve Notion page metadata and properties without fetching child block content",
       "requiresWrite": false,
@@ -222,7 +222,7 @@
       }
     },
     {
-      "id": "get_database",
+      "id": "notion__get_database",
       "name": "Get Database",
       "description": "Retrieve Notion database metadata, title, and property schema",
       "requiresWrite": false,
@@ -246,7 +246,7 @@
       }
     },
     {
-      "id": "append_blocks",
+      "id": "notion__append_blocks",
       "name": "Append Blocks",
       "description": "Append child blocks to a Notion page or block",
       "requiresWrite": true,
@@ -281,7 +281,7 @@
       }
     },
     {
-      "id": "update_page",
+      "id": "notion__update_page",
       "name": "Update Page",
       "description": "Update Notion page properties or archive/unarchive a page",
       "requiresWrite": true,
@@ -323,7 +323,7 @@
       }
     },
     {
-      "id": "create_database",
+      "id": "notion__create_database",
       "name": "Create Database",
       "description": "Create a new Notion database as a subpage with a property schema",
       "requiresWrite": true,
@@ -362,7 +362,7 @@
       }
     },
     {
-      "id": "list_users",
+      "id": "notion__list_users",
       "name": "List Users",
       "description": "List users in the Notion workspace so pages can mention or attribute the right person",
       "requiresWrite": false,

--- a/cli/templates/integrations/onedrive/connector.json
+++ b/cli/templates/integrations/onedrive/connector.json
@@ -42,7 +42,7 @@
   ],
   "tools": [
     {
-      "id": "list_files",
+      "id": "onedrive__list_files",
       "name": "List Files",
       "description": "List files and folders in a OneDrive folder",
       "requiresWrite": false,
@@ -65,7 +65,7 @@
       }
     },
     {
-      "id": "search_files",
+      "id": "onedrive__search_files",
       "name": "Search Files",
       "description": "Search for files and folders in OneDrive by name or content",
       "requiresWrite": false,
@@ -89,7 +89,7 @@
       }
     },
     {
-      "id": "upload_file",
+      "id": "onedrive__upload_file",
       "name": "Upload File",
       "description": "Upload or update a file in OneDrive",
       "requiresWrite": true,
@@ -121,7 +121,7 @@
       }
     },
     {
-      "id": "download_file",
+      "id": "onedrive__download_file",
       "name": "Download File",
       "description": "Download file content from OneDrive",
       "requiresWrite": false,
@@ -139,7 +139,7 @@
       }
     },
     {
-      "id": "get_file",
+      "id": "onedrive__get_file",
       "name": "Get File",
       "description": "Get metadata for a OneDrive file or folder",
       "requiresWrite": false,
@@ -162,7 +162,7 @@
       }
     },
     {
-      "id": "create_folder",
+      "id": "onedrive__create_folder",
       "name": "Create Folder",
       "description": "Create a new folder in OneDrive",
       "requiresWrite": true,
@@ -197,7 +197,7 @@
       }
     },
     {
-      "id": "delete_file",
+      "id": "onedrive__delete_file",
       "name": "Delete File",
       "description": "Delete a file or folder from OneDrive (moves it to the recycle bin)",
       "requiresWrite": true,

--- a/cli/templates/integrations/openai/connector.json
+++ b/cli/templates/integrations/openai/connector.json
@@ -27,7 +27,7 @@
   ],
   "tools": [
     {
-      "id": "list_models",
+      "id": "openai__list_models",
       "name": "List Models",
       "description": "List the models available to the API key",
       "requiresWrite": false,
@@ -50,7 +50,7 @@
       }
     },
     {
-      "id": "get_model",
+      "id": "openai__get_model",
       "name": "Get Model",
       "description": "Get details about a specific model",
       "requiresWrite": false,
@@ -68,7 +68,7 @@
       }
     },
     {
-      "id": "create_response",
+      "id": "openai__create_response",
       "name": "Create Response",
       "description": "Generate a model response using the OpenAI Responses API",
       "requiresWrite": true,
@@ -102,7 +102,7 @@
       }
     },
     {
-      "id": "create_chat_completion",
+      "id": "openai__create_chat_completion",
       "name": "Create Chat Completion",
       "description": "Generate a chat completion from a list of messages",
       "requiresWrite": true,
@@ -132,7 +132,7 @@
       }
     },
     {
-      "id": "create_embedding",
+      "id": "openai__create_embedding",
       "name": "Create Embedding",
       "description": "Create an embedding vector for input text",
       "requiresWrite": true,
@@ -158,7 +158,7 @@
       }
     },
     {
-      "id": "generate_image",
+      "id": "openai__generate_image",
       "name": "Generate Image",
       "description": "Generate an image from a text prompt",
       "requiresWrite": true,
@@ -189,7 +189,7 @@
       }
     },
     {
-      "id": "upload_file",
+      "id": "openai__upload_file",
       "name": "Upload File",
       "description": "Upload a file for use with assistants, batch, fine-tune, vision, user_data, or evals",
       "requiresWrite": true,
@@ -220,7 +220,7 @@
       }
     },
     {
-      "id": "list_files",
+      "id": "openai__list_files",
       "name": "List Files",
       "description": "List files uploaded to the organization, optionally filtered by purpose",
       "requiresWrite": false,
@@ -269,7 +269,7 @@
       }
     },
     {
-      "id": "get_file",
+      "id": "openai__get_file",
       "name": "Get File",
       "description": "Get metadata about an uploaded file by ID",
       "requiresWrite": false,
@@ -287,7 +287,7 @@
       }
     },
     {
-      "id": "delete_file",
+      "id": "openai__delete_file",
       "name": "Delete File",
       "description": "Delete an uploaded file and remove it from all vector stores",
       "requiresWrite": true,
@@ -305,7 +305,7 @@
       }
     },
     {
-      "id": "get_usage_completions",
+      "id": "openai__get_usage_completions",
       "name": "Get Completions Usage",
       "description": "Get token usage for completions across the organization, bucketed over time. Requires an organization admin API key (created under Settings → Organization → Admin keys) set as OPENAI_API_KEY — a regular project key returns 401",
       "requiresWrite": false,
@@ -349,7 +349,7 @@
       }
     },
     {
-      "id": "get_costs",
+      "id": "openai__get_costs",
       "name": "Get Costs",
       "description": "Get daily spend (in USD) for the organization, bucketed by day. Requires an organization admin API key (created under Settings → Organization → Admin keys) set as OPENAI_API_KEY — a regular project key returns 401",
       "requiresWrite": false,
@@ -388,7 +388,7 @@
       }
     },
     {
-      "id": "get_file_content",
+      "id": "openai__get_file_content",
       "name": "Get File Content",
       "description": "Download the raw contents of an uploaded file by ID — required to read batch output files and other generated artifacts",
       "requiresWrite": false,
@@ -406,7 +406,7 @@
       }
     },
     {
-      "id": "get_usage_embeddings",
+      "id": "openai__get_usage_embeddings",
       "name": "Get Embeddings Usage",
       "description": "Get token usage for embeddings across the organization, bucketed over time. Requires an organization admin API key (created under Settings → Organization → Admin keys) set as OPENAI_API_KEY — a regular project key returns 401",
       "requiresWrite": false,

--- a/cli/templates/integrations/openrouter/connector.json
+++ b/cli/templates/integrations/openrouter/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_models",
+      "id": "openrouter__list_models",
       "name": "List Models",
       "description": "List the models available through OpenRouter",
       "requiresWrite": false,
@@ -49,7 +49,7 @@
       }
     },
     {
-      "id": "create_chat_completion",
+      "id": "openrouter__create_chat_completion",
       "name": "Create Chat Completion",
       "description": "Generate a chat completion from any OpenRouter model",
       "requiresWrite": true,
@@ -79,7 +79,7 @@
       }
     },
     {
-      "id": "get_generation",
+      "id": "openrouter__get_generation",
       "name": "Get Generation",
       "description": "Get metadata, token counts, and cost for a past generation by ID",
       "requiresWrite": false,
@@ -97,7 +97,7 @@
       }
     },
     {
-      "id": "get_key",
+      "id": "openrouter__get_key",
       "name": "Get Current Key",
       "description": "Get the current API key's label, credit usage (total/daily/weekly/monthly in USD), spend limit, remaining limit, and free-tier status — works with the regular inference key",
       "requiresWrite": false,
@@ -110,7 +110,7 @@
       }
     },
     {
-      "id": "get_credits",
+      "id": "openrouter__get_credits",
       "name": "Get Credits",
       "description": "Get total credits purchased and used for the account (OpenRouter requires a management key for this endpoint)",
       "requiresWrite": false,

--- a/cli/templates/integrations/outlook/connector.json
+++ b/cli/templates/integrations/outlook/connector.json
@@ -45,7 +45,7 @@
   ],
   "tools": [
     {
-      "id": "list_emails",
+      "id": "outlook__list_emails",
       "name": "List Emails",
       "description": "List recent emails from inbox or a specific folder",
       "requiresWrite": false,
@@ -167,7 +167,7 @@
       }
     },
     {
-      "id": "get_email",
+      "id": "outlook__get_email",
       "name": "Get Email",
       "description": "Get detailed information about a specific email",
       "requiresWrite": false,
@@ -191,7 +191,7 @@
       }
     },
     {
-      "id": "send_email",
+      "id": "outlook__send_email",
       "name": "Send Email",
       "description": "Send a new email message",
       "requiresWrite": true,
@@ -213,7 +213,7 @@
       }
     },
     {
-      "id": "search_emails",
+      "id": "outlook__search_emails",
       "name": "Search Emails",
       "description": "Search emails by query, subject, sender, or date",
       "requiresWrite": false,
@@ -325,7 +325,7 @@
       }
     },
     {
-      "id": "list_folders",
+      "id": "outlook__list_folders",
       "name": "List Folders",
       "description": "List all mail folders in the mailbox",
       "requiresWrite": false,
@@ -389,7 +389,7 @@
       }
     },
     {
-      "id": "get_folder",
+      "id": "outlook__get_folder",
       "name": "Get Folder",
       "description": "Get metadata for a mail folder",
       "requiresWrite": false,
@@ -407,7 +407,7 @@
       }
     },
     {
-      "id": "create_folder",
+      "id": "outlook__create_folder",
       "name": "Create Folder",
       "description": "Create a mail folder",
       "requiresWrite": true,
@@ -424,7 +424,7 @@
       }
     },
     {
-      "id": "update_folder",
+      "id": "outlook__update_folder",
       "name": "Update Folder",
       "description": "Rename a mail folder",
       "requiresWrite": true,
@@ -449,7 +449,7 @@
       }
     },
     {
-      "id": "delete_folder",
+      "id": "outlook__delete_folder",
       "name": "Delete Folder",
       "description": "Delete a mail folder",
       "requiresWrite": true,
@@ -467,7 +467,7 @@
       }
     },
     {
-      "id": "mark_email_read",
+      "id": "outlook__mark_email_read",
       "name": "Mark Email Read",
       "description": "Mark an email as read",
       "requiresWrite": true,
@@ -492,7 +492,7 @@
       }
     },
     {
-      "id": "mark_email_unread",
+      "id": "outlook__mark_email_unread",
       "name": "Mark Email Unread",
       "description": "Mark an email as unread",
       "requiresWrite": true,
@@ -517,7 +517,7 @@
       }
     },
     {
-      "id": "delete_email",
+      "id": "outlook__delete_email",
       "name": "Delete Email",
       "description": "Delete an email message",
       "requiresWrite": true,
@@ -535,7 +535,7 @@
       }
     },
     {
-      "id": "move_email",
+      "id": "outlook__move_email",
       "name": "Move Email",
       "description": "Move an email to another folder",
       "requiresWrite": true,
@@ -560,7 +560,7 @@
       }
     },
     {
-      "id": "archive_email",
+      "id": "outlook__archive_email",
       "name": "Archive Email",
       "description": "Move an email to the archive folder",
       "requiresWrite": true,
@@ -585,7 +585,7 @@
       }
     },
     {
-      "id": "flag_email",
+      "id": "outlook__flag_email",
       "name": "Flag Email",
       "description": "Set a follow-up flag on an email",
       "requiresWrite": true,
@@ -610,7 +610,7 @@
       }
     },
     {
-      "id": "clear_email_flag",
+      "id": "outlook__clear_email_flag",
       "name": "Clear Email Flag",
       "description": "Clear the follow-up flag on an email",
       "requiresWrite": true,
@@ -637,7 +637,7 @@
       }
     },
     {
-      "id": "categorize_email",
+      "id": "outlook__categorize_email",
       "name": "Categorize Email",
       "description": "Replace the categories on an email",
       "requiresWrite": true,
@@ -662,7 +662,7 @@
       }
     },
     {
-      "id": "list_categories",
+      "id": "outlook__list_categories",
       "name": "List Categories",
       "description": "List Outlook master categories",
       "requiresWrite": false,
@@ -703,7 +703,7 @@
       }
     },
     {
-      "id": "create_category",
+      "id": "outlook__create_category",
       "name": "Create Category",
       "description": "Create an Outlook master category",
       "requiresWrite": true,
@@ -724,7 +724,7 @@
       }
     },
     {
-      "id": "update_category",
+      "id": "outlook__update_category",
       "name": "Update Category",
       "description": "Update an Outlook master category color",
       "requiresWrite": true,
@@ -749,7 +749,7 @@
       }
     },
     {
-      "id": "delete_category",
+      "id": "outlook__delete_category",
       "name": "Delete Category",
       "description": "Delete an Outlook master category",
       "requiresWrite": true,
@@ -767,7 +767,7 @@
       }
     },
     {
-      "id": "create_draft",
+      "id": "outlook__create_draft",
       "name": "Create Draft",
       "description": "Create a draft email message",
       "requiresWrite": true,
@@ -814,7 +814,7 @@
       }
     },
     {
-      "id": "list_drafts",
+      "id": "outlook__list_drafts",
       "name": "List Drafts",
       "description": "List draft email messages",
       "requiresWrite": false,
@@ -924,7 +924,7 @@
       }
     },
     {
-      "id": "get_draft",
+      "id": "outlook__get_draft",
       "name": "Get Draft",
       "description": "Get a draft message",
       "requiresWrite": false,
@@ -948,7 +948,7 @@
       }
     },
     {
-      "id": "update_draft",
+      "id": "outlook__update_draft",
       "name": "Update Draft",
       "description": "Update a draft email message",
       "requiresWrite": true,
@@ -1000,7 +1000,7 @@
       }
     },
     {
-      "id": "send_draft",
+      "id": "outlook__send_draft",
       "name": "Send Draft",
       "description": "Send a draft email message",
       "requiresWrite": true,
@@ -1018,7 +1018,7 @@
       }
     },
     {
-      "id": "delete_draft",
+      "id": "outlook__delete_draft",
       "name": "Delete Draft",
       "description": "Delete a draft email message",
       "requiresWrite": true,
@@ -1036,7 +1036,7 @@
       }
     },
     {
-      "id": "reply_email",
+      "id": "outlook__reply_email",
       "name": "Reply Email",
       "description": "Reply to an email",
       "requiresWrite": true,
@@ -1061,7 +1061,7 @@
       }
     },
     {
-      "id": "reply_all_email",
+      "id": "outlook__reply_all_email",
       "name": "Reply All Email",
       "description": "Reply all to an email",
       "requiresWrite": true,
@@ -1086,7 +1086,7 @@
       }
     },
     {
-      "id": "forward_email",
+      "id": "outlook__forward_email",
       "name": "Forward Email",
       "description": "Forward an email",
       "requiresWrite": true,
@@ -1115,7 +1115,7 @@
       }
     },
     {
-      "id": "create_reply_draft",
+      "id": "outlook__create_reply_draft",
       "name": "Create Reply Draft",
       "description": "Create a reply draft for an email",
       "requiresWrite": true,
@@ -1133,7 +1133,7 @@
       }
     },
     {
-      "id": "create_reply_all_draft",
+      "id": "outlook__create_reply_all_draft",
       "name": "Create Reply All Draft",
       "description": "Create a reply-all draft for an email",
       "requiresWrite": true,
@@ -1151,7 +1151,7 @@
       }
     },
     {
-      "id": "create_forward_draft",
+      "id": "outlook__create_forward_draft",
       "name": "Create Forward Draft",
       "description": "Create a forward draft for an email",
       "requiresWrite": true,
@@ -1169,7 +1169,7 @@
       }
     },
     {
-      "id": "list_attachments",
+      "id": "outlook__list_attachments",
       "name": "List Attachments",
       "description": "List attachments for an email message",
       "requiresWrite": false,
@@ -1227,7 +1227,7 @@
       }
     },
     {
-      "id": "get_attachment",
+      "id": "outlook__get_attachment",
       "name": "Get Attachment",
       "description": "Get metadata and content for an email attachment",
       "requiresWrite": false,
@@ -1251,7 +1251,7 @@
       }
     },
     {
-      "id": "add_attachment_to_message",
+      "id": "outlook__add_attachment_to_message",
       "name": "Add Attachment To Message",
       "description": "Add a small attachment to a draft message",
       "requiresWrite": true,
@@ -1295,7 +1295,7 @@
       }
     },
     {
-      "id": "list_conversation_messages",
+      "id": "outlook__list_conversation_messages",
       "name": "List Conversation Messages",
       "description": "List messages in an Outlook conversation",
       "requiresWrite": false,
@@ -1405,7 +1405,7 @@
       }
     },
     {
-      "id": "list_threads",
+      "id": "outlook__list_threads",
       "name": "List Threads",
       "description": "List recent Outlook conversation threads for request-desk triage. Returns one representative message per conversationId; pass that value as thread_id to the template get-thread tool or use it in get_thread's filter.",
       "requiresWrite": false,
@@ -1527,7 +1527,7 @@
       }
     },
     {
-      "id": "get_thread",
+      "id": "outlook__get_thread",
       "name": "Get Thread",
       "description": "Get Outlook messages in a conversation. Pass a Microsoft Graph OData filter such as conversationId eq 'AAQk...'.",
       "requiresWrite": false,
@@ -1561,7 +1561,7 @@
       }
     },
     {
-      "id": "list_shared_mailbox_emails",
+      "id": "outlook__list_shared_mailbox_emails",
       "name": "List Shared Mailbox Emails",
       "description": "List messages from a shared or delegated mailbox that the signed-in Microsoft account can access",
       "requiresWrite": false,
@@ -1689,7 +1689,7 @@
       }
     },
     {
-      "id": "search_shared_mailbox_emails",
+      "id": "outlook__search_shared_mailbox_emails",
       "name": "Search Shared Mailbox Emails",
       "description": "Search messages in a shared or delegated mailbox that the signed-in Microsoft account can access",
       "requiresWrite": false,
@@ -1807,7 +1807,7 @@
       }
     },
     {
-      "id": "find_group_by_mail",
+      "id": "outlook__find_group_by_mail",
       "name": "Find Group By Mail",
       "description": "Find a Microsoft 365 group by primary email address before reading its group inbox threads",
       "requiresWrite": false,
@@ -1840,7 +1840,7 @@
       }
     },
     {
-      "id": "list_group_threads",
+      "id": "outlook__list_group_threads",
       "name": "List Group Threads",
       "description": "List Microsoft 365 group inbox conversation threads",
       "requiresWrite": false,
@@ -1915,7 +1915,7 @@
       }
     },
     {
-      "id": "list_group_thread_posts",
+      "id": "outlook__list_group_thread_posts",
       "name": "List Group Thread Posts",
       "description": "List posts from a Microsoft 365 group inbox conversation thread",
       "requiresWrite": false,
@@ -2007,7 +2007,7 @@
       }
     },
     {
-      "id": "list_calendars",
+      "id": "outlook__list_calendars",
       "name": "List Calendars",
       "description": "List Outlook calendars",
       "requiresWrite": false,
@@ -2069,7 +2069,7 @@
       }
     },
     {
-      "id": "get_calendar",
+      "id": "outlook__get_calendar",
       "name": "Get Calendar",
       "description": "Get metadata for an Outlook calendar",
       "requiresWrite": false,
@@ -2087,7 +2087,7 @@
       }
     },
     {
-      "id": "create_calendar",
+      "id": "outlook__create_calendar",
       "name": "Create Calendar",
       "description": "Create an Outlook calendar",
       "requiresWrite": true,
@@ -2104,7 +2104,7 @@
       }
     },
     {
-      "id": "update_calendar",
+      "id": "outlook__update_calendar",
       "name": "Update Calendar",
       "description": "Update an Outlook calendar",
       "requiresWrite": true,
@@ -2132,7 +2132,7 @@
       }
     },
     {
-      "id": "delete_calendar",
+      "id": "outlook__delete_calendar",
       "name": "Delete Calendar",
       "description": "Delete an Outlook calendar",
       "requiresWrite": true,
@@ -2150,7 +2150,7 @@
       }
     },
     {
-      "id": "list_events",
+      "id": "outlook__list_events",
       "name": "List Events",
       "description": "List events from a specific Outlook calendar",
       "requiresWrite": false,
@@ -2256,7 +2256,7 @@
       }
     },
     {
-      "id": "list_calendar_view",
+      "id": "outlook__list_calendar_view",
       "name": "List Calendar View",
       "description": "List occurrences in a calendar time window",
       "requiresWrite": false,
@@ -2363,7 +2363,7 @@
       }
     },
     {
-      "id": "get_event",
+      "id": "outlook__get_event",
       "name": "Get Event",
       "description": "Get details for an Outlook event",
       "requiresWrite": false,
@@ -2387,7 +2387,7 @@
       }
     },
     {
-      "id": "create_event",
+      "id": "outlook__create_event",
       "name": "Create Event",
       "description": "Create an Outlook calendar event",
       "requiresWrite": true,
@@ -2454,7 +2454,7 @@
       }
     },
     {
-      "id": "update_event",
+      "id": "outlook__update_event",
       "name": "Update Event",
       "description": "Update an Outlook calendar event",
       "requiresWrite": true,
@@ -2526,7 +2526,7 @@
       }
     },
     {
-      "id": "delete_event",
+      "id": "outlook__delete_event",
       "name": "Delete Event",
       "description": "Delete an Outlook calendar event",
       "requiresWrite": true,
@@ -2544,7 +2544,7 @@
       }
     },
     {
-      "id": "respond_to_event",
+      "id": "outlook__respond_to_event",
       "name": "Respond To Event",
       "description": "Accept, tentatively accept, or decline an event invitation",
       "requiresWrite": true,
@@ -2579,7 +2579,7 @@
       }
     },
     {
-      "id": "get_event_instances",
+      "id": "outlook__get_event_instances",
       "name": "Get Event Instances",
       "description": "List instances of a recurring event in a time window",
       "requiresWrite": false,
@@ -2686,7 +2686,7 @@
       }
     },
     {
-      "id": "list_event_attachments",
+      "id": "outlook__list_event_attachments",
       "name": "List Event Attachments",
       "description": "List attachments for an event",
       "requiresWrite": false,
@@ -2744,7 +2744,7 @@
       }
     },
     {
-      "id": "get_event_attachment",
+      "id": "outlook__get_event_attachment",
       "name": "Get Event Attachment",
       "description": "Get metadata and content for an event attachment",
       "requiresWrite": false,
@@ -2768,7 +2768,7 @@
       }
     },
     {
-      "id": "add_event_attachment",
+      "id": "outlook__add_event_attachment",
       "name": "Add Event Attachment",
       "description": "Add a small attachment to an event",
       "requiresWrite": true,
@@ -2812,7 +2812,7 @@
       }
     },
     {
-      "id": "find_free_time",
+      "id": "outlook__find_free_time",
       "name": "Find Free Time",
       "description": "Return free/busy schedule information for users or resources",
       "requiresWrite": false,
@@ -2876,7 +2876,7 @@
       }
     },
     {
-      "id": "get_schedule",
+      "id": "outlook__get_schedule",
       "name": "Get Schedule",
       "description": "Get detailed free/busy schedule information",
       "requiresWrite": false,
@@ -2940,7 +2940,7 @@
       }
     },
     {
-      "id": "find_meeting_times",
+      "id": "outlook__find_meeting_times",
       "name": "Find Meeting Times",
       "description": "Find meeting time suggestions from attendees and constraints",
       "requiresWrite": false,

--- a/cli/templates/integrations/paddle/connector.json
+++ b/cli/templates/integrations/paddle/connector.json
@@ -29,7 +29,7 @@
   ],
   "tools": [
     {
-      "id": "list_products",
+      "id": "paddle__list_products",
       "name": "List Products",
       "description": "List products in the Paddle catalog, optionally including their prices",
       "requiresWrite": false,
@@ -65,7 +65,7 @@
       }
     },
     {
-      "id": "list_prices",
+      "id": "paddle__list_prices",
       "name": "List Prices",
       "description": "List prices for Paddle products to find price IDs for checkouts and subscriptions",
       "requiresWrite": false,
@@ -101,7 +101,7 @@
       }
     },
     {
-      "id": "list_customers",
+      "id": "paddle__list_customers",
       "name": "List Customers",
       "description": "List or search Paddle customers to find customer IDs and contact details",
       "requiresWrite": false,
@@ -137,7 +137,7 @@
       }
     },
     {
-      "id": "list_transactions",
+      "id": "paddle__list_transactions",
       "name": "List Transactions",
       "description": "List Paddle transactions for revenue review, filtered by status, customer, or subscription",
       "requiresWrite": false,
@@ -183,7 +183,7 @@
       }
     },
     {
-      "id": "list_subscriptions",
+      "id": "paddle__list_subscriptions",
       "name": "List Subscriptions",
       "description": "List Paddle subscriptions to review recurring revenue, statuses, and renewal dates",
       "requiresWrite": false,
@@ -224,7 +224,7 @@
       }
     },
     {
-      "id": "get_subscription",
+      "id": "paddle__get_subscription",
       "name": "Get Subscription",
       "description": "Retrieve a single Paddle subscription with its items, status, and billing dates",
       "requiresWrite": false,
@@ -250,7 +250,7 @@
       }
     },
     {
-      "id": "create_customer",
+      "id": "paddle__create_customer",
       "name": "Create Customer",
       "description": "Create a new Paddle customer, e.g. before creating transactions or subscriptions for a new buyer",
       "requiresWrite": true,
@@ -279,7 +279,7 @@
       }
     },
     {
-      "id": "create_price",
+      "id": "paddle__create_price",
       "name": "Create Price",
       "description": "Create a price for a Paddle product so it can be used in checkouts, transactions, and subscriptions",
       "requiresWrite": true,
@@ -322,7 +322,7 @@
       }
     },
     {
-      "id": "create_product",
+      "id": "paddle__create_product",
       "name": "Create Product",
       "description": "Create a new product in the Paddle catalog",
       "requiresWrite": true,

--- a/cli/templates/integrations/pagerduty/connector.json
+++ b/cli/templates/integrations/pagerduty/connector.json
@@ -42,7 +42,7 @@
   ],
   "tools": [
     {
-      "id": "list_incidents",
+      "id": "pagerduty__list_incidents",
       "name": "List Incidents",
       "description": "List PagerDuty incidents with optional status, service, and time filters",
       "requiresWrite": false,
@@ -137,7 +137,7 @@
       }
     },
     {
-      "id": "get_incident",
+      "id": "pagerduty__get_incident",
       "name": "Get Incident",
       "description": "Get a PagerDuty incident by ID or incident number",
       "requiresWrite": false,
@@ -155,7 +155,7 @@
       }
     },
     {
-      "id": "create_incident",
+      "id": "pagerduty__create_incident",
       "name": "Create Incident",
       "description": "Manually trigger a new incident on a service",
       "requiresWrite": true,
@@ -181,7 +181,7 @@
       }
     },
     {
-      "id": "manage_incident",
+      "id": "pagerduty__manage_incident",
       "name": "Manage Incident",
       "description": "Acknowledge, resolve, reassign, or escalate an incident",
       "requiresWrite": true,
@@ -213,7 +213,7 @@
       }
     },
     {
-      "id": "list_services",
+      "id": "pagerduty__list_services",
       "name": "List Services",
       "description": "List PagerDuty services",
       "requiresWrite": false,
@@ -281,7 +281,7 @@
       }
     },
     {
-      "id": "list_oncalls",
+      "id": "pagerduty__list_oncalls",
       "name": "List On-Calls",
       "description": "List on-call entries for schedules, escalation policies, and users",
       "requiresWrite": false,

--- a/cli/templates/integrations/pandadoc/connector.json
+++ b/cli/templates/integrations/pandadoc/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "list_documents",
+      "id": "pandadoc__list_documents",
       "name": "List Documents",
       "description": "List and search documents with optional filtering by status, template, folder, or date",
       "requiresWrite": false,
@@ -103,7 +103,7 @@
       }
     },
     {
-      "id": "get_document_status",
+      "id": "pandadoc__get_document_status",
       "name": "Get Document Status",
       "description": "Get basic info and current status of a document — useful to confirm it reached the expected state (e.g. document.draft before sending, document.completed before downloading)",
       "requiresWrite": false,
@@ -121,7 +121,7 @@
       }
     },
     {
-      "id": "get_document_details",
+      "id": "pandadoc__get_document_details",
       "name": "Get Document Details",
       "description": "Get full details of a document: recipients and their completion status, fields, tokens, pricing tables, metadata, and timestamps",
       "requiresWrite": false,
@@ -139,7 +139,7 @@
       }
     },
     {
-      "id": "list_templates",
+      "id": "pandadoc__list_templates",
       "name": "List Templates",
       "description": "List templates in the workspace to find template IDs for creating documents",
       "requiresWrite": false,
@@ -193,7 +193,7 @@
       }
     },
     {
-      "id": "get_template_details",
+      "id": "pandadoc__get_template_details",
       "name": "Get Template Details",
       "description": "Get a template's roles, tokens, fields, and pricing tables to know what Create Document from Template needs",
       "requiresWrite": false,
@@ -211,7 +211,7 @@
       }
     },
     {
-      "id": "create_document_link",
+      "id": "pandadoc__create_document_link",
       "name": "Create Document Link",
       "description": "Create a signing session link for a recipient to view and sign a sent document, without sending an email",
       "requiresWrite": true,
@@ -240,7 +240,7 @@
       }
     },
     {
-      "id": "create_document_from_template",
+      "id": "pandadoc__create_document_from_template",
       "name": "Create Document from Template",
       "description": "Create a new draft document from an existing template, pre-filling recipients, tokens, and fields",
       "requiresWrite": true,
@@ -286,7 +286,7 @@
       }
     },
     {
-      "id": "send_document",
+      "id": "pandadoc__send_document",
       "name": "Send Document",
       "description": "Send a draft document to its recipients for completion and signing (document must be in document.draft status)",
       "requiresWrite": true,

--- a/cli/templates/integrations/paypal/connector.json
+++ b/cli/templates/integrations/paypal/connector.json
@@ -34,7 +34,7 @@
   ],
   "tools": [
     {
-      "id": "list_transactions",
+      "id": "paypal__list_transactions",
       "name": "List Transactions",
       "description": "Search account transactions in a date window (max 31 days per request)",
       "requiresWrite": false,
@@ -90,7 +90,7 @@
       }
     },
     {
-      "id": "list_balances",
+      "id": "paypal__list_balances",
       "name": "List Balances",
       "description": "Get current account balances by currency",
       "requiresWrite": false,
@@ -107,7 +107,7 @@
       }
     },
     {
-      "id": "list_invoices",
+      "id": "paypal__list_invoices",
       "name": "List Invoices",
       "description": "List invoices",
       "requiresWrite": false,
@@ -150,7 +150,7 @@
       }
     },
     {
-      "id": "get_invoice",
+      "id": "paypal__get_invoice",
       "name": "Get Invoice",
       "description": "Get details of an invoice",
       "requiresWrite": false,
@@ -168,7 +168,7 @@
       }
     },
     {
-      "id": "get_order",
+      "id": "paypal__get_order",
       "name": "Get Order",
       "description": "Get details of a checkout order",
       "requiresWrite": false,

--- a/cli/templates/integrations/perplexity/connector.json
+++ b/cli/templates/integrations/perplexity/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "search_web",
+      "id": "perplexity__search_web",
       "name": "Search Web",
       "description": "Search the web with Perplexity's Search API and get ranked results",
       "requiresWrite": false,
@@ -61,7 +61,7 @@
       }
     },
     {
-      "id": "create_chat_completion",
+      "id": "perplexity__create_chat_completion",
       "name": "Create Chat Completion",
       "description": "Generate a web-grounded chat completion with citations using a Sonar model",
       "requiresWrite": true,
@@ -100,7 +100,7 @@
       }
     },
     {
-      "id": "create_agent_response",
+      "id": "perplexity__create_agent_response",
       "name": "Create Agent Response",
       "description": "Generate a response with Perplexity's Agent API using optional web search and reasoning",
       "requiresWrite": true,

--- a/cli/templates/integrations/persona/connector.json
+++ b/cli/templates/integrations/persona/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_inquiries",
+      "id": "persona__list_inquiries",
       "name": "List Inquiries",
       "description": "List Persona inquiries for KYC and onboarding review",
       "requiresWrite": false,
@@ -49,7 +49,7 @@
       }
     },
     {
-      "id": "get_inquiry",
+      "id": "persona__get_inquiry",
       "name": "Get Inquiry",
       "description": "Get a Persona inquiry by ID",
       "requiresWrite": false,
@@ -67,7 +67,7 @@
       }
     },
     {
-      "id": "approve_inquiry",
+      "id": "persona__approve_inquiry",
       "name": "Approve Inquiry",
       "description": "Approve a Persona inquiry after compliance review",
       "requiresWrite": true,
@@ -85,7 +85,7 @@
       }
     },
     {
-      "id": "decline_inquiry",
+      "id": "persona__decline_inquiry",
       "name": "Decline Inquiry",
       "description": "Decline a Persona inquiry after compliance review",
       "requiresWrite": true,

--- a/cli/templates/integrations/personio/connector.json
+++ b/cli/templates/integrations/personio/connector.json
@@ -35,7 +35,7 @@
   ],
   "tools": [
     {
-      "id": "list_persons",
+      "id": "personio__list_persons",
       "name": "List Persons",
       "description": "List employees (persons) in the Personio account with optional email filtering",
       "requiresWrite": false,
@@ -63,7 +63,7 @@
       }
     },
     {
-      "id": "get_person",
+      "id": "personio__get_person",
       "name": "Get Person",
       "description": "Retrieve a single employee (person) by ID",
       "requiresWrite": false,
@@ -81,7 +81,7 @@
       }
     },
     {
-      "id": "list_employments",
+      "id": "personio__list_employments",
       "name": "List Employments",
       "description": "List a person's employment records (position, department, supervisor, status), most recent first",
       "requiresWrite": false,
@@ -110,7 +110,7 @@
       }
     },
     {
-      "id": "list_absence_types",
+      "id": "personio__list_absence_types",
       "name": "List Absence Types",
       "description": "List the account's absence types (vacation, sick leave, ...) to find the absence_type IDs needed to create absences",
       "requiresWrite": false,
@@ -133,7 +133,7 @@
       }
     },
     {
-      "id": "list_absence_periods",
+      "id": "personio__list_absence_periods",
       "name": "List Absence Periods",
       "description": "List absence periods (vacation, sick leave, etc.) with person and date-range filters",
       "requiresWrite": false,
@@ -176,7 +176,7 @@
       }
     },
     {
-      "id": "list_attendance_periods",
+      "id": "personio__list_attendance_periods",
       "name": "List Attendance Periods",
       "description": "List attendance periods (work and break times) with person and update-date filters",
       "requiresWrite": false,
@@ -204,7 +204,7 @@
       }
     },
     {
-      "id": "create_absence_period",
+      "id": "personio__create_absence_period",
       "name": "Create Absence Period",
       "description": "Create an absence period (e.g. vacation or sick leave) for an employee",
       "requiresWrite": true,

--- a/cli/templates/integrations/pinecone/connector.json
+++ b/cli/templates/integrations/pinecone/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_indexes",
+      "id": "pinecone__list_indexes",
       "name": "List Indexes",
       "description": "List all indexes in the Pinecone project",
       "requiresWrite": false,
@@ -60,7 +60,7 @@
       }
     },
     {
-      "id": "describe_index",
+      "id": "pinecone__describe_index",
       "name": "Describe Index",
       "description": "Get an index's configuration and its data-plane host (needed for Query Vectors and Upsert Vectors)",
       "requiresWrite": false,
@@ -85,7 +85,7 @@
       }
     },
     {
-      "id": "create_index",
+      "id": "pinecone__create_index",
       "name": "Create Index",
       "description": "Create a new serverless or pod-based index",
       "requiresWrite": true,
@@ -125,7 +125,7 @@
       }
     },
     {
-      "id": "query_vectors",
+      "id": "pinecone__query_vectors",
       "name": "Query Vectors",
       "description": "Query an index for the nearest vectors (run Describe Index first to get the index host)",
       "requiresWrite": false,
@@ -180,7 +180,7 @@
       }
     },
     {
-      "id": "upsert_vectors",
+      "id": "pinecone__upsert_vectors",
       "name": "Upsert Vectors",
       "description": "Write vectors into an index (run Describe Index first to get the index host)",
       "requiresWrite": true,

--- a/cli/templates/integrations/pipedrive/connector.json
+++ b/cli/templates/integrations/pipedrive/connector.json
@@ -41,7 +41,7 @@
   ],
   "tools": [
     {
-      "id": "list_deals",
+      "id": "pipedrive__list_deals",
       "name": "List Deals",
       "description": "List deals in the Pipedrive account",
       "requiresWrite": false,
@@ -125,7 +125,7 @@
       }
     },
     {
-      "id": "get_deal",
+      "id": "pipedrive__get_deal",
       "name": "Get Deal",
       "description": "Get full details of a Pipedrive deal",
       "requiresWrite": false,
@@ -146,7 +146,7 @@
       }
     },
     {
-      "id": "create_deal",
+      "id": "pipedrive__create_deal",
       "name": "Create Deal",
       "description": "Create a new deal in Pipedrive",
       "requiresWrite": true,
@@ -191,7 +191,7 @@
       }
     },
     {
-      "id": "update_deal",
+      "id": "pipedrive__update_deal",
       "name": "Update Deal",
       "description": "Update fields on an existing Pipedrive deal",
       "requiresWrite": true,
@@ -230,7 +230,7 @@
       }
     },
     {
-      "id": "list_persons",
+      "id": "pipedrive__list_persons",
       "name": "List Persons",
       "description": "List persons (contacts) in the Pipedrive account",
       "requiresWrite": false,
@@ -262,7 +262,7 @@
       }
     },
     {
-      "id": "create_person",
+      "id": "pipedrive__create_person",
       "name": "Create Person",
       "description": "Create a new person (contact) in Pipedrive",
       "requiresWrite": true,
@@ -294,7 +294,7 @@
       }
     },
     {
-      "id": "list_organizations",
+      "id": "pipedrive__list_organizations",
       "name": "List Organizations",
       "description": "List organizations in the Pipedrive account",
       "requiresWrite": false,

--- a/cli/templates/integrations/planetscale/connector.json
+++ b/cli/templates/integrations/planetscale/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_organizations",
+      "id": "planetscale__list_organizations",
       "name": "List Organizations",
       "description": "List organizations the service token can access",
       "requiresWrite": false,
@@ -67,7 +67,7 @@
       }
     },
     {
-      "id": "list_databases",
+      "id": "planetscale__list_databases",
       "name": "List Databases",
       "description": "List databases in an organization",
       "requiresWrite": false,
@@ -116,7 +116,7 @@
       }
     },
     {
-      "id": "get_database",
+      "id": "planetscale__get_database",
       "name": "Get Database",
       "description": "Get details of a database",
       "requiresWrite": false,
@@ -140,7 +140,7 @@
       }
     },
     {
-      "id": "list_branches",
+      "id": "planetscale__list_branches",
       "name": "List Branches",
       "description": "List branches of a database",
       "requiresWrite": false,
@@ -196,7 +196,7 @@
       }
     },
     {
-      "id": "list_deploy_requests",
+      "id": "planetscale__list_deploy_requests",
       "name": "List Deploy Requests",
       "description": "List deploy requests for a database",
       "requiresWrite": false,

--- a/cli/templates/integrations/polygon/connector.json
+++ b/cli/templates/integrations/polygon/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "get_aggregates",
+      "id": "polygon__get_aggregates",
       "name": "Get Aggregate Bars",
       "description": "Get OHLCV aggregate bars (candles) for a stock ticker over a custom date range and time window",
       "requiresWrite": false,
@@ -109,7 +109,7 @@
       }
     },
     {
-      "id": "get_previous_close",
+      "id": "polygon__get_previous_close",
       "name": "Get Previous Close",
       "description": "Get the previous trading day's open, high, low, close, and volume for a stock ticker",
       "requiresWrite": false,
@@ -133,7 +133,7 @@
       }
     },
     {
-      "id": "get_daily_open_close",
+      "id": "polygon__get_daily_open_close",
       "name": "Get Daily Open/Close",
       "description": "Get the open, close, high, low, volume, and pre-market/after-hours prices for a stock ticker on a specific date",
       "requiresWrite": false,
@@ -163,7 +163,7 @@
       }
     },
     {
-      "id": "list_tickers",
+      "id": "polygon__list_tickers",
       "name": "Search Tickers",
       "description": "Search and list ticker symbols across stocks, indices, forex, and crypto reference data",
       "requiresWrite": false,
@@ -227,7 +227,7 @@
       }
     },
     {
-      "id": "get_ticker_details",
+      "id": "polygon__get_ticker_details",
       "name": "Get Ticker Details",
       "description": "Get reference details for a single ticker: company name, market, exchange, market cap, description, and identifiers",
       "requiresWrite": false,
@@ -250,7 +250,7 @@
       }
     },
     {
-      "id": "get_market_status",
+      "id": "polygon__get_market_status",
       "name": "Get Market Status",
       "description": "Get the current trading status of US exchanges and market-wide sessions (open, closed, early hours, after hours) — a cheap check before quoting prices",
       "requiresWrite": false,
@@ -260,7 +260,7 @@
       }
     },
     {
-      "id": "get_ticker_news",
+      "id": "polygon__get_ticker_news",
       "name": "Get Ticker News",
       "description": "Get recent news articles for a ticker, including publisher, summary, and per-ticker sentiment insights",
       "requiresWrite": false,

--- a/cli/templates/integrations/portkey/connector.json
+++ b/cli/templates/integrations/portkey/connector.json
@@ -27,7 +27,7 @@
   ],
   "tools": [
     {
-      "id": "get_cost_analytics",
+      "id": "portkey__get_cost_analytics",
       "name": "Get Cost Analytics",
       "description": "Get time-series LLM spend data for a workspace over a date range, optionally filtered by model, status, or metadata",
       "requiresWrite": false,
@@ -72,7 +72,7 @@
       }
     },
     {
-      "id": "get_request_analytics",
+      "id": "portkey__get_request_analytics",
       "name": "Get Request Analytics",
       "description": "Get time-series request volume data for a workspace over a date range to spot traffic spikes and error trends",
       "requiresWrite": false,
@@ -112,7 +112,7 @@
       }
     },
     {
-      "id": "get_token_analytics",
+      "id": "portkey__get_token_analytics",
       "name": "Get Token Analytics",
       "description": "Get time-series token consumption data for a workspace over a date range",
       "requiresWrite": false,
@@ -147,7 +147,7 @@
       }
     },
     {
-      "id": "get_user_analytics_summary",
+      "id": "portkey__get_user_analytics_summary",
       "name": "Get User Analytics Summary",
       "description": "Get per-user grouped analytics (request counts and cost) for a workspace over a date range",
       "requiresWrite": false,
@@ -192,7 +192,7 @@
       }
     },
     {
-      "id": "get_model_analytics_summary",
+      "id": "portkey__get_model_analytics_summary",
       "name": "Get Model Analytics Summary",
       "description": "Get per-model grouped analytics (request counts) for a workspace over a date range — spend and traffic by model",
       "requiresWrite": false,
@@ -237,7 +237,7 @@
       }
     },
     {
-      "id": "list_workspaces",
+      "id": "portkey__list_workspaces",
       "name": "List Workspaces",
       "description": "List the organization's workspaces with their IDs and slugs — feeds the workspace_slug every analytics tool needs",
       "requiresWrite": false,
@@ -275,7 +275,7 @@
       }
     },
     {
-      "id": "list_virtual_keys",
+      "id": "portkey__list_virtual_keys",
       "name": "List Virtual Keys",
       "description": "List virtual keys (managed provider credentials) with their status, usage limits, and expiry",
       "requiresWrite": false,
@@ -314,7 +314,7 @@
       }
     },
     {
-      "id": "list_log_exports",
+      "id": "portkey__list_log_exports",
       "name": "List Log Exports",
       "description": "List log export tasks for a workspace (Portkey exposes gateway logs via exports rather than a direct list endpoint)",
       "requiresWrite": false,

--- a/cli/templates/integrations/posthog/connector.json
+++ b/cli/templates/integrations/posthog/connector.json
@@ -34,7 +34,7 @@
   ],
   "tools": [
     {
-      "id": "get_trends",
+      "id": "posthog__get_trends",
       "name": "Get Trends",
       "description": "Retrieve event trends and analytics data",
       "requiresWrite": false,
@@ -69,7 +69,7 @@
       }
     },
     {
-      "id": "list_feature_flags",
+      "id": "posthog__list_feature_flags",
       "name": "List Feature Flags",
       "description": "List all feature flags in your PostHog project",
       "requiresWrite": false,
@@ -120,7 +120,7 @@
       }
     },
     {
-      "id": "list_persons",
+      "id": "posthog__list_persons",
       "name": "List Persons",
       "description": "List persons/users tracked in PostHog",
       "requiresWrite": false,
@@ -175,7 +175,7 @@
       }
     },
     {
-      "id": "capture_event",
+      "id": "posthog__capture_event",
       "name": "Capture Event",
       "description": "Track a custom event in PostHog",
       "requiresWrite": true

--- a/cli/templates/integrations/power-bi/connector.json
+++ b/cli/templates/integrations/power-bi/connector.json
@@ -46,7 +46,7 @@
   ],
   "tools": [
     {
-      "id": "list_workspaces",
+      "id": "power-bi__list_workspaces",
       "name": "List Workspaces",
       "description": "List Power BI workspaces (groups) the signed-in user has access to",
       "requiresWrite": false,
@@ -77,7 +77,7 @@
       }
     },
     {
-      "id": "list_datasets",
+      "id": "power-bi__list_datasets",
       "name": "List My Workspace Datasets",
       "description": "List datasets in the signed-in user's My workspace",
       "requiresWrite": false,
@@ -90,7 +90,7 @@
       }
     },
     {
-      "id": "list_workspace_datasets",
+      "id": "power-bi__list_workspace_datasets",
       "name": "List Workspace Datasets",
       "description": "List datasets in a specific Power BI workspace",
       "requiresWrite": false,
@@ -111,7 +111,7 @@
       }
     },
     {
-      "id": "list_reports",
+      "id": "power-bi__list_reports",
       "name": "List My Workspace Reports",
       "description": "List reports in the signed-in user's My workspace",
       "requiresWrite": false,
@@ -124,7 +124,7 @@
       }
     },
     {
-      "id": "list_workspace_reports",
+      "id": "power-bi__list_workspace_reports",
       "name": "List Workspace Reports",
       "description": "List reports in a specific Power BI workspace",
       "requiresWrite": false,
@@ -145,7 +145,7 @@
       }
     },
     {
-      "id": "execute_dax_query",
+      "id": "power-bi__execute_dax_query",
       "name": "Execute DAX Query",
       "description": "Run a read-only DAX query against a dataset and return the resulting rows",
       "requiresWrite": false,
@@ -181,7 +181,7 @@
       }
     },
     {
-      "id": "refresh_dataset",
+      "id": "power-bi__refresh_dataset",
       "name": "Refresh Dataset",
       "description": "Trigger a data refresh for a dataset in the signed-in user's My workspace (returns 202 Accepted; the refresh runs asynchronously). Datasets in shared workspaces are not supported by this endpoint",
       "requiresWrite": true,
@@ -207,7 +207,7 @@
       }
     },
     {
-      "id": "refresh_workspace_dataset",
+      "id": "power-bi__refresh_workspace_dataset",
       "name": "Refresh Workspace Dataset",
       "description": "Trigger a data refresh for a dataset in a specific workspace (returns 202 Accepted; the refresh runs asynchronously)",
       "requiresWrite": true,
@@ -239,7 +239,7 @@
       }
     },
     {
-      "id": "list_refresh_history",
+      "id": "power-bi__list_refresh_history",
       "name": "List Refresh History",
       "description": "Get the refresh history of a dataset in the signed-in user's My workspace — the way to follow up the 202 returned by Refresh Dataset",
       "requiresWrite": false,
@@ -265,7 +265,7 @@
       }
     },
     {
-      "id": "list_workspace_refresh_history",
+      "id": "power-bi__list_workspace_refresh_history",
       "name": "List Workspace Refresh History",
       "description": "Get the refresh history of a dataset in a specific workspace, including status and failure error codes",
       "requiresWrite": false,

--- a/cli/templates/integrations/productboard/connector.json
+++ b/cli/templates/integrations/productboard/connector.json
@@ -41,7 +41,7 @@
   ],
   "tools": [
     {
-      "id": "list_notes",
+      "id": "productboard__list_notes",
       "name": "List Notes",
       "description": "List customer feedback notes in the Productboard workspace",
       "requiresWrite": false,
@@ -109,7 +109,7 @@
       }
     },
     {
-      "id": "get_note",
+      "id": "productboard__get_note",
       "name": "Get Note",
       "description": "Get a Productboard note by ID",
       "requiresWrite": false,
@@ -127,7 +127,7 @@
       }
     },
     {
-      "id": "create_note",
+      "id": "productboard__create_note",
       "name": "Create Note",
       "description": "Create a feedback note in Productboard",
       "requiresWrite": true,
@@ -144,7 +144,7 @@
       }
     },
     {
-      "id": "list_entities",
+      "id": "productboard__list_entities",
       "name": "List Entities",
       "description": "List product hierarchy entities (features, components, initiatives, releases, etc.)",
       "requiresWrite": false,
@@ -214,7 +214,7 @@
       }
     },
     {
-      "id": "get_entity",
+      "id": "productboard__get_entity",
       "name": "Get Entity",
       "description": "Get a hierarchy entity (e.g. a feature) by ID",
       "requiresWrite": false,
@@ -232,7 +232,7 @@
       }
     },
     {
-      "id": "create_entity",
+      "id": "productboard__create_entity",
       "name": "Create Entity",
       "description": "Create a hierarchy entity such as a feature or initiative",
       "requiresWrite": true,
@@ -249,7 +249,7 @@
       }
     },
     {
-      "id": "update_entity",
+      "id": "productboard__update_entity",
       "name": "Update Entity",
       "description": "Update fields of a hierarchy entity (e.g. rename a feature or change its status)",
       "requiresWrite": true,

--- a/cli/templates/integrations/qdrant/connector.json
+++ b/cli/templates/integrations/qdrant/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_collections",
+      "id": "qdrant__list_collections",
       "name": "List Collections",
       "description": "List all collections in the Qdrant cluster",
       "requiresWrite": false,
@@ -53,7 +53,7 @@
       }
     },
     {
-      "id": "get_collection",
+      "id": "qdrant__get_collection",
       "name": "Get Collection Info",
       "description": "Get a collection's configuration, vector parameters, and point count",
       "requiresWrite": false,
@@ -80,7 +80,7 @@
       }
     },
     {
-      "id": "search_points",
+      "id": "qdrant__search_points",
       "name": "Search Points",
       "description": "Search a collection for the points nearest to a query vector",
       "requiresWrite": false,
@@ -137,7 +137,7 @@
       }
     },
     {
-      "id": "upsert_points",
+      "id": "qdrant__upsert_points",
       "name": "Upsert Points",
       "description": "Insert or update points (vectors with payloads) in a collection",
       "requiresWrite": true,

--- a/cli/templates/integrations/qonto/connector.json
+++ b/cli/templates/integrations/qonto/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "get_organization",
+      "id": "qonto__get_organization",
       "name": "Get Organization",
       "description": "Retrieve the authenticated organization with its bank accounts, including IBAN, BIC, currency, status, and current/authorized balances",
       "requiresWrite": false,
@@ -46,7 +46,7 @@
       }
     },
     {
-      "id": "list_transactions",
+      "id": "qonto__list_transactions",
       "name": "List Transactions",
       "description": "List transactions for one bank account (identified by bank_account_id or IBAN) with status, side, and date filtering",
       "requiresWrite": false,
@@ -142,7 +142,7 @@
       }
     },
     {
-      "id": "get_transaction",
+      "id": "qonto__get_transaction",
       "name": "Get Transaction",
       "description": "Retrieve a single transaction by its UUID, optionally embedding VAT details, labels, or attachments",
       "requiresWrite": false,
@@ -165,7 +165,7 @@
       }
     },
     {
-      "id": "list_transaction_attachments",
+      "id": "qonto__list_transaction_attachments",
       "name": "List Transaction Attachments",
       "description": "List the attachments (receipts, invoices) of a transaction with download URLs",
       "requiresWrite": false,
@@ -193,7 +193,7 @@
       }
     },
     {
-      "id": "upload_transaction_attachment",
+      "id": "qonto__upload_transaction_attachment",
       "name": "Upload Transaction Attachment",
       "description": "Upload a receipt or invoice (JPEG, PNG, or PDF) onto a transaction to justify it for bookkeeping; the file is processed in the background, so the attachment is not visible immediately",
       "requiresWrite": true,
@@ -227,7 +227,7 @@
       }
     },
     {
-      "id": "get_attachment",
+      "id": "qonto__get_attachment",
       "name": "Get Attachment",
       "description": "Retrieve an attachment by id to get a fresh download URL — URLs returned by the attachment endpoints expire after 30 minutes, so re-fetch before any delayed download",
       "requiresWrite": false,
@@ -245,7 +245,7 @@
       }
     },
     {
-      "id": "list_supplier_invoices",
+      "id": "qonto__list_supplier_invoices",
       "name": "List Supplier Invoices",
       "description": "List the organization's supplier invoices (accounts payable inbox) with status and payment matching; available on all price plans except Solo Basic",
       "requiresWrite": false,

--- a/cli/templates/integrations/quickbooks/connector.json
+++ b/cli/templates/integrations/quickbooks/connector.json
@@ -37,7 +37,7 @@
   ],
   "tools": [
     {
-      "id": "list_invoices",
+      "id": "quickbooks__list_invoices",
       "name": "List Invoices",
       "description": "List recent invoices in a QuickBooks Online company",
       "requiresWrite": false,
@@ -97,7 +97,7 @@
       }
     },
     {
-      "id": "list_customers",
+      "id": "quickbooks__list_customers",
       "name": "List Customers",
       "description": "List customers in a QuickBooks Online company",
       "requiresWrite": false,
@@ -137,7 +137,7 @@
       }
     },
     {
-      "id": "list_accounts",
+      "id": "quickbooks__list_accounts",
       "name": "List Accounts",
       "description": "List the chart of accounts in a QuickBooks Online company",
       "requiresWrite": false,
@@ -177,7 +177,7 @@
       }
     },
     {
-      "id": "get_invoice",
+      "id": "quickbooks__get_invoice",
       "name": "Get Invoice",
       "description": "Get a QuickBooks invoice with its line items",
       "requiresWrite": false,
@@ -217,7 +217,7 @@
       }
     },
     {
-      "id": "create_invoice",
+      "id": "quickbooks__create_invoice",
       "name": "Create Invoice",
       "description": "Create an invoice in a QuickBooks Online company",
       "requiresWrite": true,
@@ -259,7 +259,7 @@
       }
     },
     {
-      "id": "list_bills",
+      "id": "quickbooks__list_bills",
       "name": "List Bills",
       "description": "List vendor bills (accounts payable) in a QuickBooks Online company",
       "requiresWrite": false,
@@ -318,7 +318,7 @@
       }
     },
     {
-      "id": "get_bill",
+      "id": "quickbooks__get_bill",
       "name": "Get Bill",
       "description": "Get a QuickBooks vendor bill with its line items",
       "requiresWrite": false,
@@ -358,7 +358,7 @@
       }
     },
     {
-      "id": "create_bill",
+      "id": "quickbooks__create_bill",
       "name": "Create Bill",
       "description": "Create a vendor bill (accounts payable) in a QuickBooks Online company",
       "requiresWrite": true,
@@ -400,7 +400,7 @@
       }
     },
     {
-      "id": "create_purchase",
+      "id": "quickbooks__create_purchase",
       "name": "Create Purchase",
       "description": "Record an expense (cash, check, or credit card purchase) in a QuickBooks Online company",
       "requiresWrite": true,
@@ -442,7 +442,7 @@
       }
     },
     {
-      "id": "upload_attachment",
+      "id": "quickbooks__upload_attachment",
       "name": "Upload Attachment",
       "description": "Upload a file and attach it to a QuickBooks transaction (bill, invoice, purchase, ...) via the Attachable API",
       "requiresWrite": true,
@@ -494,7 +494,7 @@
       }
     },
     {
-      "id": "run_query",
+      "id": "quickbooks__run_query",
       "name": "Run Query",
       "description": "Run an arbitrary QuickBooks query against any entity (Invoice, Customer, Account, Payment, Bill, Item, ...)",
       "requiresWrite": false,
@@ -534,7 +534,7 @@
       }
     },
     {
-      "id": "list_vendors",
+      "id": "quickbooks__list_vendors",
       "name": "List Vendors",
       "description": "List vendors in a QuickBooks Online company — use this to find the VendorRef IDs that Create Bill requires",
       "requiresWrite": false,
@@ -591,7 +591,7 @@
       }
     },
     {
-      "id": "list_purchases",
+      "id": "quickbooks__list_purchases",
       "name": "List Purchases",
       "description": "List purchase transactions (cash, check, or credit card expenses) in a QuickBooks Online company — the read counterpart to Create Purchase",
       "requiresWrite": false,

--- a/cli/templates/integrations/railway/connector.json
+++ b/cli/templates/integrations/railway/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_projects",
+      "id": "railway__list_projects",
       "name": "List Projects",
       "description": "List Railway projects accessible to the token",
       "requiresWrite": false,
@@ -63,7 +63,7 @@
       }
     },
     {
-      "id": "get_project",
+      "id": "railway__get_project",
       "name": "Get Project",
       "description": "Get a project with its services and environments",
       "requiresWrite": false,
@@ -86,7 +86,7 @@
       }
     },
     {
-      "id": "list_deployments",
+      "id": "railway__list_deployments",
       "name": "List Deployments",
       "description": "List deployments filtered by project, service, or environment",
       "requiresWrite": false,
@@ -146,7 +146,7 @@
       }
     },
     {
-      "id": "get_deployment",
+      "id": "railway__get_deployment",
       "name": "Get Deployment",
       "description": "Get a deployment by ID, including redeploy/rollback eligibility",
       "requiresWrite": false,
@@ -169,7 +169,7 @@
       }
     },
     {
-      "id": "restart_deployment",
+      "id": "railway__restart_deployment",
       "name": "Restart Deployment",
       "description": "Restart a running deployment",
       "requiresWrite": true,
@@ -189,7 +189,7 @@
       }
     },
     {
-      "id": "redeploy_deployment",
+      "id": "railway__redeploy_deployment",
       "name": "Redeploy Deployment",
       "description": "Redeploy an existing deployment (creates a new deployment from it)",
       "requiresWrite": true,

--- a/cli/templates/integrations/ramp/connector.json
+++ b/cli/templates/integrations/ramp/connector.json
@@ -41,7 +41,7 @@
   ],
   "tools": [
     {
-      "id": "list_transactions",
+      "id": "ramp__list_transactions",
       "name": "List Transactions",
       "description": "List card transactions with optional filtering by state, user, card, or date window",
       "requiresWrite": false,
@@ -116,7 +116,7 @@
       }
     },
     {
-      "id": "get_transaction",
+      "id": "ramp__get_transaction",
       "name": "Get Transaction",
       "description": "Fetch full details of a single card transaction",
       "requiresWrite": false,
@@ -139,7 +139,7 @@
       }
     },
     {
-      "id": "list_cards",
+      "id": "ramp__list_cards",
       "name": "List Cards",
       "description": "List corporate cards with optional filtering by owner or activation state",
       "requiresWrite": false,
@@ -198,7 +198,7 @@
       }
     },
     {
-      "id": "list_users",
+      "id": "ramp__list_users",
       "name": "List Users",
       "description": "List employees on the Ramp account with optional filtering by email, role, department, or status",
       "requiresWrite": false,
@@ -257,7 +257,7 @@
       }
     },
     {
-      "id": "get_user",
+      "id": "ramp__get_user",
       "name": "Get User",
       "description": "Fetch a single employee by ID, e.g. to resolve the user_id referenced on a transaction or card",
       "requiresWrite": false,
@@ -275,7 +275,7 @@
       }
     },
     {
-      "id": "get_card",
+      "id": "ramp__get_card",
       "name": "Get Card",
       "description": "Fetch a single corporate card by ID, e.g. to resolve the card_id referenced on a transaction",
       "requiresWrite": false,
@@ -293,7 +293,7 @@
       }
     },
     {
-      "id": "list_reimbursements",
+      "id": "ramp__list_reimbursements",
       "name": "List Reimbursements",
       "description": "List employee reimbursements with optional filtering by user, state, or date window",
       "requiresWrite": false,

--- a/cli/templates/integrations/razorpay/connector.json
+++ b/cli/templates/integrations/razorpay/connector.json
@@ -33,7 +33,7 @@
   ],
   "tools": [
     {
-      "id": "list_payments",
+      "id": "razorpay__list_payments",
       "name": "List Payments",
       "description": "List payments, optionally within a Unix-timestamp window",
       "requiresWrite": false,
@@ -86,7 +86,7 @@
       }
     },
     {
-      "id": "get_payment",
+      "id": "razorpay__get_payment",
       "name": "Get Payment",
       "description": "Get details of a payment",
       "requiresWrite": false,
@@ -104,7 +104,7 @@
       }
     },
     {
-      "id": "list_orders",
+      "id": "razorpay__list_orders",
       "name": "List Orders",
       "description": "List orders",
       "requiresWrite": false,
@@ -148,7 +148,7 @@
       }
     },
     {
-      "id": "get_order",
+      "id": "razorpay__get_order",
       "name": "Get Order",
       "description": "Get details of an order",
       "requiresWrite": false,
@@ -166,7 +166,7 @@
       }
     },
     {
-      "id": "list_refunds",
+      "id": "razorpay__list_refunds",
       "name": "List Refunds",
       "description": "List refunds",
       "requiresWrite": false,
@@ -200,7 +200,7 @@
       }
     },
     {
-      "id": "list_settlements",
+      "id": "razorpay__list_settlements",
       "name": "List Settlements",
       "description": "List settlements paid out to your bank account",
       "requiresWrite": false,

--- a/cli/templates/integrations/redis-cloud/connector.json
+++ b/cli/templates/integrations/redis-cloud/connector.json
@@ -36,7 +36,7 @@
   ],
   "tools": [
     {
-      "id": "list_subscriptions",
+      "id": "redis-cloud__list_subscriptions",
       "name": "List Subscriptions",
       "description": "List Redis Cloud Pro subscriptions in the account",
       "requiresWrite": false,
@@ -60,7 +60,7 @@
       }
     },
     {
-      "id": "list_fixed_subscriptions",
+      "id": "redis-cloud__list_fixed_subscriptions",
       "name": "List Essentials Subscriptions",
       "description": "List Redis Cloud Essentials (fixed plan) subscriptions in the account",
       "requiresWrite": false,
@@ -70,7 +70,7 @@
       }
     },
     {
-      "id": "list_databases",
+      "id": "redis-cloud__list_databases",
       "name": "List Databases",
       "description": "List databases in a Redis Cloud Pro subscription",
       "requiresWrite": false,
@@ -100,7 +100,7 @@
       }
     },
     {
-      "id": "get_database",
+      "id": "redis-cloud__get_database",
       "name": "Get Database",
       "description": "Get configuration and status of a database in a Pro subscription",
       "requiresWrite": false,
@@ -124,7 +124,7 @@
       }
     },
     {
-      "id": "list_fixed_databases",
+      "id": "redis-cloud__list_fixed_databases",
       "name": "List Essentials Databases",
       "description": "List databases in a Redis Cloud Essentials subscription",
       "requiresWrite": false,

--- a/cli/templates/integrations/render/connector.json
+++ b/cli/templates/integrations/render/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_services",
+      "id": "render__list_services",
       "name": "List Services",
       "description": "List services owned by the authenticated user or team",
       "requiresWrite": false,
@@ -82,7 +82,7 @@
       }
     },
     {
-      "id": "get_service",
+      "id": "render__get_service",
       "name": "Get Service",
       "description": "Get a service by ID",
       "requiresWrite": false,
@@ -100,7 +100,7 @@
       }
     },
     {
-      "id": "list_deploys",
+      "id": "render__list_deploys",
       "name": "List Deploys",
       "description": "List deploys for a service",
       "requiresWrite": false,
@@ -152,7 +152,7 @@
       }
     },
     {
-      "id": "trigger_deploy",
+      "id": "render__trigger_deploy",
       "name": "Trigger Deploy",
       "description": "Trigger a new deploy for a service",
       "requiresWrite": true,
@@ -185,7 +185,7 @@
       }
     },
     {
-      "id": "list_env_vars",
+      "id": "render__list_env_vars",
       "name": "List Environment Variables",
       "description": "List all environment variables for a service",
       "requiresWrite": false,

--- a/cli/templates/integrations/replicate/connector.json
+++ b/cli/templates/integrations/replicate/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_models",
+      "id": "replicate__list_models",
       "name": "List Models",
       "description": "List public models available on Replicate",
       "requiresWrite": false,
@@ -50,7 +50,7 @@
       }
     },
     {
-      "id": "get_model",
+      "id": "replicate__get_model",
       "name": "Get Model",
       "description": "Get details about a model, including its latest version ID",
       "requiresWrite": false,
@@ -74,7 +74,7 @@
       }
     },
     {
-      "id": "create_prediction",
+      "id": "replicate__create_prediction",
       "name": "Create Prediction",
       "description": "Run a model by creating a prediction from a version ID and input object",
       "requiresWrite": true,
@@ -105,7 +105,7 @@
       }
     },
     {
-      "id": "get_prediction",
+      "id": "replicate__get_prediction",
       "name": "Get Prediction",
       "description": "Get the status and output of a prediction",
       "requiresWrite": false,
@@ -123,7 +123,7 @@
       }
     },
     {
-      "id": "cancel_prediction",
+      "id": "replicate__cancel_prediction",
       "name": "Cancel Prediction",
       "description": "Cancel a running prediction",
       "requiresWrite": true,

--- a/cli/templates/integrations/resend/connector.json
+++ b/cli/templates/integrations/resend/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "send_email",
+      "id": "resend__send_email",
       "name": "Send Email",
       "description": "Send an email",
       "requiresWrite": true,
@@ -73,7 +73,7 @@
       }
     },
     {
-      "id": "get_email",
+      "id": "resend__get_email",
       "name": "Get Email",
       "description": "Get a sent email and its delivery status by ID",
       "requiresWrite": false,
@@ -91,7 +91,7 @@
       }
     },
     {
-      "id": "list_domains",
+      "id": "resend__list_domains",
       "name": "List Domains",
       "description": "List sending domains and their verification status",
       "requiresWrite": false,
@@ -116,7 +116,7 @@
       }
     },
     {
-      "id": "list_audiences",
+      "id": "resend__list_audiences",
       "name": "List Audiences",
       "description": "List audiences (contact groups)",
       "requiresWrite": false,
@@ -129,7 +129,7 @@
       }
     },
     {
-      "id": "list_contacts",
+      "id": "resend__list_contacts",
       "name": "List Contacts",
       "description": "List contacts in an audience",
       "requiresWrite": false,
@@ -150,7 +150,7 @@
       }
     },
     {
-      "id": "create_contact",
+      "id": "resend__create_contact",
       "name": "Create Contact",
       "description": "Add a contact to an audience",
       "requiresWrite": true,

--- a/cli/templates/integrations/rippling/connector.json
+++ b/cli/templates/integrations/rippling/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "list_employees",
+      "id": "rippling__list_employees",
       "name": "List Employees",
       "description": "List active employees in the Rippling company with pagination",
       "requiresWrite": false,
@@ -52,7 +52,7 @@
       }
     },
     {
-      "id": "get_employee",
+      "id": "rippling__get_employee",
       "name": "Get Employee",
       "description": "Get a single employee's record (title, department, work location, employment type) by ID",
       "requiresWrite": false,
@@ -70,7 +70,7 @@
       }
     },
     {
-      "id": "list_departments",
+      "id": "rippling__list_departments",
       "name": "List Departments",
       "description": "List the company's departments",
       "requiresWrite": false,
@@ -94,7 +94,7 @@
       }
     },
     {
-      "id": "list_teams",
+      "id": "rippling__list_teams",
       "name": "List Teams",
       "description": "List the company's teams",
       "requiresWrite": false,
@@ -118,7 +118,7 @@
       }
     },
     {
-      "id": "list_leave_requests",
+      "id": "rippling__list_leave_requests",
       "name": "List Leave Requests",
       "description": "List leave (time off) requests with optional status and date filtering",
       "requiresWrite": false,
@@ -145,7 +145,7 @@
       }
     },
     {
-      "id": "process_leave_request",
+      "id": "rippling__process_leave_request",
       "name": "Process Leave Request",
       "description": "Approve or decline a pending leave request",
       "requiresWrite": true,

--- a/cli/templates/integrations/salesflare/connector.json
+++ b/cli/templates/integrations/salesflare/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_contacts",
+      "id": "salesflare__list_contacts",
       "name": "List Contacts",
       "description": "List or search contacts in Salesflare",
       "requiresWrite": false,
@@ -71,7 +71,7 @@
       }
     },
     {
-      "id": "get_contact",
+      "id": "salesflare__get_contact",
       "name": "Get Contact",
       "description": "Get details of a Salesflare contact",
       "requiresWrite": false,
@@ -89,7 +89,7 @@
       }
     },
     {
-      "id": "create_contact",
+      "id": "salesflare__create_contact",
       "name": "Create Contact",
       "description": "Create a new contact in Salesflare",
       "requiresWrite": true,
@@ -126,7 +126,7 @@
       }
     },
     {
-      "id": "update_contact",
+      "id": "salesflare__update_contact",
       "name": "Update Contact",
       "description": "Update an existing Salesflare contact",
       "requiresWrite": true,
@@ -162,7 +162,7 @@
       }
     },
     {
-      "id": "list_accounts",
+      "id": "salesflare__list_accounts",
       "name": "List Accounts",
       "description": "List or search accounts (companies) in Salesflare",
       "requiresWrite": false,
@@ -191,7 +191,7 @@
       }
     },
     {
-      "id": "create_account",
+      "id": "salesflare__create_account",
       "name": "Create Account",
       "description": "Create a new account (company) in Salesflare",
       "requiresWrite": true,
@@ -220,7 +220,7 @@
       }
     },
     {
-      "id": "list_opportunities",
+      "id": "salesflare__list_opportunities",
       "name": "List Opportunities",
       "description": "List or search opportunities in Salesflare",
       "requiresWrite": false,

--- a/cli/templates/integrations/salesforce/connector.json
+++ b/cli/templates/integrations/salesforce/connector.json
@@ -40,7 +40,7 @@
   ],
   "tools": [
     {
-      "id": "find_customer",
+      "id": "salesforce__find_customer",
       "name": "Find Customer",
       "description": "Find customer contacts with account context for support triage. Pass a focused SOQL query when searching by email, name, phone, or account.",
       "requiresWrite": false,
@@ -61,7 +61,7 @@
       }
     },
     {
-      "id": "search_accounts",
+      "id": "salesforce__search_accounts",
       "name": "Search Accounts",
       "description": "Search Salesforce accounts with business context for support or sales work",
       "requiresWrite": false,
@@ -82,7 +82,7 @@
       }
     },
     {
-      "id": "get_account",
+      "id": "salesforce__get_account",
       "name": "Get Account",
       "description": "Get detailed information about a specific account",
       "requiresWrite": false,
@@ -100,7 +100,7 @@
       }
     },
     {
-      "id": "search_contacts",
+      "id": "salesforce__search_contacts",
       "name": "Search Contacts",
       "description": "Search contacts with account fields for CRM follow-up and support context",
       "requiresWrite": false,
@@ -121,7 +121,7 @@
       }
     },
     {
-      "id": "get_contact",
+      "id": "salesforce__get_contact",
       "name": "Get Contact",
       "description": "Get a Salesforce contact by ID",
       "requiresWrite": false,
@@ -139,7 +139,7 @@
       }
     },
     {
-      "id": "list_cases",
+      "id": "salesforce__list_cases",
       "name": "List Cases",
       "description": "List Service Cloud cases for a customer, account, owner, status, or queue",
       "requiresWrite": false,
@@ -160,7 +160,7 @@
       }
     },
     {
-      "id": "get_case",
+      "id": "salesforce__get_case",
       "name": "Get Case",
       "description": "Get a Service Cloud case by ID",
       "requiresWrite": false,
@@ -178,7 +178,7 @@
       }
     },
     {
-      "id": "list_case_activity",
+      "id": "salesforce__list_case_activity",
       "name": "List Case Activity",
       "description": "List case comments for support handoff, timeline review, and resolution context",
       "requiresWrite": false,
@@ -199,7 +199,7 @@
       }
     },
     {
-      "id": "search_knowledge_articles",
+      "id": "salesforce__search_knowledge_articles",
       "name": "Search Knowledge Articles",
       "description": "Search published Salesforce Knowledge articles that can help answer or deflect a support case",
       "requiresWrite": false,
@@ -220,7 +220,7 @@
       }
     },
     {
-      "id": "list_opportunities",
+      "id": "salesforce__list_opportunities",
       "name": "List Opportunities",
       "description": "List Sales Cloud opportunities for account planning and customer context",
       "requiresWrite": false,
@@ -241,7 +241,7 @@
       }
     },
     {
-      "id": "create_lead",
+      "id": "salesforce__create_lead",
       "name": "Create Lead",
       "description": "Create a new lead in Salesforce CRM",
       "requiresWrite": true,
@@ -279,7 +279,7 @@
       }
     },
     {
-      "id": "create_case",
+      "id": "salesforce__create_case",
       "name": "Create Case",
       "description": "Create a Service Cloud case for customer support",
       "requiresWrite": true,
@@ -326,7 +326,7 @@
       }
     },
     {
-      "id": "add_case_comment",
+      "id": "salesforce__add_case_comment",
       "name": "Add Case Comment",
       "description": "Add a support note or customer-visible comment to a Service Cloud case",
       "requiresWrite": true,
@@ -353,7 +353,7 @@
       }
     },
     {
-      "id": "update_case",
+      "id": "salesforce__update_case",
       "name": "Update Case",
       "description": "Update status, priority, owner, or resolution fields on a Service Cloud case",
       "requiresWrite": true,
@@ -397,7 +397,7 @@
       }
     },
     {
-      "id": "describe_object",
+      "id": "salesforce__describe_object",
       "name": "Describe Object",
       "description": "Get metadata and field definitions for a Salesforce object",
       "requiresWrite": false,
@@ -415,7 +415,7 @@
       }
     },
     {
-      "id": "run_soql_query",
+      "id": "salesforce__run_soql_query",
       "name": "Run SOQL Query",
       "description": "Run a read-only SOQL query for expert inspection when curated tools are not enough",
       "requiresWrite": false,

--- a/cli/templates/integrations/sap/connector.json
+++ b/cli/templates/integrations/sap/connector.json
@@ -31,7 +31,7 @@
   ],
   "tools": [
     {
-      "id": "list_supplier_invoices",
+      "id": "sap__list_supplier_invoices",
       "name": "List Supplier Invoices",
       "description": "List supplier invoices from SAP S/4HANA with optional OData filters",
       "requiresWrite": false,
@@ -72,7 +72,7 @@
       }
     },
     {
-      "id": "get_supplier_invoice",
+      "id": "sap__get_supplier_invoice",
       "name": "Get Supplier Invoice",
       "description": "Get a supplier invoice by invoice number and fiscal year",
       "requiresWrite": false,
@@ -108,7 +108,7 @@
       }
     },
     {
-      "id": "release_supplier_invoice",
+      "id": "sap__release_supplier_invoice",
       "name": "Release Supplier Invoice",
       "description": "Release a blocked supplier invoice in SAP S/4HANA",
       "requiresWrite": true,

--- a/cli/templates/integrations/segment/connector.json
+++ b/cli/templates/integrations/segment/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_sources",
+      "id": "segment__list_sources",
       "name": "List Sources",
       "description": "List sources in the Segment workspace",
       "requiresWrite": false,
@@ -95,7 +95,7 @@
       }
     },
     {
-      "id": "get_source",
+      "id": "segment__get_source",
       "name": "Get Source",
       "description": "Get a source by ID",
       "requiresWrite": false,
@@ -122,7 +122,7 @@
       }
     },
     {
-      "id": "create_source",
+      "id": "segment__create_source",
       "name": "Create Source",
       "description": "Create a new source in the workspace",
       "requiresWrite": true,
@@ -164,7 +164,7 @@
       }
     },
     {
-      "id": "update_source",
+      "id": "segment__update_source",
       "name": "Update Source",
       "description": "Update a source's name, slug, enabled state, or settings",
       "requiresWrite": true,
@@ -209,7 +209,7 @@
       }
     },
     {
-      "id": "list_destinations",
+      "id": "segment__list_destinations",
       "name": "List Destinations",
       "description": "List destinations in the Segment workspace",
       "requiresWrite": false,
@@ -275,7 +275,7 @@
       }
     },
     {
-      "id": "get_destination",
+      "id": "segment__get_destination",
       "name": "Get Destination",
       "description": "Get a destination by ID",
       "requiresWrite": false,
@@ -302,7 +302,7 @@
       }
     },
     {
-      "id": "create_destination",
+      "id": "segment__create_destination",
       "name": "Create Destination",
       "description": "Connect a new destination to a source",
       "requiresWrite": true,

--- a/cli/templates/integrations/sendcloud/connector.json
+++ b/cli/templates/integrations/sendcloud/connector.json
@@ -34,7 +34,7 @@
   ],
   "tools": [
     {
-      "id": "list_shipments",
+      "id": "sendcloud__list_shipments",
       "name": "List Shipments",
       "description": "List shipments (parcels) in the Sendcloud account with optional filters such as order number, tracking number, or update time",
       "requiresWrite": false,
@@ -85,7 +85,7 @@
       }
     },
     {
-      "id": "get_shipment",
+      "id": "sendcloud__get_shipment",
       "name": "Get Shipment",
       "description": "Get a single shipment with its parcels, addresses, tracking numbers, and label documents",
       "requiresWrite": false,
@@ -103,7 +103,7 @@
       }
     },
     {
-      "id": "create_shipment",
+      "id": "sendcloud__create_shipment",
       "name": "Create Shipment",
       "description": "Create and announce a shipment synchronously, generating a shipping label for one or more parcels",
       "requiresWrite": true,
@@ -151,7 +151,7 @@
       }
     },
     {
-      "id": "list_shipping_options",
+      "id": "sendcloud__list_shipping_options",
       "name": "List Shipping Options",
       "description": "List available carrier shipping options (methods) for a given route and parcel, optionally with price quotes",
       "requiresWrite": false,
@@ -185,7 +185,7 @@
       }
     },
     {
-      "id": "get_tracking",
+      "id": "sendcloud__get_tracking",
       "name": "Get Tracking",
       "description": "Get the current status and recent tracking events of a parcel by its carrier tracking number",
       "requiresWrite": false,
@@ -203,7 +203,7 @@
       }
     },
     {
-      "id": "cancel_shipment",
+      "id": "sendcloud__cancel_shipment",
       "name": "Cancel Shipment",
       "description": "Cancel an announced shipment and its label before carrier collection — the undo for a mis-announced (cost-incurring) label; cancellation is no longer possible once the carrier has the parcel",
       "requiresWrite": true,

--- a/cli/templates/integrations/sendgrid/connector.json
+++ b/cli/templates/integrations/sendgrid/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "send_email",
+      "id": "sendgrid__send_email",
       "name": "Send Email",
       "description": "Send an email via the SendGrid v3 Mail Send API",
       "requiresWrite": true,
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "list_contacts",
+      "id": "sendgrid__list_contacts",
       "name": "List Contacts",
       "description": "List marketing contacts in the account",
       "requiresWrite": false,
@@ -87,7 +87,7 @@
       }
     },
     {
-      "id": "search_contacts",
+      "id": "sendgrid__search_contacts",
       "name": "Search Contacts",
       "description": "Search marketing contacts with an SGQL query (read-only search via POST)",
       "requiresWrite": false,
@@ -107,7 +107,7 @@
       }
     },
     {
-      "id": "upsert_contacts",
+      "id": "sendgrid__upsert_contacts",
       "name": "Upsert Contacts",
       "description": "Add or update marketing contacts (asynchronous; returns a job_id)",
       "requiresWrite": true,
@@ -128,7 +128,7 @@
       }
     },
     {
-      "id": "list_templates",
+      "id": "sendgrid__list_templates",
       "name": "List Templates",
       "description": "List transactional email templates",
       "requiresWrite": false,
@@ -157,7 +157,7 @@
       }
     },
     {
-      "id": "get_email_stats",
+      "id": "sendgrid__get_email_stats",
       "name": "Get Email Stats",
       "description": "Get global email statistics (delivered, opens, clicks, bounces) for a date range",
       "requiresWrite": false,

--- a/cli/templates/integrations/sentry/connector.json
+++ b/cli/templates/integrations/sentry/connector.json
@@ -44,7 +44,7 @@
   ],
   "tools": [
     {
-      "id": "list_organizations",
+      "id": "sentry__list_organizations",
       "name": "List Organizations",
       "description": "List Sentry organizations available to the authenticated user so agents can discover organization slugs before project or issue calls",
       "requiresWrite": false,
@@ -71,7 +71,7 @@
       }
     },
     {
-      "id": "list_projects",
+      "id": "sentry__list_projects",
       "name": "List Projects",
       "description": "List Sentry projects for an organization",
       "requiresWrite": false,
@@ -94,7 +94,7 @@
       }
     },
     {
-      "id": "list_issues",
+      "id": "sentry__list_issues",
       "name": "List Issues",
       "description": "List Sentry issues for a project",
       "requiresWrite": false,
@@ -138,7 +138,7 @@
       }
     },
     {
-      "id": "get_issue",
+      "id": "sentry__get_issue",
       "name": "Get Issue",
       "description": "Get details for a Sentry issue",
       "requiresWrite": false,
@@ -167,7 +167,7 @@
       }
     },
     {
-      "id": "resolve_issue",
+      "id": "sentry__resolve_issue",
       "name": "Resolve Issue",
       "description": "Resolve a Sentry issue",
       "requiresWrite": true,
@@ -202,7 +202,7 @@
       }
     },
     {
-      "id": "get_latest_event",
+      "id": "sentry__get_latest_event",
       "name": "Get Latest Event",
       "description": "Get the latest event for a Sentry issue, including the stack trace and tags needed for root-cause analysis",
       "requiresWrite": false,

--- a/cli/templates/integrations/serpapi/connector.json
+++ b/cli/templates/integrations/serpapi/connector.json
@@ -27,7 +27,7 @@
   ],
   "tools": [
     {
-      "id": "google_search",
+      "id": "serpapi__google_search",
       "name": "Google Search",
       "description": "Run a Google web search and get structured organic results, answer boxes, and related data",
       "requiresWrite": false,
@@ -66,7 +66,7 @@
       }
     },
     {
-      "id": "google_news",
+      "id": "serpapi__google_news",
       "name": "Google News Search",
       "description": "Search Google News and get structured article results with titles, sources, and publish dates",
       "requiresWrite": false,
@@ -90,7 +90,7 @@
       }
     },
     {
-      "id": "google_maps",
+      "id": "serpapi__google_maps",
       "name": "Google Maps Search",
       "description": "Search Google Maps for places and get structured local results with addresses, ratings, and coordinates",
       "requiresWrite": false,
@@ -119,7 +119,7 @@
       }
     },
     {
-      "id": "google_shopping",
+      "id": "serpapi__google_shopping",
       "name": "Google Shopping Search",
       "description": "Search Google Shopping and get structured product results with prices, merchants, and ratings",
       "requiresWrite": false,

--- a/cli/templates/integrations/servicenow/connector.json
+++ b/cli/templates/integrations/servicenow/connector.json
@@ -22,7 +22,7 @@
   },
   "tools": [
     {
-      "id": "list_incidents",
+      "id": "servicenow__list_incidents",
       "name": "List Incidents",
       "description": "List ServiceNow incidents with optional filters",
       "requiresWrite": false,
@@ -61,7 +61,7 @@
       }
     },
     {
-      "id": "get_incident",
+      "id": "servicenow__get_incident",
       "name": "Get Incident",
       "description": "Get details of a specific incident",
       "requiresWrite": false,
@@ -94,7 +94,7 @@
       }
     },
     {
-      "id": "create_incident",
+      "id": "servicenow__create_incident",
       "name": "Create Incident",
       "description": "Create a new incident in ServiceNow",
       "requiresWrite": true,
@@ -142,7 +142,7 @@
       }
     },
     {
-      "id": "update_incident",
+      "id": "servicenow__update_incident",
       "name": "Update Incident",
       "description": "Update an existing incident",
       "requiresWrite": true,
@@ -195,7 +195,7 @@
       }
     },
     {
-      "id": "list_interactions",
+      "id": "servicenow__list_interactions",
       "name": "List Interactions",
       "description": "List ServiceNow Interaction records used for request-desk intake and routing",
       "requiresWrite": false,
@@ -234,7 +234,7 @@
       }
     },
     {
-      "id": "get_interaction",
+      "id": "servicenow__get_interaction",
       "name": "Get Interaction",
       "description": "Get details of a specific ServiceNow Interaction record",
       "requiresWrite": false,
@@ -267,7 +267,7 @@
       }
     },
     {
-      "id": "create_interaction",
+      "id": "servicenow__create_interaction",
       "name": "Create Interaction",
       "description": "Create a ServiceNow Interaction intake record before converting or linking it to an incident or request",
       "requiresWrite": true,
@@ -319,7 +319,7 @@
       }
     },
     {
-      "id": "update_interaction",
+      "id": "servicenow__update_interaction",
       "name": "Update Interaction",
       "description": "Update an existing ServiceNow Interaction with routing status, parent record, notes, or comments",
       "requiresWrite": true,
@@ -372,7 +372,7 @@
       }
     },
     {
-      "id": "list_requests",
+      "id": "servicenow__list_requests",
       "name": "List Requests",
       "description": "List ServiceNow service request records from the sc_request table",
       "requiresWrite": false,
@@ -411,7 +411,7 @@
       }
     },
     {
-      "id": "get_request",
+      "id": "servicenow__get_request",
       "name": "Get Request",
       "description": "Get details of a specific ServiceNow service request",
       "requiresWrite": false,
@@ -444,7 +444,7 @@
       }
     },
     {
-      "id": "create_request",
+      "id": "servicenow__create_request",
       "name": "Create Request",
       "description": "Order a Service Catalog item to create a workflow-backed ServiceNow request",
       "requiresWrite": true,
@@ -482,7 +482,7 @@
       }
     },
     {
-      "id": "list_request_items",
+      "id": "servicenow__list_request_items",
       "name": "List Request Items",
       "description": "List ServiceNow requested item records from the sc_req_item table",
       "requiresWrite": false,
@@ -521,7 +521,7 @@
       }
     },
     {
-      "id": "get_request_item",
+      "id": "servicenow__get_request_item",
       "name": "Get Request Item",
       "description": "Get details of a specific ServiceNow requested item",
       "requiresWrite": false,
@@ -554,7 +554,7 @@
       }
     },
     {
-      "id": "create_request_item",
+      "id": "servicenow__create_request_item",
       "name": "Create Request Item",
       "description": "Create a requested item table record when direct sc_req_item writes are allowed",
       "requiresWrite": true,
@@ -619,7 +619,7 @@
       }
     },
     {
-      "id": "search_knowledge",
+      "id": "servicenow__search_knowledge",
       "name": "Search Knowledge Base",
       "description": "Search ServiceNow knowledge base articles",
       "requiresWrite": false,
@@ -658,7 +658,7 @@
       }
     },
     {
-      "id": "search_users",
+      "id": "servicenow__search_users",
       "name": "Search Users",
       "description": "Search ServiceNow users to find the sys_id needed for assigning incidents",
       "requiresWrite": false,
@@ -697,7 +697,7 @@
       }
     },
     {
-      "id": "query_table",
+      "id": "servicenow__query_table",
       "name": "Query Table",
       "description": "Query any ServiceNow table with an encoded query (covers change requests, problems, CMDB, catalog tasks, etc.)",
       "requiresWrite": false,
@@ -745,7 +745,7 @@
       }
     },
     {
-      "id": "create_table_record",
+      "id": "servicenow__create_table_record",
       "name": "Create Table Record",
       "description": "Create a record in any ServiceNow table",
       "requiresWrite": true,
@@ -780,7 +780,7 @@
       }
     },
     {
-      "id": "update_table_record",
+      "id": "servicenow__update_table_record",
       "name": "Update Table Record",
       "description": "Update a record in any ServiceNow table",
       "requiresWrite": true,

--- a/cli/templates/integrations/sevdesk/connector.json
+++ b/cli/templates/integrations/sevdesk/connector.json
@@ -27,7 +27,7 @@
   ],
   "tools": [
     {
-      "id": "list_contacts",
+      "id": "sevdesk__list_contacts",
       "name": "List Contacts",
       "description": "List sevdesk contacts (organizations and persons), e.g. to find a contact id before creating an invoice",
       "requiresWrite": false,
@@ -64,7 +64,7 @@
       }
     },
     {
-      "id": "list_invoices",
+      "id": "sevdesk__list_invoices",
       "name": "List Invoices",
       "description": "List sevdesk invoices with optional status, number, date, and contact filters",
       "requiresWrite": false,
@@ -120,7 +120,7 @@
       }
     },
     {
-      "id": "get_invoice",
+      "id": "sevdesk__get_invoice",
       "name": "Get Invoice",
       "description": "Retrieve a single sevdesk invoice by its id",
       "requiresWrite": false,
@@ -141,7 +141,7 @@
       }
     },
     {
-      "id": "create_invoice",
+      "id": "sevdesk__create_invoice",
       "name": "Create Invoice",
       "description": "Create a sevdesk invoice with positions via the saveInvoice factory endpoint; create with status 100 for an editable draft",
       "requiresWrite": true,
@@ -179,7 +179,7 @@
       }
     },
     {
-      "id": "upload_voucher_file",
+      "id": "sevdesk__upload_voucher_file",
       "name": "Upload Voucher File",
       "description": "Upload a receipt or invoice file to sevdesk; returns an internal filename that can be attached when creating a voucher",
       "requiresWrite": true,
@@ -208,7 +208,7 @@
       }
     },
     {
-      "id": "list_vouchers",
+      "id": "sevdesk__list_vouchers",
       "name": "List Vouchers",
       "description": "List sevdesk accounting vouchers (receipts) with optional status, type, date, and description filters",
       "requiresWrite": false,
@@ -259,7 +259,7 @@
       }
     },
     {
-      "id": "create_voucher",
+      "id": "sevdesk__create_voucher",
       "name": "Create Voucher",
       "description": "Create a bookable voucher (receipt) with positions via the saveVoucher factory endpoint — the step that turns a file staged with Upload Voucher File into an actual accounting record",
       "requiresWrite": true,
@@ -292,7 +292,7 @@
       }
     },
     {
-      "id": "get_invoice_pdf",
+      "id": "sevdesk__get_invoice_pdf",
       "name": "Get Invoice PDF",
       "description": "Retrieve the rendered PDF document of an invoice for sending or archiving",
       "requiresWrite": false,
@@ -323,7 +323,7 @@
       }
     },
     {
-      "id": "book_invoice_amount",
+      "id": "sevdesk__book_invoice_amount",
       "name": "Book Invoice Amount",
       "description": "Register a (partial) payment on an invoice and mark it paid when settled — closes the reconciliation loop after money arrives",
       "requiresWrite": true,

--- a/cli/templates/integrations/sharepoint/connector.json
+++ b/cli/templates/integrations/sharepoint/connector.json
@@ -42,7 +42,7 @@
   ],
   "tools": [
     {
-      "id": "list_sites",
+      "id": "sharepoint__list_sites",
       "name": "List SharePoint Sites",
       "description": "List all SharePoint sites the user has access to",
       "requiresWrite": false,
@@ -69,7 +69,7 @@
       }
     },
     {
-      "id": "get_site",
+      "id": "sharepoint__get_site",
       "name": "Get Site Details",
       "description": "Get detailed information about a specific SharePoint site",
       "requiresWrite": false,
@@ -87,7 +87,7 @@
       }
     },
     {
-      "id": "list_files",
+      "id": "sharepoint__list_files",
       "name": "List Files",
       "description": "List files and folders in a SharePoint document library",
       "requiresWrite": false,
@@ -111,7 +111,7 @@
       }
     },
     {
-      "id": "get_file",
+      "id": "sharepoint__get_file",
       "name": "Get File",
       "description": "Get file metadata and content from SharePoint",
       "requiresWrite": false,
@@ -135,7 +135,7 @@
       }
     },
     {
-      "id": "upload_file",
+      "id": "sharepoint__upload_file",
       "name": "Upload File",
       "description": "Upload a file to a SharePoint document library",
       "requiresWrite": true,
@@ -173,7 +173,7 @@
       }
     },
     {
-      "id": "search_files",
+      "id": "sharepoint__search_files",
       "name": "Search Files",
       "description": "Search for files and folders in a SharePoint document library by name or content",
       "requiresWrite": false,
@@ -206,7 +206,7 @@
       }
     },
     {
-      "id": "download_file",
+      "id": "sharepoint__download_file",
       "name": "Download File",
       "description": "Download file content from a SharePoint document library",
       "requiresWrite": false,

--- a/cli/templates/integrations/sheets/connector.json
+++ b/cli/templates/integrations/sheets/connector.json
@@ -43,7 +43,7 @@
   ],
   "tools": [
     {
-      "id": "list_spreadsheets",
+      "id": "sheets__list_spreadsheets",
       "name": "List Spreadsheets",
       "description": "List recent Google Sheets spreadsheets from Drive",
       "requiresWrite": false,
@@ -81,7 +81,7 @@
       }
     },
     {
-      "id": "get_spreadsheet",
+      "id": "sheets__get_spreadsheet",
       "name": "Get Spreadsheet",
       "description": "Get spreadsheet metadata including sheet names and properties",
       "requiresWrite": false,
@@ -110,7 +110,7 @@
       }
     },
     {
-      "id": "read_range",
+      "id": "sheets__read_range",
       "name": "Read Range",
       "description": "Read cell data from a spreadsheet range",
       "requiresWrite": false,
@@ -144,7 +144,7 @@
       }
     },
     {
-      "id": "write_range",
+      "id": "sheets__write_range",
       "name": "Write Range",
       "description": "Write data to a spreadsheet range",
       "requiresWrite": true,
@@ -192,7 +192,7 @@
       }
     },
     {
-      "id": "create_spreadsheet",
+      "id": "sheets__create_spreadsheet",
       "name": "Create Spreadsheet",
       "description": "Create a new spreadsheet with optional initial data",
       "requiresWrite": true,
@@ -213,7 +213,7 @@
       }
     },
     {
-      "id": "append_rows",
+      "id": "sheets__append_rows",
       "name": "Append Rows",
       "description": "Append rows to a spreadsheet range",
       "requiresWrite": true,
@@ -267,7 +267,7 @@
       }
     },
     {
-      "id": "clear_range",
+      "id": "sheets__clear_range",
       "name": "Clear Range",
       "description": "Clear values from a spreadsheet range",
       "requiresWrite": true,
@@ -292,7 +292,7 @@
       }
     },
     {
-      "id": "batch_update",
+      "id": "sheets__batch_update",
       "name": "Batch Update",
       "description": "Run raw Google Sheets batchUpdate requests for formatting and structural changes",
       "requiresWrite": true,
@@ -321,7 +321,7 @@
       }
     },
     {
-      "id": "add_sheet",
+      "id": "sheets__add_sheet",
       "name": "Add Sheet",
       "description": "Add a new sheet/tab to a spreadsheet",
       "requiresWrite": true,
@@ -346,7 +346,7 @@
       }
     },
     {
-      "id": "delete_sheet",
+      "id": "sheets__delete_sheet",
       "name": "Delete Sheet",
       "description": "Delete a sheet/tab from a spreadsheet by sheet ID",
       "requiresWrite": true,
@@ -371,7 +371,7 @@
       }
     },
     {
-      "id": "rename_sheet",
+      "id": "sheets__rename_sheet",
       "name": "Rename Sheet",
       "description": "Rename a sheet/tab by sheet ID",
       "requiresWrite": true,
@@ -396,7 +396,7 @@
       }
     },
     {
-      "id": "delete_spreadsheet",
+      "id": "sheets__delete_spreadsheet",
       "name": "Delete Spreadsheet",
       "description": "Move an app-accessible spreadsheet file to trash",
       "requiresWrite": true,
@@ -421,7 +421,7 @@
       }
     },
     {
-      "id": "find_replace",
+      "id": "sheets__find_replace",
       "name": "Find and Replace",
       "description": "Find and replace text in a spreadsheet or sheet",
       "requiresWrite": true,
@@ -446,7 +446,7 @@
       }
     },
     {
-      "id": "copy_sheet",
+      "id": "sheets__copy_sheet",
       "name": "Copy Sheet",
       "description": "Copy a sheet/tab to another spreadsheet",
       "requiresWrite": true,
@@ -477,7 +477,7 @@
       }
     },
     {
-      "id": "create_chart",
+      "id": "sheets__create_chart",
       "name": "Create Chart",
       "description": "Create an embedded chart using a Sheets API chart specification",
       "requiresWrite": true,
@@ -502,7 +502,7 @@
       }
     },
     {
-      "id": "set_data_validation",
+      "id": "sheets__set_data_validation",
       "name": "Set Data Validation",
       "description": "Set data validation rules on a sheet range",
       "requiresWrite": true,

--- a/cli/templates/integrations/shopify/connector.json
+++ b/cli/templates/integrations/shopify/connector.json
@@ -42,31 +42,31 @@
   ],
   "tools": [
     {
-      "id": "list_products",
+      "id": "shopify__list_products",
       "name": "List Products",
       "description": "List products in your Shopify store",
       "requiresWrite": false
     },
     {
-      "id": "get_product",
+      "id": "shopify__get_product",
       "name": "Get Product",
       "description": "Get details of a specific product",
       "requiresWrite": false
     },
     {
-      "id": "list_orders",
+      "id": "shopify__list_orders",
       "name": "List Orders",
       "description": "List orders from your Shopify store",
       "requiresWrite": false
     },
     {
-      "id": "get_order",
+      "id": "shopify__get_order",
       "name": "Get Order",
       "description": "Get details of a specific order",
       "requiresWrite": false
     },
     {
-      "id": "list_customers",
+      "id": "shopify__list_customers",
       "name": "List Customers",
       "description": "List customers in your Shopify store",
       "requiresWrite": false

--- a/cli/templates/integrations/shopware/connector.json
+++ b/cli/templates/integrations/shopware/connector.json
@@ -42,7 +42,7 @@
   ],
   "tools": [
     {
-      "id": "search_products",
+      "id": "shopware__search_products",
       "name": "Search Products",
       "description": "Search products with the Admin API search criteria (term, filters, sorting, paging)",
       "requiresWrite": false,
@@ -89,7 +89,7 @@
       }
     },
     {
-      "id": "search_orders",
+      "id": "shopware__search_orders",
       "name": "Search Orders",
       "description": "Search orders with the Admin API search criteria (filters, sorting, paging)",
       "requiresWrite": false,
@@ -136,7 +136,7 @@
       }
     },
     {
-      "id": "search_customers",
+      "id": "shopware__search_customers",
       "name": "Search Customers",
       "description": "Search customers with the Admin API search criteria (term, filters, sorting, paging)",
       "requiresWrite": false,
@@ -183,7 +183,7 @@
       }
     },
     {
-      "id": "get_order",
+      "id": "shopware__get_order",
       "name": "Get Order",
       "description": "Get full details of a single order by ID",
       "requiresWrite": false,
@@ -210,7 +210,7 @@
       }
     },
     {
-      "id": "get_product",
+      "id": "shopware__get_product",
       "name": "Get Product",
       "description": "Get full details of a single product by ID",
       "requiresWrite": false,
@@ -237,7 +237,7 @@
       }
     },
     {
-      "id": "create_product",
+      "id": "shopware__create_product",
       "name": "Create Product",
       "description": "Create a new product (requires name, productNumber, stock, taxId, and a price array)",
       "requiresWrite": true,
@@ -272,7 +272,7 @@
       }
     },
     {
-      "id": "update_product",
+      "id": "shopware__update_product",
       "name": "Update Product",
       "description": "Partially update a product, e.g. change its price, stock, or visibility",
       "requiresWrite": true,
@@ -313,7 +313,7 @@
       }
     },
     {
-      "id": "transition_order_state",
+      "id": "shopware__transition_order_state",
       "name": "Transition Order State",
       "description": "Move an order to its next state via a state machine transition (e.g. process, complete, cancel, reopen)",
       "requiresWrite": true,

--- a/cli/templates/integrations/shortcut/connector.json
+++ b/cli/templates/integrations/shortcut/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "search_stories",
+      "id": "shortcut__search_stories",
       "name": "Search Stories",
       "description": "Search Shortcut stories with the Shortcut search syntax",
       "requiresWrite": false,
@@ -108,7 +108,7 @@
       }
     },
     {
-      "id": "get_story",
+      "id": "shortcut__get_story",
       "name": "Get Story",
       "description": "Get a Shortcut story by its public ID",
       "requiresWrite": false,
@@ -126,7 +126,7 @@
       }
     },
     {
-      "id": "create_story",
+      "id": "shortcut__create_story",
       "name": "Create Story",
       "description": "Create a new story in Shortcut",
       "requiresWrite": true,
@@ -168,7 +168,7 @@
       }
     },
     {
-      "id": "update_story",
+      "id": "shortcut__update_story",
       "name": "Update Story",
       "description": "Update an existing Shortcut story",
       "requiresWrite": true,
@@ -216,7 +216,7 @@
       }
     },
     {
-      "id": "list_epics",
+      "id": "shortcut__list_epics",
       "name": "List Epics",
       "description": "List epics in the Shortcut workspace",
       "requiresWrite": false,
@@ -268,7 +268,7 @@
       }
     },
     {
-      "id": "list_members",
+      "id": "shortcut__list_members",
       "name": "List Members",
       "description": "List members of the Shortcut workspace (use member UUIDs as owner_ids)",
       "requiresWrite": false,
@@ -278,7 +278,7 @@
       }
     },
     {
-      "id": "list_workflows",
+      "id": "shortcut__list_workflows",
       "name": "List Workflows",
       "description": "List workflows and their states (use state IDs as workflow_state_id)",
       "requiresWrite": false,

--- a/cli/templates/integrations/slack/connector.json
+++ b/cli/templates/integrations/slack/connector.json
@@ -40,7 +40,7 @@
   ],
   "tools": [
     {
-      "id": "list_channels",
+      "id": "slack__list_channels",
       "name": "List Channels",
       "description": "Get list of Slack channels",
       "requiresWrite": false,
@@ -98,7 +98,7 @@
       }
     },
     {
-      "id": "send_message",
+      "id": "slack__send_message",
       "name": "Send Message",
       "description": "Send a message to a Slack channel",
       "requiresWrite": true,
@@ -114,7 +114,7 @@
       }
     },
     {
-      "id": "update_message",
+      "id": "slack__update_message",
       "name": "Update Message",
       "description": "Update a message previously sent by this integration",
       "requiresWrite": true,
@@ -129,7 +129,7 @@
       }
     },
     {
-      "id": "delete_message",
+      "id": "slack__delete_message",
       "name": "Delete Message",
       "description": "Delete a message previously sent by this integration",
       "requiresWrite": true,
@@ -143,7 +143,7 @@
       }
     },
     {
-      "id": "get_messages",
+      "id": "slack__get_messages",
       "name": "Get Messages",
       "description": "Get recent messages from a channel",
       "requiresWrite": false,
@@ -159,7 +159,7 @@
       }
     },
     {
-      "id": "get_thread",
+      "id": "slack__get_thread",
       "name": "Get Thread",
       "description": "Get all replies in a Slack message thread",
       "requiresWrite": false,
@@ -175,7 +175,7 @@
       }
     },
     {
-      "id": "list_users",
+      "id": "slack__list_users",
       "name": "List Users",
       "description": "List members of the Slack workspace",
       "requiresWrite": false,

--- a/cli/templates/integrations/snowflake/connector.json
+++ b/cli/templates/integrations/snowflake/connector.json
@@ -69,7 +69,7 @@
   ],
   "tools": [
     {
-      "id": "run_query",
+      "id": "snowflake__run_query",
       "name": "Run Query",
       "description": "Execute a SQL query against your Snowflake data warehouse",
       "requiresWrite": true,
@@ -121,25 +121,25 @@
       }
     },
     {
-      "id": "list_databases",
+      "id": "snowflake__list_databases",
       "name": "List Databases",
       "description": "List all databases in your Snowflake account",
       "requiresWrite": false
     },
     {
-      "id": "list_schemas",
+      "id": "snowflake__list_schemas",
       "name": "List Schemas",
       "description": "List all schemas in a Snowflake database",
       "requiresWrite": false
     },
     {
-      "id": "list_tables",
+      "id": "snowflake__list_tables",
       "name": "List Tables",
       "description": "List all tables in a Snowflake database schema",
       "requiresWrite": false
     },
     {
-      "id": "describe_table",
+      "id": "snowflake__describe_table",
       "name": "Describe Table",
       "description": "Get detailed column information for a specific table",
       "requiresWrite": false

--- a/cli/templates/integrations/snyk/connector.json
+++ b/cli/templates/integrations/snyk/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_orgs",
+      "id": "snyk__list_orgs",
       "name": "List Organizations",
       "description": "List Snyk organizations the token can access",
       "requiresWrite": false,
@@ -50,7 +50,7 @@
       }
     },
     {
-      "id": "list_projects",
+      "id": "snyk__list_projects",
       "name": "List Projects",
       "description": "List projects in a Snyk organization",
       "requiresWrite": false,
@@ -98,7 +98,7 @@
       }
     },
     {
-      "id": "get_project",
+      "id": "snyk__get_project",
       "name": "Get Project",
       "description": "Get a project's details in a Snyk organization",
       "requiresWrite": false,
@@ -128,7 +128,7 @@
       }
     },
     {
-      "id": "list_issues",
+      "id": "snyk__list_issues",
       "name": "List Issues",
       "description": "List security issues in a Snyk organization, optionally filtered by severity or status",
       "requiresWrite": false,
@@ -171,7 +171,7 @@
       }
     },
     {
-      "id": "get_org",
+      "id": "snyk__get_org",
       "name": "Get Organization",
       "description": "Get details of a Snyk organization",
       "requiresWrite": false,

--- a/cli/templates/integrations/sprites/connector.json
+++ b/cli/templates/integrations/sprites/connector.json
@@ -29,7 +29,7 @@
   ],
   "tools": [
     {
-      "id": "list_sprites",
+      "id": "sprites__list_sprites",
       "name": "List Sprites",
       "description": "List sprites in the organization, optionally filtered by name prefix and paginated",
       "requiresWrite": false,
@@ -57,7 +57,7 @@
       }
     },
     {
-      "id": "create_sprite",
+      "id": "sprites__create_sprite",
       "name": "Create Sprite",
       "description": "Create a new sprite — a persistent, hardware-isolated Linux VM that keeps its filesystem state between runs",
       "requiresWrite": true,
@@ -78,7 +78,7 @@
       }
     },
     {
-      "id": "get_sprite",
+      "id": "sprites__get_sprite",
       "name": "Get Sprite",
       "description": "Get a sprite by name, including its URL, runtime status (cold, warm, or running), and creation/activity timestamps",
       "requiresWrite": false,
@@ -96,7 +96,7 @@
       }
     },
     {
-      "id": "delete_sprite",
+      "id": "sprites__delete_sprite",
       "name": "Destroy Sprite",
       "description": "Destroy a sprite by name, permanently deleting the VM and its persisted filesystem state",
       "requiresWrite": true,
@@ -114,7 +114,7 @@
       }
     },
     {
-      "id": "exec_command",
+      "id": "sprites__exec_command",
       "name": "Execute Command",
       "description": "Execute a command inside a sprite over HTTP (non-interactive) and return its output as JSON",
       "requiresWrite": true,
@@ -148,7 +148,7 @@
       }
     },
     {
-      "id": "create_checkpoint",
+      "id": "sprites__create_checkpoint",
       "name": "Create Checkpoint",
       "description": "Create a point-in-time checkpoint of a sprite (filesystem and memory) before risky operations; the response is a stream of NDJSON progress events",
       "requiresWrite": true,
@@ -172,7 +172,7 @@
       }
     },
     {
-      "id": "list_checkpoints",
+      "id": "sprites__list_checkpoints",
       "name": "List Checkpoints",
       "description": "List a sprite's checkpoints with their IDs (e.g. v7), creation times, and comments — discover restore points",
       "requiresWrite": false,
@@ -190,7 +190,7 @@
       }
     },
     {
-      "id": "restore_checkpoint",
+      "id": "sprites__restore_checkpoint",
       "name": "Restore Checkpoint",
       "description": "Roll a sprite back to a checkpoint, replacing its current state with the snapshot; the response is a stream of NDJSON progress events",
       "requiresWrite": true,

--- a/cli/templates/integrations/square/connector.json
+++ b/cli/templates/integrations/square/connector.json
@@ -42,7 +42,7 @@
   ],
   "tools": [
     {
-      "id": "list_payments",
+      "id": "square__list_payments",
       "name": "List Payments",
       "description": "List payments taken by the seller account",
       "requiresWrite": false,
@@ -111,7 +111,7 @@
       }
     },
     {
-      "id": "get_payment",
+      "id": "square__get_payment",
       "name": "Get Payment",
       "description": "Get details of a payment",
       "requiresWrite": false,
@@ -139,7 +139,7 @@
       }
     },
     {
-      "id": "search_orders",
+      "id": "square__search_orders",
       "name": "Search Orders",
       "description": "Search orders across locations (read-only search via POST)",
       "requiresWrite": false,
@@ -178,7 +178,7 @@
       }
     },
     {
-      "id": "list_customers",
+      "id": "square__list_customers",
       "name": "List Customers",
       "description": "List customer profiles",
       "requiresWrite": false,
@@ -220,7 +220,7 @@
       }
     },
     {
-      "id": "list_locations",
+      "id": "square__list_locations",
       "name": "List Locations",
       "description": "List the seller's business locations",
       "requiresWrite": false,
@@ -242,7 +242,7 @@
       }
     },
     {
-      "id": "list_catalog",
+      "id": "square__list_catalog",
       "name": "List Catalog",
       "description": "List catalog objects such as items and categories",
       "requiresWrite": false,

--- a/cli/templates/integrations/stability-ai/connector.json
+++ b/cli/templates/integrations/stability-ai/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_engines",
+      "id": "stability-ai__list_engines",
       "name": "List Engines",
       "description": "List the generation engines (models) available to your account",
       "requiresWrite": false,
@@ -49,7 +49,7 @@
       }
     },
     {
-      "id": "get_balance",
+      "id": "stability-ai__get_balance",
       "name": "Get Balance",
       "description": "Get the credit balance of your Stability AI account",
       "requiresWrite": false,
@@ -59,7 +59,7 @@
       }
     },
     {
-      "id": "get_account",
+      "id": "stability-ai__get_account",
       "name": "Get Account",
       "description": "Get profile and organization details for the account that owns the API key",
       "requiresWrite": false,
@@ -69,7 +69,7 @@
       }
     },
     {
-      "id": "text_to_image",
+      "id": "stability-ai__text_to_image",
       "name": "Text to Image",
       "description": "Generate images from a text prompt with a Stable Diffusion engine (consumes credits)",
       "requiresWrite": true,

--- a/cli/templates/integrations/stackit/connector.json
+++ b/cli/templates/integrations/stackit/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "list_projects",
+      "id": "stackit__list_projects",
       "name": "List Projects",
       "description": "List STACKIT projects visible to the service account via the Resource Manager. At least one of containerParentId or member must be provided (use the service account's email as member).",
       "requiresWrite": false,
@@ -77,7 +77,7 @@
       }
     },
     {
-      "id": "list_servers",
+      "id": "stackit__list_servers",
       "name": "List Servers",
       "description": "List IaaS servers in a STACKIT project and region",
       "requiresWrite": false,
@@ -128,7 +128,7 @@
       }
     },
     {
-      "id": "get_server",
+      "id": "stackit__get_server",
       "name": "Get Server",
       "description": "Get a single IaaS server in a project and region, including status, machine type, and availability zone",
       "requiresWrite": false,
@@ -164,7 +164,7 @@
       }
     },
     {
-      "id": "list_machine_types",
+      "id": "stackit__list_machine_types",
       "name": "List Machine Types",
       "description": "List available machine types (server flavors) in a project and region, useful before creating or resizing servers",
       "requiresWrite": false,
@@ -207,7 +207,7 @@
       }
     },
     {
-      "id": "start_server",
+      "id": "stackit__start_server",
       "name": "Start Server",
       "description": "Boot up a stopped server, or allocate it again if it was deallocated (returns 202 Accepted; completes asynchronously)",
       "requiresWrite": true,
@@ -237,7 +237,7 @@
       }
     },
     {
-      "id": "stop_server",
+      "id": "stackit__stop_server",
       "name": "Stop Server",
       "description": "Stop a server (returns 202 Accepted; completes asynchronously). Note: a stopped server remains on the hypervisor and is still charged full price for its attached resources",
       "requiresWrite": true,
@@ -267,7 +267,7 @@
       }
     },
     {
-      "id": "reboot_server",
+      "id": "stackit__reboot_server",
       "name": "Reboot Server",
       "description": "Reboot a server (returns 202 Accepted; completes asynchronously); soft reboots ask the OS to shut down gracefully, hard reboots power-cycle",
       "requiresWrite": true,

--- a/cli/templates/integrations/stripe/connector.json
+++ b/cli/templates/integrations/stripe/connector.json
@@ -34,7 +34,7 @@
   ],
   "tools": [
     {
-      "id": "list_customers",
+      "id": "stripe__list_customers",
       "name": "List Customers",
       "description": "List Stripe customers with optional filtering",
       "requiresWrite": false,
@@ -78,7 +78,7 @@
       }
     },
     {
-      "id": "get_customer",
+      "id": "stripe__get_customer",
       "name": "Get Customer",
       "description": "Retrieve detailed information about a specific customer",
       "requiresWrite": false,
@@ -96,7 +96,7 @@
       }
     },
     {
-      "id": "list_payments",
+      "id": "stripe__list_payments",
       "name": "List Payments",
       "description": "List payment intents with optional status filtering",
       "requiresWrite": false,
@@ -141,7 +141,7 @@
       }
     },
     {
-      "id": "get_balance",
+      "id": "stripe__get_balance",
       "name": "Get Balance",
       "description": "Retrieve the current account balance",
       "requiresWrite": false,
@@ -151,7 +151,7 @@
       }
     },
     {
-      "id": "list_subscriptions",
+      "id": "stripe__list_subscriptions",
       "name": "List Subscriptions",
       "description": "List subscriptions with optional status filtering",
       "requiresWrite": false,
@@ -205,7 +205,7 @@
       }
     },
     {
-      "id": "list_invoices",
+      "id": "stripe__list_invoices",
       "name": "List Invoices",
       "description": "List invoices with optional customer and status filtering",
       "requiresWrite": false,
@@ -260,7 +260,7 @@
       }
     },
     {
-      "id": "list_charges",
+      "id": "stripe__list_charges",
       "name": "List Charges",
       "description": "List charges with optional customer or payment intent filtering",
       "requiresWrite": false,

--- a/cli/templates/integrations/supabase/connector.json
+++ b/cli/templates/integrations/supabase/connector.json
@@ -52,37 +52,37 @@
   ],
   "tools": [
     {
-      "id": "list_tables",
+      "id": "supabase__list_tables",
       "name": "List Tables",
       "description": "List all tables in your Supabase database",
       "requiresWrite": false
     },
     {
-      "id": "query_table",
+      "id": "supabase__query_table",
       "name": "Query Table",
       "description": "Select rows from a table with optional filters and sorting",
       "requiresWrite": false
     },
     {
-      "id": "insert_row",
+      "id": "supabase__insert_row",
       "name": "Insert Row",
       "description": "Insert a new row into a table",
       "requiresWrite": true
     },
     {
-      "id": "update_row",
+      "id": "supabase__update_row",
       "name": "Update Row",
       "description": "Update an existing row in a table",
       "requiresWrite": true
     },
     {
-      "id": "delete_row",
+      "id": "supabase__delete_row",
       "name": "Delete Row",
       "description": "Delete a row from a table",
       "requiresWrite": true
     },
     {
-      "id": "list_organizations",
+      "id": "supabase__list_organizations",
       "name": "List Organizations",
       "description": "List the organizations your access token can manage",
       "requiresWrite": false,
@@ -92,7 +92,7 @@
       }
     },
     {
-      "id": "list_projects",
+      "id": "supabase__list_projects",
       "name": "List Projects",
       "description": "List all Supabase projects across your organizations",
       "requiresWrite": false,
@@ -102,7 +102,7 @@
       }
     },
     {
-      "id": "get_project",
+      "id": "supabase__get_project",
       "name": "Get Project",
       "description": "Get details and status of a Supabase project",
       "requiresWrite": false,
@@ -120,7 +120,7 @@
       }
     },
     {
-      "id": "run_sql",
+      "id": "supabase__run_sql",
       "name": "Run SQL",
       "description": "Run a SQL query against a project's Postgres database via the Management API",
       "requiresWrite": true,

--- a/cli/templates/integrations/surveymonkey/connector.json
+++ b/cli/templates/integrations/surveymonkey/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "list_surveys",
+      "id": "surveymonkey__list_surveys",
       "name": "List Surveys",
       "description": "List surveys owned by or shared with the authenticated account",
       "requiresWrite": false,
@@ -82,7 +82,7 @@
       }
     },
     {
-      "id": "get_survey_details",
+      "id": "surveymonkey__get_survey_details",
       "name": "Get Survey Details",
       "description": "Get a survey's full design, including pages, questions, and answer option IDs needed to interpret responses",
       "requiresWrite": false,
@@ -100,7 +100,7 @@
       }
     },
     {
-      "id": "list_survey_responses",
+      "id": "surveymonkey__list_survey_responses",
       "name": "List Survey Responses",
       "description": "List full responses for a survey, including each answer keyed by question and choice IDs",
       "requiresWrite": false,
@@ -133,7 +133,7 @@
       }
     },
     {
-      "id": "get_response_details",
+      "id": "surveymonkey__get_response_details",
       "name": "Get Response Details",
       "description": "Get a single survey response with all answers expanded",
       "requiresWrite": false,
@@ -157,7 +157,7 @@
       }
     },
     {
-      "id": "get_survey_rollups",
+      "id": "surveymonkey__get_survey_rollups",
       "name": "Get Survey Rollups",
       "description": "Get aggregated answer counts and statistics per question — summarize results without paging every response",
       "requiresWrite": false,
@@ -195,7 +195,7 @@
       }
     },
     {
-      "id": "list_survey_folders",
+      "id": "surveymonkey__list_survey_folders",
       "name": "List Survey Folders",
       "description": "List the survey folders in the account to find folder IDs for filtering surveys",
       "requiresWrite": false,
@@ -222,7 +222,7 @@
       }
     },
     {
-      "id": "list_collectors",
+      "id": "surveymonkey__list_collectors",
       "name": "List Collectors",
       "description": "List the collectors (web links, email invitations, etc.) that gather responses for a survey",
       "requiresWrite": false,

--- a/cli/templates/integrations/tally/connector.json
+++ b/cli/templates/integrations/tally/connector.json
@@ -21,7 +21,7 @@
   ],
   "tools": [
     {
-      "id": "list_forms",
+      "id": "tally__list_forms",
       "name": "List Forms",
       "description": "List forms in the Tally account, optionally filtered by workspace",
       "requiresWrite": false,
@@ -50,7 +50,7 @@
       }
     },
     {
-      "id": "get_form",
+      "id": "tally__get_form",
       "name": "Get Form",
       "description": "Retrieve a single form by ID with all its blocks and settings",
       "requiresWrite": false,
@@ -68,7 +68,7 @@
       }
     },
     {
-      "id": "list_submissions",
+      "id": "tally__list_submissions",
       "name": "List Submissions",
       "description": "List submissions of a form with their responses, filterable by status and date range",
       "requiresWrite": false,
@@ -118,7 +118,7 @@
       }
     },
     {
-      "id": "get_submission",
+      "id": "tally__get_submission",
       "name": "Get Submission",
       "description": "Retrieve a specific form submission with all its responses and the form questions",
       "requiresWrite": false,
@@ -142,7 +142,7 @@
       }
     },
     {
-      "id": "list_form_questions",
+      "id": "tally__list_form_questions",
       "name": "List Form Questions",
       "description": "List a form's questions with their IDs, types, and response counts — lighter than parsing the full form blocks for mapping answers",
       "requiresWrite": false,
@@ -160,7 +160,7 @@
       }
     },
     {
-      "id": "list_workspaces",
+      "id": "tally__list_workspaces",
       "name": "List Workspaces",
       "description": "List workspaces with their members and pending invites",
       "requiresWrite": false,

--- a/cli/templates/integrations/tavily/connector.json
+++ b/cli/templates/integrations/tavily/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "search",
+      "id": "tavily__search",
       "name": "Search",
       "description": "Search the web and get ranked results with optional LLM answer",
       "requiresWrite": false,
@@ -81,7 +81,7 @@
       }
     },
     {
-      "id": "extract",
+      "id": "tavily__extract",
       "name": "Extract",
       "description": "Extract clean page content from one or more URLs",
       "requiresWrite": false,
@@ -108,7 +108,7 @@
       }
     },
     {
-      "id": "crawl",
+      "id": "tavily__crawl",
       "name": "Crawl",
       "description": "Crawl a website from a root URL and extract content from discovered pages",
       "requiresWrite": false,
@@ -139,7 +139,7 @@
       }
     },
     {
-      "id": "map",
+      "id": "tavily__map",
       "name": "Map",
       "description": "Get a list of URLs discovered on a website without extracting content",
       "requiresWrite": false,

--- a/cli/templates/integrations/teams/connector.json
+++ b/cli/templates/integrations/teams/connector.json
@@ -43,7 +43,7 @@
   ],
   "tools": [
     {
-      "id": "list_chats",
+      "id": "teams__list_chats",
       "name": "List Chats",
       "description": "List recent Teams chats",
       "requiresWrite": false,
@@ -64,7 +64,7 @@
       }
     },
     {
-      "id": "get_messages",
+      "id": "teams__get_messages",
       "name": "Get Messages",
       "description": "Get messages from a specific chat",
       "requiresWrite": false,
@@ -91,7 +91,7 @@
       }
     },
     {
-      "id": "send_message",
+      "id": "teams__send_message",
       "name": "Send Channel Message",
       "description": "Send a message to a Teams channel",
       "requiresWrite": true,
@@ -122,7 +122,7 @@
       }
     },
     {
-      "id": "send_chat_message",
+      "id": "teams__send_chat_message",
       "name": "Send Chat Message",
       "description": "Send a message to a Teams 1:1 or group chat",
       "requiresWrite": true,
@@ -147,7 +147,7 @@
       }
     },
     {
-      "id": "list_teams",
+      "id": "teams__list_teams",
       "name": "List Teams",
       "description": "List all joined Teams",
       "requiresWrite": false,
@@ -168,7 +168,7 @@
       }
     },
     {
-      "id": "list_channels",
+      "id": "teams__list_channels",
       "name": "List Channels",
       "description": "List channels in a specific Team",
       "requiresWrite": false,
@@ -189,7 +189,7 @@
       }
     },
     {
-      "id": "create_chat",
+      "id": "teams__create_chat",
       "name": "Create Chat",
       "description": "Create a new 1:1 or group chat so a message can be sent to someone without an existing chat",
       "requiresWrite": true,

--- a/cli/templates/integrations/telegram/connector.json
+++ b/cli/templates/integrations/telegram/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "send_message",
+      "id": "telegram__send_message",
       "name": "Send Message",
       "description": "Send a text message to a chat, group, or channel the bot has access to",
       "requiresWrite": true,
@@ -52,7 +52,7 @@
       }
     },
     {
-      "id": "get_updates",
+      "id": "telegram__get_updates",
       "name": "Get Updates",
       "description": "Receive incoming updates (messages sent to the bot) via long polling; use it to discover chat ids",
       "requiresWrite": false,
@@ -81,7 +81,7 @@
       }
     },
     {
-      "id": "get_me",
+      "id": "telegram__get_me",
       "name": "Get Me",
       "description": "Return basic information about the bot itself; useful for verifying the token works",
       "requiresWrite": false,
@@ -91,7 +91,7 @@
       }
     },
     {
-      "id": "send_photo",
+      "id": "telegram__send_photo",
       "name": "Send Photo",
       "description": "Send a photo to a chat by passing a publicly reachable HTTP URL or an existing Telegram file_id",
       "requiresWrite": true,
@@ -117,7 +117,7 @@
       }
     },
     {
-      "id": "edit_message_text",
+      "id": "telegram__edit_message_text",
       "name": "Edit Message Text",
       "description": "Edit the text of a message previously sent by the bot",
       "requiresWrite": true,

--- a/cli/templates/integrations/todoist/connector.json
+++ b/cli/templates/integrations/todoist/connector.json
@@ -36,7 +36,7 @@
   ],
   "tools": [
     {
-      "id": "list_tasks",
+      "id": "todoist__list_tasks",
       "name": "List Tasks",
       "description": "List active tasks, optionally filtered by project",
       "requiresWrite": false,
@@ -86,7 +86,7 @@
       }
     },
     {
-      "id": "get_task",
+      "id": "todoist__get_task",
       "name": "Get Task",
       "description": "Get details of a specific task",
       "requiresWrite": false,
@@ -104,7 +104,7 @@
       }
     },
     {
-      "id": "create_task",
+      "id": "todoist__create_task",
       "name": "Create Task",
       "description": "Create a new task",
       "requiresWrite": true,
@@ -141,7 +141,7 @@
       }
     },
     {
-      "id": "update_task",
+      "id": "todoist__update_task",
       "name": "Update Task",
       "description": "Update an existing task",
       "requiresWrite": true,
@@ -181,7 +181,7 @@
       }
     },
     {
-      "id": "close_task",
+      "id": "todoist__close_task",
       "name": "Complete Task",
       "description": "Mark a task as complete",
       "requiresWrite": true,
@@ -199,7 +199,7 @@
       }
     },
     {
-      "id": "list_projects",
+      "id": "todoist__list_projects",
       "name": "List Projects",
       "description": "List the user's projects",
       "requiresWrite": false,

--- a/cli/templates/integrations/together-ai/connector.json
+++ b/cli/templates/integrations/together-ai/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_models",
+      "id": "together-ai__list_models",
       "name": "List Models",
       "description": "List the models available on Together AI",
       "requiresWrite": false,
@@ -49,7 +49,7 @@
       }
     },
     {
-      "id": "create_chat_completion",
+      "id": "together-ai__create_chat_completion",
       "name": "Create Chat Completion",
       "description": "Generate a chat completion from a list of messages",
       "requiresWrite": true,
@@ -79,7 +79,7 @@
       }
     },
     {
-      "id": "create_embedding",
+      "id": "together-ai__create_embedding",
       "name": "Create Embedding",
       "description": "Create an embedding vector for input text",
       "requiresWrite": true,
@@ -101,7 +101,7 @@
       }
     },
     {
-      "id": "generate_image",
+      "id": "together-ai__generate_image",
       "name": "Generate Image",
       "description": "Generate an image from a text prompt",
       "requiresWrite": true,

--- a/cli/templates/integrations/trello/connector.json
+++ b/cli/templates/integrations/trello/connector.json
@@ -35,31 +35,31 @@
   ],
   "tools": [
     {
-      "id": "list_boards",
+      "id": "trello__list_boards",
       "name": "List Boards",
       "description": "List all boards accessible to the user",
       "requiresWrite": false
     },
     {
-      "id": "list_cards",
+      "id": "trello__list_cards",
       "name": "List Cards",
       "description": "List cards in a board or list",
       "requiresWrite": false
     },
     {
-      "id": "get_card",
+      "id": "trello__get_card",
       "name": "Get Card",
       "description": "Get details of a specific card",
       "requiresWrite": false
     },
     {
-      "id": "create_card",
+      "id": "trello__create_card",
       "name": "Create Card",
       "description": "Create a new card in a list",
       "requiresWrite": true
     },
     {
-      "id": "update_card",
+      "id": "trello__update_card",
       "name": "Update Card",
       "description": "Update an existing card",
       "requiresWrite": true

--- a/cli/templates/integrations/trusted-shops/connector.json
+++ b/cli/templates/integrations/trusted-shops/connector.json
@@ -35,7 +35,7 @@
   ],
   "tools": [
     {
-      "id": "list_reviews",
+      "id": "trusted-shops__list_reviews",
       "name": "List Reviews",
       "description": "List service and product reviews for the whole account or specific channels, with filters and cursor pagination",
       "requiresWrite": false,
@@ -119,7 +119,7 @@
       }
     },
     {
-      "id": "get_review",
+      "id": "trusted-shops__get_review",
       "name": "Get Review",
       "description": "Get a single review with full comment, customer, transaction, product, and reply details",
       "requiresWrite": false,
@@ -137,7 +137,7 @@
       }
     },
     {
-      "id": "list_channels",
+      "id": "trusted-shops__list_channels",
       "name": "List Channels",
       "description": "List all review channels (shops/touchpoints) of the account with their IDs, names, URLs, and locales",
       "requiresWrite": false,
@@ -147,7 +147,7 @@
       }
     },
     {
-      "id": "get_channel_rating",
+      "id": "trusted-shops__get_channel_rating",
       "name": "Get Channel Aggregate Rating",
       "description": "Get aggregate service review ratings for a channel across 7-day, 30-day, 90-day, 365-day, and overall periods, including star distribution",
       "requiresWrite": false,
@@ -165,7 +165,7 @@
       }
     },
     {
-      "id": "create_review_invites",
+      "id": "trusted-shops__create_review_invites",
       "name": "Create Review Invites",
       "description": "Schedule review invite emails for one or more customers of a channel after a transaction",
       "requiresWrite": true,
@@ -197,7 +197,7 @@
       }
     },
     {
-      "id": "get_reviews_count",
+      "id": "trusted-shops__get_reviews_count",
       "name": "Get Reviews Count",
       "description": "Get the total number of reviews matching a filter — cheap KPI queries without paging through review lists",
       "requiresWrite": false,
@@ -250,7 +250,7 @@
       }
     },
     {
-      "id": "reply_to_review",
+      "id": "trusted-shops__reply_to_review",
       "name": "Reply to Review",
       "description": "Save a public reply on a review — the natural follow-up to negative reviews",
       "requiresWrite": true,

--- a/cli/templates/integrations/twilio/connector.json
+++ b/cli/templates/integrations/twilio/connector.json
@@ -40,19 +40,19 @@
   ],
   "tools": [
     {
-      "id": "send_sms",
+      "id": "twilio__send_sms",
       "name": "Send SMS",
       "description": "Send an SMS text message to a phone number",
       "requiresWrite": true
     },
     {
-      "id": "send_whatsapp",
+      "id": "twilio__send_whatsapp",
       "name": "Send WhatsApp Message",
       "description": "Send a WhatsApp message to a phone number",
       "requiresWrite": true
     },
     {
-      "id": "list_messages",
+      "id": "twilio__list_messages",
       "name": "List Messages",
       "description": "List recent SMS and WhatsApp messages",
       "requiresWrite": false,
@@ -112,7 +112,7 @@
       }
     },
     {
-      "id": "get_message",
+      "id": "twilio__get_message",
       "name": "Get Message",
       "description": "Get details about a specific message",
       "requiresWrite": false,
@@ -136,7 +136,7 @@
       }
     },
     {
-      "id": "list_calls",
+      "id": "twilio__list_calls",
       "name": "List Calls",
       "description": "List recent phone calls",
       "requiresWrite": false,

--- a/cli/templates/integrations/typeform/connector.json
+++ b/cli/templates/integrations/typeform/connector.json
@@ -42,7 +42,7 @@
   ],
   "tools": [
     {
-      "id": "list_forms",
+      "id": "typeform__list_forms",
       "name": "List Forms",
       "description": "List forms in the account or a workspace",
       "requiresWrite": false,
@@ -91,7 +91,7 @@
       }
     },
     {
-      "id": "get_form",
+      "id": "typeform__get_form",
       "name": "Get Form",
       "description": "Get a form definition including its fields",
       "requiresWrite": false,
@@ -109,7 +109,7 @@
       }
     },
     {
-      "id": "list_responses",
+      "id": "typeform__list_responses",
       "name": "List Responses",
       "description": "List responses submitted to a form",
       "requiresWrite": false,
@@ -173,7 +173,7 @@
       }
     },
     {
-      "id": "list_workspaces",
+      "id": "typeform__list_workspaces",
       "name": "List Workspaces",
       "description": "List workspaces in the account",
       "requiresWrite": false,
@@ -202,7 +202,7 @@
       }
     },
     {
-      "id": "get_me",
+      "id": "typeform__get_me",
       "name": "Get Me",
       "description": "Get the authenticated Typeform account profile",
       "requiresWrite": false,

--- a/cli/templates/integrations/unstructured/connector.json
+++ b/cli/templates/integrations/unstructured/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "partition_document",
+      "id": "unstructured__partition_document",
       "name": "Partition Document",
       "description": "Parse one local document into structured JSON elements (titles, narrative text, tables, lists) with optional chunking for RAG. The file content is uploaded as the multipart/form-data 'files' field together with the other fields; remote URLs are not accepted — fetch the file first and pass its content",
       "requiresWrite": false,

--- a/cli/templates/integrations/unzer/connector.json
+++ b/cli/templates/integrations/unzer/connector.json
@@ -34,7 +34,7 @@
   ],
   "tools": [
     {
-      "id": "get_payment",
+      "id": "unzer__get_payment",
       "name": "Get Payment",
       "description": "Retrieve a payment resource with its state, amounts (total, charged, canceled, remaining), and linked transactions",
       "requiresWrite": false,
@@ -52,7 +52,7 @@
       }
     },
     {
-      "id": "get_charge",
+      "id": "unzer__get_charge",
       "name": "Get Charge",
       "description": "Retrieve a specific charge transaction of a payment, including amount, status, and processing details",
       "requiresWrite": false,
@@ -76,7 +76,7 @@
       }
     },
     {
-      "id": "create_charge",
+      "id": "unzer__create_charge",
       "name": "Create Charge",
       "description": "Directly charge a payment type (one-step payment without prior authorization) using a payment type ID",
       "requiresWrite": true,
@@ -115,7 +115,7 @@
       }
     },
     {
-      "id": "refund_charge",
+      "id": "unzer__refund_charge",
       "name": "Refund Charge",
       "description": "Cancel (refund) a charge fully or partially, returning money to the customer",
       "requiresWrite": true,
@@ -149,7 +149,7 @@
       }
     },
     {
-      "id": "authorize_payment",
+      "id": "unzer__authorize_payment",
       "name": "Authorize Payment",
       "description": "Reserve funds on a payment type without charging yet (first step of the two-step authorize-then-charge flow, e.g. charge on shipment); reservations are held for about 7 days",
       "requiresWrite": true,
@@ -188,7 +188,7 @@
       }
     },
     {
-      "id": "charge_authorization",
+      "id": "unzer__charge_authorization",
       "name": "Charge Authorization",
       "description": "Capture a previously authorized payment, fully (empty body) or partially (with amount) — the second step of the authorize-then-charge flow",
       "requiresWrite": true,
@@ -216,7 +216,7 @@
       }
     },
     {
-      "id": "cancel_authorization",
+      "id": "unzer__cancel_authorization",
       "name": "Cancel Authorization",
       "description": "Cancel (reverse) an uncaptured authorization fully or partially, releasing the reserved funds — distinct from refunding a charge",
       "requiresWrite": true,

--- a/cli/templates/integrations/vercel/connector.json
+++ b/cli/templates/integrations/vercel/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "list_projects",
+      "id": "vercel__list_projects",
       "name": "List Projects",
       "description": "List projects of the authenticated user or team",
       "requiresWrite": false,
@@ -80,7 +80,7 @@
       }
     },
     {
-      "id": "get_project",
+      "id": "vercel__get_project",
       "name": "Get Project",
       "description": "Get a project by ID or name",
       "requiresWrite": false,
@@ -108,7 +108,7 @@
       }
     },
     {
-      "id": "list_deployments",
+      "id": "vercel__list_deployments",
       "name": "List Deployments",
       "description": "List deployments under the authenticated user or team",
       "requiresWrite": false,
@@ -183,7 +183,7 @@
       }
     },
     {
-      "id": "get_deployment",
+      "id": "vercel__get_deployment",
       "name": "Get Deployment",
       "description": "Get a deployment by ID or hostname URL",
       "requiresWrite": false,
@@ -211,7 +211,7 @@
       }
     },
     {
-      "id": "list_env_vars",
+      "id": "vercel__list_env_vars",
       "name": "List Environment Variables",
       "description": "List the environment variables of a project (values stay encrypted unless decrypt is set)",
       "requiresWrite": false,

--- a/cli/templates/integrations/voyage-ai/connector.json
+++ b/cli/templates/integrations/voyage-ai/connector.json
@@ -27,7 +27,7 @@
   ],
   "tools": [
     {
-      "id": "create_embeddings",
+      "id": "voyage-ai__create_embeddings",
       "name": "Create Embeddings",
       "description": "Create embedding vectors for one or more texts — use input_type to optimize for retrieval queries vs documents",
       "requiresWrite": false,
@@ -65,7 +65,7 @@
       }
     },
     {
-      "id": "rerank_documents",
+      "id": "voyage-ai__rerank_documents",
       "name": "Rerank Documents",
       "description": "Rank candidate documents by relevance to a query with a Voyage reranker — use as a precision pass after vector search",
       "requiresWrite": false,
@@ -104,7 +104,7 @@
       }
     },
     {
-      "id": "create_contextualized_embeddings",
+      "id": "voyage-ai__create_contextualized_embeddings",
       "name": "Create Contextualized Embeddings",
       "description": "Embed document chunks with document-level context (voyage-context-3) so each chunk vector also captures the surrounding document",
       "requiresWrite": false,
@@ -138,7 +138,7 @@
       }
     },
     {
-      "id": "create_multimodal_embeddings",
+      "id": "voyage-ai__create_multimodal_embeddings",
       "name": "Create Multimodal Embeddings",
       "description": "Embed interleaved text and images into one vector space (voyage-multimodal models) for visual RAG over screenshots, slides, and PDFs",
       "requiresWrite": false,

--- a/cli/templates/integrations/weaviate/connector.json
+++ b/cli/templates/integrations/weaviate/connector.json
@@ -26,7 +26,7 @@
   ],
   "tools": [
     {
-      "id": "get_schema",
+      "id": "weaviate__get_schema",
       "name": "Get Schema",
       "description": "List all collections (classes) and their property definitions",
       "requiresWrite": false,
@@ -56,7 +56,7 @@
       }
     },
     {
-      "id": "graphql_query",
+      "id": "weaviate__graphql_query",
       "name": "Run GraphQL Query",
       "description": "Run a GraphQL query against the cluster (Get, Aggregate, Explore — including nearText/nearVector search)",
       "requiresWrite": false,
@@ -85,7 +85,7 @@
       }
     },
     {
-      "id": "list_objects",
+      "id": "weaviate__list_objects",
       "name": "List Objects",
       "description": "List objects, optionally filtered to one collection (class)",
       "requiresWrite": false,
@@ -119,7 +119,7 @@
       }
     },
     {
-      "id": "get_object",
+      "id": "weaviate__get_object",
       "name": "Get Object",
       "description": "Get a single object by collection (class) and ID",
       "requiresWrite": false,
@@ -149,7 +149,7 @@
       }
     },
     {
-      "id": "create_object",
+      "id": "weaviate__create_object",
       "name": "Create Object",
       "description": "Create a new object in a collection (class)",
       "requiresWrite": true,

--- a/cli/templates/integrations/webex/connector.json
+++ b/cli/templates/integrations/webex/connector.json
@@ -42,7 +42,7 @@
   ],
   "tools": [
     {
-      "id": "list_rooms",
+      "id": "webex__list_rooms",
       "name": "List Rooms",
       "description": "List Webex rooms (spaces) the authenticated user belongs to",
       "requiresWrite": false,
@@ -87,7 +87,7 @@
       }
     },
     {
-      "id": "list_messages",
+      "id": "webex__list_messages",
       "name": "List Messages",
       "description": "List recent messages in a Webex room",
       "requiresWrite": false,
@@ -116,7 +116,7 @@
       }
     },
     {
-      "id": "create_message",
+      "id": "webex__create_message",
       "name": "Send Message",
       "description": "Send a message to a Webex room or directly to a person",
       "requiresWrite": true,
@@ -144,7 +144,7 @@
       }
     },
     {
-      "id": "get_my_details",
+      "id": "webex__get_my_details",
       "name": "Get My Details",
       "description": "Get the authenticated Webex user's profile",
       "requiresWrite": false,
@@ -154,7 +154,7 @@
       }
     },
     {
-      "id": "list_people",
+      "id": "webex__list_people",
       "name": "List People",
       "description": "Look up people in the organization by email or display name",
       "requiresWrite": false,

--- a/cli/templates/integrations/whatsapp/connector.json
+++ b/cli/templates/integrations/whatsapp/connector.json
@@ -42,7 +42,7 @@
   ],
   "tools": [
     {
-      "id": "send_text_message",
+      "id": "whatsapp__send_text_message",
       "name": "Send Text Message",
       "description": "Send a free-form text message to a WhatsApp user (only within 24 hours of their last message; otherwise use a template)",
       "requiresWrite": true,
@@ -87,7 +87,7 @@
       }
     },
     {
-      "id": "send_template_message",
+      "id": "whatsapp__send_template_message",
       "name": "Send Template Message",
       "description": "Send an approved message template to a WhatsApp user; required to start conversations outside the 24-hour customer service window",
       "requiresWrite": true,
@@ -127,7 +127,7 @@
       }
     },
     {
-      "id": "send_media_message",
+      "id": "whatsapp__send_media_message",
       "name": "Send Media Message",
       "description": "Send an image, document, video, or audio message to a WhatsApp user by public URL or uploaded media ID (subject to the same 24-hour window as text messages)",
       "requiresWrite": true,
@@ -178,7 +178,7 @@
       }
     },
     {
-      "id": "get_media_url",
+      "id": "whatsapp__get_media_url",
       "name": "Get Media URL",
       "description": "Get a short-lived download URL and metadata for a media ID, e.g. to retrieve an image or document a customer sent inbound",
       "requiresWrite": false,
@@ -201,7 +201,7 @@
       }
     },
     {
-      "id": "update_business_profile",
+      "id": "whatsapp__update_business_profile",
       "name": "Update Business Profile",
       "description": "Update the business profile (about, address, description, email, websites, vertical) shown to customers for a business phone number",
       "requiresWrite": true,
@@ -250,7 +250,7 @@
       }
     },
     {
-      "id": "mark_message_read",
+      "id": "whatsapp__mark_message_read",
       "name": "Mark Message as Read",
       "description": "Mark an inbound WhatsApp message as read so the customer sees read receipts after the agent processes it",
       "requiresWrite": true,
@@ -285,7 +285,7 @@
       }
     },
     {
-      "id": "get_business_profile",
+      "id": "whatsapp__get_business_profile",
       "name": "Get Business Profile",
       "description": "Read the business profile (about, address, email, websites) shown to customers for a business phone number",
       "requiresWrite": false,
@@ -312,7 +312,7 @@
       }
     },
     {
-      "id": "list_message_templates",
+      "id": "whatsapp__list_message_templates",
       "name": "List Message Templates",
       "description": "List the message templates on a WhatsApp Business Account so an agent can pick an approved template name and language before sending",
       "requiresWrite": false,

--- a/cli/templates/integrations/wix/connector.json
+++ b/cli/templates/integrations/wix/connector.json
@@ -37,7 +37,7 @@
   ],
   "tools": [
     {
-      "id": "query_products",
+      "id": "wix__query_products",
       "name": "Query Products",
       "description": "Query Wix Stores catalog products with filtering, sorting, and paging",
       "requiresWrite": false,
@@ -60,7 +60,7 @@
       }
     },
     {
-      "id": "search_orders",
+      "id": "wix__search_orders",
       "name": "Search Orders",
       "description": "Search Wix eCommerce orders with filtering, sorting, and cursor paging",
       "requiresWrite": false,
@@ -79,7 +79,7 @@
       }
     },
     {
-      "id": "get_order",
+      "id": "wix__get_order",
       "name": "Get Order",
       "description": "Get full details of a single eCommerce order, including line items, totals, and buyer info",
       "requiresWrite": false,
@@ -100,7 +100,7 @@
       }
     },
     {
-      "id": "query_contacts",
+      "id": "wix__query_contacts",
       "name": "Query Contacts",
       "description": "Query CRM contacts with filtering, sorting, and paging (up to 1000 per request)",
       "requiresWrite": false,
@@ -119,7 +119,7 @@
       }
     },
     {
-      "id": "create_fulfillment",
+      "id": "wix__create_fulfillment",
       "name": "Create Fulfillment",
       "description": "Mark eCommerce order line items as fulfilled, optionally with shipping tracking info",
       "requiresWrite": true,
@@ -144,7 +144,7 @@
       }
     },
     {
-      "id": "create_contact",
+      "id": "wix__create_contact",
       "name": "Create Contact",
       "description": "Create a new CRM contact with at least a name, email address, or phone number",
       "requiresWrite": true,
@@ -168,7 +168,7 @@
       }
     },
     {
-      "id": "create_product",
+      "id": "wix__create_product",
       "name": "Create Product",
       "description": "Create a new product in the Wix Stores catalog",
       "requiresWrite": true,

--- a/cli/templates/integrations/woocommerce/connector.json
+++ b/cli/templates/integrations/woocommerce/connector.json
@@ -41,7 +41,7 @@
   ],
   "tools": [
     {
-      "id": "list_orders",
+      "id": "woocommerce__list_orders",
       "name": "List Orders",
       "description": "List orders in the store with optional status, search, and date filters",
       "requiresWrite": false,
@@ -87,7 +87,7 @@
       }
     },
     {
-      "id": "get_order",
+      "id": "woocommerce__get_order",
       "name": "Get Order",
       "description": "Retrieve full details of a specific order, including line items, totals, and shipping",
       "requiresWrite": false,
@@ -111,7 +111,7 @@
       }
     },
     {
-      "id": "update_order_status",
+      "id": "woocommerce__update_order_status",
       "name": "Update Order Status",
       "description": "Update an order's status (e.g. mark as completed) and optionally add a customer note",
       "requiresWrite": true,
@@ -146,7 +146,7 @@
       }
     },
     {
-      "id": "list_products",
+      "id": "woocommerce__list_products",
       "name": "List Products",
       "description": "List products in the catalog with optional search, status, and SKU filters",
       "requiresWrite": false,
@@ -192,7 +192,7 @@
       }
     },
     {
-      "id": "create_product",
+      "id": "woocommerce__create_product",
       "name": "Create Product",
       "description": "Create a new product in the store catalog",
       "requiresWrite": true,
@@ -249,7 +249,7 @@
       }
     },
     {
-      "id": "get_product",
+      "id": "woocommerce__get_product",
       "name": "Get Product",
       "description": "Retrieve full details of a specific product, including price, stock, and categories",
       "requiresWrite": false,
@@ -273,7 +273,7 @@
       }
     },
     {
-      "id": "update_product",
+      "id": "woocommerce__update_product",
       "name": "Update Product",
       "description": "Update an existing product's price, stock, status, or descriptions",
       "requiresWrite": true,
@@ -331,7 +331,7 @@
       }
     },
     {
-      "id": "get_sales_report",
+      "id": "woocommerce__get_sales_report",
       "name": "Get Sales Report",
       "description": "Get a sales report with totals for revenue, orders, items, and customers over a period or date range",
       "requiresWrite": false,
@@ -364,7 +364,7 @@
       }
     },
     {
-      "id": "list_customers",
+      "id": "woocommerce__list_customers",
       "name": "List Customers",
       "description": "List store customers with optional email, role, and search filters",
       "requiresWrite": false,

--- a/cli/templates/integrations/workable/connector.json
+++ b/cli/templates/integrations/workable/connector.json
@@ -35,7 +35,7 @@
   ],
   "tools": [
     {
-      "id": "list_jobs",
+      "id": "workable__list_jobs",
       "name": "List Jobs",
       "description": "List jobs in the Workable account with optional state filtering",
       "requiresWrite": false,
@@ -100,7 +100,7 @@
       }
     },
     {
-      "id": "get_job",
+      "id": "workable__get_job",
       "name": "Get Job",
       "description": "Get the full details of a job by its shortcode",
       "requiresWrite": false,
@@ -124,7 +124,7 @@
       }
     },
     {
-      "id": "list_candidates",
+      "id": "workable__list_candidates",
       "name": "List Candidates",
       "description": "List candidates account-wide or for a specific job (filter by job shortcode, stage, or email)",
       "requiresWrite": false,
@@ -194,7 +194,7 @@
       }
     },
     {
-      "id": "get_candidate",
+      "id": "workable__get_candidate",
       "name": "Get Candidate",
       "description": "Get the full profile of a candidate by ID, including stage, answers, and attachments",
       "requiresWrite": false,
@@ -218,7 +218,7 @@
       }
     },
     {
-      "id": "list_members",
+      "id": "workable__list_members",
       "name": "List Members",
       "description": "List account members to find the member IDs required by the comment and move-candidate tools",
       "requiresWrite": false,
@@ -276,7 +276,7 @@
       }
     },
     {
-      "id": "list_stages",
+      "id": "workable__list_stages",
       "name": "List Stages",
       "description": "List the recruitment pipeline stages to find stage slugs for candidate filtering and moves",
       "requiresWrite": false,
@@ -294,7 +294,7 @@
       }
     },
     {
-      "id": "create_candidate",
+      "id": "workable__create_candidate",
       "name": "Create Candidate",
       "description": "Add a candidate to a job, either as sourced or as having applied",
       "requiresWrite": true,
@@ -333,7 +333,7 @@
       }
     },
     {
-      "id": "create_candidate_comment",
+      "id": "workable__create_candidate_comment",
       "name": "Create Candidate Comment",
       "description": "Post a comment on a candidate's timeline on behalf of a team member",
       "requiresWrite": true,
@@ -369,7 +369,7 @@
       }
     },
     {
-      "id": "move_candidate",
+      "id": "workable__move_candidate",
       "name": "Move Candidate",
       "description": "Move a candidate to another pipeline stage on behalf of a team member",
       "requiresWrite": true,

--- a/cli/templates/integrations/xentral/connector.json
+++ b/cli/templates/integrations/xentral/connector.json
@@ -28,7 +28,7 @@
   ],
   "tools": [
     {
-      "id": "list_sales_orders",
+      "id": "xentral__list_sales_orders",
       "name": "List Sales Orders",
       "description": "List sales orders in the Xentral instance with optional filtering and pagination",
       "requiresWrite": false,
@@ -76,7 +76,7 @@
       }
     },
     {
-      "id": "get_sales_order",
+      "id": "xentral__get_sales_order",
       "name": "Get Sales Order",
       "description": "Get a single sales order with its positions and financial details",
       "requiresWrite": false,
@@ -103,7 +103,7 @@
       }
     },
     {
-      "id": "list_products",
+      "id": "xentral__list_products",
       "name": "List Products",
       "description": "List products in the Xentral instance (v2 API) with optional filtering and pagination",
       "requiresWrite": false,
@@ -151,7 +151,7 @@
       }
     },
     {
-      "id": "list_customers",
+      "id": "xentral__list_customers",
       "name": "List Customers",
       "description": "List customers in the Xentral instance (v2 API) with optional filtering and pagination",
       "requiresWrite": false,
@@ -199,7 +199,7 @@
       }
     },
     {
-      "id": "create_sales_order",
+      "id": "xentral__create_sales_order",
       "name": "Create Sales Order",
       "description": "Import a new sales order into Xentral with customer, financials, delivery, and order positions",
       "requiresWrite": true,
@@ -261,7 +261,7 @@
       }
     },
     {
-      "id": "get_product",
+      "id": "xentral__get_product",
       "name": "Get Product",
       "description": "Get a single product with full details (v2 API) after finding it via List Products",
       "requiresWrite": false,
@@ -288,7 +288,7 @@
       }
     },
     {
-      "id": "get_customer",
+      "id": "xentral__get_customer",
       "name": "Get Customer",
       "description": "Get a single customer record with full details including addresses (v2 API) — useful before creating a sales order",
       "requiresWrite": false,

--- a/cli/templates/integrations/xero/connector.json
+++ b/cli/templates/integrations/xero/connector.json
@@ -43,7 +43,7 @@
   ],
   "tools": [
     {
-      "id": "list_connections",
+      "id": "xero__list_connections",
       "name": "List Connections",
       "description": "List Xero tenants (organisations) connected to this token — run this first to discover the tenantId used by every other tool",
       "requiresWrite": false,
@@ -68,7 +68,7 @@
       }
     },
     {
-      "id": "list_invoices",
+      "id": "xero__list_invoices",
       "name": "List Invoices",
       "description": "List invoices in a Xero organisation",
       "requiresWrite": false,
@@ -131,7 +131,7 @@
       }
     },
     {
-      "id": "get_invoice",
+      "id": "xero__get_invoice",
       "name": "Get Invoice",
       "description": "Get a Xero sales invoice or supplier bill with its line items",
       "requiresWrite": false,
@@ -166,7 +166,7 @@
       }
     },
     {
-      "id": "create_invoice",
+      "id": "xero__create_invoice",
       "name": "Create Invoice",
       "description": "Create an invoice in a Xero organisation",
       "requiresWrite": true,
@@ -203,7 +203,7 @@
       }
     },
     {
-      "id": "list_bills",
+      "id": "xero__list_bills",
       "name": "List Bills",
       "description": "List supplier bills (accounts payable) in a Xero organisation — bills are Invoices with Type ACCPAY",
       "requiresWrite": false,
@@ -267,7 +267,7 @@
       }
     },
     {
-      "id": "create_bill",
+      "id": "xero__create_bill",
       "name": "Create Bill",
       "description": "Create a supplier bill (accounts payable) in a Xero organisation — a bill is an Invoice with Type \"ACCPAY\"",
       "requiresWrite": true,
@@ -304,7 +304,7 @@
       }
     },
     {
-      "id": "create_invoice_attachment",
+      "id": "xero__create_invoice_attachment",
       "name": "Create Invoice Attachment",
       "description": "Attach a file to a Xero sales invoice or supplier bill (max 10 MB per attachment)",
       "requiresWrite": true,
@@ -355,7 +355,7 @@
       }
     },
     {
-      "id": "create_purchase_order",
+      "id": "xero__create_purchase_order",
       "name": "Create Purchase Order",
       "description": "Create a purchase order in a Xero organisation",
       "requiresWrite": true,
@@ -392,7 +392,7 @@
       }
     },
     {
-      "id": "list_contacts",
+      "id": "xero__list_contacts",
       "name": "List Contacts",
       "description": "List contacts in a Xero organisation",
       "requiresWrite": false,
@@ -437,7 +437,7 @@
       }
     },
     {
-      "id": "list_accounts",
+      "id": "xero__list_accounts",
       "name": "List Accounts",
       "description": "List the chart of accounts in a Xero organisation",
       "requiresWrite": false,
@@ -471,7 +471,7 @@
       }
     },
     {
-      "id": "list_invoice_attachments",
+      "id": "xero__list_invoice_attachments",
       "name": "List Invoice Attachments",
       "description": "List the attachments on an invoice or bill (AttachmentID, FileName, MimeType, ContentLength) — see what Create Invoice Attachment uploaded",
       "requiresWrite": false,
@@ -506,7 +506,7 @@
       }
     },
     {
-      "id": "list_purchase_orders",
+      "id": "xero__list_purchase_orders",
       "name": "List Purchase Orders",
       "description": "List purchase orders in a Xero organisation — the read counterpart to Create Purchase Order",
       "requiresWrite": false,

--- a/cli/templates/integrations/zendesk/connector.json
+++ b/cli/templates/integrations/zendesk/connector.json
@@ -31,7 +31,7 @@
   ],
   "tools": [
     {
-      "id": "list_tickets",
+      "id": "zendesk__list_tickets",
       "name": "List Tickets",
       "description": "List Zendesk support tickets",
       "requiresWrite": false,
@@ -62,7 +62,7 @@
       }
     },
     {
-      "id": "get_ticket",
+      "id": "zendesk__get_ticket",
       "name": "Get Ticket",
       "description": "Get a Zendesk ticket by ID",
       "requiresWrite": false,
@@ -87,7 +87,7 @@
       }
     },
     {
-      "id": "search_tickets",
+      "id": "zendesk__search_tickets",
       "name": "Search Tickets",
       "description": "Search Zendesk tickets with the Zendesk search API",
       "requiresWrite": false,
@@ -112,7 +112,7 @@
       }
     },
     {
-      "id": "update_ticket",
+      "id": "zendesk__update_ticket",
       "name": "Update Ticket",
       "description": "Update a Zendesk ticket status, priority, tags, or comment",
       "requiresWrite": true,
@@ -144,7 +144,7 @@
       }
     },
     {
-      "id": "create_ticket",
+      "id": "zendesk__create_ticket",
       "name": "Create Ticket",
       "description": "Create a new Zendesk support ticket",
       "requiresWrite": true,
@@ -170,7 +170,7 @@
       }
     },
     {
-      "id": "list_ticket_comments",
+      "id": "zendesk__list_ticket_comments",
       "name": "List Ticket Comments",
       "description": "List comments on a Zendesk ticket",
       "requiresWrite": false,

--- a/cli/templates/integrations/zoho-crm/connector.json
+++ b/cli/templates/integrations/zoho-crm/connector.json
@@ -52,7 +52,7 @@
   ],
   "tools": [
     {
-      "id": "list_records",
+      "id": "zoho-crm__list_records",
       "name": "List Records",
       "description": "List records from a Zoho CRM module such as Leads, Contacts, Deals, or Accounts",
       "requiresWrite": false,
@@ -101,7 +101,7 @@
       }
     },
     {
-      "id": "get_record",
+      "id": "zoho-crm__get_record",
       "name": "Get Record",
       "description": "Get a single Zoho CRM record by ID from any module",
       "requiresWrite": false,
@@ -133,7 +133,7 @@
       }
     },
     {
-      "id": "search_records",
+      "id": "zoho-crm__search_records",
       "name": "Search Records",
       "description": "Search records in a Zoho CRM module by criteria, email, phone, or a free-text word",
       "requiresWrite": false,
@@ -191,7 +191,7 @@
       }
     },
     {
-      "id": "get_fields",
+      "id": "zoho-crm__get_fields",
       "name": "Get Fields Metadata",
       "description": "List the field metadata of a Zoho CRM module so agents can discover the field API names required by list, search, and write tools",
       "requiresWrite": false,
@@ -212,7 +212,7 @@
       }
     },
     {
-      "id": "coql_query",
+      "id": "zoho-crm__coql_query",
       "name": "Run COQL Query",
       "description": "Run a CRM Object Query Language (COQL) SELECT query for filtered reads, joins, and aggregation that the list and search tools cannot express",
       "requiresWrite": false,
@@ -232,7 +232,7 @@
       }
     },
     {
-      "id": "create_records",
+      "id": "zoho-crm__create_records",
       "name": "Create Records",
       "description": "Create up to 100 records in a Zoho CRM module (requires the ZohoCRM.modules.CREATE scope)",
       "requiresWrite": true,
@@ -260,7 +260,7 @@
       }
     },
     {
-      "id": "update_record",
+      "id": "zoho-crm__update_record",
       "name": "Update Record",
       "description": "Update fields on an existing Zoho CRM record (requires the ZohoCRM.modules.UPDATE scope)",
       "requiresWrite": true,

--- a/cli/templates/integrations/zoom/connector.json
+++ b/cli/templates/integrations/zoom/connector.json
@@ -43,7 +43,7 @@
   ],
   "tools": [
     {
-      "id": "list_meetings",
+      "id": "zoom__list_meetings",
       "name": "List Meetings",
       "description": "List scheduled or upcoming Zoom meetings for the authenticated user",
       "requiresWrite": false,
@@ -101,7 +101,7 @@
       }
     },
     {
-      "id": "get_meeting",
+      "id": "zoom__get_meeting",
       "name": "Get Meeting",
       "description": "Get details of a Zoom meeting by ID",
       "requiresWrite": false,
@@ -119,7 +119,7 @@
       }
     },
     {
-      "id": "create_meeting",
+      "id": "zoom__create_meeting",
       "name": "Create Meeting",
       "description": "Schedule a new Zoom meeting for the authenticated user",
       "requiresWrite": true,
@@ -169,7 +169,7 @@
       }
     },
     {
-      "id": "list_recordings",
+      "id": "zoom__list_recordings",
       "name": "List Recordings",
       "description": "List cloud recordings for the authenticated user",
       "requiresWrite": false,
@@ -208,7 +208,7 @@
       }
     },
     {
-      "id": "get_me",
+      "id": "zoom__get_me",
       "name": "Get My Profile",
       "description": "Get the authenticated Zoom user's profile",
       "requiresWrite": false,

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1024",
+  "version": "0.1.1025",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/scripts/build/generate-integrations-module.ts
+++ b/scripts/build/generate-integrations-module.ts
@@ -33,6 +33,15 @@ function getNamespacedToolId(connectorName: string, toolId: string): string {
   return toolId.startsWith(prefix) ? toolId : `${prefix}${toolId}`;
 }
 
+function normalizeConnectorToolIds(connector: IntegrationConfig): IntegrationConfig {
+  return {
+    ...connector,
+    tools: connector.tools.map((tool) =>
+      tool.id ? { ...tool, id: getNamespacedToolId(connector.name, tool.id) } : tool
+    ),
+  };
+}
+
 for await (const entry of Deno.readDir(integrationsDir)) {
   if (!entry.isDirectory || entry.name === "_base") continue;
 
@@ -86,23 +95,25 @@ for await (const entry of Deno.readDir(integrationsDir)) {
       continue;
     }
 
-    connectors.push(result.data);
-    for (const tool of result.data.tools) {
+    const connector = normalizeConnectorToolIds(result.data);
+
+    connectors.push(connector);
+    for (const tool of connector.tools) {
       const historicalSummary = tool.endpoint?.response?.historicalSummary;
       if (!tool.id || !historicalSummary) continue;
       historicalToolSummaries.push([
-        getNamespacedToolId(result.data.name, tool.id),
+        getNamespacedToolId(connector.name, tool.id),
         historicalSummary,
       ]);
     }
 
-    if (result.data.icon) {
+    if (connector.icon) {
       try {
-        const svg = await Deno.readTextFile(`${dirPath}/${result.data.icon}`);
-        icons.push([result.data.name, svg]);
+        const svg = await Deno.readTextFile(`${dirPath}/${connector.icon}`);
+        icons.push([connector.name, svg]);
       } catch {
         errors.push(
-          `${entry.name}: icon "${result.data.icon}" declared but file not found`,
+          `${entry.name}: icon "${connector.icon}" declared but file not found`,
         );
       }
     }

--- a/scripts/build/generate-integrations-module.ts
+++ b/scripts/build/generate-integrations-module.ts
@@ -28,6 +28,11 @@ const historicalToolSummaries: [string, NonNullable<
 >["historicalSummary"]][] = [];
 const errors: string[] = [];
 
+function getNamespacedToolId(connectorName: string, toolId: string): string {
+  const prefix = `${connectorName}__`;
+  return toolId.startsWith(prefix) ? toolId : `${prefix}${toolId}`;
+}
+
 for await (const entry of Deno.readDir(integrationsDir)) {
   if (!entry.isDirectory || entry.name === "_base") continue;
 
@@ -85,7 +90,10 @@ for await (const entry of Deno.readDir(integrationsDir)) {
     for (const tool of result.data.tools) {
       const historicalSummary = tool.endpoint?.response?.historicalSummary;
       if (!tool.id || !historicalSummary) continue;
-      historicalToolSummaries.push([`${result.data.name}__${tool.id}`, historicalSummary]);
+      historicalToolSummaries.push([
+        getNamespacedToolId(result.data.name, tool.id),
+        historicalSummary,
+      ]);
     }
 
     if (result.data.icon) {

--- a/src/integrations/_data.test.ts
+++ b/src/integrations/_data.test.ts
@@ -19,6 +19,16 @@ function getTool(connectorName: string, toolId: string) {
   return tool;
 }
 
+function getNamespacedToolId(connectorName: string, toolId: string): string {
+  const prefix = `${connectorName}__`;
+  return toolId.startsWith(prefix) ? toolId : `${prefix}${toolId}`;
+}
+
+function getConnectorLocalToolId(connectorName: string, toolId: string): string {
+  const prefix = `${connectorName}__`;
+  return toolId.startsWith(prefix) ? toolId.slice(prefix.length) : toolId;
+}
+
 describe("integration endpoint specs", () => {
   it("keeps all source connectors while showing only the supported end-user surface by default", () => {
     const supportedConnectors = [
@@ -520,6 +530,16 @@ describe("integration endpoint specs", () => {
         `Expected ${connectorName} to expose ${expectedEndpointCount} callable endpoint tools`,
       );
     }
+  });
+
+  it("publishes Harvest tool IDs with the Harvest namespace prefix", () => {
+    const harvest = getConnector("harvest");
+
+    assertEquals(
+      harvest.tools.every((tool) => tool.id?.startsWith("harvest__")),
+      true,
+    );
+    assertExists(getTool("harvest", "harvest__list_accounts"));
   });
 
   it("uses the documented SAP supplier invoice release function import", () => {
@@ -1910,17 +1930,17 @@ describe("integration endpoint specs", () => {
           tool.requiresWrite !== false ||
           !tool.endpoint ||
           !tool.id ||
-          !collectionToolPattern.test(tool.id)
+          !collectionToolPattern.test(getConnectorLocalToolId(connectorName, tool.id))
         ) {
           continue;
         }
 
         assertExists(
           tool.endpoint.response?.historicalSummary,
-          `Expected ${connectorName}__${tool.id} to declare historicalSummary`,
+          `Expected ${getNamespacedToolId(connectorName, tool.id)} to declare historicalSummary`,
         );
         assertEquals(
-          historicalToolSummaries[`${connectorName}__${tool.id}`],
+          historicalToolSummaries[getNamespacedToolId(connectorName, tool.id)],
           tool.endpoint.response?.historicalSummary,
         );
       }

--- a/src/integrations/_data.test.ts
+++ b/src/integrations/_data.test.ts
@@ -14,7 +14,8 @@ function getConnector(name: string) {
 
 function getTool(connectorName: string, toolId: string) {
   const connector = getConnector(connectorName);
-  const tool = connector.tools.find((item) => item.id === toolId);
+  const namespacedToolId = getNamespacedToolId(connectorName, toolId);
+  const tool = connector.tools.find((item) => item.id === toolId || item.id === namespacedToolId);
   assertExists(tool, `Expected ${connectorName}:${toolId} to exist`);
   return tool;
 }
@@ -27,6 +28,10 @@ function getNamespacedToolId(connectorName: string, toolId: string): string {
 function getConnectorLocalToolId(connectorName: string, toolId: string): string {
   const prefix = `${connectorName}__`;
   return toolId.startsWith(prefix) ? toolId.slice(prefix.length) : toolId;
+}
+
+function getLocalToolIds(connectorName: string, tools: { id?: string }[]): (string | undefined)[] {
+  return tools.map((tool) => tool.id ? getConnectorLocalToolId(connectorName, tool.id) : tool.id);
 }
 
 describe("integration endpoint specs", () => {
@@ -342,7 +347,7 @@ describe("integration endpoint specs", () => {
 
   it("keeps Salesforce write tools curated instead of exposing generic record mutation", () => {
     const salesforce = getConnector("salesforce");
-    const toolIds = salesforce.tools.map((tool) => tool.id);
+    const toolIds = getLocalToolIds("salesforce", salesforce.tools);
 
     assertEquals(toolIds.includes("create_record"), false);
     assertEquals(toolIds.includes("update_record"), false);
@@ -367,7 +372,7 @@ describe("integration endpoint specs", () => {
     const connector = getConnector("salesforce");
 
     assertEquals(
-      connector.tools.map((tool) => tool.id),
+      getLocalToolIds("salesforce", connector.tools),
       [
         "find_customer",
         "search_accounts",
@@ -440,7 +445,7 @@ describe("integration endpoint specs", () => {
 
   it("publishes HubSpot lead and form submission endpoint tools", () => {
     const hubspot = getConnector("hubspot");
-    const toolIds = hubspot.tools.map((tool) => tool.id);
+    const toolIds = getLocalToolIds("hubspot", hubspot.tools);
 
     assertEquals(hubspot.auth.provider, "hubspot");
     assertEquals(hubspot.auth.scopes?.includes("oauth"), true);
@@ -532,14 +537,61 @@ describe("integration endpoint specs", () => {
     }
   });
 
-  it("publishes Harvest tool IDs with the Harvest namespace prefix", () => {
-    const harvest = getConnector("harvest");
+  it("publishes all connector tool IDs with their integration namespace prefix", () => {
+    for (const connector of connectors) {
+      const prefix = `${connector.name}__`;
 
-    assertEquals(
-      harvest.tools.every((tool) => tool.id?.startsWith("harvest__")),
-      true,
-    );
+      for (const tool of connector.tools) {
+        if (!tool.id) continue;
+        assertEquals(
+          tool.id.startsWith(prefix),
+          true,
+          `Expected ${connector.name}:${tool.id} to start with ${prefix}`,
+        );
+        assertEquals(
+          tool.id.indexOf("__"),
+          tool.id.lastIndexOf("__"),
+          `Expected ${connector.name}:${tool.id} to contain a single namespace separator`,
+        );
+      }
+    }
+
     assertExists(getTool("harvest", "harvest__list_accounts"));
+  });
+
+  it("keeps source connector template tool IDs prefixed before generation", async () => {
+    for await (const entry of Deno.readDir("cli/templates/integrations")) {
+      if (!entry.isDirectory || entry.name === "_base") continue;
+
+      try {
+        const raw = await Deno.readTextFile(
+          `cli/templates/integrations/${entry.name}/connector.json`,
+        );
+        const connector = JSON.parse(raw) as {
+          name?: string;
+          tools?: Array<{ id?: string }>;
+        };
+        const connectorName = connector.name ?? entry.name;
+        const prefix = `${connectorName}__`;
+
+        for (const tool of connector.tools ?? []) {
+          if (!tool.id) continue;
+          assertEquals(
+            tool.id.startsWith(prefix),
+            true,
+            `Expected ${entry.name}:${tool.id} to start with ${prefix}`,
+          );
+          assertEquals(
+            tool.id.indexOf("__"),
+            tool.id.lastIndexOf("__"),
+            `Expected ${entry.name}:${tool.id} to contain a single namespace separator`,
+          );
+        }
+      } catch (error) {
+        if (error instanceof Deno.errors.NotFound) continue;
+        throw error;
+      }
+    }
   });
 
   it("uses the documented SAP supplier invoice release function import", () => {
@@ -587,8 +639,18 @@ describe("integration endpoint specs", () => {
 
   it("does not expose unsupported Figma project listing tools for public OAuth apps", () => {
     const figma = getConnector("figma");
-    assertEquals(figma.tools.some((tool) => tool.id === "list_projects"), false);
-    assertEquals(figma.tools.some((tool) => tool.id === "list_files"), false);
+    assertEquals(
+      figma.tools.some((tool) =>
+        tool.id && getConnectorLocalToolId("figma", tool.id) === "list_projects"
+      ),
+      false,
+    );
+    assertEquals(
+      figma.tools.some((tool) =>
+        tool.id && getConnectorLocalToolId("figma", tool.id) === "list_files"
+      ),
+      false,
+    );
 
     const getFile = getTool("figma", "get_file");
     assertStringIncludes(getFile.description, "pages");
@@ -654,7 +716,7 @@ describe("integration endpoint specs", () => {
       false,
     );
     assertEquals(
-      endpointTools.map((tool) => tool.id).sort(),
+      getLocalToolIds("sentry", endpointTools).sort(),
       [
         "get_issue",
         "get_latest_event",
@@ -789,7 +851,7 @@ describe("integration endpoint specs", () => {
 
     const jira = getConnector("jira");
     assertEquals(
-      jira.tools.map((tool) => tool.id),
+      getLocalToolIds("jira", jira.tools),
       [
         "list_sites",
         "list_projects",
@@ -806,8 +868,8 @@ describe("integration endpoint specs", () => {
       ],
     );
     assertEquals(
-      jira.tools.filter((tool) => tool.endpoint).map((tool) => tool.id),
-      jira.tools.map((tool) => tool.id),
+      getLocalToolIds("jira", jira.tools.filter((tool) => tool.endpoint)),
+      getLocalToolIds("jira", jira.tools),
     );
 
     const jiraListProjects = getTool("jira", "list_projects");
@@ -1196,7 +1258,7 @@ describe("integration endpoint specs", () => {
 
   it("exposes Airtable CRUD and schema mutation endpoint tools", () => {
     const airtable = getConnector("airtable");
-    const toolIds = airtable.tools.map((tool) => tool.id);
+    const toolIds = getLocalToolIds("airtable", airtable.tools);
 
     assertEquals(toolIds, [
       "list_bases",
@@ -1269,7 +1331,9 @@ describe("integration endpoint specs", () => {
       }
     }
 
-    const expectedFiles = airtable.tools.map((tool) => tool.id?.replaceAll("_", "-")).sort();
+    const expectedFiles = getLocalToolIds("airtable", airtable.tools).map((toolId) =>
+      toolId?.replaceAll("_", "-")
+    ).sort();
     assertEquals(toolFiles.sort(), expectedFiles);
   });
 
@@ -1312,7 +1376,7 @@ describe("integration endpoint specs", () => {
 
     const expectedFiles = github.tools.map((tool) => {
       assertExists(tool.id);
-      return tool.id.replaceAll("_", "-");
+      return getConnectorLocalToolId("github", tool.id).replaceAll("_", "-");
     }).sort();
     assertEquals(toolFiles.sort(), expectedFiles);
   });
@@ -1333,7 +1397,7 @@ describe("integration endpoint specs", () => {
 
     const expectedFiles = gmail.tools.map((tool) => {
       assertExists(tool.id);
-      return tool.id.replaceAll("_", "-");
+      return getConnectorLocalToolId("gmail", tool.id).replaceAll("_", "-");
     }).sort();
     assertEquals(toolFiles.sort(), expectedFiles);
   });
@@ -1375,7 +1439,7 @@ describe("integration endpoint specs", () => {
       "set_data_validation",
     ];
 
-    assertEquals(sheets.tools.map((tool) => tool.id), expectedToolIds);
+    assertEquals(getLocalToolIds("sheets", sheets.tools), expectedToolIds);
 
     const toolFiles: string[] = [];
     for await (
@@ -1647,7 +1711,7 @@ describe("integration endpoint specs", () => {
       "offline_access",
     ]);
 
-    assertEquals(outlook.tools.map((tool) => tool.id), [
+    assertEquals(getLocalToolIds("outlook", outlook.tools), [
       "list_emails",
       "get_email",
       "send_email",

--- a/src/integrations/_data.ts
+++ b/src/integrations/_data.ts
@@ -26385,7 +26385,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://id.getharvest.com/developers",
     }],
     "tools": [{
-      "id": "list_accounts",
+      "id": "harvest__list_accounts",
       "name": "List Accounts",
       "description":
         "List all Harvest accounts the authenticated user can access. Call this first to get your Harvest-Account-Id for subsequent API calls.",
@@ -26404,7 +26404,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_current_user",
+      "id": "harvest__get_current_user",
       "name": "Get Current User",
       "description":
         "Get the authenticated user's Harvest profile (id, name, email, timezone, roles)",
@@ -26416,14 +26416,14 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
         },
       },
     }, {
-      "id": "list_users",
+      "id": "harvest__list_users",
       "name": "List Users",
       "description": "List all active users in the Harvest account",
       "requiresWrite": false,
@@ -26434,7 +26434,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -26484,7 +26484,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_time_entries",
+      "id": "harvest__list_time_entries",
       "name": "List Time Entries",
       "description":
         "List time entries (timesheets). Filter by user, project, client, or date range.",
@@ -26496,7 +26496,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -26566,7 +26566,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_time_entry",
+      "id": "harvest__get_time_entry",
       "name": "Get Time Entry",
       "description": "Get details of a specific time entry by ID",
       "requiresWrite": false,
@@ -26577,7 +26577,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -26590,7 +26590,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_time_entry",
+      "id": "harvest__create_time_entry",
       "name": "Create Time Entry",
       "description":
         "Create a new time entry (timesheet). Provide either hours or start/end times.",
@@ -26602,7 +26602,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -26641,7 +26641,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_time_entry",
+      "id": "harvest__update_time_entry",
       "name": "Update Time Entry",
       "description": "Update an existing time entry",
       "requiresWrite": true,
@@ -26652,7 +26652,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -26675,7 +26675,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_time_entry",
+      "id": "harvest__delete_time_entry",
       "name": "Delete Time Entry",
       "description": "Delete a time entry. Only unlocked, non-billed entries can be deleted.",
       "requiresWrite": true,
@@ -26686,7 +26686,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -26699,7 +26699,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "stop_timer",
+      "id": "harvest__stop_timer",
       "name": "Stop Timer",
       "description": "Stop a running timer for a time entry",
       "requiresWrite": true,
@@ -26710,7 +26710,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -26723,7 +26723,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "restart_timer",
+      "id": "harvest__restart_timer",
       "name": "Restart Timer",
       "description": "Restart a stopped timer for a time entry",
       "requiresWrite": true,
@@ -26734,7 +26734,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -26747,7 +26747,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_projects",
+      "id": "harvest__list_projects",
       "name": "List Projects",
       "description": "List all projects in the Harvest account",
       "requiresWrite": false,
@@ -26758,7 +26758,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -26808,7 +26808,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_project",
+      "id": "harvest__get_project",
       "name": "Get Project",
       "description": "Get details of a specific project",
       "requiresWrite": false,
@@ -26819,7 +26819,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -26832,7 +26832,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_tasks",
+      "id": "harvest__list_tasks",
       "name": "List Tasks",
       "description": "List all tasks available in the Harvest account",
       "requiresWrite": false,
@@ -26843,7 +26843,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -26887,7 +26887,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_project_task_assignments",
+      "id": "harvest__list_project_task_assignments",
       "name": "List Project Task Assignments",
       "description":
         "List all task assignments for a specific project (tasks billable to this project)",
@@ -26899,7 +26899,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -26953,7 +26953,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_clients",
+      "id": "harvest__list_clients",
       "name": "List Clients",
       "description": "List all clients in the Harvest account",
       "requiresWrite": false,
@@ -26964,7 +26964,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -27008,7 +27008,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_client",
+      "id": "harvest__get_client",
       "name": "Get Client",
       "description": "Get details of a specific client",
       "requiresWrite": false,
@@ -27019,7 +27019,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -27032,7 +27032,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_invoices",
+      "id": "harvest__list_invoices",
       "name": "List Invoices",
       "description": "List all invoices. Filter by client, status, or date range.",
       "requiresWrite": false,
@@ -27043,7 +27043,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -27105,7 +27105,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_invoice",
+      "id": "harvest__get_invoice",
       "name": "Get Invoice",
       "description": "Get details of a specific invoice including line items",
       "requiresWrite": false,
@@ -27116,7 +27116,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -27129,7 +27129,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_invoice",
+      "id": "harvest__create_invoice",
       "name": "Create Invoice",
       "description": "Create a new invoice for a client",
       "requiresWrite": true,
@@ -27140,7 +27140,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -27175,7 +27175,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_invoice",
+      "id": "harvest__update_invoice",
       "name": "Update Invoice",
       "description": "Update an existing invoice (subject, notes, dates, line items, state)",
       "requiresWrite": true,
@@ -27186,7 +27186,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -27206,7 +27206,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_invoice_payments",
+      "id": "harvest__list_invoice_payments",
       "name": "List Invoice Payments",
       "description": "List all payments recorded for an invoice",
       "requiresWrite": false,
@@ -27217,7 +27217,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -27262,7 +27262,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_invoice_payment",
+      "id": "harvest__create_invoice_payment",
       "name": "Create Invoice Payment",
       "description": "Record a payment for an invoice",
       "requiresWrite": true,
@@ -27273,7 +27273,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -27303,7 +27303,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "time_report_by_project",
+      "id": "harvest__time_report_by_project",
       "name": "Time Report by Project",
       "description": "Get a time report aggregated by project. Requires from and to date range.",
       "requiresWrite": false,
@@ -27314,7 +27314,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -27375,7 +27375,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "time_report_by_team",
+      "id": "harvest__time_report_by_team",
       "name": "Time Report by Team",
       "description":
         "Get a time report aggregated by team member. Requires from and to date range.",
@@ -27387,7 +27387,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -27441,7 +27441,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "time_report_by_client",
+      "id": "harvest__time_report_by_client",
       "name": "Time Report by Client",
       "description": "Get a time report aggregated by client. Requires from and to date range.",
       "requiresWrite": false,
@@ -27452,7 +27452,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -27506,7 +27506,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "time_report_by_task",
+      "id": "harvest__time_report_by_task",
       "name": "Time Report by Task",
       "description": "Get a time report aggregated by task. Requires from and to date range.",
       "requiresWrite": false,
@@ -27517,7 +27517,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },
@@ -27571,7 +27571,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "invoice_report",
+      "id": "harvest__invoice_report",
       "name": "Invoice Report",
       "description": "Get an invoiced time and expenses report. Requires from and to date range.",
       "requiresWrite": false,
@@ -27582,7 +27582,7 @@ export const connectors: IntegrationConfig[] = [
           "account_id": {
             "type": "string",
             "in": "header",
-            "description": "Harvest Account ID (get it from list_accounts)",
+            "description": "Harvest Account ID (get it from harvest__list_accounts)",
             "required": true,
             "headerName": "Harvest-Account-Id",
           },

--- a/src/integrations/_data.ts
+++ b/src/integrations/_data.ts
@@ -26,7 +26,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developers.activecampaign.com/reference/authentication",
     }],
     "tools": [{
-      "id": "list_contacts",
+      "id": "activecampaign__list_contacts",
       "name": "List Contacts",
       "description": "List or search contacts in ActiveCampaign",
       "requiresWrite": false,
@@ -83,7 +83,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_contact",
+      "id": "activecampaign__get_contact",
       "name": "Get Contact",
       "description": "Get details of an ActiveCampaign contact",
       "requiresWrite": false,
@@ -107,7 +107,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_contact",
+      "id": "activecampaign__create_contact",
       "name": "Create Contact",
       "description": "Create a new contact in ActiveCampaign",
       "requiresWrite": true,
@@ -134,7 +134,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "contact" },
       },
     }, {
-      "id": "update_contact",
+      "id": "activecampaign__update_contact",
       "name": "Update Contact",
       "description": "Update an existing ActiveCampaign contact",
       "requiresWrite": true,
@@ -166,7 +166,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "contact" },
       },
     }, {
-      "id": "list_deals",
+      "id": "activecampaign__list_deals",
       "name": "List Deals",
       "description": "List deals in ActiveCampaign",
       "requiresWrite": false,
@@ -197,7 +197,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_deal",
+      "id": "activecampaign__create_deal",
       "name": "Create Deal",
       "description": "Create a new deal in ActiveCampaign",
       "requiresWrite": true,
@@ -224,7 +224,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "deal" },
       },
     }, {
-      "id": "list_accounts",
+      "id": "activecampaign__list_accounts",
       "name": "List Accounts",
       "description": "List accounts (companies) in ActiveCampaign",
       "requiresWrite": false,
@@ -326,7 +326,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.adyen.com/account/account-structure/",
     }],
     "tools": [{
-      "id": "create_payment_session",
+      "id": "adyen__create_payment_session",
       "name": "Create Payment Session",
       "description":
         "Create an Adyen Checkout payment session that a Drop-in or Component can use to collect payment",
@@ -383,7 +383,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_session_result",
+      "id": "adyen__get_session_result",
       "name": "Get Session Result",
       "description":
         "Get the final result of an Adyen payment session, including authorized payments and status",
@@ -415,7 +415,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_payment_methods",
+      "id": "adyen__list_payment_methods",
       "name": "List Payment Methods",
       "description":
         "List the payment methods available for a merchant account, amount, and shopper country",
@@ -453,7 +453,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_payment_link",
+      "id": "adyen__create_payment_link",
       "name": "Create Payment Link",
       "description":
         "Create a hosted Pay by Link URL the shopper can open to pay, without needing a Drop-in or Component frontend",
@@ -517,7 +517,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "capture_payment",
+      "id": "adyen__capture_payment",
       "name": "Capture Payment",
       "description":
         "Capture an authorised Adyen payment (for manual-capture flows); the outcome arrives asynchronously via a CAPTURE webhook",
@@ -560,7 +560,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_refund",
+      "id": "adyen__create_refund",
       "name": "Create Refund",
       "description":
         "Refund all or part of a captured Adyen payment; the outcome arrives asynchronously via a REFUND webhook",
@@ -701,7 +701,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://airtable.com/create/oauth",
     }],
     "tools": [{
-      "id": "list_bases",
+      "id": "airtable__list_bases",
       "name": "List Bases",
       "description": "List all accessible Airtable bases",
       "requiresWrite": false,
@@ -724,7 +724,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "bases" },
       },
     }, {
-      "id": "get_base",
+      "id": "airtable__get_base",
       "name": "Get Base",
       "description": "Get schema information for a specific base",
       "requiresWrite": false,
@@ -741,7 +741,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_records",
+      "id": "airtable__list_records",
       "name": "List Records",
       "description": "List records from a table with optional filtering",
       "requiresWrite": false,
@@ -787,7 +787,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "records" },
       },
     }, {
-      "id": "get_record",
+      "id": "airtable__get_record",
       "name": "Get Record",
       "description": "Get a specific record by ID",
       "requiresWrite": false,
@@ -816,7 +816,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_record",
+      "id": "airtable__create_record",
       "name": "Create Record",
       "description": "Create a new record in a table",
       "requiresWrite": true,
@@ -851,7 +851,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_records",
+      "id": "airtable__create_records",
       "name": "Create Records",
       "description": "Create multiple records in a table",
       "requiresWrite": true,
@@ -887,7 +887,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "records" },
       },
     }, {
-      "id": "update_record",
+      "id": "airtable__update_record",
       "name": "Update Record",
       "description": "Update fields on an existing record",
       "requiresWrite": true,
@@ -924,7 +924,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_record",
+      "id": "airtable__delete_record",
       "name": "Delete Record",
       "description": "Delete a record from a table",
       "requiresWrite": true,
@@ -953,7 +953,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_table",
+      "id": "airtable__create_table",
       "name": "Create Table",
       "description": "Create a new table in an Airtable base",
       "requiresWrite": true,
@@ -979,7 +979,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_table",
+      "id": "airtable__update_table",
       "name": "Update Table",
       "description": "Update table metadata such as name or description using the table ID",
       "requiresWrite": true,
@@ -1006,7 +1006,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_field",
+      "id": "airtable__create_field",
       "name": "Create Field",
       "description": "Create a new field in an Airtable table",
       "requiresWrite": true,
@@ -1090,7 +1090,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://www.algolia.com/doc/guides/security/api-keys/",
     }],
     "tools": [{
-      "id": "list_indices",
+      "id": "algolia__list_indices",
       "name": "List Indices",
       "description": "List the indices in the Algolia application",
       "requiresWrite": false,
@@ -1125,7 +1125,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_index",
+      "id": "algolia__search_index",
       "name": "Search Index",
       "description": "Run a search query against an index",
       "requiresWrite": false,
@@ -1170,7 +1170,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "browse_index",
+      "id": "algolia__browse_index",
       "name": "Browse Index",
       "description": "Browse all records in an index with cursor-based pagination",
       "requiresWrite": false,
@@ -1209,7 +1209,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_object",
+      "id": "algolia__get_object",
       "name": "Get Object",
       "description": "Retrieve a single record from an index by objectID",
       "requiresWrite": false,
@@ -1244,7 +1244,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "save_objects",
+      "id": "algolia__save_objects",
       "name": "Save Objects",
       "description": "Add or update records in an index via a batch operation",
       "requiresWrite": true,
@@ -1345,7 +1345,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://www.alphavantage.co/support/#api-key",
     }],
     "tools": [{
-      "id": "quote",
+      "id": "alphavantage__quote",
       "name": "Get Quote",
       "description": "Get the latest price and volume information for an equity ticker",
       "requiresWrite": false,
@@ -1368,7 +1368,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "daily_time_series",
+      "id": "alphavantage__daily_time_series",
       "name": "Daily Time Series",
       "description": "Get daily open, high, low, close, and volume history for an equity ticker",
       "requiresWrite": false,
@@ -1398,7 +1398,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "symbol_search",
+      "id": "alphavantage__symbol_search",
       "name": "Symbol Search",
       "description": "Search for ticker symbols and companies matching keywords",
       "requiresWrite": false,
@@ -1422,7 +1422,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "company_overview",
+      "id": "alphavantage__company_overview",
       "name": "Company Overview",
       "description":
         "Get company information and key fundamentals (market cap, PE ratio, EPS, sector) for an equity ticker",
@@ -1446,7 +1446,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "fx_rate",
+      "id": "alphavantage__fx_rate",
       "name": "FX Exchange Rate",
       "description":
         "Get the realtime exchange rate between two currencies (physical or digital, e.g. USD to EUR or BTC to USD)",
@@ -1532,7 +1532,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://amplitude.com/docs/apis/authentication",
     }],
     "tools": [{
-      "id": "list_events",
+      "id": "amplitude__list_events",
       "name": "List Events",
       "description": "List event types visible in the project with current week totals",
       "requiresWrite": false,
@@ -1561,7 +1561,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "query_event_segmentation",
+      "id": "amplitude__query_event_segmentation",
       "name": "Query Event Segmentation",
       "description": "Get metrics for an event over a date range (Event Segmentation chart data)",
       "requiresWrite": false,
@@ -1615,7 +1615,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "query_active_users",
+      "id": "amplitude__query_active_users",
       "name": "Query Active Users",
       "description": "Get active or new user counts over a date range",
       "requiresWrite": false,
@@ -1663,7 +1663,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_chart_results",
+      "id": "amplitude__get_chart_results",
       "name": "Get Chart Results",
       "description": "Get JSON results from a saved Amplitude chart by chart ID",
       "requiresWrite": false,
@@ -1687,7 +1687,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "track_event",
+      "id": "amplitude__track_event",
       "name": "Track Event",
       "description": "Send events to Amplitude via the HTTP V2 ingestion API",
       "requiresWrite": true,
@@ -1791,7 +1791,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.anthropic.com/en/api/admin-api",
     }],
     "tools": [{
-      "id": "list_workspaces",
+      "id": "anthropic__list_workspaces",
       "name": "list-workspaces",
       "description": "List all workspaces in the organization",
       "requiresWrite": false,
@@ -1836,7 +1836,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_usage",
+      "id": "anthropic__get_usage",
       "name": "get-usage",
       "description": "Get API usage statistics for a date range",
       "requiresWrite": false,
@@ -1882,7 +1882,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_api_keys",
+      "id": "anthropic__list_api_keys",
       "name": "list-api-keys",
       "description": "List API keys for a workspace or organization",
       "requiresWrite": false,
@@ -1937,7 +1937,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_members",
+      "id": "anthropic__list_members",
       "name": "list-members",
       "description": "List all members in the organization",
       "requiresWrite": false,
@@ -1982,7 +1982,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_organization",
+      "id": "anthropic__get_organization",
       "name": "get-organization",
       "description": "Get organization details and settings",
       "requiresWrite": false,
@@ -2076,7 +2076,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.apify.com/platform/integrations/api",
     }],
     "tools": [{
-      "id": "list_actors",
+      "id": "apify__list_actors",
       "name": "List Actors",
       "description": "List actors in your Apify account",
       "requiresWrite": false,
@@ -2118,7 +2118,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "run_actor_sync",
+      "id": "apify__run_actor_sync",
       "name": "Run Actor (Sync)",
       "description":
         "Run an actor, wait for it to finish (up to 300s), and return its dataset items (consumes platform credits)",
@@ -2161,7 +2161,7 @@ export const connectors: IntegrationConfig[] = [
         "bodyMode": "passthrough",
       },
     }, {
-      "id": "get_run",
+      "id": "apify__get_run",
       "name": "Get Run",
       "description": "Get the status and details of an actor run, including its defaultDatasetId",
       "requiresWrite": false,
@@ -2179,7 +2179,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_runs",
+      "id": "apify__list_runs",
       "name": "List Runs",
       "description": "List recent actor runs in your account",
       "requiresWrite": false,
@@ -2209,7 +2209,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_dataset_items",
+      "id": "apify__get_dataset_items",
       "name": "Get Dataset Items",
       "description": "Fetch items from a dataset produced by an actor run",
       "requiresWrite": false,
@@ -2319,7 +2319,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.apollo.io/docs/create-api-key",
     }],
     "tools": [{
-      "id": "search_people",
+      "id": "apollo__search_people",
       "name": "Search People",
       "description": "Search the Apollo database for people by keywords, titles, and locations",
       "requiresWrite": false,
@@ -2368,7 +2368,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_organizations",
+      "id": "apollo__search_organizations",
       "name": "Search Organizations",
       "description": "Search the Apollo database for companies; consumes Apollo credits",
       "requiresWrite": true,
@@ -2394,7 +2394,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "enrich_person",
+      "id": "apollo__enrich_person",
       "name": "Enrich Person",
       "description":
         "Enrich a person's profile by name, email, domain, or LinkedIn URL; consumes Apollo credits",
@@ -2421,7 +2421,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "person" },
       },
     }, {
-      "id": "enrich_organization",
+      "id": "apollo__enrich_organization",
       "name": "Enrich Organization",
       "description": "Enrich a company profile from its domain; consumes Apollo credits",
       "requiresWrite": true,
@@ -2439,7 +2439,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "organization" },
       },
     }, {
-      "id": "search_contacts",
+      "id": "apollo__search_contacts",
       "name": "Search Contacts",
       "description": "Search contacts already saved to your Apollo account",
       "requiresWrite": false,
@@ -2464,7 +2464,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_contact",
+      "id": "apollo__create_contact",
       "name": "Create Contact",
       "description": "Create a new contact in your Apollo account",
       "requiresWrite": true,
@@ -2485,7 +2485,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "contact" },
       },
     }, {
-      "id": "update_contact",
+      "id": "apollo__update_contact",
       "name": "Update Contact",
       "description": "Update an existing contact in your Apollo account",
       "requiresWrite": true,
@@ -2585,7 +2585,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developers.asana.com/docs/oauth",
     }],
     "tools": [{
-      "id": "list_tasks",
+      "id": "asana__list_tasks",
       "name": "List Tasks",
       "description": "List tasks in a project or assigned to a user",
       "requiresWrite": false,
@@ -2669,7 +2669,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_task",
+      "id": "asana__get_task",
       "name": "Get Task",
       "description": "Get details of a specific task",
       "requiresWrite": false,
@@ -2692,7 +2692,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "create_task",
+      "id": "asana__create_task",
       "name": "Create Task",
       "description": "Create a new task in a project",
       "requiresWrite": true,
@@ -2710,7 +2710,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "update_task",
+      "id": "asana__update_task",
       "name": "Update Task",
       "description": "Update an existing task",
       "requiresWrite": true,
@@ -2735,7 +2735,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "delete_task",
+      "id": "asana__delete_task",
       "name": "Delete Task",
       "description": "Delete an Asana task by GID",
       "requiresWrite": true,
@@ -2752,7 +2752,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_projects",
+      "id": "asana__list_projects",
       "name": "List Projects",
       "description": "List all projects in the workspace",
       "requiresWrite": false,
@@ -2831,7 +2831,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_workspaces",
+      "id": "asana__list_workspaces",
       "name": "List Workspaces",
       "description": "List Asana workspaces accessible to the authenticated user",
       "requiresWrite": false,
@@ -2894,7 +2894,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_users",
+      "id": "asana__list_users",
       "name": "List Users",
       "description": "List users in an Asana workspace",
       "requiresWrite": false,
@@ -2947,7 +2947,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_teams",
+      "id": "asana__list_teams",
       "name": "List Teams",
       "description": "List teams in an Asana workspace",
       "requiresWrite": false,
@@ -3022,7 +3022,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "add_task_comment",
+      "id": "asana__add_task_comment",
       "name": "Add Task Comment",
       "description": "Add a story/comment to an Asana task",
       "requiresWrite": true,
@@ -3047,7 +3047,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_task_comments",
+      "id": "asana__list_task_comments",
       "name": "List Task Comments",
       "description": "List comment stories for an Asana task",
       "requiresWrite": false,
@@ -3105,7 +3105,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_project",
+      "id": "asana__get_project",
       "name": "Get Project",
       "description": "Get details of a specific Asana project",
       "requiresWrite": false,
@@ -3174,7 +3174,7 @@ export const connectors: IntegrationConfig[] = [
       "default": "",
     }],
     "tools": [{
-      "id": "list_candidates",
+      "id": "ashby__list_candidates",
       "name": "List Candidates",
       "description": "List all candidates in the organization (read-only RPC via POST)",
       "requiresWrite": false,
@@ -3212,7 +3212,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_candidate",
+      "id": "ashby__get_candidate",
       "name": "Get Candidate",
       "description": "Get a candidate by ID (read-only RPC via POST)",
       "requiresWrite": false,
@@ -3223,7 +3223,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "search_candidates",
+      "id": "ashby__search_candidates",
       "name": "Search Candidates",
       "description": "Search candidates by email or name (read-only RPC via POST)",
       "requiresWrite": false,
@@ -3237,7 +3237,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "create_candidate",
+      "id": "ashby__create_candidate",
       "name": "Create Candidate",
       "description": "Create a new candidate",
       "requiresWrite": true,
@@ -3253,7 +3253,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "list_jobs",
+      "id": "ashby__list_jobs",
       "name": "List Jobs",
       "description": "List jobs, optionally filtered by status (read-only RPC via POST)",
       "requiresWrite": false,
@@ -3278,7 +3278,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "list_applications",
+      "id": "ashby__list_applications",
       "name": "List Applications",
       "description":
         "List applications, optionally filtered by job or status (read-only RPC via POST)",
@@ -3376,7 +3376,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://www.assemblyai.com/app",
     }],
     "tools": [{
-      "id": "submit_transcript",
+      "id": "assemblyai__submit_transcript",
       "name": "Submit Transcript",
       "description": "Submit an audio or video URL for transcription (processing is asynchronous)",
       "requiresWrite": true,
@@ -3397,7 +3397,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_transcript",
+      "id": "assemblyai__get_transcript",
       "name": "Get Transcript",
       "description": "Get the status and text of a transcript by ID",
       "requiresWrite": false,
@@ -3414,7 +3414,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_transcripts",
+      "id": "assemblyai__list_transcripts",
       "name": "List Transcripts",
       "description": "List transcripts created by the account",
       "requiresWrite": false,
@@ -3458,7 +3458,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_transcript",
+      "id": "assemblyai__delete_transcript",
       "name": "Delete Transcript",
       "description": "Permanently delete a transcript and its data",
       "requiresWrite": true,
@@ -3555,7 +3555,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.attio.com/rest-api/tutorials/connect-an-app-through-oauth",
     }],
     "tools": [{
-      "id": "list_objects",
+      "id": "attio__list_objects",
       "name": "List Objects",
       "description":
         "List object types in the Attio workspace (people, companies, deals, and custom objects)",
@@ -3566,7 +3566,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "query_records",
+      "id": "attio__query_records",
       "name": "Query Records",
       "description": "Query records of an object with optional filters and sorts",
       "requiresWrite": false,
@@ -3618,7 +3618,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_record",
+      "id": "attio__get_record",
       "name": "Get Record",
       "description": "Get a single record of an object by ID",
       "requiresWrite": false,
@@ -3642,7 +3642,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "create_record",
+      "id": "attio__create_record",
       "name": "Create Record",
       "description": "Create a new record of an object (person, company, deal, or custom object)",
       "requiresWrite": true,
@@ -3667,7 +3667,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "update_record",
+      "id": "attio__update_record",
       "name": "Update Record",
       "description": "Update attribute values on an existing record",
       "requiresWrite": true,
@@ -3699,7 +3699,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_lists",
+      "id": "attio__list_lists",
       "name": "List Lists",
       "description": "List all lists in the Attio workspace",
       "requiresWrite": false,
@@ -3856,7 +3856,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://axiom.co/docs/reference/tokens",
     }],
     "tools": [{
-      "id": "list_datasets",
+      "id": "axiom__list_datasets",
       "name": "List Datasets",
       "description": "List datasets in the Axiom organization",
       "requiresWrite": false,
@@ -3875,7 +3875,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_dataset",
+      "id": "axiom__get_dataset",
       "name": "Get Dataset",
       "description": "Get a dataset's details",
       "requiresWrite": false,
@@ -3892,7 +3892,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "query_apl",
+      "id": "axiom__query_apl",
       "name": "Run APL Query",
       "description": "Run an APL (Axiom Processing Language) query across datasets",
       "requiresWrite": false,
@@ -3925,7 +3925,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "ingest_events",
+      "id": "axiom__ingest_events",
       "name": "Ingest Events",
       "description": "Ingest a batch of JSON events into a dataset",
       "requiresWrite": true,
@@ -4032,7 +4032,7 @@ export const connectors: IntegrationConfig[] = [
         "https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade",
     }],
     "tools": [{
-      "id": "list_subscriptions",
+      "id": "azure__list_subscriptions",
       "name": "List Subscriptions",
       "description":
         "List all Azure subscriptions the signed-in user can access; use this first to get subscription IDs for the other tools",
@@ -4051,7 +4051,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "list_resource_groups",
+      "id": "azure__list_resource_groups",
       "name": "List Resource Groups",
       "description": "List the resource groups in an Azure subscription",
       "requiresWrite": false,
@@ -4085,7 +4085,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "list_virtual_machines",
+      "id": "azure__list_virtual_machines",
       "name": "List Virtual Machines",
       "description":
         "List all virtual machines in an Azure subscription, optionally with runtime power state",
@@ -4117,7 +4117,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "start_virtual_machine",
+      "id": "azure__start_virtual_machine",
       "name": "Start Virtual Machine",
       "description":
         "Start a stopped or deallocated virtual machine (returns 202 Accepted; the operation completes asynchronously)",
@@ -4154,7 +4154,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "deallocate_virtual_machine",
+      "id": "azure__deallocate_virtual_machine",
       "name": "Deallocate Virtual Machine",
       "description":
         "Shut down a virtual machine and release its compute resources so it stops incurring compute charges (returns 202 Accepted)",
@@ -4197,7 +4197,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_storage_accounts",
+      "id": "azure__list_storage_accounts",
       "name": "List Storage Accounts",
       "description":
         "List all storage accounts in an Azure subscription (storage keys are not returned)",
@@ -4224,7 +4224,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "list_function_apps",
+      "id": "azure__list_function_apps",
       "name": "List Function and Web Apps",
       "description":
         "List all App Service sites (function apps and web apps, Microsoft.Web/sites) in an Azure subscription; function apps have kind 'functionapp'",
@@ -4250,7 +4250,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "restart_virtual_machine",
+      "id": "azure__restart_virtual_machine",
       "name": "Restart Virtual Machine",
       "description":
         "Restart a running virtual machine (returns 202 Accepted; the operation completes asynchronously)",
@@ -4287,7 +4287,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_vm_instance_view",
+      "id": "azure__get_vm_instance_view",
       "name": "Get VM Instance View",
       "description":
         "Get the runtime state of a single virtual machine, including power state (statuses with code PowerState/running etc.), OS info, and boot diagnostics — cheaper than listing all VMs with statusOnly",
@@ -4324,7 +4324,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_resources",
+      "id": "azure__list_resources",
       "name": "List Resources",
       "description":
         "List all resources in an Azure subscription across every resource type — a generic inventory beyond the dedicated list tools",
@@ -4473,7 +4473,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://portal.azure.com/#browse/Microsoft.Storage%2FStorageAccounts",
     }],
     "tools": [{
-      "id": "list_containers",
+      "id": "azure-blob-storage__list_containers",
       "name": "List Containers",
       "description":
         "List blob containers in a storage account; the response is XML (EnumerationResults), not JSON",
@@ -4509,7 +4509,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_blobs",
+      "id": "azure-blob-storage__list_blobs",
       "name": "List Blobs",
       "description":
         "List blobs in a container, optionally filtered by name prefix; the response is XML (EnumerationResults), not JSON",
@@ -4553,7 +4553,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "download_blob",
+      "id": "azure-blob-storage__download_blob",
       "name": "Download Blob",
       "description":
         "Download a blob's content (Get Blob); blob properties are returned as x-ms-* response headers",
@@ -4591,7 +4591,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "upload_blob",
+      "id": "azure-blob-storage__upload_blob",
       "name": "Upload Blob",
       "description": "Create or overwrite a block blob with the given content (Put Blob)",
       "requiresWrite": true,
@@ -4649,7 +4649,7 @@ export const connectors: IntegrationConfig[] = [
         "bodyMode": "passthrough",
       },
     }, {
-      "id": "delete_blob",
+      "id": "azure-blob-storage__delete_blob",
       "name": "Delete Blob",
       "description": "Delete a blob from a container (Delete Blob); errors are returned as XML",
       "requiresWrite": true,
@@ -4685,7 +4685,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_container",
+      "id": "azure-blob-storage__create_container",
       "name": "Create Container",
       "description":
         "Create a new blob container in the storage account (Create Container); fails with 409 if a container with the same name already exists",
@@ -4723,7 +4723,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "copy_blob",
+      "id": "azure-blob-storage__copy_blob",
       "name": "Copy Blob",
       "description":
         "Server-side copy of a blob to a destination within the storage account (Copy Blob) — no download/re-upload needed; returns 202 with x-ms-copy-status 'success' or 'pending' (poll the destination blob until the copy finishes)",
@@ -4854,7 +4854,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://portal.azure.com",
     }],
     "tools": [{
-      "id": "analyze_invoice",
+      "id": "azure-document-intelligence__analyze_invoice",
       "name": "Analyze Invoice",
       "description":
         "Start analysis of an invoice with the prebuilt-invoice model (vendor, customer, line items, totals, taxes, payment terms). Asynchronous: the API responds 202 Accepted with an Operation-Location header containing the result ID — poll Get Analyze Result with that ID to fetch the extracted fields.",
@@ -4896,7 +4896,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "analyze_receipt",
+      "id": "azure-document-intelligence__analyze_receipt",
       "name": "Analyze Receipt",
       "description":
         "Start analysis of a sales receipt with the prebuilt-receipt model (merchant, transaction date/time, line items, tax, tip, total). Asynchronous: responds 202 Accepted with an Operation-Location header containing the result ID — poll Get Analyze Result with that ID.",
@@ -4938,7 +4938,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "analyze_layout",
+      "id": "azure-document-intelligence__analyze_layout",
       "name": "Analyze Layout",
       "description":
         "Start analysis of any document with the prebuilt-layout model to extract text, tables, selection marks, and document structure (optionally as Markdown). Asynchronous: responds 202 Accepted with an Operation-Location header containing the result ID — poll Get Analyze Result with that ID.",
@@ -4980,7 +4980,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_analyze_result",
+      "id": "azure-document-intelligence__get_analyze_result",
       "name": "Get Analyze Result",
       "description":
         "Fetch the result of a previously started analysis. Use the result ID (GUID) from the Operation-Location response header of an analyze call, and the same model ID that started it. While status is 'running', wait and poll again; when status is 'succeeded', the extracted fields are in analyzeResult.",
@@ -5014,7 +5014,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "analyze_read",
+      "id": "azure-document-intelligence__analyze_read",
       "name": "Analyze Read (OCR)",
       "description":
         "Start pure OCR text extraction with the prebuilt-read model — the cheapest option for plain scans where only the text matters (no tables or key-value pairs). Asynchronous: responds 202 Accepted with an Operation-Location header containing the result ID — poll Get Analyze Result with that ID.",
@@ -5056,7 +5056,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_document_models",
+      "id": "azure-document-intelligence__list_document_models",
       "name": "List Document Models",
       "description":
         "List the document models available on the resource (prebuilt and custom) with their model IDs and descriptions — use this to discover valid model IDs",
@@ -5168,7 +5168,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://documentation.bamboohr.com/docs/getting-started",
     }],
     "tools": [{
-      "id": "get_employee_directory",
+      "id": "bamboohr__get_employee_directory",
       "name": "Get Employee Directory",
       "description":
         "Get the company employee directory with names, job titles, departments, and contact details",
@@ -5196,7 +5196,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "employees" },
       },
     }, {
-      "id": "get_employee",
+      "id": "bamboohr__get_employee",
       "name": "Get Employee",
       "description": "Get a single employee record with the specific fields you request",
       "requiresWrite": false,
@@ -5241,7 +5241,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_time_off_requests",
+      "id": "bamboohr__list_time_off_requests",
       "name": "List Time-Off Requests",
       "description":
         "List time-off requests that overlap a date range, optionally filtered by employee or status",
@@ -5302,7 +5302,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_time_off_request",
+      "id": "bamboohr__create_time_off_request",
       "name": "Create Time-Off Request",
       "description":
         "Create a time-off request for an employee; it must be approved before it appears in history",
@@ -5374,7 +5374,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_time_off_types",
+      "id": "bamboohr__list_time_off_types",
       "name": "List Time-Off Types",
       "description":
         "List the company's time-off types and their IDs - needed to fill the timeOffTypeId field when creating a time-off request",
@@ -5401,7 +5401,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_time_off_request_status",
+      "id": "bamboohr__update_time_off_request_status",
       "name": "Update Time-Off Request Status",
       "description":
         "Approve, deny, or cancel an existing time-off request (the API user must have approval permissions)",
@@ -5445,7 +5445,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_fields",
+      "id": "bamboohr__list_fields",
       "name": "List Field Metadata",
       "description":
         "List all employee fields available in the account (standard and custom) so agents know which field names Get Employee accepts",
@@ -5472,7 +5472,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_whos_out",
+      "id": "bamboohr__list_whos_out",
       "name": "List Who's Out",
       "description":
         "List approved time off and company holidays in a date range to see who is out of office",
@@ -5595,7 +5595,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://github.com/basecamp/bc3-api/blob/master/sections/authentication.md",
     }],
     "tools": [{
-      "id": "list_projects",
+      "id": "basecamp__list_projects",
       "name": "List Projects",
       "description": "List active projects in a Basecamp account",
       "requiresWrite": false,
@@ -5641,7 +5641,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_project",
+      "id": "basecamp__get_project",
       "name": "Get Project",
       "description":
         "Get a project including its dock (the todoset ID needed for to-do tools is in the dock entry named 'todoset')",
@@ -5665,7 +5665,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_project",
+      "id": "basecamp__create_project",
       "name": "Create Project",
       "description": "Create a new Basecamp project",
       "requiresWrite": true,
@@ -5686,7 +5686,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_todolists",
+      "id": "basecamp__list_todolists",
       "name": "List To-do Lists",
       "description":
         "List to-do lists in a project's todoset (get the todoset ID from Get Project's dock)",
@@ -5733,7 +5733,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_todos",
+      "id": "basecamp__list_todos",
       "name": "List To-dos",
       "description": "List to-dos in a to-do list",
       "requiresWrite": false,
@@ -5780,7 +5780,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_todo",
+      "id": "basecamp__create_todo",
       "name": "Create To-do",
       "description": "Create a to-do in a to-do list",
       "requiresWrite": true,
@@ -5814,7 +5814,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "complete_todo",
+      "id": "basecamp__complete_todo",
       "name": "Complete To-do",
       "description": "Mark a Basecamp to-do as completed",
       "requiresWrite": true,
@@ -5899,7 +5899,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://betterstack.com/docs/uptime/api/getting-started-with-uptime-api/",
     }],
     "tools": [{
-      "id": "list_monitors",
+      "id": "betterstack__list_monitors",
       "name": "List Monitors",
       "description": "List uptime monitors, optionally filtered by URL or name",
       "requiresWrite": false,
@@ -5939,7 +5939,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_monitor",
+      "id": "betterstack__get_monitor",
       "name": "Get Monitor",
       "description": "Get a monitor's configuration and current status",
       "requiresWrite": false,
@@ -5957,7 +5957,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_monitor_sla",
+      "id": "betterstack__get_monitor_sla",
       "name": "Get Monitor Availability",
       "description": "Get a monitor's availability (SLA) summary for a time range",
       "requiresWrite": false,
@@ -5977,7 +5977,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_incidents",
+      "id": "betterstack__list_incidents",
       "name": "List Incidents",
       "description": "List incidents, optionally limited to a date range or unresolved only",
       "requiresWrite": false,
@@ -6010,7 +6010,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_heartbeats",
+      "id": "betterstack__list_heartbeats",
       "name": "List Heartbeats",
       "description": "List heartbeat (cron/job) monitors and their status",
       "requiresWrite": false,
@@ -6100,7 +6100,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.bigcommerce.com/docs/start/authentication/api-accounts",
     }],
     "tools": [{
-      "id": "list_orders",
+      "id": "bigcommerce__list_orders",
       "name": "List Orders",
       "description":
         "List store orders with optional status, customer, and date filtering (Orders are served by the v2 API)",
@@ -6151,7 +6151,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_order",
+      "id": "bigcommerce__get_order",
       "name": "Get Order",
       "description": "Get full details of a single order (Orders are served by the v2 API)",
       "requiresWrite": false,
@@ -6174,7 +6174,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_order_products",
+      "id": "bigcommerce__list_order_products",
       "name": "List Order Products",
       "description":
         "List the line items of an order — v2 order responses do not embed products, so use this to see what was bought",
@@ -6210,7 +6210,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_order",
+      "id": "bigcommerce__update_order",
       "name": "Update Order",
       "description":
         "Update an order, e.g. change its status to Shipped/Cancelled/Refunded or add staff notes",
@@ -6246,7 +6246,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_products",
+      "id": "bigcommerce__list_products",
       "name": "List Products",
       "description": "List catalog products with optional keyword, SKU, and availability filtering",
       "requiresWrite": false,
@@ -6293,7 +6293,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_product",
+      "id": "bigcommerce__get_product",
       "name": "Get Product",
       "description": "Get full details of a single catalog product",
       "requiresWrite": false,
@@ -6323,7 +6323,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_customers",
+      "id": "bigcommerce__list_customers",
       "name": "List Customers",
       "description": "List store customers with optional email and name filtering",
       "requiresWrite": false,
@@ -6363,7 +6363,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "create_product",
+      "id": "bigcommerce__create_product",
       "name": "Create Product",
       "description": "Create a new product in the catalog",
       "requiresWrite": true,
@@ -6414,7 +6414,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "update_product",
+      "id": "bigcommerce__update_product",
       "name": "Update Product",
       "description":
         "Update fields of an existing catalog product, such as price, visibility, or inventory",
@@ -6549,7 +6549,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://app.billbee.io/swagger/ui/index",
     }],
     "tools": [{
-      "id": "list_orders",
+      "id": "billbee__list_orders",
       "name": "List Orders",
       "description":
         "List orders across all connected shops, optionally filtered by date range, modification time, or order state",
@@ -6599,7 +6599,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_order",
+      "id": "billbee__get_order",
       "name": "Get Order",
       "description":
         "Get a single order with positions, addresses, and payment details by its internal Billbee ID",
@@ -6617,7 +6617,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_order_state",
+      "id": "billbee__update_order_state",
       "name": "Update Order State",
       "description":
         "Change the main state of an order, e.g. mark it as confirmed, paid, or shipped",
@@ -6643,7 +6643,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_products",
+      "id": "billbee__list_products",
       "name": "List Products",
       "description": "List products (articles) in the Billbee account",
       "requiresWrite": false,
@@ -6671,7 +6671,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_customers",
+      "id": "billbee__list_customers",
       "name": "List Customers",
       "description": "List customers in the Billbee account",
       "requiresWrite": false,
@@ -6694,7 +6694,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_invoices",
+      "id": "billbee__list_invoices",
       "name": "List Invoices",
       "description":
         "List invoices with positions and amounts over a date range — the export feed into accounting tools. Throttled to 1 request per minute for the same page and minInvoiceDate.",
@@ -6733,14 +6733,14 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_order_states",
+      "id": "billbee__get_order_states",
       "name": "Get Order States",
       "description":
         "List all defined order state IDs and names — resolves the NewStateId values used by Update Order State",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.billbee.io/api/v1/enums/orderstates" },
     }, {
-      "id": "update_stock",
+      "id": "billbee__update_stock",
       "name": "Update Stock",
       "description":
         "Set the absolute stock quantity of a product by SKU or Billbee product ID — the most common multichannel write; the change is pushed to connected shops",
@@ -6856,7 +6856,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/",
     }],
     "tools": [{
-      "id": "list_repositories",
+      "id": "bitbucket__list_repositories",
       "name": "List Repositories",
       "description": "Get list of user's repositories",
       "requiresWrite": false,
@@ -6914,7 +6914,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_repository",
+      "id": "bitbucket__get_repository",
       "name": "Get Repository",
       "description": "Get details of a specific repository",
       "requiresWrite": false,
@@ -6937,7 +6937,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_pull_requests",
+      "id": "bitbucket__list_pull_requests",
       "name": "List Pull Requests",
       "description": "Get pull requests for a repository",
       "requiresWrite": false,
@@ -6998,7 +6998,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_pull_request",
+      "id": "bitbucket__get_pull_request",
       "name": "Get Pull Request",
       "description": "Get details of a specific pull request",
       "requiresWrite": false,
@@ -7028,7 +7028,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_pull_request",
+      "id": "bitbucket__create_pull_request",
       "name": "Create Pull Request",
       "description": "Create a new pull request",
       "requiresWrite": true,
@@ -7076,7 +7076,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "add_pull_request_comment",
+      "id": "bitbucket__add_pull_request_comment",
       "name": "Add Pull Request Comment",
       "description": "Add a comment to a pull request",
       "requiresWrite": true,
@@ -7113,7 +7113,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_issues",
+      "id": "bitbucket__list_issues",
       "name": "List Issues",
       "description": "Get issues for a repository",
       "requiresWrite": false,
@@ -7208,7 +7208,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.box.com/guides/authentication/oauth2/oauth2-setup/",
     }],
     "tools": [{
-      "id": "list_folder_items",
+      "id": "box__list_folder_items",
       "name": "List Folder Items",
       "description": "List files and subfolders inside a Box folder (folder 0 is the root)",
       "requiresWrite": false,
@@ -7259,7 +7259,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_file",
+      "id": "box__get_file",
       "name": "Get File",
       "description": "Get metadata about a Box file",
       "requiresWrite": false,
@@ -7281,7 +7281,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_folder",
+      "id": "box__get_folder",
       "name": "Get Folder",
       "description": "Get metadata about a Box folder",
       "requiresWrite": false,
@@ -7298,7 +7298,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search",
+      "id": "box__search",
       "name": "Search",
       "description": "Search for files and folders across the Box account",
       "requiresWrite": false,
@@ -7337,7 +7337,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_folder",
+      "id": "box__create_folder",
       "name": "Create Folder",
       "description": "Create a new folder inside a Box parent folder",
       "requiresWrite": true,
@@ -7350,12 +7350,12 @@ export const connectors: IntegrationConfig[] = [
             "type": "object",
             "description": 'Parent folder reference, e.g. { "id": "0" } for the root folder',
             "required": true,
-            "default": { "id": "0" },
+            "default": { "id": "box__0" },
           },
         },
       },
     }, {
-      "id": "upload_file",
+      "id": "box__upload_file",
       "name": "Upload File",
       "description":
         "Upload a new file (up to 50 MB) into a Box folder; larger files require Box's chunked upload API",
@@ -7396,7 +7396,7 @@ export const connectors: IntegrationConfig[] = [
         "contentType": "multipart/form-data",
       },
     }, {
-      "id": "upload_file_version",
+      "id": "box__upload_file_version",
       "name": "Upload File Version",
       "description": "Upload a new version of an existing Box file (up to 50 MB)",
       "requiresWrite": true,
@@ -7436,7 +7436,7 @@ export const connectors: IntegrationConfig[] = [
         "contentType": "multipart/form-data",
       },
     }, {
-      "id": "list_file_comments",
+      "id": "box__list_file_comments",
       "name": "List File Comments",
       "description": "List comments on a Box file",
       "requiresWrite": false,
@@ -7465,7 +7465,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "add_comment",
+      "id": "box__add_comment",
       "name": "Add Comment",
       "description": "Add a comment to a Box file",
       "requiresWrite": true,
@@ -7486,7 +7486,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "download_file",
+      "id": "box__download_file",
       "name": "Download File",
       "description":
         "Download a file's content; Box responds with a 302 redirect to a short-lived dl.boxcloud.com URL that is followed to fetch the binary content (a 202 with Retry-After means the file is not yet ready)",
@@ -7578,7 +7578,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://api-dashboard.search.brave.com/app/keys",
     }],
     "tools": [{
-      "id": "web_search",
+      "id": "brave-search__web_search",
       "name": "Web Search",
       "description": "Search the web and get ranked results from Brave's independent index",
       "requiresWrite": false,
@@ -7637,7 +7637,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "news_search",
+      "id": "brave-search__news_search",
       "name": "News Search",
       "description": "Search recent and historical news articles from trusted outlets worldwide",
       "requiresWrite": false,
@@ -7705,7 +7705,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "image_search",
+      "id": "brave-search__image_search",
       "name": "Image Search",
       "description": "Search Brave's image index and get image URLs with source page metadata",
       "requiresWrite": false,
@@ -7746,7 +7746,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "video_search",
+      "id": "brave-search__video_search",
       "name": "Video Search",
       "description":
         "Search for videos and get results with titles, creators, durations, and thumbnails",
@@ -7799,7 +7799,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "local_descriptions",
+      "id": "brave-search__local_descriptions",
       "name": "Get Local Descriptions",
       "description":
         "Get AI-generated text descriptions for up to 20 locations using location IDs returned in a Web Search response's locations results",
@@ -7818,7 +7818,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "local_pois",
+      "id": "brave-search__local_pois",
       "name": "Get Local Places",
       "description":
         "Get rich details (address, hours, ratings, pictures) for up to 20 locations using location IDs returned in a Web Search response's locations results",
@@ -7927,7 +7927,7 @@ export const connectors: IntegrationConfig[] = [
         "https://developers.brevo.com/docs/getting-started#using-your-api-key-to-authenticate",
     }],
     "tools": [{
-      "id": "send_email",
+      "id": "brevo__send_email",
       "name": "Send Email",
       "description": "Send a transactional email",
       "requiresWrite": true,
@@ -7953,7 +7953,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_contacts",
+      "id": "brevo__list_contacts",
       "name": "List Contacts",
       "description": "List contacts in the account",
       "requiresWrite": false,
@@ -8003,7 +8003,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_contact",
+      "id": "brevo__get_contact",
       "name": "Get Contact",
       "description": "Get a contact by email address or numeric ID",
       "requiresWrite": false,
@@ -8020,7 +8020,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_contact",
+      "id": "brevo__create_contact",
       "name": "Create Contact",
       "description": "Create a new contact",
       "requiresWrite": true,
@@ -8042,7 +8042,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_lists",
+      "id": "brevo__list_lists",
       "name": "List Lists",
       "description": "List contact lists",
       "requiresWrite": false,
@@ -8065,7 +8065,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_email_campaigns",
+      "id": "brevo__list_email_campaigns",
       "name": "List Email Campaigns",
       "description": "List email campaigns with status and scheduling info",
       "requiresWrite": false,
@@ -8168,7 +8168,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.browserbase.com/introduction/getting-started",
     }],
     "tools": [{
-      "id": "list_sessions",
+      "id": "browserbase__list_sessions",
       "name": "List Sessions",
       "description": "List browser sessions, optionally filtered by status",
       "requiresWrite": false,
@@ -8199,7 +8199,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_session",
+      "id": "browserbase__create_session",
       "name": "Create Session",
       "description": "Create a new cloud browser session (consumes plan browser minutes)",
       "requiresWrite": true,
@@ -8232,7 +8232,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_session",
+      "id": "browserbase__get_session",
       "name": "Get Session",
       "description": "Get a session's status, connection URL, and metadata",
       "requiresWrite": false,
@@ -8249,7 +8249,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "release_session",
+      "id": "browserbase__release_session",
       "name": "Release Session",
       "description": "Request release of a running session to stop billing for it",
       "requiresWrite": true,
@@ -8278,7 +8278,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_projects",
+      "id": "browserbase__list_projects",
       "name": "List Projects",
       "description": "List the Browserbase projects available to the API key",
       "requiresWrite": false,
@@ -8354,13 +8354,13 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://buildkite.com/docs/apis/managing-api-tokens",
     }],
     "tools": [{
-      "id": "list_organizations",
+      "id": "buildkite__list_organizations",
       "name": "List Organizations",
       "description": "List Buildkite organizations the token can access",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.buildkite.com/v2/organizations" },
     }, {
-      "id": "list_pipelines",
+      "id": "buildkite__list_pipelines",
       "name": "List Pipelines",
       "description": "List pipelines in an organization",
       "requiresWrite": false,
@@ -8394,7 +8394,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_pipeline",
+      "id": "buildkite__get_pipeline",
       "name": "Get Pipeline",
       "description": "Get a pipeline's configuration and build stats",
       "requiresWrite": false,
@@ -8417,7 +8417,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_builds",
+      "id": "buildkite__list_builds",
       "name": "List Builds",
       "description": "List builds for a pipeline, optionally filtered by branch or state",
       "requiresWrite": false,
@@ -8473,7 +8473,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_build",
+      "id": "buildkite__get_build",
       "name": "Get Build",
       "description": "Get a build including its jobs and their states",
       "requiresWrite": false,
@@ -8503,7 +8503,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_build",
+      "id": "buildkite__create_build",
       "name": "Create Build",
       "description": "Trigger a new build on a pipeline",
       "requiresWrite": true,
@@ -8612,7 +8612,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://cal.com/docs/api-reference/v2/introduction",
     }],
     "tools": [{
-      "id": "list_bookings",
+      "id": "cal-com__list_bookings",
       "name": "List Bookings",
       "description":
         "List bookings for the authenticated user with optional status, event type, and attendee filters",
@@ -8660,7 +8660,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_event_types",
+      "id": "cal-com__list_event_types",
       "name": "List Event Types",
       "description":
         "List event types so the agent can find the event type ID needed for slots and bookings",
@@ -8695,7 +8695,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_available_slots",
+      "id": "cal-com__get_available_slots",
       "name": "Get Available Slots",
       "description":
         "Find available time slots for an event type within a date range, e.g. before creating a booking",
@@ -8756,7 +8756,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "create_booking",
+      "id": "cal-com__create_booking",
       "name": "Create Booking",
       "description": "Book a time slot on an event type for an attendee",
       "requiresWrite": true,
@@ -8812,7 +8812,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_booking",
+      "id": "cal-com__get_booking",
       "name": "Get Booking",
       "description":
         "Get a single booking by UID, e.g. to confirm details before rescheduling or cancelling",
@@ -8839,7 +8839,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "reschedule_booking",
+      "id": "cal-com__reschedule_booking",
       "name": "Reschedule Booking",
       "description":
         "Move an existing booking to a new start time (only accepted or pending bookings can be rescheduled)",
@@ -8882,7 +8882,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "confirm_booking",
+      "id": "cal-com__confirm_booking",
       "name": "Confirm Booking",
       "description":
         "Confirm a booking that is awaiting host approval (status unconfirmed in list_bookings)",
@@ -8908,7 +8908,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "cancel_booking",
+      "id": "cal-com__cancel_booking",
       "name": "Cancel Booking",
       "description": "Cancel an existing booking, optionally recording a cancellation reason",
       "requiresWrite": true,
@@ -9022,7 +9022,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://console.cloud.google.com/apis/credentials",
     }],
     "tools": [{
-      "id": "list_calendars",
+      "id": "calendar__list_calendars",
       "name": "List Calendars",
       "description": "List all calendars in the authenticated user's calendar list",
       "requiresWrite": false,
@@ -9040,7 +9040,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "items" },
       },
     }, {
-      "id": "list_events",
+      "id": "calendar__list_events",
       "name": "List Events",
       "description": "Get upcoming calendar events",
       "requiresWrite": false,
@@ -9079,7 +9079,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "items" },
       },
     }, {
-      "id": "create_event",
+      "id": "calendar__create_event",
       "name": "Create Event",
       "description": "Schedule a new calendar event",
       "requiresWrite": true,
@@ -9113,7 +9113,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_event",
+      "id": "calendar__get_event",
       "name": "Get Event",
       "description": "Get details of a specific calendar event",
       "requiresWrite": false,
@@ -9137,7 +9137,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_event",
+      "id": "calendar__update_event",
       "name": "Update Event",
       "description": "Update an existing calendar event",
       "requiresWrite": true,
@@ -9184,7 +9184,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_event",
+      "id": "calendar__delete_event",
       "name": "Delete Event",
       "description": "Delete a calendar event by ID",
       "requiresWrite": true,
@@ -9214,7 +9214,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "find_free_time",
+      "id": "calendar__find_free_time",
       "name": "Find Free Time",
       "description": "Find available time slots in calendar",
       "requiresWrite": false,
@@ -9294,7 +9294,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.calendly.com/create-a-developer-account",
     }],
     "tools": [{
-      "id": "get_current_user",
+      "id": "calendly__get_current_user",
       "name": "Get Current User",
       "description":
         "Get the connected Calendly user, including their user URI and organization URI (needed by the other tools)",
@@ -9305,7 +9305,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "resource" },
       },
     }, {
-      "id": "list_event_types",
+      "id": "calendly__list_event_types",
       "name": "List Event Types",
       "description": "List the user's or organization's event types (scheduling links)",
       "requiresWrite": false,
@@ -9358,7 +9358,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_scheduled_events",
+      "id": "calendly__list_scheduled_events",
       "name": "List Scheduled Events",
       "description": "List scheduled events for a user or organization",
       "requiresWrite": false,
@@ -9421,7 +9421,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_scheduled_event",
+      "id": "calendly__get_scheduled_event",
       "name": "Get Scheduled Event",
       "description": "Get details of a specific scheduled event",
       "requiresWrite": false,
@@ -9439,7 +9439,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "resource" },
       },
     }, {
-      "id": "list_event_invitees",
+      "id": "calendly__list_event_invitees",
       "name": "List Event Invitees",
       "description": "List invitees of a scheduled event",
       "requiresWrite": false,
@@ -9483,7 +9483,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "cancel_event",
+      "id": "calendly__cancel_event",
       "name": "Cancel Event",
       "description": "Cancel a scheduled event",
       "requiresWrite": true,
@@ -9587,7 +9587,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://apidocs.chargebee.com/docs/api",
     }],
     "tools": [{
-      "id": "list_subscriptions",
+      "id": "chargebee__list_subscriptions",
       "name": "List Subscriptions",
       "description": "List subscriptions with optional status or customer filtering",
       "requiresWrite": false,
@@ -9637,7 +9637,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_subscription",
+      "id": "chargebee__get_subscription",
       "name": "Get Subscription",
       "description": "Retrieve a single subscription with its plan, status, and billing details",
       "requiresWrite": false,
@@ -9661,7 +9661,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_customers",
+      "id": "chargebee__list_customers",
       "name": "List Customers",
       "description": "List customers with optional email filtering",
       "requiresWrite": false,
@@ -9705,7 +9705,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_invoices",
+      "id": "chargebee__list_invoices",
       "name": "List Invoices",
       "description": "List invoices with optional status, customer, or subscription filtering",
       "requiresWrite": false,
@@ -9760,7 +9760,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_item_prices",
+      "id": "chargebee__list_item_prices",
       "name": "List Item Prices",
       "description":
         "List item prices (plans, addons, charges) in the catalog to find IDs and pricing for subscriptions",
@@ -9820,7 +9820,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_invoice",
+      "id": "chargebee__get_invoice",
       "name": "Get Invoice",
       "description":
         "Retrieve a single invoice with its line items, amounts due, and linked payments",
@@ -9845,7 +9845,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_transactions",
+      "id": "chargebee__list_transactions",
       "name": "List Transactions",
       "description":
         "List payment-level transactions (payments, refunds, authorizations) behind invoices, e.g. to review failed payments",
@@ -9907,7 +9907,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_customer",
+      "id": "chargebee__create_customer",
       "name": "Create Customer",
       "description": "Create a new customer record in Chargebee",
       "requiresWrite": true,
@@ -10021,7 +10021,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://www.checklyhq.com/docs/api-reference/overview/",
     }],
     "tools": [{
-      "id": "list_checks",
+      "id": "checkly__list_checks",
       "name": "List Checks",
       "description": "List API and browser checks in the account",
       "requiresWrite": false,
@@ -10054,7 +10054,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_check",
+      "id": "checkly__get_check",
       "name": "Get Check",
       "description": "Get a check's full configuration",
       "requiresWrite": false,
@@ -10071,7 +10071,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_check_results",
+      "id": "checkly__list_check_results",
       "name": "List Check Results",
       "description":
         "List raw results for a check within a time window (from/to must be at most 6 hours apart)",
@@ -10116,13 +10116,13 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_check_statuses",
+      "id": "checkly__list_check_statuses",
       "name": "List Check Statuses",
       "description": "Get the current status of every check in the account",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.checklyhq.com/v1/check-statuses" },
     }, {
-      "id": "get_check_status",
+      "id": "checkly__get_check_status",
       "name": "Get Check Status",
       "description": "Get the current status of a single check",
       "requiresWrite": false,
@@ -10208,7 +10208,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://circleci.com/docs/managing-api-tokens/",
     }],
     "tools": [{
-      "id": "list_pipelines",
+      "id": "circleci__list_pipelines",
       "name": "List Pipelines",
       "description": "List recent pipelines for a project",
       "requiresWrite": false,
@@ -10253,7 +10253,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_pipeline",
+      "id": "circleci__get_pipeline",
       "name": "Get Pipeline",
       "description": "Get a pipeline by its ID",
       "requiresWrite": false,
@@ -10270,7 +10270,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "trigger_pipeline",
+      "id": "circleci__trigger_pipeline",
       "name": "Trigger Pipeline",
       "description": "Trigger a new pipeline for a project on a branch or tag",
       "requiresWrite": true,
@@ -10301,7 +10301,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_workflows",
+      "id": "circleci__list_workflows",
       "name": "List Pipeline Workflows",
       "description": "List the workflows of a pipeline",
       "requiresWrite": false,
@@ -10340,7 +10340,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_workflow",
+      "id": "circleci__get_workflow",
       "name": "Get Workflow",
       "description": "Get a workflow by its ID",
       "requiresWrite": false,
@@ -10357,7 +10357,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_workflow_jobs",
+      "id": "circleci__list_workflow_jobs",
       "name": "List Workflow Jobs",
       "description": "List the jobs of a workflow with their statuses",
       "requiresWrite": false,
@@ -10374,7 +10374,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "cancel_workflow",
+      "id": "circleci__cancel_workflow",
       "name": "Cancel Workflow",
       "description": "Cancel a running workflow",
       "requiresWrite": true,
@@ -10470,7 +10470,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developers.cleverreach.com/api/authentication/",
     }],
     "tools": [{
-      "id": "list_groups",
+      "id": "cleverreach__list_groups",
       "name": "List Groups",
       "description":
         "List CleverReach groups (recipient lists) so agents can find a group ID before reading or adding recipients",
@@ -10488,7 +10488,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_group_receivers",
+      "id": "cleverreach__list_group_receivers",
       "name": "List Group Receivers",
       "description":
         "List the receivers (recipients) of a CleverReach group, with paging and email filters",
@@ -10535,7 +10535,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "add_receiver",
+      "id": "cleverreach__add_receiver",
       "name": "Add Receiver",
       "description": "Add (subscribe) a new receiver to a CleverReach group",
       "requiresWrite": true,
@@ -10583,7 +10583,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_mailings",
+      "id": "cleverreach__list_mailings",
       "name": "List Mailings",
       "description":
         "List CleverReach mailings (email campaigns) filtered by state, such as drafts or finished mailings",
@@ -10628,7 +10628,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_mailing",
+      "id": "cleverreach__create_mailing",
       "name": "Create Mailing Draft",
       "description":
         "Create a new CleverReach mailing as a draft with subject, sender, and HTML/text content; sending is triggered separately",
@@ -10676,7 +10676,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_mailing",
+      "id": "cleverreach__get_mailing",
       "name": "Get Mailing",
       "description":
         "Get a single mailing by ID, e.g. to inspect a draft created with Create Mailing Draft",
@@ -10694,7 +10694,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "deactivate_receiver",
+      "id": "cleverreach__deactivate_receiver",
       "name": "Deactivate Receiver",
       "description":
         "Deactivate (unsubscribe) a receiver in a group by ID or email — the counterpart to Add Receiver for unsubscribe handling",
@@ -10718,7 +10718,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_group_stats",
+      "id": "cleverreach__get_group_stats",
       "name": "Get Group Stats",
       "description":
         "Get list health statistics for a group: active, inactive, and bounced receiver counts",
@@ -10808,7 +10808,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://clickhouse.com/docs/cloud/manage/openapi",
     }],
     "tools": [{
-      "id": "list_organizations",
+      "id": "clickhouse__list_organizations",
       "name": "List Organizations",
       "description": "List organizations the API key has access to",
       "requiresWrite": false,
@@ -10826,7 +10826,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_organization",
+      "id": "clickhouse__get_organization",
       "name": "Get Organization",
       "description": "Get details of an organization",
       "requiresWrite": false,
@@ -10844,7 +10844,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "list_services",
+      "id": "clickhouse__list_services",
       "name": "List Services",
       "description": "List all ClickHouse services in an organization",
       "requiresWrite": false,
@@ -10878,7 +10878,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_service",
+      "id": "clickhouse__get_service",
       "name": "Get Service",
       "description": "Get details of a ClickHouse service, including endpoints and state",
       "requiresWrite": false,
@@ -10980,13 +10980,13 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.clickup.com/docs/authentication",
     }],
     "tools": [{
-      "id": "list_workspaces",
+      "id": "clickup__list_workspaces",
       "name": "List Workspaces",
       "description": "List ClickUp Workspaces (teams) the authorized user can access",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.clickup.com/api/v2/team" },
     }, {
-      "id": "list_spaces",
+      "id": "clickup__list_spaces",
       "name": "List Spaces",
       "description": "List Spaces in a ClickUp Workspace",
       "requiresWrite": false,
@@ -11009,7 +11009,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_lists",
+      "id": "clickup__list_lists",
       "name": "List Lists",
       "description": "List folderless Lists in a ClickUp Space",
       "requiresWrite": false,
@@ -11032,7 +11032,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_tasks",
+      "id": "clickup__list_tasks",
       "name": "List Tasks",
       "description": "List tasks in a ClickUp List",
       "requiresWrite": false,
@@ -11085,7 +11085,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_task",
+      "id": "clickup__get_task",
       "name": "Get Task",
       "description": "Get details of a ClickUp task",
       "requiresWrite": false,
@@ -11108,7 +11108,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_task",
+      "id": "clickup__create_task",
       "name": "Create Task",
       "description": "Create a new task in a ClickUp List",
       "requiresWrite": true,
@@ -11136,7 +11136,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_task",
+      "id": "clickup__update_task",
       "name": "Update Task",
       "description": "Update fields on an existing ClickUp task",
       "requiresWrite": true,
@@ -11238,7 +11238,7 @@ export const connectors: IntegrationConfig[] = [
       "default": "",
     }],
     "tools": [{
-      "id": "list_leads",
+      "id": "close__list_leads",
       "name": "List Leads",
       "description": "List or search leads in Close using the lead query language",
       "requiresWrite": false,
@@ -11284,7 +11284,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_lead",
+      "id": "close__get_lead",
       "name": "Get Lead",
       "description": "Get full details of a Close lead, including contacts and opportunities",
       "requiresWrite": false,
@@ -11301,7 +11301,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_lead",
+      "id": "close__create_lead",
       "name": "Create Lead",
       "description": "Create a new lead in Close, optionally with contacts",
       "requiresWrite": true,
@@ -11324,7 +11324,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_lead",
+      "id": "close__update_lead",
       "name": "Update Lead",
       "description": "Update fields on an existing Close lead",
       "requiresWrite": true,
@@ -11347,7 +11347,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_opportunities",
+      "id": "close__list_opportunities",
       "name": "List Opportunities",
       "description": "List opportunities, optionally filtered by lead",
       "requiresWrite": false,
@@ -11375,7 +11375,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_opportunity",
+      "id": "close__create_opportunity",
       "name": "Create Opportunity",
       "description": "Create an opportunity on a Close lead",
       "requiresWrite": true,
@@ -11403,7 +11403,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_contacts",
+      "id": "close__list_contacts",
       "name": "List Contacts",
       "description": "List contacts, optionally filtered by lead",
       "requiresWrite": false,
@@ -11499,7 +11499,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developers.cloudflare.com/fundamentals/api/get-started/create-token/",
     }],
     "tools": [{
-      "id": "verify_token",
+      "id": "cloudflare__verify_token",
       "name": "Verify Token",
       "description": "Check that the configured Cloudflare API token is valid and active",
       "requiresWrite": false,
@@ -11509,7 +11509,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "list_zones",
+      "id": "cloudflare__list_zones",
       "name": "List Zones",
       "description": "List zones (domains) the token can access",
       "requiresWrite": false,
@@ -11553,7 +11553,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_zone",
+      "id": "cloudflare__get_zone",
       "name": "Get Zone",
       "description": "Get details of a zone by ID",
       "requiresWrite": false,
@@ -11572,7 +11572,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "list_dns_records",
+      "id": "cloudflare__list_dns_records",
       "name": "List DNS Records",
       "description": "List DNS records in a zone",
       "requiresWrite": false,
@@ -11618,7 +11618,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_dns_record",
+      "id": "cloudflare__create_dns_record",
       "name": "Create DNS Record",
       "description": "Create a DNS record in a zone",
       "requiresWrite": true,
@@ -11662,7 +11662,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "update_dns_record",
+      "id": "cloudflare__update_dns_record",
       "name": "Update DNS Record",
       "description": "Update fields of an existing DNS record",
       "requiresWrite": true,
@@ -11691,7 +11691,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "list_accounts",
+      "id": "cloudflare__list_accounts",
       "name": "List Accounts",
       "description":
         "List Cloudflare accounts the token can access (account IDs are needed for account-scoped APIs)",
@@ -11776,7 +11776,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://coda.io/developers/apis/v1#section/Authentication",
     }],
     "tools": [{
-      "id": "list_docs",
+      "id": "coda__list_docs",
       "name": "List Docs",
       "description": "List Coda docs accessible to the token",
       "requiresWrite": false,
@@ -11824,7 +11824,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_doc",
+      "id": "coda__get_doc",
       "name": "Get Doc",
       "description": "Get metadata for a Coda doc",
       "requiresWrite": false,
@@ -11841,7 +11841,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_doc",
+      "id": "coda__create_doc",
       "name": "Create Doc",
       "description": "Create a new Coda doc, optionally copying an existing doc",
       "requiresWrite": true,
@@ -11861,7 +11861,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_pages",
+      "id": "coda__list_pages",
       "name": "List Pages",
       "description": "List pages in a Coda doc",
       "requiresWrite": false,
@@ -11906,7 +11906,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_page",
+      "id": "coda__get_page",
       "name": "Get Page",
       "description": "Get metadata for a page in a Coda doc",
       "requiresWrite": false,
@@ -11929,7 +11929,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_page",
+      "id": "coda__update_page",
       "name": "Update Page",
       "description": "Update a page's name, subtitle, or content in a Coda doc",
       "requiresWrite": true,
@@ -12028,7 +12028,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://dashboard.cohere.com/api-keys",
     }],
     "tools": [{
-      "id": "list_models",
+      "id": "cohere__list_models",
       "name": "List Models",
       "description": "List the Cohere models available to the API key",
       "requiresWrite": false,
@@ -12068,7 +12068,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_chat",
+      "id": "cohere__create_chat",
       "name": "Create Chat",
       "description": "Generate a chat response with a Cohere Command model (v2 Chat API)",
       "requiresWrite": true,
@@ -12094,7 +12094,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_embedding",
+      "id": "cohere__create_embedding",
       "name": "Create Embedding",
       "description": "Create embedding vectors for input texts (v2 Embed API)",
       "requiresWrite": true,
@@ -12126,7 +12126,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "rerank_documents",
+      "id": "cohere__rerank_documents",
       "name": "Rerank Documents",
       "description": "Rank a list of documents by relevance to a query (v2 Rerank API)",
       "requiresWrite": true,
@@ -12243,7 +12243,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.atlassian.com/console/myapps/",
     }],
     "tools": [{
-      "id": "list_sites",
+      "id": "confluence__list_sites",
       "name": "List Atlassian Sites",
       "description":
         "List Atlassian cloud sites/resources the OAuth token can access; use the returned id as cloudId for Jira and Confluence tools",
@@ -12265,7 +12265,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_content",
+      "id": "confluence__search_content",
       "name": "Search Confluence",
       "description": "Search for pages and blog posts in Confluence",
       "requiresWrite": false,
@@ -12328,7 +12328,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_page",
+      "id": "confluence__get_page",
       "name": "Get Page",
       "description": "Get the content of a specific Confluence page (uses v2 API)",
       "requiresWrite": false,
@@ -12357,7 +12357,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_page",
+      "id": "confluence__create_page",
       "name": "Create Page",
       "description":
         "Create a new page in a Confluence space (uses v2 API; requires spaceId from list_spaces)",
@@ -12390,7 +12390,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_page",
+      "id": "confluence__update_page",
       "name": "Update Page",
       "description":
         "Update the content of an existing Confluence page (uses v2 API; version.number must be current+1)",
@@ -12432,7 +12432,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_spaces",
+      "id": "confluence__list_spaces",
       "name": "List Spaces",
       "description": "List all accessible Confluence spaces",
       "requiresWrite": false,
@@ -12481,7 +12481,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "add_comment",
+      "id": "confluence__add_comment",
       "name": "Add Comment",
       "description": "Add a comment to a Confluence page (uses v1 content API)",
       "requiresWrite": true,
@@ -12569,7 +12569,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.customer.io/integrations/api/app/",
     }],
     "tools": [{
-      "id": "search_customers",
+      "id": "customer-io__search_customers",
       "name": "Search Customers",
       "description": "Search Customer.io people by attribute or segment filter conditions",
       "requiresWrite": false,
@@ -12600,7 +12600,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "identifiers" },
       },
     }, {
-      "id": "list_campaigns",
+      "id": "customer-io__list_campaigns",
       "name": "List Campaigns",
       "description": "List campaigns in the Customer.io workspace with their state and goals",
       "requiresWrite": false,
@@ -12610,7 +12610,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "campaigns" },
       },
     }, {
-      "id": "get_campaign_metrics",
+      "id": "customer-io__get_campaign_metrics",
       "name": "Get Campaign Metrics",
       "description":
         "Get delivery and conversion metrics for a Customer.io campaign over a time period",
@@ -12655,7 +12655,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_person_attributes",
+      "id": "customer-io__get_person_attributes",
       "name": "Get Person Attributes",
       "description":
         "Get a person's full attribute profile by ID, email, or cio_id (Search Customers returns only identifiers)",
@@ -12680,7 +12680,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "customer" },
       },
     }, {
-      "id": "list_transactional_messages",
+      "id": "customer-io__list_transactional_messages",
       "name": "List Transactional Messages",
       "description":
         "List the workspace's transactional message templates so agents can find a valid transactional_message_id before sending",
@@ -12691,7 +12691,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "messages" },
       },
     }, {
-      "id": "trigger_broadcast",
+      "id": "customer-io__trigger_broadcast",
       "name": "Trigger Broadcast",
       "description":
         "Trigger an API-triggered broadcast campaign, optionally overriding the recipients and passing liquid data into the messages",
@@ -12740,7 +12740,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_segments",
+      "id": "customer-io__list_segments",
       "name": "List Segments",
       "description":
         "List segments in the Customer.io workspace so agents can target or filter people",
@@ -12751,7 +12751,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "segments" },
       },
     }, {
-      "id": "send_transactional_email",
+      "id": "customer-io__send_transactional_email",
       "name": "Send Transactional Email",
       "description":
         "Send a transactional email to a recipient, using a transactional message template or inline subject and body",
@@ -12873,7 +12873,7 @@ export const connectors: IntegrationConfig[] = [
       "placeholder": "dbc-a1b2345c-d6e7.cloud.databricks.com",
     }],
     "tools": [{
-      "id": "list_clusters",
+      "id": "databricks__list_clusters",
       "name": "List Clusters",
       "description":
         "List all-purpose and job compute clusters in the workspace with their state and configuration",
@@ -12920,7 +12920,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_jobs",
+      "id": "databricks__list_jobs",
       "name": "List Jobs",
       "description": "List jobs defined in the workspace, optionally filtered by name",
       "requiresWrite": false,
@@ -12964,7 +12964,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "run_job_now",
+      "id": "databricks__run_job_now",
       "name": "Run Job Now",
       "description":
         "Trigger an immediate run of an existing job, optionally overriding job parameters",
@@ -12994,7 +12994,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_job_runs",
+      "id": "databricks__list_job_runs",
       "name": "List Job Runs",
       "description":
         "List recent job runs, optionally filtered to one job or to active/completed runs",
@@ -13049,7 +13049,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "cancel_job_run",
+      "id": "databricks__cancel_job_run",
       "name": "Cancel Job Run",
       "description":
         "Cancel a job run; the cancellation happens asynchronously, so the run may still be running briefly",
@@ -13075,7 +13075,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_job_run",
+      "id": "databricks__get_job_run",
       "name": "Get Job Run",
       "description":
         "Get the status, timing, and task results of a job run (use the run_id returned by Run Job Now)",
@@ -13099,7 +13099,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "execute_sql_statement",
+      "id": "databricks__execute_sql_statement",
       "name": "Execute SQL Statement",
       "description":
         "Execute a SQL query against a SQL warehouse and return the result rows (queries; the warehouse enforces table permissions)",
@@ -13149,7 +13149,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_sql_statement",
+      "id": "databricks__get_sql_statement",
       "name": "Get SQL Statement",
       "description":
         "Poll the status and result of a previously submitted SQL statement, e.g. after an async or timed-out execution",
@@ -13173,7 +13173,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_sql_warehouses",
+      "id": "databricks__list_sql_warehouses",
       "name": "List SQL Warehouses",
       "description":
         "List SQL warehouses in the workspace to find a warehouse_id for executing SQL statements",
@@ -13299,7 +13299,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.datadoghq.com/account_management/api-app-keys/",
     }],
     "tools": [{
-      "id": "validate_api_key",
+      "id": "datadog__validate_api_key",
       "name": "Validate API Key",
       "description": "Check that the configured Datadog API key is valid",
       "requiresWrite": false,
@@ -13317,7 +13317,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_monitors",
+      "id": "datadog__list_monitors",
       "name": "List Monitors",
       "description": "List monitors with optional name or tag filtering",
       "requiresWrite": false,
@@ -13366,7 +13366,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_monitor",
+      "id": "datadog__get_monitor",
       "name": "Get Monitor",
       "description": "Get details and current state of a monitor",
       "requiresWrite": false,
@@ -13389,7 +13389,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "mute_monitor",
+      "id": "datadog__mute_monitor",
       "name": "Mute Monitor",
       "description": "Mute notifications for a monitor",
       "requiresWrite": true,
@@ -13417,7 +13417,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_dashboards",
+      "id": "datadog__list_dashboards",
       "name": "List Dashboards",
       "description": "List all dashboards",
       "requiresWrite": false,
@@ -13445,7 +13445,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "query_timeseries",
+      "id": "datadog__query_timeseries",
       "name": "Query Timeseries Metrics",
       "description": "Query timeseries metric data over a time window",
       "requiresWrite": false,
@@ -13480,7 +13480,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_logs",
+      "id": "datadog__search_logs",
       "name": "Search Logs",
       "description": "Search log events with a Datadog log query",
       "requiresWrite": false,
@@ -13586,7 +13586,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.datev.de/en/",
     }],
     "tools": [{
-      "id": "list_clients",
+      "id": "datev__list_clients",
       "name": "List Clients",
       "description":
         "List the DATEV clients (Mandanten) the connected user may upload documents for, including each client's ID needed by the other tools",
@@ -13596,7 +13596,7 @@ export const connectors: IntegrationConfig[] = [
         "url": "https://accounting-documents.api.datev.de/platform/v2/clients",
       },
     }, {
-      "id": "list_document_types",
+      "id": "datev__list_document_types",
       "name": "List Document Types",
       "description":
         "List the document types (e.g. incoming invoices, outgoing invoices, cash receipts) available in Belege online for a specific DATEV client, used to classify uploads",
@@ -13615,7 +13615,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "upload_document",
+      "id": "datev__upload_document",
       "name": "Upload Document",
       "description":
         "Upload a receipt or invoice file to DATEV Unternehmen online (Belege online) for a client so the tax advisor can process it for bookkeeping",
@@ -13729,7 +13729,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://www.daytona.io/docs/en/api-keys/",
     }],
     "tools": [{
-      "id": "list_sandboxes",
+      "id": "daytona__list_sandboxes",
       "name": "List Sandboxes",
       "description":
         "List sandboxes in the organization with optional name, label, and state filtering",
@@ -13786,7 +13786,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_sandbox",
+      "id": "daytona__create_sandbox",
       "name": "Create Sandbox",
       "description":
         "Create a new sandbox, optionally from a snapshot and with custom resources (starts billable compute)",
@@ -13827,7 +13827,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_sandbox",
+      "id": "daytona__get_sandbox",
       "name": "Get Sandbox",
       "description":
         "Get sandbox details by ID or name, including state, snapshot, resources, and timestamps",
@@ -13846,7 +13846,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_sandbox",
+      "id": "daytona__delete_sandbox",
       "name": "Delete Sandbox",
       "description": "Delete a sandbox by ID or name, discarding its state and filesystem",
       "requiresWrite": true,
@@ -13863,7 +13863,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "execute_command",
+      "id": "daytona__execute_command",
       "name": "Execute Command",
       "description":
         "Execute a shell command inside a running sandbox via the toolbox and return its exit code and output (legacy REST route; Daytona's current toolbox API is SDK-first)",
@@ -13890,7 +13890,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "start_sandbox",
+      "id": "daytona__start_sandbox",
       "name": "Start Sandbox",
       "description":
         "Start a stopped sandbox — required before Execute Command, since sandboxes auto-stop after the autoStopInterval (15 minutes by default)",
@@ -13908,7 +13908,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "stop_sandbox",
+      "id": "daytona__stop_sandbox",
       "name": "Stop Sandbox",
       "description":
         "Stop a running sandbox to pause billable compute without destroying its state",
@@ -13926,7 +13926,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_snapshots",
+      "id": "daytona__list_snapshots",
       "name": "List Snapshots",
       "description":
         "List available snapshots (sandbox base images) — use these names or IDs in the snapshot field of Create Sandbox",
@@ -14027,7 +14027,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.deel.com/docs/api-tokens-1",
     }],
     "tools": [{
-      "id": "list_contracts",
+      "id": "deel__list_contracts",
       "name": "List Contracts",
       "description": "List contracts in the Deel account, optionally filtered by contract type",
       "requiresWrite": false,
@@ -14055,7 +14055,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_contract",
+      "id": "deel__get_contract",
       "name": "Get Contract",
       "description": "Retrieve full details of a single contract by ID",
       "requiresWrite": false,
@@ -14072,7 +14072,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_people",
+      "id": "deel__list_people",
       "name": "List People",
       "description": "List people (workers) in the organization with their employment details",
       "requiresWrite": false,
@@ -14101,7 +14101,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_person",
+      "id": "deel__get_person",
       "name": "Get Person",
       "description":
         "Retrieve a single person (worker) with their employments, manager, and direct reports",
@@ -14119,7 +14119,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_invoices",
+      "id": "deel__list_invoices",
       "name": "List Invoices",
       "description":
         "List worker invoices; only paid invoices are returned unless status=all is passed",
@@ -14159,7 +14159,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_timesheets",
+      "id": "deel__list_timesheets",
       "name": "List Timesheets",
       "description": "List timesheet entries, optionally filtered to a single contract",
       "requiresWrite": false,
@@ -14187,7 +14187,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_timesheet",
+      "id": "deel__create_timesheet",
       "name": "Create Timesheet Entry",
       "description": "Submit a timesheet entry (work performed) for a contractor contract",
       "requiresWrite": true,
@@ -14204,7 +14204,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "review_timesheet",
+      "id": "deel__review_timesheet",
       "name": "Review Timesheet",
       "description":
         "Approve or decline a submitted timesheet entry; approved hours flow onto the contractor's invoice",
@@ -14305,7 +14305,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developers.deepgram.com/docs/create-additional-api-keys",
     }],
     "tools": [{
-      "id": "transcribe_url",
+      "id": "deepgram__transcribe_url",
       "name": "Transcribe URL",
       "description": "Transcribe a prerecorded audio file from a publicly accessible URL",
       "requiresWrite": true,
@@ -14350,7 +14350,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_projects",
+      "id": "deepgram__list_projects",
       "name": "List Projects",
       "description": "List the Deepgram projects associated with the API key",
       "requiresWrite": false,
@@ -14367,7 +14367,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_project_balances",
+      "id": "deepgram__get_project_balances",
       "name": "Get Project Balances",
       "description": "Get the outstanding credit balances for a project",
       "requiresWrite": false,
@@ -14384,7 +14384,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_models",
+      "id": "deepgram__list_models",
       "name": "List Models",
       "description": "List the speech-to-text and text-to-speech models Deepgram offers",
       "requiresWrite": false,
@@ -14476,7 +14476,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developers.dialpad.com/docs/oauth",
     }],
     "tools": [{
-      "id": "list_contacts",
+      "id": "dialpad__list_contacts",
       "name": "List Contacts",
       "description": "List Dialpad contacts visible to the authenticated user",
       "requiresWrite": false,
@@ -14520,7 +14520,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_contact",
+      "id": "dialpad__get_contact",
       "name": "Get Contact",
       "description": "Get details of a Dialpad contact",
       "requiresWrite": false,
@@ -14537,7 +14537,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_contact",
+      "id": "dialpad__create_contact",
       "name": "Create Contact",
       "description": "Create a new contact in Dialpad",
       "requiresWrite": true,
@@ -14554,7 +14554,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_contact",
+      "id": "dialpad__update_contact",
       "name": "Update Contact",
       "description": "Update an existing Dialpad contact",
       "requiresWrite": true,
@@ -14579,7 +14579,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_users",
+      "id": "dialpad__list_users",
       "name": "List Users",
       "description": "List Dialpad users in the company",
       "requiresWrite": false,
@@ -14605,7 +14605,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "send_sms",
+      "id": "dialpad__send_sms",
       "name": "Send SMS",
       "description": "Send an SMS message on behalf of a Dialpad user",
       "requiresWrite": true,
@@ -14706,7 +14706,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.digitalocean.com/reference/api/oauth/",
     }],
     "tools": [{
-      "id": "list_droplets",
+      "id": "digitalocean__list_droplets",
       "name": "List Droplets",
       "description": "List Droplets in the account",
       "requiresWrite": false,
@@ -14749,7 +14749,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_droplet",
+      "id": "digitalocean__get_droplet",
       "name": "Get Droplet",
       "description": "Get a Droplet by ID",
       "requiresWrite": false,
@@ -14767,7 +14767,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "droplet" },
       },
     }, {
-      "id": "create_droplet",
+      "id": "digitalocean__create_droplet",
       "name": "Create Droplet",
       "description": "Create a new Droplet (provisions billable infrastructure)",
       "requiresWrite": true,
@@ -14802,7 +14802,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "droplet" },
       },
     }, {
-      "id": "delete_droplet",
+      "id": "digitalocean__delete_droplet",
       "name": "Delete Droplet",
       "description": "Permanently destroy a Droplet by ID",
       "requiresWrite": true,
@@ -14819,7 +14819,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_databases",
+      "id": "digitalocean__list_databases",
       "name": "List Database Clusters",
       "description": "List managed database clusters in the account",
       "requiresWrite": false,
@@ -14846,7 +14846,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_account",
+      "id": "digitalocean__get_account",
       "name": "Get Account",
       "description": "Get account information and limits for the authenticated user",
       "requiresWrite": false,
@@ -14927,14 +14927,14 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://discord.com/developers/applications",
     }],
     "tools": [{
-      "id": "get_bot_user",
+      "id": "discord__get_bot_user",
       "name": "Get Bot User",
       "description":
         "Get the bot's own user account to confirm the token works and learn the bot's ID and username",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://discord.com/api/v10/users/@me" },
     }, {
-      "id": "list_guilds",
+      "id": "discord__list_guilds",
       "name": "List Guilds",
       "description":
         "List the servers (guilds) the bot has been added to, so an agent can find a guild ID",
@@ -14968,7 +14968,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_guild_channels",
+      "id": "discord__list_guild_channels",
       "name": "List Guild Channels",
       "description":
         "List the channels in a server so an agent can find the right channel ID before reading or posting",
@@ -14986,7 +14986,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_channel_messages",
+      "id": "discord__get_channel_messages",
       "name": "Get Channel Messages",
       "description":
         "Read recent messages from a channel for summaries, support triage, or context before replying",
@@ -15025,7 +15025,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "send_message",
+      "id": "discord__send_message",
       "name": "Send Message",
       "description": "Post a message to a channel, optionally as a reply to an existing message",
       "requiresWrite": true,
@@ -15059,7 +15059,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_dm",
+      "id": "discord__create_dm",
       "name": "Create DM Channel",
       "description":
         "Open (or return the existing) direct-message channel with a user; use the returned channel ID with Send Message to DM the user",
@@ -15077,7 +15077,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "edit_message",
+      "id": "discord__edit_message",
       "name": "Edit Message",
       "description":
         "Edit the text of a message the bot previously sent, e.g. to update a status post or correct an announcement",
@@ -15108,7 +15108,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_guild_members",
+      "id": "discord__search_guild_members",
       "name": "Search Guild Members",
       "description":
         "Find members of a server whose username or nickname starts with a string, e.g. to resolve a name to a user ID for mentions or DMs",
@@ -15138,7 +15138,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "add_reaction",
+      "id": "discord__add_reaction",
       "name": "Add Reaction",
       "description": "React to a message with an emoji, e.g. to acknowledge or label it",
       "requiresWrite": true,
@@ -15168,7 +15168,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_thread",
+      "id": "discord__create_thread",
       "name": "Create Thread",
       "description": "Start a thread from an existing message to keep a discussion organized",
       "requiresWrite": true,
@@ -15295,7 +15295,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://console.cloud.google.com/apis/credentials",
     }],
     "tools": [{
-      "id": "list_documents",
+      "id": "docs-google__list_documents",
       "name": "List Documents",
       "description": "List recent Google Docs documents from Drive",
       "requiresWrite": false,
@@ -15326,7 +15326,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "files" },
       },
     }, {
-      "id": "get_document",
+      "id": "docs-google__get_document",
       "name": "Get Document",
       "description": "Get document content and metadata",
       "requiresWrite": false,
@@ -15348,7 +15348,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_document",
+      "id": "docs-google__create_document",
       "name": "Create Document",
       "description": "Create a new document with optional initial content",
       "requiresWrite": true,
@@ -15360,7 +15360,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_document",
+      "id": "docs-google__update_document",
       "name": "Update Document",
       "description": "Update document content using batch requests",
       "requiresWrite": true,
@@ -15386,7 +15386,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_documents",
+      "id": "docs-google__search_documents",
       "name": "Search Documents",
       "description": "Search for documents by query string",
       "requiresWrite": false,
@@ -15483,14 +15483,14 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developers.docusign.com/platform/auth/authcode/",
     }],
     "tools": [{
-      "id": "get_user_info",
+      "id": "docusign__get_user_info",
       "name": "Get User Info",
       "description":
         "Get the connected user's accounts from the OAuth userinfo endpoint - the source of the accountServer (base_uri host) and accountId values every other tool needs",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://account.docusign.com/oauth/userinfo" },
     }, {
-      "id": "list_envelopes",
+      "id": "docusign__list_envelopes",
       "name": "List Envelopes",
       "description":
         "List envelope status changes in an account to track what is sent, delivered, or completed",
@@ -15545,7 +15545,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "envelopes" },
       },
     }, {
-      "id": "get_envelope",
+      "id": "docusign__get_envelope",
       "name": "Get Envelope",
       "description": "Get the status and details of a single envelope by ID",
       "requiresWrite": false,
@@ -15581,7 +15581,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_envelope_recipients",
+      "id": "docusign__list_envelope_recipients",
       "name": "List Envelope Recipients",
       "description": "List the recipients of an envelope and their signing status",
       "requiresWrite": false,
@@ -15618,7 +15618,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_envelope",
+      "id": "docusign__create_envelope",
       "name": "Create and Send Envelope",
       "description": "Create an envelope with documents and recipients and send it for signature",
       "requiresWrite": true,
@@ -15670,7 +15670,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "resend_envelope",
+      "id": "docusign__resend_envelope",
       "name": "Resend Envelope",
       "description":
         "Resend the signing request email to an in-progress envelope's pending recipients, e.g. to chase outstanding signers",
@@ -15710,7 +15710,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_templates",
+      "id": "docusign__list_templates",
       "name": "List Templates",
       "description":
         "List the reusable envelope templates in an account, e.g. to find a template before sending from it",
@@ -15757,7 +15757,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "envelopeTemplates" },
       },
     }, {
-      "id": "download_envelope_documents",
+      "id": "docusign__download_envelope_documents",
       "name": "Download Envelope Documents",
       "description": "Download all documents of an envelope as a single combined PDF",
       "requiresWrite": false,
@@ -15883,7 +15883,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://console.cloud.google.com/apis/credentials",
     }],
     "tools": [{
-      "id": "list_files",
+      "id": "drive__list_files",
       "name": "List Files",
       "description": "List files and folders in a Google Drive folder or root",
       "requiresWrite": false,
@@ -15914,7 +15914,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "files" },
       },
     }, {
-      "id": "get_file",
+      "id": "drive__get_file",
       "name": "Get File",
       "description": "Get metadata and details about a specific file or folder",
       "requiresWrite": false,
@@ -15937,7 +15937,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_files",
+      "id": "drive__search_files",
       "name": "Search Files",
       "description": "Search for files and folders using queries",
       "requiresWrite": false,
@@ -15969,7 +15969,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "files" },
       },
     }, {
-      "id": "create_folder",
+      "id": "drive__create_folder",
       "name": "Create Folder",
       "description": "Create a new folder in Google Drive",
       "requiresWrite": true,
@@ -15987,7 +15987,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "upload_file",
+      "id": "drive__upload_file",
       "name": "Upload File",
       "description": "Upload or create a file in Google Drive",
       "requiresWrite": true,
@@ -16028,7 +16028,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_file",
+      "id": "drive__update_file",
       "name": "Update File",
       "description":
         "Rename a file, update its description, or move it to a different folder in Google Drive",
@@ -16068,7 +16068,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_file",
+      "id": "drive__delete_file",
       "name": "Delete File",
       "description": "Permanently delete a file or folder from Google Drive",
       "requiresWrite": true,
@@ -16085,7 +16085,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "download_file",
+      "id": "drive__download_file",
       "name": "Download File",
       "description":
         "Download the content of a binary or text file stored in Google Drive (not Google Docs/Sheets/Slides; use export_file for those)",
@@ -16109,7 +16109,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "export_file",
+      "id": "drive__export_file",
       "name": "Export File",
       "description":
         "Export a Google Docs/Sheets/Slides file to another format such as text/plain, text/csv, or application/pdf",
@@ -16217,7 +16217,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://e2b.dev/dashboard?tab=keys",
     }],
     "tools": [{
-      "id": "list_sandboxes",
+      "id": "e2b__list_sandboxes",
       "name": "List Sandboxes",
       "description": "List all running sandboxes, optionally filtered by metadata key/value pairs",
       "requiresWrite": false,
@@ -16233,7 +16233,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_sandbox",
+      "id": "e2b__create_sandbox",
       "name": "Create Sandbox",
       "description": "Create a new sandbox from a template (starts a billable running sandbox)",
       "requiresWrite": true,
@@ -16271,7 +16271,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_sandbox",
+      "id": "e2b__get_sandbox",
       "name": "Get Sandbox",
       "description":
         "Get a sandbox by ID, including template, state, resources, and start/end times",
@@ -16289,7 +16289,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "kill_sandbox",
+      "id": "e2b__kill_sandbox",
       "name": "Kill Sandbox",
       "description": "Kill a sandbox by ID, immediately terminating it and discarding its state",
       "requiresWrite": true,
@@ -16306,7 +16306,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_templates",
+      "id": "e2b__list_templates",
       "name": "List Templates",
       "description":
         "List all sandbox templates available to the account, with CPU, memory, and disk defaults",
@@ -16323,7 +16323,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "pause_sandbox",
+      "id": "e2b__pause_sandbox",
       "name": "Pause Sandbox",
       "description":
         "Pause a running sandbox, preserving its state so it can be resumed later — the middle ground between running and killed (returns 204 on success)",
@@ -16341,7 +16341,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "resume_sandbox",
+      "id": "e2b__resume_sandbox",
       "name": "Resume Sandbox",
       "description": "Resume a paused sandbox with its preserved state and a fresh timeout",
       "requiresWrite": true,
@@ -16365,7 +16365,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "set_sandbox_timeout",
+      "id": "e2b__set_sandbox_timeout",
       "name": "Set Sandbox Timeout",
       "description":
         "Reset a running sandbox's TTL: the sandbox will expire the given number of seconds from now (each call overwrites the previous timeout) — use this to keep a sandbox alive mid-task (returns 204 on success)",
@@ -16466,7 +16466,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://elevenlabs.io/app/settings/api-keys",
     }],
     "tools": [{
-      "id": "list_voices",
+      "id": "elevenlabs__list_voices",
       "name": "List Voices",
       "description": "List and search the voices available to the account",
       "requiresWrite": false,
@@ -16507,7 +16507,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_voice",
+      "id": "elevenlabs__get_voice",
       "name": "Get Voice",
       "description": "Get details about a specific voice",
       "requiresWrite": false,
@@ -16524,19 +16524,19 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_models",
+      "id": "elevenlabs__list_models",
       "name": "List Models",
       "description": "List the speech models available to the account",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.elevenlabs.io/v1/models" },
     }, {
-      "id": "get_subscription",
+      "id": "elevenlabs__get_subscription",
       "name": "Get Subscription",
       "description": "Get subscription tier, character usage, and limits for the account",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.elevenlabs.io/v1/user/subscription" },
     }, {
-      "id": "text_to_speech",
+      "id": "elevenlabs__text_to_speech",
       "name": "Text to Speech",
       "description":
         "Convert text to speech with a chosen voice; the response is binary audio (not JSON), so route the output to a file or player rather than parsing it",
@@ -16641,7 +16641,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.exa.ai/reference/getting-started",
     }],
     "tools": [{
-      "id": "search",
+      "id": "exa__search",
       "name": "Search",
       "description": "Search the web with Exa's neural and keyword search",
       "requiresWrite": false,
@@ -16681,7 +16681,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_contents",
+      "id": "exa__get_contents",
       "name": "Get Contents",
       "description": "Get parsed page contents, summaries, and metadata for a list of URLs",
       "requiresWrite": false,
@@ -16706,7 +16706,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "find_similar",
+      "id": "exa__find_similar",
       "name": "Find Similar Links",
       "description": "Find pages similar in meaning to a given URL",
       "requiresWrite": false,
@@ -16731,7 +16731,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "answer",
+      "id": "exa__answer",
       "name": "Answer",
       "description":
         "Get an LLM-generated answer to a question grounded in Exa search results with citations",
@@ -16817,7 +16817,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://apidoc.factorialhr.com/docs/api-keys",
     }],
     "tools": [{
-      "id": "list_employees",
+      "id": "factorial__list_employees",
       "name": "List Employees",
       "description":
         "List employees in the Factorial account, with filters for name, activity status, and team",
@@ -16860,7 +16860,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_employee",
+      "id": "factorial__get_employee",
       "name": "Get Employee",
       "description": "Get a single Factorial employee record by ID",
       "requiresWrite": false,
@@ -16877,7 +16877,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_leaves",
+      "id": "factorial__list_leaves",
       "name": "List Leaves",
       "description":
         "List time-off leaves (absences) with filters for employee, date range, and approval status",
@@ -16932,7 +16932,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_leave",
+      "id": "factorial__create_leave",
       "name": "Create Leave",
       "description":
         "Create a time-off leave (absence) for an employee, such as vacation or sick leave",
@@ -16968,7 +16968,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_teams",
+      "id": "factorial__list_teams",
       "name": "List Teams",
       "description":
         "List all teams in the Factorial account, useful before filtering employees by team",
@@ -16986,7 +16986,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_leave_types",
+      "id": "factorial__list_leave_types",
       "name": "List Leave Types",
       "description":
         "List the leave types configured in the account (vacation, sick leave, ...) with their IDs — required to pick a valid leave_type_id for Create Leave",
@@ -17014,7 +17014,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_leave",
+      "id": "factorial__delete_leave",
       "name": "Delete Leave",
       "description": "Delete (cancel) a leave request by its ID",
       "requiresWrite": true,
@@ -17094,7 +17094,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://fal.ai/dashboard/keys",
     }],
     "tools": [{
-      "id": "run_model",
+      "id": "fal__run_model",
       "name": "Run Model",
       "description":
         "Run a fal model synchronously and wait for the result (best for fast models; billed per run). The model endpoint ID is split into owner / app / variant segments, e.g. fal-ai/flux/schnell",
@@ -17135,7 +17135,7 @@ export const connectors: IntegrationConfig[] = [
         "bodyMode": "passthrough",
       },
     }, {
-      "id": "queue_submit",
+      "id": "fal__queue_submit",
       "name": "Submit Queue Request",
       "description":
         "Submit a request to the fal queue and return immediately with a request_id (billed per run)",
@@ -17176,7 +17176,7 @@ export const connectors: IntegrationConfig[] = [
         "bodyMode": "passthrough",
       },
     }, {
-      "id": "queue_status",
+      "id": "fal__queue_status",
       "name": "Get Queue Status",
       "description":
         "Check the status of a queued request (IN_QUEUE, IN_PROGRESS, or COMPLETED). Use the base app ID without the variant segment, matching the status_url returned at submit time",
@@ -17213,7 +17213,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "queue_result",
+      "id": "fal__queue_result",
       "name": "Get Queue Result",
       "description":
         "Fetch the result of a completed queue request. Use the base app ID without the variant segment, matching the response_url returned at submit time",
@@ -17244,7 +17244,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "queue_cancel",
+      "id": "fal__queue_cancel",
       "name": "Cancel Queue Request",
       "description": "Cancel a queued request that has not started running yet",
       "requiresWrite": true,
@@ -17345,7 +17345,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developers.fathom.ai",
     }],
     "tools": [{
-      "id": "list_meetings",
+      "id": "fathom__list_meetings",
       "name": "List Meetings",
       "description": "List recorded meetings, optionally including summaries and action items",
       "requiresWrite": false,
@@ -17406,7 +17406,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_transcript",
+      "id": "fathom__get_transcript",
       "name": "Get Transcript",
       "description": "Get the transcript of a recording",
       "requiresWrite": false,
@@ -17423,7 +17423,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_summary",
+      "id": "fathom__get_summary",
       "name": "Get Summary",
       "description": "Get the AI summary of a recording",
       "requiresWrite": false,
@@ -17440,7 +17440,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_teams",
+      "id": "fathom__list_teams",
       "name": "List Teams",
       "description": "List teams in the Fathom workspace",
       "requiresWrite": false,
@@ -17456,7 +17456,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_team_members",
+      "id": "fathom__list_team_members",
       "name": "List Team Members",
       "description": "List team members in the Fathom workspace",
       "requiresWrite": false,
@@ -17552,14 +17552,14 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://www.figma.com/developers/apps",
     }],
     "tools": [{
-      "id": "get_me",
+      "id": "figma__get_me",
       "name": "Get Me",
       "description":
         "Get the authenticated user's Figma profile (id, email, handle). Use this to verify the connection and identify the user.",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.figma.com/v1/me" },
     }, {
-      "id": "get_file",
+      "id": "figma__get_file",
       "name": "Get File",
       "description":
         "Get detailed information about a Figma file, including pages, frames, components, and styles. Requires a Figma file key from a file or design URL.",
@@ -17597,7 +17597,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_comments",
+      "id": "figma__get_comments",
       "name": "Get Comments",
       "description": "Get all comments on a Figma file",
       "requiresWrite": false,
@@ -17615,7 +17615,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "comments" },
       },
     }, {
-      "id": "post_comment",
+      "id": "figma__post_comment",
       "name": "Post Comment",
       "description": "Post a comment on a Figma file",
       "requiresWrite": true,
@@ -17702,7 +17702,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.finapi.io/",
     }],
     "tools": [{
-      "id": "search_banks",
+      "id": "finapi__search_banks",
       "name": "Search Banks",
       "description":
         "Search finAPI's database of supported banks by name, BLZ, BIC, or city, with interface and location filters",
@@ -17775,7 +17775,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_bank",
+      "id": "finapi__get_bank",
       "name": "Get Bank",
       "description":
         "Retrieve a single bank from finAPI's catalog by its identifier, including supported interfaces and login requirements",
@@ -17793,14 +17793,14 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_client_configuration",
+      "id": "finapi__get_client_configuration",
       "name": "Get Client Configuration",
       "description":
         "Get your finAPI client's configuration: token validity periods, callback URLs, enabled bank sets, and consent settings",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://live.finapi.io/api/v2/clientConfiguration" },
     }, {
-      "id": "create_user",
+      "id": "finapi__create_user",
       "name": "Create User",
       "description":
         "Provision a new finAPI end user (one per application end user); user-level operations then authenticate with that user's own token",
@@ -17895,7 +17895,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.firecrawl.dev/introduction",
     }],
     "tools": [{
-      "id": "scrape",
+      "id": "firecrawl__scrape",
       "name": "Scrape Page",
       "description": "Scrape a single URL into markdown or other formats",
       "requiresWrite": false,
@@ -17918,7 +17918,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "search",
+      "id": "firecrawl__search",
       "name": "Search Web",
       "description": "Search the web and optionally scrape the results' content",
       "requiresWrite": false,
@@ -17952,7 +17952,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "map_site",
+      "id": "firecrawl__map_site",
       "name": "Map Site",
       "description": "Quickly list the URLs discovered on a website",
       "requiresWrite": false,
@@ -17970,7 +17970,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "start_crawl",
+      "id": "firecrawl__start_crawl",
       "name": "Start Crawl",
       "description": "Start an asynchronous crawl job over a website (returns a job ID)",
       "requiresWrite": true,
@@ -17991,7 +17991,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_crawl_status",
+      "id": "firecrawl__get_crawl_status",
       "name": "Get Crawl Status",
       "description": "Get the status and results of a crawl job",
       "requiresWrite": false,
@@ -18075,7 +18075,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.fireflies.ai/getting-started/quickstart",
     }],
     "tools": [{
-      "id": "list_transcripts",
+      "id": "fireflies__list_transcripts",
       "name": "List Transcripts",
       "description":
         "List meeting transcripts, optionally filtered by date, participants, or keyword",
@@ -18144,7 +18144,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_transcript",
+      "id": "fireflies__get_transcript",
       "name": "Get Transcript",
       "description": "Get a transcript with its sentences and AI summary",
       "requiresWrite": false,
@@ -18165,7 +18165,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "transcript" },
       },
     }, {
-      "id": "search_transcripts",
+      "id": "fireflies__search_transcripts",
       "name": "Search Transcripts",
       "description": "Keyword-search transcripts and return matches with summaries",
       "requiresWrite": false,
@@ -18192,7 +18192,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "transcripts" },
       },
     }, {
-      "id": "list_users",
+      "id": "fireflies__list_users",
       "name": "List Users",
       "description": "List teammates in the Fireflies workspace",
       "requiresWrite": false,
@@ -18204,7 +18204,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "users" },
       },
     }, {
-      "id": "get_user",
+      "id": "fireflies__get_user",
       "name": "Get User",
       "description": "Get a workspace user by ID",
       "requiresWrite": false,
@@ -18294,7 +18294,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.fireworks.ai/api-reference/introduction",
     }],
     "tools": [{
-      "id": "list_models",
+      "id": "fireworks-ai__list_models",
       "name": "List Models",
       "description": "List the models available on Fireworks AI",
       "requiresWrite": false,
@@ -18312,7 +18312,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_chat_completion",
+      "id": "fireworks-ai__create_chat_completion",
       "name": "Create Chat Completion",
       "description": "Generate a chat completion from a list of messages",
       "requiresWrite": true,
@@ -18336,7 +18336,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_completion",
+      "id": "fireworks-ai__create_completion",
       "name": "Create Completion",
       "description": "Generate a text completion from a raw prompt",
       "requiresWrite": true,
@@ -18360,7 +18360,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_embedding",
+      "id": "fireworks-ai__create_embedding",
       "name": "Create Embedding",
       "description": "Create an embedding vector for input text",
       "requiresWrite": true,
@@ -18453,7 +18453,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://fly.io/docs/security/tokens/",
     }],
     "tools": [{
-      "id": "list_apps",
+      "id": "fly-io__list_apps",
       "name": "List Apps",
       "description": "List apps in a Fly.io organization",
       "requiresWrite": false,
@@ -18482,7 +18482,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_app",
+      "id": "fly-io__get_app",
       "name": "Get App",
       "description": "Get details about an app, including its organization and status",
       "requiresWrite": false,
@@ -18499,7 +18499,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_machines",
+      "id": "fly-io__list_machines",
       "name": "List Machines",
       "description": "List Machines of an app with their states",
       "requiresWrite": false,
@@ -18542,7 +18542,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_machine",
+      "id": "fly-io__get_machine",
       "name": "Get Machine",
       "description": "Get a Machine by ID, including its config and state",
       "requiresWrite": false,
@@ -18565,7 +18565,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "start_machine",
+      "id": "fly-io__start_machine",
       "name": "Start Machine",
       "description": "Start a stopped Machine",
       "requiresWrite": true,
@@ -18588,7 +18588,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "stop_machine",
+      "id": "fly-io__stop_machine",
       "name": "Stop Machine",
       "description": "Stop a running Machine",
       "requiresWrite": true,
@@ -18689,7 +18689,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.folk.app/api-reference/authentication",
     }],
     "tools": [{
-      "id": "list_people",
+      "id": "folk__list_people",
       "name": "List People",
       "description": "List people in the folk workspace with optional filters",
       "requiresWrite": false,
@@ -18728,7 +18728,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_person",
+      "id": "folk__get_person",
       "name": "Get Person",
       "description": "Get details of a person in folk",
       "requiresWrite": false,
@@ -18746,7 +18746,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "create_person",
+      "id": "folk__create_person",
       "name": "Create Person",
       "description": "Create a new person in folk",
       "requiresWrite": true,
@@ -18767,7 +18767,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "update_person",
+      "id": "folk__update_person",
       "name": "Update Person",
       "description": "Update fields on an existing person in folk",
       "requiresWrite": true,
@@ -18792,7 +18792,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_companies",
+      "id": "folk__list_companies",
       "name": "List Companies",
       "description": "List companies in the folk workspace",
       "requiresWrite": false,
@@ -18815,7 +18815,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "create_company",
+      "id": "folk__create_company",
       "name": "Create Company",
       "description": "Create a new company in folk",
       "requiresWrite": true,
@@ -18834,7 +18834,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_groups",
+      "id": "folk__list_groups",
       "name": "List Groups",
       "description": "List groups (pipelines/segments) in the folk workspace",
       "requiresWrite": false,
@@ -18932,7 +18932,7 @@ export const connectors: IntegrationConfig[] = [
       "default": "X",
     }],
     "tools": [{
-      "id": "list_tickets",
+      "id": "freshdesk__list_tickets",
       "name": "List Tickets",
       "description": "List support tickets in the Freshdesk account",
       "requiresWrite": false,
@@ -18997,7 +18997,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_ticket",
+      "id": "freshdesk__get_ticket",
       "name": "Get Ticket",
       "description": "Get details of a Freshdesk ticket",
       "requiresWrite": false,
@@ -19025,7 +19025,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_ticket",
+      "id": "freshdesk__create_ticket",
       "name": "Create Ticket",
       "description": "Create a new support ticket in Freshdesk",
       "requiresWrite": true,
@@ -19068,7 +19068,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_ticket",
+      "id": "freshdesk__update_ticket",
       "name": "Update Ticket",
       "description": "Update fields on an existing Freshdesk ticket",
       "requiresWrite": true,
@@ -19102,7 +19102,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_contacts",
+      "id": "freshdesk__list_contacts",
       "name": "List Contacts",
       "description": "List contacts in the Freshdesk account",
       "requiresWrite": false,
@@ -19206,7 +19206,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://dev.frontapp.com/docs/create-and-revoke-api-tokens",
     }],
     "tools": [{
-      "id": "list_conversations",
+      "id": "front__list_conversations",
       "name": "List Conversations",
       "description": "List conversations across your Front inboxes, most recently updated first",
       "requiresWrite": false,
@@ -19257,7 +19257,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_conversation",
+      "id": "front__get_conversation",
       "name": "Get Conversation",
       "description":
         "Retrieve a single conversation with its subject, status, assignee, recipient, and tags",
@@ -19275,7 +19275,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_conversation_messages",
+      "id": "front__list_conversation_messages",
       "name": "List Conversation Messages",
       "description": "List the messages in a conversation thread, including bodies and authors",
       "requiresWrite": false,
@@ -19321,7 +19321,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "reply_to_conversation",
+      "id": "front__reply_to_conversation",
       "name": "Reply to Conversation",
       "description":
         "Send a reply message in an existing conversation (archives the conversation by default)",
@@ -19374,7 +19374,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_conversation",
+      "id": "front__update_conversation",
       "name": "Update Conversation",
       "description":
         "Update a conversation's assignee, status, inbox, or tags, e.g. to assign, archive, or reopen it without sending a message",
@@ -19411,7 +19411,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_conversations",
+      "id": "front__search_conversations",
       "name": "Search Conversations",
       "description":
         "Full-text search across conversations with operators like from:, tag:, inbox:, is:open, before:/after:",
@@ -19457,7 +19457,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_teammates",
+      "id": "front__list_teammates",
       "name": "List Teammates",
       "description":
         "List the teammates in the company to find teammate IDs for assignment and reply authorship",
@@ -19478,7 +19478,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_inboxes",
+      "id": "front__list_inboxes",
       "name": "List Inboxes",
       "description": "List the shared inboxes in the company to find inbox IDs and names",
       "requiresWrite": false,
@@ -19608,7 +19608,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://console.cloud.google.com/apis/credentials",
     }],
     "tools": [{
-      "id": "list_compute_instances",
+      "id": "gcp__list_compute_instances",
       "name": "List Compute Instances",
       "description": "List Compute Engine VM instances in a specific zone of a project",
       "requiresWrite": false,
@@ -19649,7 +19649,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "items" },
       },
     }, {
-      "id": "list_all_compute_instances",
+      "id": "gcp__list_all_compute_instances",
       "name": "List All Compute Instances",
       "description":
         "List Compute Engine VM instances across all zones of a project (aggregated list), useful when you don't know which zones are in use",
@@ -19692,7 +19692,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "items" },
       },
     }, {
-      "id": "get_compute_instance",
+      "id": "gcp__get_compute_instance",
       "name": "Get Compute Instance",
       "description":
         "Get one Compute Engine VM instance's details - machine type, status, IPs, and disks - e.g. to confirm a start or stop completed",
@@ -19723,7 +19723,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_zones",
+      "id": "gcp__list_zones",
       "name": "List Zones",
       "description":
         "List the Compute Engine zones available in a project, so agents can discover valid zone names for the zone-scoped tools",
@@ -19758,7 +19758,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "items" },
       },
     }, {
-      "id": "start_compute_instance",
+      "id": "gcp__start_compute_instance",
       "name": "Start Compute Instance",
       "description":
         "Start a stopped Compute Engine VM instance (returns a zone operation that completes asynchronously) — requires the full cloud-platform scope",
@@ -19789,7 +19789,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "stop_compute_instance",
+      "id": "gcp__stop_compute_instance",
       "name": "Stop Compute Instance",
       "description":
         "Stop a running Compute Engine VM instance so it stops incurring compute charges (returns a zone operation that completes asynchronously) — requires the full cloud-platform scope",
@@ -19820,7 +19820,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_cloud_run_services",
+      "id": "gcp__list_cloud_run_services",
       "name": "List Cloud Run Services",
       "description": "List Cloud Run services in a project location (region)",
       "requiresWrite": false,
@@ -19862,7 +19862,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "services" },
       },
     }, {
-      "id": "get_cloud_run_service",
+      "id": "gcp__get_cloud_run_service",
       "name": "Get Cloud Run Service",
       "description":
         "Get one Cloud Run service's details - URL, container image, environment, and traffic split",
@@ -19893,7 +19893,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_cloud_functions",
+      "id": "gcp__list_cloud_functions",
       "name": "List Cloud Functions",
       "description":
         "List Cloud Functions (2nd gen API) in a project location — requires the optional cloud-platform scope (the only scope the Cloud Functions API accepts)",
@@ -20022,7 +20022,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://ai.google.dev/gemini-api/docs/api-key",
     }],
     "tools": [{
-      "id": "list_models",
+      "id": "gemini__list_models",
       "name": "List Models",
       "description": "List the Gemini models available to the API key",
       "requiresWrite": false,
@@ -20055,7 +20055,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_model",
+      "id": "gemini__get_model",
       "name": "Get Model",
       "description": "Get details about a specific Gemini model",
       "requiresWrite": false,
@@ -20072,7 +20072,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "generate_content",
+      "id": "gemini__generate_content",
       "name": "Generate Content",
       "description": "Generate a model response from text or multimodal content",
       "requiresWrite": true,
@@ -20106,7 +20106,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "embed_content",
+      "id": "gemini__embed_content",
       "name": "Embed Content",
       "description": "Create an embedding vector for input text",
       "requiresWrite": true,
@@ -20140,7 +20140,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "count_tokens",
+      "id": "gemini__count_tokens",
       "name": "Count Tokens",
       "description": "Count the tokens a prompt would use for a given model",
       "requiresWrite": false,
@@ -20165,7 +20165,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "generate_image",
+      "id": "gemini__generate_image",
       "name": "Generate Image",
       "description":
         "Generate or edit an image with a Nano Banana model via generateContent; the response returns image parts as base64 inlineData",
@@ -20198,7 +20198,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "edit_image",
+      "id": "gemini__edit_image",
       "name": "Edit Image",
       "description":
         "Edit an existing image with a Nano Banana model: send the source image as a base64 inlineData part plus a text instruction (add/remove/modify elements, change style, adjust color grading); the edited image is returned as base64 inlineData",
@@ -20231,7 +20231,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "imagen_generate",
+      "id": "gemini__imagen_generate",
       "name": "Generate Image (Imagen)",
       "description":
         "Generate text-to-image samples with an Imagen 4 model via the predict endpoint; returns base64-encoded images in predictions",
@@ -20263,7 +20263,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "upload_file",
+      "id": "gemini__upload_file",
       "name": "Upload File",
       "description":
         "Upload content to the Files API for use in later generateContent calls via its file URI; this simple media upload sends the decoded bytes directly as the request body (a custom displayName requires the multipart or resumable X-Goog-Upload protocol), and files expire after 48 hours",
@@ -20299,7 +20299,7 @@ export const connectors: IntegrationConfig[] = [
         "bodyMode": "raw",
       },
     }, {
-      "id": "list_files",
+      "id": "gemini__list_files",
       "name": "List Files",
       "description": "List files uploaded to the Files API for this project",
       "requiresWrite": false,
@@ -20332,7 +20332,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_file",
+      "id": "gemini__get_file",
       "name": "Get File",
       "description": "Get metadata for an uploaded file, including its uri and processing state",
       "requiresWrite": false,
@@ -20349,7 +20349,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_file",
+      "id": "gemini__delete_file",
       "name": "Delete File",
       "description": "Delete an uploaded file before its automatic 48-hour expiry",
       "requiresWrite": true,
@@ -20442,13 +20442,13 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://github.com/settings/developers",
     }],
     "tools": [{
-      "id": "get_current_user",
+      "id": "github__get_current_user",
       "name": "Get Current User",
       "description": "Get the authenticated GitHub user identity",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.github.com/user" },
     }, {
-      "id": "list_repos",
+      "id": "github__list_repos",
       "name": "List Repositories",
       "description": "Get list of user's repositories",
       "requiresWrite": false,
@@ -20503,7 +20503,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_user",
+      "id": "github__get_user",
       "name": "Get User",
       "description":
         "Get a GitHub user profile by username. Use this to verify repository owners, assignees, and other GitHub usernames before acting.",
@@ -20521,7 +20521,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_repo",
+      "id": "github__get_repo",
       "name": "Get Repository",
       "description": "Get details of a specific repository",
       "requiresWrite": false,
@@ -20544,7 +20544,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_prs",
+      "id": "github__list_prs",
       "name": "List Pull Requests",
       "description": "Get pull requests for a repository",
       "requiresWrite": false,
@@ -20606,7 +20606,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_issue",
+      "id": "github__create_issue",
       "name": "Create Issue",
       "description": "Create a new issue in a repository",
       "requiresWrite": true,
@@ -20635,7 +20635,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_pr_diff",
+      "id": "github__get_pr_diff",
       "name": "Get PR Diff",
       "description": "Get the diff for a pull request",
       "requiresWrite": false,
@@ -20670,7 +20670,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_issues",
+      "id": "github__list_issues",
       "name": "List Issues",
       "description": "List issues for a repository",
       "requiresWrite": false,
@@ -20740,7 +20740,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_issue",
+      "id": "github__get_issue",
       "name": "Get Issue",
       "description": "Get details of a GitHub issue",
       "requiresWrite": false,
@@ -20794,7 +20794,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_issue",
+      "id": "github__update_issue",
       "name": "Update Issue",
       "description": "Update, close, or reopen a GitHub issue",
       "requiresWrite": true,
@@ -20830,7 +20830,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "add_issue_comment",
+      "id": "github__add_issue_comment",
       "name": "Add Issue Comment",
       "description": "Add a comment to a GitHub issue or pull request",
       "requiresWrite": true,
@@ -20862,7 +20862,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_pr",
+      "id": "github__get_pr",
       "name": "Get Pull Request",
       "description":
         "Get details of a specific pull request (title, body, status, author, reviewers, labels)",
@@ -20920,7 +20920,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_pr",
+      "id": "github__create_pr",
       "name": "Create Pull Request",
       "description": "Create a new pull request in a repository",
       "requiresWrite": true,
@@ -20958,7 +20958,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "merge_pr",
+      "id": "github__merge_pr",
       "name": "Merge Pull Request",
       "description": "Merge an open pull request",
       "requiresWrite": true,
@@ -20996,7 +20996,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_commits",
+      "id": "github__list_commits",
       "name": "List Commits",
       "description": "List commits for a repository, branch, or file path",
       "requiresWrite": false,
@@ -21105,7 +21105,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.gitlab.com/ee/api/oauth2.html",
     }],
     "tools": [{
-      "id": "list_projects",
+      "id": "gitlab__list_projects",
       "name": "List Projects",
       "description": "List accessible GitLab projects",
       "requiresWrite": false,
@@ -21136,7 +21136,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_project",
+      "id": "gitlab__get_project",
       "name": "Get Project",
       "description": "Get detailed information about a GitLab project",
       "requiresWrite": false,
@@ -21153,7 +21153,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_issues",
+      "id": "gitlab__search_issues",
       "name": "Search Issues",
       "description": "Search for issues across projects",
       "requiresWrite": false,
@@ -21193,7 +21193,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_issue",
+      "id": "gitlab__get_issue",
       "name": "Get Issue",
       "description": "Get detailed information about a specific issue",
       "requiresWrite": false,
@@ -21216,7 +21216,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_issue",
+      "id": "gitlab__create_issue",
       "name": "Create Issue",
       "description": "Create a new issue in a project",
       "requiresWrite": true,
@@ -21239,7 +21239,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_issue",
+      "id": "gitlab__update_issue",
       "name": "Update Issue",
       "description": "Update, close, or reopen a GitLab issue",
       "requiresWrite": true,
@@ -21269,7 +21269,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "add_issue_comment",
+      "id": "gitlab__add_issue_comment",
       "name": "Add Issue Comment",
       "description": "Add a comment/note to a GitLab issue",
       "requiresWrite": true,
@@ -21299,7 +21299,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_merge_requests",
+      "id": "gitlab__list_merge_requests",
       "name": "List Merge Requests",
       "description": "List merge requests for a project or across projects",
       "requiresWrite": false,
@@ -21334,7 +21334,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_merge_request",
+      "id": "gitlab__get_merge_request",
       "name": "Get Merge Request",
       "description": "Get detailed information about a specific GitLab merge request",
       "requiresWrite": false,
@@ -21357,7 +21357,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "add_merge_request_comment",
+      "id": "gitlab__add_merge_request_comment",
       "name": "Add Merge Request Comment",
       "description": "Add a comment/note to a GitLab merge request",
       "requiresWrite": true,
@@ -21452,7 +21452,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://console.cloud.google.com/apis/credentials",
     }],
     "tools": [{
-      "id": "list_emails",
+      "id": "gmail__list_emails",
       "name": "List Emails",
       "description":
         "List Gmail message summaries with IDs, sender, recipient, subject, date, snippet, labels, and pagination tokens. Use get-email only when full message content is needed.",
@@ -21514,7 +21514,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "send_email",
+      "id": "gmail__send_email",
       "name": "Send Email",
       "description": "Send an email to recipients",
       "requiresWrite": true,
@@ -21531,7 +21531,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_email",
+      "id": "gmail__get_email",
       "name": "Get Email",
       "description": "Get a specific email by ID with full content",
       "requiresWrite": false,
@@ -21560,7 +21560,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_emails",
+      "id": "gmail__search_emails",
       "name": "Search Emails",
       "description":
         "Search Gmail messages and return summaries with IDs, sender, recipient, subject, date, snippet, labels, and pagination tokens.",
@@ -21618,7 +21618,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "mark_email_read",
+      "id": "gmail__mark_email_read",
       "name": "Mark Email Read",
       "description": "Mark an email as read",
       "requiresWrite": true,
@@ -21642,7 +21642,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "archive_email",
+      "id": "gmail__archive_email",
       "name": "Archive Email",
       "description": "Archive an email",
       "requiresWrite": true,
@@ -21666,7 +21666,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_labels",
+      "id": "gmail__list_labels",
       "name": "List Labels",
       "description": "List Gmail labels",
       "requiresWrite": false,
@@ -21684,7 +21684,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_label",
+      "id": "gmail__get_label",
       "name": "Get Label",
       "description": "Get a Gmail label",
       "requiresWrite": false,
@@ -21701,7 +21701,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_label",
+      "id": "gmail__create_label",
       "name": "Create Label",
       "description": "Create a Gmail user label",
       "requiresWrite": true,
@@ -21719,7 +21719,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_label",
+      "id": "gmail__update_label",
       "name": "Update Label",
       "description": "Update a Gmail user label",
       "requiresWrite": true,
@@ -21745,7 +21745,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_label",
+      "id": "gmail__delete_label",
       "name": "Delete Label",
       "description": "Delete a Gmail user label",
       "requiresWrite": true,
@@ -21762,7 +21762,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "apply_labels",
+      "id": "gmail__apply_labels",
       "name": "Apply Labels",
       "description": "Apply or remove labels on an email",
       "requiresWrite": true,
@@ -21783,7 +21783,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "modify_email_labels",
+      "id": "gmail__modify_email_labels",
       "name": "Modify Email Labels",
       "description": "Modify labels on an email",
       "requiresWrite": true,
@@ -21804,7 +21804,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "trash_email",
+      "id": "gmail__trash_email",
       "name": "Trash Email",
       "description": "Move an email to trash",
       "requiresWrite": true,
@@ -21821,7 +21821,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "untrash_email",
+      "id": "gmail__untrash_email",
       "name": "Untrash Email",
       "description": "Remove an email from trash",
       "requiresWrite": true,
@@ -21838,7 +21838,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_email",
+      "id": "gmail__delete_email",
       "name": "Delete Email",
       "description": "Permanently delete an email",
       "requiresWrite": true,
@@ -21855,7 +21855,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "batch_modify_emails",
+      "id": "gmail__batch_modify_emails",
       "name": "Batch Modify Emails",
       "description": "Modify labels on multiple emails",
       "requiresWrite": true,
@@ -21869,7 +21869,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "batch_delete_emails",
+      "id": "gmail__batch_delete_emails",
       "name": "Batch Delete Emails",
       "description": "Permanently delete multiple emails",
       "requiresWrite": true,
@@ -21881,7 +21881,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_threads",
+      "id": "gmail__list_threads",
       "name": "List Threads",
       "description": "List Gmail threads",
       "requiresWrite": false,
@@ -21921,7 +21921,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_thread",
+      "id": "gmail__get_thread",
       "name": "Get Thread",
       "description": "Get a Gmail thread",
       "requiresWrite": false,
@@ -21944,7 +21944,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "modify_thread_labels",
+      "id": "gmail__modify_thread_labels",
       "name": "Modify Thread Labels",
       "description": "Modify labels on a Gmail thread",
       "requiresWrite": true,
@@ -21965,7 +21965,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "trash_thread",
+      "id": "gmail__trash_thread",
       "name": "Trash Thread",
       "description": "Move a Gmail thread to trash",
       "requiresWrite": true,
@@ -21982,7 +21982,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "untrash_thread",
+      "id": "gmail__untrash_thread",
       "name": "Untrash Thread",
       "description": "Remove a Gmail thread from trash",
       "requiresWrite": true,
@@ -21999,7 +21999,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_thread",
+      "id": "gmail__delete_thread",
       "name": "Delete Thread",
       "description": "Permanently delete a Gmail thread",
       "requiresWrite": true,
@@ -22016,7 +22016,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_draft",
+      "id": "gmail__create_draft",
       "name": "Create Draft",
       "description": "Create a Gmail draft",
       "requiresWrite": true,
@@ -22032,7 +22032,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_drafts",
+      "id": "gmail__list_drafts",
       "name": "List Drafts",
       "description": "List Gmail drafts",
       "requiresWrite": false,
@@ -22065,7 +22065,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_draft",
+      "id": "gmail__get_draft",
       "name": "Get Draft",
       "description": "Get a Gmail draft",
       "requiresWrite": false,
@@ -22088,7 +22088,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_draft",
+      "id": "gmail__update_draft",
       "name": "Update Draft",
       "description": "Replace a Gmail draft",
       "requiresWrite": true,
@@ -22112,7 +22112,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "send_draft",
+      "id": "gmail__send_draft",
       "name": "Send Draft",
       "description": "Send an existing Gmail draft",
       "requiresWrite": true,
@@ -22122,7 +22122,7 @@ export const connectors: IntegrationConfig[] = [
         "body": { "id": { "type": "string", "description": "Draft ID", "required": true } },
       },
     }, {
-      "id": "delete_draft",
+      "id": "gmail__delete_draft",
       "name": "Delete Draft",
       "description": "Permanently delete a Gmail draft",
       "requiresWrite": true,
@@ -22139,7 +22139,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_attachment",
+      "id": "gmail__get_attachment",
       "name": "Get Attachment",
       "description": "Get a Gmail message attachment",
       "requiresWrite": false,
@@ -22163,7 +22163,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_profile",
+      "id": "gmail__get_profile",
       "name": "Get Profile",
       "description": "Get the Gmail mailbox profile",
       "requiresWrite": false,
@@ -22172,7 +22172,7 @@ export const connectors: IntegrationConfig[] = [
         "url": "https://gmail.googleapis.com/gmail/v1/users/me/profile",
       },
     }, {
-      "id": "list_history",
+      "id": "gmail__list_history",
       "name": "List History",
       "description": "List Gmail mailbox history changes",
       "requiresWrite": false,
@@ -22271,7 +22271,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.gocardless.com/getting-started/set-up/",
     }],
     "tools": [{
-      "id": "list_customers",
+      "id": "gocardless__list_customers",
       "name": "List Customers",
       "description": "List GoCardless customers to find customer IDs and contact details",
       "requiresWrite": false,
@@ -22307,7 +22307,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "customers" },
       },
     }, {
-      "id": "list_payments",
+      "id": "gocardless__list_payments",
       "name": "List Payments",
       "description":
         "List GoCardless payments with optional status, customer, or mandate filtering",
@@ -22355,7 +22355,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "payments" },
       },
     }, {
-      "id": "get_payment",
+      "id": "gocardless__get_payment",
       "name": "Get Payment",
       "description":
         "Get a single GoCardless payment by ID to check its status, amount, and linked mandate",
@@ -22381,7 +22381,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_mandates",
+      "id": "gocardless__list_mandates",
       "name": "List Mandates",
       "description":
         "List Direct Debit mandates to find an active mandate before collecting a payment",
@@ -22424,7 +22424,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "mandates" },
       },
     }, {
-      "id": "create_payment",
+      "id": "gocardless__create_payment",
       "name": "Create Payment",
       "description": "Collect a one-off payment against an existing active Direct Debit mandate",
       "requiresWrite": true,
@@ -22457,7 +22457,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_subscription",
+      "id": "gocardless__create_subscription",
       "name": "Create Subscription",
       "description":
         "Set up a recurring payment collection against an existing active Direct Debit mandate",
@@ -22491,7 +22491,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "retry_payment",
+      "id": "gocardless__retry_payment",
       "name": "Retry Payment",
       "description":
         "Retry a failed payment if its mandate is still active; a payment can be retried at most three times",
@@ -22518,7 +22518,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_events",
+      "id": "gocardless__list_events",
       "name": "List Events",
       "description":
         "List GoCardless events (status changes such as payment failures, chargebacks, and mandate cancellations) for monitoring and audit workflows",
@@ -22661,7 +22661,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://help.gong.io/docs/receive-access-to-the-api",
     }],
     "tools": [{
-      "id": "list_calls",
+      "id": "gong__list_calls",
       "name": "List Calls",
       "description": "List calls in a date window (max 90 days per request)",
       "requiresWrite": false,
@@ -22706,7 +22706,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_call",
+      "id": "gong__get_call",
       "name": "Get Call",
       "description": "Get metadata for a single call",
       "requiresWrite": false,
@@ -22724,7 +22724,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "call" },
       },
     }, {
-      "id": "get_calls_extensive",
+      "id": "gong__get_calls_extensive",
       "name": "Get Calls Extensive",
       "description":
         "Retrieve detailed call data with content selectors (read-only retrieval via POST)",
@@ -22751,7 +22751,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_call_transcripts",
+      "id": "gong__get_call_transcripts",
       "name": "Get Call Transcripts",
       "description": "Retrieve transcripts for specific calls (read-only retrieval via POST)",
       "requiresWrite": false,
@@ -22773,7 +22773,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "callTranscripts" },
       },
     }, {
-      "id": "list_users",
+      "id": "gong__list_users",
       "name": "List Users",
       "description": "List Gong users in the company",
       "requiresWrite": false,
@@ -22789,7 +22789,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_user",
+      "id": "gong__get_user",
       "name": "Get User",
       "description": "Get a Gong user by ID",
       "requiresWrite": false,
@@ -22886,7 +22886,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://console.cloud.google.com/apis/credentials",
     }],
     "tools": [{
-      "id": "list_account_summaries",
+      "id": "google-analytics__list_account_summaries",
       "name": "List Account Summaries",
       "description":
         "List GA4 accounts and their properties accessible to the connected user (use this to find property IDs)",
@@ -22921,7 +22921,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "run_report",
+      "id": "google-analytics__run_report",
       "name": "Run Report",
       "description": "Run a GA4 report for a property over one or more date ranges",
       "requiresWrite": false,
@@ -22965,7 +22965,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "run_realtime_report",
+      "id": "google-analytics__run_realtime_report",
       "name": "Run Realtime Report",
       "description": "Run a GA4 realtime report showing activity from the last 30 minutes",
       "requiresWrite": false,
@@ -22995,7 +22995,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_metadata",
+      "id": "google-analytics__get_metadata",
       "name": "Get Report Metadata",
       "description":
         "List the dimensions and metrics available for a GA4 property (use before building reports)",
@@ -23098,7 +23098,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://console.cloud.google.com/apis/credentials",
     }],
     "tools": [{
-      "id": "list_projects",
+      "id": "google-bigquery__list_projects",
       "name": "List Projects",
       "description":
         "List the Google Cloud projects the connected user can access, so agents can discover the projectId every other tool requires",
@@ -23122,7 +23122,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "projects" },
       },
     }, {
-      "id": "list_datasets",
+      "id": "google-bigquery__list_datasets",
       "name": "List Datasets",
       "description": "List all BigQuery datasets in a Google Cloud project",
       "requiresWrite": false,
@@ -23157,7 +23157,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "datasets" },
       },
     }, {
-      "id": "list_tables",
+      "id": "google-bigquery__list_tables",
       "name": "List Tables",
       "description": "List tables and views in a BigQuery dataset",
       "requiresWrite": false,
@@ -23193,7 +23193,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "tables" },
       },
     }, {
-      "id": "get_table",
+      "id": "google-bigquery__get_table",
       "name": "Get Table Schema",
       "description": "Get a table's metadata including its full column schema, row count, and size",
       "requiresWrite": false,
@@ -23229,7 +23229,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "preview_table_data",
+      "id": "google-bigquery__preview_table_data",
       "name": "Preview Table Data",
       "description":
         "Read sample rows directly from a table without running a query - no bytes are billed, ideal for inspecting data before writing SQL",
@@ -23283,7 +23283,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "rows" },
       },
     }, {
-      "id": "run_query",
+      "id": "google-bigquery__run_query",
       "name": "Run SQL Query",
       "description":
         "Run a read/SELECT GoogleSQL query and return the first page of results. With the default read-only scope only SELECT queries work; DML statements (INSERT/UPDATE/DELETE) require the full https://www.googleapis.com/auth/bigquery scope.",
@@ -23336,7 +23336,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_query_results",
+      "id": "google-bigquery__get_query_results",
       "name": "Get Query Results",
       "description":
         "Fetch additional pages of results from a previously started query job, using the jobId and pageToken returned by Run SQL Query",
@@ -23475,7 +23475,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://console.cloud.google.com/apis/credentials",
     }],
     "tools": [{
-      "id": "list_spaces",
+      "id": "google-chat__list_spaces",
       "name": "List Spaces",
       "description":
         "List Google Chat spaces (rooms and direct messages) the authenticated user is a member of",
@@ -23515,7 +23515,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_space",
+      "id": "google-chat__get_space",
       "name": "Get Space",
       "description": "Get details of a Google Chat space",
       "requiresWrite": false,
@@ -23533,7 +23533,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_messages",
+      "id": "google-chat__list_messages",
       "name": "List Messages",
       "description": "List messages in a Google Chat space, including messages in threads",
       "requiresWrite": false,
@@ -23587,7 +23587,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_message",
+      "id": "google-chat__get_message",
       "name": "Get Message",
       "description": "Get details of a specific Google Chat message",
       "requiresWrite": false,
@@ -23610,7 +23610,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "send_message",
+      "id": "google-chat__send_message",
       "name": "Send Message",
       "description": "Send a text message to a Google Chat space",
       "requiresWrite": true,
@@ -23728,7 +23728,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://console.cloud.google.com/apis/credentials",
     }],
     "tools": [{
-      "id": "list_buckets",
+      "id": "google-cloud-storage__list_buckets",
       "name": "List Buckets",
       "description": "List Cloud Storage buckets in a Google Cloud project",
       "requiresWrite": false,
@@ -23763,7 +23763,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "items" },
       },
     }, {
-      "id": "get_bucket",
+      "id": "google-cloud-storage__get_bucket",
       "name": "Get Bucket Metadata",
       "description":
         "Get a bucket's metadata - location, storage class, versioning, and lifecycle configuration",
@@ -23786,7 +23786,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_objects",
+      "id": "google-cloud-storage__list_objects",
       "name": "List Objects",
       "description":
         "List objects in a bucket, optionally filtered by name prefix or grouped by delimiter",
@@ -23828,7 +23828,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "items" },
       },
     }, {
-      "id": "download_object",
+      "id": "google-cloud-storage__download_object",
       "name": "Download Object",
       "description":
         "Download an object's content (alt=media), or set alt=json to return the object's metadata instead",
@@ -23860,7 +23860,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "upload_object",
+      "id": "google-cloud-storage__upload_object",
       "name": "Upload Object",
       "description":
         "Upload content as a new object (or overwrite an existing one) using a simple media upload — requires the read-write scope",
@@ -23907,7 +23907,7 @@ export const connectors: IntegrationConfig[] = [
         "bodyMode": "passthrough",
       },
     }, {
-      "id": "copy_object",
+      "id": "google-cloud-storage__copy_object",
       "name": "Copy Object",
       "description":
         "Copy an object to another name or bucket server-side (rewrite), without downloading and re-uploading - requires the read-write scope",
@@ -23952,7 +23952,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_object",
+      "id": "google-cloud-storage__delete_object",
       "name": "Delete Object",
       "description": "Permanently delete an object from a bucket — requires the read-write scope",
       "requiresWrite": true,
@@ -24064,7 +24064,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://console.cloud.google.com/apis/credentials",
     }],
     "tools": [{
-      "id": "list_contacts",
+      "id": "google-contacts__list_contacts",
       "name": "List Contacts",
       "description":
         "List the authenticated user's contacts (connections) with the requested person fields",
@@ -24102,7 +24102,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "connections" },
       },
     }, {
-      "id": "search_contacts",
+      "id": "google-contacts__search_contacts",
       "name": "Search Contacts",
       "description":
         "Search the user's contacts by prefix match on names, nicknames, email addresses, and phone numbers. For best results send a warmup request with an empty query first, then search.",
@@ -24136,7 +24136,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "get_contact",
+      "id": "google-contacts__get_contact",
       "name": "Get Contact",
       "description": "Get a single contact by person ID, including the etag needed for updates",
       "requiresWrite": false,
@@ -24162,7 +24162,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_contact_groups",
+      "id": "google-contacts__list_contact_groups",
       "name": "List Contact Groups",
       "description":
         "List the user's contact groups (labels), including system groups and member counts, e.g. to organize or filter contacts",
@@ -24192,7 +24192,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "contactGroups" },
       },
     }, {
-      "id": "create_contact",
+      "id": "google-contacts__create_contact",
       "name": "Create Contact",
       "description":
         "Create a new contact in the user's Google Contacts (requires the full contacts scope)",
@@ -24235,7 +24235,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_contact",
+      "id": "google-contacts__update_contact",
       "name": "Update Contact",
       "description":
         "Update an existing contact (requires the full contacts scope). You must pass updatePersonFields naming the fields you are changing, and the body must include the contact's current etag (fetch it with Get Contact including metadata first); a stale etag fails with a 400 failedPrecondition error.",
@@ -24390,7 +24390,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://console.cloud.google.com/apis/credentials",
     }],
     "tools": [{
-      "id": "get_form",
+      "id": "google-forms__get_form",
       "name": "Get Form",
       "description":
         "Get a form's metadata, settings, and items (questions) including the question IDs needed to interpret responses",
@@ -24408,7 +24408,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_form_responses",
+      "id": "google-forms__list_form_responses",
       "name": "List Form Responses",
       "description": "List submitted responses for a form, with answers keyed by question ID",
       "requiresWrite": false,
@@ -24438,7 +24438,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "responses" },
       },
     }, {
-      "id": "get_form_response",
+      "id": "google-forms__get_form_response",
       "name": "Get Form Response",
       "description": "Get a single response submitted to a form",
       "requiresWrite": false,
@@ -24456,7 +24456,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_form",
+      "id": "google-forms__create_form",
       "name": "Create Form",
       "description":
         "Create a new form with a title; add questions afterwards with Batch Update Form",
@@ -24474,7 +24474,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "set_publish_settings",
+      "id": "google-forms__set_publish_settings",
       "name": "Set Publish Settings",
       "description":
         "Publish or unpublish a form and toggle whether it accepts responses, e.g. to open a survey after building it or close it when done (requires the forms.body scope)",
@@ -24505,7 +24505,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "batch_update_form",
+      "id": "google-forms__batch_update_form",
       "name": "Batch Update Form",
       "description":
         "Apply a batch of updates to a form, such as adding questions, updating form info, or changing settings",
@@ -24631,7 +24631,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developers.gorgias.com/reference/authentication",
     }],
     "tools": [{
-      "id": "list_tickets",
+      "id": "gorgias__list_tickets",
       "name": "List Tickets",
       "description":
         "List helpdesk tickets, optionally filtered by customer or ordered by creation/update time",
@@ -24690,7 +24690,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_ticket",
+      "id": "gorgias__get_ticket",
       "name": "Get Ticket",
       "description":
         "Retrieve a single ticket with its full details (customer, assignee, status, tags)",
@@ -24715,7 +24715,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_ticket_messages",
+      "id": "gorgias__list_ticket_messages",
       "name": "List Ticket Messages",
       "description": "List the messages (customer and agent) in a ticket's conversation thread",
       "requiresWrite": false,
@@ -24766,7 +24766,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_ticket_message",
+      "id": "gorgias__create_ticket_message",
       "name": "Create Ticket Message",
       "description":
         "Add a message to a ticket, e.g. an agent reply to the customer or an internal note",
@@ -24814,7 +24814,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_ticket",
+      "id": "gorgias__create_ticket",
       "name": "Create Ticket",
       "description":
         "Create a new helpdesk ticket with an initial message, e.g. to open an issue on behalf of a customer",
@@ -24858,7 +24858,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_customers",
+      "id": "gorgias__list_customers",
       "name": "List Customers",
       "description":
         "List or search helpdesk customers, e.g. to find a customer ID by email for ticket filtering",
@@ -24917,7 +24917,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_users",
+      "id": "gorgias__list_users",
       "name": "List Users",
       "description":
         "List helpdesk agents/users, e.g. to find the user IDs needed for ticket assignment and message senders",
@@ -24968,7 +24968,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_ticket_status",
+      "id": "gorgias__update_ticket_status",
       "name": "Update Ticket Status",
       "description": "Update a ticket, e.g. close or reopen it, or change its assignee",
       "requiresWrite": true,
@@ -25081,7 +25081,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://grafana.com/docs/grafana/latest/administration/service-accounts/",
     }],
     "tools": [{
-      "id": "search_dashboards",
+      "id": "grafana-cloud__search_dashboards",
       "name": "Search Dashboards",
       "description": "Search dashboards and folders in the Grafana stack",
       "requiresWrite": false,
@@ -25136,7 +25136,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_dashboard",
+      "id": "grafana-cloud__get_dashboard",
       "name": "Get Dashboard",
       "description": "Get a dashboard's full JSON model by UID",
       "requiresWrite": false,
@@ -25159,7 +25159,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_folders",
+      "id": "grafana-cloud__list_folders",
       "name": "List Folders",
       "description": "List dashboard folders in the Grafana stack",
       "requiresWrite": false,
@@ -25182,7 +25182,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_annotations",
+      "id": "grafana-cloud__list_annotations",
       "name": "List Annotations",
       "description": "List annotations and alert events in a time range",
       "requiresWrite": false,
@@ -25225,7 +25225,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_annotation",
+      "id": "grafana-cloud__create_annotation",
       "name": "Create Annotation",
       "description": "Create an annotation (e.g. mark a deploy) on a dashboard or globally",
       "requiresWrite": true,
@@ -25260,7 +25260,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_datasources",
+      "id": "grafana-cloud__list_datasources",
       "name": "List Data Sources",
       "description": "List data sources configured in the Grafana stack",
       "requiresWrite": false,
@@ -25356,7 +25356,7 @@ export const connectors: IntegrationConfig[] = [
       "default": "",
     }],
     "tools": [{
-      "id": "list_jobs",
+      "id": "greenhouse__list_jobs",
       "name": "List Jobs",
       "description":
         "List jobs in the Greenhouse organization with optional status and date filtering",
@@ -25394,7 +25394,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_candidates",
+      "id": "greenhouse__list_candidates",
       "name": "List Candidates",
       "description": "List candidates with optional job, email, and date filtering",
       "requiresWrite": false,
@@ -25436,7 +25436,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_candidate",
+      "id": "greenhouse__get_candidate",
       "name": "Get Candidate",
       "description":
         "Get a candidate's full record, including applications, attachments, and contact details",
@@ -25454,7 +25454,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_applications",
+      "id": "greenhouse__list_applications",
       "name": "List Applications",
       "description": "List applications with optional job, status, and activity filtering",
       "requiresWrite": false,
@@ -25497,7 +25497,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_users",
+      "id": "greenhouse__list_users",
       "name": "List Users",
       "description":
         "List Greenhouse users to find the numeric user IDs needed for On-Behalf-Of headers and notes",
@@ -25530,7 +25530,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_job_stages",
+      "id": "greenhouse__list_job_stages",
       "name": "List Job Stages",
       "description":
         "List the interview stages of a job to find the stage IDs needed to move applications",
@@ -25559,7 +25559,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "move_application",
+      "id": "greenhouse__move_application",
       "name": "Move Application",
       "description":
         "Move an active application to another stage on the same job (the core pipeline action)",
@@ -25596,7 +25596,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "add_candidate_note",
+      "id": "greenhouse__add_candidate_note",
       "name": "Add Candidate Note",
       "description":
         "Create a note on a candidate's activity feed (requires the acting Greenhouse user's ID)",
@@ -25712,7 +25712,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://console.groq.com/keys",
     }],
     "tools": [{
-      "id": "list_models",
+      "id": "groq__list_models",
       "name": "List Models",
       "description": "List the models available on Groq",
       "requiresWrite": false,
@@ -25732,7 +25732,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_model",
+      "id": "groq__get_model",
       "name": "Get Model",
       "description": "Get details about a specific Groq model",
       "requiresWrite": false,
@@ -25749,7 +25749,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_chat_completion",
+      "id": "groq__create_chat_completion",
       "name": "Create Chat Completion",
       "description": "Generate a chat completion from a list of messages",
       "requiresWrite": true,
@@ -25778,7 +25778,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_batches",
+      "id": "groq__list_batches",
       "name": "List Batches",
       "description": "List the organization's batch jobs",
       "requiresWrite": false,
@@ -25861,7 +25861,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.getguru.com/docs/getting-started",
     }],
     "tools": [{
-      "id": "search_cards",
+      "id": "guru__search_cards",
       "name": "Search Cards",
       "description": "Search the knowledge base for cards matching search terms",
       "requiresWrite": false,
@@ -25901,7 +25901,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_card",
+      "id": "guru__get_card",
       "name": "Get Card",
       "description":
         "Get a single card with its full content and additional details (collection, verifiers, collaborators)",
@@ -25919,13 +25919,13 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_collections",
+      "id": "guru__list_collections",
       "name": "List Collections",
       "description": "List the collections in the team to find collection IDs, names, and stats",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.getguru.com/api/v1/collections" },
     }, {
-      "id": "create_card",
+      "id": "guru__create_card",
       "name": "Create Card",
       "description": "Create a new knowledge-base card in a collection",
       "requiresWrite": true,
@@ -25961,7 +25961,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_card",
+      "id": "guru__update_card",
       "name": "Update Card",
       "description":
         "Update an existing card's title, content, or visibility to keep knowledge current",
@@ -26007,7 +26007,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "verify_card",
+      "id": "guru__verify_card",
       "name": "Verify Card",
       "description": "Mark a card as verified, confirming its content is accurate and up to date",
       "requiresWrite": true,
@@ -26107,7 +26107,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.gusto.com/app-integrations/docs/introduction",
     }],
     "tools": [{
-      "id": "get_token_info",
+      "id": "gusto__get_token_info",
       "name": "Get Token Info",
       "description":
         "Get the resource (company) and scope associated with the current access token",
@@ -26126,7 +26126,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_company",
+      "id": "gusto__get_company",
       "name": "Get Company",
       "description": "Get a company's profile, locations, and entity details",
       "requiresWrite": false,
@@ -26150,7 +26150,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_employees",
+      "id": "gusto__list_employees",
       "name": "List Employees",
       "description": "List employees of a company",
       "requiresWrite": false,
@@ -26209,7 +26209,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_employee",
+      "id": "gusto__get_employee",
       "name": "Get Employee",
       "description": "Get a single employee",
       "requiresWrite": false,
@@ -26233,7 +26233,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_payrolls",
+      "id": "gusto__list_payrolls",
       "name": "List Payrolls",
       "description": "List payrolls for a company",
       "requiresWrite": false,
@@ -26277,7 +26277,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_payroll",
+      "id": "gusto__get_payroll",
       "name": "Get Payroll",
       "description": "Get a single payroll with totals",
       "requiresWrite": false,
@@ -27705,7 +27705,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.helpscout.com/mailbox-api/overview/authentication/",
     }],
     "tools": [{
-      "id": "list_mailboxes",
+      "id": "help-scout__list_mailboxes",
       "name": "List Mailboxes",
       "description":
         "List Help Scout mailboxes (inboxes) so agents can find a mailbox ID before reading conversations",
@@ -27724,7 +27724,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "_embedded.mailboxes" },
       },
     }, {
-      "id": "list_conversations",
+      "id": "help-scout__list_conversations",
       "name": "List Conversations",
       "description":
         "List Help Scout conversations, optionally filtered by mailbox, status, tag, or assignee",
@@ -27785,7 +27785,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "_embedded.conversations" },
       },
     }, {
-      "id": "get_conversation",
+      "id": "help-scout__get_conversation",
       "name": "Get Conversation",
       "description": "Get a Help Scout conversation by ID, including its message threads",
       "requiresWrite": false,
@@ -27809,7 +27809,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_customers",
+      "id": "help-scout__list_customers",
       "name": "List Customers",
       "description":
         "List Help Scout customers, optionally filtered by mailbox, name, or a search query",
@@ -27858,7 +27858,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "_embedded.customers" },
       },
     }, {
-      "id": "list_users",
+      "id": "help-scout__list_users",
       "name": "List Users",
       "description":
         "List Help Scout users (team members) so agents can find user IDs for assignment and reply attribution",
@@ -27887,7 +27887,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "_embedded.users" },
       },
     }, {
-      "id": "add_note",
+      "id": "help-scout__add_note",
       "name": "Add Note",
       "description":
         "Add an internal note to a conversation - visible to the team only, never emailed to the customer",
@@ -27913,7 +27913,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_tags",
+      "id": "help-scout__update_tags",
       "name": "Update Tags",
       "description":
         "Replace the tag list of a conversation, e.g. to label it during triage. Send the full list: tags omitted from the payload are removed.",
@@ -27939,7 +27939,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_reply",
+      "id": "help-scout__create_reply",
       "name": "Reply to Conversation",
       "description":
         "Send a reply on an existing Help Scout conversation, optionally changing its status",
@@ -27982,7 +27982,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_conversation",
+      "id": "help-scout__create_conversation",
       "name": "Create Conversation",
       "description": "Create a new Help Scout conversation in a mailbox with an initial thread",
       "requiresWrite": true,
@@ -28109,7 +28109,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://devcenter.heroku.com/articles/platform-api-quickstart",
     }],
     "tools": [{
-      "id": "list_apps",
+      "id": "heroku__list_apps",
       "name": "List Apps",
       "description": "List apps the authenticated user can access",
       "requiresWrite": false,
@@ -28151,7 +28151,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_app",
+      "id": "heroku__get_app",
       "name": "Get App",
       "description": "Get details of an app",
       "requiresWrite": false,
@@ -28175,7 +28175,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_dynos",
+      "id": "heroku__list_dynos",
       "name": "List Dynos",
       "description": "List the dynos of an app with their state",
       "requiresWrite": false,
@@ -28216,7 +28216,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "restart_dyno",
+      "id": "heroku__restart_dyno",
       "name": "Restart Dyno",
       "description": "Restart a specific dyno of an app",
       "requiresWrite": true,
@@ -28246,7 +28246,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "restart_all_dynos",
+      "id": "heroku__restart_all_dynos",
       "name": "Restart All Dynos",
       "description": "Restart every dyno of an app",
       "requiresWrite": true,
@@ -28270,7 +28270,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_config_vars",
+      "id": "heroku__get_config_vars",
       "name": "Get Config Vars",
       "description": "Get the config vars (environment variables) of an app",
       "requiresWrite": false,
@@ -28294,7 +28294,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_releases",
+      "id": "heroku__list_releases",
       "name": "List Releases",
       "description": "List the release history of an app",
       "requiresWrite": false,
@@ -28410,7 +28410,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.hetzner.cloud/reference/cloud",
     }],
     "tools": [{
-      "id": "list_servers",
+      "id": "hetzner__list_servers",
       "name": "List Servers",
       "description":
         "List servers in the Hetzner Cloud project with optional name, label, and status filtering",
@@ -28453,7 +28453,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_server",
+      "id": "hetzner__get_server",
       "name": "Get Server",
       "description":
         "Get a server by ID, including status, server type, image, and public network info",
@@ -28472,7 +28472,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "server" },
       },
     }, {
-      "id": "create_server",
+      "id": "hetzner__create_server",
       "name": "Create Server",
       "description": "Create a new server (provisions billable infrastructure)",
       "requiresWrite": true,
@@ -28514,7 +28514,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "power_on_server",
+      "id": "hetzner__power_on_server",
       "name": "Power On Server",
       "description": "Power on a server by ID",
       "requiresWrite": true,
@@ -28532,7 +28532,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "action" },
       },
     }, {
-      "id": "power_off_server",
+      "id": "hetzner__power_off_server",
       "name": "Power Off Server",
       "description":
         "Cut power to a server by ID (hard power off, like pulling the plug; data may be lost if the OS is running)",
@@ -28551,7 +28551,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "action" },
       },
     }, {
-      "id": "list_images",
+      "id": "hetzner__list_images",
       "name": "List Images",
       "description":
         "List available images (system images, backups, snapshots) usable for server creation",
@@ -28602,7 +28602,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_server_types",
+      "id": "hetzner__list_server_types",
       "name": "List Server Types",
       "description": "List available server types (sizes) with cores, memory, disk, and pricing",
       "requiresWrite": false,
@@ -28641,7 +28641,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "shutdown_server",
+      "id": "hetzner__shutdown_server",
       "name": "Shutdown Server",
       "description":
         "Gracefully shut down a server by sending an ACPI shutdown signal to the OS — prefer this over Power Off for running workloads",
@@ -28660,7 +28660,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "action" },
       },
     }, {
-      "id": "reboot_server",
+      "id": "hetzner__reboot_server",
       "name": "Reboot Server",
       "description": "Gracefully reboot a server by sending an ACPI reboot signal to the OS",
       "requiresWrite": true,
@@ -28678,7 +28678,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "action" },
       },
     }, {
-      "id": "list_ssh_keys",
+      "id": "hetzner__list_ssh_keys",
       "name": "List SSH Keys",
       "description":
         "List SSH keys in the project — use these IDs or names in the ssh_keys field of Create Server",
@@ -28812,7 +28812,7 @@ export const connectors: IntegrationConfig[] = [
         "https://developers.hubspot.com/docs/apps/developer-platform/build-apps/authentication/oauth",
     }],
     "tools": [{
-      "id": "list_forms",
+      "id": "hubspot__list_forms",
       "name": "List Forms",
       "description": "List HubSpot forms so agents can find a form ID before reading submissions",
       "requiresWrite": false,
@@ -28841,7 +28841,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "list_form_submissions",
+      "id": "hubspot__list_form_submissions",
       "name": "List Form Submissions",
       "description": "List recent submissions for a HubSpot form in reverse chronological order",
       "requiresWrite": false,
@@ -28870,7 +28870,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "get_contact",
+      "id": "hubspot__get_contact",
       "name": "Get Contact",
       "description": "Get a HubSpot contact by ID or email before scoring, dedupe, or updates",
       "requiresWrite": false,
@@ -28908,7 +28908,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_contacts",
+      "id": "hubspot__search_contacts",
       "name": "Search Contacts",
       "description": "Search HubSpot contacts by filters for lead research and CRM lookup",
       "requiresWrite": false,
@@ -28929,7 +28929,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "create_contact",
+      "id": "hubspot__create_contact",
       "name": "Create Contact",
       "description": "Create a HubSpot contact from form submission or researched lead data",
       "requiresWrite": true,
@@ -28946,7 +28946,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_contact",
+      "id": "hubspot__update_contact",
       "name": "Update Contact",
       "description": "Update HubSpot contact properties, including lead score or research notes",
       "requiresWrite": true,
@@ -28975,7 +28975,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_lead",
+      "id": "hubspot__get_lead",
       "name": "Get Lead",
       "description": "Get a HubSpot CRM lead before scoring, routing, or updates",
       "requiresWrite": false,
@@ -29008,7 +29008,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_leads",
+      "id": "hubspot__list_leads",
       "name": "List Leads",
       "description":
         "List HubSpot CRM leads for scoring, spreadsheet updates, or research workflows",
@@ -29048,7 +29048,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "search_leads",
+      "id": "hubspot__search_leads",
       "name": "Search Leads",
       "description": "Search HubSpot CRM leads for dedupe, scoring, and routing workflows",
       "requiresWrite": false,
@@ -29069,7 +29069,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "create_lead",
+      "id": "hubspot__create_lead",
       "name": "Create Lead",
       "description": "Create a HubSpot CRM lead associated with an existing contact or company",
       "requiresWrite": true,
@@ -29090,7 +29090,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_lead",
+      "id": "hubspot__update_lead",
       "name": "Update Lead",
       "description":
         "Update a HubSpot CRM lead with score, qualification, owner, or research fields",
@@ -29115,7 +29115,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_company",
+      "id": "hubspot__get_company",
       "name": "Get Company",
       "description": "Get a HubSpot company by ID or domain before lead research or association",
       "requiresWrite": false,
@@ -29153,7 +29153,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_companies",
+      "id": "hubspot__search_companies",
       "name": "Search Companies",
       "description": "Search HubSpot companies by domain, name, or firmographic properties",
       "requiresWrite": false,
@@ -29178,7 +29178,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "create_company",
+      "id": "hubspot__create_company",
       "name": "Create Company",
       "description": "Create a HubSpot company for researched lead accounts",
       "requiresWrite": true,
@@ -29195,7 +29195,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_company",
+      "id": "hubspot__update_company",
       "name": "Update Company",
       "description": "Update HubSpot company properties with research or enrichment data",
       "requiresWrite": true,
@@ -29224,7 +29224,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_properties",
+      "id": "hubspot__list_properties",
       "name": "List Properties",
       "description":
         "List HubSpot CRM properties for contacts, leads, or companies before updating custom fields",
@@ -29255,7 +29255,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "list_owners",
+      "id": "hubspot__list_owners",
       "name": "List Owners",
       "description": "List HubSpot owners so agents can assign or route contacts and leads",
       "requiresWrite": false,
@@ -29285,7 +29285,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "list_association_labels",
+      "id": "hubspot__list_association_labels",
       "name": "List Association Labels",
       "description":
         "List HubSpot association labels between CRM object types before associating records",
@@ -29310,7 +29310,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "list_associations",
+      "id": "hubspot__list_associations",
       "name": "List Associations",
       "description": "List records associated with a HubSpot CRM record",
       "requiresWrite": false,
@@ -29352,7 +29352,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "associate_records",
+      "id": "hubspot__associate_records",
       "name": "Associate Records",
       "description": "Create a default HubSpot association between two CRM records",
       "requiresWrite": true,
@@ -29388,7 +29388,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "remove_association",
+      "id": "hubspot__remove_association",
       "name": "Remove Association",
       "description": "Remove all HubSpot associations between two CRM records",
       "requiresWrite": true,
@@ -29466,7 +29466,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://huggingface.co/settings/tokens",
     }],
     "tools": [{
-      "id": "search_models",
+      "id": "huggingface__search_models",
       "name": "Search Models",
       "description": "Search models on the Hugging Face Hub",
       "requiresWrite": false,
@@ -29513,7 +29513,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_model",
+      "id": "huggingface__get_model",
       "name": "Get Model",
       "description": "Get details about a model repository on the Hub",
       "requiresWrite": false,
@@ -29536,7 +29536,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_datasets",
+      "id": "huggingface__search_datasets",
       "name": "Search Datasets",
       "description": "Search datasets on the Hugging Face Hub",
       "requiresWrite": false,
@@ -29563,13 +29563,13 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "whoami",
+      "id": "huggingface__whoami",
       "name": "Who Am I",
       "description": "Get the account and permissions associated with the access token",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://huggingface.co/api/whoami-v2" },
     }, {
-      "id": "create_chat_completion",
+      "id": "huggingface__create_chat_completion",
       "name": "Create Chat Completion",
       "description":
         "Generate a chat completion through the Hugging Face Inference Providers router (OpenAI-compatible)",
@@ -29675,7 +29675,7 @@ export const connectors: IntegrationConfig[] = [
         "https://developers.intercom.com/docs/build-an-integration/learn-more/authentication/setting-up-oauth",
     }],
     "tools": [{
-      "id": "list_contacts",
+      "id": "intercom__list_contacts",
       "name": "List Contacts",
       "description": "List contacts (users and leads) in the Intercom workspace",
       "requiresWrite": false,
@@ -29716,7 +29716,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_contacts",
+      "id": "intercom__search_contacts",
       "name": "Search Contacts",
       "description": "Search Intercom contacts with a field/operator/value query",
       "requiresWrite": false,
@@ -29737,7 +29737,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_contact",
+      "id": "intercom__get_contact",
       "name": "Get Contact",
       "description": "Get a single Intercom contact by ID",
       "requiresWrite": false,
@@ -29754,7 +29754,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_conversations",
+      "id": "intercom__list_conversations",
       "name": "List Conversations",
       "description": "List conversations in the Intercom workspace, newest first",
       "requiresWrite": false,
@@ -29776,7 +29776,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "reply_to_conversation",
+      "id": "intercom__reply_to_conversation",
       "name": "Reply To Conversation",
       "description": "Reply to an Intercom conversation as an admin (comment or internal note)",
       "requiresWrite": true,
@@ -29817,7 +29817,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_articles",
+      "id": "intercom__list_articles",
       "name": "List Articles",
       "description": "List help center articles in the Intercom workspace",
       "requiresWrite": false,
@@ -29912,7 +29912,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.ionos.com/cloud/reference/get-started",
     }],
     "tools": [{
-      "id": "list_datacenters",
+      "id": "ionos__list_datacenters",
       "name": "List Data Centers",
       "description":
         "List virtual data centers in the account; each data center contains servers, volumes, and networks",
@@ -29955,7 +29955,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_servers",
+      "id": "ionos__list_servers",
       "name": "List Servers",
       "description": "List servers inside a virtual data center",
       "requiresWrite": false,
@@ -30003,7 +30003,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_server",
+      "id": "ionos__get_server",
       "name": "Get Server",
       "description":
         "Get a server in a data center, including name, vmState, cores, RAM, and boot device",
@@ -30033,7 +30033,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "start_server",
+      "id": "ionos__start_server",
       "name": "Start Server",
       "description":
         "Start (power on) an Enterprise server; CUBE servers cannot be started with this endpoint (they use suspend/resume instead)",
@@ -30058,7 +30058,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "stop_server",
+      "id": "ionos__stop_server",
       "name": "Stop Server",
       "description":
         "Stop (power off) an Enterprise server; the server is forcefully powered off and billing for compute stops; public IPv4 addresses that are not reserved are returned to the IPv4 pool (reserved IPs are kept). CUBE servers cannot be stopped with this endpoint (they use suspend/resume instead)",
@@ -30083,7 +30083,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "reboot_server",
+      "id": "ionos__reboot_server",
       "name": "Reboot Server",
       "description":
         "Force a hard reboot of a server (equivalent to powering it down and back on) — recovers hung servers without a separate stop/start cycle; not a graceful OS reboot",
@@ -30108,7 +30108,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_request_status",
+      "id": "ionos__get_request_status",
       "name": "Get Request Status",
       "description":
         "Poll the status of an asynchronous write operation (202 Accepted responses) until it reports DONE or FAILED; the request ID comes from the Location response header of the write call",
@@ -30206,7 +30206,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.atlassian.com/console/myapps/",
     }],
     "tools": [{
-      "id": "list_sites",
+      "id": "jira__list_sites",
       "name": "List Atlassian Sites",
       "description":
         "List Atlassian cloud sites/resources the OAuth token can access; use the returned id as cloudId for Jira and Confluence tools",
@@ -30257,7 +30257,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_projects",
+      "id": "jira__list_projects",
       "name": "List Projects",
       "description": "List all accessible Jira projects",
       "requiresWrite": false,
@@ -30332,7 +30332,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_project",
+      "id": "jira__get_project",
       "name": "Get Project",
       "description": "Get detailed information about a Jira project",
       "requiresWrite": false,
@@ -30355,7 +30355,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_issues",
+      "id": "jira__search_issues",
       "name": "Search Issues",
       "description": "Search Jira issues using JQL (Jira Query Language)",
       "requiresWrite": false,
@@ -30412,7 +30412,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_issue",
+      "id": "jira__get_issue",
       "name": "Get Issue",
       "description": "Get detailed information about a specific Jira issue",
       "requiresWrite": false,
@@ -30440,7 +30440,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_issue",
+      "id": "jira__create_issue",
       "name": "Create Issue",
       "description": "Create a new Jira issue in a project",
       "requiresWrite": true,
@@ -30465,7 +30465,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_issue",
+      "id": "jira__update_issue",
       "name": "Update Issue",
       "description": "Update an existing Jira issue (status, fields, etc.)",
       "requiresWrite": true,
@@ -30492,7 +30492,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_comments",
+      "id": "jira__list_comments",
       "name": "List Comments",
       "description": "List comments on a Jira issue",
       "requiresWrite": false,
@@ -30543,7 +30543,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "add_comment",
+      "id": "jira__add_comment",
       "name": "Add Comment",
       "description": "Add a comment to a Jira issue",
       "requiresWrite": true,
@@ -30574,7 +30574,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_transitions",
+      "id": "jira__get_transitions",
       "name": "Get Transitions",
       "description": "List available workflow transitions for a Jira issue",
       "requiresWrite": false,
@@ -30598,7 +30598,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "transition_issue",
+      "id": "jira__transition_issue",
       "name": "Transition Issue",
       "description":
         "Move a Jira issue to a new workflow status. First call get_transitions to get valid transition IDs, then pass the ID here.",
@@ -30639,7 +30639,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_users",
+      "id": "jira__search_users",
       "name": "Search Users",
       "description":
         "Search Jira users by name or email to find the accountId needed for assigning issues",
@@ -30739,7 +30739,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://api.jotform.com/docs/#gettingstarted",
     }],
     "tools": [{
-      "id": "list_forms",
+      "id": "jotform__list_forms",
       "name": "List Forms",
       "description": "List forms owned by the account",
       "requiresWrite": false,
@@ -30792,7 +30792,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_form",
+      "id": "jotform__get_form",
       "name": "Get Form",
       "description": "Get basic details of a form",
       "requiresWrite": false,
@@ -30810,7 +30810,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "content" },
       },
     }, {
-      "id": "get_form_questions",
+      "id": "jotform__get_form_questions",
       "name": "Get Form Questions",
       "description": "List the questions/fields on a form",
       "requiresWrite": false,
@@ -30828,7 +30828,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "content" },
       },
     }, {
-      "id": "list_submissions",
+      "id": "jotform__list_submissions",
       "name": "List Submissions",
       "description": "List submissions for a form",
       "requiresWrite": false,
@@ -30869,7 +30869,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "content" },
       },
     }, {
-      "id": "get_submission",
+      "id": "jotform__get_submission",
       "name": "Get Submission",
       "description": "Get a single submission with its answers",
       "requiresWrite": false,
@@ -30887,7 +30887,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "content" },
       },
     }, {
-      "id": "get_user",
+      "id": "jotform__get_user",
       "name": "Get User",
       "description": "Get the authenticated account profile and usage",
       "requiresWrite": false,
@@ -30967,7 +30967,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.klarna.com/api/authentication/",
     }],
     "tools": [{
-      "id": "get_order",
+      "id": "klarna__get_order",
       "name": "Get Order",
       "description":
         "Retrieve a Klarna order including status, amounts, order lines, captures, and refunds",
@@ -30992,7 +30992,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "capture_order",
+      "id": "klarna__capture_order",
       "name": "Capture Order",
       "description":
         "Capture a full or partial amount of an authorized order (activates the payment after fulfillment)",
@@ -31033,7 +31033,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "refund_order",
+      "id": "klarna__refund_order",
       "name": "Refund Order",
       "description": "Refund a full or partial captured amount back to the customer",
       "requiresWrite": true,
@@ -31069,7 +31069,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "cancel_order",
+      "id": "klarna__cancel_order",
       "name": "Cancel Order",
       "description":
         "Cancel an authorized order that has not been captured, releasing the full authorization",
@@ -31094,7 +31094,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "release_remaining_authorization",
+      "id": "klarna__release_remaining_authorization",
       "name": "Release Remaining Authorization",
       "description":
         "Release the remaining (uncaptured) authorized amount of an order after the final partial capture — the standard end-of-fulfillment step that frees the customer's remaining authorization",
@@ -31120,7 +31120,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_capture",
+      "id": "klarna__get_capture",
       "name": "Get Capture",
       "description": "Get a single capture of an order with its status and amounts",
       "requiresWrite": false,
@@ -31229,7 +31229,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developers.klaviyo.com/en/docs/authenticate_",
     }],
     "tools": [{
-      "id": "list_profiles",
+      "id": "klaviyo__list_profiles",
       "name": "List Profiles",
       "description": "List customer profiles",
       "requiresWrite": false,
@@ -31273,7 +31273,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_profile",
+      "id": "klaviyo__get_profile",
       "name": "Get Profile",
       "description": "Get a customer profile by ID",
       "requiresWrite": false,
@@ -31297,7 +31297,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "create_profile",
+      "id": "klaviyo__create_profile",
       "name": "Create Profile",
       "description": "Create a new customer profile",
       "requiresWrite": true,
@@ -31323,7 +31323,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_lists",
+      "id": "klaviyo__list_lists",
       "name": "List Lists",
       "description": "List marketing lists",
       "requiresWrite": false,
@@ -31355,7 +31355,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_segments",
+      "id": "klaviyo__list_segments",
       "name": "List Segments",
       "description": "List audience segments",
       "requiresWrite": false,
@@ -31378,7 +31378,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_metrics",
+      "id": "klaviyo__list_metrics",
       "name": "List Metrics",
       "description": "List tracked event metrics (e.g. Placed Order, Opened Email)",
       "requiresWrite": false,
@@ -31401,7 +31401,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_event",
+      "id": "klaviyo__create_event",
       "name": "Create Event",
       "description": "Track a custom event for a profile",
       "requiresWrite": true,
@@ -31494,7 +31494,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://langfuse.com/faq/all/where-are-langfuse-api-keys",
     }],
     "tools": [{
-      "id": "list_traces",
+      "id": "langfuse__list_traces",
       "name": "List Traces",
       "description": "List traces in the Langfuse project with optional filters",
       "requiresWrite": false,
@@ -31571,7 +31571,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_trace",
+      "id": "langfuse__get_trace",
       "name": "Get Trace",
       "description": "Get a single trace with its full observation tree and scores",
       "requiresWrite": false,
@@ -31595,7 +31595,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_observations",
+      "id": "langfuse__list_observations",
       "name": "List Observations",
       "description": "List observations (spans, generations, events) with optional filters",
       "requiresWrite": false,
@@ -31645,7 +31645,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_score",
+      "id": "langfuse__create_score",
       "name": "Create Score",
       "description": "Attach a score (evaluation result) to a trace or observation",
       "requiresWrite": true,
@@ -31756,7 +31756,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.langchain.com/langsmith/create-account-api-key",
     }],
     "tools": [{
-      "id": "list_projects",
+      "id": "langsmith__list_projects",
       "name": "List Projects",
       "description": "List tracing projects (tracer sessions) in your LangSmith workspace",
       "requiresWrite": false,
@@ -31794,7 +31794,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "query_runs",
+      "id": "langsmith__query_runs",
       "name": "Query Runs",
       "description":
         "Query traced runs with filters (project, trace filter expressions, root runs only)",
@@ -31832,7 +31832,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "runs" },
       },
     }, {
-      "id": "get_run",
+      "id": "langsmith__get_run",
       "name": "Get Run",
       "description": "Get full details of a single run, including inputs, outputs, and errors",
       "requiresWrite": false,
@@ -31844,7 +31844,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_datasets",
+      "id": "langsmith__list_datasets",
       "name": "List Datasets",
       "description": "List evaluation datasets in your LangSmith workspace",
       "requiresWrite": false,
@@ -31872,7 +31872,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_examples",
+      "id": "langsmith__list_examples",
       "name": "List Examples",
       "description": "List examples in a LangSmith dataset",
       "requiresWrite": false,
@@ -31969,7 +31969,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://launchdarkly.com/docs/home/account/api-create",
     }],
     "tools": [{
-      "id": "list_projects",
+      "id": "launchdarkly__list_projects",
       "name": "List Projects",
       "description": "List projects in the LaunchDarkly account",
       "requiresWrite": false,
@@ -31996,7 +31996,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_flags",
+      "id": "launchdarkly__list_flags",
       "name": "List Feature Flags",
       "description": "List feature flags in a project, optionally scoped to one environment",
       "requiresWrite": false,
@@ -32046,7 +32046,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_flag",
+      "id": "launchdarkly__get_flag",
       "name": "Get Feature Flag",
       "description":
         "Get a feature flag including its variations and per-environment configuration",
@@ -32075,7 +32075,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_environments",
+      "id": "launchdarkly__list_environments",
       "name": "List Environments",
       "description": "List environments in a LaunchDarkly project",
       "requiresWrite": false,
@@ -32103,7 +32103,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "toggle_flag",
+      "id": "launchdarkly__toggle_flag",
       "name": "Toggle Feature Flag",
       "description":
         "Turn a feature flag on or off in one environment using a semantic patch instruction",
@@ -32227,7 +32227,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://hire.lever.co/developer/documentation#authentication",
     }],
     "tools": [{
-      "id": "list_opportunities",
+      "id": "lever__list_opportunities",
       "name": "List Opportunities",
       "description": "List candidate opportunities",
       "requiresWrite": false,
@@ -32291,7 +32291,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_opportunity",
+      "id": "lever__get_opportunity",
       "name": "Get Opportunity",
       "description": "Get a single opportunity",
       "requiresWrite": false,
@@ -32314,7 +32314,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_postings",
+      "id": "lever__list_postings",
       "name": "List Postings",
       "description": "List job postings",
       "requiresWrite": false,
@@ -32344,7 +32344,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_posting",
+      "id": "lever__get_posting",
       "name": "Get Posting",
       "description": "Get a single job posting",
       "requiresWrite": false,
@@ -32362,7 +32362,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_stages",
+      "id": "lever__list_stages",
       "name": "List Stages",
       "description": "List pipeline stages",
       "requiresWrite": false,
@@ -32448,7 +32448,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://app.lexware.de/addons/public-api",
     }],
     "tools": [{
-      "id": "list_vouchers",
+      "id": "lexoffice__list_vouchers",
       "name": "List Vouchers",
       "description":
         "List and filter bookkeeping vouchers (sales and purchase invoices, credit notes) via the voucherlist, e.g. to find open or overdue invoices",
@@ -32514,7 +32514,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "content" },
       },
     }, {
-      "id": "get_invoice",
+      "id": "lexoffice__get_invoice",
       "name": "Get Invoice",
       "description":
         "Retrieve a single invoice with line items, totals, tax conditions, and payment status",
@@ -32532,7 +32532,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_invoice",
+      "id": "lexoffice__create_invoice",
       "name": "Create Invoice",
       "description":
         "Create a sales invoice. Created as an editable draft by default; set finalize=true to immediately open it",
@@ -32595,7 +32595,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_contacts",
+      "id": "lexoffice__list_contacts",
       "name": "List Contacts",
       "description":
         "List and filter customers and vendors, e.g. to find the contactId for an invoice",
@@ -32647,7 +32647,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "content" },
       },
     }, {
-      "id": "create_contact",
+      "id": "lexoffice__create_contact",
       "name": "Create Contact",
       "description": "Create a customer or vendor contact for use on invoices and vouchers",
       "requiresWrite": true,
@@ -32694,7 +32694,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "upload_voucher_file",
+      "id": "lexoffice__upload_voucher_file",
       "name": "Upload Voucher File",
       "description":
         "Upload a receipt image or invoice file (pdf, jpg, png, xml; max 5 MB) for bookkeeping; returns the file id and the id of the voucher created for it",
@@ -32728,7 +32728,7 @@ export const connectors: IntegrationConfig[] = [
         "contentType": "multipart/form-data",
       },
     }, {
-      "id": "download_file",
+      "id": "lexoffice__download_file",
       "name": "Download File",
       "description":
         "Download an uploaded bookkeeping voucher file (receipt/invoice image) as binary data by its file id; Content-Type and Content-Disposition response headers carry the MIME type and suggested filename. For sales voucher documents prefer the document render flow.",
@@ -32747,7 +32747,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_invoice_document",
+      "id": "lexoffice__get_invoice_document",
       "name": "Get Invoice Document",
       "description":
         "Trigger PDF rendering for an invoice and return its documentFileId, which can then be downloaded via Download File. Required for invoices created through the API with status open; draft invoices have no document file and are rejected with 406.",
@@ -32765,7 +32765,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_payments",
+      "id": "lexoffice__get_payments",
       "name": "Get Payments",
       "description":
         "Get the payment status of an invoice or voucher: open amount, paid date, and payment items — the reliable way to check who actually paid",
@@ -32866,7 +32866,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://linear.app/settings/api",
     }],
     "tools": [{
-      "id": "search_issues",
+      "id": "linear__search_issues",
       "name": "Search Issues",
       "description": "Search for Linear issues by title or description",
       "requiresWrite": false,
@@ -32906,7 +32906,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_issue",
+      "id": "linear__get_issue",
       "name": "Get Issue",
       "description": "Get detailed information about a specific Linear issue",
       "requiresWrite": false,
@@ -32927,7 +32927,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "issue" },
       },
     }, {
-      "id": "create_issue",
+      "id": "linear__create_issue",
       "name": "Create Issue",
       "description": "Create a new Linear issue in a team",
       "requiresWrite": true,
@@ -32959,7 +32959,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "issueCreate" },
       },
     }, {
-      "id": "update_issue",
+      "id": "linear__update_issue",
       "name": "Update Issue",
       "description": "Update the status, assignee, or other properties of an issue",
       "requiresWrite": true,
@@ -32978,7 +32978,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "issueUpdate" },
       },
     }, {
-      "id": "delete_issue",
+      "id": "linear__delete_issue",
       "name": "Delete Issue",
       "description":
         "Archive a Linear issue. By default this is non-permanent so canary-created issues do not remain active.",
@@ -33001,7 +33001,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "issueDelete" },
       },
     }, {
-      "id": "list_projects",
+      "id": "linear__list_projects",
       "name": "List Projects",
       "description": "List all projects in the workspace",
       "requiresWrite": false,
@@ -33057,7 +33057,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_teams",
+      "id": "linear__list_teams",
       "name": "List Teams",
       "description":
         "List Linear teams in the workspace so issues can be created in the right team",
@@ -33114,7 +33114,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_workflow_states",
+      "id": "linear__list_workflow_states",
       "name": "List Workflow States",
       "description":
         "List workflow states for a Linear team so issues can be moved to the right status",
@@ -33171,7 +33171,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_users",
+      "id": "linear__list_users",
       "name": "List Users",
       "description":
         "List Linear users in the workspace so issues can be assigned to the right person",
@@ -33199,7 +33199,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "add_comment",
+      "id": "linear__add_comment",
       "name": "Add Comment",
       "description": "Add a comment to a Linear issue",
       "requiresWrite": true,
@@ -33226,7 +33226,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "commentCreate" },
       },
     }, {
-      "id": "list_issue_labels",
+      "id": "linear__list_issue_labels",
       "name": "List Issue Labels",
       "description":
         "List Linear issue labels so the right label IDs can be applied when creating or updating issues",
@@ -33312,7 +33312,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://mailchimp.com/developer/marketing/guides/access-user-data-oauth-2/",
     }],
     "tools": [{
-      "id": "list_audiences",
+      "id": "mailchimp__list_audiences",
       "name": "List Audiences",
       "description": "List audiences (lists) in the Mailchimp account",
       "requiresWrite": false,
@@ -33354,7 +33354,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_members",
+      "id": "mailchimp__list_members",
       "name": "List Members",
       "description": "List members of a Mailchimp audience",
       "requiresWrite": false,
@@ -33396,7 +33396,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_member",
+      "id": "mailchimp__get_member",
       "name": "Get Member",
       "description":
         "Get a single audience member by email (MD5 hash of the lowercase address) or contact ID",
@@ -33428,7 +33428,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "add_member",
+      "id": "mailchimp__add_member",
       "name": "Add Member",
       "description": "Add a new member to a Mailchimp audience",
       "requiresWrite": true,
@@ -33471,7 +33471,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_campaigns",
+      "id": "mailchimp__list_campaigns",
       "name": "List Campaigns",
       "description": "List campaigns in the Mailchimp account",
       "requiresWrite": false,
@@ -33574,7 +33574,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://www.metabase.com/docs/latest/people-and-groups/api-keys",
     }],
     "tools": [{
-      "id": "list_databases",
+      "id": "metabase__list_databases",
       "name": "List Databases",
       "description": "List databases connected to the Metabase instance",
       "requiresWrite": false,
@@ -33603,7 +33603,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_cards",
+      "id": "metabase__list_cards",
       "name": "List Questions",
       "description": "List saved questions (cards) on the Metabase instance",
       "requiresWrite": false,
@@ -33626,7 +33626,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "run_card_query",
+      "id": "metabase__run_card_query",
       "name": "Run Question Query",
       "description": "Execute a saved question (card) and return its query results",
       "requiresWrite": false,
@@ -33656,7 +33656,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search",
+      "id": "metabase__search",
       "name": "Search",
       "description": "Search questions, dashboards, collections, and tables across the instance",
       "requiresWrite": false,
@@ -33680,7 +33680,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_dashboard",
+      "id": "metabase__get_dashboard",
       "name": "Get Dashboard",
       "description": "Get a dashboard and its cards by ID",
       "requiresWrite": false,
@@ -33703,7 +33703,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_collections",
+      "id": "metabase__list_collections",
       "name": "List Collections",
       "description": "List collections that organize questions and dashboards",
       "requiresWrite": false,
@@ -33787,7 +33787,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.mindee.com/integrations/api-keys",
     }],
     "tools": [{
-      "id": "parse_invoice",
+      "id": "mindee__parse_invoice",
       "name": "Parse Invoice",
       "description":
         "Extract structured fields (supplier, customer, line items, totals, taxes, dates, payment details) from an invoice PDF or image using the Invoice OCR model. Consumes a page of your Mindee quota per call.",
@@ -33808,7 +33808,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "document" },
       },
     }, {
-      "id": "parse_receipt",
+      "id": "mindee__parse_receipt",
       "name": "Parse Receipt",
       "description":
         "Extract structured fields (merchant, date, time, category, line items, taxes, total amounts, tip) from an expense receipt photo or PDF using the Receipt OCR model. Consumes a page of your Mindee quota per call.",
@@ -33829,7 +33829,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "document" },
       },
     }, {
-      "id": "parse_financial_document",
+      "id": "mindee__parse_financial_document",
       "name": "Parse Financial Document",
       "description":
         "Parse a document that may be either an invoice or a receipt: the Financial Document model classifies it and returns the union of invoice and receipt fields. Use this when the document type is unknown. Consumes a page of your Mindee quota per call.",
@@ -33917,7 +33917,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.mistral.ai/getting-started/quickstart/",
     }],
     "tools": [{
-      "id": "list_models",
+      "id": "mistral__list_models",
       "name": "List Models",
       "description": "List the Mistral models available to the API key",
       "requiresWrite": false,
@@ -33937,7 +33937,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_model",
+      "id": "mistral__get_model",
       "name": "Get Model",
       "description": "Get details about a specific Mistral model",
       "requiresWrite": false,
@@ -33954,7 +33954,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_chat_completion",
+      "id": "mistral__create_chat_completion",
       "name": "Create Chat Completion",
       "description": "Generate a chat completion from a list of messages",
       "requiresWrite": true,
@@ -33980,7 +33980,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_embedding",
+      "id": "mistral__create_embedding",
       "name": "Create Embedding",
       "description": "Create embedding vectors for input text",
       "requiresWrite": true,
@@ -34099,12 +34099,12 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.mixpanel.com/docs/admin/organizations-projects/manage-projects",
     }],
     "tools": [{
-      "id": "track_event",
+      "id": "mixpanel__track_event",
       "name": "Track Event",
       "description": "Track a custom event in Mixpanel with properties",
       "requiresWrite": true,
     }, {
-      "id": "query_events",
+      "id": "mixpanel__query_events",
       "name": "Query Events",
       "description": "Query and export event data from Mixpanel",
       "requiresWrite": false,
@@ -34156,7 +34156,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_funnel",
+      "id": "mixpanel__get_funnel",
       "name": "Get Funnel",
       "description": "Retrieve funnel analysis data to understand conversion rates",
       "requiresWrite": false,
@@ -34203,7 +34203,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_funnels",
+      "id": "mixpanel__list_funnels",
       "name": "List Funnels",
       "description": "List saved funnels with their names and funnel IDs",
       "requiresWrite": false,
@@ -34227,7 +34227,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_retention",
+      "id": "mixpanel__get_retention",
       "name": "Get Retention",
       "description": "Analyze user retention cohorts over time",
       "requiresWrite": false,
@@ -34284,7 +34284,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_cohorts",
+      "id": "mixpanel__list_cohorts",
       "name": "List Cohorts",
       "description": "List all user cohorts defined in your Mixpanel project",
       "requiresWrite": false,
@@ -34373,7 +34373,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.mollie.com/reference/authentication",
     }],
     "tools": [{
-      "id": "list_payments",
+      "id": "mollie__list_payments",
       "name": "List Payments",
       "description":
         "List Mollie payments in reverse chronological order to review recent transactions",
@@ -34402,7 +34402,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "_embedded.payments" },
       },
     }, {
-      "id": "get_payment",
+      "id": "mollie__get_payment",
       "name": "Get Payment",
       "description": "Retrieve a single Mollie payment with its current status and details",
       "requiresWrite": false,
@@ -34425,7 +34425,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_payment",
+      "id": "mollie__create_payment",
       "name": "Create Payment",
       "description": "Create a Mollie payment and get a checkout URL to send to the customer",
       "requiresWrite": true,
@@ -34470,7 +34470,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_customers",
+      "id": "mollie__list_customers",
       "name": "List Customers",
       "description": "List Mollie customers to find customer IDs for payments or refund context",
       "requiresWrite": false,
@@ -34493,7 +34493,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "_embedded.customers" },
       },
     }, {
-      "id": "list_payment_methods",
+      "id": "mollie__list_payment_methods",
       "name": "List Payment Methods",
       "description":
         "List the payment methods enabled on your Mollie profile, e.g. to pick a valid method for a new payment",
@@ -34522,7 +34522,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "_embedded.methods" },
       },
     }, {
-      "id": "create_payment_link",
+      "id": "mollie__create_payment_link",
       "name": "Create Payment Link",
       "description":
         "Create a shareable hosted payment link the customer can open to pay, without building a checkout",
@@ -34563,7 +34563,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_payment_refunds",
+      "id": "mollie__list_payment_refunds",
       "name": "List Payment Refunds",
       "description": "List the refunds created for a payment to review refund status and history",
       "requiresWrite": false,
@@ -34592,7 +34592,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "_embedded.refunds" },
       },
     }, {
-      "id": "create_refund",
+      "id": "mollie__create_refund",
       "name": "Create Refund",
       "description": "Refund all or part of a Mollie payment back to the customer",
       "requiresWrite": true,
@@ -34704,7 +34704,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.monday.com/apps/docs/oauth",
     }],
     "tools": [{
-      "id": "list_boards",
+      "id": "monday__list_boards",
       "name": "List Boards",
       "description": "List boards in the monday.com account",
       "requiresWrite": false,
@@ -34747,7 +34747,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_items",
+      "id": "monday__list_items",
       "name": "List Items",
       "description": "List items on a monday.com board with their column values",
       "requiresWrite": false,
@@ -34779,7 +34779,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "boards" },
       },
     }, {
-      "id": "get_item",
+      "id": "monday__get_item",
       "name": "Get Item",
       "description": "Get a monday.com item by ID with its column values and updates",
       "requiresWrite": false,
@@ -34795,7 +34795,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "items" },
       },
     }, {
-      "id": "create_item",
+      "id": "monday__create_item",
       "name": "Create Item",
       "description": "Create a new item on a monday.com board",
       "requiresWrite": true,
@@ -34833,7 +34833,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "create_item" },
       },
     }, {
-      "id": "update_column_values",
+      "id": "monday__update_column_values",
       "name": "Update Column Values",
       "description": "Update one or more column values on an existing monday.com item",
       "requiresWrite": true,
@@ -34942,7 +34942,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://www.mongodb.com/docs/atlas/api/service-accounts-overview/",
     }],
     "tools": [{
-      "id": "list_projects",
+      "id": "mongodb-atlas__list_projects",
       "name": "List Projects",
       "description": "List Atlas projects (groups) the service account can access",
       "requiresWrite": false,
@@ -34983,7 +34983,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_clusters",
+      "id": "mongodb-atlas__list_clusters",
       "name": "List Clusters",
       "description": "List clusters in an Atlas project",
       "requiresWrite": false,
@@ -35038,7 +35038,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_cluster",
+      "id": "mongodb-atlas__get_cluster",
       "name": "Get Cluster",
       "description": "Get details of a cluster, including state and connection strings",
       "requiresWrite": false,
@@ -35068,7 +35068,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_database_users",
+      "id": "mongodb-atlas__list_database_users",
       "name": "List Database Users",
       "description": "List database users configured in an Atlas project",
       "requiresWrite": false,
@@ -35203,7 +35203,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developers.getmoss.com/",
     }],
     "tools": [{
-      "id": "list_expenses",
+      "id": "moss__list_expenses",
       "name": "List Expenses",
       "description":
         "List expenses — card transactions, invoices, and reimbursements — with status, export status, and date filters; the basis for accounting exports",
@@ -35284,7 +35284,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_bank_transactions",
+      "id": "moss__search_bank_transactions",
       "name": "Search Bank Transactions",
       "description":
         "Search bank transactions of a Moss bank account within a booking-date window (read-only search query)",
@@ -35311,14 +35311,14 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_bank_accounts",
+      "id": "moss__list_bank_accounts",
       "name": "List Bank Accounts",
       "description":
         "List the company's bank accounts in Moss (use the IDs with Search Bank Transactions)",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://public-api.getmoss.com/v1/bank-accounts" },
     }, {
-      "id": "search_receipt_files",
+      "id": "moss__search_receipt_files",
       "name": "Search Receipt Files",
       "description":
         "Find receipt and invoice files attached to specific expenses (read-only search query); download via the returned file IDs",
@@ -35340,7 +35340,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_expense_accounts",
+      "id": "moss__list_expense_accounts",
       "name": "List Expense Accounts",
       "description":
         "List the chart of accounts used for ledger posting, for mapping expenses into your accounting system",
@@ -35369,7 +35369,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_suppliers",
+      "id": "moss__list_suppliers",
       "name": "List Suppliers",
       "description":
         "List supplier master data for spend-by-vendor analysis and accounting export enrichment",
@@ -35404,7 +35404,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_file_content",
+      "id": "moss__get_file_content",
       "name": "Get File Content",
       "description":
         "Download the binary content of a receipt or invoice file (application/octet-stream) using a file ID from Search Receipt Files",
@@ -35422,7 +35422,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_bank_account_balance",
+      "id": "moss__get_bank_account_balance",
       "name": "Get Bank Account Balance",
       "description": "Get the current balance of a Moss bank account for liquidity overviews",
       "requiresWrite": false,
@@ -35439,7 +35439,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_tax_rates",
+      "id": "moss__list_tax_rates",
       "name": "List Tax Rates",
       "description":
         "List VAT/tax rate master data for mapping expenses into the accounting system",
@@ -35556,7 +35556,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://neo4j.com/docs/query-api/current/",
     }],
     "tools": [{
-      "id": "run_cypher_query",
+      "id": "neo4j__run_cypher_query",
       "name": "Run Cypher Query",
       "description":
         "Execute a read-only Cypher query (MATCH ... RETURN) in an implicit transaction and get back fields and result rows — use for lookups, traversals, and GraphRAG retrieval. Note: the Query API does not enforce read-only access, so only submit read statements here (use a read-only database user to guarantee no writes)",
@@ -35594,7 +35594,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "run_cypher_write",
+      "id": "neo4j__run_cypher_write",
       "name": "Run Cypher Write",
       "description":
         "Execute a Cypher statement that modifies the graph (CREATE, MERGE, SET, DELETE) in an implicit transaction",
@@ -35718,7 +35718,7 @@ export const connectors: IntegrationConfig[] = [
     }],
     "npmDependencies": { "pg": "^8.13.1" },
     "tools": [{
-      "id": "list_projects",
+      "id": "neon__list_projects",
       "name": "List Projects",
       "description": "List all Neon projects in your account",
       "requiresWrite": false,
@@ -35755,7 +35755,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_project",
+      "id": "neon__get_project",
       "name": "Get Project",
       "description": "Get details of a specific Neon project",
       "requiresWrite": false,
@@ -35772,7 +35772,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_branches",
+      "id": "neon__list_branches",
       "name": "List Branches",
       "description": "List all branches for a specific project",
       "requiresWrite": false,
@@ -35804,7 +35804,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_branch",
+      "id": "neon__create_branch",
       "name": "Create Branch",
       "description": "Create a new branch in a Neon project",
       "requiresWrite": true,
@@ -35833,7 +35833,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_databases",
+      "id": "neon__list_databases",
       "name": "List Databases",
       "description": "List databases on a specific branch of a project",
       "requiresWrite": false,
@@ -35857,17 +35857,17 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "query_database",
+      "id": "neon__query_database",
       "name": "Query Database",
       "description": "Execute SQL queries against the connected database",
       "requiresWrite": false,
     }, {
-      "id": "list_tables",
+      "id": "neon__list_tables",
       "name": "List Tables",
       "description": "List all tables in the connected database",
       "requiresWrite": false,
     }, {
-      "id": "describe_table",
+      "id": "neon__describe_table",
       "name": "Describe Table",
       "description": "Get detailed schema information for a specific table",
       "requiresWrite": false,
@@ -35917,7 +35917,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.netlify.com/api/get-started/#authentication",
     }],
     "tools": [{
-      "id": "list_sites",
+      "id": "netlify__list_sites",
       "name": "List Sites",
       "description": "List all sites the authenticated user has access to",
       "requiresWrite": false,
@@ -35959,7 +35959,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_site",
+      "id": "netlify__get_site",
       "name": "Get Site",
       "description": "Get a site by ID or custom domain",
       "requiresWrite": false,
@@ -35976,7 +35976,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_deploys",
+      "id": "netlify__list_deploys",
       "name": "List Deploys",
       "description": "List deploys for a site",
       "requiresWrite": false,
@@ -36029,7 +36029,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_deploy",
+      "id": "netlify__get_deploy",
       "name": "Get Deploy",
       "description": "Get a deploy by ID",
       "requiresWrite": false,
@@ -36046,7 +36046,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "trigger_build",
+      "id": "netlify__trigger_build",
       "name": "Trigger Build",
       "description": "Trigger a new build of a site from its linked repository",
       "requiresWrite": true,
@@ -36070,7 +36070,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_form_submissions",
+      "id": "netlify__list_form_submissions",
       "name": "List Form Submissions",
       "description": "List verified form submissions across all forms of a site",
       "requiresWrite": false,
@@ -36191,7 +36191,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/",
     }],
     "tools": [{
-      "id": "run_nrql_query",
+      "id": "new-relic__run_nrql_query",
       "name": "Run NRQL Query",
       "description": "Run an NRQL query against a New Relic account and return the results",
       "requiresWrite": false,
@@ -36218,7 +36218,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "actor.account.nrql.results" },
       },
     }, {
-      "id": "search_entities",
+      "id": "new-relic__search_entities",
       "name": "Search Entities",
       "description":
         "Search monitored entities (apps, hosts, services) with an entity search query",
@@ -36256,7 +36256,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_entity",
+      "id": "new-relic__get_entity",
       "name": "Get Entity",
       "description": "Get an entity's details and tags by GUID",
       "requiresWrite": false,
@@ -36277,7 +36277,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "actor.entity" },
       },
     }, {
-      "id": "list_issues",
+      "id": "new-relic__list_issues",
       "name": "List Issues",
       "description":
         "List alert issues from the last day in an account (queries the NrAiIssue event type via NRQL)",
@@ -36370,7 +36370,7 @@ export const connectors: IntegrationConfig[] = [
         "https://github.com/northdata/api/blob/master/doc/data-api-userguide/data-api-userguide.md",
     }],
     "tools": [{
-      "id": "search_companies",
+      "id": "north-data__search_companies",
       "name": "Search Companies",
       "description":
         "Fuzzy universal search for companies (and optionally persons) by free-text query, e.g. 'Siemens, München'. Use this to find a company before fetching its details.",
@@ -36415,7 +36415,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_company",
+      "id": "north-data__get_company",
       "name": "Get Company",
       "description":
         "Retrieve a single company's profile (register info, address, status, financial indicators). Identify it either by name + address (city), or by registerId + registerCity, or by companyId from a previous search.",
@@ -36460,7 +36460,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "power_search",
+      "id": "north-data__power_search",
       "name": "Power Search",
       "description":
         "Structured company search with filters for location radius, industry segment, legal form, status, and countries. Billed per unique company returned, so keep filters narrow.",
@@ -36507,7 +36507,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "suggest",
+      "id": "north-data__suggest",
       "name": "Suggest Companies",
       "description":
         "Auto-complete suggestions for a partial company or person name. Free of charge — suggested companies do not count toward the monthly quota, so use this as a cheap first pass before Get Company.",
@@ -36550,7 +36550,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_person",
+      "id": "north-data__get_person",
       "name": "Get Person",
       "description":
         "Look up a person (officer, shareholder, representative) by name and address or by a person ID from a previous search result. Billed like company lookups.",
@@ -36673,7 +36673,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://www.notion.so/my-integrations",
     }],
     "tools": [{
-      "id": "search_notion",
+      "id": "notion__search_notion",
       "name": "Search Notion",
       "description": "Search pages and databases in the workspace",
       "requiresWrite": false,
@@ -36702,7 +36702,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "read_page",
+      "id": "notion__read_page",
       "name": "Read Page",
       "description": "Read the content of a Notion page",
       "requiresWrite": false,
@@ -36733,7 +36733,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "create_page",
+      "id": "notion__create_page",
       "name": "Create Page",
       "description": "Create a new page in a database or as a subpage",
       "requiresWrite": true,
@@ -36759,7 +36759,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "query_database",
+      "id": "notion__query_database",
       "name": "Query Database",
       "description": "Query a Notion database with filters and sorts",
       "requiresWrite": false,
@@ -36793,7 +36793,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "get_page",
+      "id": "notion__get_page",
       "name": "Get Page Metadata",
       "description":
         "Retrieve Notion page metadata and properties without fetching child block content",
@@ -36817,7 +36817,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_database",
+      "id": "notion__get_database",
       "name": "Get Database",
       "description": "Retrieve Notion database metadata, title, and property schema",
       "requiresWrite": false,
@@ -36840,7 +36840,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "append_blocks",
+      "id": "notion__append_blocks",
       "name": "Append Blocks",
       "description": "Append child blocks to a Notion page or block",
       "requiresWrite": true,
@@ -36874,7 +36874,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_page",
+      "id": "notion__update_page",
       "name": "Update Page",
       "description": "Update Notion page properties or archive/unarchive a page",
       "requiresWrite": true,
@@ -36903,7 +36903,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_database",
+      "id": "notion__create_database",
       "name": "Create Database",
       "description": "Create a new Notion database as a subpage with a property schema",
       "requiresWrite": true,
@@ -36942,7 +36942,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_users",
+      "id": "notion__list_users",
       "name": "List Users",
       "description":
         "List users in the Notion workspace so pages can mention or attribute the right person",
@@ -37031,7 +37031,7 @@ export const connectors: IntegrationConfig[] = [
         "https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade",
     }],
     "tools": [{
-      "id": "list_files",
+      "id": "onedrive__list_files",
       "name": "List Files",
       "description": "List files and folders in a OneDrive folder",
       "requiresWrite": false,
@@ -37053,7 +37053,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_files",
+      "id": "onedrive__search_files",
       "name": "Search Files",
       "description": "Search for files and folders in OneDrive by name or content",
       "requiresWrite": false,
@@ -37076,7 +37076,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "upload_file",
+      "id": "onedrive__upload_file",
       "name": "Upload File",
       "description": "Upload or update a file in OneDrive",
       "requiresWrite": true,
@@ -37108,7 +37108,7 @@ export const connectors: IntegrationConfig[] = [
         "contentType": "application/octet-stream",
       },
     }, {
-      "id": "download_file",
+      "id": "onedrive__download_file",
       "name": "Download File",
       "description": "Download file content from OneDrive",
       "requiresWrite": false,
@@ -37125,7 +37125,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_file",
+      "id": "onedrive__get_file",
       "name": "Get File",
       "description": "Get metadata for a OneDrive file or folder",
       "requiresWrite": false,
@@ -37147,7 +37147,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_folder",
+      "id": "onedrive__create_folder",
       "name": "Create Folder",
       "description": "Create a new folder in OneDrive",
       "requiresWrite": true,
@@ -37177,7 +37177,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_file",
+      "id": "onedrive__delete_file",
       "name": "Delete File",
       "description": "Delete a file or folder from OneDrive (moves it to the recycle bin)",
       "requiresWrite": true,
@@ -37246,7 +37246,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://platform.openai.com/api-keys",
     }],
     "tools": [{
-      "id": "list_models",
+      "id": "openai__list_models",
       "name": "List Models",
       "description": "List the models available to the API key",
       "requiresWrite": false,
@@ -37264,7 +37264,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_model",
+      "id": "openai__get_model",
       "name": "Get Model",
       "description": "Get details about a specific model",
       "requiresWrite": false,
@@ -37281,7 +37281,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_response",
+      "id": "openai__create_response",
       "name": "Create Response",
       "description": "Generate a model response using the OpenAI Responses API",
       "requiresWrite": true,
@@ -37311,7 +37311,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_chat_completion",
+      "id": "openai__create_chat_completion",
       "name": "Create Chat Completion",
       "description": "Generate a chat completion from a list of messages",
       "requiresWrite": true,
@@ -37337,7 +37337,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_embedding",
+      "id": "openai__create_embedding",
       "name": "Create Embedding",
       "description": "Create an embedding vector for input text",
       "requiresWrite": true,
@@ -37358,7 +37358,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "generate_image",
+      "id": "openai__generate_image",
       "name": "Generate Image",
       "description": "Generate an image from a text prompt",
       "requiresWrite": true,
@@ -37381,7 +37381,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "upload_file",
+      "id": "openai__upload_file",
       "name": "Upload File",
       "description":
         "Upload a file for use with assistants, batch, fine-tune, vision, user_data, or evals",
@@ -37415,7 +37415,7 @@ export const connectors: IntegrationConfig[] = [
         "contentType": "multipart/form-data",
       },
     }, {
-      "id": "list_files",
+      "id": "openai__list_files",
       "name": "List Files",
       "description": "List files uploaded to the organization, optionally filtered by purpose",
       "requiresWrite": false,
@@ -37459,7 +37459,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_file",
+      "id": "openai__get_file",
       "name": "Get File",
       "description": "Get metadata about an uploaded file by ID",
       "requiresWrite": false,
@@ -37476,7 +37476,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_file",
+      "id": "openai__delete_file",
       "name": "Delete File",
       "description": "Delete an uploaded file and remove it from all vector stores",
       "requiresWrite": true,
@@ -37493,7 +37493,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_usage_completions",
+      "id": "openai__get_usage_completions",
       "name": "Get Completions Usage",
       "description":
         "Get token usage for completions across the organization, bucketed over time. Requires an organization admin API key (created under Settings → Organization → Admin keys) set as OPENAI_API_KEY — a regular project key returns 401",
@@ -37538,7 +37538,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_costs",
+      "id": "openai__get_costs",
       "name": "Get Costs",
       "description":
         "Get daily spend (in USD) for the organization, bucketed by day. Requires an organization admin API key (created under Settings → Organization → Admin keys) set as OPENAI_API_KEY — a regular project key returns 401",
@@ -37577,7 +37577,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_file_content",
+      "id": "openai__get_file_content",
       "name": "Get File Content",
       "description":
         "Download the raw contents of an uploaded file by ID — required to read batch output files and other generated artifacts",
@@ -37595,7 +37595,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_usage_embeddings",
+      "id": "openai__get_usage_embeddings",
       "name": "Get Embeddings Usage",
       "description":
         "Get token usage for embeddings across the organization, bucketed over time. Requires an organization admin API key (created under Settings → Organization → Admin keys) set as OPENAI_API_KEY — a regular project key returns 401",
@@ -37715,7 +37715,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://openrouter.ai/settings/keys",
     }],
     "tools": [{
-      "id": "list_models",
+      "id": "openrouter__list_models",
       "name": "List Models",
       "description": "List the models available through OpenRouter",
       "requiresWrite": false,
@@ -37733,7 +37733,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_chat_completion",
+      "id": "openrouter__create_chat_completion",
       "name": "Create Chat Completion",
       "description": "Generate a chat completion from any OpenRouter model",
       "requiresWrite": true,
@@ -37759,7 +37759,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_generation",
+      "id": "openrouter__get_generation",
       "name": "Get Generation",
       "description": "Get metadata, token counts, and cost for a past generation by ID",
       "requiresWrite": false,
@@ -37776,7 +37776,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_key",
+      "id": "openrouter__get_key",
       "name": "Get Current Key",
       "description":
         "Get the current API key's label, credit usage (total/daily/weekly/monthly in USD), spend limit, remaining limit, and free-tier status — works with the regular inference key",
@@ -37787,7 +37787,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_credits",
+      "id": "openrouter__get_credits",
       "name": "Get Credits",
       "description":
         "Get total credits purchased and used for the account (OpenRouter requires a management key for this endpoint)",
@@ -37883,7 +37883,7 @@ export const connectors: IntegrationConfig[] = [
         "https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade",
     }],
     "tools": [{
-      "id": "list_emails",
+      "id": "outlook__list_emails",
       "name": "List Emails",
       "description": "List recent emails from inbox or a specific folder",
       "requiresWrite": false,
@@ -37949,7 +37949,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_email",
+      "id": "outlook__get_email",
       "name": "Get Email",
       "description": "Get detailed information about a specific email",
       "requiresWrite": false,
@@ -37973,7 +37973,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "send_email",
+      "id": "outlook__send_email",
       "name": "Send Email",
       "description": "Send a new email message",
       "requiresWrite": true,
@@ -37995,7 +37995,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_emails",
+      "id": "outlook__search_emails",
       "name": "Search Emails",
       "description": "Search emails by query, subject, sender, or date",
       "requiresWrite": false,
@@ -38056,7 +38056,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_folders",
+      "id": "outlook__list_folders",
       "name": "List Folders",
       "description": "List all mail folders in the mailbox",
       "requiresWrite": false,
@@ -38096,7 +38096,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_folder",
+      "id": "outlook__get_folder",
       "name": "Get Folder",
       "description": "Get metadata for a mail folder",
       "requiresWrite": false,
@@ -38113,7 +38113,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_folder",
+      "id": "outlook__create_folder",
       "name": "Create Folder",
       "description": "Create a mail folder",
       "requiresWrite": true,
@@ -38129,7 +38129,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_folder",
+      "id": "outlook__update_folder",
       "name": "Update Folder",
       "description": "Rename a mail folder",
       "requiresWrite": true,
@@ -38153,7 +38153,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_folder",
+      "id": "outlook__delete_folder",
       "name": "Delete Folder",
       "description": "Delete a mail folder",
       "requiresWrite": true,
@@ -38170,7 +38170,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "mark_email_read",
+      "id": "outlook__mark_email_read",
       "name": "Mark Email Read",
       "description": "Mark an email as read",
       "requiresWrite": true,
@@ -38188,7 +38188,7 @@ export const connectors: IntegrationConfig[] = [
         "body": { "isRead": { "type": "boolean", "description": "Read state", "default": true } },
       },
     }, {
-      "id": "mark_email_unread",
+      "id": "outlook__mark_email_unread",
       "name": "Mark Email Unread",
       "description": "Mark an email as unread",
       "requiresWrite": true,
@@ -38206,7 +38206,7 @@ export const connectors: IntegrationConfig[] = [
         "body": { "isRead": { "type": "boolean", "description": "Read state", "default": false } },
       },
     }, {
-      "id": "delete_email",
+      "id": "outlook__delete_email",
       "name": "Delete Email",
       "description": "Delete an email message",
       "requiresWrite": true,
@@ -38223,7 +38223,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "move_email",
+      "id": "outlook__move_email",
       "name": "Move Email",
       "description": "Move an email to another folder",
       "requiresWrite": true,
@@ -38247,7 +38247,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "archive_email",
+      "id": "outlook__archive_email",
       "name": "Archive Email",
       "description": "Move an email to the archive folder",
       "requiresWrite": true,
@@ -38271,7 +38271,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "flag_email",
+      "id": "outlook__flag_email",
       "name": "Flag Email",
       "description": "Set a follow-up flag on an email",
       "requiresWrite": true,
@@ -38295,7 +38295,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "clear_email_flag",
+      "id": "outlook__clear_email_flag",
       "name": "Clear Email Flag",
       "description": "Clear the follow-up flag on an email",
       "requiresWrite": true,
@@ -38319,7 +38319,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "categorize_email",
+      "id": "outlook__categorize_email",
       "name": "Categorize Email",
       "description": "Replace the categories on an email",
       "requiresWrite": true,
@@ -38343,7 +38343,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_categories",
+      "id": "outlook__list_categories",
       "name": "List Categories",
       "description": "List Outlook master categories",
       "requiresWrite": false,
@@ -38362,7 +38362,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_category",
+      "id": "outlook__create_category",
       "name": "Create Category",
       "description": "Create an Outlook master category",
       "requiresWrite": true,
@@ -38379,7 +38379,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_category",
+      "id": "outlook__update_category",
       "name": "Update Category",
       "description": "Update an Outlook master category color",
       "requiresWrite": true,
@@ -38399,7 +38399,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_category",
+      "id": "outlook__delete_category",
       "name": "Delete Category",
       "description": "Delete an Outlook master category",
       "requiresWrite": true,
@@ -38416,7 +38416,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_draft",
+      "id": "outlook__create_draft",
       "name": "Create Draft",
       "description": "Create a draft email message",
       "requiresWrite": true,
@@ -38446,7 +38446,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_drafts",
+      "id": "outlook__list_drafts",
       "name": "List Drafts",
       "description": "List draft email messages",
       "requiresWrite": false,
@@ -38504,7 +38504,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_draft",
+      "id": "outlook__get_draft",
       "name": "Get Draft",
       "description": "Get a draft message",
       "requiresWrite": false,
@@ -38528,7 +38528,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_draft",
+      "id": "outlook__update_draft",
       "name": "Update Draft",
       "description": "Update a draft email message",
       "requiresWrite": true,
@@ -38561,7 +38561,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "send_draft",
+      "id": "outlook__send_draft",
       "name": "Send Draft",
       "description": "Send a draft email message",
       "requiresWrite": true,
@@ -38578,7 +38578,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_draft",
+      "id": "outlook__delete_draft",
       "name": "Delete Draft",
       "description": "Delete a draft email message",
       "requiresWrite": true,
@@ -38595,7 +38595,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "reply_email",
+      "id": "outlook__reply_email",
       "name": "Reply Email",
       "description": "Reply to an email",
       "requiresWrite": true,
@@ -38615,7 +38615,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "reply_all_email",
+      "id": "outlook__reply_all_email",
       "name": "Reply All Email",
       "description": "Reply all to an email",
       "requiresWrite": true,
@@ -38635,7 +38635,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "forward_email",
+      "id": "outlook__forward_email",
       "name": "Forward Email",
       "description": "Forward an email",
       "requiresWrite": true,
@@ -38660,7 +38660,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_reply_draft",
+      "id": "outlook__create_reply_draft",
       "name": "Create Reply Draft",
       "description": "Create a reply draft for an email",
       "requiresWrite": true,
@@ -38677,7 +38677,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_reply_all_draft",
+      "id": "outlook__create_reply_all_draft",
       "name": "Create Reply All Draft",
       "description": "Create a reply-all draft for an email",
       "requiresWrite": true,
@@ -38694,7 +38694,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_forward_draft",
+      "id": "outlook__create_forward_draft",
       "name": "Create Forward Draft",
       "description": "Create a forward draft for an email",
       "requiresWrite": true,
@@ -38711,7 +38711,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_attachments",
+      "id": "outlook__list_attachments",
       "name": "List Attachments",
       "description": "List attachments for an email message",
       "requiresWrite": false,
@@ -38745,7 +38745,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_attachment",
+      "id": "outlook__get_attachment",
       "name": "Get Attachment",
       "description": "Get metadata and content for an email attachment",
       "requiresWrite": false,
@@ -38769,7 +38769,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "add_attachment_to_message",
+      "id": "outlook__add_attachment_to_message",
       "name": "Add Attachment To Message",
       "description": "Add a small attachment to a draft message",
       "requiresWrite": true,
@@ -38805,7 +38805,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_conversation_messages",
+      "id": "outlook__list_conversation_messages",
       "name": "List Conversation Messages",
       "description": "List messages in an Outlook conversation",
       "requiresWrite": false,
@@ -38864,7 +38864,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_threads",
+      "id": "outlook__list_threads",
       "name": "List Threads",
       "description":
         "List recent Outlook conversation threads for request-desk triage. Returns one representative message per conversationId; pass that value as thread_id to the template get-thread tool or use it in get_thread's filter.",
@@ -38935,7 +38935,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_thread",
+      "id": "outlook__get_thread",
       "name": "Get Thread",
       "description":
         "Get Outlook messages in a conversation. Pass a Microsoft Graph OData filter such as conversationId eq 'AAQk...'.",
@@ -38969,7 +38969,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "list_shared_mailbox_emails",
+      "id": "outlook__list_shared_mailbox_emails",
       "name": "List Shared Mailbox Emails",
       "description":
         "List messages from a shared or delegated mailbox that the signed-in Microsoft account can access",
@@ -39042,7 +39042,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_shared_mailbox_emails",
+      "id": "outlook__search_shared_mailbox_emails",
       "name": "Search Shared Mailbox Emails",
       "description":
         "Search messages in a shared or delegated mailbox that the signed-in Microsoft account can access",
@@ -39110,7 +39110,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "find_group_by_mail",
+      "id": "outlook__find_group_by_mail",
       "name": "Find Group By Mail",
       "description":
         "Find a Microsoft 365 group by primary email address before reading its group inbox threads",
@@ -39141,7 +39141,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "list_group_threads",
+      "id": "outlook__list_group_threads",
       "name": "List Group Threads",
       "description": "List Microsoft 365 group inbox conversation threads",
       "requiresWrite": false,
@@ -39189,7 +39189,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_group_thread_posts",
+      "id": "outlook__list_group_thread_posts",
       "name": "List Group Thread Posts",
       "description": "List posts from a Microsoft 365 group inbox conversation thread",
       "requiresWrite": false,
@@ -39246,7 +39246,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_calendars",
+      "id": "outlook__list_calendars",
       "name": "List Calendars",
       "description": "List Outlook calendars",
       "requiresWrite": false,
@@ -39281,7 +39281,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_calendar",
+      "id": "outlook__get_calendar",
       "name": "Get Calendar",
       "description": "Get metadata for an Outlook calendar",
       "requiresWrite": false,
@@ -39298,7 +39298,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_calendar",
+      "id": "outlook__create_calendar",
       "name": "Create Calendar",
       "description": "Create an Outlook calendar",
       "requiresWrite": true,
@@ -39308,7 +39308,7 @@ export const connectors: IntegrationConfig[] = [
         "body": { "name": { "type": "string", "description": "Calendar name", "required": true } },
       },
     }, {
-      "id": "update_calendar",
+      "id": "outlook__update_calendar",
       "name": "Update Calendar",
       "description": "Update an Outlook calendar",
       "requiresWrite": true,
@@ -39329,7 +39329,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_calendar",
+      "id": "outlook__delete_calendar",
       "name": "Delete Calendar",
       "description": "Delete an Outlook calendar",
       "requiresWrite": true,
@@ -39346,7 +39346,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_events",
+      "id": "outlook__list_events",
       "name": "List Events",
       "description": "List events from a specific Outlook calendar",
       "requiresWrite": false,
@@ -39406,7 +39406,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_calendar_view",
+      "id": "outlook__list_calendar_view",
       "name": "List Calendar View",
       "description": "List occurrences in a calendar time window",
       "requiresWrite": false,
@@ -39471,7 +39471,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_event",
+      "id": "outlook__get_event",
       "name": "Get Event",
       "description": "Get details for an Outlook event",
       "requiresWrite": false,
@@ -39495,7 +39495,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_event",
+      "id": "outlook__create_event",
       "name": "Create Event",
       "description": "Create an Outlook calendar event",
       "requiresWrite": true,
@@ -39545,7 +39545,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_event",
+      "id": "outlook__update_event",
       "name": "Update Event",
       "description": "Update an Outlook calendar event",
       "requiresWrite": true,
@@ -39601,7 +39601,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_event",
+      "id": "outlook__delete_event",
       "name": "Delete Event",
       "description": "Delete an Outlook calendar event",
       "requiresWrite": true,
@@ -39618,7 +39618,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "respond_to_event",
+      "id": "outlook__respond_to_event",
       "name": "Respond To Event",
       "description": "Accept, tentatively accept, or decline an event invitation",
       "requiresWrite": true,
@@ -39649,7 +39649,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_event_instances",
+      "id": "outlook__get_event_instances",
       "name": "Get Event Instances",
       "description": "List instances of a recurring event in a time window",
       "requiresWrite": false,
@@ -39714,7 +39714,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_event_attachments",
+      "id": "outlook__list_event_attachments",
       "name": "List Event Attachments",
       "description": "List attachments for an event",
       "requiresWrite": false,
@@ -39748,7 +39748,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_event_attachment",
+      "id": "outlook__get_event_attachment",
       "name": "Get Event Attachment",
       "description": "Get metadata and content for an event attachment",
       "requiresWrite": false,
@@ -39771,7 +39771,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "add_event_attachment",
+      "id": "outlook__add_event_attachment",
       "name": "Add Event Attachment",
       "description": "Add a small attachment to an event",
       "requiresWrite": true,
@@ -39807,7 +39807,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "find_free_time",
+      "id": "outlook__find_free_time",
       "name": "Find Free Time",
       "description": "Return free/busy schedule information for users or resources",
       "requiresWrite": false,
@@ -39854,7 +39854,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_schedule",
+      "id": "outlook__get_schedule",
       "name": "Get Schedule",
       "description": "Get detailed free/busy schedule information",
       "requiresWrite": false,
@@ -39901,7 +39901,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "find_meeting_times",
+      "id": "outlook__find_meeting_times",
       "name": "Find Meeting Times",
       "description": "Find meeting time suggestions from attendees and constraints",
       "requiresWrite": false,
@@ -40004,7 +40004,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.paddle.com/api-reference/about/authentication",
     }],
     "tools": [{
-      "id": "list_products",
+      "id": "paddle__list_products",
       "name": "List Products",
       "description": "List products in the Paddle catalog, optionally including their prices",
       "requiresWrite": false,
@@ -40037,7 +40037,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_prices",
+      "id": "paddle__list_prices",
       "name": "List Prices",
       "description":
         "List prices for Paddle products to find price IDs for checkouts and subscriptions",
@@ -40071,7 +40071,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_customers",
+      "id": "paddle__list_customers",
       "name": "List Customers",
       "description": "List or search Paddle customers to find customer IDs and contact details",
       "requiresWrite": false,
@@ -40104,7 +40104,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_transactions",
+      "id": "paddle__list_transactions",
       "name": "List Transactions",
       "description":
         "List Paddle transactions for revenue review, filtered by status, customer, or subscription",
@@ -40150,7 +40150,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_subscriptions",
+      "id": "paddle__list_subscriptions",
       "name": "List Subscriptions",
       "description":
         "List Paddle subscriptions to review recurring revenue, statuses, and renewal dates",
@@ -40190,7 +40190,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_subscription",
+      "id": "paddle__get_subscription",
       "name": "Get Subscription",
       "description":
         "Retrieve a single Paddle subscription with its items, status, and billing dates",
@@ -40215,7 +40215,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "create_customer",
+      "id": "paddle__create_customer",
       "name": "Create Customer",
       "description":
         "Create a new Paddle customer, e.g. before creating transactions or subscriptions for a new buyer",
@@ -40241,7 +40241,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_price",
+      "id": "paddle__create_price",
       "name": "Create Price",
       "description":
         "Create a price for a Paddle product so it can be used in checkouts, transactions, and subscriptions",
@@ -40288,7 +40288,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_product",
+      "id": "paddle__create_product",
       "name": "Create Product",
       "description": "Create a new product in the Paddle catalog",
       "requiresWrite": true,
@@ -40406,7 +40406,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.pagerduty.com/docs/user-oauth-token-via-code-grant",
     }],
     "tools": [{
-      "id": "list_incidents",
+      "id": "pagerduty__list_incidents",
       "name": "List Incidents",
       "description": "List PagerDuty incidents with optional status, service, and time filters",
       "requiresWrite": false,
@@ -40466,7 +40466,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_incident",
+      "id": "pagerduty__get_incident",
       "name": "Get Incident",
       "description": "Get a PagerDuty incident by ID or incident number",
       "requiresWrite": false,
@@ -40483,7 +40483,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_incident",
+      "id": "pagerduty__create_incident",
       "name": "Create Incident",
       "description": "Manually trigger a new incident on a service",
       "requiresWrite": true,
@@ -40510,7 +40510,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "manage_incident",
+      "id": "pagerduty__manage_incident",
       "name": "Manage Incident",
       "description": "Acknowledge, resolve, reassign, or escalate an incident",
       "requiresWrite": true,
@@ -40543,7 +40543,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_services",
+      "id": "pagerduty__list_services",
       "name": "List Services",
       "description": "List PagerDuty services",
       "requiresWrite": false,
@@ -40576,7 +40576,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_oncalls",
+      "id": "pagerduty__list_oncalls",
       "name": "List On-Calls",
       "description": "List on-call entries for schedules, escalation policies, and users",
       "requiresWrite": false,
@@ -40685,7 +40685,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developers.pandadoc.com/reference/api-key-authentication-process",
     }],
     "tools": [{
-      "id": "list_documents",
+      "id": "pandadoc__list_documents",
       "name": "List Documents",
       "description":
         "List and search documents with optional filtering by status, template, folder, or date",
@@ -40762,7 +40762,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_document_status",
+      "id": "pandadoc__get_document_status",
       "name": "Get Document Status",
       "description":
         "Get basic info and current status of a document — useful to confirm it reached the expected state (e.g. document.draft before sending, document.completed before downloading)",
@@ -40780,7 +40780,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_document_details",
+      "id": "pandadoc__get_document_details",
       "name": "Get Document Details",
       "description":
         "Get full details of a document: recipients and their completion status, fields, tokens, pricing tables, metadata, and timestamps",
@@ -40798,7 +40798,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_templates",
+      "id": "pandadoc__list_templates",
       "name": "List Templates",
       "description": "List templates in the workspace to find template IDs for creating documents",
       "requiresWrite": false,
@@ -40843,7 +40843,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_template_details",
+      "id": "pandadoc__get_template_details",
       "name": "Get Template Details",
       "description":
         "Get a template's roles, tokens, fields, and pricing tables to know what Create Document from Template needs",
@@ -40861,7 +40861,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_document_link",
+      "id": "pandadoc__create_document_link",
       "name": "Create Document Link",
       "description":
         "Create a signing session link for a recipient to view and sign a sent document, without sending an email",
@@ -40890,7 +40890,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_document_from_template",
+      "id": "pandadoc__create_document_from_template",
       "name": "Create Document from Template",
       "description":
         "Create a new draft document from an existing template, pre-filling recipients, tokens, and fields",
@@ -40932,7 +40932,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "send_document",
+      "id": "pandadoc__send_document",
       "name": "Send Document",
       "description":
         "Send a draft document to its recipients for completion and signing (document must be in document.draft status)",
@@ -41050,7 +41050,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.paypal.com/dashboard/applications/live",
     }],
     "tools": [{
-      "id": "list_transactions",
+      "id": "paypal__list_transactions",
       "name": "List Transactions",
       "description": "Search account transactions in a date window (max 31 days per request)",
       "requiresWrite": false,
@@ -41102,7 +41102,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_balances",
+      "id": "paypal__list_balances",
       "name": "List Balances",
       "description": "Get current account balances by currency",
       "requiresWrite": false,
@@ -41118,7 +41118,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_invoices",
+      "id": "paypal__list_invoices",
       "name": "List Invoices",
       "description": "List invoices",
       "requiresWrite": false,
@@ -41159,7 +41159,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_invoice",
+      "id": "paypal__get_invoice",
       "name": "Get Invoice",
       "description": "Get details of an invoice",
       "requiresWrite": false,
@@ -41176,7 +41176,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_order",
+      "id": "paypal__get_order",
       "name": "Get Order",
       "description": "Get details of a checkout order",
       "requiresWrite": false,
@@ -41260,7 +41260,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.perplexity.ai/getting-started/quickstart",
     }],
     "tools": [{
-      "id": "search_web",
+      "id": "perplexity__search_web",
       "name": "Search Web",
       "description": "Search the web with Perplexity's Search API and get ranked results",
       "requiresWrite": false,
@@ -41288,7 +41288,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_chat_completion",
+      "id": "perplexity__create_chat_completion",
       "name": "Create Chat Completion",
       "description": "Generate a web-grounded chat completion with citations using a Sonar model",
       "requiresWrite": true,
@@ -41324,7 +41324,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_agent_response",
+      "id": "perplexity__create_agent_response",
       "name": "Create Agent Response",
       "description":
         "Generate a response with Perplexity's Agent API using optional web search and reasoning",
@@ -41417,7 +41417,7 @@ export const connectors: IntegrationConfig[] = [
       "sensitive": true,
     }],
     "tools": [{
-      "id": "list_inquiries",
+      "id": "persona__list_inquiries",
       "name": "List Inquiries",
       "description": "List Persona inquiries for KYC and onboarding review",
       "requiresWrite": false,
@@ -41439,7 +41439,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_inquiry",
+      "id": "persona__get_inquiry",
       "name": "Get Inquiry",
       "description": "Get a Persona inquiry by ID",
       "requiresWrite": false,
@@ -41456,7 +41456,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "approve_inquiry",
+      "id": "persona__approve_inquiry",
       "name": "Approve Inquiry",
       "description": "Approve a Persona inquiry after compliance review",
       "requiresWrite": true,
@@ -41473,7 +41473,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "decline_inquiry",
+      "id": "persona__decline_inquiry",
       "name": "Decline Inquiry",
       "description": "Decline a Persona inquiry after compliance review",
       "requiresWrite": true,
@@ -41542,7 +41542,7 @@ export const connectors: IntegrationConfig[] = [
         "https://support.personio.de/hc/en-us/articles/4404623630993-Generate-and-manage-API-credentials",
     }],
     "tools": [{
-      "id": "list_persons",
+      "id": "personio__list_persons",
       "name": "List Persons",
       "description":
         "List employees (persons) in the Personio account with optional email filtering",
@@ -41570,7 +41570,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_person",
+      "id": "personio__get_person",
       "name": "Get Person",
       "description": "Retrieve a single employee (person) by ID",
       "requiresWrite": false,
@@ -41587,7 +41587,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_employments",
+      "id": "personio__list_employments",
       "name": "List Employments",
       "description":
         "List a person's employment records (position, department, supervisor, status), most recent first",
@@ -41616,7 +41616,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_absence_types",
+      "id": "personio__list_absence_types",
       "name": "List Absence Types",
       "description":
         "List the account's absence types (vacation, sick leave, ...) to find the absence_type IDs needed to create absences",
@@ -41639,7 +41639,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_absence_periods",
+      "id": "personio__list_absence_periods",
       "name": "List Absence Periods",
       "description":
         "List absence periods (vacation, sick leave, etc.) with person and date-range filters",
@@ -41679,7 +41679,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_attendance_periods",
+      "id": "personio__list_attendance_periods",
       "name": "List Attendance Periods",
       "description":
         "List attendance periods (work and break times) with person and update-date filters",
@@ -41703,7 +41703,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_absence_period",
+      "id": "personio__create_absence_period",
       "name": "Create Absence Period",
       "description": "Create an absence period (e.g. vacation or sick leave) for an employee",
       "requiresWrite": true,
@@ -41807,7 +41807,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.pinecone.io/guides/projects/manage-api-keys",
     }],
     "tools": [{
-      "id": "list_indexes",
+      "id": "pinecone__list_indexes",
       "name": "List Indexes",
       "description": "List all indexes in the Pinecone project",
       "requiresWrite": false,
@@ -41836,7 +41836,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "describe_index",
+      "id": "pinecone__describe_index",
       "name": "Describe Index",
       "description":
         "Get an index's configuration and its data-plane host (needed for Query Vectors and Upsert Vectors)",
@@ -41861,7 +41861,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_index",
+      "id": "pinecone__create_index",
       "name": "Create Index",
       "description": "Create a new serverless or pod-based index",
       "requiresWrite": true,
@@ -41901,7 +41901,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "query_vectors",
+      "id": "pinecone__query_vectors",
       "name": "Query Vectors",
       "description":
         "Query an index for the nearest vectors (run Describe Index first to get the index host)",
@@ -41957,7 +41957,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "upsert_vectors",
+      "id": "pinecone__upsert_vectors",
       "name": "Upsert Vectors",
       "description": "Write vectors into an index (run Describe Index first to get the index host)",
       "requiresWrite": true,
@@ -42071,7 +42071,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://pipedrive.readme.io/docs/marketplace-oauth-authorization",
     }],
     "tools": [{
-      "id": "list_deals",
+      "id": "pipedrive__list_deals",
       "name": "List Deals",
       "description": "List deals in the Pipedrive account",
       "requiresWrite": false,
@@ -42126,7 +42126,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_deal",
+      "id": "pipedrive__get_deal",
       "name": "Get Deal",
       "description": "Get full details of a Pipedrive deal",
       "requiresWrite": false,
@@ -42144,7 +42144,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "create_deal",
+      "id": "pipedrive__create_deal",
       "name": "Create Deal",
       "description": "Create a new deal in Pipedrive",
       "requiresWrite": true,
@@ -42177,7 +42177,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "update_deal",
+      "id": "pipedrive__update_deal",
       "name": "Update Deal",
       "description": "Update fields on an existing Pipedrive deal",
       "requiresWrite": true,
@@ -42201,7 +42201,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_persons",
+      "id": "pipedrive__list_persons",
       "name": "List Persons",
       "description": "List persons (contacts) in the Pipedrive account",
       "requiresWrite": false,
@@ -42230,7 +42230,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "create_person",
+      "id": "pipedrive__create_person",
       "name": "Create Person",
       "description": "Create a new person (contact) in Pipedrive",
       "requiresWrite": true,
@@ -42255,7 +42255,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_organizations",
+      "id": "pipedrive__list_organizations",
       "name": "List Organizations",
       "description": "List organizations in the Pipedrive account",
       "requiresWrite": false,
@@ -42349,7 +42349,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://planetscale.com/docs/api/reference/service-tokens",
     }],
     "tools": [{
-      "id": "list_organizations",
+      "id": "planetscale__list_organizations",
       "name": "List Organizations",
       "description": "List organizations the service token can access",
       "requiresWrite": false,
@@ -42383,7 +42383,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_databases",
+      "id": "planetscale__list_databases",
       "name": "List Databases",
       "description": "List databases in an organization",
       "requiresWrite": false,
@@ -42428,7 +42428,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_database",
+      "id": "planetscale__get_database",
       "name": "Get Database",
       "description": "Get details of a database",
       "requiresWrite": false,
@@ -42451,7 +42451,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_branches",
+      "id": "planetscale__list_branches",
       "name": "List Branches",
       "description": "List branches of a database",
       "requiresWrite": false,
@@ -42504,7 +42504,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_deploy_requests",
+      "id": "planetscale__list_deploy_requests",
       "name": "List Deploy Requests",
       "description": "List deploy requests for a database",
       "requiresWrite": false,
@@ -42639,7 +42639,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://massive.com/dashboard/keys",
     }],
     "tools": [{
-      "id": "get_aggregates",
+      "id": "polygon__get_aggregates",
       "name": "Get Aggregate Bars",
       "description":
         "Get OHLCV aggregate bars (candles) for a stock ticker over a custom date range and time window",
@@ -42722,7 +42722,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_previous_close",
+      "id": "polygon__get_previous_close",
       "name": "Get Previous Close",
       "description":
         "Get the previous trading day's open, high, low, close, and volume for a stock ticker",
@@ -42746,7 +42746,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_daily_open_close",
+      "id": "polygon__get_daily_open_close",
       "name": "Get Daily Open/Close",
       "description":
         "Get the open, close, high, low, volume, and pre-market/after-hours prices for a stock ticker on a specific date",
@@ -42776,7 +42776,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_tickers",
+      "id": "polygon__list_tickers",
       "name": "Search Tickers",
       "description":
         "Search and list ticker symbols across stocks, indices, forex, and crypto reference data",
@@ -42838,7 +42838,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_ticker_details",
+      "id": "polygon__get_ticker_details",
       "name": "Get Ticker Details",
       "description":
         "Get reference details for a single ticker: company name, market, exchange, market cap, description, and identifiers",
@@ -42861,14 +42861,14 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_market_status",
+      "id": "polygon__get_market_status",
       "name": "Get Market Status",
       "description":
         "Get the current trading status of US exchanges and market-wide sessions (open, closed, early hours, after hours) — a cheap check before quoting prices",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.polygon.io/v1/marketstatus/now" },
     }, {
-      "id": "get_ticker_news",
+      "id": "polygon__get_ticker_news",
       "name": "Get Ticker News",
       "description":
         "Get recent news articles for a ticker, including publisher, summary, and per-ticker sentiment insights",
@@ -42989,7 +42989,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://portkey.ai/docs/api-reference/admin-api/introduction",
     }],
     "tools": [{
-      "id": "get_cost_analytics",
+      "id": "portkey__get_cost_analytics",
       "name": "Get Cost Analytics",
       "description":
         "Get time-series LLM spend data for a workspace over a date range, optionally filtered by model, status, or metadata",
@@ -43035,7 +43035,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_request_analytics",
+      "id": "portkey__get_request_analytics",
       "name": "Get Request Analytics",
       "description":
         "Get time-series request volume data for a workspace over a date range to spot traffic spikes and error trends",
@@ -43076,7 +43076,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_token_analytics",
+      "id": "portkey__get_token_analytics",
       "name": "Get Token Analytics",
       "description": "Get time-series token consumption data for a workspace over a date range",
       "requiresWrite": false,
@@ -43111,7 +43111,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_user_analytics_summary",
+      "id": "portkey__get_user_analytics_summary",
       "name": "Get User Analytics Summary",
       "description":
         "Get per-user grouped analytics (request counts and cost) for a workspace over a date range",
@@ -43154,7 +43154,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_model_analytics_summary",
+      "id": "portkey__get_model_analytics_summary",
       "name": "Get Model Analytics Summary",
       "description":
         "Get per-model grouped analytics (request counts) for a workspace over a date range — spend and traffic by model",
@@ -43197,7 +43197,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_workspaces",
+      "id": "portkey__list_workspaces",
       "name": "List Workspaces",
       "description":
         "List the organization's workspaces with their IDs and slugs — feeds the workspace_slug every analytics tool needs",
@@ -43232,7 +43232,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_virtual_keys",
+      "id": "portkey__list_virtual_keys",
       "name": "List Virtual Keys",
       "description":
         "List virtual keys (managed provider credentials) with their status, usage limits, and expiry",
@@ -43267,7 +43267,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_log_exports",
+      "id": "portkey__list_log_exports",
       "name": "List Log Exports",
       "description":
         "List log export tasks for a workspace (Portkey exposes gateway logs via exports rather than a direct list endpoint)",
@@ -43374,7 +43374,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://posthog.com/docs/self-host",
     }],
     "tools": [{
-      "id": "get_trends",
+      "id": "posthog__get_trends",
       "name": "Get Trends",
       "description": "Retrieve event trends and analytics data",
       "requiresWrite": false,
@@ -43410,7 +43410,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_feature_flags",
+      "id": "posthog__list_feature_flags",
       "name": "List Feature Flags",
       "description": "List all feature flags in your PostHog project",
       "requiresWrite": false,
@@ -43457,7 +43457,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_persons",
+      "id": "posthog__list_persons",
       "name": "List Persons",
       "description": "List persons/users tracked in PostHog",
       "requiresWrite": false,
@@ -43510,7 +43510,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "capture_event",
+      "id": "posthog__capture_event",
       "name": "Capture Event",
       "description": "Track a custom event in PostHog",
       "requiresWrite": true,
@@ -43578,7 +43578,7 @@ export const connectors: IntegrationConfig[] = [
         "https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade",
     }],
     "tools": [{
-      "id": "list_workspaces",
+      "id": "power-bi__list_workspaces",
       "name": "List Workspaces",
       "description": "List Power BI workspaces (groups) the signed-in user has access to",
       "requiresWrite": false,
@@ -43602,7 +43602,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "list_datasets",
+      "id": "power-bi__list_datasets",
       "name": "List My Workspace Datasets",
       "description": "List datasets in the signed-in user's My workspace",
       "requiresWrite": false,
@@ -43612,7 +43612,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "list_workspace_datasets",
+      "id": "power-bi__list_workspace_datasets",
       "name": "List Workspace Datasets",
       "description": "List datasets in a specific Power BI workspace",
       "requiresWrite": false,
@@ -43630,7 +43630,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "list_reports",
+      "id": "power-bi__list_reports",
       "name": "List My Workspace Reports",
       "description": "List reports in the signed-in user's My workspace",
       "requiresWrite": false,
@@ -43640,7 +43640,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "list_workspace_reports",
+      "id": "power-bi__list_workspace_reports",
       "name": "List Workspace Reports",
       "description": "List reports in a specific Power BI workspace",
       "requiresWrite": false,
@@ -43658,7 +43658,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "execute_dax_query",
+      "id": "power-bi__execute_dax_query",
       "name": "Execute DAX Query",
       "description": "Run a read-only DAX query against a dataset and return the resulting rows",
       "requiresWrite": false,
@@ -43693,7 +43693,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "refresh_dataset",
+      "id": "power-bi__refresh_dataset",
       "name": "Refresh Dataset",
       "description":
         "Trigger a data refresh for a dataset in the signed-in user's My workspace (returns 202 Accepted; the refresh runs asynchronously). Datasets in shared workspaces are not supported by this endpoint",
@@ -43721,7 +43721,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "refresh_workspace_dataset",
+      "id": "power-bi__refresh_workspace_dataset",
       "name": "Refresh Workspace Dataset",
       "description":
         "Trigger a data refresh for a dataset in a specific workspace (returns 202 Accepted; the refresh runs asynchronously)",
@@ -43754,7 +43754,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_refresh_history",
+      "id": "power-bi__list_refresh_history",
       "name": "List Refresh History",
       "description":
         "Get the refresh history of a dataset in the signed-in user's My workspace — the way to follow up the 202 returned by Refresh Dataset",
@@ -43780,7 +43780,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "list_workspace_refresh_history",
+      "id": "power-bi__list_workspace_refresh_history",
       "name": "List Workspace Refresh History",
       "description":
         "Get the refresh history of a dataset in a specific workspace, including status and failure error codes",
@@ -43896,7 +43896,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.productboard.com/reference/oauth-authorization-code",
     }],
     "tools": [{
-      "id": "list_notes",
+      "id": "productboard__list_notes",
       "name": "List Notes",
       "description": "List customer feedback notes in the Productboard workspace",
       "requiresWrite": false,
@@ -43944,7 +43944,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_note",
+      "id": "productboard__get_note",
       "name": "Get Note",
       "description": "Get a Productboard note by ID",
       "requiresWrite": false,
@@ -43961,7 +43961,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_note",
+      "id": "productboard__create_note",
       "name": "Create Note",
       "description": "Create a feedback note in Productboard",
       "requiresWrite": true,
@@ -43978,7 +43978,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_entities",
+      "id": "productboard__list_entities",
       "name": "List Entities",
       "description":
         "List product hierarchy entities (features, components, initiatives, releases, etc.)",
@@ -44024,7 +44024,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_entity",
+      "id": "productboard__get_entity",
       "name": "Get Entity",
       "description": "Get a hierarchy entity (e.g. a feature) by ID",
       "requiresWrite": false,
@@ -44041,7 +44041,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_entity",
+      "id": "productboard__create_entity",
       "name": "Create Entity",
       "description": "Create a hierarchy entity such as a feature or initiative",
       "requiresWrite": true,
@@ -44058,7 +44058,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_entity",
+      "id": "productboard__update_entity",
       "name": "Update Entity",
       "description":
         "Update fields of a hierarchy entity (e.g. rename a feature or change its status)",
@@ -44147,7 +44147,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://qdrant.tech/documentation/cloud/authentication/",
     }],
     "tools": [{
-      "id": "list_collections",
+      "id": "qdrant__list_collections",
       "name": "List Collections",
       "description": "List all collections in the Qdrant cluster",
       "requiresWrite": false,
@@ -44174,7 +44174,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_collection",
+      "id": "qdrant__get_collection",
       "name": "Get Collection Info",
       "description": "Get a collection's configuration, vector parameters, and point count",
       "requiresWrite": false,
@@ -44199,7 +44199,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "search_points",
+      "id": "qdrant__search_points",
       "name": "Search Points",
       "description": "Search a collection for the points nearest to a query vector",
       "requiresWrite": false,
@@ -44255,7 +44255,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "upsert_points",
+      "id": "qdrant__upsert_points",
       "name": "Upsert Points",
       "description": "Insert or update points (vectors with payloads) in a collection",
       "requiresWrite": true,
@@ -44363,7 +44363,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.qonto.com/get-started/business-api/authentication/api-key",
     }],
     "tools": [{
-      "id": "get_organization",
+      "id": "qonto__get_organization",
       "name": "Get Organization",
       "description":
         "Retrieve the authenticated organization with its bank accounts, including IBAN, BIC, currency, status, and current/authorized balances",
@@ -44381,7 +44381,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_transactions",
+      "id": "qonto__list_transactions",
       "name": "List Transactions",
       "description":
         "List transactions for one bank account (identified by bank_account_id or IBAN) with status, side, and date filtering",
@@ -44476,7 +44476,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_transaction",
+      "id": "qonto__get_transaction",
       "name": "Get Transaction",
       "description":
         "Retrieve a single transaction by its UUID, optionally embedding VAT details, labels, or attachments",
@@ -44499,7 +44499,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_transaction_attachments",
+      "id": "qonto__list_transaction_attachments",
       "name": "List Transaction Attachments",
       "description":
         "List the attachments (receipts, invoices) of a transaction with download URLs",
@@ -44523,7 +44523,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "upload_transaction_attachment",
+      "id": "qonto__upload_transaction_attachment",
       "name": "Upload Transaction Attachment",
       "description":
         "Upload a receipt or invoice (JPEG, PNG, or PDF) onto a transaction to justify it for bookkeeping; the file is processed in the background, so the attachment is not visible immediately",
@@ -44558,7 +44558,7 @@ export const connectors: IntegrationConfig[] = [
         "contentType": "multipart/form-data",
       },
     }, {
-      "id": "get_attachment",
+      "id": "qonto__get_attachment",
       "name": "Get Attachment",
       "description":
         "Retrieve an attachment by id to get a fresh download URL — URLs returned by the attachment endpoints expire after 30 minutes, so re-fetch before any delayed download",
@@ -44577,7 +44577,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_supplier_invoices",
+      "id": "qonto__list_supplier_invoices",
       "name": "List Supplier Invoices",
       "description":
         "List the organization's supplier invoices (accounts payable inbox) with status and payment matching; available on all price plans except Solo Basic",
@@ -44706,7 +44706,7 @@ export const connectors: IntegrationConfig[] = [
         "https://developer.intuit.com/app/developer/qbo/docs/develop/authentication-and-authorization/oauth-2.0",
     }],
     "tools": [{
-      "id": "list_invoices",
+      "id": "quickbooks__list_invoices",
       "name": "List Invoices",
       "description": "List recent invoices in a QuickBooks Online company",
       "requiresWrite": false,
@@ -44765,7 +44765,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_customers",
+      "id": "quickbooks__list_customers",
       "name": "List Customers",
       "description": "List customers in a QuickBooks Online company",
       "requiresWrite": false,
@@ -44803,7 +44803,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "QueryResponse" },
       },
     }, {
-      "id": "list_accounts",
+      "id": "quickbooks__list_accounts",
       "name": "List Accounts",
       "description": "List the chart of accounts in a QuickBooks Online company",
       "requiresWrite": false,
@@ -44841,7 +44841,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "QueryResponse" },
       },
     }, {
-      "id": "get_invoice",
+      "id": "quickbooks__get_invoice",
       "name": "Get Invoice",
       "description": "Get a QuickBooks invoice with its line items",
       "requiresWrite": false,
@@ -44879,7 +44879,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "Invoice" },
       },
     }, {
-      "id": "create_invoice",
+      "id": "quickbooks__create_invoice",
       "name": "Create Invoice",
       "description": "Create an invoice in a QuickBooks Online company",
       "requiresWrite": true,
@@ -44920,7 +44920,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "Invoice" },
       },
     }, {
-      "id": "list_bills",
+      "id": "quickbooks__list_bills",
       "name": "List Bills",
       "description": "List vendor bills (accounts payable) in a QuickBooks Online company",
       "requiresWrite": false,
@@ -44977,7 +44977,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_bill",
+      "id": "quickbooks__get_bill",
       "name": "Get Bill",
       "description": "Get a QuickBooks vendor bill with its line items",
       "requiresWrite": false,
@@ -45015,7 +45015,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "Bill" },
       },
     }, {
-      "id": "create_bill",
+      "id": "quickbooks__create_bill",
       "name": "Create Bill",
       "description": "Create a vendor bill (accounts payable) in a QuickBooks Online company",
       "requiresWrite": true,
@@ -45056,7 +45056,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "Bill" },
       },
     }, {
-      "id": "create_purchase",
+      "id": "quickbooks__create_purchase",
       "name": "Create Purchase",
       "description":
         "Record an expense (cash, check, or credit card purchase) in a QuickBooks Online company",
@@ -45098,7 +45098,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "Purchase" },
       },
     }, {
-      "id": "upload_attachment",
+      "id": "quickbooks__upload_attachment",
       "name": "Upload Attachment",
       "description":
         "Upload a file and attach it to a QuickBooks transaction (bill, invoice, purchase, ...) via the Attachable API",
@@ -45154,7 +45154,7 @@ export const connectors: IntegrationConfig[] = [
         "contentType": "multipart/form-data",
       },
     }, {
-      "id": "run_query",
+      "id": "quickbooks__run_query",
       "name": "Run Query",
       "description":
         "Run an arbitrary QuickBooks query against any entity (Invoice, Customer, Account, Payment, Bill, Item, ...)",
@@ -45194,7 +45194,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "QueryResponse" },
       },
     }, {
-      "id": "list_vendors",
+      "id": "quickbooks__list_vendors",
       "name": "List Vendors",
       "description":
         "List vendors in a QuickBooks Online company — use this to find the VendorRef IDs that Create Bill requires",
@@ -45247,7 +45247,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_purchases",
+      "id": "quickbooks__list_purchases",
       "name": "List Purchases",
       "description":
         "List purchase transactions (cash, check, or credit card expenses) in a QuickBooks Online company — the read counterpart to Create Purchase",
@@ -45380,7 +45380,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.railway.com/guides/public-api#authentication",
     }],
     "tools": [{
-      "id": "list_projects",
+      "id": "railway__list_projects",
       "name": "List Projects",
       "description": "List Railway projects accessible to the token",
       "requiresWrite": false,
@@ -45402,7 +45402,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_project",
+      "id": "railway__get_project",
       "name": "Get Project",
       "description": "Get a project with its services and environments",
       "requiresWrite": false,
@@ -45418,7 +45418,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "project" },
       },
     }, {
-      "id": "list_deployments",
+      "id": "railway__list_deployments",
       "name": "List Deployments",
       "description": "List deployments filtered by project, service, or environment",
       "requiresWrite": false,
@@ -45455,7 +45455,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_deployment",
+      "id": "railway__get_deployment",
       "name": "Get Deployment",
       "description": "Get a deployment by ID, including redeploy/rollback eligibility",
       "requiresWrite": false,
@@ -45476,7 +45476,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "deployment" },
       },
     }, {
-      "id": "restart_deployment",
+      "id": "railway__restart_deployment",
       "name": "Restart Deployment",
       "description": "Restart a running deployment",
       "requiresWrite": true,
@@ -45495,7 +45495,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "redeploy_deployment",
+      "id": "railway__redeploy_deployment",
       "name": "Redeploy Deployment",
       "description": "Redeploy an existing deployment (creates a new deployment from it)",
       "requiresWrite": true,
@@ -45588,7 +45588,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.ramp.com/developer-api/v1/getting-started",
     }],
     "tools": [{
-      "id": "list_transactions",
+      "id": "ramp__list_transactions",
       "name": "List Transactions",
       "description":
         "List card transactions with optional filtering by state, user, card, or date window",
@@ -45667,7 +45667,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_transaction",
+      "id": "ramp__get_transaction",
       "name": "Get Transaction",
       "description": "Fetch full details of a single card transaction",
       "requiresWrite": false,
@@ -45689,7 +45689,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_cards",
+      "id": "ramp__list_cards",
       "name": "List Cards",
       "description": "List corporate cards with optional filtering by owner or activation state",
       "requiresWrite": false,
@@ -45747,7 +45747,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_users",
+      "id": "ramp__list_users",
       "name": "List Users",
       "description":
         "List employees on the Ramp account with optional filtering by email, role, department, or status",
@@ -45804,7 +45804,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_user",
+      "id": "ramp__get_user",
       "name": "Get User",
       "description":
         "Fetch a single employee by ID, e.g. to resolve the user_id referenced on a transaction or card",
@@ -45822,7 +45822,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_card",
+      "id": "ramp__get_card",
       "name": "Get Card",
       "description":
         "Fetch a single corporate card by ID, e.g. to resolve the card_id referenced on a transaction",
@@ -45840,7 +45840,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_reimbursements",
+      "id": "ramp__list_reimbursements",
       "name": "List Reimbursements",
       "description":
         "List employee reimbursements with optional filtering by user, state, or date window",
@@ -45986,7 +45986,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://razorpay.com/docs/api/authentication/",
     }],
     "tools": [{
-      "id": "list_payments",
+      "id": "razorpay__list_payments",
       "name": "List Payments",
       "description": "List payments, optionally within a Unix-timestamp window",
       "requiresWrite": false,
@@ -46038,7 +46038,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_payment",
+      "id": "razorpay__get_payment",
       "name": "Get Payment",
       "description": "Get details of a payment",
       "requiresWrite": false,
@@ -46055,7 +46055,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_orders",
+      "id": "razorpay__list_orders",
       "name": "List Orders",
       "description": "List orders",
       "requiresWrite": false,
@@ -46098,7 +46098,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_order",
+      "id": "razorpay__get_order",
       "name": "Get Order",
       "description": "Get details of an order",
       "requiresWrite": false,
@@ -46115,7 +46115,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_refunds",
+      "id": "razorpay__list_refunds",
       "name": "List Refunds",
       "description": "List refunds",
       "requiresWrite": false,
@@ -46148,7 +46148,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_settlements",
+      "id": "razorpay__list_settlements",
       "name": "List Settlements",
       "description": "List settlements paid out to your bank account",
       "requiresWrite": false,
@@ -46256,7 +46256,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://redis.io/docs/latest/operate/rc/api/get-started/manage-api-keys/",
     }],
     "tools": [{
-      "id": "list_subscriptions",
+      "id": "redis-cloud__list_subscriptions",
       "name": "List Subscriptions",
       "description": "List Redis Cloud Pro subscriptions in the account",
       "requiresWrite": false,
@@ -46275,13 +46275,13 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_fixed_subscriptions",
+      "id": "redis-cloud__list_fixed_subscriptions",
       "name": "List Essentials Subscriptions",
       "description": "List Redis Cloud Essentials (fixed plan) subscriptions in the account",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.redislabs.com/v1/fixed/subscriptions" },
     }, {
-      "id": "list_databases",
+      "id": "redis-cloud__list_databases",
       "name": "List Databases",
       "description": "List databases in a Redis Cloud Pro subscription",
       "requiresWrite": false,
@@ -46310,7 +46310,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_database",
+      "id": "redis-cloud__get_database",
       "name": "Get Database",
       "description": "Get configuration and status of a database in a Pro subscription",
       "requiresWrite": false,
@@ -46333,7 +46333,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_fixed_databases",
+      "id": "redis-cloud__list_fixed_databases",
       "name": "List Essentials Databases",
       "description": "List databases in a Redis Cloud Essentials subscription",
       "requiresWrite": false,
@@ -46419,7 +46419,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://render.com/docs/api",
     }],
     "tools": [{
-      "id": "list_services",
+      "id": "render__list_services",
       "name": "List Services",
       "description": "List services owned by the authenticated user or team",
       "requiresWrite": false,
@@ -46457,7 +46457,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_service",
+      "id": "render__get_service",
       "name": "Get Service",
       "description": "Get a service by ID",
       "requiresWrite": false,
@@ -46474,7 +46474,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_deploys",
+      "id": "render__list_deploys",
       "name": "List Deploys",
       "description": "List deploys for a service",
       "requiresWrite": false,
@@ -46511,7 +46511,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "trigger_deploy",
+      "id": "render__trigger_deploy",
       "name": "Trigger Deploy",
       "description": "Trigger a new deploy for a service",
       "requiresWrite": true,
@@ -46545,7 +46545,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_env_vars",
+      "id": "render__list_env_vars",
       "name": "List Environment Variables",
       "description": "List all environment variables for a service",
       "requiresWrite": false,
@@ -46640,7 +46640,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://replicate.com/account/api-tokens",
     }],
     "tools": [{
-      "id": "list_models",
+      "id": "replicate__list_models",
       "name": "List Models",
       "description": "List public models available on Replicate",
       "requiresWrite": false,
@@ -46661,7 +46661,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_model",
+      "id": "replicate__get_model",
       "name": "Get Model",
       "description": "Get details about a model, including its latest version ID",
       "requiresWrite": false,
@@ -46684,7 +46684,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_prediction",
+      "id": "replicate__create_prediction",
       "name": "Create Prediction",
       "description": "Run a model by creating a prediction from a version ID and input object",
       "requiresWrite": true,
@@ -46715,7 +46715,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_prediction",
+      "id": "replicate__get_prediction",
       "name": "Get Prediction",
       "description": "Get the status and output of a prediction",
       "requiresWrite": false,
@@ -46732,7 +46732,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "cancel_prediction",
+      "id": "replicate__cancel_prediction",
       "name": "Cancel Prediction",
       "description": "Cancel a running prediction",
       "requiresWrite": true,
@@ -46815,7 +46815,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://resend.com/docs/dashboard/api-keys/introduction",
     }],
     "tools": [{
-      "id": "send_email",
+      "id": "resend__send_email",
       "name": "Send Email",
       "description": "Send an email",
       "requiresWrite": true,
@@ -46843,7 +46843,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_email",
+      "id": "resend__get_email",
       "name": "Get Email",
       "description": "Get a sent email and its delivery status by ID",
       "requiresWrite": false,
@@ -46860,7 +46860,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_domains",
+      "id": "resend__list_domains",
       "name": "List Domains",
       "description": "List sending domains and their verification status",
       "requiresWrite": false,
@@ -46880,7 +46880,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_audiences",
+      "id": "resend__list_audiences",
       "name": "List Audiences",
       "description": "List audiences (contact groups)",
       "requiresWrite": false,
@@ -46890,7 +46890,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_contacts",
+      "id": "resend__list_contacts",
       "name": "List Contacts",
       "description": "List contacts in an audience",
       "requiresWrite": false,
@@ -46908,7 +46908,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "create_contact",
+      "id": "resend__create_contact",
       "name": "Create Contact",
       "description": "Add a contact to an audience",
       "requiresWrite": true,
@@ -47009,7 +47009,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.rippling.com/documentation/base-api",
     }],
     "tools": [{
-      "id": "list_employees",
+      "id": "rippling__list_employees",
       "name": "List Employees",
       "description": "List active employees in the Rippling company with pagination",
       "requiresWrite": false,
@@ -47032,7 +47032,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_employee",
+      "id": "rippling__get_employee",
       "name": "Get Employee",
       "description":
         "Get a single employee's record (title, department, work location, employment type) by ID",
@@ -47050,7 +47050,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_departments",
+      "id": "rippling__list_departments",
       "name": "List Departments",
       "description": "List the company's departments",
       "requiresWrite": false,
@@ -47073,7 +47073,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_teams",
+      "id": "rippling__list_teams",
       "name": "List Teams",
       "description": "List the company's teams",
       "requiresWrite": false,
@@ -47096,7 +47096,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_leave_requests",
+      "id": "rippling__list_leave_requests",
       "name": "List Leave Requests",
       "description": "List leave (time off) requests with optional status and date filtering",
       "requiresWrite": false,
@@ -47122,7 +47122,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "process_leave_request",
+      "id": "rippling__process_leave_request",
       "name": "Process Leave Request",
       "description": "Approve or decline a pending leave request",
       "requiresWrite": true,
@@ -47223,7 +47223,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://howto.salesflare.com/en/articles/1017460-do-you-have-an-api",
     }],
     "tools": [{
-      "id": "list_contacts",
+      "id": "salesflare__list_contacts",
       "name": "List Contacts",
       "description": "List or search contacts in Salesflare",
       "requiresWrite": false,
@@ -47267,7 +47267,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_contact",
+      "id": "salesflare__get_contact",
       "name": "Get Contact",
       "description": "Get details of a Salesflare contact",
       "requiresWrite": false,
@@ -47284,7 +47284,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_contact",
+      "id": "salesflare__create_contact",
       "name": "Create Contact",
       "description": "Create a new contact in Salesflare",
       "requiresWrite": true,
@@ -47301,7 +47301,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_contact",
+      "id": "salesflare__update_contact",
       "name": "Update Contact",
       "description": "Update an existing Salesflare contact",
       "requiresWrite": true,
@@ -47324,7 +47324,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_accounts",
+      "id": "salesflare__list_accounts",
       "name": "List Accounts",
       "description": "List or search accounts (companies) in Salesflare",
       "requiresWrite": false,
@@ -47348,7 +47348,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_account",
+      "id": "salesflare__create_account",
       "name": "Create Account",
       "description": "Create a new account (company) in Salesflare",
       "requiresWrite": true,
@@ -47363,7 +47363,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_opportunities",
+      "id": "salesflare__list_opportunities",
       "name": "List Opportunities",
       "description": "List or search opportunities in Salesflare",
       "requiresWrite": false,
@@ -47461,7 +47461,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://help.salesforce.com/s/articleView?id=sf.connected_app_create.htm",
     }],
     "tools": [{
-      "id": "find_customer",
+      "id": "salesforce__find_customer",
       "name": "Find Customer",
       "description":
         "Find customer contacts with account context for support triage. Pass a focused SOQL query when searching by email, name, phone, or account.",
@@ -47482,7 +47482,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "records" },
       },
     }, {
-      "id": "search_accounts",
+      "id": "salesforce__search_accounts",
       "name": "Search Accounts",
       "description": "Search Salesforce accounts with business context for support or sales work",
       "requiresWrite": false,
@@ -47501,7 +47501,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "records" },
       },
     }, {
-      "id": "get_account",
+      "id": "salesforce__get_account",
       "name": "Get Account",
       "description": "Get detailed information about a specific account",
       "requiresWrite": false,
@@ -47518,7 +47518,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_contacts",
+      "id": "salesforce__search_contacts",
       "name": "Search Contacts",
       "description": "Search contacts with account fields for CRM follow-up and support context",
       "requiresWrite": false,
@@ -47537,7 +47537,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "records" },
       },
     }, {
-      "id": "get_contact",
+      "id": "salesforce__get_contact",
       "name": "Get Contact",
       "description": "Get a Salesforce contact by ID",
       "requiresWrite": false,
@@ -47554,7 +47554,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_cases",
+      "id": "salesforce__list_cases",
       "name": "List Cases",
       "description": "List Service Cloud cases for a customer, account, owner, status, or queue",
       "requiresWrite": false,
@@ -47574,7 +47574,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "records" },
       },
     }, {
-      "id": "get_case",
+      "id": "salesforce__get_case",
       "name": "Get Case",
       "description": "Get a Service Cloud case by ID",
       "requiresWrite": false,
@@ -47591,7 +47591,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_case_activity",
+      "id": "salesforce__list_case_activity",
       "name": "List Case Activity",
       "description":
         "List case comments for support handoff, timeline review, and resolution context",
@@ -47612,7 +47612,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "records" },
       },
     }, {
-      "id": "search_knowledge_articles",
+      "id": "salesforce__search_knowledge_articles",
       "name": "Search Knowledge Articles",
       "description":
         "Search published Salesforce Knowledge articles that can help answer or deflect a support case",
@@ -47633,7 +47633,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "records" },
       },
     }, {
-      "id": "list_opportunities",
+      "id": "salesforce__list_opportunities",
       "name": "List Opportunities",
       "description": "List Sales Cloud opportunities for account planning and customer context",
       "requiresWrite": false,
@@ -47652,7 +47652,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "records" },
       },
     }, {
-      "id": "create_lead",
+      "id": "salesforce__create_lead",
       "name": "Create Lead",
       "description": "Create a new lead in Salesforce CRM",
       "requiresWrite": true,
@@ -47669,7 +47669,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_case",
+      "id": "salesforce__create_case",
       "name": "Create Case",
       "description": "Create a Service Cloud case for customer support",
       "requiresWrite": true,
@@ -47688,7 +47688,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "add_case_comment",
+      "id": "salesforce__add_case_comment",
       "name": "Add Case Comment",
       "description": "Add a support note or customer-visible comment to a Service Cloud case",
       "requiresWrite": true,
@@ -47706,7 +47706,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_case",
+      "id": "salesforce__update_case",
       "name": "Update Case",
       "description": "Update status, priority, owner, or resolution fields on a Service Cloud case",
       "requiresWrite": true,
@@ -47731,7 +47731,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "describe_object",
+      "id": "salesforce__describe_object",
       "name": "Describe Object",
       "description": "Get metadata and field definitions for a Salesforce object",
       "requiresWrite": false,
@@ -47749,7 +47749,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "run_soql_query",
+      "id": "salesforce__run_soql_query",
       "name": "Run SOQL Query",
       "description":
         "Run a read-only SOQL query for expert inspection when curated tools are not enough",
@@ -47862,7 +47862,7 @@ export const connectors: IntegrationConfig[] = [
       "sensitive": true,
     }],
     "tools": [{
-      "id": "list_supplier_invoices",
+      "id": "sap__list_supplier_invoices",
       "name": "List Supplier Invoices",
       "description": "List supplier invoices from SAP S/4HANA with optional OData filters",
       "requiresWrite": false,
@@ -47899,7 +47899,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_supplier_invoice",
+      "id": "sap__get_supplier_invoice",
       "name": "Get Supplier Invoice",
       "description": "Get a supplier invoice by invoice number and fiscal year",
       "requiresWrite": false,
@@ -47935,7 +47935,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "release_supplier_invoice",
+      "id": "sap__release_supplier_invoice",
       "name": "Release Supplier Invoice",
       "description": "Release a blocked supplier invoice in SAP S/4HANA",
       "requiresWrite": true,
@@ -48009,7 +48009,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.segmentapis.com/tag/Getting-Started",
     }],
     "tools": [{
-      "id": "list_sources",
+      "id": "segment__list_sources",
       "name": "List Sources",
       "description": "List sources in the Segment workspace",
       "requiresWrite": false,
@@ -48057,7 +48057,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_source",
+      "id": "segment__get_source",
       "name": "Get Source",
       "description": "Get a source by ID",
       "requiresWrite": false,
@@ -48082,7 +48082,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "create_source",
+      "id": "segment__create_source",
       "name": "Create Source",
       "description": "Create a new source in the workspace",
       "requiresWrite": true,
@@ -48122,7 +48122,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "update_source",
+      "id": "segment__update_source",
       "name": "Update Source",
       "description": "Update a source's name, slug, enabled state, or settings",
       "requiresWrite": true,
@@ -48153,7 +48153,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_destinations",
+      "id": "segment__list_destinations",
       "name": "List Destinations",
       "description": "List destinations in the Segment workspace",
       "requiresWrite": false,
@@ -48196,7 +48196,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_destination",
+      "id": "segment__get_destination",
       "name": "Get Destination",
       "description": "Get a destination by ID",
       "requiresWrite": false,
@@ -48221,7 +48221,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "create_destination",
+      "id": "segment__create_destination",
       "name": "Create Destination",
       "description": "Connect a new destination to a source",
       "requiresWrite": true,
@@ -48337,7 +48337,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://sendcloud.dev/docs/getting-started/how-to-create-your-api-keys",
     }],
     "tools": [{
-      "id": "list_shipments",
+      "id": "sendcloud__list_shipments",
       "name": "List Shipments",
       "description":
         "List shipments (parcels) in the Sendcloud account with optional filters such as order number, tracking number, or update time",
@@ -48387,7 +48387,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_shipment",
+      "id": "sendcloud__get_shipment",
       "name": "Get Shipment",
       "description":
         "Get a single shipment with its parcels, addresses, tracking numbers, and label documents",
@@ -48405,7 +48405,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_shipment",
+      "id": "sendcloud__create_shipment",
       "name": "Create Shipment",
       "description":
         "Create and announce a shipment synchronously, generating a shipping label for one or more parcels",
@@ -48458,7 +48458,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_shipping_options",
+      "id": "sendcloud__list_shipping_options",
       "name": "List Shipping Options",
       "description":
         "List available carrier shipping options (methods) for a given route and parcel, optionally with price quotes",
@@ -48493,7 +48493,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_tracking",
+      "id": "sendcloud__get_tracking",
       "name": "Get Tracking",
       "description":
         "Get the current status and recent tracking events of a parcel by its carrier tracking number",
@@ -48511,7 +48511,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "cancel_shipment",
+      "id": "sendcloud__cancel_shipment",
       "name": "Cancel Shipment",
       "description":
         "Cancel an announced shipment and its label before carrier collection — the undo for a mis-announced (cost-incurring) label; cancellation is no longer possible once the carrier has the parcel",
@@ -48608,7 +48608,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://www.twilio.com/docs/sendgrid/ui/account-and-settings/api-keys",
     }],
     "tools": [{
-      "id": "send_email",
+      "id": "sendgrid__send_email",
       "name": "Send Email",
       "description": "Send an email via the SendGrid v3 Mail Send API",
       "requiresWrite": true,
@@ -48638,7 +48638,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_contacts",
+      "id": "sendgrid__list_contacts",
       "name": "List Contacts",
       "description": "List marketing contacts in the account",
       "requiresWrite": false,
@@ -48661,7 +48661,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "search_contacts",
+      "id": "sendgrid__search_contacts",
       "name": "Search Contacts",
       "description": "Search marketing contacts with an SGQL query (read-only search via POST)",
       "requiresWrite": false,
@@ -48678,7 +48678,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "upsert_contacts",
+      "id": "sendgrid__upsert_contacts",
       "name": "Upsert Contacts",
       "description": "Add or update marketing contacts (asynchronous; returns a job_id)",
       "requiresWrite": true,
@@ -48698,7 +48698,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_templates",
+      "id": "sendgrid__list_templates",
       "name": "List Templates",
       "description": "List transactional email templates",
       "requiresWrite": false,
@@ -48726,7 +48726,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_email_stats",
+      "id": "sendgrid__get_email_stats",
       "name": "Get Email Stats",
       "description":
         "Get global email statistics (delivered, opens, clicks, bounces) for a date range",
@@ -48838,7 +48838,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.sentry.io/api/organizations/",
     }],
     "tools": [{
-      "id": "list_organizations",
+      "id": "sentry__list_organizations",
       "name": "List Organizations",
       "description":
         "List Sentry organizations available to the authenticated user so agents can discover organization slugs before project or issue calls",
@@ -48862,7 +48862,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_projects",
+      "id": "sentry__list_projects",
       "name": "List Projects",
       "description": "List Sentry projects for an organization",
       "requiresWrite": false,
@@ -48880,7 +48880,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_issues",
+      "id": "sentry__list_issues",
       "name": "List Issues",
       "description": "List Sentry issues for a project",
       "requiresWrite": false,
@@ -48919,7 +48919,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_issue",
+      "id": "sentry__get_issue",
       "name": "Get Issue",
       "description": "Get details for a Sentry issue",
       "requiresWrite": false,
@@ -48947,7 +48947,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "resolve_issue",
+      "id": "sentry__resolve_issue",
       "name": "Resolve Issue",
       "description": "Resolve a Sentry issue",
       "requiresWrite": true,
@@ -48974,7 +48974,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_latest_event",
+      "id": "sentry__get_latest_event",
       "name": "Get Latest Event",
       "description":
         "Get the latest event for a Sentry issue, including the stack trace and tags needed for root-cause analysis",
@@ -49048,7 +49048,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://serpapi.com/manage-api-key",
     }],
     "tools": [{
-      "id": "google_search",
+      "id": "serpapi__google_search",
       "name": "Google Search",
       "description":
         "Run a Google web search and get structured organic results, answer boxes, and related data",
@@ -49088,7 +49088,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "google_news",
+      "id": "serpapi__google_news",
       "name": "Google News Search",
       "description":
         "Search Google News and get structured article results with titles, sources, and publish dates",
@@ -49112,7 +49112,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "google_maps",
+      "id": "serpapi__google_maps",
       "name": "Google Maps Search",
       "description":
         "Search Google Maps for places and get structured local results with addresses, ratings, and coordinates",
@@ -49142,7 +49142,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "google_shopping",
+      "id": "serpapi__google_shopping",
       "name": "Google Shopping Search",
       "description":
         "Search Google Shopping and get structured product results with prices, merchants, and ratings",
@@ -49222,7 +49222,7 @@ export const connectors: IntegrationConfig[] = [
       "sensitive": true,
     }],
     "tools": [{
-      "id": "list_incidents",
+      "id": "servicenow__list_incidents",
       "name": "List Incidents",
       "description": "List ServiceNow incidents with optional filters",
       "requiresWrite": false,
@@ -49259,7 +49259,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "get_incident",
+      "id": "servicenow__get_incident",
       "name": "Get Incident",
       "description": "Get details of a specific incident",
       "requiresWrite": false,
@@ -49289,7 +49289,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "create_incident",
+      "id": "servicenow__create_incident",
       "name": "Create Incident",
       "description": "Create a new incident in ServiceNow",
       "requiresWrite": true,
@@ -49322,7 +49322,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "update_incident",
+      "id": "servicenow__update_incident",
       "name": "Update Incident",
       "description": "Update an existing incident",
       "requiresWrite": true,
@@ -49357,7 +49357,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "list_interactions",
+      "id": "servicenow__list_interactions",
       "name": "List Interactions",
       "description": "List ServiceNow Interaction records used for request-desk intake and routing",
       "requiresWrite": false,
@@ -49394,7 +49394,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "get_interaction",
+      "id": "servicenow__get_interaction",
       "name": "Get Interaction",
       "description": "Get details of a specific ServiceNow Interaction record",
       "requiresWrite": false,
@@ -49424,7 +49424,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "create_interaction",
+      "id": "servicenow__create_interaction",
       "name": "Create Interaction",
       "description":
         "Create a ServiceNow Interaction intake record before converting or linking it to an incident or request",
@@ -49459,7 +49459,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "update_interaction",
+      "id": "servicenow__update_interaction",
       "name": "Update Interaction",
       "description":
         "Update an existing ServiceNow Interaction with routing status, parent record, notes, or comments",
@@ -49492,7 +49492,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "list_requests",
+      "id": "servicenow__list_requests",
       "name": "List Requests",
       "description": "List ServiceNow service request records from the sc_request table",
       "requiresWrite": false,
@@ -49529,7 +49529,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "get_request",
+      "id": "servicenow__get_request",
       "name": "Get Request",
       "description": "Get details of a specific ServiceNow service request",
       "requiresWrite": false,
@@ -49559,7 +49559,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "create_request",
+      "id": "servicenow__create_request",
       "name": "Create Request",
       "description": "Order a Service Catalog item to create a workflow-backed ServiceNow request",
       "requiresWrite": true,
@@ -49596,7 +49596,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "list_request_items",
+      "id": "servicenow__list_request_items",
       "name": "List Request Items",
       "description": "List ServiceNow requested item records from the sc_req_item table",
       "requiresWrite": false,
@@ -49633,7 +49633,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "get_request_item",
+      "id": "servicenow__get_request_item",
       "name": "Get Request Item",
       "description": "Get details of a specific ServiceNow requested item",
       "requiresWrite": false,
@@ -49663,7 +49663,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "create_request_item",
+      "id": "servicenow__create_request_item",
       "name": "Create Request Item",
       "description":
         "Create a requested item table record when direct sc_req_item writes are allowed",
@@ -49705,7 +49705,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "search_knowledge",
+      "id": "servicenow__search_knowledge",
       "name": "Search Knowledge Base",
       "description": "Search ServiceNow knowledge base articles",
       "requiresWrite": false,
@@ -49741,7 +49741,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "search_users",
+      "id": "servicenow__search_users",
       "name": "Search Users",
       "description": "Search ServiceNow users to find the sys_id needed for assigning incidents",
       "requiresWrite": false,
@@ -49777,7 +49777,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "query_table",
+      "id": "servicenow__query_table",
       "name": "Query Table",
       "description":
         "Query any ServiceNow table with an encoded query (covers change requests, problems, CMDB, catalog tasks, etc.)",
@@ -49823,7 +49823,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "create_table_record",
+      "id": "servicenow__create_table_record",
       "name": "Create Table Record",
       "description": "Create a record in any ServiceNow table",
       "requiresWrite": true,
@@ -49856,7 +49856,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "result" },
       },
     }, {
-      "id": "update_table_record",
+      "id": "servicenow__update_table_record",
       "name": "Update Table Record",
       "description": "Update a record in any ServiceNow table",
       "requiresWrite": true,
@@ -49940,7 +49940,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://api.sevdesk.de/",
     }],
     "tools": [{
-      "id": "list_contacts",
+      "id": "sevdesk__list_contacts",
       "name": "List Contacts",
       "description":
         "List sevdesk contacts (organizations and persons), e.g. to find a contact id before creating an invoice",
@@ -49971,7 +49971,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "objects" },
       },
     }, {
-      "id": "list_invoices",
+      "id": "sevdesk__list_invoices",
       "name": "List Invoices",
       "description":
         "List sevdesk invoices with optional status, number, date, and contact filters",
@@ -50023,7 +50023,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "objects" },
       },
     }, {
-      "id": "get_invoice",
+      "id": "sevdesk__get_invoice",
       "name": "Get Invoice",
       "description": "Retrieve a single sevdesk invoice by its id",
       "requiresWrite": false,
@@ -50041,7 +50041,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "objects" },
       },
     }, {
-      "id": "create_invoice",
+      "id": "sevdesk__create_invoice",
       "name": "Create Invoice",
       "description":
         "Create a sevdesk invoice with positions via the saveInvoice factory endpoint; create with status 100 for an editable draft",
@@ -50082,7 +50082,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "upload_voucher_file",
+      "id": "sevdesk__upload_voucher_file",
       "name": "Upload Voucher File",
       "description":
         "Upload a receipt or invoice file to sevdesk; returns an internal filename that can be attached when creating a voucher",
@@ -50110,7 +50110,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "objects" },
       },
     }, {
-      "id": "list_vouchers",
+      "id": "sevdesk__list_vouchers",
       "name": "List Vouchers",
       "description":
         "List sevdesk accounting vouchers (receipts) with optional status, type, date, and description filters",
@@ -50155,7 +50155,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "objects" },
       },
     }, {
-      "id": "create_voucher",
+      "id": "sevdesk__create_voucher",
       "name": "Create Voucher",
       "description":
         "Create a bookable voucher (receipt) with positions via the saveVoucher factory endpoint — the step that turns a file staged with Upload Voucher File into an actual accounting record",
@@ -50189,7 +50189,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "objects" },
       },
     }, {
-      "id": "get_invoice_pdf",
+      "id": "sevdesk__get_invoice_pdf",
       "name": "Get Invoice PDF",
       "description": "Retrieve the rendered PDF document of an invoice for sending or archiving",
       "requiresWrite": false,
@@ -50217,7 +50217,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "objects" },
       },
     }, {
-      "id": "book_invoice_amount",
+      "id": "sevdesk__book_invoice_amount",
       "name": "Book Invoice Amount",
       "description":
         "Register a (partial) payment on an invoice and mark it paid when settled — closes the reconciliation loop after money arrives",
@@ -50348,7 +50348,7 @@ export const connectors: IntegrationConfig[] = [
         "https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade",
     }],
     "tools": [{
-      "id": "list_sites",
+      "id": "sharepoint__list_sites",
       "name": "List SharePoint Sites",
       "description": "List all SharePoint sites the user has access to",
       "requiresWrite": false,
@@ -50372,7 +50372,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "get_site",
+      "id": "sharepoint__get_site",
       "name": "Get Site Details",
       "description": "Get detailed information about a specific SharePoint site",
       "requiresWrite": false,
@@ -50389,7 +50389,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_files",
+      "id": "sharepoint__list_files",
       "name": "List Files",
       "description": "List files and folders in a SharePoint document library",
       "requiresWrite": false,
@@ -50412,7 +50412,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_file",
+      "id": "sharepoint__get_file",
       "name": "Get File",
       "description": "Get file metadata and content from SharePoint",
       "requiresWrite": false,
@@ -50435,7 +50435,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "upload_file",
+      "id": "sharepoint__upload_file",
       "name": "Upload File",
       "description": "Upload a file to a SharePoint document library",
       "requiresWrite": true,
@@ -50473,7 +50473,7 @@ export const connectors: IntegrationConfig[] = [
         "contentType": "application/octet-stream",
       },
     }, {
-      "id": "search_files",
+      "id": "sharepoint__search_files",
       "name": "Search Files",
       "description":
         "Search for files and folders in a SharePoint document library by name or content",
@@ -50504,7 +50504,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "download_file",
+      "id": "sharepoint__download_file",
       "name": "Download File",
       "description": "Download file content from a SharePoint document library",
       "requiresWrite": false,
@@ -50586,7 +50586,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://console.cloud.google.com/apis/credentials",
     }],
     "tools": [{
-      "id": "list_spreadsheets",
+      "id": "sheets__list_spreadsheets",
       "name": "List Spreadsheets",
       "description": "List recent Google Sheets spreadsheets from Drive",
       "requiresWrite": false,
@@ -50617,7 +50617,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "files" },
       },
     }, {
-      "id": "get_spreadsheet",
+      "id": "sheets__get_spreadsheet",
       "name": "Get Spreadsheet",
       "description": "Get spreadsheet metadata including sheet names and properties",
       "requiresWrite": false,
@@ -50645,7 +50645,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "read_range",
+      "id": "sheets__read_range",
       "name": "Read Range",
       "description": "Read cell data from a spreadsheet range",
       "requiresWrite": false,
@@ -50678,7 +50678,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "write_range",
+      "id": "sheets__write_range",
       "name": "Write Range",
       "description": "Write data to a spreadsheet range",
       "requiresWrite": true,
@@ -50725,7 +50725,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_spreadsheet",
+      "id": "sheets__create_spreadsheet",
       "name": "Create Spreadsheet",
       "description": "Create a new spreadsheet with optional initial data",
       "requiresWrite": true,
@@ -50742,7 +50742,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "append_rows",
+      "id": "sheets__append_rows",
       "name": "Append Rows",
       "description": "Append rows to a spreadsheet range",
       "requiresWrite": true,
@@ -50796,7 +50796,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "clear_range",
+      "id": "sheets__clear_range",
       "name": "Clear Range",
       "description": "Clear values from a spreadsheet range",
       "requiresWrite": true,
@@ -50820,7 +50820,7 @@ export const connectors: IntegrationConfig[] = [
         "body": {},
       },
     }, {
-      "id": "batch_update",
+      "id": "sheets__batch_update",
       "name": "Batch Update",
       "description":
         "Run raw Google Sheets batchUpdate requests for formatting and structural changes",
@@ -50849,7 +50849,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "add_sheet",
+      "id": "sheets__add_sheet",
       "name": "Add Sheet",
       "description": "Add a new sheet/tab to a spreadsheet",
       "requiresWrite": true,
@@ -50873,7 +50873,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_sheet",
+      "id": "sheets__delete_sheet",
       "name": "Delete Sheet",
       "description": "Delete a sheet/tab from a spreadsheet by sheet ID",
       "requiresWrite": true,
@@ -50897,7 +50897,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "rename_sheet",
+      "id": "sheets__rename_sheet",
       "name": "Rename Sheet",
       "description": "Rename a sheet/tab by sheet ID",
       "requiresWrite": true,
@@ -50922,7 +50922,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_spreadsheet",
+      "id": "sheets__delete_spreadsheet",
       "name": "Delete Spreadsheet",
       "description": "Move an app-accessible spreadsheet file to trash",
       "requiresWrite": true,
@@ -50946,7 +50946,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "find_replace",
+      "id": "sheets__find_replace",
       "name": "Find and Replace",
       "description": "Find and replace text in a spreadsheet or sheet",
       "requiresWrite": true,
@@ -50970,7 +50970,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "copy_sheet",
+      "id": "sheets__copy_sheet",
       "name": "Copy Sheet",
       "description": "Copy a sheet/tab to another spreadsheet",
       "requiresWrite": true,
@@ -51001,7 +51001,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_chart",
+      "id": "sheets__create_chart",
       "name": "Create Chart",
       "description": "Create an embedded chart using a Sheets API chart specification",
       "requiresWrite": true,
@@ -51025,7 +51025,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "set_data_validation",
+      "id": "sheets__set_data_validation",
       "name": "Set Data Validation",
       "description": "Set data validation rules on a sheet range",
       "requiresWrite": true,
@@ -51109,27 +51109,27 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://shopify.dev/docs/apps/auth/oauth",
     }],
     "tools": [{
-      "id": "list_products",
+      "id": "shopify__list_products",
       "name": "List Products",
       "description": "List products in your Shopify store",
       "requiresWrite": false,
     }, {
-      "id": "get_product",
+      "id": "shopify__get_product",
       "name": "Get Product",
       "description": "Get details of a specific product",
       "requiresWrite": false,
     }, {
-      "id": "list_orders",
+      "id": "shopify__list_orders",
       "name": "List Orders",
       "description": "List orders from your Shopify store",
       "requiresWrite": false,
     }, {
-      "id": "get_order",
+      "id": "shopify__get_order",
       "name": "Get Order",
       "description": "Get details of a specific order",
       "requiresWrite": false,
     }, {
-      "id": "list_customers",
+      "id": "shopify__list_customers",
       "name": "List Customers",
       "description": "List customers in your Shopify store",
       "requiresWrite": false,
@@ -51195,7 +51195,7 @@ export const connectors: IntegrationConfig[] = [
       "sensitive": false,
     }],
     "tools": [{
-      "id": "search_products",
+      "id": "shopware__search_products",
       "name": "Search Products",
       "description":
         "Search products with the Admin API search criteria (term, filters, sorting, paging)",
@@ -51235,7 +51235,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "search_orders",
+      "id": "shopware__search_orders",
       "name": "Search Orders",
       "description": "Search orders with the Admin API search criteria (filters, sorting, paging)",
       "requiresWrite": false,
@@ -51274,7 +51274,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "search_customers",
+      "id": "shopware__search_customers",
       "name": "Search Customers",
       "description":
         "Search customers with the Admin API search criteria (term, filters, sorting, paging)",
@@ -51314,7 +51314,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_order",
+      "id": "shopware__get_order",
       "name": "Get Order",
       "description": "Get full details of a single order by ID",
       "requiresWrite": false,
@@ -51338,7 +51338,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_product",
+      "id": "shopware__get_product",
       "name": "Get Product",
       "description": "Get full details of a single product by ID",
       "requiresWrite": false,
@@ -51362,7 +51362,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "create_product",
+      "id": "shopware__create_product",
       "name": "Create Product",
       "description":
         "Create a new product (requires name, productNumber, stock, taxId, and a price array)",
@@ -51396,7 +51396,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "update_product",
+      "id": "shopware__update_product",
       "name": "Update Product",
       "description": "Partially update a product, e.g. change its price, stock, or visibility",
       "requiresWrite": true,
@@ -51435,7 +51435,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "transition_order_state",
+      "id": "shopware__transition_order_state",
       "name": "Transition Order State",
       "description":
         "Move an order to its next state via a state machine transition (e.g. process, complete, cancel, reopen)",
@@ -51545,7 +51545,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.shortcut.com/api/rest/v3#Authentication",
     }],
     "tools": [{
-      "id": "search_stories",
+      "id": "shortcut__search_stories",
       "name": "Search Stories",
       "description": "Search Shortcut stories with the Shortcut search syntax",
       "requiresWrite": false,
@@ -51599,7 +51599,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_story",
+      "id": "shortcut__get_story",
       "name": "Get Story",
       "description": "Get a Shortcut story by its public ID",
       "requiresWrite": false,
@@ -51616,7 +51616,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_story",
+      "id": "shortcut__create_story",
       "name": "Create Story",
       "description": "Create a new story in Shortcut",
       "requiresWrite": true,
@@ -51641,7 +51641,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_story",
+      "id": "shortcut__update_story",
       "name": "Update Story",
       "description": "Update an existing Shortcut story",
       "requiresWrite": true,
@@ -51670,7 +51670,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_epics",
+      "id": "shortcut__list_epics",
       "name": "List Epics",
       "description": "List epics in the Shortcut workspace",
       "requiresWrite": false,
@@ -51704,13 +51704,13 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_members",
+      "id": "shortcut__list_members",
       "name": "List Members",
       "description": "List members of the Shortcut workspace (use member UUIDs as owner_ids)",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.app.shortcut.com/api/v3/members" },
     }, {
-      "id": "list_workflows",
+      "id": "shortcut__list_workflows",
       "name": "List Workflows",
       "description": "List workflows and their states (use state IDs as workflow_state_id)",
       "requiresWrite": false,
@@ -51855,7 +51855,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://api.slack.com/apps",
     }],
     "tools": [{
-      "id": "list_channels",
+      "id": "slack__list_channels",
       "name": "List Channels",
       "description": "Get list of Slack channels",
       "requiresWrite": false,
@@ -51896,7 +51896,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "send_message",
+      "id": "slack__send_message",
       "name": "Send Message",
       "description": "Send a message to a Slack channel",
       "requiresWrite": true,
@@ -51915,7 +51915,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_message",
+      "id": "slack__update_message",
       "name": "Update Message",
       "description": "Update a message previously sent by this integration",
       "requiresWrite": true,
@@ -51941,7 +51941,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_message",
+      "id": "slack__delete_message",
       "name": "Delete Message",
       "description": "Delete a message previously sent by this integration",
       "requiresWrite": true,
@@ -51962,7 +51962,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_messages",
+      "id": "slack__get_messages",
       "name": "Get Messages",
       "description": "Get recent messages from a channel",
       "requiresWrite": false,
@@ -51977,7 +51977,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "messages" },
       },
     }, {
-      "id": "get_thread",
+      "id": "slack__get_thread",
       "name": "Get Thread",
       "description": "Get all replies in a Slack message thread",
       "requiresWrite": false,
@@ -52000,7 +52000,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "messages" },
       },
     }, {
-      "id": "list_users",
+      "id": "slack__list_users",
       "name": "List Users",
       "description": "List members of the Slack workspace",
       "requiresWrite": false,
@@ -52104,7 +52104,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.snowflake.com/en/user-guide/databases",
     }],
     "tools": [{
-      "id": "run_query",
+      "id": "snowflake__run_query",
       "name": "Run Query",
       "description": "Execute a SQL query against your Snowflake data warehouse",
       "requiresWrite": true,
@@ -52145,22 +52145,22 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_databases",
+      "id": "snowflake__list_databases",
       "name": "List Databases",
       "description": "List all databases in your Snowflake account",
       "requiresWrite": false,
     }, {
-      "id": "list_schemas",
+      "id": "snowflake__list_schemas",
       "name": "List Schemas",
       "description": "List all schemas in a Snowflake database",
       "requiresWrite": false,
     }, {
-      "id": "list_tables",
+      "id": "snowflake__list_tables",
       "name": "List Tables",
       "description": "List all tables in a Snowflake database schema",
       "requiresWrite": false,
     }, {
-      "id": "describe_table",
+      "id": "snowflake__describe_table",
       "name": "Describe Table",
       "description": "Get detailed column information for a specific table",
       "requiresWrite": false,
@@ -52248,7 +52248,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.snyk.io/snyk-api/authentication-for-api",
     }],
     "tools": [{
-      "id": "list_orgs",
+      "id": "snyk__list_orgs",
       "name": "List Organizations",
       "description": "List Snyk organizations the token can access",
       "requiresWrite": false,
@@ -52271,7 +52271,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_projects",
+      "id": "snyk__list_projects",
       "name": "List Projects",
       "description": "List projects in a Snyk organization",
       "requiresWrite": false,
@@ -52317,7 +52317,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_project",
+      "id": "snyk__get_project",
       "name": "Get Project",
       "description": "Get a project's details in a Snyk organization",
       "requiresWrite": false,
@@ -52346,7 +52346,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_issues",
+      "id": "snyk__list_issues",
       "name": "List Issues",
       "description":
         "List security issues in a Snyk organization, optionally filtered by severity or status",
@@ -52387,7 +52387,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_org",
+      "id": "snyk__get_org",
       "name": "Get Organization",
       "description": "Get details of a Snyk organization",
       "requiresWrite": false,
@@ -52483,7 +52483,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.sprites.dev/cli/authentication/",
     }],
     "tools": [{
-      "id": "list_sprites",
+      "id": "sprites__list_sprites",
       "name": "List Sprites",
       "description":
         "List sprites in the organization, optionally filtered by name prefix and paginated",
@@ -52511,7 +52511,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_sprite",
+      "id": "sprites__create_sprite",
       "name": "Create Sprite",
       "description":
         "Create a new sprite — a persistent, hardware-isolated Linux VM that keeps its filesystem state between runs",
@@ -52533,7 +52533,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_sprite",
+      "id": "sprites__get_sprite",
       "name": "Get Sprite",
       "description":
         "Get a sprite by name, including its URL, runtime status (cold, warm, or running), and creation/activity timestamps",
@@ -52551,7 +52551,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "delete_sprite",
+      "id": "sprites__delete_sprite",
       "name": "Destroy Sprite",
       "description":
         "Destroy a sprite by name, permanently deleting the VM and its persisted filesystem state",
@@ -52569,7 +52569,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "exec_command",
+      "id": "sprites__exec_command",
       "name": "Execute Command",
       "description":
         "Execute a command inside a sprite over HTTP (non-interactive) and return its output as JSON",
@@ -52605,7 +52605,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_checkpoint",
+      "id": "sprites__create_checkpoint",
       "name": "Create Checkpoint",
       "description":
         "Create a point-in-time checkpoint of a sprite (filesystem and memory) before risky operations; the response is a stream of NDJSON progress events",
@@ -52629,7 +52629,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_checkpoints",
+      "id": "sprites__list_checkpoints",
       "name": "List Checkpoints",
       "description":
         "List a sprite's checkpoints with their IDs (e.g. v7), creation times, and comments — discover restore points",
@@ -52647,7 +52647,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "restore_checkpoint",
+      "id": "sprites__restore_checkpoint",
       "name": "Restore Checkpoint",
       "description":
         "Roll a sprite back to a checkpoint, replacing its current state with the snapshot; the response is a stream of NDJSON progress events",
@@ -52761,7 +52761,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.squareup.com/apps",
     }],
     "tools": [{
-      "id": "list_payments",
+      "id": "square__list_payments",
       "name": "List Payments",
       "description": "List payments taken by the seller account",
       "requiresWrite": false,
@@ -52829,7 +52829,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_payment",
+      "id": "square__get_payment",
       "name": "Get Payment",
       "description": "Get details of a payment",
       "requiresWrite": false,
@@ -52854,7 +52854,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "payment" },
       },
     }, {
-      "id": "search_orders",
+      "id": "square__search_orders",
       "name": "Search Orders",
       "description": "Search orders across locations (read-only search via POST)",
       "requiresWrite": false,
@@ -52889,7 +52889,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_customers",
+      "id": "square__list_customers",
       "name": "List Customers",
       "description": "List customer profiles",
       "requiresWrite": false,
@@ -52930,7 +52930,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_locations",
+      "id": "square__list_locations",
       "name": "List Locations",
       "description": "List the seller's business locations",
       "requiresWrite": false,
@@ -52949,7 +52949,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "locations" },
       },
     }, {
-      "id": "list_catalog",
+      "id": "square__list_catalog",
       "name": "List Catalog",
       "description": "List catalog objects such as items and categories",
       "requiresWrite": false,
@@ -53047,7 +53047,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://platform.stability.ai/account/keys",
     }],
     "tools": [{
-      "id": "list_engines",
+      "id": "stability-ai__list_engines",
       "name": "List Engines",
       "description": "List the generation engines (models) available to your account",
       "requiresWrite": false,
@@ -53067,19 +53067,19 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_balance",
+      "id": "stability-ai__get_balance",
       "name": "Get Balance",
       "description": "Get the credit balance of your Stability AI account",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.stability.ai/v1/user/balance" },
     }, {
-      "id": "get_account",
+      "id": "stability-ai__get_account",
       "name": "Get Account",
       "description": "Get profile and organization details for the account that owns the API key",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.stability.ai/v1/user/account" },
     }, {
-      "id": "text_to_image",
+      "id": "stability-ai__text_to_image",
       "name": "Text to Image",
       "description":
         "Generate images from a text prompt with a Stable Diffusion engine (consumes credits)",
@@ -53218,7 +53218,7 @@ export const connectors: IntegrationConfig[] = [
         "https://docs.stackit.cloud/platform/access-and-identity/service-accounts/how-tos/get-access-token/",
     }],
     "tools": [{
-      "id": "list_projects",
+      "id": "stackit__list_projects",
       "name": "List Projects",
       "description":
         "List STACKIT projects visible to the service account via the Resource Manager. At least one of containerParentId or member must be provided (use the service account's email as member).",
@@ -53265,7 +53265,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_servers",
+      "id": "stackit__list_servers",
       "name": "List Servers",
       "description": "List IaaS servers in a STACKIT project and region",
       "requiresWrite": false,
@@ -53315,7 +53315,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_server",
+      "id": "stackit__get_server",
       "name": "Get Server",
       "description":
         "Get a single IaaS server in a project and region, including status, machine type, and availability zone",
@@ -53352,7 +53352,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_machine_types",
+      "id": "stackit__list_machine_types",
       "name": "List Machine Types",
       "description":
         "List available machine types (server flavors) in a project and region, useful before creating or resizing servers",
@@ -53393,7 +53393,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "start_server",
+      "id": "stackit__start_server",
       "name": "Start Server",
       "description":
         "Boot up a stopped server, or allocate it again if it was deallocated (returns 202 Accepted; completes asynchronously)",
@@ -53424,7 +53424,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "stop_server",
+      "id": "stackit__stop_server",
       "name": "Stop Server",
       "description":
         "Stop a server (returns 202 Accepted; completes asynchronously). Note: a stopped server remains on the hypervisor and is still charged full price for its attached resources",
@@ -53455,7 +53455,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "reboot_server",
+      "id": "stackit__reboot_server",
       "name": "Reboot Server",
       "description":
         "Reboot a server (returns 202 Accepted; completes asynchronously); soft reboots ask the OS to shut down gracefully, hard reboots power-cycle",
@@ -53575,7 +53575,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://dashboard.stripe.com/webhooks",
     }],
     "tools": [{
-      "id": "list_customers",
+      "id": "stripe__list_customers",
       "name": "List Customers",
       "description": "List Stripe customers with optional filtering",
       "requiresWrite": false,
@@ -53618,7 +53618,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_customer",
+      "id": "stripe__get_customer",
       "name": "Get Customer",
       "description": "Retrieve detailed information about a specific customer",
       "requiresWrite": false,
@@ -53635,7 +53635,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_payments",
+      "id": "stripe__list_payments",
       "name": "List Payments",
       "description": "List payment intents with optional status filtering",
       "requiresWrite": false,
@@ -53680,13 +53680,13 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_balance",
+      "id": "stripe__get_balance",
       "name": "Get Balance",
       "description": "Retrieve the current account balance",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.stripe.com/v1/balance" },
     }, {
-      "id": "list_subscriptions",
+      "id": "stripe__list_subscriptions",
       "name": "List Subscriptions",
       "description": "List subscriptions with optional status filtering",
       "requiresWrite": false,
@@ -53740,7 +53740,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_invoices",
+      "id": "stripe__list_invoices",
       "name": "List Invoices",
       "description": "List invoices with optional customer and status filtering",
       "requiresWrite": false,
@@ -53794,7 +53794,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_charges",
+      "id": "stripe__list_charges",
       "name": "List Charges",
       "description": "List charges with optional customer or payment intent filtering",
       "requiresWrite": false,
@@ -53915,44 +53915,44 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://supabase.com/docs/guides/api#api-url-and-keys",
     }],
     "tools": [{
-      "id": "list_tables",
+      "id": "supabase__list_tables",
       "name": "List Tables",
       "description": "List all tables in your Supabase database",
       "requiresWrite": false,
     }, {
-      "id": "query_table",
+      "id": "supabase__query_table",
       "name": "Query Table",
       "description": "Select rows from a table with optional filters and sorting",
       "requiresWrite": false,
     }, {
-      "id": "insert_row",
+      "id": "supabase__insert_row",
       "name": "Insert Row",
       "description": "Insert a new row into a table",
       "requiresWrite": true,
     }, {
-      "id": "update_row",
+      "id": "supabase__update_row",
       "name": "Update Row",
       "description": "Update an existing row in a table",
       "requiresWrite": true,
     }, {
-      "id": "delete_row",
+      "id": "supabase__delete_row",
       "name": "Delete Row",
       "description": "Delete a row from a table",
       "requiresWrite": true,
     }, {
-      "id": "list_organizations",
+      "id": "supabase__list_organizations",
       "name": "List Organizations",
       "description": "List the organizations your access token can manage",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.supabase.com/v1/organizations" },
     }, {
-      "id": "list_projects",
+      "id": "supabase__list_projects",
       "name": "List Projects",
       "description": "List all Supabase projects across your organizations",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.supabase.com/v1/projects" },
     }, {
-      "id": "get_project",
+      "id": "supabase__get_project",
       "name": "Get Project",
       "description": "Get details and status of a Supabase project",
       "requiresWrite": false,
@@ -53969,7 +53969,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "run_sql",
+      "id": "supabase__run_sql",
       "name": "Run SQL",
       "description": "Run a SQL query against a project's Postgres database via the Management API",
       "requiresWrite": true,
@@ -54046,7 +54046,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.surveymonkey.com/apps/",
     }],
     "tools": [{
-      "id": "list_surveys",
+      "id": "surveymonkey__list_surveys",
       "name": "List Surveys",
       "description": "List surveys owned by or shared with the authenticated account",
       "requiresWrite": false,
@@ -54098,7 +54098,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_survey_details",
+      "id": "surveymonkey__get_survey_details",
       "name": "Get Survey Details",
       "description":
         "Get a survey's full design, including pages, questions, and answer option IDs needed to interpret responses",
@@ -54116,7 +54116,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_survey_responses",
+      "id": "surveymonkey__list_survey_responses",
       "name": "List Survey Responses",
       "description":
         "List full responses for a survey, including each answer keyed by question and choice IDs",
@@ -54147,7 +54147,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_response_details",
+      "id": "surveymonkey__get_response_details",
       "name": "Get Response Details",
       "description": "Get a single survey response with all answers expanded",
       "requiresWrite": false,
@@ -54170,7 +54170,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_survey_rollups",
+      "id": "surveymonkey__get_survey_rollups",
       "name": "Get Survey Rollups",
       "description":
         "Get aggregated answer counts and statistics per question — summarize results without paging every response",
@@ -54206,7 +54206,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_survey_folders",
+      "id": "surveymonkey__list_survey_folders",
       "name": "List Survey Folders",
       "description":
         "List the survey folders in the account to find folder IDs for filtering surveys",
@@ -54231,7 +54231,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_collectors",
+      "id": "surveymonkey__list_collectors",
       "name": "List Collectors",
       "description":
         "List the collectors (web links, email invitations, etc.) that gather responses for a survey",
@@ -54343,7 +54343,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developers.tally.so/api-reference/api-keys",
     }],
     "tools": [{
-      "id": "list_forms",
+      "id": "tally__list_forms",
       "name": "List Forms",
       "description": "List forms in the Tally account, optionally filtered by workspace",
       "requiresWrite": false,
@@ -54371,7 +54371,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_form",
+      "id": "tally__get_form",
       "name": "Get Form",
       "description": "Retrieve a single form by ID with all its blocks and settings",
       "requiresWrite": false,
@@ -54388,7 +54388,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_submissions",
+      "id": "tally__list_submissions",
       "name": "List Submissions",
       "description":
         "List submissions of a form with their responses, filterable by status and date range",
@@ -54438,7 +54438,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_submission",
+      "id": "tally__get_submission",
       "name": "Get Submission",
       "description":
         "Retrieve a specific form submission with all its responses and the form questions",
@@ -54462,7 +54462,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_form_questions",
+      "id": "tally__list_form_questions",
       "name": "List Form Questions",
       "description":
         "List a form's questions with their IDs, types, and response counts — lighter than parsing the full form blocks for mapping answers",
@@ -54480,7 +54480,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_workspaces",
+      "id": "tally__list_workspaces",
       "name": "List Workspaces",
       "description": "List workspaces with their members and pending invites",
       "requiresWrite": false,
@@ -54565,7 +54565,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.tavily.com/documentation/quickstart",
     }],
     "tools": [{
-      "id": "search",
+      "id": "tavily__search",
       "name": "Search",
       "description": "Search the web and get ranked results with optional LLM answer",
       "requiresWrite": false,
@@ -54615,7 +54615,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "extract",
+      "id": "tavily__extract",
       "name": "Extract",
       "description": "Extract clean page content from one or more URLs",
       "requiresWrite": false,
@@ -54641,7 +54641,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "crawl",
+      "id": "tavily__crawl",
       "name": "Crawl",
       "description": "Crawl a website from a root URL and extract content from discovered pages",
       "requiresWrite": false,
@@ -54672,7 +54672,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "map",
+      "id": "tavily__map",
       "name": "Map",
       "description": "Get a list of URLs discovered on a website without extracting content",
       "requiresWrite": false,
@@ -54778,7 +54778,7 @@ export const connectors: IntegrationConfig[] = [
         "https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade",
     }],
     "tools": [{
-      "id": "list_chats",
+      "id": "teams__list_chats",
       "name": "List Chats",
       "description": "List recent Teams chats",
       "requiresWrite": false,
@@ -54796,7 +54796,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "get_messages",
+      "id": "teams__get_messages",
       "name": "Get Messages",
       "description": "Get messages from a specific chat",
       "requiresWrite": false,
@@ -54820,7 +54820,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "send_message",
+      "id": "teams__send_message",
       "name": "Send Channel Message",
       "description": "Send a message to a Teams channel",
       "requiresWrite": true,
@@ -54851,7 +54851,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "send_chat_message",
+      "id": "teams__send_chat_message",
       "name": "Send Chat Message",
       "description": "Send a message to a Teams 1:1 or group chat",
       "requiresWrite": true,
@@ -54876,7 +54876,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_teams",
+      "id": "teams__list_teams",
       "name": "List Teams",
       "description": "List all joined Teams",
       "requiresWrite": false,
@@ -54894,7 +54894,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "list_channels",
+      "id": "teams__list_channels",
       "name": "List Channels",
       "description": "List channels in a specific Team",
       "requiresWrite": false,
@@ -54912,7 +54912,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "value" },
       },
     }, {
-      "id": "create_chat",
+      "id": "teams__create_chat",
       "name": "Create Chat",
       "description":
         "Create a new 1:1 or group chat so a message can be sent to someone without an existing chat",
@@ -54980,7 +54980,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://core.telegram.org/bots/features#botfather",
     }],
     "tools": [{
-      "id": "send_message",
+      "id": "telegram__send_message",
       "name": "Send Message",
       "description": "Send a text message to a chat, group, or channel the bot has access to",
       "requiresWrite": true,
@@ -55007,7 +55007,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_updates",
+      "id": "telegram__get_updates",
       "name": "Get Updates",
       "description":
         "Receive incoming updates (messages sent to the bot) via long polling; use it to discover chat ids",
@@ -55037,14 +55037,14 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_me",
+      "id": "telegram__get_me",
       "name": "Get Me",
       "description":
         "Return basic information about the bot itself; useful for verifying the token works",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.telegram.org/bot{{auth.token}}/getMe" },
     }, {
-      "id": "send_photo",
+      "id": "telegram__send_photo",
       "name": "Send Photo",
       "description":
         "Send a photo to a chat by passing a publicly reachable HTTP URL or an existing Telegram file_id",
@@ -55072,7 +55072,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "edit_message_text",
+      "id": "telegram__edit_message_text",
       "name": "Edit Message Text",
       "description": "Edit the text of a message previously sent by the bot",
       "requiresWrite": true,
@@ -55157,7 +55157,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.todoist.com/appconsole.html",
     }],
     "tools": [{
-      "id": "list_tasks",
+      "id": "todoist__list_tasks",
       "name": "List Tasks",
       "description": "List active tasks, optionally filtered by project",
       "requiresWrite": false,
@@ -55206,7 +55206,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_task",
+      "id": "todoist__get_task",
       "name": "Get Task",
       "description": "Get details of a specific task",
       "requiresWrite": false,
@@ -55223,7 +55223,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_task",
+      "id": "todoist__create_task",
       "name": "Create Task",
       "description": "Create a new task",
       "requiresWrite": true,
@@ -55250,7 +55250,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_task",
+      "id": "todoist__update_task",
       "name": "Update Task",
       "description": "Update an existing task",
       "requiresWrite": true,
@@ -55277,7 +55277,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "close_task",
+      "id": "todoist__close_task",
       "name": "Complete Task",
       "description": "Mark a task as complete",
       "requiresWrite": true,
@@ -55294,7 +55294,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_projects",
+      "id": "todoist__list_projects",
       "name": "List Projects",
       "description": "List the user's projects",
       "requiresWrite": false,
@@ -55395,7 +55395,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.together.ai/docs/quickstart",
     }],
     "tools": [{
-      "id": "list_models",
+      "id": "together-ai__list_models",
       "name": "List Models",
       "description": "List the models available on Together AI",
       "requiresWrite": false,
@@ -55414,7 +55414,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_chat_completion",
+      "id": "together-ai__create_chat_completion",
       "name": "Create Chat Completion",
       "description": "Generate a chat completion from a list of messages",
       "requiresWrite": true,
@@ -55437,7 +55437,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_embedding",
+      "id": "together-ai__create_embedding",
       "name": "Create Embedding",
       "description": "Create an embedding vector for input text",
       "requiresWrite": true,
@@ -55454,7 +55454,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "generate_image",
+      "id": "together-ai__generate_image",
       "name": "Generate Image",
       "description": "Generate an image from a text prompt",
       "requiresWrite": true,
@@ -55552,27 +55552,27 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.atlassian.com/cloud/trello/guides/rest-api/authorization/",
     }],
     "tools": [{
-      "id": "list_boards",
+      "id": "trello__list_boards",
       "name": "List Boards",
       "description": "List all boards accessible to the user",
       "requiresWrite": false,
     }, {
-      "id": "list_cards",
+      "id": "trello__list_cards",
       "name": "List Cards",
       "description": "List cards in a board or list",
       "requiresWrite": false,
     }, {
-      "id": "get_card",
+      "id": "trello__get_card",
       "name": "Get Card",
       "description": "Get details of a specific card",
       "requiresWrite": false,
     }, {
-      "id": "create_card",
+      "id": "trello__create_card",
       "name": "Create Card",
       "description": "Create a new card in a list",
       "requiresWrite": true,
     }, {
-      "id": "update_card",
+      "id": "trello__update_card",
       "name": "Update Card",
       "description": "Update an existing card",
       "requiresWrite": true,
@@ -55624,7 +55624,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developers.etrusted.com/docs/generating-api-credentials",
     }],
     "tools": [{
-      "id": "list_reviews",
+      "id": "trusted-shops__list_reviews",
       "name": "List Reviews",
       "description":
         "List service and product reviews for the whole account or specific channels, with filters and cursor pagination",
@@ -55709,7 +55709,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_review",
+      "id": "trusted-shops__get_review",
       "name": "Get Review",
       "description":
         "Get a single review with full comment, customer, transaction, product, and reply details",
@@ -55727,14 +55727,14 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_channels",
+      "id": "trusted-shops__list_channels",
       "name": "List Channels",
       "description":
         "List all review channels (shops/touchpoints) of the account with their IDs, names, URLs, and locales",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://api.etrusted.com/channels" },
     }, {
-      "id": "get_channel_rating",
+      "id": "trusted-shops__get_channel_rating",
       "name": "Get Channel Aggregate Rating",
       "description":
         "Get aggregate service review ratings for a channel across 7-day, 30-day, 90-day, 365-day, and overall periods, including star distribution",
@@ -55752,7 +55752,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_review_invites",
+      "id": "trusted-shops__create_review_invites",
       "name": "Create Review Invites",
       "description":
         "Schedule review invite emails for one or more customers of a channel after a transaction",
@@ -55786,7 +55786,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_reviews_count",
+      "id": "trusted-shops__get_reviews_count",
       "name": "Get Reviews Count",
       "description":
         "Get the total number of reviews matching a filter — cheap KPI queries without paging through review lists",
@@ -55839,7 +55839,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "reply_to_review",
+      "id": "trusted-shops__reply_to_review",
       "name": "Reply to Review",
       "description": "Save a public reply on a review — the natural follow-up to negative reviews",
       "requiresWrite": true,
@@ -55955,17 +55955,17 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://console.twilio.com/us1/develop/phone-numbers/manage/incoming",
     }],
     "tools": [{
-      "id": "send_sms",
+      "id": "twilio__send_sms",
       "name": "Send SMS",
       "description": "Send an SMS text message to a phone number",
       "requiresWrite": true,
     }, {
-      "id": "send_whatsapp",
+      "id": "twilio__send_whatsapp",
       "name": "Send WhatsApp Message",
       "description": "Send a WhatsApp message to a phone number",
       "requiresWrite": true,
     }, {
-      "id": "list_messages",
+      "id": "twilio__list_messages",
       "name": "List Messages",
       "description": "List recent SMS and WhatsApp messages",
       "requiresWrite": false,
@@ -56025,7 +56025,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_message",
+      "id": "twilio__get_message",
       "name": "Get Message",
       "description": "Get details about a specific message",
       "requiresWrite": false,
@@ -56049,7 +56049,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_calls",
+      "id": "twilio__list_calls",
       "name": "List Calls",
       "description": "List recent phone calls",
       "requiresWrite": false,
@@ -56191,7 +56191,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://www.typeform.com/developers/get-started/applications/",
     }],
     "tools": [{
-      "id": "list_forms",
+      "id": "typeform__list_forms",
       "name": "List Forms",
       "description": "List forms in the account or a workspace",
       "requiresWrite": false,
@@ -56231,7 +56231,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_form",
+      "id": "typeform__get_form",
       "name": "Get Form",
       "description": "Get a form definition including its fields",
       "requiresWrite": false,
@@ -56248,7 +56248,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_responses",
+      "id": "typeform__list_responses",
       "name": "List Responses",
       "description": "List responses submitted to a form",
       "requiresWrite": false,
@@ -56311,7 +56311,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_workspaces",
+      "id": "typeform__list_workspaces",
       "name": "List Workspaces",
       "description": "List workspaces in the account",
       "requiresWrite": false,
@@ -56335,7 +56335,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_me",
+      "id": "typeform__get_me",
       "name": "Get Me",
       "description": "Get the authenticated Typeform account profile",
       "requiresWrite": false,
@@ -56404,7 +56404,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.unstructured.io/api-reference/partition/overview",
     }],
     "tools": [{
-      "id": "partition_document",
+      "id": "unstructured__partition_document",
       "name": "Partition Document",
       "description":
         "Parse one local document into structured JSON elements (titles, narrative text, tables, lists) with optional chunking for RAG. The file content is uploaded as the multipart/form-data 'files' field together with the other fields; remote URLs are not accepted — fetch the file first and pass its content",
@@ -56554,7 +56554,7 @@ export const connectors: IntegrationConfig[] = [
       "default": "",
     }],
     "tools": [{
-      "id": "get_payment",
+      "id": "unzer__get_payment",
       "name": "Get Payment",
       "description":
         "Retrieve a payment resource with its state, amounts (total, charged, canceled, remaining), and linked transactions",
@@ -56572,7 +56572,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_charge",
+      "id": "unzer__get_charge",
       "name": "Get Charge",
       "description":
         "Retrieve a specific charge transaction of a payment, including amount, status, and processing details",
@@ -56596,7 +56596,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_charge",
+      "id": "unzer__create_charge",
       "name": "Create Charge",
       "description":
         "Directly charge a payment type (one-step payment without prior authorization) using a payment type ID",
@@ -56637,7 +56637,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "refund_charge",
+      "id": "unzer__refund_charge",
       "name": "Refund Charge",
       "description": "Cancel (refund) a charge fully or partially, returning money to the customer",
       "requiresWrite": true,
@@ -56670,7 +56670,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "authorize_payment",
+      "id": "unzer__authorize_payment",
       "name": "Authorize Payment",
       "description":
         "Reserve funds on a payment type without charging yet (first step of the two-step authorize-then-charge flow, e.g. charge on shipment); reservations are held for about 7 days",
@@ -56711,7 +56711,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "charge_authorization",
+      "id": "unzer__charge_authorization",
       "name": "Charge Authorization",
       "description":
         "Capture a previously authorized payment, fully (empty body) or partially (with amount) — the second step of the authorize-then-charge flow",
@@ -56740,7 +56740,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "cancel_authorization",
+      "id": "unzer__cancel_authorization",
       "name": "Cancel Authorization",
       "description":
         "Cancel (reverse) an uncaptured authorization fully or partially, releasing the reserved funds — distinct from refunding a charge",
@@ -56838,7 +56838,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://vercel.com/docs/rest-api/authentication/create-an-auth-token",
     }],
     "tools": [{
-      "id": "list_projects",
+      "id": "vercel__list_projects",
       "name": "List Projects",
       "description": "List projects of the authenticated user or team",
       "requiresWrite": false,
@@ -56888,7 +56888,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_project",
+      "id": "vercel__get_project",
       "name": "Get Project",
       "description": "Get a project by ID or name",
       "requiresWrite": false,
@@ -56915,7 +56915,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_deployments",
+      "id": "vercel__list_deployments",
       "name": "List Deployments",
       "description": "List deployments under the authenticated user or team",
       "requiresWrite": false,
@@ -56986,7 +56986,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_deployment",
+      "id": "vercel__get_deployment",
       "name": "Get Deployment",
       "description": "Get a deployment by ID or hostname URL",
       "requiresWrite": false,
@@ -57013,7 +57013,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_env_vars",
+      "id": "vercel__list_env_vars",
       "name": "List Environment Variables",
       "description":
         "List the environment variables of a project (values stay encrypted unless decrypt is set)",
@@ -57121,7 +57121,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.voyageai.com/docs/api-key-and-installation",
     }],
     "tools": [{
-      "id": "create_embeddings",
+      "id": "voyage-ai__create_embeddings",
       "name": "Create Embeddings",
       "description":
         "Create embedding vectors for one or more texts — use input_type to optimize for retrieval queries vs documents",
@@ -57163,7 +57163,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "rerank_documents",
+      "id": "voyage-ai__rerank_documents",
       "name": "Rerank Documents",
       "description":
         "Rank candidate documents by relevance to a query with a Voyage reranker — use as a precision pass after vector search",
@@ -57204,7 +57204,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_contextualized_embeddings",
+      "id": "voyage-ai__create_contextualized_embeddings",
       "name": "Create Contextualized Embeddings",
       "description":
         "Embed document chunks with document-level context (voyage-context-3) so each chunk vector also captures the surrounding document",
@@ -57241,7 +57241,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_multimodal_embeddings",
+      "id": "voyage-ai__create_multimodal_embeddings",
       "name": "Create Multimodal Embeddings",
       "description":
         "Embed interleaved text and images into one vector space (voyage-multimodal models) for visual RAG over screenshots, slides, and PDFs",
@@ -57350,7 +57350,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://docs.weaviate.io/cloud/manage-clusters/connect",
     }],
     "tools": [{
-      "id": "get_schema",
+      "id": "weaviate__get_schema",
       "name": "Get Schema",
       "description": "List all collections (classes) and their property definitions",
       "requiresWrite": false,
@@ -57378,7 +57378,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "graphql_query",
+      "id": "weaviate__graphql_query",
       "name": "Run GraphQL Query",
       "description":
         "Run a GraphQL query against the cluster (Get, Aggregate, Explore — including nearText/nearVector search)",
@@ -57405,7 +57405,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_objects",
+      "id": "weaviate__list_objects",
       "name": "List Objects",
       "description": "List objects, optionally filtered to one collection (class)",
       "requiresWrite": false,
@@ -57439,7 +57439,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_object",
+      "id": "weaviate__get_object",
       "name": "Get Object",
       "description": "Get a single object by collection (class) and ID",
       "requiresWrite": false,
@@ -57464,7 +57464,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_object",
+      "id": "weaviate__create_object",
       "name": "Create Object",
       "description": "Create a new object in a collection (class)",
       "requiresWrite": true,
@@ -57587,7 +57587,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.webex.com/docs/integrations",
     }],
     "tools": [{
-      "id": "list_rooms",
+      "id": "webex__list_rooms",
       "name": "List Rooms",
       "description": "List Webex rooms (spaces) the authenticated user belongs to",
       "requiresWrite": false,
@@ -57631,7 +57631,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_messages",
+      "id": "webex__list_messages",
       "name": "List Messages",
       "description": "List recent messages in a Webex room",
       "requiresWrite": false,
@@ -57659,7 +57659,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_message",
+      "id": "webex__create_message",
       "name": "Send Message",
       "description": "Send a message to a Webex room or directly to a person",
       "requiresWrite": true,
@@ -57683,13 +57683,13 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_my_details",
+      "id": "webex__get_my_details",
       "name": "Get My Details",
       "description": "Get the authenticated Webex user's profile",
       "requiresWrite": false,
       "endpoint": { "method": "GET", "url": "https://webexapis.com/v1/people/me" },
     }, {
-      "id": "list_people",
+      "id": "webex__list_people",
       "name": "List People",
       "description": "Look up people in the organization by email or display name",
       "requiresWrite": false,
@@ -57801,7 +57801,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developers.facebook.com/docs/whatsapp/cloud-api/get-started",
     }],
     "tools": [{
-      "id": "send_text_message",
+      "id": "whatsapp__send_text_message",
       "name": "Send Text Message",
       "description":
         "Send a free-form text message to a WhatsApp user (only within 24 hours of their last message; otherwise use a template)",
@@ -57843,7 +57843,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "send_template_message",
+      "id": "whatsapp__send_template_message",
       "name": "Send Template Message",
       "description":
         "Send an approved message template to a WhatsApp user; required to start conversations outside the 24-hour customer service window",
@@ -57880,7 +57880,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "send_media_message",
+      "id": "whatsapp__send_media_message",
       "name": "Send Media Message",
       "description":
         "Send an image, document, video, or audio message to a WhatsApp user by public URL or uploaded media ID (subject to the same 24-hour window as text messages)",
@@ -57936,7 +57936,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_media_url",
+      "id": "whatsapp__get_media_url",
       "name": "Get Media URL",
       "description":
         "Get a short-lived download URL and metadata for a media ID, e.g. to retrieve an image or document a customer sent inbound",
@@ -57960,7 +57960,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_business_profile",
+      "id": "whatsapp__update_business_profile",
       "name": "Update Business Profile",
       "description":
         "Update the business profile (about, address, description, email, websites, vertical) shown to customers for a business phone number",
@@ -58004,7 +58004,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "mark_message_read",
+      "id": "whatsapp__mark_message_read",
       "name": "Mark Message as Read",
       "description":
         "Mark an inbound WhatsApp message as read so the customer sees read receipts after the agent processes it",
@@ -58035,7 +58035,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_business_profile",
+      "id": "whatsapp__get_business_profile",
       "name": "Get Business Profile",
       "description":
         "Read the business profile (about, address, email, websites) shown to customers for a business phone number",
@@ -58060,7 +58060,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_message_templates",
+      "id": "whatsapp__list_message_templates",
       "name": "List Message Templates",
       "description":
         "List the message templates on a WhatsApp Business Account so an agent can pick an approved template name and language before sending",
@@ -58187,7 +58187,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://dev.wix.com/docs/rest/articles/getting-started/api-keys",
     }],
     "tools": [{
-      "id": "query_products",
+      "id": "wix__query_products",
       "name": "Query Products",
       "description": "Query Wix Stores catalog products with filtering, sorting, and paging",
       "requiresWrite": false,
@@ -58208,7 +58208,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "products" },
       },
     }, {
-      "id": "search_orders",
+      "id": "wix__search_orders",
       "name": "Search Orders",
       "description": "Search Wix eCommerce orders with filtering, sorting, and cursor paging",
       "requiresWrite": false,
@@ -58225,7 +58225,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "orders" },
       },
     }, {
-      "id": "get_order",
+      "id": "wix__get_order",
       "name": "Get Order",
       "description":
         "Get full details of a single eCommerce order, including line items, totals, and buyer info",
@@ -58244,7 +58244,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "order" },
       },
     }, {
-      "id": "query_contacts",
+      "id": "wix__query_contacts",
       "name": "Query Contacts",
       "description":
         "Query CRM contacts with filtering, sorting, and paging (up to 1000 per request)",
@@ -58262,7 +58262,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "contacts" },
       },
     }, {
-      "id": "create_fulfillment",
+      "id": "wix__create_fulfillment",
       "name": "Create Fulfillment",
       "description":
         "Mark eCommerce order line items as fulfilled, optionally with shipping tracking info",
@@ -58288,7 +58288,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_contact",
+      "id": "wix__create_contact",
       "name": "Create Contact",
       "description":
         "Create a new CRM contact with at least a name, email address, or phone number",
@@ -58312,7 +58312,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "contact" },
       },
     }, {
-      "id": "create_product",
+      "id": "wix__create_product",
       "name": "Create Product",
       "description": "Create a new product in the Wix Stores catalog",
       "requiresWrite": true,
@@ -58425,7 +58425,7 @@ export const connectors: IntegrationConfig[] = [
       "placeholder": "shop.example.com",
     }],
     "tools": [{
-      "id": "list_orders",
+      "id": "woocommerce__list_orders",
       "name": "List Orders",
       "description": "List orders in the store with optional status, search, and date filters",
       "requiresWrite": false,
@@ -58472,7 +58472,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_order",
+      "id": "woocommerce__get_order",
       "name": "Get Order",
       "description":
         "Retrieve full details of a specific order, including line items, totals, and shipping",
@@ -58496,7 +58496,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_order_status",
+      "id": "woocommerce__update_order_status",
       "name": "Update Order Status",
       "description":
         "Update an order's status (e.g. mark as completed) and optionally add a customer note",
@@ -58532,7 +58532,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_products",
+      "id": "woocommerce__list_products",
       "name": "List Products",
       "description": "List products in the catalog with optional search, status, and SKU filters",
       "requiresWrite": false,
@@ -58577,7 +58577,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_product",
+      "id": "woocommerce__create_product",
       "name": "Create Product",
       "description": "Create a new product in the store catalog",
       "requiresWrite": true,
@@ -58629,7 +58629,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_product",
+      "id": "woocommerce__get_product",
       "name": "Get Product",
       "description":
         "Retrieve full details of a specific product, including price, stock, and categories",
@@ -58653,7 +58653,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "update_product",
+      "id": "woocommerce__update_product",
       "name": "Update Product",
       "description": "Update an existing product's price, stock, status, or descriptions",
       "requiresWrite": true,
@@ -58709,7 +58709,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_sales_report",
+      "id": "woocommerce__get_sales_report",
       "name": "Get Sales Report",
       "description":
         "Get a sales report with totals for revenue, orders, items, and customers over a period or date range",
@@ -58743,7 +58743,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_customers",
+      "id": "woocommerce__list_customers",
       "name": "List Customers",
       "description": "List store customers with optional email, role, and search filters",
       "requiresWrite": false,
@@ -58873,7 +58873,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://workable.readme.io/reference/generate-an-access-token",
     }],
     "tools": [{
-      "id": "list_jobs",
+      "id": "workable__list_jobs",
       "name": "List Jobs",
       "description": "List jobs in the Workable account with optional state filtering",
       "requiresWrite": false,
@@ -58939,7 +58939,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_job",
+      "id": "workable__get_job",
       "name": "Get Job",
       "description": "Get the full details of a job by its shortcode",
       "requiresWrite": false,
@@ -58962,7 +58962,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_candidates",
+      "id": "workable__list_candidates",
       "name": "List Candidates",
       "description":
         "List candidates account-wide or for a specific job (filter by job shortcode, stage, or email)",
@@ -59034,7 +59034,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_candidate",
+      "id": "workable__get_candidate",
       "name": "Get Candidate",
       "description":
         "Get the full profile of a candidate by ID, including stage, answers, and attachments",
@@ -59058,7 +59058,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_members",
+      "id": "workable__list_members",
       "name": "List Members",
       "description":
         "List account members to find the member IDs required by the comment and move-candidate tools",
@@ -59115,7 +59115,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_stages",
+      "id": "workable__list_stages",
       "name": "List Stages",
       "description":
         "List the recruitment pipeline stages to find stage slugs for candidate filtering and moves",
@@ -59133,7 +59133,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_candidate",
+      "id": "workable__create_candidate",
       "name": "Create Candidate",
       "description": "Add a candidate to a job, either as sourced or as having applied",
       "requiresWrite": true,
@@ -59174,7 +59174,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_candidate_comment",
+      "id": "workable__create_candidate_comment",
       "name": "Create Candidate Comment",
       "description": "Post a comment on a candidate's timeline on behalf of a team member",
       "requiresWrite": true,
@@ -59211,7 +59211,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "move_candidate",
+      "id": "workable__move_candidate",
       "name": "Move Candidate",
       "description": "Move a candidate to another pipeline stage on behalf of a team member",
       "requiresWrite": true,
@@ -59326,7 +59326,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.xentral.com/reference/authentication",
     }],
     "tools": [{
-      "id": "list_sales_orders",
+      "id": "xentral__list_sales_orders",
       "name": "List Sales Orders",
       "description":
         "List sales orders in the Xentral instance with optional filtering and pagination",
@@ -59375,7 +59375,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_sales_order",
+      "id": "xentral__get_sales_order",
       "name": "Get Sales Order",
       "description": "Get a single sales order with its positions and financial details",
       "requiresWrite": false,
@@ -59399,7 +59399,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_products",
+      "id": "xentral__list_products",
       "name": "List Products",
       "description":
         "List products in the Xentral instance (v2 API) with optional filtering and pagination",
@@ -59442,7 +59442,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "list_customers",
+      "id": "xentral__list_customers",
       "name": "List Customers",
       "description":
         "List customers in the Xentral instance (v2 API) with optional filtering and pagination",
@@ -59485,7 +59485,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "create_sales_order",
+      "id": "xentral__create_sales_order",
       "name": "Create Sales Order",
       "description":
         "Import a new sales order into Xentral with customer, financials, delivery, and order positions",
@@ -59545,7 +59545,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_product",
+      "id": "xentral__get_product",
       "name": "Get Product",
       "description":
         "Get a single product with full details (v2 API) after finding it via List Products",
@@ -59570,7 +59570,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_customer",
+      "id": "xentral__get_customer",
       "name": "Get Customer",
       "description":
         "Get a single customer record with full details including addresses (v2 API) — useful before creating a sales order",
@@ -59688,7 +59688,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developer.xero.com/documentation/guides/oauth2/auth-flow/",
     }],
     "tools": [{
-      "id": "list_connections",
+      "id": "xero__list_connections",
       "name": "List Connections",
       "description":
         "List Xero tenants (organisations) connected to this token — run this first to discover the tenantId used by every other tool",
@@ -59709,7 +59709,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_invoices",
+      "id": "xero__list_invoices",
       "name": "List Invoices",
       "description": "List invoices in a Xero organisation",
       "requiresWrite": false,
@@ -59771,7 +59771,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_invoice",
+      "id": "xero__get_invoice",
       "name": "Get Invoice",
       "description": "Get a Xero sales invoice or supplier bill with its line items",
       "requiresWrite": false,
@@ -59803,7 +59803,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "Invoices" },
       },
     }, {
-      "id": "create_invoice",
+      "id": "xero__create_invoice",
       "name": "Create Invoice",
       "description": "Create an invoice in a Xero organisation",
       "requiresWrite": true,
@@ -59838,7 +59838,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "Invoices" },
       },
     }, {
-      "id": "list_bills",
+      "id": "xero__list_bills",
       "name": "List Bills",
       "description":
         "List supplier bills (accounts payable) in a Xero organisation — bills are Invoices with Type ACCPAY",
@@ -59903,7 +59903,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_bill",
+      "id": "xero__create_bill",
       "name": "Create Bill",
       "description":
         'Create a supplier bill (accounts payable) in a Xero organisation — a bill is an Invoice with Type "ACCPAY"',
@@ -59939,7 +59939,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "Invoices" },
       },
     }, {
-      "id": "create_invoice_attachment",
+      "id": "xero__create_invoice_attachment",
       "name": "Create Invoice Attachment",
       "description":
         "Attach a file to a Xero sales invoice or supplier bill (max 10 MB per attachment)",
@@ -59989,7 +59989,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "Attachments" },
       },
     }, {
-      "id": "create_purchase_order",
+      "id": "xero__create_purchase_order",
       "name": "Create Purchase Order",
       "description": "Create a purchase order in a Xero organisation",
       "requiresWrite": true,
@@ -60024,7 +60024,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "PurchaseOrders" },
       },
     }, {
-      "id": "list_contacts",
+      "id": "xero__list_contacts",
       "name": "List Contacts",
       "description": "List contacts in a Xero organisation",
       "requiresWrite": false,
@@ -60062,7 +60062,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "Contacts" },
       },
     }, {
-      "id": "list_accounts",
+      "id": "xero__list_accounts",
       "name": "List Accounts",
       "description": "List the chart of accounts in a Xero organisation",
       "requiresWrite": false,
@@ -60093,7 +60093,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "Accounts" },
       },
     }, {
-      "id": "list_invoice_attachments",
+      "id": "xero__list_invoice_attachments",
       "name": "List Invoice Attachments",
       "description":
         "List the attachments on an invoice or bill (AttachmentID, FileName, MimeType, ContentLength) — see what Create Invoice Attachment uploaded",
@@ -60126,7 +60126,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "Attachments" },
       },
     }, {
-      "id": "list_purchase_orders",
+      "id": "xero__list_purchase_orders",
       "name": "List Purchase Orders",
       "description":
         "List purchase orders in a Xero organisation — the read counterpart to Create Purchase Order",
@@ -60253,7 +60253,7 @@ export const connectors: IntegrationConfig[] = [
       "sensitive": true,
     }],
     "tools": [{
-      "id": "list_tickets",
+      "id": "zendesk__list_tickets",
       "name": "List Tickets",
       "description": "List Zendesk support tickets",
       "requiresWrite": false,
@@ -60283,7 +60283,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "tickets" },
       },
     }, {
-      "id": "get_ticket",
+      "id": "zendesk__get_ticket",
       "name": "Get Ticket",
       "description": "Get a Zendesk ticket by ID",
       "requiresWrite": false,
@@ -60307,7 +60307,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "ticket" },
       },
     }, {
-      "id": "search_tickets",
+      "id": "zendesk__search_tickets",
       "name": "Search Tickets",
       "description": "Search Zendesk tickets with the Zendesk search API",
       "requiresWrite": false,
@@ -60331,7 +60331,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "results" },
       },
     }, {
-      "id": "update_ticket",
+      "id": "zendesk__update_ticket",
       "name": "Update Ticket",
       "description": "Update a Zendesk ticket status, priority, tags, or comment",
       "requiresWrite": true,
@@ -60362,7 +60362,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "ticket" },
       },
     }, {
-      "id": "create_ticket",
+      "id": "zendesk__create_ticket",
       "name": "Create Ticket",
       "description": "Create a new Zendesk support ticket",
       "requiresWrite": true,
@@ -60388,7 +60388,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "ticket" },
       },
     }, {
-      "id": "list_ticket_comments",
+      "id": "zendesk__list_ticket_comments",
       "name": "List Ticket Comments",
       "description": "List comments on a Zendesk ticket",
       "requiresWrite": false,
@@ -60480,7 +60480,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://www.zoho.com/crm/developer/docs/api/v8/register-client.html",
     }],
     "tools": [{
-      "id": "list_records",
+      "id": "zoho-crm__list_records",
       "name": "List Records",
       "description":
         "List records from a Zoho CRM module such as Leads, Contacts, Deals, or Accounts",
@@ -60528,7 +60528,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_record",
+      "id": "zoho-crm__get_record",
       "name": "Get Record",
       "description": "Get a single Zoho CRM record by ID from any module",
       "requiresWrite": false,
@@ -60557,7 +60557,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "search_records",
+      "id": "zoho-crm__search_records",
       "name": "Search Records",
       "description":
         "Search records in a Zoho CRM module by criteria, email, phone, or a free-text word",
@@ -60614,7 +60614,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "get_fields",
+      "id": "zoho-crm__get_fields",
       "name": "Get Fields Metadata",
       "description":
         "List the field metadata of a Zoho CRM module so agents can discover the field API names required by list, search, and write tools",
@@ -60634,7 +60634,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "fields" },
       },
     }, {
-      "id": "coql_query",
+      "id": "zoho-crm__coql_query",
       "name": "Run COQL Query",
       "description":
         "Run a CRM Object Query Language (COQL) SELECT query for filtered reads, joins, and aggregation that the list and search tools cannot express",
@@ -60653,7 +60653,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "create_records",
+      "id": "zoho-crm__create_records",
       "name": "Create Records",
       "description":
         "Create up to 100 records in a Zoho CRM module (requires the ZohoCRM.modules.CREATE scope)",
@@ -60680,7 +60680,7 @@ export const connectors: IntegrationConfig[] = [
         "response": { "transform": "data" },
       },
     }, {
-      "id": "update_record",
+      "id": "zoho-crm__update_record",
       "name": "Update Record",
       "description":
         "Update fields on an existing Zoho CRM record (requires the ZohoCRM.modules.UPDATE scope)",
@@ -60805,7 +60805,7 @@ export const connectors: IntegrationConfig[] = [
       "docsUrl": "https://developers.zoom.us/docs/integrations/oauth/",
     }],
     "tools": [{
-      "id": "list_meetings",
+      "id": "zoom__list_meetings",
       "name": "List Meetings",
       "description": "List scheduled or upcoming Zoom meetings for the authenticated user",
       "requiresWrite": false,
@@ -60861,7 +60861,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_meeting",
+      "id": "zoom__get_meeting",
       "name": "Get Meeting",
       "description": "Get details of a Zoom meeting by ID",
       "requiresWrite": false,
@@ -60878,7 +60878,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "create_meeting",
+      "id": "zoom__create_meeting",
       "name": "Create Meeting",
       "description": "Schedule a new Zoom meeting for the authenticated user",
       "requiresWrite": true,
@@ -60919,7 +60919,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "list_recordings",
+      "id": "zoom__list_recordings",
       "name": "List Recordings",
       "description": "List cloud recordings for the authenticated user",
       "requiresWrite": false,
@@ -60957,7 +60957,7 @@ export const connectors: IntegrationConfig[] = [
         },
       },
     }, {
-      "id": "get_me",
+      "id": "zoom__get_me",
       "name": "Get My Profile",
       "description": "Get the authenticated Zoom user's profile",
       "requiresWrite": false,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1024";
+export const VERSION = "0.1.1025";


### PR DESCRIPTION
## Summary
- Prefix all integration connector template tool IDs with `<integration>__` at the source `connector.json` level, not just Harvest.
- Keep integration module generation idempotent and prefix-aware so generated catalog data and historical-summary keys do not double-prefix.
- Regenerate `src/integrations/_data.ts` and add regression coverage for both source templates and generated catalog output.
- Bump the framework release metadata from `0.1.1024` to `0.1.1025` in `deno.json` and `src/utils/version-constant.ts`.

## Release Notes
- veryfront-code integration catalog source and generated runtime data now publish namespaced tool IDs for every integration, for example `github__list_repos`, `slack__send_message`, and `harvest__list_accounts`.
- Historical summary keys remain namespaced once and do not double-prefix when source IDs are already namespaced.
- Framework package version is prepared as `0.1.1025` for the all-integration tool-ID namespace release.

## Test Plan
- [x] `deno test --allow-all src/integrations/_data.test.ts` (40 BDD steps passed)
- [x] `deno test --no-check --allow-all src/utils/version.test.ts` (21 BDD steps passed)
- [x] Static source-template namespace scan: 0 violations
- [x] Static generated catalog namespace scan: 0 violations
- [x] `deno fmt --check scripts/build/generate-integrations-module.ts src/integrations/_data.test.ts src/integrations/_data.ts`
- [x] `deno fmt --check deno.json src/utils/version-constant.ts`
- [x] `git diff --check`
- [ ] Full local pre-push hook is still not clean in this checkout because unrelated observability config tests read local OTLP/Grafana env and expect console/undefined defaults.