### PR TITLE
Prepare release 0.1.1031

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1030",
+  "version": "0.1.1031",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1030";
+export const VERSION = "0.1.1031";


### PR DESCRIPTION
## Summary
- bump root Veryfront release metadata from 0.1.1030 to 0.1.1031
- keep the checked-in runtime version constant synchronized with deno.json
- release includes the merged Kreuzberg PDF text extraction fix from #2801

## Tests
- deno fmt --check deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all src/utils/version.test.ts
- deno task typecheck
- git diff --check
- pre-push hook: format, lint, typecheck, unit tests (2299 passed, 0 failed)

## Notes
- npm currently has no `veryfront@0.1.1031` or `@veryfront/ext-document-kreuzberg@0.1.1031`; this bump gives CI a new stable version to publish.