### PR TITLE
Release veryfront 0.1.1044

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1043",
+  "version": "0.1.1044",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1043";
+export const VERSION = "0.1.1044";


### PR DESCRIPTION
## Summary
- Bump Veryfront from 0.1.1043 to 0.1.1044
- Publish the merged codebase hardening changes from #2853
- Resolve the failed main release preflight caused by the already-published 0.1.1043 version

## Validation
- npm workspace release preflight passes for 0.1.1044
- deno test --no-check --allow-all src/utils/version.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts
- deno task lint
- deno task typecheck
- npm, source tag, and both GitHub release targets confirm 0.1.1044 is unused
- Pre-push hook passed: formatting, lint, typecheck, and unit tests (2314 passed)

Related: #2853
Related: main CI run 29123578613