### PR TITLE
docs(plans): veryfront/chat composition & API overhaul — epic breakdown

### DIFF
--- a/docs/plans/2026-07-08-chat-composition-handoff.md
+++ b/docs/plans/2026-07-08-chat-composition-handoff.md
@@ -1,0 +1,618 @@
+# Handoff: `veryfront/chat` — composition & API changes for a "perfect" demo
+
+**Audience:** veryfront-code maintainers.
+**Author:** produced while building the customer-operations-agent chat examples.
+**Goal:** ship two demos off **one** set of primitives:
+
+1. **Batteries-included** — `<Chat>` + `<ConversationsProvider>` + a layout, using
+   built-in components as-is. Great defaults, zero config.
+2. **Fully composed** — the *same* hooks, providers, and UI leaves arranged by
+   hand for total control.
+
+The non-negotiable: **#1 must be nothing more than a default arrangement of the
+public parts from #2.** No private internals, no logic that only exists inside
+`<Chat>`. If `<Chat>` can do it, userland composition must be able to do it too,
+with no `useEffect`/`useRef`/glue code.
+
+Everything below is verified against the shipped package
+(`node_modules/veryfront@0.1.998`) — file/line evidence in the Appendix.
+
+---
+
+## The acid test
+
+> **"Can I change the X on Y?"** — the first thing every developer asks. Today,
+> when `Y` is nested inside some `<ZComponent>`, the answer is often "no, not
+> without replacing all of Z," and the demo falls over. Customers hate that.
+
+**Every node must pass this test:** any leaf `X` — an icon, a label, a class, a
+handler — must be changeable *in place*, without re-implementing its parent `Z`.
+That is the single measure of success for this work. If changing the send-button
+icon, a sidebar row's menu, or a message avatar requires forking a whole region,
+the API has failed.
+
+The API must feel like **idiomatic React**: developers already know how to
+customize with **props, `children`, and compound components** (Radix / Headless
+UI / Chakra mental model). Don't invent new patterns — meet that expectation.
+
+## North-star principles
+
+1. **Change-X-on-Y passes everywhere.** Every leaf is reachable and overridable
+   in place (props/children/compound) without touching its ancestors.
+2. **Presentation and business logic are split.** Logic lives in **headless
+   hooks/providers**; components are **presentational** — they take props +
+   `children` and render, holding no wiring. This split is *what makes* the acid
+   test pass: dumb components are trivially customizable; a component that owns
+   logic can't be reshaped. (Headless-UI / TanStack model.)
+3. **No userland glue.** Hooks + providers do the wiring. A composed app contains
+   zero `useEffect`/`useRef`. If integration needs an effect, it belongs *inside*
+   a library hook/provider — never in app code.
+4. **Children first; render props only for data-passing.** Static structure
+   composes via `children`/compound sub-components. A `renderX` prop is justified
+   *only* where the parent must inject per-item data (lists) — and there, offer
+   both a function-child and `renderItem`. Don't bolt `renderX` onto static
+   leaves (`renderHeader`, `renderCard`, `renderTrigger` are smells — those want
+   composition). *(composition-patterns §3.2)*
+5. **Down to ALL child nodes.** Every visual leaf is an addressable, composable
+   sub-component — not just the top-level regions. Nothing is a black box you
+   can't reach into.
+6. **No boolean feature toggles.** Presence is composition. `showSources` →
+   render `<Message.Sources/>` or don't. No `show*`/`enable*`/`hide*`.
+7. **One root `className` per component.** No `contentClassName`,
+   `cardClassName`, `subComponentClassName`, or `xxxProps={{}}` passthrough
+   objects. Want to style a child? Compose the child and give *it* a className.
+8. **Documented, non-magic props.** Every prop's effect is obvious from its name
+   and doc. No resolved-by-presence behaviour, no deprecated shadow-API.
+9. **Three usage tiers, one implementation.** Every component works as (a) a
+   **black box** with sensible defaults, (b) **props-customized**, and (c)
+   **fully compound-composed** — and all three are the *same* implementation, not
+   parallel code paths. Storybook proves all three (§J).
+
+---
+
+## The two target demos (end state)
+
+### Demo 1 — batteries-included
+
+```tsx
+// app/page.tsx
+<ConversationsProvider store={localConversationStore('ops')}>
+  <ChatLayout>                     {/* AppShell preset: sidebar + main */}
+    <ChatSidebar />                {/* reads provider from context */}
+    <Chat agentId="support-agent" api="/api/ag-ui" uploadApi="/api/uploads" />
+  </ChatLayout>
+</ConversationsProvider>
+```
+
+### Demo 2 — fully composed (same primitives, arranged by hand)
+
+```tsx
+<ConversationsProvider store={localConversationStore('ops')}>
+  <AppShell>
+    <AppShell.Sidebar>
+      <ChatSidebar.Root>
+        <ChatSidebar.NewButton>New chat</ChatSidebar.NewButton>
+        <ChatSidebar.List>
+          {(conversation) => (
+            <ChatSidebar.Item conversation={conversation}>
+              <ChatSidebar.Item.Title />
+              <ChatSidebar.Item.Menu>
+                <ChatSidebar.Item.Rename />
+                <DropdownMenu.Item onSelect={copyTitle}>Copy title</DropdownMenu.Item>
+                <ChatSidebar.Item.Delete />
+              </ChatSidebar.Item.Menu>
+            </ChatSidebar.Item>
+          )}
+        </ChatSidebar.List>
+      </ChatSidebar.Root>
+    </AppShell.Sidebar>
+
+    <AppShell.Main>
+      <AppShell.Header>
+        <AgentPicker /> {/* or fully composed AgentPicker.Trigger/.Content/.Item */}
+      </AppShell.Header>
+
+      {/* useConversationChat = useChat bound to the active conversation +
+          provider store. No effect in userland. */}
+      <ConversationChat.Root>
+        <ConversationChat.Transcript>
+          {(message) => (
+            <Message.Root message={message}>
+              <Message.Avatar />
+              {/* headless: parts are data, you switch. `Message.Part` renders
+                  the default for any type (text, reasoning, sources). */}
+              {useMessageParts().map((part, i) =>
+                part.type === 'tool'
+                  ? <ToolCall.Root key={i} tool={part}>…</ToolCall.Root>
+                  : <Message.Part key={i} part={part} />
+              )}
+              <Message.Sources />
+              <Message.Actions>
+                <Message.CopyAction />
+                <Message.RegenerateAction />
+              </Message.Actions>
+            </Message.Root>
+          )}
+        </ConversationChat.Transcript>
+
+        <ChatInput.Root>
+          <ChatInput.Field placeholder="Ask the support agent…" />
+          <ChatInput.Attach />
+          <ChatInput.Model />
+          <ChatInput.Voice />
+          <ChatInput.Send icon={<MailIcon />} />
+        </ChatInput.Root>
+      </ConversationChat.Root>
+    </AppShell.Main>
+  </AppShell>
+</ConversationsProvider>
+```
+
+Every node above is a public export. There is no `useChat` + `useEffect`
+persistence dance, no `showSources`, no `renderItem` escape hatch that
+reimplements a built-in worse than the original.
+
+---
+
+## Required changes in `veryfront/chat`
+
+### A. Kill userland state glue (highest priority)
+
+**Problem.** To compose the transcript/composer from sub-components you must
+hand-drive `useChat`, and then persistence is on you. The bridge that syncs a
+live `useChat` into the conversation store **exists only inside `<Chat>`**
+(`UncontrolledChat`'s `React.useEffect(… sink(conversation) …, [chat.messages,
+boundId])`, with a `persistRef` + first-render-skip). Composed apps must
+re-implement that effect (`usePersistMessages` in our demo). That violates
+principles 1 and "#1 = arrangement of #2's parts."
+
+**What the ecosystem does** (for reference):
+- **Vercel AI SDK v5**: persistence is **server-side**, in the route's
+  `toUIMessageStreamResponse({ onFinish: ({ messages }) => saveChat(...) })`.
+  The client `useChat({ id, messages })` only carries identity + seed. No client
+  persistence callback.
+- **TanStack AI**: stateless today; the planned answer is a pluggable
+  **`ChatPersistenceAdapter`** (`getItem`/`setItem`/`removeItem`) bound to the
+  client — i.e. a store adapter, which veryfront *already has* as
+  `ConversationStore`.
+
+**Asks (do both):**
+
+1. **Server-side finish hook on `createAgUiHandler`.** It already has
+   `beforeStream`; add the symmetric `onFinish`/`afterStream({ messages })` so
+   durable persistence can live at the route boundary (the AI SDK model). This is
+   the "right" default and needs no client state at all.
+
+2. **Bind the client chat to the store — as a hook/provider, not an effect.**
+   Expose `useConversationChat({ conversationId, store, agentId })` (and/or a
+   `<ConversationChat.Root>` provider) that internally does `useChat` + seeding +
+   the persist bridge and returns the session. This is exactly what `<Chat>` does
+   privately today — promote it to a public headless primitive so composition
+   reaches parity. Then **`<Chat>` is refactored to consume it**, guaranteeing #1
+   and #2 share one code path.
+
+   Net userland result: `const chat = useConversationChat()` — no `useEffect`,
+   no `useRef`, no first-render guard.
+
+> Acceptance: a fully-composed multi-conversation chat with persistence contains
+> **zero** `useEffect`/`useRef` in app code.
+
+---
+
+### B. Remove boolean feature toggles → composition
+
+**Problem.** Behaviour is toggled by booleans instead of presence. Several are
+already `@deprecated` with the note "renders automatically" — meaning the flag
+is vestigial. Full list found in the shipped types:
+
+| Toggle | Replace with (composition) |
+| --- | --- |
+| `showSources` *(already @deprecated)* | render `<Message.Sources/>` or omit |
+| `showSteps` *(already @deprecated)* | render `<Message.Steps/>` / `<StepIndicator/>` or omit |
+| `showScrollButton` | render `<ConversationScrollButton/>` or omit |
+| `showMessageActions` | render `<Message.Actions/>` or omit |
+| `showExport` | render an export action or omit |
+| `showTabs` / `hideTabSwitcher` | compose `<TabSwitcher/>` or omit |
+| `enableAttachments` | render `<ChatInput.Attach/>` or omit |
+| `enableVoice` | render `<ChatInput.Voice/>` or omit |
+| `showSearch` (AgentPicker) | render `<AgentPicker.Search/>` or omit |
+| `enableMermaid` | opt-in via a markdown plugin, not a boolean |
+| `showLabel`, `showRemove` (pills) | compose the pill's parts |
+
+**Ask.** Delete the toggles from the composition layer. Presence of a
+sub-component *is* the switch. For the **preset `<Chat>`** (batteries mode) it's
+fine to keep a small, documented set of *convenience* booleans **if** they map
+1:1 to "include this default sub-component" — but the composed layer must never
+require them, and none should gate behaviour magically.
+
+> These are "exemplars to discuss" per your note — flagging all of them; we can
+> decide per-item whether the preset keeps a convenience alias.
+
+---
+
+### C. Composition down to ALL child nodes
+
+**Problem.** Compounds exist for the big regions, but several leaves are still
+opaque, forcing `renderX`-reimplementation-from-scratch (which loses the
+built-in behaviour — e.g. our sidebar `renderItem` had to re-do inline rename as
+a native `prompt()` and hand-roll a menu).
+
+**Ask.** Every visual leaf is a named sub-component with a single root
+`className`, reachable via composition, and each list also takes a `renderX`.
+Concretely, complete these compounds down to the leaves:
+
+- **`Message`** — expose `Message.Header.Name`, `Message.Header.Timestamp`,
+  `Message.Avatar` (already), and make `Message.Content` accept **per-part
+  render slots** (see D) so tool/reasoning/source/text each compose.
+- **`ChatSidebar.Item`** — expose `.Title`, `.Menu`, `.Rename`, `.Delete` so you
+  can **add** a menu entry *without* replacing the row (today `renderItem` is the
+  only hook and it discards the built-in inline-rename + menu).
+- **`ChatInput`** — already good (`.Field/.Attach/.Model/.Voice/.Send/.Stop`);
+  expose the toolbar container as `.Toolbar` so layout is composable too.
+- **`ChatEmptyState`** — already compound; fix its types (see F).
+- **`AgentPicker`** — expose `.Search` (replaces `showSearch`).
+
+> Acceptance: for every built-in region, I can replace any single leaf while
+> keeping its siblings' built-in behaviour — no full-region re-implementation.
+
+---
+
+### D. Composition first; render props only for data-passing
+
+`composition-patterns` §3.2 is explicit: **`children` for static structure;
+`renderX` only when the parent must pass per-item data back** (lists). Today the
+library over-uses render props as an *alternative* to composition — `renderTool`,
+`renderMessage`, `renderItem`, `renderRow`, `renderPill`, `renderCodeBlock`,
+`renderScrollButton`, `renderTrigger`, `renderSkill`, `renderHeader`,
+`renderCard` — and inconsistently (`renderItem` vs `renderRow` vs `renderPill`).
+
+**Asks:**
+
+1. **Demote static render props to composition.** `renderHeader`, `renderCard`,
+   `renderTrigger`, `renderSkill` render *static structure* → they should be
+   compound children (`<X.Header>…</X.Header>`), not callbacks.
+2. **Keep render props only for data lists, and offer both forms.** Where the
+   parent supplies each item's data, support a function-child *and* `renderItem`:
+   `<X.List>{(item) => <X.Item …/>}</X.List>` (function-child is the norm, like
+   `Message.Content`'s). Standardize the name to `render<Child>` matching the
+   sub-component (`renderItem` ↔ `<X.Item>`).
+3. **Message parts are headless data — expose them, don't slot-map them.** This
+   is how AI SDK (`message.parts.map(part => switch(part.type))`) and assistant-ui
+   (`<MessagePrimitive.Parts>{({ part }) => …}`) both do it. Provide four access
+   points off **one** implementation, message-scoped:
+   - **Data / headless:** `message.parts` (already data) + `useMessageParts()`
+     from message context — map with a `switch`.
+   - **Leaf renderers exposed:** `Message.Part` (default render for any one part)
+     plus `Message.Text`, `Message.Reasoning`, `Message.Source`, `ToolCall.*` —
+     so a `switch` returns composed *defaults*, not reinventions.
+   - **`Message.Parts` primitive:** iterates + function-child `({ part }) => …`,
+     defaults when you return nothing (the assistant-ui shape).
+   - **`Message.Content` batteries:** `= <Message.Parts>` with the default
+     switch. Zero-config.
+   Drop the `renderTool` bag and the slot-map idea entirely — parts render via
+   the switch/primitive, not per-type render props.
+
+---
+
+### E. One root `className`; delete passthrough props
+
+**Problem (found in shipped types):**
+- `contentClassName` (ChatMessageList), `cardClassName` (a card component) —
+  second class-names for nested nodes.
+- `dragProps` — an object-passthrough prop.
+- `icons?: XxxIcons` slot objects on **7** components (`ChatInputIcons`,
+  `ChatSidebarIcons`, `AgentPickerIcons`, `MessageActionBarIcons`,
+  `MessageFeedbackIcons`, `BranchPickerIcons`, `AttachmentPillIcons`) — this is
+  the `subComponentProps={{}}` smell: you configure a child through a bag on the
+  parent instead of composing the child.
+
+**Asks:**
+- Remove `*ClassName` (keep only the single root `className`). Styling a nested
+  node = composing that node and styling it directly.
+- Remove `*Props`/`dragProps` passthrough objects.
+- Replace `icons={{…}}` bags with per-sub-component `icon` props (which already
+  exist, e.g. `<ChatInput.Send icon={…}>`). Keep one narrow exception only if a
+  component has no composable form.
+
+---
+
+### F. Export the UI-kit primitives — ✅ in flight (PR #2798)
+
+**Problem.** `DropdownMenu`, `Button`, `IconButton`, `Dialog`, etc. were used
+*internally* (e.g. `ChatSidebar.Item`'s "…" menu is a `DropdownMenu`) but were
+**not on any public export** — no `./ui`, `./components/chat`, or `./*`. So the
+moment you compose a custom row with a menu, you couldn't reuse vf's own menu;
+you hand-rolled one (our demo did). That directly blocked principle 2/3.
+
+**Status.** **PR #2798 does exactly this** — moves the 39 primitives to
+`src/react/components/ui/` and exposes a new **`veryfront/ui`** namespace
+(`veryfront/ui`, `veryfront/components/ui`, `veryfront/react/components/ui`),
+with `chat` depending on `ui` (never the reverse) and no break to existing
+consumers. This is the base-layer split the rest of the handoff assumes.
+
+**Remaining under this heading:** once merged, (a) `DropdownMenu` et al. import
+from `veryfront/ui` — wire `<ChatSidebar.Item.Menu>` + `<DropdownMenu.Item>` so
+adding a row-menu entry (§C) uses the real primitive, not a hand-roll; (b) ensure
+every primitive is a **compound** with a single root `className` (feeds §C/§E);
+(c) point the composed example at `veryfront/ui`.
+
+---
+
+### G. Fix composition-blocking type bugs
+
+**Problem.** Components whose props are `extends React.HTMLAttributes<T>` without
+re-declaring `children` fail to typecheck under React 19 types — `Property
+'children' does not exist on type 'IntrinsicAttributes & AppShellProps'`. Hit on
+`AppShell`, `AppShell.Sidebar`, `AppShell.Header`, and all `ChatEmptyState.*`.
+This makes the *documented* composition examples not typecheck (they build,
+because `veryfront build` skips `tsc`, but a consuming app that runs `tsc`
+errors).
+
+**Ask.** Explicitly declare `children: React.ReactNode` on every compound
+component's props (don't rely on inherited `HTMLAttributes.children`). Add a
+`tsc --noEmit` gate to CI so composition examples stay type-clean.
+
+**React 19 modernization (`composition-patterns` §4.1).** The chat components use
+`forwardRef` ~140× (e.g. `message.tsx` 6×, `chat-root.tsx` 1×) while
+`ui/button.tsx` already dropped it — inconsistent and obsolete. Under React 19,
+`ref` is a regular prop (no `forwardRef` wrapper) and `use(Context)` replaces
+`useContext` (and can be called conditionally). Migrate wholesale so the codebase
+models the current idiom consumers will expect to mirror.
+
+---
+
+### H. Collapse the deprecated flat controlled API
+
+**Problem.** `ChatProps` carries a large `@deprecated` flat surface
+(`messages`, `input`, `onChange`, `onSubmit`, `sendMessage`, `stop`, `reload`,
+`setInput`, `model`, `activeModel`, `onModelChange`, `inferenceMode`,
+`renderTool`, `quickActions`, `onQuickAction`, `showSources`, `showSteps`,
+`showExport`, `editMessage`, `getBranches`, `switchBranch`, …) alongside the new
+`chat={useChat()}`. Two ways to do everything = magic + confusion.
+
+**Ask.** Remove the deprecated flat props. One controlled path:
+`chat={useChat()}` (or `<Chat.Root>` context). Document the migration.
+
+---
+
+### I. Split presentation from business logic (headless)
+
+**Problem.** Several components fuse logic with rendering, which is the root cause
+the acid test fails: if `<ChatSidebar.Item>` owns select/rename/delete *and* the
+row markup, you can't change the row without inheriting or discarding its logic
+(exactly why our `renderItem` had to reimplement rename as `prompt()`).
+
+**Ask.** Enforce the headless split across the surface:
+- **Logic → hooks/providers/context.** `useConversations`, `useConversationChat`,
+  `useAgentPicker`, composer context, message context — these own state,
+  handlers, and side effects.
+- **Presentation → components.** Every component is a thin, dumb consumer of that
+  context (or of props): it reads `select`/`rename`/`isActive` from context and
+  renders. No fetching, no effects, no persistence inside a presentational node.
+- **Result:** because the row is dumb and pulls behaviour from context, a custom
+  row (or a swapped leaf) keeps *all* the behaviour for free — the acid test
+  passes by construction. This is the Radix/Headless-UI/TanStack separation and
+  it's what React developers expect.
+
+**Current state (not there yet).** `ChatContextValue` and `ComposerContextValue`
+are **flat bags** — state (`messages`, `input`, `isLoading`), actions
+(`setInput`, `onSubmit`, `editMessage`), and meta (`theme`, `scrollToBottom`,
+`isAtBottom`) all mixed in one interface, and `showSources: boolean` is baked
+*into the context* (a toggle in the shared contract). And the "provider"
+(`ChatRoot`) is fed ~25 flat props rather than injecting a state owner.
+
+**Sub-ask — adopt the generic `{ state, actions, meta }` context interface**
+(`composition-patterns` §2.2/§2.3). Restructure each context as a contract any
+provider can implement:
+
+```ts
+interface ChatContextValue {
+  state:   { messages; input; isLoading; error; model; attachments }
+  actions: { setInput; submit; stop; reload; setModel; attach; edit }
+  meta:    { agent; theme; scrollToBottom; isAtBottom }
+}
+```
+
+Then **different providers implement the same interface** and the *same* UI
+composes over all of them — which is precisely how batteries `<Chat>` and the
+hand-composed demo share one implementation (principle 9): e.g. a
+`ConversationChatProvider` (persisted), an `EphemeralChatProvider` (local), a
+`ServerChatProvider` (route-persisted, §A) all satisfy `ChatContextValue`.
+
+This also **kills the persistence effect the right way.** `composition-patterns`
+§2.3 shows the exact anti-pattern — *"Incorrect: useEffect to sync state up"* →
+*"Correct: lift state into a provider."* Our `usePersistMessages` effect is that
+"sync up" smell; lifting chat+persistence into the provider (§A) removes it, and
+lets components *outside* the transcript (a header token counter, a preview)
+read chat state from context without prop-drilling or refs.
+
+**Hooks vs components — don't hookify presentation.** The scoping discipline
+applies to *data*, not every node:
+- **Data/state → scope-prefixed hooks:** `useMessage()`, `useConversation()`,
+  `useComposer()`, `useAgents()`. The prefix names *where the data lives*. One
+  context hook per scope — not one per pixel.
+- **Collections → list hooks** returning arrays (`useMessageParts`,
+  `useConversationMessages`, `useConversationAttachments`) — data you map (§K).
+- **Display → compound components reading context:** `Message.Avatar`,
+  `Message.Header`, `ChatInput.Send`. Scope comes from the *namespace*
+  (`Message.*`), not a hook. So a message avatar is `Message.Avatar` (reads
+  `useMessage()`), **not** a `useConversationAvatar`; there is no hook per visual
+  node. Rule: hook when it's data/state you read or mutate; component (reading
+  context) when it's a presentational node.
+- **One hook per scope, structured — not one per slice.** Access is
+  `const { state, actions, meta } = useMessage()`. `useMessageActions` /
+  `useMessageMeta` are just `.actions` / `.meta` — a destructure away; don't ship
+  them as separate hooks (surface for nothing). Split `state` and `actions` into
+  separate *contexts* only as a *measured* render-isolation optimization (actions
+  are stable; action-only consumers shouldn't re-render on state change) — an
+  internal optimization, never the default surface.
+
+> Acceptance: every presentational component can be replaced by a hand-written
+> equivalent that reads the same `{state, actions, meta}` context and loses
+> **no** behaviour; the same composed UI renders under ≥2 different providers.
+
+### J. Storybook is the completeness contract (started, unfinished)
+
+**Problem.** The composition story was *begun* in Storybook (there are
+`Composed` stories for `Chat`, `ChatInput`, `ChatSidebar`, `ToolCall`, …) but not
+finished to satisfaction — coverage is partial and inconsistent, so the acid test
+isn't provable per-component. Concretely, `storybook:check` **already fails on
+`main`**: the Overview `COMPOSITION` array and `storybook/stories/chat/
+ChatComposition.stories.tsx` don't exist (noted in PR #2798). The composition
+narrative was scaffolded and abandoned — this section is about finishing it.
+
+**Note:** PR #2798 already splits the Storybook sidebar into a top-level **UI**
+section and a **Chat** section — the right structure to build the three-tier
+stories onto.
+
+**Ask.** Make Storybook the enforced contract. **Every** component ships **three
+stories, all backed by the same implementation:**
+
+1. **Black box** — defaults only (`<Chat/>`, `<ChatSidebar/>`), proving great
+   out-of-the-box behaviour.
+2. **Props** — customized via props (icons, labels, class, handlers), proving the
+   common "change X" cases idiomatically.
+3. **Compound** — fully composed from sub-components down to the leaves, proving
+   "change X on Y buried in Z" for that component.
+
+Additionally:
+- A story per component demonstrating the **acid test** explicitly: "change this
+  one leaf" (e.g. swap the send icon, add a sidebar-menu item, restyle the tool
+  output) — each a few lines, no region re-implementation.
+- The docs "Composition" tab must render the full sub-component tree (many
+  already do — finish the ones that don't).
+- Gate CI on Storybook build + a `tsc --noEmit` over the stories so the
+  documented composition always typechecks (see §G).
+
+> Acceptance: for every exported component, all three tiers render in Storybook,
+> and there is a one-leaf-override story that compiles and works.
+
+### K. Codify the "collection pattern" and apply it to every list
+
+The Message-parts resolution (§D.3) isn't a special case — it's the shape **every
+collection** in the chat domain should share. **It is the data/display split
+(principle 2, §I) applied to lists:** the hook is the *data*, the leaf/primitive/
+batteries are *display*. Define it once, apply it uniformly, so the whole API is
+learnable from any one list ("if you know parts, you know attachments").
+
+**And it's always achievable** — the data already exists as hooks
+(`chat.messages`, `useUpload().attachments`, `useAgents().agents`,
+`useConversations().conversations`). The display components exist too. The only
+work is *decoupling* them: stop having the display component own the iteration +
+data plumbing, and expose the data hook + a leaf so the consumer can map. Nothing
+here requires new capability — just separating what's already there.
+
+The four access points, all off one implementation:
+
+1. **`useX()` → data** (headless; e.g. `useMessageParts`, `useUpload().attachments`).
+2. **`<X.Item>` / leaf** — the composable default for one element
+   (`Message.Part`, `AttachmentPill`, `SourcePill`, `ChatSidebar.Item`).
+3. **`<X.List>` primitive** — iterates + function-child `({ item }) => …`,
+   renders defaults when you return nothing (assistant-ui shape).
+4. **`<X>` batteries** — `<X.List>` with the default renderer. Zero-config.
+
+Apply to (components/hooks that exist today but aren't unified on this shape):
+
+| Collection | Data | Leaf | Batteries | Heterogeneous |
+| --- | --- | --- | --- | --- |
+| Message parts (incl. file attachments) | `useMessageParts()` | `Message.Part` | `Message.Content` | ✅ |
+| Composer attachments (pending draft) | `useComposerAttachments()` *(today `useUpload().attachments`)* | `AttachmentPill` | composer strip | ✅ mediaType |
+| Conversation files (durable) | `useConversationAttachments()` *(today `useUploadsRegistry`)* | `AttachmentPill` | `AttachmentsPanel` | ✅ mediaType |
+| Transcript | `useConversationMessages()` *(today `chat.messages`)* | `Message.Root` | `ChatMessageList` | ~ role |
+| Conversations | `useConversations().conversations` | `ChatSidebar.Item` | `ChatSidebar.List` | ~ recency |
+| Sources | `extractSourcesFromParts()` | `SourcePill` | `Sources` | — |
+| Agents | `useAgents().agents` | `AgentPicker.Item` | `AgentPicker` | — |
+| Suggestions | `agent.suggestions` | `Suggestion` | `Suggestions` | — |
+| Steps | `useMessageParts()` | `StepIndicator` step | `StepIndicator` | — |
+| Branches | `chat.getBranches()` | — | `BranchPicker` | — |
+| Models | prop | `ModelOption` | `ModelSelector` | — |
+
+**Priority within §K:** **attachments** (heterogeneous `switch` on file type — the
+exact twin of parts) and **transcript** (the message list) are the highest-value
+unifications; the homogeneous lists are mechanical once the shape is a documented
+house rule.
+
+> Acceptance: a single "Collections" doc page + Storybook section shows the
+> identical four-tier pattern for parts, attachments, and the transcript; the
+> rest follow by convention.
+
+## Changes in THIS example repo once the above land
+
+The composed demo (`app/custom/page.tsx`) currently carries the workarounds the
+above changes eliminate. When they land, delete:
+
+- `usePersistMessages` + its `useRef`/`useEffect` → replaced by
+  `useConversationChat` / `<ConversationChat.Root>` (§A).
+- The hand-rolled `ConversationRow` popover + native `prompt()` → `ChatSidebar.Item`
+  sub-parts + `DropdownMenu` from **`veryfront/ui`** (§C, §F/PR #2798).
+- The `MailIcon` stays (legit), but via `<ChatInput.Send icon>` (already fine).
+- Any remaining boolean props (none should survive §B).
+- The `AppShell`/`ChatEmptyState` `tsc` suppressions (§G).
+
+Result: `app/custom/page.tsx` becomes pure composition of public parts with no
+custom logic — the reference for Demo 2. `app/page.tsx` stays the 1-line Demo 1.
+
+---
+
+## Suggested phasing
+
+1. **§F (export ui)** — ✅ in flight as **PR #2798** (`veryfront/ui`). Land it
+   first; it's the base-layer split everything else composes on. Pair with
+   **§G (types)** — small, unblocks composition immediately.
+2. **§I (headless split)** — foundational; it's what makes the acid test pass.
+   Land the presentation/logic separation before the depth work builds on it.
+3. **§A (state glue)** — the headline; `useConversationChat` + route `onFinish`,
+   refactor `<Chat>` onto it (consumes §I).
+4. **§C/§D (leaf composition + render-prop parity)** — the depth work: reach
+   every child node, unify render props.
+5. **§B/§E/§H (toggle/className/deprecation cleanup)** — API-surface polish;
+   coordinate as breaking changes / a major.
+6. **§J (Storybook contract)** — runs *alongside* every phase: each component
+   isn't "done" until its three-tier + acid-test stories exist and typecheck.
+
+The through-line: **§I + §J are the definition of done.** Every component lands
+its headless split and its three Storybook tiers, or it isn't finished.
+
+---
+
+## Appendix — evidence (shipped `veryfront@0.1.998`)
+
+- **Persistence bridge is `<Chat>`-private:** `react/components/chat/chat/index.tsx`
+  `UncontrolledChat` — `useEffect(… sink(conversation) …, [chat.messages, boundId])`
+  with `persistRef`/`lastEmittedRef`.
+- **`showSources` deprecated:** `ChatProps` — "Sources render automatically when a
+  message carries them"; `MessageContentProps` — "Prefer composition — render
+  `Message.Sources` or omit."
+- **Boolean toggles (count):** `showSources`, `showSteps` (×5 each),
+  `showScrollButton`, `showMessageActions`, `showExport`, `showTabs`,
+  `hideTabSwitcher`, `enableAttachments`, `enableVoice`, `enableMermaid`,
+  `showSearch`, `showLabel`, `showRemove`.
+- **Second class-names / passthrough:** `contentClassName`, `cardClassName`,
+  `dragProps`.
+- **`icons={{}}` slot objects (7):** `ChatInputIcons`, `ChatSidebarIcons`,
+  `AgentPickerIcons`, `MessageActionBarIcons`, `MessageFeedbackIcons`,
+  `BranchPickerIcons`, `AttachmentPillIcons`.
+- **Render props present (unstandardized):** `renderTool`, `renderMessage`,
+  `renderItem`, `renderRow`, `renderPill`, `renderCodeBlock`,
+  `renderScrollButton`, `renderTrigger`, `renderSkill`, `renderHeader`,
+  `renderCard`.
+- **UI kit not exported** (being fixed by **PR #2798**): shipped
+  `package.json#exports` has no `./ui` / `./components/chat` / `./*`;
+  `DropdownMenu` lives at `react/components/chat/ui/dropdown-menu` (used by
+  `ChatSidebar.Item`) but is unreachable publicly. #2798 promotes these to
+  `veryfront/ui`.
+- **Flat contexts + boolean-in-contract:** `ChatContextValue` /
+  `ComposerContextValue` mix state/actions/meta flatly and include
+  `showSources: boolean` (context files under `chat/chat/contexts/`).
+- **`forwardRef` ~140× across chat components** (message.tsx 6×, chat-root 1×),
+  while `ui/button.tsx` already dropped it — React-19 migration pending.
+- **Storybook composition incomplete:** `storybook:check` fails on `main` — the
+  Overview `COMPOSITION` array and `stories/chat/ChatComposition.stories.tsx`
+  don't exist (per PR #2798).
+- **Type bug:** `tsc --noEmit` errors `children does not exist on AppShellProps`
+  / `ChatEmptyStateRootProps` (props extend `HTMLAttributes` without re-declaring
+  `children`).
+- **External references:** AI SDK v5 server-side `onFinish` persistence
+  (ai-sdk.dev/docs/ai-sdk-ui/chatbot-message-persistence); TanStack AI planned
+  `ChatPersistenceAdapter` (github.com/TanStack/ai/discussions/201).
+```

--- a/docs/plans/2026-07-08-chat-composition-overhaul.md
+++ b/docs/plans/2026-07-08-chat-composition-overhaul.md
@@ -1,0 +1,291 @@
+# Plan — `veryfront/chat` composition & API overhaul
+
+Source of truth: the handoff brief — [`./2026-07-08-chat-composition-handoff.md`](./2026-07-08-chat-composition-handoff.md) (§A–§K).
+Assumes **PR #2798 (`veryfront/ui`) has landed** as the base layer.
+This document is the execution plan: **epics → tasks → quality gates → tests → acceptance criteria**, plus the strategy that sequences them. It is intentionally *not* code.
+
+> The handoff is **input, not gospel.** Where its solution is right, we adopt it; where the code shows a deeper problem or a better fix, we diverge (see §0.8 "Where we improve on the handoff" and the "Additional findings" appendix — smells found by auditing the shipped code, not just reading the doc).
+
+---
+
+## 0. Strategic framing (read first)
+
+### 0.1 The one non-negotiable = the acid test
+"Change any leaf X on any node Y, in place, without re-implementing its parent Z." Everything below is in service of that. **A principle that isn't enforced by a gate will rot** — so each epic ships an *enforcement mechanism*, not just an implementation.
+
+### 0.2 Definition of Done
+**Every exported component (UI primitives + chat) — "composable, no black box":**
+1. Presentation is a dumb consumer of `{state, actions, meta}` context or props (no fetching/effects/persistence inside it).
+2. Every visual leaf is an addressable sub-component with **one** root `className`.
+3. A runtime composability-contract test asserts each leaf is individually overridable without losing sibling behaviour.
+4. Public types pass `tsc --noEmit`.
+5. No boolean feature toggles, no `*ClassName`/`*Props`/`icons={{}}` bags.
+
+**Chat components — additionally (three-tier + acid-test stories, §J):**
+6. Three Storybook tiers (black-box / props / compound) **off one implementation**, plus one explicit "one-leaf-override" acid-test story.
+
+> **Scope (Q4, locked).** `veryfront/ui` primitives must be composable/no-black-box (1–5) but are **not** required to ship the three-tier story set. Chat components carry **both** (1–6). Keeps the ~180-story explosion off the UI kit while still guaranteeing every primitive is reachable.
+
+### 0.3 Breaking-change strategy (the most important strategic call)
+The work is ~70% **additive/non-breaking** (§F✅, §G, §I-internal, §A, §C, §D, §K, §J) and ~30% **breaking removals** (§B toggles, §E passthrough props, §H flat API).
+
+**Recommendation: ratchet, then batch.**
+- Land *all* additive work first — introduce the compositional replacements so both old (deprecated) and new APIs coexist.
+- Add **deprecation lints/ratchets** the moment a replacement exists (freeze the old surface; forbid new usages).
+- **Batch every removal (§B/§E/§H) into a single breaking release** with a codemod + migration guide — do **not** dribble breaking changes across many PRs (that's N migrations for consumers instead of one).
+
+### 0.4 Enforcement philosophy — gates as ratchets, not one-time cleanups
+Each anti-pattern gets a lint seeded with a **baseline allowlist of today's violations**; the lint fails on any *new* violation and the allowlist only shrinks. This lets us stop the bleeding immediately and burn down incrementally. (Same shape as the repo's existing `check-sanitizer-baseline` / `check-skipped-tests-baseline`.)
+
+### 0.5 Reframes vs. the handoff's phasing
+- **§J (Storybook) is infrastructure, not a final phase.** Build the harness + CI gate *first* (E0), then fold the per-component stories into each component epic's DoD.
+- **§G splits**: G1 (children types + `tsc` gate — tiny, do first) vs G2 (React-19 `forwardRef` codemod — large, mechanical, parallelizable, independent).
+- **§I splits**: I(i) the `{state,actions,meta}` *contract* (spine, foundational) vs I(ii) the per-component dumb-down (folds into §C/§K per component).
+- **§K is a house rule**: codify the 4-tier collection pattern once (K0), then application is mechanical per list.
+
+### 0.6 Dependency graph
+```
+E0 (enablement/gates) ──┬─> E1 (context spine, I-i) ──> E3 (state glue, A) ──> E4/E6 (depth: C/D/K + I-ii)
+                        ├─> E2 (React19 codemod, G2)  [parallel, independent]
+                        └─> J-harness ─────────────────────────────────────> (folds into every epic's DoD)
+E4/E6 ──> E8/E9/E10 (BREAKING batch: B/E/H) ──> major release + codemod + migration guide
+```
+
+### 0.7 Risk register
+- **R1 (high):** E1+E3 rewire the `<Chat>` core. Mitigation: freeze behaviour with the *existing* runtime tests + an expanded contract test **before** refactoring; refactor under green.
+- **R2 (med):** "acid test" is subjective → it must become concrete per-component contract tests, or the gate is theatre.
+- **R3 (med):** §K × 11 collections risks drift → the house-rule doc + a shared list primitive + a lint template.
+- **R4 (low/annoying):** breaking batch timing vs. the repo's rolling `0.1.x` versioning — needs a release/signalling decision (see Open Decisions Q1).
+
+---
+
+## Cross-cutting quality gates (built in E0, enforced forever after)
+
+| Gate | What it enforces | Mechanism |
+| --- | --- | --- |
+| `tsc --noEmit` (public + stories) | Documented composition typechecks under React 19 (deno check misses this) | new CI job over `tsconfig.json` + a stories tsconfig |
+| Storybook three-tier | Every exported component has black-box / props / compound + 1 acid-test story | extend `scripts/storybook/storybook-workbench.test.ts` |
+| Composability contract (runtime) | Every compound's leaves are individually overridable, siblings keep behaviour | extend `composability.contract.test.tsx` |
+| Composability contract (static) | Every compound re-exports its leaves; no black-box regions | extend `scripts/lint/audit-chat-composability.ts` |
+| No-new-boolean-toggle lint | Bans new `show*/enable*/hide*` props; baseline = current list | new `scripts/lint/ban-feature-toggles.ts` (+ baseline) |
+| No-passthrough lint | Bans new `*ClassName`, `*Props`, `icons={{}}` bags; baseline seeded | new `scripts/lint/ban-passthrough-props.ts` (+ baseline) |
+| No-`forwardRef` lint | Bans new `forwardRef` (post-E2); baseline shrinks to 0 | new lint (+ baseline) |
+| Composed-demo purity | The composed example app has **zero** `useEffect`/`useRef` | lint over the example app dir |
+
+---
+
+## Epics
+
+> Legend — **Breaking?** additive unless marked. **DoD** = §0.2 applies on top of the epic-specific acceptance.
+
+### E0 — Enablement & gates (do first; unblocks everything)
+**Goal.** Stand up the enforcement infra so later epics land under gates, and fix the tiny type bugs blocking documented composition.
+**Breaking?** No.
+**Tasks.**
+- G1: re-declare `children: React.ReactNode` on every compound props interface that `extends HTMLAttributes` (confirmed offenders: `AppShellProps`, `AppShell.Sidebar/Header`, `ChatEmptyState*`; sweep for the rest).
+- Add `tsc --noEmit` CI job (public entry types) + a **stories** tsconfig so `deno task` gates story typechecking.
+- J-harness: a Storybook helper + `storybook-workbench.test.ts` extension asserting the three-tier + acid-test story set per exported component (seed with an allowlist of components not yet covered).
+- Extend `audit-chat-composability.ts` + `composability.contract.test.tsx` into the general "acid-test" contract (leaf-override probe).
+- Seed the three ratchet lints (feature-toggle, passthrough, forwardRef) with today's violations as baselines.
+- K0: write the "Collections" house-rule doc (the 4 access points) — spec only, no application yet.
+**Tests.** The gates test themselves (a passing + a deliberately-failing fixture per lint/contract). `tsc` job green on current tree.
+**Quality gates added.** All of the cross-cutting table above.
+**Acceptance.**
+- `deno task <new gates>` all green on the current tree.
+- Each ratchet lint fails on an injected new violation and passes on baseline.
+- Documented composition examples from the handoff typecheck under `tsc --noEmit`.
+
+### E1 — Headless context spine (§I-i)
+**Goal.** Restructure `ChatContextValue` / `ComposerContextValue` / message context to the generic `{ state, actions, meta }` contract; remove `showSources: boolean` from the contract.
+**Breaking?** Internal-only if these contexts aren't publicly exported; if any hook (`useChatContext` etc.) is public, ship a back-compat shim (flat getters delegating to structured) for one release, then remove in the breaking batch.
+**Depends.** E0.
+**Tasks.** Define the interfaces; migrate providers (`ChatRoot`) to inject a state owner instead of ~25 flat props; move `showSources`-style meta out of context (presence-driven); update all internal consumers to `const { state, actions, meta } = useX()`.
+**Tests.** Contract test: the same UI subtree renders identically under **≥2 provider implementations** satisfying `ChatContextValue` (e.g. an ephemeral vs a persisted provider stub). Existing chat runtime tests stay green.
+**Quality gates.** Composability contract; no-boolean-in-context assertion.
+**Acceptance.** Every presentational chat node reads only `{state,actions,meta}`; a hand-written component reading the same context loses no behaviour; ≥2 providers drive the same UI.
+
+### E2 — React 19 modernization (§G-2) — *parallel, independent*
+**Goal.** Drop `forwardRef` (29 sites/17 files in chat) → `ref` as a regular prop; `useContext` → `use()` where it clarifies.
+**Breaking?** No (internal idiom).
+**Depends.** E0 (the forwardRef baseline lint).
+**Tasks.** Codemod pass, component by component; delete the baseline entries as they burn down to 0.
+**Tests.** Existing render/ref tests green; add a ref-forwarding assertion where missing.
+**Acceptance.** `forwardRef` baseline = 0 in chat; ref still attaches on every leaf (test-proven).
+
+### E3 — Kill userland state glue (§A) — the headline
+**Goal.** Persistence + chat binding become library primitives, not app effects.
+**Breaking?** Additive (new exports), then internal refactor of `<Chat>`.
+**Depends.** E1.
+**Tasks.**
+- Add `afterStream`/`onFinish({ messages })` to `createAgUiHandler` (symmetric with `beforeStream`) — server-side persistence at the route boundary.
+- Add `useConversationChat({ conversationId, store, agentId })` and/or `<ConversationChat.Root>` provider: does `useChat` + seeding + the persist bridge internally (the logic currently private to `UncontrolledChat`'s effect).
+- **Refactor `<Chat>` to consume it** — one code path for batteries + composed.
+**Tests.** Provider-level test: multi-conversation persistence with **zero** `useEffect`/`useRef` in the test's "userland" harness; switching conversations seeds+persists correctly; `<Chat>` batteries behaviour unchanged (existing tests green).
+**Quality gates.** Composed-demo purity lint (zero effects/refs).
+**Acceptance.** A fully-composed multi-conversation persisted chat contains zero `useEffect`/`useRef` in app code; `<Chat>` and the composed demo share the same hook/provider.
+
+### E4 — Leaf composition depth (§C) + headless dumb-down (§I-ii)
+**Goal.** Complete compounds to the leaves; each leaf a dumb context consumer.
+**Breaking?** Additive (adds sub-components; keeps existing).
+**Depends.** E1, E3.
+**Tasks.** `Message.Header.Name/.Timestamp`; `ChatSidebar.Item.Title/.Menu/.Rename/.Delete` (menu built on `veryfront/ui` `DropdownMenu`); `ChatInput.Toolbar`; `AgentPicker.Search`; each reads behaviour from context so a swapped leaf keeps rename/delete/select for free.
+**Tests.** Per-leaf acid-test: replace one leaf, assert siblings' behaviour intact; sidebar row-menu **addition** (not replacement) works.
+**Quality gates.** Composability contract per completed compound; its three Storybook tiers.
+**Acceptance.** For every region, any single leaf is replaceable with built-in sibling behaviour retained; "add a sidebar menu entry" needs no region re-implementation.
+
+### E5 — Render-prop discipline + headless message parts (§D)
+**Goal.** `children` for static structure; `renderItem` only for data lists; message parts exposed as headless data.
+**Breaking?** Additive now; the *removal* of `renderHeader/renderCard/renderTrigger/renderSkill` etc. joins the breaking batch (E8–E10).
+**Depends.** E4.
+**Tasks.** Convert static render props → compound children (keep old as deprecated). Standardize list render props to `render<Child>` + function-child. Ship `useMessageParts()`, `Message.Part`, `Message.Text/.Reasoning/.Source`, `Message.Parts` (function-child), `Message.Content = <Message.Parts>` default switch. Delete the `renderTool` *concept* (superseded; actual prop removed in batch).
+**Tests.** Parts render via `switch` returning composed defaults; `Message.Parts` defaults-on-empty-return; `Message.Content` zero-config equals the manual switch.
+**Acceptance.** Four documented access points to parts off one implementation; no slot-map; render props exist only on data lists.
+
+### E6 — Collection pattern applied everywhere (§K)
+**Goal.** Every chat collection shares the 4-tier shape from K0.
+**Breaking?** Additive.
+**Depends.** E5 (parts is the exemplar), K0.
+**Tasks.** Apply to: composer attachments, conversation files, transcript, conversations, sources, agents, suggestions, steps, branches, models. **Priority: attachments (heterogeneous, twin of parts) + transcript.** Each: expose `useX()` data hook, `<X.Item>` leaf, `<X.List>` function-child primitive, `<X>` batteries.
+**Tests.** For parts + attachments + transcript: all four tiers render; homogeneous lists get a lighter conformance test.
+**Quality gates.** A "collection conformance" contract test template per list.
+**Acceptance.** One "Collections" doc + Storybook section shows the identical four-tier pattern for parts/attachments/transcript; the rest follow by convention.
+
+### E7 — Storybook three-tier + acid-test coverage (§J) — *tracking epic, folds into E1–E6*
+**Goal.** Every exported component ships its three tiers + one-leaf-override story, all typechecked.
+**Breaking?** No.
+**Depends.** E0 (harness).
+**Tasks.** Per component (tracked as a checklist), author the tiers; finish the abandoned `Composition` narrative; the storybook gate flips each component from allowlisted → enforced.
+**Acceptance.** The storybook three-tier gate has an **empty allowlist** (every exported component enforced); `tsc` over stories green.
+
+### E8 — BREAKING: remove boolean toggles (§B)
+**Depends.** E4–E6 (replacements exist). **Breaking? Yes.**
+**Tasks.** Remove `showSources/showSteps/showScrollButton/showMessageActions/showExport/showTabs/hideTabSwitcher/enableAttachments/enableVoice/showSearch/enableMermaid/showLabel/showRemove` from the **composition** layer. Decide per-item whether the **preset `<Chat>`** keeps a convenience alias (Open Decision Q2).
+**Tests.** Presence-driven behaviour proven; preset aliases (if kept) map 1:1 to including a default sub-component.
+**Acceptance.** Composed layer requires no booleans; feature-toggle baseline = 0.
+
+### E9 — BREAKING: remove passthrough props (§E)
+**Depends.** E4. **Breaking? Yes.**
+**Tasks.** Remove `contentClassName`/`cardClassName` (keep single root `className`), `dragProps`, and the 7 `icons={{}}` bags → per-sub-component `icon` props.
+**Acceptance.** Passthrough baseline = 0; styling/icon customization is composition-only.
+
+### E10 — BREAKING: collapse deprecated flat controlled API (§H)
+**Depends.** E1, E3. **Breaking? Yes.**
+**Tasks.** Remove the `@deprecated` flat `ChatProps` surface (`messages/input/onChange/onSubmit/sendMessage/stop/reload/setInput/model/activeModel/onModelChange/inferenceMode/renderTool/quickActions/…`). One controlled path: `chat={useChat()}` / `<Chat.Root>`.
+**Acceptance.** One documented controlled path; migration guide covers every removed prop.
+
+### E11 — BREAKING release cut (batches E8+E9+E10)
+**Goal.** Ship all removals as one major with a codemod + migration guide + changelog.
+**Depends.** E8, E9, E10, and each replacement gate at baseline 0.
+**Acceptance.** Codemod migrates the removed props to composition; migration guide complete; npm-smoke + downstream example build green on the new surface.
+
+---
+
+## Recommended PR sequence
+1. **PR-1 = E0** (types + `tsc` gate + storybook harness + contract extension + ratchet baselines + K0 doc). Small-ish, unblocks all.
+2. **PR-2 = E2** (React 19 codemod) — parallelizable, land anytime after E0.
+3. **PR-3 = E1** (context spine).
+4. **PR-4 = E3** (state glue) — the headline.
+5. **PR-5…N = E4/E5/E6** per region/collection, each self-contained with its stories + contract test (attachments + transcript first).
+6. **PR-final = E8+E9+E10 → E11** one breaking release.
+
+Each PR's merge bar = the cross-cutting gates + that component's DoD.
+
+---
+
+## Open decisions — need your call before building
+- **Q1 (release/versioning).** How do we signal the breaking batch (E11) in a repo that uses a rolling `0.1.x` patch counter? Options: (a) reserve a version + CHANGELOG + codemod and treat it as "the breaking one"; (b) actually move to `0.2.0`/`1.0.0` to use semver's minor/major properly. Recommendation: (b) — a real minor/major bump is the honest signal for consumers.
+- **Q2 (preset booleans).** Does the batteries `<Chat>` keep *any* convenience booleans (mapping 1:1 to "include default sub-component"), or go strictly zero-boolean everywhere? Affects E8 + the 1-line Demo-1 ergonomics.
+- **Q3 (persistence priority).** §A asks for **both** server-side `onFinish` and client `useConversationChat`. The demos are client-composed — do we ship the client hook first (unblocks both demos) and the route `onFinish` second, or together?
+- **Q4 (Storybook scope).** "Every component, three tiers" — does that include the 39 `veryfront/ui` primitives (~60 components × 3 ≈ 180 stories), or scope the three-tier contract to **chat** components and keep UI primitives at single-story? (Big effort delta.)
+- **Q5 (first-PR scope).** Confirm PR-1 = E0 as scoped above. Anything you want pulled forward (e.g. start E1 in the same PR) or dropped?
+- **Q6 (issues).** Want me to turn this into GitHub issues (one epic → tracking issue + task issues), or keep it as this doc + drive PRs directly?
+
+---
+
+## 0.8 Where we improve on the handoff (critical divergences)
+
+The handoff is a strong *symptom* list but under-plays three things the code audit makes obvious:
+
+1. **The real spine is decomposing one god file, not "context shape."** `chat/chat/index.tsx` is **1,153 LOC, 26 `@deprecated` markers, ~117 prop/field lines** — it fuses `<Chat>`, `UncontrolledChat` (the persistence effect §A), the entire deprecated flat API (§H), and the mega-prop surface. §I/§A/§H all converge here. Treat **shrinking this file** as the master burn-down metric; the context restructure (§I) is a *means* to that end, not the end.
+
+2. **We are missing a safety net, not just stories.** **36 chat components have no co-located test.** §J's three-tier stories are aspirational polish; the *prerequisite* for safely rewiring the core (E1/E3) is **characterization tests** locking current behaviour. This is a new epic (E0.5) the handoff omits — refactoring a 1,153-LOC untested god file blind is the single biggest risk.
+
+3. **Progress must be measured, or "done" is subjective.** The acid test is qualitative. Convert the whole effort into **metric ratchets** (below) wired into CI, so every PR provably moves the numbers down and can never regress. This makes §J's "definition of done" objective.
+
+## 0.9 Metric ratchets (wired into CI in E0; each PR must not regress)
+
+| Metric | Today | Target | Gate |
+| --- | --- | --- | --- |
+| `chat/index.tsx` LOC | 1,153 | < ~300 | file-size ratchet |
+| `@deprecated` in chat | 32 (26 in index.tsx) | 0 (after E10) | grep ratchet |
+| Feature-toggle booleans | ~13 | 0 in composition layer | `ban-feature-toggles` |
+| Passthrough props (`*ClassName`/`*Props`/`icons={{}}`) | ~10 | 0 | `ban-passthrough-props` |
+| `forwardRef` in chat | 29 (17 files) | 0 | `ban-forwardRef` |
+| Public barrel compat aliases | ≥5 (`Attachment`, `StandaloneMessage`, `StreamingMessage`, …) | 0 (after E10) | barrel-surface test |
+| Chat components w/o test | 36 | 0 | coverage-per-component gate |
+| Storybook three-tier coverage | partial | 100% (empty allowlist) | `storybook-workbench` |
+| Unmemoized context `value={{…}}` | ≥1 (agent-picker) | 0 | lint/contract |
+
+## Additional findings appendix (audited in the shipped tree, beyond §A–§K)
+
+- **F-1 God components.** `index.tsx` 1153 · `message.tsx` 970 (92 props) · `chat-composer.tsx` 644 · `sidebar.tsx` 630 (70 props) · `agent-picker.tsx` 520 · `chat-actions.tsx` 515. Presentation+logic fused → the structural reason the acid test fails. Decomposition is implicit in §I but the **size** is the concrete, measurable smell. *(Feeds E1/E4; add a per-file LOC ratchet.)*
+- **F-2 Prop-count explosion.** `ChatProps` ~117 members, `MessageProps` ~92, `ChatSidebarProps` ~70 — the quantified form of "boolean/flat-prop proliferation." *(composition-patterns §1: replace with children/compound.)*
+- **F-3 Unmemoized context value** (`agent-picker.tsx` `.Provider value={{…}}` inline) → new object every render → all consumers re-render. §I must mandate memoized, ideally state/actions-split contexts. *(Add to E1 acceptance + a lint.)*
+- **F-4 Public-barrel deprecation debt.** `src/chat/index.ts` ships compat aliases from the earlier rename (`AttachmentPill as Attachment`, `Message as StandaloneMessage`/`StreamingMessage`, `MessageProps as Standalone/StreamingMessageProps`). Two names per concept = the "two ways to do everything" smell in the *public* surface. *(Fold into E10 breaking batch + migration guide.)*
+- **F-5 Two class-join helpers.** `theme.ts` exports `cn`; `ui/cva.ts` exports `cx` — both are `clsx`. `ui` standardized on `cx`; chat still uses `cn`. One concept, two names. *(Low priority: standardize on one, re-export the other as a deprecated alias.)*
+- **F-6 Index-as-key (×8).** `key={i}`/`key={index}` on lists that reorder (messages/parts/attachments/conversations) risks React reconciliation bugs on insert/delete/reorder — precisely the §K/§D collections. *(Fold stable-key fixes into E5/E6; add a lint over the chat lists.)*
+- **F-7 Timer cluster (10 prod `setTimeout`/`setInterval`).** Scroll/focus/debounce logic implemented with raw timers inside components. Audit for effects that should be derived state or extracted into a named hook (§I "logic → hooks"). Not all wrong, but a review target.
+- **Corrected non-findings (audit hygiene).** Batch-1's high counts for direct-DOM (`querySelector`/`getElementById` ×31), `as unknown as` (×6), and `: any` (×5) were **test-file noise** — production chat code is **0/0/0** on these. No production type-escape or imperative-DOM smell. Reported so priorities aren't skewed by false positives.
+
+## New/updated epics from the audit
+
+### E0.5 — Characterization safety net (NEW; do before E1/E3)
+**Goal.** Lock current behaviour of the god file + the 36 untested components before any rewire.
+**Breaking?** No. **Depends.** E0.
+**Tasks.** Characterization tests (render + key interactions: send, edit, persist, switch conversation, rename/delete, attach) for `<Chat>`/`UncontrolledChat`, `message`, `sidebar`, `chat-composer`, `agent-picker`. Prioritize the files E1/E3 touch.
+**Tests/Acceptance.** Named behaviours pass on the current tree; the suite stays green through E1/E3 (the definition of "no regression"); untested-component count strictly decreases toward 0.
+
+### E1 addendum — god-file decomposition + memoized structured context
+Add to E1 tasks: extract `UncontrolledChat`/persistence out of `index.tsx` (→ E3's provider), extract the deprecated flat API into a clearly-marked `chat-compat.tsx` slated for E10 deletion, and require every context `value` be memoized (F-3). Acceptance gains: `index.tsx` < ~300 LOC; no inline context object.
+
+---
+
+## Canonical alignment — `composition-patterns` v1.0 (the cited reference)
+
+Mapping each rule → epic → the concrete acceptance criterion it dictates, and where the shipped code violates it.
+
+| Rule (priority) | Epic | Code violates it via | Acceptance criterion (verbatim to the rule) |
+| --- | --- | --- | --- |
+| **§1.1 Avoid boolean prop proliferation** (CRITICAL) | E8 (§B) | ~13 `show*/enable*/hide*` toggles; `ChatProps` ~117 fields | No behaviour-customizing booleans on the composition layer; each mode is composition or an explicit variant (see below) |
+| **§1.2 Use compound components** (HIGH) | E4 (§C) | opaque leaves; `renderItem` as the only hook on `ChatSidebar.Item` | Every region is a `Provider`+parts compound; each part reads `use(Context)`, exported as a compound object |
+| **§2.1 Decouple state from UI** (MED) | E1/E3 (§I/§A) | god components fuse state+markup; `UncontrolledChat` owns persistence | UI components know only the context interface; provider is the *only* place state impl lives |
+| **§2.2 Generic `{state, actions, meta}` interface** (HIGH) | E1 (§I) | flat context bags; `showSources: boolean` in-contract; unmemoized value | Each context is `{state, actions, meta}`, memoized; ≥2 providers implement it and drive the same UI |
+| **§2.3 Lift state into providers** (HIGH) | E3 (§A) | **the persistence `useEffect(…sink…)` IS the doc's "Incorrect: useEffect to sync state up"** | Chat+persistence lifted into a provider; a sibling (header token counter) reads chat state *outside* the transcript with no prop-drill/ref/effect |
+| **§3.1 Explicit variants** (MED) | E8 / **Q2** | (would-be) convenience booleans on `<Chat>` | Modes are **explicit variant components** (`<Chat>` default, a distinct preset if needed) — **not** `<Chat compact/thread/edit>` |
+| **§3.2 Children over render props** (MED) | E5 (§D) | `renderHeader/renderCard/renderTrigger/renderSkill` (static) + inconsistent `renderItem/renderRow/renderPill` | `children` for static structure; `renderItem` **only** where the parent passes data, shaped `({ item, index }) => …` |
+| **§4.1 React 19 (`ref` prop, `use()`)** (MED) | E2 (§G2) | 29 `forwardRef` in chat; `useContext` throughout | 0 `forwardRef`; `use(Context)` (conditional-capable) replaces `useContext` |
+
+### Decision resolved by the reference — Q2 (preset booleans)
+`composition-patterns` §1.1+§3.1 are explicit: the answer to "modes" is **explicit variant components**, never booleans. So the batteries `<Chat>` should be *the default explicit variant* (a fixed arrangement of the public parts), and any alternative mode ships as its **own named component** (e.g. a hypothetical `<CompactChat>`), not a `<Chat compact>` flag. **Recommendation: zero behaviour-booleans anywhere; presets are variant components.** This tightens E8 and removes the "convenience alias" carve-out the handoff left open — unless you explicitly want ergonomic aliases despite the rule (your call, but the cited guide says no).
+
+### The strongest single lever
+§2.3's "Incorrect: useEffect to sync state up" is a **line-for-line description of the shipped persistence bridge** (`UncontrolledChat`'s `useEffect(…sink(conversation)…, [chat.messages, boundId])`). The reference doesn't just say "this is bad" — it prescribes the exact fix (lift into a provider). That makes **E3 the highest-conviction, best-supported change in the whole plan**: it's not opinion, it's the cited anti-pattern with the cited remedy.
+
+---
+
+## Decisions locked (2026-07-08)
+
+- **Q1 — Versioning: no version bump in any of these PRs.** The version/release call is made **after merge** as a separate step (matches the repo's rolling `0.1.x` cadence — bumps are their own dedicated PRs). E11 therefore does **not** touch `deno.json`; it ships the breaking *code* + codemod + migration guide, and the version/release decision follows independently.
+- **Q3 — Persistence: ship both together.** E3 delivers server-side `afterStream/onFinish({messages})` on `createAgUiHandler` **and** the client `useConversationChat` / `<ConversationChat.Root>` in the same epic (they're the two halves of "kill the persistence effect").
+- **Q4 — Storybook scope: split by layer.** UI primitives = composable/no-black-box only (DoD 1–5); chat components = both (DoD 1–6, incl. three-tier + acid-test stories). The three-tier storybook gate's enforced allowlist covers **chat** components; UI primitives are held to the composability contract, not the story-tier count.
+- **Q5 — Docs first.** PR-1 is **spec/docs to work through the design before code**: the collections house-rule doc (K0), the `{state,actions,meta}` context contract spec, and the per-component DoD checklist — landed as `.context`/`docs` markdown. The gate *infrastructure* (E0) + characterization safety net (E0.5) follow once the specs are agreed. **Do not start component code until the specs are reviewed.**
+- **Q6 — Tracking in markdown, no GitHub issues.** This plan file is the tracker. Each epic gets a checklist here; progress + burn-down metrics are updated in-file per PR. (Companion per-epic md files may be split out under `.context/plans/` if any single epic's checklist grows large.)
+
+### Revised PR sequence (post-decisions)
+1. **PR-1 — Docs/specs (Q5):** K0 collections house-rule, context contract spec, DoD checklist, metric-ratchet definitions. **Review gate before any code.**
+2. **PR-2 — E0 gates + G1 types:** the enforcement infra + `tsc` gate + ratchet baselines (built to the PR-1 specs).
+3. **PR-3 — E0.5 characterization tests:** safety net over the god file + the 36 untested components.
+4. **PR-4 — E2** React 19 codemod (parallelizable).
+5. **PR-5 — E1** context spine → **PR-6 — E3** state glue (both halves, Q3).
+6. **PR-7…N — E4/E5/E6** depth (attachments + transcript first), each with its chat three-tier stories.
+7. **PR-final — E8+E9+E10 → E11** breaking batch + codemod + migration guide (**no version bump**, Q1).

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -7,4 +7,5 @@ and are not part of the published documentation surface.
 
 | Plan | Status |
 | --- | --- |
+| [**START HERE** — implementation kickoff handoff](./START-HERE.md) | — |
 | [`veryfront/chat` composition & API overhaul](./2026-07-08-chat-composition-overhaul.md) — full epic breakdown, from the [handoff brief](./2026-07-08-chat-composition-handoff.md) | Proposed |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,10 @@
+# Engineering plans
+
+Internal, forward-looking execution plans (epics, phasing, quality gates,
+acceptance criteria). These are working documents for maintainers — not public
+guides or API reference — so they live outside `docs/guides`/`docs/api-reference`
+and are not part of the published documentation surface.
+
+| Plan | Status |
+| --- | --- |
+| [`veryfront/chat` composition & API overhaul](./2026-07-08-chat-composition-overhaul.md) — full epic breakdown, from the [handoff brief](./2026-07-08-chat-composition-handoff.md) | Proposed |

--- a/docs/plans/START-HERE.md
+++ b/docs/plans/START-HERE.md
@@ -1,0 +1,87 @@
+# START HERE — implementing the `veryfront/chat` composition overhaul
+
+Kickoff handoff for the engineer/agent picking up the implementation. Read this,
+then the [full plan](./2026-07-08-chat-composition-overhaul.md), then load the
+`composition-patterns` skill (the canonical reference the plan maps to).
+
+## 1. Current state — two open PRs
+- **PR #2798** (`mattboon/veryfront-ui-namespace`) — promotes the 39 UI
+  primitives to a public **`veryfront/ui`** package (the base-layer split).
+  Green; all review rounds addressed; **basically ready — awaiting re-review**
+  to clear `CHANGES_REQUESTED`. This is the base everything stacks on.
+- **PR #2809** (`mattboon/chat-composition-plan`, stacked on #2798) — **this
+  docs folder**: the plan + brief + this handoff.
+
+## 2. Where everything lives
+- **The plan:** [`2026-07-08-chat-composition-overhaul.md`](./2026-07-08-chat-composition-overhaul.md)
+  — 13 epics (E0–E11), each with tasks / quality gates / tests / acceptance
+  criteria; dependency graph; metric ratchets; smell audit; canonical alignment.
+- **Source brief:** [`2026-07-08-chat-composition-handoff.md`](./2026-07-08-chat-composition-handoff.md) (§A–§K).
+- **Canonical reference:** the `composition-patterns` skill (v1.0). Load first.
+- **Extend, don't reinvent:** `scripts/lint/audit-chat-composability.ts` (static
+  contract) + `src/react/components/chat/chat/composability.contract.test.tsx`
+  (runtime contract).
+- **Main smell targets:** `src/react/components/chat/chat/index.tsx` (1,153 LOC,
+  26 `@deprecated`, ~117 props), `message.tsx` (970/92 props), `sidebar.tsx`,
+  `chat-composer.tsx`.
+
+## 3. Locked decisions (do not relitigate)
+- **Q1** No version bump anywhere in this work — release/version is decided
+  separately after merge.
+- **Q2** Zero behaviour-booleans; modes are explicit *variant components*, not
+  flags (`composition-patterns` §1.1/§3.1).
+- **Q3** Persistence: ship server `onFinish` + client `useConversationChat`
+  **together** (E3).
+- **Q4** UI primitives = composable/no-black-box; three-tier stories = **chat
+  components only**.
+- **Q5** Docs-first: component *redesign* (E1/E4/…) waits until the design specs
+  are reviewed. Infra / gates / type-fixes do **not** wait.
+- **Q6** Track progress in these md plan files; no GitHub issues.
+
+## 4. First implementation PR — E0 slice: G1 (children types) + `tsc` gate
+Non-breaking; doesn't touch component design; unblocks everything.
+
+1. **Branch off #2798:** `git checkout -b <name> mattboon/veryfront-ui-namespace`.
+2. **Reproduce §G first** (disciplined — `deno check` passes today because it's a
+   consumer-`tsc` issue). Environment facts: `tsc` is at
+   `storybook/node_modules/.bin/tsc`; `@types/react` is **19.2.17** (React-19
+   types, where `HTMLAttributes` no longer carries `children`). Write a tiny
+   consumer usage (`<AppShell><div/></AppShell>`, `<ChatEmptyState.Root>…`) and
+   run `tsc --noEmit`. Confirm the `children does not exist on AppShellProps /
+   ChatEmptyStateRootProps` errors. **If it does not reproduce, stop and report**
+   — don't invent a fix.
+3. **Fix G1:** explicitly declare `children: React.ReactNode` on every compound
+   props interface that `extends HTMLAttributes` (confirmed: `AppShellProps`,
+   `AppShell.Sidebar/Header`, `ChatEmptyState*`; sweep for the rest).
+4. **Add the gate:** a `tsc --noEmit` task/CI job over the public entry types +
+   a `stories` tsconfig, wired into `verify`, so documented composition stays
+   type-clean.
+5. **Verify:** tsc gate green; `deno task typecheck`, `fmt:check`,
+   `storybook:check`, unit tests all green.
+
+**Then, in order (separate PRs):** rest of E0 (ratchet-lint baselines for
+feature-toggle / passthrough / forwardRef; storybook three-tier harness;
+composability-contract extension; K0 collections doc) → **E0.5 characterization
+tests** (safety net over the god file — MUST precede E1/E3) → E2 (React-19
+`forwardRef` codemod, parallelizable) → E1 (context spine) → E3 (state glue) →
+E4/E5/E6 (depth) → E8/E9/E10 (breaking batch + codemod + migration guide).
+
+## 5. Working agreement
+- **Gates as ratchets:** each anti-pattern gets a lint seeded with today's
+  violations as a baseline that only shrinks.
+- **Ratchet-then-batch breaking:** land additive replacements + deprecate; batch
+  all removals (§B/§E/§H) into one breaking PR with a codemod + migration guide.
+- **The acid test is the bar:** every leaf overridable in place without
+  re-implementing its parent — encode it as concrete contract tests.
+- **Highest-conviction change = E3:** the shipped persistence
+  `useEffect(…sink…)` is a line-for-line match for `composition-patterns` §2.3's
+  "useEffect to sync state up" anti-pattern; the fix (lift into a provider) is
+  prescribed.
+
+## 6. Open flags to confirm with reviewers (carried from #2798)
+- `veryfront/ui/icons` was exposed as a public subpath (surfaced by a story
+  teaching a never-real `veryfront/chat/icons`). Revertible if the team doesn't
+  want the icon set public yet.
+- `veryfront/ui`'s theming scope is still `[data-vf-chat]` (deliberate compat
+  shim, noted in `design-tokens.ts`); neutral `[data-vf-ui]` migration is a
+  tracked follow-up (a candidate for the E8/E9 breaking batch).


### PR DESCRIPTION
## What

Planning-only PR. Adds the execution plan for the `veryfront/chat` composition/API overhaul — the follow-on work to the `veryfront/ui` split in #2798 — plus the source handoff brief it derives from.

**Stacked on #2798** (`mattboon/veryfront-ui-namespace`) since the plan assumes that base-layer split has landed. Diff is docs-only.

### Files
- `docs/plans/2026-07-08-chat-composition-overhaul.md` — the plan.
- `docs/plans/2026-07-08-chat-composition-handoff.md` — the input brief (§A–§K).
- `docs/plans/README.md` — index; marks these as internal (non-published) engineering plans, outside the validated public-doc roots.

## What's in the plan
- **13 epics** (E0–E11) each with tasks, quality gates, tests, and **acceptance criteria**, sequenced by a dependency graph.
- **Strategy calls:** ratchet-then-batch breaking changes (all removals in one breaking batch, not dribbled); Storybook-as-infrastructure; a per-component Definition of Done.
- **8 CI metric ratchets** so "done" is objective and non-regressing (e.g. `chat/index.tsx` 1,153 LOC → <300; feature-toggles 13 → 0; `forwardRef` 29 → 0; untested chat components 36 → 0).
- **Audit of additional smells** found in the shipped tree beyond the handoff (god file fusing `<Chat>` + persistence effect + deprecated flat API; unmemoized context; index-as-key on reorderable lists; public-barrel compat aliases; two class-join helpers) — with corrected non-findings (the direct-DOM/`any`/cast counts were test-file noise; production is clean).
- **Canonical alignment** to `composition-patterns` v1.0 (the reference the handoff cites): each of the 8 rules mapped → epic → the exact code violation → its acceptance criterion. Notably, §2.3's *"useEffect to sync state up"* anti-pattern is a line-for-line match for the shipped persistence bridge, making the state-glue epic the highest-conviction change.

## Locked decisions (from review)
- **No version bump** in any of this work — the release/version call is made after merge.
- Persistence: ship **server `onFinish` + client `useConversationChat` together**.
- Storybook scope: UI primitives must be **composable/no-black-box**; the three-tier + acid-test story contract applies to **chat** components only.
- **Docs-first**: this plan is PR-1; component code doesn't start until the specs here are reviewed.
- Tracking stays in these markdown plan files (no GitHub issues).

## Not in scope
No code changes. This is the design/plan to review before implementation begins.