### PR TITLE
Reduce read-only lockfile noise for remote imports

### DIFF
--- a/src/routing/api/module-loader/esbuild-plugin.test.ts
+++ b/src/routing/api/module-loader/esbuild-plugin.test.ts
@@ -394,35 +394,47 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
       }
     });
 
-    it("serves freshly fetched remote modules when lockfile flush fails on a read-only filesystem", async () => {
+    it("serves remote modules without repeated warnings when lockfile flush hits a read-only filesystem", async () => {
       const originalFetch = globalThis.fetch;
       const originalWarn = console.warn;
+      const projectDir = await Deno.makeTempDir();
       const moduleSource = "export const ok = true;";
       const warnings: string[] = [];
-      let lockfileSet = false;
+      const entries = new Map<string, {
+        resolved: string;
+        integrity: string;
+        fetchedAt?: string;
+      }>();
+      let lockfileSets = 0;
+      let lockfileFlushes = 0;
+      let failRemoteFetches = false;
       let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
 
       const readOnlyLockfile: LockfileManager = {
         read: () => Promise.resolve(null),
         write: () => Promise.reject(new Error("read-only lockfile")),
-        get: () => Promise.resolve(null),
-        set: () => {
-          lockfileSet = true;
+        get: (url) => Promise.resolve(entries.get(url) ?? null),
+        set: (url, entry) => {
+          lockfileSets += 1;
+          entries.set(url, entry);
           return Promise.resolve();
         },
         has: () => Promise.resolve(false),
         clear: () => Promise.resolve(),
-        flush: () =>
-          Promise.reject(
+        flush: () => {
+          lockfileFlushes += 1;
+          return Promise.reject(
             new Error(
               "Read-only file system (os error 30): writefile '/app/project/veryfront.lock'",
             ),
-          ),
+          );
+        },
       };
 
       const plugin = createHTTPPlugin({
         allowedHosts: ["https://esm.sh"],
         lockfile: readOnlyLockfile,
+        projectDir,
       });
       const mockBuild = createMockBuild(
         () => {},
@@ -438,23 +450,50 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
           warnings.push(args.map(String).join(" "));
         }) as typeof console.warn;
         globalThis.fetch = (async () =>
-          new Response(moduleSource, { status: 200 })) as typeof fetch;
+          failRemoteFetches
+            ? new Response("cdn unavailable", { status: 599 })
+            : new Response(moduleSource, { status: 200 })) as typeof fetch;
 
-        const result = await loadHandler({
-          path: "https://esm.sh/yaml@2",
+        const first = await loadHandler({
+          path: "https://esm.sh/yaml@2/stringify",
+          namespace: "http-url",
+          pluginData: undefined,
+          suffix: "",
+        });
+        const second = await loadHandler({
+          path: "https://esm.sh/yaml@2/parse",
           namespace: "http-url",
           pluginData: undefined,
           suffix: "",
         });
 
-        assertEquals((result as { contents: string }).contents, moduleSource);
-        assertEquals(lockfileSet, true);
-        assertEquals(warnings.some((warning) => warning.includes("Error")), true);
+        assertEquals((first as { contents: string }).contents, moduleSource);
+        assertEquals((second as { contents: string }).contents, moduleSource);
+        assertEquals(lockfileSets, 2);
+        assertEquals(lockfileFlushes, 1);
+        assertEquals(warnings, []);
+
+        failRemoteFetches = true;
+        const cached = await loadHandler({
+          path: "https://esm.sh/yaml@2/parse",
+          namespace: "http-url",
+          pluginData: undefined,
+          suffix: "",
+        });
+
+        assertEquals((cached as { contents: string }).contents, moduleSource);
+        assertEquals(
+          warnings.some((warning) =>
+            warning.includes("could not persist lockfile entry")
+          ),
+          false,
+        );
         assertEquals(warnings.some((warning) => warning.includes("veryfront.lock")), false);
         assertEquals(warnings.some((warning) => warning.includes("/app/project")), false);
       } finally {
         globalThis.fetch = originalFetch;
         console.warn = originalWarn;
+        await Deno.remove(projectDir, { recursive: true }).catch(() => {});
       }
     });
 

--- a/src/routing/api/module-loader/esbuild-plugin.ts
+++ b/src/routing/api/module-loader/esbuild-plugin.ts
@@ -138,6 +138,7 @@ export function createHTTPPlugin(options: HTTPPluginOptions | string[]): Plugin 
   const lockfile = opts.lockfile ??
     (opts.projectDir ? createLockfileManager(opts.projectDir) : null);
   const moduleCache = createHTTPModuleCache(opts.projectDir);
+  let lockfileFlushDisabled = false;
 
   return {
     name: "vf-api-http-fetch",
@@ -197,13 +198,16 @@ export function createHTTPPlugin(options: HTTPPluginOptions | string[]): Plugin 
 
         await lockfile.set(url, entry);
 
+        if (lockfileFlushDisabled) return;
+
         try {
           await lockfile.flush();
           logger.debug(`[http] lockfile updated: ${url} -> ${entry.resolved}`);
         } catch (error) {
           if (!isReadOnlyFileSystemError(error)) throw error;
-          logger.warn(
-            `[http] could not persist lockfile entry for ${url}: ${
+          lockfileFlushDisabled = true;
+          logger.debug(
+            `[http] lockfile flush disabled on read-only filesystem for ${url}: ${
               describePersistenceError(error)
             }`,
           );


### PR DESCRIPTION
## Summary

Fixes the read-only filesystem noise path from veryfront-studio#5767.

When the API HTTP module loader fetches remote esm.sh modules on a read-only project filesystem, the first lockfile flush can fail with EROFS. Previously every remote dependency repeated the flush and emitted a warning, producing noisy bursts while the runtime still served the fetched modules.

This PR keeps the runtime behavior intact but treats read-only **disk flush** as an expected production constraint:

- after the first read-only flush failure, only lockfile disk flush is disabled for that plugin instance;
- in-memory lockfile `set()` still runs so later imports retain lockfile entries for module-cache fallback;
- fetched remote modules continue to load and populate the module cache;
- the read-only condition is logged at debug level instead of warn;
- non-read-only lockfile set/flush failures still propagate.

## Evidence

Red/green:

- RED: `deno test -A src/routing/api/module-loader/esbuild-plugin.test.ts` failed because two read-only remote imports caused two lockfile persistence attempts.
- Review iteration: architect review found the first patch skipped `set()` as well as `flush()`. The final patch disables flush only and adds coverage proving a later module fetched after the first read-only failure can still be served from module cache when the CDN later fails.
- GREEN: `deno test -A src/routing/api/module-loader/esbuild-plugin.test.ts` passed: 1 file, 21 steps.

Local verification:

- `deno fmt --check src/routing/api/module-loader/esbuild-plugin.ts src/routing/api/module-loader/esbuild-plugin.test.ts`
- `deno lint src/routing/api/module-loader/esbuild-plugin.ts src/routing/api/module-loader/esbuild-plugin.test.ts`
- `deno check src/routing/api/module-loader/esbuild-plugin.ts src/routing/api/module-loader/esbuild-plugin.test.ts`
- `deno task typecheck`

Known unrelated base-main verification gap:

- `deno task verify:quick` stops at `cli/shared/reserve-slug.ts:29:15 [no-explicit-public]`, which is unchanged by this PR and exists on `origin/main`.

## Issue

Fixes veryfront/veryfront-studio#5767.