### PR TITLE
Bump veryfront runtime to 0.1.1036

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1035",
+  "version": "0.1.1036",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1035";
+export const VERSION = "0.1.1036";


### PR DESCRIPTION
## Summary\n- Bump the root Deno package version to 0.1.1036\n- Keep the shared runtime VERSION constant in sync\n\n## Verification\n- deno fmt --check deno.json src/utils/version-constant.ts\n- deno task typecheck\n- pre-push hook passed: format, lint, typecheck, and unit tests (2,311 passed)