### PR TITLE
Publish Veryfront 0.1.1048 with dedicated startup fallback

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1047",
+  "version": "0.1.1048",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1047";
+export const VERSION = "0.1.1048";


### PR DESCRIPTION
## Summary

- Publish the merged bodyless run-stream fallback from #2872 as immutable framework version `0.1.1048`.
- Keep `deno.json` and `src/utils/version-constant.ts` synchronized.
- Changes only the two version declarations.

## Verification

- Protected-main CI/CD for merge commit `e4121bce9edd`: success, with unchanged `0.1.1047` publication correctly skipped.
- Pre-push format, lint, and typecheck: pass.
- Unit suite: 2,356 tests / 19,990 steps, zero failures.
- Focused version test: 1 test / 21 steps, zero failures.
- `deno fmt --check` and `git diff --check`: pass.

## Downstream acceptance

After publication, verify the framework release dispatches complete, build a server artifact that consumes `0.1.1048`, promote it through staging/production, and retest the dedicated startup fallback tracked in veryfront/veryfront-studio#5791.

Related: veryfront/veryfront-code#2872
Related: veryfront/veryfront-studio#5791
Related: veryfront/veryfront-studio#5766