### PR TITLE
Shim bare veryfront imports when loading project configs from temp files

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1051",
+  "version": "0.1.1052",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -7,6 +7,7 @@ import {
   getCachedConfigSync,
   getConfig,
   mergeConfigs,
+  rewriteBareVeryfrontConfigImports,
   transpileConfigSourceForImport,
 } from "./loader.ts";
 import { createMockAdapter } from "../platform/adapters/mock.ts";
@@ -45,6 +46,67 @@ export default config as const;
       assert(result.includes('"keep as const text"'));
       assertEquals(module.default.title, "Typed Project");
       assertEquals(module.default.description, "keep as const text");
+    });
+  });
+
+  describe("rewriteBareVeryfrontConfigImports", () => {
+    afterAll(async () => {
+      await stopEsbuild();
+    });
+
+    it("rewrites bare veryfront specifiers to a loadable shim", () => {
+      const rewritten = rewriteBareVeryfrontConfigImports(
+        'import { defineConfig } from "veryfront";\nexport default defineConfig({});',
+      );
+
+      assert(!rewritten.includes('"veryfront"'), "bare specifier must be replaced");
+      assert(rewritten.includes("data:text/javascript,"), "specifier must point at the shim");
+    });
+
+    it("handles single quotes and leaves other specifiers untouched", () => {
+      const rewritten = rewriteBareVeryfrontConfigImports(
+        "import { defineConfig } from 'veryfront';\nimport other from './local.ts';\nimport 'veryfront';",
+      );
+
+      assert(!rewritten.includes("'veryfront'"));
+      assert(rewritten.includes("./local.ts"), "relative imports must stay untouched");
+    });
+
+    it("does not rewrite veryfront subpath or lookalike specifiers", () => {
+      const source =
+        'import { a } from "veryfront/head";\nimport { b } from "not-veryfront";\nconst s = "veryfront";';
+      assertEquals(rewriteBareVeryfrontConfigImports(source), source);
+    });
+
+    it("produces a module whose defineConfig behaves as identity end to end", async () => {
+      const source = [
+        'import { defineConfig } from "veryfront";',
+        'export default defineConfig({ projectSlug: "shimmed", title: "Shim" });',
+      ].join("\n");
+
+      const transpiled = await transpileConfigSourceForImport(source, "/app/veryfront.config.ts");
+      const rewritten = rewriteBareVeryfrontConfigImports(transpiled);
+      const module = await import(`data:application/javascript;base64,${btoa(rewritten)}`) as {
+        default: { projectSlug: string; title: string };
+      };
+
+      assertEquals(module.default.projectSlug, "shimmed");
+      assertEquals(module.default.title, "Shim");
+    });
+
+    it("shims defineConfigWithEnv with a working environment factory", async () => {
+      const source = [
+        'import { defineConfigWithEnv } from "veryfront";',
+        "export default defineConfigWithEnv((env) => ({ title: `env:${env}` }));",
+      ].join("\n");
+
+      const transpiled = await transpileConfigSourceForImport(source, "/app/veryfront.config.ts");
+      const rewritten = rewriteBareVeryfrontConfigImports(transpiled);
+      const module = await import(`data:application/javascript;base64,${btoa(rewritten)}`) as {
+        default: { title: string };
+      };
+
+      assert(module.default.title.startsWith("env:"), "factory must receive an env name");
     });
   });
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -325,12 +325,53 @@ async function loadConfigFromTempFile(
   const tempFile = join(tempDir, `config${extension}`);
 
   try {
-    await fs.writeTextFile(tempFile, processedSource);
+    await fs.writeTextFile(tempFile, rewriteBareVeryfrontConfigImports(processedSource));
     const configModule = await import(loadUrl(tempFile));
     return configModule.default || configModule;
   } finally {
     await fs.remove(tempDir, { recursive: true });
   }
+}
+
+/**
+ * Inline stand-in for the bare `veryfront` specifier in user config files.
+ *
+ * Config modules loaded through {@link loadConfigFromTempFile} execute from a
+ * temp file, where bare specifiers have no resolver: Node has no node_modules
+ * relative to the temp dir, and compiled Deno binaries have no import map for
+ * external dynamic imports. Every config helper the framework entrypoint
+ * exposes is a thin pure function, so a data: URL module is a faithful
+ * stand-in. Written with double quotes only — encodeURIComponent escapes
+ * them, keeping the URL safe inside either quote style of the rewritten
+ * import statement.
+ */
+const VERYFRONT_CONFIG_SHIM = [
+  "export const defineConfig = (config) => config;",
+  "export const defineConfigWithEnv = (factory, envConfig) =>",
+  '  factory(envConfig?.nodeEnv ?? globalThis.Deno?.env?.get?.("NODE_ENV") ??',
+  '    globalThis.process?.env?.NODE_ENV ?? "production");',
+  "export const mergeConfigs = (...configs) => Object.assign({}, ...configs);",
+].join("\n");
+
+const VERYFRONT_CONFIG_SHIM_URL = `data:text/javascript,${
+  encodeURIComponent(VERYFRONT_CONFIG_SHIM)
+}`;
+
+/**
+ * Rewrite bare `veryfront` import specifiers to the inline config shim so
+ * temp-file config modules can load. Static imports only (`import ... from
+ * "veryfront"` and side-effect `import "veryfront"`); subpaths like
+ * `veryfront/head` are left untouched and will fail loudly, which is correct —
+ * they have no meaning in a config file.
+ *
+ * @internal exported for tests
+ */
+export function rewriteBareVeryfrontConfigImports(source: string): string {
+  return source.replace(
+    /(\bfrom\s*|\bimport\s+)(["'])veryfront\2/g,
+    (_match, prefix: string, quote: string) =>
+      `${prefix}${quote}${VERYFRONT_CONFIG_SHIM_URL}${quote}`,
+  );
 }
 
 /** @internal */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1051";
+export const VERSION = "0.1.1052";


### PR DESCRIPTION
## Problem — production outage class

Project configs conventionally start with `import { defineConfig } from "veryfront"`, but `loadConfigFromTempFile` executes configs from a **temp file**, where that bare specifier has no resolver: Node has no `node_modules` relative to the temp dir, and compiled Deno binaries have no import map for external dynamic imports. TypeScript configs therefore **never loaded on the hosted runtime** (proxy mode / compiled binary):

- **≤ 0.1.1049:** the failure was silently swallowed and the loader fell back to defaults — configured values like `tailwind.stylesheet` never took effect remotely (long-standing mystery behavior).
- **0.1.1050:** the fail-closed `CONFIG_PARSE_ERROR` hardening turned the same failure into a **hard 500 on every request** for any project with a TS config. Observed live in production after the 0.1.1050 server rollout: `"Failed to load veryfront.config.ts"` from `adapter-factory` on every request to `veryfront-planning.production.veryfront.com` (mitigated at the project level by removing the import from the config file — service restored immediately, confirming the diagnosis).

Local dev never hits this because the non-compiled path dynamic-imports the config **in place**, where Node resolves `veryfront` via the project's `node_modules`.

## Fix

Rewrite bare `veryfront` import specifiers in the temp-file source to an inline `data:` URL shim exporting `defineConfig` (identity), `defineConfigWithEnv`, and `mergeConfigs` — the pure helpers the config entrypoint exposes. The shim uses double quotes only so `encodeURIComponent` keeps the URL safe inside either quote style. Subpath specifiers (`veryfront/head` etc.) are intentionally left untouched to fail loudly — they have no meaning in a config file.

The fail-closed behavior from 0.1.1050 is kept: with the loader fixed it now surfaces genuinely broken configs instead of masking a resolver gap.

Version bumped to 0.1.1052.

## Verification

- New unit tests: specifier rewriting (double/single quotes, side-effect imports, subpath/lookalike non-matches) and end-to-end transpile → rewrite → dynamic import for both `defineConfig` and `defineConfigWithEnv`.
- Full unit suite: 2,374 passed, 0 failed.
- Production evidence chain: the same config exported as a plain object (no import) loads fine on the hosted 0.1.1050 runtime — 500s cleared instantly.

## Impact once rolled out

Hosted TS configs load for the first time — this also makes configured `tailwind.stylesheet` reach release builds and the preview stylesheet route, closing another gap behind the "hosted projects render unstyled" saga (#2883).