### PR TITLE
Fix Kreuzberg PDF text extraction

### DIFF
--- a/extensions/ext-document-kreuzberg/src/extraction-config.ts
+++ b/extensions/ext-document-kreuzberg/src/extraction-config.ts
@@ -2,8 +2,7 @@ const MARKDOWN_EXTRACTION_CONFIG = {
   outputFormat: "markdown",
 } as const;
 
-const PDF_MARKDOWN_EXTRACTION_CONFIG = {
-  ...MARKDOWN_EXTRACTION_CONFIG,
+const PDF_TEXT_EXTRACTION_CONFIG = {
   images: { extractImages: false },
   pdfOptions: {
     extractImages: false,
@@ -19,6 +18,6 @@ function normalizeMimeType(mimeType: string): string {
 
 export function extractionConfigForMimeType(mimeType: string): Record<string, unknown> {
   return normalizeMimeType(mimeType) === "application/pdf"
-    ? PDF_MARKDOWN_EXTRACTION_CONFIG
+    ? PDF_TEXT_EXTRACTION_CONFIG
     : MARKDOWN_EXTRACTION_CONFIG;
 }

--- a/extensions/ext-document-kreuzberg/src/index.test.ts
+++ b/extensions/ext-document-kreuzberg/src/index.test.ts
@@ -311,11 +311,10 @@ describe("ext-document-kreuzberg extension", () => {
     assertEquals(EXTRACTION_TIMEOUT_MS, 10 * 60_000);
   });
 
-  it("requests markdown extraction for rich document types", () => {
+  it("requests markdown extraction for rich non-PDF document types and plain text for PDFs", () => {
     assertEquals(extractionConfigForMimeType(PPT_MIME_TYPE), { outputFormat: "markdown" });
     assertEquals(extractionConfigForMimeType(PPTX_MIME_TYPE), { outputFormat: "markdown" });
     assertEquals(extractionConfigForMimeType("application/pdf"), {
-      outputFormat: "markdown",
       images: { extractImages: false },
       pdfOptions: {
         extractImages: false,
@@ -350,7 +349,6 @@ describe("ext-document-kreuzberg extension", () => {
       bytes: "%PDF-1.4\n",
       mimeType: "application/pdf",
       config: {
-        outputFormat: "markdown",
         images: { extractImages: false },
         pdfOptions: {
           extractImages: false,
@@ -459,7 +457,6 @@ describe("ext-document-kreuzberg extension", () => {
       bytes: "%PDF-1.4\n",
       mimeType: "application/pdf",
       config: {
-        outputFormat: "markdown",
         images: { extractImages: false },
         pdfOptions: {
           extractImages: false,


### PR DESCRIPTION
## Summary
- Stop requesting Kreuzberg markdown output for PDFs, while keeping markdown output for rich non-PDF document types.
- Update the document extractor tests so PDF native extraction uses plain text config.
- Verify the Bosch manual extraction preserves `Inhaltsverzeichnis` and avoids the reported spacing/drop patterns.

Refs veryfront/veryfront-studio#5606.

## Test plan
- `deno test --no-check --allow-all extensions/ext-document-kreuzberg/src/index.test.ts`
- `deno fmt --check extensions/ext-document-kreuzberg/src/extraction-config.ts extensions/ext-document-kreuzberg/src/index.test.ts`
- `deno lint extensions/ext-document-kreuzberg/src/extraction-config.ts extensions/ext-document-kreuzberg/src/index.test.ts`
- Bosch PDF smoke via `KreuzbergDocumentExtractor`: `chars=143520`, `hasInhaltsverzeichnis=true`, `hasDroppedLeadingI=false`, `hasBrokenRegisterSpacing=false`, `hasBrokenBoschSpacing=false`
- Pre-push hook with telemetry env cleared: format, lint, typecheck, unit tests: `2301 passed`, `0 failed`

## Follow-up
- Publish a new `veryfront` / `@veryfront/ext-document-kreuzberg` release after this merges.
- Bump Studio to that released version so issue #5606 is fixed in the app runtime.
