### PR TITLE
Let control-plane streams survive stale config bootstrap

### DIFF
--- a/cli/shared/deployment-provenance.ts
+++ b/cli/shared/deployment-provenance.ts
@@ -1,12 +1,5 @@
-import {
-  createFileSystem,
-  env,
-  getEnv,
-  isNotFoundError,
-  lstat,
-  realPath,
-  runCommand,
-} from "veryfront/platform";
+import { createFileSystem, env, getEnv, runCommand } from "veryfront/platform";
+import { isNotFoundError, lstat, realPath } from "veryfront/fs";
 import { join, relative } from "veryfront/platform/path";
 import type { ApiClient } from "./config.ts";
 

--- a/cli/shared/deployment-provenance.ts
+++ b/cli/shared/deployment-provenance.ts
@@ -1,5 +1,12 @@
-import { createFileSystem, env, getEnv, runCommand } from "veryfront/platform";
-import { isNotFoundError, lstat, realPath } from "#veryfront/platform/compat/fs.ts";
+import {
+  createFileSystem,
+  env,
+  getEnv,
+  isNotFoundError,
+  lstat,
+  realPath,
+  runCommand,
+} from "veryfront/platform";
 import { join, relative } from "veryfront/platform/path";
 import type { ApiClient } from "./config.ts";
 

--- a/cli/shared/reserve-slug.ts
+++ b/cli/shared/reserve-slug.ts
@@ -26,7 +26,7 @@ export interface ReserveProjectSlugOptions {
 }
 
 export class ProjectSlugConflictError extends Error {
-  constructor(public readonly slug: string) {
+  constructor(readonly slug: string) {
     super(`Project slug "${slug}" is already in use.`);
     this.name = "ProjectSlugConflictError";
   }

--- a/src/channels/control-plane.test.ts
+++ b/src/channels/control-plane.test.ts
@@ -7,7 +7,9 @@ import { registerSkill, skillRegistry } from "#veryfront/skill/registry.ts";
 import type { HandlerContext } from "#veryfront/types";
 import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
 import {
+  isConfigOptionalControlPlaneRunRequest,
   listRuntimeAgents,
+  resolveAgentSkills,
   RuntimeAgentListResponseSchema,
   verifyControlPlaneJws,
 } from "./control-plane.ts";
@@ -122,6 +124,33 @@ function createAgent(overrides: {
     clearMemory: async () => {},
   };
 }
+
+describe("control-plane run route classification", () => {
+  for (
+    const { method, pathname } of [
+      { method: "POST", pathname: "/api/control-plane/runs/run_1/stream" },
+      { method: "POST", pathname: "/api/control-plane/runs/run_1/resume" },
+      { method: "DELETE", pathname: "/api/control-plane/runs/run_1" },
+    ]
+  ) {
+    it(`treats ${method} ${pathname} as config optional`, () => {
+      assertEquals(isConfigOptionalControlPlaneRunRequest(method, pathname), true);
+    });
+  }
+
+  for (
+    const { method, pathname } of [
+      { method: "POST", pathname: "/api/control-plane/runs/run_1/execute" },
+      { method: "GET", pathname: "/api/control-plane/runs/run_1/stream" },
+      { method: "DELETE", pathname: "/api/control-plane/runs/run_1/extra" },
+      { method: "POST", pathname: "/page" },
+    ]
+  ) {
+    it(`keeps ${method} ${pathname} strict`, () => {
+      assertEquals(isConfigOptionalControlPlaneRunRequest(method, pathname), false);
+    });
+  }
+});
 
 describe("channels/control-plane", () => {
   describe("verifyControlPlaneJws", () => {
@@ -555,11 +584,6 @@ describe("channels/control-plane", () => {
     });
   });
 });
-
-// ── Owner-aware agent skill metadata (review round 3) ─────────────────────
-
-import { resolveAgentSkills } from "./control-plane.ts";
-import type { Agent } from "#veryfront/agent/types.ts";
 
 Deno.test("resolveAgentSkills includes the agent's own skills and excludes others'", () => {
   skillRegistry.clearAll();

--- a/src/channels/control-plane.ts
+++ b/src/channels/control-plane.ts
@@ -14,6 +14,37 @@ export const CONTROL_PLANE_RUNS_PATH_PREFIX = "/api/control-plane/runs/";
 /** Shared control plane run stream path value. */
 export const CONTROL_PLANE_RUN_STREAM_PATH = "/api/control-plane/runs/:runId/stream";
 
+const CONTROL_PLANE_RUN_ID_PATH_SEGMENT = "[^/]+";
+const CONTROL_PLANE_RUNS_REGEX_PREFIX = CONTROL_PLANE_RUNS_PATH_PREFIX.replaceAll("/", "\\/");
+
+/**
+ * True for control-plane run surfaces that can dispatch without project config.
+ *
+ * Stream/resume/cancel use signed request payload/session state and must not be
+ * blocked by stale release config bootstraps. Execute deliberately remains
+ * strict because it can consume project config for React/CSS build inputs.
+ */
+export function isConfigOptionalControlPlaneRunRequest(
+  method: string,
+  pathname: string | undefined,
+): boolean {
+  const normalizedMethod = method.toUpperCase();
+  const requestPath = pathname ?? "";
+
+  if (normalizedMethod === "DELETE") {
+    return new RegExp(`^${CONTROL_PLANE_RUNS_REGEX_PREFIX}${CONTROL_PLANE_RUN_ID_PATH_SEGMENT}$`)
+      .test(requestPath);
+  }
+
+  if (normalizedMethod !== "POST") {
+    return false;
+  }
+
+  return new RegExp(
+    `^${CONTROL_PLANE_RUNS_REGEX_PREFIX}${CONTROL_PLANE_RUN_ID_PATH_SEGMENT}\\/(?:stream|resume)$`,
+  ).test(requestPath);
+}
+
 const getCompactJwsHeaderSchema = defineSchema((v) =>
   v.object({
     alg: v.literal("EdDSA"),

--- a/src/fs/index.test.ts
+++ b/src/fs/index.test.ts
@@ -14,7 +14,9 @@ const expectedRuntimeExports = [
   "dirname",
   "exists",
   "extname",
+  "isNotFoundError",
   "join",
+  "lstat",
   "mkdir",
   "readDir",
   "readTextFile",
@@ -38,6 +40,8 @@ describe("fs/index.ts exports", () => {
     assertEquals(fsModule.remove, compatFsModule.remove);
     assertEquals(fsModule.readDir, compatFsModule.readDir);
     assertEquals(fsModule.realPath, compatFsModule.realPath);
+    assertEquals(fsModule.isNotFoundError, compatFsModule.isNotFoundError);
+    assertEquals(fsModule.lstat, compatFsModule.lstat);
     assertEquals(fsModule.basename, pathModule.basename);
     assertEquals(fsModule.dirname, pathModule.dirname);
     assertEquals(fsModule.extname, pathModule.extname);

--- a/src/fs/index.ts
+++ b/src/fs/index.ts
@@ -32,6 +32,8 @@ export {
   createFileSystem,
   exists,
   type FileSystem,
+  isNotFoundError,
+  lstat,
   mkdir,
   readDir,
   readTextFile,

--- a/src/observability/metrics/config.test.ts
+++ b/src/observability/metrics/config.test.ts
@@ -9,6 +9,8 @@ function adapterWithEnv(env: { get: (key: string) => string | undefined }): Runt
   return { env } as unknown as RuntimeAdapter;
 }
 
+const emptyEnvAdapter = adapterWithEnv({ get: () => undefined });
+
 describe("observability/metrics/config", () => {
   describe("DEFAULT_CONFIG", () => {
     it("should have expected defaults", () => {
@@ -22,14 +24,14 @@ describe("observability/metrics/config", () => {
 
   describe("loadConfig", () => {
     it("should return defaults for empty config", () => {
-      const result = loadConfig({});
+      const result = loadConfig({}, emptyEnvAdapter);
       assertEquals(result.enabled, false);
       assertEquals(result.exporter, "console");
       assertEquals(result.prefix, "veryfront");
     });
 
     it("should merge user config", () => {
-      const result = loadConfig({ enabled: true, prefix: "myapp" });
+      const result = loadConfig({ enabled: true, prefix: "myapp" }, emptyEnvAdapter);
       assertEquals(result.enabled, true);
       assertEquals(result.prefix, "myapp");
       assertEquals(result.exporter, "console");

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -42,12 +42,9 @@ export {
   createFileSystem,
   exists,
   type FileSystem,
-  isNotFoundError,
-  lstat,
   mkdir,
   readDir,
   readTextFile,
-  realPath,
   remove,
   writeTextFile,
 } from "./compat/fs.ts";

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -42,9 +42,12 @@ export {
   createFileSystem,
   exists,
   type FileSystem,
+  isNotFoundError,
+  lstat,
   mkdir,
   readDir,
   readTextFile,
+  realPath,
   remove,
   writeTextFile,
 } from "./compat/fs.ts";

--- a/src/server/runtime-handler/adapter-factory.test.ts
+++ b/src/server/runtime-handler/adapter-factory.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { CONFIG_PARSE_ERROR } from "#veryfront/errors/error-registry.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
 import { resolveAdapter } from "./adapter-factory.ts";
@@ -676,6 +677,146 @@ describe("adapter-factory", () => {
           }),
         Error,
         "proxy config fail",
+      );
+    });
+
+    it("falls back to defaults when a proxy-mode control-plane run stream cannot load config", async () => {
+      const base = createMockAdapter({});
+      const extendedFs = {
+        ...base.fs,
+        isVeryfrontAdapter: () => true,
+        getUnderlyingAdapter: () => ({}),
+        isMultiProjectMode: () => false,
+        runWithContext: () => {
+          throw CONFIG_PARSE_ERROR.create({
+            detail: "Failed to load veryfront.config.ts",
+            cause: new Error("stale release config loaded host-only bootstrap"),
+            context: { configFile: "veryfront.config.ts" },
+          });
+        },
+      };
+      const adapter = { ...base, fs: extendedFs } as unknown as RuntimeAdapter;
+      const req = new Request("http://example.com/api/control-plane/runs/run_1/stream", {
+        method: "POST",
+      });
+
+      const result = await resolveAdapter({
+        projectDir: "/base/project",
+        adapter,
+        config: undefined,
+        projectSlug: "proxy-slug",
+        projectId: "proj_proxy",
+        proxyToken: "tok-123",
+        releaseId: "rel-stale",
+        proxyEnv: "production",
+        branch: null,
+        environmentName: "production",
+        parsedDomain: {
+          slug: null,
+          branch: null,
+          environment: null,
+          isVeryfrontDomain: false,
+          isDraft: false,
+          allowIframeEmbed: false,
+        },
+        req,
+        pathname: "/api/control-plane/runs/run_1/stream",
+        isProxyMode: true,
+      });
+
+      assertEquals(result.isLocalProject, false);
+      assertEquals(result.config, undefined);
+    });
+
+    it("keeps arbitrary control-plane stream config errors strict", async () => {
+      const base = createMockAdapter({});
+      const extendedFs = {
+        ...base.fs,
+        isVeryfrontAdapter: () => true,
+        getUnderlyingAdapter: () => ({}),
+        isMultiProjectMode: () => false,
+        runWithContext: () => {
+          throw new Error("adapter context unavailable");
+        },
+      };
+      const adapter = { ...base, fs: extendedFs } as unknown as RuntimeAdapter;
+      const req = new Request("http://example.com/api/control-plane/runs/run_1/stream", {
+        method: "POST",
+      });
+
+      await assertRejects(
+        () =>
+          resolveAdapter({
+            projectDir: "/base/project",
+            adapter,
+            config: undefined,
+            projectSlug: "proxy-slug",
+            projectId: "proj_proxy",
+            proxyToken: "tok-123",
+            releaseId: "rel-stale",
+            proxyEnv: "production",
+            branch: null,
+            environmentName: "production",
+            parsedDomain: {
+              slug: null,
+              branch: null,
+              environment: null,
+              isVeryfrontDomain: false,
+              isDraft: false,
+              allowIframeEmbed: false,
+            },
+            req,
+            pathname: "/api/control-plane/runs/run_1/stream",
+            isProxyMode: true,
+          }),
+        Error,
+        "adapter context unavailable",
+      );
+    });
+
+    it("keeps config errors strict for control-plane execute requests", async () => {
+      const base = createMockAdapter({});
+      const extendedFs = {
+        ...base.fs,
+        isVeryfrontAdapter: () => true,
+        getUnderlyingAdapter: () => ({}),
+        isMultiProjectMode: () => false,
+        runWithContext: () => {
+          throw new Error("execute config fail");
+        },
+      };
+      const adapter = { ...base, fs: extendedFs } as unknown as RuntimeAdapter;
+      const req = new Request("http://example.com/api/control-plane/runs/run_1/execute", {
+        method: "POST",
+      });
+
+      await assertRejects(
+        () =>
+          resolveAdapter({
+            projectDir: "/base/project",
+            adapter,
+            config: undefined,
+            projectSlug: "proxy-slug",
+            projectId: "proj_proxy",
+            proxyToken: "tok-123",
+            releaseId: "rel-stale",
+            proxyEnv: "production",
+            branch: null,
+            environmentName: "production",
+            parsedDomain: {
+              slug: null,
+              branch: null,
+              environment: null,
+              isVeryfrontDomain: false,
+              isDraft: false,
+              allowIframeEmbed: false,
+            },
+            req,
+            pathname: "/api/control-plane/runs/run_1/execute",
+            isProxyMode: true,
+          }),
+        Error,
+        "execute config fail",
       );
     });
 

--- a/src/server/runtime-handler/adapter-factory.ts
+++ b/src/server/runtime-handler/adapter-factory.ts
@@ -14,6 +14,7 @@ import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
 import { getConfig } from "#veryfront/config/loader.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
+import { isConfigOptionalControlPlaneRunRequest } from "#veryfront/channels/control-plane.ts";
 import { timeAsync } from "./request-lifecycle.ts";
 import {
   defaultDiscoveryCache,
@@ -67,10 +68,36 @@ interface AdapterResolutionOptions {
   environmentName: string | undefined;
   /** Parsed domain info */
   parsedDomain: ParsedDomain;
+  /** Request pathname, used to decide whether config failures can safely fall back. */
+  pathname?: string;
   /** Whether running in proxy mode */
   isProxyMode: boolean;
   /** Optional injectable cache (defaults to module-level singleton) */
   cache?: ProjectDiscoveryCache;
+}
+
+function shouldFallbackOnProxyConfigError(opts: AdapterResolutionOptions): boolean {
+  return opts.isProxyMode &&
+    !!opts.projectSlug &&
+    !!opts.proxyToken &&
+    isConfigOptionalControlPlaneRunRequest(opts.req.method, opts.pathname);
+}
+
+function isRecoverableProxyConfigLoadError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const configError = error as Error & {
+    slug?: unknown;
+    detail?: unknown;
+    context?: unknown;
+  };
+  if (configError.slug !== "config-parse-error") return false;
+  if (typeof configError.detail !== "string") return false;
+  if (!configError.detail.startsWith("Failed to load veryfront.config.")) return false;
+
+  const context = configError.context;
+  if (!context || typeof context !== "object") return false;
+  const configFile = (context as { configFile?: unknown }).configFile;
+  return typeof configFile === "string" && configFile.startsWith("veryfront.config.");
 }
 
 /**
@@ -191,6 +218,25 @@ export async function resolveAdapter(
         router: effectiveConfig?.router,
       });
     } catch (error) {
+      if (
+        shouldFallbackOnProxyConfigError(opts) &&
+        isRecoverableProxyConfigLoadError(error)
+      ) {
+        logger.warn("Failed to load project config for control-plane request, using defaults", {
+          projectSlug: opts.projectSlug,
+          projectId: opts.projectId,
+          releaseId: opts.releaseId,
+          proxyEnv: opts.proxyEnv,
+          pathname: opts.pathname,
+          error: getErrorMessage(error),
+        });
+        return {
+          projectDir: effectiveProjectDir,
+          adapter: effectiveAdapter,
+          config: effectiveConfig,
+          isLocalProject,
+        };
+      }
       // Log at error level — this is a real failure that will affect rendering.
       // Config loading failure in proxy mode means the project's routes, layouts,
       // and settings won't be available, leading to 404s for valid pages.

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -586,6 +586,7 @@ export function createVeryfrontHandler(
               branch: reqCtx.branch,
               environmentName: projectRes.environmentName,
               parsedDomain: projectRes.parsedDomain,
+              pathname: url.pathname,
               isProxyMode,
             }));
 


### PR DESCRIPTION
## Summary
- pass request pathname into runtime adapter resolution
- add one shared classifier for config-optional control-plane run routes
- let proxy-mode stream/resume/cancel recover from structured `veryfront.config.*` load failures by using default runtime config
- keep execute/rendering and unrelated adapter/context errors strict

Closes veryfront/veryfront-studio#5805.

## Why
Staging `.org` runtime dispatch was failing before stream dispatch when a stale release config bootstrap threw while loading `veryfront.config.ts`. Control-plane stream/resume/cancel do not need project config, so those signed control-plane routes can safely dispatch with defaults. Execute and page/rendering paths still fail fast because they can depend on project config.

## Red / green evidence
- RED: `deno test --no-check --allow-all src/server/runtime-handler/adapter-factory.test.ts` failed for execute strictness before narrowing the fallback.
- RED: `deno test --no-check --allow-all src/channels/control-plane.test.ts` failed before exporting the shared route classifier.
- RED: `deno test --no-check --allow-all src/server/runtime-handler/adapter-factory.test.ts` failed for arbitrary stream config errors before structured error gating.
- GREEN: `deno test --no-check --allow-all src/server/runtime-handler/adapter-factory.test.ts`
- GREEN: `deno task test src/channels/control-plane.test.ts src/server/runtime-handler/adapter-factory.test.ts`
- GREEN: `deno fmt --check` on modified files
- GREEN: `deno check` on modified files
- GREEN: `deno lint` on modified files
- GREEN: `deno task lint:style`
- GREEN: `deno task lint:cli-boundary`
- GREEN: `deno task build`
- GREEN: pre-commit `deno task verify:quick`

## Independent review
- code-reviewer: 95/100, merge-ready yes, APPROVE
- architect: 91/100, WATCH, merge-ready yes

## Notes
The architecture watch item is intentionally accepted for this small fix: the recovery is narrow to the observed stale config bootstrap failure and does not hide validation/config regressions outside the stream/resume/cancel dispatch path.
