### PR TITLE
Stop retrying permanent durable mirror auth failures

### DIFF
--- a/src/agent/conversation/durable-append-errors.ts
+++ b/src/agent/conversation/durable-append-errors.ts
@@ -75,6 +75,16 @@ export function isPayloadTooLargeConversationRunAppendError(
   );
 }
 
+/** Error shape for permanent auth rejection while appending run events. */
+export function isPermanentAuthConversationRunAppendError(
+  error: unknown,
+): error is AppendConversationRunEventsError {
+  return (
+    error instanceof AppendConversationRunEventsError &&
+    (error.status === 401 || error.status === 403)
+  );
+}
+
 /** Error shape for is cursor mismatch conversation run append. */
 export function isCursorMismatchConversationRunAppendError(
   error: unknown,

--- a/src/agent/conversation/durable-contracts.ts
+++ b/src/agent/conversation/durable-contracts.ts
@@ -200,7 +200,8 @@ export interface ConversationRunEventQueueController {
         | "cursor_resyncs_exhausted"
         | "non_appendable"
         | "ignorable_append_rejection"
-        | "payload_too_large";
+        | "payload_too_large"
+        | "auth_rejected";
     }
     | {
       outcome: "retry_scheduled";

--- a/src/agent/conversation/durable.test.ts
+++ b/src/agent/conversation/durable.test.ts
@@ -16,6 +16,7 @@ import {
   isAppendableConversationRunProjection,
   isCursorMismatchConversationRunAppendError,
   isIgnorableConversationRunAppendError,
+  isPermanentAuthConversationRunAppendError,
   monitorConversationRunStatus,
   parseAppendConversationRunEventsErrorBody,
   recoverConversationRunAppendExecution,
@@ -813,6 +814,37 @@ describe("agent/durable", () => {
       errorMessage: "Append conversation run events failed (500): internal failure",
     });
 
+    const authStopController = createConversationRunEventQueueController({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      runId: "run_queue_controller_auth_stop",
+      latestEventId: 2,
+      latestExternalEventSequence: 4,
+      maxEventsPerBatch: 2,
+    });
+
+    authStopController.enqueue([{ type: "STATE_DELTA", id: 1 }]);
+    globalThis.fetch =
+      (async () => jsonResponse({ detail: "Invalid authentication token" }, 401)) as typeof fetch;
+
+    assertEquals(await authStopController.flush(), {
+      outcome: "stopped",
+      latestEventId: 2,
+      latestExternalEventSequence: 4,
+      pendingEventCount: 0,
+      consecutiveFailures: 0,
+      disabled: true,
+      disableReason: "auth_rejected",
+    });
+    assertEquals(authStopController.getSnapshot(), {
+      latestEventId: 2,
+      latestExternalEventSequence: 4,
+      pendingEventCount: 0,
+      consecutiveFailures: 0,
+      disabled: true,
+    });
+
     const stopController = createConversationRunEventQueueController({
       authToken: AUTH_TOKEN,
       apiUrl: API_URL,
@@ -963,10 +995,15 @@ describe("agent/durable", () => {
       status: 400,
       detail: "External run event cursor mismatch",
     });
+    const invalidToken = new AppendConversationRunEventsError({
+      status: 401,
+      detail: "Invalid authentication token",
+    });
 
     assertEquals(isIgnorableConversationRunAppendError(ignorable), true);
     assertEquals(isIgnorableConversationRunAppendError(cursorMismatch), false);
     assertEquals(isCursorMismatchConversationRunAppendError(cursorMismatch), true);
+    assertEquals(isPermanentAuthConversationRunAppendError(invalidToken), true);
     assertEquals(isActiveConversationRunStatus("running"), true);
     assertEquals(isActiveConversationRunStatus("completed"), false);
     assertEquals(
@@ -1354,6 +1391,29 @@ describe("agent/durable", () => {
     assertEquals(
       await recoverConversationRunAppendFailure({
         error: new AppendConversationRunEventsError({
+          status: 401,
+          detail: "Invalid authentication token",
+        }),
+        authToken: AUTH_TOKEN,
+        apiUrl: API_URL,
+        conversationId: CONVERSATION_ID,
+        runId: "run_append_failure_auth",
+        latestEventId: 2,
+        latestExternalEventSequence: 4,
+        cursorResyncsThisFlush: 0,
+        maxCursorResyncsPerFlush: 3,
+      }),
+      {
+        outcome: "stopped",
+        latestEventId: 2,
+        latestExternalEventSequence: 4,
+        disableReason: "auth_rejected",
+      },
+    );
+
+    assertEquals(
+      await recoverConversationRunAppendFailure({
+        error: new AppendConversationRunEventsError({
           status: 400,
           detail: "External run event cursor mismatch",
         }),
@@ -1469,6 +1529,32 @@ describe("agent/durable", () => {
         latestEventId: 2,
         latestExternalEventSequence: 4,
         disableReason: "ignorable_append_rejection",
+      },
+    );
+
+    assertEquals(
+      await recoverConversationRunAppendExecution({
+        error: new AppendConversationRunEventsError({
+          status: 401,
+          detail: "Invalid authentication token",
+        }),
+        authToken: AUTH_TOKEN,
+        apiUrl: API_URL,
+        conversationId: CONVERSATION_ID,
+        runId: "run_append_execution_auth",
+        latestEventId: 2,
+        latestExternalEventSequence: 4,
+        remainingEvents: [{ type: "STATE_DELTA" }],
+        pendingEvents: [{ type: "CUSTOM" }],
+        cursorResyncsThisFlush: 0,
+        consecutiveFailures: 1,
+        maxCursorResyncsPerFlush: 3,
+      }),
+      {
+        outcome: "stopped",
+        latestEventId: 2,
+        latestExternalEventSequence: 4,
+        disableReason: "auth_rejected",
       },
     );
 

--- a/src/agent/conversation/durable.ts
+++ b/src/agent/conversation/durable.ts
@@ -23,6 +23,7 @@ import {
   isCursorMismatchConversationRunAppendError,
   isIgnorableConversationRunAppendError,
   isPayloadTooLargeConversationRunAppendError,
+  isPermanentAuthConversationRunAppendError,
   parseAppendConversationRunEventsErrorBody,
 } from "./durable-append-errors.ts";
 
@@ -45,6 +46,7 @@ export {
   AppendConversationRunEventsError,
   isCursorMismatchConversationRunAppendError,
   isIgnorableConversationRunAppendError,
+  isPermanentAuthConversationRunAppendError,
   parseAppendConversationRunEventsErrorBody,
 } from "./durable-append-errors.ts";
 import { normalizeConversationRunEvents } from "./run-event-normalization.ts";
@@ -262,7 +264,8 @@ export async function recoverConversationRunAppendFailure(input: {
     | "cursor_resyncs_exhausted"
     | "non_appendable"
     | "ignorable_append_rejection"
-    | "payload_too_large";
+    | "payload_too_large"
+    | "auth_rejected";
   errorMessage?: string;
   run?: ConversationRunProjection;
 }> {
@@ -304,6 +307,16 @@ export async function recoverConversationRunAppendFailure(input: {
       latestEventId: cursorRecovery.latestEventId,
       latestExternalEventSequence: cursorRecovery.latestExternalEventSequence,
       disableReason: "ignorable_append_rejection",
+      ...(cursorRecovery.run ? { run: cursorRecovery.run } : {}),
+    };
+  }
+
+  if (isPermanentAuthConversationRunAppendError(input.error)) {
+    return {
+      outcome: "stopped",
+      latestEventId: cursorRecovery.latestEventId,
+      latestExternalEventSequence: cursorRecovery.latestExternalEventSequence,
+      disableReason: "auth_rejected",
       ...(cursorRecovery.run ? { run: cursorRecovery.run } : {}),
     };
   }
@@ -360,7 +373,8 @@ export async function recoverConversationRunAppendExecution(input: {
       | "cursor_resyncs_exhausted"
       | "non_appendable"
       | "ignorable_append_rejection"
-      | "payload_too_large";
+      | "payload_too_large"
+      | "auth_rejected";
   }
   | {
     outcome: "retry_scheduled";
@@ -490,7 +504,8 @@ export async function flushConversationRunEventBatches(input: {
       | "cursor_resyncs_exhausted"
       | "non_appendable"
       | "ignorable_append_rejection"
-      | "payload_too_large";
+      | "payload_too_large"
+      | "auth_rejected";
   }
 > {
   const batches = buildConversationRunEventBatches({
@@ -593,7 +608,8 @@ export async function flushConversationRunEventQueue(input: {
       | "cursor_resyncs_exhausted"
       | "non_appendable"
       | "ignorable_append_rejection"
-      | "payload_too_large";
+      | "payload_too_large"
+      | "auth_rejected";
   }
   | {
     outcome: "retry_scheduled";

--- a/src/agent/conversation/run-chunk-mirror.test.ts
+++ b/src/agent/conversation/run-chunk-mirror.test.ts
@@ -2,17 +2,20 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ChatUiMessageChunk } from "../../chat/protocol.ts";
-import type {
-  ConversationRunEventQueueController,
-  ConversationRunEventQueueFlushResult,
-  ConversationRunEventQueueSnapshot,
-} from "./durable.ts";
+import type { ConversationRunEventQueueController } from "./durable.ts";
 import type { ConversationRunEvent } from "./run-events.ts";
 import {
   createConversationRunChunkMirror,
   createHostedConversationRunChunkMirror,
   type HostedConversationRunChunkMirrorTraceAttributes,
 } from "./run-chunk-mirror.ts";
+
+type ConversationRunEventQueueFlushResult = Awaited<
+  ReturnType<ConversationRunEventQueueController["flush"]>
+>;
+type ConversationRunEventQueueSnapshot = ReturnType<
+  ConversationRunEventQueueController["getSnapshot"]
+>;
 
 function createQueueController(): ConversationRunEventQueueController & {
   enqueued: unknown[];
@@ -27,7 +30,14 @@ function createQueueController(): ConversationRunEventQueueController & {
     },
     async flush(): Promise<ConversationRunEventQueueFlushResult> {
       enqueued.length = 0;
-      return { outcome: "flushed", latestEventId: 0, latestExternalEventSequence: 0 };
+      return {
+        outcome: "flushed",
+        latestEventId: 0,
+        latestExternalEventSequence: 0,
+        pendingEventCount: 0,
+        consecutiveFailures: 0,
+        disabled: this.disabled,
+      };
     },
     getSnapshot(): ConversationRunEventQueueSnapshot {
       return {
@@ -252,6 +262,52 @@ describe("agent/conversation-run-chunk-mirror", () => {
           pendingEventCount: 3,
           consecutiveFailures: 0,
           threshold: 2,
+        },
+      }]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("records a terminal auth rejection instead of retrying forever", async () => {
+    const originalFetch = globalThis.fetch;
+    const errors: Array<{ message: string; metadata: Record<string, unknown> }> = [];
+    try {
+      globalThis.fetch = (() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ detail: "Invalid authentication token" }),
+            { status: 401, headers: { "Content-Type": "application/json" } },
+          ),
+        )) as typeof fetch;
+      const mirror = createHostedConversationRunChunkMirror({
+        authToken: "expired-token",
+        apiUrl: "https://api.example.test",
+        conversationId: "11111111-1111-4111-8111-111111111111",
+        runId: "run-1",
+        latestEventId: 10,
+        latestExternalEventSequence: 20,
+        instrumentation: {
+          error: (message, metadata) => {
+            errors.push({ message, metadata });
+          },
+        },
+      });
+
+      await mirror.appendEvents([{ type: "TEXT_MESSAGE_CONTENT", delta: "persisted" }]);
+      const snapshot = await mirror.flush();
+      mirror.dispose();
+
+      assertEquals(snapshot.disabled, true);
+      assertEquals(snapshot.pendingEventCount, 0);
+      assertEquals(snapshot.hasRetryTimer, false);
+      assertEquals(errors, [{
+        message: "Disabling durable run mirroring after permanent append authentication rejection",
+        metadata: {
+          conversationId: "11111111-1111-4111-8111-111111111111",
+          runId: "run-1",
+          latestEventId: 10,
+          latestExternalEventSequence: 20,
         },
       }]);
     } finally {

--- a/src/agent/conversation/run-chunk-mirror.ts
+++ b/src/agent/conversation/run-chunk-mirror.ts
@@ -308,6 +308,19 @@ function recordHostedChunkMirrorStopped(input: {
     return;
   }
 
+  if (input.flushAttempt.disableReason === "auth_rejected") {
+    input.instrumentation?.error?.(
+      "Disabling durable run mirroring after permanent append authentication rejection",
+      {
+        conversationId: input.conversationId,
+        runId: input.runId,
+        latestEventId: input.flushAttempt.latestEventId,
+        latestExternalEventSequence: input.flushAttempt.latestExternalEventSequence,
+      },
+    );
+    return;
+  }
+
   if (input.flushAttempt.disableReason === "ignorable_append_rejection") {
     input.instrumentation?.warn?.(
       "Disabling durable run mirroring after external append rejection",

--- a/src/agent/conversation/run-mirror.ts
+++ b/src/agent/conversation/run-mirror.ts
@@ -23,7 +23,8 @@ export interface ConversationRunMirrorStoppedState {
     | "cursor_resyncs_exhausted"
     | "non_appendable"
     | "ignorable_append_rejection"
-    | "payload_too_large";
+    | "payload_too_large"
+    | "auth_rejected";
 }
 
 /** State for conversation run mirror retry scheduled. */


### PR DESCRIPTION
## Summary
- classify append-event HTTP 401/403 responses as permanent durable mirror auth rejections
- stop and drain the durable run event queue instead of scheduling another retry timer for invalid credentials
- log a hosted mirror auth-stop reason and add regressions for helper classification, recovery, controller flushing, and hosted chunk mirroring
- repair the touched chunk mirror test mock so it typechecks against the queue controller contract

## Verification
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/agent/conversation/durable.test.ts src/agent/conversation/run-mirror.test.ts src/agent/conversation/run-chunk-mirror.test.ts src/agent/conversation/run-stream-mirror.test.ts
- deno check src/agent/conversation/durable-append-errors.ts src/agent/conversation/durable.ts src/agent/conversation/durable-contracts.ts src/agent/conversation/run-mirror.ts src/agent/conversation/run-chunk-mirror.ts src/agent/conversation/durable.test.ts src/agent/conversation/run-chunk-mirror.test.ts
- deno lint src/agent/conversation/durable-append-errors.ts src/agent/conversation/durable.ts src/agent/conversation/durable-contracts.ts src/agent/conversation/run-mirror.ts src/agent/conversation/run-chunk-mirror.ts src/agent/conversation/durable.test.ts src/agent/conversation/run-chunk-mirror.test.ts
- deno task typecheck
- git diff --check
- git push pre-push hook: format, lint, typecheck, generated manifests/prebundles, unit tests: 2302 passed, 0 failed

Fixes veryfront/veryfront-studio#5555