### PR TITLE
Deduplicate render bursts before taking slots

### DIFF
--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -12,6 +12,7 @@ import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import type { CachePayload, CacheStore } from "./cache/types.ts";
 import type { RenderContext } from "./context/render-context.ts";
 import { destroyRenderer, getRenderer, initializeRenderer, Renderer } from "./renderer.ts";
+import { projectRenderCounts } from "./renderer-concurrency.ts";
 
 function getEnv(name: string): string | undefined {
   // deno-lint-ignore no-explicit-any
@@ -496,6 +497,67 @@ describe("Renderer release asset cache isolation", () => {
     assertEquals(renderedSlugs, ["/"]);
     assertEquals(getAllPagesCalls, 0);
     assertEquals(store.data.size, 0);
+  });
+
+  it("deduplicates identical cacheable render misses before taking project slots", async () => {
+    const store = createInMemoryStore();
+    const renderer = new Renderer({ cache: { store } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+
+    let renderCalls = 0;
+    let releaseRender!: () => void;
+    const renderGate = new Promise<void>((resolve) => {
+      releaseRender = resolve;
+    });
+
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: (slug: string) => Promise<{
+            html: string;
+            frontmatter: Record<string, unknown>;
+            headings: never[];
+            stream: null;
+          }>;
+        };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: async (slug) => {
+          renderCalls++;
+          await renderGate;
+          return {
+            html: `<html>${slug}</html>`,
+            frontmatter: {},
+            headings: [],
+            stream: null,
+          };
+        },
+      },
+    });
+
+    const ctx = makeRenderContext();
+    const renders = Array.from(
+      { length: 11 },
+      () =>
+        renderer.renderPage("/burst", ctx, {
+          environment: "production",
+          releaseId: "rel-1",
+          releaseAssetManifest: null,
+        }),
+    );
+
+    for (let i = 0; i < 20 && renderCalls === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    releaseRender();
+    const results = await Promise.all(renders);
+
+    assertEquals(results.length, 11);
+    assertEquals(renderCalls, 1);
+    assertEquals(projectRenderCounts.get(ctx.projectId) ?? 0, 0);
   });
 });
 

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -294,60 +294,15 @@ export class Renderer {
           return cacheResult.cachedResult;
         }
 
-        if (!(await acquireProjectSlot(effectiveCtx.projectId))) {
-          const activeCount = projectRenderCounts.get(effectiveCtx.projectId) ?? 0;
-          logger.error("Per-project render limit reached", {
-            slug,
-            projectId: effectiveCtx.projectId,
-            activeRenders: activeCount,
-            limit: RENDER_PER_PROJECT_LIMIT,
-          });
-          throw SERVICE_OVERLOADED.create({
-            detail:
-              `Per-project render limit reached (${activeCount}/${RENDER_PER_PROJECT_LIMIT} active). Try again shortly.`,
-            context: {
-              slug,
-              projectId: ctx.projectId,
-              activeRenders: activeCount,
-              limit: RENDER_PER_PROJECT_LIMIT,
-            },
-          });
-        }
-
-        const acquired = await renderSemaphore.tryAcquire(RENDER_ACQUIRE_TIMEOUT_MS);
-        if (!acquired) {
-          await releaseProjectSlot(effectiveCtx.projectId);
-          logger.error("Render capacity exceeded - service overloaded", {
-            slug,
-            projectId: effectiveCtx.projectId,
-            waiting: renderSemaphore.waiting,
-            available: renderSemaphore.available,
-          });
-          throw SERVICE_OVERLOADED.create({
-            detail:
-              `Render capacity exceeded (${renderSemaphore.waiting} waiting). Service is overloaded.`,
-            context: { slug, projectId: ctx.projectId, waiting: renderSemaphore.waiting },
-          });
-        }
-
-        let renderedSuccessfully = false;
-        try {
-          const result = await this.doRenderPage(
-            slug,
-            effectiveCtx,
-            effectiveOptions,
-            startTime,
-            cacheKey,
-          );
-          renderedSuccessfully = true;
-          return result;
-        } finally {
-          renderSemaphore.release();
-          await releaseProjectSlot(effectiveCtx.projectId);
-          if (renderedSuccessfully) {
-            this.scheduleProductionRenderPrewarm(slug, effectiveCtx, effectiveOptions, cacheKey);
-          }
-        }
+        const result = await this.doRenderPage(
+          slug,
+          effectiveCtx,
+          effectiveOptions,
+          startTime,
+          cacheKey,
+        );
+        this.scheduleProductionRenderPrewarm(slug, effectiveCtx, effectiveOptions, cacheKey);
+        return result;
       },
       {
         "renderer.slug": slug,
@@ -571,24 +526,8 @@ export class Renderer {
     const isFollower = cacheKey !== null ? this.renderFlight.has(flightKey) : false;
 
     const runRender = async () => {
-      const services = this.createServicesForContext(ctx, options?.colorScheme);
-
-      let result: RenderResult;
       try {
-        result = await withTimeoutThrow(
-          services.pipeline.renderPage(slug, {
-            ...options,
-            delivery: "string",
-            projectId: ctx.projectId,
-            projectSlug: ctx.projectSlug,
-            environment: ctx.environment,
-            contentSourceId: ctx.contentSourceId,
-            skipCacheCheck: true,
-            skipCachePersist: true,
-          }),
-          RENDER_PIPELINE_TIMEOUT_MS,
-          `Render pipeline for ${ctx.projectId}:${slug}`,
-        );
+        return await this.runRenderWithCapacity(slug, ctx, options, startTime, cacheKey);
       } catch (error) {
         if (error instanceof TimeoutError) {
           logger.error("Render pipeline timeout - aborting", {
@@ -599,25 +538,6 @@ export class Renderer {
         }
         throw error;
       }
-
-      if (cacheKey !== null) {
-        await this.cache.persistResult(result, slug, ctx, options?.colorScheme, cacheKey);
-      }
-
-      logger.debug("Render complete (leader)", {
-        slug,
-        projectId: ctx.projectId,
-        duration: `${(performance.now() - startTime).toFixed(2)}ms`,
-        htmlLength: result.html?.length ?? 0,
-      });
-
-      return {
-        html: result.html,
-        frontmatter: result.frontmatter,
-        headings: result.headings,
-        ssrHash: result.ssrHash,
-        pageModule: result.pageModule,
-      };
     };
 
     const cachedData = cacheKey !== null
@@ -641,6 +561,90 @@ export class Renderer {
       pageModule: cachedData.pageModule,
       stream: null,
     };
+  }
+
+  private async runRenderWithCapacity(
+    slug: string,
+    ctx: RenderContext,
+    options: RenderOptions | undefined,
+    startTime: number,
+    cacheKey: string | null,
+  ): Promise<CachedRenderData> {
+    if (!(await acquireProjectSlot(ctx.projectId))) {
+      const activeCount = projectRenderCounts.get(ctx.projectId) ?? 0;
+      logger.error("Per-project render limit reached", {
+        slug,
+        projectId: ctx.projectId,
+        activeRenders: activeCount,
+        limit: RENDER_PER_PROJECT_LIMIT,
+      });
+      throw SERVICE_OVERLOADED.create({
+        detail:
+          `Per-project render limit reached (${activeCount}/${RENDER_PER_PROJECT_LIMIT} active). Try again shortly.`,
+        context: {
+          slug,
+          projectId: ctx.projectId,
+          activeRenders: activeCount,
+          limit: RENDER_PER_PROJECT_LIMIT,
+        },
+      });
+    }
+
+    const acquired = await renderSemaphore.tryAcquire(RENDER_ACQUIRE_TIMEOUT_MS);
+    if (!acquired) {
+      await releaseProjectSlot(ctx.projectId);
+      logger.error("Render capacity exceeded - service overloaded", {
+        slug,
+        projectId: ctx.projectId,
+        waiting: renderSemaphore.waiting,
+        available: renderSemaphore.available,
+      });
+      throw SERVICE_OVERLOADED.create({
+        detail:
+          `Render capacity exceeded (${renderSemaphore.waiting} waiting). Service is overloaded.`,
+        context: { slug, projectId: ctx.projectId, waiting: renderSemaphore.waiting },
+      });
+    }
+
+    try {
+      const services = this.createServicesForContext(ctx, options?.colorScheme);
+      const result = await withTimeoutThrow(
+        services.pipeline.renderPage(slug, {
+          ...options,
+          delivery: "string",
+          projectId: ctx.projectId,
+          projectSlug: ctx.projectSlug,
+          environment: ctx.environment,
+          contentSourceId: ctx.contentSourceId,
+          skipCacheCheck: true,
+          skipCachePersist: true,
+        }),
+        RENDER_PIPELINE_TIMEOUT_MS,
+        `Render pipeline for ${ctx.projectId}:${slug}`,
+      );
+
+      if (cacheKey !== null) {
+        await this.cache.persistResult(result, slug, ctx, options?.colorScheme, cacheKey);
+      }
+
+      logger.debug("Render complete (leader)", {
+        slug,
+        projectId: ctx.projectId,
+        duration: `${(performance.now() - startTime).toFixed(2)}ms`,
+        htmlLength: result.html?.length ?? 0,
+      });
+
+      return {
+        html: result.html,
+        frontmatter: result.frontmatter,
+        headings: result.headings,
+        ssrHash: result.ssrHash,
+        pageModule: result.pageModule,
+      };
+    } finally {
+      renderSemaphore.release();
+      await releaseProjectSlot(ctx.projectId);
+    }
   }
 
   resolvePageData(


### PR DESCRIPTION
## Summary
- move per-project/global render capacity acquisition into the existing render singleflight leader path
- keep cacheable followers outside the render limiter so identical cold-cache bursts share one slot and one render
- add a regression for 11 identical cacheable render misses, proving one render and no leaked project slots

## Why
Studio issue veryfront/veryfront-studio#5585 shows a thundering-herd on one cacheable URL filling all 10 per-project render slots. The renderer already had singleflight dedupe, but it happened after slot acquisition, so followers still consumed permits before they could deduplicate.

## Verification
- First ran `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/rendering/renderer.test.ts` before the fix and reproduced `Per-project render limit reached (10/10 active)`
- `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/rendering/renderer.test.ts`
- `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/rendering/renderer-concurrency.test.ts tests/integration/critical-bugs/cache-behavioral-parity.test.ts`
- `deno check src/rendering/renderer.ts src/rendering/renderer.test.ts src/rendering/renderer-concurrency.test.ts`
- `deno lint src/rendering/renderer.ts src/rendering/renderer.test.ts src/rendering/renderer-concurrency.test.ts`
- `deno task typecheck`
- `git diff --check`
- pre-push hook: format, lint, typecheck, generated manifests, and unit tests (`2302 passed`)

Fixes veryfront/veryfront-studio#5585
Related: veryfront/veryfront-issue-inbox#51