### PR TITLE
Keep upstream HMR WebSockets from idling out

### DIFF
--- a/src/platform/adapters/base.ts
+++ b/src/platform/adapters/base.ts
@@ -81,8 +81,14 @@ export interface RuntimeCapabilities {
   writableFs: boolean;
 }
 
+export interface WebSocketUpgradeOptions {
+  protocol?: string;
+  headers?: Headers | Record<string, string>;
+  idleTimeout?: number;
+}
+
 export interface ServerAdapter {
-  upgradeWebSocket(request: Request): WebSocketUpgrade;
+  upgradeWebSocket(request: Request, options?: WebSocketUpgradeOptions): WebSocketUpgrade;
 }
 
 export interface WebSocketConnection {

--- a/src/platform/adapters/runtime/deno/adapter.ts
+++ b/src/platform/adapters/runtime/deno/adapter.ts
@@ -14,6 +14,7 @@ import type {
   ShellAdapter,
   WatchOptions,
   WebSocketUpgrade,
+  WebSocketUpgradeOptions,
 } from "../../base.ts";
 import { serverLogger } from "#veryfront/utils";
 import {
@@ -33,6 +34,7 @@ import {
   getNativeResponse,
   toNativeResponse,
 } from "../../../compat/http/native-response.ts";
+import { resolveDenoUpgradeWebSocketOptions } from "../../../compat/http/websocket.ts";
 
 const logger = serverLogger.component("deno");
 
@@ -299,7 +301,7 @@ class DenoEnvironmentAdapter implements EnvironmentAdapter {
 }
 
 class DenoServerAdapter implements ServerAdapter {
-  upgradeWebSocket(request: Request): WebSocketUpgrade {
+  upgradeWebSocket(request: Request, options?: WebSocketUpgradeOptions): WebSocketUpgrade {
     // Access native Deno via `self` to bypass dnt shim transform.
     // dnt rewrites `globalThis.Deno` to @deno/shim-deno, which lacks upgradeWebSocket.
     const nativeDeno = getNativeDeno();
@@ -308,7 +310,10 @@ class DenoServerAdapter implements ServerAdapter {
         detail: "DenoServerAdapter.upgradeWebSocket() can only be used in Deno runtime",
       });
     }
-    const { socket, response } = nativeDeno.upgradeWebSocket(request);
+    const { socket, response } = nativeDeno.upgradeWebSocket(
+      request,
+      resolveDenoUpgradeWebSocketOptions(options),
+    );
     return { socket, response };
   }
 }

--- a/src/server/handlers/preview/hmr.handler.test.ts
+++ b/src/server/handlers/preview/hmr.handler.test.ts
@@ -448,6 +448,31 @@ describe("server/handlers/preview/hmr.handler", () => {
       assertEquals(result.response!.status, 101);
     });
 
+    it("disables runtime idle timeout for upstream HMR WebSocket upgrades", async () => {
+      const handler = new HMRHandler();
+      const mock = createMockSocket();
+      let upgradeOptions: unknown;
+      const req = new Request("http://localhost/_ws", {
+        headers: { upgrade: "websocket" },
+      });
+      const ctx = makeCtx({
+        isLocalProject: true,
+        adapter: createMockAdapter({
+          upgradeWebSocket: (_request: Request, options?: unknown) => {
+            upgradeOptions = options;
+            return {
+              socket: mock.socket,
+              response: createWebSocketUpgradeResponse(),
+            };
+          },
+        }),
+      });
+
+      await handler.handle(req, ctx);
+
+      assertEquals(upgradeOptions, { idleTimeout: 0 });
+    });
+
     it("preserves data from structurally compatible message events", async () => {
       const handler = new HMRHandler();
       const mock = createMockSocket();

--- a/src/server/handlers/preview/hmr.handler.ts
+++ b/src/server/handlers/preview/hmr.handler.ts
@@ -28,6 +28,7 @@ import { isProxyTrusted } from "../../utils/proxy-trust.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 const logger = serverLogger.component("hmr-handler");
+const HMR_WEBSOCKET_UPGRADE_OPTIONS = { idleTimeout: 0 } as const;
 
 // Re-export the interface so external consumers can still access it from this module
 export type { HMRClientInfo } from "./hmr-client-manager.ts";
@@ -160,7 +161,10 @@ export class HMRHandler extends BaseHandler {
     }
 
     try {
-      const { socket, response } = ctx.adapter.server.upgradeWebSocket(req);
+      const { socket, response } = ctx.adapter.server.upgradeWebSocket(
+        req,
+        HMR_WEBSOCKET_UPGRADE_OPTIONS,
+      );
 
       const now = Date.now();
       const clientId = crypto.randomUUID().slice(0, 8);


### PR DESCRIPTION
## Summary
- thread WebSocket upgrade options through the runtime adapter contract and Deno adapter
- disable Deno transport idle timeout for server-side HMR WebSocket upgrades
- add a regression test that HMR passes `{ idleTimeout: 0 }` into the upstream upgrade path

## Why
Studio issue veryfront/veryfront-studio#5574 shows proxied preview sockets failing with `Server connection error` toward `ws://veryfront-server/_ws`. The proxy browser-side upgrade already disables the Deno transport idle timeout, but the upstream server HMR upgrade still used runtime defaults.

## Verification
- `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/server/handlers/preview/hmr.handler.test.ts src/proxy/websocket-proxy.test.ts src/platform/compat/http/websocket.test.ts`
- `deno check src/platform/adapters/base.ts src/platform/adapters/runtime/deno/adapter.ts src/server/handlers/preview/hmr.handler.ts src/proxy/main.ts`
- `deno task typecheck`
- `deno lint src/platform/adapters/base.ts src/platform/adapters/runtime/deno/adapter.ts src/server/handlers/preview/hmr.handler.ts src/server/handlers/preview/hmr.handler.test.ts`
- `git diff --check`

Fixes veryfront/veryfront-studio#5574