### PR TITLE
Trace scheduled agent telemetry

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -34,13 +34,18 @@
     "npm:@kreuzberg/wasm@4.5.2": "4.5.2",
     "npm:@mdx-js/mdx@3.1.1": "3.1.1",
     "npm:@mdx-js/react@3.1.1": "3.1.1_@types+react@19.2.17_react@19.2.7",
+    "npm:@opentelemetry/api-logs@0.208.0": "0.208.0",
+    "npm:@opentelemetry/api-logs@0.219.0": "0.219.0",
     "npm:@opentelemetry/api@1.9.1": "1.9.1",
     "npm:@opentelemetry/auto-instrumentations-node@0.77.0": "0.77.0_@opentelemetry+api@1.9.1_@opentelemetry+core@2.8.0__@opentelemetry+api@1.9.1",
     "npm:@opentelemetry/context-async-hooks@2.8.0": "2.8.0_@opentelemetry+api@1.9.1",
     "npm:@opentelemetry/core@2.8.0": "2.8.0_@opentelemetry+api@1.9.1",
+    "npm:@opentelemetry/exporter-logs-otlp-http@0.219.0": "0.219.0_@opentelemetry+api@1.9.1",
     "npm:@opentelemetry/exporter-metrics-otlp-http@0.219.0": "0.219.0_@opentelemetry+api@1.9.1",
     "npm:@opentelemetry/exporter-trace-otlp-http@0.219.0": "0.219.0_@opentelemetry+api@1.9.1",
     "npm:@opentelemetry/resources@2.8.0": "2.8.0_@opentelemetry+api@1.9.1",
+    "npm:@opentelemetry/sdk-logs@*": "0.219.0_@opentelemetry+api@1.9.1",
+    "npm:@opentelemetry/sdk-logs@0.219.0": "0.219.0_@opentelemetry+api@1.9.1",
     "npm:@opentelemetry/sdk-metrics@2.8.0": "2.8.0_@opentelemetry+api@1.9.1",
     "npm:@opentelemetry/sdk-node@0.219.0": "0.219.0_@opentelemetry+api@1.9.1",
     "npm:@opentelemetry/sdk-trace-base@2.8.0": "2.8.0_@opentelemetry+api@1.9.1",
@@ -833,6 +838,12 @@
         "fastq"
       ]
     },
+    "@opentelemetry/api-logs@0.208.0": {
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "dependencies": [
+        "@opentelemetry/api"
+      ]
+    },
     "@opentelemetry/api-logs@0.219.0": {
       "integrity": "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==",
       "dependencies": [
@@ -935,7 +946,7 @@
       "integrity": "sha512-mhl2HL6GmZI8b8PwPfqMws/5ovJfbRTxwc9Y5agVVHiQ+e5SL1btsFr/kJDgt7YCexDtsUn5HAreHQO9szFS0A==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/api-logs",
+        "@opentelemetry/api-logs@0.219.0",
         "@opentelemetry/core",
         "@opentelemetry/otlp-exporter-base",
         "@opentelemetry/otlp-transformer",
@@ -946,7 +957,7 @@
       "integrity": "sha512-Ayw4Gf71PS9jhBVaYywa4WsajnqfDehMkTdVH3TSAVHqPcsAv/AhH/wTNRYNt99szeYr6Gbd/D6RjZD77wAxHg==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/api-logs",
+        "@opentelemetry/api-logs@0.219.0",
         "@opentelemetry/core",
         "@opentelemetry/otlp-exporter-base",
         "@opentelemetry/otlp-transformer",
@@ -1079,7 +1090,7 @@
       "integrity": "sha512-jrRNFvpREutmpoWhk1T8n9q/RYdxbViXwSUPHN8yQR1bzgtwfOl/y8G/p8Xfudlky9GGsqw5WRc6q6QrfgF3pw==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/api-logs",
+        "@opentelemetry/api-logs@0.219.0",
         "@opentelemetry/instrumentation",
         "@types/bunyan"
       ]
@@ -1295,7 +1306,7 @@
       "integrity": "sha512-X3aEZnzj7SJkn1nmqEoD9IljmqENnGrd0vcJngcEApT8uqhFaeimONqKeIzKYvUgC7k4OkAUxC7yfXzxIK1KlA==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/api-logs",
+        "@opentelemetry/api-logs@0.219.0",
         "@opentelemetry/instrumentation",
         "@opentelemetry/semantic-conventions"
       ]
@@ -1325,7 +1336,7 @@
       "integrity": "sha512-p6eh+NRmzi1F+/4QG7XDqRk4ICdCNTsM5vdcwUPnpMie2MddgY1/ENmWvCF9r0Kh6QQRA2kkpnhoJFaiRQ5kVw==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/api-logs",
+        "@opentelemetry/api-logs@0.219.0",
         "@opentelemetry/core",
         "@opentelemetry/instrumentation"
       ]
@@ -1360,7 +1371,7 @@
       "integrity": "sha512-Jo1jSgrHlah3lPpGNPsIpF0q52D5uSLRJrztWUoPc1/Tli2ZWZ+cArgNtcdmiLuKhW21MwYbbcrNw1fbOPeR3A==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/api-logs",
+        "@opentelemetry/api-logs@0.219.0",
         "@opentelemetry/core",
         "@opentelemetry/instrumentation"
       ]
@@ -1394,7 +1405,7 @@
       "integrity": "sha512-NFMHLYODph0rWGfT/QLv75hCsu1sxVAV79L8HduBCMo181jOTSRZHaqxfrvDtFOsvgYBaiUBa7Ga50w47wM3FA==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/api-logs",
+        "@opentelemetry/api-logs@0.219.0",
         "@opentelemetry/instrumentation"
       ]
     },
@@ -1402,7 +1413,7 @@
       "integrity": "sha512-X5t7I8GyIO9rmGHwoedZLREpQqrF1WW2nxzNNym6HOKpFiE+rvqV3ngC0xcZVO2YwIGf3KKmRdWrYwdwz3H9RQ==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/api-logs",
+        "@opentelemetry/api-logs@0.219.0",
         "import-in-the-middle",
         "require-in-the-middle"
       ]
@@ -1429,7 +1440,7 @@
       "integrity": "sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/api-logs",
+        "@opentelemetry/api-logs@0.219.0",
         "@opentelemetry/core",
         "@opentelemetry/resources",
         "@opentelemetry/sdk-logs",
@@ -1515,7 +1526,7 @@
       "integrity": "sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/api-logs",
+        "@opentelemetry/api-logs@0.219.0",
         "@opentelemetry/core",
         "@opentelemetry/resources",
         "@opentelemetry/semantic-conventions"
@@ -1533,7 +1544,7 @@
       "integrity": "sha512-NWLpWLEb8gV3+JBHYoIrktbM385wyHpRJoh3J/4Q52d4PR+AlPMNGJT3DzBUrDSUEVbKAXoHR+EDAPxtiNcj8g==",
       "dependencies": [
         "@opentelemetry/api",
-        "@opentelemetry/api-logs",
+        "@opentelemetry/api-logs@0.219.0",
         "@opentelemetry/configuration",
         "@opentelemetry/context-async-hooks",
         "@opentelemetry/core",
@@ -5234,13 +5245,16 @@
         "dependencies": [
           "jsr:@std/assert@1.0.19",
           "jsr:@std/testing@1.0.17",
+          "npm:@opentelemetry/api-logs@0.219.0",
           "npm:@opentelemetry/api@1.9.1",
           "npm:@opentelemetry/auto-instrumentations-node@0.77.0",
           "npm:@opentelemetry/context-async-hooks@2.8.0",
           "npm:@opentelemetry/core@2.8.0",
+          "npm:@opentelemetry/exporter-logs-otlp-http@0.219.0",
           "npm:@opentelemetry/exporter-metrics-otlp-http@0.219.0",
           "npm:@opentelemetry/exporter-trace-otlp-http@0.219.0",
           "npm:@opentelemetry/resources@2.8.0",
+          "npm:@opentelemetry/sdk-logs@0.219.0",
           "npm:@opentelemetry/sdk-metrics@2.8.0",
           "npm:@opentelemetry/sdk-node@0.219.0",
           "npm:@opentelemetry/sdk-trace-base@2.8.0",

--- a/extensions/ext-observability-opentelemetry/README.md
+++ b/extensions/ext-observability-opentelemetry/README.md
@@ -2,7 +2,7 @@
 
 > **Category:** Observability | **Contracts:** `TracingExporter`, `NodeTelemetryProvider` | **Optional**
 
-Provides distributed tracing, OTLP metrics export, the OpenTelemetry metrics API bridge, and Node telemetry bootstrap for Veryfront via the [OpenTelemetry JS SDK](https://github.com/open-telemetry/opentelemetry-js). Exports trace spans and metrics over OTLP/HTTP to any OpenTelemetry-compatible collector.
+Provides distributed tracing, OTLP log export, OTLP metrics export, the OpenTelemetry metrics API bridge, and Node telemetry bootstrap for Veryfront via the [OpenTelemetry JS SDK](https://github.com/open-telemetry/opentelemetry-js). Exports trace spans, log records, and metrics over OTLP/HTTP to any OpenTelemetry-compatible collector.
 
 ## Installation
 
@@ -20,18 +20,22 @@ export default defineConfig({
 
 The extension reads the standard OpenTelemetry env vars at setup time:
 
-| Variable                              | Required         | Description                                                       |
-| ------------------------------------- | ---------------- | ----------------------------------------------------------------- |
-| Variable                              | Required         | Description                                                       |
-| ------------------------------------  | ---------------- | ----------------------------------------------------------------- |
-| `OTEL_EXPORTER_OTLP_ENDPOINT`         | Yes (for export) | Base collector URL, e.g. `http://localhost:4318`                  |
-| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  | No               | Trace-specific OTLP HTTP URL                                      |
-| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | No               | Metric-specific OTLP HTTP URL                                     |
-| `OTEL_EXPORTER_OTLP_HEADERS`          | No               | Comma-separated `key=value` pairs (commonly used for auth tokens) |
-| `OTEL_SERVICE_NAME`                   | No               | Service name attached to telemetry                                |
-| `OTEL_TRACES_ENABLED`                 | No               | Set to `true` to enable trace export                              |
-| `OTEL_METRICS_ENABLED`                | No               | Set to `true` to enable metric export                             |
-| `OTEL_METRIC_EXPORT_INTERVAL`         | No               | Metric export interval in milliseconds                            |
+| Variable                                                  | Required         | Description                                                       |
+| --------------------------------------------------------- | ---------------- | ----------------------------------------------------------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`                             | Yes (for export) | Base collector URL, e.g. `http://localhost:4318`                  |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`                      | No               | Trace-specific OTLP HTTP URL                                      |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`                     | No               | Metric-specific OTLP HTTP URL                                     |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`                        | No               | Log-specific OTLP HTTP URL                                        |
+| `OTEL_EXPORTER_OTLP_HEADERS`                              | No               | Comma-separated `key=value` pairs (commonly used for auth tokens) |
+| `OTEL_EXPORTER_OTLP_TRACES_HEADERS`                       | No               | Trace-specific headers merged over global headers                 |
+| `OTEL_EXPORTER_OTLP_METRICS_HEADERS`                      | No               | Metric-specific headers merged over global headers                |
+| `OTEL_EXPORTER_OTLP_LOGS_HEADERS`                         | No               | Log-specific headers merged over global headers                   |
+| `OTEL_SERVICE_NAME`                                       | No               | Service name attached to telemetry                                |
+| `OTEL_TRACES_ENABLED` / `OTEL_TRACES_EXPORTER=otlp`       | No               | Enables trace export                                              |
+| `OTEL_METRICS_ENABLED` / `OTEL_METRICS_EXPORTER=otlp`     | No               | Enables metric export                                             |
+| `OTEL_LOGS_ENABLED` / `OTEL_LOGS_EXPORTER=otlp`           | No               | Enables log export                                                |
+| `OTEL_METRIC_EXPORT_INTERVAL`                             | No               | Metric export interval in milliseconds                            |
+| `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta` | No               | Metrics temporality. Dedicated service defaults to `delta`.       |
 
 Configuration is read from process `OTEL_*` environment variables. In shared Veryfront runtimes these are platform-owned host env vars. The extension does not accept `ctx.config.otel` exporter endpoint, header, service name, or enable-flag overrides because project config is tenant controlled in shared runtimes.
 
@@ -46,6 +50,14 @@ Exporter configuration is process-level. Dedicated runtimes can use project-spec
 ## Metrics
 
 Set `OTEL_METRICS_ENABLED=true` to export framework metrics through OTLP HTTP. The extension resolves `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` first, then `OTEL_EXPORTER_OTLP_ENDPOINT`. A base OTLP endpoint receives `/v1/metrics`.
+
+Dedicated Node agent services create a startup counter named `veryfront.agent.telemetry.startups` when metrics export is enabled. The dedicated service defaults metric temporality to `delta`, which matches Datadog's OTLP metrics intake requirement.
+
+## Logs
+
+Set `OTEL_LOGS_ENABLED=true` or `OTEL_LOGS_EXPORTER=otlp` to export structured Veryfront agent logs through OTLP HTTP. The extension resolves `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` first, then `OTEL_EXPORTER_OTLP_ENDPOINT`. A base OTLP endpoint receives `/v1/logs`.
+
+Dedicated Node agent services bridge Veryfront's structured logger into OpenTelemetry logs after telemetry initialization. Log records include the active `trace_id` and `span_id` when available, so Datadog can correlate logs with traces.
 
 In shared Veryfront runtimes, these variables are platform-owned host env vars. Project env overlays must not control the shared runtime metrics exporter. Use a dedicated runtime for project-owned collector endpoints or credentials.
 

--- a/extensions/ext-observability-opentelemetry/deno.json
+++ b/extensions/ext-observability-opentelemetry/deno.json
@@ -15,11 +15,20 @@
           "OTEL_EXPORTER_OTLP_ENDPOINT",
           "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
           "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+          "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
           "OTEL_EXPORTER_OTLP_HEADERS",
+          "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+          "OTEL_EXPORTER_OTLP_METRICS_HEADERS",
+          "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
           "OTEL_SERVICE_NAME",
           "OTEL_TRACES_ENABLED",
           "OTEL_METRICS_ENABLED",
-          "OTEL_METRIC_EXPORT_INTERVAL"
+          "OTEL_LOGS_ENABLED",
+          "OTEL_TRACES_EXPORTER",
+          "OTEL_METRICS_EXPORTER",
+          "OTEL_LOGS_EXPORTER",
+          "OTEL_METRIC_EXPORT_INTERVAL",
+          "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"
         ]
       }
     ]
@@ -29,7 +38,10 @@
     "@opentelemetry/auto-instrumentations-node": "npm:@opentelemetry/auto-instrumentations-node@0.77.0",
     "@opentelemetry/core": "npm:@opentelemetry/core@2.8.0",
     "@opentelemetry/context-async-hooks": "npm:@opentelemetry/context-async-hooks@2.8.0",
+    "@opentelemetry/api-logs": "npm:@opentelemetry/api-logs@0.219.0",
+    "@opentelemetry/exporter-logs-otlp-http": "npm:@opentelemetry/exporter-logs-otlp-http@0.219.0",
     "@opentelemetry/exporter-metrics-otlp-http": "npm:@opentelemetry/exporter-metrics-otlp-http@0.219.0",
+    "@opentelemetry/sdk-logs": "npm:@opentelemetry/sdk-logs@0.219.0",
     "@opentelemetry/sdk-metrics": "npm:@opentelemetry/sdk-metrics@2.8.0",
     "@opentelemetry/sdk-node": "npm:@opentelemetry/sdk-node@0.219.0",
     "@opentelemetry/sdk-trace-base": "npm:@opentelemetry/sdk-trace-base@2.8.0",

--- a/extensions/ext-observability-opentelemetry/src/index.test.ts
+++ b/extensions/ext-observability-opentelemetry/src/index.test.ts
@@ -60,16 +60,24 @@ describe("ext-observability-opentelemetry config helpers", () => {
     const config = resolveOtlpExtensionConfig(env({
       OTEL_TRACES_ENABLED: "false",
       OTEL_METRICS_ENABLED: "true",
+      OTEL_LOGS_EXPORTER: "otlp",
       OTEL_EXPORTER_OTLP_ENDPOINT: "https://collector.example/otlp",
+      OTEL_EXPORTER_OTLP_LOGS_HEADERS: "x-log-route=logs",
       OTEL_EXPORTER_OTLP_HEADERS: "Authorization=Basic platform-token",
       OTEL_SERVICE_NAME: "veryfront-server",
     }));
 
     assertEquals(config.tracesEnabled, false);
     assertEquals(config.metricsEnabled, true);
+    assertEquals(config.logsEnabled, true);
     assertEquals(config.tracesUrl, "https://collector.example/otlp/v1/traces");
     assertEquals(config.metricsUrl, "https://collector.example/otlp/v1/metrics");
+    assertEquals(config.logsUrl, "https://collector.example/otlp/v1/logs");
     assertEquals(config.headers, { Authorization: "Basic platform-token" });
+    assertEquals(config.logsHeaders, {
+      Authorization: "Basic platform-token",
+      "x-log-route": "logs",
+    });
     assertEquals(config.serviceName, "veryfront-server");
   });
 

--- a/extensions/ext-observability-opentelemetry/src/index.ts
+++ b/extensions/ext-observability-opentelemetry/src/index.ts
@@ -17,6 +17,7 @@
 import type { ExtensionFactory } from "veryfront/extensions";
 import type {
   NodeTelemetryInitializeOptions,
+  NodeTelemetryLogRecord,
   NodeTelemetryProvider,
   SpanData,
   TracingExporter,
@@ -33,9 +34,12 @@ interface ShimTracerProvider {
 type OpenTelemetryRuntime = {
   api: typeof import("@opentelemetry/api");
   autoInstrumentations: typeof import("@opentelemetry/auto-instrumentations-node");
+  apiLogs: typeof import("@opentelemetry/api-logs");
   core: typeof import("@opentelemetry/core");
   contextAsyncHooks: typeof import("@opentelemetry/context-async-hooks");
+  logsExporter: typeof import("@opentelemetry/exporter-logs-otlp-http");
   sdkNode: typeof import("@opentelemetry/sdk-node");
+  sdkLogs: typeof import("@opentelemetry/sdk-logs");
   metricsExporter: typeof import("@opentelemetry/exporter-metrics-otlp-http");
   sdkMetrics: typeof import("@opentelemetry/sdk-metrics");
   sdkTraceBase: typeof import("@opentelemetry/sdk-trace-base");
@@ -49,6 +53,9 @@ type SdkMeterProvider = InstanceType<
 >;
 type SdkTracerProvider = InstanceType<
   typeof import("@opentelemetry/sdk-trace-base").BasicTracerProvider
+>;
+type SdkLoggerProvider = InstanceType<
+  typeof import("@opentelemetry/sdk-logs").LoggerProvider
 >;
 type MetricsAPI = { getMeter(name: string | undefined, version?: string): unknown };
 type TraceAPI = { getActiveSpan(): unknown; getSpan(ctx: unknown): unknown };
@@ -110,9 +117,12 @@ async function loadOpenTelemetryRuntime(): Promise<OpenTelemetryRuntime> {
     const [
       api,
       autoInstrumentations,
+      apiLogs,
       core,
       contextAsyncHooks,
+      logsExporter,
       sdkNode,
+      sdkLogs,
       metricsExporter,
       sdkMetrics,
       sdkTraceBase,
@@ -122,9 +132,12 @@ async function loadOpenTelemetryRuntime(): Promise<OpenTelemetryRuntime> {
     ] = await Promise.all([
       import("@opentelemetry/api"),
       import("@opentelemetry/auto-instrumentations-node"),
+      import("@opentelemetry/api-logs"),
       import("@opentelemetry/core"),
       import("@opentelemetry/context-async-hooks"),
+      import("@opentelemetry/exporter-logs-otlp-http"),
       import("@opentelemetry/sdk-node"),
+      import("@opentelemetry/sdk-logs"),
       import("@opentelemetry/exporter-metrics-otlp-http"),
       import("@opentelemetry/sdk-metrics"),
       import("@opentelemetry/sdk-trace-base"),
@@ -136,9 +149,12 @@ async function loadOpenTelemetryRuntime(): Promise<OpenTelemetryRuntime> {
     return {
       api,
       autoInstrumentations,
+      apiLogs,
       core,
       contextAsyncHooks,
+      logsExporter,
       sdkNode,
+      sdkLogs,
       metricsExporter,
       sdkMetrics,
       sdkTraceBase,
@@ -160,11 +176,17 @@ export interface ResolvedOtlpExtensionConfig {
   serviceName: string;
   serviceVersion: string;
   headers: Record<string, string>;
+  tracesHeaders: Record<string, string>;
+  metricsHeaders: Record<string, string>;
+  logsHeaders: Record<string, string>;
   tracesEnabled: boolean;
   metricsEnabled: boolean;
+  logsEnabled: boolean;
   tracesUrl: string | undefined;
   metricsUrl: string | undefined;
+  logsUrl: string | undefined;
   metricsExportIntervalMillis: number;
+  metricsTemporalityPreference: "delta" | "cumulative" | "lowmemory";
 }
 
 function readEnv(name: string): string | undefined {
@@ -197,14 +219,117 @@ function parseHeaders(headerInput: string | Record<string, string> | undefined):
   return result;
 }
 
+function headersOrDefault(
+  signalHeaders: Record<string, string> | undefined,
+  defaultHeaders: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  return signalHeaders ?? defaultHeaders;
+}
+
+function metricTemporalityPreference(
+  otel: OpenTelemetryRuntime,
+  preference: NodeTelemetryInitializeOptions["metricsTemporalityPreference"],
+): number {
+  const enumValue = otel.metricsExporter.AggregationTemporalityPreference;
+  if (preference === "cumulative") return enumValue.CUMULATIVE;
+  if (preference === "lowmemory") return enumValue.LOWMEMORY;
+  return enumValue.DELTA;
+}
+
+function logSeverityNumber(
+  otel: OpenTelemetryRuntime,
+  level: string | undefined,
+): number {
+  switch (level) {
+    case "debug":
+      return otel.apiLogs.SeverityNumber.DEBUG;
+    case "warn":
+      return otel.apiLogs.SeverityNumber.WARN;
+    case "error":
+      return otel.apiLogs.SeverityNumber.ERROR;
+    case "info":
+    default:
+      return otel.apiLogs.SeverityNumber.INFO;
+  }
+}
+
+function logAttributes(record: NodeTelemetryLogRecord): Record<string, string | number | boolean> {
+  const attributes: Record<string, string | number | boolean> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (
+      key === "timestamp" ||
+      key === "level" ||
+      key === "message" ||
+      key === "context" ||
+      key === "error"
+    ) {
+      continue;
+    }
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      attributes[key] = value;
+    }
+  }
+
+  if (record.context) {
+    for (const [key, value] of Object.entries(record.context)) {
+      if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+        attributes[`context.${key}`] = value;
+      }
+    }
+  }
+
+  if (record.error && typeof record.error === "object") {
+    const error = record.error as Record<string, unknown>;
+    if (typeof error.name === "string") attributes["error.type"] = error.name;
+    if (typeof error.message === "string") attributes["error.message"] = error.message;
+  }
+
+  return attributes;
+}
+
 export function resolveOtlpSignalUrl(
   endpoint: string | undefined,
-  signal: "traces" | "metrics",
+  signal: "traces" | "metrics" | "logs",
 ): string | undefined {
   if (!endpoint) return undefined;
   const trimmed = endpoint.replace(/\/$/, "");
   const suffix = `/v1/${signal}`;
   return trimmed.endsWith(suffix) ? trimmed : `${trimmed}${suffix}`;
+}
+
+function isTruthySignalFlag(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  return value === "true" || value === "1";
+}
+
+function exporterIncludesOtlp(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (value === "none") return false;
+  return value.split(",").map((part) => part.trim()).includes("otlp");
+}
+
+function resolveSignalEnabled(
+  enabledValue: string | undefined,
+  exporterValue: string | undefined,
+): boolean {
+  const enabledFlag = isTruthySignalFlag(enabledValue);
+  if (enabledFlag !== undefined) return enabledFlag;
+  return exporterIncludesOtlp(exporterValue) ?? false;
+}
+
+function mergeHeaders(
+  base: Record<string, string>,
+  override: Record<string, string>,
+): Record<string, string> {
+  return { ...base, ...override };
+}
+
+function resolveMetricsTemporalityPreference(
+  value: string | undefined,
+): "delta" | "cumulative" | "lowmemory" {
+  const normalized = value?.toLowerCase();
+  if (normalized === "cumulative" || normalized === "lowmemory") return normalized;
+  return "delta";
 }
 
 export function resolveOtlpExtensionConfig(
@@ -213,28 +338,54 @@ export function resolveOtlpExtensionConfig(
   const endpoint = read("OTEL_EXPORTER_OTLP_ENDPOINT");
   const tracesEndpoint = read("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") ?? endpoint;
   const metricsEndpoint = read("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT") ?? endpoint;
+  const logsEndpoint = read("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT") ?? endpoint;
   const metricsExportIntervalMillis = Number.parseInt(
     read("OTEL_METRIC_EXPORT_INTERVAL") ?? "60000",
     10,
+  );
+  const headers = parseHeaders(read("OTEL_EXPORTER_OTLP_HEADERS"));
+  const tracesHeaders = mergeHeaders(
+    headers,
+    parseHeaders(read("OTEL_EXPORTER_OTLP_TRACES_HEADERS")),
+  );
+  const metricsHeaders = mergeHeaders(
+    headers,
+    parseHeaders(read("OTEL_EXPORTER_OTLP_METRICS_HEADERS")),
+  );
+  const logsHeaders = mergeHeaders(
+    headers,
+    parseHeaders(read("OTEL_EXPORTER_OTLP_LOGS_HEADERS")),
   );
 
   return {
     serviceName: read("OTEL_SERVICE_NAME") ?? "veryfront",
     serviceVersion: "0.1.0",
-    headers: parseHeaders(read("OTEL_EXPORTER_OTLP_HEADERS")),
-    tracesEnabled: read("OTEL_TRACES_ENABLED") === "true",
-    metricsEnabled: read("OTEL_METRICS_ENABLED") === "true",
+    headers,
+    tracesHeaders,
+    metricsHeaders,
+    logsHeaders,
+    tracesEnabled: resolveSignalEnabled(read("OTEL_TRACES_ENABLED"), read("OTEL_TRACES_EXPORTER")),
+    metricsEnabled: resolveSignalEnabled(
+      read("OTEL_METRICS_ENABLED"),
+      read("OTEL_METRICS_EXPORTER"),
+    ),
+    logsEnabled: resolveSignalEnabled(read("OTEL_LOGS_ENABLED"), read("OTEL_LOGS_EXPORTER")),
     tracesUrl: resolveOtlpSignalUrl(tracesEndpoint, "traces"),
     metricsUrl: resolveOtlpSignalUrl(metricsEndpoint, "metrics"),
+    logsUrl: resolveOtlpSignalUrl(logsEndpoint, "logs"),
     metricsExportIntervalMillis: Number.isFinite(metricsExportIntervalMillis)
       ? metricsExportIntervalMillis
       : 60_000,
+    metricsTemporalityPreference: resolveMetricsTemporalityPreference(
+      read("OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"),
+    ),
   };
 }
 
 class OtlpTracingExporter implements TracingExporter {
   private sdkProvider: SdkTracerProvider | null = null;
   private meterProvider: SdkMeterProvider | null = null;
+  private logProvider: SdkLoggerProvider | null = null;
   private metricsApi: MetricsAPI | null = null;
   private traceApi: TraceAPI | null = null;
 
@@ -243,7 +394,7 @@ class OtlpTracingExporter implements TracingExporter {
 
     // Honor OTEL_TRACES_ENABLED: when unset/false, skip exporter wiring so
     // deployments opting out never create OTLP traffic or set globals.
-    if (!cfg.tracesEnabled && !cfg.metricsEnabled) return;
+    if (!cfg.tracesEnabled && !cfg.metricsEnabled && !cfg.logsEnabled) return;
 
     const otel = await loadOpenTelemetryRuntime();
     const resource = otel.resources.resourceFromAttributes({
@@ -260,7 +411,7 @@ class OtlpTracingExporter implements TracingExporter {
 
       const exporter = new otel.traceExporter.OTLPTraceExporter({
         url: cfg.tracesUrl,
-        headers: cfg.headers,
+        headers: cfg.tracesHeaders,
       });
 
       const provider = new otel.sdkTraceBase.BasicTracerProvider({
@@ -298,7 +449,11 @@ class OtlpTracingExporter implements TracingExporter {
       const metricReader = new otel.sdkMetrics.PeriodicExportingMetricReader({
         exporter: new otel.metricsExporter.OTLPMetricExporter({
           url: cfg.metricsUrl,
-          headers: cfg.headers,
+          headers: cfg.metricsHeaders,
+          temporalityPreference: metricTemporalityPreference(
+            otel,
+            cfg.metricsTemporalityPreference,
+          ),
         }),
         exportIntervalMillis: cfg.metricsExportIntervalMillis,
       });
@@ -310,6 +465,35 @@ class OtlpTracingExporter implements TracingExporter {
       otel.api.metrics.setGlobalMeterProvider(this.meterProvider);
       this.metricsApi = otel.api.metrics;
     }
+
+    if (cfg.logsEnabled) {
+      if (!cfg.logsUrl) {
+        throw new Error(
+          "OTEL_LOGS_ENABLED=true requires OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+        );
+      }
+
+      this.logProvider = new otel.sdkLogs.LoggerProvider({
+        resource,
+        processors: [
+          new otel.sdkLogs.BatchLogRecordProcessor(
+            new otel.logsExporter.OTLPLogExporter({
+              url: cfg.logsUrl,
+              headers: cfg.logsHeaders,
+            }),
+          ),
+        ],
+      });
+      otel.apiLogs.logs.setGlobalLoggerProvider(this.logProvider);
+      otel.apiLogs.logs.getLogger(cfg.serviceName, cfg.serviceVersion).emit({
+        severityNumber: otel.apiLogs.SeverityNumber.INFO,
+        severityText: "INFO",
+        body: "OpenTelemetry log export initialized",
+        attributes: {
+          "service.name": cfg.serviceName,
+        },
+      });
+    }
   }
 
   // eslint-disable-next-line require-await
@@ -319,6 +503,14 @@ class OtlpTracingExporter implements TracingExporter {
   }
 
   async shutdown(): Promise<void> {
+    if (this.logProvider) {
+      try {
+        await this.logProvider.shutdown();
+      } finally {
+        this.logProvider = null;
+      }
+    }
+
     if (this.meterProvider) {
       try {
         await this.meterProvider.shutdown();
@@ -354,25 +546,69 @@ class OpenTelemetryNodeTelemetryProvider implements NodeTelemetryProvider {
   private sdk: { shutdown(): Promise<void> } | null = null;
 
   async initialize(options: NodeTelemetryInitializeOptions): Promise<boolean> {
+    const tracesEnabled = options.tracesEnabled ?? true;
+    const metricsEnabled = options.metricsEnabled ?? false;
+    const logsEnabled = options.logsEnabled ?? false;
+
+    if (!tracesEnabled && !metricsEnabled && !logsEnabled) return false;
+
     const otel = await loadOpenTelemetryRuntime();
     const resource = otel.resources.resourceFromAttributes({
       "service.name": options.serviceName,
       "service.version": options.serviceVersion,
       "deployment.environment": options.deploymentEnvironment,
     });
-    const traceExporter = new otel.traceExporter.OTLPTraceExporter({
-      headers: options.exporterHeaders,
-    });
+
+    const spanProcessors = tracesEnabled
+      ? [
+        new otel.sdkTraceBase.BatchSpanProcessor(
+          new otel.traceExporter.OTLPTraceExporter({
+            url: options.tracesEndpoint,
+            headers: headersOrDefault(options.tracesHeaders, options.exporterHeaders),
+          }),
+          {
+            maxExportBatchSize: 100,
+            scheduledDelayMillis: 500,
+          },
+        ),
+      ]
+      : [];
+
+    const metricReaders = metricsEnabled
+      ? [
+        new otel.sdkMetrics.PeriodicExportingMetricReader({
+          exporter: new otel.metricsExporter.OTLPMetricExporter({
+            url: options.metricsEndpoint,
+            headers: headersOrDefault(options.metricsHeaders, options.exporterHeaders),
+            temporalityPreference: metricTemporalityPreference(
+              otel,
+              options.metricsTemporalityPreference,
+            ),
+          }),
+          exportIntervalMillis: options.metricsExportIntervalMillis ?? 60_000,
+        }),
+      ]
+      : [];
+
+    const logRecordProcessors = logsEnabled
+      ? [
+        new otel.sdkLogs.BatchLogRecordProcessor(
+          new otel.logsExporter.OTLPLogExporter({
+            url: options.logsEndpoint,
+            headers: headersOrDefault(options.logsHeaders, options.exporterHeaders),
+          }),
+        ),
+      ]
+      : [];
 
     const sdk = new otel.sdkNode.NodeSDK({
       resource,
       sampler: new otel.sdkTraceBase.ParentBasedSampler({
         root: new otel.sdkTraceBase.TraceIdRatioBasedSampler(options.samplingRatio),
       }),
-      spanProcessor: new otel.sdkTraceBase.BatchSpanProcessor(traceExporter, {
-        maxExportBatchSize: 100,
-        scheduledDelayMillis: 500,
-      }),
+      spanProcessors,
+      metricReaders,
+      logRecordProcessors,
       instrumentations: [
         otel.autoInstrumentations.getNodeAutoInstrumentations({
           "@opentelemetry/instrumentation-fs": { enabled: options.instrumentation.fs },
@@ -385,9 +621,44 @@ class OpenTelemetryNodeTelemetryProvider implements NodeTelemetryProvider {
     sdk.start();
     this.sdk = sdk;
 
+    if (metricsEnabled) {
+      otel.api.metrics
+        .getMeter(options.serviceName, options.serviceVersion)
+        .createCounter("veryfront.agent.telemetry.startups")
+        .add(1, {
+          "deployment.environment": options.deploymentEnvironment,
+          "service.name": options.serviceName,
+        });
+    }
+
+    if (logsEnabled) {
+      const otelLogger = otel.apiLogs.logs.getLogger(options.serviceName, options.serviceVersion);
+      options.registerLogRecordEmitter?.((record) => {
+        otelLogger.emit({
+          timestamp: record.timestamp ? new Date(record.timestamp) : new Date(),
+          severityNumber: logSeverityNumber(otel, record.level),
+          severityText: record.level?.toUpperCase() ?? "INFO",
+          body: record.message,
+          attributes: logAttributes(record),
+        });
+      });
+      otelLogger.emit({
+        severityNumber: otel.apiLogs.SeverityNumber.INFO,
+        severityText: "INFO",
+        body: "OpenTelemetry log export initialized",
+        attributes: {
+          "deployment.environment": options.deploymentEnvironment,
+          "service.name": options.serviceName,
+        },
+      });
+    }
+
     options.logger?.info("OpenTelemetry initialized", {
       serviceName: options.serviceName,
       samplingRatio: options.samplingRatio,
+      tracesEnabled,
+      metricsEnabled,
+      logsEnabled,
     });
 
     options.processTarget?.on("SIGTERM", async () => {
@@ -432,11 +703,20 @@ const extOpenTelemetry: ExtensionFactory = () => {
           "OTEL_EXPORTER_OTLP_ENDPOINT",
           "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
           "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+          "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
           "OTEL_EXPORTER_OTLP_HEADERS",
+          "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+          "OTEL_EXPORTER_OTLP_METRICS_HEADERS",
+          "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
           "OTEL_SERVICE_NAME",
           "OTEL_TRACES_ENABLED",
           "OTEL_METRICS_ENABLED",
+          "OTEL_LOGS_ENABLED",
+          "OTEL_TRACES_EXPORTER",
+          "OTEL_METRICS_EXPORTER",
+          "OTEL_LOGS_EXPORTER",
           "OTEL_METRIC_EXPORT_INTERVAL",
+          "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE",
         ],
       },
     ],

--- a/src/agent/hosted/agent-run-lifecycle.test.ts
+++ b/src/agent/hosted/agent-run-lifecycle.test.ts
@@ -80,6 +80,12 @@ describe("hosted-agent-run-lifecycle", () => {
       upstreamParentConversationId: "parent-conversation-1",
       upstreamParentRunId: "parent-run-1",
       spawnedFromToolCallId: "tool-call-1",
+      traceAttributes: {
+        "schedule.id": "schedule-1",
+        "schedule.name": "Triage sweep",
+        "run.trigger.kind": "schedule",
+        "run.trigger.id": "schedule-1",
+      },
     });
 
     assertEquals(span.attributes["conversation.id"], "conversation-1");
@@ -89,6 +95,10 @@ describe("hosted-agent-run-lifecycle", () => {
     assertEquals(span.attributes["parent.conversation.id"], "parent-conversation-1");
     assertEquals(span.attributes["parent.run.id"], "parent-run-1");
     assertEquals(span.attributes["tool.call.id"], "tool-call-1");
+    assertEquals(span.attributes["schedule.id"], "schedule-1");
+    assertEquals(span.attributes["schedule.name"], "Triage sweep");
+    assertEquals(span.attributes["run.trigger.kind"], "schedule");
+    assertEquals(span.attributes["run.trigger.id"], "schedule-1");
     assertEquals(span.attributes["gen_ai.operation.name"], "chat");
 
     const value = controller.withContext(() => "ok");

--- a/src/agent/hosted/agent-run-lifecycle.ts
+++ b/src/agent/hosted/agent-run-lifecycle.ts
@@ -61,6 +61,7 @@ export interface CreateHostedAgentRunSpanControllerInput {
   upstreamParentConversationId?: string;
   upstreamParentRunId?: string;
   spawnedFromToolCallId?: string;
+  traceAttributes?: AgentTraceAttributes;
 }
 
 /** Create hosted agent run span controller. */
@@ -82,8 +83,17 @@ export function createHostedAgentRunSpanController(
       parentRunId: input.upstreamParentRunId,
       messageId: input.rootRun?.messageId,
       toolCallId: input.spawnedFromToolCallId,
+      scheduleId: typeof input.traceAttributes?.["schedule.id"] === "string"
+        ? input.traceAttributes["schedule.id"]
+        : null,
+      scheduleName: typeof input.traceAttributes?.["schedule.name"] === "string"
+        ? input.traceAttributes["schedule.name"]
+        : null,
     }),
   );
+  if (input.traceAttributes) {
+    span.setAttributes(input.traceAttributes);
+  }
 
   return {
     withContext: (fn) => span.withContext(fn),

--- a/src/agent/hosted/chat-execution-runtime.ts
+++ b/src/agent/hosted/chat-execution-runtime.ts
@@ -148,6 +148,7 @@ export interface CreateBootstrappedHostedChatExecutionRuntimeInput {
   upstreamParentConversationId?: string;
   upstreamParentRunId?: string;
   spawnedFromToolCallId?: string;
+  traceAttributes?: Parameters<HostedAgentRunSpanController["setAttributes"]>[0];
   tracer: HostedAgentRunTracer;
   resolveProvider: (modelId: string) => string;
   traceStream?: CreateHostedChatExecutionRuntimeBootstrapInput["traceStream"];
@@ -413,6 +414,7 @@ export async function createBootstrappedHostedChatExecutionRuntime(
     upstreamParentConversationId: input.upstreamParentConversationId,
     upstreamParentRunId: input.upstreamParentRunId,
     spawnedFromToolCallId: input.spawnedFromToolCallId,
+    traceAttributes: input.traceAttributes,
   });
 
   try {

--- a/src/agent/hosted/prepared-chat-execution.ts
+++ b/src/agent/hosted/prepared-chat-execution.ts
@@ -5,6 +5,7 @@ import {
   createBootstrappedHostedChatExecutionRuntime,
   type CreateBootstrappedHostedChatExecutionRuntimeInput,
 } from "./chat-execution-runtime.ts";
+import type { HostedAgentRunSpanFinalState } from "./agent-run-lifecycle.ts";
 import { runHostedLifecycle } from "./lifecycle.ts";
 import type { AgUiRuntimeRequest } from "../runtime/ag-ui-contract.ts";
 
@@ -77,6 +78,7 @@ function tracePreparedHostedChatExecution<TResult>(input: {
       "conversation.id": input.execution.conversationId,
       "project.id": input.execution.projectId ?? "none",
       "agent.runtime.kind": input.execution.runtimeKind,
+      ...input.execution.traceAttributes,
     });
     return await input.run();
   };
@@ -172,8 +174,8 @@ export async function runPreparedHostedChatExecutionDetached<
         });
 
       try {
-        await agentRunSpan.withContext(async () => {
-          await runHostedLifecycle({
+        const result = await agentRunSpan.withContext(async () => {
+          return await runHostedLifecycle({
             abortSignal: input.execution.abortSignal,
             execution: {
               stream: execution.agentUIStream,
@@ -189,7 +191,17 @@ export async function runPreparedHostedChatExecutionDetached<
             }),
           });
         });
+        agentRunSpan.finalize({ status: result.terminalState.status });
       } catch (error) {
+        const finalStatus: HostedAgentRunSpanFinalState["status"] = input.execution.abortSignal
+            .aborted
+          ? "cancelled"
+          : "failed";
+        agentRunSpan.finalize({
+          status: finalStatus,
+          terminalErrorCode: finalStatus === "cancelled" ? "ABORTED" : "STREAM_ERROR",
+          terminalErrorMessage: error instanceof Error ? error.message : String(error),
+        });
         input.runtime.logger?.error("Detached durable chat execution failed", {
           conversationId: input.execution.conversationId,
           runId: input.execution.rootRunContext.durableRootRun?.runId,

--- a/src/agent/hosted/trace-attributes.test.ts
+++ b/src/agent/hosted/trace-attributes.test.ts
@@ -6,6 +6,7 @@ import {
   buildExecuteToolTraceAttributes,
   buildFinalizedAgentRunTraceAttributes,
   buildInvokeAgentTraceAttributes,
+  buildScheduleTraceAttributes,
   filterAgentTraceAttributes,
   isAgentTraceAttributeValue,
 } from "../index.ts";
@@ -48,6 +49,8 @@ describe("agent/agent-trace-attributes", () => {
         parentConversationId: "conversation-parent",
         messageId: "message-1",
         toolCallId: "tool-call-1",
+        scheduleId: "schedule-1",
+        scheduleName: "Triage sweep",
       }),
       {
         "conversation.id": "conversation-1",
@@ -59,9 +62,29 @@ describe("agent/agent-trace-attributes", () => {
         "parent.conversation.id": "conversation-parent",
         "message.id": "message-1",
         "tool.call.id": "tool-call-1",
+        "schedule.id": "schedule-1",
+        "schedule.name": "Triage sweep",
+        "run.trigger.kind": "schedule",
+        "run.trigger.id": "schedule-1",
         "gen_ai.operation.name": "chat",
         "gen_ai.conversation.id": "conversation-1",
         "gen_ai.agent.id": "builder",
+      },
+    );
+  });
+
+  it("builds schedule trigger attributes from forwarded props", () => {
+    assertEquals(
+      buildScheduleTraceAttributes({
+        schedule_id: "schedule-1",
+        schedule_name: "Triage sweep",
+        unrelated: { nested: true },
+      }),
+      {
+        "schedule.id": "schedule-1",
+        "schedule.name": "Triage sweep",
+        "run.trigger.kind": "schedule",
+        "run.trigger.id": "schedule-1",
       },
     );
   });

--- a/src/agent/hosted/trace-attributes.ts
+++ b/src/agent/hosted/trace-attributes.ts
@@ -24,6 +24,10 @@ function compactTraceAttributes(attributes: AgentTraceAttributes): AgentTraceAtt
   );
 }
 
+function getNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
 function isAgentTraceAttributePrimitive(value: unknown): value is TracePrimitive {
   return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
 }
@@ -50,6 +54,23 @@ export function filterAgentTraceAttributes(
   }
 
   return traceAttributes;
+}
+
+/** Builds schedule trigger trace attributes from schedule forwarded props. */
+export function buildScheduleTraceAttributes(
+  forwardedProps?: Record<string, unknown>,
+): AgentTraceAttributes {
+  const scheduleId = getNonEmptyString(forwardedProps?.schedule_id) ??
+    getNonEmptyString(forwardedProps?.scheduleId);
+  const scheduleName = getNonEmptyString(forwardedProps?.schedule_name) ??
+    getNonEmptyString(forwardedProps?.scheduleName);
+
+  return compactTraceAttributes({
+    "schedule.id": scheduleId,
+    "schedule.name": scheduleName,
+    "run.trigger.kind": scheduleId ? "schedule" : undefined,
+    "run.trigger.id": scheduleId,
+  });
 }
 
 function resolveGenAiProviderName(modelId: string | null | undefined): string | null {
@@ -107,6 +128,8 @@ export function buildAgentRunTraceAttributes(input: {
   parentConversationId?: string | null;
   messageId?: string | null;
   toolCallId?: string | null;
+  scheduleId?: string | null;
+  scheduleName?: string | null;
 }): AgentTraceAttributes {
   return compactTraceAttributes({
     "conversation.id": input.conversationId,
@@ -118,6 +141,10 @@ export function buildAgentRunTraceAttributes(input: {
     "parent.conversation.id": input.parentConversationId,
     "message.id": input.messageId,
     "tool.call.id": input.toolCallId,
+    "schedule.id": input.scheduleId,
+    "schedule.name": input.scheduleName,
+    "run.trigger.kind": input.scheduleId ? "schedule" : undefined,
+    "run.trigger.id": input.scheduleId,
     "gen_ai.operation.name": input.operationName,
     "gen_ai.conversation.id": input.conversationId,
     "gen_ai.agent.id": input.agentId,

--- a/src/agent/hosted/veryfront-cloud-agent-service.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.ts
@@ -45,6 +45,7 @@ import { __registerTraceContextGetter } from "../../utils/logger/logger.ts";
 import {
   buildAgentRunTraceAttributes,
   buildExecuteToolTraceAttributes,
+  buildScheduleTraceAttributes,
   filterAgentTraceAttributes,
 } from "./trace-attributes.ts";
 import {
@@ -835,8 +836,10 @@ function setPrepareChatExecutionResultAttributes(
     upstreamParentRunId?: string;
     spawnedFromToolCallId?: string;
     runtimeKind: "framework";
+    forwardedProps?: Record<string, unknown>;
   },
 ): void {
+  const scheduleTraceAttributes = buildScheduleTraceAttributes(input.forwardedProps);
   const span = context.infrastructure.tracer.scope().active();
   span?.setAttributes(
     buildAgentRunTraceAttributes({
@@ -849,10 +852,17 @@ function setPrepareChatExecutionResultAttributes(
       parentConversationId: input.upstreamParentConversationId,
       parentRunId: input.upstreamParentRunId,
       toolCallId: input.spawnedFromToolCallId,
+      scheduleId: typeof scheduleTraceAttributes["schedule.id"] === "string"
+        ? scheduleTraceAttributes["schedule.id"]
+        : null,
+      scheduleName: typeof scheduleTraceAttributes["schedule.name"] === "string"
+        ? scheduleTraceAttributes["schedule.name"]
+        : null,
     }),
   );
   span?.setAttributes({
     "agent.runtime.kind": input.runtimeKind,
+    ...scheduleTraceAttributes,
   });
 }
 
@@ -969,6 +979,7 @@ async function prepareChatExecution(
     upstreamParentRunId,
     spawnedFromToolCallId,
     runtimeKind,
+    forwardedProps: req.forwardedProps,
   });
 
   return {
@@ -988,6 +999,7 @@ async function prepareChatExecution(
     upstreamParentConversationId,
     upstreamParentRunId,
     spawnedFromToolCallId,
+    traceAttributes: buildScheduleTraceAttributes(req.forwardedProps),
   };
 }
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -542,6 +542,7 @@ export {
   buildExecuteToolTraceAttributes,
   buildFinalizedAgentRunTraceAttributes,
   buildInvokeAgentTraceAttributes,
+  buildScheduleTraceAttributes,
   filterAgentTraceAttributes,
   isAgentTraceAttributeValue,
 } from "./hosted/trace-attributes.ts";

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -35,6 +35,10 @@ import {
   setSpanAttributes,
   withSpan,
 } from "#veryfront/observability/tracing/index.ts";
+import {
+  setActiveSpanAttributes as setOtelActiveSpanAttributes,
+  withSpan as withOtelSpan,
+} from "#veryfront/observability/tracing/otlp-setup.ts";
 import { convertToTextGenerationRuntimeRequestMessages } from "./text-generation-runtime-message-converter.ts";
 import { convertToolsToRuntimeTools } from "./model-tool-converter.ts";
 import { getRuntimeRemoteToolSources } from "./mcp-server-tool-sources.ts";
@@ -146,7 +150,12 @@ export {
 
 import { DEFAULT_MAX_TOKENS, DEFAULT_TEMPERATURE, getModelMaxOutputTokens } from "./constants.ts";
 import { closeSSEStream, generateMessageId, sendSSE } from "./sse-utils.ts";
-import { executeConfiguredTool, getAvailableTools, isDynamicTool } from "./tool-helpers.ts";
+import {
+  executeConfiguredTool,
+  getAvailableTools,
+  isDynamicTool,
+  type ToolConfigEntry,
+} from "./tool-helpers.ts";
 import { accumulateUsage, getMaxSteps, normalizeInput } from "./input-utils.ts";
 import { resolveRuntimeModel } from "./model-resolution.ts";
 import type { RuntimeGenerateToolResult } from "./runtime-tool-types.ts";
@@ -248,6 +257,146 @@ function containsSubmittedFormInputExecutionResult(result: unknown, depth = 0): 
 
 function isSubmittedFormInputExecutionResult(toolName: string, result: unknown): boolean {
   return toolName === FORM_INPUT_TOOL_ID && containsSubmittedFormInputExecutionResult(result);
+}
+
+type RuntimeTraceAttributes = Record<string, string | number | boolean | undefined | null>;
+
+function compactRuntimeTraceAttributes(
+  attributes: RuntimeTraceAttributes,
+): Record<string, string | number | boolean> {
+  return Object.fromEntries(
+    Object.entries(attributes).filter(([, value]) =>
+      typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+    ),
+  ) as Record<string, string | number | boolean>;
+}
+
+function buildRuntimeToolTraceAttributes(input: {
+  mode: "generate" | "stream";
+  agentId: string;
+  toolName: string;
+  toolCallId: string;
+  context?: ToolExecutionContext;
+  status?: "executing" | "completed" | "failed";
+  providerExecuted?: boolean;
+}): Record<string, string | number | boolean> {
+  return compactRuntimeTraceAttributes({
+    "agent.id": input.agentId,
+    "run.id": input.context?.runId,
+    "project.id": input.context?.projectId,
+    "project.slug": input.context?.projectSlug,
+    "tool.name": input.toolName,
+    "tool.call.id": input.toolCallId,
+    "tool.id": input.toolCallId,
+    "agent.tool.execution_mode": input.mode,
+    "agent.tool.status": input.status,
+    "agent.tool.provider_executed": input.providerExecuted,
+    "gen_ai.operation.name": "execute_tool",
+    "gen_ai.agent.id": input.agentId,
+    "gen_ai.tool.name": input.toolName,
+    "gen_ai.tool.type": "function",
+    "gen_ai.tool.call.id": input.toolCallId,
+  });
+}
+
+async function traceConfiguredToolExecution(input: {
+  mode: "generate" | "stream";
+  agentId: string;
+  toolName: string;
+  toolCallId: string;
+  args: Record<string, unknown>;
+  toolsConfig: true | Record<string, ToolConfigEntry> | undefined;
+  context: ToolExecutionContext;
+  allowedRemoteToolNames: string[] | undefined;
+  remoteToolSources: ReturnType<typeof getRuntimeRemoteToolSources>;
+}): Promise<unknown> {
+  return await withOtelSpan(
+    "agent.tool_execute",
+    async () => {
+      setOtelActiveSpanAttributes(
+        buildRuntimeToolTraceAttributes({
+          mode: input.mode,
+          agentId: input.agentId,
+          toolName: input.toolName,
+          toolCallId: input.toolCallId,
+          context: input.context,
+          status: "executing",
+          providerExecuted: false,
+        }),
+      );
+      try {
+        const result = await executeConfiguredTool(
+          input.toolName,
+          input.args,
+          input.toolsConfig,
+          input.context,
+          input.allowedRemoteToolNames,
+          input.remoteToolSources,
+        );
+        setOtelActiveSpanAttributes(
+          buildRuntimeToolTraceAttributes({
+            mode: input.mode,
+            agentId: input.agentId,
+            toolName: input.toolName,
+            toolCallId: input.toolCallId,
+            context: input.context,
+            status: "completed",
+            providerExecuted: false,
+          }),
+        );
+        return result;
+      } catch (error) {
+        setOtelActiveSpanAttributes({
+          ...buildRuntimeToolTraceAttributes({
+            mode: input.mode,
+            agentId: input.agentId,
+            toolName: input.toolName,
+            toolCallId: input.toolCallId,
+            context: input.context,
+            status: "failed",
+            providerExecuted: false,
+          }),
+          "error.message": error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
+    },
+    buildRuntimeToolTraceAttributes({
+      mode: input.mode,
+      agentId: input.agentId,
+      toolName: input.toolName,
+      toolCallId: input.toolCallId,
+      context: input.context,
+      status: "executing",
+      providerExecuted: false,
+    }),
+  );
+}
+
+async function traceProviderExecutedTool(input: {
+  mode: "generate" | "stream";
+  agentId: string;
+  toolName: string;
+  toolCallId: string;
+  context?: ToolExecutionContext;
+}): Promise<void> {
+  await withOtelSpan(
+    "agent.tool_execute",
+    async () => {
+      setOtelActiveSpanAttributes(
+        buildRuntimeToolTraceAttributes({
+          ...input,
+          status: "completed",
+          providerExecuted: true,
+        }),
+      );
+    },
+    buildRuntimeToolTraceAttributes({
+      ...input,
+      status: "completed",
+      providerExecuted: true,
+    }),
+  );
 }
 
 function markSubmittedFormInputRuntimeContext(
@@ -793,6 +942,19 @@ export class AgentRuntime {
             setSpanAttributes(toolSpan, { "tool.name": tc.toolName, "tool.id": tc.toolCallId });
 
             if (generatedToolResult) {
+              if (generatedToolResult.providerExecuted === true) {
+                await traceProviderExecutedTool({
+                  mode: "generate",
+                  agentId: this.id,
+                  toolName: tc.toolName,
+                  toolCallId: tc.toolCallId,
+                  context: {
+                    toolCallId: tc.toolCallId,
+                    ...toolContext,
+                    agentId: this.id,
+                  },
+                });
+              }
               await persistGeneratedToolResult(generatedToolResult);
               toolCall.status = generatedToolResult.isError === true ? "error" : "completed";
               toolCall.result = generatedToolResult.result;
@@ -851,14 +1013,17 @@ export class AgentRuntime {
                 // spreads so caller-supplied context cannot spoof it.
                 agentId: this.id,
               };
-              const result = await executeConfiguredTool(
-                tc.toolName,
-                toolCall.args,
-                this.config.tools,
-                executionContext,
+              const result = await traceConfiguredToolExecution({
+                mode: "generate",
+                agentId: this.id,
+                toolName: tc.toolName,
+                toolCallId: tc.toolCallId,
+                args: toolCall.args,
+                toolsConfig: this.config.tools,
+                context: executionContext,
                 allowedRemoteToolNames,
                 remoteToolSources,
-              );
+              });
               await this.notifyToolResult({
                 mode: "generate",
                 toolName: tc.toolName,
@@ -1287,6 +1452,17 @@ export class AgentRuntime {
         }
 
         if (tc.providerExecuted === true) {
+          await traceProviderExecutedTool({
+            mode: "stream",
+            agentId: this.id,
+            toolName: tc.name,
+            toolCallId: tc.id,
+            context: {
+              toolCallId: tc.id,
+              ...toolContext,
+              agentId: this.id,
+            },
+          });
           toolCall.status = "completed";
           toolCalls.push(toolCall);
           continue;
@@ -1356,14 +1532,17 @@ export class AgentRuntime {
             // spread so caller-supplied context cannot spoof it.
             agentId: this.id,
           };
-          const result = await executeConfiguredTool(
-            tc.name,
-            toolCall.args,
-            this.config.tools,
-            executionContext,
+          const result = await traceConfiguredToolExecution({
+            mode: "stream",
+            agentId: this.id,
+            toolName: tc.name,
+            toolCallId: tc.id,
+            args: toolCall.args,
+            toolsConfig: this.config.tools,
+            context: executionContext,
             allowedRemoteToolNames,
             remoteToolSources,
-          );
+          });
           throwIfAborted(abortSignal);
           await this.notifyToolResult({
             mode: "stream",

--- a/src/agent/service/node-runtime-infrastructure.ts
+++ b/src/agent/service/node-runtime-infrastructure.ts
@@ -3,7 +3,7 @@ import {
   createOpenTelemetryServiceTracer,
   type ServiceTracerAttributes,
 } from "../../observability/tracing/service-tracer.ts";
-import { agentLogger, type Logger } from "../../utils/logger/index.ts";
+import { __registerLogRecordEmitter, agentLogger, type Logger } from "../../utils/logger/index.ts";
 import {
   type AgentServiceConfig,
   type AgentServiceConfigInput,
@@ -68,6 +68,7 @@ export function createNodeAgentServiceRuntimeInfrastructure(
         ...telemetryConfig,
         logger: options.telemetryLogger,
         processTarget: options.processTarget,
+        registerLogRecordEmitter: __registerLogRecordEmitter,
       }),
   };
 }

--- a/src/agent/service/node-telemetry.test.ts
+++ b/src/agent/service/node-telemetry.test.ts
@@ -31,6 +31,17 @@ describe("agent/node-agent-service-telemetry", () => {
       deploymentEnvironment: "production",
       samplingRatio: 1,
       exporterHeaders: undefined,
+      tracesEnabled: true,
+      metricsEnabled: false,
+      logsEnabled: false,
+      tracesEndpoint: undefined,
+      metricsEndpoint: undefined,
+      logsEndpoint: undefined,
+      tracesHeaders: undefined,
+      metricsHeaders: undefined,
+      logsHeaders: undefined,
+      metricsExportIntervalMillis: 60000,
+      metricsTemporalityPreference: "delta",
       instrumentation: {
         http: true,
         express: true,
@@ -48,6 +59,11 @@ describe("agent/node-agent-service-telemetry", () => {
         OTEL_SERVICE_NAME: "custom-agent",
         OTEL_SAMPLING_RATIO: "0.5",
         OTEL_EXPORTER_OTLP_HEADERS: "x-api-key=secret,x-tenant=myorg",
+        OTEL_EXPORTER_OTLP_ENDPOINT: "https://collector.example/otlp",
+        OTEL_EXPORTER_OTLP_LOGS_HEADERS: "x-log-route=logs",
+        OTEL_METRICS_ENABLED: "true",
+        OTEL_LOGS_EXPORTER: "otlp",
+        OTEL_METRIC_EXPORT_INTERVAL: "15000",
         OTEL_INSTRUMENTATION_HTTP: "false",
         OTEL_INSTRUMENTATION_EXPRESS: "false",
         OTEL_INSTRUMENTATION_FS: "true",
@@ -62,6 +78,21 @@ describe("agent/node-agent-service-telemetry", () => {
       deploymentEnvironment: "test",
       samplingRatio: 0.5,
       exporterHeaders: { "x-api-key": "secret", "x-tenant": "myorg" },
+      tracesEnabled: true,
+      metricsEnabled: true,
+      logsEnabled: true,
+      tracesEndpoint: "https://collector.example/otlp/v1/traces",
+      metricsEndpoint: "https://collector.example/otlp/v1/metrics",
+      logsEndpoint: "https://collector.example/otlp/v1/logs",
+      tracesHeaders: { "x-api-key": "secret", "x-tenant": "myorg" },
+      metricsHeaders: { "x-api-key": "secret", "x-tenant": "myorg" },
+      logsHeaders: {
+        "x-api-key": "secret",
+        "x-tenant": "myorg",
+        "x-log-route": "logs",
+      },
+      metricsExportIntervalMillis: 15000,
+      metricsTemporalityPreference: "delta",
       instrumentation: {
         http: false,
         express: false,
@@ -109,6 +140,34 @@ describe("agent/node-agent-service-telemetry", () => {
     assertEquals(config.exporterHeaders, { Authorization: "Basic dXNlcjpwYXNz" });
   });
 
+  it("supports signal-specific OTLP endpoint overrides and metrics temporality", () => {
+    const config = resolveNodeHostedAgentServiceTelemetryConfig({
+      env: {
+        OTEL_ENABLED: "false",
+        OTEL_TRACES_ENABLED: "false",
+        OTEL_METRICS_EXPORTER: "otlp",
+        OTEL_LOGS_ENABLED: "true",
+        OTEL_EXPORTER_OTLP_ENDPOINT: "https://collector.example/base",
+        OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://metrics.example/v1/metrics",
+        OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "https://logs.example",
+        OTEL_EXPORTER_OTLP_HEADERS: "dd-api-key=global",
+        OTEL_EXPORTER_OTLP_METRICS_HEADERS: "dd-api-key=metrics",
+        OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: "cumulative",
+      },
+      defaultServiceName: "agent-service",
+    });
+
+    assertEquals(config.enabled, true);
+    assertEquals(config.tracesEnabled, false);
+    assertEquals(config.metricsEnabled, true);
+    assertEquals(config.logsEnabled, true);
+    assertEquals(config.metricsEndpoint, "https://metrics.example/v1/metrics");
+    assertEquals(config.logsEndpoint, "https://logs.example/v1/logs");
+    assertEquals(config.metricsHeaders, { "dd-api-key": "metrics" });
+    assertEquals(config.logsHeaders, { "dd-api-key": "global" });
+    assertEquals(config.metricsTemporalityPreference, "cumulative");
+  });
+
   it("delegates enabled telemetry initialization to a NodeTelemetryProvider", async () => {
     const calls: unknown[] = [];
     const result = await initializeNodeAgentServiceOpenTelemetry({
@@ -118,11 +177,20 @@ describe("agent/node-agent-service-telemetry", () => {
       deploymentEnvironment: "production",
       samplingRatio: 0.5,
       exporterHeaders: { "x-api-key": "redacted" },
+      tracesEnabled: true,
+      metricsEnabled: true,
+      logsEnabled: true,
+      tracesEndpoint: "https://collector.example/v1/traces",
+      metricsEndpoint: "https://collector.example/v1/metrics",
+      logsEndpoint: "https://collector.example/v1/logs",
+      metricsExportIntervalMillis: 10000,
+      metricsTemporalityPreference: "delta",
       instrumentation: {
         http: true,
         express: false,
         fs: true,
       },
+      registerLogRecordEmitter: () => {},
       telemetryProvider: {
         initialize(options) {
           calls.push(options);
@@ -139,6 +207,17 @@ describe("agent/node-agent-service-telemetry", () => {
         deploymentEnvironment: "production",
         samplingRatio: 0.5,
         exporterHeaders: { "x-api-key": "redacted" },
+        tracesEnabled: true,
+        metricsEnabled: true,
+        logsEnabled: true,
+        tracesEndpoint: "https://collector.example/v1/traces",
+        metricsEndpoint: "https://collector.example/v1/metrics",
+        logsEndpoint: "https://collector.example/v1/logs",
+        tracesHeaders: undefined,
+        metricsHeaders: undefined,
+        logsHeaders: undefined,
+        metricsExportIntervalMillis: 10000,
+        metricsTemporalityPreference: "delta",
         instrumentation: {
           http: true,
           express: false,
@@ -146,6 +225,8 @@ describe("agent/node-agent-service-telemetry", () => {
         },
         logger: undefined,
         processTarget: undefined,
+        registerLogRecordEmitter: calls[0] &&
+          (calls[0] as { registerLogRecordEmitter?: unknown }).registerLogRecordEmitter,
       },
     ]);
   });

--- a/src/agent/service/node-telemetry.ts
+++ b/src/agent/service/node-telemetry.ts
@@ -3,6 +3,7 @@ import {
   type NodeTelemetryInitializeOptions,
   type NodeTelemetryInstrumentationConfig,
   type NodeTelemetryLogger,
+  type NodeTelemetryLogRecordEmitter,
   type NodeTelemetryProcessTarget,
   type NodeTelemetryProvider,
   NodeTelemetryProviderName,
@@ -28,6 +29,17 @@ export type NodeHostedAgentServiceTelemetryConfig = {
   deploymentEnvironment: string;
   samplingRatio: number;
   exporterHeaders?: Record<string, string>;
+  tracesEnabled: boolean;
+  metricsEnabled: boolean;
+  logsEnabled: boolean;
+  tracesEndpoint?: string;
+  metricsEndpoint?: string;
+  logsEndpoint?: string;
+  tracesHeaders?: Record<string, string>;
+  metricsHeaders?: Record<string, string>;
+  logsHeaders?: Record<string, string>;
+  metricsExportIntervalMillis: number;
+  metricsTemporalityPreference: "delta" | "cumulative" | "lowmemory";
   instrumentation: NodeHostedAgentServiceInstrumentationConfig;
 };
 
@@ -65,6 +77,7 @@ export type InitializeNodeHostedAgentServiceTelemetryOptions =
     logger?: NodeHostedAgentServiceTelemetryLogger;
     processTarget?: NodeHostedAgentServiceTelemetryProcessTarget;
     telemetryProvider?: NodeTelemetryProvider;
+    registerLogRecordEmitter?: (emitter: NodeTelemetryLogRecordEmitter) => void;
   };
 
 /** Options accepted by initialize node agent service telemetry. */
@@ -77,6 +90,40 @@ function resolveEnabled(env: NodeHostedAgentServiceTelemetryEnv, defaultEnabled:
     return envValue !== "false" && envValue !== "0";
   }
   return defaultEnabled;
+}
+
+function isTruthySignalFlag(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  return value === "true" || value === "1";
+}
+
+function exporterIncludesOtlp(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (value === "none") return false;
+  return value.split(",").map((part) => part.trim()).includes("otlp");
+}
+
+function resolveTraceSignalEnabled(
+  env: NodeHostedAgentServiceTelemetryEnv,
+  defaultEnabled: boolean,
+): boolean {
+  const enabledFlag = isTruthySignalFlag(env.OTEL_TRACES_ENABLED);
+  if (enabledFlag !== undefined) return enabledFlag;
+  const exporterFlag = exporterIncludesOtlp(env.OTEL_TRACES_EXPORTER);
+  if (exporterFlag !== undefined) return exporterFlag;
+  return defaultEnabled;
+}
+
+function resolveMetricSignalEnabled(env: NodeHostedAgentServiceTelemetryEnv): boolean {
+  const enabledFlag = isTruthySignalFlag(env.OTEL_METRICS_ENABLED);
+  if (enabledFlag !== undefined) return enabledFlag;
+  return exporterIncludesOtlp(env.OTEL_METRICS_EXPORTER) ?? false;
+}
+
+function resolveLogSignalEnabled(env: NodeHostedAgentServiceTelemetryEnv): boolean {
+  const enabledFlag = isTruthySignalFlag(env.OTEL_LOGS_ENABLED);
+  if (enabledFlag !== undefined) return enabledFlag;
+  return exporterIncludesOtlp(env.OTEL_LOGS_EXPORTER) ?? false;
 }
 
 function resolveSamplingRatio(env: NodeHostedAgentServiceTelemetryEnv): number {
@@ -112,6 +159,47 @@ function parseExporterHeaders(headersEnv: string | undefined): Record<string, st
   return Object.keys(headers).length > 0 ? headers : undefined;
 }
 
+function mergeHeaders(
+  base: Record<string, string> | undefined,
+  override: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!base && !override) return undefined;
+  return { ...(base ?? {}), ...(override ?? {}) };
+}
+
+function resolveSignalHeaders(
+  env: NodeHostedAgentServiceTelemetryEnv,
+  signal: "TRACES" | "METRICS" | "LOGS",
+): Record<string, string> | undefined {
+  return mergeHeaders(
+    parseExporterHeaders(env.OTEL_EXPORTER_OTLP_HEADERS),
+    parseExporterHeaders(env[`OTEL_EXPORTER_OTLP_${signal}_HEADERS`]),
+  );
+}
+
+function resolveOtlpSignalEndpoint(
+  endpoint: string | undefined,
+  signal: "traces" | "metrics" | "logs",
+): string | undefined {
+  if (!endpoint) return undefined;
+  const trimmed = endpoint.replace(/\/$/, "");
+  const suffix = `/v1/${signal}`;
+  return trimmed.endsWith(suffix) ? trimmed : `${trimmed}${suffix}`;
+}
+
+function resolveMetricsExportIntervalMillis(env: NodeHostedAgentServiceTelemetryEnv): number {
+  const value = Number.parseInt(env.OTEL_METRIC_EXPORT_INTERVAL ?? "", 10);
+  return Number.isFinite(value) && value > 0 ? value : 60_000;
+}
+
+function resolveMetricsTemporalityPreference(
+  env: NodeHostedAgentServiceTelemetryEnv,
+): "delta" | "cumulative" | "lowmemory" {
+  const value = env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE?.toLowerCase();
+  if (value === "cumulative" || value === "lowmemory") return value;
+  return "delta";
+}
+
 function resolveInstrumentationConfig(
   env: NodeHostedAgentServiceTelemetryEnv,
 ): NodeHostedAgentServiceInstrumentationConfig {
@@ -127,14 +215,42 @@ export function resolveNodeHostedAgentServiceTelemetryConfig(
   options: ResolveNodeHostedAgentServiceTelemetryConfigOptions,
 ): NodeHostedAgentServiceTelemetryConfig {
   const defaultEnabled = options.defaultEnabled ?? options.env.NODE_ENV === "production";
+  const tracesEnabled = resolveTraceSignalEnabled(
+    options.env,
+    resolveEnabled(options.env, defaultEnabled),
+  );
+  const metricsEnabled = resolveMetricSignalEnabled(options.env);
+  const logsEnabled = resolveLogSignalEnabled(options.env);
+  const baseEndpoint = options.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  const exporterHeaders = parseExporterHeaders(options.env.OTEL_EXPORTER_OTLP_HEADERS);
 
   return {
-    enabled: resolveEnabled(options.env, defaultEnabled),
+    enabled: tracesEnabled || metricsEnabled || logsEnabled,
     serviceName: options.env.OTEL_SERVICE_NAME ?? options.defaultServiceName,
     serviceVersion: options.env.npm_package_version ?? options.defaultServiceVersion ?? "0.1.0",
     deploymentEnvironment: resolveDeploymentEnvironment(options.env),
     samplingRatio: resolveSamplingRatio(options.env),
-    exporterHeaders: parseExporterHeaders(options.env.OTEL_EXPORTER_OTLP_HEADERS),
+    exporterHeaders,
+    tracesEnabled,
+    metricsEnabled,
+    logsEnabled,
+    tracesEndpoint: resolveOtlpSignalEndpoint(
+      options.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ?? baseEndpoint,
+      "traces",
+    ),
+    metricsEndpoint: resolveOtlpSignalEndpoint(
+      options.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT ?? baseEndpoint,
+      "metrics",
+    ),
+    logsEndpoint: resolveOtlpSignalEndpoint(
+      options.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT ?? baseEndpoint,
+      "logs",
+    ),
+    tracesHeaders: resolveSignalHeaders(options.env, "TRACES"),
+    metricsHeaders: resolveSignalHeaders(options.env, "METRICS"),
+    logsHeaders: resolveSignalHeaders(options.env, "LOGS"),
+    metricsExportIntervalMillis: resolveMetricsExportIntervalMillis(options.env),
+    metricsTemporalityPreference: resolveMetricsTemporalityPreference(options.env),
     instrumentation: resolveInstrumentationConfig(options.env),
   };
 }
@@ -203,9 +319,21 @@ export async function initializeNodeHostedAgentServiceOpenTelemetry(
       deploymentEnvironment: options.deploymentEnvironment,
       samplingRatio: options.samplingRatio,
       exporterHeaders: options.exporterHeaders,
+      tracesEnabled: options.tracesEnabled,
+      metricsEnabled: options.metricsEnabled,
+      logsEnabled: options.logsEnabled,
+      tracesEndpoint: options.tracesEndpoint,
+      metricsEndpoint: options.metricsEndpoint,
+      logsEndpoint: options.logsEndpoint,
+      tracesHeaders: options.tracesHeaders,
+      metricsHeaders: options.metricsHeaders,
+      logsHeaders: options.logsHeaders,
+      metricsExportIntervalMillis: options.metricsExportIntervalMillis,
+      metricsTemporalityPreference: options.metricsTemporalityPreference,
       instrumentation: options.instrumentation,
       logger: options.logger,
       processTarget: options.processTarget,
+      registerLogRecordEmitter: options.registerLogRecordEmitter,
     };
 
     return await telemetryProvider.initialize(initializeOptions);

--- a/src/extensions/observability/index.ts
+++ b/src/extensions/observability/index.ts
@@ -9,6 +9,8 @@ export type {
   NodeTelemetryInitializeOptions,
   NodeTelemetryInstrumentationConfig,
   NodeTelemetryLogger,
+  NodeTelemetryLogRecord,
+  NodeTelemetryLogRecordEmitter,
   NodeTelemetryProcessTarget,
   NodeTelemetryProvider,
 } from "./node-telemetry-provider.ts";

--- a/src/extensions/observability/node-telemetry-provider.ts
+++ b/src/extensions/observability/node-telemetry-provider.ts
@@ -26,6 +26,22 @@ export type NodeTelemetryProcessTarget = {
   on(event: "SIGTERM", listener: () => void | Promise<void>): unknown;
 };
 
+/** Structured log record shape accepted by the telemetry provider. */
+export type NodeTelemetryLogRecord = {
+  timestamp?: string;
+  level?: string;
+  service?: string;
+  message: string;
+  component?: string;
+  context?: Record<string, unknown>;
+  error?: unknown;
+  trace_id?: string;
+  span_id?: string;
+};
+
+/** Emits a structured logger record into the active telemetry pipeline. */
+export type NodeTelemetryLogRecordEmitter = (record: NodeTelemetryLogRecord) => void;
+
 /** Options accepted by node telemetry initialize. */
 export type NodeTelemetryInitializeOptions = {
   serviceName: string;
@@ -33,9 +49,21 @@ export type NodeTelemetryInitializeOptions = {
   deploymentEnvironment: string;
   samplingRatio: number;
   exporterHeaders?: Record<string, string>;
+  tracesEnabled?: boolean;
+  metricsEnabled?: boolean;
+  logsEnabled?: boolean;
+  tracesEndpoint?: string;
+  metricsEndpoint?: string;
+  logsEndpoint?: string;
+  tracesHeaders?: Record<string, string>;
+  metricsHeaders?: Record<string, string>;
+  logsHeaders?: Record<string, string>;
+  metricsExportIntervalMillis?: number;
+  metricsTemporalityPreference?: "delta" | "cumulative" | "lowmemory";
   instrumentation: NodeTelemetryInstrumentationConfig;
   logger?: NodeTelemetryLogger;
   processTarget?: NodeTelemetryProcessTarget;
+  registerLogRecordEmitter?: (emitter: NodeTelemetryLogRecordEmitter) => void;
 };
 
 /**

--- a/src/utils/logger/index.ts
+++ b/src/utils/logger/index.ts
@@ -5,9 +5,11 @@
  */
 
 export {
+  __registerLogRecordEmitter,
   __registerRequestContextGetter,
   __registerTraceContextGetter,
   __resetLoggerConfigForTests,
+  __resetLogRecordEmitterForTests,
   __resetTraceContextGetterForTests,
   agentLogger,
   bundlerLogger,

--- a/src/utils/logger/logger.ts
+++ b/src/utils/logger/logger.ts
@@ -105,6 +105,8 @@ type ConsoleLoggerOptions = {
   injectTraceContext?: boolean;
 };
 
+type LogRecordEmitter = (entry: LogEntry) => void;
+
 // ---- Config helpers (must be declared before the eager init below) ----
 
 const LOG_LEVEL_MAP: Readonly<Record<string, LogLevel>> = {
@@ -159,6 +161,8 @@ let loggerConfig: LoggerConfig = {
   format: getDefaultFormat(),
 };
 
+let logRecordEmitter: LogRecordEmitter | null = null;
+
 /**
  * Re-read logger configuration from environment variables.
  * Call after loading .env files so the logger picks up any overrides.
@@ -172,6 +176,16 @@ export function refreshLoggerConfig(): void {
 
 /** @internal Alias kept for tests. */
 export const __resetLoggerConfigForTests = refreshLoggerConfig;
+
+/** Register a process-level structured log emitter, for example an OTel bridge. */
+export function __registerLogRecordEmitter(emitter: LogRecordEmitter | null): void {
+  logRecordEmitter = emitter;
+}
+
+/** Reset the process-level structured log emitter. Only intended for tests. */
+export function __resetLogRecordEmitterForTests(): void {
+  logRecordEmitter = null;
+}
 
 function resolveLoggerConfig(): LoggerConfig {
   return loggerConfig;
@@ -279,7 +293,7 @@ class ConsoleLogger implements Logger {
     return new ConsoleLogger(this.prefix, { ...this.boundContext }, name, this.options);
   }
 
-  private formatJson(level: LogEntry["level"], message: string, args: unknown[]): string {
+  private createEntry(level: LogEntry["level"], message: string, args: unknown[]): LogEntry {
     const { context, error } = extractContext(args);
     const mergedContext: Record<string, unknown> = { ...this.boundContext, ...context };
 
@@ -362,6 +376,11 @@ class ConsoleLogger implements Logger {
     // URIs, ?access_token= URLs, userinfo) before emission (#1989).
     if (error) entry.error = sanitizeSerializedError(error);
 
+    return entry;
+  }
+
+  private formatJson(level: LogEntry["level"], message: string, args: unknown[]): string {
+    const entry = this.createEntry(level, message, args);
     return JSON.stringify(entry);
   }
 
@@ -395,9 +414,21 @@ class ConsoleLogger implements Logger {
     const { level: resolvedLevel, format: resolvedFormat } = resolveLoggerConfig();
     if (resolvedLevel > logLevel) return;
 
+    let entry: LogEntry | undefined;
     const line = resolvedFormat === "json"
-      ? this.formatJson(level, message, args)
+      ? (() => {
+        entry = this.createEntry(level, message, args);
+        return JSON.stringify(entry);
+      })()
       : this.formatTextLine(level, message, args);
+
+    if (logRecordEmitter) {
+      try {
+        logRecordEmitter(entry ?? this.createEntry(level, message, args));
+      } catch (_) {
+        /* do not let telemetry export failures affect application logging */
+      }
+    }
 
     consoleFn(line);
   }


### PR DESCRIPTION
## Summary
- add schedule trigger attributes to hosted agent run/preparation spans from forwarded schedule props
- guarantee detached `agent.run` spans finalize even if the terminal callback does not finalize them
- emit Datadog-visible `agent.tool_execute` spans for generate/stream tool execution and provider-executed tools
- add dedicated Node agent OTLP support for traces, logs, and metrics, including signal-specific endpoints/headers
- bridge Veryfront structured agent logs into OTel logs with trace/span correlation and emit a startup metric smoke signal

## Why
Datadog showed `veryfront-ops-agent` APM connectivity, but scheduled runs were too flat: the visible trace could be a single `agent.runtime.processStream` span and tool calls/logs/metrics were not guaranteed to be observable in the dedicated runtime.

## Verification
- `deno fmt --check` on touched telemetry/runtime files
- `deno check` on touched runtime/telemetry files
- `env -u OTEL_* deno test --allow-env src/agent/service/node-telemetry.test.ts extensions/ext-observability-opentelemetry/src/index.test.ts src/utils/logger/logger.test.ts`
- `deno test src/agent/hosted/trace-attributes.test.ts src/agent/hosted/agent-run-lifecycle.test.ts src/agent/hosted/prepared-chat-execution.test.ts src/agent/runtime/model-tool-converter.test.ts`
- full pre-push hook: format, lint, typecheck, generated assets, and 2,301 unit tests
