### PR TITLE
Release veryfront 0.1.1043

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1042",
+  "version": "0.1.1043",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1042";
+export const VERSION = "0.1.1043";


### PR DESCRIPTION
## Summary
- Bump veryfront from 0.1.1042 to 0.1.1043
- Publish the merged CLI auth precedence fix from #2854
- Publish the merged release concurrency guard from #2848

## Validation
- jq -e '.version == "0.1.1043"' deno.json
- deno fmt --check deno.json src/utils/version-constant.ts
- deno check src/utils/version-constant.ts
- npm view veryfront@0.1.1043 version returns E404
- gh release view v0.1.1043 -R veryfront/veryfront-code returns release not found
- gh release view v0.1.1043 -R veryfront/veryfront returns release not found
- Pre-push hook passed: formatting, lint, typecheck, unit tests (2311 passed)

Related: #2854
Related: #2848