### PR TITLE
Bump version to 0.1.1026

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1025",
+  "version": "0.1.1026",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1025";
+export const VERSION = "0.1.1026";


### PR DESCRIPTION
## Summary
- bump `deno.json` from `0.1.1025` to `0.1.1026`
- bump `src/utils/version-constant.ts` to match

## Why
The merge commit for #2804 reached `main`, but the release job failed because `veryfront@0.1.1025` was already published, so the downstream server deploy was skipped. This bump gives the release pipeline an unpublished stable version so the dedicated runtime can receive the #2804 SSR fix.

## Verification
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno check src/utils/version-constant.ts`
- `VERSION=0.1.1026 GITHUB_SHA=$(git rev-parse HEAD) scripts/ci/publish-npm-packages.sh preflight`
- pre-push full repo checks: `2301 passed (19441 steps) | 0 failed`
