### PR TITLE
Bump version to 0.1.1032

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1031",
+  "version": "0.1.1032",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1031";
+export const VERSION = "0.1.1032";


### PR DESCRIPTION
## Summary\n- Bump Veryfront version from 0.1.1031 to 0.1.1032 in deno.json and src/utils/version-constant.ts.\n- Keeps the Datadog OTEL fix release on a fresh version after 0.1.1031 was already consumed.\n\n## Verification\n- deno fmt --check deno.json src/utils/version-constant.ts\n- deno task typecheck\n- git diff --check