### PR TITLE
Publish credential capability hardening as Veryfront 0.1.1050

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1049",
+  "version": "0.1.1050",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1049";
+export const VERSION = "0.1.1050";


### PR DESCRIPTION
## Summary

- publish Veryfront 0.1.1050 from current protected `main`
- include the host-key-verified, single-use cache credential capability merged in #2878
- keep repository version declarations synchronized

## Release reason

Veryfront 0.1.1049 predates the final credential-provenance hardening. The immutable fix-forward release lets a dedicated runtime use the signed control-plane credential only through a host-key-verified, exact-claims, single-consume capability while rejecting adapter-only or request-supplied provenance markers.

Related platform issue: veryfront/veryfront-studio#5784.

## Verification

- npm publication preflight confirms all 16 packages are unused at 0.1.1050
- `v0.1.1050` tag and GitHub release do not exist
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno check src/utils/version.ts`
- version and stable-release tests passed, 25 steps
- full pre-push checks passed, 2,373 tests and 20,072 steps
- framework hardening passed protected-branch CI before this version bump

## Merge gate

Merge only after required independent review, all refreshed CI checks, and the immutable-version collision checks remain green.