### PR TITLE
Harden signed run stream fallback retries

### DIFF
--- a/src/proxy/main.test.ts
+++ b/src/proxy/main.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "#veryfront/testing/assert";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 
 describe("proxy main request URL parsing", () => {
@@ -7,5 +7,12 @@ describe("proxy main request URL parsing", () => {
     const requestUrlParses = source.match(/new URL\(req\.url\)/g) ?? [];
 
     assertEquals(requestUrlParses.length, 1);
+  });
+
+  it("uses an independent request body for every upstream attempt", async () => {
+    const source = await Deno.readTextFile(new URL("./main.ts", import.meta.url));
+
+    assertStringIncludes(source, "getReplayableRequestBodies(req, maxRetries)");
+    assertStringIncludes(source, "body: upstreamBodies[attempt] ?? null");
   });
 });

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -23,9 +23,9 @@
 import { createProxyHandler, INTERNAL_PROXY_HEADERS, type ProxyConfig } from "./handler.ts";
 import { createCacheFromEnv } from "./cache/index.ts";
 import {
-  getFramedRequestBody,
+  getReplayableRequestBodies,
   getUpstreamRetryCount,
-  isRetryableConnectionError,
+  shouldRetryUpstreamRequest,
 } from "./retry.ts";
 import {
   authorizeWebSocketRequest,
@@ -398,12 +398,11 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
           injectContext(newHeaders);
 
           const maxRetries = getUpstreamRetryCount(
-            req.method,
+            req,
             url.pathname,
-            req.headers,
             VERYFRONT_SERVER_RETRY_COUNT,
           );
-          const upstreamBody = getFramedRequestBody(req.headers, req.body);
+          const upstreamBodies = getReplayableRequestBodies(req, maxRetries);
           let lastError: Error | null = null;
           // After a retryable connection error to a dedicated server, fall back to shared pool
           let skipDedicated = false;
@@ -457,7 +456,7 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
                       fetch(serverUrl.toString(), {
                         method: req.method,
                         headers: newHeaders,
-                        body: upstreamBody,
+                        body: upstreamBodies[attempt] ?? null,
                         redirect: "manual",
                         signal: abortController.signal,
                       }),
@@ -511,7 +510,10 @@ function forwardToServer(req: Request, url: URL): Promise<Response> {
               }
 
               // Check if this is a retryable error and we have retries left
-              if (isRetryableConnectionError(error) && attempt < maxRetries) {
+              if (
+                shouldRetryUpstreamRequest(req, url.pathname, error) &&
+                attempt < maxRetries
+              ) {
                 // If we were targeting a dedicated server, fall back to shared pool on retry
                 if (dedicatedServerUrl) {
                   skipDedicated = true;

--- a/src/proxy/retry.test.ts
+++ b/src/proxy/retry.test.ts
@@ -1,11 +1,16 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
+import { DEFAULT_MAX_BODY_SIZE_BYTES } from "#veryfront/utils/constants/index.ts";
 import {
-  getFramedRequestBody,
+  getReplayableRequestBodies,
   getUpstreamRetryCount,
   isRetryableConnectionError,
+  shouldRetryUpstreamRequest,
 } from "./retry.ts";
+
+const RUN_STREAM_PATH = "/api/control-plane/runs/run_1/stream";
+const RUN_STREAM_URL = `http://proxy.test${RUN_STREAM_PATH}`;
 
 describe("isRetryableConnectionError", () => {
   it("returns false for non-Error values", () => {
@@ -91,83 +96,161 @@ describe("isRetryableConnectionError", () => {
 
 describe("getUpstreamRetryCount", () => {
   it("retries idempotent requests", () => {
-    assertEquals(getUpstreamRetryCount("GET", "/", new Headers(), 1), 1);
-    assertEquals(getUpstreamRetryCount("HEAD", "/", new Headers(), 2), 2);
+    assertEquals(getUpstreamRetryCount(new Request("http://proxy.test/"), "/", 1), 1);
+    assertEquals(
+      getUpstreamRetryCount(
+        new Request("http://proxy.test/", { method: "HEAD" }),
+        "/",
+        2,
+      ),
+      2,
+    );
   });
 
   it("does not retry ordinary POST requests", () => {
-    assertEquals(getUpstreamRetryCount("POST", "/api/submit", new Headers(), 1), 0);
+    const request = new Request("http://proxy.test/api/submit", {
+      method: "POST",
+      headers: { "content-length": "2" },
+      body: "{}",
+    });
+
+    assertEquals(getUpstreamRetryCount(request, "/api/submit", 1), 0);
   });
 
-  it("retries bodyless control-plane run stream POST requests", () => {
+  it("retries bounded signed control-plane run stream requests", () => {
+    const request = new Request(RUN_STREAM_URL, {
+      method: "POST",
+      headers: { "content-length": "2" },
+      body: "{}",
+    });
+
     assertEquals(
-      getUpstreamRetryCount("POST", "/api/control-plane/runs/run_1/stream", new Headers(), 1),
+      getUpstreamRetryCount(request, RUN_STREAM_PATH, 1),
+      1,
+    );
+    assertEquals(
+      getUpstreamRetryCount(request, RUN_STREAM_PATH, 3),
       1,
     );
   });
 
-  it("retries control-plane run stream POST requests with explicit zero content length", () => {
+  it("keeps chunked, invalid, and oversized stream requests single-shot", () => {
+    const requests = [
+      new Request(RUN_STREAM_URL, {
+        method: "POST",
+        headers: { "transfer-encoding": "chunked" },
+        body: "{}",
+      }),
+      new Request(RUN_STREAM_URL, {
+        method: "POST",
+        headers: { "content-length": "invalid" },
+        body: "{}",
+      }),
+      new Request(RUN_STREAM_URL, {
+        method: "POST",
+        headers: { "content-length": String(DEFAULT_MAX_BODY_SIZE_BYTES + 1) },
+        body: "{}",
+      }),
+    ];
+
+    for (const request of requests) {
+      assertEquals(getUpstreamRetryCount(request, RUN_STREAM_PATH, 1), 0);
+    }
+  });
+});
+
+describe("shouldRetryUpstreamRequest", () => {
+  it("retries a bounded stream invocation only when connection is refused", () => {
+    const request = new Request(RUN_STREAM_URL, {
+      method: "POST",
+      headers: { "content-length": "2" },
+      body: "{}",
+    });
+
     assertEquals(
-      getUpstreamRetryCount(
-        "POST",
-        "/api/control-plane/runs/run_1/stream",
-        new Headers({ "content-length": "0" }),
-        1,
-      ),
-      1,
+      shouldRetryUpstreamRequest(request, RUN_STREAM_PATH, new Error("connection refused")),
+      true,
+    );
+    assertEquals(
+      shouldRetryUpstreamRequest(request, RUN_STREAM_PATH, new Error("os error 111")),
+      true,
+    );
+    assertEquals(
+      shouldRetryUpstreamRequest(request, RUN_STREAM_PATH, new Error("connection reset")),
+      false,
+    );
+    assertEquals(
+      shouldRetryUpstreamRequest(request, RUN_STREAM_PATH, new Error("connection closed")),
+      false,
     );
   });
 
-  it("does not retry control-plane run stream POST requests with a body", () => {
+  it("retains broad connection retries for bodyless idempotent requests", () => {
+    const request = new Request("http://proxy.test/");
     assertEquals(
-      getUpstreamRetryCount(
-        "POST",
-        "/api/control-plane/runs/run_1/stream",
-        new Headers({ "content-length": "1" }),
-        1,
-      ),
-      0,
+      shouldRetryUpstreamRequest(request, "/", new Error("connection reset")),
+      true,
     );
+  });
+
+  it("never retries an ordinary POST", () => {
+    const request = new Request("http://proxy.test/api/submit", {
+      method: "POST",
+      headers: { "content-length": "2" },
+      body: "{}",
+    });
+
     assertEquals(
-      getUpstreamRetryCount(
-        "POST",
-        "/api/control-plane/runs/run_1/stream",
-        new Headers({ "transfer-encoding": "chunked" }),
-        1,
-      ),
-      0,
+      shouldRetryUpstreamRequest(request, "/api/submit", new Error("connection refused")),
+      false,
     );
   });
 });
 
-describe("getFramedRequestBody", () => {
-  function createBody(): ReadableStream<Uint8Array> {
-    return new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.close();
-      },
+describe("getReplayableRequestBodies", () => {
+  it("creates an independent signed payload stream for every attempt", async () => {
+    const payload = JSON.stringify({ run: { runId: "run_1" } });
+    const request = new Request(RUN_STREAM_URL, {
+      method: "POST",
+      headers: { "content-length": String(payload.length) },
+      body: payload,
     });
-  }
 
-  it("drops Deno-style empty POST streams when content length is zero", () => {
-    const body = createBody();
+    const bodies = getReplayableRequestBodies(request, 2);
 
-    assertEquals(
-      getFramedRequestBody(new Headers({ "content-length": "0" }), body),
-      null,
-    );
+    assertEquals(bodies.length, 3);
+    assertEquals(await new Response(bodies[0]).text(), payload);
+    assertEquals(await new Response(bodies[1]).text(), payload);
+    assertEquals(await new Response(bodies[2]).text(), payload);
   });
 
-  it("preserves request streams when body framing is present", () => {
-    const body = createBody();
+  it("keeps every bodyless attempt bodyless", () => {
+    const request = new Request(RUN_STREAM_URL, {
+      method: "POST",
+      headers: { "content-length": "0" },
+    });
 
-    assertEquals(
-      getFramedRequestBody(new Headers({ "content-length": "1" }), body),
-      body,
-    );
-    assertEquals(
-      getFramedRequestBody(new Headers({ "transfer-encoding": "chunked" }), body),
-      body,
-    );
+    assertEquals(getReplayableRequestBodies(request, 1), [null, null]);
+  });
+
+  it("does not tee chunked or oversized request bodies", () => {
+    const requests = [
+      new Request(RUN_STREAM_URL, {
+        method: "POST",
+        headers: { "transfer-encoding": "chunked" },
+        body: "{}",
+      }),
+      new Request(RUN_STREAM_URL, {
+        method: "POST",
+        headers: { "content-length": String(DEFAULT_MAX_BODY_SIZE_BYTES + 1) },
+        body: "{}",
+      }),
+    ];
+
+    for (const request of requests) {
+      const bodies = getReplayableRequestBodies(request, 1);
+      assertEquals(bodies.length, 1);
+      assertEquals(bodies[0], request.body);
+    }
   });
 });

--- a/src/proxy/retry.ts
+++ b/src/proxy/retry.ts
@@ -2,6 +2,12 @@
  * Retry utilities for the proxy server.
  */
 
+import { DEFAULT_MAX_BODY_SIZE_BYTES } from "#veryfront/utils/constants/index.ts";
+
+const CONTROL_PLANE_RUN_STREAM_PATH = /^\/api\/control-plane\/runs\/[^/]+\/stream$/;
+
+type RequestBodyReplayKind = "bodyless" | "bounded" | "unsupported";
+
 /**
  * Check if a fetch error is a transient connection error worth retrying.
  * These occur when renderer pods are being recycled or temporarily unavailable.
@@ -18,42 +24,104 @@ export function isRetryableConnectionError(error: unknown): boolean {
   );
 }
 
+function isConnectionRefusedError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const message = error.message.toLowerCase();
+  return message.includes("connection refused") || message.includes("os error 111");
+}
+
+function isIdempotentMethod(method: string): boolean {
+  return method === "GET" || method === "HEAD" || method === "OPTIONS";
+}
+
+function isControlPlaneRunStreamPost(request: Request, pathname: string): boolean {
+  return request.method === "POST" && CONTROL_PLANE_RUN_STREAM_PATH.test(pathname);
+}
+
+function getRequestBodyReplayKind(request: Request): RequestBodyReplayKind {
+  const transferEncoding = request.headers.get("transfer-encoding");
+  if (transferEncoding !== null && transferEncoding.trim() !== "") {
+    return "unsupported";
+  }
+
+  const contentLength = request.headers.get("content-length");
+  if (contentLength === null) return request.body === null ? "bodyless" : "unsupported";
+
+  const normalizedLength = contentLength.trim();
+  if (!/^\d+$/.test(normalizedLength)) return "unsupported";
+
+  const length = Number(normalizedLength);
+  if (length === 0) return "bodyless";
+  if (
+    request.body === null ||
+    !Number.isSafeInteger(length) ||
+    length > DEFAULT_MAX_BODY_SIZE_BYTES
+  ) {
+    return "unsupported";
+  }
+  return "bounded";
+}
+
 /**
  * Decide how many times the proxy can safely retry an upstream request.
  *
- * Ordinary non-idempotent requests are not replayed. The control-plane run
- * stream attach endpoint is a bodyless POST, so it can safely retry once to
- * fall back from an unavailable dedicated runtime to the shared runtime during
- * operator reconciliation.
+ * Ordinary non-idempotent requests are not replayed. A bounded control-plane
+ * run stream invocation may retry to the shared runtime when the dedicated
+ * runtime refuses the connection. Missing, chunked, invalid, and oversized
+ * bodies remain single-shot so cloning cannot buffer unbounded input.
  */
 export function getUpstreamRetryCount(
-  method: string,
+  request: Request,
   pathname: string,
-  headers: Headers,
   configuredRetryCount: number,
 ): number {
-  if (["GET", "HEAD", "OPTIONS"].includes(method)) return configuredRetryCount;
-
-  const isBodylessControlPlaneRunStreamPost = method === "POST" &&
-    requestHeadersDeclareBody(headers) === false &&
-    /^\/api\/control-plane\/runs\/[^/]+\/stream$/.test(pathname);
-
-  return isBodylessControlPlaneRunStreamPost ? configuredRetryCount : 0;
-}
-
-export function getFramedRequestBody(
-  headers: Headers,
-  body: ReadableStream<Uint8Array> | null,
-): ReadableStream<Uint8Array> | null {
-  return requestHeadersDeclareBody(headers) ? body : null;
-}
-
-function requestHeadersDeclareBody(headers: Headers): boolean {
-  const contentLength = headers.get("content-length");
-  if (contentLength !== null && contentLength.trim() !== "" && contentLength !== "0") {
-    return true;
+  const bodyKind = getRequestBodyReplayKind(request);
+  if (bodyKind === "unsupported") return 0;
+  const retryCount = Math.max(0, configuredRetryCount);
+  if (isIdempotentMethod(request.method)) return retryCount;
+  if (isControlPlaneRunStreamPost(request, pathname)) {
+    return Math.min(retryCount, 1);
   }
 
-  const transferEncoding = headers.get("transfer-encoding");
-  return transferEncoding !== null && transferEncoding.trim() !== "";
+  return 0;
+}
+
+/** Decide whether this failure mode is safe to replay for the request. */
+export function shouldRetryUpstreamRequest(
+  request: Request,
+  pathname: string,
+  error: unknown,
+): boolean {
+  if (!isRetryableConnectionError(error)) return false;
+  if (isIdempotentMethod(request.method)) return true;
+  if (!isControlPlaneRunStreamPost(request, pathname)) return false;
+
+  const bodyKind = getRequestBodyReplayKind(request);
+  if (bodyKind === "bodyless") return true;
+  return bodyKind === "bounded" && isConnectionRefusedError(error);
+}
+
+/**
+ * Build one independently consumable body stream for every upstream attempt.
+ * Request bodies are one-shot streams, so reusing the first stream would make
+ * a retry fail before it reaches the fallback runtime. Cloning before the
+ * first fetch preserves the exact signed bytes for each attempt.
+ */
+export function getReplayableRequestBodies(
+  request: Request,
+  retryCount: number,
+): Array<ReadableStream<Uint8Array> | null> {
+  const attemptCount = Math.max(0, retryCount) + 1;
+  const bodyKind = getRequestBodyReplayKind(request);
+  if (bodyKind === "bodyless") {
+    return Array.from({ length: attemptCount }, () => null);
+  }
+  if (bodyKind === "unsupported" || attemptCount === 1) return [request.body];
+
+  const bodies: Array<ReadableStream<Uint8Array> | null> = [];
+  for (let attempt = 1; attempt < attemptCount; attempt++) {
+    bodies.push(request.clone().body);
+  }
+  bodies.push(request.body);
+  return bodies;
 }


### PR DESCRIPTION
## Summary

- Retry the signed control-plane run-stream POST when a dedicated runtime refuses the connection.
- Preserve the exact signed body through one independent request clone.
- Keep reset/closed failures, ordinary POSTs, chunked bodies, invalid lengths, and bodies over 1 MiB single-shot.
- Add policy, replay-byte, and proxy wiring regression coverage.

This is the fix-forward for the incomplete bodyless-only fallback merged in #2872.

## Verification

- Focused proxy and Node request-adapter tests: 6 groups, 28 steps passed.
- Format, lint, targeted check, full typecheck, and git diff check passed.
- Repository pre-push gate passed: 2,357 groups and 19,994 steps.
- Independent merge-gate review confidence: 94%.