### PR TITLE
Release veryfront 0.1.1045

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1044",
+  "version": "0.1.1045",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1044";
+export const VERSION = "0.1.1045";


### PR DESCRIPTION
## Summary
- Publish the request-scoped dedicated-runtime credential fix merged in #2858
- Advance the framework manifest and runtime constant from 0.1.1044 to the next unused stable version
- Trigger downstream `veryfront-server` image build and staging deployment after release

## Validation
- `deno test --no-check --allow-all src/utils/version.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts`
- npm workspace release preflight for 0.1.1045
- `deno task lint`
- `deno task typecheck`
- pre-push hook: formatting, lint, typecheck, and 2,314 unit tests / 19,570 steps
- npm, source tag, and both GitHub release targets confirm 0.1.1045 is unused

Related: #2858
Related: veryfront/veryfront-studio#5766