### PR TITLE
test: make timing-sensitive runtime tests deterministic

### DIFF
--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -5,12 +5,48 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { withToolInputStatusTransitions } from "./runtime-loader.ts";
 import { createOpenAIModelRuntime } from "../../extensions/ext-llm-openai/src/openai-provider.ts";
 
-async function collectAsync<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function deferred<T = void>(description: string, timeoutMs = 1_000): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(`Timed out waiting for ${description}`));
+    }, timeoutMs);
+    resolve = (value) => {
+      clearTimeout(timeoutId);
+      resolvePromise(value);
+    };
+  });
+
+  return { promise, resolve };
+}
+
+async function collectAsync<T>(
+  iterable: AsyncIterable<T>,
+  onValue?: (value: T, values: T[]) => void,
+): Promise<T[]> {
   const values: T[] = [];
   for await (const value of iterable) {
     values.push(value);
+    onValue?.(value, values);
   }
   return values;
+}
+
+function isToolStatusEvent(
+  event: unknown,
+  status: "pending_input" | "streaming_input",
+): event is { type: "data-tool-call-status"; data: { toolCallId: string; status: string } } {
+  return (
+    !!event &&
+    typeof event === "object" &&
+    (event as { type?: string }).type === "data-tool-call-status" &&
+    (event as { data?: { status?: string } }).data?.status === status
+  );
 }
 
 function readRequestBody(init: RequestInit | undefined): string | null {
@@ -22,21 +58,37 @@ function readRequestBody(init: RequestInit | undefined): string | null {
 
 describe("provider/runtime-loader", () => {
   it("emits pending_input and streaming_input transitions when tool input goes silent and resumes", async () => {
-    const events = await collectAsync(withToolInputStatusTransitions({
-      async *[Symbol.asyncIterator]() {
-        yield { type: "tool-input-start", id: "tool-1", toolName: "create_file" };
-        await new Promise((resolve) => setTimeout(resolve, 8));
-        yield { type: "tool-input-delta", id: "tool-1", delta: '{"path":"docs/report.md"' };
-        await new Promise((resolve) => setTimeout(resolve, 8));
-        yield {
-          type: "tool-call",
-          toolCallId: "tool-1",
-          toolName: "create_file",
-          input: { path: "docs/report.md" },
-        };
-        yield { type: "finish", finishReason: "tool-calls" };
+    const pendingAfterStart = deferred("pending_input after tool-input-start");
+    const pendingAfterDelta = deferred("pending_input after tool-input-delta");
+    let pendingCount = 0;
+
+    const events = await collectAsync(
+      withToolInputStatusTransitions({
+        async *[Symbol.asyncIterator]() {
+          yield { type: "tool-input-start", id: "tool-1", toolName: "create_file" };
+          await pendingAfterStart.promise;
+          yield { type: "tool-input-delta", id: "tool-1", delta: '{"path":"docs/report.md"' };
+          await pendingAfterDelta.promise;
+          yield {
+            type: "tool-call",
+            toolCallId: "tool-1",
+            toolName: "create_file",
+            input: { path: "docs/report.md" },
+          };
+          yield { type: "finish", finishReason: "tool-calls" };
+        },
+      }, 0),
+      (event) => {
+        if (isToolStatusEvent(event, "pending_input")) {
+          pendingCount += 1;
+          if (pendingCount === 1) {
+            pendingAfterStart.resolve();
+          } else if (pendingCount === 2) {
+            pendingAfterDelta.resolve();
+          }
+        }
       },
-    }, 5));
+    );
 
     assertEquals(events, [
       { type: "tool-input-start", id: "tool-1", toolName: "create_file" },
@@ -64,28 +116,51 @@ describe("provider/runtime-loader", () => {
   });
 
   it("repeats pending_input heartbeats while create_file content stays silent after the path", async () => {
-    const events = await collectAsync(withToolInputStatusTransitions({
-      async *[Symbol.asyncIterator]() {
-        yield { type: "tool-input-start", id: "tool-1", toolName: "create_file" };
-        yield {
-          type: "tool-input-delta",
-          id: "tool-1",
-          delta: '{"path":"plans/ai-ontologies-research.md"',
-        };
-        await new Promise((resolve) => setTimeout(resolve, 18));
-        yield { type: "tool-input-delta", id: "tool-1", delta: ', "content":"# AI Ontologies"' };
-        yield {
-          type: "tool-call",
-          toolCallId: "tool-1",
-          toolName: "create_file",
-          input: {
-            path: "plans/ai-ontologies-research.md",
-            content: "# AI Ontologies",
-          },
-        };
-        yield { type: "finish", finishReason: "tool-calls" };
+    const repeatedPendingAfterPath = deferred("repeated pending_input after the path delta");
+    let pendingAfterPathCount = 0;
+    let sawPathDelta = false;
+
+    const events = await collectAsync(
+      withToolInputStatusTransitions({
+        async *[Symbol.asyncIterator]() {
+          yield { type: "tool-input-start", id: "tool-1", toolName: "create_file" };
+          yield {
+            type: "tool-input-delta",
+            id: "tool-1",
+            delta: '{"path":"plans/ai-ontologies-research.md"',
+          };
+          await repeatedPendingAfterPath.promise;
+          yield { type: "tool-input-delta", id: "tool-1", delta: ', "content":"# AI Ontologies"' };
+          yield {
+            type: "tool-call",
+            toolCallId: "tool-1",
+            toolName: "create_file",
+            input: {
+              path: "plans/ai-ontologies-research.md",
+              content: "# AI Ontologies",
+            },
+          };
+          yield { type: "finish", finishReason: "tool-calls" };
+        },
+      }, 0),
+      (event) => {
+        if (
+          event &&
+          typeof event === "object" &&
+          (event as { type?: string }).type === "tool-input-delta"
+        ) {
+          sawPathDelta = true;
+          return;
+        }
+
+        if (sawPathDelta && isToolStatusEvent(event, "pending_input")) {
+          pendingAfterPathCount += 1;
+          if (pendingAfterPathCount === 2) {
+            repeatedPendingAfterPath.resolve();
+          }
+        }
       },
-    }, 5));
+    );
 
     const firstDeltaIndex = events.findIndex((event) =>
       event && typeof event === "object" && (event as { type?: string }).type === "tool-input-delta"

--- a/src/security/sandbox/project-worker.test.ts
+++ b/src/security/sandbox/project-worker.test.ts
@@ -57,6 +57,10 @@ function createTestWorker(projectId = "test-project"): ProjectWorker {
   });
 }
 
+async function assertWorkerReady(worker: ProjectWorker): Promise<void> {
+  assertEquals(await worker.isHealthy(30_000), true);
+}
+
 testSuite("ProjectWorker", () => {
   it("starts in idle state after start()", () => {
     const worker = createTestWorker();
@@ -193,6 +197,8 @@ testSuite("ProjectWorker - real worker request isolation", () => {
 
     worker.start();
     try {
+      await assertWorkerReady(worker);
+
       const response = await worker.execute(
         {
           type: "unknown-request",
@@ -232,6 +238,8 @@ testSuite("ProjectWorker - real worker request isolation", () => {
 
     worker.start();
     try {
+      await assertWorkerReady(worker);
+
       const first = await worker.execute({
         type: "execute-app-route",
         id: "first",
@@ -282,7 +290,7 @@ testSuite("ProjectWorker - real worker request isolation", () => {
     }
   });
 
-  it("does not leak overlapping projectEnv overlays between concurrent requests", async () => {
+  it("does not leak projectEnv overlays between queued back-to-back requests", async () => {
     const projectDir = await Deno.makeTempDir();
     const modulePath = await Deno.makeTempFile({ dir: projectDir, suffix: ".mjs" });
     const requestAKey = "VERYFRONT_TEST_REQUEST_A_SECRET";
@@ -318,6 +326,8 @@ testSuite("ProjectWorker - real worker request isolation", () => {
 
     worker.start();
     try {
+      await assertWorkerReady(worker);
+
       const first = worker.execute({
         type: "execute-app-route",
         id: "request-a",
@@ -334,9 +344,7 @@ testSuite("ProjectWorker - real worker request isolation", () => {
         projectEnv: { [requestAKey]: "tenant-a" },
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 20));
-
-      const second = await worker.execute({
+      const second = worker.execute({
         type: "execute-app-route",
         id: "request-b",
         modulePath,
@@ -352,12 +360,12 @@ testSuite("ProjectWorker - real worker request isolation", () => {
         projectEnv: { [requestBKey]: "tenant-b" },
       });
 
-      const firstResponse = await first;
+      const [firstResponse, secondResponse] = await Promise.all([first, second]);
 
-      assertEquals(second.type, "result");
-      if (second.type !== "result") throw new Error("expected result response");
+      assertEquals(secondResponse.type, "result");
+      if (secondResponse.type !== "result") throw new Error("expected result response");
       assertEquals(
-        JSON.parse(new TextDecoder().decode(second.response.body ?? new Uint8Array())),
+        JSON.parse(new TextDecoder().decode(secondResponse.response.body ?? new Uint8Array())),
         { request: "b", requestA: null, requestB: "tenant-b" },
       );
 
@@ -423,6 +431,8 @@ testSuite("ProjectWorker - real worker request isolation", () => {
 
     worker.start();
     try {
+      await assertWorkerReady(worker);
+
       const response = await worker.execute({
         type: "execute-app-route",
         id: "env-allowlist",
@@ -483,6 +493,8 @@ testSuite("ProjectWorker - real worker request isolation", () => {
 
     worker.start();
     try {
+      await assertWorkerReady(worker);
+
       const response = await worker.execute({
         type: "execute-app-route",
         id: "direct-read",
@@ -538,6 +550,8 @@ testSuite("ProjectWorker - real worker request isolation", () => {
 
     worker.start();
     try {
+      await assertWorkerReady(worker);
+
       const response = await worker.execute({
         type: "execute-app-route",
         id: "loopback-fetch",
@@ -597,6 +611,8 @@ testSuite("ProjectWorker - real worker request isolation", () => {
 
     worker.start();
     try {
+      await assertWorkerReady(worker);
+
       const response = await worker.execute({
         type: "execute-app-route",
         id: "loopback-connect",
@@ -656,6 +672,8 @@ testSuite("ProjectWorker - real worker request isolation", () => {
 
     worker.start();
     try {
+      await assertWorkerReady(worker);
+
       const response = await worker.execute({
         type: "execute-app-route",
         id: "loopback-fetch-override",

--- a/src/skill/executor.test.ts
+++ b/src/skill/executor.test.ts
@@ -39,17 +39,24 @@ function mockFetch(responses: MockResponseEntry[]): void {
   globalThis.fetch = installMockFetch({ calls: fetchCalls, responses: fetchResponses });
 }
 
-function delayedErrorNdjsonResponse(error: Error, delayMs: number): Response {
+function pendingErrorNdjsonResponse(error: Error): {
+  response: Response;
+  reject: () => void;
+} {
+  let rejectBody!: (reason: Error) => void;
   const body = new ReadableStream<Uint8Array>({
     start(controller) {
-      setTimeout(() => controller.error(error), delayMs);
+      rejectBody = (reason) => controller.error(reason);
     },
   });
 
-  return new Response(body, {
-    status: 200,
-    headers: { "Content-Type": "application/x-ndjson" },
-  });
+  return {
+    response: new Response(body, {
+      status: 200,
+      headers: { "Content-Type": "application/x-ndjson" },
+    }),
+    reject: () => rejectBody(error),
+  };
 }
 
 describe("src/skill/executor", () => {
@@ -150,6 +157,7 @@ describe("src/skill/executor", () => {
     it("handles a late sandbox command rejection after timeout", async () => {
       setEnv("SANDBOX_AUTH_TOKEN", "sandbox-token");
       setEnv("VERYFRONT_API_URL", "https://api.test.com");
+      const pendingCommand = pendingErrorNdjsonResponse(new Error("sandbox process killed"));
       mockFetch([
         jsonResponse({
           id: "session-timeout",
@@ -158,7 +166,7 @@ describe("src/skill/executor", () => {
         }),
         textResponse(""),
         ndjsonResponse([{ type: "exit", exitCode: 0 }]),
-        delayedErrorNdjsonResponse(new Error("sandbox process killed"), 30),
+        pendingCommand.response,
         ndjsonResponse([{ type: "exit", exitCode: 0 }]),
         textResponse(""),
       ]);
@@ -170,7 +178,8 @@ describe("src/skill/executor", () => {
         timeoutMs: 1,
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      pendingCommand.reject();
+      await Promise.resolve();
 
       assertEquals(result.exitCode, 124);
       assertStringIncludes(result.stderr, "timed out");


### PR DESCRIPTION
## Description

Makes the three full-suite timing regressions deterministic without changing production behavior:

- gates tool-input heartbeat producers on observed consumer checkpoints and fails fast when an expected heartbeat is absent
- warms real project workers before applying the unchanged 10-second behavior timeout, then tests queued environment isolation back-to-back
- drives the late sandbox NDJSON stream error explicitly after the timeout path returns

No production source, heartbeat threshold, request timeout, or cancellation behavior changes.

## Related Issue(s)

Fixes #2865

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Verification

- DENO_JOBS=4 deno task test:unit: 2,322 suites, 19,639 steps, 0 failures
- heartbeat and executor files: 50 consecutive passes
- real-worker isolation suite: 20 consecutive passes
- protected pre-push format, lint, typecheck, and unit gates passed

## Checklist

- [x] Documentation is not applicable because runtime behavior is unchanged
- [x] Existing behavior assertions are preserved with deterministic synchronization