### PR TITLE
Quiet expected project-file 404 telemetry noise

### DIFF
--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -730,6 +730,11 @@ export class VeryfrontFSAdapter implements FSAdapter {
     return this.withBranchSnapshotRecovery(path, () => this.readOps.readTextFile(path));
   }
 
+  async readOptionalTextFile(path: string): Promise<string> {
+    await this.ensureInitialized();
+    return this.withBranchSnapshotRecovery(path, () => this.readOps.readOptionalTextFile(path));
+  }
+
   async readdir(path: string): Promise<DirectoryEntry[]> {
     await this.ensureInitialized();
     return this.withBranchSnapshotRecovery(

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
@@ -80,6 +80,10 @@ describe("MultiProjectFSAdapter", () => {
       withAdapter((adapter) => assertMethod(adapter, "readTextFile"));
     });
 
+    it("should have readOptionalTextFile method", () => {
+      withAdapter((adapter) => assertMethod(adapter, "readOptionalTextFile"));
+    });
+
     it("should have exists method", () => {
       withAdapter((adapter) => assertMethod(adapter, "exists"));
     });
@@ -182,6 +186,47 @@ describe("MultiProjectFSAdapter", () => {
         assertEquals(capturedBranch, "main");
         assertEquals(cachedBeforeRefresh, "stale-content");
         assertEquals(cachedAfterRefresh, undefined);
+      });
+    });
+
+    it("delegates optional text reads to the active project adapter", async () => {
+      await withAdapterAsync(async (adapter) => {
+        const originalManager = (adapter as any).manager;
+        let optionalPath: string | undefined;
+        let normalReadCalled = false;
+
+        (adapter as any).manager = {
+          getAdapter() {
+            return Promise.resolve({
+              readOptionalTextFile(path: string) {
+                optionalPath = path;
+                return Promise.resolve("optional stylesheet");
+              },
+              readTextFile() {
+                normalReadCalled = true;
+                return Promise.resolve("normal read");
+              },
+            });
+          },
+          getStats: () => ({ adapters: 0, stats: [] }),
+          dispose: () => {},
+        };
+
+        try {
+          const content = await adapter.runWithContext(
+            "project-a",
+            "test-token",
+            () => adapter.readOptionalTextFile("app/globals.css"),
+            "project-id-a",
+            { branch: "main" },
+          );
+
+          assertEquals(content, "optional stylesheet");
+          assertEquals(optionalPath, "app/globals.css");
+          assertEquals(normalReadCalled, false);
+        } finally {
+          (adapter as any).manager = originalManager;
+        }
       });
     });
 

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
@@ -185,6 +185,11 @@ export class MultiProjectFSAdapter implements FSAdapter {
     return adapter.readTextFile(path);
   }
 
+  async readOptionalTextFile(path: string): Promise<string> {
+    const adapter = await this.getAdapter();
+    return adapter.readOptionalTextFile(path);
+  }
+
   async exists(path: string): Promise<boolean> {
     const adapter = await this.getAdapter();
     return adapter.exists(path);

--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -90,6 +90,19 @@ export class ReadOperations {
     );
   }
 
+  readOptionalTextFile(path: string): Promise<string> {
+    return withSpan(
+      "fs.veryfront.readOptionalTextFile",
+      async () => {
+        const normalizedPath = this.normalizer.normalize(path);
+        const apiPath = this.getOriginalApiPath?.(normalizedPath) ?? normalizedPath;
+        logger.debug("readOptionalTextFile called", { path, normalizedPath, apiPath });
+        return await this.client.getOptionalFileContent(apiPath);
+      },
+      { "fs.path": path },
+    );
+  }
+
   private getRequestScopedHit(
     normalizedPath: string,
     cacheKey: string,

--- a/src/platform/adapters/veryfront-api-client/client.ts
+++ b/src/platform/adapters/veryfront-api-client/client.ts
@@ -283,22 +283,27 @@ export class VeryfrontApiClient {
     }
   }
 
-  getFile(pathOrId: string): Promise<FileDetail> {
+  getFile(pathOrId: string, options: { expectedMissing?: boolean } = {}): Promise<FileDetail> {
     const projectRef = this.requireProjectSlug();
     const context = this.getContext();
 
     switch (context.type) {
       case "branch":
-        return this.operations.getBranchFile(projectRef, context.name, pathOrId);
+        return this.operations.getBranchFile(projectRef, context.name, pathOrId, options);
       case "environment":
-        return this.operations.getEnvironmentFile(projectRef, context.name, pathOrId);
+        return this.operations.getEnvironmentFile(projectRef, context.name, pathOrId, options);
       case "release":
-        return this.operations.getReleaseFile(projectRef, context.version, pathOrId);
+        return this.operations.getReleaseFile(projectRef, context.version, pathOrId, options);
     }
   }
 
   async getFileContent(pathOrId: string): Promise<string> {
     const file = await this.getFile(pathOrId);
+    return file.content;
+  }
+
+  async getOptionalFileContent(pathOrId: string): Promise<string> {
+    const file = await this.getFile(pathOrId, { expectedMissing: true });
     return file.content;
   }
 

--- a/src/platform/adapters/veryfront-api-client/operations.test.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.test.ts
@@ -3,10 +3,16 @@ import "#veryfront/schemas/_test-setup.ts";
 import {
   assertEquals,
   assertExists,
+  assertRejects,
   assertStringIncludes,
   assertThrows,
 } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  __registerLogRecordEmitter,
+  __resetLogRecordEmitterForTests,
+  type LogEntry,
+} from "#veryfront/utils/logger/index.ts";
 import { VeryfrontAPIOperations } from "./operations.ts";
 
 function createOps(
@@ -44,6 +50,7 @@ describe("VeryfrontAPIOperations", () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    __resetLogRecordEmitterForTests();
   });
 
   describe("class", () => {
@@ -188,6 +195,185 @@ describe("VeryfrontAPIOperations", () => {
       await createOps().getBranchFile("project-slug", "main", "app/api/ag-ui/route.ts");
 
       assertStringIncludes(requestedUrl, "include_server_functions=true");
+    });
+
+    it("warn-logs normal 404s for branch file content reads", async () => {
+      const entries: LogEntry[] = [];
+      const originalWarn = console.warn;
+      console.warn = () => {};
+      __registerLogRecordEmitter((entry) => entries.push(entry));
+      globalThis.fetch = (() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ error: "Not found" }), {
+            status: 404,
+            statusText: "Not Found",
+            headers: { "Content-Type": "application/json" },
+          }),
+        )) as typeof fetch;
+
+      try {
+        await assertRejects(
+          () => createOps().getBranchFile("project-slug", "main", "app/globals.css"),
+          Error,
+          "API request failed: 404 Not Found",
+        );
+      } finally {
+        console.warn = originalWarn;
+      }
+
+      assertEquals(
+        entries.some((entry) =>
+          entry.level === "warn" &&
+          entry.component === "veryfront-api-client" &&
+          entry.message === "Request failed"
+        ),
+        true,
+      );
+    });
+
+    it("does not warn-log expected 404s for branch file content probes", async () => {
+      const entries: LogEntry[] = [];
+      const originalWarn = console.warn;
+      console.warn = () => {};
+      __registerLogRecordEmitter((entry) => entries.push(entry));
+      globalThis.fetch = (() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ error: "Not found" }), {
+            status: 404,
+            statusText: "Not Found",
+            headers: { "Content-Type": "application/json" },
+          }),
+        )) as typeof fetch;
+
+      try {
+        await assertRejects(
+          () =>
+            createOps().getBranchFile("project-slug", "main", "app/globals.css", {
+              expectedMissing: true,
+            }),
+          Error,
+          "API request failed: 404 Not Found",
+        );
+      } finally {
+        console.warn = originalWarn;
+      }
+
+      assertEquals(
+        entries.some((entry) =>
+          (entry.level === "warn" || entry.level === "error") &&
+          entry.component === "veryfront-api-client" &&
+          entry.message === "Request failed"
+        ),
+        false,
+      );
+    });
+
+    it("does not warn-log expected 404s for environment file content probes", async () => {
+      const entries: LogEntry[] = [];
+      const originalWarn = console.warn;
+      console.warn = () => {};
+      __registerLogRecordEmitter((entry) => entries.push(entry));
+      globalThis.fetch = (() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ error: "Not found" }), {
+            status: 404,
+            statusText: "Not Found",
+            headers: { "Content-Type": "application/json" },
+          }),
+        )) as typeof fetch;
+
+      try {
+        await assertRejects(
+          () =>
+            createOps().getEnvironmentFile("project-slug", "production", "app/globals.css", {
+              expectedMissing: true,
+            }),
+          Error,
+          "API request failed: 404 Not Found",
+        );
+      } finally {
+        console.warn = originalWarn;
+      }
+
+      assertEquals(
+        entries.some((entry) =>
+          (entry.level === "warn" || entry.level === "error") &&
+          entry.component === "veryfront-api-client" &&
+          entry.message === "Request failed"
+        ),
+        false,
+      );
+    });
+
+    it("does not warn-log expected 404s for release file content probes", async () => {
+      const entries: LogEntry[] = [];
+      const originalWarn = console.warn;
+      console.warn = () => {};
+      __registerLogRecordEmitter((entry) => entries.push(entry));
+      globalThis.fetch = (() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ error: "Not found" }), {
+            status: 404,
+            statusText: "Not Found",
+            headers: { "Content-Type": "application/json" },
+          }),
+        )) as typeof fetch;
+
+      try {
+        await assertRejects(
+          () =>
+            createOps().getReleaseFile("project-slug", "release-id", "app/globals.css", {
+              expectedMissing: true,
+            }),
+          Error,
+          "API request failed: 404 Not Found",
+        );
+      } finally {
+        console.warn = originalWarn;
+      }
+
+      assertEquals(
+        entries.some((entry) =>
+          (entry.level === "warn" || entry.level === "error") &&
+          entry.component === "veryfront-api-client" &&
+          entry.message === "Request failed"
+        ),
+        false,
+      );
+    });
+
+    it("still warn-logs authentication failures for branch file content", async () => {
+      const entries: LogEntry[] = [];
+      const originalWarn = console.warn;
+      console.warn = () => {};
+      __registerLogRecordEmitter((entry) => entries.push(entry));
+      globalThis.fetch = (() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ error: "Invalid authentication token" }), {
+            status: 401,
+            statusText: "Unauthorized",
+            headers: { "Content-Type": "application/json" },
+          }),
+        )) as typeof fetch;
+
+      try {
+        await assertRejects(
+          () => createOps().getBranchFile("project-slug", "main", "app/globals.css"),
+          Error,
+          "API request failed: 401 Unauthorized",
+        );
+      } finally {
+        console.warn = originalWarn;
+      }
+
+      assertEquals(
+        entries.some((entry) =>
+          entry.level === "warn" &&
+          entry.component === "veryfront-api-client" &&
+          entry.message === "Request failed"
+        ),
+        true,
+      );
     });
 
     it("requests release file lists with server functions for runtime route discovery", async () => {

--- a/src/platform/adapters/veryfront-api-client/operations.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.ts
@@ -63,6 +63,11 @@ export interface FileDetail {
   release_version?: string | null;
 }
 
+export interface GetFileOptions {
+  /** True when the caller is probing an optional candidate and expects a possible 404. */
+  expectedMissing?: boolean;
+}
+
 export interface StyleArtifactSelector {
   branch?: string;
   environmentName?: string;
@@ -276,7 +281,12 @@ export class VeryfrontAPIOperations {
     return allFiles;
   }
 
-  getBranchFile(projectRef: string, branchRef: string, pathOrId: string): Promise<FileDetail> {
+  getBranchFile(
+    projectRef: string,
+    branchRef: string,
+    pathOrId: string,
+    options: GetFileOptions = {},
+  ): Promise<FileDetail> {
     return withSpan(
       SpanNames.API_GET_FILE,
       async () => {
@@ -286,7 +296,7 @@ export class VeryfrontAPIOperations {
         }?${params}`;
         logger.debug("getBranchFile", { projectRef, branchRef, pathOrId });
 
-        const raw = await this.request(url);
+        const raw = await this.request(url, { expected404: options.expectedMissing === true });
         const response = getBranchFileDetailSchema().parse(raw);
 
         return {
@@ -360,6 +370,7 @@ export class VeryfrontAPIOperations {
     projectRef: string,
     environmentName: string,
     pathOrId: string,
+    options: GetFileOptions = {},
   ): Promise<FileDetail> {
     return withSpan(
       SpanNames.API_GET_FILE,
@@ -370,7 +381,7 @@ export class VeryfrontAPIOperations {
         }/files/${encodeURIComponent(pathOrId)}?${params}`;
         logger.debug("getEnvironmentFile", { projectRef, environmentName, pathOrId });
 
-        const raw = await this.request(url);
+        const raw = await this.request(url, { expected404: options.expectedMissing === true });
         const response = getEnvironmentFileDetailSchema().parse(raw);
 
         return {
@@ -423,7 +434,12 @@ export class VeryfrontAPIOperations {
     );
   }
 
-  getReleaseFile(projectRef: string, version: string, pathOrId: string): Promise<FileDetail> {
+  getReleaseFile(
+    projectRef: string,
+    version: string,
+    pathOrId: string,
+    options: GetFileOptions = {},
+  ): Promise<FileDetail> {
     return withSpan(
       SpanNames.API_GET_FILE,
       async () => {
@@ -433,7 +449,7 @@ export class VeryfrontAPIOperations {
         }/files/${encodeURIComponent(pathOrId)}?${params}`;
         logger.debug("getReleaseFile", { projectRef, version, pathOrId });
 
-        const raw = await this.request(url);
+        const raw = await this.request(url, { expected404: options.expectedMissing === true });
         const response = getReleaseFileDetailSchema().parse(raw);
 
         return {

--- a/src/platform/adapters/veryfront-api-client/retry-handler.ts
+++ b/src/platform/adapters/veryfront-api-client/retry-handler.ts
@@ -20,6 +20,8 @@ export interface RequestOptions {
   method?: string;
   body?: BodyInit | null;
   headers?: HeadersInit;
+  /** Demote an expected 404 miss to debug while preserving thrown error semantics. */
+  expected404?: boolean;
 }
 
 /** Default timeout for API requests (30 seconds) */
@@ -76,9 +78,12 @@ export async function requestWithRetry(
           if (!response.ok) {
             const text = await response.text();
 
+            // Optional probes (for example stylesheet candidates) may expect a 404.
+            // Keep only explicit opt-ins below warn while preserving thrown error semantics.
+            const isExpected404 = options.expected404 === true && response.status === 404;
             // 4xx = client errors (expected, e.g. 404 for missing deno.json) → warn
             // 5xx = server errors (unexpected) → error
-            const logLevel = response.status >= 500 ? "error" : "warn";
+            const logLevel = isExpected404 ? "debug" : response.status >= 500 ? "error" : "warn";
             veryfrontApiClientLog[logLevel]("Request failed", {
               url: url.replace(/token=[^&]+/, "token=***"),
               status: response.status,

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -1147,6 +1147,10 @@ type StyleArtifactSourceProvider = {
   getContentContext?: () => ResolvedContentContext | null;
 };
 
+type OptionalTextFileReader = {
+  readOptionalTextFile(path: string): Promise<string>;
+};
+
 const DEFAULT_STYLESHEET_PATHS = [
   "globals.css",
   "global.css",
@@ -1207,14 +1211,35 @@ function textFromFileContent(content: Uint8Array | string): string {
   return typeof content === "string" ? content : new TextDecoder().decode(content);
 }
 
+function getOptionalTextFileReader(ctx: HandlerContext): OptionalTextFileReader | null {
+  const wrappedFs = ctx.adapter.fs as {
+    getUnderlyingAdapter?: () => unknown;
+    readOptionalTextFile?: OptionalTextFileReader["readOptionalTextFile"];
+  };
+
+  if (typeof wrappedFs.readOptionalTextFile === "function") {
+    return { readOptionalTextFile: wrappedFs.readOptionalTextFile.bind(wrappedFs) };
+  }
+
+  if (typeof wrappedFs.getUnderlyingAdapter !== "function") return null;
+  const underlying = wrappedFs.getUnderlyingAdapter() as Partial<OptionalTextFileReader>;
+  if (typeof underlying.readOptionalTextFile !== "function") return null;
+
+  return { readOptionalTextFile: underlying.readOptionalTextFile.bind(underlying) };
+}
+
 async function readStylesheetFromAdapter(
   ctx: HandlerContext,
   stylesheetPath?: string,
 ): Promise<string | undefined> {
+  const optionalReader = getOptionalTextFileReader(ctx);
+
   for (const path of stylesheetCandidatePaths(stylesheetPath)) {
     try {
-      const content = await ctx.adapter.fs.readFile(path);
-      if (content) return textFromFileContent(content);
+      const content = optionalReader
+        ? await optionalReader.readOptionalTextFile(path)
+        : textFromFileContent(await ctx.adapter.fs.readFile(path));
+      if (content) return content;
     } catch {
       // keep searching
     }


### PR DESCRIPTION
## Summary
- keep expected 404s for project file content probes below warn level in the Veryfront API client
- preserve warn-level logging for auth failures such as 401s and error-level logging for 5xx responses
- add regression coverage for the optional stylesheet probe path that caused production warning noise

Fixes veryfront/veryfront-studio#5794

## Red / green evidence
- **Red:** `deno test --allow-env --allow-net src/platform/adapters/veryfront-api-client/operations.test.ts` failed because `getBranchFile(..., "app/globals.css")` returned 404 and emitted a warn-level `veryfront-api-client` `Request failed` record.
- **Green:** the same test now passes: expected 404 file probes emit no warn record, while a 401 file fetch still emits warn.

## Verification
- `deno fmt --check src/platform/adapters/veryfront-api-client/retry-handler.ts src/platform/adapters/veryfront-api-client/operations.test.ts` ✅
- `deno lint src/platform/adapters/veryfront-api-client/retry-handler.ts src/platform/adapters/veryfront-api-client/operations.test.ts` ✅
- `deno check src/platform/adapters/veryfront-api-client/retry-handler.ts src/platform/adapters/veryfront-api-client/operations.test.ts` ✅
- `deno test --allow-env --allow-net src/platform/adapters/veryfront-api-client/operations.test.ts` ✅
- `deno task typecheck` ✅

## Notes
- Full local pre-commit `verify:quick` is currently blocked by a pre-existing unrelated style violation in `cli/shared/reserve-slug.ts` (`no-explicit-public`); this PR intentionally keeps the #5794 fix narrow.
