### PR TITLE
Surface child run result truncation metadata

### DIFF
--- a/src/agent/child-run/execution-snapshot.ts
+++ b/src/agent/child-run/execution-snapshot.ts
@@ -1,3 +1,5 @@
+import type { ChildRunResultSummary } from "./result-summary.ts";
+
 /** Public API contract for child run execution usage. */
 export interface ChildRunExecutionUsage {
   inputTokens: number;
@@ -38,7 +40,7 @@ export type ChildRunExecutionResult =
   | {
     success: true;
     description: string;
-    summary: { text: string };
+    summary: ChildRunResultSummary;
     steps: number;
     toolCalls: ChildRunToolCallSnapshot[];
     toolResults: ChildRunToolResultSnapshot[];
@@ -98,7 +100,7 @@ export function buildChildRunResultCommon(input: ChildRunResultCommon): ChildRun
 /** Result returned from build child run success. */
 export function buildChildRunSuccessResult(
   common: ChildRunResultCommon,
-  summary: { text: string },
+  summary: ChildRunResultSummary,
 ): ChildRunExecutionResult & { success: true } {
   return {
     success: true,

--- a/src/agent/child-run/result-summary.test.ts
+++ b/src/agent/child-run/result-summary.test.ts
@@ -10,6 +10,7 @@ import {
   buildRootOwnedChildRunResultHint,
   buildRootOwnedChildRunResultText,
   summarizeChildRunResultText,
+  summarizeChildRunResultTextWithMetadata,
   summarizeChildRunResultValue,
 } from "./result-summary.ts";
 
@@ -44,34 +45,58 @@ describe("child-run-result-summary", () => {
     it("respects custom maxLength", () => {
       assertEquals(summarizeChildRunResultText("hello world", 5), "hello… [truncated 6 chars]");
     });
+
+    it("returns structured truncation metadata", () => {
+      assertEquals(summarizeChildRunResultTextWithMetadata("hello world", 5), {
+        text: "hello… [truncated 6 chars]",
+        status: "truncated",
+        truncated: true,
+        originalChars: 11,
+        returnedChars: 26,
+        omittedChars: 6,
+        limitChars: 5,
+      });
+    });
   });
 
   describe("buildChildRunResultSummary", () => {
     it("wraps text in a summary object", () => {
-      assertEquals(buildChildRunResultSummary("done"), { text: "done" });
+      assertEquals(buildChildRunResultSummary("done"), {
+        text: "done",
+        status: "complete",
+        truncated: false,
+        originalChars: 4,
+        returnedChars: 4,
+        omittedChars: 0,
+        limitChars: 64_000,
+      });
     });
 
     it("removes malformed tool transcript wrappers while preserving result content", () => {
-      assertEquals(
-        buildChildRunResultSummary(
-          'I will fetch the docs.\n\n<tool_call>{"name":"web_fetch","parameters":{"url":"https://example.com"}}</tool_call><tool_response>Title: Example Content: Example Domain</tool_response>\n\nNow I can continue.',
-        ),
-        {
-          text:
-            "I will fetch the docs.\n\nTitle: Example Content: Example Domain\n\nNow I can continue.",
-        },
+      const result = buildChildRunResultSummary(
+        'I will fetch the docs.\n\n<tool_call>{"name":"web_fetch","parameters":{"url":"https://example.com"}}</tool_call><tool_response>Title: Example Content: Example Domain</tool_response>\n\nNow I can continue.',
       );
+
+      assertObjectMatch(result, {
+        text:
+          "I will fetch the docs.\n\nTitle: Example Content: Example Domain\n\nNow I can continue.",
+        status: "complete",
+        truncated: false,
+        omittedChars: 0,
+      });
     });
 
     it("removes malformed function transcript wrappers while preserving function result content", () => {
-      assertEquals(
-        buildChildRunResultSummary(
-          '```\nbash\n```\n\n<function_calls>\n<invoke name="run_bash">\n<parameter name="command">curl -s "https://docs.example.test/platform/" 2>&1 | head -5</parameter>\n</invoke>\n</function_calls>\n<function_result>\nExample Platform\nOverview\nArchitecture\n</parameter>\n</invoke>\n</function_calls>',
-        ),
-        {
-          text: "Example Platform\nOverview\nArchitecture",
-        },
+      const result = buildChildRunResultSummary(
+        '```\nbash\n```\n\n<function_calls>\n<invoke name="run_bash">\n<parameter name="command">curl -s "https://docs.example.test/platform/" 2>&1 | head -5</parameter>\n</invoke>\n</function_calls>\n<function_result>\nExample Platform\nOverview\nArchitecture\n</parameter>\n</invoke>\n</function_calls>',
       );
+
+      assertObjectMatch(result, {
+        text: "Example Platform\nOverview\nArchitecture",
+        status: "complete",
+        truncated: false,
+        omittedChars: 0,
+      });
     });
   });
 

--- a/src/agent/child-run/result-summary.ts
+++ b/src/agent/child-run/result-summary.ts
@@ -18,6 +18,17 @@ const ROOT_RESPONSE_PROCESS_PREFIX_PATTERNS = [
   /^first,? [^.?!]+[.?!]\s*/i,
 ];
 
+/** Summary metadata returned to parent runs after child delegation. */
+export type ChildRunResultSummary = {
+  text: string;
+  status?: "complete" | "truncated";
+  truncated?: boolean;
+  originalChars?: number;
+  returnedChars?: number;
+  omittedChars?: number;
+  limitChars?: number;
+};
+
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -39,18 +50,45 @@ export function summarizeChildRunResultText(
   text: string,
   maxLength = CHILD_RUN_RESULT_TEXT_LIMIT,
 ): string {
+  return summarizeChildRunResultTextWithMetadata(text, maxLength).text;
+}
+
+/** Summarize child run result text with machine-readable truncation metadata. */
+export function summarizeChildRunResultTextWithMetadata(
+  text: string,
+  maxLength = CHILD_RUN_RESULT_TEXT_LIMIT,
+): ChildRunResultSummary {
   const normalized = sanitizeMalformedToolTranscriptText(text);
 
   if (normalized.length <= maxLength) {
-    return normalized;
+    return {
+      text: normalized,
+      status: "complete",
+      truncated: false,
+      originalChars: normalized.length,
+      returnedChars: normalized.length,
+      omittedChars: 0,
+      limitChars: maxLength,
+    };
   }
 
-  return `${normalized.slice(0, maxLength)}… [truncated ${normalized.length - maxLength} chars]`;
+  const omittedChars = normalized.length - maxLength;
+  const summaryText = `${normalized.slice(0, maxLength)}… [truncated ${omittedChars} chars]`;
+
+  return {
+    text: summaryText,
+    status: "truncated",
+    truncated: true,
+    originalChars: normalized.length,
+    returnedChars: summaryText.length,
+    omittedChars,
+    limitChars: maxLength,
+  };
 }
 
 /** Builds child run result summary. */
-export function buildChildRunResultSummary(text: string): { text: string } {
-  return { text: summarizeChildRunResultText(text) };
+export function buildChildRunResultSummary(text: string): ChildRunResultSummary {
+  return summarizeChildRunResultTextWithMetadata(text);
 }
 
 /** Builds root owned child run result text. */

--- a/src/agent/hosted/default-invoke-agent-tool.test.ts
+++ b/src/agent/hosted/default-invoke-agent-tool.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import type { CreateSandboxBashTool } from "#veryfront/sandbox";
+import { buildChildRunResultSummary } from "../child-run/result-summary.ts";
 import {
   createDefaultHostedInvokeAgentTool,
   type DefaultHostedInvokeAgentContext,
@@ -11,6 +12,8 @@ import {
 } from "./default-invoke-agent-tool.ts";
 
 const createBashTool: CreateSandboxBashTool = () => Promise.resolve({ tools: {} });
+const DURABLE_CONTEXT_FAILURE_TEXT =
+  "invoke_agent failed: invoke_agent requires durable conversation context when durable child runs are enabled.";
 
 function createTestOptions(input?: {
   context?: DefaultHostedInvokeAgentContext;
@@ -108,12 +111,8 @@ Deno.test("executeDefaultHostedInvokeAgentTool returns durable context failure b
   assertEquals(result, {
     ok: false,
     status: "failed",
-    text:
-      "invoke_agent failed: invoke_agent requires durable conversation context when durable child runs are enabled.",
-    summary: {
-      text:
-        "invoke_agent failed: invoke_agent requires durable conversation context when durable child runs are enabled.",
-    },
+    text: DURABLE_CONTEXT_FAILURE_TEXT,
+    summary: buildChildRunResultSummary(DURABLE_CONTEXT_FAILURE_TEXT),
     terminalErrorCode: "DURABLE_INVOKE_CONTEXT_UNAVAILABLE",
     terminalErrorMessage:
       "invoke_agent requires durable conversation context when durable child runs are enabled.",
@@ -144,12 +143,8 @@ Deno.test("createDefaultHostedInvokeAgentTool adds child selection guidance and 
   assertEquals(result, {
     ok: false,
     status: "failed",
-    text:
-      "invoke_agent failed: invoke_agent requires durable conversation context when durable child runs are enabled.",
-    summary: {
-      text:
-        "invoke_agent failed: invoke_agent requires durable conversation context when durable child runs are enabled.",
-    },
+    text: DURABLE_CONTEXT_FAILURE_TEXT,
+    summary: buildChildRunResultSummary(DURABLE_CONTEXT_FAILURE_TEXT),
     terminalErrorCode: "DURABLE_INVOKE_CONTEXT_UNAVAILABLE",
     terminalErrorMessage:
       "invoke_agent requires durable conversation context when durable child runs are enabled.",
@@ -176,12 +171,8 @@ Deno.test("createDefaultHostedInvokeAgentTool treats omitted context as empty st
   assertEquals(result, {
     ok: false,
     status: "failed",
-    text:
-      "invoke_agent failed: invoke_agent requires durable conversation context when durable child runs are enabled.",
-    summary: {
-      text:
-        "invoke_agent failed: invoke_agent requires durable conversation context when durable child runs are enabled.",
-    },
+    text: DURABLE_CONTEXT_FAILURE_TEXT,
+    summary: buildChildRunResultSummary(DURABLE_CONTEXT_FAILURE_TEXT),
     terminalErrorCode: "DURABLE_INVOKE_CONTEXT_UNAVAILABLE",
     terminalErrorMessage:
       "invoke_agent requires durable conversation context when durable child runs are enabled.",

--- a/src/agent/hosted/durable-child-fork-execution.test.ts
+++ b/src/agent/hosted/durable-child-fork-execution.test.ts
@@ -5,6 +5,7 @@ import {
   buildChildRunExecutionSnapshot,
   type ChildRunExecutionResult,
 } from "../child-run/execution-snapshot.ts";
+import { buildChildRunResultSummary } from "../child-run/result-summary.ts";
 import type { ConversationRunTargets } from "../conversation/durable.ts";
 import {
   buildHostedDurableChildInvokeFailureResult,
@@ -88,11 +89,11 @@ function getPublicId(value: unknown): string {
   return value.public_id;
 }
 
-function baseSuccessResult(): ChildRunExecutionResult {
+function baseSuccessResult(): ChildRunExecutionResult & { success: true } {
   return {
     success: true,
     description: "Inspect logs",
-    summary: { text: "Found logs" },
+    summary: buildChildRunResultSummary("Found logs"),
     steps: 2,
     toolCalls: [],
     toolResults: [],
@@ -131,7 +132,7 @@ describe("agent/hosted-durable-child-fork-execution", () => {
         ok: false,
         status: "failed",
         text: "invoke_agent failed: setup failed",
-        summary: { text: "invoke_agent failed: setup failed" },
+        summary: buildChildRunResultSummary("invoke_agent failed: setup failed"),
         childConversationId: CHILD_CONVERSATION_ID,
         sourceTargetKind: "preview_branch",
         runtimeTargetKind: "preview_branch",
@@ -152,7 +153,7 @@ describe("agent/hosted-durable-child-fork-execution", () => {
         ok: false,
         status: "failed",
         text: "invoke_agent failed: child failed",
-        summary: { text: "invoke_agent failed: child failed" },
+        summary: buildChildRunResultSummary("invoke_agent failed: child failed"),
         childConversationId: CHILD_CONVERSATION_ID,
         childRunId: "run_child_1",
         childMessageId: CHILD_MESSAGE_ID,
@@ -174,7 +175,7 @@ describe("agent/hosted-durable-child-fork-execution", () => {
         ok: true,
         status: "completed",
         text: "Found logs",
-        summary: { text: "Found logs" },
+        summary: buildChildRunResultSummary("Found logs"),
         steps: 2,
         toolCalls: [],
         toolResults: [],
@@ -258,7 +259,7 @@ describe("agent/hosted-durable-child-fork-execution", () => {
         ok: true,
         status: "completed",
         text: "Title: Example Content",
-        summary: { text: "Title: Example Content" },
+        summary: buildChildRunResultSummary("Title: Example Content"),
         steps: 2,
         toolCalls: [],
         toolResults: [],
@@ -359,7 +360,7 @@ describe("agent/hosted-durable-child-fork-execution", () => {
         ok: false,
         status: "failed",
         text: "invoke_agent failed: setup failed",
-        summary: { text: "invoke_agent failed: setup failed" },
+        summary: buildChildRunResultSummary("invoke_agent failed: setup failed"),
         childConversationId: CHILD_CONVERSATION_ID,
         childRunId: "run_child_1",
         childMessageId: CHILD_MESSAGE_ID,
@@ -508,7 +509,7 @@ describe("agent/hosted-durable-child-fork-execution", () => {
       {
         authToken: AUTH_TOKEN,
         apiUrl: API_URL,
-        forkInput: { description: "Inspect logs", prompt: "Find logs" },
+        forkInput: { description: "Inspect logs", prompt: "Find logs", context: {} },
         executionOptions: { toolCallId: "tool-call-1" },
         childAgentId: "invoke-agent-child",
         getProjectId: () => PROJECT_ID,

--- a/src/agent/hosted/durable-child-fork-execution.ts
+++ b/src/agent/hosted/durable-child-fork-execution.ts
@@ -3,7 +3,10 @@ import type {
   ChildRunExecutionSnapshot,
 } from "../child-run/execution-snapshot.ts";
 import { parseProviderError } from "../../chat/provider-errors.ts";
-import { buildChildRunResultSummary } from "../child-run/result-summary.ts";
+import {
+  buildChildRunResultSummary,
+  type ChildRunResultSummary,
+} from "../child-run/result-summary.ts";
 import {
   type ConversationRunTargets,
   resolveConversationRunTargets,
@@ -39,7 +42,7 @@ export type HostedDurableChildInvokeResult = {
   status: "completed" | "failed";
   text?: string;
   error?: string;
-  summary?: { text: string };
+  summary?: ChildRunResultSummary;
   steps?: number;
   toolCalls?: ChildRunExecutionSnapshot["toolCalls"];
   toolResults?: ChildRunExecutionSnapshot["toolResults"];


### PR DESCRIPTION
## Summary
- add structured metadata to delegated child-run result summaries: status, truncated, originalChars, returnedChars, omittedChars, and limitChars
- keep the existing summary.text field unchanged for compatibility
- widen child-run result types so older minimal { text } fixtures remain valid while runtime builders emit complete metadata

This is a scoped step toward veryfront/veryfront-studio#5614: parent runs no longer need to infer truncation/completeness by scraping the summary text marker. It does not close the broader full-fidelity retrieval design.

Refs veryfront/veryfront-studio#5614

## Tests
- deno test --no-check --allow-all src/agent/child-run/result-summary.test.ts src/agent/child-run/execution-snapshot.test.ts src/agent/hosted/durable-child-fork-execution.test.ts src/agent/hosted/child-lifecycle.test.ts src/agent/hosted/default-invoke-agent-tool.test.ts src/agent/conversation/delegation-policy.test.ts
- deno check src/agent/child-run/result-summary.ts src/agent/child-run/execution-snapshot.ts src/agent/hosted/durable-child-fork-execution.ts src/agent/hosted/default-invoke-agent-tool.test.ts src/agent/hosted/durable-child-fork-execution.test.ts
- deno fmt --check src/agent/child-run/result-summary.ts src/agent/child-run/result-summary.test.ts src/agent/child-run/execution-snapshot.ts src/agent/hosted/durable-child-fork-execution.ts src/agent/hosted/default-invoke-agent-tool.test.ts src/agent/hosted/durable-child-fork-execution.test.ts
- deno lint src/agent/child-run/result-summary.ts src/agent/child-run/result-summary.test.ts src/agent/child-run/execution-snapshot.ts src/agent/hosted/durable-child-fork-execution.ts src/agent/hosted/default-invoke-agent-tool.test.ts src/agent/hosted/durable-child-fork-execution.test.ts
- pre-push hook: formatting, lint, type check, and unit tests (2301 passed, 0 failed)