### PR TITLE
Keep Deno std aliases out of CDN caching

### DIFF
--- a/src/transforms/esm/http-cache-helpers.test.ts
+++ b/src/transforms/esm/http-cache-helpers.test.ts
@@ -53,6 +53,10 @@ describe("transforms/esm/http-cache-helpers", () => {
       assertEquals(isExternalScheme("bun:test"), true);
     });
 
+    it("returns true for jsr: scheme", () => {
+      assertEquals(isExternalScheme("jsr:@std/dotenv@0.225.6"), true);
+    });
+
     it("returns false for https scheme", () => {
       assertEquals(isExternalScheme("https://example.com"), false);
     });
@@ -105,6 +109,11 @@ describe("transforms/esm/http-cache-helpers", () => {
 
     it("returns true for #veryfront/ imports", () => {
       assertEquals(isInternalBare("#veryfront/utils"), true);
+    });
+
+    it("returns true for private import-map aliases", () => {
+      assertEquals(isInternalBare("#std/dotenv.ts"), true);
+      assertEquals(isInternalBare("#project/env"), true);
     });
 
     it("returns true for _vf_modules/ imports", () => {

--- a/src/transforms/esm/http-cache-helpers.ts
+++ b/src/transforms/esm/http-cache-helpers.ts
@@ -52,7 +52,8 @@ export function isExternalScheme(specifier: string): boolean {
   return specifier.startsWith("node:") ||
     specifier.startsWith("data:") ||
     specifier.startsWith("file:") ||
-    specifier.startsWith("bun:");
+    specifier.startsWith("bun:") ||
+    specifier.startsWith("jsr:");
 }
 
 export function isRelative(specifier: string): boolean {
@@ -69,7 +70,7 @@ export function isParentHttpModule(baseUrl: string | undefined): boolean {
 
 export function isInternalBare(specifier: string): boolean {
   return specifier.startsWith("veryfront/") ||
-    specifier.startsWith("#veryfront/") ||
+    specifier.startsWith("#") ||
     specifier.startsWith("@std/") ||
     specifier.startsWith("_vf_modules/") ||
     specifier.startsWith("/_vf_modules/") ||

--- a/src/transforms/esm/specifier-resolver.test.ts
+++ b/src/transforms/esm/specifier-resolver.test.ts
@@ -31,6 +31,29 @@ describe("transforms/esm/specifier-resolver", () => {
       assertEquals(result.size, 0);
     });
 
+    it("does not rewrite private import-map aliases to esm.sh fragments", async () => {
+      const code = `import { load } from "#std/dotenv.ts";`;
+      const cacheCalls: string[] = [];
+      const result = await buildReplacements(
+        code,
+        "https://esm.sh/?external=react&target=es2022",
+        defaultOptions,
+        async (url) => {
+          cacheCalls.push(url);
+          return "/tmp/cache/http-std.mjs";
+        },
+      );
+
+      assertEquals(result.size, 0);
+      assertEquals(cacheCalls, []);
+    });
+
+    it("returns empty map for jsr: specifiers", async () => {
+      const code = `import { load } from "jsr:@std/dotenv@0.225.6";`;
+      const result = await buildReplacements(code, undefined, defaultOptions, noopCache);
+      assertEquals(result.size, 0);
+    });
+
     it("rewrites npm: specifiers when cache returns a path", async () => {
       const code = `import React from "npm:react@18";`;
       const mockCache: CacheHttpModuleFn = async () => "/tmp/cache/http-12345.mjs";

--- a/src/transforms/esm/specifier-resolver.test.ts
+++ b/src/transforms/esm/specifier-resolver.test.ts
@@ -48,6 +48,30 @@ describe("transforms/esm/specifier-resolver", () => {
       assertEquals(cacheCalls, []);
     });
 
+    it("rewrites mapped private import-map aliases before skipping internal aliases", async () => {
+      const code = `import pkg from "#pkg";`;
+      const cacheCalls: string[] = [];
+      const result = await buildReplacements(
+        code,
+        "https://esm.sh/parent@1/index.js",
+        {
+          ...defaultOptions,
+          importMap: {
+            imports: {
+              "#pkg": "https://cdn.example.com/pkg.js",
+            },
+          },
+        },
+        async (url) => {
+          cacheCalls.push(url);
+          return "/tmp/cache/http-pkg.mjs";
+        },
+      );
+
+      assertEquals(result.get("#pkg"), "./http-pkg.mjs");
+      assertEquals(cacheCalls, ["https://cdn.example.com/pkg.js"]);
+    });
+
     it("returns empty map for jsr: specifiers", async () => {
       const code = `import { load } from "jsr:@std/dotenv@0.225.6";`;
       const result = await buildReplacements(code, undefined, defaultOptions, noopCache);

--- a/src/transforms/esm/specifier-resolver.ts
+++ b/src/transforms/esm/specifier-resolver.ts
@@ -41,7 +41,14 @@ async function resolveSpecifier(
   options: CacheOptions,
   cacheHttpModule: CacheHttpModuleFn,
 ): Promise<string | null> {
-  if (isExternalScheme(specifier) || isInternalBare(specifier)) return null;
+  if (isExternalScheme(specifier)) return null;
+
+  if (isInternalBare(specifier)) {
+    const mapped = resolveImport(specifier, options.importMap);
+    if (mapped === specifier) return null;
+    if (isLocalMappedSpecifier(mapped)) return mapped;
+    return resolveSpecifier(mapped, baseUrl, options, cacheHttpModule);
+  }
 
   if (specifier.startsWith("npm:")) {
     const bareSpecifier = specifier.slice(4);


### PR DESCRIPTION
## Summary
- prevent the HTTP module cache from treating private `#...` import-map aliases as npm packages
- keep `jsr:` specifiers out of esm.sh URL construction
- add regression coverage for `#std/dotenv.ts` under an esm.sh parent URL so it cannot become an esm.sh fragment URL

## Root cause
The HTTP cache resolver did not classify `#std/*` as internal. When a cached HTTP module referenced `#std/dotenv.ts`, the resolver built `https://esm.sh/#std/dotenv.ts?target=es2022`. URL normalization then sent esm.sh a root request with the std path in the fragment, which can return HTML instead of JavaScript.

## Testing
- `deno test --no-check --allow-all src/transforms/esm/http-cache-helpers.test.ts src/transforms/esm/specifier-resolver.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --unstable-net src/transforms/esm/*.test.ts`
- `deno task fmt:check`
- `deno task lint`
- `deno task typecheck`
- `deno task test:unit`
- pre-push hook: format, lint, typecheck, unit tests

Related: https://github.com/veryfront/veryfront-studio/issues/5676
