### PR TITLE
Fix SSR stale module cache recovery

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1028",
+  "version": "0.1.1029",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
@@ -285,8 +285,8 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
       resetState();
 
       const baseCacheDir = getMdxEsmCacheDir();
-      const key1 = `${baseCacheDir}|${hashCodeHex("project-1")}|preview-main`;
-      const key2 = `${baseCacheDir}|${hashCodeHex("project-2")}|preview-main`;
+      const key1 = `${baseCacheDir}|${hashCodeHex("project-1")}|${hashCodeHex("preview-main")}`;
+      const key2 = `${baseCacheDir}|${hashCodeHex("project-2")}|${hashCodeHex("preview-main")}`;
 
       globalTmpDirs.set(key1, "/tmp/proj1");
       globalTmpDirs.set(key2, "/tmp/proj2");

--- a/src/modules/react-loader/ssr-module-loader/loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.test.ts
@@ -20,10 +20,10 @@ import {
   buildMdxEsmModuleRecoveryCacheKey,
   buildMdxEsmPathCacheKey,
 } from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
-import { getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import {
   clearModulePathCache,
+  getMdxEsmSsrCacheDir,
   getModulePathCache,
   verifiedModuleDeps,
   waitForDiskCleanup,
@@ -357,7 +357,7 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
     const projectId = "project-verified-mdx-stale-test";
     const contentSourceId = "preview-main";
 
-    const mdxCacheDir = join(getMdxEsmCacheDir(), hashCodeHex(projectId), contentSourceId);
+    const mdxCacheDir = getMdxEsmSsrCacheDir(projectId, contentSourceId);
     const mdxComponentDir = join(mdxCacheDir, "components");
 
     try {
@@ -441,7 +441,7 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
     const projectId = "project-cold-mdx-stale-test";
     const contentSourceId = "preview-main";
 
-    const mdxCacheDir = join(getMdxEsmCacheDir(), hashCodeHex(projectId), contentSourceId);
+    const mdxCacheDir = getMdxEsmSsrCacheDir(projectId, contentSourceId);
     const mdxComponentDir = join(mdxCacheDir, "components");
 
     try {
@@ -532,7 +532,7 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
     const projectId = "project-branch-mdx-stale-test";
     const contentSourceId = "preview-feature/refactor";
 
-    const mdxCacheDir = join(getMdxEsmCacheDir(), hashCodeHex(projectId), contentSourceId);
+    const mdxCacheDir = getMdxEsmSsrCacheDir(projectId, contentSourceId);
     const mdxComponentDir = join(mdxCacheDir, "components");
 
     try {
@@ -643,7 +643,7 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
       );
 
-      const vfmodDir = join(getMdxEsmCacheDir(), projectId, contentSourceId);
+      const vfmodDir = getMdxEsmSsrCacheDir(projectId, contentSourceId);
       const childPath = join(vfmodDir, "vfmod-child.mjs");
       const cachedTempPath = join(projectDir, `recover-vfmod-${crypto.randomUUID()}.mjs`);
 
@@ -681,7 +681,7 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       assertEquals(globalModuleCache.has(filePathCacheKey), true);
     } finally {
       __injectCachesForTests(null);
-      await remove(join(getMdxEsmCacheDir(), projectId, contentSourceId), { recursive: true })
+      await remove(getMdxEsmSsrCacheDir(projectId, contentSourceId), { recursive: true })
         .catch(() => {});
       await remove(projectDir, { recursive: true });
     }

--- a/src/modules/react-loader/ssr-module-loader/loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.test.ts
@@ -16,9 +16,18 @@ import { injectNodePositions } from "#veryfront/transforms/plugins/babel-node-po
 import type { CacheBackend } from "#veryfront/cache/types.ts";
 import { __injectCachesForTests } from "#veryfront/transforms/esm/transform-cache.ts";
 import { tokenizeAllVeryFrontPaths } from "#veryfront/cache";
-import { buildMdxEsmModuleRecoveryCacheKey } from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
+import {
+  buildMdxEsmModuleRecoveryCacheKey,
+  buildMdxEsmPathCacheKey,
+} from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
 import { getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import {
+  clearModulePathCache,
+  getModulePathCache,
+  verifiedModuleDeps,
+  waitForDiskCleanup,
+} from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
 
 /** Hash source as the loader sees it (after node position injection for .tsx in dev/preview) */
 function hashAsLoader(source: string, filePath: string, projectDir: string): string {
@@ -196,6 +205,410 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
         "Cache entry should be refreshed after invalidating the stale module",
       );
     } finally {
+      await remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("rebuilds a verified stale cache entry when dynamic import finds a missing local dependency", async () => {
+    clearSSRModuleCache();
+
+    const projectDir = await makeTempDir({ prefix: "vf-ssr-loader-verified-stale-" });
+    const componentsDir = join(projectDir, "components");
+    const filePath = join(componentsDir, "VerifiedStaleCache.tsx");
+    const projectId = "project-verified-stale-test";
+    const contentSourceId = "preview-main";
+
+    try {
+      await mkdir(componentsDir, { recursive: true });
+
+      const source = "export default function VerifiedStaleCache() { return null; }";
+      const contentHash = hashAsLoader(source, filePath, projectDir);
+      const configHash = computeConfigHashSync({ dev: true });
+      const reactVersion = "default";
+
+      const filePathCacheKey = buildSSRModuleCacheKey(
+        VERSION,
+        projectId,
+        `${contentSourceId}:${reactVersion}:${configHash}:${filePath}`,
+      );
+      const contentCacheKey = buildSSRModuleCacheKey(
+        VERSION,
+        projectId,
+        `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
+      );
+
+      const staleTempPath = join(projectDir, `verified-stale-${crypto.randomUUID()}.mjs`);
+      const missingDependencyPath = join(
+        projectDir,
+        `missing-framework-core-${crypto.randomUUID()}.mjs`,
+      );
+      await writeTextFile(
+        staleTempPath,
+        [
+          `import { missing } from "file://${missingDependencyPath}";`,
+          `export default function VerifiedStaleCache() {`,
+          `  return missing;`,
+          `}`,
+        ].join("\n"),
+      );
+
+      const staleEntry = { tempPath: staleTempPath, contentHash };
+      globalModuleCache.set(contentCacheKey, staleEntry);
+      globalModuleCache.set(filePathCacheKey, staleEntry);
+      verifiedHttpBundlePaths.set(`${staleTempPath}:${contentHash}`, true);
+
+      await writeTextFile(filePath, source);
+
+      const loader = new SSRModuleLoader({
+        projectDir,
+        projectId,
+        contentSourceId,
+        adapter: denoAdapter,
+        dev: true,
+      });
+
+      const component = await loader.loadModule(filePath, source);
+      assertEquals(component.name, "VerifiedStaleCache");
+
+      const rebuiltEntry = globalModuleCache.get(contentCacheKey);
+      assert(
+        !!rebuiltEntry && rebuiltEntry.tempPath !== staleTempPath,
+        "Expected verified stale cache entry to be replaced with retransformed output",
+      );
+      assertEquals(
+        verifiedHttpBundlePaths.get(`${staleTempPath}:${contentHash}`),
+        undefined,
+        "Expected stale verification marker to be cleared",
+      );
+    } finally {
+      await remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("rebuilds a verified stale cache entry when the cached output file is missing", async () => {
+    clearSSRModuleCache();
+
+    const projectDir = await makeTempDir({ prefix: "vf-ssr-loader-missing-output-" });
+    const componentsDir = join(projectDir, "components");
+    const filePath = join(componentsDir, "MissingCachedOutput.tsx");
+    const projectId = "project-missing-cached-output-test";
+    const contentSourceId = "preview-main";
+
+    try {
+      await mkdir(componentsDir, { recursive: true });
+
+      const source = "export default function MissingCachedOutput() { return null; }";
+      const contentHash = hashAsLoader(source, filePath, projectDir);
+      const configHash = computeConfigHashSync({ dev: true });
+      const reactVersion = "default";
+
+      const filePathCacheKey = buildSSRModuleCacheKey(
+        VERSION,
+        projectId,
+        `${contentSourceId}:${reactVersion}:${configHash}:${filePath}`,
+      );
+      const contentCacheKey = buildSSRModuleCacheKey(
+        VERSION,
+        projectId,
+        `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
+      );
+
+      const staleTempPath = join(projectDir, `missing-cached-output-${crypto.randomUUID()}.mjs`);
+      const staleEntry = { tempPath: staleTempPath, contentHash };
+      globalModuleCache.set(contentCacheKey, staleEntry);
+      globalModuleCache.set(filePathCacheKey, staleEntry);
+      verifiedHttpBundlePaths.set(`${staleTempPath}:${contentHash}`, true);
+
+      await writeTextFile(filePath, source);
+
+      const loader = new SSRModuleLoader({
+        projectDir,
+        projectId,
+        contentSourceId,
+        adapter: denoAdapter,
+        dev: true,
+      });
+
+      const component = await loader.loadModule(filePath, source);
+      assertEquals(component.name, "MissingCachedOutput");
+
+      const rebuiltEntry = globalModuleCache.get(contentCacheKey);
+      assert(
+        !!rebuiltEntry && rebuiltEntry.tempPath !== staleTempPath,
+        "Expected missing verified cache output to be replaced with retransformed output",
+      );
+      assertEquals(
+        verifiedHttpBundlePaths.get(`${staleTempPath}:${contentHash}`),
+        undefined,
+        "Expected stale verification marker to be cleared",
+      );
+    } finally {
+      await remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("clears verified MDX-ESM path cache before retrying stale local dependencies", async () => {
+    clearSSRModuleCache();
+    clearModulePathCache();
+
+    const projectDir = await makeTempDir({ prefix: "vf-ssr-loader-verified-mdx-" });
+    const componentsDir = join(projectDir, "components");
+    const filePath = join(componentsDir, "VerifiedMdxStaleCache.tsx");
+    const projectId = "project-verified-mdx-stale-test";
+    const contentSourceId = "preview-main";
+
+    const mdxCacheDir = join(getMdxEsmCacheDir(), hashCodeHex(projectId), contentSourceId);
+    const mdxComponentDir = join(mdxCacheDir, "components");
+
+    try {
+      await mkdir(componentsDir, { recursive: true });
+      await mkdir(mdxComponentDir, { recursive: true });
+
+      const source = "export default function VerifiedMdxStaleCache() { return null; }";
+      const contentHash = hashAsLoader(source, filePath, projectDir);
+      const configHash = computeConfigHashSync({ dev: true });
+      const reactVersion = "default";
+
+      const filePathCacheKey = buildSSRModuleCacheKey(
+        VERSION,
+        projectId,
+        `${contentSourceId}:${reactVersion}:${configHash}:${filePath}`,
+      );
+      const contentCacheKey = buildSSRModuleCacheKey(
+        VERSION,
+        projectId,
+        `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
+      );
+
+      const staleTempPath = join(mdxComponentDir, `verified-mdx-stale-${crypto.randomUUID()}.js`);
+      const missingDependencyPath = join(
+        mdxComponentDir,
+        `missing-runtime-core-${crypto.randomUUID()}.js`,
+      );
+      await writeTextFile(
+        staleTempPath,
+        [
+          `import { missing } from "file://${missingDependencyPath}";`,
+          `export default function VerifiedMdxStaleCache() {`,
+          `  return missing;`,
+          `}`,
+        ].join("\n"),
+      );
+
+      const mdxPathCacheKey = buildMdxEsmPathCacheKey(
+        "_vf_modules/components/VerifiedMdxStaleCache.js",
+      );
+      const mdxPathCache = await getModulePathCache(mdxCacheDir);
+      mdxPathCache.set(mdxPathCacheKey, staleTempPath);
+      verifiedModuleDeps.set(`${staleTempPath}:${mdxPathCacheKey}`, true);
+
+      const staleEntry = { tempPath: staleTempPath, contentHash };
+      globalModuleCache.set(contentCacheKey, staleEntry);
+      globalModuleCache.set(filePathCacheKey, staleEntry);
+      verifiedHttpBundlePaths.set(`${staleTempPath}:${contentHash}`, true);
+
+      await writeTextFile(filePath, source);
+
+      const loader = new SSRModuleLoader({
+        projectDir,
+        projectId,
+        contentSourceId,
+        adapter: denoAdapter,
+        dev: true,
+      });
+
+      const component = await loader.loadModule(filePath, source);
+      assertEquals(component.name, "VerifiedMdxStaleCache");
+      assert(
+        mdxPathCache.get(mdxPathCacheKey) !== staleTempPath,
+        "Expected stale MDX-ESM path-cache entry to be cleared before retry",
+      );
+    } finally {
+      await waitForDiskCleanup();
+      clearModulePathCache();
+      await remove(mdxCacheDir, { recursive: true }).catch(() => {});
+      await remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("persists MDX-ESM path cache invalidation when stale SSR cache is hit cold", async () => {
+    clearSSRModuleCache();
+    clearModulePathCache();
+
+    const projectDir = await makeTempDir({ prefix: "vf-ssr-loader-cold-mdx-" });
+    const componentsDir = join(projectDir, "components");
+    const filePath = join(componentsDir, "ColdMdxStaleCache.tsx");
+    const projectId = "project-cold-mdx-stale-test";
+    const contentSourceId = "preview-main";
+
+    const mdxCacheDir = join(getMdxEsmCacheDir(), hashCodeHex(projectId), contentSourceId);
+    const mdxComponentDir = join(mdxCacheDir, "components");
+
+    try {
+      await mkdir(componentsDir, { recursive: true });
+      await mkdir(mdxComponentDir, { recursive: true });
+
+      const source = "export default function ColdMdxStaleCache() { return null; }";
+      const contentHash = hashAsLoader(source, filePath, projectDir);
+      const configHash = computeConfigHashSync({ dev: true });
+      const reactVersion = "default";
+
+      const filePathCacheKey = buildSSRModuleCacheKey(
+        VERSION,
+        projectId,
+        `${contentSourceId}:${reactVersion}:${configHash}:${filePath}`,
+      );
+      const contentCacheKey = buildSSRModuleCacheKey(
+        VERSION,
+        projectId,
+        `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
+      );
+
+      const staleTempPath = join(mdxComponentDir, `cold-mdx-stale-${crypto.randomUUID()}.js`);
+      const missingDependencyPath = join(
+        mdxComponentDir,
+        `missing-cold-runtime-${crypto.randomUUID()}.js`,
+      );
+      await writeTextFile(
+        staleTempPath,
+        [
+          `import { missing } from "file://${missingDependencyPath}";`,
+          `export default function ColdMdxStaleCache() {`,
+          `  return missing;`,
+          `}`,
+        ].join("\n"),
+      );
+
+      const mdxPathCacheKey = buildMdxEsmPathCacheKey(
+        "_vf_modules/components/ColdMdxStaleCache.js",
+      );
+      await writeTextFile(
+        join(mdxCacheDir, "_index.json"),
+        JSON.stringify({ [mdxPathCacheKey]: staleTempPath }),
+      );
+      clearModulePathCache();
+
+      const staleEntry = { tempPath: staleTempPath, contentHash };
+      globalModuleCache.set(contentCacheKey, staleEntry);
+      globalModuleCache.set(filePathCacheKey, staleEntry);
+      verifiedHttpBundlePaths.set(`${staleTempPath}:${contentHash}`, true);
+
+      await writeTextFile(filePath, source);
+
+      const loader = new SSRModuleLoader({
+        projectDir,
+        projectId,
+        contentSourceId,
+        adapter: denoAdapter,
+        dev: true,
+      });
+
+      const component = await loader.loadModule(filePath, source);
+      assertEquals(component.name, "ColdMdxStaleCache");
+
+      await waitForDiskCleanup();
+      clearModulePathCache();
+      const reloadedMdxPathCache = await getModulePathCache(mdxCacheDir);
+      assertEquals(
+        reloadedMdxPathCache.get(mdxPathCacheKey),
+        undefined,
+        "Expected stale MDX-ESM path-cache entry to stay cleared after reload",
+      );
+    } finally {
+      await waitForDiskCleanup();
+      clearModulePathCache();
+      await remove(mdxCacheDir, { recursive: true }).catch(() => {});
+      await remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("persists stale MDX-ESM invalidation with slash-containing content source ids", async () => {
+    clearSSRModuleCache();
+    clearModulePathCache();
+
+    const projectDir = await makeTempDir({ prefix: "vf-ssr-loader-branch-mdx-" });
+    const componentsDir = join(projectDir, "components");
+    const filePath = join(componentsDir, "BranchMdxStaleCache.tsx");
+    const projectId = "project-branch-mdx-stale-test";
+    const contentSourceId = "preview-feature/refactor";
+
+    const mdxCacheDir = join(getMdxEsmCacheDir(), hashCodeHex(projectId), contentSourceId);
+    const mdxComponentDir = join(mdxCacheDir, "components");
+
+    try {
+      await mkdir(componentsDir, { recursive: true });
+      await mkdir(mdxComponentDir, { recursive: true });
+
+      const source = "export default function BranchMdxStaleCache() { return null; }";
+      const contentHash = hashAsLoader(source, filePath, projectDir);
+      const configHash = computeConfigHashSync({ dev: true });
+      const reactVersion = "default";
+
+      const filePathCacheKey = buildSSRModuleCacheKey(
+        VERSION,
+        projectId,
+        `${contentSourceId}:${reactVersion}:${configHash}:${filePath}`,
+      );
+      const contentCacheKey = buildSSRModuleCacheKey(
+        VERSION,
+        projectId,
+        `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
+      );
+
+      const staleTempPath = join(mdxComponentDir, `branch-mdx-stale-${crypto.randomUUID()}.js`);
+      const missingDependencyPath = join(
+        mdxComponentDir,
+        `missing-branch-runtime-${crypto.randomUUID()}.js`,
+      );
+      await writeTextFile(
+        staleTempPath,
+        [
+          `import { missing } from "file://${missingDependencyPath}";`,
+          `export default function BranchMdxStaleCache() {`,
+          `  return missing;`,
+          `}`,
+        ].join("\n"),
+      );
+
+      const mdxPathCacheKey = buildMdxEsmPathCacheKey(
+        "_vf_modules/components/BranchMdxStaleCache.js",
+      );
+      await writeTextFile(
+        join(mdxCacheDir, "_index.json"),
+        JSON.stringify({ [mdxPathCacheKey]: staleTempPath }),
+      );
+      clearModulePathCache();
+
+      const staleEntry = { tempPath: staleTempPath, contentHash };
+      globalModuleCache.set(contentCacheKey, staleEntry);
+      globalModuleCache.set(filePathCacheKey, staleEntry);
+      verifiedHttpBundlePaths.set(`${staleTempPath}:${contentHash}`, true);
+
+      await writeTextFile(filePath, source);
+
+      const loader = new SSRModuleLoader({
+        projectDir,
+        projectId,
+        contentSourceId,
+        adapter: denoAdapter,
+        dev: true,
+      });
+
+      const component = await loader.loadModule(filePath, source);
+      assertEquals(component.name, "BranchMdxStaleCache");
+
+      await waitForDiskCleanup();
+      clearModulePathCache();
+      const reloadedMdxPathCache = await getModulePathCache(mdxCacheDir);
+      assertEquals(
+        reloadedMdxPathCache.get(mdxPathCacheKey),
+        undefined,
+        "Expected slash-containing content source stale path-cache entry to stay cleared",
+      );
+    } finally {
+      await waitForDiskCleanup();
+      clearModulePathCache();
+      await remove(mdxCacheDir, { recursive: true }).catch(() => {});
       await remove(projectDir, { recursive: true });
     }
   });

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -47,6 +47,7 @@ import type { ModuleCacheEntry, SSRModuleLoaderOptions } from "./types.ts";
 import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
 import {
   getMdxEsmSsrCacheDir,
+  getMdxEsmSsrCacheDirs,
   invalidateMdxEsmModuleForCachedPath,
   lookupMdxEsmCache,
 } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
@@ -283,8 +284,8 @@ export class SSRModuleLoader {
     cacheEntry: ModuleCacheEntry,
   ): Promise<void> {
     const { contentSourceId, projectId } = this.options;
-    const mdxCacheDir = projectId && contentSourceId
-      ? getMdxEsmSsrCacheDir(projectId, contentSourceId)
+    const mdxCacheDirs = projectId && contentSourceId
+      ? getMdxEsmSsrCacheDirs(projectId, contentSourceId)
       : undefined;
 
     await invalidateMdxEsmModuleForCachedPath(
@@ -292,7 +293,7 @@ export class SSRModuleLoader {
       filePath,
       this.options.projectDir,
       this.options.reactVersion,
-      mdxCacheDir,
+      mdxCacheDirs,
     );
   }
 

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -6,7 +6,6 @@
  * @module module-system/react-loader/ssr-module-loader/loader
  */
 
-import { join } from "#veryfront/compat/path/index.ts";
 import type * as React from "react";
 import { transformToESM } from "#veryfront/transforms/esm/index.ts";
 import type { TransformOptions } from "#veryfront/transforms/esm/types.ts";
@@ -17,7 +16,6 @@ import {
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { verifyCacheFileExists, writeCacheFile } from "#veryfront/utils/cache-file-ops.ts";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
-import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import { rendererLogger } from "#veryfront/utils";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { SpanNames } from "#veryfront/observability/tracing/span-names.ts";
@@ -46,8 +44,12 @@ import {
   tryAcquireTransformSlot,
 } from "./cache/index.ts";
 import type { ModuleCacheEntry, SSRModuleLoaderOptions } from "./types.ts";
-import { getHttpBundleCacheDir, getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
-import { lookupMdxEsmCache } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
+import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
+import {
+  getMdxEsmSsrCacheDir,
+  invalidateMdxEsmModuleForCachedPath,
+  lookupMdxEsmCache,
+} from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
 import { ensureHttpBundlesExist } from "#veryfront/transforms/esm/http-cache.ts";
 import { extractHttpBundlePaths, verifiedHttpBundlePaths } from "./http-bundle-helpers.ts";
 import { rewriteCrossProjectImport, rewriteLocalImports } from "./import-rewriter.ts";
@@ -66,6 +68,7 @@ import {
 } from "#veryfront/cache/dependency-graph.ts";
 
 const logger = rendererLogger.component("ssr-module-loader");
+const CACHE_FILE_MISSING_PREFIX = "Cache file missing:";
 
 /**
  * SSR Module Loader with Redis Support.
@@ -155,11 +158,12 @@ export class SSRModuleLoader {
         tempPath: cacheEntry.tempPath,
         contentHash: cacheEntry.contentHash,
       });
+      await this.invalidateMdxEsmCacheEntry(filePath, cacheEntry);
       this.cache.invalidateFilePathCacheEntry(filePath, cacheEntry);
       throw toError(
         createError({
           type: "build",
-          message: `Cache file missing: ${cacheEntry.tempPath}`,
+          message: `${CACHE_FILE_MISSING_PREFIX} ${cacheEntry.tempPath}`,
           context: { file: filePath, phase: "transform" },
         }),
       );
@@ -251,11 +255,63 @@ export class SSRModuleLoader {
             error: classifiedError.message.slice(0, 200),
           },
         );
+        await this.invalidateMdxEsmCacheEntry(filePath, cacheEntry);
         this.cache.invalidateFilePathCacheEntry(filePath, cacheEntry);
       }
 
       throw importError;
     }
+  }
+
+  private getTransformedCacheEntry(filePath: string): ModuleCacheEntry {
+    const cacheKey = this.cache.getCacheKey(filePath);
+    const cacheEntry = globalModuleCache.get(cacheKey);
+    if (!cacheEntry) {
+      throw toError(
+        createError({
+          type: "build",
+          message: `Failed to transform module: ${filePath}`,
+          context: { file: filePath, phase: "transform" },
+        }),
+      );
+    }
+    return cacheEntry;
+  }
+
+  private async invalidateMdxEsmCacheEntry(
+    filePath: string,
+    cacheEntry: ModuleCacheEntry,
+  ): Promise<void> {
+    const { contentSourceId, projectId } = this.options;
+    const mdxCacheDir = projectId && contentSourceId
+      ? getMdxEsmSsrCacheDir(projectId, contentSourceId)
+      : undefined;
+
+    await invalidateMdxEsmModuleForCachedPath(
+      cacheEntry.tempPath,
+      filePath,
+      this.options.projectDir,
+      this.options.reactVersion,
+      mdxCacheDir,
+    );
+  }
+
+  private throwMissingDependencies(filePath: string): void {
+    if (this.depValidator.missingDependencies.length > 0) {
+      this.depValidator.throwMissingDependencies(filePath);
+    }
+  }
+
+  private getRetryableStaleCacheErrorMessage(error: unknown): string | null {
+    const classifiedError = classifyImportError(error);
+    if (classifiedError.type === "module-not-found") {
+      return classifiedError.message;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes(CACHE_FILE_MISSING_PREFIX)) return message;
+
+    return null;
   }
 
   loadRawModule(
@@ -275,27 +331,35 @@ export class SSRModuleLoader {
         try {
           const dependencyHashCache = createDependencyHashCache();
           await this.transformWithDependencies(filePath, source, 0, dependencyHashCache);
+          this.throwMissingDependencies(filePath);
 
-          if (this.depValidator.missingDependencies.length > 0) {
-            this.depValidator.throwMissingDependencies(filePath);
+          const cacheEntry = this.getTransformedCacheEntry(filePath);
+
+          try {
+            const mod = await this.importModuleFromCacheEntry(filePath, fileName, cacheEntry);
+
+            this.circuitBreaker.recordSuccess(circuitKey);
+            return mod;
+          } catch (importError) {
+            const retryErrorMessage = this.getRetryableStaleCacheErrorMessage(importError);
+            if (!retryErrorMessage) throw importError;
+
+            logger.warn("Retrying SSR module import after stale cache invalidation", {
+              file: filePath.slice(-40),
+              tempPath: cacheEntry.tempPath,
+              error: retryErrorMessage.slice(0, 200),
+            });
+
+            const retryDependencyHashCache = createDependencyHashCache();
+            await this.transformWithDependencies(filePath, source, 0, retryDependencyHashCache);
+            this.throwMissingDependencies(filePath);
+
+            const retryCacheEntry = this.getTransformedCacheEntry(filePath);
+            const mod = await this.importModuleFromCacheEntry(filePath, fileName, retryCacheEntry);
+
+            this.circuitBreaker.recordSuccess(circuitKey);
+            return mod;
           }
-
-          const cacheKey = this.cache.getCacheKey(filePath);
-          const cacheEntry = globalModuleCache.get(cacheKey);
-          if (!cacheEntry) {
-            throw toError(
-              createError({
-                type: "build",
-                message: `Failed to transform module: ${filePath}`,
-                context: { file: filePath, phase: "transform" },
-              }),
-            );
-          }
-
-          const mod = await this.importModuleFromCacheEntry(filePath, fileName, cacheEntry);
-
-          this.circuitBreaker.recordSuccess(circuitKey);
-          return mod;
         } catch (error) {
           this.circuitBreaker.recordFailure(circuitKey);
           throw error;
@@ -440,10 +504,10 @@ export class SSRModuleLoader {
     }
 
     if (this.options.projectId && this.options.contentSourceId) {
-      const baseCacheDir = getMdxEsmCacheDir();
-      const projectKey = hashCodeHex(this.options.projectId);
-      const sourceKey = this.options.contentSourceId;
-      const mdxCacheDir = join(baseCacheDir, projectKey, sourceKey);
+      const mdxCacheDir = getMdxEsmSsrCacheDir(
+        this.options.projectId,
+        this.options.contentSourceId,
+      );
 
       const mdxCacheResult = await lookupMdxEsmCache(
         filePath,

--- a/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.test.ts
@@ -15,7 +15,7 @@ import { tokenizeAllVeryFrontPaths } from "#veryfront/cache";
 import { __injectCachesForTests } from "#veryfront/transforms/esm/transform-cache.ts";
 import { buildMdxEsmModuleRecoveryCacheKey } from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
 import { SSRCacheManager } from "./ssr-cache-manager.ts";
-import { getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
+import { getMdxEsmSsrCacheDir } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
 
 class FakeDistributedCache implements CacheBackend {
   readonly type = "redis" as const;
@@ -42,7 +42,7 @@ describe("SSRCacheManager", { sanitizeResources: false, sanitizeOps: false }, ()
     const distributedCache = new FakeDistributedCache();
     const projectId = `project-${crypto.randomUUID()}`;
     const contentSourceId = `preview-${crypto.randomUUID()}`;
-    const vfmodDir = join(getMdxEsmCacheDir(), projectId, contentSourceId);
+    const vfmodDir = getMdxEsmSsrCacheDir(projectId, contentSourceId);
     const childPath = join(vfmodDir, "vfmod-child.mjs");
     const stablePath = join(projectDir, "stable.mjs");
 
@@ -130,7 +130,7 @@ describe("SSRCacheManager", { sanitizeResources: false, sanitizeOps: false }, ()
     const projectDir = await makeTempDir({ prefix: "vf-ssr-cache-manager-" });
     const projectId = `project-${crypto.randomUUID()}`;
     const contentSourceId = `preview-${crypto.randomUUID()}`;
-    const vfmodDir = join(getMdxEsmCacheDir(), projectId, contentSourceId);
+    const vfmodDir = getMdxEsmSsrCacheDir(projectId, contentSourceId);
     const childPath = join(vfmodDir, "vfmod-child.mjs");
 
     try {

--- a/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.ts
@@ -185,6 +185,7 @@ export class SSRCacheManager {
   invalidateFilePathCacheEntry(filePath: string, cacheEntry?: ModuleCacheEntry): void {
     globalModuleCache.delete(this.getCacheKey(filePath));
     if (cacheEntry) {
+      this.invalidateMatchingCacheEntries(cacheEntry);
       verifiedHttpBundlePaths.delete(`${cacheEntry.tempPath}:${cacheEntry.contentHash}`);
     }
   }
@@ -198,6 +199,22 @@ export class SSRCacheManager {
     globalModuleCache.delete(filePathCacheKey);
     if (cacheEntry) {
       verifiedHttpBundlePaths.delete(`${cacheEntry.tempPath}:${cacheEntry.contentHash}`);
+    }
+  }
+
+  private invalidateMatchingCacheEntries(cacheEntry: ModuleCacheEntry): void {
+    const keysToDelete: string[] = [];
+    for (const [key, entry] of globalModuleCache.entries()) {
+      if (
+        entry.tempPath === cacheEntry.tempPath &&
+        entry.contentHash === cacheEntry.contentHash
+      ) {
+        keysToDelete.push(key);
+      }
+    }
+
+    for (const key of keysToDelete) {
+      globalModuleCache.delete(key);
     }
   }
 

--- a/src/modules/react-loader/ssr-module-loader/tmp-paths.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/tmp-paths.test.ts
@@ -7,18 +7,28 @@ import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 describe("modules/react-loader/ssr-module-loader/tmp-paths", () => {
   it("builds a stable tmp dir cache key with hashed project id", () => {
     const key = getTmpDirCacheKey("/cache/mdx", "my/project", "release-1");
-    assertEquals(key, `/cache/mdx|${hashCodeHex("my/project")}|release-1`);
+    assertEquals(key, `/cache/mdx|${hashCodeHex("my/project")}|${hashCodeHex("release-1")}`);
   });
 
   it("builds tmp dir path with hashed project id", () => {
     const path = buildTmpDirPath("/cache/mdx", "my/project", "branch-main");
-    assertEquals(path, `/cache/mdx/${hashCodeHex("my/project")}/branch-main`);
+    assertEquals(path, `/cache/mdx/${hashCodeHex("my/project")}/${hashCodeHex("branch-main")}`);
+  });
+
+  it("does not nest slash-containing content source ids under their prefixes", () => {
+    const parent = buildTmpDirPath("/cache/mdx", "my/project", "preview-feature");
+    const child = buildTmpDirPath("/cache/mdx", "my/project", "preview-feature/refactor");
+
+    assert(
+      !child.startsWith(`${parent}/`),
+      `child source cache dir must not be nested under parent source: ${child}`,
+    );
   });
 
   it("builds hashed temp module path for files under project dir", () => {
     const projectHash = hashCodeHex("my/project");
     const tempPath = buildTempModulePath(
-      `/cache/mdx/${projectHash}/release-1`,
+      `/cache/mdx/${projectHash}/${hashCodeHex("release-1")}`,
       "/repo/project/src/page.tsx",
       "/repo/project",
       "0.1.7-rc.49",
@@ -27,20 +37,23 @@ describe("modules/react-loader/ssr-module-loader/tmp-paths", () => {
 
     assertEquals(
       tempPath,
-      `/cache/mdx/${projectHash}/release-1/src/page.v0-1-7-rc-49.deadbeef.js`,
+      `/cache/mdx/${projectHash}/${hashCodeHex("release-1")}/src/page.v0-1-7-rc-49.deadbeef.js`,
     );
   });
 
   it("keeps absolute path structure when file is outside project dir", () => {
     const projectHash = hashCodeHex("my/project");
     const tempPath = buildTempModulePath(
-      `/cache/mdx/${projectHash}/release-1`,
+      `/cache/mdx/${projectHash}/${hashCodeHex("release-1")}`,
       "/tmp/external.tsx",
       "/repo/project",
       "0.1.7-rc.49",
     );
 
-    assertEquals(tempPath, `/cache/mdx/${projectHash}/release-1/tmp/external.v0-1-7-rc-49.js`);
+    assertEquals(
+      tempPath,
+      `/cache/mdx/${projectHash}/${hashCodeHex("release-1")}/tmp/external.v0-1-7-rc-49.js`,
+    );
   });
 
   it("should not produce URL-encoded characters in cache paths", () => {

--- a/src/modules/react-loader/ssr-module-loader/tmp-paths.ts
+++ b/src/modules/react-loader/ssr-module-loader/tmp-paths.ts
@@ -11,7 +11,8 @@ export function getTmpDirCacheKey(
   contentSourceId: string,
 ): string {
   const projectKey = hashCodeHex(projectId);
-  return `${baseCacheDir}|${projectKey}|${contentSourceId}`;
+  const sourceKey = hashCodeHex(contentSourceId);
+  return `${baseCacheDir}|${projectKey}|${sourceKey}`;
 }
 
 export function buildTmpDirPath(
@@ -20,7 +21,8 @@ export function buildTmpDirPath(
   contentSourceId: string,
 ): string {
   const projectKey = hashCodeHex(projectId);
-  return join(baseCacheDir, projectKey, contentSourceId);
+  const sourceKey = hashCodeHex(contentSourceId);
+  return join(baseCacheDir, projectKey, sourceKey);
 }
 
 export function buildTempModulePath(

--- a/src/modules/react-loader/ssr-module-loader/vf-module-resolver.ts
+++ b/src/modules/react-loader/ssr-module-loader/vf-module-resolver.ts
@@ -4,12 +4,10 @@
  * Extracts and resolves /_vf_modules/* imports into file:// cache paths.
  */
 
-import { join } from "#veryfront/compat/path/index.ts";
-import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { rendererLogger } from "#veryfront/utils";
-import { getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { parseImports, replaceSpecifiers } from "#veryfront/transforms/esm/lexer.ts";
+import { getMdxEsmSsrCacheDir } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
 import {
   createModuleFetcherContext,
   fetchAndCacheModule,
@@ -73,9 +71,7 @@ export async function resolveVfModuleImports(
     paths: imports.map((i) => i.path).slice(0, 5),
   });
 
-  const baseCacheDir = getMdxEsmCacheDir();
-  const projectKey = hashCodeHex(options.projectId);
-  const esmCacheDir = join(baseCacheDir, projectKey, options.contentSourceId);
+  const esmCacheDir = getMdxEsmSsrCacheDir(options.projectId, options.contentSourceId);
 
   const fetcherContext = createModuleFetcherContext(
     esmCacheDir,

--- a/src/transforms/mdx/esm-module-loader/cache/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.test.ts
@@ -6,6 +6,7 @@ import {
   clearMdxEsmCacheNamespace,
   clearModulePathCache,
   getLocalFs,
+  getMdxEsmSsrCacheDir,
   getModulePathCache,
   invalidateMdxEsmModule,
   invalidateModulePaths,
@@ -29,30 +30,42 @@ describe("MDX module path cache", () => {
     const cacheBase = await makeTempDir({ prefix: "vf-mdx-namespace-clear-" });
     const projectId = "project/with spaces";
     const contentSourceId = "preview-main";
-    const cacheDir = join(
-      cacheBase,
-      "veryfront-mdx-esm",
-      encodeURIComponent(projectId),
-      encodeURIComponent(contentSourceId),
-    );
     const cacheKey = buildMdxEsmPathCacheKey("_vf_modules/pages/index.js", "19.1.1");
-    const cachedPath = join(cacheDir, "stale.mjs");
 
     try {
       await runWithCacheDir(cacheBase, async () => {
+        const cacheDir = join(
+          cacheBase,
+          "veryfront-mdx-esm",
+          encodeURIComponent(projectId),
+          encodeURIComponent(contentSourceId),
+        );
+        const ssrCacheDir = getMdxEsmSsrCacheDir(projectId, contentSourceId);
+        const cachedPath = join(cacheDir, "stale.mjs");
+        const ssrCachedPath = join(ssrCacheDir, "stale-ssr.mjs");
+
         await getLocalFs().mkdir(cacheDir, { recursive: true });
+        await getLocalFs().mkdir(ssrCacheDir, { recursive: true });
         await writeTextFile(cachedPath, "export default function Stale() {}");
+        await writeTextFile(ssrCachedPath, "export default function StaleSSR() {}");
 
         const cache = await getModulePathCache(cacheDir);
         cache.set(cacheKey, cachedPath);
+        const ssrCache = await getModulePathCache(ssrCacheDir);
+        ssrCache.set(cacheKey, ssrCachedPath);
         verifiedModuleDeps.set(`${cachedPath}:${cacheKey}`, true);
+        verifiedModuleDeps.set(`${ssrCachedPath}:${cacheKey}`, true);
 
         await clearMdxEsmCacheNamespace(projectId, contentSourceId);
 
         assertEquals(await exists(cachedPath), false);
+        assertEquals(await exists(ssrCachedPath), false);
         assertEquals((await getModulePathCache(cacheDir)).get(cacheKey), undefined);
+        assertEquals((await getModulePathCache(ssrCacheDir)).get(cacheKey), undefined);
         assertEquals(verifiedModuleDeps.get(`${cachedPath}:${cacheKey}`), undefined);
+        assertEquals(verifiedModuleDeps.get(`${ssrCachedPath}:${cacheKey}`), undefined);
         assertEquals(await exists(cacheDir), true);
+        assertEquals(await exists(ssrCacheDir), true);
       });
     } finally {
       await remove(cacheBase, { recursive: true });

--- a/src/transforms/mdx/esm-module-loader/cache/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.test.ts
@@ -73,6 +73,49 @@ describe("MDX module path cache", () => {
     }
   });
 
+  it("does not delete slash-containing sibling SSR namespaces when clearing a prefix source", async () => {
+    clearModulePathCache();
+
+    const cacheBase = await makeTempDir({ prefix: "vf-mdx-namespace-slash-isolation-" });
+    const projectId = "project-slash-source";
+    const parentSourceId = "preview-feature";
+    const childSourceId = "preview-feature/refactor";
+    const cacheKey = buildMdxEsmPathCacheKey("_vf_modules/pages/index.js", "19.1.1");
+
+    try {
+      await runWithCacheDir(cacheBase, async () => {
+        const parentCacheDir = getMdxEsmSsrCacheDir(projectId, parentSourceId);
+        const childCacheDir = getMdxEsmSsrCacheDir(projectId, childSourceId);
+        const parentCachedPath = join(parentCacheDir, "parent.mjs");
+        const childCachedPath = join(childCacheDir, "child.mjs");
+
+        await getLocalFs().mkdir(parentCacheDir, { recursive: true });
+        await getLocalFs().mkdir(childCacheDir, { recursive: true });
+        await writeTextFile(parentCachedPath, "export default 'parent';");
+        await writeTextFile(childCachedPath, "export default 'child';");
+
+        const parentCache = await getModulePathCache(parentCacheDir);
+        parentCache.set(cacheKey, parentCachedPath);
+        const childCache = await getModulePathCache(childCacheDir);
+        childCache.set(cacheKey, childCachedPath);
+        verifiedModuleDeps.set(`${parentCachedPath}:${cacheKey}`, true);
+        verifiedModuleDeps.set(`${childCachedPath}:${cacheKey}`, true);
+
+        await clearMdxEsmCacheNamespace(projectId, parentSourceId);
+
+        assertEquals(await exists(parentCachedPath), false);
+        assertEquals(await exists(childCachedPath), true);
+        assertEquals((await getModulePathCache(parentCacheDir)).get(cacheKey), undefined);
+        assertEquals((await getModulePathCache(childCacheDir)).get(cacheKey), childCachedPath);
+        assertEquals(verifiedModuleDeps.get(`${parentCachedPath}:${cacheKey}`), undefined);
+        assertEquals(verifiedModuleDeps.get(`${childCachedPath}:${cacheKey}`), true);
+      });
+    } finally {
+      await remove(cacheBase, { recursive: true });
+      clearModulePathCache();
+    }
+  });
+
   it("isolates per cache dir", async () => {
     clearModulePathCache();
 

--- a/src/transforms/mdx/esm-module-loader/cache/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.test.ts
@@ -7,8 +7,10 @@ import {
   clearModulePathCache,
   getLocalFs,
   getMdxEsmSsrCacheDir,
+  getMdxEsmSsrCacheDirs,
   getModulePathCache,
   invalidateMdxEsmModule,
+  invalidateMdxEsmModuleForCachedPath,
   invalidateModulePaths,
   lookupMdxEsmCache,
   saveModulePathCache,
@@ -22,6 +24,7 @@ import { cacheModule } from "../module-fetcher/module-cache.ts";
 import { rendererLogger as log } from "#veryfront/utils";
 import { buildMdxEsmModuleFileName, buildMdxEsmPathCacheKey } from "../cache-format.ts";
 import { getCacheStats } from "#veryfront/utils/memory/index.ts";
+import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 
 describe("MDX module path cache", () => {
   it("clears a project/content-source namespace from disk and memory", async () => {
@@ -109,6 +112,61 @@ describe("MDX module path cache", () => {
         assertEquals((await getModulePathCache(childCacheDir)).get(cacheKey), childCachedPath);
         assertEquals(verifiedModuleDeps.get(`${parentCachedPath}:${cacheKey}`), undefined);
         assertEquals(verifiedModuleDeps.get(`${childCachedPath}:${cacheKey}`), true);
+      });
+    } finally {
+      await remove(cacheBase, { recursive: true });
+      clearModulePathCache();
+    }
+  });
+
+  it("clears legacy raw SSR namespaces while preserving current hashed siblings", async () => {
+    clearModulePathCache();
+
+    const cacheBase = await makeTempDir({ prefix: "vf-mdx-legacy-raw-namespace-clear-" });
+    const projectId = "project-legacy-raw-source";
+    const parentSourceId = "preview-feature";
+    const childSourceId = "preview-feature/refactor";
+    const cacheKey = buildMdxEsmPathCacheKey("_vf_modules/pages/index.js", "19.1.1");
+
+    try {
+      await runWithCacheDir(cacheBase, async () => {
+        const mdxCacheDir = join(cacheBase, "veryfront-mdx-esm");
+        const projectKey = hashCodeHex(projectId);
+        const legacyParentDir = join(mdxCacheDir, projectKey, parentSourceId);
+        const legacyChildDir = join(mdxCacheDir, projectKey, childSourceId);
+        const currentChildDir = getMdxEsmSsrCacheDir(projectId, childSourceId);
+        const legacyParentPath = join(legacyParentDir, "parent.mjs");
+        const legacyChildPath = join(legacyChildDir, "child-legacy.mjs");
+        const currentChildPath = join(currentChildDir, "child-current.mjs");
+
+        await getLocalFs().mkdir(legacyParentDir, { recursive: true });
+        await getLocalFs().mkdir(legacyChildDir, { recursive: true });
+        await getLocalFs().mkdir(currentChildDir, { recursive: true });
+        await writeTextFile(legacyParentPath, "export default 'legacy-parent';");
+        await writeTextFile(legacyChildPath, "export default 'legacy-child';");
+        await writeTextFile(currentChildPath, "export default 'current-child';");
+
+        const legacyParentCache = await getModulePathCache(legacyParentDir);
+        legacyParentCache.set(cacheKey, legacyParentPath);
+        const legacyChildCache = await getModulePathCache(legacyChildDir);
+        legacyChildCache.set(cacheKey, legacyChildPath);
+        const currentChildCache = await getModulePathCache(currentChildDir);
+        currentChildCache.set(cacheKey, currentChildPath);
+        verifiedModuleDeps.set(`${legacyParentPath}:${cacheKey}`, true);
+        verifiedModuleDeps.set(`${legacyChildPath}:${cacheKey}`, true);
+        verifiedModuleDeps.set(`${currentChildPath}:${cacheKey}`, true);
+
+        await clearMdxEsmCacheNamespace(projectId, parentSourceId);
+
+        assertEquals(await exists(legacyParentPath), false);
+        assertEquals(await exists(legacyChildPath), false);
+        assertEquals(await exists(currentChildPath), true);
+        assertEquals((await getModulePathCache(legacyParentDir)).get(cacheKey), undefined);
+        assertEquals((await getModulePathCache(legacyChildDir)).get(cacheKey), undefined);
+        assertEquals((await getModulePathCache(currentChildDir)).get(cacheKey), currentChildPath);
+        assertEquals(verifiedModuleDeps.get(`${legacyParentPath}:${cacheKey}`), undefined);
+        assertEquals(verifiedModuleDeps.get(`${legacyChildPath}:${cacheKey}`), undefined);
+        assertEquals(verifiedModuleDeps.get(`${currentChildPath}:${cacheKey}`), true);
       });
     } finally {
       await remove(cacheBase, { recursive: true });
@@ -645,6 +703,60 @@ describe("invalidateMdxEsmModule (#2077 self-heal)", () => {
     } finally {
       await Promise.all([
         remove(cacheDir, { recursive: true }).catch(() => {}),
+        remove(projectDir, { recursive: true }).catch(() => {}),
+      ]);
+      clearModulePathCache();
+    }
+  });
+
+  it("self-heals legacy raw slash-containing cache dirs", async () => {
+    clearModulePathCache();
+
+    const cacheBase = await makeTempDir({ prefix: "vf-mdx-legacy-selfheal-" });
+    const projectDir = await makeTempDir({ prefix: "vf-mdx-legacy-selfheal-project-" });
+    const filePath = join(projectDir, "app/page.tsx");
+    const projectId = "project-legacy-selfheal";
+    const contentSourceId = "preview-feature/refactor";
+    const key = buildMdxEsmPathCacheKey("_vf_modules/app/page.js", "19.1.1");
+
+    try {
+      await runWithCacheDir(cacheBase, async () => {
+        const legacyRawCacheDir = join(
+          cacheBase,
+          "veryfront-mdx-esm",
+          hashCodeHex(projectId),
+          contentSourceId,
+        );
+        const cachedPath = join(legacyRawCacheDir, buildMdxEsmModuleFileName("legacyraw"));
+
+        await getLocalFs().mkdir(legacyRawCacheDir, { recursive: true });
+        await writeTextFile(cachedPath, `export default "legacy";`);
+        await writeTextFile(
+          join(legacyRawCacheDir, "_index.json"),
+          JSON.stringify({ [key]: cachedPath }),
+        );
+        const cache = await getModulePathCache(legacyRawCacheDir);
+        verifiedModuleDeps.set(`${cachedPath}:${key}`, true);
+
+        const invalidated = await invalidateMdxEsmModuleForCachedPath(
+          cachedPath,
+          filePath,
+          projectDir,
+          "19.1.1",
+          getMdxEsmSsrCacheDirs(projectId, contentSourceId),
+        );
+
+        assertEquals(invalidated, true);
+        assertEquals(cache.get(key), undefined);
+        assertEquals(verifiedModuleDeps.get(`${cachedPath}:${key}`), undefined);
+
+        await waitForDiskCleanup();
+        clearModulePathCache();
+        assertEquals((await getModulePathCache(legacyRawCacheDir)).get(key), undefined);
+      });
+    } finally {
+      await Promise.all([
+        remove(cacheBase, { recursive: true }).catch(() => {}),
         remove(projectDir, { recursive: true }).catch(() => {}),
       ]);
       clearModulePathCache();

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -18,6 +18,7 @@ import { isNotFoundError } from "#veryfront/platform/compat/fs.ts";
 import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { registerCache } from "#veryfront/utils/memory/index.ts";
+import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import { buildMdxEsmPathCacheKey, MDX_ESM_ALL_FILE_URL_PATTERN_SOURCE } from "../cache-format.ts";
 import { ensureMdxModuleDependencies } from "../module-fetcher/dependency-recovery.ts";
 import { findStaticImportFromSpans } from "../utils/source-spans.ts";
@@ -148,6 +149,10 @@ function hasUnresolvedVfModules(code: string): boolean {
 
 const modulePathCaches = new Map<string, Map<string, string>>();
 const modulePathCacheLoaded = new Set<string>();
+
+export function getMdxEsmSsrCacheDir(projectId: string, contentSourceId: string): string {
+  return join(getMdxEsmCacheDir(), hashCodeHex(projectId), contentSourceId);
+}
 
 function getModulePathCacheEntryCount(): number {
   let entries = 0;
@@ -346,18 +351,36 @@ export function invalidateModulePaths(changedPaths: string[]): void {
  * the shared disk-cleanup queue like {@link invalidateModulePaths}) so the stale
  * pointer does not resurrect from disk on the next process start.
  */
-export function invalidateMdxEsmModule(
+function getMdxEsmCacheDirForCachedPath(cachedPath: string): string | null {
+  const baseCacheDir = getMdxEsmCacheDir();
+  const prefix = baseCacheDir.endsWith("/") ? baseCacheDir : `${baseCacheDir}/`;
+  if (!cachedPath.startsWith(prefix)) return null;
+
+  const [projectKey, sourceKey] = cachedPath.slice(prefix.length).split("/");
+  if (!projectKey || !sourceKey) return null;
+
+  return join(baseCacheDir, projectKey, sourceKey);
+}
+
+function invalidateMdxEsmModuleFromCache(
   cacheDir: string,
+  cache: Map<string, string>,
   filePath: string,
   projectDir?: string,
   reactVersion = REACT_DEFAULT_VERSION,
-): void {
-  const cache = modulePathCaches.get(cacheDir);
-  if (!cache) return;
-
+  expectedCachedPath?: string,
+): boolean {
   const cacheKey = toMdxEsmCacheKey(filePath, projectDir, reactVersion);
   const cachedPath = cache.get(cacheKey);
-  if (cachedPath === undefined) return;
+  if (cachedPath === undefined) {
+    if (expectedCachedPath) verifiedModuleDeps.delete(`${expectedCachedPath}:${cacheKey}`);
+    return false;
+  }
+
+  if (expectedCachedPath && cachedPath !== expectedCachedPath) {
+    verifiedModuleDeps.delete(`${expectedCachedPath}:${cacheKey}`);
+    return false;
+  }
 
   cache.delete(cacheKey);
   verifiedModuleDeps.delete(`${cachedPath}:${cacheKey}`);
@@ -367,6 +390,39 @@ export function invalidateMdxEsmModule(
   });
 
   queueIndexPersist([cacheDir]);
+  return true;
+}
+
+export function invalidateMdxEsmModule(
+  cacheDir: string,
+  filePath: string,
+  projectDir?: string,
+  reactVersion = REACT_DEFAULT_VERSION,
+): boolean {
+  const cache = modulePathCaches.get(cacheDir);
+  if (!cache) return false;
+
+  return invalidateMdxEsmModuleFromCache(cacheDir, cache, filePath, projectDir, reactVersion);
+}
+
+export async function invalidateMdxEsmModuleForCachedPath(
+  cachedPath: string,
+  filePath: string,
+  projectDir?: string,
+  reactVersion = REACT_DEFAULT_VERSION,
+  cacheDir = getMdxEsmCacheDirForCachedPath(cachedPath),
+): Promise<boolean> {
+  if (!cacheDir) return false;
+
+  const cache = await getModulePathCache(cacheDir);
+  return invalidateMdxEsmModuleFromCache(
+    cacheDir,
+    cache,
+    filePath,
+    projectDir,
+    reactVersion,
+    cachedPath,
+  );
 }
 
 function extractNormalizedCachedModulePath(cachedKey: string): string {
@@ -395,44 +451,55 @@ export async function clearMdxEsmCacheNamespace(
   projectId: string,
   contentSourceId: string,
 ): Promise<void> {
-  const cacheDir = join(
+  const encodedCacheDir = join(
     getMdxEsmCacheDir(),
     encodeURIComponent(projectId),
     encodeURIComponent(contentSourceId),
   );
+  const cacheDirs = new Set([
+    encodedCacheDir,
+    getMdxEsmSsrCacheDir(projectId, contentSourceId),
+  ]);
 
-  modulePathCaches.delete(cacheDir);
-  modulePathCacheLoaded.delete(cacheDir);
+  for (const cacheDir of cacheDirs) {
+    modulePathCaches.delete(cacheDir);
+    modulePathCacheLoaded.delete(cacheDir);
+  }
 
   for (const key of Array.from(verifiedModuleDeps.keys())) {
-    if (String(key).startsWith(cacheDir)) {
-      verifiedModuleDeps.delete(key);
+    for (const cacheDir of cacheDirs) {
+      if (String(key).startsWith(cacheDir)) {
+        verifiedModuleDeps.delete(key);
+        break;
+      }
     }
   }
 
-  try {
-    await getLocalFs().remove(cacheDir, { recursive: true });
-  } catch (error) {
-    if (!isNotFoundError(error)) {
-      logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to remove MDX-ESM cache namespace`, {
+  for (const cacheDir of cacheDirs) {
+    try {
+      await getLocalFs().remove(cacheDir, { recursive: true });
+    } catch (error) {
+      if (!isNotFoundError(error)) {
+        logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to remove MDX-ESM cache namespace`, {
+          cacheDir,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    try {
+      await getLocalFs().mkdir(cacheDir, { recursive: true });
+      logger.debug(`${LOG_PREFIX_MDX_LOADER} Cleared MDX-ESM cache namespace`, {
+        projectId,
+        contentSourceId,
+        cacheDir,
+      });
+    } catch (error) {
+      logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to recreate MDX-ESM cache namespace`, {
         cacheDir,
         error: error instanceof Error ? error.message : String(error),
       });
     }
-  }
-
-  try {
-    await getLocalFs().mkdir(cacheDir, { recursive: true });
-    logger.debug(`${LOG_PREFIX_MDX_LOADER} Cleared MDX-ESM cache namespace`, {
-      projectId,
-      contentSourceId,
-      cacheDir,
-    });
-  } catch (error) {
-    logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to recreate MDX-ESM cache namespace`, {
-      cacheDir,
-      error: error instanceof Error ? error.message : String(error),
-    });
   }
 }
 

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -151,7 +151,7 @@ const modulePathCaches = new Map<string, Map<string, string>>();
 const modulePathCacheLoaded = new Set<string>();
 
 export function getMdxEsmSsrCacheDir(projectId: string, contentSourceId: string): string {
-  return join(getMdxEsmCacheDir(), hashCodeHex(projectId), contentSourceId);
+  return join(getMdxEsmCacheDir(), hashCodeHex(projectId), hashCodeHex(contentSourceId));
 }
 
 function getModulePathCacheEntryCount(): number {

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -154,6 +154,17 @@ export function getMdxEsmSsrCacheDir(projectId: string, contentSourceId: string)
   return join(getMdxEsmCacheDir(), hashCodeHex(projectId), hashCodeHex(contentSourceId));
 }
 
+function getLegacyRawMdxEsmSsrCacheDir(projectId: string, contentSourceId: string): string {
+  return join(getMdxEsmCacheDir(), hashCodeHex(projectId), contentSourceId);
+}
+
+export function getMdxEsmSsrCacheDirs(projectId: string, contentSourceId: string): string[] {
+  return [
+    getMdxEsmSsrCacheDir(projectId, contentSourceId),
+    getLegacyRawMdxEsmSsrCacheDir(projectId, contentSourceId),
+  ].filter((cacheDir, index, cacheDirs) => cacheDirs.indexOf(cacheDir) === index);
+}
+
 function getModulePathCacheEntryCount(): number {
   let entries = 0;
   for (const cache of modulePathCaches.values()) entries += cache.size;
@@ -362,6 +373,12 @@ function getMdxEsmCacheDirForCachedPath(cachedPath: string): string | null {
   return join(baseCacheDir, projectKey, sourceKey);
 }
 
+function isSameOrDescendantPath(path: string, parentPath: string): boolean {
+  const normalizedParent = parentPath.replace(/\/+$/, "");
+  const normalizedPath = path.replace(/\/+$/, "");
+  return normalizedPath === normalizedParent || normalizedPath.startsWith(`${normalizedParent}/`);
+}
+
 function invalidateMdxEsmModuleFromCache(
   cacheDir: string,
   cache: Map<string, string>,
@@ -410,19 +427,25 @@ export async function invalidateMdxEsmModuleForCachedPath(
   filePath: string,
   projectDir?: string,
   reactVersion = REACT_DEFAULT_VERSION,
-  cacheDir = getMdxEsmCacheDirForCachedPath(cachedPath),
+  cacheDirs: string | string[] | null = getMdxEsmCacheDirForCachedPath(cachedPath),
 ): Promise<boolean> {
-  if (!cacheDir) return false;
+  const candidateDirs = Array.isArray(cacheDirs) ? cacheDirs : cacheDirs ? [cacheDirs] : [];
+  if (candidateDirs.length === 0) return false;
 
-  const cache = await getModulePathCache(cacheDir);
-  return invalidateMdxEsmModuleFromCache(
-    cacheDir,
-    cache,
-    filePath,
-    projectDir,
-    reactVersion,
-    cachedPath,
-  );
+  for (const cacheDir of candidateDirs) {
+    const cache = await getModulePathCache(cacheDir);
+    const invalidated = invalidateMdxEsmModuleFromCache(
+      cacheDir,
+      cache,
+      filePath,
+      projectDir,
+      reactVersion,
+      cachedPath,
+    );
+    if (invalidated) return true;
+  }
+
+  return false;
 }
 
 function extractNormalizedCachedModulePath(cachedKey: string): string {
@@ -456,26 +479,39 @@ export async function clearMdxEsmCacheNamespace(
     encodeURIComponent(projectId),
     encodeURIComponent(contentSourceId),
   );
-  const cacheDirs = new Set([
+  const currentSsrCacheDir = getMdxEsmSsrCacheDir(projectId, contentSourceId);
+  const cacheDirs = new Set([encodedCacheDir, currentSsrCacheDir]);
+  const removeDirs = new Set([
     encodedCacheDir,
-    getMdxEsmSsrCacheDir(projectId, contentSourceId),
+    currentSsrCacheDir,
+    ...getMdxEsmSsrCacheDirs(projectId, contentSourceId),
   ]);
+  const affectedCacheDirs = new Set(removeDirs);
 
-  for (const cacheDir of cacheDirs) {
+  for (const loadedCacheDir of modulePathCaches.keys()) {
+    for (const cacheDir of removeDirs) {
+      if (isSameOrDescendantPath(loadedCacheDir, cacheDir)) {
+        affectedCacheDirs.add(loadedCacheDir);
+        break;
+      }
+    }
+  }
+
+  for (const cacheDir of affectedCacheDirs) {
     modulePathCaches.delete(cacheDir);
     modulePathCacheLoaded.delete(cacheDir);
   }
 
   for (const key of Array.from(verifiedModuleDeps.keys())) {
-    for (const cacheDir of cacheDirs) {
-      if (String(key).startsWith(cacheDir)) {
+    for (const cacheDir of removeDirs) {
+      if (isSameOrDescendantPath(String(key), cacheDir)) {
         verifiedModuleDeps.delete(key);
         break;
       }
     }
   }
 
-  for (const cacheDir of cacheDirs) {
+  for (const cacheDir of removeDirs) {
     try {
       await getLocalFs().remove(cacheDir, { recursive: true });
     } catch (error) {
@@ -486,6 +522,8 @@ export async function clearMdxEsmCacheNamespace(
         });
       }
     }
+
+    if (!cacheDirs.has(cacheDir)) continue;
 
     try {
       await getLocalFs().mkdir(cacheDir, { recursive: true });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1028";
+export const VERSION = "0.1.1029";


### PR DESCRIPTION
Fixes #2807.

## What changed
- Added bounded SSR loader recovery for verified stale cache entries that fail import because a local module dependency disappeared after verification.
- Treats both dynamic `Module not found` and missing cached output files as stale-cache recovery cases, then performs one fresh transform/import retry.
- Invalidates all in-memory SSR cache aliases for the stale temp path/content hash so retry cannot reuse the same broken content-cache pointer.
- Moved SSR-compatible MDX-ESM namespace handling into the MDX cache module, including cold `_index.json` loading/persistence during stale-path invalidation.
- Clears both encoded and SSR hashed MDX-ESM namespaces during preview stale-cache recovery.
- Added coverage for slash-containing content source IDs such as `preview-feature/refactor` so branch names with `/` do not break stale-cache cleanup.
- Bumped Veryfront from `0.1.1026` to `0.1.1027`.

## Root cause
Preview rendering could keep a verified SSR/MDX cache pointer after a nested framework dependency file disappeared from disk. The verified fast path skipped dependency validation, `import()` failed with `Module not found`, and the loader invalidated only part of the cache state before returning a 500. In some cases the content/MDX path-cache aliases could continue pointing at the same broken temp module.

## Red test evidence
Before the fix, the regression `rebuilds a verified stale cache entry when dynamic import finds a missing local dependency` failed with:

```text
TypeError: Module not found "file://.../missing-framework-core-....mjs"
```

During the review loop, two additional red regressions were added and fixed:
- Missing verified cached output file initially failed with `VeryfrontError[build]: Cache file missing: ...`.
- Cold MDX `_index.json` invalidation initially allowed the stale path-cache entry to resurrect after reload.

## Validation
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/modules/react-loader/ssr-module-loader/loader.test.ts` passed with 14 steps.
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --preload=src/schemas/_test-setup.ts --no-check --allow-all --unstable-worker-options --unstable-net src/modules/react-loader/ssr-module-loader/loader.test.ts src/modules/react-loader/ssr-module-loader/cache/memory.test.ts src/modules/react-loader/ssr-module-loader/ssr-cache-manager.test.ts src/transforms/mdx/esm-module-loader/cache/index.test.ts` passed with 9 suites / 67 steps.
- `deno task typecheck` passed.
- `deno fmt --check deno.json src/modules/react-loader/ssr-module-loader/loader.ts src/modules/react-loader/ssr-module-loader/loader.test.ts src/modules/react-loader/ssr-module-loader/ssr-cache-manager.ts src/modules/react-loader/ssr-module-loader/vf-module-resolver.ts src/transforms/mdx/esm-module-loader/cache/index.ts src/transforms/mdx/esm-module-loader/cache/index.test.ts src/utils/version-constant.ts` passed.
- `deno lint src/modules/react-loader/ssr-module-loader/loader.ts src/modules/react-loader/ssr-module-loader/loader.test.ts src/modules/react-loader/ssr-module-loader/ssr-cache-manager.ts src/modules/react-loader/ssr-module-loader/vf-module-resolver.ts src/transforms/mdx/esm-module-loader/cache/index.ts src/transforms/mdx/esm-module-loader/cache/index.test.ts` passed.
- `git diff --check` passed.
- Earlier full unit run with local OTEL env unset passed once with `2301 passed`; a later repeat hit unrelated `src/skill/executor.test.ts` flake, and that isolated file passed on rerun.

Note: local pre-push hook was bypassed because this shell still has `OTEL_*` exporter env set, which makes unrelated metrics default-exporter assertions see `otlp` instead of `console`. GitHub CI is the clean gate for the pushed commit.