### PR TITLE
fix(proxy): de-escalate transient WebSocket client errors

### DIFF
--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -26,6 +26,7 @@ import { isRetryableConnectionError } from "./retry.ts";
 import {
   closeBridgePeer,
   createProxyClientWebSocketUpgradeOptions,
+  getClientWebSocketErrorLogLevel,
   getServerWebSocketErrorLogLevel,
 } from "./websocket-bridge.ts";
 import { register } from "../extensions/contracts.ts";
@@ -299,8 +300,10 @@ function handleWebSocketUpgrade(req: Request, url: URL): Response {
 
   clientSocket.onerror = (event) => {
     clearConnectTimeout();
-    proxyLogger.error("[WebSocket] Client connection error", {
-      error: event instanceof ErrorEvent ? event.message : "Unknown error",
+    const error = event instanceof ErrorEvent ? event.message : "Unknown error";
+    const logLevel = getClientWebSocketErrorLogLevel(error);
+    proxyLogger[logLevel]("[WebSocket] Client connection error", {
+      error,
     });
   };
 

--- a/src/proxy/websocket-bridge.ts
+++ b/src/proxy/websocket-bridge.ts
@@ -11,8 +11,22 @@ const TRANSIENT_SERVER_ERROR_PATTERNS = [
   /socket closed/i,
 ];
 
+const TRANSIENT_CLIENT_ERROR_PATTERNS = [
+  /unexpected eof/i,
+  /no response from ping frame/i,
+  /connection reset/i,
+  /connection closed/i,
+  /socket closed/i,
+];
+
 export function getServerWebSocketErrorLogLevel(message: string): ServerWebSocketErrorLogLevel {
   return TRANSIENT_SERVER_ERROR_PATTERNS.some((pattern) => pattern.test(message))
+    ? "warn"
+    : "error";
+}
+
+export function getClientWebSocketErrorLogLevel(message: string): ServerWebSocketErrorLogLevel {
+  return TRANSIENT_CLIENT_ERROR_PATTERNS.some((pattern) => pattern.test(message))
     ? "warn"
     : "error";
 }

--- a/src/proxy/websocket-proxy.test.ts
+++ b/src/proxy/websocket-proxy.test.ts
@@ -5,6 +5,7 @@ import { parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
 import {
   closeBridgePeer,
   createProxyClientWebSocketUpgradeOptions,
+  getClientWebSocketErrorLogLevel,
   getServerWebSocketErrorLogLevel,
 } from "./websocket-bridge.ts";
 
@@ -154,6 +155,11 @@ describe("Proxy WebSocket Handler Tests", () => {
   describe("Server WebSocket error handling", () => {
     it("treats upstream EOF as a transient warning", () => {
       assertEquals(getServerWebSocketErrorLogLevel("Unexpected EOF"), "warn");
+    });
+
+    it("treats browser-side EOF and ping timeouts as transient warnings", () => {
+      assertEquals(getClientWebSocketErrorLogLevel("Unexpected EOF"), "warn");
+      assertEquals(getClientWebSocketErrorLogLevel("No response from ping frame."), "warn");
     });
 
     it("closes the accepted client socket when the upstream bridge fails", () => {


### PR DESCRIPTION
## Summary

- Classify transient browser-side WebSocket bridge errors as warnings instead of production errors
- Covers `Unexpected EOF` and Deno transport ping-frame timeout messages from veryfront-studio#5545
- Keeps unknown client socket errors at error level

## TDD / Verification

- Red: `deno test --no-check --allow-all src/proxy/websocket-proxy.test.ts` failed before implementation because `getClientWebSocketErrorLogLevel` was missing
- Green: `deno test --no-check --allow-all src/proxy/websocket-proxy.test.ts`
- `deno fmt --check src/proxy/websocket-bridge.ts src/proxy/main.ts src/proxy/websocket-proxy.test.ts`
- `deno lint src/proxy/websocket-bridge.ts src/proxy/main.ts src/proxy/websocket-proxy.test.ts`
- `deno task typecheck`
- `git diff --check`
- pre-push hook: format, lint, typecheck, full unit suite (`2311` passed)

Related: veryfront/veryfront-studio#5545