### PR TITLE
Fix Datadog deployment tracking tags

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1037",
+  "version": "0.1.1038",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/extensions/ext-observability-opentelemetry/src/index.test.ts
+++ b/extensions/ext-observability-opentelemetry/src/index.test.ts
@@ -12,6 +12,7 @@ import factory, {
   logAttributes,
   resolveOtlpExtensionConfig,
   resolveOtlpSignalUrl,
+  unifiedServiceResourceAttributes,
 } from "./index.ts";
 
 const noopLogger = {
@@ -156,6 +157,25 @@ describe("ext-observability-opentelemetry config helpers", () => {
     assertEquals(config.serviceName, "resource-service");
     assertEquals(config.serviceVersion, "7.8.9");
     assertEquals(config.deploymentEnvironment, "production");
+  });
+
+  it("emits Datadog reserved tag aliases with OTel resource attributes", () => {
+    assertEquals(
+      unifiedServiceResourceAttributes({
+        serviceName: "veryfront-ops-agent",
+        serviceVersion: "20260709144949-fe7bf026a69d",
+        deploymentEnvironment: "production",
+      }),
+      {
+        "service.name": "veryfront-ops-agent",
+        "service.version": "20260709144949-fe7bf026a69d",
+        "deployment.environment": "production",
+        "deployment.environment.name": "production",
+        service: "veryfront-ops-agent",
+        version: "20260709144949-fe7bf026a69d",
+        env: "production",
+      },
+    );
   });
 
   it("does not expose a ctx.config.otel exporter-routing override", () => {

--- a/extensions/ext-observability-opentelemetry/src/index.ts
+++ b/extensions/ext-observability-opentelemetry/src/index.ts
@@ -277,6 +277,22 @@ function resolveDeploymentEnvironment(
     "development";
 }
 
+export function unifiedServiceResourceAttributes(options: {
+  serviceName: string;
+  serviceVersion: string;
+  deploymentEnvironment: string;
+}): Record<string, string> {
+  return {
+    "service.name": options.serviceName,
+    "service.version": options.serviceVersion,
+    "deployment.environment": options.deploymentEnvironment,
+    "deployment.environment.name": options.deploymentEnvironment,
+    service: options.serviceName,
+    version: options.serviceVersion,
+    env: options.deploymentEnvironment,
+  };
+}
+
 function headersOrDefault(
   signalHeaders: Record<string, string> | undefined,
   defaultHeaders: Record<string, string> | undefined,
@@ -647,12 +663,11 @@ class OtlpTracingExporter implements TracingExporter {
     }
 
     const otel = await loadOpenTelemetryRuntime();
-    const resource = otel.resources.resourceFromAttributes({
-      [otel.semanticConventions.ATTR_SERVICE_NAME]: cfg.serviceName,
-      [otel.semanticConventions.ATTR_SERVICE_VERSION]: cfg.serviceVersion,
-      "deployment.environment": cfg.deploymentEnvironment,
-      "deployment.environment.name": cfg.deploymentEnvironment,
-    });
+    const resource = otel.resources.resourceFromAttributes(unifiedServiceResourceAttributes({
+      serviceName: cfg.serviceName,
+      serviceVersion: cfg.serviceVersion,
+      deploymentEnvironment: cfg.deploymentEnvironment,
+    }));
 
     if (cfg.tracesEnabled || cfg.llmObservabilityEnabled) {
       if (cfg.tracesEnabled && !cfg.tracesUrl) {
@@ -795,6 +810,11 @@ class OtlpTracingExporter implements TracingExporter {
         body: "OpenTelemetry log export initialized",
         attributes: {
           "service.name": cfg.serviceName,
+          "service.version": cfg.serviceVersion,
+          "deployment.environment.name": cfg.deploymentEnvironment,
+          service: cfg.serviceName,
+          version: cfg.serviceVersion,
+          env: cfg.deploymentEnvironment,
         },
       });
     }
@@ -869,12 +889,11 @@ class OpenTelemetryNodeTelemetryProvider implements NodeTelemetryProvider {
     if (!tracesEnabled && !llmObservabilityEnabled && !metricsEnabled && !logsEnabled) return false;
 
     const otel = await loadOpenTelemetryRuntime();
-    const resource = otel.resources.resourceFromAttributes({
-      "service.name": options.serviceName,
-      "service.version": options.serviceVersion,
-      "deployment.environment": options.deploymentEnvironment,
-      "deployment.environment.name": options.deploymentEnvironment,
-    });
+    const resource = otel.resources.resourceFromAttributes(unifiedServiceResourceAttributes({
+      serviceName: options.serviceName,
+      serviceVersion: options.serviceVersion,
+      deploymentEnvironment: options.deploymentEnvironment,
+    }));
 
     const spanProcessors = [];
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1037";
+export const VERSION = "0.1.1038";


### PR DESCRIPTION
## Summary
- add Datadog reserved resource tag aliases (env, service, version) alongside OTel semantic resource attributes
- include the same aliases on the OTLP log-export initialization record
- bump veryfront runtime to 0.1.1038 for release rollout

## Why
Datadog IDP default scorecards evaluate deployment tracking from APM/USM version tags. The runtime already sends OTel service.version/deployment.environment.name, but Datadog's failing scorecard is looking for the reserved version tag, so this emits both forms from one source of truth.

## Verification
- deno test --allow-all extensions/ext-observability-opentelemetry/src/index.test.ts src/agent/service/node-telemetry.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts extensions/ext-observability-opentelemetry/src/index.ts extensions/ext-observability-opentelemetry/src/index.test.ts
- deno lint extensions/ext-observability-opentelemetry/src/index.ts extensions/ext-observability-opentelemetry/src/index.test.ts src/utils/version-constant.ts
- pre-push hook: format, lint, typecheck, test:unit (2311 passed)