### PR TITLE
Let invoke_agent request full child results

### DIFF
--- a/src/agent/child-run/result-summary.test.ts
+++ b/src/agent/child-run/result-summary.test.ts
@@ -72,6 +72,38 @@ describe("child-run-result-summary", () => {
       });
     });
 
+    it("returns complete text when full mode is requested", () => {
+      const text = [
+        "x".repeat(64_500),
+        '    "model": "anthropic/claude-sonnet-4-6"',
+      ].join("\n");
+
+      assertEquals(buildChildRunResultSummary(text, { mode: "full" }), {
+        text,
+        status: "complete",
+        truncated: false,
+        originalChars: text.length,
+        returnedChars: text.length,
+        omittedChars: 0,
+        limitChars: text.length,
+      });
+    });
+
+    it("preserves raw text when full mode is requested", () => {
+      const text =
+        '  <function_calls><invoke name="run_bash">curl</invoke></function_calls><function_result>Title: Example</function_result>\n';
+
+      assertEquals(buildChildRunResultSummary(text, { mode: "full" }), {
+        text,
+        status: "complete",
+        truncated: false,
+        originalChars: text.length,
+        returnedChars: text.length,
+        omittedChars: 0,
+        limitChars: text.length,
+      });
+    });
+
     it("removes malformed tool transcript wrappers while preserving result content", () => {
       const result = buildChildRunResultSummary(
         'I will fetch the docs.\n\n<tool_call>{"name":"web_fetch","parameters":{"url":"https://example.com"}}</tool_call><tool_response>Title: Example Content: Example Domain</tool_response>\n\nNow I can continue.',

--- a/src/agent/child-run/result-summary.ts
+++ b/src/agent/child-run/result-summary.ts
@@ -18,6 +18,14 @@ const ROOT_RESPONSE_PROCESS_PREFIX_PATTERNS = [
   /^first,? [^.?!]+[.?!]\s*/i,
 ];
 
+/** Result return modes supported by delegated child runs. */
+export type ChildRunResultMode = "summary" | "full";
+
+/** Options accepted when building child run result summaries. */
+export type BuildChildRunResultSummaryOptions = {
+  mode?: ChildRunResultMode;
+};
+
 /** Summary metadata returned to parent runs after child delegation. */
 export type ChildRunResultSummary = {
   text: string;
@@ -45,21 +53,10 @@ function sanitizeMalformedToolTranscriptText(text: string): string {
     .trim();
 }
 
-/** Summarize child run result text helper. */
-export function summarizeChildRunResultText(
-  text: string,
-  maxLength = CHILD_RUN_RESULT_TEXT_LIMIT,
-): string {
-  return summarizeChildRunResultTextWithMetadata(text, maxLength).text;
-}
-
-/** Summarize child run result text with machine-readable truncation metadata. */
-export function summarizeChildRunResultTextWithMetadata(
-  text: string,
-  maxLength = CHILD_RUN_RESULT_TEXT_LIMIT,
+function summarizeNormalizedChildRunResultTextWithMetadata(
+  normalized: string,
+  maxLength: number,
 ): ChildRunResultSummary {
-  const normalized = sanitizeMalformedToolTranscriptText(text);
-
   if (normalized.length <= maxLength) {
     return {
       text: normalized,
@@ -86,9 +83,32 @@ export function summarizeChildRunResultTextWithMetadata(
   };
 }
 
+/** Summarize child run result text helper. */
+export function summarizeChildRunResultText(
+  text: string,
+  maxLength = CHILD_RUN_RESULT_TEXT_LIMIT,
+): string {
+  return summarizeChildRunResultTextWithMetadata(text, maxLength).text;
+}
+
+/** Summarize child run result text with machine-readable truncation metadata. */
+export function summarizeChildRunResultTextWithMetadata(
+  text: string,
+  maxLength = CHILD_RUN_RESULT_TEXT_LIMIT,
+): ChildRunResultSummary {
+  const normalized = sanitizeMalformedToolTranscriptText(text);
+  return summarizeNormalizedChildRunResultTextWithMetadata(normalized, maxLength);
+}
+
 /** Builds child run result summary. */
-export function buildChildRunResultSummary(text: string): ChildRunResultSummary {
-  return summarizeChildRunResultTextWithMetadata(text);
+export function buildChildRunResultSummary(
+  text: string,
+  options: BuildChildRunResultSummaryOptions = {},
+): ChildRunResultSummary {
+  const normalized = options.mode === "full" ? text : sanitizeMalformedToolTranscriptText(text);
+  const maxLength = options.mode === "full" ? normalized.length : CHILD_RUN_RESULT_TEXT_LIMIT;
+
+  return summarizeNormalizedChildRunResultTextWithMetadata(normalized, maxLength);
 }
 
 /** Builds root owned child run result text. */

--- a/src/agent/hosted/child-fork-stream-execution.test.ts
+++ b/src/agent/hosted/child-fork-stream-execution.test.ts
@@ -1,11 +1,17 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import {
   executeHostedChildForkStream,
   handleHostedChildForkFailure,
   type HostedChildForkPendingToolLifecycle,
 } from "./child-fork-stream-execution.ts";
+import type { ChildRunExecutionSnapshot } from "../child-run/execution-snapshot.ts";
 import type { ForkPart, ForkRuntimeStep } from "../streaming/fork-runtime-stream.ts";
 
 function createPendingToolLifecycle(chunks: unknown[]): HostedChildForkPendingToolLifecycle {
@@ -128,6 +134,58 @@ describe("hosted child fork stream execution", () => {
       chunks.find((chunk) => typeof chunk === "object" && chunk !== null && "type" in chunk),
     );
     assertEquals(writeLogs.length, 1);
+  });
+
+  it("keeps the raw stream text in the settlement snapshot", async () => {
+    const rawText =
+      '  <function_calls><invoke name="run_bash">curl</invoke></function_calls><function_result>Title: Example</function_result>\n';
+    const chunks: unknown[] = [];
+    const streamState = { finalText: "" };
+    const snapshots: ChildRunExecutionSnapshot[] = [];
+
+    const result = await executeHostedChildForkStream({
+      streamResult: {
+        fullStream: partsStream([{ type: "text-delta", text: rawText }]),
+        steps: Promise.resolve([createStep({ text: rawText })]),
+        totalUsage: Promise.resolve({ inputTokens: 3, outputTokens: 4 }),
+      },
+      abortForkStream: () => undefined,
+      description: "Inspect repo",
+      kind: "invoke_agent",
+      durableRunMirror: true,
+      durableMessageId: "msg-1",
+      durableReasoningMessageId: "reasoning-1",
+      durableMirrorState: { reasoningStarted: false, textStarted: false },
+      appendDurableMirrorChunk: (chunk) => {
+        chunks.push(chunk);
+        return Promise.resolve();
+      },
+      closeDurableMirrorReasoning: () => Promise.resolve(),
+      closeDurableMirrorText: () => Promise.resolve(),
+      markDurableStepStarted: () => {},
+      durableMirrorHasEmittedProgress: () => true,
+      pendingToolLifecycle: createPendingToolLifecycle(chunks),
+      toolCalls: [],
+      toolResults: [],
+      streamState,
+      maxSteps: 10,
+      startTime: Date.now(),
+      finalizationTimeoutMs: 100,
+      idleTimeoutMs: 1_000,
+      activeToolTimeoutMs: 1_000,
+      postToolIdleTimeoutMs: 1_000,
+      onSettled: (snapshot) => {
+        snapshots.push(snapshot);
+      },
+    });
+
+    assertEquals(result.success, true);
+    if (result.success) {
+      assertEquals(result.summary.text, "Title: Example");
+    }
+    assertEquals(snapshots.length, 1);
+    assertEquals(snapshots[0]?.fullResultText, rawText);
+    assertStringIncludes(streamState.finalText, "<function_calls>");
   });
 
   it("builds failure result and snapshot for child fork errors", async () => {

--- a/src/agent/hosted/child-tool-input.ts
+++ b/src/agent/hosted/child-tool-input.ts
@@ -1,10 +1,15 @@
 import { defineSchema, getJsonValueSchema, lazySchema } from "#veryfront/schemas/index.ts";
 import type { InferSchema } from "#veryfront/extensions/schema/index.ts";
 import { withDefaultResearchArtifactPath } from "../artifacts/default-research-artifact-policy.ts";
+import type { ChildRunResultMode } from "../child-run/result-summary.ts";
 import type { RuntimeAgentThinkingConfig } from "../runtime/agent-definition.ts";
 
 /** Default value for hosted child agent ID. */
 export const DEFAULT_HOSTED_CHILD_AGENT_ID = "invoke-agent-child";
+const HOSTED_CHILD_FORK_RESULT_MODES = ["summary", "full"] as const;
+
+/** Hosted child fork result return mode. */
+export type HostedChildForkResultMode = ChildRunResultMode;
 
 export const getHostedChildForkToolInputSchema = defineSchema((v) =>
   v.object({
@@ -27,6 +32,9 @@ export const getHostedChildForkToolInputSchema = defineSchema((v) =>
       .describe("Thinking override in budget tokens. Use 0 to disable thinking."),
     max_steps: v.number().optional().describe(
       "Max steps override. Omit for the hosted child default. Values below the default are raised to the default.",
+    ),
+    result_mode: v.enum(HOSTED_CHILD_FORK_RESULT_MODES).optional().describe(
+      'Result return mode. Omit or use "summary" for the bounded default. Use "full" only when exact delegated output is required.',
     ),
   })
 );

--- a/src/agent/hosted/default-invoke-agent-tool.test.ts
+++ b/src/agent/hosted/default-invoke-agent-tool.test.ts
@@ -57,12 +57,14 @@ Deno.test("defaultHostedInvokeAgentInputSchema accepts child-agent selection", (
       prompt: "Inspect auth flow.",
       context: {},
       agent_id: "security-reviewer",
+      result_mode: "full",
     }),
     {
       description: "inspect auth",
       prompt: "Inspect auth flow.",
       context: {},
       agent_id: "security-reviewer",
+      result_mode: "full",
     },
   );
 });
@@ -91,6 +93,21 @@ Deno.test("defaultHostedInvokeAgentInputSchema rejects blank child-agent selecti
       }),
     Error,
     "agent_id must not be blank",
+  );
+});
+
+Deno.test("defaultHostedInvokeAgentInputSchema rejects invalid result mode", async () => {
+  await assertRejects(
+    async () =>
+      defaultHostedInvokeAgentInputSchema.parse({
+        description: "inspect auth",
+        prompt: "Inspect auth flow.",
+        context: {},
+        agent_id: "security-reviewer",
+        result_mode: "verbose",
+      }),
+    Error,
+    "result_mode",
   );
 });
 
@@ -129,6 +146,7 @@ Deno.test("createDefaultHostedInvokeAgentTool adds child selection guidance and 
   );
 
   assertStringIncludes(invokeTool.description, "agent_id is required");
+  assertStringIncludes(invokeTool.description, "result_mode defaults");
 
   const result = await invokeTool.execute(
     {

--- a/src/agent/hosted/default-invoke-agent-tool.ts
+++ b/src/agent/hosted/default-invoke-agent-tool.ts
@@ -466,6 +466,8 @@ export async function executeDefaultHostedInvokeAgentTool<
       abortSignal,
       traceRecorder: durableInvokeRecorder,
       execute: executeLocalInvoke,
+      getExecutionSnapshot: () => executionSnapshot,
+      resultMode: input.result_mode,
     });
   }
 
@@ -516,7 +518,8 @@ export async function executeDefaultHostedInvokeAgentTool<
       },
       buildSetupFailureResult: (failure) => durableInvokeRecorder.recordSetupFailure(failure),
       buildTerminalFailureResult: (failure) => durableInvokeRecorder.recordTerminalFailure(failure),
-      buildSuccessResult: (success) => durableInvokeRecorder.recordSuccess(success),
+      buildSuccessResult: (success) =>
+        durableInvokeRecorder.recordSuccess(success, { resultMode: input.result_mode }),
       runtime: {
         bootstrapChildRun: bootstrapHostedChildRun,
         createLifecycleAdapter: createConversationChildLifecycleAdapter,
@@ -597,6 +600,7 @@ export function createDefaultHostedInvokeAgentTool<
     inputSchema: defaultHostedInvokeAgentInputSchema,
     additionalDescriptionParts: [
       "agent_id is required. Use it to target a specific built-in or custom child agent.",
+      'result_mode defaults to "summary"; use "full" only when exact delegated output is required.',
     ],
     buildFailureResult: buildHostedDurableChildInvokeFailureResult,
     decorateResult: withRootOwnedChildResultHint,

--- a/src/agent/hosted/durable-child-fork-execution.test.ts
+++ b/src/agent/hosted/durable-child-fork-execution.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   buildChildRunExecutionSnapshot,
@@ -276,6 +276,93 @@ describe("agent/hosted-durable-child-fork-execution", () => {
     );
   });
 
+  it("keeps durable invoke summaries bounded unless full result mode is requested", () => {
+    const identifiers = {
+      childConversationId: CHILD_CONVERSATION_ID,
+      childRunId: "run_child_1",
+      childMessageId: CHILD_MESSAGE_ID,
+      latestEventId: 7,
+      latestExternalEventSequence: 3,
+    };
+    const targets = {
+      sourceTargetKind: "preview_branch",
+      runtimeTargetKind: "preview_branch",
+      targetBranchId: BRANCH_ID,
+    } satisfies ConversationRunTargets;
+    const fullResultText = [
+      "# Create an agent",
+      "x".repeat(64_500),
+      '    "model": "anthropic/claude-sonnet-4-6"',
+    ].join("\n");
+    const snapshot = {
+      ...buildChildRunExecutionSnapshot(baseSuccessResult()),
+      fullResultText,
+    };
+
+    const defaultResult = buildHostedDurableChildInvokeSuccessResult({
+      result: baseSuccessResult(),
+      snapshot,
+      identifiers,
+      targets,
+    });
+    assertEquals(defaultResult.summary?.truncated, true);
+    assertStringIncludes(defaultResult.text ?? "", "[truncated");
+
+    const fullResult = buildHostedDurableChildInvokeSuccessResult(
+      {
+        result: baseSuccessResult(),
+        snapshot,
+        identifiers,
+        targets,
+      },
+      { resultMode: "full" },
+    );
+    assertEquals(fullResult.summary?.truncated, false);
+    assertEquals(fullResult.summary?.originalChars, fullResultText.length);
+    assertStringIncludes(fullResult.text ?? "", '"model": "anthropic/claude-sonnet-4-6"');
+  });
+
+  it("preserves existing durable summary metadata when full snapshot text is unavailable", () => {
+    const identifiers = {
+      childConversationId: CHILD_CONVERSATION_ID,
+      childRunId: "run_child_1",
+      childMessageId: CHILD_MESSAGE_ID,
+      latestEventId: 7,
+      latestExternalEventSequence: 3,
+    };
+    const targets = {
+      sourceTargetKind: "preview_branch",
+      runtimeTargetKind: "preview_branch",
+      targetBranchId: BRANCH_ID,
+    } satisfies ConversationRunTargets;
+    const fullResultText = [
+      "# Create an agent",
+      "x".repeat(64_500),
+      '    "model": "anthropic/claude-sonnet-4-6"',
+    ].join("\n");
+    const result: ChildRunExecutionResult = {
+      ...baseSuccessResult(),
+      summary: buildChildRunResultSummary(fullResultText),
+    };
+    const snapshot = {
+      ...buildChildRunExecutionSnapshot(result),
+      fullResultText: null,
+    };
+
+    const fullResult = buildHostedDurableChildInvokeSuccessResult(
+      {
+        result,
+        snapshot,
+        identifiers,
+        targets,
+      },
+      { resultMode: "full" },
+    );
+
+    assertEquals(fullResult.summary?.truncated, true);
+    assertStringIncludes(fullResult.text ?? "", "[truncated");
+  });
+
   it("records standard hosted invoke trace attributes while building results", () => {
     const recordedAttributes: unknown[] = [];
     const identifiers = {
@@ -451,6 +538,63 @@ describe("agent/hosted-durable-child-fork-execution", () => {
 
     assertEquals(result, localResult);
     assertEquals(recordedFailures, []);
+  });
+
+  it("returns local child full snapshot text when full result mode is requested", async () => {
+    const fullResultText = [
+      "# Create an agent",
+      "x".repeat(64_500),
+      '    "model": "anthropic/claude-sonnet-4-6"',
+    ].join("\n");
+    const localResult = baseSuccessResult();
+    const result = await executeHostedLocalChildInvoke({
+      forkInput: { description: "Inspect logs" },
+      traceRecorder: {
+        recordLocalResult: (recordedResult) => recordedResult,
+        recordLocalFailure: () => {},
+      },
+      execute: () => localResult,
+      getExecutionSnapshot: () => ({
+        ...buildChildRunExecutionSnapshot(localResult),
+        fullResultText,
+      }),
+      resultMode: "full",
+    });
+
+    assertEquals(result.success, true);
+    if (result.success) {
+      assertEquals(result.summary.truncated, false);
+      assertEquals(result.summary.originalChars, fullResultText.length);
+      assertStringIncludes(result.summary.text, '"model": "anthropic/claude-sonnet-4-6"');
+    }
+  });
+
+  it("preserves local child summary metadata when full snapshot text is unavailable", async () => {
+    const fullResultText = [
+      "# Create an agent",
+      "x".repeat(64_500),
+      '    "model": "anthropic/claude-sonnet-4-6"',
+    ].join("\n");
+    const localResult: ChildRunExecutionResult = {
+      ...baseSuccessResult(),
+      summary: buildChildRunResultSummary(fullResultText),
+    };
+    const result = await executeHostedLocalChildInvoke({
+      forkInput: { description: "Inspect logs" },
+      traceRecorder: {
+        recordLocalResult: (recordedResult) => recordedResult,
+        recordLocalFailure: () => {},
+      },
+      execute: () => localResult,
+      getExecutionSnapshot: () => null,
+      resultMode: "full",
+    });
+
+    assertEquals(result.success, true);
+    if (result.success) {
+      assertEquals(result.summary.truncated, true);
+      assertStringIncludes(result.summary.text, "[truncated");
+    }
   });
 
   it("normalizes non-abort local child invoke failures", async () => {

--- a/src/agent/hosted/durable-child-fork-execution.ts
+++ b/src/agent/hosted/durable-child-fork-execution.ts
@@ -5,6 +5,7 @@ import type {
 import { parseProviderError } from "../../chat/provider-errors.ts";
 import {
   buildChildRunResultSummary,
+  type ChildRunResultMode,
   type ChildRunResultSummary,
 } from "../child-run/result-summary.ts";
 import {
@@ -75,6 +76,11 @@ export type HostedDurableChildSuccess<TLocalResult extends ChildRunExecutionResu
   targets: ConversationRunTargets;
 };
 
+/** Options accepted when building hosted durable child invoke success results. */
+export type HostedDurableChildInvokeSuccessResultOptions = {
+  resultMode?: ChildRunResultMode;
+};
+
 /** Public API contract for hosted durable child terminal failure. */
 export type HostedDurableChildTerminalFailure = {
   status: HostedChildTerminalStatus;
@@ -129,8 +135,26 @@ export type ExecuteHostedLocalChildInvokeInput = {
   abortSignal?: AbortSignal;
   traceRecorder: HostedLocalChildInvokeTraceRecorder;
   execute: () => Promise<ChildRunExecutionResult> | ChildRunExecutionResult;
+  getExecutionSnapshot?: () => ChildRunExecutionSnapshot | null;
+  resultMode?: ChildRunResultMode;
   isAbortError?: (error: unknown) => boolean;
 };
+
+function buildHostedChildResultSummaryForMode(input: {
+  result: ChildRunExecutionResult;
+  snapshot: ChildRunExecutionSnapshot | null;
+  resultMode?: ChildRunResultMode;
+}): ChildRunResultSummary {
+  if (input.snapshot?.fullResultText !== null && input.snapshot?.fullResultText !== undefined) {
+    return buildChildRunResultSummary(input.snapshot.fullResultText, {
+      mode: input.resultMode,
+    });
+  }
+
+  return input.result.success
+    ? input.result.summary
+    : buildChildRunResultSummary(input.result.error);
+}
 
 /** Result returned from build hosted durable child invoke failure. */
 export function buildHostedDurableChildInvokeFailureResult(
@@ -192,10 +216,15 @@ function resolveKnownProviderTerminalError(error: unknown): {
 /** Result returned from build hosted durable child invoke success. */
 export function buildHostedDurableChildInvokeSuccessResult<
   TLocalResult extends ChildRunExecutionResult,
->(input: HostedDurableChildSuccess<TLocalResult>): HostedDurableChildInvokeResult {
-  const summaryText = input.snapshot.fullResultText ??
-    (input.result.success ? input.result.summary.text : input.result.error);
-  const summary = summaryText ? buildChildRunResultSummary(summaryText) : null;
+>(
+  input: HostedDurableChildSuccess<TLocalResult>,
+  options: HostedDurableChildInvokeSuccessResultOptions = {},
+): HostedDurableChildInvokeResult {
+  const summary = buildHostedChildResultSummaryForMode({
+    result: input.result,
+    snapshot: input.snapshot,
+    resultMode: options.resultMode,
+  });
   const terminalError = input.snapshot.success
     ? null
     : resolveKnownProviderTerminalError(input.snapshot.error);
@@ -304,6 +333,7 @@ export function createHostedDurableChildInvokeTraceRecorder(input: {
     },
     recordSuccess<TLocalResult extends ChildRunExecutionResult>(
       success: HostedDurableChildSuccess<TLocalResult>,
+      options: HostedDurableChildInvokeSuccessResultOptions = {},
     ): HostedDurableChildInvokeResult {
       annotate({
         childConversationId: success.identifiers.childConversationId,
@@ -317,7 +347,7 @@ export function createHostedDurableChildInvokeTraceRecorder(input: {
         terminalErrorMessage: success.snapshot.success ? null : success.snapshot.error,
       });
 
-      return buildHostedDurableChildInvokeSuccessResult(success);
+      return buildHostedDurableChildInvokeSuccessResult(success, options);
     },
   };
 }
@@ -328,7 +358,20 @@ export async function executeHostedLocalChildInvoke(
 ): Promise<ChildRunExecutionResult> {
   try {
     const result = await input.execute();
-    return input.traceRecorder.recordLocalResult(result);
+    const recordedResult = input.traceRecorder.recordLocalResult(result);
+
+    if (input.resultMode !== "full" || !recordedResult.success) {
+      return recordedResult;
+    }
+
+    return {
+      ...recordedResult,
+      summary: buildHostedChildResultSummaryForMode({
+        result: recordedResult,
+        snapshot: input.getExecutionSnapshot?.() ?? null,
+        resultMode: input.resultMode,
+      }),
+    };
   } catch (error) {
     const isAbortError = input.isAbortError ?? isChildRunAbortError;
     const errorMessage = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

- Adds an explicit `result_mode` option to hosted `invoke_agent` input: `summary` remains the bounded default, `full` opts into complete child output.
- Rebuilds hosted invoke success summaries from the stored full execution snapshot when full mode is requested.
- Adds regressions proving late contract facts such as `anthropic/claude-sonnet-4-6` remain available in full mode while the default still truncates.

## Verification

- `deno test --no-check --allow-all src/agent/child-run/result-summary.test.ts src/agent/hosted/durable-child-fork-execution.test.ts src/agent/hosted/default-invoke-agent-tool.test.ts`
- `deno check src/agent/child-run/result-summary.ts src/agent/hosted/child-tool-input.ts src/agent/hosted/default-invoke-agent-tool.ts src/agent/hosted/durable-child-fork-execution.ts src/agent/child-run/result-summary.test.ts src/agent/hosted/default-invoke-agent-tool.test.ts src/agent/hosted/durable-child-fork-execution.test.ts`
- `deno task fmt:check`
- `deno task lint`
- `deno task typecheck`
- pre-push hook: full unit suite, `2303 passed`, `0 failed`

Fixes part of https://github.com/veryfront/veryfront-studio/issues/5614