### PR TITLE
fix(cache): sanitize module-server response cache keys (#5559)

### DIFF
--- a/src/modules/server/module-response-cache.test.ts
+++ b/src/modules/server/module-response-cache.test.ts
@@ -3,11 +3,31 @@ import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { CacheBackend } from "#veryfront/cache/types.ts";
 import {
   __setReleaseModuleResponseDistributedCacheForTests,
+  buildReleaseModuleResponseCacheKey,
   clearReleaseModuleResponseCache,
   getReleaseModuleResponse,
   type ReleaseModuleResponseCacheEntry,
   rememberReleaseModuleResponse,
 } from "./module-response-cache.ts";
+
+// Mirrors the distributed cache backend's key validator
+// (veryfront-api `CACHE_KEY_PATTERN`): only alphanumeric, underscore, colon,
+// dot, hyphen, and forward slash are accepted by GET/SET operations.
+const CACHE_KEY_PATTERN = /^[a-zA-Z0-9_:.\-/]+$/;
+
+function baseKeyOptions(modulePath: string) {
+  return {
+    projectIdentity: "94af4820-ce16-44e0-9fc4-cd8688f3cc1d",
+    projectDir: "/srv/releases/tomcode",
+    projectSlug: "tomcode",
+    branch: null,
+    releaseId: "4dcecc2c-dd99-4005-bed7-a9203efa0f37",
+    runtimeVersion: "0.1.1040",
+    reactVersion: "18.3.1",
+    releaseDependencyManifestVersion: 7,
+    modulePath,
+  };
+}
 
 class FakeDistributedCache implements CacheBackend {
   readonly type = "redis" as const;
@@ -56,6 +76,36 @@ describe("release module response cache", () => {
     assertEquals(recovered?.source, "distributed");
     assertEquals(recovered?.entry, entry);
     assertEquals(typeof distributedCache.ttlSeconds.get(cacheKey), "number");
+  });
+
+  it("builds cache keys within the distributed backend's allowed charset", () => {
+    // Request paths that previously produced HTTP 400 "Cache key contains
+    // invalid characters" from api-cache-backend (issue #5559).
+    for (
+      const modulePath of [
+        "@vite/env",
+        "_veryfront/chat/index.js",
+        "@/components/ResponsiveImage",
+        "deps/@scope/pkg@1.2.3.js",
+      ]
+    ) {
+      const key = buildReleaseModuleResponseCacheKey(baseKeyOptions(modulePath));
+      assertEquals(
+        CACHE_KEY_PATTERN.test(key),
+        true,
+        `key must satisfy cache validator for modulePath "${modulePath}": ${key}`,
+      );
+      assertEquals(key.includes("\0"), false, "key must not contain NUL separators");
+      assertEquals(key.includes("@"), false, "key must not contain '@'");
+    }
+  });
+
+  it("produces distinct keys for distinct module paths", () => {
+    const a = buildReleaseModuleResponseCacheKey(baseKeyOptions("@vite/env"));
+    // Differs from "@vite/env" only by a character the readable form clamps to
+    // "-"; the path hash keeps the keys apart.
+    const b = buildReleaseModuleResponseCacheKey(baseKeyOptions("-vite/env"));
+    assertEquals(a === b, false);
   });
 
   it("does not use disk cache backends for release module responses", async () => {

--- a/src/modules/server/module-response-cache.ts
+++ b/src/modules/server/module-response-cache.ts
@@ -79,6 +79,23 @@ async function getDistributedCache(): Promise<CacheBackend | null> {
   return cache.type === "api" || cache.type === "redis" ? cache : null;
 }
 
+/**
+ * The distributed cache backend validates keys against a strict charset
+ * (alphanumeric plus `_ : . - /`) and rejects anything else with HTTP 400.
+ * Request module paths routinely contain characters outside that set — notably
+ * `@` (e.g. `/@vite/env`) — so an unsanitized path makes the composed key
+ * unstorable and the response is silently never cached.
+ *
+ * We prefix a hash of the exact path (collision resistance for two paths that
+ * clamp to the same readable form) with a charset-clamped readable form (kept
+ * for debuggability). `:` is deliberately excluded from the readable form so it
+ * cannot be confused with the key's field separator.
+ */
+function sanitizeModulePathForCacheKey(modulePath: string): string {
+  const readable = modulePath.replace(/[^a-zA-Z0-9_.\-/]/g, "-");
+  return `${hashString(modulePath)}-${readable}`;
+}
+
 export function buildReleaseModuleResponseCacheKey(
   options: ReleaseModuleResponseCacheKeyOptions,
 ): string {
@@ -89,6 +106,8 @@ export function buildReleaseModuleResponseCacheKey(
     options.branch ?? "",
   ].join("\0");
 
+  // Fields are joined with `:` (an allowed key character) rather than a NUL
+  // byte, which the distributed cache backend's key validator also rejects.
   return [
     "module-server-release-response",
     hashString(projectScope),
@@ -98,8 +117,8 @@ export function buildReleaseModuleResponseCacheKey(
     options.releaseDependencyManifestVersion == null
       ? ""
       : `release-dependency-manifest:${options.releaseDependencyManifestVersion}`,
-    options.modulePath,
-  ].join("\0");
+    sanitizeModulePathForCacheKey(options.modulePath),
+  ].join(":");
 }
 
 export async function getReleaseModuleResponse(


### PR DESCRIPTION
## Problem

`buildReleaseModuleResponseCacheKey` (release module-server response cache) built its distributed cache key by joining fields with `\0` (NUL) and appending the **raw** request module path, e.g. `@vite/env` or `_veryfront/chat/index.js`.

The distributed backend (`api-cache-backend`) validates keys against `CACHE_KEY_PATTERN = /^[a-zA-Z0-9_:.\-/]+$/` (veryfront-api `src/api/shared/cache/index.ts`). Both the `\0` separators **and** characters like `@` are outside that set, so every GET/SET returned:

```
HTTP 400 Cache key contains invalid characters. Only alphanumeric, underscore, colon, dot, hyphen, and forward slash are allowed.
```

Effect: the module-server response cache was effectively **non-functional** — nothing could be stored or retrieved from the shared cache, and prod logged this error continuously across projects (observed for `codersociety` and `tomcode`) for paths such as `/@vite/env` and `/_vf_modules/_veryfront/chat/index.js`.

## Fix

In `src/modules/server/module-response-cache.ts`:
- Join key fields with `:` (an allowed character) instead of `\0`.
- Sanitize the module path with a new `sanitizeModulePathForCacheKey`: a hash of the exact path (collision resistance) prefixed to a charset-clamped readable form (debuggability). `:` is excluded from the readable form so it can't be confused with the field separator.

The `projectScope` NUL-join is unchanged and safe — it is fed through `hashString` before entering the key, so those NULs never reach the backend.

## Tests

Added to `module-response-cache.test.ts`:
- Every built key satisfies the backend's `CACHE_KEY_PATTERN` for the previously-failing paths (`@vite/env`, `_veryfront/chat/index.js`, `@/components/ResponsiveImage`, `deps/@scope/pkg@1.2.3.js`), and contains no `\0` or `@`.
- Distinct module paths that clamp to the same readable form still produce distinct keys.

`deno test` (focused), `deno fmt`, `deno lint`, and `deno check` all pass on the changed files.

Note: no `deno.json` version bump included — this repo bumps the release line in dedicated release PRs, not per feature PR.

Refs veryfront/veryfront-issue-inbox#50
