### PR TITLE
Fix proxy SSR project dependency reads

### DIFF
--- a/src/modules/react-loader/ssr-module-loader/loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.test.ts
@@ -18,6 +18,7 @@ import { __injectCachesForTests } from "#veryfront/transforms/esm/transform-cach
 import { tokenizeAllVeryFrontPaths } from "#veryfront/cache";
 import { buildMdxEsmModuleRecoveryCacheKey } from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
 import { getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 
 /** Hash source as the loader sees it (after node position injection for .tsx in dev/preview) */
 function hashAsLoader(source: string, filePath: string, projectDir: string): string {
@@ -44,6 +45,54 @@ class FakeDistributedCache implements CacheBackend {
     this.values.delete(key);
     return Promise.resolve();
   }
+}
+
+function createProxyProjectAdapter(files: Record<string, string>): RuntimeAdapter {
+  const normalize = (path: string) => path.replace(/^\/app\/+/, "");
+
+  return {
+    id: "deno",
+    name: "proxy-project-test",
+    capabilities: denoAdapter.capabilities,
+    fs: {
+      async readFile(path: string): Promise<string> {
+        const normalized = normalize(path);
+        const content = files[normalized];
+        if (content == null) throw new Error(`File not found: ${path}`);
+        return content;
+      },
+      async writeFile(): Promise<void> {
+        throw new Error("writeFile is not supported in this test adapter");
+      },
+      async exists(path: string): Promise<boolean> {
+        return files[normalize(path)] != null;
+      },
+      async *readDir(): AsyncIterableIterator<never> {},
+      async stat(path: string) {
+        const content = files[normalize(path)];
+        if (content == null) throw new Error(`File not found: ${path}`);
+        return {
+          size: content.length,
+          mtime: new Date(0),
+          isDirectory: false,
+          isFile: true,
+          isSymlink: false,
+        };
+      },
+      async mkdir(): Promise<void> {},
+      async remove(): Promise<void> {},
+      async makeTempDir(prefix: string): Promise<string> {
+        return await makeTempDir({ prefix });
+      },
+      watch: denoAdapter.fs.watch.bind(denoAdapter.fs),
+      async resolveFile(): Promise<string | null> {
+        return null;
+      },
+    },
+    env: denoAdapter.env,
+    server: denoAdapter.server,
+    serve: denoAdapter.serve.bind(denoAdapter),
+  };
 }
 
 describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, () => {
@@ -369,6 +418,36 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
     } finally {
       await remove(projectDir, { recursive: true });
     }
+  });
+
+  it("loads project-relative dependencies through the runtime adapter for proxy project paths", async () => {
+    clearSSRModuleCache();
+
+    const projectDir = "/app";
+    const filePath = "/app/app/layout.tsx";
+    const adapter = createProxyProjectAdapter({
+      "app/runtime-registry.ts": `export const registered = true;`,
+    });
+
+    const loader = new SSRModuleLoader({
+      projectDir,
+      projectId: "project-proxy-adapter-deps",
+      contentSourceId: "release-1",
+      adapter,
+      dev: true,
+    });
+
+    const component = await loader.loadModule(
+      filePath,
+      [
+        `import "./runtime-registry.ts";`,
+        `export default function RootLayout() {`,
+        `  return null;`,
+        `}`,
+      ].join("\n"),
+    );
+
+    assertEquals(component.name, "RootLayout");
   });
 
   it("invalidates stale cache entries with unresolved _vf_modules imports and retransforms", async () => {

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -537,11 +537,10 @@ export class SSRModuleLoader {
       }
 
       if (parseResult.imports.length > 0) {
-        const preflightFs = createFileSystem();
         const { validImports, missingImports: preflightMissing } = await preflightLocalImports(
           parseResult.imports,
           filePath,
-          preflightFs,
+          this.options.adapter.fs,
         );
 
         if (preflightMissing.length > 0) {

--- a/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
@@ -154,9 +154,7 @@ export class SSRDependencyValidator {
       await Promise.all(
         batch.map(async (imp) => {
           try {
-            const depSource = imp.absolutePath.startsWith("/")
-              ? await localFs.readTextFile(imp.absolutePath)
-              : await this.adapter.fs.readFile(imp.absolutePath);
+            const depSource = await this.readLocalImportSource(imp.absolutePath, localFs);
 
             await this.transformWithDependencies(
               imp.absolutePath,
@@ -185,5 +183,26 @@ export class SSRDependencyValidator {
     }
 
     return importPathMap;
+  }
+
+  private isProjectAbsolutePath(path: string): boolean {
+    const projectDir = this.projectDir.replace(/\/+$/, "");
+    if (!projectDir || projectDir === "/") return false;
+    return path === projectDir || path.startsWith(`${projectDir}/`);
+  }
+
+  private readLocalImportSource(
+    path: string,
+    localFs: ReturnType<typeof createFileSystem>,
+  ): Promise<string> {
+    if (!path.startsWith("/")) {
+      return this.adapter.fs.readFile(path);
+    }
+
+    if (this.isProjectAbsolutePath(path)) {
+      return this.adapter.fs.readFile(path);
+    }
+
+    return localFs.readTextFile(path);
   }
 }


### PR DESCRIPTION
## Summary
- route SSR preflight import checks through the configured runtime adapter instead of always using host filesystem access
- route recursive SSR dependency reads for project-root absolute paths through the runtime adapter
- add a regression that mirrors proxy runtime paths: projectDir `/app`, file `/app/app/layout.tsx`, dependency `/app/app/runtime-registry.ts`, and adapter-backed project file `app/runtime-registry.ts`

## Why
The dedicated veryfront-ops-agent runtime was healthy after the operator fixes, but preview/production still returned HTTP 500. Fresh runtime logs showed SSR failing with:

`Pre-flight: file not accessible: /app/app/runtime-registry.ts`

Read-only API/DB checks confirmed the deployed release does include `app/runtime-registry.ts`, so this was a runtime dependency-resolution bug, not missing project content.

## Verification
- `deno test --allow-all src/modules/react-loader/ssr-module-loader/loader.test.ts`
- `deno test --allow-all src/modules/react-loader/ssr-module-loader/preflight-imports.test.ts`
- `deno fmt --check src/modules/react-loader/ssr-module-loader/loader.ts src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts src/modules/react-loader/ssr-module-loader/loader.test.ts`
- `deno lint src/modules/react-loader/ssr-module-loader/loader.ts src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts src/modules/react-loader/ssr-module-loader/loader.test.ts`
- `deno check src/modules/react-loader/ssr-module-loader/loader.ts src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts src/modules/react-loader/ssr-module-loader/loader.test.ts`
- pre-push: full repo format, lint, typecheck, and unit tests passed: `2301 passed (19441 steps) | 0 failed`

## Review Score
Self-review: 93/100. The change is narrow and covered by a production-shaped regression; residual risk is limited to unusual absolute paths outside projectDir, which continue to use host FS as before.