### PR TITLE
Keep hosted project traces discoverable after OTel hardening

### DIFF
--- a/src/routing/registry/registry.test.ts
+++ b/src/routing/registry/registry.test.ts
@@ -115,6 +115,24 @@ describe("routing/registry/RouteRegistry", () => {
       assertEquals("veryfront.environment_name" in attributes, false);
     });
 
+    it("does not emit slug fallbacks as project id attributes", () => {
+      const req = makeReq();
+      const url = new URL(req.url);
+      const attributes = buildRouteRegistrySpanAttributes(req, url, {
+        ...makeCtx(),
+        projectSlug: "ops-agent",
+        enriched: {
+          projectSlug: "ops-agent",
+          projectId: "ops-agent",
+        } as HandlerContext["enriched"],
+      });
+
+      assertEquals(attributes["veryfront.project_slug"], "ops-agent");
+      assertEquals(attributes["project.slug"], "ops-agent");
+      assertEquals("veryfront.project_id" in attributes, false);
+      assertEquals("project.id" in attributes, false);
+    });
+
     it("should return response from first matching handler", async () => {
       const registry = new RouteRegistry();
       registry.register(

--- a/src/routing/registry/registry.test.ts
+++ b/src/routing/registry/registry.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { RouteRegistry } from "./registry.ts";
+import { buildRouteRegistrySpanAttributes, RouteRegistry } from "./registry.ts";
 import type { Handler, HandlerContext, HandlerResult } from "./types.ts";
 import { CONFIG_NOT_FOUND } from "#veryfront/errors/error-registry.ts";
 
@@ -79,6 +79,42 @@ describe("routing/registry/RouteRegistry", () => {
   });
 
   describe("execute()", () => {
+    it("adds trusted project identity to the routing span attributes", () => {
+      const req = makeReq();
+      const url = new URL(req.url);
+      const attributes = buildRouteRegistrySpanAttributes(req, url, {
+        ...makeCtx(),
+        projectSlug: "investment-ops-agent",
+        projectId: "proj-123",
+        resolvedEnvironment: "production",
+        environmentName: "Production",
+      });
+
+      assertEquals(attributes["http.method"], "GET");
+      assertEquals(attributes["http.path"], "/test");
+      assertEquals(attributes["veryfront.project_slug"], "investment-ops-agent");
+      assertEquals(attributes["project.slug"], "investment-ops-agent");
+      assertEquals(attributes["veryfront.project_id"], "proj-123");
+      assertEquals(attributes["project.id"], "proj-123");
+      assertEquals(attributes["veryfront.environment"], "production");
+      assertEquals(attributes["veryfront.environment_name"], "Production");
+    });
+
+    it("omits project attributes when no trusted project identity exists", () => {
+      const req = makeReq();
+      const url = new URL(req.url);
+      const attributes = buildRouteRegistrySpanAttributes(req, url, makeCtx());
+
+      assertEquals(attributes["http.method"], "GET");
+      assertEquals(attributes["http.path"], "/test");
+      assertEquals("veryfront.project_slug" in attributes, false);
+      assertEquals("project.slug" in attributes, false);
+      assertEquals("veryfront.project_id" in attributes, false);
+      assertEquals("project.id" in attributes, false);
+      assertEquals("veryfront.environment" in attributes, false);
+      assertEquals("veryfront.environment_name" in attributes, false);
+    });
+
     it("should return response from first matching handler", async () => {
       const registry = new RouteRegistry();
       registry.register(

--- a/src/routing/registry/registry.ts
+++ b/src/routing/registry/registry.ts
@@ -5,6 +5,39 @@ import { errorToRFC9457Response } from "#veryfront/errors/middleware/http-error-
 
 const logger = serverLogger.component("route-registry");
 
+type SpanAttributes = Record<string, string | number | boolean>;
+
+export function buildRouteRegistrySpanAttributes(
+  req: Request,
+  url: URL,
+  ctx: HandlerContext,
+): SpanAttributes {
+  const attributes: SpanAttributes = {
+    "http.method": req.method,
+    "http.path": url.pathname,
+  };
+
+  const projectSlug = ctx.projectSlug ?? ctx.enriched?.projectSlug;
+  if (projectSlug) {
+    attributes["veryfront.project_slug"] = projectSlug;
+    attributes["project.slug"] = projectSlug;
+    attributes["veryfront.environment"] = ctx.resolvedEnvironment ?? ctx.requestContext?.mode ??
+      "unknown";
+  }
+
+  const projectId = ctx.projectId ?? ctx.enriched?.projectId;
+  if (projectId) {
+    attributes["veryfront.project_id"] = projectId;
+    attributes["project.id"] = projectId;
+  }
+
+  if ((projectSlug || projectId) && ctx.environmentName) {
+    attributes["veryfront.environment_name"] = ctx.environmentName;
+  }
+
+  return attributes;
+}
+
 export class RouteRegistry {
   private handlers: Handler[] = [];
   private config: RouteRegistryConfig;
@@ -117,7 +150,7 @@ export class RouteRegistry {
 
         return null;
       },
-      { "http.method": req.method, "http.path": url.pathname },
+      buildRouteRegistrySpanAttributes(req, url, ctx),
     );
   }
 

--- a/src/routing/registry/registry.ts
+++ b/src/routing/registry/registry.ts
@@ -25,7 +25,7 @@ export function buildRouteRegistrySpanAttributes(
       "unknown";
   }
 
-  const projectId = ctx.projectId ?? ctx.enriched?.projectId;
+  const projectId = ctx.projectId;
   if (projectId) {
     attributes["veryfront.project_id"] = projectId;
     attributes["project.id"] = projectId;


### PR DESCRIPTION
## Summary
- Adds trusted project id/slug attributes to `routing.registry.execute` spans so hosted project traces remain discoverable by project-scoped Tempo queries.
- Keeps shared runtime OTel service identity host-owned instead of restoring project-controlled `OTEL_SERVICE_NAME` overrides.
- Adds regression coverage for project and no-project route span attributes.

## Testing
- `deno fmt --check src/routing/registry/registry.ts src/routing/registry/registry.test.ts`
- `deno test --no-check --allow-all src/routing/registry/registry.test.ts`
- `deno task lint`
- `deno task typecheck`
- `deno task test:unit` via pre-push hook: 2303 passed, 0 failed

Fixes veryfront/veryfront-studio#5677
