### PR TITLE
Keep cache credentials behind verified request capability

### DIFF
--- a/src/cache/backend.test.ts
+++ b/src/cache/backend.test.ts
@@ -18,6 +18,12 @@ import {
   type Tracer,
 } from "#veryfront/observability/tracing/api-shim.ts";
 import type { RedisClient } from "#veryfront/utils/redis-client.ts";
+import { verifyControlPlaneRequest } from "#veryfront/internal-agents/control-plane-auth.ts";
+import {
+  createControlPlaneSignature,
+  createCtx,
+} from "#veryfront/server/handlers/request/internal-agent-run.test-helpers.ts";
+import { runWithVerifiedCacheApiCredential } from "./verified-api-credential-context.ts";
 
 type RecordedSpan = {
   name: string;
@@ -26,6 +32,39 @@ type RecordedSpan = {
 
 async function importBackend(): Promise<typeof import("./backend.ts")> {
   return await import("./backend.ts");
+}
+
+async function createVerifiedCacheClaims(options: {
+  token: string;
+  projectId: string;
+  projectSlug: string;
+}) {
+  const rawBody = JSON.stringify({
+    credentials: { authToken: options.token },
+  });
+  const { jws, publicKeyPem } = await createControlPlaneSignature(rawBody, {
+    audience: options.projectSlug,
+    projectId: options.projectId,
+  });
+  const ctx = createCtx(publicKeyPem);
+  ctx.projectId = options.projectId;
+  ctx.projectSlug = options.projectSlug;
+  const signingKeyEnv = "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY";
+  const originalSigningKey = Deno.env.get(signingKeyEnv);
+  Deno.env.set(signingKeyEnv, publicKeyPem);
+
+  try {
+    return await verifyControlPlaneRequest(
+      new Request("https://example.test/api/control-plane/runs/run-1/stream", {
+        headers: { "x-veryfront-control-plane-jws": jws },
+      }),
+      ctx,
+      rawBody,
+    );
+  } finally {
+    if (originalSigningKey === undefined) Deno.env.delete(signingKeyEnv);
+    else Deno.env.set(signingKeyEnv, originalSigningKey);
+  }
 }
 
 function sleep(ms: number): Promise<void> {
@@ -481,7 +520,6 @@ Deno.test("ApiCacheBackend URL-encodes project refs and omits cache keys from sp
   globals.__vf_multi_project_adapter = {
     getCurrentRequestContext: () => ({
       token: "request-token",
-      tokenTrust: "verified-control-plane",
       projectSlug: projectRef,
     }),
   };
@@ -502,7 +540,15 @@ Deno.test("ApiCacheBackend URL-encodes project refs and omits cache keys from sp
       circuitBreakerName: "api-cache-url-encoding-test",
     });
 
-    await cache.get("secret-cache-key");
+    const verifiedClaims = await createVerifiedCacheClaims({
+      token: "request-token",
+      projectId: projectRef,
+      projectSlug: "project-slug",
+    });
+    await runWithVerifiedCacheApiCredential(
+      verifiedClaims,
+      () => cache.get("secret-cache-key"),
+    );
 
     const encodedProjectRef = encodeURIComponent(projectRef);
     assertEquals(
@@ -537,17 +583,19 @@ Deno.test("ApiCacheBackend only prefers verified control-plane request tokens", 
   const originalFetch = globalThis.fetch;
   const originalToken = Deno.env.get("VERYFRONT_API_TOKEN");
   const capturedAuthorizations: string[] = [];
+  const capturedUrls: string[] = [];
 
   Deno.env.set("VERYFRONT_API_TOKEN", "host-framework-token");
   globals.__vf_multi_project_adapter = {
     getCurrentRequestContext: () => ({
-      token: "run-scoped-request-token",
+      token: "forged-request-token",
       tokenTrust: "verified-control-plane",
-      projectId: "project-123",
-      projectSlug: "project-slug",
+      projectId: "forged-project",
+      projectSlug: "forged-project-slug",
     }),
   };
-  globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    capturedUrls.push(String(input));
     capturedAuthorizations.push(new Headers(init?.headers).get("authorization") ?? "");
     return Promise.resolve(
       new Response(JSON.stringify({ deleted: 3 }), {
@@ -562,9 +610,25 @@ Deno.test("ApiCacheBackend only prefers verified control-plane request tokens", 
       apiBaseUrl: "https://api.example.test",
       circuitBreakerName: "api-cache-host-token-test",
     });
-    const requestScopedDeleted = await cache.delByPattern("agent:*");
+    const verifiedClaims = await createVerifiedCacheClaims({
+      token: "run-scoped-request-token",
+      projectId: "project-123",
+      projectSlug: "project-slug",
+    });
+    const requestScopedDeleted = await runWithVerifiedCacheApiCredential(
+      verifiedClaims,
+      () => cache.delByPattern("agent:*"),
+    );
 
     assertEquals(requestScopedDeleted, 3);
+    assertEquals(
+      capturedUrls[0],
+      "https://api.example.test/projects/project-123/cache/del-pattern",
+    );
+
+    const forgedTrustDeleted = await cache.delByPattern("agent:*");
+
+    assertEquals(forgedTrustDeleted, 3);
 
     globals.__vf_multi_project_adapter = {
       getCurrentRequestContext: () => ({
@@ -576,6 +640,13 @@ Deno.test("ApiCacheBackend only prefers verified control-plane request tokens", 
     const unverifiedRequestDeleted = await cache.delByPattern("agent:*");
 
     assertEquals(unverifiedRequestDeleted, 3);
+
+    Deno.env.delete("VERYFRONT_API_TOKEN");
+    const requestFallbackDeleted = await cache.delByPattern("agent:*");
+
+    assertEquals(requestFallbackDeleted, 3);
+
+    Deno.env.set("VERYFRONT_API_TOKEN", "host-framework-token");
 
     globals.__vf_multi_project_adapter = {
       getCurrentRequestContext: () => ({
@@ -589,6 +660,8 @@ Deno.test("ApiCacheBackend only prefers verified control-plane request tokens", 
     assertEquals(capturedAuthorizations, [
       "Bearer run-scoped-request-token",
       "Bearer host-framework-token",
+      "Bearer host-framework-token",
+      "Bearer unverified-proxy-token",
       "Bearer host-framework-token",
     ]);
   } finally {

--- a/src/cache/backends/api.ts
+++ b/src/cache/backends/api.ts
@@ -9,6 +9,7 @@ import { buildBatchResults } from "../batch-results.ts";
 import { REQUEST_ERROR } from "#veryfront/errors";
 import { sanitizeUrlForSpan } from "#veryfront/utils/logger/redact.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
+import { getVerifiedCacheApiCredential } from "../verified-api-credential-context.ts";
 
 const logger = baseLogger.component("api-cache-backend");
 
@@ -20,7 +21,6 @@ const ERROR_BODY_MAX_LENGTH = 500;
 
 type CacheRequestContext = {
   token?: string;
-  tokenTrust?: "verified-control-plane";
   projectId?: string;
   projectSlug?: string;
 };
@@ -99,20 +99,22 @@ export class ApiCacheBackend implements CacheBackend {
     const reqCtx = getCurrentRequestContext();
     const hostToken = getHostEnv("VERYFRONT_API_TOKEN");
     const envToken = getEnvValue("VERYFRONT_API_TOKEN");
-    const verifiedRequestToken = reqCtx?.tokenTrust === "verified-control-plane"
-      ? reqCtx.token
-      : undefined;
-    // Ordinary proxy headers are not cache credentials. Only a request token
-    // explicitly marked after control-plane verification may override the host.
-    const token = verifiedRequestToken || hostToken || envToken || null;
+    const verifiedCredential = getVerifiedCacheApiCredential();
+    const verifiedRequestToken = verifiedCredential?.token;
+    // The private verified-request context cannot be changed through the
+    // globally exposed filesystem request context.
+    const token = verifiedRequestToken || hostToken || reqCtx?.token || envToken || null;
     const tokenSource = verifiedRequestToken
       ? "verified-control-plane"
       : hostToken
       ? "host-env"
+      : reqCtx?.token
+      ? "request"
       : envToken
       ? "env"
       : "none";
-    const projectRef = reqCtx?.projectId || reqCtx?.projectSlug ||
+    const projectRef = verifiedCredential?.projectId || verifiedCredential?.projectSlug ||
+      reqCtx?.projectId || reqCtx?.projectSlug ||
       tryGetCacheKeyContext()?.projectId || null;
 
     if (!token || !projectRef) {

--- a/src/cache/verified-api-credential-context.test.ts
+++ b/src/cache/verified-api-credential-context.test.ts
@@ -1,0 +1,114 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { verifyControlPlaneRequest } from "#veryfront/internal-agents/control-plane-auth.ts";
+import {
+  createControlPlaneSignature,
+  createCtx,
+} from "#veryfront/server/handlers/request/internal-agent-run.test-helpers.ts";
+import {
+  getVerifiedCacheApiCredential,
+  runWithVerifiedCacheApiCredential,
+} from "./verified-api-credential-context.ts";
+
+async function createVerifiedClaims(token?: string) {
+  const rawBody = JSON.stringify(
+    token ? { credentials: { authToken: token } } : {},
+  );
+  const { jws, publicKeyPem } = await createControlPlaneSignature(rawBody);
+  const signingKeyEnv = "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY";
+  const originalSigningKey = Deno.env.get(signingKeyEnv);
+  Deno.env.set(signingKeyEnv, publicKeyPem);
+
+  try {
+    return await verifyControlPlaneRequest(
+      new Request("https://example.test/api/control-plane/runs/run-1/stream", {
+        headers: { "x-veryfront-control-plane-jws": jws },
+      }),
+      createCtx(publicKeyPem),
+      rawBody,
+    );
+  } finally {
+    if (originalSigningKey === undefined) Deno.env.delete(signingKeyEnv);
+    else Deno.env.set(signingKeyEnv, originalSigningKey);
+  }
+}
+
+describe("verified cache API credential context", () => {
+  it("keeps the credential private to its async scope", async () => {
+    const verifiedClaims = await createVerifiedClaims("signed-body-token");
+    const credentiallessClaims = await createVerifiedClaims();
+    assertEquals(getVerifiedCacheApiCredential(), undefined);
+
+    await runWithVerifiedCacheApiCredential(verifiedClaims, async () => {
+      await Promise.resolve();
+      const credential = getVerifiedCacheApiCredential();
+      assertEquals(credential?.token, "signed-body-token");
+      assertEquals(credential?.projectId, "proj-1");
+      assertEquals(credential?.projectSlug, "demo-project");
+      assertEquals(Object.isFrozen(credential), true);
+
+      await runWithVerifiedCacheApiCredential(credentiallessClaims, async () => {
+        assertEquals(getVerifiedCacheApiCredential(), undefined);
+      });
+
+      assertEquals(getVerifiedCacheApiCredential()?.token, "signed-body-token");
+    });
+
+    assertEquals(getVerifiedCacheApiCredential(), undefined);
+    await runWithVerifiedCacheApiCredential(verifiedClaims, async () => {
+      assertEquals(getVerifiedCacheApiCredential(), undefined);
+    });
+  });
+
+  it("rejects copied claims and isolates concurrent credentials", async () => {
+    const firstClaims = await createVerifiedClaims("first-token");
+    const secondClaims = await createVerifiedClaims("second-token");
+    const credentiallessClaims = await createVerifiedClaims();
+    const copiedClaims = { ...firstClaims } as typeof firstClaims;
+
+    await runWithVerifiedCacheApiCredential(copiedClaims, async () => {
+      assertEquals(getVerifiedCacheApiCredential(), undefined);
+    });
+
+    const observed = await Promise.all([
+      runWithVerifiedCacheApiCredential(firstClaims, async () => {
+        await Promise.resolve();
+        return getVerifiedCacheApiCredential()?.token;
+      }),
+      runWithVerifiedCacheApiCredential(secondClaims, async () => {
+        await Promise.resolve();
+        return getVerifiedCacheApiCredential()?.token;
+      }),
+      runWithVerifiedCacheApiCredential(credentiallessClaims, async () => {
+        await Promise.resolve();
+        return getVerifiedCacheApiCredential()?.token;
+      }),
+    ]);
+
+    assertEquals(observed, ["first-token", "second-token", undefined]);
+    assertEquals(getVerifiedCacheApiCredential(), undefined);
+  });
+
+  it("preserves the scope in delayed stream work created inside it", async () => {
+    const verifiedClaims = await createVerifiedClaims("stream-token");
+    let observedToken: string | undefined;
+
+    const stream = runWithVerifiedCacheApiCredential(
+      verifiedClaims,
+      () =>
+        new ReadableStream<void>({
+          async pull(controller) {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            observedToken = getVerifiedCacheApiCredential()?.token;
+            controller.close();
+          },
+        }),
+    );
+
+    assertEquals(getVerifiedCacheApiCredential(), undefined);
+    await stream.getReader().read();
+    assertEquals(observedToken, "stream-token");
+    assertEquals(getVerifiedCacheApiCredential(), undefined);
+  });
+});

--- a/src/cache/verified-api-credential-context.ts
+++ b/src/cache/verified-api-credential-context.ts
@@ -1,0 +1,30 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import {
+  consumeVerifiedControlPlaneCacheCredential,
+  type VerifiedControlPlaneCacheCredential,
+  type VerifiedControlPlaneRequestClaims,
+} from "#veryfront/internal-agents/control-plane-auth.ts";
+
+const verifiedCredentialStorage = new AsyncLocalStorage<
+  VerifiedControlPlaneCacheCredential | null
+>();
+
+/**
+ * Runs framework work with the exact cache API credential from a verified
+ * control-plane request body. Keep this helper on internal import surfaces.
+ */
+export function runWithVerifiedCacheApiCredential<T>(
+  claims: VerifiedControlPlaneRequestClaims,
+  fn: () => T,
+): T {
+  return verifiedCredentialStorage.run(
+    consumeVerifiedControlPlaneCacheCredential(claims),
+    fn,
+  );
+}
+
+export function getVerifiedCacheApiCredential():
+  | VerifiedControlPlaneCacheCredential
+  | undefined {
+  return verifiedCredentialStorage.getStore() || undefined;
+}

--- a/src/internal-agents/control-plane-auth.test.ts
+++ b/src/internal-agents/control-plane-auth.test.ts
@@ -1,14 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { getEnv } from "#veryfront/platform/compat/process.ts";
 import type { HandlerContext } from "#veryfront/types";
-import { runWithProjectEnv } from "../server/project-env/storage.ts";
 import {
   createControlPlaneSignature,
   createCtx as createVerificationCtx,
 } from "../server/handlers/request/internal-agent-run.test-helpers.ts";
 import {
+  consumeVerifiedControlPlaneCacheCredential,
   ControlPlaneRequestError,
   getControlPlaneVerificationPublicKey,
   verifyControlPlaneRequest,
@@ -31,21 +30,29 @@ describe("internal-agents/control-plane-auth", () => {
   const envKey = "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY";
 
   it("prefers adapter-provided verification keys", () => {
-    const ctx = createCtx((key) =>
-      key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? "adapter-key" : undefined
-    );
-
-    assertEquals(getControlPlaneVerificationPublicKey(ctx), "adapter-key");
-  });
-
-  it("falls back to host env when project overlays hide adapter env reads", () => {
     const originalValue = Deno.env.get(envKey);
     Deno.env.set(envKey, "host-key");
 
     try {
-      const ctx = createCtx((key) => getEnv(key));
-      const resolvedKey = runWithProjectEnv({}, () => getControlPlaneVerificationPublicKey(ctx));
-      assertEquals(resolvedKey, "host-key");
+      const ctx = createCtx((key) =>
+        key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? "adapter-key" : undefined
+      );
+      assertEquals(getControlPlaneVerificationPublicKey(ctx), "adapter-key");
+    } finally {
+      if (originalValue === undefined) Deno.env.delete(envKey);
+      else Deno.env.set(envKey, originalValue);
+    }
+  });
+
+  it("falls back to the host key when adapter context hides it", () => {
+    const originalValue = Deno.env.get(envKey);
+    Deno.env.set(envKey, "host-key");
+
+    try {
+      assertEquals(
+        getControlPlaneVerificationPublicKey(createCtx(() => undefined)),
+        "host-key",
+      );
     } finally {
       if (originalValue === undefined) {
         Deno.env.delete(envKey);
@@ -56,7 +63,13 @@ describe("internal-agents/control-plane-auth", () => {
   });
 
   it("verifies signed control-plane requests", async () => {
-    const rawBody = JSON.stringify({ runId: "run-1" });
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+    const originalSigningKey = Deno.env.get(envKey);
+    Deno.env.delete("VERYFRONT_API_TOKEN");
+    const rawBody = JSON.stringify({
+      runId: "run-1",
+      credentials: { authToken: "signed-body-token" },
+    });
     const { jws, publicKeyPem } = await createControlPlaneSignature(rawBody, {
       requestId: "run-1",
       surface: "studio",
@@ -64,16 +77,68 @@ describe("internal-agents/control-plane-auth", () => {
     const request = new Request("https://veryfront.test/api/control-plane/runs/run_1/stream", {
       headers: { "x-veryfront-control-plane-jws": jws },
     });
+    Deno.env.set(envKey, publicKeyPem);
 
-    const claims = await verifyControlPlaneRequest(
-      request,
-      createVerificationCtx(publicKeyPem),
-      rawBody,
-      { expectedSubject: "run-1", expectedSurface: "studio" },
-    );
+    try {
+      const claims = await verifyControlPlaneRequest(
+        request,
+        createVerificationCtx(publicKeyPem),
+        rawBody,
+        { expectedSubject: "run-1", expectedSurface: "studio" },
+      );
 
-    assertEquals(claims.sub, "run-1");
-    assertEquals(claims.surface, "studio");
+      assertEquals(claims.sub, "run-1");
+      assertEquals(claims.surface, "studio");
+      assertEquals(consumeVerifiedControlPlaneCacheCredential(claims), {
+        token: "signed-body-token",
+        projectId: "proj-1",
+        projectSlug: "demo-project",
+      });
+      assertEquals(
+        consumeVerifiedControlPlaneCacheCredential({ ...claims } as typeof claims),
+        null,
+      );
+      assertEquals(consumeVerifiedControlPlaneCacheCredential(claims), null);
+    } finally {
+      if (originalApiToken === undefined) Deno.env.delete("VERYFRONT_API_TOKEN");
+      else Deno.env.set("VERYFRONT_API_TOKEN", originalApiToken);
+      if (originalSigningKey === undefined) Deno.env.delete(envKey);
+      else Deno.env.set(envKey, originalSigningKey);
+    }
+  });
+
+  it("does not mint a host override from an adapter-only verification key", async () => {
+    const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+    const originalSigningKey = Deno.env.get(envKey);
+    Deno.env.set("VERYFRONT_API_TOKEN", "host-framework-token");
+    const rawBody = JSON.stringify({
+      runId: "run-1",
+      credentials: { authToken: "adapter-context-token" },
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(rawBody, {
+      requestId: "run-1",
+      surface: "studio",
+    });
+    const { publicKeyPem: hostPublicKeyPem } = await createControlPlaneSignature("{}");
+    Deno.env.set(envKey, hostPublicKeyPem);
+
+    try {
+      const claims = await verifyControlPlaneRequest(
+        new Request("https://veryfront.test/api/control-plane/runs/run_1/stream", {
+          headers: { "x-veryfront-control-plane-jws": jws },
+        }),
+        createVerificationCtx(publicKeyPem),
+        rawBody,
+        { expectedSubject: "run-1", expectedSurface: "studio" },
+      );
+
+      assertEquals(consumeVerifiedControlPlaneCacheCredential(claims), null);
+    } finally {
+      if (originalApiToken === undefined) Deno.env.delete("VERYFRONT_API_TOKEN");
+      else Deno.env.set("VERYFRONT_API_TOKEN", originalApiToken);
+      if (originalSigningKey === undefined) Deno.env.delete(envKey);
+      else Deno.env.set(envKey, originalSigningKey);
+    }
   });
 
   it("rejects requests when verification is not configured", async () => {

--- a/src/internal-agents/control-plane-auth.ts
+++ b/src/internal-agents/control-plane-auth.ts
@@ -1,4 +1,5 @@
 import {
+  type ControlPlaneClaims,
   type ControlPlaneSurface,
   verifyControlPlaneJws,
 } from "#veryfront/channels/control-plane.ts";
@@ -9,7 +10,63 @@ import { HTTP_INTERNAL_SERVER_ERROR } from "#veryfront/utils/constants/index.ts"
 
 const CONTROL_PLANE_JWS_HEADER = "x-veryfront-control-plane-jws";
 const MAX_CONTROL_PLANE_SIGNATURE_AGE_SECONDS = 60;
+const CONTROL_PLANE_SIGNING_KEY_ENV = "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY";
 const logger = serverLogger.component("internal-agents-auth");
+
+declare const verifiedControlPlaneRequestBrand: unique symbol;
+
+export type VerifiedControlPlaneRequestClaims = ControlPlaneClaims & {
+  readonly [verifiedControlPlaneRequestBrand]: true;
+};
+
+export interface VerifiedControlPlaneCacheCredential {
+  readonly token: string;
+  readonly projectId: string;
+  readonly projectSlug: string;
+}
+
+interface VerifiedControlPlaneCacheCredentialGrant {
+  readonly credential: VerifiedControlPlaneCacheCredential | null;
+  readonly expiresAt: number;
+}
+
+const verifiedCacheCredentials = new WeakMap<
+  VerifiedControlPlaneRequestClaims,
+  VerifiedControlPlaneCacheCredentialGrant
+>();
+
+function extractVerifiedCacheCredential(
+  rawBody: string,
+  claims: ControlPlaneClaims,
+): VerifiedControlPlaneCacheCredential | null {
+  try {
+    const body = JSON.parse(rawBody) as Record<string, unknown>;
+    const credentials = body.credentials;
+    if (!credentials || typeof credentials !== "object" || Array.isArray(credentials)) {
+      return null;
+    }
+
+    const token = (credentials as Record<string, unknown>).authToken;
+    if (typeof token !== "string" || token.length === 0) return null;
+
+    return Object.freeze({
+      token,
+      projectId: claims.project_id,
+      projectSlug: claims.aud,
+    });
+  } catch {
+    return null;
+  }
+}
+
+export function consumeVerifiedControlPlaneCacheCredential(
+  claims: VerifiedControlPlaneRequestClaims,
+): VerifiedControlPlaneCacheCredential | null {
+  const grant = verifiedCacheCredentials.get(claims);
+  verifiedCacheCredentials.delete(claims);
+  if (!grant || grant.expiresAt <= Math.floor(Date.now() / 1000)) return null;
+  return grant.credential;
+}
 
 export class ControlPlaneRequestError extends Error {
   readonly status: number;
@@ -25,8 +82,8 @@ export function getControlPlaneVerificationPublicKey(ctx: HandlerContext): strin
   // Project env overlays intentionally hide host secrets from request-scoped reads.
   // Control-plane verification is framework-owned config, so it must fall back to
   // the host environment when the runtime adapter env is overlay-aware.
-  return ctx.adapter.env.get("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY") ??
-    getHostEnv("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
+  return ctx.adapter.env.get(CONTROL_PLANE_SIGNING_KEY_ENV) ??
+    getHostEnv(CONTROL_PLANE_SIGNING_KEY_ENV);
 }
 
 export async function verifyControlPlaneRequest(
@@ -37,7 +94,8 @@ export async function verifyControlPlaneRequest(
     expectedSubject?: string;
     expectedSurface?: ControlPlaneSurface;
   } = {},
-) {
+): Promise<VerifiedControlPlaneRequestClaims> {
+  const hostPublicKeyPem = getHostEnv(CONTROL_PLANE_SIGNING_KEY_ENV);
   const publicKeyPem = getControlPlaneVerificationPublicKey(ctx);
   if (!publicKeyPem) {
     throw new ControlPlaneRequestError(
@@ -57,14 +115,41 @@ export async function verifyControlPlaneRequest(
   }
 
   try {
-    return await verifyControlPlaneJws(controlPlaneJws, rawBody, {
+    const verificationOptions = {
       audience: projectSlug,
       expectedProjectId: ctx.projectId,
       expectedSubject: options.expectedSubject,
       expectedSurface: options.expectedSurface,
       publicKeyPem,
       maxAgeSeconds: MAX_CONTROL_PLANE_SIGNATURE_AGE_SECONDS,
-    });
+    };
+    const claims = await verifyControlPlaneJws(
+      controlPlaneJws,
+      rawBody,
+      verificationOptions,
+    );
+    const verifiedClaims = claims as VerifiedControlPlaneRequestClaims;
+    let hostVerified = hostPublicKeyPem === publicKeyPem && Boolean(hostPublicKeyPem);
+    if (hostPublicKeyPem && !hostVerified) {
+      try {
+        await verifyControlPlaneJws(controlPlaneJws, rawBody, {
+          ...verificationOptions,
+          publicKeyPem: hostPublicKeyPem,
+        });
+        hostVerified = true;
+      } catch {
+        // Compatibility verification can still succeed through the adapter,
+        // but only the host key may mint the cache credential capability.
+      }
+    }
+    verifiedCacheCredentials.set(
+      verifiedClaims,
+      Object.freeze({
+        credential: hostVerified ? extractVerifiedCacheCredential(rawBody, claims) : null,
+        expiresAt: claims.exp,
+      }),
+    );
+    return verifiedClaims;
   } catch (error) {
     // verifyControlPlaneJws performs only crypto and claim validation with no
     // external I/O — any error it throws means the signature is invalid.

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
@@ -108,23 +108,6 @@ describe("MultiProjectFSAdapter", () => {
       withAdapter((adapter) => assertMethod(adapter, "runWithContext"));
     });
 
-    it("preserves verified token trust in runWithContext", async () => {
-      await withAdapterAsync(async (adapter) => {
-        await adapter.runWithContext(
-          "project-a",
-          "test-token",
-          async () => {
-            assertEquals(
-              getCurrentRequestContext()?.tokenTrust,
-              "verified-control-plane",
-            );
-          },
-          "project-id-a",
-          { tokenTrust: "verified-control-plane" },
-        );
-      });
-    });
-
     it("should have refreshSourceSnapshot method", () => {
       withAdapter((adapter) => assertMethod(adapter, "refreshSourceSnapshot"));
     });
@@ -382,20 +365,6 @@ describe("runWithRequestContext", () => {
       async () => {
         const ctx = getCurrentRequestContext();
         assertEquals(ctx!.projectId, "pid-456");
-      },
-    );
-  });
-
-  it("should preserve verified control-plane token trust", async () => {
-    await runWithRequestContext(
-      {
-        projectSlug: "proj",
-        token: "tok",
-        tokenTrust: "verified-control-plane",
-      },
-      async () => {
-        const ctx = getCurrentRequestContext();
-        assertEquals(ctx!.tokenTrust, "verified-control-plane");
       },
     );
   });

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
@@ -9,7 +9,6 @@ import {
   asyncLocalStorage,
   clearRequestScopedFileCache,
   type RequestContext,
-  type RequestTokenTrust,
 } from "./request-context.ts";
 export {
   clearRequestScopedFileCache,
@@ -19,7 +18,7 @@ export {
   setRequestScopedFile,
   wrapWithCurrentContext,
 } from "./request-context.ts";
-export type { RequestContext, RequestTokenTrust } from "./request-context.ts";
+export type { RequestContext } from "./request-context.ts";
 
 const logger = baseLogger.component("multi-project-fs-adapter");
 
@@ -54,7 +53,6 @@ export class MultiProjectFSAdapter implements FSAdapter {
       releaseId?: string | null;
       branch?: string | null;
       environmentName?: string | null;
-      tokenTrust?: RequestTokenTrust;
     },
   ): Promise<T> {
     const startTime = performance.now();
@@ -76,7 +74,6 @@ export class MultiProjectFSAdapter implements FSAdapter {
       projectSlug,
       projectId,
       token,
-      tokenTrust: options?.tokenTrust,
       productionMode,
       releaseId: productionMode ? releaseId : null,
       branch: productionMode ? null : branch,
@@ -115,7 +112,6 @@ export class MultiProjectFSAdapter implements FSAdapter {
 
     store.projectSlug = projectSlug;
     store.token = token;
-    store.tokenTrust = undefined;
   }
 
   setProductionMode(_enabled: boolean, _releaseId?: string | null): void {

--- a/src/platform/adapters/fs/veryfront/request-context.ts
+++ b/src/platform/adapters/fs/veryfront/request-context.ts
@@ -1,13 +1,9 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
-export type RequestTokenTrust = "verified-control-plane";
-
 export interface RequestContext {
   projectSlug: string;
   projectId?: string;
   token: string;
-  /** Trust marker set only after the control-plane request signature is verified. */
-  tokenTrust?: RequestTokenTrust;
   productionMode: boolean;
   /** Release ID for production mode (mutually exclusive with branch) */
   releaseId?: string | null;
@@ -71,7 +67,6 @@ export function runWithRequestContext<T>(
   options: {
     projectSlug: string;
     token: string;
-    tokenTrust?: RequestTokenTrust;
     projectId?: string;
     productionMode?: boolean;
     releaseId?: string | null;
@@ -85,7 +80,6 @@ export function runWithRequestContext<T>(
     projectSlug: options.projectSlug,
     projectId: options.projectId,
     token: options.token,
-    tokenTrust: options.tokenTrust,
     productionMode,
     releaseId: options.releaseId ?? null,
     branch: productionMode ? null : (options.branch ?? null),

--- a/src/security/http/base-handler.test.ts
+++ b/src/security/http/base-handler.test.ts
@@ -34,7 +34,6 @@ class TestHandler extends BaseHandler {
     fn: () => Promise<T>,
     options?: {
       requireToken?: boolean;
-      tokenTrust?: "verified-control-plane";
     },
   ): Promise<T> {
     return this.withProxyContext(ctx, fn, options);

--- a/src/security/http/base-handler.ts
+++ b/src/security/http/base-handler.ts
@@ -6,9 +6,10 @@ import type {
   RoutePattern,
 } from "#veryfront/types";
 import { runWithCacheBatching } from "#veryfront/cache/request-cache-batcher.ts";
+import { runWithVerifiedCacheApiCredential } from "#veryfront/cache/verified-api-credential-context.ts";
+import type { VerifiedControlPlaneRequestClaims } from "#veryfront/internal-agents/control-plane-auth.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import type { WebSocketUpgradeResponse } from "#veryfront/platform/adapters/base.ts";
-import type { RequestTokenTrust } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
 import { serverLogger } from "#veryfront/utils";
 import { ResponseBuilder } from "./response/index.ts";
 
@@ -114,8 +115,21 @@ export abstract class BaseHandler implements Handler {
   protected withProxyContext<T>(
     ctx: HandlerContext,
     fn: () => Promise<T>,
-    options: { requireToken?: boolean; tokenTrust?: RequestTokenTrust } = {},
+    options: {
+      requireToken?: boolean;
+      verifiedControlPlaneClaims?: VerifiedControlPlaneRequestClaims;
+    } = {},
   ): Promise<T> {
+    if (options.verifiedControlPlaneClaims) {
+      return runWithVerifiedCacheApiCredential(
+        options.verifiedControlPlaneClaims,
+        () =>
+          this.withProxyContext(ctx, fn, {
+            requireToken: options.requireToken,
+          }),
+      );
+    }
+
     // Framework-owned token: bypass project env overlay so proxy mode works
     // when a remote project overlay is active.
     const effectiveToken = ctx.proxyToken || getHostEnv("VERYFRONT_API_TOKEN") || "";
@@ -133,7 +147,6 @@ export abstract class BaseHandler implements Handler {
           releaseId?: string | null;
           branch?: string | null;
           environmentName?: string | null;
-          tokenTrust?: RequestTokenTrust;
         },
       ) => Promise<R>;
     };
@@ -189,7 +202,6 @@ export abstract class BaseHandler implements Handler {
           releaseId: ctx.releaseId,
           branch,
           environmentName: ctx.environmentName,
-          tokenTrust: options.tokenTrust,
         },
       );
     }

--- a/src/server/dev-server/request-handler.test.ts
+++ b/src/server/dev-server/request-handler.test.ts
@@ -29,7 +29,11 @@ describe("server/dev-server/request-handler", () => {
 
   it("invalidates the project RSC handler during file-change invalidation", () => {
     __injectCacheForTests(createHandlerCache());
-    const before = getRSCHandler("/project/a", "project-a", { mode: "development" });
+    const handlerOptions = {
+      mode: "development" as const,
+      config: { react: { version: "19.1.1" } },
+    };
+    const before = getRSCHandler("/project/a", "project-a", handlerOptions);
     const requestHandler = new RequestHandler(
       "/project/a",
       {} as RuntimeAdapter,
@@ -42,7 +46,7 @@ describe("server/dev-server/request-handler", () => {
 
     requestHandler.invalidateRuntimeHandler();
 
-    const after = getRSCHandler("/project/a", "project-a", { mode: "development" });
+    const after = getRSCHandler("/project/a", "project-a", handlerOptions);
     assertEquals(after !== before, true);
   });
 });

--- a/src/server/handlers/request/agent-stream.handler.test-helpers.ts
+++ b/src/server/handlers/request/agent-stream.handler.test-helpers.ts
@@ -71,7 +71,6 @@ export type SourceContextTestFsAdapter = FileSystemAdapter & {
       releaseId?: string | null;
       branch?: string | null;
       environmentName?: string | null;
-      tokenTrust?: "verified-control-plane";
     },
   ): Promise<R>;
 };
@@ -83,7 +82,6 @@ export function createNoopFsAdapter(
     releaseId?: string | null;
     branch?: string | null;
     environmentName?: string | null;
-    tokenTrust?: "verified-control-plane";
   }>,
 ): SourceContextTestFsAdapter {
   return {

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -5,6 +5,7 @@ import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/tes
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { DEFAULT_MAX_BODY_SIZE_BYTES } from "#veryfront/utils/constants/index.ts";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { getVerifiedCacheApiCredential } from "#veryfront/cache/verified-api-credential-context.ts";
 import { AgentRunResumeHandler } from "./agent-run-resume.handler.ts";
 import { AgentStreamHandler } from "./agent-stream.handler.ts";
 import {
@@ -1888,17 +1889,21 @@ describe("server/handlers/request/agent-stream.handler", () => {
   });
 
   it("uses the verified request credential for proxy and explicit agent source contexts", async () => {
+    let observedCacheCredential:
+      | ReturnType<typeof getVerifiedCacheApiCredential>
+      | undefined;
     const runWithContextCalls: Array<{
       token?: string;
       productionMode?: boolean;
       releaseId?: string | null;
       branch?: string | null;
       environmentName?: string | null;
-      tokenTrust?: "verified-control-plane";
     }> = [];
 
     const handler = new AgentStreamHandler({
-      ensureProjectDiscovery: async () => {},
+      ensureProjectDiscovery: async () => {
+        observedCacheCredential = getVerifiedCacheApiCredential();
+      },
       getAgent: (id) => id === "assistant-1" ? createAgent("assistant-1") : undefined,
       getAllAgentIds: () => ["assistant-1"],
       sessionManager: new AgentRunSessionManager(),
@@ -1968,7 +1973,10 @@ describe("server/handlers/request/agent-stream.handler", () => {
     };
 
     const originalHostToken = Deno.env.get("VERYFRONT_API_TOKEN");
+    const signingKeyEnv = "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY";
+    const originalSigningKey = Deno.env.get(signingKeyEnv);
     Deno.env.set("VERYFRONT_API_TOKEN", "expired-host-token");
+    Deno.env.set(signingKeyEnv, publicKeyPem);
     let result;
     try {
       result = await handler.handle(
@@ -1985,18 +1993,73 @@ describe("server/handlers/request/agent-stream.handler", () => {
     } finally {
       if (originalHostToken === undefined) Deno.env.delete("VERYFRONT_API_TOKEN");
       else Deno.env.set("VERYFRONT_API_TOKEN", originalHostToken);
+      if (originalSigningKey === undefined) Deno.env.delete(signingKeyEnv);
+      else Deno.env.set(signingKeyEnv, originalSigningKey);
     }
 
     assertExists(result.response);
     assertEquals(result.response.status, 200);
     assertEquals(runWithContextCalls.length, 2);
     assertEquals(runWithContextCalls[0]?.token, "request-scoped-user-token");
-    assertEquals(runWithContextCalls[0]?.tokenTrust, "verified-control-plane");
     assertEquals(runWithContextCalls[0]?.branch, "feature-a");
     assertEquals(runWithContextCalls[1]?.token, "request-scoped-user-token");
-    assertEquals(runWithContextCalls[1]?.tokenTrust, "verified-control-plane");
     assertEquals(runWithContextCalls[1]?.branch, "main");
     assertEquals(runWithContextCalls[1]?.productionMode, false);
+    assertEquals(observedCacheCredential, {
+      token: "request-scoped-user-token",
+      projectId: "proj-1",
+      projectSlug: "demo-project",
+    });
+    assertEquals(getVerifiedCacheApiCredential(), undefined);
+  });
+
+  it("does not promote an unsigned header fallback into the verified cache scope", async () => {
+    let observedCacheCredential:
+      | ReturnType<typeof getVerifiedCacheApiCredential>
+      | undefined;
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {
+        observedCacheCredential = getVerifiedCacheApiCredential();
+      },
+      getAgent: () => undefined,
+      getAllAgentIds: () => [],
+      sessionManager: new AgentRunSessionManager(),
+      createRuntime: () => {
+        throw new Error("runtime should not be created for an unknown agent");
+      },
+    });
+    const body = createAgentStreamRequestBody();
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "run_1",
+    });
+    const ctx = createCtx(publicKeyPem);
+    ctx.proxyToken = "unsigned-header-token";
+    const signingKeyEnv = "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY";
+    const originalSigningKey = Deno.env.get(signingKeyEnv);
+    Deno.env.set(signingKeyEnv, publicKeyPem);
+
+    let result;
+    try {
+      result = await handler.handle(
+        new Request("https://example.com/api/control-plane/runs/run_1/stream", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-veryfront-control-plane-jws": jws,
+          },
+          body,
+        }),
+        ctx,
+      );
+    } finally {
+      if (originalSigningKey === undefined) Deno.env.delete(signingKeyEnv);
+      else Deno.env.set(signingKeyEnv, originalSigningKey);
+    }
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 404);
+    assertEquals(observedCacheCredential, undefined);
+    assertEquals(getVerifiedCacheApiCredential(), undefined);
   });
 
   it("returns 409 when the same run is started twice", async () => {

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -514,7 +514,6 @@ type SourceContextFsWrapper = {
       releaseId?: string | null;
       branch?: string | null;
       environmentName?: string | null;
-      tokenTrust?: "verified-control-plane";
     },
   ) => Promise<R>;
 };
@@ -524,27 +523,23 @@ function buildAgentSourceRunOptions(sourceContext: RuntimeAgentSourceContext): {
   releaseId?: string | null;
   branch?: string | null;
   environmentName?: string | null;
-  tokenTrust: "verified-control-plane";
 } {
   switch (sourceContext.type) {
     case "branch":
       return {
         productionMode: false,
         branch: sourceContext.branch,
-        tokenTrust: "verified-control-plane",
       };
     case "environment":
       return {
         productionMode: true,
         environmentName: sourceContext.environmentName,
         releaseId: sourceContext.releaseId ?? null,
-        tokenTrust: "verified-control-plane",
       };
     case "release":
       return {
         productionMode: true,
         releaseId: sourceContext.releaseId,
-        tokenTrust: "verified-control-plane",
       };
   }
 }
@@ -656,7 +651,7 @@ export class AgentStreamHandler extends BaseHandler {
       if (!pathRunId || pathRunId !== payload.runId) {
         return this.respond(builder.json({ error: "CONTROL_PLANE_RUN_ID_MISMATCH" }, 400));
       }
-      await verifyControlPlaneRequest(req, ctx, rawBody, {
+      const verifiedClaims = await verifyControlPlaneRequest(req, ctx, rawBody, {
         expectedSubject: payload.runId,
         expectedSurface: "studio",
       });
@@ -786,7 +781,7 @@ export class AgentStreamHandler extends BaseHandler {
               : response;
             return this.respond(applyBuilderHeaders(responseWithOwner, builder.headers));
           },
-        ), { tokenTrust: "verified-control-plane" });
+        ), { verifiedControlPlaneClaims: verifiedClaims });
     } catch (error) {
       if (error instanceof InternalAgentRequestBodyTooLargeError) {
         return this.respond(builder.json({ error: error.message }, error.status));


### PR DESCRIPTION
## Summary

- Replace the mutable request-context trust marker with a private, single-use, expiring credential capability.
- Bind the signed token to the signed project identity and require host-key verification before request-first cache precedence.
- Preserve host, ordinary request, and project environment token fallbacks outside verified control-plane requests.

## Why

PR #2877 restored cold runtime cache authentication, but follow-up review found that the trust marker was forgeable and ordinary hostless request fallback was no longer preserved. This change keeps the intended startup behavior while limiting privileged cache precedence to a credential from a verified signed body.

## Verification

- Focused changed surfaces: 66 groups, 94 steps
- Full unit suite: 2,373 tests, 20,072 steps
- Full typecheck
- Changed-file formatting and lint
- Dependency-boundary and normalized cycle checks
- Git diff check

Follow-up to #2877.