### PR TITLE
ci: don't cancel in-flight push runs on main (protect release publish)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -11,8 +11,15 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || format('{0}-{1}-{2}', github.workflow, github.ref, github.sha) }}
+  # Only cancel superseded pull_request runs. Never cancel push runs on main:
+  # a push run can be publishing a stable release (npm publish, git tag, GitHub
+  # release, downstream deploy dispatch), and cancelling it mid-publish leaves a
+  # partially released version. Push runs also need unique groups because
+  # GitHub keeps at most one pending run per concurrency group; a later main
+  # push can otherwise replace an earlier queued release run even when
+  # cancel-in-progress is false. See veryfront-studio#5544.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # ============================================


### PR DESCRIPTION
## Summary
Stop main `push` runs from cancelling each other in the CI/CD workflow, so a release publish can never be interrupted mid-flight again.

## Problem
The workflow used one concurrency group keyed on ref with `cancel-in-progress: true`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

On `main`, every new push shares the group `CI/CD-refs/heads/main`, so a new push cancels the previous in-flight run. The `release` job on a version-bump push is a stable publish: npm publish → git tag → GitHub release (veryfront + veryfront-code) → `veryfront-code-released` deploy dispatch to veryfront-server/job-runner/sandbox. Cancelling it mid-sequence leaves a partially released version.

This is exactly what happened for v0.1.1039 (see veryfront-studio#5544): the bump run `29044516607` was cancelled by the unrelated docs merge #2809 (run `29045075526`) after npm publish but before the tag/release/dispatch, leaving npm published with no git tag, no GitHub release, and no deploy dispatch. That state does not self-heal and forced a re-cut to 0.1.1040 (#2846).

## Fix
Make cancellation apply only to `pull_request` runs:

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- `pull_request` runs use a distinct ref group (`refs/pull/N/merge`) and keep cancel-in-progress, preserving CI cost savings on rapid PR pushes.
- `push` runs on main never cancel each other, so a release publish always runs to completion.

## Why not a job-level concurrency group for the release job
A job-level `concurrency` does not shield a job from a workflow-level `cancel-in-progress`: the whole run is cancelled at the run level regardless of any job-level grouping. The cancellation therefore has to be disabled at the workflow level for push events.

## Note (pre-existing, out of scope)
The `release` job already fails preflight on non-bump main pushes (`veryfront@<version>` already published under the bump commit's gitHead), so non-bump main runs are red on the release job today. This PR does not change that; it only stops pushes from cancelling in-flight runs. A follow-up could gate `release`/`prerelease` to run only when `deno.json` carries a not-yet-published version, to keep main green.

Refs: veryfront-studio#5544, #2846
