### PR TITLE
Prevent project runtime tokens shadowing CLI login

### DIFF
--- a/cli/shared/config.test.ts
+++ b/cli/shared/config.test.ts
@@ -10,6 +10,8 @@ import { createApiClient, readConfigFile, resolveConfig, resolveConfigWithAuth }
 import type { ResolvedConfig } from "./config.ts";
 import type { EnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import { join } from "veryfront/platform/path";
+import { __resetEnvLoaderForTests, loadEnv } from "veryfront/utils/env-loader";
+import { deleteToken, saveToken } from "../auth/token-store.ts";
 
 function createMockEnv(overrides: Partial<EnvironmentConfig> = {}): EnvironmentConfig {
   return {
@@ -150,6 +152,81 @@ describe("resolveConfigWithAuth", () => {
     const config = await resolveConfigWithAuth("/tmp/test-dir", env);
 
     assertEquals(config.apiUrl, "https://api.veryfront.com");
+  });
+
+  it("prefers the token store over a project .env API token for management commands", async () => {
+    const tempDir = await Deno.makeTempDir();
+    const configHome = await Deno.makeTempDir();
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+
+    try {
+      __resetEnvLoaderForTests();
+      Deno.env.delete("VERYFRONT_API_TOKEN");
+      await Deno.writeTextFile(join(tempDir, ".env"), "VERYFRONT_API_TOKEN=runtime-token\n");
+      await loadEnv({ cwd: tempDir });
+
+      const env = createMockEnv({
+        apiToken: "runtime-token",
+        projectSlug: "test-project",
+        xdgConfigHome: configHome,
+      });
+      await saveToken("stored-user-token", env);
+
+      const config = await resolveConfigWithAuth(tempDir, env);
+
+      assertEquals(config.apiToken, "stored-user-token");
+    } finally {
+      await deleteToken(createMockEnv({ xdgConfigHome: configHome }));
+      await Deno.remove(tempDir, { recursive: true });
+      await Deno.remove(configHome, { recursive: true });
+      __resetEnvLoaderForTests();
+
+      if (originalApiToken === undefined) {
+        Deno.env.delete("VERYFRONT_API_TOKEN");
+      } else {
+        Deno.env.set("VERYFRONT_API_TOKEN", originalApiToken);
+      }
+    }
+  });
+
+  it("prefers veryfront.json token over project .env and token store for management commands", async () => {
+    const tempDir = await Deno.makeTempDir();
+    const configHome = await Deno.makeTempDir();
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+
+    try {
+      __resetEnvLoaderForTests();
+      Deno.env.delete("VERYFRONT_API_TOKEN");
+      await Deno.writeTextFile(join(tempDir, ".env"), "VERYFRONT_API_TOKEN=runtime-token\n");
+      await Deno.writeTextFile(
+        join(tempDir, "veryfront.json"),
+        JSON.stringify({ apiToken: "config-token", projectSlug: "test-project" }),
+      );
+      await loadEnv({ cwd: tempDir });
+
+      const env = createMockEnv({
+        apiToken: "runtime-token",
+        projectSlug: "test-project",
+        xdgConfigHome: configHome,
+      });
+      await saveToken("stored-user-token", env);
+
+      const config = await resolveConfigWithAuth(tempDir, env);
+
+      assertEquals(config.apiToken, "config-token");
+      assertEquals(config.apiTokenSource, "config-file");
+    } finally {
+      await deleteToken(createMockEnv({ xdgConfigHome: configHome }));
+      await Deno.remove(tempDir, { recursive: true });
+      await Deno.remove(configHome, { recursive: true });
+      __resetEnvLoaderForTests();
+
+      if (originalApiToken === undefined) {
+        Deno.env.delete("VERYFRONT_API_TOKEN");
+      } else {
+        Deno.env.set("VERYFRONT_API_TOKEN", originalApiToken);
+      }
+    }
   });
 
   it("uses tenant project context when explicit project slug is absent", async () => {
@@ -304,6 +381,34 @@ describe("createApiClient", () => {
         globalThis.fetch = originalFetch;
       }
     });
+  });
+
+  it("explains project .env token shadowing on auth-like management API failures", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = ((_input: unknown, _init?: RequestInit) => {
+      return Promise.resolve(
+        new Response(JSON.stringify({ message: "API request failed: 403 Forbidden" }), {
+          status: 403,
+          statusText: "Forbidden",
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    }) as typeof fetch;
+
+    try {
+      const client = createApiClient(makeConfig({
+        apiToken: "runtime-token",
+        apiTokenSource: "env-file",
+      }));
+
+      await assertRejects(
+        () => client.get("/projects/test/files"),
+        Error,
+        "VERYFRONT_API_TOKEN was loaded from a project .env file",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   describe("retry on transient failures for idempotent requests", () => {

--- a/cli/shared/config.ts
+++ b/cli/shared/config.ts
@@ -10,6 +10,7 @@ import type { InferSchema } from "veryfront/extensions/schema";
 import { join } from "veryfront/platform/path";
 import { createFileSystem, cwd, getEnv } from "veryfront/platform";
 import { type EnvironmentConfig, getEnvironmentConfig } from "veryfront/config";
+import { getEnvSource } from "veryfront/utils/env-loader";
 import { cliLogger, VERSION } from "#cli/utils";
 import { readToken } from "../auth/token-store.ts";
 import { ensureAuthenticated } from "../auth/login.ts";
@@ -54,11 +55,13 @@ export const getResolvedConfigSchema = defineSchema((v) =>
   v.object({
     apiUrl: v.string(),
     apiToken: v.string(),
+    apiTokenSource: v.enum(["env", "env-file", "config-file", "token-store"]).optional(),
     projectSlug: v.string(),
   })
 );
 export const ResolvedConfigSchema = lazySchema(getResolvedConfigSchema);
 export type ResolvedConfig = InferSchema<ReturnType<typeof getResolvedConfigSchema>>;
+type ApiTokenSource = NonNullable<ResolvedConfig["apiTokenSource"]>;
 
 export async function readConfigFile(projectDir: string): Promise<VeryfrontConfig | null> {
   const fs = createFileSystem();
@@ -151,6 +154,44 @@ function resolveTenantProjectReference(): string | undefined {
     undefined;
 }
 
+async function resolveApiTokenForMode(
+  env: EnvironmentConfig,
+  configFile: VeryfrontConfig | null,
+  interactive: boolean,
+): Promise<{ apiToken: string | null; apiTokenSource?: ApiTokenSource }> {
+  const envToken = env.apiToken;
+  const envSource = envToken ? getEnvSource("VERYFRONT_API_TOKEN") : { source: "unset" as const };
+  const storedToken = await readToken(env);
+
+  if (envToken && envSource.source !== "env-file") {
+    return {
+      apiToken: envToken,
+      apiTokenSource: "env",
+    };
+  }
+
+  if (configFile?.apiToken) {
+    return { apiToken: configFile.apiToken, apiTokenSource: "config-file" };
+  }
+
+  if (interactive && envToken && envSource.source === "env-file" && storedToken) {
+    return { apiToken: storedToken, apiTokenSource: "token-store" };
+  }
+
+  if (envToken) {
+    return {
+      apiToken: envToken,
+      apiTokenSource: envSource.source === "env-file" ? "env-file" : "env",
+    };
+  }
+
+  if (storedToken) {
+    return { apiToken: storedToken, apiTokenSource: "token-store" };
+  }
+
+  return { apiToken: null };
+}
+
 async function resolveConfigBase(
   projectDir: string | undefined,
   env: EnvironmentConfig,
@@ -161,12 +202,13 @@ async function resolveConfigBase(
 
   const apiUrl = resolveCliApiUrl(env, configFile?.apiUrl);
 
-  let apiToken = env.apiToken ?? configFile?.apiToken ?? (await readToken(env));
+  let { apiToken, apiTokenSource } = await resolveApiTokenForMode(env, configFile, interactive);
 
   if (!apiToken && interactive) {
     const userInfo = await ensureAuthenticated(env);
     if (!userInfo) throw new Error("Authentication required for this operation.");
     apiToken = (await readToken(env)) ?? null;
+    apiTokenSource = apiToken ? "token-store" : undefined;
     if (!apiToken) throw new Error("Authentication failed. Please try again.");
   }
 
@@ -186,7 +228,7 @@ async function resolveConfigBase(
     );
   }
 
-  return { apiUrl, apiToken, projectSlug };
+  return { apiUrl, apiToken, ...(apiTokenSource ? { apiTokenSource } : {}), projectSlug };
 }
 
 function createConfigResolver(interactive: boolean) {
@@ -233,6 +275,13 @@ export type ApiError = InferSchema<ReturnType<typeof getApiErrorSchema>>;
 export function createApiClient(config: ResolvedConfig): ApiClient {
   const { apiUrl, apiToken } = config;
 
+  function addTokenSourceHint(message: string, status: number): string {
+    if (config.apiTokenSource !== "env-file") return message;
+    if (status !== 401 && status !== 403 && status !== 404) return message;
+
+    return `${message}. VERYFRONT_API_TOKEN was loaded from a project .env file. For management commands, run 'veryfront login' and remove or rename the project runtime token, or pass a management token explicitly in the shell.`;
+  }
+
   async function requestOnce<T>(
     method: string,
     url: string,
@@ -261,6 +310,7 @@ export function createApiClient(config: ResolvedConfig): ApiClient {
         // Keep default error message if JSON parsing fails
       }
 
+      errorMessage = addTokenSourceHint(errorMessage, response.status);
       const err = new Error(errorMessage) as Error & { status: number };
       err.status = response.status;
       throw err;


### PR DESCRIPTION
## Summary
- track the source of the CLI management API token during config resolution
- for interactive management commands, prefer the token-store login over `VERYFRONT_API_TOKEN` when that env token was loaded from a project `.env` file
- add an actionable 401/403/404 hint when a project `.env` token is used and management API auth fails

## Validation
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all cli/shared/config.test.ts`
- `deno fmt --check cli/shared/config.ts cli/shared/config.test.ts`
- `deno lint cli/shared/config.ts cli/shared/config.test.ts`
- `deno check cli/shared/config.ts cli/shared/config.test.ts`
- `deno check cli/main.ts`
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all cli/commands/files/command.test.ts cli/commands/files/handler.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all cli/commands/deploy`
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/skill/executor.test.ts`

## Notes
- Pre-push formatting, lint, and typecheck completed before the full unit suite. The full unit suite failed once in `src/skill/executor.test.ts` on the late sandbox rejection case; that same file passed immediately in isolation.
- `cli/shared/project-source-context.test.ts` fails locally on the origin-main code path while loading a temp config without schema extension support.

Closes veryfront/veryfront#6