### PR TITLE
Ship @veryfront/ext-parser-babel with the root npm package

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1049",
+  "version": "0.1.1050",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -312,6 +312,10 @@ await build({
 		pkg.dependencies["@veryfront/ext-bundler-esbuild"] = version;
 		pkg.dependencies["@veryfront/ext-content-mdx"] = version;
 		pkg.dependencies["@veryfront/ext-css-tailwind"] = version;
+		// ext-parser-babel provides the CodeParser contract that `veryfront serve`
+		// needs to vet client-page modules for /_veryfront/rsc/module hydration;
+		// without it the endpoint 404s and client pages render without hydrating.
+		pkg.dependencies["@veryfront/ext-parser-babel"] = version;
 		pkg.files = ["esm", "script", "bin", "assets", "tsconfig.json", "LICENSE", "NOTICE", "README.md"];
 		pkg.exports["./tsconfig.json"] = "./tsconfig.json";
 		addTypesExportEntries(pkg.exports);

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -61,6 +61,7 @@ Deno.test("root npm CLI package declares auto-loaded first-party extensions afte
       "@veryfront/ext-bundler-esbuild",
       "@veryfront/ext-content-mdx",
       "@veryfront/ext-css-tailwind",
+      "@veryfront/ext-parser-babel",
     ]
   ) {
     const dependencyAssignment =
@@ -93,6 +94,7 @@ Deno.test("npm publish version bump pins first-party extension dependencies to t
             "@veryfront/ext-bundler-esbuild": "0.1.1016",
             "@veryfront/ext-content-mdx": "^0.1.1016",
             "@veryfront/ext-css-tailwind": "^0.1.1016",
+            "@veryfront/ext-parser-babel": "^0.1.1016",
             "@veryfront/not-an-extension": "^0.1.1016",
             zod: "4.3.6",
           },
@@ -132,6 +134,7 @@ Deno.test("npm publish version bump pins first-party extension dependencies to t
       "@veryfront/ext-bundler-esbuild": publishVersion,
       "@veryfront/ext-content-mdx": publishVersion,
       "@veryfront/ext-css-tailwind": publishVersion,
+      "@veryfront/ext-parser-babel": publishVersion,
       "@veryfront/not-an-extension": "^0.1.1016",
       zod: "4.3.6",
     });
@@ -418,6 +421,7 @@ describe("npm supply-chain policy", () => {
       "ext-bundler-esbuild",
       "ext-content-mdx",
       "ext-css-tailwind",
+      "ext-parser-babel",
     ];
 
     for (const extensionName of autoLoadedExtensions) {

--- a/scripts/test/npm-install-smoke.sh
+++ b/scripts/test/npm-install-smoke.sh
@@ -26,17 +26,19 @@ fail() {
 [ -d "$ROOT_DIR/npm/extensions/ext-bundler-esbuild" ] || fail "ext-bundler-esbuild package output missing"
 [ -d "$ROOT_DIR/npm/extensions/ext-content-mdx" ] || fail "ext-content-mdx package output missing"
 [ -d "$ROOT_DIR/npm/extensions/ext-css-tailwind" ] || fail "ext-css-tailwind package output missing"
+[ -d "$ROOT_DIR/npm/extensions/ext-parser-babel" ] || fail "ext-parser-babel package output missing"
 [ -d "$ROOT_DIR/npm/extensions/ext-auth-jwt" ] || fail "ext-auth-jwt package output missing"
 
 (cd "$ROOT_DIR/npm" && npm pack --silent --pack-destination "$WORKDIR" >/dev/null)
 (cd "$ROOT_DIR/npm/extensions/ext-bundler-esbuild" && npm pack --silent --pack-destination "$WORKDIR" >/dev/null)
 (cd "$ROOT_DIR/npm/extensions/ext-content-mdx" && npm pack --silent --pack-destination "$WORKDIR" >/dev/null)
 (cd "$ROOT_DIR/npm/extensions/ext-css-tailwind" && npm pack --silent --pack-destination "$WORKDIR" >/dev/null)
+(cd "$ROOT_DIR/npm/extensions/ext-parser-babel" && npm pack --silent --pack-destination "$WORKDIR" >/dev/null)
 (cd "$ROOT_DIR/npm/extensions/ext-auth-jwt" && npm pack --silent --pack-destination "$WORKDIR" >/dev/null)
 
 cd "$WORKDIR"
 npm init -y >/dev/null 2>&1
-npm install --no-fund --no-audit --silent --ignore-scripts ./veryfront-[0-9]*.tgz ./veryfront-ext-bundler-esbuild-*.tgz ./veryfront-ext-content-mdx-*.tgz ./veryfront-ext-css-tailwind-*.tgz
+npm install --no-fund --no-audit --silent --ignore-scripts ./veryfront-[0-9]*.tgz ./veryfront-ext-bundler-esbuild-*.tgz ./veryfront-ext-content-mdx-*.tgz ./veryfront-ext-css-tailwind-*.tgz ./veryfront-ext-parser-babel-*.tgz
 
 echo "== 1. root install: CLI runs under Node"
 node node_modules/veryfront/bin/veryfront.js --version | grep -q "Veryfront CLI" ||

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1049";
+export const VERSION = "0.1.1050";


### PR DESCRIPTION
## Problem

The root `veryfront` npm package auto-loads `ext-parser-babel` as an optional builtin, but never declared `@veryfront/ext-parser-babel` as a dependency, unlike the other three auto-loaded first-party extensions (`ext-bundler-esbuild`, `ext-content-mdx`, `ext-css-tailwind`).

On a plain `npm install veryfront`, the failure chain is completely silent:

1. The optional-builtin loader can't import the parser package, logs only a debug line, and registers nothing, while bootstrap still prints `Extension "ext-parser-babel" v0.1.0 loaded from builtin`.
2. `veryfront serve` then 404s on `/_veryfront/rsc/module?rel=app/page.tsx`, because `analyzeComponent` throws `Missing extension for contract "CodeParser"` inside `isTrustedBrowserModuleEntry`, which swallows the error into a "Not Found".
3. The hydration runtime falls back to the Pages Router pattern (`/pages/index.js`), which also 404s for App Router projects.
4. Client pages render their SSR HTML but never hydrate, any `useEffect`-driven UI is silently dead (found via a canvas chart that rendered blank while sliders and text looked fine).

`veryfront init` already scaffolds `@veryfront/ext-parser-babel` into new projects, and `compile-binary.ts` imports it statically, the npm build was the only distribution path missing it.

## Fix

- Add `pkg.dependencies["@veryfront/ext-parser-babel"] = version` in `scripts/build/build-npm-dnt.ts`, alongside the other three auto-loaded extensions (same after-install placement so prerelease builds don't require the package to already be published).
- Extend `npm-package-metadata.test.ts`: auto-loaded dependency list, publish-version pinning fixture, and smoke-tarball assertions (written first, verified red).
- Pack and install the `ext-parser-babel` tarball in `scripts/test/npm-install-smoke.sh`.
- Bump version to 0.1.1050 (`deno.json` + `src/utils/version-constant.ts`) for a new release.

## Verification

- `scripts/build/npm-package-metadata.test.ts`: 9 passed, 0 failed
- `deno task test:scripts`: green except a step requiring `npm/` build output, which passes after `deno task build:npm`
- Full `deno task build:npm`: generated `npm/package.json` declares all four `@veryfront/ext-*` dependencies at 0.1.1050
- `scripts/test/npm-install-smoke.sh` clean-room install: all 5 checks passed
- Reproduced end-to-end downstream: a fresh `npm install veryfront` project's client page failed to hydrate; installing `@veryfront/ext-parser-babel` registered CodeParser, `/_veryfront/rsc/module` returned 200, and the page hydrated correctly (verified in a headless browser)
