### PR TITLE
Bump version to 0.1.1028

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1027",
+  "version": "0.1.1028",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1027";
+export const VERSION = "0.1.1028";


### PR DESCRIPTION
Follow-up to #2808: that PR merged after #2810 had already bumped the package to `0.1.1027`, so the OTLP dedicated-runtime fix landed without a fresh release version.

This bumps both version sources kept in sync by the release flow:
- `deno.json`
- `src/utils/version-constant.ts`

Validation:
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno check src/utils/version-constant.ts`
- `git diff --check`
- clean-env pre-push hook: format, lint, typecheck, generation, unit tests (`2301 passed`)
