### PR TITLE
fix(rendering): prioritize nearby routes during prewarm

### DIFF
--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -433,6 +433,76 @@ describe("Renderer release asset cache isolation", () => {
     assertEquals(store.data.has(`${prefix}:page:about`), false);
   });
 
+  it("prioritizes route-family siblings when prewarming production routes", async () => {
+    const store = createInMemoryStore();
+    const renderedSlugs: string[] = [];
+    const shallowPages = Array.from(
+      { length: 14 },
+      (_, index) => `/page-${index.toString().padStart(2, "0")}`,
+    );
+    const renderer = new Renderer({ cache: { store } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    (renderer as unknown as {
+      getAllPages: () => Promise<string[]>;
+      pageExists: (slug: string) => Promise<boolean>;
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: (slug: string) => Promise<{
+            html: string;
+            frontmatter: Record<string, unknown>;
+            headings: never[];
+            stream: null;
+          }>;
+        };
+      };
+    }).getAllPages = () =>
+      Promise.resolve([
+        "/blog/articles/terraform-azure-kubernetes",
+        ...shallowPages,
+        "/blog/articles/helm-best-practices",
+      ]);
+    (renderer as unknown as {
+      pageExists: (slug: string) => Promise<boolean>;
+    }).pageExists = () => Promise.resolve(true);
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: (slug: string) => Promise<{
+            html: string;
+            frontmatter: Record<string, unknown>;
+            headings: never[];
+            stream: null;
+          }>;
+        };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: (slug) => {
+          renderedSlugs.push(slug);
+          return Promise.resolve({
+            html: `<html>${slug}</html>`,
+            frontmatter: {},
+            headings: [],
+            stream: null,
+          });
+        },
+      },
+    });
+
+    const ctx = {
+      ...makeRenderContext(),
+      adapter: { fs: {} } as RenderContext["adapter"],
+    };
+    await renderer.renderPage("/blog/articles/terraform-azure-kubernetes", ctx, {
+      environment: "production",
+      releaseId: "rel-1",
+      releaseAssetManifest: null,
+    });
+    await waitForProductionPrewarm(renderer);
+
+    assertEquals(renderedSlugs.includes("/blog/articles/helm-best-practices"), true);
+  });
+
   it("does not prewarm when the request has cache-sensitive state", async () => {
     const store = createInMemoryStore();
     const renderedSlugs: string[] = [];

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -174,6 +174,23 @@ function prewarmSlugDepth(slug: string): number {
   return comparable.split("/").filter(Boolean).length;
 }
 
+function prewarmSlugSegments(slug: string): string[] {
+  const comparable = normalizeComparableSlug(slug);
+  if (comparable === "/") return [];
+  return comparable.split("/").filter(Boolean);
+}
+
+function prewarmRouteFamilyRank(currentSlug: string, candidateSlug: string): number {
+  const currentSegments = prewarmSlugSegments(currentSlug);
+  if (currentSegments.length === 0) return 0;
+
+  const candidateSegments = prewarmSlugSegments(candidateSlug);
+  if (candidateSegments[0] !== currentSegments[0]) return 2;
+  if (currentSegments.length < 2) return 0;
+
+  return candidateSegments[1] === currentSegments[1] ? 0 : 1;
+}
+
 function selectPrewarmSlugs(
   currentSlug: string,
   pages: string[],
@@ -193,6 +210,8 @@ function selectPrewarmSlugs(
   }
 
   candidates.sort((a, b) =>
+    prewarmRouteFamilyRank(currentComparable, a.comparable) -
+      prewarmRouteFamilyRank(currentComparable, b.comparable) ||
     prewarmSlugDepth(a.comparable) - prewarmSlugDepth(b.comparable) ||
     a.comparable.localeCompare(b.comparable)
   );


### PR DESCRIPTION
## Summary
- prioritize production render prewarm candidates from the same route family before unrelated shallow routes
- keep the existing prewarm budget, validation, and concurrency behavior unchanged
- add a regression test for `/blog/articles/*` sibling warming when unrelated shallow pages would otherwise consume the default 12-route budget

## Related
- Mitigates veryfront/veryfront-issue-inbox#51 by reducing distinct cold misses for neighboring article routes after the first cacheable render.

## Verification
- Red: `deno test --no-check --allow-all src/rendering/renderer.test.ts` failed before implementation on `prioritizes route-family siblings when prewarming production routes`
- Green: `deno test --no-check --allow-all src/rendering/renderer.test.ts`
- `deno fmt --check src/rendering/renderer.ts src/rendering/renderer.test.ts`
- `deno lint src/rendering/renderer.ts src/rendering/renderer.test.ts`
- `deno task typecheck`
- `git diff --check`
- Pre-push gate passed: full format, lint, typecheck, generated manifests/prebundles, and unit suite: 2311 passed, 0 failed
