### PR TITLE
Add slow request profile details to completion logs

### DIFF
--- a/src/observability/request-profiler.test.ts
+++ b/src/observability/request-profiler.test.ts
@@ -13,7 +13,11 @@ import {
   withServerTimingHeader,
 } from "./request-profiler.ts";
 
-const ENV_KEYS = ["VERYFRONT_ENABLE_PERF_PROFILING", "VERYFRONT_ENABLE_SERVER_TIMING"] as const;
+const ENV_KEYS = [
+  "VERYFRONT_ENABLE_PERF_PROFILING",
+  "VERYFRONT_ENABLE_SERVER_TIMING",
+  "VERYFRONT_DISABLE_SLOW_REQUEST_PROFILING",
+] as const;
 
 function clearProfilerEnv(): void {
   for (const key of ENV_KEYS) Deno.env.delete(key);
@@ -25,7 +29,14 @@ describe("request profiler", () => {
     resetRequestProfiles();
   });
 
-  it("keeps normal HTML requests unprofiled by default", () => {
+  it("profiles normal HTML requests by default for slow-completion diagnostics", () => {
+    assertEquals(isRequestProfilingEnabled("/"), true);
+    assertEquals(snapshotRequestProfiles().enabled, true);
+  });
+
+  it("can disable default slow-completion profiling", () => {
+    Deno.env.set("VERYFRONT_DISABLE_SLOW_REQUEST_PROFILING", "1");
+
     assertEquals(isRequestProfilingEnabled("/"), false);
     assertEquals(snapshotRequestProfiles().enabled, false);
   });

--- a/src/observability/request-profiler.ts
+++ b/src/observability/request-profiler.ts
@@ -47,6 +47,10 @@ function shouldEnableServerTiming(): boolean {
   return getEnv("VERYFRONT_ENABLE_SERVER_TIMING") === "1";
 }
 
+function shouldEnableSlowRequestProfiling(): boolean {
+  return getEnv("VERYFRONT_DISABLE_SLOW_REQUEST_PROFILING") !== "1";
+}
+
 function isHtmlPath(pathname: string): boolean {
   return !pathname.startsWith("/_") && !pathname.startsWith("/api/") &&
     !/\.[a-zA-Z0-9]+$/.test(pathname);
@@ -62,8 +66,12 @@ function shouldProfilePath(pathname: string): boolean {
 }
 
 export function isRequestProfilingEnabled(pathname?: string): boolean {
-  if (!shouldEnableProfiling() && !shouldEnableServerTiming()) return false;
+  const explicitProfiling = shouldEnableProfiling() || shouldEnableServerTiming();
+  const slowRequestProfiling = shouldEnableSlowRequestProfiling();
+
+  if (!explicitProfiling && !slowRequestProfiling) return false;
   if (!pathname) return true;
+  if (slowRequestProfiling && isHtmlPath(pathname)) return true;
   return shouldProfilePath(pathname);
 }
 
@@ -201,7 +209,8 @@ export function snapshotRequestProfiles(): {
   records: RequestProfileRecord[];
 } {
   return {
-    enabled: shouldEnableProfiling() || shouldEnableServerTiming(),
+    enabled: shouldEnableProfiling() || shouldEnableServerTiming() ||
+      shouldEnableSlowRequestProfiling(),
     last_sequence: sequence,
     records: [...records],
   };

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -734,7 +734,12 @@ export function createVeryfrontHandler(
         });
 
         const isTimeout = response.status === HTTP_GATEWAY_TIMEOUT;
-        completeRequestTracking(lifecycle.requestId, response.status, isTimeout);
+        completeRequestTracking(
+          lifecycle.requestId,
+          response.status,
+          isTimeout,
+          requestProfileRecord,
+        );
         completeIsolatedRequest(headers.projectSlug, lifecycle.shouldCheckIsolation, isTimeout);
 
         return withServerTimingHeader(response, requestProfileRecord);

--- a/src/server/runtime-handler/request-lifecycle.ts
+++ b/src/server/runtime-handler/request-lifecycle.ts
@@ -21,6 +21,7 @@ import {
 } from "#veryfront/platform/adapters/fs/veryfront/read-operations.ts";
 import { requestTracker } from "./request-tracker.ts";
 import { generateRequestId } from "#veryfront/utils/request-id.ts";
+import type { RequestProfileRecord } from "#veryfront/observability/request-profiler.ts";
 
 interface RequestLifecycleContext {
   /** Request ID for tracking */
@@ -106,8 +107,9 @@ export function completeRequestTracking(
   requestId: string,
   status: number,
   isTimeout: boolean,
+  profile?: RequestProfileRecord | null,
 ): void {
-  requestTracker.complete(requestId, status, isTimeout);
+  requestTracker.complete(requestId, status, isTimeout, profile);
 }
 
 /**

--- a/src/server/runtime-handler/request-tracker.test.ts
+++ b/src/server/runtime-handler/request-tracker.test.ts
@@ -1,6 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  __registerLogRecordEmitter,
+  __resetLogRecordEmitterForTests,
+  type LogEntry,
+} from "#veryfront/utils/logger/logger.ts";
 import { requestTracker } from "./request-tracker.ts";
 
 describe("server/runtime-handler/request-tracker", () => {
@@ -9,6 +14,8 @@ describe("server/runtime-handler/request-tracker", () => {
     for (const tracked of requestTracker.getInFlightRequests()) {
       requestTracker.complete(tracked.requestId, 200);
     }
+    Deno.env.delete("VERYFRONT_SLOW_REQUEST_PROFILE_LOG_THRESHOLD_MS");
+    __resetLogRecordEmitterForTests();
   });
 
   describe("start / complete", () => {
@@ -187,6 +194,45 @@ describe("server/runtime-handler/request-tracker", () => {
       requestTracker.start("reg-req", "proj", "/about", "GET");
       requestTracker.complete("reg-req", 200);
       // Just verify no error
+    });
+
+    it("attaches request profile details to slow completion logs", () => {
+      const entries: LogEntry[] = [];
+      __registerLogRecordEmitter((entry) => entries.push(entry));
+      Deno.env.set("VERYFRONT_SLOW_REQUEST_PROFILE_LOG_THRESHOLD_MS", "0");
+
+      requestTracker.start("profiled-req", "proj", "/", "GET", "production", "rel-1");
+      requestTracker.complete("profiled-req", 200, false, {
+        sequence: 7,
+        category: "html",
+        method: "GET",
+        pathname: "/",
+        projectSlug: "proj",
+        requestMode: "production",
+        status: 200,
+        startedAt: "2026-07-09T18:41:00.000Z",
+        completedAt: "2026-07-09T18:41:02.500Z",
+        totalMs: 2500,
+        phases: {
+          "runtime.resolve_project": 12,
+          "handler.execute": 2400,
+        },
+      });
+
+      const entry = entries.find((candidate) => candidate.message === "GET / 200");
+      const profile = entry?.context?.request_profile as
+        | {
+          sequence: number;
+          category: string;
+          totalMs: number;
+          phases: Record<string, number>;
+        }
+        | undefined;
+
+      assertEquals(profile?.sequence, 7);
+      assertEquals(profile?.category, "html");
+      assertEquals(profile?.totalMs, 2500);
+      assertEquals(profile?.phases["handler.execute"], 2400);
     });
 
     it("handles 404 status completion", () => {

--- a/src/server/runtime-handler/request-tracker.ts
+++ b/src/server/runtime-handler/request-tracker.ts
@@ -8,6 +8,8 @@
 import { serverLogger } from "#veryfront/utils";
 import { unrefTimer } from "#veryfront/compat/process.ts";
 import { isLightweightPath, isWebSocketPath } from "./request-utils.ts";
+import type { RequestProfileRecord } from "#veryfront/observability/request-profiler.ts";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 const logger = serverLogger.component("request-tracker");
 
@@ -37,6 +39,40 @@ const DRAIN_PROGRESS_LOG_INTERVAL_MS = 5_000; // 5 seconds
 
 /** Only log module requests that exceed this duration (to reduce noise) */
 const MODULE_REQUEST_LOG_THRESHOLD_MS = 100;
+
+/** Attach request-profiler details to completion logs at or above this duration. */
+const DEFAULT_SLOW_REQUEST_PROFILE_LOG_THRESHOLD_MS = 2_000;
+
+function getSlowRequestProfileLogThresholdMs(): number {
+  const raw = getEnv("VERYFRONT_SLOW_REQUEST_PROFILE_LOG_THRESHOLD_MS");
+  if (!raw) return DEFAULT_SLOW_REQUEST_PROFILE_LOG_THRESHOLD_MS;
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_SLOW_REQUEST_PROFILE_LOG_THRESHOLD_MS;
+  }
+  return parsed;
+}
+
+function buildRequestProfileLogContext(record: RequestProfileRecord): Record<string, unknown> {
+  const slowestPhases = Object.entries(record.phases)
+    .sort(([, left], [, right]) => right - left)
+    .slice(0, 10)
+    .map(([name, durationMs]) => ({ name, durationMs }));
+
+  return {
+    sequence: record.sequence,
+    category: record.category,
+    method: record.method,
+    pathname: record.pathname,
+    projectSlug: record.projectSlug,
+    requestMode: record.requestMode,
+    status: record.status,
+    totalMs: record.totalMs,
+    phases: record.phases,
+    slowestPhases,
+  };
+}
 
 class RequestTracker {
   private inFlight = new Map<string, TrackedRequest>();
@@ -139,7 +175,12 @@ class RequestTracker {
     });
   }
 
-  complete(requestId: string, statusCode: number, timedOut = false): void {
+  complete(
+    requestId: string,
+    statusCode: number,
+    timedOut = false,
+    profile?: RequestProfileRecord | null,
+  ): void {
     const tracked = this.inFlight.get(requestId);
     if (!tracked) return;
 
@@ -160,7 +201,7 @@ class RequestTracker {
       return;
     }
 
-    logger.info(`${tracked.method} ${tracked.path} ${statusCode}`, {
+    const logContext: Record<string, unknown> = {
       project_slug: tracked.projectSlug,
       request_url: tracked.path,
       durationMs,
@@ -168,7 +209,13 @@ class RequestTracker {
       statusCode,
       env: tracked.env,
       release_id: tracked.releaseId,
-    });
+    };
+
+    if (profile && durationMs >= getSlowRequestProfileLogThresholdMs()) {
+      logContext.request_profile = buildRequestProfileLogContext(profile);
+    }
+
+    logger.info(`${tracked.method} ${tracked.path} ${statusCode}`, logContext);
   }
 
   getInFlightCount(): number {


### PR DESCRIPTION
## Summary

Follow-up for veryfront-studio#5544 after the `0.1.1038` production retest.

The latest retest showed the render semaphore saturation signal was gone, but production `veryfront-proxy` completion logs still had p-tail `GET /` latency for `codersociety`. Those completion logs only include total elapsed milliseconds today, so the remaining production-only latency cannot be isolated to project resolution, adapter/release loading, env var loading, render/cache, or another runtime phase.

This PR adds slow-request phase diagnostics to the existing completed-request log path:

- HTML request profiling is enabled by default for slow-completion diagnostics.
- `VERYFRONT_DISABLE_SLOW_REQUEST_PROFILING=1` opts out of that default.
- Completed request logs attach `context.request_profile` when a profile is present and the completed duration is at least `VERYFRONT_SLOW_REQUEST_PROFILE_LOG_THRESHOLD_MS`, defaulting to `2000`.
- The attached profile includes total profile time, all phase timings, and the 10 slowest phases.

This is intentionally scoped to observability/runtime tracking so the next production retest can identify the remaining #5544 bottleneck from normal proxy/server logs.

## Red / Green

Red:

```text
deno test --no-check --allow-all src/observability/request-profiler.test.ts src/server/runtime-handler/request-tracker.test.ts
```

Failed before implementation because normal HTML profiling was disabled by default and request tracker completion logs ignored the profile object.

Green:

```text
deno test --no-check --allow-all src/observability/request-profiler.test.ts src/server/runtime-handler/request-tracker.test.ts src/server/runtime-handler/request-lifecycle.test.ts
deno fmt --check src/observability/request-profiler.ts src/observability/request-profiler.test.ts src/server/runtime-handler/request-tracker.ts src/server/runtime-handler/request-tracker.test.ts src/server/runtime-handler/request-lifecycle.ts src/server/runtime-handler/index.ts
deno lint src/observability/request-profiler.ts src/observability/request-profiler.test.ts src/server/runtime-handler/request-tracker.ts src/server/runtime-handler/request-tracker.test.ts src/server/runtime-handler/request-lifecycle.ts src/server/runtime-handler/index.ts
deno task typecheck
deno task test:unit
```

Pre-push hook also passed: format, lint, typecheck, and unit suite (`2311 passed, 0 failed`).
