### PR TITLE
Publish npm extensions before the root package

### DIFF
--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -146,6 +146,41 @@ Deno.test("npm publish version bump pins first-party extension dependencies to t
   }
 });
 
+Deno.test("npm publish orders extensions before the root package", async () => {
+  const packageRoot = await Deno.makeTempDir();
+
+  try {
+    await Deno.mkdir(`${packageRoot}/npm/extensions/ext-zeta`, {
+      recursive: true,
+    });
+    await Deno.mkdir(`${packageRoot}/npm/extensions/ext-alpha`, {
+      recursive: true,
+    });
+
+    const output = await new Deno.Command("bash", {
+      args: ["-c", 'source "$SCRIPT_PATH"\npackage_dirs'],
+      cwd: packageRoot,
+      env: {
+        SCRIPT_PATH: `${Deno.cwd()}/scripts/ci/publish-npm-packages.sh`,
+      },
+      stderr: "piped",
+      stdout: "piped",
+    }).output();
+
+    assertEquals(output.code, 0, new TextDecoder().decode(output.stderr));
+    assertEquals(
+      new TextDecoder().decode(output.stdout).trim().split("\n"),
+      [
+        "npm/extensions/ext-alpha",
+        "npm/extensions/ext-zeta",
+        "npm",
+      ],
+    );
+  } finally {
+    await Deno.remove(packageRoot, { recursive: true });
+  }
+});
+
 // Extensions whose implementations are statically imported by
 // src/extensions/builtin-extensions.ts and therefore ship inside the root
 // npm package. Their dependencies must stay in root; every other workspace
@@ -415,7 +450,7 @@ describe("npm supply-chain policy", () => {
     assertEquals(source.includes("importFirstPartyExtensionModule"), false);
   });
 
-  it("packs auto-loaded extension tarballs for npm install smoke tests", async () => {
+  it("packs and exercises auto-loaded extensions in npm install smoke tests", async () => {
     const source = await Deno.readTextFile("scripts/test/npm-install-smoke.sh");
     const autoLoadedExtensions = [
       "ext-bundler-esbuild",
@@ -436,6 +471,9 @@ describe("npm supply-chain policy", () => {
         tarballName,
       );
     }
+
+    assertStringIncludes(source, "CodeParser was not registered");
+    assertStringIncludes(source, "app/page.tsx");
   });
 
   it("loads CLI command handlers after global routing decisions", async () => {

--- a/scripts/ci/publish-npm-packages.sh
+++ b/scripts/ci/publish-npm-packages.sh
@@ -35,10 +35,11 @@ require_env() {
   done
 }
 
-# Package directories in the `deno task build:npm` output (publish modes).
+# Package directories in dependency order for publish modes. The root package
+# pins auto-loaded extensions to the same version, so publish it last.
 package_dirs() {
-  printf '%s\n' npm
   find npm/extensions -mindepth 1 -maxdepth 1 -type d | sort
+  printf '%s\n' npm
 }
 
 # Package names derived from the deno.json workspace (preflight runs before

--- a/scripts/test/npm-install-smoke.sh
+++ b/scripts/test/npm-install-smoke.sh
@@ -3,7 +3,8 @@
 #
 # Verifies, against the real `deno task build:npm` artifacts installed into a
 # throwaway npm project, that:
-#   1. a `veryfront` install with co-published required packages runs the CLI under Node
+#   1. a `veryfront` install with co-published required packages runs the CLI
+#      and activates the parser extension under Node
 #   2. the @huggingface/transformers optional peer is declared
 #   3. loading a missing extension fails naming the installable package
 #   4. installing @veryfront/ext-auth-jwt makes the extension load
@@ -40,11 +41,41 @@ cd "$WORKDIR"
 npm init -y >/dev/null 2>&1
 npm install --no-fund --no-audit --silent --ignore-scripts ./veryfront-[0-9]*.tgz ./veryfront-ext-bundler-esbuild-*.tgz ./veryfront-ext-content-mdx-*.tgz ./veryfront-ext-css-tailwind-*.tgz ./veryfront-ext-parser-babel-*.tgz
 
-echo "== 1. root install: CLI runs under Node"
+echo "== 1. root install: CLI and parser extension run under Node"
 node node_modules/veryfront/bin/veryfront.js --version | grep -q "Veryfront CLI" ||
   fail "CLI --version failed on root install"
 node node_modules/veryfront/bin/veryfront.js schema --json >/dev/null ||
   fail "CLI schema --json failed on root install (bundled ext-schema-zod broken)"
+node -e "
+const p = require('./node_modules/veryfront/package.json');
+if (p.dependencies?.['@veryfront/ext-parser-babel'] !== p.version) process.exit(1);
+" || fail "root package does not pin @veryfront/ext-parser-babel to its version"
+node --input-type=module -e "
+const m = await import('./node_modules/veryfront/esm/src/extensions/builtin-extensions.js');
+const resolved = m.createOptionalBuiltinExtension({
+  name: 'ext-parser-babel',
+  origin: 'veryfront/ext-parser-babel',
+  sourceDirectory: 'ext-parser-babel',
+  contracts: { provides: ['CodeParser'] },
+  capabilities: [],
+});
+let codeParser;
+const logger = { debug() {}, info() {}, warn() {}, error() {} };
+await resolved.extension.setup({
+  get() {},
+  require() { throw new Error('unexpected contract requirement'); },
+  provide(name, impl) { if (name === 'CodeParser') codeParser = impl; },
+  config: {},
+  logger,
+});
+if (!codeParser) throw new Error('CodeParser was not registered');
+const ast = await codeParser.parse({
+  code: 'export default function Page(): JSX.Element { return <main />; }',
+  filePath: 'app/page.tsx',
+});
+if (ast?.type !== 'File') throw new Error('TSX parse failed');
+await resolved.extension.teardown?.();
+" || fail "root optional builtin did not register a working CodeParser"
 
 echo "== 2. root install: transformers optional peer declared"
 node -e "


### PR DESCRIPTION
## Summary

- publish all `@veryfront/ext-*` packages before `veryfront`
- keep the root package last because it pins auto-loaded extensions to the exact release version
- verify the packed root package registers `CodeParser` and parses TSX through the optional-builtin path

## Diagnosis

PR #2879 makes the parser dependency explicit. The release script published the root package first, so npm could expose `veryfront@latest` before the required extension version existed. Registry timestamps for 0.1.1049 show a 3 minute 38 second root install failure window. This change closes that window before 0.1.1050 publication.

## Verification

- focused publish-order test failed before the implementation and passed afterward
- `deno task build:npm`
- npm package metadata suite passed, 10 tests and 24 steps
- clean npm install smoke passed all 5 checks, including parser registration and TSX parsing
- shell syntax, formatting, and `git diff --check` passed
- full pre-push checks passed, 2,373 tests and 20,072 steps

Related: #2879