### PR TITLE
Fix compiled framework preflight SSR deps

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1029",
+  "version": "0.1.1030",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/modules/react-loader/ssr-module-loader/preflight-imports.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/preflight-imports.test.ts
@@ -1,6 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { join } from "#veryfront/compat/path";
+import { FRAMEWORK_SRC_DIR } from "#veryfront/platform/compat/framework-source-resolver.ts";
 import type { LocalImport } from "#veryfront/transforms/esm/import-parser.ts";
 import { preflightLocalImports } from "./preflight-imports.ts";
 
@@ -42,5 +44,30 @@ describe("modules/react-loader/ssr-module-loader/preflight-imports", () => {
     assertEquals(result.missingImports.length, 2);
     assertEquals(result.missingImports[0]?.reason.includes("not a file on disk"), true);
     assertEquals(result.missingImports[1]?.reason.includes("file not accessible"), true);
+  });
+
+  it("checks framework source imports with the local filesystem", async () => {
+    const frameworkCorePath = join(FRAMEWORK_SRC_DIR, "react/runtime/core.ts");
+    const imports: LocalImport[] = [
+      { specifier: "../runtime/core.ts", absolutePath: frameworkCorePath },
+    ];
+
+    let projectFsStatCalls = 0;
+    const projectFs = {
+      stat: (_path: string) => {
+        projectFsStatCalls++;
+        return Promise.reject(new Error("project fs cannot stat framework source"));
+      },
+    };
+
+    const result = await preflightLocalImports(
+      imports,
+      join(FRAMEWORK_SRC_DIR, "react/router/index.tsx"),
+      projectFs,
+    );
+
+    assertEquals(result.validImports, imports);
+    assertEquals(result.missingImports, []);
+    assertEquals(projectFsStatCalls, 0);
   });
 });

--- a/src/modules/react-loader/ssr-module-loader/preflight-imports.ts
+++ b/src/modules/react-loader/ssr-module-loader/preflight-imports.ts
@@ -1,4 +1,5 @@
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { isFrameworkSourcePath } from "#veryfront/platform/compat/framework-source-resolver.ts";
 import type { LocalImport, MissingImport } from "#veryfront/transforms/esm/import-parser.ts";
 
 interface PreflightImportsResult {
@@ -13,6 +14,7 @@ export async function preflightLocalImports(
 ): Promise<PreflightImportsResult> {
   const validImports: LocalImport[] = [];
   const missingImports: MissingImport[] = [];
+  const localFs = createFileSystem();
 
   for (const imp of imports) {
     if (!imp.absolutePath.startsWith("/")) {
@@ -20,8 +22,10 @@ export async function preflightLocalImports(
       continue;
     }
 
+    const statFs = isFrameworkSourcePath(imp.absolutePath) ? localFs : fs;
+
     try {
-      const stat = await fs.stat(imp.absolutePath);
+      const stat = await statFs.stat(imp.absolutePath);
       if (stat?.isFile) {
         validImports.push(imp);
       } else {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1029";
+export const VERSION = "0.1.1030";


### PR DESCRIPTION
## Summary
- Fix SSR preflight for compiled Veryfront framework source imports by checking framework paths with the local runtime filesystem instead of the project/proxy filesystem.
- Add a regression that models the staging failure: proxy project FS cannot stat framework source paths, but `../runtime/core.ts` from framework modules must still validate.
- Bump runtime version to `0.1.1030` for a deployable follow-up release.

## Staging root cause
After PR #2811 deployed as `v0.1.1029`, the authenticated preview still returned `500`. Current staging logs showed the new failure was not the stale cache case anymore:

- proxy `veryfrontVersion=0.1.1029`, project `test-0ffaae1e`, `GET / 500`
- server request id `df547467-5b0a-42dc-9f28-788d62eb67a0`
- error: `Component has missing dependencies: ../runtime/core.ts`
- source: `/tmp/deno-compile-veryfront/src/react/router/index.tsx` and `/tmp/deno-compile-veryfront/src/react/context/index.tsx`
- reason: proxy/project FS could not stat `/tmp/deno-compile-veryfront/src/react/runtime/core.ts`

Framework source files live in the compiled runtime/VFS namespace, so their preflight checks must not use the tenant project FS adapter.

## Red/green proof
Red before fix:

```text
deno test -A src/modules/react-loader/ssr-module-loader/preflight-imports.test.ts
checks framework source imports with the local filesystem ... FAILED
```

Green after fix:

```text
deno test -A src/modules/react-loader/ssr-module-loader/preflight-imports.test.ts
ok | 1 passed (3 steps) | 0 failed
```

## Verification
Passed:

```text
deno test -A src/modules/react-loader/ssr-module-loader/preflight-imports.test.ts src/modules/react-loader/ssr-module-loader/loader.test.ts
ok | 2 passed (17 steps) | 0 failed


deno test -A src/platform/compat/framework-source-resolver.test.ts src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.test.ts
ok | 5 passed (29 steps) | 0 failed


deno test -A src/modules/react-loader/ssr-module-loader/ssr-cache-manager.test.ts src/modules/react-loader/ssr-module-loader/tmp-paths.test.ts src/modules/react-loader/ssr-module-loader/cache/memory.test.ts src/transforms/mdx/esm-module-loader/cache/index.test.ts
ok | 9 passed (62 steps) | 0 failed


deno fmt --check src/modules/react-loader/ssr-module-loader/preflight-imports.ts src/modules/react-loader/ssr-module-loader/preflight-imports.test.ts deno.json src/utils/version-constant.ts
Checked 4 files


deno lint src/modules/react-loader/ssr-module-loader/preflight-imports.ts src/modules/react-loader/ssr-module-loader/preflight-imports.test.ts src/utils/version-constant.ts
Checked 3 files


deno task typecheck
passed


git diff --check
passed
```

Full local suite caveat:

```text
env -u OTEL_EXPORTER_OTLP_ENDPOINT -u OTEL_EXPORTER_OTLP_HEADERS -u OTEL_METRICS_EXPORTER -u OTEL_TRACES_EXPORTER -u OTEL_LOGS_EXPORTER deno task test
FAILED | 2656 passed (22779 steps) | 4 failed (4 steps) | 0 ignored (27 steps)
```

The failures were isolated to existing script/storybook checks outside this diff:
- `EXTENSION_OWNED_DEPENDENCIES` missing `@opentelemetry/api-logs`
- missing generated `npm/esm/cli/commands/mcp/handler.js`
- generated API reference expected text drift for `veryfront/router`
- Storybook workbench missing `COMPOSITION` section and `storybook/stories/chat/ChatComposition.stories.tsx`

These were reproduced with:

```text
deno test --config=scripts/test.deno.json --no-check --allow-read --allow-write --allow-run scripts/build/npm-package-metadata.test.ts scripts/docs/generate-api-reference.test.ts scripts/storybook/storybook-workbench.test.ts
```

## Review score
Self-review score: 92/100.

Why not 100: the most direct end-to-end proof requires this to deploy to staging and retest the original authenticated preview URL. The local regression models the failing adapter boundary and the targeted SSR/framework suites pass, but staging verification is still the final proof after CI/deploy.
