### PR TITLE
Prevent SSR cache reuse across runtime rollbacks

### DIFF
--- a/src/modules/react-loader/ssr-module-loader/loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.test.ts
@@ -8,7 +8,7 @@ import { clearSSRModuleCache, SSRModuleLoader } from "./index.ts";
 import { globalInProgress, globalModuleCache } from "./cache/memory.ts";
 import { verifiedHttpBundlePaths } from "./http-bundle-helpers.ts";
 import { buildSSRModuleCacheKey } from "../../../cache/keys.ts";
-import { VERSION } from "#veryfront/utils/version.ts";
+import { RUNTIME_VERSION } from "#veryfront/utils/version.ts";
 import { computeConfigHashSync } from "../../../cache/config-hash.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import { makeTempDir, mkdir, remove, writeTextFile } from "#veryfront/testing/deno-compat.ts";
@@ -164,12 +164,12 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       const reactVersion = "default";
 
       const filePathCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}`,
       );
       const contentCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
       );
@@ -227,12 +227,12 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       const reactVersion = "default";
 
       const filePathCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}`,
       );
       const contentCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
       );
@@ -303,12 +303,12 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       const reactVersion = "default";
 
       const filePathCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}`,
       );
       const contentCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
       );
@@ -370,12 +370,12 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       const reactVersion = "default";
 
       const filePathCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}`,
       );
       const contentCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
       );
@@ -454,12 +454,12 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       const reactVersion = "default";
 
       const filePathCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}`,
       );
       const contentCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
       );
@@ -545,12 +545,12 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       const reactVersion = "default";
 
       const filePathCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}`,
       );
       const contentCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
       );
@@ -633,12 +633,12 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       const reactVersion = "default";
 
       const filePathCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}`,
       );
       const contentCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
       );
@@ -705,12 +705,12 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       const reactVersion = "default";
 
       const filePathCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}`,
       );
       const contentCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
       );
@@ -881,12 +881,12 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       const reactVersion = "default";
 
       const filePathCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}`,
       );
       const contentCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
       );
@@ -951,7 +951,7 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       const configHash = computeConfigHashSync({ dev: true });
       const reactVersion = "default";
       const contentCacheKey = buildSSRModuleCacheKey(
-        VERSION,
+        RUNTIME_VERSION,
         projectId,
         `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
       );

--- a/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.ts
@@ -7,7 +7,7 @@
  * @module module-system/react-loader/ssr-module-loader/ssr-cache-manager
  */
 
-import { VERSION } from "#veryfront/utils/version.ts";
+import { RUNTIME_VERSION } from "#veryfront/utils/version.ts";
 import { INVALID_ARGUMENT } from "#veryfront/errors";
 import { buildSSRModuleCacheKey } from "#veryfront/cache/keys.ts";
 import { computeConfigHashSync } from "#veryfront/cache/config-hash.ts";
@@ -69,7 +69,7 @@ export class SSRCacheManager {
     const configHash = this.getConfigHash();
 
     return buildSSRModuleCacheKey(
-      VERSION,
+      RUNTIME_VERSION,
       this.options.projectId,
       `${this.options.contentSourceId}:${reactVersion}:${configHash}:${filePath}`,
     );
@@ -94,7 +94,13 @@ export class SSRCacheManager {
 
   async getTempPath(filePath: string, contentHash?: string): Promise<string> {
     const tmpDir = await this.ensureTmpDir();
-    return buildTempModulePath(tmpDir, filePath, this.options.projectDir, VERSION, contentHash);
+    return buildTempModulePath(
+      tmpDir,
+      filePath,
+      this.options.projectDir,
+      RUNTIME_VERSION,
+      contentHash,
+    );
   }
 
   isProductionContentSource(): boolean {
@@ -327,12 +333,12 @@ export class SSRCacheManager {
 
     const baseCacheDir = getMdxEsmCacheDir();
     const sourceKey = contentSourceId;
-    const cacheKey = getTmpDirCacheKey(baseCacheDir, projectId, sourceKey);
+    const cacheKey = getTmpDirCacheKey(baseCacheDir, projectId, sourceKey, RUNTIME_VERSION);
 
     const existingDir = globalTmpDirs.get(cacheKey);
     if (existingDir) return existingDir;
 
-    const tmpDir = buildTmpDirPath(baseCacheDir, projectId, sourceKey);
+    const tmpDir = buildTmpDirPath(baseCacheDir, projectId, sourceKey, RUNTIME_VERSION);
 
     await this.fs.mkdir(tmpDir, { recursive: true });
     globalTmpDirs.set(cacheKey, tmpDir);

--- a/src/modules/react-loader/ssr-module-loader/tmp-paths.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/tmp-paths.test.ts
@@ -2,22 +2,43 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { buildTempModulePath, buildTmpDirPath, getTmpDirCacheKey } from "./tmp-paths.ts";
+import { formatCacheVersionSegment } from "#veryfront/utils/cache-version.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 
 describe("modules/react-loader/ssr-module-loader/tmp-paths", () => {
   it("builds a stable tmp dir cache key with hashed project id", () => {
-    const key = getTmpDirCacheKey("/cache/mdx", "my/project", "release-1");
-    assertEquals(key, `/cache/mdx|${hashCodeHex("my/project")}|${hashCodeHex("release-1")}`);
+    const key = getTmpDirCacheKey("/cache/mdx", "my/project", "release-1", "0.1.7");
+    assertEquals(
+      key,
+      `/cache/mdx|v0-1-7|${hashCodeHex("my/project")}|${hashCodeHex("release-1")}`,
+    );
   });
 
   it("builds tmp dir path with hashed project id", () => {
-    const path = buildTmpDirPath("/cache/mdx", "my/project", "branch-main");
-    assertEquals(path, `/cache/mdx/${hashCodeHex("my/project")}/${hashCodeHex("branch-main")}`);
+    const path = buildTmpDirPath("/cache/mdx", "my/project", "branch-main", "0.1.7");
+    assertEquals(
+      path,
+      `/cache/mdx/v0-1-7/${hashCodeHex("my/project")}/${hashCodeHex("branch-main")}`,
+    );
+  });
+
+  it("isolates tmp directories by runtime version", () => {
+    const oldPath = buildTmpDirPath("/cache/mdx", "my/project", "branch-main", "0.1.9");
+    const newPath = buildTmpDirPath("/cache/mdx", "my/project", "branch-main", "0.1.1030");
+
+    assert(oldPath.includes("/v0-1-9/"));
+    assert(newPath.includes("/v0-1-1030/"));
+    assert(oldPath !== newPath);
   });
 
   it("does not nest slash-containing content source ids under their prefixes", () => {
-    const parent = buildTmpDirPath("/cache/mdx", "my/project", "preview-feature");
-    const child = buildTmpDirPath("/cache/mdx", "my/project", "preview-feature/refactor");
+    const parent = buildTmpDirPath("/cache/mdx", "my/project", "preview-feature", "0.1.7");
+    const child = buildTmpDirPath(
+      "/cache/mdx",
+      "my/project",
+      "preview-feature/refactor",
+      "0.1.7",
+    );
 
     assert(
       !child.startsWith(`${parent}/`),
@@ -60,11 +81,13 @@ describe("modules/react-loader/ssr-module-loader/tmp-paths", () => {
     // Regression: encodeURIComponent created dirs with literal %2F chars
     // which broke Deno's file:// URL module resolution.
     const deepPath = "/home/user/Documents/Projects/org/my-app";
-    const path = buildTmpDirPath("/cache/mdx", deepPath, "build-static");
-    const key = getTmpDirCacheKey("/cache/mdx", deepPath, "build-static");
+    const runtimeVersion = "0.1.7+build@42";
+    const path = buildTmpDirPath("/cache/mdx", deepPath, "build-static", runtimeVersion);
+    const key = getTmpDirCacheKey("/cache/mdx", deepPath, "build-static", runtimeVersion);
 
     assert(!path.includes("%"), `cache path must not contain percent-encoded chars: ${path}`);
     assert(!key.includes("%"), `cache key must not contain percent-encoded chars: ${key}`);
+    assert(path.includes(`/${formatCacheVersionSegment(runtimeVersion)}/`));
     assert(/^[a-f0-9]+$/.test(hashCodeHex(deepPath)), "project key should be hex-only");
   });
 });

--- a/src/modules/react-loader/ssr-module-loader/tmp-paths.ts
+++ b/src/modules/react-loader/ssr-module-loader/tmp-paths.ts
@@ -3,26 +3,32 @@
  */
 
 import { join } from "#veryfront/compat/path/index.ts";
+import { formatCacheVersionSegment } from "#veryfront/utils/cache-version.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
+import { RUNTIME_VERSION } from "#veryfront/utils/version.ts";
 
 export function getTmpDirCacheKey(
   baseCacheDir: string,
   projectId: string,
   contentSourceId: string,
+  runtimeVersion: string = RUNTIME_VERSION,
 ): string {
+  const versionKey = formatCacheVersionSegment(runtimeVersion);
   const projectKey = hashCodeHex(projectId);
   const sourceKey = hashCodeHex(contentSourceId);
-  return `${baseCacheDir}|${projectKey}|${sourceKey}`;
+  return `${baseCacheDir}|${versionKey}|${projectKey}|${sourceKey}`;
 }
 
 export function buildTmpDirPath(
   baseCacheDir: string,
   projectId: string,
   contentSourceId: string,
+  runtimeVersion: string = RUNTIME_VERSION,
 ): string {
+  const versionKey = formatCacheVersionSegment(runtimeVersion);
   const projectKey = hashCodeHex(projectId);
   const sourceKey = hashCodeHex(contentSourceId);
-  return join(baseCacheDir, projectKey, sourceKey);
+  return join(baseCacheDir, versionKey, projectKey, sourceKey);
 }
 
 export function buildTempModulePath(
@@ -37,7 +43,7 @@ export function buildTempModulePath(
     ? filePath.substring(normalizedProjectDir.length)
     : filePath;
 
-  const versionPrefix = version.replace(/\./g, "-");
+  const versionPrefix = formatCacheVersionSegment(version).replace(/^v/, "");
   const hashSuffix = contentHash
     ? `.v${versionPrefix}.${contentHash.slice(0, 8)}`
     : `.v${versionPrefix}`;

--- a/src/transforms/mdx/esm-module-loader/cache-format.ts
+++ b/src/transforms/mdx/esm-module-loader/cache-format.ts
@@ -1,7 +1,7 @@
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import { createCacheNamespace } from "#veryfront/utils/cache-namespace.ts";
 import { REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
-import { VERSION } from "#veryfront/utils/version.ts";
+import { RUNTIME_VERSION } from "#veryfront/utils/version.ts";
 import {
   resolveVeryfrontModuleTarget,
   resolveVeryfrontModuleUrl,
@@ -120,7 +120,7 @@ function buildMdxEsmCacheSchemaSample() {
       "veryfront/router": "./src/react/runtime/core.ts",
       "veryfront/context": "./src/react/runtime/core.ts",
     }),
-    frameworkVersion: VERSION,
+    frameworkVersion: RUNTIME_VERSION,
   };
 }
 

--- a/src/transforms/mdx/esm-module-loader/cache/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.test.ts
@@ -24,9 +24,41 @@ import { cacheModule } from "../module-fetcher/module-cache.ts";
 import { rendererLogger as log } from "#veryfront/utils";
 import { buildMdxEsmModuleFileName, buildMdxEsmPathCacheKey } from "../cache-format.ts";
 import { getCacheStats } from "#veryfront/utils/memory/index.ts";
+import { formatCacheVersionSegment } from "#veryfront/utils/cache-version.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
+import { RUNTIME_VERSION } from "#veryfront/utils/version.ts";
 
 describe("MDX module path cache", () => {
+  it("partitions SSR cache directories by runtime version", async () => {
+    const cacheBase = await makeTempDir({ prefix: "vf-mdx-versioned-cache-dir-" });
+    const projectId = "project-versioned-cache";
+    const contentSourceId = "preview-main";
+
+    try {
+      await runWithCacheDir(cacheBase, () => {
+        const projectKey = hashCodeHex(projectId);
+        const sourceKey = hashCodeHex(contentSourceId);
+        const versionKey = formatCacheVersionSegment(RUNTIME_VERSION);
+        const currentDir = getMdxEsmSsrCacheDir(projectId, contentSourceId);
+
+        assertEquals(
+          currentDir,
+          join(cacheBase, "veryfront-mdx-esm", versionKey, projectKey, sourceKey),
+        );
+        assertEquals(
+          getMdxEsmSsrCacheDirs(projectId, contentSourceId),
+          [
+            currentDir,
+            join(cacheBase, "veryfront-mdx-esm", projectKey, sourceKey),
+            join(cacheBase, "veryfront-mdx-esm", projectKey, contentSourceId),
+          ],
+        );
+      });
+    } finally {
+      await remove(cacheBase, { recursive: true });
+    }
+  });
+
   it("clears a project/content-source namespace from disk and memory", async () => {
     clearModulePathCache();
 
@@ -753,6 +785,61 @@ describe("invalidateMdxEsmModule (#2077 self-heal)", () => {
         await waitForDiskCleanup();
         clearModulePathCache();
         assertEquals((await getModulePathCache(legacyRawCacheDir)).get(key), undefined);
+      });
+    } finally {
+      await Promise.all([
+        remove(cacheBase, { recursive: true }).catch(() => {}),
+        remove(projectDir, { recursive: true }).catch(() => {}),
+      ]);
+      clearModulePathCache();
+    }
+  });
+
+  it("self-heals stale entries from older versioned cache dirs", async () => {
+    clearModulePathCache();
+
+    const cacheBase = await makeTempDir({ prefix: "vf-mdx-old-version-selfheal-" });
+    const projectDir = await makeTempDir({ prefix: "vf-mdx-old-version-project-" });
+    const filePath = join(projectDir, "app/page.tsx");
+    const projectId = "project-old-version-selfheal";
+    const contentSourceId = "preview-main";
+    const key = buildMdxEsmPathCacheKey("_vf_modules/app/page.js", "19.1.1");
+
+    try {
+      await runWithCacheDir(cacheBase, async () => {
+        const oldVersionCacheDir = join(
+          cacheBase,
+          "veryfront-mdx-esm",
+          formatCacheVersionSegment("0.1.1030"),
+          hashCodeHex(projectId),
+          hashCodeHex(contentSourceId),
+        );
+        const cachedPath = join(oldVersionCacheDir, buildMdxEsmModuleFileName("oldversion"));
+
+        await getLocalFs().mkdir(oldVersionCacheDir, { recursive: true });
+        await writeTextFile(cachedPath, `export default "old-version";`);
+        await writeTextFile(
+          join(oldVersionCacheDir, "_index.json"),
+          JSON.stringify({ [key]: cachedPath }),
+        );
+        const cache = await getModulePathCache(oldVersionCacheDir);
+        verifiedModuleDeps.set(`${cachedPath}:${key}`, true);
+
+        const invalidated = await invalidateMdxEsmModuleForCachedPath(
+          cachedPath,
+          filePath,
+          projectDir,
+          "19.1.1",
+          getMdxEsmSsrCacheDirs(projectId, contentSourceId),
+        );
+
+        assertEquals(invalidated, true);
+        assertEquals(cache.get(key), undefined);
+        assertEquals(verifiedModuleDeps.get(`${cachedPath}:${key}`), undefined);
+
+        await waitForDiskCleanup();
+        clearModulePathCache();
+        assertEquals((await getModulePathCache(oldVersionCacheDir)).get(key), undefined);
       });
     } finally {
       await Promise.all([

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -22,6 +22,11 @@ import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import { buildMdxEsmPathCacheKey, MDX_ESM_ALL_FILE_URL_PATTERN_SOURCE } from "../cache-format.ts";
 import { ensureMdxModuleDependencies } from "../module-fetcher/dependency-recovery.ts";
 import { findStaticImportFromSpans } from "../utils/source-spans.ts";
+import {
+  formatCacheVersionSegment,
+  isCacheVersionSegment,
+} from "#veryfront/utils/cache-version.ts";
+import { RUNTIME_VERSION } from "#veryfront/utils/version.ts";
 export { getLocalFs } from "./local-fs.ts";
 import { getLocalFs } from "./local-fs.ts";
 
@@ -151,6 +156,15 @@ const modulePathCaches = new Map<string, Map<string, string>>();
 const modulePathCacheLoaded = new Set<string>();
 
 export function getMdxEsmSsrCacheDir(projectId: string, contentSourceId: string): string {
+  return join(
+    getMdxEsmCacheDir(),
+    formatCacheVersionSegment(RUNTIME_VERSION),
+    hashCodeHex(projectId),
+    hashCodeHex(contentSourceId),
+  );
+}
+
+function getLegacyHashedMdxEsmSsrCacheDir(projectId: string, contentSourceId: string): string {
   return join(getMdxEsmCacheDir(), hashCodeHex(projectId), hashCodeHex(contentSourceId));
 }
 
@@ -161,6 +175,7 @@ function getLegacyRawMdxEsmSsrCacheDir(projectId: string, contentSourceId: strin
 export function getMdxEsmSsrCacheDirs(projectId: string, contentSourceId: string): string[] {
   return [
     getMdxEsmSsrCacheDir(projectId, contentSourceId),
+    getLegacyHashedMdxEsmSsrCacheDir(projectId, contentSourceId),
     getLegacyRawMdxEsmSsrCacheDir(projectId, contentSourceId),
   ].filter((cacheDir, index, cacheDirs) => cacheDirs.indexOf(cacheDir) === index);
 }
@@ -367,10 +382,16 @@ function getMdxEsmCacheDirForCachedPath(cachedPath: string): string | null {
   const prefix = baseCacheDir.endsWith("/") ? baseCacheDir : `${baseCacheDir}/`;
   if (!cachedPath.startsWith(prefix)) return null;
 
-  const [projectKey, sourceKey] = cachedPath.slice(prefix.length).split("/");
+  const parts = cachedPath.slice(prefix.length).split("/");
+  const [maybeVersionKey, maybeProjectKey, maybeSourceKey] = parts;
+  const hasVersionSegment = isCacheVersionSegment(maybeVersionKey);
+  const projectKey = hasVersionSegment ? maybeProjectKey : maybeVersionKey;
+  const sourceKey = hasVersionSegment ? maybeSourceKey : maybeProjectKey;
   if (!projectKey || !sourceKey) return null;
 
-  return join(baseCacheDir, projectKey, sourceKey);
+  return hasVersionSegment
+    ? join(baseCacheDir, maybeVersionKey!, projectKey, sourceKey)
+    : join(baseCacheDir, projectKey, sourceKey);
 }
 
 function isSameOrDescendantPath(path: string, parentPath: string): boolean {
@@ -429,7 +450,12 @@ export async function invalidateMdxEsmModuleForCachedPath(
   reactVersion = REACT_DEFAULT_VERSION,
   cacheDirs: string | string[] | null = getMdxEsmCacheDirForCachedPath(cachedPath),
 ): Promise<boolean> {
-  const candidateDirs = Array.isArray(cacheDirs) ? cacheDirs : cacheDirs ? [cacheDirs] : [];
+  const derivedCacheDir = getMdxEsmCacheDirForCachedPath(cachedPath);
+  const configuredDirs = Array.isArray(cacheDirs) ? cacheDirs : cacheDirs ? [cacheDirs] : [];
+  const candidateDirs = [
+    ...(derivedCacheDir ? [derivedCacheDir] : []),
+    ...configuredDirs,
+  ].filter((cacheDir, index, dirs) => dirs.indexOf(cacheDir) === index);
   if (candidateDirs.length === 0) return false;
 
   for (const cacheDir of candidateDirs) {

--- a/src/utils/cache-version.ts
+++ b/src/utils/cache-version.ts
@@ -1,0 +1,16 @@
+/**
+ * Helpers for using runtime versions in filesystem cache paths.
+ */
+
+export function formatCacheVersionSegment(version: string | number): string {
+  const normalized = String(version)
+    .replace(/^v(?=\d)/, "")
+    .replace(/[^A-Za-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return `v${normalized || "unknown"}`;
+}
+
+export function isCacheVersionSegment(segment: string | undefined): boolean {
+  return typeof segment === "string" && /^v\d[A-Za-z0-9_-]*$/.test(segment);
+}


### PR DESCRIPTION
## Summary
- partition SSR module cache keys and temp directories by `RUNTIME_VERSION`
- partition MDX-ESM SSR cache directories/namespaces by runtime version while keeping legacy dirs as cleanup candidates
- add regression coverage for runtime-versioned cache paths and stale older-version cache self-healing

## Why
Studio issue veryfront/veryfront-studio#5670 shows a production server reporting `veryfrontVersion: 0.1.9` importing a cached SSR artifact named `layout.v0-1-1030...js`. The stale-cache retry path detected the bad artifact, but retrying cannot make a rolled-back runtime satisfy imports compiled for a newer runtime.

## Verification
- `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/modules/react-loader/ssr-module-loader/tmp-paths.test.ts src/transforms/mdx/esm-module-loader/cache/index.test.ts src/modules/react-loader/ssr-module-loader/ssr-cache-manager.test.ts src/modules/react-loader/ssr-module-loader/loader.test.ts`
- `deno check src/utils/cache-version.ts src/modules/react-loader/ssr-module-loader/tmp-paths.ts src/modules/react-loader/ssr-module-loader/tmp-paths.test.ts src/modules/react-loader/ssr-module-loader/ssr-cache-manager.ts src/modules/react-loader/ssr-module-loader/loader.test.ts src/transforms/mdx/esm-module-loader/cache-format.ts src/transforms/mdx/esm-module-loader/cache/index.ts src/transforms/mdx/esm-module-loader/cache/index.test.ts src/modules/react-loader/ssr-module-loader/ssr-cache-manager.test.ts`
- `deno lint src/utils/cache-version.ts src/modules/react-loader/ssr-module-loader/tmp-paths.ts src/modules/react-loader/ssr-module-loader/tmp-paths.test.ts src/modules/react-loader/ssr-module-loader/ssr-cache-manager.ts src/modules/react-loader/ssr-module-loader/loader.test.ts src/transforms/mdx/esm-module-loader/cache-format.ts src/transforms/mdx/esm-module-loader/cache/index.ts src/transforms/mdx/esm-module-loader/cache/index.test.ts src/modules/react-loader/ssr-module-loader/ssr-cache-manager.test.ts`
- `deno task typecheck`
- `git diff --check`

Fixes veryfront/veryfront-studio#5670