### PR TITLE
Fix LLMObs project service identity

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1041",
+  "version": "0.1.1042",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/extensions/ext-observability-opentelemetry/src/index.test.ts
+++ b/extensions/ext-observability-opentelemetry/src/index.test.ts
@@ -12,6 +12,7 @@ import factory, {
   logAttributes,
   resolveOtlpExtensionConfig,
   resolveOtlpSignalUrl,
+  rewriteLlmObservabilitySpanResource,
   unifiedServiceResourceAttributes,
 } from "./index.ts";
 
@@ -220,6 +221,89 @@ describe("ext-observability-opentelemetry config helpers", () => {
 
     assertEquals(config.serviceName, "veryfront-server");
     assertEquals(config.tracesUrl, "https://platform-collector.example/otlp/v1/traces");
+  });
+});
+
+describe("ext-observability-opentelemetry LLMObs resource rewriting", () => {
+  it("rewrites GenAI span resource tags from span service attributes", () => {
+    const span = {
+      attributes: {
+        "gen_ai.operation.name": "chat",
+        "service.name": "veryfront-ops-agent",
+        "service.version": "0.0.34",
+        "deployment.environment.name": "production",
+      },
+      resource: {
+        attributes: {
+          "service.name": "investment-ops-agent",
+          "service.version": "0.0.13",
+          "deployment.environment.name": "production",
+          service: "investment-ops-agent",
+          version: "0.0.13",
+          env: "production",
+        },
+      },
+      instrumentationScope: {
+        name: "investment-ops-agent",
+        version: "0.1.1042",
+      },
+    };
+
+    const rewritten = rewriteLlmObservabilitySpanResource(span) as typeof span;
+
+    assertEquals(Object.is(rewritten, span), false);
+    assertEquals(rewritten.resource.attributes["service.name"], "veryfront-ops-agent");
+    assertEquals(rewritten.resource.attributes.service, "veryfront-ops-agent");
+    assertEquals(rewritten.resource.attributes["service.version"], "0.0.34");
+    assertEquals(rewritten.resource.attributes.version, "0.0.34");
+    assertEquals(rewritten.resource.attributes["deployment.environment.name"], "production");
+    assertEquals(rewritten.resource.attributes.env, "production");
+    assertEquals(rewritten.instrumentationScope.name, "veryfront-ops-agent");
+    assertEquals(span.resource.attributes["service.name"], "investment-ops-agent");
+    assertEquals(span.instrumentationScope.name, "investment-ops-agent");
+  });
+
+  it("uses a trace fallback identity for GenAI child spans without service attributes", () => {
+    const span = {
+      attributes: {
+        "gen_ai.operation.name": "execute_tool",
+      },
+      resource: {
+        attributes: {
+          "service.name": "investment-ops-agent",
+          "service.version": "0.0.13",
+          "deployment.environment.name": "production",
+        },
+      },
+      instrumentationScope: {
+        name: "investment-ops-agent",
+      },
+    };
+
+    const rewritten = rewriteLlmObservabilitySpanResource(span, {
+      serviceName: "veryfront-ops-agent",
+      serviceVersion: "0.0.34",
+      deploymentEnvironment: "production",
+    }) as typeof span;
+
+    assertEquals(rewritten.resource.attributes["service.name"], "veryfront-ops-agent");
+    assertEquals(rewritten.resource.attributes["service.version"], "0.0.34");
+    assertEquals(rewritten.instrumentationScope.name, "veryfront-ops-agent");
+  });
+
+  it("keeps spans unchanged when no project service identity is available", () => {
+    const span = {
+      attributes: {
+        "gen_ai.operation.name": "chat",
+      },
+      resource: {
+        attributes: {
+          "service.name": "veryfront-server",
+        },
+      },
+    };
+
+    assertEquals(Object.is(rewriteLlmObservabilitySpanResource(span), span), true);
   });
 });
 

--- a/extensions/ext-observability-opentelemetry/src/index.ts
+++ b/extensions/ext-observability-opentelemetry/src/index.ts
@@ -612,11 +612,156 @@ type SpanExporterLike = {
 
 type ReadableSpanLike = {
   attributes?: Record<string, unknown>;
+  resource?: {
+    attributes?: Record<string, unknown>;
+  };
+  instrumentationScope?: {
+    name?: string;
+    version?: string;
+    schemaUrl?: string;
+  };
+  spanContext?: (() => { traceId?: string }) | { traceId?: string };
 };
 
 function isGenAiSpan(span: unknown): boolean {
   const attributes = (span as ReadableSpanLike).attributes;
   return typeof attributes?.["gen_ai.operation.name"] === "string";
+}
+
+type LlmObservabilityServiceIdentity = {
+  serviceName: string;
+  serviceVersion: string;
+  deploymentEnvironment: string;
+};
+
+function getStringAttribute(
+  attributes: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = attributes?.[key];
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function getSpanTraceId(span: unknown): string | undefined {
+  const context = (span as ReadableSpanLike).spanContext;
+  const spanContext = typeof context === "function" ? context.call(span) : context;
+  return typeof spanContext?.traceId === "string" ? spanContext.traceId : undefined;
+}
+
+function resolveLlmObservabilityServiceIdentity(
+  span: unknown,
+  fallback?: LlmObservabilityServiceIdentity,
+): LlmObservabilityServiceIdentity | null {
+  const readableSpan = span as ReadableSpanLike;
+  const spanAttributes = readableSpan.attributes;
+  const resourceAttributes = readableSpan.resource?.attributes;
+  const serviceName = getStringAttribute(spanAttributes, "service.name") ??
+    getStringAttribute(spanAttributes, "service") ??
+    fallback?.serviceName;
+  if (!serviceName) return null;
+
+  const serviceVersion = getStringAttribute(spanAttributes, "service.version") ??
+    getStringAttribute(spanAttributes, "version") ??
+    fallback?.serviceVersion ??
+    getStringAttribute(resourceAttributes, "service.version") ??
+    getStringAttribute(resourceAttributes, "version") ??
+    VERSION;
+  const deploymentEnvironment = getStringAttribute(spanAttributes, "deployment.environment.name") ??
+    getStringAttribute(spanAttributes, "deployment.environment") ??
+    getStringAttribute(spanAttributes, "env") ??
+    fallback?.deploymentEnvironment ??
+    getStringAttribute(resourceAttributes, "deployment.environment.name") ??
+    getStringAttribute(resourceAttributes, "deployment.environment") ??
+    getStringAttribute(resourceAttributes, "env") ??
+    "development";
+
+  return { serviceName, serviceVersion, deploymentEnvironment };
+}
+
+function cloneResourceWithAttributes(
+  resource: ReadableSpanLike["resource"],
+  attributes: Record<string, string>,
+): ReadableSpanLike["resource"] {
+  if (!resource) return { attributes };
+  const clone = Object.create(Object.getPrototypeOf(resource)) as ReadableSpanLike["resource"];
+  Object.defineProperties(clone, Object.getOwnPropertyDescriptors(resource));
+  Object.defineProperty(clone, "attributes", {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: {
+      ...(resource.attributes ?? {}),
+      ...attributes,
+    },
+  });
+  return clone;
+}
+
+function cloneInstrumentationScopeWithName(
+  instrumentationScope: ReadableSpanLike["instrumentationScope"],
+  name: string,
+): ReadableSpanLike["instrumentationScope"] {
+  return {
+    ...(instrumentationScope ?? {}),
+    name,
+  };
+}
+
+function cloneReadableSpanWithResource(
+  span: unknown,
+  resource: ReadableSpanLike["resource"],
+  instrumentationScope: ReadableSpanLike["instrumentationScope"],
+): unknown {
+  const clone = Object.create(Object.getPrototypeOf(span));
+  Object.defineProperties(clone, Object.getOwnPropertyDescriptors(span));
+  Object.defineProperty(clone, "resource", {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: resource,
+  });
+  Object.defineProperty(clone, "instrumentationScope", {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: instrumentationScope,
+  });
+  return clone;
+}
+
+export function rewriteLlmObservabilitySpanResource(
+  span: unknown,
+  fallback?: LlmObservabilityServiceIdentity,
+): unknown {
+  const identity = resolveLlmObservabilityServiceIdentity(span, fallback);
+  if (!identity) return span;
+
+  const readableSpan = span as ReadableSpanLike;
+  const resource = cloneResourceWithAttributes(
+    readableSpan.resource,
+    unifiedServiceResourceAttributes(identity),
+  );
+  const instrumentationScope = cloneInstrumentationScopeWithName(
+    readableSpan.instrumentationScope,
+    identity.serviceName,
+  );
+  return cloneReadableSpanWithResource(span, resource, instrumentationScope);
+}
+
+function rewriteLlmObservabilitySpanResources(spans: unknown[]): unknown[] {
+  const identitiesByTraceId = new Map<string, LlmObservabilityServiceIdentity>();
+  for (const span of spans) {
+    const traceId = getSpanTraceId(span);
+    if (!traceId) continue;
+    const identity = resolveLlmObservabilityServiceIdentity(span);
+    if (identity) identitiesByTraceId.set(traceId, identity);
+  }
+
+  return spans.map((span) =>
+    rewriteLlmObservabilitySpanResource(span, identitiesByTraceId.get(getSpanTraceId(span) ?? ""))
+  );
 }
 
 class FilteringSpanExporter {
@@ -630,7 +775,7 @@ class FilteringSpanExporter {
     spans: unknown[],
     resultCallback: (result: { code: number; error?: Error }) => void,
   ): void {
-    const includedSpans = spans.filter(this.includeSpan);
+    const includedSpans = rewriteLlmObservabilitySpanResources(spans.filter(this.includeSpan));
     if (includedSpans.length === 0) {
       resultCallback({ code: this.successCode });
       return;

--- a/src/agent/hosted/agent-run-lifecycle.test.ts
+++ b/src/agent/hosted/agent-run-lifecycle.test.ts
@@ -83,6 +83,14 @@ describe("hosted-agent-run-lifecycle", () => {
       upstreamParentRunId: "parent-run-1",
       spawnedFromToolCallId: "tool-call-1",
       traceAttributes: {
+        "project.slug": "veryfront-ops-agent",
+        "service.name": "veryfront-ops-agent",
+        service: "veryfront-ops-agent",
+        "service.version": "0.0.34",
+        version: "0.0.34",
+        "deployment.environment.name": "production",
+        "deployment.environment": "production",
+        env: "production",
         "schedule.id": "schedule-1",
         "schedule.name": "Triage sweep",
         "run.trigger.kind": "schedule",
@@ -97,6 +105,14 @@ describe("hosted-agent-run-lifecycle", () => {
     assertEquals(span.attributes["parent.conversation.id"], "parent-conversation-1");
     assertEquals(span.attributes["parent.run.id"], "parent-run-1");
     assertEquals(span.attributes["tool.call.id"], "tool-call-1");
+    assertEquals(span.attributes["project.slug"], "veryfront-ops-agent");
+    assertEquals(span.attributes["service.name"], "veryfront-ops-agent");
+    assertEquals(span.attributes["service"], "veryfront-ops-agent");
+    assertEquals(span.attributes["service.version"], "0.0.34");
+    assertEquals(span.attributes["version"], "0.0.34");
+    assertEquals(span.attributes["deployment.environment.name"], "production");
+    assertEquals(span.attributes["deployment.environment"], "production");
+    assertEquals(span.attributes["env"], "production");
     assertEquals(span.attributes["schedule.id"], "schedule-1");
     assertEquals(span.attributes["schedule.name"], "Triage sweep");
     assertEquals(span.attributes["run.trigger.kind"], "schedule");

--- a/src/agent/hosted/trace-attributes.test.ts
+++ b/src/agent/hosted/trace-attributes.test.ts
@@ -6,6 +6,7 @@ import {
   buildExecuteToolTraceAttributes,
   buildFinalizedAgentRunTraceAttributes,
   buildInvokeAgentTraceAttributes,
+  buildProjectServiceTraceAttributes,
   buildScheduleTraceAttributes,
   filterAgentTraceAttributes,
   isAgentTraceAttributeValue,
@@ -89,6 +90,58 @@ describe("agent/agent-trace-attributes", () => {
         "schedule.name": "Triage sweep",
         "run.trigger.kind": "schedule",
         "run.trigger.id": "schedule-1",
+      },
+    );
+  });
+
+  it("builds project service attributes from Datadog env aliases", () => {
+    const vars: Record<string, string> = {
+      DD_SERVICE: "veryfront-ops-agent",
+      DD_VERSION: "0.0.34",
+      DD_ENV: "production",
+    };
+
+    assertEquals(
+      buildProjectServiceTraceAttributes({
+        projectSlug: "veryfront-ops-agent",
+        readEnv: (key) => vars[key],
+      }),
+      {
+        "project.slug": "veryfront-ops-agent",
+        "service.name": "veryfront-ops-agent",
+        service: "veryfront-ops-agent",
+        "service.version": "0.0.34",
+        version: "0.0.34",
+        "deployment.environment.name": "production",
+        "deployment.environment": "production",
+        env: "production",
+      },
+    );
+  });
+
+  it("prefers OpenTelemetry resource attributes for project service attributes", () => {
+    const vars: Record<string, string> = {
+      OTEL_RESOURCE_ATTRIBUTES:
+        "service.name=investment-ops-agent,service.version=0.0.13,deployment.environment=production",
+      DD_SERVICE: "veryfront-ops-agent",
+      DD_VERSION: "0.0.34",
+      DD_ENV: "staging",
+    };
+
+    assertEquals(
+      buildProjectServiceTraceAttributes({
+        projectSlug: "investment-ops-agent",
+        readEnv: (key) => vars[key],
+      }),
+      {
+        "project.slug": "investment-ops-agent",
+        "service.name": "investment-ops-agent",
+        service: "investment-ops-agent",
+        "service.version": "0.0.13",
+        version: "0.0.13",
+        "deployment.environment.name": "production",
+        "deployment.environment": "production",
+        env: "production",
       },
     );
   });

--- a/src/agent/hosted/trace-attributes.ts
+++ b/src/agent/hosted/trace-attributes.ts
@@ -1,4 +1,5 @@
 type TracePrimitive = string | number | boolean;
+type EnvReader = (name: string) => string | undefined;
 /** Public API contract for a value can be used as an agent trace attribute. */
 export type AgentTraceAttributeValue =
   | TracePrimitive
@@ -27,6 +28,20 @@ function compactTraceAttributes(attributes: AgentTraceAttributes): AgentTraceAtt
 
 function getNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function parseResourceAttributes(value: string | undefined): Record<string, string> {
+  if (!value) return {};
+
+  const attributes: Record<string, string> = {};
+  for (const part of value.split(",")) {
+    const [rawKey, ...rawValueParts] = part.split("=");
+    const key = rawKey?.trim();
+    if (!key || rawValueParts.length === 0) continue;
+    const attributeValue = rawValueParts.join("=").trim();
+    if (attributeValue) attributes[key] = attributeValue;
+  }
+  return attributes;
 }
 
 function isAgentTraceAttributePrimitive(value: unknown): value is TracePrimitive {
@@ -71,6 +86,44 @@ export function buildScheduleTraceAttributes(
     "schedule.name": scheduleName,
     "run.trigger.kind": scheduleId ? "schedule" : undefined,
     "run.trigger.id": scheduleId,
+  });
+}
+
+/** Builds Datadog unified service trace attributes for a hosted project run. */
+export function buildProjectServiceTraceAttributes(input: {
+  projectSlug?: string | null;
+  readEnv: EnvReader;
+}): AgentTraceAttributes {
+  const resourceAttributes = parseResourceAttributes(input.readEnv("OTEL_RESOURCE_ATTRIBUTES"));
+  const projectSlug = getNonEmptyString(input.projectSlug);
+  const serviceName = getNonEmptyString(input.readEnv("OTEL_SERVICE_NAME")) ??
+    getNonEmptyString(resourceAttributes["service.name"]) ??
+    getNonEmptyString(input.readEnv("DD_SERVICE")) ??
+    projectSlug ??
+    "veryfront-agent-service";
+  const serviceVersion = getNonEmptyString(resourceAttributes["service.version"]) ??
+    getNonEmptyString(input.readEnv("OTEL_SERVICE_VERSION")) ??
+    getNonEmptyString(input.readEnv("DD_VERSION")) ??
+    getNonEmptyString(input.readEnv("VERYFRONT_VERSION")) ??
+    getNonEmptyString(input.readEnv("RELEASE_VERSION"));
+  const deploymentEnvironment = getNonEmptyString(
+    resourceAttributes["deployment.environment.name"],
+  ) ??
+    getNonEmptyString(resourceAttributes["deployment.environment"]) ??
+    getNonEmptyString(input.readEnv("OTEL_DEPLOYMENT_ENVIRONMENT")) ??
+    getNonEmptyString(input.readEnv("DD_ENV")) ??
+    getNonEmptyString(input.readEnv("APP_ENVIRONMENT")) ??
+    getNonEmptyString(input.readEnv("VERYFRONT_ENVIRONMENT"));
+
+  return compactTraceAttributes({
+    "project.slug": projectSlug,
+    "service.name": serviceName,
+    "service": serviceName,
+    "service.version": serviceVersion,
+    "version": serviceVersion,
+    "deployment.environment.name": deploymentEnvironment,
+    "deployment.environment": deploymentEnvironment,
+    "env": deploymentEnvironment,
   });
 }
 

--- a/src/agent/hosted/veryfront-cloud-agent-service.ts
+++ b/src/agent/hosted/veryfront-cloud-agent-service.ts
@@ -9,7 +9,7 @@ import {
   isMissingFirstPartyExtensionModule,
 } from "#veryfront/extensions/first-party-import.ts";
 import { dirname, resolve } from "#veryfront/platform/compat/path/index.ts";
-import { cwd, env } from "#veryfront/platform/compat/process.ts";
+import { cwd, env, getEnv } from "#veryfront/platform/compat/process.ts";
 import type { AuthProvider } from "#veryfront/extensions/auth/index.ts";
 import type { SchemaValidator } from "#veryfront/extensions/schema/index.ts";
 import { defineSchema } from "#veryfront/schemas/index.ts";
@@ -45,6 +45,7 @@ import { __registerTraceContextGetter } from "../../utils/logger/logger.ts";
 import {
   buildAgentRunTraceAttributes,
   buildExecuteToolTraceAttributes,
+  buildProjectServiceTraceAttributes,
   buildScheduleTraceAttributes,
   filterAgentTraceAttributes,
 } from "./trace-attributes.ts";
@@ -838,6 +839,7 @@ function setPrepareChatExecutionResultAttributes(
     spawnedFromToolCallId?: string;
     runtimeKind: "framework";
     forwardedProps?: Record<string, unknown>;
+    projectServiceTraceAttributes?: ReturnType<typeof buildProjectServiceTraceAttributes>;
   },
 ): void {
   const scheduleTraceAttributes = buildScheduleTraceAttributes(input.forwardedProps);
@@ -865,6 +867,7 @@ function setPrepareChatExecutionResultAttributes(
   );
   span?.setAttributes({
     "agent.runtime.kind": input.runtimeKind,
+    ...input.projectServiceTraceAttributes,
     ...scheduleTraceAttributes,
   });
 }
@@ -929,6 +932,10 @@ async function prepareChatExecution(
     spawnedFromToolCallId,
   } = req;
   const config = context.infrastructure.getConfig();
+  const projectServiceTraceAttributes = buildProjectServiceTraceAttributes({
+    projectSlug: req.projectSlug,
+    readEnv: getEnv,
+  });
 
   setPrepareChatExecutionStartAttributes(context, { projectId, userId });
 
@@ -985,6 +992,7 @@ async function prepareChatExecution(
     spawnedFromToolCallId,
     runtimeKind,
     forwardedProps: req.forwardedProps,
+    projectServiceTraceAttributes,
   });
 
   return {
@@ -1004,7 +1012,10 @@ async function prepareChatExecution(
     upstreamParentConversationId,
     upstreamParentRunId,
     spawnedFromToolCallId,
-    traceAttributes: buildScheduleTraceAttributes(req.forwardedProps),
+    traceAttributes: {
+      ...projectServiceTraceAttributes,
+      ...buildScheduleTraceAttributes(req.forwardedProps),
+    },
   };
 }
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -542,6 +542,7 @@ export {
   buildExecuteToolTraceAttributes,
   buildFinalizedAgentRunTraceAttributes,
   buildInvokeAgentTraceAttributes,
+  buildProjectServiceTraceAttributes,
   buildScheduleTraceAttributes,
   filterAgentTraceAttributes,
   isAgentTraceAttributeValue,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1041";
+export const VERSION = "0.1.1042";


### PR DESCRIPTION
## Summary
- stamp hosted agent runs with project service/version/env trace attributes from project env
- rewrite Datadog LLMObs GenAI span resources from project-scoped span attributes before export
- bump framework package version to 0.1.1042

## Verification
- deno fmt on touched files
- deno test -A extensions/ext-observability-opentelemetry/src/index.test.ts src/agent/hosted/trace-attributes.test.ts src/agent/hosted/agent-run-lifecycle.test.ts
- deno task typecheck
- pre-push checks with local OTEL env stripped: format, lint, typecheck, unit tests: 2311 passed