### PR TITLE
Lock generic managed agent runtime behavior

### DIFF
--- a/docs/guides/agent-service-runtime.md
+++ b/docs/guides/agent-service-runtime.md
@@ -8,6 +8,12 @@ An agent service runs your agent as its own process, independent of the app serv
 
 Veryfront Cloud can invoke a push runtime directly against an agent service, which is the main reason to deploy one even when the app and the agent share a host.
 
+Shared and managed dedicated servers use the framework-owned `veryfront serve`
+runtime instead. That runtime discovers all project agents and tools, then routes
+each signed control-plane request by `agentId`. Projects on a managed dedicated
+server do not require a `service.ts` entrypoint. Add one only when you
+intentionally run the standalone Agent Service process described in this guide.
+
 ## Prerequisites
 
 - At least one agent in `agents/` that the service should expose (see

--- a/src/agent/project/agent-runtime.test.ts
+++ b/src/agent/project/agent-runtime.test.ts
@@ -129,8 +129,77 @@ Deno.test("discoverProjectAgentRuntime clears stale runtime registries before re
   });
 });
 
+async function assertMultiAgentProjectDiscoveryWithoutServiceEntrypoint(): Promise<void> {
+  await withTempDir(async (rootDir) => {
+    const agentsDir = resolve(rootDir, "agents");
+    const toolsDir = resolve(rootDir, "tools");
+    Deno.mkdirSync(agentsDir, { recursive: true });
+    Deno.mkdirSync(toolsDir, { recursive: true });
+
+    for (
+      const [fileName, id, name] of [
+        ["reviewer.ts", "reviewer", "Reviewer"],
+        ["support.ts", "support", "Support"],
+      ] as const
+    ) {
+      Deno.writeTextFileSync(
+        resolve(agentsDir, fileName),
+        [
+          'import { agent } from "veryfront/agent";',
+          "",
+          "export default agent({",
+          `  id: "${id}",`,
+          `  name: "${name}",`,
+          '  model: "openai/gpt-5.4",',
+          `  system: "You are the ${name.toLowerCase()} agent.",`,
+          "});",
+          "",
+        ].join("\n"),
+      );
+    }
+
+    for (
+      const [fileName, id] of [
+        ["echo.ts", "echo"],
+        ["lookup.ts", "lookup"],
+      ] as const
+    ) {
+      Deno.writeTextFileSync(
+        resolve(toolsDir, fileName),
+        [
+          'import { tool } from "veryfront/tool";',
+          'import { defineSchema } from "veryfront/schemas";',
+          "",
+          "export default tool({",
+          `  id: "${id}",`,
+          `  description: "${id} a value",`,
+          "  inputSchema: defineSchema((v) => v.object({ value: v.string() }))(),",
+          "  execute: ({ value }) => ({ value }),",
+          "});",
+          "",
+        ].join("\n"),
+      );
+    }
+
+    assertEquals(await nodeAdapter.fs.exists(resolve(rootDir, "service.ts")), false);
+
+    const result = await discoverProjectAgentRuntime({
+      projectDir: rootDir,
+      adapter: nodeAdapter,
+    });
+
+    assertEquals([...result.agents.keys()].sort(), ["reviewer", "support"]);
+    assertEquals([...result.tools.keys()].sort(), ["echo", "lookup"]);
+    assertEquals(getProjectAgentRuntimeAgentIdCandidates(result), {
+      codeAgentIds: ["reviewer", "support"],
+      markdownAgentIds: [],
+    });
+  });
+}
+
 Deno.test({
-  name: "discoverProjectAgentRuntime discovers configured project agent paths",
+  name:
+    "discoverProjectAgentRuntime supports configured paths and multi-agent projects without service.ts",
   // Code primitive discovery invokes the esbuild-backed transpiler, which starts
   // an esbuild child process. This matches the sanitizer policy in the other
   // discovery tests that import TypeScript project primitives.
@@ -192,5 +261,7 @@ Help from configured markdown.
         markdownAgentIds: ["support"],
       });
     });
+
+    await assertMultiAgentProjectDiscoveryWithoutServiceEntrypoint();
   },
 });

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -302,6 +302,93 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(result.response.status, 200);
   });
 
+  it("selects a requested agent and its local tools from a multi-agent runtime", async () => {
+    const agents = new Map([
+      ["assistant-1", createAgent("assistant-1")],
+      [
+        "assistant-2",
+        createAgentWithConfig("assistant-2", {
+          tools: { local_lookup: true },
+        }),
+      ],
+    ]);
+    let localToolsAgentId: string | undefined;
+    let runtimeAgentId: string | undefined;
+    let runtimeToolNames: string[] | undefined;
+
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: (id) => agents.get(id),
+      getAllAgentIds: () => [...agents.keys()],
+      getLocalTools: (agentId) => {
+        localToolsAgentId = agentId;
+        return { local_lookup: true };
+      },
+      sessionManager: new AgentRunSessionManager(),
+      createRuntime: (runtimeAgent, mergedTools) => {
+        runtimeAgentId = runtimeAgent.id;
+        runtimeToolNames = mergedTools && mergedTools !== true
+          ? Object.keys(mergedTools).sort()
+          : [];
+
+        return {
+          stream: async (_messages, _context, callbacks) => {
+            callbacks?.onFinish?.({
+              text: "selected assistant-2",
+              messages: [],
+              toolCalls: [],
+              status: "completed",
+              usage: undefined,
+              metadata: { finishReason: "stop" },
+            });
+
+            return new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(
+                  encodeDataStreamEvent({ type: "message-start", messageId: "assistant-msg-1" }),
+                );
+                controller.enqueue(encodeDataStreamEvent({ type: "text-start", id: "text-1" }));
+                controller.enqueue(
+                  encodeDataStreamEvent({
+                    type: "text-delta",
+                    id: "text-1",
+                    delta: "selected assistant-2",
+                  }),
+                );
+                controller.enqueue(encodeDataStreamEvent({ type: "text-end", id: "text-1" }));
+                controller.close();
+              },
+            });
+          },
+        };
+      },
+    });
+
+    const body = createAgentStreamRequestBody({ agentId: "assistant-2" });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "run_1",
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/api/control-plane/runs/run_1/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    await result.response.text();
+    assertEquals(localToolsAgentId, "assistant-2");
+    assertEquals(runtimeAgentId, "assistant-2");
+    assertEquals(runtimeToolNames, ["local_lookup", "studio_focus_component"]);
+  });
+
   it("accepts the canonical runtime AG-UI request shape on the control-plane run stream route", async () => {
     let streamContext: Record<string, unknown> | undefined;
 

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -63,7 +63,14 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "../api-reference/veryfront/agent.md",
       "../api-reference/veryfront/channels.md",
     ],
-    snippets: ["startAgentService", "VERYFRONT_AGENT_SERVICE_URL", "/api/runs"],
+    snippets: [
+      "startAgentService",
+      "VERYFRONT_AGENT_SERVICE_URL",
+      "/api/runs",
+      "managed dedicated servers",
+      "`veryfront serve`",
+      "do not require a `service.ts`",
+    ],
   },
   "guides/agents.md": {
     references: ["../api-reference/veryfront/agent.md"],


### PR DESCRIPTION
## Summary

- prove project discovery loads multiple agents and tools without `service.ts`
- prove signed control-plane runs select the requested agent and attach its local tools
- clarify that `service.ts` is a standalone Agent Service entrypoint, not a managed shared or dedicated server requirement
- keep the public guide distinction under a docs contract

## Architecture

Managed shared and dedicated compute starts the framework-owned `veryfront serve` runtime. `startAgentService()` remains the separate custom-process hosting surface. This PR locks the existing architecture without changing runtime behavior.

## Verification

- pre-push checks: formatting, lint, source typecheck, and 2,314 unit tests / 19,571 steps
- focused agent discovery and control-plane handler suites
- direct typecheck of changed test files
- full docs validation
- sanitizer baseline: 422/422

## Baseline note

`deno task verify:quick` reaches two pre-existing `lint:style` violations in untouched `src/server/utils/domain-lookup.ts`. The repository CI lint job does not currently run that stricter task; all CI-equivalent checks and the full pre-push suite pass.

Related: veryfront/veryfront-studio#5766