### PR TITLE
chore: bump code release to 0.1.1040

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1039",
+  "version": "0.1.1040",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1039";
+export const VERSION = "0.1.1040";


### PR DESCRIPTION
## Summary
Bump veryfront-code release version 0.1.1039 → 0.1.1040 to recover the release train after the 0.1.1039 release job was cancelled mid-publish.

Driver: veryfront-studio#5544 (the v0.1.1039 diagnostic build #2844 needs to reach production so the remaining `GET /` p-tail latency can be phase-profiled).

## Why a new version is required
The 0.1.1039 CI/CD release run (`29044516607`, the #2845 bump merge) was cancelled ~9m in when the unrelated docs merge #2809 landed on main and the `concurrency: cancel-in-progress: true` group killed the in-flight run. The cancellation landed after npm publish but before the rest of the release job, leaving 0.1.1039 half-published:
- npm `veryfront@latest` = 0.1.1039 (published, under the #2845 commit's gitHead)
- git tag `v0.1.1039` = absent (both veryfront-code and veryfront)
- GitHub release `v0.1.1039` = absent (both repos)
- `veryfront-code-released` deploy dispatch to veryfront-server = never fired

This state does not self-heal and cannot be re-published under 0.1.1039: `scripts/ci/publish-npm-packages.sh preflight` fails because `veryfront@0.1.1039` already exists on npm with a gitHead that won't match any later commit ("Bump deno.json before releasing"). The release job now fails on every main push until the version is bumped. Bumping to 0.1.1040 is the clean recovery.

## Scope note
0.1.1040 releases the current tip of main, which includes #2844 (the diagnostic profiling that motivated this) plus everything else merged since 0.1.1039, notably #2809 (chat composition & API overhaul — plan/docs only). 0.1.1039 is left as an orphaned npm version.

## Follow-up (separate PR)
Recurrence-prevention for the cancellation itself: fix/release-concurrency-guard makes `cancel-in-progress` apply only to pull_request runs, so a main push can never cancel an in-flight release publish again.

## Verification
- deno fmt --check deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- VERSION=0.1.1040 GITHUB_SHA=$(git rev-parse HEAD) scripts/ci/publish-npm-packages.sh preflight
- git push pre-push hook: format, lint, typecheck, unit tests (2311 passed)
- PR CI: all required checks green (format, lint, typecheck, unit/integration, coverage shards + gate, rsc/binary e2e, npm install smoke, CodeQL, dependency audit)
