### PR TITLE
Publish dedicated runtime startup fixes as Veryfront 0.1.1049

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1048",
+  "version": "0.1.1049",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1048";
+export const VERSION = "0.1.1049";


### PR DESCRIPTION
## Summary

- publish Veryfront 0.1.1049 from current protected `main`
- include the bounded signed-body connection replay merged in #2875
- include verified control-plane cache credential propagation merged in #2877
- keep repository version declarations synchronized

## Release reason

Veryfront 0.1.1048 predates both corrected startup paths. The immutable fix-forward release restores cold dedicated startup while preserving the proxy trust boundary: body-bearing signed stream requests replay once only when a refused connection proves the request was not delivered, and cache calls prefer request credentials only after control-plane verification.

Related platform issue: veryfront/veryfront-studio#5784.

## Verification

- npm publication preflight confirms all 16 packages are unused at 0.1.1049
- `v0.1.1049` tag and GitHub release do not exist
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno check src/utils/version.ts`
- version and stable-release tests passed, 25 steps
- full pre-push checks passed, 2,372 tests and 20,069 steps
- both framework fixes passed protected-branch CI before this version bump

## Merge gate

Merge only after required independent review, all refreshed CI checks, and the immutable-version collision checks remain green.