### PR TITLE
chore(release): bump version to 0.1.1047

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1046",
+  "version": "0.1.1047",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1046";
+export const VERSION = "0.1.1047";


### PR DESCRIPTION
## Summary

- publish a new immutable stable version containing the merged project API-key CLI correction from #2862
- keep `deno.json` and `src/utils/version-constant.ts` synchronized at `0.1.1047`
- leave dependencies, lockfiles, generated assets, and runtime code unchanged

## Verification

- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno test --no-check -A src/utils/version.test.ts` (21 steps, 0 failures)
- mandatory pre-push format, lint, typecheck, and complete unit gate with `DENO_JOBS=1`

## Release preflight

- `0.1.1047` was unused on npm and GitHub before this branch
- diff is limited to the two canonical version files

Related: #2861
Related: #2862