### PR TITLE
Retry bodyless run-stream fallback safely

### DIFF
--- a/src/platform/compat/http/request-adapter.test.ts
+++ b/src/platform/compat/http/request-adapter.test.ts
@@ -65,7 +65,7 @@ describe("convertNodeRequestToWebRequest", () => {
     const result = convertNodeRequestToWebRequest(
       createMockReq(
         "POST",
-        { "content-type": "application/json" },
+        { "content-type": "application/json", "content-length": "38" },
         ['{"jsonrpc":"2.0",', '"method":"initialize"}'],
       ) as never,
       "http://localhost/mcp",
@@ -75,6 +75,26 @@ describe("convertNodeRequestToWebRequest", () => {
     assertEquals(result.method, "POST");
     assertExists(result.body);
     assertEquals(await result.text(), '{"jsonrpc":"2.0","method":"initialize"}');
+  });
+
+  it("should not attach a body stream for bodyless POST requests", () => {
+    const result = convertNodeRequestToWebRequest(
+      createMockReq("POST", {}) as never,
+      "http://localhost/api/control-plane/runs/run_1/stream",
+    );
+
+    assertEquals(result.method, "POST");
+    assertEquals(result.body, null);
+  });
+
+  it("should attach a body stream for chunked POST requests", async () => {
+    const result = convertNodeRequestToWebRequest(
+      createMockReq("POST", { "transfer-encoding": "chunked" }, ["chunk"]) as never,
+      "http://localhost/mcp",
+    );
+
+    assertExists(result.body);
+    assertEquals(await result.text(), "chunk");
   });
 
   it("should preserve headers", () => {

--- a/src/platform/compat/http/request-adapter.ts
+++ b/src/platform/compat/http/request-adapter.ts
@@ -20,7 +20,7 @@ export function convertNodeRequestToWebRequest(
   url: string,
 ): Request {
   const method = req.method ?? "GET";
-  const hasBody = !BODYLESS_METHODS.has(method.toUpperCase());
+  const hasBody = requestCanCarryBody(method) && requestDeclaresBody(req.headers);
 
   // `duplex` is part of the WHATWG fetch spec but not yet in the lib.dom
   // `RequestInit` type, hence the intersection.
@@ -35,6 +35,27 @@ export function convertNodeRequestToWebRequest(
   }
 
   return new Request(url, init);
+}
+
+function requestCanCarryBody(method: string): boolean {
+  return !BODYLESS_METHODS.has(method.toUpperCase());
+}
+
+function requestDeclaresBody(headers: NodeIncomingMessage["headers"]): boolean {
+  const contentLengthHeader = headers["content-length"];
+  const contentLength = Array.isArray(contentLengthHeader)
+    ? contentLengthHeader.find((value) => value.trim().length > 0)
+    : contentLengthHeader;
+  if (contentLength !== undefined && contentLength.trim() !== "" && contentLength !== "0") {
+    return true;
+  }
+
+  const transferEncodingHeader = headers["transfer-encoding"];
+  const transferEncoding = Array.isArray(transferEncodingHeader)
+    ? transferEncodingHeader.join(",")
+    : transferEncodingHeader;
+
+  return transferEncoding !== undefined && transferEncoding.trim() !== "";
 }
 
 /**

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -22,7 +22,11 @@
 
 import { createProxyHandler, INTERNAL_PROXY_HEADERS, type ProxyConfig } from "./handler.ts";
 import { createCacheFromEnv } from "./cache/index.ts";
-import { isRetryableConnectionError } from "./retry.ts";
+import {
+  getFramedRequestBody,
+  getUpstreamRetryCount,
+  isRetryableConnectionError,
+} from "./retry.ts";
 import {
   authorizeWebSocketRequest,
   closeBridgePeer,
@@ -393,9 +397,13 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
 
           injectContext(newHeaders);
 
-          // Only retry idempotent methods (GET, HEAD, OPTIONS)
-          const isIdempotent = ["GET", "HEAD", "OPTIONS"].includes(req.method);
-          const maxRetries = isIdempotent ? VERYFRONT_SERVER_RETRY_COUNT : 0;
+          const maxRetries = getUpstreamRetryCount(
+            req.method,
+            url.pathname,
+            req.headers,
+            VERYFRONT_SERVER_RETRY_COUNT,
+          );
+          const upstreamBody = getFramedRequestBody(req.headers, req.body);
           let lastError: Error | null = null;
           // After a retryable connection error to a dedicated server, fall back to shared pool
           let skipDedicated = false;
@@ -449,7 +457,7 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
                       fetch(serverUrl.toString(), {
                         method: req.method,
                         headers: newHeaders,
-                        body: req.body,
+                        body: upstreamBody,
                         redirect: "manual",
                         signal: abortController.signal,
                       }),

--- a/src/proxy/retry.test.ts
+++ b/src/proxy/retry.test.ts
@@ -1,7 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
-import { isRetryableConnectionError } from "./retry.ts";
+import {
+  getFramedRequestBody,
+  getUpstreamRetryCount,
+  isRetryableConnectionError,
+} from "./retry.ts";
 
 describe("isRetryableConnectionError", () => {
   it("returns false for non-Error values", () => {
@@ -81,6 +85,89 @@ describe("isRetryableConnectionError", () => {
         ),
       ),
       true,
+    );
+  });
+});
+
+describe("getUpstreamRetryCount", () => {
+  it("retries idempotent requests", () => {
+    assertEquals(getUpstreamRetryCount("GET", "/", new Headers(), 1), 1);
+    assertEquals(getUpstreamRetryCount("HEAD", "/", new Headers(), 2), 2);
+  });
+
+  it("does not retry ordinary POST requests", () => {
+    assertEquals(getUpstreamRetryCount("POST", "/api/submit", new Headers(), 1), 0);
+  });
+
+  it("retries bodyless control-plane run stream POST requests", () => {
+    assertEquals(
+      getUpstreamRetryCount("POST", "/api/control-plane/runs/run_1/stream", new Headers(), 1),
+      1,
+    );
+  });
+
+  it("retries control-plane run stream POST requests with explicit zero content length", () => {
+    assertEquals(
+      getUpstreamRetryCount(
+        "POST",
+        "/api/control-plane/runs/run_1/stream",
+        new Headers({ "content-length": "0" }),
+        1,
+      ),
+      1,
+    );
+  });
+
+  it("does not retry control-plane run stream POST requests with a body", () => {
+    assertEquals(
+      getUpstreamRetryCount(
+        "POST",
+        "/api/control-plane/runs/run_1/stream",
+        new Headers({ "content-length": "1" }),
+        1,
+      ),
+      0,
+    );
+    assertEquals(
+      getUpstreamRetryCount(
+        "POST",
+        "/api/control-plane/runs/run_1/stream",
+        new Headers({ "transfer-encoding": "chunked" }),
+        1,
+      ),
+      0,
+    );
+  });
+});
+
+describe("getFramedRequestBody", () => {
+  function createBody(): ReadableStream<Uint8Array> {
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    });
+  }
+
+  it("drops Deno-style empty POST streams when content length is zero", () => {
+    const body = createBody();
+
+    assertEquals(
+      getFramedRequestBody(new Headers({ "content-length": "0" }), body),
+      null,
+    );
+  });
+
+  it("preserves request streams when body framing is present", () => {
+    const body = createBody();
+
+    assertEquals(
+      getFramedRequestBody(new Headers({ "content-length": "1" }), body),
+      body,
+    );
+    assertEquals(
+      getFramedRequestBody(new Headers({ "transfer-encoding": "chunked" }), body),
+      body,
     );
   });
 });

--- a/src/proxy/retry.ts
+++ b/src/proxy/retry.ts
@@ -17,3 +17,43 @@ export function isRetryableConnectionError(error: unknown): boolean {
     msg.includes("os error 111") // ECONNREFUSED
   );
 }
+
+/**
+ * Decide how many times the proxy can safely retry an upstream request.
+ *
+ * Ordinary non-idempotent requests are not replayed. The control-plane run
+ * stream attach endpoint is a bodyless POST, so it can safely retry once to
+ * fall back from an unavailable dedicated runtime to the shared runtime during
+ * operator reconciliation.
+ */
+export function getUpstreamRetryCount(
+  method: string,
+  pathname: string,
+  headers: Headers,
+  configuredRetryCount: number,
+): number {
+  if (["GET", "HEAD", "OPTIONS"].includes(method)) return configuredRetryCount;
+
+  const isBodylessControlPlaneRunStreamPost = method === "POST" &&
+    requestHeadersDeclareBody(headers) === false &&
+    /^\/api\/control-plane\/runs\/[^/]+\/stream$/.test(pathname);
+
+  return isBodylessControlPlaneRunStreamPost ? configuredRetryCount : 0;
+}
+
+export function getFramedRequestBody(
+  headers: Headers,
+  body: ReadableStream<Uint8Array> | null,
+): ReadableStream<Uint8Array> | null {
+  return requestHeadersDeclareBody(headers) ? body : null;
+}
+
+function requestHeadersDeclareBody(headers: Headers): boolean {
+  const contentLength = headers.get("content-length");
+  if (contentLength !== null && contentLength.trim() !== "" && contentLength !== "0") {
+    return true;
+  }
+
+  const transferEncoding = headers.get("transfer-encoding");
+  return transferEncoding !== null && transferEncoding.trim() !== "";
+}


### PR DESCRIPTION
Fixes veryfront/veryfront-studio#5791

## Summary
- Adds a narrowly-scoped proxy retry policy helper.
- Keeps existing retries for idempotent methods.
- Allows the bodyless `POST /api/control-plane/runs/:runId/stream` attach request to use the existing single retry/fallback path, so a dedicated runtime connection refusal can retry against the shared pool during operator reconciliation.
- Keeps ordinary POST requests and any POST with a body single-shot to avoid replaying side effects.

## Red / Green evidence
- Red: `deno test --allow-env --allow-read src/proxy/retry.test.ts` failed before implementation because `getUpstreamRetryCount` did not exist.
- Green: targeted retry tests now prove idempotent retries stay enabled, ordinary POSTs stay non-retried, bodyless control-plane run-stream POSTs retry, and body-bearing stream POSTs do not retry.

## Verification
- `deno fmt --check src/proxy/retry.ts src/proxy/retry.test.ts src/proxy/main.ts`
- `deno lint src/proxy/retry.ts src/proxy/retry.test.ts src/proxy/main.ts`
- `deno check src/proxy/retry.ts src/proxy/retry.test.ts src/proxy/main.ts`
- `deno test --allow-env --allow-read src/proxy/retry.test.ts src/proxy/main.test.ts`
- `deno task typecheck`

Note: local `verify:quick` is still blocked by the pre-existing unrelated style violation in `cli/shared/reserve-slug.ts` (`no-explicit-public`).
