### PR TITLE
Handle internal style artifact build runs

### DIFF
--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -11,6 +11,7 @@ import { runEval as runEvalDefinition } from "#veryfront/eval/runner.ts";
 import { datasets, evalAgent, type EvalReport, metrics } from "veryfront/eval";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { toolRegistry } from "#veryfront/tool";
 import {
   ProjectRunExecuteHandler,
@@ -151,6 +152,16 @@ function createDeps(
       logs: null,
       duration_ms: 10,
     }),
+    executeStyleArtifactBuild: async () => ({
+      success: true,
+      result: {
+        state: "ready",
+        artifactHash: "hash-1",
+        assetPath: "/_vf/css/hash-1.css",
+      },
+      logs: null,
+      duration_ms: 12,
+    }),
     ensureProjectDiscovery: async () => {
       const discovery = createEmptyDiscoveryResult();
       discovery.tasks.set("sync-calendar-events", {
@@ -181,6 +192,11 @@ function createEmptyDiscoveryResult(): DiscoveryResult {
   };
 }
 
+function requestJsonBody(init: RequestInit | undefined): Record<string, unknown> | null {
+  const body = init?.body;
+  return typeof body === "string" ? JSON.parse(body) as Record<string, unknown> : null;
+}
+
 async function signedRequest(
   path: string,
   body: Record<string, unknown>,
@@ -204,6 +220,101 @@ async function signedRequest(
       },
       body: rawBody,
     }),
+  };
+}
+
+function createStyleArtifactCtx(
+  publicKeyPem: string,
+  options: {
+    files: Array<{ path: string; content?: string }>;
+    stylesheet?: string;
+    stylesheetPath?: string;
+    contentContext?: {
+      sourceType: "branch" | "environment" | "release";
+      projectSlug: string;
+      branch?: string;
+      environmentName?: string;
+      releaseId?: string;
+    };
+  },
+): { ctx: HandlerContext; readCalls: string[]; sourceFileCalls: { count: number } } {
+  const ctx = createCtx(publicKeyPem);
+  const readCalls: string[] = [];
+  const sourceFileCalls = { count: 0 };
+  const stylesheetPath = options.stylesheetPath ?? "src/styles.css";
+  const underlyingAdapter = {
+    async getAllSourceFiles() {
+      sourceFileCalls.count++;
+      return options.files;
+    },
+    getContentContext() {
+      return options.contentContext ?? {
+        sourceType: "environment" as const,
+        projectSlug: "demo-project",
+        environmentName: "Preview",
+      };
+    },
+  };
+
+  ctx.projectDir = "/unrelated-runtime-dir";
+  ctx.config = { tailwind: { stylesheet: stylesheetPath } };
+  ctx.environmentName = "Preview";
+  ctx.adapter = ({
+    ...ctx.adapter,
+    fs: {
+      getUnderlyingAdapter: () => underlyingAdapter,
+      async readFile(path: string) {
+        readCalls.push(path);
+        if (path === stylesheetPath && options.stylesheet !== undefined) {
+          return options.stylesheet;
+        }
+        throw new Error(`Missing test file: ${path}`);
+      },
+    },
+  } as unknown) as HandlerContext["adapter"];
+
+  return { ctx, readCalls, sourceFileCalls };
+}
+
+function createStyleArtifactFetchRecorder(): {
+  upserts: Record<string, unknown>[];
+  fetch: typeof fetch;
+} {
+  const upserts: Record<string, unknown>[] = [];
+
+  return {
+    upserts,
+    fetch: ((input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof Request
+        ? input.url
+        : input.toString();
+      if (url.endsWith("/projects/demo-project/style-artifacts/current")) {
+        const body = requestJsonBody(init) ?? {};
+        upserts.push(body);
+        const artifactHash = typeof body.artifact_hash === "string"
+          ? body.artifact_hash
+          : undefined;
+
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              status: body.status === "failed" ? "failed" : "ready",
+              ...(artifactHash ? { artifact_hash: artifactHash } : {}),
+              asset_path: artifactHash ? `/_vf/css/${artifactHash}.css` : undefined,
+              content_type: "text/css; charset=utf-8",
+              etag: artifactHash ? `"${artifactHash}"` : undefined,
+              failure_reason: body.failure_reason,
+              updated_at: "2026-07-08T00:00:00.000Z",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+
+      return Promise.resolve(new Response("Not found", { status: 404, statusText: "Not Found" }));
+    }) as typeof fetch,
   };
 }
 
@@ -376,6 +487,144 @@ describe("server/handlers/request/project-run-execute.handler", () => {
       duration_ms: 51,
     });
     assertEquals(receivedConfig, { upload_ids: ["upload-1"] });
+  });
+
+  it("dispatches built-in style artifact builds through the reusable style executor", async () => {
+    let receivedConfig: Record<string, unknown> | undefined;
+    let attemptedProjectDiscovery = false;
+    const handler = new ProjectRunExecuteHandler(createDeps({
+      ensureProjectDiscovery: async () => {
+        attemptedProjectDiscovery = true;
+        return createEmptyDiscoveryResult();
+      },
+      executeStyleArtifactBuild: async (input) => {
+        receivedConfig = input.request.config;
+        return {
+          success: true,
+          result: {
+            state: "ready",
+            artifactHash: "hash-1",
+            assetPath: "/_vf/css/hash-1.css",
+          },
+          logs: null,
+          duration_ms: 12,
+        };
+      },
+    }));
+    const body = {
+      runId: "run_style_artifact_1",
+      kind: "task",
+      target: "task:style-artifact-build",
+      projectId: "proj-1",
+      config: { environment_name: "preview" },
+    };
+    const { request, publicKeyPem } = await signedRequest(
+      "/api/control-plane/runs/run_style_artifact_1/execute",
+      body,
+    );
+
+    const result = await handler.handle(request, createCtx(publicKeyPem));
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(await result.response.json(), {
+      success: true,
+      result: {
+        state: "ready",
+        artifactHash: "hash-1",
+        assetPath: "/_vf/css/hash-1.css",
+      },
+      logs: null,
+      duration_ms: 12,
+    });
+    assertEquals(receivedConfig, { environment_name: "preview" });
+    assertEquals(attemptedProjectDiscovery, false);
+  });
+
+  it("builds style artifacts from adapter source files and adapter stylesheet reads", async () => {
+    const body = {
+      runId: "run_style_artifact_adapter_source",
+      kind: "task",
+      target: "task:style-artifact-build",
+      projectId: "proj-1",
+      config: { environment_name: "Preview" },
+    };
+    const { request, publicKeyPem } = await signedRequest(
+      "/api/control-plane/runs/run_style_artifact_adapter_source/execute",
+      body,
+      { "x-token": "test-token" },
+    );
+    const { ctx, readCalls, sourceFileCalls } = createStyleArtifactCtx(publicKeyPem, {
+      files: [{
+        path: "pages/index.tsx",
+        content:
+          'export default function Page() { return <main className="px-4 text-red-500">Hi</main>; }',
+      }],
+      stylesheet: "@tailwind utilities; .from-css { color: red; }",
+      stylesheetPath: "src/styles.css",
+    });
+    const recorder = createStyleArtifactFetchRecorder();
+
+    const result = await withMockFetch(
+      recorder.fetch,
+      async () => await new ProjectRunExecuteHandler().handle(request, ctx),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    const json = await result.response.json();
+    assertEquals(json.success, true);
+    assertEquals(sourceFileCalls.count, 1);
+    assertEquals(readCalls, ["src/styles.css"]);
+    assertEquals(recorder.upserts.length, 1);
+    assertEquals(recorder.upserts[0]?.environment_name, "Preview");
+    assertEquals(recorder.upserts[0]?.status, "ready");
+    assertEquals(typeof recorder.upserts[0]?.artifact_hash, "string");
+  });
+
+  it("rejects mismatched style profile hashes before scanning source files", async () => {
+    const body = {
+      runId: "run_style_artifact_hash_mismatch",
+      kind: "task",
+      target: "task:style-artifact-build",
+      projectId: "proj-1",
+      config: {
+        environment_name: "Preview",
+        style_profile_hash: "queued-profile-hash",
+      },
+    };
+    const { request, publicKeyPem } = await signedRequest(
+      "/api/control-plane/runs/run_style_artifact_hash_mismatch/execute",
+      body,
+      { "x-token": "test-token" },
+    );
+    const { ctx, sourceFileCalls } = createStyleArtifactCtx(publicKeyPem, {
+      files: [{
+        path: "pages/index.tsx",
+        content: 'export default function Page() { return <main className="px-4">Hi</main>; }',
+      }],
+      stylesheet: "@tailwind utilities;",
+    });
+    const recorder = createStyleArtifactFetchRecorder();
+
+    const result = await withMockFetch(
+      recorder.fetch,
+      async () => await new ProjectRunExecuteHandler().handle(request, ctx),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    const json = await result.response.json();
+    assertEquals(json.success, false);
+    assertStringIncludes(json.error, "Style profile hash mismatch");
+    assertEquals(sourceFileCalls.count, 0);
+    assertEquals(recorder.upserts.length, 1);
+    assertEquals(recorder.upserts[0]?.style_profile_hash, "queued-profile-hash");
+    assertEquals(recorder.upserts[0]?.status, "failed");
+    assertStringIncludes(
+      String(recorder.upserts[0]?.failure_reason),
+      "Style profile hash mismatch",
+    );
   });
 
   it("runs a discovered workflow with the canonical run id and input", async () => {
@@ -975,7 +1224,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
           token: "runtime-token",
           slug: "demo-project",
           branch: "main",
-          mode: "preview",
+          mode: "preview" as const,
         },
         resolvedEnvironment: "preview",
       } as HandlerContext;

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -10,6 +10,9 @@ import {
   readInternalAgentRequestBody,
 } from "#veryfront/internal-agents/request-body.ts";
 import type { RuntimeAdapter } from "#veryfront/platform";
+import type { VeryfrontApiClient } from "#veryfront/platform/adapters/veryfront-api-client/client.ts";
+import type { ResolvedContentContext } from "#veryfront/platform/adapters/fs/veryfront/types.ts";
+import type { StyleScopeProfile } from "#veryfront/html/styles-builder/style-scope-profile.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import type { DiscoveryResult } from "#veryfront/discovery";
@@ -133,6 +136,11 @@ export interface ProjectRunExecuteHandlerDeps {
     req: Request;
   }): Promise<ProjectRunExecuteResponse>;
   executeReleaseAssetBuild(input: {
+    request: ProjectRunExecuteRequest;
+    ctx: HandlerContext;
+    req: Request;
+  }): Promise<ProjectRunExecuteResponse>;
+  executeStyleArtifactBuild(input: {
     request: ProjectRunExecuteRequest;
     ctx: HandlerContext;
     req: Request;
@@ -1096,6 +1104,247 @@ async function executeReleaseAssetBuildRun(input: {
   }
 }
 
+type StyleArtifactBuildSelector = {
+  branch?: string;
+  environmentName?: string;
+  releaseId?: string;
+};
+
+type StyleArtifactSourceFile = { path: string; content?: string };
+
+type StyleArtifactSourceProvider = {
+  getAllSourceFiles: () => Promise<StyleArtifactSourceFile[]> | StyleArtifactSourceFile[];
+  getContentContext?: () => ResolvedContentContext | null;
+};
+
+const DEFAULT_STYLESHEET_PATHS = [
+  "globals.css",
+  "global.css",
+  "styles/globals.css",
+  "app/globals.css",
+  "src/globals.css",
+  "src/styles/globals.css",
+];
+
+function optionalString(value: string | null | undefined): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function resolveStyleArtifactBuildSelector(
+  config: Record<string, unknown>,
+  ctx: HandlerContext,
+): StyleArtifactBuildSelector {
+  const selector: StyleArtifactBuildSelector = {
+    branch: getStringConfig(config, ["branch"]) ?? optionalString(ctx.parsedDomain?.branch),
+    environmentName: getStringConfig(config, ["environment_name", "environmentName"]) ??
+      optionalString(ctx.environmentName),
+    releaseId: getStringConfig(config, ["release_id", "releaseId"]) ??
+      optionalString(ctx.releaseId),
+  };
+  const count = [selector.branch, selector.environmentName, selector.releaseId]
+    .filter((value) => typeof value === "string" && value.length > 0).length;
+
+  if (count !== 1) {
+    throw new Error("Exactly one style artifact selector is required");
+  }
+
+  return selector;
+}
+
+function getStyleArtifactSourceProvider(ctx: HandlerContext): StyleArtifactSourceProvider | null {
+  const wrappedFs = ctx.adapter.fs as { getUnderlyingAdapter?: () => unknown };
+  if (typeof wrappedFs.getUnderlyingAdapter !== "function") return null;
+
+  const fsAdapter = wrappedFs.getUnderlyingAdapter() as {
+    getAllSourceFiles?: StyleArtifactSourceProvider["getAllSourceFiles"];
+    getContentContext?: StyleArtifactSourceProvider["getContentContext"];
+  };
+  if (typeof fsAdapter.getAllSourceFiles !== "function") return null;
+
+  return {
+    getAllSourceFiles: fsAdapter.getAllSourceFiles.bind(fsAdapter),
+    getContentContext: typeof fsAdapter.getContentContext === "function"
+      ? fsAdapter.getContentContext.bind(fsAdapter)
+      : undefined,
+  };
+}
+
+function stylesheetCandidatePaths(stylesheetPath?: string): string[] {
+  return stylesheetPath ? [stylesheetPath.replace(/^\/+/, "")] : DEFAULT_STYLESHEET_PATHS;
+}
+
+function textFromFileContent(content: Uint8Array | string): string {
+  return typeof content === "string" ? content : new TextDecoder().decode(content);
+}
+
+async function readStylesheetFromAdapter(
+  ctx: HandlerContext,
+  stylesheetPath?: string,
+): Promise<string | undefined> {
+  for (const path of stylesheetCandidatePaths(stylesheetPath)) {
+    try {
+      const content = await ctx.adapter.fs.readFile(path);
+      if (content) return textFromFileContent(content);
+    } catch {
+      // keep searching
+    }
+  }
+
+  return undefined;
+}
+
+async function resolveStyleArtifactSourceFiles(
+  ctx: HandlerContext,
+  styleProfile: StyleScopeProfile,
+  collectLocalProjectSourceFiles: (
+    options: { projectDir: string; styleProfile: StyleScopeProfile },
+  ) => Promise<StyleArtifactSourceFile[]>,
+): Promise<{ files: StyleArtifactSourceFile[]; contentContext: ResolvedContentContext | null }> {
+  const sourceProvider = getStyleArtifactSourceProvider(ctx);
+  if (sourceProvider) {
+    return {
+      files: await sourceProvider.getAllSourceFiles(),
+      contentContext: sourceProvider.getContentContext?.() ?? null,
+    };
+  }
+
+  return {
+    files: await collectLocalProjectSourceFiles({
+      projectDir: ctx.projectDir,
+      styleProfile,
+    }),
+    contentContext: null,
+  };
+}
+
+async function executeStyleArtifactBuildRun(input: {
+  request: ProjectRunExecuteRequest;
+  ctx: HandlerContext;
+  req: Request;
+}): Promise<ProjectRunExecuteResponse> {
+  const startedAt = Date.now();
+  const config = input.request.config ?? {};
+  const projectReference = input.ctx.projectSlug ?? input.request.projectId;
+  let apiClient: VeryfrontApiClient | null = null;
+  let selector: StyleArtifactBuildSelector | null = null;
+  let styleProfileHash: string | null = null;
+
+  try {
+    const { VeryfrontApiClient } = await import(
+      "#veryfront/platform/adapters/veryfront-api-client/client.ts"
+    );
+    const {
+      buildPreparedCSSArtifactFromFiles,
+      collectLocalProjectSourceFiles,
+      findStylesheetFromFiles,
+      readLocalProjectStylesheet,
+    } = await import("#veryfront/html/styles-builder/css-pregeneration.ts");
+    const { resolveStyleContentVersion } = await import(
+      "#veryfront/html/styles-builder/content-version.ts"
+    );
+    const { createStyleScopeProfile } = await import(
+      "#veryfront/html/styles-builder/style-scope-profile.ts"
+    );
+
+    const token = input.req.headers.get("x-token") ?? input.ctx.proxyToken ??
+      input.ctx.requestContext?.token ?? "";
+    if (!token) throw new Error("Missing project runtime API token");
+
+    apiClient = new VeryfrontApiClient({
+      apiBaseUrl: getEnvironmentConfig().apiBaseUrl,
+      apiToken: token,
+      projectSlug: projectReference,
+      projectId: input.ctx.projectId,
+    });
+    apiClient.setProjectSlug(projectReference);
+
+    selector = resolveStyleArtifactBuildSelector(config, input.ctx);
+    const styleProfile = createStyleScopeProfile(input.ctx.config);
+    const requestedStyleProfileHash = getStringConfig(config, [
+      "style_profile_hash",
+      "styleProfileHash",
+    ]);
+    styleProfileHash = requestedStyleProfileHash ?? styleProfile.hash;
+
+    if (requestedStyleProfileHash && requestedStyleProfileHash !== styleProfile.hash) {
+      throw new Error(
+        `Style profile hash mismatch: expected ${requestedStyleProfileHash}, got ${styleProfile.hash}`,
+      );
+    }
+
+    const { files, contentContext } = await resolveStyleArtifactSourceFiles(
+      input.ctx,
+      styleProfile,
+      collectLocalProjectSourceFiles,
+    );
+    if (files.length === 0) {
+      throw new Error("No project source files were available to build the style artifact");
+    }
+
+    const stylesheetPath = input.ctx.config?.tailwind?.stylesheet;
+    const stylesheet = findStylesheetFromFiles(files, stylesheetPath) ??
+      (getStyleArtifactSourceProvider(input.ctx)
+        ? await readStylesheetFromAdapter(input.ctx, stylesheetPath)
+        : await readLocalProjectStylesheet(input.ctx.projectDir, stylesheetPath));
+    const result = await buildPreparedCSSArtifactFromFiles({
+      projectSlug: projectReference,
+      projectVersion: resolveStyleContentVersion(contentContext, {
+        branch: selector.branch,
+        environmentName: selector.environmentName,
+        releaseId: selector.releaseId,
+      }),
+      projectDir: input.ctx.projectDir,
+      files,
+      styleProfile,
+      stylesheet,
+      stylesheetPath,
+      minify: true,
+      environment: "preview",
+      buildMode: "production",
+    });
+
+    await apiClient.upsertStyleArtifact({
+      ...selector,
+      styleProfileHash,
+      status: "ready",
+      artifactHash: result.hash,
+      assetPath: `/_vf/css/${result.hash}.css`,
+      contentType: "text/css; charset=utf-8",
+      buildRunId: input.request.runId,
+    });
+
+    return {
+      success: true,
+      result: {
+        state: "ready",
+        artifactHash: result.hash,
+        assetPath: `/_vf/css/${result.hash}.css`,
+        candidateCount: result.candidateCount,
+        fromCache: result.fromCache,
+      },
+      logs: null,
+      duration_ms: Date.now() - startedAt,
+    };
+  } catch (error) {
+    if (apiClient && selector && styleProfileHash) {
+      await apiClient.upsertStyleArtifact({
+        ...selector,
+        styleProfileHash,
+        status: "failed",
+        buildRunId: input.request.runId,
+        failureReason: errorMessage(error),
+      }).catch(() => undefined);
+    }
+
+    return {
+      success: false,
+      error: errorMessage(error),
+      logs: null,
+      duration_ms: Date.now() - startedAt,
+    };
+  }
+}
+
 const defaultDeps: ProjectRunExecuteHandlerDeps = {
   runTask,
   findWorkflowById,
@@ -1107,6 +1356,7 @@ const defaultDeps: ProjectRunExecuteHandlerDeps = {
   ensureProjectDiscovery,
   executeKnowledgeIngest: executeKnowledgeIngestRun,
   executeReleaseAssetBuild: executeReleaseAssetBuildRun,
+  executeStyleArtifactBuild: executeStyleArtifactBuildRun,
   sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   now: () => Date.now(),
 };
@@ -1163,6 +1413,8 @@ export class ProjectRunExecuteHandler extends BaseHandler {
             ? await this.deps.executeKnowledgeIngest({ request, ctx, req })
             : request.kind === "task" && request.target === "task:release-asset-build"
             ? await this.deps.executeReleaseAssetBuild({ request, ctx, req })
+            : request.kind === "task" && request.target === "task:style-artifact-build"
+            ? await this.deps.executeStyleArtifactBuild({ request, ctx, req })
             : request.kind === "task"
             ? await executeTaskRun(request, ctx, this.deps)
             : request.kind === "eval"


### PR DESCRIPTION
## Summary
- dispatch task:style-artifact-build as an internal project-runtime task instead of user task discovery
- build and register prepared CSS style artifacts through the existing style artifact API
- add a regression test proving the internal task target does not call findTaskById

## Validation
- deno fmt --check src/server/handlers/request/project-run-execute.handler.ts src/server/handlers/request/project-run-execute.handler.test.ts
- deno check src/server/handlers/request/project-run-execute.handler.ts src/server/handlers/request/project-run-execute.handler.test.ts
- deno test --no-check --allow-all src/server/handlers/request/project-run-execute.handler.test.ts
- pre-push hook: formatting, lint, typecheck, unit tests (2220 passed, 0 failed)