### PR TITLE
Align Datadog LLM app with service identity

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1040",
+  "version": "0.1.1041",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/extensions/ext-observability-opentelemetry/src/index.test.ts
+++ b/extensions/ext-observability-opentelemetry/src/index.test.ts
@@ -147,6 +147,39 @@ describe("ext-observability-opentelemetry config helpers", () => {
     });
   });
 
+  it("defaults the Datadog LLM app to the resolved service name", () => {
+    const config = resolveOtlpExtensionConfig(env({
+      OTEL_RESOURCE_ATTRIBUTES: "service.name=investment-ops-agent",
+      OTEL_TRACES_ENABLED: "true",
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "https://otlp.datadoghq.eu/v1/traces",
+      OTEL_EXPORTER_OTLP_TRACES_HEADERS: "dd-api-key=redacted",
+      DD_LLMOBS_ENABLED: "true",
+    }));
+
+    assertEquals(config.serviceName, "investment-ops-agent");
+    assertEquals(config.llmObservabilityHeaders, {
+      "dd-api-key": "redacted",
+      "dd-otlp-source": "llmobs",
+      "dd-ml-app": "investment-ops-agent",
+    });
+  });
+
+  it("preserves a Datadog LLM app supplied through OTLP headers", () => {
+    const config = resolveOtlpExtensionConfig(env({
+      OTEL_RESOURCE_ATTRIBUTES: "service.name=investment-ops-agent",
+      OTEL_TRACES_ENABLED: "true",
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "https://otlp.datadoghq.eu/v1/traces",
+      OTEL_EXPORTER_OTLP_TRACES_HEADERS: "dd-api-key=redacted,dd-ml-app=header-app",
+      DD_LLMOBS_ENABLED: "true",
+    }));
+
+    assertEquals(config.llmObservabilityHeaders, {
+      "dd-api-key": "redacted",
+      "dd-otlp-source": "llmobs",
+      "dd-ml-app": "header-app",
+    });
+  });
+
   it("resolves Datadog unified service tags from OTel resource attributes", () => {
     const config = resolveOtlpExtensionConfig(env({
       OTEL_RESOURCE_ATTRIBUTES:

--- a/extensions/ext-observability-opentelemetry/src/index.ts
+++ b/extensions/ext-observability-opentelemetry/src/index.ts
@@ -330,6 +330,7 @@ function resolveLlmObservabilityEnabled(
 function resolveLlmObservabilityHeaders(
   read: EnvReader,
   tracesHeaders: Record<string, string>,
+  mlAppFallback: string | undefined,
 ): Record<string, string> {
   const headers = { ...tracesHeaders };
   const datadogApiKey = getHeaderValue(headers, "dd-api-key") ??
@@ -340,7 +341,9 @@ function resolveLlmObservabilityHeaders(
   }
   setHeaderValue(headers, "dd-otlp-source", "llmobs");
 
-  const mlApp = read("DD_LLMOBS_ML_APP");
+  const mlApp = read("DD_LLMOBS_ML_APP")?.trim() ||
+    getHeaderValue(headers, "dd-ml-app")?.trim() ||
+    mlAppFallback?.trim();
   if (mlApp) {
     setHeaderValue(headers, "dd-ml-app", mlApp);
   }
@@ -567,12 +570,15 @@ export function resolveOtlpExtensionConfig(
     headers,
     parseHeaders(read("OTEL_EXPORTER_OTLP_LOGS_HEADERS")),
   );
-  const llmObservabilityHeaders = resolveLlmObservabilityHeaders(read, tracesHeaders);
+  const serviceName = resolveServiceName(read, resourceAttributes);
+  const serviceVersion = resolveServiceVersion(read, resourceAttributes);
+  const deploymentEnvironment = resolveDeploymentEnvironment(read, resourceAttributes);
+  const llmObservabilityHeaders = resolveLlmObservabilityHeaders(read, tracesHeaders, serviceName);
 
   return {
-    serviceName: resolveServiceName(read, resourceAttributes),
-    serviceVersion: resolveServiceVersion(read, resourceAttributes),
-    deploymentEnvironment: resolveDeploymentEnvironment(read, resourceAttributes),
+    serviceName,
+    serviceVersion,
+    deploymentEnvironment,
     headers,
     tracesHeaders,
     metricsHeaders,

--- a/src/agent/service/node-telemetry.test.ts
+++ b/src/agent/service/node-telemetry.test.ts
@@ -190,6 +190,7 @@ describe("agent/node-agent-service-telemetry", () => {
     assertEquals(config.llmObservabilityHeaders, {
       "dd-api-key": "global",
       "dd-otlp-source": "llmobs",
+      "dd-ml-app": "agent-service",
     });
     assertEquals(config.metricsHeaders, { "dd-api-key": "metrics" });
     assertEquals(config.logsHeaders, { "dd-api-key": "global" });
@@ -214,6 +215,45 @@ describe("agent/node-agent-service-telemetry", () => {
       "dd-api-key": "redacted",
       "dd-otlp-source": "llmobs",
       "dd-ml-app": "veryfront-ops-agent",
+    });
+  });
+
+  it("defaults the Datadog LLM app to the resolved service name", () => {
+    const config = resolveNodeHostedAgentServiceTelemetryConfig({
+      env: {
+        DD_SERVICE: "investment-ops-agent",
+        OTEL_TRACES_ENABLED: "true",
+        OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "https://otlp.datadoghq.eu/v1/traces",
+        OTEL_EXPORTER_OTLP_TRACES_HEADERS: "dd-api-key=redacted",
+        DD_LLMOBS_ENABLED: "true",
+      },
+      defaultServiceName: "veryfront-ops-agent",
+    });
+
+    assertEquals(config.serviceName, "investment-ops-agent");
+    assertEquals(config.llmObservabilityHeaders, {
+      "dd-api-key": "redacted",
+      "dd-otlp-source": "llmobs",
+      "dd-ml-app": "investment-ops-agent",
+    });
+  });
+
+  it("preserves a Datadog LLM app supplied through OTLP headers", () => {
+    const config = resolveNodeHostedAgentServiceTelemetryConfig({
+      env: {
+        DD_SERVICE: "investment-ops-agent",
+        OTEL_TRACES_ENABLED: "true",
+        OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "https://otlp.datadoghq.eu/v1/traces",
+        OTEL_EXPORTER_OTLP_TRACES_HEADERS: "dd-api-key=redacted,dd-ml-app=header-app",
+        DD_LLMOBS_ENABLED: "true",
+      },
+      defaultServiceName: "veryfront-ops-agent",
+    });
+
+    assertEquals(config.llmObservabilityHeaders, {
+      "dd-api-key": "redacted",
+      "dd-otlp-source": "llmobs",
+      "dd-ml-app": "header-app",
     });
   });
 

--- a/src/agent/service/node-telemetry.ts
+++ b/src/agent/service/node-telemetry.ts
@@ -257,6 +257,7 @@ function resolveLlmObservabilityEnabled(
 function resolveLlmObservabilityHeaders(
   env: NodeHostedAgentServiceTelemetryEnv,
   tracesHeaders: Record<string, string> | undefined,
+  mlAppFallback: string | undefined,
 ): Record<string, string> | undefined {
   const datadogApiKey = getHeaderValue(tracesHeaders, "dd-api-key") ??
     env.DD_API_KEY ??
@@ -267,7 +268,9 @@ function resolveLlmObservabilityHeaders(
   setHeaderValue(headers, "dd-api-key", datadogApiKey);
   setHeaderValue(headers, "dd-otlp-source", "llmobs");
 
-  const mlApp = env.DD_LLMOBS_ML_APP;
+  const mlApp = env.DD_LLMOBS_ML_APP?.trim() ||
+    getHeaderValue(headers, "dd-ml-app")?.trim() ||
+    mlAppFallback?.trim();
   if (mlApp) {
     setHeaderValue(headers, "dd-ml-app", mlApp);
   }
@@ -322,14 +325,21 @@ export function resolveNodeHostedAgentServiceTelemetryConfig(
   const baseEndpoint = options.env.OTEL_EXPORTER_OTLP_ENDPOINT;
   const exporterHeaders = parseExporterHeaders(options.env.OTEL_EXPORTER_OTLP_HEADERS);
   const tracesHeaders = resolveSignalHeaders(options.env, "TRACES");
-  const llmObservabilityHeaders = resolveLlmObservabilityHeaders(options.env, tracesHeaders);
+  const serviceName = resolveServiceName(options.env, options.defaultServiceName);
+  const serviceVersion = resolveServiceVersion(options.env, options.defaultServiceVersion);
+  const deploymentEnvironment = resolveDeploymentEnvironment(options.env);
+  const llmObservabilityHeaders = resolveLlmObservabilityHeaders(
+    options.env,
+    tracesHeaders,
+    serviceName,
+  );
   const llmObservabilityEnabled = resolveLlmObservabilityEnabled(options.env, tracesHeaders);
 
   return {
     enabled: tracesEnabled || llmObservabilityEnabled || metricsEnabled || logsEnabled,
-    serviceName: resolveServiceName(options.env, options.defaultServiceName),
-    serviceVersion: resolveServiceVersion(options.env, options.defaultServiceVersion),
-    deploymentEnvironment: resolveDeploymentEnvironment(options.env),
+    serviceName,
+    serviceVersion,
+    deploymentEnvironment,
     samplingRatio: resolveSamplingRatio(options.env),
     exporterHeaders,
     tracesEnabled,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1040";
+export const VERSION = "0.1.1041";


### PR DESCRIPTION
## Summary
- default Datadog LLM Observability `dd-ml-app` to the resolved service name when `DD_LLMOBS_ML_APP` is not explicitly set
- apply the same fallback in hosted runtime telemetry and the OpenTelemetry extension resolver
- keep explicit customer-provided `DD_LLMOBS_ML_APP` behavior unchanged

Release note: the package version bump is already tracked in #2846 (`0.1.1040`). This PR should merge before #2846 so the release includes the attribution fix.

## Verification
- `deno fmt --check src/agent/service/node-telemetry.ts src/agent/service/node-telemetry.test.ts extensions/ext-observability-opentelemetry/src/index.ts extensions/ext-observability-opentelemetry/src/index.test.ts`
- `deno test -A src/agent/service/node-telemetry.test.ts extensions/ext-observability-opentelemetry/src/index.test.ts`
- pre-push hook passed: formatting, lint, typecheck, and unit tests (`2311 passed`)
