### PR TITLE
Return 404 for missing managed-domain token lookups

### DIFF
--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -520,6 +520,53 @@ describe("Proxy Handler", () => {
       }
     });
 
+    it("returns 404 for managed production hosts when token mint reports no project for domain", async () => {
+      const { entries, logger } = createRecordingLogger();
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") {
+          return new Response('{"error":"Project not found for domain"}', {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      let handler: ReturnType<typeof createProxyHandler> | undefined;
+      try {
+        handler = createProxyHandler({
+          config: {
+            apiBaseUrl: `http://127.0.0.1:${port}`,
+            apiClientId: "test-client",
+            apiClientSecret: "test-secret",
+            previewApiClientId: "test-client",
+            previewApiClientSecret: "test-secret",
+          },
+          logger,
+        });
+
+        const req = new Request("http://stripe.production.veryfront.com/", {
+          headers: { host: "stripe.production.veryfront.com" },
+        });
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.projectSlug, undefined);
+        assertEquals(ctx.error?.status, 404);
+        assertEquals(ctx.error?.message, "Project not found");
+        assertEquals(
+          entries.filter((entry) => entry.level === "error").map((entry) => entry.message),
+          [],
+        );
+      } finally {
+        await handler?.close();
+        await server.shutdown();
+      }
+    });
+
     it("logs expected custom domain token-mint misses below error level", async () => {
       const { entries, logger } = createRecordingLogger();
       const { server, port } = createMockServer((req: Request) => {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -698,7 +698,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
       if (projectSlug && !token) {
         const status = parseStatusFromError(tokenFetchError);
-        if (status === 404) {
+        if (status === 404 || isMissingCustomDomainProjectError(tokenFetchError)) {
           if (scope === "preview") {
             logger?.info("Preview project not found", { projectSlug, host });
             return createProjectNotFoundProxyContext(base, "Preview project not found");

--- a/src/proxy/proxy-token-resolution.ts
+++ b/src/proxy/proxy-token-resolution.ts
@@ -97,7 +97,7 @@ export async function resolveProxyRequestToken(
         tokenSource = "service";
       } catch (error) {
         tokenFetchError = error;
-        if (!(customDomain && isMissingCustomDomainProjectError(error))) {
+        if (!isMissingCustomDomainProjectError(error)) {
           logger?.error(tokenFetchErrorMessage, error as Error, {
             projectSlug,
             customDomain,


### PR DESCRIPTION
## Summary\n- treat API token-mint `Project not found for domain` responses as project-not-found for managed production hosts too\n- suppress error-level logging for that known domain-miss response\n- add a regression test for `stripe.production.veryfront.com` returning 404 instead of 502\n\n## Verification\n- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/proxy/handler.test.ts\n- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/proxy/proxy-token-resolution.test.ts src/proxy/token-manager.test.ts src/proxy/oauth-client.test.ts\n- deno fmt --check src/proxy/handler.ts src/proxy/handler.test.ts src/proxy/proxy-token-resolution.ts\n- deno task typecheck\n- pre-push hook: format, lint, typecheck, generated manifests/prebundles, 2311 unit tests