### PR TITLE
Prevent root framework imports from keeping Node alive

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1052",
+  "version": "0.1.1053",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -99,7 +99,10 @@ await build({
 	// FormData/File/Blob as globals natively, so no shim is needed.
 	shims: {
 		deno: true,
-		timers: true,
+		// Node 18+ provides native timers. Keeping the dnt timer shim here turns
+		// Timeout objects into numbers, which prevents unrefTimer() from releasing
+		// framework background intervals in short-lived Node processes.
+		timers: false,
 		crypto: true,
 	},
 
@@ -331,6 +334,57 @@ await buildExtensionPackages({
 	version,
 	license,
 });
+
+await verifyNpmRootImportLifecycle();
+
+async function verifyNpmRootImportLifecycle(): Promise<void> {
+	const timeoutMs = 10_000;
+	const child = new Deno.Command("node", {
+		args: [
+			"--input-type=module",
+			"--eval",
+			'const mod = await import("./esm/src/index.js"); if (typeof mod.defineConfig !== "function") throw new Error("defineConfig export missing");',
+		],
+		cwd: "./npm",
+		env: { VF_DISABLE_LRU_INTERVAL: "0" },
+		stdout: "piped",
+		stderr: "piped",
+	}).spawn();
+	const outputPromise = child.output();
+	let timeoutId: number | undefined;
+	const result = await Promise.race([
+		outputPromise.then((output) => ({ kind: "complete" as const, output })),
+		new Promise<{ kind: "timeout" }>((resolve) => {
+			timeoutId = setTimeout(() => resolve({ kind: "timeout" }), timeoutMs);
+		}),
+	]);
+
+	if (timeoutId !== undefined) clearTimeout(timeoutId);
+
+	if (result.kind === "timeout") {
+		try {
+			child.kill();
+		} catch {
+			// The process may exit between the timeout and the kill attempt.
+		}
+		const output = await outputPromise.catch(() => undefined);
+		const stderr = output ? new TextDecoder().decode(output.stderr).trim() : "";
+		throw new Error(
+			`Built npm root import did not exit within ${timeoutMs}ms; ` +
+				`a referenced import-time handle is still active.${stderr ? `\n${stderr}` : ""}`,
+		);
+	}
+
+	if (!result.output.success) {
+		const stderr = new TextDecoder().decode(result.output.stderr).trim();
+		throw new Error(
+			`Built npm root import failed with exit code ${result.output.code}.` +
+				(stderr ? `\n${stderr}` : ""),
+		);
+	}
+
+	console.log("✅ Verified npm root import lifecycle");
+}
 
 function addTypesExportEntries(
 	exportsMap: Record<string, string | { import?: string; types?: string }>,

--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -603,6 +603,15 @@ describe("npm supply-chain policy", () => {
     );
   });
 
+  it("uses native Node timers so root imports can release background intervals", async () => {
+    const source = await Deno.readTextFile("scripts/build/build-npm-dnt.ts");
+
+    assertStringIncludes(source, "timers: false");
+    assertEquals(source.includes("timers: true"), false);
+    assertStringIncludes(source, 'VF_DISABLE_LRU_INTERVAL: "0"');
+    assertStringIncludes(source, "await verifyNpmRootImportLifecycle();");
+  });
+
   it("keeps npm CLI agent workflow paths off the DNT Deno shim in real Deno", async () => {
     const generatedFiles = [
       "npm/esm/cli/commands/mcp/handler.js",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1052";
+export const VERSION = "0.1.1053";


### PR DESCRIPTION
## Problem

Importing the published `veryfront` root entrypoint creates framework cleanup intervals. The root dnt build currently enables the timer shim, which turns Node `Timeout` objects into numeric IDs. `unrefTimer()` therefore cannot call `.unref()`, so short-lived consumers such as `node --test` finish every assertion but never exit.

This is the direct cause of the investment agent config-loader PR consuming the full CI timeout after it switched to the canonical `import { defineConfig } from "veryfront"` form.

## Fix

- Use native timers in the root npm package. Node 18+ is already the package minimum.
- Keep extension-package shim behavior unchanged.
- Add a build-time lifecycle probe against the emitted root package. It verifies `defineConfig` and requires the child process to terminate naturally.
- Force `VF_DISABLE_LRU_INTERVAL=0` in the probe child so CI environment settings cannot mask the regression.
- Publish as `0.1.1053`.

## Verification

- Full framework suite: 2,793 tests / 23,466 steps passed.
- Script suite: 53 tests / 142 steps passed.
- npm build passed its new root-import lifecycle gate.
- Node 22.14 and Node 24.8 each observed five native `Timeout` handles, all unreferenced, and exited naturally.
- Packed npm install smoke passed all scenarios.
- Published-package consumer typecheck passed.
- Lint, formatting, and framework typecheck passed.
- Pre-push repository checks passed.

Related to veryfront/veryfront-studio#5818.