### PR TITLE
Bump veryfront runtime to 0.1.1037

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1036",
+  "version": "0.1.1037",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1036";
+export const VERSION = "0.1.1037";


### PR DESCRIPTION
## Summary
- bump veryfront-code runtime package version to 0.1.1037
- publish a package version that includes #2839 environment-target propagation for delegated agent runs

## Why
0.1.1036 was released before #2839 merged. The dedicated veryfront-ops-agent runtime needs a new package version so the scheduled child agent runs keep the dedicated environment target and emit Datadog traces/logs from the dedicated runtime.

## Validation
- deno task fmt:check
- deno task typecheck
- full pre-push checks passed: format, lint, typecheck, unit tests (2311 passed)
