### PR TITLE
Make WebSocket recovery visible in production logs

### DIFF
--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -89,6 +89,7 @@ function withJsonLogFormat<T>(fn: () => T): T {
 }
 
 function createWebSocketManager(options: {
+  apiBaseUrl?: string;
   client?: Partial<VeryfrontApiClient>;
   invalidationCallbacks?: InvalidationCallbacks;
   pregenerateStyles?: (
@@ -109,7 +110,7 @@ function createWebSocketManager(options: {
   const invalidationCallbacks: InvalidationCallbacks = options.invalidationCallbacks ?? {};
 
   return new WebSocketManager({
-    apiBaseUrl: "https://api.example.com/api",
+    apiBaseUrl: options.apiBaseUrl ?? "https://api.example.com/api",
     apiToken: "test-token",
     projectSlug: "test-project",
     cache,
@@ -497,6 +498,40 @@ describe("WebSocketManager", () => {
     } finally {
       debugCapture.restore();
       logCapture.restore();
+      warnCapture.restore();
+    }
+  });
+
+  it("redacts WebSocket URL credentials from reconnect warnings", () => {
+    const warnCapture = captureConsoleMethod("warn");
+
+    try {
+      withJsonLogFormat(() => {
+        const manager = createWebSocketManager({
+          apiBaseUrl: "https://user:secret@api.example.com/api",
+        });
+        manager.connect("project-1");
+
+        const socket = MockWebSocket.instances[0];
+        assertExists(socket);
+        socket.emitClose();
+
+        const rawLog = warnCapture.getOutput();
+        assertEquals(rawLog.includes("user:secret"), false);
+        assertEquals(rawLog.includes("secret@"), false);
+
+        const closeEntry = JSON.parse(rawLog) as {
+          message: string;
+          context?: {
+            url?: string;
+          };
+        };
+        assertEquals(closeEntry.message, "WebSocket reconnect scheduled after close");
+        assertEquals(closeEntry.context?.url, "wss://api.example.com/ws/project-1/events");
+
+        manager.dispose();
+      });
+    } finally {
       warnCapture.restore();
     }
   });

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -50,7 +50,7 @@ class MockWebSocket {
 }
 
 function captureConsoleMethod(
-  method: "debug" | "warn",
+  method: "debug" | "log" | "warn",
 ): { getOutput: () => string; reset: () => void; restore: () => void } {
   const original = console[method];
   let capturedOutput = "";
@@ -418,6 +418,7 @@ describe("WebSocketManager", () => {
 
   it("should include projectSlug in connection lifecycle logs", () => {
     const debugCapture = captureConsoleMethod("debug");
+    const logCapture = captureConsoleMethod("log");
     const warnCapture = captureConsoleMethod("warn");
 
     try {
@@ -438,12 +439,48 @@ describe("WebSocketManager", () => {
         debugCapture.reset();
         socket.emitClose();
 
-        const closeEntry = JSON.parse(debugCapture.getOutput()) as {
+        const closeEntry = JSON.parse(warnCapture.getOutput()) as {
           message: string;
           projectSlug?: string;
+          project_id?: string;
+          context?: {
+            delayMs?: number;
+            consecutiveFailures?: number;
+            projectId?: string;
+            url?: string;
+          };
         };
-        assertEquals(closeEntry.message, "WebSocket closed, reconnecting");
+        assertEquals(closeEntry.message, "WebSocket reconnect scheduled after close");
         assertEquals(closeEntry.projectSlug, "test-project");
+        assertEquals(closeEntry.project_id, "project-1");
+        assertEquals(closeEntry.context?.projectId, "project-1");
+        assertEquals(closeEntry.context?.url, "wss://api.example.com/ws/project-1/events");
+        assertEquals(closeEntry.context?.delayMs, 5000);
+        assertEquals(closeEntry.context?.consecutiveFailures, 1);
+
+        logCapture.reset();
+        runOnlyScheduledTimer();
+        const reconnectedSocket = MockWebSocket.instances[1];
+        assertExists(reconnectedSocket);
+        reconnectedSocket.onopen?.call(
+          reconnectedSocket as unknown as WebSocket,
+          new Event("open"),
+        );
+
+        const recoveryEntry = JSON.parse(logCapture.getOutput()) as {
+          message: string;
+          projectSlug?: string;
+          project_id?: string;
+          context?: {
+            consecutiveFailures?: number;
+            projectId?: string;
+          };
+        };
+        assertEquals(recoveryEntry.message, "WebSocket reconnect recovered");
+        assertEquals(recoveryEntry.projectSlug, "test-project");
+        assertEquals(recoveryEntry.project_id, "project-1");
+        assertEquals(recoveryEntry.context?.projectId, "project-1");
+        assertEquals(recoveryEntry.context?.consecutiveFailures, 1);
 
         warnCapture.reset();
         socket.onerror?.call(socket as unknown as WebSocket, new Event("error"));
@@ -459,6 +496,7 @@ describe("WebSocketManager", () => {
       });
     } finally {
       debugCapture.restore();
+      logCapture.restore();
       warnCapture.restore();
     }
   });

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -1,4 +1,5 @@
 import { getBaseLogger } from "#veryfront/utils/logger/logger.ts";
+import { sanitizeUrlForSpan } from "#veryfront/utils/logger/redact.ts";
 import type { FileCache } from "../cache/file-cache.ts";
 import type { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
 import type {
@@ -35,6 +36,10 @@ import {
 const logger = getBaseLogger("SERVER", { injectTraceContext: false }).component(
   "web-socket-manager",
 );
+
+function sanitizeWebSocketLogUrl(url: string | undefined): string | undefined {
+  return typeof url === "string" ? sanitizeUrlForSpan(url) : undefined;
+}
 
 interface WebSocketDeps {
   apiBaseUrl: string;
@@ -152,7 +157,7 @@ export class WebSocketManager {
     logger.debug(
       "Connecting to WebSocket",
       this.getConnectionLogContext({
-        url,
+        url: sanitizeWebSocketLogUrl(url),
         consecutiveFailures: this.wsConsecutiveFailures,
       }),
     );
@@ -214,7 +219,7 @@ export class WebSocketManager {
             projectId,
             project_id: projectId,
             connectionId,
-            url,
+            url: sanitizeWebSocketLogUrl(url),
             delayMs: delay,
             totalPokesReceived: this.pokeMetrics.received,
             consecutiveFailures: this.wsConsecutiveFailures,
@@ -234,7 +239,7 @@ export class WebSocketManager {
             "WebSocket error",
             this.getConnectionLogContext({
               type: event.type,
-              url: (event.target as WebSocket)?.url,
+              url: sanitizeWebSocketLogUrl((event.target as WebSocket)?.url),
               readyState: (event.target as WebSocket)?.readyState,
               consecutiveFailures: this.wsConsecutiveFailures,
             }),

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -166,6 +166,7 @@ export class WebSocketManager {
       this.wsErrorLogged = false;
 
       this.ws.onopen = () => {
+        const recoveredFailures = this.wsConsecutiveFailures;
         this.wsConsecutiveFailures = 0;
         logger.debug(
           "WebSocket connected to events channel",
@@ -175,6 +176,18 @@ export class WebSocketManager {
             ...buildContentSourceLabel(this.deps.getContentSource, this.deps.getContentContext),
           }),
         );
+        if (recoveredFailures > 0) {
+          logger.info(
+            "WebSocket reconnect recovered",
+            this.getConnectionLogContext({
+              projectId,
+              project_id: projectId,
+              connectionId: this.wsConnectionId,
+              consecutiveFailures: recoveredFailures,
+              ...buildContentSourceLabel(this.deps.getContentSource, this.deps.getContentContext),
+            }),
+          );
+        }
         this.wsLastPong = Date.now();
         this.startHeartbeat(projectId);
       };
@@ -185,7 +198,9 @@ export class WebSocketManager {
         this.handlePokeMessage(event);
       };
 
-      this.ws.onclose = () => {
+      this.ws.onclose = (event) => {
+        const connectionId = this.wsConnectionId;
+        const url = this.ws?.url;
         this.wsConnectionId = null;
         this.cleanupTimers();
 
@@ -193,12 +208,19 @@ export class WebSocketManager {
 
         this.wsConsecutiveFailures++;
         const delay = this.getReconnectDelay();
-        logger.debug(
-          "WebSocket closed, reconnecting",
+        logger.warn(
+          "WebSocket reconnect scheduled after close",
           this.getConnectionLogContext({
+            projectId,
+            project_id: projectId,
+            connectionId,
+            url,
             delayMs: delay,
             totalPokesReceived: this.pokeMetrics.received,
             consecutiveFailures: this.wsConsecutiveFailures,
+            closeCode: event.code,
+            closeReason: event.reason,
+            wasClean: event.wasClean,
           }),
         );
         this.wsReconnectTimer = setTimeout(() => this.connect(projectId), delay);


### PR DESCRIPTION
## Summary
- raise WebSocket close retry scheduling from debug to warn so production Loki can see reconnect attempts
- add an info-level recovery event when a retry successfully reconnects after failures
- include project_id, projectId, URL, connection id, close details, delay, and consecutiveFailures for alerting and issue correlation

## Validation
- deno test --allow-all src/platform/adapters/fs/veryfront/websocket-manager.test.ts
- deno fmt --check src/platform/adapters/fs/veryfront/websocket-manager.ts src/platform/adapters/fs/veryfront/websocket-manager.test.ts
- deno task lint
- deno task lint:sanitizer-baseline
- deno task typecheck
- pre-push hook: format, lint, typecheck, unit tests passed: 2299 passed, 0 failed

Refs veryfront/veryfront-studio#5658