### PR TITLE
fix: drain Anthropic gateway usage stream

### DIFF
--- a/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
@@ -23,6 +23,30 @@ function streamFromChunks(
   });
 }
 
+function streamFromChunksWithCancelSpy(
+  chunks: string[],
+  options: { closeDelayMs?: number; onCancel: () => void },
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let closeTimer: ReturnType<typeof setTimeout> | undefined;
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      if (options.closeDelayMs !== undefined) {
+        closeTimer = setTimeout(() => controller.close(), options.closeDelayMs);
+      }
+    },
+    cancel() {
+      if (closeTimer) {
+        clearTimeout(closeTimer);
+      }
+      options.onCancel();
+    },
+  });
+}
+
 async function collectParts(stream: ReadableStream<Uint8Array>): Promise<unknown[]> {
   const parts: unknown[] = [];
   for await (const part of streamAnthropicCompatibleParts(stream)) {
@@ -303,6 +327,60 @@ describe("ext-llm-anthropic/anthropic-stream", () => {
         },
       },
     ]);
+  });
+
+  it("drains the gateway billing metadata close after a client tool-use step", async () => {
+    let cancelCount = 0;
+    const parts = await collectParts(streamFromChunksWithCancelSpy([
+      [
+        data({
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "tool_use", id: "toolu_1", name: "bash" },
+        }),
+        data({
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "input_json_delta", partial_json: '{"command":"pwd"}' },
+        }),
+        data({ type: "content_block_stop", index: 0 }),
+        data({
+          type: "message_delta",
+          delta: { stop_reason: "tool_use" },
+          usage: { output_tokens: 4 },
+        }),
+        data({ type: "message_stop" }),
+      ].join(""),
+      data({
+        type: "message_delta",
+        delta: {},
+        usage: {
+          input_tokens: 10,
+          output_tokens: 4,
+          veryfront: {
+            billable_input_tokens: 10,
+            billable_output_tokens: 4,
+            cost_source: "gateway",
+            usage_capture_status: "complete",
+          },
+        },
+      }),
+    ], { closeDelayMs: 5, onCancel: () => cancelCount++ }));
+
+    assertEquals(cancelCount, 0);
+    assertEquals(parts.at(-1), {
+      type: "finish",
+      finishReason: { unified: "tool-calls", raw: "tool_use" },
+      usage: {
+        inputTokens: 10,
+        outputTokens: 4,
+        totalTokens: 14,
+        billableInputTokens: 10,
+        billableOutputTokens: 4,
+        costSource: "gateway",
+        usageCaptureStatus: "complete",
+      },
+    });
   });
 
   it("finishes a client tool-use step when trailing metadata never arrives", async () => {

--- a/extensions/ext-llm-anthropic/src/anthropic-stream.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-stream.ts
@@ -134,22 +134,6 @@ function isToolCallsFinishReason(
     (typeof finishReason === "object" && finishReason?.unified === "tool-calls");
 }
 
-function hasGatewayUsageMetadata(usage: RuntimeUsage | undefined): boolean {
-  return usage?.billableInputTokens !== undefined ||
-    usage?.billableOutputTokens !== undefined ||
-    usage?.providerInputCostUsd !== undefined ||
-    usage?.providerOutputCostUsd !== undefined ||
-    usage?.providerCostUsd !== undefined ||
-    usage?.veryfrontInputChargeUsd !== undefined ||
-    usage?.veryfrontOutputChargeUsd !== undefined ||
-    usage?.veryfrontChargeUsd !== undefined ||
-    usage?.veryfrontBilledUsd !== undefined ||
-    usage?.costCredits !== undefined ||
-    usage?.costSource !== undefined ||
-    usage?.billingMode !== undefined ||
-    usage?.usageCaptureStatus !== undefined;
-}
-
 async function readStreamChunk(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   timeoutMs?: number,
@@ -501,14 +485,6 @@ export async function* streamAnthropicCompatibleParts(
         if (isToolCallsFinishReason(finishReason)) {
           clientToolUseIdleDeadlineMs = null;
           clientToolUseTerminalDeadlineMs ??= Date.now() + trailingUsageGraceMs;
-          if (hasGatewayUsageMetadata(usage)) {
-            await cancelStreamReader(
-              reader,
-              "Finished Anthropic tool-use turn after gateway usage metadata",
-            );
-            yield buildFinishPart();
-            return;
-          }
         } else {
           clientToolUseIdleDeadlineMs ??= Date.now() + trailingUsageGraceMs;
         }


### PR DESCRIPTION
## Summary
- let Anthropic client-tool streams drain the gateway billing metadata close instead of cancelling immediately
- keep the existing short terminal grace timeout for streams that never close
- add regression coverage for the delayed-close case that produced reverse-proxy context-canceled warnings

Fixes veryfront/veryfront-studio#5648

## Verification
- deno fmt --check extensions/ext-llm-anthropic/src/anthropic-stream.ts extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
- deno lint extensions/ext-llm-anthropic/src/anthropic-stream.ts extensions/ext-llm-anthropic/src/anthropic-stream.test.ts
- deno task --cwd extensions/ext-llm-anthropic test
- pre-push hook: fmt, lint, typecheck, unit tests (`2302 passed`, `0 failed`)
