### PR TITLE
Verify production deployment before reporting success

### DIFF
--- a/.veryfront
+++ b/.veryfront
@@ -1,0 +1,1 @@
+/var/folders/s1/93kv444x1836wks3wh0y62c40000gn/T/be7656c62c9a488c

--- a/.veryfront
+++ b/.veryfront
@@ -1,1 +1,0 @@
-/var/folders/s1/93kv444x1836wks3wh0y62c40000gn/T/be7656c62c9a488c

--- a/cli/commands/deploy/command-help.ts
+++ b/cli/commands/deploy/command-help.ts
@@ -36,7 +36,8 @@ export const deployHelp: CommandHelp = {
   ],
   notes: [
     "Requires VERYFRONT_API_TOKEN env var or veryfront.json config",
+    "Requires a successful veryfront push for the same project and branch",
     "Creates a new release from the specified branch",
-    "Deploys the release to the target environment",
+    "Verifies the target environment points to the created deployment before succeeding",
   ],
 };

--- a/cli/commands/deploy/command.integration.test.ts
+++ b/cli/commands/deploy/command.integration.test.ts
@@ -1,0 +1,206 @@
+import "#veryfront/schemas/_test-setup.ts";
+
+import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { it } from "#veryfront/testing/bdd.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
+import { computeSourceDigest, writePushReceipt } from "../../shared/deployment-provenance.ts";
+import { setJsonMode } from "../../shared/json-output.ts";
+import { deployCommand } from "./command.ts";
+
+const PROJECT_ID = "550e8400-e29b-41d4-a716-446655440000";
+const ENVIRONMENT_ID = "660e8400-e29b-41d4-a716-446655440000";
+const RELEASE_ID = "770e8400-e29b-41d4-a716-446655440000";
+const DEPLOYMENT_ID = "880e8400-e29b-41d4-a716-446655440000";
+
+it("uses canonical production read-back in human and JSON modes", async () => {
+  const originalCwd = Deno.cwd();
+  const projectDir = await Deno.makeTempDir();
+  const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];
+  const savedEnv = envKeys.map((key) => Deno.env.get(key));
+  const requests: string[] = [];
+  let environmentReads = 0;
+
+  const runGit = async (...args: string[]) => {
+    const result = await new Deno.Command("git", {
+      args,
+      cwd: projectDir,
+      clearEnv: true,
+      env: Object.fromEntries(
+        Object.entries(Deno.env.toObject()).filter(([key]) => !key.startsWith("GIT_")),
+      ),
+      stdout: "null",
+      stderr: "piped",
+    }).output();
+    assertEquals(result.success, true, new TextDecoder().decode(result.stderr));
+  };
+
+  try {
+    await runGit("init", "--quiet");
+    await runGit("config", "user.email", "test@veryfront.com");
+    await runGit("config", "user.name", "Veryfront Test");
+    await Deno.writeTextFile(`${projectDir}/.gitignore`, ".veryfront/\n");
+    await Deno.writeTextFile(`${projectDir}/app.ts`, "export const value = 1;\n");
+    await runGit("add", ".");
+    await runGit("commit", "--quiet", "-m", "initial");
+    const actualSha = new TextDecoder().decode(
+      (await new Deno.Command("git", {
+        args: ["rev-parse", "HEAD"],
+        cwd: projectDir,
+        clearEnv: true,
+        env: Object.fromEntries(
+          Object.entries(Deno.env.toObject()).filter(([key]) => !key.startsWith("GIT_")),
+        ),
+        stdout: "piped",
+      }).output()).stdout,
+    ).trim();
+    const sourceDigest = await computeSourceDigest([
+      { path: "app.ts", content: "export const value = 1;\n" },
+    ]);
+
+    await writePushReceipt(projectDir, {
+      controlPlane: "https://control.example.test/api",
+      projectId: PROJECT_ID,
+      projectSlug: "my-project",
+      branch: "main",
+      commitSha: actualSha,
+      sourceDigest,
+      clean: true,
+      pushedAt: "2026-07-10T09:20:00.000Z",
+    });
+
+    Deno.env.set("VERYFRONT_API_TOKEN", "test-token");
+    Deno.env.set("VERYFRONT_API_URL", "https://control.example.test/api");
+    Deno.env.set("VERYFRONT_PROJECT_SLUG", "my-project");
+    _resetEnvironmentConfig();
+    Deno.chdir(projectDir);
+
+    let releaseSourceContent = "export const value = 1;\n";
+    const handleRequest = async (input: string | URL | Request, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      const url = new URL(request.url);
+      requests.push(`${request.method} ${url.pathname}`);
+
+      if (request.method === "GET" && url.pathname === "/api/projects/my-project") {
+        return Response.json({ id: PROJECT_ID, slug: "my-project" });
+      }
+      if (request.method === "GET" && url.pathname.endsWith("/environments")) {
+        environmentReads++;
+        return Response.json({
+          data: [{
+            id: ENVIRONMENT_ID,
+            name: "production",
+            project_id: PROJECT_ID,
+            protected: true,
+            deployment: environmentReads === 1 ? null : {
+              id: DEPLOYMENT_ID,
+              release: { id: RELEASE_ID, name: `github-main-${actualSha}` },
+            },
+          }],
+        });
+      }
+      if (request.method === "POST" && url.pathname.endsWith("/releases")) {
+        return Response.json({
+          id: RELEASE_ID,
+          name: `github-main-${actualSha}`,
+          version: "0.0.41",
+          project_id: PROJECT_ID,
+        }, { status: 201 });
+      }
+      if (request.method === "POST" && url.pathname.endsWith("/deployments")) {
+        return Response.json({
+          id: DEPLOYMENT_ID,
+          release_id: RELEASE_ID,
+          environment_id: ENVIRONMENT_ID,
+        }, { status: 201 });
+      }
+      if (request.method === "GET" && url.pathname.endsWith(`/deployments/${DEPLOYMENT_ID}`)) {
+        return Response.json({
+          id: DEPLOYMENT_ID,
+          release_id: RELEASE_ID,
+          environment_id: ENVIRONMENT_ID,
+        });
+      }
+      if (request.method === "GET" && url.pathname.endsWith(`/releases/${RELEASE_ID}`)) {
+        return Response.json({
+          id: RELEASE_ID,
+          name: `github-main-${actualSha}`,
+          version: "0.0.41",
+          project_id: PROJECT_ID,
+        });
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname.endsWith(`/releases/${RELEASE_ID}/versions`)
+      ) {
+        return Response.json({
+          data: [{
+            path: "app.ts",
+            data: JSON.stringify({ body: releaseSourceContent, path: "app.ts" }),
+          }],
+          page_info: {},
+        });
+      }
+      return Response.json({ message: "not found" }, { status: 404 });
+    };
+
+    const runDeploy = () =>
+      deployCommand({
+        branch: "main",
+        env: "production",
+        releaseName: `github-main-${actualSha}`,
+        dryRun: false,
+        force: true,
+        quiet: true,
+      });
+
+    for (const jsonMode of [false, true]) {
+      setJsonMode(jsonMode);
+      requests.length = 0;
+      environmentReads = 0;
+
+      await withMockFetch(handleRequest, runDeploy);
+
+      assertEquals(environmentReads, 2);
+      assertEquals(requests, [
+        "GET /api/projects/my-project",
+        `GET /api/projects/${PROJECT_ID}/environments`,
+        `POST /api/projects/${PROJECT_ID}/releases`,
+        `GET /api/projects/${PROJECT_ID}/releases/${RELEASE_ID}`,
+        `GET /api/projects/${PROJECT_ID}/releases/${RELEASE_ID}/versions`,
+        `POST /api/projects/${PROJECT_ID}/deployments`,
+        `GET /api/projects/${PROJECT_ID}/deployments/${DEPLOYMENT_ID}`,
+        `GET /api/projects/${PROJECT_ID}/environments`,
+      ]);
+    }
+
+    setJsonMode(false);
+    releaseSourceContent = "export const value = 2;\n";
+    requests.length = 0;
+    environmentReads = 0;
+
+    await assertRejects(
+      () => withMockFetch(handleRequest, runDeploy),
+      Error,
+      "does not match pushed commit",
+    );
+    assertEquals(environmentReads, 1);
+    assertEquals(requests, [
+      "GET /api/projects/my-project",
+      `GET /api/projects/${PROJECT_ID}/environments`,
+      `POST /api/projects/${PROJECT_ID}/releases`,
+      `GET /api/projects/${PROJECT_ID}/releases/${RELEASE_ID}`,
+      `GET /api/projects/${PROJECT_ID}/releases/${RELEASE_ID}/versions`,
+    ]);
+  } finally {
+    Deno.chdir(originalCwd);
+    envKeys.forEach((key, index) => {
+      const value = savedEnv[index];
+      if (value === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, value);
+    });
+    _resetEnvironmentConfig();
+    setJsonMode(false);
+    await Deno.remove(projectDir, { recursive: true });
+  }
+});

--- a/cli/commands/deploy/command.test.ts
+++ b/cli/commands/deploy/command.test.ts
@@ -4,17 +4,25 @@ import "#veryfront/schemas/_test-setup.ts";
  * @module cli/commands/deploy.test
  */
 
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  assertProjectOwnership,
   createDeployment,
   createRelease,
   DeployArgsSchema,
+  getDeployment,
   getEnvironmentByName,
+  getProject,
+  getRelease,
+  getReleaseSourceDigest,
   parseDeployArgs,
+  verifyDeployment,
+  verifyReleaseSource,
 } from "./index.ts";
 import type { ApiClient } from "#cli/shared/config";
 import type { ParsedArgs } from "#cli/shared/types";
+import { computeSourceDigest } from "../../shared/deployment-provenance.ts";
 
 type MockClientOverrides = Partial<{
   get: (path: string, params?: Record<string, string>) => Promise<unknown>;
@@ -316,8 +324,8 @@ describe("createDeployment", () => {
         capturedBody = body;
         return Promise.resolve({
           id: "deploy-123",
-          release: "rel-456",
-          environment: "env-789",
+          release_id: "rel-456",
+          environment_id: "env-789",
         });
       },
     });
@@ -326,6 +334,21 @@ describe("createDeployment", () => {
     assertEquals(capturedUrl, "/projects/my-project/deployments");
     assertEquals(capturedBody, { release_id: "rel-456", environment_id: "env-789" });
     assertEquals(deployment.id, "deploy-123");
+  });
+
+  it("normalizes legacy nested release and environment references", async () => {
+    const mockClient = createMockClient({
+      post: () =>
+        Promise.resolve({
+          id: "deploy-123",
+          release: { id: "rel-456" },
+          environment: { id: "env-789" },
+        }),
+    });
+
+    const deployment = await createDeployment(mockClient, "my-project", "rel-456", "env-789");
+    assertEquals(deployment.release_id, "rel-456");
+    assertEquals(deployment.environment_id, "env-789");
   });
 });
 
@@ -362,5 +385,309 @@ describe("createDeployment - error handling", () => {
       createDeployment(mockClient, "my-project", "rel-123", "invalid-env")
     );
     assertEquals(message, "Environment not found");
+  });
+});
+
+describe("project ownership", () => {
+  it("accepts a project-scoped response without redundant ownership metadata", () => {
+    assertProjectOwnership("Environment", { id: "env-1" }, "project-1");
+  });
+
+  it("rejects ownership metadata for another project", async () => {
+    await assertRejects(
+      () =>
+        Promise.resolve().then(() =>
+          assertProjectOwnership(
+            "Environment",
+            { id: "env-1", project_id: "project-2" },
+            "project-1",
+          )
+        ),
+      Error,
+      "does not belong to resolved project project-1",
+    );
+  });
+});
+
+describe("release source verification", () => {
+  it("hashes the body from the API's legacy version data envelope", async () => {
+    const body = "export const value = 1;\n";
+    const expectedDigest = await computeSourceDigest([{ path: "app.ts", content: body }]);
+    const mockClient = createMockClient({
+      get: () =>
+        Promise.resolve({
+          data: [{
+            path: "app.ts",
+            data: JSON.stringify({ body, path: "app.ts", language: "typescript" }),
+          }],
+          page_info: {},
+        }),
+    });
+
+    assertEquals(
+      await getReleaseSourceDigest(mockClient, "project-1", "release-1"),
+      expectedDigest,
+    );
+  });
+
+  it("rejects a release whose source differs from the pushed commit", async () => {
+    const expectedDigest = await computeSourceDigest([
+      { path: "app.ts", content: "commit A\n" },
+    ]);
+    const mockClient = createMockClient({
+      get: (path) => {
+        if (path.endsWith("/versions")) {
+          return Promise.resolve({
+            data: [{
+              path: "app.ts",
+              data: JSON.stringify({ body: "commit B\n", path: "app.ts" }),
+            }],
+            page_info: {},
+          });
+        }
+        return Promise.resolve({
+          id: "release-1",
+          name: "github-main-90719c01",
+          version: "0.0.41",
+          project_id: "project-1",
+        });
+      },
+    });
+
+    await assertRejects(
+      () =>
+        verifyReleaseSource(mockClient, "project-1", {
+          projectId: "project-1",
+          releaseId: "release-1",
+          commitSha: "90719c01c1dded95a6b6df46b0fb17ea37d3ace8",
+          sourceDigest: expectedDigest,
+        }),
+      Error,
+      "does not match pushed commit",
+    );
+  });
+});
+
+describe("deployment verification", () => {
+  const projectId = "550e8400-e29b-41d4-a716-446655440000";
+  const environmentId = "660e8400-e29b-41d4-a716-446655440000";
+  const releaseId = "770e8400-e29b-41d4-a716-446655440000";
+  const deploymentId = "880e8400-e29b-41d4-a716-446655440000";
+
+  it("loads canonical project, release, and deployment records", async () => {
+    const requests: string[] = [];
+    const mockClient = createMockClient({
+      get: (path) => {
+        requests.push(path);
+        if (path === "/projects/my-project") {
+          return Promise.resolve({ id: projectId, slug: "my-project" });
+        }
+        if (path.endsWith(`/releases/${releaseId}`)) {
+          return Promise.resolve({
+            id: releaseId,
+            name: "github-main-90719c01",
+            version: "0.0.41",
+            project_id: projectId,
+          });
+        }
+        return Promise.resolve({
+          id: deploymentId,
+          release_id: releaseId,
+          environment_id: environmentId,
+        });
+      },
+    });
+
+    assertEquals(await getProject(mockClient, "my-project"), {
+      id: projectId,
+      slug: "my-project",
+    });
+    assertEquals((await getRelease(mockClient, "my-project", releaseId)).version, "0.0.41");
+    assertEquals(
+      (await getDeployment(mockClient, "my-project", deploymentId)).environment_id,
+      environmentId,
+    );
+    assertEquals(requests, [
+      "/projects/my-project",
+      `/projects/my-project/releases/${releaseId}`,
+      `/projects/my-project/deployments/${deploymentId}`,
+    ]);
+  });
+
+  it("returns evidence only after the environment pointer advances", async () => {
+    let environmentReads = 0;
+    const sourceDigest = await computeSourceDigest([
+      { path: "app.ts", content: "export const value = 1;\n" },
+    ]);
+    const mockClient = createMockClient({
+      get: (path) => {
+        if (path.endsWith(`/deployments/${deploymentId}`)) {
+          return Promise.resolve({
+            id: deploymentId,
+            release_id: releaseId,
+            environment_id: environmentId,
+          });
+        }
+        if (path.endsWith(`/releases/${releaseId}`)) {
+          return Promise.resolve({
+            id: releaseId,
+            name: "github-main-90719c01",
+            version: "0.0.41",
+          });
+        }
+        if (path.endsWith(`/releases/${releaseId}/versions`)) {
+          return Promise.resolve({
+            data: [{ path: "app.ts", content: "export const value = 1;\n" }],
+            page_info: {},
+          });
+        }
+        environmentReads++;
+        return Promise.resolve({
+          data: [{
+            id: environmentId,
+            name: "production",
+            protected: true,
+            deployment: environmentReads === 1
+              ? {
+                id: "old-deployment",
+                release: { id: "old-release", name: "previous" },
+              }
+              : {
+                id: deploymentId,
+                release: { id: releaseId, name: "github-main-90719c01" },
+              },
+          }],
+        });
+      },
+    });
+
+    const result = await verifyDeployment(mockClient, "my-project", {
+      projectId,
+      projectSlug: "my-project",
+      environmentId,
+      environmentName: "production",
+      releaseId,
+      deploymentId,
+      commitSha: "90719c01c1dded95a6b6df46b0fb17ea37d3ace8",
+      sourceDigest,
+    }, { attempts: 2, delayMs: 0 });
+
+    assertEquals(result, {
+      projectId,
+      projectSlug: "my-project",
+      environmentId,
+      environmentName: "production",
+      releaseId,
+      releaseVersion: "0.0.41",
+      deploymentId,
+      commitSha: "90719c01c1dded95a6b6df46b0fb17ea37d3ace8",
+      sourceDigest,
+    });
+    assertEquals(environmentReads, 2);
+  });
+
+  it("fails when production never advances to the created deployment", async () => {
+    const sourceDigest = await computeSourceDigest([]);
+    const mockClient = createMockClient({
+      get: (path) => {
+        if (path.endsWith(`/deployments/${deploymentId}`)) {
+          return Promise.resolve({
+            id: deploymentId,
+            release_id: releaseId,
+            environment_id: environmentId,
+          });
+        }
+        if (path.endsWith(`/releases/${releaseId}`)) {
+          return Promise.resolve({
+            id: releaseId,
+            name: "github-main-90719c01",
+            version: "0.0.41",
+            project_id: projectId,
+          });
+        }
+        if (path.endsWith(`/releases/${releaseId}/versions`)) {
+          return Promise.resolve({ data: [], page_info: {} });
+        }
+        return Promise.resolve({
+          data: [{
+            id: environmentId,
+            name: "production",
+            project_id: projectId,
+            protected: true,
+            deployment: {
+              id: "old-deployment",
+              release: { id: "old-release", name: "previous" },
+            },
+          }],
+        });
+      },
+    });
+
+    await assertRejects(
+      () =>
+        verifyDeployment(mockClient, "my-project", {
+          projectId,
+          projectSlug: "my-project",
+          environmentId,
+          environmentName: "production",
+          releaseId,
+          deploymentId,
+          commitSha: "90719c01c1dded95a6b6df46b0fb17ea37d3ace8",
+          sourceDigest,
+        }, { attempts: 2, delayMs: 0 }),
+      Error,
+      "still points to deployment old-deployment",
+    );
+  });
+
+  it("fails when the release snapshot differs from the pushed commit", async () => {
+    const sourceDigest = await computeSourceDigest([
+      { path: "app.ts", content: "commit A\n" },
+    ]);
+    const mockClient = createMockClient({
+      get: (path) => {
+        if (path.endsWith(`/deployments/${deploymentId}`)) {
+          return Promise.resolve({
+            id: deploymentId,
+            release: { id: releaseId },
+            environment: { id: environmentId },
+          });
+        }
+        if (path.endsWith(`/releases/${releaseId}`)) {
+          return Promise.resolve({
+            id: releaseId,
+            name: "github-main-90719c01",
+            version: "0.0.41",
+            project: projectId,
+          });
+        }
+        if (path.endsWith(`/releases/${releaseId}/versions`)) {
+          return Promise.resolve({
+            data: [{
+              path: "app.ts",
+              data: JSON.stringify({ body: "commit B\n", path: "app.ts" }),
+            }],
+            page_info: {},
+          });
+        }
+        return Promise.resolve({ data: [] });
+      },
+    });
+
+    await assertRejects(
+      () =>
+        verifyDeployment(mockClient, "my-project", {
+          projectId,
+          projectSlug: "my-project",
+          environmentId,
+          environmentName: "production",
+          releaseId,
+          deploymentId,
+          commitSha: "90719c01c1dded95a6b6df46b0fb17ea37d3ace8",
+          sourceDigest,
+        }, { attempts: 1, delayMs: 0 }),
+      Error,
+      "does not match pushed commit",
+    );
   });
 });

--- a/cli/commands/deploy/command.ts
+++ b/cli/commands/deploy/command.ts
@@ -15,6 +15,14 @@ import { CommonArgs, createArgParser } from "#cli/shared/args";
 import { confirmPrompt, logInfo, logSuccess } from "#cli/utils";
 import { createNoopSpinner, createSpinner, muted } from "#cli/ui";
 import { isJsonMode, streamJsonLine } from "../../shared/json-output.ts";
+import {
+  computeSourceDigest,
+  getProjectTarget,
+  normalizeControlPlane,
+  readPushReceipt,
+  resolveGitSource,
+  validatePushReceipt,
+} from "../../shared/deployment-provenance.ts";
 
 /**
  * Schema factory for deploy command arguments
@@ -53,10 +61,22 @@ export const parseDeployArgs = createArgParser(DeployArgsSchema, {
 /**
  * Environment from the API
  */
+interface EnvironmentDeployment {
+  id: string;
+  release: {
+    id: string;
+    name: string | null;
+  } | null;
+}
+
 interface Environment {
   id: string;
   name: string;
   protected: boolean;
+  project_id?: string;
+  project?: string | { id: string };
+  projectId?: string;
+  deployment?: EnvironmentDeployment | null;
 }
 
 /**
@@ -65,7 +85,10 @@ interface Environment {
 interface Release {
   id: string;
   name: string;
-  version: string;
+  version: string | null;
+  project_id?: string;
+  project?: string | { id: string };
+  projectId?: string;
   export_status: string;
   build_status: string;
   deploy_status: string;
@@ -74,10 +97,64 @@ interface Release {
 /**
  * Deployment from the API
  */
+interface DeploymentResponse {
+  id: string;
+  release_id?: string;
+  environment_id?: string;
+  release?: string | { id: string };
+  environment?: string | { id: string };
+}
+
 interface Deployment {
   id: string;
-  release: string;
-  environment: string;
+  release_id: string;
+  environment_id: string;
+}
+
+export interface DeploymentVerification {
+  projectId: string;
+  projectSlug: string;
+  environmentId: string;
+  environmentName: string;
+  releaseId: string;
+  releaseVersion: string;
+  deploymentId: string;
+  commitSha: string;
+  sourceDigest: string;
+}
+
+export interface ReleaseSourceVerification {
+  projectId: string;
+  releaseId: string;
+  releaseVersion: string;
+  commitSha: string;
+  sourceDigest: string;
+}
+
+interface ReleaseSourceExpectation {
+  projectId: string;
+  releaseId: string;
+  commitSha: string;
+  sourceDigest: string;
+  releaseName?: string;
+}
+
+interface DeploymentExpectation {
+  projectId: string;
+  projectSlug: string;
+  environmentId: string;
+  environmentName: string;
+  releaseId: string;
+  deploymentId: string;
+  commitSha: string;
+  sourceDigest: string;
+  releaseName?: string;
+}
+
+interface DeploymentVerificationOptions {
+  attempts?: number;
+  delayMs?: number;
+  verifiedRelease?: ReleaseSourceVerification;
 }
 
 /**
@@ -88,6 +165,92 @@ interface ListEnvironmentsResponse {
   page_info?: {
     next?: string;
   };
+}
+
+interface ReleaseFileVersion {
+  path: string;
+  content?: unknown;
+  data?: unknown;
+}
+
+interface ListReleaseVersionsResponse {
+  data: ReleaseFileVersion[];
+  page_info?: {
+    next?: string;
+  };
+}
+
+function referenceId(value: string | { id: string } | undefined): string | undefined {
+  return typeof value === "string" ? value : value?.id;
+}
+
+function normalizeEnvironment(environment: Environment): Environment {
+  const projectId = environment.project_id ?? environment.projectId ??
+    referenceId(environment.project);
+  return projectId ? { ...environment, project_id: projectId } : environment;
+}
+
+function normalizeRelease(release: Release): Release {
+  const projectId = release.project_id ?? release.projectId ?? referenceId(release.project);
+  return projectId ? { ...release, project_id: projectId } : release;
+}
+
+function normalizeDeployment(deployment: DeploymentResponse): Deployment {
+  const releaseId = deployment.release_id ?? referenceId(deployment.release);
+  const environmentId = deployment.environment_id ?? referenceId(deployment.environment);
+  if (!releaseId || !environmentId) {
+    throw new Error(`Deployment ${deployment.id} response is missing release or environment IDs`);
+  }
+  return {
+    id: deployment.id,
+    release_id: releaseId,
+    environment_id: environmentId,
+  };
+}
+
+export function assertProjectOwnership(
+  resourceType: "Environment" | "Release",
+  resource: { id: string; project_id?: string },
+  projectId: string,
+): void {
+  if (resource.project_id && resource.project_id !== projectId) {
+    throw new Error(
+      `${resourceType} ${resource.id} does not belong to resolved project ${projectId}`,
+    );
+  }
+}
+
+function getReleaseFileContent(file: ReleaseFileVersion): string {
+  const content = typeof file.content === "string" ? file.content : undefined;
+  let legacyBody: string | undefined;
+
+  if (typeof file.data === "string") {
+    let envelope: unknown;
+    try {
+      envelope = JSON.parse(file.data);
+    } catch {
+      throw new Error(`Release file ${file.path} has invalid version data`);
+    }
+    if (typeof envelope !== "object" || envelope === null || Array.isArray(envelope)) {
+      throw new Error(`Release file ${file.path} has invalid version data`);
+    }
+
+    const record = envelope as Record<string, unknown>;
+    if (typeof record.body !== "string") {
+      throw new Error(`Release file ${file.path} version data has no body`);
+    }
+    if (typeof record.path === "string" && record.path !== file.path) {
+      throw new Error(`Release file ${file.path} version data references ${record.path}`);
+    }
+    legacyBody = record.body;
+  }
+
+  if (content !== undefined && legacyBody !== undefined && content !== legacyBody) {
+    throw new Error(`Release file ${file.path} has conflicting content fields`);
+  }
+  const value = content ?? legacyBody;
+  if (value === undefined) throw new Error(`Release file ${file.path} has no content`);
+  return value;
 }
 
 /**
@@ -110,7 +273,7 @@ export async function getEnvironmentByName(
     );
 
     const found = response.data.find((e) => e.name === name);
-    if (found) return found;
+    if (found) return normalizeEnvironment(found);
 
     cursor = response.page_info?.next;
   } while (cursor);
@@ -118,10 +281,61 @@ export async function getEnvironmentByName(
   return null;
 }
 
+export function getProject(client: ApiClient, projectReference: string) {
+  return getProjectTarget(client, projectReference);
+}
+
+export async function getRelease(
+  client: ApiClient,
+  projectReference: string,
+  releaseId: string,
+): Promise<Release> {
+  const release = await client.get<Release>(
+    `/projects/${projectReference}/releases/${releaseId}`,
+  );
+  return normalizeRelease(release);
+}
+
+export async function getDeployment(
+  client: ApiClient,
+  projectReference: string,
+  deploymentId: string,
+): Promise<Deployment> {
+  const deployment = await client.get<DeploymentResponse>(
+    `/projects/${projectReference}/deployments/${deploymentId}`,
+  );
+  return normalizeDeployment(deployment);
+}
+
+export async function getReleaseSourceDigest(
+  client: ApiClient,
+  projectReference: string,
+  releaseId: string,
+): Promise<string> {
+  const files: ReleaseFileVersion[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const params: Record<string, string> = { limit: "100" };
+    if (cursor) params.cursor = cursor;
+    const response = await client.get<ListReleaseVersionsResponse>(
+      `/projects/${projectReference}/releases/${releaseId}/versions`,
+      params,
+    );
+    files.push(...response.data);
+    cursor = response.page_info?.next;
+  } while (cursor);
+
+  return computeSourceDigest(files.map((file) => ({
+    path: file.path,
+    content: getReleaseFileContent(file),
+  })));
+}
+
 /**
  * Create a new release
  */
-export function createRelease(
+export async function createRelease(
   client: ApiClient,
   projectSlug: string,
   options?: { name?: string; branch?: string },
@@ -130,22 +344,166 @@ export function createRelease(
   if (options?.name) body.name = options.name;
   if (options?.branch) body.branch_reference = options.branch;
 
-  return client.post<Release>(`/projects/${projectSlug}/releases`, body);
+  return normalizeRelease(await client.post<Release>(`/projects/${projectSlug}/releases`, body));
 }
 
 /**
  * Create a new deployment
  */
-export function createDeployment(
+export async function createDeployment(
   client: ApiClient,
   projectSlug: string,
   releaseId: string,
   environmentId: string,
 ): Promise<Deployment> {
-  return client.post<Deployment>(`/projects/${projectSlug}/deployments`, {
-    release_id: releaseId,
-    environment_id: environmentId,
+  const deployment = await client.post<DeploymentResponse>(
+    `/projects/${projectSlug}/deployments`,
+    {
+      release_id: releaseId,
+      environment_id: environmentId,
+    },
+  );
+  return normalizeDeployment(deployment);
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function verifyReleaseSource(
+  client: ApiClient,
+  projectReference: string,
+  expected: ReleaseSourceExpectation,
+): Promise<ReleaseSourceVerification> {
+  const release = await getRelease(client, projectReference, expected.releaseId);
+  if (release.id !== expected.releaseId) {
+    throw new Error(`Release read-back returned ${release.id}; expected ${expected.releaseId}`);
+  }
+  assertProjectOwnership("Release", release, expected.projectId);
+  if (expected.releaseName && release.name !== expected.releaseName) {
+    throw new Error(`Release ${expected.releaseId} no longer matches the created release name`);
+  }
+  if (!release.version) {
+    throw new Error(`Release ${expected.releaseId} has no version`);
+  }
+
+  const sourceDigest = await getReleaseSourceDigest(client, projectReference, expected.releaseId);
+  if (sourceDigest !== expected.sourceDigest) {
+    throw new Error(
+      `Release ${expected.releaseId} source does not match pushed commit ${expected.commitSha}`,
+    );
+  }
+
+  return {
+    projectId: expected.projectId,
+    releaseId: expected.releaseId,
+    releaseVersion: release.version,
+    commitSha: expected.commitSha,
+    sourceDigest,
+  };
+}
+
+export async function verifyDeployment(
+  client: ApiClient,
+  projectReference: string,
+  expected: DeploymentExpectation,
+  options: DeploymentVerificationOptions = {},
+): Promise<DeploymentVerification> {
+  const deployment = await getDeployment(client, projectReference, expected.deploymentId);
+  if (
+    deployment.id !== expected.deploymentId || deployment.release_id !== expected.releaseId ||
+    deployment.environment_id !== expected.environmentId
+  ) {
+    throw new Error(
+      `Deployment ${expected.deploymentId} does not reference release ${expected.releaseId} and environment ${expected.environmentId}`,
+    );
+  }
+
+  const verifiedRelease = options.verifiedRelease ?? await verifyReleaseSource(
+    client,
+    projectReference,
+    expected,
+  );
+  if (
+    verifiedRelease.projectId !== expected.projectId ||
+    verifiedRelease.releaseId !== expected.releaseId ||
+    verifiedRelease.commitSha !== expected.commitSha ||
+    verifiedRelease.sourceDigest !== expected.sourceDigest
+  ) {
+    throw new Error(
+      `Verified release source does not match deployment ${expected.deploymentId}`,
+    );
+  }
+
+  const attempts = Math.max(1, options.attempts ?? 20);
+  const delayMs = Math.max(0, options.delayMs ?? 500);
+  let observedEnvironment: Environment | null = null;
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    observedEnvironment = await getEnvironmentByName(
+      client,
+      projectReference,
+      expected.environmentName,
+    );
+
+    if (observedEnvironment) {
+      assertProjectOwnership("Environment", observedEnvironment, expected.projectId);
+    }
+
+    if (
+      observedEnvironment?.id === expected.environmentId &&
+      observedEnvironment.deployment?.id === expected.deploymentId &&
+      observedEnvironment.deployment.release?.id === expected.releaseId
+    ) {
+      return {
+        projectId: expected.projectId,
+        projectSlug: expected.projectSlug,
+        environmentId: expected.environmentId,
+        environmentName: expected.environmentName,
+        releaseId: expected.releaseId,
+        releaseVersion: verifiedRelease.releaseVersion,
+        deploymentId: expected.deploymentId,
+        commitSha: expected.commitSha,
+        sourceDigest: verifiedRelease.sourceDigest,
+      };
+    }
+
+    if (attempt < attempts - 1 && delayMs > 0) await wait(delayMs);
+  }
+
+  const observedDeploymentId = observedEnvironment?.deployment?.id ?? "none";
+  const observedReleaseId = observedEnvironment?.deployment?.release?.id ?? "none";
+  throw new Error(
+    `Deployment verification failed: environment "${expected.environmentName}" still points to deployment ${observedDeploymentId} / release ${observedReleaseId}; expected deployment ${expected.deploymentId} / release ${expected.releaseId}`,
+  );
+}
+
+export async function resolvePushedSource(input: {
+  projectDir: string;
+  controlPlane: string;
+  projectId: string;
+  projectSlug: string;
+  branch: string;
+  requireClean: boolean;
+}): Promise<{ commitSha: string; sourceDigest: string }> {
+  const receipt = await readPushReceipt(input.projectDir);
+  if (!receipt) {
+    throw new Error(
+      `No verified push found for branch "${input.branch}". Run veryfront push --branch ${input.branch} before deploying.`,
+    );
+  }
+
+  const gitSource = await resolveGitSource(input.projectDir);
+  const commitSha = validatePushReceipt(receipt, {
+    controlPlane: input.controlPlane,
+    projectId: input.projectId,
+    projectSlug: input.projectSlug,
+    branch: input.branch,
+    commitSha: gitSource.commitSha,
+    clean: gitSource.clean,
+    requireClean: input.requireClean,
   });
+  return { commitSha, sourceDigest: receipt.sourceDigest };
 }
 
 /**
@@ -158,24 +516,49 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
     return deployCommandJson(options);
   }
 
+  const projectDir = cwd();
   let spinner = quiet ? createNoopSpinner() : createSpinner("Resolving configuration...");
 
-  const config = await resolveConfigWithAuth(cwd());
+  const config = await resolveConfigWithAuth(projectDir);
   const client = createApiClient(config);
+
+  spinner.update("Resolving project...");
+  const project = await getProject(client, config.projectSlug);
 
   spinner.update(`Looking up environment "${env}"...`);
 
-  const environment = await getEnvironmentByName(client, config.projectSlug, env);
+  const environment = await getEnvironmentByName(client, project.id, env);
   if (!environment) {
     spinner.stop();
     throw new Error(`Environment "${env}" not found`);
   }
 
-  spinner.stop();
+  try {
+    assertProjectOwnership("Environment", environment, project.id);
+  } catch (error) {
+    spinner.stop();
+    throw error;
+  }
 
   if (dryRun) {
+    spinner.stop();
     if (!quiet) logInfo(`Would create release from "${branch}" and deploy to "${env}"`);
     return;
+  }
+
+  spinner.update("Verifying pushed source...");
+  let source: { commitSha: string; sourceDigest: string };
+  try {
+    source = await resolvePushedSource({
+      projectDir,
+      controlPlane: config.apiUrl,
+      projectId: project.id,
+      projectSlug: project.slug,
+      branch,
+      requireClean: env === "production",
+    });
+  } finally {
+    spinner.stop();
   }
 
   if (!force) {
@@ -191,19 +574,55 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
 
   spinner = quiet ? createNoopSpinner() : createSpinner(`Creating release from "${branch}"...`);
 
-  const release = await createRelease(client, config.projectSlug, { name: releaseName, branch });
+  let release: Release;
+  let deployment: Deployment;
+  let verification: DeploymentVerification;
+  try {
+    release = await createRelease(client, project.id, { name: releaseName, branch });
+    if (!release.version) throw new Error(`Release ${release.id} has no version`);
 
-  spinner.update(`Deploying ${release.version} to ${env}...`);
+    spinner.update(`Verifying ${release.version} source...`);
+    const verifiedRelease = await verifyReleaseSource(client, project.id, {
+      projectId: project.id,
+      releaseId: release.id,
+      releaseName: release.name,
+      commitSha: source.commitSha,
+      sourceDigest: source.sourceDigest,
+    });
 
-  await createDeployment(client, config.projectSlug, release.id, environment.id);
+    spinner.update(`Deploying ${release.version} to ${env}...`);
+    deployment = await createDeployment(client, project.id, release.id, environment.id);
 
-  spinner.stop();
+    spinner.update(`Verifying ${env} deployment...`);
+    verification = await verifyDeployment(client, project.id, {
+      projectId: project.id,
+      projectSlug: project.slug,
+      environmentId: environment.id,
+      environmentName: env,
+      releaseId: release.id,
+      releaseName: release.name,
+      deploymentId: deployment.id,
+      commitSha: source.commitSha,
+      sourceDigest: source.sourceDigest,
+    }, { verifiedRelease });
+    spinner.stop();
+  } catch (error) {
+    spinner.stop();
+    throw error;
+  }
 
   if (quiet) return;
 
-  logSuccess(`Deployed ${release.version} to ${env}`);
-  logInfo(`  Release: ${release.name} (${release.version})`);
-  logInfo(`  Environment: ${env}`);
+  logSuccess(`Deployed ${verification.releaseVersion} to ${env}`);
+  logInfo(`  Project: ${verification.projectSlug} (${verification.projectId})`);
+  logInfo(`  Environment: ${env} (${verification.environmentId})`);
+  logInfo(
+    `  Release: ${release.name} (${verification.releaseVersion}, ${verification.releaseId})`,
+  );
+  logInfo(`  Deployment: ${verification.deploymentId}`);
+  logInfo(`  Commit: ${verification.commitSha}`);
+  logInfo(`  Source digest: ${verification.sourceDigest}`);
+  logInfo(`  Control plane: ${normalizeControlPlane(config.apiUrl)}`);
 
   const { getPostDeployTips } = await import("../../help/tips.ts");
   console.log(getPostDeployTips());
@@ -228,12 +647,14 @@ async function deployCommandJson(options: DeployOptions): Promise<void> {
     }
 
     streamJsonLine({ type: "step", name: "resolve-config", status: "started" });
-    const config = await resolveConfigWithAuth(cwd());
+    const projectDir = cwd();
+    const config = await resolveConfigWithAuth(projectDir);
     const client = createApiClient(config);
     streamJsonLine({ type: "step", name: "resolve-config", status: "completed" });
 
-    streamJsonLine({ type: "step", name: "resolve-environment", status: "started" });
-    const environment = await getEnvironmentByName(client, config.projectSlug, env);
+    streamJsonLine({ type: "step", name: "resolve-target", status: "started" });
+    const project = await getProject(client, config.projectSlug);
+    const environment = await getEnvironmentByName(client, project.id, env);
     if (!environment) {
       streamJsonLine({
         type: "result",
@@ -244,34 +665,95 @@ async function deployCommandJson(options: DeployOptions): Promise<void> {
       exit(1);
       return;
     }
-    streamJsonLine({ type: "step", name: "resolve-environment", status: "completed" });
+    assertProjectOwnership("Environment", environment, project.id);
+    streamJsonLine({ type: "step", name: "resolve-target", status: "completed" });
 
     if (dryRun) {
       streamJsonLine({
         type: "result",
         success: true,
-        data: { dryRun: true, branch, environment: env },
+        data: {
+          dryRun: true,
+          branch,
+          projectId: project.id,
+          projectSlug: project.slug,
+          environment: env,
+          environmentId: environment.id,
+          controlPlane: normalizeControlPlane(config.apiUrl),
+        },
       });
       return;
     }
 
+    streamJsonLine({ type: "step", name: "verify-source", status: "started" });
+    const source = await resolvePushedSource({
+      projectDir,
+      controlPlane: config.apiUrl,
+      projectId: project.id,
+      projectSlug: project.slug,
+      branch,
+      requireClean: env === "production",
+    });
+    streamJsonLine({ type: "step", name: "verify-source", status: "completed" });
+
     streamJsonLine({ type: "step", name: "create-release", status: "started" });
-    const release = await createRelease(client, config.projectSlug, {
+    const release = await createRelease(client, project.id, {
       name: releaseName,
       branch,
     });
+    if (!release.version) throw new Error(`Release ${release.id} has no version`);
     streamJsonLine({ type: "step", name: "create-release", status: "completed" });
 
+    streamJsonLine({ type: "step", name: "verify-release-source", status: "started" });
+    const verifiedRelease = await verifyReleaseSource(client, project.id, {
+      projectId: project.id,
+      releaseId: release.id,
+      releaseName: release.name,
+      commitSha: source.commitSha,
+      sourceDigest: source.sourceDigest,
+    });
+    streamJsonLine({ type: "step", name: "verify-release-source", status: "completed" });
+
     streamJsonLine({ type: "step", name: "deploy", status: "started" });
-    await createDeployment(client, config.projectSlug, release.id, environment.id);
+    const deployment = await createDeployment(
+      client,
+      project.id,
+      release.id,
+      environment.id,
+    );
     streamJsonLine({ type: "step", name: "deploy", status: "completed" });
+
+    streamJsonLine({ type: "step", name: "verify-deployment", status: "started" });
+    const verification = await verifyDeployment(client, project.id, {
+      projectId: project.id,
+      projectSlug: project.slug,
+      environmentId: environment.id,
+      environmentName: env,
+      releaseId: release.id,
+      releaseName: release.name,
+      deploymentId: deployment.id,
+      commitSha: source.commitSha,
+      sourceDigest: source.sourceDigest,
+    }, { verifiedRelease });
+    streamJsonLine({ type: "step", name: "verify-deployment", status: "completed" });
 
     streamJsonLine({
       type: "result",
       success: true,
       data: {
-        release: { id: release.id, name: release.name, version: release.version },
+        projectId: verification.projectId,
+        projectSlug: verification.projectSlug,
+        release: {
+          id: verification.releaseId,
+          name: release.name,
+          version: verification.releaseVersion,
+        },
         environment: env,
+        environmentId: verification.environmentId,
+        deploymentId: verification.deploymentId,
+        commitSha: verification.commitSha,
+        sourceDigest: verification.sourceDigest,
+        controlPlane: normalizeControlPlane(config.apiUrl),
         branch,
       },
     });

--- a/cli/commands/deploy/deploy.integration.test.ts
+++ b/cli/commands/deploy/deploy.integration.test.ts
@@ -83,8 +83,8 @@ describe("deploy command integration", () => {
 
       assertExists(deployment, "Deployment should be created");
       assertExists(deployment.id, "Deployment should have an id");
-      assertExists(deployment.release, "Deployment should reference release");
-      assertExists(deployment.environment, "Deployment should reference environment");
+      assertEquals(deployment.release_id, testReleaseId);
+      assertEquals(deployment.environment_id, env.id);
     });
   });
 });

--- a/cli/commands/deploy/index.ts
+++ b/cli/commands/deploy/index.ts
@@ -3,12 +3,24 @@
  */
 
 export {
+  assertProjectOwnership,
   createDeployment,
   createRelease,
   DeployArgsSchema,
   deployCommand,
+  getDeployment,
   getEnvironmentByName,
+  getProject,
+  getRelease,
+  getReleaseSourceDigest,
   parseDeployArgs,
+  resolvePushedSource,
+  verifyDeployment,
+  verifyReleaseSource,
 } from "./command.ts";
-export type { DeployOptions } from "./command.ts";
+export type {
+  DeploymentVerification,
+  DeployOptions,
+  ReleaseSourceVerification,
+} from "./command.ts";
 export { handleDeployCommand } from "./handler.ts";

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -23,7 +23,7 @@ import {
   uploadFiles,
   type UploadOp,
 } from "./command.ts";
-import type { ApiClient } from "#cli/shared/config";
+import { type ApiClient, resolveConfig } from "#cli/shared/config";
 import { createDefaultIgnoreChecker } from "../../sync/ignore.ts";
 import { readPushReceipt } from "../../shared/deployment-provenance.ts";
 
@@ -459,25 +459,70 @@ describe("push receipt source snapshot", () => {
     }
   });
 
-  it("uploads the persisted slug when first-project reservation renames it", async () => {
+  it("marks an uploaded Git-ignored source as unclean", async () => {
+    await withGitProject(async ({ projectDir, runGit }) => {
+      await Deno.writeTextFile(`${projectDir}/.gitignore`, "ignored.ts\n");
+      await runGit("add", ".gitignore");
+      await runGit("commit", "--quiet", "-m", "ignore generated source");
+      await Deno.writeTextFile(`${projectDir}/ignored.ts`, "export const ignored = true;\n");
+      assertEquals(await runGit("status", "--porcelain=v1", "--untracked-files=all"), "");
+
+      const snapshot = await capturePushSourceSnapshot(
+        projectDir,
+        createDefaultIgnoreChecker(),
+      );
+
+      assertEquals(snapshot.files.some((file) => file.path === "ignored.ts"), true);
+      assertEquals(snapshot.gitSource.clean, false);
+    });
+  });
+
+  it("recognizes tracked source paths containing newlines", async () => {
+    if (Deno.build.os === "windows") return;
+
+    await withGitProject(async ({ projectDir, runGit }) => {
+      const path = "line\nbreak.ts";
+      await Deno.writeTextFile(`${projectDir}/${path}`, "export const tracked = true;\n");
+      await runGit("add", path);
+      await runGit("commit", "--quiet", "-m", "add unusual source path");
+
+      const snapshot = await capturePushSourceSnapshot(
+        projectDir,
+        createDefaultIgnoreChecker(),
+      );
+
+      assertEquals(snapshot.files.some((file) => file.path === path), true);
+      assertEquals(snapshot.gitSource.clean, true);
+    });
+  });
+
+  it("persists a renamed inferred slug for later push and deploy commands", async () => {
     const originalFetch = globalThis.fetch;
     const envKeys = [
       "VERYFRONT_API_TOKEN",
       "VERYFRONT_API_URL",
       "VERYFRONT_API_BASE_URL",
       "VERYFRONT_PROJECT_SLUG",
+      "TENANT_PROJECT_SLUG",
+      "VERYFRONT_PROJECT_ID",
+      "TENANT_PROJECT_ID",
     ];
     const savedEnv = envKeys.map((key) => Deno.env.get(key));
 
     await withGitProject(async ({ projectDir }) => {
       let reservedSlug = "";
+      let projectCreateRequests = 0;
       const uploaded = new Map<string, string>();
 
       try {
         Deno.env.set("VERYFRONT_API_TOKEN", "<TOKEN>");
         Deno.env.set("VERYFRONT_API_URL", "https://control.example.test");
         Deno.env.delete("VERYFRONT_API_BASE_URL");
-        Deno.env.set("VERYFRONT_PROJECT_SLUG", "my-project");
+        for (const key of envKeys.slice(3)) Deno.env.delete(key);
+        await Deno.writeTextFile(
+          `${projectDir}/package.json`,
+          `${JSON.stringify({ name: "my-project" }, null, 2)}\n`,
+        );
         _resetEnvironmentConfig();
 
         globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
@@ -488,6 +533,7 @@ describe("push receipt source snapshot", () => {
             return Response.json({ error: "not found" }, { status: 404 });
           }
           if (request.method === "POST" && url.pathname === "/projects") {
+            projectCreateRequests++;
             const body = await request.json() as { slug: string };
             if (body.slug === "my-project") {
               return Response.json({ error: "slug taken" }, { status: 409 });
@@ -529,7 +575,17 @@ describe("push receipt source snapshot", () => {
 
         const config = JSON.parse(await Deno.readTextFile(`${projectDir}/veryfront.json`));
         assertEquals(config.projectSlug, reservedSlug);
-        assertEquals([...uploaded.keys()].sort(), ["app.ts", "veryfront.json"]);
+        assertEquals((await resolveConfig(projectDir)).projectSlug, reservedSlug);
+
+        await pushCommand({
+          projectDir,
+          branch: "main",
+          force: true,
+          quiet: true,
+        });
+
+        assertEquals(projectCreateRequests, 2);
+        assertEquals([...uploaded.keys()].sort(), ["app.ts", "package.json", "veryfront.json"]);
         assertEquals(JSON.parse(uploaded.get("veryfront.json") ?? "{}").projectSlug, reservedSlug);
         assertEquals((await readPushReceipt(projectDir))?.projectSlug, reservedSlug);
       } finally {
@@ -538,6 +594,87 @@ describe("push receipt source snapshot", () => {
         _resetEnvironmentConfig();
       }
     });
+  });
+
+  it("does not reserve alternative projects for explicit slug sources", async () => {
+    const originalFetch = globalThis.fetch;
+    const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];
+    const savedEnv = envKeys.map((key) => Deno.env.get(key));
+    const requestedSlugs: string[] = [];
+
+    try {
+      Deno.env.set("VERYFRONT_API_TOKEN", "<TOKEN>");
+      Deno.env.set("VERYFRONT_API_URL", "https://control.example.test");
+      globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const url = new URL(request.url);
+        if (request.method === "GET" && url.pathname === "/projects/my-project/files") {
+          return Response.json({ error: "not found" }, { status: 404 });
+        }
+        if (request.method === "POST" && url.pathname === "/projects") {
+          requestedSlugs.push((await request.json() as { slug: string }).slug);
+          return Response.json({ error: "taken" }, { status: 409 });
+        }
+        throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+      }) as typeof fetch;
+
+      const scenarios: Array<{
+        prepare: (projectDir: string) => Promise<void>;
+        options?: { projectSlug: string };
+        message: string;
+      }> = [
+        {
+          prepare: () => {
+            Deno.env.set("VERYFRONT_PROJECT_SLUG", "my-project");
+            return Promise.resolve();
+          },
+          message: "Update or remove VERYFRONT_PROJECT_SLUG",
+        },
+        {
+          prepare: async (projectDir) => {
+            Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+            await Deno.writeTextFile(
+              `${projectDir}/veryfront.config.ts`,
+              'export default { projectSlug: "my-project" };\n',
+            );
+          },
+          message: "Update projectSlug in veryfront.config.ts",
+        },
+        {
+          prepare: () => {
+            Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+            return Promise.resolve();
+          },
+          options: { projectSlug: "my-project" },
+          message: "Use a different --project-slug value",
+        },
+      ];
+
+      for (const scenario of scenarios) {
+        await withGitProject(async ({ projectDir }) => {
+          await scenario.prepare(projectDir);
+          _resetEnvironmentConfig();
+          await assertRejects(
+            () =>
+              pushCommand({
+                projectDir,
+                branch: "main",
+                force: true,
+                quiet: true,
+                ...scenario.options,
+              }),
+            Error,
+            scenario.message,
+          );
+        });
+      }
+
+      assertEquals(requestedSlugs, ["my-project", "my-project", "my-project"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
+      _resetEnvironmentConfig();
+    }
   });
 });
 

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -11,11 +11,13 @@ import {
   assertRejects,
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import {
   capturePushSourceSnapshot,
   createBranch,
   ensureBranch,
   generateBranchName,
+  pushCommand,
   recordPushReceipt,
   resolvePushRemoteFiles,
   uploadFiles,
@@ -88,6 +90,11 @@ async function withGitProject(test: (project: GitProject) => Promise<void>): Pro
     else Deno.env.set("GITHUB_SHA", originalGithubSha);
     await Deno.remove(projectDir, { recursive: true });
   }
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) Deno.env.delete(key);
+  else Deno.env.set(key, value);
 }
 
 describe("generateBranchName", () => {
@@ -423,6 +430,113 @@ describe("push receipt source snapshot", () => {
         "Local source changed during push",
       );
       assertEquals(await readPushReceipt(projectDir), null);
+    });
+  });
+
+  it("rejects a clean tracked symlink whose target bytes are outside the commit", async () => {
+    if (Deno.build.os === "windows") return;
+
+    const externalDir = await Deno.makeTempDir();
+    try {
+      await withGitProject(async ({ projectDir, runGit }) => {
+        const targetPath = `${externalDir}/outside.ts`;
+        await Deno.writeTextFile(targetPath, "export const value = 1;\n");
+        await Deno.symlink(targetPath, `${projectDir}/linked.ts`);
+        await runGit("add", "linked.ts");
+        await runGit("commit", "--quiet", "-m", "add linked source");
+
+        await Deno.writeTextFile(targetPath, "export const value = 2;\n");
+        assertEquals(await runGit("status", "--porcelain=v1"), "");
+
+        await assertRejects(
+          () => capturePushSourceSnapshot(projectDir, createDefaultIgnoreChecker()),
+          Error,
+          "Veryfront push does not support symbolic links",
+        );
+      });
+    } finally {
+      await Deno.remove(externalDir, { recursive: true });
+    }
+  });
+
+  it("uploads the persisted slug when first-project reservation renames it", async () => {
+    const originalFetch = globalThis.fetch;
+    const envKeys = [
+      "VERYFRONT_API_TOKEN",
+      "VERYFRONT_API_URL",
+      "VERYFRONT_API_BASE_URL",
+      "VERYFRONT_PROJECT_SLUG",
+    ];
+    const savedEnv = envKeys.map((key) => Deno.env.get(key));
+
+    await withGitProject(async ({ projectDir }) => {
+      let reservedSlug = "";
+      const uploaded = new Map<string, string>();
+
+      try {
+        Deno.env.set("VERYFRONT_API_TOKEN", "<TOKEN>");
+        Deno.env.set("VERYFRONT_API_URL", "https://control.example.test");
+        Deno.env.delete("VERYFRONT_API_BASE_URL");
+        Deno.env.set("VERYFRONT_PROJECT_SLUG", "my-project");
+        _resetEnvironmentConfig();
+
+        globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          const url = new URL(request.url);
+
+          if (request.method === "GET" && url.pathname === "/projects/my-project/files") {
+            return Response.json({ error: "not found" }, { status: 404 });
+          }
+          if (request.method === "POST" && url.pathname === "/projects") {
+            const body = await request.json() as { slug: string };
+            if (body.slug === "my-project") {
+              return Response.json({ error: "slug taken" }, { status: 409 });
+            }
+            reservedSlug = body.slug;
+            return Response.json({ id: "project-123" }, { status: 201 });
+          }
+          if (
+            request.method === "GET" &&
+            url.pathname === `/projects/${reservedSlug}/files`
+          ) {
+            return Response.json({ data: [], page_info: {} });
+          }
+          if (
+            request.method === "PUT" &&
+            url.pathname.startsWith(`/projects/${reservedSlug}/files/`)
+          ) {
+            const path = decodeURIComponent(url.pathname.split("/").at(-1) ?? "");
+            const body = await request.json() as { content: string };
+            uploaded.set(path, body.content);
+            return Response.json({});
+          }
+          if (
+            request.method === "GET" &&
+            url.pathname === `/projects/${reservedSlug}`
+          ) {
+            return Response.json({ id: "project-123", slug: reservedSlug });
+          }
+
+          throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+        }) as typeof fetch;
+
+        await pushCommand({
+          projectDir,
+          branch: "main",
+          force: true,
+          quiet: true,
+        });
+
+        const config = JSON.parse(await Deno.readTextFile(`${projectDir}/veryfront.json`));
+        assertEquals(config.projectSlug, reservedSlug);
+        assertEquals([...uploaded.keys()].sort(), ["app.ts", "veryfront.json"]);
+        assertEquals(JSON.parse(uploaded.get("veryfront.json") ?? "{}").projectSlug, reservedSlug);
+        assertEquals((await readPushReceipt(projectDir))?.projectSlug, reservedSlug);
+      } finally {
+        globalThis.fetch = originalFetch;
+        envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
+        _resetEnvironmentConfig();
+      }
     });
   });
 });

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -4,17 +4,26 @@ import "#veryfront/schemas/_test-setup.ts";
  * @module cli/commands/push.test
  */
 
-import { assertEquals, assertMatch, assertRejects } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertMatch,
+  assertRejects,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  capturePushSourceSnapshot,
   createBranch,
   ensureBranch,
   generateBranchName,
+  recordPushReceipt,
   resolvePushRemoteFiles,
   uploadFiles,
   type UploadOp,
 } from "./command.ts";
 import type { ApiClient } from "#cli/shared/config";
+import { createDefaultIgnoreChecker } from "../../sync/ignore.ts";
+import { readPushReceipt } from "../../shared/deployment-provenance.ts";
 
 type MockClientOverrides = Partial<{
   get: (path: string, params?: Record<string, string>) => Promise<unknown>;
@@ -39,6 +48,46 @@ function createMockClient(overrides: MockClientOverrides = {}): ApiClient {
     patch: <T>(): Promise<T> => Promise.resolve({} as T),
     delete: <T>(): Promise<T> => Promise.resolve({} as T),
   };
+}
+
+interface GitProject {
+  projectDir: string;
+  runGit: (...args: string[]) => Promise<string>;
+}
+
+async function withGitProject(test: (project: GitProject) => Promise<void>): Promise<void> {
+  const projectDir = await Deno.makeTempDir();
+  const originalGithubSha = Deno.env.get("GITHUB_SHA");
+  const runGit = async (...args: string[]): Promise<string> => {
+    const result = await new Deno.Command("git", {
+      args,
+      cwd: projectDir,
+      clearEnv: true,
+      env: Object.fromEntries(
+        Object.entries(Deno.env.toObject()).filter(([key]) => !key.startsWith("GIT_")),
+      ),
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    const stderr = new TextDecoder().decode(result.stderr);
+    assertEquals(result.success, true, stderr);
+    return new TextDecoder().decode(result.stdout).trim();
+  };
+
+  try {
+    Deno.env.delete("GITHUB_SHA");
+    await runGit("init", "--quiet");
+    await runGit("config", "user.email", "test@veryfront.com");
+    await runGit("config", "user.name", "Veryfront Test");
+    await Deno.writeTextFile(`${projectDir}/app.ts`, "export const value = 1;\n");
+    await runGit("add", ".");
+    await runGit("commit", "--quiet", "-m", "initial");
+    await test({ projectDir, runGit });
+  } finally {
+    if (originalGithubSha === undefined) Deno.env.delete("GITHUB_SHA");
+    else Deno.env.set("GITHUB_SHA", originalGithubSha);
+    await Deno.remove(projectDir, { recursive: true });
+  }
 }
 
 describe("generateBranchName", () => {
@@ -284,6 +333,97 @@ describe("resolvePushRemoteFiles", () => {
         params: { limit: "100", sort_by: "updated_at", sort_order: "desc" },
       },
     ]);
+  });
+});
+
+describe("push receipt source snapshot", () => {
+  const config = {
+    apiUrl: "https://api.veryfront.com",
+    apiToken: "<TOKEN>",
+    projectSlug: "my-project",
+  };
+  const client = createMockClient({
+    get: () => Promise.resolve({ id: "project-123", slug: "my-project" }),
+  });
+
+  it("records the Git source captured with the uploaded files", async () => {
+    await withGitProject(async ({ projectDir }) => {
+      const ignoreChecker = createDefaultIgnoreChecker();
+      const snapshot = await capturePushSourceSnapshot(projectDir, ignoreChecker);
+
+      await recordPushReceipt(
+        client,
+        config,
+        projectDir,
+        "main",
+        snapshot,
+        ignoreChecker,
+      );
+
+      const receipt = await readPushReceipt(projectDir);
+      assertExists(receipt);
+      assertEquals(receipt.commitSha, snapshot.gitSource.commitSha);
+      assertEquals(receipt.clean, snapshot.gitSource.clean);
+      assertEquals(receipt.sourceDigest, snapshot.sourceDigest);
+    });
+  });
+
+  it("clears the receipt when source bytes change without changing Git state", async () => {
+    await withGitProject(async ({ projectDir }) => {
+      const ignoreChecker = createDefaultIgnoreChecker();
+      await Deno.writeTextFile(`${projectDir}/app.ts`, "export const value = 2;\n");
+      const snapshot = await capturePushSourceSnapshot(projectDir, ignoreChecker);
+      assertEquals(snapshot.gitSource.clean, false);
+      await recordPushReceipt(
+        client,
+        config,
+        projectDir,
+        "main",
+        snapshot,
+        ignoreChecker,
+      );
+      assertExists(await readPushReceipt(projectDir));
+
+      await Deno.writeTextFile(`${projectDir}/app.ts`, "export const value = 3;\n");
+
+      await assertRejects(
+        () =>
+          recordPushReceipt(
+            client,
+            config,
+            projectDir,
+            "main",
+            snapshot,
+            ignoreChecker,
+          ),
+        Error,
+        "Local source changed during push",
+      );
+      assertEquals(await readPushReceipt(projectDir), null);
+    });
+  });
+
+  it("rejects a later commit even when its source bytes are unchanged", async () => {
+    await withGitProject(async ({ projectDir, runGit }) => {
+      const ignoreChecker = createDefaultIgnoreChecker();
+      const snapshot = await capturePushSourceSnapshot(projectDir, ignoreChecker);
+      await runGit("commit", "--quiet", "--allow-empty", "-m", "advance HEAD");
+
+      await assertRejects(
+        () =>
+          recordPushReceipt(
+            client,
+            config,
+            projectDir,
+            "main",
+            snapshot,
+            ignoreChecker,
+          ),
+        Error,
+        "Local source changed during push",
+      );
+      assertEquals(await readPushReceipt(projectDir), null);
+    });
   });
 });
 

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -31,6 +31,7 @@ import {
   clearPushReceipt,
   computeSourceDigest,
   getProjectTarget,
+  type GitSource,
   normalizeControlPlane,
   resolveGitSource,
   writePushReceipt,
@@ -93,6 +94,12 @@ export interface UploadOp {
   content: string;
 }
 
+export interface PushSourceSnapshot {
+  files: UploadOp[];
+  gitSource: GitSource;
+  sourceDigest: string;
+}
+
 /**
  * API response for branch creation
  */
@@ -148,6 +155,37 @@ async function scanLocalFiles(
 
   await walk(projectDir);
   return ops;
+}
+
+function gitSourcesMatch(left: GitSource, right: GitSource): boolean {
+  return left.commitSha === right.commitSha && left.clean === right.clean;
+}
+
+function sourceSnapshotsMatch(
+  left: PushSourceSnapshot,
+  right: PushSourceSnapshot,
+): boolean {
+  return gitSourcesMatch(left.gitSource, right.gitSource) &&
+    left.sourceDigest === right.sourceDigest;
+}
+
+function sourceChangedError(): Error {
+  return new Error("Local source changed during push. Run veryfront push again.");
+}
+
+export async function capturePushSourceSnapshot(
+  projectDir: string,
+  ignoreChecker: IgnoreChecker,
+): Promise<PushSourceSnapshot> {
+  const gitSourceBefore = await resolveGitSource(projectDir);
+  const files = await scanLocalFiles(projectDir, ignoreChecker);
+  const [gitSource, sourceDigest] = await Promise.all([
+    resolveGitSource(projectDir),
+    computeSourceDigest(files),
+  ]);
+
+  if (!gitSourcesMatch(gitSourceBefore, gitSource)) throw sourceChangedError();
+  return { files, gitSource, sourceDigest };
 }
 
 export function generateBranchName(): string {
@@ -324,26 +362,32 @@ function buildConfirmParts(ops: UploadOp[], toDelete: string[]): string[] {
   return buildOpParts(ops, toDelete, (count) => `upload ${count}`, (count) => `delete ${count}`);
 }
 
-async function recordPushReceipt(
+export async function recordPushReceipt(
   client: ApiClient,
   config: ResolvedConfig,
   projectDir: string,
   branch: string,
-  files: UploadOp[],
+  snapshot: PushSourceSnapshot,
+  ignoreChecker: IgnoreChecker,
 ): Promise<void> {
-  const [project, gitSource, sourceDigest] = await Promise.all([
-    getProjectTarget(client, config.projectSlug),
-    resolveGitSource(projectDir),
-    computeSourceDigest(files),
-  ]);
+  const project = await getProjectTarget(client, config.projectSlug);
+  let currentSnapshot: PushSourceSnapshot;
+  try {
+    currentSnapshot = await capturePushSourceSnapshot(projectDir, ignoreChecker);
+    if (!sourceSnapshotsMatch(snapshot, currentSnapshot)) throw sourceChangedError();
+  } catch (error) {
+    await clearPushReceipt(projectDir);
+    throw error;
+  }
+
   await writePushReceipt(projectDir, {
     controlPlane: normalizeControlPlane(config.apiUrl),
     projectId: project.id,
     projectSlug: project.slug,
     branch,
-    commitSha: gitSource.commitSha,
-    sourceDigest,
-    clean: gitSource.clean,
+    commitSha: snapshot.gitSource.commitSha,
+    sourceDigest: snapshot.sourceDigest,
+    clean: snapshot.gitSource.clean,
   });
 }
 
@@ -378,7 +422,14 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
       const ignoreChecker = createIgnoreChecker(ignorePatterns);
 
       spinner.update("Scanning local files...");
-      const ops = await scanLocalFiles(projectDir, ignoreChecker);
+      let sourceSnapshot: PushSourceSnapshot;
+      try {
+        sourceSnapshot = await capturePushSourceSnapshot(projectDir, ignoreChecker);
+      } catch (error) {
+        spinner.stop();
+        throw error;
+      }
+      const ops = sourceSnapshot.files;
       const localPaths = new Set(ops.map((op) => op.path));
 
       spinner.update("Fetching remote files...");
@@ -430,7 +481,14 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           if (!dryRun) {
             await clearPushReceipt(projectDir);
             spinner.update("Verifying push target...");
-            await recordPushReceipt(client, config, projectDir, branchName, ops);
+            await recordPushReceipt(
+              client,
+              config,
+              projectDir,
+              branchName,
+              sourceSnapshot,
+              ignoreChecker,
+            );
           }
         } finally {
           spinner.stop();
@@ -520,7 +578,14 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
 
       spinner.update("Verifying push target...");
       try {
-        await recordPushReceipt(client, config, projectDir, branchName, ops);
+        await recordPushReceipt(
+          client,
+          config,
+          projectDir,
+          branchName,
+          sourceSnapshot,
+          ignoreChecker,
+        );
       } finally {
         spinner.stop();
       }

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -21,12 +21,20 @@ import {
   writeProjectSlug,
 } from "#cli/shared/config";
 import { reserveProjectSlug } from "#cli/shared/reserve-slug";
-import { confirmPrompt, logInfo, logSuccess, logWarning } from "#cli/utils";
+import { confirmPrompt, logInfo, logSuccess } from "#cli/utils";
 import { createNoopSpinner, createSpinner } from "#cli/ui";
 import { withSpan } from "veryfront/observability/otlp-setup";
 import { createIgnoreChecker, type IgnoreChecker, loadIgnorePatterns } from "../../sync/ignore.ts";
 import { listAllFiles, type PullSource } from "../pull/index.ts";
 import { CommonArgs, createArgParser } from "#cli/shared/args";
+import {
+  clearPushReceipt,
+  computeSourceDigest,
+  getProjectTarget,
+  normalizeControlPlane,
+  resolveGitSource,
+  writePushReceipt,
+} from "../../shared/deployment-provenance.ts";
 
 /**
  * Schema factory for push command arguments
@@ -316,6 +324,29 @@ function buildConfirmParts(ops: UploadOp[], toDelete: string[]): string[] {
   return buildOpParts(ops, toDelete, (count) => `upload ${count}`, (count) => `delete ${count}`);
 }
 
+async function recordPushReceipt(
+  client: ApiClient,
+  config: ResolvedConfig,
+  projectDir: string,
+  branch: string,
+  files: UploadOp[],
+): Promise<void> {
+  const [project, gitSource, sourceDigest] = await Promise.all([
+    getProjectTarget(client, config.projectSlug),
+    resolveGitSource(projectDir),
+    computeSourceDigest(files),
+  ]);
+  await writePushReceipt(projectDir, {
+    controlPlane: normalizeControlPlane(config.apiUrl),
+    projectId: project.id,
+    projectSlug: project.slug,
+    branch,
+    commitSha: gitSource.commitSha,
+    sourceDigest,
+    clean: gitSource.clean,
+  });
+}
+
 export function pushCommand(options: PushOptions = {}): Promise<void> {
   return withSpan(
     "cli.command.push",
@@ -363,7 +394,12 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
         // Project doesn't exist yet - create it on first push
         if (getErrorStatus(error) === 404) {
           spinner.update("Creating project...");
-          const reserveResult = await reserveProjectSlug(config.projectSlug, config.apiToken);
+          const reserveResult = await reserveProjectSlug(
+            config.projectSlug,
+            config.apiToken,
+            undefined,
+            config.apiUrl,
+          );
           if (reserveResult.slug !== config.projectSlug) {
             await writeProjectSlug(projectDir, reserveResult.slug);
             logInfo(`Project slug: ${reserveResult.slug}`);
@@ -390,7 +426,15 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
       const toDelete = target.remoteFiles.map((f) => f.path).filter((p) => !localPaths.has(p));
 
       if (ops.length === 0 && toDelete.length === 0) {
-        spinner.stop();
+        try {
+          if (!dryRun) {
+            await clearPushReceipt(projectDir);
+            spinner.update("Verifying push target...");
+            await recordPushReceipt(client, config, projectDir, branchName, ops);
+          }
+        } finally {
+          spinner.stop();
+        }
         if (!quiet) logInfo("No changes to push.");
         return;
       }
@@ -434,6 +478,8 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
         return;
       }
 
+      await clearPushReceipt(projectDir);
+
       let branchId = target.branchId;
       const uploadMsg = isMainBranch
         ? "Pushing to main..."
@@ -466,7 +512,18 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
         deleteResult = await deleteFiles(client, config.projectSlug, branchId, toDelete, false);
       }
 
-      spinner.stop();
+      const failedTotal = uploadResult.failed + deleteResult.failed;
+      if (failedTotal > 0) {
+        spinner.stop();
+        throw new Error(`Push failed for ${failedTotal} file${failedTotal === 1 ? "" : "s"}`);
+      }
+
+      spinner.update("Verifying push target...");
+      try {
+        await recordPushReceipt(client, config, projectDir, branchName, ops);
+      } finally {
+        spinner.stop();
+      }
 
       if (quiet) return;
 
@@ -484,9 +541,6 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           logInfo(`Merge:   https://veryfront.com/projects/${config.projectSlug}/branches`);
         }
       }
-
-      const failedTotal = uploadResult.failed + deleteResult.failed;
-      if (failedTotal > 0) logWarning(`Failed: ${failedTotal} files.`);
     },
     { "cli.dryRun": options.dryRun ?? false },
   );

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -141,6 +141,15 @@ async function scanLocalFiles(
 
       if (ignoreChecker.isIgnored(relativePath)) continue;
 
+      if (entry.isSymlink) {
+        if (ignoreChecker.isSupportedExtension(entry.name)) {
+          throw new Error(
+            `Veryfront push does not support symbolic links: "${relativePath}". Replace the link with a file and run veryfront push again.`,
+          );
+        }
+        continue;
+      }
+
       if (entry.isDirectory) {
         await walk(entryPath);
         continue;
@@ -421,17 +430,6 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
       const ignorePatterns = await loadIgnorePatterns(projectDir);
       const ignoreChecker = createIgnoreChecker(ignorePatterns);
 
-      spinner.update("Scanning local files...");
-      let sourceSnapshot: PushSourceSnapshot;
-      try {
-        sourceSnapshot = await capturePushSourceSnapshot(projectDir, ignoreChecker);
-      } catch (error) {
-        spinner.stop();
-        throw error;
-      }
-      const ops = sourceSnapshot.files;
-      const localPaths = new Set(ops.map((op) => op.path));
-
       spinner.update("Fetching remote files...");
       const client = createApiClient(config);
       const branchName = branch || generateBranchName();
@@ -467,6 +465,17 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           throw error;
         }
       }
+
+      spinner.update("Scanning local files...");
+      let sourceSnapshot: PushSourceSnapshot;
+      try {
+        sourceSnapshot = await capturePushSourceSnapshot(projectDir, ignoreChecker);
+      } catch (error) {
+        spinner.stop();
+        throw error;
+      }
+      const ops = sourceSnapshot.files;
+      const localPaths = new Set(ops.map((op) => op.path));
 
       const target = await resolvePushRemoteFiles(
         client,

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -16,11 +16,12 @@ import { createFileSystem } from "veryfront/platform";
 import {
   type ApiClient,
   createApiClient,
-  resolveConfigWithAuth,
+  type ProjectReferenceSource,
+  resolveConfigWithAuthDetails,
   type ResolvedConfig,
   writeProjectSlug,
 } from "#cli/shared/config";
-import { reserveProjectSlug } from "#cli/shared/reserve-slug";
+import { ProjectSlugConflictError, reserveProjectSlug } from "#cli/shared/reserve-slug";
 import { confirmPrompt, logInfo, logSuccess } from "#cli/utils";
 import { createNoopSpinner, createSpinner } from "#cli/ui";
 import { withSpan } from "veryfront/observability/otlp-setup";
@@ -28,6 +29,7 @@ import { createIgnoreChecker, type IgnoreChecker, loadIgnorePatterns } from "../
 import { listAllFiles, type PullSource } from "../pull/index.ts";
 import { CommonArgs, createArgParser } from "#cli/shared/args";
 import {
+  areSourceFilesTracked,
   clearPushReceipt,
   computeSourceDigest,
   getProjectTarget,
@@ -182,19 +184,54 @@ function sourceChangedError(): Error {
   return new Error("Local source changed during push. Run veryfront push again.");
 }
 
+function canPersistAlternativeSlug(source: ProjectReferenceSource): boolean {
+  return source.kind === "json-config" || source.kind === "inferred";
+}
+
+function projectSlugConflictError(
+  error: ProjectSlugConflictError,
+  source: ProjectReferenceSource,
+): Error {
+  let action: string;
+  switch (source.kind) {
+    case "argument":
+      action = "Use a different --project-slug value";
+      break;
+    case "environment":
+      action = "Update or remove VERYFRONT_PROJECT_SLUG";
+      break;
+    case "module-config":
+      action = `Update projectSlug in ${source.name}`;
+      break;
+    case "tenant-environment":
+      action = `Update or remove ${source.name}`;
+      break;
+    case "json-config":
+    case "inferred":
+      action = "Choose a different project slug";
+      break;
+  }
+  return new Error(`${error.message} ${action}, then run veryfront push again.`);
+}
+
 export async function capturePushSourceSnapshot(
   projectDir: string,
   ignoreChecker: IgnoreChecker,
 ): Promise<PushSourceSnapshot> {
   const gitSourceBefore = await resolveGitSource(projectDir);
   const files = await scanLocalFiles(projectDir, ignoreChecker);
-  const [gitSource, sourceDigest] = await Promise.all([
-    resolveGitSource(projectDir),
+  const [sourceDigest, filesTracked] = await Promise.all([
     computeSourceDigest(files),
+    areSourceFilesTracked(projectDir, files),
   ]);
+  const gitSource = await resolveGitSource(projectDir);
 
   if (!gitSourcesMatch(gitSourceBefore, gitSource)) throw sourceChangedError();
-  return { files, gitSource, sourceDigest };
+  return {
+    files,
+    gitSource: { ...gitSource, clean: gitSource.clean && filesTracked },
+    sourceDigest,
+  };
 }
 
 export function generateBranchName(): string {
@@ -416,15 +453,21 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
       let spinner = quiet ? createNoopSpinner() : createSpinner("Resolving configuration...");
 
       let config: ResolvedConfig;
+      let projectReferenceSource: ProjectReferenceSource;
       try {
         // Use interactive auth - prompts for login if not authenticated
-        config = await resolveConfigWithAuth(projectDir);
+        const resolved = await resolveConfigWithAuthDetails(projectDir);
+        config = resolved.config;
+        projectReferenceSource = resolved.projectReferenceSource;
       } catch (error) {
         spinner.stop();
         throw error;
       }
 
-      if (slugOverride) config = { ...config, projectSlug: slugOverride };
+      if (slugOverride) {
+        config = { ...config, projectSlug: slugOverride };
+        projectReferenceSource = { kind: "argument", name: "--project-slug" };
+      }
 
       spinner.update("Loading ignore patterns...");
       const ignorePatterns = await loadIgnorePatterns(projectDir);
@@ -443,12 +486,22 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
         // Project doesn't exist yet - create it on first push
         if (getErrorStatus(error) === 404) {
           spinner.update("Creating project...");
-          const reserveResult = await reserveProjectSlug(
-            config.projectSlug,
-            config.apiToken,
-            undefined,
-            config.apiUrl,
-          );
+          let reserveResult: Awaited<ReturnType<typeof reserveProjectSlug>>;
+          try {
+            reserveResult = await reserveProjectSlug(
+              config.projectSlug,
+              config.apiToken,
+              undefined,
+              config.apiUrl,
+              { allowAlternativeSlug: canPersistAlternativeSlug(projectReferenceSource) },
+            );
+          } catch (reserveError) {
+            spinner.stop();
+            if (reserveError instanceof ProjectSlugConflictError) {
+              throw projectSlugConflictError(reserveError, projectReferenceSource);
+            }
+            throw reserveError;
+          }
           if (reserveResult.slug !== config.projectSlug) {
             await writeProjectSlug(projectDir, reserveResult.slug);
             logInfo(`Project slug: ${reserveResult.slug}`);

--- a/cli/mcp/skills/deploy-safely/SKILL.md
+++ b/cli/mcp/skills/deploy-safely/SKILL.md
@@ -23,17 +23,23 @@ Build, test, deploy, and verify with rollback on failure.
    ```
    Abort if any test fails.
 
-3. **Deploy**
+3. **Push**
+   ```bash
+   veryfront push --branch <branch> --force
+   ```
+   Abort if any file fails to upload.
+
+4. **Deploy**
    ```bash
    veryfront deploy --env <environment> --branch <branch> --yes --json
    ```
-   Record the release version from the response.
+   Record the project, environment, release, deployment, and commit IDs from the response.
 
-4. **Verify health** (via MCP)
+5. **Verify health** (via MCP)
    Use `vf_get_errors` to check for runtime errors after deploy.
    Wait 30 seconds, then check again.
 
-5. **Confirm or rollback**
+6. **Confirm or rollback**
    - If no errors: deployment is successful
    - If errors detected: deploy the previous version
 
@@ -41,5 +47,6 @@ Build, test, deploy, and verify with rollback on failure.
 
 - **Build fails**: Check `vf_get_errors` for compilation errors, fix and retry
 - **Tests fail**: Read failure details from JSON output, fix failing tests
+- **Push fails**: Fix failed uploads before retrying deploy
 - **Deploy fails**: Check environment name, auth token, branch existence
 - **Post-deploy errors**: Redeploy previous release with `--release-name <previous>`

--- a/cli/mcp/tools/deploy-tool.test.ts
+++ b/cli/mcp/tools/deploy-tool.test.ts
@@ -6,6 +6,8 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
+import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
+import { computeSourceDigest, writePushReceipt } from "../../shared/deployment-provenance.ts";
 import { triggerDeploy, vfTriggerDeploy } from "./deploy-tool.ts";
 
 // ---------------------------------------------------------------------------
@@ -158,60 +160,136 @@ describe("mcp/tools/deploy-tool", () => {
   describe("triggerDeploy happy path", () => {
     it("creates release and deployment, returns structured result", async () => {
       const originalToken = Deno.env.get("VERYFRONT_API_TOKEN");
+      const originalApiUrl = Deno.env.get("VERYFRONT_API_URL");
+      const originalGithubSha = Deno.env.get("GITHUB_SHA");
+      const projectDir = await Deno.makeTempDir();
       try {
         Deno.env.set("VERYFRONT_API_TOKEN", "test-token-abc");
+        Deno.env.set("VERYFRONT_API_URL", "https://control.example.test/api");
+        _resetEnvironmentConfig();
+
+        const runGit = async (...args: string[]) => {
+          const output = await new Deno.Command("git", {
+            args,
+            cwd: projectDir,
+            clearEnv: true,
+            env: Object.fromEntries(
+              Object.entries(Deno.env.toObject()).filter(([key]) => !key.startsWith("GIT_")),
+            ),
+            stdout: "null",
+            stderr: "piped",
+          }).output();
+          assertEquals(output.success, true, new TextDecoder().decode(output.stderr));
+        };
+        await runGit("init", "--quiet");
+        await runGit("config", "user.email", "test@veryfront.com");
+        await runGit("config", "user.name", "Veryfront Test");
+        await runGit("commit", "--allow-empty", "--quiet", "-m", "initial");
+        const commitSha = new TextDecoder().decode(
+          (await new Deno.Command("git", {
+            args: ["rev-parse", "HEAD"],
+            cwd: projectDir,
+            clearEnv: true,
+            env: Object.fromEntries(
+              Object.entries(Deno.env.toObject()).filter(([key]) => !key.startsWith("GIT_")),
+            ),
+            stdout: "piped",
+          }).output()).stdout,
+        ).trim();
+        Deno.env.set("GITHUB_SHA", commitSha);
+        const sourceDigest = await computeSourceDigest([]);
+        await writePushReceipt(projectDir, {
+          controlPlane: "https://control.example.test/api",
+          projectId: "project-1",
+          projectSlug: "my-app",
+          branch: "main",
+          commitSha,
+          sourceDigest,
+          clean: true,
+        });
 
         const capturedRequests: { method: string; url: string }[] = [];
+        let environmentReads = 0;
+        let releaseFiles: Array<{ path: string; data: string }> = [];
 
-        const result = await withMockFetch(
-          async (input: string | URL | Request, init?: RequestInit) => {
-            const request = input instanceof Request ? input : new Request(input, init);
-            const url = request.url;
-            const method = request.method;
-            capturedRequests.push({ method, url });
+        const handleRequest = async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          const url = request.url;
+          const pathname = new URL(url).pathname;
+          const method = request.method;
+          capturedRequests.push({ method, url });
 
-            // GET /projects/my-app/environments
-            if (method === "GET" && url.includes("/environments")) {
-              return Response.json({
-                data: [
-                  { id: "env-1", name: "production", protected: true },
-                  { id: "env-2", name: "staging", protected: false },
-                ],
-              });
-            }
+          if (method === "GET" && pathname.endsWith("/projects/my-app")) {
+            return Response.json({ id: "project-1", slug: "my-app" });
+          }
 
-            // POST /projects/my-app/releases
-            if (method === "POST" && url.includes("/releases")) {
-              return Response.json({
-                id: "rel-42",
-                name: "Release 42",
-                version: "v1.0.42",
-                export_status: "completed",
-                build_status: "completed",
-                deploy_status: "pending",
-              });
-            }
+          if (method === "GET" && url.includes("/environments")) {
+            environmentReads++;
+            return Response.json({
+              data: [
+                {
+                  id: "env-1",
+                  name: "production",
+                  protected: true,
+                  deployment: environmentReads === 1
+                    ? null
+                    : { id: "deploy-99", release: { id: "rel-42" } },
+                },
+              ],
+            });
+          }
 
-            // POST /projects/my-app/deployments
-            if (method === "POST" && url.includes("/deployments")) {
-              return Response.json({
-                id: "deploy-99",
-                release: "rel-42",
-                environment: "env-1",
-              });
-            }
+          if (method === "POST" && url.includes("/releases")) {
+            return Response.json({
+              id: "rel-42",
+              name: "Release 42",
+              version: "v1.0.42",
+              export_status: "completed",
+              build_status: "completed",
+              deploy_status: "pending",
+            });
+          }
 
-            return new Response("Not Found", { status: 404 });
-          },
-          async () =>
-            await triggerDeploy({
-              projectSlug: "my-app",
-              environment: "production",
-              branch: "main",
-            }),
-        );
+          if (method === "POST" && url.includes("/deployments")) {
+            return Response.json({
+              id: "deploy-99",
+              release: "rel-42",
+              environment: "env-1",
+            });
+          }
 
-        assertEquals(result.success, true);
+          if (method === "GET" && pathname.endsWith("/deployments/deploy-99")) {
+            return Response.json({
+              id: "deploy-99",
+              release: { id: "rel-42" },
+              environment: { id: "env-1" },
+            });
+          }
+
+          if (method === "GET" && pathname.endsWith("/releases/rel-42/versions")) {
+            return Response.json({ data: releaseFiles, page_info: {} });
+          }
+
+          if (method === "GET" && pathname.endsWith("/releases/rel-42")) {
+            return Response.json({
+              id: "rel-42",
+              name: "Release 42",
+              version: "v1.0.42",
+            });
+          }
+
+          return new Response("Not Found", { status: 404 });
+        };
+        const runDeploy = () =>
+          triggerDeploy({
+            projectSlug: "my-app",
+            environment: "production",
+            branch: "main",
+          }, { projectDir });
+
+        const result = await withMockFetch(handleRequest, runDeploy);
+
+        assertEquals(result.success, true, result.error);
         assertEquals(result.deploymentId, "deploy-99");
         assertEquals(result.release, {
           id: "rel-42",
@@ -222,21 +300,58 @@ describe("mcp/tools/deploy-tool", () => {
           id: "env-1",
           name: "production",
         });
+        assertEquals(result.project, { id: "project-1", slug: "my-app" });
+        assertEquals(result.commitSha, commitSha);
+        assertEquals(result.sourceDigest, sourceDigest);
+        assertEquals(result.controlPlane, "https://control.example.test/api");
 
         // Verify correct API calls were made
-        assertEquals(capturedRequests.length, 3);
-        assertEquals(capturedRequests[0].method, "GET");
-        assertEquals(capturedRequests[0].url.includes("/environments"), true);
-        assertEquals(capturedRequests[1].method, "POST");
-        assertEquals(capturedRequests[1].url.includes("/releases"), true);
-        assertEquals(capturedRequests[2].method, "POST");
-        assertEquals(capturedRequests[2].url.includes("/deployments"), true);
+        assertEquals(
+          capturedRequests.map(({ method, url }) => `${method} ${new URL(url).pathname}`),
+          [
+            "GET /api/projects/my-app",
+            "GET /api/projects/project-1/environments",
+            "POST /api/projects/project-1/releases",
+            "GET /api/projects/project-1/releases/rel-42",
+            "GET /api/projects/project-1/releases/rel-42/versions",
+            "POST /api/projects/project-1/deployments",
+            "GET /api/projects/project-1/deployments/deploy-99",
+            "GET /api/projects/project-1/environments",
+          ],
+        );
+
+        releaseFiles = [{
+          path: "app.ts",
+          data: JSON.stringify({ body: "changed after push\n", path: "app.ts" }),
+        }];
+        capturedRequests.length = 0;
+        environmentReads = 0;
+        const mismatchResult = await withMockFetch(handleRequest, runDeploy);
+
+        assertEquals(mismatchResult.success, false);
+        assertEquals(mismatchResult.error?.includes("does not match pushed commit"), true);
+        assertEquals(
+          capturedRequests.map(({ method, url }) => `${method} ${new URL(url).pathname}`),
+          [
+            "GET /api/projects/my-app",
+            "GET /api/projects/project-1/environments",
+            "POST /api/projects/project-1/releases",
+            "GET /api/projects/project-1/releases/rel-42",
+            "GET /api/projects/project-1/releases/rel-42/versions",
+          ],
+        );
       } finally {
         if (originalToken !== undefined) {
           Deno.env.set("VERYFRONT_API_TOKEN", originalToken);
         } else {
           Deno.env.delete("VERYFRONT_API_TOKEN");
         }
+        if (originalApiUrl !== undefined) Deno.env.set("VERYFRONT_API_URL", originalApiUrl);
+        else Deno.env.delete("VERYFRONT_API_URL");
+        if (originalGithubSha !== undefined) Deno.env.set("GITHUB_SHA", originalGithubSha);
+        else Deno.env.delete("GITHUB_SHA");
+        _resetEnvironmentConfig();
+        await Deno.remove(projectDir, { recursive: true });
       }
     });
   });
@@ -254,6 +369,10 @@ describe("mcp/tools/deploy-tool", () => {
         const result = await withMockFetch(
           async (input: string | URL | Request, init?: RequestInit) => {
             const request = input instanceof Request ? input : new Request(input, init);
+
+            if (request.method === "GET" && request.url.endsWith("/projects/my-app")) {
+              return Response.json({ id: "project-1", slug: "my-app" });
+            }
 
             if (request.method === "GET" && request.url.includes("/environments")) {
               return Response.json({ data: [] });

--- a/cli/mcp/tools/deploy-tool.ts
+++ b/cli/mcp/tools/deploy-tool.ts
@@ -9,12 +9,19 @@ import { defineSchema, lazySchema } from "veryfront/schemas";
 import type { InferSchema } from "veryfront/extensions/schema";
 import type { MCPTool } from "veryfront/mcp";
 import { getEnvironmentConfig } from "veryfront/config";
+import { cwd } from "veryfront/platform";
 import { createApiClient, resolveConfig } from "#cli/shared/config";
 import {
+  assertProjectOwnership,
   createDeployment,
   createRelease,
   getEnvironmentByName,
+  getProject,
+  resolvePushedSource,
+  verifyDeployment,
+  verifyReleaseSource,
 } from "../../commands/deploy/command.ts";
+import { normalizeControlPlane } from "../../shared/deployment-provenance.ts";
 
 const getTriggerDeployInput = defineSchema((v) =>
   v.object({
@@ -35,10 +42,18 @@ export type TriggerDeployInput = InferSchema<ReturnType<typeof getTriggerDeployI
 
 export interface TriggerDeployResult {
   success: boolean;
+  project?: { id: string; slug: string };
   deploymentId?: string;
   release?: { id: string; name: string; version: string };
   environment?: { id: string; name: string };
+  commitSha?: string;
+  sourceDigest?: string;
+  controlPlane?: string;
   error?: string;
+}
+
+export interface TriggerDeployOptions {
+  projectDir?: string;
 }
 
 /**
@@ -48,6 +63,7 @@ export interface TriggerDeployResult {
  */
 export async function triggerDeploy(
   input: TriggerDeployInput,
+  options: TriggerDeployOptions = {},
 ): Promise<TriggerDeployResult> {
   try {
     const env = getEnvironmentConfig();
@@ -67,10 +83,11 @@ export async function triggerDeploy(
     });
 
     const client = createApiClient(config);
+    const project = await getProject(client, input.projectSlug);
 
     const environment = await getEnvironmentByName(
       client,
-      input.projectSlug,
+      project.id,
       input.environment,
     );
     if (!environment) {
@@ -79,23 +96,66 @@ export async function triggerDeploy(
         error: `Environment "${input.environment}" not found.`,
       };
     }
+    assertProjectOwnership("Environment", environment, project.id);
 
-    const release = await createRelease(client, input.projectSlug, {
+    const source = await resolvePushedSource({
+      projectDir: options.projectDir ?? cwd(),
+      controlPlane: config.apiUrl,
+      projectId: project.id,
+      projectSlug: project.slug,
       branch: input.branch,
+      requireClean: input.environment === "production",
+    });
+
+    const release = await createRelease(client, project.id, {
+      branch: input.branch,
+    });
+    if (!release.version) {
+      return {
+        success: false,
+        error: `Release ${release.id} has no version.`,
+      };
+    }
+
+    const verifiedRelease = await verifyReleaseSource(client, project.id, {
+      projectId: project.id,
+      releaseId: release.id,
+      releaseName: release.name,
+      commitSha: source.commitSha,
+      sourceDigest: source.sourceDigest,
     });
 
     const deployment = await createDeployment(
       client,
-      input.projectSlug,
+      project.id,
       release.id,
       environment.id,
     );
+    const verification = await verifyDeployment(client, project.id, {
+      projectId: project.id,
+      projectSlug: project.slug,
+      environmentId: environment.id,
+      environmentName: input.environment,
+      releaseId: release.id,
+      releaseName: release.name,
+      deploymentId: deployment.id,
+      commitSha: source.commitSha,
+      sourceDigest: source.sourceDigest,
+    }, { verifiedRelease });
 
     return {
       success: true,
-      deploymentId: deployment.id,
-      release: { id: release.id, name: release.name, version: release.version },
-      environment: { id: environment.id, name: environment.name },
+      project: { id: verification.projectId, slug: verification.projectSlug },
+      deploymentId: verification.deploymentId,
+      release: {
+        id: verification.releaseId,
+        name: release.name,
+        version: verification.releaseVersion,
+      },
+      environment: { id: verification.environmentId, name: verification.environmentName },
+      commitSha: verification.commitSha,
+      sourceDigest: verification.sourceDigest,
+      controlPlane: normalizeControlPlane(config.apiUrl),
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -126,8 +186,9 @@ export const vfTriggerDeploy: MCPTool<TriggerDeployInput, TriggerDeployResult> =
   },
   description:
     "Use this when you need to deploy a project to an environment via the Veryfront API. " +
-    "Creates a release from the specified branch and deploys it to the target environment. " +
-    "Returns the deployment ID, release info, and environment info on success. " +
+    "Requires a successful vf push from the current project, then creates and verifies a release " +
+    "from the specified branch and deploys it to the target environment. " +
+    "Returns project, deployment, release, environment, and commit evidence on success. " +
     "Requires a valid API token (set VERYFRONT_API_TOKEN or run 'veryfront login'). " +
     "Do not use for local builds — use vf_build instead. " +
     "Do not use for running tests before deploy — use vf_run_tests instead.",

--- a/cli/shared/config.ts
+++ b/cli/shared/config.ts
@@ -63,10 +63,31 @@ export const ResolvedConfigSchema = lazySchema(getResolvedConfigSchema);
 export type ResolvedConfig = InferSchema<ReturnType<typeof getResolvedConfigSchema>>;
 type ApiTokenSource = NonNullable<ResolvedConfig["apiTokenSource"]>;
 
-export async function readConfigFile(projectDir: string): Promise<VeryfrontConfig | null> {
+interface ConfigFileResolution {
+  config: VeryfrontConfig | null;
+  jsonProjectSlug?: string;
+  moduleProjectSlug?: string;
+  moduleProjectSlugFile?: string;
+}
+
+export type ProjectReferenceSource =
+  | { kind: "argument"; name: "--project-slug" }
+  | { kind: "environment"; name: "environment configuration" }
+  | { kind: "module-config"; name: string }
+  | { kind: "json-config"; name: "veryfront.json" }
+  | { kind: "tenant-environment"; name: string }
+  | { kind: "inferred"; name: "project files" };
+
+export interface ResolvedConfigDetails {
+  config: ResolvedConfig;
+  projectReferenceSource: ProjectReferenceSource;
+}
+
+async function readConfigFileResolution(projectDir: string): Promise<ConfigFileResolution> {
   const fs = createFileSystem();
 
   let moduleProjectSlug: string | undefined;
+  let moduleProjectSlugFile: string | undefined;
   for (const ext of [".ts", ".js"]) {
     const configPath = join(projectDir, `veryfront.config${ext}`);
 
@@ -78,6 +99,7 @@ export async function readConfigFile(projectDir: string): Promise<VeryfrontConfi
 
       if (config?.projectSlug) {
         moduleProjectSlug = config.projectSlug;
+        moduleProjectSlugFile = `veryfront.config${ext}`;
         break;
       }
     } catch (error) {
@@ -101,11 +123,20 @@ export async function readConfigFile(projectDir: string): Promise<VeryfrontConfi
     cliLogger.debug(`Failed to read veryfront.json:`, error);
   }
 
-  if (!moduleProjectSlug && !jsonConfig) return null;
-  return {
+  const config = !moduleProjectSlug && !jsonConfig ? null : {
     ...jsonConfig,
     ...(moduleProjectSlug ? { projectSlug: moduleProjectSlug } : {}),
   };
+  return {
+    config,
+    jsonProjectSlug: jsonConfig?.projectSlug,
+    moduleProjectSlug,
+    moduleProjectSlugFile,
+  };
+}
+
+export async function readConfigFile(projectDir: string): Promise<VeryfrontConfig | null> {
+  return (await readConfigFileResolution(projectDir)).config;
 }
 
 export async function writeProjectSlug(projectDir: string, slug: string): Promise<void> {
@@ -146,12 +177,19 @@ async function inferProjectSlug(projectDir: string): Promise<string | null> {
   return dirName ? slugify(dirName) : null;
 }
 
-function resolveTenantProjectReference(): string | undefined {
-  return getEnv("VERYFRONT_PROJECT_SLUG") ||
-    getEnv("TENANT_PROJECT_SLUG") ||
-    getEnv("VERYFRONT_PROJECT_ID") ||
-    getEnv("TENANT_PROJECT_ID") ||
-    undefined;
+function resolveTenantProjectReference(): { reference: string; name: string } | undefined {
+  for (
+    const name of [
+      "VERYFRONT_PROJECT_SLUG",
+      "TENANT_PROJECT_SLUG",
+      "VERYFRONT_PROJECT_ID",
+      "TENANT_PROJECT_ID",
+    ] as const
+  ) {
+    const reference = getEnv(name);
+    if (reference) return { reference, name };
+  }
+  return undefined;
 }
 
 async function resolveApiTokenForMode(
@@ -196,9 +234,10 @@ async function resolveConfigBase(
   projectDir: string | undefined,
   env: EnvironmentConfig,
   interactive: boolean,
-): Promise<ResolvedConfig> {
+): Promise<ResolvedConfigDetails> {
   const dir = projectDir ?? cwd();
-  const configFile = await readConfigFile(dir);
+  const configFileResolution = await readConfigFileResolution(dir);
+  const configFile = configFileResolution.config;
 
   const apiUrl = resolveCliApiUrl(env, configFile?.apiUrl);
 
@@ -218,22 +257,45 @@ async function resolveConfigBase(
     );
   }
 
-  const projectSlug = env.projectSlug ??
-    configFile?.projectSlug ??
-    resolveTenantProjectReference() ??
-    (await inferProjectSlug(dir));
+  let projectSlug: string | null | undefined;
+  let projectReferenceSource: ProjectReferenceSource;
+  if (env.projectSlug !== undefined) {
+    projectSlug = env.projectSlug;
+    projectReferenceSource = { kind: "environment", name: "environment configuration" };
+  } else if (configFileResolution.moduleProjectSlug !== undefined) {
+    projectSlug = configFileResolution.moduleProjectSlug;
+    projectReferenceSource = {
+      kind: "module-config",
+      name: configFileResolution.moduleProjectSlugFile ?? "veryfront.config.ts",
+    };
+  } else if (configFileResolution.jsonProjectSlug !== undefined) {
+    projectSlug = configFileResolution.jsonProjectSlug;
+    projectReferenceSource = { kind: "json-config", name: "veryfront.json" };
+  } else {
+    const tenantReference = resolveTenantProjectReference();
+    if (tenantReference) {
+      projectSlug = tenantReference.reference;
+      projectReferenceSource = { kind: "tenant-environment", name: tenantReference.name };
+    } else {
+      projectSlug = await inferProjectSlug(dir);
+      projectReferenceSource = { kind: "inferred", name: "project files" };
+    }
+  }
   if (!projectSlug) {
     throw new Error(
       "Could not determine project reference. Set VERYFRONT_PROJECT_SLUG, TENANT_PROJECT_SLUG, VERYFRONT_PROJECT_ID, or add projectSlug to veryfront.config.ts",
     );
   }
 
-  return { apiUrl, apiToken, ...(apiTokenSource ? { apiTokenSource } : {}), projectSlug };
+  return {
+    config: { apiUrl, apiToken, ...(apiTokenSource ? { apiTokenSource } : {}), projectSlug },
+    projectReferenceSource,
+  };
 }
 
 function createConfigResolver(interactive: boolean) {
-  return (projectDir?: string, env?: EnvironmentConfig): Promise<ResolvedConfig> =>
-    resolveConfigByMode(projectDir, env, interactive);
+  return async (projectDir?: string, env?: EnvironmentConfig): Promise<ResolvedConfig> =>
+    (await resolveConfigByMode(projectDir, env, interactive)).config;
 }
 
 export const resolveConfig = createConfigResolver(false);
@@ -246,11 +308,18 @@ export const resolveConfig = createConfigResolver(false);
  */
 export const resolveConfigWithAuth = createConfigResolver(true);
 
+export function resolveConfigWithAuthDetails(
+  projectDir?: string,
+  env?: EnvironmentConfig,
+): Promise<ResolvedConfigDetails> {
+  return resolveConfigByMode(projectDir, env, true);
+}
+
 function resolveConfigByMode(
   projectDir: string | undefined,
   env: EnvironmentConfig | undefined,
   interactive: boolean,
-): Promise<ResolvedConfig> {
+): Promise<ResolvedConfigDetails> {
   return resolveConfigBase(projectDir, env ?? getEnvironmentConfig(), interactive);
 }
 

--- a/cli/shared/deployment-provenance.test.ts
+++ b/cli/shared/deployment-provenance.test.ts
@@ -197,6 +197,74 @@ describe("push receipt persistence", () => {
       await Deno.remove(projectDir, { recursive: true });
     }
   });
+
+  it("rejects a tracked Veryfront directory symlink without touching its target", async () => {
+    if (Deno.build.os === "windows") return;
+
+    const projectDir = await Deno.makeTempDir();
+    const externalDir = await Deno.makeTempDir();
+    const externalReceipt = `${externalDir}/push-receipt.json`;
+    const runGit = async (...args: string[]) => {
+      const result = await new Deno.Command("git", {
+        args,
+        cwd: projectDir,
+        stdout: "null",
+        stderr: "piped",
+      }).output();
+      assertEquals(result.success, true, new TextDecoder().decode(result.stderr));
+    };
+
+    try {
+      await Deno.writeTextFile(externalReceipt, "sentinel\n");
+      await Deno.symlink(externalDir, `${projectDir}/.veryfront`);
+      await runGit("init", "--quiet");
+      await runGit("config", "user.email", "test@veryfront.com");
+      await runGit("config", "user.name", "Veryfront Test");
+      await runGit("add", ".veryfront");
+      await runGit("commit", "--quiet", "-m", "track receipt directory link");
+
+      for (
+        const operation of [
+          () => readPushReceipt(projectDir),
+          () => clearPushReceipt(projectDir),
+          () => writePushReceipt(projectDir, RECEIPT),
+        ]
+      ) {
+        await assertRejects(operation, Error, "through a symbolic link");
+      }
+      assertEquals(await Deno.readTextFile(externalReceipt), "sentinel\n");
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(externalDir, { recursive: true });
+    }
+  });
+
+  it("rejects a receipt file symlink without touching its target", async () => {
+    if (Deno.build.os === "windows") return;
+
+    const projectDir = await Deno.makeTempDir();
+    const externalDir = await Deno.makeTempDir();
+    const externalReceipt = `${externalDir}/receipt.json`;
+    try {
+      await Deno.mkdir(`${projectDir}/.veryfront`);
+      await Deno.writeTextFile(externalReceipt, "sentinel\n");
+      await Deno.symlink(externalReceipt, `${projectDir}/.veryfront/push-receipt.json`);
+
+      for (
+        const operation of [
+          () => readPushReceipt(projectDir),
+          () => clearPushReceipt(projectDir),
+          () => writePushReceipt(projectDir, RECEIPT),
+        ]
+      ) {
+        await assertRejects(operation, Error, "Remove the link");
+      }
+      assertEquals(await Deno.readTextFile(externalReceipt), "sentinel\n");
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(externalDir, { recursive: true });
+    }
+  });
 });
 
 describe("resolveGitSource", () => {

--- a/cli/shared/deployment-provenance.test.ts
+++ b/cli/shared/deployment-provenance.test.ts
@@ -1,0 +1,266 @@
+import "#veryfront/schemas/_test-setup.ts";
+
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  clearPushReceipt,
+  computeSourceDigest,
+  normalizeControlPlane,
+  type PushReceipt,
+  readPushReceipt,
+  resolveGitSource,
+  validatePushReceipt,
+  writePushReceipt,
+} from "./deployment-provenance.ts";
+
+const RECEIPT: PushReceipt = {
+  version: 2,
+  controlPlane: "https://api.veryfront.com",
+  projectId: "550e8400-e29b-41d4-a716-446655440000",
+  projectSlug: "veryfront-ops-agent",
+  branch: "main",
+  commitSha: "90719c01c1dded95a6b6df46b0fb17ea37d3ace8",
+  sourceDigest: "sha256:8427243a30c3d9af7609e7d18e06172d6e6edba76a84f4d7f80dfdb4a01e09d7",
+  clean: true,
+  pushedAt: "2026-07-10T09:20:00.000Z",
+};
+
+describe("computeSourceDigest", () => {
+  it("is stable across file order and changes when source changes", async () => {
+    const first = await computeSourceDigest([
+      { path: "app/page.tsx", content: "export default function Page() {}\n" },
+      { path: "veryfront.config.ts", content: "export default {};\n" },
+    ]);
+    const reordered = await computeSourceDigest([
+      { path: "veryfront.config.ts", content: "export default {};\n" },
+      { path: "app/page.tsx", content: "export default function Page() {}\n" },
+    ]);
+    const changed = await computeSourceDigest([
+      { path: "app/page.tsx", content: "export default function Page() { return null; }\n" },
+      { path: "veryfront.config.ts", content: "export default {};\n" },
+    ]);
+
+    assertEquals(first, reordered);
+    assertEquals(first.startsWith("sha256:"), true);
+    assertEquals(first === changed, false);
+  });
+});
+
+describe("normalizeControlPlane", () => {
+  it("normalizes a trailing slash without dropping an API path", () => {
+    assertEquals(
+      normalizeControlPlane("https://API.VERYFRONT.COM/control-plane/"),
+      "https://api.veryfront.com/control-plane",
+    );
+  });
+});
+
+describe("validatePushReceipt", () => {
+  it("returns the pushed commit for the same deployment target", () => {
+    const result = validatePushReceipt(RECEIPT, {
+      controlPlane: "https://api.veryfront.com/",
+      projectId: RECEIPT.projectId,
+      projectSlug: RECEIPT.projectSlug,
+      branch: "main",
+      commitSha: RECEIPT.commitSha,
+      requireClean: true,
+    });
+
+    assertEquals(result, RECEIPT.commitSha);
+  });
+
+  it("rejects a push from another control plane", async () => {
+    await assertRejects(
+      () =>
+        Promise.resolve().then(() =>
+          validatePushReceipt(RECEIPT, {
+            controlPlane: "https://api.veryfront.org",
+            projectId: RECEIPT.projectId,
+            projectSlug: RECEIPT.projectSlug,
+            branch: "main",
+            commitSha: RECEIPT.commitSha,
+          })
+        ),
+      Error,
+      "different control plane",
+    );
+  });
+
+  it("rejects a stale project or branch", async () => {
+    await assertRejects(
+      () =>
+        Promise.resolve().then(() =>
+          validatePushReceipt(RECEIPT, {
+            controlPlane: RECEIPT.controlPlane,
+            projectId: "660e8400-e29b-41d4-a716-446655440000",
+            projectSlug: "another-project",
+            branch: "feature-x",
+            commitSha: RECEIPT.commitSha,
+          })
+        ),
+      Error,
+      "different project",
+    );
+
+    await assertRejects(
+      () =>
+        Promise.resolve().then(() =>
+          validatePushReceipt(RECEIPT, {
+            controlPlane: RECEIPT.controlPlane,
+            projectId: RECEIPT.projectId,
+            projectSlug: RECEIPT.projectSlug,
+            branch: "feature-x",
+            commitSha: RECEIPT.commitSha,
+          })
+        ),
+      Error,
+      "different branch",
+    );
+  });
+
+  it("rejects a different or dirty commit for production", async () => {
+    await assertRejects(
+      () =>
+        Promise.resolve().then(() =>
+          validatePushReceipt(RECEIPT, {
+            controlPlane: RECEIPT.controlPlane,
+            projectId: RECEIPT.projectId,
+            projectSlug: RECEIPT.projectSlug,
+            branch: RECEIPT.branch,
+            commitSha: "80719c01c1dded95a6b6df46b0fb17ea37d3ace8",
+          })
+        ),
+      Error,
+      "different commit",
+    );
+
+    await assertRejects(
+      () =>
+        Promise.resolve().then(() =>
+          validatePushReceipt({ ...RECEIPT, clean: false }, {
+            controlPlane: RECEIPT.controlPlane,
+            projectId: RECEIPT.projectId,
+            projectSlug: RECEIPT.projectSlug,
+            branch: RECEIPT.branch,
+            commitSha: RECEIPT.commitSha,
+            requireClean: true,
+          })
+        ),
+      Error,
+      "uncommitted changes",
+    );
+
+    await assertRejects(
+      () =>
+        Promise.resolve().then(() =>
+          validatePushReceipt(RECEIPT, {
+            controlPlane: RECEIPT.controlPlane,
+            projectId: RECEIPT.projectId,
+            projectSlug: RECEIPT.projectSlug,
+            branch: RECEIPT.branch,
+            commitSha: RECEIPT.commitSha,
+            clean: false,
+            requireClean: true,
+          })
+        ),
+      Error,
+      "uncommitted changes",
+    );
+  });
+});
+
+describe("push receipt persistence", () => {
+  it("round-trips a receipt in the ignored Veryfront directory", async () => {
+    const projectDir = await Deno.makeTempDir();
+    try {
+      await writePushReceipt(projectDir, {
+        ...RECEIPT,
+        controlPlane: "https://api.veryfront.com/",
+      });
+
+      const receipt = await readPushReceipt(projectDir);
+      assertExists(receipt);
+      assertEquals(receipt, RECEIPT);
+
+      await clearPushReceipt(projectDir);
+      assertEquals(await readPushReceipt(projectDir), null);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("returns null for a missing receipt", async () => {
+    const projectDir = await Deno.makeTempDir();
+    try {
+      assertEquals(await readPushReceipt(projectDir), null);
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+});
+
+describe("resolveGitSource", () => {
+  it("resolves the committed SHA and detects later working-tree changes", async () => {
+    const projectDir = await Deno.makeTempDir();
+    const originalGithubSha = Deno.env.get("GITHUB_SHA");
+    const originalGitDir = Deno.env.get("GIT_DIR");
+    const runGit = async (...args: string[]) => {
+      const result = await new Deno.Command("git", {
+        args,
+        cwd: projectDir,
+        clearEnv: true,
+        env: Object.fromEntries(
+          Object.entries(Deno.env.toObject()).filter(([key]) => !key.startsWith("GIT_")),
+        ),
+        stdout: "null",
+        stderr: "piped",
+      }).output();
+      assertEquals(result.success, true, new TextDecoder().decode(result.stderr));
+    };
+
+    try {
+      Deno.env.delete("GITHUB_SHA");
+      await runGit("init", "--quiet");
+      await runGit("config", "user.email", "test@veryfront.com");
+      await runGit("config", "user.name", "Veryfront Test");
+      await Deno.writeTextFile(`${projectDir}/app.ts`, "export const value = 1;\n");
+      await runGit("add", ".");
+      await runGit("commit", "--quiet", "-m", "initial");
+      await writePushReceipt(projectDir, RECEIPT);
+
+      Deno.env.set("GIT_DIR", `${projectDir}/not-a-repository`);
+      const clean = await resolveGitSource(projectDir);
+      if (originalGitDir === undefined) Deno.env.delete("GIT_DIR");
+      else Deno.env.set("GIT_DIR", originalGitDir);
+      assertEquals(clean.commitSha?.length, 40);
+      assertEquals(clean.clean, true);
+
+      Deno.env.set("GITHUB_SHA", "a".repeat(40));
+      const mismatchedCiSource = await resolveGitSource(projectDir);
+      assertEquals(mismatchedCiSource.commitSha, null);
+      assertEquals(mismatchedCiSource.clean, false);
+
+      Deno.env.set("GITHUB_SHA", "not-a-commit");
+      const invalidCiSource = await resolveGitSource(projectDir);
+      assertEquals(invalidCiSource.commitSha, null);
+      assertEquals(invalidCiSource.clean, false);
+      Deno.env.delete("GITHUB_SHA");
+
+      await Deno.writeTextFile(`${projectDir}/.veryfront/other.txt`, "untracked\n");
+      const untracked = await resolveGitSource(projectDir);
+      assertEquals(untracked.clean, false);
+      await Deno.remove(`${projectDir}/.veryfront/other.txt`);
+
+      await Deno.writeTextFile(`${projectDir}/app.ts`, "export const value = 2;\n");
+      const dirty = await resolveGitSource(projectDir);
+      assertEquals(dirty.commitSha, clean.commitSha);
+      assertEquals(dirty.clean, false);
+    } finally {
+      if (originalGitDir === undefined) Deno.env.delete("GIT_DIR");
+      else Deno.env.set("GIT_DIR", originalGitDir);
+      if (originalGithubSha === undefined) Deno.env.delete("GITHUB_SHA");
+      else Deno.env.set("GITHUB_SHA", originalGithubSha);
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+});

--- a/cli/shared/deployment-provenance.test.ts
+++ b/cli/shared/deployment-provenance.test.ts
@@ -208,6 +208,10 @@ describe("push receipt persistence", () => {
       const result = await new Deno.Command("git", {
         args,
         cwd: projectDir,
+        clearEnv: true,
+        env: Object.fromEntries(
+          Object.entries(Deno.env.toObject()).filter(([key]) => !key.startsWith("GIT_")),
+        ),
         stdout: "null",
         stderr: "piped",
       }).output();

--- a/cli/shared/deployment-provenance.ts
+++ b/cli/shared/deployment-provenance.ts
@@ -1,5 +1,6 @@
 import { createFileSystem, env, getEnv, runCommand } from "veryfront/platform";
-import { join } from "veryfront/platform/path";
+import { isNotFoundError, lstat, realPath } from "#veryfront/platform/compat/fs.ts";
+import { join, relative } from "veryfront/platform/path";
 import type { ApiClient } from "./config.ts";
 
 const RECEIPT_VERSION = 2 as const;
@@ -47,6 +48,49 @@ interface PushReceiptExpectation {
 
 function receiptPath(projectDir: string): string {
   return join(projectDir, RECEIPT_DIRECTORY, RECEIPT_FILENAME);
+}
+
+function receiptPathError(): Error {
+  return new Error(
+    `Veryfront cannot use ${RECEIPT_DIRECTORY}/${RECEIPT_FILENAME} through a symbolic link. Remove the link and run the command again.`,
+  );
+}
+
+async function lstatIfPresent(path: string) {
+  try {
+    return await lstat(path);
+  } catch (error) {
+    if (isNotFoundError(error)) return null;
+    throw error;
+  }
+}
+
+async function inspectReceiptPath(
+  projectDir: string,
+): Promise<{ directoryExists: boolean; receiptExists: boolean }> {
+  const directory = join(projectDir, RECEIPT_DIRECTORY);
+  const directoryInfo = await lstatIfPresent(directory);
+  if (!directoryInfo) return { directoryExists: false, receiptExists: false };
+  if (directoryInfo.isSymlink) throw receiptPathError();
+  if (!directoryInfo.isDirectory) {
+    throw new Error(`${RECEIPT_DIRECTORY} must be a directory inside the project.`);
+  }
+
+  const [canonicalProject, canonicalDirectory] = await Promise.all([
+    realPath(projectDir),
+    realPath(directory),
+  ]);
+  if (relative(canonicalProject, canonicalDirectory) !== RECEIPT_DIRECTORY) {
+    throw receiptPathError();
+  }
+
+  const receiptInfo = await lstatIfPresent(receiptPath(projectDir));
+  if (!receiptInfo) return { directoryExists: true, receiptExists: false };
+  if (receiptInfo.isSymlink) throw receiptPathError();
+  if (!receiptInfo.isFile) {
+    throw new Error(`${RECEIPT_DIRECTORY}/${RECEIPT_FILENAME} must be a file.`);
+  }
+  return { directoryExists: true, receiptExists: true };
 }
 
 function isPushReceipt(value: unknown): value is PushReceipt {
@@ -141,6 +185,37 @@ export async function resolveGitSource(projectDir: string): Promise<GitSource> {
   };
 }
 
+export async function areSourceFilesTracked(
+  projectDir: string,
+  files: readonly SourceFile[],
+): Promise<boolean> {
+  if (files.length === 0) return true;
+
+  const gitEnv = env();
+  for (const key of Object.keys(gitEnv)) {
+    if (key.startsWith("GIT_")) delete gitEnv[key];
+  }
+
+  try {
+    const result = await runCommand("git", {
+      args: ["ls-files", "--cached", "-z"],
+      cwd: projectDir,
+      clearEnv: true,
+      env: gitEnv,
+      capture: true,
+      timeoutMs: 5_000,
+    });
+    if (!result.success) return false;
+
+    const trackedPaths = new Set(
+      (result.stdout ?? "").split("\0").filter((path) => path.length > 0),
+    );
+    return files.every((file) => trackedPaths.has(file.path));
+  } catch {
+    return false;
+  }
+}
+
 export async function writePushReceipt(
   projectDir: string,
   receipt: Omit<PushReceipt, "version" | "pushedAt"> & { pushedAt?: string },
@@ -155,13 +230,16 @@ export async function writePushReceipt(
     pushedAt: receipt.pushedAt ?? new Date().toISOString(),
   };
 
-  await fs.mkdir(directory, { recursive: true });
+  const before = await inspectReceiptPath(projectDir);
+  if (!before.directoryExists) await fs.mkdir(directory, { recursive: true });
+  await inspectReceiptPath(projectDir);
   await fs.writeTextFile(receiptPath(projectDir), `${JSON.stringify(value, null, 2)}\n`);
   return value;
 }
 
 export async function readPushReceipt(projectDir: string): Promise<PushReceipt | null> {
   const fs = createFileSystem();
+  await inspectReceiptPath(projectDir);
   try {
     const value: unknown = JSON.parse(await fs.readTextFile(receiptPath(projectDir)));
     return isPushReceipt(value) ? value : null;
@@ -173,7 +251,8 @@ export async function readPushReceipt(projectDir: string): Promise<PushReceipt |
 export async function clearPushReceipt(projectDir: string): Promise<void> {
   const fs = createFileSystem();
   const path = receiptPath(projectDir);
-  if (await fs.exists(path)) await fs.remove(path);
+  const inspected = await inspectReceiptPath(projectDir);
+  if (inspected.receiptExists) await fs.remove(path);
 }
 
 export function validatePushReceipt(

--- a/cli/shared/deployment-provenance.ts
+++ b/cli/shared/deployment-provenance.ts
@@ -1,0 +1,208 @@
+import { createFileSystem, env, getEnv, runCommand } from "veryfront/platform";
+import { join } from "veryfront/platform/path";
+import type { ApiClient } from "./config.ts";
+
+const RECEIPT_VERSION = 2 as const;
+const RECEIPT_DIRECTORY = ".veryfront";
+const RECEIPT_FILENAME = "push-receipt.json";
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40,64}$/i;
+const SOURCE_DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
+
+export interface SourceFile {
+  path: string;
+  content: string;
+}
+
+export interface PushReceipt {
+  version: typeof RECEIPT_VERSION;
+  controlPlane: string;
+  projectId: string;
+  projectSlug: string;
+  branch: string;
+  commitSha: string | null;
+  sourceDigest: string;
+  clean: boolean;
+  pushedAt: string;
+}
+
+export interface GitSource {
+  commitSha: string | null;
+  clean: boolean;
+}
+
+export interface ProjectTarget {
+  id: string;
+  slug: string;
+}
+
+interface PushReceiptExpectation {
+  controlPlane: string;
+  projectId: string;
+  projectSlug: string;
+  branch: string;
+  commitSha?: string | null;
+  clean?: boolean;
+  requireClean?: boolean;
+}
+
+function receiptPath(projectDir: string): string {
+  return join(projectDir, RECEIPT_DIRECTORY, RECEIPT_FILENAME);
+}
+
+function isPushReceipt(value: unknown): value is PushReceipt {
+  if (!value || typeof value !== "object") return false;
+  const receipt = value as Record<string, unknown>;
+  return receipt.version === RECEIPT_VERSION &&
+    typeof receipt.controlPlane === "string" &&
+    typeof receipt.projectId === "string" &&
+    typeof receipt.projectSlug === "string" &&
+    typeof receipt.branch === "string" &&
+    (receipt.commitSha === null ||
+      (typeof receipt.commitSha === "string" && COMMIT_SHA_PATTERN.test(receipt.commitSha))) &&
+    typeof receipt.sourceDigest === "string" &&
+    SOURCE_DIGEST_PATTERN.test(receipt.sourceDigest) &&
+    typeof receipt.clean === "boolean" &&
+    typeof receipt.pushedAt === "string";
+}
+
+export async function computeSourceDigest(files: SourceFile[]): Promise<string> {
+  const canonicalFiles = files.map(({ path, content }) => [path, content] as const).sort(
+    ([left], [right]) => left < right ? -1 : left > right ? 1 : 0,
+  );
+  const bytes = new TextEncoder().encode(JSON.stringify(canonicalFiles));
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+  const hex = Array.from(digest, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `sha256:${hex}`;
+}
+
+export function normalizeControlPlane(apiUrl: string): string {
+  const url = new URL(apiUrl);
+  const pathname = url.pathname.replace(/\/+$/, "");
+  return `${url.origin}${pathname}`;
+}
+
+export function getProjectTarget(
+  client: ApiClient,
+  projectReference: string,
+): Promise<ProjectTarget> {
+  return client.get<ProjectTarget>(`/projects/${projectReference}`);
+}
+
+export async function resolveGitSource(projectDir: string): Promise<GitSource> {
+  const envSha = getEnv("GITHUB_SHA")?.trim();
+  const gitEnv = env();
+  for (const key of Object.keys(gitEnv)) {
+    if (key.startsWith("GIT_")) delete gitEnv[key];
+  }
+  let commandResults;
+  try {
+    commandResults = await Promise.all([
+      runCommand("git", {
+        args: ["rev-parse", "HEAD"],
+        cwd: projectDir,
+        clearEnv: true,
+        env: gitEnv,
+        capture: true,
+        timeoutMs: 5_000,
+      }),
+      runCommand("git", {
+        args: ["status", "--porcelain=v1", "--untracked-files=all"],
+        cwd: projectDir,
+        clearEnv: true,
+        env: gitEnv,
+        capture: true,
+        timeoutMs: 5_000,
+      }),
+    ]);
+  } catch {
+    return {
+      commitSha: envSha && COMMIT_SHA_PATTERN.test(envSha) ? envSha.toLowerCase() : null,
+      clean: false,
+    };
+  }
+
+  const [head, status] = commandResults;
+
+  const headSha = head.success ? head.stdout?.trim() : undefined;
+  const normalizedEnvSha = envSha && COMMIT_SHA_PATTERN.test(envSha) ? envSha.toLowerCase() : null;
+  const normalizedHeadSha = headSha && COMMIT_SHA_PATTERN.test(headSha)
+    ? headSha.toLowerCase()
+    : null;
+  const sourcesAgree = (!envSha || normalizedEnvSha !== null) &&
+    (!normalizedEnvSha || !normalizedHeadSha || normalizedEnvSha === normalizedHeadSha);
+  const commitSha = sourcesAgree ? normalizedEnvSha ?? normalizedHeadSha : null;
+
+  return {
+    commitSha,
+    clean: sourcesAgree && status.success &&
+      !(status.stdout ?? "").split("\n").some((line) =>
+        line !== "" && line !== `?? ${RECEIPT_DIRECTORY}/${RECEIPT_FILENAME}`
+      ),
+  };
+}
+
+export async function writePushReceipt(
+  projectDir: string,
+  receipt: Omit<PushReceipt, "version" | "pushedAt"> & { pushedAt?: string },
+): Promise<PushReceipt> {
+  const fs = createFileSystem();
+  const directory = join(projectDir, RECEIPT_DIRECTORY);
+  const value: PushReceipt = {
+    version: RECEIPT_VERSION,
+    ...receipt,
+    controlPlane: normalizeControlPlane(receipt.controlPlane),
+    commitSha: receipt.commitSha?.toLowerCase() ?? null,
+    pushedAt: receipt.pushedAt ?? new Date().toISOString(),
+  };
+
+  await fs.mkdir(directory, { recursive: true });
+  await fs.writeTextFile(receiptPath(projectDir), `${JSON.stringify(value, null, 2)}\n`);
+  return value;
+}
+
+export async function readPushReceipt(projectDir: string): Promise<PushReceipt | null> {
+  const fs = createFileSystem();
+  try {
+    const value: unknown = JSON.parse(await fs.readTextFile(receiptPath(projectDir)));
+    return isPushReceipt(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function clearPushReceipt(projectDir: string): Promise<void> {
+  const fs = createFileSystem();
+  const path = receiptPath(projectDir);
+  if (await fs.exists(path)) await fs.remove(path);
+}
+
+export function validatePushReceipt(
+  receipt: PushReceipt,
+  expected: PushReceiptExpectation,
+): string {
+  if (
+    normalizeControlPlane(receipt.controlPlane) !== normalizeControlPlane(expected.controlPlane)
+  ) {
+    throw new Error(
+      "The latest push targeted a different control plane. Run veryfront push again.",
+    );
+  }
+  if (receipt.projectId !== expected.projectId || receipt.projectSlug !== expected.projectSlug) {
+    throw new Error("The latest push targeted a different project. Run veryfront push again.");
+  }
+  if (receipt.branch !== expected.branch) {
+    throw new Error("The latest push targeted a different branch. Run veryfront push again.");
+  }
+  if (!receipt.commitSha) {
+    throw new Error("The latest push has no Git commit SHA. Commit the source and push again.");
+  }
+  if (expected.commitSha && receipt.commitSha !== expected.commitSha.toLowerCase()) {
+    throw new Error("The latest push came from a different commit. Run veryfront push again.");
+  }
+  if (expected.requireClean && (!receipt.clean || expected.clean === false)) {
+    throw new Error(
+      "The latest push included uncommitted changes. Commit the source and push again.",
+    );
+  }
+  return receipt.commitSha;
+}

--- a/cli/shared/reserve-slug.test.ts
+++ b/cli/shared/reserve-slug.test.ts
@@ -1,29 +1,52 @@
 import "#veryfront/schemas/_test-setup.ts";
 
-import { assertEquals } from "#veryfront/testing/assert.ts";
-import { it } from "#veryfront/testing/bdd.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
 import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
-import { reserveProjectSlug } from "./reserve-slug.ts";
+import { ProjectSlugConflictError, reserveProjectSlug } from "./reserve-slug.ts";
 
-it("reserves a first-push project on the resolved control plane", async () => {
-  let requestUrl = "";
+describe("reserveProjectSlug", () => {
+  it("reserves a first-push project on the resolved control plane", async () => {
+    let requestUrl = "";
 
-  const result = await withMockFetch(async (input: string | URL | Request) => {
-    const request = input instanceof Request ? input : new Request(input);
-    requestUrl = request.url;
-    return Response.json({ id: "550e8400-e29b-41d4-a716-446655440000" });
-  }, () =>
-    reserveProjectSlug(
-      "my-project",
-      "token",
-      undefined,
-      "https://control.example.test/api",
-    ));
+    const result = await withMockFetch(async (input: string | URL | Request) => {
+      const request = input instanceof Request ? input : new Request(input);
+      requestUrl = request.url;
+      return Response.json({ id: "550e8400-e29b-41d4-a716-446655440000" });
+    }, () =>
+      reserveProjectSlug(
+        "my-project",
+        "token",
+        undefined,
+        "https://control.example.test/api",
+      ));
 
-  assertEquals(requestUrl, "https://control.example.test/api/projects");
-  assertEquals(result, {
-    slug: "my-project",
-    projectId: "550e8400-e29b-41d4-a716-446655440000",
-    created: true,
+    assertEquals(requestUrl, "https://control.example.test/api/projects");
+    assertEquals(result, {
+      slug: "my-project",
+      projectId: "550e8400-e29b-41d4-a716-446655440000",
+      created: true,
+    });
+  });
+
+  it("does not create an alternative project for an explicit slug", async () => {
+    let requests = 0;
+    await assertRejects(
+      () =>
+        withMockFetch(() => {
+          requests++;
+          return Promise.resolve(Response.json({ error: "taken" }, { status: 409 }));
+        }, () =>
+          reserveProjectSlug(
+            "my-project",
+            "token",
+            undefined,
+            "https://control.example.test/api",
+            { allowAlternativeSlug: false },
+          )),
+      ProjectSlugConflictError,
+      "already in use",
+    );
+    assertEquals(requests, 1);
   });
 });

--- a/cli/shared/reserve-slug.test.ts
+++ b/cli/shared/reserve-slug.test.ts
@@ -1,0 +1,29 @@
+import "#veryfront/schemas/_test-setup.ts";
+
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { it } from "#veryfront/testing/bdd.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
+import { reserveProjectSlug } from "./reserve-slug.ts";
+
+it("reserves a first-push project on the resolved control plane", async () => {
+  let requestUrl = "";
+
+  const result = await withMockFetch(async (input: string | URL | Request) => {
+    const request = input instanceof Request ? input : new Request(input);
+    requestUrl = request.url;
+    return Response.json({ id: "550e8400-e29b-41d4-a716-446655440000" });
+  }, () =>
+    reserveProjectSlug(
+      "my-project",
+      "token",
+      undefined,
+      "https://control.example.test/api",
+    ));
+
+  assertEquals(requestUrl, "https://control.example.test/api/projects");
+  assertEquals(result, {
+    slug: "my-project",
+    projectId: "550e8400-e29b-41d4-a716-446655440000",
+    created: true,
+  });
+});

--- a/cli/shared/reserve-slug.ts
+++ b/cli/shared/reserve-slug.ts
@@ -38,12 +38,13 @@ export async function reserveProjectSlug(
   slug: string,
   token: string,
   env: EnvironmentConfig = getEnvironmentConfig(),
+  apiUrl: string = getApiUrl(env),
 ): Promise<ReserveResult> {
   const name = slugToName(slug);
   let currentSlug = slug;
 
   for (let attempt = 1; attempt <= MAX_SLUG_ATTEMPTS; attempt++) {
-    const result = await tryCreateProject(currentSlug, name, token, env);
+    const result = await tryCreateProject(currentSlug, name, token, apiUrl);
 
     if (result.success) {
       return {
@@ -67,10 +68,10 @@ async function tryCreateProject(
   slug: string,
   name: string,
   token: string,
-  env: EnvironmentConfig = getEnvironmentConfig(),
+  apiUrl: string,
 ): Promise<CreateProjectResult> {
   try {
-    const response = await fetch(`${getApiUrl(env)}/projects`, {
+    const response = await fetch(`${apiUrl.replace(/\/+$/, "")}/projects`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/cli/shared/reserve-slug.ts
+++ b/cli/shared/reserve-slug.ts
@@ -21,6 +21,17 @@ export interface ReserveResult {
   created: boolean;
 }
 
+export interface ReserveProjectSlugOptions {
+  allowAlternativeSlug?: boolean;
+}
+
+export class ProjectSlugConflictError extends Error {
+  constructor(public readonly slug: string) {
+    super(`Project slug "${slug}" is already in use.`);
+    this.name = "ProjectSlugConflictError";
+  }
+}
+
 interface ApiError {
   message?: string;
 }
@@ -39,6 +50,7 @@ export async function reserveProjectSlug(
   token: string,
   env: EnvironmentConfig = getEnvironmentConfig(),
   apiUrl: string = getApiUrl(env),
+  options: ReserveProjectSlugOptions = {},
 ): Promise<ReserveResult> {
   const name = slugToName(slug);
   let currentSlug = slug;
@@ -56,6 +68,10 @@ export async function reserveProjectSlug(
 
     if (!result.isSlugTaken) {
       throw new Error(result.error ?? "Failed to create project");
+    }
+
+    if (options.allowAlternativeSlug === false) {
+      throw new ProjectSlugConflictError(slug);
     }
 
     currentSlug = `${slug}-${randomSuffix()}`;

--- a/cli/skills/core-skills.ts
+++ b/cli/skills/core-skills.ts
@@ -87,14 +87,17 @@ Build, test, deploy, and verify with rollback on failure.
 
 1. \`veryfront build --json\`, abort if success: false
 2. \`veryfront test --json\`, abort if any test fails
-3. \`veryfront deploy --env <environment> --branch <branch> --yes --json\`
-4. Use vf_get_errors to verify no runtime errors after deploy
-5. If errors: redeploy previous version
+3. \`veryfront push --branch <branch> --force\`, abort if any upload fails
+4. \`veryfront deploy --env <environment> --branch <branch> --yes --json\`
+5. Record the project, environment, release, deployment, and commit IDs
+6. Use vf_get_errors to verify no runtime errors after deploy
+7. If errors: redeploy previous version
 
 ## Error Recovery
 
 - **Build fails**: Check vf_get_errors, fix and retry
 - **Tests fail**: Read JSON output, fix failing tests
+- **Push fails**: Fix failed uploads before retrying deploy
 - **Deploy fails**: Check environment, auth, branch
 - **Post-deploy errors**: Redeploy previous release`,
     directory: "core:deploy-safely",

--- a/src/platform/compat/cross-runtime.test.ts
+++ b/src/platform/compat/cross-runtime.test.ts
@@ -34,6 +34,7 @@ import {
   env,
   getArgs,
   getEnv,
+  getOsType,
   getRuntimeVersion,
   memoryUsage,
   pid,
@@ -41,7 +42,7 @@ import {
   unrefTimer,
 } from "./process.ts";
 
-import { createFileSystem } from "./fs.ts";
+import { createFileSystem, lstat, symlink } from "./fs.ts";
 import { isBun, isDeno, isNode } from "./runtime.ts";
 
 function getCurrentRuntime(): string {
@@ -214,6 +215,25 @@ describe("Filesystem Operations", () => {
     const thisFile = new URL(import.meta.url).pathname;
     const content = await fs.readTextFile(thisFile);
     assert(content.includes("Cross-Runtime Compatibility Tests"), "should read this file");
+  });
+
+  it("fs.readDir and lstat report symbolic links", async () => {
+    if (getOsType() === "windows") return;
+
+    const fs = createFileSystem();
+    const directory = await fs.makeTempDir({ prefix: "veryfront-fs-link-" });
+    const target = join(directory, "target.ts");
+    const link = join(directory, "linked.ts");
+    try {
+      await fs.writeTextFile(target, "export const value = 1;\n");
+      await symlink(target, link);
+
+      const entries = await Array.fromAsync(fs.readDir(directory));
+      assertEquals(entries.find((entry) => entry.name === "linked.ts")?.isSymlink, true);
+      assertEquals((await lstat(link)).isSymlink, true);
+    } finally {
+      await fs.remove(directory, { recursive: true });
+    }
   });
 });
 

--- a/src/platform/compat/fs.test.ts
+++ b/src/platform/compat/fs.test.ts
@@ -13,6 +13,7 @@ import {
   exists,
   isAlreadyExistsError,
   isNotFoundError,
+  lstat,
   makeTempDir,
   mkdir,
   readDir,
@@ -228,6 +229,7 @@ describe("Filesystem Compat", () => {
 
       const content = await readTextFile(linkPath);
       assertEquals(content, "symlink test");
+      assertEquals((await lstat(linkPath)).isSymlink, true);
     });
   });
 

--- a/src/platform/compat/fs.ts
+++ b/src/platform/compat/fs.ts
@@ -23,7 +23,9 @@ export interface FileSystem {
   exists(path: string): Promise<boolean>;
   stat(path: string): Promise<FileInfo>;
   mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
-  readDir(path: string): AsyncIterable<{ name: string; isFile: boolean; isDirectory: boolean }>;
+  readDir(
+    path: string,
+  ): AsyncIterable<{ name: string; isFile: boolean; isDirectory: boolean; isSymlink?: boolean }>;
   remove(path: string, options?: { recursive?: boolean }): Promise<void>;
   makeTempDir(options?: { prefix?: string }): Promise<string>;
   chmod(path: string, mode: number): Promise<void>;
@@ -156,11 +158,21 @@ class NodeFileSystem implements FileSystem {
 
   async *readDir(
     path: string,
-  ): AsyncIterable<{ name: string; isFile: boolean; isDirectory: boolean }> {
+  ): AsyncIterable<{
+    name: string;
+    isFile: boolean;
+    isDirectory: boolean;
+    isSymlink?: boolean;
+  }> {
     await this.ensureInitialized();
     const entries = await this.getFs().readdir(path, { withFileTypes: true });
     for (const entry of entries) {
-      yield { name: entry.name, isFile: entry.isFile(), isDirectory: entry.isDirectory() };
+      yield {
+        name: entry.name,
+        isFile: entry.isFile(),
+        isDirectory: entry.isDirectory(),
+        isSymlink: entry.isSymbolicLink(),
+      };
     }
   }
 
@@ -236,9 +248,19 @@ class DenoFileSystem implements FileSystem {
 
   async *readDir(
     path: string,
-  ): AsyncIterable<{ name: string; isFile: boolean; isDirectory: boolean }> {
+  ): AsyncIterable<{
+    name: string;
+    isFile: boolean;
+    isDirectory: boolean;
+    isSymlink?: boolean;
+  }> {
     for await (const entry of denoGlobal().readDir(path)) {
-      yield { name: entry.name, isFile: entry.isFile, isDirectory: entry.isDirectory };
+      yield {
+        name: entry.name,
+        isFile: entry.isFile,
+        isDirectory: entry.isDirectory,
+        isSymlink: entry.isSymlink,
+      };
     }
   }
 
@@ -314,7 +336,12 @@ export function remove(path: string, options?: { recursive?: boolean }): Promise
 /** Read directory entries. */
 export function readDir(
   path: string,
-): AsyncIterable<{ name: string; isFile: boolean; isDirectory: boolean }> {
+): AsyncIterable<{
+  name: string;
+  isFile: boolean;
+  isDirectory: boolean;
+  isSymlink?: boolean;
+}> {
   return getFs().readDir(path);
 }
 

--- a/src/platform/compat/fs.ts
+++ b/src/platform/compat/fs.ts
@@ -323,6 +323,30 @@ export function stat(path: string): Promise<FileInfo> {
   return getFs().stat(path);
 }
 
+/** Read file metadata without following a terminal symbolic link. */
+export async function lstat(path: string): Promise<FileInfo> {
+  if (isDeno) {
+    const info = await denoGlobal().lstat(path);
+    return {
+      isFile: info.isFile,
+      isDirectory: info.isDirectory,
+      isSymlink: info.isSymlink,
+      size: info.size,
+      mtime: info.mtime,
+    };
+  }
+
+  const fs = await import("node:fs/promises");
+  const info = await fs.lstat(path);
+  return {
+    isFile: info.isFile(),
+    isDirectory: info.isDirectory(),
+    isSymlink: info.isSymbolicLink(),
+    size: info.size,
+    mtime: info.mtime,
+  };
+}
+
 /** Create a directory. */
 export function mkdir(path: string, options?: { recursive?: boolean }): Promise<void> {
   return getFs().mkdir(path, options);

--- a/src/platform/compat/process/command.test.ts
+++ b/src/platform/compat/process/command.test.ts
@@ -1,0 +1,30 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { deleteEnv, getEnv, runCommand, setEnv } from "../process.ts";
+
+describe("runCommand", () => {
+  it("clears inherited environment variables", async () => {
+    const inheritedKey = "VERYFRONT_RUN_COMMAND_INHERITED";
+    const explicitKey = "VERYFRONT_RUN_COMMAND_EXPLICIT";
+    setEnv(inheritedKey, "must-not-leak");
+
+    try {
+      const path = getEnv("PATH");
+      const result = await runCommand("env", {
+        capture: true,
+        clearEnv: true,
+        env: {
+          ...(path ? { PATH: path } : {}),
+          [explicitKey]: "available",
+        },
+      });
+
+      assertEquals(result.success, true);
+      assertEquals(result.stdout?.includes(`${explicitKey}=available`), true);
+      assertEquals(result.stdout?.includes(`${inheritedKey}=`), false);
+    } finally {
+      deleteEnv(inheritedKey);
+    }
+  });
+});

--- a/src/platform/compat/process/command.ts
+++ b/src/platform/compat/process/command.ts
@@ -13,6 +13,8 @@ export interface CommandOptions {
   args?: string[];
   cwd?: string;
   env?: Record<string, string>;
+  /** Start from an empty environment before applying `env`. */
+  clearEnv?: boolean;
   /** Capture stdout/stderr to return in result */
   capture?: boolean;
   /** Inherit stdio from parent process (shows output in terminal) */
@@ -116,6 +118,7 @@ export async function runCommand(
     args = [],
     cwd: cmdCwd,
     env: cmdEnv,
+    clearEnv = false,
     capture = false,
     inherit = false,
     shell = false,
@@ -132,6 +135,7 @@ export async function runCommand(
       args,
       cwd: cmdCwd,
       env: cmdEnv,
+      clearEnv,
       stdin: inherit ? "inherit" : "null",
       stdout: stdioMode,
       stderr: stdioMode,
@@ -198,7 +202,7 @@ export async function runCommand(
     const proc = bunGlobal.Bun.spawn({
       cmd: bunCmd,
       cwd: cmdCwd,
-      env: cmdEnv,
+      env: clearEnv ? cmdEnv ?? {} : cmdEnv,
       stdout: bunStdio,
       stderr: bunStdio,
     });
@@ -244,7 +248,7 @@ export async function runCommand(
   return await new Promise((resolve) => {
     const child = spawn(cmd, args, {
       cwd: cmdCwd,
-      env: cmdEnv ? { ...process.env, ...cmdEnv } : undefined,
+      env: clearEnv ? cmdEnv ?? {} : cmdEnv ? { ...process.env, ...cmdEnv } : undefined,
       stdio: nodeStdio,
       shell,
     });


### PR DESCRIPTION
## Summary
- bind deploys to a successful push receipt containing the canonical control plane/project, clean Git SHA, and deterministic source digest
- prove the created release snapshot matches that pushed source, then read back deployment/release/environment IDs and wait for the exact production pointer
- use the same verifier for human CLI, `--json` CI, and MCP deploys while supporting current and legacy API response shapes

## Verification
- `deno task typecheck`
- `deno task test:unit` (2329 tests, 19644 steps)
- `deno task test:integration:cli` (20 suites, 166 steps)
- focused deploy/push/MCP/provenance tests (25 tests/suites, 97 steps)
- `deno lint` and `deno fmt --check`

Known baseline: the extended style and CLI-boundary gates still report pre-existing violations in `src/server/utils/domain-lookup.ts`, `cli/utils/index.ts`, and `cli/commands/pull/command.ts`; none are touched here.

Fixes veryfront/veryfront-studio#5731