### PR TITLE
Forward runtime environment to project tasks

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1033",
+  "version": "0.1.1034",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -269,6 +269,43 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     assertEquals(receivedEnvironmentId, "11111111-1111-4111-8111-111111111111");
   });
 
+  it("preserves explicit null runtime environment targets", async () => {
+    let receivedEnvironmentId: string | undefined;
+    const handler = new ProjectRunExecuteHandler(createDeps({
+      runTask: async (options) => {
+        receivedEnvironmentId = options.environmentId;
+        return {
+          success: true,
+          result: { synced: 12 },
+          durationMs: 42,
+        };
+      },
+    }));
+    const body = {
+      runId: "run_task_main",
+      kind: "task",
+      target: "task:sync-calendar-events",
+      projectId: "proj-1",
+      runtimeTargetKind: "main_branch",
+      runtimeTargetEnvironmentId: null,
+      config: {},
+    };
+    const { request, publicKeyPem } = await signedRequest(
+      "/api/control-plane/runs/run_task_main/execute",
+      body,
+    );
+    const ctx = {
+      ...createCtx(publicKeyPem),
+      environmentId: "22222222-2222-4222-8222-222222222222",
+    } as HandlerContext;
+
+    const result = await handler.handle(request, ctx);
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(receivedEnvironmentId, undefined);
+  });
+
   it("runs cloud task targets from project runtime discovery", async () => {
     const order: string[] = [];
     const discovery = createEmptyDiscoveryResult();

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -229,9 +229,11 @@ describe("server/handlers/request/project-run-execute.handler", () => {
 
   it("runs a discovered task and returns canonical runtime execution output", async () => {
     let receivedConfig: Record<string, unknown> | undefined;
+    let receivedEnvironmentId: string | undefined;
     const handler = new ProjectRunExecuteHandler(createDeps({
       runTask: async (options) => {
         receivedConfig = options.config;
+        receivedEnvironmentId = options.environmentId;
         return {
           success: true,
           result: { synced: 12 },
@@ -244,6 +246,8 @@ describe("server/handlers/request/project-run-execute.handler", () => {
       kind: "task",
       target: "task:sync-calendar-events",
       projectId: "proj-1",
+      runtimeTargetKind: "environment",
+      runtimeTargetEnvironmentId: "11111111-1111-4111-8111-111111111111",
       config: { dry_run: true },
     };
     const { request, publicKeyPem } = await signedRequest(
@@ -262,6 +266,7 @@ describe("server/handlers/request/project-run-execute.handler", () => {
       logs: null,
     });
     assertEquals(receivedConfig, { dry_run: true });
+    assertEquals(receivedEnvironmentId, "11111111-1111-4111-8111-111111111111");
   });
 
   it("runs cloud task targets from project runtime discovery", async () => {

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -55,6 +55,9 @@ export interface ProjectRunExecuteRequest {
   target: string;
   projectId: string;
   runtimeAgUiEndpoint?: string;
+  runtimeTargetKind?: "main_branch" | "environment" | "preview_branch";
+  runtimeTargetEnvironmentId?: string | null;
+  runtimeTargetBranchId?: string | null;
   config?: Record<string, unknown>;
   input?: Record<string, unknown>;
 }
@@ -166,6 +169,21 @@ function parseOptionalUrl(value: unknown, fieldName: string): string | undefined
   }
 }
 
+function parseRuntimeTargetKind(value: unknown): ProjectRunExecuteRequest["runtimeTargetKind"] {
+  if (value === undefined || value === null) return undefined;
+  if (value === "main_branch" || value === "environment" || value === "preview_branch") {
+    return value;
+  }
+  throw new Error("Invalid runtimeTargetKind");
+}
+
+function parseOptionalNullableString(value: unknown, fieldName: string): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value !== "string" || value.length === 0) throw new Error(`Invalid ${fieldName}`);
+  return value;
+}
+
 function parseExecuteRequest(value: unknown, pathRunId: string): ProjectRunExecuteRequest {
   if (!isRecord(value)) throw new Error("Expected object");
 
@@ -193,6 +211,15 @@ function parseExecuteRequest(value: unknown, pathRunId: string): ProjectRunExecu
     target,
     projectId,
     runtimeAgUiEndpoint: parseOptionalUrl(value.runtimeAgUiEndpoint, "runtimeAgUiEndpoint"),
+    runtimeTargetKind: parseRuntimeTargetKind(value.runtimeTargetKind),
+    runtimeTargetEnvironmentId: parseOptionalNullableString(
+      value.runtimeTargetEnvironmentId,
+      "runtimeTargetEnvironmentId",
+    ),
+    runtimeTargetBranchId: parseOptionalNullableString(
+      value.runtimeTargetBranchId,
+      "runtimeTargetBranchId",
+    ),
     config: parseRecord(value.config),
     input: parseRecord(value.input),
   };
@@ -299,6 +326,7 @@ async function executeTaskRun(
     task,
     config: request.config ?? {},
     projectId: request.projectId,
+    environmentId: request.runtimeTargetEnvironmentId ?? ctx.environmentId,
     debug: ctx.debug,
   });
 

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -326,7 +326,9 @@ async function executeTaskRun(
     task,
     config: request.config ?? {},
     projectId: request.projectId,
-    environmentId: request.runtimeTargetEnvironmentId ?? ctx.environmentId,
+    environmentId: request.runtimeTargetEnvironmentId === undefined
+      ? ctx.environmentId
+      : request.runtimeTargetEnvironmentId ?? undefined,
     debug: ctx.debug,
   });
 

--- a/src/task/runner.test.ts
+++ b/src/task/runner.test.ts
@@ -103,6 +103,20 @@ describe("src/task/runner", () => {
       assertEquals(receivedProjectId, "proj-123");
     });
 
+    it("should pass environmentId to task context", async () => {
+      let receivedEnvironmentId: string | undefined;
+      const task = makeTask({
+        run: (ctx) => {
+          receivedEnvironmentId = ctx.environmentId;
+          return null;
+        },
+      });
+
+      await runTask({ task, environmentId: "env-123" });
+
+      assertEquals(receivedEnvironmentId, "env-123");
+    });
+
     it("should merge injected task env into ctx.env without exposing reserved runtime env", async () => {
       let receivedEnv: Record<string, string> = {};
       const originalTaskEnvJson = Deno.env.get("VERYFRONT_TASK_ENV_JSON");

--- a/src/task/runner.ts
+++ b/src/task/runner.ts
@@ -37,6 +37,9 @@ export interface RunTaskOptions {
   /** Project ID (for cloud context) */
   projectId?: string;
 
+  /** Environment ID for the runtime target executing this task */
+  environmentId?: string;
+
   /** If set, only these env var names are passed to the task. */
   envAllowlist?: string[];
 
@@ -65,7 +68,7 @@ export interface TaskRunResult {
  * Run a task with the given options
  */
 export async function runTask(options: RunTaskOptions): Promise<TaskRunResult> {
-  const { task, config = {}, projectId, envAllowlist, debug = false } = options;
+  const { task, config = {}, projectId, environmentId, envAllowlist, debug = false } = options;
   const start = Date.now();
 
   if (debug) {
@@ -79,6 +82,7 @@ export async function runTask(options: RunTaskOptions): Promise<TaskRunResult> {
     env,
     config,
     projectId,
+    environmentId,
   };
 
   try {

--- a/src/task/types.ts
+++ b/src/task/types.ts
@@ -16,6 +16,8 @@ export interface TaskContext {
   config: Record<string, unknown>;
   /** Project ID (when executed by the platform) */
   projectId?: string;
+  /** Environment ID for the runtime target executing this task */
+  environmentId?: string;
 }
 
 /**

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1033";
+export const VERSION = "0.1.1034";


### PR DESCRIPTION
## Summary
- add `TaskContext.environmentId` and pass it through `runTask`
- accept runtime target metadata on project-run `/execute` requests
- use the target environment id when executing project tasks
- bump `veryfront` to `0.1.1034` and keep the runtime version constant in sync

## Verification
- `deno test --allow-all src/task/runner.test.ts src/server/handlers/request/project-run-execute.handler.test.ts`
- `deno fmt --check deno.json src/task/types.ts src/task/runner.ts src/task/runner.test.ts src/server/handlers/request/project-run-execute.handler.ts src/server/handlers/request/project-run-execute.handler.test.ts`
- `env -u OTEL_METRICS_EXPORTER -u OTEL_EXPORTER_OTLP_ENDPOINT -u OTEL_EXPORTER_OTLP_METRICS_ENDPOINT -u OTEL_EXPORTER_OTLP_HEADERS -u OTEL_EXPORTER_OTLP_METRICS_HEADERS -u DATADOG_OTLP_API_KEY deno test --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/observability/metrics/config.test.ts src/task/runner.test.ts src/server/handlers/request/project-run-execute.handler.test.ts`

## Note
The first local full pre-push run exposed local OTEL env pollution in metrics defaults plus an unrelated Deno TLS leak. Targeted tests pass cleanly; GitHub CI is the integration authority.