### PR TITLE
Expose resumable hosted web_fetch slices

### DIFF
--- a/src/agent/hosted/web-fetch-tool.test.ts
+++ b/src/agent/hosted/web-fetch-tool.test.ts
@@ -110,6 +110,37 @@ Deno.test("createHostedWebFetchTool returns resumable slices for large pages", a
   });
 });
 
+Deno.test("createHostedWebFetchTool honors host content limits above the default", async () => {
+  const body = "x".repeat(500_001);
+  const tool = createHostedWebFetchTool({
+    maxContentChars: 600_000,
+    fetch: () =>
+      Promise.resolve(
+        new Response(body, {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        }),
+      ),
+  });
+
+  const result = await tool.execute?.({
+    url: "https://veryfront.com/large-doc",
+  });
+
+  assertEquals(
+    (result as { content?: { source?: { data?: string } } }).content?.source?.data?.length,
+    500_001,
+  );
+  assertEquals((result as { complete?: unknown }).complete, true);
+  assertEquals((result as { truncated?: unknown }).truncated, false);
+  assertEquals((result as { page_info?: unknown }).page_info, {
+    offset: 0,
+    returned_chars: 500_001,
+    total_chars: 500_001,
+    next: null,
+  });
+});
+
 Deno.test("createHostedWebFetchTool honors smaller per-call content limits", async () => {
   const tool = createHostedWebFetchTool({
     fetch: () =>

--- a/src/agent/hosted/web-fetch-tool.test.ts
+++ b/src/agent/hosted/web-fetch-tool.test.ts
@@ -43,6 +43,8 @@ Deno.test("createHostedWebFetchTool fetches an explicit HTTPS URL without prior 
     String((result as { content?: { source?: { data?: unknown } } }).content?.source?.data),
     "Create agent docs",
   );
+  assertEquals((result as { complete?: unknown }).complete, true);
+  assertEquals((result as { truncated?: unknown }).truncated, false);
 });
 
 Deno.test("createHostedWebFetchTool rejects non-http URLs", async () => {
@@ -56,5 +58,110 @@ Deno.test("createHostedWebFetchTool rejects non-http URLs", async () => {
     () => tool.execute?.({ url: "file:///etc/passwd" }) as Promise<unknown>,
     Error,
     "web_fetch only supports http and https URLs",
+  );
+});
+
+Deno.test("createHostedWebFetchTool returns resumable slices for large pages", async () => {
+  const body = "0123456789abcdef";
+  const tool = createHostedWebFetchTool({
+    maxContentChars: 8,
+    fetch: () =>
+      Promise.resolve(
+        new Response(body, {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        }),
+      ),
+  });
+
+  const first = await tool.execute?.({
+    url: "https://veryfront.com/long-doc",
+  });
+
+  assertEquals(
+    (first as { content?: { source?: { data?: unknown } } }).content?.source?.data,
+    "01234567",
+  );
+  assertEquals((first as { complete?: unknown }).complete, false);
+  assertEquals((first as { truncated?: unknown }).truncated, true);
+  assertEquals((first as { page_info?: unknown }).page_info, {
+    offset: 0,
+    returned_chars: 8,
+    total_chars: 16,
+    next: "8",
+  });
+
+  const second = await tool.execute?.({
+    url: "https://veryfront.com/long-doc",
+    cursor: "8",
+  });
+
+  assertEquals(
+    (second as { content?: { source?: { data?: unknown } } }).content?.source?.data,
+    "89abcdef",
+  );
+  assertEquals((second as { complete?: unknown }).complete, true);
+  assertEquals((second as { truncated?: unknown }).truncated, false);
+  assertEquals((second as { page_info?: unknown }).page_info, {
+    offset: 8,
+    returned_chars: 8,
+    total_chars: 16,
+    next: null,
+  });
+});
+
+Deno.test("createHostedWebFetchTool honors smaller per-call content limits", async () => {
+  const tool = createHostedWebFetchTool({
+    fetch: () =>
+      Promise.resolve(
+        new Response("anthropic/claude-sonnet-4-6 appears after the old cutoff", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        }),
+      ),
+  });
+
+  const first = await tool.execute?.({
+    url: "https://veryfront.com/docs/create-agent",
+    max_content_chars: 10,
+  });
+
+  assertEquals(
+    (first as { content?: { source?: { data?: unknown } } }).content?.source?.data,
+    "anthropic/",
+  );
+  assertEquals((first as { complete?: unknown }).complete, false);
+  assertEquals((first as { page_info?: { next?: unknown } }).page_info?.next, "10");
+});
+
+Deno.test("createHostedWebFetchTool rejects invalid pagination inputs", async () => {
+  const tool = createHostedWebFetchTool({
+    fetch: () =>
+      Promise.resolve(
+        new Response("docs", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        }),
+      ),
+  });
+
+  await assertRejects(
+    () =>
+      tool.execute?.({
+        url: "https://veryfront.com/docs",
+        cursor: "not-an-offset",
+      }) as Promise<unknown>,
+    Error,
+    "web_fetch cursor must be a non-negative integer offset returned by a previous web_fetch result",
+  );
+
+  await assertRejects(
+    () =>
+      tool.execute?.({
+        url: "https://veryfront.com/docs",
+        max_content_chars: 0,
+      }) as Promise<unknown>,
+    Error,
+    "web_fetch max_content_chars must be a positive integer",
   );
 });

--- a/src/agent/hosted/web-fetch-tool.test.ts
+++ b/src/agent/hosted/web-fetch-tool.test.ts
@@ -195,4 +195,14 @@ Deno.test("createHostedWebFetchTool rejects invalid pagination inputs", async ()
     Error,
     "web_fetch max_content_chars must be a positive integer",
   );
+
+  await assertRejects(
+    () =>
+      tool.execute?.({
+        url: "https://veryfront.com/docs",
+        cursor: "5",
+      }) as Promise<unknown>,
+    Error,
+    "web_fetch cursor exceeds fetched content length",
+  );
 });

--- a/src/agent/hosted/web-fetch-tool.ts
+++ b/src/agent/hosted/web-fetch-tool.ts
@@ -40,17 +40,18 @@ export type HostedWebFetchToolOptions = {
   maxContentChars?: number;
 };
 
-const getHostedWebFetchInputSchema = defineSchema((v) =>
-  v.object({
-    url: v.string().min(1),
-    cursor: v.string().min(1).optional(),
-    max_content_chars: v.number().int().positive(
-      "web_fetch max_content_chars must be a positive integer",
-    )
-      .max(DEFAULT_MAX_CONTENT_CHARS)
-      .optional(),
-  })
-);
+const getHostedWebFetchInputSchema = (maxContentChars: number) =>
+  defineSchema((v) =>
+    v.object({
+      url: v.string().min(1),
+      cursor: v.string().min(1).optional(),
+      max_content_chars: v.number().int().positive(
+        "web_fetch max_content_chars must be a positive integer",
+      )
+        .max(maxContentChars)
+        .optional(),
+    })
+  );
 
 function parseFetchUrl(value: string): URL {
   let url: URL;
@@ -91,28 +92,40 @@ function parseCursor(value: string | undefined): number {
   return offset;
 }
 
-function normalizeMaxContentChars(value: number | undefined, label: string): number {
+function normalizeMaxContentChars(
+  value: number | undefined,
+  label: string,
+  fallback: number,
+): number {
   if (value === undefined) {
-    return DEFAULT_MAX_CONTENT_CHARS;
+    return fallback;
   }
 
   if (!Number.isSafeInteger(value) || value < 1) {
     throw new Error(`web_fetch ${label} must be a positive integer`);
   }
 
-  return Math.min(value, DEFAULT_MAX_CONTENT_CHARS);
+  return value;
 }
 
 function resolveMaxContentChars(
   input: HostedWebFetchToolInput,
   options: Required<HostedWebFetchToolOptions>,
 ): number {
-  const optionMax = normalizeMaxContentChars(options.maxContentChars, "maxContentChars option");
+  const optionMax = normalizeMaxContentChars(
+    options.maxContentChars,
+    "maxContentChars option",
+    DEFAULT_MAX_CONTENT_CHARS,
+  );
   if (input.max_content_chars === undefined) {
     return optionMax;
   }
 
-  const inputMax = normalizeMaxContentChars(input.max_content_chars, "max_content_chars");
+  const inputMax = normalizeMaxContentChars(
+    input.max_content_chars,
+    "max_content_chars",
+    optionMax,
+  );
   return Math.min(inputMax, optionMax);
 }
 
@@ -180,7 +193,7 @@ export function createHostedWebFetchTool(options: HostedWebFetchToolOptions = {}
     id: "web_fetch",
     description:
       "Fetch the content of an explicit http or https URL directly. Use this for canonical documentation or pages named in the task or available context; no prior web_search is required. Returns complete, truncated, and page_info.next metadata when a response is sliced; pass cursor to continue.",
-    inputSchema: getHostedWebFetchInputSchema(),
+    inputSchema: getHostedWebFetchInputSchema(resolvedOptions.maxContentChars)(),
     execute: (input, context) => executeHostedWebFetch(input, resolvedOptions, context),
   });
 }

--- a/src/agent/hosted/web-fetch-tool.ts
+++ b/src/agent/hosted/web-fetch-tool.ts
@@ -6,6 +6,8 @@ const DEFAULT_MAX_CONTENT_CHARS = 500_000;
 /** Input payload for hosted web_fetch. */
 export type HostedWebFetchToolInput = {
   url: string;
+  cursor?: string;
+  max_content_chars?: number;
 };
 
 /** Output payload matching provider-native web_fetch result shape. */
@@ -22,7 +24,14 @@ export type HostedWebFetchToolOutput = {
   };
   retrievedAt: string;
   status: number;
-  truncated?: boolean;
+  complete: boolean;
+  truncated: boolean;
+  page_info: {
+    offset: number;
+    returned_chars: number;
+    total_chars: number;
+    next: string | null;
+  };
 };
 
 /** Options accepted by hosted web_fetch. */
@@ -34,6 +43,12 @@ export type HostedWebFetchToolOptions = {
 const getHostedWebFetchInputSchema = defineSchema((v) =>
   v.object({
     url: v.string().min(1),
+    cursor: v.string().min(1).optional(),
+    max_content_chars: v.number().int().positive(
+      "web_fetch max_content_chars must be a positive integer",
+    )
+      .max(DEFAULT_MAX_CONTENT_CHARS)
+      .optional(),
   })
 );
 
@@ -55,12 +70,60 @@ function parseFetchUrl(value: string): URL {
   return url;
 }
 
+function parseCursor(value: string | undefined): number {
+  if (value === undefined) {
+    return 0;
+  }
+
+  if (!/^\d+$/.test(value)) {
+    throw new Error(
+      "web_fetch cursor must be a non-negative integer offset returned by a previous web_fetch result",
+    );
+  }
+
+  const offset = Number(value);
+  if (!Number.isSafeInteger(offset)) {
+    throw new Error(
+      "web_fetch cursor must be a non-negative integer offset returned by a previous web_fetch result",
+    );
+  }
+
+  return offset;
+}
+
+function normalizeMaxContentChars(value: number | undefined, label: string): number {
+  if (value === undefined) {
+    return DEFAULT_MAX_CONTENT_CHARS;
+  }
+
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`web_fetch ${label} must be a positive integer`);
+  }
+
+  return Math.min(value, DEFAULT_MAX_CONTENT_CHARS);
+}
+
+function resolveMaxContentChars(
+  input: HostedWebFetchToolInput,
+  options: Required<HostedWebFetchToolOptions>,
+): number {
+  const optionMax = normalizeMaxContentChars(options.maxContentChars, "maxContentChars option");
+  if (input.max_content_chars === undefined) {
+    return optionMax;
+  }
+
+  const inputMax = normalizeMaxContentChars(input.max_content_chars, "max_content_chars");
+  return Math.min(inputMax, optionMax);
+}
+
 async function executeHostedWebFetch(
   input: HostedWebFetchToolInput,
   options: Required<HostedWebFetchToolOptions>,
   context?: ToolExecutionContext,
 ): Promise<HostedWebFetchToolOutput> {
   const url = parseFetchUrl(input.url);
+  const offset = parseCursor(input.cursor);
+  const maxContentChars = resolveMaxContentChars(input, options);
   const response = await options.fetch(url.toString(), {
     method: "GET",
     redirect: "follow",
@@ -77,7 +140,10 @@ async function executeHostedWebFetch(
 
   const mediaType = response.headers.get("content-type") ?? "text/plain";
   const text = await response.text();
-  const truncated = text.length > options.maxContentChars;
+  const end = Math.min(text.length, offset + maxContentChars);
+  const data = text.slice(offset, end);
+  const next = end < text.length ? String(end) : null;
+  const complete = next === null;
 
   return {
     type: "web_fetch_result",
@@ -87,12 +153,19 @@ async function executeHostedWebFetch(
       source: {
         type: "text",
         mediaType,
-        data: truncated ? text.slice(0, options.maxContentChars) : text,
+        data,
       },
     },
     retrievedAt: new Date().toISOString(),
     status: response.status,
-    ...(truncated ? { truncated } : {}),
+    complete,
+    truncated: !complete,
+    page_info: {
+      offset,
+      returned_chars: data.length,
+      total_chars: text.length,
+      next,
+    },
   };
 }
 
@@ -106,7 +179,7 @@ export function createHostedWebFetchTool(options: HostedWebFetchToolOptions = {}
   return tool<HostedWebFetchToolInput, HostedWebFetchToolOutput>({
     id: "web_fetch",
     description:
-      "Fetch the content of an explicit http or https URL directly. Use this for canonical documentation or pages named in the task or available context; no prior web_search is required.",
+      "Fetch the content of an explicit http or https URL directly. Use this for canonical documentation or pages named in the task or available context; no prior web_search is required. Returns complete, truncated, and page_info.next metadata when a response is sliced; pass cursor to continue.",
     inputSchema: getHostedWebFetchInputSchema(),
     execute: (input, context) => executeHostedWebFetch(input, resolvedOptions, context),
   });

--- a/src/agent/hosted/web-fetch-tool.ts
+++ b/src/agent/hosted/web-fetch-tool.ts
@@ -153,6 +153,10 @@ async function executeHostedWebFetch(
 
   const mediaType = response.headers.get("content-type") ?? "text/plain";
   const text = await response.text();
+  if (offset > text.length) {
+    throw new Error("web_fetch cursor exceeds fetched content length");
+  }
+
   const end = Math.min(text.length, offset + maxContentChars);
   const data = text.slice(offset, end);
   const next = end < text.length ? String(end) : null;


### PR DESCRIPTION
## Summary
- add optional cursor and max_content_chars inputs to hosted web_fetch
- return explicit complete, truncated, and page_info metadata for every fetch result
- cover resumable large-page reads, smaller per-call limits, and invalid pagination inputs

## Scope
This is a scoped follow-up for https://github.com/veryfront/veryfront-studio/issues/5614. It improves hosted web_fetch full-fidelity retrieval controls without overlapping the separate invoke_agent full-result work in PR #2829.

## Testing
- deno test --no-check --allow-all src/agent/hosted/web-fetch-tool.test.ts
- deno test --no-check --allow-all src/agent/hosted/*.test.ts
- deno task fmt:check
- deno task lint
- deno task typecheck
- deno task test:unit
- git diff --check
- pre-push hook: format, lint, typecheck, unit tests