### PR TITLE
fix(ci): skip stable publication when version is unchanged

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -343,16 +343,30 @@ jobs:
     outputs:
       version: ${{ steps.check.outputs.version }}
       is_stable: ${{ steps.check.outputs.is_stable }}
+      stable_release_requested: ${{ steps.check.outputs.stable_release_requested }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
       - name: Detect release type
         id: check
         run: |
           VERSION=$(jq -r '.version' deno.json)
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+          STABLE_RELEASE_REQUESTED=$(bash scripts/ci/stable-release-requested.sh \
+            "${{ github.event_name }}" \
+            "$VERSION" \
+            "${{ github.event.before }}")
+          echo "stable_release_requested=${STABLE_RELEASE_REQUESTED}" >> $GITHUB_OUTPUT
+
           if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "is_stable=true" >> $GITHUB_OUTPUT
-            echo "::notice::Stable version detected: $VERSION → will publish as latest"
+            if [[ "$STABLE_RELEASE_REQUESTED" == "true" ]]; then
+              echo "::notice::Stable release requested: $VERSION → will publish as latest"
+            else
+              echo "::notice::Stable version unchanged: $VERSION → skipping publication"
+            fi
           else
             echo "is_stable=false" >> $GITHUB_OUTPUT
             echo "::notice::Pre-release version detected: $VERSION → will publish as rc"
@@ -525,12 +539,12 @@ jobs:
 
   # ============================================
   # CD: Stable Release (clean semver only)
-  # Runs when deno.json version is X.Y.Z (no suffix)
+  # Runs when deno.json changes to X.Y.Z (no suffix), or on manual dispatch
   # Publishes with --tag latest, creates git tag, updates Homebrew
   # ============================================
 
   release:
-    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && needs.version-check.outputs.is_stable == 'true' }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && needs.version-check.outputs.is_stable == 'true' && needs.version-check.outputs.stable_release_requested == 'true' }}
     needs: [ci, tests, coverage, tests-binary-e2e, tests-npm-install-smoke, build-binaries, version-check]
     runs-on: ubuntu-latest
     environment: production

--- a/scripts/ci/stable-release-requested.sh
+++ b/scripts/ci/stable-release-requested.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EVENT_NAME="${1:-}"
+CURRENT_VERSION="${2:-}"
+BEFORE="${3:-}"
+
+if [[ -z "$EVENT_NAME" || -z "$CURRENT_VERSION" ]]; then
+  echo "usage: stable-release-requested.sh <event-name> <current-version> [before-revision]" >&2
+  exit 2
+fi
+
+STABLE_RELEASE_REQUESTED=false
+if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+  STABLE_RELEASE_REQUESTED=true
+elif [[ "$EVENT_NAME" == "push" ]]; then
+  if [[ -n "$BEFORE" ]] && git cat-file -e "${BEFORE}:deno.json" 2>/dev/null; then
+    PREVIOUS_VERSION=$(git show "${BEFORE}:deno.json" | jq -r '.version')
+    if [[ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]]; then
+      STABLE_RELEASE_REQUESTED=true
+    fi
+  else
+    echo "::warning::Could not read deno.json at ${BEFORE}; preserving the collision-checked release path" >&2
+    STABLE_RELEASE_REQUESTED=true
+  fi
+fi
+
+printf '%s\n' "$STABLE_RELEASE_REQUESTED"

--- a/src/config/cicd-stable-release.test.ts
+++ b/src/config/cicd-stable-release.test.ts
@@ -1,0 +1,176 @@
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+
+const decoder = new TextDecoder();
+// Git hooks export repository-local GIT_* variables that must not leak into fixtures.
+const commandEnv = Object.fromEntries(
+  Object.entries(Deno.env.toObject()).filter(([key]) => !key.startsWith("GIT_")),
+);
+
+type CommandResult = {
+  code: number;
+  stdout: string;
+  stderr: string;
+};
+
+async function runCommand(
+  command: string,
+  args: string[],
+  cwd: string,
+): Promise<CommandResult> {
+  const result = await new Deno.Command(command, {
+    args,
+    clearEnv: true,
+    cwd,
+    env: commandEnv,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+
+  return {
+    code: result.code,
+    stdout: decoder.decode(result.stdout).trim(),
+    stderr: decoder.decode(result.stderr).trim(),
+  };
+}
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const result = await runCommand("git", args, cwd);
+  assertEquals(result.code, 0, result.stderr);
+  return result.stdout;
+}
+
+async function commitAll(cwd: string, message: string): Promise<void> {
+  await git(cwd, "add", ".");
+  await git(cwd, "commit", "-m", message);
+}
+
+async function createRepository(): Promise<{
+  cwd: string;
+  before: string;
+  scriptPath: string;
+}> {
+  const cwd = await Deno.makeTempDir();
+  const scriptPath = await Deno.realPath(
+    "scripts/ci/stable-release-requested.sh",
+  );
+
+  await git(cwd, "init", "--quiet");
+  await git(cwd, "config", "user.name", "CI Test");
+  await git(cwd, "config", "user.email", "ci@example.test");
+  await git(cwd, "config", "commit.gpgsign", "false");
+  await Deno.writeTextFile(
+    `${cwd}/deno.json`,
+    JSON.stringify({ version: "1.0.0" }),
+  );
+  await commitAll(cwd, "initial version");
+
+  return {
+    cwd,
+    before: await git(cwd, "rev-parse", "HEAD"),
+    scriptPath,
+  };
+}
+
+async function detectRelease(
+  cwd: string,
+  scriptPath: string,
+  eventName: string,
+  currentVersion: string,
+  before: string,
+): Promise<CommandResult> {
+  return await runCommand(
+    "bash",
+    [scriptPath, eventName, currentVersion, before],
+    cwd,
+  );
+}
+
+describe("stable release intent", () => {
+  it("skips publication when a multi-commit push keeps the version unchanged", async () => {
+    const repository = await createRepository();
+    try {
+      await Deno.writeTextFile(`${repository.cwd}/first.txt`, "first");
+      await commitAll(repository.cwd, "first feature commit");
+      await Deno.writeTextFile(`${repository.cwd}/second.txt`, "second");
+      await commitAll(repository.cwd, "second feature commit");
+
+      const result = await detectRelease(
+        repository.cwd,
+        repository.scriptPath,
+        "push",
+        "1.0.0",
+        repository.before,
+      );
+
+      assertEquals(result.code, 0);
+      assertEquals(result.stdout, "false");
+      assertEquals(result.stderr, "");
+    } finally {
+      await Deno.remove(repository.cwd, { recursive: true });
+    }
+  });
+
+  it("requests publication when the pushed version changed", async () => {
+    const repository = await createRepository();
+    try {
+      await Deno.writeTextFile(
+        `${repository.cwd}/deno.json`,
+        JSON.stringify({ version: "1.0.1" }),
+      );
+      await commitAll(repository.cwd, "bump version");
+
+      const result = await detectRelease(
+        repository.cwd,
+        repository.scriptPath,
+        "push",
+        "1.0.1",
+        repository.before,
+      );
+
+      assertEquals(result.code, 0);
+      assertEquals(result.stdout, "true");
+      assertEquals(result.stderr, "");
+    } finally {
+      await Deno.remove(repository.cwd, { recursive: true });
+    }
+  });
+
+  it("treats manual dispatch as explicit release intent", async () => {
+    const repository = await createRepository();
+    try {
+      const result = await detectRelease(
+        repository.cwd,
+        repository.scriptPath,
+        "workflow_dispatch",
+        "1.0.0",
+        "",
+      );
+
+      assertEquals(result.code, 0);
+      assertEquals(result.stdout, "true");
+      assertEquals(result.stderr, "");
+    } finally {
+      await Deno.remove(repository.cwd, { recursive: true });
+    }
+  });
+
+  it("fails open to collision checks when the prior revision is unavailable", async () => {
+    const repository = await createRepository();
+    try {
+      const result = await detectRelease(
+        repository.cwd,
+        repository.scriptPath,
+        "push",
+        "1.0.0",
+        "0000000000000000000000000000000000000000",
+      );
+
+      assertEquals(result.code, 0);
+      assertEquals(result.stdout, "true");
+      assert(result.stderr.includes("preserving the collision-checked release path"));
+    } finally {
+      await Deno.remove(repository.cwd, { recursive: true });
+    }
+  });
+});

--- a/src/security/repository-hardening.test.ts
+++ b/src/security/repository-hardening.test.ts
@@ -99,6 +99,31 @@ describe("repository hardening", () => {
     assert(publishScript.includes("npm publish --provenance --access public 2>&1"));
   });
 
+  it("only publishes a stable version after a version change or manual dispatch", async () => {
+    const workflow = await readText(".github/workflows/cicd.yml");
+    const versionCheck = jobBlock(workflow, "version-check");
+    const prerelease = jobBlock(workflow, "prerelease");
+    const release = jobBlock(workflow, "release");
+
+    assert(versionCheck.includes("stable_release_requested:"));
+    assert(versionCheck.includes("fetch-depth: 0"));
+    assert(
+      versionCheck.includes(
+        "bash scripts/ci/stable-release-requested.sh",
+      ),
+    );
+    assert(versionCheck.includes("github.event.before"));
+    assert(
+      release.includes(
+        "needs.version-check.outputs.stable_release_requested == 'true'",
+      ),
+    );
+    assert(
+      release.includes("needs.version-check.outputs.is_stable == 'true'"),
+    );
+    assertEquals(prerelease.includes("stable_release_requested"), false);
+  });
+
   it("uses scoped GitHub App tokens instead of release PATs", async () => {
     const releaseWorkflow = await readText(".github/workflows/cicd.yml");
     const docsWorkflow = await readText(".github/workflows/sync-docs.yml");


### PR DESCRIPTION
## Summary

- derive stable release intent from the version at the push before revision
- skip stable publication for ordinary main merges that retain the published version
- preserve manual dispatch, RC publication, and the existing artifact collision guards
- behavior-test unchanged multi-commit pushes, version bumps, manual dispatch, and unavailable history

## Why

Healthy feature merges currently pass every test and then leave main red because the release job tries to republish the prior stable version. Existing package or tag collisions must still fail when a release is actually requested.

## Verification

- full protected pre-push gate with DENO_JOBS=1: 2,323 suites, 19,644 steps, 0 failures
- format, lint, typecheck, bash syntax, and workflow wiring checks passed
- real commit decisions: unchanged 0.1.1046 -> false; release bump 0.1.1047 -> true

Fixes #2867