### PR TITLE
Propagate environment targets for delegated agent runs

### DIFF
--- a/src/agent/conversation/bootstrap.ts
+++ b/src/agent/conversation/bootstrap.ts
@@ -315,6 +315,8 @@ export async function bootstrapConversationAgentRun(input: {
   agentId: string;
   implementationKind?: string | null;
   projectId?: string | null;
+  runtimeTargetKind?: "main_branch" | "environment" | "preview_branch" | null;
+  runtimeTargetEnvironmentId?: string | null;
   branchId?: string | null;
 }): Promise<BootstrapConversationAgentRunResult> {
   if (input.parentConversationId && input.ensureProjectId) {
@@ -347,6 +349,8 @@ export async function bootstrapConversationAgentRun(input: {
     agentId: input.agentId,
     implementationKind: input.implementationKind,
     projectId: effectiveProjectId,
+    runtimeTargetKind: input.runtimeTargetKind,
+    runtimeTargetEnvironmentId: input.runtimeTargetEnvironmentId,
     branchId: input.branchId,
   });
 

--- a/src/agent/conversation/durable-contracts.test.ts
+++ b/src/agent/conversation/durable-contracts.test.ts
@@ -10,6 +10,7 @@ import {
 const CONVERSATION_ID = "11111111-1111-4111-a111-111111111111";
 const MESSAGE_ID = "22222222-2222-4222-a222-222222222222";
 const PROJECT_ID = "33333333-3333-4333-a333-333333333333";
+const ENVIRONMENT_ID = "55555555-5555-4555-8555-555555555555";
 const BRANCH_ID = "44444444-4444-4444-8444-444444444444";
 
 describe("agent/durable-contracts", () => {
@@ -17,16 +18,33 @@ describe("agent/durable-contracts", () => {
     assertEquals(resolveConversationRunTargets({ projectId: null, branchId: null }), {
       sourceTargetKind: null,
       runtimeTargetKind: null,
+      targetEnvironmentId: null,
       targetBranchId: null,
     });
     assertEquals(resolveConversationRunTargets({ projectId: PROJECT_ID, branchId: BRANCH_ID }), {
       sourceTargetKind: "preview_branch",
       runtimeTargetKind: "preview_branch",
+      targetEnvironmentId: null,
       targetBranchId: BRANCH_ID,
     });
+    assertEquals(
+      resolveConversationRunTargets({
+        projectId: PROJECT_ID,
+        runtimeTargetKind: "environment",
+        environmentId: ENVIRONMENT_ID,
+        branchId: null,
+      }),
+      {
+        sourceTargetKind: "environment",
+        runtimeTargetKind: "environment",
+        targetEnvironmentId: ENVIRONMENT_ID,
+        targetBranchId: null,
+      },
+    );
     assertEquals(resolveConversationRunTargets({ projectId: PROJECT_ID, branchId: null }), {
       sourceTargetKind: "project",
       runtimeTargetKind: "main_branch",
+      targetEnvironmentId: null,
       targetBranchId: null,
     });
   });

--- a/src/agent/conversation/durable-contracts.ts
+++ b/src/agent/conversation/durable-contracts.ts
@@ -1,11 +1,11 @@
-import type { InferSchema } from "#veryfront/extensions/schema/index.ts";
 import { defineSchema, lazySchema } from "#veryfront/schemas/index.ts";
 
 /** Zod schema for get conversation run targets. */
 export const getConversationRunTargetsSchema = defineSchema((v) =>
   v.object({
-    sourceTargetKind: v.enum(["project", "preview_branch"]).nullable(),
-    runtimeTargetKind: v.enum(["main_branch", "preview_branch"]).nullable(),
+    sourceTargetKind: v.enum(["project", "environment", "preview_branch"]).nullable(),
+    runtimeTargetKind: v.enum(["main_branch", "environment", "preview_branch"]).nullable(),
+    targetEnvironmentId: v.string().uuid().nullable().optional(),
     targetBranchId: v.string().uuid().nullable(),
   })
 );
@@ -15,35 +15,60 @@ export const getConversationRunTargetsSchema = defineSchema((v) =>
  */
 export const ConversationRunTargetsSchema = lazySchema(getConversationRunTargetsSchema);
 
+/** Source target kind recorded on project-backed conversation runs. */
+export type ConversationRunSourceTargetKind = "project" | "environment" | "preview_branch";
+
+/** Runtime target kind recorded on project-backed conversation runs. */
+export type ConversationRunRuntimeTargetKind = "main_branch" | "environment" | "preview_branch";
+
 /** Public API contract for conversation run targets. */
-export type ConversationRunTargets = InferSchema<
-  ReturnType<typeof getConversationRunTargetsSchema>
->;
+export interface ConversationRunTargets {
+  sourceTargetKind: ConversationRunSourceTargetKind | null;
+  runtimeTargetKind: ConversationRunRuntimeTargetKind | null;
+  targetEnvironmentId?: string | null;
+  targetBranchId: string | null;
+}
 
 /** Resolves conversation run targets. */
 export function resolveConversationRunTargets(input: {
   projectId?: string | null;
+  runtimeTargetKind?: "main_branch" | "environment" | "preview_branch" | null;
+  environmentId?: string | null;
   branchId?: string | null;
 }): ConversationRunTargets {
+  if (!input.projectId) {
+    return getConversationRunTargetsSchema().parse({
+      sourceTargetKind: null,
+      runtimeTargetKind: null,
+      targetEnvironmentId: null,
+      targetBranchId: null,
+    }) as ConversationRunTargets;
+  }
+
+  if (input.runtimeTargetKind === "environment" && input.environmentId) {
+    return getConversationRunTargetsSchema().parse({
+      sourceTargetKind: "environment",
+      runtimeTargetKind: "environment",
+      targetEnvironmentId: input.environmentId,
+      targetBranchId: null,
+    }) as ConversationRunTargets;
+  }
+
   return getConversationRunTargetsSchema().parse(
-    !input.projectId
-      ? {
-        sourceTargetKind: null,
-        runtimeTargetKind: null,
-        targetBranchId: null,
-      }
-      : input.branchId
+    input.branchId
       ? {
         sourceTargetKind: "preview_branch",
         runtimeTargetKind: "preview_branch",
+        targetEnvironmentId: null,
         targetBranchId: input.branchId,
       }
       : {
         sourceTargetKind: "project",
         runtimeTargetKind: "main_branch",
+        targetEnvironmentId: null,
         targetBranchId: null,
       },
-  );
+  ) as ConversationRunTargets;
 }
 
 /** Zod schema for get conversation run status. */
@@ -367,6 +392,8 @@ export interface CreateConversationAgentRunInput {
   agentId: string;
   implementationKind?: string | null;
   projectId?: string | null;
+  runtimeTargetKind?: "main_branch" | "environment" | "preview_branch" | null;
+  runtimeTargetEnvironmentId?: string | null;
   branchId?: string | null;
   abortSignal?: AbortSignal;
 }

--- a/src/agent/conversation/durable.test.ts
+++ b/src/agent/conversation/durable.test.ts
@@ -31,6 +31,7 @@ const AUTH_TOKEN = "token-123";
 const CONVERSATION_ID = "11111111-1111-4111-a111-111111111111";
 const MESSAGE_ID = "22222222-2222-4222-a222-222222222222";
 const PROJECT_ID = "33333333-3333-4333-a333-333333333333";
+const ENVIRONMENT_ID = "55555555-5555-4555-8555-555555555555";
 const BRANCH_ID = "44444444-4444-4444-8444-444444444444";
 
 const originalFetch = globalThis.fetch;
@@ -112,6 +113,7 @@ describe("agent/durable", () => {
     assertEquals(resolveConversationRunTargets({ projectId: null, branchId: null }), {
       sourceTargetKind: null,
       runtimeTargetKind: null,
+      targetEnvironmentId: null,
       targetBranchId: null,
     });
   });
@@ -120,14 +122,33 @@ describe("agent/durable", () => {
     assertEquals(resolveConversationRunTargets({ projectId: PROJECT_ID, branchId: BRANCH_ID }), {
       sourceTargetKind: "preview_branch",
       runtimeTargetKind: "preview_branch",
+      targetEnvironmentId: null,
       targetBranchId: BRANCH_ID,
     });
+  });
+
+  it("resolves project environment targets when an environment is present", () => {
+    assertEquals(
+      resolveConversationRunTargets({
+        projectId: PROJECT_ID,
+        runtimeTargetKind: "environment",
+        environmentId: ENVIRONMENT_ID,
+        branchId: null,
+      }),
+      {
+        sourceTargetKind: "environment",
+        runtimeTargetKind: "environment",
+        targetEnvironmentId: ENVIRONMENT_ID,
+        targetBranchId: null,
+      },
+    );
   });
 
   it("resolves project main branch targets with main_branch runtime metadata", () => {
     assertEquals(resolveConversationRunTargets({ projectId: PROJECT_ID, branchId: null }), {
       sourceTargetKind: "project",
       runtimeTargetKind: "main_branch",
+      targetEnvironmentId: null,
       targetBranchId: null,
     });
   });
@@ -206,6 +227,53 @@ describe("agent/durable", () => {
           runtime_target_kind: "preview_branch",
           source_target_branch_id: BRANCH_ID,
           runtime_target_branch_id: BRANCH_ID,
+        },
+      },
+    );
+  });
+
+  it("preserves environment target metadata for project-backed runs", async () => {
+    const fetchCalls = stubFetchSequence(
+      acceptedRunResponse({ run_id: "run_child_env_1" }),
+      jsonResponse(
+        durableRunProjection({
+          run_id: "run_child_env_1",
+          project_id: PROJECT_ID,
+          source_target_kind: "environment",
+        }),
+        200,
+      ),
+    );
+
+    await createConversationAgentRun({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      runId: "run_child_env_1",
+      agentId: "invoke-agent-child",
+      projectId: PROJECT_ID,
+      runtimeTargetKind: "environment",
+      runtimeTargetEnvironmentId: ENVIRONMENT_ID,
+      branchId: null,
+    });
+
+    assertEquals(
+      JSON.parse(String(fetchCalls[0]?.[1]?.body)),
+      {
+        kind: "agent",
+        owner: {
+          kind: "conversation",
+          id: CONVERSATION_ID,
+        },
+        public_id: "run_child_env_1",
+        request: {
+          mode: "agent",
+          agent_id: "invoke-agent-child",
+          initial_status: "running",
+          source_target_kind: "environment",
+          runtime_target_kind: "environment",
+          source_target_environment_id: ENVIRONMENT_ID,
+          runtime_target_environment_id: ENVIRONMENT_ID,
         },
       },
     );

--- a/src/agent/conversation/durable.ts
+++ b/src/agent/conversation/durable.ts
@@ -1064,6 +1064,8 @@ export async function createConversationAgentRun(
 ): Promise<ConversationRunProjection> {
   const targets = resolveConversationRunTargets({
     projectId: input.projectId ?? null,
+    runtimeTargetKind: input.runtimeTargetKind ?? null,
+    environmentId: input.runtimeTargetEnvironmentId ?? null,
     branchId: input.branchId ?? null,
   });
   const runId = input.runId ?? `run_${crypto.randomUUID()}`;
@@ -1082,6 +1084,12 @@ export async function createConversationAgentRun(
           runtime_target_branch_id: targets.targetBranchId,
         }
         : {}),
+      ...(targets.targetEnvironmentId
+        ? {
+          source_target_environment_id: targets.targetEnvironmentId,
+          runtime_target_environment_id: targets.targetEnvironmentId,
+        }
+        : {}),
     }
     : {
       mode: "agent" as const,
@@ -1093,6 +1101,12 @@ export async function createConversationAgentRun(
         ? {
           source_target_branch_id: targets.targetBranchId,
           runtime_target_branch_id: targets.targetBranchId,
+        }
+        : {}),
+      ...(targets.targetEnvironmentId
+        ? {
+          source_target_environment_id: targets.targetEnvironmentId,
+          runtime_target_environment_id: targets.targetEnvironmentId,
         }
         : {}),
     };

--- a/src/agent/hosted/chat-preparation.ts
+++ b/src/agent/hosted/chat-preparation.ts
@@ -98,6 +98,8 @@ export type HostedChatRuntimeCreationPreparationInput<TRuntimeAgentDefinition> =
   authToken: string;
   conversationId?: string;
   branchId?: string | null;
+  runtimeTargetKind?: ChatRequestContext["runtimeTargetKind"];
+  runtimeTargetEnvironmentId?: string | null;
   environmentContext?: string;
   rootRunContext?: HostedChatRuntimePreparationRootRunContext;
   resolveModelId: (modelId: string | undefined) => string | undefined;
@@ -303,6 +305,12 @@ export async function prepareHostedChatRuntimeCreationOptions<
       authToken: input.authToken,
       instructions: agentInstructions,
       ...(input.branchId !== undefined ? { branchId: input.branchId } : {}),
+      ...(input.runtimeTargetKind !== undefined
+        ? { runtimeTargetKind: input.runtimeTargetKind }
+        : {}),
+      ...(input.runtimeTargetEnvironmentId !== undefined
+        ? { runtimeTargetEnvironmentId: input.runtimeTargetEnvironmentId }
+        : {}),
       ...(runtimeConfig.requestedModel ? { model: runtimeConfig.requestedModel } : {}),
       ...(runtimeConfig.requestedThinking ? { thinking: runtimeConfig.requestedThinking } : {}),
       ...(runtimeConfig.requestedTemperature !== undefined
@@ -402,6 +410,8 @@ export async function prepareHostedChatExecution<
     authToken: input.request.authToken,
     conversationId: input.request.conversationId,
     branchId: normalized.effectiveValidatedContext.branchId,
+    runtimeTargetKind: normalized.effectiveValidatedContext.runtimeTargetKind,
+    runtimeTargetEnvironmentId: normalized.effectiveValidatedContext.runtimeTargetEnvironmentId,
     environmentContext: normalized.effectiveValidatedContext.environmentContext,
     rootRunContext,
     resolveModelId: input.resolveModelId,

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -18,6 +18,7 @@ const inputAnchorMessageId = "10000000-1000-4000-8000-100000000003";
 const userId = "10000000-1000-4000-8000-100000000004";
 const projectId = "10000000-1000-4000-8000-100000000005";
 const branchId = "10000000-1000-4000-8000-100000000006";
+const environmentId = "10000000-1000-4000-8000-100000000008";
 
 function createRuntimeInvocation() {
   return RuntimeAgentRunInvocationSchema.parse({
@@ -148,6 +149,7 @@ describe("agent/hosted-chat-request", () => {
       projectId,
       projectSlug: "demo-project",
       branchId,
+      runtimeTargetKind: "preview_branch",
     });
     assertEquals(request.durableRootRun, {
       runId: "run_root_1",
@@ -155,6 +157,33 @@ describe("agent/hosted-chat-request", () => {
       parentConversationId: "10000000-1000-4000-8000-100000000007",
       parentRunId: "run_parent_1",
       spawnedFromToolCallId: "tool_1",
+    });
+  });
+
+  it("carries environment runtime target metadata from runtime invocations", () => {
+    const baseInvocation = createRuntimeInvocation();
+    const invocation = RuntimeAgentRunInvocationSchema.parse({
+      ...baseInvocation,
+      run: {
+        ...baseInvocation.run,
+        project: {
+          projectId,
+          projectSlug: "demo-project",
+          runtimeTargetKind: "environment",
+          runtimeTargetEnvironmentId: environmentId,
+        },
+      },
+    });
+
+    const request = buildHostedChatRequestFromRuntimeAgentInvocation(invocation);
+
+    assertEquals(request.context, {
+      conversationId,
+      projectId,
+      projectSlug: "demo-project",
+      branchId: null,
+      runtimeTargetKind: "environment",
+      runtimeTargetEnvironmentId: environmentId,
     });
   });
   it("carries Studio environment context from runtime context into hosted chat context", () => {

--- a/src/agent/hosted/chat-request.ts
+++ b/src/agent/hosted/chat-request.ts
@@ -104,6 +104,14 @@ function getStudioRuntimeEnvironmentContext(input: RuntimeAgentRunInvocation): s
   return undefined;
 }
 
+function getRuntimeTargetKind(
+  value: unknown,
+): HostedChatRequestInput["context"]["runtimeTargetKind"] {
+  return value === "main_branch" || value === "environment" || value === "preview_branch"
+    ? value
+    : undefined;
+}
+
 /** Builds hosted chat request forwarded props from runtime agent invocation. */
 export function buildHostedChatRequestForwardedPropsFromRuntimeAgentInvocation(
   input: RuntimeAgentRunInvocation,
@@ -128,6 +136,7 @@ export function buildHostedChatRequestInputFromRuntimeAgentInvocation(
   input: RuntimeAgentRunInvocation,
 ): HostedChatRequestInput {
   const environmentContext = getStudioRuntimeEnvironmentContext(input);
+  const runtimeTargetKind = getRuntimeTargetKind(input.run.project.runtimeTargetKind);
 
   return {
     messages: input.messages,
@@ -136,6 +145,10 @@ export function buildHostedChatRequestInputFromRuntimeAgentInvocation(
       projectId: input.run.project.projectId,
       projectSlug: input.run.project.projectSlug,
       branchId: input.run.project.runtimeTargetBranchId ?? null,
+      ...(runtimeTargetKind ? { runtimeTargetKind } : {}),
+      ...(input.run.project.runtimeTargetEnvironmentId !== undefined
+        ? { runtimeTargetEnvironmentId: input.run.project.runtimeTargetEnvironmentId ?? null }
+        : {}),
       ...(environmentContext ? { environmentContext } : {}),
     },
     forwardedProps: buildHostedChatRequestForwardedPropsFromRuntimeAgentInvocation(input),

--- a/src/agent/hosted/chat-runtime-contract.ts
+++ b/src/agent/hosted/chat-runtime-contract.ts
@@ -109,10 +109,15 @@ export type HostedSubmittedFormInputResult = {
   inputRequestId: string;
 };
 
+/** Runtime target kind carried by hosted project-agent runs. */
+export type HostedChatRuntimeTargetKind = "main_branch" | "environment" | "preview_branch";
+
 /** Options accepted by hosted chat runtime creation. */
 export type HostedChatRuntimeCreationOptions<TRuntimeAgentDefinition, TThinkingConfig> = {
   projectId: string | null;
   branchId?: string | null;
+  runtimeTargetKind?: HostedChatRuntimeTargetKind | null;
+  runtimeTargetEnvironmentId?: string | null;
   authToken: string;
   instructions: string | ChatSystemMessage[];
   runId?: string;

--- a/src/agent/hosted/child-bootstrap.test.ts
+++ b/src/agent/hosted/child-bootstrap.test.ts
@@ -10,6 +10,7 @@ const CHILD_CONVERSATION_ID = "22222222-2222-4222-a222-222222222222";
 const PARENT_MESSAGE_ID = "33333333-3333-4333-a333-333333333333";
 const CHILD_MESSAGE_ID = "44444444-4444-4444-8444-444444444444";
 const PROJECT_ID = "55555555-5555-4555-8555-555555555555";
+const ENVIRONMENT_ID = "77777777-7777-4777-8777-777777777777";
 const BRANCH_ID = "66666666-6666-4666-8666-666666666666";
 const originalFetch = globalThis.fetch;
 
@@ -167,6 +168,81 @@ describe("agent/hosted-child-bootstrap", () => {
         runtime_target_kind: "preview_branch",
         source_target_branch_id: BRANCH_ID,
         runtime_target_branch_id: BRANCH_ID,
+      },
+    });
+  });
+
+  it("bootstraps child runs with environment source and runtime targets", async () => {
+    const requests: { url: string; body: unknown }[] = [];
+    stubFetchWithRecorder(async (input, init) => {
+      requests.push({
+        url: String(input),
+        body: init?.body ? JSON.parse(String(init.body)) : null,
+      });
+
+      const requestCount = requests.length;
+      if (requestCount === 1) {
+        return jsonResponse({ id: PARENT_CONVERSATION_ID, project_id: PROJECT_ID }, 200);
+      }
+      if (requestCount === 2) {
+        return jsonResponse({ id: CHILD_CONVERSATION_ID, project_id: PROJECT_ID }, 200);
+      }
+      if (requestCount === 3) {
+        return jsonResponse({ id: CHILD_MESSAGE_ID }, 200);
+      }
+      if (requestCount === 4) {
+        return acceptedRunResponse({ run_id: "run_child_env_1" });
+      }
+      if (requestCount === 5) {
+        return jsonResponse(
+          {
+            run_id: "run_child_env_1",
+            conversation_id: CHILD_CONVERSATION_ID,
+            message_id: CHILD_MESSAGE_ID,
+            latest_event_id: 7,
+            latest_external_event_sequence: 3,
+            status: "running",
+          },
+          200,
+        );
+      }
+
+      throw new Error("Unexpected fetch call");
+    });
+
+    await bootstrapHostedChildRun({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      ensureProjectId: PROJECT_ID,
+      runProjectId: PROJECT_ID,
+      parentConversationId: PARENT_CONVERSATION_ID,
+      parentRunId: "parent-run-1",
+      parentMessageId: PARENT_MESSAGE_ID,
+      spawnedFromToolCallId: "tool-call-1",
+      description: "Inspect logs",
+      prompt: "Find the latest logs.",
+      runId: "run_child_env_1",
+      agentId: "invoke-agent-child",
+      runtimeTargetKind: "environment",
+      runtimeTargetEnvironmentId: ENVIRONMENT_ID,
+    });
+
+    assertEquals(requests[3]?.body, {
+      kind: "agent",
+      owner: {
+        kind: "conversation",
+        id: CHILD_CONVERSATION_ID,
+      },
+      public_id: "run_child_env_1",
+      parent_run_id: "parent-run-1",
+      request: {
+        mode: "agent",
+        agent_id: "invoke-agent-child",
+        initial_status: "running",
+        source_target_kind: "environment",
+        runtime_target_kind: "environment",
+        source_target_environment_id: ENVIRONMENT_ID,
+        runtime_target_environment_id: ENVIRONMENT_ID,
       },
     });
   });

--- a/src/agent/hosted/child-bootstrap.ts
+++ b/src/agent/hosted/child-bootstrap.ts
@@ -21,6 +21,8 @@ export interface BootstrapHostedChildRunInput extends HostedChildConversationBod
   runId?: string;
   agentId: string;
   implementationKind?: string | null;
+  runtimeTargetKind?: "main_branch" | "environment" | "preview_branch" | null;
+  runtimeTargetEnvironmentId?: string | null;
   branchId?: string | null;
 }
 
@@ -67,6 +69,8 @@ export async function bootstrapHostedChildRun(
     agentId: input.agentId,
     implementationKind: input.implementationKind,
     projectId: input.runProjectId ?? null,
+    runtimeTargetKind: input.runtimeTargetKind,
+    runtimeTargetEnvironmentId: input.runtimeTargetEnvironmentId,
     branchId: input.branchId,
   });
 

--- a/src/agent/hosted/default-chat-runtime.ts
+++ b/src/agent/hosted/default-chat-runtime.ts
@@ -75,6 +75,8 @@ export type DefaultHostedChatRuntimeTaskContext = HostedRuntimeStateResolverCont
   agentId?: string;
   projectId: string;
   branchId: string | null;
+  runtimeTargetKind?: DefaultHostedChatRuntimeCreationOptions["runtimeTargetKind"];
+  runtimeTargetEnvironmentId?: string | null;
   model: string | undefined;
   clientProfile?: DefaultHostedChatRuntimeCreationOptions["clientProfile"];
   conversationId?: string;
@@ -148,6 +150,8 @@ function createDefaultTaskContext(
     agentId: input.options.agentId,
     projectId: input.options.projectId ?? "",
     branchId: input.options.branchId ?? null,
+    runtimeTargetKind: input.options.runtimeTargetKind ?? null,
+    runtimeTargetEnvironmentId: input.options.runtimeTargetEnvironmentId ?? null,
     model: input.modelId,
     clientProfile: input.options.clientProfile,
     conversationId: input.options.conversationId,

--- a/src/agent/hosted/default-invoke-agent-tool.ts
+++ b/src/agent/hosted/default-invoke-agent-tool.ts
@@ -491,6 +491,8 @@ export async function executeDefaultHostedInvokeAgentTool<
       parentRunId: options.context.parentRunId,
       parentMessageId: options.context.parentMessageId,
       getProjectId: () => options.context.projectId,
+      getRuntimeTargetKind: () => options.context.runtimeTargetKind,
+      getRuntimeTargetEnvironmentId: () => options.context.runtimeTargetEnvironmentId,
       getBranchId: () => options.context.branchId,
       getContextModel: () => options.context.model,
       defaultModel: options.defaultModel ?? DEFAULT_USER_AGENT_MODEL,

--- a/src/agent/hosted/durable-child-fork-execution.test.ts
+++ b/src/agent/hosted/durable-child-fork-execution.test.ts
@@ -26,6 +26,7 @@ const CHILD_CONVERSATION_ID = "22222222-2222-4222-a222-222222222222";
 const PARENT_MESSAGE_ID = "33333333-3333-4333-a333-333333333333";
 const CHILD_MESSAGE_ID = "44444444-4444-4444-8444-444444444444";
 const PROJECT_ID = "55555555-5555-4555-8555-555555555555";
+const ENVIRONMENT_ID = "77777777-7777-4777-8777-777777777777";
 const BRANCH_ID = "66666666-6666-4666-8666-666666666666";
 const originalFetch = globalThis.fetch;
 
@@ -468,6 +469,7 @@ describe("agent/hosted-durable-child-fork-execution", () => {
       "child.message.id": CHILD_MESSAGE_ID,
       "source.target.kind": "preview_branch",
       "runtime.target.kind": "preview_branch",
+      "target.branch.id": BRANCH_ID,
       "agent.run.final_status": "failed",
       "tool.name": "invoke_agent",
       "tool.call.id": "tool-call-1",
@@ -503,6 +505,7 @@ describe("agent/hosted-durable-child-fork-execution", () => {
       "child.message.id": CHILD_MESSAGE_ID,
       "source.target.kind": "preview_branch",
       "runtime.target.kind": "preview_branch",
+      "target.branch.id": BRANCH_ID,
       "agent.run.final_status": "completed",
       "tool.name": "invoke_agent",
       "tool.call.id": "tool-call-1",
@@ -677,7 +680,7 @@ describe("agent/hosted-durable-child-fork-execution", () => {
     assertEquals(result, { status: "missing_context", message: "missing context" });
   });
 
-  it("bootstraps, runs lifecycle progress, and returns host-shaped success", async () => {
+  it("bootstraps environment-targeted child runs and returns host-shaped success", async () => {
     let projectId = PROJECT_ID;
     const lifecycleStatuses: string[] = [];
     const bootstrapCalls: string[] = [];
@@ -743,7 +746,9 @@ describe("agent/hosted-durable-child-fork-execution", () => {
         parentRunId: "run_parent_1",
         parentMessageId: PARENT_MESSAGE_ID,
         getProjectId: () => projectId,
-        getBranchId: () => BRANCH_ID,
+        getRuntimeTargetKind: () => "environment",
+        getRuntimeTargetEnvironmentId: () => ENVIRONMENT_ID,
+        getBranchId: () => null,
         getContextModel: () => "sonnet",
         defaultModel: "opus",
         resolveModelId: (model) => `resolved-${model}`,
@@ -797,9 +802,10 @@ describe("agent/hosted-durable-child-fork-execution", () => {
       latestExternalEventSequence: 3,
     });
     assertEquals(result.success.targets, {
-      sourceTargetKind: "preview_branch",
-      runtimeTargetKind: "preview_branch",
-      targetBranchId: BRANCH_ID,
+      sourceTargetKind: "environment",
+      runtimeTargetKind: "environment",
+      targetEnvironmentId: ENVIRONMENT_ID,
+      targetBranchId: null,
     });
     assertEquals(result.success.snapshot.success, true);
     const handoffMessageBody = getRecordedRequest(requests, 2).body;
@@ -826,10 +832,10 @@ describe("agent/hosted-durable-child-fork-execution", () => {
         mode: "agent",
         agent_id: "invoke-agent-child",
         initial_status: "running",
-        source_target_kind: "preview_branch",
-        runtime_target_kind: "preview_branch",
-        source_target_branch_id: BRANCH_ID,
-        runtime_target_branch_id: BRANCH_ID,
+        source_target_kind: "environment",
+        runtime_target_kind: "environment",
+        source_target_environment_id: ENVIRONMENT_ID,
+        runtime_target_environment_id: ENVIRONMENT_ID,
       },
     });
     assertEquals(getRecordedRequest(requests, 5).body, {

--- a/src/agent/hosted/durable-child-fork-execution.ts
+++ b/src/agent/hosted/durable-child-fork-execution.ts
@@ -301,6 +301,8 @@ export function createHostedDurableChildInvokeTraceRecorder(input: {
         childMessageId: failure.childMessageId,
         sourceTargetKind: failure.targets.sourceTargetKind,
         runtimeTargetKind: failure.targets.runtimeTargetKind,
+        targetEnvironmentId: failure.targets.targetEnvironmentId,
+        targetBranchId: failure.targets.targetBranchId,
         status: "failed",
         terminalErrorCode: failure.terminalErrorCode,
         terminalErrorMessage: failure.terminalErrorMessage,
@@ -324,6 +326,8 @@ export function createHostedDurableChildInvokeTraceRecorder(input: {
         childMessageId: failure.identifiers.childMessageId,
         sourceTargetKind: failure.targets.sourceTargetKind,
         runtimeTargetKind: failure.targets.runtimeTargetKind,
+        targetEnvironmentId: failure.targets.targetEnvironmentId,
+        targetBranchId: failure.targets.targetBranchId,
         status: "failed",
         terminalErrorCode: failure.terminalErrorCode,
         terminalErrorMessage: failure.terminalErrorMessage,
@@ -341,6 +345,8 @@ export function createHostedDurableChildInvokeTraceRecorder(input: {
         childMessageId: success.identifiers.childMessageId,
         sourceTargetKind: success.targets.sourceTargetKind,
         runtimeTargetKind: success.targets.runtimeTargetKind,
+        targetEnvironmentId: success.targets.targetEnvironmentId,
+        targetBranchId: success.targets.targetBranchId,
         status: success.snapshot.success ? "completed" : "failed",
         usage: success.snapshot.usage,
         terminalErrorCode: success.snapshot.success ? null : input.executionFailedCode,
@@ -444,6 +450,8 @@ export type ExecuteHostedDurableChildForkInput<
   parentRunId?: string;
   parentMessageId?: string;
   getProjectId: () => string | null | undefined;
+  getRuntimeTargetKind?: () => ConversationRunTargets["runtimeTargetKind"] | undefined;
+  getRuntimeTargetEnvironmentId?: () => string | null | undefined;
   getBranchId?: () => string | null | undefined;
   getContextModel?: () => string | undefined;
   defaultModel: string;
@@ -477,6 +485,18 @@ function getBranchId(input: {
   return input.getBranchId?.();
 }
 
+function getRuntimeTargetKind(input: {
+  getRuntimeTargetKind?: () => ConversationRunTargets["runtimeTargetKind"] | undefined;
+}): ConversationRunTargets["runtimeTargetKind"] | undefined {
+  return input.getRuntimeTargetKind?.();
+}
+
+function getRuntimeTargetEnvironmentId(input: {
+  getRuntimeTargetEnvironmentId?: () => string | null | undefined;
+}): string | null | undefined {
+  return input.getRuntimeTargetEnvironmentId?.();
+}
+
 function resolveContextModel(input: {
   forkInput: HostedChildForkToolInput;
   getContextModel?: () => string | undefined;
@@ -505,6 +525,8 @@ async function prepareHostedDurableChildBootstrapContext<
 
   const targets = resolveConversationRunTargets({
     projectId: input.getProjectId() ?? null,
+    runtimeTargetKind: getRuntimeTargetKind(input) ?? null,
+    environmentId: getRuntimeTargetEnvironmentId(input) ?? null,
     branchId: getBranchId(input) ?? null,
   });
   const resolvedModel = input.resolveModelId(resolveContextModel(input));
@@ -555,6 +577,8 @@ async function bootstrapHostedDurableChildFork<
         runId: input.executionOptions.toolCallId,
       }),
       agentId: input.childAgentId,
+      runtimeTargetKind: getRuntimeTargetKind(input),
+      runtimeTargetEnvironmentId: getRuntimeTargetEnvironmentId(input),
       branchId: getBranchId(input),
     });
     const identifiers: HostedChildRunIdentifiers = {
@@ -603,6 +627,7 @@ async function executeHostedDurableChildLifecycle<
       description: input.forkInput.description,
       sourceTargetKind: targets.sourceTargetKind,
       runtimeTargetKind: targets.runtimeTargetKind,
+      targetEnvironmentId: targets.targetEnvironmentId,
       targetBranchId: targets.targetBranchId,
     },
     model: bootstrapContext.resolvedModel,

--- a/src/agent/project/context.test.ts
+++ b/src/agent/project/context.test.ts
@@ -21,6 +21,8 @@ Deno.test("applyAgentProjectContextChange updates project and resets branch and 
   assertEquals(context, {
     projectId: "project-2",
     branchId: null,
+    runtimeTargetKind: "main_branch",
+    runtimeTargetEnvironmentId: null,
     availableSkillIds: undefined,
     skillSourcePaths: undefined,
     steeringRevision: 3,

--- a/src/agent/project/context.ts
+++ b/src/agent/project/context.ts
@@ -2,6 +2,8 @@
 export interface MutableAgentProjectContext {
   projectId: string;
   branchId?: string | null;
+  runtimeTargetKind?: "main_branch" | "environment" | "preview_branch" | null;
+  runtimeTargetEnvironmentId?: string | null;
   availableSkillIds?: string[];
   /** Per-run skill id -> discovered SKILL.md source path (owner-aware catalog). */
   skillSourcePaths?: Readonly<Record<string, string>>;
@@ -18,6 +20,8 @@ export function applyAgentProjectContextChange(
 
   context.projectId = projectId;
   context.branchId = null;
+  context.runtimeTargetKind = "main_branch";
+  context.runtimeTargetEnvironmentId = null;
   context.availableSkillIds = undefined;
   context.skillSourcePaths = undefined;
   return true;

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -336,6 +336,10 @@ export const getChatRequestContextSchema = defineSchema((v) =>
     projectId: v.string().nullable(),
     projectSlug: v.string().optional(),
     branchId: v.string().nullable(),
+    runtimeTargetKind: v.enum(["main_branch", "environment", "preview_branch"] as const)
+      .nullable()
+      .optional(),
+    runtimeTargetEnvironmentId: v.string().uuid().nullable().optional(),
     environmentContext: v.string().optional(),
   }).strict()
 );


### PR DESCRIPTION
## Summary
- preserve environment runtime targets when scheduled/durable agent runs delegate to child agent runs
- carry target environment/branch ids into child lifecycle progress and trace attributes
- bump veryfront-code to 0.1.1036 so dedicated runtime rollout can pick up the fix

## Why
Scheduled veryfront-ops-agent task runs were executing on the dedicated runtime, but delegated child agent runs were recreated as main-branch runs. That prevented tool/LLM spans from being emitted by the dedicated runtime with the Datadog service/version tags that the IDP scorecards need.

## Validation
- deno test src/agent/conversation/durable-contracts.test.ts src/agent/conversation/durable.test.ts src/agent/hosted/chat-request.test.ts src/agent/hosted/child-bootstrap.test.ts src/agent/hosted/durable-child-fork-execution.test.ts src/agent/hosted/default-invoke-agent-tool.test.ts
- deno test src/agent/project/context.test.ts
- deno task typecheck
- deno task fmt:check
- deno task lint

## Notes
Full pre-push was retried with host observability env unset; the targeted tests and static checks above passed locally.