### PR TITLE
Use run credentials for dedicated runtime discovery

### DIFF
--- a/src/server/handlers/request/agent-stream.handler.test-helpers.ts
+++ b/src/server/handlers/request/agent-stream.handler.test-helpers.ts
@@ -77,6 +77,7 @@ export type SourceContextTestFsAdapter = FileSystemAdapter & {
 
 export function createNoopFsAdapter(
   runWithContextCalls: Array<{
+    token?: string;
     productionMode?: boolean;
     releaseId?: string | null;
     branch?: string | null;
@@ -105,12 +106,12 @@ export function createNoopFsAdapter(
     isMultiProjectMode: () => true,
     runWithContext: async (
       _projectSlug,
-      _token,
+      token,
       fn,
       _projectId,
       options,
     ) => {
-      runWithContextCalls.push(options ?? {});
+      runWithContextCalls.push({ token, ...options });
       return await fn();
     },
   };

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -1800,8 +1800,9 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertStringIncludes(text, "event: RunFinished");
   });
 
-  it("uses explicit agent source context when the control plane requests a different source", async () => {
+  it("uses the verified request credential for proxy and explicit agent source contexts", async () => {
     const runWithContextCalls: Array<{
+      token?: string;
       productionMode?: boolean;
       releaseId?: string | null;
       branch?: string | null;
@@ -1853,6 +1854,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
 
     const body = createAgentStreamRequestBody({
       agentSource: { type: "branch", branch: "main" },
+      credentials: { authToken: "request-scoped-user-token" },
     });
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
     const ctx = createCtx(publicKeyPem);
@@ -1877,22 +1879,32 @@ describe("server/handlers/request/agent-stream.handler", () => {
       fs: createNoopFsAdapter(runWithContextCalls),
     };
 
-    const result = await handler.handle(
-      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-veryfront-control-plane-jws": jws,
-        },
-        body,
-      }),
-      ctx,
-    );
+    const originalHostToken = Deno.env.get("VERYFRONT_API_TOKEN");
+    Deno.env.set("VERYFRONT_API_TOKEN", "expired-host-token");
+    let result;
+    try {
+      result = await handler.handle(
+        new Request("https://example.com/api/control-plane/runs/run_1/stream", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-veryfront-control-plane-jws": jws,
+          },
+          body,
+        }),
+        ctx,
+      );
+    } finally {
+      if (originalHostToken === undefined) Deno.env.delete("VERYFRONT_API_TOKEN");
+      else Deno.env.set("VERYFRONT_API_TOKEN", originalHostToken);
+    }
 
     assertExists(result.response);
     assertEquals(result.response.status, 200);
     assertEquals(runWithContextCalls.length, 2);
+    assertEquals(runWithContextCalls[0]?.token, "request-scoped-user-token");
     assertEquals(runWithContextCalls[0]?.branch, "feature-a");
+    assertEquals(runWithContextCalls[1]?.token, "request-scoped-user-token");
     assertEquals(runWithContextCalls[1]?.branch, "main");
     assertEquals(runWithContextCalls[1]?.productionMode, false);
   });

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -637,50 +637,59 @@ export class AgentStreamHandler extends BaseHandler {
       return this.respond(buildRuntimeShuttingDownResponse(this.createResponseBuilder(ctx)));
     }
 
-    return this.withProxyContext(ctx, async () => {
-      const builder = this.createResponseBuilder(ctx)
-        .withCORS(req, ctx.securityConfig?.cors)
-        .withSecurity(ctx.securityConfig ?? undefined, req);
+    const builder = this.createResponseBuilder(ctx)
+      .withCORS(req, ctx.securityConfig?.cors)
+      .withSecurity(ctx.securityConfig ?? undefined, req);
 
-      try {
-        const pathRunId = getPathRunId(new URL(req.url).pathname);
-        const rawBody = await readInternalAgentRequestBody(
-          req,
-          INTERNAL_AGENT_STREAM_MAX_BODY_BYTES,
-        );
-        const payload = parseAgentStreamPayload(JSON.parse(rawBody));
-        if (!pathRunId || pathRunId !== payload.runId) {
-          return this.respond(builder.json({ error: "CONTROL_PLANE_RUN_ID_MISMATCH" }, 400));
-        }
-        await verifyControlPlaneRequest(req, ctx, rawBody, {
-          expectedSubject: payload.runId,
-          expectedSurface: "studio",
-        });
-        logger.info("Accepted internal agent stream request", {
-          runId: payload.runId,
-          threadId: payload.threadId,
-          agentId: payload.agentId,
-          projectId: ctx.projectId,
-          projectSlug: ctx.projectSlug,
-          messageCount: payload.messages.length,
-          toolCount: payload.tools.length,
-          hasAgentSource: Boolean(payload.agentSource),
-          hasAgentConfig: Boolean(payload.agentConfig),
-        });
+    try {
+      const pathRunId = getPathRunId(new URL(req.url).pathname);
+      const rawBody = await readInternalAgentRequestBody(
+        req,
+        INTERNAL_AGENT_STREAM_MAX_BODY_BYTES,
+      );
+      const payload = parseAgentStreamPayload(JSON.parse(rawBody));
+      if (!pathRunId || pathRunId !== payload.runId) {
+        return this.respond(builder.json({ error: "CONTROL_PLANE_RUN_ID_MISMATCH" }, 400));
+      }
+      await verifyControlPlaneRequest(req, ctx, rawBody, {
+        expectedSubject: payload.runId,
+        expectedSurface: "studio",
+      });
+      const apiAuthToken = payload.credentials?.authToken || ctx.proxyToken ||
+        getHostEnv("VERYFRONT_API_TOKEN") || "";
+      const requestScopedContext: HandlerContext = {
+        ...ctx,
+        proxyToken: apiAuthToken || undefined,
+        requestContext: ctx.requestContext
+          ? { ...ctx.requestContext, token: apiAuthToken }
+          : ctx.requestContext,
+      };
+      logger.info("Accepted internal agent stream request", {
+        runId: payload.runId,
+        threadId: payload.threadId,
+        agentId: payload.agentId,
+        projectId: requestScopedContext.projectId,
+        projectSlug: requestScopedContext.projectSlug,
+        messageCount: payload.messages.length,
+        toolCount: payload.tools.length,
+        hasAgentSource: Boolean(payload.agentSource),
+        hasAgentConfig: Boolean(payload.agentConfig),
+      });
 
-        return await this.withAgentSourceContext(
-          ctx,
+      return await this.withProxyContext(requestScopedContext, () =>
+        this.withAgentSourceContext(
+          requestScopedContext,
           payload.agentSource,
           async () => {
-            await this.deps.ensureProjectDiscovery(ctx);
+            await this.deps.ensureProjectDiscovery(requestScopedContext);
 
             const agent = this.deps.getAgent(payload.agentId);
             if (!agent) {
               logger.warn("Internal agent stream request referenced unknown agent", {
                 runId: payload.runId,
                 agentId: payload.agentId,
-                projectId: ctx.projectId,
-                projectSlug: ctx.projectSlug,
+                projectId: requestScopedContext.projectId,
+                projectSlug: requestScopedContext.projectSlug,
               });
               return this.respond(builder.json({ error: "Agent not found" }, 404));
             }
@@ -692,18 +701,16 @@ export class AgentStreamHandler extends BaseHandler {
               : agent;
             const runtimeInput = sanitizeRuntimeRunAgentInput(toRuntimeRunAgentInput(payload));
             const localTools = this.deps.getLocalTools?.(runtimeBaseAgent.id);
-            const apiAuthToken = payload.credentials?.authToken || ctx.proxyToken ||
-              getHostEnv("VERYFRONT_API_TOKEN") || "";
             const platformRuntimeAgent = await withVeryfrontPlatformRemoteTools({
               agent: runtimeBaseAgent as Agent,
               token: apiAuthToken || null,
-              projectId: ctx.projectId ?? null,
+              projectId: requestScopedContext.projectId ?? null,
               availableToolNames: runtimeInput.tools.map((tool) => tool.name),
             });
             const runtimeAgent = withVeryfrontStudioRemoteTools({
               agent: platformRuntimeAgent,
               token: apiAuthToken || null,
-              projectId: ctx.projectId ?? null,
+              projectId: requestScopedContext.projectId ?? null,
               forwardedProps: runtimeInput.forwardedProps,
               availableToolNames: runtimeInput.tools.map((tool) => tool.name),
               conversationId: runtimeInput.threadId,
@@ -714,18 +721,21 @@ export class AgentStreamHandler extends BaseHandler {
             // therefore don't carry x-environment-id, so we discover the production env ID
             // from the API (one fetch per project per server lifetime, then cached).
             let envVarsForAgent: Record<string, string> = {};
-            if (ctx.projectSlug && apiAuthToken) {
-              const environmentId = ctx.environmentId ??
-                await _resolveProductionEnvironmentId(ctx.projectSlug, apiAuthToken);
+            if (requestScopedContext.projectSlug && apiAuthToken) {
+              const environmentId = requestScopedContext.environmentId ??
+                await _resolveProductionEnvironmentId(
+                  requestScopedContext.projectSlug,
+                  apiAuthToken,
+                );
               if (environmentId) {
                 envVarsForAgent = await _agentEnvVarCache.get(
                   environmentId,
                   apiAuthToken,
-                  ctx.projectSlug,
+                  requestScopedContext.projectSlug,
                 );
                 logger.debug("Agent stream env vars loaded", {
                   runId: payload.runId,
-                  projectSlug: ctx.projectSlug,
+                  projectSlug: requestScopedContext.projectSlug,
                   environmentId,
                   count: Object.keys(envVarsForAgent).length,
                 });
@@ -739,7 +749,7 @@ export class AgentStreamHandler extends BaseHandler {
                 projectAgentSandbox: {
                   apiUrl: resolveVeryfrontApiBaseUrlFromHostEnv(),
                   authToken: apiAuthToken || undefined,
-                  projectId: ctx.projectId ?? null,
+                  projectId: requestScopedContext.projectId ?? null,
                 },
               });
             const shouldIsolateEnv = apiAuthToken.length > 0;
@@ -748,7 +758,7 @@ export class AgentStreamHandler extends BaseHandler {
                 buildAgentStreamEnv({
                   envVars: envVarsForAgent,
                   proxyToken: apiAuthToken,
-                  projectSlug: ctx.projectSlug,
+                  projectSlug: requestScopedContext.projectSlug,
                 }),
                 runAgentStream,
               )
@@ -757,8 +767,8 @@ export class AgentStreamHandler extends BaseHandler {
               runId: payload.runId,
               threadId: payload.threadId,
               agentId: payload.agentId,
-              projectId: ctx.projectId,
-              projectSlug: ctx.projectSlug,
+              projectId: requestScopedContext.projectId,
+              projectSlug: requestScopedContext.projectSlug,
             });
             const runtimeOwnerInvokeUrl = await this.deps.resolveRuntimeOwnerInvokeUrl?.(req) ??
               null;
@@ -771,44 +781,43 @@ export class AgentStreamHandler extends BaseHandler {
               : response;
             return this.respond(applyBuilderHeaders(responseWithOwner, builder.headers));
           },
-        );
-      } catch (error) {
-        if (error instanceof InternalAgentRequestBodyTooLargeError) {
-          return this.respond(builder.json({ error: error.message }, error.status));
-        }
-
-        if (error instanceof ControlPlaneRequestError) {
-          return this.respond(builder.json({ error: error.message }, error.status));
-        }
-
-        if (error instanceof SyntaxError) {
-          return this.respond(
-            builder.json({ error: "Invalid internal agent stream request" }, 400),
-          );
-        }
-
-        if (error instanceof AgentRunAlreadyExistsError) {
-          return this.respond(builder.json({ error: error.message }, 409));
-        }
-
-        if (error instanceof Error && error.name === "ZodError") {
-          return this.respond(
-            builder.json({ error: "Invalid internal agent stream request" }, 400),
-          );
-        }
-
-        this.logWarn("Internal agent stream request failed", {
-          error: error instanceof Error ? error.message : String(error),
-          projectId: ctx.projectId,
-          projectSlug: ctx.projectSlug,
-        });
-        logger.error("Internal agent stream handler failed", {
-          projectId: ctx.projectId,
-          projectSlug: ctx.projectSlug,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return this.respond(builder.json({ error: "Internal agent stream failed" }, 500));
+        ));
+    } catch (error) {
+      if (error instanceof InternalAgentRequestBodyTooLargeError) {
+        return this.respond(builder.json({ error: error.message }, error.status));
       }
-    });
+
+      if (error instanceof ControlPlaneRequestError) {
+        return this.respond(builder.json({ error: error.message }, error.status));
+      }
+
+      if (error instanceof SyntaxError) {
+        return this.respond(
+          builder.json({ error: "Invalid internal agent stream request" }, 400),
+        );
+      }
+
+      if (error instanceof AgentRunAlreadyExistsError) {
+        return this.respond(builder.json({ error: error.message }, 409));
+      }
+
+      if (error instanceof Error && error.name === "ZodError") {
+        return this.respond(
+          builder.json({ error: "Invalid internal agent stream request" }, 400),
+        );
+      }
+
+      this.logWarn("Internal agent stream request failed", {
+        error: error instanceof Error ? error.message : String(error),
+        projectId: ctx.projectId,
+        projectSlug: ctx.projectSlug,
+      });
+      logger.error("Internal agent stream handler failed", {
+        projectId: ctx.projectId,
+        projectSlug: ctx.projectSlug,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return this.respond(builder.json({ error: "Internal agent stream failed" }, 500));
+    }
   }
 }


### PR DESCRIPTION
## Description

Dedicated agent streams selected the verified run-scoped credential only after project discovery. When the request header was unavailable, the multi-project filesystem and API cache contexts fell back to the server host token; on the live dedicated server that token had expired, causing repeated cache 401s despite a fresh credential in the signed payload.

This change verifies the control-plane JWS first, then binds the payload credential to the proxy and explicit source contexts before discovery. Environment loading, remote tools, sandbox calls, and project env isolation continue to use the same request-scoped credential. The static host token remains only as a compatibility fallback.

## Related Issue(s)

Related to veryfront/veryfront-studio#5766

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Validation

- Full agent-stream handler test suite: 27 steps passed
- Pre-push formatting, lint, typecheck, and unit test suite passed
- `deno task typecheck` passed
- `deno task verify:quick` reaches an unrelated pre-existing style finding in `src/server/utils/domain-lookup.ts`

## Checklist

- [x] I have made corresponding changes to the documentation (not applicable; internal behavior only)
- [x] I have added tests that prove my fix is effective or that my feature works