### PR TITLE
Publish Anthropic stream drain fix as 0.1.1051

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1050",
+  "version": "0.1.1051",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1050";
+export const VERSION = "0.1.1051";


### PR DESCRIPTION
## Summary
- bumps Veryfront from `0.1.1050` to `0.1.1051`
- releases already-merged `veryfront/veryfront-code#2881`, which drains delayed Anthropic gateway stream tails instead of canceling the response reader
- keeps the diff limited to `deno.json` and `src/utils/version-constant.ts`

Fixes veryfront/veryfront-studio#5809.

## Why this is separate from #2883
`veryfront/veryfront-code#2883` also targets `0.1.1051`, but it is a broader CSS feature PR and is currently failing coverage. The Anthropic gateway stream fix is already merged on `main`; production is still seeing the same abort signature because no release containing #2881 has been published/staged yet.

If this PR lands first, #2883 must rebase and move to the next unused version.

## Verification
- `gh release view v0.1.1051` returned no existing release
- `npm view veryfront@0.1.1051 version gitHead --json` returned npm 404 / no existing version
- `jq -e '.version == "0.1.1051"' deno.json` passed\n- `deno test --no-check --allow-all extensions/ext-llm-anthropic/src/anthropic-stream.test.ts extensions/ext-llm-anthropic/src/anthropic-provider.test.ts` passed: 2 tests / 83 steps\n- `deno fmt --check deno.json src/utils/version-constant.ts extensions/ext-llm-anthropic/src/anthropic-stream.test.ts extensions/ext-llm-anthropic/src/anthropic-provider.test.ts extensions/ext-llm-anthropic/src/anthropic-stream.ts extensions/ext-llm-anthropic/src/anthropic-provider.ts` passed\n- `git diff --check` passed\n\n## Local validation gap\n`verify:quick` was not completed locally because the pre-commit hook stops on the existing unrelated style violation in `cli/shared/reserve-slug.ts` (`no-explicit-public`), which was already documented on #2881. The PR relies on GitHub Actions for the protected full matrix.