### PR TITLE
Bump veryfront-code to 0.1.1039

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1038",
+  "version": "0.1.1039",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1038";
+export const VERSION = "0.1.1039";


### PR DESCRIPTION
## Summary
- Bump `deno.json` and runtime version constant to `0.1.1039`.
- Unblocks stable release after veryfront-code#2844 merged with slow-request profile diagnostics for veryfront-studio#5544.

## Verification
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts`
- `VERSION=0.1.1039 GITHUB_SHA=$(git rev-parse HEAD) scripts/ci/publish-npm-packages.sh preflight`
- pre-push hook: format, lint, typecheck, unit suite (`2311 passed`)
