### PR TITLE
Allow project OTEL config in dedicated runtimes

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -164,7 +164,7 @@ jobs:
 
           for attempt in 1 2 3; do
             wait_for_apt_locks
-            deno run -A npm:playwright install --with-deps chromium && exit 0
+            timeout 10m deno run -A npm:playwright install --with-deps chromium && exit 0
             status=$?
 
             if [ "$attempt" -eq 3 ]; then
@@ -223,7 +223,7 @@ jobs:
 
           for attempt in 1 2 3; do
             wait_for_apt_locks
-            deno run -A npm:playwright install --with-deps chromium && exit 0
+            timeout 10m deno run -A npm:playwright install --with-deps chromium && exit 0
             status=$?
 
             if [ "$attempt" -eq 3 ]; then

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -8,6 +8,8 @@ import {
   setGlobalMetricsAPI,
 } from "#veryfront/observability/tracing/api-shim.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
+import { runWithProjectEnv } from "#veryfront/server/project-env/storage.ts";
+import { withEnv } from "#veryfront/testing/deno-compat.ts";
 import { metrics } from "./index.ts";
 
 describe("metrics public SDK", () => {
@@ -336,6 +338,53 @@ describe("metrics public SDK", () => {
     assertEquals(
       (requests[0]?.init?.headers as Record<string, string>).Authorization,
       "Basic aW50ZXJuYWwtdXNlcjppbnRlcm5hbC1wYXNz",
+    );
+  });
+
+  it("uses project OTLP metrics config in dedicated runtimes", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-1",
+      VERYFRONT_API_BASE_URL: "http://veryfront-api:80",
+      VERYFRONT_API_INTERNAL_USER: "internal-user",
+      VERYFRONT_API_INTERNAL_PASS: "internal-pass",
+    }, async () => {
+      globalThis.fetch = ((url: string | URL | Request, init?: RequestInit) => {
+        requests.push({ url: String(url), init });
+        return Promise.resolve(new Response("{}", { status: 200 }));
+      }) as typeof fetch;
+
+      try {
+        await runWithProjectEnv({
+          OTEL_METRICS_ENABLED: "true",
+          OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://otlp.datadoghq.eu/v1/metrics",
+          OTEL_EXPORTER_OTLP_METRICS_HEADERS: "dd-api-key=project-key",
+          OTEL_SERVICE_NAME: "veryfront-ops-agent",
+        }, async () => {
+          metrics.counter("vf_eval_result_total", 1, { project_id: "project-123" });
+          await (metrics as unknown as { __flushForTests(): Promise<void> }).__flushForTests();
+        });
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    assertEquals(requests.length, 1);
+    assertEquals(requests[0]?.url, "https://otlp.datadoghq.eu/v1/metrics");
+    assertEquals(
+      (requests[0]?.init?.headers as Record<string, string>)["dd-api-key"],
+      "project-key",
+    );
+
+    const body = JSON.parse(String(requests[0]?.init?.body));
+    assertEquals(
+      body.resourceMetrics[0].resource.attributes.find(
+        (attr: { key: string }) => attr.key === "service.name",
+      ).value.stringValue,
+      "veryfront-ops-agent",
     );
   });
 

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -388,6 +388,44 @@ describe("metrics public SDK", () => {
     );
   });
 
+  it("routes dedicated runtime host OTLP metrics through the internal API proxy without project env", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-1",
+      OTEL_METRICS_ENABLED: "true",
+      OTEL_EXPORTER_OTLP_ENDPOINT: "https://collector.example/otlp",
+      OTEL_EXPORTER_OTLP_HEADERS: "Authorization=Basic external-secret",
+      VERYFRONT_API_BASE_URL: "http://veryfront-api:80",
+      VERYFRONT_API_INTERNAL_USER: "internal-user",
+      VERYFRONT_API_INTERNAL_PASS: "internal-pass",
+    }, async () => {
+      globalThis.fetch = ((url: string | URL | Request, init?: RequestInit) => {
+        requests.push({ url: String(url), init });
+        return Promise.resolve(new Response("{}", { status: 200 }));
+      }) as typeof fetch;
+
+      try {
+        metrics.counter("vf_runtime_metric_total", 1, { source: "host" });
+        await (metrics as unknown as { __flushForTests(): Promise<void> }).__flushForTests();
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    assertEquals(requests.length, 1);
+    assertEquals(
+      requests[0]?.url,
+      "http://veryfront-api:80/internal/metrics/otlp/v1/metrics",
+    );
+    assertEquals(
+      (requests[0]?.init?.headers as Record<string, string>).Authorization,
+      "Basic aW50ZXJuYWwtdXNlcjppbnRlcm5hbC1wYXNz",
+    );
+  });
+
   it("exports direct histograms with cumulative temporality", async () => {
     const originalFetch = globalThis.fetch;
     const requests: Array<{ url: string; init?: RequestInit }> = [];

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -22,6 +22,7 @@ import {
 } from "#veryfront/observability/tracing/api-shim.ts";
 import { getCurrentRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
 import { getEnv, getHostEnv } from "#veryfront/platform/compat/process.ts";
+import { isProjectEnvActive } from "#veryfront/server/project-env/storage.ts";
 
 export type MetricAttributeValue = string | number | boolean | null | undefined;
 export type MetricAttributes = Record<string, MetricAttributeValue>;
@@ -158,8 +159,21 @@ function readHostEnv(name: string): string | undefined {
   return getHostEnv(name);
 }
 
+function readProjectEnv(name: string): string | undefined {
+  return isProjectEnvActive() ? getEnv(name) : undefined;
+}
+
 function isDedicatedRuntime(): boolean {
   return Boolean(readHostEnv("SERVER_ID") && readHostEnv("ENVIRONMENT_IDS"));
+}
+
+function resolveProjectOtlpMetricsUrl(): string | null {
+  if (readProjectEnv("OTEL_METRICS_ENABLED") !== "true") return null;
+  const endpoint = readProjectEnv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT") ??
+    readProjectEnv("OTEL_EXPORTER_OTLP_ENDPOINT");
+  if (!endpoint) return null;
+  const trimmed = endpoint.replace(/\/$/, "");
+  return trimmed.endsWith("/v1/metrics") ? trimmed : `${trimmed}/v1/metrics`;
 }
 
 function resolveOtlpMetricsUrl(): string | null {
@@ -203,13 +217,13 @@ function parseHeaders(headerInput: string | undefined): Record<string, string> {
 }
 
 function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
-  const otlpUrl = resolveOtlpMetricsUrl();
-  if (isDedicatedRuntime() && otlpUrl) {
+  const projectOtlpUrl = resolveProjectOtlpMetricsUrl();
+  if (isDedicatedRuntime() && projectOtlpUrl) {
     return {
-      url: otlpUrl,
+      url: projectOtlpUrl,
       headers: parseHeaders(
-        readEnv("OTEL_EXPORTER_OTLP_METRICS_HEADERS") ??
-          readEnv("OTEL_EXPORTER_OTLP_HEADERS"),
+        readProjectEnv("OTEL_EXPORTER_OTLP_METRICS_HEADERS") ??
+          readProjectEnv("OTEL_EXPORTER_OTLP_HEADERS"),
       ),
     };
   }
@@ -227,6 +241,7 @@ function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
     };
   }
 
+  const otlpUrl = resolveOtlpMetricsUrl();
   if (!otlpUrl) return null;
   return {
     url: otlpUrl,

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -21,6 +21,7 @@ import {
   type ObservableGauge,
 } from "#veryfront/observability/tracing/api-shim.ts";
 import { getCurrentRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
+import { getEnv, getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 export type MetricAttributeValue = string | number | boolean | null | undefined;
 export type MetricAttributes = Record<string, MetricAttributeValue>;
@@ -150,11 +151,15 @@ function getGauge(name: string, options?: MetricInstrumentOptions) {
 }
 
 function readEnv(name: string): string | undefined {
-  try {
-    return Deno.env.get(name);
-  } catch {
-    return undefined;
-  }
+  return getEnv(name);
+}
+
+function readHostEnv(name: string): string | undefined {
+  return getHostEnv(name);
+}
+
+function isDedicatedRuntime(): boolean {
+  return Boolean(readHostEnv("SERVER_ID") && readHostEnv("ENVIRONMENT_IDS"));
 }
 
 function resolveOtlpMetricsUrl(): string | null {
@@ -167,10 +172,10 @@ function resolveOtlpMetricsUrl(): string | null {
 }
 
 function resolveInternalMetricsUrl(): string | null {
-  if (readEnv("OTEL_METRICS_ENABLED") !== "true") return null;
-  const apiBaseUrl = readEnv("VERYFRONT_API_BASE_URL") ?? readEnv("VERYFRONT_API_URL");
-  const username = readEnv("VERYFRONT_API_INTERNAL_USER");
-  const password = readEnv("VERYFRONT_API_INTERNAL_PASS");
+  if (readHostEnv("OTEL_METRICS_ENABLED") !== "true") return null;
+  const apiBaseUrl = readHostEnv("VERYFRONT_API_BASE_URL") ?? readHostEnv("VERYFRONT_API_URL");
+  const username = readHostEnv("VERYFRONT_API_INTERNAL_USER");
+  const password = readHostEnv("VERYFRONT_API_INTERNAL_PASS");
   if (!apiBaseUrl || !username || !password) return null;
   return `${apiBaseUrl.replace(/\/$/, "")}/internal/metrics/otlp/v1/metrics`;
 }
@@ -198,24 +203,37 @@ function parseHeaders(headerInput: string | undefined): Record<string, string> {
 }
 
 function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
+  const otlpUrl = resolveOtlpMetricsUrl();
+  if (isDedicatedRuntime() && otlpUrl) {
+    return {
+      url: otlpUrl,
+      headers: parseHeaders(
+        readEnv("OTEL_EXPORTER_OTLP_METRICS_HEADERS") ??
+          readEnv("OTEL_EXPORTER_OTLP_HEADERS"),
+      ),
+    };
+  }
+
   const internalUrl = resolveInternalMetricsUrl();
   if (internalUrl) {
     return {
       url: internalUrl,
       headers: {
         Authorization: buildBasicAuth(
-          readEnv("VERYFRONT_API_INTERNAL_USER") ?? "",
-          readEnv("VERYFRONT_API_INTERNAL_PASS") ?? "",
+          readHostEnv("VERYFRONT_API_INTERNAL_USER") ?? "",
+          readHostEnv("VERYFRONT_API_INTERNAL_PASS") ?? "",
         ),
       },
     };
   }
 
-  const otlpUrl = resolveOtlpMetricsUrl();
   if (!otlpUrl) return null;
   return {
     url: otlpUrl,
-    headers: parseHeaders(readEnv("OTEL_EXPORTER_OTLP_HEADERS")),
+    headers: parseHeaders(
+      readEnv("OTEL_EXPORTER_OTLP_METRICS_HEADERS") ??
+        readEnv("OTEL_EXPORTER_OTLP_HEADERS"),
+    ),
   };
 }
 

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -58,7 +58,7 @@ import { serverLogger } from "#veryfront/utils";
 import {
   EnvironmentVariableCache,
   fetchProjectEnvVars,
-  filterSharedRuntimeProjectEnv,
+  filterRuntimeProjectEnv,
   runWithProjectEnv,
 } from "../../project-env/index.ts";
 
@@ -493,7 +493,7 @@ function buildAgentStreamEnv(input: {
 }): Record<string, string> {
   const apiUrl = resolveVeryfrontApiBaseUrlFromHostEnv();
   return {
-    ...filterSharedRuntimeProjectEnv(input.envVars),
+    ...filterRuntimeProjectEnv(input.envVars),
     // Framework-owned values must override project env to keep request-scoped
     // credentials bound to trusted Veryfront endpoints and the current project.
     ...(input.proxyToken ? { VERYFRONT_API_TOKEN: input.proxyToken } : {}),

--- a/src/server/project-env/index.ts
+++ b/src/server/project-env/index.ts
@@ -6,5 +6,5 @@
 
 export { getProjectEnv, isProjectEnvActive, runWithProjectEnv } from "./storage.ts";
 export { EnvironmentVariableCache } from "./cache.ts";
-export { filterSharedRuntimeProjectEnv } from "./reserved-env.ts";
+export { filterRuntimeProjectEnv, filterSharedRuntimeProjectEnv } from "./reserved-env.ts";
 export { fetchProjectEnvVars } from "./fetcher.ts";

--- a/src/server/project-env/reserved-env.test.ts
+++ b/src/server/project-env/reserved-env.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { filterSharedRuntimeProjectEnv } from "./reserved-env.ts";
+import { withEnv } from "#veryfront/testing/deno-compat.ts";
+import { filterRuntimeProjectEnv, filterSharedRuntimeProjectEnv } from "./reserved-env.ts";
 
 describe("server/project-env/reserved-env", () => {
   it("removes telemetry exporter routing env vars from shared runtime project env", () => {
@@ -24,6 +25,27 @@ describe("server/project-env/reserved-env", () => {
   it("returns the original project env values for non-reserved keys", () => {
     assertEquals(filterSharedRuntimeProjectEnv({ DATABASE_URL: "postgres://project-db" }), {
       DATABASE_URL: "postgres://project-db",
+    });
+  });
+
+  it("keeps customer telemetry env vars for dedicated runtimes", async () => {
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-1",
+    }, async () => {
+      const filtered = filterRuntimeProjectEnv({
+        OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://otlp.datadoghq.eu/v1/metrics",
+        OTEL_EXPORTER_OTLP_METRICS_HEADERS: "dd-api-key=project-key",
+        OTEL_SERVICE_NAME: "veryfront-ops-agent",
+        OPENAI_API_KEY: "project-openai-key",
+      });
+
+      assertEquals(filtered, {
+        OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://otlp.datadoghq.eu/v1/metrics",
+        OTEL_EXPORTER_OTLP_METRICS_HEADERS: "dd-api-key=project-key",
+        OTEL_SERVICE_NAME: "veryfront-ops-agent",
+        OPENAI_API_KEY: "project-openai-key",
+      });
     });
   });
 });

--- a/src/server/project-env/reserved-env.ts
+++ b/src/server/project-env/reserved-env.ts
@@ -1,4 +1,5 @@
 import { isReservedSharedRuntimeTelemetryEnvKey } from "#veryfront/observability/tracing/telemetry-env.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 export function filterSharedRuntimeProjectEnv(
   vars: Record<string, string>,
@@ -6,4 +7,15 @@ export function filterSharedRuntimeProjectEnv(
   return Object.fromEntries(
     Object.entries(vars).filter(([key]) => !isReservedSharedRuntimeTelemetryEnvKey(key)),
   );
+}
+
+function isDedicatedRuntime(): boolean {
+  return Boolean(getHostEnv("SERVER_ID") && getHostEnv("ENVIRONMENT_IDS"));
+}
+
+export function filterRuntimeProjectEnv(
+  vars: Record<string, string>,
+): Record<string, string> {
+  if (isDedicatedRuntime()) return { ...vars };
+  return filterSharedRuntimeProjectEnv(vars);
 }

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -115,7 +115,7 @@ import { withRequestTimeout } from "./timeout-manager.ts";
 import {
   EnvironmentVariableCache,
   fetchProjectEnvVars,
-  filterSharedRuntimeProjectEnv,
+  filterRuntimeProjectEnv,
   runWithProjectEnv,
 } from "../project-env/index.ts";
 import { SCANNER_PATH_PATTERN } from "#veryfront/utils/constants/security.ts";
@@ -675,7 +675,7 @@ export function createVeryfrontHandler(
               profilePhase("handler.execute", () => {
                 if (shouldIsolateEnv) {
                   return runWithProjectEnv(
-                    filterSharedRuntimeProjectEnv(envVarsForRequest),
+                    filterRuntimeProjectEnv(envVarsForRequest),
                     executeRoute,
                   );
                 }


### PR DESCRIPTION
## Summary
- preserve project/customer OTEL env vars in dedicated runtimes while keeping shared-runtime telemetry filtering intact
- make `veryfront/metrics` read request/project env for direct OTLP metrics targets in dedicated runtimes
- prefer the project OTLP metrics endpoint over the platform internal metrics proxy only when the runtime is dedicated

## Why
The customer owns Datadog/OTEL configuration through project environment variables. The platform should not inject a Datadog API key into dedicated runtime infrastructure secrets.

Expected project env shape, set by the customer through the normal project env path:
- `OTEL_METRICS_ENABLED=true`
- `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=https://otlp.datadoghq.eu/v1/metrics`
- `OTEL_EXPORTER_OTLP_METRICS_HEADERS=dd-api-key=<project api key>`
- `OTEL_SERVICE_NAME=veryfront-ops-agent`

## Verification
- `deno fmt --check src/server/project-env/reserved-env.ts src/server/project-env/reserved-env.test.ts src/server/project-env/index.ts src/server/runtime-handler/index.ts src/server/handlers/request/agent-stream.handler.ts src/metrics/index.ts src/metrics/index.test.ts`
- `deno test --quiet --allow-env --allow-net --allow-read --allow-write src/server/project-env/reserved-env.test.ts src/metrics/index.test.ts src/server/handlers/request/agent-stream.handler.test.ts`
- `deno task build`
- pre-push hook with local OTEL host vars unset: formatting, lint, type check, unit tests; `2301 passed (19443 steps), 0 failed`
- `git diff --check`
