### PR TITLE
Prefer signed request credentials for cache API calls

### DIFF
--- a/src/cache/backend.test.ts
+++ b/src/cache/backend.test.ts
@@ -481,6 +481,7 @@ Deno.test("ApiCacheBackend URL-encodes project refs and omits cache keys from sp
   globals.__vf_multi_project_adapter = {
     getCurrentRequestContext: () => ({
       token: "request-token",
+      tokenTrust: "verified-control-plane",
       projectSlug: projectRef,
     }),
   };
@@ -529,7 +530,7 @@ Deno.test("ApiCacheBackend URL-encodes project refs and omits cache keys from sp
   }
 });
 
-Deno.test("ApiCacheBackend prefers request token and falls back to host API token", async () => {
+Deno.test("ApiCacheBackend only prefers verified control-plane request tokens", async () => {
   const { ApiCacheBackend } = await importBackend();
   const globals = globalThis as Record<string, unknown>;
   const originalAdapter = globals.__vf_multi_project_adapter;
@@ -541,6 +542,7 @@ Deno.test("ApiCacheBackend prefers request token and falls back to host API toke
   globals.__vf_multi_project_adapter = {
     getCurrentRequestContext: () => ({
       token: "run-scoped-request-token",
+      tokenTrust: "verified-control-plane",
       projectId: "project-123",
       projectSlug: "project-slug",
     }),
@@ -566,6 +568,17 @@ Deno.test("ApiCacheBackend prefers request token and falls back to host API toke
 
     globals.__vf_multi_project_adapter = {
       getCurrentRequestContext: () => ({
+        token: "unverified-proxy-token",
+        projectId: "project-123",
+        projectSlug: "project-slug",
+      }),
+    };
+    const unverifiedRequestDeleted = await cache.delByPattern("agent:*");
+
+    assertEquals(unverifiedRequestDeleted, 3);
+
+    globals.__vf_multi_project_adapter = {
+      getCurrentRequestContext: () => ({
         projectId: "project-123",
         projectSlug: "project-slug",
       }),
@@ -575,6 +588,7 @@ Deno.test("ApiCacheBackend prefers request token and falls back to host API toke
     assertEquals(hostFallbackDeleted, 3);
     assertEquals(capturedAuthorizations, [
       "Bearer run-scoped-request-token",
+      "Bearer host-framework-token",
       "Bearer host-framework-token",
     ]);
   } finally {

--- a/src/cache/backend.test.ts
+++ b/src/cache/backend.test.ts
@@ -529,13 +529,13 @@ Deno.test("ApiCacheBackend URL-encodes project refs and omits cache keys from sp
   }
 });
 
-Deno.test("ApiCacheBackend uses host API token before request token", async () => {
+Deno.test("ApiCacheBackend prefers request token and falls back to host API token", async () => {
   const { ApiCacheBackend } = await importBackend();
   const globals = globalThis as Record<string, unknown>;
   const originalAdapter = globals.__vf_multi_project_adapter;
   const originalFetch = globalThis.fetch;
   const originalToken = Deno.env.get("VERYFRONT_API_TOKEN");
-  let capturedAuthorization = "";
+  const capturedAuthorizations: string[] = [];
 
   Deno.env.set("VERYFRONT_API_TOKEN", "host-framework-token");
   globals.__vf_multi_project_adapter = {
@@ -546,7 +546,7 @@ Deno.test("ApiCacheBackend uses host API token before request token", async () =
     }),
   };
   globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
-    capturedAuthorization = new Headers(init?.headers).get("authorization") ?? "";
+    capturedAuthorizations.push(new Headers(init?.headers).get("authorization") ?? "");
     return Promise.resolve(
       new Response(JSON.stringify({ deleted: 3 }), {
         status: 200,
@@ -560,10 +560,23 @@ Deno.test("ApiCacheBackend uses host API token before request token", async () =
       apiBaseUrl: "https://api.example.test",
       circuitBreakerName: "api-cache-host-token-test",
     });
-    const deleted = await cache.delByPattern("agent:*");
+    const requestScopedDeleted = await cache.delByPattern("agent:*");
 
-    assertEquals(deleted, 3);
-    assertEquals(capturedAuthorization, "Bearer host-framework-token");
+    assertEquals(requestScopedDeleted, 3);
+
+    globals.__vf_multi_project_adapter = {
+      getCurrentRequestContext: () => ({
+        projectId: "project-123",
+        projectSlug: "project-slug",
+      }),
+    };
+    const hostFallbackDeleted = await cache.delByPattern("agent:*");
+
+    assertEquals(hostFallbackDeleted, 3);
+    assertEquals(capturedAuthorizations, [
+      "Bearer run-scoped-request-token",
+      "Bearer host-framework-token",
+    ]);
   } finally {
     if (originalAdapter === undefined) {
       delete globals.__vf_multi_project_adapter;

--- a/src/cache/backends/api.ts
+++ b/src/cache/backends/api.ts
@@ -20,6 +20,7 @@ const ERROR_BODY_MAX_LENGTH = 500;
 
 type CacheRequestContext = {
   token?: string;
+  tokenTrust?: "verified-control-plane";
   projectId?: string;
   projectSlug?: string;
 };
@@ -98,11 +99,14 @@ export class ApiCacheBackend implements CacheBackend {
     const reqCtx = getCurrentRequestContext();
     const hostToken = getHostEnv("VERYFRONT_API_TOKEN");
     const envToken = getEnvValue("VERYFRONT_API_TOKEN");
-    // Request credentials are verified control-plane context. Host credentials
-    // remain a fallback, while project environment values cannot shadow either.
-    const token = reqCtx?.token || hostToken || envToken || null;
-    const tokenSource = reqCtx?.token
-      ? "request"
+    const verifiedRequestToken = reqCtx?.tokenTrust === "verified-control-plane"
+      ? reqCtx.token
+      : undefined;
+    // Ordinary proxy headers are not cache credentials. Only a request token
+    // explicitly marked after control-plane verification may override the host.
+    const token = verifiedRequestToken || hostToken || envToken || null;
+    const tokenSource = verifiedRequestToken
+      ? "verified-control-plane"
       : hostToken
       ? "host-env"
       : envToken

--- a/src/cache/backends/api.ts
+++ b/src/cache/backends/api.ts
@@ -98,13 +98,13 @@ export class ApiCacheBackend implements CacheBackend {
     const reqCtx = getCurrentRequestContext();
     const hostToken = getHostEnv("VERYFRONT_API_TOKEN");
     const envToken = getEnvValue("VERYFRONT_API_TOKEN");
-    // Cache API calls are framework-owned operations; use the host token when
-    // available so project/request-scoped credentials cannot shadow it.
-    const token = hostToken || reqCtx?.token || envToken || null;
-    const tokenSource = hostToken
-      ? "host-env"
-      : reqCtx?.token
+    // Request credentials are verified control-plane context. Host credentials
+    // remain a fallback, while project environment values cannot shadow either.
+    const token = reqCtx?.token || hostToken || envToken || null;
+    const tokenSource = reqCtx?.token
       ? "request"
+      : hostToken
+      ? "host-env"
       : envToken
       ? "env"
       : "none";

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
@@ -108,6 +108,23 @@ describe("MultiProjectFSAdapter", () => {
       withAdapter((adapter) => assertMethod(adapter, "runWithContext"));
     });
 
+    it("preserves verified token trust in runWithContext", async () => {
+      await withAdapterAsync(async (adapter) => {
+        await adapter.runWithContext(
+          "project-a",
+          "test-token",
+          async () => {
+            assertEquals(
+              getCurrentRequestContext()?.tokenTrust,
+              "verified-control-plane",
+            );
+          },
+          "project-id-a",
+          { tokenTrust: "verified-control-plane" },
+        );
+      });
+    });
+
     it("should have refreshSourceSnapshot method", () => {
       withAdapter((adapter) => assertMethod(adapter, "refreshSourceSnapshot"));
     });
@@ -365,6 +382,20 @@ describe("runWithRequestContext", () => {
       async () => {
         const ctx = getCurrentRequestContext();
         assertEquals(ctx!.projectId, "pid-456");
+      },
+    );
+  });
+
+  it("should preserve verified control-plane token trust", async () => {
+    await runWithRequestContext(
+      {
+        projectSlug: "proj",
+        token: "tok",
+        tokenTrust: "verified-control-plane",
+      },
+      async () => {
+        const ctx = getCurrentRequestContext();
+        assertEquals(ctx!.tokenTrust, "verified-control-plane");
       },
     );
   });

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
@@ -9,6 +9,7 @@ import {
   asyncLocalStorage,
   clearRequestScopedFileCache,
   type RequestContext,
+  type RequestTokenTrust,
 } from "./request-context.ts";
 export {
   clearRequestScopedFileCache,
@@ -18,7 +19,7 @@ export {
   setRequestScopedFile,
   wrapWithCurrentContext,
 } from "./request-context.ts";
-export type { RequestContext } from "./request-context.ts";
+export type { RequestContext, RequestTokenTrust } from "./request-context.ts";
 
 const logger = baseLogger.component("multi-project-fs-adapter");
 
@@ -53,6 +54,7 @@ export class MultiProjectFSAdapter implements FSAdapter {
       releaseId?: string | null;
       branch?: string | null;
       environmentName?: string | null;
+      tokenTrust?: RequestTokenTrust;
     },
   ): Promise<T> {
     const startTime = performance.now();
@@ -74,6 +76,7 @@ export class MultiProjectFSAdapter implements FSAdapter {
       projectSlug,
       projectId,
       token,
+      tokenTrust: options?.tokenTrust,
       productionMode,
       releaseId: productionMode ? releaseId : null,
       branch: productionMode ? null : branch,
@@ -112,6 +115,7 @@ export class MultiProjectFSAdapter implements FSAdapter {
 
     store.projectSlug = projectSlug;
     store.token = token;
+    store.tokenTrust = undefined;
   }
 
   setProductionMode(_enabled: boolean, _releaseId?: string | null): void {

--- a/src/platform/adapters/fs/veryfront/request-context.ts
+++ b/src/platform/adapters/fs/veryfront/request-context.ts
@@ -1,9 +1,13 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
+export type RequestTokenTrust = "verified-control-plane";
+
 export interface RequestContext {
   projectSlug: string;
   projectId?: string;
   token: string;
+  /** Trust marker set only after the control-plane request signature is verified. */
+  tokenTrust?: RequestTokenTrust;
   productionMode: boolean;
   /** Release ID for production mode (mutually exclusive with branch) */
   releaseId?: string | null;
@@ -67,6 +71,7 @@ export function runWithRequestContext<T>(
   options: {
     projectSlug: string;
     token: string;
+    tokenTrust?: RequestTokenTrust;
     projectId?: string;
     productionMode?: boolean;
     releaseId?: string | null;
@@ -80,6 +85,7 @@ export function runWithRequestContext<T>(
     projectSlug: options.projectSlug,
     projectId: options.projectId,
     token: options.token,
+    tokenTrust: options.tokenTrust,
     productionMode,
     releaseId: options.releaseId ?? null,
     branch: productionMode ? null : (options.branch ?? null),

--- a/src/security/http/base-handler.test.ts
+++ b/src/security/http/base-handler.test.ts
@@ -32,7 +32,10 @@ class TestHandler extends BaseHandler {
   testWithProxyContext<T>(
     ctx: HandlerContext,
     fn: () => Promise<T>,
-    options?: { requireToken?: boolean },
+    options?: {
+      requireToken?: boolean;
+      tokenTrust?: "verified-control-plane";
+    },
   ): Promise<T> {
     return this.withProxyContext(ctx, fn, options);
   }

--- a/src/security/http/base-handler.ts
+++ b/src/security/http/base-handler.ts
@@ -8,6 +8,7 @@ import type {
 import { runWithCacheBatching } from "#veryfront/cache/request-cache-batcher.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import type { WebSocketUpgradeResponse } from "#veryfront/platform/adapters/base.ts";
+import type { RequestTokenTrust } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
 import { serverLogger } from "#veryfront/utils";
 import { ResponseBuilder } from "./response/index.ts";
 
@@ -113,7 +114,7 @@ export abstract class BaseHandler implements Handler {
   protected withProxyContext<T>(
     ctx: HandlerContext,
     fn: () => Promise<T>,
-    options: { requireToken?: boolean } = {},
+    options: { requireToken?: boolean; tokenTrust?: RequestTokenTrust } = {},
   ): Promise<T> {
     // Framework-owned token: bypass project env overlay so proxy mode works
     // when a remote project overlay is active.
@@ -132,6 +133,7 @@ export abstract class BaseHandler implements Handler {
           releaseId?: string | null;
           branch?: string | null;
           environmentName?: string | null;
+          tokenTrust?: RequestTokenTrust;
         },
       ) => Promise<R>;
     };
@@ -187,6 +189,7 @@ export abstract class BaseHandler implements Handler {
           releaseId: ctx.releaseId,
           branch,
           environmentName: ctx.environmentName,
+          tokenTrust: options.tokenTrust,
         },
       );
     }

--- a/src/server/handlers/request/agent-stream.handler.test-helpers.ts
+++ b/src/server/handlers/request/agent-stream.handler.test-helpers.ts
@@ -71,6 +71,7 @@ export type SourceContextTestFsAdapter = FileSystemAdapter & {
       releaseId?: string | null;
       branch?: string | null;
       environmentName?: string | null;
+      tokenTrust?: "verified-control-plane";
     },
   ): Promise<R>;
 };
@@ -82,6 +83,7 @@ export function createNoopFsAdapter(
     releaseId?: string | null;
     branch?: string | null;
     environmentName?: string | null;
+    tokenTrust?: "verified-control-plane";
   }>,
 ): SourceContextTestFsAdapter {
   return {

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -1894,6 +1894,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
       releaseId?: string | null;
       branch?: string | null;
       environmentName?: string | null;
+      tokenTrust?: "verified-control-plane";
     }> = [];
 
     const handler = new AgentStreamHandler({
@@ -1990,8 +1991,10 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(result.response.status, 200);
     assertEquals(runWithContextCalls.length, 2);
     assertEquals(runWithContextCalls[0]?.token, "request-scoped-user-token");
+    assertEquals(runWithContextCalls[0]?.tokenTrust, "verified-control-plane");
     assertEquals(runWithContextCalls[0]?.branch, "feature-a");
     assertEquals(runWithContextCalls[1]?.token, "request-scoped-user-token");
+    assertEquals(runWithContextCalls[1]?.tokenTrust, "verified-control-plane");
     assertEquals(runWithContextCalls[1]?.branch, "main");
     assertEquals(runWithContextCalls[1]?.productionMode, false);
   });

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -514,6 +514,7 @@ type SourceContextFsWrapper = {
       releaseId?: string | null;
       branch?: string | null;
       environmentName?: string | null;
+      tokenTrust?: "verified-control-plane";
     },
   ) => Promise<R>;
 };
@@ -523,23 +524,27 @@ function buildAgentSourceRunOptions(sourceContext: RuntimeAgentSourceContext): {
   releaseId?: string | null;
   branch?: string | null;
   environmentName?: string | null;
+  tokenTrust: "verified-control-plane";
 } {
   switch (sourceContext.type) {
     case "branch":
       return {
         productionMode: false,
         branch: sourceContext.branch,
+        tokenTrust: "verified-control-plane",
       };
     case "environment":
       return {
         productionMode: true,
         environmentName: sourceContext.environmentName,
         releaseId: sourceContext.releaseId ?? null,
+        tokenTrust: "verified-control-plane",
       };
     case "release":
       return {
         productionMode: true,
         releaseId: sourceContext.releaseId,
+        tokenTrust: "verified-control-plane",
       };
   }
 }
@@ -781,7 +786,7 @@ export class AgentStreamHandler extends BaseHandler {
               : response;
             return this.respond(applyBuilderHeaders(responseWithOwner, builder.headers));
           },
-        ));
+        ), { tokenTrust: "verified-control-plane" });
     } catch (error) {
       if (error instanceof InternalAgentRequestBodyTooLargeError) {
         return this.respond(builder.json({ error: error.message }, error.status));


### PR DESCRIPTION
## Summary

- prefer the verified request credential for framework-owned cache API calls
- retain the host API token as a compatibility fallback
- keep tenant/project environment credentials below both trusted sources
- cover request-first and host-fallback behavior in one regression

## Root cause

A cold dedicated runtime can retain a host token that expires independently of a signed run request. The agent-stream handler correctly installs the fresh verified request credential, but `ApiCacheBackend` still selected the host token first. Cache reads then received HTTP 401 and project config loading failed.

The request credential is trusted control-plane context, not tenant environment input. This change aligns the cache backend with project discovery and the other runtime API clients without allowing project environment values to shadow framework credentials.

Closes veryfront/veryfront-studio#5784.
Related: veryfront/veryfront-studio#5766.

## Verification

- regression failed before the implementation change and passed afterward
- cache suite: 55 passed
- cache, request-context, and agent-stream suites: 63 tests / 75 steps passed
- full framework typecheck passed
- pre-push gate passed: format, lint, typecheck, and 2,357 test groups / 19,994 steps

## Release gate

Publish this together with merged #2875, deploy the resulting server artifact to staging, and prove a cold dedicated run with a stale host fallback before promoting production.